### PR TITLE
fix: MCP 정리 + OpenAI 가격 그라운딩 + live 테스트 제외 (develop → main)

### DIFF
--- a/.claude/mcp_servers.json
+++ b/.claude/mcp_servers.json
@@ -6,31 +6,9 @@
       "BRAVE_API_KEY": "${BRAVE_API_KEY}"
     }
   },
-  "igdb": {
-    "command": "npx",
-    "args": ["-y", "igdb-mcp-server"],
-    "env": {
-      "IGDB_CLIENT_ID": "${TWITCH_CLIENT_ID}",
-      "IGDB_CLIENT_SECRET": "${TWITCH_CLIENT_SECRET}"
-    }
-  },
   "steam": {
     "command": "npx",
     "args": ["-y", "steam-mcp-server"]
-  },
-  "discord": {
-    "command": "npx",
-    "args": ["-y", "mcp-server-discord"],
-    "env": {
-      "DISCORD_BOT_TOKEN": "${DISCORD_BOT_TOKEN}"
-    }
-  },
-  "e2b": {
-    "command": "npx",
-    "args": ["-y", "@e2b/mcp-server"],
-    "env": {
-      "E2B_API_KEY": "${E2B_API_KEY}"
-    }
   },
   "arxiv": {
     "command": "npx",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,10 @@ Decision Tree on D-E-F axes:
 | Anthropic | `claude-haiku-4-5-20251001` | $1.00 | $5.00 | Lightweight |
 | **OpenAI** | `gpt-5.4` | $2.50 | $15.00 | Cross-LLM Secondary (default) |
 | OpenAI | `gpt-5.2` | $1.75 | $14.00 | Fallback 1 |
-| OpenAI | `gpt-4.1` | $2.00 | $8.00 | Fallback 2 |
-| OpenAI | `gpt-4.1-mini` | $0.40 | $1.60 | Budget |
-| OpenAI | `o3` | $2.00 | $8.00 | Reasoning |
-| OpenAI | `o4-mini` | $1.10 | $4.40 | Reasoning (budget) |
+| OpenAI | `gpt-4.1` | $3.50 | $14.00 | Fallback 2 |
+| OpenAI | `gpt-4.1-mini` | $0.70 | $2.80 | Budget |
+| OpenAI | `o3` | $3.50 | $14.00 | Reasoning |
+| OpenAI | `o4-mini` | $2.00 | $8.00 | Reasoning (budget) |
 
 - **Fallback chain** (OpenAI): `gpt-5.4` → `gpt-5.2` → `gpt-4.1`
 - **Pricing source**: [OpenAI API Pricing](https://developers.openai.com/api/docs/pricing/)

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -11,7 +11,7 @@ Replaces the previous triple-call pattern::
     # After — 1 call:
     get_tracker().record(model, in_tok, out_tok)
 
-Pricing verified 2026-03-12 against:
+Pricing verified 2026-03-14 against:
   - Anthropic: https://platform.claude.com/docs/en/docs/about-claude/pricing
   - OpenAI: https://developers.openai.com/api/docs/pricing/
 """
@@ -145,17 +145,17 @@ MODEL_PRICING: dict[str, ModelPrice] = {
     "gpt-5-mini":   _oai(0.25,  2.00, cached_mtok=0.025),
     "gpt-5-nano":   _oai(0.05,  0.40, cached_mtok=0.005),
 
-    # ── OpenAI GPT-4 family ────────────────────────────────────────────
-    "gpt-4.1":      _oai(2.00,  8.00, cached_mtok=0.50),
-    "gpt-4.1-mini": _oai(0.40,  1.60, cached_mtok=0.10),
-    "gpt-4.1-nano": _oai(0.10,  0.40, cached_mtok=0.025),
-    "gpt-4o":       _oai(2.50, 10.00, cached_mtok=1.25),
-    "gpt-4o-mini":  _oai(0.15,  0.60, cached_mtok=0.075),
+    # ── OpenAI GPT-4 family (updated 2026-03-14) ────────────────────────
+    "gpt-4.1":      _oai(3.50, 14.00, cached_mtok=0.875),
+    "gpt-4.1-mini": _oai(0.70,  2.80, cached_mtok=0.175),
+    "gpt-4.1-nano": _oai(0.20,  0.80, cached_mtok=0.05),
+    "gpt-4o":       _oai(4.25, 17.00, cached_mtok=2.125),
+    "gpt-4o-mini":  _oai(0.25,  1.00, cached_mtok=0.125),
 
-    # ── OpenAI Reasoning ───────────────────────────────────────────────
-    "o3":       _oai(2.00, 8.00, cached_mtok=0.50),
-    "o3-mini":  _oai(1.10, 4.40, cached_mtok=0.55),
-    "o4-mini":  _oai(1.10, 4.40, cached_mtok=0.275),
+    # ── OpenAI Reasoning (updated 2026-03-14) ─────────────────────────
+    "o3":       _oai(3.50, 14.00, cached_mtok=0.875),
+    "o3-mini":  _oai(1.10,  4.40, cached_mtok=0.55),
+    "o4-mini":  _oai(2.00,  8.00, cached_mtok=0.50),
 }
 # fmt: on
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ packages = ["core"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-q --tb=short --strict-markers"
+addopts = "-q --tb=short --strict-markers -m 'not live'"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks integration tests requiring external services",


### PR DESCRIPTION
## 요약
develop → main 프로모션. PR #72 머지 내용 포함.

## 변경 사항
- MCP: discord/e2b/igdb 제거 → 4개 서버 유지
- OpenAI 가격 7개 모델 그라운딩 업데이트
- pytest addopts: live 테스트 기본 제외

## 테스트
- [x] CI 전체 통과 (PR #72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)