### PR TITLE
feat: P2-C on_progress 와이어링 + 서브에이전트 플랜 완료

### DIFF
--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -276,7 +276,20 @@ class ToolExecutor:
             for i, t in enumerate(tasks_raw)
         ]
 
-        results = self._sub_agent_manager.delegate(sub_tasks)
+        # P2-C: progress callback — update spinner on each sub-agent completion
+        completed_count = 0
+        total_count = len(sub_tasks)
+
+        def _on_progress(result: Any) -> None:
+            nonlocal completed_count
+            completed_count += 1
+            status_icon = "[green]ok[/green]" if result.success else "[red]err[/red]"
+            console.print(
+                f"  [dim]  sub-agent {completed_count}/{total_count}"
+                f" {status_icon} {result.task_id}[/dim]"
+            )
+
+        results = self._sub_agent_manager.delegate(sub_tasks, on_progress=_on_progress)
 
         # P2-A: unified response format (single and batch identical)
         succeeded = sum(1 for r in results if r.success)

--- a/docs/plans/_done/P2-subagent-orchestration-hardening.md
+++ b/docs/plans/_done/P2-subagent-orchestration-hardening.md
@@ -1,8 +1,8 @@
 # P2: Sub-Agent Orchestration Hardening
 
-**Status**: IN_PROGRESS
+**Status**: COMPLETE (P2-A/B/C done, P2-D RLM deferred)
 **Created**: 2026-03-15
-**Updated**: 2026-03-15 (RLM 리서치 + Full Inheritance 방향 확정)
+**Updated**: 2026-03-19 (G1-G8,G10 해소, G3 on_progress 완료, G9 보류)
 **Priority**: P2
 **Depends**: P1-subagent-parallel-execution (completed)
 


### PR DESCRIPTION
## Summary

- P2-subagent-orchestration-hardening 플랜의 마지막 미구현 건(G3 on_progress) 해소
- `_execute_delegate()` → `delegate(on_progress=callback)` 와이어링 추가
- 플랜 상태 COMPLETE → `_done/` 이동

## Why

서브에이전트 병렬 실행 시 진행 상황이 보이지 않아 사용자가 대기 중 불안함.
완료 건마다 "sub-agent 1/3 ok task-id" 콘솔 출력으로 피드백 제공.

## Test plan

- [x] Lint/Type/Test 전체 통과 (2930 passed)
- [x] 코드 변경 1파일 (tool_executor.py), 문서 1파일 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)