### PR TITLE
refactor: deprecated MCP port stub 3개 삭제

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-27T00:23:30+09:00 task_id=proxy-cleanup
+session=2026-03-27T00:45:03+09:00 task_id=port-stubs

--- a/core/infrastructure/ports/calendar_port.py
+++ b/core/infrastructure/ports/calendar_port.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.mcp.calendar_port instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.mcp.calendar_port")

--- a/core/infrastructure/ports/notification_port.py
+++ b/core/infrastructure/ports/notification_port.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.mcp.notification_port instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.mcp.notification_port")

--- a/core/infrastructure/ports/signal_port.py
+++ b/core/infrastructure/ports/signal_port.py
@@ -1,6 +1,0 @@
-"""DEPRECATED: Use core.mcp.signal_port instead."""
-
-import importlib as _il
-import sys as _sys
-
-_sys.modules[__name__] = _il.import_module("core.mcp.signal_port")

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.29.1"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why

proxy-cleanup #470 이후 `infrastructure/ports/`에 남아 있던 3개 DEPRECATED 리다이렉터 삭제.
소비자 0 확인 (grep 결과). 행동 변경 없음.

## Changes

- `core/infrastructure/ports/calendar_port.py` — DEPRECATED → `core.mcp.calendar_port`, 소비자 0
- `core/infrastructure/ports/notification_port.py` — DEPRECATED → `core.mcp.notification_port`, 소비자 0
- `core/infrastructure/ports/signal_port.py` — DEPRECATED → `core.mcp.signal_port`, 소비자 0

## Test Plan

- [x] `ruff check` — 0 errors
- [x] `mypy core/` — 192 files clean
- [x] `pytest -m "not live"` — 3246 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)