### PR TITLE
refactor: NL Router 제거 — AgenticLoop 직행 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ uv run geode analyze "Cowboy Bebop" --verbose
 6-Layer Architecture based on `architecture-v6.md` SOT.
 
 ```
-L0: CLI & AGENT      — Typer CLI, NL Router, AgenticLoop, SubAgentManager, Batch
+L0: CLI & AGENT      — Typer CLI, AgenticLoop, SubAgentManager, Batch
 L1: INFRASTRUCTURE   — Ports (Protocol), ClaudeAdapter, OpenAIAdapter, MCP Adapters
 L2: MEMORY           — Organization > Project > Session + User Profile (4-Tier + Hybrid L1/L2)
 L3: ORCHESTRATION    — HookSystem(32), TaskGraph DAG, PlanMode, CoalescingQueue, LaneQueue
@@ -150,11 +150,13 @@ START → router → signals → analyst×4 (Send API)
 
 ```
 core/
-├── cli/                 # CLI + NL Router + Agentic Loop + Sub-Agent
+├── cli/                 # CLI + Agentic Loop + Sub-Agent
 │   ├── agentic_loop.py  # while(tool_use) multi-round + Token Guard
 │   ├── sub_agent.py     # SubAgentManager + SubAgentResult + ErrorCategory
 │   ├── tool_executor.py # Tool dispatch + HITL + delegate_task handler
-│   ├── nl_router.py     # NL intent classification (LLM → regex → help)
+│   ├── nl_router.py     # NL intent classification (legacy, not in main routing path)
+│   ├── system_prompt.py # System prompt builder for AgenticLoop
+│   ├── ip_names.py      # IP name registry (canonical names from fixtures)
 │   ├── conversation.py  # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── batch.py         # Batch analysis (ThreadPoolExecutor)
 │   ├── commands.py      # Slash command dispatch (17 commands)
@@ -315,32 +317,14 @@ Decision Tree on D-E-F axes:
 - **Pricing source**: [OpenAI API Pricing](https://developers.openai.com/api/docs/pricing/)
 - **Cache pricing** (Anthropic): creation = input × 1.25, read = input × 0.1
 
-## NL Router (20 Tools)
+## Tool Routing (AgenticLoop Direct)
 
-NLRouter는 Claude Opus 4.6 Tool Use로 자연어 → 도구 호출을 매핑한다. 3단계 fallback: LLM → regex → help.
+모든 자유 텍스트 입력은 AgenticLoop로 직행한다. Claude가 46개 도구 정의를 직접 보고 tool_use로 자율 선택한다.
 
-| Tool | Action | 설명 |
-|------|--------|------|
-| `list_ips` | list | IP 목록 조회 |
-| `analyze_ip` | analyze | IP 분석 실행 |
-| `search_ips` | search | IP 검색 |
-| `compare_ips` | compare | IP 비교 |
-| `show_help` | help | 도움말 |
-| `generate_report` | report | 리포트 생성 |
-| `batch_analyze` | batch | 배치 분석 |
-| `check_status` | status | 시스템 상태 |
-| `switch_model` | model | 모델 전환 |
-| `memory_search` | memory | 메모리 검색 |
-| `memory_save` | memory | 메모리 저장 |
-| `manage_rule` | memory | 규칙 관리 |
-| `set_api_key` | key | API 키 설정 |
-| `manage_auth` | auth | 인증 관리 |
-| `generate_data` | generate | 데이터 생성 |
-| `schedule_job` | schedule | 작업 스케줄링 |
-| `trigger_event` | trigger | 이벤트 트리거 |
-| `create_plan` | plan | 분석 계획 생성 |
-| `approve_plan` | plan | 계획 승인/실행 |
-| `delegate_task` | delegate | 서브에이전트 병렬 위임 |
+- `/command` -> commands.py 슬래시 커맨드 디스패치
+- 자유 텍스트 -> AgenticLoop.run() (while tool_use 루프)
+
+도구 정의는 `core/tools/definitions.json` (46개)에 통합 관리된다.
 
 ### Claude Code-style UI (agentic_ui.py)
 
@@ -452,7 +436,7 @@ Mock E2E → CLI dry-run → Live E2E → LangSmith 검증 순서로 점검. 각
 |------|------|
 | 테스트 실패 | → 2번(코드 수정) |
 | CLI 오류/crash | → 2번(코드 수정) |
-| NL 의도 불일치 | → nl_router 패턴/매핑 수정 → 2번 |
+| NL 의도 불일치 | → system prompt / tool definitions 수정 → 2번 |
 | LangSmith 트레이스 누락 | → tracing 데코레이터 확인 → 2번 |
 | 품질 저하 (score 이상) | → 해당 노드 로직 점검 → 2번 |
 | 모두 통과 | → 4번 진행 |
@@ -514,7 +498,7 @@ echo "Tests: $TESTS  Modules: $MODULES  Tools: $TOOLS"
 |----------|---------------|---------------|
 | 테스트 수 | `Tests: XXXX+` | Features 테이블 마지막 행 |
 | 모듈 수 | `Modules: XXX` | Features 테이블 마지막 행 |
-| Tool 수 | NL Router 테이블 | Features 테이블 + Tool 목록 38종 |
+| Tool 수 | Tool Routing 섹션 + definitions.json | Features 테이블 + Tool 목록 |
 | HookSystem 이벤트 수 | Orchestration 섹션 | Sub-Agent Orchestration 테이블 |
 | MCP Adapter 수 | MCP 설정 | MCP & Tool Architecture 섹션 |
 | 프로젝트 구조 | Project Structure 트리 | Project Structure 트리 |
@@ -612,7 +596,7 @@ PR 생성 → CI 실행 → 실패?
 | 새 tool 추가 | `definitions.json` + `_build_tool_handlers()` + `test_e2e_live_llm.py` + E2E 시나리오 문서 |
 | 파이프라인 노드 변경 | `graph.py` + `test_e2e_orchestration_live.py` + `test_e2e_live_llm.py` (§5) |
 | LLM 어댑터 변경 | `client.py` + `test_e2e_live_llm.py` (§4 LangSmith) |
-| Offline 패턴 추가 | `nl_router.py` regex + `test_e2e_live_llm.py` (§C5) |
+| Tool 라우팅 변경 | `definitions.json` tool descriptions + `router.md` system prompt |
 
 ### 품질 게이트
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2,7 +2,7 @@
 
 Architecture (OpenClaw-inspired):
   /command  → commands.py (Binding Router: deterministic dispatch)
-  free-text → nl_router.py (NL Router: intent classification)
+  free-text → agentic_loop.py (AgenticLoop: multi-turn tool_use loop)
               → search.py (IP Search Engine: keyword matching)
 """
 
@@ -912,7 +912,7 @@ def _resolve_ip_name(ip_name: str) -> str | None:
     3. Substring: fixture key is contained in input
     4. Substring: input is contained in fixture key
     """
-    from core.cli.nl_router import get_ip_name_map
+    from core.cli.ip_names import get_ip_name_map
     from core.fixtures import FIXTURE_MAP
 
     key = ip_name.lower().strip()
@@ -1293,11 +1293,11 @@ def _show_commentary(
 
 
 def _handle_memory_action(intent: Any, user_text: str, is_offline: bool) -> None:
-    """Handle memory-related actions from NL Router (P0-A + P1-B)."""
-    from core.cli.nl_router import NLIntent
+    """Handle memory-related actions (P0-A + P1-B).
 
-    intent = cast(NLIntent, intent)
-    args = intent.args
+    Accepts either an object with an `args` dict attribute, or a plain dict.
+    """
+    args = intent if isinstance(intent, dict) else intent.args
 
     # Determine sub-action from tool routing
     rule_action = args.get("rule_action")
@@ -1800,22 +1800,17 @@ def _build_tool_handlers(
             return {"error": str(exc)}
 
     def handle_manage_rule(**kwargs: Any) -> dict[str, Any]:
-        from core.cli.nl_router import NLIntent
-
         rule_action = kwargs.get("action", "list")
         name = kwargs.get("name", "")
         if rule_action in ("add", "delete") and not name:
             return _clarify("manage_rule", ["name"], "규칙 이름을 알려주세요.")
-        intent = NLIntent(
-            action="memory",
-            args={
-                "rule_action": rule_action,
-                "name": name,
-                "paths": kwargs.get("paths", []),
-                "content": kwargs.get("content", ""),
-            },
-        )
-        _handle_memory_action(intent, "", False)
+        memory_args = {
+            "rule_action": rule_action,
+            "name": name,
+            "paths": kwargs.get("paths", []),
+            "content": kwargs.get("content", ""),
+        }
+        _handle_memory_action(memory_args, "", False)
         # Return rule list for LLM context
         try:
             mem = ProjectMemory()

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -1,8 +1,8 @@
 """AgenticLoop — while(tool_use) agentic execution loop.
 
-Replaces the single-shot NLRouter classify() → action dispatch pattern
-with a Claude Code-style agentic loop that continues until the LLM
-emits end_turn (no more tool calls).
+Claude Code-style agentic loop that continues until the LLM
+emits end_turn (no more tool calls). All free-text user input
+is routed directly here.
 
 Supports:
 - Multi-intent: "분석하고 비교해줘" → sequential tool calls
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from core.cli.conversation import ConversationContext
 from core.cli.error_recovery import ErrorRecoveryStrategy
-from core.cli.nl_router import _build_system_prompt
+from core.cli.system_prompt import build_system_prompt as _build_system_prompt
 from core.cli.tool_executor import (
     AUTO_APPROVED_MCP_SERVERS,
     DANGEROUS_TOOLS,

--- a/core/cli/ip_names.py
+++ b/core/cli/ip_names.py
@@ -1,0 +1,43 @@
+"""IP name registry — canonical names from fixtures.
+
+Extracted from ``nl_router.py`` so that IP name resolution is available
+without importing the NL Router.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def _load_ip_names() -> dict[str, str]:
+    """Load canonical IP names from fixtures.
+
+    Returns a mapping of lowercased canonical name -> fixture key.
+    Example: {"ghost in the shell": "ghost in shell", "berserk": "berserk"}
+    """
+    from core.fixtures import FIXTURE_MAP, load_fixture
+
+    name_to_key: dict[str, str] = {}
+    for fk in FIXTURE_MAP:
+        try:
+            fixture = load_fixture(fk)
+            canonical = fixture["ip_info"]["ip_name"]
+            name_to_key[canonical.lower()] = fk
+        except Exception:
+            # Fixture without ip_info -- use key as-is
+            name_to_key[fk] = fk
+    return name_to_key
+
+
+# Lazy-loaded cache
+_ip_name_cache: dict[str, str] | None = None
+
+
+def get_ip_name_map() -> dict[str, str]:
+    """Get the canonical name -> fixture key map (cached)."""
+    global _ip_name_cache
+    if _ip_name_cache is None:
+        _ip_name_cache = _load_ip_names()
+    return _ip_name_cache

--- a/core/cli/nl_router.py
+++ b/core/cli/nl_router.py
@@ -32,13 +32,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from core.cli.ip_names import get_ip_name_map
+from core.cli.system_prompt import build_system_prompt as _build_system_prompt
 from core.config import settings
 from core.llm.client import (
     LLMAuthenticationError,
     LLMBadRequestError,
     get_anthropic_client,
 )
-from core.llm.prompts import ROUTER_SYSTEM
 
 if TYPE_CHECKING:
     from core.cli.conversation import ConversationContext
@@ -101,130 +102,9 @@ class NLIntent:
 
 
 # ---------------------------------------------------------------------------
-# IP name registry — canonical names from fixtures
+# IP name registry — re-exported from ip_names.py (imported at top of file)
+# System prompt builder — re-exported from system_prompt.py (imported at top of file)
 # ---------------------------------------------------------------------------
-
-
-def _load_ip_names() -> dict[str, str]:
-    """Load canonical IP names from fixtures.
-
-    Returns a mapping of lowercased canonical name → fixture key.
-    Example: {"ghost in the shell": "ghost in shell", "berserk": "berserk"}
-    """
-    from core.fixtures import FIXTURE_MAP, load_fixture
-
-    name_to_key: dict[str, str] = {}
-    for fk in FIXTURE_MAP:
-        try:
-            fixture = load_fixture(fk)
-            canonical = fixture["ip_info"]["ip_name"]
-            name_to_key[canonical.lower()] = fk
-        except Exception:
-            # Fixture without ip_info — use key as-is
-            name_to_key[fk] = fk
-    return name_to_key
-
-
-# Lazy-loaded cache
-_ip_name_cache: dict[str, str] | None = None
-
-
-def get_ip_name_map() -> dict[str, str]:
-    """Get the canonical name → fixture key map (cached)."""
-    global _ip_name_cache
-    if _ip_name_cache is None:
-        _ip_name_cache = _load_ip_names()
-    return _ip_name_cache
-
-
-# ---------------------------------------------------------------------------
-# System prompt — dynamically built with all available IP names
-# ---------------------------------------------------------------------------
-
-_SYSTEM_PROMPT_TEMPLATE = ROUTER_SYSTEM
-
-# Well-known IPs to include as examples (recognizable across languages)
-_NOTABLE_IPS = {
-    "berserk",
-    "cowboy bebop",
-    "ghost in shell",
-    "hollow knight",
-    "disco elysium",
-    "hades",
-    "celeste",
-    "cult of the lamb",
-    "dead cells",
-    "slay the spire",
-    "vampire survivors",
-    "factorio",
-    "stardew valley",
-    "cuphead",
-    "balatro",
-    "rimworld",
-}
-
-
-def _build_system_prompt() -> str:
-    """Build system prompt with notable IP examples and memory context (P1-C)."""
-    from core.fixtures import FIXTURE_MAP, load_fixture
-
-    name_map = get_ip_name_map()
-    ip_count = len(name_map)
-
-    # Prefer notable IPs as examples, then fill with others
-    examples: list[str] = []
-    for fk in _NOTABLE_IPS:
-        if fk in FIXTURE_MAP:
-            try:
-                canonical = load_fixture(fk)["ip_info"]["ip_name"]
-                examples.append(canonical)
-            except Exception:
-                examples.append(fk.title())
-
-    base = _SYSTEM_PROMPT_TEMPLATE.format(
-        ip_count=ip_count,
-        ip_examples=", ".join(sorted(examples)),
-    )
-
-    # P1-C: Inject memory context (recent insights + active rules)
-    memory_ctx = _build_memory_context()
-    if memory_ctx:
-        base += "\n\n" + memory_ctx
-
-    return base
-
-
-def _build_memory_context() -> str:
-    """Build memory context string from ProjectMemory (recent insights + rules)."""
-    try:
-        from core.memory.project import ProjectMemory
-
-        mem = ProjectMemory()
-        if not mem.exists():
-            return ""
-
-        parts: list[str] = []
-
-        # Recent insights (last 5 lines from MEMORY.md's 최근 인사이트 section)
-        content = mem.load_memory()
-        if "## 최근 인사이트" in content:
-            section = content.split("## 최근 인사이트")[1]
-            lines = [ln.strip() for ln in section.split("\n") if ln.strip().startswith("- ")]
-            if lines:
-                parts.append("Recent insights:\n" + "\n".join(lines[:5]))
-
-        # Active rules summary
-        rules = mem.list_rules()
-        if rules:
-            rule_summaries = [
-                f"- {r['name']} (paths: {', '.join(r.get('paths', []))})" for r in rules[:5]
-            ]
-            parts.append("Active analysis rules:\n" + "\n".join(rule_summaries))
-
-        return "\n\n".join(parts)
-    except Exception:
-        log.debug("Failed to build memory context for system prompt", exc_info=True)
-        return ""
 
 
 # ---------------------------------------------------------------------------

--- a/core/cli/repl.py
+++ b/core/cli/repl.py
@@ -2,10 +2,9 @@
 
 Extracted from ``core/cli/__init__.py`` for architectural clarity.
 
-Three routing paths:
+Two routing paths:
   /command  -> deterministic dispatch (commands.py)
   free-text -> agentic loop (AgenticLoop, multi-turn + multi-intent)
-  fallback  -> single-shot NL Router (when agentic unavailable)
 """
 
 from __future__ import annotations
@@ -188,10 +187,9 @@ def _render_agentic_result(result: AgenticResult) -> None:
 def _interactive_loop() -> None:
     """Claude Code / OpenClaw-style interactive REPL.
 
-    Three routing paths:
+    Two routing paths:
       /command  -> deterministic dispatch (commands.py)
       free-text -> agentic loop (AgenticLoop, multi-turn + multi-intent)
-      fallback  -> single-shot NL Router (when agentic unavailable)
     """
     from core.cli import (
         _build_sub_agent_manager,
@@ -432,7 +430,7 @@ def _interactive_loop() -> None:
                 )
                 agentic_ref[0] = agentic
         else:
-            # Agentic loop: multi-turn + multi-intent (online) or offline regex
+            # Agentic loop: multi-turn + multi-intent
             try:
                 result = agentic.run(user_input)
                 _render_agentic_result(result)

--- a/core/cli/system_prompt.py
+++ b/core/cli/system_prompt.py
@@ -1,0 +1,102 @@
+"""System prompt builder for AgenticLoop.
+
+Builds the base system prompt from the router.md template, enriched with
+domain plugin IP examples and project memory context.
+
+Extracted from ``nl_router.py`` so that the AgenticLoop can use the system
+prompt without depending on the NL Router module.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.cli.ip_names import get_ip_name_map
+from core.llm.prompts import ROUTER_SYSTEM
+
+log = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT_TEMPLATE = ROUTER_SYSTEM
+
+# Well-known IPs to include as examples (recognizable across languages)
+_NOTABLE_IPS = {
+    "berserk",
+    "cowboy bebop",
+    "ghost in shell",
+    "hollow knight",
+    "disco elysium",
+    "hades",
+    "celeste",
+    "cult of the lamb",
+    "dead cells",
+    "slay the spire",
+    "vampire survivors",
+    "factorio",
+    "stardew valley",
+    "cuphead",
+    "balatro",
+    "rimworld",
+}
+
+
+def build_system_prompt() -> str:
+    """Build system prompt with notable IP examples and memory context (P1-C)."""
+    from core.fixtures import FIXTURE_MAP, load_fixture
+
+    name_map = get_ip_name_map()
+    ip_count = len(name_map)
+
+    # Prefer notable IPs as examples, then fill with others
+    examples: list[str] = []
+    for fk in _NOTABLE_IPS:
+        if fk in FIXTURE_MAP:
+            try:
+                canonical = load_fixture(fk)["ip_info"]["ip_name"]
+                examples.append(canonical)
+            except Exception:
+                examples.append(fk.title())
+
+    base = _SYSTEM_PROMPT_TEMPLATE.format(
+        ip_count=ip_count,
+        ip_examples=", ".join(sorted(examples)),
+    )
+
+    # P1-C: Inject memory context (recent insights + active rules)
+    memory_ctx = _build_memory_context()
+    if memory_ctx:
+        base += "\n\n" + memory_ctx
+
+    return base
+
+
+def _build_memory_context() -> str:
+    """Build memory context string from ProjectMemory (recent insights + rules)."""
+    try:
+        from core.memory.project import ProjectMemory
+
+        mem = ProjectMemory()
+        if not mem.exists():
+            return ""
+
+        parts: list[str] = []
+
+        # Recent insights (last 5 lines from MEMORY.md's recent insights section)
+        content = mem.load_memory()
+        if "## 최근 인사이트" in content:
+            section = content.split("## 최근 인사이트")[1]
+            lines = [ln.strip() for ln in section.split("\n") if ln.strip().startswith("- ")]
+            if lines:
+                parts.append("Recent insights:\n" + "\n".join(lines[:5]))
+
+        # Active rules summary
+        rules = mem.list_rules()
+        if rules:
+            rule_summaries = [
+                f"- {r['name']} (paths: {', '.join(r.get('paths', []))})" for r in rules[:5]
+            ]
+            parts.append("Active analysis rules:\n" + "\n".join(rule_summaries))
+
+        return "\n\n".join(parts)
+    except Exception:
+        log.debug("Failed to build memory context for system prompt", exc_info=True)
+        return ""

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -275,22 +275,17 @@ def _build_memory_handlers() -> dict[str, Any]:
             return {"error": str(exc)}
 
     def handle_manage_rule(**kwargs: Any) -> dict[str, Any]:
-        from core.cli.nl_router import NLIntent
-
         rule_action = kwargs.get("action", "list")
         name = kwargs.get("name", "")
         if rule_action in ("add", "delete") and not name:
             return _clarify("manage_rule", ["name"], "규칙 이름을 알려주세요.")
-        intent = NLIntent(
-            action="memory",
-            args={
-                "rule_action": rule_action,
-                "name": name,
-                "paths": kwargs.get("paths", []),
-                "content": kwargs.get("content", ""),
-            },
-        )
-        _handle_memory_action(intent, "", False)
+        memory_args = {
+            "rule_action": rule_action,
+            "name": name,
+            "paths": kwargs.get("paths", []),
+            "content": kwargs.get("content", ""),
+        }
+        _handle_memory_action(memory_args, "", False)
         # Return rule list for LLM context
         try:
             mem = ProjectMemory()

--- a/core/ui/status.py
+++ b/core/ui/status.py
@@ -1,4 +1,4 @@
-"""Claude Code-style status spinner for NLRouter LLM calls.
+"""Claude Code-style status spinner for AgenticLoop LLM calls.
 
 Shows a braille-dot spinner during API calls, then replaces with a
 permanent summary line including action, token counts, cost and elapsed time.


### PR DESCRIPTION
## 요약

PR #243 반영. NL Router 이중 라우팅 제거, 모든 입력 AgenticLoop 직행.

## 테스트

CI 6/6 통과 (Lint, Type, Test 3.12/3.13, Security, Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)