### PR TITLE
chore: v0.20.0 릴리스 — Multi-Provider + .geode Context Hub + CANNOT 워크플로우

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [0.20.0] — 2026-03-19
 
-P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
+Multi-Provider LLM (3사 failover) + .geode Context Hub (5-Layer) + CANNOT 워크플로우 고도화.
 
 ### Added
 - IP 보고서 상세 섹션 보강 — Analyst Reasoning, Cross-LLM Verification, Rights Risk, Decision Tree Classification 4개 섹션 추가

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화, 스케줄링을 자율적으로 수행합니다.
 
-- **Version**: 0.19.1
+- **Version**: 0.20.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
 
-# GEODE v0.19.1 — Autonomous Execution Harness
+# GEODE v0.20.0 — Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.19.1"
+version = "0.20.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 요약

[Unreleased] → [0.20.0] 버전 부여. CANNOT 규칙("main에 [Unreleased] 항목 잔류 금지")에 따라 버전을 확정한다.

## 변경 사항

### 핵심 변경

- `CHANGELOG.md:29`: `[Unreleased]` → `[0.20.0] — 2026-03-19` + 요약 문구 갱신
  - 근거: 새 기능 다수 (Multi-Provider LLM, .geode Context Hub, CANNOT 워크플로우) → MINOR bump
- `CLAUDE.md:7`: Version 0.19.1 → 0.20.0
- `README.md:13`: v0.19.1 → v0.20.0
- `pyproject.toml:3`: version 0.19.1 → 0.20.0

### 부수 변경

없음

### 문서/설정 변경

- CHANGELOG.md: [Unreleased] → [0.20.0] 확정

## 영향 범위

- **영향받는 모듈**: 없음 (버전 문자열만 변경)
- **하위 호환성**: 유지
- **테스트 변경**: 없음

## 설계 판단

- 새 기능(Multi-Provider, .geode, 워크플로우 고도화) → MINOR bump (0.19.1 → 0.20.0)

## Pre-PR Quality Gate

- [x] `ruff check` — no files to check
- [x] `ruff format --check` — no files to check
- [x] `mypy core/` — no files to check
- [x] `bandit -r core/` — no files to check
- [x] `pytest -m "not live"` — pre-commit hooks passed
- [x] CHANGELOG.md [Unreleased] → [0.20.0] 확정
- [x] 버전 4곳 동기화 확인 (CHANGELOG, CLAUDE.md, README.md, pyproject.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)