### PR TITLE
fix: SDK 이중 재시도 제거 + APIConnectionError 커버리지

### DIFF
--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -243,7 +243,10 @@ class AgenticLoop:
             return None
 
         if self._client is None:
-            self._client = anthropic.Anthropic(api_key=api_key)
+            # Disable SDK-level retries to prevent double-retry with our own loop.
+            # Default max_retries=2 causes SDK to retry timeouts 3× internally,
+            # compounding with our 3 retries → 9 total attempts / 18min worst case.
+            self._client = anthropic.Anthropic(api_key=api_key, max_retries=0)
 
         is_last_round = round_idx == self.max_rounds - 1
         tool_choice: dict[str, str] = {"type": "none"} if is_last_round else {"type": "auto"}
@@ -263,10 +266,12 @@ class AgenticLoop:
                 )
                 return response  # type: ignore[no-any-return]
 
-            except anthropic.APITimeoutError:
+            except (anthropic.APITimeoutError, anthropic.APIConnectionError) as exc:
                 wait = 2**attempt * 5  # 5s, 10s, 20s
+                exc_type = type(exc).__name__
                 log.warning(
-                    "API timeout (attempt %d/%d), retrying in %ds",
+                    "%s (attempt %d/%d), retrying in %ds",
+                    exc_type,
                     attempt + 1,
                     max_retries,
                     wait,
@@ -274,7 +279,7 @@ class AgenticLoop:
                 if attempt < max_retries - 1:
                     time.sleep(wait)
                 else:
-                    log.error("API timeout exhausted after %d retries", max_retries)
+                    log.error("%s exhausted after %d retries", exc_type, max_retries)
                     return None
             except anthropic.RateLimitError:
                 wait = 2**attempt * 10  # 10s, 20s, 40s


### PR DESCRIPTION
## 요약
Anthropic SDK 기본 `max_retries=2`로 인한 이중 재시도 제거, 연결 오류 커버리지 확대.

## 변경 사항
### 코드 변경
- `core/cli/agentic_loop.py`: 
  - `Anthropic(max_retries=0)` — SDK 내부 재시도 비활성화 (기존: 3×120s=360s → 자체 3회 = 9회/18분)
  - `except (APITimeoutError, APIConnectionError)` — 연결 오류 전반 커버

## 영향 범위
- AgenticLoop LLM 호출만 영향
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 2082 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)