### PR TITLE
fix: scheduler NL — regex extraction → original text + LLM framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- **Scheduler action queue** — `ScheduledJob.action` 필드 추가. NL 파서가 스케줄 표현식에서 action 텍스트를 추출(`_extract_action()`)하여 job에 저장. `SchedulerService`가 job 발화 시 `action_queue: queue.Queue[tuple[str, str]]`에 `(job_id, action)` 삽입. REPL 루프가 큐를 drain하여 `AgenticLoop.run(action)` 호출 — NL 예약 작업이 실제로 실행됨.
+- **Scheduler action queue** — `ScheduledJob.action` 필드 추가. 원문 텍스트를 그대로 저장(정규식 추출 제거). `SchedulerService`가 job 발화 시 `action_queue`에 삽입. REPL이 `[scheduled-job:{id}]` 프레이밍으로 AgenticLoop에 위임 — LLM이 자체 판단으로 스케줄 의도를 분리하여 실행.
 
 ### Architecture
 - **`core/hooks/` 신설** — HookSystem/HookEvent/HookResult + HookPluginLoader + plugins/를 `core/orchestration/`에서 분리. Cross-cutting concern이므로 별도 최상위 모듈로. 26개 소비자 `from core.hooks import HookSystem` 경로 통일. L0~L4가 L3(orchestration)에 의존하던 레이어 위반 해소.

--- a/core/automation/nl_scheduler.py
+++ b/core/automation/nl_scheduler.py
@@ -313,7 +313,7 @@ class NLScheduleParser:
 
         job_id = self._generate_job_id(job_name, agent_id)
         now_ms = time.time() * 1000
-        action = self._extract_action(original)
+        action = original
 
         job = ScheduledJob(
             job_id=job_id,
@@ -587,41 +587,6 @@ class NLScheduleParser:
         if target <= now:
             target += datetime.timedelta(days=1)
         return target.timestamp() * 1000
-
-    def _extract_action(self, original: str) -> str:
-        """Strip scheduling keywords from *original* to recover the action text.
-
-        For example:
-        - "remind me to check emails every 5 minutes" → "remind me to check emails"
-        - "daily at 9am send standup summary" → "send standup summary"
-        - "every 5 minutes" → ""
-        """
-        t = original.strip()
-        # Remove active-hours clauses ("during 09:00-22:00", "between 8am-6pm")
-        t = _ACTIVE_HOURS_24H_RE.sub("", t)
-        t = _ACTIVE_HOURS_AMPM_RE.sub("", t)
-        # Remove "every N unit" intervals (e.g. "every 5 minutes")
-        t = re.sub(r"\bevery\s+\d+\s*\w+\b", "", t, flags=re.IGNORECASE)
-        # Remove "every <unit>" without a number (e.g. "every hour", "every day")
-        _unit_words = r"(?:seconds?|minutes?|hours?|days?|weeks?|months?)"
-        t = re.sub(rf"\bevery\s+{_unit_words}\b", "", t, flags=re.IGNORECASE)
-        # Remove cron keywords
-        _cron_kw = r"\b(?:hourly|daily|weekly|monthly|weekday|weekdays)\b"
-        t = re.sub(_cron_kw, "", t, flags=re.IGNORECASE)
-        # Remove "at HH:MM" / "at H am/pm"
-        t = re.sub(r"\bat\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b", "", t, flags=re.IGNORECASE)
-        # Remove "in N unit" relative one-shots
-        t = re.sub(r"\bin\s+\d+\s*\w+\b", "", t, flags=re.IGNORECASE)
-        # Remove "once" keyword
-        t = re.sub(r"\bonce\b", "", t, flags=re.IGNORECASE)
-        # Remove "on <day>" / bare day names
-        t = re.sub(
-            r"\b(?:on\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|wed|thu|fri|sat|sun)\b",
-            "",
-            t,
-            flags=re.IGNORECASE,
-        )
-        return re.sub(r"\s+", " ", t).strip()
 
     @staticmethod
     def _generate_job_id(name: str, agent_id: str) -> str:

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -969,7 +969,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                 job_id, fired_action = _action_queue.get_nowait()
                 if fired_action:
                     console.print(f"\n  [muted]Scheduler: running job {job_id}[/muted]")
-                    agentic.run(fired_action)
+                    agentic.run(f"[scheduled-job:{job_id}] {fired_action}")
         except _queue_mod.Empty:
             pass
 

--- a/tests/test_nl_scheduler.py
+++ b/tests/test_nl_scheduler.py
@@ -482,51 +482,35 @@ class TestEdgeCases:
 
 
 # ===========================================================================
-# Action extraction
+# Action stores original text (LLM does extraction at fire time)
 # ===========================================================================
 
 
-class TestExtractAction:
-    """Tests for NLScheduleParser._extract_action() and job.action field."""
+class TestActionStoresOriginal:
+    """job.action stores the full original text — no regex extraction."""
 
     @pytest.fixture
     def parser(self) -> NLScheduleParser:
         return NLScheduleParser()
 
-    def test_extract_action_every_interval(self, parser: NLScheduleParser) -> None:
-        # "every N unit" schedule keywords stripped, remainder is action
-        assert (
-            parser._extract_action("remind me to check emails every hour")
-            == "remind me to check emails"
-        )
-
-    def test_extract_action_daily_at(self, parser: NLScheduleParser) -> None:
-        assert parser._extract_action("daily at 9am send standup summary") == "send standup summary"
-
-    def test_extract_action_schedule_only(self, parser: NLScheduleParser) -> None:
-        # Pure schedule text → empty action
-        assert parser._extract_action("every 5 minutes") == ""
-
-    def test_extract_action_weekly(self, parser: NLScheduleParser) -> None:
-        assert parser._extract_action("weekly on monday run drift check") == "run drift check"
-
-    def test_extract_action_in_relative(self, parser: NLScheduleParser) -> None:
-        assert parser._extract_action("in 30 minutes summarize inbox") == "summarize inbox"
-
-    def test_extract_action_once_at(self, parser: NLScheduleParser) -> None:
-        assert parser._extract_action("once at 15:00 send report") == "send report"
-
-    def test_extract_action_hourly(self, parser: NLScheduleParser) -> None:
-        assert parser._extract_action("hourly check server health") == "check server health"
-
-    def test_job_action_field_set_by_parse(self, parser: NLScheduleParser) -> None:
-        result = parser.parse("remind me to check emails every 5 minutes")
+    def test_action_is_original_text(self, parser: NLScheduleParser) -> None:
+        text = "remind me to check emails every 5 minutes"
+        result = parser.parse(text)
         assert result.success
         assert result.job is not None
-        assert result.job.action == "remind me to check emails"
+        assert result.job.action == text
 
-    def test_job_action_empty_for_pure_schedule(self, parser: NLScheduleParser) -> None:
-        result = parser.parse("every 5 minutes")
+    def test_action_preserves_schedule_keywords(self, parser: NLScheduleParser) -> None:
+        text = "every 5 minutes"
+        result = parser.parse(text)
         assert result.success
         assert result.job is not None
-        assert result.job.action == ""
+        assert result.job.action == text
+
+    def test_action_preserves_daily_context(self, parser: NLScheduleParser) -> None:
+        text = "daily at 9:00 generate daily standup summary"
+        result = parser.parse(text)
+        assert result.success
+        assert result.job is not None
+        # "daily" in "daily standup summary" is preserved — no regex noise
+        assert "daily standup summary" in result.job.action


### PR DESCRIPTION
## Why

`_extract_action()` regex stripping garbled action text when schedule keywords overlapped with action words:
- "generate **daily** standup summary" → "generate standup summary" (context loss)
- "daily report every monday" → "report every" (incomplete strip)

LLM is better at separating schedule intent from action intent than regex.

## What

- **Removed** `NLScheduleParser._extract_action()` (34 lines of regex)
- **`job.action = original`** — stores the full original text verbatim
- **REPL framing** — `[scheduled-job:{id}] {original}` prefix tells LLM this is a fired job, not a new scheduling request
- Tests updated: 9 regex extraction tests → 3 original-text-preservation tests

## Test plan

- [ ] `uv run pytest tests/test_nl_scheduler.py tests/test_scheduler.py -q` — all pass
- [ ] `uv run ruff check core/ tests/` — 0 errors
- [ ] `uv run mypy core/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)