### PR TITLE
feat: autonomous safety — cost auto-stop + runtime ratchet + diversity forcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Autonomous safety 3조건** — (1) 비용 상한 자동 정지: 세션 비용 budget 초과 시 루프 중단 (Karpathy P3). (2) 런타임 래칫: 동일 에러 3회 수렴 감지 시 모델 에스컬레이션 후 재시도 (Karpathy P4). (3) 다양성 강제: 동일 도구 5회 연속 호출 시 다른 접근 유도 힌트 주입.
 - **Plan-first 프롬프트 가이드** — 복잡한 요청(3+ 스텝, 고비용)에 대해 LLM이 자발적으로 `create_plan` 호출 후 사용자 승인 대기. Claude Code 패턴.
 - **Plan HITL UI 보강** — 계획 표시 시 승인/수정/거부 안내 표시. plan_id 노출.
 - **Provider-aware context compaction** — 장시간 운용을 위한 프로바이더별 컨텍스트 관리. Anthropic: 서버사이드 compaction(`compact_20260112`) + `clear_tool_uses` 결합. OpenAI/GLM: 80%에서 LLM 요약 기반 클라이언트 compaction 발동. `context_action.py` hook이 프로바이더별 전략을 분화.

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -111,7 +111,7 @@ class AgenticResult:
     rounds: int = 0
     error: str | None = None
     # "natural" | "forced_text" | "max_rounds" | "time_budget_expired"
-    # | "llm_error" | "context_exhausted"
+    # | "llm_error" | "context_exhausted" | "cost_budget_exceeded"
     termination_reason: str = "unknown"
     summary: str = ""  # Tier 1 compact action summary (auto-generated)
 
@@ -140,6 +140,7 @@ class AgenticLoop:
         max_rounds: int = DEFAULT_MAX_ROUNDS,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         time_budget_s: float = 0.0,  # 0 = no time limit (OpenClaw pattern)
+        cost_budget: float = 0.0,  # 0 = no cost limit (Karpathy P3)
         model: str | None = None,
         provider: str = "anthropic",
         tool_registry: ToolRegistry | None = None,
@@ -159,6 +160,7 @@ class AgenticLoop:
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens
         self._time_budget_s = time_budget_s
+        self._cost_budget = cost_budget
         self._loop_start_time: float = 0.0
         self.model = model or ANTHROPIC_PRIMARY
         self._provider = provider  # "anthropic", "openai", or "glm"
@@ -211,6 +213,10 @@ class AgenticLoop:
 
         # Feature 6: Convergence detection (stuck loop)
         self._recent_errors: list[str] = []
+        self._convergence_escalated: bool = False
+
+        # Feature 8: Diversity forcing — prevent same tool 5x consecutively
+        self._consecutive_tool_tracker: list[str] = []
 
         # C3 checkpoint: full message persistence for /resume (Claude Code pattern)
         self._checkpoint: Any | None = None
@@ -546,6 +552,32 @@ class AgenticLoop:
             # Track usage + Claude Code-style token display
             self._track_usage(response)
 
+            # Guard 3: Cost budget (Karpathy P3 — resource budget)
+            if self._cost_budget > 0:
+                try:
+                    from core.llm.token_tracker import get_tracker as _get_cost_tracker
+
+                    _cost_tracker = _get_cost_tracker()
+                    _session_cost = _cost_tracker.accumulator.total_cost_usd
+                    if _session_cost >= self._cost_budget:
+                        self._op_logger.finalize()
+                        self._sync_messages_to_context(messages)
+                        text = (
+                            f"Cost budget (${self._cost_budget:.2f}) exceeded. "
+                            f"Session cost: ${_session_cost:.2f}"
+                        )
+                        log.warning(text)
+                        result = AgenticResult(
+                            text=text,
+                            tool_calls=self._tool_processor.tool_log,
+                            rounds=round_idx + 1,
+                            error="cost_budget_exceeded",
+                            termination_reason="cost_budget_exceeded",
+                        )
+                        return self._finalize_and_return(result, user_input, round_idx + 1)
+                except Exception:
+                    log.debug("Cost budget check failed", exc_info=True)
+
             if response.stop_reason != "tool_use":
                 # end_turn or max_tokens → extract text, done
                 self._op_logger.finalize()
@@ -594,6 +626,31 @@ class AgenticLoop:
                     ),
                 }
                 tool_results.append(backpressure_hint)
+
+            # Feature 8: Diversity forcing — prevent same tool 5x consecutively
+            for block in response.content:
+                if getattr(block, "type", None) == "tool_use":
+                    self._consecutive_tool_tracker.append(getattr(block, "name", ""))
+            if len(self._consecutive_tool_tracker) > 10:
+                self._consecutive_tool_tracker = self._consecutive_tool_tracker[-10:]
+            if len(self._consecutive_tool_tracker) >= 5:
+                _last_5 = self._consecutive_tool_tracker[-5:]
+                if len(set(_last_5)) == 1:
+                    _repeated_tool = _last_5[0]
+                    diversity_hint = {
+                        "type": "text",
+                        "text": (
+                            f"[system] The tool '{_repeated_tool}' has been called 5 times "
+                            "consecutively with similar results. "
+                            "Try a different approach or tool to make progress."
+                        ),
+                    }
+                    tool_results.append(diversity_hint)
+                    self._consecutive_tool_tracker.clear()
+                    log.warning(
+                        "Diversity forcing: %s called 5x — injecting hint",
+                        _repeated_tool,
+                    )
 
             # Accumulate messages for next round
             # Convert content blocks to serializable format
@@ -1199,9 +1256,9 @@ class AgenticLoop:
     def _check_convergence_break(self) -> bool:
         """Check if the loop is stuck in a repeating failure pattern.
 
-        Returns True if 4+ of the last entries are identical errors,
-        indicating the loop should break.
-        Injects a warning into messages if 3 identical errors are detected.
+        On first detection of 3 identical errors, attempts model escalation
+        (runtime ratchet — Karpathy P4) instead of breaking immediately.
+        Only breaks after escalation has been tried and errors persist.
         """
         if len(self._recent_errors) < 3:
             return False
@@ -1209,17 +1266,31 @@ class AgenticLoop:
         # Check last 3 entries for identical pattern
         last_3 = self._recent_errors[-3:]
         if last_3[0] == last_3[1] == last_3[2]:
+            # Runtime ratchet: try model escalation before giving up
+            if not self._convergence_escalated:
+                self._convergence_escalated = True
+                log.warning(
+                    "Convergence detected (%s x3) — escalating model",
+                    last_3[0],
+                )
+                escalated = self._try_model_escalation()
+                if escalated:
+                    self._recent_errors.clear()
+                    return False  # Give escalated model a chance
+                # Escalation failed (no fallback) — fall through to break check
+
+            # Already escalated and still stuck — check for 4+ identical
             if len(self._recent_errors) >= 4:
                 last_4 = self._recent_errors[-4:]
                 if last_4[0] == last_4[1] == last_4[2] == last_4[3]:
                     log.warning(
-                        "Convergence detected: 4+ identical errors '%s'",
+                        "Convergence detected after escalation: 4+ identical errors '%s'",
                         last_4[0],
                     )
                     return True
-            # 3 identical — log warning (convergence warning injected via backpressure)
+            # 3 identical post-escalation — log warning, don't break yet
             log.warning(
-                "Convergence warning: 3 identical errors '%s'",
+                "Convergence warning (post-escalation): 3 identical errors '%s'",
                 last_3[0],
             )
         return False

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -592,6 +592,7 @@ def _build_agentic_stack(
     hitl_level: int = 2,
     max_rounds: int = 50,
     time_budget_s: float = 0.0,
+    cost_budget: float = 0.0,
     model: str | None = None,
     provider: str | None = None,
     system_suffix: str = "",
@@ -611,6 +612,12 @@ def _build_agentic_stack(
 
     _model = model or _stk_settings.model
     _provider = provider or _resolve_provider(_model)
+
+    # Resolve cost budget: explicit param > config/env setting
+    if cost_budget <= 0:
+        from core.cli.commands import _get_cost_budget
+
+        cost_budget = _get_cost_budget()
 
     agentic_ref: list[Any] = [None]
     handlers = _build_tool_handlers(
@@ -637,6 +644,7 @@ def _build_agentic_stack(
         executor,
         max_rounds=max_rounds,
         time_budget_s=time_budget_s,
+        cost_budget=cost_budget,
         model=_model,
         provider=_provider,
         mcp_manager=mcp_manager,

--- a/tests/test_autonomous_safety.py
+++ b/tests/test_autonomous_safety.py
@@ -1,0 +1,349 @@
+"""Tests for autonomous safety mechanisms: cost auto-stop, runtime ratchet, diversity forcing."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.agent.agentic_loop import AgenticLoop, AgenticResult
+from core.agent.conversation import ConversationContext
+from core.agent.tool_executor import ToolExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_text_response(text: str = "done") -> MagicMock:
+    """Create a mock LLM response with text content (end_turn)."""
+    resp = MagicMock()
+    resp.stop_reason = "end_turn"
+    resp.usage = MagicMock()
+    resp.usage.input_tokens = 100
+    resp.usage.output_tokens = 50
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    resp.content = [block]
+    return resp
+
+
+def _make_tool_response(tool_name: str = "web_search", tool_id: str = "toolu_1") -> MagicMock:
+    """Create a mock LLM response with a single tool_use block."""
+    resp = MagicMock()
+    resp.stop_reason = "tool_use"
+    resp.usage = MagicMock()
+    resp.usage.input_tokens = 100
+    resp.usage.output_tokens = 50
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = tool_name
+    block.input = {"query": "test"}
+    block.id = tool_id
+    resp.content = [block]
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# 1. Cost budget auto-stop
+# ---------------------------------------------------------------------------
+
+
+class TestCostBudgetAutoStop:
+    """Verify the loop terminates when session cost exceeds cost_budget."""
+
+    @pytest.fixture
+    def context(self) -> ConversationContext:
+        return ConversationContext(max_turns=10)
+
+    @pytest.fixture
+    def executor(self) -> ToolExecutor:
+        handler = MagicMock(return_value={"status": "ok"})
+        return ToolExecutor(action_handlers={"web_search": handler})
+
+    def test_cost_budget_terminates(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """When session cost >= cost_budget, loop should terminate with cost_budget_exceeded."""
+        loop = AgenticLoop(context, executor, cost_budget=1.00)
+
+        # Mock tracker with accumulated cost above budget
+        mock_tracker = MagicMock()
+        mock_tracker.accumulator.total_cost_usd = 1.50
+
+        response = _make_text_response("Hello")
+
+        # Patch the module that the inline import resolves to
+        mock_module = MagicMock(get_tracker=lambda: mock_tracker)
+        with (
+            patch.object(loop, "_call_llm", return_value=response),
+            patch.object(loop, "_track_usage"),
+            patch.dict(
+                "sys.modules",
+                {"core.llm.token_tracker": mock_module},
+            ),
+        ):
+            result = loop.run("test cost")
+
+        assert result.termination_reason == "cost_budget_exceeded"
+        assert "1.00" in result.text
+        assert "1.50" in result.text
+
+    def test_cost_budget_zero_no_check(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """When cost_budget=0 (default), no cost check should happen."""
+        loop = AgenticLoop(context, executor, cost_budget=0.0)
+        assert loop._cost_budget == 0.0
+
+        response = _make_text_response("Hello")
+        with (
+            patch.object(loop, "_call_llm", return_value=response),
+            patch.object(loop, "_track_usage"),
+        ):
+            result = loop.run("test no budget")
+
+        assert result.termination_reason == "natural"
+
+    def test_cost_budget_under_limit_continues(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """When session cost < cost_budget, loop should continue normally."""
+        loop = AgenticLoop(context, executor, cost_budget=10.00)
+
+        mock_tracker = MagicMock()
+        mock_tracker.accumulator.total_cost_usd = 0.50
+
+        response = _make_text_response("Hello")
+
+        with (
+            patch.object(loop, "_call_llm", return_value=response),
+            patch.object(loop, "_track_usage"),
+            patch.dict(
+                "sys.modules",
+                {"core.llm.token_tracker": MagicMock(get_tracker=lambda: mock_tracker)},
+            ),
+        ):
+            result = loop.run("test under budget")
+
+        assert result.termination_reason == "natural"
+
+
+# ---------------------------------------------------------------------------
+# 2. Runtime ratchet — escalate on convergence
+# ---------------------------------------------------------------------------
+
+
+class TestConvergenceEscalation:
+    """Verify convergence detection tries model escalation before breaking."""
+
+    @pytest.fixture
+    def context(self) -> ConversationContext:
+        return ConversationContext(max_turns=10)
+
+    @pytest.fixture
+    def executor(self) -> ToolExecutor:
+        handler = MagicMock(return_value={"status": "ok"})
+        return ToolExecutor(action_handlers={"web_search": handler})
+
+    def test_convergence_escalates_model_first(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """3 identical errors should trigger model escalation, not immediate break."""
+        loop = AgenticLoop(context, executor)
+
+        # Simulate 3 identical errors
+        loop._recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
+
+        with patch.object(loop, "_try_model_escalation", return_value=True) as mock_escalate:
+            result = loop._check_convergence_break()
+
+        assert result is False  # Should NOT break (escalation succeeded)
+        mock_escalate.assert_called_once()
+        assert loop._convergence_escalated is True
+        assert loop._recent_errors == []  # Cleared after escalation
+
+    def test_convergence_breaks_after_failed_escalation(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """If escalation fails and 4 identical errors persist, should break."""
+        loop = AgenticLoop(context, executor)
+        loop._convergence_escalated = True  # Already tried escalation
+
+        # 4 identical errors post-escalation
+        loop._recent_errors = [
+            "web_search:timeout",
+            "web_search:timeout",
+            "web_search:timeout",
+            "web_search:timeout",
+        ]
+
+        result = loop._check_convergence_break()
+        assert result is True  # Should break now
+
+    def test_convergence_escalation_no_fallback(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """If no fallback model is available, escalation returns False."""
+        loop = AgenticLoop(context, executor)
+        loop._recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
+
+        with patch.object(loop, "_try_model_escalation", return_value=False):
+            # First call: tries escalation, fails, then checks for 4+
+            result = loop._check_convergence_break()
+
+        # Only 3 errors, escalation failed — doesn't break yet (needs 4)
+        assert result is False
+        assert loop._convergence_escalated is True
+
+    def test_convergence_3_errors_post_escalation_warns_no_break(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """After escalation, 3 identical errors should warn but not break."""
+        loop = AgenticLoop(context, executor)
+        loop._convergence_escalated = True
+
+        loop._recent_errors = [
+            "web_search:timeout",
+            "web_search:timeout",
+            "web_search:timeout",
+        ]
+
+        result = loop._check_convergence_break()
+        assert result is False  # Only warns, doesn't break (needs 4)
+
+    def test_convergence_flag_resets_on_new_loop(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """_convergence_escalated should start as False."""
+        loop = AgenticLoop(context, executor)
+        assert loop._convergence_escalated is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Diversity forcing
+# ---------------------------------------------------------------------------
+
+
+class TestDiversityForcing:
+    """Verify that same tool called 5x consecutively triggers diversity hint."""
+
+    @pytest.fixture
+    def context(self) -> ConversationContext:
+        return ConversationContext(max_turns=10)
+
+    @pytest.fixture
+    def executor(self) -> ToolExecutor:
+        handler = MagicMock(return_value={"status": "ok"})
+        return ToolExecutor(action_handlers={"web_search": handler})
+
+    def test_diversity_hint_injected(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """After 5 consecutive same-tool calls, a diversity hint should be injected."""
+        loop = AgenticLoop(context, executor, max_rounds=7)
+
+        # Pre-fill 4 calls to the same tool
+        loop._consecutive_tool_tracker = ["web_search"] * 4
+
+        call_count = 0
+        tool_resp = _make_tool_response("web_search", "toolu_div")
+        text_resp = _make_text_response("Done")
+
+        captured_messages: list[Any] = []
+
+        async def fake_call_llm(system_prompt: str, messages: list, **kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            captured_messages.clear()
+            captured_messages.extend(messages)
+            if call_count <= 1:
+                return tool_resp
+            return text_resp
+
+        tool_result_item = {
+            "type": "tool_result",
+            "tool_use_id": "toolu_div",
+            "content": '{"status": "ok"}',
+        }
+
+        with (
+            patch.object(loop, "_call_llm", side_effect=fake_call_llm),
+            patch.object(loop, "_track_usage"),
+            patch.object(loop._tool_processor, "process", return_value=[tool_result_item]),
+        ):
+            result = loop.run("search something")
+
+        # Verify diversity hint was injected (tracker was cleared)
+        assert loop._consecutive_tool_tracker == []  # Cleared after hint
+        assert result.termination_reason == "natural"
+
+    def test_no_diversity_hint_under_threshold(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """Under 5 consecutive calls, no diversity hint should be injected."""
+        loop = AgenticLoop(context, executor)
+        loop._consecutive_tool_tracker = ["web_search"] * 3  # Only 3
+
+        # Running the diversity check logic manually
+        # After adding one more "web_search", tracker has 4 — still under 5
+        loop._consecutive_tool_tracker.append("web_search")
+        assert len(loop._consecutive_tool_tracker) == 4
+        # No hint should be needed (check inline)
+        last_5 = (
+            loop._consecutive_tool_tracker[-5:] if len(loop._consecutive_tool_tracker) >= 5 else []
+        )
+        assert len(last_5) == 0 or len(set(last_5)) != 1
+
+    def test_diverse_tools_no_hint(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """Different tools should not trigger diversity hint even after 5 calls."""
+        loop = AgenticLoop(context, executor)
+        loop._consecutive_tool_tracker = [
+            "web_search",
+            "memory_load",
+            "web_search",
+            "run_bash",
+            "web_search",
+        ]
+        last_5 = loop._consecutive_tool_tracker[-5:]
+        assert len(set(last_5)) > 1  # Multiple distinct tools — no hint needed
+
+    def test_tracker_capped_at_10(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """Tracker should keep at most 10 entries."""
+        loop = AgenticLoop(context, executor)
+        loop._consecutive_tool_tracker = ["tool_a"] * 12
+        # Cap logic: if > 10, trim to last 10
+        if len(loop._consecutive_tool_tracker) > 10:
+            loop._consecutive_tool_tracker = loop._consecutive_tool_tracker[-10:]
+        assert len(loop._consecutive_tool_tracker) == 10
+
+
+# ---------------------------------------------------------------------------
+# Integration: AgenticResult fields
+# ---------------------------------------------------------------------------
+
+
+class TestAgenticResultSafety:
+    """Verify AgenticResult supports safety-related termination reasons."""
+
+    def test_cost_budget_exceeded_reason(self) -> None:
+        result = AgenticResult(
+            text="Cost exceeded",
+            termination_reason="cost_budget_exceeded",
+            error="cost_budget_exceeded",
+        )
+        assert result.termination_reason == "cost_budget_exceeded"
+        d = result.to_dict()
+        assert d["termination_reason"] == "cost_budget_exceeded"
+
+    def test_convergence_detected_reason(self) -> None:
+        result = AgenticResult(
+            text="Convergence",
+            termination_reason="convergence_detected",
+        )
+        assert result.termination_reason == "convergence_detected"

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -4,10 +4,10 @@ Feature 5: Backpressure on tool failures
   - Track consecutive tool errors across rounds
   - After 3+ consecutive errors, inject a cooldown delay and hint
 
-Feature 6: Convergence detection (stuck loop)
+Feature 6: Convergence detection (stuck loop) + runtime ratchet
   - Track recent error keys (tool_name:error_type)
-  - 3 identical errors → warning
-  - 4+ identical errors → force break
+  - 3 identical errors → model escalation attempt (runtime ratchet)
+  - 4+ identical errors after escalation → force break
 """
 
 from __future__ import annotations
@@ -142,15 +142,19 @@ class TestConvergenceDetection:
         loop._recent_errors = ["tool_a:timeout", "tool_a:timeout"]
         assert loop._check_convergence_break() is False
 
-    def test_check_convergence_3_identical_no_break(self) -> None:
-        """3 identical errors → warning but no break (need 4)."""
+    def test_check_convergence_3_identical_escalates(self) -> None:
+        """3 identical errors → model escalation, errors cleared, no break."""
         loop = _make_loop()
         loop._recent_errors = ["tool_a:timeout", "tool_a:timeout", "tool_a:timeout"]
-        assert loop._check_convergence_break() is False
+        with patch.object(loop, "_try_model_escalation", return_value=True):
+            assert loop._check_convergence_break() is False
+        assert loop._convergence_escalated is True
+        assert loop._recent_errors == []  # Cleared after escalation
 
-    def test_check_convergence_4_identical_breaks(self) -> None:
-        """4 identical errors → force break."""
+    def test_check_convergence_4_identical_breaks_after_escalation(self) -> None:
+        """4 identical errors after escalation already tried → force break."""
         loop = _make_loop()
+        loop._convergence_escalated = True  # Already escalated
         loop._recent_errors = [
             "tool_a:timeout",
             "tool_a:timeout",
@@ -159,9 +163,10 @@ class TestConvergenceDetection:
         ]
         assert loop._check_convergence_break() is True
 
-    def test_check_convergence_5_identical_breaks(self) -> None:
-        """5+ identical errors → force break."""
+    def test_check_convergence_5_identical_breaks_after_escalation(self) -> None:
+        """5+ identical errors after escalation already tried → force break."""
         loop = _make_loop()
+        loop._convergence_escalated = True  # Already escalated
         loop._recent_errors = [
             "tool_a:timeout",
             "tool_a:timeout",


### PR DESCRIPTION
## Why

야간 무인 배치(overnight unattended) 전제조건 3가지가 미구현:
1. 비용 상한 초과 시 자동 정지 없음 (표시만)
2. 수렴 감지 시 단순 중단 (전략 전환 없음)
3. 동일 도구 반복 감지 없음

## What

### 1. Cost budget auto-stop
- 매 라운드 `token_tracker.total_cost_usd >= budget` 체크
- 초과 시 `cost_budget_exceeded` termination reason으로 중단
- `/cost budget $X`로 설정한 값 적용

### 2. Runtime ratchet (Karpathy P4)
- 동일 에러 3회 수렴 감지 → **모델 에스컬레이션** (Sonnet→Opus, Haiku→Sonnet 등)
- 에스컬레이션 후 재시도, 재차 수렴 시 중단
- 기존: 3회 → 즉시 중단 / 개선: 3회 → 에스컬레이션 → 재시도 → 실패 시 중단

### 3. Diversity forcing
- 동일 도구 5회 연속 호출 감지
- 시스템 힌트 주입: "다른 접근을 시도하라"
- 트래커 초기화 후 루프 계속

## Test plan

- [x] 3299 passed (12 new: test_autonomous_safety.py + test_backpressure.py 갱신)
- [x] ruff/mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)