### PR TITLE
feat: MCP loading progress UI

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -926,15 +926,28 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
     # --- Unified bootstrap (domain, memory, readiness, MCP, skills) ---
     from core.cli.bootstrap import bootstrap_geode
+    from core.cli.ui.status import TextSpinner
 
-    console.print("  [dim]Initializing...[/dim]", end="\r")
+    spinner = TextSpinner("Initializing...")
+    spinner.start()
+
     boot = bootstrap_geode()
     mcp_mgr = boot.mcp_manager
     skill_registry = boot.skill_registry
 
-    n_mcp = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
+    # Eagerly connect MCP servers with live progress
+    n_total = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
+    n_connected = 0
+    if mcp_mgr and n_total > 0:
+        spinner.update(f"Loading MCP (0/{n_total})...")
+
+        def _on_mcp_progress(done: int, total: int, name: str) -> None:
+            spinner.update(f"Loading MCP ({done}/{total})...")
+
+        n_connected = mcp_mgr.startup(on_progress=_on_mcp_progress)
+
     n_skills = len(skill_registry._skills) if hasattr(skill_registry, "_skills") else 0
-    console.print(f"  [bold green]ok[/bold green] Bootstrap (MCP {n_mcp}, Skills {n_skills})")
+    spinner.stop(f"\x1b[1;32mok\x1b[0m Bootstrap (MCP {n_connected}/{n_total}, Skills {n_skills})")
 
     # Key gate (REPL-only: interactive prompt if API key missing)
     readiness = boot.readiness

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -133,6 +133,7 @@ class OperationLogger:
             console.print(f"  ⎿ [error]✗ {tool_name}[/error] — {result['error']}")
             return
         summary_parts: list[str] = []
+        # Domain-specific keys (Game IP pipeline)
         if "tier" in result:
             summary_parts.append(result["tier"])
         if "score" in result:
@@ -141,6 +142,17 @@ class OperationLogger:
             summary_parts.append(f"{result['count']} items")
         if "plan_id" in result:
             summary_parts.append(f"plan:{result['plan_id'][:8]}")
+        # Generic keys (MCP tools, web search, etc.)
+        if not summary_parts:
+            for key in ("output", "content", "text", "result", "message", "summary"):
+                val = result.get(key)
+                if val and isinstance(val, str):
+                    # Truncate long values for display (max 80 chars)
+                    preview = val.replace("\n", " ").strip()
+                    if len(preview) > 80:
+                        preview = preview[:77] + "..."
+                    summary_parts.append(preview)
+                    break
         summary = " · ".join(summary_parts) if summary_parts else "ok"
         console.print(f"  ⎿ [success]✓ {tool_name}[/success] → {summary}")
 

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import signal
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -107,13 +108,22 @@ class MCPServerManager:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def startup(self) -> int:
+    def startup(
+        self,
+        *,
+        on_progress: Callable[[int, int, str], None] | None = None,
+    ) -> int:
         """Full lifecycle startup: load config, connect all servers, register signal handlers.
+
+        Args:
+            on_progress: Optional callback ``(done, total, server_name)`` invoked
+                each time a server finishes connecting (success or failure).
 
         Returns the number of servers that connected successfully.
         """
-        self.load_config()
-        connected = self._connect_all()
+        if not self._servers:
+            self.load_config()
+        connected = self._connect_all(on_progress=on_progress)
         self._install_signal_handlers()
         log.info("MCP startup complete: %d/%d servers connected", connected, len(self._servers))
         return connected
@@ -131,12 +141,20 @@ class MCPServerManager:
         self._uninstall_signal_handlers()
         log.info("MCP shutdown complete")
 
-    def _connect_all(self) -> int:
+    def _connect_all(
+        self,
+        *,
+        on_progress: Callable[[int, int, str], None] | None = None,
+    ) -> int:
         """Connect to all configured servers in parallel.
 
         Uses ThreadPoolExecutor to start all MCP subprocess connections
         concurrently. Each server takes ~10s (npx startup + JSON-RPC
         handshake), so parallel execution reduces total from N×10s to ~10-15s.
+
+        Args:
+            on_progress: Optional callback ``(done, total, server_name)`` invoked
+                each time a server finishes connecting (success or failure).
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -145,7 +163,9 @@ class MCPServerManager:
             return 0
 
         connected = 0
-        max_workers = min(len(server_names), 8)
+        done = 0
+        total = len(server_names)
+        max_workers = min(total, 8)
 
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(self._get_client, name): name for name in server_names}
@@ -157,6 +177,9 @@ class MCPServerManager:
                         connected += 1
                 except Exception:
                     log.debug("MCP parallel connect failed: %s", name, exc_info=True)
+                done += 1
+                if on_progress:
+                    on_progress(done, total, name)
 
         return connected
 


### PR DESCRIPTION
## Summary

- REPL 부트스트랩 시 MCP 서버 연결 진행률을 TextSpinner로 실시간 표시
- `Loading MCP (3/13)...` → `Loading MCP (13/13)...` → `ok Bootstrap (MCP 11/13, Skills 20)`
- `_connect_all()` + `startup()`에 `on_progress` 콜백 파라미터 추가

### Before
```
  Initializing...
  ok Bootstrap (MCP 13, Skills 20)
```

### After
```
  ⠹ Loading MCP (7/13)...        ← 실시간 갱신
  ok Bootstrap (MCP 11/13, Skills 20)
```

### Why

MCP 서버 13개 병렬 연결에 ~10-15초 소요. 기존에는 "Initializing..." 상태로 멈춰 보였음. 진행률 표시로 사용자가 로딩 상태를 직관적으로 파악 가능.

## Test plan

- [x] MCP 관련 테스트 114개 통과
- [x] 전체 테스트 3162 passed
- [x] Lint 0, Type 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)