### PR TITLE
fix: GLM base URL + keepalive + MCP test

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -250,7 +250,7 @@ class Settings(BaseSettings):
     # LLM Connection — httpx pool & timeout tuning
     llm_max_connections: int = 20  # httpx pool: max total connections
     llm_max_keepalive_connections: int = 5  # httpx pool: max idle keep-alive connections
-    llm_keepalive_expiry: float = 15.0  # idle conn TTL (shorter = fewer stale)
+    llm_keepalive_expiry: float = 30.0  # idle conn TTL (match API server timeout)
     llm_connect_timeout: float = 5.0  # TCP connect timeout (fail fast)
     llm_read_timeout: float = 300.0  # response read timeout (5min for 1M context)
     llm_write_timeout: float = 30.0  # request write timeout (seconds)
@@ -301,7 +301,7 @@ OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.4", "gpt-5.2", "gpt-4.1"]
 # ZhipuAI (GLM) models — OpenAI-compatible API, separate provider
 GLM_PRIMARY = "glm-5"
 GLM_FALLBACK_CHAIN: list[str] = ["glm-5", "glm-5-turbo", "glm-4.7-flash"]
-GLM_BASE_URL = "https://api.z.ai/v1"
+GLM_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
 
 
 def _resolve_provider(model: str) -> str:

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -133,10 +133,13 @@ class TestMCPRegistry:
     def test_discover_excludes_auto_servers_when_env_missing(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("BRAVE_API_KEY", None)
-            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
-            result = registry.discover()
-            # brave-search requires BRAVE_API_KEY
-            assert "brave-search" not in result
+            # Also mock global .env to prevent cascade loading
+            with patch("core.infrastructure.adapters.mcp.registry.Path") as mock_path:
+                mock_path.home.return_value = Path("/nonexistent_home")
+                registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+                result = registry.discover()
+                # brave-search requires BRAVE_API_KEY
+                assert "brave-search" not in result
 
     def test_discover_server_config_structure(self) -> None:
         registry = MCPRegistry(dotenv_path="/nonexistent/.env")
@@ -154,10 +157,13 @@ class TestMCPRegistry:
     def test_list_missing_env(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("BRAVE_API_KEY", None)
-            registry = MCPRegistry(dotenv_path="/nonexistent/.env")
-            missing = registry.list_missing_env()
-            assert "brave-search" in missing
-            assert "BRAVE_API_KEY" in missing["brave-search"]
+            # Mock global .env to prevent cascade loading
+            with patch("core.infrastructure.adapters.mcp.registry.Path") as mock_path:
+                mock_path.home.return_value = Path("/nonexistent_home")
+                registry = MCPRegistry(dotenv_path="/nonexistent/.env")
+                missing = registry.list_missing_env()
+                assert "brave-search" in missing
+                assert "BRAVE_API_KEY" in missing["brave-search"]
 
     def test_defaults_all_in_catalog(self) -> None:
         """All DEFAULT_SERVERS must exist in MCP_CATALOG."""


### PR DESCRIPTION
- #343 GLM 404 + keepalive 30s + test isolation