### PR TITLE
docs: 워크플로우 고도화 (develop → main)

### DIFF
--- a/.claude/skills/geode-gitflow/SKILL.md
+++ b/.claude/skills/geode-gitflow/SKILL.md
@@ -95,13 +95,21 @@ DISCOVER (병렬 Agent로 하네스 조사)
 **모든 작업 단위**는 worktree를 열어서 시작한다. 예외 없음.
 
 ```bash
-# 1. develop 최신화 (본 레포에서)
-git checkout develop && git pull origin develop
+# 0. 동기화 검증 게이트 (CANNOT 규칙 — 생략 금지)
+git fetch origin
 
-# 2. worktree 생성 = 작업 공간 할당
+LOCAL_MAIN=$(git rev-parse main)
+REMOTE_MAIN=$(git rev-parse origin/main)
+[ "$LOCAL_MAIN" != "$REMOTE_MAIN" ] && echo "STOP: local main ≠ origin/main" && git checkout main && git pull origin main
+
+LOCAL_DEV=$(git rev-parse develop)
+REMOTE_DEV=$(git rev-parse origin/develop)
+[ "$LOCAL_DEV" != "$REMOTE_DEV" ] && echo "STOP: local develop ≠ origin/develop" && git checkout develop && git pull origin develop
+
+# 1. worktree 생성 = 작업 공간 할당 (develop 기반)
 git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명> develop
 
-# 3. 작업 디렉터리 이동
+# 2. 작업 디렉터리 이동
 cd .claude/worktrees/<작업명>
 
 # → 이후 Step 2~11은 모두 이 worktree 안에서 수행

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,11 @@ Decision Tree on D-E-F axes:
 - 타 세션의 worktree 삭제 금지 — `.owner` task_id 불일치 시 절대 제거하지 않음
 - worktree 내 `git checkout` 브랜치 전환 금지
 - `docs/progress.md`를 feature/develop 브랜치에서 수정 금지 — main에서만
+- 원격/로컬 브랜치 동기화 미확인 상태에서 feature 브랜치 생성 금지 — `git fetch origin` 후 main·develop 양쪽 HEAD 일치 확인 필수
+
+**워크플로우:**
+- Plan 없이 구현 착수 금지 — 반드시 EnterPlanMode 진입 → 계획 승인 → ExitPlanMode 경유 (단순 버그 수정·문서 수정 제외)
+- 칸반(progress.md) 필수 컬럼 빈칸 기재 금지 — 모든 필수 컬럼에 값 기입, "—" 허용하되 빈칸 금지
 
 **코드 품질:**
 - lint/type/test 실패 상태에서 커밋 금지
@@ -398,15 +403,36 @@ Decision Tree on D-E-F axes:
 #### 0. Worktree
 
 ```bash
-git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명>
+# 0-a. 원격 fetch
+git fetch origin
+
+# 0-b. main 동기화 확인
+LOCAL_MAIN=$(git rev-parse main)
+REMOTE_MAIN=$(git rev-parse origin/main)
+[ "$LOCAL_MAIN" != "$REMOTE_MAIN" ] && echo "STOP: local main ≠ origin/main" && git checkout main && git pull origin main
+
+# 0-c. develop 동기화 확인
+LOCAL_DEV=$(git rev-parse develop)
+REMOTE_DEV=$(git rev-parse origin/develop)
+[ "$LOCAL_DEV" != "$REMOTE_DEV" ] && echo "STOP: local develop ≠ origin/develop" && git checkout develop && git pull origin develop
+
+# 0-d. worktree 생성 (develop 기반)
+git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명> develop
 echo "session=$(date -Iseconds) task_id=<작업명>" > .claude/worktrees/<작업명>/.owner
 ```
 
 완료 후: `git push origin feature/<브랜치명>` → 소유권 검증 → `git worktree remove`
 
-#### 1. Research → Plan
+#### 1. Plan (필수)
 
-`frontier-harness-research` 스킬 참조. AS-IS 탐색 → 프론티어 4종 리서치 → GAP 분석 → `docs/plans/` 작성. 검증팀 GAP 탐지를 병렬 실행.
+> 단순 버그 수정·문서만 수정은 Plan 생략 가능. 그 외 모든 구현 작업은 Plan 필수.
+
+1. `EnterPlanMode` 진입
+2. Explore Agent로 AS-IS 탐색 + 프론티어 리서치 (해당 시, `frontier-harness-research` 스킬 참조)
+3. Plan Agent로 설계 → 플랜 파일 작성 (`docs/plans/`)
+4. `ExitPlanMode`로 사용자 승인 요청
+5. 승인 후 `TaskCreate`로 작업 항목 등록 — 칸반 In Progress와 1:1 매핑
+6. 구현 착수 (Step 2)
 
 #### 2. Implement → Unit Verify (반복)
 


### PR DESCRIPTION
## 요약

develop → main 머지. 워크플로우 CANNOT 규칙 3건 추가 + Step 0 동기화 게이트 + Step 1 Plan 강제 절차.

## 포함된 변경

- #304 `docs: 워크플로우 고도화 — 동기화 검증 + Plan 강제 + 칸반 규칙 강화` — CLAUDE.md CANNOT 규칙 3건, Step 0/1 강화, geode-gitflow 스킬 동기화 검증

## 변경 수치

- **파일**: 2개 변경 (CLAUDE.md, .claude/skills/geode-gitflow/SKILL.md)
- **테스트**: 변동 없음 (문서만 수정)
- **모듈**: 변동 없음

## 테스트

- [x] CI 전체 통과 (`gh pr checks --watch` 확인 완료)
- [x] feature → develop CI 통과 확인됨 (PR #304)

🤖 Generated with [Claude Code](https://claude.com/claude-code)