### PR TITLE
develop → main: v0.15.0 릴리스 준비

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Tier 0.5 User Profile 시스템 -- `~/.geode/user_profile/` 글로벌 + `.geode/user_profile/` 프로젝트 로컬 오버라이드, 프로필/선호/학습 패턴 영속 저장
 - `UserProfilePort` Protocol + `FileBasedUserProfile` 어댑터 (`core/memory/user_profile.py`)
 - 프로필 도구 4종 (`profile_show`, `profile_update`, `profile_preference`, `profile_learn`) -- ContextAssembler Tier 0.5 주입
+- MCP 서버 코드 레벨 등록 (`MCPRegistry`) — 카탈로그 기반 자동 탐지로 세션 간 설정 영속화. 기본 서버 4종(steam, fetch, sequential-thinking, playwright) 항상 등록, env var 보유 서버 19종 자동 발견, `.claude/mcp_servers.json` 파일 오버라이드 병합
 
 ### Changed
 - README 예시 리뉴얼 — 게임 IP 중심 예시를 범용 리서치 에이전트 자연어 쿼리로 교체. Quick Start REPL 우선, 자연어 입력 예시 7종 추가, Game IP는 Domain Plugin 하위로 이동

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - 프로필 도구 4종 (`profile_show`, `profile_update`, `profile_preference`, `profile_learn`) -- ContextAssembler Tier 0.5 주입
 
 ### Changed
+- README 예시 리뉴얼 — 게임 IP 중심 예시를 범용 리서치 에이전트 자연어 쿼리로 교체. Quick Start REPL 우선, 자연어 입력 예시 7종 추가, Game IP는 Domain Plugin 하위로 이동
 - Token Guard 상한 제거 — `MAX_TOOL_RESULT_TOKENS` 기본값 0 (무제한). 프론티어 합의: 하드 캡 대신 압축(Karpathy P6) + `clear_tool_uses` 서버측 정리로 컨텍스트 관리. `GEODE_MAX_TOOL_RESULT_TOKENS` 환경변수로 필요 시 상한 재설정 가능
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Token Guard 상한 제거 — `MAX_TOOL_RESULT_TOKENS` 기본값 0 (무제한). 프론티어 합의: 하드 캡 대신 압축(Karpathy P6) + `clear_tool_uses` 서버측 정리로 컨텍스트 관리. `GEODE_MAX_TOOL_RESULT_TOKENS` 환경변수로 필요 시 상한 재설정 가능
+- 대화 턴/라운드 제한 대폭 완화 — `max_turns` 20→200, `DEFAULT_MAX_ROUNDS` 30→50. 1M 컨텍스트 + 서버측 `clear_tool_uses`가 주 관리 담당, 클라이언트 제한은 극단적 runaway 방지용 안전망으로만 유지
 
 ### Fixed
 - 프롬프트/REPL 출력에서 장식용 이모지 제거 — 리포트 생성 외 모든 CLI 출력에서 이모지(⚡⚠✏⏸) 삭제, UI 마커(✓✗✢●)는 유지

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ core/
 │   ├── sub_agent.py     # SubAgentManager + SubAgentResult + ErrorCategory
 │   ├── tool_executor.py # Tool dispatch + HITL + delegate_task handler
 │   ├── nl_router.py     # NL intent classification (LLM → regex → help)
-│   ├── conversation.py  # Multi-turn sliding-window (max 20 turns)
+│   ├── conversation.py  # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── batch.py         # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py      # Slash command dispatch (17 commands)
 │   ├── error_recovery.py # ErrorRecoveryStrategy (retry → alternative → fallback → escalate)

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@
 
 # GEODE v0.14.0 — Autonomous Research Harness
 
-Loop-based 자율 실행 에이전트. `while(tool_use)` 루프를 핵심 프리미티브로 하여 리서치, 분석, 자동화, 스케줄링을 자율적으로 수행합니다.
+범용 자율 실행 에이전트. `while(tool_use)` 루프를 핵심 프리미티브로 하여 리서치, 분석, 자동화, 스케줄링을 자연어 한 줄로 수행합니다.
 
-> *LLM이 도구를 호출하고, 결과를 관찰하고, 다음 행동을 결정하는 루프를 반복합니다. 복합 요청은 자동 분해하고, 실패는 자동 복구하며, 그래프 토폴로지는 결과에 따라 동적으로 변형됩니다. 사람은 `program.md`를 작성하고, 에이전트는 밤새 실행합니다.*
+> *"AI 에이전트 트렌드 조사해줘", "이 URL 요약해줘", "매주 월요일 뉴스 브리핑 잡아줘" -- 자연어로 요청하면 LLM이 도구를 호출하고, 결과를 관찰하고, 다음 행동을 결정하는 루프를 반복합니다. 복합 요청은 자동 분해하고, 실패는 자동 복구하며, 도메인별 분석 파이프라인은 플러그인으로 교체됩니다.*
 
 ### Highlights
 
-- **`while(tool_use)` Loop** — 모든 자율 행동의 핵심 프리미티브. 도구를 호출하고, 관찰하고, 반복.
+- **Natural Language Interface** — 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링 수행
+- **`while(tool_use)` Loop** — 모든 자율 행동의 핵심 프리미티브. 도구를 호출하고, 관찰하고, 반복
+- **38 Tools + MCP** — 웹 검색, URL 요약, YouTube, arXiv, LinkedIn 등 38개 도구 + MCP 자동설치
 - **Goal Decomposition** — 복합 요청을 하위 목표 DAG로 자동 분해 (Haiku, ~$0.01/호출)
 - **Error Recovery** — 실패 시 retry → alternative → fallback → escalate 4단계 자동 복구
-- **Dynamic Graph** — 분석 결과에 따라 노드 건너뛰기 / enrichment 경로 동적 분기
 - **Sub-Agent** — 부모 역량 전체 상속, 병렬 위임, Token Guard, as_completed 수집
 - **3-Tier Memory** — SOUL → Organization → Project → Session 계층적 맥락 조합
-- **38 Tools + MCP** — `definitions.json` 기반 + 38개 MCP 카탈로그 자동설치
-- **Domain Plugin** — `DomainPort` Protocol로 분석 파이프라인 교체 (Game IP 기본 탑재)
+- **Domain Plugin** — `DomainPort` Protocol로 도메인별 파이프라인 교체 (Game IP 기본 탑재)
 - **Safety** — 4-tier HITL (SAFE/STANDARD/WRITE/DANGEROUS), Grounding Truth, 9종 bash 차단
 
 ## Installation
@@ -37,20 +37,20 @@ uv sync
 ## Quick Start
 
 ```bash
-# 인터랙티브 모드 (권장)
+# 인터랙티브 REPL (권장) — 자연어로 무엇이든 요청
 uv run geode
 
-# IP 분석 (API 키 있으면 LLM 호출, 없으면 자동 dry-run)
+# 자연어 쿼리 (CLI에서 직접)
+uv run geode "최근 AI 에이전트 프레임워크 트렌드 조사해줘"
+
+# 웹 리서치
+uv run geode "이 URL 내용 요약해줘: https://example.com/article"
+
+# 스케줄링
+uv run geode "매주 월요일 AI 뉴스 브리핑 스케줄 잡아줘"
+
+# Domain Plugin: 게임 IP 분석 (API 키 있으면 LLM 호출, 없으면 자동 dry-run)
 uv run geode analyze "Berserk"
-
-# Streaming 분석
-uv run geode analyze "Berserk" --stream
-
-# 배치 분석
-uv run geode batch --top 5 --dry-run
-
-# 리포트 생성
-uv run geode report "Berserk" --format html --output berserk.html
 ```
 
 ### Setup
@@ -62,8 +62,8 @@ cp .env.example .env
 # 2. .env 편집 — API 키 입력
 ANTHROPIC_API_KEY=sk-ant-...
 
-# 3. Full 분석 실행
-uv run geode analyze "Cowboy Bebop"
+# 3. REPL 시작
+uv run geode
 ```
 
 API 키 없이 시작하면 자동으로 dry-run 모드로 전환됩니다.
@@ -233,8 +233,8 @@ graph LR
 
 | 전략 | 동작 | 예시 |
 |------|------|------|
-| **Retry** | 동일 도구 재실행 (1s backoff) | `steam_info` 재시도 |
-| **Alternative** | 같은 `category` 다른 도구 (`definitions.json`) | `steam_info` → `web_fetch` |
+| **Retry** | 동일 도구 재실행 (1s backoff) | `web_fetch` 재시도 |
+| **Alternative** | 같은 `category` 다른 도구 (`definitions.json`) | `web_fetch` → `general_web_search` |
 | **Fallback** | 더 낮은 `cost_tier` 도구 | `expensive` → `cheap` → `free` |
 | **Escalate** | 사용자 개입 요청 (terminal) | HITL 승인 |
 
@@ -290,7 +290,7 @@ graph LR
 | `mixed` | MCP 반환 1개 + fixture 존재 | live 값이 fixture를 override |
 | `fixture` | MCP 미연결/에러 | 자동 fallback |
 
-`CompositeSignalAdapter`는 `SteamMCPSignalAdapter` + `BraveSignalAdapter`를 체이닝하며, `_enrichment_sources` 리스트로 provenance를 추적합니다.
+`CompositeSignalAdapter`는 여러 MCP 어댑터(Steam, Brave 등)를 체이닝하며, `_enrichment_sources` 리스트로 provenance를 추적합니다.
 
 ### Plan Auto-Execute
 
@@ -417,10 +417,9 @@ graph TB
     end
 
     subgraph MCPServer["MCP Server (FastMCP)"]
-        T1["analyze_ip"]
-        T2["quick_score"]
-        T3["get_ip_signals"]
-        T4["list_fixtures / query_memory / get_health"]
+        T1["analyze_ip / quick_score"]
+        T2["get_ip_signals"]
+        T3["list_fixtures / query_memory / get_health"]
     end
 
     Registry --> Policy
@@ -434,15 +433,15 @@ graph TB
     style MCPServer fill:#1e293b,stroke:#f59e0b,color:#e2e8f0
 ```
 
-- **38 base tools** — `definitions.json` 기반 + `category`/`cost_tier` 메타데이터 (Error Recovery에서 활용)
-- **MCP Adapters** — Brave Search, Steam, arXiv, Playwright, LinkedIn (env var 비어있으면 graceful skip)
+- **38 base tools** — `web_fetch`, `general_web_search`, `youtube_search`, `read_document` 등 범용 도구 + `category`/`cost_tier` 메타데이터
+- **MCP Adapters** — Brave Search, arXiv, Playwright, LinkedIn, Steam (env var 비어있으면 graceful skip)
 - **MCP Server** — `uv run python -m core.mcp_server` 로 GEODE를 외부 에이전트에서 호출 가능 (6 tools, 2 resources)
 - **Skills** — `.claude/skills/` 자동 발견 + YAML frontmatter 기반 도구 핫 리로드
 - **MCP 자동설치** — `install_mcp_server` tool → 38개 카탈로그 검색 + 설치 + `refresh_tools()`
 
 ### Domain Plugin
 
-`DomainPort` Protocol로 도메인별 분석 파이프라인을 플러그인으로 교체합니다. 아래는 기본 탑재된 Game IP 도메인의 구조입니다.
+`DomainPort` Protocol로 도메인별 분석 파이프라인을 플러그인으로 교체합니다. 동일한 자율 실행 하네스 위에 게임 IP, 금융, 콘텐츠 등 다양한 도메인 파이프라인을 탑재할 수 있습니다. 아래는 기본 탑재된 Game IP 도메인의 구조입니다.
 
 ```mermaid
 graph LR
@@ -534,13 +533,13 @@ uv run geode
 
 | Command | Alias | Description |
 |---------|-------|-------------|
-| `/analyze <IP>` | `/a` | IP 분석 |
-| `/search <query>` | `/s` | IP 검색 |
+| `/analyze <IP>` | `/a` | IP 분석 (Domain Plugin) |
+| `/search <query>` | `/s` | 검색 |
 | `/report <IP> [fmt]` | `/rpt` | 리포트 생성 (md/html/json) |
-| `/list` | | IP 목록 |
+| `/list` | | IP 목록 (Domain Plugin) |
 | `/batch [--top N]` | `/b` | 배치 분석 |
-| `/compare <A> <B>` | | 두 IP 비교 |
-| `/schedule <cron>` | `/sched` | 배치 스케줄 |
+| `/compare <A> <B>` | | 비교 분석 |
+| `/schedule <cron>` | `/sched` | 작업 스케줄 |
 | `/mcp status\|tools\|reload\|add` | | MCP 관리 |
 | `/skills` | | 스킬 목록/상세 |
 | `/status` | | 시스템 상태 |
@@ -548,25 +547,39 @@ uv run geode
 | `/verbose` | | 상세 출력 토글 |
 | `/quit` | `/q` | 종료 |
 
-**자연어 입력:**
+**자연어 입력 (리서치 에이전트):**
+
+```
+> 최근 AI 에이전트 프레임워크 트렌드 조사해줘       → 웹 리서치 + 요약
+> 이 사람 LinkedIn 프로필 분석해줘                  → LinkedIn MCP 호출
+> YouTube에서 LangGraph 관련 영상 찾아서 요약해줘    → youtube_search + 요약
+> 이 URL 내용 요약하고 핵심 포인트 정리해줘          → web_fetch + 분석
+> 매주 월요일 AI 뉴스 브리핑 스케줄 잡아줘           → NL 스케줄 생성
+> arXiv에서 RAG 관련 최신 논문 찾아줘               → arXiv MCP 검색
+> LinkedIn MCP 달아줘                              → MCP 자동설치
+```
+
+**자연어 입력 (Game IP Domain Plugin):**
 
 ```
 > Berserk 분석해           → LLM 분석 / dry-run
 > 소울라이크 찾아줘         → 장르 검색
 > Berserk vs Cowboy Bebop  → 비교 분석
-> LinkedIn MCP 달아줘      → MCP 자동설치
-> 스케줄 걸어줘            → 배치 스케줄
 ```
 
 ### CLI Mode
 
 ```bash
+# 범용 리서치 쿼리
+uv run geode "최근 AI 에이전트 프레임워크 트렌드 조사해줘"
+uv run geode "이 URL 요약해줘: https://example.com/article"
+uv run geode "매주 월요일 AI 뉴스 브리핑 스케줄 잡아줘"
+
+# Domain Plugin: 게임 IP 분석
 uv run geode analyze "Berserk"                    # CLI 분석
-uv run geode "Berserk 분석해줘" --stream           # 스트리밍
 uv run geode search "사이버펑크"                   # 장르 검색
 uv run geode report "Berserk" -f html -o out.html # HTML 리포트
 uv run geode batch --top 5                        # 배치 분석
-uv run geode "오늘 AI 뉴스 정리해줘"               # 범용 리서치
 ```
 
 ---
@@ -655,9 +668,10 @@ core/
 
 ## Design Choices
 
+- **Natural language first.** 자연어 한 줄이 입력이고, 에이전트가 도구 선택부터 결과 종합까지 자율적으로 수행한다. 리서치, 요약, 스케줄링, 분석 -- 도메인을 가리지 않는다.
 - **`while(tool_use)` as primitive.** 모든 자율 행동은 하나의 루프에서 나온다. 서브에이전트도, 계획 실행도, 배치 분석도 전부 AgenticLoop 인스턴스. 추상화가 아닌 구체적 실행 단위.
 - **Port/Adapter DI.** 모든 인프라는 `Protocol` 포트 + `contextvars` 주입. LLM, 메모리, MCP 전부 교체 가능. 테스트에서 mock 주입, 프로덕션에서 실제 어댑터.
-- **도메인은 플러그인.** `DomainPort` Protocol 구현체를 교체하면 Game IP가 아닌 다른 도메인(금융, 의료, 콘텐츠)에도 동일한 자율 하네스를 적용할 수 있다.
+- **도메인은 플러그인.** `DomainPort` Protocol 구현체를 교체하면 게임 IP, 금융, 의료, 콘텐츠 등 어떤 도메인이든 동일한 자율 하네스 위에 탑재할 수 있다.
 - **Safety by default.** 자율 에이전트는 위험하다. DANGEROUS 도구는 항상 사용자 승인, Error Recovery에서도 제외, 서브에이전트에서도 제외. 안전 게이트 우회 경로가 없다.
 - **Graceful degradation.** API 키 없으면 dry-run, MCP 미연결이면 fixture fallback, LLM 실패하면 retry chain. 어떤 상태에서든 에이전트는 멈추지 않는다.
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ graph TB
 | **LLM Tool Use** | Claude Opus 4.6 — base 38 + MCP 20+ tool 정의 전달, `stop_reason` 기반 루프 제어 |
 | **ToolExecutor** | 4-tier safety: SAFE / STANDARD / WRITE / DANGEROUS (bash 사용자 승인 필수) |
 | **Clarification** | 필수 파라미터 누락 시 LLM이 사용자에게 되묻기 |
-| **max_rounds** | 기본 15 라운드 — 마지막 2라운드에서 텍스트 응답 강제 |
-| **Multi-turn** | 슬라이딩 윈도우 (max 20 turns) — 대명사 해석, follow-up 쿼리 지원 |
+| **max_rounds** | 기본 50 라운드 — 마지막 2라운드에서 텍스트 응답 강제 (1M 컨텍스트 + `clear_tool_uses` 활용) |
+| **Multi-turn** | 슬라이딩 윈도우 (max 200 turns) — 서버측 `clear_tool_uses`가 주 컨텍스트 관리, 클라이언트 제한은 안전망 |
 | **LangSmith** | 토큰 수/비용을 RunTree에 기록, 세션 합산 |
 
 ### Goal Decomposition
@@ -616,7 +616,7 @@ core/
 │   ├── sub_agent.py            # SubAgentManager + SubAgentResult + ErrorCategory
 │   ├── tool_executor.py        # Tool dispatch + HITL approval gate
 │   ├── nl_router.py            # Natural language intent classification
-│   ├── conversation.py         # Multi-turn sliding-window context
+│   ├── conversation.py         # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── bash_tool.py            # Shell execution + HITL safety gate
 │   ├── batch.py                # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py             # Slash command dispatch (17 commands)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2503,7 +2503,7 @@ def _interactive_loop() -> None:
       fallback  → single-shot NL Router (when agentic unavailable)
     """
     verbose = False
-    conversation = ConversationContext(max_turns=20)
+    conversation = ConversationContext()
 
     # --- Startup initialization with progressive status ---
     def _init_step(label: str) -> None:

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -147,7 +147,7 @@ class AgenticLoop:
         execute tools → feed results back → continue
     """
 
-    DEFAULT_MAX_ROUNDS = 30
+    DEFAULT_MAX_ROUNDS = 50
     DEFAULT_MAX_TOKENS = 32768
     MAX_CLARIFICATION_ROUNDS = 3
     WRAP_UP_HEADROOM = 2  # force text response N rounds before max

--- a/core/cli/conversation.py
+++ b/core/cli/conversation.py
@@ -1,8 +1,12 @@
 """ConversationContext — session-level multi-turn message history.
 
-Maintains a sliding window of user/assistant messages for multi-turn
-agentic conversations. Used by AgenticLoop to preserve context across
-tool-use rounds and follow-up questions.
+Maintains user/assistant messages for multi-turn agentic conversations.
+Used by AgenticLoop to preserve context across tool-use rounds and
+follow-up questions.
+
+With 1M context models and server-side ``clear_tool_uses`` context
+management, aggressive client-side trimming is unnecessary. The default
+``max_turns=200`` acts as a safety net, not a performance optimisation.
 """
 
 from __future__ import annotations
@@ -19,12 +23,13 @@ log = logging.getLogger(__name__)
 class ConversationContext:
     """Session-level conversation history for multi-turn agentic interactions.
 
-    Keeps the most recent ``max_turns`` user+assistant pairs to avoid
-    exceeding the context window while enabling pronoun resolution and
-    follow-up queries.
+    Keeps the most recent ``max_turns`` user+assistant pairs as a safety
+    net.  With 1M context models and server-side ``clear_tool_uses``,
+    the primary context management is handled server-side; this limit
+    only guards against extreme runaway sessions.
     """
 
-    max_turns: int = 50
+    max_turns: int = 200
     messages: list[dict[str, Any]] = field(default_factory=list)
 
     # ------------------------------------------------------------------

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -1,7 +1,11 @@
 """MCP Server Manager — load config, discover tools, and call MCP servers.
 
 Manages external MCP server connections using stdio-based JSON-RPC protocol.
-Configuration is loaded from .claude/mcp_servers.json.
+Configuration is loaded in two layers:
+  1. Code-level registry — auto-discovers servers from MCP_CATALOG based on
+     available env vars (always persists across sessions).
+  2. File overrides — .claude/mcp_servers.json entries override/extend
+     registry defaults.
 """
 
 from __future__ import annotations
@@ -50,19 +54,51 @@ class MCPServerManager:
         self._clients: dict[str, StdioMCPClient] = {}
 
     def load_config(self) -> int:
-        """Load MCP server configurations. Returns number of servers loaded."""
-        if not self._config_path.exists():
-            log.debug("MCP config not found: %s", self._config_path)
-            return 0
+        """Load MCP server configurations from registry + file overrides.
 
+        Layer 1: Code-level registry auto-discovers servers from MCP_CATALOG
+        whose required env vars are present (persists across sessions).
+        Layer 2: .claude/mcp_servers.json entries override/extend registry
+        defaults (backward-compatible).
+
+        Returns total number of servers loaded.
+        """
+        from core.infrastructure.adapters.mcp.registry import MCPRegistry
+
+        # Layer 1: code-level registry (auto-discovery)
         try:
-            raw = self._config_path.read_text(encoding="utf-8")
-            self._servers = json.loads(raw)
-            log.info("Loaded %d MCP server configs", len(self._servers))
-            return len(self._servers)
-        except (json.JSONDecodeError, OSError) as exc:
-            log.warning("Failed to load MCP config: %s", exc)
-            return 0
+            registry = MCPRegistry(dotenv_path=str(_DOTENV_PATH))
+            self._servers = registry.discover()
+            registry_count = len(self._servers)
+            if registry_count > 0:
+                log.info("MCP registry: %d servers auto-discovered", registry_count)
+        except Exception as exc:
+            log.warning("MCP registry discovery failed: %s", exc)
+
+        # Layer 2: file overrides (merge on top)
+        file_count = 0
+        if self._config_path.exists():
+            try:
+                raw = self._config_path.read_text(encoding="utf-8")
+                file_servers: dict[str, dict[str, Any]] = json.loads(raw)
+                file_count = len(file_servers)
+                # File entries override registry defaults
+                self._servers.update(file_servers)
+                if file_count > 0:
+                    log.info(
+                        "MCP file overrides: %d from %s",
+                        file_count,
+                        self._config_path,
+                    )
+            except (json.JSONDecodeError, OSError) as exc:
+                log.warning("Failed to load MCP config file: %s", exc)
+
+        total = len(self._servers)
+        if total > 0:
+            log.info("MCP total: %d servers configured", total)
+        else:
+            log.debug("MCP: no servers configured")
+        return total
 
     def _resolve_env(self, env: dict[str, str]) -> dict[str, str]:
         """Resolve ${VAR} references in env values.

--- a/core/infrastructure/adapters/mcp/registry.py
+++ b/core/infrastructure/adapters/mcp/registry.py
@@ -1,0 +1,186 @@
+"""MCP Server Registry — code-level server registration for session persistence.
+
+Builds MCP server configs from the built-in catalog based on environment
+variable availability.  Servers whose required env vars are present are
+auto-discovered; servers with no required env vars (e.g. steam, arxiv)
+are registered as "always available" defaults.
+
+The registry output is a plain dict[str, ServerConfig] that MCPServerManager
+can merge with the file-based .claude/mcp_servers.json overrides.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from dotenv import dotenv_values
+
+from core.infrastructure.adapters.mcp.catalog import MCP_CATALOG, MCPCatalogEntry
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MCPServerConfig:
+    """Resolved MCP server connection configuration."""
+
+    command: str
+    args: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the dict format MCPServerManager expects."""
+        d: dict[str, Any] = {"command": self.command, "args": self.args}
+        if self.env:
+            d["env"] = self.env
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Default servers — always registered (no API key required)
+# ---------------------------------------------------------------------------
+
+DEFAULT_SERVERS: tuple[str, ...] = (
+    "steam",
+    "fetch",
+    "sequential-thinking",
+    "playwright",
+)
+
+# ---------------------------------------------------------------------------
+# Auto-discovered servers — registered when their env vars are present
+# ---------------------------------------------------------------------------
+
+AUTO_DISCOVER_SERVERS: tuple[str, ...] = (
+    "brave-search",
+    "linkedin",
+    "github",
+    "slack",
+    "tavily-search",
+    "langsmith",
+    "youtube",
+    "sentry",
+    "google-maps",
+    "notion",
+    "firecrawl",
+    "exa",
+    "twitter",
+    "discord",
+    "igdb",
+    "qdrant",
+    "pinecone",
+    "zep",
+    "e2b",
+)
+
+
+def _catalog_entry_to_config(entry: MCPCatalogEntry) -> MCPServerConfig:
+    """Convert a catalog entry to a server config."""
+    args = ["-y", entry.package, *entry.extra_args]
+    env = {k: f"${{{k}}}" for k in entry.env_keys}
+    return MCPServerConfig(command=entry.command, args=args, env=env)
+
+
+def _has_env_keys(
+    keys: tuple[str, ...],
+    dotenv_cache: dict[str, str | None],
+) -> bool:
+    """Check whether all required env vars are set (os.environ or .env)."""
+    for key in keys:
+        val = os.environ.get(key) or dotenv_cache.get(key)
+        if not val:
+            return False
+    return True
+
+
+class MCPRegistry:
+    """Builds MCP server configs from catalog + environment detection.
+
+    Usage::
+
+        registry = MCPRegistry()
+        servers = registry.discover()
+        # servers: dict[str, dict] ready for MCPServerManager
+    """
+
+    def __init__(
+        self,
+        *,
+        dotenv_path: str = ".env",
+        defaults: tuple[str, ...] = DEFAULT_SERVERS,
+        auto_discover: tuple[str, ...] = AUTO_DISCOVER_SERVERS,
+    ) -> None:
+        self._dotenv_path = dotenv_path
+        self._defaults = defaults
+        self._auto_discover = auto_discover
+        self._dotenv_cache: dict[str, str | None] = {}
+        if os.path.exists(dotenv_path):
+            self._dotenv_cache = dotenv_values(dotenv_path)
+
+    def discover(self) -> dict[str, dict[str, Any]]:
+        """Return server configs for all available MCP servers.
+
+        1. Always include DEFAULT_SERVERS (no env requirement).
+        2. Include AUTO_DISCOVER_SERVERS whose env vars are present.
+        3. Return as dict[server_name, config_dict] for MCPServerManager.
+        """
+        result: dict[str, dict[str, Any]] = {}
+
+        # 1. Default servers (no env keys required)
+        for name in self._defaults:
+            entry = MCP_CATALOG.get(name)
+            if entry is None:
+                continue
+            config = _catalog_entry_to_config(entry)
+            result[name] = config.to_dict()
+            log.debug("MCP registry: default server '%s'", name)
+
+        # 2. Auto-discover servers (env keys required)
+        for name in self._auto_discover:
+            entry = MCP_CATALOG.get(name)
+            if entry is None:
+                continue
+            if not entry.env_keys:
+                # No env required — treat as default
+                config = _catalog_entry_to_config(entry)
+                result[name] = config.to_dict()
+                log.debug("MCP registry: auto server '%s' (no env required)", name)
+                continue
+            if _has_env_keys(entry.env_keys, self._dotenv_cache):
+                config = _catalog_entry_to_config(entry)
+                result[name] = config.to_dict()
+                log.debug("MCP registry: auto-discovered '%s'", name)
+            else:
+                log.debug(
+                    "MCP registry: skipped '%s' (missing: %s)",
+                    name,
+                    ", ".join(entry.env_keys),
+                )
+
+        return result
+
+    def list_available(self) -> list[str]:
+        """Return names of servers that would be registered."""
+        return sorted(self.discover().keys())
+
+    def list_missing_env(self) -> dict[str, list[str]]:
+        """Return servers that could be enabled with missing env vars.
+
+        Useful for showing users what they need to configure.
+        """
+        missing: dict[str, list[str]] = {}
+        for name in self._auto_discover:
+            entry = MCP_CATALOG.get(name)
+            if entry is None or not entry.env_keys:
+                continue
+            if not _has_env_keys(entry.env_keys, self._dotenv_cache):
+                absent = [
+                    k
+                    for k in entry.env_keys
+                    if not (os.environ.get(k) or self._dotenv_cache.get(k))
+                ]
+                missing[name] = absent
+        return missing

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -287,8 +287,8 @@ class TestAgenticLoop:
         assert context.turn_count >= 1
 
     def test_default_max_rounds(self) -> None:
-        """Verify DEFAULT_MAX_ROUNDS is 30 (1M context model)."""
-        assert AgenticLoop.DEFAULT_MAX_ROUNDS == 30
+        """Verify DEFAULT_MAX_ROUNDS is 50 (1M context + clear_tool_uses)."""
+        assert AgenticLoop.DEFAULT_MAX_ROUNDS == 50
 
     def test_forced_text_on_last_round(
         self, context: ConversationContext, executor: ToolExecutor

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -1,0 +1,256 @@
+"""Tests for MCP server registry — code-level server registration."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from core.infrastructure.adapters.mcp.catalog import MCP_CATALOG
+from core.infrastructure.adapters.mcp.registry import (
+    AUTO_DISCOVER_SERVERS,
+    DEFAULT_SERVERS,
+    MCPRegistry,
+    MCPServerConfig,
+    _catalog_entry_to_config,
+    _has_env_keys,
+)
+
+# ---------------------------------------------------------------------------
+# MCPServerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServerConfig:
+    def test_to_dict_basic(self) -> None:
+        config = MCPServerConfig(command="npx", args=["-y", "some-pkg"])
+        d = config.to_dict()
+        assert d == {"command": "npx", "args": ["-y", "some-pkg"]}
+
+    def test_to_dict_with_env(self) -> None:
+        config = MCPServerConfig(
+            command="npx",
+            args=["-y", "pkg"],
+            env={"API_KEY": "${API_KEY}"},
+        )
+        d = config.to_dict()
+        assert d["env"] == {"API_KEY": "${API_KEY}"}
+
+    def test_to_dict_no_env_omits_key(self) -> None:
+        config = MCPServerConfig(command="npx", args=[])
+        d = config.to_dict()
+        assert "env" not in d
+
+    def test_frozen(self) -> None:
+        config = MCPServerConfig(command="npx", args=[])
+        with pytest.raises(AttributeError):
+            config.command = "uvx"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _catalog_entry_to_config
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogEntryToConfig:
+    def test_converts_steam_entry(self) -> None:
+        entry = MCP_CATALOG["steam"]
+        config = _catalog_entry_to_config(entry)
+        assert config.command == "npx"
+        assert "-y" in config.args
+        assert entry.package in config.args
+        assert config.env == {}
+
+    def test_converts_brave_entry_with_env(self) -> None:
+        entry = MCP_CATALOG["brave-search"]
+        config = _catalog_entry_to_config(entry)
+        assert config.env == {"BRAVE_API_KEY": "${BRAVE_API_KEY}"}
+
+    def test_converts_entry_with_extra_args(self) -> None:
+        from core.infrastructure.adapters.mcp.catalog import MCPCatalogEntry
+
+        entry = MCPCatalogEntry(
+            name="test",
+            package="test-pkg",
+            description="Test",
+            tags=("test",),
+            extra_args=("--flag", "value"),
+        )
+        config = _catalog_entry_to_config(entry)
+        assert config.args == ["-y", "test-pkg", "--flag", "value"]
+
+
+# ---------------------------------------------------------------------------
+# _has_env_keys
+# ---------------------------------------------------------------------------
+
+
+class TestHasEnvKeys:
+    def test_empty_keys_returns_true(self) -> None:
+        assert _has_env_keys((), {}) is True
+
+    def test_key_in_environ(self) -> None:
+        with patch.dict(os.environ, {"MY_KEY": "val"}):
+            assert _has_env_keys(("MY_KEY",), {}) is True
+
+    def test_key_in_dotenv(self) -> None:
+        assert _has_env_keys(("MY_KEY",), {"MY_KEY": "val"}) is True
+
+    def test_key_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            # Ensure MY_MISSING_KEY is not in environ
+            os.environ.pop("MY_MISSING_KEY", None)
+            assert _has_env_keys(("MY_MISSING_KEY",), {}) is False
+
+    def test_partial_keys_returns_false(self) -> None:
+        with patch.dict(os.environ, {"KEY_A": "val"}):
+            os.environ.pop("KEY_B", None)
+            assert _has_env_keys(("KEY_A", "KEY_B"), {}) is False
+
+
+# ---------------------------------------------------------------------------
+# MCPRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestMCPRegistry:
+    def test_discover_returns_default_servers(self) -> None:
+        registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+        result = registry.discover()
+        for name in DEFAULT_SERVERS:
+            if name in MCP_CATALOG:
+                assert name in result, f"Default server '{name}' not in discovery result"
+
+    def test_discover_includes_auto_servers_when_env_present(self) -> None:
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "test-key"}):
+            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+            result = registry.discover()
+            assert "brave-search" in result
+
+    def test_discover_excludes_auto_servers_when_env_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRAVE_API_KEY", None)
+            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+            result = registry.discover()
+            # brave-search requires BRAVE_API_KEY
+            assert "brave-search" not in result
+
+    def test_discover_server_config_structure(self) -> None:
+        registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+        result = registry.discover()
+        for name, config in result.items():
+            assert "command" in config, f"Server '{name}' missing 'command'"
+            assert "args" in config, f"Server '{name}' missing 'args'"
+
+    def test_list_available(self) -> None:
+        registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+        available = registry.list_available()
+        assert isinstance(available, list)
+        assert available == sorted(available)  # sorted
+
+    def test_list_missing_env(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRAVE_API_KEY", None)
+            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+            missing = registry.list_missing_env()
+            assert "brave-search" in missing
+            assert "BRAVE_API_KEY" in missing["brave-search"]
+
+    def test_defaults_all_in_catalog(self) -> None:
+        """All DEFAULT_SERVERS must exist in MCP_CATALOG."""
+        for name in DEFAULT_SERVERS:
+            assert name in MCP_CATALOG, f"Default '{name}' not in MCP_CATALOG"
+
+    def test_auto_discover_all_in_catalog(self) -> None:
+        """All AUTO_DISCOVER_SERVERS must exist in MCP_CATALOG."""
+        for name in AUTO_DISCOVER_SERVERS:
+            assert name in MCP_CATALOG, f"Auto-discover '{name}' not in MCP_CATALOG"
+
+    def test_custom_defaults(self) -> None:
+        registry = MCPRegistry(
+            dotenv_path="/nonexistent/.env",
+            defaults=("steam",),
+            auto_discover=(),
+        )
+        result = registry.discover()
+        assert "steam" in result
+        assert len(result) == 1
+
+    def test_custom_auto_discover_empty(self) -> None:
+        registry = MCPRegistry(
+            dotenv_path="/nonexistent/.env",
+            defaults=(),
+            auto_discover=(),
+        )
+        result = registry.discover()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# MCPServerManager integration with registry
+# ---------------------------------------------------------------------------
+
+
+class TestManagerRegistryIntegration:
+    def test_load_config_uses_registry(self, tmp_path: Path) -> None:
+        """Manager.load_config() should include registry-discovered servers."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "mcp_servers.json"
+        # No config file exists
+        manager = MCPServerManager(config_path=config_path)
+        count = manager.load_config()
+        # Should have at least the default servers
+        assert count >= len(DEFAULT_SERVERS)
+
+    def test_file_overrides_registry(self, tmp_path: Path) -> None:
+        """File config should override registry defaults."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "mcp_servers.json"
+        # Write a file override for steam with custom args
+        override: dict[str, Any] = {
+            "steam": {
+                "command": "node",
+                "args": ["custom-steam-server.js"],
+            }
+        }
+        config_path.write_text(json.dumps(override), encoding="utf-8")
+
+        manager = MCPServerManager(config_path=config_path)
+        manager.load_config()
+
+        # Steam should use the file override, not the registry default
+        assert manager._servers["steam"]["command"] == "node"
+        assert manager._servers["steam"]["args"] == ["custom-steam-server.js"]
+
+    def test_file_adds_extra_servers(self, tmp_path: Path) -> None:
+        """File config can add servers not in the registry."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "mcp_servers.json"
+        override: dict[str, Any] = {
+            "my-custom-server": {
+                "command": "python",
+                "args": ["-m", "my_mcp_server"],
+            }
+        }
+        config_path.write_text(json.dumps(override), encoding="utf-8")
+
+        manager = MCPServerManager(config_path=config_path)
+        manager.load_config()
+
+        assert "my-custom-server" in manager._servers
+
+    def test_load_config_no_file_still_works(self, tmp_path: Path) -> None:
+        """Without a config file, registry defaults should still load."""
+        from core.infrastructure.adapters.mcp.manager import MCPServerManager
+
+        config_path = tmp_path / "nonexistent.json"
+        manager = MCPServerManager(config_path=config_path)
+        count = manager.load_config()
+        # At minimum, default servers
+        assert count >= 1


### PR DESCRIPTION
## 요약
v0.14.0 이후 8건의 개선/수정 통합. MINOR 릴리스 (User Profile + MCP Registry 신규 기능).

## 포함 PR
- #186 Token Guard 완화 (16384)
- #187 이모지 제거
- #188 APIConnectionError 해소
- #189 User Profile 시스템 (Tier 0.5)
- #191 Token Guard 상한 제거 (무제한)
- #192 README 예시 리뉴얼
- #193 턴/라운드 제한 완화
- #194 MCP 서버 코드 레벨 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)