### PR TITLE
chore: v0.20.0 릴리스 (develop → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [0.20.0] — 2026-03-19
 
-P1 전체 완료 + .geode Context Hub (5-Layer C0-C4) Phase A+B.
+Multi-Provider LLM (3사 failover) + .geode Context Hub (5-Layer) + CANNOT 워크플로우 고도화.
 
 ### Added
 - IP 보고서 상세 섹션 보강 — Analyst Reasoning, Cross-LLM Verification, Rights Risk, Decision Tree Classification 4개 섹션 추가

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화, 스케줄링을 자율적으로 수행합니다.
 
-- **Version**: 0.19.1
+- **Version**: 0.20.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
 
-# GEODE v0.19.1 — Autonomous Execution Harness
+# GEODE v0.20.0 — Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.19.1"
+version = "0.20.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 요약

develop → main 머지. v0.20.0 릴리스 — [Unreleased] → [0.20.0] 확정, 4곳 버전 동기화.

## 포함된 변경

- #308 `chore: v0.20.0 릴리스` — CHANGELOG [Unreleased]→[0.20.0], CLAUDE.md/README.md/pyproject.toml 버전 동기화

## 변경 수치

- **파일**: 4개 변경 (CHANGELOG.md, CLAUDE.md, README.md, pyproject.toml)
- **테스트**: 변동 없음

## 테스트

- [x] CI 전체 통과 (PR #308)

🤖 Generated with [Claude Code](https://claude.com/claude-code)