### PR TITLE
fix: 멀티턴 tool_result 고아 참조 400 에러 — 3중 방어

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - 복사/붙여넣기 알림 — 멀티라인 paste 감지 시 `[Pasted text +N lines]` 표시 후 추가 입력 대기 (즉시 실행 방지)
 
+### Fixed
+- 멀티턴 tool_result 고아 참조 400 에러 — 3중 방어: (1) Anthropic `clear_tool_uses` 서버사이드 컨텍스트 관리, (2) `ConversationContext._trim()`에 tool pair sanitization 추가, (3) 기존 `_repair_messages()` 유지
+
 ### Changed
 - Identity Pivot 완성 — `analyst.md` SYSTEM 프롬프트에서 "undervalued IP discovery agent" 제거, 게임 전용 예시를 도메인 비의존적 예시로 교체
 - `ANALYST_SYSTEM` 해시 핀 갱신 (`924433f5bf11` → `90acc856a5b2`)

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -553,6 +553,19 @@ class AgenticLoop:
                     max_tokens=self.max_tokens,
                     temperature=0.0,
                     timeout=120.0,
+                    extra_headers={
+                        "anthropic-beta": "context-management-2025-06-27",
+                    },
+                    extra_body={
+                        "context_management": {
+                            "edits": [
+                                {
+                                    "type": "clear_tool_uses_20250919",
+                                    "keep": {"type": "tool_uses", "value": 5},
+                                }
+                            ]
+                        }
+                    },
                 )
                 return response  # type: ignore[no-any-return]
 

--- a/core/cli/conversation.py
+++ b/core/cli/conversation.py
@@ -70,8 +70,9 @@ class ConversationContext:
     def _trim(self) -> None:
         """Keep only the last ``max_turns * 2`` messages.
 
-        We preserve pairs so the message list always starts with a user
-        message (required by the Anthropic API).
+        Preserves tool_use/tool_result pairs: after slicing, any orphaned
+        tool_result blocks (whose tool_use was trimmed away) are removed
+        to prevent Anthropic API 400 errors.
         """
         max_msgs = self.max_turns * 2
         if len(self.messages) <= max_msgs:
@@ -83,8 +84,54 @@ class ConversationContext:
         while self.messages and self.messages[0]["role"] != "user":
             self.messages.pop(0)
 
+        # Sanitize orphaned tool_result blocks.
+        # A tool_result in a user message must reference a tool_use_id
+        # in the immediately preceding assistant message.
+        self._sanitize_tool_pairs()
+
         log.debug(
             "ConversationContext trimmed to %d messages (%d turns)",
             len(self.messages),
             self.turn_count,
         )
+
+    def _sanitize_tool_pairs(self) -> None:
+        """Remove orphaned tool_result blocks from conversation history.
+
+        Scans user messages with list content; for each tool_result block,
+        checks that the preceding assistant message has a matching tool_use.
+        Orphans are dropped silently.
+        """
+        sanitized: list[dict[str, Any]] = []
+        for i, msg in enumerate(self.messages):
+            if msg["role"] == "user" and isinstance(msg.get("content"), list):
+                # Collect valid tool_use IDs from preceding assistant message
+                prev_tool_ids: set[str] = set()
+                if i > 0 and self.messages[i - 1]["role"] == "assistant":
+                    prev = self.messages[i - 1]
+                    for blk in prev.get("content") or []:
+                        if isinstance(blk, dict) and blk.get("type") == "tool_use":
+                            prev_tool_ids.add(blk["id"])
+
+                valid_content: list[Any] = []
+                dropped = 0
+                for blk in msg["content"]:
+                    if (
+                        isinstance(blk, dict)
+                        and blk.get("type") == "tool_result"
+                        and blk.get("tool_use_id") not in prev_tool_ids
+                    ):
+                        dropped += 1
+                        continue
+                    valid_content.append(blk)
+
+                if dropped:
+                    log.debug("Dropped %d orphaned tool_result blocks at index %d", dropped, i)
+
+                if valid_content:
+                    sanitized.append({**msg, "content": valid_content})
+                # else: entire message was orphaned tool_results — drop it
+            else:
+                sanitized.append(msg)
+
+        self.messages = sanitized


### PR DESCRIPTION
## 요약

장시간 세션에서 대화 슬라이딩 윈도우가 tool_use/tool_result 쌍을 분리하여 Anthropic API 400 에러 발생하는 근본 버그 수정.

## 변경 사항

### 핵심
- **`agentic_loop.py`**: Anthropic `context_management` (clear_tool_uses_20250919) 서버사이드 적용 — **왜?** API가 tool pair 무결성을 원자적으로 보장. 최근 5개 tool pair 유지, 나머지 자동 정리. 클라이언트 sanitization보다 안전
- **`conversation.py`**: `_trim()` 후 `_sanitize_tool_pairs()` 호출 — **왜?** 서버사이드가 beta이므로 방어적 클라이언트 sanitization 추가. 고아 tool_result 블록을 사전 제거

### 유지
- `_repair_messages()` (agentic_loop.py:381-434) — 3차 방어선. 400 에러 발생 시 reactive 수정

## 설계 판단

**3중 방어 전략** (프론티어 조사 기반):

| 계층 | 메커니즘 | 시점 | 출처 |
|------|---------|------|------|
| L1 서버 | `clear_tool_uses_20250919` | API 호출 시 | Anthropic Context Management Beta |
| L2 클라이언트 | `_sanitize_tool_pairs()` | `_trim()` 후 | OpenClaw #5832 패턴 |
| L3 복구 | `_repair_messages()` | 400 에러 후 | 기존 코드 유지 |

프론티어 조사:
- Anthropic SDK: 서버사이드 `clear_tool_uses` + `compact` 제공 (클라이언트 trim 유틸 없음)
- OpenClaw #5832/#7527: 동일 버그, sanitization이 trimming 이전에 실행되어 문제 발생
- LangChain #29637: `trim_messages`가 tool pair 미보존 (known bug)
- LiteLLM #19061: 양방향 sanitization 함수로 해결

## 테스트

- `uv run pytest tests/ -q`: 전체 통과
- `uv run ruff check core/ tests/`: 0 errors
- mypy 통과

## 검증 체크리스트

- [x] conversation._trim() tool-aware
- [x] 서버사이드 context_management 적용
- [x] 기존 _repair_messages() 유지
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)