### PR TITLE
fix: pre-commit mypy/bandit cache 오탐 수정

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,14 +36,14 @@ repos:
     hooks:
       - id: mypy
         name: mypy type check
-        entry: uv run mypy --cache-dir /tmp/.mypy_cache_geode core/
+        entry: uv run --frozen mypy --no-incremental core/
         language: system
         pass_filenames: false
         types: [python]
 
       - id: bandit
         name: bandit security
-        entry: uv run bandit -r core/ -c pyproject.toml
+        entry: uv run --frozen bandit -r core/ -c pyproject.toml --quiet
         language: system
         pass_filenames: false
         types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Pre-commit mypy/bandit "files were modified" 오탐 — mypy `--cache-dir` → `--no-incremental`, bandit `--quiet` 추가
+
 ---
 
 ## [0.13.1] — 2026-03-16


### PR DESCRIPTION
## 요약

pre-commit mypy/bandit 훅 "files were modified" 오탐 수정.

## 변경 사항

- mypy: `--cache-dir /tmp/...` → `--no-incremental` (캐시 파일 생성 원천 차단)
- bandit: `--quiet` 플래그 추가

## 테스트

pre-commit run mypy/bandit --all-files 모두 Passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)