### PR TITLE
feat: Gateway 멀티턴 대화 지원

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1667,18 +1667,35 @@ def serve(
         "This message comes from an external messaging channel (Slack/Discord/Telegram).\n"
         "- Do NOT echo, repeat, or quote the user's message in your response.\n"
         "- Do NOT prefix your response with 'GEODE:' or the user's original text.\n"
-        "- Respond directly with the answer only. Be concise."
+        "- Respond directly with the answer only. Be concise.\n"
+        "- You have access to prior messages in this thread as conversation history."
     )
 
-    def _gateway_processor(content: str) -> str:
-        """Process a gateway message with a fresh AgenticLoop per message.
+    # Max conversation turns to persist per thread (safety net)
+    _GATEWAY_MAX_TURNS = 20
 
-        Uses bootstrap.propagate_to_thread() to fix ContextVar visibility
-        in daemon threads, then builds a per-message AgenticLoop with
-        the same MCP/skills/handlers as the REPL.
+    def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:
+        """Process a gateway message with multi-turn context.
+
+        Loads prior conversation from SessionStore (keyed by thread),
+        runs AgenticLoop, then persists the updated conversation back.
         """
         boot.propagate_to_thread()  # Fix ContextVar propagation for daemon thread
-        ctx = ConversationContext(max_turns=20)
+
+        session_key = metadata.get("session_key", "")
+
+        # --- Load prior conversation from session store ---
+        ctx = ConversationContext(max_turns=_GATEWAY_MAX_TURNS)
+        if session_key:
+            prior = runtime.session_store.get(session_key)
+            if prior and isinstance(prior.get("messages"), list):
+                ctx.messages = prior["messages"]
+                log.info(
+                    "Gateway multi-turn: loaded %d messages for %s",
+                    len(ctx.messages),
+                    session_key,
+                )
+
         agentic_ref: list[Any] = [None]
         handlers = _build_tool_handlers(
             mcp_manager=boot.mcp_manager,
@@ -1714,6 +1731,15 @@ def serve(
         agentic_ref[0] = loop
         try:
             result = loop.run(content)
+
+            # --- Persist conversation for next turn ---
+            if session_key:
+                runtime.session_store.set(session_key, {
+                    "messages": ctx.messages,
+                    "thread_id": metadata.get("thread_id", ""),
+                    "channel": metadata.get("channel", ""),
+                })
+
             return result.text if result else ""
         except Exception as exc:
             log.warning("Gateway processor error: %s", exc, exc_info=True)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1734,11 +1734,14 @@ def serve(
 
             # --- Persist conversation for next turn ---
             if session_key:
-                runtime.session_store.set(session_key, {
-                    "messages": ctx.messages,
-                    "thread_id": metadata.get("thread_id", ""),
-                    "channel": metadata.get("channel", ""),
-                })
+                runtime.session_store.set(
+                    session_key,
+                    {
+                        "messages": ctx.messages,
+                        "thread_id": metadata.get("thread_id", ""),
+                        "channel": metadata.get("channel", ""),
+                    },
+                )
 
             return result.text if result else ""
         except Exception as exc:

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -8,17 +8,14 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
 from typing import Any
 
 from core.gateway.models import ChannelBinding, InboundMessage
 from core.gateway.pollers.base import BasePoller
+from core.infrastructure.ports.gateway_port import MessageProcessor
 from core.memory.session_key import build_gateway_session_key
 
 log = logging.getLogger(__name__)
-
-# Type for the message processor callback
-MessageProcessor = Callable[[str], str]  # input → response
 
 
 class ChannelManager:
@@ -110,10 +107,21 @@ class ChannelManager:
             log.warning("No message processor set — cannot process inbound message")
             return None
 
-        # Build gateway session key for context isolation
+        # Build gateway session key for context isolation (thread-scoped)
         session_key = build_gateway_session_key(
-            message.channel, message.channel_id, message.sender_id
+            message.channel,
+            message.channel_id,
+            message.sender_id,
+            thread_id=message.thread_id,
         )
+
+        metadata: dict[str, Any] = {
+            "session_key": session_key,
+            "thread_id": message.thread_id,
+            "channel": message.channel,
+            "channel_id": message.channel_id,
+            "sender_id": message.sender_id,
+        }
 
         # Strip mention tags so the LLM receives clean content
         content = self._strip_mentions(message.content)
@@ -128,11 +136,11 @@ class ChannelManager:
                 gateway_lane = self._lane_queue.get_lane("gateway")
                 if gateway_lane is not None:
                     with gateway_lane.acquire(session_key):
-                        response = self._processor(content)
+                        response = self._processor(content, metadata)
                 else:
-                    response = self._processor(content)
+                    response = self._processor(content, metadata)
             else:
-                response = self._processor(content)
+                response = self._processor(content, metadata)
 
             self._stats["processed"] += 1
             return response

--- a/core/infrastructure/ports/gateway_port.py
+++ b/core/infrastructure/ports/gateway_port.py
@@ -10,6 +10,11 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, Protocol, runtime_checkable
 
+#: Processor callback signature.
+#: ``(content, metadata) -> response``
+#: metadata keys: ``session_key``, ``thread_id``, ``channel``, ``channel_id``, ``sender_id``
+MessageProcessor = Callable[[str, dict[str, Any]], str]
+
 
 @runtime_checkable
 class GatewayPort(Protocol):
@@ -23,7 +28,7 @@ class GatewayPort(Protocol):
         """Stop all pollers."""
         ...
 
-    def set_processor(self, processor: Callable[[str], str]) -> None:
+    def set_processor(self, processor: MessageProcessor) -> None:
         """Set the message processor callback."""
         ...
 

--- a/core/memory/session_key.py
+++ b/core/memory/session_key.py
@@ -133,20 +133,27 @@ def build_gateway_session_key(
     channel: str,
     channel_id: str,
     sender_id: str = "",
+    thread_id: str = "",
 ) -> str:
     """Build a session key for a gateway inbound message.
 
-    Format: gateway:{channel}:{channel_id}[:{sender_id}]
+    Format: gateway:{channel}:{channel_id}[:{sender_id}][:{thread_id}]
+
+    When ``thread_id`` is provided the key scopes to a specific
+    conversation thread, enabling multi-turn context within that thread.
 
     Examples:
         gateway:slack:C12345
+        gateway:slack:C12345:U789:1234567890.123456
         gateway:telegram:987654321:U123
         gateway:discord:456789
     """
-    parts = [f"gateway:{channel}:{_normalize_name(channel_id)}"]
+    key = f"gateway:{channel}:{_normalize_name(channel_id)}"
     if sender_id:
-        parts[0] += f":{_normalize_name(sender_id)}"
-    return parts[0]
+        key += f":{_normalize_name(sender_id)}"
+    if thread_id:
+        key += f":{_normalize_name(thread_id)}"
+    return key
 
 
 def build_thread_config(ip_name: str, phase: str, sub_context: str | None = None) -> dict[str, Any]:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -68,7 +68,7 @@ class TestChannelBinding:
 class TestChannelManager:
     def test_route_message_with_binding(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: f"Response to: {content}")
+        manager.set_processor(lambda content, meta: f"Response to: {content}")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -84,7 +84,7 @@ class TestChannelManager:
 
     def test_route_message_no_binding(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: "response")
+        manager.set_processor(lambda content, meta: "response")
 
         msg = InboundMessage(
             channel="telegram",
@@ -100,7 +100,7 @@ class TestChannelManager:
     def test_specific_binding_wins(self):
         """Most-specific binding (channel + channel_id) should win."""
         manager = ChannelManager()
-        manager.set_processor(lambda content: "processed")
+        manager.set_processor(lambda content, meta: "processed")
 
         # Add generic binding
         manager.add_binding(ChannelBinding(channel="slack"))
@@ -120,7 +120,7 @@ class TestChannelManager:
 
     def test_require_mention_filter(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: "processed")
+        manager.set_processor(lambda content, meta: "processed")
         manager.add_binding(ChannelBinding(channel="discord", require_mention=True))
 
         # Without mention — should be ignored
@@ -160,7 +160,7 @@ class TestChannelManager:
 
     def test_stats(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: "ok")
+        manager.set_processor(lambda content, meta: "ok")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -187,7 +187,7 @@ class TestChannelManager:
 
     def test_processor_exception(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: 1 / 0)
+        manager.set_processor(lambda content, meta: 1 / 0)
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -325,13 +325,31 @@ class TestGatewaySessionKey:
         key = build_gateway_session_key("telegram", "987654")
         assert key == "gateway:telegram:987654"
 
+    def test_build_gateway_session_key_with_thread_id(self):
+        from core.memory.session_key import build_gateway_session_key
+
+        key = build_gateway_session_key("slack", "C12345", "U67890", thread_id="1234567890.123456")
+        assert "1234567890_123456" in key
+        # Without thread_id should be shorter
+        key_no_thread = build_gateway_session_key("slack", "C12345", "U67890")
+        assert len(key) > len(key_no_thread)
+
+    def test_different_threads_different_keys(self):
+        from core.memory.session_key import build_gateway_session_key
+
+        k1 = build_gateway_session_key("slack", "C1", "U1", thread_id="111.000")
+        k2 = build_gateway_session_key("slack", "C1", "U1", thread_id="222.000")
+        k3 = build_gateway_session_key("slack", "C1", "U1")
+        assert k1 != k2
+        assert k1 != k3
+
 
 class TestAllowedToolsEnforcement:
     def test_allowed_tools_hint_injected(self):
         """Binding's allowed_tools should be prefixed to content."""
         received_content = []
         manager = ChannelManager()
-        manager.set_processor(lambda c: (received_content.append(c), "ok")[1])
+        manager.set_processor(lambda c, m: (received_content.append(c), "ok")[1])
         manager.add_binding(
             ChannelBinding(
                 channel="slack",
@@ -355,7 +373,7 @@ class TestAllowedToolsEnforcement:
         """Without allowed_tools, content passes through unchanged."""
         received_content = []
         manager = ChannelManager()
-        manager.set_processor(lambda c: (received_content.append(c), "ok")[1])
+        manager.set_processor(lambda c, m: (received_content.append(c), "ok")[1])
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -379,7 +397,7 @@ class TestLaneQueueIntegration:
         lq.add_lane("gateway", max_concurrent=2)
 
         manager = ChannelManager(lane_queue=lq)
-        manager.set_processor(lambda c: f"processed: {c}")
+        manager.set_processor(lambda c, m: f"processed: {c}")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -396,7 +414,7 @@ class TestLaneQueueIntegration:
     def test_route_without_lane_queue(self):
         """Messages should still work without lane queue."""
         manager = ChannelManager(lane_queue=None)
-        manager.set_processor(lambda c: "ok")
+        manager.set_processor(lambda c, m: "ok")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -451,6 +469,80 @@ class TestBindingConfigReload:
         bindings = manager.list_bindings()
         assert len(bindings) == 1
         assert bindings[0]["channel"] == "slack"
+
+
+class TestMultiTurnMetadata:
+    """Verify that route_message passes metadata to the processor."""
+
+    def test_metadata_contains_session_key(self):
+        """Processor receives session_key in metadata."""
+        captured: list[dict] = []
+        manager = ChannelManager()
+        manager.set_processor(lambda c, m: (captured.append(m), "ok")[1])
+        manager.add_binding(ChannelBinding(channel="slack"))
+
+        msg = InboundMessage(
+            channel="slack",
+            channel_id="C123",
+            sender_id="U456",
+            sender_name="Bob",
+            content="hello",
+            timestamp=time.time(),
+            thread_id="1234567890.123456",
+        )
+        manager.route_message(msg)
+
+        assert len(captured) == 1
+        meta = captured[0]
+        assert "session_key" in meta
+        assert "c123" in meta["session_key"]
+        assert "u456" in meta["session_key"]
+        assert "1234567890_123456" in meta["session_key"]
+        assert meta["thread_id"] == "1234567890.123456"
+        assert meta["channel"] == "slack"
+
+    def test_metadata_without_thread_id(self):
+        """Messages without thread_id still get session_key."""
+        captured: list[dict] = []
+        manager = ChannelManager()
+        manager.set_processor(lambda c, m: (captured.append(m), "ok")[1])
+        manager.add_binding(ChannelBinding(channel="slack"))
+
+        msg = InboundMessage(
+            channel="slack",
+            channel_id="C123",
+            sender_id="U456",
+            sender_name="Bob",
+            content="hello",
+            timestamp=time.time(),
+        )
+        manager.route_message(msg)
+
+        meta = captured[0]
+        assert "session_key" in meta
+        assert meta["thread_id"] == ""
+
+    def test_thread_scoped_session_keys_differ(self):
+        """Different threads produce different session keys."""
+        keys: list[str] = []
+        manager = ChannelManager()
+        manager.set_processor(lambda c, m: (keys.append(m["session_key"]), "ok")[1])
+        manager.add_binding(ChannelBinding(channel="slack"))
+
+        for thread_id in ["111.000", "222.000"]:
+            msg = InboundMessage(
+                channel="slack",
+                channel_id="C123",
+                sender_id="U456",
+                sender_name="Bob",
+                content="hello",
+                timestamp=time.time(),
+                thread_id=thread_id,
+            )
+            manager.route_message(msg)
+
+        assert len(keys) == 2
+        assert keys[0] != keys[1]
 
 
 class TestPollerLifecycle:


### PR DESCRIPTION
## Summary
- MessageProcessor 시그니처 확장 `(str) → (str, dict[str, Any])` — session_key, thread_id 메타데이터 전달
- `_gateway_processor`에서 SessionStore 기반 대화 이력 로드/저장 연결
- `build_gateway_session_key()`에 thread_id 파라미터 추가 — Slack 스레드별 세션 분리

## Why
`geode serve`가 매 메시지마다 빈 ConversationContext를 생성하여 이전 대화 맥락이 유실됨.
모든 인프라(SessionStore, ConversationContext, session_key, thread_id 캡처)는 존재했으나 연결되지 않은 상태였음.

## Test plan
- [x] 기존 gateway 테스트 37건 시그니처 갱신 → 전체 통과
- [x] 멀티턴 메타데이터 테스트 3건 추가
- [x] thread_id 기반 세션 키 테스트 2건 추가
- [x] 품질 게이트: lint 0, type 0, 3224 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)