### PR TITLE
docs: 워크플로우 고도화 — 동기화 검증 + Plan 강제 + 칸반 규칙 강화

### DIFF
--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -95,13 +95,21 @@ DISCOVER (병렬 Agent로 하네스 조사)
 **모든 작업 단위**는 worktree를 열어서 시작한다. 예외 없음.
 
 ```bash
-# 1. develop 최신화 (본 레포에서)
-git checkout develop && git pull origin develop
+# 0. 동기화 검증 게이트 (CANNOT 규칙 — 생략 금지)
+git fetch origin
 
-# 2. worktree 생성 = 작업 공간 할당
+LOCAL_MAIN=$(git rev-parse main)
+REMOTE_MAIN=$(git rev-parse origin/main)
+[ "$LOCAL_MAIN" != "$REMOTE_MAIN" ] && echo "STOP: local main ≠ origin/main" && git checkout main && git pull origin main
+
+LOCAL_DEV=$(git rev-parse develop)
+REMOTE_DEV=$(git rev-parse origin/develop)
+[ "$LOCAL_DEV" != "$REMOTE_DEV" ] && echo "STOP: local develop ≠ origin/develop" && git checkout develop && git pull origin develop
+
+# 1. worktree 생성 = 작업 공간 할당 (develop 기반)
 git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명> develop
 
-# 3. 작업 디렉터리 이동
+# 2. 작업 디렉터리 이동
 cd .claude/worktrees/<작업명>
 
 # → 이후 Step 2~11은 모두 이 worktree 안에서 수행

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,11 @@ Decision Tree on D-E-F axes:
 - 타 세션의 worktree 삭제 금지 — `.owner` task_id 불일치 시 절대 제거하지 않음
 - worktree 내 `git checkout` 브랜치 전환 금지
 - `docs/progress.md`를 feature/develop 브랜치에서 수정 금지 — main에서만
+- 원격/로컬 브랜치 동기화 미확인 상태에서 feature 브랜치 생성 금지 — `git fetch origin` 후 main·develop 양쪽 HEAD 일치 확인 필수
+
+**워크플로우:**
+- Plan 없이 구현 착수 금지 — 반드시 EnterPlanMode 진입 → 계획 승인 → ExitPlanMode 경유 (단순 버그 수정·문서 수정 제외)
+- 칸반(progress.md) 필수 컬럼 빈칸 기재 금지 — 모든 필수 컬럼에 값 기입, "—" 허용하되 빈칸 금지
 
 **코드 품질:**
 - lint/type/test 실패 상태에서 커밋 금지
@@ -398,15 +403,36 @@ Decision Tree on D-E-F axes:
 #### 0. Worktree
 
 ```bash
-git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명>
+# 0-a. 원격 fetch
+git fetch origin
+
+# 0-b. main 동기화 확인
+LOCAL_MAIN=$(git rev-parse main)
+REMOTE_MAIN=$(git rev-parse origin/main)
+[ "$LOCAL_MAIN" != "$REMOTE_MAIN" ] && echo "STOP: local main ≠ origin/main" && git checkout main && git pull origin main
+
+# 0-c. develop 동기화 확인
+LOCAL_DEV=$(git rev-parse develop)
+REMOTE_DEV=$(git rev-parse origin/develop)
+[ "$LOCAL_DEV" != "$REMOTE_DEV" ] && echo "STOP: local develop ≠ origin/develop" && git checkout develop && git pull origin develop
+
+# 0-d. worktree 생성 (develop 기반)
+git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명> develop
 echo "session=$(date -Iseconds) task_id=<작업명>" > .claude/worktrees/<작업명>/.owner
 ```
 
 완료 후: `git push origin feature/<브랜치명>` → 소유권 검증 → `git worktree remove`
 
-#### 1. Research → Plan
+#### 1. Plan (필수)
 
-`frontier-harness-research` 스킬 참조. AS-IS 탐색 → 프론티어 4종 리서치 → GAP 분석 → `docs/plans/` 작성. 검증팀 GAP 탐지를 병렬 실행.
+> 단순 버그 수정·문서만 수정은 Plan 생략 가능. 그 외 모든 구현 작업은 Plan 필수.
+
+1. `EnterPlanMode` 진입
+2. Explore Agent로 AS-IS 탐색 + 프론티어 리서치 (해당 시, `frontier-harness-research` 스킬 참조)
+3. Plan Agent로 설계 → 플랜 파일 작성 (`docs/plans/`)
+4. `ExitPlanMode`로 사용자 승인 요청
+5. 승인 후 `TaskCreate`로 작업 항목 등록 — 칸반 In Progress와 1:1 매핑
+6. 구현 착수 (Step 2)
 
 #### 2. Implement → Unit Verify (반복)
 


### PR DESCRIPTION
## 요약

워크플로우(CLAUDE.md Step 0~6)에 세 가지 구조적 허점(브랜치 동기화 미검증, Plan 미강제, 칸반 컬럼 누락)을 CANNOT 규칙으로 강제하고, 워크플로우 절차를 고도화한다.

## 변경 사항

### 핵심 변경 (문서)

- `CLAUDE.md:368-378`: CANNOT 규칙 3건 추가
  - Git/Branch: 원격/로컬 동기화 미확인 시 feature 브랜치 생성 금지
  - 워크플로우(신설): Plan 없이 구현 착수 금지, 칸반 필수 컬럼 빈칸 금지
  - 근거: 머지 충돌 방지 + 방향 잘못 잡았을 때 되돌리기 비용 절감 + 추적성 확보
- `CLAUDE.md:403-421`: Step 0 동기화 검증 게이트 삽입
  - AS-IS: 단순 `git worktree add`
  - TO-BE: `git fetch origin` → main/develop HEAD 비교 → 불일치 시 pull 후 생성
  - 근거: 낙후된 코드 기반 작업 원천 차단
- `CLAUDE.md:426-435`: Step 1 "Research → Plan" → "Plan (필수)" 강화
  - AS-IS: 프론티어 리서치만 언급
  - TO-BE: EnterPlanMode → 설계 → ExitPlanMode → TaskCreate 6단계 절차 명시
  - 근거: 구현 전 계획 승인을 강제하여 방향 오류 조기 차단
- `.claude/skills/geode-gitflow/SKILL.md:97-115`: Step 1에 동기화 검증 스크립트 삽입
  - AS-IS: develop pull 후 바로 worktree 생성
  - TO-BE: fetch → main/develop HEAD 비교 → 불일치 시 자동 pull → worktree 생성
  - 근거: CLAUDE.md Step 0과 스킬 간 정합성 유지

### 부수 변경

없음

### 문서/설정 변경

- 코드 변경 없음 (문서만 수정). CHANGELOG 스코프 규칙에 따라 CHANGELOG 항목 생략.

## 영향 범위

- **영향받는 모듈**: 없음 (문서/워크플로우 변경만)
- **하위 호환성**: 유지
- **테스트 변경**: 없음

## 설계 판단

- progress.md 칸반 재설계는 CANNOT 규칙("progress.md는 main에서만 수정")에 따라 이 PR에 미포함. main 머지 후 별도 적용 예정.

## Pre-PR Quality Gate

- [x] `ruff check` — no files to check (docs only)
- [x] `ruff format --check` — no files to check (docs only)
- [x] `mypy core/` — no files to check (docs only)
- [x] `bandit -r core/` — no files to check (docs only)
- [x] `pytest -m "not live"` — pre-commit hooks passed
- [x] 코드 변경 없으므로 CHANGELOG 생략 (scope rules: "Documentation-only changes")
- [x] README.md 수치 정합성 — 변동 없음
- [ ] CLAUDE.md 동기화 — 이번 변경 자체가 CLAUDE.md 수정
- [x] docs/progress.md — main에서 별도 갱신 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)