### PR TITLE
fix: MCP 부트스트랩 0 이슈 — 경로 산출 수정 + load_config

### DIFF
--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -115,10 +115,12 @@ def bootstrap_geode(
     readiness = check_readiness()
     _set_readiness(readiness)
 
-    # 4. MCP
+    # 4. MCP — load config (server discovery) without connecting subprocesses.
+    #    Full startup() (connect all) is deferred to first tool use.
     from core.mcp.manager import get_mcp_manager
 
     mcp_mgr = get_mcp_manager()
+    mcp_mgr.load_config()
 
     # 5. Skills
     from core.skills.skills import SkillLoader, SkillRegistry

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -29,7 +29,7 @@ from core.mcp.stdio_client import StdioMCPClient
 
 log = logging.getLogger(__name__)
 
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _CONFIG_PATH = _PROJECT_ROOT / ".claude" / "mcp_servers.json"
 _DOTENV_PATH = _PROJECT_ROOT / ".env"
 _GLOBAL_DOTENV_PATH = Path.home() / ".geode" / ".env"


### PR DESCRIPTION
## Summary
- `_PROJECT_ROOT` parent 5단계 → 3단계 수정 — manager.py 기준 올바른 프로젝트 루트 산출
- `bootstrap_geode()`에서 `mcp_mgr.load_config()` 호출 추가 — 서버 발견(카탈로그 + 파일)만 수행, subprocess 연결은 첫 tool use 시 지연
- 외부 디렉토리(portfolio 등)에서 `geode` 실행 시 MCP 0개 표시 문제 해결

## Root Cause
1. `_PROJECT_ROOT`가 `Path(__file__).parent` x5로 `/Users/mango/`까지 올라감 → `.claude/mcp_servers.json` 미발견
2. `get_mcp_manager(auto_startup=False)` 기본값으로 `load_config()` 미호출 → `_servers` 빈 dict

## Test plan
- [x] ruff check 0 errors
- [x] mypy 0 errors
- [x] 3078 tests pass (MCP 86 포함)
- [ ] portfolio 디렉토리에서 geode 실행 → MCP 카운트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)