### PR TITLE
fix: /model non-tty graceful fallback

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -323,8 +323,22 @@ def cmd_model(args: str) -> None:
     """
     arg = args.strip()
 
-    # /model (no args) → interactive picker
+    # /model (no args) → interactive picker (requires tty)
     if not arg:
+        import sys
+
+        if not sys.stdin.isatty():
+            from core.config import settings
+
+            console.print()
+            console.print("  [header]Models[/header]")
+            for i, p in enumerate(MODEL_PROFILES, 1):
+                marker = " ←" if p.id == settings.model else ""
+                console.print(f"  {i}. {p.label:<12} {p.provider:<10} {p.cost}{marker}")
+            console.print()
+            console.print("  [muted]Usage: /model <number> or /model <name>[/muted]")
+            console.print()
+            return
         _interactive_model_picker()
         return
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -159,7 +159,11 @@ class TestCmdModel:
 
         old = settings.model
         try:
-            with patch("core.cli.commands.TerminalMenu") as MockMenu:
+            with (
+                patch("core.cli.commands.TerminalMenu") as MockMenu,
+                patch("sys.stdin") as mock_stdin,
+            ):
+                mock_stdin.isatty.return_value = True
                 MockMenu.return_value.show.return_value = 2  # Haiku
                 cmd_model("")
             assert settings.model == MODEL_PROFILES[2].id
@@ -172,7 +176,11 @@ class TestCmdModel:
         from core.config import settings
 
         old = settings.model
-        with patch("core.cli.commands.TerminalMenu") as MockMenu:
+        with (
+            patch("core.cli.commands.TerminalMenu") as MockMenu,
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = True
             MockMenu.return_value.show.return_value = None
             cmd_model("")
         assert settings.model == old


### PR DESCRIPTION
## Summary

non-interactive 환경(파이프, CI)에서 `/model` 인자 없이 호출 시 TerminalMenu crash 대신 모델 목록 표시.

## Why

E2E 검증 Case 1.9에서 발견. `sys.stdin.isatty()` 체크 → fallback list.

## Test plan

- [x] `echo '/model\n/quit' | uv run geode` → 7개 모델 + 현재 선택(←) 표시
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)