### PR TITLE
fix: Slack Gateway 사용자 메시지 반복 에코 제거

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -3349,12 +3349,20 @@ def serve(
         console.print("  [warning]No gateway available after runtime init.[/warning]")
         raise typer.Exit(1)
 
+    _GATEWAY_SUFFIX = (
+        "## Gateway response rules\n"
+        "This message comes from an external messaging channel (Slack/Discord/Telegram).\n"
+        "- Do NOT echo, repeat, or quote the user's message in your response.\n"
+        "- Do NOT prefix your response with 'GEODE:' or the user's original text.\n"
+        "- Respond directly with the answer only. Be concise."
+    )
+
     def _gateway_processor(content: str) -> str:
         """Process a gateway message with a fresh AgenticLoop per message."""
         ctx = ConversationContext(max_turns=20)
         handlers = _build_tool_handlers()
         executor = ToolExecutor(action_handlers=handlers, hitl_level=0)
-        loop = AgenticLoop(ctx, executor, max_rounds=5)
+        loop = AgenticLoop(ctx, executor, max_rounds=5, system_suffix=_GATEWAY_SUFFIX)
         try:
             result = loop.run(content)
             return result.text if result else ""

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -183,10 +183,12 @@ class AgenticLoop:
         hooks: HookSystem | None = None,
         enable_goal_decomposition: bool = True,
         parent_session_key: str = "",
+        system_suffix: str = "",
     ) -> None:
         self.context = context
         self.executor = tool_executor
         self._parent_session_key = parent_session_key
+        self._system_suffix = system_suffix
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens
         self.model = model or ANTHROPIC_PRIMARY
@@ -709,7 +711,10 @@ class AgenticLoop:
         if self._skill_registry is not None:
             skill_ctx = self._skill_registry.get_context_block()
         base = base.replace("{skill_context}", skill_ctx or "No skills loaded.")
-        return base + "\n" + AGENTIC_SUFFIX
+        prompt = base + "\n" + AGENTIC_SUFFIX
+        if self._system_suffix:
+            prompt += "\n\n" + self._system_suffix
+        return prompt
 
     def _try_decompose(self, user_input: str) -> str | None:
         """Attempt to decompose a compound user request into sub-goals.

--- a/core/gateway/pollers/slack_poller.py
+++ b/core/gateway/pollers/slack_poller.py
@@ -134,8 +134,10 @@ class SlackPoller(BasePoller):
                     thread_id=msg.get("thread_ts", ""),
                 )
 
+                self._set_reaction(channel_id, ts, "hourglass_flowing_sand", add=True)
                 response = self._manager.route_message(inbound)
                 log.info("Processor returned: %s", (response or "")[:80])
+                self._set_reaction(channel_id, ts, "hourglass_flowing_sand", add=False)
 
                 if response:
                     self._send_response(channel_id, response, thread_ts=inbound.thread_id or ts)
@@ -144,6 +146,20 @@ class SlackPoller(BasePoller):
 
         except Exception:
             log.warning("Slack poll error for %s", channel_id, exc_info=True)
+
+    def _set_reaction(
+        self, channel_id: str, message_ts: str, name: str, *, add: bool = True
+    ) -> None:
+        """Add or remove a reaction on a message (non-critical, best-effort)."""
+        if self._mcp is None:
+            return
+        action = "slack_add_reaction" if add else "slack_remove_reaction"
+        try:
+            self._mcp.call_tool(
+                "slack", action, {"channel_id": channel_id, "timestamp": message_ts, "name": name}
+            )
+        except Exception:
+            log.debug("Reaction %s failed for %s", action, channel_id)
 
     def _send_response(self, channel_id: str, text: str, *, thread_ts: str = "") -> None:
         """Send response back to Slack via the same MCP connection used for polling."""


### PR DESCRIPTION
## Summary

- Slack에서 GEODE 응답 시 사용자 메시지를 4회 반복 에코하던 문제 수정
- AgenticLoop에 `system_suffix` 파라미터 추가 → Gateway 모드 전용 시스템 프롬프트 주입
- SlackPoller에 모래시계 리액션 인디케이터 추가 (처리 중 → 완료 시 제거)

## Why

Slack 채널에서 사용자가 메시지를 보내면 GEODE가 "GEODE: [사용자 메시지]"를 4회 반복 출력 후 실제 답변을 보내는 UX 문제. LLM이 multi-round agentic loop에서 매 라운드마다 사용자 메시지를 에코하고, 최종 응답에 이 패턴이 그대로 포함됨.

## Changes

| File | Change |
|------|--------|
| `core/cli/agentic_loop.py` | `system_suffix` 파라미터 추가 + `_build_system_prompt()`에서 주입 |
| `core/cli/__init__.py` | `_GATEWAY_SUFFIX` — 에코/반복 금지 지시, `AgenticLoop` 생성 시 전달 |
| `core/gateway/pollers/slack_poller.py` | `_set_reaction()` — 처리 중 모래시계 리액션 표시/제거 |

## Test plan

- [x] Lint 0 errors
- [x] Type check 0 errors
- [x] 전체 테스트 3055+ pass
- [x] 관련 테스트 (test_agentic_loop, test_gateway) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)