### PR TITLE
feat: 글로벌 ~/.geode/.env — 어디서든 API 키 접근

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -2966,6 +2966,23 @@ def init(
     project_mem = ProjectMemory(Path("."))
     user_profile = FileBasedUserProfile()
 
+    # 0. Global ~/.geode/ directory + .env (API key storage)
+    global_geode = Path.home() / ".geode"
+    global_geode.mkdir(parents=True, exist_ok=True)
+    global_env = global_geode / ".env"
+    if not global_env.exists():
+        global_env.write_text(
+            "# GEODE global API keys (shared across all projects)\n"
+            "# Keys here are used when project-local .env is absent.\n"
+            "# Priority: env vars > CWD/.env > ~/.geode/.env\n\n"
+            "# ANTHROPIC_API_KEY=sk-ant-...\n"
+            "# OPENAI_API_KEY=sk-proj-...\n"
+            "# BRAVE_API_KEY=...\n",
+            encoding="utf-8",
+        )
+        global_env.chmod(0o600)
+        console.print(f"  Created {global_env} (global API keys)")
+
     # 1. Detect project type (harness-for-real init.sh pattern)
     project_info = detect_project_type(Path("."))
     console.print(

--- a/core/config.py
+++ b/core/config.py
@@ -132,10 +132,13 @@ def _apply_toml_overlay(s: Settings) -> None:
             object.__setattr__(s, field_name, toml_value)
 
 
+GLOBAL_ENV_PATH = Path.home() / ".geode" / ".env"
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="GEODE_",
-        env_file=".env",
+        env_file=(".env", str(Path.home() / ".geode" / ".env")),
         extra="ignore",
     )
 

--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -32,6 +32,7 @@ log = logging.getLogger(__name__)
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 _CONFIG_PATH = _PROJECT_ROOT / ".claude" / "mcp_servers.json"
 _DOTENV_PATH = _PROJECT_ROOT / ".env"
+_GLOBAL_DOTENV_PATH = Path.home() / ".geode" / ".env"
 
 _EMPTY_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
 
@@ -237,10 +238,15 @@ class MCPServerManager:
         os.environ, so MCP keys defined only in .env would be invisible.
         """
         # Lazy-load .env values (cached after first call)
+        # Cascade: CWD/.env (project) → ~/.geode/.env (global)
         if not hasattr(self, "_dotenv_cache"):
             self._dotenv_cache: dict[str, str | None] = {}
+            # Global first (lower priority)
+            if _GLOBAL_DOTENV_PATH.exists():
+                self._dotenv_cache.update(dotenv_values(str(_GLOBAL_DOTENV_PATH)))
+            # Project .env overrides global
             if _DOTENV_PATH.exists():
-                self._dotenv_cache = dotenv_values(str(_DOTENV_PATH))
+                self._dotenv_cache.update(dotenv_values(str(_DOTENV_PATH)))
 
         resolved: dict[str, str] = {}
         for key, value in env.items():

--- a/core/infrastructure/adapters/mcp/registry.py
+++ b/core/infrastructure/adapters/mcp/registry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from dotenv import dotenv_values
@@ -120,9 +121,13 @@ class MCPRegistry:
         self._dotenv_path = dotenv_path
         self._defaults = defaults
         self._auto_discover = auto_discover
+        # Cascade: ~/.geode/.env (global) → CWD/.env (project overrides)
         self._dotenv_cache: dict[str, str | None] = {}
+        global_env = Path.home() / ".geode" / ".env"
+        if global_env.exists():
+            self._dotenv_cache.update(dotenv_values(str(global_env)))
         if os.path.exists(dotenv_path):
-            self._dotenv_cache = dotenv_values(dotenv_path)
+            self._dotenv_cache.update(dotenv_values(dotenv_path))
 
     def discover(self) -> dict[str, dict[str, Any]]:
         """Return server configs for all available MCP servers.


### PR DESCRIPTION
## Summary

`~/.geode/.env`를 글로벌 API 키 저장소로 추가. 어떤 디렉토리에서 GEODE를 실행해도 API 키에 접근 가능.

## Config Cascade

```
1. 환경변수 (os.environ)      ← 최고 우선순위
2. CWD/.env (프로젝트별)       ← 프로젝트 override
3. ~/.geode/.env (글로벌)      ← fallback (신규)
```

## 프론티어 근거

| 시스템 | 글로벌 키 저장소 | 패턴 |
|--------|---------------|------|
| Claude Code | `~/.claude/.credentials.json` | 글로벌 인증 |
| Codex CLI | `~/.codex/auth.json` | 글로벌 인증 |
| Aider | `~/.env` | 글로벌 .env fallback |
| Continue.dev | `~/.continue/config.yaml` | 글로벌 설정 |

## Why

`workspace/blog/`에서 `geode analyze` 실행 시 프로젝트 `.env`가 없으면 API 키를 찾지 못함.
사용자가 16개 키를 shell export하는 것은 비현실적.
`~/.geode/.env`에 한 번 저장하면 모든 프로젝트에서 동작.

## 변경 파일 (4건)

- `config.py`: Pydantic `env_file` 튜플 확장
- `mcp/manager.py`: `_resolve_env()` 글로벌 fallback
- `mcp/registry.py`: `discover()` 글로벌 fallback
- `cli/__init__.py`: `geode init`에 `~/.geode/.env` 템플릿 생성

## Test plan

- [x] 2941 passed
- [x] Lint/Type 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)