### PR TITLE
feat: P2 서브에이전트 Full AgenticLoop 상속 + 결과 표준화

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1361,18 +1361,31 @@ def _text_requests_dry_run(text: str) -> bool:
     return bool(_DRY_RUN_PATTERN.search(text))
 
 
-def _build_sub_agent_manager(verbose: bool = False) -> Any:
-    """Build a SubAgentManager wired to real pipeline functions."""
+def _build_sub_agent_manager(
+    verbose: bool = False,
+    *,
+    action_handlers: dict[str, Any] | None = None,
+    mcp_manager: Any = None,
+    skill_registry: Any = None,
+) -> Any:
+    """Build a SubAgentManager wired to real pipeline functions.
+
+    P2-B: When ``action_handlers`` is provided, sub-agents receive a full
+    AgenticLoop with the same tool set, MCP servers, and skills as the parent.
+    Falls back to legacy ``make_pipeline_handler`` if handlers are not provided.
+    """
     from core.cli.sub_agent import (
         SubAgentManager,
         make_pipeline_handler,
     )
+    from core.config import settings
     from core.extensibility.agents import AgentRegistry
     from core.orchestration.isolated_execution import IsolatedRunner
 
     readiness = _get_readiness()
     force_dry = readiness.force_dry_run if readiness else True
 
+    # Legacy fallback handler (used when action_handlers is not provided)
     handler = make_pipeline_handler(
         run_analysis_fn=lambda ip_name, dry_run=force_dry, **_kw: _run_analysis(
             ip_name, dry_run=dry_run, verbose=verbose
@@ -1402,6 +1415,12 @@ def _build_sub_agent_manager(verbose: bool = False) -> Any:
         handler,
         timeout_s=300.0,
         agent_registry=registry,
+        # P2-B: Full AgenticLoop inheritance
+        action_handlers=action_handlers,
+        mcp_manager=mcp_manager,
+        skill_registry=skill_registry,
+        depth=0,
+        max_depth=settings.max_subagent_depth,
     )
 
 
@@ -2444,7 +2463,12 @@ def _interactive_loop() -> None:
     handlers = _build_tool_handlers(
         verbose=verbose, mcp_manager=mcp_mgr, agentic_ref=agentic_ref, skill_registry=skill_registry
     )
-    sub_mgr = _build_sub_agent_manager(verbose=verbose)
+    sub_mgr = _build_sub_agent_manager(
+        verbose=verbose,
+        action_handlers=handlers,
+        mcp_manager=mcp_mgr,
+        skill_registry=skill_registry,
+    )
     executor = ToolExecutor(
         action_handlers=handlers,
         mcp_manager=mcp_mgr,
@@ -2510,6 +2534,9 @@ def _interactive_loop() -> None:
                 )
                 sub_mgr = _build_sub_agent_manager(
                     verbose=verbose,
+                    action_handlers=handlers,
+                    mcp_manager=mcp_mgr,
+                    skill_registry=skill_registry,
                 )
                 executor = ToolExecutor(
                     action_handlers=handlers,

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -55,6 +55,44 @@ def get_agentic_tools(registry: ToolRegistry | None = None) -> list[dict[str, An
     return tools
 
 
+# ---------------------------------------------------------------------------
+# Token guard — prevent oversized tool results from exploding context (P2-A)
+# ---------------------------------------------------------------------------
+MAX_TOOL_RESULT_TOKENS = 4096  # ~16K chars
+
+
+def _guard_tool_result(
+    result: dict[str, Any],
+    max_tokens: int = MAX_TOOL_RESULT_TOKENS,
+) -> dict[str, Any]:
+    """Truncate oversized tool results while preserving summary."""
+    try:
+        serialized = json.dumps(result, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return result
+    estimated_tokens = len(serialized) // 4
+    if estimated_tokens <= max_tokens:
+        return result
+    # Preserve summary if present (SubAgentResult always has one)
+    if "summary" in result:
+        guarded: dict[str, Any] = {
+            "summary": result["summary"],
+            "_truncated": True,
+            "_original_tokens": estimated_tokens,
+        }
+        # Keep lightweight fields
+        for key in ("task_id", "task_type", "status", "error_message", "tier"):
+            if key in result:
+                guarded[key] = result[key]
+        return guarded
+    # No summary — return preview
+    return {
+        "_truncated": True,
+        "_original_tokens": estimated_tokens,
+        "preview": serialized[: max_tokens * 4],
+    }
+
+
 @dataclass
 class AgenticResult:
     """Result of an agentic loop execution."""
@@ -78,7 +116,7 @@ class AgenticLoop:
     """
 
     DEFAULT_MAX_ROUNDS = 15
-    DEFAULT_MAX_TOKENS = 8192
+    DEFAULT_MAX_TOKENS = 16384
     MAX_CLARIFICATION_ROUNDS = 3
     WRAP_UP_HEADROOM = 2  # force text response N rounds before max
 
@@ -530,6 +568,10 @@ class AgenticLoop:
                     "result": result,
                 }
             )
+
+            # Token guard: truncate oversized results to prevent context explosion
+            if isinstance(result, dict):
+                result = _guard_tool_result(result)
 
             # Serialize result as JSON for LLM (not Python repr)
             try:

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -20,8 +20,9 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from core.orchestration.coalescing import CoalescingQueue
 from core.orchestration.hooks import HookEvent, HookSystem
@@ -83,6 +84,53 @@ class SubResult:
         return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}
 
 
+class ErrorCategory(StrEnum):
+    """Sub-agent error classification for retry policy."""
+
+    TIMEOUT = "timeout"
+    API_ERROR = "api_error"
+    VALIDATION = "validation"
+    RESOURCE = "resource"
+    DEPTH_EXCEEDED = "depth_exceeded"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class SubAgentResult:
+    """Standardized result from sub-agent execution (P2-A).
+
+    Every sub-agent returns this format, enabling:
+    - Consistent LLM parsing (``summary`` always present)
+    - Token guard (``summary`` preserved on truncation)
+    - Error classification + retry decisions
+    - Depth tracking for recursive orchestration
+    """
+
+    task_id: str
+    task_type: str
+    status: Literal["ok", "error", "timeout", "partial"] = "ok"
+    depth: int = 0
+    summary: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
+    duration_ms: float = 0.0
+    token_usage: dict[str, int] | None = None
+    children_count: int = 0
+    error_category: str | None = None
+    error_message: str | None = None
+    retryable: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize, omitting None-valued fields."""
+        return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, default=str)
+
+    @property
+    def success(self) -> bool:
+        return self.status == "ok"
+
+
 @dataclass
 class SubagentRunRecord:
     """Track parent-child relationship (OpenClaw Spawn pattern)."""
@@ -105,6 +153,8 @@ class SubAgentManager:
     - **HookSystem**: Emits SUBAGENT_STARTED/COMPLETED/FAILED events.
     - **CoalescingQueue**: Deduplicates identical task_id submissions.
     - **AgentRegistry**: Resolves agent definitions for context injection.
+    - **Full AgenticLoop inheritance** (P2-B): sub-agents get the same tools,
+      MCP, skills, memory as the parent.  Controlled by ``depth`` / ``max_depth``.
     """
 
     def __init__(
@@ -117,6 +167,12 @@ class SubAgentManager:
         coalescing: CoalescingQueue | None = None,
         agent_registry: AgentRegistry | None = None,
         parent_session_key: str = "",
+        # P2-B: Full AgenticLoop inheritance
+        action_handlers: dict[str, Callable[..., dict[str, Any]]] | None = None,
+        mcp_manager: Any | None = None,
+        skill_registry: Any | None = None,
+        depth: int = 0,
+        max_depth: int = 2,
     ) -> None:
         self._runner = runner
         self._task_handler = task_handler
@@ -127,6 +183,12 @@ class SubAgentManager:
         self._parent_session_key = parent_session_key
         self._run_records: dict[str, SubagentRunRecord] = {}
         self._records_lock = threading.Lock()
+        # P2-B fields
+        self._action_handlers = action_handlers
+        self._mcp_manager = mcp_manager
+        self._skill_registry = skill_registry
+        self._depth = depth
+        self._max_depth = max_depth
 
     def delegate(
         self,
@@ -352,39 +414,111 @@ class SubAgentManager:
             )
 
     def _execute_subtask(self, task: SubTask) -> str:
-        """Execute a single sub-task (runs in isolated thread)."""
-        if self._task_handler is None:
-            return json.dumps({"error": "No task handler configured"})
+        """Execute a single sub-task (runs in isolated thread).
 
-        agent_context = self._resolve_agent(task)
-
-        # Set thread-local subagent context for downstream session isolation (G7)
+        P2-B: if ``action_handlers`` is set, creates a full AgenticLoop with
+        the parent's tools, MCP, skills, and memory.  Falls back to the legacy
+        ``task_handler`` function for backward compatibility.
+        """
         from core.memory.session_key import build_subagent_session_key
 
         child_key = build_subagent_session_key(task.args.get("ip_name", "unknown"), task.task_id)
         _subagent_context.is_subagent = True
         _subagent_context.child_session_key = child_key
         try:
-            try:
-                result: dict[str, Any] = self._task_handler(
-                    task.task_type,
-                    task.args,
-                    agent_context=agent_context,
-                )
-            except TypeError:
-                result = self._task_handler(task.task_type, task.args)
-            return json.dumps(result, default=str)
+            # P2-B: Full AgenticLoop path
+            if self._action_handlers is not None:
+                return self._execute_with_agentic_loop(task)
+
+            # Legacy path: simple task_handler function
+            return self._execute_with_handler(task)
         except Exception as exc:
-            log.error(
-                "SubTask %s failed: %s",
-                task.task_id,
-                exc,
-                exc_info=True,
-            )
+            log.error("SubTask %s failed: %s", task.task_id, exc, exc_info=True)
             return json.dumps({"error": str(exc)})
         finally:
             _subagent_context.is_subagent = False
             _subagent_context.child_session_key = ""
+
+    def _execute_with_agentic_loop(self, task: SubTask) -> str:
+        """Run sub-task through a full AgenticLoop (P2-B)."""
+        from core.cli.agentic_loop import AgenticLoop
+        from core.cli.conversation import ConversationContext
+        from core.cli.tool_executor import ToolExecutor
+        from core.config import settings
+
+        # 1. Propagate ContextVars to child thread
+        _propagate_context_vars()
+
+        # 2. Fresh conversation context (independent context window)
+        conversation = ConversationContext(max_turns=10)
+
+        # 3. Build child SubAgentManager if depth allows recursion
+        child_sam: SubAgentManager | None = None
+        if self._depth < self._max_depth:
+            child_sam = SubAgentManager(
+                runner=IsolatedRunner(),
+                action_handlers=self._action_handlers,
+                mcp_manager=self._mcp_manager,
+                skill_registry=self._skill_registry,
+                depth=self._depth + 1,
+                max_depth=self._max_depth,
+                timeout_s=self._timeout_s,
+                hooks=self._hooks,
+                agent_registry=self._agent_registry,
+                parent_session_key=self._parent_session_key,
+            )
+
+        # 4. ToolExecutor with full handler set
+        executor = ToolExecutor(
+            action_handlers=self._action_handlers,
+            sub_agent_manager=child_sam,
+            mcp_manager=self._mcp_manager,
+            auto_approve=True,  # sub-agents skip HITL prompts
+        )
+
+        # 5. AgenticLoop (same capabilities as parent)
+        loop = AgenticLoop(
+            conversation,
+            executor,
+            max_rounds=settings.subagent_max_rounds,
+            max_tokens=settings.subagent_max_tokens,
+            mcp_manager=self._mcp_manager,
+            skill_registry=self._skill_registry,
+        )
+
+        # 6. Run: use task description as user prompt
+        prompt = task.description
+        if task.args:
+            prompt += f"\n\nParameters: {json.dumps(task.args, ensure_ascii=False)}"
+        agentic_result = loop.run(prompt)
+
+        # 7. Build SubAgentResult
+        text = agentic_result.text if agentic_result else ""
+        result = SubAgentResult(
+            task_id=task.task_id,
+            task_type=task.task_type,
+            status="ok" if text else "error",
+            depth=self._depth,
+            summary=text[:500] if text else "No response from sub-agent",
+            data={"response": text},
+            error_message=None if text else "Empty response",
+        )
+        return result.to_json()
+
+    def _execute_with_handler(self, task: SubTask) -> str:
+        """Legacy path: simple task_handler function call."""
+        if self._task_handler is None:
+            return json.dumps({"error": "No task handler configured"})
+        agent_context = self._resolve_agent(task)
+        try:
+            result: dict[str, Any] = self._task_handler(
+                task.task_type,
+                task.args,
+                agent_context=agent_context,
+            )
+        except TypeError:
+            result = self._task_handler(task.task_type, task.args)
+        return json.dumps(result, default=str)
 
     def _wait_for_result(self, session_id: str) -> IsolationResult | None:
         deadline = time.time() + self._timeout_s
@@ -428,6 +562,87 @@ class SubAgentManager:
             output=output,
             duration_ms=isolation.duration_ms,
         )
+
+    def _to_agent_result(self, task: SubTask, isolation: IsolationResult | None) -> SubAgentResult:
+        """Convert IsolationResult to standardized SubAgentResult (P2-A)."""
+        if isolation is None:
+            return SubAgentResult(
+                task_id=task.task_id,
+                task_type=task.task_type,
+                status="timeout",
+                summary=f"Task timed out after {self._timeout_s}s",
+                error_category=ErrorCategory.TIMEOUT,
+                error_message=f"Timeout after {self._timeout_s}s",
+                retryable=True,
+            )
+        if not isolation.success:
+            category = self._classify_error(isolation.error or "")
+            return SubAgentResult(
+                task_id=task.task_id,
+                task_type=task.task_type,
+                status="error",
+                summary=f"Failed: {isolation.error or 'unknown'}",
+                error_category=category,
+                error_message=isolation.error,
+                retryable=category in {ErrorCategory.TIMEOUT, ErrorCategory.API_ERROR},
+                duration_ms=isolation.duration_ms,
+            )
+        data: dict[str, Any]
+        try:
+            parsed = json.loads(isolation.output) if isolation.output else {}
+            data = parsed if isinstance(parsed, dict) else {"raw": parsed}
+        except (json.JSONDecodeError, RecursionError):
+            data = {"raw": isolation.output}
+        summary = data.get("summary", "")
+        if not summary:
+            summary = str(data.get("tier", data.get("status", "")))[:200]
+        return SubAgentResult(
+            task_id=task.task_id,
+            task_type=task.task_type,
+            status="ok",
+            summary=summary,
+            data=data,
+            duration_ms=isolation.duration_ms,
+        )
+
+    @staticmethod
+    def _classify_error(error_msg: str) -> str:
+        """Classify error message into ErrorCategory."""
+        lower = error_msg.lower()
+        if "timeout" in lower or "timed out" in lower:
+            return ErrorCategory.TIMEOUT
+        if "api" in lower or "rate limit" in lower or "authentication" in lower:
+            return ErrorCategory.API_ERROR
+        if "validation" in lower or "required" in lower or "invalid" in lower:
+            return ErrorCategory.VALIDATION
+        if "memory" in lower or "disk" in lower or "resource" in lower:
+            return ErrorCategory.RESOURCE
+        if "depth" in lower:
+            return ErrorCategory.DEPTH_EXCEEDED
+        return ErrorCategory.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# ContextVar propagation for sub-agent threads (P2-B)
+# ---------------------------------------------------------------------------
+
+
+def _propagate_context_vars() -> None:
+    """Propagate memory ContextVars to the current (child) thread.
+
+    Python ``contextvars`` do not automatically inherit across threads.
+    This function re-initializes memory bindings so that tools like
+    ``note_read``, ``memory_search`` work inside sub-agents.
+    """
+    try:
+        from core.memory.organization import MonoLakeOrganizationMemory
+        from core.memory.project import ProjectMemory
+        from core.tools.memory_tools import set_org_memory, set_project_memory
+
+        set_project_memory(ProjectMemory())
+        set_org_memory(MonoLakeOrganizationMemory())
+    except Exception:
+        log.debug("ContextVar propagation skipped (memory modules unavailable)")
 
 
 # ---------------------------------------------------------------------------

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -153,16 +153,17 @@ class ToolExecutor:
 
         results = self._sub_agent_manager.delegate(sub_tasks)
 
-        if len(results) == 1:
-            r = results[0]
-            if r.success:
-                return {"result": r.output, "task_id": r.task_id}
-            return {"error": r.error or "No result"}
-
+        # P2-A: unified response format (single and batch identical)
+        succeeded = sum(1 for r in results if r.success)
+        summary_parts = []
+        for r in results:
+            status = "ok" if r.success else "error"
+            summary_parts.append(f"{r.task_id}:{status}")
         return {
-            "results": [r.to_dict() for r in results],
+            "tasks": [r.to_dict() for r in results],
             "total": len(results),
-            "succeeded": sum(1 for r in results if r.success),
+            "succeeded": succeeded,
+            "summary": f"{succeeded}/{len(results)} tasks completed. [{', '.join(summary_parts)}]",
         }
 
     def _execute_dangerous(self, tool_name: str, tool_input: dict[str, Any]) -> dict[str, Any]:

--- a/core/config.py
+++ b/core/config.py
@@ -84,6 +84,12 @@ class Settings(BaseSettings):
     default_secondary_model: str = "gpt-5.4"  # see OPENAI_PRIMARY
     agreement_threshold: float = 0.67
 
+    # Sub-Agent Orchestration (P2)
+    max_subagent_depth: int = 2  # 최대 재귀 깊이 (root=0 → depth 2까지 허용)
+    max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
+    subagent_max_rounds: int = 10  # 서브에이전트 agentic loop 라운드 제한
+    subagent_max_tokens: int = 8192  # 서브에이전트 출력 토큰 제한
+
 
 _settings_instance: Settings | None = None
 

--- a/docs/plans/P2-subagent-orchestration-hardening.md
+++ b/docs/plans/P2-subagent-orchestration-hardening.md
@@ -1,0 +1,326 @@
+# P2: Sub-Agent Orchestration Hardening
+
+**Status**: IN_PROGRESS
+**Created**: 2026-03-15
+**Updated**: 2026-03-15 (RLM 리서치 + Full Inheritance 방향 확정)
+**Priority**: P2
+**Depends**: P1-subagent-parallel-execution (completed)
+
+---
+
+## 0. 핵심 방향: 서브에이전트 = 부모와 동일한 AgenticLoop
+
+> 서브에이전트는 "축소된 미니 에이전트"가 아니라, 부모 AgenticLoop의 모든 요소(도구, 메모리, MCP, 스킬, HITL)를 **그대로 상속**받는 완전한 에이전트여야 한다.
+> 재귀 서브에이전트 호출 시 각 레벨이 독립 context window를 가지므로, 유효 컨텍스트는 이론적으로 무한해진다 (MIT RLM, arXiv:2512.24601 실증).
+
+### AS-IS vs TO-BE
+
+```
+AS-IS (현재):
+  AgenticLoop (full) → delegate_task → task_handler(analyze/search/compare)
+                                         ↑ 단순 함수 호출, 도구 없음, 재귀 불가
+
+TO-BE (목표):
+  AgenticLoop (depth=0) → delegate_task
+    → AgenticLoop (depth=1, 부모 전체 상속)
+        ├─ 동일 action_handlers (38+ tools)
+        ├─ 동일 MCP manager (4 active servers)
+        ├─ 동일 skill_registry
+        ├─ 동일 Memory ContextVars
+        ├─ 자체 ConversationContext (독립 context window)
+        ├─ 자체 ToolExecutor (HITL 포함)
+        ├─ depth < MAX_DEPTH → delegate_task 포함 (재귀 가능)
+        └─ depth >= MAX_DEPTH → delegate_task 제외 (재귀 차단)
+```
+
+---
+
+## 1. 현황 (AS-IS)
+
+### 재귀 차단 5개 포인트
+
+| 차단 포인트 | 위치 | 설명 |
+|------------|------|------|
+| **ToolExecutor 미주입** | `sub_agent.py:354` | `_execute_subtask()`는 `task_handler`만 호출 |
+| **delegate_task 미노출** | `tool_executor.py:126` | 메인 AgenticLoop에서만 등록 |
+| **AgenticLoop 미생성** | `sub_agent.py:438` | `make_pipeline_handler()`는 단순 라우터 |
+| **ContextVar 미상속** | `sub_agent.py:365` | 자식 스레드에 Memory/Hook 미전파 |
+| **MAX_DEPTH 미정의** | `config.py` | 재귀 깊이 설정 없음 |
+
+### Gap 10건
+
+| # | Gap | Phase | 심각도 |
+|---|-----|-------|--------|
+| G1 | max_tokens 8192 부족 | P2-A | HIGH |
+| G2 | 결과 형태 불일치 (단건 vs 배치) | P2-A | MED |
+| G3 | on_progress 미와이어링 | P2-C | MED |
+| G4 | tool_result 무제한 (context 폭발) | P2-A | HIGH |
+| G5 | 에러 분류 부재 | P2-A | MED |
+| G6 | HookSystem 동기 호출 | 보류 | LOW |
+| G7 | 결과 표준화 부재 | P2-A | HIGH |
+| G8 | 재귀 depth 미지원 | P2-B | HIGH |
+| G9 | 코드 매개 재귀(RLM) 미지원 | P2-D | HIGH |
+| G10 | 컨텍스트 압축 없음 | P2-B | MED |
+
+---
+
+## 2. 설계 (4 Phase)
+
+### Phase 1: 기반 구축 (P2-A) — SubAgentResult + Token Guard + Config
+
+결과 표준화, 에러 분류, 토큰 가드, 설정 추가. Phase 2의 선제 조건.
+
+#### 2.1 SubAgentResult
+
+```python
+@dataclass
+class SubAgentResult:
+    task_id: str
+    task_type: str
+    status: Literal["ok", "error", "timeout", "partial"]
+    depth: int = 0
+    summary: str = ""          # 항상 존재 (LLM 결과 요약)
+    data: dict[str, Any] = field(default_factory=dict)
+    duration_ms: float = 0.0
+    token_usage: dict[str, int] | None = None
+    children_count: int = 0
+    error_category: str | None = None
+    error_message: str | None = None
+    retryable: bool = False
+```
+
+#### 2.2 ErrorCategory
+
+```python
+class ErrorCategory(str, Enum):
+    TIMEOUT = "timeout"
+    API_ERROR = "api_error"
+    VALIDATION = "validation"
+    RESOURCE = "resource"
+    DEPTH_EXCEEDED = "depth_exceeded"
+    UNKNOWN = "unknown"
+```
+
+#### 2.3 Tool Result Token Guard
+
+```python
+# agentic_loop.py — _process_tool_calls()에 삽입
+MAX_TOOL_RESULT_TOKENS = 4096
+
+def _guard_tool_result(result: dict) -> dict:
+    serialized = json.dumps(result, ensure_ascii=False, default=str)
+    if len(serialized) // 4 <= MAX_TOOL_RESULT_TOKENS:
+        return result
+    if "summary" in result:
+        return {"summary": result["summary"], "_truncated": True}
+    return {"_truncated": True, "preview": serialized[:16000]}
+```
+
+#### 2.4 Config 추가
+
+```python
+# core/config.py
+max_subagent_depth: int = 2
+max_total_subagents: int = 15
+subagent_max_rounds: int = 10
+subagent_max_tokens: int = 8192
+default_max_tokens: int = 16384  # 메인 루프 확장
+```
+
+#### 2.5 응답 통일
+
+```python
+# tool_executor.py — _execute_delegate() 반환 형태 통일
+# 단건이든 배치든 동일 구조:
+{
+    "tasks": [sub_result.to_dict() for sub_result in results],
+    "total": len(results),
+    "succeeded": sum(1 for r in results if r.status == "ok"),
+    "summary": "3/5 tasks completed successfully."
+}
+```
+
+**변경 파일**: `sub_agent.py`, `agentic_loop.py`, `tool_executor.py`, `config.py`
+
+---
+
+### Phase 2: Full AgenticLoop 상속 (P2-B) — 핵심 변경
+
+서브에이전트가 부모와 동일한 AgenticLoop을 받도록 전환.
+
+#### 2.6 SubAgentManager 확장
+
+```python
+class SubAgentManager:
+    def __init__(
+        self,
+        runner: IsolatedRunner,
+        task_handler: Any | None = None,        # 기존 호환 유지
+        *,
+        # 신규: Full AgenticLoop 상속용
+        action_handlers: dict[str, Callable] | None = None,
+        tool_definitions: list[dict] | None = None,
+        mcp_manager: Any | None = None,
+        skill_registry: Any | None = None,
+        depth: int = 0,
+        max_depth: int = 2,
+        # 기존
+        timeout_s: float = 120.0,
+        hooks: HookSystem | None = None,
+        ...
+    ):
+```
+
+#### 2.7 _execute_subtask() — AgenticLoop 생성
+
+```python
+def _execute_subtask(self, task: SubTask) -> str:
+    # 1. ContextVar 상속 (명시적)
+    _propagate_context_vars()
+
+    # 2. 독립 ConversationContext
+    conversation = ConversationContext(max_turns=10)
+
+    # 3. 자식 SubAgentManager (depth+1, depth < max_depth일 때만)
+    child_sam = None
+    if self._depth < self._max_depth:
+        child_sam = SubAgentManager(
+            runner=IsolatedRunner(max_concurrent=3),
+            action_handlers=self._action_handlers,
+            depth=self._depth + 1,
+            max_depth=self._max_depth,
+            ...
+        )
+
+    # 4. ToolExecutor (부모 handlers 상속)
+    executor = ToolExecutor(
+        action_handlers=self._action_handlers,
+        sub_agent_manager=child_sam,
+        mcp_manager=self._mcp_manager,
+        auto_approve=True,  # 서브에이전트는 HITL 스킵
+    )
+
+    # 5. AgenticLoop (부모와 동일 구성)
+    loop = AgenticLoop(
+        conversation,
+        executor,
+        max_rounds=settings.subagent_max_rounds,  # 10
+        max_tokens=settings.subagent_max_tokens,   # 8192
+        mcp_manager=self._mcp_manager,
+        skill_registry=self._skill_registry,
+    )
+
+    # 6. 실행: task description을 user input으로 전달
+    result = loop.run(task.description)
+
+    # 7. SubAgentResult로 표준화
+    return SubAgentResult(
+        task_id=task.task_id,
+        summary=result.text[:500] if result else "",
+        data={"full_response": result.text} if result else {},
+        ...
+    ).to_json()
+```
+
+#### 2.8 _build_sub_agent_manager() 변경 (cli/__init__.py)
+
+```python
+def _build_sub_agent_manager(...) -> SubAgentManager:
+    handlers = _build_tool_handlers(...)  # 기존 handlers dict 그대로 전달
+
+    return SubAgentManager(
+        runner=IsolatedRunner(),
+        action_handlers=handlers,           # 전체 도구 상속
+        mcp_manager=mcp_mgr,               # MCP 상속
+        skill_registry=skill_registry,      # 스킬 상속
+        depth=0,
+        max_depth=settings.max_subagent_depth,
+        timeout_s=300.0,
+        agent_registry=registry,
+    )
+```
+
+#### 2.9 ContextVar 전파
+
+```python
+def _propagate_context_vars():
+    """Propagate parent ContextVars to child thread."""
+    from core.tools.memory_tools import set_project_memory, set_org_memory
+    from core.memory.project import ProjectMemory
+    from core.memory.organization import MonoLakeOrganizationMemory
+
+    try:
+        set_project_memory(ProjectMemory())
+        set_org_memory(MonoLakeOrganizationMemory())
+    except Exception:
+        pass  # Graceful degradation
+```
+
+**변경 파일**: `sub_agent.py`, `cli/__init__.py`
+
+---
+
+### Phase 3: 진행 보고 + 튜닝 (P2-C)
+
+#### 2.10 on_progress → GeodeStatus
+
+```python
+# tool_executor.py
+def _execute_delegate(self, tool_input):
+    ...
+    def _on_progress(result):
+        # GeodeStatus 스피너 업데이트
+        ...
+    results = self._sub_agent_manager.delegate(tasks, on_progress=_on_progress)
+```
+
+#### 2.11 max_tokens 메인루프 확장
+
+`DEFAULT_MAX_TOKENS = 16384` (기존 8192). 서브에이전트는 8192 유지.
+
+**변경 파일**: `tool_executor.py`, `agentic_loop.py`
+
+---
+
+### Phase 4: RLM 코드 매개 재귀 (P2-D) — 향후
+
+Phase 1-3 완비 후 코드 기반 재귀 패턴 도입. `run_bash` + `delegate_task` 조합으로 10M+ 토큰 처리.
+
+---
+
+## 3. 구현 순서
+
+| Phase | 작업 | 파일 | Gap |
+|-------|------|------|-----|
+| **P2-A** | SubAgentResult + ErrorCategory | `sub_agent.py` | G7, G5 |
+| | tool_result token guard | `agentic_loop.py` | G4 |
+| | 응답 통일 (단건/배치) | `tool_executor.py` | G2 |
+| | Config (depth, max_tokens) | `config.py` | G1, G8 |
+| **P2-B** | SubAgentManager → Full AgenticLoop 상속 | `sub_agent.py` | G8, G10 |
+| | _build_sub_agent_manager() 재설계 | `cli/__init__.py` | G8 |
+| | ContextVar 명시 전파 | `sub_agent.py` | G8 |
+| | make_pipeline_handler() → 기존 호환 유지 (fallback) | `sub_agent.py` | — |
+| **P2-C** | on_progress → GeodeStatus | `tool_executor.py` | G3 |
+| | DEFAULT_MAX_TOKENS 16384 | `agentic_loop.py` | G1 |
+| **P2-D** | RLM 패턴 가이드 | docs/skill | G9 |
+
+---
+
+## 4. 참조
+
+### 프론티어 벤치마크 (2026-03-15)
+
+| 시스템 | depth | 격리 | 결과 포맷 | 비용 |
+|--------|-------|------|----------|------|
+| OpenClaw | 1 (flat) | Session | Text announce | 7x/agent |
+| Claude Code | 1 (flat) | Git worktree | Final msg verbatim | 7x/agent |
+| Codex | 1 (실험적) | OS sandbox | LLM-consolidated | 미공개 |
+| RLM (MIT) | 2-3 | REPL | 코드 구조화 | 0.03% |
+| **GEODE (목표)** | **2 (설정 가능)** | **Thread + ContextVar** | **SubAgentResult** | **상속 기반** |
+
+### 학술 논문
+
+- RLM (arXiv:2512.24601) — 10M+ 토큰, BrowseComp 91.33%
+- MAS Failure (arXiv:2503.13657) — 41-86.7% 실패율, 14 failure modes
+- ACON (arXiv:2510.00615) — 에이전트 컨텍스트 압축 26-54%
+- Complexity Trap (arXiv:2508.21433) — 단순 마스킹 ≈ LLM 요약


### PR DESCRIPTION
## 요약

- 서브에이전트가 부모 AgenticLoop의 모든 요소(도구 38+, MCP 4서버, 스킬, 메모리)를 그대로 상속
- 재귀 서브에이전트 호출 지원 (depth 제어, 기본 MAX_DEPTH=2)
- SubAgentResult 표준 스키마 + ErrorCategory 에러 분류 + tool_result 토큰 가드

## 변경 사항

### P2-A: 기반 구축

| 파일 | 변경 |
|------|------|
| `core/cli/sub_agent.py` | `SubAgentResult` 표준 dataclass + `ErrorCategory` StrEnum + `_to_agent_result()` + `_classify_error()` |
| `core/cli/agentic_loop.py` | `_guard_tool_result()` 토큰 가드 (4096 초과 시 summary 보존 truncation), `DEFAULT_MAX_TOKENS` 8192→16384 |
| `core/cli/tool_executor.py` | `_execute_delegate()` 단건/배치 통일 형식 `{tasks, total, succeeded, summary}` |
| `core/config.py` | `max_subagent_depth=2`, `max_total_subagents=15`, `subagent_max_rounds=10`, `subagent_max_tokens=8192` |

### P2-B: Full AgenticLoop 상속 (핵심)

| 파일 | 변경 |
|------|------|
| `core/cli/sub_agent.py` | `SubAgentManager.__init__()`: `action_handlers`, `mcp_manager`, `skill_registry`, `depth`, `max_depth` 파라미터 추가 |
| `core/cli/sub_agent.py` | `_execute_with_agentic_loop()`: 서브에이전트에 독립 `ConversationContext` + 동일 `ToolExecutor` + `AgenticLoop` 생성 |
| `core/cli/sub_agent.py` | `_propagate_context_vars()`: 자식 스레드에 `ProjectMemory`/`OrgMemory` 명시 전파 |
| `core/cli/sub_agent.py` | depth < max_depth → 재귀 `delegate_task` 포함, depth >= max_depth → 차단 |
| `core/cli/__init__.py` | `_build_sub_agent_manager()`: `action_handlers`, `mcp_manager`, `skill_registry` 파라미터 추가 + 호출부 2곳 수정 |
| `core/cli/sub_agent.py` | `_execute_with_handler()`: 기존 `task_handler` 경로를 호환 메서드로 분리 |

### 아키텍처 변경

```
AS-IS:
  AgenticLoop → delegate_task → task_handler(analyze/search/compare)
                                 ↑ 단순 함수 호출, 도구 없음, 재귀 불가

TO-BE:
  AgenticLoop (depth=0) → delegate_task
    → AgenticLoop (depth=1, 부모 전체 상속)
        ├─ 동일 action_handlers (38+ tools)
        ├─ 동일 MCP manager
        ├─ 동일 skill_registry
        ├─ 동일 Memory ContextVars (명시 전파)
        ├─ 독립 ConversationContext (별도 context window)
        ├─ depth < 2 → delegate_task 재귀 가능
        └─ depth >= 2 → delegate_task 차단
```

## 설계 판단

- **MiniAgenticLoop 별도 클래스 대신 기존 AgenticLoop 재사용**: 서브에이전트 = 부모와 동일한 에이전트. 별도 클래스는 불필요한 분기와 유지보수 부담
- **auto_approve=True**: 서브에이전트는 HITL 프롬프트 스킵 (부모 레벨에서 이미 승인)
- **subagent_max_rounds=10**: 부모(15)보다 짧게. 서브에이전트는 집중된 단일 작업
- **기존 task_handler 호환**: `action_handlers`가 None이면 레거시 경로 사용. 테스트 호환성 유지

## 테스트

- `uv run ruff check`: 0 errors
- `uv run mypy`: 0 errors
- `uv run pytest -m "not live"`: **2168 passed**, 0 failed
- pre-commit hooks 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)