### PR TITLE
feat: /compact, /clear + 모델 스위칭 컨텍스트 가드

### DIFF
--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -68,6 +68,7 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "profile_learn",
         "calendar_create_event",
         "calendar_sync_scheduler",
+        "manage_context",
     }
 )
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -534,6 +534,14 @@ def _handle_command(
         cmd_context(args)
     elif action == "apply":
         cmd_apply(args)
+    elif action == "compact":
+        from core.cli.commands import cmd_compact
+
+        cmd_compact(args)
+    elif action == "clear":
+        from core.cli.commands import cmd_clear
+
+        cmd_clear(args)
     else:
         console.print(f"  [warning]Unknown command: {cmd}[/warning]")
         console.print("  [muted]Type /help for available commands.[/muted]")
@@ -910,6 +918,11 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     """
     verbose = False
     conversation = ConversationContext()
+
+    # Inject ConversationContext for slash commands (/compact, /clear, /model guard)
+    from core.cli.commands import set_conversation_context
+
+    set_conversation_context(conversation)
 
     # --- Unified bootstrap (domain, memory, readiness, MCP, skills) ---
     from core.cli.bootstrap import bootstrap_geode

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -56,6 +56,22 @@ MODEL_PROFILES: list[ModelProfile] = [
 
 _MODEL_INDEX: dict[str, ModelProfile] = {m.id: m for m in MODEL_PROFILES}
 
+# ---------------------------------------------------------------------------
+# Conversation Context ContextVar (shared with tool handlers)
+# ---------------------------------------------------------------------------
+
+_conversation_ctx: ContextVar[_Any] = ContextVar("conversation_ctx", default=None)
+
+
+def set_conversation_context(ctx: _Any) -> None:
+    """Inject the active ConversationContext for command handlers."""
+    _conversation_ctx.set(ctx)
+
+
+def get_conversation_context() -> _Any:
+    """Retrieve the active ConversationContext (None if not set)."""
+    return _conversation_ctx.get(None)
+
 
 # ---------------------------------------------------------------------------
 # Command Map (OpenClaw Binding pattern: deterministic routing)
@@ -95,6 +111,8 @@ COMMAND_MAP: dict[str, str] = {
     "/context": "context",
     "/ctx": "context",
     "/apply": "apply",
+    "/compact": "compact",
+    "/clear": "clear",
 }
 
 
@@ -125,6 +143,8 @@ def show_help() -> None:
     console.print("  [label]/resume[/label]             — Resume interrupted session")
     console.print("  [label]/context[/label]            — Show assembled context tiers")
     console.print("  [label]/apply[/label]              — Manage job applications")
+    console.print("  [label]/compact[/label]            — Compact conversation context")
+    console.print("  [label]/clear[/label]              — Clear conversation history")
     console.print("  [label]/help[/label]               — Show this help")
     console.print("  [label]/quit[/label]               — Exit GEODE")
     console.print()
@@ -265,7 +285,11 @@ def _check_provider_key(selected: ModelProfile) -> None:
 
 
 def _apply_model(selected: ModelProfile) -> None:
-    """Apply a model selection — update settings + .env."""
+    """Apply a model selection — update settings + .env.
+
+    Includes context window guard: blocks downgrade when current context
+    exceeds 80% of the target model's window.
+    """
     from core.config import settings
 
     old = settings.model
@@ -275,6 +299,30 @@ def _apply_model(selected: ModelProfile) -> None:
         return
 
     _check_provider_key(selected)
+
+    # --- Context Window Guard ---
+    ctx = get_conversation_context()
+    if ctx is not None and ctx.messages:
+        from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
+        from core.orchestration.context_monitor import estimate_message_tokens
+
+        current_tokens = estimate_message_tokens(ctx.messages)
+        target_window = MODEL_CONTEXT_WINDOW.get(selected.id, 200_000)
+        threshold = int(target_window * 0.8)
+
+        if current_tokens > threshold:
+            console.print()
+            console.print(
+                f"  [warning]Context guard: {current_tokens:,} tokens "
+                f"exceeds {selected.label} limit "
+                f"({target_window:,} x 80% = {threshold:,})[/warning]"
+            )
+            console.print(
+                "  [muted]Run /compact or /clear first, "
+                "then retry /model.[/muted]"
+            )
+            console.print()
+            return
 
     settings.model = selected.id
     _upsert_env("GEODE_MODEL", selected.id)
@@ -1592,6 +1640,109 @@ def cmd_context(args: str) -> None:
 
     console.print()
     console.print("  [muted]Subcommands: /context career | /context profile[/muted]")
+    console.print()
+
+
+# ---------------------------------------------------------------------------
+# /compact — Context Budget compaction (Karpathy P6)
+# ---------------------------------------------------------------------------
+
+
+def cmd_compact(args: str) -> None:
+    """Compact conversation context to fit within model budget.
+
+    /compact         -> compact to current model's 70% budget
+    /compact --hard  -> keep only last 1 turn
+    """
+    from core.config import settings
+    from core.orchestration.context_monitor import (
+        adaptive_prune,
+        check_context,
+        summarize_tool_results,
+    )
+
+    ctx = get_conversation_context()
+    if ctx is None or not ctx.messages:
+        console.print("  [muted]Nothing to compact.[/muted]")
+        console.print()
+        return
+
+    before = check_context(ctx.messages, settings.model)
+    console.print()
+    console.print(
+        f"  [label]Before:[/label] {before.estimated_tokens:,} tokens "
+        f"({before.usage_pct:.0f}% of {settings.model} "
+        f"{before.context_window:,})"
+    )
+
+    hard = "--hard" in args
+    if hard:
+        last_pair = (
+            ctx.messages[-2:]
+            if len(ctx.messages) >= 2
+            else list(ctx.messages)
+        )
+        ctx.messages.clear()
+        ctx.messages.extend(last_pair)
+    else:
+        summarize_tool_results(ctx.messages, before.context_window)
+        compacted = adaptive_prune(ctx.messages, before.context_window)
+        ctx.messages.clear()
+        ctx.messages.extend(compacted)
+
+    ctx._sanitize_tool_pairs()
+
+    after = check_context(ctx.messages, settings.model)
+    console.print(
+        f"  [label]After:[/label]  {after.estimated_tokens:,} tokens "
+        f"({after.usage_pct:.0f}% of {settings.model} "
+        f"{after.context_window:,})"
+    )
+    console.print(
+        f"  [success]Compacted[/success]  "
+        f"{before.estimated_tokens:,} → {after.estimated_tokens:,} tokens"
+    )
+    console.print()
+
+
+# ---------------------------------------------------------------------------
+# /clear — Clear conversation history
+# ---------------------------------------------------------------------------
+
+
+def cmd_clear(args: str) -> None:
+    """Clear conversation context entirely.
+
+    /clear         -> confirm prompt before clearing
+    /clear --force -> clear without confirmation
+    """
+    ctx = get_conversation_context()
+    if ctx is None or not ctx.messages:
+        console.print("  [muted]Conversation already empty.[/muted]")
+        console.print()
+        return
+
+    msg_count = len(ctx.messages)
+    console.print()
+
+    if "--force" not in args:
+        console.print(
+            f"  Clear all {msg_count} messages? (y/N): ", end=""
+        )
+        try:
+            answer = input().strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        if answer != "y":
+            console.print("  [muted]Cancelled.[/muted]")
+            console.print()
+            return
+
+    ctx.clear()
+    console.print(
+        f"  [success]Conversation cleared[/success] "
+        f"({msg_count} messages removed)"
+    )
     console.print()
 
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -317,10 +317,7 @@ def _apply_model(selected: ModelProfile) -> None:
                 f"exceeds {selected.label} limit "
                 f"({target_window:,} x 80% = {threshold:,})[/warning]"
             )
-            console.print(
-                "  [muted]Run /compact or /clear first, "
-                "then retry /model.[/muted]"
-            )
+            console.print("  [muted]Run /compact or /clear first, then retry /model.[/muted]")
             console.print()
             return
 
@@ -1677,11 +1674,7 @@ def cmd_compact(args: str) -> None:
 
     hard = "--hard" in args
     if hard:
-        last_pair = (
-            ctx.messages[-2:]
-            if len(ctx.messages) >= 2
-            else list(ctx.messages)
-        )
+        last_pair = ctx.messages[-2:] if len(ctx.messages) >= 2 else list(ctx.messages)
         ctx.messages.clear()
         ctx.messages.extend(last_pair)
     else:
@@ -1726,9 +1719,7 @@ def cmd_clear(args: str) -> None:
     console.print()
 
     if "--force" not in args:
-        console.print(
-            f"  Clear all {msg_count} messages? (y/N): ", end=""
-        )
+        console.print(f"  Clear all {msg_count} messages? (y/N): ", end="")
         try:
             answer = input().strip().lower()
         except (EOFError, KeyboardInterrupt):
@@ -1739,10 +1730,7 @@ def cmd_clear(args: str) -> None:
             return
 
     ctx.clear()
-    console.print(
-        f"  [success]Conversation cleared[/success] "
-        f"({msg_count} messages removed)"
-    )
+    console.print(f"  [success]Conversation cleared[/success] ({msg_count} messages removed)")
     console.print()
 
 

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -1061,6 +1061,84 @@ def _build_mcp_handler(
 
 
 # ---------------------------------------------------------------------------
+# Context management handlers
+# ---------------------------------------------------------------------------
+
+
+def _build_context_handlers() -> dict[str, Any]:
+    """Build context management tool handlers (manage_context)."""
+
+    def handle_manage_context(**kwargs: Any) -> dict[str, Any]:
+        action = kwargs.get("action", "status")
+        force = kwargs.get("force", False)
+
+        from core.cli.commands import get_conversation_context
+        from core.config import settings
+        from core.orchestration.context_monitor import check_context
+
+        ctx = get_conversation_context()
+        if ctx is None:
+            return {"error": "No active conversation context"}
+
+        if action == "status":
+            if not ctx.messages:
+                return {
+                    "status": "ok",
+                    "action": "status",
+                    "messages": 0,
+                    "estimated_tokens": 0,
+                }
+            metrics = check_context(ctx.messages, settings.model)
+            return {
+                "status": "ok",
+                "action": "status",
+                "messages": len(ctx.messages),
+                "estimated_tokens": metrics.estimated_tokens,
+                "context_window": metrics.context_window,
+                "usage_pct": round(metrics.usage_pct, 1),
+                "model": settings.model,
+            }
+        elif action == "compact":
+            from core.cli.commands import cmd_compact
+
+            cmd_compact("--hard" if force else "")
+            if ctx.messages:
+                metrics = check_context(ctx.messages, settings.model)
+                return {
+                    "status": "ok",
+                    "action": "compacted",
+                    "messages_after": len(ctx.messages),
+                    "estimated_tokens": metrics.estimated_tokens,
+                    "usage_pct": round(metrics.usage_pct, 1),
+                }
+            return {
+                "status": "ok",
+                "action": "compacted",
+                "messages_after": 0,
+                "estimated_tokens": 0,
+                "usage_pct": 0.0,
+            }
+        elif action == "clear":
+            if not force:
+                return {
+                    "status": "confirmation_needed",
+                    "action": "clear",
+                    "summary": (
+                        f"대화 기록 {len(ctx.messages)}개 "
+                        "메시지를 삭제합니다. "
+                        "force=true로 확인하세요."
+                    ),
+                    "messages_count": len(ctx.messages),
+                }
+            ctx.clear()
+            return {"status": "ok", "action": "cleared"}
+
+        return {"error": f"Unknown action: {action}"}
+
+    return {"manage_context": handle_manage_context}
+
+
+# ---------------------------------------------------------------------------
 # Public API: dispatcher
 # ---------------------------------------------------------------------------
 
@@ -1098,6 +1176,7 @@ def _build_tool_handlers(
     handlers.update(_build_notification_handlers())
     handlers.update(_build_calendar_handlers())
     handlers.update(_build_mcp_handler(mcp_manager, agentic_ref))
+    handlers.update(_build_context_handlers())
     return handlers
 
 

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -1072,5 +1072,26 @@
       },
       "required": []
     }
+  },
+  {
+    "name": "manage_context",
+    "description": "대화 컨텍스트를 관리합니다. 사용자가 '컨텍스트 정리', '대화 초기화', '컨텍스트 줄여줘', 'compact', 'clear context', '대화 리셋', '토큰 확인' 등을 요청할 때 사용하세요.",
+    "category": "model",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["compact", "clear", "status"],
+          "description": "compact: 대화 압축, clear: 전체 초기화, status: 현재 토큰 사용량 확인"
+        },
+        "force": {
+          "type": "boolean",
+          "description": "true이면 확인 없이 실행 (clear 시 적용). 기본값 false."
+        }
+      },
+      "required": ["action"]
+    }
   }
 ]

--- a/tests/test_compact_clear.py
+++ b/tests/test_compact_clear.py
@@ -23,24 +23,18 @@ def _make_msg(role: str, text: str) -> dict[str, Any]:
 def _make_tool_result(tool_use_id: str, content: str) -> dict[str, Any]:
     return {
         "role": "user",
-        "content": [
-            {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
-        ],
+        "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": content}],
     }
 
 
 def _make_tool_use_assistant(tool_use_id: str, name: str) -> dict[str, Any]:
     return {
         "role": "assistant",
-        "content": [
-            {"type": "tool_use", "id": tool_use_id, "name": name, "input": {}}
-        ],
+        "content": [{"type": "tool_use", "id": tool_use_id, "name": name, "input": {}}],
     }
 
 
-def _build_conversation(
-    n_pairs: int, tool_result_size: int = 100
-) -> list[dict[str, Any]]:
+def _build_conversation(n_pairs: int, tool_result_size: int = 100) -> list[dict[str, Any]]:
     """Build conversation with n tool_use/tool_result pairs."""
     msgs: list[dict[str, Any]] = [_make_msg("user", "initial question")]
     for i in range(n_pairs):
@@ -232,9 +226,7 @@ class TestModelSwitchGuard:
     def _make_profile(self, model_id: str, label: str) -> Any:
         from core.cli.commands import ModelProfile
 
-        return ModelProfile(
-            id=model_id, provider="test", label=label, cost="$"
-        )
+        return ModelProfile(id=model_id, provider="test", label=label, cost="$")
 
     @patch("core.cli.commands._upsert_env")
     @patch("core.cli.commands._check_provider_key")
@@ -397,9 +389,7 @@ class TestEscalationCompact:
         loop.model = "glm-5"
         loop.context = context
         loop._provider = "glm"
-        loop._adapter = MagicMock(
-            fallback_chain=["glm-5", "glm-5-turbo", "glm-4.7-flash"]
-        )
+        loop._adapter = MagicMock(fallback_chain=["glm-5", "glm-5-turbo", "glm-4.7-flash"])
         loop.update_model = MagicMock()
 
         from core.agent.agentic_loop import AgenticLoop

--- a/tests/test_compact_clear.py
+++ b/tests/test_compact_clear.py
@@ -1,0 +1,426 @@
+"""Tests for /compact, /clear, manage_context tool, and model switch guard."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from core.orchestration.context_monitor import (
+    adaptive_prune,
+    estimate_message_tokens,
+    summarize_tool_results,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_msg(role: str, text: str) -> dict[str, Any]:
+    return {"role": role, "content": text}
+
+
+def _make_tool_result(tool_use_id: str, content: str) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
+        ],
+    }
+
+
+def _make_tool_use_assistant(tool_use_id: str, name: str) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": tool_use_id, "name": name, "input": {}}
+        ],
+    }
+
+
+def _build_conversation(
+    n_pairs: int, tool_result_size: int = 100
+) -> list[dict[str, Any]]:
+    """Build conversation with n tool_use/tool_result pairs."""
+    msgs: list[dict[str, Any]] = [_make_msg("user", "initial question")]
+    for i in range(n_pairs):
+        msgs.append(_make_tool_use_assistant(f"tool_{i}", "web_fetch"))
+        msgs.append(_make_tool_result(f"tool_{i}", "x" * tool_result_size))
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# TestSummarizeToolResults
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeToolResults:
+    def test_small_results_unchanged(self):
+        msgs = _build_conversation(3, tool_result_size=50)
+        count = summarize_tool_results(msgs, target_window=100_000)
+        assert count == 0
+
+    def test_large_result_summarized(self):
+        msgs = [
+            _make_msg("user", "hello"),
+            _make_tool_use_assistant("t1", "web_fetch"),
+            _make_tool_result("t1", "x" * 10_000),
+        ]
+        count = summarize_tool_results(msgs, target_window=10_000)
+        assert count == 1
+        result_block = msgs[2]["content"][0]
+        assert "[summarized:" in result_block["content"]
+        assert result_block["type"] == "tool_result"
+        assert result_block["tool_use_id"] == "t1"
+
+    def test_idempotent(self):
+        msgs = [
+            _make_msg("user", "hello"),
+            _make_tool_use_assistant("t1", "web_fetch"),
+            _make_tool_result("t1", "x" * 10_000),
+        ]
+        summarize_tool_results(msgs, target_window=10_000)
+        count = summarize_tool_results(msgs, target_window=10_000)
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# TestAdaptivePrune
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptivePrune:
+    def test_under_budget_no_change(self):
+        msgs = [_make_msg("user", "hi"), _make_msg("assistant", "hello")]
+        result = adaptive_prune(msgs, target_tokens=100_000)
+        assert len(result) == 2
+
+    def test_preserves_first_message(self):
+        msgs = _build_conversation(20, tool_result_size=500)
+        result = adaptive_prune(msgs, target_tokens=5_000)
+        assert result[0] == msgs[0]
+
+    def test_preserves_last_pair(self):
+        msgs = _build_conversation(20, tool_result_size=500)
+        result = adaptive_prune(msgs, target_tokens=5_000)
+        assert result[-1] == msgs[-1]
+        assert result[-2] == msgs[-2]
+
+    def test_prunes_large_conversation(self):
+        msgs = _build_conversation(50, tool_result_size=1000)
+        result = adaptive_prune(msgs, target_tokens=10_000)
+        assert len(result) < len(msgs)
+
+    def test_returns_new_list(self):
+        msgs = _build_conversation(5)
+        result = adaptive_prune(msgs, target_tokens=100_000)
+        assert result is not msgs
+
+    def test_within_budget(self):
+        msgs = _build_conversation(10, tool_result_size=200)
+        result = adaptive_prune(msgs, target_tokens=50_000)
+        tokens = estimate_message_tokens(result)
+        assert tokens <= 50_000 * 0.7 + 1000
+
+
+# ---------------------------------------------------------------------------
+# TestUsagePctUncapped
+# ---------------------------------------------------------------------------
+
+
+class TestUsagePctUncapped:
+    def test_usage_pct_exceeds_100(self):
+        """usage_pct should reflect actual value, not capped at 100."""
+        from core.orchestration.context_monitor import check_context
+
+        msgs = [_make_msg("user", "x" * 400_000)]
+        # Patch at the import source inside check_context
+        with patch(
+            "core.llm.token_tracker.MODEL_CONTEXT_WINDOW",
+            {"tiny-model": 10_000},
+        ):
+            metrics = check_context(msgs, "tiny-model")
+            assert metrics.usage_pct > 100.0
+
+
+# ---------------------------------------------------------------------------
+# TestCmdCompact
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCompact:
+    def _make_ctx(self, messages: list[dict[str, Any]]) -> MagicMock:
+        ctx = MagicMock()
+        ctx.messages = messages
+        ctx._sanitize_tool_pairs = MagicMock()
+        return ctx
+
+    def test_compact_empty(self):
+        from core.cli.commands import cmd_compact, set_conversation_context
+
+        set_conversation_context(None)
+        cmd_compact("")  # should not raise
+
+    def test_compact_normal(self):
+        from core.cli.commands import cmd_compact, set_conversation_context
+
+        msgs = _build_conversation(10, tool_result_size=500)
+        ctx = self._make_ctx(msgs)
+        set_conversation_context(ctx)
+
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "glm-5"
+            cmd_compact("")
+
+        ctx._sanitize_tool_pairs.assert_called_once()
+
+    def test_compact_hard(self):
+        from core.cli.commands import cmd_compact, set_conversation_context
+
+        msgs = _build_conversation(10, tool_result_size=500)
+        ctx = self._make_ctx(msgs)
+        set_conversation_context(ctx)
+
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "glm-5"
+            cmd_compact("--hard")
+
+        assert len(ctx.messages) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestCmdClear
+# ---------------------------------------------------------------------------
+
+
+class TestCmdClear:
+    def test_clear_empty(self):
+        from core.cli.commands import cmd_clear, set_conversation_context
+
+        ctx = MagicMock()
+        ctx.messages = []
+        set_conversation_context(ctx)
+        cmd_clear("")
+        ctx.clear.assert_not_called()
+
+    def test_clear_with_force(self):
+        from core.cli.commands import cmd_clear, set_conversation_context
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "hi"), _make_msg("assistant", "hello")]
+        set_conversation_context(ctx)
+        cmd_clear("--force")
+        ctx.clear.assert_called_once()
+
+    @patch("builtins.input", return_value="n")
+    def test_clear_cancel(self, mock_input: MagicMock):
+        from core.cli.commands import cmd_clear, set_conversation_context
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "hi")]
+        set_conversation_context(ctx)
+        cmd_clear("")
+        ctx.clear.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestModelSwitchGuard
+# ---------------------------------------------------------------------------
+
+
+class TestModelSwitchGuard:
+    def _make_profile(self, model_id: str, label: str) -> Any:
+        from core.cli.commands import ModelProfile
+
+        return ModelProfile(
+            id=model_id, provider="test", label=label, cost="$"
+        )
+
+    @patch("core.cli.commands._upsert_env")
+    @patch("core.cli.commands._check_provider_key")
+    def test_downgrade_blocked(
+        self,
+        mock_key: MagicMock,
+        mock_env: MagicMock,
+    ):
+        from core.cli.commands import (
+            _apply_model,
+            set_conversation_context,
+        )
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "x" * 400_000)]
+        set_conversation_context(ctx)
+
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "claude-opus-4-6"
+            profile = self._make_profile("glm-5", "GLM-5")
+            _apply_model(profile)
+
+        mock_env.assert_not_called()
+
+    @patch("core.cli.commands._upsert_env")
+    @patch("core.cli.commands._check_provider_key")
+    def test_downgrade_allowed_when_fits(
+        self,
+        mock_key: MagicMock,
+        mock_env: MagicMock,
+    ):
+        from core.cli.commands import (
+            _apply_model,
+            set_conversation_context,
+        )
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "small context")]
+        set_conversation_context(ctx)
+
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "claude-opus-4-6"
+            profile = self._make_profile("glm-5", "GLM-5")
+            _apply_model(profile)
+
+        mock_env.assert_called_once()
+
+    @patch("core.cli.commands._upsert_env")
+    @patch("core.cli.commands._check_provider_key")
+    def test_upgrade_always_allowed(
+        self,
+        mock_key: MagicMock,
+        mock_env: MagicMock,
+    ):
+        from core.cli.commands import (
+            _apply_model,
+            set_conversation_context,
+        )
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "x" * 400_000)]
+        set_conversation_context(ctx)
+
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "glm-5"
+            profile = self._make_profile("claude-opus-4-6", "Opus 4.6")
+            _apply_model(profile)
+
+        mock_env.assert_called_once()
+
+    @patch("core.cli.commands._upsert_env")
+    @patch("core.cli.commands._check_provider_key")
+    def test_same_model_no_guard(
+        self,
+        mock_key: MagicMock,
+        mock_env: MagicMock,
+    ):
+        from core.cli.commands import _apply_model
+
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "glm-5"
+            profile = self._make_profile("glm-5", "GLM-5")
+            _apply_model(profile)
+
+        mock_env.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestManageContextHandler
+# ---------------------------------------------------------------------------
+
+
+class TestManageContextHandler:
+    def test_status(self):
+        from core.cli.commands import set_conversation_context
+        from core.cli.tool_handlers import _build_context_handlers
+
+        ctx = MagicMock()
+        ctx.messages = [
+            _make_msg("user", "hi"),
+            _make_msg("assistant", "hello"),
+        ]
+        set_conversation_context(ctx)
+
+        handlers = _build_context_handlers()
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.model = "claude-opus-4-6"
+            result = handlers["manage_context"](action="status")
+
+        assert result["status"] == "ok"
+        assert result["messages"] == 2
+
+    def test_clear_needs_force(self):
+        from core.cli.commands import set_conversation_context
+        from core.cli.tool_handlers import _build_context_handlers
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "hi")]
+        set_conversation_context(ctx)
+
+        handlers = _build_context_handlers()
+        result = handlers["manage_context"](action="clear", force=False)
+        assert result["status"] == "confirmation_needed"
+        ctx.clear.assert_not_called()
+
+    def test_clear_with_force(self):
+        from core.cli.commands import set_conversation_context
+        from core.cli.tool_handlers import _build_context_handlers
+
+        ctx = MagicMock()
+        ctx.messages = [_make_msg("user", "hi")]
+        set_conversation_context(ctx)
+
+        handlers = _build_context_handlers()
+        result = handlers["manage_context"](action="clear", force=True)
+        assert result["status"] == "ok"
+        ctx.clear.assert_called_once()
+
+    def test_no_context(self):
+        from core.cli.commands import set_conversation_context
+        from core.cli.tool_handlers import _build_context_handlers
+
+        set_conversation_context(None)
+        handlers = _build_context_handlers()
+        result = handlers["manage_context"](action="status")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# TestEscalationCompact
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationCompact:
+    def test_escalation_compacts_when_needed(self):
+        context = MagicMock()
+        context.messages = [_make_msg("user", "x" * 400_000)]
+
+        loop = MagicMock()
+        loop.model = "glm-5"
+        loop.context = context
+        loop._provider = "glm"
+        loop._adapter = MagicMock(
+            fallback_chain=["glm-5", "glm-5-turbo", "glm-4.7-flash"]
+        )
+        loop.update_model = MagicMock()
+
+        from core.agent.agentic_loop import AgenticLoop
+
+        result = AgenticLoop._try_model_escalation(loop)
+        assert result is True
+        loop.update_model.assert_called_once()
+
+    def test_escalation_no_compact_when_fits(self):
+        context = MagicMock()
+        context.messages = [_make_msg("user", "small")]
+
+        loop = MagicMock()
+        loop.model = "glm-5"
+        loop.context = context
+        loop._provider = "glm"
+        loop._adapter = MagicMock(fallback_chain=["glm-5", "glm-5-turbo"])
+        loop.update_model = MagicMock()
+
+        from core.agent.agentic_loop import AgenticLoop
+
+        result = AgenticLoop._try_model_escalation(loop)
+        assert result is True
+        loop.update_model.assert_called_once()


### PR DESCRIPTION
## Summary
- `/compact` 명령: Context Budget 패턴으로 대화 압축 (도구 결과 요약 + 토큰 기반 pruning)
- `/clear` 명령: 대화 히스토리 초기화 (`--force` 옵션)
- `manage_context` 도구: 자연어 라우팅으로 compact/clear/status 실행 (WRITE 권한)
- 모델 스위칭 가드: 다운그레이드 시 컨텍스트 80% 초과면 차단 + `/compact` 또는 `/clear` 안내

## Why
Opus(1M)에서 12분간 1.7M 토큰 누적 후 `/model`로 GLM-5(80K) 전환 시, 192K 토큰이 80K를 초과하여 전 모델 exhausted 장애 발생. 리서치: `docs/research/model-switch-context-management.md`

## Changes (6 files, +692)
- `core/cli/commands.py`: ContextVar 인프라 + COMMAND_MAP + cmd_compact + cmd_clear + _apply_model 가드
- `core/cli/__init__.py`: set_conversation_context 호출 + compact/clear 분기
- `core/cli/tool_handlers.py`: _build_context_handlers (manage_context 핸들러)
- `core/tools/definitions.json`: manage_context 도구 (#47)
- `core/agent/tool_executor.py`: WRITE_TOOLS + manage_context
- `tests/test_compact_clear.py`: 26개 테스트

## Test plan
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run pytest tests/test_compact_clear.py -v` — 26 passed
- [x] `uv run pytest tests/ -m "not live" -q` — 3134 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)