### PR TITLE
docs: Workflow Docs-Sync 게이트 + Worktree 단계 + CHANGELOG 동기화

### DIFF
--- a/.claude/skills/geode-changelog/SKILL.md
+++ b/.claude/skills/geode-changelog/SKILL.md
@@ -61,10 +61,18 @@ PATCH: 버그 수정, 성능 개선
 
 ## 작성 절차
 
-### 새 기능 개발 완료 시
-1. `[Unreleased]` 섹션에 항목 추가
-2. 카테고리별 정리 (Added/Changed/Fixed)
-3. 한 줄 요약 + 필요시 커밋 해시 참조
+### 코드 변경 커밋 시 (매번 필수)
+
+**코드 변경과 동일 커밋에 CHANGELOG 항목을 포함한다.** PR 후 별도 커밋으로 미루지 않는다.
+
+```
+1. 변경 유형 판별 → [Unreleased] 해당 카테고리에 1줄 추가
+2. CLAUDE.md 수치 변경 시 동기화 (Tests, Modules)
+3. README.md 수치 변경 시 동기화
+4. 코드 + CHANGELOG + 문서를 하나의 커밋으로
+```
+
+**예외**: 문서/리팩터만 변경 시 CHANGELOG 항목 불필요.
 
 ### 릴리스 시
 1. `[Unreleased]` → `[X.Y.Z] — YYYY-MM-DD` 로 전환

--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -89,6 +89,11 @@ gh pr merge <PR#> --merge
 - 고려했으나 채택하지 않은 대안은?
 - 향후 확장 시 주의할 점은?
 
+## Docs-Sync (필수)
+- [ ] `CHANGELOG.md` `[Unreleased]`에 변경 항목 추가됨 (Added/Changed/Fixed)
+- [ ] `CLAUDE.md` 수치 동기화 (Tests, Modules — 변경 시)
+- [ ] `README.md` 수치 동기화 (변경 시)
+
 ## 테스트
 - [ ] `uv run ruff check core/ tests/` — 0 errors
 - [ ] `uv run mypy core/` — 0 errors
@@ -163,6 +168,25 @@ PR 생성 → CI 실행 → 실패?
 | `bandit` 보안 경고 | `# nosec` 또는 pyproject.toml skips에 추가 (정당한 경우만) |
 | pre-commit stash 충돌 | `git stash` → 커밋 → `git stash pop` |
 
+## Worktree 작업 공간 분할
+
+병렬 작업이나 독립 기능 개발 시 git worktree로 격리된 작업 공간을 생성한다.
+
+```bash
+# 생성
+git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명>
+cd .claude/worktrees/<작업명>
+
+# 작업 완료 후 정리 (worktree + 브랜치 삭제)
+git push origin feature/<브랜치명>
+cd /path/to/original/repo
+git worktree remove .claude/worktrees/<작업명>
+git branch -d feature/<브랜치명>
+```
+
+- worktree 내에서 `git checkout` 금지
+- `.claude/worktrees/`는 `.gitignore`에 포함
+
 ## Branch Structure
 
 ```
@@ -189,7 +213,7 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 ## CI 게이트 (모든 PR)
 
 ```bash
-uv run pytest tests/ -q              # 2125+ pass, coverage ≥ 75%
+uv run pytest tests/ -q              # 2168+ pass, coverage ≥ 75%
 uv run ruff check core/ tests/       # 0 errors
 uv run mypy core/                    # 0 errors
 uv run bandit -r core/ -c pyproject.toml  # 0 errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+운영 안정성 강화 + 외부 IP 분석 지원 + BiasBuster 성능 최적화 + D1-D5 디버깅 패턴 감사.
+
+### Added
+- 미등록 IP 외부 시그널 수집 — `signals.py` 3단계 fallback (adapter → fixture → Anthropic web search)
+- 외부 IP graceful degradation — `router.py` fixture 미존재 시 최소 `ip_info` 스켈레톤 자동 생성
+
+### Changed
+- BiasBuster 통계 fast path — CV≥0.10 && score range≥0.5일 때 LLM 호출 생략 (10-30초 절감)
+- 외부 IP feedback loop 1회 제한 (`max_iterations=1`) — 동일 웹 검색 데이터 재분석 방지
+- `batch.py` 3함수 `dry_run` 기본값 `True` → `False` — caller 결정 원칙 적용
+- `graph.py` cross_llm 검증 결과 누락 시 fail-safe (`passed=True` → `False`)
+- OpenAI 7개 모델 가격 공식 그라운딩 (GPT-4.1, 4o, o3, o4-mini 등)
+- `pyproject.toml` live 테스트 기본 제외 (`addopts += -m 'not live'`)
+
+### Fixed
+- MCP orphan 프로세스 방지 — REPL 종료 시 `close_all()` + `atexit.register()` 호출
+- MCP 미연결 서버 제거 (discord/e2b/igdb → 4개 유지: brave-search, steam, arxiv, playwright)
+- MCP 미설정 서버 자동 skip — env 빈 값 체크 + `.env` fallback
+- REPL memory contextvars 초기화 — `note_read` 등 6개 메모리 도구 "not available" 해소
+- 서브에이전트 dry-run 강제 해제 (ADR-008) — API 키 존재 시 live LLM 호출 가능
+- CLI 한글 wide-char 백스페이스 잔상 + 방향키 escape code 필터링
+- D1: `sub_agent.py` 리포트 경로 `force_dry_run` 적용
+- D3: `trigger_endpoint.py` 메모리 ContextVar 초기화 누락
+- D4: `triggers.py` 클로저 config 선캡처 + `isolated_execution.py` cancel_flags lock
+- D5: `hybrid_session.py` L1(Redis) 예외 시 L2 fallback 추가
+
+### Infrastructure
+- Test count: 2077+ → 2168+
+- Module count: 125 → 131
+
 ---
 
 ## [0.10.1] — 2026-03-13
@@ -467,6 +497,7 @@ Initial release of GEODE — Undervalued IP Discovery Agent.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 0.10.1 | 2026-03-13 | UI/UX 리브랜딩, Domain Plugin, Agentic 강건성, 리포트 상용화, MCP 정규화 |
 | 0.10.0 | 2026-03-12 | SubAgent 병렬 실행, SchedulerService 와이어링, NL 스케줄, OpenClaw 세션 격리 |
 | 0.9.0 | 2026-03-11 | General Assistant, Skills, MCP 자동설치, Clarification, 마스코트 |
 | 0.8.0 | 2026-03-11 | Plan/Sub-agent NL, Claude Code UI, response quality, verification tracing |
@@ -475,7 +506,8 @@ Initial release of GEODE — Undervalued IP Discovery Agent.
 | 0.6.0 | 2026-03-10 | Initial release — full pipeline, agentic loop, 3-tier memory |
 
 <!-- Links -->
-[Unreleased]: https://github.com/mangowhoiscloud/geode/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/mangowhoiscloud/geode/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/mangowhoiscloud/geode/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/mangowhoiscloud/geode/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mangowhoiscloud/geode/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mangowhoiscloud/geode/compare/v0.7.0...v0.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 124
-- **Tests**: 2125+
+- **Modules**: 131
+- **Tests**: 2168+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -265,6 +265,41 @@ NLRouter는 Claude Opus 4.6 Tool Use로 자연어 → 도구 호출을 매핑한
 
 기능 구현 시 아래 재귀개선 루프를 따른다. 각 단계에서 실패/품질 저하 발견 시 이전 단계로 돌아간다.
 
+### 0. Worktree 작업 공간 분할
+
+**병렬 작업이나 독립 기능 개발 시 git worktree로 격리된 작업 공간을 생성한다.** main 저장소를 오염시키지 않고 안전하게 실험/개발 가능.
+
+```bash
+# 생성: feature 브랜치 + 격리된 디렉토리
+git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명>
+
+# 작업 디렉토리로 이동 (Claude Code는 자동 인식)
+cd .claude/worktrees/<작업명>
+
+# 작업 중 원본 저장소와 독립적으로 커밋/테스트 가능
+uv run pytest tests/ -q
+git add -A && git commit -m "feat: ..."
+```
+
+**작업 완료 후 정리:**
+
+```bash
+# 1. 변경사항을 원본 저장소 브랜치로 푸시
+git push origin feature/<브랜치명>
+
+# 2. 원본 저장소로 돌아가기
+cd /Users/mango/workspace/nexon/ai-live/geode
+
+# 3. worktree 제거 + 브랜치 삭제 (PR merge 후)
+git worktree remove .claude/worktrees/<작업명>
+git branch -d feature/<브랜치명>
+```
+
+**주의사항:**
+- worktree 내에서 `git checkout`으로 브랜치 전환 금지 (같은 브랜치를 두 곳에서 체크아웃 불가)
+- `.claude/worktrees/`는 `.gitignore`에 포함되어 원격에 푸시되지 않음
+- worktree에서 작업 중이면 원본에서 해당 브랜치 체크아웃 불가
+
 ### 1. Research → Plan
 
 ```
@@ -317,37 +352,51 @@ Mock E2E → CLI dry-run → Live E2E → LangSmith 검증 순서로 점검. 각
 | 품질 저하 (score 이상) | → 해당 노드 로직 점검 → 2번 |
 | 모두 통과 | → 4번 진행 |
 
-### 4. Document → Skill Update
+### 4. Docs-Sync (PR 전 필수 게이트)
 
+**코드 변경과 동일 커밋에 문서를 동기화한다.** PR 생성 전에 반드시 완료. 별도 후속 커밋으로 미루지 않는다.
+
+#### 4a. CHANGELOG.md 동기화 (매 커밋)
+
+**모든 코드 변경 커밋에 CHANGELOG 항목을 포함한다.** `[Unreleased]`에 누적 → 릴리스 시 버전 부여.
+
+```bash
+# 변경 유형 판별 → 해당 카테고리에 1줄 추가
+#   Added:    새 기능, 새 모듈, 새 도구
+#   Changed:  기존 동작 변경, 성능 개선, 기본값 변경
+#   Fixed:    버그 수정
+#   Removed:  삭제된 기능
+#   Infrastructure: CI, 의존성, 빌드
+#   Architecture:   구조적 결정
+
+# 예시 — 커밋 메시지가 "fix: MCP orphan 방지" 이면:
+# CHANGELOG.md [Unreleased] → Fixed 에 추가:
+# - MCP orphan 프로세스 방지 — REPL 종료 시 close_all() 호출
 ```
-1. docs/e2e-orchestration-scenarios.md 갱신 (시나리오 추가/변경)
-2. tests/test_e2e_live_llm.py 갱신 (라이브 테스트 추가)
-3. .claude/skills/geode-e2e/SKILL.md 갱신 (시나리오 매핑 테이블)
-4. CLAUDE.md 갱신 (기능/테스트 수/NL 도구 수)
-5. README.md 정합성 검증 (아래 §4a 참조)
-6. CHANGELOG.md 버전업 판단 (아래 §4b 참조)
+
+**문서/리팩터만 변경 시**: CHANGELOG 항목 불필요 (Scope Rules 참조).
+
+#### 4b. README.md + CLAUDE.md 수치 동기화 (매 커밋)
+
+```bash
+# 아래 수치가 변경되면 README.md + CLAUDE.md를 같이 갱신
+TESTS=$(uv run pytest tests/ -q 2>&1 | grep -oP '\d+ passed' | grep -oP '\d+')
+MODULES=$(find core/ -name "*.py" | wc -l | tr -d ' ')
+TOOLS=$(python3 -c "import json; print(len(json.load(open('core/tools/definitions.json'))))")
+
+echo "Tests: $TESTS  Modules: $MODULES  Tools: $TOOLS"
+# → CLAUDE.md Tests/Modules, README.md 해당 수치와 대조
 ```
 
-#### 4a. README.md 정합성 검증 (PR 전 필수)
+| 검증 항목 | CLAUDE.md 위치 | README.md 위치 |
+|----------|---------------|---------------|
+| 테스트 수 | `Tests: XXXX+` | Architecture 섹션 |
+| 모듈 수 | `Modules: XXX` | Architecture 섹션 |
+| Tool 수 | NL Router 테이블 | Tool 테이블 |
+| 프로젝트 구조 | Project Structure 트리 | 해당 시 |
+| Tier/Score | Expected Test Results | 해당 시 |
 
-PR 생성 전 README.md가 코드와 일치하는지 검증한다.
-
-| 검증 항목 | 확인 방법 |
-|----------|----------|
-| 테스트 수 | `uv run pytest tests/ -q` 결과와 README 기재 수 일치 |
-| 모듈 수 | `find core/ -name "*.py" \| wc -l` 결과와 일치 |
-| Tool 수 | `definitions.json` 항목 수 = README tool 테이블 행 수 |
-| 프로젝트 구조 | 신규 파일/디렉토리가 README 트리에 반영됨 |
-| 다이어그램 | 파이프라인 노드/엣지 변경 시 아키텍처 다이어그램 갱신 |
-| Tier/Score | fixture 결과(Berserk S/81.3 등)가 변경 시 README 업데이트 |
-
-불일치 발견 시 README를 수정하고 동일 커밋에 포함한다.
-
-#### 4b. CHANGELOG.md 버전업 절차
-
-변경 규모에 따라 버전업 여부를 판단하고, 필요 시 아래 절차를 수행한다.
-
-**버전업 판단 기준 (SemVer):**
+#### 4c. 버전업 판단 (릴리스 시에만)
 
 | 변경 규모 | 버전 | 예시 |
 |----------|------|------|
@@ -356,19 +405,22 @@ PR 생성 전 README.md가 코드와 일치하는지 검증한다.
 | 버그 수정/개선 | PATCH (0.0.x) | 직렬화 수정, 트레이싱 추가 |
 | 문서/리팩터만 | 버전업 안 함 | README 수정, 내부 리팩터 |
 
-**절차:**
+```
+릴리스 절차:
+1. [Unreleased] → [x.y.z] — YYYY-MM-DD 로 변환
+2. CLAUDE.md Version 필드 업데이트
+3. pyproject.toml version 필드 업데이트
+4. Version History 테이블에 행 추가
+5. 비교 링크 업데이트 ([Unreleased] compare URL)
+6. 동일 커밋에 CHANGELOG.md + CLAUDE.md + pyproject.toml 포함
+```
+
+#### 4d. Skill / E2E 문서 (해당 시)
 
 ```
-1. CHANGELOG.md [Unreleased] 섹션에 변경 사항 기록
-   - Added / Changed / Fixed / Removed / Infrastructure / Architecture 카테고리 사용
-   - Feature-level 단위 (커밋 단위 X)
-2. 버전업 필요 시:
-   a. [Unreleased] → [x.y.z] — YYYY-MM-DD 로 변환
-   b. CLAUDE.md Version 필드 업데이트
-   c. pyproject.toml version 필드 업데이트 (있는 경우)
-   d. 하단 Version History 테이블에 행 추가
-   e. 비교 링크 업데이트 ([Unreleased] compare URL)
-3. 동일 커밋에 CHANGELOG.md + CLAUDE.md + pyproject.toml 포함
+1. docs/e2e-orchestration-scenarios.md 갱신 (시나리오 추가/변경)
+2. tests/test_e2e_live_llm.py 갱신 (라이브 테스트 추가)
+3. .claude/skills/ 갱신 (시나리오 매핑 테이블)
 ```
 
 ### 5. PR & Merge


### PR DESCRIPTION
## 요약
develop → main 머지. Workflow에 Docs-Sync 필수 게이트 + Worktree 단계 추가, CHANGELOG 누락 항목 보충.

## 포함된 변경
- docs: Workflow Docs-Sync 게이트 + Worktree 단계 추가 + CHANGELOG 동기화 #88

## 테스트
- [x] CI 전체 통과 (Lint, Type Check, Security, Test 3.12/3.13, Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>