### PR TITLE
feat: P3 hook batch — MODEL_SWITCHED + filesystem plugin + docs-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **MODEL_SWITCHED hook** --- `HookEvent.MODEL_SWITCHED` 추가 (45 -> 46). `AgenticLoop.update_model()` 발화, `bootstrap.py`에 `model_switch_logger` 핸들러 등록.
+- **Filesystem hook plugin auto-discovery** --- `bootstrap.py`에서 `.geode/hooks/` + `core/hooks/plugins/` 자동 스캔 및 등록. `HookPluginLoader`를 부트스트랩에 통합.
+- **README docs-sync** --- 도구(52), Hook(46) 수치를 실측값으로 갱신.
 - **TOOL_APPROVAL hooks** --- `TOOL_APPROVAL_REQUESTED`, `TOOL_APPROVAL_GRANTED`, `TOOL_APPROVAL_DENIED` 3종 HookEvent 추가 (42 -> 45). HITL 승인/거부/Always 패턴 추적. `ToolExecutor`에 hooks 주입, `bootstrap.py`에 `approval_tracker`/`denial_logger` 핸들러 등록.
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Decision Tree on D-E-F axes:
 - **Verbose gating**: Debug prints only with `--verbose` flag
 - **Node contract**: Each node returns `dict` with only its output keys
 - **Reducer fields**: `analyses` and `errors` use `Annotated[list, operator.add]`
-- **Hook-driven**: `core.hooks` — 45 lifecycle events (incl. `SUBAGENT_*`, `TOOL_RECOVERY_*`, `CONTEXT_*`, `SESSION_*`, `TURN_COMPLETE`, `LLM_CALL_*`, `TOOL_APPROVAL_*`) for extensibility. Cross-cutting; accessible from all layers via `from core.hooks import HookSystem, HookEvent`.
+- **Hook-driven**: `core.hooks` — 46 lifecycle events (incl. `SUBAGENT_*`, `TOOL_RECOVERY_*`, `CONTEXT_*`, `SESSION_*`, `TURN_COMPLETE`, `LLM_CALL_*`, `TOOL_APPROVAL_*`, `MODEL_SWITCHED`) for extensibility. Cross-cutting; accessible from all layers via `from core.hooks import HookSystem, HookEvent`.
 - **Domain Plugin**: `DomainPort` Protocol — 도메인별 pipeline 교체 가능 (`set_domain()` / `get_domain()`). 도메인 외 인프라는 직접 import (ContextVar DI 최소화).
 
 ## Implementation Workflow

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/while(tool__use)-agentic%20loop-1e293b?style=flat-square" alt="while(tool_use)">
   <img src="https://img.shields.io/badge/Opus%204.6-1M%20context-1e293b?style=flat-square" alt="Opus 4.6">
-  <img src="https://img.shields.io/badge/47%20tools-MCP%20native-1e293b?style=flat-square" alt="47 Tools">
+  <img src="https://img.shields.io/badge/52%20tools-MCP%20native-1e293b?style=flat-square" alt="52 Tools">
   <img src="https://img.shields.io/badge/LangGraph-StateGraph-1e293b?style=flat-square" alt="LangGraph">
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
@@ -15,7 +15,7 @@
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 
 **생산**: Claude Code Scaffold(CLAUDE.md + 개발 Skills + CI Hooks)가 GEODE를 만듭니다.
-**실행**: GEODE(`while(tool_use)` 루프)가 47 도구 + 44 MCP 중에서 자율 선택하고, 36개 런타임 Hook이 라이프사이클을 제어하고, 5-Layer Verification이 출력을 검증합니다.
+**실행**: GEODE(`while(tool_use)` 루프)가 52 도구 + 44 MCP 중에서 자율 선택하고, 46개 런타임 Hook이 라이프사이클을 제어하고, 5-Layer Verification이 출력을 검증합니다.
 
 ## Quick Start
 
@@ -76,7 +76,7 @@ cd geode && uv sync
 | 기능 | 설명 |
 |------|------|
 | **`while(tool_use)` Loop** | 모든 자율 행동의 핵심 프리미티브. 서브에이전트, 계획 실행, 배치 분석 전부 AgenticLoop 인스턴스 |
-| **47 Tools + MCP** | 네이티브 47개 도구 + MCP 카탈로그 44종 자동 설치. Bash 실행 (41종 자동승인, 9종 차단) |
+| **52 Tools + MCP** | 네이티브 52개 도구 + MCP 카탈로그 44종 자동 설치. Bash 실행 (41종 자동승인, 9종 차단) |
 | **Sub-Agent** | 부모 역량 전체 상속, 최대 5 병렬, Token Guard, DAG 의존성 |
 | **Multi-Provider LLM** | Anthropic + OpenAI + ZhipuAI 3-provider failover chain |
 | **4-Tier Memory** | SOUL → User Profile → Organization → Project → Session |
@@ -84,7 +84,7 @@ cd geode && uv sync
 | **Domain Plugin** | `DomainPort` Protocol로 파이프라인 교체 — Game IP 분석 기본 탑재 |
 | **Scaffold (생산)** | Claude Code + CLAUDE.md(428줄) + 개발 Skills + CI Hooks — GEODE를 만드는 제어 구조 |
 | **20 Runtime Skills** | `.geode/skills/` — 도메인별 지식을 프롬프트로 주입. 파이프라인, 스코어링, 검증, 아키텍처 패턴 등 |
-| **36 Runtime Hooks** | 파이프라인/노드/검증/메모리/서브에이전트 라이프사이클 이벤트 — GEODE 런타임 제어 |
+| **46 Runtime Hooks** | 파이프라인/노드/검증/메모리/서브에이전트 라이프사이클 이벤트 — GEODE 런타임 제어 |
 | **5-Layer Verification** | Guardrails G1-G4 + BiasBuster + Cross-LLM(Krippendorff α ≥ 0.67) + Confidence Gate + Rights Risk |
 | **Safety** | 4-tier HITL(SAFE/STANDARD/WRITE/DANGEROUS), 9종 bash 차단, PolicyChain 6-layer |
 
@@ -96,7 +96,7 @@ cd geode && uv sync
 
 **Scaffold (생산 체계)**: Claude Code + CLAUDE.md + 개발 Skills + CI Hooks. GEODE의 코드를 생산하고 품질을 보장하는 외부 하네스.
 
-**GEODE Runtime (에이전트)**: `while(tool_use)` 루프 + 47 도구 + 20 런타임 Skills + 36 런타임 Hooks + 5-Layer Verification. 자율 실행하는 에이전트의 내부 시스템.
+**GEODE Runtime (에이전트)**: `while(tool_use)` 루프 + 52 도구 + 20 런타임 Skills + 46 런타임 Hooks + 5-Layer Verification. 자율 실행하는 에이전트의 내부 시스템.
 
 ### Project Structure
 
@@ -107,7 +107,7 @@ geode/
 │   ├── cli/                       # L0: REPL, Commands, UI
 │   ├── llm/                       # L1: Claude/OpenAI/GLM Adapters, Router, Prompts
 │   ├── memory/                    # L2: 4-Tier Memory, Context Assembly, User Profile
-│   ├── hooks/                     # HookSystem(36) — cross-cutting lifecycle events
+│   ├── hooks/                     # HookSystem(46) — cross-cutting lifecycle events
 │   ├── orchestration/             # L3: TaskGraph, PlanMode, LaneQueue, CoalescingQueue
 │   ├── tools/                     # L4: 54 Tool Definitions + Handlers
 │   ├── skills/                    # L4: Skill Templates
@@ -153,8 +153,8 @@ graph LR
 graph LR
     L0["L0 CLI & Agent<br/>AgenticLoop, SubAgent"] --> L1["L1 Infra<br/>Port/Adapter DI"]
     L0 --> L3["L3 Orchestration<br/>TaskGraph, LaneQueue"]
-    L0 --> HK["Hooks (cross-cutting)<br/>36 events"]
-    L0 --> L4["L4 Extensibility<br/>Tools(47), MCP(44)"]
+    L0 --> HK["Hooks (cross-cutting)<br/>46 events"]
+    L0 --> L4["L4 Extensibility<br/>Tools(52), MCP(44)"]
     L4 --> L5["L5 Domain<br/>DomainPort Plugin"]
     L0 --> L2["L2 Memory<br/>4-Tier + Checkpoint"]
 
@@ -235,7 +235,7 @@ main-only 수정. 3-Checkpoint 필수. TaskCreate ↔ 칸반 task_id 1:1 매핑.
 
 주요 구성:
 - **Agentic Loop**: Claude Opus 4.6 기반 `while(tool_use)` 루프. max 50 rounds, 1M context.
-- **Tool Hierarchy**: Built-in(47) + MCP(44) + Bash. 4-tier safety (SAFE/STANDARD/WRITE/DANGEROUS).
+- **Tool Hierarchy**: Built-in(52) + MCP(44) + Bash. 4-tier safety (SAFE/STANDARD/WRITE/DANGEROUS).
 - **Sub-Agent**: 부모 역량 전체 상속, MAX_CONCURRENT=5, Token Guard.
 - **Memory**: SOUL → User Profile → Organization → Project → Session. ContextAssembler 280자 압축.
 - **Domain Plugin**: `DomainPort` Protocol로 파이프라인 교체. Game IP 기본 탑재 (LangGraph 9-node).

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -304,6 +304,7 @@ class AgenticLoop:
         same provider, the adapter is reused (it owns its own client).
         Also syncs the SessionMeter so status lines show the correct model.
         """
+        old_model = self.model
         new_provider = provider or _resolve_provider(model)
         if new_provider != self._provider:
             self._provider = new_provider
@@ -316,6 +317,19 @@ class AgenticLoop:
 
         update_session_model(model)
         log.info("AgenticLoop model updated: %s (provider=%s)", model, self._provider)
+
+        # Fire MODEL_SWITCHED hook for observability
+        if self._hooks and old_model != model:
+            from core.hooks import HookEvent
+
+            self._hooks.trigger(
+                HookEvent.MODEL_SWITCHED,
+                {
+                    "from_model": old_model,
+                    "to_model": model,
+                    "reason": "user_switch",
+                },
+            )
 
         # Proactively adapt context for the new model's context window
         self._adapt_context_for_model(model)

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class HookEvent(Enum):
-    """Pipeline lifecycle events (45 events)."""
+    """Pipeline lifecycle events (46 events)."""
 
     # Pipeline level
     PIPELINE_START = "pipeline_start"
@@ -97,6 +97,9 @@ class HookEvent(Enum):
     TOOL_APPROVAL_REQUESTED = "tool_approval_requested"
     TOOL_APPROVAL_GRANTED = "tool_approval_granted"
     TOOL_APPROVAL_DENIED = "tool_approval_denied"
+
+    # Model switching (agentic loop model change observability)
+    MODEL_SWITCHED = "model_switched"
 
 
 @dataclass

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -320,6 +320,25 @@ def build_hooks(
 
     _register_plugin("tool_approval_hook", _reg_tool_approval)
 
+    # C7: Model switch observability hook (MODEL_SWITCHED -> log)
+    hooks.register(
+        HookEvent.MODEL_SWITCHED,
+        lambda e, d: log.info("Model switched: %s -> %s", d.get("from_model"), d.get("to_model")),
+        name="model_switch_logger",
+        priority=90,
+    )
+
+    # C8: Filesystem hook plugin auto-discovery (.geode/hooks/ + core/hooks/plugins/)
+    def _reg_filesystem_plugins() -> None:
+        from core.hooks.discovery import HookPluginLoader
+
+        loader = HookPluginLoader()
+        plugin_dirs = [Path(".geode/hooks"), Path("core/hooks/plugins")]
+        loader.load_from_dirs(plugin_dirs)
+        loader.register_all(hooks)
+
+    _register_plugin("filesystem_hook_plugins", _reg_filesystem_plugins)
+
     return hooks, run_log, stuck_detector
 
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -45,6 +45,7 @@
 
 | task_id | 작업 내용 | 담당 | 브랜치 | 시작일 | 비고 |
 |---------|----------|------|--------|--------|------|
+| p3-hook-gateway-batch | P3 일괄 — hook-model-switched + hook-filesystem-plugin + gateway-hotreload + gateway-hooks-l4 + README docs-sync | @mangowhoiscloud | feature/p3-batch | 2026-03-28 | |
 | context-long-session | 장시간 운용 컨텍스트 관리 — GAP-1~5 일괄 해소 | @mangowhoiscloud | feature/context-long-session | 2026-03-28 | Provider별 압축 + 대화 요약 |
 
 ### In Review

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -299,7 +299,7 @@ class TestApplyContext:
 class TestHookEventCount:
     def test_events_exist(self) -> None:
         """HookEvent has 45 events (+TURN_COMPLETE +SESSION_START/END +CONTEXT_OVERFLOW_ACTION +LLM_CALL_START/END)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -411,10 +411,10 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count is 39 (27 + 3 recovery + 2 gateway + 2 mcp + 2 context + 1 turn + 2 session)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
         """Verify total hook event count is 38 (27 + 3 recovery + 2 gateway + 2 mcp + 3 context + 1 turn)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -6,9 +6,9 @@ from core.hooks import HookEvent, HookResult, HookSystem
 class TestHookEvent:
     def test_all_events_exist(self):
 
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -357,10 +357,10 @@ class TestHookEventTypes:
 
     def test_hook_event_count(self):
         """Total hook events should be 39 (+1 TURN_COMPLETE + 2 SESSION_*)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
         """Total hook events should be 38 (+1 TURN_COMPLETE + CONTEXT_OVERFLOW_ACTION)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -27,7 +27,7 @@ class TestLLMLifecycleEvents:
 
     def test_event_count_includes_llm_events(self) -> None:
         """42 events total (40 base + LLM_CALL_START + LLM_CALL_END)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
 
 class TestFireHook:

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -38,10 +38,10 @@ class TestMCPHookEvents:
 
     def test_hook_event_count_includes_mcp(self) -> None:
         """Total hook events should be 39 (includes TURN_COMPLETE + 2 MCP_SERVER_* + 2 CONTEXT_* + 2 SESSION_*)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
         """Total hook events should be 38 (includes TURN_COMPLETE + 2 MCP_SERVER_* + 3 CONTEXT_*)."""
-        assert len(HookEvent) == 45
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **MODEL_SWITCHED hook**: `HookEvent.MODEL_SWITCHED` 추가 (45->46). `AgenticLoop.update_model()`에서 모델 변경 시 발화. `bootstrap.py`에 `model_switch_logger` 핸들러 등록.
- **Filesystem hook plugin auto-discovery**: `bootstrap.py`에서 `.geode/hooks/` + `core/hooks/plugins/` 자동 스캔 및 등록. 기존 `HookPluginLoader`를 부트스트랩 체인에 통합.
- **README docs-sync**: 도구(47->52), Hook(36->46) 수치를 `definitions.json` 및 `HookEvent` enum 실측값으로 갱신. 배지, 하이라이트, 구조도, Mermaid 다이어그램 등 8곳 일괄 수정.

## Why
- MODEL_SWITCHED: 모델 전환 시 observability 부재 — 로그/Hook으로 추적 불가
- Filesystem plugin: `HookPluginLoader` 구현 완료되었으나 부트스트랩 미연결 — `.geode/hooks/` 플러그인 자동 등록 안 됨
- README: 도구/Hook 수치가 6+ 버전 전 값으로 고정 — 실측값과 불일치

## Test plan
- [x] `len(HookEvent) == 46` 단언 6개 파일 갱신 — 전체 통과
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors (185 files)
- [x] `uv run pytest tests/ -m "not live" -q` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)