### PR TITLE
feat: 시스템 프롬프트 현재 날짜 주입 — LLM 연도 오류 방지

### DIFF
--- a/core/cli/system_prompt.py
+++ b/core/cli/system_prompt.py
@@ -10,6 +10,7 @@ prompt without depending on the NL Router module.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 
 from core.cli.ip_names import get_ip_name_map
 from core.llm.prompts import ROUTER_SYSTEM
@@ -67,12 +68,30 @@ def build_system_prompt(model: str = "") -> str:
         if model_card:
             base += "\n\n" + model_card
 
+    # Inject current date so LLM uses the correct year for searches
+    base += "\n\n" + _build_date_context()
+
     # P1-C: Inject memory context (recent insights + active rules)
     memory_ctx = _build_memory_context()
     if memory_ctx:
         base += "\n\n" + memory_ctx
 
     return base
+
+
+def _build_date_context() -> str:
+    """Build current date string for system prompt injection.
+
+    Prevents the LLM from defaulting to its knowledge-cutoff year when
+    searching for recent information.
+    """
+    now = datetime.now()
+    return (
+        f"## Current Date\n"
+        f"Today is {now.strftime('%Y-%m-%d (%A)')}. "
+        f"The current year is {now.year}. "
+        f"When searching for recent or latest information, use {now.year} as the base year."
+    )
 
 
 def _build_model_card(model: str) -> str:

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -8,6 +8,7 @@ Provides:
 from __future__ import annotations
 
 import logging
+from datetime import date
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -83,7 +84,11 @@ class GeneralWebSearchTool:
 
     @property
     def description(self) -> str:
-        return "Search the web for current information on any topic."
+        today = date.today()
+        return (
+            f"Search the web for current information on any topic. "
+            f"Today is {today.isoformat()} (year {today.year})."
+        )
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         query: str = kwargs["query"]
@@ -96,6 +101,7 @@ class GeneralWebSearchTool:
             if not settings.anthropic_api_key:
                 return {"error": "No API key configured for web search"}
 
+            today = date.today()
             client = get_anthropic_client()
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
@@ -105,6 +111,7 @@ class GeneralWebSearchTool:
                     {
                         "role": "user",
                         "content": (
+                            f"Today is {today.isoformat()}. "
                             f"Search the web for: {query}. "
                             f"Return up to {max_results} relevant results "
                             "with titles, URLs, and brief summaries."


### PR DESCRIPTION
## Summary

- LLM knowledge cutoff(2025) 때문에 "최근 자료 찾아줘" 시 2025로 검색하는 문제 해결
- `system_prompt.py`에 `_build_date_context()` 추가 — 모든 대화 시작 시 `Today is 2026-03-22 (Sunday). The current year is 2026.` 주입
- `web_tools.py` GeneralWebSearchTool의 description과 검색 쿼리에 현재 날짜 동적 반영

## Why

LLM의 학습 데이터 기준 연도와 실제 연도 차이로 인해 웹 검색, 트렌드 조사 등에서 잘못된 연도를 사용하는 반복적 문제 발생. 시스템 프롬프트에 날짜를 명시하면 LLM이 올바른 시간 기준으로 작업 수행.

## Changes

| File | Change |
|------|--------|
| `core/cli/system_prompt.py` | `_build_date_context()` 함수 추가, `build_system_prompt()`에서 호출 |
| `core/tools/web_tools.py` | `GeneralWebSearchTool.description` 동적 날짜 포함, 검색 쿼리에 날짜 프리픽스 |

## Test plan

- [x] Lint 0 errors (`ruff check`)
- [x] Type check 0 errors (`mypy`)
- [x] 전체 테스트 3055+ pass (`pytest -m "not live"`)
- [x] `build_system_prompt()` 출력에 `## Current Date` 섹션 + 현재 연도 포함 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)