### PR TITLE
fix: create_plan goal 경로 template UnboundLocalError 수정

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1003,9 +1003,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                     )
                     result = iso_loop.run(prompt)
                     status = "ok" if not result.error else "err"
-                    console.print(
-                        f"  [dim]scheduled:{job_id} → {status}[/dim]"
-                    )
+                    console.print(f"  [dim]scheduled:{job_id} → {status}[/dim]")
                 else:
                     # OpenClaw systemEvent: inject into main session (visible)
                     agentic.run(prompt)

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -363,6 +363,7 @@ def _build_plan_handlers(force_dry: bool) -> dict[str, Any]:
 
             from core.orchestration.plan_mode import AnalysisPlan, PlanStep
 
+            template = "agentic"
             plan_id = f"plan_{uuid.uuid4().hex[:8]}"
             if custom_steps:
                 steps = [


### PR DESCRIPTION
## Summary
- `handle_create_plan`의 `goal` 분기에서 `template` 변수 미할당 → 반환 dict에서 `UnboundLocalError` 발생
- `f18fe13`에서 `create_plan` 범용화 시 `goal` 경로에 `template` 할당 누락
- `template = "agentic"` 1줄 추가로 수정

## Test plan
- [x] `pytest -k create_plan` 통과
- [x] import 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)