### PR TITLE
fix: scheduler WHEN/WHAT 분리 + every-weekday CRON 파싱

### DIFF
--- a/core/automation/nl_scheduler.py
+++ b/core/automation/nl_scheduler.py
@@ -420,9 +420,7 @@ class NLScheduleParser:
         # Exclude stop words AND day names (they describe schedule, not task)
         day_names = set(_DAY_MAP.keys())
         significant = [
-            w.lower()
-            for w in words
-            if w.lower() not in _STOP_WORDS and w.lower() not in day_names
+            w.lower() for w in words if w.lower() not in _STOP_WORDS and w.lower() not in day_names
         ]
         if significant:
             return "_".join(significant[:3])
@@ -504,8 +502,7 @@ class NLScheduleParser:
 
         # "weekly on <day>", "every monday", or just "weekly"
         if "weekly" in text or (
-            re.search(r"\bevery\b", text, re.IGNORECASE)
-            and any(d in text for d in _DAY_MAP)
+            re.search(r"\bevery\b", text, re.IGNORECASE) and any(d in text for d in _DAY_MAP)
         ):
             day_num = self._extract_weekday(text)
             hour, minute = self._extract_time(text)

--- a/core/automation/nl_scheduler.py
+++ b/core/automation/nl_scheduler.py
@@ -326,7 +326,6 @@ class NLScheduleParser:
 
         job_id = self._generate_job_id(job_name, agent_id)
         now_ms = time.time() * 1000
-        action = original
 
         job = ScheduledJob(
             job_id=job_id,
@@ -334,7 +333,7 @@ class NLScheduleParser:
             schedule=schedule,
             enabled=True,
             delete_after_run=(kind == ScheduleKind.AT),
-            action=action,
+            action="",  # caller sets action (schedule expression != task to execute)
             active_hours=active_hours,
             created_at_ms=now_ms,
             metadata={"source": "nl_parser", "original_text": original},
@@ -418,7 +417,13 @@ class NLScheduleParser:
     def _auto_name(self, text: str) -> str:
         """Generate a name from the first significant words of *text*."""
         words = re.findall(r"[a-zA-Z]+", text)
-        significant = [w.lower() for w in words if w.lower() not in _STOP_WORDS]
+        # Exclude stop words AND day names (they describe schedule, not task)
+        day_names = set(_DAY_MAP.keys())
+        significant = [
+            w.lower()
+            for w in words
+            if w.lower() not in _STOP_WORDS and w.lower() not in day_names
+        ]
         if significant:
             return "_".join(significant[:3])
         return "scheduled_task"
@@ -434,6 +439,12 @@ class NLScheduleParser:
         for kw in cron_keywords:
             if kw in text:
                 return ScheduleKind.CRON
+
+        # "every <day-of-week>" → CRON (weekly)
+        if re.search(r"\bevery\b", text, re.IGNORECASE):
+            for day_name in _DAY_MAP:
+                if day_name in text:
+                    return ScheduleKind.CRON
 
         # Check for one-shot patterns
         if re.search(r"\b(once|in\s+\d+)\b", text, re.IGNORECASE):
@@ -491,8 +502,11 @@ class NLScheduleParser:
             hour, minute = self._extract_time(text)
             return f"{minute} {hour} * * *"
 
-        # "weekly on <day>" or just "weekly"
-        if "weekly" in text:
+        # "weekly on <day>", "every monday", or just "weekly"
+        if "weekly" in text or (
+            re.search(r"\bevery\b", text, re.IGNORECASE)
+            and any(d in text for d in _DAY_MAP)
+        ):
             day_num = self._extract_weekday(text)
             hour, minute = self._extract_time(text)
             return f"{minute} {hour} * * {day_num}"

--- a/core/cli/cmd_schedule.py
+++ b/core/cli/cmd_schedule.py
@@ -27,16 +27,17 @@ def _format_schedule_desc(job: _Any) -> str:
 
 def _print_job_status(job: _Any) -> None:
     """Print detailed status for a dynamic ScheduledJob."""
-    console.print(f"  Name: {job.name}")
-    console.print(f"  Schedule: {_format_schedule_desc(job)}")
-    state = "enabled" if job.enabled else "disabled"
-    console.print(f"  State: {state}")
+    state = "[success]ON[/success]" if job.enabled else "[muted]OFF[/muted]"
+    console.print(f"  {state} {job.name} ({_format_schedule_desc(job)})")
+    if job.action:
+        action_preview = job.action[:60] + ("..." if len(job.action) > 60 else "")
+        console.print(f"  Action: {action_preview}")
+    elif not job.action:
+        console.print("  [warning]Action: (empty — job fires but does nothing)[/warning]")
     if job.last_status:
-        console.print(f"  Last status: {job.last_status}")
-    if job.last_duration_ms is not None:
-        console.print(f"  Last duration: {job.last_duration_ms:.1f}ms")
+        console.print(f"  Last: {job.last_status} ({job.last_duration_ms:.0f}ms)")
     if job.active_hours:
-        console.print(f"  Active hours: {job.active_hours.start}-{job.active_hours.end}")
+        console.print(f"  Hours: {job.active_hours.start}-{job.active_hours.end}")
 
 
 def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
@@ -76,9 +77,14 @@ def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
                 for job in jobs:
                     state = "[success]ON[/success]" if job.enabled else "[muted]OFF[/muted]"
                     desc = _format_schedule_desc(job)
+                    action_hint = ""
+                    if job.action:
+                        action_hint = f" → {job.action[:40]}"
+                    else:
+                        action_hint = " [warning](no action)[/warning]"
                     console.print(
                         f"  {state}  [label]{job.job_id:<30}[/label] "
-                        f"[muted]{desc:<16}[/muted] {job.name}"
+                        f"[muted]{desc:<16}[/muted] {job.name}{action_hint}"
                     )
 
         console.print()
@@ -115,6 +121,9 @@ def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
         scheduler_service.save()  # persist immediately — prevent crash data loss
         console.print(f"  [success]Created: {result.job.job_id}[/success]")
         console.print(f"  Schedule: {_format_schedule_desc(result.job)}")
+        if not result.job.action:
+            console.print("  [warning]Action not set — job will fire but do nothing.[/warning]")
+            console.print("  [muted]Tip: use schedule_job tool with action param[/muted]")
         console.print()
         return
 

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -878,9 +878,7 @@ def _build_execution_handlers() -> dict[str, Any]:
                     "action": "schedule",
                     "sub_action": "create",
                     "job_id": job.job_id,
-                    "schedule_kind": (
-                        result.inferred_kind.value if result.inferred_kind else ""
-                    ),
+                    "schedule_kind": (result.inferred_kind.value if result.inferred_kind else ""),
                     "expression": expression,
                     "job_action": action_text,
                 }

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -845,30 +845,44 @@ def _build_execution_handlers() -> dict[str, Any]:
         sub_action = kwargs.get("sub_action", "") or "list"
         target_id = kwargs.get("target_id", "")
         expression = kwargs.get("expression", "")
+        action_text = kwargs.get("action", "")
         svc = _scheduler_service_ctx.get(None)
 
         if sub_action == "create" and expression:
-            cmd_schedule(f"create {expression}", scheduler_service=svc)
+            if not svc:
+                return {"status": "error", "action": "schedule", "error": "Scheduler not available"}
             try:
                 from core.automation.nl_scheduler import NLScheduleParser
 
                 result = NLScheduleParser().parse(expression)
-                if result.success and result.job:
+                if not result.success or not result.job:
                     return {
-                        "status": "ok",
+                        "status": "error",
                         "action": "schedule",
                         "sub_action": "create",
-                        "job_id": result.job.job_id,
-                        "schedule_kind": (
-                            result.inferred_kind.value if result.inferred_kind else ""
-                        ),
-                        "expression": expression,
+                        "error": result.error or "parse failed",
                     }
+                job = result.job
+                job.action = action_text
+                svc.add_job(job)
+                svc.save()
+                from core.cli.cmd_schedule import _format_schedule_desc
+
+                console.print(f"  [success]Created: {job.job_id}[/success]")
+                console.print(f"  Schedule: {_format_schedule_desc(job)}")
+                if action_text:
+                    console.print(f"  Action: {action_text[:80]}")
+                console.print()
                 return {
-                    "status": "error",
+                    "status": "ok",
                     "action": "schedule",
                     "sub_action": "create",
-                    "error": result.error or "parse failed",
+                    "job_id": job.job_id,
+                    "schedule_kind": (
+                        result.inferred_kind.value if result.inferred_kind else ""
+                    ),
+                    "expression": expression,
+                    "job_action": action_text,
                 }
             except Exception as exc:
                 return {

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -309,7 +309,7 @@
   },
   {
     "name": "schedule_job",
-    "description": "배치 분석 스케줄을 관리합니다. 자연어로 스케줄 생성/삭제/상태조회가 가능합니다.",
+    "description": "반복 작업 스케줄을 관리합니다. create 시 expression(언제)과 action(무엇을)을 함께 지정해야 합니다.",
     "category": "scheduling",
     "cost_tier": "cheap",
     "input_schema": {
@@ -334,7 +334,11 @@
         },
         "expression": {
           "type": "string",
-          "description": "자연어 스케줄 표현식 (create 시). Examples: 'every 5 minutes', 'daily at 9:00', 'in 30 minutes', 'every 2 hours during 09:00-18:00'"
+          "description": "자연어 스케줄 표현식 — 언제 실행할지 (create 시). Examples: 'every 5 minutes', 'daily at 9:00', 'every monday at 9:00', 'every 2 hours during 09:00-18:00'"
+        },
+        "action": {
+          "type": "string",
+          "description": "실행할 작업 내용 — 무엇을 할지 (create 시 필수). 스케줄 시점에 AgenticLoop이 수행할 프롬프트. Example: 'ML Engineer 채용 공고를 검색하고 요약해서 이메일로 보내줘'"
         }
       },
       "required": []

--- a/tests/test_nl_scheduler.py
+++ b/tests/test_nl_scheduler.py
@@ -191,6 +191,29 @@ class TestCronInference:
         assert result.job is not None
         assert result.job.schedule.cron_expr == "0 0 * * 5"
 
+    def test_every_monday_at_9(self, parser: NLScheduleParser) -> None:
+        """'every monday at 9:00' should be CRON weekly, not AT one-shot."""
+        result = parser.parse("every monday at 9:00")
+        assert result.success is True
+        assert result.inferred_kind == ScheduleKind.CRON
+        assert result.job is not None
+        assert result.job.schedule.cron_expr == "0 9 * * 1"
+        assert result.job.delete_after_run is False
+
+    def test_every_friday_at_6pm(self, parser: NLScheduleParser) -> None:
+        result = parser.parse("every friday at 6pm")
+        assert result.success is True
+        assert result.inferred_kind == ScheduleKind.CRON
+        assert result.job is not None
+        assert result.job.schedule.cron_expr == "0 18 * * 5"
+
+    def test_every_sunday(self, parser: NLScheduleParser) -> None:
+        result = parser.parse("every sunday at 10:00")
+        assert result.success is True
+        assert result.inferred_kind == ScheduleKind.CRON
+        assert result.job is not None
+        assert result.job.schedule.cron_expr == "0 10 * * 0"
+
 
 # ===========================================================================
 # AT parsing (one-shot)
@@ -486,31 +509,32 @@ class TestEdgeCases:
 # ===========================================================================
 
 
-class TestActionStoresOriginal:
-    """job.action stores the full original text — no regex extraction."""
+class TestActionEmpty:
+    """NL parser sets action="" — caller (tool handler) provides the action."""
 
     @pytest.fixture
     def parser(self) -> NLScheduleParser:
         return NLScheduleParser()
 
-    def test_action_is_original_text(self, parser: NLScheduleParser) -> None:
+    def test_action_is_empty_by_default(self, parser: NLScheduleParser) -> None:
         text = "remind me to check emails every 5 minutes"
         result = parser.parse(text)
         assert result.success
         assert result.job is not None
-        assert result.job.action == text
+        assert result.job.action == ""
 
-    def test_action_preserves_schedule_keywords(self, parser: NLScheduleParser) -> None:
+    def test_action_empty_for_schedule_only(self, parser: NLScheduleParser) -> None:
         text = "every 5 minutes"
         result = parser.parse(text)
         assert result.success
         assert result.job is not None
-        assert result.job.action == text
+        assert result.job.action == ""
 
-    def test_action_preserves_daily_context(self, parser: NLScheduleParser) -> None:
-        text = "daily at 9:00 generate daily standup summary"
+    def test_caller_can_set_action(self, parser: NLScheduleParser) -> None:
+        text = "daily at 9:00"
         result = parser.parse(text)
         assert result.success
         assert result.job is not None
-        # "daily" in "daily standup summary" is preserved — no regex noise
-        assert "daily standup summary" in result.job.action
+        assert result.job.action == ""
+        result.job.action = "generate daily standup summary"
+        assert result.job.action == "generate daily standup summary"


### PR DESCRIPTION
## Summary
- **G1**: NL parser가 `action=original_text` (스케줄 표현식)로 설정 → `action=""` (caller가 설정). 스케줄 표현식 ≠ 실행할 작업.
- **G2**: `schedule_job` 도구에 `action` 파라미터 추가. LLM이 "언제(expression)" + "뭘 할지(action)" 분리 전달.
- **G3**: "every monday at 9:00" → AT(1회성) 파싱 버그 → CRON(weekly) 수정. 요일명 감지 추가.
- **G4**: auto_name에서 요일명 제외 → "monday" 대신 "scheduled_task"
- **G5**: UI — job list/status에 action 표시 + empty action 경고
- **G6**: tool handler 이중 파싱 버그 수정 (cmd_schedule + NLScheduleParser 2회 호출 → 1회)

Why: 모든 스케줄 잡이 `action=""` 또는 NL 텍스트 그대로여서 실제로 아무것도 실행하지 않음. 이메일 스케줄이 첫 등록 이후 동작하지 않은 근본 원인.

## Test plan
- [x] `test_nl_scheduler.py` — action="" 검증 3건, every-weekday CRON 3건 추가
- [x] `test_scheduler.py` + `test_scheduler_integration.py` 전체 통과
- [x] Full test suite pass (`pytest -m "not live"`)
- [x] ruff + mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)