### PR TITLE
fix: Gateway 양방향 소통 — 로깅 + 중복 방지 + 메시지별 독립 context

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -3296,8 +3296,14 @@ def serve(
     ),
 ) -> None:
     """Run GEODE Gateway in headless mode (no REPL, Slack/Discord/Telegram only)."""
+    import logging as _logging
     import signal
     import time as _time
+
+    _logging.basicConfig(
+        level=_logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
 
     # Load .env files into os.environ so Pollers can see credentials
     # (Pydantic Settings loads them internally, but os.environ is not populated)
@@ -3343,20 +3349,20 @@ def serve(
         console.print("  [warning]No gateway available after runtime init.[/warning]")
         raise typer.Exit(1)
 
-    def _make_processor() -> Any:
-        """Create a fresh AgenticLoop processor for each inbound message."""
+    def _gateway_processor(content: str) -> str:
+        """Process a gateway message with a fresh AgenticLoop per message."""
         ctx = ConversationContext(max_turns=20)
         handlers = _build_tool_handlers()
         executor = ToolExecutor(action_handlers=handlers, hitl_level=0)
         loop = AgenticLoop(ctx, executor, max_rounds=5)
-
-        def _process(content: str) -> str:
+        try:
             result = loop.run(content)
             return result.text if result else ""
+        except Exception as exc:
+            log.warning("Gateway processor error: %s", exc, exc_info=True)
+            return f"Error: {exc}"
 
-        return _process
-
-    gateway.set_processor(_make_processor())
+    gateway.set_processor(_gateway_processor)
 
     # Start pollers
     gateway.start()

--- a/core/gateway/pollers/slack_poller.py
+++ b/core/gateway/pollers/slack_poller.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from typing import TYPE_CHECKING, Any
 
 from core.gateway.models import InboundMessage
@@ -65,6 +64,8 @@ class SlackPoller(BasePoller):
 
     def _poll_channel(self, channel_id: str) -> None:
         """Poll a single Slack channel for new messages."""
+        import json as _json
+
         try:
             args: dict[str, Any] = {"channel_id": channel_id, "limit": 5}
             oldest = self._last_ts.get(channel_id)
@@ -74,9 +75,6 @@ class SlackPoller(BasePoller):
             result = self._mcp.call_tool("slack", "slack_get_channel_history", args)  # type: ignore[union-attr]
 
             # MCP returns {"content": [{"text": "{\"ok\":true,\"messages\":[...]}"}]}
-            # Parse the nested JSON from MCP content wrapper
-            import json as _json
-
             parsed = result
             if "content" in result and isinstance(result["content"], list):
                 try:
@@ -86,35 +84,66 @@ class SlackPoller(BasePoller):
                     parsed = result
 
             if "error" in parsed or not parsed.get("ok", True):
+                log.debug("Slack history error: %s", parsed.get("error", "unknown"))
                 return
 
             messages = parsed.get("messages", [])
+            if not messages:
+                return
+
+            # First poll: seed oldest ts and skip all existing messages
+            if not oldest:
+                latest_ts = max(m.get("ts", "0") for m in messages)
+                self._last_ts[channel_id] = latest_ts
+                log.info(
+                    "Slack poller seeded ts=%s for %s (%d skipped)",
+                    latest_ts,
+                    channel_id,
+                    len(messages),
+                )
+                return
+
+            # Process only new messages (newer than oldest)
+            new_max_ts = oldest
             for msg in messages:
                 ts = msg.get("ts", "")
+                if not ts or ts <= oldest:
+                    continue
                 # Skip bot messages (own messages + other bots)
                 if msg.get("subtype") == "bot_message" or "bot_id" in msg:
+                    if ts > new_max_ts:
+                        new_max_ts = ts
                     continue
-                if ts and (not oldest or ts > oldest):
-                    self._last_ts[channel_id] = ts
+
+                if ts > new_max_ts:
+                    new_max_ts = ts
+
+                content = msg.get("text", "").strip()
+                if not content:
+                    continue
+
+                log.info("Slack message from %s: %s", msg.get("user", "?"), content[:80])
 
                 inbound = InboundMessage(
                     channel="slack",
                     channel_id=channel_id,
                     sender_id=msg.get("user", ""),
                     sender_name=msg.get("username", msg.get("user", "")),
-                    content=msg.get("text", ""),
-                    timestamp=float(ts) if ts else time.time(),
+                    content=content,
+                    timestamp=float(ts),
                     thread_id=msg.get("thread_ts", ""),
                 )
 
                 response = self._manager.route_message(inbound)
+                log.info("Processor returned: %s", (response or "")[:80])
 
-                # Send response back if auto_respond is enabled
                 if response:
                     self._send_response(channel_id, response, thread_ts=inbound.thread_id or ts)
 
-        except Exception as exc:
-            log.debug("Slack poll error for %s: %s", channel_id, exc)
+            self._last_ts[channel_id] = new_max_ts
+
+        except Exception:
+            log.warning("Slack poll error for %s", channel_id, exc_info=True)
 
     def _send_response(self, channel_id: str, text: str, *, thread_ts: str = "") -> None:
         """Send response back to Slack via the same MCP connection used for polling."""


### PR DESCRIPTION
## Summary

`geode serve`로 Slack Gateway 실행 시 유저 메시지에 응답하지 못하던 5건 버그 수정.

- **로깅 설정**: serve()에 `logging.basicConfig(INFO)` — 디버깅 가시성 확보
- **중복 방지**: 첫 폴링 시 oldest ts seeding → 기존 메시지 스킵
- **에러 가시성**: `_poll_channel()` except를 `log.warning(exc_info=True)`로 상향
- **독립 context**: 매 메시지마다 새 AgenticLoop + ConversationContext 생성
- **ts 추적 수정**: 메시지 처리 후 `new_max_ts` 갱신으로 중복 처리 근절

## Root Cause

`.geode/config.toml` 미존재 시 바인딩 0개 → 폴링할 채널 없음 → 무응답.
에러 로그가 `log.debug`로만 출력되어 원인 파악 불가.

## Test plan

- [x] Slack `#새-채널`에서 유저 메시지 전송 → GEODE 봇 응답 확인 (자기소개 생성)
- [x] 기존 메시지 재처리 없음 확인 (seeding)
- [x] `tests/test_gateway.py` + `tests/test_notification_adapters.py` 전부 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)