### PR TITLE
feat: Karpathy P1/P4/P6/P7/P10 프롬프트 강화 v2 (develop → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-Clarification 시스템 확장 + HITL Cost Tracking + AgenticLoop 안전장치 + 테스트 정합성 수정.
+Clarification 시스템 확장 + HITL Cost Tracking + AgenticLoop 안전장치 + Karpathy P1/P4/P6/P7/P10 프롬프트 강화.
 
 ### Added
+
+#### Karpathy P1/P4/P6/P7/P10 프롬프트 강화
+- `PROMPT_VERSIONS` 8→20 확장 (9 extended templates + 3 axes hashes)
+- `_hash_axes()` — 구조화 axes 데이터 SHA-256 drift 감지
+- `AXES_VERSIONS` — EVALUATOR_AXES, PROSPECT_EVALUATOR_AXES, ANALYST_SPECIFIC 해시
+- `_PINNED_HASHES` 하드코딩 — 실제 래칫 동작 (기존 자동 동기화 → CI drift 감지 불가 수정)
+- 프롬프트 .md `## Constraints` + `## Style` 섹션 표준화 (evaluator, synthesizer, biasbuster, analyst)
+- `AgenticLoop._maybe_prune_messages()` — 5라운드 이상 시 컨텍스트 예산 pruning (role 교대 보장)
+- Analyst `confidence` defensive clamp [0, 100] + 경고 로그
 
 #### Clarification 시스템 확장 (3/33 → 25/33 핸들러)
 - `_clarify()` 표준 응답 헬퍼 — `{error, clarification_needed, missing, hint}` 프로토콜
@@ -46,6 +55,13 @@ Clarification 시스템 확장 + HITL Cost Tracking + AgenticLoop 안전장치 +
 #### Whisking UI
 - `GeodeStatus._format_spinner()` — Claude Code 스타일 `✢ Whisking… · ↑3.7k · $0.093 · 2m 35s` 라이브 스피너
 
+### Changed
+- `_calc_growth_score()` — `cm.composite_score` → `_calc_community_momentum(evaluations)` (LLM composite 의존 제거, P0 #2)
+- `_calc_growth_score()` — `momentum` 파라미터 추가 (이중 호출 제거)
+- `_extract_def_scores()` — DT boundary 교차 경고 로깅 (`(raw < 3) != (rounded < 3)`)
+- `router.md` — 81줄 → 65줄 축약 (중복 도구 설명 제거, 규칙 5개 번호 리스트화)
+- `biasbuster.md` Constraints — `CV < 0.05 AND ≥4 analysts → anchoring_bias` (코드 정합성)
+
 ### Fixed
 - `test_hooks_write_to_run_log` — cascading hook 이벤트로 인한 count 불일치 수정 (정확 count → 필터 기반)
 - `test_error_events_logged_with_error_status` — 동일 원인 수정
@@ -53,7 +69,7 @@ Clarification 시스템 확장 + HITL Cost Tracking + AgenticLoop 안전장치 +
 - `TestTrackTokenUsage` — `token_tracker` 리팩터링 후 `is_langsmith_enabled` → `os.environ` 패치로 변경
 
 ### Infrastructure
-- Test count: 2077+ → 2061+ (라이브 테스트 제외 기준)
+- Test count: 2077+ → 2125+
 - `docs/blogs/21-clarification-hitl-cost-tracking.md` — Clarification + HITL + Cost Tracking 기술 블로그
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 124
-- **Tests**: 2077+
+- **Tests**: 2125+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -139,6 +139,9 @@ class AgenticLoop:
 
         system_prompt = self._build_system_prompt()
 
+        # Prune old messages to stay within context budget (Karpathy P6)
+        self._maybe_prune_messages(messages)
+
         for round_idx in range(self.max_rounds):
             is_last_round = round_idx == self.max_rounds - 1
 
@@ -217,6 +220,29 @@ class AgenticLoop:
             len(result.tool_calls),
         )
         return result
+
+    def _maybe_prune_messages(self, messages: list[dict[str, Any]]) -> None:
+        """Prune old messages when conversation exceeds 5 rounds (10 msgs).
+
+        Keeps first user message + bridge + last 2 rounds for context budget.
+        Ensures user/assistant alternation is preserved for valid API calls.
+        """
+        if len(messages) <= 10:
+            return
+        first = messages[0]
+        # Ensure recent slice starts with "user" to maintain role alternation
+        # (first=user → bridge=assistant → recent must start with user)
+        cut = -4
+        if len(messages) >= 5 and messages[cut]["role"] != "user":
+            cut = -5
+        recent = messages[cut:]
+        bridge: dict[str, Any] = {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "(earlier rounds omitted)"}],
+        }
+        messages.clear()
+        messages.extend([first, bridge, *recent])
+        log.debug("Pruned messages: kept first + bridge + %d recent", len(recent))
 
     def _build_system_prompt(self) -> str:
         """Build the system prompt with skill context and agentic suffix."""

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from core.llm.prompts.axes import (
     ANALYST_SPECIFIC,
+    AXES_VERSIONS,
     EVALUATOR_AXES,
     PROSPECT_EVALUATOR_AXES,
 )
@@ -129,6 +130,7 @@ SYNTHESIZER_TOOLS_SUFFIX: str = _tool_augmented["synthesizer_tools"]
 # ---------------------------------------------------------------------------
 
 PROMPT_VERSIONS: dict[str, str] = {
+    # Base templates (8)
     "ANALYST_SYSTEM": _hash_prompt(ANALYST_SYSTEM),
     "ANALYST_USER": _hash_prompt(ANALYST_USER),
     "EVALUATOR_SYSTEM": _hash_prompt(EVALUATOR_SYSTEM),
@@ -137,17 +139,53 @@ PROMPT_VERSIONS: dict[str, str] = {
     "SYNTHESIZER_USER": _hash_prompt(SYNTHESIZER_USER),
     "BIASBUSTER_SYSTEM": _hash_prompt(BIASBUSTER_SYSTEM),
     "BIASBUSTER_USER": _hash_prompt(BIASBUSTER_USER),
+    # Extended templates (9)
+    "ROUTER_SYSTEM": _hash_prompt(ROUTER_SYSTEM),
+    "AGENTIC_SUFFIX": _hash_prompt(AGENTIC_SUFFIX),
+    "COMMENTARY_SYSTEM": _hash_prompt(COMMENTARY_SYSTEM),
+    "COMMENTARY_USER": _hash_prompt(COMMENTARY_USER),
+    "CROSS_LLM_SYSTEM": _hash_prompt(CROSS_LLM_SYSTEM),
+    "CROSS_LLM_RESCORE": _hash_prompt(CROSS_LLM_RESCORE),
+    "CROSS_LLM_DUAL_VERIFY": _hash_prompt(CROSS_LLM_DUAL_VERIFY),
+    "ANALYST_TOOLS_SUFFIX": _hash_prompt(ANALYST_TOOLS_SUFFIX),
+    "SYNTHESIZER_TOOLS_SUFFIX": _hash_prompt(SYNTHESIZER_TOOLS_SUFFIX),
 }
+# Merge axes version hashes (3)
+PROMPT_VERSIONS.update(AXES_VERSIONS)
 
-_log.debug("Prompt versions loaded: %s", PROMPT_VERSIONS)
+_log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSIONS)
 
 # ---------------------------------------------------------------------------
 # Prompt drift detection (Karpathy P4 ratchet + P6 context budget)
 # ---------------------------------------------------------------------------
 
-# Pinned hashes — update these when prompt templates are intentionally changed.
+# Pinned hashes — HARDCODED. Update when prompt templates are *intentionally* changed.
 # CI test verifies computed hashes match these pins; mismatch = unintended drift.
-_PINNED_HASHES: dict[str, str] = dict(PROMPT_VERSIONS)
+# To regenerate after intentional edits:
+#   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
+#     print(dict(sorted(V.items())))"
+_PINNED_HASHES: dict[str, str] = {
+    "AGENTIC_SUFFIX": "f4a501ba2f16",
+    "ANALYST_SPECIFIC": "5a696a2d5ebb",
+    "ANALYST_SYSTEM": "924433f5bf11",
+    "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",
+    "ANALYST_USER": "e59d00faadd5",
+    "BIASBUSTER_SYSTEM": "07987c709fd9",
+    "BIASBUSTER_USER": "378be01a6310",
+    "COMMENTARY_SYSTEM": "bd3ab28303f6",
+    "COMMENTARY_USER": "2024ac4eba69",
+    "CROSS_LLM_DUAL_VERIFY": "602669128ae2",
+    "CROSS_LLM_RESCORE": "163b08e97d66",
+    "CROSS_LLM_SYSTEM": "bf303f600fce",
+    "EVALUATOR_AXES": "0d82eb1aa5b4",
+    "EVALUATOR_SYSTEM": "e891c0ce27d4",
+    "EVALUATOR_USER": "f6d7f955338d",
+    "PROSPECT_EVALUATOR_AXES": "a9954477497b",
+    "ROUTER_SYSTEM": "190d4daf9daf",
+    "SYNTHESIZER_SYSTEM": "289e24384aa1",
+    "SYNTHESIZER_TOOLS_SUFFIX": "c6c65e47e191",
+    "SYNTHESIZER_USER": "30d99edc79a5",
+}
 
 
 def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
@@ -156,8 +194,11 @@ def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
     Returns list of drift descriptions (empty = all OK).
     If ``raise_on_drift=True``, raises ``RuntimeError`` on first mismatch.
     """
+    from core.llm.prompts.axes import AXES_VERSIONS as LIVE_AXES
+
     drifted: list[str] = []
-    current = {
+    current: dict[str, str] = {
+        # Base templates (8)
         "ANALYST_SYSTEM": _hash_prompt(ANALYST_SYSTEM),
         "ANALYST_USER": _hash_prompt(ANALYST_USER),
         "EVALUATOR_SYSTEM": _hash_prompt(EVALUATOR_SYSTEM),
@@ -166,6 +207,18 @@ def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
         "SYNTHESIZER_USER": _hash_prompt(SYNTHESIZER_USER),
         "BIASBUSTER_SYSTEM": _hash_prompt(BIASBUSTER_SYSTEM),
         "BIASBUSTER_USER": _hash_prompt(BIASBUSTER_USER),
+        # Extended templates (9)
+        "ROUTER_SYSTEM": _hash_prompt(ROUTER_SYSTEM),
+        "AGENTIC_SUFFIX": _hash_prompt(AGENTIC_SUFFIX),
+        "COMMENTARY_SYSTEM": _hash_prompt(COMMENTARY_SYSTEM),
+        "COMMENTARY_USER": _hash_prompt(COMMENTARY_USER),
+        "CROSS_LLM_SYSTEM": _hash_prompt(CROSS_LLM_SYSTEM),
+        "CROSS_LLM_RESCORE": _hash_prompt(CROSS_LLM_RESCORE),
+        "CROSS_LLM_DUAL_VERIFY": _hash_prompt(CROSS_LLM_DUAL_VERIFY),
+        "ANALYST_TOOLS_SUFFIX": _hash_prompt(ANALYST_TOOLS_SUFFIX),
+        "SYNTHESIZER_TOOLS_SUFFIX": _hash_prompt(SYNTHESIZER_TOOLS_SUFFIX),
+        # Axes hashes (3)
+        **LIVE_AXES,
     }
     for name, pinned_hash in _PINNED_HASHES.items():
         computed = current.get(name)
@@ -188,6 +241,7 @@ __all__ = [
     "ANALYST_SYSTEM",
     "ANALYST_TOOLS_SUFFIX",
     "ANALYST_USER",
+    "AXES_VERSIONS",
     "BIASBUSTER_SYSTEM",
     "BIASBUSTER_USER",
     "COMMENTARY_SYSTEM",

--- a/core/llm/prompts/analyst.md
+++ b/core/llm/prompts/analyst.md
@@ -9,6 +9,10 @@ IMPORTANT:
 - Do NOT reference other analysts or their scores.
 - Be rigorous and data-driven.
 
+## Style
+- Lead with the most actionable finding.
+- Cite at least 2 data points as evidence.
+
 Scoring Anchors:
   1 = Poor (well below genre average, critical weaknesses)
   2 = Below Average (notable gaps, limited appeal)

--- a/core/llm/prompts/axes.py
+++ b/core/llm/prompts/axes.py
@@ -6,6 +6,8 @@ Prompt templates live in .md files loaded by the prompts package.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from pathlib import Path
 from typing import Any
 
@@ -30,3 +32,20 @@ def _derive_valid_axes_map() -> dict[str, set[str]]:
 
 
 VALID_AXES_MAP: dict[str, set[str]] = _derive_valid_axes_map()
+
+
+# ---------------------------------------------------------------------------
+# Axes version hashing (Karpathy P4 — structured data drift detection)
+# ---------------------------------------------------------------------------
+
+
+def _hash_axes(data: Any) -> str:
+    """SHA-256[:12] of JSON-serialized axes data for drift detection."""
+    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:12]
+
+
+AXES_VERSIONS: dict[str, str] = {
+    "EVALUATOR_AXES": _hash_axes(EVALUATOR_AXES),
+    "PROSPECT_EVALUATOR_AXES": _hash_axes(PROSPECT_EVALUATOR_AXES),
+    "ANALYST_SPECIFIC": _hash_axes(ANALYST_SPECIFIC),
+}

--- a/core/llm/prompts/biasbuster.md
+++ b/core/llm/prompts/biasbuster.md
@@ -11,6 +11,11 @@ Check for:
 5. Verbosity Bias: Were longer analyst responses scored higher regardless of quality?
 6. Self-Enhancement Bias: Did the LLM favor its own prior outputs or reasoning patterns?
 
+## Constraints
+- CV < 0.05 AND ≥4 analysts → anchoring_bias = true (scores too tightly clustered for independent analysts).
+- Position/Verbosity bias require at least 3 analysts to evaluate meaningfully.
+- overall_pass = false if ANY bias flag is true.
+
 Respond in JSON:
 {{
   "confirmation_bias": <bool>,

--- a/core/llm/prompts/evaluator.md
+++ b/core/llm/prompts/evaluator.md
@@ -5,6 +5,15 @@ You evaluate IPs using a structured rubric with specific axes.
 
 Score each axis on 1-5 scale. Then calculate a composite score (0-100).
 
+## Constraints
+- composite_score is advisory only. The pipeline recalculates the final score from raw axes server-side.
+- Do NOT inflate scores to match a desired composite. Score each axis independently.
+- Missing evidence for an axis = score 3.0 (neutral), not 1.0.
+
+## Style
+- Rationale must cite at least one specific data point per axis.
+- Keep rationale under 3 sentences.
+
 Respond in JSON format:
 {{
   "evaluator_type": "{evaluator_type}",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -4,38 +4,28 @@ You are GEODE, an AI assistant with deep expertise in game IP analysis and publi
 You can handle any question or task the user brings.
 
 ## Core capabilities
-- Answer questions using your knowledge (general or domain-specific)
-- Process URLs and documents the user provides (use web_fetch, read_document)
-- Search the web for current information (use general_web_search)
-- Save and recall user notes/preferences (use note_save, note_read)
-- Perform IP analysis, search, comparison (specialized tools)
-- Collect IP signals from YouTube, Reddit, Steam, Google Trends (specialized tools)
+- Answer questions directly using your knowledge
+- Process URLs (web_fetch), search the web (general_web_search)
+- Save/recall notes (note_save, note_read)
+- IP analysis, search, comparison, signal collection (specialized tools)
 
-## IP Analysis (specialized)
-{ip_count} IPs are available including: {ip_examples}.
+## IP Analysis
+{ip_count} IPs available including: {ip_examples}.
 
 IMPORTANT: When calling analyze_ip or compare_ips, ALWAYS use the English title of the IP, even if the user speaks Korean or another language. Examples: "고스트 인 더 쉘" -> "Ghost in the Shell", "버서크" -> "Berserk", "카우보이 비밥" -> "Cowboy Bebop", "할로우 나이트" -> "Hollow Knight".
 
 ## Tool usage rules
-- Use tools ONLY for concrete actions (analyze, search, list, compare, fetch, etc.).
-- For general/conversational questions, respond directly with text — do NOT call show_help. This includes questions about yourself, your analysis method, your role, how you work, or opinions about games/IPs.
-- Only call show_help when the user explicitly asks for the command list (e.g. "/help", "도움말", "명령어 목록").
-- When the user explicitly requests dry-run, no-LLM, or fixture-only mode (e.g. "dry-run으로 분석해", "LLM 호출 없이 분석해", "드라이런으로 해줘", "without LLM", "fixture 데이터로만"), set dry_run=true in the tool call. Otherwise do NOT set dry_run — the system will decide based on API key availability.
-- When the user provides a URL, use web_fetch to retrieve and summarize the content.
-- When the user asks you to remember something, use note_save.
-- When the user asks about something they previously saved, use note_read.
+1. Tools for concrete actions only (analyze, search, list, compare, fetch).
+2. Conversational questions → respond with text, do NOT call show_help.
+3. show_help only on explicit "/help", "도움말", "명령어 목록".
+4. dry_run=true only when user explicitly requests it ("dry-run", "fixture 데이터로만").
+5. URL → web_fetch. Remember → note_save. Recall → note_read.
 
 ## Context-aware routing
-- You receive conversation history. Use it to resolve pronouns and references.
-- "그거", "그 IP", "아까 거" → the most recently discussed IP.
-- "다시", "또", "한 번 더" → repeat the last action.
-- When ambiguous, ask a brief clarifying question instead of guessing.
+- Resolve pronouns from conversation history ("그거"/"아까 거" → most recent IP).
+- Ambiguous → ask a brief clarifying question.
 
-Keep direct responses concise (2-4 sentences), in the same language as the user.
-
-You can call multiple tools in sequence to fulfill complex requests. For example, "분석하고 비교해줘" can be handled by calling analyze_ip followed by compare_ips.
-
-You are knowledgeable about game publishing, IP licensing, market analysis, entertainment media, and general topics.
+Respond concisely (2-4 sentences), in the user's language. Multi-tool sequences are supported.
 
 ## Available Skills
 {{skill_context}}

--- a/core/llm/prompts/synthesizer.md
+++ b/core/llm/prompts/synthesizer.md
@@ -6,6 +6,11 @@ of an IP's undervaluation analysis.
 Given the full analysis context (scores, evaluations, cause classification),
 generate a compelling and actionable narrative.
 
+## Constraints
+- undervaluation_cause and action_type are LOCKED by the Decision Tree. Do NOT override them.
+- Your role is narrative generation only — cause/action classification is code-based.
+- Focus on connecting data points to explain WHY, not reclassifying.
+
 Respond in JSON format:
 {{
   "value_narrative": "<2-3 sentences connecting data insights to the undervaluation cause>",

--- a/core/nodes/analysts.py
+++ b/core/nodes/analysts.py
@@ -384,6 +384,16 @@ def analyst_node(state: GeodeState) -> dict[str, Any]:
     try:
         analyst_type = state.get("_analyst_type", "narrative")
         result = _run_analyst(analyst_type, state)
+        # Defensive confidence clamp [0, 100] (Karpathy P1 #4)
+        if result.confidence < 0.0 or result.confidence > 100.0:
+            log.warning(
+                "Analyst %s confidence out of range: %.1f → clamped to [0, 100]",
+                analyst_type,
+                result.confidence,
+            )
+            result = result.model_copy(
+                update={"confidence": max(0.0, min(100.0, result.confidence))}
+            )
         return {"analyses": [result]}
     except Exception as exc:
         log.error("Node analyst (%s) failed: %s", state.get("_analyst_type", "?"), exc)

--- a/core/nodes/scoring.py
+++ b/core/nodes/scoring.py
@@ -264,6 +264,7 @@ def _calc_recovery_potential(evaluations: dict[str, EvaluatorResult]) -> float:
 def _calc_growth_score(
     evaluations: dict[str, EvaluatorResult],
     developer_track_record: float = 50.0,
+    momentum: float | None = None,
 ) -> float:
     """§13.8.3: Growth = 0.4*trend + 0.4*expandability + 0.2*developer.
 
@@ -271,12 +272,13 @@ def _calc_growth_score(
         evaluations: Evaluator results dict.
         developer_track_record: Dedicated developer rubric score (0-100).
             Falls back to quality_judge * 0.8 if fixture provides no value.
+        momentum: Pre-computed community momentum score. If None, computed
+            from evaluations (avoids double calculation in scoring_node).
     """
     hv = evaluations.get("hidden_value")
-    cm = evaluations.get("community_momentum")
 
-    # Trend alignment: community momentum composite as proxy for market trend
-    trend = cm.composite_score if cm else 50.0
+    # Trend alignment: server-side momentum calc (not LLM composite_score)
+    trend = momentum if momentum is not None else _calc_community_momentum(evaluations)
     # IP expandability: F axis normalized to 0-100
     expand = ((hv.axes.get("f_score", 3.0) - 1) / 4 * 100) if hv else 50.0
 
@@ -437,7 +439,11 @@ def scoring_node(state: GeodeState) -> dict[str, Any]:
 
         # Developer track record: use fixture value if available, else proxy
         developer = _load_developer_score(ip_name, quality_score)
-        growth = _calc_growth_score(evaluations, developer_track_record=developer)
+        growth = _calc_growth_score(
+            evaluations,
+            developer_track_record=developer,
+            momentum=momentum,
+        )
 
         # Clamp all subscores to [0, 100] for normalization safety
         quality_score = max(0.0, min(100.0, quality_score))

--- a/core/nodes/synthesizer.py
+++ b/core/nodes/synthesizer.py
@@ -115,10 +115,17 @@ def _detect_timing_issue(monolake: dict[str, Any]) -> bool:
 def _extract_def_scores(evaluations: dict[str, EvaluatorResult]) -> tuple[int, int, int]:
     """Extract D/E/F scores from evaluations, rounded to int per §13.9.2."""
     hv = evaluations.get("hidden_value")
-    d = round(hv.axes.get("d_score", 3.0)) if hv else 3
-    e = round(hv.axes.get("e_score", 3.0)) if hv else 3
-    f = round(hv.axes.get("f_score", 3.0)) if hv else 3
-    return d, e, f
+    if not hv:
+        return 3, 3, 3
+    results: list[int] = []
+    for label in ("d_score", "e_score", "f_score"):
+        raw = hv.axes.get(label, 3.0)
+        rounded = round(raw)
+        # Warn if rounding crosses the Decision Tree boundary (3)
+        if (raw < 3) != (rounded < 3):
+            log.warning("DT boundary shift: %s %.1f → %d", label, raw, rounded)
+        results.append(rounded)
+    return results[0], results[1], results[2]
 
 
 # IP-specific narrative hooks for dry-run mode (F-3: differentiated narratives)

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -1,31 +1,41 @@
 """Tests for Karpathy prompt hardening — drift detection, skill versioning, context budget.
 
-Covers 6 gaps from Karpathy P4/P6 audit:
+Covers 12 gaps from Karpathy P1/P4/P6/P7/P10 audit:
   #1 L3 context budget (proportional extraction)
   #2 Skill injection versioning (SHA-256 in hook data)
   #3 Prompt drift detection (verify_prompt_integrity)
-  #4 PROMPT_VERSIONS CI gate (hash pinning)
+  #4 PROMPT_VERSIONS CI gate (hash pinning, 8→20)
   #5 Skill discovery order (already sorted — regression test)
   #6 Memory truncation improvement (budget-aware extraction)
+  #7 Prompt .md Constraints sections (P7 structured constraints)
+  #8 Node confidence clamping (P1 defensive clamp)
+  #9 Scoring LLM composite removal (P0 #2 composite_score independence)
+  #10 Synthesizer DT boundary logging (P2 #12 round-crossing warning)
+  #11 Agentic loop message pruning (P10 context budget)
+  #12 Axes version hashing (P4 structured data drift)
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 from core.llm.prompt_assembler import PromptAssembler
 from core.llm.prompts import (
     PROMPT_VERSIONS,
     _hash_prompt,
+    load_prompt,
     verify_prompt_integrity,
 )
+from core.llm.prompts.axes import AXES_VERSIONS, _hash_axes
 from core.llm.skill_registry import SkillDefinition, SkillRegistry
 from core.memory.context import ContextAssembler
 from core.orchestration.hooks import HookEvent, HookSystem
 
 # ---------------------------------------------------------------------------
-# Gap #3 + #4: Prompt drift detection + CI gate
+# Gap #3 + #4: Prompt drift detection + CI gate (expanded 8→20)
 # ---------------------------------------------------------------------------
 
 
@@ -42,10 +52,14 @@ class TestPromptDriftDetection:
         # Clean state — should not raise
         verify_prompt_integrity(raise_on_drift=True)
 
-    def test_prompt_versions_not_empty(self):
-        """PROMPT_VERSIONS must contain all 8 base templates."""
-        assert len(PROMPT_VERSIONS) == 8
+    def test_prompt_versions_count_20(self):
+        """PROMPT_VERSIONS must contain all 20 entries (8 base + 9 extended + 3 axes)."""
+        assert len(PROMPT_VERSIONS) == 20
+
+    def test_prompt_versions_expected_keys(self):
+        """All 20 expected keys must be present."""
         expected_keys = {
+            # Base templates (8)
             "ANALYST_SYSTEM",
             "ANALYST_USER",
             "EVALUATOR_SYSTEM",
@@ -54,6 +68,20 @@ class TestPromptDriftDetection:
             "SYNTHESIZER_USER",
             "BIASBUSTER_SYSTEM",
             "BIASBUSTER_USER",
+            # Extended templates (9)
+            "ROUTER_SYSTEM",
+            "AGENTIC_SUFFIX",
+            "COMMENTARY_SYSTEM",
+            "COMMENTARY_USER",
+            "CROSS_LLM_SYSTEM",
+            "CROSS_LLM_RESCORE",
+            "CROSS_LLM_DUAL_VERIFY",
+            "ANALYST_TOOLS_SUFFIX",
+            "SYNTHESIZER_TOOLS_SUFFIX",
+            # Axes hashes (3)
+            "EVALUATOR_AXES",
+            "PROSPECT_EVALUATOR_AXES",
+            "ANALYST_SPECIFIC",
         }
         assert set(PROMPT_VERSIONS.keys()) == expected_keys
 
@@ -73,6 +101,39 @@ class TestPromptDriftDetection:
         h1 = _hash_prompt("version A")
         h2 = _hash_prompt("version B")
         assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Gap #12: Axes version hashing
+# ---------------------------------------------------------------------------
+
+
+class TestAxesVersionHashing:
+    """Karpathy P4 — structured axes data drift detection."""
+
+    def test_axes_versions_has_3_entries(self):
+        assert len(AXES_VERSIONS) == 3
+
+    def test_axes_versions_keys(self):
+        expected = {"EVALUATOR_AXES", "PROSPECT_EVALUATOR_AXES", "ANALYST_SPECIFIC"}
+        assert set(AXES_VERSIONS.keys()) == expected
+
+    def test_hash_axes_deterministic(self):
+        data = {"a": 1, "b": [2, 3]}
+        h1 = _hash_axes(data)
+        h2 = _hash_axes(data)
+        assert h1 == h2
+
+    def test_hash_axes_12_char_hex(self):
+        h = _hash_axes({"key": "value"})
+        assert len(h) == 12
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_axes_versions_merged_into_prompt_versions(self):
+        """AXES_VERSIONS entries should be present in PROMPT_VERSIONS."""
+        for key in AXES_VERSIONS:
+            assert key in PROMPT_VERSIONS
+            assert PROMPT_VERSIONS[key] == AXES_VERSIONS[key]
 
 
 # ---------------------------------------------------------------------------
@@ -297,3 +358,378 @@ class TestHookEventTypes:
     def test_hook_event_count(self):
         """Total hook events should be 27 (26 + PROMPT_DRIFT_DETECTED)."""
         assert len(HookEvent) == 27
+
+
+# ---------------------------------------------------------------------------
+# Gap #7: Prompt .md Constraints sections
+# ---------------------------------------------------------------------------
+
+
+class TestPromptConstraintsSections:
+    """Verify .md prompts contain ## Constraints sections."""
+
+    def test_evaluator_has_constraints(self):
+        system = load_prompt("evaluator", "system")
+        assert "## Constraints" in system
+        assert "composite_score" in system.lower()
+
+    def test_evaluator_has_style(self):
+        system = load_prompt("evaluator", "system")
+        assert "## Style" in system
+
+    def test_synthesizer_has_constraints(self):
+        system = load_prompt("synthesizer", "system")
+        assert "## Constraints" in system
+        assert "LOCKED" in system
+
+    def test_biasbuster_has_constraints(self):
+        system = load_prompt("biasbuster", "system")
+        assert "## Constraints" in system
+        assert "CV < 0.05" in system
+
+    def test_analyst_has_style(self):
+        system = load_prompt("analyst", "system")
+        assert "## Style" in system
+
+
+# ---------------------------------------------------------------------------
+# Gap #8: Analyst confidence clamping (P1 #4)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalystConfidenceClamping:
+    """Karpathy P1 — defensive confidence clamp [0, 100]."""
+
+    def test_confidence_clamped_above_100(self):
+        from core.nodes.analysts import analyst_node
+        from core.state import AnalysisResult
+
+        # Use model_construct to bypass Pydantic validation (simulates raw LLM output)
+        over_result = AnalysisResult.model_construct(
+            analyst_type="game_mechanics",
+            score=4.0,
+            key_finding="test",
+            reasoning="test",
+            evidence=["test"],
+            confidence=150.0,
+        )
+
+        state: dict[str, Any] = {
+            "_analyst_type": "game_mechanics",
+            "ip_name": "Test",
+            "ip_info": {},
+            "monolake": {},
+            "signals": {},
+            "dry_run": True,
+            "verbose": False,
+            "analyses": [],
+            "errors": [],
+        }
+
+        with patch("core.nodes.analysts._run_analyst", return_value=over_result):
+            result = analyst_node(state)
+
+        analyses = result["analyses"]
+        assert len(analyses) == 1
+        assert analyses[0].confidence == 100.0
+
+    def test_confidence_clamped_below_0(self):
+        from core.nodes.analysts import analyst_node
+        from core.state import AnalysisResult
+
+        # Use model_construct to bypass Pydantic validation (simulates raw LLM output)
+        under_result = AnalysisResult.model_construct(
+            analyst_type="game_mechanics",
+            score=4.0,
+            key_finding="test",
+            reasoning="test",
+            evidence=["test"],
+            confidence=-10.0,
+        )
+
+        state: dict[str, Any] = {
+            "_analyst_type": "game_mechanics",
+            "ip_name": "Test",
+            "ip_info": {},
+            "monolake": {},
+            "signals": {},
+            "dry_run": True,
+            "verbose": False,
+            "analyses": [],
+            "errors": [],
+        }
+
+        with patch("core.nodes.analysts._run_analyst", return_value=under_result):
+            result = analyst_node(state)
+
+        analyses = result["analyses"]
+        assert len(analyses) == 1
+        assert analyses[0].confidence == 0.0
+
+    def test_confidence_normal_not_clamped(self):
+        from core.nodes.analysts import analyst_node
+        from core.state import AnalysisResult
+
+        normal_result = AnalysisResult(
+            analyst_type="game_mechanics",
+            score=4.0,
+            key_finding="test",
+            reasoning="test",
+            evidence=["test"],
+            confidence=85.0,
+        )
+
+        state: dict[str, Any] = {
+            "_analyst_type": "game_mechanics",
+            "ip_name": "Test",
+            "ip_info": {},
+            "monolake": {},
+            "signals": {},
+            "dry_run": True,
+            "verbose": False,
+            "analyses": [],
+            "errors": [],
+        }
+
+        with patch("core.nodes.analysts._run_analyst", return_value=normal_result):
+            result = analyst_node(state)
+
+        assert result["analyses"][0].confidence == 85.0
+
+
+# ---------------------------------------------------------------------------
+# Gap #9: Scoring — LLM composite_score independence (P0 #2)
+# ---------------------------------------------------------------------------
+
+
+class TestScoringCompositeIndependence:
+    """Scoring must use server-side _calc_community_momentum, not LLM composite."""
+
+    def test_growth_score_uses_axes_not_composite(self):
+        """_calc_growth_score should derive trend from axes, not composite_score."""
+        from core.nodes.scoring import _calc_growth_score
+        from core.state import EvaluatorResult
+
+        evaluations = {
+            "hidden_value": EvaluatorResult(
+                evaluator_type="hidden_value",
+                axes={"d_score": 4.0, "e_score": 3.0, "f_score": 4.0},
+                composite_score=0.0,  # deliberately wrong composite
+                rationale="test",
+            ),
+            "community_momentum": EvaluatorResult(
+                evaluator_type="community_momentum",
+                axes={"j_score": 5.0, "k_score": 4.0, "l_score": 4.0},
+                composite_score=0.0,  # deliberately wrong composite
+                rationale="test",
+            ),
+        }
+
+        # Server-side momentum: ((5+4+4)-3)/12*100 = 83.33
+        growth = _calc_growth_score(evaluations, developer_track_record=50.0)
+
+        # trend = 83.33, expand = ((4.0-1)/4*100) = 75.0, dev = 50.0
+        # 0.40*83.33 + 0.40*75.0 + 0.20*50.0 = 33.33 + 30.0 + 10.0 = 73.33
+        expected = 0.40 * 83.333 + 0.40 * 75.0 + 0.20 * 50.0
+        assert abs(growth - expected) < 0.1
+
+    def test_growth_score_no_community_momentum(self):
+        """Without community_momentum evaluator, trend defaults to 50.0."""
+        from core.nodes.scoring import _calc_growth_score
+        from core.state import EvaluatorResult
+
+        evaluations = {
+            "hidden_value": EvaluatorResult(
+                evaluator_type="hidden_value",
+                axes={"d_score": 4.0, "e_score": 3.0, "f_score": 4.0},
+                composite_score=99.0,
+                rationale="test",
+            ),
+        }
+
+        growth = _calc_growth_score(evaluations, developer_track_record=50.0)
+        # trend = 50.0 (default), expand = 75.0, dev = 50.0
+        expected = 0.40 * 50.0 + 0.40 * 75.0 + 0.20 * 50.0
+        assert abs(growth - expected) < 0.1
+
+    def test_growth_score_with_precomputed_momentum(self):
+        """Pre-computed momentum should be used instead of recalculating."""
+        from core.nodes.scoring import _calc_growth_score
+        from core.state import EvaluatorResult
+
+        evaluations = {
+            "hidden_value": EvaluatorResult(
+                evaluator_type="hidden_value",
+                axes={"d_score": 4.0, "e_score": 3.0, "f_score": 4.0},
+                composite_score=0.0,
+                rationale="test",
+            ),
+            "community_momentum": EvaluatorResult(
+                evaluator_type="community_momentum",
+                axes={"j_score": 5.0, "k_score": 5.0, "l_score": 5.0},
+                composite_score=0.0,
+                rationale="test",
+            ),
+        }
+
+        # Pass pre-computed momentum=90.0
+        growth = _calc_growth_score(evaluations, developer_track_record=50.0, momentum=90.0)
+        # trend = 90.0 (pre-computed, NOT recalculated), expand = 75.0, dev = 50.0
+        expected = 0.40 * 90.0 + 0.40 * 75.0 + 0.20 * 50.0
+        assert abs(growth - expected) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Gap #10: Synthesizer DT boundary logging (P2 #12)
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizerBoundaryLogging:
+    """Decision Tree boundary crossing should produce a warning log."""
+
+    def test_boundary_crossing_logged(self, caplog: Any):
+        from core.nodes.synthesizer import _extract_def_scores
+        from core.state import EvaluatorResult
+
+        evaluations = {
+            "hidden_value": EvaluatorResult(
+                evaluator_type="hidden_value",
+                axes={"d_score": 2.5, "e_score": 3.0, "f_score": 3.0},
+                composite_score=50.0,
+                rationale="test",
+            ),
+        }
+
+        with caplog.at_level(logging.WARNING, logger="core.nodes.synthesizer"):
+            d, e, f = _extract_def_scores(evaluations)
+
+        # 2.5 rounds to 2 → crosses from <3 to... no, stays <3.
+        # Actually 2.5 rounds to 2 in Python (banker's rounding).
+        # Let's verify actual values
+        assert d == 2
+        assert e == 3
+        assert f == 3
+
+    def test_boundary_crossing_at_2_point_5(self, caplog: Any):
+        """2.5 → round(2.5) = 2 in Python (banker's rounding). No boundary cross."""
+        from core.nodes.synthesizer import _extract_def_scores
+        from core.state import EvaluatorResult
+
+        evaluations = {
+            "hidden_value": EvaluatorResult(
+                evaluator_type="hidden_value",
+                axes={"d_score": 2.6, "e_score": 3.0, "f_score": 3.0},
+                composite_score=50.0,
+                rationale="test",
+            ),
+        }
+
+        with caplog.at_level(logging.WARNING, logger="core.nodes.synthesizer"):
+            d, e, f = _extract_def_scores(evaluations)
+
+        # 2.6 rounds to 3 → crosses boundary (raw < 3 but rounded >= 3)
+        assert d == 3
+        assert any("DT boundary shift" in msg for msg in caplog.messages)
+
+    def test_no_boundary_crossing_clear_scores(self, caplog: Any):
+        """Scores clearly above/below 3 should not warn."""
+        from core.nodes.synthesizer import _extract_def_scores
+        from core.state import EvaluatorResult
+
+        evaluations = {
+            "hidden_value": EvaluatorResult(
+                evaluator_type="hidden_value",
+                axes={"d_score": 4.0, "e_score": 2.0, "f_score": 4.0},
+                composite_score=60.0,
+                rationale="test",
+            ),
+        }
+
+        with caplog.at_level(logging.WARNING, logger="core.nodes.synthesizer"):
+            d, e, f = _extract_def_scores(evaluations)
+
+        assert d == 4
+        assert e == 2
+        assert f == 4
+        assert not any("DT boundary shift" in msg for msg in caplog.messages)
+
+    def test_no_hidden_value_returns_defaults(self):
+        from core.nodes.synthesizer import _extract_def_scores
+
+        d, e, f = _extract_def_scores({})
+        assert (d, e, f) == (3, 3, 3)
+
+
+# ---------------------------------------------------------------------------
+# Gap #11: Agentic loop message pruning (P10 context budget)
+# ---------------------------------------------------------------------------
+
+
+class TestAgenticLoopPruning:
+    """Karpathy P10 — message pruning for context budget."""
+
+    def test_no_pruning_under_threshold(self):
+        from core.cli.agentic_loop import AgenticLoop
+
+        loop = AgenticLoop.__new__(AgenticLoop)
+        messages: list[dict[str, Any]] = [{"role": "user", "content": f"msg{i}"} for i in range(8)]
+        loop._maybe_prune_messages(messages)
+        assert len(messages) == 8  # No change
+
+    def test_pruning_at_threshold(self):
+        from core.cli.agentic_loop import AgenticLoop
+
+        loop = AgenticLoop.__new__(AgenticLoop)
+        messages: list[dict[str, Any]] = [{"role": "user", "content": f"msg{i}"} for i in range(10)]
+        loop._maybe_prune_messages(messages)
+        assert len(messages) == 10  # Exactly 10 = no prune
+
+    def test_pruning_above_threshold(self):
+        from core.cli.agentic_loop import AgenticLoop
+
+        loop = AgenticLoop.__new__(AgenticLoop)
+        # Build alternating user/assistant (12 msgs = 6 rounds)
+        messages: list[dict[str, Any]] = [{"role": "user", "content": "first message"}]
+        for i in range(1, 12):
+            role = "assistant" if i % 2 else "user"
+            messages.append({"role": role, "content": f"msg{i}"})
+        assert len(messages) == 12
+
+        loop._maybe_prune_messages(messages)
+
+        # first(user) + bridge(assistant) + recent(user-start) = 7
+        assert messages[0]["content"] == "first message"
+        assert messages[0]["role"] == "user"
+        assert messages[1]["role"] == "assistant"
+        assert "(earlier rounds omitted)" in str(messages[1]["content"])
+        # Verify alternation: no consecutive same roles
+        for i in range(1, len(messages)):
+            assert messages[i]["role"] != messages[i - 1]["role"], (
+                f"Consecutive {messages[i]['role']} at index {i - 1},{i}"
+            )
+
+    def test_pruning_preserves_recent_and_alternation(self):
+        from core.cli.agentic_loop import AgenticLoop
+
+        loop = AgenticLoop.__new__(AgenticLoop)
+        # Build proper alternating conversation (13 msgs: 6 turns + current user)
+        messages: list[dict[str, Any]] = [{"role": "user", "content": "original"}]
+        for i in range(1, 11):
+            role = "assistant" if i % 2 else "user"
+            messages.append({"role": role, "content": f"old{i}"})
+        messages.extend(
+            [
+                {"role": "assistant", "content": "recent_a1"},
+                {"role": "user", "content": "recent_u2"},
+            ]
+        )
+        assert len(messages) == 13
+
+        loop._maybe_prune_messages(messages)
+
+        contents = [m["content"] for m in messages]
+        assert "original" in contents
+        assert "recent_u2" in contents
+        # Verify alternation
+        for i in range(1, len(messages)):
+            assert messages[i]["role"] != messages[i - 1]["role"]


### PR DESCRIPTION
## 요약
develop → main 머지. Karpathy 프롬프트 아키텍처 GAP 12개 해소.

## 변경 사항
- PROMPT_VERSIONS 8→20 + _PINNED_HASHES 하드코딩 (CI drift ratchet)
- .md Constraints/Style 표준화 (evaluator, synthesizer, biasbuster, analyst, router)
- scoring composite_score 의존 제거 + momentum 이중 호출 제거
- analyst confidence clamp + DT boundary 경고 + agentic loop pruning
- Tests: 2077+ → 2125+

## 테스트
- [x] CI 전체 통과 (Lint, Type, Test 3.12/3.13, Security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)