### PR TITLE
fix: CLI/REPL 출력에서 장식용 이모지 제거

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - Token Guard 완화 — `MAX_TOOL_RESULT_TOKENS` 4096 → 16384 (1M 컨텍스트 활용 극대화). `settings.max_tool_result_tokens`로 설정 가능
 
+### Fixed
+- 프롬프트/REPL 출력에서 장식용 이모지 제거 — 리포트 생성 외 모든 CLI 출력에서 이모지(⚡⚠✏⏸) 삭제, UI 마커(✓✗✢●)는 유지
+
 ---
 
 ## [0.14.0] — 2026-03-16

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -571,7 +571,7 @@ def _handle_interrupt(
     iteration = final_state.get("iteration", 1)
     confidence = final_state.get("composite_score", {})
     console.print(
-        f"\n  [bold yellow]⏸ Pipeline paused[/bold yellow] (iter={iteration}, steps={len(done)})"
+        f"\n  [bold yellow]Pipeline paused[/bold yellow] (iter={iteration}, steps={len(done)})"
     )
     if confidence:
         console.print(f"  [dim]Current confidence: {confidence}[/dim]")
@@ -1918,7 +1918,7 @@ def _build_tool_handlers(
 
             if failed:
                 console.print(
-                    f"  [warning]⚠ Partial success: {completed}/{total} steps "
+                    f"  [warning]Partial success: {completed}/{total} steps "
                     f"(failed: {', '.join(failed)})[/warning]"
                 )
             else:

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -329,7 +329,7 @@ class ToolExecutor:
 
         _restore_terminal()
         console.print()
-        console.print("  [bold yellow]⚡ MCP tool requires approval[/bold yellow]")
+        console.print("  [bold yellow]MCP tool requires approval[/bold yellow]")
         console.print(f"  [dim]Server:[/dim] [bold]{server}[/bold]")
         console.print(f"  [dim]Tool:[/dim]   [bold]{tool_name}[/bold]")
         console.print()
@@ -356,7 +356,7 @@ class ToolExecutor:
             summary = f"action={tool_input.get('action', '?')}"
 
         console.print()
-        console.print("  [bold yellow]✏ Write operation requires approval[/bold yellow]")
+        console.print("  [bold yellow]Write operation requires approval[/bold yellow]")
         console.print(f"  [dim]Tool:[/dim]    [bold]{tool_name}[/bold]")
         if summary:
             console.print(f"  [dim]Summary:[/dim] {summary}")
@@ -391,7 +391,7 @@ class ToolExecutor:
 
         _restore_terminal()
         console.print()
-        console.print("  [bold yellow]⚠ Bash command requires approval[/bold yellow]")
+        console.print("  [bold yellow]Bash command requires approval[/bold yellow]")
         console.print(f"  [dim]Command:[/dim] [bold]{command}[/bold]")
         if reason:
             console.print(f"  [dim]Reason:[/dim]  {reason}")

--- a/tests/_live_audit_runner.py
+++ b/tests/_live_audit_runner.py
@@ -124,7 +124,7 @@ def main():
     # Output JSON for collection
     print(f"\n--- {group.upper()} RESULTS ---")
     for r in results:
-        mark = "✓" if r["status"] == "PASS" else "⚠" if r["status"] == "WARN" else "✗"
+        mark = "✓" if r["status"] == "PASS" else "!" if r["status"] == "WARN" else "✗"
         issues_str = f" | {', '.join(r['issues'])}" if r["issues"] else ""
         print(
             f"  {mark} {r['tool']:20s} [{r['status']}] rounds={r['rounds']} called={r['called']} "


### PR DESCRIPTION
## 요약
- CLI/REPL 출력의 장식용 이모지 6건 제거
- UI 기능 마커(✓, ✗, ✢, ●, ▸)는 유지, 리포트 이모지도 유지

## 변경 사항

### 핵심
- `core/cli/tool_executor.py`: MCP/Write/Bash 승인 프롬프트에서 ⚡✏⚠ 제거 → 텍스트만
- `core/cli/__init__.py`: 파이프라인 일시정지 ⏸, 부분 성공 ⚠ 제거 → 텍스트만
- `tests/_live_audit_runner.py`: WARN 마커 ⚠ → `!`

### 보존 대상
- UI 마커 (✓ ✗ ✢ ● ▸ ⎿) — Claude Code 스타일 기능 마커, 유지
- 리포트 이모지 (📊 🔍 🔬 🛡️) — reports.py, 유지
- 프롬프트 .md 파일 — 이모지 없음 확인, 변경 불필요

## 영향 범위
- HITL 승인 프롬프트 텍스트 변경 (기능 무변경)
- 핀드 해시 변경 없음 (프롬프트 템플릿 미변경)

## 테스트
- ruff: 0 errors
- mypy: 0 errors
- pytest: 2367 passed, 19 deselected

## 검증 체크리스트
- [x] lint 통과
- [x] type check 통과
- [x] 전체 테스트 통과
- [x] 프롬프트 핀 해시 변경 없음
- [x] 리포트 이모지 보존 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)