### PR TITLE
feat: .geode Context Hub — 5-Layer 목적 중심 컨텍스트 계층 (Phase A+B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-P1 전체 완료: Model Failover, MCP Lifecycle, Sub-agent Announce, Batch Approval, Context Overflow, Cost Dashboard, 6-Layer Policy, Multi-Provider, Write Fallback + 검증팀 감사.
+P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
 
 ### Added
+- `.geode` Context Hub — 5-Layer 목적 중심 컨텍스트 계층 (C0 Identity → C1 Project → C2 Journal → C3 Session → C4 Plan)
+- `ProjectJournal` (C2) — `.geode/journal/` append-only 실행 기록 (runs.jsonl, costs.jsonl, learned.md, errors.jsonl)
+- Journal Hook 자동 기록 — PIPELINE_END/ERROR → runs.jsonl + learned.md 자동 침전
+- `SessionCheckpoint` (C3) — `.geode/session/` 세션 체크포인트 저장/복원/정리 (72h auto-cleanup)
+- ContextAssembler C2 통합 — Journal 이력 + 학습 패턴 시스템 프롬프트 자동 주입
+- `geode init` 5-Layer 디렉토리 — project/, journal/, session/, plan/, cache/ 생성
 - Multi-Provider AgenticLoop — `AgenticResponse` 정규화 레이어 + Anthropic/OpenAI 이중 경로 (`_call_llm_anthropic`/`_call_llm_openai`)
 - Write Fallback — WRITE 거부 시 도구별 대안 제안 메시지 (`_write_denial_with_fallback`)
 - `agentic_response.py` (신규) — `normalize_anthropic()`, `normalize_openai()`, `AgenticResponse` 프로바이더 비종속 응답 모델

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 167
-- **Tests**: 2688+
+- **Modules**: 170
+- **Tests**: 2718+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -155,6 +155,7 @@ core/
 │   ├── agentic_response.py # AgenticResponse — provider-agnostic response normalization
 │   ├── sub_agent.py     # SubAgentManager + SubAgentResult + ErrorCategory
 │   ├── tool_executor.py # Tool dispatch + HITL + delegate_task + write fallback
+│   ├── session_checkpoint.py # C3 Session checkpoint — save/restore/resume
 │   ├── system_prompt.py # System prompt builder for AgenticLoop
 │   ├── ip_names.py      # IP name registry (canonical names from fixtures)
 │   ├── conversation.py  # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
@@ -189,6 +190,8 @@ core/
 ├── memory/
 │   ├── organization.py  # Org tier — fixture-based, read-only
 │   ├── project.py       # Project tier — .claude/MEMORY.md, rules, insights
+│   ├── project_journal.py # C2 Journal — .geode/journal/ append-only execution record
+│   ├── journal_hooks.py # Hook handlers for auto-recording to Journal
 │   ├── session.py       # Session tier — in-memory with TTL
 │   ├── hybrid_session.py # L1(Redis) → L2(PostgreSQL) hybrid store
 │   ├── session_key.py   # Hierarchical key builder (ip:name:phase)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2900,11 +2900,22 @@ def init(
 
     # .geode/ directories
     geode_dirs = [
-        Path(".geode/snapshots"),
+        # C1: Project config
+        Path(".geode/project"),
+        # C2: Journal (append-only execution history)
+        Path(".geode/journal"),
+        # C3: Session (checkpoints, resumable)
+        Path(".geode/session"),
+        # C4: Plan (goals, pending tasks)
+        Path(".geode/plan"),
+        # Cache + outputs
+        Path(".geode/cache"),
         Path(".geode/reports"),
-        Path(".geode/result_cache"),
+        Path(".geode/snapshots"),
         Path(".geode/models"),
+        # Legacy compat
         Path(".geode/sessions"),
+        Path(".geode/result_cache"),
     ]
     for d in geode_dirs:
         d.mkdir(parents=True, exist_ok=True)

--- a/core/cli/session_checkpoint.py
+++ b/core/cli/session_checkpoint.py
@@ -1,0 +1,212 @@
+"""Session Checkpoint — save/restore agentic loop state for resume.
+
+Context Layer C3: "What are we doing right now?"
+
+Persists session state to .geode/session/{id}/ so that:
+- Sessions can be resumed after interruption
+- Core results settle into C2 (Journal) on completion
+- Old checkpoints are auto-cleaned after 72 hours
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_SESSION_DIR = Path(".geode") / "session"
+CHECKPOINT_MAX_MESSAGES = 20  # Context Budget: keep recent N messages
+CLEANUP_AGE_HOURS = 72
+
+
+@dataclass
+class SessionState:
+    """Serializable session checkpoint."""
+
+    session_id: str
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    round_idx: int = 0
+    model: str = ""
+    provider: str = "anthropic"
+    status: str = "active"  # active | paused | completed | error
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    tool_log: list[dict[str, Any]] = field(default_factory=list)
+    system_prompt_hash: str = ""
+    user_input: str = ""  # original user request for context
+
+
+class SessionCheckpoint:
+    """Manage session checkpoints in .geode/session/.
+
+    Usage::
+
+        cp = SessionCheckpoint()
+        cp.save(SessionState(session_id="s1", messages=[...], round_idx=3))
+        state = cp.load("s1")
+        active = cp.list_resumable()
+        cp.cleanup()
+    """
+
+    def __init__(self, session_dir: Path | str | None = None) -> None:
+        self._dir = Path(session_dir) if session_dir else DEFAULT_SESSION_DIR
+
+    def save(self, state: SessionState) -> None:
+        """Save session checkpoint. Overwrites previous checkpoint for same ID."""
+        state.updated_at = time.time()
+        session_path = self._dir / state.session_id
+        session_path.mkdir(parents=True, exist_ok=True)
+
+        # Trim messages to budget
+        trimmed = state.messages[-CHECKPOINT_MAX_MESSAGES:]
+
+        data = {
+            "session_id": state.session_id,
+            "created_at": state.created_at,
+            "updated_at": state.updated_at,
+            "round_idx": state.round_idx,
+            "model": state.model,
+            "provider": state.provider,
+            "status": state.status,
+            "system_prompt_hash": state.system_prompt_hash,
+            "user_input": state.user_input,
+        }
+
+        # Write state.json (metadata)
+        state_file = session_path / "state.json"
+        state_file.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        # Write messages.json (conversation, trimmed)
+        msg_file = session_path / "messages.json"
+        msg_file.write_text(
+            json.dumps(trimmed, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+
+        # Write tools.json (tool call log)
+        if state.tool_log:
+            tools_file = session_path / "tools.json"
+            tools_file.write_text(
+                json.dumps(state.tool_log[-50:], ensure_ascii=False, default=str),
+                encoding="utf-8",
+            )
+
+        # Update active.json pointer
+        active_file = self._dir / "active.json"
+        self._dir.mkdir(parents=True, exist_ok=True)
+        active_file.write_text(
+            json.dumps(
+                {"session_id": state.session_id, "updated_at": state.updated_at},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    def load(self, session_id: str) -> SessionState | None:
+        """Load a session checkpoint. Returns None if not found."""
+        session_path = self._dir / session_id
+        state_file = session_path / "state.json"
+        if not state_file.exists():
+            return None
+
+        try:
+            data = json.loads(state_file.read_text(encoding="utf-8"))
+            messages = []
+            msg_file = session_path / "messages.json"
+            if msg_file.exists():
+                messages = json.loads(msg_file.read_text(encoding="utf-8"))
+
+            tool_log = []
+            tools_file = session_path / "tools.json"
+            if tools_file.exists():
+                tool_log = json.loads(tools_file.read_text(encoding="utf-8"))
+
+            return SessionState(
+                session_id=data["session_id"],
+                created_at=data.get("created_at", 0),
+                updated_at=data.get("updated_at", 0),
+                round_idx=data.get("round_idx", 0),
+                model=data.get("model", ""),
+                provider=data.get("provider", "anthropic"),
+                status=data.get("status", "paused"),
+                messages=messages,
+                tool_log=tool_log,
+                system_prompt_hash=data.get("system_prompt_hash", ""),
+                user_input=data.get("user_input", ""),
+            )
+        except (json.JSONDecodeError, KeyError, OSError) as e:
+            log.warning("Failed to load session %s: %s", session_id, e)
+            return None
+
+    def mark_completed(self, session_id: str) -> None:
+        """Mark a session as completed (no longer resumable)."""
+        session_path = self._dir / session_id
+        state_file = session_path / "state.json"
+        if not state_file.exists():
+            return
+        try:
+            data = json.loads(state_file.read_text(encoding="utf-8"))
+            data["status"] = "completed"
+            data["updated_at"] = time.time()
+            state_file.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+        # Clear active pointer if it points to this session
+        self._clear_active_if_matches(session_id)
+
+    def list_resumable(self) -> list[SessionState]:
+        """List sessions that can be resumed (status=active or paused)."""
+        if not self._dir.exists():
+            return []
+
+        sessions = []
+        for entry in self._dir.iterdir():
+            if not entry.is_dir():
+                continue
+            state = self.load(entry.name)
+            if state and state.status in ("active", "paused"):
+                sessions.append(state)
+
+        # Sort by updated_at descending (most recent first)
+        sessions.sort(key=lambda s: s.updated_at, reverse=True)
+        return sessions
+
+    def cleanup(self, max_age_hours: float = CLEANUP_AGE_HOURS) -> int:
+        """Remove completed/old session checkpoints. Returns count removed."""
+        if not self._dir.exists():
+            return 0
+
+        cutoff = time.time() - (max_age_hours * 3600)
+        removed = 0
+
+        for entry in list(self._dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            state = self.load(entry.name)
+            if state is None:
+                continue
+            # Remove completed sessions or sessions older than cutoff
+            if state.status == "completed" or state.updated_at < cutoff:
+                import shutil
+
+                shutil.rmtree(entry, ignore_errors=True)
+                removed += 1
+
+        return removed
+
+    def _clear_active_if_matches(self, session_id: str) -> None:
+        active_file = self._dir / "active.json"
+        if not active_file.exists():
+            return
+        try:
+            data = json.loads(active_file.read_text(encoding="utf-8"))
+            if data.get("session_id") == session_id:
+                active_file.unlink(missing_ok=True)
+        except (json.JSONDecodeError, OSError):
+            pass

--- a/core/memory/context.py
+++ b/core/memory/context.py
@@ -69,6 +69,7 @@ class ContextAssembler:
         user_profile: UserProfilePort | None = None,
         freshness_threshold_s: float = DEFAULT_FRESHNESS_THRESHOLD_S,
         run_log_dir: Path | str | None = None,
+        project_journal: Any | None = None,
     ) -> None:
         self._org_memory = organization_memory
         self._project_memory = project_memory
@@ -77,6 +78,7 @@ class ContextAssembler:
         self._freshness_threshold = freshness_threshold_s
         self._last_assembly_time: float = 0.0
         self._run_log_dir: Path | None = Path(run_log_dir) if run_log_dir else None
+        self._project_journal = project_journal  # C2: ProjectJournal
 
     def assemble(
         self,
@@ -158,6 +160,9 @@ class ContextAssembler:
         # Run History: inject recent execution summaries (Karpathy P6 L3)
         self._inject_run_history(ip_name, context)
 
+        # C2 Journal: inject project-level context (history + learned patterns)
+        self._inject_journal_context(context)
+
         assembled_at = time.time()
         context["_assembled_at"] = assembled_at
         context["_session_id"] = session_id
@@ -232,6 +237,23 @@ class ContextAssembler:
             context["_run_history"] = " | ".join(summaries)
         except Exception:
             log.debug("Failed to inject run history", exc_info=True)
+
+    def _inject_journal_context(self, context: dict[str, Any]) -> None:
+        """C2 Journal: inject project-level history and learned patterns."""
+        if not self._project_journal:
+            return
+        try:
+            summary = self._project_journal.get_context_summary(max_runs=3)
+            if summary:
+                context["_journal_summary"] = summary
+
+            patterns = self._project_journal.get_learned_patterns()
+            if patterns:
+                # Take last 5 patterns for context budget
+                recent = patterns[-5:]
+                context["_journal_learned"] = " | ".join(p.lstrip("- ") for p in recent)
+        except Exception:
+            log.debug("Failed to inject journal context", exc_info=True)
 
     @staticmethod
     def _build_llm_summary(

--- a/core/memory/journal_hooks.py
+++ b/core/memory/journal_hooks.py
@@ -1,0 +1,118 @@
+"""Journal Hook Handlers — auto-record to .geode/journal/ on pipeline events.
+
+Bridges HookSystem events to ProjectJournal (C2 layer).
+Registered by GeodeRuntime at startup.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.orchestration.hooks import HookEvent
+
+log = logging.getLogger(__name__)
+
+
+def make_journal_handlers(
+    journal: Any,
+) -> list[tuple[str, Any]]:
+    """Create hook handlers that auto-record to ProjectJournal.
+
+    Args:
+        journal: ProjectJournal instance.
+
+    Returns:
+        List of (handler_name, handler_fn) tuples for HookSystem.register().
+    """
+
+    def _on_pipeline_end(event: HookEvent, data: dict[str, Any]) -> None:
+        if event != HookEvent.PIPELINE_END:
+            return
+        ip_name = data.get("ip_name", "")
+        tier = data.get("tier", "")
+        score = data.get("score")
+        cause = data.get("cause", "")
+        status = data.get("status", "ok")
+        cost = data.get("cost_usd", 0.0)
+        duration = data.get("duration_ms", 0.0)
+        session_id = data.get("session_id", "")
+
+        # Build 1-line summary
+        if tier and score is not None:
+            summary = f"{ip_name} {tier}/{score:.1f}"
+            if cause:
+                summary += f" ({cause})"
+        elif ip_name:
+            summary = f"{ip_name} completed"
+        else:
+            summary = data.get("summary", "pipeline completed")
+
+        journal.record_run(
+            session_id=session_id,
+            run_type="analysis",
+            summary=summary,
+            cost_usd=cost,
+            duration_ms=duration,
+            status=status,
+            metadata={
+                k: v
+                for k, v in {
+                    "ip_name": ip_name,
+                    "tier": tier,
+                    "score": score,
+                    "cause": cause,
+                }.items()
+                if v
+            },
+        )
+
+        # Learn from tier results (Karpathy P4)
+        if tier and score is not None:
+            journal.add_learned(
+                f"[{ip_name}] Tier {tier} / {score:.1f} — {cause}",
+                "analysis",
+            )
+
+    def _on_pipeline_error(event: HookEvent, data: dict[str, Any]) -> None:
+        if event != HookEvent.PIPELINE_ERROR:
+            return
+        ip_name = data.get("ip_name", "unknown")
+        error_msg = data.get("error", "unknown error")
+        session_id = data.get("session_id", "")
+
+        journal.record_error(
+            session_id=session_id,
+            error_type=data.get("error_type", "pipeline_error"),
+            message=f"[{ip_name}] {error_msg}",
+            metadata={"ip_name": ip_name},
+        )
+
+        journal.record_run(
+            session_id=session_id,
+            run_type="analysis",
+            summary=f"{ip_name} FAILED: {error_msg[:80]}",
+            status="error",
+            metadata={"ip_name": ip_name, "error": error_msg[:200]},
+        )
+
+    def _on_subagent_completed(event: HookEvent, data: dict[str, Any]) -> None:
+        if event != HookEvent.SUBAGENT_COMPLETED:
+            return
+        task_id = data.get("task_id", "")
+        summary = data.get("summary", "")
+        if not summary:
+            return
+        session_id = data.get("session_id", "")
+        journal.record_run(
+            session_id=session_id,
+            run_type="subagent",
+            summary=f"[subagent:{task_id}] {summary[:100]}",
+            status=data.get("status", "ok"),
+        )
+
+    return [
+        ("journal_pipeline_end", _on_pipeline_end),
+        ("journal_pipeline_error", _on_pipeline_error),
+        ("journal_subagent", _on_subagent_completed),
+    ]

--- a/core/memory/project_journal.py
+++ b/core/memory/project_journal.py
@@ -1,0 +1,341 @@
+"""Project Journal — append-only execution record for the .geode/journal/ directory.
+
+Context Layer C2: "What have we done so far?"
+
+All writes are append-only (immutable log). The journal answers:
+- What analyses/tasks were run in this project?
+- What patterns did the agent learn?
+- How much did it cost?
+- What errors occurred?
+
+Files:
+  .geode/journal/runs.jsonl     — execution history (1 line per run)
+  .geode/journal/costs.jsonl    — per-call LLM cost records
+  .geode/journal/learned.md     — project-level learned patterns
+  .geode/journal/errors.jsonl   — error records
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_JOURNAL_DIR = Path(".geode") / "journal"
+MAX_LEARNED_PATTERNS = 100
+
+
+@dataclass(slots=True)
+class RunRecord:
+    """Single execution record for runs.jsonl."""
+
+    ts: float
+    session_id: str
+    run_type: str  # analysis, research, automation, chat
+    summary: str  # 1-line human-readable summary
+    cost_usd: float = 0.0
+    duration_ms: float = 0.0
+    status: str = "ok"  # ok, error, partial
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        d: dict[str, Any] = {
+            "ts": self.ts,
+            "sid": self.session_id,
+            "type": self.run_type,
+            "summary": self.summary,
+            "status": self.status,
+        }
+        if self.cost_usd:
+            d["cost"] = round(self.cost_usd, 4)
+        if self.duration_ms:
+            d["dur_ms"] = round(self.duration_ms, 1)
+        if self.metadata:
+            d["meta"] = self.metadata
+        return json.dumps(d, ensure_ascii=False, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, line: str) -> RunRecord:
+        d = json.loads(line)
+        return cls(
+            ts=d.get("ts", 0.0),
+            session_id=d.get("sid", ""),
+            run_type=d.get("type", ""),
+            summary=d.get("summary", ""),
+            cost_usd=d.get("cost", 0.0),
+            duration_ms=d.get("dur_ms", 0.0),
+            status=d.get("status", "ok"),
+            metadata=d.get("meta", {}),
+        )
+
+
+class ProjectJournal:
+    """Append-only project journal backed by .geode/journal/.
+
+    Usage::
+
+        journal = ProjectJournal()
+        journal.record_run("s1", "analysis", "Berserk S/81.3", cost_usd=0.15)
+        journal.record_cost("claude-opus-4-6", 1200, 350, 0.015)
+        journal.add_learned("Dark fantasy IPs tend to score S tier", "domain")
+        recent = journal.get_recent_runs(5)
+    """
+
+    def __init__(self, journal_dir: Path | str | None = None) -> None:
+        self._dir = Path(journal_dir) if journal_dir else DEFAULT_JOURNAL_DIR
+        self._lock = threading.Lock()
+
+    @property
+    def journal_dir(self) -> Path:
+        return self._dir
+
+    def ensure_structure(self) -> None:
+        """Create journal directory if missing."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # C2.1: Runs (execution history)
+    # ------------------------------------------------------------------
+
+    def record_run(
+        self,
+        session_id: str,
+        run_type: str,
+        summary: str,
+        *,
+        cost_usd: float = 0.0,
+        duration_ms: float = 0.0,
+        status: str = "ok",
+        metadata: dict[str, Any] | None = None,
+    ) -> RunRecord:
+        """Append a run record to runs.jsonl."""
+        record = RunRecord(
+            ts=time.time(),
+            session_id=session_id,
+            run_type=run_type,
+            summary=summary,
+            cost_usd=cost_usd,
+            duration_ms=duration_ms,
+            status=status,
+            metadata=metadata or {},
+        )
+        self._append_jsonl("runs.jsonl", record.to_json())
+        return record
+
+    def get_recent_runs(self, limit: int = 5) -> list[RunRecord]:
+        """Read most recent N run records."""
+        lines = self._read_jsonl_tail("runs.jsonl", limit)
+        records = []
+        for line in lines:
+            try:
+                records.append(RunRecord.from_json(line))
+            except (json.JSONDecodeError, KeyError):
+                continue
+        return records
+
+    # ------------------------------------------------------------------
+    # C2.2: Costs (project-level LLM cost)
+    # ------------------------------------------------------------------
+
+    def record_cost(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        *,
+        session_id: str = "",
+    ) -> None:
+        """Append a cost record to costs.jsonl."""
+        d = {
+            "ts": time.time(),
+            "model": model,
+            "in": input_tokens,
+            "out": output_tokens,
+            "cost": round(cost_usd, 6),
+        }
+        if session_id:
+            d["sid"] = session_id
+        self._append_jsonl("costs.jsonl", json.dumps(d, separators=(",", ":")))
+
+    def get_project_cost_summary(self) -> dict[str, Any]:
+        """Aggregate project-level costs from costs.jsonl."""
+        lines = self._read_jsonl_all("costs.jsonl")
+        total_cost = 0.0
+        total_calls = 0
+        by_model: dict[str, float] = {}
+        for line in lines:
+            try:
+                d = json.loads(line)
+                cost = d.get("cost", 0.0)
+                model = d.get("model", "unknown")
+                total_cost += cost
+                total_calls += 1
+                by_model[model] = by_model.get(model, 0.0) + cost
+            except (json.JSONDecodeError, KeyError):
+                continue
+        return {
+            "total_cost": round(total_cost, 4),
+            "total_calls": total_calls,
+            "by_model": by_model,
+        }
+
+    # ------------------------------------------------------------------
+    # C2.3: Learned patterns (project-level)
+    # ------------------------------------------------------------------
+
+    def add_learned(self, pattern: str, category: str = "general") -> None:
+        """Append a learned pattern to learned.md (dedup + rotation)."""
+        learned_path = self._dir / "learned.md"
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+        existing_lines: list[str] = []
+        if learned_path.exists():
+            existing_lines = learned_path.read_text(encoding="utf-8").splitlines()
+
+        # Dedup: skip if pattern already present
+        for line in existing_lines:
+            if pattern in line:
+                return
+
+        # Format: "- [category] pattern (YYYY-MM-DD)"
+        today = date.today().isoformat()
+        entry = f"- [{category}] {pattern} ({today})"
+
+        with self._lock:
+            existing_lines.append(entry)
+            # Rotation: keep most recent MAX entries
+            if len(existing_lines) > MAX_LEARNED_PATTERNS:
+                existing_lines = existing_lines[-MAX_LEARNED_PATTERNS:]
+            learned_path.write_text("\n".join(existing_lines) + "\n", encoding="utf-8")
+
+    def get_learned_patterns(self) -> list[str]:
+        """Read all learned patterns."""
+        learned_path = self._dir / "learned.md"
+        if not learned_path.exists():
+            return []
+        return [
+            line for line in learned_path.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+
+    # ------------------------------------------------------------------
+    # C2.4: Errors
+    # ------------------------------------------------------------------
+
+    def record_error(
+        self,
+        session_id: str,
+        error_type: str,
+        message: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Append an error record to errors.jsonl."""
+        d: dict[str, Any] = {
+            "ts": time.time(),
+            "sid": session_id,
+            "type": error_type,
+            "msg": message[:500],
+        }
+        if metadata:
+            d["meta"] = metadata
+        self._append_jsonl("errors.jsonl", json.dumps(d, separators=(",", ":")))
+
+    # ------------------------------------------------------------------
+    # C2.5: Context summary (for LLM injection)
+    # ------------------------------------------------------------------
+
+    def get_context_summary(self, max_runs: int = 3) -> str:
+        """Build a 1-line summary for system prompt injection (P6 L2 extraction).
+
+        Format: "Project history: Berserk S/81.3 (2h ago) | Research done (1d ago)"
+        """
+        runs = self.get_recent_runs(max_runs)
+        if not runs:
+            return ""
+
+        now = time.time()
+        parts = []
+        for r in runs:
+            age = _format_age(now - r.ts)
+            parts.append(f"{r.summary} ({age})")
+        return "Project history: " + " | ".join(parts)
+
+    # ------------------------------------------------------------------
+    # Internal file I/O
+    # ------------------------------------------------------------------
+
+    def _append_jsonl(self, filename: str, line: str) -> None:
+        fpath = self._dir / filename
+        with self._lock:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            try:
+                with open(fpath, "a", encoding="utf-8") as f:
+                    f.write(line + "\n")
+            except OSError as e:
+                log.warning("Failed to write journal %s: %s", filename, e)
+
+    def _read_jsonl_tail(self, filename: str, limit: int) -> list[str]:
+        fpath = self._dir / filename
+        if not fpath.exists():
+            return []
+        try:
+            lines = fpath.read_text(encoding="utf-8").splitlines()
+            return [ln for ln in lines[-limit:] if ln.strip()]
+        except OSError:
+            return []
+
+    def _read_jsonl_all(self, filename: str) -> list[str]:
+        fpath = self._dir / filename
+        if not fpath.exists():
+            return []
+        try:
+            return [ln for ln in fpath.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        except OSError:
+            return []
+
+
+def _format_age(seconds: float) -> str:
+    """Format elapsed seconds as human-readable age."""
+    if seconds < 60:
+        return "now"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{int(minutes)}m ago"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{int(hours)}h ago"
+    days = hours / 24
+    return f"{int(days)}d ago"
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_journal: ProjectJournal | None = None
+_journal_lock = threading.Lock()
+
+
+def get_project_journal(journal_dir: Path | str | None = None) -> ProjectJournal:
+    """Get or create the module-level ProjectJournal singleton."""
+    global _journal
+    if _journal is not None:
+        return _journal
+    with _journal_lock:
+        if _journal is None:
+            _journal = ProjectJournal(journal_dir)
+        return _journal
+
+
+def reset_project_journal(journal: ProjectJournal | None = None) -> None:
+    """Reset singleton (for testing)."""
+    global _journal
+    _journal = journal

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -428,6 +428,23 @@ class GeodeRuntime:
         except Exception:
             log.debug("Notification hook registration skipped", exc_info=True)
 
+        # C2: Journal auto-record hooks (PIPELINE_END → runs.jsonl, errors.jsonl)
+        try:
+            from core.memory.journal_hooks import make_journal_handlers
+            from core.memory.project_journal import get_project_journal
+
+            journal = get_project_journal()
+            for handler_name, handler_fn in make_journal_handlers(journal):
+                target_events = {
+                    "journal_pipeline_end": [HookEvent.PIPELINE_END],
+                    "journal_pipeline_error": [HookEvent.PIPELINE_ERROR],
+                    "journal_subagent": [HookEvent.SUBAGENT_COMPLETED],
+                }
+                for evt in target_events.get(handler_name, []):
+                    hooks.register(evt, handler_fn, name=handler_name, priority=60)
+        except Exception:
+            log.debug("Journal hook registration skipped", exc_info=True)
+
         return hooks, run_log, stuck_detector
 
     @staticmethod
@@ -450,12 +467,19 @@ class GeodeRuntime:
             project_dir=project_profile_dir if project_profile_dir.parent.exists() else None,
         )
 
+        # C2: Project Journal — append-only execution history
+        from core.memory.project_journal import ProjectJournal
+
+        project_journal = ProjectJournal()
+        project_journal.ensure_structure()
+
         context_assembler = ContextAssembler(
             organization_memory=organization_memory,
             project_memory=project_memory,
             session_store=session_store,
             user_profile=user_profile,
             run_log_dir=DEFAULT_LOG_DIR,
+            project_journal=project_journal,
         )
 
         # Wire ContextAssembler into router node (L2 → L3 bridge)

--- a/docs/plans/geode-context-hub.md
+++ b/docs/plans/geode-context-hub.md
@@ -1,0 +1,292 @@
+# .geode Context Hub — 목적 중심 컨텍스트 계층 설계
+
+> Date: 2026-03-18 | Status: **Planning**
+> 선행: `research-geode-enhancement.md`, `ADR-011`, 프론티어 4종 리서치
+
+## 1. 설계 원칙
+
+**"각 계층은 하나의 질문에 답한다."**
+
+현재 GEODE의 컨텍스트는 **저장 위치** 중심으로 분류된다 (`~/.geode/`, `.geode/`, `.claude/`). 이를 **목적** 중심으로 재구성한다. 각 계층이 에이전트의 특정 질문에 답하도록 설계하면, 어떤 정보가 어디에 있어야 하는지가 자명해진다.
+
+## 2. 5-Layer Context Hierarchy
+
+```
+Layer  질문                    수명         소유자          저장소
+─────────────────────────────────────────────────────────────────────
+ C0    "나는 누구인가?"          영구         사용자          ~/.geode/identity/
+ C1    "이 프로젝트는 무엇인가?"  프로젝트      프로젝트        .geode/project/
+ C2    "지금까지 무엇을 했는가?"  누적(불변)    에이전트        .geode/journal/
+ C3    "지금 무엇을 하고 있는가?" 세션         에이전트        .geode/session/
+ C4    "다음에 무엇을 해야 하는가?" 단기        에이전트+사용자  .geode/plan/
+```
+
+### C0: Identity — "나는 누구인가?"
+
+**목적**: 프로젝트/사용자와 무관하게 유지되는 에이전트의 정체성과 사용자 선호.
+
+| 파일 | 역할 | 생산자 | 소비자 |
+|------|------|--------|--------|
+| `~/.geode/identity/profile.md` | 사용자 역할, 전문성, 선호 언어 | 사용자 (수동 편집) | 시스템 프롬프트 |
+| `~/.geode/identity/preferences.toml` | 구조화된 선호 (모델, 출력 형식, 예산) | `/cost budget`, `/model` | Config Cascade, cmd_cost |
+| `~/.geode/identity/policies.toml` | 사용자 수준 도구 정책 (ProfilePolicy) | 사용자 (수동) | PolicyChain Layer 1 |
+| `~/.geode/config.toml` | 글로벌 기본 설정 | `geode init` | Settings Cascade |
+
+**핵심 속성**:
+- 전 프로젝트 공유 (Cross-project)
+- 사용자가 명시적으로 작성/수정
+- 거의 변하지 않음
+
+**프론티어 매핑**: Claude Code `~/.claude/`, Cursor global settings, Karpathy P7 program.md
+
+---
+
+### C1: Project — "이 프로젝트는 무엇인가?"
+
+**목적**: 이 프로젝트의 목표, 규칙, 도메인 지식. 에이전트가 "이 프로젝트에서 무엇이 중요한지" 판단하는 근거.
+
+| 파일 | 역할 | 생산자 | 소비자 |
+|------|------|--------|--------|
+| `.geode/project/config.toml` | 프로젝트별 설정 오버라이드 | 사용자 | Settings Cascade |
+| `.geode/project/policies.toml` | 조직/프로젝트 도구 정책 (OrgPolicy) | 사용자 | PolicyChain Layer 2 |
+| `.claude/CLAUDE.md` | 프로젝트 지시서 (Claude Code 호환) | 사용자 | 시스템 프롬프트 |
+| `.claude/MEMORY.md` | 프로젝트 메모리 (200줄, Claude Code 호환) | 에이전트+사용자 | ContextAssembler |
+| `.claude/SOUL.md` | 조직 미션 | 사용자 | ContextAssembler Tier 0 |
+| `.claude/rules/*.md` | 조건부 규칙 | 사용자 | ProjectMemory |
+| `.claude/skills/` | 프로젝트 스킬 | 사용자 | SkillRegistry |
+
+**핵심 속성**:
+- Git 추적 가능 (팀 공유)
+- 사용자가 주도적으로 관리
+- `.claude/`는 Claude Code 호환 유지, `.geode/project/`는 GEODE 전용
+
+**프론티어 매핑**: Claude Code `.claude/`, Codex `AGENTS.md`, Cursor `.cursor/rules`
+
+---
+
+### C2: Journal — "지금까지 무엇을 했는가?"
+
+**목적**: 프로젝트 내 모든 실행의 **불변 기록**. 에이전트가 과거를 참조하여 더 나은 판단을 내리는 근거. Append-only — 절대 삭제/수정하지 않는다.
+
+| 파일 | 역할 | 생산자 | 소비자 |
+|------|------|--------|--------|
+| `.geode/journal/runs.jsonl` | 실행 이력 (분석, 리서치, 자동화) | Hook: PIPELINE_END | ContextAssembler, `/context history` |
+| `.geode/journal/costs.jsonl` | 프로젝트 수준 비용 기록 | TokenTracker | `/cost`, 예산 관리 |
+| `.geode/journal/learned.md` | 프로젝트 수준 학습 패턴 | Hook: Agent Reflection | 시스템 프롬프트, ContextAssembler |
+| `.geode/journal/errors.jsonl` | 실패 기록 (에러 타입, 복구 여부) | Hook: PIPELINE_ERROR | ErrorRecovery 학습 |
+
+**핵심 속성**:
+- **Append-only** (불변 로그 — 신뢰의 근거)
+- 에이전트가 자동 생성 (사용자 편집 불필요)
+- 시간순 누적 — 오래된 항목은 pruning 가능하되 요약은 보존
+- gitignored (프로젝트별 실행 데이터)
+
+**프론티어 매핑**: Karpathy P4 Ratchet (tier 변동 기록), P5 Git State (실험 기록), OpenClaw Run Log JSONL
+
+**설계 판단 — 왜 Journal이 C2인가?**
+
+Journal이 Project(C1) 아래, Session(C3) 위에 있는 이유: 세션은 소멸하지만, 그 세션에서 배운 것은 프로젝트 수준에서 영속해야 한다. Journal은 "세션의 결과가 침전되는 곳"이다.
+
+---
+
+### C3: Session — "지금 무엇을 하고 있는가?"
+
+**목적**: 현재 실행 중인 세션의 라이브 상태. 세션 재개(resume)와 멀티턴 대화 연속성의 근거.
+
+| 파일 | 역할 | 생산자 | 소비자 |
+|------|------|--------|--------|
+| `.geode/session/active.json` | 현재 활성 세션 메타 (세션 ID, 시작 시각, 모델) | REPL 시작 시 | REPL 시작 시 (재개 판단) |
+| `.geode/session/{id}/messages.json` | 대화 이력 체크포인트 (최근 N턴) | AgenticLoop 라운드 종료 시 | `geode resume` |
+| `.geode/session/{id}/tools.json` | 도구 호출 기록 | AgenticLoop | 세션 재개 시 복원 |
+| `.geode/session/{id}/state.json` | 세션 메타 (round_idx, model, status) | AgenticLoop | 세션 재개 시 복원 |
+
+**핵심 속성**:
+- **Mutable** (매 라운드 갱신)
+- 세션 종료 시 핵심 결과 → C2(Journal)로 침전
+- 72시간 후 자동 정리 (cleanup)
+- 비정상 종료 시에도 마지막 체크포인트에서 재개 가능
+
+**프론티어 매핑**: OpenClaw Session Persistence, Karpathy P6 Context Budget (최근 N턴만 보존)
+
+**생명주기**:
+```
+세션 시작 → active.json 생성 → 매 라운드 체크포인트 → 세션 종료
+  → active.json 삭제
+  → 핵심 결과 Journal로 침전 (runs.jsonl, learned.md)
+  → 체크포인트 72h 후 정리
+```
+
+---
+
+### C4: Plan — "다음에 무엇을 해야 하는가?"
+
+**목적**: 미완료 작업, 분해된 목표, 예약된 자동화. 에이전트가 "아직 안 한 것"을 추적하는 근거.
+
+| 파일 | 역할 | 생산자 | 소비자 |
+|------|------|--------|--------|
+| `.geode/plan/goals.json` | 분해된 목표 DAG (GoalDecomposer 결과) | GoalDecomposer | AgenticLoop (다음 액션 결정) |
+| `.geode/plan/pending.json` | 미완료 도구 호출 (거부된 WRITE 등) | ToolExecutor | 다음 세션 시작 시 알림 |
+| `.geode/plan/schedule.json` | 예약된 자동화 (cron, 반복 작업) | SchedulerService | Cron Runner |
+
+**핵심 속성**:
+- **Consumable** (완료되면 삭제/아카이브)
+- 에이전트 + 사용자 공동 생산
+- 세션 시작 시 "이전에 못 끝낸 작업이 있습니다" 알림의 근거
+
+**프론티어 매핑**: Claude Code Tasks, OpenClaw TaskGraph, Codex auto-plan
+
+---
+
+## 3. 계층 간 데이터 흐름
+
+```
+사용자 입력 → AgenticLoop
+               │
+               ├─ 읽기: C0(Identity) + C1(Project) + C2(Journal 최근 3건) + C4(Plan)
+               │        → 시스템 프롬프트 조립
+               │
+               ├─ 실행 중: C3(Session) 체크포인트 매 라운드 갱신
+               │
+               └─ 종료 시:
+                    ├─ C2(Journal) ← runs.jsonl append (불변 기록)
+                    ├─ C2(Journal) ← learned.md append (학습 패턴)
+                    ├─ C2(Journal) ← costs.jsonl append (비용 기록)
+                    ├─ C3(Session) → 정리 or 보존 (재개용)
+                    └─ C4(Plan) ← 미완료 작업 기록 (다음 세션용)
+```
+
+## 4. 물리적 디렉토리 매핑
+
+```
+~/.geode/                           C0: Identity (글로벌)
+├── identity/
+│   ├── profile.md                  사용자 역할/전문성
+│   ├── preferences.toml            구조화된 선호
+│   └── policies.toml               사용자 수준 도구 정책
+├── config.toml                     글로벌 기본 설정
+├── usage/                          글로벌 비용 (전 프로젝트 합산)
+│   └── YYYY-MM.jsonl
+└── scheduler/                      글로벌 스케줄러
+    └── jobs.json
+
+.geode/                             C1-C4: 프로젝트 컨텍스트 (gitignored)
+├── project/                        C1: Project
+│   ├── config.toml                 프로젝트 설정 오버라이드
+│   └── policies.toml               조직 수준 도구 정책
+├── journal/                        C2: Journal (append-only)
+│   ├── runs.jsonl                  실행 이력
+│   ├── costs.jsonl                 프로젝트 비용
+│   ├── learned.md                  학습 패턴
+│   └── errors.jsonl                에러 기록
+├── session/                        C3: Session (mutable)
+│   ├── active.json                 활성 세션 메타
+│   └── {session-id}/               세션별 체크포인트
+│       ├── messages.json
+│       ├── tools.json
+│       └── state.json
+├── plan/                           C4: Plan (consumable)
+│   ├── goals.json                  목표 DAG
+│   ├── pending.json                미완료 작업
+│   └── schedule.json               예약 자동화
+├── cache/                          캐시 (TTL 기반, 계층 외)
+│   └── {hash}.json
+├── reports/                        산출물 (계층 외)
+└── snapshots/                      스냅샷 (계층 외)
+
+.claude/                            C1: Project (Claude Code 호환)
+├── CLAUDE.md                       프로젝트 지시서
+├── MEMORY.md                       프로젝트 메모리
+├── SOUL.md                         조직 미션
+├── rules/                          조건부 규칙
+├── skills/                         프로젝트 스킬
+└── mcp_servers.json                MCP 설정
+```
+
+## 5. 기존 구현 매핑 + 마이그레이션
+
+### 5.1. 이미 구현된 것 → 새 계층 매핑
+
+| 기존 구현 | 기존 위치 | 새 계층 | 변경 |
+|----------|----------|:------:|------|
+| FileBasedUserProfile | `~/.geode/user_profile/` | **C0** | `~/.geode/identity/`로 이동 |
+| ProfilePolicy TOML | `~/.geode/user_profile/preferences.toml` | **C0** | `~/.geode/identity/policies.toml` |
+| Config Cascade | `.geode/config.toml` | **C1** | `.geode/project/config.toml` |
+| OrgPolicy TOML | `.geode/config.toml [policy.org]` | **C1** | `.geode/project/policies.toml` |
+| RunLog | `~/.geode/runs/*.jsonl` | **C2** | `.geode/journal/runs.jsonl` (프로젝트 수준) |
+| UsageStore | `~/.geode/usage/` | **C0+C2** | 글로벌 유지 + `.geode/journal/costs.jsonl` 추가 |
+| Agent Reflection | `~/.geode/user_profile/learned.md` | **C0+C2** | 글로벌 유지 + `.geode/journal/learned.md` 추가 |
+| InMemorySessionStore | `.geode/sessions/` | **C3** | `.geode/session/` (체크포인트 추가) |
+| ResultCache | `.geode/result_cache/` | 캐시 | `.geode/cache/` |
+| GoalDecomposer | 메모리 내 | **C4** | `.geode/plan/goals.json` 영속화 |
+
+### 5.2. 하위 호환 전략
+
+**Phase 0 (이번 구현)**: 새 디렉토리 구조를 생성하되, 기존 경로도 fallback으로 계속 읽는다.
+
+```python
+# 예: UserProfile 로딩
+def _resolve_identity_dir() -> Path:
+    new_path = Path.home() / ".geode" / "identity"
+    old_path = Path.home() / ".geode" / "user_profile"
+    if new_path.exists():
+        return new_path
+    return old_path  # fallback to old location
+```
+
+**Phase 1 (추후)**: `geode migrate` 명령으로 기존 파일을 새 위치로 이동.
+
+## 6. 구현 계획
+
+### Phase A: Journal + 자동 기록 (핵심)
+
+**"무엇을 했는가"를 자동으로 쌓는다.**
+
+| # | 작업 | 파일 | 설명 |
+|---|------|------|------|
+| A1 | `ProjectJournal` 모듈 | `core/memory/project_journal.py` (신규) | `.geode/journal/` 읽기/쓰기 (runs.jsonl, costs.jsonl, learned.md, errors.jsonl) |
+| A2 | Hook 자동 기록 | `core/orchestration/hooks.py` 연동 | PIPELINE_END → runs.jsonl + learned.md, PIPELINE_ERROR → errors.jsonl |
+| A3 | ContextAssembler 통합 | `core/memory/context.py` 수정 | C2(Journal) 최근 이력을 시스템 프롬프트에 주입 |
+| A4 | `geode init` 확장 | `core/cli/__init__.py` 수정 | `.geode/journal/`, `.geode/session/`, `.geode/plan/`, `.geode/project/` 디렉토리 생성 |
+| A5 | 비용 이중 기록 | `core/llm/token_tracker.py` 수정 | 글로벌(~/.geode/usage) + 프로젝트(.geode/journal/costs.jsonl) |
+
+### Phase B: Session Checkpoint + Resume
+
+**"중단해도 이어갈 수 있다."**
+
+| # | 작업 | 파일 | 설명 |
+|---|------|------|------|
+| B1 | `SessionCheckpoint` 모듈 | `core/cli/session_checkpoint.py` (신규) | `.geode/session/` 체크포인트 저장/복원/정리 |
+| B2 | AgenticLoop 통합 | `core/cli/agentic_loop.py` 수정 | 매 라운드 체크포인트, 세션 ID 관리 |
+| B3 | `geode resume` 커맨드 | `core/cli/__init__.py` 수정 | 중단 세션 목록 + 선택 재개 |
+| B4 | 침전 메커니즘 | `core/cli/agentic_loop.py` 수정 | 세션 종료 → Journal(C2)로 핵심 결과 기록 |
+| B5 | REPL 시작 알림 | `core/cli/repl.py` 수정 | "이전 세션이 있습니다" 알림 |
+
+### Phase C: Plan Persistence + Context Command
+
+**"아직 안 한 것을 기억한다."**
+
+| # | 작업 | 파일 | 설명 |
+|---|------|------|------|
+| C1 | Plan 영속화 | `core/orchestration/plan_mode.py` 수정 | goals.json 저장/복원 |
+| C2 | Pending 추적 | `core/cli/tool_executor.py` 수정 | 거부된 WRITE → pending.json |
+| C3 | `/context` 커맨드 | `core/cli/commands.py` 추가 | 전 계층 컨텍스트 요약 표시 |
+| C4 | Startup 주입 | `core/cli/repl.py` 수정 | 시작 시 C2+C4 자동 요약 주입 |
+
+### 구현 우선순위
+
+```
+Phase A (Journal) ──→ Phase B (Session) ──→ Phase C (Plan)
+  "과거를 기억"          "현재를 보존"          "미래를 계획"
+```
+
+**Phase A만 완료해도** 프로젝트 컨텍스트 축적의 기본 메커니즘이 동작한다.
+
+## 7. 프론티어 대비 차별점
+
+| 프론티어 | 패턴 | GEODE 적용 | 차별점 |
+|---------|------|-----------|--------|
+| Claude Code | `.claude/` 단일 디렉토리 | C0-C4 5계층 분리 | 목적별 계층화 — "왜 이 데이터가 여기 있는지" 자명 |
+| Codex | `AGENTS.md` 단일 파일 | C1(Project) + C2(Journal) | 지시서와 학습 기록 분리 — 지시는 사람이, 학습은 에이전트가 |
+| Cursor | `.cursor/rules` | C1(Project rules) + C2(Journal learned) | 규칙(명시적)과 학습(암묵적) 구분 |
+| OpenClaw | Session Key + Log | C3(Session checkpoint) + C2(Journal) | 세션 → 저널 침전 메커니즘 |
+| Karpathy | P6 Context Budget | C2 1줄 요약 주입 | 계층별 예산 할당 (C0 10%, C1 25%, C2 25%, C3 40%) |

--- a/tests/test_project_journal.py
+++ b/tests/test_project_journal.py
@@ -1,0 +1,195 @@
+"""Tests for ProjectJournal — C2 layer append-only execution record."""
+
+from __future__ import annotations
+
+import json
+
+from core.memory.project_journal import ProjectJournal, RunRecord, _format_age
+
+
+class TestRunRecord:
+    def test_to_json_and_back(self):
+        rec = RunRecord(
+            ts=1710000000,
+            session_id="s1",
+            run_type="analysis",
+            summary="Berserk S/81.3",
+            cost_usd=0.15,
+            duration_ms=12000,
+            metadata={"tier": "S"},
+        )
+        line = rec.to_json()
+        restored = RunRecord.from_json(line)
+        assert restored.session_id == "s1"
+        assert restored.summary == "Berserk S/81.3"
+        assert restored.cost_usd == 0.15
+        assert restored.metadata["tier"] == "S"
+
+    def test_minimal_record(self):
+        rec = RunRecord(ts=0, session_id="", run_type="chat", summary="hello")
+        line = rec.to_json()
+        d = json.loads(line)
+        assert "cost" not in d  # zero cost omitted
+        assert "dur_ms" not in d  # zero duration omitted
+
+
+class TestProjectJournal:
+    def test_record_and_get_runs(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        journal.record_run("s1", "analysis", "Berserk S/81.3", cost_usd=0.15)
+        journal.record_run("s2", "research", "AI trends", cost_usd=0.08)
+
+        runs = journal.get_recent_runs(5)
+        assert len(runs) == 2
+        assert runs[0].summary == "Berserk S/81.3"
+        assert runs[1].summary == "AI trends"
+
+    def test_record_cost(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        journal.record_cost("claude-opus-4-6", 1200, 350, 0.015)
+        journal.record_cost("gpt-5.4", 800, 200, 0.005)
+
+        summary = journal.get_project_cost_summary()
+        assert summary["total_calls"] == 2
+        assert summary["total_cost"] > 0
+        assert "claude-opus-4-6" in summary["by_model"]
+
+    def test_add_learned_dedup(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        journal.add_learned("pattern A", "domain")
+        journal.add_learned("pattern A", "domain")  # duplicate
+
+        patterns = journal.get_learned_patterns()
+        # Should have only 1 (dedup)
+        matching = [p for p in patterns if "pattern A" in p]
+        assert len(matching) == 1
+
+    def test_add_learned_rotation(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        for i in range(120):
+            journal.add_learned(f"pattern {i}", "test")
+
+        patterns = journal.get_learned_patterns()
+        assert len(patterns) <= 100
+        # Most recent should be preserved
+        assert any("pattern 119" in p for p in patterns)
+
+    def test_record_error(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        journal.record_error("s1", "timeout", "API call timed out")
+
+        errors_file = tmp_path / "journal" / "errors.jsonl"
+        assert errors_file.exists()
+        line = errors_file.read_text().strip()
+        d = json.loads(line)
+        assert d["type"] == "timeout"
+        assert "timed out" in d["msg"]
+
+    def test_get_context_summary(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        journal.record_run("s1", "analysis", "Berserk S/81.3")
+        journal.record_run("s2", "research", "AI trends report")
+
+        summary = journal.get_context_summary()
+        assert "Project history:" in summary
+        assert "Berserk" in summary
+        assert "AI trends" in summary
+
+    def test_get_context_summary_empty(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        assert journal.get_context_summary() == ""
+
+    def test_ensure_structure(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "new_journal")
+        assert not (tmp_path / "new_journal").exists()
+        journal.ensure_structure()
+        assert (tmp_path / "new_journal").exists()
+
+    def test_get_recent_runs_limit(self, tmp_path):
+        journal = ProjectJournal(tmp_path / "journal")
+        for i in range(10):
+            journal.record_run(f"s{i}", "chat", f"chat {i}")
+
+        runs = journal.get_recent_runs(3)
+        assert len(runs) == 3
+        # Should be most recent 3
+        assert runs[-1].summary == "chat 9"
+
+
+class TestJournalHooks:
+    def test_pipeline_end_records_run(self, tmp_path):
+        from core.memory.journal_hooks import make_journal_handlers
+        from core.orchestration.hooks import HookEvent
+
+        journal = ProjectJournal(tmp_path / "journal")
+        handlers = make_journal_handlers(journal)
+        assert len(handlers) == 3
+
+        # Simulate PIPELINE_END
+        end_handler = next(fn for name, fn in handlers if name == "journal_pipeline_end")
+        end_handler(
+            HookEvent.PIPELINE_END,
+            {
+                "ip_name": "Berserk",
+                "tier": "S",
+                "score": 81.3,
+                "cause": "conversion_failure",
+                "session_id": "test-s1",
+            },
+        )
+
+        runs = journal.get_recent_runs(5)
+        assert len(runs) == 1
+        assert "Berserk" in runs[0].summary
+        assert "S/81.3" in runs[0].summary
+
+        # Should also add learned pattern
+        patterns = journal.get_learned_patterns()
+        assert any("Berserk" in p for p in patterns)
+
+    def test_pipeline_error_records(self, tmp_path):
+        from core.memory.journal_hooks import make_journal_handlers
+        from core.orchestration.hooks import HookEvent
+
+        journal = ProjectJournal(tmp_path / "journal")
+        handlers = make_journal_handlers(journal)
+
+        error_handler = next(fn for name, fn in handlers if name == "journal_pipeline_error")
+        error_handler(
+            HookEvent.PIPELINE_ERROR,
+            {
+                "ip_name": "Test",
+                "error": "API timeout",
+                "session_id": "test-s2",
+            },
+        )
+
+        runs = journal.get_recent_runs(5)
+        assert len(runs) == 1
+        assert runs[0].status == "error"
+
+    def test_wrong_event_ignored(self, tmp_path):
+        from core.memory.journal_hooks import make_journal_handlers
+        from core.orchestration.hooks import HookEvent
+
+        journal = ProjectJournal(tmp_path / "journal")
+        handlers = make_journal_handlers(journal)
+
+        end_handler = next(fn for name, fn in handlers if name == "journal_pipeline_end")
+        # Send wrong event type
+        end_handler(HookEvent.NODE_ENTER, {"ip_name": "X"})
+        assert journal.get_recent_runs(5) == []
+
+
+class TestFormatAge:
+    def test_now(self):
+        assert _format_age(30) == "now"
+
+    def test_minutes(self):
+        assert _format_age(300) == "5m ago"
+
+    def test_hours(self):
+        assert _format_age(7200) == "2h ago"
+
+    def test_days(self):
+        assert _format_age(172800) == "2d ago"

--- a/tests/test_session_checkpoint.py
+++ b/tests/test_session_checkpoint.py
@@ -1,0 +1,146 @@
+"""Tests for SessionCheckpoint — C3 layer session persistence."""
+
+from __future__ import annotations
+
+import time
+
+from core.cli.session_checkpoint import (
+    CHECKPOINT_MAX_MESSAGES,
+    SessionCheckpoint,
+    SessionState,
+)
+
+
+class TestSessionState:
+    def test_default_values(self):
+        state = SessionState(session_id="s1")
+        assert state.status == "active"
+        assert state.provider == "anthropic"
+        assert state.round_idx == 0
+        assert state.messages == []
+
+
+class TestSessionCheckpoint:
+    def test_save_and_load(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        state = SessionState(
+            session_id="test-1",
+            model="claude-opus-4-6",
+            round_idx=3,
+            messages=[{"role": "user", "content": "hello"}],
+            user_input="hello",
+        )
+        cp.save(state)
+
+        loaded = cp.load("test-1")
+        assert loaded is not None
+        assert loaded.session_id == "test-1"
+        assert loaded.model == "claude-opus-4-6"
+        assert loaded.round_idx == 3
+        assert len(loaded.messages) == 1
+        assert loaded.user_input == "hello"
+
+    def test_load_nonexistent(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        assert cp.load("nonexistent") is None
+
+    def test_message_trimming(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        messages = [{"role": "user", "content": f"msg {i}"} for i in range(50)]
+        state = SessionState(session_id="trim-test", messages=messages)
+        cp.save(state)
+
+        loaded = cp.load("trim-test")
+        assert loaded is not None
+        assert len(loaded.messages) == CHECKPOINT_MAX_MESSAGES
+        # Should keep most recent
+        assert loaded.messages[-1]["content"] == "msg 49"
+
+    def test_mark_completed(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        state = SessionState(session_id="done-test")
+        cp.save(state)
+        cp.mark_completed("done-test")
+
+        loaded = cp.load("done-test")
+        assert loaded is not None
+        assert loaded.status == "completed"
+
+    def test_list_resumable(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="active-1", status="active"))
+        cp.save(SessionState(session_id="paused-1", status="paused"))
+        cp.save(SessionState(session_id="done-1", status="completed"))
+
+        resumable = cp.list_resumable()
+        ids = [s.session_id for s in resumable]
+        assert "active-1" in ids
+        assert "paused-1" in ids
+        assert "done-1" not in ids
+
+    def test_cleanup_completed(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="keep"))
+        cp.save(SessionState(session_id="remove"))
+        cp.mark_completed("remove")
+
+        removed = cp.cleanup()
+        assert removed == 1
+        assert cp.load("keep") is not None
+        assert cp.load("remove") is None
+
+    def test_cleanup_old(self, tmp_path):
+        import json
+
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="old"))
+        # Manually backdate the checkpoint
+        state_file = tmp_path / "session" / "old" / "state.json"
+        data = json.loads(state_file.read_text())
+        data["updated_at"] = time.time() - 100 * 3600  # 100h ago
+        state_file.write_text(json.dumps(data))
+
+        removed = cp.cleanup(max_age_hours=72)
+        assert removed == 1
+
+    def test_active_json_pointer(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="s1"))
+
+        active_file = tmp_path / "session" / "active.json"
+        assert active_file.exists()
+
+        import json
+
+        data = json.loads(active_file.read_text())
+        assert data["session_id"] == "s1"
+
+    def test_active_cleared_on_complete(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="s1"))
+        cp.mark_completed("s1")
+
+        active_file = tmp_path / "session" / "active.json"
+        assert not active_file.exists()
+
+    def test_overwrite_checkpoint(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="s1", round_idx=1))
+        cp.save(SessionState(session_id="s1", round_idx=5))
+
+        loaded = cp.load("s1")
+        assert loaded is not None
+        assert loaded.round_idx == 5
+
+    def test_tool_log_saved(self, tmp_path):
+        cp = SessionCheckpoint(tmp_path / "session")
+        state = SessionState(
+            session_id="tools-test",
+            tool_log=[{"name": "search", "result": "ok"}],
+        )
+        cp.save(state)
+
+        loaded = cp.load("tools-test")
+        assert loaded is not None
+        assert len(loaded.tool_log) == 1
+        assert loaded.tool_log[0]["name"] == "search"


### PR DESCRIPTION
## 요약

`.geode/`를 **5-Layer 목적 중심 컨텍스트 계층**으로 재설계. 각 계층이 에이전트의 특정 질문에 답한다:

- **C0 Identity**: "나는 누구인가?" (`~/.geode/identity/`)
- **C1 Project**: "이 프로젝트는 무엇인가?" (`.geode/project/` + `.claude/`)
- **C2 Journal**: "지금까지 무엇을 했는가?" (`.geode/journal/` — append-only)
- **C3 Session**: "지금 무엇을 하고 있는가?" (`.geode/session/` — checkpoint)
- **C4 Plan**: "다음에 무엇을 해야 하는가?" (`.geode/plan/` — consumable)

## 변경 사항

### 핵심
- `core/memory/project_journal.py` (신규) — C2 Journal: `runs.jsonl`, `costs.jsonl`, `learned.md`, `errors.jsonl` append-only 기록
- `core/memory/journal_hooks.py` (신규) — PIPELINE_END/ERROR → Journal 자동 침전 Hook
- `core/cli/session_checkpoint.py` (신규) — C3 Session: 체크포인트 저장/복원/정리 (72h cleanup, Context Budget 20턴)
- `core/memory/context.py` — ContextAssembler에 C2 Journal 주입 (이력 + 학습 패턴)
- `core/runtime.py` — ProjectJournal 와이어링 + Journal Hook 등록
- `core/cli/__init__.py` — `geode init` 5-Layer 디렉토리 (project/journal/session/plan/cache)

### 문서
- `docs/plans/geode-context-hub.md` — 5-Layer 설계 문서 (목적, 생명주기, 데이터 흐름, 프론티어 매핑)
- CHANGELOG.md, CLAUDE.md 수치 갱신 (170 modules, 2718+ tests)

## 설계 판단

**왜 5계층인가?** 기존 "저장 위치 중심"(~/.geode, .geode, .claude) 분류에서 "목적 중심" 분류로 전환. 각 계층이 하나의 질문에 답하므로, 데이터 배치 근거가 자명.

**왜 Journal이 append-only인가?** 실행 기록은 신뢰의 근거. 수정/삭제 허용 시 "이전에 뭘 했는지" 판단이 불안정. Karpathy P5 Git State 패턴.

**왜 Session → Journal 침전인가?** 세션은 소멸하지만 결과는 영속해야 함. OpenClaw 패턴.

## Pre-PR Quality Gate

- [x] ruff: 0 errors
- [x] mypy: 0 errors (170 files)
- [x] pytest: 2718 passed
- [x] pre-commit: all passed