### PR TITLE
docs: 워크플로우 Step 0 Board 선행 + CANNOT CI 가드레일 규칙

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,7 @@ Decision Tree on D-E-F axes:
 | | 버전 4곳 불일치 금지 | 단일 진실 |
 | **PR** | HEREDOC 없이 PR body 금지 | 형식 일관성 |
 | | Why 근거 없이 PR 금지 | 의사결정 기록 |
+| | CI 가드레일 미통과 PR 머지 금지 | 래칫 (P4) |
 
 ### CAN — 허용된 자유도
 
@@ -407,19 +408,23 @@ CANNOT에 없는 것은 자유롭게 할 수 있다. 특히:
 ### 워크플로우 단계
 
 ```
-0. Worktree → 1. GAP Audit → 2. Plan + Socratic Gate → 3. Implement+Test → 4. E2E Verify → 5. Docs-Sync → 6. PR → 7. Board
+0. Board + Worktree → 1. GAP Audit → 2. Plan + Socratic Gate → 3. Implement+Test → 4. E2E Verify → 5. Docs-Sync → 6. PR → 7. Board
 ```
 
-#### 0. Worktree Alloc
+#### 0. Board + Worktree Alloc
 
 ```bash
+# 1) Progress Board에 Backlog → In Progress 기록 (main에서)
+# docs/progress.md에 작업 항목 추가/이동
+
+# 2) Worktree 할당
 git fetch origin
 # main·develop 동기화 확인 (불일치 시 pull)
 git worktree add .claude/worktrees/<작업명> -b feature/<브랜치명> develop
 echo "session=$(date -Iseconds) task_id=<작업명>" > .claude/worktrees/<작업명>/.owner
 ```
 
-완료 후: `git push` → `git worktree remove`
+Progress Board 기록 후 Worktree 할당. 완료 후: `git push` → `git worktree remove`
 
 #### 1. GAP Audit (신규)
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -762,7 +762,6 @@ def _build_sub_agent_manager(
     )
 
 
-
 def _render_agentic_result(result: AgenticResult) -> None:
     """Render the final result from an agentic loop execution."""
     if result.error == "llm_call_failed":
@@ -1484,15 +1483,15 @@ def init(
     if not career_toml.exists():
         identity_dir.mkdir(parents=True, exist_ok=True)
         career_toml.write_text(
-            '# Career identity — injected into system prompt context\n'
-            '# Edit this file to personalize GEODE for job search / career tasks.\n\n'
-            '[identity]\n'
+            "# Career identity — injected into system prompt context\n"
+            "# Edit this file to personalize GEODE for job search / career tasks.\n\n"
+            "[identity]\n"
             'title = ""\n'
             'experience = ""\n'
-            'skills = []\n\n'
-            '[goals]\n'
+            "skills = []\n\n"
+            "[goals]\n"
             'seeking = ""\n'
-            'target_companies = []\n'
+            "target_companies = []\n"
             'preferred_location = ""\n',
             encoding="utf-8",
         )

--- a/core/memory/vault.py
+++ b/core/memory/vault.py
@@ -341,14 +341,16 @@ class ApplicationTracker:
     def add(self, entry: ApplicationEntry) -> None:
         """Add a new application entry."""
         raw = self._load()
-        raw.append({
-            "company": entry.company,
-            "position": entry.position,
-            "status": entry.status,
-            "applied_at": entry.applied_at,
-            "url": entry.url,
-            "notes": entry.notes,
-        })
+        raw.append(
+            {
+                "company": entry.company,
+                "position": entry.position,
+                "status": entry.status,
+                "applied_at": entry.applied_at,
+                "url": entry.url,
+                "notes": entry.notes,
+            }
+        )
         self._save(raw)
 
     def update_status(self, company: str, status: str) -> bool:

--- a/tests/test_context_hub.py
+++ b/tests/test_context_hub.py
@@ -261,7 +261,9 @@ class TestApplicationTracker:
         from core.memory.vault import ApplicationEntry, ApplicationTracker
 
         tracker = ApplicationTracker(vault_dir=tmp_path)
-        tracker.add(ApplicationEntry(company="Anthropic", position="Engineer", url="https://example.com"))
+        tracker.add(
+            ApplicationEntry(company="Anthropic", position="Engineer", url="https://example.com")
+        )
 
         json_path = tmp_path / "applications" / "tracker.json"
         assert json_path.exists()
@@ -291,8 +293,10 @@ class TestCmdApply:
         from core.cli.commands import cmd_apply
         from core.memory.vault import ApplicationTracker
 
-        with patch.object(ApplicationTracker, "__init__", return_value=None), \
-             patch.object(ApplicationTracker, "add") as mock_add:
+        with (
+            patch.object(ApplicationTracker, "__init__", return_value=None),
+            patch.object(ApplicationTracker, "add") as mock_add,
+        ):
             # Need _path for __init__ bypass
             cmd_apply("add Anthropic AI Engineer")
             mock_add.assert_called_once()
@@ -304,16 +308,20 @@ class TestCmdApply:
         from core.cli.commands import cmd_apply
         from core.memory.vault import ApplicationTracker
 
-        with patch.object(ApplicationTracker, "__init__", return_value=None), \
-             patch.object(ApplicationTracker, "update_status", return_value=True):
+        with (
+            patch.object(ApplicationTracker, "__init__", return_value=None),
+            patch.object(ApplicationTracker, "update_status", return_value=True),
+        ):
             cmd_apply("status Anthropic interview")
 
     def test_apply_remove(self) -> None:
         from core.cli.commands import cmd_apply
         from core.memory.vault import ApplicationTracker
 
-        with patch.object(ApplicationTracker, "__init__", return_value=None), \
-             patch.object(ApplicationTracker, "remove", return_value=True):
+        with (
+            patch.object(ApplicationTracker, "__init__", return_value=None),
+            patch.object(ApplicationTracker, "remove", return_value=True),
+        ):
             cmd_apply("remove Anthropic")
 
 
@@ -340,9 +348,7 @@ class TestContextAssemblerCareer:
         profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
         # Create minimal profile so exists() returns True
         (tmp_path / "profile").mkdir(parents=True, exist_ok=True)
-        (tmp_path / "profile" / "profile.md").write_text(
-            "---\nrole: dev\n---\n", encoding="utf-8"
-        )
+        (tmp_path / "profile" / "profile.md").write_text("---\nrole: dev\n---\n", encoding="utf-8")
 
         assembler = ContextAssembler(user_profile=profile)
 


### PR DESCRIPTION
## Summary
- Step 0: `Worktree Alloc` → `Board + Worktree Alloc` — Progress Board 기록을 Worktree 할당 전에 수행
- CANNOT 테이블에 "CI 가드레일 미통과 PR 머지 금지" 규칙 추가 (래칫 P4)
- 워크플로우 다이어그램 `0. Worktree` → `0. Board + Worktree` 동기화

## Why
칸반 3-Checkpoint 규칙(feedback_kanban_checkpoint) 강화. 작업 시작 시점부터 Progress Board에 기록해야 세션 간 작업 추적이 가능.
CI 미통과 PR 머지는 래칫 원칙 위반이므로 CANNOT에 명시.

## Test plan
- [ ] CLAUDE.md 워크플로우 다이어그램 확인
- [ ] CANNOT 테이블 CI 규칙 확인
- [ ] Step 0 설명 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)