### PR TITLE
fix: UI 마커 브랜딩 통일 — 비표준 이모지 일괄 교체

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Pre-commit mypy/bandit "files were modified" 오탐 — mypy `--cache-dir` → `--no-incremental`, bandit `--quiet` 추가
 
+### Changed
+- UI 마커 브랜딩 통일 — 비표준 이모지(⏳, ✻, ⏺)를 GEODE 표준 마커(✢, ●)로 일괄 교체
+
 ---
 
 ## [0.13.1] — 2026-03-16
@@ -48,7 +51,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - 서브에이전트 결과 수집 `as_completed` 패턴 — 순차 블로킹 → polling round-robin 전환. 먼저 끝난 태스크의 SUBAGENT_COMPLETED 훅이 즉시 발행
 
 ### Added
-- HITL 승인 후 스피너 — `_tool_spinner()` 컨텍스트 매니저로 bash/MCP/write/expensive 도구 실행 중 `⏳` dots 스피너 표시, 승인 거부·Safe/Standard 도구에는 미표시
+- HITL 승인 후 스피너 — `_tool_spinner()` 컨텍스트 매니저로 bash/MCP/write/expensive 도구 실행 중 `✢` dots 스피너 표시, 승인 거부·Safe/Standard 도구에는 미표시
 - Signal Liveification — MCP 기반 라이브 시그널 수집 (`CompositeSignalAdapter` → `SteamMCPSignalAdapter` + `BraveSignalAdapter`), fixture fallback 보존, `signal_source` 필드로 provenance 추적
 - Plan 자율 실행 모드 — `GEODE_PLAN_AUTO_EXECUTE=true`로 계획 생성→승인→실행을 사용자 개입 없이 자동 수행, step 실패 시 재시도 1회 후 partial success로 계속 진행 (`PlanExecutionMode.AUTO`)
 - Dynamic Graph — 분석 결과에 따라 노드 동적 건너뛰기/enrichment 경로 분기 (`skip_nodes`, `skipped_nodes`, `enrichment_needed` state 필드 + `skip_check` 조건부 노드)

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -329,8 +329,8 @@ def cmd_auth(args: str) -> None:
         console.print()
         console.print("  [header]Auth Profiles[/header]")
         for s in statuses:
-            icon = "✓" if s["status"] == "active" else "⏳" if "cooldown" in s["status"] else "✗"
-            style = "success" if icon == "✓" else "warning" if icon == "⏳" else "error"
+            icon = "✓" if s["status"] == "active" else "●" if "cooldown" in s["status"] else "✗"
+            style = "success" if icon == "✓" else "warning" if icon == "●" else "error"
             console.print(
                 f"  [{style}]{icon}[/{style}] {s['name']:<22} "
                 f"{s['type']:<10} {s['display']:<18} [{style}][{s['status']}][/{style}]"

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -72,7 +72,7 @@ def _tool_spinner(label: str) -> Iterator[None]:
     Displays ``label`` with a spinner while the wrapped block runs,
     then clears it on exit so OperationLogger markers (✓/✗) render cleanly.
     """
-    status = console.status(f"  [dim]⏳ {label}[/dim]", spinner="dots", spinner_style="cyan")
+    status = console.status(f"  [dim]✢ {label}[/dim]", spinner="dots", spinner_style="cyan")
     status.start()
     try:
         yield

--- a/core/ui/agentic_ui.py
+++ b/core/ui/agentic_ui.py
@@ -88,7 +88,7 @@ class OperationLogger:
     def begin_round(self, label: str = "AgenticLoop") -> None:
         """Start a new agentic round — print header if not yet shown."""
         if not self._header_printed:
-            console.print(f"\n[bold]⏺ {label}[/bold]")
+            console.print(f"\n[bold]● {label}[/bold]")
             self._header_printed = True
 
     def log_tool_call(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
@@ -252,7 +252,7 @@ def render_subagent_complete(count: int, elapsed_s: float) -> None:
 def render_status_line() -> None:
     """Render Claude Code-style status line after each agentic result.
 
-    Format: ✻ Worked for 48s · claude-opus-4-6 · ↓12.3k ↑2.1k · $0.42 · 11% context
+    Format: ✢ Worked for 48s · claude-opus-4-6 · ↓12.3k ↑2.1k · $0.42 · 11% context
     """
     meter = get_session_meter()
     if meter is None:
@@ -267,7 +267,7 @@ def render_status_line() -> None:
         cost = acc.total_cost_usd
         ctx_pct = tracker.context_usage_pct(meter.model)
 
-        parts = [f"✻ Worked for {meter.elapsed_display}"]
+        parts = [f"✢ Worked for {meter.elapsed_display}"]
         parts.append(meter.model)
         parts.append(f"↓{in_str} ↑{out_str}")
         if cost > 0:
@@ -278,7 +278,7 @@ def render_status_line() -> None:
         console.print(f"\n  [dim]{line}[/dim]")
     except Exception:
         # Fallback: just show elapsed time
-        console.print(f"\n  [dim]✻ Worked for {meter.elapsed_display}[/dim]")
+        console.print(f"\n  [dim]✢ Worked for {meter.elapsed_display}[/dim]")
 
 
 def _fmt_tokens(n: int) -> str:

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -279,7 +279,7 @@ class TestRenderStatusLine:
 
         render_status_line()
         printed = str(mock_console.print.call_args)
-        assert "✻" in printed
+        assert "✢" in printed
         assert "Worked for" in printed
         assert "claude-opus-4-6" in printed
         assert "context" in printed


### PR DESCRIPTION
## 요약

GEODE Claude Code-style UI의 비표준 이모지(⏳, ✻, ⏺)를 표준 마커(✢, ●)로 일괄 교체하여 브랜딩 일관성 확보.

## 변경 사항

### 핵심
- **`tool_executor.py`**: `⏳` → `✢` (도구 실행 스피너) — **왜?** token/LLM 관련 표시는 ✢로 통일
- **`agentic_ui.py`**: `✻` → `✢` (세션 요약 라인), `⏺` → `●` (라운드 헤더) — **왜?** 각각 token 정보, plan/state 마커에 해당
- **`commands.py`**: `⏳` → `●` (auth cooldown 상태 아이콘) — **왜?** 상태 표시는 ● 마커 영역

### 부수
- **`test_agentic_ui.py`**: `✻` → `✢` assertion 업데이트
- **`CHANGELOG.md`**: v0.13.0 Added 섹션 `⏳` → `✢` 수정
- **`.pre-commit-config.yaml`**: `uv run --frozen` + `--no-incremental` 적용

## 설계 판단

GEODE 표준 마커 팔레트 (5종):
| 마커 | 용도 |
|------|------|
| `▸` | tool call |
| `✓` | success |
| `✗` | error |
| `✢` | token/LLM info |
| `●` | plan/state |

## 테스트

- `uv run pytest tests/ -q`: 전체 통과
- `uv run ruff check core/ tests/`: 0 errors
- pre-commit 전체 통과

## 검증 체크리스트

- [x] lint 통과
- [x] type check 통과
- [x] 전체 테스트 통과
- [x] pre-commit 통과
- [x] CHANGELOG 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)