### PR TITLE
docs: SOT 참조 정정 + Tests 수치 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 178
-- **Tests**: 2930+
+- **Tests**: 2941+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -35,7 +35,7 @@ uv run geode analyze "Cowboy Bebop" --verbose
 
 ## Architecture
 
-6-Layer Architecture based on `architecture-v6.md` SOT.
+6-Layer Architecture.
 
 ```
 L0: CLI & AGENT      — Typer CLI, AgenticLoop, SubAgentManager, Batch
@@ -147,9 +147,9 @@ START → router → signals → analyst×4 (Send API)
 
 | Document | Path | Content |
 |----------|------|---------|
-| Architecture v6 | `docs/architecture-v6.md` | Full spec (335KB) |
-| LangGraph Flow | `docs/langgraph-flow.md` | StateGraph topology |
 | Layer Plan | `docs/architecture/layer-implementation-plan.md` | 6-layer roadmap |
+| Orchestration | `docs/architecture/orchestration-tools-hooks-plans.md` | L3/L4 설계 |
+| CLAUDE.md | `CLAUDE.md` | Architecture overview + conventions (이 파일) |
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

- 존재하지 않는 SOT 문서 2건(architecture-v6.md, langgraph-flow.md) 참조 제거
- 실제 존재하는 문서로 교체 (layer-implementation-plan, orchestration-tools-hooks-plans)
- Tests 수치 2930+ → 2941+ 실측 반영

## Why

에이전트(Claude)가 CLAUDE.md를 program.md로 참조할 때 존재하지 않는 파일을
찾으려 시도하여 불필요한 탐색 발생.

🤖 Generated with [Claude Code](https://claude.com/claude-code)