### PR TITLE
Merge develop → main (/model non-tty fix)

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -323,8 +323,22 @@ def cmd_model(args: str) -> None:
     """
     arg = args.strip()
 
-    # /model (no args) → interactive picker
+    # /model (no args) → interactive picker (requires tty)
     if not arg:
+        import sys
+
+        if not sys.stdin.isatty():
+            from core.config import settings
+
+            console.print()
+            console.print("  [header]Models[/header]")
+            for i, p in enumerate(MODEL_PROFILES, 1):
+                marker = " ←" if p.id == settings.model else ""
+                console.print(f"  {i}. {p.label:<12} {p.provider:<10} {p.cost}{marker}")
+            console.print()
+            console.print("  [muted]Usage: /model <number> or /model <name>[/muted]")
+            console.print()
+            return
         _interactive_model_picker()
         return
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -159,7 +159,11 @@ class TestCmdModel:
 
         old = settings.model
         try:
-            with patch("core.cli.commands.TerminalMenu") as MockMenu:
+            with (
+                patch("core.cli.commands.TerminalMenu") as MockMenu,
+                patch("sys.stdin") as mock_stdin,
+            ):
+                mock_stdin.isatty.return_value = True
                 MockMenu.return_value.show.return_value = 2  # Haiku
                 cmd_model("")
             assert settings.model == MODEL_PROFILES[2].id
@@ -172,7 +176,11 @@ class TestCmdModel:
         from core.config import settings
 
         old = settings.model
-        with patch("core.cli.commands.TerminalMenu") as MockMenu:
+        with (
+            patch("core.cli.commands.TerminalMenu") as MockMenu,
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = True
             MockMenu.return_value.show.return_value = None
             cmd_model("")
         assert settings.model == old


### PR DESCRIPTION
## Summary

- `/model` non-tty graceful fallback (interactive picker → list)
- model picker 테스트 isatty mock 추가

## Test plan

- [x] CI 5/5 pass (PR #423)

🤖 Generated with [Claude Code](https://claude.com/claude-code)