### PR TITLE
fix: prompt_toolkit Backspace/Delete 와이드 문자 잔상 해소

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - REPL memory contextvars 초기화 — `note_read` 등 6개 메모리 도구 "not available" 해소
 - 서브에이전트 dry-run 강제 해제 (ADR-008) — API 키 존재 시 live LLM 호출 가능
 - CLI 한글 wide-char 백스페이스 잔상 + 방향키 escape code 필터링
+- prompt_toolkit Backspace/Delete 키 바인딩 — `renderer.reset()` + `invalidate()` 강제 redraw로 와이드 문자 잔상 해소
 - D1: `sub_agent.py` 리포트 경로 `force_dry_run` 적용
 - D3: `trigger_endpoint.py` 메모리 ContextVar 초기화 누락
 - D4: `triggers.py` 클로저 config 선캡처 + `isolated_execution.py` cancel_flags lock

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2283,10 +2283,35 @@ def _restore_terminal() -> None:
 # prompt_toolkit REPL input (arrow keys, history, multi-line paste)
 # ---------------------------------------------------------------------------
 def _build_prompt_session() -> Any:
-    """Create a prompt_toolkit PromptSession with history + GEODE styling."""
+    """Create a prompt_toolkit PromptSession with history + GEODE styling.
+
+    Includes a custom Backspace/Delete key binding that forces a full
+    renderer redraw after deletion — fixes wide-char (Korean jamo) ghost
+    artifacts where the display doesn't update even though the buffer is
+    correctly modified.
+    """
     from prompt_toolkit import PromptSession
     from prompt_toolkit.formatted_text import HTML
     from prompt_toolkit.history import FileHistory
+    from prompt_toolkit.key_binding import KeyBindings
+
+    kb = KeyBindings()
+
+    @kb.add("backspace")
+    def _backspace(event: Any) -> None:
+        buf = event.app.current_buffer
+        if buf.cursor_position > 0:
+            buf.delete_before_cursor(count=1)
+            event.app.renderer.reset()
+            event.app.invalidate()
+
+    @kb.add("delete")
+    def _delete(event: Any) -> None:
+        buf = event.app.current_buffer
+        if buf.cursor_position < len(buf.text):
+            buf.delete(count=1)
+            event.app.renderer.reset()
+            event.app.invalidate()
 
     history_path = Path.home() / ".geode_history"
     return PromptSession(
@@ -2294,6 +2319,7 @@ def _build_prompt_session() -> Any:
         message=HTML("<b>&gt;</b> "),
         enable_history_search=True,
         multiline=False,
+        key_bindings=kb,
     )
 
 


### PR DESCRIPTION
## 요약
develop → main 머지. REPL 백스페이스 와이드 문자 잔상 버그 수정.

## 포함된 변경
- fix: prompt_toolkit Backspace/Delete 와이드 문자 잔상 해소 #91

## 테스트
- [x] CI 전체 통과 (Lint, Type Check, Security, Test Python 3.12/3.13, Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)