### PR TITLE
fix: MCP bootstrap 4건 — env cascade + 패키지명 + 미존재 서버 제거

### DIFF
--- a/core/mcp/catalog.py
+++ b/core/mcp/catalog.py
@@ -115,7 +115,7 @@ MCP_CATALOG: dict[str, MCPCatalogEntry] = {
     ),
     "reddit": MCPCatalogEntry(
         name="reddit",
-        package="arindam200/reddit-mcp-server",
+        package="reddit-mcp-server",
         description="Reddit subreddit analysis, posts, sentiment",
         tags=("reddit", "social", "community", "sentiment", "forum"),
     ),

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -314,14 +314,17 @@ class MCPServerManager:
         os.environ, so MCP keys defined only in .env would be invisible.
         """
         # Lazy-load .env values (cached after first call)
-        # Cascade: CWD/.env (project) → ~/.geode/.env (global)
+        # Cascade: ~/.geode/.env (global) → CWD/.env (project, non-empty only)
         if not self._dotenv_cache:
-            # Global first (lower priority)
+            # Global first (baseline)
             if _GLOBAL_DOTENV_PATH.exists():
                 self._dotenv_cache.update(dotenv_values(str(_GLOBAL_DOTENV_PATH)))
-            # Project .env overrides global
+            # Project .env overrides — only non-empty values
+            # Empty values (e.g. BRAVE_API_KEY=) must NOT clobber global keys
             if _DOTENV_PATH.exists():
-                self._dotenv_cache.update(dotenv_values(str(_DOTENV_PATH)))
+                for k, v in dotenv_values(str(_DOTENV_PATH)).items():
+                    if v:  # skip empty/None values
+                        self._dotenv_cache[k] = v
 
         resolved: dict[str, str] = {}
         for key, value in env.items():

--- a/core/mcp/registry.py
+++ b/core/mcp/registry.py
@@ -46,14 +46,14 @@ class MCPServerConfig:
 
 DEFAULT_SERVERS: tuple[str, ...] = (
     "steam",
-    "fetch",
     "sequential-thinking",
     "playwright",
     "arxiv",
     "gmail",
     "youtube-transcript",
     "reddit",
-    "google-trends",
+    # NOTE: fetch (@modelcontextprotocol/server-fetch) — npm E404, removed
+    # NOTE: google-trends (andrewlwn77/google-trends-mcp) — npm E404, removed
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- env cascade 빈값 override 방지 — 로컬 `.env`의 빈 `BRAVE_API_KEY=`가 글로벌 유효값 덮어쓰기 차단
- reddit 카탈로그 패키지명 수정 (`arindam200/reddit-mcp-server` → `reddit-mcp-server`)
- DEFAULT_SERVERS에서 fetch, google-trends 제거 (npm E404 실측 확인)

### Before / After

| 항목 | Before | After |
|------|--------|-------|
| MCP 연결 | 9/13 | **12/14** |
| brave-search | ✗ (env 빈값 override) | ✓ |
| reddit | ✗ (GitHub repo format) | ✓ |
| fetch | ✗ (npm E404) | 제거 |
| google-trends | ✗ (npm E404) | 제거 |

### Why

blog 등 외부 디렉토리에서 geode 실행 시 MCP 9/13만 연결되어 기능 제한. env cascade 버그와 잘못된 npm 패키지명이 원인.

## Test plan

- [x] MCP 관련 테스트 114 passed
- [x] 전체 테스트 3181 passed
- [x] 실측 MCP 연결 12/14 (discord/youtube만 키 미설정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)