### PR TITLE
feat: LinkedIn 우선 라우팅 — 프로필/커리어 쿼리 site:linkedin.com 우선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - 시작 화면 초기화 진행 표시 — Domain/Memory/MCP/Skills/Scheduler 단계별 `ok`/`skip` 상태 출력
+- LinkedIn 우선 라우팅 — 프로필/커리어/채용 쿼리 시 `site:linkedin.com` 프리픽스 우선 검색 (AGENTIC_SUFFIX)
 
 ---
 

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -165,7 +165,7 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "f4a501ba2f16",
+    "AGENTIC_SUFFIX": "70d83fb83a63",
     "ANALYST_SPECIFIC": "5a696a2d5ebb",
     "ANALYST_SYSTEM": "924433f5bf11",
     "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -54,6 +54,15 @@ Anti-exploration: NEVER explore beyond what was asked. When a tool succeeds, sum
 - Use delegate_task only for truly independent parallel work.
 - Keep your final text response concise and in the user's language.
 
+## Tool priority routing
+
+When the user asks about **people, profiles, careers, recruiting, companies, or job positions**:
+1. First try LinkedIn-specific search: use `brave_web_search` or `general_web_search` with `site:linkedin.com` prefix in the query.
+2. If LinkedIn MCP tools are available (e.g. from the `linkedin` server), prefer those over general web search.
+3. Fall back to general web search only if LinkedIn-specific results are insufficient.
+
+Example: "홍길동 프로필 찾아줘" → search "site:linkedin.com 홍길동" first.
+
 ## Clarification rules (CRITICAL)
 Before calling a tool, verify ALL required parameters can be filled from context:
 - If a required parameter is missing or ambiguous, ask the user BEFORE calling the tool.


### PR DESCRIPTION
## 요약

프로필/커리어/채용 쿼리 시 일반 웹 검색보다 LinkedIn을 먼저 검색하도록 시스템 프롬프트 라우팅 힌트 추가.

## 변경 사항

### 핵심 변경
- `core/llm/prompts/router.md`: AGENTIC_SUFFIX에 Tool priority routing 섹션 추가
- `core/llm/prompts/__init__.py`: pinned hash 갱신
- `CHANGELOG.md`: [Unreleased] Added 항목

## Pre-PR Quality Gate
- [x] ruff/mypy/bandit — 0 errors
- [x] pytest — 2168 passed
- [x] CHANGELOG 항목 추가
- [x] pre-commit 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)