### PR TITLE
fix: Pipeline None 반환 방어 — Hades 분석 크래시 해소

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -520,8 +520,11 @@ def _progress_line(done: list[str], active: str = "") -> str:
     return " → ".join(parts) if parts else "[header]Starting...[/header]"
 
 
-def _merge_event_output(final_state: dict[str, Any], output: dict[str, Any]) -> None:
+def _merge_event_output(final_state: dict[str, Any], output: dict[str, Any] | None) -> None:
     """Merge a single node's output into the accumulated final state."""
+    if output is None:
+        log.warning("Node returned None output, skipping merge")
+        return
     for k, v in output.items():
         if k in ("analyses", "errors"):
             lst = v if isinstance(v, list) else [v]


### PR DESCRIPTION
LangGraph stream에서 노드 None 반환 시 방어. _merge_event_output null guard.