### PR TITLE
feat: 미등록 IP 외부 시그널 수집 — 웹 검색 fallback

### DIFF
--- a/core/nodes/router.py
+++ b/core/nodes/router.py
@@ -45,12 +45,30 @@ def router_node(state: GeodeState) -> dict[str, Any]:
         if ip_type == "prospect" and mode == "full_pipeline":
             mode = "prospect"
 
-        # Load fixture data
-        fixture = load_fixture(ip_name)
+        # Load fixture data (graceful degradation for unknown IPs)
+        try:
+            fixture = load_fixture(ip_name)
+            ip_info = fixture["ip_info"]
+            monolake = fixture["monolake"]
+        except ValueError:
+            log.info("No fixture for '%s' — using external data mode", ip_name)
+            ip_info = {
+                "ip_name": ip_name,
+                "media_type": "unknown",
+                "release_year": 0,
+                "studio": "unknown",
+                "genre": "unknown",
+                "synopsis": "",
+                "proof_of_game": "none",
+                "franchise_size": 0,
+                "ip_age_years": 0,
+            }
+            monolake = {}
+
         result: dict[str, Any] = {
             "pipeline_mode": mode,
-            "ip_info": fixture["ip_info"],
-            "monolake": fixture["monolake"],
+            "ip_info": ip_info,
+            "monolake": monolake,
         }
 
         # Generate session_id for memory context (fixes GAP-005)

--- a/core/nodes/signals.py
+++ b/core/nodes/signals.py
@@ -2,7 +2,8 @@
 
 Execution path:
   1. SignalEnrichmentPort adapter (live API if available)
-  2. Fixture fallback (always available)
+  2. Fixture fallback (known IPs)
+  3. Web search fallback (unknown IPs — external data mode)
 """
 
 from __future__ import annotations
@@ -27,12 +28,54 @@ def set_signal_adapter(adapter: SignalEnrichmentPort | None) -> None:
     _signal_adapter_ctx.set(adapter)
 
 
+def _fetch_web_signals(ip_name: str) -> dict[str, Any]:
+    """Last-resort: web search for signal data on unknown IPs.
+
+    Uses Anthropic native web_search to collect public data, then returns
+    raw results as signals. Analysts (LLM-based) can work with unstructured text.
+    """
+    from core.tools.web_tools import GeneralWebSearchTool
+
+    search = GeneralWebSearchTool()
+    queries = [
+        f"{ip_name} game franchise popularity statistics",
+        f"{ip_name} anime manga fan community size reddit youtube",
+    ]
+
+    web_results: list[str] = []
+    for query in queries:
+        try:
+            result = search.execute(query=query, max_results=3)
+            text = result.get("result", {}).get("search_results", "")
+            if text:
+                web_results.append(text)
+        except Exception as exc:
+            log.debug("Web search failed for '%s': %s", query, exc)
+
+    if not web_results:
+        return {}
+
+    return {
+        "web_search_data": "\n---\n".join(web_results),
+        "youtube_views": 0,
+        "reddit_subscribers": 0,
+        "fan_art_yoy_pct": 0.0,
+        "google_trends_index": 0,
+        "twitter_mentions_monthly": 0,
+        "cosplay_events_annual": 0,
+        "mod_patch_activity": "unknown",
+        "genre_fit_keywords": [],
+        "game_sales_data": "No fixture data — see web_search_data for live results.",
+        "_enrichment_source": "web_search",
+    }
+
+
 def signals_node(state: GeodeState) -> dict[str, Any]:
-    """Load external signals — adapter-first with fixture fallback."""
+    """Load external signals — adapter → fixture → web search fallback."""
     try:
         ip_name = state["ip_name"]
 
-        # Try injected adapter first (may be live API)
+        # 1. Try injected adapter first (may be live API)
         adapter = _signal_adapter_ctx.get()
         if adapter is not None and adapter.is_available():
             try:
@@ -40,12 +83,24 @@ def signals_node(state: GeodeState) -> dict[str, Any]:
                 if signals:
                     return {"signals": signals}
             except Exception as exc:
-                log.warning("Signal adapter failed for %s: %s — using fixture", ip_name, exc)
+                log.warning("Signal adapter failed for %s: %s", ip_name, exc)
 
-        # Fixture fallback (always works)
-        fixture = load_fixture(ip_name)
-        fixture_signals: dict[str, Any] = fixture["signals"]
-        return {"signals": fixture_signals}
+        # 2. Fixture fallback (known IPs)
+        try:
+            fixture = load_fixture(ip_name)
+            return {"signals": fixture["signals"]}
+        except ValueError:
+            pass
+
+        # 3. Web search fallback (unknown IPs)
+        log.info("No fixture for '%s' — fetching signals via web search", ip_name)
+        web_signals = _fetch_web_signals(ip_name)
+        if web_signals:
+            return {"signals": web_signals}
+
+        # 4. All sources exhausted — empty signals (analysts will handle)
+        log.warning("No signal data available for '%s'", ip_name)
+        return {"signals": {}}
     except Exception as exc:
         log.error("Node signals failed: %s", exc)
         return {"errors": [f"signals: {exc}"]}


### PR DESCRIPTION
## 요약
fixture에 없는 IP 분석 시 무한 루프 방지 + 외부 웹 검색으로 시그널 자동 수집.

## 변경 사항
### 핵심
- **router.py**: `load_fixture()` 실패 시 최소 `ip_info` 스켈레톤 생성
  - **왜?** ValueError → `{"errors": [...]}` 반환만 하고 `ip_info`/`monolake` 미설정 → downstream 노드 전부 실패 → 저신뢰도 루프
- **signals.py**: 3단계 fallback 체인 구현
  1. `SignalEnrichmentPort` 어댑터 (MCP 라이브 API)
  2. Fixture (기존 3개 IP: Berserk, Cowboy Bebop, Ghost in the Shell)
  3. **Web search** (Anthropic `web_search_20250305`)
  - **왜?** 미등록 IP도 웹 검색으로 시그널 수집하면 analysts가 의미 있는 분석 가능

### 설계 판단
- 웹 검색 결과는 `web_search_data` 키에 raw text로 전달. Analysts가 LLM이므로 비정형 텍스트도 처리 가능.
- 구조화된 signal 키들(`youtube_views` 등)은 0/빈값으로 초기화 → downstream 스키마 호환성 유지.
- 검색 쿼리 2개: 게임 프랜차이즈 통계 + 팬 커뮤니티 규모.

## 영향 범위
- `core/nodes/router.py`, `core/nodes/signals.py`
- 기존 fixture IP 동작 변경 없음 (fixture 경로 우선)

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/` — 2148 passed, 19 deselected, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)