### PR TITLE
develop → main: 칸반 정비 + Stop Hook 보강 + docs-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+P1 배치: Model Failover, MCP Lifecycle, Sub-agent Announce, Batch Approval + 칸반 정비.
+
+### Added
+- Model Failover — `call_with_failover()` async 체인 + circuit breaker + per-model exponential backoff
+- MCP Lifecycle — `MCPServerManager.startup()/shutdown()` + SIGTERM/atexit 이중방어 + PID 추적
+- Sub-agent Announce — `drain_announced_results()` 큐 기반 비동기 결과 주입 (OpenClaw Spawn+Announce)
+- Tiered Batch Approval — 5단계 안전등급 (SAFE→MCP→EXPENSIVE→WRITE→DANGEROUS) 분류 + 배치 비용 승인
+- `HookEvent.MCP_SERVER_STARTED` / `MCP_SERVER_STOPPED` — MCP 라이프사이클 이벤트 2건 (32→34)
+- Stop Hook `check-progress.sh` — develop→main 격차 감지 추가 (블로그 §5.2 스펙)
+
+### Infrastructure
+- Worktree 좀비 3건 + dangling 브랜치 40건 정리 (alloc/free 누수 해소)
+- GAP Registry `gap-multi-provider` P2→P1 승격 (Backlog 정합)
+
+---
+
 ## [0.19.1] — 2026-03-18
 
 NL Router 완전 제거, 워크플로우 리서치 + 검증팀 체계화.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ graph TB
     end
 
     subgraph L3["L3 — Orchestration"]
-        Hooks["HookSystem (30)"]
+        Hooks["HookSystem (34)"]
         Tasks["TaskGraph (DAG)"]
         Plan["PlanMode"]
         Coal["CoalescingQueue"]
@@ -185,7 +185,7 @@ graph TB
 | **L0** CLI & Agent | Typer CLI, AgenticLoop, SubAgentManager, Batch, Gateway | 사용자 인터페이스 + 자율 실행 코어 |
 | **L1** Infra | Ports (Protocol), ClaudeAdapter, OpenAIAdapter, MCP Adapters | Port/Adapter DI — `contextvars` 주입 |
 | **L2** Memory | SOUL → User Profile → Organization → Project → Session (4-Tier), SqliteSaver | 계층적 메모리 + LangGraph 체크포인트 |
-| **L3** Orchestration | HookSystem (32 events), TaskGraph DAG, PlanMode, CoalescingQueue | 라이프사이클 이벤트, 동시성 제어 |
+| **L3** Orchestration | HookSystem (34 events), TaskGraph DAG, PlanMode, CoalescingQueue | 라이프사이클 이벤트, 동시성 제어 |
 | **L4** Extensibility | ToolRegistry (46), PolicyChain, Skills, MCP Catalog (42) | 런타임 tool/skill 확장, MCP 자동설치 |
 | **L5** Domain Plugins | DomainPort Protocol, GameIPDomain, LangGraph StateGraph | 도메인별 파이프라인 플러그인 교체 |
 
@@ -818,7 +818,7 @@ core/
 ├── memory/                     # 4-Tier: SOUL → User Profile → Organization → Project → Session
 ├── nodes/                      # Pipeline nodes (router, signals, analyst, evaluator, scoring, verification, gather, synthesizer)
 ├── orchestration/
-│   ├── hooks.py                # HookSystem (30 events + async atrigger)
+│   ├── hooks.py                # HookSystem (34 events + async atrigger)
 │   ├── goal_decomposer.py      # GoalDecomposer (compound request → sub-goal DAG)
 │   ├── plan_mode.py            # DRAFT → APPROVED → EXECUTING (MANUAL / AUTO)
 │   ├── task_system.py          # TaskGraph DAG (dependency, cycle detection)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
 # GEODE Progress Board
 
 > 멀티 에이전트 공유 칸반 보드. 모든 세션/에이전트가 이 파일을 읽고 갱신한다.
-> 마지막 갱신: 2026-03-18 (세션 2)
+> 마지막 갱신: 2026-03-18 (세션 3)
 
 ---
 
@@ -21,11 +21,7 @@
 
 | task_id | 설명 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|------|------|--------|--------|------|
-| model-failover | Model Failover — call_with_failover + circuit breaker | @mangowhoiscloud | feature/p1-batch2-kanban-docsync | 2026-03-18 | 코드 완료, PR 대기 |
-| mcp-lifecycle | MCP Lifecycle — startup/shutdown + SIGTERM + atexit | @mangowhoiscloud | feature/p1-batch2-kanban-docsync | 2026-03-18 | 코드 완료, PR 대기 |
-| subagent-announce | Sub-agent Announce — drain queue + conversation 주입 | @mangowhoiscloud | feature/p1-batch2-kanban-docsync | 2026-03-18 | 코드 완료, PR 대기 |
-| batch-approval | Tiered Batch Tool Approval — 5단계 안전등급 분류 | @mangowhoiscloud | feature/p1-batch2-kanban-docsync | 2026-03-18 | 신규. 코드 완료, PR 대기 |
-| kanban-cleanup | Worktree 누수 3건 + 좀비 브랜치 40건 + Stop Hook 보강 | @mangowhoiscloud | feature/p1-batch2-kanban-docsync | 2026-03-18 | alloc/free 정리 |
+| — | — | — | — | — | — |
 
 ### In Review
 
@@ -37,6 +33,11 @@
 
 | task_id | 설명 | PR | 담당 | 완료일 |
 |---------|------|----|------|--------|
+| model-failover | Model Failover — call_with_failover + circuit breaker | #269→#270 | @mangowhoiscloud | 2026-03-18 |
+| mcp-lifecycle | MCP Lifecycle — startup/shutdown + SIGTERM + atexit | #269→#270 | @mangowhoiscloud | 2026-03-18 |
+| subagent-announce | Sub-agent Announce — drain queue + conversation 주입 | #269→#270 | @mangowhoiscloud | 2026-03-18 |
+| batch-approval | Tiered Batch Tool Approval — 5단계 안전등급 분류 | #269→#270 | @mangowhoiscloud | 2026-03-18 |
+| kanban-cleanup | Worktree 누수 3건 + 좀비 브랜치 40건 + Stop Hook 보강 | #269→#270 | @mangowhoiscloud | 2026-03-18 |
 | messaging-v019 | Slack/Discord/Telegram + Google/Apple Calendar 통합 (v0.19.0) | #241→#242 | @mangowhoiscloud | 2026-03-18 |
 | gateway-wiring | 검증팀 발견 — GatewayPort + runtime 와이어링 수정 | #241 | @mangowhoiscloud | 2026-03-18 |
 | openclaw-gap6 | OpenClaw GAP 6건 수정 (Lane Queue, Session Key 등) | #241 | @mangowhoiscloud | 2026-03-18 |


### PR DESCRIPTION
## 요약

- Stop Hook develop→main 격차 감지 추가 (블로그 §5.2 스펙)
- 칸반 보드 정합성 확보 (In Progress 5건, GAP P1 승격)
- README HookEvents 30/32→34 수치 동기화
- Worktree 좀비 3건 + dangling 브랜치 40건 정리

## 포함된 변경

- #271 칸반 정비 + Stop Hook 보강 + HookEvents 34 docs-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)