### PR TITLE
fix: MCP 서버 orphan 프로세스 방지 — 종료 시 close_all() 호출

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2388,6 +2388,9 @@ def _interactive_loop() -> None:
         _mgr = MCPServerManager()
         if _mgr.load_config() > 0:
             mcp_mgr = _mgr
+            import atexit
+
+            atexit.register(_mgr.close_all)
     except Exception:
         log.debug("MCP initialization skipped", exc_info=True)
 
@@ -2506,7 +2509,13 @@ def _interactive_loop() -> None:
                 log.error("Agentic loop error: %s", exc, exc_info=True)
                 console.print(f"\n  [error]Error: {exc}[/error]\n")
 
-    # Clean shutdown of SchedulerService
+    # Clean shutdown: MCP servers → SchedulerService
+    if mcp_mgr is not None:
+        try:
+            mcp_mgr.close_all()
+        except Exception:
+            log.debug("MCP shutdown error", exc_info=True)
+
     _sched = _scheduler_service_ctx.get(None)
     if _sched is not None:
         try:


### PR DESCRIPTION
## 요약
REPL 종료 시 MCP 서브프로세스가 orphan으로 남는 버그 수정.

## 변경 사항
- **정상 종료**: REPL while 루프 탈출 후 `mcp_mgr.close_all()` 호출
  - **왜?** 기존에는 SchedulerService만 정리하고 MCP는 미처리. `StdioMCPClient.close()`가 `terminate()→kill()` fallback 구현되어 있지만 호출되지 않았음
- **비정상 종료**: `atexit.register(close_all)`로 프로세스 종료 시에도 정리 보장

## 영향 범위
- `core/cli/__init__.py` — REPL 진입점의 초기화/종료 경로

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/` — 2148 passed, 19 deselected, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)