### PR TITLE
refactor: context management Claude Code 정합 — clear_tool_uses 의존

### DIFF
--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -578,11 +578,11 @@ class AgenticLoop:
         log.debug("Pruned messages: kept first + bridge + %d recent", len(recent))
 
     def _check_context_overflow(self, system: str, messages: list[dict[str, Any]]) -> None:
-        """Check context window usage and emit hooks if near limits.
+        """Check context window usage and emergency prune if critical.
 
-        GAP 7 strategy:
-        - WARNING (80%): LLM-based compaction (summarize older messages)
-        - CRITICAL (95%): Emergency mechanical prune + tool_result truncation
+        Claude Code pattern: trust server-side clear_tool_uses as primary.
+        Client-side only intervenes at CRITICAL (95%) as safety net.
+        No 80% compaction — clear_tool_uses handles gradual cleanup.
         """
         try:
             from core.config import settings
@@ -591,12 +591,11 @@ class AgenticLoop:
                 prune_oldest_messages,
             )
 
-            keep_recent = settings.compact_keep_recent
             metrics = check_context(messages, self.model, system_prompt=system)
 
             if metrics.is_critical:
                 log.warning(
-                    "Context CRITICAL: %.0f%% (%d/%d tokens)",
+                    "Context CRITICAL: %.0f%% (%d/%d tokens) — emergency prune",
                     metrics.usage_pct,
                     metrics.estimated_tokens,
                     metrics.context_window,
@@ -606,77 +605,24 @@ class AgenticLoop:
                         HookEvent.CONTEXT_CRITICAL,
                         {"metrics": dataclasses.asdict(metrics), "model": self.model},
                     )
-                # Emergency: truncate large tool_result content in remaining messages
-                self._truncate_tool_results(messages, max_chars=2000)
-                # Emergency prune: keep first + last N messages
+                keep_recent = settings.compact_keep_recent
                 pruned = prune_oldest_messages(messages, keep_recent=keep_recent)
                 original_count = len(messages)
                 if len(pruned) < original_count:
                     messages.clear()
                     messages.extend(pruned)
                     log.info(
-                        "Emergency pruned conversation: %d → %d messages",
+                        "Emergency pruned: %d → %d messages",
                         original_count,
                         len(pruned),
                     )
             elif metrics.is_warning:
                 log.info(
-                    "Context WARNING: %.0f%% (%d/%d tokens) — attempting compaction",
+                    "Context at %.0f%% — clear_tool_uses will handle cleanup",
                     metrics.usage_pct,
-                    metrics.estimated_tokens,
-                    metrics.context_window,
                 )
-                if self._hooks:
-                    self._hooks.trigger(
-                        HookEvent.CONTEXT_WARNING,
-                        {"metrics": dataclasses.asdict(metrics), "model": self.model},
-                    )
-                # GAP 7: LLM-based context compaction
-                try:
-                    from core.orchestration.context_compactor import compact_context
-
-                    result = compact_context(messages, keep_recent=keep_recent)
-                    if result.tokens_saved_estimate > 0:
-                        log.info(
-                            "Compaction saved ~%d tokens (%d→%d messages)",
-                            result.tokens_saved_estimate,
-                            result.original_count,
-                            result.compacted_count,
-                        )
-                except Exception:
-                    log.debug("Context compaction failed, falling back to prune", exc_info=True)
-                    pruned = prune_oldest_messages(messages, keep_recent=keep_recent)
-                    if len(pruned) < len(messages):
-                        messages.clear()
-                        messages.extend(pruned)
         except Exception:
             log.debug("Context monitor check failed", exc_info=True)
-
-    @staticmethod
-    def _truncate_tool_results(messages: list[dict[str, Any]], *, max_chars: int = 2000) -> None:
-        """Truncate large tool_result content blocks to free context space.
-
-        Extractive pattern: preserves first max_chars of text content,
-        appends [truncated] marker. Only modifies tool_result blocks.
-        """
-        for msg in messages:
-            if msg.get("role") != "user":
-                continue
-            content = msg.get("content")
-            if not isinstance(content, list):
-                continue
-            for block in content:
-                if block.get("type") != "tool_result":
-                    continue
-                inner = block.get("content")
-                if isinstance(inner, str) and len(inner) > max_chars:
-                    block["content"] = inner[:max_chars] + "\n[truncated]"
-                elif isinstance(inner, list):
-                    for sub in inner:
-                        if isinstance(sub, dict) and sub.get("type") == "text":
-                            text = sub.get("text", "")
-                            if len(text) > max_chars:
-                                sub["text"] = text[:max_chars] + "\n[truncated]"
 
     @staticmethod
     def _repair_messages(messages: list[dict[str, Any]]) -> None:


### PR DESCRIPTION
## Summary

Claude Code 패턴에 정합: `clear_tool_uses` 서버사이드가 주력, 클라이언트는 CRITICAL(95%)만.

**제거**: 80% LLM compaction, `_truncate_tool_results()`
**유지**: 95% emergency prune, sliding window, message sanitization, max rounds

agentic_loop.py -54줄 (62 삭제, 8 추가)

## Test plan
- [x] test_agentic_loop 75/75 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)