### PR TITLE
fix: MCP 미설정 서버 자동 skip + CLI 입력 렌더링 버그 수정

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2330,10 +2330,17 @@ def _read_multiline_input(prompt: str) -> str:
     else:
         first_line = console.input("> ").strip()
 
+    # Repaint the prompt line to erase wide-char rendering artifacts
+    # (Korean jamo ghosts left after backspace in some terminals).
+    # After Enter, cursor is on the NEXT line; move up, clear, rewrite.
+    if first_line:
+        sys.stdout.write(f"\x1b[F\x1b[2K> {first_line}\n")
+        sys.stdout.flush()
+
     if not first_line:
         return ""
 
-    # Drain pasted lines from stdin buffer
+    # Drain pasted lines from stdin buffer (skip escape sequences)
     lines = [first_line]
     try:
         fd = sys.stdin.fileno()
@@ -2342,7 +2349,9 @@ def _read_multiline_input(prompt: str) -> str:
             if not line:
                 break
             stripped = line.rstrip("\n")
-            if stripped:
+            # Filter out arrow-key / terminal escape sequences that leak
+            # into the buffer (e.g. \x1b[A for Up, \x1b[B for Down).
+            if stripped and "\x1b" not in stripped:
                 lines.append(stripped)
     except (ValueError, OSError):
         pass  # stdin not selectable (piped / non-TTY)

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -101,6 +101,16 @@ class MCPServerManager:
         args = config.get("args", [])
         env = self._resolve_env(config.get("env", {}))
 
+        # Skip server if any required env var resolved to empty string
+        missing = [k for k, v in env.items() if not v]
+        if missing:
+            log.debug(
+                "MCP server '%s' skipped — missing env: %s",
+                server_name,
+                ", ".join(missing),
+            )
+            return None
+
         client = StdioMCPClient(command=command, args=args, env=env)
         if client.connect():
             self._clients[server_name] = client


### PR DESCRIPTION
## 요약
API 키 미설정 MCP 서버가 연결 실패 에러를 쏟는 문제와, CLI 대화형 입력에서 한글 backspace 잔상 + 방향키 escape 코드 유입 버그를 수정.

## 변경 사항

### 핵심 변경 (코드)
- `core/infrastructure/adapters/mcp/manager.py`: `_get_client()`에서 env var가 빈 문자열로 resolve되면 연결 시도 없이 skip
  - 왜: discord, slack, notion, google-drive 등 API 키 미발급 서버가 매 실행마다 "Failed to connect" 에러 출력 → debug 로그로 전환
- `core/cli/__init__.py`: paste drain에서 `\x1b` 포함 라인 필터링
  - 왜: 방향키(↑↓←→) escape sequence(`\x1b[A` 등)가 stdin 버퍼에 남아 입력에 유입
- `core/cli/__init__.py`: prompt 반환 후 이전 줄 재렌더링 (`\x1b[F\x1b[2K`)
  - 왜: 한글 jamo(ㅛ 등) wide-char backspace 시 터미널에 고스트 잔상 남는 렌더링 버그

## 영향 범위
- **영향받는 모듈**: MCP 어댑터, CLI 대화형 입력
- **하위 호환성**: 유지 — API 키가 설정된 서버는 동작 변경 없음

## 설계 판단
- **env 빈값 체크 위치**: `_get_client()` 내부, 연결 시도 전. `_resolve_env()`는 순수 변환만 담당하도록 SRP 유지.
- **escape 필터링 방식**: `\x1b in stripped` 조건으로 escape sequence 포함 라인 전체 drop. 정상 텍스트에 ESC가 포함될 일 없으므로 안전.
- **prompt 재렌더링**: `\x1b[F` (커서 이전 줄) + `\x1b[2K` (줄 전체 삭제) 후 clean 텍스트 출력. `multiline=False`이므로 단일 줄 가정 안전.

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -q -m "not live"` — 2168 passed
- [x] pre-commit hooks 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)