### PR TITLE
fix: MCP lazy parallel 연결 — REPL 프롬프트 지연 해소

### DIFF
--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -353,7 +353,14 @@ class MCPServerManager:
         MCP spec uses camelCase (``inputSchema``), but Anthropic API
         requires snake_case (``input_schema``).  This method normalises
         each tool dict so it can be passed directly to ``messages.create(tools=...)``.
+
+        If servers haven't been connected yet, triggers parallel connection
+        via ``_connect_all()`` to avoid sequential ~10s-per-server latency.
         """
+        # Lazy parallel connect: avoid sequential _get_client() per server
+        if self._servers and not self._clients:
+            self._connect_all()
+
         all_tools: list[dict[str, Any]] = []
         for server_name in self._servers:
             client = self._get_client(server_name)


### PR DESCRIPTION
## Summary
- `get_all_tools()` 최초 호출 시 `_connect_all()`(ThreadPoolExecutor) 병렬 연결 선행
- REPL 프롬프트 표시 전 ~100s 멈춤 → ~15s로 단축

## Why
`bootstrap_geode()` → `load_config()`만 호출 (설정 로딩, 연결 없음). 이후 `AgenticLoop.__init__` → `get_all_tools()`에서 10개 서버 순차 `_get_client()` 호출로 REPL이 얼어붙는 현상 발생.

## Changes
- `core/mcp/manager.py`: `get_all_tools()`에 lazy parallel connect guard 추가 (#432)

## Test plan
- [x] CI 5/5 pass (Lint, Type, Test 3078, Security, Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)