### PR TITLE
Merge develop → main: fix memory path display

### DIFF
--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -309,7 +309,7 @@ def check_readiness(project_root: Path | None = None) -> ReadinessReport:
         Capability(
             name="Project Memory",
             available=mem.exists(),
-            reason="" if mem.exists() else ".claude/MEMORY.md not found",
+            reason="" if mem.exists() else ".geode/memory/PROJECT.md not found",
         )
     )
 

--- a/core/memory/project.py
+++ b/core/memory/project.py
@@ -98,7 +98,7 @@ class ProjectMemory:
             return ""
 
     def load_rules(self, context: str = "*") -> list[dict[str, Any]]:
-        """Load matching rules from .claude/rules/*.md.
+        """Load matching rules from .geode/rules/*.md.
 
         Args:
             context: Context string to match against rule paths (e.g. "anime", "berserk").

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -332,7 +332,7 @@ class MemorySaveTool:
 class RuleCreateTool:
     """Tool for creating analysis rules from learned patterns.
 
-    Enables the agent to autonomously create .claude/rules/*.md files
+    Enables the agent to autonomously create .geode/rules/*.md files
     when it discovers recurring analysis patterns.
     """
 
@@ -343,7 +343,7 @@ class RuleCreateTool:
     @property
     def description(self) -> str:
         return (
-            "Create a new analysis rule in .claude/rules/. "
+            "Create a new analysis rule in .geode/rules/. "
             "Use when you discover a recurring pattern that should be "
             "applied to future IP analyses matching the given paths."
         )
@@ -404,7 +404,7 @@ class RuleUpdateTool:
     @property
     def description(self) -> str:
         return (
-            "Update an existing analysis rule in .claude/rules/. "
+            "Update an existing analysis rule in .geode/rules/. "
             "Preserves frontmatter (paths) and replaces the rule body content."
         )
 
@@ -456,7 +456,7 @@ class RuleDeleteTool:
 
     @property
     def description(self) -> str:
-        return "Delete an analysis rule from .claude/rules/ by name."
+        return "Delete an analysis rule from .geode/rules/ by name."
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -502,7 +502,7 @@ class RuleListTool:
     @property
     def description(self) -> str:
         return (
-            "List all active analysis rules in .claude/rules/ with their paths and content preview."
+            "List all active analysis rules in .geode/rules/ with their paths and content preview."
         )
 
     @property


### PR DESCRIPTION
## Summary
- PR #425 머지: startup/memory_tools의 `.claude/` 옛 경로 표시를 `.geode/`로 수정

## Changes
- `startup.py`: readiness 메시지 `.claude/MEMORY.md` → `.geode/memory/PROJECT.md`
- `memory_tools.py`: 도구 설명 5곳 `.claude/rules/` → `.geode/rules/`
- `project.py`: docstring 경로 수정

## Test plan
- [x] CI 5/5 passed on PR #425
- [x] Local: 3078 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)