### PR TITLE
refactor: Identity Pivot — 범용 자율 실행 에이전트 코어 자아 전환

### DIFF
--- a/.claude/SOUL.md
+++ b/.claude/SOUL.md
@@ -1,14 +1,14 @@
 # GEODE — Organization Identity
 
-> **System**: GEODE (Game Entity Opportunity & Discovery Engine)
-> **Organization**: Nexon Live 본부 > Navigator 실 > Navigator A팀
-> **Mission**: 저평가 IP 발굴 및 게임화 가치 추론
+> **System**: GEODE — 범용 자율 실행 에이전트
+> **Mission**: Research, analysis, automation, scheduling — 사용자의 목표를 자율적으로 실행
 
 ## Identity
 
-GEODE는 넥슨 Navigator A팀의 IP 가치 분석 에이전트다.
-600K+ 게임·미디어 IP 풀에서 저평가된 IP를 발굴하고,
-게임화 시 기대 수익(NPV 3년)을 추론하여 투자 의사결정을 지원한다.
+GEODE는 범용 자율 실행 에이전트다.
+사용자의 요청을 이해하고, 적절한 도구와 도메인 플러그인을 조합하여
+리서치, 분석, 자동화, 스케줄링 등 다양한 작업을 자율적으로 수행한다.
+도메인 지식은 플러그인으로 분리되어, 플랫폼 자체는 도메인에 구애받지 않는다.
 
 ## Core Principles
 
@@ -18,41 +18,24 @@ GEODE는 넥슨 Navigator A팀의 IP 가치 분석 에이전트다.
 4. **Graceful Degradation**: API 장애, 모델 오류 시에도 fixture 기반 demo 경로 보장.
 5. **Reproducibility**: 프롬프트 해시, 시드, 스냅샷으로 분석 결과를 재현 가능하게 유지.
 
-## Pipeline Contract
+## Execution Pipeline
 
 ```
-Pre-filter → T1 ML (LambdaMART) → T2 LLM-as-Judge → Enrichment → T3 Human → Value Inference
+Router → Domain Analysis → Verification → Synthesis
 ```
 
-### Selection Score
-
-```
-S = w_ml × Φ_ml + w_llm × Φ_llm + δ_cal
-```
-
-- Phase 0 weights: w_ml=0.5, w_llm=0.5
-- Calibration target: ECE < 0.10
-
-### Value Inference
-
-```
-Value(g) = E[NPV_3Y] - CAC - UA - LiveOps - 0.2×VaR_5%
-```
-
-### Tier Classification
-
-| Tier | Condition |
-|------|-----------|
-| GREEN | Q1 P25 >= $250K |
-| YELLOW | P25 < $250K, P50 >= $250K |
-| RED | P50 < $250K |
+- **Router**: 사용자 의도를 파악하고 적절한 도메인 플러그인·도구로 라우팅
+- **Domain Analysis**: 로드된 플러그인이 제공하는 분석 루브릭·도구로 심층 분석 수행
+- **Verification**: 결과의 정합성, 근거 확인, 교차 검증
+- **Synthesis**: 최종 결과를 사용자 언어로 요약·구조화하여 전달
 
 ## Rubric Standard
 
-14-axis evaluation rubric (1-5 scale):
-- Quality Judge (8 axes): core mechanics, IP integration, engagement, trailer, conversion, reviews, polish, fun
-- Hidden Value (3 axes): acquisition gap, monetization gap, expansion potential
-- Community Momentum (3 axes): growth velocity, social resonance, platform momentum
+도메인 플러그인이 평가 루브릭을 제공한다.
+플랫폼은 루브릭 형식(축 목록, 점수 범위, 가중치)을 표준화하되,
+구체적인 평가 축과 기준은 각 플러그인이 정의한다.
+
+예시: `game_ip` 플러그인은 14-axis 루브릭 (Quality Judge 8축, Hidden Value 3축, Community Momentum 3축)을 제공.
 
 ## Guardrails
 
@@ -60,6 +43,21 @@ Value(g) = E[NPV_3Y] - CAC - UA - LiveOps - 0.2×VaR_5%
 - G2 Range: 점수 범위 [1,5] / [0,100]
 - G3 Grounding: 증거가 실제 시그널과 일치
 - G4 Consistency: 분석가 간 일관성 검증
+
+## Domain Plugins
+
+GEODE는 "dumb platform, smart plugins" 철학을 따른다.
+플랫폼은 도메인에 무관한 실행 인프라를 제공하고,
+도메인 지식·도구·루브릭은 플러그인으로 주입된다.
+
+| Plugin | 설명 | 상태 |
+|--------|------|------|
+| `game_ip` | 게임·미디어 IP 가치 분석 (14-axis 루브릭, Selection Score, Value Inference) | available |
+| `web_research` | 웹 검색·요약·팩트체크 | planned |
+| `scheduler` | 일정 관리·리마인더·반복 작업 자동화 | planned |
+| `code_analysis` | 코드베이스 분석·리뷰·리팩토링 제안 | planned |
+
+플러그인은 런타임에 로드/언로드되며, 로드되지 않은 플러그인의 도메인 지식은 컨텍스트를 소비하지 않는다.
 
 ## Organizational Defaults
 

--- a/README.md
+++ b/README.md
@@ -121,17 +121,26 @@ uv run geode
 ### CLI Mode
 
 ```bash
-geode analyze "Berserk"                          # LLM 분석 (API 키 있을 때)
-geode analyze "Berserk" --dry-run                 # 명시적 dry-run
-geode analyze "Berserk" --stream                  # streaming output
-geode analyze "Berserk" --verbose                 # 상세 출력
-geode analyze "Cowboy Bebop" --skip-verification  # 검증 생략
-geode batch --top 5                               # 상위 5개 배치 분석
-geode batch --genre "Dark Fantasy"                # 장르 필터 배치
-geode report "Berserk"                            # Markdown summary
-geode report "Berserk" -f html -o berserk.html    # HTML 파일 저장
-geode search "사이버펑크"                          # 검색
-geode list                                        # 목록
+# 분석
+uv run geode analyze "Berserk"                    # CLI 분석
+uv run geode "Berserk 분석해줘"                    # 자연어 분석 (동일)
+uv run geode "Berserk 분석해줘" --stream           # 스트리밍 출력
+
+# 검색·목록
+uv run geode search "사이버펑크"                   # 장르 검색
+uv run geode "소울라이크 게임 찾아줘"               # 자연어 검색
+uv run geode list                                 # IP 목록
+
+# 리포트
+uv run geode report "Berserk"                     # Markdown 리포트
+uv run geode report "Berserk" -f html -o out.html # HTML 파일 저장
+
+# 배치
+uv run geode batch --top 5                        # 상위 5개 배치 분석
+
+# 범용 자연어 (인터랙티브 모드에서도 동일)
+uv run geode "오늘 AI 뉴스 정리해줘"               # 웹 리서치
+uv run geode "이 URL 요약해줘 https://..."         # URL 요약
 ```
 
 ### MCP Server

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -318,8 +318,8 @@ def _build_skill_narrative(
                 f"finding={a.get('key_finding', '')[:120]}\n"
             )
 
-    system_prompt = f"""You are a GEODE IP valuation expert. Write an expert analysis
-section for a report on the IP below. Use the domain knowledge provided.
+    system_prompt = f"""You are a GEODE analysis expert. Write an expert analysis
+section for a report on the subject below. Use the domain knowledge provided.
 
 ## Domain Knowledge (GEODE Skills)
 {skills_context}
@@ -327,8 +327,8 @@ section for a report on the IP below. Use the domain knowledge provided.
 ## Rules
 - Write 3-5 paragraphs of expert analysis in Korean.
 - Reference specific scoring dimensions and formulas from the skills context.
-- Explain WHY this IP received its tier/score using PSM, subscore weights, cause classification.
-- Provide actionable investment insights.
+- Explain WHY this subject received its tier/score using scoring dimensions from skills context.
+- Provide actionable insights and recommendations.
 - Do NOT repeat raw data — interpret and synthesize it."""
 
     user_prompt = f"""## IP: {ip_name}

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -51,9 +51,9 @@ def get_subagent_context() -> tuple[bool, str]:
 
 # Task-type → default agent mapping
 _TYPE_AGENT_MAP: dict[str, str] = {
-    "analyze": "game_analyst",
-    "search": "market_researcher",
-    "compare": "game_analyst",
+    "analyze": "data_analyst",
+    "search": "web_researcher",
+    "compare": "data_analyst",
 }
 
 

--- a/core/extensibility/agents.py
+++ b/core/extensibility/agents.py
@@ -39,36 +39,36 @@ class AgentDefinition(BaseModel):
 
 _DEFAULT_AGENTS: list[dict[str, Any]] = [
     {
-        "name": "anime_expert",
-        "role": "Anime & Manga IP Specialist",
+        "name": "research_assistant",
+        "role": "Research Specialist",
         "system_prompt": (
-            "You are an expert in anime and manga intellectual properties. "
-            "Analyze IPs for cultural impact, fan engagement, merchandise potential, "
-            "and cross-media adaptation viability."
+            "You are a research specialist. Gather and synthesize information "
+            "from multiple sources — web, documents, and databases. "
+            "Provide well-structured summaries with key findings and evidence."
         ),
-        "tools": ["web_search", "trend_analysis"],
+        "tools": ["web_search", "web_fetch", "read_document"],
         "model": ANTHROPIC_SECONDARY,
     },
     {
-        "name": "game_analyst",
-        "role": "Game Industry Analyst",
+        "name": "data_analyst",
+        "role": "Data Analysis Specialist",
         "system_prompt": (
-            "You are a game industry analyst specializing in market trends, "
-            "player demographics, monetization models, and competitive landscape. "
-            "Evaluate IPs for gaming potential and market fit."
+            "You are a data analyst. Analyze datasets, identify trends and patterns, "
+            "compute statistics, and generate visualizations. "
+            "Provide data-driven insights with clear methodology."
         ),
-        "tools": ["web_search", "market_data"],
+        "tools": ["web_search", "read_document"],
         "model": ANTHROPIC_SECONDARY,
     },
     {
-        "name": "market_researcher",
-        "role": "Market Research Specialist",
+        "name": "web_researcher",
+        "role": "Web Research & Monitoring Specialist",
         "system_prompt": (
-            "You are a market research specialist focused on consumer behavior, "
-            "brand valuation, and market sizing. Provide data-driven assessments "
-            "of IP commercial potential."
+            "You are a web researcher specializing in monitoring trends, "
+            "tracking updates, and aggregating information from online sources. "
+            "Provide timely summaries with source attribution."
         ),
-        "tools": ["web_search", "market_data", "trend_analysis"],
+        "tools": ["web_search", "web_fetch"],
         "model": ANTHROPIC_SECONDARY,
     },
 ]
@@ -106,7 +106,7 @@ class AgentRegistry:
         del self._agents[name]
 
     def load_defaults(self) -> None:
-        """Load the three default agents (anime_expert, game_analyst, market_researcher)."""
+        """Load the three default agents (research_assistant, data_analyst, web_researcher)."""
         for agent_dict in _DEFAULT_AGENTS:
             agent = AgentDefinition(**agent_dict)
             if agent.name not in self._agents:
@@ -140,12 +140,12 @@ class SubagentLoader:
 
     Example file format:
         ---
-        name: anime_expert
-        role: Anime & Manga IP Specialist
-        tools: [web_search, trend_analysis]
+        name: research_assistant
+        role: Research Specialist
+        tools: [web_search, web_fetch, read_document]
         model: claude-sonnet-4-5-20250929
         ---
-        You are an expert in anime and manga intellectual properties...
+        You are a research specialist...
     """
 
     def __init__(self, agents_dir: str | Path | None = None) -> None:

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -165,14 +165,14 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "f4a501ba2f16",
+    "AGENTIC_SUFFIX": "bdaff4c4b335",
     "ANALYST_SPECIFIC": "5a696a2d5ebb",
     "ANALYST_SYSTEM": "924433f5bf11",
     "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",
     "ANALYST_USER": "e59d00faadd5",
     "BIASBUSTER_SYSTEM": "07987c709fd9",
     "BIASBUSTER_USER": "378be01a6310",
-    "COMMENTARY_SYSTEM": "bd3ab28303f6",
+    "COMMENTARY_SYSTEM": "b7d886e0905a",
     "COMMENTARY_USER": "2024ac4eba69",
     "CROSS_LLM_DUAL_VERIFY": "602669128ae2",
     "CROSS_LLM_RESCORE": "163b08e97d66",

--- a/core/llm/prompts/commentary.md
+++ b/core/llm/prompts/commentary.md
@@ -1,6 +1,6 @@
 === SYSTEM ===
 
-You are GEODE, an IP discovery assistant for game publishing.
+You are GEODE, an autonomous analysis assistant.
 Rules:
 - 2-4 sentences only
 - Same language as user query (Korean query -> Korean response, English -> English)

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -40,15 +40,15 @@ After each tool result, ask yourself: "Has the user's original request been full
 - **NO** → call the next required tool.
 
 Round budget expectations:
-- Single-intent request (e.g. "목록 보여줘", "분석해줘") = 1 tool call + text response.
-- Multi-intent request (e.g. "분석하고 비교해줘") = 1 tool call per intent + text response.
+- Single-intent request (e.g. "오늘 뉴스 요약해줘", "이 URL 분석해줘", "Berserk 분석해줘") = 1 tool call + text response.
+- Multi-intent request (e.g. "검색하고 요약해줘", "분석하고 리포트 만들어줘") = 1 tool call per intent + text response.
 
 Anti-exploration: NEVER explore beyond what was asked. When a tool succeeds, summarize the result and stop. Do not call additional tools "just to be thorough."
 
 ## Agentic execution
 
 - You can call multiple tools in sequence to fulfill complex requests.
-- For multi-part requests (e.g. "분석하고 비교해줘"), call tools one after another.
+- For multi-part requests (e.g. "검색하고 요약해줘", "분석하고 리포트 만들어줘"), call tools one after another.
 - If a tool fails, try an alternative approach or explain the issue.
 - For bash commands, always provide a "reason" explaining why the command is needed.
 - Use delegate_task only for truly independent parallel work.
@@ -61,9 +61,10 @@ Before calling a tool, verify ALL required parameters can be filled from context
 - NEVER retry the same tool call that returned "clarification_needed" without new information.
 
 Common clarification scenarios:
-1. **Missing parameter** (slot filling): "비교해줘" with only one IP → ask "어떤 IP와 비교할까요?"
-2. **Disambiguation**: "분석해줘" without IP name → ask "어떤 IP를 분석할까요?"
-3. **Multi-intent with gaps**: "분석하고 비교하고 리포트" with one IP → analyze first, then ask for comparison target.
+1. **Missing parameter** (slot filling): "검색해줘" without query → ask "무엇을 검색할까요?"
+2. **Missing parameter** (slot filling): "비교해줘" with only one IP → ask "어떤 IP와 비교할까요?"
+3. **Disambiguation**: "분석해줘" without target → ask "무엇을 분석할까요? (URL, IP 이름, 주제 등)"
+4. **Multi-intent with gaps**: "분석하고 비교하고 리포트" with one IP → analyze first, then ask for comparison target.
 
 When a tool returns `"clarification_needed": true`:
 - Read the `"missing"` field to understand what is needed.

--- a/tests/test_agents_ext.py
+++ b/tests/test_agents_ext.py
@@ -79,9 +79,9 @@ class TestAgentRegistry:
         registry = AgentRegistry()
         registry.load_defaults()
         assert len(registry) == 3
-        assert "anime_expert" in registry
-        assert "game_analyst" in registry
-        assert "market_researcher" in registry
+        assert "research_assistant" in registry
+        assert "data_analyst" in registry
+        assert "web_researcher" in registry
 
     def test_len_and_contains(self):
         registry = AgentRegistry()

--- a/tests/test_e2e_live_llm.py
+++ b/tests/test_e2e_live_llm.py
@@ -472,7 +472,7 @@ class TestSubAgentLive:
         assert len(received_ctx) == 1
         ctx = received_ctx[0]
         assert ctx is not None, "E5: agent_context=None (registry not wired)"
-        assert ctx["agent_name"] == "game_analyst"
+        assert ctx["agent_name"] == "data_analyst"
         assert "system_prompt" in ctx
         assert len(ctx["tools"]) > 0
 

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -235,11 +235,11 @@ class TestContextBudget:
         """Summary should respect tier budgets instead of hard-cutting."""
         ctx: dict[str, Any] = {
             "_soul_loaded": True,
-            "_soul": "# Mission\nDiscover undervalued IPs through data-driven analysis",
+            "_soul": "# Mission\nAutonomous research, analysis, and task execution",
             "_org_loaded": True,
-            "organization_strategy": "Data-driven IP acquisition for game publishing portfolio",
+            "organization_strategy": "Data-driven autonomous execution with domain plugins",
             "_project_loaded": True,
-            "project_goal": "Build automated pipeline for IP evaluation and scoring",
+            "project_goal": "Build automated pipeline for analysis and scoring",
             "_session_loaded": True,
             "previous_results": ["Berserk: S/81.3", "Cowboy Bebop: A/68.4"],
         }


### PR DESCRIPTION
## 요약
GEODE의 코어 자아를 "게임 IP 발굴 에이전트"에서 "범용 자율 실행 에이전트"로 전환. 게임 IP 분석은 DomainPort 플러그인 레벨로 격하. Karpathy "dumb platform, smart plugins" 패턴 적용.

## 변경 사항

### 핵심 변경 (프롬프트/Identity)
- `.claude/SOUL.md`: 전면 재작성 — "Game Entity Opportunity & Discovery Engine" → "범용 자율 실행 에이전트". Pipeline Contract → Execution Pipeline 일반화. 14-axis 루브릭 → 도메인 플러그인 제공으로 전환. Domain Plugins 섹션 추가 (game_ip = 하나의 available 플러그인)
  - Karpathy P4 "program.md = single identity source" 적용
- `core/llm/prompts/router.md` (AGENTIC_SUFFIX만): 예시를 IP 전용 → 범용 혼합으로 변경 ("오늘 뉴스 요약해줘", "이 URL 분석해줘", "Berserk 분석해줘"). Clarification 시나리오에 범용 슬롯 추가
- `core/llm/prompts/commentary.md`: "IP discovery assistant for game publishing" → "autonomous analysis assistant"
- `core/cli/__init__.py:321-332`: "GEODE IP valuation expert" → "GEODE analysis expert". 도메인 특화 용어(PSM, investment) 제거

### 핵심 변경 (코드)
- `core/extensibility/agents.py`: 기본 서브에이전트 anime_expert/game_analyst/market_researcher → research_assistant/data_analyst/web_researcher
  - OpenClaw Plugin Architecture "dumb platform" 패턴 적용
- `core/cli/sub_agent.py`: _TYPE_AGENT_MAP 에이전트명 동기화
- `core/llm/prompts/__init__.py`: 프롬프트 해시 핀 업데이트 (AGENTIC_SUFFIX, COMMENTARY_SYSTEM)

### 문서 변경
- `README.md` CLI Mode: 플래그 전용 → 자연어 예시 혼합 ("Berserk 분석해줘", "AI 뉴스 정리해줘")

### 테스트 동기화
- `tests/test_agents_ext.py`: 기본 에이전트 이름 assert 업데이트
- `tests/test_e2e_live_llm.py`: game_analyst → data_analyst
- `tests/test_karpathy_prompt_hardening.py`: 테스트 fixture 내 조직 전략 텍스트 업데이트

## 영향 범위
- **영향받는 모듈**: SOUL.md, 프롬프트 4개, agents.py, sub_agent.py, CLI 리포트 생성
- **하위 호환성**: 유지 — 파이프라인 프롬프트 (analyst/evaluator/synthesizer/biasbuster/cross_llm)는 변경 없음. DomainPort 인터페이스 불변
- **유지된 파이프라인 프롬프트**: analyst.md, evaluator.md, synthesizer.md, biasbuster.md, cross_llm.md — 파이프라인 내부에서만 호출되므로 도메인 플러그인 범위에 해당

## 설계 판단
- **왜 파이프라인 프롬프트는 유지?**: analyst.md 등은 GameIPDomain 플러그인이 로드될 때만 호출됨. 이미 올바른 스코프에 있음
- **왜 SOUL.md에서 넥슨/Navigator 제거?**: 라이프스타일 에이전트 방향 전환 — 조직 종속성 제거
- **Karpathy 패턴 적용**: P4 program.md ratchet (SOUL = single identity), P6 context budget (범용 요청 시 게임 IP 컨텍스트 소비 방지)

## Docs-Sync (필수)
- [x] `CHANGELOG.md` — 행동 변경에 해당하므로 [Unreleased] Changed 추가 필요 (merge 후)
- [x] `README.md` — CLI Mode 자연어 예시 추가 완료
- [x] `.claude/SOUL.md` — 이번 PR에서 직접 변경

## 테스트
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors (pre-commit 통과)
- [x] `uv run pytest tests/ -q` — 전체 pass
- [x] pre-commit hooks 전체 통과
- [x] 프롬프트 해시 핀 업데이트 완료 (drift 테스트 pass)

## 검증 체크리스트
- [x] `grep -r "IP valuation expert\|IP discovery assistant\|game publishing\|Game Entity" core/ .claude/SOUL.md` — 0 hits
- [x] `grep -r "anime_expert\|game_analyst\|market_researcher" core/ tests/` — 0 hits (docs 제외)
- [x] 파이프라인 프롬프트 (analyst/evaluator/synthesizer) — 변경 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)