### PR TITLE
fix: MCP get_all_tools() lazy parallel 연결

### DIFF
--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -353,7 +353,14 @@ class MCPServerManager:
         MCP spec uses camelCase (``inputSchema``), but Anthropic API
         requires snake_case (``input_schema``).  This method normalises
         each tool dict so it can be passed directly to ``messages.create(tools=...)``.
+
+        If servers haven't been connected yet, triggers parallel connection
+        via ``_connect_all()`` to avoid sequential ~10s-per-server latency.
         """
+        # Lazy parallel connect: avoid sequential _get_client() per server
+        if self._servers and not self._clients:
+            self._connect_all()
+
         all_tools: list[dict[str, Any]] = []
         for server_name in self._servers:
             client = self._get_client(server_name)


### PR DESCRIPTION
## Summary
- `get_all_tools()` 최초 호출 시 `_connect_all()`(ThreadPoolExecutor)로 병렬 연결 선행
- 기존: 10서버 × ~10s = ~100s REPL 멈춤 → 병렬 ~15s로 단축

## Why
`bootstrap_geode()`가 `load_config()`만 호출하고 실제 연결은 지연. 이후 `AgenticLoop.__init__` → `get_all_tools()`에서 순차 `_get_client()` 호출로 REPL 프롬프트 표시 전 ~100초 멈춤 발생.

## Test plan
- [x] `uv run ruff check core/mcp/manager.py` — 0 errors
- [x] `uv run mypy core/mcp/manager.py` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3078 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)