### PR TITLE
fix: switch_model 퍼지 매칭 — 하이픈/공백 정규화

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -337,9 +337,11 @@ def cmd_model(args: str) -> None:
     else:
         selected = _MODEL_INDEX.get(arg)
         if not selected:
-            arg_lower = arg.lower()
+            arg_norm = arg.lower().replace("-", "").replace(" ", "").replace("_", "")
             for p in MODEL_PROFILES:
-                if arg_lower in p.id.lower() or arg_lower in p.label.lower():
+                id_norm = p.id.lower().replace("-", "").replace(" ", "").replace("_", "")
+                label_norm = p.label.lower().replace("-", "").replace(" ", "").replace("_", "")
+                if arg_norm in id_norm or arg_norm in label_norm:
                     selected = p
                     break
 


### PR DESCRIPTION
## Summary

- `cmd_model()` 매칭에서 하이픈/공백/언더스코어 제거 후 비교하도록 정규화
- "GLM5"→`glm-5`, "gpt5"→`gpt-5.4`, "glm5turbo"→`glm-5-turbo` 등 자연스러운 입력 지원

## Why

Gateway에서 LLM이 `switch_model(model_hint="GLM5")`로 호출 시 "Unknown model" 에러. `"glm5" in "glm-5"` = `False`가 원인. 정규화 비교로 해결.

## Test plan

- [x] Lint + format 통과
- [x] 매칭 검증: GLM5, opus, sonnet, haiku, gpt5, glm5turbo 전부 정상
- [x] 전체 테스트 3055+ pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)