### PR TITLE
fix: MCP 카탈로그 패키지명 5건 + StdioMCPClient 연결 안정화

### DIFF
--- a/core/infrastructure/adapters/mcp/catalog.py
+++ b/core/infrastructure/adapters/mcp/catalog.py
@@ -93,10 +93,10 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     ),
     "igdb": MCPCatalogEntry(
         name="igdb",
-        package="bielacki/igdb-mcp-server",
+        package="igdb-mcp-server",
         description="IGDB game metadata (genre, platform, rating, franchise)",
         tags=("igdb", "game", "gaming", "metadata", "twitch"),
-        env_keys=("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
+        env_keys=("IGDB_CLIENT_ID", "IGDB_CLIENT_SECRET"),
     ),
     # --- Social / Community ---
     "discord": MCPCatalogEntry(
@@ -205,10 +205,10 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     # --- Messaging ---
     "slack": MCPCatalogEntry(
         name="slack",
-        package="@anthropic/mcp-server-slack",
+        package="@modelcontextprotocol/server-slack",
         description="Slack messaging and channel management",
         tags=("slack", "chat", "messaging", "team"),
-        env_keys=("SLACK_BOT_TOKEN",),
+        env_keys=("SLACK_BOT_TOKEN", "SLACK_TEAM_ID"),
     ),
     "telegram": MCPCatalogEntry(
         name="telegram",
@@ -248,7 +248,7 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     ),
     "google-maps": MCPCatalogEntry(
         name="google-maps",
-        package="@anthropic/mcp-server-google-maps",
+        package="@modelcontextprotocol/server-google-maps",
         description="Google Maps places, directions, geocoding",
         tags=("google", "maps", "location", "geo"),
         env_keys=("GOOGLE_MAPS_API_KEY",),
@@ -256,7 +256,7 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     # --- Agent Infrastructure ---
     "e2b": MCPCatalogEntry(
         name="e2b",
-        package="e2b-dev/mcp-server",
+        package="@e2b/mcp-server",
         description="Secure cloud sandbox for code execution (Python/JS)",
         tags=("sandbox", "code", "execution", "e2b", "isolated"),
         env_keys=("E2B_API_KEY",),
@@ -297,7 +297,7 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     # --- AI / LLM ---
     "langsmith": MCPCatalogEntry(
         name="langsmith",
-        package="langchain-ai/langsmith-mcp-server",
+        package="langsmith-mcp-server",
         description="LangSmith tracing, datasets, and evaluation",
         tags=("langsmith", "tracing", "eval", "langchain"),
         env_keys=("LANGSMITH_API_KEY",),

--- a/core/infrastructure/adapters/mcp/stdio_client.py
+++ b/core/infrastructure/adapters/mcp/stdio_client.py
@@ -70,6 +70,22 @@ class StdioMCPClient:
                 self._pid,
             )
 
+            # Wait for server to be ready (npx may download packages first)
+            import time
+
+            wait_deadline = time.time() + min(self._timeout_s, 10.0)
+            while time.time() < wait_deadline:
+                if self._process.poll() is not None:
+                    log.warning(
+                        "MCP server exited prematurely (PID %d, code=%s)",
+                        self._pid,
+                        self._process.returncode,
+                    )
+                    self._process = None
+                    self._pid = None
+                    return False
+                time.sleep(0.5)
+
             # Send initialize request
             init_response = self._send_request(
                 "initialize",
@@ -162,7 +178,7 @@ class StdioMCPClient:
         return self._request_id
 
     def _send_request(self, method: str, params: dict[str, Any]) -> dict[str, Any] | None:
-        """Send a JSON-RPC request and wait for response."""
+        """Send a JSON-RPC request and wait for response with timeout."""
         if self._process is None or self._process.stdin is None or self._process.stdout is None:
             return None
 
@@ -178,7 +194,22 @@ class StdioMCPClient:
             self._process.stdin.write(message.encode("utf-8"))
             self._process.stdin.flush()
 
-            # Read response line
+            # Read response with timeout (select-based, fallback to blocking)
+            try:
+                import select
+
+                ready, _, _ = select.select(
+                    [self._process.stdout],
+                    [],
+                    [],
+                    self._timeout_s,
+                )
+                if not ready:
+                    log.warning("MCP timeout waiting for %s response", method)
+                    return None
+            except (TypeError, ValueError):
+                pass  # mock/non-real fd — fall through to blocking read
+
             line = self._process.stdout.readline()
             if not line:
                 return None


### PR DESCRIPTION
## Summary

- MCP 카탈로그 패키지명 5건 수정 (npm 404 해소)
- StdioMCPClient에 서버 시작 대기 + 읽기 타임아웃 추가
- IGDB env 키 TWITCH_* → IGDB_*, Slack에 SLACK_TEAM_ID 추가

## Why

키 제공된 MCP 서버 8개 중 5개가 패키지명 오류로 연결 실패.
또한 npx가 패키지를 다운로드하는 동안 init 요청을 보내면 broken pipe 발생.

## 수정 후 결과

11/14 서버 연결 성공 (키 제공 서버 전부 OK):
brave-search(6), slack(8), google-maps(7), igdb(2), langsmith(15),
e2b(1), linkedin-reader(7), arxiv(5), steam(12), playwright(22),
sequential-thinking(1)

## Test plan

- [x] 2941 passed, 0 failed
- [x] 11/14 MCP 서버 연결 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)