### PR TITLE
feat: Action Display — tool-type 그루핑 + 서브에이전트 카운터 + 턴 요약

### DIFF
--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import sys
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -346,26 +345,28 @@ class ToolExecutor:
             for i, t in enumerate(tasks_raw)
         ]
 
-        # P2-C: progress callback — consolidated progress line (Claude Code pattern)
+        # P2-C: progress callback — progressive counter (Claude Code pattern)
         completed_count = 0
         total_count = len(sub_tasks)
         _start_ts = time.time()
+        _task_starts: dict[str, float] = {t.task_id: time.time() for t in sub_tasks}
 
         def _on_progress(result: Any) -> None:
             nonlocal completed_count
             completed_count += 1
-            status = "ok" if result.success else "err"
-            # Single overwriting line — no scroll flood
-            sys.stdout.write(
-                f"\r\x1b[2K  \x1b[2msub-agent {completed_count}/{total_count} {status}\x1b[0m"
+            task_elapsed = time.time() - _task_starts.get(result.task_id, _start_ts)
+            from core.cli.ui.agentic_ui import render_subagent_progress
+
+            render_subagent_progress(
+                completed_count,
+                total_count,
+                result.description or result.task_id,
+                task_elapsed,
             )
-            sys.stdout.flush()
 
         results = self._sub_agent_manager.delegate(sub_tasks, on_progress=_on_progress)
 
-        # Clear progress line and show final summary
-        sys.stdout.write("\r\x1b[2K")
-        sys.stdout.flush()
+        # Final summary line
         from core.cli.ui.agentic_ui import render_subagent_complete
 
         render_subagent_complete(len(results), time.time() - _start_ts)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1114,9 +1114,37 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                 result = agentic.run(user_input)
                 _render_agentic_result(result)
                 # Claude Code-style status line after each result
-                from core.cli.ui.agentic_ui import render_status_line
+                from core.cli.ui.agentic_ui import render_status_line, render_turn_summary
 
                 render_status_line()
+
+                # Turn-end compact summary (rounds · tools · time · cost)
+                if result and result.tool_calls:
+                    from core.cli.ui.agentic_ui import get_session_meter
+
+                    _meter = get_session_meter()
+                    _turn_elapsed = _meter.turn_elapsed_s if _meter else 0.0
+                    _turn_cost = 0.0
+                    try:
+                        from core.llm.token_tracker import get_tracker as _get_tk
+
+                        _tk = _get_tk()
+                        import core.cli.ui.agentic_ui as _ui_mod
+
+                        _snap = _ui_mod._turn_snapshot
+                        if _snap is not None:
+                            _delta = _tk.delta_since(_snap)
+                            _turn_cost = _delta.total_cost_usd
+                        else:
+                            _turn_cost = _tk.accumulator.total_cost_usd
+                    except Exception:
+                        log.debug("Turn cost calculation failed", exc_info=True)
+                    render_turn_summary(
+                        result.rounds,
+                        len(result.tool_calls),
+                        _turn_elapsed,
+                        _turn_cost,
+                    )
             except KeyboardInterrupt:
                 console.show_cursor(True)
                 console.print("\n  [dim]Interrupted.[/dim]\n")

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -112,23 +112,35 @@ class OperationLogger:
 
     Manages the progressive log display with tree structure and
     auto-collapse after COLLAPSE_THRESHOLD visible operations.
+
+    When finalize() is called with 6+ total tools, renders a grouped
+    summary by tool type instead of the simple collapsed count.
     """
 
     COLLAPSE_THRESHOLD = 5
+    GROUPING_THRESHOLD = 6
 
     def __init__(self) -> None:
         self._visible_count = 0
         self._collapsed_count = 0
         self._header_printed = False
+        # Tool-type grouping state
+        self._tool_type_counts: dict[str, int] = {}
+        self._tool_type_last_summary: dict[str, str] = {}
+        self._total_tool_count = 0
+        self._round_count = 0
 
     def begin_round(self, label: str = "AgenticLoop") -> None:
         """Start a new agentic round — print header if not yet shown."""
         if not self._header_printed:
             console.print(f"\n[bold]● {label}[/bold]")
             self._header_printed = True
+        self._round_count += 1
 
     def log_tool_call(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
         """Log a tool call. Returns True if visible, False if collapsed."""
+        self._total_tool_count += 1
+        self._tool_type_counts[tool_name] = self._tool_type_counts.get(tool_name, 0) + 1
         if self._visible_count < self.COLLAPSE_THRESHOLD:
             args_parts: list[str] = []
             for k, v in tool_input.items():
@@ -152,12 +164,28 @@ class OperationLogger:
     def log_tool_result(
         self, tool_name: str, result: dict[str, Any], *, visible: bool = True
     ) -> None:
-        """Log a tool result (only renders if the call was visible)."""
+        """Log a tool result (only renders if the call was visible).
+
+        Also tracks per-type last summary for grouped finalize display.
+        """
+        # Build summary string (needed for both visible rendering and grouping)
+        summary = self._build_result_summary(tool_name, result)
+
+        # Track per-type last summary for grouped display
+        self._tool_type_last_summary[tool_name] = summary
+
         if not visible:
             return
         if result.get("error"):
             console.print(f"  ⎿ [error]✗ {tool_name}[/error] — {result['error']}")
             return
+        console.print(f"  ⎿ [success]✓ {tool_name}[/success] → {summary}")
+
+    @staticmethod
+    def _build_result_summary(tool_name: str, result: dict[str, Any]) -> str:
+        """Build a compact summary string from a tool result dict."""
+        if result.get("error"):
+            return str(result["error"])
         summary_parts: list[str] = []
         # Domain-specific keys (Game IP pipeline)
         if "tier" in result:
@@ -179,12 +207,24 @@ class OperationLogger:
                         preview = preview[:77] + "..."
                     summary_parts.append(preview)
                     break
-        summary = " · ".join(summary_parts) if summary_parts else "ok"
-        console.print(f"  ⎿ [success]✓ {tool_name}[/success] → {summary}")
+        return " · ".join(summary_parts) if summary_parts else "ok"
 
     def finalize(self) -> None:
-        """Print collapsed count if any tools were hidden."""
-        if self._collapsed_count > 0:
+        """Print collapsed count or grouped summary.
+
+        When total tool count >= GROUPING_THRESHOLD (6), renders a grouped
+        summary by tool type (e.g., ``web_search (3) · memory (2) · bash (1)``).
+        Otherwise, falls back to the simple collapsed count message.
+        """
+        if self._total_tool_count >= self.GROUPING_THRESHOLD:
+            # Grouped summary: tool_type (count) sorted by count descending
+            sorted_types = sorted(self._tool_type_counts.items(), key=lambda x: -x[1])
+            type_parts = [f"{name} ({count})" for name, count in sorted_types]
+            group_line = " · ".join(type_parts)
+            console.print(f"  ⎿ [dim]{group_line}[/dim]")
+            rounds = max(self._round_count, 1)
+            console.print(f"  ⎿ [dim]{self._total_tool_count} tools · {rounds} rounds[/dim]")
+        elif self._collapsed_count > 0:
             console.print(f"  ⎿ [dim]+{self._collapsed_count} more tool uses (collapsed)[/dim]")
 
     def reset(self) -> None:
@@ -192,6 +232,10 @@ class OperationLogger:
         self._visible_count = 0
         self._collapsed_count = 0
         self._header_printed = False
+        self._tool_type_counts.clear()
+        self._tool_type_last_summary.clear()
+        self._total_tool_count = 0
+        self._round_count = 0
 
 
 def render_tool_call(tool_name: str, tool_input: dict[str, Any]) -> None:
@@ -291,6 +335,25 @@ def render_subagent_dispatch(task_id: str, task_type: str, description: str) -> 
     console.print(f'  [subagent]▸ delegate_task[/subagent]({task_type}, "{description}")')
 
 
+def render_subagent_progress(
+    completed: int, total: int, latest_name: str, latest_time: float
+) -> None:
+    """Render sub-agent progress with counter.
+
+    Shows progressive ``[completed/total]`` counter as each sub-agent finishes.
+    """
+    if completed < total:
+        console.print(
+            f"  [dim]⎿[/dim] [success]✓[/success] {latest_name} ({latest_time:.1f}s)"
+            f"  [{completed}/{total}]"
+        )
+    else:
+        console.print(
+            f"  [dim]⎿[/dim] [success]✓[/success] {latest_name} ({latest_time:.1f}s)"
+            f"  [{completed}/{total}]"
+        )
+
+
 def render_subagent_complete(count: int, elapsed_s: float) -> None:
     """Render sub-agent batch completion."""
     console.print(f"  [success]✓ {count} sub-agents completed[/success] ({elapsed_s:.1f}s)")
@@ -344,6 +407,21 @@ def render_status_line() -> None:
     except Exception:
         # Fallback: just show elapsed time
         console.print(f"\n  [dim]✢ Worked for {meter.turn_elapsed_display}[/dim]")
+
+
+def render_turn_summary(rounds: int, tool_count: int, elapsed_s: float, cost: float) -> None:
+    """Render compact turn-end summary line.
+
+    Format: ``──── 3 rounds · 8 tools · 4.2s · $0.012 ────``
+    Only renders when there is meaningful activity (at least 1 tool call).
+    """
+    if tool_count == 0:
+        return
+    parts = [f"{rounds} rounds", f"{tool_count} tools", f"{elapsed_s:.1f}s"]
+    if cost > 0:
+        parts.append(f"${cost:.3f}")
+    summary = " · ".join(parts)
+    console.print(f"\n  [dim]──── {summary} ────[/dim]")
 
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -16,9 +16,11 @@ from core.cli.ui.agentic_ui import (
     render_status_line,
     render_subagent_complete,
     render_subagent_dispatch,
+    render_subagent_progress,
     render_tokens,
     render_tool_call,
     render_tool_result,
+    render_turn_summary,
 )
 
 
@@ -229,14 +231,18 @@ class TestOperationLogger:
         assert logger.log_tool_call("tool_extra", {}) is False
 
     @patch("core.cli.ui.agentic_ui.console")
-    def test_finalize_shows_collapsed_count(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+    def test_finalize_shows_grouped_summary(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """When total tools >= GROUPING_THRESHOLD (6), finalize shows grouped summary."""
         logger = OperationLogger()
+        logger.begin_round()
         for i in range(OperationLogger.COLLAPSE_THRESHOLD + 3):
             logger.log_tool_call(f"tool_{i}", {})
         logger.finalize()
         calls = [str(c) for c in mock_console.print.call_args_list]
         combined = " ".join(calls)
-        assert "+3 more tool uses" in combined
+        # Should show grouped summary, not collapsed count
+        assert "8 tools" in combined
+        assert "1 rounds" in combined
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_finalize_no_collapsed(self, mock_console) -> None:  # type: ignore[no-untyped-def]
@@ -269,6 +275,9 @@ class TestOperationLogger:
         assert logger._visible_count == 0
         assert logger._collapsed_count == 0
         assert logger._header_printed is False
+        assert logger._total_tool_count == 0
+        assert logger._tool_type_counts == {}
+        assert logger._round_count == 0
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_log_tool_result_error(self, mock_console) -> None:  # type: ignore[no-untyped-def]
@@ -466,3 +475,205 @@ class TestMarkTurnStart:
 
         mark_turn_start()
         assert meter.turn_elapsed_s < 1
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Action Display — tool-type grouping, sub-agent counter, turn summary
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestToolTypeGrouping:
+    """OperationLogger tool-type grouping (6+ tools)."""
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_grouping_with_mixed_types(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """8 tool calls of mixed types produce grouped summary in finalize()."""
+        logger = OperationLogger()
+        logger.begin_round()
+        # 3 web_search + 2 memory_search + 2 bash + 1 analyze_ip = 8
+        for _ in range(3):
+            logger.log_tool_call("web_search", {"query": "test"})
+        for _ in range(2):
+            logger.log_tool_call("memory_search", {"query": "test"})
+        for _ in range(2):
+            logger.log_tool_call("run_bash", {"command": "ls"})
+        logger.log_tool_call("analyze_ip", {"ip_name": "Berserk"})
+
+        mock_console.print.reset_mock()
+        logger.finalize()
+        calls = [str(c) for c in mock_console.print.call_args_list]
+        combined = " ".join(calls)
+
+        # Should show grouped summary
+        assert "web_search (3)" in combined
+        assert "memory_search (2)" in combined
+        assert "run_bash (2)" in combined
+        assert "analyze_ip (1)" in combined
+        assert "8 tools" in combined
+        assert "1 rounds" in combined
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_grouping_sorted_by_count(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Grouped types are sorted by count descending."""
+        logger = OperationLogger()
+        logger.begin_round()
+        # 1 alpha + 4 beta + 1 gamma = 6
+        logger.log_tool_call("alpha", {})
+        for _ in range(4):
+            logger.log_tool_call("beta", {})
+        logger.log_tool_call("gamma", {})
+
+        mock_console.print.reset_mock()
+        logger.finalize()
+        calls = [str(c) for c in mock_console.print.call_args_list]
+        combined = " ".join(calls)
+
+        # beta should come first (4 > 1)
+        assert "beta (4)" in combined
+        beta_pos = combined.index("beta (4)")
+        alpha_pos = combined.index("alpha (1)")
+        assert beta_pos < alpha_pos
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_below_grouping_threshold_no_summary(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """<= 5 tools: no grouping, no collapsed count."""
+        logger = OperationLogger()
+        for i in range(5):
+            logger.log_tool_call(f"tool_{i}", {})
+
+        mock_console.print.reset_mock()
+        logger.finalize()
+        # 5 tools, 0 collapsed, total < 6 → nothing printed
+        assert not mock_console.print.called
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_exactly_6_tools_triggers_grouping(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Exactly 6 tools (GROUPING_THRESHOLD) triggers grouping."""
+        logger = OperationLogger()
+        logger.begin_round()
+        for i in range(6):
+            logger.log_tool_call("web_search", {"q": str(i)})
+
+        mock_console.print.reset_mock()
+        logger.finalize()
+        calls = [str(c) for c in mock_console.print.call_args_list]
+        combined = " ".join(calls)
+
+        assert "web_search (6)" in combined
+        assert "6 tools" in combined
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_round_counting(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Multiple begin_round() calls increment round count."""
+        logger = OperationLogger()
+        logger.begin_round()
+        for _ in range(3):
+            logger.log_tool_call("tool_a", {})
+        logger.begin_round()  # header already printed, but round count++
+        for _ in range(3):
+            logger.log_tool_call("tool_b", {})
+
+        mock_console.print.reset_mock()
+        logger.finalize()
+        calls = [str(c) for c in mock_console.print.call_args_list]
+        combined = " ".join(calls)
+
+        assert "6 tools" in combined
+        assert "2 rounds" in combined
+
+
+class TestSubagentProgressCounter:
+    """Sub-agent progressive counter rendering."""
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_progress_in_flight(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Partial completion shows [completed/total] counter."""
+        render_subagent_progress(2, 5, "thread-safety", 2.1)
+        printed = str(mock_console.print.call_args)
+        assert "thread-safety" in printed
+        assert "2.1s" in printed
+        assert "[2/5]" in printed
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_progress_final(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Last completion still shows [completed/total]."""
+        render_subagent_progress(5, 5, "final-task", 3.4)
+        printed = str(mock_console.print.call_args)
+        assert "final-task" in printed
+        assert "3.4s" in printed
+        assert "[5/5]" in printed
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_progress_first(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """First completion shows [1/total]."""
+        render_subagent_progress(1, 3, "task-alpha", 1.0)
+        printed = str(mock_console.print.call_args)
+        assert "[1/3]" in printed
+        assert "task-alpha" in printed
+
+
+class TestTurnSummary:
+    """Turn-end compact summary line."""
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_basic_summary(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Summary shows rounds, tools, time, cost."""
+        render_turn_summary(3, 8, 4.2, 0.012)
+        printed = str(mock_console.print.call_args)
+        assert "3 rounds" in printed
+        assert "8 tools" in printed
+        assert "4.2s" in printed
+        assert "$0.012" in printed
+        assert "────" in printed
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_summary_no_cost(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """When cost is 0, cost part is omitted."""
+        render_turn_summary(2, 5, 1.5, 0.0)
+        printed = str(mock_console.print.call_args)
+        assert "2 rounds" in printed
+        assert "5 tools" in printed
+        assert "1.5s" in printed
+        assert "$" not in printed
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_summary_zero_tools_noop(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """No tool calls means no summary rendered."""
+        render_turn_summary(1, 0, 0.5, 0.0)
+        assert not mock_console.print.called
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_summary_single_round(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Single round summary."""
+        render_turn_summary(1, 2, 0.8, 0.001)
+        printed = str(mock_console.print.call_args)
+        assert "1 rounds" in printed
+        assert "2 tools" in printed
+        assert "$0.001" in printed
+
+
+class TestBuildResultSummary:
+    """OperationLogger._build_result_summary static method."""
+
+    def test_tier_and_score(self) -> None:
+        s = OperationLogger._build_result_summary("t", {"tier": "S", "score": 81.2})
+        assert "S" in s
+        assert "81.2" in s
+
+    def test_error(self) -> None:
+        s = OperationLogger._build_result_summary("t", {"error": "Not found"})
+        assert s == "Not found"
+
+    def test_generic_text(self) -> None:
+        s = OperationLogger._build_result_summary("t", {"output": "some text"})
+        assert "some text" in s
+
+    def test_empty(self) -> None:
+        s = OperationLogger._build_result_summary("t", {})
+        assert s == "ok"
+
+    def test_long_text_truncated(self) -> None:
+        long_text = "x" * 100
+        s = OperationLogger._build_result_summary("t", {"output": long_text})
+        assert len(s) <= 80
+        assert s.endswith("...")


### PR DESCRIPTION
## Summary
- **Tool-type 그루핑**: 6건+ 도구 호출 시 동일 타입 그룹 요약 (`web_search (3) · memory (2) · bash (1)`)
- **서브에이전트 카운터**: 완료 순 progressive counter (`✓ S1 thread-safety (2.1s) [3/5]`)
- **턴 끝 요약**: 컴팩트 라인 (`──── 3 rounds · 8 tools · 4.2s · $0.012 ────`)

Tier1 결정론적, LLM 호출 0, 토큰 비용 0.

## Test plan
- [x] 17 new tests (그루핑, 카운터, 요약, build_result_summary)
- [x] 3219 passed, 0 failed
- [x] mypy 0 errors, ruff 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)