### PR TITLE
refactor: remove 8 unnecessary ContextVar DI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Scheduler action queue** — `ScheduledJob.action` 필드 추가. 원문 텍스트를 그대로 저장(정규식 추출 제거). `SchedulerService`가 job 발화 시 `action_queue`에 삽입. REPL이 `[scheduled-job:{id}]` 프레이밍으로 AgenticLoop에 위임 — LLM이 자체 판단으로 스케줄 의도를 분리하여 실행.
 
 ### Architecture
+- **ContextVar DI 정리** — 불필요한 ContextVar 8개 제거. 단일 소비자·동일 파일 내 접근인 경우 module-level 변수로 교체. dead code `_llm_text_ctx` 완전 삭제. `set_*/get_*` API 유지로 호출부 변경 없음.
 - **`core/fixtures/` 삭제** — 중복 fixture 디렉터리 제거. 소비자 2곳(`core/memory/organization.py`, `core/verification/calibration.py`) import 경로를 `core.domains.game_ip.fixtures`로 갱신. `tests/test_calibration.py` 경로 동기화.
 - **Scaffold skills 경로 분리** — `.geode/skills/` 내 Scaffold 21종(SKILL.md 기반)을 `.claude/skills/`로 이동. Runtime skills(`geode-analysts/` 4종) 는 `.geode/skills/`에 유지. CLAUDE.md 경로 갱신.
 - **`core/hooks/` 신설** — HookSystem/HookEvent/HookResult + HookPluginLoader + plugins/를 `core/orchestration/`에서 분리. Cross-cutting concern이므로 별도 최상위 모듈로. 26개 소비자 `from core.hooks import HookSystem` 경로 통일. L0~L4가 L3(orchestration)에 의존하던 레이어 위반 해소.

--- a/core/automation/calendar_bridge.py
+++ b/core/automation/calendar_bridge.py
@@ -9,7 +9,6 @@ Registers with TRIGGER_FIRED hook for automatic sync after scheduler runs.
 from __future__ import annotations
 
 import logging
-from contextvars import ContextVar
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -157,19 +156,18 @@ class CalendarSchedulerBridge:
 
 
 # ---------------------------------------------------------------------------
-# contextvars injection
+# Module-level singleton
 # ---------------------------------------------------------------------------
 
-_bridge_ctx: ContextVar[CalendarSchedulerBridge | None] = ContextVar(
-    "calendar_bridge", default=None
-)
+_bridge: CalendarSchedulerBridge | None = None
 
 
 def set_calendar_bridge(bridge: CalendarSchedulerBridge | None) -> None:
-    """Set the active calendar bridge for the current context."""
-    _bridge_ctx.set(bridge)
+    """Set the active calendar bridge."""
+    global _bridge
+    _bridge = bridge
 
 
 def get_calendar_bridge() -> CalendarSchedulerBridge | None:
     """Get the active calendar bridge, or None if not set."""
-    return _bridge_ctx.get()
+    return _bridge

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -12,7 +12,6 @@ import logging
 import signal
 import sys
 import termios
-from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
@@ -87,13 +86,13 @@ from core.llm.commentary import (
 
 log = logging.getLogger(__name__)
 
-# Hook system context for memory event firing (P1.5)
-_hooks_ctx: ContextVar[HookSystem | None] = ContextVar("cli_hooks", default=None)
+# Hook system module-level variable for memory event firing (P1.5)
+_hooks_ctx: HookSystem | None = None
 
 
 def _fire_hook(event: HookEvent, data: dict[str, Any]) -> None:
     """Fire a hook event if HookSystem is available in context."""
-    hooks = _hooks_ctx.get()
+    hooks = _hooks_ctx
     if hooks is not None:
         try:
             hooks.trigger(event, data)

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from typing import Any as _Any
 
 if TYPE_CHECKING:
@@ -552,17 +552,17 @@ def _auth_add_interactive(store: ProfileStore, add_args: str) -> None:
     console.print()
 
 
-# Thread-safe profile store via contextvars
-_profile_store_ctx: ContextVar[_Any] = ContextVar("profile_store", default=None)
+# Module-level profile store singleton
+_profile_store: ProfileStore | None = None
 
 
 def _get_profile_store() -> ProfileStore:
-    """Get or create the context-local profile store, seeded from settings."""
+    """Get or create the module-level profile store, seeded from settings."""
+    global _profile_store
     from core.gateway.auth.profiles import AuthProfile, CredentialType
 
-    store = _profile_store_ctx.get()
-    if store is not None:
-        return cast(ProfileStore, store)
+    if _profile_store is not None:
+        return _profile_store
 
     store = ProfileStore()
 
@@ -596,7 +596,7 @@ def _get_profile_store() -> ProfileStore:
                 key=settings.zai_api_key,
             )
         )
-    _profile_store_ctx.set(store)
+    _profile_store = store
     return store
 
 

--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -530,7 +530,9 @@ def _run_analysis(
     domain_name: str = "game_ip",
 ) -> dict[str, Any] | None:
     """Core analysis logic shared by interactive and CLI modes."""
-    from core.cli import _hooks_ctx, _set_last_result
+    import core.cli as _cli_mod
+
+    _set_last_result = _cli_mod._set_last_result
     from core.domains.game_ip.fixtures import FIXTURE_MAP
     from core.utils.language import detect_language
 
@@ -560,7 +562,7 @@ def _run_analysis(
     if is_subagent:
         runtime.is_subagent = True
 
-    _hooks_ctx.set(runtime.hooks)
+    _cli_mod._hooks_ctx = runtime.hooks
 
     # Log available tools for current mode
     mode = "dry_run" if dry_run else pipeline_mode

--- a/core/cli/session_state.py
+++ b/core/cli/session_state.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 # Thread-safe singletons for REPL session via contextvars
 _search_engine_ctx: ContextVar[Any] = ContextVar("search_engine", default=None)
-_readiness_ctx: ContextVar[Any] = ContextVar("readiness", default=None)
+_readiness: Any = None
 _scheduler_service_ctx: ContextVar[Any] = ContextVar("scheduler_service", default=None)
 _user_task_graph_ctx: ContextVar[Any] = ContextVar("user_task_graph", default=None)
 
@@ -114,13 +114,14 @@ def _get_search_engine() -> IPSearchEngine:
 
 
 def _get_readiness() -> ReadinessReport | None:
-    """Get the context-local ReadinessReport."""
-    return cast("ReadinessReport | None", _readiness_ctx.get())
+    """Get the module-level ReadinessReport."""
+    return cast("ReadinessReport | None", _readiness)
 
 
 def _set_readiness(report: ReadinessReport) -> None:
-    """Set the context-local ReadinessReport."""
-    _readiness_ctx.set(report)
+    """Set the module-level ReadinessReport."""
+    global _readiness
+    _readiness = report
 
 
 def _get_last_result() -> dict[str, Any] | None:

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
-from contextvars import ContextVar
 from typing import Any
 
 from core.gateway.models import ChannelBinding, InboundMessage
@@ -18,17 +17,18 @@ from core.memory.session_key import build_gateway_session_key
 
 MessageProcessor = Callable[[str, dict[str, Any]], str]
 
-_gateway_ctx: ContextVar[ChannelManager | None] = ContextVar("gateway_ctx", default=None)
+_gateway: ChannelManager | None = None
 
 
 def set_gateway(gateway: ChannelManager | None) -> None:
-    """Set the active gateway for the current context."""
-    _gateway_ctx.set(gateway)
+    """Set the active gateway."""
+    global _gateway
+    _gateway = gateway
 
 
 def get_gateway() -> ChannelManager | None:
     """Get the active gateway, or None if not set."""
-    return _gateway_ctx.get()
+    return _gateway
 
 
 log = logging.getLogger(__name__)

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -1021,7 +1021,6 @@ class LLMToolCallable(Protocol):
 # ---------------------------------------------------------------------------
 
 _llm_json_ctx: ContextVar[LLMJsonCallable | None] = ContextVar("llm_json", default=None)
-_llm_text_ctx: ContextVar[LLMTextCallable | None] = ContextVar("llm_text", default=None)
 _llm_parsed_ctx: ContextVar[LLMParsedCallable | None] = ContextVar("llm_parsed", default=None)
 _llm_tool_ctx: ContextVar[LLMToolCallable | None] = ContextVar("llm_tool", default=None)
 
@@ -1044,7 +1043,6 @@ def set_llm_callable(
 ) -> None:
     """Inject LLM callables (typically called by GeodeRuntime.create())."""
     _llm_json_ctx.set(json_fn)
-    _llm_text_ctx.set(text_fn)
     if parsed_fn is not None:
         _llm_parsed_ctx.set(parsed_fn)
     if tool_fn is not None:
@@ -1060,17 +1058,6 @@ def get_llm_json() -> LLMJsonCallable:
     if fn is None:
         raise RuntimeError(
             "LLM JSON callable not injected. "
-            "Call set_llm_callable() first (done by GeodeRuntime.create())."
-        )
-    return fn
-
-
-def get_llm_text() -> LLMTextCallable:
-    """Return the injected text callable. Raises if not injected."""
-    fn = _llm_text_ctx.get()
-    if fn is None:
-        raise RuntimeError(
-            "LLM text callable not injected. "
             "Call set_llm_callable() first (done by GeodeRuntime.create())."
         )
     return fn

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -27,9 +27,7 @@ log = logging.getLogger(__name__)
 _default_session_store_ctx: ContextVar[SessionStorePort | None] = ContextVar(
     "default_session_store", default=None
 )
-_project_memory_ctx: ContextVar[ProjectMemory | None] = ContextVar(
-    "project_memory_tools", default=None
-)
+_project_memory: ProjectMemory | None = None
 _org_memory_ctx: ContextVar[MonoLakeOrganizationMemory | None] = ContextVar(
     "org_memory_tools", default=None
 )
@@ -41,8 +39,9 @@ def set_default_session_store(store: SessionStorePort) -> None:
 
 
 def set_project_memory(mem: ProjectMemory | None) -> None:
-    """Set the context-local project memory for memory tools."""
-    _project_memory_ctx.set(mem)
+    """Set the module-level project memory for memory tools."""
+    global _project_memory
+    _project_memory = mem
 
 
 def set_org_memory(mem: MonoLakeOrganizationMemory | None) -> None:
@@ -136,7 +135,7 @@ class MemorySearchTool:
 
         # Project tier (MEMORY.md + rules)
         if tier in ("project", "all") and len(matches) < limit:
-            proj = _project_memory_ctx.get()
+            proj = _project_memory
             if proj is not None:
                 # Search MEMORY.md content
                 memory_text = proj.load_memory()
@@ -311,7 +310,7 @@ class MemorySaveTool:
 
         # Persistent write to MEMORY.md (P1.5)
         if persistent:
-            proj = _project_memory_ctx.get()
+            proj = _project_memory
             if proj is not None:
                 from core.memory.project import ProjectMemory
 
@@ -376,7 +375,7 @@ class RuleCreateTool:
         paths: list[str] = kwargs["paths"]
         content: str = kwargs["content"]
 
-        proj = _project_memory_ctx.get()
+        proj = _project_memory
         if proj is None:
             return {"result": {"created": False, "error": "Project memory not available"}}
 
@@ -425,7 +424,7 @@ class RuleUpdateTool:
         rule_name: str = kwargs["name"]
         content: str = kwargs["content"]
 
-        proj = _project_memory_ctx.get()
+        proj = _project_memory
         if proj is None:
             return {"result": {"updated": False, "error": "Project memory not available"}}
 
@@ -465,7 +464,7 @@ class RuleDeleteTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         rule_name: str = kwargs["name"]
 
-        proj = _project_memory_ctx.get()
+        proj = _project_memory
         if proj is None:
             return {"result": {"deleted": False, "error": "Project memory not available"}}
 
@@ -500,7 +499,7 @@ class RuleListTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        proj = _project_memory_ctx.get()
+        proj = _project_memory
         if proj is None:
             return {"result": {"rules": [], "error": "Project memory not available"}}
 
@@ -531,7 +530,7 @@ class NoteSaveTool:
         key: str = kwargs["key"]
         content: str = kwargs["content"]
 
-        proj = _project_memory_ctx.get()
+        proj = _project_memory
         if proj is None:
             return {"error": "Project memory not available"}
 
@@ -562,7 +561,7 @@ class NoteReadTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         query: str = kwargs.get("query", "")
 
-        proj = _project_memory_ctx.get()
+        proj = _project_memory
         if proj is None:
             return {"error": "Project memory not available"}
 

--- a/core/tools/profile_tools.py
+++ b/core/tools/profile_tools.py
@@ -10,27 +10,25 @@ Tools for viewing, updating, and learning from user interactions:
 from __future__ import annotations
 
 import logging
-from contextvars import ContextVar
 from typing import Any
 
 from core.memory.user_profile import FileBasedUserProfile
 
 log = logging.getLogger(__name__)
 
-# Thread-safe user profile via contextvars
-_user_profile_ctx: ContextVar[FileBasedUserProfile | None] = ContextVar(
-    "user_profile_tools", default=None
-)
+# Module-level user profile singleton
+_user_profile: FileBasedUserProfile | None = None
 
 
 def set_user_profile(profile: FileBasedUserProfile | None) -> None:
-    """Set the context-local user profile for profile tools."""
-    _user_profile_ctx.set(profile)
+    """Set the module-level user profile for profile tools."""
+    global _user_profile
+    _user_profile = profile
 
 
 def get_user_profile() -> FileBasedUserProfile | None:
-    """Get the context-local user profile."""
-    return _user_profile_ctx.get()
+    """Get the module-level user profile."""
+    return _user_profile
 
 
 class ProfileShowTool:
@@ -56,7 +54,7 @@ class ProfileShowTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile_ctx.get()
+        profile = _user_profile
         if profile is None:
             return {"error": "User profile not configured"}
 
@@ -122,7 +120,7 @@ class ProfileUpdateTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile_ctx.get()
+        profile = _user_profile
         if profile is None:
             return {"error": "User profile not configured"}
 
@@ -173,7 +171,7 @@ class ProfilePreferenceTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile_ctx.get()
+        profile = _user_profile
         if profile is None:
             return {"error": "User profile not configured"}
 
@@ -235,7 +233,7 @@ class ProfileLearnTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile_ctx.get()
+        profile = _user_profile
         if profile is None:
             return {"error": "User profile not configured"}
 

--- a/tests/test_cli_bootstrap.py
+++ b/tests/test_cli_bootstrap.py
@@ -41,7 +41,8 @@ class TestGeodeBootstrapDefaults:
 class TestPropagateToThread:
     def test_propagate_sets_memory_contextvars_in_new_thread(self) -> None:
         """propagate_to_thread() makes ProjectMemory/OrgMemory available in a child thread."""
-        from core.tools.memory_tools import _org_memory_ctx, _project_memory_ctx
+        import core.tools.memory_tools as _mem_mod
+        from core.tools.memory_tools import _org_memory_ctx
 
         # Create a bootstrap with a mock readiness
         readiness = MagicMock()
@@ -53,7 +54,7 @@ class TestPropagateToThread:
         def worker() -> None:
             try:
                 boot.propagate_to_thread()
-                results["project"] = _project_memory_ctx.get()
+                results["project"] = _mem_mod._project_memory
                 results["org"] = _org_memory_ctx.get()
             except Exception as exc:
                 errors.append(exc)


### PR DESCRIPTION
## Summary
- Remove 8 unnecessary ContextVar patterns, replacing with module-level variables for single-consumer cases
- Delete dead code `_llm_text_ctx` / `get_llm_text()` (0 consumers)
- Replace `_profile_store_ctx`, `_user_profile_ctx`, `_hooks_ctx`, `_readiness_ctx`, `_gateway_ctx`, `_bridge_ctx`, `_project_memory_ctx` with module-level variables
- All `set_*/get_*` function APIs preserved — zero caller changes needed

## Why
ContextVar DI is warranted only when multiple implementations exist or thread-boundary isolation is needed. These 8 cases had a single consumer, same-file access, or were dead code. Module-level variables are simpler and equally correct for the actual usage pattern.

## Files changed (11)
| File | Change |
|------|--------|
| `core/llm/router.py` | Delete `_llm_text_ctx` + `get_llm_text()` |
| `core/cli/commands.py` | `_profile_store_ctx` → `_profile_store` |
| `core/tools/profile_tools.py` | `_user_profile_ctx` → `_user_profile` |
| `core/cli/__init__.py` | `_hooks_ctx` ContextVar → module-level |
| `core/cli/session_state.py` | `_readiness_ctx` → `_readiness` |
| `core/gateway/channel_manager.py` | `_gateway_ctx` → `_gateway` |
| `core/automation/calendar_bridge.py` | `_bridge_ctx` → `_bridge` |
| `core/tools/memory_tools.py` | `_project_memory_ctx` → `_project_memory` |
| `core/cli/pipeline_executor.py` | Update `_hooks_ctx` setter to module attr |
| `tests/test_cli_bootstrap.py` | Update `_project_memory` access in test |
| `CHANGELOG.md` | Add Architecture entry |

## Test plan
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run ruff format --check core/ tests/` — all formatted
- [x] `uv run mypy core/` — 0 errors (183 files)
- [x] `uv run pytest tests/ -m "not live"` — 3226 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)