### PR TITLE
feat: 도구 카테고리 및 비용 태깅 메타데이터 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- 도구 카테고리/비용 태깅 — `definitions.json` 전 38개 도구에 `category`(8종)와 `cost_tier`(3종) 메타데이터 추가, `ToolRegistry.get_tools_by_category()`/`get_tools_by_cost_tier()` 필터링 메서드
+
 ---
 
 ## [0.12.0] — 2026-03-15

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -8,6 +8,22 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
+# Valid values for tool metadata fields.
+VALID_CATEGORIES = frozenset(
+    {
+        "discovery",
+        "analysis",
+        "memory",
+        "planning",
+        "external",
+        "model",
+        "data",
+        "scheduling",
+    }
+)
+
+VALID_COST_TIERS = frozenset({"free", "cheap", "expensive"})
+
 
 @runtime_checkable
 class Tool(Protocol):
@@ -15,6 +31,10 @@ class Tool(Protocol):
 
     Any class implementing these 4 attributes/methods is a valid Tool.
     Uses @runtime_checkable for isinstance() checks.
+
+    Optional metadata:
+        category  — functional group (discovery, analysis, memory, ...).
+        cost_tier — resource cost indicator (free, cheap, expensive).
     """
 
     @property

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -2,6 +2,8 @@
   {
     "name": "list_ips",
     "description": "사용 가능한 IP 목록을 표시합니다. 사용자가 어떤 IP가 있는지 물어볼 때 사용하세요. Examples: 'IP 목록', '리스트 보여줘', '뭐가 있어?', 'show all', 'list available IPs'",
+    "category": "discovery",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {},
@@ -11,6 +13,8 @@
   {
     "name": "analyze_ip",
     "description": "특정 IP를 분석합니다. 사용자가 IP 이름을 말하거나 분석을 요청할 때 사용하세요. IP 이름만 단독으로 입력한 경우에도 이 도구를 사용하세요. 사용자가 'dry-run', '드라이런', 'LLM 없이', 'fixture로만' 등을 명시하면 반드시 dry_run=true로 설정하세요. Examples: 'Berserk 분석해', 'analyze Cowboy Bebop', 'Berserk', 'Berserk dry-run으로 분석해'",
+    "category": "analysis",
+    "cost_tier": "expensive",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -31,6 +35,8 @@
   {
     "name": "search_ips",
     "description": "키워드나 장르로 IP를 검색합니다. 사용자가 특정 장르나 키워드로 IP를 찾을 때 사용하세요. Examples: '다크 판타지 게임 찾아줘', 'search soulslike', 'SF 장르 있어?', 'find cyberpunk games'",
+    "category": "discovery",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -47,6 +53,8 @@
   {
     "name": "compare_ips",
     "description": "두 IP를 비교 분석합니다. 사용자가 두 IP를 비교하고 싶을 때 사용하세요. 사용자가 'dry-run', '드라이런', 'LLM 없이' 등을 명시하면 dry_run=true. Examples: 'Berserk vs Cowboy Bebop', '버서크랑 공각기동대 비교해줘', 'dry-run으로 비교해'",
+    "category": "analysis",
+    "cost_tier": "expensive",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -72,6 +80,8 @@
   {
     "name": "show_help",
     "description": "슬래시 명령어 목록을 표시합니다. 사용자가 명령어 목록이나 도움말 메뉴를 명시적으로 요청할 때만 사용하세요. 일반적인 질문(분석 방식, 역할, 의견 등)에는 이 도구를 사용하지 마세요 — 그런 경우 텍스트로 직접 응답하세요. Examples: '도움말', 'help', '명령어 목록', 'show commands'",
+    "category": "discovery",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {},
@@ -81,6 +91,8 @@
   {
     "name": "generate_report",
     "description": "IP 분석 결과를 리포트로 생성합니다. 사용자가 리포트, 보고서, report 생성을 요청할 때 사용하세요. 사용자가 'dry-run', '드라이런', 'LLM 없이' 등을 명시하면 dry_run=true. Examples: 'Berserk 리포트 생성해', 'generate a report for Cowboy Bebop', '보고서 만들어줘', 'dry-run 리포트 생성'",
+    "category": "analysis",
+    "cost_tier": "expensive",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -101,6 +113,8 @@
   {
     "name": "batch_analyze",
     "description": "여러 IP를 동시에 배치 분석합니다. 사용자가 전체/다수 IP를 한번에 분석하거나 순위를 보고 싶을 때 사용하세요. 사용자가 'dry-run', '드라이런', 'LLM 없이' 등을 명시하면 dry_run=true. Examples: '전체 IP 분석해줘', '배치 돌려', 'batch analyze all', '모든 IP 점수 보여줘', '상위 5개 분석해', 'top 10 dry-run'",
+    "category": "analysis",
+    "cost_tier": "expensive",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -127,6 +141,8 @@
   {
     "name": "check_status",
     "description": "GEODE 시스템 상태를 확인합니다. 사용자가 시스템 상태, 건강 체크, 모델 정보, 설정을 물어볼 때 사용하세요. Examples: '시스템 상태', 'health check', '지금 모델 뭐야?', '상태 확인', 'status', '설정 보여줘', 'what model are you using?'",
+    "category": "discovery",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {},
@@ -136,6 +152,8 @@
   {
     "name": "switch_model",
     "description": "LLM 모델이나 앙상블 모드를 변경합니다. 사용자가 모델 변경, 앙상블 모드 전환을 요청할 때 사용하세요. Examples: '모델 바꿔', 'switch to GPT', '앙상블 모드로', 'cross 모드 켜줘', 'change model', 'use Haiku'",
+    "category": "model",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -150,6 +168,8 @@
   {
     "name": "memory_search",
     "description": "메모리에서 과거 분석 결과, 인사이트, 규칙을 검색합니다. 사용자가 이전 분석 기록이나 학습된 패턴을 물어볼 때 사용하세요. Examples: '지난번 Berserk 결과 알려줘', '다크판타지 관련 규칙 있어?', '이전에 분석한 거 뭐 있어?', 'what did we learn about anime IPs?'",
+    "category": "memory",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -176,6 +196,8 @@
   {
     "name": "memory_save",
     "description": "메모리에 정보를 저장합니다. 사용자가 '이거 기억해', '저장해둬' 같은 요청을 할 때 사용하세요. Examples: '이 결과 기억해', 'remember this', '다음에 참고할 수 있게 저장해줘'",
+    "category": "memory",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -197,6 +219,8 @@
   {
     "name": "manage_rule",
     "description": "분석 규칙을 생성, 수정, 삭제, 조회합니다. 사용자가 분석 규칙을 관리하거나, 패턴을 학습시키려 할 때 사용하세요. Examples: '애니메이션 IP 규칙 만들어', '규칙 목록 보여줘', 'anime 규칙 수정해', 'create a rule for dark fantasy IPs', 'delete the old rule', '규칙 삭제해'",
+    "category": "memory",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -234,6 +258,8 @@
   {
     "name": "set_api_key",
     "description": "API 키를 설정합니다. 사용자가 API 키 설정, 변경을 요청할 때 사용하세요. Examples: 'API 키 설정해', 'set my API key', '키 바꿔줘', '인증 키 입력'",
+    "category": "model",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -248,6 +274,8 @@
   {
     "name": "manage_auth",
     "description": "인증 프로필을 관리합니다. 사용자가 인증, 프로필, 자격증명을 관리하려 할 때 사용하세요. Examples: '인증 프로필 보여줘', 'show auth profiles', '인증 추가해', 'manage credentials'",
+    "category": "model",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -262,6 +290,8 @@
   {
     "name": "generate_data",
     "description": "테스트/데모용 합성 IP 데이터를 생성합니다. 사용자가 테스트 데이터, 샘플 데이터, 데모 데이터 생성을 요청할 때 사용하세요. Examples: '테스트 데이터 생성해', 'generate sample data', '데모 데이터 만들어줘', '합성 IP 생성'",
+    "category": "data",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -280,6 +310,8 @@
   {
     "name": "schedule_job",
     "description": "배치 분석 스케줄을 관리합니다. 자연어로 스케줄 생성/삭제/상태조회가 가능합니다. Examples: '5분마다 분석 스케줄 만들어', 'every 10 minutes 스케줄 생성', '스케줄 목록', '예약 작업 삭제해줘', 'schedule status'",
+    "category": "scheduling",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -303,6 +335,8 @@
   {
     "name": "trigger_event",
     "description": "이벤트 또는 크론 트리거를 관리하거나 수동 실행합니다. 사용자가 트리거, 이벤트 발생, 수동 실행을 요청할 때 사용하세요. Examples: 'drift scan 트리거해', 'fire an event', '트리거 목록 보여줘', '수동으로 이벤트 발생'",
+    "category": "scheduling",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -321,6 +355,8 @@
   {
     "name": "run_bash",
     "description": "Execute a shell command on the user's local machine. REQUIRES user approval before execution. Use for: file operations, system checks, data processing. DO NOT use for: destructive operations, privilege escalation.",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -342,6 +378,8 @@
   {
     "name": "delegate_task",
     "description": "서브에이전트에게 작업을 위임하여 병렬로 실행합니다. 사용자가 여러 IP를 동시에 분석하거나, 병렬 작업을 요청할 때 사용하세요. Examples: '3개 IP 동시 분석해', 'Berserk, Cowboy Bebop 병렬로 분석', 'parallel analysis', '서브에이전트 돌려'",
+    "category": "planning",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -382,6 +420,8 @@
   {
     "name": "create_plan",
     "description": "분석 실행 계획을 생성합니다. 사용자가 계획을 세우거나 사전 검토를 요청할 때 사용하세요. Examples: '계획 세워줘', 'plan this', 'Berserk 분석 계획', '먼저 계획부터', 'plan before executing', '어떤 순서로 분석할지 보여줘'",
+    "category": "planning",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -406,6 +446,8 @@
   {
     "name": "approve_plan",
     "description": "생성된 분석 계획을 승인하고 실행합니다. create_plan으로 계획을 먼저 생성한 후 사용하세요. Examples: '승인', 'approve', '계획 실행해', 'go ahead', '진행해'",
+    "category": "planning",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -422,6 +464,8 @@
   {
     "name": "youtube_search",
     "description": "YouTube에서 IP 관련 영상과 참여 지표를 검색합니다. IP의 YouTube 인기도를 확인할 때 사용하세요. Examples: 'Berserk YouTube 인기도', 'YouTube views for Cowboy Bebop'",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -442,6 +486,8 @@
   {
     "name": "reddit_sentiment",
     "description": "Reddit에서 IP 관련 커뮤니티 감성을 분석합니다. IP의 Reddit 커뮤니티 반응을 확인할 때 사용하세요. Examples: 'Berserk Reddit 반응', 'Reddit sentiment for Ghost in the Shell'",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -462,6 +508,8 @@
   {
     "name": "steam_info",
     "description": "Steam 상점에서 IP 관련 게임 정보와 리뷰를 조회합니다. IP의 Steam 데이터를 확인할 때 사용하세요. Examples: 'Berserk Steam 정보', 'Steam reviews for Hollow Knight'",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -478,6 +526,8 @@
   {
     "name": "google_trends",
     "description": "Google Trends에서 IP의 검색 관심도를 조회합니다. IP의 트렌드를 확인할 때 사용하세요. Examples: 'Berserk Google 트렌드', 'Google Trends for Cowboy Bebop'",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -498,6 +548,8 @@
   {
     "name": "web_fetch",
     "description": "URL에서 텍스트 콘텐츠를 가져옵니다. 사용자가 URL을 제공하거나 웹 페이지 내용을 요청할 때 사용하세요. Examples: 'https://example.com 내용 알려줘', 'fetch this URL', '이 링크 읽어봐'",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -518,6 +570,8 @@
   {
     "name": "general_web_search",
     "description": "웹에서 최신 정보를 검색합니다. 사용자가 현재 정보, 뉴스, 트렌드를 물어볼 때 사용하세요. Examples: '오늘 날씨', 'latest news about...', '최신 정보 찾아줘'",
+    "category": "external",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -538,6 +592,8 @@
   {
     "name": "read_document",
     "description": "로컬 파일을 읽습니다 (markdown, text, JSON). 사용자가 파일 내용을 보고 싶을 때 사용하세요. Examples: '이 파일 읽어줘', 'read this file', '문서 내용 보여줘'",
+    "category": "discovery",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -558,6 +614,8 @@
   {
     "name": "note_save",
     "description": "사용자 메모를 영구 저장합니다. 사용자가 '기억해', '저장해', 'remember this' 등을 요청할 때 사용하세요. Examples: '이거 기억해: 다음 미팅은 금요일', 'remember my preference', '메모 저장해'",
+    "category": "memory",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -579,6 +637,8 @@
   {
     "name": "note_read",
     "description": "저장된 메모를 읽습니다. 사용자가 이전에 저장한 정보를 물어볼 때 사용하세요. Examples: '이전에 저장한 거 뭐 있어?', 'what did I save?', '메모 보여줘'",
+    "category": "memory",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -593,6 +653,8 @@
   {
     "name": "reject_plan",
     "description": "생성된 분석 계획을 거부합니다. 계획이 마음에 들지 않을 때 사용하세요. Examples: '계획 거부', 'reject plan', '이 계획 안 할래'",
+    "category": "planning",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -611,6 +673,8 @@
   {
     "name": "modify_plan",
     "description": "생성된 분석 계획을 수정합니다. 템플릿 변경, 단계 제거 가능. Examples: '계획 수정해', 'modify plan', '이 단계 빼줘'",
+    "category": "planning",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -640,6 +704,8 @@
   {
     "name": "list_plans",
     "description": "생성된 분석 계획 목록을 조회합니다. Examples: '계획 목록', 'list plans', '어떤 계획들이 있어?'",
+    "category": "planning",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {},
@@ -649,6 +715,8 @@
   {
     "name": "rate_result",
     "description": "분석 결과에 대해 평점을 매깁니다. 사용자 피드백 수집용. Examples: '이 결과 4점', 'rate 5 stars', '평가해줄게'",
+    "category": "analysis",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -674,6 +742,8 @@
   {
     "name": "accept_result",
     "description": "분석 결과를 수락합니다. Examples: '결과 수락', 'accept', '이 결과 괜찮아'",
+    "category": "analysis",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -690,6 +760,8 @@
   {
     "name": "reject_result",
     "description": "분석 결과를 거부합니다. 재분석이 필요할 때. Examples: '결과 거부', 'reject result', '이건 다시 해줘'",
+    "category": "analysis",
+    "cost_tier": "free",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -710,6 +782,8 @@
   {
     "name": "rerun_node",
     "description": "파이프라인의 특정 노드를 재실행합니다. scoring, verification, synthesizer만 가능. Examples: '스코어링 다시 해', 'rerun scoring', '검증 재실행'",
+    "category": "analysis",
+    "cost_tier": "expensive",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -736,6 +810,8 @@
   {
     "name": "install_mcp_server",
     "description": "MCP 서버를 검색하고 설치합니다. 외부 도구/서비스 연결 요청 시 사용. Examples: 'LinkedIn MCP 달아줘', 'Steam MCP 설치해', 'web search 추가해', 'Reddit MCP 연결해'",
+    "category": "model",
+    "cost_tier": "cheap",
     "input_schema": {
       "type": "object",
       "properties": {

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -267,6 +267,36 @@ class ToolRegistry:
             raise PermissionError(f"Tool '{name}' blocked by policy in mode '{mode}'")
         return tool.execute(**kwargs)
 
+    # ------------------------------------------------------------------
+    # Category / cost-tier filtering
+    # ------------------------------------------------------------------
+
+    def get_tools_by_category(self, category: str) -> list[Tool]:
+        """Return tools that belong to *category*.
+
+        The category is read from the ``category`` attribute on each tool.
+        Tools without a ``category`` attribute are silently skipped.
+        """
+        result: list[Tool] = []
+        for tool in self._tools.values():
+            tool_category = getattr(tool, "category", None)
+            if tool_category == category:
+                result.append(tool)
+        return result
+
+    def get_tools_by_cost_tier(self, tier: str) -> list[Tool]:
+        """Return tools that belong to *tier* (free / cheap / expensive).
+
+        The tier is read from the ``cost_tier`` attribute on each tool.
+        Tools without a ``cost_tier`` attribute are silently skipped.
+        """
+        result: list[Tool] = []
+        for tool in self._tools.values():
+            tool_tier = getattr(tool, "cost_tier", None)
+            if tool_tier == tier:
+                result.append(tool)
+        return result
+
     def __len__(self) -> int:
         return len(self._tools)
 

--- a/tests/test_tool_category_tagging.py
+++ b/tests/test_tool_category_tagging.py
@@ -1,0 +1,305 @@
+"""Tests for tool category and cost_tier metadata (1-A).
+
+Validates that:
+- All tools in definitions.json have category and cost_tier fields
+- category and cost_tier values are from the allowed set
+- ToolRegistry.get_tools_by_category() returns correct tools
+- ToolRegistry.get_tools_by_cost_tier() returns correct tools
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from core.tools.base import VALID_CATEGORIES, VALID_COST_TIERS, Tool
+from core.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Fixture: definitions.json path
+# ---------------------------------------------------------------------------
+
+_DEFINITIONS_PATH = Path(__file__).resolve().parent.parent / "core" / "tools" / "definitions.json"
+
+
+def _load_definitions() -> list[dict[str, Any]]:
+    with open(_DEFINITIONS_PATH) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Helper tools for registry tests
+# ---------------------------------------------------------------------------
+
+
+class _TaggedTool:
+    """Minimal Tool with category and cost_tier."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        category: str = "discovery",
+        cost_tier: str = "free",
+    ) -> None:
+        self._name = name
+        self.category = category
+        self.cost_tier = cost_tier
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Tagged tool {self._name}"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    def execute(self, **kwargs: Any) -> dict[str, Any]:
+        return {"result": "ok"}
+
+
+class _UntaggedTool:
+    """Minimal Tool WITHOUT category / cost_tier."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Untagged tool {self._name}"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    def execute(self, **kwargs: Any) -> dict[str, Any]:
+        return {"result": "ok"}
+
+
+# ===================================================================
+# definitions.json validation
+# ===================================================================
+
+
+class TestDefinitionsJsonMetadata:
+    """Every entry in definitions.json must have category + cost_tier."""
+
+    def test_all_tools_have_category(self) -> None:
+        for tool in _load_definitions():
+            assert "category" in tool, f"Tool '{tool['name']}' missing 'category' field"
+
+    def test_all_tools_have_cost_tier(self) -> None:
+        for tool in _load_definitions():
+            assert "cost_tier" in tool, f"Tool '{tool['name']}' missing 'cost_tier' field"
+
+    def test_categories_are_valid(self) -> None:
+        for tool in _load_definitions():
+            assert tool["category"] in VALID_CATEGORIES, (
+                f"Tool '{tool['name']}' has invalid category '{tool['category']}'"
+            )
+
+    def test_cost_tiers_are_valid(self) -> None:
+        for tool in _load_definitions():
+            assert tool["cost_tier"] in VALID_COST_TIERS, (
+                f"Tool '{tool['name']}' has invalid cost_tier '{tool['cost_tier']}'"
+            )
+
+    def test_every_category_has_at_least_one_tool(self) -> None:
+        used = {t["category"] for t in _load_definitions()}
+        assert used == VALID_CATEGORIES
+
+    def test_every_cost_tier_has_at_least_one_tool(self) -> None:
+        used = {t["cost_tier"] for t in _load_definitions()}
+        assert used == VALID_COST_TIERS
+
+
+# ===================================================================
+# Specific category membership (from task spec)
+# ===================================================================
+
+
+class TestCategoryMembership:
+    """Verify the category mapping matches the task specification."""
+
+    def _category_map(self) -> dict[str, str]:
+        return {t["name"]: t["category"] for t in _load_definitions()}
+
+    def test_discovery_tools(self) -> None:
+        m = self._category_map()
+        for name in ("list_ips", "search_ips", "check_status", "show_help"):
+            assert m.get(name) == "discovery", f"{name} should be discovery"
+
+    def test_analysis_tools(self) -> None:
+        m = self._category_map()
+        for name in ("analyze_ip", "compare_ips", "batch_analyze", "generate_report"):
+            assert m.get(name) == "analysis", f"{name} should be analysis"
+
+    def test_memory_tools(self) -> None:
+        m = self._category_map()
+        for name in ("memory_search", "memory_save", "note_read", "note_save", "manage_rule"):
+            assert m.get(name) == "memory", f"{name} should be memory"
+
+    def test_planning_tools(self) -> None:
+        m = self._category_map()
+        for name in ("create_plan", "approve_plan", "delegate_task"):
+            assert m.get(name) == "planning", f"{name} should be planning"
+
+    def test_external_tools(self) -> None:
+        m = self._category_map()
+        for name in ("web_fetch", "general_web_search"):
+            assert m.get(name) == "external", f"{name} should be external"
+
+    def test_model_tools(self) -> None:
+        m = self._category_map()
+        for name in ("switch_model", "set_api_key", "manage_auth"):
+            assert m.get(name) == "model", f"{name} should be model"
+
+    def test_data_tools(self) -> None:
+        m = self._category_map()
+        assert m.get("generate_data") == "data"
+
+    def test_scheduling_tools(self) -> None:
+        m = self._category_map()
+        for name in ("schedule_job", "trigger_event"):
+            assert m.get(name) == "scheduling", f"{name} should be scheduling"
+
+
+class TestCostTierMembership:
+    """Verify the cost_tier mapping matches the task specification."""
+
+    def _tier_map(self) -> dict[str, str]:
+        return {t["name"]: t["cost_tier"] for t in _load_definitions()}
+
+    def test_free_tools(self) -> None:
+        m = self._tier_map()
+        for name in (
+            "list_ips",
+            "search_ips",
+            "check_status",
+            "show_help",
+            "memory_search",
+            "note_read",
+            "manage_rule",
+            "switch_model",
+        ):
+            assert m.get(name) == "free", f"{name} should be free"
+
+    def test_cheap_tools(self) -> None:
+        m = self._tier_map()
+        for name in (
+            "web_fetch",
+            "general_web_search",
+            "memory_save",
+            "note_save",
+            "set_api_key",
+            "manage_auth",
+            "create_plan",
+            "approve_plan",
+            "generate_data",
+            "schedule_job",
+            "trigger_event",
+            "delegate_task",
+        ):
+            assert m.get(name) == "cheap", f"{name} should be cheap"
+
+    def test_expensive_tools(self) -> None:
+        m = self._tier_map()
+        for name in ("analyze_ip", "compare_ips", "batch_analyze", "generate_report"):
+            assert m.get(name) == "expensive", f"{name} should be expensive"
+
+
+# ===================================================================
+# ToolRegistry.get_tools_by_category / get_tools_by_cost_tier
+# ===================================================================
+
+
+class TestRegistryGetByCategory:
+    """Test ToolRegistry.get_tools_by_category()."""
+
+    def _build_registry(self) -> ToolRegistry:
+        reg = ToolRegistry()
+        reg.register(_TaggedTool("a", category="discovery", cost_tier="free"))
+        reg.register(_TaggedTool("b", category="discovery", cost_tier="cheap"))
+        reg.register(_TaggedTool("c", category="analysis", cost_tier="expensive"))
+        reg.register(_UntaggedTool("d"))
+        return reg
+
+    def test_returns_matching_category(self) -> None:
+        reg = self._build_registry()
+        result = reg.get_tools_by_category("discovery")
+        names = {t.name for t in result}
+        assert names == {"a", "b"}
+
+    def test_returns_empty_for_unknown_category(self) -> None:
+        reg = self._build_registry()
+        assert reg.get_tools_by_category("nonexistent") == []
+
+    def test_skips_untagged_tools(self) -> None:
+        reg = self._build_registry()
+        # "d" has no category — should not appear in any result
+        all_returned = set()
+        for cat in VALID_CATEGORIES:
+            all_returned.update(t.name for t in reg.get_tools_by_category(cat))
+        assert "d" not in all_returned
+
+    def test_single_match(self) -> None:
+        reg = self._build_registry()
+        result = reg.get_tools_by_category("analysis")
+        assert len(result) == 1
+        assert result[0].name == "c"
+
+
+class TestRegistryGetByCostTier:
+    """Test ToolRegistry.get_tools_by_cost_tier()."""
+
+    def _build_registry(self) -> ToolRegistry:
+        reg = ToolRegistry()
+        reg.register(_TaggedTool("x", category="discovery", cost_tier="free"))
+        reg.register(_TaggedTool("y", category="analysis", cost_tier="expensive"))
+        reg.register(_TaggedTool("z", category="external", cost_tier="cheap"))
+        reg.register(_UntaggedTool("w"))
+        return reg
+
+    def test_returns_matching_tier(self) -> None:
+        reg = self._build_registry()
+        result = reg.get_tools_by_cost_tier("free")
+        names = {t.name for t in result}
+        assert names == {"x"}
+
+    def test_expensive_tier(self) -> None:
+        reg = self._build_registry()
+        result = reg.get_tools_by_cost_tier("expensive")
+        assert len(result) == 1
+        assert result[0].name == "y"
+
+    def test_returns_empty_for_unknown_tier(self) -> None:
+        reg = self._build_registry()
+        assert reg.get_tools_by_cost_tier("nonexistent") == []
+
+    def test_skips_untagged_tools(self) -> None:
+        reg = self._build_registry()
+        all_returned = set()
+        for tier in VALID_COST_TIERS:
+            all_returned.update(t.name for t in reg.get_tools_by_cost_tier(tier))
+        assert "w" not in all_returned
+
+
+class TestTaggedToolSatisfiesProtocol:
+    """Tagged tools still satisfy the Tool protocol."""
+
+    def test_tagged_tool_is_tool(self) -> None:
+        tool = _TaggedTool("t", category="analysis", cost_tier="expensive")
+        assert isinstance(tool, Tool)
+
+    def test_untagged_tool_is_tool(self) -> None:
+        tool = _UntaggedTool("u")
+        assert isinstance(tool, Tool)


### PR DESCRIPTION
## 요약

- definitions.json 전 38개 도구에 `category`(8종)와 `cost_tier`(3종) 메타데이터 추가
- ToolRegistry에 카테고리/비용 기반 필터링 메서드 추가

## 변경 사항

### 핵심

| 파일 | 변경 | 이유 |
|------|------|------|
| `core/tools/definitions.json` | 38개 도구에 `category`, `cost_tier` 필드 추가 | 도구 선택 최적화 및 비용 인식 라우팅 기반 |
| `core/tools/registry.py` | `get_tools_by_category()`, `get_tools_by_cost_tier()` 추가 | 카테고리/비용별 필터링으로 컨텍스트 최적화 |
| `core/tools/base.py` | `VALID_CATEGORIES`(8종), `VALID_COST_TIERS`(3종) 상수 | 유효값 중앙 정의 |

### 부수

| 파일 | 변경 |
|------|------|
| `tests/test_tool_category_tagging.py` | **신규** 27개 테스트 |
| `CHANGELOG.md` | [Unreleased] Added 항목 |

## 테스트

```
ruff: All checks passed
mypy: 0 errors (132 files)
pytest: 2206 passed, 19 deselected
pre-commit: 12/12 passed
```

## 검증 체크리스트

- [x] 전 38개 도구에 category/cost_tier 존재
- [x] 값이 유효 집합에 포함
- [x] 레지스트리 필터링 정상 동작
- [x] 기존 Tool Protocol 호환 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)