### PR TITLE
fix: 파이프라인 모델 고정 — Analyst/Evaluator/Synthesizer Opus 4.6 기본값 + 유저 안내

### DIFF
--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -533,6 +533,12 @@ class ToolExecutor:
         console.print("  [warning]$ Cost confirmation[/warning]")
         console.print(f"  [dim]Tool:[/dim] [bold]{tool_name}[/bold]")
         console.print(f"  [dim]Estimated cost:[/dim] ~${estimated_cost:.2f}")
+        # Show pipeline model info for analysis tools
+        if tool_name in ("analyze_ip", "compare_ips", "batch_analyze"):
+            from core.config import ANTHROPIC_PRIMARY, get_node_model
+
+            primary = get_node_model("analyst") or ANTHROPIC_PRIMARY
+            console.print(f"  [dim]Pipeline model:[/dim] {primary}")
         console.print()
 
         response = self._prompt_with_always("Proceed?", tool_name)

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -94,6 +94,13 @@ def _build_analysis_handlers(
             return _clarify("analyze_ip", ["ip_name"], "어떤 IP를 분석할까요?")
         dry_run = kwargs.get("dry_run", force_dry)
         result = _run_analysis(ip_name, dry_run=dry_run, verbose=verbose)
+        # Pipeline cost/model notice for live runs (non-dry-run)
+        pipeline_notice: str | None = None
+        if not dry_run:
+            pipeline_notice = (
+                "이 분석은 claude-opus-4-6 (Primary) + gpt-5.4 (Cross-LLM)을 사용합니다. "
+                "예상: ~8 LLM 호출, ~$0.15, ~15초."
+            )
         if result is None:
             return {"error": f"Analysis failed for '{ip_name}'"}
         # Extract analyst summaries for LLM context
@@ -111,7 +118,7 @@ def _build_analysis_handlers(
         synthesis = result.get("synthesis")
         if synthesis is not None and hasattr(synthesis, "model_dump"):
             synthesis = synthesis.model_dump()
-        return {
+        out: dict[str, Any] = {
             "status": "ok",
             "action": "analyze",
             "ip_name": result.get("ip_name", ip_name),
@@ -124,6 +131,9 @@ def _build_analysis_handlers(
             ),
             "analyses": analyses_summary,
         }
+        if pipeline_notice:
+            out["pipeline_notice"] = pipeline_notice
+        return out
 
     def handle_search_ips(**kwargs: Any) -> dict[str, Any]:
         query = kwargs.get("query", "")

--- a/core/config.py
+++ b/core/config.py
@@ -430,10 +430,26 @@ def load_routing_config(path: Path | None = None) -> RoutingConfig:
         return _routing_config_cache
 
 
+# Pipeline nodes ALWAYS use these models regardless of user's REPL model.
+# When routing.toml has no per-node config, these defaults prevent
+# fallback to settings.model (the user's active REPL model like glm-5).
+_PIPELINE_NODE_DEFAULTS: dict[str, str] = {
+    "analyst": ANTHROPIC_PRIMARY,
+    "evaluator": ANTHROPIC_PRIMARY,
+    "scoring": ANTHROPIC_PRIMARY,
+    "synthesizer": ANTHROPIC_PRIMARY,
+}
+
+
 def get_node_model(node_name: str) -> str | None:
-    """Return the model for a pipeline node, or None for default fallback."""
+    """Return the model for a pipeline node, or None for default fallback.
+
+    Priority: routing.toml > _PIPELINE_NODE_DEFAULTS > None.
+    Pipeline nodes (analyst, evaluator, scoring, synthesizer) always return
+    a fixed model so they never inherit the user's REPL model.
+    """
     cfg = load_routing_config()
-    return cfg.nodes.get(node_name) or None
+    return cfg.nodes.get(node_name) or _PIPELINE_NODE_DEFAULTS.get(node_name)
 
 
 def reset_routing_cache() -> None:

--- a/core/domains/game_ip/nodes/analysts.py
+++ b/core/domains/game_ip/nodes/analysts.py
@@ -139,6 +139,7 @@ def _run_analyst(analyst_type: str, state: GeodeState) -> AnalysisResult:
                 tool_executor=tool_executor,
                 temperature=0.5,
                 max_tool_rounds=2,
+                model=get_node_model("analyst"),
             )
             if result.text:
                 data = json.loads(result.text)

--- a/core/domains/game_ip/nodes/evaluators.py
+++ b/core/domains/game_ip/nodes/evaluators.py
@@ -249,6 +249,7 @@ def _run_evaluator(evaluator_type: str, state: GeodeState) -> EvaluatorResult:
                 tool_executor=tool_executor,
                 temperature=0.3,
                 max_tool_rounds=2,
+                model=get_node_model("evaluator"),
             )
             if result.text:
                 data = json.loads(result.text)

--- a/core/domains/game_ip/nodes/synthesizer.py
+++ b/core/domains/game_ip/nodes/synthesizer.py
@@ -360,6 +360,7 @@ def _build_tool_augmented_synthesis(
             tools=tool_defs,
             tool_executor=get_tool_executor(),
             max_tool_rounds=3,
+            model=get_node_model("synthesizer"),
         )
         if result.text:
             return SynthesisResult(

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -12,7 +12,7 @@
   },
   {
     "name": "analyze_ip",
-    "description": "특정 IP를 분석합니다. 사용자가 IP 이름을 말하거나 분석을 요청할 때 사용하세요. IP 이름만 단독으로 입력한 경우에도 이 도구를 사용하세요. 사용자가 'dry-run', '드라이런', 'LLM 없이', 'fixture로만' 등을 명시하면 반드시 dry_run=true로 설정하세요.",
+    "description": "특정 IP를 분석합니다. 사용자가 IP 이름을 말하거나 분석을 요청할 때 사용하세요. IP 이름만 단독으로 입력한 경우에도 이 도구를 사용하세요. 사용자가 'dry-run', '드라이런', 'LLM 없이', 'fixture로만' 등을 명시하면 반드시 dry_run=true로 설정하세요. dry_run=false (live 분석) 시 claude-opus-4-6 + gpt-5.4로 ~8회 LLM 호출, ~$0.15 비용이 발생합니다. 실행 전 사용자에게 비용을 안내하세요.",
     "category": "analysis",
     "cost_tier": "expensive",
     "input_schema": {

--- a/tests/test_routing_config.py
+++ b/tests/test_routing_config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 from core.config import (
+    _PIPELINE_NODE_DEFAULTS,
+    ANTHROPIC_PRIMARY,
     RoutingConfig,
     get_node_model,
     load_routing_config,
@@ -84,12 +86,20 @@ class TestLoadRoutingConfig:
 class TestGetNodeModel:
     """get_node_model() integration."""
 
-    def test_no_config_returns_none(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def test_no_config_returns_pipeline_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Pipeline nodes return fixed defaults even without routing.toml."""
         import core.config as cfg
 
         monkeypatch.setattr(cfg, "ROUTING_CONFIG_PATH", tmp_path / "nope.toml")
-        assert get_node_model("analyst") is None
-        assert get_node_model("evaluator") is None
+        # Pipeline nodes get fixed defaults (never None → never inherit REPL model)
+        assert get_node_model("analyst") == ANTHROPIC_PRIMARY
+        assert get_node_model("evaluator") == ANTHROPIC_PRIMARY
+        assert get_node_model("scoring") == ANTHROPIC_PRIMARY
+        assert get_node_model("synthesizer") == ANTHROPIC_PRIMARY
+        # Non-pipeline nodes still return None
+        assert get_node_model("unknown_node") is None
 
     def test_configured_node_returns_model(
         self,
@@ -107,4 +117,34 @@ class TestGetNodeModel:
         )
         monkeypatch.setattr(cfg, "ROUTING_CONFIG_PATH", toml_file)
         assert get_node_model("analyst") == "claude-sonnet-4-6"
-        assert get_node_model("evaluator") is None  # not configured → fallback
+        # evaluator not in routing.toml → falls back to pipeline default
+        assert get_node_model("evaluator") == ANTHROPIC_PRIMARY
+
+    def test_pipeline_node_defaults_cover_all_nodes(self) -> None:
+        """Verify _PIPELINE_NODE_DEFAULTS covers analyst/evaluator/scoring/synthesizer."""
+        expected_nodes = {"analyst", "evaluator", "scoring", "synthesizer"}
+        assert set(_PIPELINE_NODE_DEFAULTS.keys()) == expected_nodes
+        # All defaults must be ANTHROPIC_PRIMARY
+        for node, model in _PIPELINE_NODE_DEFAULTS.items():
+            assert model == ANTHROPIC_PRIMARY, f"{node} default should be {ANTHROPIC_PRIMARY}"
+
+    def test_routing_toml_overrides_pipeline_defaults(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """routing.toml takes priority over _PIPELINE_NODE_DEFAULTS."""
+        import core.config as cfg
+
+        toml_file = tmp_path / "routing.toml"
+        toml_file.write_text(
+            textwrap.dedent("""\
+            [nodes]
+            analyst = "glm-5"
+            """)
+        )
+        monkeypatch.setattr(cfg, "ROUTING_CONFIG_PATH", toml_file)
+        # Explicit routing.toml override takes priority
+        assert get_node_model("analyst") == "glm-5"
+        # Others still use pipeline defaults
+        assert get_node_model("evaluator") == ANTHROPIC_PRIMARY

--- a/tests/test_tool_augmented_nodes.py
+++ b/tests/test_tool_augmented_nodes.py
@@ -84,7 +84,7 @@ class TestToolAugmentedSynthesis:
             rounds=2,
         )
 
-        def mock_tool_fn(system, user, *, tools, tool_executor, max_tool_rounds=5):
+        def mock_tool_fn(system, user, *, tools, tool_executor, max_tool_rounds=5, model=None):
             return mock_result
 
         result = _build_tool_augmented_synthesis(
@@ -97,7 +97,7 @@ class TestToolAugmentedSynthesis:
     def test_returns_none_on_failure(self):
         state = _make_state(with_tools=True)
 
-        def failing_tool_fn(system, user, *, tools, tool_executor, max_tool_rounds=5):
+        def failing_tool_fn(system, user, *, tools, tool_executor, max_tool_rounds=5, model=None):
             raise RuntimeError("API error")
 
         result = _build_tool_augmented_synthesis(


### PR DESCRIPTION
## Summary
- **Pipeline model defaults**: `get_node_model()`에 `_PIPELINE_NODE_DEFAULTS` 추가. routing.toml 미설정 시 `settings.model`(유저 REPL 모델) 대신 `claude-opus-4-6` 고정.
- **Tool-augmented paths**: Analyst/Evaluator/Synthesizer의 `call_llm_with_tools()` 호출에 `model=get_node_model()` 명시 추가.
- **User notice**: live 분석 실행 시 사용 모델/비용 안내 (`pipeline_notice`). `definitions.json` 설명에 비용 안내 추가.

## Root cause
`get_node_model("analyst")` → None → `call_llm_parsed(model=None)` → `settings.model` ("glm-5") → GLM RateLimitError → Circuit Breaker → 파이프라인 전체 실패.

## Test plan
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run ruff format --check core/ tests/` — 0 reformats
- [x] `uv run python -m pytest tests/ -m "not live"` — 3181 passed
- [x] `get_node_model("analyst") == "claude-opus-4-6"` 검증
- [x] routing.toml 오버라이드 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)