### PR TITLE
fix: web_search tool name 필드 누락 수정

### DIFF
--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -264,7 +264,7 @@ class WebSearchTool:
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,
-                tools=[{"type": "web_search_20250305"}],  # type: ignore[list-item]
+                tools=[{"type": "web_search_20250305", "name": "web_search"}],
                 messages=[
                     {
                         "role": "user",

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -100,7 +100,7 @@ class GeneralWebSearchTool:
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,
-                tools=[{"type": "web_search_20250305"}],  # type: ignore[list-item]
+                tools=[{"type": "web_search_20250305", "name": "web_search"}],
                 messages=[
                     {
                         "role": "user",


### PR DESCRIPTION
## 요약
develop → main 승격. Anthropic web_search_20250305 API 호출 시 필수 `name` 필드 누락 수정.

## 변경 사항
- `core/tools/web_tools.py`: `{"type": "web_search_20250305"}` → `{"type": "web_search_20250305", "name": "web_search"}`
- `core/tools/signal_tools.py`: 동일 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)