### PR TITLE
fix: Failover 로그 노이즈 + LLM timeout 120s

### DIFF
--- a/core/infrastructure/adapters/llm/openai_adapter.py
+++ b/core/infrastructure/adapters/llm/openai_adapter.py
@@ -112,7 +112,7 @@ class OpenAIAdapter:
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
-                timeout=90.0,
+                timeout=120.0,
             )
             # Track usage
             if response.usage:
@@ -175,7 +175,7 @@ class OpenAIAdapter:
                     {"role": "user", "content": user},
                 ],
                 response_format=output_model,
-                timeout=90.0,
+                timeout=120.0,
             )
             # Track usage
             if response.usage:
@@ -214,7 +214,7 @@ class OpenAIAdapter:
                 ],
                 stream=True,
                 stream_options={"include_usage": True},
-                timeout=90.0,
+                timeout=120.0,
             )
             for chunk in response:
                 if chunk.choices and chunk.choices[0].delta.content:
@@ -263,7 +263,7 @@ class OpenAIAdapter:
                     messages=messages,
                     tools=tools,
                     tool_choice=_tc,
-                    timeout=90.0,
+                    timeout=120.0,
                 )
 
             response = self._retry_with_backoff(_do_call, model=target)

--- a/core/infrastructure/adapters/llm/openai_agentic_adapter.py
+++ b/core/infrastructure/adapters/llm/openai_agentic_adapter.py
@@ -119,7 +119,7 @@ class OpenAIAgenticAdapter:
                 tool_choice=tc_val if oai_tools else None,
                 max_completion_tokens=max_tokens,
                 temperature=temperature,
-                timeout=90.0,
+                timeout=120.0,
             )
 
         try:

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -237,7 +237,7 @@ async def call_with_failover(
             except _RETRYABLE_ERRORS as exc:
                 last_error = exc
                 wait = min(_base_delay * (2**attempt), _max_delay)
-                log.warning(
+                log.debug(
                     "Failover: model=%s attempt=%d/%d error=%s, retrying in %.1fs",
                     current_model,
                     attempt + 1,
@@ -250,7 +250,7 @@ async def call_with_failover(
             except Exception as exc:
                 # Unexpected error: log and move on to next model
                 last_error = exc
-                log.warning(
+                log.debug(
                     "Failover: unexpected error on model=%s: %s",
                     current_model,
                     exc,
@@ -260,8 +260,8 @@ async def call_with_failover(
         # All retries exhausted for this model
         if model_idx < len(allowed_models) - 1:
             next_model = allowed_models[model_idx + 1]
-            log.warning(
-                "Failover: all retries exhausted for model=%s, falling back to %s",
+            log.info(
+                "Failover: model=%s exhausted, falling back to %s",
                 current_model,
                 next_model,
             )


### PR DESCRIPTION
## Summary
- Failover retry/fallback 로그 warning→debug/info (유저 콘솔 노이즈 제거)
- OpenAI/GLM timeout 90s→120s (ZhipuAI 응답 지연 대응)

## Test plan
- [x] ruff lint passed
- [x] mypy 3 files passed
- [x] test_model_failover + test_model_escalation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)