### PR TITLE
fix: AgenticLoop LLM 호출 대기 스피너 추가

### DIFF
--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -32,6 +32,7 @@ from core.llm.client import _maybe_traceable
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.orchestration.hooks import HookEvent, HookSystem
 from core.ui.agentic_ui import OperationLogger
+from core.ui.console import console
 
 if TYPE_CHECKING:
     from core.tools.registry import ToolRegistry
@@ -226,7 +227,18 @@ class AgenticLoop:
             is_last_round = round_idx == self.max_rounds - 1
             self._op_logger.begin_round("AgenticLoop")
 
-            response = await self._call_llm(system_prompt, messages, round_idx=round_idx)
+            # Show spinner while waiting for LLM response
+            label = "Thinking..." if round_idx == 0 else f"Thinking... (round {round_idx + 1})"
+            _status = console.status(
+                f"  ✢ {label}",
+                spinner="dots",
+                spinner_style="cyan",
+            )
+            _status.start()
+            try:
+                response = await self._call_llm(system_prompt, messages, round_idx=round_idx)
+            finally:
+                _status.stop()
 
             if response is None:
                 # Persist intermediate tool-use messages so next turn sees them


### PR DESCRIPTION
## 요약

- AgenticLoop에서 LLM 응답 대기 중 UI가 비는 문제 수정
- `_call_llm()` 호출 구간에 `console.status()` 스피너 추가

## 원인

`arun()` 내부에서 `_call_llm()` 호출 시 어떤 UI 피드백도 없어 사용자에게 빈 화면이 보임.
ToolExecutor에는 `_tool_spinner()`가 있었으나, LLM 호출 대기 구간에는 누락.

## 수정

- `arun()` 메인 루프에서 `_call_llm()` 전후로 `console.status()` 스피너 감싸기
- 첫 라운드: `"✢ Thinking..."`, 이후: `"✢ Thinking... (round N)"`
- LLM 응답 또는 에러 시 `finally` 블록에서 자동 종료

## 테스트

| 게이트 | 결과 |
|--------|------|
| ruff | All checks passed |
| mypy | 0 errors (134 files) |
| pytest | 2366 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)