### PR TITLE
refactor: 시스템 프롬프트 하드캡 제거

### DIFF
--- a/core/llm/prompt_assembler.py
+++ b/core/llm/prompt_assembler.py
@@ -71,7 +71,6 @@ class PromptAssembler:
         max_extra_instructions: int = 5,
         max_extra_instruction_chars: int = 100,
         prompt_warning_chars: int = 4000,
-        prompt_hard_limit_chars: int = 6000,
     ) -> None:
         self._skills = skill_registry or SkillRegistry()
         self._hooks = hooks
@@ -82,7 +81,6 @@ class PromptAssembler:
         self._max_extra_instructions = max_extra_instructions
         self._max_extra_instruction_chars = max_extra_instruction_chars
         self._prompt_warning_chars = prompt_warning_chars
-        self._prompt_hard_limit_chars = prompt_hard_limit_chars
 
     # -- Public API ---------------------------------------------------------
 
@@ -162,19 +160,12 @@ class PromptAssembler:
 
         user = base_user
 
-        # --- Phase 5: Token Budget Enforcement ---
+        # --- Phase 5: Token Budget Observability ---
+        # Frontier consensus: no hard cap on system prompt.
+        # 1M context models handle large prompts natively.
+        # We only warn for observability; never truncate.
         total_system_chars = len(system)
-        if total_system_chars > self._prompt_hard_limit_chars:
-            log.error(
-                "System prompt %d chars exceeds hard limit %d -- trimming",
-                total_system_chars,
-                self._prompt_hard_limit_chars,
-            )
-            truncation_events.append(
-                f"system:{total_system_chars}->{self._prompt_hard_limit_chars}"
-            )
-            system = system[: self._prompt_hard_limit_chars]
-        elif total_system_chars > self._prompt_warning_chars:
+        if total_system_chars > self._prompt_warning_chars:
             log.warning(
                 "System prompt %d chars exceeds warning threshold %d",
                 total_system_chars,

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -302,10 +302,10 @@ class TestPromptOverride:
 
 
 class TestTokenBudget:
-    def test_system_prompt_hard_limit(self, base_user: str) -> None:
-        """System prompt exceeding hard limit is trimmed."""
+    def test_large_system_prompt_not_truncated(self, base_user: str) -> None:
+        """Large system prompt is NOT truncated — frontier consensus: no hard cap."""
         big_system = "S" * 7000
-        assembler = PromptAssembler(prompt_hard_limit_chars=6000)
+        assembler = PromptAssembler()
         result = assembler.assemble(
             base_system=big_system,
             base_user=base_user,
@@ -314,7 +314,8 @@ class TestTokenBudget:
             role_type="game_mechanics",
         )
 
-        assert len(result.system) == 6000
+        # No truncation: full prompt preserved
+        assert len(result.system) >= 7000
 
 
 class TestHashing:


### PR DESCRIPTION
## Summary
- prompt_hard_limit_chars=6000 제거. 프론티어 합의: 하드캡 대신 압축.

🤖 Generated with [Claude Code](https://claude.com/claude-code)