### PR TITLE
fix: 노이즈 3건 — Node None 경고 + 점수 실측

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,9 +279,9 @@ uv run mypy core/
 ### Expected Test Results
 
 2000+ tests pass. 3 IP fixtures produce tier spread:
-- Berserk: **S** (81.3) — conversion_failure
+- Berserk: **S** (81.2) — conversion_failure
 - Cowboy Bebop: **A** (68.4) — undermarketed
-- Ghost in the Shell: **B** (51.6) — discovery_failure
+- Ghost in the Shell: **B** (51.7) — discovery_failure
 
 ## Domain Plugin: Game IP — Scoring & Classification
 
@@ -345,7 +345,7 @@ Decision Tree on D-E-F axes:
 
 ```
 ▸ analyze_ip(ip_name="Berserk")        # tool call
-✓ analyze_ip → S · 81.3               # tool result
+✓ analyze_ip → S · 81.2               # tool result
 ✗ analyze_ip — Not found              # error
 ✢ claude-opus-4-6 · ↓1.2k ↑350 · 2.1s  # token usage
 ● Plan: Berserk                        # plan steps

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -591,7 +591,7 @@ def _progress_line(done: list[str], active: str = "") -> str:
 def _merge_event_output(final_state: dict[str, Any], output: dict[str, Any] | None) -> None:
     """Merge a single node's output into the accumulated final state."""
     if output is None:
-        log.warning("Node returned None output, skipping merge")
+        log.debug("Node returned None output, skipping merge")
         return
     for k, v in output.items():
         if k in ("analyses", "errors"):


### PR DESCRIPTION
## Summary

- N1: "Node returned None output" warning → debug (Send API 정상 동작에서 발생)
- N2: CLAUDE.md 점수 실측 반영 (Berserk 81.3→81.2, GiTS 51.6→51.7)

## Why

live 분석 시 콘솔에 "Node returned None output" 경고가 출력되어 사용자 혼란.
CLAUDE.md 점수가 dry-run 실측과 ±0.1 불일치.

## Test plan

- [x] 2941 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)