### PR TITLE
fix: gh CLI 플래그 수정 (develop → main 동기화)

### DIFF
--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -20,7 +20,7 @@ feature/xxx ──PR──→ develop ──PR──→ main
 git push origin feature/<name>
 
 # 2. feature → develop PR 생성 (한글, assignee 자신)
-gh pr create --base develop --assignees mangowhoiscloud \
+gh pr create --base develop --assignee mangowhoiscloud \
   --title "<type>: <한글 설명>" \
   --body "$(cat <<'EOF'
 ## 요약
@@ -46,7 +46,7 @@ gh pr checks <PR#> --watch
 gh pr merge <PR#> --merge
 
 # 5. develop → main PR 생성 (동일 형식)
-gh pr create --base main --head develop --assignees mangowhoiscloud \
+gh pr create --base main --head develop --assignee mangowhoiscloud \
   --title "<type>: <동일 한글 설명>" \
   --body "$(cat <<'EOF'
 ## 요약
@@ -91,7 +91,7 @@ PR 생성 → CI 실행 → 실패?
 |------|------|
 | **언어** | **한글** (제목 + 본문) |
 | **제목** | `<type>: <한글 설명>` (70자 이내) |
-| **Assignee** | `--assignees mangowhoiscloud` (항상) |
+| **Assignee** | `--assignee mangowhoiscloud` (항상) |
 | **본문** | `## 요약` → `## 변경 사항` → `## 테스트` |
 | **Base** | feature → `develop`, develop → `main` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,13 +279,13 @@ PR 생성 → CI 실행 → 실패?
 | 언어 | **한글** (제목 + 본문 모두) |
 | 제목 | `<type>: <한글 설명>` (70자 이내) |
 | 본문 | `## 요약` + `## 변경 사항` + `## 테스트` |
-| Assignee | `--assignees mangowhoiscloud` (항상) |
+| Assignee | `--assignee mangowhoiscloud` (항상) |
 | Base | feature → `develop`, develop → `main` |
 
 **PR 생성 커맨드:**
 
 ```bash
-gh pr create --base develop --assignees mangowhoiscloud \
+gh pr create --base develop --assignee mangowhoiscloud \
   --title "<type>: <한글 설명>" \
   --body "$(cat <<'EOF'
 ## 요약


### PR DESCRIPTION
## 요약
develop → main 동기화. CLAUDE.md 및 geode-gitflow SKILL.md에서 `--assignees` → `--assignee` (gh CLI 올바른 플래그) 수정.

## 변경 사항
- CLAUDE.md: `--assignees` → `--assignee` 전체 수정
- `.claude/skills/geode-gitflow/SKILL.md`: 동일 플래그 수정

## 테스트
- [x] `uv run pytest tests/ -q` 통과
- [x] `uv run ruff check core/ tests/` 통과
- [x] `uv run mypy core/` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)