### PR TITLE
fix: 중복 load_career 제거 + context 테스트 갱신

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -1580,7 +1580,6 @@ def cmd_context(args: str) -> None:
     console.print()
 
 
-
 def resolve_action(cmd: str) -> str | None:
     """Resolve a slash command to its action name. Returns None if unknown."""
     return COMMAND_MAP.get(cmd)

--- a/core/memory/user_profile.py
+++ b/core/memory/user_profile.py
@@ -362,23 +362,6 @@ Write your bio, background, or any context you want GEODE to remember here.
         log.info("Created user profile structure at %s", self._global_dir)
         return True
 
-    def load_career(self) -> dict[str, Any]:
-        """Load career identity from ~/.geode/identity/career.toml.
-
-        Returns parsed TOML dict, or empty dict if not found / parse error.
-        """
-        import tomllib
-
-        career_path = Path.home() / ".geode" / "identity" / "career.toml"
-        if not career_path.exists():
-            return {}
-        try:
-            with open(career_path, "rb") as f:
-                return tomllib.load(f)
-        except Exception:
-            log.debug("Failed to load career.toml", exc_info=True)
-            return {}
-
     def get_career_summary(self) -> str:
         """Build a 1-line career summary for system prompt injection.
 

--- a/tests/test_context_command.py
+++ b/tests/test_context_command.py
@@ -2,13 +2,10 @@
 
 Covers:
 - COMMAND_MAP registration
-- cmd_context with assembler (full + summary modes)
-- cmd_context without assembler (graceful degradation)
+- cmd_context default / career / profile modes
 """
 
 from __future__ import annotations
-
-from unittest.mock import MagicMock
 
 from core.cli.commands import COMMAND_MAP, cmd_context
 
@@ -22,43 +19,18 @@ class TestContextCommandMap:
 
 
 class TestCmdContext:
-    def test_no_assembler_graceful(self, capsys) -> None:
-        """Should print message when no assembler is available."""
-        cmd_context("", context_assembler=None)
-        # No crash = pass (Rich output not easily captured by capsys)
+    def test_default_mode_no_crash(self) -> None:
+        """Default /context should not raise."""
+        cmd_context("")
 
-    def test_full_mode_with_mock_assembler(self) -> None:
-        """Should call assemble and display tiers."""
-        assembler = MagicMock()
-        assembler.assemble.return_value = {
-            "_soul_loaded": True,
-            "_soul": "Test mission",
-            "_user_profile_loaded": True,
-            "_user_profile_summary": "User: Tester",
-            "_org_loaded": False,
-            "_project_loaded": False,
-            "_session_loaded": False,
-            "_llm_summary": "Summary line",
-            "_assembled_at": 0,
-            "_session_id": "_inspect",
-            "_ip_name": "_inspect",
-        }
-        # Should not raise
-        cmd_context("", context_assembler=assembler)
-        assembler.assemble.assert_called_once_with("_inspect", "_inspect")
+    def test_career_mode_no_crash(self) -> None:
+        """/context career should not raise."""
+        cmd_context("career")
 
-    def test_summary_mode_with_mock_assembler(self) -> None:
-        """Should only show LLM summary."""
-        assembler = MagicMock()
-        assembler.assemble.return_value = {
-            "_llm_summary": "Compact summary",
-            "_assembled_at": 0,
-        }
-        cmd_context("summary", context_assembler=assembler)
-        assembler.assemble.assert_called_once()
+    def test_profile_mode_no_crash(self) -> None:
+        """/context profile should not raise."""
+        cmd_context("profile")
 
-    def test_summary_mode_empty(self) -> None:
-        """Should show 'no summary' when LLM summary is empty."""
-        assembler = MagicMock()
-        assembler.assemble.return_value = {"_llm_summary": ""}
-        cmd_context("summary", context_assembler=assembler)
+    def test_unknown_subcommand_shows_tiers(self) -> None:
+        """/context xyz falls through to default tier display."""
+        cmd_context("xyz")

--- a/tests/test_context_hub.py
+++ b/tests/test_context_hub.py
@@ -18,27 +18,23 @@ class TestLoadCareer:
         from core.memory.user_profile import FileBasedUserProfile
 
         profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
-        # Patch Path.home to return tmp_path so career.toml won't exist
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            result = profile.load_career()
+        result = profile.load_career()
         assert result == {}
 
     def test_load_career_valid_toml(self, tmp_path: Path) -> None:
         from core.memory.user_profile import FileBasedUserProfile
 
-        identity_dir = tmp_path / ".geode" / "identity"
-        identity_dir.mkdir(parents=True)
-        career_toml = identity_dir / "career.toml"
-        career_toml.write_text(
+        gdir = tmp_path / "profile"
+        gdir.mkdir(parents=True)
+        (gdir / "career.toml").write_text(
             '[identity]\ntitle = "AI Engineer"\nexperience = "5y"\n'
             'skills = ["Python", "LangGraph"]\n\n'
             '[goals]\nseeking = "remote AI roles"\n',
             encoding="utf-8",
         )
 
-        profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            result = profile.load_career()
+        profile = FileBasedUserProfile(global_dir=gdir)
+        result = profile.load_career()
 
         assert result["identity"]["title"] == "AI Engineer"
         assert result["identity"]["experience"] == "5y"
@@ -48,31 +44,28 @@ class TestLoadCareer:
     def test_load_career_invalid_toml(self, tmp_path: Path) -> None:
         from core.memory.user_profile import FileBasedUserProfile
 
-        identity_dir = tmp_path / ".geode" / "identity"
-        identity_dir.mkdir(parents=True)
-        career_toml = identity_dir / "career.toml"
-        career_toml.write_text("not valid toml {{{}}", encoding="utf-8")
+        gdir = tmp_path / "profile"
+        gdir.mkdir(parents=True)
+        (gdir / "career.toml").write_text("not valid toml {{{}}", encoding="utf-8")
 
-        profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            result = profile.load_career()
+        profile = FileBasedUserProfile(global_dir=gdir)
+        result = profile.load_career()
         assert result == {}
 
     def test_get_career_summary(self, tmp_path: Path) -> None:
         from core.memory.user_profile import FileBasedUserProfile
 
-        identity_dir = tmp_path / ".geode" / "identity"
-        identity_dir.mkdir(parents=True)
-        (identity_dir / "career.toml").write_text(
+        gdir = tmp_path / "profile"
+        gdir.mkdir(parents=True)
+        (gdir / "career.toml").write_text(
             '[identity]\ntitle = "Senior AI Engineer"\nexperience = "5y"\n'
             'skills = ["Python", "LangGraph", "MLOps"]\n\n'
             '[goals]\nseeking = "remote AI roles"\n',
             encoding="utf-8",
         )
 
-        profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            summary = profile.get_career_summary()
+        profile = FileBasedUserProfile(global_dir=gdir)
+        summary = profile.get_career_summary()
 
         assert "Senior AI Engineer" in summary
         assert "5y" in summary
@@ -83,8 +76,7 @@ class TestLoadCareer:
         from core.memory.user_profile import FileBasedUserProfile
 
         profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            summary = profile.get_career_summary()
+        summary = profile.get_career_summary()
         assert summary == ""
 
 
@@ -99,9 +91,9 @@ class TestCareerSystemPrompt:
     def test_build_career_context_with_data(self, tmp_path: Path) -> None:
         from core.cli.system_prompt import _build_career_context
 
-        identity_dir = tmp_path / ".geode" / "identity"
-        identity_dir.mkdir(parents=True)
-        (identity_dir / "career.toml").write_text(
+        profile_dir = tmp_path / ".geode" / "user_profile"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "career.toml").write_text(
             '[identity]\ntitle = "ML Engineer"\nexperience = "3y"\n'
             'skills = ["Python"]\n\n[goals]\nseeking = "startup"\n',
             encoding="utf-8",
@@ -337,23 +329,18 @@ class TestContextAssemblerCareer:
         from core.memory.context import ContextAssembler
         from core.memory.user_profile import FileBasedUserProfile
 
-        identity_dir = tmp_path / ".geode" / "identity"
-        identity_dir.mkdir(parents=True)
-        (identity_dir / "career.toml").write_text(
+        gdir = tmp_path / "profile"
+        gdir.mkdir(parents=True)
+        (gdir / "career.toml").write_text(
             '[identity]\ntitle = "AI Engineer"\nskills = ["Python"]\n'
             '[goals]\nseeking = "startup"\n',
             encoding="utf-8",
         )
+        (gdir / "profile.md").write_text("---\nrole: dev\n---\n", encoding="utf-8")
 
-        profile = FileBasedUserProfile(global_dir=tmp_path / "profile")
-        # Create minimal profile so exists() returns True
-        (tmp_path / "profile").mkdir(parents=True, exist_ok=True)
-        (tmp_path / "profile" / "profile.md").write_text("---\nrole: dev\n---\n", encoding="utf-8")
-
+        profile = FileBasedUserProfile(global_dir=gdir)
         assembler = ContextAssembler(user_profile=profile)
-
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            ctx = assembler.assemble("test-session", "test-ip")
+        ctx = assembler.assemble("test-session", "test-ip")
 
         assert "_career_summary" in ctx
         assert "AI Engineer" in ctx["_career_summary"]


### PR DESCRIPTION
## Summary

- `user_profile.py`: 중복 정의된 `load_career()` 제거 (PR #337 merge 시 auto-merge로 중복 발생)
- `test_context_command.py`: develop의 `cmd_context(args)` 시그니처에 맞게 테스트 갱신

## Why

PR #337 merge 후 CI 실패 — mypy `no-redef` + 10 test failures.

## Test plan

- [x] 57 tests passed (context_command + user_profile + atomic_io)
- [x] Lint: 0 errors
- [x] Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)