### PR TITLE
feat: REPL bootstrap 통합 + Slack mrkdwn v2

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -930,9 +930,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
     n_mcp = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
     n_skills = len(skill_registry._skills) if hasattr(skill_registry, "_skills") else 0
-    console.print(
-        f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})"
-    )
+    console.print(f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})")
 
     # Key gate (REPL-only: interactive prompt if API key missing)
     readiness = boot.readiness

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -920,43 +920,22 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     verbose = False
     conversation = ConversationContext()
 
-    # --- Startup initialization with progressive status ---
-    def _init_step(label: str) -> None:
-        """Print a compact startup progress indicator."""
-        console.print(f"  [dim]Loading {label}...[/dim]", end="\r")
+    # --- Unified bootstrap (domain, memory, readiness, MCP, skills) ---
+    from core.cli.bootstrap import bootstrap_geode
 
-    def _init_done(label: str, ok: bool = True) -> None:
-        mark = "[bold green]ok[/bold green]" if ok else "[dim]skip[/dim]"
-        console.print(f"  {mark} {label}          ")
+    console.print("  [dim]Initializing...[/dim]", end="\r")
+    boot = bootstrap_geode()
+    mcp_mgr = boot.mcp_manager
+    skill_registry = boot.skill_registry
 
-    # 1. Domain adapter
-    _init_step("domain")
-    from core.domains.loader import load_domain_adapter
-    from core.infrastructure.ports.domain_port import set_domain
+    n_mcp = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
+    n_skills = len(skill_registry._skills) if hasattr(skill_registry, "_skills") else 0
+    console.print(
+        f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})"
+    )
 
-    try:
-        set_domain(load_domain_adapter("game_ip"))
-        _init_done("Domain")
-    except Exception:
-        _init_done("Domain", ok=False)
-        log.debug("Domain adapter initialization skipped", exc_info=True)
-
-    # 2. Memory contextvars
-    _init_step("memory")
-    from core.memory.organization import MonoLakeOrganizationMemory
-    from core.memory.project import ProjectMemory
-    from core.tools.memory_tools import set_org_memory, set_project_memory
-
-    try:
-        set_project_memory(ProjectMemory())
-        set_org_memory(MonoLakeOrganizationMemory())
-        _init_done("Memory")
-    except Exception:
-        _init_done("Memory", ok=False)
-        log.debug("Memory context initialization skipped", exc_info=True)
-
-    # 3. Key gate
-    readiness = _get_readiness()
+    # Key gate (REPL-only: interactive prompt if API key missing)
+    readiness = boot.readiness
     if readiness is None or readiness.blocked:
         key = key_registration_gate()
         if key is None:
@@ -964,38 +943,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         readiness = check_readiness()
         _set_readiness(readiness)
 
-    # 4. MCP servers (slowest — npx subprocess spawn)
-    #    Uses startup() for full lifecycle: config + connect + signal handlers + atexit
-    _init_step("MCP servers")
-    from core.infrastructure.adapters.mcp.manager import MCPServerManager
-
-    mcp_mgr: MCPServerManager | None = None
-    try:
-        _mgr = MCPServerManager()
-        n_connected = _mgr.startup()
-        if len(_mgr._servers) > 0:
-            mcp_mgr = _mgr
-            _init_done(f"MCP ({n_connected}/{len(_mgr._servers)} servers)")
-        else:
-            _init_done("MCP (none)", ok=False)
-    except Exception:
-        _init_done("MCP", ok=False)
-        log.debug("MCP initialization skipped", exc_info=True)
-
-    # 5. Skills
-    _init_step("skills")
-    from core.extensibility.skills import SkillLoader, SkillRegistry
-
-    skill_registry = SkillRegistry()
-    try:
-        loaded_skills = SkillLoader().load_all(registry=skill_registry)
-        _init_done(f"Skills ({len(loaded_skills)})" if loaded_skills else "Skills (0)")
-    except Exception:
-        _init_done("Skills", ok=False)
-        log.debug("Skill loading skipped", exc_info=True)
-
-    # 6. Scheduler
-    _init_step("scheduler")
+    # Scheduler (REPL-only: cron + /schedule command)
     try:
         from core.automation.scheduler import SchedulerService
 
@@ -1003,9 +951,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         _sched_svc.load()
         _sched_svc.start()
         _scheduler_service_ctx.set(_sched_svc)
-        _init_done("Scheduler")
     except Exception:
-        _init_done("Scheduler", ok=False)
         log.debug("SchedulerService initialization skipped", exc_info=True)
 
     console.print()  # blank line before prompt

--- a/core/gateway/slack_formatter.py
+++ b/core/gateway/slack_formatter.py
@@ -4,48 +4,170 @@ from __future__ import annotations
 
 import re
 
+_CODE_SENTINEL = "\x00CODE"
+_ZWS = "\u200b"  # zero-width space — Slack word-boundary fix
+
+# Characters that Slack treats as word boundaries for *bold* formatting
+_BOUNDARY_AFTER = frozenset(" \t\n,.\u2014!?;:)]>*_~`\"'\u200b")
+_BOUNDARY_BEFORE = frozenset(" \t\n,.\u2014!?;:([<*_~`\"'\u200b")
+
 
 def markdown_to_slack_mrkdwn(text: str) -> str:
     """Convert Markdown to Slack mrkdwn.
 
     Conversions:
-    - **bold** → *bold*
+    - **bold** → *bold* with ZWS at non-boundary edges
+    - ~~strike~~ → ~strike~
     - # Heading → *Heading*
-    - ## Heading → *Heading*
     - [text](url) → <url|text>
-    - Markdown tables → code block wrapped
+    - Markdown tables → vertical section format
+    - --- → removed
     """
-    # Headers: # Heading → *Heading*
-    text = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", text, flags=re.MULTILINE)
+    if not text:
+        return text
 
-    # Bold: **text** → *text* (must do before italic)
-    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+    # ── 1. Protect code blocks ──
+    code_blocks: list[str] = []
 
-    # Links: [text](url) → <url|text>
+    def _save(m: re.Match[str]) -> str:
+        code_blocks.append(m.group(0))
+        return f"{_CODE_SENTINEL}{len(code_blocks) - 1}\x00"
+
+    text = re.sub(r"```[\s\S]*?```", _save, text)
+    text = re.sub(r"`[^`\n]+`", _save, text)
+
+    # ── 2. Tables → sections (before inline fmt) ──
+    text = _convert_tables(text)
+
+    # ── 3. Bold with Slack boundary fix ──
+    text = _convert_bold(text)
+
+    # ── 4. Strikethrough ──
+    text = re.sub(r"~~(.+?)~~", r"~\1~", text)
+
+    # ── 5. Block-level ──
+    def _heading(m: re.Match[str]) -> str:
+        c = m.group(1)
+        c = re.sub(r"\*\*(.+?)\*\*", r"\1", c)
+        c = re.sub(r"^\*(.+)\*$", r"\1", c)
+        return f"*{c}*"
+
+    text = re.sub(r"^#{1,6}\s+(.+)$", _heading, text, flags=re.MULTILINE)
     text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", text)
+    text = re.sub(r"^[\s]*[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
 
-    # Tables: wrap in code block if detected
-    # (Slack doesn't render tables, so wrap them for readability)
+    # Collapse 3+ blank lines
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+
+    # ── 6. Restore code blocks ──
+    for i, block in enumerate(code_blocks):
+        text = text.replace(f"{_CODE_SENTINEL}{i}\x00", block)
+
+    return text.strip()
+
+
+def _convert_bold(text: str) -> str:
+    """Convert **bold** → *bold* with ZWS at non-boundary edges.
+
+    Slack mrkdwn requires word boundaries around *bold*.
+    *LangGraph*가 won't render — needs *LangGraph*​가 (ZWS).
+    """
+
+    def _repl(m: re.Match[str]) -> str:
+        content = m.group(1)
+        result = f"*{content}*"
+
+        end = m.end()
+        if end < len(text) and text[end] not in _BOUNDARY_AFTER:
+            result += _ZWS
+
+        start = m.start()
+        if start > 0 and text[start - 1] not in _BOUNDARY_BEFORE:
+            result = _ZWS + result
+
+        return result
+
+    return re.sub(r"\*\*(.+?)\*\*", _repl, text)
+
+
+# ── Table conversion ──
+
+
+def _strip_md(text: str) -> str:
+    """Strip Markdown formatting from cell text."""
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"\*(.+?)\*", r"\1", text)
+    text = re.sub(r"~~(.+?)~~", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    return text.strip()
+
+
+def _parse_table(lines: list[str]) -> tuple[list[str], list[list[str]]]:
+    """Parse table lines → (headers, data_rows) with formatting stripped."""
+    rows: list[list[str]] = []
+    for line in lines:
+        s = line.strip()
+        if re.match(r"^\|[\s\-:|]+\|$", s):
+            continue
+        cells = [_strip_md(c) for c in s.strip("|").split("|")]
+        if any(c for c in cells):
+            rows.append(cells)
+    if not rows:
+        return [], []
+    return rows[0], rows[1:]
+
+
+def _table_to_sections(headers: list[str], data: list[list[str]]) -> str:
+    """Convert table to Slack-friendly vertical sections."""
+    ncols = len(headers)
+
+    if ncols > 2 and data:
+        parts: list[str] = []
+        for ci in range(1, ncols):
+            title = headers[ci] if ci < ncols else ""
+            lines = [f"*{title}*"]
+            for row in data:
+                label = row[0] if row else ""
+                val = row[ci] if ci < len(row) else ""
+                if val and val.strip() and val.strip() != "-":
+                    lines.append(f"  • {label}: {val}")
+            parts.append("\n".join(lines))
+        return "\n\n".join(parts)
+
+    out: list[str] = []
+    for row in data:
+        if len(row) >= 2:
+            out.append(f"• *{row[0]}*: {row[1]}")
+        elif row:
+            out.append(f"• {row[0]}")
+    return "\n".join(out)
+
+
+def _convert_tables(text: str) -> str:
+    """Find and convert Markdown tables."""
     lines = text.split("\n")
     result: list[str] = []
-    in_table = False
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if not buf:
+            return
+        h, d = _parse_table(buf)
+        if h and d:
+            result.append(_table_to_sections(h, d))
+        else:
+            result.extend(buf)
+        buf.clear()
+
     for line in lines:
-        is_table_line = bool(re.match(r"^\s*\|", line))
-        is_separator = bool(re.match(r"^\s*\|[\s\-:|]+\|", line))
+        if re.match(r"^\s*\|", line):
+            buf.append(line)
+        else:
+            if buf:
+                _flush()
+            result.append(line)
 
-        if is_table_line and not in_table:
-            in_table = True
-            result.append("```")
-        elif not is_table_line and in_table:
-            in_table = False
-            result.append("```")
-
-        if is_separator:
-            continue  # Skip Markdown table separators
-
-        result.append(line)
-
-    if in_table:
-        result.append("```")
+    if buf:
+        _flush()
 
     return "\n".join(result)

--- a/docs/plans/portfolio-v024-redesign.md
+++ b/docs/plans/portfolio-v024-redesign.md
@@ -69,21 +69,43 @@
 | **PPTX** | `portfolio/geode/GEODE-Portfolio.pptx` | 발표/공유용 — 33 슬라이드 | Backlog (수치 갱신) |
 | **5-Slide HTML (보존)** | `resume/portfolio/geode.html` | resume 스타일 — 배포하지 않음 | 보존 |
 
-## PPTX Outdated (12건)
+## PPTX Outdated
+
+### 1. 구조 변경 (v0.8.0에 없거나 근본적으로 바뀐 것)
+
+| 영역 | v0.8.0 PPTX | v0.24.0 현재 | 슬라이드 |
+|------|-------------|-------------|----------|
+| **아이덴티티** | "Autonomous IP Discovery Agent" | 범용 자율 실행 에이전트 하네스 — 도메인 피봇 완료 | s00, s01 |
+| **레이어** | L1-L5, 11 Hook | L0-L5, 36 Hook — L0(CLI & Agent) 신설, Hook 3배 | s07, s10 |
+| **메모리** | 3-Tier (Org > Project > Session) | 5-Layer Context Hub (C0-C4) + Context Compaction | s11 |
+| **도메인 분리** | 없음 (게임 IP 하드코딩) | DomainPort Protocol — 플러그인 교체 가능, REODE 이식 검증 | 신규 슬라이드 필요 |
+| **LLM** | Claude Opus 4.5, GPT-5.2, Gemini 3.0 | Opus 4.6, Sonnet 4.6, GPT-5.4, GLM-5 — 3사 Failover | s05, s17 |
+| **Sub-Agent** | 기본 병렬 실행 | CoalescingQueue + TaskGraph DAG + IsolatedRunner + 메모리 격리 | s18b |
+| **프레이밍** | 없음 | Karpathy/Beck 프레이밍 적용 (PPTX harness-for-real에서 검증) | 전체 |
+
+### 2. 기능 추가 (v0.8.0에 완전히 없던 것)
+
+| 기능 | 설명 | 후보 슬라이드 |
+|------|------|-------------|
+| **geode serve Gateway** | Slack 헤드리스 데몬, ChannelBinding, LaneQueue, Echo Prevention 3중 | s18c~s18f (이미 추가됨, 내용 점검) |
+| **Security Envelope** | Secret Redaction 8패턴, Bash 3-Layer, PolicyChain 6-layer, Tool permission 3단계 | s21b (이미 추가됨, 내용 점검) |
+| **REODE 피봇** | DomainPort 삭제 → 2-Protocol 재설계, 프리랜스 계약, 산업 현장 도입 | 신규 슬라이드 또는 s14-connection에 통합 |
+| **외부 하네스 구축** | Claude Code로 GEODE 생산, harness-for-real, REODE 납품 | 신규 또는 s16-summary에 통합 |
+| **장애 시나리오** | 7건 Failure Mode + ContextVar 전파 | s15-tradeoffs에 통합 검토 |
+| **Cross-Project Loop** | Eco²→GEODE→REODE 패턴 전이 테이블 | 신규 또는 s14-connection에 통합 |
+| **.geode Context Hub** | config.toml, model-policy.toml, routing.toml, career.toml | s11b (이미 추가됨, 내용 점검) |
+
+### 3. 수치 갱신 (12건)
 
 | 파일 | 현재값 | 정확값 |
 |------|--------|--------|
-| s00-cover.html | 178 modules | **182** |
-| s00-cover.html | 2930+ tests | **3,055+** |
-| s01-intro.html | 178 모듈, 21 릴리스 | **182 모듈, 25+ 릴리스** |
-| s13-results.html | Berserk 81.3 | **81.2** |
-| s13-results.html | GitS 51.6 | **51.7** |
-| s16-summary.html | 184 modules | **182** |
-| s16-summary.html | 3058+ tests | **3,055+** |
-| s16-summary.html | 24 releases | **25+** |
-| s17-tools.html | 48 tools (2곳) | **46** |
-| s19-skills.html | 21+ skills | **25** |
-| s20-mcp.html | 42 MCP servers | **43 catalog** |
+| s00-cover | 178 modules, 2930+ tests | **182, 3,055+** |
+| s01-intro | 178 모듈, 21 릴리스 | **182, 25+** |
+| s13-results | Berserk 81.3, GitS 51.6 | **81.2, 51.7** |
+| s16-summary | 184 modules, 3058+ tests, 24 releases | **182, 3,055+, 25+** |
+| s17-tools | 48 tools (2곳) | **46** |
+| s19-skills | 21+ skills | **25** |
+| s20-mcp | 42 MCP | **43 catalog** |
 
 ## CSS/디자인 보존 규칙
 - `:root` CSS 변수 전체 유지 (Deep Sea Discovery Theme)

--- a/docs/plans/portfolio-v024-redesign.md
+++ b/docs/plans/portfolio-v024-redesign.md
@@ -61,6 +61,30 @@
 - harness-for-real: 4-Phase FSM, Backpressure hooks, LEARNINGS.md 축적, Token budget 자동 정지
 - GEODE→REODE 2-Protocol 재설계로 클라이언트 납품
 
+## 산출물 구분
+
+| 매체 | 파일 | 용도 | 상태 |
+|------|------|------|------|
+| **Web (GitHub Pages)** | `resume/portfolio/public/geode.html` | 배포 포트폴리오 — v0.8.0 디자인 보존 + v0.24.0 콘텐츠 | Backlog |
+| **PPTX** | `portfolio/geode/GEODE-Portfolio.pptx` | 발표/공유용 — 33 슬라이드 | Backlog (수치 갱신) |
+| **5-Slide HTML (보존)** | `resume/portfolio/geode.html` | resume 스타일 — 배포하지 않음 | 보존 |
+
+## PPTX Outdated (12건)
+
+| 파일 | 현재값 | 정확값 |
+|------|--------|--------|
+| s00-cover.html | 178 modules | **182** |
+| s00-cover.html | 2930+ tests | **3,055+** |
+| s01-intro.html | 178 모듈, 21 릴리스 | **182 모듈, 25+ 릴리스** |
+| s13-results.html | Berserk 81.3 | **81.2** |
+| s13-results.html | GitS 51.6 | **51.7** |
+| s16-summary.html | 184 modules | **182** |
+| s16-summary.html | 3058+ tests | **3,055+** |
+| s16-summary.html | 24 releases | **25+** |
+| s17-tools.html | 48 tools (2곳) | **46** |
+| s19-skills.html | 21+ skills | **25** |
+| s20-mcp.html | 42 MCP servers | **43 catalog** |
+
 ## CSS/디자인 보존 규칙
 - `:root` CSS 변수 전체 유지 (Deep Sea Discovery Theme)
 - 섹션 구조 (`section.slide`, `.hero`, `.nav`) 유지

--- a/docs/plans/portfolio-v024-redesign.md
+++ b/docs/plans/portfolio-v024-redesign.md
@@ -1,0 +1,58 @@
+# portfolio-v024-redesign
+
+## 목적
+배포된 GEODE 포트폴리오(v0.8.0 디자인)의 CSS/레이아웃/애니메이션을 보존하면서, 콘텐츠를 v0.24.0 기준으로 전면 교체.
+
+## 파일
+- **원본(디자인 기준)**: `resume/portfolio/public/geode.html` (9,421줄, v0.8.0)
+- **현행 5-Slide 버전(보존)**: `resume/portfolio/geode.html` (resume 스타일, 배포하지 않음)
+- **작업 결과물**: `resume/portfolio/public/geode.html` 덮어쓰기 → GitHub Pages 자동 배포
+
+## 배포된 v0.8.0 구조 (8 섹션)
+
+| # | 섹션 | 현재 콘텐츠 (v0.8.0) | 교체 콘텐츠 (v0.24.0) |
+|---|------|---------------------|---------------------|
+| 00 | Agentic Engineering | 6 원칙 카드 (21 tools, 5 LLM, 10 rounds) | 5축 하네스 엔지니어링 (46 tools, 42 MCP, 36 hooks) + Karpathy/Beck 프레이밍 |
+| 00 | Agent Reasoning Flow | while(tool_use) 루프 + Cowboy Bebop 예시 | AgenticLoop + Sub-Agent 병렬 위임 + 3사 LLM Failover |
+| 01 | Agent Architecture | 6-Layer (L1-L5, 11 Hook) | 6-Layer 갱신 (L0-L5, 36 Hook) + geode serve Gateway + 5-Layer Context Hub |
+| 02 | Causal Scoring (Game Domain) | 14-Axis PSM + 3 Fixture (Berserk 82.2, CB 69.4, GitS 54.0) | Game IP 도메인 플러그인으로 프레이밍 — DomainPort Protocol 교체 가능한 DAG, 수치 갱신 (81.2/68.4/51.7). portfolio/geode PPTX+HTML 참고 |
+| 03 | Self-Correction | G1-G4 + BiasBuster + Cross-LLM (Claude/GPT-4/Gemini) | 5-Layer Verification + Cross-LLM (Claude×GPT, Krippendorff α ≥ 0.67) |
+| 04 | Multi-Agent Coordination | Sub-Agent + 3-Tier Memory + Plan Mode + 11 Hook | Sub-Agent (CoalescingQueue+TaskGraph+IsolatedRunner) + 5-Layer Context Hub + 36 Hook |
+| 05 | Self-Improvement | CUSUM + RLAIF + Feedback Loop 5-Phase | 유지 (대부분 동일) |
+| 06 | Multi-LLM Ensemble | 5 LLM (Opus 4.5, GPT-5.2, Gemini 3.0) + 21 tools | 3사 Failover (Opus 4.6/Sonnet 4.6, GPT-5.4, GLM-5) + 46 tools + 42 MCP + Security Envelope |
+| 07 | Timeline | v0.6.0 ~ v0.9.0 | v0.6.0 ~ v0.24.0 핵심 마일스톤 |
+
+## Hero 섹션 변경
+- 제목: "Autonomous IP Discovery Agent" → "범용 자율 실행 에이전트 하네스"
+- 부제: "모델 능력이 상수일 때, 변수는 오케스트레이션의 구조입니다"
+- 수치 배지: 21 tools → 46 tools, 5 LLMs → 3 Providers, 10 rounds → 50 rounds, 14 PSM → 182 modules
+
+## 프레이밍 (PPTX 검증 완료)
+- "모델 능력이 상수일 때, 변수는 오케스트레이션의 구조입니다"
+- "제어 없는 확률적 시스템은 발산한다"
+- "입력의 정밀도가 출력의 상한을 결정한다"
+- "v1이 정상 경로를 구현, v2는 장애 경로까지 설계"
+- Karpathy: 확률적 시스템의 제어 평면 필요성
+- Beck: "테스트 없는 코드는 레거시 코드다", "모든 설계는 트레이드오프다"
+
+## 신규 추가 콘텐츠
+- **DomainPort → REODE 피봇**: 게임 IP → 범용 하네스 → 코드 마이그레이션 도메인 이식
+- **geode serve Gateway**: Slack 데몬, ChannelBinding, LaneQueue, Echo Prevention
+- **Security Envelope**: Secret Redaction 8패턴, Bash 3-Layer, PolicyChain 6-layer
+- **MCP 42 카탈로그**: 병렬 연결 110s→15s, Deferred Loading
+- **외부 하네스 구축 축**: Claude Code로 GEODE 생산, harness-for-real, REODE 납품
+
+## CSS/디자인 보존 규칙
+- `:root` CSS 변수 전체 유지 (Deep Sea Discovery Theme)
+- 섹션 구조 (`section.slide`, `.hero`, `.nav`) 유지
+- 애니메이션/트랜지션 유지
+- 반응형 breakpoint (768px, 480px) 유지
+- 폰트 (Inter, Fira Code, Noto Sans KR) 유지
+- 한/영 토글 유지
+
+## 작업 순서
+1. `portfolio/public/geode.html` 백업 (`geode-v080.html`)
+2. CSS `<style>` 블록 + `<script>` 블록 그대로 보존
+3. `<body>` 내 HTML 콘텐츠만 섹션별 교체
+4. 브라우저에서 레이아웃 확인
+5. resume 레포 커밋 + 푸시 → GitHub Pages 배포

--- a/docs/plans/portfolio-v024-redesign.md
+++ b/docs/plans/portfolio-v024-redesign.md
@@ -36,11 +36,30 @@
 - Beck: "테스트 없는 코드는 레거시 코드다", "모든 설계는 트레이드오프다"
 
 ## 신규 추가 콘텐츠
-- **DomainPort → REODE 피봇**: 게임 IP → 범용 하네스 → 코드 마이그레이션 도메인 이식
-- **geode serve Gateway**: Slack 데몬, ChannelBinding, LaneQueue, Echo Prevention
-- **Security Envelope**: Secret Redaction 8패턴, Bash 3-Layer, PolicyChain 6-layer
-- **MCP 42 카탈로그**: 병렬 연결 110s→15s, Deferred Loading
-- **외부 하네스 구축 축**: Claude Code로 GEODE 생산, harness-for-real, REODE 납품
+
+### 핵심 서사 (v0.8.0에 없던 것)
+- **DomainPort → REODE 피봇**: 게임 IP → 범용 하네스 → 코드 마이그레이션 도메인 이식, 실제 산업 현장 레거시 Java 마이그레이션에 도입 운영 중
+- **REODE 재설계 상세**: DomainPort 삭제 → PipelineTemplate(L1) + LanguageAdapter(L2) 2-Protocol 직교 분리, DI 3점, 그래프 정의 L0→L1 이동
+- **Cross-Project Loop**: Eco²→GEODE→REODE 패턴 전이 테이블 (메모리, 평가, 컨텍스트, Resilience, 루프 제어)
+
+### 시스템 신규
+- **geode serve Gateway**: Slack 데몬, ChannelBinding, LaneQueue, Echo Prevention 3중
+- **Security Envelope**: Secret Redaction 8패턴, Bash 3-Layer, PolicyChain 6-layer, Tool permission 3단계(STANDARD/WRITE/DANGEROUS)
+- **MCP 42 카탈로그**: 병렬 연결 110s→15s, Deferred Loading, Singleton MCPServerManager
+- **5-Layer Context Hub (C0-C4)**: System Prompt → Org → Project → Session → User Profile, Context Compaction (80% WARNING → Haiku 압축)
+- **Sub-Agent 메모리 격리**: 부모 스냅샷 읽기 전용, task_id 스코프 버퍼, summary만 병합
+- **장애 시나리오 7건**: 네트워크 다운, CI 타임아웃, 메모리 부패, Confidence 미달, LLM 전체 장애, MCP 실패, .owner 부재
+
+### REODE 관련 (포트폴리오에 섹션 추가 검토)
+- **Migration Scorecard 3-Tier**: 5 Gate(Reward Hacking 방지) + S/A/B/C 4등급 + Insight
+- **Fix Node**: Explore→Reason→Act 재귀 수정, 수렴 감지(동일 에러 3회 → 에스컬레이션)
+- **AgentRole 4종**: ARCHITECT(Opus)/ENGINEER(Sonnet)/REVIEWER(Haiku)/SCOUT(Haiku) 노드별 비용 라우팅
+- **OpenRewrite(결정적 70%) + LLM(확률적 30%)**: 확률적 시스템 개입 범위 최소화
+
+### 외부 하네스 구축 (5축)
+- Claude Code(.claude/ Skills·Hooks·CLAUDE.md)로 GEODE를 생산
+- harness-for-real: 4-Phase FSM, Backpressure hooks, LEARNINGS.md 축적, Token budget 자동 정지
+- GEODE→REODE 2-Protocol 재설계로 클라이언트 납품
 
 ## CSS/디자인 보존 규칙
 - `:root` CSS 변수 전체 유지 (Deep Sea Discovery Theme)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
 # GEODE Progress Board
 
 > 멀티 에이전트 공유 칸반 보드. 모든 세션/에이전트가 이 파일을 읽고 갱신한다.
-> 마지막 갱신: 2026-03-24 (세션 13 — .geode/+CLAUDE.md 컨텍스트 품질 점검)
+> 마지막 갱신: 2026-03-24 (세션 14 — Slack E2E 3시나리오 + mrkdwn 개선 + REPL bootstrap 통합)
 > **규칙**: progress.md는 main에서만 수정. feature/develop 수정 금지.
 
 ---
@@ -18,7 +18,7 @@
 
 | task_id | 작업 내용 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|----------|------|--------|--------|------|
-| — | — | — | — | — | — |
+| portfolio-v024-redesign | GEODE 포트폴리오 v0.8.0 디자인 유지 + v0.24.0 콘텐츠 재설정 | @mangowhoiscloud | resume repo | 2026-03-24 | 배포 페이지 기준, 디자인 보존 |
 
 ### In Review
 
@@ -30,6 +30,9 @@
 
 | task_id | 작업 내용 | PR | 담당 | 완료일 |
 |---------|----------|----|------|--------|
+| repl-bootstrap-unify | REPL→bootstrap_geode() 통합 — 인라인 6단계→bootstrap 호출 (serve/REPL 단일 경로) | main direct | @mangowhoiscloud | 2026-03-24 |
+| slack-mrkdwn-v2 | Slack mrkdwn 개선 — ZWS 경계 수정 + 테이블→섹션 + 코드블록 보호 (33 tests) | main direct | @mangowhoiscloud | 2026-03-24 |
+| slack-e2e-scenarios | Slack @GEODE 3시나리오 E2E — web_fetch + web_search + memory_save 실증 | main direct | @mangowhoiscloud | 2026-03-24 |
 | context-quality-review | .geode/ + CLAUDE.md 컨텍스트 품질 — 3인 검증팀, -132줄 블로트 제거 | #400→#401 | @mangowhoiscloud | 2026-03-24 |
 | gmail-integration | Gmail MCP 통합 — OAuth 기반, DEFAULT_SERVERS 등록, catalog 43개 | #396→#397 | @mangowhoiscloud | 2026-03-24 |
 | serve-repl-unify | bootstrap_geode() 단일 초기화 + ContextVar 전파 (14 tests) | #394→#395 | @mangowhoiscloud | 2026-03-24 |
@@ -188,9 +191,9 @@
 |------|-----|--------|
 | Version | 0.24.0 | 2026-03-22 |
 | Modules | 178 | 2026-03-23 |
-| Tests | 2972 | 2026-03-23 |
+| Tests | 3051 | 2026-03-24 |
 | Tools | 46 (+MCP 86) | 2026-03-22 |
-| MCP Catalog | 42 | 2026-03-19 |
+| MCP Catalog | 43 | 2026-03-24 |
 | HookEvents | 36 | 2026-03-19 |
 | Skills | 25 | 2026-03-21 |
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -12,13 +12,13 @@
 
 | task_id | 작업 내용 | 우선순위 | plan | 비고 |
 |---------|----------|:--------:|------|------|
-| — | — | — | — | — |
+| portfolio-v024-redesign | GEODE 포트폴리오 v0.8.0 디자인(CSS+레이아웃) 유지 + v0.24.0 콘텐츠 전면 교체 (8섹션, 9,421줄) | P0 | 아래 참조 | 원본: `resume/portfolio/public/geode.html`, 현행 5-Slide 버전은 `portfolio/geode.html`에 보존 |
 
 ### In Progress
 
 | task_id | 작업 내용 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|----------|------|--------|--------|------|
-| portfolio-v024-redesign | GEODE 포트폴리오 v0.8.0 디자인 유지 + v0.24.0 콘텐츠 재설정 | @mangowhoiscloud | resume repo | 2026-03-24 | 배포 페이지 기준, 디자인 보존 |
+| — | — | — | — | — | — |
 
 ### In Review
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -18,7 +18,7 @@
 
 | task_id | 작업 내용 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|----------|------|--------|--------|------|
-| context-quality-review | .geode/ + CLAUDE.md 컨텍스트 품질 점검 — 3인 검증팀(Karpathy/OpenClaw/Claude Code) | @mangowhoiscloud | feature/context-quality-review | 2026-03-24 | 리서치+플랜→구현 |
+| — | — | — | — | — | — |
 
 ### In Review
 
@@ -26,10 +26,11 @@
 |---------|----------|-----|------|-----|------|
 | — | — | — | — | — | — |
 
-### Done (2026-03-22)
+### Done (2026-03-24)
 
 | task_id | 작업 내용 | PR | 담당 | 완료일 |
 |---------|----------|----|------|--------|
+| context-quality-review | .geode/ + CLAUDE.md 컨텍스트 품질 — 3인 검증팀, -132줄 블로트 제거 | #400→#401 | @mangowhoiscloud | 2026-03-24 |
 | gmail-integration | Gmail MCP 통합 — OAuth 기반, DEFAULT_SERVERS 등록, catalog 43개 | #396→#397 | @mangowhoiscloud | 2026-03-24 |
 | serve-repl-unify | bootstrap_geode() 단일 초기화 + ContextVar 전파 (14 tests) | #394→#395 | @mangowhoiscloud | 2026-03-24 |
 | web-fetch-ssl | web_fetch SSL fallback — Python 3.14 certifi 호환 | #392→#393 | @mangowhoiscloud | 2026-03-24 |

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -54,6 +54,11 @@ class TestMemorySearchTool:
 
     def test_search_empty_store(self):
         store = InMemorySessionStore()
+        # Isolate from global project/org contextvars that may leak from other tests
+        from core.tools.memory_tools import set_org_memory as _set_org
+
+        set_project_memory(None)
+        _set_org(None)
         tool = MemorySearchTool(session_store=store)
         result = tool.execute(query="anything")
         assert result["result"]["total_found"] == 0

--- a/tests/test_serve_e2e.py
+++ b/tests/test_serve_e2e.py
@@ -17,6 +17,7 @@ class TestServeToolExecution:
 
     def test_bootstrap_handlers_count(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         assert len(boot.tool_handlers) >= 44
         assert "web_fetch" in boot.tool_handlers
@@ -24,6 +25,7 @@ class TestServeToolExecution:
 
     def test_web_fetch_http(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         result = boot.tool_handlers["web_fetch"](url="http://example.com", max_chars=200)
         assert "result" in result
@@ -31,6 +33,7 @@ class TestServeToolExecution:
 
     def test_web_fetch_https_ssl_fallback(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         result = boot.tool_handlers["web_fetch"](url="https://example.com", max_chars=200)
         # Should succeed via SSL fallback
@@ -42,6 +45,7 @@ class TestServeToolExecution:
     )
     def test_general_web_search(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         result = boot.tool_handlers["general_web_search"](query="test", max_results=1)
         assert "result" in result
@@ -49,6 +53,7 @@ class TestServeToolExecution:
     def test_executor_web_fetch(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
         from core.cli.tool_executor import ToolExecutor
+
         boot = bootstrap_geode(load_env=True)
         executor = ToolExecutor(
             action_handlers=boot.tool_handlers,

--- a/tests/test_serve_e2e.py
+++ b/tests/test_serve_e2e.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import os
 import threading
+from pathlib import Path
 
 import pytest
-
-# Load env before any imports
 from dotenv import load_dotenv
-from pathlib import Path
+
 load_dotenv(str(Path.home() / ".geode" / ".env"), override=False)
 
 

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from core.gateway.slack_formatter import markdown_to_slack_mrkdwn
 
+_ZWS = "\u200b"
+
 
 class TestBoldConversion:
     def test_double_asterisk_to_single(self) -> None:
@@ -18,6 +20,39 @@ class TestBoldConversion:
         assert result == "This is *important* text"
 
 
+class TestSlackBoundaryFix:
+    """Slack requires whitespace/punctuation around *bold* markers."""
+
+    def test_bold_followed_by_korean(self) -> None:
+        result = markdown_to_slack_mrkdwn("**LangGraph**가 좋다")
+        assert f"*LangGraph*{_ZWS}가 좋다" == result
+
+    def test_bold_followed_by_space(self) -> None:
+        result = markdown_to_slack_mrkdwn("**bold** text")
+        assert result == "*bold* text"
+        assert _ZWS not in result
+
+    def test_bold_followed_by_comma(self) -> None:
+        result = markdown_to_slack_mrkdwn("**bold**, text")
+        assert result == "*bold*, text"
+        assert _ZWS not in result
+
+    def test_bold_followed_by_period(self) -> None:
+        assert markdown_to_slack_mrkdwn("**bold**.") == "*bold*."
+
+    def test_bold_at_end_of_line(self) -> None:
+        assert markdown_to_slack_mrkdwn("This is **bold**") == "This is *bold*"
+
+    def test_korean_before_bold(self) -> None:
+        result = markdown_to_slack_mrkdwn("프레임워크**LangGraph**가")
+        assert f"프레임워크{_ZWS}*LangGraph*{_ZWS}가" == result
+
+    def test_multiple_bold_with_korean(self) -> None:
+        result = markdown_to_slack_mrkdwn("**LangGraph**가 성숙하고, **CrewAI**가 적합")
+        assert f"*LangGraph*{_ZWS}가" in result
+        assert f"*CrewAI*{_ZWS}가" in result
+
+
 class TestHeadingConversion:
     def test_h1(self) -> None:
         assert markdown_to_slack_mrkdwn("# Title") == "*Title*"
@@ -28,49 +63,69 @@ class TestHeadingConversion:
     def test_h3(self) -> None:
         assert markdown_to_slack_mrkdwn("### Section") == "*Section*"
 
-    def test_h6(self) -> None:
-        assert markdown_to_slack_mrkdwn("###### Deep") == "*Deep*"
-
     def test_multiline_headings(self) -> None:
         text = "# First\nsome text\n## Second"
         result = markdown_to_slack_mrkdwn(text)
         assert result == "*First*\nsome text\n*Second*"
 
+    def test_heading_with_bold(self) -> None:
+        result = markdown_to_slack_mrkdwn("# **Important** Update")
+        assert "Important" in result
+        assert "Update" in result
+        assert "***" not in result
+
 
 class TestLinkConversion:
     def test_basic_link(self) -> None:
-        result = markdown_to_slack_mrkdwn("[Google](https://google.com)")
-        assert result == "<https://google.com|Google>"
+        assert markdown_to_slack_mrkdwn("[Google](https://google.com)") == "<https://google.com|Google>"
 
     def test_link_in_sentence(self) -> None:
         result = markdown_to_slack_mrkdwn("Visit [docs](https://docs.example.com) for info")
         assert result == "Visit <https://docs.example.com|docs> for info"
 
-    def test_multiple_links(self) -> None:
-        text = "[a](https://a.com) and [b](https://b.com)"
-        result = markdown_to_slack_mrkdwn(text)
-        assert result == "<https://a.com|a> and <https://b.com|b>"
 
-
-class TestTableWrapping:
-    def test_simple_table(self) -> None:
+class TestTableToSections:
+    def test_two_column_to_bullets(self) -> None:
         text = "| Name | Score |\n| --- | --- |\n| Alice | 90 |"
         result = markdown_to_slack_mrkdwn(text)
-        assert result == "```\n| Name | Score |\n| Alice | 90 |\n```"
+        assert "• *Alice*: 90" in result
+        assert "```" not in result
 
-    def test_table_separator_stripped(self) -> None:
-        text = "| H1 | H2 |\n| --- | --- |\n| v1 | v2 |"
+    def test_comparison_to_vertical(self) -> None:
+        text = "| 항목 | LangGraph | CrewAI |\n| --- | --- | --- |\n| 개발사 | LangChain | CrewAI Inc. |"
         result = markdown_to_slack_mrkdwn(text)
-        assert "| --- |" not in result
+        assert "*LangGraph*" in result
+        assert "*CrewAI*" in result
+        assert "개발사: LangChain" in result
+        assert "|" not in result
+
+    def test_bold_stripped_in_cells(self) -> None:
+        text = "| 항목 | **LG** | **CR** |\n| --- | --- | --- |\n| **특징** | a | b |"
+        result = markdown_to_slack_mrkdwn(text)
+        assert "**" not in result
+
+    def test_dash_values_omitted(self) -> None:
+        text = "| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | - |"
+        result = markdown_to_slack_mrkdwn(text)
+        assert "점수: 90" in result
 
     def test_table_surrounded_by_text(self) -> None:
         text = "Before\n| A | B |\n| - | - |\n| 1 | 2 |\nAfter"
         result = markdown_to_slack_mrkdwn(text)
-        lines = result.split("\n")
-        assert lines[0] == "Before"
-        assert lines[1] == "```"
-        assert lines[-2] == "```"
-        assert lines[-1] == "After"
+        assert result.startswith("Before")
+        assert result.rstrip().endswith("After")
+
+
+class TestHorizontalRule:
+    def test_triple_dash(self) -> None:
+        result = markdown_to_slack_mrkdwn("Before\n---\nAfter")
+        assert "---" not in result
+        assert "Before" in result and "After" in result
+
+
+class TestStrikethrough:
+    def test_basic(self) -> None:
+        assert markdown_to_slack_mrkdwn("~~removed~~") == "~removed~"
 
 
 class TestMixedContent:
@@ -81,45 +136,35 @@ class TestMixedContent:
         assert "*Status*" in result
         assert "<https://x.com|link>" in result
 
-    def test_bold_in_heading(self) -> None:
-        # Heading conversion happens first, then bold
-        text = "# **Important** Update"
+    def test_realistic_response(self) -> None:
+        text = "## 비교\n\n| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | 80 |\n\n**A**가 높다."
         result = markdown_to_slack_mrkdwn(text)
-        # After heading: ***Important** Update* → then bold: **Important* Update*
-        # The heading wraps entire line, bold converts inside
-        assert "Important" in result
-        assert "Update" in result
+        assert "**" not in result
+        assert "##" not in result
+        assert "|" not in result
+        assert f"*A*{_ZWS}가" in result
 
 
 class TestNoOp:
     def test_plain_text(self) -> None:
-        text = "Hello, world!"
-        assert markdown_to_slack_mrkdwn(text) == text
+        assert markdown_to_slack_mrkdwn("Hello!") == "Hello!"
 
     def test_empty_string(self) -> None:
         assert markdown_to_slack_mrkdwn("") == ""
 
-    def test_already_slack_format(self) -> None:
-        text = "*bold* and <https://x.com|link>"
-        result = markdown_to_slack_mrkdwn(text)
-        # Single asterisks should pass through unchanged
-        assert "*bold*" in result
-
 
 class TestCodeBlockPreserved:
     def test_inline_code(self) -> None:
-        text = "Use `pip install geode` to install"
-        assert markdown_to_slack_mrkdwn(text) == text
+        assert markdown_to_slack_mrkdwn("Use `pip install geode`") == "Use `pip install geode`"
 
-    def test_fenced_code_block(self) -> None:
-        text = "```python\nprint('hello')\n```"
-        result = markdown_to_slack_mrkdwn(text)
-        assert "print('hello')" in result
+    def test_fenced_code(self) -> None:
+        assert "print('hello')" in markdown_to_slack_mrkdwn("```python\nprint('hello')\n```")
 
-    def test_heading_hash_inside_code_not_converted(self) -> None:
-        # Fenced code blocks: the ``` lines don't start with |, so they're not tables
-        # The inner content doesn't start with #, so heading regex won't match
-        text = "```\nsome code\n```"
-        result = markdown_to_slack_mrkdwn(text)
-        assert "```" in result
-        assert "some code" in result
+    def test_bold_inside_code_preserved(self) -> None:
+        assert "**not bold**" in markdown_to_slack_mrkdwn("```\n**not bold**\n```")
+
+    def test_heading_inside_code_preserved(self) -> None:
+        assert "# not heading" in markdown_to_slack_mrkdwn("```\n# not heading\n```")
+
+    def test_inline_kwargs_preserved(self) -> None:
+        assert "`**kwargs`" in markdown_to_slack_mrkdwn("Use `**kwargs` in function")

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -77,7 +77,10 @@ class TestHeadingConversion:
 
 class TestLinkConversion:
     def test_basic_link(self) -> None:
-        assert markdown_to_slack_mrkdwn("[Google](https://google.com)") == "<https://google.com|Google>"
+        assert (
+            markdown_to_slack_mrkdwn("[Google](https://google.com)")
+            == "<https://google.com|Google>"
+        )
 
     def test_link_in_sentence(self) -> None:
         result = markdown_to_slack_mrkdwn("Visit [docs](https://docs.example.com) for info")
@@ -137,7 +140,9 @@ class TestMixedContent:
         assert "<https://x.com|link>" in result
 
     def test_realistic_response(self) -> None:
-        text = "## 비교\n\n| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | 80 |\n\n**A**가 높다."
+        text = (
+            "## 비교\n\n| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | 80 |\n\n**A**가 높다."
+        )
         result = markdown_to_slack_mrkdwn(text)
         assert "**" not in result
         assert "##" not in result


### PR DESCRIPTION
## Summary
- REPL 초기화를 `bootstrap_geode()` 단일 함수로 통합 (REPL/serve 동일 경로)
- Slack mrkdwn 변환기 v2: ZWS 경계 보정, 테이블→세로 섹션, strikethrough, 코드블록 보호
- 테스트 33개 통과, 전체 3051 pass

## Test plan
- [x] `ruff check` — 0 errors
- [x] `mypy` — 0 errors  
- [x] `pytest tests/test_slack_formatter.py` — 33 passed
- [x] `pytest tests/ -m "not live"` — 3051 passed (1 기존 flaky 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)