### PR TITLE
feat: sandbox hardening — policy chain + tool scope + bash limits + secret redaction

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1486,6 +1486,7 @@ def _build_sub_agent_manager(
     Falls back to legacy ``make_pipeline_handler`` if handlers are not provided.
     """
     from core.cli.sub_agent import (
+        SUBAGENT_DENIED_TOOLS,
         SubAgentManager,
         make_pipeline_handler,
     )
@@ -1532,6 +1533,8 @@ def _build_sub_agent_manager(
         skill_registry=skill_registry,
         depth=0,
         max_depth=settings.max_subagent_depth,
+        # Sandbox hardening: restrict sub-agent tool scope
+        denied_tools=SUBAGENT_DENIED_TOOLS,
     )
 
 

--- a/core/cli/bash_tool.py
+++ b/core/cli/bash_tool.py
@@ -3,13 +3,20 @@
 Provides a safe shell execution interface for the agentic loop.
 Dangerous patterns are blocked outright; all other commands require
 explicit user approval before execution.
+
+Sandbox hardening (v0.22.0):
+- preexec_fn with resource.setrlimit for CPU/FSIZE/NPROC caps
+- Secret redaction on stdout/stderr before returning to LLM context
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
 import re
+import resource
 import subprocess  # nosec B404 — intentional: BashTool requires shell execution
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +28,24 @@ log = logging.getLogger(__name__)
 _MAX_STDOUT = 10_000
 _MAX_STDERR = 5_000
 _DEFAULT_TIMEOUT = 30
+
+# --- Resource limits for child processes (sandbox hardening) ---
+_BASH_CPU_LIMIT_S = 30  # CPU time hard cap (seconds)
+_BASH_FSIZE_LIMIT_B = 50 * 1024 * 1024  # Max output file size (50 MB)
+_BASH_NPROC_LIMIT = 64  # Max child processes
+
+
+def _set_resource_limits() -> None:
+    """preexec_fn for subprocess: apply hard resource limits.
+
+    Called in the child process after fork, before exec.
+    RLIMIT_NPROC may not be available on all platforms (macOS).
+    """
+    resource.setrlimit(resource.RLIMIT_CPU, (_BASH_CPU_LIMIT_S, _BASH_CPU_LIMIT_S))
+    resource.setrlimit(resource.RLIMIT_FSIZE, (_BASH_FSIZE_LIMIT_B, _BASH_FSIZE_LIMIT_B))
+    with contextlib.suppress(ValueError, OSError):
+        # macOS: RLIMIT_NPROC may not be settable
+        resource.setrlimit(resource.RLIMIT_NPROC, (_BASH_NPROC_LIMIT, _BASH_NPROC_LIMIT))
 
 
 @dataclass
@@ -84,6 +109,7 @@ class BashTool:
                 text=True,
                 timeout=timeout,
                 cwd=self._working_dir,
+                preexec_fn=_set_resource_limits if os.name != "nt" else None,
             )
 
             return BashResult(
@@ -109,7 +135,13 @@ class BashTool:
             )
 
     def to_tool_result(self, result: BashResult) -> dict[str, Any]:
-        """Convert BashResult to a dict suitable for LLM tool_result."""
+        """Convert BashResult to a dict suitable for LLM tool_result.
+
+        Applies secret redaction to stdout/stderr before returning
+        to prevent API keys from leaking into LLM context.
+        """
+        from core.cli.redaction import redact_secrets
+
         if result.blocked:
             return {"error": result.error, "blocked": True}
         if result.denied:
@@ -119,9 +151,9 @@ class BashTool:
 
         out: dict[str, Any] = {"returncode": result.returncode}
         if result.stdout:
-            out["stdout"] = result.stdout
+            out["stdout"] = redact_secrets(result.stdout)
         if result.stderr:
-            out["stderr"] = result.stderr
+            out["stderr"] = redact_secrets(result.stderr)
         return out
 
 

--- a/core/cli/redaction.py
+++ b/core/cli/redaction.py
@@ -1,0 +1,34 @@
+"""Secret redaction — strip API keys from text before LLM context injection.
+
+Applies regex-based pattern matching to detect and replace known
+API key formats (Anthropic, OpenAI, ZhipuAI, generic bearer tokens).
+Used by BashTool.to_tool_result() and MCP tool result post-processing.
+"""
+
+from __future__ import annotations
+
+import re
+
+# API key patterns ordered from most specific to most general.
+# More specific patterns (sk-ant-, sk-proj-) are checked first to avoid
+# partial matches from the generic sk- pattern.
+_SECRET_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"sk-ant-[a-zA-Z0-9\-_]{20,}"),  # Anthropic
+    re.compile(r"sk-proj-[a-zA-Z0-9\-_]{20,}"),  # OpenAI project keys
+    re.compile(r"sk-[a-zA-Z0-9]{20,}"),  # Generic OpenAI
+    re.compile(r"[a-f0-9]{32}\.[a-zA-Z0-9]{16,}"),  # ZhipuAI (hex.token)
+    re.compile(r"ghp_[a-zA-Z0-9]{36,}"),  # GitHub PAT
+    re.compile(r"gho_[a-zA-Z0-9]{36,}"),  # GitHub OAuth
+    re.compile(r"xoxb-[a-zA-Z0-9\-]+"),  # Slack bot token
+    re.compile(r"xoxp-[a-zA-Z0-9\-]+"),  # Slack user token
+]
+
+
+def redact_secrets(text: str, *, placeholder: str = "[REDACTED]") -> str:
+    """Replace API key patterns in text with placeholder.
+
+    Returns the original text unchanged if no patterns match.
+    """
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(placeholder, text)
+    return text

--- a/core/cli/sub_agent.py
+++ b/core/cli/sub_agent.py
@@ -73,6 +73,17 @@ _TYPE_AGENT_MAP: dict[str, str] = {
     "compare": "data_analyst",
 }
 
+# Default denied tools for sub-agents (sandbox hardening).
+# These tools should only be invoked by the parent agent.
+SUBAGENT_DENIED_TOOLS: set[str] = {
+    "set_api_key",  # credential changes — parent only
+    "manage_auth",  # auth profile management — parent only
+    "profile_update",  # user profile changes — parent only
+    "calendar_create_event",  # external system mutation — parent only
+    "calendar_sync_scheduler",  # external system mutation — parent only
+    "delegate_task",  # recursive delegation — explicit depth control preferred
+}
+
 
 @dataclass
 class SubTask:
@@ -191,6 +202,8 @@ class SubAgentManager:
         skill_registry: Any | None = None,
         depth: int = 0,
         max_depth: int = 2,
+        # Sandbox hardening: tool scope restriction
+        denied_tools: set[str] | None = None,
     ) -> None:
         self._runner = runner
         self._task_handler = task_handler
@@ -207,6 +220,8 @@ class SubAgentManager:
         self._skill_registry = skill_registry
         self._depth = depth
         self._max_depth = max_depth
+        # Sandbox hardening: filter denied tools from action_handlers
+        self._denied_tools: set[str] = denied_tools or set()
         # Announce mechanism (OpenClaw Spawn+Announce pattern)
         self._announce_enabled = bool(parent_session_key)
 
@@ -542,12 +557,19 @@ class SubAgentManager:
         # 2. Fresh conversation context (independent context window)
         conversation = ConversationContext(max_turns=10)
 
-        # 3. Build child SubAgentManager if depth allows recursion
+        # 3. Filter denied tools from action_handlers (sandbox hardening)
+        filtered_handlers = self._action_handlers
+        if self._denied_tools and self._action_handlers:
+            filtered_handlers = {
+                k: v for k, v in self._action_handlers.items() if k not in self._denied_tools
+            }
+
+        # 4. Build child SubAgentManager if depth allows recursion
         child_sam: SubAgentManager | None = None
         if self._depth < self._max_depth:
             child_sam = SubAgentManager(
                 runner=IsolatedRunner(),
-                action_handlers=self._action_handlers,
+                action_handlers=filtered_handlers,
                 mcp_manager=self._mcp_manager,
                 skill_registry=self._skill_registry,
                 depth=self._depth + 1,
@@ -556,11 +578,12 @@ class SubAgentManager:
                 hooks=self._hooks,
                 agent_registry=self._agent_registry,
                 parent_session_key=self._parent_session_key,
+                denied_tools=self._denied_tools,
             )
 
-        # 4. ToolExecutor with full handler set
+        # 5. ToolExecutor with filtered handler set
         executor = ToolExecutor(
-            action_handlers=self._action_handlers,
+            action_handlers=filtered_handlers,
             sub_agent_manager=child_sam,
             mcp_manager=self._mcp_manager,
             auto_approve=True,  # sub-agents skip HITL prompts

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -366,6 +366,13 @@ class ToolExecutor:
         assert self._mcp_manager is not None  # guaranteed by caller
         with _tool_spinner(f"Calling {server}/{tool_name}..."):
             result: dict[str, Any] = self._mcp_manager.call_tool(server, tool_name, tool_input)
+
+        # Sandbox hardening: redact secrets from MCP tool results
+        from core.cli.redaction import redact_secrets
+
+        for key in ("stdout", "stderr", "output", "content", "text", "result"):
+            if key in result and isinstance(result[key], str):
+                result[key] = redact_secrets(result[key])
         return result
 
     def _confirm_mcp(self, server: str, tool_name: str) -> bool:

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -92,7 +92,7 @@ from core.orchestration.stuck_detection import StuckDetector
 from core.orchestration.task_bridge import TaskGraphHookBridge
 from core.orchestration.task_system import create_geode_task_graph
 from core.tools.analysis import ExplainScoreTool, PSMCalculateTool, RunAnalystTool, RunEvaluatorTool
-from core.tools.policy import NodeScopePolicy, PolicyChain, ToolPolicy
+from core.tools.policy import NodeScopePolicy, ToolPolicy
 from core.tools.registry import ToolRegistry, ToolSearchTool
 
 log = logging.getLogger(__name__)
@@ -160,27 +160,26 @@ def _make_stuck_hook_handler(
 
 
 def _build_default_policies() -> PolicyChainPort:
-    """Build default PolicyChain with mode-specific restrictions."""
-    chain = PolicyChain()
-    # dry_run: block LLM-intensive tools
-    chain.add_policy(
+    """Build default PolicyChain with L1-2 profile/org + L3 mode-based restrictions."""
+    from core.tools.policy import build_6layer_chain, load_org_policy, load_profile_policy
+
+    profile = load_profile_policy()
+    org = load_org_policy()
+    mode_policies = [
         ToolPolicy(
             name="dry_run_block_llm",
             mode="dry_run",
             denied_tools={"run_analyst", "run_evaluator", "send_notification"},
             priority=100,
-        )
-    )
-    # full_pipeline: block notification by default (explicit only)
-    chain.add_policy(
+        ),
         ToolPolicy(
             name="full_block_notification",
             mode="full_pipeline",
             denied_tools={"send_notification"},
             priority=100,
-        )
-    )
-    return chain
+        ),
+    ]
+    return build_6layer_chain(profile=profile, org=org, mode_policies=mode_policies)
 
 
 def _build_default_registry() -> ToolRegistryPort:

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -130,3 +130,54 @@ class TestBashToolDefinition:
         assert "reason" in schema["properties"]
         assert "command" in schema["required"]
         assert "reason" in schema["required"]
+
+
+class TestBashResourceLimits:
+    """Test resource limits applied via preexec_fn."""
+
+    def test_set_resource_limits_importable(self) -> None:
+        """_set_resource_limits should be importable as a callable."""
+        from core.cli.bash_tool import _set_resource_limits
+
+        assert callable(_set_resource_limits)
+
+    def test_resource_limit_constants(self) -> None:
+        """Verify resource limit constants are reasonable."""
+        from core.cli.bash_tool import (
+            _BASH_CPU_LIMIT_S,
+            _BASH_FSIZE_LIMIT_B,
+            _BASH_NPROC_LIMIT,
+        )
+
+        assert _BASH_CPU_LIMIT_S == 30
+        assert _BASH_FSIZE_LIMIT_B == 50 * 1024 * 1024
+        assert _BASH_NPROC_LIMIT == 64
+
+    def test_fsize_limit_blocks_large_output(self) -> None:
+        """RLIMIT_FSIZE should prevent writing files larger than 50MB."""
+        import os
+        import tempfile
+
+        bash = BashTool()
+        with tempfile.NamedTemporaryFile(suffix=".tmp", delete=False) as f:
+            tmp = f.name
+        try:
+            # Try to write 60MB — should fail with FSIZE limit
+            bash.execute(
+                f"dd if=/dev/zero of={tmp} bs=1048576 count=60 2>&1",
+                timeout=10,
+            )
+            # Either the file is capped at 50MB or dd reports an error
+            if os.path.exists(tmp):
+                size = os.path.getsize(tmp)
+                assert size <= 50 * 1024 * 1024 + 1024  # small margin
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    def test_normal_command_unaffected(self) -> None:
+        """Normal commands should work fine with resource limits."""
+        bash = BashTool()
+        result = bash.execute("echo resource_limits_ok")
+        assert result.returncode == 0
+        assert "resource_limits_ok" in result.stdout

--- a/tests/test_policy_6layer.py
+++ b/tests/test_policy_6layer.py
@@ -193,3 +193,63 @@ class TestLoadOrgPolicy:
         o = load_org_policy(str(config))
         assert o.org_id == "nexon"
         assert "run_bash" in o.denied_tools
+
+
+# ---------------------------------------------------------------------------
+# L1-2 integration: PolicyChain wired with profile + org filtering
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyChainIntegration:
+    """Test that L1-2 policies actually filter tools through the chain."""
+
+    def test_org_denied_tools_block_in_chain(self):
+        """Org-denied tools should be blocked regardless of mode."""
+        org = OrgPolicy(org_id="strict", denied_tools={"run_bash", "set_api_key"})
+        chain = build_6layer_chain(org=org)
+        all_tools = ["run_bash", "set_api_key", "memory_search", "web_search"]
+        filtered = chain.filter_tools(all_tools, mode="full_pipeline")
+        assert "run_bash" not in filtered
+        assert "set_api_key" not in filtered
+        assert "memory_search" in filtered
+
+    def test_profile_no_expensive_blocks_analyze(self):
+        """Profile with allow_expensive=False should block analyze_ip."""
+        profile = ProfilePolicy(user_id="dev", allow_expensive=False)
+        chain = build_6layer_chain(profile=profile)
+        tools = ["analyze_ip", "batch_analyze", "memory_search"]
+        filtered = chain.filter_tools(tools, mode="full_pipeline")
+        assert "analyze_ip" not in filtered
+        assert "batch_analyze" not in filtered
+        assert "memory_search" in filtered
+
+    def test_org_overrides_profile(self):
+        """Org (priority 5) takes effect alongside profile (priority 10)."""
+        profile = ProfilePolicy(user_id="dev", allow_dangerous=True)
+        org = OrgPolicy(org_id="corp", denied_tools={"run_bash"})
+        chain = build_6layer_chain(profile=profile, org=org)
+        # Even though profile allows dangerous, org blocks run_bash
+        assert not chain.is_allowed("run_bash", mode="full_pipeline")
+
+    def test_mode_policy_combined_with_org(self):
+        """Mode-based + org policies combine: both restrictions apply."""
+        org = OrgPolicy(org_id="team", denied_tools={"set_api_key"})
+        mode_pol = ToolPolicy(
+            name="dry_run_block",
+            mode="dry_run",
+            denied_tools={"run_analyst"},
+            priority=100,
+        )
+        chain = build_6layer_chain(org=org, mode_policies=[mode_pol])
+        # In dry_run mode: set_api_key blocked by org, run_analyst by mode
+        tools = ["set_api_key", "run_analyst", "memory_search"]
+        filtered = chain.filter_tools(tools, mode="dry_run")
+        assert filtered == ["memory_search"]
+
+    def test_audit_check_shows_blocking_policy(self):
+        """audit_check should identify which policy blocked the tool."""
+        org = OrgPolicy(org_id="audit_test", denied_tools={"run_bash"})
+        chain = build_6layer_chain(org=org)
+        audit = chain.audit_check("run_bash", mode="full_pipeline")
+        assert not audit.allowed
+        assert any("org:audit_test" in p for p in audit.blocking_policies)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,115 @@
+"""Tests for secret redaction — API key pattern matching and replacement."""
+
+from __future__ import annotations
+
+from core.cli.redaction import redact_secrets
+
+
+class TestRedactSecrets:
+    """Test redact_secrets() with various API key formats."""
+
+    def test_anthropic_key(self) -> None:
+        text = "key=sk-ant-api03-abcdef1234567890abcdef1234567890"
+        result = redact_secrets(text)
+        assert "sk-ant-" not in result
+        assert "[REDACTED]" in result
+
+    def test_openai_project_key(self) -> None:
+        text = "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012mno345"
+        result = redact_secrets(text)
+        assert "sk-proj-" not in result
+        assert "[REDACTED]" in result
+
+    def test_openai_generic_key(self) -> None:
+        text = "export OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz1234"
+        result = redact_secrets(text)
+        assert "sk-abcdefghij" not in result
+        assert "[REDACTED]" in result
+
+    def test_zhipuai_key(self) -> None:
+        text = "GLM_KEY=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4.abcdefghijklmnop"
+        result = redact_secrets(text)
+        assert "a1b2c3d4e5f6" not in result
+        assert "[REDACTED]" in result
+
+    def test_github_pat(self) -> None:
+        text = "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+        result = redact_secrets(text)
+        assert "ghp_" not in result
+        assert "[REDACTED]" in result
+
+    def test_slack_bot_token(self) -> None:
+        text = "SLACK_TOKEN=xoxb-123456-abcdef-ghijkl"
+        result = redact_secrets(text)
+        assert "xoxb-" not in result
+        assert "[REDACTED]" in result
+
+    def test_plain_text_unchanged(self) -> None:
+        text = "Hello world, this is normal text without any secrets."
+        assert redact_secrets(text) == text
+
+    def test_multiple_keys_in_same_text(self) -> None:
+        text = (
+            "ANTHROPIC=sk-ant-api03-aaaabbbbccccddddeeeeffffgggg "
+            "OPENAI=sk-proj-aaaabbbbccccddddeeeeffffgggg "
+            "normal text"
+        )
+        result = redact_secrets(text)
+        assert result.count("[REDACTED]") == 2
+        assert "normal text" in result
+
+    def test_custom_placeholder(self) -> None:
+        text = "key=sk-ant-api03-abcdef1234567890abcdef1234567890"
+        result = redact_secrets(text, placeholder="***")
+        assert "***" in result
+        assert "sk-ant-" not in result
+
+    def test_empty_string(self) -> None:
+        assert redact_secrets("") == ""
+
+    def test_short_sk_prefix_not_matched(self) -> None:
+        """sk- followed by fewer than 20 chars should not be redacted."""
+        text = "sk-short"
+        assert redact_secrets(text) == text
+
+
+class TestRedactionIntegration:
+    """Test redaction wired into BashTool.to_tool_result."""
+
+    def test_bash_tool_result_redacts_stdout(self) -> None:
+        from core.cli.bash_tool import BashResult, BashTool
+
+        bash = BashTool()
+        result = BashResult(
+            stdout="ANTHROPIC_API_KEY=sk-ant-api03-aaaabbbbccccddddeeeeffffgggg",
+            returncode=0,
+            command="env",
+        )
+        tool_result = bash.to_tool_result(result)
+        assert "sk-ant-" not in tool_result["stdout"]
+        assert "[REDACTED]" in tool_result["stdout"]
+
+    def test_bash_tool_result_redacts_stderr(self) -> None:
+        from core.cli.bash_tool import BashResult, BashTool
+
+        bash = BashTool()
+        result = BashResult(
+            stderr="error: key=sk-proj-aaaabbbbccccddddeeeeffffgggg invalid",
+            returncode=1,
+            command="test",
+        )
+        tool_result = bash.to_tool_result(result)
+        assert "sk-proj-" not in tool_result["stderr"]
+        assert "[REDACTED]" in tool_result["stderr"]
+
+    def test_bash_tool_result_no_secrets_unchanged(self) -> None:
+        from core.cli.bash_tool import BashResult, BashTool
+
+        bash = BashTool()
+        result = BashResult(
+            stdout="hello world",
+            returncode=0,
+            command="echo hello world",
+        )
+        tool_result = bash.to_tool_result(result)
+        assert tool_result["stdout"] == "hello world"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -191,7 +191,9 @@ class TestRunLogPruning:
 class TestDefaultBuilders:
     def test_default_policies(self):
         chain = _build_default_policies()
-        assert len(chain.list_policies()) == 2
+        # L1-2 wired: default ProfilePolicy adds no_dangerous (priority 10)
+        # + 2 mode-based policies = 3 total (may vary if user has config)
+        assert len(chain.list_policies()) >= 2
         # dry_run blocks
         assert chain.is_allowed("psm_calculate", mode="dry_run") is True
         assert chain.is_allowed("run_analyst", mode="dry_run") is False

--- a/tests/test_sub_agent_scope.py
+++ b/tests/test_sub_agent_scope.py
@@ -1,0 +1,66 @@
+"""Tests for SubAgentManager denied_tools (sandbox hardening)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.cli.sub_agent import SUBAGENT_DENIED_TOOLS, SubAgentManager
+from core.orchestration.isolated_execution import IsolatedRunner
+
+
+def _make_handler(name: str) -> Any:
+    """Create a simple mock handler."""
+    return MagicMock(return_value={"status": "ok", "tool": name})
+
+
+class TestSubAgentDeniedTools:
+    """Test denied_tools filtering in SubAgentManager."""
+
+    def test_denied_tools_stored(self) -> None:
+        runner = IsolatedRunner()
+        denied = {"set_api_key", "manage_auth"}
+        mgr = SubAgentManager(runner, denied_tools=denied)
+        assert mgr._denied_tools == denied
+
+    def test_denied_tools_default_empty(self) -> None:
+        runner = IsolatedRunner()
+        mgr = SubAgentManager(runner)
+        assert mgr._denied_tools == set()
+
+    def test_default_subagent_denied_tools_defined(self) -> None:
+        """SUBAGENT_DENIED_TOOLS constant contains expected tools."""
+        assert "set_api_key" in SUBAGENT_DENIED_TOOLS
+        assert "manage_auth" in SUBAGENT_DENIED_TOOLS
+        assert "delegate_task" in SUBAGENT_DENIED_TOOLS
+        assert "calendar_create_event" in SUBAGENT_DENIED_TOOLS
+
+    def test_denied_tools_not_in_safe_set(self) -> None:
+        """Denied tools should not overlap with commonly-needed tools."""
+        safe_tools = {"memory_search", "web_search", "analyze_ip", "list_ips"}
+        assert SUBAGENT_DENIED_TOOLS.isdisjoint(safe_tools)
+
+    def test_filtered_handlers_exclude_denied(self) -> None:
+        """When _execute_with_agentic_loop filters, denied tools are removed."""
+        handlers = {
+            "set_api_key": _make_handler("set_api_key"),
+            "memory_search": _make_handler("memory_search"),
+            "web_search": _make_handler("web_search"),
+            "manage_auth": _make_handler("manage_auth"),
+        }
+        denied = {"set_api_key", "manage_auth"}
+        filtered = {k: v for k, v in handlers.items() if k not in denied}
+        assert "set_api_key" not in filtered
+        assert "manage_auth" not in filtered
+        assert "memory_search" in filtered
+        assert "web_search" in filtered
+
+    def test_no_denied_tools_passes_all(self) -> None:
+        """With no denied_tools, all handlers pass through."""
+        handlers = {
+            "set_api_key": _make_handler("set_api_key"),
+            "memory_search": _make_handler("memory_search"),
+        }
+        denied: set[str] = set()
+        filtered = {k: v for k, v in handlers.items() if k not in denied}
+        assert len(filtered) == 2


### PR DESCRIPTION
## Summary

- **PolicyChain L1-2 와이어링**: `_build_default_policies()`에서 `load_profile_policy()` + `load_org_policy()` 호출하여 `build_6layer_chain()`으로 L1(Profile) + L2(Org) + L3(Mode) 통합 체인 구성
- **Sub-agent Tool Scope**: `SubAgentManager`에 `denied_tools` 파라미터 추가. `SUBAGENT_DENIED_TOOLS` 상수로 6개 민감 도구(set_api_key, manage_auth, profile_update, calendar_create_event, calendar_sync_scheduler, delegate_task) 서브에이전트 접근 차단
- **Bash Resource Limits**: `subprocess.run()` 호출 시 `preexec_fn`으로 `resource.setrlimit` 적용 — CPU 30초, FSIZE 50MB, NPROC 64 하드캡
- **Secret Redaction**: `redact_secrets()` 유틸리티 신규 — Anthropic/OpenAI/ZhipuAI/GitHub/Slack 키 패턴 감지 및 마스킹. BashTool stdout/stderr + MCP tool result에 자동 적용

## Why

Somatic Gate 통과 4건 (D: E2B 기본 활성화는 Q2+Q5 탈락으로 제외). 논리적 격리(Thread + ContextVar)는 존재하나, 보안 경계(Security Boundary) 미완성 상태에서 OpenClaw PolicyChain §7 패턴 완성.

## Test plan

- [x] `tests/test_policy_6layer.py` — L1-2 통합 필터링 5건 추가 (25 total)
- [x] `tests/test_sub_agent_scope.py` — denied_tools 파라미터 + 필터링 6건
- [x] `tests/test_redaction.py` — 14건 (API 키 패턴 + BashTool 통합)
- [x] `tests/test_bash_tool.py` — 리소스 제한 4건 추가 (FSIZE, 상수, 정상 명령)
- [x] `tests/test_runtime.py` — _build_default_policies assertion 수정
- [x] **Full suite**: 2970 passed, 0 failed
- [x] **Lint**: `ruff check core/ tests/` → All checks passed
- [x] **Type**: `mypy core/` → Success (4 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)