### PR TITLE
release: v0.8.0 — 응답 품질 표준 + LangSmith 트레이싱 + Plan/Sub-agent NL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,42 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [0.8.0] — 2026-03-11
+
+Plan/Sub-agent NL integration, Claude Code-style UI, response quality hardening.
+
+### Added
+
+#### Plan & Sub-agent NL Integration
+- `create_plan` tool — NL로 분석 계획 생성 ("Berserk 분석 계획 세워줘")
+- `approve_plan` tool — 계획 승인 및 실행 ("계획 승인해")
+- `delegate_task` tool — 서브에이전트 병렬 위임 ("병렬로 처리해")
+- NL Router tool count: 17 → 20 (plan/delegate 3개 추가)
+- Offline fallback: plan/delegate regex 패턴 추가 (LLM 없이 동작)
+
+#### Claude Code-style UI
+- `core/ui/agentic_ui.py` — tool call/result/error/token/plan 렌더러
+- `core/ui/console.py` — Rich Console 싱글톤 (width=120, GEODE 테마)
+- Marker system: `▸` tool call, `✓` success, `✗` error, `✢` tokens, `●` plan
+
+#### LangSmith Trace Coverage
+- `@_maybe_traceable` added to verification layer: `run_guardrails`, `run_biasbuster`, `run_cross_llm_check`, `check_rights_risk`
+- Full pipeline tracing coverage: router → signals → analysts → evaluators → scoring → verification → synthesizer
+
+### Changed
+- `AgenticLoop._process_tool_calls()`: `str(result)` → `json.dumps(result, ensure_ascii=False, default=str)` — LLM이 파싱 가능한 JSON 형식으로 tool 결과 전달
+- `snapshot._persist_snapshot()`: `json.dumps(..., default=str)` — non-serializable 필드 안전 처리
+- `snapshot.capture()`: `_sanitize_state()` 추가 — `_`-prefixed 내부 필드 필터링
+- NL Router offline fallback 순서: plan/delegate 패턴을 known IP 매칭보다 먼저 검사
+
+### Fixed
+- Offline mode `_run_offline()`: action name("list") → tool name("list_ips") 매핑 누락 수정 (`_ACTION_TO_TOOL` dict 추가)
+- `_TOOL_ACTION_MAP` 누락: `create_plan`, `approve_plan`, `delegate_task` 미등록 → 추가
+
+### Infrastructure
+- Test count: 1909+ → 2000+
+- Module count: 116 → 118
+- `tests/test_agentic_ui.py` (20 tests), plan/delegate NL tests (20 tests)
 
 ---
 
@@ -222,12 +257,14 @@ Initial release of GEODE — Undervalued IP Discovery Agent.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 0.8.0 | 2026-03-11 | Plan/Sub-agent NL, Claude Code UI, response quality, verification tracing |
 | 0.7.0 | 2026-03-11 | C2-C5 flexibility, LangSmith observability, orchestration integration, 17-tool audit |
 | 0.6.1 | 2026-03-10 | Content/code separation, package rename, pre-commit hooks |
 | 0.6.0 | 2026-03-10 | Initial release — full pipeline, agentic loop, 3-tier memory |
 
 <!-- Links -->
-[Unreleased]: https://github.com/mangowhoiscloud/geode/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mangowhoiscloud/geode/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/mangowhoiscloud/geode/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mangowhoiscloud/geode/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/mangowhoiscloud/geode/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mangowhoiscloud/geode/releases/tag/v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@
 
 저평가 IP를 데이터 기반으로 발굴하는 LangGraph Agent CLI.
 
-- **Version**: 0.7.0
+- **Version**: 0.8.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 118
 - **Tests**: 2000+
+- **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
 
@@ -161,7 +162,7 @@ uv run mypy core/
 
 ### Expected Test Results
 
-1950+ tests pass. 3 IP fixtures produce tier spread:
+2000+ tests pass. 3 IP fixtures produce tier spread:
 - Berserk: **S** (81.3) — conversion_failure
 - Cowboy Bebop: **A** (68.4) — undermarketed
 - Ghost in the Shell: **B** (51.6) — discovery_failure
@@ -323,6 +324,51 @@ Mock E2E → CLI dry-run → Live E2E → LangSmith 검증 순서로 점검. 각
 2. tests/test_e2e_live_llm.py 갱신 (라이브 테스트 추가)
 3. .claude/skills/geode-e2e/SKILL.md 갱신 (시나리오 매핑 테이블)
 4. CLAUDE.md 갱신 (기능/테스트 수/NL 도구 수)
+5. README.md 정합성 검증 (아래 §4a 참조)
+6. CHANGELOG.md 버전업 판단 (아래 §4b 참조)
+```
+
+#### 4a. README.md 정합성 검증 (PR 전 필수)
+
+PR 생성 전 README.md가 코드와 일치하는지 검증한다.
+
+| 검증 항목 | 확인 방법 |
+|----------|----------|
+| 테스트 수 | `uv run pytest tests/ -q` 결과와 README 기재 수 일치 |
+| 모듈 수 | `find core/ -name "*.py" \| wc -l` 결과와 일치 |
+| Tool 수 | `definitions.json` 항목 수 = README tool 테이블 행 수 |
+| 프로젝트 구조 | 신규 파일/디렉토리가 README 트리에 반영됨 |
+| 다이어그램 | 파이프라인 노드/엣지 변경 시 아키텍처 다이어그램 갱신 |
+| Tier/Score | fixture 결과(Berserk S/81.3 등)가 변경 시 README 업데이트 |
+
+불일치 발견 시 README를 수정하고 동일 커밋에 포함한다.
+
+#### 4b. CHANGELOG.md 버전업 절차
+
+변경 규모에 따라 버전업 여부를 판단하고, 필요 시 아래 절차를 수행한다.
+
+**버전업 판단 기준 (SemVer):**
+
+| 변경 규모 | 버전 | 예시 |
+|----------|------|------|
+| 호환 깨짐 (API/State 변경) | MAJOR (x.0.0) | GeodeState 필드 삭제, CLI 명령어 변경 |
+| 새 기능 추가 | MINOR (0.x.0) | 새 tool, 새 노드, 새 검증 레이어 |
+| 버그 수정/개선 | PATCH (0.0.x) | 직렬화 수정, 트레이싱 추가 |
+| 문서/리팩터만 | 버전업 안 함 | README 수정, 내부 리팩터 |
+
+**절차:**
+
+```
+1. CHANGELOG.md [Unreleased] 섹션에 변경 사항 기록
+   - Added / Changed / Fixed / Removed / Infrastructure / Architecture 카테고리 사용
+   - Feature-level 단위 (커밋 단위 X)
+2. 버전업 필요 시:
+   a. [Unreleased] → [x.y.z] — YYYY-MM-DD 로 변환
+   b. CLAUDE.md Version 필드 업데이트
+   c. pyproject.toml version 필드 업데이트 (있는 경우)
+   d. 하단 Version History 테이블에 행 추가
+   e. 비교 링크 업데이트 ([Unreleased] compare URL)
+3. 동일 커밋에 CHANGELOG.md + CLAUDE.md + pyproject.toml 포함
 ```
 
 ### 5. PR & Merge
@@ -360,9 +406,39 @@ PR 생성 → CI 실행 → 실패?
 |------|------|
 | 언어 | **한글** (제목 + 본문 모두) |
 | 제목 | `<type>: <한글 설명>` (70자 이내) |
-| 본문 | `## 요약` + `## 변경 사항` + `## 테스트` |
+| 본문 | 아래 상세 템플릿 참조 |
 | Assignee | `--assignee mangowhoiscloud` (항상) |
 | Base | feature → `develop`, develop → `main` |
+
+**PR 본문 상세 템플릿:**
+
+```markdown
+## 요약
+<1-3줄. 무엇을 왜 변경했는지 핵심만>
+
+## 변경 사항
+### 코드 변경
+- `파일경로`: 변경 내용 (AS-IS → TO-BE 간략 설명)
+- `파일경로`: 변경 내용
+
+### 문서/설정 변경
+- `CLAUDE.md`: 갱신 항목
+- `README.md`: 갱신 항목 (정합성 검증 포함)
+- `CHANGELOG.md`: 버전/기록 변경 (해당 시)
+
+## 영향 범위
+- 영향받는 모듈/기능: <목록>
+- 하위 호환성: 유지 / 깨짐 (깨짐 시 상세 기술)
+
+## 테스트
+- [ ] `uv run ruff check core/ tests/` — 0 errors
+- [ ] `uv run mypy core/` — 0 errors
+- [ ] `uv run pytest tests/ -q` — XXXX+ pass
+- [ ] CLI dry-run 정상: `uv run geode analyze "Berserk" --dry-run`
+- [ ] 신규 테스트 추가: X개 (해당 시)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
 
 **PR 생성 커맨드:**
 
@@ -370,19 +446,7 @@ PR 생성 → CI 실행 → 실패?
 gh pr create --base develop --assignee mangowhoiscloud \
   --title "<type>: <한글 설명>" \
   --body "$(cat <<'EOF'
-## 요약
-<1-3줄 요약>
-
-## 변경 사항
-- 항목 1
-- 항목 2
-
-## 테스트
-- [ ] `uv run pytest tests/ -q` 통과
-- [ ] `uv run ruff check core/ tests/` 통과
-- [ ] `uv run mypy core/` 통과
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+<위 템플릿 내용>
 EOF
 )"
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEODE v0.7.0 — Undervalued IP Discovery Agent
 
-LangGraph 기반 게임화 IP 도메인 자율 에이전트입니다. 주요 기능은 아래와 같습니다. 
+LangGraph 기반 게임화 IP 도메인 자율 에이전트입니다. 주요 기능은 아래와 같습니다.
 - 미디어 IP(애니메이션, 만화 등)의 게임화 잠재력을 6-Layer 아키텍처로 분석하고, PSM 14-Axis 루브릭으로 분석/평가 루프와 리포트 생성을 지원합니다.
 - Runtime Orchestration, Tool-Registry/Tool-Use, Bash, Hook-System으로 Agentic Loop(Gather->Action->Verify)를 구성, 자율 행동이 가능합니다.
 - 사용자의 의도와 맥락을 파악하기 위한 NL Router(Multi-turn, Multi-intent), 메모리 시스템, HITL이 내장되어 있습니다.
@@ -21,7 +21,7 @@ LangGraph 기반 게임화 IP 도메인 자율 에이전트입니다. 주요 기
 | **14-Axis Rubric** | PSM(Prospect Scoring Model) 기반 정량 평가 |
 | **Cross-LLM Ensemble** | Claude Opus 4.6 + GPT-5.4 듀얼 평가, `cross` / `primary_only` 모드 |
 | **Prompt Caching** | Anthropic `cache_control` 적용, 40-60% 비용 절감 |
-| **19 Tool Definitions** | `definitions.json` 기반 + ToolRegistry 런타임 확장 + PolicyChain 접근 제어 |
+| **21 Tool Definitions** | `definitions.json` 기반 + ToolRegistry 런타임 확장 + PolicyChain 접근 제어 |
 | **MCP Adapters** | Steam, Brave Search, KG Memory 외부 데이터 소스 연결 |
 | **MCP Server** | FastMCP 기반 6 tools + 2 resources (다른 에이전트에서 GEODE 호출) |
 | **Prompt Templates** | `.md` 템플릿 8종 + YAML/JSON 설정 분리 (content/code separation) |
@@ -37,7 +37,7 @@ LangGraph 기반 게임화 IP 도메인 자율 에이전트입니다. 주요 기
 | **Dynamic Tools** | ToolRegistry 기반 런타임 tool 추가, plugin activate → 즉시 반영 |
 | **Pipeline Flexibility** | Analyst 타입 YAML 동적 로드, `interrupt_before` 사용자 개입 |
 | **Pre-commit Hooks** | ruff lint/format + mypy + bandit + standard hooks |
-| **1950 Tests** | 116 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit 전체 통과 |
+| **2000+ Tests** | 118 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit 전체 통과 |
 
 ## Architecture
 
@@ -84,7 +84,7 @@ graph TB
     end
 
     subgraph L5["L5 — Extensibility"]
-        Tools["ToolRegistry (19)"]
+        Tools["ToolRegistry (21)"]
         Policy["PolicyChain"]
         Reports["Report Generator"]
         Templates["Prompt Skills"]
@@ -112,7 +112,7 @@ graph TB
 | **L2** Memory | Organization (fixture), Project (.claude/MEMORY.md), Session (TTL), SqliteSaver | 3-Tier 메모리 + LangGraph 체크포인트 영속화 |
 | **L3** Pipeline | StateGraph, 8 Pipeline Nodes, GeodeState (TypedDict) | LangGraph `graph.stream()` 단계별 실행, Send API 병렬 분석 |
 | **L4** Orchestration | HookSystem (23 events), TaskGraph DAG, PlanMode, CoalescingQueue, LaneQueue, RunLog | 라이프사이클 이벤트, 중복 요청 제거, 동시성 제어 |
-| **L5** Extensibility | ToolRegistry (19), PolicyChain, Report Generator, Prompt Skills | 런타임 tool 확장, 노드별 접근 제어, HTML/JSON/MD 리포트 |
+| **L5** Extensibility | ToolRegistry (21), PolicyChain, Report Generator, Prompt Skills | 런타임 tool 확장, 노드별 접근 제어, HTML/JSON/MD 리포트 |
 
 ### Pipeline Flow
 
@@ -166,7 +166,7 @@ graph TB
     Mode -->|No| LLM["Claude Opus 4.6<br/>Tool Use API"]
     Regex --> Exec
     LLM --> Decision{stop_reason}
-    Decision -->|tool_use| Exec["ToolExecutor<br/>(19 tools)"]
+    Decision -->|tool_use| Exec["ToolExecutor<br/>(21 tools)"]
     Exec --> Results["tool_result"]
     Results --> LLM
     Decision -->|end_turn| Output["AgenticResult<br/>(text + tool_calls)"]
@@ -188,7 +188,7 @@ graph TB
 | 구성 요소 | 설명 |
 |----------|------|
 | **offline mode** | `_offline_fallback()` — 10개 regex 패턴 기반 intent 매칭, LLM 호출 없이 1-round 결정론적 실행 |
-| **LLM Tool Use** | Claude Opus 4.6 `tool_use` API — `definitions.json` 19개 tool 정의 전달, `stop_reason` 기반 루프 제어 |
+| **LLM Tool Use** | Claude Opus 4.6 `tool_use` API — `definitions.json` 21개 tool 정의 전달, `stop_reason` 기반 루프 제어 |
 | **ToolExecutor** | 3-tier safety: SAFE (7종, 무조건 실행) / STANDARD (일반) / DANGEROUS (bash, 사용자 승인 필수) |
 | **max_rounds** | 기본 10 라운드 — `end_turn` 또는 라운드 초과 시 종료 |
 | **LangSmith** | `track_token_usage()` — 토큰 수/비용을 RunTree.extra.metrics에 기록, `LLMUsageAccumulator`로 세션 합산 |
@@ -267,7 +267,7 @@ graph LR
 ```mermaid
 graph TB
     subgraph GEODE["GEODE Pipeline"]
-        Registry["ToolRegistry<br/>19 base tools"]
+        Registry["ToolRegistry<br/>21 base tools"]
         Policy["PolicyChain<br/>+ NodeScopePolicy"]
         TS["tool_search<br/>(meta-tool)"]
     end
@@ -474,7 +474,7 @@ graph LR
 ```mermaid
 graph LR
     Plugin["Plugin"] -->|"activate()"| Reg["ToolRegistry"]
-    Reg -->|"register(tool)"| Tools["19 base + N extra"]
+    Reg -->|"register(tool)"| Tools["21 base + N extra"]
     Tools --> AL["AgenticLoop<br/>get_agentic_tools()"]
     Reg --> Policy["PolicyChain<br/>+ NodeScopePolicy"]
 
@@ -482,7 +482,7 @@ graph LR
     style Policy fill:#f59e0b,stroke:#f59e0b,color:#fff
 ```
 
-> `definitions.json` 19개 기본 도구 + `ToolRegistry.register()` 런타임 확장. `get_agentic_tools(registry)` 호출 시 base + plugin 도구 병합. `PolicyChain`으로 노드별 도구 접근 제어.
+> `definitions.json` 21개 기본 도구 + `ToolRegistry.register()` 런타임 확장. `get_agentic_tools(registry)` 호출 시 base + plugin 도구 병합. `PolicyChain`으로 노드별 도구 접근 제어.
 
 **기본 Tool 목록 (19종):**
 
@@ -507,6 +507,8 @@ graph LR
 | 17 | `trigger_event` | 이벤트 트리거 | STANDARD |
 | 18 | `run_bash` | 셸 명령 실행 | DANGEROUS |
 | 19 | `delegate_task` | 서브에이전트 위임 | STANDARD |
+| 20 | `create_plan` | 분석 계획 생성 | STANDARD |
+| 21 | `approve_plan` | 계획 승인/실행 | STANDARD |
 
 ### Pipeline Flexibility (C2-C5)
 
@@ -711,12 +713,14 @@ core/
 ├── runtime.py                  # GeodeRuntime (production wiring)
 ├── state.py                    # GeodeState (TypedDict + Pydantic models)
 ├── tools/                      # Tool Protocol + Registry + Policy
-│   ├── registry.py             # ToolRegistry (19 tools + runtime extensions)
-│   ├── definitions.json        # Centralized tool definitions (19 tools)
+│   ├── registry.py             # ToolRegistry (21 tools + runtime extensions)
+│   ├── definitions.json        # Centralized tool definitions (21 tools)
 │   ├── tool_schemas.json       # Parameter schemas for signal/analysis tools
 │   ├── policy.py               # PolicyChain + NodeScopePolicy
 │   └── ...                     # analysis, signal_tools, data_tools, etc.
-├── ui/                         # Rich console + panels + streaming
+├── ui/                         # Rich console + Claude Code-style agentic UI
+│   ├── agentic_ui.py           # ▸/✓/✗/✢/● markers (tool call/result/token rendering)
+│   └── console.py              # Rich Console singleton (width=120, GEODE theme)
 └── verification/               # Guardrails + BiasBuster + Rights Risk
 ```
 

--- a/core/automation/snapshot.py
+++ b/core/automation/snapshot.py
@@ -24,6 +24,17 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 DEFAULT_MAX_RECENT = 30
+
+
+def _sanitize_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Filter internal (``_``-prefixed) fields that may not be JSON-serializable.
+
+    Objects like PromptAssembler, ToolDefinitions, and bootstrap parameters are
+    injected into the state at graph compile time but should not be persisted.
+    """
+    return {k: v for k, v in state.items() if not k.startswith("_")}
+
+
 DEFAULT_PRUNE_KEEP_WEEKLY = True
 
 
@@ -101,15 +112,21 @@ class SnapshotManager:
         rubric_hash: str = "",
         config_hash: str = "",
     ) -> Snapshot:
-        """Capture a new snapshot."""
+        """Capture a new snapshot.
+
+        Internal fields (prefixed with ``_``) are filtered out to avoid
+        serialization errors from non-JSON-serializable objects like
+        PromptAssembler or ToolDefinitions.
+        """
         snapshot_id = f"snap-{uuid.uuid4().hex[:12]}"
+        clean_state = _sanitize_state(pipeline_state or {})
         snap = Snapshot(
             snapshot_id=snapshot_id,
             session_id=session_id,
             prompt_hash=prompt_hash,
             rubric_hash=rubric_hash,
             config_hash=config_hash,
-            pipeline_state=pipeline_state or {},
+            pipeline_state=clean_state,
             context=context or {},
         )
         with self._lock:
@@ -206,7 +223,10 @@ class SnapshotManager:
             return
         f = self._storage_dir / f"{snap.snapshot_id}.json"
         tmp = f.with_suffix(".tmp")
-        tmp.write_text(json.dumps(snap.to_dict(), indent=2), encoding="utf-8")
+        tmp.write_text(
+            json.dumps(snap.to_dict(), indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
         os.replace(str(tmp), str(f))
 
     def _remove_from_disk(self, snapshot_id: str) -> None:

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -285,11 +285,17 @@ class AgenticLoop:
                 }
             )
 
+            # Serialize result as JSON for LLM (not Python repr)
+            try:
+                content = json.dumps(result, ensure_ascii=False, default=str)
+            except (TypeError, ValueError):
+                content = str(result)
+
             tool_results.append(
                 {
                     "type": "tool_result",
                     "tool_use_id": block.id,
-                    "content": str(result),
+                    "content": content,
                 }
             )
 

--- a/core/verification/biasbuster.py
+++ b/core/verification/biasbuster.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from core.infrastructure.ports.llm_port import get_llm_json, get_llm_parsed, get_llm_tool
 from core.infrastructure.ports.tool_port import get_tool_executor
+from core.llm.client import _maybe_traceable
 from core.llm.prompts import BIASBUSTER_SYSTEM, BIASBUSTER_USER
 from core.state import AnalysisResult, BiasBusterResult, GeodeState
 
@@ -40,6 +41,7 @@ def _run_statistical_checks(analyses: list[AnalysisResult]) -> dict[str, float]:
     }
 
 
+@_maybe_traceable(run_type="chain", name="run_biasbuster")  # type: ignore[untyped-decorator]
 def run_biasbuster(state: GeodeState) -> BiasBusterResult:
     """Run BiasBuster 4-step verification."""
     try:

--- a/core/verification/cross_llm.py
+++ b/core/verification/cross_llm.py
@@ -15,6 +15,7 @@ import numpy as np
 from core.automation.expert_panel import calculate_krippendorff_alpha
 from core.config import settings
 from core.infrastructure.ports.llm_port import LLMClientPort
+from core.llm.client import _maybe_traceable
 from core.llm.prompts import CROSS_LLM_DUAL_VERIFY, CROSS_LLM_RESCORE, CROSS_LLM_SYSTEM
 from core.state import AnalysisResult, GeodeState
 
@@ -79,6 +80,7 @@ def _calc_agreement(scores: list[float], scale_max_var: float = _MAX_VARIANCE) -
     return max(0.0, min(1.0, agreement))
 
 
+@_maybe_traceable(run_type="chain", name="run_cross_llm_check")  # type: ignore[untyped-decorator]
 def run_cross_llm_check(
     state: GeodeState,
     *,
@@ -240,12 +242,12 @@ def run_dual_adapter_check(
     """
     # If no adapters, fall back to standard check
     if primary_adapter is None or secondary_adapter is None:
-        result = run_cross_llm_check(state)
-        result["verification_mode"] = "agreement_only"
-        return result
+        fallback: dict[str, Any] = run_cross_llm_check(state)
+        fallback["verification_mode"] = "agreement_only"
+        return fallback
 
     # Standard agreement check first
-    base_result = run_cross_llm_check(state)
+    base_result: dict[str, Any] = run_cross_llm_check(state)
 
     # Dual-adapter verification: ask secondary model for a quick sanity check
     ip_name = state.get("ip_name", "Unknown")

--- a/core/verification/guardrails.py
+++ b/core/verification/guardrails.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 
+from core.llm.client import _maybe_traceable
 from core.state import AnalysisResult, EvaluatorResult, GeodeState, GuardrailResult
 
 
@@ -134,6 +135,7 @@ def _g4_consistency(state: GeodeState) -> tuple[bool, str]:
     return not errors, "; ".join(errors) or "Consistency OK"
 
 
+@_maybe_traceable(run_type="chain", name="run_guardrails")  # type: ignore[untyped-decorator]
 def run_guardrails(
     state: GeodeState,
     *,

--- a/core/verification/rights_risk.py
+++ b/core/verification/rights_risk.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from core.llm.client import _maybe_traceable
+
 
 class RightsStatus(StrEnum):
     """IP rights clearance status."""
@@ -106,6 +108,7 @@ _FIXTURE_RIGHTS: dict[str, dict[str, Any]] = {
 }
 
 
+@_maybe_traceable(run_type="chain", name="check_rights_risk")  # type: ignore[untyped-decorator]
 def check_rights_risk(ip_name: str, ip_info: dict[str, Any] | None = None) -> RightsRiskResult:
     """Assess IP rights and licensing risk.
 


### PR DESCRIPTION
## 요약

develop → main 통합. v0.8.0 릴리스 — Plan/Sub-agent NL 통합, Claude Code-style UI, 응답/에러 품질 표준, LangSmith Verification 트레이싱.

## 변경 사항 (PR #24, #26, #28 통합)

### 신규 기능
- Plan/Sub-agent NL: `create_plan`, `approve_plan`, `delegate_task` 3개 tool 추가 (NL Router 17→20)
- Claude Code-style UI: `agentic_ui.py` + `console.py` (▸/✓/✗/✢/● 마커 시스템)
- Offline fallback: plan/delegate regex 패턴 추가

### 품질 개선
- AgenticLoop tool 결과: `str()` → `json.dumps()` (LLM 파싱 가능 JSON)
- Snapshot: `_sanitize_state()` + `default=str` (non-serializable 안전 처리)
- Verification 4개 함수 `@_maybe_traceable` 추가 (LangSmith 전체 파이프라인 커버리지)
- Offline action→tool 매핑 수정 (`_ACTION_TO_TOOL` dict)

### 문서
- CLAUDE.md: README 정합성 검증 절차, CHANGELOG 버전업 절차, PR 상세 템플릿
- CHANGELOG.md: v0.8.0 릴리스 기록
- README.md: tool 21개, 테스트 2000+

## 테스트
- [x] CI 6/6 (lint, type, test×2, security, gate) — PR #24, #26, #28 모두 통과
- [x] 2000 passed, 13 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)