### PR TITLE
develop → main: pre-commit 수정 + cron weekday 버그 + UI 마커 통일

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,14 +36,14 @@ repos:
     hooks:
       - id: mypy
         name: mypy type check
-        entry: uv run mypy --cache-dir /tmp/.mypy_cache_geode core/
+        entry: uv run --frozen mypy --no-incremental core/
         language: system
         pass_filenames: false
         types: [python]
 
       - id: bandit
         name: bandit security
-        entry: uv run bandit -r core/ -c pyproject.toml
+        entry: uv run --frozen bandit -r core/ -c pyproject.toml --quiet
         language: system
         pass_filenames: false
         types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Pre-commit mypy/bandit "files were modified" 오탐 — mypy `--cache-dir` → `--no-incremental`, bandit `--quiet` 추가
+- Cron weekday 변환 버그 — Python weekday(0=Mon) → cron 표준(0=Sun) 미변환으로 일요일 스케줄이 월요일에 실행되던 문제
+- `/trigger fire` 명령이 TriggerManager 없이 성공으로 표시되던 문제를 경고 메시지로 변경
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Pre-commit mypy/bandit "files were modified" 오탐 — mypy `--cache-dir` → `--no-incremental`, bandit `--quiet` 추가
+
 ---
 
 ## [0.13.1] — 2026-03-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Pre-commit mypy/bandit "files were modified" 오탐 — mypy `--cache-dir` → `--no-incremental`, bandit `--quiet` 추가
 
+### Changed
+- UI 마커 브랜딩 통일 — 비표준 이모지(⏳, ✻, ⏺)를 GEODE 표준 마커(✢, ●)로 일괄 교체
+
 ---
 
 ## [0.13.1] — 2026-03-16
@@ -48,7 +51,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - 서브에이전트 결과 수집 `as_completed` 패턴 — 순차 블로킹 → polling round-robin 전환. 먼저 끝난 태스크의 SUBAGENT_COMPLETED 훅이 즉시 발행
 
 ### Added
-- HITL 승인 후 스피너 — `_tool_spinner()` 컨텍스트 매니저로 bash/MCP/write/expensive 도구 실행 중 `⏳` dots 스피너 표시, 승인 거부·Safe/Standard 도구에는 미표시
+- HITL 승인 후 스피너 — `_tool_spinner()` 컨텍스트 매니저로 bash/MCP/write/expensive 도구 실행 중 `✢` dots 스피너 표시, 승인 거부·Safe/Standard 도구에는 미표시
 - Signal Liveification — MCP 기반 라이브 시그널 수집 (`CompositeSignalAdapter` → `SteamMCPSignalAdapter` + `BraveSignalAdapter`), fixture fallback 보존, `signal_source` 필드로 provenance 추적
 - Plan 자율 실행 모드 — `GEODE_PLAN_AUTO_EXECUTE=true`로 계획 생성→승인→실행을 사용자 개입 없이 자동 수행, step 실패 시 재시도 1회 후 partial success로 계속 진행 (`PlanExecutionMode.AUTO`)
 - Dynamic Graph — 분석 결과에 따라 노드 동적 건너뛰기/enrichment 경로 분기 (`skip_nodes`, `skipped_nodes`, `enrichment_needed` state 필드 + `skip_check` 조건부 노드)

--- a/core/automation/scheduler.py
+++ b/core/automation/scheduler.py
@@ -275,7 +275,12 @@ def _now_minutes(timezone: str) -> int:
 
 
 def _cron_tuple_for_tz(timezone: str) -> tuple[int, int, int, int, int]:
-    """Get a cron-compatible tuple, optionally in a specific timezone."""
+    """Get a cron-compatible tuple, optionally in a specific timezone.
+
+    Returns weekday in standard cron convention: 0=Sun, 1=Mon, ..., 6=Sat.
+    Python's ``datetime.weekday()`` uses 0=Mon, so we convert:
+    ``(weekday() + 1) % 7``.
+    """
     if timezone:
         try:
             import datetime
@@ -283,7 +288,8 @@ def _cron_tuple_for_tz(timezone: str) -> tuple[int, int, int, int, int]:
 
             tz = zoneinfo.ZoneInfo(timezone)
             now = datetime.datetime.now(tz=tz)
-            return (now.minute, now.hour, now.day, now.month, now.weekday())
+            cron_wday = (now.weekday() + 1) % 7  # Python 0=Mon -> cron 0=Sun
+            return (now.minute, now.hour, now.day, now.month, cron_wday)
         except Exception:  # noqa: S110 — fallback to CronParser.current_tuple() below
             pass
     return CronParser.current_tuple()

--- a/core/automation/triggers.py
+++ b/core/automation/triggers.py
@@ -89,7 +89,8 @@ class CronParser:
 
         Args:
             cron_expr: Cron string "min hour day month weekday".
-            dt_tuple: (minute, hour, day, month, weekday) where weekday 0=Mon.
+            dt_tuple: (minute, hour, day, month, weekday) where weekday
+                uses standard cron convention: 0=Sun, 1=Mon, ..., 6=Sat.
 
         Returns:
             True if the cron expression matches the given time.
@@ -132,9 +133,14 @@ class CronParser:
 
     @staticmethod
     def current_tuple() -> tuple[int, int, int, int, int]:
-        """Get current time as a cron-compatible tuple."""
+        """Get current time as a cron-compatible tuple.
+
+        Returns weekday in standard cron convention: 0=Sun, 1=Mon, ..., 6=Sat.
+        Python's ``tm_wday`` uses 0=Mon, so we convert: ``(tm_wday + 1) % 7``.
+        """
         t = time.localtime()
-        return (t.tm_min, t.tm_hour, t.tm_mday, t.tm_mon, t.tm_wday)
+        cron_wday = (t.tm_wday + 1) % 7  # Python 0=Mon -> cron 0=Sun
+        return (t.tm_min, t.tm_hour, t.tm_mday, t.tm_mon, cron_wday)
 
 
 # ---------------------------------------------------------------------------

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -329,8 +329,8 @@ def cmd_auth(args: str) -> None:
         console.print()
         console.print("  [header]Auth Profiles[/header]")
         for s in statuses:
-            icon = "✓" if s["status"] == "active" else "⏳" if "cooldown" in s["status"] else "✗"
-            style = "success" if icon == "✓" else "warning" if icon == "⏳" else "error"
+            icon = "✓" if s["status"] == "active" else "●" if "cooldown" in s["status"] else "✗"
+            style = "success" if icon == "✓" else "warning" if icon == "●" else "error"
             console.print(
                 f"  [{style}]{icon}[/{style}] {s['name']:<22} "
                 f"{s['type']:<10} {s['display']:<18} [{style}][{s['status']}][/{style}]"

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -808,8 +808,11 @@ def cmd_trigger(args: str) -> None:
     parts = arg.split(None, 1)
     if parts[0] == "fire" and len(parts) > 1:
         event_name = parts[1]
-        console.print(f"  [success]Fired event: {event_name}[/success]")
-        console.print("  [muted]Dispatched to TriggerManager via HookSystem.[/muted]")
+        console.print(f"  [warning]Cannot fire event: {event_name}[/warning]")
+        console.print(
+            "  [muted]Manual event dispatch requires a running TriggerManager "
+            "instance (available in GeodeRuntime, not standalone REPL).[/muted]"
+        )
         console.print()
         return
 

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -72,7 +72,7 @@ def _tool_spinner(label: str) -> Iterator[None]:
     Displays ``label`` with a spinner while the wrapped block runs,
     then clears it on exit so OperationLogger markers (✓/✗) render cleanly.
     """
-    status = console.status(f"  [dim]⏳ {label}[/dim]", spinner="dots", spinner_style="cyan")
+    status = console.status(f"  [dim]✢ {label}[/dim]", spinner="dots", spinner_style="cyan")
     status.start()
     try:
         yield

--- a/core/ui/agentic_ui.py
+++ b/core/ui/agentic_ui.py
@@ -88,7 +88,7 @@ class OperationLogger:
     def begin_round(self, label: str = "AgenticLoop") -> None:
         """Start a new agentic round — print header if not yet shown."""
         if not self._header_printed:
-            console.print(f"\n[bold]⏺ {label}[/bold]")
+            console.print(f"\n[bold]● {label}[/bold]")
             self._header_printed = True
 
     def log_tool_call(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
@@ -252,7 +252,7 @@ def render_subagent_complete(count: int, elapsed_s: float) -> None:
 def render_status_line() -> None:
     """Render Claude Code-style status line after each agentic result.
 
-    Format: ✻ Worked for 48s · claude-opus-4-6 · ↓12.3k ↑2.1k · $0.42 · 11% context
+    Format: ✢ Worked for 48s · claude-opus-4-6 · ↓12.3k ↑2.1k · $0.42 · 11% context
     """
     meter = get_session_meter()
     if meter is None:
@@ -267,7 +267,7 @@ def render_status_line() -> None:
         cost = acc.total_cost_usd
         ctx_pct = tracker.context_usage_pct(meter.model)
 
-        parts = [f"✻ Worked for {meter.elapsed_display}"]
+        parts = [f"✢ Worked for {meter.elapsed_display}"]
         parts.append(meter.model)
         parts.append(f"↓{in_str} ↑{out_str}")
         if cost > 0:
@@ -278,7 +278,7 @@ def render_status_line() -> None:
         console.print(f"\n  [dim]{line}[/dim]")
     except Exception:
         # Fallback: just show elapsed time
-        console.print(f"\n  [dim]✻ Worked for {meter.elapsed_display}[/dim]")
+        console.print(f"\n  [dim]✢ Worked for {meter.elapsed_display}[/dim]")
 
 
 def _fmt_tokens(n: int) -> str:

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -279,7 +279,7 @@ class TestRenderStatusLine:
 
         render_status_line()
         printed = str(mock_console.print.call_args)
-        assert "✻" in printed
+        assert "✢" in printed
         assert "Worked for" in printed
         assert "claude-opus-4-6" in printed
         assert "context" in printed


### PR DESCRIPTION
## 요약

develop 브랜치의 3개 fix PR을 main으로 머지.

## 변경 사항

### PR #160 — pre-commit cache 오탐 수정
- mypy `--cache-dir` → `--no-incremental` + `--frozen` 전환
- bandit `--quiet` + `--frozen` 추가
- **왜?** `uv run`이 `uv.lock`을 수정하여 pre-commit "files were modified" false positive 발생

### PR #161 — cron weekday 변환 버그 수정
- `_cron_tuple_for_tz()`, `CronParser.current_tuple()`에서 Python weekday(0=Mon) → cron(0=Sun) 변환 추가
- `/trigger fire` 명령 오류 메시지 개선
- **왜?** 변환 누락으로 일요일 스케줄이 월요일에 실행됨

### PR #162 — UI 마커 브랜딩 통일
- ⏳ → ✢, ✻ → ✢, ⏺ → ● 일괄 교체
- **왜?** GEODE 표준 팔레트(▸/✓/✗/✢/●) 일관성 확보

## 테스트

- CI 전체 통과 (Lint, Type, Test 3.12/3.13, Security, Gate)

## 검증 체크리스트

- [x] PR #160 CI 통과 + merge
- [x] PR #161 CI 통과 + merge
- [x] PR #162 CI 통과 + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)