### PR TITLE
fix: MCP 도구 스키마 정규화 + UI 렌더링 잔상 방지

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -635,6 +635,8 @@ def _execute_pipeline(
                 input_state = None  # resume from checkpoint
                 status.start()
         except Exception as e:
+            # Ensure cursor/spinner cleanup before printing error
+            console.show_cursor(True)
             console.print(f"[error]Pipeline error: {e}[/error]")
             if verbose:
                 console.print_exception()
@@ -769,6 +771,7 @@ def _execute_pipeline_streaming(
             input_state = None
 
     except Exception as e:
+        console.show_cursor(True)
         console.print(f"[error]Pipeline error: {e}[/error]")
         if verbose:
             console.print_exception()

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -324,7 +324,14 @@ class AgenticLoop:
                 log.warning("Anthropic API key is invalid in agentic loop")
                 return None
             except anthropic.BadRequestError as exc:
-                log.warning("Anthropic BadRequest in agentic loop: %s", exc)
+                msg = str(exc)
+                log.warning("Anthropic BadRequest in agentic loop: %s", msg)
+                if "input_schema" in msg:
+                    log.error(
+                        "Tool schema error — likely an MCP tool missing input_schema. "
+                        "tools count=%d",
+                        len(self._tools),
+                    )
                 return None
             except KeyboardInterrupt:
                 log.info("LLM call interrupted by user")

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -529,13 +529,18 @@ def cmd_batch(
     for i, ip_name in enumerate(ip_names, 1):
         console.print(f"  [{i}/{len(ip_names)}] [value]{ip_name}[/value]")
         if run_fn is not None:
-            with console.status(
-                f"  [cyan]Analyzing {ip_name}...[/cyan]",
-                spinner="dots",
-                spinner_style="cyan",
-            ):
-                result = run_fn(ip_name, dry_run=dry_run, verbose=verbose)
-            results.append(result)
+            try:
+                with console.status(
+                    f"  [cyan]Analyzing {ip_name}...[/cyan]",
+                    spinner="dots",
+                    spinner_style="cyan",
+                ):
+                    result = run_fn(ip_name, dry_run=dry_run, verbose=verbose)
+                results.append(result)
+            except Exception as exc:
+                console.show_cursor(True)
+                console.print(f"  [error]Failed: {exc}[/error]")
+                results.append(None)
         else:
             results.append(None)
 

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -20,6 +20,23 @@ log = logging.getLogger(__name__)
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 _CONFIG_PATH = _PROJECT_ROOT / ".claude" / "mcp_servers.json"
 
+_EMPTY_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
+
+
+def _normalise_mcp_tool(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert an MCP tool dict to Anthropic API format.
+
+    MCP spec returns ``inputSchema`` (camelCase); Anthropic requires
+    ``input_schema`` (snake_case).  Missing schema is replaced with a
+    minimal ``{"type": "object", "properties": {}}``.
+    """
+    schema = raw.get("input_schema") or raw.get("inputSchema") or _EMPTY_SCHEMA
+    return {
+        "name": raw.get("name", ""),
+        "description": raw.get("description", ""),
+        "input_schema": schema,
+    }
+
 
 class MCPServerManager:
     """Manages multiple MCP server connections and tool dispatch."""
@@ -79,7 +96,12 @@ class MCPServerManager:
         return None
 
     def get_all_tools(self) -> list[dict[str, Any]]:
-        """Gather tool definitions from all configured MCP servers."""
+        """Gather tool definitions from all configured MCP servers.
+
+        MCP spec uses camelCase (``inputSchema``), but Anthropic API
+        requires snake_case (``input_schema``).  This method normalises
+        each tool dict so it can be passed directly to ``messages.create(tools=...)``.
+        """
         all_tools: list[dict[str, Any]] = []
         for server_name in self._servers:
             client = self._get_client(server_name)
@@ -87,8 +109,9 @@ class MCPServerManager:
                 continue
             tools = client.list_tools()
             for tool in tools:
-                tool["_mcp_server"] = server_name
-                all_tools.append(tool)
+                normalised = _normalise_mcp_tool(tool)
+                normalised["_mcp_server"] = server_name
+                all_tools.append(normalised)
         return all_tools
 
     def call_tool(self, server_name: str, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## 요약
MCP 도구 inputSchema → input_schema 변환 누락으로 Anthropic API 400 에러 발생 수정. 파이프라인/배치 예외 경로에서 커서 복원 누락으로 UI 잔상 남는 문제 수정.

## 변경 사항
### 코드 변경
- `core/infrastructure/adapters/mcp/manager.py`: `_normalise_mcp_tool()` 추가 — MCP camelCase → Anthropic snake_case 변환 + 누락 스키마 기본값
- `core/cli/agentic_loop.py`: BadRequestError에서 input_schema 관련 디버그 로그 추가
- `core/cli/__init__.py`: 파이프라인/스트리밍 예외 경로에 `console.show_cursor(True)` 추가
- `core/cli/commands.py`: 배치 분석 per-IP try-except + 커서 복원

## 영향 범위
- 영향받는 모듈/기능: MCP 도구 연동, 파이프라인 실행, 배치 분석
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors (pre-commit 통과)
- [x] `uv run pytest tests/ -q` — 2125 pass
- [x] MCP 정규화 단위 테스트: camelCase, snake_case, 누락 스키마 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)