### PR TITLE
fix: APIConnectionError 간헐 반복 — httpx 풀 설정 + 싱글턴 전환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - 프롬프트/REPL 출력에서 장식용 이모지 제거 — 리포트 생성 외 모든 CLI 출력에서 이모지(⚡⚠✏⏸) 삭제, UI 마커(✓✗✢●)는 유지
+- APIConnectionError 간헐 반복 — httpx 커넥션 풀 설정 추가 (max_connections=20, keepalive_expiry=30s), 싱글턴 Anthropic 클라이언트로 전환, 재시도 백오프 2s/4s/8s로 단축, 연결 관련 설정 config.py로 이관
 
 ---
 

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -28,7 +28,7 @@ from core.cli.error_recovery import ErrorRecoveryStrategy
 from core.cli.nl_router import _build_system_prompt
 from core.cli.tool_executor import ToolExecutor
 from core.config import ANTHROPIC_PRIMARY, settings
-from core.llm.client import _maybe_traceable
+from core.llm.client import _maybe_traceable, get_async_anthropic_client
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.orchestration.hooks import HookEvent, HookSystem
 from core.ui.agentic_ui import OperationLogger
@@ -524,10 +524,10 @@ class AgenticLoop:
             return None
 
         if self._client is None:
-            # Disable SDK-level retries to prevent double-retry with our own loop.
-            # Default max_retries=2 causes SDK to retry timeouts 3× internally,
-            # compounding with our 3 retries → 9 total attempts / 18min worst case.
-            self._client = anthropic.AsyncAnthropic(api_key=api_key, max_retries=0)
+            # Use singleton async client with configured httpx connection pool.
+            # SDK max_retries=0 is set in the singleton to prevent double-retry
+            # with our app-level backoff loop below.
+            self._client = get_async_anthropic_client(api_key)
 
         # Force text response in the last WRAP_UP_HEADROOM rounds
         # so the LLM always has a chance to summarize before max_rounds
@@ -535,7 +535,7 @@ class AgenticLoop:
         force_text = remaining <= self.WRAP_UP_HEADROOM
         tool_choice: dict[str, str] = {"type": "none"} if force_text else {"type": "auto"}
 
-        max_retries = 3
+        max_retries = settings.llm_max_retries
         for attempt in range(max_retries):
             try:
                 # Strip non-API fields before sending to Anthropic.
@@ -554,7 +554,6 @@ class AgenticLoop:
                     tool_choice=tool_choice,
                     max_tokens=self.max_tokens,
                     temperature=0.0,
-                    timeout=120.0,
                     extra_headers={
                         "anthropic-beta": "context-management-2025-06-27",
                     },
@@ -572,10 +571,15 @@ class AgenticLoop:
                 return response  # type: ignore[no-any-return]
 
             except (anthropic.APITimeoutError, anthropic.APIConnectionError) as exc:
-                wait = 2**attempt * 5  # 5s, 10s, 20s
+                # Exponential backoff: 2s, 4s, 8s (fast initial retry for transient
+                # connection resets, capped by settings.llm_retry_max_delay)
+                wait = min(
+                    settings.llm_retry_base_delay * (2**attempt),
+                    settings.llm_retry_max_delay,
+                )
                 exc_type = type(exc).__name__
                 log.warning(
-                    "%s (attempt %d/%d), retrying in %ds",
+                    "%s (attempt %d/%d), retrying in %.1fs",
                     exc_type,
                     attempt + 1,
                     max_retries,
@@ -588,9 +592,10 @@ class AgenticLoop:
                     self._last_llm_error = f"{exc_type} after {max_retries} retries"
                     return None
             except anthropic.RateLimitError:
-                wait = 2**attempt * 10  # 10s, 20s, 40s
+                # Rate limits use longer backoff: 10s, 20s, 40s
+                wait = min(2**attempt * 10, settings.llm_retry_max_delay)
                 log.warning(
-                    "Rate limited (attempt %d/%d), retrying in %ds",
+                    "Rate limited (attempt %d/%d), retrying in %.1fs",
                     attempt + 1,
                     max_retries,
                     wait,

--- a/core/cli/nl_router.py
+++ b/core/cli/nl_router.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any
 import anthropic
 
 from core.config import settings
+from core.llm.client import get_anthropic_client
 from core.llm.prompts import ROUTER_SYSTEM
 
 if TYPE_CHECKING:
@@ -544,7 +545,7 @@ def _call_tool_use_router(
             log.debug("No Anthropic API key — LLM router unavailable")
             return _offline_fallback(text, error="no_api_key")
 
-        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        client = get_anthropic_client()
 
         # Build messages with conversation history for context-aware routing
         if context is not None and not context.is_empty:

--- a/core/config.py
+++ b/core/config.py
@@ -96,6 +96,18 @@ class Settings(BaseSettings):
     # Plan Mode — Autonomous Execution
     plan_auto_execute: bool = False  # GEODE_PLAN_AUTO_EXECUTE=true to enable
 
+    # LLM Connection — httpx pool & timeout tuning
+    llm_max_connections: int = 20  # httpx pool: max total connections
+    llm_max_keepalive_connections: int = 5  # httpx pool: max idle keep-alive connections
+    llm_keepalive_expiry: float = 30.0  # seconds before idle connection is closed
+    llm_connect_timeout: float = 10.0  # TCP connect timeout (seconds)
+    llm_read_timeout: float = 120.0  # response read timeout (seconds)
+    llm_write_timeout: float = 30.0  # request write timeout (seconds)
+    llm_pool_timeout: float = 10.0  # wait for available connection from pool (seconds)
+    llm_retry_base_delay: float = 2.0  # base delay for exponential backoff (seconds)
+    llm_retry_max_delay: float = 30.0  # max delay cap for retries (seconds)
+    llm_max_retries: int = 3  # max retry attempts per model
+
 
 _settings_instance: Settings | None = None
 

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -5,20 +5,29 @@ Failover strategy (OpenClaw-inspired 4-stage):
 2. Model fallback chain (primary → fallback models)
 3. Context overflow detection (token limit → truncation hint)
 4. Graceful degradation (log + raise after all retries exhausted)
+
+Connection pool strategy:
+- Singleton Anthropic clients (sync + async) with configured httpx pool
+- max_connections=20, max_keepalive=5, keepalive_expiry=30s
+- Explicit connect/read/write/pool timeouts prevent stale connection hangs
+- SDK max_retries=0 to avoid double-retry with app-level backoff
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os as _os
 import re
+import threading
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import anthropic
+import httpx
 from anthropic.types import TextBlockParam
 from pydantic import BaseModel
 
@@ -81,11 +90,45 @@ def _maybe_traceable(
 # ---------------------------------------------------------------------------
 
 
-# Failover configuration
-MAX_RETRIES = 3
-RETRY_BASE_DELAY = 1.0  # seconds
-RETRY_MAX_DELAY = 30.0
+# Failover configuration — sourced from settings with backward-compat defaults
+MAX_RETRIES = settings.llm_max_retries
+RETRY_BASE_DELAY = settings.llm_retry_base_delay
+RETRY_MAX_DELAY = settings.llm_retry_max_delay
 FALLBACK_MODELS = ANTHROPIC_FALLBACK_CHAIN
+
+
+# ---------------------------------------------------------------------------
+# httpx connection pool — configured for long-lived REPL sessions
+# ---------------------------------------------------------------------------
+
+
+def _build_httpx_timeout() -> httpx.Timeout:
+    """Build httpx Timeout from settings."""
+    return httpx.Timeout(
+        connect=settings.llm_connect_timeout,
+        read=settings.llm_read_timeout,
+        write=settings.llm_write_timeout,
+        pool=settings.llm_pool_timeout,
+    )
+
+
+def _build_httpx_limits() -> httpx.Limits:
+    """Build httpx connection pool Limits from settings."""
+    return httpx.Limits(
+        max_connections=settings.llm_max_connections,
+        max_keepalive_connections=settings.llm_max_keepalive_connections,
+        keepalive_expiry=settings.llm_keepalive_expiry,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Singleton Anthropic clients — reuse connection pool across all calls
+# ---------------------------------------------------------------------------
+_sync_client: anthropic.Anthropic | None = None
+_sync_client_lock = threading.Lock()
+
+_async_client: anthropic.AsyncAnthropic | None = None
+_async_client_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +187,72 @@ _RETRYABLE_ERRORS = (
 
 
 def get_anthropic_client() -> anthropic.Anthropic:
-    return anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    """Return a singleton sync Anthropic client with configured connection pool.
+
+    Thread-safe. The client is created once and reused for all sync LLM calls,
+    ensuring httpx connection pooling works effectively across calls.
+    SDK-level retries are disabled (max_retries=0) to avoid conflict with
+    app-level retry logic in ``_retry_with_backoff()``.
+    """
+    global _sync_client
+    if _sync_client is not None:
+        return _sync_client
+    with _sync_client_lock:
+        if _sync_client is None:
+            http_client = httpx.Client(
+                limits=_build_httpx_limits(),
+                timeout=_build_httpx_timeout(),
+            )
+            _sync_client = anthropic.Anthropic(
+                api_key=settings.anthropic_api_key,
+                max_retries=0,  # app-level retry handles this
+                http_client=http_client,
+            )
+        return _sync_client
+
+
+def get_async_anthropic_client(api_key: str | None = None) -> anthropic.AsyncAnthropic:
+    """Return a singleton async Anthropic client with configured connection pool.
+
+    Thread-safe. The client is created once and reused for all async LLM calls
+    (AgenticLoop, etc.), ensuring httpx connection pooling works effectively.
+    SDK-level retries are disabled (max_retries=0) to avoid conflict with
+    app-level retry logic.
+
+    Args:
+        api_key: Optional API key override. If None, uses settings.
+    """
+    global _async_client
+    if _async_client is not None:
+        return _async_client
+    with _async_client_lock:
+        if _async_client is None:
+            key = api_key or settings.anthropic_api_key
+            http_client = httpx.AsyncClient(
+                limits=_build_httpx_limits(),
+                timeout=_build_httpx_timeout(),
+            )
+            _async_client = anthropic.AsyncAnthropic(
+                api_key=key,
+                max_retries=0,  # app-level retry handles this
+                http_client=http_client,
+            )
+        return _async_client
+
+
+def reset_clients() -> None:
+    """Close and reset singleton clients. Used in tests and on API key change."""
+    global _sync_client, _async_client
+    with _sync_client_lock:
+        if _sync_client is not None:
+            with contextlib.suppress(Exception):
+                _sync_client.close()
+            _sync_client = None
+    with _async_client_lock:
+        if _async_client is not None:
+            # AsyncClient.close() is a coroutine but we're in sync context
+            # Just drop the reference — GC will clean up
+            _async_client = None
 
 
 def _system_with_cache(system: str) -> list[TextBlockParam]:
@@ -263,7 +371,6 @@ def call_llm(
             temperature=temperature,
             system=system_cached,
             messages=[{"role": "user", "content": user}],
-            timeout=90.0,
         )
         # Capture token usage
         if hasattr(response, "usage") and response.usage:
@@ -327,7 +434,6 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
             system=system_cached,
             messages=[{"role": "user", "content": user}],
             output_format=output_model,
-            timeout=90.0,
         )
         # Capture token usage
         if hasattr(response, "usage") and response.usage:
@@ -486,7 +592,6 @@ def call_llm_with_tools(
                 messages=messages,
                 tools=tools,
                 tool_choice=_tc,
-                timeout=90.0,
             )
 
         response = _retry_with_backoff(_do_call, model=target_model)

--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -253,14 +253,13 @@ class WebSearchTool:
 
         # Attempt real web search via Anthropic SDK
         try:
-            import anthropic
-
             from core.config import settings
+            from core.llm.client import get_anthropic_client
 
             if not settings.anthropic_api_key:
                 return self._stub_result(query, "no_api_key")
 
-            client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+            client = get_anthropic_client()
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -90,14 +90,13 @@ class GeneralWebSearchTool:
         max_results: int = kwargs.get("max_results", 5)
 
         try:
-            import anthropic
-
             from core.config import ANTHROPIC_BUDGET, settings
+            from core.llm.client import get_anthropic_client
 
             if not settings.anthropic_api_key:
                 return {"error": "No API key configured for web search"}
 
-            client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+            client = get_anthropic_client()
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,

--- a/tests/test_nl_router.py
+++ b/tests/test_nl_router.py
@@ -232,12 +232,12 @@ class TestToolUseRouter:
         """LLM calls list_ips tool."""
         resp = _make_tool_use_response("list_ips", {})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("IP 목록 보여줘")
@@ -249,12 +249,12 @@ class TestToolUseRouter:
         """LLM calls analyze_ip tool with ip_name."""
         resp = _make_tool_use_response("analyze_ip", {"ip_name": "Cowboy Bebop"})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("Cowboy Bebop 분석해")
@@ -266,12 +266,12 @@ class TestToolUseRouter:
         """LLM calls search_ips tool."""
         resp = _make_tool_use_response("search_ips", {"query": "소울라이크"})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("소울라이크 검색")
@@ -286,12 +286,12 @@ class TestToolUseRouter:
             {"ip_a": "Berserk", "ip_b": "Ghost In The Shell"},
         )
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("Berserk vs Ghost In The Shell")
@@ -304,12 +304,12 @@ class TestToolUseRouter:
         """LLM calls show_help tool."""
         resp = _make_tool_use_response("show_help", {})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("도움말")
@@ -321,12 +321,12 @@ class TestToolUseRouter:
         """LLM responds with text → chat intent."""
         resp = _make_text_response("게임 퍼블리싱은 계약을 통해 진행됩니다.")
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("게임 퍼블리싱이 뭐야?")
@@ -367,12 +367,11 @@ class TestGracefulDegradation:
     def test_api_error(self, router_llm: NLRouter) -> None:
         """API exception → offline fallback."""
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
-            _preserve_exceptions(mock_anthropic)
-            mock_anthropic.Anthropic.side_effect = Exception("API down")
+            mock_get_client.side_effect = Exception("API down")
 
             intent = router_llm.classify("이상한 입력")
 
@@ -383,13 +382,12 @@ class TestGracefulDegradation:
     def test_api_timeout(self, router_llm: NLRouter) -> None:
         """Timeout → offline fallback."""
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
-            _preserve_exceptions(mock_anthropic)
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.side_effect = TimeoutError("Request timed out")
 
             intent = router_llm.classify("타임아웃 테스트")
@@ -401,13 +399,12 @@ class TestGracefulDegradation:
     def test_auth_error(self, router_llm: NLRouter) -> None:
         """Invalid API key → offline fallback with auth_error."""
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-invalid"
-            _preserve_exceptions(mock_anthropic)
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.side_effect = anthropic.AuthenticationError(
                 message="invalid x-api-key",
                 response=MagicMock(status_code=401),
@@ -422,13 +419,12 @@ class TestGracefulDegradation:
     def test_billing_error(self, router_llm: NLRouter) -> None:
         """Credit balance error → offline fallback with billing error."""
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
-            _preserve_exceptions(mock_anthropic)
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.side_effect = anthropic.BadRequestError(
                 message="Your credit balance is too low",
                 response=MagicMock(status_code=400),
@@ -443,13 +439,12 @@ class TestGracefulDegradation:
     def test_billing_error_unknown_input(self, router_llm: NLRouter) -> None:
         """Billing error on unrecognized input → help with billing."""
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
-            _preserve_exceptions(mock_anthropic)
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.side_effect = anthropic.BadRequestError(
                 message="Your credit balance is too low",
                 response=MagicMock(status_code=400),
@@ -465,12 +460,12 @@ class TestGracefulDegradation:
         """LLM returns empty text → help fallback."""
         resp = _make_text_response("", with_usage=False)
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("빈 응답 테스트")
@@ -493,13 +488,13 @@ class TestTokenUsageTracking:
         mock_tracker = MagicMock()
         mock_tracker.record.return_value = MagicMock(cost_usd=0.0035)
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
             patch("core.llm.token_tracker.get_tracker", return_value=mock_tracker),
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             router_llm.classify("목록")
@@ -510,12 +505,12 @@ class TestTokenUsageTracking:
         """No usage field → no tracking error."""
         resp = _make_tool_use_response("list_ips", {}, with_usage=False)
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("목록")
@@ -735,12 +730,12 @@ class TestNewToolParsing:
         """Full flow: LLM calls batch_analyze."""
         resp = _make_tool_use_response("batch_analyze", {"top": 10})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("전체 IP 배치 분석해줘")
@@ -752,12 +747,12 @@ class TestNewToolParsing:
         """Full flow: LLM calls check_status."""
         resp = _make_tool_use_response("check_status", {})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("시스템 상태 보여줘")
@@ -809,12 +804,12 @@ class TestPlanDelegateNL:
         """Full flow: LLM calls create_plan."""
         resp = _make_tool_use_response("create_plan", {"ip_name": "Berserk"})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("Berserk 분석 계획 세워줘")
@@ -829,12 +824,12 @@ class TestPlanDelegateNL:
             {"tasks": [{"type": "analyze", "ip_name": "Berserk"}]},
         )
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             intent = router_llm.classify("병렬로 Berserk 분석해줘")
@@ -892,12 +887,12 @@ class TestContextInjection:
 
         resp = _make_tool_use_response("analyze_ip", {"ip_name": "Berserk"})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             router = NLRouter(llm_enabled=True)
@@ -914,12 +909,12 @@ class TestContextInjection:
         """context=None sends single message (backward compat)."""
         resp = _make_tool_use_response("list_ips", {})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             router = NLRouter(llm_enabled=True)
@@ -941,12 +936,12 @@ class TestContextInjection:
 
         resp = _make_tool_use_response("list_ips", {})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             router = NLRouter(llm_enabled=True)
@@ -968,12 +963,12 @@ class TestContextInjection:
 
         resp = _make_tool_use_response("list_ips", {})
         with (
-            patch("core.cli.nl_router.anthropic") as mock_anthropic,
+            patch("core.cli.nl_router.get_anthropic_client") as mock_get_client,
             patch("core.cli.nl_router.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = "sk-ant-test"
             mock_client = MagicMock()
-            mock_anthropic.Anthropic.return_value = mock_client
+            mock_get_client.return_value = mock_client
             mock_client.messages.create.return_value = resp
 
             router = NLRouter(llm_enabled=True)


### PR DESCRIPTION
## 요약
- GEODE REPL에서 간헐 발생하던 `APIConnectionError (attempt 1/3)` 근본 원인 4건 해소
- httpx 커넥션 풀 설정, 싱글턴 클라이언트, 재시도 최적화, 타임아웃 세분화

## 변경 사항

### 핵심
- `core/llm/client.py`: 싱글턴 sync/async Anthropic 클라이언트 + httpx 풀 설정 (max_connections, keepalive_expiry) + `reset_clients()` 테스트용
- `core/cli/agentic_loop.py`: 싱글턴 async 클라이언트 사용, backoff 2s/4s/8s (기존 5s/10s/20s)
- `core/config.py`: LLM 연결 설정 11개 추가 (풀 크기, 타임아웃, 재시도 파라미터)

### 부수
- `core/cli/nl_router.py`: bare `anthropic.Anthropic()` → `get_anthropic_client()` 싱글턴
- `core/tools/signal_tools.py`: 동일 싱글턴 전환
- `core/tools/web_tools.py`: 동일 싱글턴 전환
- `tests/test_nl_router.py`: mock target 업데이트

## 근본 원인 분석

| 원인 | 해소 방법 |
|------|----------|
| httpx 풀 미설정 → stale keep-alive 누적 | max_connections/keepalive_expiry 설정 |
| 파편화된 다중 클라이언트 | 싱글턴 팩토리 전환 |
| 과도한 재시도 대기 (5/10/20s) | 2/4/8s로 단축 |
| per-call timeout 덮어쓰기 | 클라이언트 레벨 세분화 타임아웃 |

## 테스트
- ruff: 0 errors
- mypy: 0 errors (134 modules)
- pytest: 2367 passed, 19 deselected

## 검증 체크리스트
- [x] lint 통과
- [x] type check 통과
- [x] 전체 테스트 통과
- [x] pre-commit hooks 통과
- [x] CHANGELOG 항목 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)