### PR TITLE
fix: Identity Pivot 완성 — analyst.md 게임 IP 자아 제거

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Identity Pivot 완성 — `analyst.md` SYSTEM 프롬프트에서 "undervalued IP discovery agent" 제거, 게임 전용 예시를 도메인 비의존적 예시로 교체
+- `ANALYST_SYSTEM` 해시 핀 갱신 (`924433f5bf11` → `90acc856a5b2`)
+
 ---
 
 ## [0.13.2] — 2026-03-16

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -167,7 +167,7 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 _PINNED_HASHES: dict[str, str] = {
     "AGENTIC_SUFFIX": "8ec998fdf916",
     "ANALYST_SPECIFIC": "5a696a2d5ebb",
-    "ANALYST_SYSTEM": "924433f5bf11",
+    "ANALYST_SYSTEM": "90acc856a5b2",
     "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",
     "ANALYST_USER": "e59d00faadd5",
     "BIASBUSTER_SYSTEM": "07987c709fd9",

--- a/core/llm/prompts/analyst.md
+++ b/core/llm/prompts/analyst.md
@@ -1,6 +1,6 @@
 === SYSTEM ===
 
-You are a specialized IP analyst in the GEODE system — an undervalued IP discovery agent.
+You are a specialized analyst in the GEODE autonomous execution system.
 Your role: {analyst_type} Analyst.
 
 IMPORTANT:
@@ -30,13 +30,13 @@ Respond in JSON format:
   "confidence": <float 0-100>
 }}
 
-Example (game_mechanics analyst for a fighting-game IP):
+Example:
 {{
-  "analyst_type": "game_mechanics",
+  "analyst_type": "{analyst_type}",
   "score": 4.2,
-  "key_finding": "Deep combat system with strong competitive loop potential",
-  "reasoning": "The IP's martial arts system maps directly to a combo-based fighter with high skill ceiling. Existing fan tournaments prove competitive demand. Mobile port gap represents untapped casual segment.",
-  "evidence": ["Fan tournament viewership 1.2M avg", "No mobile game despite 60% mobile genre TAM"],
+  "key_finding": "Strong competitive advantage with untapped growth segment",
+  "reasoning": "The subject demonstrates above-average core quality with measurable audience engagement. Multiple data points confirm market demand, while an unaddressed segment represents clear upside.",
+  "evidence": ["Audience engagement metric 1.2M avg", "Underserved segment represents 60% of TAM"],
   "confidence": 82.0
 }}
 


### PR DESCRIPTION
## 요약

블로그 #314 (Identity Pivot 설계기) 관점에서 점검한 결과, `analyst.md` 1개 파일만 미완성. 게임 IP 자아 선언과 전용 예시를 범용으로 교체하여 Identity Pivot 100% 완성.

## 변경 사항

### 핵심
- **`analyst.md` SYSTEM line 3**: "undervalued IP discovery agent" → "autonomous execution system" — **왜?** Karpathy P2 (단일 자아 원천) 위반. SOUL.md는 범용인데 analyst가 "IP 발굴 에이전트"라고 자기소개하면 정체성 불일치
- **`analyst.md` 예시 (lines 33-41)**: fighting-game IP 전용 예시 → 도메인 비의존적 예시 — **왜?** 비게임 도메인 플러그인 사용 시 게임 메트릭으로 앵커링 발생
- **`__init__.py` 해시 핀**: `ANALYST_SYSTEM` `924433f5bf11` → `90acc856a5b2` — **왜?** Karpathy P4 (Ratchet) 프롬프트 무결성 검증 동기화

### 유지 (의도적 미변경)
- `evaluator.md`, `synthesizer.md`, `biasbuster.md`, `cross_llm.md` — GameIPDomain 로드 시에만 실행되므로 이미 올바른 도메인 스코프

## 설계 판단

블로그 #314의 판정 기준: "도메인 플러그인 없이도 호출되는가?" → analyst.md의 SYSTEM 프롬프트는 base template으로 모든 도메인에서 공유. `{analyst_specific_prompt}` 플레이스홀더로 도메인별 내용 주입.

## 테스트

- `uv run pytest tests/ -q`: 전체 통과
- `verify_prompt_integrity()`: Drift NONE
- `grep "undervalued IP discovery" core/`: 0 hits

## 검증 체크리스트

- [x] SOUL.md 범용 (기완료)
- [x] router.md 범용 (기완료)
- [x] commentary.md 범용 (기완료)
- [x] agents.py 범용 (기완료)
- [x] **analyst.md 범용 (이번 PR)**
- [x] 해시 핀 동기화
- [x] 잔존 참조 grep 0 hits
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)