### PR TITLE
docs: 5-feature 병합 후 docs-sync — 리포트 누락 복구 + 수치/구조 정합

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 133
-- **Tests**: 2258+
+- **Modules**: 134
+- **Tests**: 2366+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -39,7 +39,7 @@ uv run geode
 L0: CLI & AGENT      — Typer CLI, NL Router, AgenticLoop, SubAgentManager, Batch
 L1: INFRASTRUCTURE   — Ports (Protocol), ClaudeAdapter, OpenAIAdapter, MCP Adapters
 L2: MEMORY           — Organization > Project > Session (3-Tier + Hybrid L1/L2)
-L3: ORCHESTRATION    — HookSystem(27), TaskGraph DAG, PlanMode, CoalescingQueue, LaneQueue
+L3: ORCHESTRATION    — HookSystem(30), TaskGraph DAG, PlanMode, CoalescingQueue, LaneQueue
 L4: EXTENSIBILITY    — ToolRegistry(38+), PolicyChain, Skills, MCP Catalog(29), Reports
 L5: DOMAIN PLUGINS   — DomainPort Protocol, GameIPDomain, LangGraph StateGraph
 ```
@@ -140,6 +140,7 @@ core/
 │   ├── conversation.py  # Multi-turn sliding-window (max 20 turns)
 │   ├── batch.py         # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py      # Slash command dispatch (17 commands)
+│   ├── error_recovery.py # ErrorRecoveryStrategy (retry → alternative → fallback → escalate)
 │   └── search.py        # IP search engine (synonym expansion)
 ├── config.py            # Pydantic Settings (.env)
 ├── state.py             # GeodeState TypedDict + Pydantic models
@@ -169,7 +170,7 @@ core/
 │   ├── session_key.py   # Hierarchical key builder (ip:name:phase)
 │   └── context.py       # 3-tier context assembler
 ├── orchestration/
-│   ├── hooks.py         # HookSystem (27 events + SUBAGENT_* + async atrigger)
+│   ├── hooks.py         # HookSystem (30 events + async atrigger)
 │   ├── bootstrap.py     # Node bootstrap (pre-execution context injection)
 │   ├── goal_decomposer.py # GoalDecomposer (compound request → sub-goal DAG)
 │   ├── planner.py       # Planner (multi-step plan generation)
@@ -205,7 +206,7 @@ core/
 │   ├── ports/           # Protocol interfaces (LLM, Memory, Auth, Hook, Tool, DomainPort)
 │   └── adapters/
 │       ├── llm/         # ClaudeAdapter, OpenAIAdapter
-│       └── mcp/         # Steam, Brave, LinkedIn MCP adapters + catalog (29 entries)
+│       └── mcp/         # Steam, Brave, LinkedIn MCP adapters + CompositeSignalAdapter + catalog (29 entries)
 ├── tools/               # Tool Protocol + Registry + Policy + definitions.json
 ├── auth/                # API key rotation, cooldown, profiles
 ├── extensibility/       # Report generation + Skills + AgentRegistry (3 defaults)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ API 키 없이 시작하면 자동으로 dry-run 모드로 전환됩니다:
 | **Domain Plugin** | `DomainPort` Protocol — 도메인별 analysts/evaluators/scoring 플러그인 (게임 IP: `GameIPDomain`) |
 | **Observability** | LangSmith 토큰 추적 + 비용 계산, Claude Code 스타일 상태줄 |
 | **Scheduler** | 자연어 스케줄링 ("매일 오전 9시 분석해줘" → AT/EVERY/CRON) |
-| **2243+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
+| **2366+ Tests** | 134 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
 
 ## Usage
 
@@ -957,6 +957,7 @@ core/
 │   ├── batch.py                # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py             # Slash command dispatch (17 commands)
 │   ├── conversation.py         # Multi-turn sliding-window context
+│   ├── error_recovery.py       # ErrorRecoveryStrategy (retry → alternative → fallback → escalate)
 │   ├── nl_router.py            # Natural language intent classification
 │   ├── search.py               # IP search engine (synonym expansion)
 │   ├── startup.py              # Readiness check, Graceful Degradation
@@ -981,7 +982,7 @@ core/
 │   ├── ports/                  # LLMClientPort, SignalEnrichmentPort, DomainPort
 │   └── adapters/
 │       ├── llm/                # ClaudeAdapter, OpenAIAdapter
-│       └── mcp/                # Steam, Brave, LinkedIn MCP adapters + catalog (29 entries)
+│       └── mcp/                # Steam, Brave, LinkedIn MCP adapters + CompositeSignalAdapter + catalog (29 entries)
 ├── llm/                        # LLM client (prompt caching, streaming)
 │   ├── client.py               # Anthropic wrapper + token tracking + cost
 │   ├── token_tracker.py        # TokenTracker singleton (model pricing)
@@ -991,6 +992,7 @@ core/
 ├── nodes/                      # Pipeline nodes (8: router, signals, analyst, evaluator, scoring, verification, gather, synthesizer)
 ├── orchestration/
 │   ├── hooks.py                # HookSystem (30 events + async atrigger)
+│   ├── goal_decomposer.py     # GoalDecomposer (compound request → sub-goal DAG)
 │   ├── hook_discovery.py       # Plugin-based hook loading
 │   ├── isolated_execution.py   # IsolatedRunner (MAX_CONCURRENT=5, thread pool)
 │   ├── task_system.py          # TaskGraph DAG (dependency, cycle detection)

--- a/docs/adr/ADR-009-async-pipeline-migration.md
+++ b/docs/adr/ADR-009-async-pipeline-migration.md
@@ -1,0 +1,247 @@
+# ADR-009: 파이프라인 Async 전환 전략
+
+> Status: **PROPOSED** | Date: 2026-03-16 | Author: geode-team
+
+## Context
+
+GEODE 파이프라인은 현재 **전면 sync**입니다. LangGraph 노드가 `def` (sync)이고, LLM 호출이 `Anthropic` (sync client)이며, `graph.stream()`으로 실행됩니다.
+
+v0.12.0에서 직접 검증한 결과, LangGraph는 `async def` 노드 + `Send()` + `.astream()` + `.ainvoke()`를 **완전히 지원**합니다.
+
+```python
+# 검증 결과: Send + async 4개 병렬 → 3.9x speedup
+async def async_worker(state):
+    await asyncio.sleep(0.1)
+    return {'values': [f'{state["_worker_type"]}_done']}
+
+# 0.4초 순차 → 0.103초 병렬 (3.9x)
+```
+
+이전 P3 asyncio 시도(v0.11.0)가 리버트된 이유는 LangGraph 제약이 아니라 **전환 범위의 파급**이었습니다. 이 ADR은 리서치 결과를 기반으로 전환 전략을 결정합니다.
+
+## Decision Drivers
+
+1. **4 Analyst 병렬 실행**: 현재 Send API가 라우팅만 하고 LLM 호출은 순차 실행 (sync `call_llm_parsed`)
+2. **시간 예산 (Karpathy P3)**: `asyncio.timeout()`으로 wall-clock 예산 제어 가능
+3. **관측성 즉시성**: Hook 발행이 완료 즉시 (as_completed 패턴 이미 적용)
+4. **프론티어 정렬**: Claude Code(asyncio), LangGraph 4.x(native async), OpenClaw(Spawn+Announce)
+
+## Considered Options
+
+### Option A: Big-Bang 전환 (전체 async 전환)
+
+모든 노드를 `async def`로, `graph.stream()` → `graph.astream()`으로 일괄 전환.
+
+| 장점 | 단점 |
+|------|------|
+| 깔끔한 코드베이스 | 9개 노드 + 3개 stream 호출 + 23개 테스트 파일 일괄 변경 |
+| 최대 성능 | 중간 상태 없음 (작동하거나 깨지거나) |
+| | LangGraph mixed sync/async 미지원 → 전부 바꿔야 함 |
+
+### Option B: 하이브리드 전환 (LLM client async + sync 노드 유지)
+
+LLM client에 async 변형 추가하되, 노드는 sync로 유지. 노드 내부에서 `asyncio.to_thread()` 역패턴 사용.
+
+| 장점 | 단점 |
+|------|------|
+| 노드 시그니처 유지 | sync 노드 안에서 async 호출은 안티패턴 |
+| 테스트 영향 최소 | 실질적 병렬 이득 없음 (event loop 중첩 불가) |
+
+### Option C: 단계적 전환 + Feature Flag (채택)
+
+3 Phase로 나누어 점진적 전환. Feature flag로 sync/async 경로 공존.
+
+| 장점 | 단점 |
+|------|------|
+| 각 Phase 독립 검증 가능 | 코드 중복 (sync + async 경로 공존) |
+| 기존 테스트 유지 | Feature flag 관리 부담 |
+| 롤백 안전 | 완전 전환까지 시간 소요 |
+
+## Decision
+
+**Option C: 단계적 전환 + Feature Flag**를 채택합니다.
+
+## Implementation Plan
+
+### Phase 1: AsyncAnthropic LLM Client
+
+**범위**: `core/llm/client.py`에 async 함수 추가
+
+```python
+# 신규 함수 (기존 sync 함수 유지)
+async def acall_llm(system: str, user: str, **kwargs) -> str: ...
+async def acall_llm_parsed(system: str, user: str, *, output_model: type[T]) -> T: ...
+```
+
+**영향**: 0개 기존 파일 변경. 신규 함수만 추가.
+**검증**: 단위 테스트로 async LLM 호출 검증.
+
+### Phase 2: Async 노드 + astream 경로
+
+**범위**: 9개 노드 함수를 `async def`로 전환, `graph.astream()` 경로 추가
+
+```python
+# AS-IS
+def analyst_node(state: GeodeState) -> dict[str, Any]:
+    result = parsed_fn(system, user, output_model=AnalysisResult)
+    return {"analyses": [result]}
+
+# TO-BE
+async def analyst_node(state: GeodeState) -> dict[str, Any]:
+    result = await acall_llm_parsed(system, user, output_model=AnalysisResult)
+    return {"analyses": [result]}
+```
+
+**영향**:
+- `core/nodes/*.py`: 6개 노드 함수 → `async def`
+- `core/graph.py`: `_make_hooked_node`, `_verification_node`, `_gather_node` → `async def`
+- `core/graph.py`: `compile_graph()` 내부 변경 없음 (LangGraph가 async 노드 자동 감지)
+- `core/runtime.py`: `graph.stream()` → `graph.astream()` (feature flag)
+- `core/cli/__init__.py`: 2개 stream 호출 → astream (feature flag)
+
+**Feature Flag**:
+```python
+# core/config.py
+async_pipeline: bool = False  # GEODE_ASYNC_PIPELINE=true로 활성화
+```
+
+**검증**: `uv run geode analyze "Berserk" --dry-run`이 동일 결과 산출.
+
+### Phase 3: Hook System async 선택적 지원
+
+**범위**: `_make_hooked_node`가 async가 되면 Hook trigger도 async 가능
+
+```python
+# _make_hooked_node 내부 (async 노드 경로)
+async def _wrapped(state):
+    hooks.trigger(HookEvent.NODE_ENTER, data)  # sync hook — 여전히 동작
+    result = await node_fn(state)              # async 노드 실행
+    hooks.trigger(HookEvent.NODE_EXIT, data)   # sync hook — 여전히 동작
+    return result
+```
+
+**핵심 결정**: Hook trigger는 **sync 유지**. async 노드 안에서 sync 함수 호출은 문제 없음 (반대가 문제).
+
+## Impact Analysis
+
+| 구성 요소 | 파일 수 | 변경 유형 |
+|----------|--------|----------|
+| LLM client | 1 | 신규 async 함수 추가 |
+| 노드 함수 | 6 | `def` → `async def` + `await` |
+| graph.py 내부 노드 | 3 | `def` → `async def` |
+| Stream 호출 | 3 | `.stream()` → `.astream()` (flag) |
+| Hook system | 0 | 변경 없음 (sync 유지) |
+| 테스트 | 23 파일 | async 경로 테스트 추가 (기존 유지) |
+
+## Frontier Alignment — GitHub 코드베이스 기반 실증
+
+### Anthropic Claude Agent SDK (`anthropics/claude-agent-sdk-python`)
+
+**아키텍처**: Async-first. 진입점이 `anyio.run(main)`, 에이전트 루프가 `async for message in query()`.
+
+```python
+# Claude Agent SDK 패턴
+async def main():
+    async for message in query(prompt="Hello"):
+        print(message)
+anyio.run(main)
+```
+
+**도구 실행**: 순차 (병렬 아님). 각 `ToolUseBlock`을 하나씩 처리 후 결과 반환.
+**Hook**: **Sync 콜백**을 async 루프 안에서 호출. `PreToolUse`/`PostToolUse` hook은 sync function.
+**MCP**: In-process MCP 서버 (subprocess 대신 동일 프로세스에서 async 실행).
+
+> **GEODE 시사점**: Claude Agent SDK는 "async 루프 + sync hook" 패턴을 공식 채택. GEODE의 "async 노드 + sync Hook trigger" 결정과 정확히 일치.
+
+### OpenAI Codex (`openai/codex`)
+
+**아키텍처**: Rust async (tokio). 도구 호출을 `FuturesOrdered`로 병렬 디스패치.
+
+```rust
+// Codex 병렬 도구 실행 패턴 (PR #10505, 2026-02)
+if let Some(tool_future) = output_result.tool_future {
+    in_flight.push_back(tool_future);  // 큐에 추가, 즉시 await 안 함
+}
+```
+
+**문제 발견**: 3+ 병렬 tool_call 시 `ResponseEvent::Completed`가 모든 future 완료 전에 도착 → 응답 유실 (#8479). **async 병렬의 실전 위험**을 보여줌.
+**시사점**: 병렬 도구 실행은 race condition 위험이 있으며, drain/completion 보장 메커니즘 필수.
+
+### CrewAI (`crewAIInc/crewAI`)
+
+**아키텍처**: `async_execution=True` 플래그로 태스크별 병렬 전환.
+
+```python
+# CrewAI 패턴
+task1 = Task(description="...", async_execution=True)
+task2 = Task(description="...", async_execution=True)
+# asyncio.gather()로 병렬 실행
+```
+
+**시사점**: 태스크 레벨 `async_execution` 플래그는 GEODE의 feature flag 전략과 동일한 접근.
+
+### LangGraph (`langchain-ai/langgraph`)
+
+**아키텍처**: Superstep 모델. 동일 depth의 노드는 동시 실행. `.astream()`으로 async 노드 네이티브 지원.
+
+```python
+# LangGraph 공식 패턴
+async def my_node(state):
+    result = await llm.ainvoke(state["messages"])
+    return {"messages": [result]}
+
+graph.add_node("chat", my_node)  # async def 직접 등록
+async for event in graph.astream(input):  # async 스트리밍
+    process(event)
+```
+
+**검증 결과**: Send API + async 노드 4개 → 0.103초 (sync 대비 3.9x speedup). `max_concurrency` 설정으로 동시 노드 수 제한 가능.
+
+### 프론티어 비교 매트릭스
+
+| 차원 | Claude Agent SDK | Codex | CrewAI | LangGraph | **GEODE (현재)** | **GEODE (전환 후)** |
+|------|-----------------|-------|--------|-----------|-----------------|-------------------|
+| **코어 루프** | async iterator | Rust async | asyncio.gather | superstep | sync for-loop | async superstep |
+| **도구 병렬** | 순차 | 병렬 (race 위험) | 플래그 기반 | Send API | Send + sync | Send + async |
+| **Hook** | **sync** callback | N/A | N/A | N/A | **sync** | **sync (유지)** |
+| **LLM 호출** | async | async | async | async | **sync** | **async** |
+| **스트리밍** | async iterator | SSE | N/A | `.astream()` | `.stream()` | `.astream()` |
+
+> **핵심 발견**: 모든 프론티어가 **LLM 호출은 async, Hook/이벤트는 sync**를 채택. GEODE의 "Phase 2에서 노드 async 전환, Hook은 sync 유지" 전략은 프론티어 컨센서스와 일치.
+
+## Trade-offs
+
+| 측면 | Sync (현재) | Async (전환 후) |
+|------|-----------|----------------|
+| **4 Analyst 병렬** | Send API 라우팅만, LLM 순차 | 4개 동시 `await` → 3.9x speedup |
+| **디버깅** | 직관적 스택트레이스 | async 스택 깊어짐 |
+| **테스트** | 단순 assert | `pytest-asyncio` 필요 (async 경로) |
+| **시간 예산** | iteration count (간접) | `asyncio.timeout()` (직접) |
+| **Hook** | sync 유지 | sync 유지 (변경 없음) |
+| **롤백** | N/A | Feature flag로 즉시 sync 복귀 |
+
+## Risks
+
+1. **LangGraph mixed sync/async**: 모든 노드가 일괄 전환되어야 함. 부분 전환 불가.
+   - **완화**: Feature flag로 sync/async 그래프를 별도 빌드.
+
+2. **Nested event loop**: Typer CLI 안에서 `asyncio.run()` 중첩 위험.
+   - **완화**: 진입점 하나에서만 `asyncio.run()`. REPL은 이미 `asyncio.run(agentic.arun())` 사용.
+
+3. **ContextVar 전파**: async task 간 contextvars 전파 확인 필요.
+   - **완화**: Python 3.12+ `asyncio.TaskGroup`은 자동 전파.
+
+## Consequences
+
+- Phase 1 후: 코드 변경 최소, 성능 변화 없음 (인프라 준비)
+- Phase 2 후: 4 Analyst 병렬 LLM 호출 → 분석 시간 ~70% 단축
+- Phase 3 후: Hook은 sync 유지하므로 영향 없음
+
+## References
+
+- LangGraph async 검증: `uv run python` 직접 테스트 (Send + async 4x parallel, 3.9x speedup)
+- [LangGraph async example](https://github.com/langchain-ai/langgraph/blob/main/examples/async.ipynb)
+- [LangGraph Send API parallel execution](https://dev.to/sreeni5018/leveraging-langgraphs-send-api-for-dynamic-and-parallel-workflow-execution-4pgd)
+- OpenClaw Spawn+Announce: `.claude/skills/openclaw-patterns/SKILL.md` §4
+- Karpathy P3 Fixed Time Budget: `.claude/skills/karpathy-patterns/SKILL.md` §P3
+- P3 asyncio 리버트 이력: commit 5357e66 → 59ddde3

--- a/docs/blogs/28-hitl-hardening-security-audit.md
+++ b/docs/blogs/28-hitl-hardening-security-audit.md
@@ -1,0 +1,342 @@
+# HITL 보안 강화 — 자율 에이전트의 안전 게이트 진화 과정
+
+> Date: 2026-03-15 | Author: geode-team | Tags: [hitl, security, tool-executor, sub-agent, mcp, write-tools, auto-approve]
+
+## 목차
+
+1. [도입 — 왜 HITL을 다시 점검해야 했는가](#1-도입--왜-hitl을-다시-점검해야-했는가)
+2. [보안 감사 — 7개 우회 벡터 발견](#2-보안-감사--7개-우회-벡터-발견)
+3. [설계 결정 1: WRITE_TOOLS 분류 신설](#3-설계-결정-1-write_tools-분류-신설)
+4. [설계 결정 2: DANGEROUS auto_approve 무시](#4-설계-결정-2-dangerous-auto_approve-무시)
+5. [설계 결정 3: MCP 안전 라우팅](#5-설계-결정-3-mcp-안전-라우팅)
+6. [트레이드오프 — 안전성 vs 자율성](#6-트레이드오프--안전성-vs-자율성)
+7. [HITL 매트릭스 — 최종 안전 분류 체계](#7-hitl-매트릭스--최종-안전-분류-체계)
+8. [마무리](#8-마무리)
+
+---
+
+## 1. 도입 — 왜 HITL을 다시 점검해야 했는가
+
+[이전 포스트](21-clarification-hitl-cost-tracking.md)에서 GEODE의 HITL Safety Gate를 소개했습니다. `SAFE` / `STANDARD` / `DANGEROUS` 3단계 분류로 도구를 나누고, `DANGEROUS`(bash)와 `EXPENSIVE`(분석) 도구에 사용자 승인을 요구하는 구조였습니다.
+
+이 설계는 단일 AgenticLoop 환경에서는 충분했습니다. 그러나 v0.11.0에서 **Sub-Agent 시스템**(P2-B Full AgenticLoop Inheritance)이 도입되면서 상황이 달라졌습니다.
+
+서브에이전트는 부모의 전체 도구 세트를 상속받아 독립 스레드에서 실행됩니다. 이때 `ToolExecutor`가 `auto_approve=True`로 생성되어 HITL 프롬프트 없이 도구를 실행합니다. 이 설계는 서브에이전트가 사용자에게 매번 승인을 요청하는 것이 현실적이지 않다는 판단에서 비롯되었습니다.
+
+문제는 이 `auto_approve=True`가 **모든** 안전 게이트를 우회했다는 점입니다.
+
+```
+Parent AgenticLoop (auto_approve=False)
+  └─ delegate_task → SubAgentManager
+      └─ Worker Thread (auto_approve=True)
+          ├─ run_bash("rm -rf /tmp/data")     ← 승인 없이 실행?
+          ├─ memory_save("malicious rule")     ← 영속적 상태 변경?
+          └─ MCP tool("외부 API 호출")          ← 검사 없이 통과?
+```
+
+> 자율성을 높이기 위한 `auto_approve`가 안전 경계까지 무력화한 것입니다. 서브에이전트 도입 후 HITL 체계를 재점검해야 한다는 것은 아키텍처 결정의 2차 효과(second-order effect)입니다.
+
+---
+
+## 2. 보안 감사 — 7개 우회 벡터 발견
+
+ToolExecutor의 전체 실행 경로를 추적하여 7개의 HITL 우회 벡터를 식별했습니다.
+
+### 감사 방법
+
+1. `tool_executor.py`의 `execute()` 메서드에서 모든 분기 경로를 추적
+2. 각 분기에서 `auto_approve` 플래그가 안전 게이트를 어떻게 영향하는지 분석
+3. MCP 도구가 ToolExecutor를 경유하지 않는 직접 호출 경로 확인
+4. 서브에이전트의 재귀 위임(depth > 0) 시나리오 검증
+
+### 발견 결과
+
+| # | 벡터 | 심각도 | 경로 |
+|---|------|--------|------|
+| 1 | 쓰기 도구(`memory_save`, `note_save`, `set_api_key`, `manage_auth`)가 STANDARD 분류 — 게이트 없음 | **HIGH** | `execute()` → handler 직접 호출 |
+| 2 | `auto_approve=True`가 DANGEROUS(`run_bash`)까지 우회 | **HIGH** | `_execute_bash()` → `if not self._auto_approve` 스킵 |
+| 3 | MCP 도구가 ToolExecutor 안전 검사 없이 `call_tool()` 직접 실행 | **MEDIUM** | `execute()` → `mcp_manager.call_tool()` |
+| 4 | Token Guard는 차단이 아닌 절삭 — 실행 자체는 막지 않음 | **LOW** | `_guard_tool_result()` |
+| 5 | EXPENSIVE 도구 서브에이전트 우회 | **MEDIUM** | `auto_approve` → `_confirm_cost()` 스킵 |
+| 6 | 중첩 위임으로 bash 승인 우회 | **LOW** | delegate → sub-agent → run_bash |
+| 7 | STANDARD 카테고리에 쓰기 도구 포함 | **MEDIUM** | 분류 체계 자체의 공백 |
+
+> 감사 결과, 핵심 문제는 **분류 체계의 공백**(#1, #7)과 **auto_approve의 과도한 범위**(#2, #5)로 수렴했습니다.
+
+---
+
+## 3. 설계 결정 1: WRITE_TOOLS 분류 신설
+
+### 문제
+
+기존 3단계 분류(SAFE / STANDARD / DANGEROUS)에서 쓰기 도구는 STANDARD에 속했습니다. STANDARD는 "일반 실행, 특별한 게이트 없음"을 의미하므로, `memory_save`가 사용자 확인 없이 영속적 상태를 변경할 수 있었습니다.
+
+```python
+# AS-IS: memory_save는 STANDARD — 바로 실행
+handler = self._handlers.get("memory_save")
+return handler(**tool_input)  # 승인 없이 실행
+```
+
+### 해결: WRITE_TOOLS 4번째 분류
+
+```python
+# core/cli/tool_executor.py
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "memory_save",
+        "note_save",
+        "set_api_key",
+        "manage_auth",
+    }
+)
+```
+
+> 이 4개 도구를 WRITE_TOOLS로 분리한 기준은 **영속적 상태 변경 여부**입니다. `memory_save`는 세션 메모리에, `note_save`는 `.claude/MEMORY.md`에, `set_api_key`는 인증 정보에, `manage_auth`는 프로필에 영구적인 변경을 가합니다. 읽기 전용 도구(`memory_search`, `note_read`)와 명확히 구분되는 위험 프로필입니다.
+
+### auto_approve 무시 결정
+
+WRITE_TOOLS의 가장 중요한 설계 결정은 **`auto_approve`를 무시**하는 것입니다.
+
+```python
+# auto_approve 상태와 무관하게 항상 승인 요구
+if tool_name in WRITE_TOOLS and not self._confirm_write(tool_name, tool_input):
+    return {"error": "User denied write operation", "denied": True}
+```
+
+> DANGEROUS와 WRITE는 모두 `auto_approve`를 무시합니다. 서브에이전트가 사용자 모르게 API 키를 변경하거나 메모리에 악의적 규칙을 주입하는 시나리오를 원천 차단합니다.
+
+### 대안 검토
+
+| 대안 | 장점 | 단점 | 결정 |
+|------|------|------|------|
+| DANGEROUS에 포함 | 단순 | bash와 쓰기의 위험 프로필이 다름 | 기각 |
+| STANDARD 유지 + 별도 화이트리스트 | 기존 구조 유지 | 화이트리스트 관리 복잡 | 기각 |
+| **별도 WRITE 분류** | 위험 프로필에 맞는 세분화 | 분류 4단계로 증가 | **채택** |
+| 전부 DANGEROUS | 가장 안전 | 쓰기마다 bash 수준 경고는 과잉 | 기각 |
+
+---
+
+## 4. 설계 결정 2: DANGEROUS auto_approve 무시
+
+### 문제
+
+서브에이전트의 `ToolExecutor`는 `auto_approve=True`로 생성됩니다. 기존 코드에서 `_execute_bash()`는 `if not self._auto_approve` 조건으로 승인을 스킵했습니다.
+
+```python
+# AS-IS: auto_approve=True이면 bash도 승인 없이 실행
+if not self._auto_approve:
+    approved = self._request_approval(command, reason)
+    if not approved:
+        return {"error": "User denied execution", "denied": True}
+```
+
+이는 `delegate_task` → 서브에이전트 → `run_bash` 경로로 셸 명령을 무승인 실행할 수 있다는 의미였습니다.
+
+### 해결: auto_approve 조건 제거
+
+```python
+# TO-BE: auto_approve 상태와 무관하게 항상 승인 요구
+approved = self._request_approval(command, reason)
+if not approved:
+    return {"error": "User denied execution", "denied": True}
+```
+
+> `run_bash`는 시스템 수준의 부작용을 가집니다. 파일 삭제, 프로세스 종료, 네트워크 호출 등 어떤 명령이든 실행 가능합니다. 이런 도구에 `auto_approve`를 적용하는 것은 "편의를 위해 자물쇠를 제거하는 것"과 같습니다. **DANGEROUS 도구는 항상 사용자 승인이 필수**라는 불변 규칙을 확립했습니다.
+
+### 서브에이전트에서의 영향
+
+서브에이전트가 `run_bash`를 호출하면 부모 REPL의 터미널에서 승인 프롬프트가 표시됩니다. 서브에이전트는 승인이 올 때까지 블로킹됩니다.
+
+```
+  ⚠ Bash command requires approval
+  Command: echo "test from sub-agent"
+  Reason:  Sub-agent needs file check
+
+  Allow? [Y/n]
+```
+
+> 이 동작은 의도적입니다. 서브에이전트가 셸 명령을 실행해야 한다면, 사용자가 명시적으로 허용해야 합니다. 프롬프트가 방해가 될 수 있지만, 무승인 셸 실행의 위험보다 낫습니다.
+
+---
+
+## 5. 설계 결정 3: MCP 안전 라우팅
+
+### 문제
+
+MCP 도구는 ToolExecutor의 안전 게이트를 **완전히 우회**했습니다. 등록된 핸들러가 없을 때 `mcp_manager.call_tool()`을 직접 호출하여 결과를 반환했습니다.
+
+```python
+# AS-IS: MCP 도구 → 안전 검사 없이 직접 실행
+if self._mcp_manager is not None:
+    server = self._mcp_manager.find_server_for_tool(tool_name)
+    if server is not None:
+        result = self._mcp_manager.call_tool(server, tool_name, tool_input)
+        return result  # 어떤 검사도 없음
+```
+
+MCP 서버는 외부 프로세스입니다. 파일시스템 접근, 네트워크 호출, 브라우저 자동화 등 어떤 작업이든 수행할 수 있습니다.
+
+### 해결: _execute_mcp() 경유
+
+```python
+# core/cli/tool_executor.py
+def _execute_mcp(
+    self, server: str, tool_name: str, tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    log.info("MCP tool: %s → %s (args=%s)", tool_name, server,
+             list(tool_input.keys()))
+
+    if not self._auto_approve and not self._confirm_mcp(server, tool_name):
+        return {"error": "User denied MCP tool execution", "denied": True}
+
+    assert self._mcp_manager is not None
+    result: dict[str, Any] = self._mcp_manager.call_tool(
+        server, tool_name, tool_input
+    )
+    return result
+```
+
+> MCP 도구에 대해서는 `auto_approve`를 존중합니다. 서브에이전트가 Steam API나 arXiv 검색을 호출하는 것은 정상적인 분석 흐름의 일부이기 때문입니다. 그러나 부모 AgenticLoop에서는 사용자 확인을 거칩니다.
+
+### MCP와 DANGEROUS/WRITE의 차이
+
+| 분류 | auto_approve 존중 | 이유 |
+|------|-------------------|------|
+| **DANGEROUS** | 무시 (항상 승인) | 시스템 수준 부작용 (bash) |
+| **WRITE** | 무시 (항상 승인) | 영속적 상태 변경 (메모리, 인증) |
+| **MCP** | 존중 | 외부 데이터 조회가 주 용도, 서브에이전트 분석 흐름에 필수 |
+| **EXPENSIVE** | 존중 | 비용 확인은 편의 기능, 안전 필수 아님 |
+
+---
+
+## 6. 트레이드오프 — 안전성 vs 자율성
+
+### 발전 과정
+
+GEODE의 HITL 체계는 3단계를 거쳐 진화했습니다.
+
+**Phase 1 (v0.6.0)**: 초기 설계
+```
+SAFE(7종) → 즉시 실행
+STANDARD(나머지) → 즉시 실행
+DANGEROUS(bash) → 사용자 승인
+```
+
+**Phase 2 (v0.10.0)**: 서브에이전트 도입
+```
+auto_approve=True → STANDARD 스킵 (의도)
+auto_approve=True → DANGEROUS 스킵 (비의도적 우회)
+auto_approve=True → 쓰기 도구 스킵 (인식 못한 공백)
+MCP 도구 → ToolExecutor 우회 (설계 누락)
+```
+
+**Phase 3 (v0.12.0)**: 보안 강화
+```
+SAFE(11종) → 즉시 실행
+STANDARD(나머지) → auto_approve 존중
+WRITE(4종) → 항상 승인 필수 (auto_approve 무시)
+DANGEROUS(1종) → 항상 승인 필수 (auto_approve 무시)
+EXPENSIVE(3종) → auto_approve 존중
+MCP(외부) → auto_approve 존중 + 로깅
+```
+
+### 안전-자율 매트릭스
+
+```
+                    안전성 높음
+                        │
+    DANGEROUS ──────────┼───── WRITE
+    (bash: 항상 승인)    │    (쓰기: 항상 승인)
+                        │
+  ──────────────────────┼──────────────────── 자율성 높음
+                        │
+    MCP ────────────────┼───── EXPENSIVE
+    (외부: 부모만 승인)   │    (비용: 부모만 승인)
+                        │
+    STANDARD ───────────┼───── SAFE
+    (일반: 무게이트)     │    (읽기: 무게이트)
+                        │
+                    안전성 낮음
+```
+
+> 좌상단(DANGEROUS, WRITE)은 어떤 상황에서든 사용자 승인이 필수입니다. 우하단(STANDARD, SAFE)은 자율 실행을 허용합니다. 중간 영역(MCP, EXPENSIVE)은 부모 AgenticLoop에서만 승인을 요구하고 서브에이전트에서는 자율 실행합니다.
+
+---
+
+## 7. HITL 매트릭스 — 최종 안전 분류 체계
+
+### 도구별 분류표
+
+| 분류 | auto_approve 시 | UI 마커 | 도구 | 개수 |
+|------|----------------|---------|------|------|
+| **SAFE** | 즉시 실행 | (없음) | `list_ips`, `search_ips`, `show_help`, `check_status`, `switch_model`, `memory_search`, `manage_rule`, `web_fetch`, `general_web_search`, `note_read`, `read_document` | 11 |
+| **STANDARD** | 즉시 실행 | (없음) | `analyze_ip`*, `batch_analyze`*, `compare_ips`*, `generate_report`, `generate_data`, `schedule_job`, `trigger_event`, `create_plan`, `approve_plan`, `reject_plan`, `modify_plan`, `list_plans`, `youtube_search`, `reddit_sentiment`, `steam_info`, `google_trends`, `rate_result`, `accept_result`, `reject_result`, `rerun_node`, `delegate_task` | 21 |
+| **EXPENSIVE** | 즉시 실행 | `$ Cost confirmation` | `analyze_ip` (~$1.50), `batch_analyze` (~$5.00), `compare_ips` (~$3.00) | 3* |
+| **WRITE** | 항상 승인 | `✏ Write operation` | `memory_save`, `note_save`, `set_api_key`, `manage_auth` | 4 |
+| **DANGEROUS** | 항상 승인 | `⚠ Bash command` | `run_bash` | 1 |
+| **MCP** | 즉시 실행 | `⚡ MCP tool` | 외부 MCP 서버 도구 (Steam, Brave, arXiv, Playwright, LinkedIn) | 45+ |
+
+*EXPENSIVE는 STANDARD의 부분집합입니다. 부모 AgenticLoop에서만 비용 확인을 표시합니다.
+
+### 실행 흐름 결정 트리
+
+```
+도구 호출 수신
+  │
+  ├─ DANGEROUS? ──→ 항상 _request_approval() ──→ 승인/거부
+  │
+  ├─ WRITE? ──→ 항상 _confirm_write() ──→ 승인/거부
+  │
+  ├─ EXPENSIVE? ──→ auto_approve?
+  │                  ├─ True → 즉시 실행 (서브에이전트)
+  │                  └─ False → _confirm_cost() → 승인/거부
+  │
+  ├─ delegate_task? ──→ _execute_delegate() → SubAgentManager
+  │
+  ├─ 핸들러 있음? ──→ handler(**tool_input)
+  │
+  └─ MCP fallback? ──→ auto_approve?
+                        ├─ True → 즉시 실행 (서브에이전트)
+                        └─ False → _confirm_mcp() → 승인/거부
+```
+
+### 서브에이전트 안전 보장
+
+| 시나리오 | 부모 | 서브에이전트 | 결과 |
+|----------|------|------------|------|
+| `analyze_ip` 호출 | 비용 확인 | 즉시 실행 | 서브에이전트는 분석이 주 업무 |
+| `memory_save` 호출 | 승인 필수 | **승인 필수** | 영속 상태 변경 차단 |
+| `run_bash` 호출 | 승인 필수 | **승인 필수** | 셸 실행 차단 |
+| Steam MCP 검색 | 승인 필수 | 즉시 실행 | 외부 데이터 조회는 정상 흐름 |
+| `delegate_task` 재귀 | 즉시 실행 | 즉시 실행 | depth 제한(max=2)으로 제어 |
+
+---
+
+## 8. 마무리
+
+### 핵심 정리
+
+| 항목 | 값 |
+|------|-----|
+| 발견된 우회 벡터 | 7건 (HIGH 2, MEDIUM 3, LOW 2) |
+| 수정된 벡터 | 5건 (의도적 허용 2건 제외) |
+| 신규 안전 분류 | `WRITE_TOOLS` (4개 도구) |
+| auto_approve 무시 대상 | `DANGEROUS` + `WRITE` (5개 도구) |
+| auto_approve 존중 대상 | `EXPENSIVE` + `MCP` |
+| 추가된 HITL 프롬프트 | 3종 (`_confirm_write`, `_confirm_mcp`, `_request_approval` 강제) |
+| 테스트 추가 | 6건 (bash 승인 강제, WRITE 승인 강제, auto_approve 무시 검증) |
+
+### 설계 원칙
+
+1. **DANGEROUS와 WRITE는 불변 게이트**: `auto_approve`, `is_subagent`, `depth` 어떤 플래그도 이 게이트를 비활성화할 수 없습니다.
+2. **자율성은 읽기와 분석에만**: 서브에이전트가 자율적으로 수행할 수 있는 것은 데이터 조회와 분석뿐입니다. 상태 변경과 시스템 명령은 항상 사용자 동의가 필요합니다.
+3. **외부 도구는 로깅 필수**: MCP 도구는 `auto_approve` 여부와 관계없이 `log.info()`로 기록됩니다. 사후 감사(audit trail)를 위한 최소한의 가시성입니다.
+
+### 체크리스트
+
+- [x] DANGEROUS 도구 auto_approve 우회 차단
+- [x] WRITE_TOOLS 신규 분류 + 승인 게이트
+- [x] MCP 도구 _execute_mcp() 경유 라우팅
+- [x] 서브에이전트 WRITE/DANGEROUS 테스트 검증
+- [x] README Delegation Flow 코드 경로 정합성
+- [x] CLAUDE.md auto_approve 설명 정확성

--- a/docs/blogs/29-grounding-truth-autonomous-agent.md
+++ b/docs/blogs/29-grounding-truth-autonomous-agent.md
@@ -1,0 +1,336 @@
+# 자율 에이전트의 그라운딩 트루스 — 도구 결과만으로 말하게 하기
+
+> Date: 2026-03-16 | Author: geode-team | Tags: [grounding, hallucination, citation, web-search, tool-result, guardrails, agentic-loop]
+
+## 목차
+
+1. [문제 — 에이전트가 거짓을 말할 때](#1-문제--에이전트가-거짓을-말할-때)
+2. [두 가지 그라운딩 — 도메인 vs 에이전트](#2-두-가지-그라운딩--도메인-vs-에이전트)
+3. [설계 결정 — 프롬프트 레벨 강제](#3-설계-결정--프롬프트-레벨-강제)
+4. [구현 — 소스 태깅과 인용 규칙](#4-구현--소스-태깅과-인용-규칙)
+5. [도메인 가드레일 완화](#5-도메인-가드레일-완화)
+6. [트레이드오프 — 정확성 vs 유용성](#6-트레이드오프--정확성-vs-유용성)
+7. [한계와 발전 방향](#7-한계와-발전-방향)
+8. [마무리](#8-마무리)
+
+---
+
+## 1. 문제 — 에이전트가 거짓을 말할 때
+
+GEODE는 `while(tool_use)` 루프로 도구를 호출하고, 결과를 받아 사용자에게 응답합니다. `web_fetch`로 URL을 읽고, `general_web_search`로 검색하고, MCP 도구로 Steam/arXiv 데이터를 가져옵니다.
+
+문제는 LLM이 도구 결과를 **받은 뒤** 응답을 생성하는 단계에서 발생합니다.
+
+```
+User: "이 회사 최근 실적 알려줘"
+  → web_fetch("https://example.com/earnings") → 매출 $2.1B, 영업이익 $340M
+  → LLM 응답: "매출은 $2.1B이며, 전년 대비 15% 성장했습니다."
+                                              ↑ 이 숫자는 도구 결과에 없음
+```
+
+도구 결과에는 `$2.1B`과 `$340M`만 있었지만, LLM이 **"전년 대비 15% 성장"**이라는 정보를 스스로 생성했습니다. 사전 학습 데이터에서 가져왔을 수도 있고, 완전한 날조일 수도 있습니다. 사용자는 도구로 검증된 정보와 LLM이 추가한 정보를 구분할 수 없습니다.
+
+이것이 자율 에이전트의 **그라운딩 트루스(Grounding Truth)** 문제입니다.
+
+---
+
+## 2. 두 가지 그라운딩 — 도메인 vs 에이전트
+
+GEODE에는 그라운딩이 필요한 두 개의 계층이 있습니다. 각 계층의 특성이 다르므로 다른 전략이 필요합니다.
+
+### 도메인 파이프라인 (L5)
+
+게임 IP 분석 파이프라인은 이미 강력한 그라운딩 체계를 갖추고 있습니다.
+
+```
+Fixture signals (YouTube views, Reddit subs, ...)
+  → Analyst evidence[] (LLM이 signal 기반으로 생성)
+  → G3 Guardrail (_check_evidence_grounding)
+  → grounding_ratio 산출
+```
+
+| 요소 | 상태 | 방식 |
+|------|------|------|
+| 입력 데이터 | 통제됨 | fixture JSON, 구조화된 signal |
+| evidence 검증 | 자동 | signal key/value 대조 (G3) |
+| 점수 산출 | 결정적 | PSM 공식, 코드 기반 Decision Tree |
+| 내러티브 | 반자동 | LLM이 signal summary 기반으로 생성 |
+
+> 도메인 파이프라인은 **구조화된 입력 → 구조화된 출력** 패턴입니다. 입력이 통제되므로 출력도 검증 가능합니다.
+
+### 자율 에이전트 (L0)
+
+AgenticLoop은 근본적으로 다릅니다.
+
+```
+User free-text input
+  → Claude Tool Use → web_fetch / web_search / MCP tools
+  → 비구조화 텍스트 결과
+  → LLM이 자유 형식으로 응답 생성
+```
+
+| 요소 | 상태 | 문제 |
+|------|------|------|
+| 입력 데이터 | 비통제 | 사용자가 어떤 질문이든 가능 |
+| 도구 결과 | 비구조화 | HTML 텍스트, 검색 스니펫 |
+| 응답 생성 | 자유 형식 | LLM이 도구 결과 + 사전 학습 혼합 |
+| 출처 표기 | 없음 | URL이 결과에 있지만 인용 안 됨 |
+
+> 자율 에이전트의 그라운딩은 **비구조화 입력 → 비구조화 출력** 환경에서 작동해야 합니다. 도메인 파이프라인과 같은 스키마 검증은 불가능합니다.
+
+이 차이가 핵심 설계 결정을 결정합니다. 도메인 가드레일을 에이전트에 그대로 적용하면 false positive가 폭발하고, 에이전트 수준의 느슨한 검증을 도메인에 적용하면 분석 품질이 하락합니다.
+
+---
+
+## 3. 설계 결정 — 프롬프트 레벨 강제
+
+자율 에이전트의 그라운딩을 어디에서 강제할지 3가지 선택지를 검토했습니다.
+
+| 방식 | 장점 | 단점 | 결정 |
+|------|------|------|------|
+| **프롬프트 규칙** | 구현 단순, 즉시 적용, 모든 도구 커버 | LLM이 규칙을 무시할 수 있음 | **채택** |
+| **사후 검증** | 정확도 높음, 자동화 가능 | 비구조화 텍스트에서 claim 추출 어려움, 비용 2배 | 보류 |
+| **도구 결과 강제 태깅** | 출처가 구조화됨 | 모든 도구(38+MCP) 수정 필요, 외부 도구 통제 불가 | 부분 채택 |
+
+최종 설계는 **프롬프트 규칙 + 부분 도구 태깅**의 조합입니다.
+
+### 왜 프롬프트 규칙이 1순위인가
+
+자율 에이전트의 응답은 **자유 형식 텍스트**입니다. 응답에서 "이 문장은 tool_result에서 온 것이고, 이 문장은 LLM이 추가한 것"을 자동으로 구분하는 것은 사실상 또 다른 LLM 호출이 필요합니다. 이는 비용과 지연을 2배로 만듭니다.
+
+반면 프롬프트 규칙은 **생성 시점**에서 그라운딩을 강제합니다. LLM이 응답을 생성하는 동안 "이 정보가 도구 결과에 있었는가?"를 스스로 판단하게 합니다.
+
+```python
+# core/llm/prompts/router.md (AGENTIC_SUFFIX)
+## Grounding & Citation (CRITICAL)
+
+1. ONLY state facts that appear in the tool result.
+   Do NOT invent statistics, dates, names, or claims
+   beyond what the tool returned.
+
+2. Cite the source for each key claim.
+   - Format: "According to [URL]..." or "Sources:" section.
+
+3. When data is insufficient, say so explicitly.
+
+4. Numerical data: quote the exact number from the tool result.
+```
+
+> `CRITICAL` 태그는 GEODE의 프롬프트 체계에서 최우선 규칙을 의미합니다. Completion criteria, Clarification rules와 같은 수준으로 그라운딩을 배치한 것은 의도적인 결정입니다. LLM이 우선순위를 판단할 때 그라운딩 규칙이 "도구를 더 호출할까" 같은 전략적 판단보다 앞서도록 합니다.
+
+---
+
+## 4. 구현 — 소스 태깅과 인용 규칙
+
+프롬프트 규칙만으로는 LLM에게 "출처를 인용하라"고 할 때 인용할 출처가 결과에 명시되어 있어야 합니다. 두 가지 핵심 도구에 소스 태깅을 추가했습니다.
+
+### web_fetch — source 필드 추가
+
+```python
+# core/tools/web_tools.py
+return {
+    "result": {
+        "url": url,
+        "source": url,  # explicit source tag for grounding
+        "content": text[:max_chars],
+        "truncated": len(text) > max_chars,
+        "content_type": content_type,
+        "status_code": resp.status_code,
+    }
+}
+```
+
+> `url`과 `source`가 동일한 값이지만, `source`라는 이름을 명시적으로 추가한 이유는 LLM의 **semantic priming(의미적 점화)** 때문입니다. tool_result에 `"source": "https://..."` 필드가 있으면 LLM이 응답에서 해당 URL을 인용할 확률이 높아집니다. 필드 이름 자체가 행동을 유도합니다.
+
+### general_web_search — source_urls 추출
+
+```python
+# core/tools/web_tools.py
+text_parts: list[str] = []
+source_urls: list[str] = []
+for block in response.content:
+    if hasattr(block, "text"):
+        text_parts.append(block.text)
+    if getattr(block, "type", "") == "web_search_tool_result":
+        for entry in getattr(block, "content", []):
+            url = getattr(entry, "url", None)
+            if url:
+                source_urls.append(url)
+return {
+    "result": {
+        "query": query,
+        "search_results": "\n".join(text_parts),
+        "source": "anthropic_web_search",
+        "source_urls": source_urls,
+    }
+}
+```
+
+> Anthropic의 `web_search_20250305` 도구는 검색 결과를 텍스트 블록과 `web_search_tool_result` 블록으로 반환합니다. 기존에는 텍스트만 추출하고 URL은 버렸습니다. 이제 `source_urls` 리스트로 구조화하여 LLM이 개별 결과를 인용할 수 있게 합니다.
+
+### 프롬프트에서의 인용 규칙
+
+```
+2. Cite the source for each key claim:
+   - For web_fetch: use the `url` field from the result.
+   - For general_web_search: cite individual result URLs when available.
+   - For MCP tools: cite the server name (e.g. "Steam API", "arXiv").
+```
+
+MCP 도구는 외부 프로세스이므로 결과 구조를 통제할 수 없습니다. 대신 서버 이름을 출처로 인용하도록 합니다. Steam MCP가 반환한 데이터는 "Steam API에 따르면..."으로, arXiv MCP 결과는 "arXiv에 따르면..."으로 인용됩니다.
+
+---
+
+## 5. 도메인 가드레일 완화
+
+에이전트 그라운딩을 추가하면서 도메인 파이프라인의 G3 가드레일을 동시에 완화했습니다.
+
+### AS-IS: quantitative analyst hard fail
+
+```python
+# 이전 코드
+if g_count == 0 and a.analyst_type in quantitative_analysts:
+    errors.append(f"Analyst {a.analyst_type}: 0/{ev_count} evidence "
+                  f"grounded in signals (quantitative analyst requires grounding)")
+```
+
+`growth_potential`이나 `discovery` 분석가의 evidence가 signal key와 0% 매칭이면 G3가 hard fail했습니다.
+
+### TO-BE: soft warning으로 복원
+
+```python
+# core/verification/guardrails.py
+if g_count == 0:
+    # Soft warning for all analysts — domain guardrails are
+    # already strong enough; hard failures here caused
+    # false positives in dry-run fixtures.
+    details_only.append(
+        f"Analyst {a.analyst_type}: 0/{ev_count} evidence "
+        f"grounded (review recommended)"
+    )
+```
+
+> **왜 완화했는가?** dry-run fixture의 evidence 문자열 `"YouTube 12M views"`가 signal key `youtube_views`와 부분 매칭은 되지만, 매칭 알고리즘의 한계로 false positive가 발생했습니다. 도메인 파이프라인은 이미 G1(스키마), G2(범위), G4(일관성), BiasBuster(편향), Cross-LLM(교차 검증) 등 5겹의 검증을 갖추고 있어 G3 하나를 완화해도 전체 품질이 유지됩니다.
+
+### grounding_ratio는 유지
+
+```python
+# core/state.py
+class GuardrailResult(BaseModel):
+    ...
+    grounding_ratio: float = 0.0  # [0.0, 1.0]
+```
+
+hard fail은 제거했지만 **grounding_ratio는 계속 산출**합니다. 이 값은 리포트에 표시되어 사용자가 evidence의 신뢰도를 판단할 수 있습니다. "이 분석의 evidence 중 70%가 실제 signal 데이터에 근거합니다"와 같은 투명성을 제공합니다.
+
+---
+
+## 6. 트레이드오프 — 정확성 vs 유용성
+
+그라운딩 정책은 **정확성과 유용성** 사이의 긴장을 내포합니다.
+
+| 강도 | 정확성 | 유용성 | 예시 |
+|------|--------|--------|------|
+| **무제한** | 낮음 | 높음 | LLM이 사전 학습 지식도 자유롭게 활용, 풍부한 응답 |
+| **엄격 (현재)** | 높음 | 중간 | tool_result 데이터만 인용, 부족 시 명시 |
+| **극단** | 최고 | 낮음 | 모든 문장에 출처 태그, 사후 검증으로 미그라운딩 문장 삭제 |
+
+현재 GEODE는 **엄격** 수준을 택했습니다.
+
+### 유용성 감소 사례
+
+```
+User: "Berserk 원작자에 대해 알려줘"
+Tool: web_fetch → 미우라 켄타로 Wikipedia 페이지 (1966-2021 정보)
+
+엄격 그라운딩:
+  "미우라 켄타로(1966-2021)는 Berserk의 원작자입니다. (Source: Wikipedia)"
+
+무제한:
+  "미우라 켄타로는 일본 만화 역사상 가장 영향력 있는 작가 중 한 명으로,
+   다크 판타지 장르를 재정의했습니다. 그의 사후 제자인 스튜디오 갸가가
+   연재를 이어가고 있으며..."
+```
+
+> 엄격 모드의 응답은 짧지만 **모든 문장이 검증 가능**합니다. 무제한 모드의 응답은 풍부하지만 "다크 판타지 장르를 재정의했다"는 주관적 평가이며, "스튜디오 갸가" 정보가 도구 결과에 없다면 할루시네이션입니다.
+
+### 의도적으로 허용하는 영역
+
+에이전트의 그라운딩 규칙에는 **의도적 예외**가 있습니다.
+
+1. **사전 지식 기반 질답**: "Python의 list comprehension 문법 알려줘" 같은 일반 지식 질문은 도구 호출 없이 LLM의 사전 학습 지식으로 답변합니다. 이 경우 그라운딩 규칙이 적용되지 않습니다.
+
+2. **도구 결과 해석**: "이 데이터가 무엇을 의미하는지 설명해줘"와 같은 요청에서 LLM이 분석적 해석을 추가하는 것은 허용합니다. 단, 새로운 **사실**을 추가하는 것은 금지합니다.
+
+이 구분이 프롬프트 규칙 1번의 "facts that appear in the tool result"라는 표현에 담겨 있습니다. **사실(fact)**만 제한하고, **해석(interpretation)**은 허용합니다.
+
+---
+
+## 7. 한계와 발전 방향
+
+### 현재 한계
+
+**1. 프롬프트 규칙은 강제가 아닌 권고입니다.**
+
+LLM은 프롬프트 규칙을 99% 따르지만, 복잡한 멀티턴 대화에서 규칙 준수율이 하락할 수 있습니다. 특히 도구 호출이 5회 이상 누적된 후 최종 응답을 생성할 때, 초기 도구 결과의 세부 사항을 사전 학습 지식으로 채우는 경향이 관찰됩니다.
+
+**2. 비구조화 텍스트의 그라운딩 검증은 어렵습니다.**
+
+"매출이 $2.1B"이라는 응답이 도구 결과의 "$2.1 billion"과 같은 값인지 자동으로 판단하려면 의미적 매칭이 필요합니다. 단순 문자열 비교로는 불가능합니다.
+
+**3. MCP 도구의 결과 구조를 통제할 수 없습니다.**
+
+Steam MCP가 반환하는 JSON 구조, Brave Search가 반환하는 텍스트 형식은 외부 패키지에 의존합니다. `source` 필드를 강제할 수 없으므로 서버 이름 수준의 인용만 가능합니다.
+
+### 발전 방향
+
+**단기**: 도구 결과에 `_grounding_id`를 태깅하여 LLM 응답에서 참조할 수 있게 합니다. `[ref:1]`, `[ref:2]` 형태의 인라인 참조를 통해 사후 검증이 가능해집니다.
+
+**중기**: 응답 생성 후 경량 모델(Haiku)로 "이 응답의 각 주장이 제공된 도구 결과에 근거하는가?"를 검증하는 2단계 파이프라인을 추가합니다. 비용은 증가하지만 정확도가 크게 향상됩니다.
+
+**장기**: 에이전트의 응답을 구조화된 형식(`claim + source_ref`)으로 생성한 뒤 자연어로 렌더링하는 방식으로 전환합니다. Structured Output을 응답 레벨에도 적용하는 것입니다.
+
+---
+
+## 8. 마무리
+
+### 핵심 정리
+
+| 항목 | 값 |
+|------|-----|
+| 그라운딩 대상 | 자율 에이전트 레벨 (L0) — web_fetch, web_search, MCP 도구 결과 기반 응답 |
+| 강제 방식 | AGENTIC_SUFFIX 프롬프트 규칙 (CRITICAL 등급) |
+| 소스 태깅 | web_fetch `source` 필드, web_search `source_urls` 리스트 |
+| 인용 포맷 | "According to [URL]..." 또는 "Sources:" 섹션 |
+| 도메인 G3 | hard fail → soft warning 완화 + grounding_ratio 유지 |
+| 도메인 가드레일 | G1-G4 + BiasBuster + Cross-LLM — 이미 5겹 검증 |
+| 의도적 예외 | 사전 지식 질답, 도구 결과 해석 (사실 추가만 금지) |
+
+### 그라운딩 계층 구조
+
+```
+L0 에이전트    프롬프트 규칙 (Citation & Grounding)
+               → tool_result 데이터만 인용
+               → 출처 URL/서버명 필수 표기
+               → 미확인 정보 생성 금지
+
+L1 도구        소스 태깅 (source, source_urls)
+               → web_fetch: URL 명시
+               → web_search: 개별 검색 결과 URL 추출
+               → MCP: 서버 이름 수준 인용
+
+L5 도메인      G3 grounding_ratio (soft warning)
+               → evidence vs signal 교차 검증
+               → 비율 산출 + 리포트 Evidence Chain 표시
+```
+
+### 체크리스트
+
+- [x] AGENTIC_SUFFIX에 Grounding & Citation 규칙 추가
+- [x] web_fetch `source` 필드 태깅
+- [x] web_search `source_urls` 추출
+- [x] G3 quantitative hard fail → soft warning 완화
+- [x] grounding_ratio 필드 + 리포트 Evidence Chain
+- [ ] 응답 내 인라인 참조 (`[ref:N]`) 체계
+- [ ] 2단계 사후 검증 (Haiku 기반 claim verification)
+- [ ] Structured Output 응답 레벨 적용

--- a/docs/blogs/30-prompt-architecture-composition-system.md
+++ b/docs/blogs/30-prompt-architecture-composition-system.md
@@ -1,0 +1,440 @@
+# GEODE 프롬프트 아키텍처 — 조합, 격리, 캐싱, 그리고 무결성 검증
+
+> Date: 2026-03-16 | Author: geode-team | Tags: [prompt-engineering, prompt-caching, clean-context, skill-injection, karpathy-p4, structured-output, agentic-loop]
+
+## 목차
+
+1. [도입 — 프롬프트가 코드가 될 때](#1-도입--프롬프트가-코드가-될-때)
+2. [템플릿 구조 — 마크다운 섹션 기반 로더](#2-템플릿-구조--마크다운-섹션-기반-로더)
+3. [6단계 조합 파이프라인 (ADR-007)](#3-6단계-조합-파이프라인-adr-007)
+4. [Clean Context — 앵커링 방지 격리](#4-clean-context--앵커링-방지-격리)
+5. [동적 축 주입 — YAML에서 루브릭으로](#5-동적-축-주입--yaml에서-루브릭으로)
+6. [프롬프트 캐싱 — 반복 호출 비용 절감](#6-프롬프트-캐싱--반복-호출-비용-절감)
+7. [무결성 검증 — SHA-256 해시 핀닝](#7-무결성-검증--sha-256-해시-핀닝)
+8. [Structured Output — 자유 텍스트의 종말](#8-structured-output--자유-텍스트의-종말)
+9. [마무리](#9-마무리)
+
+---
+
+## 1. 도입 — 프롬프트가 코드가 될 때
+
+GEODE의 파이프라인은 8개 노드에서 최소 10회의 LLM 호출을 수행합니다. 4명의 Analyst가 병렬로 호출되고, 3명의 Evaluator가 14개 축을 평가하며, Synthesizer가 최종 내러티브를 생성합니다. 각 호출에는 서로 다른 시스템 프롬프트, 사용자 프롬프트, 루브릭 데이터, 스킬 컨텍스트가 필요합니다.
+
+이 상황에서 프롬프트를 Python 문자열 상수로 관리하면 어떻게 될까요?
+
+```python
+# 이렇게 하지 않습니다
+ANALYST_SYSTEM = """You are a game mechanics analyst.
+Focus on: core gameplay loop quality, combat/interaction system potential,
+progression mechanics, skill/ability design space, and replay value.
+..."""
+```
+
+프롬프트 하나를 수정하면 관련된 10개 호출 지점을 확인해야 하고, 루브릭을 변경하면 3개 Evaluator 프롬프트를 동시에 갱신해야 합니다. 프롬프트가 3000자를 넘어가면 코드 리뷰에서 diff를 읽기 어렵고, 의도하지 않은 변경이 CI를 통과할 수 있습니다.
+
+이 글에서는 GEODE가 프롬프트를 **코드와 동일한 수준으로 관리**하는 방법을 다룹니다.
+
+---
+
+## 2. 템플릿 구조 — 마크다운 섹션 기반 로더
+
+### 파일 포맷
+
+GEODE의 프롬프트 템플릿은 `.md` 파일입니다. `=== SECTION_NAME ===` 구분자로 하나의 파일 안에 여러 프롬프트를 정의합니다.
+
+```markdown
+=== SYSTEM ===
+
+You are GEODE, a general-purpose autonomous execution agent.
+You help the user with any task — research, analysis, automation.
+
+## Core capabilities
+- Answer questions directly using your knowledge
+- Process URLs (web_fetch), search the web (general_web_search)
+...
+
+=== AGENTIC_SUFFIX ===
+
+## Completion criteria (CRITICAL)
+After each tool result, ask yourself:
+"Has the user's original request been fully answered?"
+...
+```
+
+> 하나의 `.md` 파일에 SYSTEM과 AGENTIC_SUFFIX를 함께 두는 이유는 **관련 프롬프트의 공동 변경(co-change)**을 보장하기 위해서입니다. SYSTEM에서 도구 사용 규칙을 변경하면 AGENTIC_SUFFIX의 완료 기준도 함께 검토해야 합니다. 같은 파일에 있으면 PR의 diff에서 자연스럽게 함께 보입니다.
+
+### 로딩 메커니즘
+
+```python
+# core/llm/prompts/__init__.py
+def _load_template(name: str) -> dict[str, str]:
+    """Load a .md template, split by === SECTION === markers."""
+    path = _PROMPT_DIR / f"{name}.md"
+    text = path.read_text(encoding="utf-8")
+    sections: dict[str, str] = {}
+    current_key = ""
+    for line in text.splitlines():
+        m = re.match(r"^===\s*(\w+)\s*===$", line)
+        if m:
+            current_key = m.group(1).lower()
+            sections[current_key] = ""
+        elif current_key:
+            sections[current_key] += line + "\n"
+    return {k: v.strip() for k, v in sections.items()}
+```
+
+> 정규식 `^===\s*(\w+)\s*===$`은 Markdown 렌더링에서도 시각적으로 구분되는 구분자입니다. GitHub에서 `.md` 파일을 열면 `=== SYSTEM ===`이 구분선처럼 보여서 편집 시 섹션 경계가 명확합니다.
+
+### 7개 템플릿 파일
+
+| 파일 | 섹션 | 용도 |
+|------|------|------|
+| `router.md` | SYSTEM, AGENTIC_SUFFIX | AgenticLoop 자율 실행 |
+| `analyst.md` | SYSTEM, USER | 4 Analyst 병렬 분석 |
+| `evaluator.md` | SYSTEM, USER | 3 Evaluator 14축 평가 |
+| `synthesizer.md` | SYSTEM, USER | 최종 내러티브 + 원인 분류 |
+| `biasbuster.md` | SYSTEM, USER | 인지 편향 탐지 |
+| `commentary.md` | SYSTEM, USER | 사용자 대면 코멘터리 |
+| `cross_llm.md` | SYSTEM, RESCORE, DUAL_VERIFY | Cross-LLM 교차 검증 |
+
+---
+
+## 3. 6단계 조합 파이프라인 (ADR-007)
+
+프롬프트는 로딩 후 바로 LLM에 전달되지 않습니다. `PromptAssembler`가 6단계를 거쳐 최종 프롬프트를 조합합니다.
+
+```
+Base Template (.md)
+  ↓ Phase 1: Prompt Overrides (append/replace)
+  ↓ Phase 2: Skill Fragment Injection (max 3, 500자/skill)
+  ↓ Phase 3: Memory Context Injection (max 300자)
+  ↓ Phase 4: Extra Instructions — Bootstrap (max 5, 100자/inst)
+  ↓ Phase 5: Token Budget Enforcement (hard limit 6000자)
+  ↓ Phase 6: Hash + Hook Event
+  → AssembledPrompt (system, user, assembled_hash, fragments_used)
+```
+
+### 조합 결과 스키마
+
+```python
+# core/llm/prompt_assembler.py
+class AssembledPrompt(frozen=True):
+    system: str              # 최종 조합된 시스템 프롬프트
+    user: str                # 사용자 프롬프트 (보통 변경 없음)
+    assembled_hash: str      # SHA-256[:12] of (system + user)
+    base_template_hash: str  # 원본 템플릿의 해시
+    fragment_count: int      # 주입된 프래그먼트 수
+    total_chars: int         # 총 문자 수
+    fragments_used: list[str]  # 사용된 프래그먼트 목록
+```
+
+> 조합 결과를 `frozen=True` 데이터클래스로 만든 이유는 **불변성 보장**입니다. 조합된 프롬프트가 LLM 호출 직전에 변조되면 재현이 불가능합니다. `assembled_hash`로 어떤 프롬프트가 사용되었는지 사후 추적할 수 있습니다.
+
+### Phase 2: 스킬 주입
+
+스킬은 `.claude/skills/` 디렉토리에 YAML frontmatter + Markdown body 형태로 정의됩니다.
+
+```yaml
+---
+name: "geode-analysis-tuning"
+node: "analyst"
+type: "game_mechanics"
+priority: 10
+version: "1.0"
+role: "system"
+enabled: true
+---
+## Pattern Recognition
+When analyzing combat systems, look for Souls-like mechanics.
+```
+
+PromptAssembler는 `(node, role_type)` 매칭으로 해당 스킬을 찾아 시스템 프롬프트에 `## Skill: {name}` 헤더와 함께 추가합니다. `max_skills_per_node=3`으로 제한하여 컨텍스트 폭발을 방지합니다.
+
+### Phase 5: 토큰 예산
+
+```python
+# 경고 임계값과 하드 리밋
+prompt_warning_chars = 4000   # 초과 시 로그 경고
+prompt_hard_limit_chars = 6000  # 초과 시 시스템 프롬프트 절삭
+```
+
+> Claude Opus 4.6의 컨텍스트 윈도우는 충분하지만, 프롬프트가 길면 **주의력 분산(attention dilution)**이 발생합니다. 6000자 하드 리밋은 프롬프트의 지시 밀도를 유지하기 위한 설계 제약입니다.
+
+---
+
+## 4. Clean Context — 앵커링 방지 격리
+
+4명의 Analyst가 동일한 IP를 평가할 때, 한 Analyst의 점수가 다른 Analyst의 판단에 영향을 주면 **앵커링 편향(anchoring bias)**이 발생합니다.
+
+### 격리 메커니즘
+
+```python
+# core/nodes/analysts.py — Send API 호출 전
+base = {k: v for k, v in state.items()
+        if k not in ("analyses", "_analyst_type")}
+Send("analyst", {**base, "_analyst_type": analyst_type})
+```
+
+> `analyses` 키를 제거하여 각 Analyst가 다른 Analyst의 결과를 볼 수 없게 합니다. LangGraph의 `Send()` API가 병렬 실행을 보장하므로, 실행 순서에 의한 정보 누출도 발생하지 않습니다.
+
+### 프롬프트 수준 격리
+
+Analyst 시스템 프롬프트에도 명시적 격리 지시가 포함됩니다.
+
+```
+# analyst.md — SYSTEM
+Evaluate this IP from the perspective of {analyst_type}.
+Do NOT reference other analysts or their scores.
+Your evaluation must be independent.
+```
+
+### 앵커링 탐지 (BiasBuster)
+
+격리가 실패했는지 사후 검증합니다.
+
+```python
+# Coefficient of Variation(변동계수) 기반 앵커링 탐지
+CV = std / mean
+anchoring_bias = CV < 0.05 and n >= 4
+```
+
+> CV가 0.05 미만이면 4명의 Analyst가 거의 같은 점수를 냈다는 의미입니다. 독립 평가인데 점수가 이렇게 밀집되는 것은 통계적으로 의심스럽습니다. 이 경우 `anchoring_bias` 플래그가 활성화되어 전체 LLM BiasBuster 검사를 트리거합니다.
+
+---
+
+## 5. 동적 축 주입 — YAML에서 루브릭으로
+
+Evaluator는 14개 축(axis)에 대해 1-5점 루브릭 평가를 수행합니다. 축 정의와 앵커 기준은 코드가 아닌 **YAML**에서 관리됩니다.
+
+### YAML 구조
+
+```yaml
+# core/config/evaluator_axes.yaml
+evaluator_axes:
+  quality_judge:
+    description: "Game Quality Evaluator"
+    axes:
+      a_score: "Core Mechanics potential"
+      b_score: "IP Integration depth"
+      c_score: "Gameplay Depth"
+      # ... 5 more axes
+    rubric:
+      a_score:
+        "1": "기본 조작 불량"
+        "2": "장르 이하"
+        "3": "장르 평균"
+        "4": "장르 이상"
+        "5": "혁신적 메카닉"
+```
+
+### 주입 과정
+
+YAML → `_format_axes_schema()` → `{axes_schema}` 플레이스홀더 → Evaluator 시스템 프롬프트:
+
+```
+## Required axes (respond with exactly these keys):
+"a_score": <float 1-5 — Core Mechanics potential>,
+"b_score": <float 1-5 — IP Integration depth>,
+...
+```
+
+YAML → `_format_rubric_anchors()` → `{rubric_anchors}` 플레이스홀더:
+
+```
+## Rubric Anchors
+- a_score: 1=기본 조작 불량, 2=장르 이하, 3=장르 평균, 4=장르 이상, 5=혁신적 메카닉
+```
+
+> 축 정의를 YAML로 분리한 이유는 **도메인 교체**입니다. `DomainPort` 프로토콜을 통해 게임 IP가 아닌 다른 도메인(예: 연구 논문 평가)으로 전환할 때 YAML 파일만 교체하면 Evaluator 프롬프트가 자동으로 새 축을 사용합니다.
+
+### 축 버전 해싱
+
+```python
+AXES_VERSIONS: dict[str, str] = {
+    "EVALUATOR_AXES": _hash_axes(EVALUATOR_AXES),
+    "PROSPECT_EVALUATOR_AXES": _hash_axes(PROSPECT_EVALUATOR_AXES),
+    "ANALYST_SPECIFIC": _hash_axes(ANALYST_SPECIFIC),
+}
+```
+
+축 데이터도 해싱하여 프롬프트와 동일한 무결성 검증 체계에 포함됩니다.
+
+---
+
+## 6. 프롬프트 캐싱 — 반복 호출 비용 절감
+
+4명의 Analyst가 동일한 시스템 프롬프트를 사용합니다. Anthropic의 프롬프트 캐싱을 활용하면 2번째 호출부터 입력 토큰 비용이 90% 절감됩니다.
+
+### 구현
+
+```python
+# core/llm/client.py
+def _system_with_cache(system: str) -> list[TextBlockParam]:
+    return [
+        TextBlockParam(
+            type="text",
+            text=system,
+            cache_control={"type": "ephemeral"},
+        )
+    ]
+```
+
+> `ephemeral` 캐시는 5분간 유지됩니다. 4명의 Analyst는 수 초 간격으로 호출되므로 첫 호출의 캐시가 나머지 3회에 적중합니다.
+
+### 비용 절감 계산
+
+| 호출 | 캐시 | 입력 토큰 비용 | 비고 |
+|------|------|----------------|------|
+| Analyst 1 | Creation | 1.25x | 캐시 생성 비용 |
+| Analyst 2 | Read | 0.10x | 캐시 적중 |
+| Analyst 3 | Read | 0.10x | 캐시 적중 |
+| Analyst 4 | Read | 0.10x | 캐시 적중 |
+| **합계** | | **1.55x** | 캐시 없이 4.0x 대비 **61% 절감** |
+
+3명의 Evaluator도 유사한 시스템 프롬프트 구조를 공유하므로 추가 절감이 발생합니다.
+
+---
+
+## 7. 무결성 검증 — SHA-256 해시 핀닝
+
+프롬프트는 LLM 출력의 품질을 결정하는 핵심 요소입니다. 의도하지 않은 프롬프트 변경은 분석 결과의 일관성을 깨뜨립니다. GEODE는 Karpathy P4(Ratchet Mechanism) 패턴을 적용하여 프롬프트 변경을 CI 게이트에서 감지합니다.
+
+### 해시 계산
+
+```python
+# core/llm/prompts/__init__.py
+def _hash_prompt(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:12]
+
+PROMPT_VERSIONS: dict[str, str] = {
+    "ANALYST_SYSTEM": _hash_prompt(ANALYST_SYSTEM),
+    "ANALYST_USER": _hash_prompt(ANALYST_USER),
+    # ... 20개 프롬프트 × 12자리 해시
+}
+```
+
+### 핀 등록
+
+```python
+_PINNED_HASHES: dict[str, str] = {
+    "AGENTIC_SUFFIX": "8ec998fdf916",
+    "ANALYST_SYSTEM": "924433f5bf11",
+    "EVALUATOR_AXES": "0d82eb1aa5b4",
+    # ... 20개 항목
+}
+```
+
+> 핀 해시는 **하드코딩**입니다. 프롬프트를 의도적으로 변경하면 개발자가 이 값을 함께 갱신해야 합니다. 갱신 없이 프롬프트만 변경하면 CI 테스트가 실패합니다.
+
+### CI 테스트
+
+```python
+def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
+    """런타임 해시를 핀과 비교. 불일치 시 drift 목록 반환."""
+    drifted = []
+    for name, pinned in _PINNED_HASHES.items():
+        computed = PROMPT_VERSIONS.get(name, "")
+        if computed != pinned:
+            drifted.append(f"{name}: pinned={pinned} computed={computed}")
+    if drifted and raise_on_drift:
+        raise RuntimeError(f"Prompt drift detected: {drifted}")
+    return drifted
+```
+
+```python
+# tests/test_karpathy_prompt_hardening.py
+class TestPromptDriftDetection:
+    def test_no_drift_on_clean_state(self):
+        drifted = verify_prompt_integrity()
+        assert drifted == [], f"Unexpected prompt drift: {drifted}"
+```
+
+> 이 테스트는 매 PR의 CI에서 실행됩니다. 프롬프트 `.md` 파일을 수정했는데 핀 해시를 갱신하지 않으면 테스트가 실패하며, 의도치 않은 프롬프트 변경이 main 브랜치에 도달하는 것을 방지합니다.
+
+---
+
+## 8. Structured Output — 자유 텍스트의 종말
+
+프롬프트의 출력을 자유 텍스트로 받으면 JSON 파싱 실패, 키 누락, 타입 불일치 등의 문제가 발생합니다. GEODE는 Anthropic의 `messages.parse()`와 Pydantic 모델을 결합하여 **구조화된 출력**을 강제합니다.
+
+### Pydantic 모델 기반 파싱
+
+```python
+# core/llm/client.py
+def call_llm_parsed(
+    system: str,
+    user: str,
+    response_model: type[T],
+    **kwargs,
+) -> T:
+    """Anthropic SDK messages.parse() — 타입 안전 응답."""
+    return client.messages.parse(
+        model=model,
+        system=_system_with_cache(system),
+        messages=[{"role": "user", "content": user}],
+        response_model=response_model,
+    )
+```
+
+### Evaluator별 타입 모델
+
+```python
+# core/state.py
+class QualityJudgeAxes(BaseModel):
+    a_score: float = Field(ge=1.0, le=5.0)  # Core Mechanics
+    b_score: float = Field(ge=1.0, le=5.0)  # IP Integration
+    # ... 8축 각각 [1.0, 5.0] 범위 강제
+
+class HiddenValueAxes(BaseModel):
+    d_score: float = Field(ge=1.0, le=5.0)  # Discovery Gap
+    e_score: float = Field(ge=1.0, le=5.0)  # Exploitation Gap
+    f_score: float = Field(ge=1.0, le=5.0)  # Fandom Resilience
+```
+
+> Evaluator마다 다른 Pydantic 모델을 사용합니다. `quality_judge`가 8개 축을, `hidden_value`가 3개 축을 반환해야 하는데, 단일 모델로는 이를 표현할 수 없습니다. 모델이 축 이름과 범위를 강제하므로 LLM이 잘못된 키를 반환하거나 범위를 벗어난 점수를 줄 수 없습니다.
+
+### 레거시 JSON 추출 (Fallback)
+
+```python
+def call_llm_json(system: str, user: str, **kwargs) -> dict[str, Any]:
+    """raw text → JSON 추출 (레거시 호환)."""
+    text = call_llm(system, user, **kwargs)
+    # 코드블록, JSON 라인, 부분 JSON 등 다양한 포맷에서 추출
+```
+
+> Structured Output이 실패하는 경우(API 버전 불일치, 모델 미지원 등)를 위한 fallback입니다. 실제 프로덕션에서는 99% 이상 `call_llm_parsed`를 사용합니다.
+
+---
+
+## 9. 마무리
+
+### 핵심 정리
+
+| 항목 | 값 |
+|------|-----|
+| 템플릿 파일 | 7개 `.md` + 1개 YAML (축 정의) |
+| 프롬프트 상수 | 20개 (PROMPT_VERSIONS에 등록) |
+| 변수 플레이스홀더 | 50+ 고유 변수 |
+| 조합 단계 | 6 Phase (Override → Skill → Memory → Bootstrap → Budget → Hash) |
+| 캐시 전략 | Anthropic ephemeral (5분), 4 Analyst 호출에서 61% 절감 |
+| 무결성 검증 | SHA-256[:12] 핀 해싱, CI 테스트 게이트 |
+| 앵커링 방지 | Send API Clean Context + BiasBuster CV 탐지 |
+| 출력 구조화 | Pydantic 모델 기반 `messages.parse()` + JSON fallback |
+
+### 설계 원칙
+
+1. **프롬프트는 코드다**: 버전 관리, 해시 검증, CI 게이트를 코드와 동일하게 적용합니다.
+2. **조합은 결정적이다**: 같은 입력(스킬, 메모리, 부트스트랩)이면 같은 프롬프트가 생성됩니다. `assembled_hash`로 재현 가능합니다.
+3. **격리는 구조적이다**: 프롬프트 수준 지시(텍스트)와 데이터 수준 격리(Send API state 필터링)를 이중으로 적용합니다.
+4. **확장은 주입으로**: 프롬프트 본문을 수정하지 않고 스킬, 메모리, 부트스트랩을 주입하여 동작을 변경합니다.
+
+### 체크리스트
+
+- [x] `.md` 섹션 기반 템플릿 로더
+- [x] 6단계 PromptAssembler (ADR-007)
+- [x] Clean Context 앵커링 방지 (Send API + 프롬프트 지시)
+- [x] YAML 축 정의 → 동적 루브릭 주입
+- [x] Anthropic ephemeral 프롬프트 캐싱
+- [x] SHA-256 핀 해싱 + CI drift 테스트
+- [x] Pydantic Structured Output + JSON fallback
+- [x] Hook 이벤트 관측성 (PROMPT_ASSEMBLED)

--- a/docs/blogs/31-hook-system-event-driven-orchestration.md
+++ b/docs/blogs/31-hook-system-event-driven-orchestration.md
@@ -1,0 +1,613 @@
+# GEODE Hook System — 27개 이벤트로 파이프라인을 관통하는 이벤트 버스
+
+> Date: 2026-03-16 | Author: geode-team | Tags: [hooks, event-driven, orchestration, plugin, bootstrap, stuck-detection, run-log, pub-sub]
+
+## 목차
+
+1. [도입 — 노드 사이의 보이지 않는 연결](#1-도입--노드-사이의-보이지-않는-연결)
+2. [27개 이벤트 — 전체 분류 체계](#2-27개-이벤트--전체-분류-체계)
+3. [HookSystem — 우선순위 기반 동기 실행](#3-hooksystem--우선순위-기반-동기-실행)
+4. [파이프라인 관통 — 노드 래핑 패턴](#4-파이프라인-관통--노드-래핑-패턴)
+5. [Bootstrap — 실행 전 컨텍스트 주입](#5-bootstrap--실행-전-컨텍스트-주입)
+6. [소비자들 — 로그, 탐지, 메모리, 자동화](#6-소비자들--로그-탐지-메모리-자동화)
+7. [플러그인 확장 — YAML과 클래스 기반 디스커버리](#7-플러그인-확장--yaml과-클래스-기반-디스커버리)
+8. [합성 패턴 — 팬아웃, 체이닝, 루프백](#8-합성-패턴--팬아웃-체이닝-루프백)
+9. [왜 Sync인가 — async 전환 시도와 좌절](#9-왜-sync인가--async-전환-시도와-좌절)
+10. [서브에이전트와 Hook의 관계 — as_completed 패턴](#10-서브에이전트와-hook의-관계--as_completed-패턴)
+11. [마무리](#11-마무리)
+
+---
+
+## 1. 도입 — 노드 사이의 보이지 않는 연결
+
+GEODE의 LangGraph 파이프라인은 8개 노드가 순차/병렬로 실행됩니다. 각 노드는 자신의 출력만 상태에 기록하고, 다른 노드의 내부 동작을 알지 못합니다. 이것이 Clean Architecture의 핵심입니다.
+
+그러나 프로덕션 환경에서는 노드 **사이**에서 일어나야 할 일이 있습니다.
+
+| 요구 사항 | 노드 안에서 처리? | 문제 |
+|----------|-----------------|------|
+| Analyst 실행 시간 로깅 | 가능 | 모든 노드에 로깅 코드 중복 |
+| Scoring 후 drift 감지 | 가능 | scoring.py가 CUSUM 의존 |
+| 파이프라인 종료 후 메모리 저장 | 가능 | synthesizer.py가 memory 의존 |
+| 노드 실행 전 프롬프트 오버라이드 | 불가능 | 노드 시작 **전**에 개입 필요 |
+
+노드에 이 로직을 직접 넣으면 **순환 의존(circular dependency)**이 발생합니다. scoring 노드가 drift 감지를 알아야 하고, 감지 결과가 다시 scoring에 영향을 주는 구조입니다.
+
+Hook System은 이 문제를 **이벤트 기반 pub/sub**로 해결합니다. 노드는 이벤트를 **발행(publish)**만 하고, 누가 구독(subscribe)하는지 알지 못합니다.
+
+```
+Node(scoring) → emit(SCORING_COMPLETE) → ?
+                                         ├─ RunLog: 로깅
+                                         ├─ StuckDetector: 완료 마킹
+                                         └─ DriftDetector: CUSUM 검사
+```
+
+---
+
+## 2. 27개 이벤트 — 전체 분류 체계
+
+```python
+# core/orchestration/hooks.py
+class HookEvent(Enum):
+    # Pipeline (3)
+    PIPELINE_START = "pipeline_start"
+    PIPELINE_END = "pipeline_end"
+    PIPELINE_ERROR = "pipeline_error"
+
+    # Node (4)
+    NODE_BOOTSTRAP = "node_bootstrap"
+    NODE_ENTER = "node_enter"
+    NODE_EXIT = "node_exit"
+    NODE_ERROR = "node_error"
+
+    # Analysis (3)
+    ANALYST_COMPLETE = "analyst_complete"
+    EVALUATOR_COMPLETE = "evaluator_complete"
+    SCORING_COMPLETE = "scoring_complete"
+
+    # Verification (2)
+    VERIFICATION_PASS = "verification_pass"
+    VERIFICATION_FAIL = "verification_fail"
+
+    # Automation (6)
+    DRIFT_DETECTED = "drift_detected"
+    OUTCOME_COLLECTED = "outcome_collected"
+    MODEL_PROMOTED = "model_promoted"
+    SNAPSHOT_CAPTURED = "snapshot_captured"
+    TRIGGER_FIRED = "trigger_fired"
+    POST_ANALYSIS = "post_analysis"
+
+    # Memory (4)
+    MEMORY_SAVED = "memory_saved"
+    RULE_CREATED = "rule_created"
+    RULE_UPDATED = "rule_updated"
+    RULE_DELETED = "rule_deleted"
+
+    # Prompt (2)
+    PROMPT_ASSEMBLED = "prompt_assembled"
+    PROMPT_DRIFT_DETECTED = "prompt_drift_detected"
+
+    # SubAgent (3)
+    SUBAGENT_STARTED = "subagent_started"
+    SUBAGENT_COMPLETED = "subagent_completed"
+    SUBAGENT_FAILED = "subagent_failed"
+```
+
+> 27개 이벤트를 8개 카테고리로 분류한 이유는 **관심사 분리**입니다. RunLog는 모든 이벤트를 구독하지만, DriftDetector는 `SCORING_COMPLETE`만, BootstrapManager는 `NODE_BOOTSTRAP`만 구독합니다. 각 소비자가 자신에게 필요한 이벤트만 선택적으로 수신합니다.
+
+| 카테고리 | 이벤트 수 | 발행자 | 대표 소비자 |
+|---------|----------|--------|-----------|
+| Pipeline | 3 | `_make_hooked_node` | RunLog, StuckDetector |
+| Node | 4 | `_make_hooked_node` | BootstrapManager, RunLog |
+| Analysis | 3 | `_make_hooked_node` | DriftDetector |
+| Verification | 2 | `_verification_node` | TriggerManager |
+| Automation | 6 | TriggerManager, DriftDetector | RunLog |
+| Memory | 4 | ProjectMemory | RunLog |
+| Prompt | 2 | PromptAssembler | Drift 감사 |
+| SubAgent | 3 | SubAgentManager | RunLog, HookSystem |
+
+---
+
+## 3. HookSystem — 우선순위 기반 동기 실행
+
+### 핵심 인터페이스
+
+```python
+# core/infrastructure/ports/hook_port.py
+@runtime_checkable
+class HookSystemPort(Protocol):
+    def trigger(self, event: Enum, data: dict[str, Any]) -> None: ...
+    def register(self, event: Enum, handler: Callable,
+                 *, name: str = "", priority: int = 50) -> None: ...
+    def unregister(self, event: Enum, name: str) -> bool: ...
+```
+
+> `HookSystemPort`를 Protocol로 정의한 이유는 Port/Adapter 패턴입니다. 테스트에서 `MockHookSystem`으로 교체하거나, 향후 async 구현으로 전환할 때 소비자 코드를 변경하지 않아도 됩니다.
+
+### 구현 — 우선순위 정렬 + 에러 격리
+
+```python
+# core/orchestration/hooks.py
+class HookSystem:
+    def trigger(self, event: HookEvent, data: dict[str, Any]) -> list[HookResult]:
+        results: list[HookResult] = []
+        for hook in sorted(self._hooks.get(event, []), key=lambda h: h.priority):
+            try:
+                hook.handler(event, data)
+                results.append(HookResult(success=True, event=event,
+                                         handler_name=hook.name))
+            except Exception as exc:
+                log.warning("Hook '%s' failed on %s: %s", hook.name, event.value, exc)
+                results.append(HookResult(success=False, event=event,
+                                         handler_name=hook.name, error=str(exc)))
+        return results
+```
+
+> 두 가지 핵심 설계 결정이 있습니다. 첫째, **동기 실행**입니다. 핸들러가 순서대로 실행되므로 priority 50의 RunLog가 priority 80의 Snapshot보다 먼저 기록됩니다. 비동기로 전환하면 실행 순서를 보장할 수 없습니다. 둘째, **에러 격리**입니다. 한 핸들러의 예외가 나머지 핸들러와 파이프라인 자체에 영향을 주지 않습니다.
+
+---
+
+## 4. 파이프라인 관통 — 노드 래핑 패턴
+
+모든 노드는 `_make_hooked_node()` 래퍼를 통해 실행됩니다. 이 함수가 노드 실행 전후에 Hook 이벤트를 발행합니다.
+
+```python
+# core/graph.py — _make_hooked_node() (simplified)
+def _make_hooked_node(node_fn, node_name, hooks, bootstrap_mgr):
+    def _wrapped(state: GeodeState) -> dict[str, Any]:
+        hook_data = {"node": node_name, "ip_name": state.get("ip_name", "")}
+
+        # Phase 1: Bootstrap (pre-execution injection)
+        if bootstrap_mgr:
+            ctx = bootstrap_mgr.prepare_node(node_name, ...)
+            if ctx.skip:
+                return {}
+            state = bootstrap_mgr.apply_context(state, ctx)
+
+        # Phase 2: NODE_ENTER
+        hooks.trigger(HookEvent.NODE_ENTER, hook_data)
+        if node_name == "router":
+            hooks.trigger(HookEvent.PIPELINE_START, hook_data)
+
+        # Phase 3: Execute
+        start = time.time()
+        result = node_fn(state)
+
+        # Phase 4: NODE_EXIT + completion events
+        hook_data["duration_ms"] = (time.time() - start) * 1000
+        hooks.trigger(HookEvent.NODE_EXIT, hook_data)
+
+        if node_name in _NODE_COMPLETION_EVENTS:
+            hooks.trigger(_NODE_COMPLETION_EVENTS[node_name], hook_data)
+
+        # Phase 5: Special — scoring drift hint, verification pass/fail
+        if node_name == "scoring" and result.get("final_score", 0) > 0:
+            hook_data["drift_scan_hint"] = True
+        if node_name == "synthesizer":
+            hooks.trigger(HookEvent.PIPELINE_END, hook_data)
+
+        return result
+
+    return _wrapped
+```
+
+> 노드 함수 `node_fn`은 Hook의 존재를 전혀 모릅니다. `_make_hooked_node`가 데코레이터처럼 노드를 감싸서 라이프사이클 이벤트를 주입합니다. 이 패턴 덕분에 `analysts.py`나 `scoring.py`에 Hook 관련 코드가 단 한 줄도 없습니다.
+
+### 노드별 이벤트 발행 맵
+
+```mermaid
+graph LR
+    R["router"] -->|NODE_ENTER| H["HookSystem"]
+    R -->|PIPELINE_START| H
+    R -->|NODE_EXIT| H
+
+    A["analyst ×4"] -->|NODE_ENTER| H
+    A -->|NODE_EXIT| H
+    A -->|ANALYST_COMPLETE| H
+
+    E["evaluator ×3"] -->|NODE_EXIT| H
+    E -->|EVALUATOR_COMPLETE| H
+
+    S["scoring"] -->|SCORING_COMPLETE| H
+    S -->|drift_scan_hint| H
+
+    V["verification"] -->|VERIFICATION_PASS| H
+    V -->|VERIFICATION_FAIL| H
+
+    SY["synthesizer"] -->|PIPELINE_END| H
+
+    style H fill:#1e293b,stroke:#f59e0b,color:#e2e8f0
+```
+
+---
+
+## 5. Bootstrap — 실행 전 컨텍스트 주입
+
+`NODE_BOOTSTRAP`는 다른 이벤트와 근본적으로 다릅니다. 다른 이벤트가 **관찰(observation)**을 위한 것이라면, Bootstrap은 **개입(intervention)**을 위한 것입니다.
+
+### BootstrapContext
+
+```python
+# core/orchestration/bootstrap.py
+@dataclass
+class BootstrapContext:
+    node_name: str
+    ip_name: str
+    prompt_overrides: dict[str, str] = field(default_factory=dict)
+    extra_instructions: list[str] = field(default_factory=list)
+    parameters: dict[str, Any] = field(default_factory=dict)
+    skip: bool = False  # True이면 노드 실행 자체를 건너뜀
+```
+
+> `BootstrapContext`는 **mutable(변경 가능)**입니다. Hook 핸들러가 이 객체를 참조로 받아 in-place로 수정합니다. 이 설계는 여러 핸들러가 독립적으로 ctx에 지시를 추가할 수 있게 합니다.
+
+### 사용 시나리오
+
+```python
+# 특정 IP에 대해 Analyst 온도 조정
+def custom_bootstrap(ctx: BootstrapContext) -> None:
+    if ctx.ip_name == "Berserk" and ctx.node_name == "analyst":
+        ctx.parameters["temperature"] = 0.1  # 더 결정적으로
+        ctx.extra_instructions.append("Focus on Souls-like mechanics.")
+
+bootstrap_mgr.register_override("analyst", custom_bootstrap)
+```
+
+> `register_override(node_name, fn)`은 내부적으로 `NODE_BOOTSTRAP` 이벤트에 핸들러를 등록하되, 핸들러 안에서 `data["node"] != node_name`이면 early return합니다. 노드 이름 필터링을 캡슐화하여 사용자가 이벤트 필터링을 직접 구현할 필요가 없습니다.
+
+---
+
+## 6. 소비자들 — 로그, 탐지, 메모리, 자동화
+
+### RunLog — 전 이벤트 감사 로그
+
+```python
+# core/runtime.py — 모든 이벤트에 대해 등록
+for event in HookEvent:
+    hooks.register(event, run_log_handler, name="run_log_writer", priority=50)
+```
+
+RunLog는 **모든 27개 이벤트**를 구독합니다. JSONL 형식으로 디스크에 기록하며, 2MB 또는 2000줄 초과 시 자동 정리됩니다.
+
+```json
+{"event": "node_exit", "node": "analyst", "ip_name": "Berserk",
+ "duration_ms": 2341.5, "status": "ok", "run_id": "a1b2c3"}
+```
+
+> priority 50은 GEODE의 기본 핸들러 중 **가장 낮은** 우선순위입니다. 다른 핸들러(Snapshot 80, Memory 85)보다 먼저 실행되어 이벤트 발생 시점을 정확히 기록합니다.
+
+### StuckDetector — 데드락 감지
+
+```python
+# core/orchestration/stuck_detection.py
+hooks.register(HookEvent.NODE_ENTER, _on_enter, name="stuck_detector_enter", priority=90)
+hooks.register(HookEvent.NODE_EXIT, _on_exit, name="stuck_detector_exit", priority=90)
+hooks.register(HookEvent.NODE_ERROR, _on_error, name="stuck_detector_error", priority=90)
+```
+
+`NODE_ENTER`에서 타이머를 시작하고, `NODE_EXIT`이나 `NODE_ERROR`에서 타이머를 해제합니다. 2시간(기본값) 동안 EXIT이 오지 않으면 `PIPELINE_ERROR`를 발행합니다.
+
+> StuckDetector는 Hook을 **소비하면서 동시에 발행**합니다. NODE_ENTER를 소비하고, 타임아웃 시 PIPELINE_ERROR를 발행합니다. 이것이 Hook 시스템의 **체이닝(chaining)** 패턴입니다.
+
+### Memory Write-Back — L3 → L2 피드백
+
+```python
+# PIPELINE_END → memory_write_back (priority 85)
+def _pipeline_end_handler(event, data):
+    if data.get("dry_run"):
+        return  # dry-run에서는 메모리 저장 안 함
+    insight = f"{data['ip_name']}: {data['tier']} ({data['final_score']:.1f})"
+    project_memory.save_insight(insight)
+```
+
+> 파이프라인 결과가 자동으로 프로젝트 메모리(`.claude/MEMORY.md`)에 기록됩니다. 다음 분석 시 `memory_context`로 이전 결과를 참조할 수 있습니다. 이것이 L3(Orchestration) → L2(Memory) 피드백 루프의 구현입니다.
+
+### 기본 핸들러 전체 목록
+
+| 핸들러 | 이벤트 | Priority | 역할 |
+|--------|--------|----------|------|
+| `run_log_writer` | ALL (27) | 50 | JSONL 감사 로그 |
+| `stuck_detector_enter` | NODE_ENTER | 90 | 실행 타이머 시작 |
+| `stuck_detector_exit` | NODE_EXIT | 90 | 타이머 해제 |
+| `stuck_detector_error` | NODE_ERROR | 90 | 타이머 해제 |
+| `drift_auto_snapshot` | DRIFT_DETECTED | 80 | 자동 스냅샷 |
+| `drift_pipeline_trigger` | DRIFT_DETECTED | 70 | 후속 분석 트리거 |
+| `pipeline_end_snapshot` | PIPELINE_END | 80 | 최종 상태 스냅샷 |
+| `memory_write_back` | PIPELINE_END | 85 | 분석 인사이트 저장 |
+| `drift_logger` | DRIFT_DETECTED | 90 | Drift 로깅 |
+| `snapshot_logger` | SNAPSHOT_CAPTURED | 90 | 스냅샷 ID 로깅 |
+| `trigger_logger` | TRIGGER_FIRED | 90 | 트리거 로깅 |
+| `outcome_logger` | OUTCOME_COLLECTED | 90 | 피드백 로깅 |
+
+---
+
+## 7. 플러그인 확장 — YAML과 클래스 기반 디스커버리
+
+외부 개발자가 코어 코드를 수정하지 않고 Hook 핸들러를 추가할 수 있습니다.
+
+### YAML 기반 플러그인
+
+```yaml
+# plugins/slow_node_monitor/hook.yaml
+name: slow-node-monitor
+events:
+  - node_exit
+  - verification_fail
+priority: 75
+enabled: true
+handler: monitor.py
+```
+
+```python
+# plugins/slow_node_monitor/monitor.py
+def handle(event, data):
+    if event.value == "node_exit":
+        duration = data.get("duration_ms", 0)
+        if duration > 5000:
+            log.warning("Slow node: %s took %.1fs", data["node"], duration / 1000)
+```
+
+### 클래스 기반 플러그인
+
+```python
+# plugins/custom_analytics/hook.py
+class AnalyticsPlugin:
+    @property
+    def metadata(self) -> HookPluginMetadata:
+        return HookPluginMetadata(
+            name="analytics",
+            events=[HookEvent.PIPELINE_END, HookEvent.SCORING_COMPLETE],
+            priority=60,
+        )
+
+    def handle(self, event: HookEvent, data: dict[str, Any]) -> None:
+        if event == HookEvent.PIPELINE_END:
+            self._send_to_dashboard(data)
+```
+
+### 디스커버리 프로세스
+
+```python
+# core/orchestration/hook_discovery.py
+loader = HookPluginLoader()
+loader.load_from_dirs([Path("./plugins"), Path("~/.geode/plugins")])
+loader.register_all(hooks)  # 모든 플러그인의 핸들러를 HookSystem에 등록
+```
+
+> 디스커버리는 **lazy loading**입니다. `discover_hooks()`는 메타데이터만 파싱하고, `load_from_dirs()`에서 비로소 핸들러 모듈을 `importlib`로 로딩합니다. 비활성(`enabled: false`) 플러그인은 모듈 로딩조차 하지 않습니다.
+
+---
+
+## 8. 합성 패턴 — 팬아웃, 체이닝, 루프백
+
+### 팬아웃 — 하나의 이벤트, 다수의 소비자
+
+```
+PIPELINE_END
+  ├─ (priority 50) run_log_writer → JSONL 기록
+  ├─ (priority 80) pipeline_end_snapshot → 상태 스냅샷
+  └─ (priority 85) memory_write_back → MEMORY.md 갱신
+```
+
+세 핸들러가 순서대로 실행됩니다. RunLog가 먼저 기록하므로 스냅샷이나 메모리 저장 중 오류가 발생해도 이벤트 기록은 보존됩니다.
+
+### 체이닝 — 이벤트가 이벤트를 발행
+
+```
+SCORING_COMPLETE
+  → drift_scan_hint = True
+    → DriftDetector 검사
+      → DRIFT_DETECTED 발행
+        → drift_auto_snapshot → SNAPSHOT_CAPTURED
+        → drift_pipeline_trigger → 후속 분석 실행
+          → PIPELINE_END
+            → memory_write_back
+```
+
+> 체이닝은 **무한 루프 위험**이 있습니다. GEODE에서는 PIPELINE_END → 메모리 저장으로 체인이 종결되며, 메모리 저장은 MEMORY_SAVED 이벤트를 발행하지만 이를 구독하는 핸들러가 파이프라인을 재실행하지 않습니다. 체인의 종결 조건이 구조적으로 보장됩니다.
+
+### 의도적 미구현 — Hook 기반 루프백
+
+파이프라인의 verification → gather → signals 루프백은 **Hook이 아닌 LangGraph 조건부 엣지**로 구현됩니다.
+
+```python
+# core/graph.py — conditional edge
+graph.add_conditional_edges("verification", _should_loop_back,
+                           {"gather": "gather", "synthesizer": "synthesizer"})
+```
+
+> 루프백을 Hook으로 구현하면 `VERIFICATION_FAIL` → 핸들러가 상태를 수정 → 파이프라인 재실행이라는 복잡한 제어 흐름이 생깁니다. LangGraph의 조건부 엣지는 이 흐름을 그래프 토폴로지로 선언적으로 표현합니다. Hook은 **관찰과 부수 효과**에, LangGraph는 **제어 흐름**에 사용하는 것이 GEODE의 원칙입니다.
+
+---
+
+## 9. Sync Hook + Async 노드 — 프론티어 코드베이스에서 증류한 결론
+
+### 전제 정정: LangGraph는 async 노드를 지원한다
+
+이전에 "LangGraph 노드는 sync여야 한다"고 가정했으나 직접 검증 결과 **async def 노드 + Send API + .astream()이 완전히 작동**합니다.
+
+```python
+# 검증: Send + async 4개 병렬 → 3.9x speedup
+async def async_worker(state):
+    await asyncio.sleep(0.1)
+    return {'values': [f'{state["_worker_type"]}_done']}
+
+def fan_out(state):
+    return [Send('worker', {'_worker_type': f'w_{i}', 'values': []}) for i in range(4)]
+
+# 결과: 0.103초 (순차 0.4초 대비 3.9x)
+```
+
+P3 asyncio 시도(v0.11.0)가 리버트된 이유는 LangGraph 제약이 아니라 **Big-Bang 전환의 파급 범위**(9개 노드 + 2000 테스트 일괄 변경)였습니다.
+
+### 그렇다면 Hook은 왜 sync로 남기는가
+
+핵심 질문은 "LangGraph가 async를 지원하니 Hook도 async로 바꿔야 하지 않는가"입니다. GitHub 코드베이스 4곳을 조사한 결과, 답은 **아니오**입니다.
+
+### 프론티어 코드베이스 실증 분석
+
+**Anthropic Claude Agent SDK** ([github.com/anthropics/claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python))
+
+에이전트 루프는 async (`async for message in query()`), 도구 함수도 async (`async def greet_user`). 그러나 **Hook은 sync 콜백**입니다.
+
+```python
+# Claude Agent SDK — Hook은 sync function
+async def check_bash_command(input_data, tool_use_id, context):
+    # sync 로직으로 permission 결정
+    return {"hookSpecificOutput": {"permissionDecision": "deny"}}
+
+options = ClaudeAgentOptions(
+    hooks={"PreToolUse": [HookMatcher(matcher="Bash", hooks=[check_bash_command])]}
+)
+```
+
+> Anthropic이 공식 SDK에서 "async 루프 + sync Hook" 패턴을 채택한 것은 **Hook의 역할이 관찰/제어이지 I/O가 아니기 때문**입니다. permission 결정, 로깅, 메트릭 수집은 메모리 연산이라 async의 이점이 없습니다.
+
+**OpenAI Codex** ([github.com/openai/codex](https://github.com/openai/codex))
+
+Rust tokio 기반 async. 도구를 `FuturesOrdered`로 병렬 디스패치하지만, PR #10505에서 3+ 병렬 tool_call 시 **race condition으로 응답 유실** 버그(#8479)가 발견되었습니다.
+
+```
+// Codex 버그: ResponseEvent::Completed가 tool future 완료 전에 도착
+Stream completed → loop breaks → drain_in_flight 호출
+  → 일부 future 결과 누락 → 세션 복구 불가
+```
+
+> async 병렬 도구 실행의 실전 위험을 보여줍니다. completion 보장 없이 async 병렬을 도입하면 데이터 유실이 발생합니다.
+
+**CrewAI** ([github.com/crewAIInc/crewAI](https://github.com/crewAIInc/crewAI))
+
+태스크별 `async_execution=True` 플래그로 opt-in 병렬. `asyncio.gather()`로 여러 Crew를 동시 실행.
+
+**LangGraph** ([github.com/langchain-ai/langgraph](https://github.com/langchain-ai/langgraph))
+
+Superstep 모델로 동일 depth 노드를 자동 병렬 실행. `max_concurrency` 설정으로 제어.
+
+### 프론티어 컨센서스
+
+| 프로젝트 | LLM 호출 | Hook/Event | 결론 |
+|---------|---------|-----------|------|
+| **Claude Agent SDK** | **async** | **sync** callback | 공식 패턴 |
+| **OpenAI Codex** | **async** | N/A | 병렬 race condition 경험 |
+| **CrewAI** | **async** | N/A | 플래그 기반 opt-in |
+| **LangGraph** | **async** 지원 | N/A | superstep 자동 병렬 |
+
+**모든 프론티어가 "LLM 호출 = async, Hook = sync"를 채택합니다.** Hook을 async로 바꾼 프로젝트는 없습니다.
+
+### GEODE의 결정
+
+ADR-009에서 단계적 전환을 결정했습니다:
+
+1. **Phase 1**: `acall_llm_parsed()` async 함수 추가 (기존 sync 유지)
+2. **Phase 2**: 9개 노드 `async def` + `graph.astream()` (feature flag)
+3. **Hook은 sync 유지**: 프론티어 컨센서스와 일치. async 노드 안에서 sync `hooks.trigger()` 호출은 안전
+
+```python
+# Phase 2 이후의 _make_hooked_node
+async def _wrapped(state):
+    hooks.trigger(HookEvent.NODE_ENTER, data)  # sync — 안전
+    result = await node_fn(state)              # async 노드
+    hooks.trigger(HookEvent.NODE_EXIT, data)   # sync — 안전
+    return result
+```
+
+> async 함수 안에서 sync 함수를 호출하는 것은 문제 없습니다 (반대가 문제). Python의 `await`는 코루틴에만 적용되고, 일반 함수 호출은 그대로 동기 실행됩니다. Claude Agent SDK가 이 패턴을 공식 채택한 것이 가장 강력한 근거입니다.
+
+---
+
+## 10. 서브에이전트와 Hook의 관계 — as_completed 패턴
+
+### 문제: 결과 수집의 직렬 블로킹
+
+서브에이전트의 LLM 호출은 `IsolatedRunner` 스레드로 병렬 실행됩니다. 그러나 결과 수집 루프가 제출 순서대로 블로킹하여 **관측성이 지연**되었습니다.
+
+```
+AS-IS (순차 블로킹):
+  wait(task1: 30초) → COMPLETED(task1)
+  wait(task2: 5초)  → COMPLETED(task2)  ← task2는 25초 전에 끝났지만 여기서야 훅 발행
+  wait(task3: 15초) → COMPLETED(task3)
+```
+
+task2가 5초에 끝나도, task1이 30초 걸리면 task2의 `SUBAGENT_COMPLETED` 훅이 30초 후에 발행됩니다. RunLog에 기록되는 타이밍이 실제 완료 시점과 최대 25초 차이가 납니다.
+
+### 해결: polling round-robin
+
+```python
+# core/cli/sub_agent.py — delegate() Phase 3
+pending: dict[str, SubTask] = {sid: task for task, sid in session_ids}
+
+while pending and time.time() < deadline:
+    completed_sids: list[str] = []
+    for sid in list(pending):
+        isolation = self._runner.get_result(sid)
+        if isolation is not None:
+            completed_sids.append(sid)
+            task = pending.pop(sid)
+            # 즉시 훅 발행 + on_progress 콜백
+            self._emit_hook(HookEvent.SUBAGENT_COMPLETED, task, ...)
+
+    if not completed_sids and pending:
+        time.sleep(poll_interval)  # 0.05초 → 최대 0.5초
+        poll_interval = min(poll_interval * 1.5, max_poll)
+```
+
+> `concurrent.futures.as_completed()` 대신 직접 polling을 구현한 이유: `IsolatedRunner`는 `Future`를 반환하지 않고 `session_id` 문자열을 반환합니다. 기존 API를 변경하지 않으면서 as_completed 의미론을 구현하기 위해 round-robin polling을 선택했습니다.
+
+```
+TO-BE (round-robin):
+  poll(1,2,3) → task2 완료! → COMPLETED(task2) 즉시 발행
+  poll(1,3)   → task3 완료! → COMPLETED(task3) 즉시 발행
+  poll(1)     → task1 완료! → COMPLETED(task1) 즉시 발행
+```
+
+### 성능 특성
+
+| 항목 | AS-IS | TO-BE |
+|------|-------|-------|
+| **관측성 지연** | 최대 `max(duration) - min(duration)` | 0 (완료 즉시 훅 발행) |
+| **on_progress 콜백** | 순차 | 완료 순 |
+| **CPU 오버헤드** | polling 없음 | 0.05-0.5초 간격 polling (무시 가능) |
+| **타임아웃 처리** | 개별 `_wait_for_result` | 글로벌 deadline + 일괄 FAILED |
+
+> 이 변경은 sync Hook의 한계를 우회합니다. 병렬 실행 자체(threading)는 유지하면서, 결과 **수집 순서만** 완료 순으로 바꿔 관측성 지연을 제거했습니다. Hook을 async로 바꿀 필요가 없습니다.
+
+---
+
+## 11. 마무리
+
+### 핵심 정리
+
+| 항목 | 값 |
+|------|-----|
+| 이벤트 수 | 27개 (8 카테고리) |
+| 실행 모델 | 동기, 우선순위 정렬, 에러 격리 |
+| 기본 핸들러 | 12+ (RunLog, StuckDetector, Drift, Snapshot, Memory 등) |
+| 플러그인 형식 | YAML + Class 기반, lazy loading |
+| 관측성 | JSONL RunLog (전 이벤트), HookResult 반환 |
+| 주입 패턴 | NODE_BOOTSTRAP → BootstrapContext (mutable, in-place) |
+| DI | HookSystemPort Protocol — 구현 교체 가능 |
+| 코드 규모 | 10+ 파일, ~4000 LOC |
+
+### 설계 원칙
+
+1. **노드는 Hook을 모른다**: 발행은 래퍼(`_make_hooked_node`)가 담당. 노드 코드에 Hook import 없음.
+2. **관찰과 제어의 분리**: Hook = 관찰 + 부수 효과. 제어 흐름 = LangGraph 조건부 엣지.
+3. **에러는 격리한다**: 핸들러 하나의 실패가 파이프라인을 멈추지 않음.
+4. **확장은 등록으로**: 코어 수정 없이 플러그인 디렉토리에 파일 추가만으로 확장.
+
+### 체크리스트
+
+- [x] 27개 HookEvent 전체 분류
+- [x] HookSystem 우선순위 + 에러 격리 구현
+- [x] `_make_hooked_node` 래핑 패턴
+- [x] BootstrapManager — NODE_BOOTSTRAP 개입
+- [x] RunLog 전 이벤트 감사 로그
+- [x] StuckDetector 데드락 감지
+- [x] Memory write-back L3→L2 피드백
+- [x] YAML/Class 기반 플러그인 디스커버리
+- [x] 팬아웃/체이닝 합성 패턴
+- [x] HookSystemPort Protocol DI
+- [x] LangGraph async 노드 지원 검증 (Send + async = 3.9x speedup)
+- [x] 프론티어 4곳 코드베이스 실증 ("LLM=async, Hook=sync" 컨센서스)
+- [x] 서브에이전트 결과 수집 as_completed 패턴 적용
+- [x] ADR-009 async 전환 전략 수립 (단계적 + feature flag)

--- a/docs/reports/signal-liveification.md
+++ b/docs/reports/signal-liveification.md
@@ -1,0 +1,101 @@
+# Signal Liveification — Implementation Report
+
+**Date**: 2026-03-16
+**Branch**: `feature/signal-liveification`
+**Status**: Complete
+
+## Summary
+
+MCP 기반 라이브 시그널 수집 시스템을 구현하여, fixture-only였던 signals 노드를
+MCP 어댑터 우선 호출 → fixture fallback 구조로 전환했다. `signal_source` 상태 필드로
+데이터 출처(live/mixed/fixture)를 추적한다.
+
+## Architecture
+
+```
+signals_node(state)
+    │
+    ▼
+Injected adapter? ──No──→ Load fixture → signal_source="fixture"
+    │
+   Yes
+    │
+    ▼
+CompositeSignalAdapter.fetch_signals(ip_name)
+    │
+    ├─ SteamMCPSignalAdapter  → Steam MCP server (player_count, review_score, review_count)
+    │
+    ├─ BraveSignalAdapter     → Brave Search MCP (snippets, urls, result_count)
+    │
+    └─ _enrichment_sources    → provenance list
+    │
+    ▼
+data keys >= 3? ──Yes──→ signal_source="live"
+    │
+   No (1-2 keys)
+    │
+    ▼
+Known fixture IP? ──Yes──→ Merge live + fixture → signal_source="mixed"
+    │
+   No
+    │
+    ▼
+signal_source="fixture" (fallback)
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/nodes/signals.py` | Modified — MCP adapter 우선 호출 로직, `signal_source` 반환, `set_signal_adapter()` DI |
+| `core/runtime.py` | Modified — `_build_signal_adapter()` 메서드 추가 (CompositeSignalAdapter 조립 + 주입) |
+| `core/state.py` | Modified — `signal_source` 필드 추가 (`Literal["live", "mixed", "fixture", "web_search"]`) |
+| `core/infrastructure/adapters/mcp/steam_adapter.py` | Modified — `SteamMCPSignalAdapter` MCP manager 모드 추가 |
+| `core/infrastructure/adapters/mcp/brave_adapter.py` | Modified — `BraveSignalAdapter` Brave Search 기반 시그널 추출 |
+| `core/infrastructure/adapters/mcp/composite_signal.py` | **NEW** — `CompositeSignalAdapter` 다중 어댑터 체이닝 |
+| `tests/test_signal_liveification.py` | **NEW** — 20 tests |
+| `CHANGELOG.md` | Updated |
+| `README.md` | Updated |
+
+## Signal Source Determination
+
+| Condition | signal_source | Description |
+|-----------|--------------|-------------|
+| MCP adapter returns >= 3 data keys | `live` | 충분한 라이브 데이터 |
+| MCP adapter returns 1-2 data keys + fixture 존재 | `mixed` | 라이브 + fixture 병합 (live overrides) |
+| MCP adapter 미설정 / unavailable / 에러 | `fixture` | fixture 자동 fallback |
+| Web search enrichment 경로 | `web_search` | (향후 확장) |
+
+## Design Decisions
+
+1. **DI via `set_signal_adapter()`**: `contextvars` 기반 주입으로 테스트에서 어댑터를 자유롭게 교체 가능. 프로덕션에서는 `GeodeRuntime._build_signal_adapter()`가 조립.
+
+2. **CompositeSignalAdapter 체이닝**: 개별 어댑터(Steam, Brave)를 합성하여 단일 인터페이스로 제공. `_enrichment_sources` 리스트로 어느 소스에서 데이터가 왔는지 추적.
+
+3. **Graceful degradation**: MCP 서버 미연결, 에러, 빈 결과 모두 fixture로 자동 fallback. 파이프라인은 항상 정상 완료.
+
+4. **Live override in mixed mode**: 동일 키가 live와 fixture 양쪽에 존재하면 live 값이 우선. fixture는 live에 없는 키만 보충.
+
+5. **Threshold 3 keys**: 데이터 키 3개 이상이면 "충분한 라이브 데이터"로 판정하여 fixture 병합 없이 진행.
+
+## Test Coverage
+
+20 tests across 7 test classes:
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| `TestLiveSignals` | 2 | CompositeSignalAdapter 라이브 시그널 수집 |
+| `TestFixtureFallback` | 3 | 어댑터 없음/unavailable/에러 시 fixture fallback |
+| `TestMixedSignals` | 2 | 부분 라이브 + fixture 병합, live override |
+| `TestSignalSourceTracking` | 4 | signal_source 필드 값 검증 (live/fixture/mixed) |
+| `TestCompositeSignalAdapter` | 4 | 다중 소스 병합, unavailable 건너뛰기, is_available |
+| `TestSteamMCPSignalAdapterManager` | 3 | MCP manager 모드 (healthy/unhealthy/error) |
+| `TestBraveSignalAdapter` | 3 | Brave Search 성공/unavailable/빈 결과 |
+
+## Quality Gates
+
+| Gate | Result |
+|------|--------|
+| `ruff check core/ tests/` | All checks passed |
+| `mypy core/` | Success: 132 source files |
+| `pytest tests/ -q` | 2226 passed, 19 deselected |


### PR DESCRIPTION
## 요약

5개 자율 에이전트 기능(Signal Liveification, Plan Auto-Execute, Dynamic Graph, Error Recovery, Goal Decomposition) 병렬 구현 후 순차 rebase/merge 과정에서 발생한 docs-sync 누락을 수정.

## 변경 사항

### 핵심
- `docs/reports/signal-liveification.md` 신규 생성 — 나머지 4개 리포트와 동일 형식
  - **왜?** 5개 기능 중 유일하게 리포트가 누락됨

### 부수 (수치/구조 정합)
- CLAUDE.md: Modules 133→134, Tests 2258+→2366+, HookSystem 27→30 (2곳)
  - **왜?** 5개 기능 병합으로 모듈/테스트/이벤트 수가 증가했으나 문서에 미반영
- README.md: Tests 2243+→2366+, Modules 132→134
  - **왜?** CLAUDE.md와 동일 사유
- CLAUDE.md/README.md 프로젝트 구조 트리: `error_recovery.py`, `goal_decomposer.py`, `CompositeSignalAdapter` 추가
  - **왜?** 신규 모듈이 구조 트리에 미반영

## 영향 범위

- 문서만 변경, 코드 변경 없음
- 기존 테스트/기능에 영향 없음

## 테스트

| 게이트 | 결과 |
|--------|------|
| ruff | All checks passed |
| mypy | 0 errors (134 files) |
| pytest | 2366 passed, 19 deselected |

## 검증 체크리스트

- [x] `docs/reports/` 5개 파일 확인
- [x] CLAUDE.md 수치 = 실제 값 일치
- [x] README.md 수치 = 실제 값 일치
- [x] HookSystem 이벤트 수 30 = `hooks.py` HookEvent 멤버 수 일치
- [x] 프로젝트 구조 트리에 신규 모듈 반영
- [x] Worktree 5개 정리 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)