### PR TITLE
fix: CLI 품질 개선 — 토큰 추적·msgpack 경고·HITL 터미널 복원

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,9 @@ Decision Tree on D-E-F axes:
 
 | Provider | Model | Input $/M | Output $/M | 용도 |
 |----------|-------|-----------|------------|------|
-| **Anthropic** | `claude-opus-4-6` | $15.00 | $75.00 | Primary (Pipeline + Agentic) |
+| **Anthropic** | `claude-opus-4-6` | $5.00 | $25.00 | Primary (Pipeline + Agentic) |
 | Anthropic | `claude-sonnet-4-5-20250929` | $3.00 | $15.00 | Fallback |
-| Anthropic | `claude-haiku-4-5-20251001` | $0.80 | $4.00 | Lightweight |
+| Anthropic | `claude-haiku-4-5-20251001` | $1.00 | $5.00 | Lightweight |
 | **OpenAI** | `gpt-5.4` | $2.50 | $15.00 | Cross-LLM Secondary (default) |
 | OpenAI | `gpt-5.2` | $1.75 | $14.00 | Fallback 1 |
 | OpenAI | `gpt-4.1` | $2.00 | $8.00 | Fallback 2 |

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -466,8 +466,16 @@ def _suppress_noisy_warnings() -> None:
 
     # Pydantic V1 deprecation from langchain_core on Python 3.14+
     warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")
-    # LangGraph msgpack deserialization warning
+    # LangGraph msgpack deserialization warning (warnings.warn path)
     warnings.filterwarnings("ignore", message="Deserializing unregistered type")
+
+    # LangGraph checkpoint deserialization also logs via logging.warning —
+    # suppress those at the logging level.
+    for noisy_logger in (
+        "langgraph.checkpoint.serde.jsonplus",
+        "langgraph.checkpoint.serde.base",
+    ):
+        logging.getLogger(noisy_logger).setLevel(logging.ERROR)
 
 
 def _welcome_screen() -> None:
@@ -559,6 +567,7 @@ def _handle_interrupt(
     Options: [C]ontinue / [I]nspect / [S]kip / [A]bort.
     Returns True to continue, False to abort.
     """
+    _restore_terminal()
     iteration = final_state.get("iteration", 1)
     confidence = final_state.get("composite_score", {})
     console.print(

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -196,6 +196,9 @@ class ToolExecutor:
 
     def _confirm_cost(self, tool_name: str, estimated_cost: float) -> bool:
         """Prompt user for cost confirmation on expensive tools."""
+        from core.cli import _restore_terminal
+
+        _restore_terminal()
         console.print()
         console.print("  [bold yellow]$ Cost confirmation[/bold yellow]")
         console.print(f"  [dim]Tool:[/dim] [bold]{tool_name}[/bold]")
@@ -210,6 +213,9 @@ class ToolExecutor:
 
     def _request_approval(self, command: str, reason: str) -> bool:
         """Prompt user for bash command approval."""
+        from core.cli import _restore_terminal
+
+        _restore_terminal()
         console.print()
         console.print("  [bold yellow]⚠ Bash command requires approval[/bold yellow]")
         console.print(f"  [dim]Command:[/dim] [bold]{command}[/bold]")

--- a/core/graph.py
+++ b/core/graph.py
@@ -538,9 +538,9 @@ def compile_graph(
 
     compile_kwargs: dict[str, Any] = {}
 
-    # Register Pydantic models for checkpoint deserialization to prevent
-    # "Deserializing unregistered type" warnings (future LangGraph versions
-    # will block unregistered types entirely).
+    # Register Pydantic models for checkpoint (de)serialization.
+    # allowed_json_modules covers both JSON and msgpack paths internally
+    # (langgraph-checkpoint >=4.0.1 warns on unregistered types).
     _allowed_modules: list[tuple[str, ...]] = [
         ("core.state", "AnalysisResult"),
         ("core.state", "EvaluatorResult"),

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -106,7 +106,7 @@ class MCPServerManager:
             self._clients[server_name] = client
             return client
 
-        log.warning("Failed to connect to MCP server: %s", server_name)
+        log.debug("MCP server not available (skipped): %s", server_name)
         return None
 
     def get_all_tools(self) -> list[dict[str, Any]]:

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -269,7 +269,15 @@ def call_llm(
         if hasattr(response, "usage") and response.usage:
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens
-            usage = get_tracker().record(model, in_tok, out_tok)
+            cache_create = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            usage = get_tracker().record(
+                model,
+                in_tok,
+                out_tok,
+                cache_creation_tokens=cache_create,
+                cache_read_tokens=cache_read,
+            )
             log.info(
                 "LLM call: model=%s in=%d out=%d cost=$%.4f",
                 model,
@@ -277,9 +285,6 @@ def call_llm(
                 out_tok,
                 usage.cost_usd,
             )
-            # Log cache hit/miss if available
-            cache_create = getattr(response.usage, "cache_creation_input_tokens", 0)
-            cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
             if cache_create or cache_read:
                 log.debug("Cache: create=%d read=%d", cache_create, cache_read)
 
@@ -328,7 +333,15 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
         if hasattr(response, "usage") and response.usage:
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens
-            usage = get_tracker().record(model, in_tok, out_tok)
+            cache_create = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            usage = get_tracker().record(
+                model,
+                in_tok,
+                out_tok,
+                cache_creation_tokens=cache_create,
+                cache_read_tokens=cache_read,
+            )
             log.info(
                 "LLM call (parsed): model=%s in=%d out=%d cost=$%.4f",
                 model,
@@ -336,8 +349,6 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
                 out_tok,
                 usage.cost_usd,
             )
-            cache_create = getattr(response.usage, "cache_creation_input_tokens", 0)
-            cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
             if cache_create or cache_read:
                 log.debug("Cache: create=%d read=%d", cache_create, cache_read)
 
@@ -484,7 +495,15 @@ def call_llm_with_tools(
         if hasattr(response, "usage") and response.usage:
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens
-            usage = get_tracker().record(target_model, in_tok, out_tok)
+            cache_create = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            usage = get_tracker().record(
+                target_model,
+                in_tok,
+                out_tok,
+                cache_creation_tokens=cache_create,
+                cache_read_tokens=cache_read,
+            )
             all_usage.append(usage)
 
         # Check if model wants to use tools
@@ -583,7 +602,15 @@ def call_llm_streaming(
             if final and hasattr(final, "usage") and final.usage:
                 in_tok = final.usage.input_tokens
                 out_tok = final.usage.output_tokens
-                usage = get_tracker().record(model, in_tok, out_tok)
+                cache_create = getattr(final.usage, "cache_creation_input_tokens", 0) or 0
+                cache_read = getattr(final.usage, "cache_read_input_tokens", 0) or 0
+                usage = get_tracker().record(
+                    model,
+                    in_tok,
+                    out_tok,
+                    cache_creation_tokens=cache_create,
+                    cache_read_tokens=cache_read,
+                )
                 log.info(
                     "LLM call (stream): model=%s in=%d out=%d cost=$%.4f",
                     model,
@@ -591,10 +618,6 @@ def call_llm_streaming(
                     out_tok,
                     usage.cost_usd,
                 )
-
-                # Log cache hit/miss if available
-                cache_create = getattr(final.usage, "cache_creation_input_tokens", 0)
-                cache_read = getattr(final.usage, "cache_read_input_tokens", 0)
                 if cache_create or cache_read:
                     log.debug(
                         "Streaming cache: create=%d read=%d",

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -226,6 +226,7 @@ class TokenTracker:
         """Calculate cost in USD for a single LLM call."""
         price = self._pricing.get(model)
         if price is None:
+            log.warning("Unknown model '%s' — cost tracked as $0.00", model)
             return 0.0
         cost = input_tokens * price.input + output_tokens * price.output
         if cache_creation_tokens:


### PR DESCRIPTION
## 요약
토큰 캐시 비용 미반영, checkpoint msgpack 역직렬화 경고 폭주, prompt_toolkit 후 HITL 프롬프트 깨짐 등 CLI 품질 이슈 7건 일괄 수정.

## 변경 사항
### 코드 변경
- `core/llm/client.py`: 4개 LLM 호출 사이트에 `cache_creation_tokens`/`cache_read_tokens`를 `record()`에 전달 → 캐시 비용 정확 추적
- `core/llm/token_tracker.py`: 미등록 모델에 대한 `log.warning()` 추가
- `core/graph.py`: `allowed_msgpack_modules` 제거 (`allowed_json_modules`가 JSON+msgpack 양쪽 커버)
- `core/cli/__init__.py`: langgraph checkpoint 로거 ERROR 레벨 억제 + HITL `_restore_terminal()` 호출
- `core/cli/tool_executor.py`: HITL 승인 프롬프트 전 `_restore_terminal()` 호출 (bash/cost 양쪽)
- `core/infrastructure/adapters/mcp/manager.py`: MCP 서버 연결 실패 로그 `warning→debug` 하향

### 문서/설정 변경
- `CLAUDE.md`: Anthropic 가격표 그라운딩 수정 (opus-4-6: $15/$75→$5/$25, haiku-4-5: $0.80/$4→$1/$5)

## 영향 범위
- 영향받는 모듈/기능: 토큰 추적, 체크포인트 직렬화, HITL 프롬프트, MCP 로깅
- 하위 호환성: 유지

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] graph/runtime/hook/production/feedback 10개 실패 테스트 → 전부 통과
- [x] agentic_loop/e2e/multiline_input 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)