### PR TITLE
fix: cron weekday 변환 버그 수정 + trigger fire 오류 메시지 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Pre-commit mypy/bandit "files were modified" 오탐 — mypy `--cache-dir` → `--no-incremental`, bandit `--quiet` 추가
+- Cron weekday 변환 버그 — Python weekday(0=Mon) → cron 표준(0=Sun) 미변환으로 일요일 스케줄이 월요일에 실행되던 문제
+- `/trigger fire` 명령이 TriggerManager 없이 성공으로 표시되던 문제를 경고 메시지로 변경
 
 ---
 

--- a/core/automation/scheduler.py
+++ b/core/automation/scheduler.py
@@ -275,7 +275,12 @@ def _now_minutes(timezone: str) -> int:
 
 
 def _cron_tuple_for_tz(timezone: str) -> tuple[int, int, int, int, int]:
-    """Get a cron-compatible tuple, optionally in a specific timezone."""
+    """Get a cron-compatible tuple, optionally in a specific timezone.
+
+    Returns weekday in standard cron convention: 0=Sun, 1=Mon, ..., 6=Sat.
+    Python's ``datetime.weekday()`` uses 0=Mon, so we convert:
+    ``(weekday() + 1) % 7``.
+    """
     if timezone:
         try:
             import datetime
@@ -283,7 +288,8 @@ def _cron_tuple_for_tz(timezone: str) -> tuple[int, int, int, int, int]:
 
             tz = zoneinfo.ZoneInfo(timezone)
             now = datetime.datetime.now(tz=tz)
-            return (now.minute, now.hour, now.day, now.month, now.weekday())
+            cron_wday = (now.weekday() + 1) % 7  # Python 0=Mon -> cron 0=Sun
+            return (now.minute, now.hour, now.day, now.month, cron_wday)
         except Exception:  # noqa: S110 — fallback to CronParser.current_tuple() below
             pass
     return CronParser.current_tuple()

--- a/core/automation/triggers.py
+++ b/core/automation/triggers.py
@@ -89,7 +89,8 @@ class CronParser:
 
         Args:
             cron_expr: Cron string "min hour day month weekday".
-            dt_tuple: (minute, hour, day, month, weekday) where weekday 0=Mon.
+            dt_tuple: (minute, hour, day, month, weekday) where weekday
+                uses standard cron convention: 0=Sun, 1=Mon, ..., 6=Sat.
 
         Returns:
             True if the cron expression matches the given time.
@@ -132,9 +133,14 @@ class CronParser:
 
     @staticmethod
     def current_tuple() -> tuple[int, int, int, int, int]:
-        """Get current time as a cron-compatible tuple."""
+        """Get current time as a cron-compatible tuple.
+
+        Returns weekday in standard cron convention: 0=Sun, 1=Mon, ..., 6=Sat.
+        Python's ``tm_wday`` uses 0=Mon, so we convert: ``(tm_wday + 1) % 7``.
+        """
         t = time.localtime()
-        return (t.tm_min, t.tm_hour, t.tm_mday, t.tm_mon, t.tm_wday)
+        cron_wday = (t.tm_wday + 1) % 7  # Python 0=Mon -> cron 0=Sun
+        return (t.tm_min, t.tm_hour, t.tm_mday, t.tm_mon, cron_wday)
 
 
 # ---------------------------------------------------------------------------

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -808,8 +808,11 @@ def cmd_trigger(args: str) -> None:
     parts = arg.split(None, 1)
     if parts[0] == "fire" and len(parts) > 1:
         event_name = parts[1]
-        console.print(f"  [success]Fired event: {event_name}[/success]")
-        console.print("  [muted]Dispatched to TriggerManager via HookSystem.[/muted]")
+        console.print(f"  [warning]Cannot fire event: {event_name}[/warning]")
+        console.print(
+            "  [muted]Manual event dispatch requires a running TriggerManager "
+            "instance (available in GeodeRuntime, not standalone REPL).[/muted]"
+        )
         console.print()
         return
 


### PR DESCRIPTION
## 요약

- Cron 스케줄러의 weekday 변환 버그 수정 (Python 0=Mon → cron 0=Sun)
- `/trigger fire` 명령의 잘못된 성공 메시지를 경고로 변경
- pre-commit `uv run --frozen` 적용으로 uv.lock 수정 방지

## 변경 사항

### 핵심
- **`scheduler.py`**: `_cron_tuple_for_tz()`에서 `(weekday() + 1) % 7` 변환 추가 — **왜?** Python의 `datetime.weekday()`는 0=Mon이지만 cron 표준은 0=Sun. 변환 없이 그대로 전달하면 일요일 스케줄이 월요일에 실행됨
- **`triggers.py`**: `CronParser.current_tuple()`에 동일 변환 적용 — **왜?** `time.localtime().tm_wday`도 0=Mon 기준이므로 동일 문제 존재
- **`commands.py`**: `/trigger fire` 명령이 TriggerManager 인스턴스 없이 성공으로 표시되던 문제를 경고 메시지로 변경 — **왜?** Standalone REPL에서는 TriggerManager가 없어 이벤트 디스패치 불가

### 부수
- **`.pre-commit-config.yaml`**: `uv run` → `uv run --frozen` 전환 — **왜?** `uv run`이 uv.lock을 수정하여 pre-commit "files were modified" false positive 발생

## 영향 범위

- `core/automation/scheduler.py` — cron 스케줄 매칭
- `core/automation/triggers.py` — CronParser 시간 튜플
- `core/cli/commands.py` — `/trigger` slash command
- `.pre-commit-config.yaml` — pre-commit hook 설정

## 테스트

- `uv run pytest tests/ -q`: 전체 통과
- `uv run ruff check core/ tests/`: 0 errors
- pre-commit 전체 통과 (mypy/bandit 포함)

## 검증 체크리스트

- [x] lint 통과
- [x] type check 통과
- [x] 전체 테스트 통과
- [x] pre-commit 통과
- [x] CHANGELOG 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)