### PR TITLE
fix: REPL 터미널 프리즈 방지 + 멀티라인 붙여넣기 + LLM 스피너 + 서브에이전트 리포트

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import logging
 import re as _re
+import select
+import sys
 from contextvars import ContextVar
 from enum import Enum
 from pathlib import Path
@@ -1294,6 +1296,13 @@ def _build_sub_agent_manager(verbose: bool = False) -> Any:
                 {"name": r.ip_name, "score": r.score} for r in _get_search_engine().search(query)
             ],
         },
+        report_fn=lambda ip_name, **kw: _generate_report(
+            ip_name,
+            dry_run=kw.get("dry_run", force_dry),
+            verbose=verbose,
+            fmt=kw.get("fmt", "markdown"),
+            template=kw.get("template", "summary"),
+        ),
     )
     runner = IsolatedRunner()
     registry = AgentRegistry()
@@ -2154,6 +2163,33 @@ def _render_agentic_result(result: AgenticResult) -> None:
         )
 
 
+def _read_multiline_input(prompt: str) -> str:
+    """Read user input with multi-line paste detection.
+
+    After reading the first line, drains any remaining data buffered
+    on stdin (from a paste operation) and joins all lines into a single
+    input string.  Timeout of 50 ms distinguishes paste from manual typing.
+    """
+    first_line = console.input(prompt).strip()
+    if not first_line:
+        return ""
+
+    lines = [first_line]
+    try:
+        fd = sys.stdin.fileno()
+        while select.select([fd], [], [], 0.05)[0]:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            stripped = line.rstrip("\n")
+            if stripped:
+                lines.append(stripped)
+    except (ValueError, OSError):
+        pass  # stdin not selectable (piped / non-TTY)
+
+    return "\n".join(lines)
+
+
 def _interactive_loop() -> None:
     """Claude Code / OpenClaw-style interactive REPL.
 
@@ -2226,8 +2262,12 @@ def _interactive_loop() -> None:
     agentic_ref[0] = agentic
 
     while True:
+        # Defensive: restore terminal state before each prompt
+        # (Rich Status/Live may leave cursor hidden or echo off)
+        console.show_cursor(True)
+
         try:
-            user_input = console.input("[bold cyan]>[/bold cyan] ").strip()
+            user_input = _read_multiline_input("[bold cyan]>[/bold cyan] ")
         except (KeyboardInterrupt, EOFError):
             from core.ui.agentic_ui import render_session_cost_summary
 
@@ -2238,7 +2278,9 @@ def _interactive_loop() -> None:
         if not user_input:
             continue
 
-        if user_input.startswith("/"):
+        # Multi-line paste → always route to agentic (never slash-dispatch)
+        is_multiline = "\n" in user_input
+        if not is_multiline and user_input.startswith("/"):
             # Slash command → deterministic routing (OpenClaw Binding)
             cmd = user_input.split()[0].lower()
             args = user_input[len(cmd) :].strip()
@@ -2276,8 +2318,16 @@ def _interactive_loop() -> None:
                 agentic_ref[0] = agentic
         else:
             # Agentic loop: multi-turn + multi-intent (online) or offline regex
-            result = agentic.run(user_input)
-            _render_agentic_result(result)
+            try:
+                result = agentic.run(user_input)
+                _render_agentic_result(result)
+            except KeyboardInterrupt:
+                console.show_cursor(True)
+                console.print("\n  [dim]Interrupted.[/dim]\n")
+            except Exception as exc:
+                console.show_cursor(True)
+                log.error("Agentic loop error: %s", exc, exc_info=True)
+                console.print(f"\n  [error]Error: {exc}[/error]\n")
 
     # Clean shutdown of SchedulerService
     _sched = _scheduler_service_ctx.get(None)

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -29,6 +29,7 @@ from core.config import ANTHROPIC_PRIMARY, settings
 from core.llm.client import _maybe_traceable
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.ui.agentic_ui import render_tool_call, render_tool_result
+from core.ui.console import console
 
 if TYPE_CHECKING:
     from core.tools.registry import ToolRegistry
@@ -140,7 +141,15 @@ class AgenticLoop:
 
         for round_idx in range(self.max_rounds):
             is_last_round = round_idx == self.max_rounds - 1
-            response = self._call_llm(system_prompt, messages, round_idx=round_idx)
+
+            # Claude Code-style: spinner during LLM API call
+            with console.status(
+                "  [cyan]Thinking...[/cyan]",
+                spinner="dots",
+                spinner_style="cyan",
+            ):
+                response = self._call_llm(system_prompt, messages, round_idx=round_idx)
+
             if response is None:
                 result = AgenticResult(
                     text="LLM call failed. Try again or use /help.",
@@ -272,6 +281,9 @@ class AgenticLoop:
                 return None
             except anthropic.BadRequestError as exc:
                 log.warning("Anthropic BadRequest in agentic loop: %s", exc)
+                return None
+            except KeyboardInterrupt:
+                log.info("LLM call interrupted by user")
                 return None
             except Exception:
                 log.warning("Agentic LLM call failed", exc_info=True)

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -440,6 +440,7 @@ def make_pipeline_handler(
     run_analysis_fn: Callable[..., dict[str, Any] | None],
     search_fn: Callable[..., dict[str, Any]] | None = None,
     compare_fn: Callable[..., dict[str, Any]] | None = None,
+    report_fn: Callable[..., tuple[str, str] | None] | None = None,
 ) -> Callable[..., dict[str, Any]]:
     """Create a task_handler routing task_type to pipeline functions."""
 
@@ -467,6 +468,28 @@ def make_pipeline_handler(
             if compare_fn is None:
                 return {"error": "Compare not configured"}
             return compare_fn(**args)
+        if task_type == "report":
+            if report_fn is None:
+                return {"error": "Report generation not configured"}
+            ip_name = args.get("ip_name", "")
+            if not ip_name:
+                return {"error": "ip_name required for report task"}
+            report_result = report_fn(
+                ip_name,
+                fmt=args.get("format", "markdown"),
+                template=args.get("template", "summary"),
+                dry_run=args.get("dry_run", True),
+            )
+            if report_result is None:
+                return {"error": f"Report generation failed for '{ip_name}'"}
+            file_path, content = report_result
+            return {
+                "status": "ok",
+                "action": "report",
+                "ip_name": ip_name,
+                "file_path": file_path,
+                "content_length": len(content),
+            }
         return {"error": f"Unknown task_type: {task_type}"}
 
     return handler

--- a/tests/test_multiline_input.py
+++ b/tests/test_multiline_input.py
@@ -1,0 +1,119 @@
+"""Tests for multi-line paste detection in REPL input."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestReadMultilineInput:
+    """_read_multiline_input drains paste-buffered stdin lines."""
+
+    def test_single_line_returns_as_is(self):
+        """Single line input (no paste) returns the line unchanged."""
+        from core.cli import _read_multiline_input
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = "Berserk 분석해줘"
+
+        with (
+            patch("core.cli.console", mock_console),
+            patch("core.cli.select.select", return_value=([], [], [])),
+        ):
+            result = _read_multiline_input("[bold cyan]>[/bold cyan] ")
+
+        assert result == "Berserk 분석해줘"
+
+    def test_empty_input_returns_empty(self):
+        """Empty input returns empty string."""
+        from core.cli import _read_multiline_input
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = "   "
+
+        with patch("core.cli.console", mock_console):
+            result = _read_multiline_input("> ")
+
+        assert result == ""
+
+    def test_multiline_paste_joins_lines(self):
+        """Pasted multi-line text is joined into a single string."""
+        from core.cli import _read_multiline_input
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = "line 1"
+
+        # Simulate two additional lines buffered from paste
+        paste_lines = iter(["line 2\n", "line 3\n", ""])
+        call_count = [0]
+
+        def fake_select(rlist, wlist, xlist, timeout):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return (rlist, [], [])  # data available
+            return ([], [], [])  # no more data
+
+        def fake_readline():
+            return next(paste_lines, "")
+
+        with (
+            patch("core.cli.console", mock_console),
+            patch("core.cli.select.select", side_effect=fake_select),
+            patch("core.cli.sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.fileno.return_value = 0
+            mock_stdin.readline = fake_readline
+            result = _read_multiline_input("> ")
+
+        assert result == "line 1\nline 2\nline 3"
+
+    def test_multiline_paste_skips_blank_lines(self):
+        """Blank lines in paste are excluded."""
+        from core.cli import _read_multiline_input
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = "first"
+
+        paste_lines = iter(["\n", "second\n", ""])
+        call_count = [0]
+
+        def fake_select(rlist, wlist, xlist, timeout):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return (rlist, [], [])
+            return ([], [], [])
+
+        with (
+            patch("core.cli.console", mock_console),
+            patch("core.cli.select.select", side_effect=fake_select),
+            patch("core.cli.sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.fileno.return_value = 0
+            mock_stdin.readline = lambda: next(paste_lines, "")
+            result = _read_multiline_input("> ")
+
+        assert result == "first\nsecond"
+
+    def test_select_oserror_falls_back_to_single_line(self):
+        """When select fails (e.g. piped stdin), returns first line only."""
+        from core.cli import _read_multiline_input
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = "hello"
+
+        with (
+            patch("core.cli.console", mock_console),
+            patch("core.cli.sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.fileno.side_effect = ValueError("not a tty")
+            result = _read_multiline_input("> ")
+
+        assert result == "hello"
+
+    def test_multiline_routes_to_agentic_not_slash(self):
+        """Multi-line paste starting with '/' goes to agentic, not slash command."""
+        user_input = "/some command\nmore content\neven more"
+        is_multiline = "\n" in user_input
+
+        # Multi-line → should NOT enter slash command branch
+        assert is_multiline is True
+        assert not (not is_multiline and user_input.startswith("/"))


### PR DESCRIPTION
## 요약
REPL 터미널 프리즈 버그 수정, 멀티라인 붙여넣기 지원, LLM 대기 중 스피너 표시, 서브에이전트 리포트 생성 누락 수정.

## 변경 사항
### 코드 변경
- `core/cli/__init__.py`: 매 프롬프트 전 `console.show_cursor(True)` 터미널 상태 방어적 복원, `agentic.run()` KeyboardInterrupt/Exception 래핑, `_read_multiline_input()` paste 감지 함수 추가, `_build_sub_agent_manager`에 `report_fn` 배선
- `core/cli/agentic_loop.py`: `_call_llm()`에 `except KeyboardInterrupt` 추가 (BaseException 계열), `console.status("Thinking...")` 스피너 래핑
- `core/cli/sub_agent.py`: `make_pipeline_handler`에 `report` task type 핸들러 추가

### 테스트
- `tests/test_multiline_input.py`: 6개 테스트 (단일줄, 빈입력, 멀티라인 합침, 빈줄 스킵, OSError 폴백, 멀티라인 슬래시 라우팅)

## 영향 범위
- 영향받는 모듈/기능: REPL 입력, AgenticLoop, SubAgentManager
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -q` — 2068+ pass
- [x] 신규 테스트 추가: 6개

🤖 Generated with [Claude Code](https://claude.com/claude-code)