### PR TITLE
docs: commands 수치 20→21 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ core/
 │   ├── ip_names.py      # IP name registry (canonical names from fixtures)
 │   ├── conversation.py  # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── batch.py         # Batch analysis (ThreadPoolExecutor)
-│   ├── commands.py      # Slash command dispatch (20 commands)
+│   ├── commands.py      # Slash command dispatch (21 commands)
 │   ├── repl.py          # REPL 메인 루프 (prompt_toolkit 기반)
 │   ├── tool_handlers.py # 10개 논리 그룹 tool handler 디스패처
 │   ├── result_cache.py  # ResultCache (24h TTL + SHA-256 content hash)

--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ core/
 │   ├── conversation.py         # Multi-turn sliding-window (max 200 turns, server-side clear_tool_uses)
 │   ├── bash_tool.py            # Shell execution + HITL safety gate
 │   ├── batch.py                # Batch analysis (ThreadPoolExecutor)
-│   ├── commands.py             # Slash command dispatch (20 commands)
+│   ├── commands.py             # Slash command dispatch (21 commands)
 │   ├── project_detect.py       # Project type auto-detection (7 types)
 │   ├── search.py               # IP search engine (synonym expansion)
 │   └── startup.py              # Readiness check, Graceful Degradation


### PR DESCRIPTION
## Summary
- CLAUDE.md + README.md: 슬래시 커맨드 수 20→21 갱신 (/resume 추가, v0.21.0)

## Why
- README Mermaid 다이어그램 GAP 점검에서 발견
- v0.21.0에서 `/resume` 커맨드 추가되었으나 수치 미반영

## Test Plan
- [x] 문서만 수정, 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)