### PR TITLE
Merge develop — signal tools MCP live integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Signal Tools MCP Live Integration** — 5개 signal stub 도구를 MCP-first + fixture fallback 패턴으로 전환. YouTube(youtube MCP), Reddit(reddit MCP), Twitch(igdb MCP), Steam(steam MCP), Google Trends(google-trends MCP) 서버 연동. `source` 필드로 데이터 출처 추적 (`*_mcp_live` / `*_api_stub`).
+- **MCP DEFAULT_SERVERS 확장** — reddit, google-trends를 키 불필요 기본 서버로 등록. youtube-transcript 카탈로그 항목 추가.
+- **Signal MCP 테스트 28건** — MCP 라이브 경로, fixture 폴백, 에러 핸들링 검증.
+
 ## [0.25.1] — 2026-03-25
 
 MCP REPL 프롬프트 지연 해소.

--- a/core/mcp/catalog.py
+++ b/core/mcp/catalog.py
@@ -273,6 +273,12 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
         description="Browser automation via Playwright (navigate, click, scrape)",
         tags=("browser", "playwright", "automation", "scrape"),
     ),
+    "youtube-transcript": MCPCatalogEntry(
+        name="youtube-transcript",
+        package="@fabriqa.ai/youtube-transcript-mcp@latest",
+        description="YouTube video transcript extraction with language selection and timestamps",
+        tags=("youtube", "transcript", "video", "chapter", "subtitle", "timeline"),
+    ),
     # --- Financial ---
     "financial-datasets": MCPCatalogEntry(
         name="financial-datasets",

--- a/core/mcp/registry.py
+++ b/core/mcp/registry.py
@@ -51,6 +51,9 @@ DEFAULT_SERVERS: tuple[str, ...] = (
     "playwright",
     "arxiv",
     "gmail",
+    "youtube-transcript",
+    "reddit",
+    "google-trends",
 )
 
 # ---------------------------------------------------------------------------

--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -1,30 +1,107 @@
 """Signal Collection Tools — external signal retrieval as LLM-callable tools.
 
-Layer 5 tools for external signal collection (demo/stub):
-- YouTubeSearchTool: YouTube engagement data
-- RedditSentimentTool: Reddit community sentiment
-- TwitchStatsTool: Twitch streaming statistics
-- SteamInfoTool: Steam store/review data
-- GoogleTrendsTool: Google Trends interest data
+Layer 4 tools for external signal collection:
+- YouTubeSearchTool: YouTube engagement data (MCP -> fixture fallback)
+- RedditSentimentTool: Reddit community sentiment (MCP -> fixture fallback)
+- TwitchStatsTool: Twitch streaming statistics (MCP -> fixture fallback)
+- SteamInfoTool: Steam store/review data (MCP -> fixture fallback)
+- GoogleTrendsTool: Google Trends interest data (MCP -> fixture fallback)
 - WebSearchTool: Anthropic native web search for real-time signal enrichment
 
-All tools return fixture data for known IPs and plausible
-stub data for unknown IPs.
+Each tool tries MCP server first, then falls back to fixture data.
+The ``source`` field in results indicates data provenance.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from core.config import ANTHROPIC_BUDGET
 from core.domains.game_ip.fixtures import load_fixture
 
+log = logging.getLogger(__name__)
+
 # Load parameter schemas from centralized JSON
 _SCHEMAS_PATH = Path(__file__).resolve().parent / "tool_schemas.json"
 with _SCHEMAS_PATH.open(encoding="utf-8") as _f:
     _TOOL_SCHEMAS: dict[str, dict[str, Any]] = json.load(_f)
+
+
+# ---------------------------------------------------------------------------
+# MCP helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_mcp_content(result: dict[str, Any]) -> dict[str, Any]:
+    """Extract structured data from MCP tool result.
+
+    MCP tools return ``content`` array with text/image blocks.
+    Tries to parse text content as JSON, falls back to raw text dict.
+    Some non-standard servers may return data keys directly.
+    """
+    content = result.get("content")
+    if not isinstance(content, list) or not content:
+        # Direct dict with data keys (non-standard) — return as-is
+        return result
+
+    texts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text", "")
+            # Try parsing as JSON first
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, dict):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+            texts.append(text)
+
+    if texts:
+        return {"text": "\n".join(texts)}
+    return result
+
+
+def _try_mcp_signal(
+    server_name: str,
+    tool_name: str,
+    args: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Try calling an MCP tool. Returns parsed result dict or None on failure.
+
+    Lazily imports MCPServerManager to avoid circular imports.
+    Never raises -- all errors are caught and logged.
+    """
+    try:
+        from core.mcp.manager import get_mcp_manager
+
+        manager = get_mcp_manager()
+        health = manager.check_health()
+        if not health.get(server_name, False):
+            return None
+
+        result = manager.call_tool(server_name, tool_name, args)
+        if "error" in result:
+            log.debug(
+                "MCP signal %s/%s error: %s",
+                server_name,
+                tool_name,
+                result["error"],
+            )
+            return None
+
+        return _parse_mcp_content(result)
+    except Exception as exc:
+        log.debug("MCP signal %s/%s failed: %s", server_name, tool_name, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
 
 
 def _load_signal(ip_name: str, key: str, default: Any = None) -> Any:
@@ -34,6 +111,11 @@ def _load_signal(ip_name: str, key: str, default: Any = None) -> Any:
         return fixture.get("signals", {}).get(key, default)
     except ValueError:
         return default
+
+
+# ---------------------------------------------------------------------------
+# Signal Tools
+# ---------------------------------------------------------------------------
 
 
 class YouTubeSearchTool:
@@ -56,6 +138,23 @@ class YouTubeSearchTool:
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         ip_name: str = kwargs["ip_name"]
+
+        # Tier 1: YouTube MCP server
+        mcp = _try_mcp_signal("youtube", "search_videos", {"query": ip_name})
+        if mcp is not None:
+            return {
+                "result": {
+                    "ip_name": ip_name,
+                    "total_views": mcp.get("total_views", mcp.get("view_count", 0)),
+                    "top_video_views": mcp.get("top_video_views", 0),
+                    "avg_comment_sentiment": mcp.get("avg_sentiment", 0.0),
+                    "video_count": mcp.get("video_count", mcp.get("total_results", 0)),
+                    "source": "youtube_mcp_live",
+                    "raw_mcp": mcp.get("text") if "text" in mcp else None,
+                }
+            }
+
+        # Tier 2: Fixture fallback
         views = _load_signal(ip_name, "youtube_views", 0)
         return {
             "result": {
@@ -89,6 +188,25 @@ class RedditSentimentTool:
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         ip_name: str = kwargs["ip_name"]
+
+        # Tier 1: Reddit MCP server
+        mcp = _try_mcp_signal("reddit", "search_posts", {"query": ip_name})
+        if mcp is not None:
+            return {
+                "result": {
+                    "ip_name": ip_name,
+                    "subreddit_subscribers": mcp.get(
+                        "subscribers", mcp.get("subreddit_subscribers", 0)
+                    ),
+                    "posts_per_week": mcp.get("posts_per_week", 0),
+                    "avg_sentiment": mcp.get("avg_sentiment", 0.0),
+                    "top_topics": mcp.get("top_topics", []),
+                    "source": "reddit_mcp_live",
+                    "raw_mcp": mcp.get("text") if "text" in mcp else None,
+                }
+            }
+
+        # Tier 2: Fixture fallback
         subscribers = _load_signal(ip_name, "reddit_subscribers", 0)
         return {
             "result": {
@@ -122,7 +240,23 @@ class TwitchStatsTool:
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         ip_name: str = kwargs["ip_name"]
-        # Derive Twitch metrics from YouTube views as proxy
+
+        # Tier 1: IGDB MCP server (Twitch/IGDB share Twitch API ecosystem)
+        mcp = _try_mcp_signal("igdb", "search_games", {"query": ip_name})
+        if mcp is not None:
+            return {
+                "result": {
+                    "ip_name": ip_name,
+                    "avg_concurrent_viewers": mcp.get("avg_concurrent_viewers", 0),
+                    "peak_concurrent_viewers": mcp.get("peak_concurrent_viewers", 0),
+                    "total_stream_hours_30d": mcp.get("total_stream_hours_30d", 0),
+                    "unique_streamers_30d": mcp.get("unique_streamers_30d", 0),
+                    "source": "igdb_mcp_live",
+                    "raw_mcp": mcp.get("text") if "text" in mcp else None,
+                }
+            }
+
+        # Tier 2: Fixture fallback (derive from YouTube views as proxy)
         views = _load_signal(ip_name, "youtube_views", 0)
         has_data = views > 0
         return {
@@ -157,6 +291,27 @@ class SteamInfoTool:
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         ip_name: str = kwargs["ip_name"]
+
+        # Tier 1: Steam MCP server (tool name confirmed: get_game_info)
+        mcp = _try_mcp_signal("steam", "get_game_info", {"query": ip_name})
+        if mcp is not None:
+            return {
+                "result": {
+                    "ip_name": ip_name,
+                    "metacritic_score": mcp.get("metacritic_score", 0),
+                    "store_page_score": mcp.get("store_page_score", 0),
+                    "dau_peak": mcp.get("player_count", mcp.get("dau_peak", 0)),
+                    "price_tier": mcp.get("price_tier", "unknown"),
+                    "game_sales_data": mcp.get("game_sales_data", "N/A"),
+                    "platform": mcp.get("platform", "unknown"),
+                    "review_score": mcp.get("review_score", 0),
+                    "review_count": mcp.get("review_count", 0),
+                    "source": "steam_mcp_live",
+                    "raw_mcp": mcp.get("text") if "text" in mcp else None,
+                }
+            }
+
+        # Tier 2: Fixture fallback
         try:
             fixture = load_fixture(ip_name)
             monolake = fixture.get("monolake", {})
@@ -209,6 +364,30 @@ class GoogleTrendsTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         ip_name: str = kwargs["ip_name"]
         region: str = kwargs.get("region", "global")
+
+        # Tier 1: Google Trends MCP server
+        mcp = _try_mcp_signal(
+            "google-trends",
+            "get_interest_over_time",
+            {"keyword": ip_name, "region": region},
+        )
+        if mcp is not None:
+            trends_val = mcp.get(
+                "interest_index", mcp.get("trends_index", mcp.get("average_interest", 0))
+            )
+            return {
+                "result": {
+                    "ip_name": ip_name,
+                    "trends_index": trends_val,
+                    "region": region,
+                    "trend_direction": "rising" if trends_val > 60 else "stable",
+                    "related_queries": mcp.get("related_queries", []),
+                    "source": "google_trends_mcp_live",
+                    "raw_mcp": mcp.get("text") if "text" in mcp else None,
+                }
+            }
+
+        # Tier 2: Fixture fallback
         trends_index = _load_signal(ip_name, "google_trends_index", 0)
         genre_keywords = _load_signal(ip_name, "genre_fit_keywords", [])
         return {

--- a/docs/plans/signal-live-api.md
+++ b/docs/plans/signal-live-api.md
@@ -1,0 +1,63 @@
+# Signal Tools Liveification — MCP 연동 계획
+
+**task_id**: signal-live-api
+**Date**: 2026-03-26
+**Branch**: feature/signal-live-api
+
+## 목표
+
+signal_tools.py의 5개 stub 도구를 MCP-first + fixture fallback 패턴으로 전환.
+
+## 현황
+
+| Tool | 현재 | MCP Server | 키 필요 |
+|------|------|-----------|---------|
+| SteamInfoTool | fixture stub | steam (활성) | X |
+| RedditSentimentTool | fixture stub | reddit (미등록) | X |
+| GoogleTrendsTool | fixture stub | google-trends (미등록) | X |
+| YouTubeSearchTool | fixture stub | youtube (키 없으면 미활성) | YOUTUBE_API_KEY |
+| TwitchStatsTool | fixture stub | igdb (키 없으면 미활성) | IGDB 키 |
+
+## 구현 전략
+
+### 3-Tier Fallback
+
+```
+Tier 1: Direct MCP 호출 (서버 활성 시)
+  ↓ 실패/미연결
+Tier 2: Brave Search 쿼리 (brave-search 활성 시)
+  ↓ 실패/미연결
+Tier 3: Fixture 반환 (기존 stub 동작)
+```
+
+### 변경 파일
+
+| File | Change |
+|------|--------|
+| `core/tools/signal_tools.py` | 5개 도구 execute() → MCP-first + fallback |
+| `core/mcp/registry.py` | DEFAULT_SERVERS에 reddit, google-trends 추가 |
+| `core/mcp/catalog.py` | reddit, google-trends 패키지명 검증 |
+| `tests/test_signal_tools.py` | MCP mock 테스트 추가 |
+
+### 패턴: 공유 헬퍼
+
+```python
+def _try_mcp(server_name: str, tool_name: str, args: dict) -> dict | None:
+    """MCP 호출 시도. 실패 시 None 반환."""
+
+def _try_brave_search(query: str) -> str | None:
+    """Brave Search fallback. 실패 시 None 반환."""
+```
+
+### MCP 도구명 (확인 필요)
+
+Steam MCP의 `get_game_info`처럼, 각 서버의 도구명은 런타임에 discovery.
+`manager.get_all_tools()` 필터링으로 서버별 도구 목록 확인.
+
+## 소크라틱 5문
+
+- Q1: 코드에 이미 있는가? → LiveSignalAdapter에 TODO만 존재. 미구현.
+- Q2: 안 하면 무엇이 깨지는가? → 범용 에이전트로서 실시간 데이터 수집 불가.
+- Q3: 효과 측정? → `source` 필드로 live/stub 추적. 테스트에서 MCP mock.
+- Q4: 가장 단순한 구현? → 기존 execute() 메서드에 MCP 호출 추가, 실패 시 기존 로직 유지.
+- Q5: 프론티어 패턴? → SteamMCPSignalAdapter, BraveSearchAdapter 동일 패턴.

--- a/tests/test_signal_tools_mcp.py
+++ b/tests/test_signal_tools_mcp.py
@@ -1,0 +1,413 @@
+"""Tests for Signal Tools MCP live integration paths.
+
+Verifies that each signal tool correctly:
+1. Calls the appropriate MCP server when available
+2. Falls back to fixture data when MCP is unavailable
+3. Handles MCP errors gracefully
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.tools.signal_tools import (
+    GoogleTrendsTool,
+    RedditSentimentTool,
+    SteamInfoTool,
+    TwitchStatsTool,
+    YouTubeSearchTool,
+    _parse_mcp_content,
+    _try_mcp_signal,
+)
+
+# Patch target: lazy import inside _try_mcp_signal
+_MCP_MANAGER_PATCH = "core.mcp.manager.get_mcp_manager"
+
+
+# ---------------------------------------------------------------------------
+# _parse_mcp_content
+# ---------------------------------------------------------------------------
+
+
+class TestParseMCPContent:
+    def test_direct_dict_passthrough(self):
+        """Non-standard MCP servers returning data keys directly."""
+        result = {"player_count": 123, "review_score": 85}
+        assert _parse_mcp_content(result) == result
+
+    def test_text_content_json(self):
+        """Standard MCP content with JSON text."""
+        result = {"content": [{"type": "text", "text": '{"views": 1000, "subscribers": 50}'}]}
+        parsed = _parse_mcp_content(result)
+        assert parsed == {"views": 1000, "subscribers": 50}
+
+    def test_text_content_plain(self):
+        """MCP content with plain text (not JSON)."""
+        result = {"content": [{"type": "text", "text": "Game not found on platform."}]}
+        parsed = _parse_mcp_content(result)
+        assert parsed == {"text": "Game not found on platform."}
+
+    def test_empty_content_list(self):
+        """Empty content list returns original dict."""
+        result = {"content": []}
+        assert _parse_mcp_content(result) == result
+
+    def test_non_list_content(self):
+        """Non-list content returns original dict."""
+        result = {"content": "not a list", "data": 42}
+        assert _parse_mcp_content(result) == result
+
+    def test_multiple_text_blocks(self):
+        """Multiple text blocks concatenated."""
+        result = {
+            "content": [
+                {"type": "text", "text": "Part 1"},
+                {"type": "text", "text": "Part 2"},
+            ]
+        }
+        parsed = _parse_mcp_content(result)
+        assert parsed == {"text": "Part 1\nPart 2"}
+
+    def test_first_json_wins(self):
+        """First parseable JSON block wins."""
+        result = {
+            "content": [
+                {"type": "text", "text": '{"key": "value"}'},
+                {"type": "text", "text": "ignored plain text"},
+            ]
+        }
+        parsed = _parse_mcp_content(result)
+        assert parsed == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# _try_mcp_signal
+# ---------------------------------------------------------------------------
+
+
+class TestTryMCPSignal:
+    def test_server_not_healthy(self):
+        """Returns None when server is not in health check."""
+        mock_manager = MagicMock()
+        mock_manager.check_health.return_value = {"steam": False}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=mock_manager,
+        ):
+            result = _try_mcp_signal("steam", "get_game_info", {"query": "Test"})
+        assert result is None
+
+    def test_server_healthy_success(self):
+        """Returns parsed result when MCP call succeeds."""
+        mock_manager = MagicMock()
+        mock_manager.check_health.return_value = {"steam": True}
+        mock_manager.call_tool.return_value = {
+            "content": [{"type": "text", "text": '{"player_count": 500}'}]
+        }
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=mock_manager,
+        ):
+            result = _try_mcp_signal("steam", "get_game_info", {"query": "Test"})
+        assert result == {"player_count": 500}
+
+    def test_mcp_returns_error(self):
+        """Returns None when MCP returns error dict."""
+        mock_manager = MagicMock()
+        mock_manager.check_health.return_value = {"steam": True}
+        mock_manager.call_tool.return_value = {"error": "tool not found"}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=mock_manager,
+        ):
+            result = _try_mcp_signal("steam", "get_game_info", {"query": "Test"})
+        assert result is None
+
+    def test_manager_import_fails(self):
+        """Returns None when MCPServerManager import fails."""
+        with patch(
+            _MCP_MANAGER_PATCH,
+            side_effect=ImportError("no module"),
+        ):
+            result = _try_mcp_signal("steam", "get_game_info", {"query": "Test"})
+        assert result is None
+
+    def test_call_tool_exception(self):
+        """Returns None when call_tool raises."""
+        mock_manager = MagicMock()
+        mock_manager.check_health.return_value = {"steam": True}
+        mock_manager.call_tool.side_effect = ConnectionError("lost connection")
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=mock_manager,
+        ):
+            result = _try_mcp_signal("steam", "get_game_info", {"query": "Test"})
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a mock MCP manager for tool tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mcp_manager(
+    server_name: str,
+    tool_result: dict[str, Any],
+) -> MagicMock:
+    """Create a mock MCPServerManager that returns tool_result for one server."""
+    manager = MagicMock()
+    manager.check_health.return_value = {server_name: True}
+    manager.call_tool.return_value = tool_result
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# YouTubeSearchTool — MCP path
+# ---------------------------------------------------------------------------
+
+
+class TestYouTubeSearchToolMCP:
+    def test_live_source(self):
+        """Returns youtube_mcp_live when MCP succeeds."""
+        manager = _make_mcp_manager(
+            "youtube",
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": '{"total_views": 999000, "video_count": 42}',
+                    }
+                ]
+            },
+        )
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = YouTubeSearchTool().execute(ip_name="TestIP")
+        data = result["result"]
+        assert data["source"] == "youtube_mcp_live"
+        assert data["total_views"] == 999000
+        assert data["video_count"] == 42
+
+    def test_fallback_to_fixture(self):
+        """Falls back to fixture when MCP unavailable."""
+        manager = MagicMock()
+        manager.check_health.return_value = {}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = YouTubeSearchTool().execute(ip_name="Berserk")
+        data = result["result"]
+        assert data["source"] == "youtube_api_stub"
+        assert data["total_views"] == 25_000_000
+
+
+# ---------------------------------------------------------------------------
+# RedditSentimentTool — MCP path
+# ---------------------------------------------------------------------------
+
+
+class TestRedditSentimentToolMCP:
+    def test_live_source(self):
+        manager = _make_mcp_manager(
+            "reddit",
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": '{"subscribers": 120000, "posts_per_week": 85}',
+                    }
+                ]
+            },
+        )
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = RedditSentimentTool().execute(ip_name="TestIP")
+        data = result["result"]
+        assert data["source"] == "reddit_mcp_live"
+        assert data["subreddit_subscribers"] == 120000
+
+    def test_fallback_to_fixture(self):
+        manager = MagicMock()
+        manager.check_health.return_value = {}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = RedditSentimentTool().execute(ip_name="Berserk")
+        data = result["result"]
+        assert data["source"] == "reddit_api_stub"
+        assert data["subreddit_subscribers"] == 520_000
+
+
+# ---------------------------------------------------------------------------
+# SteamInfoTool — MCP path
+# ---------------------------------------------------------------------------
+
+
+class TestSteamInfoToolMCP:
+    def test_live_source(self):
+        manager = _make_mcp_manager(
+            "steam",
+            {"player_count": 5000, "review_score": 92, "review_count": 1500},
+        )
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = SteamInfoTool().execute(ip_name="TestIP")
+        data = result["result"]
+        assert data["source"] == "steam_mcp_live"
+        assert data["dau_peak"] == 5000
+        assert data["review_score"] == 92
+
+    def test_fallback_to_fixture(self):
+        manager = MagicMock()
+        manager.check_health.return_value = {}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = SteamInfoTool().execute(ip_name="Berserk")
+        data = result["result"]
+        assert data["source"] == "steam_api_stub"
+        assert data["metacritic_score"] == 58
+
+
+# ---------------------------------------------------------------------------
+# TwitchStatsTool — MCP path
+# ---------------------------------------------------------------------------
+
+
+class TestTwitchStatsToolMCP:
+    def test_live_source(self):
+        manager = _make_mcp_manager(
+            "igdb",
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": '{"avg_concurrent_viewers": 300, "peak_concurrent_viewers": 1200}',
+                    }
+                ]
+            },
+        )
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = TwitchStatsTool().execute(ip_name="TestIP")
+        data = result["result"]
+        assert data["source"] == "igdb_mcp_live"
+        assert data["avg_concurrent_viewers"] == 300
+
+    def test_fallback_to_fixture(self):
+        manager = MagicMock()
+        manager.check_health.return_value = {}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = TwitchStatsTool().execute(ip_name="Cowboy Bebop")
+        data = result["result"]
+        assert data["source"] == "twitch_api_stub"
+        assert data["avg_concurrent_viewers"] > 0
+
+
+# ---------------------------------------------------------------------------
+# GoogleTrendsTool — MCP path
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleTrendsToolMCP:
+    def test_live_source(self):
+        manager = _make_mcp_manager(
+            "google-trends",
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": '{"interest_index": 85, "related_queries": ["game", "anime"]}',
+                    }
+                ]
+            },
+        )
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = GoogleTrendsTool().execute(ip_name="TestIP")
+        data = result["result"]
+        assert data["source"] == "google_trends_mcp_live"
+        assert data["trends_index"] == 85
+        assert data["trend_direction"] == "rising"
+        assert data["related_queries"] == ["game", "anime"]
+
+    def test_fallback_to_fixture(self):
+        manager = MagicMock()
+        manager.check_health.return_value = {}
+
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = GoogleTrendsTool().execute(ip_name="Berserk")
+        data = result["result"]
+        assert data["source"] == "google_trends_stub"
+        assert data["trends_index"] == 78
+
+    def test_live_with_region(self):
+        manager = _make_mcp_manager(
+            "google-trends",
+            {"content": [{"type": "text", "text": '{"interest_index": 45}'}]},
+        )
+        with patch(
+            _MCP_MANAGER_PATCH,
+            return_value=manager,
+        ):
+            result = GoogleTrendsTool().execute(ip_name="TestIP", region="KR")
+        data = result["result"]
+        assert data["region"] == "KR"
+        assert data["trend_direction"] == "stable"  # 45 <= 60
+
+
+# ---------------------------------------------------------------------------
+# MCP error handling — all tools
+# ---------------------------------------------------------------------------
+
+
+class TestMCPErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_cls,ip_name,expected_stub_source",
+        [
+            (YouTubeSearchTool, "Berserk", "youtube_api_stub"),
+            (RedditSentimentTool, "Berserk", "reddit_api_stub"),
+            (TwitchStatsTool, "Berserk", "twitch_api_stub"),
+            (SteamInfoTool, "Berserk", "steam_api_stub"),
+            (GoogleTrendsTool, "Berserk", "google_trends_stub"),
+        ],
+    )
+    def test_mcp_exception_falls_back(
+        self, tool_cls: type, ip_name: str, expected_stub_source: str
+    ):
+        """All tools gracefully fall back when MCP raises."""
+        with patch(
+            _MCP_MANAGER_PATCH,
+            side_effect=RuntimeError("MCP down"),
+        ):
+            result = tool_cls().execute(ip_name=ip_name)
+        assert result["result"]["source"] == expected_stub_source


### PR DESCRIPTION
## Summary

- Signal stub 도구 5종을 MCP-first + fixture fallback 패턴으로 전환 (#447)
- DEFAULT_SERVERS에 reddit, google-trends 추가
- 28개 MCP 경로 테스트 신규, 전체 3162 passed

## Why

범용 에이전트로서 실시간 외부 데이터 수집 기반 마련.

## Test plan

- [x] CI 5/5 pass on #447
- [x] Lint 0, Type 0, Test 3162 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)