### PR TITLE
feat: cron session isolation — OpenClaw agentTurn/systemEvent pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - **Scheduler action queue** — `ScheduledJob.action` 필드 추가. 원문 텍스트를 그대로 저장(정규식 추출 제거). `SchedulerService`가 job 발화 시 `action_queue`에 삽입. REPL이 `[scheduled-job:{id}]` 프레이밍으로 AgenticLoop에 위임 — LLM이 자체 판단으로 스케줄 의도를 분리하여 실행.
+- **Cron 세션 격리** — `ScheduledJob.isolated` 필드 추가 (기본값 `True`). OpenClaw `agentTurn` 패턴: 스케줄 발화 시 fresh ConversationContext + AgenticLoop에서 독립 실행하여 메인 대화 오염 방지. `isolated=False`(systemEvent)로 메인 세션 주입도 가능.
 - **OpenAI Responses API 전환** — `OpenAIAgenticAdapter`를 Chat Completions → Responses API(`client.responses.create`)로 마이그레이션. 네이티브 `web_search` 호스티드 도구 주입. `normalize_openai_responses()` 정규화기 추가.
 - **3사 네이티브 웹 검색 fallback** — `GeneralWebSearchTool`/`WebSearchTool`을 Anthropic(Opus) → OpenAI(gpt-5.4) → GLM(glm-5) 순차 fallback으로 전환. 외부 API 키 의존 제로.
 

--- a/core/automation/scheduler.py
+++ b/core/automation/scheduler.py
@@ -88,6 +88,7 @@ class ScheduledJob:
     delete_after_run: bool = False  # For AT type: auto-delete after success
     callback: Any = None  # Callable[[dict], None]
     action: str = ""  # Prompt text to enqueue when fired (no callback)
+    isolated: bool = True  # Run in isolated session (agentTurn) vs main session (systemEvent)
     active_hours: ActiveHours | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     # State tracking
@@ -119,6 +120,7 @@ def _job_to_dict(job: ScheduledJob) -> dict[str, Any]:
         "enabled": job.enabled,
         "delete_after_run": job.delete_after_run,
         "action": job.action,
+        "isolated": job.isolated,
         "active_hours": (asdict(job.active_hours) if job.active_hours is not None else None),
         "metadata": job.metadata,
         "created_at_ms": job.created_at_ms,
@@ -151,6 +153,7 @@ def _job_from_dict(data: dict[str, Any]) -> ScheduledJob:
         delete_after_run=data.get("delete_after_run", False),
         callback=None,  # Callbacks are not serialised
         action=data.get("action", ""),
+        isolated=data.get("isolated", True),
         active_hours=active_hours,
         metadata=data.get("metadata", {}),
         created_at_ms=data.get("created_at_ms", 0.0),
@@ -318,7 +321,7 @@ class SchedulerService:
         hooks: HookSystem | None = None,
         store_path: Path | None = None,
         log_dir: Path | None = None,
-        action_queue: queue.Queue[tuple[str, str]] | None = None,
+        action_queue: queue.Queue[tuple[str, str, bool]] | None = None,
     ) -> None:
         self._trigger_manager = trigger_manager
         self._hooks = hooks
@@ -546,8 +549,13 @@ class SchedulerService:
             if job.callback is not None:
                 job.callback({"job_id": job.job_id, "name": job.name, **job.metadata})
             elif job.action and self._action_queue is not None:
-                self._action_queue.put((job.job_id, job.action))
-                log.debug("Job '%s' enqueued action: %s", job.job_id, job.action[:60])
+                self._action_queue.put((job.job_id, job.action, job.isolated))
+                log.debug(
+                    "Job '%s' enqueued action (isolated=%s): %s",
+                    job.job_id,
+                    job.isolated,
+                    job.action[:60],
+                )
         except Exception as exc:
             status = "error"
             error = str(exc)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -910,7 +910,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     # Scheduler (REPL-only: cron + /schedule command)
     import queue as _queue_mod
 
-    _action_queue: _queue_mod.Queue[tuple[str, str]] = _queue_mod.Queue()
+    _action_queue: _queue_mod.Queue[tuple[str, str, bool]] = _queue_mod.Queue()
     try:
         from core.automation.scheduler import SchedulerService
 
@@ -965,10 +965,28 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         # Drain scheduled actions before prompting (scheduler fires in background thread)
         try:
             while True:
-                job_id, fired_action = _action_queue.get_nowait()
-                if fired_action:
+                job_id, fired_action, isolated = _action_queue.get_nowait()
+                if not fired_action:
+                    continue
+                prompt = f"[scheduled-job:{job_id}] {fired_action}"
+                if isolated:
+                    # OpenClaw agentTurn: fresh context, no conversation pollution
+                    console.print(f"\n  [muted]Scheduler (isolated): {job_id}[/muted]")
+                    iso_conv = ConversationContext()
+                    _, _, iso_loop = _build_agentic_stack(
+                        iso_conv,
+                        mcp_manager=mcp_mgr,
+                        skill_registry=skill_registry,
+                        verbose=verbose,
+                        quiet=True,
+                    )
+                    result = iso_loop.run(prompt)
+                    summary = result.text[:200] if result and result.text else "(no output)"
+                    console.print(f"  [muted]  Result: {summary}[/muted]\n")
+                else:
+                    # OpenClaw systemEvent: inject into main session
                     console.print(f"\n  [muted]Scheduler: running job {job_id}[/muted]")
-                    agentic.run(f"[scheduled-job:{job_id}] {fired_action}")
+                    agentic.run(prompt)
         except _queue_mod.Empty:
             pass
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -781,7 +781,7 @@ class TestActionQueue:
     ) -> None:
         import queue
 
-        q: queue.Queue[tuple[str, str]] = queue.Queue()
+        q: queue.Queue[tuple[str, str, bool]] = queue.Queue()
         svc = SchedulerService(store_path=tmp_store, log_dir=tmp_log_dir, action_queue=q)
         job = ScheduledJob(
             job_id="act1",
@@ -793,9 +793,10 @@ class TestActionQueue:
         result = svc.run_now("act1")
         assert result["status"] == "ok"
         assert not q.empty()
-        queued_id, queued_action = q.get_nowait()
+        queued_id, queued_action, queued_isolated = q.get_nowait()
         assert queued_id == "act1"
         assert queued_action == "summarize today's news"
+        assert queued_isolated is True  # default: isolated
 
     def test_callback_takes_precedence_over_action(
         self,
@@ -804,7 +805,7 @@ class TestActionQueue:
     ) -> None:
         import queue
 
-        q: queue.Queue[tuple[str, str]] = queue.Queue()
+        q: queue.Queue[tuple[str, str, bool]] = queue.Queue()
         calls: list[str] = []
         svc = SchedulerService(store_path=tmp_store, log_dir=tmp_log_dir, action_queue=q)
         job = ScheduledJob(
@@ -836,3 +837,25 @@ class TestActionQueue:
         svc.add_job(job)
         result = svc.run_now("noq1")
         assert result["status"] == "ok"
+
+    def test_non_isolated_enqueued(
+        self,
+        tmp_store: Path,
+        tmp_log_dir: Path,
+    ) -> None:
+        """Jobs with isolated=False enqueue with isolated=False flag."""
+        import queue
+
+        q: queue.Queue[tuple[str, str, bool]] = queue.Queue()
+        svc = SchedulerService(store_path=tmp_store, log_dir=tmp_log_dir, action_queue=q)
+        job = ScheduledJob(
+            job_id="main1",
+            name="main_session",
+            schedule=Schedule(kind=ScheduleKind.AT, at_ms=0.0),
+            action="check status",
+            isolated=False,
+        )
+        svc.add_job(job)
+        svc.run_now("main1")
+        _, _, is_isolated = q.get_nowait()
+        assert is_isolated is False


### PR DESCRIPTION
## Why

Scheduled jobs fired into the main REPL conversation pollute the user's context. OpenClaw separates `agentTurn` (isolated session) from `systemEvent` (main session injection). Without isolation, a cron job "summarize news every hour" contaminates the user's current multi-turn conversation.

## What

- **`ScheduledJob.isolated: bool = True`** — default isolated (OpenClaw `agentTurn`)
- **Queue tuple**: `(job_id, action, isolated)` — carries isolation flag
- **REPL drain**: isolated jobs get fresh `ConversationContext` + `_build_agentic_stack(quiet=True)`, result summary printed. Non-isolated jobs inject into main `agentic` as before.
- **Serialization**: `isolated` persisted in `jobs.json`

## Test plan

- [ ] `uv run pytest tests/test_scheduler.py -q` — all pass (1 new test: `test_non_isolated_enqueued`)
- [ ] `uv run ruff check core/ tests/` — 0 errors
- [ ] `uv run mypy core/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)