### PR TITLE
fix: gh CLI 플래그 수정 (--assignees → --assignee)

### DIFF
--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -20,7 +20,7 @@ feature/xxx ──PR──→ develop ──PR──→ main
 git push origin feature/<name>
 
 # 2. feature → develop PR 생성 (한글, assignee 자신)
-gh pr create --base develop --assignees mangowhoiscloud \
+gh pr create --base develop --assignee mangowhoiscloud \
   --title "<type>: <한글 설명>" \
   --body "$(cat <<'EOF'
 ## 요약
@@ -46,7 +46,7 @@ gh pr checks <PR#> --watch
 gh pr merge <PR#> --merge
 
 # 5. develop → main PR 생성 (동일 형식)
-gh pr create --base main --head develop --assignees mangowhoiscloud \
+gh pr create --base main --head develop --assignee mangowhoiscloud \
   --title "<type>: <동일 한글 설명>" \
   --body "$(cat <<'EOF'
 ## 요약
@@ -91,7 +91,7 @@ PR 생성 → CI 실행 → 실패?
 |------|------|
 | **언어** | **한글** (제목 + 본문) |
 | **제목** | `<type>: <한글 설명>` (70자 이내) |
-| **Assignee** | `--assignees mangowhoiscloud` (항상) |
+| **Assignee** | `--assignee mangowhoiscloud` (항상) |
 | **본문** | `## 요약` → `## 변경 사항` → `## 테스트` |
 | **Base** | feature → `develop`, develop → `main` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,13 +279,13 @@ PR 생성 → CI 실행 → 실패?
 | 언어 | **한글** (제목 + 본문 모두) |
 | 제목 | `<type>: <한글 설명>` (70자 이내) |
 | 본문 | `## 요약` + `## 변경 사항` + `## 테스트` |
-| Assignee | `--assignees mangowhoiscloud` (항상) |
+| Assignee | `--assignee mangowhoiscloud` (항상) |
 | Base | feature → `develop`, develop → `main` |
 
 **PR 생성 커맨드:**
 
 ```bash
-gh pr create --base develop --assignees mangowhoiscloud \
+gh pr create --base develop --assignee mangowhoiscloud \
   --title "<type>: <한글 설명>" \
   --body "$(cat <<'EOF'
 ## 요약


### PR DESCRIPTION
## 요약
CLAUDE.md, geode-gitflow/SKILL.md의 `--assignees` → `--assignee` 수정 (gh CLI 올바른 플래그).

## 변경 사항
- `--assignees` → `--assignee` (5곳)

## 테스트
- [x] 로컬 pre-commit 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)