### PR TITLE
fix: UI 팔레트 톤다운 — 차분한 브랜딩 색상 통일

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - Identity Pivot 완성 — `analyst.md` SYSTEM 프롬프트에서 "undervalued IP discovery agent" 제거, 게임 전용 예시를 도메인 비의존적 예시로 교체
 - `ANALYST_SYSTEM` 해시 핀 갱신 (`924433f5bf11` → `90acc856a5b2`)
+- UI 팔레트 톤다운 — 선명한 5색(coral/gold/cyan/magenta/crystal)을 차분한 톤(rose/amber/cadet/iris/lavender)으로 교체. HTML 리포트 CSS 변수 + gradient 동기화
 
 ---
 

--- a/core/extensibility/templates/report.html
+++ b/core/extensibility/templates/report.html
@@ -6,11 +6,11 @@
 <title>GEODE Analysis — ${ip_name}</title>
 <style>
   :root {
-    --coral: #f5a0a0;
-    --gold: #ffd700;
-    --cyan: #00ced1;
-    --magenta: #d946ef;
-    --crystal: #c8a2ff;
+    --coral: #d4a0a0;
+    --gold: #e0b040;
+    --cyan: #5f9ea0;
+    --magenta: #9775c4;
+    --crystal: #a88fd4;
     --dark: #0f172a;
     --surface: #1e293b;
     --card: #ffffff;
@@ -227,11 +227,11 @@
     border-radius: 4px;
     transition: width 0.8s ease;
   }
-  .bar-fill-psm { background: linear-gradient(90deg, var(--coral), #e06060); }
-  .bar-fill-quality { background: linear-gradient(90deg, var(--cyan), #009ca3); }
-  .bar-fill-recovery { background: linear-gradient(90deg, var(--crystal), #9060e0); }
-  .bar-fill-growth { background: linear-gradient(90deg, var(--gold), #cc9900); }
-  .bar-fill-momentum { background: linear-gradient(90deg, var(--magenta), #b030d0); }
+  .bar-fill-psm { background: linear-gradient(90deg, var(--coral), #b88080); }
+  .bar-fill-quality { background: linear-gradient(90deg, var(--cyan), #4a8082); }
+  .bar-fill-recovery { background: linear-gradient(90deg, var(--crystal), #7a60b0); }
+  .bar-fill-growth { background: linear-gradient(90deg, var(--gold), #b89830); }
+  .bar-fill-momentum { background: linear-gradient(90deg, var(--magenta), #7058a0); }
   .bar-fill-dev { background: linear-gradient(90deg, #60a0ff, #3070cc); }
   .subscore-value {
     font-size: 0.85rem;

--- a/core/ui/console.py
+++ b/core/ui/console.py
@@ -1,10 +1,11 @@
 """Rich Console singleton — GEODE brand theme.
 
-Brand colors (from axolotl mascot):
-  Coral/pink (#f5a0a0)  — axolotl body → brand identity
-  Gold (#ffd700)         — headlamp → energy, highlights
-  Cyan (#00ced1)         — crystals, tech → interactive elements
-  Magenta (#d946ef)      — gills → accent, tool names
+Brand colors (from axolotl mascot, toned-down for readability):
+  Rose (#d4a0a0)     — axolotl body → brand identity (muted coral)
+  Amber (#e0b040)    — headlamp → energy, highlights (warm gold)
+  Cadet (#5f9ea0)    — crystals, tech → interactive elements (calm cyan)
+  Iris (#9775c4)     — gills → accent, tool names (soft purple)
+  Lavender (#a88fd4) — geode crystal purple (muted crystal)
 """
 
 from __future__ import annotations
@@ -12,12 +13,12 @@ from __future__ import annotations
 from rich.console import Console
 from rich.theme import Theme
 
-# -- Brand palette (terminal-safe) --
-_CORAL = "#f5a0a0"  # axolotl body
-_GOLD = "#ffd700"  # headlamp
-_CYAN = "#00ced1"  # crystals / tech
-_MAGENTA = "#d946ef"  # gills / accent
-_CRYSTAL = "#c8a2ff"  # geode crystal purple
+# -- Brand palette (terminal-safe, toned-down) --
+_CORAL = "#d4a0a0"  # axolotl body (muted rose)
+_GOLD = "#e0b040"  # headlamp (warm amber)
+_CYAN = "#5f9ea0"  # crystals / tech (calm cadet)
+_MAGENTA = "#9775c4"  # gills / accent (soft iris)
+_CRYSTAL = "#a88fd4"  # geode crystal (muted lavender)
 
 GEODE_THEME = Theme(
     {


### PR DESCRIPTION
## 요약

GEODE 5색 팔레트를 차분한 톤으로 교체. Claude Code 수준의 절제된 터미널 미학 지향.

## 변경 사항

### 핵심
- **`console.py`**: 5색 팔레트 톤다운 — **왜?** 기존 max saturation(coral/gold/cyan/magenta/crystal)이 터미널에서 눈부시고 프로페셔널하지 않음

| AS-IS | TO-BE | 변경 |
|-------|-------|------|
| coral `#f5a0a0` | rose `#d4a0a0` | 채도 낮춤 |
| gold `#ffd700` | amber `#e0b040` | 따뜻한 앰버 |
| cyan `#00ced1` | cadet `#5f9ea0` | 차분한 블루그린 |
| magenta `#d946ef` | iris `#9775c4` | 부드러운 퍼플 |
| crystal `#c8a2ff` | lavender `#a88fd4` | 차분한 라벤더 |

### 부수
- **`report.html`**: CSS 변수 5색 동기화 + score bar gradient 종점 색상 동기화

## 설계 판단

GEODE_THEME은 console.py에서 1곳에만 정의. 모든 UI 컴포넌트(agentic_ui, panels, status, streaming, commands)가 theme style tag로 참조하므로, console.py만 수정하면 전체 UI에 반영됨. HTML 리포트만 별도 CSS 변수이므로 추가 동기화 필요.

## 테스트

- `uv run pytest tests/ -q`: 전체 통과
- `uv run ruff check core/ tests/`: 0 errors

## 검증 체크리스트

- [x] console.py 5색 교체
- [x] report.html CSS 변수 동기화
- [x] report.html gradient 종점 동기화
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)