### PR TITLE
feat: Task Tool 노출 — task_create/update/get/list/stop + /tasks 커맨드

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1667,18 +1667,35 @@ def serve(
         "This message comes from an external messaging channel (Slack/Discord/Telegram).\n"
         "- Do NOT echo, repeat, or quote the user's message in your response.\n"
         "- Do NOT prefix your response with 'GEODE:' or the user's original text.\n"
-        "- Respond directly with the answer only. Be concise."
+        "- Respond directly with the answer only. Be concise.\n"
+        "- You have access to prior messages in this thread as conversation history."
     )
 
-    def _gateway_processor(content: str) -> str:
-        """Process a gateway message with a fresh AgenticLoop per message.
+    # Max conversation turns to persist per thread (safety net)
+    _GATEWAY_MAX_TURNS = 20
 
-        Uses bootstrap.propagate_to_thread() to fix ContextVar visibility
-        in daemon threads, then builds a per-message AgenticLoop with
-        the same MCP/skills/handlers as the REPL.
+    def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:
+        """Process a gateway message with multi-turn context.
+
+        Loads prior conversation from SessionStore (keyed by thread),
+        runs AgenticLoop, then persists the updated conversation back.
         """
         boot.propagate_to_thread()  # Fix ContextVar propagation for daemon thread
-        ctx = ConversationContext(max_turns=20)
+
+        session_key = metadata.get("session_key", "")
+
+        # --- Load prior conversation from session store ---
+        ctx = ConversationContext(max_turns=_GATEWAY_MAX_TURNS)
+        if session_key:
+            prior = runtime.session_store.get(session_key)
+            if prior and isinstance(prior.get("messages"), list):
+                ctx.messages = prior["messages"]
+                log.info(
+                    "Gateway multi-turn: loaded %d messages for %s",
+                    len(ctx.messages),
+                    session_key,
+                )
+
         agentic_ref: list[Any] = [None]
         handlers = _build_tool_handlers(
             mcp_manager=boot.mcp_manager,
@@ -1714,6 +1731,18 @@ def serve(
         agentic_ref[0] = loop
         try:
             result = loop.run(content)
+
+            # --- Persist conversation for next turn ---
+            if session_key:
+                runtime.session_store.set(
+                    session_key,
+                    {
+                        "messages": ctx.messages,
+                        "thread_id": metadata.get("thread_id", ""),
+                        "channel": metadata.get("channel", ""),
+                    },
+                )
+
             return result.text if result else ""
         except Exception as exc:
             log.warning("Gateway processor error: %s", exc, exc_info=True)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -110,6 +110,7 @@ app = typer.Typer(
 _search_engine_ctx: ContextVar[Any] = ContextVar("search_engine", default=None)
 _readiness_ctx: ContextVar[Any] = ContextVar("readiness", default=None)
 _scheduler_service_ctx: ContextVar[Any] = ContextVar("scheduler_service", default=None)
+_user_task_graph_ctx: ContextVar[Any] = ContextVar("user_task_graph", default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +206,24 @@ def _get_readiness() -> ReadinessReport | None:
 def _set_readiness(report: ReadinessReport) -> None:
     """Set the context-local ReadinessReport."""
     _readiness_ctx.set(report)
+
+
+def _get_user_task_graph() -> Any:
+    """Get (or lazily create) the context-local user TaskGraph."""
+    from core.orchestration.task_system import TaskGraph
+
+    graph = _user_task_graph_ctx.get()
+    if graph is None:
+        graph = TaskGraph()
+        _user_task_graph_ctx.set(graph)
+    return graph
+
+
+def _reset_user_task_graph() -> None:
+    """Reset the context-local user TaskGraph (new session)."""
+    from core.orchestration.task_system import TaskGraph
+
+    _user_task_graph_ctx.set(TaskGraph())
 
 
 def _get_last_result() -> dict[str, Any] | None:
@@ -542,6 +561,10 @@ def _handle_command(
         from core.cli.commands import cmd_clear
 
         cmd_clear(args)
+    elif action in ("tasks", "task"):
+        from core.cli.commands import cmd_tasks
+
+        cmd_tasks(args)
     else:
         console.print(f"  [warning]Unknown command: {cmd}[/warning]")
         console.print("  [muted]Type /help for available commands.[/muted]")

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -113,6 +113,9 @@ COMMAND_MAP: dict[str, str] = {
     "/apply": "apply",
     "/compact": "compact",
     "/clear": "clear",
+    "/tasks": "tasks",
+    "/task": "tasks",
+    "/t": "tasks",
 }
 
 
@@ -143,6 +146,7 @@ def show_help() -> None:
     console.print("  [label]/resume[/label]             — Resume interrupted session")
     console.print("  [label]/context[/label]            — Show assembled context tiers")
     console.print("  [label]/apply[/label]              — Manage job applications")
+    console.print("  [label]/tasks[/label]              — Show task list")
     console.print("  [label]/compact[/label]            — Compact conversation context")
     console.print("  [label]/clear[/label]              — Clear conversation history")
     console.print("  [label]/help[/label]               — Show this help")
@@ -1731,6 +1735,77 @@ def cmd_clear(args: str) -> None:
 
     ctx.clear()
     console.print(f"  [success]Conversation cleared[/success] ({msg_count} messages removed)")
+    console.print()
+
+
+def cmd_tasks(args: str) -> None:
+    """Show user task list.
+
+    Usage:
+        /tasks            — show all tasks
+        /tasks pending    — show pending only
+        /tasks done       — show completed tasks
+    """
+    from core.cli import _get_user_task_graph
+    from core.orchestration.task_system import TaskStatus
+
+    _STATUS_LABEL: dict[TaskStatus, tuple[str, str]] = {
+        TaskStatus.PENDING: ("○", "muted"),
+        TaskStatus.READY: ("○", "muted"),
+        TaskStatus.RUNNING: ("▶", "value"),
+        TaskStatus.COMPLETED: ("✓", "success"),
+        TaskStatus.FAILED: ("✗", "error"),
+        TaskStatus.SKIPPED: ("–", "muted"),
+    }
+
+    filter_arg = args.strip().lower()
+    graph = _get_user_task_graph()
+    all_tasks = [graph.get_task(tid) for batch in graph.topological_order() for tid in batch]
+    all_tasks = [t for t in all_tasks if t is not None]
+
+    # Apply filter
+    if filter_arg in ("pending", "todo"):
+        all_tasks = [t for t in all_tasks if t.status in (TaskStatus.PENDING, TaskStatus.READY)]
+    elif filter_arg in ("done", "completed"):
+        all_tasks = [t for t in all_tasks if t.status == TaskStatus.COMPLETED]
+    elif filter_arg in ("active", "running"):
+        all_tasks = [t for t in all_tasks if t.status == TaskStatus.RUNNING]
+
+    console.print()
+    if not all_tasks:
+        console.print("  [muted]No tasks.[/muted]")
+        console.print()
+        return
+
+    # Sort: running first, then pending, then completed/failed
+    _order = {
+        TaskStatus.RUNNING: 0,
+        TaskStatus.READY: 1,
+        TaskStatus.PENDING: 1,
+        TaskStatus.FAILED: 2,
+        TaskStatus.SKIPPED: 2,
+        TaskStatus.COMPLETED: 3,
+    }
+    all_tasks.sort(key=lambda t: _order.get(t.status, 9))
+
+    console.print("  [header]Tasks[/header]")
+    for task in all_tasks:
+        icon, style = _STATUS_LABEL.get(task.status, ("?", "muted"))
+        owner = task.metadata.get("owner", "")
+        owner_tag = f"  [muted]{owner}[/muted]" if owner else ""
+        elapsed = f"  [muted]{task.elapsed_s:.1f}s[/muted]" if task.elapsed_s else ""
+        console.print(
+            f"  [{style}]{icon}[/{style}]  [{style}]{task.task_id}[/{style}]"
+            f"  {task.name}{owner_tag}{elapsed}"
+        )
+    console.print()
+    running = sum(1 for t in all_tasks if t.status == TaskStatus.RUNNING)
+    pending = sum(1 for t in all_tasks if t.status in (TaskStatus.PENDING, TaskStatus.READY))
+    done = sum(1 for t in all_tasks if t.status == TaskStatus.COMPLETED)
+    console.print(
+        f"  [muted]{len(all_tasks)} total"
+        f"  ▶ {running} active  ○ {pending} pending  ✓ {done} done[/muted]"
+    )
     console.print()
 
 

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -1187,7 +1187,156 @@ def _build_tool_handlers(
     handlers.update(_build_calendar_handlers())
     handlers.update(_build_mcp_handler(mcp_manager, agentic_ref))
     handlers.update(_build_context_handlers())
+    handlers.update(_build_task_handlers())
     return handlers
+
+
+# ---------------------------------------------------------------------------
+# Task handlers
+# ---------------------------------------------------------------------------
+
+
+def _build_task_handlers() -> dict[str, Any]:
+    """Build user-facing task management handlers (task_create/update/get/list/stop)."""
+    import uuid
+
+    from core.cli import _get_user_task_graph
+    from core.orchestration.task_system import Task, TaskStatus
+
+    def _status_to_internal(status: str) -> TaskStatus:
+        return {
+            "pending": TaskStatus.PENDING,
+            "in_progress": TaskStatus.RUNNING,
+            "completed": TaskStatus.COMPLETED,
+            "failed": TaskStatus.FAILED,
+        }.get(status, TaskStatus.PENDING)
+
+    def _status_to_external(status: TaskStatus) -> str:
+        return {
+            TaskStatus.PENDING: "pending",
+            TaskStatus.READY: "pending",
+            TaskStatus.RUNNING: "in_progress",
+            TaskStatus.COMPLETED: "completed",
+            TaskStatus.FAILED: "failed",
+            TaskStatus.SKIPPED: "failed",
+        }.get(status, "pending")
+
+    def _task_to_dict(task: Task, detail: bool = False) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "task_id": task.task_id,
+            "subject": task.name,
+            "task_status": _status_to_external(task.status),
+            "owner": task.metadata.get("owner", ""),
+        }
+        if detail:
+            out["description"] = task.metadata.get("description", "")
+            out["elapsed_s"] = task.elapsed_s
+            out["metadata"] = {
+                k: v for k, v in task.metadata.items()
+                if k not in ("owner", "description")
+            }
+            if task.error:
+                out["error"] = task.error
+        return out
+
+    def handle_task_create(**kwargs: Any) -> dict[str, Any]:
+        subject = kwargs.get("subject", "")
+        if not subject:
+            return _clarify("task_create", ["subject"], "작업 제목을 알려주세요.")
+        graph = _get_user_task_graph()
+        task_id = f"t_{uuid.uuid4().hex[:8]}"
+        metadata: dict[str, Any] = dict(kwargs.get("metadata") or {})
+        if desc := kwargs.get("description"):
+            metadata["description"] = desc
+        task = Task(task_id=task_id, name=subject, metadata=metadata)
+        graph.add_task(task)
+        return {"status": "ok", "action": "created", "task_id": task_id, "subject": subject}
+
+    def handle_task_update(**kwargs: Any) -> dict[str, Any]:
+        task_id = kwargs.get("task_id", "")
+        if not task_id:
+            return _clarify("task_update", ["task_id"], "변경할 task_id를 알려주세요.")
+        graph = _get_user_task_graph()
+        task = graph.get_task(task_id)
+        if task is None:
+            return {"error": f"Task '{task_id}' not found"}
+        if new_subject := kwargs.get("subject"):
+            task.name = new_subject
+        if owner := kwargs.get("owner"):
+            task.metadata["owner"] = owner
+        if desc := kwargs.get("description"):
+            task.metadata["description"] = desc
+        if extra_meta := kwargs.get("metadata"):
+            for k, v in extra_meta.items():
+                if v is None:
+                    task.metadata.pop(k, None)
+                else:
+                    task.metadata[k] = v
+        if new_status := kwargs.get("status"):
+            try:
+                if new_status == "in_progress":
+                    graph.mark_running(task_id)
+                elif new_status == "completed":
+                    graph.mark_completed(task_id)
+                elif new_status == "failed":
+                    graph.mark_failed(task_id, error="manually failed")
+            except ValueError as exc:
+                return {"error": str(exc)}
+        return {"status": "ok", "action": "updated", **_task_to_dict(task)}
+
+    def handle_task_get(**kwargs: Any) -> dict[str, Any]:
+        task_id = kwargs.get("task_id", "")
+        if not task_id:
+            return _clarify("task_get", ["task_id"], "조회할 task_id를 알려주세요.")
+        graph = _get_user_task_graph()
+        task = graph.get_task(task_id)
+        if task is None:
+            return {"error": f"Task '{task_id}' not found"}
+        return {"status": "ok", **_task_to_dict(task, detail=True)}
+
+    def handle_task_list(**kwargs: Any) -> dict[str, Any]:
+        graph = _get_user_task_graph()
+        status_filter = kwargs.get("status_filter", "all")
+        tasks = list(graph._tasks.values())
+        if status_filter != "all":
+            target = _status_to_internal(status_filter)
+            # pending filter includes READY
+            if status_filter == "pending":
+                tasks = [t for t in tasks if t.status in (TaskStatus.PENDING, TaskStatus.READY)]
+            else:
+                tasks = [t for t in tasks if t.status == target]
+        # Sort: in_progress first, then pending, then completed/failed
+        order = {"in_progress": 0, "pending": 1, "completed": 2, "failed": 3}
+        tasks.sort(key=lambda t: order.get(_status_to_external(t.status), 9))
+        return {
+            "status": "ok",
+            "count": len(tasks),
+            "tasks": [_task_to_dict(t) for t in tasks],
+        }
+
+    def handle_task_stop(**kwargs: Any) -> dict[str, Any]:
+        task_id = kwargs.get("task_id", "")
+        if not task_id:
+            return _clarify("task_stop", ["task_id"], "취소할 task_id를 알려주세요.")
+        graph = _get_user_task_graph()
+        task = graph.get_task(task_id)
+        if task is None:
+            return {"error": f"Task '{task_id}' not found"}
+        reason = kwargs.get("reason", "stopped")
+        try:
+            graph.mark_failed(task_id, error=reason)
+            graph.propagate_failure(task_id)
+        except ValueError as exc:
+            return {"error": str(exc)}
+        return {"status": "ok", "action": "stopped", "task_id": task_id, "reason": reason}
+
+    return {
+        "task_create": handle_task_create,
+        "task_update": handle_task_update,
+        "task_get": handle_task_get,
+        "task_list": handle_task_list,
+        "task_stop": handle_task_stop,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -1232,8 +1232,7 @@ def _build_task_handlers() -> dict[str, Any]:
             out["description"] = task.metadata.get("description", "")
             out["elapsed_s"] = task.elapsed_s
             out["metadata"] = {
-                k: v for k, v in task.metadata.items()
-                if k not in ("owner", "description")
+                k: v for k, v in task.metadata.items() if k not in ("owner", "description")
             }
             if task.error:
                 out["error"] = task.error

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -8,17 +8,14 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
 from typing import Any
 
 from core.gateway.models import ChannelBinding, InboundMessage
 from core.gateway.pollers.base import BasePoller
+from core.infrastructure.ports.gateway_port import MessageProcessor
 from core.memory.session_key import build_gateway_session_key
 
 log = logging.getLogger(__name__)
-
-# Type for the message processor callback
-MessageProcessor = Callable[[str], str]  # input → response
 
 
 class ChannelManager:
@@ -110,10 +107,21 @@ class ChannelManager:
             log.warning("No message processor set — cannot process inbound message")
             return None
 
-        # Build gateway session key for context isolation
+        # Build gateway session key for context isolation (thread-scoped)
         session_key = build_gateway_session_key(
-            message.channel, message.channel_id, message.sender_id
+            message.channel,
+            message.channel_id,
+            message.sender_id,
+            thread_id=message.thread_id,
         )
+
+        metadata: dict[str, Any] = {
+            "session_key": session_key,
+            "thread_id": message.thread_id,
+            "channel": message.channel,
+            "channel_id": message.channel_id,
+            "sender_id": message.sender_id,
+        }
 
         # Strip mention tags so the LLM receives clean content
         content = self._strip_mentions(message.content)
@@ -128,11 +136,11 @@ class ChannelManager:
                 gateway_lane = self._lane_queue.get_lane("gateway")
                 if gateway_lane is not None:
                     with gateway_lane.acquire(session_key):
-                        response = self._processor(content)
+                        response = self._processor(content, metadata)
                 else:
-                    response = self._processor(content)
+                    response = self._processor(content, metadata)
             else:
-                response = self._processor(content)
+                response = self._processor(content, metadata)
 
             self._stats["processed"] += 1
             return response

--- a/core/infrastructure/ports/gateway_port.py
+++ b/core/infrastructure/ports/gateway_port.py
@@ -10,6 +10,11 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, Protocol, runtime_checkable
 
+#: Processor callback signature.
+#: ``(content, metadata) -> response``
+#: metadata keys: ``session_key``, ``thread_id``, ``channel``, ``channel_id``, ``sender_id``
+MessageProcessor = Callable[[str, dict[str, Any]], str]
+
 
 @runtime_checkable
 class GatewayPort(Protocol):
@@ -23,7 +28,7 @@ class GatewayPort(Protocol):
         """Stop all pollers."""
         ...
 
-    def set_processor(self, processor: Callable[[str], str]) -> None:
+    def set_processor(self, processor: MessageProcessor) -> None:
         """Set the message processor callback."""
         ...
 

--- a/core/memory/session_key.py
+++ b/core/memory/session_key.py
@@ -133,20 +133,27 @@ def build_gateway_session_key(
     channel: str,
     channel_id: str,
     sender_id: str = "",
+    thread_id: str = "",
 ) -> str:
     """Build a session key for a gateway inbound message.
 
-    Format: gateway:{channel}:{channel_id}[:{sender_id}]
+    Format: gateway:{channel}:{channel_id}[:{sender_id}][:{thread_id}]
+
+    When ``thread_id`` is provided the key scopes to a specific
+    conversation thread, enabling multi-turn context within that thread.
 
     Examples:
         gateway:slack:C12345
+        gateway:slack:C12345:U789:1234567890.123456
         gateway:telegram:987654321:U123
         gateway:discord:456789
     """
-    parts = [f"gateway:{channel}:{_normalize_name(channel_id)}"]
+    key = f"gateway:{channel}:{_normalize_name(channel_id)}"
     if sender_id:
-        parts[0] += f":{_normalize_name(sender_id)}"
-    return parts[0]
+        key += f":{_normalize_name(sender_id)}"
+    if thread_id:
+        key += f":{_normalize_name(thread_id)}"
+    return key
 
 
 def build_thread_config(ip_name: str, phase: str, sub_context: str | None = None) -> dict[str, Any]:

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -22,6 +22,7 @@ VALID_CATEGORIES = frozenset(
         "profile",
         "notification",
         "calendar",
+        "task",
     }
 )
 

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -1093,5 +1093,119 @@
       },
       "required": ["action"]
     }
+  },
+  {
+    "name": "task_create",
+    "description": "새 작업(task)을 생성합니다. 복잡한 요청을 단계별 작업으로 분해하거나 진행 상황을 추적할 때 사용하세요.",
+    "category": "task",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "작업 제목 (imperative form, e.g. 'Analyze Berserk IP')"
+        },
+        "description": {
+          "type": "string",
+          "description": "작업 상세 설명 (선택)"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "추가 메타데이터 (선택) — {priority, source, tool_name, tool_args}"
+        }
+      },
+      "required": ["subject"]
+    }
+  },
+  {
+    "name": "task_update",
+    "description": "기존 작업의 상태나 내용을 변경합니다. 작업을 시작하거나 완료 처리할 때 사용하세요.",
+    "category": "task",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "description": "변경할 task ID (task_create 반환값)"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["in_progress", "completed", "failed"],
+          "description": "새 상태 (in_progress: 작업 시작, completed: 완료, failed: 실패)"
+        },
+        "subject": {
+          "type": "string",
+          "description": "변경할 작업 제목 (선택)"
+        },
+        "description": {
+          "type": "string",
+          "description": "변경할 설명 (선택)"
+        },
+        "owner": {
+          "type": "string",
+          "description": "작업 담당자 (선택, e.g. 'subagent-1')"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "메타데이터 병합 (선택, null 값으로 키 삭제)"
+        }
+      },
+      "required": ["task_id"]
+    }
+  },
+  {
+    "name": "task_get",
+    "description": "특정 작업의 상세 정보를 조회합니다.",
+    "category": "task",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "description": "조회할 task ID"
+        }
+      },
+      "required": ["task_id"]
+    }
+  },
+  {
+    "name": "task_list",
+    "description": "전체 작업 목록을 조회합니다. 현재 진행 상황을 파악하거나 다음 작업을 결정할 때 사용하세요.",
+    "category": "task",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "status_filter": {
+          "type": "string",
+          "enum": ["pending", "in_progress", "completed", "failed", "all"],
+          "description": "상태 필터 (기본값: all)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "task_stop",
+    "description": "실행 중인 작업을 취소(실패 처리)합니다. 다운스트림 의존 작업도 함께 스킵됩니다.",
+    "category": "task",
+    "cost_tier": "free",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "description": "취소할 task ID"
+        },
+        "reason": {
+          "type": "string",
+          "description": "취소 사유 (선택)"
+        }
+      },
+      "required": ["task_id"]
+    }
   }
 ]

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
 # GEODE Progress Board
 
 > 멀티 에이전트 공유 칸반 보드. 모든 세션/에이전트가 이 파일을 읽고 갱신한다.
-> 마지막 갱신: 2026-03-26 (세션 32 — v0.29.1 릴리스 docs-sync)
+> 마지막 갱신: 2026-03-26 (세션 33 — Gateway 멀티턴)
 > **규칙**: progress.md는 main에서만 수정. feature/develop 수정 금지.
 
 ---
@@ -21,7 +21,6 @@
 
 | task_id | 작업 내용 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|----------|------|--------|--------|------|
-| gateway-multiturn | Gateway 멀티턴 — thread_id 기반 대화 이력 연결 + SessionStore 영속화 | @mangowhoiscloud | feature/gateway-multiturn | 2026-03-26 | P0 |
 | web-search-fix | 웹검색 수정 — general_web_search Haiku→Sonnet + signal tools stub 활성화 + MCP 도구명 매핑 | @mangowhoiscloud | feature/web-search-fix | 2026-03-26 | P0 유저 피드백 |
 
 ### In Review
@@ -29,6 +28,12 @@
 | task_id | 작업 내용 | PR | 담당 | CI | 비고 |
 |---------|----------|-----|------|-----|------|
 | — | — | — | — | — | — |
+
+### Done (2026-03-26 — 세션 33)
+
+| task_id | 작업 내용 | PR | 담당 | 완료일 |
+|---------|----------|----|------|--------|
+| gateway-multiturn | Gateway 멀티턴 대화 지원 — thread_id 기반 세션 영속화 + MessageProcessor 확장 | #459 | @mangowhoiscloud | 2026-03-26 |
 
 ### Done (2026-03-26 — 세션 32)
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -21,7 +21,7 @@
 
 | task_id | 작업 내용 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|----------|------|--------|--------|------|
-| web-search-fix | 웹검색 수정 — general_web_search Haiku→Sonnet + signal tools stub 활성화 + MCP 도구명 매핑 | @mangowhoiscloud | feature/web-search-fix | 2026-03-26 | P0 유저 피드백 |
+| gateway-config | Gateway 하드코딩 상수화 — max_rounds/max_turns config.toml 연동 + GATEWAY_SUFFIX 적극성 조정 | @mangowhoiscloud | feature/gateway-config | 2026-03-26 | P0 serve 포기 이슈 |
 
 ### In Review
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -68,7 +68,7 @@ class TestChannelBinding:
 class TestChannelManager:
     def test_route_message_with_binding(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: f"Response to: {content}")
+        manager.set_processor(lambda content, meta: f"Response to: {content}")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -84,7 +84,7 @@ class TestChannelManager:
 
     def test_route_message_no_binding(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: "response")
+        manager.set_processor(lambda content, meta: "response")
 
         msg = InboundMessage(
             channel="telegram",
@@ -100,7 +100,7 @@ class TestChannelManager:
     def test_specific_binding_wins(self):
         """Most-specific binding (channel + channel_id) should win."""
         manager = ChannelManager()
-        manager.set_processor(lambda content: "processed")
+        manager.set_processor(lambda content, meta: "processed")
 
         # Add generic binding
         manager.add_binding(ChannelBinding(channel="slack"))
@@ -120,7 +120,7 @@ class TestChannelManager:
 
     def test_require_mention_filter(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: "processed")
+        manager.set_processor(lambda content, meta: "processed")
         manager.add_binding(ChannelBinding(channel="discord", require_mention=True))
 
         # Without mention — should be ignored
@@ -160,7 +160,7 @@ class TestChannelManager:
 
     def test_stats(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: "ok")
+        manager.set_processor(lambda content, meta: "ok")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -187,7 +187,7 @@ class TestChannelManager:
 
     def test_processor_exception(self):
         manager = ChannelManager()
-        manager.set_processor(lambda content: 1 / 0)
+        manager.set_processor(lambda content, meta: 1 / 0)
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -325,13 +325,31 @@ class TestGatewaySessionKey:
         key = build_gateway_session_key("telegram", "987654")
         assert key == "gateway:telegram:987654"
 
+    def test_build_gateway_session_key_with_thread_id(self):
+        from core.memory.session_key import build_gateway_session_key
+
+        key = build_gateway_session_key("slack", "C12345", "U67890", thread_id="1234567890.123456")
+        assert "1234567890_123456" in key
+        # Without thread_id should be shorter
+        key_no_thread = build_gateway_session_key("slack", "C12345", "U67890")
+        assert len(key) > len(key_no_thread)
+
+    def test_different_threads_different_keys(self):
+        from core.memory.session_key import build_gateway_session_key
+
+        k1 = build_gateway_session_key("slack", "C1", "U1", thread_id="111.000")
+        k2 = build_gateway_session_key("slack", "C1", "U1", thread_id="222.000")
+        k3 = build_gateway_session_key("slack", "C1", "U1")
+        assert k1 != k2
+        assert k1 != k3
+
 
 class TestAllowedToolsEnforcement:
     def test_allowed_tools_hint_injected(self):
         """Binding's allowed_tools should be prefixed to content."""
         received_content = []
         manager = ChannelManager()
-        manager.set_processor(lambda c: (received_content.append(c), "ok")[1])
+        manager.set_processor(lambda c, m: (received_content.append(c), "ok")[1])
         manager.add_binding(
             ChannelBinding(
                 channel="slack",
@@ -355,7 +373,7 @@ class TestAllowedToolsEnforcement:
         """Without allowed_tools, content passes through unchanged."""
         received_content = []
         manager = ChannelManager()
-        manager.set_processor(lambda c: (received_content.append(c), "ok")[1])
+        manager.set_processor(lambda c, m: (received_content.append(c), "ok")[1])
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -379,7 +397,7 @@ class TestLaneQueueIntegration:
         lq.add_lane("gateway", max_concurrent=2)
 
         manager = ChannelManager(lane_queue=lq)
-        manager.set_processor(lambda c: f"processed: {c}")
+        manager.set_processor(lambda c, m: f"processed: {c}")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -396,7 +414,7 @@ class TestLaneQueueIntegration:
     def test_route_without_lane_queue(self):
         """Messages should still work without lane queue."""
         manager = ChannelManager(lane_queue=None)
-        manager.set_processor(lambda c: "ok")
+        manager.set_processor(lambda c, m: "ok")
         manager.add_binding(ChannelBinding(channel="slack"))
 
         msg = InboundMessage(
@@ -451,6 +469,80 @@ class TestBindingConfigReload:
         bindings = manager.list_bindings()
         assert len(bindings) == 1
         assert bindings[0]["channel"] == "slack"
+
+
+class TestMultiTurnMetadata:
+    """Verify that route_message passes metadata to the processor."""
+
+    def test_metadata_contains_session_key(self):
+        """Processor receives session_key in metadata."""
+        captured: list[dict] = []
+        manager = ChannelManager()
+        manager.set_processor(lambda c, m: (captured.append(m), "ok")[1])
+        manager.add_binding(ChannelBinding(channel="slack"))
+
+        msg = InboundMessage(
+            channel="slack",
+            channel_id="C123",
+            sender_id="U456",
+            sender_name="Bob",
+            content="hello",
+            timestamp=time.time(),
+            thread_id="1234567890.123456",
+        )
+        manager.route_message(msg)
+
+        assert len(captured) == 1
+        meta = captured[0]
+        assert "session_key" in meta
+        assert "c123" in meta["session_key"]
+        assert "u456" in meta["session_key"]
+        assert "1234567890_123456" in meta["session_key"]
+        assert meta["thread_id"] == "1234567890.123456"
+        assert meta["channel"] == "slack"
+
+    def test_metadata_without_thread_id(self):
+        """Messages without thread_id still get session_key."""
+        captured: list[dict] = []
+        manager = ChannelManager()
+        manager.set_processor(lambda c, m: (captured.append(m), "ok")[1])
+        manager.add_binding(ChannelBinding(channel="slack"))
+
+        msg = InboundMessage(
+            channel="slack",
+            channel_id="C123",
+            sender_id="U456",
+            sender_name="Bob",
+            content="hello",
+            timestamp=time.time(),
+        )
+        manager.route_message(msg)
+
+        meta = captured[0]
+        assert "session_key" in meta
+        assert meta["thread_id"] == ""
+
+    def test_thread_scoped_session_keys_differ(self):
+        """Different threads produce different session keys."""
+        keys: list[str] = []
+        manager = ChannelManager()
+        manager.set_processor(lambda c, m: (keys.append(m["session_key"]), "ok")[1])
+        manager.add_binding(ChannelBinding(channel="slack"))
+
+        for thread_id in ["111.000", "222.000"]:
+            msg = InboundMessage(
+                channel="slack",
+                channel_id="C123",
+                sender_id="U456",
+                sender_name="Bob",
+                content="hello",
+                timestamp=time.time(),
+                thread_id=thread_id,
+            )
+            manager.route_message(msg)
+
+        assert len(keys) == 2
+        assert keys[0] != keys[1]
 
 
 class TestPollerLifecycle:

--- a/tests/test_tool_handlers_task.py
+++ b/tests/test_tool_handlers_task.py
@@ -1,0 +1,219 @@
+"""Unit tests for task management tool handlers.
+
+Tests task_create / task_update / task_get / task_list / task_stop handlers
+via _build_task_handlers() without touching the IP analysis pipeline.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.cli.tool_handlers import _build_task_handlers
+
+
+@pytest.fixture()
+def handlers():
+    """Fresh handler map with isolated TaskGraph per test."""
+    # Reset user task graph for isolation
+    from core.cli import _reset_user_task_graph
+
+    _reset_user_task_graph()
+    return _build_task_handlers()
+
+
+# ---------------------------------------------------------------------------
+# task_create
+# ---------------------------------------------------------------------------
+
+
+class TestTaskCreate:
+    def test_creates_task_returns_task_id(self, handlers):
+        result = handlers["task_create"](subject="Analyze Berserk")
+        assert result["status"] == "ok"
+        assert result["action"] == "created"
+        assert result["task_id"].startswith("t_")
+        assert result["subject"] == "Analyze Berserk"
+
+    def test_missing_subject_returns_clarification(self, handlers):
+        result = handlers["task_create"]()
+        assert result.get("clarification_needed") is True
+        assert "subject" in result["missing"]
+
+    def test_description_stored_in_metadata(self, handlers):
+        result = handlers["task_create"](
+            subject="Run analysis", description="detailed desc"
+        )
+        task_id = result["task_id"]
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["description"] == "detailed desc"
+
+    def test_metadata_stored(self, handlers):
+        result = handlers["task_create"](
+            subject="Step 1", metadata={"priority": "P0"}
+        )
+        task_id = result["task_id"]
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["metadata"]["priority"] == "P0"
+
+
+# ---------------------------------------------------------------------------
+# task_update
+# ---------------------------------------------------------------------------
+
+
+class TestTaskUpdate:
+    def _create(self, handlers, subject="Test task"):
+        return handlers["task_create"](subject=subject)["task_id"]
+
+    def test_status_pending_to_in_progress(self, handlers):
+        task_id = self._create(handlers)
+        result = handlers["task_update"](task_id=task_id, status="in_progress")
+        assert result["status"] == "ok"
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["task_status"] == "in_progress"
+
+    def test_status_in_progress_to_completed(self, handlers):
+        task_id = self._create(handlers)
+        handlers["task_update"](task_id=task_id, status="in_progress")
+        result = handlers["task_update"](task_id=task_id, status="completed")
+        assert result["status"] == "ok"
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["task_status"] == "completed"
+
+    def test_update_subject(self, handlers):
+        task_id = self._create(handlers, subject="Old title")
+        handlers["task_update"](task_id=task_id, subject="New title")
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["subject"] == "New title"
+
+    def test_update_owner(self, handlers):
+        task_id = self._create(handlers)
+        handlers["task_update"](task_id=task_id, owner="subagent-1")
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["owner"] == "subagent-1"
+
+    def test_missing_task_id_clarification(self, handlers):
+        result = handlers["task_update"]()
+        assert result.get("clarification_needed") is True
+
+    def test_nonexistent_task_returns_error(self, handlers):
+        result = handlers["task_update"](task_id="t_999999")
+        assert "error" in result
+
+    def test_invalid_status_transition_returns_error(self, handlers):
+        task_id = self._create(handlers)
+        # Cannot go directly pending → completed (must be running first)
+        result = handlers["task_update"](task_id=task_id, status="completed")
+        assert "error" in result
+
+    def test_metadata_merge(self, handlers):
+        task_id = self._create(handlers, subject="Meta test")
+        handlers["task_update"](task_id=task_id, metadata={"key1": "v1"})
+        handlers["task_update"](task_id=task_id, metadata={"key2": "v2"})
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["metadata"]["key1"] == "v1"
+        assert detail["metadata"]["key2"] == "v2"
+
+    def test_metadata_delete_with_none(self, handlers):
+        task_id = self._create(handlers, subject="Delete meta")
+        handlers["task_update"](task_id=task_id, metadata={"to_remove": "val"})
+        handlers["task_update"](task_id=task_id, metadata={"to_remove": None})
+        detail = handlers["task_get"](task_id=task_id)
+        assert "to_remove" not in detail["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# task_get
+# ---------------------------------------------------------------------------
+
+
+class TestTaskGet:
+    def test_get_existing_task(self, handlers):
+        task_id = handlers["task_create"](subject="Get me")["task_id"]
+        result = handlers["task_get"](task_id=task_id)
+        assert result["status"] == "ok"
+        assert result["task_id"] == task_id
+        assert result["subject"] == "Get me"
+        assert result.get("status_field", True)
+        assert "elapsed_s" in result
+
+    def test_get_nonexistent_returns_error(self, handlers):
+        result = handlers["task_get"](task_id="t_does_not_exist")
+        assert "error" in result
+
+    def test_missing_task_id_clarification(self, handlers):
+        result = handlers["task_get"]()
+        assert result.get("clarification_needed") is True
+
+
+# ---------------------------------------------------------------------------
+# task_list
+# ---------------------------------------------------------------------------
+
+
+class TestTaskList:
+    def test_empty_list(self, handlers):
+        result = handlers["task_list"]()
+        assert result["status"] == "ok"
+        assert result["count"] == 0
+        assert result["tasks"] == []
+
+    def test_lists_created_tasks(self, handlers):
+        handlers["task_create"](subject="Task A")
+        handlers["task_create"](subject="Task B")
+        result = handlers["task_list"]()
+        assert result["count"] == 2
+        subjects = {t["subject"] for t in result["tasks"]}
+        assert subjects == {"Task A", "Task B"}
+
+    def test_status_filter_pending(self, handlers):
+        t1 = handlers["task_create"](subject="Pending")["task_id"]
+        t2 = handlers["task_create"](subject="Running")["task_id"]
+        handlers["task_update"](task_id=t2, status="in_progress")
+        result = handlers["task_list"](status_filter="pending")
+        assert result["count"] == 1
+        assert result["tasks"][0]["task_id"] == t1
+
+    def test_status_filter_in_progress(self, handlers):
+        t1 = handlers["task_create"](subject="Task")["task_id"]
+        handlers["task_update"](task_id=t1, status="in_progress")
+        result = handlers["task_list"](status_filter="in_progress")
+        assert result["count"] == 1
+
+    def test_in_progress_sorted_first(self, handlers):
+        handlers["task_create"](subject="Pending task")
+        t2 = handlers["task_create"](subject="Running task")["task_id"]
+        handlers["task_update"](task_id=t2, status="in_progress")
+        result = handlers["task_list"]()
+        assert result["tasks"][0]["task_status"] == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# task_stop
+# ---------------------------------------------------------------------------
+
+
+class TestTaskStop:
+    def test_stop_running_task(self, handlers):
+        task_id = handlers["task_create"](subject="Stoppable")["task_id"]
+        handlers["task_update"](task_id=task_id, status="in_progress")
+        result = handlers["task_stop"](task_id=task_id, reason="user cancelled")
+        assert result["status"] == "ok"
+        assert result["action"] == "stopped"
+        assert result["reason"] == "user cancelled"
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["task_status"] == "failed"
+
+    def test_stop_pending_task(self, handlers):
+        task_id = handlers["task_create"](subject="Pending stop")["task_id"]
+        result = handlers["task_stop"](task_id=task_id)
+        assert result["status"] == "ok"
+        detail = handlers["task_get"](task_id=task_id)
+        assert detail["task_status"] == "failed"
+
+    def test_stop_nonexistent_returns_error(self, handlers):
+        result = handlers["task_stop"](task_id="t_ghost")
+        assert "error" in result
+
+    def test_missing_task_id_clarification(self, handlers):
+        result = handlers["task_stop"]()
+        assert result.get("clarification_needed") is True

--- a/tests/test_tool_handlers_task.py
+++ b/tests/test_tool_handlers_task.py
@@ -39,17 +39,13 @@ class TestTaskCreate:
         assert "subject" in result["missing"]
 
     def test_description_stored_in_metadata(self, handlers):
-        result = handlers["task_create"](
-            subject="Run analysis", description="detailed desc"
-        )
+        result = handlers["task_create"](subject="Run analysis", description="detailed desc")
         task_id = result["task_id"]
         detail = handlers["task_get"](task_id=task_id)
         assert detail["description"] == "detailed desc"
 
     def test_metadata_stored(self, handlers):
-        result = handlers["task_create"](
-            subject="Step 1", metadata={"priority": "P0"}
-        )
+        result = handlers["task_create"](subject="Step 1", metadata={"priority": "P0"})
         task_id = result["task_id"]
         detail = handlers["task_get"](task_id=task_id)
         assert detail["metadata"]["priority"] == "P0"


### PR DESCRIPTION
## Why

AgenticLoop의 Claude가 복잡한 요청을 단계별 작업으로 분해하고 진행 상황을 추적할
수 있는 도구가 없었습니다. 내부 `TaskGraph` 엔진(L3)은 이미 완성됐지만
`definitions.json` + 핸들러가 미구현 상태였습니다.

## Changes

- `core/cli/__init__.py` — `_user_task_graph_ctx` ContextVar + `_get_user_task_graph()` lazy accessor 추가 (IP 파이프라인 TaskGraph와 독립)
- `core/tools/definitions.json` — `task_create`, `task_update`, `task_get`, `task_list`, `task_stop` 5개 tool schema 추가 (category: "task")
- `core/tools/base.py` — `VALID_CATEGORIES`에 `"task"` 추가
- `core/cli/tool_handlers.py` — `_build_task_handlers()` 그룹 추가 (uuid 기반 task_id, task_status 필드로 응답 키 충돌 방지)
- `core/cli/commands.py` — `/tasks` (`/task`, `/t`) 슬래시 커맨드 추가 (Claude Code 스타일 UI — icon/status/elapsed 표시)
- `tests/test_tool_handlers_task.py` — unit tests 25개 신규

**변경 없는 파일**: `task_system.py`, `task_bridge.py`, `runtime.py`, `graph.py`

## Frontier Reference

Claude Code의 TaskCreate/Update/Get/List/Stop JSON 스키마 실측 참조.
상태 전환: `pending → in_progress → completed` (외부 노출), 내부는 6-state TaskGraph 유지.

## Test Plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run mypy` — 0 errors
- [x] `uv run pytest tests/test_tool_handlers_task.py` — 25/25 pass
- [x] `uv run pytest tests/ -m "not live"` — 3249 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)