### PR TITLE
refactor: 시스템 프롬프트 하드캡(6000자) 제거

### DIFF
--- a/core/llm/prompt_assembler.py
+++ b/core/llm/prompt_assembler.py
@@ -71,7 +71,6 @@ class PromptAssembler:
         max_extra_instructions: int = 5,
         max_extra_instruction_chars: int = 100,
         prompt_warning_chars: int = 4000,
-        prompt_hard_limit_chars: int = 6000,
     ) -> None:
         self._skills = skill_registry or SkillRegistry()
         self._hooks = hooks
@@ -82,7 +81,6 @@ class PromptAssembler:
         self._max_extra_instructions = max_extra_instructions
         self._max_extra_instruction_chars = max_extra_instruction_chars
         self._prompt_warning_chars = prompt_warning_chars
-        self._prompt_hard_limit_chars = prompt_hard_limit_chars
 
     # -- Public API ---------------------------------------------------------
 
@@ -162,19 +160,12 @@ class PromptAssembler:
 
         user = base_user
 
-        # --- Phase 5: Token Budget Enforcement ---
+        # --- Phase 5: Token Budget Observability ---
+        # Frontier consensus: no hard cap on system prompt.
+        # 1M context models handle large prompts natively.
+        # We only warn for observability; never truncate.
         total_system_chars = len(system)
-        if total_system_chars > self._prompt_hard_limit_chars:
-            log.error(
-                "System prompt %d chars exceeds hard limit %d -- trimming",
-                total_system_chars,
-                self._prompt_hard_limit_chars,
-            )
-            truncation_events.append(
-                f"system:{total_system_chars}->{self._prompt_hard_limit_chars}"
-            )
-            system = system[: self._prompt_hard_limit_chars]
-        elif total_system_chars > self._prompt_warning_chars:
+        if total_system_chars > self._prompt_warning_chars:
             log.warning(
                 "System prompt %d chars exceeds warning threshold %d",
                 total_system_chars,

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -302,10 +302,10 @@ class TestPromptOverride:
 
 
 class TestTokenBudget:
-    def test_system_prompt_hard_limit(self, base_user: str) -> None:
-        """System prompt exceeding hard limit is trimmed."""
+    def test_large_system_prompt_not_truncated(self, base_user: str) -> None:
+        """Large system prompt is NOT truncated — frontier consensus: no hard cap."""
         big_system = "S" * 7000
-        assembler = PromptAssembler(prompt_hard_limit_chars=6000)
+        assembler = PromptAssembler()
         result = assembler.assemble(
             base_system=big_system,
             base_user=base_user,
@@ -314,7 +314,8 @@ class TestTokenBudget:
             role_type="game_mechanics",
         )
 
-        assert len(result.system) == 6000
+        # No truncation: full prompt preserved
+        assert len(result.system) >= 7000
 
 
 class TestHashing:


### PR DESCRIPTION
## Summary
- `prompt_hard_limit_chars=6000` 파라미터 및 강제 truncation 로직 제거
- 경고(warning)만 유지, 시스템 프롬프트를 자르지 않음

## Why
- 프론티어 합의(Claude Code, Codex): 1M 컨텍스트 시대에 하드캡은 잠재력 낭비
- GEODE의 다른 하드캡(tool result 4096, 턴 20)은 이미 제거 완료
- 시스템 프롬프트 6000자 캡만 잔존하고 있었음
- 대안: clear_tool_uses 서버사이드 정리 + 80%/95% 2단계 압축이 컨텍스트 관리

## Changed Files
| 파일 | Why |
|------|-----|
| `core/llm/prompt_assembler.py` | prompt_hard_limit_chars 파라미터 제거, Phase 5 truncation → warning only |
| `tests/test_prompt_assembler.py` | 하드캡 truncation 테스트 → "not truncated" 테스트로 교체 |

## Test Plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run mypy core/llm/prompt_assembler.py` — 0 errors
- [x] `uv run pytest tests/test_prompt_assembler.py` — 15 passed
- [x] `uv run pytest tests/` — 2941 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)