### PR TITLE
fix: MCP 세션 승인 캐시 + 이중 로깅 + APITimeout 상세 메시지

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - LinkedIn MCP 어댑터 — `LinkedInPort` Protocol + `LinkedInMCPAdapter` 구현 (Port/Adapter 패턴, graceful degradation)
 - 도구 카테고리/비용 태깅 — `definitions.json` 전 38개 도구에 `category`(8종)와 `cost_tier`(3종) 메타데이터 추가, `ToolRegistry.get_tools_by_category()`/`get_tools_by_cost_tier()` 필터링 메서드
+- MCP 서버별 세션 승인 캐시 — 한 서버 최초 승인 후 동일 세션 내 재승인 생략 (`_mcp_approved_servers`)
+
+### Fixed
+- 연속 실패 도구 스킵 메시지 중복 출력 — `skipped` 결과 이중 로깅 방지
+- APITimeoutError 소진 시 에러 상세 정보 누락 — `_last_llm_error`로 에러 유형/재시도 횟수 표시
 
 ### Changed
 - NL Router 시스템 프롬프트 Tool Selection Priority Matrix 추가 — 12개 의도별 1st/2nd Choice + 사용 금지 도구 매트릭스, 비용 인식 규칙, 도구 호출 금지 사항 (AGENTIC_SUFFIX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- LinkedIn MCP 어댑터 — `LinkedInPort` Protocol + `LinkedInMCPAdapter` 구현 (Port/Adapter 패턴, graceful degradation)
 - 도구 카테고리/비용 태깅 — `definitions.json` 전 38개 도구에 `category`(8종)와 `cost_tier`(3종) 메타데이터 추가, `ToolRegistry.get_tools_by_category()`/`get_tools_by_cost_tier()` 필터링 메서드
 
 ### Changed
@@ -46,7 +47,6 @@ HITL 보안 강화 + README/CLAUDE.md 자율 실행 코어 재구성 + Domain Pl
 - LinkedIn 우선 라우팅 — 프로필/커리어/채용 쿼리 시 `site:linkedin.com` 프리픽스 우선 검색 (AGENTIC_SUFFIX)
 - `WRITE_TOOLS` 안전 분류 — `memory_save`/`note_save`/`set_api_key`/`manage_auth` 쓰기 작업 HITL 확인 게이트
 - MCP 도구 안전 라우팅 — 외부 MCP 도구 호출 시 `_execute_mcp()` 경유, 사용자 승인 게이트 적용
-- LinkedIn MCP 어댑터 — `LinkedInPort` Protocol + `LinkedInMCPAdapter` 구현 (Port/Adapter 패턴, graceful degradation)
 
 ### Fixed
 - DANGEROUS 도구(bash) `auto_approve` 우회 차단 — 서브에이전트에서도 항상 사용자 승인 필수

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 132
-- **Tests**: 2179+
+- **Tests**: 2180+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 132
-- **Tests**: 2180+
+- **Tests**: 2226+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ core/
 │   ├── ports/                  # LLMClientPort, SignalEnrichmentPort, DomainPort
 │   └── adapters/
 │       ├── llm/                # ClaudeAdapter, OpenAIAdapter
-│       └── mcp/                # Steam, Brave MCP adapters + catalog (29 entries)
+│       └── mcp/                # Steam, Brave, LinkedIn MCP adapters + catalog (29 entries)
 ├── llm/                        # LLM client (prompt caching, streaming)
 │   ├── client.py               # Anthropic wrapper + token tracking + cost
 │   ├── token_tracker.py        # TokenTracker singleton (model pricing)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ API 키 없이 시작하면 자동으로 dry-run 모드로 전환됩니다:
 | **Domain Plugin** | `DomainPort` Protocol — 도메인별 analysts/evaluators/scoring 플러그인 (게임 IP: `GameIPDomain`) |
 | **Observability** | LangSmith 토큰 추적 + 비용 계산, Claude Code 스타일 상태줄 |
 | **Scheduler** | 자연어 스케줄링 ("매일 오전 9시 분석해줘" → AT/EVERY/CRON) |
-| **2179+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
+| **2180+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
 
 ## Usage
 
@@ -416,11 +416,12 @@ graph TB
         MCPInstall["MCP Auto-Install<br/>(29 catalog)"]
     end
 
-    subgraph MCPAdapters["MCP Adapters (Client, 4 active)"]
+    subgraph MCPAdapters["MCP Adapters (Client, 5 active)"]
         Brave["Brave Search"]
         Steam["Steam MCP"]
         ArXiv["arXiv MCP"]
         PW["Playwright MCP"]
+        LI["LinkedIn Reader"]
     end
 
     subgraph MCPServer["MCP Server (FastMCP)"]
@@ -443,7 +444,7 @@ graph TB
     style MCPServer fill:#1e293b,stroke:#f59e0b,color:#e2e8f0
 ```
 
-**MCP Adapters (Client, 4 active)** — 외부 데이터 소스 연결:
+**MCP Adapters (Client, 5 active)** — 외부 데이터 소스 연결:
 
 | Adapter | 패키지 | 용도 |
 |---------|--------|------|
@@ -451,6 +452,7 @@ graph TB
 | **Steam** | `steam-mcp-server` | Steam API 게임 데이터 (가격, 리뷰, 태그, 동접) |
 | **arXiv** | `@fre4x/arxiv` | 학술 논문 검색/조회 (게임 연구 시그널) |
 | **Playwright** | `@playwright/mcp` | 브라우저 자동화 (웹 크롤링, 스크린샷) |
+| **LinkedIn Reader** | `linkedin-scraper-mcp` | LinkedIn 프로필/채용 정보 검색 (Patchright 브라우저, 인증 필요) |
 
 > `MCPServerManager`는 env var가 빈 문자열이면 연결 시도 없이 graceful skip.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ API 키 없이 시작하면 자동으로 dry-run 모드로 전환됩니다:
 | **Domain Plugin** | `DomainPort` Protocol — 도메인별 analysts/evaluators/scoring 플러그인 (게임 IP: `GameIPDomain`) |
 | **Observability** | LangSmith 토큰 추적 + 비용 계산, Claude Code 스타일 상태줄 |
 | **Scheduler** | 자연어 스케줄링 ("매일 오전 9시 분석해줘" → AT/EVERY/CRON) |
-| **2180+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
+| **2226+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
 
 ## Usage
 

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -163,6 +163,7 @@ class AgenticLoop:
         self._tools = get_agentic_tools(tool_registry, mcp_tools=mcp_tool_list)
         self._tool_log: list[dict[str, Any]] = []
         self._consecutive_failures: dict[str, int] = {}
+        self._last_llm_error: str | None = None  # last error type for user message
         self._client: anthropic.AsyncAnthropic | None = None
         self._op_logger = OperationLogger()
 
@@ -212,8 +213,13 @@ class AgenticLoop:
             if response is None:
                 # Persist intermediate tool-use messages so next turn sees them
                 self._sync_messages_to_context(messages)
+                detail = self._last_llm_error or "unknown error"
+                text = (
+                    f"LLM call failed ({detail}). "
+                    "Your conversation context is preserved — try again."
+                )
                 result = AgenticResult(
-                    text="LLM call failed. Try again or use /help.",
+                    text=text,
                     rounds=round_idx + 1,
                     error="llm_call_failed",
                     termination_reason="llm_error",
@@ -466,6 +472,7 @@ class AgenticLoop:
                     await asyncio.sleep(wait)
                 else:
                     log.error("%s exhausted after %d retries", exc_type, max_retries)
+                    self._last_llm_error = f"{exc_type} after {max_retries} retries"
                     return None
             except anthropic.RateLimitError:
                 wait = 2**attempt * 10  # 10s, 20s, 40s
@@ -479,9 +486,11 @@ class AgenticLoop:
                     await asyncio.sleep(wait)
                 else:
                     log.error("Rate limit exhausted after %d retries", max_retries)
+                    self._last_llm_error = f"RateLimitError after {max_retries} retries"
                     return None
             except anthropic.AuthenticationError:
                 log.warning("Anthropic API key is invalid in agentic loop")
+                self._last_llm_error = "AuthenticationError — API key invalid"
                 return None
             except anthropic.BadRequestError as exc:
                 msg = str(exc)
@@ -563,8 +572,8 @@ class AgenticLoop:
                         "max_clarifications_exceeded": True,
                     }
 
-            # Progressive log: show tool result summary
-            if isinstance(result, dict):
+            # Progressive log: show tool result summary (skip if already logged above)
+            if isinstance(result, dict) and not result.get("skipped"):
                 self._op_logger.log_tool_result(tool_name, result, visible=visible)
 
             self._tool_log.append(

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -87,6 +87,8 @@ class ToolExecutor:
         self._auto_approve = auto_approve  # for testing only
         self._sub_agent_manager = sub_agent_manager
         self._mcp_manager = mcp_manager
+        # Per-server MCP approval cache — approve once per server per session
+        self._mcp_approved_servers: set[str] = set()
 
     def register(self, tool_name: str, handler: Callable[..., dict[str, Any]]) -> None:
         """Register a tool handler."""
@@ -221,9 +223,12 @@ class ToolExecutor:
         """
         log.info("MCP tool: %s → %s (args=%s)", tool_name, server, list(tool_input.keys()))
 
-        # MCP tools are external — confirm if not auto-approved
-        if not self._auto_approve and not self._confirm_mcp(server, tool_name):
-            return {"error": "User denied MCP tool execution", "denied": True}
+        # MCP tools are external — confirm once per server per session.
+        # After first approval, subsequent calls to the same server auto-execute.
+        if not self._auto_approve and server not in self._mcp_approved_servers:
+            if not self._confirm_mcp(server, tool_name):
+                return {"error": "User denied MCP tool execution", "denied": True}
+            self._mcp_approved_servers.add(server)
 
         assert self._mcp_manager is not None  # guaranteed by caller
         result: dict[str, Any] = self._mcp_manager.call_tool(server, tool_name, tool_input)


### PR DESCRIPTION
## 요약

- AgenticLoop 운영 중 발견된 UX/안정성 이슈 3건 수정

## 변경 사항

### 핵심

- **MCP 서버별 세션 승인 캐시**: `_mcp_approved_servers: set[str]` 도입. 한 서버 최초 승인 후 동일 세션 내 재승인 생략. Playwright 브라우저 자동화 시 navigate/screenshot 매번 승인하던 피로 해소
  - **왜?** `browser_navigate` → `browser_take_screenshot` → `browser_navigate` 순차 호출에서 3번 연속 "Allow? [Y/n]" 프롬프트가 출현하여 자동화 워크플로우를 방해

- **연속 실패 스킵 메시지 이중 출력 수정**: `log_tool_result()` 호출이 스킵 경로(line 540)와 일반 경로(line 568)에서 2회 발생. `result.get("skipped")` 체크로 일반 경로에서 스킵 결과 재로깅 방지
  - **왜?** `web_fetch` 404 연속 실패 시 동일 에러 메시지가 2줄씩 출력되어 시각적 노이즈 발생

- **APITimeoutError 소진 시 상세 에러 메시지**: `_last_llm_error` 필드 추가. 재시도 소진 시 에러 유형(APITimeoutError/RateLimitError/AuthenticationError)과 재시도 횟수를 사용자에게 표시. "LLM call failed" → "LLM call failed (APITimeoutError after 3 retries). Your conversation context is preserved — try again."
  - **왜?** 기존 메시지가 너무 모호하여 원인 파악 불가. 컨텍스트 보존 여부도 안내 필요

## 테스트

- 전체 테스트 통과
- pre-commit hooks 통과


🤖 Generated with [Claude Code](https://claude.com/claude-code)