### PR TITLE
fix: 대화 턴/라운드 제한 완화 — max_turns 200, max_rounds 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Token Guard 상한 제거 — `MAX_TOOL_RESULT_TOKENS` 기본값 0 (무제한). 프론티어 합의: 하드 캡 대신 압축(Karpathy P6) + `clear_tool_uses` 서버측 정리로 컨텍스트 관리. `GEODE_MAX_TOOL_RESULT_TOKENS` 환경변수로 필요 시 상한 재설정 가능
+- 대화 턴/라운드 제한 대폭 완화 — `max_turns` 20→200, `DEFAULT_MAX_ROUNDS` 30→50. 1M 컨텍스트 + 서버측 `clear_tool_uses`가 주 관리 담당, 클라이언트 제한은 극단적 runaway 방지용 안전망으로만 유지
 
 ### Fixed
 - 프롬프트/REPL 출력에서 장식용 이모지 제거 — 리포트 생성 외 모든 CLI 출력에서 이모지(⚡⚠✏⏸) 삭제, UI 마커(✓✗✢●)는 유지

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ core/
 │   ├── sub_agent.py     # SubAgentManager + SubAgentResult + ErrorCategory
 │   ├── tool_executor.py # Tool dispatch + HITL + delegate_task handler
 │   ├── nl_router.py     # NL intent classification (LLM → regex → help)
-│   ├── conversation.py  # Multi-turn sliding-window (max 20 turns)
+│   ├── conversation.py  # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── batch.py         # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py      # Slash command dispatch (17 commands)
 │   ├── error_recovery.py # ErrorRecoveryStrategy (retry → alternative → fallback → escalate)

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ graph TB
 | **LLM Tool Use** | Claude Opus 4.6 — base 38 + MCP 20+ tool 정의 전달, `stop_reason` 기반 루프 제어 |
 | **ToolExecutor** | 4-tier safety: SAFE / STANDARD / WRITE / DANGEROUS (bash 사용자 승인 필수) |
 | **Clarification** | 필수 파라미터 누락 시 LLM이 사용자에게 되묻기 |
-| **max_rounds** | 기본 15 라운드 — 마지막 2라운드에서 텍스트 응답 강제 |
-| **Multi-turn** | 슬라이딩 윈도우 (max 20 turns) — 대명사 해석, follow-up 쿼리 지원 |
+| **max_rounds** | 기본 50 라운드 — 마지막 2라운드에서 텍스트 응답 강제 (1M 컨텍스트 + `clear_tool_uses` 활용) |
+| **Multi-turn** | 슬라이딩 윈도우 (max 200 turns) — 서버측 `clear_tool_uses`가 주 컨텍스트 관리, 클라이언트 제한은 안전망 |
 | **LangSmith** | 토큰 수/비용을 RunTree에 기록, 세션 합산 |
 
 ### Goal Decomposition
@@ -616,7 +616,7 @@ core/
 │   ├── sub_agent.py            # SubAgentManager + SubAgentResult + ErrorCategory
 │   ├── tool_executor.py        # Tool dispatch + HITL approval gate
 │   ├── nl_router.py            # Natural language intent classification
-│   ├── conversation.py         # Multi-turn sliding-window context
+│   ├── conversation.py         # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── bash_tool.py            # Shell execution + HITL safety gate
 │   ├── batch.py                # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py             # Slash command dispatch (17 commands)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2503,7 +2503,7 @@ def _interactive_loop() -> None:
       fallback  → single-shot NL Router (when agentic unavailable)
     """
     verbose = False
-    conversation = ConversationContext(max_turns=20)
+    conversation = ConversationContext()
 
     # --- Startup initialization with progressive status ---
     def _init_step(label: str) -> None:

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -147,7 +147,7 @@ class AgenticLoop:
         execute tools → feed results back → continue
     """
 
-    DEFAULT_MAX_ROUNDS = 30
+    DEFAULT_MAX_ROUNDS = 50
     DEFAULT_MAX_TOKENS = 32768
     MAX_CLARIFICATION_ROUNDS = 3
     WRAP_UP_HEADROOM = 2  # force text response N rounds before max

--- a/core/cli/conversation.py
+++ b/core/cli/conversation.py
@@ -1,8 +1,12 @@
 """ConversationContext — session-level multi-turn message history.
 
-Maintains a sliding window of user/assistant messages for multi-turn
-agentic conversations. Used by AgenticLoop to preserve context across
-tool-use rounds and follow-up questions.
+Maintains user/assistant messages for multi-turn agentic conversations.
+Used by AgenticLoop to preserve context across tool-use rounds and
+follow-up questions.
+
+With 1M context models and server-side ``clear_tool_uses`` context
+management, aggressive client-side trimming is unnecessary. The default
+``max_turns=200`` acts as a safety net, not a performance optimisation.
 """
 
 from __future__ import annotations
@@ -19,12 +23,13 @@ log = logging.getLogger(__name__)
 class ConversationContext:
     """Session-level conversation history for multi-turn agentic interactions.
 
-    Keeps the most recent ``max_turns`` user+assistant pairs to avoid
-    exceeding the context window while enabling pronoun resolution and
-    follow-up queries.
+    Keeps the most recent ``max_turns`` user+assistant pairs as a safety
+    net.  With 1M context models and server-side ``clear_tool_uses``,
+    the primary context management is handled server-side; this limit
+    only guards against extreme runaway sessions.
     """
 
-    max_turns: int = 50
+    max_turns: int = 200
     messages: list[dict[str, Any]] = field(default_factory=list)
 
     # ------------------------------------------------------------------

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -287,8 +287,8 @@ class TestAgenticLoop:
         assert context.turn_count >= 1
 
     def test_default_max_rounds(self) -> None:
-        """Verify DEFAULT_MAX_ROUNDS is 30 (1M context model)."""
-        assert AgenticLoop.DEFAULT_MAX_ROUNDS == 30
+        """Verify DEFAULT_MAX_ROUNDS is 50 (1M context + clear_tool_uses)."""
+        assert AgenticLoop.DEFAULT_MAX_ROUNDS == 50
 
     def test_forced_text_on_last_round(
         self, context: ConversationContext, executor: ToolExecutor


### PR DESCRIPTION
## 요약
- 프론티어 조사 결과 Claude Code/OpenClaw/Karpathy 모두 하드 턴 제한 없음
- max_turns 50→200, DEFAULT_MAX_ROUNDS 30→50으로 완화
- clear_tool_uses 서버측 관리가 주 방어선, 클라이언트 제한은 안전망

## 변경 사항
### 핵심
- `conversation.py`: max_turns 기본값 50→200
- `agentic_loop.py`: DEFAULT_MAX_ROUNDS 30→50
- `cli/__init__.py`: REPL ConversationContext가 기본값(200) 사용

### 부수
- 테스트: max_rounds 단언값 갱신
- README/CLAUDE.md: 수치 동기화
- 서브에이전트 max_rounds=10 유지 (단기 실행 설계)

## 설계 판단
| 시스템 | 턴 제한 | 컨텍스트 관리 |
|---|---|---|
| Claude Code | 없음 | clear_tool_uses + end_turn |
| OpenClaw | 없음 | Session lanes + 2h stuck detection |
| Karpathy | 없음 | 3-layer 압축 (L1/L2/L3) |
| GEODE (변경 후) | 200 (안전망) | clear_tool_uses keep=5 |

## 테스트
- ruff: 0 errors, mypy: 0 errors, pytest: 2397 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)