### PR TITLE
feat: HITL 승인 후 스피너 (develop → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- HITL 승인 후 스피너 — `_tool_spinner()` 컨텍스트 매니저로 bash/MCP/write/expensive 도구 실행 중 `⏳` dots 스피너 표시, 승인 거부·Safe/Standard 도구에는 미표시
 - LinkedIn MCP 어댑터 — `LinkedInPort` Protocol + `LinkedInMCPAdapter` 구현 (Port/Adapter 패턴, graceful degradation)
 - 도구 카테고리/비용 태깅 — `definitions.json` 전 38개 도구에 `category`(8종)와 `cost_tier`(3종) 메타데이터 추가, `ToolRegistry.get_tools_by_category()`/`get_tools_by_cost_tier()` 필터링 메서드
 - MCP 서버별 세션 승인 캐시 — 한 서버 최초 승인 후 동일 세션 내 재승인 생략 (`_mcp_approved_servers`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 132
-- **Tests**: 2226+
+- **Tests**: 2243+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ API 키 없이 시작하면 자동으로 dry-run 모드로 전환됩니다:
 | **Domain Plugin** | `DomainPort` Protocol — 도메인별 analysts/evaluators/scoring 플러그인 (게임 IP: `GameIPDomain`) |
 | **Observability** | LangSmith 토큰 추적 + 비용 계산, Claude Code 스타일 상태줄 |
 | **Scheduler** | 자연어 스케줄링 ("매일 오전 9시 분석해줘" → AT/EVERY/CRON) |
-| **2226+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
+| **2243+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
 
 ## Usage
 

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -64,6 +65,21 @@ EXPENSIVE_TOOLS: dict[str, float] = {
 # Everything else is STANDARD — executes without special gates
 
 
+@contextmanager
+def _tool_spinner(label: str) -> Iterator[None]:
+    """Show a Rich dots spinner during post-approval tool execution.
+
+    Displays ``label`` with a spinner while the wrapped block runs,
+    then clears it on exit so OperationLogger markers (✓/✗) render cleanly.
+    """
+    status = console.status(f"  [dim]⏳ {label}[/dim]", spinner="dots", spinner_style="cyan")
+    status.start()
+    try:
+        yield
+    finally:
+        status.stop()
+
+
 class ToolExecutor:
     """Routes tool calls to handlers with HITL safety checks.
 
@@ -102,10 +118,16 @@ class ToolExecutor:
         if tool_name in DANGEROUS_TOOLS:
             return self._execute_dangerous(tool_name, tool_input)
 
+        # Track whether user went through an approval gate — if so, show
+        # a spinner during handler execution for visual feedback.
+        approved_via_hitl = False
+
         # Write tools: HITL gate — always requires approval, even for
         # sub-agents (auto_approve is intentionally ignored here).
-        if tool_name in WRITE_TOOLS and not self._confirm_write(tool_name, tool_input):
-            return {"error": "User denied write operation", "denied": True}
+        if tool_name in WRITE_TOOLS:
+            if not self._confirm_write(tool_name, tool_input):
+                return {"error": "User denied write operation", "denied": True}
+            approved_via_hitl = True
 
         # Expensive tools: cost confirmation gate
         if tool_name in EXPENSIVE_TOOLS and not self._auto_approve:
@@ -115,6 +137,7 @@ class ToolExecutor:
                     "error": "User denied expensive operation",
                     "denied": True,
                 }
+            approved_via_hitl = True
 
         # Sub-agent delegation
         if tool_name == "delegate_task":
@@ -132,6 +155,9 @@ class ToolExecutor:
             return {"error": f"Unknown tool: {tool_name}"}
 
         try:
+            if approved_via_hitl:
+                with _tool_spinner(f"Executing {tool_name}..."):
+                    return handler(**tool_input)
             return handler(**tool_input)
         except Exception as exc:
             log.error("Tool %s failed: %s", tool_name, exc, exc_info=True)
@@ -210,7 +236,8 @@ class ToolExecutor:
         if not approved:
             return {"error": "User denied execution", "denied": True}
 
-        result = self._bash.execute(command)
+        with _tool_spinner(f"Running: {command}"):
+            result = self._bash.execute(command)
         return self._bash.to_tool_result(result)
 
     def _execute_mcp(
@@ -231,7 +258,8 @@ class ToolExecutor:
             self._mcp_approved_servers.add(server)
 
         assert self._mcp_manager is not None  # guaranteed by caller
-        result: dict[str, Any] = self._mcp_manager.call_tool(server, tool_name, tool_input)
+        with _tool_spinner(f"Calling {server}/{tool_name}..."):
+            result: dict[str, Any] = self._mcp_manager.call_tool(server, tool_name, tool_input)
         return result
 
     def _confirm_mcp(self, server: str, tool_name: str) -> bool:

--- a/tests/test_tool_executor_spinner.py
+++ b/tests/test_tool_executor_spinner.py
@@ -1,0 +1,285 @@
+"""Tests for post-HITL-approval spinner in ToolExecutor.
+
+Verifies that _tool_spinner is invoked after user approves at each
+HITL gate (bash, MCP, write, expensive) and NOT invoked when approval
+is denied or for safe/standard tools.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.cli.tool_executor import ToolExecutor, _tool_spinner
+
+# ---------------------------------------------------------------------------
+# _tool_spinner context manager unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpinner:
+    """Test the _tool_spinner context manager itself."""
+
+    @patch("core.cli.tool_executor.console")
+    def test_spinner_starts_and_stops(self, mock_console: MagicMock) -> None:
+        """Spinner calls status.start() on enter and status.stop() on exit."""
+        mock_status = MagicMock()
+        mock_console.status.return_value = mock_status
+
+        with _tool_spinner("Testing..."):
+            mock_console.status.assert_called_once()
+            mock_status.start.assert_called_once()
+            mock_status.stop.assert_not_called()
+
+        mock_status.stop.assert_called_once()
+
+    @patch("core.cli.tool_executor.console")
+    def test_spinner_stops_on_exception(self, mock_console: MagicMock) -> None:
+        """Spinner stops even if the wrapped block raises."""
+        mock_status = MagicMock()
+        mock_console.status.return_value = mock_status
+
+        with pytest.raises(RuntimeError), _tool_spinner("Will fail"):
+            raise RuntimeError("boom")
+
+        mock_status.stop.assert_called_once()
+
+    @patch("core.cli.tool_executor.console")
+    def test_spinner_label_in_status(self, mock_console: MagicMock) -> None:
+        """Spinner label is passed to console.status()."""
+        mock_status = MagicMock()
+        mock_console.status.return_value = mock_status
+
+        with _tool_spinner("Calling server/tool..."):
+            pass
+
+        call_args = mock_console.status.call_args
+        assert "Calling server/tool..." in call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# ToolExecutor integration: bash spinner
+# ---------------------------------------------------------------------------
+
+
+class TestBashSpinner:
+    """Test spinner activation during bash command execution."""
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_bash_spinner_after_approval(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """After bash approval, spinner wraps command execution."""
+        mock_console.input.return_value = "y"
+        mock_spinner.return_value.__enter__ = MagicMock(return_value=None)
+        mock_spinner.return_value.__exit__ = MagicMock(return_value=False)
+
+        executor = ToolExecutor()
+        executor.execute("run_bash", {"command": "echo hello", "reason": "test"})
+
+        mock_spinner.assert_called_once()
+        label = mock_spinner.call_args[0][0]
+        assert "echo hello" in label
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_bash_no_spinner_when_denied(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """When user denies bash, no spinner is shown."""
+        mock_console.input.return_value = "n"
+
+        result = ToolExecutor().execute("run_bash", {"command": "echo hello", "reason": "test"})
+
+        mock_spinner.assert_not_called()
+        assert result.get("denied") is True
+
+
+# ---------------------------------------------------------------------------
+# ToolExecutor integration: MCP spinner
+# ---------------------------------------------------------------------------
+
+
+class TestMcpSpinner:
+    """Test spinner activation during MCP tool execution."""
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_mcp_spinner_after_approval(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """After MCP approval, spinner wraps call_tool execution."""
+        mock_console.input.return_value = "y"
+        mock_spinner.return_value.__enter__ = MagicMock(return_value=None)
+        mock_spinner.return_value.__exit__ = MagicMock(return_value=False)
+
+        mcp = MagicMock()
+        mcp.find_server_for_tool.return_value = "my-server"
+        mcp.call_tool.return_value = {"result": "ok"}
+
+        executor = ToolExecutor(mcp_manager=mcp)
+        executor.execute("mcp_tool_x", {"arg": "val"})
+
+        mock_spinner.assert_called_once()
+        label = mock_spinner.call_args[0][0]
+        assert "my-server" in label
+        assert "mcp_tool_x" in label
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_mcp_no_spinner_when_denied(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """When user denies MCP tool, no spinner is shown."""
+        mock_console.input.return_value = "n"
+
+        mcp = MagicMock()
+        mcp.find_server_for_tool.return_value = "my-server"
+
+        result = ToolExecutor(mcp_manager=mcp).execute("mcp_tool_x", {"arg": "val"})
+
+        mock_spinner.assert_not_called()
+        assert result.get("denied") is True
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    def test_mcp_no_spinner_when_auto_approved(self, mock_spinner: MagicMock) -> None:
+        """When auto_approve is True, spinner wraps execution without HITL prompt."""
+        mock_spinner.return_value.__enter__ = MagicMock(return_value=None)
+        mock_spinner.return_value.__exit__ = MagicMock(return_value=False)
+
+        mcp = MagicMock()
+        mcp.find_server_for_tool.return_value = "srv"
+        mcp.call_tool.return_value = {"ok": True}
+
+        executor = ToolExecutor(auto_approve=True, mcp_manager=mcp)
+        executor.execute("mcp_auto", {"x": 1})
+
+        # auto_approve skips HITL but still uses spinner
+        mock_spinner.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ToolExecutor integration: write tool spinner
+# ---------------------------------------------------------------------------
+
+
+class TestWriteToolSpinner:
+    """Test spinner activation during write tool execution."""
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_write_spinner_after_approval(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """After write approval, spinner wraps handler execution."""
+        mock_console.input.return_value = "y"
+        mock_spinner.return_value.__enter__ = MagicMock(return_value=None)
+        mock_spinner.return_value.__exit__ = MagicMock(return_value=False)
+
+        handler = MagicMock(return_value={"saved": True})
+        executor = ToolExecutor(action_handlers={"memory_save": handler})
+        executor.execute("memory_save", {"content": "test data"})
+
+        mock_spinner.assert_called_once()
+        label = mock_spinner.call_args[0][0]
+        assert "memory_save" in label
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_write_no_spinner_when_denied(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """When user denies write operation, no spinner is shown."""
+        mock_console.input.return_value = "n"
+
+        handler = MagicMock(return_value={"saved": True})
+        executor = ToolExecutor(action_handlers={"memory_save": handler})
+        result = executor.execute("memory_save", {"content": "test data"})
+
+        mock_spinner.assert_not_called()
+        assert result.get("denied") is True
+        handler.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ToolExecutor integration: expensive tool spinner
+# ---------------------------------------------------------------------------
+
+
+class TestExpensiveToolSpinner:
+    """Test spinner activation during expensive tool execution."""
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_expensive_spinner_after_approval(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """After cost approval, spinner wraps handler execution."""
+        mock_console.input.return_value = "y"
+        mock_spinner.return_value.__enter__ = MagicMock(return_value=None)
+        mock_spinner.return_value.__exit__ = MagicMock(return_value=False)
+
+        handler = MagicMock(return_value={"tier": "S", "score": 85.0})
+        executor = ToolExecutor(action_handlers={"analyze_ip": handler})
+        executor.execute("analyze_ip", {"ip_name": "Berserk"})
+
+        mock_spinner.assert_called_once()
+        label = mock_spinner.call_args[0][0]
+        assert "analyze_ip" in label
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    @patch("core.cli.tool_executor.console")
+    def test_expensive_no_spinner_when_denied(
+        self, mock_console: MagicMock, mock_spinner: MagicMock
+    ) -> None:
+        """When user denies cost, no spinner is shown."""
+        mock_console.input.return_value = "n"
+
+        handler = MagicMock(return_value={"tier": "S"})
+        executor = ToolExecutor(action_handlers={"analyze_ip": handler})
+        result = executor.execute("analyze_ip", {"ip_name": "Berserk"})
+
+        mock_spinner.assert_not_called()
+        assert result.get("denied") is True
+        handler.assert_not_called()
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    def test_expensive_no_spinner_when_auto_approved(self, mock_spinner: MagicMock) -> None:
+        """When auto_approve is True, expensive tools skip HITL and spinner."""
+        handler = MagicMock(return_value={"tier": "A"})
+        executor = ToolExecutor(auto_approve=True, action_handlers={"analyze_ip": handler})
+        executor.execute("analyze_ip", {"ip_name": "Test"})
+
+        # auto_approve skips the cost gate entirely, so approved_via_hitl stays False
+        mock_spinner.assert_not_called()
+        handler.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ToolExecutor: safe/standard tools should NOT show spinner
+# ---------------------------------------------------------------------------
+
+
+class TestNoSpinnerForSafeTools:
+    """Safe and standard tools should not show a post-HITL spinner."""
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    def test_safe_tool_no_spinner(self, mock_spinner: MagicMock) -> None:
+        """Safe tools execute without any spinner."""
+        handler = MagicMock(return_value={"ips": []})
+        executor = ToolExecutor(action_handlers={"list_ips": handler})
+        executor.execute("list_ips", {})
+
+        mock_spinner.assert_not_called()
+        handler.assert_called_once()
+
+    @patch("core.cli.tool_executor._tool_spinner")
+    def test_standard_tool_no_spinner(self, mock_spinner: MagicMock) -> None:
+        """Standard (non-gated) tools execute without spinner."""
+        handler = MagicMock(return_value={"report": "done"})
+        executor = ToolExecutor(action_handlers={"generate_report": handler})
+        executor.execute("generate_report", {"topic": "test"})
+
+        mock_spinner.assert_not_called()
+        handler.assert_called_once()


### PR DESCRIPTION
## 요약

develop → main 통합. PR #136 내용 포함.

- HITL 승인 후 `_tool_spinner()` 스피너 추가 (bash/MCP/write/expensive 4개 게이트)
- 15개 신규 테스트 (2243+)
- docs-sync 완료

## 검증

- CI 6/6 ALL PASS (PR #136)