### PR TITLE
fix: context exhausted 명시적 종료 경로

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -98,6 +98,10 @@ MAX_TOOL_RESULT_TOKENS = 0  # backward-compat alias; canonical: settings.max_too
 TOOL_LAZY_LOAD_THRESHOLD = 50  # Above this count, skip MCP lazy loading
 
 
+class _ContextExhaustedError(Exception):
+    """Raised when context remains critical after pruning — unrecoverable."""
+
+
 @dataclass
 class AgenticResult:
     """Result of an agentic loop execution."""
@@ -106,7 +110,8 @@ class AgenticResult:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     rounds: int = 0
     error: str | None = None
-    # "natural" | "forced_text" | "max_rounds" | "time_budget_expired" | "llm_error"
+    # "natural" | "forced_text" | "max_rounds" | "time_budget_expired"
+    # | "llm_error" | "context_exhausted"
     termination_reason: str = "unknown"
     summary: str = ""  # Tier 1 compact action summary (auto-generated)
 
@@ -478,6 +483,31 @@ class AgenticLoop:
                     rounds=round_idx + 1,
                     termination_reason="user_cancelled",
                 )
+            except _ContextExhaustedError as exc:
+                _spinner.stop()
+                log.warning("Context exhausted: %s", exc)
+                self._notify_context_event(
+                    "exhausted",
+                    original_count=len(messages),
+                    new_count=len(messages),
+                )
+                self._sync_messages_to_context(messages)
+                result = AgenticResult(
+                    text=(
+                        "Context window exhausted after pruning. "
+                        "Your conversation is preserved — start a new request "
+                        "or use /compact to manually reduce context."
+                    ),
+                    tool_calls=self._tool_processor.tool_log,
+                    rounds=round_idx + 1,
+                    error="context_exhausted",
+                    termination_reason="context_exhausted",
+                )
+                return self._finalize_and_return(
+                    result,
+                    user_input,
+                    round_idx + 1,
+                )
             finally:
                 _spinner.stop()
 
@@ -685,6 +715,13 @@ class AgenticLoop:
 
                 strategy = self._resolve_overflow_strategy(metrics, settings)
                 self._apply_overflow_strategy(strategy, messages, settings)
+
+                # Re-check: if still critical after pruning, context is exhausted
+                post = check_context(messages, self.model, system_prompt=system)
+                if post.is_critical:
+                    raise _ContextExhaustedError(
+                        f"Context exhausted: {post.usage_pct:.0f}% after pruning"
+                    )
 
             elif metrics.is_warning:
                 # For non-Anthropic providers, 80% triggers client compaction

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -425,6 +425,11 @@ def render_context_event(
         ⟳ Context compacted: 45 → 12 messages
         ⟳ Context pruned: 30 → 10 messages
     """
+    if event_type == "exhausted":
+        console.print(
+            "  [warning]⟳ Context exhausted — pruning could not free enough space[/warning]"
+        )
+        return
     label = "compacted" if event_type == "compact" else "pruned"
     console.print(f"  [dim]⟳ Context {label}: {original_count} → {new_count} messages[/dim]")
 


### PR DESCRIPTION
## Summary
- 프루닝 후 재측정 → 여전히 95%+ → `_ContextExhaustedError` raise
- `context_exhausted` termination_reason으로 정상 종료 (API 에러 의존 제거)
- UI에 `⟳ Context exhausted` 경고 표시

## Why
프루닝 후에도 컨텍스트가 넘치는 경우(시스템 프롬프트가 거대한 경우 등)
명시적 종료 경로가 없어 API 토큰 초과 에러에 의존.

## Test plan
- [x] 3285 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)