### PR TITLE
fix: v0.7.0 버전 동기화 + 스트리밍 수정 + PR 워크플로우 규칙

### DIFF
--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -1,41 +1,110 @@
 ---
 name: geode-gitflow
-description: GEODE 프로젝트 Gitflow 브랜치 전략 가이드. feature/release/hotfix 브랜치 생성, PR 규칙, 커밋 컨벤션, CI 워크플로우. "branch", "git", "gitflow", "feature", "release", "hotfix", "pr", "merge", "커밋" 키워드로 트리거.
+description: GEODE 브랜치 전략 및 PR 규칙. feature → develop → main 머지 플로우, 한글 PR, assignee 설정, CI 실패 수정 루프. "branch", "git", "pr", "merge", "커밋", "풀리퀘스트" 키워드로 트리거.
 ---
 
-# GEODE Gitflow Strategy
+# GEODE Git & PR Workflow
+
+## Merge Flow (필수)
+
+**feature → develop → main** 순서. 직접 로컬 머지 금지 — 반드시 PR 생성 → CI 통과 → merge.
+
+```
+feature/xxx ──PR──→ develop ──PR──→ main
+```
+
+## PR 생성 → CI → Merge 절차
+
+```bash
+# 1. feature 브랜치에서 커밋 + 푸시
+git push origin feature/<name>
+
+# 2. feature → develop PR 생성 (한글, assignee 자신)
+gh pr create --base develop --assignees mangowhoiscloud \
+  --title "<type>: <한글 설명>" \
+  --body "$(cat <<'EOF'
+## 요약
+<1-3줄 요약>
+
+## 변경 사항
+- 항목 1
+- 항목 2
+
+## 테스트
+- [ ] `uv run pytest tests/ -q` 통과
+- [ ] `uv run ruff check core/ tests/` 통과
+- [ ] `uv run mypy core/` 통과
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# 3. CI 통과 대기
+gh pr checks <PR#> --watch
+
+# 4. CI 통과 → merge
+gh pr merge <PR#> --merge
+
+# 5. develop → main PR 생성 (동일 형식)
+gh pr create --base main --head develop --assignees mangowhoiscloud \
+  --title "<type>: <동일 한글 설명>" \
+  --body "$(cat <<'EOF'
+## 요약
+develop → main 동기화. <요약>
+
+## 테스트
+- [ ] CI 통과
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# 6. CI 통과 → merge
+gh pr checks <PR#> --watch
+gh pr merge <PR#> --merge
+```
+
+## CI 실패 시 수정 루프
+
+```
+PR 생성 → CI 실행 → 실패?
+  ├─ Yes → 로그 확인 (gh pr checks / gh run view)
+  │        → 원인 수정 (lint/type/test/coverage)
+  │        → 커밋 + 푸시 (같은 브랜치)
+  │        → CI 자동 재실행 → 실패? (통과할 때까지 반복)
+  └─ No  → gh pr merge --merge
+```
+
+### 흔한 CI 실패 원인과 대응
+
+| 실패 | 대응 |
+|------|------|
+| `coverage < 75%` | 커버리지 부족 모듈에 테스트 추가 |
+| `ruff` lint 에러 | `uv run ruff check --fix core/ tests/` + `uv run ruff format core/ tests/` |
+| `mypy` 타입 에러 | 타입 수정, `# type: ignore` 최소화 |
+| `bandit` 보안 경고 | `# nosec` 또는 pyproject.toml skips에 추가 (정당한 경우만) |
+| pre-commit stash 충돌 | `git stash` → 커밋 → `git stash pop` |
+
+## PR 작성 규칙
+
+| 항목 | 규칙 |
+|------|------|
+| **언어** | **한글** (제목 + 본문) |
+| **제목** | `<type>: <한글 설명>` (70자 이내) |
+| **Assignee** | `--assignees mangowhoiscloud` (항상) |
+| **본문** | `## 요약` → `## 변경 사항` → `## 테스트` |
+| **Base** | feature → `develop`, develop → `main` |
 
 ## Branch Structure
 
 ```
-main ──────────────────────────────────── production (tag: v6.x.x)
+main ─────────────────────────── production (stable, tagged)
   │
-  └── develop ─────────────────────────── integration
+  └── develop ────────────────── integration (CI 필수)
         │
-        ├── feature/feedback-loop ──────── GAP-1 구현
-        ├── feature/tool-system ────────── Tool Protocol + Registry
-        ├── feature/memory-layer ───────── L2 Memory
-        ├── release/v6.1.0 ─────────────── 릴리스 준비
-        └── hotfix/scoring-fix ─────────── 긴급 수정
-```
-
-## Branch Rules
-
-| Branch | From | Merge To | PR Required | CI Must Pass |
-|--------|------|----------|-------------|--------------|
-| `main` | — | — | Yes (from release/hotfix) | Yes |
-| `develop` | main | — | Yes (from feature) | Yes |
-| `feature/*` | develop | develop | Yes | Yes |
-| `release/*` | develop | main + develop | Yes | Yes |
-| `hotfix/*` | main | main + develop | Yes | Yes |
-
-## Branch Naming
-
-```
-feature/<short-description>    # feature/feedback-loop
-feature/<issue-id>-<desc>      # feature/GAP-1-verify-loop
-release/v<semver>              # release/v6.1.0
-hotfix/<description>           # hotfix/scoring-weight-fix
+        ├── feature/<name> ───── 기능 개발
+        ├── hotfix/<name> ────── 긴급 수정 (main에서 분기)
+        └── release/v<semver> ── 릴리스 준비
 ```
 
 ## Commit Convention
@@ -44,63 +113,27 @@ hotfix/<description>           # hotfix/scoring-weight-fix
 <type>(<scope>): <description>
 
 Types: feat, fix, refactor, test, docs, ci, chore
-Scopes: pipeline, scoring, analysis, verification, cli, memory, tools
+Scopes: pipeline, scoring, analysis, verification, cli, memory, tools, llm
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 ```
 
-Examples:
-```
-feat(pipeline): add VERIFY→GATHER feedback loop
-fix(scoring): correct D-axis exclusion from recovery
-test(analysis): add clean context isolation tests
-ci: add mypy to GitHub Actions workflow
-docs: update CLAUDE.md with gitflow skill
-```
+## CI 게이트 (모든 PR)
 
-## Workflow Commands
-
-### Start feature
 ```bash
-git checkout develop
-git pull origin develop
-git checkout -b feature/<name>
+uv run pytest tests/ -q              # 1950+ pass, coverage ≥ 75%
+uv run ruff check core/ tests/       # 0 errors
+uv run mypy core/                    # 0 errors
+uv run bandit -r core/ -c pyproject.toml  # 0 errors
 ```
 
-### Complete feature
+## 로컬 머지 (PR 생성 불가 시 예외)
+
+GitHub "No commits between" 오류 등 PR 생성 불가 시에만 로컬 머지 허용:
+
 ```bash
-git push -u origin feature/<name>
-gh pr create --base develop --title "feat: <description>"
+git stash
+git checkout develop && git merge feature/<name> --no-edit && git push origin develop
+git checkout main && git merge develop --no-edit && git push origin main
+git checkout feature/<name> && git stash pop
 ```
-
-### Start release
-```bash
-git checkout develop
-git checkout -b release/v6.x.0
-# bump version in pyproject.toml
-# test, fix, then PR to main + develop
-```
-
-### Hotfix
-```bash
-git checkout main
-git checkout -b hotfix/<name>
-# fix, then PR to main + develop
-```
-
-## CI Requirements
-
-All PRs must pass:
-1. `ruff check` — lint
-2. `ruff format --check` — formatting
-3. `mypy` — type checking
-4. `pytest` — 98+ tests pass
-
-## Priority Feature Branches (from layer-implementation-plan.md)
-
-| Priority | Branch | GAP |
-|----------|--------|-----|
-| P0 | `feature/feedback-loop` | GAP-1: VERIFY→GATHER 루프 |
-| P0 | `feature/tool-system` | Tool Protocol + Registry |
-| P0 | `feature/llm-port` | LLMClientPort multi-provider |
-| P1 | `feature/cross-llm` | GAP-4: Cross-LLM 실제 구현 |
-| P1 | `feature/planner` | L4 Planner (Gemini Flash) |
-| P1 | `feature/memory-layer` | L2 Memory 3-tier |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@
 
 저평가 IP를 데이터 기반으로 발굴하는 LangGraph Agent CLI.
 
-- **Version**: 0.6.0
+- **Version**: 0.7.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 102
-- **Tests**: 1541+
+- **Modules**: 116
+- **Tests**: 1950+
 
 ## Quick Start
 
@@ -73,7 +73,7 @@ START → router → signals → analyst×4 (Send API)
 ## Project Structure
 
 ```
-src/geode/
+core/
 ├── cli/                 # Typer CLI + NL router + search
 ├── config.py            # Pydantic Settings (.env)
 ├── state.py             # GeodeState TypedDict + Pydantic models
@@ -148,15 +148,15 @@ src/geode/
 uv run python -m pytest tests/ -q
 
 # Lint
-uv run ruff check src/geode/ tests/
+uv run ruff check core/ tests/
 
 # Type check
-uv run mypy src/geode/
+uv run mypy core/
 ```
 
 ### Expected Test Results
 
-1541+ tests pass. 3 IP fixtures produce tier spread:
+1950+ tests pass. 3 IP fixtures produce tier spread:
 - Berserk: **S** (82.2) — conversion_failure
 - Cowboy Bebop: **A** (69.4) — undermarketed
 - Ghost in the Shell: **B** (54.0) — discovery_failure
@@ -243,6 +243,78 @@ Decision Tree on D-E-F axes:
 4. CHANGELOG.md 갱신 (feature-level)
 ```
 
+### 5. PR & Merge
+
+feature → develop → main 순서로 머지한다. **직접 로컬 머지 금지** — 반드시 PR 생성 → CI 통과 → merge 순서.
+
+```
+1. feature 브랜치에서 커밋 + 푸시
+2. feature → develop PR 생성 (한글, assignee: mangowhoiscloud)
+3. CI 통과 대기 → 실패 시 수정 루프 (아래 참조)
+4. CI 통과 → gh pr merge
+5. develop → main PR 생성 (동일 형식)
+6. CI 통과 → gh pr merge
+```
+
+**CI 실패 시 수정 루프:**
+
+```
+PR 생성 → CI 실행 → 실패?
+  ├─ Yes → 로그 확인 (gh pr checks / gh run view)
+  │        → 원인 수정 (lint/type/test/coverage)
+  │        → 커밋 + 푸시 → CI 재실행 → 실패? (반복)
+  └─ No  → gh pr merge --merge
+```
+
+주의사항:
+- `coverage fail_under=75` 미달 시: 커버리지 부족 모듈에 테스트 추가
+- `ruff` 실패 시: `uv run ruff check --fix core/ tests/` 후 포맷 확인
+- `mypy` 실패 시: 타입 에러 수정, `# type: ignore` 최소화
+- pre-commit stash 충돌 시: `git stash` → 커밋 → `git stash pop`
+
+**PR 작성 규칙:**
+
+| 항목 | 규칙 |
+|------|------|
+| 언어 | **한글** (제목 + 본문 모두) |
+| 제목 | `<type>: <한글 설명>` (70자 이내) |
+| 본문 | `## 요약` + `## 변경 사항` + `## 테스트` |
+| Assignee | `--assignees mangowhoiscloud` (항상) |
+| Base | feature → `develop`, develop → `main` |
+
+**PR 생성 커맨드:**
+
+```bash
+gh pr create --base develop --assignees mangowhoiscloud \
+  --title "<type>: <한글 설명>" \
+  --body "$(cat <<'EOF'
+## 요약
+<1-3줄 요약>
+
+## 변경 사항
+- 항목 1
+- 항목 2
+
+## 테스트
+- [ ] `uv run pytest tests/ -q` 통과
+- [ ] `uv run ruff check core/ tests/` 통과
+- [ ] `uv run mypy core/` 통과
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**PR 머지 커맨드:**
+
+```bash
+# CI 통과 확인
+gh pr checks <PR#> --watch
+
+# 머지
+gh pr merge <PR#> --merge
+```
+
 ### E2E 업데이트 규칙 (필수)
 
 **기능 변경 시 반드시 아래 파일을 함께 업데이트:**
@@ -260,7 +332,7 @@ Decision Tree on D-E-F axes:
 |--------|--------|------|
 | Lint | `uv run ruff check core/ tests/` | 0 errors |
 | Type | `uv run mypy core/` | 0 errors |
-| Mock | `uv run pytest tests/ -q` | 1909+ pass |
+| Mock | `uv run pytest tests/ -q` | 1950+ pass |
 | Live | `uv run pytest tests/test_e2e_live_llm.py -v -m live` | All pass, tool results valid |
 
 ## Custom Skills


### PR DESCRIPTION
## 요약
GEODE 실행 검증에서 발견된 6건의 문제 수정 + PR/머지 워크플로우 규칙 문서화.

## 변경 사항
- 버전 `v0.6.0` → `v0.7.0` 전체 동기화 (cli, panels, report template, `__init__`)
- 스트리밍 evaluator 중복 출력 수정 (`"evaluators"` → `"evaluator"` 노드명 일치)
- `mcp>=1.0.0` optional dependency 추가
- README: batch `--dry-run` 안내, `/compare` Interactive 전용 명시, retry 타이밍 구분
- CLAUDE.md: v0.7.0 정보 동기화 + PR & Merge 워크플로우 섹션 추가
- geode-gitflow/SKILL.md: PR 생성 → CI → merge 절차, CI 실패 수정 루프

## 테스트
- [x] `uv run pytest tests/ -q` — 1950 passed
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)