### PR TITLE
feat: IP 보고서 보강 — 테스트 + 검증팀 수정 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
 
 ### Added
+- IP 보고서 상세 섹션 보강 — Analyst Reasoning, Cross-LLM Verification, Rights Risk, Decision Tree Classification 4개 섹션 추가
+- 보고서 하위 섹션 — Scoring Breakdown, BiasBuster, Signals, PSM Engine, Evidence Chain, Axis Breakdown
 - Multi-Provider LLM — ZhipuAI GLM-5 (glm-5, glm-5-turbo, glm-4.7-flash) 프로바이더 추가, OpenAI-compatible API 활용
 - `.env` Setup Wizard — .env 미존재 시 대화형 API 키 입력 (Anthropic/OpenAI/ZhipuAI, Enter 스킵, Ctrl+C 중단)
 - 자연어 API 키 탐지 — REPL 자유 텍스트에 `sk-ant-*`, `sk-*`, `{hex}.{hex}` 패턴 감지 → 자동 키 등록, LLM 전송 방지

--- a/core/extensibility/reports.py
+++ b/core/extensibility/reports.py
@@ -243,6 +243,29 @@ def _format_analyses_md(analyses: list[dict[str, Any]]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Evaluator data extraction helper
+# ---------------------------------------------------------------------------
+
+
+def _extract_eval_fields(ev: Any) -> tuple[float, str, dict[str, Any]]:
+    """Extract (composite_score, rationale, axes) from a dict or Pydantic object.
+
+    Evaluator results may arrive as plain dicts (from JSON deserialization) or
+    as Pydantic model instances.  This helper normalises access so callers
+    don't need to repeat the isinstance/getattr dispatch.
+    """
+    if isinstance(ev, dict):
+        composite: float = ev.get("composite_score", 0)
+        rationale: str = ev.get("rationale", "")
+        axes: dict[str, Any] = ev.get("axes", {})
+    else:
+        composite = getattr(ev, "composite_score", 0)
+        rationale = getattr(ev, "rationale", "")
+        axes = getattr(ev, "axes", {})
+    return composite, rationale, axes
+
+
+# ---------------------------------------------------------------------------
 # Evaluator formatters
 # ---------------------------------------------------------------------------
 
@@ -252,14 +275,7 @@ def _format_evaluators_html(evaluations: dict[str, Any]) -> str:
         return ""
     rows = ""
     for etype, ev in evaluations.items():
-        if isinstance(ev, dict):
-            composite = ev.get("composite_score", 0)
-            rationale = ev.get("rationale", "")
-            axes = ev.get("axes", {})
-        else:
-            composite = getattr(ev, "composite_score", 0)
-            rationale = getattr(ev, "rationale", "")
-            axes = getattr(ev, "axes", {})
+        composite, rationale, axes = _extract_eval_fields(ev)
         axes_str = ", ".join(f"{k}: {v:.1f}" for k, v in axes.items()) if axes else "---"
         rows += (
             f"      <tr><td style='font-weight:600'>{etype}</td>"
@@ -287,14 +303,7 @@ def _format_evaluators_md(evaluations: dict[str, Any]) -> str:
         "| --- | ---: | --- |",
     ]
     for etype, ev in evaluations.items():
-        if isinstance(ev, dict):
-            composite = ev.get("composite_score", 0)
-            rationale = ev.get("rationale", "")
-            axes = ev.get("axes", {})
-        else:
-            composite = getattr(ev, "composite_score", 0)
-            rationale = getattr(ev, "rationale", "")
-            axes = getattr(ev, "axes", {})
+        composite, rationale, axes = _extract_eval_fields(ev)
         lines.append(f"| {etype} | {composite:.1f} | {rationale[:80]} |")
 
     # Axis breakdown per evaluator
@@ -302,7 +311,7 @@ def _format_evaluators_md(evaluations: dict[str, Any]) -> str:
     lines.append("### Axis Breakdown")
     lines.append("")
     for etype, ev in evaluations.items():
-        axes = ev.get("axes", {}) if isinstance(ev, dict) else getattr(ev, "axes", {})
+        _, _, axes = _extract_eval_fields(ev)
         if axes:
             lines.append(f"**{etype}**:")
             for axis_name, axis_val in axes.items():
@@ -796,7 +805,7 @@ def _format_decision_tree_md(synthesis: dict[str, Any], evaluations: dict[str, A
         return ""
     # Extract D/E/F from hidden_value evaluator
     hv = evaluations.get("hidden_value", {})
-    axes = hv.get("axes", {}) if isinstance(hv, dict) else getattr(hv, "axes", {})
+    _, _, axes = _extract_eval_fields(hv)
     d = axes.get("d_score", axes.get("D", "?"))
     e = axes.get("e_score", axes.get("E", "?"))
     f = axes.get("f_score", axes.get("F", "?"))
@@ -826,7 +835,7 @@ def _format_decision_tree_html(synthesis: dict[str, Any], evaluations: dict[str,
     if not cause or not evaluations:
         return ""
     hv = evaluations.get("hidden_value", {})
-    axes = hv.get("axes", {}) if isinstance(hv, dict) else getattr(hv, "axes", {})
+    _, _, axes = _extract_eval_fields(hv)
     d = axes.get("d_score", axes.get("D", "?"))
     e = axes.get("e_score", axes.get("E", "?"))
     f = axes.get("f_score", axes.get("F", "?"))

--- a/core/extensibility/reports.py
+++ b/core/extensibility/reports.py
@@ -76,10 +76,10 @@ _SUBSCORE_BARS = [
 
 def _tier_class(tier: str) -> str:
     """Map tier string to CSS class."""
-    tier_lower = tier.upper()
-    if tier_lower in ("S", "A"):
+    tier_upper = tier.upper()
+    if tier_upper in ("S", "A"):
         return "tier-high"
-    if tier_lower in ("B",):
+    if tier_upper in ("B",):
         return "tier-mid"
     return "tier-low"
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -10,6 +10,14 @@ from core.extensibility.reports import (
     ReportFormat,
     ReportGenerator,
     ReportTemplate,
+    _format_analyst_reasoning_html,
+    _format_analyst_reasoning_md,
+    _format_cross_llm_html,
+    _format_cross_llm_md,
+    _format_decision_tree_html,
+    _format_decision_tree_md,
+    _format_rights_risk_html,
+    _format_rights_risk_md,
 )
 
 # ---------------------------------------------------------------------------
@@ -41,12 +49,18 @@ _SAMPLE_RESULT: dict[str, Any] = {
             "score": 4.2,
             "key_finding": "Strong gameplay loop",
             "confidence": 85.0,
+            "reasoning": "The core loop rewards mastery through progressive difficulty scaling.",
+            "evidence": ["Steam reviews cite 'addictive loop'", "Average session 3.2h"],
+            "model_provider": "claude-opus-4-6",
         },
         {
             "analyst_type": "market_position",
             "score": 3.5,
             "key_finding": "Crowded segment",
             "confidence": 78.0,
+            "reasoning": "Competing against 12 titles in the same sub-genre released this quarter.",
+            "evidence": ["SteamSpy genre overlap 68%", "Metacritic median 74"],
+            "model_provider": "gpt-5.4",
         },
     ],
     "evaluations": {
@@ -61,6 +75,12 @@ _SAMPLE_RESULT: dict[str, Any] = {
             "composite_score": 80.0,
             "rationale": "High production value with polished mechanics.",
             "axes": {"a_score": 4.5, "b_score": 3.9},
+        },
+        "hidden_value": {
+            "evaluator_type": "hidden_value",
+            "composite_score": 71.0,
+            "rationale": "Strong discovery but limited monetization path.",
+            "axes": {"d_score": 3.5, "e_score": 2.8, "f_score": 4.0},
         },
     },
     "psm_result": {
@@ -100,6 +120,22 @@ _SAMPLE_RESULT: dict[str, Any] = {
         "mod_patch_activity": "medium",
         "genre_fit_keywords": ["action RPG", "souls-like"],
         "game_sales_data": "~100K units",
+    },
+    "cross_llm": {
+        "cross_llm_agreement": 0.82,
+        "models_compared": ["claude-opus-4-6", "gpt-5.4"],
+        "passed": True,
+        "verification_mode": "full_rescore",
+        "secondary_score": 76.3,
+    },
+    "rights_risk": {
+        "status": "NEGOTIABLE",
+        "risk_score": 35,
+        "concerns": [
+            "Existing exclusive console license until 2027",
+            "Partial rights held by third-party publisher",
+        ],
+        "recommendation": "Negotiate limited digital distribution rights with current holder.",
     },
 }
 
@@ -369,3 +405,359 @@ class TestHtmlReport:
         )
         assert "Unknown IP" in report
         assert "0.0" in report
+
+
+# ---------------------------------------------------------------------------
+# Cross-LLM Verification formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrossLlmMd:
+    def test_populated_data(self):
+        result = _format_cross_llm_md(_SAMPLE_RESULT["cross_llm"])
+        assert "## Cross-LLM Verification" in result
+        assert "0.82" in result
+        assert "PASS" in result
+        assert "full_rescore" in result
+        assert "claude-opus-4-6" in result
+        assert "gpt-5.4" in result
+        assert "76.3" in result
+
+    def test_empty_data(self):
+        assert _format_cross_llm_md({}) == ""
+
+    def test_failed_agreement(self):
+        data = {
+            "cross_llm_agreement": 0.45,
+            "models_compared": ["claude-opus-4-6", "gpt-5.4"],
+            "passed": False,
+            "verification_mode": "spot_check",
+        }
+        result = _format_cross_llm_md(data)
+        assert "FAIL" in result
+        assert "0.45" in result
+        assert "spot_check" in result
+
+    def test_no_secondary_score(self):
+        data = {
+            "cross_llm_agreement": 0.90,
+            "models_compared": [],
+            "passed": True,
+            "verification_mode": "full_rescore",
+        }
+        result = _format_cross_llm_md(data)
+        assert "Secondary" not in result
+
+
+class TestCrossLlmHtml:
+    def test_populated_data(self):
+        result = _format_cross_llm_html(_SAMPLE_RESULT["cross_llm"])
+        assert "Cross-LLM Verification" in result
+        assert "0.82" in result
+        assert "verify-pass" in result
+        assert "full_rescore" in result
+        assert "claude-opus-4-6, gpt-5.4" in result
+
+    def test_empty_data(self):
+        assert _format_cross_llm_html({}) == ""
+
+    def test_failed_badge(self):
+        data = {
+            "cross_llm_agreement": 0.30,
+            "models_compared": [],
+            "passed": False,
+            "verification_mode": "spot_check",
+        }
+        result = _format_cross_llm_html(data)
+        assert "verify-fail" in result
+
+
+class TestCrossLlmIntegration:
+    """Cross-LLM sections appear in full detailed reports."""
+
+    def test_detailed_md_includes_cross_llm(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.MARKDOWN,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Cross-LLM Verification" in report
+        assert "0.82" in report
+
+    def test_detailed_html_includes_cross_llm(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.HTML,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Cross-LLM Verification" in report
+
+    def test_detailed_json_includes_cross_llm(self, generator: ReportGenerator):
+        raw = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.JSON,
+            template=ReportTemplate.DETAILED,
+        )
+        data = json.loads(raw)
+        assert "cross_llm" in data
+        assert data["cross_llm"]["cross_llm_agreement"] == 0.82
+
+
+# ---------------------------------------------------------------------------
+# Rights Risk formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestRightsRiskMd:
+    def test_populated_data(self):
+        result = _format_rights_risk_md(_SAMPLE_RESULT["rights_risk"])
+        assert "## IP Rights Risk" in result
+        assert "NEGOTIABLE" in result
+        assert "35/100" in result
+        assert "Existing exclusive console license until 2027" in result
+        assert "Partial rights held by third-party publisher" in result
+        assert "Negotiate limited digital distribution" in result
+
+    def test_empty_data(self):
+        assert _format_rights_risk_md({}) == ""
+
+    def test_clear_status(self):
+        data = {"status": "CLEAR", "risk_score": 5, "concerns": []}
+        result = _format_rights_risk_md(data)
+        assert "CLEAR" in result
+        assert "5/100" in result
+        assert "Concerns" not in result
+
+    def test_no_recommendation(self):
+        data = {"status": "RESTRICTED", "risk_score": 90, "concerns": ["All rights held"]}
+        result = _format_rights_risk_md(data)
+        assert "RESTRICTED" in result
+        assert "All rights held" in result
+
+
+class TestRightsRiskHtml:
+    def test_populated_data(self):
+        result = _format_rights_risk_html(_SAMPLE_RESULT["rights_risk"])
+        assert "IP Rights Risk" in result
+        assert "NEGOTIABLE" in result
+        assert "35/100" in result
+        assert "Existing exclusive console license until 2027" in result
+        assert "Negotiate limited digital distribution" in result
+
+    def test_empty_data(self):
+        assert _format_rights_risk_html({}) == ""
+
+    def test_color_coding_clear(self):
+        data = {"status": "CLEAR", "risk_score": 5, "concerns": []}
+        result = _format_rights_risk_html(data)
+        assert "#16a34a" in result  # green
+
+    def test_color_coding_restricted(self):
+        data = {"status": "RESTRICTED", "risk_score": 90, "concerns": []}
+        result = _format_rights_risk_html(data)
+        assert "#dc2626" in result  # red
+
+    def test_color_coding_negotiable(self):
+        data = {"status": "NEGOTIABLE", "risk_score": 40, "concerns": []}
+        result = _format_rights_risk_html(data)
+        assert "#eab308" in result  # yellow
+
+
+class TestRightsRiskIntegration:
+    """Rights risk sections appear in full detailed reports."""
+
+    def test_detailed_md_includes_rights_risk(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.MARKDOWN,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "IP Rights Risk" in report
+        assert "NEGOTIABLE" in report
+
+    def test_detailed_html_includes_rights_risk(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.HTML,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "IP Rights Risk" in report
+
+    def test_detailed_json_includes_rights_risk(self, generator: ReportGenerator):
+        raw = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.JSON,
+            template=ReportTemplate.DETAILED,
+        )
+        data = json.loads(raw)
+        assert "rights_risk" in data
+        assert data["rights_risk"]["status"] == "NEGOTIABLE"
+
+
+# ---------------------------------------------------------------------------
+# Analyst Reasoning formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalystReasoningMd:
+    def test_populated_data(self):
+        result = _format_analyst_reasoning_md(_SAMPLE_RESULT["analyses"])
+        assert "## Analyst Reasoning" in result
+        assert "### game_mechanics" in result
+        assert "(claude-opus-4-6)" in result
+        assert "core loop rewards mastery" in result
+        assert "Steam reviews cite 'addictive loop'" in result
+        assert "Average session 3.2h" in result
+        assert "### market_position" in result
+        assert "(gpt-5.4)" in result
+        assert "Competing against 12 titles" in result
+        assert "SteamSpy genre overlap 68%" in result
+
+    def test_empty_list(self):
+        assert _format_analyst_reasoning_md([]) == ""
+
+    def test_no_reasoning(self):
+        """Analysts without reasoning should produce empty output."""
+        analyses = [
+            {"analyst_type": "test", "score": 3.0, "key_finding": "ok"},
+        ]
+        assert _format_analyst_reasoning_md(analyses) == ""
+
+    def test_partial_reasoning(self):
+        """Only analysts with reasoning/evidence should appear."""
+        analyses = [
+            {
+                "analyst_type": "has_reasoning",
+                "score": 4.0,
+                "reasoning": "Good analysis",
+                "evidence": ["ev1"],
+            },
+            {"analyst_type": "no_reasoning", "score": 3.0},
+        ]
+        result = _format_analyst_reasoning_md(analyses)
+        assert "has_reasoning" in result
+        assert "no_reasoning" not in result
+
+
+class TestAnalystReasoningHtml:
+    def test_populated_data(self):
+        result = _format_analyst_reasoning_html(_SAMPLE_RESULT["analyses"])
+        assert "Analyst Reasoning" in result
+        assert "game_mechanics" in result
+        assert "claude-opus-4-6" in result
+        assert "core loop rewards mastery" in result
+        assert "<li>" in result  # evidence list items
+        assert "Steam reviews" in result
+
+    def test_empty_list(self):
+        assert _format_analyst_reasoning_html([]) == ""
+
+    def test_no_reasoning(self):
+        analyses = [{"analyst_type": "test", "score": 3.0}]
+        assert _format_analyst_reasoning_html(analyses) == ""
+
+
+class TestAnalystReasoningIntegration:
+    """Analyst reasoning sections in full detailed reports."""
+
+    def test_detailed_md_includes_reasoning(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.MARKDOWN,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Analyst Reasoning" in report
+        assert "core loop rewards mastery" in report
+
+    def test_detailed_html_includes_reasoning(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.HTML,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Analyst Reasoning" in report
+
+    def test_evidence_chain_in_analyses_md(self, generator: ReportGenerator):
+        """The Evidence Chain sub-section should also appear in _format_analyses_md."""
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.MARKDOWN,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Evidence Chain" in report
+        assert "Steam reviews cite 'addictive loop'" in report
+
+
+# ---------------------------------------------------------------------------
+# Decision Tree formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionTreeMd:
+    def test_populated_data(self):
+        result = _format_decision_tree_md(
+            _SAMPLE_RESULT["synthesis"],
+            _SAMPLE_RESULT["evaluations"],
+        )
+        assert "## Cause Classification Logic" in result
+        assert "D (Discovery Difficulty): 3.5" in result
+        assert "E (Monetization Capability): 2.8" in result
+        assert "F (Franchise Expandability): 4.0" in result
+        assert "`undermarketed`" in result
+        assert "Decision Tree:" in result
+
+    def test_empty_synthesis(self):
+        assert _format_decision_tree_md({}, _SAMPLE_RESULT["evaluations"]) == ""
+
+    def test_no_cause(self):
+        synthesis = {"action_type": "marketing_boost"}
+        assert _format_decision_tree_md(synthesis, _SAMPLE_RESULT["evaluations"]) == ""
+
+    def test_no_evaluations(self):
+        assert _format_decision_tree_md(_SAMPLE_RESULT["synthesis"], {}) == ""
+
+    def test_missing_hidden_value(self):
+        """When hidden_value evaluator is missing, axes default to '?'."""
+        evals = {"market_evaluator": _SAMPLE_RESULT["evaluations"]["market_evaluator"]}
+        result = _format_decision_tree_md(_SAMPLE_RESULT["synthesis"], evals)
+        assert "D (Discovery Difficulty): ?" in result
+
+
+class TestDecisionTreeHtml:
+    def test_populated_data(self):
+        result = _format_decision_tree_html(
+            _SAMPLE_RESULT["synthesis"],
+            _SAMPLE_RESULT["evaluations"],
+        )
+        assert "Cause Classification Logic" in result
+        assert "3.5" in result  # d_score
+        assert "2.8" in result  # e_score
+        assert "4.0" in result  # f_score
+        assert "<code>undermarketed</code>" in result
+
+    def test_empty_synthesis(self):
+        assert _format_decision_tree_html({}, _SAMPLE_RESULT["evaluations"]) == ""
+
+    def test_no_evaluations(self):
+        assert _format_decision_tree_html(_SAMPLE_RESULT["synthesis"], {}) == ""
+
+
+class TestDecisionTreeIntegration:
+    """Decision tree sections in full detailed reports."""
+
+    def test_detailed_md_includes_decision_tree(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.MARKDOWN,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Cause Classification Logic" in report
+        assert "undermarketed" in report
+
+    def test_detailed_html_includes_decision_tree(self, generator: ReportGenerator):
+        report = generator.generate(
+            _SAMPLE_RESULT,
+            fmt=ReportFormat.HTML,
+            template=ReportTemplate.DETAILED,
+        )
+        assert "Cause Classification Logic" in report


### PR DESCRIPTION
## Summary
- IP 보고서 상세 섹션 4개 (Analyst Reasoning, Cross-LLM, Rights Risk, Decision Tree) + 하위 섹션 6개 추가
- 36개 테스트 추가 (12 classes) — cross_llm, rights_risk, reasoning, decision_tree 양성/음성/통합
- 검증팀(Beck) P1 수정: evaluator 데이터 추출 4곳 중복 → `_extract_eval_fields()` 헬퍼 추출
- CHANGELOG `[Unreleased]` 항목 추가

## Why
- DAG 파이프라인이 풍부한 분석 결과를 생산하지만, 보고서가 빈약했음
- 검증팀 4인 페르소나 리뷰에서 코드 중복(P1) + 테스트 갭(P1) 발견
- P0 이슈 없음, P2는 후속 리팩토링으로 유예 (24개 포매터 과잉, HTML 이스케이프, 보고서 크기 제어)

## Changed Files
| 파일 | Why |
|------|-----|
| `core/extensibility/reports.py` | 보고서 포매터 4+6개 섹션 추가 + `_extract_eval_fields()` 헬퍼 추출 |
| `core/extensibility/templates/report.html` | HTML 템플릿에 신규 섹션 placeholder 추가 |
| `core/extensibility/templates/report_detailed.md` | Markdown 템플릿에 신규 섹션 placeholder 추가 |
| `tests/test_reports.py` | 36개 테스트 추가 (4개 섹션 × md/html/integration) |
| `CHANGELOG.md` | 보고서 보강 섹션 기록 |

## Test Plan
- [x] `uv run ruff check core/extensibility/reports.py` — 0 errors
- [x] `uv run mypy core/extensibility/reports.py` — 0 errors
- [x] `uv run pytest tests/test_reports.py -q` — 66 passed
- [x] `uv run pytest tests/ -q` — 2856 passed
- [x] 검증팀 4인 리뷰 (Beck/Karpathy/Steinberger/Cherny) — P0 없음, P1 수정 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)