### PR TITLE
feat: 워크플로우 프론티어 하네스 리서치 프로세스 추가

### DIFF
--- a/.claude/skills/frontier-harness-research/SKILL.md
+++ b/.claude/skills/frontier-harness-research/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: frontier-harness-research
+description: 기능 구현 전 프론티어 하네스 4종(Claude Code, Codex, OpenClaw, autoresearch)에서 관련 패턴을 탐색하고 GAP 분석을 수행하는 리서치 프로세스. "리서치", "research", "gap", "frontier", "harness", "사례 조사", "패턴 탐색", "비교 분석" 키워드로 트리거.
+user-invocable: false
+---
+
+# Frontier Harness Research — 프론티어 비교 리서치 프로세스
+
+> **목적**: 기능 구현 전에 4개 프론티어 하네스에서 주제 관련 패턴을 탐색하고, GEODE에 적용할 설계 판단 근거를 확보한다.
+> **적용 시점**: Implementation Workflow Step 1 (Research → Plan) 단계에서 반드시 수행.
+
+## 프론티어 하네스 4종
+
+| # | 시스템 | 유형 | 핵심 패턴 영역 | GEODE 스킬 참조 |
+|---|--------|------|---------------|----------------|
+| 1 | **Claude Code** | CLI 에이전트 | 권한 모델, Hook, Memory, Skill, Context 관리, UI | (내장 지식) |
+| 2 | **Codex** | 클라우드 에이전트 | Sandbox 실행, TDD 루프, PR 워크플로우, 코드 리뷰, 멀티파일 편집 | (내장 지식) |
+| 3 | **OpenClaw** | 채팅 에이전트 | Gateway, Session Key, Binding, Lane Queue, Plugin, Failover, 4계층 자동화 | `openclaw-patterns` |
+| 4 | **autoresearch** | 자율 실험 루프 | 제약 기반 설계, 래칫, Context Budget, program.md, Simplicity Selection | `karpathy-patterns` |
+
+## 리서치 프로세스
+
+### Step 1: 주제 정의
+
+구현할 기능을 한 줄로 정의하고, 관련 키워드를 추출한다.
+
+```
+예시:
+  주제: "Model Failover 자동화"
+  키워드: failover, fallback, retry, circuit breaker, model switching
+```
+
+### Step 2: 4종 패턴 탐색
+
+각 시스템에서 주제 관련 패턴을 탐색한다. **스킬 파일이 있으면 먼저 읽고**, 없으면 내장 지식에서 추출한다.
+
+#### 2a. Claude Code 패턴 탐색
+
+| 탐색 영역 | 확인 포인트 |
+|----------|-----------|
+| Permission Model | allowlist/denylist, auto-approve, 거부 후 fallback |
+| Hook System | pre/post tool hooks, settings.json 기반 자동화 |
+| Memory | CLAUDE.md, project memory, 자동 기억 |
+| Skill System | skill discovery, trigger 키워드, 4단계 우선순위 |
+| Context Management | sliding window, compression, token 관리 |
+| UI Patterns | status line, progress indicators, error display |
+| Safety | HITL tiers, bash safety, dangerous tool gates |
+
+#### 2b. Codex 패턴 탐색
+
+| 탐색 영역 | 확인 포인트 |
+|----------|-----------|
+| Sandbox Execution | 격리 환경, 파일시스템 제한, 네트워크 제한 |
+| TDD Loop | test-first, red-green-refactor, 자동 검증 |
+| PR Workflow | 브랜치 생성, 변경사항 요약, 리뷰 요청 |
+| Multi-file Editing | 의존성 추적, 일관성 유지, 리팩토링 범위 |
+| Task Decomposition | 복합 작업 분해, 순차/병렬 판단 |
+
+#### 2c. OpenClaw 패턴 탐색 (`openclaw-patterns` 스킬 참조)
+
+| 탐색 영역 | 확인 포인트 |
+|----------|-----------|
+| Gateway + Agent 이중 체계 | 제어 플레인 vs 실행 플레인 분리 |
+| Session Key 계층 | `agent:{id}:{context}` 형식 세션 격리 |
+| Binding 라우팅 | Most-Specific Wins, 정적 규칙, hot reload |
+| Lane Queue | Session/Global/Subagent Lane 동시성 제어 |
+| Sub-agent Spawn+Announce | 격리 실행, 결과 자동 주입 |
+| 4계층 자동화 | Heartbeat, Cron, Internal Hooks, Gateway Hooks |
+| Plugin 아키텍처 | Channel/Tool/Skill/Hook 4가지 확장점 |
+| Policy Chain | 6-계층 도구 접근 제어 |
+| Failover | Auth Rotation, Thinking Fallback, Context Overflow, Model Failover |
+| 운영 패턴 | Coalescing, Atomic Store, Run Log, Hot Reload, Stuck Detection |
+
+#### 2d. autoresearch 패턴 탐색 (`karpathy-patterns` 스킬 참조)
+
+| 탐색 영역 | 확인 포인트 |
+|----------|-----------|
+| P1 제약 기반 설계 | "무엇을 할 수 없는가"를 먼저 정의 |
+| P2 단일 파일 제약 | 수정 표면적 최소화 |
+| P3 고정 시간 예산 | 스텝이 아닌 벽시계로 제한 |
+| P4 래칫 메커니즘 | 개선만 유지, 악화 시 자동 복구 |
+| P5 Git as State Machine | 커밋=실험, reset=폐기 |
+| P6 Context Budget | 리다이렉트 + 선택 추출 |
+| P7 program.md | 에이전트 행동 = 지시서 수정 |
+| P10 Simplicity Selection | 코드 삭제 > 코드 추가 |
+
+### Step 3: GAP 분석
+
+탐색 결과를 GEODE 현재 상태와 대조하여 GAP을 식별한다.
+
+```
+출력 형식:
+
+| # | 패턴 | 출처 | GEODE 상태 | GAP | 우선순위 |
+|---|------|------|-----------|-----|---------|
+| 1 | Model Failover | OpenClaw | ⚠️ 정의만 | 자동 전환 로직 없음 | P1 |
+| 2 | Circuit Breaker | Codex | ✗ 없음 | 연속 실패 시 차단 없음 | P1 |
+| 3 | Retry Budget | autoresearch P3 | ⚠️ 부분 | 시간 기반 제한 없음 | P2 |
+```
+
+### Step 4: 설계 판단
+
+GAP 분석 결과에서 구현할 항목을 선택하고 설계 판단 근거를 문서화한다.
+
+**판단 기준:**
+
+| 기준 | 적용 |
+|------|------|
+| 3종 이상에서 동일 패턴 | → 반드시 채택 |
+| 2종에서 유사 패턴 | → 핵심 추출, GEODE 맥락 변형 |
+| 1종에서만 존재 | → 필요성 검증 후 판단 |
+| 과잉 엔지니어링 위험 | → Karpathy P10 적용, 최소 구현 |
+| 기존 GEODE 패턴과 충돌 | → 기존 패턴 우선, 점진적 전환 |
+
+### Step 5: 계획 문서 작성
+
+`docs/plans/`에 계획 문서를 작성한다. 반드시 리서치 결과 요약을 포함한다.
+
+```markdown
+# Plan: [기능명]
+
+## 프론티어 리서치 요약
+
+| 시스템 | 관련 패턴 | 채택 여부 | 근거 |
+|--------|----------|----------|------|
+| Claude Code | ... | 채택/변형/불채택 | ... |
+| Codex | ... | 채택/변형/불채택 | ... |
+| OpenClaw | ... | 채택/변형/불채택 | ... |
+| autoresearch | ... | 채택/변형/불채택 | ... |
+
+## 설계 판단
+...
+
+## 구현 Phase
+...
+```
+
+## 리서치 체크리스트
+
+기능 구현 전 아래를 확인한다:
+
+- [ ] 주제 키워드 정의
+- [ ] Claude Code 패턴 탐색 완료
+- [ ] Codex 패턴 탐색 완료
+- [ ] OpenClaw 패턴 탐색 완료 (`openclaw-patterns` 스킬 참조)
+- [ ] autoresearch 패턴 탐색 완료 (`karpathy-patterns` 스킬 참조)
+- [ ] GAP 분석 테이블 작성
+- [ ] 설계 판단 근거 문서화
+- [ ] docs/plans/ 계획 문서에 리서치 요약 포함
+
+## 주의사항
+
+- **리서치는 구현 전에 수행한다.** 구현 중 패턴을 발견해도 되돌아가지 않고, 다음 이터레이션에서 개선한다.
+- **4종 모두 탐색할 필요는 없다.** 주제와 무관한 시스템은 "해당 없음"으로 스킵.
+- **스킬 파일이 있으면 반드시 먼저 읽는다.** `openclaw-patterns`, `karpathy-patterns` 스킬은 이미 증류된 패턴을 담고 있으므로 중복 탐색을 방지한다.
+- **과잉 리서치 방지**: 리서치 시간이 구현 시간을 초과하면 안 된다. Karpathy P3(고정 시간 예산) 적용.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,12 +391,36 @@ git branch -d feature/<브랜치명>
 
 ### 1. Research → Plan
 
+**모든 기능 구현 전에 프론티어 하네스 리서치를 수행한다.** 주제와 관련된 패턴을 4개 참조 시스템에서 탐색하고, GAP 분석 후 계획을 수립한다.
+
 ```
-1. 기존 코드 탐색 (Explore agent, Grep, Read)
-2. 외부 사례 조사 (Eco², OpenClaw, Claude Code 패턴 참조)
-3. Gap 분석 (AS-IS → TO-BE 정리)
-4. docs/plans/에 계획 문서 작성
+1a. 기존 코드 탐색 (Explore agent, Grep, Read)
+    - AS-IS 구조 파악, 관련 Port/Adapter/Hook/Tool 식별
+
+1b. 프론티어 하네스 리서치 (frontier-harness-research 스킬 참조)
+    - Claude Code: 권한 모델, Hook, Memory, Skill, Context 관리 패턴
+    - Codex: Sandbox 실행, TDD 루프, PR 워크플로우, 코드 리뷰 패턴
+    - OpenClaw: Gateway, Session Key, Binding, Lane Queue, Plugin, Failover 패턴
+    - autoresearch: 제약 기반 설계, 래칫, Context Budget, program.md 패턴
+    - 각 시스템에서 주제 관련 패턴 추출 → GEODE 적용 가능성 판단
+
+1c. Gap 분석 (AS-IS → TO-BE 정리)
+    - 프론티어 대비 빠진 패턴/기능 식별
+    - P0/P1/P2 우선순위 분류
+    - 구현 범위 결정 (전체 적용 vs 핵심만)
+
+1d. docs/plans/에 계획 문서 작성
+    - 리서치 결과 요약 + 설계 판단 근거 포함
 ```
+
+**리서치 판정 기준:**
+
+| 발견 | 조치 |
+|------|------|
+| 프론티어에 동일 패턴 존재 | → 패턴 채택, 구현 방식 참조 |
+| 프론티어에 유사 패턴 존재 | → 핵심만 추출, GEODE 맥락에 맞게 변형 |
+| 프론티어에 패턴 없음 | → 자체 설계, 근거 문서화 |
+| 과잉 엔지니어링 위험 | → Karpathy P10 (Simplicity Selection) 적용 |
 
 ### 2. Implement → Unit Verify (반복)
 
@@ -415,10 +439,12 @@ Mock E2E → CLI dry-run → Live E2E → LangSmith 검증 순서로 점검. 각
 ```
 3a. Mock E2E: uv run pytest tests/test_agentic_loop.py tests/test_e2e.py tests/test_e2e_orchestration_live.py -v
 3b. CLI dry-run: uv run geode analyze "Berserk" --dry-run  (실제 CLI 동작 확인)
-3c. NL 의도→행동 점검:
+3c. AgenticLoop 의도→행동 점검 (tool_use 직행):
     - "목록 보여줘" → list_ips 호출 확인
     - "Berserk 분석 계획 세워줘" → create_plan 호출 확인
     - "병렬로 처리해" → delegate_task 호출 확인
+    - "Slack에 알림 보내줘" → send_notification 호출 확인
+    - "내일 일정 뭐 있어?" → calendar_list_events 호출 확인
 3d. Live E2E (API 키 필요): set -a && source .env && set +a && uv run pytest tests/test_e2e_live_llm.py -v -m live
 3e. LangSmith 트레이스 확인: smith.langchain.com → geode 프로젝트
     - AgenticLoop 트레이스 존재
@@ -436,7 +462,7 @@ Mock E2E → CLI dry-run → Live E2E → LangSmith 검증 순서로 점검. 각
 |------|------|
 | 테스트 실패 | → 2번(코드 수정) |
 | CLI 오류/crash | → 2번(코드 수정) |
-| NL 의도 불일치 | → system prompt / tool definitions 수정 → 2번 |
+| 의도→tool 불일치 | → system prompt / tool definitions 수정 → 2번 |
 | LangSmith 트레이스 누락 | → tracing 데코레이터 확인 → 2번 |
 | 품질 저하 (score 이상) | → 해당 노드 로직 점검 → 2번 |
 | 모두 통과 | → 4번 진행 |
@@ -623,6 +649,7 @@ Project-specific skills in `.claude/skills/`:
 | `karpathy-patterns` | autoresearch, agenthub, ratchet, context budget | 자율 에이전트 10대 설계 원칙 (P1-P10) |
 | `openclaw-patterns` | gateway, session, binding, lane, plugin | 에이전트 시스템 설계 패턴 (OpenClaw) |
 | `architecture-patterns` | clean architecture, hexagonal, DDD | Backend 아키텍처 패턴 |
+| `frontier-harness-research` | 리서치, research, gap, frontier, harness, 사례 조사 | 프론티어 하네스 4종 비교 리서치 프로세스 |
 | `tech-blog-writer` | blog, 포스팅, 블로그, tech blog | 기술 블로그 작성 가이드 |
 
 ## Linked Skills (from parent project)


### PR DESCRIPTION
## 요약

Implementation Workflow Step 1에 프론티어 하네스 4종 리서치 프로세스 체계화.

## 변경 사항

### 핵심
- **CLAUDE.md Step 1 확장** — 1a(코드 탐색) → 1b(프론티어 리서치) → 1c(GAP 분석) → 1d(계획 문서) 4단계
- **`frontier-harness-research` 스킬 신규** — Claude Code/Codex/OpenClaw/autoresearch 4종 비교 탐색 + GAP 분석 + 설계 판단 프로세스

### 부수
- E2E 검증 항목에 send_notification, calendar_list_events 의도→행동 점검 추가
- NL Router 제거 반영 (NL 의도→AgenticLoop 의도)

### 왜?
- 기능 구현 전 프론티어 시스템에서 검증된 패턴을 탐색하지 않으면 자체 설계로 수렴 → GAP 누적
- 이번 세션에서 OpenClaw GAP 6건 사후 발견 → 사전 리서치로 방지

## 테스트

문서/스킬 변경만 — 코드 변경 없음. 2636 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)