### PR TITLE
docs: 5-feature 병합 후 docs-sync 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 133
-- **Tests**: 2258+
+- **Modules**: 134
+- **Tests**: 2366+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -39,7 +39,7 @@ uv run geode
 L0: CLI & AGENT      — Typer CLI, NL Router, AgenticLoop, SubAgentManager, Batch
 L1: INFRASTRUCTURE   — Ports (Protocol), ClaudeAdapter, OpenAIAdapter, MCP Adapters
 L2: MEMORY           — Organization > Project > Session (3-Tier + Hybrid L1/L2)
-L3: ORCHESTRATION    — HookSystem(27), TaskGraph DAG, PlanMode, CoalescingQueue, LaneQueue
+L3: ORCHESTRATION    — HookSystem(30), TaskGraph DAG, PlanMode, CoalescingQueue, LaneQueue
 L4: EXTENSIBILITY    — ToolRegistry(38+), PolicyChain, Skills, MCP Catalog(29), Reports
 L5: DOMAIN PLUGINS   — DomainPort Protocol, GameIPDomain, LangGraph StateGraph
 ```
@@ -140,6 +140,7 @@ core/
 │   ├── conversation.py  # Multi-turn sliding-window (max 20 turns)
 │   ├── batch.py         # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py      # Slash command dispatch (17 commands)
+│   ├── error_recovery.py # ErrorRecoveryStrategy (retry → alternative → fallback → escalate)
 │   └── search.py        # IP search engine (synonym expansion)
 ├── config.py            # Pydantic Settings (.env)
 ├── state.py             # GeodeState TypedDict + Pydantic models
@@ -169,7 +170,7 @@ core/
 │   ├── session_key.py   # Hierarchical key builder (ip:name:phase)
 │   └── context.py       # 3-tier context assembler
 ├── orchestration/
-│   ├── hooks.py         # HookSystem (27 events + SUBAGENT_* + async atrigger)
+│   ├── hooks.py         # HookSystem (30 events + async atrigger)
 │   ├── bootstrap.py     # Node bootstrap (pre-execution context injection)
 │   ├── goal_decomposer.py # GoalDecomposer (compound request → sub-goal DAG)
 │   ├── planner.py       # Planner (multi-step plan generation)
@@ -205,7 +206,7 @@ core/
 │   ├── ports/           # Protocol interfaces (LLM, Memory, Auth, Hook, Tool, DomainPort)
 │   └── adapters/
 │       ├── llm/         # ClaudeAdapter, OpenAIAdapter
-│       └── mcp/         # Steam, Brave, LinkedIn MCP adapters + catalog (29 entries)
+│       └── mcp/         # Steam, Brave, LinkedIn MCP adapters + CompositeSignalAdapter + catalog (29 entries)
 ├── tools/               # Tool Protocol + Registry + Policy + definitions.json
 ├── auth/                # API key rotation, cooldown, profiles
 ├── extensibility/       # Report generation + Skills + AgentRegistry (3 defaults)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ API 키 없이 시작하면 자동으로 dry-run 모드로 전환됩니다:
 | **Domain Plugin** | `DomainPort` Protocol — 도메인별 analysts/evaluators/scoring 플러그인 (게임 IP: `GameIPDomain`) |
 | **Observability** | LangSmith 토큰 추적 + 비용 계산, Claude Code 스타일 상태줄 |
 | **Scheduler** | 자연어 스케줄링 ("매일 오전 9시 분석해줘" → AT/EVERY/CRON) |
-| **2243+ Tests** | 132 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
+| **2366+ Tests** | 134 modules, coverage ≥ 75%, pytest + ruff + mypy strict + bandit |
 
 ## Usage
 
@@ -957,6 +957,7 @@ core/
 │   ├── batch.py                # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py             # Slash command dispatch (17 commands)
 │   ├── conversation.py         # Multi-turn sliding-window context
+│   ├── error_recovery.py       # ErrorRecoveryStrategy (retry → alternative → fallback → escalate)
 │   ├── nl_router.py            # Natural language intent classification
 │   ├── search.py               # IP search engine (synonym expansion)
 │   ├── startup.py              # Readiness check, Graceful Degradation
@@ -981,7 +982,7 @@ core/
 │   ├── ports/                  # LLMClientPort, SignalEnrichmentPort, DomainPort
 │   └── adapters/
 │       ├── llm/                # ClaudeAdapter, OpenAIAdapter
-│       └── mcp/                # Steam, Brave, LinkedIn MCP adapters + catalog (29 entries)
+│       └── mcp/                # Steam, Brave, LinkedIn MCP adapters + CompositeSignalAdapter + catalog (29 entries)
 ├── llm/                        # LLM client (prompt caching, streaming)
 │   ├── client.py               # Anthropic wrapper + token tracking + cost
 │   ├── token_tracker.py        # TokenTracker singleton (model pricing)
@@ -991,6 +992,7 @@ core/
 ├── nodes/                      # Pipeline nodes (8: router, signals, analyst, evaluator, scoring, verification, gather, synthesizer)
 ├── orchestration/
 │   ├── hooks.py                # HookSystem (30 events + async atrigger)
+│   ├── goal_decomposer.py     # GoalDecomposer (compound request → sub-goal DAG)
 │   ├── hook_discovery.py       # Plugin-based hook loading
 │   ├── isolated_execution.py   # IsolatedRunner (MAX_CONCURRENT=5, thread pool)
 │   ├── task_system.py          # TaskGraph DAG (dependency, cycle detection)

--- a/docs/reports/signal-liveification.md
+++ b/docs/reports/signal-liveification.md
@@ -1,0 +1,101 @@
+# Signal Liveification — Implementation Report
+
+**Date**: 2026-03-16
+**Branch**: `feature/signal-liveification`
+**Status**: Complete
+
+## Summary
+
+MCP 기반 라이브 시그널 수집 시스템을 구현하여, fixture-only였던 signals 노드를
+MCP 어댑터 우선 호출 → fixture fallback 구조로 전환했다. `signal_source` 상태 필드로
+데이터 출처(live/mixed/fixture)를 추적한다.
+
+## Architecture
+
+```
+signals_node(state)
+    │
+    ▼
+Injected adapter? ──No──→ Load fixture → signal_source="fixture"
+    │
+   Yes
+    │
+    ▼
+CompositeSignalAdapter.fetch_signals(ip_name)
+    │
+    ├─ SteamMCPSignalAdapter  → Steam MCP server (player_count, review_score, review_count)
+    │
+    ├─ BraveSignalAdapter     → Brave Search MCP (snippets, urls, result_count)
+    │
+    └─ _enrichment_sources    → provenance list
+    │
+    ▼
+data keys >= 3? ──Yes──→ signal_source="live"
+    │
+   No (1-2 keys)
+    │
+    ▼
+Known fixture IP? ──Yes──→ Merge live + fixture → signal_source="mixed"
+    │
+   No
+    │
+    ▼
+signal_source="fixture" (fallback)
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/nodes/signals.py` | Modified — MCP adapter 우선 호출 로직, `signal_source` 반환, `set_signal_adapter()` DI |
+| `core/runtime.py` | Modified — `_build_signal_adapter()` 메서드 추가 (CompositeSignalAdapter 조립 + 주입) |
+| `core/state.py` | Modified — `signal_source` 필드 추가 (`Literal["live", "mixed", "fixture", "web_search"]`) |
+| `core/infrastructure/adapters/mcp/steam_adapter.py` | Modified — `SteamMCPSignalAdapter` MCP manager 모드 추가 |
+| `core/infrastructure/adapters/mcp/brave_adapter.py` | Modified — `BraveSignalAdapter` Brave Search 기반 시그널 추출 |
+| `core/infrastructure/adapters/mcp/composite_signal.py` | **NEW** — `CompositeSignalAdapter` 다중 어댑터 체이닝 |
+| `tests/test_signal_liveification.py` | **NEW** — 20 tests |
+| `CHANGELOG.md` | Updated |
+| `README.md` | Updated |
+
+## Signal Source Determination
+
+| Condition | signal_source | Description |
+|-----------|--------------|-------------|
+| MCP adapter returns >= 3 data keys | `live` | 충분한 라이브 데이터 |
+| MCP adapter returns 1-2 data keys + fixture 존재 | `mixed` | 라이브 + fixture 병합 (live overrides) |
+| MCP adapter 미설정 / unavailable / 에러 | `fixture` | fixture 자동 fallback |
+| Web search enrichment 경로 | `web_search` | (향후 확장) |
+
+## Design Decisions
+
+1. **DI via `set_signal_adapter()`**: `contextvars` 기반 주입으로 테스트에서 어댑터를 자유롭게 교체 가능. 프로덕션에서는 `GeodeRuntime._build_signal_adapter()`가 조립.
+
+2. **CompositeSignalAdapter 체이닝**: 개별 어댑터(Steam, Brave)를 합성하여 단일 인터페이스로 제공. `_enrichment_sources` 리스트로 어느 소스에서 데이터가 왔는지 추적.
+
+3. **Graceful degradation**: MCP 서버 미연결, 에러, 빈 결과 모두 fixture로 자동 fallback. 파이프라인은 항상 정상 완료.
+
+4. **Live override in mixed mode**: 동일 키가 live와 fixture 양쪽에 존재하면 live 값이 우선. fixture는 live에 없는 키만 보충.
+
+5. **Threshold 3 keys**: 데이터 키 3개 이상이면 "충분한 라이브 데이터"로 판정하여 fixture 병합 없이 진행.
+
+## Test Coverage
+
+20 tests across 7 test classes:
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| `TestLiveSignals` | 2 | CompositeSignalAdapter 라이브 시그널 수집 |
+| `TestFixtureFallback` | 3 | 어댑터 없음/unavailable/에러 시 fixture fallback |
+| `TestMixedSignals` | 2 | 부분 라이브 + fixture 병합, live override |
+| `TestSignalSourceTracking` | 4 | signal_source 필드 값 검증 (live/fixture/mixed) |
+| `TestCompositeSignalAdapter` | 4 | 다중 소스 병합, unavailable 건너뛰기, is_available |
+| `TestSteamMCPSignalAdapterManager` | 3 | MCP manager 모드 (healthy/unhealthy/error) |
+| `TestBraveSignalAdapter` | 3 | Brave Search 성공/unavailable/빈 결과 |
+
+## Quality Gates
+
+| Gate | Result |
+|------|--------|
+| `ruff check core/ tests/` | All checks passed |
+| `mypy core/` | Success: 132 source files |
+| `pytest tests/ -q` | 2226 passed, 19 deselected |


### PR DESCRIPTION
## 요약

- Signal Liveification 리포트 누락 복구
- CLAUDE.md/README.md 수치·구조 정합 (Tests 2366+, Modules 134, HookSystem 30)

## 변경 사항

- `docs/reports/signal-liveification.md` 신규 — 5개 리포트 완성
- CLAUDE.md/README.md: 테스트 수, 모듈 수, HookEvent 수, 프로젝트 구조 트리 동기화

## 테스트

| 게이트 | 결과 |
|--------|------|
| Lint & Format | pass |
| Type Check | pass |
| Test (3.12) | pass |
| Test (3.13) | pass |
| Security Scan | pass |
| Gate | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)