### PR TITLE
fix: D1-D5 운영 디버깅 패턴 기반 코드베이스 7건 개선

### DIFF
--- a/core/automation/trigger_endpoint.py
+++ b/core/automation/trigger_endpoint.py
@@ -133,6 +133,20 @@ class TriggerEndpoint:
         self._auth_token = auth_token
         self._mappings: dict[str, TriggerMapping] = {}
 
+        # ContextVar initialization — TriggerManager callbacks may invoke
+        # pipeline nodes that depend on memory ContextVars (org_memory,
+        # project_memory).  Without this, any callback touching LLM tools
+        # would find None callables → RuntimeError.
+        try:
+            from core.memory.organization import MonoLakeOrganizationMemory
+            from core.memory.project import ProjectMemory
+            from core.tools.memory_tools import set_org_memory, set_project_memory
+
+            set_project_memory(ProjectMemory())
+            set_org_memory(MonoLakeOrganizationMemory())
+        except Exception:
+            log.debug("Memory context initialization skipped", exc_info=True)
+
     # -- auth ---------------------------------------------------------------
 
     def validate_auth(self, token: str | None) -> bool:

--- a/core/automation/triggers.py
+++ b/core/automation/triggers.py
@@ -252,11 +252,15 @@ class TriggerManager:
         """Create a HookSystem-compatible handler for an event trigger (F3).
 
         Returns a handler that can be registered with HookSystem.
+        The config is captured at creation time to avoid a race condition
+        on self._triggers when the handler is called from another thread.
         """
+        config = self._triggers.get(trigger_id)
+        if config is None:
+            return lambda _event, _data: None
 
         def _handler(event: Any, data: dict[str, Any]) -> None:
-            config = self._triggers.get(trigger_id)
-            if config and config.enabled:
+            if config.enabled:
                 self._execute_trigger(config, {**data, "event": str(event)})
 
         return _handler

--- a/core/cli/batch.py
+++ b/core/cli/batch.py
@@ -63,7 +63,7 @@ def select_ips(
     return candidates[:top]
 
 
-def _run_analysis_standalone(ip_name: str, *, dry_run: bool = True) -> dict[str, Any]:
+def _run_analysis_standalone(ip_name: str, *, dry_run: bool = False) -> dict[str, Any]:
     """Run analysis pipeline for a single IP (no circular import to core.cli).
 
     This is thread-safe: each call creates its own GeodeRuntime.
@@ -120,7 +120,7 @@ def _run_analysis_standalone(ip_name: str, *, dry_run: bool = True) -> dict[str,
 def run_single_analysis(
     ip_name: str,
     *,
-    dry_run: bool = True,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Run analysis on a single IP and return summary dict."""
     try:
@@ -142,7 +142,7 @@ def run_batch(
     genre: str | None = None,
     ips: list[str] | None = None,
     concurrency: int = 2,
-    dry_run: bool = True,
+    dry_run: bool = False,
 ) -> list[dict[str, Any]]:
     """Run batch analysis on multiple IPs."""
     selected = select_ips(top=top, genre=genre, ips=ips)

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -479,7 +479,7 @@ def make_pipeline_handler(
                 ip_name,
                 fmt=args.get("format", "markdown"),
                 template=args.get("template", "summary"),
-                dry_run=args.get("dry_run", True),
+                dry_run=args.get("dry_run", force_dry_run),
             )
             if report_result is None:
                 return {"error": f"Report generation failed for '{ip_name}'"}

--- a/core/graph.py
+++ b/core/graph.py
@@ -277,7 +277,7 @@ def _verification_node(state: GeodeState) -> dict[str, Any]:
         errors.append("Guardrails failed — results may be unreliable (demo mode)")
     if not biasbuster.overall_pass:
         errors.append("BiasBuster flagged potential bias in analysis")
-    if not cross_llm.get("passed", True):
+    if not cross_llm.get("passed", False):
         errors.append("Cross-LLM agreement below threshold")
     if rights_risk.status in (RightsStatus.RESTRICTED, RightsStatus.UNKNOWN):
         errors.append(

--- a/core/memory/hybrid_session.py
+++ b/core/memory/hybrid_session.py
@@ -215,19 +215,29 @@ class HybridSessionStore:
 
     def get(self, session_id: str) -> dict[str, Any] | None:
         """Get from L1, fallback to L2. Backfill L1 on L2 hit."""
-        data = self._l1.get(session_id)
+        try:
+            data = self._l1.get(session_id)
+        except Exception:
+            log.debug("L1 read failed for %s, falling back to L2", session_id)
+            data = None
         if data is not None:
             return data
 
         data = self._l2.get(session_id)
         if data is not None:
             # Backfill L1
-            self._l1.set(session_id, data)
+            try:
+                self._l1.set(session_id, data)
+            except Exception:
+                log.debug("L1 backfill failed for %s", session_id)
         return data
 
     def set(self, session_id: str, data: dict[str, Any]) -> None:
         """Write-through: write to both L1 and L2."""
-        self._l1.set(session_id, data)
+        try:
+            self._l1.set(session_id, data)
+        except Exception:
+            log.debug("L1 write failed for %s, continuing with L2", session_id)
         self._l2.set(session_id, data)
 
     def delete(self, session_id: str) -> bool:
@@ -242,12 +252,19 @@ class HybridSessionStore:
 
     def save_checkpoint(self, session_id: str, checkpoint_data: dict[str, Any]) -> None:
         """Save checkpoint to both tiers."""
-        self._l1.save_checkpoint(session_id, checkpoint_data)
+        try:
+            self._l1.save_checkpoint(session_id, checkpoint_data)
+        except Exception:
+            log.debug("L1 checkpoint write failed for %s", session_id)
         self._l2.save_checkpoint(session_id, checkpoint_data)
 
     def load_checkpoint(self, session_id: str) -> dict[str, Any] | None:
         """Load checkpoint from L1, fallback to L2."""
-        data = self._l1.load_checkpoint(session_id)
+        try:
+            data = self._l1.load_checkpoint(session_id)
+        except Exception:
+            log.debug("L1 checkpoint read failed for %s, falling back to L2", session_id)
+            data = None
         if data is not None:
             return data
         return self._l2.load_checkpoint(session_id)

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -197,10 +197,14 @@ class IsolatedRunner:
         result_holder: list[IsolationResult] = []
         error_holder: list[str] = []
 
+        # Capture cancel event before thread creation to avoid
+        # a race condition on self._cancel_flags inside the thread.
+        with self._lock:
+            cancel_event = self._cancel_flags.get(config.session_id)
+
         def _target() -> None:
             try:
-                # Check cancel flag before execution
-                cancel_event = self._cancel_flags.get(config.session_id)
+                # Check cancel flag before execution (uses captured value)
                 if cancel_event and cancel_event.is_set():
                     error_holder.append("Cancelled before execution")
                     return


### PR DESCRIPTION
## 요약

- agent-ops-debugging 스킬(D1-D5) 기반 코드베이스 자동 점검 결과 발견된 7건의 버그/취약점 일괄 수정
- 5개 병렬 에이전트로 점검 → 3개 병렬 에이전트로 수정 → 품질 게이트 통과

## 변경 사항

### D1 Safe Default Anti-pattern (3건)

| 파일 | 변경 | 이유 |
|------|------|------|
| `core/cli/sub_agent.py:482` | `args.get("dry_run", True)` → `force_dry_run` | 리포트 생성 경로도 ADR-008과 동일 패턴 적용 |
| `core/cli/batch.py` (3함수) | `dry_run: bool = True` → `False` | 배치 분석 전체 체인이 항상 fixture 모드였음. caller 결정 원칙 |
| `core/graph.py:280` | `cross_llm.get("passed", True)` → `False` | 검증 결과 누락 시 fail-safe (통과 가정 → 실패 가정) |

### D3 ContextVar Lifecycle (1건)

| 파일 | 변경 | 이유 |
|------|------|------|
| `core/automation/trigger_endpoint.py` | 메모리 ContextVar 초기화 추가 | 트리거 콜백이 파이프라인 노드 호출 시 메모리 도구 실패 방지 |

### D4 Closure Capture Bypass (2건)

| 파일 | 변경 | 이유 |
|------|------|------|
| `core/automation/triggers.py:251` | `make_event_handler()` config 선캡처 | 클로저 내 `self._triggers` dict lock 없는 조회 → race condition |
| `core/orchestration/isolated_execution.py:200` | `cancel_flags` lock 하 조회 후 캡처 | `_target()` 스레드 내 비동기 dict 접근 → race condition |

### D5 Degradation ≠ Correctness (1건)

| 파일 | 변경 | 이유 |
|------|------|------|
| `core/memory/hybrid_session.py` | L1 read/write/checkpoint에 try/except 추가 | Redis ConnectionError 시 L2 fallback 대신 크래시 |

## 설계 판단

- **batch.py default를 False로**: caller(`run_batch`, CLI)가 이미 `dry_run` 명시 전달 → 함수 자체가 dry-run 강제하면 안 됨
- **graph.py fail-safe**: 검증 결과 누락은 "통과"가 아닌 "실패"로 간주해야 안전
- **triggers.py 선캡처**: config가 핸들러 생성 후 변경되지 않는다는 가정 하에 클로저 캡처가 최선 (ADR-008 D4 패턴)

## 테스트

- `uv run ruff check`: 0 errors
- `uv run mypy`: 0 errors
- `uv run pytest tests/ -m "not live"`: **2168 passed**

## 검증 체크리스트

- [x] sub_agent.py 리포트 경로 `force_dry_run` 적용
- [x] batch.py 3함수 dry_run 기본값 변경
- [x] graph.py cross_llm fail-safe
- [x] trigger_endpoint.py 메모리 초기화
- [x] triggers.py 클로저 선캡처
- [x] isolated_execution.py lock 하 조회
- [x] hybrid_session.py L1 예외 처리
- [x] pre-commit 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)