### PR TITLE
feat: MCP 서버 코드 레벨 등록 — 세션 간 설정 영속화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Tier 0.5 User Profile 시스템 -- `~/.geode/user_profile/` 글로벌 + `.geode/user_profile/` 프로젝트 로컬 오버라이드, 프로필/선호/학습 패턴 영속 저장
 - `UserProfilePort` Protocol + `FileBasedUserProfile` 어댑터 (`core/memory/user_profile.py`)
 - 프로필 도구 4종 (`profile_show`, `profile_update`, `profile_preference`, `profile_learn`) -- ContextAssembler Tier 0.5 주입
+- MCP 서버 코드 레벨 등록 (`MCPRegistry`) — 카탈로그 기반 자동 탐지로 세션 간 설정 영속화. 기본 서버 4종(steam, fetch, sequential-thinking, playwright) 항상 등록, env var 보유 서버 19종 자동 발견, `.claude/mcp_servers.json` 파일 오버라이드 병합
 
 ### Changed
 - README 예시 리뉴얼 — 게임 IP 중심 예시를 범용 리서치 에이전트 자연어 쿼리로 교체. Quick Start REPL 우선, 자연어 입력 예시 7종 추가, Game IP는 Domain Plugin 하위로 이동

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -1,7 +1,11 @@
 """MCP Server Manager — load config, discover tools, and call MCP servers.
 
 Manages external MCP server connections using stdio-based JSON-RPC protocol.
-Configuration is loaded from .claude/mcp_servers.json.
+Configuration is loaded in two layers:
+  1. Code-level registry — auto-discovers servers from MCP_CATALOG based on
+     available env vars (always persists across sessions).
+  2. File overrides — .claude/mcp_servers.json entries override/extend
+     registry defaults.
 """
 
 from __future__ import annotations
@@ -50,19 +54,51 @@ class MCPServerManager:
         self._clients: dict[str, StdioMCPClient] = {}
 
     def load_config(self) -> int:
-        """Load MCP server configurations. Returns number of servers loaded."""
-        if not self._config_path.exists():
-            log.debug("MCP config not found: %s", self._config_path)
-            return 0
+        """Load MCP server configurations from registry + file overrides.
 
+        Layer 1: Code-level registry auto-discovers servers from MCP_CATALOG
+        whose required env vars are present (persists across sessions).
+        Layer 2: .claude/mcp_servers.json entries override/extend registry
+        defaults (backward-compatible).
+
+        Returns total number of servers loaded.
+        """
+        from core.infrastructure.adapters.mcp.registry import MCPRegistry
+
+        # Layer 1: code-level registry (auto-discovery)
         try:
-            raw = self._config_path.read_text(encoding="utf-8")
-            self._servers = json.loads(raw)
-            log.info("Loaded %d MCP server configs", len(self._servers))
-            return len(self._servers)
-        except (json.JSONDecodeError, OSError) as exc:
-            log.warning("Failed to load MCP config: %s", exc)
-            return 0
+            registry = MCPRegistry(dotenv_path=str(_DOTENV_PATH))
+            self._servers = registry.discover()
+            registry_count = len(self._servers)
+            if registry_count > 0:
+                log.info("MCP registry: %d servers auto-discovered", registry_count)
+        except Exception as exc:
+            log.warning("MCP registry discovery failed: %s", exc)
+
+        # Layer 2: file overrides (merge on top)
+        file_count = 0
+        if self._config_path.exists():
+            try:
+                raw = self._config_path.read_text(encoding="utf-8")
+                file_servers: dict[str, dict[str, Any]] = json.loads(raw)
+                file_count = len(file_servers)
+                # File entries override registry defaults
+                self._servers.update(file_servers)
+                if file_count > 0:
+                    log.info(
+                        "MCP file overrides: %d from %s",
+                        file_count,
+                        self._config_path,
+                    )
+            except (json.JSONDecodeError, OSError) as exc:
+                log.warning("Failed to load MCP config file: %s", exc)
+
+        total = len(self._servers)
+        if total > 0:
+            log.info("MCP total: %d servers configured", total)
+        else:
+            log.debug("MCP: no servers configured")
+        return total
 
     def _resolve_env(self, env: dict[str, str]) -> dict[str, str]:
         """Resolve ${VAR} references in env values.

--- a/core/infrastructure/adapters/mcp/registry.py
+++ b/core/infrastructure/adapters/mcp/registry.py
@@ -1,0 +1,186 @@
+"""MCP Server Registry — code-level server registration for session persistence.
+
+Builds MCP server configs from the built-in catalog based on environment
+variable availability.  Servers whose required env vars are present are
+auto-discovered; servers with no required env vars (e.g. steam, arxiv)
+are registered as "always available" defaults.
+
+The registry output is a plain dict[str, ServerConfig] that MCPServerManager
+can merge with the file-based .claude/mcp_servers.json overrides.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from dotenv import dotenv_values
+
+from core.infrastructure.adapters.mcp.catalog import MCP_CATALOG, MCPCatalogEntry
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MCPServerConfig:
+    """Resolved MCP server connection configuration."""
+
+    command: str
+    args: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the dict format MCPServerManager expects."""
+        d: dict[str, Any] = {"command": self.command, "args": self.args}
+        if self.env:
+            d["env"] = self.env
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Default servers — always registered (no API key required)
+# ---------------------------------------------------------------------------
+
+DEFAULT_SERVERS: tuple[str, ...] = (
+    "steam",
+    "fetch",
+    "sequential-thinking",
+    "playwright",
+)
+
+# ---------------------------------------------------------------------------
+# Auto-discovered servers — registered when their env vars are present
+# ---------------------------------------------------------------------------
+
+AUTO_DISCOVER_SERVERS: tuple[str, ...] = (
+    "brave-search",
+    "linkedin",
+    "github",
+    "slack",
+    "tavily-search",
+    "langsmith",
+    "youtube",
+    "sentry",
+    "google-maps",
+    "notion",
+    "firecrawl",
+    "exa",
+    "twitter",
+    "discord",
+    "igdb",
+    "qdrant",
+    "pinecone",
+    "zep",
+    "e2b",
+)
+
+
+def _catalog_entry_to_config(entry: MCPCatalogEntry) -> MCPServerConfig:
+    """Convert a catalog entry to a server config."""
+    args = ["-y", entry.package, *entry.extra_args]
+    env = {k: f"${{{k}}}" for k in entry.env_keys}
+    return MCPServerConfig(command=entry.command, args=args, env=env)
+
+
+def _has_env_keys(
+    keys: tuple[str, ...],
+    dotenv_cache: dict[str, str | None],
+) -> bool:
+    """Check whether all required env vars are set (os.environ or .env)."""
+    for key in keys:
+        val = os.environ.get(key) or dotenv_cache.get(key)
+        if not val:
+            return False
+    return True
+
+
+class MCPRegistry:
+    """Builds MCP server configs from catalog + environment detection.
+
+    Usage::
+
+        registry = MCPRegistry()
+        servers = registry.discover()
+        # servers: dict[str, dict] ready for MCPServerManager
+    """
+
+    def __init__(
+        self,
+        *,
+        dotenv_path: str = ".env",
+        defaults: tuple[str, ...] = DEFAULT_SERVERS,
+        auto_discover: tuple[str, ...] = AUTO_DISCOVER_SERVERS,
+    ) -> None:
+        self._dotenv_path = dotenv_path
+        self._defaults = defaults
+        self._auto_discover = auto_discover
+        self._dotenv_cache: dict[str, str | None] = {}
+        if os.path.exists(dotenv_path):
+            self._dotenv_cache = dotenv_values(dotenv_path)
+
+    def discover(self) -> dict[str, dict[str, Any]]:
+        """Return server configs for all available MCP servers.
+
+        1. Always include DEFAULT_SERVERS (no env requirement).
+        2. Include AUTO_DISCOVER_SERVERS whose env vars are present.
+        3. Return as dict[server_name, config_dict] for MCPServerManager.
+        """
+        result: dict[str, dict[str, Any]] = {}
+
+        # 1. Default servers (no env keys required)
+        for name in self._defaults:
+            entry = MCP_CATALOG.get(name)
+            if entry is None:
+                continue
+            config = _catalog_entry_to_config(entry)
+            result[name] = config.to_dict()
+            log.debug("MCP registry: default server '%s'", name)
+
+        # 2. Auto-discover servers (env keys required)
+        for name in self._auto_discover:
+            entry = MCP_CATALOG.get(name)
+            if entry is None:
+                continue
+            if not entry.env_keys:
+                # No env required — treat as default
+                config = _catalog_entry_to_config(entry)
+                result[name] = config.to_dict()
+                log.debug("MCP registry: auto server '%s' (no env required)", name)
+                continue
+            if _has_env_keys(entry.env_keys, self._dotenv_cache):
+                config = _catalog_entry_to_config(entry)
+                result[name] = config.to_dict()
+                log.debug("MCP registry: auto-discovered '%s'", name)
+            else:
+                log.debug(
+                    "MCP registry: skipped '%s' (missing: %s)",
+                    name,
+                    ", ".join(entry.env_keys),
+                )
+
+        return result
+
+    def list_available(self) -> list[str]:
+        """Return names of servers that would be registered."""
+        return sorted(self.discover().keys())
+
+    def list_missing_env(self) -> dict[str, list[str]]:
+        """Return servers that could be enabled with missing env vars.
+
+        Useful for showing users what they need to configure.
+        """
+        missing: dict[str, list[str]] = {}
+        for name in self._auto_discover:
+            entry = MCP_CATALOG.get(name)
+            if entry is None or not entry.env_keys:
+                continue
+            if not _has_env_keys(entry.env_keys, self._dotenv_cache):
+                absent = [
+                    k
+                    for k in entry.env_keys
+                    if not (os.environ.get(k) or self._dotenv_cache.get(k))
+                ]
+                missing[name] = absent
+        return missing

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -1,0 +1,256 @@
+"""Tests for MCP server registry — code-level server registration."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from core.infrastructure.adapters.mcp.catalog import MCP_CATALOG
+from core.infrastructure.adapters.mcp.registry import (
+    AUTO_DISCOVER_SERVERS,
+    DEFAULT_SERVERS,
+    MCPRegistry,
+    MCPServerConfig,
+    _catalog_entry_to_config,
+    _has_env_keys,
+)
+
+# ---------------------------------------------------------------------------
+# MCPServerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServerConfig:
+    def test_to_dict_basic(self) -> None:
+        config = MCPServerConfig(command="npx", args=["-y", "some-pkg"])
+        d = config.to_dict()
+        assert d == {"command": "npx", "args": ["-y", "some-pkg"]}
+
+    def test_to_dict_with_env(self) -> None:
+        config = MCPServerConfig(
+            command="npx",
+            args=["-y", "pkg"],
+            env={"API_KEY": "${API_KEY}"},
+        )
+        d = config.to_dict()
+        assert d["env"] == {"API_KEY": "${API_KEY}"}
+
+    def test_to_dict_no_env_omits_key(self) -> None:
+        config = MCPServerConfig(command="npx", args=[])
+        d = config.to_dict()
+        assert "env" not in d
+
+    def test_frozen(self) -> None:
+        config = MCPServerConfig(command="npx", args=[])
+        with pytest.raises(AttributeError):
+            config.command = "uvx"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _catalog_entry_to_config
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogEntryToConfig:
+    def test_converts_steam_entry(self) -> None:
+        entry = MCP_CATALOG["steam"]
+        config = _catalog_entry_to_config(entry)
+        assert config.command == "npx"
+        assert "-y" in config.args
+        assert entry.package in config.args
+        assert config.env == {}
+
+    def test_converts_brave_entry_with_env(self) -> None:
+        entry = MCP_CATALOG["brave-search"]
+        config = _catalog_entry_to_config(entry)
+        assert config.env == {"BRAVE_API_KEY": "${BRAVE_API_KEY}"}
+
+    def test_converts_entry_with_extra_args(self) -> None:
+        from core.infrastructure.adapters.mcp.catalog import MCPCatalogEntry
+
+        entry = MCPCatalogEntry(
+            name="test",
+            package="test-pkg",
+            description="Test",
+            tags=("test",),
+            extra_args=("--flag", "value"),
+        )
+        config = _catalog_entry_to_config(entry)
+        assert config.args == ["-y", "test-pkg", "--flag", "value"]
+
+
+# ---------------------------------------------------------------------------
+# _has_env_keys
+# ---------------------------------------------------------------------------
+
+
+class TestHasEnvKeys:
+    def test_empty_keys_returns_true(self) -> None:
+        assert _has_env_keys((), {}) is True
+
+    def test_key_in_environ(self) -> None:
+        with patch.dict(os.environ, {"MY_KEY": "val"}):
+            assert _has_env_keys(("MY_KEY",), {}) is True
+
+    def test_key_in_dotenv(self) -> None:
+        assert _has_env_keys(("MY_KEY",), {"MY_KEY": "val"}) is True
+
+    def test_key_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            # Ensure MY_MISSING_KEY is not in environ
+            os.environ.pop("MY_MISSING_KEY", None)
+            assert _has_env_keys(("MY_MISSING_KEY",), {}) is False
+
+    def test_partial_keys_returns_false(self) -> None:
+        with patch.dict(os.environ, {"KEY_A": "val"}):
+            os.environ.pop("KEY_B", None)
+            assert _has_env_keys(("KEY_A", "KEY_B"), {}) is False
+
+
+# ---------------------------------------------------------------------------
+# MCPRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestMCPRegistry:
+    def test_discover_returns_default_servers(self) -> None:
+        registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+        result = registry.discover()
+        for name in DEFAULT_SERVERS:
+            if name in MCP_CATALOG:
+                assert name in result, f"Default server '{name}' not in discovery result"
+
+    def test_discover_includes_auto_servers_when_env_present(self) -> None:
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "test-key"}):
+            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+            result = registry.discover()
+            assert "brave-search" in result
+
+    def test_discover_excludes_auto_servers_when_env_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRAVE_API_KEY", None)
+            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+            result = registry.discover()
+            # brave-search requires BRAVE_API_KEY
+            assert "brave-search" not in result
+
+    def test_discover_server_config_structure(self) -> None:
+        registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+        result = registry.discover()
+        for name, config in result.items():
+            assert "command" in config, f"Server '{name}' missing 'command'"
+            assert "args" in config, f"Server '{name}' missing 'args'"
+
+    def test_list_available(self) -> None:
+        registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+        available = registry.list_available()
+        assert isinstance(available, list)
+        assert available == sorted(available)  # sorted
+
+    def test_list_missing_env(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRAVE_API_KEY", None)
+            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+            missing = registry.list_missing_env()
+            assert "brave-search" in missing
+            assert "BRAVE_API_KEY" in missing["brave-search"]
+
+    def test_defaults_all_in_catalog(self) -> None:
+        """All DEFAULT_SERVERS must exist in MCP_CATALOG."""
+        for name in DEFAULT_SERVERS:
+            assert name in MCP_CATALOG, f"Default '{name}' not in MCP_CATALOG"
+
+    def test_auto_discover_all_in_catalog(self) -> None:
+        """All AUTO_DISCOVER_SERVERS must exist in MCP_CATALOG."""
+        for name in AUTO_DISCOVER_SERVERS:
+            assert name in MCP_CATALOG, f"Auto-discover '{name}' not in MCP_CATALOG"
+
+    def test_custom_defaults(self) -> None:
+        registry = MCPRegistry(
+            dotenv_path="/nonexistent/.env",
+            defaults=("steam",),
+            auto_discover=(),
+        )
+        result = registry.discover()
+        assert "steam" in result
+        assert len(result) == 1
+
+    def test_custom_auto_discover_empty(self) -> None:
+        registry = MCPRegistry(
+            dotenv_path="/nonexistent/.env",
+            defaults=(),
+            auto_discover=(),
+        )
+        result = registry.discover()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# MCPServerManager integration with registry
+# ---------------------------------------------------------------------------
+
+
+class TestManagerRegistryIntegration:
+    def test_load_config_uses_registry(self, tmp_path: Path) -> None:
+        """Manager.load_config() should include registry-discovered servers."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "mcp_servers.json"
+        # No config file exists
+        manager = MCPServerManager(config_path=config_path)
+        count = manager.load_config()
+        # Should have at least the default servers
+        assert count >= len(DEFAULT_SERVERS)
+
+    def test_file_overrides_registry(self, tmp_path: Path) -> None:
+        """File config should override registry defaults."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "mcp_servers.json"
+        # Write a file override for steam with custom args
+        override: dict[str, Any] = {
+            "steam": {
+                "command": "node",
+                "args": ["custom-steam-server.js"],
+            }
+        }
+        config_path.write_text(json.dumps(override), encoding="utf-8")
+
+        manager = MCPServerManager(config_path=config_path)
+        manager.load_config()
+
+        # Steam should use the file override, not the registry default
+        assert manager._servers["steam"]["command"] == "node"
+        assert manager._servers["steam"]["args"] == ["custom-steam-server.js"]
+
+    def test_file_adds_extra_servers(self, tmp_path: Path) -> None:
+        """File config can add servers not in the registry."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "mcp_servers.json"
+        override: dict[str, Any] = {
+            "my-custom-server": {
+                "command": "python",
+                "args": ["-m", "my_mcp_server"],
+            }
+        }
+        config_path.write_text(json.dumps(override), encoding="utf-8")
+
+        manager = MCPServerManager(config_path=config_path)
+        manager.load_config()
+
+        assert "my-custom-server" in manager._servers
+
+    def test_load_config_no_file_still_works(self, tmp_path: Path) -> None:
+        """Without a config file, registry defaults should still load."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "nonexistent.json"
+        manager = MCPServerManager(config_path=config_path)
+        count = manager.load_config()
+        # At minimum, default servers
+        assert count >= 1


### PR DESCRIPTION
## 요약
- MCPRegistry: 카탈로그 기반 서버 자동 검색 + 환경변수 감지
- 세션마다 MCP 설정이 날아가는 문제 해소

## 변경 사항
### 핵심
- `core/infrastructure/adapters/mcp/registry.py`: MCPRegistry 신규
  - DEFAULT_SERVERS(4): steam, fetch, sequential-thinking, playwright (항상 등록)
  - AUTO_DISCOVER(19): brave-search, linkedin, github, slack 등 (환경변수 존재 시 등록)
- `core/infrastructure/adapters/mcp/manager.py`: load_config()에 2-layer 적용
  - Layer 1: 코드 레벨 레지스트리 자동 검색
  - Layer 2: `.claude/mcp_servers.json` 오버라이드 (하위 호환)

### 테스트
- `tests/test_mcp_registry.py`: 26개 신규 테스트

## 테스트
- ruff: 0 errors, mypy: 0 errors, pytest: 2423 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)