### PR TITLE
fix: web_search tool 정의에 누락된 name 필드 추가

### DIFF
--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -264,7 +264,7 @@ class WebSearchTool:
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,
-                tools=[{"type": "web_search_20250305"}],  # type: ignore[list-item]
+                tools=[{"type": "web_search_20250305", "name": "web_search"}],
                 messages=[
                     {
                         "role": "user",

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -100,7 +100,7 @@ class GeneralWebSearchTool:
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,
-                tools=[{"type": "web_search_20250305"}],  # type: ignore[list-item]
+                tools=[{"type": "web_search_20250305", "name": "web_search"}],
                 messages=[
                     {
                         "role": "user",


### PR DESCRIPTION
## 요약
Anthropic `web_search_20250305` tool 정의에 required 필드 `name: "web_search"` 누락 → API 400 에러 수정

## 변경 사항
### 코드 변경
- `core/tools/web_tools.py:103`: tool 정의에 `"name": "web_search"` 추가
- `core/tools/signal_tools.py:267`: 동일 수정

## 영향 범위
- 영향받는 모듈: web_tools (GeneralWebSearchTool), signal_tools (WebSearchTool)
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [ ] `uv run pytest tests/ -q` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)