### PR TITLE
perf: BiasBuster 통계 fast path + 외부 IP feedback loop 제한

### DIFF
--- a/core/nodes/router.py
+++ b/core/nodes/router.py
@@ -50,6 +50,7 @@ def router_node(state: GeodeState) -> dict[str, Any]:
             fixture = load_fixture(ip_name)
             ip_info = fixture["ip_info"]
             monolake = fixture["monolake"]
+            is_external = False
         except ValueError:
             log.info("No fixture for '%s' — using external data mode", ip_name)
             ip_info = {
@@ -64,12 +65,18 @@ def router_node(state: GeodeState) -> dict[str, Any]:
                 "ip_age_years": 0,
             }
             monolake = {}
+            is_external = True
 
         result: dict[str, Any] = {
             "pipeline_mode": mode,
             "ip_info": ip_info,
             "monolake": monolake,
         }
+
+        # External IPs: cap feedback loop to 1 iteration.
+        # Re-running with the same web search data won't improve confidence.
+        if is_external:
+            result["max_iterations"] = 1
 
         # Generate session_id for memory context (fixes GAP-005)
         session_id = state.get("session_id", "")

--- a/core/verification/biasbuster.py
+++ b/core/verification/biasbuster.py
@@ -66,6 +66,32 @@ def run_biasbuster(state: GeodeState) -> BiasBusterResult:
                 ),
             )
 
+        # Fast path: when stats look clean, skip expensive LLM call.
+        # LLM bias detection rarely overturns a clean statistical profile,
+        # so we only invoke LLM when CV < 0.10 (potential anchoring) or
+        # score range is suspiciously narrow.
+        score_range = stats["max"] - stats["min"]
+        if not low_variance_flag and stats["cv"] >= 0.10 and score_range >= 0.5:
+            log.info(
+                "BiasBuster fast path: CV=%.2f, range=%.1f — stats clean, LLM skipped",
+                stats["cv"],
+                score_range,
+            )
+            return BiasBusterResult(
+                confirmation_bias=False,
+                recency_bias=False,
+                anchoring_bias=False,
+                position_bias=False,
+                verbosity_bias=False,
+                self_enhancement_bias=False,
+                overall_pass=True,
+                explanation=(
+                    f"Statistical check clean (CV={stats['cv']:.2f}, "
+                    f"range=[{stats['min']:.1f}, {stats['max']:.1f}]). "
+                    "LLM verification skipped."
+                ),
+            )
+
         # Tool-augmented path: LLM can query memory for historical bias patterns
         raw_tool_defs: Any = state.get("_tool_definitions", [])
         if raw_tool_defs and not low_variance_flag:


### PR DESCRIPTION
## 요약

develop → main 머지. BiasBuster 성능 최적화 + 외부 IP feedback loop 제한.

- BiasBuster: CV≥0.10 && score range≥0.5일 때 LLM 호출 생략 (10-30초 절감)
- 외부 IP: `max_iterations=1`로 불필요한 반복 분석 방지

## 테스트

- CI 전체 통과 (Lint, Type Check, Security, Test 3.12/3.13, Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>