### PR TITLE
fix: MCP 로딩 중 TextSpinner 적용

### DIFF
--- a/core/cli/repl.py
+++ b/core/cli/repl.py
@@ -267,20 +267,23 @@ def _interactive_loop() -> None:
 
     # 4. MCP servers (slowest -- npx subprocess spawn)
     #    Uses startup() for full lifecycle: config + connect + signal handlers + atexit
-    _init_step("MCP servers")
+    #    TextSpinner blocks visual input during the slow npx subprocess phase.
     from core.infrastructure.adapters.mcp.manager import MCPServerManager
+    from core.ui.status import TextSpinner
 
     mcp_mgr: MCPServerManager | None = None
+    _mcp_spinner = TextSpinner("MCP servers")
+    _mcp_spinner.start()
     try:
         _mgr = MCPServerManager()
         n_connected = _mgr.startup()
         if len(_mgr._servers) > 0:
             mcp_mgr = _mgr
-            _init_done(f"MCP ({n_connected}/{len(_mgr._servers)} servers)")
+            _mcp_spinner.stop(f"  ok MCP ({n_connected}/{len(_mgr._servers)} servers)")
         else:
-            _init_done("MCP (none)", ok=False)
+            _mcp_spinner.stop("  skip MCP (none)")
     except Exception:
-        _init_done("MCP", ok=False)
+        _mcp_spinner.stop("  skip MCP")
         log.debug("MCP initialization skipped", exc_info=True)
 
     # 5. Skills


### PR DESCRIPTION
## Summary

- MCP 서버 초기화(npx subprocess spawn) 동안 TextSpinner 애니메이션 적용
- 기존 `_init_step()` 단순 출력 → `TextSpinner` 스피닝으로 교체
- 로딩 중임을 시각적으로 표시하여 사용자 입력 방지

## Why

MCP 서버 로딩은 가장 느린 스타트업 단계(서버당 5-10초). 기존에는 `Loading MCP servers...` 텍스트만 표시되어 로딩 중에 사용자가 입력을 시작할 수 있었음.

## Test plan

- [x] ruff lint: 0 errors
- [x] pytest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)