### PR TITLE
feat: 복사/붙여넣기 알림 — Claude Code 스타일 paste notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- 복사/붙여넣기 알림 — 멀티라인 paste 감지 시 `[Pasted text +N lines]` 표시 후 추가 입력 대기 (즉시 실행 방지)
+
 ### Changed
 - Identity Pivot 완성 — `analyst.md` SYSTEM 프롬프트에서 "undervalued IP discovery agent" 제거, 게임 전용 예시를 도메인 비의존적 예시로 교체
 - `ANALYST_SYSTEM` 해시 핀 갱신 (`924433f5bf11` → `90acc856a5b2`)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2401,8 +2401,9 @@ def _read_multiline_input(prompt: str) -> str:
     """Read user input via prompt_toolkit (arrow keys, history, paste).
 
     Falls back to Rich console.input if prompt_toolkit is unavailable.
-    Multi-line paste is handled by draining buffered stdin after the
-    first line (50 ms timeout).
+    Multi-line paste is detected by draining buffered stdin (50 ms timeout).
+    When paste is detected, shows ``[Pasted text +N lines]`` notification
+    and waits for additional input before submitting.
     """
     _restore_terminal()
 
@@ -2442,6 +2443,27 @@ def _read_multiline_input(prompt: str) -> str:
                 lines.append(stripped)
     except (ValueError, OSError):
         pass  # stdin not selectable (piped / non-TTY)
+
+    # Paste notification — show count and wait for explicit submit
+    extra_count = len(lines) - 1
+    if extra_count > 0:
+        console.print(f"  [dim][Pasted text +{extra_count} lines][/dim]")
+        # Allow user to add more input or press Enter to submit
+        _restore_terminal()
+        if session is not None:
+            try:
+                additional = session.prompt().strip()
+            except (KeyboardInterrupt, EOFError):
+                additional = ""
+            except Exception:
+                additional = ""
+        else:
+            try:
+                additional = console.input("> ").strip()
+            except (KeyboardInterrupt, EOFError):
+                additional = ""
+        if additional:
+            lines.append(additional)
 
     return "\n".join(lines)
 

--- a/tests/test_multiline_input.py
+++ b/tests/test_multiline_input.py
@@ -45,11 +45,12 @@ class TestReadMultilineInput:
         assert result == ""
 
     def test_multiline_paste_joins_lines(self):
-        """Pasted multi-line text is joined into a single string."""
+        """Pasted multi-line text is joined and shows notification."""
         from core.cli import _read_multiline_input
 
         mock_console = MagicMock()
-        mock_console.input.return_value = "line 1"
+        # First call: initial input; second call: submit after paste notification
+        mock_console.input.side_effect = ["line 1", ""]
 
         # Simulate two additional lines buffered from paste
         paste_lines = iter(["line 2\n", "line 3\n", ""])
@@ -75,13 +76,18 @@ class TestReadMultilineInput:
             result = _read_multiline_input("> ")
 
         assert result == "line 1\nline 2\nline 3"
+        # Verify paste notification was shown
+        mock_console.print.assert_called()
+        notif_call = str(mock_console.print.call_args_list)
+        assert "Pasted text +2 lines" in notif_call
 
     def test_multiline_paste_skips_blank_lines(self):
         """Blank lines in paste are excluded."""
         from core.cli import _read_multiline_input
 
         mock_console = MagicMock()
-        mock_console.input.return_value = "first"
+        # First call: initial input; second call: submit after paste notification
+        mock_console.input.side_effect = ["first", ""]
 
         paste_lines = iter(["\n", "second\n", ""])
         call_count = [0]


### PR DESCRIPTION
## 요약

멀티라인 paste 시 Claude Code처럼 `[Pasted text +N lines]` 알림을 표시하고, 즉시 실행 대신 추가 입력 대기 프롬프트를 제공.

## 변경 사항

### 핵심
- **`_read_multiline_input()`**: paste 감지(기존 `select()` 50ms polling) 후 `console.print("[Pasted text +N lines]")` 알림 출력 — **왜?** 기존에는 복붙하면 바로 실행되어 의도치 않은 작업 수행
- 알림 후 `session.prompt()` 2차 호출로 추가 입력 대기 — Enter(빈줄)로 제출, 추가 텍스트도 가능

### 부수
- **`test_multiline_input.py`**: `mock_console.input.side_effect` 다중 응답으로 2차 프롬프트 동작 검증 + 알림 문자열 assert

## 영향 범위

- `core/cli/__init__.py` `_read_multiline_input()` 1개 함수
- `tests/test_multiline_input.py` 2개 테스트 업데이트

## 테스트

- `uv run pytest tests/test_multiline_input.py -v`: 7/7 통과
- `uv run pytest tests/ -q`: 전체 통과

## 검증 체크리스트

- [x] 단일 라인 입력 동작 변경 없음
- [x] 멀티라인 paste 시 알림 표시
- [x] 2차 프롬프트에서 빈 Enter → 기존 paste 내용 제출
- [x] 2차 프롬프트에서 추가 입력 → 결합하여 제출
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)