### PR TITLE
feat: TURN_COMPLETE hook + auto-memory (OpenClaw command:new)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - **Scheduler action queue** — `ScheduledJob.action` 필드 추가. 원문 텍스트를 그대로 저장(정규식 추출 제거). `SchedulerService`가 job 발화 시 `action_queue`에 삽입. REPL이 `[scheduled-job:{id}]` 프레이밍으로 AgenticLoop에 위임 — LLM이 자체 판단으로 스케줄 의도를 분리하여 실행.
 - **Cron 세션 격리** — `ScheduledJob.isolated` 필드 추가 (기본값 `True`). OpenClaw `agentTurn` 패턴: 스케줄 발화 시 fresh ConversationContext + AgenticLoop에서 독립 실행하여 메인 대화 오염 방지. `isolated=False`(systemEvent)로 메인 세션 주입도 가능.
+- **TURN_COMPLETE 자동 메모리** — 37번째 HookEvent. AgenticLoop 매 턴 종료 시 발화, user_input + tool_calls + result 데이터 전달. `turn_auto_memory` 핸들러가 자동으로 project memory에 턴 요약 기록 (OpenClaw `command:new` 패턴).
 - **OpenAI Responses API 전환** — `OpenAIAgenticAdapter`를 Chat Completions → Responses API(`client.responses.create`)로 마이그레이션. 네이티브 `web_search` 호스티드 도구 주입. `normalize_openai_responses()` 정규화기 추가.
 - **3사 네이티브 웹 검색 fallback** — `GeneralWebSearchTool`/`WebSearchTool`을 Anthropic(Opus) → OpenAI(gpt-5.4) → GLM(glm-5) 순차 fallback으로 전환. 외부 API 키 의존 제로.
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -269,6 +269,17 @@ class AgenticLoop:
         )
         self._record_transcript_end(result)
         self._save_checkpoint(user_input, round_idx=round_idx)
+        if self._hooks:
+            self._hooks.trigger(
+                HookEvent.TURN_COMPLETE,
+                {
+                    "user_input": user_input,
+                    "text": result.text[:500] if result.text else "",
+                    "rounds": result.rounds,
+                    "tool_calls": [tc.get("name", "") for tc in result.tool_calls],
+                    "termination_reason": result.termination_reason,
+                },
+            )
         return result
 
     def refresh_tools(self) -> int:

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -77,6 +77,9 @@ class HookEvent(Enum):
     MCP_SERVER_STARTED = "mcp_server_started"
     MCP_SERVER_STOPPED = "mcp_server_stopped"
 
+    # Agentic turn lifecycle (OpenClaw command:new pattern)
+    TURN_COMPLETE = "turn_complete"
+
     # Context overflow detection (Karpathy P6 Context Budget)
     CONTEXT_WARNING = "context_warning"
     CONTEXT_CRITICAL = "context_critical"

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -176,6 +176,33 @@ def build_hooks(
 
     _register_plugin("journal_hook", _reg_journal)
 
+    # C3: Auto-memory on turn complete (OpenClaw command:new pattern)
+    def _reg_turn_memory() -> None:
+        from core.tools import memory_tools
+
+        def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
+            pm = memory_tools._project_memory
+            if pm is None:
+                return
+            text = data.get("text", "")
+            user_input = data.get("user_input", "")
+            tools = data.get("tool_calls", [])
+            if not text or len(text) < 20:
+                return  # too short to be useful
+            # Build concise insight from turn
+            tool_str = ", ".join(tools[:5]) if tools else "none"
+            insight = f"[turn] {user_input[:80]} → tools=[{tool_str}]"
+            pm.add_insight(insight)
+
+        hooks.register(
+            HookEvent.TURN_COMPLETE,
+            _on_turn_complete,
+            name="turn_auto_memory",
+            priority=85,
+        )
+
+    _register_plugin("turn_memory_hook", _reg_turn_memory)
+
     return hooks, run_log, stuck_detector
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -299,7 +299,7 @@ class TestApplyContext:
 class TestHookEventCount:
     def test_events_exist(self) -> None:
         """HookEvent has 36 events (27 base + 3 TOOL_RECOVERY_* + 2 GATEWAY_* + 2 MCP_SERVER_* + 2 CONTEXT_*)."""
-        assert len(HookEvent) == 36
+        assert len(HookEvent) == 37
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -411,7 +411,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count is 36 (27 + 3 recovery + 2 gateway + 2 mcp + 2 context)."""
-        assert len(HookEvent) == 36
+        assert len(HookEvent) == 37
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from core.hooks import HookEvent, HookResult, HookSystem
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 36
+        assert len(HookEvent) == 37
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,8 +356,8 @@ class TestHookEventTypes:
         assert HookEvent.PROMPT_DRIFT_DETECTED.value == "prompt_drift_detected"
 
     def test_hook_event_count(self):
-        """Total hook events should be 36 (27 + 3 TOOL_RECOVERY_* + 2 GATEWAY_* + 2 MCP_SERVER_* + 2 CONTEXT_*)."""
-        assert len(HookEvent) == 36
+        """Total hook events should be 37 (+1 TURN_COMPLETE)."""
+        assert len(HookEvent) == 37
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -37,8 +37,8 @@ class TestMCPHookEvents:
         assert HookEvent.MCP_SERVER_STOPPED.value == "mcp_server_stopped"
 
     def test_hook_event_count_includes_mcp(self) -> None:
-        """Total hook events should be 36 (includes 2 MCP_SERVER_* + 2 CONTEXT_* events)."""
-        assert len(HookEvent) == 36
+        """Total hook events should be 37 (includes TURN_COMPLETE + 2 MCP_SERVER_* + 2 CONTEXT_*)."""
+        assert len(HookEvent) == 37
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

REPL 경로에서 Hook은 관측만 하고 행동을 바꾸지 않았다. OpenClaw의 `command:new` 패턴처럼 매 턴 종료 시 자동으로 메모리에 기록하면, 사용자가 `/memory save`를 호출하지 않아도 대화의 key insight가 축적된다.

## What

- **`HookEvent.TURN_COMPLETE`** — 37번째 이벤트. `_finalize_and_return()`에서 발화
- **데이터**: `user_input`, `text` (응답 500자), `rounds`, `tool_calls`, `termination_reason`
- **`turn_auto_memory` 핸들러** (priority 85) — project memory에 `[turn] input → tools=[...]` 형식으로 자동 기록
- 응답 20자 미만은 skip (noise 방지)

REPL에서 행동을 변경하는 **첫 번째 Hook 핸들러**.

## Test plan

- [ ] `uv run pytest tests/ -m "not live" -q` — 3229 passed
- [ ] `uv run ruff check core/ tests/` — 0 errors
- [ ] `uv run mypy core/` — 0 errors
- [ ] HookEvent count assertions 36 → 37 (5 test files updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)