### PR TITLE
feat: Action Summary Tier 1 — deterministic per-tool summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Action Summary (Tier 1)** --- AgenticLoop 턴 종료 시 개별 도구 호출 + 결과를 결정론적으로 요약 표시. `AgenticResult.summary` 필드에 저장. 토큰 비용 0.
 - **Gateway binding hot-reload** --- `ConfigWatcher` watches `.geode/config.toml` and reloads `ChannelManager` bindings on file change (OpenClaw hot-reload pattern). No restart required.
 - **L4 webhook endpoint** --- `geode serve` optionally starts an HTTP POST endpoint (`/webhook`, default port 8765) that triggers AgenticLoop execution from external systems (OpenClaw L4 Gateway Hooks pattern). Controlled by `GEODE_WEBHOOK_ENABLED` / `GEODE_WEBHOOK_PORT` settings.
 - **TOOL_APPROVAL hooks** --- `TOOL_APPROVAL_REQUESTED`, `TOOL_APPROVAL_GRANTED`, `TOOL_APPROVAL_DENIED` 3종 HookEvent 추가 (42 -> 45). HITL 승인/거부/Always 패턴 추적. `ToolExecutor`에 hooks 주입, `bootstrap.py`에 `approval_tracker`/`denial_logger` 핸들러 등록.

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -107,6 +107,7 @@ class AgenticResult:
     rounds: int = 0
     error: str | None = None
     termination_reason: str = "unknown"  # "natural" | "forced_text" | "max_rounds" | "llm_error"
+    summary: str = ""  # Tier 1 compact action summary (auto-generated)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting None-valued fields."""

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1091,13 +1091,13 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                 result = agentic.run(user_input)
                 _render_agentic_result(result)
                 # Claude Code-style status line after each result
-                from core.cli.ui.agentic_ui import render_status_line, render_turn_summary
+                from core.cli.ui.agentic_ui import render_status_line
 
                 render_status_line()
 
-                # Turn-end compact summary (rounds · tools · time · cost)
+                # Turn-end action summary (per-tool detail + header)
                 if result and result.tool_calls:
-                    from core.cli.ui.agentic_ui import get_session_meter
+                    from core.cli.ui.agentic_ui import get_session_meter, render_action_summary
 
                     _meter = get_session_meter()
                     _turn_elapsed = _meter.turn_elapsed_s if _meter else 0.0
@@ -1116,9 +1116,9 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                             _turn_cost = _tk.accumulator.total_cost_usd
                     except Exception:
                         log.debug("Turn cost calculation failed", exc_info=True)
-                    render_turn_summary(
+                    result.summary = render_action_summary(
+                        result.tool_calls,
                         result.rounds,
-                        len(result.tool_calls),
                         _turn_elapsed,
                         _turn_cost,
                     )

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -424,6 +424,82 @@ def render_turn_summary(rounds: int, tool_count: int, elapsed_s: float, cost: fl
     console.print(f"\n  [dim]──── {summary} ────[/dim]")
 
 
+def render_action_summary(
+    tool_calls: list[dict[str, Any]],
+    rounds: int,
+    elapsed_s: float,
+    cost: float,
+) -> str:
+    """Render Tier 1 deterministic action summary with per-tool detail.
+
+    Displays a header line (rounds/tools/time/cost) followed by individual
+    tool call results.  Returns the summary string for storing in
+    ``AgenticResult.summary``.  Zero LLM tokens consumed.
+    """
+    if not tool_calls:
+        return ""
+
+    lines: list[str] = []
+
+    # Header
+    header_parts = [f"{rounds} rounds", f"{len(tool_calls)} tools", f"{elapsed_s:.1f}s"]
+    if cost > 0:
+        header_parts.append(f"${cost:.3f}")
+    header = " \u00b7 ".join(header_parts)
+    lines.append("\u2500\u2500\u2500\u2500 Action Summary \u2500\u2500\u2500\u2500")
+    lines.append(header)
+    lines.append("")
+
+    # Per-tool lines (cap at 10)
+    for tc in tool_calls[:10]:
+        name = tc.get("name", "?")
+        inp = tc.get("input", {})
+        result = tc.get("result", {})
+
+        # Concise arg preview: first meaningful value
+        arg_preview = ""
+        if isinstance(inp, dict):
+            for _k, v in inp.items():
+                if v and _k not in ("verbose",):
+                    arg_preview = str(v)[:40]
+                    break
+
+        # Concise result preview
+        result_preview = ""
+        if isinstance(result, dict):
+            if "error" in result:
+                result_preview = f"ERROR: {str(result['error'])[:30]}"
+            elif "result" in result:
+                result_preview = str(result["result"])[:40]
+            elif "status" in result:
+                result_preview = str(result["status"])
+            else:
+                for rk, rv in result.items():
+                    if rk not in ("_meta", "_timing") and rv:
+                        result_preview = f"{rk}={str(rv)[:30]}"
+                        break
+
+        if arg_preview:
+            lines.append(f"  {name}({arg_preview}) \u2192 {result_preview}")
+        else:
+            lines.append(f"  {name} \u2192 {result_preview}")
+
+    if len(tool_calls) > 10:
+        lines.append(f"  ... +{len(tool_calls) - 10} more")
+
+    lines.append(
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500"
+    )
+
+    summary_text = "\n".join(lines)
+
+    # Render to console
+    for line in lines:
+        console.print(f"  [dim]{line}[/dim]")
+
+    return summary_text
+
+
 # ───────────────────────────────────────────────────────────────────────────
 # Per-turn snapshot state (set before each agentic.run(), read by render)
 # ───────────────────────────────────────────────────────────────────────────

--- a/tests/test_action_summary.py
+++ b/tests/test_action_summary.py
@@ -1,0 +1,84 @@
+"""Tests for Tier 1 deterministic action summary."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.cli.ui.agentic_ui import render_action_summary
+
+
+class TestRenderActionSummary:
+    """render_action_summary produces structured per-tool summaries."""
+
+    def test_empty_tools_returns_empty(self) -> None:
+        assert render_action_summary([], 0, 0.0, 0.0) == ""
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_basic_summary(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        tool_calls = [
+            {"name": "web_search", "input": {"query": "ML Engineer"}, "result": {"status": "ok"}},
+            {"name": "memory_save", "input": {"key": "result"}, "result": {"status": "saved"}},
+        ]
+        summary = render_action_summary(tool_calls, 2, 3.5, 0.01)
+        assert "web_search" in summary
+        assert "memory_save" in summary
+        assert "2 rounds" in summary
+        assert "2 tools" in summary
+        assert "3.5s" in summary
+        assert "$0.010" in summary
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_cap_at_10(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        tool_calls = [{"name": f"tool_{i}", "input": {}, "result": {}} for i in range(15)]
+        summary = render_action_summary(tool_calls, 1, 1.0, 0.0)
+        assert "+5 more" in summary
+        # First 10 tools present
+        assert "tool_0" in summary
+        assert "tool_9" in summary
+        # 11th tool NOT present directly
+        assert "tool_10" not in summary
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_error_result(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        tool_calls = [{"name": "fail_tool", "input": {}, "result": {"error": "timeout"}}]
+        summary = render_action_summary(tool_calls, 1, 0.5, 0.0)
+        assert "ERROR" in summary
+        assert "timeout" in summary
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_no_cost_omits_dollar(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        tool_calls = [{"name": "t", "input": {}, "result": {"status": "ok"}}]
+        summary = render_action_summary(tool_calls, 1, 1.0, 0.0)
+        assert "$" not in summary
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_arg_preview_truncated(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        long_query = "a" * 100
+        tool_calls = [
+            {"name": "search", "input": {"query": long_query}, "result": {"status": "ok"}}
+        ]
+        summary = render_action_summary(tool_calls, 1, 0.5, 0.0)
+        # Arg preview capped at 40 chars
+        assert "a" * 40 in summary
+        assert "a" * 41 not in summary
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_result_preview_dict_key(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """When result has a custom key (not error/result/status), show key=value."""
+        tool_calls = [{"name": "calc", "input": {}, "result": {"answer": 42}}]
+        summary = render_action_summary(tool_calls, 1, 0.1, 0.0)
+        assert "answer=42" in summary
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_console_print_called(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        """Each line of the summary is printed to console."""
+        tool_calls = [{"name": "t1", "input": {}, "result": {"status": "done"}}]
+        render_action_summary(tool_calls, 1, 1.0, 0.0)
+        # Header + stats + blank + tool line + footer = 5 lines
+        assert mock_console.print.call_count == 5
+
+    @patch("core.cli.ui.agentic_ui.console")
+    def test_action_summary_header(self, mock_console) -> None:  # type: ignore[no-untyped-def]
+        tool_calls = [{"name": "t", "input": {}, "result": {}}]
+        summary = render_action_summary(tool_calls, 1, 0.5, 0.0)
+        assert "Action Summary" in summary


### PR DESCRIPTION
## Summary
- **`render_action_summary()`** 추가 (`core/cli/ui/agentic_ui.py`) — 턴 종료 시 개별 도구 호출명 + arg preview + result preview를 결정론적으로 표시. 10개 cap, LLM 토큰 소비 0.
- **`AgenticResult.summary`** 필드 추가 — 생성된 요약 문자열을 구조체에 저장하여 서브에이전트·메모리·로깅에서 재활용 가능.
- REPL call site(`core/cli/__init__.py`)에서 기존 `render_turn_summary` 대신 `render_action_summary` 호출로 교체. 기존 함수는 하위호환 유지.

## Why
기존 `render_turn_summary`는 "3 rounds · 8 tools · 4.2s" 한 줄만 표시하여, 어떤 도구가 어떤 결과를 냈는지 추적 불가. Action Summary는 도구별 인자·결과를 보여주어 디버깅·감사 추적성을 확보한다.

## Test plan
- [x] `tests/test_action_summary.py` — 9개 유닛 테스트 (빈 입력, 기본 요약, 10개 cap, 에러 결과, cost 생략, arg 잘림, dict key 미리보기, 콘솔 호출, 헤더)
- [x] 기존 `tests/test_agentic_ui.py` 64개 테스트 통과 (render_turn_summary 하위호환)
- [x] 전체 테스트 3285 pass, 0 fail
- [x] ruff check + ruff format + mypy 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)