### PR TITLE
develop → main: REPL bootstrap 통합 + Slack mrkdwn v2 + CI 수정

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -930,9 +930,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
     n_mcp = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
     n_skills = len(skill_registry._skills) if hasattr(skill_registry, "_skills") else 0
-    console.print(
-        f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})"
-    )
+    console.print(f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})")
 
     # Key gate (REPL-only: interactive prompt if API key missing)
     readiness = boot.readiness

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -920,43 +920,22 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     verbose = False
     conversation = ConversationContext()
 
-    # --- Startup initialization with progressive status ---
-    def _init_step(label: str) -> None:
-        """Print a compact startup progress indicator."""
-        console.print(f"  [dim]Loading {label}...[/dim]", end="\r")
+    # --- Unified bootstrap (domain, memory, readiness, MCP, skills) ---
+    from core.cli.bootstrap import bootstrap_geode
 
-    def _init_done(label: str, ok: bool = True) -> None:
-        mark = "[bold green]ok[/bold green]" if ok else "[dim]skip[/dim]"
-        console.print(f"  {mark} {label}          ")
+    console.print("  [dim]Initializing...[/dim]", end="\r")
+    boot = bootstrap_geode()
+    mcp_mgr = boot.mcp_manager
+    skill_registry = boot.skill_registry
 
-    # 1. Domain adapter
-    _init_step("domain")
-    from core.domains.loader import load_domain_adapter
-    from core.infrastructure.ports.domain_port import set_domain
+    n_mcp = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
+    n_skills = len(skill_registry._skills) if hasattr(skill_registry, "_skills") else 0
+    console.print(
+        f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})"
+    )
 
-    try:
-        set_domain(load_domain_adapter("game_ip"))
-        _init_done("Domain")
-    except Exception:
-        _init_done("Domain", ok=False)
-        log.debug("Domain adapter initialization skipped", exc_info=True)
-
-    # 2. Memory contextvars
-    _init_step("memory")
-    from core.memory.organization import MonoLakeOrganizationMemory
-    from core.memory.project import ProjectMemory
-    from core.tools.memory_tools import set_org_memory, set_project_memory
-
-    try:
-        set_project_memory(ProjectMemory())
-        set_org_memory(MonoLakeOrganizationMemory())
-        _init_done("Memory")
-    except Exception:
-        _init_done("Memory", ok=False)
-        log.debug("Memory context initialization skipped", exc_info=True)
-
-    # 3. Key gate
-    readiness = _get_readiness()
+    # Key gate (REPL-only: interactive prompt if API key missing)
+    readiness = boot.readiness
     if readiness is None or readiness.blocked:
         key = key_registration_gate()
         if key is None:
@@ -964,38 +943,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         readiness = check_readiness()
         _set_readiness(readiness)
 
-    # 4. MCP servers (slowest — npx subprocess spawn)
-    #    Uses startup() for full lifecycle: config + connect + signal handlers + atexit
-    _init_step("MCP servers")
-    from core.infrastructure.adapters.mcp.manager import MCPServerManager
-
-    mcp_mgr: MCPServerManager | None = None
-    try:
-        _mgr = MCPServerManager()
-        n_connected = _mgr.startup()
-        if len(_mgr._servers) > 0:
-            mcp_mgr = _mgr
-            _init_done(f"MCP ({n_connected}/{len(_mgr._servers)} servers)")
-        else:
-            _init_done("MCP (none)", ok=False)
-    except Exception:
-        _init_done("MCP", ok=False)
-        log.debug("MCP initialization skipped", exc_info=True)
-
-    # 5. Skills
-    _init_step("skills")
-    from core.extensibility.skills import SkillLoader, SkillRegistry
-
-    skill_registry = SkillRegistry()
-    try:
-        loaded_skills = SkillLoader().load_all(registry=skill_registry)
-        _init_done(f"Skills ({len(loaded_skills)})" if loaded_skills else "Skills (0)")
-    except Exception:
-        _init_done("Skills", ok=False)
-        log.debug("Skill loading skipped", exc_info=True)
-
-    # 6. Scheduler
-    _init_step("scheduler")
+    # Scheduler (REPL-only: cron + /schedule command)
     try:
         from core.automation.scheduler import SchedulerService
 
@@ -1003,9 +951,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         _sched_svc.load()
         _sched_svc.start()
         _scheduler_service_ctx.set(_sched_svc)
-        _init_done("Scheduler")
     except Exception:
-        _init_done("Scheduler", ok=False)
         log.debug("SchedulerService initialization skipped", exc_info=True)
 
     console.print()  # blank line before prompt

--- a/core/gateway/slack_formatter.py
+++ b/core/gateway/slack_formatter.py
@@ -4,48 +4,170 @@ from __future__ import annotations
 
 import re
 
+_CODE_SENTINEL = "\x00CODE"
+_ZWS = "\u200b"  # zero-width space — Slack word-boundary fix
+
+# Characters that Slack treats as word boundaries for *bold* formatting
+_BOUNDARY_AFTER = frozenset(" \t\n,.\u2014!?;:)]>*_~`\"'\u200b")
+_BOUNDARY_BEFORE = frozenset(" \t\n,.\u2014!?;:([<*_~`\"'\u200b")
+
 
 def markdown_to_slack_mrkdwn(text: str) -> str:
     """Convert Markdown to Slack mrkdwn.
 
     Conversions:
-    - **bold** → *bold*
+    - **bold** → *bold* with ZWS at non-boundary edges
+    - ~~strike~~ → ~strike~
     - # Heading → *Heading*
-    - ## Heading → *Heading*
     - [text](url) → <url|text>
-    - Markdown tables → code block wrapped
+    - Markdown tables → vertical section format
+    - --- → removed
     """
-    # Headers: # Heading → *Heading*
-    text = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", text, flags=re.MULTILINE)
+    if not text:
+        return text
 
-    # Bold: **text** → *text* (must do before italic)
-    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+    # ── 1. Protect code blocks ──
+    code_blocks: list[str] = []
 
-    # Links: [text](url) → <url|text>
+    def _save(m: re.Match[str]) -> str:
+        code_blocks.append(m.group(0))
+        return f"{_CODE_SENTINEL}{len(code_blocks) - 1}\x00"
+
+    text = re.sub(r"```[\s\S]*?```", _save, text)
+    text = re.sub(r"`[^`\n]+`", _save, text)
+
+    # ── 2. Tables → sections (before inline fmt) ──
+    text = _convert_tables(text)
+
+    # ── 3. Bold with Slack boundary fix ──
+    text = _convert_bold(text)
+
+    # ── 4. Strikethrough ──
+    text = re.sub(r"~~(.+?)~~", r"~\1~", text)
+
+    # ── 5. Block-level ──
+    def _heading(m: re.Match[str]) -> str:
+        c = m.group(1)
+        c = re.sub(r"\*\*(.+?)\*\*", r"\1", c)
+        c = re.sub(r"^\*(.+)\*$", r"\1", c)
+        return f"*{c}*"
+
+    text = re.sub(r"^#{1,6}\s+(.+)$", _heading, text, flags=re.MULTILINE)
     text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", text)
+    text = re.sub(r"^[\s]*[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
 
-    # Tables: wrap in code block if detected
-    # (Slack doesn't render tables, so wrap them for readability)
+    # Collapse 3+ blank lines
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+
+    # ── 6. Restore code blocks ──
+    for i, block in enumerate(code_blocks):
+        text = text.replace(f"{_CODE_SENTINEL}{i}\x00", block)
+
+    return text.strip()
+
+
+def _convert_bold(text: str) -> str:
+    """Convert **bold** → *bold* with ZWS at non-boundary edges.
+
+    Slack mrkdwn requires word boundaries around *bold*.
+    *LangGraph*가 won't render — needs *LangGraph*​가 (ZWS).
+    """
+
+    def _repl(m: re.Match[str]) -> str:
+        content = m.group(1)
+        result = f"*{content}*"
+
+        end = m.end()
+        if end < len(text) and text[end] not in _BOUNDARY_AFTER:
+            result += _ZWS
+
+        start = m.start()
+        if start > 0 and text[start - 1] not in _BOUNDARY_BEFORE:
+            result = _ZWS + result
+
+        return result
+
+    return re.sub(r"\*\*(.+?)\*\*", _repl, text)
+
+
+# ── Table conversion ──
+
+
+def _strip_md(text: str) -> str:
+    """Strip Markdown formatting from cell text."""
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"\*(.+?)\*", r"\1", text)
+    text = re.sub(r"~~(.+?)~~", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    return text.strip()
+
+
+def _parse_table(lines: list[str]) -> tuple[list[str], list[list[str]]]:
+    """Parse table lines → (headers, data_rows) with formatting stripped."""
+    rows: list[list[str]] = []
+    for line in lines:
+        s = line.strip()
+        if re.match(r"^\|[\s\-:|]+\|$", s):
+            continue
+        cells = [_strip_md(c) for c in s.strip("|").split("|")]
+        if any(c for c in cells):
+            rows.append(cells)
+    if not rows:
+        return [], []
+    return rows[0], rows[1:]
+
+
+def _table_to_sections(headers: list[str], data: list[list[str]]) -> str:
+    """Convert table to Slack-friendly vertical sections."""
+    ncols = len(headers)
+
+    if ncols > 2 and data:
+        parts: list[str] = []
+        for ci in range(1, ncols):
+            title = headers[ci] if ci < ncols else ""
+            lines = [f"*{title}*"]
+            for row in data:
+                label = row[0] if row else ""
+                val = row[ci] if ci < len(row) else ""
+                if val and val.strip() and val.strip() != "-":
+                    lines.append(f"  • {label}: {val}")
+            parts.append("\n".join(lines))
+        return "\n\n".join(parts)
+
+    out: list[str] = []
+    for row in data:
+        if len(row) >= 2:
+            out.append(f"• *{row[0]}*: {row[1]}")
+        elif row:
+            out.append(f"• {row[0]}")
+    return "\n".join(out)
+
+
+def _convert_tables(text: str) -> str:
+    """Find and convert Markdown tables."""
     lines = text.split("\n")
     result: list[str] = []
-    in_table = False
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if not buf:
+            return
+        h, d = _parse_table(buf)
+        if h and d:
+            result.append(_table_to_sections(h, d))
+        else:
+            result.extend(buf)
+        buf.clear()
+
     for line in lines:
-        is_table_line = bool(re.match(r"^\s*\|", line))
-        is_separator = bool(re.match(r"^\s*\|[\s\-:|]+\|", line))
+        if re.match(r"^\s*\|", line):
+            buf.append(line)
+        else:
+            if buf:
+                _flush()
+            result.append(line)
 
-        if is_table_line and not in_table:
-            in_table = True
-            result.append("```")
-        elif not is_table_line and in_table:
-            in_table = False
-            result.append("```")
-
-        if is_separator:
-            continue  # Skip Markdown table separators
-
-        result.append(line)
-
-    if in_table:
-        result.append("```")
+    if buf:
+        _flush()
 
     return "\n".join(result)

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -54,6 +54,11 @@ class TestMemorySearchTool:
 
     def test_search_empty_store(self):
         store = InMemorySessionStore()
+        # Isolate from global project/org contextvars that may leak from other tests
+        from core.tools.memory_tools import set_org_memory as _set_org
+
+        set_project_memory(None)
+        _set_org(None)
         tool = MemorySearchTool(session_store=store)
         result = tool.execute(query="anything")
         assert result["result"]["total_found"] == 0

--- a/tests/test_serve_e2e.py
+++ b/tests/test_serve_e2e.py
@@ -17,6 +17,7 @@ class TestServeToolExecution:
 
     def test_bootstrap_handlers_count(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         assert len(boot.tool_handlers) >= 44
         assert "web_fetch" in boot.tool_handlers
@@ -24,6 +25,7 @@ class TestServeToolExecution:
 
     def test_web_fetch_http(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         result = boot.tool_handlers["web_fetch"](url="http://example.com", max_chars=200)
         assert "result" in result
@@ -31,6 +33,7 @@ class TestServeToolExecution:
 
     def test_web_fetch_https_ssl_fallback(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         result = boot.tool_handlers["web_fetch"](url="https://example.com", max_chars=200)
         # Should succeed via SSL fallback
@@ -42,6 +45,7 @@ class TestServeToolExecution:
     )
     def test_general_web_search(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
+
         boot = bootstrap_geode(load_env=True)
         result = boot.tool_handlers["general_web_search"](query="test", max_results=1)
         assert "result" in result
@@ -49,6 +53,7 @@ class TestServeToolExecution:
     def test_executor_web_fetch(self) -> None:
         from core.cli.bootstrap import bootstrap_geode
         from core.cli.tool_executor import ToolExecutor
+
         boot = bootstrap_geode(load_env=True)
         executor = ToolExecutor(
             action_handlers=boot.tool_handlers,

--- a/tests/test_serve_e2e.py
+++ b/tests/test_serve_e2e.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import os
 import threading
+from pathlib import Path
 
 import pytest
-
-# Load env before any imports
 from dotenv import load_dotenv
-from pathlib import Path
+
 load_dotenv(str(Path.home() / ".geode" / ".env"), override=False)
 
 

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from core.gateway.slack_formatter import markdown_to_slack_mrkdwn
 
+_ZWS = "\u200b"
+
 
 class TestBoldConversion:
     def test_double_asterisk_to_single(self) -> None:
@@ -18,6 +20,39 @@ class TestBoldConversion:
         assert result == "This is *important* text"
 
 
+class TestSlackBoundaryFix:
+    """Slack requires whitespace/punctuation around *bold* markers."""
+
+    def test_bold_followed_by_korean(self) -> None:
+        result = markdown_to_slack_mrkdwn("**LangGraph**가 좋다")
+        assert f"*LangGraph*{_ZWS}가 좋다" == result
+
+    def test_bold_followed_by_space(self) -> None:
+        result = markdown_to_slack_mrkdwn("**bold** text")
+        assert result == "*bold* text"
+        assert _ZWS not in result
+
+    def test_bold_followed_by_comma(self) -> None:
+        result = markdown_to_slack_mrkdwn("**bold**, text")
+        assert result == "*bold*, text"
+        assert _ZWS not in result
+
+    def test_bold_followed_by_period(self) -> None:
+        assert markdown_to_slack_mrkdwn("**bold**.") == "*bold*."
+
+    def test_bold_at_end_of_line(self) -> None:
+        assert markdown_to_slack_mrkdwn("This is **bold**") == "This is *bold*"
+
+    def test_korean_before_bold(self) -> None:
+        result = markdown_to_slack_mrkdwn("프레임워크**LangGraph**가")
+        assert f"프레임워크{_ZWS}*LangGraph*{_ZWS}가" == result
+
+    def test_multiple_bold_with_korean(self) -> None:
+        result = markdown_to_slack_mrkdwn("**LangGraph**가 성숙하고, **CrewAI**가 적합")
+        assert f"*LangGraph*{_ZWS}가" in result
+        assert f"*CrewAI*{_ZWS}가" in result
+
+
 class TestHeadingConversion:
     def test_h1(self) -> None:
         assert markdown_to_slack_mrkdwn("# Title") == "*Title*"
@@ -28,49 +63,69 @@ class TestHeadingConversion:
     def test_h3(self) -> None:
         assert markdown_to_slack_mrkdwn("### Section") == "*Section*"
 
-    def test_h6(self) -> None:
-        assert markdown_to_slack_mrkdwn("###### Deep") == "*Deep*"
-
     def test_multiline_headings(self) -> None:
         text = "# First\nsome text\n## Second"
         result = markdown_to_slack_mrkdwn(text)
         assert result == "*First*\nsome text\n*Second*"
 
+    def test_heading_with_bold(self) -> None:
+        result = markdown_to_slack_mrkdwn("# **Important** Update")
+        assert "Important" in result
+        assert "Update" in result
+        assert "***" not in result
+
 
 class TestLinkConversion:
     def test_basic_link(self) -> None:
-        result = markdown_to_slack_mrkdwn("[Google](https://google.com)")
-        assert result == "<https://google.com|Google>"
+        assert markdown_to_slack_mrkdwn("[Google](https://google.com)") == "<https://google.com|Google>"
 
     def test_link_in_sentence(self) -> None:
         result = markdown_to_slack_mrkdwn("Visit [docs](https://docs.example.com) for info")
         assert result == "Visit <https://docs.example.com|docs> for info"
 
-    def test_multiple_links(self) -> None:
-        text = "[a](https://a.com) and [b](https://b.com)"
-        result = markdown_to_slack_mrkdwn(text)
-        assert result == "<https://a.com|a> and <https://b.com|b>"
 
-
-class TestTableWrapping:
-    def test_simple_table(self) -> None:
+class TestTableToSections:
+    def test_two_column_to_bullets(self) -> None:
         text = "| Name | Score |\n| --- | --- |\n| Alice | 90 |"
         result = markdown_to_slack_mrkdwn(text)
-        assert result == "```\n| Name | Score |\n| Alice | 90 |\n```"
+        assert "• *Alice*: 90" in result
+        assert "```" not in result
 
-    def test_table_separator_stripped(self) -> None:
-        text = "| H1 | H2 |\n| --- | --- |\n| v1 | v2 |"
+    def test_comparison_to_vertical(self) -> None:
+        text = "| 항목 | LangGraph | CrewAI |\n| --- | --- | --- |\n| 개발사 | LangChain | CrewAI Inc. |"
         result = markdown_to_slack_mrkdwn(text)
-        assert "| --- |" not in result
+        assert "*LangGraph*" in result
+        assert "*CrewAI*" in result
+        assert "개발사: LangChain" in result
+        assert "|" not in result
+
+    def test_bold_stripped_in_cells(self) -> None:
+        text = "| 항목 | **LG** | **CR** |\n| --- | --- | --- |\n| **특징** | a | b |"
+        result = markdown_to_slack_mrkdwn(text)
+        assert "**" not in result
+
+    def test_dash_values_omitted(self) -> None:
+        text = "| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | - |"
+        result = markdown_to_slack_mrkdwn(text)
+        assert "점수: 90" in result
 
     def test_table_surrounded_by_text(self) -> None:
         text = "Before\n| A | B |\n| - | - |\n| 1 | 2 |\nAfter"
         result = markdown_to_slack_mrkdwn(text)
-        lines = result.split("\n")
-        assert lines[0] == "Before"
-        assert lines[1] == "```"
-        assert lines[-2] == "```"
-        assert lines[-1] == "After"
+        assert result.startswith("Before")
+        assert result.rstrip().endswith("After")
+
+
+class TestHorizontalRule:
+    def test_triple_dash(self) -> None:
+        result = markdown_to_slack_mrkdwn("Before\n---\nAfter")
+        assert "---" not in result
+        assert "Before" in result and "After" in result
+
+
+class TestStrikethrough:
+    def test_basic(self) -> None:
+        assert markdown_to_slack_mrkdwn("~~removed~~") == "~removed~"
 
 
 class TestMixedContent:
@@ -81,45 +136,35 @@ class TestMixedContent:
         assert "*Status*" in result
         assert "<https://x.com|link>" in result
 
-    def test_bold_in_heading(self) -> None:
-        # Heading conversion happens first, then bold
-        text = "# **Important** Update"
+    def test_realistic_response(self) -> None:
+        text = "## 비교\n\n| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | 80 |\n\n**A**가 높다."
         result = markdown_to_slack_mrkdwn(text)
-        # After heading: ***Important** Update* → then bold: **Important* Update*
-        # The heading wraps entire line, bold converts inside
-        assert "Important" in result
-        assert "Update" in result
+        assert "**" not in result
+        assert "##" not in result
+        assert "|" not in result
+        assert f"*A*{_ZWS}가" in result
 
 
 class TestNoOp:
     def test_plain_text(self) -> None:
-        text = "Hello, world!"
-        assert markdown_to_slack_mrkdwn(text) == text
+        assert markdown_to_slack_mrkdwn("Hello!") == "Hello!"
 
     def test_empty_string(self) -> None:
         assert markdown_to_slack_mrkdwn("") == ""
 
-    def test_already_slack_format(self) -> None:
-        text = "*bold* and <https://x.com|link>"
-        result = markdown_to_slack_mrkdwn(text)
-        # Single asterisks should pass through unchanged
-        assert "*bold*" in result
-
 
 class TestCodeBlockPreserved:
     def test_inline_code(self) -> None:
-        text = "Use `pip install geode` to install"
-        assert markdown_to_slack_mrkdwn(text) == text
+        assert markdown_to_slack_mrkdwn("Use `pip install geode`") == "Use `pip install geode`"
 
-    def test_fenced_code_block(self) -> None:
-        text = "```python\nprint('hello')\n```"
-        result = markdown_to_slack_mrkdwn(text)
-        assert "print('hello')" in result
+    def test_fenced_code(self) -> None:
+        assert "print('hello')" in markdown_to_slack_mrkdwn("```python\nprint('hello')\n```")
 
-    def test_heading_hash_inside_code_not_converted(self) -> None:
-        # Fenced code blocks: the ``` lines don't start with |, so they're not tables
-        # The inner content doesn't start with #, so heading regex won't match
-        text = "```\nsome code\n```"
-        result = markdown_to_slack_mrkdwn(text)
-        assert "```" in result
-        assert "some code" in result
+    def test_bold_inside_code_preserved(self) -> None:
+        assert "**not bold**" in markdown_to_slack_mrkdwn("```\n**not bold**\n```")
+
+    def test_heading_inside_code_preserved(self) -> None:
+        assert "# not heading" in markdown_to_slack_mrkdwn("```\n# not heading\n```")
+
+    def test_inline_kwargs_preserved(self) -> None:
+        assert "`**kwargs`" in markdown_to_slack_mrkdwn("Use `**kwargs` in function")

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -77,7 +77,10 @@ class TestHeadingConversion:
 
 class TestLinkConversion:
     def test_basic_link(self) -> None:
-        assert markdown_to_slack_mrkdwn("[Google](https://google.com)") == "<https://google.com|Google>"
+        assert (
+            markdown_to_slack_mrkdwn("[Google](https://google.com)")
+            == "<https://google.com|Google>"
+        )
 
     def test_link_in_sentence(self) -> None:
         result = markdown_to_slack_mrkdwn("Visit [docs](https://docs.example.com) for info")
@@ -137,7 +140,9 @@ class TestMixedContent:
         assert "<https://x.com|link>" in result
 
     def test_realistic_response(self) -> None:
-        text = "## 비교\n\n| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | 80 |\n\n**A**가 높다."
+        text = (
+            "## 비교\n\n| 항목 | A | B |\n| --- | --- | --- |\n| 점수 | 90 | 80 |\n\n**A**가 높다."
+        )
         result = markdown_to_slack_mrkdwn(text)
         assert "**" not in result
         assert "##" not in result


### PR DESCRIPTION
## Summary
- REPL 초기화 `bootstrap_geode()` 통합 (REPL/serve 동일 경로)
- Slack mrkdwn v2: ZWS 경계 보정, 테이블→세로 섹션, strikethrough, 코드블록 보호
- CI 가드레일 수정: import 정렬 + flaky 테스트 격리

## Test plan
- [x] CI 5/5 통과 (PR #402)
- [x] 3051 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)