### PR TITLE
refactor: Kent Beck Phase 5 — 핸들러 레지스트리 + Executor 분해

### DIFF
--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -602,6 +602,57 @@ class ToolCallProcessor:
 
         return await self._execute_parallel(tool_blocks)
 
+    def _record_tool_activity(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        result: Any,
+        visible: bool,
+    ) -> None:
+        """Log result, record transcript events, and append to tool_log."""
+        # Progressive log: show tool result summary (skip if already logged)
+        if isinstance(result, dict):
+            skip_log = result.get("skipped") or result.get("recovery_attempted")
+            if not skip_log:
+                self._op_logger.log_tool_result(tool_name, result, visible=visible)
+
+        # Transcript: tool_call + tool_result events
+        if self._transcript is not None:
+            self._transcript.record_tool_call(tool_name, tool_input)
+            status = "error" if isinstance(result, dict) and result.get("error") else "ok"
+            summary = ""
+            if isinstance(result, dict):
+                summary = str(result.get("summary", result.get("error", "")))
+            self._transcript.record_tool_result(tool_name, status, summary)
+
+        self._tool_log.append(
+            {
+                "tool": tool_name,
+                "input": tool_input,
+                "result": result,
+            }
+        )
+
+    def _serialize_tool_result(self, result: Any, block_id: str) -> dict[str, Any]:
+        """Apply token guard and serialize result as JSON for LLM consumption."""
+        # Token guard: truncate oversized results to prevent context explosion
+        # For small-context models (e.g. GLM-5 80K), apply model-aware limit
+        if isinstance(result, dict):
+            model_limit = _compute_model_tool_limit(self._model) if self._model else 0
+            result = _guard_tool_result(result, max_tokens=model_limit or None)
+
+        # Serialize result as JSON for LLM (not Python repr)
+        try:
+            content = json.dumps(result, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            content = str(result)
+
+        return {
+            "type": "tool_result",
+            "tool_use_id": block_id,
+            "content": content,
+        }
+
     async def _execute_single(self, block: Any) -> dict[str, Any]:
         """Execute a single tool_use block and return its processed result dict.
 
@@ -649,45 +700,8 @@ class ToolCallProcessor:
                     "max_clarifications_exceeded": True,
                 }
 
-        # Progressive log: show tool result summary (skip if already logged)
-        skip_log = result.get("skipped") or result.get("recovery_attempted")
-        if isinstance(result, dict) and not skip_log:
-            self._op_logger.log_tool_result(tool_name, result, visible=visible)
-
-        # Transcript: tool_call + tool_result events
-        if self._transcript is not None:
-            self._transcript.record_tool_call(tool_name, tool_input)
-            status = "error" if isinstance(result, dict) and result.get("error") else "ok"
-            summary = ""
-            if isinstance(result, dict):
-                summary = str(result.get("summary", result.get("error", "")))
-            self._transcript.record_tool_result(tool_name, status, summary)
-
-        self._tool_log.append(
-            {
-                "tool": tool_name,
-                "input": tool_input,
-                "result": result,
-            }
-        )
-
-        # Token guard: truncate oversized results to prevent context explosion
-        # For small-context models (e.g. GLM-5 80K), apply model-aware limit
-        if isinstance(result, dict):
-            model_limit = _compute_model_tool_limit(self._model) if self._model else 0
-            result = _guard_tool_result(result, max_tokens=model_limit or None)
-
-        # Serialize result as JSON for LLM (not Python repr)
-        try:
-            content = json.dumps(result, ensure_ascii=False, default=str)
-        except (TypeError, ValueError):
-            content = str(result)
-
-        return {
-            "type": "tool_result",
-            "tool_use_id": block.id,
-            "content": content,
-        }
+        self._record_tool_activity(tool_name, tool_input, result, visible)
+        return self._serialize_tool_result(result, block.id)
 
     async def _execute_sequential(self, tool_blocks: list[Any]) -> list[dict[str, Any]]:
         """Execute tool blocks one by one (single-tool fast path)."""

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -10,15 +10,16 @@ Handlers are organized into logical groups:
 - HITL: rate_result, accept_result, reject_result, rerun_node
 - System: check_status, show_help, switch_model, set_api_key, manage_auth
 - Execution: generate_data, schedule_job, trigger_event
-- Delegated: web_fetch, general_web_search, read_document, note_save, note_read
-- Profile: profile_show, profile_update, profile_preference, profile_learn
-- Signal: youtube_search, reddit_sentiment, steam_info, google_trends
+- Delegated: web_fetch, general_web_search, read_document, note_save, note_read,
+             profile_show, profile_update, profile_preference, profile_learn,
+             youtube_search, reddit_sentiment, steam_info, google_trends
 - MCP: install_mcp_server
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from core.cli.ui.console import console
@@ -884,116 +885,52 @@ def _build_execution_handlers() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Handler group: Delegated tools (web, document, note)
+# Handler group: Delegated tools (registry-based)
 # ---------------------------------------------------------------------------
+
+# Maps tool name → (module_path, class_name) for lazy-import delegation.
+# Adding a new delegated tool requires only one line here.
+_DELEGATED_TOOLS: dict[str, tuple[str, str]] = {
+    # web / document / note
+    "web_fetch": ("core.tools.web_tools", "WebFetchTool"),
+    "general_web_search": ("core.tools.web_tools", "GeneralWebSearchTool"),
+    "read_document": ("core.tools.document_tools", "ReadDocumentTool"),
+    "note_save": ("core.tools.memory_tools", "NoteSaveTool"),
+    "note_read": ("core.tools.memory_tools", "NoteReadTool"),
+    # profile
+    "profile_show": ("core.tools.profile_tools", "ProfileShowTool"),
+    "profile_update": ("core.tools.profile_tools", "ProfileUpdateTool"),
+    "profile_preference": ("core.tools.profile_tools", "ProfilePreferenceTool"),
+    "profile_learn": ("core.tools.profile_tools", "ProfileLearnTool"),
+    # signals
+    "youtube_search": ("core.tools.signal_tools", "YouTubeSearchTool"),
+    "reddit_sentiment": ("core.tools.signal_tools", "RedditSentimentTool"),
+    "steam_info": ("core.tools.signal_tools", "SteamInfoTool"),
+    "google_trends": ("core.tools.signal_tools", "GoogleTrendsTool"),
+}
+
+
+def _make_delegate_handler(
+    module_path: str,
+    class_name: str,
+) -> Callable[..., dict[str, Any]]:
+    """Return a handler that lazily imports *class_name* from *module_path* and delegates."""
+
+    def _handler(**kwargs: Any) -> dict[str, Any]:
+        import importlib
+
+        mod = importlib.import_module(module_path)
+        tool_cls = getattr(mod, class_name)
+        return _safe_delegate(tool_cls, kwargs)
+
+    return _handler
 
 
 def _build_delegated_handlers() -> dict[str, Any]:
-    """Build delegated tool handlers (web, document, note)."""
-
-    def handle_web_fetch(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.web_tools import WebFetchTool
-
-        return _safe_delegate(WebFetchTool, kwargs)
-
-    def handle_general_web_search(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.web_tools import GeneralWebSearchTool
-
-        return _safe_delegate(GeneralWebSearchTool, kwargs)
-
-    def handle_read_document(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.document_tools import ReadDocumentTool
-
-        return _safe_delegate(ReadDocumentTool, kwargs)
-
-    def handle_note_save(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.memory_tools import NoteSaveTool
-
-        return _safe_delegate(NoteSaveTool, kwargs)
-
-    def handle_note_read(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.memory_tools import NoteReadTool
-
-        return _safe_delegate(NoteReadTool, kwargs)
-
+    """Build all delegated tool handlers from ``_DELEGATED_TOOLS`` registry."""
     return {
-        "web_fetch": handle_web_fetch,
-        "general_web_search": handle_general_web_search,
-        "read_document": handle_read_document,
-        "note_save": handle_note_save,
-        "note_read": handle_note_read,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Handler group: Profile tools
-# ---------------------------------------------------------------------------
-
-
-def _build_profile_handlers() -> dict[str, Any]:
-    """Build user profile tool handlers."""
-
-    def handle_profile_show(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.profile_tools import ProfileShowTool
-
-        return _safe_delegate(ProfileShowTool, kwargs)
-
-    def handle_profile_update(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.profile_tools import ProfileUpdateTool
-
-        return _safe_delegate(ProfileUpdateTool, kwargs)
-
-    def handle_profile_preference(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.profile_tools import ProfilePreferenceTool
-
-        return _safe_delegate(ProfilePreferenceTool, kwargs)
-
-    def handle_profile_learn(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.profile_tools import ProfileLearnTool
-
-        return _safe_delegate(ProfileLearnTool, kwargs)
-
-    return {
-        "profile_show": handle_profile_show,
-        "profile_update": handle_profile_update,
-        "profile_preference": handle_profile_preference,
-        "profile_learn": handle_profile_learn,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Handler group: Signal tools
-# ---------------------------------------------------------------------------
-
-
-def _build_signal_handlers() -> dict[str, Any]:
-    """Build external signal tool handlers."""
-
-    def handle_youtube_search(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.signal_tools import YouTubeSearchTool
-
-        return _safe_delegate(YouTubeSearchTool, kwargs)
-
-    def handle_reddit_sentiment(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.signal_tools import RedditSentimentTool
-
-        return _safe_delegate(RedditSentimentTool, kwargs)
-
-    def handle_steam_info(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.signal_tools import SteamInfoTool
-
-        return _safe_delegate(SteamInfoTool, kwargs)
-
-    def handle_google_trends(**kwargs: Any) -> dict[str, Any]:
-        from core.tools.signal_tools import GoogleTrendsTool
-
-        return _safe_delegate(GoogleTrendsTool, kwargs)
-
-    return {
-        "youtube_search": handle_youtube_search,
-        "reddit_sentiment": handle_reddit_sentiment,
-        "steam_info": handle_steam_info,
-        "google_trends": handle_google_trends,
+        name: _make_delegate_handler(mod, cls)
+        for name, (mod, cls) in _DELEGATED_TOOLS.items()
     }
 
 
@@ -1181,8 +1118,6 @@ def _build_tool_handlers(
     handlers.update(_build_system_handlers(readiness, force_dry, mcp_manager))
     handlers.update(_build_execution_handlers())
     handlers.update(_build_delegated_handlers())
-    handlers.update(_build_profile_handlers())
-    handlers.update(_build_signal_handlers())
     handlers.update(_build_notification_handlers())
     handlers.update(_build_calendar_handlers())
     handlers.update(_build_mcp_handler(mcp_manager, agentic_ref))

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -928,10 +928,7 @@ def _make_delegate_handler(
 
 def _build_delegated_handlers() -> dict[str, Any]:
     """Build all delegated tool handlers from ``_DELEGATED_TOOLS`` registry."""
-    return {
-        name: _make_delegate_handler(mod, cls)
-        for name, (mod, cls) in _DELEGATED_TOOLS.items()
-    }
+    return {name: _make_delegate_handler(mod, cls) for name, (mod, cls) in _DELEGATED_TOOLS.items()}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Kent Beck Simple Design: Fewest Elements 위반 — 13개 위임 핸들러 클로저(동일 패턴 반복) +
`_execute_single` 86줄 모놀리스(10개 책임 혼재).

## What

### 5A: Delegation Handler Registry (`core/cli/tool_handlers.py`)

- `_build_delegated_handlers` + `_build_profile_handlers` + `_build_signal_handlers` (3함수 112줄)
  → `_DELEGATED_TOOLS` 레지스트리 + `_make_delegate_handler` 팩토리 + 단일 함수 (~48줄)
- 신규 위임 핸들러 추가: 레지스트리에 1줄로 충분
- 행동 변경 없음 (lazy import 패턴 동일)

### 5B: `_execute_single` 분해 (`core/agent/tool_executor.py`)

- 86줄 모놀리스 → 40줄 오케스트레이터 + 2 서브메서드
  - `_record_tool_activity`: 관찰성 (op_logger + transcript + tool_log)
  - `_serialize_tool_result`: 출력 포맷 (token guard + JSON 직렬화)
- 행동 변경 없음

## Metrics

| 지표 | 변경 전 | 변경 후 |
|------|--------|--------|
| tool_handlers.py 위임 섹션 | 112줄 (3함수) | ~48줄 (레지스트리) |
| _execute_single | 86줄 | ~40줄 오케스트레이터 |
| Tests | 3224 passed | 3224 passed |
| E2E dry-run | A (68.4) | A (68.4) |

## Test plan

- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run ruff format --check core/ tests/` — clean
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3224 passed
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)