### PR TITLE
feat: SessionTranscript + Snapshot 재설계 + REODE 워크플로우 이식

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
 - `ProjectJournal` (C2) — `.geode/journal/` append-only 실행 기록 (runs.jsonl, costs.jsonl, learned.md, errors.jsonl)
 - Journal Hook 자동 기록 — PIPELINE_END/ERROR → runs.jsonl + learned.md 자동 침전
 - `SessionCheckpoint` (C3) — `.geode/session/` 세션 체크포인트 저장/복원/정리 (72h auto-cleanup)
+- `SessionTranscript` (Tier 1) — `.geode/journal/transcripts/` JSONL 이벤트 스트림 (대화, 도구, 비용, 에러 감사 추적)
 - `Vault` (V0) — `.geode/vault/` 목적별 산출물 영속 저장소 (profile/research/applications/general), 자동 분류 + 버전 관리
 - ContextAssembler C2 통합 — Journal 이력 + 학습 패턴 시스템 프롬프트 자동 주입
 - `geode init` 5-Layer 디렉토리 — project/, journal/, session/, plan/, cache/ 생성

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 171
-- **Tests**: 2740+
+- **Modules**: 172
+- **Tests**: 2759+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2904,6 +2904,7 @@ def init(
         Path(".geode/project"),
         # C2: Journal (append-only execution history)
         Path(".geode/journal"),
+        Path(".geode/journal/transcripts"),
         # V0: Vault (purpose-routed artifact storage)
         Path(".geode/vault/profile"),
         Path(".geode/vault/research"),

--- a/core/cli/transcript.py
+++ b/core/cli/transcript.py
@@ -1,0 +1,300 @@
+"""SessionTranscript — JSONL event stream for session audit trail.
+
+Tier 1 preservation: records every event in a session as an append-only
+JSONL file. Complementary to Journal (Tier 2, summaries) and Snapshot
+(Tier 3, pipeline state).
+
+Captures: user messages, assistant responses, tool calls/results,
+vault saves, costs, errors — everything needed to reconstruct
+"what exactly happened in this session."
+
+Storage: .geode/journal/transcripts/{session_id}.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TRANSCRIPT_DIR = Path(".geode") / "journal" / "transcripts"
+MAX_TEXT_CHARS = 500
+MAX_INPUT_CHARS = 300
+CLEANUP_AGE_DAYS = 30
+MAX_FILE_BYTES = 5 * 1024 * 1024  # 5MB per transcript
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+class SessionTranscript:
+    """Append-only JSONL event recorder for a single session.
+
+    Usage::
+
+        tx = SessionTranscript("s-abc123")
+        tx.record_session_start(model="claude-opus-4-6")
+        tx.record_user_message("내 프로필 시그널 분석해줘")
+        tx.record_tool_call("web_fetch", {"url": "https://..."})
+        tx.record_tool_result("web_fetch", "ok", "channel data...")
+        tx.record_assistant_message("분석 결과입니다...")
+        tx.record_vault_save("vault/profile/signal-report.md", "profile")
+        tx.record_cost("claude-opus-4-6", 1200, 350, 0.015)
+        tx.record_session_end(duration_s=20, total_cost=0.015, rounds=3)
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        transcript_dir: Path | str | None = None,
+    ) -> None:
+        self._session_id = session_id
+        self._dir = Path(transcript_dir) if transcript_dir else DEFAULT_TRANSCRIPT_DIR
+        self._lock = threading.Lock()
+        self._event_count = 0
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def event_count(self) -> int:
+        return self._event_count
+
+    @property
+    def file_path(self) -> Path:
+        return self._dir / f"{self._session_id}.jsonl"
+
+    # ------------------------------------------------------------------
+    # Event recorders
+    # ------------------------------------------------------------------
+
+    def record_session_start(self, *, model: str = "", provider: str = "anthropic") -> None:
+        self._append(
+            {
+                "event": "session_start",
+                "model": model,
+                "provider": provider,
+                "session_id": self._session_id,
+            }
+        )
+
+    def record_session_end(
+        self,
+        *,
+        duration_s: float = 0,
+        total_cost: float = 0,
+        rounds: int = 0,
+    ) -> None:
+        self._append(
+            {
+                "event": "session_end",
+                "duration_s": round(duration_s, 1),
+                "total_cost": round(total_cost, 4),
+                "rounds": rounds,
+            }
+        )
+        self._update_index()
+
+    def record_user_message(self, text: str) -> None:
+        self._append(
+            {
+                "event": "user_message",
+                "text": _truncate(text, MAX_TEXT_CHARS),
+            }
+        )
+
+    def record_assistant_message(self, text: str) -> None:
+        self._append(
+            {
+                "event": "assistant_message",
+                "text": _truncate(text, MAX_TEXT_CHARS),
+            }
+        )
+
+    def record_tool_call(self, tool: str, tool_input: dict[str, Any]) -> None:
+        input_str = json.dumps(tool_input, ensure_ascii=False, default=str)
+        self._append(
+            {
+                "event": "tool_call",
+                "tool": tool,
+                "input": _truncate(input_str, MAX_INPUT_CHARS),
+            }
+        )
+
+    def record_tool_result(self, tool: str, status: str, summary: str = "") -> None:
+        self._append(
+            {
+                "event": "tool_result",
+                "tool": tool,
+                "status": status,
+                "summary": _truncate(summary, MAX_INPUT_CHARS),
+            }
+        )
+
+    def record_vault_save(self, path: str, category: str) -> None:
+        self._append(
+            {
+                "event": "vault_save",
+                "path": path,
+                "category": category,
+            }
+        )
+
+    def record_cost(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+    ) -> None:
+        self._append(
+            {
+                "event": "cost",
+                "model": model,
+                "in": input_tokens,
+                "out": output_tokens,
+                "cost": round(cost_usd, 6),
+            }
+        )
+
+    def record_error(self, error_type: str, message: str) -> None:
+        self._append(
+            {
+                "event": "error",
+                "type": error_type,
+                "msg": _truncate(message, MAX_TEXT_CHARS),
+            }
+        )
+
+    def record_subagent_start(self, task_id: str, task_type: str = "") -> None:
+        self._append(
+            {
+                "event": "subagent_start",
+                "task_id": task_id,
+                "task_type": task_type,
+            }
+        )
+
+    def record_subagent_complete(self, task_id: str, status: str, summary: str = "") -> None:
+        self._append(
+            {
+                "event": "subagent_complete",
+                "task_id": task_id,
+                "status": status,
+                "summary": _truncate(summary, MAX_INPUT_CHARS),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def read_events(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Read most recent N events from this transcript."""
+        fpath = self.file_path
+        if not fpath.exists():
+            return []
+        try:
+            lines = fpath.read_text(encoding="utf-8").splitlines()
+            events = []
+            for line in lines[-limit:]:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+            return events
+        except OSError:
+            return []
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _append(self, data: dict[str, Any]) -> None:
+        data["ts"] = time.time()
+        line = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+        with self._lock:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            fpath = self.file_path
+            # Size guard
+            if fpath.exists() and fpath.stat().st_size > MAX_FILE_BYTES:
+                self._tail_truncate(fpath)
+            try:
+                with open(fpath, "a", encoding="utf-8") as f:
+                    f.write(line + "\n")
+                self._event_count += 1
+            except OSError as e:
+                log.warning("Transcript write failed: %s", e)
+
+    def _tail_truncate(self, fpath: Path) -> None:
+        """Keep only the last half of lines when file exceeds size limit."""
+        try:
+            lines = fpath.read_text(encoding="utf-8").splitlines()
+            keep = lines[len(lines) // 2 :]
+            fpath.write_text("\n".join(keep) + "\n", encoding="utf-8")
+        except OSError:
+            pass
+
+    def _update_index(self) -> None:
+        """Update the session index file with this session's metadata."""
+        index_path = self._dir / "index.json"
+        index: dict[str, Any] = {}
+        if index_path.exists():
+            try:
+                index = json.loads(index_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                index = {}
+
+        if "sessions" not in index:
+            index["sessions"] = {}
+
+        index["sessions"][self._session_id] = {
+            "event_count": self._event_count,
+            "updated_at": time.time(),
+        }
+
+        import contextlib
+
+        with contextlib.suppress(OSError):
+            index_path.write_text(
+                json.dumps(index, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cleanup utility
+# ---------------------------------------------------------------------------
+
+
+def cleanup_old_transcripts(
+    transcript_dir: Path | str | None = None,
+    max_age_days: int = CLEANUP_AGE_DAYS,
+) -> int:
+    """Remove transcript files older than max_age_days. Returns count removed."""
+    tdir = Path(transcript_dir) if transcript_dir else DEFAULT_TRANSCRIPT_DIR
+    if not tdir.exists():
+        return 0
+
+    cutoff = time.time() - (max_age_days * 86400)
+    removed = 0
+    for fpath in list(tdir.glob("*.jsonl")):
+        try:
+            if fpath.stat().st_mtime < cutoff:
+                fpath.unlink()
+                removed += 1
+        except OSError:
+            continue
+    return removed

--- a/docs/plans/snapshot-redesign.md
+++ b/docs/plans/snapshot-redesign.md
@@ -1,0 +1,156 @@
+# Snapshot 재설계 — 범용 작업 컨텍스트 보존
+
+> Date: 2026-03-18 | Status: **계획 확정**
+> 선행: snapshot 리서치, REODE SessionTranscript, Karpathy P4-P6, OpenClaw RunLog
+
+## 1. 현재 문제
+
+### 1.1. Snapshot이 게임 IP 전용
+
+현재 `SnapshotManager`는 `GeodeState`(파이프라인 상태)만 캡처한다. 이는 게임 IP 분석에만 유용하고, GEODE의 실제 워크플로우에서 의미가 없다:
+
+| GEODE 실제 작업 | Snapshot이 캡처하는가? |
+|:--|:--|
+| "AI 에이전트 시장 조사해줘" → 리서치 보고서 | X (pipeline 안 탐) |
+| "내 프로필 시그널 분석해줘" → 시그널 리포트 | X (pipeline 안 탐) |
+| "Anthropic 지원서 써줘" → 커버레터 | X (pipeline 안 탐) |
+| "Berserk 분석해줘" → IP 분석 | O (PIPELINE_END에서 캡처) |
+
+### 1.2. 캡처 범위가 좁음
+
+| 캡처됨 | 안 캡처됨 |
+|:---:|:---:|
+| 분석 결과 (tier, score) | **사용자 입력** |
+| 평가 축 점수 | **LLM 응답 원문** |
+| 검증 결과 | **도구 호출 + 결과** |
+| prompt/rubric hash | **비용 데이터** |
+| | **생성된 산출물 (보고서, 지원서)** |
+
+### 1.3. 사용자 접근 불가
+
+- CLI 명령 없음 (`/snapshots list` 같은 게 없다)
+- AgenticLoop 도구 없음 (에이전트가 과거 스냅샷 참조 불가)
+- Journal(C2)과 분리되어 있어 실행 이력과 매핑 안 됨
+
+## 2. 재정의: 3-Tier 보존 체계
+
+기존 SnapshotManager를 폐기하지 않고, **3단계 보존 체계**로 확장한다.
+
+```
+Tier 1: SessionTranscript (JSONL 이벤트 스트림)
+  ← 모든 세션의 모든 이벤트를 append-only 기록
+  ← REODE 패턴 채택
+
+Tier 2: Journal (C2, 이미 구현)
+  ← 세션 종료 시 핵심 결과 침전 (runs.jsonl, learned.md)
+
+Tier 3: Snapshot (기존, 파이프라인 전용)
+  ← 도메인 파이프라인 상태 캡처 (유지, 확장 안 함)
+```
+
+### 각 Tier의 역할
+
+| Tier | 질문 | 보존 대상 | 수명 | 형식 |
+|:--:|:--|:--|:--|:--|
+| 1 | "이 세션에서 정확히 무슨 일이 있었는가?" | 대화 전문, 도구 호출/결과, 비용 | 30일 auto-cleanup | JSONL |
+| 2 | "프로젝트에서 지금까지 무엇을 했는가?" | 실행 요약, 학습 패턴, 에러 | 영구 (pruning) | JSONL + MD |
+| 3 | "이 분석의 정확한 상태는?" | 파이프라인 GeodeState | 30 recent + weekly | JSON |
+
+**핵심 통찰**: Tier 1(Transcript)이 추가되면, "왜 이 결과가 나왔는가?"를 추적할 수 있다. 현재는 Tier 2(뭘 했는가)와 Tier 3(결과가 뭔가)만 있어 중간 과정이 소실된다.
+
+## 3. SessionTranscript 설계 (Tier 1)
+
+### 3.1. 이벤트 스키마
+
+```jsonl
+{"ts":1710000000,"event":"session_start","model":"claude-opus-4-6","session_id":"s-abc123"}
+{"ts":1710000001,"event":"user_message","text":"내 프로필 시그널 분석해줘"}
+{"ts":1710000005,"event":"tool_call","tool":"web_fetch","input":{"url":"https://youtube.com/..."}}
+{"ts":1710000008,"event":"tool_result","tool":"web_fetch","status":"ok","summary":"channel data..."}
+{"ts":1710000012,"event":"assistant_message","text":"YouTube 채널 분석 결과입니다..."}
+{"ts":1710000015,"event":"vault_save","path":"vault/profile/signal-report-2026-03-18.md","category":"profile"}
+{"ts":1710000016,"event":"cost","model":"claude-opus-4-6","input_tokens":1200,"output_tokens":350,"cost_usd":0.015}
+{"ts":1710000020,"event":"session_end","duration_s":20,"total_cost":0.015,"rounds":3}
+```
+
+### 3.2. 이벤트 타입
+
+| 이벤트 | 캡처 시점 | 데이터 |
+|:--|:--|:--|
+| `session_start` | REPL/AgenticLoop 시작 | model, provider, session_id |
+| `session_end` | 세션 종료 | duration_s, total_cost, rounds |
+| `user_message` | 사용자 입력 수신 | text (최대 500자) |
+| `assistant_message` | LLM 응답 | text (최대 500자) |
+| `tool_call` | 도구 호출 직전 | tool name, input (최대 300자) |
+| `tool_result` | 도구 실행 완료 | tool name, status, summary (최대 300자) |
+| `vault_save` | Vault에 산출물 저장 | path, category |
+| `cost` | LLM 호출 비용 | model, tokens, cost_usd |
+| `error` | 에러 발생 | error_type, message |
+| `subagent_start` | 서브에이전트 시작 | task_id, task_type |
+| `subagent_complete` | 서브에이전트 완료 | task_id, status, summary |
+
+### 3.3. 저장 위치
+
+```
+.geode/journal/transcripts/
+├── s-abc123.jsonl          # 세션별 1개 파일
+├── s-def456.jsonl
+└── index.json              # 세션 인덱스 (session_id, started_at, event_count, summary)
+```
+
+**왜 journal/ 아래인가?** Transcript는 C2(Journal)의 상세 버전이다. Journal은 요약(runs.jsonl), Transcript는 원본.
+
+### 3.4. 텍스트 절단 정책 (Karpathy P6 Context Budget)
+
+| 필드 | 최대 길이 | 이유 |
+|:--|:--|:--|
+| user_message.text | 500자 | 사용자 의도는 짧음 |
+| assistant_message.text | 500자 | 전문은 Vault에 저장됨 |
+| tool_call.input | 300자 | 도구 입력은 짧음 |
+| tool_result.summary | 300자 | 전체 결과는 session checkpoint에 |
+
+### 3.5. 정리 정책
+
+- **30일 auto-cleanup**: 30일 지난 .jsonl 파일 삭제 (REODE 패턴)
+- **index.json 유지**: 삭제된 세션도 인덱스에 메타데이터 보존 (요약만)
+- **크기 제한**: 개별 파일 최대 5MB (초과 시 tail 보존)
+
+## 4. 구현 계획
+
+### Phase 1: SessionTranscript 모듈
+
+| # | 작업 | 파일 |
+|---|------|------|
+| 1 | `SessionTranscript` 클래스 | `core/cli/transcript.py` (신규) |
+| 2 | AgenticLoop 통합 | `core/cli/agentic_loop.py` 수정 — 매 라운드 이벤트 기록 |
+| 3 | Vault 연동 | `core/memory/vault.py` 수정 — save() 시 transcript 이벤트 |
+| 4 | Journal 인덱싱 | `core/memory/project_journal.py` 수정 — transcript 인덱스 관리 |
+| 5 | `geode init` 확장 | `core/cli/__init__.py` — `journal/transcripts/` 디렉토리 |
+
+### Phase 2: CLI 노출
+
+| # | 작업 | 파일 |
+|---|------|------|
+| 6 | `/transcript` 커맨드 | `core/cli/commands.py` — 세션 목록, 특정 세션 조회 |
+| 7 | `/snapshot` 커맨드 | `core/cli/commands.py` — 기존 SnapshotManager CLI 노출 |
+
+## 5. 기존 SnapshotManager 유지 전략
+
+SnapshotManager(Tier 3)는 **게임 IP 도메인 파이프라인 전용**으로 유지한다. 범용 작업에는 Transcript(Tier 1) + Journal(Tier 2)이 대체한다.
+
+| 컴포넌트 | 역할 | 변경 |
+|----------|------|------|
+| SnapshotManager | 파이프라인 GeodeState 캡처 | 변경 없음 (유지) |
+| SessionTranscript | 세션 이벤트 스트림 (신규) | REODE 패턴 구현 |
+| ProjectJournal | 프로젝트 수준 요약 (기존) | transcript 인덱싱 추가 |
+| SessionCheckpoint | 세션 재개용 (기존) | 변경 없음 |
+
+## 6. 프론티어 매핑
+
+| 프론티어 | 패턴 | 적용 |
+|---------|------|------|
+| REODE | SessionTranscript JSONL | Tier 1 그대로 채택 |
+| Karpathy P4 | Ratchet (best-so-far) | Journal learned.md tier tracking |
+| Karpathy P6 | Context Budget (L1-L3) | 텍스트 절단 정책 (500/300자) |
+| OpenClaw | RunLog JSONL + pruning | Transcript 30일 + 5MB 정리 |
+| LangGraph | SqliteSaver per-node | Tier 3 SnapshotManager (유지) |

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,0 +1,182 @@
+"""Tests for SessionTranscript — Tier 1 JSONL event stream."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from core.cli.transcript import (
+    MAX_INPUT_CHARS,
+    MAX_TEXT_CHARS,
+    SessionTranscript,
+    _truncate,
+    cleanup_old_transcripts,
+)
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self):
+        assert _truncate("hello", 100) == "hello"
+
+    def test_long_text_truncated(self):
+        result = _truncate("a" * 600, 500)
+        assert len(result) == 500
+        assert result.endswith("...")
+
+    def test_exact_limit(self):
+        assert _truncate("a" * 500, 500) == "a" * 500
+
+
+class TestSessionTranscript:
+    def test_record_session_lifecycle(self, tmp_path):
+        tx = SessionTranscript("s-test1", tmp_path / "transcripts")
+        tx.record_session_start(model="claude-opus-4-6")
+        tx.record_user_message("hello world")
+        tx.record_assistant_message("hi there")
+        tx.record_session_end(duration_s=5.0, total_cost=0.01, rounds=1)
+
+        events = tx.read_events()
+        assert len(events) == 4
+        assert events[0]["event"] == "session_start"
+        assert events[1]["event"] == "user_message"
+        assert events[1]["text"] == "hello world"
+        assert events[2]["event"] == "assistant_message"
+        assert events[3]["event"] == "session_end"
+        assert events[3]["rounds"] == 1
+
+    def test_record_tool_call_and_result(self, tmp_path):
+        tx = SessionTranscript("s-test2", tmp_path / "transcripts")
+        tx.record_tool_call("web_fetch", {"url": "https://example.com"})
+        tx.record_tool_result("web_fetch", "ok", "page content here")
+
+        events = tx.read_events()
+        assert len(events) == 2
+        assert events[0]["event"] == "tool_call"
+        assert events[0]["tool"] == "web_fetch"
+        assert events[1]["event"] == "tool_result"
+        assert events[1]["status"] == "ok"
+
+    def test_record_vault_save(self, tmp_path):
+        tx = SessionTranscript("s-test3", tmp_path / "transcripts")
+        tx.record_vault_save("vault/profile/report.md", "profile")
+
+        events = tx.read_events()
+        assert len(events) == 1
+        assert events[0]["event"] == "vault_save"
+        assert events[0]["category"] == "profile"
+
+    def test_record_cost(self, tmp_path):
+        tx = SessionTranscript("s-test4", tmp_path / "transcripts")
+        tx.record_cost("claude-opus-4-6", 1200, 350, 0.015)
+
+        events = tx.read_events()
+        assert len(events) == 1
+        assert events[0]["event"] == "cost"
+        assert events[0]["model"] == "claude-opus-4-6"
+        assert events[0]["cost"] == 0.015
+
+    def test_record_error(self, tmp_path):
+        tx = SessionTranscript("s-test5", tmp_path / "transcripts")
+        tx.record_error("timeout", "API call timed out after 30s")
+
+        events = tx.read_events()
+        assert len(events) == 1
+        assert events[0]["event"] == "error"
+        assert events[0]["type"] == "timeout"
+
+    def test_record_subagent(self, tmp_path):
+        tx = SessionTranscript("s-test6", tmp_path / "transcripts")
+        tx.record_subagent_start("task-1", "research")
+        tx.record_subagent_complete("task-1", "ok", "found 3 results")
+
+        events = tx.read_events()
+        assert len(events) == 2
+        assert events[0]["event"] == "subagent_start"
+        assert events[1]["event"] == "subagent_complete"
+
+    def test_text_truncation(self, tmp_path):
+        tx = SessionTranscript("s-trunc", tmp_path / "transcripts")
+        long_text = "x" * 1000
+        tx.record_user_message(long_text)
+
+        events = tx.read_events()
+        assert len(events[0]["text"]) == MAX_TEXT_CHARS
+
+    def test_input_truncation(self, tmp_path):
+        tx = SessionTranscript("s-trunc2", tmp_path / "transcripts")
+        long_input = {"data": "y" * 1000}
+        tx.record_tool_call("test_tool", long_input)
+
+        events = tx.read_events()
+        assert len(events[0]["input"]) <= MAX_INPUT_CHARS
+
+    def test_event_count(self, tmp_path):
+        tx = SessionTranscript("s-count", tmp_path / "transcripts")
+        assert tx.event_count == 0
+        tx.record_user_message("a")
+        tx.record_user_message("b")
+        assert tx.event_count == 2
+
+    def test_read_events_limit(self, tmp_path):
+        tx = SessionTranscript("s-limit", tmp_path / "transcripts")
+        for i in range(20):
+            tx.record_user_message(f"msg {i}")
+
+        events = tx.read_events(limit=5)
+        assert len(events) == 5
+        # Should be most recent 5
+        assert events[-1]["text"] == "msg 19"
+
+    def test_read_empty_transcript(self, tmp_path):
+        tx = SessionTranscript("s-empty", tmp_path / "transcripts")
+        assert tx.read_events() == []
+
+    def test_timestamps_present(self, tmp_path):
+        tx = SessionTranscript("s-ts", tmp_path / "transcripts")
+        tx.record_user_message("test")
+
+        events = tx.read_events()
+        assert "ts" in events[0]
+        assert isinstance(events[0]["ts"], float)
+
+    def test_session_index_updated(self, tmp_path):
+        tx = SessionTranscript("s-idx", tmp_path / "transcripts")
+        tx.record_session_start()
+        tx.record_user_message("test")
+        tx.record_session_end()
+
+        index_path = tmp_path / "transcripts" / "index.json"
+        assert index_path.exists()
+        index = json.loads(index_path.read_text())
+        assert "s-idx" in index["sessions"]
+        assert index["sessions"]["s-idx"]["event_count"] == 3
+
+    def test_file_path(self, tmp_path):
+        tx = SessionTranscript("s-path", tmp_path / "transcripts")
+        assert tx.file_path == tmp_path / "transcripts" / "s-path.jsonl"
+
+
+class TestCleanupOldTranscripts:
+    def test_removes_old_files(self, tmp_path):
+        tdir = tmp_path / "transcripts"
+        tdir.mkdir()
+        # Create old file
+        old_file = tdir / "old-session.jsonl"
+        old_file.write_text('{"event":"test"}\n')
+        # Backdate modification time
+        import os
+
+        old_time = time.time() - 40 * 86400  # 40 days ago
+        os.utime(old_file, (old_time, old_time))
+
+        # Create recent file
+        recent_file = tdir / "recent-session.jsonl"
+        recent_file.write_text('{"event":"test"}\n')
+
+        removed = cleanup_old_transcripts(tdir, max_age_days=30)
+        assert removed == 1
+        assert not old_file.exists()
+        assert recent_file.exists()
+
+    def test_no_op_on_empty_dir(self, tmp_path):
+        assert cleanup_old_transcripts(tmp_path / "nonexistent") == 0


### PR DESCRIPTION
## 요약

- **SessionTranscript (Tier 1)**: JSONL 이벤트 스트림 — 세션별 대화/도구/비용/에러 감사 추적
- **Snapshot 재설계 계획**: 3-Tier 보존 체계 (Transcript → Journal → Snapshot)
- **REODE 워크플로우 6건 이식**: 3-Checkpoint 칸반, .owner, main-only, docs-sync 2중, PR body 엄격 규칙

## 변경 사항

### 핵심
- `core/cli/transcript.py` (신규) — SessionTranscript: 12개 이벤트 타입, 텍스트 절단(500/300자), 30일 cleanup, index.json
- `core/cli/__init__.py` — `geode init`에 `journal/transcripts/` 추가
- `CLAUDE.md` — Step 0 .owner 보호, Step 4 docs-sync 2중, Step 5 PR body 엄격, Step 6 3-checkpoint 칸반

### 문서
- `docs/plans/snapshot-redesign.md` — 3-Tier 보존 체계 설계
- `docs/progress.md` — Backlog 4건 추가, Done 갱신, 규칙 9항 강화

## Pre-PR Quality Gate
- [x] ruff: 0 errors
- [x] mypy: 0 errors (172 files)
- [x] pytest: 2759 passed
- [x] pre-commit: all passed