### PR TITLE
fix: 서브에이전트 병렬 실행 시 UI 스피너 과다 출력 정돈

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -140,11 +140,13 @@ class AgenticLoop:
         enable_goal_decomposition: bool = True,
         parent_session_key: str = "",
         system_suffix: str = "",
+        quiet: bool = False,
     ) -> None:
         self.context = context
         self.executor = tool_executor
         self._parent_session_key = parent_session_key
         self._system_suffix = system_suffix
+        self._quiet = quiet  # suppress spinner (sub-agent, headless)
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens
         self.model = model or ANTHROPIC_PRIMARY
@@ -343,7 +345,7 @@ class AgenticLoop:
 
             # Show spinner while waiting for LLM response
             label = "Thinking..." if round_idx == 0 else f"Thinking... (round {round_idx + 1})"
-            _spinner = TextSpinner(f"✢ {label}")
+            _spinner = TextSpinner(f"✢ {label}", quiet=self._quiet)
             _spinner.start()
             try:
                 response = await self._call_llm(system_prompt, messages, round_idx=round_idx)

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -601,6 +601,7 @@ class SubAgentManager:
             provider=_resolve_provider(settings.model),
             mcp_manager=self._mcp_manager,
             skill_registry=self._skill_registry,
+            quiet=True,  # suppress spinner — parent handles UI
         )
 
         # 6. Run: use task description as user prompt

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -356,9 +356,7 @@ class ToolExecutor:
             status = "ok" if result.success else "err"
             # Single overwriting line — no scroll flood
             sys.stdout.write(
-                f"\r\x1b[2K  \x1b[2m"
-                f"sub-agent {completed_count}/{total_count} {status}"
-                f"\x1b[0m"
+                f"\r\x1b[2K  \x1b[2msub-agent {completed_count}/{total_count} {status}\x1b[0m"
             )
             sys.stdout.flush()
 

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sys
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -344,20 +345,31 @@ class ToolExecutor:
             for i, t in enumerate(tasks_raw)
         ]
 
-        # P2-C: progress callback — update spinner on each sub-agent completion
+        # P2-C: progress callback — consolidated progress line (Claude Code pattern)
         completed_count = 0
         total_count = len(sub_tasks)
+        _start_ts = time.time()
 
         def _on_progress(result: Any) -> None:
             nonlocal completed_count
             completed_count += 1
-            status_icon = "[green]ok[/green]" if result.success else "[red]err[/red]"
-            console.print(
-                f"  [dim]  sub-agent {completed_count}/{total_count}"
-                f" {status_icon} {result.task_id}[/dim]"
+            status = "ok" if result.success else "err"
+            # Single overwriting line — no scroll flood
+            sys.stdout.write(
+                f"\r\x1b[2K  \x1b[2m"
+                f"sub-agent {completed_count}/{total_count} {status}"
+                f"\x1b[0m"
             )
+            sys.stdout.flush()
 
         results = self._sub_agent_manager.delegate(sub_tasks, on_progress=_on_progress)
+
+        # Clear progress line and show final summary
+        sys.stdout.write("\r\x1b[2K")
+        sys.stdout.flush()
+        from core.cli.ui.agentic_ui import render_subagent_complete
+
+        render_subagent_complete(len(results), time.time() - _start_ts)
 
         # P2-A: unified response format (single and batch identical)
         succeeded = sum(1 for r in results if r.success)

--- a/core/cli/ui/status.py
+++ b/core/cli/ui/status.py
@@ -38,12 +38,15 @@ class TextSpinner:
         "\u280f",
     ]
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, *, quiet: bool = False) -> None:
         self._message = message
         self._running = False
         self._thread: threading.Thread | None = None
+        self._quiet = quiet  # suppress output (sub-agent, headless)
 
     def start(self) -> None:
+        if self._quiet:
+            return
         self._running = True
         self._thread = threading.Thread(target=self._animate, daemon=True)
         self._thread.start()
@@ -63,6 +66,8 @@ class TextSpinner:
 
     def stop(self, final_message: str = "") -> None:
         self._running = False
+        if self._quiet:
+            return
         if self._thread:
             self._thread.join(timeout=0.2)
         sys.stdout.write("\r\x1b[2K")


### PR DESCRIPTION
## Summary
- **Sub-agent 스피너 억제**: TextSpinner에 `quiet` 모드 추가, sub-agent는 자체 스피너 비활성
- **통합 진행 표시**: `_on_progress`를 단일 덮어쓰기 라인으로 교체 (Claude Code pattern)
- **render_subagent_complete 활성화**: 기존 미사용 함수를 delegate_task 완료 시 호출

## Why
서브에이전트 병렬 실행 시 각 agent가 독립적으로 TextSpinner 데몬 스레드를 실행하여 `\x1b[2K` 클리어 라인이 폭발. `_on_progress` 콜백도 매 완료마다 `console.print`를 호출하여 부모 스피너와 경합 → 터미널 읽기 불가.

## Frontier Reference
- Claude Code: single spinner per LLM turn + progressive log collapse at threshold 5
- Codex CLI: serialized event stream, single event queue for all concurrent operations

## Test plan
- [x] Lint: 0 errors
- [x] Type: 0 errors
- [x] Tests: 138 passed (spinner, status, sub_agent, agentic_loop, tool_executor)
- [ ] CI 5/5 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)