### PR TITLE
feat: UI/UX 리브랜딩 — 마스코트 + 브랜드 테마 통일

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import typer
-from rich.text import Text
 
 from core import __version__
 from core.cli.agentic_loop import AgenticLoop, AgenticResult
@@ -394,13 +393,15 @@ def _generate_report(
     # Skill-enhanced narrative (skip in dry-run to avoid LLM call)
     enhanced_narrative = ""
     if skill_registry is not None and not dry_run:
-        console.print("  [muted]Generating expert analysis with skills context...[/muted]")
-        enhanced_narrative = _build_skill_narrative(report_dict, skill_registry)
+        with GeodeStatus("Generating expert analysis...", model=settings.model) as st:
+            enhanced_narrative = _build_skill_narrative(report_dict, skill_registry)
+            st.stop("expert analysis" if enhanced_narrative else "expert analysis (skipped)")
 
     generator = ReportGenerator()
-    content = generator.generate(
-        report_dict, fmt=report_fmt, template=report_tpl, enhanced_narrative=enhanced_narrative
-    )
+    with console.status("  [cyan]Building report...[/cyan]", spinner="dots", spinner_style="cyan"):
+        content = generator.generate(
+            report_dict, fmt=report_fmt, template=report_tpl, enhanced_narrative=enhanced_narrative
+        )
 
     # Determine save path
     ext_map = {ReportFormat.HTML: "html", ReportFormat.JSON: "json", ReportFormat.MARKDOWN: "md"}
@@ -429,65 +430,51 @@ def _generate_report(
 # Interactive welcome screen
 # ---------------------------------------------------------------------------
 
-_LOGO = r"""
-   ____  _____ ___  ____  _____
-  / ___|| ____/ _ \|  _ \| ____|
- | |  _ |  _|| | | | | | |  _|
- | |_| || |__| |_| | |_| | |___
-  \____||_____\___/|____/|_____|
-"""
+
+def _render_welcome_brand() -> None:
+    """Render animated Claude Code-style branding with axolotl mascot."""
+    from core.ui.mascot import play_mascot_animation
+
+    cwd = str(Path.cwd())
+    play_mascot_animation(version=__version__, model=settings.model, cwd=cwd)
 
 
-def _render_mascot() -> None:
-    """Render the Harness GEODE mascot with Rich markup."""
-    # Harness GEODE: axolotl operator + orbiting tools
-    # 6-color: white body, magenta gills, yellow lamp, cyan accent
-    _M = "magenta"  # gills
-    _Y = "bold yellow"  # headlamp
-    _C = "dim cyan"  # orbiting tools
-    _D = "dim"  # outlines
-    _W = "white"  # body
-    art = (
-        f"  [{_C}]    ◇                    ◆[/{_C}]\n"
-        f"                [{_Y}]_⦿_[/{_Y}]\n"
-        f"        [{_M}]╲╲╲[/{_M}] [{_W}]( ◕ [{_D}]w[/{_D}] ◕ )[/{_W}]"
-        f" [{_M}]╱╱╱[/{_M}]\n"
-        f"         [{_M}]╲╲[/{_M}] [{_W}]([/{_W}]"
-        f" [{_D}]━━━[/{_D}] [{_W}])[/{_W}] [{_M}]╱╱[/{_M}]\n"
-        f"  [{_C}]🔍[/{_C}]   [{_W}]╭─┤[/{_W}]"
-        f"[cyan]♦[/cyan][{_W}]├────╮[/{_W}]   [{_C}]💎[/{_C}]\n"
-        f"         [{_W}]│[/{_W}] [{_D}]\\\\__//[/{_D}]"
-        f" [{_W}]│[/{_W}]\n"
-        f"         [{_W}]╰─[/{_W}]"
-        f"[dim magenta]~~~~~[/dim magenta][{_W}]─╯[/{_W}]"
-    )
-    console.print(art, highlight=False)
+def _render_readiness_compact(report: ReadinessReport) -> None:
+    """Render readiness as a compact block."""
+    ready = [c for c in report.capabilities if c.available]
+    not_ready = [c for c in report.capabilities if not c.available]
+
+    if ready:
+        names = "  ".join(f"[success]✓[/success] {c.name}" for c in ready)
+        console.print(f"  {names}")
+    if not_ready:
+        for c in not_ready:
+            hint = f" [muted]({c.reason})[/muted]" if c.reason else ""
+            console.print(f"  [warning]✗[/warning] {c.name}{hint}")
+
+    if report.blocked:
+        console.print()
+        console.print("  [warning]API key not configured — key registration required[/warning]")
+
+    console.print()
 
 
 def _welcome_screen() -> None:
     """Show Claude Code-style welcome screen with readiness check."""
-    console.print()
-    _render_mascot()
-    console.print()
-    logo = Text(_LOGO, style="bold cyan")
-    console.print(logo)
-    console.print(
-        f"  [bold]GEODE v{__version__}[/bold]  [muted]— 게임화 IP 도메인 자율 실행 하네스[/muted]"
-    )
-    console.print(f"  [muted]Model: {settings.model}[/muted]")
-    console.print("  [dim]Wiring tools. Scanning worlds.[/dim]")
-    console.print()
+    _render_welcome_brand()
 
     # OpenClaw gateway:startup — readiness check
     readiness = check_readiness()
     _set_readiness(readiness)
-    render_readiness(readiness)
+    _render_readiness_compact(readiness)
 
     # OpenClaw boot-md — initialize project memory if absent
     setup_project_memory()
 
-    console.print("  [muted]/help[/muted] for commands  [muted]·[/muted]  ", end="")
-    console.print("[muted]type naturally[/muted] to search & analyze")
+    console.print(
+        "  [muted]/help[/muted] for commands  [muted]·[/muted]  "
+        "[muted]type naturally[/muted] to search & analyze"
+    )
     console.print()
 
 
@@ -510,8 +497,8 @@ def _progress_line(done: list[str], active: str = "") -> str:
     """Build a compact progress status line."""
     parts = [f"[dim]{s}[/dim]" for s in done]
     if active:
-        parts.append(f"[bold cyan]{active}[/bold cyan]")
-    return " → ".join(parts) if parts else "[bold cyan]Starting...[/bold cyan]"
+        parts.append(f"[header]{active}[/header]")
+    return " → ".join(parts) if parts else "[header]Starting...[/header]"
 
 
 def _merge_event_output(final_state: dict[str, Any], output: dict[str, Any]) -> None:
@@ -2345,7 +2332,7 @@ def _interactive_loop() -> None:
         console.show_cursor(True)
 
         try:
-            user_input = _read_multiline_input("[bold cyan]>[/bold cyan] ")
+            user_input = _read_multiline_input("[header]>[/header] ")
         except (KeyboardInterrupt, EOFError):
             from core.ui.agentic_ui import render_session_cost_summary
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -529,7 +529,12 @@ def cmd_batch(
     for i, ip_name in enumerate(ip_names, 1):
         console.print(f"  [{i}/{len(ip_names)}] [value]{ip_name}[/value]")
         if run_fn is not None:
-            result = run_fn(ip_name, dry_run=dry_run, verbose=verbose)
+            with console.status(
+                f"  [cyan]Analyzing {ip_name}...[/cyan]",
+                spinner="dots",
+                spinner_style="cyan",
+            ):
+                result = run_fn(ip_name, dry_run=dry_run, verbose=verbose)
             results.append(result)
         else:
             results.append(None)

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -67,7 +67,7 @@ def key_registration_gate() -> str | None:
     )
     while True:
         try:
-            user_input = console.input("[bold cyan]>[/bold cyan] ").strip()
+            user_input = console.input("[header]>[/header] ").strip()
         except (KeyboardInterrupt, EOFError):
             return None
         if user_input.lower() in ("/quit", "quit", "exit"):

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -202,7 +202,7 @@ class ToolExecutor:
         console.print(f"  [dim]Estimated cost:[/dim] ~${estimated_cost:.2f}")
         console.print()
         try:
-            response = console.input("  [bold cyan]Proceed? [Y/n][/bold cyan] ").strip().lower()
+            response = console.input("  [header]Proceed? [Y/n][/header] ").strip().lower()
         except (KeyboardInterrupt, EOFError):
             console.print()
             return False
@@ -218,7 +218,7 @@ class ToolExecutor:
         console.print()
 
         try:
-            response = console.input("  [bold cyan]Allow? [Y/n][/bold cyan] ").strip().lower()
+            response = console.input("  [header]Allow? [Y/n][/header] ").strip().lower()
         except (KeyboardInterrupt, EOFError):
             console.print()
             return False

--- a/core/ui/console.py
+++ b/core/ui/console.py
@@ -1,32 +1,57 @@
-"""Rich Console singleton."""
+"""Rich Console singleton — GEODE brand theme.
+
+Brand colors (from axolotl mascot):
+  Coral/pink (#f5a0a0)  — axolotl body → brand identity
+  Gold (#ffd700)         — headlamp → energy, highlights
+  Cyan (#00ced1)         — crystals, tech → interactive elements
+  Magenta (#d946ef)      — gills → accent, tool names
+"""
 
 from __future__ import annotations
 
 from rich.console import Console
 from rich.theme import Theme
 
+# -- Brand palette (terminal-safe) --
+_CORAL = "#f5a0a0"  # axolotl body
+_GOLD = "#ffd700"  # headlamp
+_CYAN = "#00ced1"  # crystals / tech
+_MAGENTA = "#d946ef"  # gills / accent
+_CRYSTAL = "#c8a2ff"  # geode crystal purple
+
 GEODE_THEME = Theme(
     {
-        "header": "bold cyan",
+        # -- Brand --
+        "brand": f"bold {_CORAL}",
+        "brand.accent": f"bold {_MAGENTA}",
+        "brand.gold": f"bold {_GOLD}",
+        "brand.crystal": _CRYSTAL,
+        # -- Semantic --
+        "header": f"bold {_CYAN}",
         "step": "bold green",
-        "score": "bold yellow",
+        "score": f"bold {_GOLD}",
         "tier_s": "bold white on red",
         "tier_a": "bold white on blue",
         "tier_b": "bold white on green",
         "tier_c": "dim white on grey37",
         "label": "bold",
-        "value": "cyan",
-        "warning": "bold yellow",
+        "value": _CYAN,
+        "warning": f"bold {_GOLD}",
         "error": "bold red",
         "success": "bold green",
         "muted": "dim",
-        "status.spinner": "cyan",
-        # Claude Code-style agentic UI
-        "tool_name": "bold magenta",
-        "tool_args": "dim cyan",
+        "status.spinner": _CYAN,
+        # -- Agentic UI (Claude Code-style) --
+        "tool_name": f"bold {_MAGENTA}",
+        "tool_args": f"dim {_CYAN}",
         "token_info": "dim",
-        "plan_step": "cyan",
+        "plan_step": _CYAN,
         "subagent": "bold blue",
+        # -- Mascot --
+        "mascot.gills": _MAGENTA,
+        "mascot.lamp": f"bold {_GOLD}",
+        "mascot.body": "white",
+        "mascot.outline": "dim",
     }
 )
 

--- a/core/ui/mascot.py
+++ b/core/ui/mascot.py
@@ -1,0 +1,151 @@
+"""GEODE mascot — minimal axolotl face, Claude Code-style layout.
+
+3-line layout mirroring Claude Code::
+
+    ╲╲( ◕ ᵕ ◕ )╱╱  GEODE v0.9.0
+                     claude-opus-4-6 · 저평가 IP 발굴 에이전트
+                     ~/geode
+
+Expression library (used across UI contexts):
+    normal   ( ◕ ᵕ ◕ )   welcome, idle
+    happy    ( ◕ ω ◕ )   success, done
+    sleepy   ( ─ ᵕ ─ )   startup animation
+    wink     ( ◕ ᵕ ˘ )   hint, tip
+    sparkle  ( ✧ ᵕ ✧ )   discovery, high score
+    thinking ( ◔ ᵕ ◔ )   processing
+    surprise ( ◉ △ ◉ )   unexpected
+    proud    ( ◕ ε ◕ )   achievement
+    cry      ( ◕ д ◕ )   error, failure
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+
+from rich.text import Text
+
+from core.ui.console import console
+
+_G = "mascot.gills"
+_B = "mascot.body"
+_D = "mascot.outline"
+
+
+# -- Expressions ----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Expression:
+    left_eye: str
+    mouth: str
+    right_eye: str
+    eye_style: str = "mascot.body"
+    mouth_style: str = "mascot.outline"
+
+
+EXPR: dict[str, Expression] = {
+    "normal": Expression("◕", "ᵕ", "◕"),
+    "happy": Expression("◕", "ω", "◕", mouth_style="brand"),
+    "sleepy": Expression("─", "ᵕ", "─", eye_style="dim"),
+    "wink": Expression("◕", "ᵕ", "˘"),
+    "sparkle": Expression("✧", "ᵕ", "✧", eye_style="brand.gold"),
+    "thinking": Expression("◔", "ᵕ", "◔"),
+    "surprise": Expression("◉", "△", "◉"),
+    "proud": Expression("◕", "ε", "◕", mouth_style="brand"),
+    "cry": Expression("◕", "д", "◕", mouth_style="error"),
+}
+
+
+# -- Frame builder --------------------------------------------------------
+
+
+def _face(expr: Expression) -> Text:
+    """Build a single mascot face: ╲╲( ◕ ᵕ ◕ )╱╱"""
+    t = Text()
+    t.append("╲╲", _G)
+    t.append("( ", _B)
+    t.append(f"{expr.left_eye} ", expr.eye_style)
+    t.append(expr.mouth, expr.mouth_style)
+    t.append(f" {expr.right_eye}", expr.eye_style)
+    t.append(" )", _B)
+    t.append("╱╱", _G)
+    return t
+
+
+def _brand_line(
+    expr: Expression,
+    version: str,
+    model: str,
+    cwd: str,
+) -> Text:
+    """Build the full 3-line brand block."""
+    pad = "                     "  # align lines 2-3 under text start
+
+    t = Text()
+    # Line 1: face + GEODE version
+    t.append("  ")
+    t.append_text(_face(expr))
+    t.append("  ")
+    t.append("GEODE", "header")
+    t.append(f" v{version}")
+    t.append("\n")
+
+    # Line 2: model + description
+    desc = "저평가 IP 발굴 에이전트"
+    t.append(f"  {pad}{model} · {desc}", "dim")
+    t.append("\n")
+
+    # Line 3: cwd
+    t.append(f"  {pad}{cwd}", "dim")
+
+    return t
+
+
+# -- Public API -----------------------------------------------------------
+
+
+def play_mascot_animation(version: str, model: str, cwd: str) -> None:
+    """Play a brief startup animation (~0.8s), then print final frame."""
+    if not sys.stdout.isatty():
+        render_mascot_static(version, model, cwd)
+        return
+
+    from rich.live import Live
+
+    frames: list[tuple[str, float]] = [
+        ("sleepy", 0.30),
+        ("normal", 0.25),
+        ("happy", 0.30),
+    ]
+
+    try:
+        with Live(
+            Text(""),
+            console=console,
+            refresh_per_second=20,
+            transient=True,
+        ) as live:
+            for expr_name, delay in frames:
+                block = _brand_line(
+                    EXPR[expr_name],
+                    version,
+                    model,
+                    cwd,
+                )
+                live.update(block)
+                time.sleep(delay)
+
+        # Final static frame persists
+        render_mascot_static(version, model, cwd)
+    except Exception:
+        render_mascot_static(version, model, cwd)
+
+
+def render_mascot_static(version: str, model: str, cwd: str) -> None:
+    """Print the mascot brand block (no animation)."""
+    block = _brand_line(EXPR["normal"], version, model, cwd)
+    console.print()
+    console.print(block, highlight=False)
+    console.print()


### PR DESCRIPTION
## 요약
아우카솔로틀 마스코트 기반 UI/UX 리브랜딩. Claude Code 스타일 3-line 시작 화면, 브랜드 컬러 통일, 누락 스피너 보강.

## 변경 사항
### 코드 변경
- `core/ui/mascot.py`: **신규** — Expression 9종, 3-line 레이아웃, 시작 애니메이션 (sleepy→normal→happy)
- `core/ui/console.py`: 브랜드 팔레트 (Coral/Gold/Cyan/Magenta/Crystal) + mascot 테마 토큰 추가
- `core/cli/__init__.py`: 시작 화면 리브랜딩 (`_render_welcome_brand`, `_render_readiness_compact`)
- `core/cli/commands.py`: 배치 분석 per-IP 스피너 추가
- `core/cli/startup.py`: 테마 토큰 통일 (`[header]`)
- `core/cli/tool_executor.py`: 테마 토큰 통일 (`[header]`)

## 영향 범위
- 영향받는 모듈/기능: UI 렌더링 (시작 화면, REPL 프롬프트, 승인 프롬프트, 배치 분석)
- 하위 호환성: 유지 (기능 변경 없음, 표시 방식만 변경)

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors (pre-commit 통과)
- [x] `uv run pytest tests/ -q` — 2125 pass
- [x] CLI 시작 화면 정상: `╲╲( ◕ ᵕ ◕ )╱╱  GEODE v0.9.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)