### PR TITLE
fix: API 타임아웃 처리 강화 — timeout 120s + 자동 재시도

### DIFF
--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -259,10 +259,23 @@ class AgenticLoop:
                     tool_choice=tool_choice,
                     max_tokens=self.max_tokens,
                     temperature=0.0,
-                    timeout=30.0,
+                    timeout=120.0,
                 )
                 return response  # type: ignore[no-any-return]
 
+            except anthropic.APITimeoutError:
+                wait = 2**attempt * 5  # 5s, 10s, 20s
+                log.warning(
+                    "API timeout (attempt %d/%d), retrying in %ds",
+                    attempt + 1,
+                    max_retries,
+                    wait,
+                )
+                if attempt < max_retries - 1:
+                    time.sleep(wait)
+                else:
+                    log.error("API timeout exhausted after %d retries", max_retries)
+                    return None
             except anthropic.RateLimitError:
                 wait = 2**attempt * 10  # 10s, 20s, 40s
                 log.warning(


### PR DESCRIPTION
## 요약
대형 컨텍스트(27k+ tokens) + tool use 시 30s 타임아웃으로 API 요청 실패하는 문제 수정.

## 변경 사항
### 코드 변경
- `core/cli/agentic_loop.py`: timeout 30s → 120s, `except anthropic.APITimeoutError` 전용 블록 추가 (3회 자동 재시도, 5/10/20s 백오프)

## 영향 범위
- 영향받는 모듈/기능: AgenticLoop LLM 호출
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -q` — 2068+ pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)