### PR TITLE
release: v0.32.0 — Autonomous Safety + Plan-first + 기망 방지

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+## [0.32.0] — 2026-03-28
+
 ### Added
 - **Autonomous safety 3조건** — (1) 비용 상한 자동 정지: 세션 비용 budget 초과 시 루프 중단 (Karpathy P3). (2) 런타임 래칫: 동일 에러 3회 수렴 감지 시 모델 에스컬레이션 후 재시도 (Karpathy P4). (3) 다양성 강제: 동일 도구 5회 연속 호출 시 다른 접근 유도 힌트 주입.
 - **Plan-first 프롬프트 가이드** — 복잡한 요청(3+ 스텝, 고비용)에 대해 LLM이 자발적으로 `create_plan` 호출 후 사용자 승인 대기. Claude Code 패턴.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@
 
 LangGraph 기반 범용 자율 실행 에이전트. 리서치, 분석, 자동화, 스케줄링을 자율적으로 수행합니다.
 
-- **Version**: 0.31.0
+- **Version**: 0.32.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 187
-- **Tests**: 3285+
+- **Tests**: 3299+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -242,6 +242,15 @@ Decision Tree on D-E-F axes:
 | **PR** | HEREDOC 없이 PR body 금지 | 형식 일관성 |
 | | Why 근거 없이 PR 금지 | 의사결정 기록 |
 | | CI 가드레일 미통과 PR 머지 금지 | 래칫 (P4) |
+
+### 리팩토링 기망 방지
+
+| 항목 | 규칙 |
+|------|------|
+| **부분 구현 위장** | 플랜 명시 항목을 일부만 수행하고 완료 처리 금지 |
+| **stub 위장** | 빈 모듈(`pass` only)로 추출 완료 위장 금지 |
+| **원본 잔류** | 원본에 코드 남긴 채 "추출 완료" 표기 금지 (re-export만 허용) |
+| **제로 컨텍스트 검증** | 독립 에이전트가 플랜 문서 + diff 대조 → 모든 항목 구현 확인 → 누락 시 FAIL |
 
 ### CAN — 허용된 자유도
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
 
-# GEODE v0.31.0 — Autonomous Execution Harness
+# GEODE v0.32.0 — Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.31.0"
+version = "0.32.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## v0.32.0

187 modules · 3299 tests · 54 tools · 46 hooks

### Highlights
- **Autonomous Safety 3조건**: 비용 상한 자동 정지, 런타임 래칫 (모델 에스컬레이션), 다양성 강제
- **Plan-first 프롬프트**: 복잡한 요청 → 자발적 계획 + 사용자 승인 대기
- **Provider-aware context compaction**: Anthropic 서버사이드 + OpenAI/GLM 클라이언트 분화
- **CLAUDE.md 기망 방지**: 부분 구현 위장, stub 위장, 원본 잔류, 제로 컨텍스트 검증

### Docs-Sync
- Version: 0.31.0 → 0.32.0 (4곳)
- Tests: 3285+ → 3299+

## Test plan
- [x] 3299 passed, lint/mypy 0 errors
- [x] E2E: Cowboy Bebop A (68.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)