### PR TITLE
feat: 3사 네이티브 도구 통합 — Anthropic 20260209 + GLM-5 web_search

### DIFF
--- a/core/infrastructure/adapters/llm/claude_agentic_adapter.py
+++ b/core/infrastructure/adapters/llm/claude_agentic_adapter.py
@@ -22,6 +22,14 @@ log = logging.getLogger(__name__)
 
 _API_ALLOWED_KEYS = frozenset({"name", "description", "input_schema", "cache_control", "type"})
 
+# Anthropic native tools injected alongside function tools.
+# These are server-side capabilities (web search, web fetch) that the API
+# handles internally without requiring local tool execution.
+_ANTHROPIC_NATIVE_TOOLS: list[dict[str, Any]] = [
+    {"type": "web_search_20260209", "name": "web_search"},
+    {"type": "web_fetch_20260209", "name": "web_fetch"},
+]
+
 
 class ClaudeAgenticAdapter:
     """Anthropic agentic adapter (P1 Gateway pattern).
@@ -68,6 +76,14 @@ class ClaudeAgenticAdapter:
             tool_choice = {"type": tool_choice}
 
         api_tools = [{k: v for k, v in t.items() if k in _API_ALLOWED_KEYS} for t in tools]
+
+        # Inject Anthropic native tools (web_search, web_fetch) — server-side capabilities.
+        # De-duplicate by name to avoid conflicts with user-defined tools.
+        existing_names = {t.get("name") for t in api_tools}
+        for native in _ANTHROPIC_NATIVE_TOOLS:
+            if native["name"] not in existing_names:
+                api_tools.append(native)
+
         failover_models = [model] + [m for m in ANTHROPIC_FALLBACK_CHAIN if m != model]
 
         async def _do_call(m: str) -> Any:

--- a/core/infrastructure/adapters/llm/glm_agentic_adapter.py
+++ b/core/infrastructure/adapters/llm/glm_agentic_adapter.py
@@ -1,17 +1,43 @@
 """GlmAgenticAdapter — ZhipuAI GLM adapter for agentic loop.
 
-Inherits from OpenAIAgenticAdapter. Only overrides _resolve_config()
-and fallback_chain for GLM-specific base_url and API key.
+Inherits from OpenAIAgenticAdapter. Overrides _resolve_config(),
+fallback_chain, and agentic_call for GLM-specific base_url, API key,
+and native web_search tool injection.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from typing import Any
+
+from core.cli.agentic_response import AgenticResponse, normalize_openai
 from core.config import GLM_BASE_URL, GLM_FALLBACK_CHAIN, settings
-from core.infrastructure.adapters.llm.openai_agentic_adapter import OpenAIAgenticAdapter
+from core.infrastructure.adapters.llm.openai_agentic_adapter import (
+    OpenAIAgenticAdapter,
+    _convert_messages_to_openai,
+    _tools_to_openai,
+)
+from core.infrastructure.ports.agentic_llm_port import UserCancelledError
+from core.llm.client import call_with_failover
+
+log = logging.getLogger(__name__)
+
+# GLM-5 native web_search configuration.
+# Injected alongside function tools for free built-in web search.
+_GLM_NATIVE_WEB_SEARCH: dict[str, Any] = {
+    "type": "web_search",
+    "web_search": {
+        "enable": True,
+    },
+}
 
 
 class GlmAgenticAdapter(OpenAIAgenticAdapter):
-    """ZhipuAI GLM adapter (glm-5, glm-5-turbo, glm-4.7-flash)."""
+    """ZhipuAI GLM adapter (glm-5, glm-5-turbo, glm-4.7-flash).
+
+    Injects GLM native web_search tool alongside function tools.
+    """
 
     @property
     def provider_name(self) -> str:
@@ -23,3 +49,71 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
 
     def _resolve_config(self, model: str) -> tuple[str, str | None]:
         return settings.zai_api_key, GLM_BASE_URL
+
+    async def agentic_call(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        tool_choice: dict[str, str] | str,
+        max_tokens: int,
+        temperature: float,
+    ) -> AgenticResponse | None:
+        """GLM agentic call with native web_search injection.
+
+        Converts function tools to OpenAI format, then appends the GLM
+        native web_search tool for free built-in web search capability.
+        """
+        client = self._ensure_client(model)
+        if client is None:
+            log.warning("No API key for %s agentic loop", self.provider_name)
+            return None
+
+        if not self._circuit_breaker.can_execute():
+            log.warning("%s circuit breaker is OPEN, skipping call", self.provider_name)
+            return None
+
+        # OpenAI tool_choice is a string
+        tc_val = tool_choice.get("type", "auto") if isinstance(tool_choice, dict) else tool_choice
+
+        oai_tools = _tools_to_openai(tools)
+
+        # Inject GLM native web_search alongside function tools
+        oai_tools.append(_GLM_NATIVE_WEB_SEARCH)
+
+        oai_messages = _convert_messages_to_openai(system, messages)
+        failover_models = [model] + [m for m in self.fallback_chain if m != model]
+
+        async def _do_call(m: str) -> Any:
+            return await asyncio.to_thread(
+                client.chat.completions.create,
+                model=m,
+                messages=oai_messages,
+                tools=oai_tools if oai_tools else None,
+                tool_choice=tc_val if oai_tools else None,
+                max_completion_tokens=max_tokens,
+                temperature=temperature,
+                timeout=120.0,
+            )
+
+        try:
+            response, used_model = await call_with_failover(failover_models, _do_call)
+        except KeyboardInterrupt:
+            raise UserCancelledError("LLM call interrupted by user") from None
+        except Exception:
+            log.warning("%s agentic LLM call failed", self.provider_name, exc_info=True)
+            self._circuit_breaker.record_failure()
+            return None
+
+        if response is None:
+            self._circuit_breaker.record_failure()
+            return None
+
+        self._circuit_breaker.record_success()
+
+        if used_model and used_model != model:
+            log.warning("Model failover: %s -> %s", model, used_model)
+
+        return normalize_openai(response)

--- a/core/infrastructure/adapters/llm/openai_agentic_adapter.py
+++ b/core/infrastructure/adapters/llm/openai_agentic_adapter.py
@@ -39,6 +39,11 @@ class OpenAIAgenticAdapter:
     - httpx connection pool (parity with Anthropic adapter)
     - CircuitBreaker
     - KeyboardInterrupt → UserCancelledError
+
+    TODO(native-tools): OpenAI native tools (web_search_preview, file_search,
+    code_interpreter) require the Responses API (client.responses.create).
+    Current adapter uses Chat Completions API. Migration planned for v0.30+.
+    See docs/plans/native-tools-integration.md for details.
     """
 
     def __init__(self) -> None:

--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -442,7 +442,7 @@ class WebSearchTool:
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,
-                tools=[{"type": "web_search_20250305", "name": "web_search"}],
+                tools=[{"type": "web_search_20260209", "name": "web_search"}],
                 messages=[
                     {
                         "role": "user",

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -110,7 +110,7 @@ class GeneralWebSearchTool:
             response = client.messages.create(
                 model=ANTHROPIC_BUDGET,
                 max_tokens=1024,
-                tools=[{"type": "web_search_20250305", "name": "web_search"}],
+                tools=[{"type": "web_search_20260209", "name": "web_search"}],
                 messages=[
                     {
                         "role": "user",

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -1,0 +1,278 @@
+"""Tests for 3-provider native tool integration.
+
+Covers:
+- Anthropic web_search version upgrade (20250305 → 20260209)
+- Anthropic web_fetch native tool injection
+- GLM native web_search injection
+- OpenAI Responses API gap documentation
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Anthropic: web_search version string tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicWebSearchVersion:
+    """Verify web_search_20260209 is used everywhere (not 20250305)."""
+
+    def test_web_tools_uses_20260209(self) -> None:
+        """GeneralWebSearchTool must use web_search_20260209."""
+        import importlib
+        import inspect
+
+        from core.tools import web_tools
+
+        importlib.reload(web_tools)
+        source = inspect.getsource(web_tools.GeneralWebSearchTool.execute)
+        assert "web_search_20260209" in source
+        assert "web_search_20250305" not in source
+
+    def test_signal_tools_uses_20260209(self) -> None:
+        """WebSearchTool (signal) must use web_search_20260209."""
+        import importlib
+        import inspect
+
+        from core.tools import signal_tools
+
+        importlib.reload(signal_tools)
+        source = inspect.getsource(signal_tools.WebSearchTool.execute)
+        assert "web_search_20260209" in source
+        assert "web_search_20250305" not in source
+
+
+# ---------------------------------------------------------------------------
+# Anthropic: native tool injection in adapter
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicNativeToolInjection:
+    """ClaudeAgenticAdapter must inject native tools into API call."""
+
+    def test_native_tools_constant_has_web_search(self) -> None:
+        """_ANTHROPIC_NATIVE_TOOLS must include web_search_20260209."""
+        from core.infrastructure.adapters.llm.claude_agentic_adapter import (
+            _ANTHROPIC_NATIVE_TOOLS,
+        )
+
+        names = {t["name"] for t in _ANTHROPIC_NATIVE_TOOLS}
+        types = {t["type"] for t in _ANTHROPIC_NATIVE_TOOLS}
+        assert "web_search" in names
+        assert "web_search_20260209" in types
+
+    def test_native_tools_constant_has_web_fetch(self) -> None:
+        """_ANTHROPIC_NATIVE_TOOLS must include web_fetch_20260209."""
+        from core.infrastructure.adapters.llm.claude_agentic_adapter import (
+            _ANTHROPIC_NATIVE_TOOLS,
+        )
+
+        names = {t["name"] for t in _ANTHROPIC_NATIVE_TOOLS}
+        types = {t["type"] for t in _ANTHROPIC_NATIVE_TOOLS}
+        assert "web_fetch" in names
+        assert "web_fetch_20260209" in types
+
+    def test_native_tools_deduplication(self) -> None:
+        """Native tools should not duplicate existing tool names."""
+        from core.infrastructure.adapters.llm.claude_agentic_adapter import (
+            _ANTHROPIC_NATIVE_TOOLS,
+            _API_ALLOWED_KEYS,
+        )
+
+        # Simulate tools list with a web_search tool already present
+        tools: list[dict[str, Any]] = [
+            {
+                "name": "web_search",
+                "description": "Custom web search",
+                "input_schema": {"type": "object"},
+                "type": "function",
+            },
+            {
+                "name": "other_tool",
+                "description": "Another tool",
+                "input_schema": {"type": "object"},
+            },
+        ]
+
+        api_tools = [{k: v for k, v in t.items() if k in _API_ALLOWED_KEYS} for t in tools]
+        existing_names = {t.get("name") for t in api_tools}
+        for native in _ANTHROPIC_NATIVE_TOOLS:
+            if native["name"] not in existing_names:
+                api_tools.append(native)
+
+        # web_search should appear only once (original, not native)
+        web_search_entries = [t for t in api_tools if t.get("name") == "web_search"]
+        assert len(web_search_entries) == 1
+        # web_fetch should be added (not in original)
+        web_fetch_entries = [t for t in api_tools if t.get("name") == "web_fetch"]
+        assert len(web_fetch_entries) == 1
+
+    def test_agentic_call_injects_native_tools(self) -> None:
+        """agentic_call must include native tools in the API request."""
+        import asyncio
+
+        from core.infrastructure.adapters.llm.claude_agentic_adapter import (
+            ClaudeAgenticAdapter,
+        )
+
+        adapter = ClaudeAgenticAdapter()
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text="hello")]
+        mock_response.stop_reason = "end_turn"
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=5)
+        mock_response.model = "claude-opus-4-6"
+
+        with (
+            patch(
+                "core.infrastructure.adapters.llm.claude_agentic_adapter.settings"
+            ) as mock_settings,
+            patch(
+                "core.infrastructure.adapters.llm.claude_agentic_adapter.call_with_failover"
+            ) as mock_failover,
+        ):
+            mock_settings.anthropic_api_key = "test-key"
+            mock_failover.return_value = (mock_response, "claude-opus-4-6")
+
+            # Set a mock client so _ensure_client path is skipped
+            adapter._client = MagicMock()
+
+            result = asyncio.run(
+                adapter.agentic_call(
+                    model="claude-opus-4-6",
+                    system="test",
+                    messages=[{"role": "user", "content": "hello"}],
+                    tools=[
+                        {
+                            "name": "test_tool",
+                            "description": "A test",
+                            "input_schema": {"type": "object"},
+                        }
+                    ],
+                    tool_choice={"type": "auto"},
+                    max_tokens=1024,
+                    temperature=0.0,
+                )
+            )
+
+            assert result is not None
+            # Verify call_with_failover was called
+            assert mock_failover.called
+
+            # Inspect the callable passed to call_with_failover
+            # The first positional arg is the model list, second is the async callable
+            call_args = mock_failover.call_args
+            model_list = call_args[0][0]
+            assert "claude-opus-4-6" in model_list
+
+
+# ---------------------------------------------------------------------------
+# GLM: native web_search injection
+# ---------------------------------------------------------------------------
+
+
+class TestGlmNativeWebSearch:
+    """GlmAgenticAdapter must inject native web_search."""
+
+    def test_glm_native_web_search_constant(self) -> None:
+        """_GLM_NATIVE_WEB_SEARCH must have correct structure."""
+        from core.infrastructure.adapters.llm.glm_agentic_adapter import (
+            _GLM_NATIVE_WEB_SEARCH,
+        )
+
+        assert _GLM_NATIVE_WEB_SEARCH["type"] == "web_search"
+        assert _GLM_NATIVE_WEB_SEARCH["web_search"]["enable"] is True
+
+    def test_glm_adapter_is_subclass_of_openai(self) -> None:
+        """GlmAgenticAdapter must inherit from OpenAIAgenticAdapter."""
+        from core.infrastructure.adapters.llm.glm_agentic_adapter import (
+            GlmAgenticAdapter,
+        )
+        from core.infrastructure.adapters.llm.openai_agentic_adapter import (
+            OpenAIAgenticAdapter,
+        )
+
+        assert issubclass(GlmAgenticAdapter, OpenAIAgenticAdapter)
+
+    def test_glm_provider_name(self) -> None:
+        """GlmAgenticAdapter.provider_name must be 'glm'."""
+        from core.infrastructure.adapters.llm.glm_agentic_adapter import (
+            GlmAgenticAdapter,
+        )
+
+        adapter = GlmAgenticAdapter()
+        assert adapter.provider_name == "glm"
+
+    def test_glm_has_own_agentic_call(self) -> None:
+        """GlmAgenticAdapter must override agentic_call (not inherit from OpenAI)."""
+        from core.infrastructure.adapters.llm.glm_agentic_adapter import (
+            GlmAgenticAdapter,
+        )
+        from core.infrastructure.adapters.llm.openai_agentic_adapter import (
+            OpenAIAgenticAdapter,
+        )
+
+        # GlmAgenticAdapter.agentic_call should be defined on the class itself
+        assert "agentic_call" in GlmAgenticAdapter.__dict__
+        # And it should be different from the parent
+        assert GlmAgenticAdapter.agentic_call is not OpenAIAgenticAdapter.agentic_call
+
+
+# ---------------------------------------------------------------------------
+# OpenAI: Responses API gap documentation
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIResponsesApiGap:
+    """Verify OpenAI adapter documents the Responses API gap."""
+
+    def test_openai_adapter_has_todo_comment(self) -> None:
+        """OpenAIAgenticAdapter docstring must mention Responses API TODO."""
+        from core.infrastructure.adapters.llm.openai_agentic_adapter import (
+            OpenAIAgenticAdapter,
+        )
+
+        docstring = OpenAIAgenticAdapter.__doc__ or ""
+        assert "Responses API" in docstring
+        assert "TODO" in docstring
+
+    def test_openai_uses_chat_completions(self) -> None:
+        """Confirm OpenAI adapter still uses Chat Completions (not yet migrated)."""
+        import inspect
+
+        from core.infrastructure.adapters.llm.openai_agentic_adapter import (
+            OpenAIAgenticAdapter,
+        )
+
+        source = inspect.getsource(OpenAIAgenticAdapter.agentic_call)
+        assert "chat.completions.create" in source
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider: _API_ALLOWED_KEYS includes 'type'
+# ---------------------------------------------------------------------------
+
+
+class TestApiAllowedKeys:
+    """Verify _API_ALLOWED_KEYS allows native tool type passthrough."""
+
+    def test_type_key_in_allowed(self) -> None:
+        """'type' must be in _API_ALLOWED_KEYS for native tool passthrough."""
+        from core.infrastructure.adapters.llm.claude_agentic_adapter import (
+            _API_ALLOWED_KEYS,
+        )
+
+        assert "type" in _API_ALLOWED_KEYS
+
+    def test_native_tool_passes_filter(self) -> None:
+        """Native tool dict must survive _API_ALLOWED_KEYS filtering."""
+        from core.infrastructure.adapters.llm.claude_agentic_adapter import (
+            _API_ALLOWED_KEYS,
+        )
+
+        native = {"type": "web_search_20260209", "name": "web_search"}
+        filtered = {k: v for k, v in native.items() if k in _API_ALLOWED_KEYS}
+        assert filtered == native


### PR DESCRIPTION
## Summary
- **Anthropic**: `web_search_20250305` → `web_search_20260209` + `web_fetch_20260209` 네이티브 주입
- **GLM-5**: 네이티브 `web_search` 무료 도구 패스스루 (agentic_call override)
- **OpenAI**: Responses API 마이그레이션 필요 → TODO 문서화 (v0.30+)

## Test plan
- [x] 14 new tests (버전 검증, 네이티브 도구 상수, 중복 제거, 어댑터 통합)
- [x] 3195 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)