### PR TITLE
feat: 서브에이전트 결과 수집 as_completed 패턴 전환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- 서브에이전트 결과 수집 `as_completed` 패턴 — 순차 블로킹 → polling round-robin 전환. 먼저 끝난 태스크의 SUBAGENT_COMPLETED 훅이 즉시 발행
+
 ### Added
 - HITL 승인 후 스피너 — `_tool_spinner()` 컨텍스트 매니저로 bash/MCP/write/expensive 도구 실행 중 `⏳` dots 스피너 표시, 승인 거부·Safe/Standard 도구에는 미표시
 - LinkedIn MCP 어댑터 — `LinkedInPort` Protocol + `LinkedInMCPAdapter` 구현 (Port/Adapter 패턴, graceful degradation)

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -257,39 +257,52 @@ class SubAgentManager:
                 child_key,
             )
 
+        # Collect results as they arrive (not in submission order).
+        # This ensures SUBAGENT_COMPLETED hooks fire immediately when
+        # a task finishes, rather than waiting for earlier tasks.
         results: list[SubResult] = []
-        for task, sid in session_ids:
-            isolation = self._wait_for_result(sid)
-            sub_result = self._to_sub_result(task, isolation)
+        pending: dict[str, SubTask] = {sid: task for task, sid in session_ids}
+        deadline = time.time() + self._timeout_s
+        poll_interval = 0.05
+        max_poll = 0.5
+
+        while pending and time.time() < deadline:
+            completed_sids: list[str] = []
+            for sid in list(pending):
+                isolation = self._runner.get_result(sid)
+                if isolation is not None:
+                    completed_sids.append(sid)
+                    task = pending.pop(sid)
+                    sub_result = self._to_sub_result(task, isolation)
+                    results.append(sub_result)
+
+                    if sub_result.success:
+                        graph.mark_completed(task.task_id, result=sub_result.output)
+                        self._emit_hook(HookEvent.SUBAGENT_COMPLETED, task, sub_result=sub_result)
+                    else:
+                        graph.mark_failed(task.task_id, error=sub_result.error or "unknown")
+                        self._emit_hook(HookEvent.SUBAGENT_FAILED, task, error=sub_result.error)
+
+                    if on_progress is not None:
+                        try:
+                            on_progress(sub_result)
+                        except Exception:
+                            log.warning(
+                                "on_progress callback failed for %s",
+                                task.task_id,
+                                exc_info=True,
+                            )
+
+            if not completed_sids and pending:
+                time.sleep(min(poll_interval, max(0, deadline - time.time())))
+                poll_interval = min(poll_interval * 1.5, max_poll)
+
+        # Handle timed-out tasks
+        for _sid, task in pending.items():
+            sub_result = self._to_sub_result(task, None)
             results.append(sub_result)
-
-            if sub_result.success:
-                graph.mark_completed(task.task_id, result=sub_result.output)
-                self._emit_hook(
-                    HookEvent.SUBAGENT_COMPLETED,
-                    task,
-                    sub_result=sub_result,
-                )
-            else:
-                graph.mark_failed(
-                    task.task_id,
-                    error=sub_result.error or "unknown",
-                )
-                self._emit_hook(
-                    HookEvent.SUBAGENT_FAILED,
-                    task,
-                    error=sub_result.error,
-                )
-
-            if on_progress is not None:
-                try:
-                    on_progress(sub_result)
-                except Exception:
-                    log.warning(
-                        "on_progress callback failed for %s",
-                        task.task_id,
-                        exc_info=True,
-                    )
+            graph.mark_failed(task.task_id, error=f"Timeout after {self._timeout_s}s")
+            self._emit_hook(HookEvent.SUBAGENT_FAILED, task, error=sub_result.error)
 
         # Update run records with outcomes (G7 observability)
         now = time.time()


### PR DESCRIPTION
## 요약

- 서브에이전트 결과 수집을 순차 블로킹에서 polling round-robin으로 전환

## 변경 사항

- `delegate()` Phase 3 결과 수집: `for task: _wait_for_result(sid)` → `while pending: poll all sids`
- 먼저 끝난 태스크의 COMPLETED/FAILED 훅이 즉시 발행
- deadline 초과 pending 태스크 일괄 FAILED 처리

**왜?** task2가 5초에 끝나도 task1이 30초이면 task2 훅이 30초 후에야 발행되는 관측성 지연

## 테스트

- 전체 테스트 통과


🤖 Generated with [Claude Code](https://claude.com/claude-code)