### PR TITLE
fix: Backlog 4건 일괄 — MCP lazy refresh + Playwright sync + YouTube key + API 링크

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,20 +250,21 @@ uv tool install . --force
 mkdir -p ~/.geode
 cat > ~/.geode/.env << 'EOF'
 # LLM Providers
-ANTHROPIC_API_KEY=sk-ant-...
-OPENAI_API_KEY=sk-proj-...
-ZAI_API_KEY=...                    # ZhipuAI GLM (선택)
+ANTHROPIC_API_KEY=sk-ant-...       # https://console.anthropic.com/settings/keys
+OPENAI_API_KEY=sk-proj-...         # https://platform.openai.com/api-keys
+ZAI_API_KEY=...                    # https://open.bigmodel.cn/usercenter/apikeys (선택)
 
 # Search & Data
-BRAVE_API_KEY=...
-GOOGLE_API_KEY=...
+BRAVE_API_KEY=...                  # https://brave.com/search/api/
+GOOGLE_API_KEY=...                 # https://console.cloud.google.com/apis/credentials
+YOUTUBE_API_KEY=...                # 위 Google API Key와 동일 (YouTube Data API v3 활성화)
 
 # Messaging (Slack Gateway)
-SLACK_BOT_TOKEN=xoxb-...
-SLACK_TEAM_ID=T...
+SLACK_BOT_TOKEN=xoxb-...           # https://api.slack.com/apps → OAuth & Permissions
+SLACK_TEAM_ID=T...                 # Slack 워크스페이스 설정에서 확인
 
 # Observability (선택)
-LANGSMITH_API_KEY=lsv2_pt_...
+LANGSMITH_API_KEY=lsv2_pt_...      # https://smith.langchain.com/settings
 EOF
 chmod 600 ~/.geode/.env
 ```

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -335,6 +335,13 @@ class AgenticLoop:
 
         # Goal decomposition: try to decompose compound requests into sub-goal DAGs.
         # If successful, inject the decomposition plan into the system prompt so the
+        # Lazy MCP tool refresh: if tools were empty at init (MCP not yet connected),
+        # try to load them now. This handles the startup timing gap.
+        if self._mcp_manager is not None and len(self._tools) < 50:
+            added = self.refresh_tools()
+            if added > 0:
+                log.info("MCP tools lazy-loaded: +%d tools (total %d)", added, len(self._tools))
+
         # LLM executes sub-goals in the correct dependency order.
         decomposition_hint = self._try_decompose(user_input)
 

--- a/core/infrastructure/adapters/mcp/catalog.py
+++ b/core/infrastructure/adapters/mcp/catalog.py
@@ -263,7 +263,7 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     ),
     "playwright": MCPCatalogEntry(
         name="playwright",
-        package="executeautomation/mcp-playwright",
+        package="@playwright/mcp",
         description="Browser automation via Playwright (navigate, click, scrape)",
         tags=("browser", "playwright", "automation", "scrape"),
     ),


### PR DESCRIPTION
## Summary

Backlog 4건 일괄 해소:

1. **mcp-tool-refresh**: `arun()` 시작 시 MCP tools lazy refresh
2. **mcp-singleton-notify**: 현재 동작 중 (SlackPoller 직접 전송), 이슈 종료
3. **playwright-catalog-sync**: catalog 패키지 `@playwright/mcp`로 정합
4. **youtube-api-key**: `YOUTUBE_API_KEY` 설정 + README 발급 링크 8종

## Test plan
- [x] test_agentic_loop + test_mcp_registry pass
- [x] ruff lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)