### PR TITLE
feat: prompt cleanup — English unification + output_language pipeline

### DIFF
--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -532,7 +532,9 @@ def _run_analysis(
     """Core analysis logic shared by interactive and CLI modes."""
     from core.cli import _hooks_ctx, _set_last_result
     from core.domains.game_ip.fixtures import FIXTURE_MAP
+    from core.utils.language import detect_language
 
+    output_language = detect_language(ip_name)  # detect before normalization
     resolved = _resolve_ip_name(ip_name)
     if resolved is None:
         available = [n.title() for n in FIXTURE_MAP]
@@ -574,6 +576,7 @@ def _run_analysis(
         "ip_name": ip_name,
         "pipeline_mode": pipeline_mode,
         "session_id": session_id,
+        "output_language": output_language,
         "dry_run": dry_run,
         "verbose": verbose,
         "skip_verification": skip_verification,

--- a/core/domains/game_ip/nodes/analysts.py
+++ b/core/domains/game_ip/nodes/analysts.py
@@ -62,7 +62,8 @@ def _build_analyst_prompt(analyst_type: str, state: GeodeState) -> tuple[str, st
     analyst_specific = "" if has_skill else analyst_specific_map.get(analyst_type, "")
 
     # Phase 1: Base template rendering
-    base_system = ANALYST_SYSTEM.format(analyst_type=analyst_type)
+    output_language = state.get("output_language", "English")
+    base_system = ANALYST_SYSTEM.format(analyst_type=analyst_type, output_language=output_language)
     base_user = ANALYST_USER.format(
         analyst_type=analyst_type,
         ip_name=ip["ip_name"],

--- a/core/domains/game_ip/nodes/synthesizer.py
+++ b/core/domains/game_ip/nodes/synthesizer.py
@@ -237,6 +237,7 @@ def _build_llm_synthesis(
     qj = evaluations.get("quality_judge")
     cm = evaluations.get("community_momentum")
 
+    output_language = state.get("output_language", "English")
     user = SYNTHESIZER_USER.format(
         ip_name=state["ip_name"],
         cause=cause,
@@ -255,7 +256,7 @@ def _build_llm_synthesis(
     )
 
     # ADR-007: PromptAssembler injection
-    system = SYNTHESIZER_SYSTEM
+    system = SYNTHESIZER_SYSTEM.format(output_language=output_language)
     assembler: Any = state.get("_prompt_assembler")
     if assembler is not None:
         result = assembler.assemble(
@@ -334,7 +335,12 @@ def _build_tool_augmented_synthesis(
     )
     eval_summary = "\n".join(f"- {k}: {v.composite_score:.0f}/100" for k, v in evaluations.items())
 
-    enhanced_system = SYNTHESIZER_SYSTEM + "\n\n" + SYNTHESIZER_TOOLS_SUFFIX
+    output_language = state.get("output_language", "English")
+    enhanced_system = (
+        SYNTHESIZER_SYSTEM.format(output_language=output_language)
+        + "\n\n"
+        + SYNTHESIZER_TOOLS_SUFFIX
+    )
 
     user = SYNTHESIZER_USER.format(
         ip_name=state["ip_name"],

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -165,9 +165,9 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "fb235a7e49e3",
+    "AGENTIC_SUFFIX": "769c33bff0d2",
     "ANALYST_SPECIFIC": "5a696a2d5ebb",
-    "ANALYST_SYSTEM": "90acc856a5b2",
+    "ANALYST_SYSTEM": "8a325a63b397",
     "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",
     "ANALYST_USER": "e59d00faadd5",
     "BIASBUSTER_SYSTEM": "07987c709fd9",
@@ -181,8 +181,8 @@ _PINNED_HASHES: dict[str, str] = {
     "EVALUATOR_SYSTEM": "e891c0ce27d4",
     "EVALUATOR_USER": "f6d7f955338d",
     "PROSPECT_EVALUATOR_AXES": "a9954477497b",
-    "ROUTER_SYSTEM": "de4cab14aadc",
-    "SYNTHESIZER_SYSTEM": "666d8e1fe137",
+    "ROUTER_SYSTEM": "076cde81e703",
+    "SYNTHESIZER_SYSTEM": "e01544c0c8d2",
     "SYNTHESIZER_TOOLS_SUFFIX": "c6c65e47e191",
     "SYNTHESIZER_USER": "30d99edc79a5",
 }

--- a/core/llm/prompts/analyst.md
+++ b/core/llm/prompts/analyst.md
@@ -20,6 +20,8 @@ Scoring Anchors:
   4 = Strong (above average, clear competitive advantages)
   5 = Outstanding (top-tier, exceptional potential)
 
+Write all text fields (key_finding, reasoning, evidence) in {output_language}.
+
 Respond in JSON format:
 {{
   "analyst_type": "{analyst_type}",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -14,17 +14,17 @@ You help the user with any task — research, analysis, automation, scheduling, 
 A domain plugin may be loaded to provide specialized tools.
 Currently loaded: {ip_count} domain entries ({ip_examples}).
 Domain tools (analyze_ip, compare_ips, etc.) are one of many capabilities, not the primary identity.
-When calling domain tools, use the canonical English title (e.g. "버서크" → "Berserk").
+When calling domain tools, use the canonical English title (e.g. local-language input → "Berserk").
 
 ## Tool usage rules
 1. Tools for concrete actions only — do not call tools speculatively.
 2. Conversational questions → respond with text, do NOT call show_help.
-3. show_help only on explicit "/help", "도움말", "명령어 목록".
+3. show_help only on explicit "/help" or "list commands".
 4. dry_run=true only when user explicitly requests it.
 5. URL → web_fetch. Remember → note_save. Recall → note_read.
 
 ## Context-aware routing
-- Resolve pronouns from conversation history ("그거"/"아까 거" → most recent subject).
+- Resolve pronouns from conversation history ("that", "the previous one" → most recent subject).
 - Ambiguous → ask a brief clarifying question.
 
 Respond concisely (2-4 sentences), in the user's language. Multi-tool sequences are supported.
@@ -41,72 +41,70 @@ After each tool result, ask yourself: "Has the user's original request been full
 - **YES** → respond with a concise text summary. Do NOT call another tool.
 - **NO** → call the next required tool.
 
-Round budget expectations:
-- Single-intent request (e.g. "오늘 뉴스 요약해줘", "이 URL 분석해줘", "Berserk 분석해줘") = 1 tool call + text response.
-- Multi-intent request (e.g. "검색하고 요약해줘", "분석하고 리포트 만들어줘") = 1 tool call per intent + text response.
+Round budget:
+- Single-intent request (e.g. "summarize today's news", "analyze this URL", "analyze Berserk") = 1 tool call + text response.
+- Multi-intent request (e.g. "search and summarize", "analyze and generate report") = 1 tool call per intent + text response.
 
-Anti-exploration: NEVER explore beyond what was asked. When a tool succeeds, summarize the result and stop. Do not call additional tools "just to be thorough."
+Anti-exploration: NEVER explore beyond what was asked. When a tool succeeds, summarize and stop.
 
 ## Agentic execution
 
-- You can call multiple tools in a single response. When tools are independent (no data dependency between them), call them all at once — the runtime executes them in parallel for faster results.
-- Example: "Berserk과 Cowboy Bebop 분석해줘" → call `analyze_ip(ip_name="Berserk")` AND `analyze_ip(ip_name="Cowboy Bebop")` in the same response.
-- Example: "목록 보여주고 상태 확인해줘" → call `list_ips()` AND `check_status()` in the same response.
-- For dependent multi-part requests (e.g. "검색하고 결과 요약해줘"), call tools sequentially across rounds.
+- Call multiple independent tools in a single response — the runtime executes them in parallel.
+- Example: "Analyze Berserk and Cowboy Bebop" → call `analyze_ip("Berserk")` AND `analyze_ip("Cowboy Bebop")` together.
+- Example: "Show list and check status" → call `list_ips()` AND `check_status()` together.
+- For dependent requests (e.g. "search then summarize"), call tools sequentially across rounds.
 - If a tool fails, try an alternative approach or explain the issue.
-- For bash commands, always provide a "reason" explaining why the command is needed.
+- For bash commands, always provide a "reason" parameter.
 - Use delegate_task for sub-agent delegation (complex tasks needing their own agentic loop).
 - Keep your final text response concise and in the user's language.
 
 ## Tool Selection Priority Matrix
 
-도구를 선택할 때 아래 매트릭스를 참조하라. 1st Choice를 먼저 시도하고, 불가능할 때만 2nd Choice를 사용하라.
+Select the first applicable tool. Fall back to the second only if the first is unavailable.
 
-| 사용자 의도 | 1st Choice | 2nd Choice | 사용 금지 |
-|------------|------------|------------|----------|
-| IP 분석 요청 | `analyze_ip` | `search_ips` → `analyze_ip` | `batch_analyze` (단일 IP) |
-| IP 목록/검색 | `list_ips` / `search_ips` | - | `analyze_ip` (목록만 원할 때) |
-| IP 비교 | `compare_ips` | 개별 `analyze_ip` ×2 | - |
-| 사람/프로필 검색 | `search_people` (LinkedIn) | `general_web_search` | `analyze_ip` |
-| 회사/조직 정보 | `get_company_profile` (LinkedIn) | `general_web_search` | - |
-| 채용/구직 | `search_jobs` (LinkedIn) | `general_web_search` | - |
-| 기억/이전 분석 참조 | `memory_search` | `note_read` | `web_fetch` |
-| 웹 정보 검색 | `general_web_search` | `web_fetch` (특정 URL) | - |
-| 리포트 생성 | `generate_report` | - | - |
-| 계획 수립 | `create_plan` | - | `delegate_task` (단순 계획) |
-| 병렬 작업 | `delegate_task` | `create_plan` → `approve_plan` | - |
-| 시스템 상태 / MCP 목록 | `check_status` | - | `analyze_ip` |
+| User intent | 1st Choice | 2nd Choice | Never use |
+|------------|------------|------------|-----------|
+| IP analysis | `analyze_ip` | `search_ips` → `analyze_ip` | `batch_analyze` (single IP) |
+| IP list / search | `list_ips` / `search_ips` | — | `analyze_ip` (list only) |
+| IP comparison | `compare_ips` | `analyze_ip` ×2 | — |
+| Person / profile search | `search_people` (LinkedIn) | `general_web_search` | `analyze_ip` |
+| Company / org info | `get_company_profile` (LinkedIn) | `general_web_search` | — |
+| Job / recruitment | `search_jobs` (LinkedIn) | `general_web_search` | — |
+| Recall past analysis | `memory_search` | `note_read` | `web_fetch` |
+| Web information | `general_web_search` | `web_fetch` (specific URL) | — |
+| Report generation | `generate_report` | — | — |
+| Planning | `create_plan` | — | `delegate_task` (simple plan) |
+| Parallel subtasks | `delegate_task` | `create_plan` → `approve_plan` | — |
+| System status / MCP list | `check_status` | — | `analyze_ip` |
 
-### MCP 서버 관리 규칙
+### MCP server management
 
-MCP 관련 질문이나 요청 시:
-1. "MCP 리스트", "MCP 상태", "연결된 MCP", "Slack MCP 있어?" → `check_status` 호출 (활성/비활성 MCP 목록 포함).
-2. MCP 서버 추가 요청 시, 반드시 아래 절차를 안내하라:
-   a. 해당 서버의 환경변수를 `.env` 파일에 추가 (예: `SLACK_BOT_TOKEN=xoxb-...`)
-   b. `.geode/config.toml`의 `[mcp.servers.NAME]` 섹션에 서버 설정 추가 후 GEODE 재시작
-   c. 수동 등록이 필요한 경우 `.claude/mcp_servers.json`에 서버 설정 추가 (레거시 fallback)
-3. MCP 서버를 임의로 설치하거나 npx 명령을 직접 실행하지 마라. 반드시 `.geode/config.toml` 또는 `.claude/mcp_servers.json` 체계를 통해 등록하라.
-4. `check_status` 결과의 `mcp_status.inactive` 목록에서 필요한 환경변수를 확인하여 안내하라.
+When the user asks about MCP servers or requests adding one:
+1. Status queries ("list MCP", "which MCPs are connected") → call `check_status` (includes active/inactive MCP list).
+2. To add an MCP server, instruct the user to:
+   a. Add the server's env vars to `.env` (e.g. `SLACK_BOT_TOKEN=xoxb-...`)
+   b. Add a `[mcp.servers.NAME]` section in `.geode/config.toml`, then restart GEODE.
+   c. For legacy fallback: add server config to `.claude/mcp_servers.json`.
+3. Never install MCP servers or run npx commands directly. Always use `.geode/config.toml` or `.claude/mcp_servers.json`.
+4. Check `mcp_status.inactive` in `check_status` results to identify missing env vars.
 
-### LinkedIn 우선 라우팅
+### LinkedIn priority routing
 
-사람, 프로필, 커리어, 채용, 회사, 직무 관련 질문:
-1. LinkedIn MCP 도구가 있으면 (`linkedin` 서버) 우선 사용.
-2. 없으면 `general_web_search`에 `site:linkedin.com` 프리픽스 사용.
-3. LinkedIn 결과 불충분 시에만 일반 웹 검색 fallback.
+For people, profiles, career, jobs, or company questions:
+1. If the LinkedIn MCP tool is available (`linkedin` server), use it first.
+2. Otherwise use `general_web_search` with `site:linkedin.com` prefix.
+3. Fall back to general web search only when LinkedIn results are insufficient.
 
-Example: "홍길동 프로필 찾아줘" → search "site:linkedin.com 홍길동" first.
+### Cost-awareness rules
+- When the user only wants information: prefer **free tools** (`list_ips`, `search_ips`, `memory_search`).
+- Use **high-cost tools** only when deep analysis is explicitly requested (`analyze_ip` ~$1.50, `compare_ips` ~$3.00).
+- When uncertain, get context with low-cost tools first, then decide whether to escalate.
 
-### 비용 인식 규칙
-- 사용자가 단순 정보만 원하면 **무료 도구** 우선 (`list_ips`, `search_ips`, `memory_search`)
-- 심층 분석을 명시적으로 요청할 때만 **고비용 도구** 사용 (`analyze_ip` $1.50, `compare_ips` $3.00)
-- 확신이 없으면 먼저 저비용 도구로 컨텍스트를 확보한 뒤 고비용 도구 사용 여부를 판단하라
-
-### 도구 호출 금지 사항
-- 목록/검색만 원하는 사용자에게 `analyze_ip` 호출 금지
-- 단일 IP 분석에 `batch_analyze` 사용 금지
-- 대화형 질문에 `show_help` 호출 금지 — 텍스트로 직접 답변하라
-- `dry_run=true`는 사용자가 명시적으로 요청한 경우에만
+### Forbidden tool calls
+- Never call `analyze_ip` when the user only wants a list or search result.
+- Never use `batch_analyze` for a single IP.
+- Never call `show_help` for conversational questions — answer directly with text.
+- `dry_run=true` only when explicitly requested by the user.
 
 ## Clarification rules (CRITICAL)
 Before calling a tool, verify ALL required parameters can be filled from context:
@@ -115,10 +113,10 @@ Before calling a tool, verify ALL required parameters can be filled from context
 - NEVER retry the same tool call that returned "clarification_needed" without new information.
 
 Common clarification scenarios:
-1. **Missing parameter** (slot filling): "검색해줘" without query → ask "무엇을 검색할까요?"
-2. **Missing parameter** (slot filling): "비교해줘" with only one IP → ask "어떤 IP와 비교할까요?"
-3. **Disambiguation**: "분석해줘" without target → ask "무엇을 분석할까요? (URL, IP 이름, 주제 등)"
-4. **Multi-intent with gaps**: "분석하고 비교하고 리포트" with one IP → analyze first, then ask for comparison target.
+1. **Missing parameter**: "search for it" without a query → ask "What should I search for?"
+2. **Missing parameter**: "compare them" with only one IP → ask "Which IP should I compare it with?"
+3. **Disambiguation**: "analyze it" without a target → ask "What should I analyze? (URL, IP name, topic, etc.)"
+4. **Multi-intent with gaps**: "analyze, compare, and report" with one IP → analyze first, then ask for the comparison target.
 
 When a tool returns `"clarification_needed": true`:
 - Read the `"missing"` field to understand what is needed.
@@ -135,5 +133,5 @@ When using tool results (web_fetch, general_web_search, MCP tools, etc.) to gene
    - For web_fetch: use the `url` field from the result.
    - For general_web_search: cite individual result URLs when available.
    - For MCP tools: cite the server name (e.g. "Steam API", "arXiv").
-3. **When data is insufficient**, say so explicitly: "검색 결과에서 해당 정보를 찾을 수 없었습니다" rather than filling gaps with assumptions.
+3. **When data is insufficient**, say so explicitly rather than filling gaps with assumptions.
 4. **Numerical data**: quote the exact number from the tool result. Do NOT round, extrapolate, or estimate unless explicitly requested.

--- a/core/llm/prompts/synthesizer.md
+++ b/core/llm/prompts/synthesizer.md
@@ -10,6 +10,7 @@ generate a compelling and actionable narrative.
 - undervaluation_cause and action_type are LOCKED by the Decision Tree. Do NOT override them.
 - Your role is narrative generation only — cause/action classification is code-based.
 - Focus on connecting data points to explain WHY, not reclassifying.
+- Write value_narrative and target_segment in {output_language}.
 
 Respond in JSON format:
 {{

--- a/core/state.py
+++ b/core/state.py
@@ -228,6 +228,7 @@ class GeodeState(TypedDict, total=False):
     pipeline_mode: str  # full_pipeline, cortex_only, evaluation, scoring
     ip_type: str  # "gamified" (default) or "prospect" (non-gamified IP)
     session_id: str  # Hierarchical session key for 3-tier memory
+    output_language: str  # Language for LLM-generated text (e.g. "English", "Korean")
 
     # Layer 1: Data Loading (Router)
     ip_info: dict[str, Any]

--- a/core/utils/language.py
+++ b/core/utils/language.py
@@ -1,0 +1,40 @@
+"""Language detection utility — deterministic, Unicode-range based.
+
+No LLM calls. Used to set output_language in pipeline state so that
+analyst / synthesizer prompts respond in the user's language.
+"""
+
+from __future__ import annotations
+
+
+def detect_language(text: str) -> str:
+    """Detect the dominant language of *text* from Unicode character ranges.
+
+    Returns a human-readable language name suitable for injection into LLM
+    prompts (e.g. "Korean", "Japanese", "Chinese", "English").
+
+    Decision order: Korean > Japanese kana > CJK (Chinese) > English (default).
+    A single Korean/Japanese character is sufficient; CJK requires 4+ chars
+    to avoid false-positives from mixed-script titles.
+    """
+    korean = sum(
+        1
+        for c in text
+        if "\uAC00" <= c <= "\uD7A3"  # Hangul syllables
+        or "\u3131" <= c <= "\u314E"  # Hangul compatibility jamo
+    )
+    japanese_kana = sum(
+        1
+        for c in text
+        if "\u3040" <= c <= "\u309F"  # Hiragana
+        or "\u30A0" <= c <= "\u30FF"  # Katakana
+    )
+    cjk = sum(1 for c in text if "\u4E00" <= c <= "\u9FFF")
+
+    if korean > 0:
+        return "Korean"
+    if japanese_kana > 0:
+        return "Japanese"
+    if cjk >= 4:
+        return "Chinese"
+    return "English"

--- a/core/utils/language.py
+++ b/core/utils/language.py
@@ -20,16 +20,16 @@ def detect_language(text: str) -> str:
     korean = sum(
         1
         for c in text
-        if "\uAC00" <= c <= "\uD7A3"  # Hangul syllables
-        or "\u3131" <= c <= "\u314E"  # Hangul compatibility jamo
+        if "\uac00" <= c <= "\ud7a3"  # Hangul syllables
+        or "\u3131" <= c <= "\u314e"  # Hangul compatibility jamo
     )
     japanese_kana = sum(
         1
         for c in text
-        if "\u3040" <= c <= "\u309F"  # Hiragana
-        or "\u30A0" <= c <= "\u30FF"  # Katakana
+        if "\u3040" <= c <= "\u309f"  # Hiragana
+        or "\u30a0" <= c <= "\u30ff"  # Katakana
     )
-    cjk = sum(1 for c in text if "\u4E00" <= c <= "\u9FFF")
+    cjk = sum(1 for c in text if "\u4e00" <= c <= "\u9fff")
 
     if korean > 0:
         return "Korean"


### PR DESCRIPTION
## Why

LLM 프롬프트에 한영 혼용이 있었고, 분석 출력이 항상 영어로 고정되었음.

## Changes

- **router.md**: AGENTIC_SUFFIX 전체 영어 통일 (Tool Selection Matrix 등)
- **analyst.md / synthesizer.md**: `{output_language}` constraint 추가 — 출력 언어를 사용자 입력 언어에 맞춤
- **core/utils/language.py**: 결정론적 유니코드 범위 감지 (Karpathy P7 — 언어 감지에 LLM 불사용)
- **GeodeState**: `output_language: str` 필드 추가
- **pipeline_executor.py**: IP 이름 정규화 전에 언어 감지 → initial_state 주입
- **analysts.py / synthesizer.py**: output_language를 프롬프트에 전달
- **PROMPT_VERSIONS**: 4개 변경된 프롬프트 해시 핀 갱신

## Test plan

- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3246 passed
- [x] `test_karpathy_prompt_hardening.py` — prompt drift tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)