### PR TITLE
fix: 빌링 에러 UI — BillingError 전용 예외 + 트레이스백 제거

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -45,7 +45,7 @@ from core.infrastructure.adapters.llm.agentic_registry import (
     CROSS_PROVIDER_FALLBACK,
     resolve_agentic_adapter,
 )
-from core.infrastructure.ports.agentic_llm_port import UserCancelledError
+from core.infrastructure.ports.agentic_llm_port import BillingError, UserCancelledError
 from core.llm.client import maybe_traceable
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.orchestration.hooks import HookEvent, HookSystem
@@ -343,7 +343,17 @@ class AgenticLoop:
 
         # Goal decomposition: try to break compound requests into sub-goal DAGs.
         # Returns a hint string appended to the system prompt, or None if not compound.
-        decomposition_hint = self._try_decompose(user_input)
+        try:
+            decomposition_hint = self._try_decompose(user_input)
+        except BillingError as exc:
+            from rich.console import Console as _Con
+
+            _Con().print(f"\n  [bold red]✗ Billing error[/bold red] — {exc}")
+            return AgenticResult(
+                text=str(exc),
+                rounds=0,
+                termination_reason="billing_error",
+            )
 
         # Add user message to conversation context
         self.context.add_user_message(user_input)
@@ -374,6 +384,16 @@ class AgenticLoop:
             _spinner.start()
             try:
                 response = await self._call_llm(system_prompt, messages, round_idx=round_idx)
+            except BillingError as exc:
+                _spinner.stop()
+                from rich.console import Console as _Con
+
+                _Con().print(f"\n  [bold red]✗ Billing error[/bold red] — {exc}")
+                return AgenticResult(
+                    text=str(exc),
+                    rounds=round_idx + 1,
+                    termination_reason="billing_error",
+                )
             except UserCancelledError:
                 _spinner.stop()
                 log.info("LLM call interrupted by user")

--- a/core/infrastructure/adapters/llm/claude_agentic_adapter.py
+++ b/core/infrastructure/adapters/llm/claude_agentic_adapter.py
@@ -100,6 +100,14 @@ class ClaudeAgenticAdapter:
             raise UserCancelledError("LLM call interrupted by user") from None
         except LLMBadRequestError as exc:
             msg = str(exc)
+            # Billing/credit errors — propagate as BillingError for clean UI
+            if "credit balance" in msg.lower() or "billing" in msg.lower():
+                from core.infrastructure.ports.agentic_llm_port import BillingError
+
+                raise BillingError(
+                    "Anthropic API credit balance too low. "
+                    "Visit https://console.anthropic.com/settings/billing to add credits."
+                ) from exc
             log.warning("Anthropic BadRequest in agentic loop: %s", msg)
             if "tool_use_id" in msg or "tool_result" in msg:
                 from core.agent.agentic_loop import AgenticLoop

--- a/core/infrastructure/adapters/llm/openai_adapter.py
+++ b/core/infrastructure/adapters/llm/openai_adapter.py
@@ -361,11 +361,11 @@ class OpenAIAdapter:
                     error_msg = str(exc)
                     # Credit balance / billing error — no retry, clear message
                     if "billing" in error_msg.lower() or "credit" in error_msg.lower():
-                        log.error("OpenAI billing error: %s", error_msg)
-                        raise RuntimeError(
+                        from core.infrastructure.ports.agentic_llm_port import BillingError
+
+                        raise BillingError(
                             "OpenAI API billing/credit error. "
-                            "Check your OpenAI account billing settings, "
-                            "or use --dry-run mode."
+                            "Check your OpenAI account billing settings."
                         ) from exc
                     # Context overflow or token limit — no retry, log details
                     if "token" in error_msg.lower() or "context" in error_msg.lower():

--- a/core/infrastructure/ports/agentic_llm_port.py
+++ b/core/infrastructure/ports/agentic_llm_port.py
@@ -21,6 +21,14 @@ class UserCancelledError(Exception):
     """
 
 
+class BillingError(Exception):
+    """Raised when an LLM provider rejects a call due to billing/credit issues.
+
+    Caught at the UI layer to display a clean one-line message instead
+    of a full traceback.  Never retried or counted as a model failure.
+    """
+
+
 @runtime_checkable
 class AgenticLLMPort(Protocol):
     """Protocol for agentic loop LLM calls.

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -501,11 +501,11 @@ def _retry_with_backoff(
                 error_msg = str(exc)
                 # Credit balance / billing error — no retry, clear message
                 if "credit balance" in error_msg.lower() or "billing" in error_msg.lower():
-                    log.error("Billing error: %s", error_msg)
-                    raise RuntimeError(
+                    from core.infrastructure.ports.agentic_llm_port import BillingError
+
+                    raise BillingError(
                         "Anthropic API credit balance too low. "
-                        "Visit https://console.anthropic.com/settings/billing to add credits, "
-                        "or use --dry-run mode."
+                        "Visit https://console.anthropic.com/settings/billing to add credits."
                     ) from exc
                 # Context overflow or invalid request — no retry
                 if "token" in error_msg.lower() or "context" in error_msg.lower():

--- a/core/orchestration/goal_decomposer.py
+++ b/core/orchestration/goal_decomposer.py
@@ -251,7 +251,12 @@ class GoalDecomposer:
             )
             return result
 
-        except Exception:
+        except Exception as exc:
+            # Billing errors must propagate for clean UI handling
+            from core.infrastructure.ports.agentic_llm_port import BillingError
+
+            if isinstance(exc, BillingError):
+                raise
             log.warning("GoalDecomposer LLM call failed", exc_info=True)
             return None
 


### PR DESCRIPTION
## Summary
- `BillingError` 전용 예외 클래스 도입 (기존 `RuntimeError` 대체)
- Anthropic/OpenAI 빌링 에러를 `BillingError`로 통일
- GoalDecomposer: `BillingError` re-raise (트레이스백 차단)
- AgenticLoop: `BillingError` catch → `✗ Billing error — {message}` 1줄 표시

## Why
빌링 크레딧 소진 시 풀 트레이스백 30줄이 REPL에 노출. `GoalDecomposer`의 `except Exception: log.warning(..., exc_info=True)` 때문. 전용 예외로 분리하여 UI 계층에서 깔끔하게 처리.

## Before / After
```
# Before:
Billing error: Error code: 400 - {...}
GoalDecomposer LLM call failed
Traceback (most recent call last):
  ... (30줄 traceback)

# After:
  ✗ Billing error — Anthropic API credit balance too low. Visit https://...
```

## Test plan
- [x] Lint 0 errors, Type 0 errors, 3078 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)