### PR TITLE
fix: 모델 자기 인식 — 하드코딩 제거 + 모델 카드 주입

### DIFF
--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -318,12 +318,18 @@ class AgenticLoop:
         Fixes the model caching bug: ``self.model`` was only set at init,
         so ``/model`` changes were not reflected in subsequent LLM calls.
         Resets the cached client so a new one is created for the new provider.
+        Also syncs the SessionMeter so status lines show the correct model.
         """
         old_provider = self._provider
         self.model = model
         self._provider = provider or _resolve_provider(model)
         if self._provider != old_provider:
             self._client = None  # force new client for new provider
+
+        # Sync SessionMeter so "Worked for" status line shows the correct model
+        from core.ui.agentic_ui import update_session_model
+
+        update_session_model(model)
         log.info("AgenticLoop model updated: %s (provider=%s)", model, self._provider)
 
     def run(self, user_input: str) -> AgenticResult:
@@ -703,7 +709,7 @@ class AgenticLoop:
 
     def _build_system_prompt(self) -> str:
         """Build the system prompt with skill context and agentic suffix."""
-        base = _build_system_prompt()
+        base = _build_system_prompt(model=self.model)
         # Inject skill context into placeholder
         skill_ctx = ""
         if self._skill_registry is not None:

--- a/core/cli/system_prompt.py
+++ b/core/cli/system_prompt.py
@@ -39,8 +39,8 @@ _NOTABLE_IPS = {
 }
 
 
-def build_system_prompt() -> str:
-    """Build system prompt with notable IP examples and memory context (P1-C)."""
+def build_system_prompt(model: str = "") -> str:
+    """Build system prompt with model card, IP examples, and memory context."""
     from core.fixtures import FIXTURE_MAP, load_fixture
 
     name_map = get_ip_name_map()
@@ -61,12 +61,73 @@ def build_system_prompt() -> str:
         ip_examples=", ".join(sorted(examples)),
     )
 
+    # Model card: inject current model info so LLM can answer model questions directly
+    if model:
+        model_card = _build_model_card(model)
+        if model_card:
+            base += "\n\n" + model_card
+
     # P1-C: Inject memory context (recent insights + active rules)
     memory_ctx = _build_memory_context()
     if memory_ctx:
         base += "\n\n" + memory_ctx
 
     return base
+
+
+def _build_model_card(model: str) -> str:
+    """Build a model card string for system prompt injection.
+
+    Reads from MODEL_PRICING and MODEL_CONTEXT_WINDOW so the LLM
+    can answer model-related questions directly without tool calls.
+    """
+    try:
+        from core.config import _resolve_provider
+        from core.llm.token_tracker import MODEL_CONTEXT_WINDOW, MODEL_PRICING
+
+        provider = _resolve_provider(model)
+        pricing = MODEL_PRICING.get(model)
+        ctx_window = MODEL_CONTEXT_WINDOW.get(model, 0)
+
+        parts: list[str] = [f"## Current Model\nYou are powered by **{model}** ({provider})."]
+
+        if ctx_window:
+            if ctx_window < 1_000_000:
+                ctx_str = f"{ctx_window // 1000}K"
+            else:
+                ctx_str = f"{ctx_window / 1_000_000:.0f}M"
+            parts.append(f"Context window: {ctx_str} tokens.")
+
+        if pricing:
+            parts.append(
+                f"Cost: ${pricing.input:.2f} input / ${pricing.output:.2f} output per 1M tokens."
+            )
+
+        # Fallback chain
+        from core.config import (
+            ANTHROPIC_FALLBACK_CHAIN,
+            GLM_FALLBACK_CHAIN,
+            OPENAI_FALLBACK_CHAIN,
+        )
+
+        chains = {
+            "anthropic": ANTHROPIC_FALLBACK_CHAIN,
+            "openai": OPENAI_FALLBACK_CHAIN,
+            "glm": GLM_FALLBACK_CHAIN,
+        }
+        chain = chains.get(provider, [])
+        if chain:
+            parts.append(f"Fallback chain: {' -> '.join(chain)}.")
+
+        parts.append(
+            "For model-related questions, answer directly from this context. "
+            "Do NOT call check_status for model info."
+        )
+
+        return "\n".join(parts)
+    except Exception:
+        log.debug("Failed to build model card", exc_info=True)
+        return ""
 
 
 def _build_memory_context() -> str:

--- a/core/ui/agentic_ui.py
+++ b/core/ui/agentic_ui.py
@@ -36,7 +36,7 @@ class SessionMeter:
     """Tracks session-level timing for status line display."""
 
     start_time: float = field(default_factory=time.monotonic)
-    model: str = "claude-opus-4-6"
+    model: str = ""
 
     @property
     def elapsed_s(self) -> float:
@@ -54,11 +54,21 @@ class SessionMeter:
 _session_meter: SessionMeter | None = None
 
 
-def init_session_meter(model: str = "claude-opus-4-6") -> SessionMeter:
+def init_session_meter(model: str = "") -> SessionMeter:
     """Initialize the session meter singleton."""
     global _session_meter
+    if not model:
+        from core.config import ANTHROPIC_PRIMARY
+
+        model = ANTHROPIC_PRIMARY
     _session_meter = SessionMeter(model=model)
     return _session_meter
+
+
+def update_session_model(model: str) -> None:
+    """Update the session meter's model after /model switch."""
+    if _session_meter is not None:
+        _session_meter.model = model
 
 
 def get_session_meter() -> SessionMeter | None:


### PR DESCRIPTION
## Summary

- SessionMeter.model 하드코딩 `"claude-opus-4-6"` 제거 → 실제 모델명 표시
- `/model` 전환 시 `update_session_model()` 호출로 "Worked for" 상태라인 동기화
- 시스템 프롬프트에 모델 카드 동적 주입 — LLM이 모델 질문에 도구 호출 없이 직답

## Why

GLM-5로 동작해도 상태라인에 항상 `claude-opus-4-6`으로 표시. 모델 관련 질문 시 `check_status()` 호출하여 시스템 전체 덤프 → 비효율적이고 부정확한 응답.

## Changes

| File | Change |
|------|--------|
| `core/ui/agentic_ui.py` | `SessionMeter.model` 기본값 제거 + `update_session_model()` 추가 |
| `core/cli/agentic_loop.py` | `update_model()` 시 SessionMeter 동기화 |
| `core/cli/system_prompt.py` | `_build_model_card()` 추가 — 모델명, 프로바이더, context window, 가격, fallback chain |

## Test plan

- [x] ruff lint: 0 errors
- [x] mypy: 0 errors
- [x] pytest 3057 pass
- [x] MODEL_CONTEXT_WINDOW vs CLAUDE.md 정합성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)