### PR TITLE
fix: MCP startup log noise — warning→debug

### DIFF
--- a/core/infrastructure/adapters/mcp/manager.py
+++ b/core/infrastructure/adapters/mcp/manager.py
@@ -203,7 +203,7 @@ class MCPServerManager:
             if registry_count > 0:
                 log.info("MCP registry: %d servers auto-discovered", registry_count)
         except Exception as exc:
-            log.warning("MCP registry discovery failed: %s", exc)
+            log.debug("MCP registry discovery failed: %s", exc)
 
         # Layer 2: file overrides (merge on top)
         file_count = 0
@@ -221,7 +221,7 @@ class MCPServerManager:
                         self._config_path,
                     )
             except (json.JSONDecodeError, OSError) as exc:
-                log.warning("Failed to load MCP config file: %s", exc)
+                log.debug("Failed to load MCP config file: %s", exc)
 
         total = len(self._servers)
         if total > 0:

--- a/core/infrastructure/adapters/mcp/stdio_client.py
+++ b/core/infrastructure/adapters/mcp/stdio_client.py
@@ -76,7 +76,7 @@ class StdioMCPClient:
             wait_deadline = time.time() + min(self._timeout_s, 10.0)
             while time.time() < wait_deadline:
                 if self._process.poll() is not None:
-                    log.warning(
+                    log.debug(
                         "MCP server exited prematurely (PID %d, code=%s)",
                         self._pid,
                         self._process.returncode,
@@ -118,7 +118,7 @@ class StdioMCPClient:
             return True
 
         except (OSError, FileNotFoundError) as exc:
-            log.warning("Failed to start MCP server '%s': %s", self._command, exc)
+            log.debug("Failed to start MCP server '%s': %s", self._command, exc)
             self._pid = None
             return False
 


### PR DESCRIPTION
## Summary

MCP 서버 연결 실패 메시지가 유저 콘솔에 노출되는 문제 수정.

**원인**: root logger에 handler가 없어 Python `lastResort` handler가 WARNING 이상을 stderr에 직접 출력.
**수정**: MCP startup 실패 로그를 `log.warning` → `log.debug`로 하향. Graceful degradation이므로 유저에게 보일 필요 없음.

## Test plan
- [x] 3058 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)