### PR TITLE
refactor: Phase 2-4 — import 마이그레이션 + proxy 제거 + CI 래칫

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,13 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: uv sync
       - run: uv run ruff check core/ tests/
       - run: uv run ruff format --check core/ tests/
+      - name: Legacy import ratchet
+        run: uv run python scripts/check_legacy_imports.py --base-ref origin/develop
 
   typecheck:
     name: Type Check

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -76,13 +76,13 @@ from core.cli.tool_executor import ToolExecutor
 from core.cli.tool_handlers import (
     _build_tool_handlers as _build_tool_handlers,
 )
+from core.cli.ui.console import console
+from core.cli.ui.status import GeodeStatus
 from core.config import settings
 from core.infrastructure.ports.hook_port import HookSystemPort
 from core.llm.commentary import (
     generate_commentary,
 )
-from core.cli.ui.console import console
-from core.cli.ui.status import GeodeStatus
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -81,8 +81,8 @@ from core.infrastructure.ports.hook_port import HookSystemPort
 from core.llm.commentary import (
     generate_commentary,
 )
-from core.ui.console import console
-from core.ui.status import GeodeStatus
+from core.cli.ui.console import console
+from core.cli.ui.status import GeodeStatus
 
 log = logging.getLogger(__name__)
 
@@ -226,7 +226,7 @@ def _set_last_result(result: dict[str, Any] | None) -> None:
 
 def _render_welcome_brand() -> None:
     """Render animated Claude Code-style branding with axolotl mascot."""
-    from core.ui.mascot import play_mascot_animation
+    from core.cli.ui.mascot import play_mascot_animation
 
     cwd = str(Path.cwd())
     play_mascot_animation(version=__version__, model=settings.model, cwd=cwd)
@@ -364,7 +364,7 @@ def _handle_command(
     action = resolve_action(cmd)
 
     if action == "quit":
-        from core.ui.agentic_ui import render_session_cost_summary
+        from core.cli.ui.agentic_ui import render_session_cost_summary
 
         render_session_cost_summary()
         console.print("  [muted]Goodbye.[/muted]\n")
@@ -470,7 +470,7 @@ def _handle_command(
         if readiness:
             mode = "Full LLM" if not readiness.force_dry_run else "Dry-Run Only"
             console.print(f"  Mode: [bold]{mode}[/bold]")
-        from core.fixtures import FIXTURE_MAP as _FM
+        from core.domains.game_ip.fixtures import FIXTURE_MAP as _FM
 
         console.print(f"  Fixtures: [bold]{len(_FM)} IPs[/bold]")
 
@@ -976,7 +976,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     agentic_ref[0] = agentic
 
     # Initialize session meter for status line
-    from core.ui.agentic_ui import init_session_meter
+    from core.cli.ui.agentic_ui import init_session_meter
 
     init_session_meter(model=agentic.model)
 
@@ -1012,7 +1012,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         try:
             user_input = _read_multiline_input("[header]>[/header] ")
         except (KeyboardInterrupt, EOFError):
-            from core.ui.agentic_ui import render_session_cost_summary
+            from core.cli.ui.agentic_ui import render_session_cost_summary
 
             agentic.mark_session_completed()
             render_session_cost_summary()
@@ -1024,7 +1024,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
         # Bare exit/quit → immediate shutdown (no LLM round-trip)
         if user_input.strip().lower() in ("exit", "quit", "q"):
-            from core.ui.agentic_ui import render_session_cost_summary
+            from core.cli.ui.agentic_ui import render_session_cost_summary
 
             agentic.mark_session_completed()
             render_session_cost_summary()
@@ -1109,7 +1109,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                 result = agentic.run(user_input)
                 _render_agentic_result(result)
                 # Claude Code-style status line after each result
-                from core.ui.agentic_ui import render_status_line
+                from core.cli.ui.agentic_ui import render_status_line
 
                 render_status_line()
             except KeyboardInterrupt:
@@ -1226,7 +1226,7 @@ def version() -> None:
 @app.command(name="list")
 def list_ips() -> None:
     """List available IP fixtures."""
-    from core.fixtures import FIXTURE_MAP as _FIXTURE_MAP
+    from core.domains.game_ip.fixtures import FIXTURE_MAP as _FIXTURE_MAP
 
     console.print("[header]Available IPs:[/header]")
     for name in _FIXTURE_MAP:

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -47,8 +47,8 @@ from core.infrastructure.ports.agentic_llm_port import UserCancelledError
 from core.llm.client import maybe_traceable
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.orchestration.hooks import HookEvent, HookSystem
-from core.ui.agentic_ui import OperationLogger
-from core.ui.status import TextSpinner
+from core.cli.ui.agentic_ui import OperationLogger
+from core.cli.ui.status import TextSpinner
 
 if TYPE_CHECKING:
     from core.tools.registry import ToolRegistry
@@ -315,7 +315,7 @@ class AgenticLoop:
         self.model = model
 
         # Sync SessionMeter so "Worked for" status line shows the correct model
-        from core.ui.agentic_ui import update_session_model
+        from core.cli.ui.agentic_ui import update_session_model
 
         update_session_model(model)
         log.info("AgenticLoop model updated: %s (provider=%s)", model, self._provider)
@@ -1065,7 +1065,7 @@ class AgenticLoop:
 
         Returns True if user approves, False if denied.
         """
-        from core.ui.console import console
+        from core.cli.ui.console import console
 
         items: list[tuple[str, dict[str, Any], float]] = []
         for block in blocks:
@@ -1232,7 +1232,7 @@ class AgenticLoop:
             return
         try:
             from core.llm.token_tracker import get_tracker
-            from core.ui.agentic_ui import render_tokens
+            from core.cli.ui.agentic_ui import render_tokens
 
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens

--- a/core/cli/agentic_loop.py
+++ b/core/cli/agentic_loop.py
@@ -34,6 +34,8 @@ from core.cli.tool_executor import (
     WRITE_TOOLS,
     ToolExecutor,
 )
+from core.cli.ui.agentic_ui import OperationLogger
+from core.cli.ui.status import TextSpinner
 from core.config import (
     ANTHROPIC_PRIMARY,
     _resolve_provider,
@@ -47,8 +49,6 @@ from core.infrastructure.ports.agentic_llm_port import UserCancelledError
 from core.llm.client import maybe_traceable
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.orchestration.hooks import HookEvent, HookSystem
-from core.cli.ui.agentic_ui import OperationLogger
-from core.cli.ui.status import TextSpinner
 
 if TYPE_CHECKING:
     from core.tools.registry import ToolRegistry
@@ -1231,8 +1231,8 @@ class AgenticLoop:
         if not response.usage:
             return
         try:
-            from core.llm.token_tracker import get_tracker
             from core.cli.ui.agentic_ui import render_tokens
+            from core.llm.token_tracker import get_tracker
 
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens

--- a/core/cli/batch.py
+++ b/core/cli/batch.py
@@ -12,7 +12,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from core.config import settings
-from core.fixtures import FIXTURE_MAP
+from core.domains.game_ip.fixtures import FIXTURE_MAP
 
 log = logging.getLogger(__name__)
 console = Console()
@@ -45,7 +45,7 @@ def select_ips(
     candidates = sorted(FIXTURE_MAP.keys())
 
     if genre:
-        from core.fixtures import load_fixture
+        from core.domains.game_ip.fixtures import load_fixture
 
         filtered: list[str] = []
         for ip_key in candidates:

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -27,7 +27,7 @@ from core.config import (
     GLM_PRIMARY,
     OPENAI_PRIMARY,
 )
-from core.ui.console import console
+from core.cli.ui.console import console
 
 # ---------------------------------------------------------------------------
 # Model Registry (OpenClaw Auth Profile Rotation pattern)
@@ -134,7 +134,7 @@ def show_help() -> None:
 
 def cmd_list() -> None:
     """List available IP fixtures."""
-    from core.fixtures import FIXTURE_MAP as _FIXTURE_MAP
+    from core.domains.game_ip.fixtures import FIXTURE_MAP as _FIXTURE_MAP
 
     console.print()
     console.print("  [header]Available IPs[/header]")
@@ -543,7 +543,7 @@ def cmd_generate(args: str) -> None:
     /generate 10      → generate 10 IPs
     /generate 3 mecha → generate 3 IPs of specific genre
     """
-    from core.fixtures.generator import GENRE_PARAMS, generate_batch
+    from core.domains.game_ip.fixtures.generator import GENRE_PARAMS, generate_batch
 
     parts = args.strip().split() if args.strip() else []
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -20,6 +20,7 @@ from core.auth.profiles import ProfileStore
 from core.cli._helpers import is_glm_key as _is_glm_key
 from core.cli._helpers import mask_key as _mask_key
 from core.cli._helpers import upsert_env as _upsert_env
+from core.cli.ui.console import console
 from core.config import (
     ANTHROPIC_BUDGET,
     ANTHROPIC_PRIMARY,
@@ -27,7 +28,6 @@ from core.config import (
     GLM_PRIMARY,
     OPENAI_PRIMARY,
 )
-from core.cli.ui.console import console
 
 # ---------------------------------------------------------------------------
 # Model Registry (OpenClaw Auth Profile Rotation pattern)

--- a/core/cli/ip_names.py
+++ b/core/cli/ip_names.py
@@ -17,7 +17,7 @@ def _load_ip_names() -> dict[str, str]:
     Returns a mapping of lowercased canonical name -> fixture key.
     Example: {"ghost in the shell": "ghost in shell", "berserk": "berserk"}
     """
-    from core.fixtures import FIXTURE_MAP, load_fixture
+    from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
     name_to_key: dict[str, str] = {}
     for fk in FIXTURE_MAP:

--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -15,8 +15,8 @@ from typing import Any
 from core.config import settings
 from core.runtime import GeodeRuntime
 from core.state import AnalysisResult, EvaluatorResult, GeodeState
-from core.ui.console import console
-from core.ui.panels import (
+from core.cli.ui.console import console
+from core.cli.ui.panels import (
     analyst_panel,
     evaluator_panel,
     gather_panel,
@@ -478,7 +478,7 @@ def _resolve_ip_name(ip_name: str) -> str | None:
     4. Substring: input is contained in fixture key
     """
     from core.cli.ip_names import get_ip_name_map
-    from core.fixtures import FIXTURE_MAP
+    from core.domains.game_ip.fixtures import FIXTURE_MAP
 
     key = ip_name.lower().strip()
 
@@ -520,7 +520,7 @@ def _run_analysis(
 ) -> dict[str, Any] | None:
     """Core analysis logic shared by interactive and CLI modes."""
     from core.cli import _hooks_ctx, _set_last_result
-    from core.fixtures import FIXTURE_MAP
+    from core.domains.game_ip.fixtures import FIXTURE_MAP
 
     resolved = _resolve_ip_name(ip_name)
     if resolved is None:

--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -12,9 +12,6 @@ import re as _re
 import shutil
 from typing import Any
 
-from core.config import settings
-from core.runtime import GeodeRuntime
-from core.state import AnalysisResult, EvaluatorResult, GeodeState
 from core.cli.ui.console import console
 from core.cli.ui.panels import (
     analyst_panel,
@@ -25,6 +22,9 @@ from core.cli.ui.panels import (
     score_panel,
     verify_panel,
 )
+from core.config import settings
+from core.runtime import GeodeRuntime
+from core.state import AnalysisResult, EvaluatorResult, GeodeState
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/report_renderer.py
+++ b/core/cli/report_renderer.py
@@ -13,10 +13,10 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from core.config import settings
-from core.extensibility.reports import ReportFormat, ReportGenerator, ReportTemplate
 from core.cli.ui.console import console
 from core.cli.ui.status import GeodeStatus
+from core.config import settings
+from core.extensibility.reports import ReportFormat, ReportGenerator, ReportTemplate
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/report_renderer.py
+++ b/core/cli/report_renderer.py
@@ -15,8 +15,8 @@ from typing import Any
 
 from core.config import settings
 from core.extensibility.reports import ReportFormat, ReportGenerator, ReportTemplate
-from core.ui.console import console
-from core.ui.status import GeodeStatus
+from core.cli.ui.console import console
+from core.cli.ui.status import GeodeStatus
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/search.py
+++ b/core/cli/search.py
@@ -10,7 +10,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from core.fixtures import FIXTURE_MAP, load_fixture
+from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
 
 @dataclass

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -19,7 +19,7 @@ from core.cli._helpers import mask_key as _mask_key
 from core.cli._helpers import upsert_env as _upsert_env
 from core.config import settings
 from core.memory.project import ProjectMemory
-from core.ui.console import console
+from core.cli.ui.console import console
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -17,9 +17,9 @@ from pathlib import Path
 
 from core.cli._helpers import mask_key as _mask_key
 from core.cli._helpers import upsert_env as _upsert_env
+from core.cli.ui.console import console
 from core.config import settings
 from core.memory.project import ProjectMemory
-from core.cli.ui.console import console
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/system_prompt.py
+++ b/core/cli/system_prompt.py
@@ -42,7 +42,7 @@ _NOTABLE_IPS = {
 
 def build_system_prompt(model: str = "") -> str:
     """Build system prompt with model card, IP examples, and memory context."""
-    from core.fixtures import FIXTURE_MAP, load_fixture
+    from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
     name_map = get_ip_name_map()
     ip_count = len(name_map)

--- a/core/cli/tool_executor.py
+++ b/core/cli/tool_executor.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from core.cli.sub_agent import SubAgentManager
 
 from core.cli.bash_tool import BashTool
-from core.ui.console import console
+from core.cli.ui.console import console
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -22,7 +22,7 @@ import logging
 from typing import Any
 
 from core.config import settings
-from core.ui.console import console
+from core.cli.ui.console import console
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def _build_analysis_handlers(
 
     def handle_list_ips(**_kwargs: Any) -> dict[str, Any]:
         from core.cli.commands import cmd_list
-        from core.fixtures import FIXTURE_MAP as _FM
+        from core.domains.game_ip.fixtures import FIXTURE_MAP as _FM
 
         cmd_list()
         names = [n.title() for n in _FM]
@@ -657,7 +657,7 @@ def _build_system_handlers(
         return {"status": "ok", "action": "help", "commands": commands}
 
     def handle_check_status(**_kwargs: Any) -> dict[str, Any]:
-        from core.fixtures import FIXTURE_MAP as _FM
+        from core.domains.game_ip.fixtures import FIXTURE_MAP as _FM
         from core.infrastructure.adapters.mcp.registry import MCPRegistry
 
         ant_ok = bool(settings.anthropic_api_key)

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from core.config import settings
 from core.cli.ui.console import console
+from core.config import settings
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -5,7 +5,7 @@ in a clean, compact format inspired by Claude Code's output style.
 
 Usage::
 
-    from core.ui.agentic_ui import render_tool_call, render_tool_result, render_tokens
+    from core.cli.ui.agentic_ui import render_tool_call, render_tool_result, render_tokens
 
     render_tool_call("analyze_ip", {"ip_name": "Berserk"})
     # ▸ analyze_ip(ip_name="Berserk")
@@ -24,7 +24,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from core.ui.console import console
+from core.cli.ui.console import console
 
 # ───────────────────────────────────────────────────────────────────────────
 # SessionMeter — session-level timing for status line

--- a/core/cli/ui/mascot.py
+++ b/core/cli/ui/mascot.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 
 from rich.text import Text
 
-from core.ui.console import console
+from core.cli.ui.console import console
 
 _G = "mascot.gills"
 _B = "mascot.body"

--- a/core/cli/ui/panels.py
+++ b/core/cli/ui/panels.py
@@ -10,8 +10,8 @@ from rich.text import Text
 from rich.tree import Tree
 
 from core import __version__
-from core.state import AnalysisResult, EvaluatorResult, PSMResult, SynthesisResult
 from core.cli.ui.console import console
+from core.state import AnalysisResult, EvaluatorResult, PSMResult, SynthesisResult
 
 
 def header_panel(ip_name: str, pipeline_mode: str, model: str) -> None:

--- a/core/cli/ui/panels.py
+++ b/core/cli/ui/panels.py
@@ -11,7 +11,7 @@ from rich.tree import Tree
 
 from core import __version__
 from core.state import AnalysisResult, EvaluatorResult, PSMResult, SynthesisResult
-from core.ui.console import console
+from core.cli.ui.console import console
 
 
 def header_panel(ip_name: str, pipeline_mode: str, model: str) -> None:

--- a/core/cli/ui/status.py
+++ b/core/cli/ui/status.py
@@ -19,7 +19,7 @@ import time
 from dataclasses import dataclass
 
 from core.llm.client import LLMUsageAccumulator, get_usage_accumulator
-from core.ui.console import console
+from core.cli.ui.console import console
 
 
 class TextSpinner:

--- a/core/cli/ui/status.py
+++ b/core/cli/ui/status.py
@@ -18,8 +18,8 @@ import threading
 import time
 from dataclasses import dataclass
 
-from core.llm.client import LLMUsageAccumulator, get_usage_accumulator
 from core.cli.ui.console import console
+from core.llm.client import LLMUsageAccumulator, get_usage_accumulator
 
 
 class TextSpinner:

--- a/core/domains/game_ip/nodes/router.py
+++ b/core/domains/game_ip/nodes/router.py
@@ -12,7 +12,7 @@ import uuid
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
-from core.fixtures import load_fixture
+from core.domains.game_ip.fixtures import load_fixture
 from core.state import GeodeState
 
 if TYPE_CHECKING:

--- a/core/domains/game_ip/nodes/scoring.py
+++ b/core/domains/game_ip/nodes/scoring.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import numpy as np
 
-from core.fixtures import load_fixture
+from core.domains.game_ip.fixtures import load_fixture
 from core.infrastructure.ports.domain_port import get_domain_or_none
 from core.infrastructure.ports.tool_port import get_tool_executor
 from core.state import (

--- a/core/domains/game_ip/nodes/signals.py
+++ b/core/domains/game_ip/nodes/signals.py
@@ -19,7 +19,7 @@ import logging
 from contextvars import ContextVar
 from typing import Any
 
-from core.fixtures import load_fixture
+from core.domains.game_ip.fixtures import load_fixture
 from core.infrastructure.ports.signal_port import SignalEnrichmentPort
 from core.state import GeodeState
 

--- a/core/fixtures/__init__.py
+++ b/core/fixtures/__init__.py
@@ -1,14 +1,8 @@
-"""DEPRECATED: Fixtures moved to core.domains.game_ip.fixtures."""
+"""Fixture utilities — re-exported from domains.game_ip.fixtures for backward compat."""
 
 from core.domains.game_ip.fixtures import (
     FIXTURE_MAP as FIXTURE_MAP,
-)
-from core.domains.game_ip.fixtures import (
     FIXTURES_DIR as FIXTURES_DIR,
-)
-from core.domains.game_ip.fixtures import (
     list_fixtures as list_fixtures,
-)
-from core.domains.game_ip.fixtures import (
     load_fixture as load_fixture,
 )

--- a/core/fixtures/__init__.py
+++ b/core/fixtures/__init__.py
@@ -2,7 +2,13 @@
 
 from core.domains.game_ip.fixtures import (
     FIXTURE_MAP as FIXTURE_MAP,
+)
+from core.domains.game_ip.fixtures import (
     FIXTURES_DIR as FIXTURES_DIR,
+)
+from core.domains.game_ip.fixtures import (
     list_fixtures as list_fixtures,
+)
+from core.domains.game_ip.fixtures import (
     load_fixture as load_fixture,
 )

--- a/core/graph.py
+++ b/core/graph.py
@@ -47,12 +47,12 @@ from langgraph.graph.state import CompiledStateGraph
 
 from core.config import settings
 from core.infrastructure.ports.hook_port import HookSystemPort
-from core.nodes.analysts import analyst_node, make_analyst_sends
-from core.nodes.evaluators import evaluator_node, make_evaluator_sends
-from core.nodes.router import route_after_router, router_node
-from core.nodes.scoring import scoring_node
-from core.nodes.signals import signals_node
-from core.nodes.synthesizer import synthesizer_node
+from core.domains.game_ip.nodes.analysts import analyst_node, make_analyst_sends
+from core.domains.game_ip.nodes.evaluators import evaluator_node, make_evaluator_sends
+from core.domains.game_ip.nodes.router import route_after_router, router_node
+from core.domains.game_ip.nodes.scoring import scoring_node
+from core.domains.game_ip.nodes.signals import signals_node
+from core.domains.game_ip.nodes.synthesizer import synthesizer_node
 from core.orchestration.bootstrap import BootstrapManager
 from core.orchestration.hooks import HookEvent
 from core.state import (

--- a/core/graph.py
+++ b/core/graph.py
@@ -46,13 +46,13 @@ from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
 from core.config import settings
-from core.infrastructure.ports.hook_port import HookSystemPort
 from core.domains.game_ip.nodes.analysts import analyst_node, make_analyst_sends
 from core.domains.game_ip.nodes.evaluators import evaluator_node, make_evaluator_sends
 from core.domains.game_ip.nodes.router import route_after_router, router_node
 from core.domains.game_ip.nodes.scoring import scoring_node
 from core.domains.game_ip.nodes.signals import signals_node
 from core.domains.game_ip.nodes.synthesizer import synthesizer_node
+from core.infrastructure.ports.hook_port import HookSystemPort
 from core.orchestration.bootstrap import BootstrapManager
 from core.orchestration.hooks import HookEvent
 from core.state import (

--- a/core/infrastructure/adapters/signal_adapter.py
+++ b/core/infrastructure/adapters/signal_adapter.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from core.fixtures import load_fixture
+from core.domains.game_ip.fixtures import load_fixture
 
 log = logging.getLogger(__name__)
 

--- a/core/mcp_server.py
+++ b/core/mcp_server.py
@@ -33,7 +33,7 @@ def create_mcp_server() -> Any:
     @mcp.tool(description=_TOOL_DESCRIPTIONS["analyze_ip"])  # type: ignore[untyped-decorator]
     def analyze_ip(ip_name: str, dry_run: bool = False) -> dict[str, Any]:
         """Run GEODE analysis pipeline on an IP."""
-        from core.fixtures import FIXTURE_MAP
+        from core.domains.game_ip.fixtures import FIXTURE_MAP
 
         key = ip_name.lower().strip()
         if key not in FIXTURE_MAP:
@@ -102,7 +102,7 @@ def create_mcp_server() -> Any:
     @mcp.tool(description=_TOOL_DESCRIPTIONS["get_ip_signals"])  # type: ignore[untyped-decorator]
     def get_ip_signals(ip_name: str) -> dict[str, Any]:
         """Get community signals for an IP."""
-        from core.fixtures import FIXTURE_MAP, load_fixture
+        from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
         key = ip_name.lower().strip()
         if key not in FIXTURE_MAP:
@@ -118,7 +118,7 @@ def create_mcp_server() -> Any:
     @mcp.tool(description=_TOOL_DESCRIPTIONS["list_fixtures"])  # type: ignore[untyped-decorator]
     def list_fixtures() -> dict[str, Any]:
         """List all available IP fixtures."""
-        from core.fixtures import FIXTURE_MAP
+        from core.domains.game_ip.fixtures import FIXTURE_MAP
 
         return {
             "count": len(FIXTURE_MAP),
@@ -155,7 +155,7 @@ def create_mcp_server() -> Any:
     @mcp.resource("geode://fixtures")  # type: ignore[untyped-decorator]
     def fixtures_resource() -> str:
         """List all available IP fixtures."""
-        from core.fixtures import FIXTURE_MAP
+        from core.domains.game_ip.fixtures import FIXTURE_MAP
 
         return json.dumps({"count": len(FIXTURE_MAP), "ips": sorted(FIXTURE_MAP.keys())})
 

--- a/core/nodes/__init__.py
+++ b/core/nodes/__init__.py
@@ -1,3 +1,0 @@
-"""DEPRECATED: Pipeline nodes moved to core.domains.game_ip.nodes."""
-
-from core.domains.game_ip.nodes import *  # noqa: F403

--- a/core/nodes/analysts.py
+++ b/core/nodes/analysts.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.domains.game_ip.nodes.analysts instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.domains.game_ip.nodes.analysts")

--- a/core/nodes/analysts.pyi
+++ b/core/nodes/analysts.pyi
@@ -1,1 +1,0 @@
-from core.domains.game_ip.nodes.analysts import *  # noqa: F403

--- a/core/nodes/evaluators.py
+++ b/core/nodes/evaluators.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.domains.game_ip.nodes.evaluators instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.domains.game_ip.nodes.evaluators")

--- a/core/nodes/evaluators.pyi
+++ b/core/nodes/evaluators.pyi
@@ -1,1 +1,0 @@
-from core.domains.game_ip.nodes.evaluators import *  # noqa: F403

--- a/core/nodes/router.py
+++ b/core/nodes/router.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.domains.game_ip.nodes.router instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.domains.game_ip.nodes.router")

--- a/core/nodes/router.pyi
+++ b/core/nodes/router.pyi
@@ -1,1 +1,0 @@
-from core.domains.game_ip.nodes.router import *  # noqa: F403

--- a/core/nodes/scoring.py
+++ b/core/nodes/scoring.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.domains.game_ip.nodes.scoring instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.domains.game_ip.nodes.scoring")

--- a/core/nodes/scoring.pyi
+++ b/core/nodes/scoring.pyi
@@ -1,1 +1,0 @@
-from core.domains.game_ip.nodes.scoring import *  # noqa: F403

--- a/core/nodes/signals.py
+++ b/core/nodes/signals.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.domains.game_ip.nodes.signals instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.domains.game_ip.nodes.signals")

--- a/core/nodes/signals.pyi
+++ b/core/nodes/signals.pyi
@@ -1,1 +1,0 @@
-from core.domains.game_ip.nodes.signals import *  # noqa: F403

--- a/core/nodes/synthesizer.py
+++ b/core/nodes/synthesizer.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.domains.game_ip.nodes.synthesizer instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.domains.game_ip.nodes.synthesizer")

--- a/core/nodes/synthesizer.pyi
+++ b/core/nodes/synthesizer.pyi
@@ -1,1 +1,0 @@
-from core.domains.game_ip.nodes.synthesizer import *  # noqa: F403

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -857,6 +857,7 @@ class GeodeRuntime:
         are configured or available, the adapter will report is_available()=False
         and signals_node falls back to fixtures.
         """
+        from core.domains.game_ip.nodes.signals import set_signal_adapter
         from core.infrastructure.adapters.mcp.brave_adapter import (
             BraveSearchAdapter,
             BraveSignalAdapter,
@@ -864,7 +865,6 @@ class GeodeRuntime:
         from core.infrastructure.adapters.mcp.composite_signal import CompositeSignalAdapter
         from core.infrastructure.adapters.mcp.manager import get_mcp_manager
         from core.infrastructure.adapters.mcp.steam_adapter import SteamMCPSignalAdapter
-        from core.domains.game_ip.nodes.signals import set_signal_adapter
 
         manager = get_mcp_manager()
         server_count = manager.load_config()

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -552,7 +552,7 @@ class GeodeRuntime:
         )
 
         # Wire ContextAssembler into router node (L2 → L3 bridge)
-        from core.nodes.router import set_context_assembler
+        from core.domains.game_ip.nodes.router import set_context_assembler
 
         set_context_assembler(context_assembler)
 
@@ -864,7 +864,7 @@ class GeodeRuntime:
         from core.infrastructure.adapters.mcp.composite_signal import CompositeSignalAdapter
         from core.infrastructure.adapters.mcp.manager import get_mcp_manager
         from core.infrastructure.adapters.mcp.steam_adapter import SteamMCPSignalAdapter
-        from core.nodes.signals import set_signal_adapter
+        from core.domains.game_ip.nodes.signals import set_signal_adapter
 
         manager = get_mcp_manager()
         server_count = manager.load_config()

--- a/core/tools/analysis.py
+++ b/core/tools/analysis.py
@@ -13,8 +13,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-from core.fixtures import load_fixture
-from core.nodes.analysts import ANALYST_TYPES, get_dry_run_result
+from core.domains.game_ip.fixtures import load_fixture
+from core.domains.game_ip.nodes.analysts import ANALYST_TYPES, get_dry_run_result
 from core.state import PSMResult
 
 # Load parameter schemas from centralized JSON
@@ -112,7 +112,7 @@ class RunEvaluatorTool:
         ip_name = kwargs["ip_name"]
 
         # Use fixture-based dry-run evaluator data
-        from core.fixtures import load_fixture
+        from core.domains.game_ip.fixtures import load_fixture
 
         try:
             data = load_fixture(ip_name)

--- a/core/tools/data_tools.py
+++ b/core/tools/data_tools.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.fixtures import FIXTURE_MAP, load_fixture
+from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
 
 class QueryMonoLakeTool:

--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from core.config import ANTHROPIC_BUDGET
-from core.fixtures import load_fixture
+from core.domains.game_ip.fixtures import load_fixture
 
 # Load parameter schemas from centralized JSON
 _SCHEMAS_PATH = Path(__file__).resolve().parent / "tool_schemas.json"

--- a/core/ui/__init__.py
+++ b/core/ui/__init__.py
@@ -1,3 +1,0 @@
-"""DEPRECATED: UI modules moved to core.cli.ui."""
-
-from core.cli.ui import *  # noqa: F403

--- a/core/ui/agentic_ui.py
+++ b/core/ui/agentic_ui.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.cli.ui.agentic_ui instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.cli.ui.agentic_ui")

--- a/core/ui/agentic_ui.pyi
+++ b/core/ui/agentic_ui.pyi
@@ -1,1 +1,0 @@
-from core.cli.ui.agentic_ui import *  # noqa: F403

--- a/core/ui/console.py
+++ b/core/ui/console.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.cli.ui.console instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.cli.ui.console")

--- a/core/ui/console.pyi
+++ b/core/ui/console.pyi
@@ -1,1 +1,0 @@
-from core.cli.ui.console import *  # noqa: F403

--- a/core/ui/mascot.py
+++ b/core/ui/mascot.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.cli.ui.mascot instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.cli.ui.mascot")

--- a/core/ui/mascot.pyi
+++ b/core/ui/mascot.pyi
@@ -1,1 +1,0 @@
-from core.cli.ui.mascot import *  # noqa: F403

--- a/core/ui/panels.py
+++ b/core/ui/panels.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.cli.ui.panels instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.cli.ui.panels")

--- a/core/ui/panels.pyi
+++ b/core/ui/panels.pyi
@@ -1,1 +1,0 @@
-from core.cli.ui.panels import *  # noqa: F403

--- a/core/ui/status.py
+++ b/core/ui/status.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.cli.ui.status instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.cli.ui.status")

--- a/core/ui/status.pyi
+++ b/core/ui/status.pyi
@@ -1,1 +1,0 @@
-from core.cli.ui.status import *  # noqa: F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,16 +120,3 @@ module = [
     "mcp.*",
 ]
 ignore_missing_imports = true
-
-# Strangler Fig proxy modules — runtime sys.modules redirect, mypy can't follow
-[[tool.mypy.overrides]]
-module = [
-    "core.nodes",
-    "core.nodes.*",
-    "core.ui",
-    "core.ui.*",
-    "core.fixtures",
-    "core.fixtures.*",
-]
-ignore_errors = true
-follow_imports = "silent"

--- a/scripts/check_legacy_imports.py
+++ b/scripts/check_legacy_imports.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""CI ratchet: reject new imports using legacy bridge paths.
+
+Checks only files changed since base-ref (default: origin/develop).
+Exits non-zero if any legacy import is found in changed files.
+Bridge proxy files themselves are excluded from checking.
+
+Usage:
+    python scripts/check_legacy_imports.py
+    python scripts/check_legacy_imports.py --base-ref origin/main
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+LEGACY_PATTERNS: list[tuple[str, str]] = [
+    (r"from core\.nodes\b", "core.domains.game_ip.nodes"),
+    (r"import core\.nodes\b", "core.domains.game_ip.nodes"),
+    (r"from core\.fixtures\b", "core.domains.game_ip.fixtures"),
+    (r"import core\.fixtures\b", "core.domains.game_ip.fixtures"),
+    (r"from core\.ui\b", "core.cli.ui"),
+    (r"import core\.ui\b", "core.cli.ui"),
+]
+
+# Bridge proxy files are exempt (they ARE the re-export layer)
+EXEMPT_FILES = {
+    "core/nodes/__init__.py",
+    "core/nodes/analysts.py",
+    "core/nodes/evaluators.py",
+    "core/nodes/router.py",
+    "core/nodes/scoring.py",
+    "core/nodes/signals.py",
+    "core/nodes/synthesizer.py",
+    "core/fixtures/__init__.py",
+    "core/ui/__init__.py",
+    "core/ui/agentic_ui.py",
+    "core/ui/console.py",
+    "core/ui/mascot.py",
+    "core/ui/panels.py",
+    "core/ui/status.py",
+}
+
+
+def main() -> int:
+    base = "origin/develop"
+    if "--base-ref" in sys.argv:
+        idx = sys.argv.index("--base-ref")
+        if idx + 1 < len(sys.argv):
+            base = sys.argv[idx + 1]
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", base, "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    changed = [
+        f
+        for f in result.stdout.strip().split("\n")
+        if f.endswith(".py") and f not in EXEMPT_FILES
+    ]
+
+    violations: list[str] = []
+    for filepath in changed:
+        try:
+            content = open(filepath, encoding="utf-8").read()  # noqa: SIM115
+        except FileNotFoundError:
+            continue
+        for i, line in enumerate(content.split("\n"), 1):
+            for pattern, replacement in LEGACY_PATTERNS:
+                if re.search(pattern, line):
+                    violations.append(f"  {filepath}:{i}: use {replacement}")
+
+    if violations:
+        print(f"Legacy import violations ({len(violations)}):")
+        for v in violations:
+            print(v)
+        return 1
+
+    print(f"No legacy imports in {len(changed)} changed files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_live_audit_runner.py
+++ b/tests/_live_audit_runner.py
@@ -15,7 +15,7 @@ import sys
 os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
 os.environ.setdefault("LANGCHAIN_PROJECT", "geode")
 
-from core.ui.console import console
+from core.cli.ui.console import console
 
 console.file = io.StringIO()
 

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from unittest.mock import patch
 
-from core.ui.agentic_ui import (
+from core.cli.ui.agentic_ui import (
     OperationLogger,
     SessionMeter,
     _fmt_tokens,
@@ -43,7 +43,7 @@ class TestFmtTokens:
 class TestRenderToolCall:
     """Tool call rendering: ▸ tool_name(args)."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_string_arg(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_call("analyze_ip", {"ip_name": "Berserk"})
         printed = str(mock_console.print.call_args)
@@ -51,25 +51,25 @@ class TestRenderToolCall:
         assert "Berserk" in printed
         assert "▸" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_bool_arg(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_call("list_ips", {"verbose": True})
         printed = str(mock_console.print.call_args)
         assert "verbose=true" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_numeric_arg(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_call("search_ips", {"limit": 10})
         printed = str(mock_console.print.call_args)
         assert "limit=10" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_dict_arg(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_call("test_tool", {"config": {"key": "val"}})
         printed = str(mock_console.print.call_args)
         assert "config=" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_empty_args(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_call("list_ips", {})
         printed = str(mock_console.print.call_args)
@@ -80,7 +80,7 @@ class TestRenderToolCall:
 class TestRenderToolResult:
     """Tool result rendering: ✓ tool_name → summary."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_success_with_tier_score(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_result("analyze_ip", {"tier": "S", "score": 81.3})
         printed = str(mock_console.print.call_args)
@@ -88,26 +88,26 @@ class TestRenderToolResult:
         assert "analyze_ip" in printed
         assert "S" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_success_with_count(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_result("list_ips", {"count": 5})
         printed = str(mock_console.print.call_args)
         assert "5 items" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_success_with_plan_id(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_result("create_plan", {"plan_id": "abc12345678"})
         printed = str(mock_console.print.call_args)
         assert "plan:abc12345" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_error_result(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_result("analyze_ip", {"error": "Not found"})
         printed = str(mock_console.print.call_args)
         assert "✗" in printed
         assert "Not found" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_empty_result_shows_ok(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tool_result("list_ips", {})
         printed = str(mock_console.print.call_args)
@@ -117,7 +117,7 @@ class TestRenderToolResult:
 class TestRenderTokens:
     """Token usage rendering: ✢ model · ↓in ↑out · time."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_with_elapsed(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tokens("claude-opus-4-6", 1200, 350, elapsed_s=2.1)
         printed = str(mock_console.print.call_args)
@@ -127,7 +127,7 @@ class TestRenderTokens:
         assert "350" in printed
         assert "2.1s" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_without_elapsed(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_tokens("claude-opus-4-6", 500, 100)
         printed = str(mock_console.print.call_args)
@@ -139,7 +139,7 @@ class TestRenderTokens:
 class TestRenderPlanSteps:
     """Plan step rendering: ● Plan: ip_name."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_renders_steps(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_plan_steps("Berserk", ["Analyze", "Score", "Verify"])
         calls = [str(c) for c in mock_console.print.call_args_list]
@@ -153,14 +153,14 @@ class TestRenderPlanSteps:
 class TestRenderSubagent:
     """Sub-agent dispatch/complete rendering."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_dispatch(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_subagent_dispatch("task-1", "analyze", "Analyze Berserk IP")
         printed = str(mock_console.print.call_args)
         assert "delegate_task" in printed
         assert "analyze" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_complete(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         render_subagent_complete(3, 5.2)
         calls = [str(c) for c in mock_console.print.call_args_list]
@@ -193,14 +193,14 @@ class TestSessionMeter:
 class TestOperationLogger:
     """OperationLogger progressive tree rendering tests."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_below_threshold_visible(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         visible = logger.log_tool_call("analyze_ip", {"ip_name": "Berserk"})
         assert visible is True
         assert mock_console.print.called
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_above_threshold_collapsed(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         for i in range(OperationLogger.COLLAPSE_THRESHOLD):
@@ -208,7 +208,7 @@ class TestOperationLogger:
         # Next call should be collapsed
         assert logger.log_tool_call("tool_extra", {}) is False
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_finalize_shows_collapsed_count(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         for i in range(OperationLogger.COLLAPSE_THRESHOLD + 3):
@@ -218,7 +218,7 @@ class TestOperationLogger:
         combined = " ".join(calls)
         assert "+3 more tool uses" in combined
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_finalize_no_collapsed(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         logger.log_tool_call("tool_1", {})
@@ -226,21 +226,21 @@ class TestOperationLogger:
         logger.finalize()
         assert not mock_console.print.called
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_begin_round_prints_header(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         logger.begin_round("TestRound")
         printed = str(mock_console.print.call_args)
         assert "TestRound" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_begin_round_only_once(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         logger.begin_round("TestRound")
         logger.begin_round("TestRound")
         assert mock_console.print.call_count == 1
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_reset_clears_state(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         for i in range(3):
@@ -250,7 +250,7 @@ class TestOperationLogger:
         assert logger._collapsed_count == 0
         assert logger._header_printed is False
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_log_tool_result_error(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         logger.log_tool_result("test", {"error": "fail"}, visible=True)
@@ -258,7 +258,7 @@ class TestOperationLogger:
         assert "✗" in printed
         assert "fail" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_log_tool_result_invisible_noop(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         logger = OperationLogger()
         logger.log_tool_result("test", {"tier": "S"}, visible=False)
@@ -268,7 +268,7 @@ class TestOperationLogger:
 class TestRenderStatusLine:
     """Status line rendering tests."""
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_renders_with_session_meter(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         init_session_meter(model="claude-opus-4-6")
         # Record some usage so tracker has data
@@ -284,10 +284,10 @@ class TestRenderStatusLine:
         assert "claude-opus-4-6" in printed
         assert "context" in printed
 
-    @patch("core.ui.agentic_ui.console")
+    @patch("core.cli.ui.agentic_ui.console")
     def test_noop_without_meter(self, mock_console) -> None:  # type: ignore[no-untyped-def]
         # Force no meter
-        import core.ui.agentic_ui as mod
+        import core.cli.ui.agentic_ui as mod
 
         old = mod._session_meter
         mod._session_meter = None

--- a/tests/test_analysts.py
+++ b/tests/test_analysts.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from core.nodes.analysts import ANALYST_TYPES, _build_analyst_prompt, _run_analyst
-from core.nodes.analysts import get_dry_run_result as _dry_run_result
+from core.domains.game_ip.nodes.analysts import ANALYST_TYPES, _build_analyst_prompt, _run_analyst
+from core.domains.game_ip.nodes.analysts import get_dry_run_result as _dry_run_result
 
 
 class TestAnalystTypes:

--- a/tests/test_bootstrap_wire.py
+++ b/tests/test_bootstrap_wire.py
@@ -208,7 +208,7 @@ class TestPromptOverridesWire:
 
 class TestAnalystSendsPropagation:
     def test_sends_contain_adr007_keys(self) -> None:
-        from core.nodes.analysts import make_analyst_sends
+        from core.domains.game_ip.nodes.analysts import make_analyst_sends
 
         state: dict[str, Any] = {
             "ip_name": "Berserk",
@@ -235,7 +235,7 @@ class TestAnalystSendsPropagation:
 
 class TestEvaluatorSendsPropagation:
     def test_sends_contain_adr007_keys(self) -> None:
-        from core.nodes.evaluators import make_evaluator_sends
+        from core.domains.game_ip.nodes.evaluators import make_evaluator_sends
 
         state: dict[str, Any] = {
             "ip_name": "Berserk",
@@ -410,7 +410,7 @@ class TestAnalystSpecificMigration:
 
         # Build a minimal state that _build_analyst_prompt() expects
         from core.llm.prompts import ANALYST_SPECIFIC
-        from core.nodes.analysts import _build_analyst_prompt
+        from core.domains.game_ip.nodes.analysts import _build_analyst_prompt
 
         state: dict[str, Any] = {
             "ip_info": {
@@ -448,7 +448,7 @@ class TestAnalystSpecificMigration:
     def test_analyst_specific_used_when_no_skill(self) -> None:
         """When no skill .md exists, ANALYST_SPECIFIC should appear in user prompt."""
         from core.llm.prompts import ANALYST_SPECIFIC
-        from core.nodes.analysts import _build_analyst_prompt
+        from core.domains.game_ip.nodes.analysts import _build_analyst_prompt
 
         assembler = PromptAssembler(skill_registry=SkillRegistry())
 

--- a/tests/test_bootstrap_wire.py
+++ b/tests/test_bootstrap_wire.py
@@ -409,8 +409,8 @@ class TestAnalystSpecificMigration:
         assembler = PromptAssembler(skill_registry=registry)
 
         # Build a minimal state that _build_analyst_prompt() expects
-        from core.llm.prompts import ANALYST_SPECIFIC
         from core.domains.game_ip.nodes.analysts import _build_analyst_prompt
+        from core.llm.prompts import ANALYST_SPECIFIC
 
         state: dict[str, Any] = {
             "ip_info": {
@@ -447,8 +447,8 @@ class TestAnalystSpecificMigration:
 
     def test_analyst_specific_used_when_no_skill(self) -> None:
         """When no skill .md exists, ANALYST_SPECIFIC should appear in user prompt."""
-        from core.llm.prompts import ANALYST_SPECIFIC
         from core.domains.game_ip.nodes.analysts import _build_analyst_prompt
+        from core.llm.prompts import ANALYST_SPECIFIC
 
         assembler = PromptAssembler(skill_registry=SkillRegistry())
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -14,16 +14,16 @@ from typing import Any, TypeVar
 
 import pytest
 from core.config import Settings
-from core.infrastructure.ports.llm_port import (
-    get_secondary_llm_json,
-    get_secondary_llm_parsed,
-    set_llm_callable,
-)
 from core.domains.game_ip.nodes.analysts import (
     _DEFAULT_PRIMARY_ANALYSTS,
     _DEFAULT_SECONDARY_ANALYSTS,
     _run_analyst,
     _should_use_secondary,
+)
+from core.infrastructure.ports.llm_port import (
+    get_secondary_llm_json,
+    get_secondary_llm_parsed,
+    set_llm_callable,
 )
 from core.state import AnalysisResult, GeodeState
 from pydantic import BaseModel

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -19,7 +19,7 @@ from core.infrastructure.ports.llm_port import (
     get_secondary_llm_parsed,
     set_llm_callable,
 )
-from core.nodes.analysts import (
+from core.domains.game_ip.nodes.analysts import (
     _DEFAULT_PRIMARY_ANALYSTS,
     _DEFAULT_SECONDARY_ANALYSTS,
     _run_analyst,

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.nodes.evaluators import (
+from core.domains.game_ip.nodes.evaluators import (
     _EVALUATOR_OUTPUT_MODELS,
     EVALUATOR_TYPES,
     CommunityMomentumAxes,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from core.fixtures.generator import (
+from core.domains.game_ip.fixtures.generator import (
     GENRE_PARAMS,
     generate_batch,
     generate_ip,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,7 +1,7 @@
 """Tests for graph construction and dry-run execution."""
 
 from core.graph import build_graph, compile_graph
-from core.nodes.synthesizer import CAUSE_TO_ACTION, _classify_cause
+from core.domains.game_ip.nodes.synthesizer import CAUSE_TO_ACTION, _classify_cause
 
 
 class TestGraphBuild:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,7 +1,7 @@
 """Tests for graph construction and dry-run execution."""
 
-from core.graph import build_graph, compile_graph
 from core.domains.game_ip.nodes.synthesizer import CAUSE_TO_ACTION, _classify_cause
+from core.graph import build_graph, compile_graph
 
 
 class TestGraphBuild:

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -401,7 +401,7 @@ class TestAnalystConfidenceClamping:
     """Karpathy P1 — defensive confidence clamp [0, 100]."""
 
     def test_confidence_clamped_above_100(self):
-        from core.nodes.analysts import analyst_node
+        from core.domains.game_ip.nodes.analysts import analyst_node
         from core.state import AnalysisResult
 
         # Use model_construct to bypass Pydantic validation (simulates raw LLM output)
@@ -426,7 +426,7 @@ class TestAnalystConfidenceClamping:
             "errors": [],
         }
 
-        with patch("core.nodes.analysts._run_analyst", return_value=over_result):
+        with patch("core.domains.game_ip.nodes.analysts._run_analyst", return_value=over_result):
             result = analyst_node(state)
 
         analyses = result["analyses"]
@@ -434,7 +434,7 @@ class TestAnalystConfidenceClamping:
         assert analyses[0].confidence == 100.0
 
     def test_confidence_clamped_below_0(self):
-        from core.nodes.analysts import analyst_node
+        from core.domains.game_ip.nodes.analysts import analyst_node
         from core.state import AnalysisResult
 
         # Use model_construct to bypass Pydantic validation (simulates raw LLM output)
@@ -459,7 +459,7 @@ class TestAnalystConfidenceClamping:
             "errors": [],
         }
 
-        with patch("core.nodes.analysts._run_analyst", return_value=under_result):
+        with patch("core.domains.game_ip.nodes.analysts._run_analyst", return_value=under_result):
             result = analyst_node(state)
 
         analyses = result["analyses"]
@@ -467,7 +467,7 @@ class TestAnalystConfidenceClamping:
         assert analyses[0].confidence == 0.0
 
     def test_confidence_normal_not_clamped(self):
-        from core.nodes.analysts import analyst_node
+        from core.domains.game_ip.nodes.analysts import analyst_node
         from core.state import AnalysisResult
 
         normal_result = AnalysisResult(
@@ -491,7 +491,7 @@ class TestAnalystConfidenceClamping:
             "errors": [],
         }
 
-        with patch("core.nodes.analysts._run_analyst", return_value=normal_result):
+        with patch("core.domains.game_ip.nodes.analysts._run_analyst", return_value=normal_result):
             result = analyst_node(state)
 
         assert result["analyses"][0].confidence == 85.0
@@ -507,7 +507,7 @@ class TestScoringCompositeIndependence:
 
     def test_growth_score_uses_axes_not_composite(self):
         """_calc_growth_score should derive trend from axes, not composite_score."""
-        from core.nodes.scoring import _calc_growth_score
+        from core.domains.game_ip.nodes.scoring import _calc_growth_score
         from core.state import EvaluatorResult
 
         evaluations = {
@@ -535,7 +535,7 @@ class TestScoringCompositeIndependence:
 
     def test_growth_score_no_community_momentum(self):
         """Without community_momentum evaluator, trend defaults to 50.0."""
-        from core.nodes.scoring import _calc_growth_score
+        from core.domains.game_ip.nodes.scoring import _calc_growth_score
         from core.state import EvaluatorResult
 
         evaluations = {
@@ -554,7 +554,7 @@ class TestScoringCompositeIndependence:
 
     def test_growth_score_with_precomputed_momentum(self):
         """Pre-computed momentum should be used instead of recalculating."""
-        from core.nodes.scoring import _calc_growth_score
+        from core.domains.game_ip.nodes.scoring import _calc_growth_score
         from core.state import EvaluatorResult
 
         evaluations = {
@@ -588,7 +588,7 @@ class TestSynthesizerBoundaryLogging:
     """Decision Tree boundary crossing should produce a warning log."""
 
     def test_boundary_crossing_logged(self, caplog: Any):
-        from core.nodes.synthesizer import _extract_def_scores
+        from core.domains.game_ip.nodes.synthesizer import _extract_def_scores
         from core.state import EvaluatorResult
 
         evaluations = {
@@ -600,7 +600,7 @@ class TestSynthesizerBoundaryLogging:
             ),
         }
 
-        with caplog.at_level(logging.WARNING, logger="core.nodes.synthesizer"):
+        with caplog.at_level(logging.WARNING, logger="core.domains.game_ip.nodes.synthesizer"):
             d, e, f = _extract_def_scores(evaluations)
 
         # 2.5 rounds to 2 → crosses from <3 to... no, stays <3.
@@ -612,7 +612,7 @@ class TestSynthesizerBoundaryLogging:
 
     def test_boundary_crossing_at_2_point_5(self, caplog: Any):
         """2.5 → round(2.5) = 2 in Python (banker's rounding). No boundary cross."""
-        from core.nodes.synthesizer import _extract_def_scores
+        from core.domains.game_ip.nodes.synthesizer import _extract_def_scores
         from core.state import EvaluatorResult
 
         evaluations = {
@@ -624,7 +624,7 @@ class TestSynthesizerBoundaryLogging:
             ),
         }
 
-        with caplog.at_level(logging.WARNING, logger="core.nodes.synthesizer"):
+        with caplog.at_level(logging.WARNING, logger="core.domains.game_ip.nodes.synthesizer"):
             d, e, f = _extract_def_scores(evaluations)
 
         # 2.6 rounds to 3 → crosses boundary (raw < 3 but rounded >= 3)
@@ -633,7 +633,7 @@ class TestSynthesizerBoundaryLogging:
 
     def test_no_boundary_crossing_clear_scores(self, caplog: Any):
         """Scores clearly above/below 3 should not warn."""
-        from core.nodes.synthesizer import _extract_def_scores
+        from core.domains.game_ip.nodes.synthesizer import _extract_def_scores
         from core.state import EvaluatorResult
 
         evaluations = {
@@ -645,7 +645,7 @@ class TestSynthesizerBoundaryLogging:
             ),
         }
 
-        with caplog.at_level(logging.WARNING, logger="core.nodes.synthesizer"):
+        with caplog.at_level(logging.WARNING, logger="core.domains.game_ip.nodes.synthesizer"):
             d, e, f = _extract_def_scores(evaluations)
 
         assert d == 4
@@ -654,7 +654,7 @@ class TestSynthesizerBoundaryLogging:
         assert not any("DT boundary shift" in msg for msg in caplog.messages)
 
     def test_no_hidden_value_returns_defaults(self):
-        from core.nodes.synthesizer import _extract_def_scores
+        from core.domains.game_ip.nodes.synthesizer import _extract_def_scores
 
         d, e, f = _extract_def_scores({})
         assert (d, e, f) == (3, 3, 3)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -46,7 +46,7 @@ class TestMCPToolFunctions:
     """Test tool logic by exercising the same code paths the MCP tools use."""
 
     def test_get_ip_signals_returns_fixture_data(self) -> None:
-        from core.fixtures import FIXTURE_MAP, load_fixture
+        from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
         ip_key = sorted(FIXTURE_MAP.keys())[0]
         fixture = load_fixture(ip_key)
@@ -59,12 +59,12 @@ class TestMCPToolFunctions:
         assert result["source"] == "fixture"
 
     def test_get_ip_signals_unknown_ip(self) -> None:
-        from core.fixtures import FIXTURE_MAP
+        from core.domains.game_ip.fixtures import FIXTURE_MAP
 
         assert "zzz_nonexistent_ip" not in FIXTURE_MAP
 
     def test_list_fixtures_returns_count_and_ips(self) -> None:
-        from core.fixtures import FIXTURE_MAP
+        from core.domains.game_ip.fixtures import FIXTURE_MAP
 
         result = {"count": len(FIXTURE_MAP), "ips": sorted(FIXTURE_MAP.keys())}
         assert result["count"] > 0
@@ -85,7 +85,7 @@ class TestMCPToolFunctions:
     def test_fixtures_resource_returns_json(self) -> None:
         import json
 
-        from core.fixtures import FIXTURE_MAP
+        from core.domains.game_ip.fixtures import FIXTURE_MAP
 
         data = json.dumps({"count": len(FIXTURE_MAP), "ips": sorted(FIXTURE_MAP.keys())})
         parsed = json.loads(data)

--- a/tests/test_production_upgrade.py
+++ b/tests/test_production_upgrade.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
-from core.nodes.scoring import _calc_analyst_confidence
+from core.domains.game_ip.nodes.scoring import _calc_analyst_confidence
 from core.state import AnalysisResult
 
 # ---------------------------------------------------------------------------
@@ -228,14 +228,14 @@ class TestPartialRetry:
         }
 
     def test_first_iteration_sends_all_four(self):
-        from core.nodes.analysts import make_analyst_sends
+        from core.domains.game_ip.nodes.analysts import make_analyst_sends
 
         state = self._base_state(iteration=1)
         sends = make_analyst_sends(state)
         assert len(sends) == 4
 
     def test_second_iteration_skips_good_results(self):
-        from core.nodes.analysts import make_analyst_sends
+        from core.domains.game_ip.nodes.analysts import make_analyst_sends
 
         good_analysis = AnalysisResult(
             analyst_type="game_mechanics",

--- a/tests/test_property_scoring.py
+++ b/tests/test_property_scoring.py
@@ -10,7 +10,7 @@ with systematic boundary values to cover the property-based test intent:
 from __future__ import annotations
 
 import pytest
-from core.nodes.scoring import (
+from core.domains.game_ip.nodes.scoring import (
     _calc_analyst_confidence,
     _calc_final_score,
     _determine_tier,

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,6 @@
 """Tests for scoring formulas."""
 
-from core.nodes.scoring import (
+from core.domains.game_ip.nodes.scoring import (
     _calc_analyst_confidence,
     _calc_community_momentum,
     _calc_final_score,

--- a/tests/test_signal_liveification.py
+++ b/tests/test_signal_liveification.py
@@ -14,7 +14,7 @@ from typing import Any
 from core.infrastructure.adapters.mcp.brave_adapter import BraveSignalAdapter
 from core.infrastructure.adapters.mcp.composite_signal import CompositeSignalAdapter
 from core.infrastructure.adapters.mcp.steam_adapter import SteamMCPSignalAdapter
-from core.nodes.signals import set_signal_adapter, signals_node
+from core.domains.game_ip.nodes.signals import set_signal_adapter, signals_node
 from core.state import GeodeState
 
 # ---------------------------------------------------------------------------

--- a/tests/test_signal_liveification.py
+++ b/tests/test_signal_liveification.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domains.game_ip.nodes.signals import set_signal_adapter, signals_node
 from core.infrastructure.adapters.mcp.brave_adapter import BraveSignalAdapter
 from core.infrastructure.adapters.mcp.composite_signal import CompositeSignalAdapter
 from core.infrastructure.adapters.mcp.steam_adapter import SteamMCPSignalAdapter
-from core.domains.game_ip.nodes.signals import set_signal_adapter, signals_node
 from core.state import GeodeState
 
 # ---------------------------------------------------------------------------

--- a/tests/test_signal_port.py
+++ b/tests/test_signal_port.py
@@ -10,7 +10,7 @@ from core.infrastructure.adapters.signal_adapter import (
     create_signal_adapter,
 )
 from core.infrastructure.ports.signal_port import SignalEnrichmentPort
-from core.nodes.signals import set_signal_adapter, signals_node
+from core.domains.game_ip.nodes.signals import set_signal_adapter, signals_node
 from core.state import GeodeState
 
 

--- a/tests/test_signal_port.py
+++ b/tests/test_signal_port.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domains.game_ip.nodes.signals import set_signal_adapter, signals_node
 from core.infrastructure.adapters.signal_adapter import (
     FixtureSignalAdapter,
     LiveSignalAdapter,
     create_signal_adapter,
 )
 from core.infrastructure.ports.signal_port import SignalEnrichmentPort
-from core.domains.game_ip.nodes.signals import set_signal_adapter, signals_node
 from core.state import GeodeState
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from core.config import ANTHROPIC_PRIMARY
 from core.llm.client import LLMUsage, LLMUsageAccumulator
-from core.ui.status import GeodeStatus, TextSpinner, _snapshot, _UsageSnapshot
+from core.cli.ui.status import GeodeStatus, TextSpinner, _snapshot, _UsageSnapshot
 
 # ---------------------------------------------------------------------------
 # _snapshot / _UsageSnapshot
@@ -73,8 +73,8 @@ class TestTextSpinner:
 class TestGeodeStatusContextManager:
     """Enter/exit lifecycle, update, and stop."""
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_enter_exit(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         """Context manager enters and exits without error."""
         mock_acc_fn.return_value = LLMUsageAccumulator()
@@ -87,8 +87,8 @@ class TestGeodeStatusContextManager:
         printed = str(mock_console.print.call_args)
         assert "done" in printed
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_update_changes_spinner(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         """update() changes the internal spinner message."""
         mock_acc_fn.return_value = LLMUsageAccumulator()
@@ -100,8 +100,8 @@ class TestGeodeStatusContextManager:
             assert status._spinner._message == "✢ Step 2"
             status.stop("done")
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_stop_prints_summary(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         """stop() prints a line with checkmark and summary."""
         mock_acc_fn.return_value = LLMUsageAccumulator()
@@ -114,8 +114,8 @@ class TestGeodeStatusContextManager:
         summary_found = any("analyze · Berserk" in p for p in printed)
         assert summary_found, f"Summary not found in prints: {printed}"
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_stop_idempotent(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         """Calling stop() twice does not double-print."""
         mock_acc_fn.return_value = LLMUsageAccumulator()
@@ -130,8 +130,8 @@ class TestGeodeStatusContextManager:
         summary_count = sum(1 for c in print_calls if "result" in str(c))
         assert summary_count == 1
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_auto_exit_summary(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         """If stop() is never called, __exit__ prints a generic summary."""
         mock_acc_fn.return_value = LLMUsageAccumulator()
@@ -152,8 +152,8 @@ class TestGeodeStatusContextManager:
 class TestTokenDelta:
     """Verify _get_token_delta computes before/after difference."""
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_delta_calculation(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         """Token delta = after - before."""
         acc = LLMUsageAccumulator()
@@ -169,8 +169,8 @@ class TestTokenDelta:
         assert delta.output_tokens == 50
         assert delta.cost_usd == pytest.approx(0.010)
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_delta_zero_when_no_calls(
         self, mock_acc_fn: MagicMock, mock_console: MagicMock
     ) -> None:
@@ -194,8 +194,8 @@ class TestTokenDelta:
 class TestSummaryFormatting:
     """Verify the summary line includes token info and elapsed time."""
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_summary_includes_tokens_and_cost(
         self, mock_acc_fn: MagicMock, mock_console: MagicMock
     ) -> None:
@@ -214,8 +214,8 @@ class TestSummaryFormatting:
         assert "↑30" in summary_line  # output tokens
         assert "$0.004" in summary_line
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_summary_no_tokens_still_shows_time(
         self, mock_acc_fn: MagicMock, mock_console: MagicMock
     ) -> None:
@@ -242,8 +242,8 @@ class TestSummaryFormatting:
 class TestModelDisplay:
     """Spinner message includes model name when provided."""
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_model_in_spinner(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         mock_acc_fn.return_value = LLMUsageAccumulator()
 
@@ -253,8 +253,8 @@ class TestModelDisplay:
             assert ANTHROPIC_PRIMARY in fmt
             status.stop("done")
 
-    @patch("core.ui.status.console")
-    @patch("core.ui.status.get_usage_accumulator")
+    @patch("core.cli.ui.status.console")
+    @patch("core.cli.ui.status.get_usage_accumulator")
     def test_no_model(self, mock_acc_fn: MagicMock, mock_console: MagicMock) -> None:
         mock_acc_fn.return_value = LLMUsageAccumulator()
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from core.cli.ui.status import GeodeStatus, TextSpinner, _snapshot, _UsageSnapshot
 from core.config import ANTHROPIC_PRIMARY
 from core.llm.client import LLMUsage, LLMUsageAccumulator
-from core.cli.ui.status import GeodeStatus, TextSpinner, _snapshot, _UsageSnapshot
 
 # ---------------------------------------------------------------------------
 # _snapshot / _UsageSnapshot

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.nodes.synthesizer import (
+from core.domains.game_ip.nodes.synthesizer import (
     ACTION_DESCRIPTIONS,
     CAUSE_DESCRIPTIONS,
     CAUSE_TO_ACTION,

--- a/tests/test_tool_augmented_nodes.py
+++ b/tests/test_tool_augmented_nodes.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from core.infrastructure.ports.tool_port import set_tool_executor
 from core.llm.client import ToolCallRecord, ToolUseResult
-from core.nodes.synthesizer import _build_tool_augmented_synthesis, synthesizer_node
+from core.domains.game_ip.nodes.synthesizer import _build_tool_augmented_synthesis, synthesizer_node
 from core.state import AnalysisResult, EvaluatorResult, GeodeState
 
 
@@ -119,8 +119,8 @@ class TestSynthesizerNodeToolPath:
 
         # Mock both get_llm_tool (raises) and standard path
         with (
-            patch("core.nodes.synthesizer.get_llm_tool", side_effect=RuntimeError("not injected")),
-            patch("core.nodes.synthesizer._build_llm_synthesis") as mock_std,
+            patch("core.domains.game_ip.nodes.synthesizer.get_llm_tool", side_effect=RuntimeError("not injected")),
+            patch("core.domains.game_ip.nodes.synthesizer._build_llm_synthesis") as mock_std,
         ):
             from core.state import SynthesisResult
 

--- a/tests/test_tool_augmented_nodes.py
+++ b/tests/test_tool_augmented_nodes.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from core.domains.game_ip.nodes.synthesizer import _build_tool_augmented_synthesis, synthesizer_node
 from core.infrastructure.ports.tool_port import set_tool_executor
 from core.llm.client import ToolCallRecord, ToolUseResult
-from core.domains.game_ip.nodes.synthesizer import _build_tool_augmented_synthesis, synthesizer_node
 from core.state import AnalysisResult, EvaluatorResult, GeodeState
 
 
@@ -119,7 +119,10 @@ class TestSynthesizerNodeToolPath:
 
         # Mock both get_llm_tool (raises) and standard path
         with (
-            patch("core.domains.game_ip.nodes.synthesizer.get_llm_tool", side_effect=RuntimeError("not injected")),
+            patch(
+                "core.domains.game_ip.nodes.synthesizer.get_llm_tool",
+                side_effect=RuntimeError("not injected"),
+            ),
             patch("core.domains.game_ip.nodes.synthesizer._build_llm_synthesis") as mock_std,
         ):
             from core.state import SynthesisResult


### PR DESCRIPTION
## Summary

- **Phase 2**: `scripts/check_legacy_imports.py` CI 래칫 — 새 코드가 구 경로 사용 시 CI 실패
- **Phase 3**: 88 import lines 일괄 마이그레이션 (nodes/fixtures/ui → 새 경로)
- **Phase 4**: proxy .py + .pyi 22파일 삭제, pyproject.toml mypy override 제거

## Why

Phase 1(PR #411)에서 Strangler Fig 브릿지를 설치했으나, 구 경로와 새 경로가 공존하는 중간 상태는 혼란 유발.
모든 import를 새 경로로 마이그레이션하고 proxy를 제거하여 최종 상태 도달.

## Test plan

- [x] 3079 passed, 0 failed
- [x] Lint: 0 errors, Format: 0 errors
- [x] Type: 0 errors (187 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)