### PR TITLE
refactor: Gateway를 geode serve 전용으로 분리 — REPL 이중 폴링 제거

### DIFF
--- a/core/cli/repl.py
+++ b/core/cli/repl.py
@@ -312,17 +312,8 @@ def _interactive_loop() -> None:
         _init_done("Scheduler", ok=False)
         log.debug("SchedulerService initialization skipped", exc_info=True)
 
-    # 7. Gateway (inbound messaging pollers)
-    gateway_mgr = None
-    try:
-        from core.infrastructure.ports.gateway_port import get_gateway
-
-        gateway_mgr = get_gateway()
-        if gateway_mgr is not None:
-            _init_step("gateway")
-            _init_done("Gateway")
-    except Exception:
-        log.debug("Gateway initialization skipped", exc_info=True)
+    # 7. Gateway — REPL에서는 시작하지 않음 (geode serve 전용)
+    # OpenClaw 패턴: Gateway는 단일 제어 플레인. 이중 폴링 방지.
 
     # 8. Calendar bridge wiring
     try:
@@ -363,18 +354,6 @@ def _interactive_loop() -> None:
         conversation, executor, mcp_manager=mcp_mgr, skill_registry=skill_registry
     )
     agentic_ref[0] = agentic
-
-    # Wire Gateway processor + start pollers (#2, #3)
-    if gateway_mgr is not None:
-
-        def _gateway_processor(content: str) -> str:
-            """Process inbound gateway message via AgenticLoop."""
-            result = agentic.run(content)
-            return result.text if result and result.text else ""
-
-        gateway_mgr.set_processor(_gateway_processor)
-        gateway_mgr.start()
-        log.info("Gateway pollers started")
 
     # Initialize session meter for status line
     from core.ui.agentic_ui import init_session_meter
@@ -492,13 +471,7 @@ def _interactive_loop() -> None:
                 log.error("Agentic loop error: %s", exc, exc_info=True)
                 console.print(f"\n  [error]Error: {exc}[/error]\n")
 
-    # Clean shutdown: Gateway -> MCP servers -> SchedulerService
-    if gateway_mgr is not None:
-        try:
-            gateway_mgr.stop()
-        except Exception:
-            log.debug("Gateway shutdown error", exc_info=True)
-
+    # Clean shutdown: MCP servers -> SchedulerService
     if mcp_mgr is not None:
         try:
             mcp_mgr.shutdown()


### PR DESCRIPTION
## Summary

OpenClaw 패턴 정합: Gateway는 단일 제어 플레인.

- REPL(`geode`)에서 Gateway 초기화/시작/종료 코드 제거 (-30줄)
- Gateway 폴링은 `geode serve`에서만 시작
- 동시 실행 시 이중 폴링 → 메시지 경합 문제 근절

## Why

`geode`(REPL)과 `geode serve`를 동시 실행하면 두 프로세스가 같은 Slack 채널을 폴링하여 메시지를 경합. 한쪽이 먼저 읽으면 다른쪽은 빈 응답 반환.

## Test plan
- [x] test_gateway 32/32 pass
- [x] ruff lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)