### PR TITLE
feat: SESSION_START/END hooks for session lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **SESSION_START / SESSION_END hooks** — 39번째/40번째(sic, enum 39개) HookEvent. REPL 세션 시작/종료 시 발화하여 동적 컨텍스트 주입 기반 마련 (OpenClaw `agent:bootstrap` 패턴). `session_lifecycle_hook` 플러그인이 model/resumed 정보를 로그에 기록.
 - **Scheduler action queue** — `ScheduledJob.action` 필드 추가. 원문 텍스트를 그대로 저장(정규식 추출 제거). `SchedulerService`가 job 발화 시 `action_queue`에 삽입. REPL이 `[scheduled-job:{id}]` 프레이밍으로 AgenticLoop에 위임 — LLM이 자체 판단으로 스케줄 의도를 분리하여 실행.
 - **Cron 세션 격리** — `ScheduledJob.isolated` 필드 추가 (기본값 `True`). OpenClaw `agentTurn` 패턴: 스케줄 발화 시 fresh ConversationContext + AgenticLoop에서 독립 실행하여 메인 대화 오염 방지. `isolated=False`(systemEvent)로 메인 세션 주입도 가능.
 - **TURN_COMPLETE 자동 메모리** — 37번째 HookEvent. AgenticLoop 매 턴 종료 시 발화, user_input + tool_calls + result 데이터 전달. `turn_auto_memory` 핸들러가 자동으로 project memory에 턴 요약 기록 (OpenClaw `command:new` 패턴).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Decision Tree on D-E-F axes:
 - **Verbose gating**: Debug prints only with `--verbose` flag
 - **Node contract**: Each node returns `dict` with only its output keys
 - **Reducer fields**: `analyses` and `errors` use `Annotated[list, operator.add]`
-- **Hook-driven**: `core.hooks` — 36 lifecycle events (incl. `SUBAGENT_*`, `TOOL_RECOVERY_*`, `CONTEXT_*`) for extensibility. Cross-cutting; accessible from all layers via `from core.hooks import HookSystem, HookEvent`.
+- **Hook-driven**: `core.hooks` — 39 lifecycle events (incl. `SUBAGENT_*`, `TOOL_RECOVERY_*`, `CONTEXT_*`, `SESSION_*`) for extensibility. Cross-cutting; accessible from all layers via `from core.hooks import HookSystem, HookEvent`.
 - **Domain Plugin**: `DomainPort` Protocol — 도메인별 pipeline 교체 가능 (`set_domain()` / `get_domain()`). 도메인 외 인프라는 직접 import (ContextVar DI 최소화).
 
 ## Implementation Workflow

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -937,6 +937,16 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
     init_session_meter(model=agentic.model)
 
+    # Fire SESSION_START for dynamic context injection (OpenClaw agent:bootstrap)
+    _fire_hook(
+        HookEvent.SESSION_START,
+        {
+            "model": agentic.model,
+            "session_id": getattr(agentic, "_session_id", ""),
+            "resumed": resume_session_id is not None,
+        },
+    )
+
     # Auto-resume: --continue (latest) or --resume <id>
     if resume_session_id is not None:
         from core.cli.session_checkpoint import SessionCheckpoint
@@ -999,6 +1009,13 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         except (KeyboardInterrupt, EOFError):
             from core.cli.ui.agentic_ui import render_session_cost_summary
 
+            _fire_hook(
+                HookEvent.SESSION_END,
+                {
+                    "model": agentic.model,
+                    "session_id": getattr(agentic, "_session_id", ""),
+                },
+            )
             agentic.mark_session_completed()
             render_session_cost_summary()
             console.print("\n  [muted]Goodbye.[/muted]\n")
@@ -1011,6 +1028,13 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         if user_input.strip().lower() in ("exit", "quit", "q"):
             from core.cli.ui.agentic_ui import render_session_cost_summary
 
+            _fire_hook(
+                HookEvent.SESSION_END,
+                {
+                    "model": agentic.model,
+                    "session_id": getattr(agentic, "_session_id", ""),
+                },
+            )
             agentic.mark_session_completed()
             render_session_cost_summary()
             console.print("  [muted]Goodbye.[/muted]\n")

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class HookEvent(Enum):
-    """Pipeline lifecycle events (36 events)."""
+    """Pipeline lifecycle events (39 events)."""
 
     # Pipeline level
     PIPELINE_START = "pipeline_start"
@@ -83,6 +83,10 @@ class HookEvent(Enum):
     # Context overflow detection (Karpathy P6 Context Budget)
     CONTEXT_WARNING = "context_warning"
     CONTEXT_CRITICAL = "context_critical"
+
+    # Session lifecycle (OpenClaw agent:bootstrap pattern)
+    SESSION_START = "session_start"
+    SESSION_END = "session_end"
 
 
 @dataclass

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -203,6 +203,33 @@ def build_hooks(
 
     _register_plugin("turn_memory_hook", _reg_turn_memory)
 
+    # C4: Session lifecycle hooks (OpenClaw agent:bootstrap pattern)
+    def _reg_session_lifecycle() -> None:
+        def _on_session_start(event: HookEvent, data: dict[str, Any]) -> None:
+            log.info(
+                "Session started: model=%s resumed=%s",
+                data.get("model"),
+                data.get("resumed"),
+            )
+
+        def _on_session_end(event: HookEvent, data: dict[str, Any]) -> None:
+            log.info("Session ended: model=%s", data.get("model"))
+
+        hooks.register(
+            HookEvent.SESSION_START,
+            _on_session_start,
+            name="session_start_logger",
+            priority=90,
+        )
+        hooks.register(
+            HookEvent.SESSION_END,
+            _on_session_end,
+            name="session_end_logger",
+            priority=90,
+        )
+
+    _register_plugin("session_lifecycle_hook", _reg_session_lifecycle)
+
     return hooks, run_log, stuck_detector
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -298,8 +298,8 @@ class TestApplyContext:
 
 class TestHookEventCount:
     def test_events_exist(self) -> None:
-        """HookEvent has 36 events (27 base + 3 TOOL_RECOVERY_* + 2 GATEWAY_* + 2 MCP_SERVER_* + 2 CONTEXT_*)."""
-        assert len(HookEvent) == 37
+        """HookEvent has 39 events (27 base + 3 TOOL_RECOVERY_* + 2 GATEWAY_* + 2 MCP_SERVER_* + 2 CONTEXT_* + 1 TURN + 2 SESSION)."""
+        assert len(HookEvent) == 39
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -410,8 +410,8 @@ class TestRecoveryHookEvents:
         assert received[0]["tool_name"] == "list_ips"
 
     def test_total_hook_event_count(self) -> None:
-        """Verify total hook event count is 36 (27 + 3 recovery + 2 gateway + 2 mcp + 2 context)."""
-        assert len(HookEvent) == 37
+        """Verify total hook event count is 39 (27 + 3 recovery + 2 gateway + 2 mcp + 2 context + 1 turn + 2 session)."""
+        assert len(HookEvent) == 39
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from core.hooks import HookEvent, HookResult, HookSystem
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 37
+        assert len(HookEvent) == 39
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,8 +356,8 @@ class TestHookEventTypes:
         assert HookEvent.PROMPT_DRIFT_DETECTED.value == "prompt_drift_detected"
 
     def test_hook_event_count(self):
-        """Total hook events should be 37 (+1 TURN_COMPLETE)."""
-        assert len(HookEvent) == 37
+        """Total hook events should be 39 (+1 TURN_COMPLETE + 2 SESSION_*)."""
+        assert len(HookEvent) == 39
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -37,8 +37,8 @@ class TestMCPHookEvents:
         assert HookEvent.MCP_SERVER_STOPPED.value == "mcp_server_stopped"
 
     def test_hook_event_count_includes_mcp(self) -> None:
-        """Total hook events should be 37 (includes TURN_COMPLETE + 2 MCP_SERVER_* + 2 CONTEXT_*)."""
-        assert len(HookEvent) == 37
+        """Total hook events should be 39 (includes TURN_COMPLETE + 2 MCP_SERVER_* + 2 CONTEXT_* + 2 SESSION_*)."""
+        assert len(HookEvent) == 39
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `HookEvent.SESSION_START` and `HookEvent.SESSION_END` (39 total events) for REPL session lifecycle tracking
- Fire `SESSION_START` once after bootstrap (before `while True` loop), `SESSION_END` on exit/quit/Ctrl+C
- Register `session_lifecycle_hook` plugin in `bootstrap.py` that logs model and resumed status
- Foundation for future dynamic prompt injection at session start (OpenClaw `agent:bootstrap` pattern)

## Why
OpenClaw's `agent:bootstrap` pattern dynamically injects context at session start. This PR establishes the event lifecycle so future handlers can modify the system prompt based on time-of-day, previous session state, or user preferences.

## Changed files
- `core/hooks/system.py` — 2 new events (SESSION_START, SESSION_END)
- `core/cli/__init__.py` — fire events in `_interactive_loop()`
- `core/runtime_wiring/bootstrap.py` — session_lifecycle_hook plugin
- `CHANGELOG.md` / `CLAUDE.md` — docs sync (hook count 37 → 39)
- 5 test files — updated HookEvent count assertions (37 → 39)

## Test plan
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors (182 files)
- [x] `uv run pytest tests/ -m "not live" -q` — 3229 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)