### PR TITLE
refactor: Kent Beck Phase 2 — Provider 디스패치 딕셔너리 통합

### DIFF
--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -312,73 +312,98 @@ async def call_with_failover(
 # ---------------------------------------------------------------------------
 
 
-def _get_provider_client(provider: str) -> Any:
-    """Return the correct SDK client for the given provider."""
-    if provider == "anthropic":
-        return get_anthropic_client()
-    if provider == "openai":
-        from core.llm.providers.openai import _get_openai_client
+# ---------------------------------------------------------------------------
+# Provider dispatch — single source of truth for per-provider configurations.
+# Replaces 6 individual _get_provider_*() functions (Kent Beck DRY).
+# ---------------------------------------------------------------------------
 
-        return _get_openai_client()
-    if provider == "glm":
-        from core.llm.providers.glm import _get_glm_client
-
-        return _get_glm_client()
-    raise ValueError(f"Unsupported provider: {provider}")
+# Per-provider circuit breakers (must be module-level singletons)
+_openai_cb = CircuitBreaker()
+_glm_cb = CircuitBreaker()
 
 
-def _get_fallback_chain(provider: str) -> list[str]:
-    """Return the fallback model chain for the given provider."""
-    if provider == "anthropic":
-        return list(ANTHROPIC_FALLBACK_CHAIN)
-    if provider == "openai":
-        return list(OPENAI_FALLBACK_CHAIN)
-    if provider == "glm":
-        return list(GLM_FALLBACK_CHAIN)
-    return []
-
-
-def _get_provider_retryable_errors(provider: str) -> tuple[type[Exception], ...]:
-    """Return retryable error types for the given provider."""
-    if provider == "anthropic":
-        return _RETRYABLE_ERRORS
-    # OpenAI and GLM both use the openai SDK
+def _openai_retryable() -> tuple[type[Exception], ...]:
     import openai
 
-    return (
-        openai.RateLimitError,
-        openai.APIConnectionError,
-        openai.InternalServerError,
-    )
+    return (openai.RateLimitError, openai.APIConnectionError, openai.InternalServerError)
 
 
-def _get_provider_bad_request_error(provider: str) -> type[Exception] | None:
-    """Return the bad-request error type for the given provider."""
-    if provider == "anthropic":
-        return anthropic.BadRequestError
+def _openai_bad_request() -> type[Exception]:
     import openai
 
     return openai.BadRequestError
 
 
-# Per-provider circuit breakers
-_openai_cb = CircuitBreaker()
-_glm_cb = CircuitBreaker()
+# Lazy dispatch table — callables to avoid import-time side effects
+_PROVIDER_DISPATCH: dict[str, dict[str, Any]] = {
+    "anthropic": {
+        "get_client": lambda: get_anthropic_client(),
+        "fallback_chain": lambda: list(ANTHROPIC_FALLBACK_CHAIN),
+        "retryable_errors": lambda: _RETRYABLE_ERRORS,
+        "bad_request_error": lambda: anthropic.BadRequestError,
+        "circuit_breaker": lambda: __import__(
+            "core.llm.providers.anthropic", fromlist=["get_circuit_breaker"]
+        ).get_circuit_breaker(),
+    },
+    "openai": {
+        "get_client": lambda: __import__(
+            "core.llm.providers.openai", fromlist=["_get_openai_client"]
+        )._get_openai_client(),
+        "fallback_chain": lambda: list(OPENAI_FALLBACK_CHAIN),
+        "retryable_errors": _openai_retryable,
+        "bad_request_error": _openai_bad_request,
+        "circuit_breaker": lambda: _openai_cb,
+    },
+    "glm": {
+        "get_client": lambda: __import__(
+            "core.llm.providers.glm", fromlist=["_get_glm_client"]
+        )._get_glm_client(),
+        "fallback_chain": lambda: list(GLM_FALLBACK_CHAIN),
+        "retryable_errors": _openai_retryable,  # GLM uses openai SDK
+        "bad_request_error": _openai_bad_request,
+        "circuit_breaker": lambda: _glm_cb,
+    },
+}
+
+
+def _get_provider_config(provider: str, key: str) -> Any:
+    """Lookup a provider-specific configuration by key.
+
+    Valid keys: get_client, fallback_chain, retryable_errors,
+    bad_request_error, circuit_breaker.
+    """
+    dispatch = _PROVIDER_DISPATCH.get(provider)
+    if dispatch is None:
+        raise ValueError(f"Unsupported provider: {provider}")
+    factory = dispatch.get(key)
+    if factory is None:
+        raise KeyError(f"Unknown config key '{key}' for provider '{provider}'")
+    return factory()
+
+
+# Convenience wrappers (preserve existing call sites)
+def _get_provider_client(provider: str) -> Any:
+    return _get_provider_config(provider, "get_client")
+
+
+def _get_fallback_chain(provider: str) -> list[str]:
+    result: list[str] = _get_provider_config(provider, "fallback_chain")
+    return result
+
+
+def _get_provider_retryable_errors(provider: str) -> tuple[type[Exception], ...]:
+    result: tuple[type[Exception], ...] = _get_provider_config(provider, "retryable_errors")
+    return result
+
+
+def _get_provider_bad_request_error(provider: str) -> type[Exception] | None:
+    result: type[Exception] | None = _get_provider_config(provider, "bad_request_error")
+    return result
 
 
 def _get_provider_circuit_breaker(provider: str) -> CircuitBreaker:
-    """Return the circuit breaker for the given provider."""
-    if provider == "anthropic":
-        from core.llm.providers.anthropic import get_circuit_breaker
-
-        return get_circuit_breaker()
-    if provider == "openai":
-        return _openai_cb
-    if provider == "glm":
-        return _glm_cb
-    from core.llm.providers.anthropic import get_circuit_breaker
-
-    return get_circuit_breaker()
+    result: CircuitBreaker = _get_provider_config(provider, "circuit_breaker")
+    return result
 
 
 def _retry_provider_aware(


### PR DESCRIPTION
## Summary
- 6개 `_get_provider_*()` if/elif 함수 → `_PROVIDER_DISPATCH` 딕셔너리 1개
- 기존 함수 시그니처 유지 (convenience wrapper)로 27 소비자 무변경
- 새 프로바이더 추가 시 딕셔너리 항목 1개만 추가

## Why
Kent Beck Rule 3 (No Duplication). provider 분기 if/elif가 5개 함수에서 각각 반복.
디스패치 테이블로 통합하면 단일 진실 소스가 되고, 확장성도 향상.

## Test plan
- [x] lint 0, format clean
- [x] type 0 (209 files)
- [x] 3224 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)