### PR TITLE
fix: REPL memory contextvars 초기화 — note_read 등 6개 도구 동작

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2379,6 +2379,18 @@ def _interactive_loop() -> None:
     except Exception:
         log.debug("Domain adapter initialization skipped", exc_info=True)
 
+    # Wire memory contextvars so note_read/note_save/rule_* tools work
+    # (otherwise they return "Project memory not available")
+    from core.memory.organization import MonoLakeOrganizationMemory
+    from core.memory.project import ProjectMemory
+    from core.tools.memory_tools import set_org_memory, set_project_memory
+
+    try:
+        set_project_memory(ProjectMemory())
+        set_org_memory(MonoLakeOrganizationMemory())
+    except Exception:
+        log.debug("Memory context initialization skipped", exc_info=True)
+
     # Key gate: block until API key provided or user quits
     readiness = _get_readiness()
     if readiness is None or readiness.blocked:


### PR DESCRIPTION
## 요약
develop → main 머지. REPL memory 도구 "Project memory not available" 에러 수정.

## 포함된 변경
- fix: REPL memory contextvars 초기화 — note_read 등 6개 도구 동작 #79

## 테스트
- [x] CI 전체 통과 (ruff, mypy, 2168 tests, bandit, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)