### PR TITLE
fix: 멀티모델 GAP — 테스트 + P0 보안 수정 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
 
 ### Added
+- `.env` 자동 생성 — `.env.example` 기반 atomic write (tmp+rename, chmod 0o600), placeholder 자동 제거
+- `/model` 전환 시 프로바이더 키 검증 — 해당 프로바이더 API 키 미설정 시 경고 표시
 - Multi-Provider LLM — ZhipuAI GLM-5 (glm-5, glm-5-turbo, glm-4.7-flash) 프로바이더 추가, OpenAI-compatible API 활용
 - `.env` Setup Wizard — .env 미존재 시 대화형 API 키 입력 (Anthropic/OpenAI/ZhipuAI, Enter 스킵, Ctrl+C 중단)
 - 자연어 API 키 탐지 — REPL 자유 텍스트에 `sk-ant-*`, `sk-*`, `{hex}.{hex}` 패턴 감지 → 자동 키 등록, LLM 전송 방지
@@ -39,6 +41,8 @@ P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
 - MODEL_PROFILES에 GLM-5, GLM-5 Turbo, GLM-4.7 Flash 추가
 
 ### Fixed
+- `.env` 파일 보안 — atomic write (tmp+rename) + chmod 0o600 파일 권한 제한
+- placeholder 검증 로직 통일 — `_is_placeholder()` 단일 소스로 `_has_any_llm_key()`/`_check_provider_key()` 일관성 확보
 - AgenticLoop 모델 캐싱 버그 — `/model` 변경이 `_call_llm()`에 반영되지 않던 문제 수정 (`update_model()` 메서드 추가)
 - `check_readiness()` ANY 프로바이더 키 unblock — Anthropic 키 없어도 OpenAI/GLM 키만으로 전체 모드 동작
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -238,6 +238,7 @@ def cmd_key(args: str) -> bool:
 
 def _check_provider_key(selected: ModelProfile) -> None:
     """Warn if the provider's API key is not set for the selected model."""
+    from core.cli.startup import _is_placeholder
     from core.config import settings
 
     provider_key_map: dict[str, tuple[str, str]] = {
@@ -249,7 +250,7 @@ def _check_provider_key(selected: ModelProfile) -> None:
     if entry is None:
         return
     key_value, env_var = entry
-    if not key_value or key_value in ("sk-ant-...", "sk-...", "..."):
+    if not key_value or _is_placeholder(key_value):
         console.print(f"  [warning]Warning: {env_var} not set. Model may not work.[/warning]")
 
 

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -59,7 +59,10 @@ def auto_generate_env(project_root: Path | None = None) -> bool:
         else:
             lines.append(line)
 
-    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    tmp_path = env_path.with_suffix(".tmp")
+    tmp_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    tmp_path.chmod(0o600)
+    tmp_path.replace(env_path)
     log.info(".env auto-generated from .env.example")
     return True
 
@@ -75,11 +78,11 @@ def _is_placeholder(value: str) -> bool:
 
 def _has_any_llm_key() -> bool:
     """Check if ANY LLM provider API key is configured."""
-    if settings.anthropic_api_key and settings.anthropic_api_key != "sk-ant-...":
+    if settings.anthropic_api_key and not _is_placeholder(settings.anthropic_api_key):
         return True
-    if settings.openai_api_key and settings.openai_api_key != "sk-...":
+    if settings.openai_api_key and not _is_placeholder(settings.openai_api_key):
         return True
-    return bool(settings.zai_api_key and settings.zai_api_key != "...")
+    return bool(settings.zai_api_key and not _is_placeholder(settings.zai_api_key))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 from core.cli.commands import (
     COMMAND_MAP,
     MODEL_PROFILES,
+    ModelProfile,
     _apply_model,
     _budget_bar,
+    _check_provider_key,
     _get_cost_budget,
     _mask_key,
     _set_cost_budget,
@@ -407,3 +409,93 @@ class TestCostBudgetPersistence:
         _set_cost_budget(50.0)
         _set_cost_budget(100.0)
         assert _get_cost_budget() == 100.0
+
+
+class TestCheckProviderKey:
+    """Test _check_provider_key warns when provider API key is missing."""
+
+    def test_warns_missing_anthropic_key(self):
+        """Switching to Anthropic model without key should warn."""
+        from core.config import settings
+
+        profile = ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.6", "$$$")
+        old = (settings.anthropic_api_key, settings.openai_api_key, settings.zai_api_key)
+        try:
+            settings.anthropic_api_key = ""
+            settings.openai_api_key = "sk-proj-real"
+            settings.zai_api_key = "real-glm-key"
+            with patch("core.cli.commands.console") as mock_console:
+                _check_provider_key(profile)
+                mock_console.print.assert_called_once()
+                call_arg = mock_console.print.call_args[0][0]
+                assert "ANTHROPIC_API_KEY" in call_arg
+                assert "Warning" in call_arg
+        finally:
+            settings.anthropic_api_key, settings.openai_api_key, settings.zai_api_key = old
+
+    def test_warns_placeholder_anthropic_key(self):
+        """Placeholder 'sk-ant-...' should also trigger warning."""
+        from core.config import settings
+
+        profile = ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.6", "$$$")
+        old = settings.anthropic_api_key
+        try:
+            settings.anthropic_api_key = "sk-ant-..."
+            with patch("core.cli.commands.console") as mock_console:
+                _check_provider_key(profile)
+                mock_console.print.assert_called_once()
+        finally:
+            settings.anthropic_api_key = old
+
+    def test_warns_missing_openai_key(self):
+        """Switching to OpenAI model without key should warn."""
+        from core.config import settings
+
+        profile = ModelProfile(OPENAI_PRIMARY, "OpenAI", "GPT-5.4", "$$")
+        old = settings.openai_api_key
+        try:
+            settings.openai_api_key = ""
+            with patch("core.cli.commands.console") as mock_console:
+                _check_provider_key(profile)
+                mock_console.print.assert_called_once()
+                call_arg = mock_console.print.call_args[0][0]
+                assert "OPENAI_API_KEY" in call_arg
+        finally:
+            settings.openai_api_key = old
+
+    def test_warns_missing_glm_key(self):
+        """Switching to ZhipuAI model without key should warn."""
+        from core.config import GLM_PRIMARY, settings
+
+        profile = ModelProfile(GLM_PRIMARY, "ZhipuAI", "GLM-5", "$")
+        old = settings.zai_api_key
+        try:
+            settings.zai_api_key = ""
+            with patch("core.cli.commands.console") as mock_console:
+                _check_provider_key(profile)
+                mock_console.print.assert_called_once()
+                call_arg = mock_console.print.call_args[0][0]
+                assert "ZAI_API_KEY" in call_arg
+        finally:
+            settings.zai_api_key = old
+
+    def test_no_warning_when_key_present(self):
+        """Valid key present — no warning should be emitted."""
+        from core.config import settings
+
+        profile = ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.6", "$$$")
+        old = settings.anthropic_api_key
+        try:
+            settings.anthropic_api_key = "sk-ant-real-key-123456"
+            with patch("core.cli.commands.console") as mock_console:
+                _check_provider_key(profile)
+                mock_console.print.assert_not_called()
+        finally:
+            settings.anthropic_api_key = old
+
+    def test_unknown_provider_no_warning(self):
+        """Unknown provider should not crash or warn."""
+        profile = ModelProfile("custom-model", "CustomProvider", "Custom", "$")
+        with patch("core.cli.commands.console") as mock_console:
+            _check_provider_key(profile)
+            mock_console.print.assert_not_called()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -294,6 +294,29 @@ class TestAutoGenerateEnv:
         # Non-placeholder value should remain
         assert "DEBUG=true" in content
 
+    def test_env_file_permissions(self, tmp_path: Path):
+        """P0-1: .env must have 0o600 permissions (owner read/write only)."""
+        from core.cli.startup import auto_generate_env
+
+        example = tmp_path / ".env.example"
+        example.write_text("KEY=sk-ant-...\n")
+
+        auto_generate_env(tmp_path)
+        env = tmp_path / ".env"
+        mode = env.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_atomic_write_no_partial(self, tmp_path: Path):
+        """P0-2: .env should not exist as .tmp after successful write."""
+        from core.cli.startup import auto_generate_env
+
+        example = tmp_path / ".env.example"
+        example.write_text("KEY=value\n")
+
+        auto_generate_env(tmp_path)
+        assert not (tmp_path / ".env.tmp").exists()
+        assert (tmp_path / ".env").exists()
+
     def test_skips_existing_env(self, tmp_path: Path):
         from core.cli.startup import auto_generate_env
 
@@ -334,13 +357,10 @@ class TestAutoGenerateEnv:
         content = (tmp_path / ".env").read_text()
         lines = content.strip().split("\n")
 
-        # Placeholders become empty
-        assert "ANTHROPIC_API_KEY=" in lines[0]
-        assert "sk-ant-..." not in lines[0]
-        assert "OPENAI_API_KEY=" in lines[1]
-        assert "sk-..." not in lines[1]
-        assert "ZAI_API_KEY=" in lines[2]
-        assert lines[2].endswith("=")
+        # Placeholders become empty — assert value after '=' is empty
+        assert lines[0] == "ANTHROPIC_API_KEY="
+        assert lines[1] == "OPENAI_API_KEY="
+        assert lines[2] == "ZAI_API_KEY="
 
         # Non-placeholders preserved
         assert "DEBUG=true" in content

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -241,6 +241,126 @@ class TestEnvSetupWizard:
         assert result is False
 
 
+class TestIsPlaceholder:
+    """Test _is_placeholder helper."""
+
+    def test_ellipsis_exact(self):
+        from core.cli.startup import _is_placeholder
+
+        assert _is_placeholder("...") is True
+
+    def test_prefixed_ellipsis(self):
+        from core.cli.startup import _is_placeholder
+
+        assert _is_placeholder("sk-ant-...") is True
+        assert _is_placeholder("sk-...") is True
+        assert _is_placeholder("lsv2_pt_...") is True
+        assert _is_placeholder("BSA...") is True
+
+    def test_real_value_not_placeholder(self):
+        from core.cli.startup import _is_placeholder
+
+        assert _is_placeholder("sk-ant-api03-realkey123456789") is False
+        assert _is_placeholder("") is False
+        assert _is_placeholder("some-real-key") is False
+        assert _is_placeholder("true") is False
+
+    def test_trailing_dots_not_three(self):
+        from core.cli.startup import _is_placeholder
+
+        # Only exactly "..." at end counts
+        assert _is_placeholder("value..") is False
+        assert _is_placeholder("value.") is False
+
+
+class TestAutoGenerateEnv:
+    """Test auto_generate_env function."""
+
+    def test_creates_env_from_example(self, tmp_path: Path):
+        from core.cli.startup import auto_generate_env
+
+        example = tmp_path / ".env.example"
+        example.write_text("ANTHROPIC_API_KEY=sk-ant-...\nDEBUG=true\n")
+
+        result = auto_generate_env(tmp_path)
+        assert result is True
+
+        env = tmp_path / ".env"
+        assert env.exists()
+        content = env.read_text()
+        assert "ANTHROPIC_API_KEY=" in content
+        # Placeholder should be replaced with empty value
+        assert "sk-ant-..." not in content
+        # Non-placeholder value should remain
+        assert "DEBUG=true" in content
+
+    def test_skips_existing_env(self, tmp_path: Path):
+        from core.cli.startup import auto_generate_env
+
+        example = tmp_path / ".env.example"
+        example.write_text("KEY=sk-...\n")
+        env = tmp_path / ".env"
+        env.write_text("KEY=my-real-key\n")
+
+        result = auto_generate_env(tmp_path)
+        assert result is False
+        # Original .env should be untouched
+        assert env.read_text() == "KEY=my-real-key\n"
+
+    def test_no_example_file(self, tmp_path: Path):
+        from core.cli.startup import auto_generate_env
+
+        # Neither .env nor .env.example exist
+        result = auto_generate_env(tmp_path)
+        assert result is False
+        assert not (tmp_path / ".env").exists()
+
+    def test_replaces_placeholders(self, tmp_path: Path):
+        from core.cli.startup import auto_generate_env
+
+        example = tmp_path / ".env.example"
+        example.write_text(
+            "ANTHROPIC_API_KEY=sk-ant-...\n"
+            "OPENAI_API_KEY=sk-...\n"
+            "ZAI_API_KEY=...\n"
+            "DEBUG=true\n"
+            "# This is a comment\n"
+            "GEODE_MODEL=claude-opus-4-6\n"
+        )
+
+        result = auto_generate_env(tmp_path)
+        assert result is True
+
+        content = (tmp_path / ".env").read_text()
+        lines = content.strip().split("\n")
+
+        # Placeholders become empty
+        assert "ANTHROPIC_API_KEY=" in lines[0]
+        assert "sk-ant-..." not in lines[0]
+        assert "OPENAI_API_KEY=" in lines[1]
+        assert "sk-..." not in lines[1]
+        assert "ZAI_API_KEY=" in lines[2]
+        assert lines[2].endswith("=")
+
+        # Non-placeholders preserved
+        assert "DEBUG=true" in content
+        assert "# This is a comment" in content
+        assert "GEODE_MODEL=claude-opus-4-6" in content
+
+    def test_preserves_comments(self, tmp_path: Path):
+        from core.cli.startup import auto_generate_env
+
+        example = tmp_path / ".env.example"
+        example.write_text(
+            "# Anthropic\nANTHROPIC_API_KEY=sk-ant-...\n\n# OpenAI\nOPENAI_API_KEY=sk-...\n"
+        )
+
+        auto_generate_env(tmp_path)
+        content = (tmp_path / ".env").read_text()
+        assert "# Anthropic" in content
+        assert "# OpenAI" in content
+
+
 class TestResolveProvider:
     """Test _resolve_provider helper."""
 


### PR DESCRIPTION
## Summary
- `.env` 자동 생성 + 키 검증 기능에 대한 17개 테스트 추가 (3 classes)
- 검증팀 P0 수정: atomic write (tmp+rename) + chmod 0o600 파일 권한 보안
- 검증팀 P1 수정: placeholder 검증 로직 `_is_placeholder()` 단일 소스 통일
- CHANGELOG `[Unreleased]` 항목 추가

## Why
- P0 (Beck/Steinberger): `.env` 파일이 world-readable 권한으로 생성되어 credential 유출 위험
- P0 (Steinberger): 비정상 종료 시 `.env` 파일 손상 가능 — atomic write 미적용
- P1 (Beck): `_has_any_llm_key()`와 `_check_provider_key()`에서 placeholder 검증 로직 이원화
- P1 (Beck): 테스트 assertion이 값 검증 대신 부재 검증으로 false positive 위험

## Changed Files
| 파일 | Why |
|------|-----|
| `core/cli/startup.py` | atomic write (tmp+rename) + chmod 0o600 + `_is_placeholder()` 통일 |
| `core/cli/commands.py` | `_check_provider_key()`에서 `_is_placeholder()` import 사용 |
| `tests/test_startup.py` | 9개 테스트 추가 (placeholder, auto_generate_env, chmod, atomic) |
| `tests/test_commands.py` | 6개 테스트 추가 (_check_provider_key 경고/정상) |
| `.env.example` | 프로바이더별 인라인 주석 추가 |
| `CHANGELOG.md` | .env 자동 생성 + 보안 수정 기록 |

## Test Plan
- [x] `uv run ruff check core/cli/startup.py core/cli/commands.py` — 0 errors
- [x] `uv run mypy core/cli/startup.py core/cli/commands.py` — 0 errors
- [x] `uv run pytest tests/test_startup.py tests/test_commands.py -q` — passed
- [x] `uv run pytest tests/ -q` — 2831 passed
- [x] 검증팀 4인 리뷰 — P0 2건 + P1 3건 수정 완료, 재검증 VERIFIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)