### PR TITLE
fix: msgpack 체크포인트 역직렬화 경고 해소 + MCP 로그 레벨 수정

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "httpx>=0.27.0",
     "langgraph>=1.1.0",
+    "langgraph-checkpoint>=4.0.1",
     "langgraph-checkpoint-sqlite>=3.0.0",
     "numpy>=2.2.0",
     "openai>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -433,6 +433,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "httpx" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "numpy" },
     { name = "openai" },
@@ -467,6 +468,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langgraph", specifier = ">=1.1.0" },
+    { name = "langgraph-checkpoint", specifier = ">=4.0.1" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=2.2.0" },
@@ -719,15 +721,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/76/55a18c59dedf39688d72c4b06af73a5e3ea0d1a01bc867b88fbf0659f203/langgraph_checkpoint-4.0.0.tar.gz", hash = "sha256:814d1bd050fac029476558d8e68d87bce9009a0262d04a2c14b918255954a624", size = 137320, upload-time = "2026-01-12T20:30:26.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/de/ddd53b7032e623f3c7bcdab2b44e8bf635e468f62e10e5ff1946f62c9356/langgraph_checkpoint-4.0.0-py3-none-any.whl", hash = "sha256:3fa9b2635a7c5ac28b338f631abf6a030c3b508b7b9ce17c22611513b589c784", size = 46329, upload-time = "2026-01-12T20:30:25.2Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 요약
langgraph-checkpoint 4.0.1의 `allowed_msgpack_modules` API를 사용하여 "Deserializing unregistered type" 경고 근본 해결. MCP 서버 연결 실패 로그를 debug로 하향.

## 변경 사항
### 코드 변경
- `core/graph.py`: `JsonPlusSerializer`에 `allowed_msgpack_modules` 파라미터 추가 (기존 `allowed_json_modules`와 동일 목록)
- `core/cli/__init__.py`: `_suppress_noisy_warnings()`에 `langgraph.checkpoint.serde.*` logger 레벨을 ERROR로 설정
- `core/infrastructure/adapters/mcp/manager.py`: MCP 서버 연결 실패 로그 `warning` → `debug` (선택적 서버이므로)
- `pyproject.toml`: `langgraph-checkpoint` 4.0.0 → 4.0.1

## 영향 범위
- 영향받는 모듈/기능: 체크포인트 직렬화, MCP 매니저 로깅
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -q` — 2168 passed
- [x] pre-commit 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)