### PR TITLE
refactor: Kent Beck Phase 1 — dry-run 파싱 + Safety 상수 추출

### DIFF
--- a/core/agent/safety_constants.py
+++ b/core/agent/safety_constants.py
@@ -1,0 +1,111 @@
+"""Safety classification constants for tool execution.
+
+Single source of truth for tool risk levels. Used by ToolExecutor
+(immediate gating) and ToolCallProcessor (tier classification for
+parallel batching).
+"""
+
+from __future__ import annotations
+
+# Read-only tools — safe for sub-agent auto-approval
+SAFE_TOOLS: frozenset[str] = frozenset(
+    {
+        "list_ips",
+        "search_ips",
+        "show_help",
+        "check_status",
+        "switch_model",
+        "memory_search",
+        "manage_rule",
+        "web_fetch",
+        "general_web_search",
+        "note_read",
+        "read_document",
+        "profile_show",
+        "calendar_list_events",
+    }
+)
+
+# System-access tools — always require HITL approval
+DANGEROUS_TOOLS: frozenset[str] = frozenset(
+    {
+        "run_bash",
+    }
+)
+
+# Write tools modify persistent state (credentials, memory, files).
+# Require explicit user confirmation — never auto-approved, even for sub-agents.
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "memory_save",
+        "note_save",
+        "set_api_key",
+        "manage_auth",
+        "profile_update",
+        "profile_preference",
+        "profile_learn",
+        "calendar_create_event",
+        "calendar_sync_scheduler",
+        "manage_context",
+    }
+)
+
+# Expensive tools require cost confirmation before execution
+EXPENSIVE_TOOLS: dict[str, float] = {
+    "analyze_ip": 1.50,
+    "batch_analyze": 5.00,
+    "compare_ips": 3.00,
+}
+
+# Bash commands starting with these prefixes are safe (read-only, no side effects).
+# They execute without HITL approval to reduce friction for common queries.
+SAFE_BASH_PREFIXES: tuple[str, ...] = (
+    "cat ",
+    "head ",
+    "tail ",
+    "ls ",
+    "ls\n",
+    "pwd",
+    "echo ",
+    "wc ",
+    "grep ",
+    "rg ",
+    "find ",
+    "which ",
+    "whoami",
+    "date",
+    "env ",
+    "printenv",
+    "uname",
+    "df ",
+    "du ",
+    "file ",
+    "stat ",
+    "curl -s",
+    "curl --silent",
+    "python3 -c",
+    "python -c",
+    "uv run pytest",
+    "uv run ruff",
+    "uv run mypy",
+    "uv run python",
+    "git status",
+    "git log",
+    "git diff",
+    "git branch",
+    "git show",
+    "git remote",
+    "gh pr",
+    "gh run",
+    "gh api",
+)
+
+# MCP servers that are read-only and auto-approved (no HITL gate on first call).
+AUTO_APPROVED_MCP_SERVERS: frozenset[str] = frozenset(
+    {
+        "brave-search",
+        "steam",
+        "arxiv",
+        "linkedin-reader",
+    }
+)

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -24,18 +24,16 @@ if TYPE_CHECKING:
     from core.cli.ui.agentic_ui import OperationLogger
     from core.orchestration.hooks import HookSystem
 
-from core.cli.bash_tool import BashTool
-from core.cli.ui.console import console
-
-log = logging.getLogger(__name__)
-
-# Re-export safety constants from single source of truth
 from core.agent.safety_constants import AUTO_APPROVED_MCP_SERVERS as AUTO_APPROVED_MCP_SERVERS
 from core.agent.safety_constants import DANGEROUS_TOOLS as DANGEROUS_TOOLS
 from core.agent.safety_constants import EXPENSIVE_TOOLS as EXPENSIVE_TOOLS
 from core.agent.safety_constants import SAFE_BASH_PREFIXES as SAFE_BASH_PREFIXES
 from core.agent.safety_constants import SAFE_TOOLS as SAFE_TOOLS
 from core.agent.safety_constants import WRITE_TOOLS as WRITE_TOOLS
+from core.cli.bash_tool import BashTool
+from core.cli.ui.console import console
+
+log = logging.getLogger(__name__)
 
 # Everything else is STANDARD — executes without special gates
 

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -29,107 +29,13 @@ from core.cli.ui.console import console
 
 log = logging.getLogger(__name__)
 
-# Tool safety classifications
-SAFE_TOOLS: frozenset[str] = frozenset(
-    {
-        "list_ips",
-        "search_ips",
-        "show_help",
-        "check_status",
-        "switch_model",
-        "memory_search",
-        "manage_rule",
-        "web_fetch",
-        "general_web_search",
-        "note_read",
-        "read_document",
-        "profile_show",
-        "calendar_list_events",
-    }
-)
-
-DANGEROUS_TOOLS: frozenset[str] = frozenset(
-    {
-        "run_bash",
-    }
-)
-
-# Write tools modify persistent state (credentials, memory, files).
-# Require explicit user confirmation — never auto-approved, even for sub-agents.
-WRITE_TOOLS: frozenset[str] = frozenset(
-    {
-        "memory_save",
-        "note_save",
-        "set_api_key",
-        "manage_auth",
-        "profile_update",
-        "profile_preference",
-        "profile_learn",
-        "calendar_create_event",
-        "calendar_sync_scheduler",
-        "manage_context",
-    }
-)
-
-# Expensive tools require cost confirmation before execution
-EXPENSIVE_TOOLS: dict[str, float] = {
-    "analyze_ip": 1.50,
-    "batch_analyze": 5.00,
-    "compare_ips": 3.00,
-}
-
-# Bash commands starting with these prefixes are safe (read-only, no side effects).
-# They execute without HITL approval to reduce friction for common queries.
-SAFE_BASH_PREFIXES: tuple[str, ...] = (
-    "cat ",
-    "head ",
-    "tail ",
-    "ls ",
-    "ls\n",
-    "pwd",
-    "echo ",
-    "wc ",
-    "grep ",
-    "rg ",
-    "find ",
-    "which ",
-    "whoami",
-    "date",
-    "env ",
-    "printenv",
-    "uname",
-    "df ",
-    "du ",
-    "file ",
-    "stat ",
-    "curl -s",
-    "curl --silent",
-    "python3 -c",
-    "python -c",
-    "uv run pytest",
-    "uv run ruff",
-    "uv run mypy",
-    "uv run python",
-    "git status",
-    "git log",
-    "git diff",
-    "git branch",
-    "git show",
-    "git remote",
-    "gh pr",
-    "gh run",
-    "gh api",
-)
-
-# MCP servers that are read-only and auto-approved (no HITL gate on first call).
-AUTO_APPROVED_MCP_SERVERS: frozenset[str] = frozenset(
-    {
-        "brave-search",
-        "steam",
-        "arxiv",
-        "linkedin-reader",
-    }
-)
+# Re-export safety constants from single source of truth
+from core.agent.safety_constants import AUTO_APPROVED_MCP_SERVERS as AUTO_APPROVED_MCP_SERVERS
+from core.agent.safety_constants import DANGEROUS_TOOLS as DANGEROUS_TOOLS
+from core.agent.safety_constants import EXPENSIVE_TOOLS as EXPENSIVE_TOOLS
+from core.agent.safety_constants import SAFE_BASH_PREFIXES as SAFE_BASH_PREFIXES
+from core.agent.safety_constants import SAFE_TOOLS as SAFE_TOOLS
+from core.agent.safety_constants import WRITE_TOOLS as WRITE_TOOLS
 
 # Everything else is STANDARD — executes without special gates
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -362,6 +362,8 @@ def _handle_command(
     mcp_manager: Any = None,
 ) -> tuple[bool, bool, Any]:
     """Handle a slash command. Returns (should_break, new_verbose, resume_state)."""
+    from core.cli._helpers import parse_dry_run_flag
+
     action = resolve_action(cmd)
 
     if action == "quit":
@@ -389,9 +391,9 @@ def _handle_command(
         readiness = _get_readiness()
         force_dry = readiness.force_dry_run if readiness else True
         # Support "--dry-run" flag in slash command args
-        if "--dry-run" in args or "--dry_run" in args:
+        dry_flag, args = parse_dry_run_flag(args)
+        if dry_flag:
             force_dry = True
-            args = args.replace("--dry-run", "").replace("--dry_run", "").strip()
         if force_dry and readiness is not None and not readiness.force_dry_run:
             console.print("  [info]Dry-run mode (explicitly requested)[/info]")
         elif force_dry:
@@ -425,8 +427,7 @@ def _handle_command(
                 " [html|json|md] [summary|detailed|executive][/warning]"
             )
         else:
-            dry_flag = "--dry-run" in args or "--dry_run" in args
-            clean_args = args.replace("--dry-run", "").replace("--dry_run", "").strip()
+            dry_flag, clean_args = parse_dry_run_flag(args)
             report_args = _parse_report_args(clean_args.split())
             readiness = _get_readiness()
             report_dry = readiness.force_dry_run if readiness else True
@@ -443,9 +444,9 @@ def _handle_command(
     elif action == "batch":
         readiness = _get_readiness()
         force_dry = readiness.force_dry_run if readiness else True
-        if "--dry-run" in args or "--dry_run" in args:
+        dry_flag, args = parse_dry_run_flag(args)
+        if dry_flag:
             force_dry = True
-            args = args.replace("--dry-run", "").replace("--dry_run", "").strip()
         cmd_batch(
             args,
             run_fn=_run_analysis,
@@ -503,7 +504,7 @@ def _handle_command(
         if len(parts) < 2:
             console.print("  [warning]Usage: /compare <IP_A> <IP_B>[/warning]")
         else:
-            dry_flag = "--dry-run" in args or "--dry_run" in args
+            dry_flag, _clean_compare = parse_dry_run_flag(args)
             clean_parts = [p for p in parts if p not in ("--dry-run", "--dry_run")]
             if len(clean_parts) < 2:
                 console.print("  [warning]Usage: /compare <IP_A> <IP_B>[/warning]")

--- a/core/cli/_helpers.py
+++ b/core/cli/_helpers.py
@@ -34,6 +34,17 @@ def upsert_env(var_name: str, value: str) -> None:
     env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def parse_dry_run_flag(args: str) -> tuple[bool, str]:
+    """Extract --dry-run / --dry_run flag from CLI args.
+
+    Returns ``(has_flag, cleaned_args)`` where ``cleaned_args`` has the
+    flag removed and is stripped of surrounding whitespace.
+    """
+    has_flag = "--dry-run" in args or "--dry_run" in args
+    cleaned = args.replace("--dry-run", "").replace("--dry_run", "").strip()
+    return has_flag, cleaned
+
+
 def is_glm_key(value: str) -> bool:
     """Detect ZhipuAI API key pattern: {id}.{secret} (e.g. abc12345.def67890).
 


### PR DESCRIPTION
## Summary
- `parse_dry_run_flag()` → `cli/_helpers.py` — 5곳 중복 → 1 함수
- Safety 상수 6개 → `agent/safety_constants.py` 단일 모듈 + re-export

## Why
Kent Beck Simple Design Rule 3 (No Duplication) 해소. dry-run 파싱 5곳 중복,
Safety 분류 상수가 tool_executor.py에 묻혀 4곳에서 참조. 기계적 추출, 행동 변경 0.

## Test plan
- [x] lint 0, format clean
- [x] type 0 (208 files)
- [x] 3224 passed, 1 skipped
- [x] re-export로 기존 import 경로 하위 호환

🤖 Generated with [Claude Code](https://claude.com/claude-code)