### PR TITLE
develop → main: ApprovalTracker + tool_executor 트리거 보충

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - **TOOL_APPROVAL hooks** --- `TOOL_APPROVAL_REQUESTED`, `TOOL_APPROVAL_GRANTED`, `TOOL_APPROVAL_DENIED` 3종 HookEvent 추가 (42 -> 45). HITL 승인/거부/Always 패턴 추적. `ToolExecutor`에 hooks 주입, `bootstrap.py`에 `approval_tracker`/`denial_logger` 핸들러 등록.
+
+### Fixed
+- **TOOL_APPROVAL 이벤트명 불일치 수정** — `tool_approval_decided` → `tool_approval_granted`/`tool_approval_denied` 분리. 이전 코드에서 `_emit_hook("tool_approval_decided")`가 HookEvent에 없어 ValueError 삼킴 → 실제 발화 안 되는 버그 해소.
 - **LLM_CALL_START / LLM_CALL_END hooks** — LLM 호출 전후 발화로 model-level latency/cost observability 제공. `call_llm()`, `call_llm_with_tools()` 계측. 10초 초과 시 slow call 경고 로깅. Hook 42개.
 - **SESSION_START / SESSION_END hooks** — REPL 세션 시작/종료 시 발화 (OpenClaw `agent:bootstrap` 패턴).
 - **CONTEXT_OVERFLOW_ACTION hook** — 압축 전략을 Hook 핸들러가 결정. `trigger_with_result()`로 핸들러 반환값 피드백. `context_action.py` 기본 핸들러 제공.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 184
-- **Tests**: 3249+
+- **Tests**: 3255+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -182,7 +182,7 @@ class ToolExecutor:
                 )
                 if not self._confirm_write(tool_name, tool_input):
                     self._fire_hook(
-                        "tool_approval_decided",
+                        "tool_approval_denied",
                         {
                             "tool_name": tool_name,
                             "safety_level": "write",
@@ -193,7 +193,7 @@ class ToolExecutor:
                     )
                     return _write_denial_with_fallback(tool_name), False
                 self._fire_hook(
-                    "tool_approval_decided",
+                    "tool_approval_granted",
                     {
                         "tool_name": tool_name,
                         "safety_level": "write",
@@ -214,7 +214,7 @@ class ToolExecutor:
                 )
                 if not self._confirm_cost(tool_name, cost):
                     self._fire_hook(
-                        "tool_approval_decided",
+                        "tool_approval_denied",
                         {
                             "tool_name": tool_name,
                             "safety_level": "cost",
@@ -225,7 +225,7 @@ class ToolExecutor:
                     )
                     return {"error": "User denied expensive operation", "denied": True}, False
                 self._fire_hook(
-                    "tool_approval_decided",
+                    "tool_approval_granted",
                     {
                         "tool_name": tool_name,
                         "safety_level": "cost",
@@ -461,7 +461,7 @@ class ToolExecutor:
         if response == "a":
             self._always_approved_categories.add(f"mcp:{server}")
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": tool_name,
                     "permission_level": "MCP",
@@ -472,7 +472,7 @@ class ToolExecutor:
             return True
         if response == "y":
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": tool_name,
                     "permission_level": "MCP",
@@ -482,7 +482,7 @@ class ToolExecutor:
             )
             return True
         self._fire_hook(
-            "tool_approval_decided",
+            "tool_approval_denied",
             {
                 "tool_name": tool_name,
                 "permission_level": "MCP",
@@ -536,7 +536,7 @@ class ToolExecutor:
         if response == "a":
             self._always_approved_categories.add("write")
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": tool_name,
                     "permission_level": "WRITE",
@@ -547,7 +547,7 @@ class ToolExecutor:
             return True
         if response == "y":
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": tool_name,
                     "permission_level": "WRITE",
@@ -557,7 +557,7 @@ class ToolExecutor:
             )
             return True
         self._fire_hook(
-            "tool_approval_decided",
+            "tool_approval_denied",
             {
                 "tool_name": tool_name,
                 "permission_level": "WRITE",
@@ -599,7 +599,7 @@ class ToolExecutor:
         if response == "a":
             self._always_approved_categories.add("cost")
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": tool_name,
                     "permission_level": "EXPENSIVE",
@@ -610,7 +610,7 @@ class ToolExecutor:
             return True
         if response == "y":
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": tool_name,
                     "permission_level": "EXPENSIVE",
@@ -620,7 +620,7 @@ class ToolExecutor:
             )
             return True
         self._fire_hook(
-            "tool_approval_decided",
+            "tool_approval_denied",
             {
                 "tool_name": tool_name,
                 "permission_level": "EXPENSIVE",
@@ -657,7 +657,7 @@ class ToolExecutor:
         if response == "a":
             self._always_approved_categories.add("bash")
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": "run_bash",
                     "permission_level": "DANGEROUS",
@@ -668,7 +668,7 @@ class ToolExecutor:
             return True
         if response == "y":
             self._fire_hook(
-                "tool_approval_decided",
+                "tool_approval_granted",
                 {
                     "tool_name": "run_bash",
                     "permission_level": "DANGEROUS",
@@ -678,7 +678,7 @@ class ToolExecutor:
             )
             return True
         self._fire_hook(
-            "tool_approval_decided",
+            "tool_approval_denied",
             {
                 "tool_name": "run_bash",
                 "permission_level": "DANGEROUS",

--- a/core/hooks/approval_tracker.py
+++ b/core/hooks/approval_tracker.py
@@ -1,0 +1,99 @@
+"""Tool approval history tracker — JSONL-based HITL pattern learning.
+
+Records approval/denial decisions and suggests auto-approve candidates
+based on consecutive approval streaks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from core.hooks.system import HookEvent
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_HISTORY_PATH: Path | None = None
+
+
+def _get_history_path() -> Path:
+    global _DEFAULT_HISTORY_PATH
+    if _DEFAULT_HISTORY_PATH is None:
+        from core.paths import GEODE_HOME
+
+        _DEFAULT_HISTORY_PATH = GEODE_HOME / "approval_history.jsonl"
+    return _DEFAULT_HISTORY_PATH
+
+
+class ApprovalTracker:
+    """Tracks HITL tool approval decisions to ~/.geode/approval_history.jsonl."""
+
+    CONSECUTIVE_THRESHOLD = 5
+    LOOKBACK_DAYS = 30
+
+    def __init__(self, history_path: Path | None = None) -> None:
+        self._path = history_path or _get_history_path()
+
+    def record(self, data: dict[str, Any]) -> None:
+        """Append a decision record to the JSONL file."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": time.time(),
+            "tool_name": data.get("tool_name", ""),
+            "permission_level": data.get("permission_level", ""),
+            "decision": data.get("decision", ""),
+            "latency_ms": data.get("latency_ms", 0),
+            "session_key": data.get("session_key", ""),
+        }
+        try:
+            with open(self._path, "a") as f:
+                f.write(json.dumps(record) + "\n")
+        except OSError:
+            log.debug("Failed to write approval record", exc_info=True)
+
+    def suggest_auto_approve(self, tool_name: str) -> bool:
+        """Return True if tool has N+ consecutive approvals with no denials in lookback."""
+        if not self._path.exists():
+            return False
+
+        cutoff = time.time() - self.LOOKBACK_DAYS * 86400
+        consecutive = 0
+
+        try:
+            with open(self._path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if rec.get("tool_name") != tool_name:
+                        continue
+                    if rec.get("ts", 0) < cutoff:
+                        continue
+                    if rec.get("decision") == "approved":
+                        consecutive += 1
+                    else:
+                        consecutive = 0
+        except OSError:
+            return False
+
+        return consecutive >= self.CONSECUTIVE_THRESHOLD
+
+    def make_hook_handler(
+        self, session_key: str = ""
+    ) -> tuple[str, Any]:
+        """Return (handler_name, handler_fn) for HookSystem registration."""
+
+        def _on_approval(event: HookEvent, data: dict[str, Any]) -> None:
+            data.setdefault("session_key", session_key)
+            decision = "approved" if event == HookEvent.TOOL_APPROVAL_GRANTED else "denied"
+            data.setdefault("decision", decision)
+            self.record(data)
+
+        return "approval_tracker", _on_approval

--- a/core/hooks/approval_tracker.py
+++ b/core/hooks/approval_tracker.py
@@ -85,9 +85,7 @@ class ApprovalTracker:
 
         return consecutive >= self.CONSECUTIVE_THRESHOLD
 
-    def make_hook_handler(
-        self, session_key: str = ""
-    ) -> tuple[str, Any]:
+    def make_hook_handler(self, session_key: str = "") -> tuple[str, Any]:
         """Return (handler_name, handler_fn) for HookSystem registration."""
 
         def _on_approval(event: HookEvent, data: dict[str, Any]) -> None:

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -299,34 +299,23 @@ def build_hooks(
 
     _register_plugin("llm_lifecycle_hook", _reg_llm_lifecycle)
 
-    # C6: Tool approval tracking hooks (HITL pattern learning)
+    # C6: Tool approval tracking hooks (HITL pattern learning → JSONL)
     def _reg_tool_approval() -> None:
-        _approval_log: list[dict[str, Any]] = []
+        from core.hooks.approval_tracker import ApprovalTracker
 
-        def _on_granted(event: HookEvent, data: dict[str, Any]) -> None:
-            _approval_log.append(
-                {
-                    "tool": data.get("tool_name"),
-                    "always": data.get("always", False),
-                }
-            )
-            if len(_approval_log) > 100:
-                _approval_log.pop(0)  # ring buffer
-
-        def _on_denied(event: HookEvent, data: dict[str, Any]) -> None:
-            log.info("Tool denied: %s", data.get("tool_name"))
-
+        tracker = ApprovalTracker()
+        handler_name, handler_fn = tracker.make_hook_handler(session_key=session_key)
         hooks.register(
             HookEvent.TOOL_APPROVAL_GRANTED,
-            _on_granted,
-            name="approval_tracker",
-            priority=85,
+            handler_fn,
+            name=handler_name,
+            priority=65,
         )
         hooks.register(
             HookEvent.TOOL_APPROVAL_DENIED,
-            _on_denied,
-            name="denial_logger",
-            priority=85,
+            handler_fn,
+            name=f"{handler_name}_denied",
+            priority=65,
         )
 
     _register_plugin("tool_approval_hook", _reg_tool_approval)

--- a/tests/test_approval_tracker.py
+++ b/tests/test_approval_tracker.py
@@ -1,0 +1,91 @@
+"""Tests for core.hooks.approval_tracker."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from core.hooks.approval_tracker import ApprovalTracker
+from core.hooks.system import HookEvent
+
+
+@pytest.fixture()
+def tracker(tmp_path):
+    return ApprovalTracker(history_path=tmp_path / "history.jsonl")
+
+
+class TestRecord:
+    def test_creates_file(self, tracker):
+        tracker.record({"tool_name": "run_bash", "decision": "approved"})
+        assert tracker._path.exists()
+
+    def test_appends_jsonl(self, tracker):
+        tracker.record({"tool_name": "a", "decision": "approved"})
+        tracker.record({"tool_name": "b", "decision": "denied"})
+        lines = tracker._path.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["tool_name"] == "a"
+        assert json.loads(lines[1])["tool_name"] == "b"
+
+    def test_record_has_timestamp(self, tracker):
+        tracker.record({"tool_name": "x", "decision": "approved"})
+        rec = json.loads(tracker._path.read_text().strip())
+        assert "ts" in rec
+        assert rec["ts"] > 0
+
+
+class TestSuggestAutoApprove:
+    def test_no_history_returns_false(self, tracker):
+        assert tracker.suggest_auto_approve("run_bash") is False
+
+    def test_below_threshold(self, tracker):
+        for _ in range(4):
+            tracker.record({"tool_name": "run_bash", "decision": "approved"})
+        assert tracker.suggest_auto_approve("run_bash") is False
+
+    def test_at_threshold(self, tracker):
+        for _ in range(5):
+            tracker.record({"tool_name": "run_bash", "decision": "approved"})
+        assert tracker.suggest_auto_approve("run_bash") is True
+
+    def test_denial_resets(self, tracker):
+        for _ in range(4):
+            tracker.record({"tool_name": "run_bash", "decision": "approved"})
+        tracker.record({"tool_name": "run_bash", "decision": "denied"})
+        for _ in range(3):
+            tracker.record({"tool_name": "run_bash", "decision": "approved"})
+        assert tracker.suggest_auto_approve("run_bash") is False
+
+    def test_tool_isolation(self, tracker):
+        for _ in range(5):
+            tracker.record({"tool_name": "other_tool", "decision": "approved"})
+        assert tracker.suggest_auto_approve("run_bash") is False
+
+    def test_old_records_ignored(self, tracker):
+        old_ts = time.time() - 40 * 86400
+        for _ in range(5):
+            tracker._path.parent.mkdir(parents=True, exist_ok=True)
+            rec = json.dumps({"ts": old_ts, "tool_name": "run_bash", "decision": "approved"})
+            with open(tracker._path, "a") as f:
+                f.write(rec + "\n")
+        assert tracker.suggest_auto_approve("run_bash") is False
+
+
+class TestMakeHookHandler:
+    def test_returns_handler(self, tracker):
+        name, fn = tracker.make_hook_handler(session_key="test")
+        assert name == "approval_tracker"
+        assert callable(fn)
+
+    def test_handler_records_granted(self, tracker):
+        _, fn = tracker.make_hook_handler()
+        fn(HookEvent.TOOL_APPROVAL_GRANTED, {"tool_name": "run_bash"})
+        rec = json.loads(tracker._path.read_text().strip())
+        assert rec["decision"] == "approved"
+
+    def test_handler_records_denied(self, tracker):
+        _, fn = tracker.make_hook_handler()
+        fn(HookEvent.TOOL_APPROVAL_DENIED, {"tool_name": "run_bash"})
+        rec = json.loads(tracker._path.read_text().strip())
+        assert rec["decision"] == "denied"


### PR DESCRIPTION
## Summary
- #498: ApprovalTracker JSONL + tool_executor GRANTED/DENIED 발화 + 12 tests
- #494 누락분 보충 완료
- 3255 tests pass

## Test plan
- [x] CI 5/5 pass
- [x] 3255 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)