### PR TITLE
feat: session resume — per-turn checkpoint + /resume 와이어링

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1140,8 +1140,8 @@ def _handle_command(
     *,
     skill_registry: Any = None,
     mcp_manager: Any = None,
-) -> tuple[bool, bool]:
-    """Handle a slash command. Returns (should_break, new_verbose)."""
+) -> tuple[bool, bool, Any]:
+    """Handle a slash command. Returns (should_break, new_verbose, resume_state)."""
     action = resolve_action(cmd)
 
     if action == "quit":
@@ -1149,7 +1149,7 @@ def _handle_command(
 
         render_session_cost_summary()
         console.print("  [muted]Goodbye.[/muted]\n")
-        return True, verbose
+        return True, verbose, None
 
     if action == "help":
         show_help()
@@ -1307,13 +1307,14 @@ def _handle_command(
     elif action == "resume":
         from core.cli.commands import cmd_resume
 
-        cmd_resume(args)
+        resume_state = cmd_resume(args)
+        return False, verbose, resume_state
     else:
         console.print(f"  [warning]Unknown command: {cmd}[/warning]")
         console.print("  [muted]Type /help for available commands.[/muted]")
         console.print()
 
-    return False, verbose
+    return False, verbose, None
 
 
 def _show_commentary(
@@ -2593,13 +2594,17 @@ def _read_multiline_input(prompt: str) -> str:
     return text
 
 
-def _interactive_loop() -> None:
+def _interactive_loop(resume_session_id: str | None = None) -> None:
     """Claude Code / OpenClaw-style interactive REPL.
 
     Three routing paths:
       /command  → deterministic dispatch (commands.py)
       free-text → agentic loop (AgenticLoop, multi-turn + multi-intent)
       fallback  → single-shot NL Router (when agentic unavailable)
+
+    Args:
+        resume_session_id: If provided, auto-resume this session at startup.
+            Use "__latest__" to resume the most recent session (--continue flag).
     """
     verbose = False
     conversation = ConversationContext()
@@ -2720,6 +2725,30 @@ def _interactive_loop() -> None:
 
     init_session_meter(model=agentic.model)
 
+    # Auto-resume: --continue (latest) or --resume <id>
+    if resume_session_id is not None:
+        from core.cli.session_checkpoint import SessionCheckpoint
+
+        _cp = SessionCheckpoint()
+        if resume_session_id == "__latest__":
+            _resumable = _cp.list_resumable()
+            _state = _resumable[0] if _resumable else None
+        else:
+            _state = _cp.load(resume_session_id)
+        if _state is not None and _state.status in ("active", "paused"):
+            conversation.messages = list(_state.messages)
+            agentic._session_id = _state.session_id
+            console.print(f"  [success]Session restored: {_state.session_id}[/success]")
+            if _state.user_input:
+                console.print(f"  [muted]Last input: {_state.user_input[:80]}[/muted]")
+            console.print(f"  [muted]{len(_state.messages)} messages restored[/muted]")
+            console.print()
+        elif resume_session_id != "__latest__":
+            console.print(
+                f"  [warning]Session not found or not resumable: {resume_session_id}[/warning]"
+            )
+            console.print()
+
     while True:
         # Defensive: restore terminal state before each prompt
         # (Rich Status/Live may leave cursor hidden or echo off)
@@ -2730,6 +2759,7 @@ def _interactive_loop() -> None:
         except (KeyboardInterrupt, EOFError):
             from core.ui.agentic_ui import render_session_cost_summary
 
+            agentic.mark_session_completed()
             render_session_cost_summary()
             console.print("\n  [muted]Goodbye.[/muted]\n")
             break
@@ -2741,6 +2771,7 @@ def _interactive_loop() -> None:
         if user_input.strip().lower() in ("exit", "quit", "q"):
             from core.ui.agentic_ui import render_session_cost_summary
 
+            agentic.mark_session_completed()
             render_session_cost_summary()
             console.print("  [muted]Goodbye.[/muted]\n")
             break
@@ -2751,7 +2782,7 @@ def _interactive_loop() -> None:
             # Slash command → deterministic routing (OpenClaw Binding)
             cmd = user_input.split()[0].lower()
             args = user_input[len(cmd) :].strip()
-            should_break, verbose = _handle_command(
+            should_break, verbose, resume_state = _handle_command(
                 cmd,
                 args,
                 verbose,
@@ -2760,6 +2791,15 @@ def _interactive_loop() -> None:
             )
             if should_break:
                 break
+            # /resume: inject saved messages into ConversationContext
+            if resume_state is not None:
+                conversation.messages = list(resume_state.messages)
+                agentic._session_id = resume_state.session_id
+                log.info(
+                    "Session restored: %s (%d messages)",
+                    resume_state.session_id,
+                    len(resume_state.messages),
+                )
             # Sync model/provider to AgenticLoop after /model command
             # (fixes model caching bug: /model changes were not reflected)
             if settings.model != agentic.model:
@@ -2847,11 +2887,22 @@ def _interactive_loop() -> None:
 
 
 @app.callback()
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    continue_session: bool = typer.Option(
+        False, "--continue", help="Resume the most recent session"
+    ),
+    resume: str = typer.Option("", "--resume", help="Resume a specific session by ID"),
+) -> None:
     """GEODE — Autonomous Research Harness."""
     if ctx.invoked_subcommand is None:
         _welcome_screen()
-        _interactive_loop()
+        resume_id: str | None = None
+        if continue_session:
+            resume_id = "__latest__"
+        elif resume:
+            resume_id = resume
+        _interactive_loop(resume_session_id=resume_id)
 
 
 @app.command()

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -222,14 +222,55 @@ class AgenticLoop:
 
         # Tier 1 transcript: append-only JSONL event stream (snapshot-redesign)
         self._transcript: Any | None = None
+        self._session_id: str = ""
         try:
             import uuid as _uuid
 
             from core.cli.transcript import SessionTranscript
 
-            self._transcript = SessionTranscript(f"s-{_uuid.uuid4().hex[:12]}")
+            self._session_id = f"s-{_uuid.uuid4().hex[:12]}"
+            self._transcript = SessionTranscript(self._session_id)
         except Exception:
             log.debug("Transcript init failed", exc_info=True)
+
+        # C3 checkpoint: full message persistence for /resume (Claude Code pattern)
+        self._checkpoint: Any | None = None
+        try:
+            from core.cli.session_checkpoint import SessionCheckpoint
+
+            self._checkpoint = SessionCheckpoint()
+        except Exception:
+            log.debug("SessionCheckpoint init failed", exc_info=True)
+
+    def _save_checkpoint(self, user_input: str, round_idx: int = 0) -> None:
+        """Persist session checkpoint for resume (per-turn, Claude Code pattern)."""
+        if self._checkpoint is None or not self._session_id:
+            return
+        try:
+            from core.cli.session_checkpoint import SessionState
+
+            state = SessionState(
+                session_id=self._session_id,
+                round_idx=round_idx,
+                model=self.model,
+                provider=self._provider,
+                status="active",
+                messages=self.context.messages,
+                tool_log=self._tool_log,
+                user_input=user_input,
+            )
+            self._checkpoint.save(state)
+        except Exception:
+            log.debug("Checkpoint save failed", exc_info=True)
+
+    def mark_session_completed(self) -> None:
+        """Mark the current session as completed (called on clean REPL exit)."""
+        if self._checkpoint is None or not self._session_id:
+            return
+        try:
+            self._checkpoint.mark_completed(self._session_id)
+        except Exception:
+            log.debug("Checkpoint mark_completed failed", exc_info=True)
 
     def _record_transcript_end(self, result: Any) -> None:
         """Record session end + assistant message to transcript."""
@@ -345,6 +386,7 @@ class AgenticLoop:
                     len(result.tool_calls),
                 )
                 self._record_transcript_end(result)
+                self._save_checkpoint(user_input, round_idx=round_idx + 1)
                 return result
 
             # Track usage + Claude Code-style token display
@@ -373,6 +415,7 @@ class AgenticLoop:
                     len(result.tool_calls),
                 )
                 self._record_transcript_end(result)
+                self._save_checkpoint(user_input, round_idx=round_idx + 1)
                 return result
 
             tool_results = await self._process_tool_calls(response)
@@ -407,6 +450,7 @@ class AgenticLoop:
             len(result.tool_calls),
         )
         self._record_transcript_end(result)
+        self._save_checkpoint(user_input, round_idx=self.max_rounds)
         return result
 
     def _sync_messages_to_context(self, messages: list[dict[str, Any]]) -> None:

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 from typing import Any as _Any
-from typing import cast
+
+if TYPE_CHECKING:
+    from core.cli.session_checkpoint import SessionState
 
 from simple_term_menu import TerminalMenu
 
@@ -1307,10 +1310,11 @@ def _set_cost_budget(amount: float) -> None:
     config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def cmd_resume(args: str) -> str | None:
+def cmd_resume(args: str) -> SessionState | None:
     """Handle /resume [session_id] — resume an interrupted session.
 
-    Returns the session_id that was selected (for caller to restore), or None.
+    Returns the full SessionState (with messages) for the caller to restore
+    into ConversationContext, or None if no session was selected.
     """
     from core.cli.session_checkpoint import SessionCheckpoint
 
@@ -1336,7 +1340,7 @@ def cmd_resume(args: str) -> str | None:
             f"  [muted]Round: {state.round_idx} | Messages: {len(state.messages)}[/muted]"
         )
         console.print()
-        return state.session_id
+        return state
 
     # No args: list resumable sessions
     sessions = checkpoint.list_resumable()

--- a/core/cli/repl.py
+++ b/core/cli/repl.py
@@ -405,6 +405,7 @@ def _interactive_loop() -> None:
         except (KeyboardInterrupt, EOFError):
             from core.ui.agentic_ui import render_session_cost_summary
 
+            agentic.mark_session_completed()
             render_session_cost_summary()
             console.print("\n  [muted]Goodbye.[/muted]\n")
             break
@@ -416,6 +417,7 @@ def _interactive_loop() -> None:
         if user_input.strip().lower() in ("exit", "quit", "q"):
             from core.ui.agentic_ui import render_session_cost_summary
 
+            agentic.mark_session_completed()
             render_session_cost_summary()
             console.print("  [muted]Goodbye.[/muted]\n")
             break
@@ -426,7 +428,7 @@ def _interactive_loop() -> None:
             # Slash command -> deterministic routing (OpenClaw Binding)
             cmd = user_input.split()[0].lower()
             args = user_input[len(cmd) :].strip()
-            should_break, verbose = _handle_command(
+            should_break, verbose, resume_state = _handle_command(
                 cmd,
                 args,
                 verbose,
@@ -435,6 +437,15 @@ def _interactive_loop() -> None:
             )
             if should_break:
                 break
+            # /resume: inject saved messages into ConversationContext
+            if resume_state is not None:
+                conversation.messages = list(resume_state.messages)
+                agentic._session_id = resume_state.session_id
+                log.info(
+                    "Session restored: %s (%d messages)",
+                    resume_state.session_id,
+                    len(resume_state.messages),
+                )
             # Update handlers if verbose changed
             if verbose != (handlers.get("_verbose_flag") is True):
                 handlers = _build_tool_handlers(

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -145,6 +145,7 @@ _WRITE_FALLBACK_HINTS: dict[str, str] = {
     "memory_save": "Try memory_search to read existing data instead.",
     "note_save": "Try reading existing notes or suggest the content to the user.",
     "set_api_key": "Show the user the /key command to set it themselves.",
+    "manage_auth": "Show the user the /auth command to manage auth profiles.",
     "profile_update": "Show current profile with profile_get instead.",
     "profile_preference": "Show current preferences with profile_get instead.",
     "profile_learn": "Show current learning patterns with profile_get instead.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ tracing should set LANGCHAIN_TRACING_V2=true explicitly.
 """
 
 import os
+import tempfile
 
 from dotenv import load_dotenv
 
@@ -18,3 +19,16 @@ load_dotenv()  # Must run before test module imports trigger decorator evaluatio
 # (e.g. LANGCHAIN_TRACING_V2=true uv run pytest -m live)
 if os.environ.get("GEODE_TEST_TRACING") != "1":
     os.environ["LANGCHAIN_TRACING_V2"] = "false"
+
+# Redirect SessionCheckpoint + SessionTranscript to temp dirs during tests
+# to prevent production data contamination (.geode/session/, .geode/journal/)
+_test_session_dir = os.path.join(tempfile.gettempdir(), "geode_test_sessions")
+_test_transcript_dir = os.path.join(tempfile.gettempdir(), "geode_test_transcripts")
+
+from pathlib import Path  # noqa: E402
+
+import core.cli.session_checkpoint as _cp_mod  # noqa: E402
+import core.cli.transcript as _tx_mod  # noqa: E402
+
+_cp_mod.DEFAULT_SESSION_DIR = Path(_test_session_dir)
+_tx_mod.DEFAULT_TRANSCRIPT_DIR = Path(_test_transcript_dir)

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -1,11 +1,13 @@
-"""Tests for GAP 5: /resume CLI command + session detection."""
+"""Tests for session resume: checkpoint save/load, /resume command, CLI flags."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from core.cli.commands import cmd_resume, resolve_action
+from core.cli.conversation import ConversationContext
 from core.cli.session_checkpoint import SessionCheckpoint, SessionState
 
 
@@ -17,7 +19,7 @@ class TestResumeCommandMap:
 
 
 class TestCmdResume:
-    """cmd_resume() function behavior."""
+    """cmd_resume() returns full SessionState for caller to restore."""
 
     @pytest.fixture()
     def session_dir(self, tmp_path: Path) -> Path:
@@ -42,19 +44,27 @@ class TestCmdResume:
         result = cmd_resume("")
         assert result is None
 
-    def test_resume_explicit_session(
+    def test_resume_explicit_session_returns_state(
         self,
         checkpoint: SessionCheckpoint,
     ) -> None:
+        messages = [
+            {"role": "user", "content": "analyze Berserk"},
+            {"role": "assistant", "content": "Starting analysis..."},
+        ]
         state = SessionState(
             session_id="test-1",
             model="claude-opus-4-6",
             user_input="analyze Berserk",
-            messages=[{"role": "user", "content": "hi"}],
+            messages=messages,
         )
         checkpoint.save(state)
         result = cmd_resume("test-1")
-        assert result == "test-1"
+        # Returns full SessionState, not just session_id
+        assert isinstance(result, SessionState)
+        assert result.session_id == "test-1"
+        assert len(result.messages) == 2
+        assert result.user_input == "analyze Berserk"
 
     def test_resume_nonexistent_returns_none(self) -> None:
         result = cmd_resume("nonexistent-id")
@@ -82,3 +92,116 @@ class TestCmdResume:
         checkpoint.save(SessionState(session_id="a2", user_input="second", messages=[]))
         result = cmd_resume("")
         assert result is None  # listing only, no auto-resume
+
+
+class TestCheckpointSaveFromAgenticLoop:
+    """AgenticLoop._save_checkpoint() persists session state."""
+
+    @pytest.fixture()
+    def session_dir(self, tmp_path: Path) -> Path:
+        return tmp_path / "session"
+
+    @pytest.fixture(autouse=True)
+    def _patch_default_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        session_dir: Path,
+    ) -> None:
+        import core.cli.session_checkpoint as cp_mod
+
+        monkeypatch.setattr(cp_mod, "DEFAULT_SESSION_DIR", session_dir)
+
+    def test_save_checkpoint_creates_files(self, session_dir: Path) -> None:
+        """_save_checkpoint writes state.json + messages.json."""
+        from core.cli.agentic_loop import AgenticLoop
+
+        ctx = ConversationContext()
+        ctx.add_user_message("hello")
+        ctx.add_assistant_message("hi there")
+        executor = MagicMock()
+        loop = AgenticLoop(ctx, executor)
+
+        loop._save_checkpoint("hello", round_idx=1)
+
+        # Checkpoint should have been created
+        sid = loop._session_id
+        assert sid  # non-empty
+        state_file = session_dir / sid / "state.json"
+        msg_file = session_dir / sid / "messages.json"
+        assert state_file.exists()
+        assert msg_file.exists()
+
+    def test_mark_session_completed(self, session_dir: Path) -> None:
+        """mark_session_completed marks checkpoint as completed."""
+        from core.cli.agentic_loop import AgenticLoop
+
+        ctx = ConversationContext()
+        ctx.add_user_message("test")
+        executor = MagicMock()
+        loop = AgenticLoop(ctx, executor)
+
+        # Save first
+        loop._save_checkpoint("test", round_idx=1)
+        # Then mark completed
+        loop.mark_session_completed()
+
+        # Verify status is completed
+        cp = SessionCheckpoint(session_dir=session_dir)
+        state = cp.load(loop._session_id)
+        assert state is not None
+        assert state.status == "completed"
+
+
+class TestSessionRestore:
+    """Session messages are restored into ConversationContext."""
+
+    def test_messages_injected_into_conversation(self) -> None:
+        """Simulates /resume wiring: messages injected into ConversationContext."""
+        saved_messages = [
+            {"role": "user", "content": "analyze Berserk"},
+            {"role": "assistant", "content": [{"type": "text", "text": "Starting..."}]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+            },
+        ]
+        state = SessionState(
+            session_id="s-resume1",
+            messages=saved_messages,
+            user_input="analyze Berserk",
+        )
+
+        # Simulate REPL wiring
+        conversation = ConversationContext()
+        conversation.messages = list(state.messages)
+
+        assert len(conversation.messages) == 3
+        assert conversation.messages[0]["role"] == "user"
+        assert conversation.messages[0]["content"] == "analyze Berserk"
+
+    def test_restored_conversation_accepts_new_messages(self) -> None:
+        """After restore, new messages can be added normally."""
+        saved = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+        conversation = ConversationContext()
+        conversation.messages = list(saved)
+
+        # Add new message after restore
+        conversation.add_user_message("follow-up question")
+        assert len(conversation.messages) == 3
+        assert conversation.messages[-1]["content"] == "follow-up question"
+
+
+class TestHandleCommandResumeReturn:
+    """_handle_command returns 3-tuple with resume state."""
+
+    def test_handle_command_returns_three_tuple(self) -> None:
+        """Non-resume commands return None as third element."""
+        from core.cli.__init__ import _handle_command
+
+        result = _handle_command("/help", "", False)
+        assert len(result) == 3
+        should_break, verbose, resume_state = result
+        assert resume_state is None


### PR DESCRIPTION
## Summary

- SessionCheckpoint이 AgenticLoop에 와이어링되지 않아 `/resume`가 동작하지 않던 GAP 해소
- 프론티어 3종(Claude Code, Codex, OpenClaw) 세션 영속 패턴 참조
- Per-turn checkpoint save + 메시지 복원 + CLI `--continue`/`--resume` 플래그

## Changes

| 파일 | 변경 |
|------|------|
| `core/cli/agentic_loop.py` | `_save_checkpoint()` per-turn, `mark_session_completed()` on exit |
| `core/cli/commands.py` | `cmd_resume()` → `SessionState` 전체 반환 (기존 `str`) |
| `core/cli/__init__.py` | 3-tuple 반환, `/resume` 와이어링, `--continue`/`--resume` CLI 플래그 |
| `core/cli/repl.py` | 동일 REPL 와이어링 |
| `tests/test_session_resume.py` | 11개 테스트 (save/load/restore/mark/3-tuple) |

## Why

GAP Audit에서 session resume flow가 3곳(save/load/return)에서 끊겨 있음을 발견.
프론티어 하네스 리서치 결과 Claude Code(JSONL per-turn + `--continue`) / Codex(`/resume` + `/fork`) / OpenClaw(session key hierarchy) 모두 per-turn 영속 + 세션 복원을 지원.

## Test plan

- [x] `tests/test_session_resume.py` 11건 통과
- [x] 기존 `test_session_checkpoint.py` 12건 통과
- [x] 기존 `test_agentic_loop.py` 75건 통과
- [x] 전체 2946 passed, 0 failed
- [x] ruff lint 0 errors
- [x] mypy 0 errors
- [x] pre-commit hooks 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)