### PR TITLE
fix: delegate_task 이중 컨텍스트 주입 제거 — announce=False

### DIFF
--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -230,8 +230,16 @@ class SubAgentManager:
         tasks: list[SubTask],
         *,
         on_progress: Callable[[SubResult], None] | None = None,
+        announce: bool = True,
     ) -> list[SubResult]:
-        """Run multiple sub-tasks in parallel, wait for all."""
+        """Run multiple sub-tasks in parallel, wait for all.
+
+        Args:
+            announce: If False, skip pushing results to the announce queue.
+                Callers that already return full results via tool_result
+                (e.g. delegate_task) should pass announce=False to avoid
+                injecting the same information into the parent context twice.
+        """
         if not tasks:
             return []
 
@@ -349,7 +357,7 @@ class SubAgentManager:
                     rec.outcome = "ok" if sub_result.success else "error"
 
         # Announce completed results to parent (OpenClaw Spawn+Announce)
-        if self._announce_enabled and self._parent_session_key:
+        if announce and self._announce_enabled and self._parent_session_key:
             for sub_result in results:
                 # Build a SubAgentResult for announce (may already be one)
                 summary = ""

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -326,7 +326,11 @@ class ToolExecutor:
                 task_elapsed,
             )
 
-        results = self._sub_agent_manager.delegate(sub_tasks, on_progress=_on_progress)
+        # announce=False: delegate_task returns full results via tool_result,
+        # so skip announce queue to avoid double context injection.
+        results = self._sub_agent_manager.delegate(
+            sub_tasks, on_progress=_on_progress, announce=False
+        )
 
         # Final summary line
         from core.cli.ui.agentic_ui import render_subagent_complete


### PR DESCRIPTION
## Summary
- `delegate_task`(동기) → tool_result로 전체 결과 반환 + announce queue에 summary 중복 push → 부모 컨텍스트에 같은 정보 이중 주입
- `delegate()`에 `announce: bool = True` 파라미터 추가, `_execute_delegate`에서 `announce=False`로 호출
- 비동기 fire-and-forget 경로는 기존대로 `announce=True` 유지

Why: 프론티어(OpenClaw)도 동기 호출에서 announce 안 함. 이중 주입은 컨텍스트 토큰 낭비.

## Test plan
- [x] sub_agent/delegate/announce 관련 테스트 전체 통과
- [x] Full test suite pass (`pytest -m "not live"`)
- [x] ruff + mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)