### PR TITLE
feat: Gateway 리소스 공유 — env cascade + 글로벌 메모리 fallback + User Context

### DIFF
--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -89,10 +89,10 @@ def build_system_prompt(model: str = "") -> str:
     if memory_ctx:
         base += "\n\n" + memory_ctx
 
-    # Career identity context (Tier 0.5 extension)
-    career_ctx = _build_career_context()
-    if career_ctx:
-        base += "\n\n" + career_ctx
+    # User context: profile + career identity
+    user_ctx = _build_user_context()
+    if user_ctx:
+        base += "\n\n" + user_ctx
 
     return base
 
@@ -167,18 +167,43 @@ def _build_model_card(model: str) -> str:
         return ""
 
 
-def _build_career_context() -> str:
-    """Build career identity context from ~/.geode/identity/career.toml."""
+def _build_user_context() -> str:
+    """Build user context from profile + career identity.
+
+    Sources:
+      ~/.geode/user_profile/profile.md   — role, expertise, bio
+      ~/.geode/user_profile/preferences.json — language, output format
+      ~/.geode/user_profile/learned.md   — learned patterns
+      ~/.geode/identity/career.toml      — career summary
+    """
     try:
         from core.memory.user_profile import FileBasedUserProfile
 
         profile = FileBasedUserProfile()
-        summary = profile.get_career_summary()
-        if summary:
-            return f"## User Career\n{summary}"
-        return ""
+        parts: list[str] = []
+
+        # Profile summary (role, expertise, lang, skills)
+        context_summary = profile.get_context_summary()
+        if context_summary:
+            parts.append(context_summary)
+
+        # Career summary (title, experience, seeking)
+        career_summary = profile.get_career_summary()
+        if career_summary:
+            parts.append(f"Career: {career_summary}")
+
+        # Learned patterns (last 5)
+        learned = profile.get_learned_patterns()
+        if learned:
+            recent = learned[:5]
+            parts.append("Learned: " + " | ".join(recent))
+
+        if not parts:
+            return ""
+
+        return "## User Context\n" + "\n".join(parts)
     except Exception:
-        log.debug("Failed to build career context", exc_info=True)
+        log.debug("Failed to build user context", exc_info=True)
         return ""
 
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -77,16 +77,23 @@ def bootstrap_geode(
             (serve needs this; REPL typically does not).
     """
     if load_env:
+        import os
         from pathlib import Path
 
-        from dotenv import load_dotenv
+        from dotenv import dotenv_values, load_dotenv
 
+        # 1) Global ~/.geode/.env — baseline for all projects
         global_env = Path.home() / ".geode" / ".env"
         if global_env.exists():
             load_dotenv(str(global_env), override=False)
+
+        # 2) Local .env — override only with non-empty values
+        #    Empty values (e.g. ANTHROPIC_API_KEY=) must NOT clobber global keys
         local_env = Path(".env")
         if local_env.exists():
-            load_dotenv(str(local_env), override=True)
+            for key, val in dotenv_values(str(local_env)).items():
+                if val:  # non-empty only
+                    os.environ[key] = val
 
     # 1. Domain adapter
     try:

--- a/core/memory/project.py
+++ b/core/memory/project.py
@@ -69,9 +69,13 @@ class ProjectMemory:
     def __init__(self, project_root: Path | None = None) -> None:
         root = project_root or Path(".")
         self._geode_dir = root / ".geode"
+        self._global_geode_dir = Path.home() / ".geode"
         self._memory_dir = self._geode_dir / "memory"
         self._memory_file = self._memory_dir / "PROJECT.md"
         self._rules_dir = self._geode_dir / "rules"
+        # Global fallback dirs
+        self._global_memory_dir = self._global_geode_dir / "memory"
+        self._global_rules_dir = self._global_geode_dir / "rules"
 
     @property
     def memory_file(self) -> Path:
@@ -86,11 +90,19 @@ class ProjectMemory:
         return self._memory_file.exists()
 
     def load_memory(self, max_lines: int = MAX_MEMORY_LINES) -> str:
-        """Load MEMORY.md content (first N lines for context window efficiency)."""
-        if not self._memory_file.exists():
-            return ""
+        """Load MEMORY.md content (first N lines for context window efficiency).
+
+        Cascade: project .geode/memory/ → global ~/.geode/memory/
+        """
+        target = self._memory_file
+        if not target.exists():
+            global_file = self._global_memory_dir / "PROJECT.md"
+            if global_file.exists():
+                target = global_file
+            else:
+                return ""
         try:
-            content = self._memory_file.read_text(encoding="utf-8")
+            content = target.read_text(encoding="utf-8")
             lines = content.split("\n")[:max_lines]
             return "\n".join(lines)
         except OSError as e:
@@ -100,17 +112,27 @@ class ProjectMemory:
     def load_rules(self, context: str = "*") -> list[dict[str, Any]]:
         """Load matching rules from .geode/rules/*.md.
 
+        Cascade: global ~/.geode/rules/ → project .geode/rules/
+        Global rules are loaded first, project rules override by name.
+
         Args:
             context: Context string to match against rule paths (e.g. "anime", "berserk").
 
         Returns:
             List of dicts with 'name', 'paths', 'content' for each matching rule.
         """
-        if not self._rules_dir.exists():
+        # Collect rule files: global first, project overrides
+        rule_files: dict[str, Path] = {}
+        for rules_dir in (self._global_rules_dir, self._rules_dir):
+            if rules_dir.exists():
+                for f in sorted(rules_dir.glob("*.md")):
+                    rule_files[f.stem] = f  # project overrides global by name
+
+        if not rule_files:
             return []
 
         matched: list[dict[str, Any]] = []
-        for rule_file in sorted(self._rules_dir.glob("*.md")):
+        for rule_file in rule_files.values():
             try:
                 raw = rule_file.read_text(encoding="utf-8")
             except OSError:

--- a/tests/test_context_hub.py
+++ b/tests/test_context_hub.py
@@ -85,11 +85,11 @@ class TestLoadCareer:
 # ---------------------------------------------------------------------------
 
 
-class TestCareerSystemPrompt:
-    """_build_career_context() injects career data."""
+class TestUserContextSystemPrompt:
+    """_build_user_context() injects user profile + career data."""
 
-    def test_build_career_context_with_data(self, tmp_path: Path) -> None:
-        from core.agent.system_prompt import _build_career_context
+    def test_build_user_context_with_data(self, tmp_path: Path) -> None:
+        from core.agent.system_prompt import _build_user_context
 
         profile_dir = tmp_path / ".geode" / "user_profile"
         profile_dir.mkdir(parents=True)
@@ -98,18 +98,22 @@ class TestCareerSystemPrompt:
             'skills = ["Python"]\n\n[goals]\nseeking = "startup"\n',
             encoding="utf-8",
         )
+        (profile_dir / "profile.md").write_text(
+            '---\nrole: "AI Engineer"\nexpertise: "ML, LLM"\n---\n',
+            encoding="utf-8",
+        )
 
         with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            result = _build_career_context()
+            result = _build_user_context()
 
-        assert "## User Career" in result
+        assert "## User Context" in result
         assert "ML Engineer" in result
 
-    def test_build_career_context_no_data(self, tmp_path: Path) -> None:
-        from core.agent.system_prompt import _build_career_context
+    def test_build_user_context_no_data(self, tmp_path: Path) -> None:
+        from core.agent.system_prompt import _build_user_context
 
         with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
-            result = _build_career_context()
+            result = _build_user_context()
         assert result == ""
 
 


### PR DESCRIPTION
## Summary
- **env cascade 수정**: 로컬 `.env` 빈 값이 `~/.geode/.env` 글로벌 키를 덮어쓰지 않도록 `dotenv_values` 필터링
- **글로벌 메모리 fallback**: `ProjectMemory.load_memory/load_rules`에 `~/.geode/` cascade 추가
- **User Context 주입**: `_build_career_context` → `_build_user_context` 확장 (profile + career + learned patterns)

## Why
Gateway(`geode serve`) Slack 폴링 시 Anthropic API 400 에러 발생. 원인: 프로젝트 `.env`의 빈 `ANTHROPIC_API_KEY=`가 글로벌 키를 clobber. 추가로 유저 프로필이 시스템 프롬프트에 미주입되어 에이전트가 사용자 컨텍스트 없이 응답.

## Test plan
- [x] Lint: `ruff check` 0 errors
- [x] Type: `mypy` 0 errors
- [x] Tests: 174 passed (bootstrap, project_memory, system_prompt, gateway, user_profile)
- [ ] CI 5/5 통과
- [ ] `geode serve` → Slack @GEODE 멘션 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)