### PR TITLE
feat: P1 배치 — Model Failover + MCP Lifecycle + Sub-agent Announce

### DIFF
--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -16,6 +16,8 @@
 - (없음 — 기본 14-axis 루브릭 사용)
 
 ## 최근 인사이트
+- 2026-03-18: [Berserk] tier=?, score=0.00
+- 2026-03-18: [unknown] tier=?, score=0.00
 - 2026-03-16: [Berserk] tier=?, score=0.00
 - 2026-03-16: [unknown] tier=?, score=0.00
 - 2026-03-15: [Berserk] tier=?, score=0.00

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2610,19 +2610,17 @@ def _interactive_loop() -> None:
         _set_readiness(readiness)
 
     # 4. MCP servers (slowest — npx subprocess spawn)
+    #    Uses startup() for full lifecycle: config + connect + signal handlers + atexit
     _init_step("MCP servers")
     from core.infrastructure.adapters.mcp.manager import MCPServerManager
 
     mcp_mgr: MCPServerManager | None = None
     try:
         _mgr = MCPServerManager()
-        n_mcp = _mgr.load_config()
-        if n_mcp > 0:
+        n_connected = _mgr.startup()
+        if len(_mgr._servers) > 0:
             mcp_mgr = _mgr
-            import atexit
-
-            atexit.register(_mgr.close_all)
-            _init_done(f"MCP ({n_mcp} servers)")
+            _init_done(f"MCP ({n_connected}/{len(_mgr._servers)} servers)")
         else:
             _init_done("MCP (none)", ok=False)
     except Exception:
@@ -2769,7 +2767,7 @@ def _interactive_loop() -> None:
     # Clean shutdown: MCP servers → SchedulerService
     if mcp_mgr is not None:
         try:
-            mcp_mgr.close_all()
+            mcp_mgr.shutdown()
         except Exception:
             log.debug("MCP shutdown error", exc_info=True)
 

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from core.cli.conversation import ConversationContext
 from core.cli.error_recovery import ErrorRecoveryStrategy
+from core.cli.sub_agent import SubAgentResult, drain_announced_results
 from core.cli.system_prompt import build_system_prompt as _build_system_prompt
 from core.cli.tool_executor import (
     AUTO_APPROVED_MCP_SERVERS,
@@ -32,14 +33,10 @@ from core.cli.tool_executor import (
     WRITE_TOOLS,
     ToolExecutor,
 )
-from core.config import ANTHROPIC_PRIMARY, settings
+from core.config import ANTHROPIC_FALLBACK_CHAIN, ANTHROPIC_PRIMARY, settings
 from core.llm.client import (
-    LLMAuthenticationError,
     LLMBadRequestError,
-    LLMConnectionError,
-    LLMInternalServerError,
-    LLMRateLimitError,
-    LLMTimeoutError,
+    call_with_failover,
     get_async_anthropic_client,
     maybe_traceable,
 )
@@ -184,9 +181,11 @@ class AgenticLoop:
         skill_registry: Any | None = None,
         hooks: HookSystem | None = None,
         enable_goal_decomposition: bool = True,
+        parent_session_key: str = "",
     ) -> None:
         self.context = context
         self.executor = tool_executor
+        self._parent_session_key = parent_session_key
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens
         self.model = model or ANTHROPIC_PRIMARY
@@ -255,6 +254,9 @@ class AgenticLoop:
         for round_idx in range(self.max_rounds):
             is_last_round = round_idx == self.max_rounds - 1
             self._op_logger.begin_round("AgenticLoop")
+
+            # Poll for sub-agent announced results (OpenClaw Spawn+Announce)
+            self._check_announced_results(messages)
 
             # Show spinner while waiting for LLM response
             label = "Thinking..." if round_idx == 0 else f"Thinking... (round {round_idx + 1})"
@@ -532,11 +534,40 @@ class AgenticLoop:
             log.debug("Goal decomposition skipped", exc_info=True)
             return None
 
+    def _check_announced_results(self, messages: list[dict[str, Any]]) -> int:
+        """Poll for sub-agent announced results and inject into conversation.
+
+        Drains the announce queue for this parent session and adds each
+        completed sub-agent's summary as a system event message.
+
+        OpenClaw Spawn+Announce pattern: parent polls at each round start.
+        """
+        if not self._parent_session_key:
+            return 0
+        announced: list[SubAgentResult] = drain_announced_results(self._parent_session_key)
+        if not announced:
+            return 0
+        for result in announced:
+            status_label = "completed" if result.success else "failed"
+            content = (
+                f"Sub-agent {status_label}: task_id={result.task_id}, summary={result.summary}"
+            )
+            if result.error_message:
+                content += f", error={result.error_message}"
+            self.context.add_system_event("subagent_completed", content)
+            messages.append({"role": "user", "content": f"[system:subagent_completed] {content}"})
+            log.debug("Injected announce for task_id=%s", result.task_id)
+        return len(announced)
+
     @maybe_traceable(run_type="llm", name="AgenticLoop._call_llm")  # type: ignore[untyped-decorator]
     async def _call_llm(
         self, system: str, messages: list[dict[str, Any]], *, round_idx: int = 0
     ) -> Any | None:
-        """Async Anthropic API call with tools.  Retries on rate-limit (3x).
+        """Async Anthropic API call with tools + automatic model failover.
+
+        Uses ``call_with_failover`` to iterate through the fallback chain
+        (ANTHROPIC_FALLBACK_CHAIN) when the current model fails with retryable
+        errors. AuthenticationError aborts immediately without failover.
 
         On the last round (round_idx == max_rounds - 1), forces tool_choice=none
         so the LLM must produce a text response instead of another tool call.
@@ -558,102 +589,80 @@ class AgenticLoop:
         force_text = remaining <= self.WRAP_UP_HEADROOM
         tool_choice: dict[str, str] = {"type": "none"} if force_text else {"type": "auto"}
 
-        max_retries = settings.llm_max_retries
-        for attempt in range(max_retries):
-            try:
-                # Strip non-API fields before sending to Anthropic.
-                # Extra fields (category, cost_tier, defer_loading,
-                # _mcp_server, etc.) cause 400 "Extra inputs are not permitted".
-                api_tools = [
-                    {k: v for k, v in t.items() if k in _API_ALLOWED_KEYS} for t in self._tools
-                ]
-                response = await self._client.messages.create(  # type: ignore[call-overload]
-                    model=self.model,
-                    system=system,
-                    messages=messages,
-                    tools=api_tools,
-                    tool_choice=tool_choice,
-                    max_tokens=self.max_tokens,
-                    temperature=0.0,
-                    extra_headers={
-                        "anthropic-beta": "context-management-2025-06-27",
-                    },
-                    extra_body={
-                        "context_management": {
-                            "edits": [
-                                {
-                                    "type": "clear_tool_uses_20250919",
-                                    "keep": {"type": "tool_uses", "value": 5},
-                                }
-                            ]
-                        }
-                    },
-                )
-                return response
+        # Strip non-API fields before sending to Anthropic.
+        # Extra fields (category, cost_tier, defer_loading,
+        # _mcp_server, etc.) cause 400 "Extra inputs are not permitted".
+        api_tools = [{k: v for k, v in t.items() if k in _API_ALLOWED_KEYS} for t in self._tools]
 
-            except (LLMTimeoutError, LLMConnectionError, LLMInternalServerError) as exc:
-                # Exponential backoff: 2s, 4s, 8s (fast initial retry for transient
-                # connection resets and server errors (500/502/503),
-                # capped by settings.llm_retry_max_delay)
-                wait = min(
-                    settings.llm_retry_base_delay * (2**attempt),
-                    settings.llm_retry_max_delay,
-                )
-                exc_type = type(exc).__name__
-                log.warning(
-                    "%s (attempt %d/%d), retrying in %.1fs",
-                    exc_type,
-                    attempt + 1,
-                    max_retries,
-                    wait,
-                )
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(wait)
-                else:
-                    log.error("%s exhausted after %d retries", exc_type, max_retries)
-                    self._last_llm_error = f"{exc_type} after {max_retries} retries"
+        # Build failover chain: current model first, then rest of ANTHROPIC_FALLBACK_CHAIN
+        failover_models = [self.model] + [m for m in ANTHROPIC_FALLBACK_CHAIN if m != self.model]
+
+        async def _do_call(model: str) -> Any:
+            return await self._client.messages.create(  # type: ignore[union-attr]
+                model=model,
+                system=system,
+                messages=messages,
+                tools=api_tools,
+                tool_choice=tool_choice,
+                max_tokens=self.max_tokens,
+                temperature=0.0,
+                extra_headers={
+                    "anthropic-beta": "context-management-2025-06-27",
+                },
+                extra_body={
+                    "context_management": {
+                        "edits": [
+                            {
+                                "type": "clear_tool_uses_20250919",
+                                "keep": {"type": "tool_uses", "value": 5},
+                            }
+                        ]
+                    }
+                },
+            )
+
+        try:
+            response, used_model = await call_with_failover(failover_models, _do_call)
+        except KeyboardInterrupt:
+            log.info("LLM call interrupted by user")
+            return None
+        except LLMBadRequestError as exc:
+            msg = str(exc)
+            log.warning("Anthropic BadRequest in agentic loop: %s", msg)
+            if "tool_use_id" in msg or "tool_result" in msg:
+                # Orphaned tool_result in conversation history — repair and retry
+                self._repair_messages(messages)
+                log.info("Repaired orphaned tool_result in conversation history")
+                # Retry once after repair (no recursive failover to keep it simple)
+                try:
+                    response = await _do_call(self.model)
+                    return response
+                except Exception:
+                    log.warning("Retry after repair failed", exc_info=True)
                     return None
-            except LLMRateLimitError:
-                # Rate limits use longer backoff: 10s, 20s, 40s
-                wait = min(2**attempt * 10, settings.llm_retry_max_delay)
-                log.warning(
-                    "Rate limited (attempt %d/%d), retrying in %.1fs",
-                    attempt + 1,
-                    max_retries,
-                    wait,
+            if "input_schema" in msg:
+                log.error(
+                    "Tool schema error — likely an MCP tool missing input_schema. tools count=%d",
+                    len(self._tools),
                 )
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(wait)
-                else:
-                    log.error("Rate limit exhausted after %d retries", max_retries)
-                    self._last_llm_error = f"RateLimitError after {max_retries} retries"
-                    return None
-            except LLMAuthenticationError:
-                log.warning("Anthropic API key is invalid in agentic loop")
-                self._last_llm_error = "AuthenticationError — API key invalid"
-                return None
-            except LLMBadRequestError as exc:
-                msg = str(exc)
-                log.warning("Anthropic BadRequest in agentic loop: %s", msg)
-                if "tool_use_id" in msg or "tool_result" in msg:
-                    # Orphaned tool_result in conversation history — repair
-                    self._repair_messages(messages)
-                    log.info("Repaired orphaned tool_result in conversation history")
-                    continue  # retry with cleaned messages
-                if "input_schema" in msg:
-                    log.error(
-                        "Tool schema error — likely an MCP tool missing input_schema. "
-                        "tools count=%d",
-                        len(self._tools),
-                    )
-                return None
-            except KeyboardInterrupt:
-                log.info("LLM call interrupted by user")
-                return None
-            except Exception:
-                log.warning("Agentic LLM call failed", exc_info=True)
-                return None
-        return None
+            return None
+        except Exception:
+            log.warning("Agentic LLM call failed", exc_info=True)
+            return None
+
+        if response is None:
+            self._last_llm_error = "All models in failover chain exhausted"
+            return None
+
+        # Log model switch for visibility
+        if used_model and used_model != self.model:
+            log.warning(
+                "Model failover: %s -> %s (primary unavailable)",
+                self.model,
+                used_model,
+            )
+
+        return response
 
     _MAX_CONSECUTIVE_FAILURES = 2  # auto-skip after N consecutive failures per tool
 

--- a/core/cli/conversation.py
+++ b/core/cli/conversation.py
@@ -64,6 +64,19 @@ class ConversationContext:
         """Number of user messages (approximate turn count)."""
         return sum(1 for m in self.messages if m["role"] == "user")
 
+    def add_system_event(self, event_type: str, content: str) -> None:
+        """Inject a system event as a user message (non-tool-result).
+
+        Used for out-of-band notifications such as sub-agent completion
+        announcements (OpenClaw Spawn+Announce pattern).  The event is
+        wrapped in a structured text block so the LLM can distinguish
+        system events from user input.
+        """
+        formatted = f"[system:{event_type}] {content}"
+        self.messages.append({"role": "user", "content": formatted})
+        self._trim()
+        log.debug("System event injected: type=%s len=%d", event_type, len(content))
+
     @property
     def is_empty(self) -> bool:
         return len(self.messages) == 0

--- a/core/cli/repl.py
+++ b/core/cli/repl.py
@@ -249,19 +249,17 @@ def _interactive_loop() -> None:
         _set_readiness(readiness)
 
     # 4. MCP servers (slowest -- npx subprocess spawn)
+    #    Uses startup() for full lifecycle: config + connect + signal handlers + atexit
     _init_step("MCP servers")
     from core.infrastructure.adapters.mcp.manager import MCPServerManager
 
     mcp_mgr: MCPServerManager | None = None
     try:
         _mgr = MCPServerManager()
-        n_mcp = _mgr.load_config()
-        if n_mcp > 0:
+        n_connected = _mgr.startup()
+        if len(_mgr._servers) > 0:
             mcp_mgr = _mgr
-            import atexit
-
-            atexit.register(_mgr.close_all)
-            _init_done(f"MCP ({n_mcp} servers)")
+            _init_done(f"MCP ({n_connected}/{len(_mgr._servers)} servers)")
         else:
             _init_done("MCP (none)", ok=False)
     except Exception:
@@ -455,7 +453,7 @@ def _interactive_loop() -> None:
 
     if mcp_mgr is not None:
         try:
-            mcp_mgr.close_all()
+            mcp_mgr.shutdown()
         except Exception:
             log.debug("MCP shutdown error", exc_info=True)
 

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -41,6 +41,23 @@ log = logging.getLogger(__name__)
 # Thread-local storage for subagent context (OpenClaw Spawn pattern)
 _subagent_context = threading.local()
 
+# Module-level announce queue: parent_session_key → list[SubAgentResult]
+# Thread-safe via _announce_lock. Parent AgenticLoop polls this queue
+# to inject completion notifications into its conversation context.
+_announce_queue: dict[str, list[SubAgentResult]] = {}
+_announce_lock = threading.Lock()
+
+
+def drain_announced_results(parent_session_key: str) -> list[SubAgentResult]:
+    """Drain all announced results for a parent session (thread-safe).
+
+    Returns the list of completed SubAgentResults and clears the queue.
+    Called by AgenticLoop._check_announced_results() each round.
+    """
+    with _announce_lock:
+        results = _announce_queue.pop(parent_session_key, [])
+    return results
+
 
 def get_subagent_context() -> tuple[bool, str]:
     """Return (is_subagent, child_session_key) from thread-local."""
@@ -118,6 +135,7 @@ class SubAgentResult:
     error_category: str | None = None
     error_message: str | None = None
     retryable: bool = False
+    announced: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize, omitting None-valued fields."""
@@ -189,6 +207,8 @@ class SubAgentManager:
         self._skill_registry = skill_registry
         self._depth = depth
         self._max_depth = max_depth
+        # Announce mechanism (OpenClaw Spawn+Announce pattern)
+        self._announce_enabled = bool(parent_session_key)
 
     def delegate(
         self,
@@ -313,6 +333,28 @@ class SubAgentManager:
                     rec.completed_at = now
                     rec.outcome = "ok" if sub_result.success else "error"
 
+        # Announce completed results to parent (OpenClaw Spawn+Announce)
+        if self._announce_enabled and self._parent_session_key:
+            for sub_result in results:
+                # Build a SubAgentResult for announce (may already be one)
+                summary = ""
+                if sub_result.success:
+                    summary = sub_result.output.get("summary", "") if sub_result.output else ""
+                    if not summary:
+                        summary = str(sub_result.output)[:200] if sub_result.output else "completed"
+                else:
+                    summary = sub_result.error or "failed"
+                agent_result = SubAgentResult(
+                    task_id=sub_result.task_id,
+                    task_type=sub_result.description,
+                    status="ok" if sub_result.success else "error",
+                    summary=summary,
+                    data=sub_result.output,
+                    duration_ms=sub_result.duration_ms,
+                    error_message=sub_result.error,
+                )
+                self._announce_result(self._parent_session_key, agent_result)
+
         succeeded = sum(1 for r in results if r.success)
         log.info(
             "SubAgent batch complete: %d/%d succeeded",
@@ -329,6 +371,29 @@ class SubAgentManager:
         """Return a snapshot of all run records for observability."""
         with self._records_lock:
             return dict(self._run_records)
+
+    def _announce_result(self, parent_session_key: str, child_result: SubAgentResult) -> None:
+        """Announce a completed sub-agent result to the parent session.
+
+        Pushes the result into the module-level ``_announce_queue`` so
+        the parent AgenticLoop can pick it up on the next round via
+        ``drain_announced_results()``.  Marks ``child_result.announced``
+        to prevent double-announce.
+
+        OpenClaw Spawn+Announce pattern: child completes -> parent is
+        notified asynchronously -> parent injects summary into context.
+        """
+        if child_result.announced:
+            return
+        child_result.announced = True
+        with _announce_lock:
+            _announce_queue.setdefault(parent_session_key, []).append(child_result)
+        log.debug(
+            "Announced result: task_id=%s to parent=%s (status=%s)",
+            child_result.task_id,
+            parent_session_key,
+            child_result.status,
+        )
 
     def _resolve_agent(self, task: SubTask) -> dict[str, Any] | None:
         """Resolve agent context.
@@ -414,6 +479,13 @@ class SubAgentManager:
         if sub_result is not None:
             data["duration_ms"] = sub_result.duration_ms
             data["success"] = sub_result.success
+            # Include result summary in SUBAGENT_COMPLETED hook data
+            # (OpenClaw Announce pattern — hooks carry the completion summary)
+            if event == HookEvent.SUBAGENT_COMPLETED:
+                summary = sub_result.output.get("summary", "") if sub_result.output else ""
+                if not summary:
+                    summary = str(sub_result.output)[:200] if sub_result.output else ""
+                data["summary"] = summary
         if error is not None:
             data["error"] = error
         try:

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -6,14 +6,20 @@ Configuration is loaded in two layers:
      available env vars (always persists across sessions).
   2. File overrides — .claude/mcp_servers.json entries override/extend
      registry defaults.
+
+Lifecycle:
+  startup()  — load config + connect all + register signal handlers
+  shutdown() — graceful close all + unregister signal handlers
 """
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import json
 import logging
 import os
+import signal
 from pathlib import Path
 from typing import Any
 
@@ -46,12 +52,135 @@ def _normalise_mcp_tool(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 class MCPServerManager:
-    """Manages multiple MCP server connections and tool dispatch."""
+    """Manages multiple MCP server connections and tool dispatch.
+
+    Provides lifecycle hooks (startup/shutdown) with signal-handler
+    registration so that MCP subprocess cleanup happens even on
+    SIGTERM/SIGINT, preventing orphan processes.
+    """
 
     def __init__(self, config_path: Path | None = None) -> None:
         self._config_path = config_path or _CONFIG_PATH
         self._servers: dict[str, dict[str, Any]] = {}
         self._clients: dict[str, StdioMCPClient] = {}
+        self._signal_installed = False
+        self._prev_sigterm: Any = None
+        self._prev_sigint: signal.Handlers | None = None
+        self._atexit_registered = False
+        self._shutdown_called = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def startup(self) -> int:
+        """Full lifecycle startup: load config, connect all servers, register signal handlers.
+
+        Returns the number of servers that connected successfully.
+        """
+        self.load_config()
+        connected = self._connect_all()
+        self._install_signal_handlers()
+        log.info("MCP startup complete: %d/%d servers connected", connected, len(self._servers))
+        return connected
+
+    def shutdown(self) -> None:
+        """Full lifecycle shutdown: close all servers, unregister signal handlers.
+
+        Safe to call multiple times (idempotent).
+        """
+        if self._shutdown_called:
+            return
+        self._shutdown_called = True
+        log.info("MCP shutdown initiated")
+        self.close_all()
+        self._uninstall_signal_handlers()
+        log.info("MCP shutdown complete")
+
+    def _connect_all(self) -> int:
+        """Connect to all configured servers. Returns count of successful connections."""
+        connected = 0
+        for server_name in list(self._servers.keys()):
+            client = self._get_client(server_name)
+            if client is not None:
+                connected += 1
+        return connected
+
+    def _install_signal_handlers(self) -> None:
+        """Register SIGTERM/SIGINT handlers for graceful cleanup.
+
+        Chains with existing handlers so other shutdown logic still runs.
+        Also registers an atexit handler as a safety net.
+        """
+        if self._signal_installed:
+            return
+
+        # Only install signal handlers in the main thread
+        try:
+            if not _is_main_thread():
+                log.debug("MCP signal handlers skipped (not main thread)")
+                return
+        except Exception:
+            return
+
+        def _signal_shutdown(signum: int, frame: Any) -> None:
+            """Signal handler that ensures MCP cleanup before exit."""
+            log.info("MCP received signal %d, shutting down servers", signum)
+            self.shutdown()
+            # Chain to previous handler
+            prev = self._prev_sigterm if signum == signal.SIGTERM else self._prev_sigint
+            if prev and callable(prev):
+                prev(signum, frame)
+            elif prev == signal.SIG_DFL:
+                # Re-raise with default handler
+                signal.signal(signum, signal.SIG_DFL)
+                signal.raise_signal(signum)
+
+        try:
+            self._prev_sigterm = signal.getsignal(signal.SIGTERM)
+            signal.signal(signal.SIGTERM, _signal_shutdown)
+            # Note: SIGINT is typically managed by the REPL's own handler.
+            # We save a reference but only install a SIGTERM handler to
+            # avoid interfering with KeyboardInterrupt handling.
+            self._signal_installed = True
+            log.debug("MCP SIGTERM handler installed")
+        except (OSError, ValueError):
+            # Cannot set signal handler (e.g., not main thread, or restricted env)
+            log.debug("MCP signal handler installation failed", exc_info=True)
+
+        # Atexit safety net
+        if not self._atexit_registered:
+            atexit.register(self._atexit_cleanup)
+            self._atexit_registered = True
+
+    def _atexit_cleanup(self) -> None:
+        """Atexit fallback — ensures cleanup even if signals were not caught."""
+        if not self._shutdown_called:
+            log.debug("MCP atexit cleanup triggered")
+            self.close_all()
+
+    def _uninstall_signal_handlers(self) -> None:
+        """Restore previous signal handlers."""
+        if not self._signal_installed:
+            return
+
+        try:
+            if not _is_main_thread():
+                return
+        except Exception:
+            return
+
+        try:
+            if self._prev_sigterm is not None:
+                signal.signal(signal.SIGTERM, self._prev_sigterm)
+            self._signal_installed = False
+            log.debug("MCP signal handlers restored")
+        except (OSError, ValueError):
+            log.debug("MCP signal handler restoration failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
 
     def load_config(self) -> int:
         """Load MCP server configurations from registry + file overrides.
@@ -155,6 +284,10 @@ class MCPServerManager:
         log.debug("MCP server not available (skipped): %s", server_name)
         return None
 
+    # ------------------------------------------------------------------
+    # Tool dispatch
+    # ------------------------------------------------------------------
+
     def get_all_tools(self) -> list[dict[str, Any]]:
         """Gather tool definitions from all configured MCP servers.
 
@@ -197,6 +330,10 @@ class MCPServerManager:
                     return server_name
         return None
 
+    # ------------------------------------------------------------------
+    # Server management
+    # ------------------------------------------------------------------
+
     def list_servers(self) -> list[dict[str, Any]]:
         """List configured servers with their status."""
         result: list[dict[str, Any]] = []
@@ -214,12 +351,29 @@ class MCPServerManager:
             )
         return result
 
-    def check_health(self) -> dict[str, bool]:
-        """Return connection health status for each configured server."""
+    def check_health(self, *, auto_restart: bool = False) -> dict[str, bool]:
+        """Return connection health status for each configured server.
+
+        Args:
+            auto_restart: If True, attempt to reconnect dead servers.
+        """
         result: dict[str, bool] = {}
         for name in self._servers:
             client = self._clients.get(name)
-            result[name] = client.is_connected() if client else False
+            alive = client.is_connected() if client else False
+
+            if not alive and auto_restart:
+                log.info("MCP server '%s' is down, attempting restart", name)
+                # Remove dead client reference
+                self._clients.pop(name, None)
+                new_client = self._get_client(name)
+                alive = new_client is not None and new_client.is_connected()
+                if alive:
+                    log.info("MCP server '%s' restarted successfully", name)
+                else:
+                    log.warning("MCP server '%s' restart failed", name)
+
+            result[name] = alive
         return result
 
     def add_server(
@@ -262,7 +416,15 @@ class MCPServerManager:
 
     def close_all(self) -> None:
         """Close all MCP server connections."""
-        for client in self._clients.values():
+        for name, client in self._clients.items():
             with contextlib.suppress(Exception):
+                log.debug("Closing MCP server '%s' (PID %s)", name, client.pid)
                 client.close()
         self._clients.clear()
+
+
+def _is_main_thread() -> bool:
+    """Check if current thread is the main thread."""
+    import threading
+
+    return threading.current_thread() is threading.main_thread()

--- a/core/infrastructure/adapters/mcp/stdio_client.py
+++ b/core/infrastructure/adapters/mcp/stdio_client.py
@@ -17,6 +17,9 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+# Graceful shutdown timeout before force kill (seconds)
+_CLOSE_TIMEOUT_S = 5
+
 
 class StdioMCPClient:
     """MCP client using stdio transport (subprocess JSON-RPC)."""
@@ -37,6 +40,12 @@ class StdioMCPClient:
         self._connected = False
         self._tools: list[dict[str, Any]] = []
         self._request_id = 0
+        self._pid: int | None = None
+
+    @property
+    def pid(self) -> int | None:
+        """Return the PID of the subprocess, or None if not running."""
+        return self._pid
 
     def is_connected(self) -> bool:
         return self._connected and self._process is not None and self._process.poll() is None
@@ -53,6 +62,12 @@ class StdioMCPClient:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env=env,
+            )
+            self._pid = self._process.pid
+            log.debug(
+                "MCP subprocess spawned: %s (PID %d)",
+                self._command,
+                self._pid,
             )
 
             # Send initialize request
@@ -79,14 +94,16 @@ class StdioMCPClient:
 
             self._connected = True
             log.info(
-                "MCP connected: %s (%d tools)",
+                "MCP connected: %s (PID %d, %d tools)",
                 self._command,
+                self._pid,
                 len(self._tools),
             )
             return True
 
         except (OSError, FileNotFoundError) as exc:
             log.warning("Failed to start MCP server '%s': %s", self._command, exc)
+            self._pid = None
             return False
 
     def list_tools(self) -> list[dict[str, Any]]:
@@ -112,17 +129,33 @@ class StdioMCPClient:
         return dict(result)
 
     def close(self) -> None:
-        """Terminate the MCP server subprocess."""
+        """Terminate the MCP server subprocess.
+
+        Two-phase shutdown: graceful SIGTERM with timeout, then SIGKILL
+        if the process does not exit within ``_CLOSE_TIMEOUT_S`` seconds.
+        """
         self._connected = False
         if self._process is not None:
+            pid = self._pid
             try:
                 self._process.stdin.close()  # type: ignore[union-attr]
                 self._process.terminate()
-                self._process.wait(timeout=5)
+                self._process.wait(timeout=_CLOSE_TIMEOUT_S)
+                log.debug("MCP subprocess terminated gracefully (PID %s)", pid)
+            except subprocess.TimeoutExpired:
+                log.warning(
+                    "MCP subprocess did not exit within %ds, sending SIGKILL (PID %s)",
+                    _CLOSE_TIMEOUT_S,
+                    pid,
+                )
+                with contextlib.suppress(Exception):
+                    self._process.kill()
+                    self._process.wait(timeout=2)
             except Exception:
                 with contextlib.suppress(Exception):
                     self._process.kill()
             self._process = None
+            self._pid = None
 
     def _next_id(self) -> int:
         self._request_id += 1

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -168,6 +168,106 @@ FALLBACK_MODELS = ANTHROPIC_FALLBACK_CHAIN
 
 
 # ---------------------------------------------------------------------------
+# Non-retryable errors — these should NOT trigger model failover
+# ---------------------------------------------------------------------------
+_NON_RETRYABLE_ERRORS = (anthropic.AuthenticationError,)
+
+
+# ---------------------------------------------------------------------------
+# call_with_failover — async model failover for AgenticLoop
+# ---------------------------------------------------------------------------
+
+
+async def call_with_failover(
+    models: list[str],
+    call_fn: Any,
+    *,
+    max_retries: int | None = None,
+    retry_base_delay: float | None = None,
+    retry_max_delay: float | None = None,
+) -> tuple[Any | None, str | None]:
+    """Execute an async LLM call with model failover chain.
+
+    Iterates through the ``models`` list. For each model, retries on
+    retryable errors (rate-limit, timeout, connection, server errors)
+    with exponential backoff. If all retries for a model are exhausted,
+    moves to the next model in the chain.
+
+    Non-retryable errors (e.g. AuthenticationError) cause immediate failure
+    without trying further models.
+
+    Args:
+        models: Ordered list of model names to try.
+        call_fn: Async callable ``(model: str) -> response``.
+        max_retries: Per-model retry count (default: settings.llm_max_retries).
+        retry_base_delay: Base delay in seconds (default: settings.llm_retry_base_delay).
+        retry_max_delay: Max delay cap in seconds (default: settings.llm_retry_max_delay).
+
+    Returns:
+        A tuple of ``(response, model_used)``. On complete failure,
+        returns ``(None, None)``.
+    """
+    import asyncio as _asyncio
+
+    _max_retries = max_retries if max_retries is not None else MAX_RETRIES
+    _base_delay = retry_base_delay if retry_base_delay is not None else RETRY_BASE_DELAY
+    _max_delay = retry_max_delay if retry_max_delay is not None else RETRY_MAX_DELAY
+
+    last_error: Exception | None = None
+
+    for model_idx, current_model in enumerate(models):
+        for attempt in range(_max_retries):
+            try:
+                result = await call_fn(current_model)
+                return result, current_model
+            except _NON_RETRYABLE_ERRORS as exc:
+                # Non-retryable: fail immediately, do not try other models
+                log.warning(
+                    "Non-retryable error on model=%s: %s — aborting failover",
+                    current_model,
+                    type(exc).__name__,
+                )
+                return None, None
+            except _RETRYABLE_ERRORS as exc:
+                last_error = exc
+                wait = min(_base_delay * (2**attempt), _max_delay)
+                log.warning(
+                    "Failover: model=%s attempt=%d/%d error=%s, retrying in %.1fs",
+                    current_model,
+                    attempt + 1,
+                    _max_retries,
+                    type(exc).__name__,
+                    wait,
+                )
+                if attempt < _max_retries - 1:
+                    await _asyncio.sleep(wait)
+            except Exception as exc:
+                # Unexpected error: log and move on to next model
+                last_error = exc
+                log.warning(
+                    "Failover: unexpected error on model=%s: %s",
+                    current_model,
+                    exc,
+                )
+                break  # break retry loop, try next model
+
+        # All retries exhausted for this model
+        if model_idx < len(models) - 1:
+            next_model = models[model_idx + 1]
+            log.warning(
+                "Failover: all retries exhausted for model=%s, falling back to %s",
+                current_model,
+                next_model,
+            )
+
+    log.error(
+        "Failover: all models exhausted. Last error: %s",
+        last_error,
+    )
+    return None, None
+
+
+# ---------------------------------------------------------------------------
 # httpx connection pool — configured for long-lived REPL sessions
 # ---------------------------------------------------------------------------
 

--- a/core/orchestration/hooks.py
+++ b/core/orchestration/hooks.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 class HookEvent(Enum):
-    """Pipeline lifecycle events (30 events)."""
+    """Pipeline lifecycle events (34 events)."""
 
     # Pipeline level
     PIPELINE_START = "pipeline_start"
@@ -70,6 +70,10 @@ class HookEvent(Enum):
     # Gateway (inbound messaging)
     GATEWAY_MESSAGE_RECEIVED = "gateway_message_received"
     GATEWAY_RESPONSE_SENT = "gateway_response_sent"
+
+    # MCP server lifecycle
+    MCP_SERVER_STARTED = "mcp_server_started"
+    MCP_SERVER_STOPPED = "mcp_server_stopped"
 
 
 @dataclass

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -11,11 +11,8 @@
 
 | task_id | 설명 | 우선순위 | plan | 비고 |
 |---------|------|:--------:|------|------|
-| model-failover | Model Failover 자동화 — FALLBACK_CHAIN 자동 전환 | P1 | — | OpenClaw Failover 패턴 |
 | context-overflow | Context Overflow Detection — Token 초과 자동 압축 | P1 | — | Karpathy P6 Context Budget |
-| subagent-announce | Sub-agent Announce — Parent 결과 자동 주입 | P1 | — | OpenClaw Spawn+Announce |
 | policy-6layer | 6-계층 Policy Chain 확대 | P1 | — | OpenClaw Policy Resolution |
-| mcp-lifecycle | MCP Adapter Lifecycle — startup/shutdown hook | P1 | — | orphan 방지 |
 | cost-approval | EXPENSIVE_TOOLS 비용 조회+승인 UI | P1 | — | Claude Code Permission 패턴 |
 | multi-provider | AgenticLoop 멀티 프로바이더 — Anthropic SDK 결합 해제 | P1 | — | P2→P1 승격 (GLM-5 버그 발견). LLMClientPort 추상화 |
 | write-fallback | WRITE_TOOLS 거부 후 fallback 경로 | P2 | — | Claude Code Permission 패턴 |
@@ -53,7 +50,10 @@
 | pr-body-align | PR body 규칙 geode-gitflow 스킬 정렬 | #261→#262 | @mangowhoiscloud | 2026-03-18 |
 | cli-audit | CLI 점검 감사 (코드 레벨) | 리서치 | @mangowhoiscloud | 2026-03-18 |
 | gap-detection | Claude Code/Codex/OpenClaw GAP 탐지 | 리서치 | @mangowhoiscloud | 2026-03-18 |
-| glm5-500-retry | LLM 500 에러 retry 미동작 수정 (LLMInternalServerError) | — | @mangowhoiscloud | 2026-03-18 |
+| glm5-500-retry | LLM 500 에러 retry 미동작 수정 (LLMInternalServerError) | #265→#266 | @mangowhoiscloud | 2026-03-18 |
+| model-failover | Model Failover 자동화 — call_with_failover + FALLBACK_CHAIN | — | @mangowhoiscloud | 2026-03-18 |
+| mcp-lifecycle | MCP Adapter Lifecycle — startup/shutdown + SIGTERM + atexit 이중방어 | — | @mangowhoiscloud | 2026-03-18 |
+| subagent-announce | Sub-agent Announce — drain queue + conversation 주입 | — | @mangowhoiscloud | 2026-03-18 |
 
 ### Blocked
 
@@ -71,11 +71,8 @@
 
 | gap_id | 설명 | 출처 | 관련 task_id |
 |--------|------|------|-------------|
-| gap-failover | Model Failover 자동 전환 | OpenClaw | model-failover |
 | gap-ctx-overflow | Token 초과 자동 압축 | OpenClaw + Karpathy P6 | context-overflow |
-| gap-announce | Sub-agent 결과 자동 주입 | OpenClaw | subagent-announce |
 | gap-policy | 6-계층 Policy Chain | OpenClaw | policy-6layer |
-| gap-mcp-lifecycle | MCP startup/shutdown hook | Claude Code | mcp-lifecycle |
 | gap-cost-approval | EXPENSIVE_TOOLS 비용 조회+승인 UI | Claude Code | cost-approval |
 
 ### P2 (Medium)
@@ -99,6 +96,9 @@
 | gap-hook-discovery | #241 | 2026-03-18 |
 | gap-binding-reload | #241 | 2026-03-18 |
 | gap-nl-router | #243→#244, #255→#256 | 2026-03-18 |
+| gap-failover | — | 2026-03-18 |
+| gap-announce | — | 2026-03-18 |
+| gap-mcp-lifecycle | — | 2026-03-18 |
 
 ---
 
@@ -108,10 +108,10 @@
 |------|-----|--------|
 | Version | 0.19.1 | 2026-03-18 |
 | Modules | 165 | 2026-03-18 |
-| Tests | 2505 | 2026-03-18 |
+| Tests | 2583 | 2026-03-18 |
 | Tools | 46 | 2026-03-18 |
 | MCP Catalog | 42 | 2026-03-18 |
-| HookEvents | 32 | 2026-03-18 |
+| HookEvents | 34 | 2026-03-18 |
 | Skills | 18 | 2026-03-18 |
 
 ---

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -298,8 +298,8 @@ class TestApplyContext:
 
 class TestHookEventCount:
     def test_events_exist(self) -> None:
-        """HookEvent has 32 events (27 base + 3 TOOL_RECOVERY_* + 2 GATEWAY_*)."""
-        assert len(HookEvent) == 32
+        """HookEvent has 34 events (27 base + 3 TOOL_RECOVERY_* + 2 GATEWAY_* + 2 MCP_SERVER_*)."""
+        assert len(HookEvent) == 34
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -410,8 +410,8 @@ class TestRecoveryHookEvents:
         assert received[0]["tool_name"] == "list_ips"
 
     def test_total_hook_event_count(self) -> None:
-        """Verify total hook event count is 32 (27 + 3 recovery + 2 gateway)."""
-        assert len(HookEvent) == 32
+        """Verify total hook event count is 34 (27 + 3 recovery + 2 gateway + 2 mcp)."""
+        assert len(HookEvent) == 34
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from core.orchestration.hooks import HookEvent, HookResult, HookSystem
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 32
+        assert len(HookEvent) == 34
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,8 +356,8 @@ class TestHookEventTypes:
         assert HookEvent.PROMPT_DRIFT_DETECTED.value == "prompt_drift_detected"
 
     def test_hook_event_count(self):
-        """Total hook events should be 32 (27 + 3 TOOL_RECOVERY_* + 2 GATEWAY_*)."""
-        assert len(HookEvent) == 32
+        """Total hook events should be 34 (27 + 3 TOOL_RECOVERY_* + 2 GATEWAY_* + 2 MCP_SERVER_*)."""
+        assert len(HookEvent) == 34
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -1,0 +1,388 @@
+"""Tests for MCP adapter lifecycle (startup/shutdown hooks, orphan prevention).
+
+Covers:
+- MCPServerManager startup/shutdown lifecycle
+- Signal handler registration/unregistration
+- StdioMCPClient PID tracking and close timeout
+- Health check with auto-restart
+- HookEvent MCP_SERVER_STARTED / MCP_SERVER_STOPPED existence
+- Idempotent shutdown
+- Atexit safety net registration
+"""
+
+from __future__ import annotations
+
+import signal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from core.infrastructure.adapters.mcp.manager import MCPServerManager
+from core.infrastructure.adapters.mcp.stdio_client import _CLOSE_TIMEOUT_S, StdioMCPClient
+from core.orchestration.hooks import HookEvent
+
+# ---------------------------------------------------------------------------
+# HookEvent tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCPHookEvents:
+    """Verify MCP lifecycle hook events exist."""
+
+    def test_mcp_server_started_event(self) -> None:
+        assert hasattr(HookEvent, "MCP_SERVER_STARTED")
+        assert HookEvent.MCP_SERVER_STARTED.value == "mcp_server_started"
+
+    def test_mcp_server_stopped_event(self) -> None:
+        assert hasattr(HookEvent, "MCP_SERVER_STOPPED")
+        assert HookEvent.MCP_SERVER_STOPPED.value == "mcp_server_stopped"
+
+    def test_hook_event_count_includes_mcp(self) -> None:
+        """Total hook events should be 34 (includes 2 MCP_SERVER_* events)."""
+        assert len(HookEvent) == 34
+
+
+# ---------------------------------------------------------------------------
+# StdioMCPClient tests
+# ---------------------------------------------------------------------------
+
+
+class TestStdioMCPClientLifecycle:
+    """Test StdioMCPClient PID tracking and close behavior."""
+
+    def test_pid_initially_none(self) -> None:
+        client = StdioMCPClient(command="echo", args=["hello"])
+        assert client.pid is None
+
+    def test_pid_set_after_connect(self) -> None:
+        """PID should be set after subprocess is spawned (mocked)."""
+        client = StdioMCPClient(command="echo", args=["hello"])
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stderr = MagicMock()
+
+        # Mock the initialize response
+        init_resp = b'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}\n'
+        tools_resp = b'{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}\n'
+        mock_proc.stdout.readline.side_effect = [init_resp, tools_resp]
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = client.connect()
+
+        assert result is True
+        assert client.pid == 12345
+
+    def test_pid_cleared_after_close(self) -> None:
+        """PID should be None after close."""
+        client = StdioMCPClient(command="echo")
+        client._process = MagicMock()
+        client._process.pid = 99
+        client._pid = 99
+        client._connected = True
+
+        client.close()
+
+        assert client.pid is None
+        assert client._process is None
+
+    def test_close_graceful_then_kill(self) -> None:
+        """Close should try terminate first, then kill on timeout."""
+        import subprocess
+
+        client = StdioMCPClient(command="echo")
+        mock_proc = MagicMock()
+        mock_proc.pid = 42
+        mock_proc.stdin = MagicMock()
+        mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="echo", timeout=5)
+        client._process = mock_proc
+        client._pid = 42
+        client._connected = True
+
+        client.close()
+
+        mock_proc.terminate.assert_called_once()
+        mock_proc.kill.assert_called_once()
+        assert client._process is None
+        assert client.pid is None
+
+    def test_close_timeout_constant(self) -> None:
+        """Verify the close timeout constant is 5 seconds."""
+        assert _CLOSE_TIMEOUT_S == 5
+
+
+# ---------------------------------------------------------------------------
+# MCPServerManager lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCPManagerStartup:
+    """Test MCPServerManager.startup() lifecycle."""
+
+    def test_startup_calls_load_config_and_connect(self) -> None:
+        mgr = MCPServerManager()
+
+        with (
+            patch.object(mgr, "load_config", return_value=2) as mock_load,
+            patch.object(mgr, "_connect_all", return_value=2) as mock_connect,
+            patch.object(mgr, "_install_signal_handlers") as mock_signals,
+        ):
+            result = mgr.startup()
+
+        mock_load.assert_called_once()
+        mock_connect.assert_called_once()
+        mock_signals.assert_called_once()
+        assert result == 2
+
+    def test_startup_returns_connected_count(self) -> None:
+        mgr = MCPServerManager()
+
+        with (
+            patch.object(mgr, "load_config", return_value=3),
+            patch.object(mgr, "_connect_all", return_value=1),
+            patch.object(mgr, "_install_signal_handlers"),
+        ):
+            result = mgr.startup()
+
+        assert result == 1
+
+
+class TestMCPManagerShutdown:
+    """Test MCPServerManager.shutdown() lifecycle."""
+
+    def test_shutdown_calls_close_all_and_uninstall(self) -> None:
+        mgr = MCPServerManager()
+
+        with (
+            patch.object(mgr, "close_all") as mock_close,
+            patch.object(mgr, "_uninstall_signal_handlers") as mock_unsig,
+        ):
+            mgr.shutdown()
+
+        mock_close.assert_called_once()
+        mock_unsig.assert_called_once()
+
+    def test_shutdown_idempotent(self) -> None:
+        """Calling shutdown() multiple times should only close once."""
+        mgr = MCPServerManager()
+        call_count = 0
+
+        def counting_close() -> None:
+            nonlocal call_count
+            call_count += 1
+
+        with (
+            patch.object(mgr, "close_all", side_effect=counting_close),
+            patch.object(mgr, "_uninstall_signal_handlers"),
+        ):
+            mgr.shutdown()
+            mgr.shutdown()
+            mgr.shutdown()
+
+        assert call_count == 1
+
+    def test_shutdown_sets_flag(self) -> None:
+        mgr = MCPServerManager()
+        assert mgr._shutdown_called is False
+
+        with (
+            patch.object(mgr, "close_all"),
+            patch.object(mgr, "_uninstall_signal_handlers"),
+        ):
+            mgr.shutdown()
+
+        assert mgr._shutdown_called is True
+
+
+class TestMCPManagerSignalHandlers:
+    """Test signal handler installation/uninstallation."""
+
+    def test_signal_handler_installation(self) -> None:
+        """Signal handler should be installed in main thread."""
+        mgr = MCPServerManager()
+
+        with (
+            patch("core.infrastructure.adapters.mcp.manager._is_main_thread", return_value=True),
+            patch("signal.getsignal", return_value=signal.SIG_DFL),
+            patch("signal.signal") as mock_signal,
+            patch("atexit.register") as mock_atexit,
+        ):
+            mgr._install_signal_handlers()
+
+        assert mgr._signal_installed is True
+        # SIGTERM handler should be installed
+        mock_signal.assert_called()
+        # atexit should be registered
+        mock_atexit.assert_called_once()
+
+    def test_signal_handler_not_installed_in_non_main_thread(self) -> None:
+        mgr = MCPServerManager()
+
+        with patch("core.infrastructure.adapters.mcp.manager._is_main_thread", return_value=False):
+            mgr._install_signal_handlers()
+
+        assert mgr._signal_installed is False
+
+    def test_signal_handler_idempotent(self) -> None:
+        """Installing twice should not double-register."""
+        mgr = MCPServerManager()
+        mgr._signal_installed = True
+
+        with patch("signal.signal") as mock_signal:
+            mgr._install_signal_handlers()
+
+        mock_signal.assert_not_called()
+
+    def test_uninstall_signal_handlers(self) -> None:
+        mgr = MCPServerManager()
+        mgr._signal_installed = True
+        mgr._prev_sigterm = signal.SIG_DFL
+
+        with (
+            patch("core.infrastructure.adapters.mcp.manager._is_main_thread", return_value=True),
+            patch("signal.signal") as mock_signal,
+        ):
+            mgr._uninstall_signal_handlers()
+
+        assert mgr._signal_installed is False
+        mock_signal.assert_called_once_with(signal.SIGTERM, signal.SIG_DFL)
+
+
+class TestMCPManagerAtexitCleanup:
+    """Test atexit safety net."""
+
+    def test_atexit_cleanup_calls_close_all_if_not_shutdown(self) -> None:
+        mgr = MCPServerManager()
+        mgr._shutdown_called = False
+
+        with patch.object(mgr, "close_all") as mock_close:
+            mgr._atexit_cleanup()
+
+        mock_close.assert_called_once()
+
+    def test_atexit_cleanup_skips_if_already_shutdown(self) -> None:
+        mgr = MCPServerManager()
+        mgr._shutdown_called = True
+
+        with patch.object(mgr, "close_all") as mock_close:
+            mgr._atexit_cleanup()
+
+        mock_close.assert_not_called()
+
+
+class TestMCPManagerHealthCheck:
+    """Test health_check with auto_restart."""
+
+    def test_health_check_basic(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers = {"server-a": {"command": "echo"}, "server-b": {"command": "cat"}}
+
+        client_a = MagicMock()
+        client_a.is_connected.return_value = True
+        client_b = MagicMock()
+        client_b.is_connected.return_value = False
+
+        mgr._clients = {"server-a": client_a, "server-b": client_b}
+
+        result = mgr.check_health()
+        assert result == {"server-a": True, "server-b": False}
+
+    def test_health_check_auto_restart(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers = {"dead-server": {"command": "echo"}}
+
+        dead_client = MagicMock()
+        dead_client.is_connected.return_value = False
+        mgr._clients = {"dead-server": dead_client}
+
+        # Mock _get_client to simulate successful restart
+        new_client = MagicMock()
+        new_client.is_connected.return_value = True
+
+        with patch.object(mgr, "_get_client", return_value=new_client):
+            result = mgr.check_health(auto_restart=True)
+
+        assert result == {"dead-server": True}
+
+    def test_health_check_auto_restart_failure(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers = {"dead-server": {"command": "echo"}}
+
+        dead_client = MagicMock()
+        dead_client.is_connected.return_value = False
+        mgr._clients = {"dead-server": dead_client}
+
+        with patch.object(mgr, "_get_client", return_value=None):
+            result = mgr.check_health(auto_restart=True)
+
+        assert result == {"dead-server": False}
+
+    def test_health_check_no_auto_restart_by_default(self) -> None:
+        """Without auto_restart, dead servers stay dead."""
+        mgr = MCPServerManager()
+        mgr._servers = {"dead-server": {"command": "echo"}}
+
+        dead_client = MagicMock()
+        dead_client.is_connected.return_value = False
+        mgr._clients = {"dead-server": dead_client}
+
+        with patch.object(mgr, "_get_client") as mock_get:
+            result = mgr.check_health()
+
+        # _get_client should NOT be called when auto_restart is False
+        mock_get.assert_not_called()
+        assert result == {"dead-server": False}
+
+
+class TestMCPManagerCloseAll:
+    """Test close_all with PID logging."""
+
+    def test_close_all_closes_every_client(self) -> None:
+        mgr = MCPServerManager()
+        client_a = MagicMock()
+        client_a.pid = 100
+        client_b = MagicMock()
+        client_b.pid = 200
+
+        mgr._clients = {"a": client_a, "b": client_b}
+
+        mgr.close_all()
+
+        client_a.close.assert_called_once()
+        client_b.close.assert_called_once()
+        assert len(mgr._clients) == 0
+
+    def test_close_all_tolerates_exceptions(self) -> None:
+        mgr = MCPServerManager()
+        client = MagicMock()
+        client.pid = 300
+        client.close.side_effect = RuntimeError("boom")
+        mgr._clients = {"failing": client}
+
+        # Should not raise
+        mgr.close_all()
+        assert len(mgr._clients) == 0
+
+
+class TestMCPManagerConnectAll:
+    """Test _connect_all helper."""
+
+    def test_connect_all_counts_successes(self) -> None:
+        mgr = MCPServerManager()
+        mgr._servers = {"s1": {}, "s2": {}, "s3": {}}
+
+        call_count = 0
+
+        def mock_get_client(name: str) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if name == "s2":
+                return None  # failed to connect
+            return MagicMock()
+
+        with patch.object(mgr, "_get_client", side_effect=mock_get_client):
+            result = mgr._connect_all()
+
+        assert result == 2
+        assert call_count == 3

--- a/tests/test_model_failover.py
+++ b/tests/test_model_failover.py
@@ -1,0 +1,443 @@
+"""Tests for model failover — call_with_failover and AgenticLoop integration.
+
+Covers:
+- Primary success (no failover needed)
+- Primary failure -> Secondary success
+- Full chain exhaustion -> None
+- AuthenticationError -> immediate failure (no failover)
+- Non-retryable errors abort the chain
+- Model switch logging
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import anthropic
+from core.config import ANTHROPIC_FALLBACK_CHAIN, ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY, settings
+from core.llm.client import call_with_failover
+
+# ---------------------------------------------------------------------------
+# Helper: construct retryable/non-retryable errors
+# ---------------------------------------------------------------------------
+
+
+def _make_rate_limit_error() -> anthropic.RateLimitError:
+    err = anthropic.RateLimitError.__new__(anthropic.RateLimitError)
+    err.status_code = 429
+    err.message = "rate limited"
+    return err
+
+
+def _make_connection_error() -> anthropic.APIConnectionError:
+    err = anthropic.APIConnectionError.__new__(anthropic.APIConnectionError)
+    err.message = "connection failed"
+    return err
+
+
+def _make_internal_server_error() -> anthropic.InternalServerError:
+    err = anthropic.InternalServerError.__new__(anthropic.InternalServerError)
+    err.status_code = 500
+    err.message = "internal server error"
+    return err
+
+
+def _make_auth_error() -> anthropic.AuthenticationError:
+    err = anthropic.AuthenticationError.__new__(anthropic.AuthenticationError)
+    err.status_code = 401
+    err.message = "invalid api key"
+    return err
+
+
+def _make_timeout_error() -> anthropic.APITimeoutError:
+    err = anthropic.APITimeoutError.__new__(anthropic.APITimeoutError)
+    return err
+
+
+# ---------------------------------------------------------------------------
+# call_with_failover — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallWithFailover:
+    """Tests for the call_with_failover async function."""
+
+    def test_success_on_first_model(self) -> None:
+        """Primary model succeeds on first try — no failover."""
+        mock_response = MagicMock()
+
+        async def call_fn(model: str) -> MagicMock:
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=3,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_PRIMARY
+
+    def test_failover_primary_to_secondary(self) -> None:
+        """Primary fails all retries, secondary succeeds."""
+        mock_response = MagicMock()
+        rate_err = _make_rate_limit_error()
+        call_count = {"n": 0}
+
+        async def call_fn(model: str) -> MagicMock:
+            call_count["n"] += 1
+            if model == ANTHROPIC_PRIMARY:
+                raise rate_err
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=2,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_SECONDARY
+        # Primary tried max_retries times + 1 for secondary
+        assert call_count["n"] == 3
+
+    def test_all_models_exhausted_returns_none(self) -> None:
+        """All models fail — returns (None, None)."""
+        rate_err = _make_rate_limit_error()
+
+        async def call_fn(model: str) -> None:
+            raise rate_err
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=2,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is None
+        assert used_model is None
+
+    def test_auth_error_aborts_immediately(self) -> None:
+        """AuthenticationError should NOT trigger failover — immediate abort."""
+        auth_err = _make_auth_error()
+        call_count = {"n": 0}
+
+        async def call_fn(model: str) -> None:
+            call_count["n"] += 1
+            raise auth_err
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=3,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is None
+        assert used_model is None
+        # Only called once — no retry, no failover
+        assert call_count["n"] == 1
+
+    def test_connection_error_triggers_failover(self) -> None:
+        """APIConnectionError is retryable and should trigger failover."""
+        conn_err = _make_connection_error()
+        mock_response = MagicMock()
+        call_count = {"n": 0}
+
+        async def call_fn(model: str) -> MagicMock:
+            call_count["n"] += 1
+            if model == ANTHROPIC_PRIMARY:
+                raise conn_err
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=1,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_SECONDARY
+
+    def test_internal_server_error_triggers_failover(self) -> None:
+        """InternalServerError (500) is retryable and should trigger failover."""
+        server_err = _make_internal_server_error()
+        mock_response = MagicMock()
+
+        async def call_fn(model: str) -> MagicMock:
+            if model == ANTHROPIC_PRIMARY:
+                raise server_err
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=1,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_SECONDARY
+
+    def test_timeout_error_triggers_failover(self) -> None:
+        """APITimeoutError is retryable and should trigger failover."""
+        timeout_err = _make_timeout_error()
+        mock_response = MagicMock()
+
+        async def call_fn(model: str) -> MagicMock:
+            if model == ANTHROPIC_PRIMARY:
+                raise timeout_err
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=1,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_SECONDARY
+
+    def test_retry_succeeds_within_same_model(self) -> None:
+        """Transient error on attempt 1, success on attempt 2 — same model."""
+        rate_err = _make_rate_limit_error()
+        mock_response = MagicMock()
+        attempts = {"n": 0}
+
+        async def call_fn(model: str) -> MagicMock:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise rate_err
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=3,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_PRIMARY
+        assert attempts["n"] == 2
+
+    def test_single_model_chain(self) -> None:
+        """Single model in chain — retries then fails gracefully."""
+        rate_err = _make_rate_limit_error()
+
+        async def call_fn(model: str) -> None:
+            raise rate_err
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY],
+                call_fn,
+                max_retries=2,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is None
+        assert used_model is None
+
+    def test_empty_model_chain(self) -> None:
+        """Empty model list — returns (None, None) immediately."""
+
+        async def call_fn(model: str) -> MagicMock:
+            return MagicMock()
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [],
+                call_fn,
+                max_retries=2,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is None
+        assert used_model is None
+
+    def test_three_model_chain(self) -> None:
+        """Three models: first two fail, third succeeds."""
+        rate_err = _make_rate_limit_error()
+        mock_response = MagicMock()
+
+        async def call_fn(model: str) -> MagicMock:
+            if model in ("model-a", "model-b"):
+                raise rate_err
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                ["model-a", "model-b", "model-c"],
+                call_fn,
+                max_retries=1,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == "model-c"
+
+    def test_unexpected_error_skips_to_next_model(self) -> None:
+        """Non-retryable, non-auth error (e.g. ValueError) skips to next model."""
+        mock_response = MagicMock()
+
+        async def call_fn(model: str) -> MagicMock:
+            if model == ANTHROPIC_PRIMARY:
+                raise ValueError("unexpected schema error")
+            return mock_response
+
+        response, used_model = asyncio.run(
+            call_with_failover(
+                [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY],
+                call_fn,
+                max_retries=2,
+                retry_base_delay=0.0,
+            )
+        )
+        assert response is mock_response
+        assert used_model == ANTHROPIC_SECONDARY
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain configuration
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackChainConfig:
+    """Verify that fallback chain constants are properly defined."""
+
+    def test_anthropic_chain_has_primary(self) -> None:
+        assert ANTHROPIC_PRIMARY in ANTHROPIC_FALLBACK_CHAIN
+
+    def test_anthropic_chain_has_secondary(self) -> None:
+        assert ANTHROPIC_SECONDARY in ANTHROPIC_FALLBACK_CHAIN
+
+    def test_anthropic_chain_primary_is_first(self) -> None:
+        assert ANTHROPIC_FALLBACK_CHAIN[0] == ANTHROPIC_PRIMARY
+
+    def test_anthropic_chain_minimum_length(self) -> None:
+        assert len(ANTHROPIC_FALLBACK_CHAIN) >= 2
+
+
+# ---------------------------------------------------------------------------
+# AgenticLoop._call_llm integration (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestAgenticLoopFailover:
+    """Verify AgenticLoop._call_llm uses call_with_failover."""
+
+    def _make_loop(self, model: str | None = None) -> Any:
+        """Create a minimal AgenticLoop instance for testing."""
+        from core.cli.agentic_loop import AgenticLoop
+        from core.cli.conversation import ConversationContext
+        from core.cli.tool_executor import ToolExecutor
+
+        context = ConversationContext()
+        executor = MagicMock(spec=ToolExecutor)
+        return AgenticLoop(
+            context=context,
+            tool_executor=executor,
+            model=model or ANTHROPIC_PRIMARY,
+            max_rounds=5,
+        )
+
+    @patch("core.cli.agentic_loop.call_with_failover")
+    @patch("core.cli.agentic_loop.get_async_anthropic_client")
+    def test_call_llm_uses_failover(
+        self, mock_get_client: MagicMock, mock_failover: MagicMock
+    ) -> None:
+        """_call_llm should delegate to call_with_failover."""
+        mock_response = MagicMock()
+        mock_failover.return_value = (mock_response, ANTHROPIC_PRIMARY)
+        mock_get_client.return_value = MagicMock()
+
+        loop = self._make_loop()
+
+        result = asyncio.run(
+            loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
+        )
+        assert result is mock_response
+        mock_failover.assert_called_once()
+
+    @patch("core.cli.agentic_loop.call_with_failover")
+    @patch("core.cli.agentic_loop.get_async_anthropic_client")
+    def test_call_llm_returns_none_on_chain_exhaustion(
+        self, mock_get_client: MagicMock, mock_failover: MagicMock
+    ) -> None:
+        """When call_with_failover returns (None, None), _call_llm returns None."""
+        mock_failover.return_value = (None, None)
+        mock_get_client.return_value = MagicMock()
+
+        loop = self._make_loop()
+
+        result = asyncio.run(
+            loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
+        )
+        assert result is None
+        assert loop._last_llm_error is not None
+
+    @patch("core.cli.agentic_loop.call_with_failover")
+    @patch("core.cli.agentic_loop.get_async_anthropic_client")
+    def test_call_llm_logs_model_switch(
+        self, mock_get_client: MagicMock, mock_failover: MagicMock
+    ) -> None:
+        """When failover switches model, it should be logged."""
+        mock_response = MagicMock()
+        mock_failover.return_value = (mock_response, ANTHROPIC_SECONDARY)
+        mock_get_client.return_value = MagicMock()
+
+        loop = self._make_loop(model=ANTHROPIC_PRIMARY)
+
+        with patch("core.cli.agentic_loop.log") as mock_log:
+            result = asyncio.run(
+                loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
+            )
+            assert result is mock_response
+            # Verify warning log about model switch
+            mock_log.warning.assert_called()
+            warning_args = mock_log.warning.call_args_list
+            found_switch_log = any("Model failover" in str(args) for args in warning_args)
+            assert found_switch_log, "Expected 'Model failover' warning log"
+
+    def test_call_llm_no_api_key_returns_none(self) -> None:
+        """When no API key is set, _call_llm returns None immediately."""
+        loop = self._make_loop()
+
+        with patch.object(settings, "anthropic_api_key", ""):
+            result = asyncio.run(loop._call_llm("system", [{"role": "user", "content": "hi"}]))
+        assert result is None
+
+    @patch("core.cli.agentic_loop.call_with_failover")
+    @patch("core.cli.agentic_loop.get_async_anthropic_client")
+    def test_failover_chain_includes_current_model_first(
+        self, mock_get_client: MagicMock, mock_failover: MagicMock
+    ) -> None:
+        """The failover chain passed to call_with_failover starts with self.model."""
+        mock_failover.return_value = (MagicMock(), ANTHROPIC_PRIMARY)
+        mock_get_client.return_value = MagicMock()
+
+        loop = self._make_loop(model=ANTHROPIC_PRIMARY)
+        asyncio.run(loop._call_llm("system prompt", [{"role": "user", "content": "hello"}]))
+
+        # Extract the models argument from the call
+        call_args = mock_failover.call_args
+        models = call_args[0][0]  # first positional arg
+        assert models[0] == ANTHROPIC_PRIMARY
+        # No duplicates
+        assert len(models) == len(set(models))

--- a/tests/test_model_failover.py
+++ b/tests/test_model_failover.py
@@ -357,12 +357,17 @@ class TestAgenticLoopFailover:
             max_rounds=5,
         )
 
+    @patch("core.cli.agentic_loop.settings")
     @patch("core.cli.agentic_loop.call_with_failover")
     @patch("core.cli.agentic_loop.get_async_anthropic_client")
     def test_call_llm_uses_failover(
-        self, mock_get_client: MagicMock, mock_failover: MagicMock
+        self, mock_get_client: MagicMock, mock_failover: MagicMock, mock_settings: MagicMock
     ) -> None:
         """_call_llm should delegate to call_with_failover."""
+        mock_settings.anthropic_api_key = "test-key"
+        mock_settings.llm_max_retries = 3
+        mock_settings.llm_retry_base_delay = 0.01
+        mock_settings.llm_retry_max_delay = 0.1
         mock_response = MagicMock()
         mock_failover.return_value = (mock_response, ANTHROPIC_PRIMARY)
         mock_get_client.return_value = MagicMock()
@@ -375,12 +380,17 @@ class TestAgenticLoopFailover:
         assert result is mock_response
         mock_failover.assert_called_once()
 
+    @patch("core.cli.agentic_loop.settings")
     @patch("core.cli.agentic_loop.call_with_failover")
     @patch("core.cli.agentic_loop.get_async_anthropic_client")
     def test_call_llm_returns_none_on_chain_exhaustion(
-        self, mock_get_client: MagicMock, mock_failover: MagicMock
+        self, mock_get_client: MagicMock, mock_failover: MagicMock, mock_settings: MagicMock
     ) -> None:
         """When call_with_failover returns (None, None), _call_llm returns None."""
+        mock_settings.anthropic_api_key = "test-key"
+        mock_settings.llm_max_retries = 3
+        mock_settings.llm_retry_base_delay = 0.01
+        mock_settings.llm_retry_max_delay = 0.1
         mock_failover.return_value = (None, None)
         mock_get_client.return_value = MagicMock()
 
@@ -392,12 +402,17 @@ class TestAgenticLoopFailover:
         assert result is None
         assert loop._last_llm_error is not None
 
+    @patch("core.cli.agentic_loop.settings")
     @patch("core.cli.agentic_loop.call_with_failover")
     @patch("core.cli.agentic_loop.get_async_anthropic_client")
     def test_call_llm_logs_model_switch(
-        self, mock_get_client: MagicMock, mock_failover: MagicMock
+        self, mock_get_client: MagicMock, mock_failover: MagicMock, mock_settings: MagicMock
     ) -> None:
         """When failover switches model, it should be logged."""
+        mock_settings.anthropic_api_key = "test-key"
+        mock_settings.llm_max_retries = 3
+        mock_settings.llm_retry_base_delay = 0.01
+        mock_settings.llm_retry_max_delay = 0.1
         mock_response = MagicMock()
         mock_failover.return_value = (mock_response, ANTHROPIC_SECONDARY)
         mock_get_client.return_value = MagicMock()
@@ -409,7 +424,6 @@ class TestAgenticLoopFailover:
                 loop._call_llm("system prompt", [{"role": "user", "content": "hello"}])
             )
             assert result is mock_response
-            # Verify warning log about model switch
             mock_log.warning.assert_called()
             warning_args = mock_log.warning.call_args_list
             found_switch_log = any("Model failover" in str(args) for args in warning_args)
@@ -423,12 +437,17 @@ class TestAgenticLoopFailover:
             result = asyncio.run(loop._call_llm("system", [{"role": "user", "content": "hi"}]))
         assert result is None
 
+    @patch("core.cli.agentic_loop.settings")
     @patch("core.cli.agentic_loop.call_with_failover")
     @patch("core.cli.agentic_loop.get_async_anthropic_client")
     def test_failover_chain_includes_current_model_first(
-        self, mock_get_client: MagicMock, mock_failover: MagicMock
+        self, mock_get_client: MagicMock, mock_failover: MagicMock, mock_settings: MagicMock
     ) -> None:
         """The failover chain passed to call_with_failover starts with self.model."""
+        mock_settings.anthropic_api_key = "test-key"
+        mock_settings.llm_max_retries = 3
+        mock_settings.llm_retry_base_delay = 0.01
+        mock_settings.llm_retry_max_delay = 0.1
         mock_failover.return_value = (MagicMock(), ANTHROPIC_PRIMARY)
         mock_get_client.return_value = MagicMock()
 

--- a/tests/test_subagent_announce.py
+++ b/tests/test_subagent_announce.py
@@ -1,0 +1,538 @@
+"""Tests for Sub-agent Announce mechanism (OpenClaw Spawn+Announce pattern).
+
+Validates that:
+1. SubAgentResult gains an `announced` field (default False).
+2. SubAgentManager._announce_result() pushes results to the announce queue.
+3. drain_announced_results() retrieves and clears pending results.
+4. AgenticLoop._check_announced_results() injects announcements into conversation.
+5. ConversationContext.add_system_event() adds structured system messages.
+6. SUBAGENT_COMPLETED hook data includes the result summary.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from core.cli.agentic_loop import AgenticLoop
+from core.cli.conversation import ConversationContext
+from core.cli.sub_agent import (
+    SubAgentManager,
+    SubAgentResult,
+    SubTask,
+    _announce_lock,
+    _announce_queue,
+    drain_announced_results,
+)
+from core.cli.tool_executor import ToolExecutor
+from core.orchestration.hooks import HookEvent, HookSystem
+from core.orchestration.isolated_execution import IsolatedRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_announce_queue() -> Any:
+    """Ensure announce queue is empty before and after each test."""
+    with _announce_lock:
+        _announce_queue.clear()
+    yield
+    with _announce_lock:
+        _announce_queue.clear()
+
+
+@pytest.fixture
+def parent_key() -> str:
+    return "ip:berserk:pipeline:parent"
+
+
+@pytest.fixture
+def hooks() -> HookSystem:
+    return HookSystem()
+
+
+@pytest.fixture
+def runner() -> IsolatedRunner:
+    return IsolatedRunner()
+
+
+# ---------------------------------------------------------------------------
+# SubAgentResult.announced field
+# ---------------------------------------------------------------------------
+
+
+class TestSubAgentResultAnnounced:
+    """SubAgentResult has an `announced` field with default False."""
+
+    def test_default_announced_false(self) -> None:
+        result = SubAgentResult(task_id="t1", task_type="analyze")
+        assert result.announced is False
+
+    def test_announced_explicit_true(self) -> None:
+        result = SubAgentResult(task_id="t1", task_type="analyze", announced=True)
+        assert result.announced is True
+
+    def test_announced_in_to_dict(self) -> None:
+        result = SubAgentResult(task_id="t1", task_type="analyze", announced=True)
+        d = result.to_dict()
+        assert d["announced"] is True
+
+    def test_announced_false_in_to_dict(self) -> None:
+        """announced=False is a falsy value but still present (it's not None)."""
+        result = SubAgentResult(task_id="t1", task_type="analyze", announced=False)
+        d = result.to_dict()
+        # to_dict omits None-valued fields but False is not None
+        assert "announced" in d
+
+    def test_backward_compat_existing_fields(self) -> None:
+        """Existing fields remain intact after adding `announced`."""
+        result = SubAgentResult(
+            task_id="t1",
+            task_type="search",
+            status="ok",
+            summary="found 3 results",
+            data={"count": 3},
+            duration_ms=150.0,
+        )
+        assert result.task_id == "t1"
+        assert result.task_type == "search"
+        assert result.status == "ok"
+        assert result.summary == "found 3 results"
+        assert result.data == {"count": 3}
+        assert result.duration_ms == 150.0
+        assert result.announced is False
+
+
+# ---------------------------------------------------------------------------
+# Announce queue module-level functions
+# ---------------------------------------------------------------------------
+
+
+class TestAnnounceQueue:
+    """Tests for the module-level announce queue and drain_announced_results."""
+
+    def test_drain_empty_queue(self, parent_key: str) -> None:
+        results = drain_announced_results(parent_key)
+        assert results == []
+
+    def test_drain_returns_results(self, parent_key: str) -> None:
+        r1 = SubAgentResult(task_id="t1", task_type="analyze", summary="done")
+        r2 = SubAgentResult(task_id="t2", task_type="search", summary="found")
+        with _announce_lock:
+            _announce_queue[parent_key] = [r1, r2]
+
+        results = drain_announced_results(parent_key)
+        assert len(results) == 2
+        assert results[0].task_id == "t1"
+        assert results[1].task_id == "t2"
+
+    def test_drain_clears_queue(self, parent_key: str) -> None:
+        r1 = SubAgentResult(task_id="t1", task_type="analyze", summary="done")
+        with _announce_lock:
+            _announce_queue[parent_key] = [r1]
+
+        drain_announced_results(parent_key)
+        # Second drain returns empty
+        assert drain_announced_results(parent_key) == []
+
+    def test_drain_isolates_sessions(self) -> None:
+        """Different parent keys have independent queues."""
+        r1 = SubAgentResult(task_id="t1", task_type="analyze", summary="a")
+        r2 = SubAgentResult(task_id="t2", task_type="search", summary="b")
+        with _announce_lock:
+            _announce_queue["parent_a"] = [r1]
+            _announce_queue["parent_b"] = [r2]
+
+        results_a = drain_announced_results("parent_a")
+        results_b = drain_announced_results("parent_b")
+        assert len(results_a) == 1
+        assert results_a[0].task_id == "t1"
+        assert len(results_b) == 1
+        assert results_b[0].task_id == "t2"
+
+    def test_drain_thread_safety(self, parent_key: str) -> None:
+        """Concurrent drains from multiple threads don't lose results."""
+        n = 50
+        results_to_add = [
+            SubAgentResult(task_id=f"t{i}", task_type="analyze", summary=f"s{i}") for i in range(n)
+        ]
+        with _announce_lock:
+            _announce_queue[parent_key] = list(results_to_add)
+
+        collected: list[SubAgentResult] = []
+        lock = threading.Lock()
+
+        def drain() -> None:
+            drained = drain_announced_results(parent_key)
+            with lock:
+                collected.extend(drained)
+
+        threads = [threading.Thread(target=drain) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All results should be drained exactly once across all threads
+        assert len(collected) == n
+
+
+# ---------------------------------------------------------------------------
+# SubAgentManager._announce_result
+# ---------------------------------------------------------------------------
+
+
+class TestSubAgentManagerAnnounce:
+    """Tests for SubAgentManager._announce_result()."""
+
+    def test_announce_pushes_to_queue(self, parent_key: str, runner: IsolatedRunner) -> None:
+        mgr = SubAgentManager(runner, parent_session_key=parent_key)
+        result = SubAgentResult(task_id="t1", task_type="analyze", summary="done")
+
+        mgr._announce_result(parent_key, result)
+
+        queued = drain_announced_results(parent_key)
+        assert len(queued) == 1
+        assert queued[0].task_id == "t1"
+        assert queued[0].announced is True
+
+    def test_announce_marks_announced(self, parent_key: str, runner: IsolatedRunner) -> None:
+        mgr = SubAgentManager(runner, parent_session_key=parent_key)
+        result = SubAgentResult(task_id="t1", task_type="analyze", summary="done")
+        assert result.announced is False
+
+        mgr._announce_result(parent_key, result)
+        assert result.announced is True
+
+    def test_double_announce_prevented(self, parent_key: str, runner: IsolatedRunner) -> None:
+        """Calling _announce_result twice only enqueues once."""
+        mgr = SubAgentManager(runner, parent_session_key=parent_key)
+        result = SubAgentResult(task_id="t1", task_type="analyze", summary="done")
+
+        mgr._announce_result(parent_key, result)
+        mgr._announce_result(parent_key, result)
+
+        queued = drain_announced_results(parent_key)
+        assert len(queued) == 1
+
+    def test_announce_disabled_without_parent_key(self, runner: IsolatedRunner) -> None:
+        """Manager without parent_session_key has announce disabled."""
+        mgr = SubAgentManager(runner, parent_session_key="")
+        assert mgr._announce_enabled is False
+
+    def test_announce_enabled_with_parent_key(
+        self, parent_key: str, runner: IsolatedRunner
+    ) -> None:
+        mgr = SubAgentManager(runner, parent_session_key=parent_key)
+        assert mgr._announce_enabled is True
+
+    def test_delegate_announces_on_completion(
+        self, parent_key: str, runner: IsolatedRunner, hooks: HookSystem
+    ) -> None:
+        """After delegate() completes, results are announced to parent."""
+        handler = MagicMock(return_value={"summary": "analysis complete", "tier": "S"})
+        mgr = SubAgentManager(
+            runner,
+            task_handler=handler,
+            timeout_s=5.0,
+            hooks=hooks,
+            parent_session_key=parent_key,
+        )
+        tasks = [SubTask(task_id="t1", description="analyze berserk", task_type="analyze")]
+        mgr.delegate(tasks)
+
+        # Results should be in announce queue
+        announced = drain_announced_results(parent_key)
+        assert len(announced) == 1
+        assert announced[0].task_id == "t1"
+        assert announced[0].announced is True
+
+    def test_delegate_announces_failed_results(
+        self, parent_key: str, runner: IsolatedRunner, hooks: HookSystem
+    ) -> None:
+        """Tasks with errors are also announced so parent knows about failures.
+
+        When the handler raises, _execute_subtask catches the exception and
+        returns a JSON error payload.  The IsolatedRunner still reports success
+        (the function returned), but the output contains an 'error' key.
+        The announce mechanism records whatever sub_result the delegate produces.
+        """
+        handler = MagicMock(side_effect=TimeoutError("too slow"))
+        mgr = SubAgentManager(
+            runner,
+            task_handler=handler,
+            timeout_s=5.0,
+            hooks=hooks,
+            parent_session_key=parent_key,
+        )
+        tasks = [SubTask(task_id="t-fail", description="will fail", task_type="analyze")]
+        mgr.delegate(tasks)
+
+        announced = drain_announced_results(parent_key)
+        assert len(announced) == 1
+        assert announced[0].task_id == "t-fail"
+        assert announced[0].announced is True
+        # The handler exception is caught by _execute_subtask and returned as
+        # {"error": "..."} — so the IsolatedRunner reports success, but the
+        # output contains the error payload. The announce still fires.
+        assert announced[0].summary  # non-empty summary
+
+    def test_delegate_multiple_tasks_all_announced(
+        self, parent_key: str, runner: IsolatedRunner
+    ) -> None:
+        """Multiple tasks in a single delegate() call are all announced."""
+        handler = MagicMock(return_value={"summary": "ok", "status": "ok"})
+        mgr = SubAgentManager(
+            runner, task_handler=handler, timeout_s=5.0, parent_session_key=parent_key
+        )
+        tasks = [
+            SubTask(task_id=f"t{i}", description=f"task {i}", task_type="analyze") for i in range(3)
+        ]
+        mgr.delegate(tasks)
+
+        announced = drain_announced_results(parent_key)
+        assert len(announced) == 3
+        announced_ids = {r.task_id for r in announced}
+        assert announced_ids == {"t0", "t1", "t2"}
+
+
+# ---------------------------------------------------------------------------
+# SUBAGENT_COMPLETED hook includes summary
+# ---------------------------------------------------------------------------
+
+
+class TestHookDataSummary:
+    """SUBAGENT_COMPLETED hook data includes the result summary."""
+
+    def test_completed_hook_has_summary(
+        self, parent_key: str, runner: IsolatedRunner, hooks: HookSystem
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+        hooks.register(
+            HookEvent.SUBAGENT_COMPLETED,
+            lambda _evt, data: captured.append(data),
+            name="test_capture",
+        )
+
+        handler = MagicMock(return_value={"summary": "Berserk is S-tier", "tier": "S"})
+        mgr = SubAgentManager(
+            runner,
+            task_handler=handler,
+            timeout_s=5.0,
+            hooks=hooks,
+            parent_session_key=parent_key,
+        )
+        tasks = [SubTask(task_id="t1", description="analyze", task_type="analyze")]
+        mgr.delegate(tasks)
+
+        assert len(captured) == 1
+        assert "summary" in captured[0]
+        assert "Berserk" in captured[0]["summary"] or captured[0]["summary"] != ""
+
+
+# ---------------------------------------------------------------------------
+# ConversationContext.add_system_event
+# ---------------------------------------------------------------------------
+
+
+class TestConversationSystemEvent:
+    """Tests for ConversationContext.add_system_event()."""
+
+    def test_system_event_added_as_user_message(self) -> None:
+        ctx = ConversationContext(max_turns=200)
+        ctx.add_system_event("subagent_completed", "Task t1 done: S-tier")
+
+        assert len(ctx.messages) == 1
+        msg = ctx.messages[0]
+        assert msg["role"] == "user"
+        assert "[system:subagent_completed]" in msg["content"]
+        assert "Task t1 done: S-tier" in msg["content"]
+
+    def test_system_event_preserves_existing_messages(self) -> None:
+        ctx = ConversationContext(max_turns=200)
+        ctx.add_user_message("hello")
+        ctx.add_system_event("test_event", "test content")
+
+        assert len(ctx.messages) == 2
+        assert ctx.messages[0]["content"] == "hello"
+        assert "[system:test_event]" in ctx.messages[1]["content"]
+
+    def test_system_event_format(self) -> None:
+        ctx = ConversationContext(max_turns=200)
+        ctx.add_system_event("my_type", "my_content")
+        assert ctx.messages[0]["content"] == "[system:my_type] my_content"
+
+    def test_system_event_trimming(self) -> None:
+        """System events respect max_turns trimming."""
+        ctx = ConversationContext(max_turns=2)
+        for i in range(10):
+            ctx.add_system_event("evt", f"event {i}")
+        # max_turns * 2 = 4 messages max
+        assert len(ctx.messages) <= 4
+
+
+# ---------------------------------------------------------------------------
+# AgenticLoop._check_announced_results
+# ---------------------------------------------------------------------------
+
+
+class TestAgenticLoopCheckAnnounced:
+    """Tests for AgenticLoop._check_announced_results()."""
+
+    def _make_loop(self, parent_key: str = "") -> AgenticLoop:
+        ctx = ConversationContext(max_turns=200)
+        executor = ToolExecutor()
+        loop = AgenticLoop(
+            ctx,
+            executor,
+            max_rounds=5,
+            parent_session_key=parent_key,
+        )
+        return loop
+
+    def test_no_parent_key_returns_zero(self) -> None:
+        loop = self._make_loop(parent_key="")
+        messages: list[dict[str, Any]] = []
+        count = loop._check_announced_results(messages)
+        assert count == 0
+
+    def test_no_pending_returns_zero(self) -> None:
+        loop = self._make_loop(parent_key="ip:test:pipeline")
+        messages: list[dict[str, Any]] = []
+        count = loop._check_announced_results(messages)
+        assert count == 0
+
+    def test_injects_announced_results(self) -> None:
+        parent_key = "ip:test:pipeline"
+        loop = self._make_loop(parent_key=parent_key)
+
+        # Enqueue an announced result
+        r = SubAgentResult(task_id="t1", task_type="analyze", summary="S-tier result")
+        with _announce_lock:
+            _announce_queue.setdefault(parent_key, []).append(r)
+
+        messages: list[dict[str, Any]] = []
+        count = loop._check_announced_results(messages)
+        assert count == 1
+
+        # Should be injected into both messages list and context
+        assert len(messages) == 1
+        assert "[system:subagent_completed]" in messages[0]["content"]
+        assert "t1" in messages[0]["content"]
+        assert "S-tier result" in messages[0]["content"]
+
+        # Also in conversation context
+        assert loop.context.turn_count >= 1
+
+    def test_injects_multiple_results(self) -> None:
+        parent_key = "ip:multi:pipeline"
+        loop = self._make_loop(parent_key=parent_key)
+
+        results = [
+            SubAgentResult(task_id=f"t{i}", task_type="analyze", summary=f"result {i}")
+            for i in range(3)
+        ]
+        with _announce_lock:
+            _announce_queue[parent_key] = results
+
+        messages: list[dict[str, Any]] = []
+        count = loop._check_announced_results(messages)
+        assert count == 3
+        assert len(messages) == 3
+
+    def test_failed_result_includes_error(self) -> None:
+        parent_key = "ip:err:pipeline"
+        loop = self._make_loop(parent_key=parent_key)
+
+        r = SubAgentResult(
+            task_id="t-err",
+            task_type="search",
+            status="error",
+            summary="failed to search",
+            error_message="API timeout",
+        )
+        with _announce_lock:
+            _announce_queue.setdefault(parent_key, []).append(r)
+
+        messages: list[dict[str, Any]] = []
+        loop._check_announced_results(messages)
+
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        assert "failed" in content
+        assert "API timeout" in content
+
+    def test_drain_is_one_shot(self) -> None:
+        """After _check_announced_results drains, second call returns 0."""
+        parent_key = "ip:oneshot:pipeline"
+        loop = self._make_loop(parent_key=parent_key)
+
+        r = SubAgentResult(task_id="t1", task_type="analyze", summary="done")
+        with _announce_lock:
+            _announce_queue.setdefault(parent_key, []).append(r)
+
+        messages: list[dict[str, Any]] = []
+        count1 = loop._check_announced_results(messages)
+        count2 = loop._check_announced_results(messages)
+        assert count1 == 1
+        assert count2 == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: delegate -> announce -> check
+# ---------------------------------------------------------------------------
+
+
+class TestAnnounceIntegration:
+    """End-to-end integration: SubAgentManager delegates, announces, parent loop checks."""
+
+    def test_full_flow(self) -> None:
+        parent_key = "ip:berserk:pipeline:parent"
+        handler = MagicMock(return_value={"summary": "Berserk S-tier 81.3", "tier": "S"})
+
+        mgr = SubAgentManager(
+            IsolatedRunner(),
+            task_handler=handler,
+            timeout_s=5.0,
+            parent_session_key=parent_key,
+        )
+
+        # 1. Delegate tasks
+        tasks = [SubTask(task_id="analyze-1", description="analyze Berserk", task_type="analyze")]
+        mgr.delegate(tasks)
+
+        # 2. Parent loop checks for announced results
+        ctx = ConversationContext(max_turns=200)
+        executor = ToolExecutor()
+        loop = AgenticLoop(ctx, executor, max_rounds=5, parent_session_key=parent_key)
+
+        messages: list[dict[str, Any]] = []
+        count = loop._check_announced_results(messages)
+
+        assert count == 1
+        assert len(messages) == 1
+        assert "analyze-1" in messages[0]["content"]
+        assert "Berserk" in messages[0]["content"]
+
+        # 3. Conversation context also has the event
+        assert loop.context.turn_count == 1
+
+    def test_no_announce_without_parent_key(self) -> None:
+        """Manager without parent key does not populate the queue."""
+        handler = MagicMock(return_value={"summary": "ok"})
+        mgr = SubAgentManager(
+            IsolatedRunner(),
+            task_handler=handler,
+            timeout_s=5.0,
+            parent_session_key="",
+        )
+        tasks = [SubTask(task_id="t1", description="test", task_type="analyze")]
+        mgr.delegate(tasks)
+
+        # No results in any queue
+        with _announce_lock:
+            assert len(_announce_queue) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.15.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## 요약

P1 백로그 3건 배치 구현. 프론티어 GAP 3건 해소.

## 변경 사항

### Model Failover (gap-failover 해소)
- `core/llm/client.py`: `call_with_failover(models, call_fn)` — 모델 체인 순회 + retry
- `core/cli/agentic_loop.py`: `_call_llm` → FALLBACK_CHAIN 자동 전환 적용

### MCP Adapter Lifecycle (gap-mcp-lifecycle 해소)
- `manager.py`: `startup()`/`shutdown()` lifecycle + SIGTERM + atexit 이중방어
- `stdio_client.py`: PID 추적 + 5초 graceful → SIGKILL
- `hooks.py`: MCP_SERVER_STARTED/STOPPED (32→34 events)

### Sub-agent Announce (gap-announce 해소)
- `sub_agent.py`: announce queue + `drain_announced_results()`
- `agentic_loop.py`: `_check_announced_results()` — round 시작 시 주입
- `conversation.py`: `add_system_event()` 메서드

## Pre-PR Quality Gate
- [x] ruff check — 0 errors
- [x] ruff format — OK
- [x] mypy — 0 errors
- [x] bandit — 0 issues
- [x] pytest — 2583 passed
- [x] progress.md 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)