### PR TITLE
feat: Gateway-REPL 통합 팩토리 + config.toml 상수화

### DIFF
--- a/.geode/config.toml.example
+++ b/.geode/config.toml.example
@@ -1,21 +1,28 @@
-# GEODE Gateway — Channel Bindings
+# GEODE Gateway Configuration
 #
 # 이 파일을 .geode/config.toml로 복사한 뒤 채널 ID를 입력하세요.
 # config.toml은 .gitignore에 의해 추적되지 않습니다 (개인정보 보호).
-#
-# 채널 ID 확인법:
-#   Slack 채널 → 채널명 클릭 → 맨 아래 "Channel ID" 복사
+
+# ---------------------------------------------------------------------------
+# Gateway 전역 설정
+# ---------------------------------------------------------------------------
+[gateway]
+max_rounds = 30       # AgenticLoop 최대 라운드 (기본 30, 복잡한 질문도 끝까지)
+max_turns = 20        # 스레드당 대화 이력 최대 턴 수
+
+# ---------------------------------------------------------------------------
+# 채널 바인딩
+# ---------------------------------------------------------------------------
+# 채널 ID 확인법: Slack 채널 → 채널명 클릭 → 맨 아래 "Channel ID" 복사
 #
 # 옵션:
 #   auto_respond    — 메시지 수신 시 자동 응답 (true/false)
 #   require_mention — @멘션 필수 여부 (true: 멘션 시에만 응답)
-#   max_rounds      — AgenticLoop 최대 라운드 수
-
-[gateway.bindings]
+#   max_rounds      — 이 채널의 AgenticLoop 최대 라운드 (전역 설정 오버라이드)
 
 [[gateway.bindings.rules]]
 channel = "slack"
 channel_id = "C0XXXXXXXXX"  # 채널 ID
 auto_respond = true
 require_mention = true
-max_rounds = 5
+# max_rounds = 30  # 채널별 오버라이드 (생략 시 [gateway] 전역값 사용)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -23,9 +23,8 @@ from typing import Any, cast
 import typer
 
 from core import __version__
-from core.agent.agentic_loop import AgenticLoop, AgenticResult
+from core.agent.agentic_loop import AgenticResult
 from core.agent.conversation import ConversationContext
-from core.agent.tool_executor import ToolExecutor
 from core.cli.commands import (
     cmd_apply,
     cmd_auth,
@@ -695,6 +694,67 @@ def _handle_memory_action(intent: Any, user_text: str, is_offline: bool) -> None
         console.print()
 
 
+def _build_agentic_stack(
+    conversation: Any,
+    *,
+    mcp_manager: Any = None,
+    skill_registry: Any = None,
+    verbose: bool = False,
+    hitl_level: int = 2,
+    max_rounds: int = 50,
+    model: str | None = None,
+    provider: str | None = None,
+    system_suffix: str = "",
+    quiet: bool = False,
+) -> tuple[Any, Any, Any]:
+    """Build ToolExecutor + AgenticLoop stack. Single source for REPL, Gateway, Batch.
+
+    Returns (agentic_ref, executor, loop).  The ``agentic_ref`` is a mutable
+    list whose [0] element is set to the created AgenticLoop — callers that
+    need it for handler closures can pass the same list to ``_build_tool_handlers``.
+    """
+    from core.agent.agentic_loop import AgenticLoop
+    from core.agent.tool_executor import ToolExecutor
+    from core.config import _resolve_provider
+    from core.config import settings as _stk_settings
+
+    _model = model or _stk_settings.model
+    _provider = provider or _resolve_provider(_model)
+
+    agentic_ref: list[Any] = [None]
+    handlers = _build_tool_handlers(
+        verbose=verbose,
+        mcp_manager=mcp_manager,
+        agentic_ref=agentic_ref,
+        skill_registry=skill_registry,
+    )
+    sub_mgr = _build_sub_agent_manager(
+        verbose=verbose,
+        action_handlers=handlers,
+        mcp_manager=mcp_manager,
+        skill_registry=skill_registry,
+    )
+    executor = ToolExecutor(
+        action_handlers=handlers,
+        mcp_manager=mcp_manager,
+        sub_agent_manager=sub_mgr,
+        hitl_level=hitl_level,
+    )
+    loop = AgenticLoop(
+        conversation,
+        executor,
+        max_rounds=max_rounds,
+        model=_model,
+        provider=_provider,
+        mcp_manager=mcp_manager,
+        skill_registry=skill_registry,
+        system_suffix=system_suffix,
+        quiet=quiet,
+    )
+    agentic_ref[0] = loop
+    return agentic_ref, executor, loop
+
+
 def _build_sub_agent_manager(
     verbose: bool = False,
     *,
@@ -971,26 +1031,14 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
     console.print()  # blank line before prompt
 
-    # Build tool handlers and executor
-    agentic_ref: list[Any] = [None]  # mutable ref for handler closure
-    handlers = _build_tool_handlers(
-        verbose=verbose, mcp_manager=mcp_mgr, agentic_ref=agentic_ref, skill_registry=skill_registry
-    )
-    sub_mgr = _build_sub_agent_manager(
-        verbose=verbose,
-        action_handlers=handlers,
+    # Build tool handlers, executor, and AgenticLoop (shared factory)
+    _last_verbose = verbose
+    agentic_ref, executor, agentic = _build_agentic_stack(
+        conversation,
         mcp_manager=mcp_mgr,
         skill_registry=skill_registry,
+        verbose=verbose,
     )
-    executor = ToolExecutor(
-        action_handlers=handlers,
-        mcp_manager=mcp_mgr,
-        sub_agent_manager=sub_mgr,
-    )
-    agentic = AgenticLoop(
-        conversation, executor, mcp_manager=mcp_mgr, skill_registry=skill_registry
-    )
-    agentic_ref[0] = agentic
 
     # Initialize session meter for status line
     from core.cli.ui.agentic_ui import init_session_meter
@@ -1077,31 +1125,14 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
             if settings.model != agentic.model:
                 agentic.update_model(settings.model)
             # Update handlers if verbose changed
-            if verbose != (handlers.get("_verbose_flag") is True):
-                handlers = _build_tool_handlers(
-                    verbose=verbose,
-                    mcp_manager=mcp_mgr,
-                    agentic_ref=agentic_ref,
-                    skill_registry=skill_registry,
-                )
-                sub_mgr = _build_sub_agent_manager(
-                    verbose=verbose,
-                    action_handlers=handlers,
-                    mcp_manager=mcp_mgr,
-                    skill_registry=skill_registry,
-                )
-                executor = ToolExecutor(
-                    action_handlers=handlers,
-                    mcp_manager=mcp_mgr,
-                    sub_agent_manager=sub_mgr,
-                )
-                agentic = AgenticLoop(
+            if verbose != _last_verbose:
+                _last_verbose = verbose
+                agentic_ref, executor, agentic = _build_agentic_stack(
                     conversation,
-                    executor,
                     mcp_manager=mcp_mgr,
                     skill_registry=skill_registry,
+                    verbose=verbose,
                 )
-                agentic_ref[0] = agentic
         else:
             # Agentic loop: multi-turn + multi-intent (online) or offline regex
             # Key management is handled via /key command or set_api_key tool.
@@ -1652,9 +1683,7 @@ def serve(
         raise typer.Exit(1)
 
     # Wire AgenticLoop as gateway processor
-    from core.agent.agentic_loop import AgenticLoop
     from core.agent.conversation import ConversationContext
-    from core.agent.tool_executor import ToolExecutor
     from core.infrastructure.ports.gateway_port import get_gateway
 
     gateway = get_gateway()
@@ -1663,29 +1692,31 @@ def serve(
         raise typer.Exit(1)
 
     _GATEWAY_SUFFIX = (
-        "## Gateway response rules\n"
-        "This message comes from an external messaging channel (Slack/Discord/Telegram).\n"
-        "- Do NOT echo, repeat, or quote the user's message in your response.\n"
-        "- Do NOT prefix your response with 'GEODE:' or the user's original text.\n"
-        "- Respond directly with the answer only. Be concise.\n"
-        "- You have access to prior messages in this thread as conversation history."
+        "## Gateway mode\n"
+        "You are responding via an external messaging channel (Slack/Discord/Telegram).\n"
+        "- Do NOT echo or quote the user's message. Respond directly.\n"
+        "- Use tools aggressively to answer thoroughly. Do not give up early.\n"
+        "- For complex questions, break them down and use multiple tool calls.\n"
+        "- You have access to prior messages in this thread as conversation history.\n"
+        "- Format responses for messaging: use short paragraphs, avoid excessive markdown."
     )
 
-    # Max conversation turns to persist per thread (safety net)
-    _GATEWAY_MAX_TURNS = 20
+    # Read gateway config from ChannelManager (loaded from config.toml)
+    _gw_max_rounds = gateway.gateway_max_rounds if hasattr(gateway, "gateway_max_rounds") else 30
+    _gw_max_turns = gateway.gateway_max_turns if hasattr(gateway, "gateway_max_turns") else 20
 
     def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:
         """Process a gateway message with multi-turn context.
 
-        Loads prior conversation from SessionStore (keyed by thread),
-        runs AgenticLoop, then persists the updated conversation back.
+        Uses the same _build_agentic_stack() factory as REPL — only
+        system_suffix, hitl_level, and quiet differ.
         """
         boot.propagate_to_thread()  # Fix ContextVar propagation for daemon thread
 
         session_key = metadata.get("session_key", "")
 
         # --- Load prior conversation from session store ---
-        ctx = ConversationContext(max_turns=_GATEWAY_MAX_TURNS)
+        ctx = ConversationContext(max_turns=_gw_max_turns)
         if session_key:
             prior = runtime.session_store.get(session_key)
             if prior and isinstance(prior.get("messages"), list):
@@ -1696,39 +1727,16 @@ def serve(
                     session_key,
                 )
 
-        agentic_ref: list[Any] = [None]
-        handlers = _build_tool_handlers(
-            mcp_manager=boot.mcp_manager,
-            agentic_ref=agentic_ref,
-            skill_registry=boot.skill_registry,
-        )
-        sub_mgr = _build_sub_agent_manager(
-            action_handlers=handlers,
-            mcp_manager=boot.mcp_manager,
-            skill_registry=boot.skill_registry,
-        )
-        executor = ToolExecutor(
-            action_handlers=handlers,
-            mcp_manager=boot.mcp_manager,
-            sub_agent_manager=sub_mgr,
-            hitl_level=0,
-        )
-        from core.config import _resolve_provider
-        from core.config import settings as _gw_settings
-
-        gw_model = _gw_settings.model
-        gw_provider = _resolve_provider(gw_model)
-        loop = AgenticLoop(
+        # Same factory as REPL — only output behavior differs
+        _ref, _executor, loop = _build_agentic_stack(
             ctx,
-            executor,
-            max_rounds=50,
-            model=gw_model,
-            provider=gw_provider,
             mcp_manager=boot.mcp_manager,
             skill_registry=boot.skill_registry,
+            hitl_level=0,
+            max_rounds=_gw_max_rounds,
             system_suffix=_GATEWAY_SUFFIX,
+            quiet=True,
         )
-        agentic_ref[0] = loop
         try:
             result = loop.run(content)
 

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -36,6 +36,9 @@ class ChannelManager:
         self._lane_queue = lane_queue  # LaneQueue for concurrency control
         self._lock = threading.Lock()
         self._stats: dict[str, int] = {"received": 0, "processed": 0, "ignored": 0}
+        # Gateway-level defaults (overridden by config.toml [gateway])
+        self.gateway_max_rounds: int = 30
+        self.gateway_max_turns: int = 20
 
     def register_poller(self, poller: BasePoller) -> None:
         """Register a poller to be managed by this gateway."""
@@ -214,25 +217,38 @@ class ChannelManager:
             ]
 
     def load_bindings_from_config(self, config: dict[str, Any]) -> int:
-        """Load bindings from TOML/dict config (hot-reloadable).
+        """Load bindings and gateway-level settings from TOML/dict config.
 
         Expected format::
 
-            [gateway.bindings]
+            [gateway]
+            max_rounds = 30
+            max_turns = 20
+
             [[gateway.bindings.rules]]
             channel = "slack"
             channel_id = "C12345"
             auto_respond = true
-            require_mention = false
 
         Returns number of bindings loaded.
         """
-        rules = config.get("gateway", {}).get("bindings", {}).get("rules", [])
+        gw = config.get("gateway", {})
+
+        # Gateway-level defaults
+        if "max_rounds" in gw:
+            self.gateway_max_rounds = int(gw["max_rounds"])
+        if "max_turns" in gw:
+            self.gateway_max_turns = int(gw["max_turns"])
+
+        rules = gw.get("bindings", {}).get("rules", [])
         if not rules:
             return 0
 
         with self._lock:
             self._bindings.clear()
+
+        # Per-binding max_rounds falls back to gateway-level default
+        default_max_rounds = self.gateway_max_rounds
 
         loaded = 0
         for rule in rules:
@@ -244,10 +260,15 @@ class ChannelManager:
                 auto_respond=rule.get("auto_respond", True),
                 require_mention=rule.get("require_mention", False),
                 allowed_tools=rule.get("allowed_tools", []),
-                max_rounds=rule.get("max_rounds", 5),
+                max_rounds=rule.get("max_rounds", default_max_rounds),
             )
             self.add_binding(binding)
             loaded += 1
 
-        log.info("Loaded %d gateway bindings from config", loaded)
+        log.info(
+            "Loaded %d gateway bindings from config (max_rounds=%d, max_turns=%d)",
+            loaded,
+            self.gateway_max_rounds,
+            self.gateway_max_turns,
+        )
         return loaded


### PR DESCRIPTION
## Summary
- `_build_agentic_stack()` 팩토리 추출 — REPL/Gateway/Batch가 동일 빌드 로직 공유 (Kent Beck DRY)
- `config.toml [gateway]` 섹션 추가 — `max_rounds`, `max_turns` 전역 설정 + 채널별 오버라이드
- `_GATEWAY_SUFFIX` 적극성 조정 — "Be concise" → "Use tools aggressively, do not give up early"

## Why
Gateway가 REPL과 별개로 AgenticLoop를 매번 수동 조립하여 동작 차이 발생 + 설정 하드코딩.
Kent Beck Simple Design Rule 3 (No Duplication) 위반. 43줄 x 3곳 중복 → 팩토리 1곳으로 통합.

## Test plan
- [x] lint 0, format clean, type 0 (208 files)
- [x] 3224 passed, 1 skipped
- [x] Gateway 테스트 37건 통과
- [x] config.toml 파싱 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)