### PR TITLE
fix: MCP 도구 메타데이터 API 전송 시 제거

### DIFF
--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -280,11 +280,15 @@ class AgenticLoop:
         max_retries = 3
         for attempt in range(max_retries):
             try:
+                # Strip internal metadata (e.g. _mcp_server) before sending to API
+                api_tools = [
+                    {k: v for k, v in t.items() if not k.startswith("_")} for t in self._tools
+                ]
                 response = self._client.messages.create(  # type: ignore[call-overload]
                     model=self.model,
                     system=system,
                     messages=messages,
-                    tools=self._tools,
+                    tools=api_tools,
                     tool_choice=tool_choice,
                     max_tokens=self.max_tokens,
                     temperature=0.0,


### PR DESCRIPTION
## 요약
MCP 도구의 내부 메타데이터(`_mcp_server`)가 Anthropic API에 전송되어 `Extra inputs are not permitted` 에러 발생. API 호출 직전에 `_` 접두사 필드를 strip.

## 변경 사항
- `core/cli/agentic_loop.py`: `_call_llm()`에서 `tools` 전달 시 `_`로 시작하는 내부 필드 제거

## 테스트
- [x] 2125 pass, pre-commit 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)