### PR TITLE
fix: REPL memory contextvars 초기화 — note_read 등 6개 도구 동작

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2379,6 +2379,18 @@ def _interactive_loop() -> None:
     except Exception:
         log.debug("Domain adapter initialization skipped", exc_info=True)
 
+    # Wire memory contextvars so note_read/note_save/rule_* tools work
+    # (otherwise they return "Project memory not available")
+    from core.memory.organization import MonoLakeOrganizationMemory
+    from core.memory.project import ProjectMemory
+    from core.tools.memory_tools import set_org_memory, set_project_memory
+
+    try:
+        set_project_memory(ProjectMemory())
+        set_org_memory(MonoLakeOrganizationMemory())
+    except Exception:
+        log.debug("Memory context initialization skipped", exc_info=True)
+
     # Key gate: block until API key provided or user quits
     readiness = _get_readiness()
     if readiness is None or readiness.blocked:


### PR DESCRIPTION
## 요약
REPL에서 note_read, note_save, rule_* 도구 호출 시 "Project memory not available" 에러 수정. _interactive_loop() 시작 시 memory contextvars를 초기화하여 분석 실행 전에도 메모리 도구가 동작하도록 함.

## 변경 사항

### 핵심 변경 (코드)
- `core/cli/__init__.py`: `_interactive_loop()`에 memory contextvars 초기화 추가
  - `ProjectMemory()` 생성 → `set_project_memory()` 호출
  - `MonoLakeOrganizationMemory()` 생성 → `set_org_memory()` 호출
  - 왜: 기존에는 `GeodeRuntime.create()` (분석 실행 시)에서만 설정 → REPL 직접 호출 시 contextvars가 None

## 영향 범위
- **영향받는 도구 6개**: note_read, note_save, rule_create, rule_update, rule_delete, rule_list
- **하위 호환성**: 유지 — GeodeRuntime.create() 경로는 변경 없음, REPL 경로만 추가

## 설계 판단
- domain adapter 초기화 직후에 배치하여 모든 도구 핸들러 등록 전에 memory가 준비되도록 함
- try/except로 감싸서 memory 초기화 실패가 REPL 전체를 중단하지 않도록 방어

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -q -m "not live"` — 2168 passed
- [x] pre-commit hooks 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)