### PR TITLE
feat: Plan-first prompt + HITL UI (Claude Code pattern)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Plan-first 프롬프트 가이드** — 복잡한 요청(3+ 스텝, 고비용)에 대해 LLM이 자발적으로 `create_plan` 호출 후 사용자 승인 대기. Claude Code 패턴.
+- **Plan HITL UI 보강** — 계획 표시 시 승인/수정/거부 안내 표시. plan_id 노출.
+
 ---
 ## [0.31.0] — 2026-03-28
 

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -353,16 +353,21 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
         plan = planner.create_plan(ip_name, template=template)
         summary = planner.present_plan(plan)
 
-        # Display plan steps
+        # Display plan steps with HITL approval prompt
         console.print()
-        console.print(f"  [header]● Plan: {ip_name} 분석 계획[/header]")
+        console.print(f"  [header]● Plan: {ip_name}[/header]")
+        console.print()
         for i, step in enumerate(plan.steps, 1):
-            console.print(f"    {i}. {step.description}")
+            console.print(f"    [bold]{i}.[/bold] {step.description}")
+        console.print()
         console.print(
-            f"  [muted]예상 시간: "
-            f"{plan.total_estimated_time_s:.0f}s "
-            f"| 단계: {plan.step_count}개[/muted]"
+            f"  [muted]예상: {plan.total_estimated_time_s:.0f}s · "
+            f"{plan.step_count} 단계 · plan_id={plan.plan_id}[/muted]"
         )
+        if not settings.plan_auto_execute:
+            console.print(
+                "  [dim]→ 승인(approve_plan) · 수정(modify_plan) · 거부(reject_plan)[/dim]"
+            )
         console.print()
         log.info(
             "Plan '%s' created for '%s' (%d steps)",

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -165,7 +165,7 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "769c33bff0d2",
+    "AGENTIC_SUFFIX": "8cabcc401dd3",
     "ANALYST_SPECIFIC": "5a696a2d5ebb",
     "ANALYST_SYSTEM": "8a325a63b397",
     "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -47,6 +47,16 @@ Round budget:
 
 Anti-exploration: NEVER explore beyond what was asked. When a tool succeeds, summarize and stop.
 
+## Plan-first for complex tasks
+
+For requests that need **3+ tool calls or involve high-cost operations**, present a plan first:
+1. Call `create_plan` to outline the steps, estimated time, and cost.
+2. The runtime displays the plan to the user with approval options.
+3. **Wait for user response** — do NOT proceed until the user approves (approve_plan), modifies (modify_plan), or rejects (reject_plan).
+
+Plan-worthy requests: multi-step research, multi-IP analysis, report generation, expensive workflows.
+Simple requests (single lookup, quick answer): execute directly, no plan needed.
+
 ## Agentic execution
 
 - Call multiple independent tools in a single response — the runtime executes them in parallel.


### PR DESCRIPTION
## Why

GEODE는 ReAct 루프지만 복잡한 요청에 대해 계획을 먼저 세우고 사용자에게 확인하는 패턴이 없었다. Claude Code는 복잡한 작업 전 plan을 보여주고 승인을 받는다.

## What

- **router.md**: Plan-first 가이드 추가 — 3+ 스텝 또는 고비용 요청에 LLM이 자발적으로 `create_plan` 호출 후 사용자 승인 대기
- **tool_handlers.py**: 계획 표시 UI 보강 — 승인(approve)/수정(modify)/거부(reject) 안내 + plan_id 노출
- **prompts/__init__.py**: AGENTIC_SUFFIX 해시 갱신 (drift pin)

## Test plan

- [x] 3285 passed (prompt drift hash 갱신 포함)
- [x] ruff/mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)