### PR TITLE
fix: 웹검색 모델 Opus 4.6 고정 + general_web_search 우선순위

### DIFF
--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -592,7 +592,7 @@
   },
   {
     "name": "general_web_search",
-    "description": "웹에서 최신 정보를 검색합니다. 사용자가 현재 정보, 뉴스, 트렌드를 물어볼 때 사용하세요.",
+    "description": "웹에서 최신 정보를 검색합니다. 기본 웹 검색 도구 — 사용자가 현재 정보, 뉴스, 트렌드를 물어볼 때 이 도구를 우선 사용하세요. Anthropic 네이티브 웹 검색으로 무제한 사용 가능합니다. (brave_web_search MCP는 무료 한도 제한이 있으므로 fallback으로만 사용)",
     "category": "external",
     "cost_tier": "cheap",
     "input_schema": {

--- a/core/tools/signal_tools.py
+++ b/core/tools/signal_tools.py
@@ -19,7 +19,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from core.config import ANTHROPIC_BUDGET
+from core.config import ANTHROPIC_PRIMARY
 from core.domains.game_ip.fixtures import load_fixture
 
 log = logging.getLogger(__name__)
@@ -440,7 +440,7 @@ class WebSearchTool:
 
             client = get_anthropic_client()
             response = client.messages.create(
-                model=ANTHROPIC_BUDGET,
+                model=ANTHROPIC_PRIMARY,
                 max_tokens=1024,
                 tools=[{"type": "web_search_20260209", "name": "web_search"}],
                 messages=[

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -99,7 +99,7 @@ class GeneralWebSearchTool:
         max_results: int = kwargs.get("max_results", 5)
 
         try:
-            from core.config import ANTHROPIC_BUDGET, settings
+            from core.config import ANTHROPIC_PRIMARY, settings
             from core.llm.router import get_anthropic_client
 
             if not settings.anthropic_api_key:
@@ -108,7 +108,7 @@ class GeneralWebSearchTool:
             today = date.today()
             client = get_anthropic_client()
             response = client.messages.create(
-                model=ANTHROPIC_BUDGET,
+                model=ANTHROPIC_PRIMARY,
                 max_tokens=1024,
                 tools=[{"type": "web_search_20260209", "name": "web_search"}],
                 messages=[


### PR DESCRIPTION
## Summary
- `general_web_search`: ANTHROPIC_BUDGET(Haiku) → **ANTHROPIC_PRIMARY(Opus 4.6)** — programmatic tool calling 지원
- `signal_tools` WebSearchTool: 동일 변경
- `definitions.json`: general_web_search를 primary로, brave_web_search를 fallback으로 안내

## Root Cause
Haiku가 `web_search_20260209`의 programmatic tool calling을 지원하지 않아 400 에러.

## Test plan
- [x] 3219 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)