### PR TITLE
feat: bootstrap_geode() — serve/REPL 단일 초기화 + ContextVar 전파

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1634,18 +1634,10 @@ def serve(
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
-    # Load .env files into os.environ so Pollers can see credentials
-    # (Pydantic Settings loads them internally, but os.environ is not populated)
-    from pathlib import Path as _Path
+    # Unified bootstrap (same init as REPL: domain, memory, readiness, MCP, skills, handlers)
+    from core.cli.bootstrap import bootstrap_geode
 
-    from dotenv import load_dotenv
-
-    _global_env = _Path.home() / ".geode" / ".env"
-    if _global_env.exists():
-        load_dotenv(str(_global_env), override=False)
-    _local_env = _Path(".env")
-    if _local_env.exists():
-        load_dotenv(str(_local_env), override=True)
+    boot = bootstrap_geode(load_env=True)
 
     from core.config import settings
 
@@ -1686,39 +1678,29 @@ def serve(
         "- Respond directly with the answer only. Be concise."
     )
 
-    # Build shared MCP + Skills
-    from core.extensibility.skills import SkillLoader, SkillRegistry
-    from core.infrastructure.adapters.mcp.manager import get_mcp_manager
-
-    mcp_mgr = get_mcp_manager()
-    skill_registry = SkillRegistry()
-    SkillLoader().load_all(registry=skill_registry)
-
-    # Readiness 설정 (REPL에서는 startup에서 수행)
-    from core.cli.startup import check_readiness
-
-    _set_readiness(check_readiness())
-
     def _gateway_processor(content: str) -> str:
         """Process a gateway message with a fresh AgenticLoop per message.
 
-        Uses tool_handlers._build_tool_handlers() — REPL과 동일한 빌더.
+        Uses bootstrap.propagate_to_thread() to fix ContextVar visibility
+        in daemon threads, then builds a per-message AgenticLoop with
+        the same MCP/skills/handlers as the REPL.
         """
+        boot.propagate_to_thread()  # Fix ContextVar propagation for daemon thread
         ctx = ConversationContext(max_turns=20)
         agentic_ref: list[Any] = [None]
         handlers = _build_tool_handlers(
-            mcp_manager=mcp_mgr,
+            mcp_manager=boot.mcp_manager,
             agentic_ref=agentic_ref,
-            skill_registry=skill_registry,
+            skill_registry=boot.skill_registry,
         )
         sub_mgr = _build_sub_agent_manager(
             action_handlers=handlers,
-            mcp_manager=mcp_mgr,
-            skill_registry=skill_registry,
+            mcp_manager=boot.mcp_manager,
+            skill_registry=boot.skill_registry,
         )
         executor = ToolExecutor(
             action_handlers=handlers,
-            mcp_manager=mcp_mgr,
+            mcp_manager=boot.mcp_manager,
             sub_agent_manager=sub_mgr,
             hitl_level=0,
         )
@@ -1726,8 +1708,8 @@ def serve(
             ctx,
             executor,
             max_rounds=50,
-            mcp_manager=mcp_mgr,
-            skill_registry=skill_registry,
+            mcp_manager=boot.mcp_manager,
+            skill_registry=boot.skill_registry,
             system_suffix=_GATEWAY_SUFFIX,
         )
         agentic_ref[0] = loop

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -1,0 +1,146 @@
+"""Unified bootstrap for REPL and serve modes.
+
+Single initialization path ensures both modes get identical:
+- Memory contextvars (ProjectMemory, OrgMemory)
+- Domain adapter
+- Readiness check
+- MCP manager
+- Skills
+- Tool handlers
+
+The returned GeodeBootstrap carries all initialized components
+and provides propagate_to_thread() for daemon thread ContextVar injection.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class GeodeBootstrap:
+    """Initialized GEODE context — shared between REPL and serve."""
+
+    mcp_manager: Any = None
+    skill_registry: Any = None
+    tool_handlers: dict[str, Any] = field(default_factory=dict)
+    readiness: Any = None
+
+    # Snapshot of ContextVars for thread propagation
+    _context: contextvars.Context = field(default_factory=contextvars.copy_context)
+
+    def propagate_to_thread(self) -> None:
+        """Re-set ContextVars in current (daemon) thread.
+
+        Python ``contextvars`` do not automatically inherit across threads.
+        Call this at the start of ``_gateway_processor`` or any function
+        running in a non-main thread so that tools like ``note_read``,
+        ``memory_search``, and ``analyze_ip`` work correctly.
+        """
+        from core.memory.organization import MonoLakeOrganizationMemory
+        from core.memory.project import ProjectMemory
+        from core.tools.memory_tools import set_org_memory, set_project_memory
+
+        set_project_memory(ProjectMemory())
+        set_org_memory(MonoLakeOrganizationMemory())
+
+        if self.readiness is not None:
+            from core.cli import _set_readiness
+
+            _set_readiness(self.readiness)
+
+        # Domain adapter
+        try:
+            from core.domains.loader import load_domain_adapter
+            from core.infrastructure.ports.domain_port import set_domain
+
+            set_domain(load_domain_adapter("game_ip"))
+        except Exception:
+            log.debug("Domain propagation skipped", exc_info=True)
+
+
+def bootstrap_geode(
+    *,
+    verbose: bool = False,
+    load_env: bool = False,
+) -> GeodeBootstrap:
+    """Single initialization for both REPL and serve.
+
+    Args:
+        verbose: Enable verbose logging.
+        load_env: Load .env files into ``os.environ``
+            (serve needs this; REPL typically does not).
+    """
+    if load_env:
+        from pathlib import Path
+
+        from dotenv import load_dotenv
+
+        global_env = Path.home() / ".geode" / ".env"
+        if global_env.exists():
+            load_dotenv(str(global_env), override=False)
+        local_env = Path(".env")
+        if local_env.exists():
+            load_dotenv(str(local_env), override=True)
+
+    # 1. Domain adapter
+    try:
+        from core.domains.loader import load_domain_adapter
+        from core.infrastructure.ports.domain_port import set_domain
+
+        set_domain(load_domain_adapter("game_ip"))
+    except Exception:
+        log.debug("Domain adapter skipped", exc_info=True)
+
+    # 2. Memory contextvars
+    try:
+        from core.memory.organization import MonoLakeOrganizationMemory
+        from core.memory.project import ProjectMemory
+        from core.tools.memory_tools import set_org_memory, set_project_memory
+
+        set_project_memory(ProjectMemory())
+        set_org_memory(MonoLakeOrganizationMemory())
+    except Exception:
+        log.debug("Memory context skipped", exc_info=True)
+
+    # 3. Readiness
+    from core.cli import _set_readiness
+    from core.cli.startup import check_readiness
+
+    readiness = check_readiness()
+    _set_readiness(readiness)
+
+    # 4. MCP
+    from core.infrastructure.adapters.mcp.manager import get_mcp_manager
+
+    mcp_mgr = get_mcp_manager()
+
+    # 5. Skills
+    from core.extensibility.skills import SkillLoader, SkillRegistry
+
+    skill_registry = SkillRegistry()
+    try:
+        SkillLoader().load_all(registry=skill_registry)
+    except Exception:
+        log.debug("Skill loading skipped", exc_info=True)
+
+    # 6. Tool handlers
+    from core.cli.tool_handlers import _build_tool_handlers
+
+    handlers = _build_tool_handlers(
+        verbose=verbose,
+        mcp_manager=mcp_mgr,
+        skill_registry=skill_registry,
+    )
+
+    return GeodeBootstrap(
+        mcp_manager=mcp_mgr,
+        skill_registry=skill_registry,
+        tool_handlers=handlers,
+        readiness=readiness,
+    )

--- a/tests/test_cli_bootstrap.py
+++ b/tests/test_cli_bootstrap.py
@@ -1,0 +1,184 @@
+"""Tests for unified CLI bootstrap (core.cli.bootstrap).
+
+Verifies that bootstrap_geode() returns a fully initialized GeodeBootstrap
+and that propagate_to_thread() correctly sets ContextVars in new threads.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from core.cli.bootstrap import GeodeBootstrap, bootstrap_geode
+
+# ---------------------------------------------------------------------------
+# GeodeBootstrap dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestGeodeBootstrapDefaults:
+    def test_default_fields(self) -> None:
+        boot = GeodeBootstrap()
+        assert boot.mcp_manager is None
+        assert boot.skill_registry is None
+        assert boot.tool_handlers == {}
+        assert boot.readiness is None
+
+    def test_context_snapshot_captured(self) -> None:
+        """_context is a contextvars.Context (snapshot at creation time)."""
+        import contextvars
+
+        boot = GeodeBootstrap()
+        assert isinstance(boot._context, contextvars.Context)
+
+
+# ---------------------------------------------------------------------------
+# propagate_to_thread()
+# ---------------------------------------------------------------------------
+
+
+class TestPropagateToThread:
+    def test_propagate_sets_memory_contextvars_in_new_thread(self) -> None:
+        """propagate_to_thread() makes ProjectMemory/OrgMemory available in a child thread."""
+        from core.tools.memory_tools import _org_memory_ctx, _project_memory_ctx
+
+        # Create a bootstrap with a mock readiness
+        readiness = MagicMock()
+        boot = GeodeBootstrap(readiness=readiness)
+
+        results: dict[str, Any] = {}
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                boot.propagate_to_thread()
+                results["project"] = _project_memory_ctx.get()
+                results["org"] = _org_memory_ctx.get()
+            except Exception as exc:
+                errors.append(exc)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert not errors, f"Thread raised: {errors}"
+        assert results.get("project") is not None
+        assert results.get("org") is not None
+
+    def test_propagate_sets_readiness(self) -> None:
+        """propagate_to_thread() sets the readiness ContextVar."""
+        readiness = MagicMock(force_dry_run=True)
+        boot = GeodeBootstrap(readiness=readiness)
+
+        results: dict[str, Any] = {}
+
+        def worker() -> None:
+            boot.propagate_to_thread()
+            from core.cli import _get_readiness
+
+            results["readiness"] = _get_readiness()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert results["readiness"] is readiness
+
+    def test_propagate_with_none_readiness(self) -> None:
+        """propagate_to_thread() with readiness=None does not crash."""
+        boot = GeodeBootstrap(readiness=None)
+
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                boot.propagate_to_thread()
+            except Exception as exc:
+                errors.append(exc)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert not errors
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_geode()
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapGeode:
+    def test_returns_geode_bootstrap(self) -> None:
+        boot = bootstrap_geode()
+        assert isinstance(boot, GeodeBootstrap)
+
+    def test_readiness_not_none(self) -> None:
+        boot = bootstrap_geode()
+        assert boot.readiness is not None
+
+    def test_mcp_manager_not_none(self) -> None:
+        boot = bootstrap_geode()
+        assert boot.mcp_manager is not None
+
+    def test_skill_registry_not_none(self) -> None:
+        boot = bootstrap_geode()
+        assert boot.skill_registry is not None
+
+    def test_tool_handlers_populated(self) -> None:
+        """tool_handlers should have 44+ handlers (all tools minus a few MCP-only)."""
+        boot = bootstrap_geode()
+        assert len(boot.tool_handlers) >= 40
+
+    def test_load_env_false_does_not_call_dotenv(self) -> None:
+        """When load_env=False, dotenv should not be invoked."""
+        with patch("core.cli.bootstrap.log") as _:
+            # Just verify no crash; dotenv import is conditional
+            boot = bootstrap_geode(load_env=False)
+            assert boot is not None
+
+    def test_load_env_true_calls_dotenv(self) -> None:
+        """When load_env=True, dotenv loading is attempted."""
+        with (
+            patch("core.cli.bootstrap.log"),
+            patch("dotenv.load_dotenv") as _mock_dotenv,
+        ):
+            boot = bootstrap_geode(load_env=True)
+            assert boot is not None
+            # load_dotenv may or may not be called depending on file existence
+            # but the code path should not crash
+
+
+class TestBootstrapIdempotent:
+    def test_double_bootstrap_does_not_crash(self) -> None:
+        """Calling bootstrap_geode() twice should not raise."""
+        boot1 = bootstrap_geode()
+        boot2 = bootstrap_geode()
+        assert boot1.readiness is not None
+        assert boot2.readiness is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration: bootstrap -> propagate -> tool_handlers work in thread
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapThreadIntegration:
+    def test_tool_handlers_usable_after_propagate(self) -> None:
+        """After propagate_to_thread(), tool_handlers should work in a new thread."""
+        boot = bootstrap_geode()
+        results: dict[str, Any] = {}
+
+        def worker() -> None:
+            boot.propagate_to_thread()
+            # Verify handler dict is accessible and non-empty
+            results["handler_count"] = len(boot.tool_handlers)
+            results["has_analyze"] = "analyze_ip" in boot.tool_handlers
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert results.get("handler_count", 0) >= 40
+        assert results.get("has_analyze") is True


### PR DESCRIPTION
## Summary

serve의 Unknown tool 에러 근본 해결.

- `core/cli/bootstrap.py`: `GeodeBootstrap` + `bootstrap_geode()` + `propagate_to_thread()`
- serve에서 `bootstrap_geode(load_env=True)` 호출 → 단일 초기화
- `_gateway_processor` 시작 시 `boot.propagate_to_thread()` → 데몬 스레드 ContextVar 주입
- 14 new tests

## Why

Python ContextVar는 스레드 간 자동 전파되지 않음. serve의 Poller 데몬 스레드에서 메인 스레드의 readiness/memory/domain ContextVar가 None → tool handler 초기화 실패.

## Test plan
- [x] 3034 passed, 0 failed
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)