### PR TITLE
feat: 스케줄 잡 비동기 실행 — IsolatedRunner.run_async() 전환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **스케줄 잡 비동기 실행** — REPL drain loop의 isolated 스케줄 잡을 `IsolatedRunner.run_async()`로 전환. 메인 REPL 스레드 블로킹 해소. OpenClaw agentTurn 패턴: 데몬 스레드에서 fresh AgenticLoop 실행, 완료 시 dim 상태줄 콜백.
 - **MODEL_SWITCHED hook** --- `HookEvent.MODEL_SWITCHED` 추가 (45 -> 46). `AgenticLoop.update_model()` 발화, `bootstrap.py`에 `model_switch_logger` 핸들러 등록.
 - **Filesystem hook plugin auto-discovery** --- `bootstrap.py`에서 `.geode/hooks/` + `core/hooks/plugins/` 자동 스캔 및 등록. `HookPluginLoader`를 부트스트랩에 통합.
 - **README docs-sync** --- 도구(52), Hook(46) 수치를 실측값으로 갱신.

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -923,6 +923,14 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     except Exception:
         log.debug("SchedulerService initialization skipped", exc_info=True)
 
+    # Isolated runner for async scheduled job execution (OpenClaw agentTurn)
+    from core.orchestration.isolated_execution import (
+        IsolatedRunner,
+        IsolationConfig,
+    )
+
+    _sched_runner = IsolatedRunner()
+
     console.print()  # blank line before prompt
 
     # Build tool handlers, executor, and AgenticLoop (shared factory)
@@ -973,6 +981,18 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
             )
             console.print()
 
+    # Completion callback for async scheduled jobs (prints dim status on finish)
+    def _on_sched_complete(result: Any, *, job_id: str) -> None:
+        from core.orchestration.isolated_execution import IsolationResult
+
+        if isinstance(result, IsolationResult):
+            status = "ok" if result.success else "err"
+            summary = result.summary or result.output[:120] or "(no output)"
+        else:
+            status = "ok"
+            summary = str(result)[:120] if result else "(no output)"
+        console.print(f"  [dim]scheduled:{job_id} → {status} — {summary}[/dim]")
+
     while True:
         # Drain scheduled actions before prompting (scheduler fires in background thread)
         try:
@@ -982,21 +1002,41 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                     continue
                 prompt = f"[scheduled-job:{job_id}] {fired_action}"
                 if isolated:
-                    # OpenClaw agentTurn: fresh context, no conversation pollution
-                    console.print(f"\n  [muted]Scheduler (isolated): {job_id}[/muted]")
-                    iso_conv = ConversationContext()
-                    _, _, iso_loop = _build_agentic_stack(
-                        iso_conv,
+                    # OpenClaw agentTurn: async execution in background thread
+                    # Non-blocking — returns immediately, result delivered via callback
+                    _iso_conv = ConversationContext()
+                    _, _, _iso_loop = _build_agentic_stack(
+                        _iso_conv,
                         mcp_manager=mcp_mgr,
                         skill_registry=skill_registry,
-                        verbose=verbose,
+                        verbose=False,
                         quiet=True,
                     )
-                    result = iso_loop.run(prompt)
-                    summary = result.text[:200] if result and result.text else "(no output)"
-                    console.print(f"  [muted]  Result: {summary}[/muted]\n")
+                    _captured_job_id = job_id
+                    _captured_prompt = prompt
+                    _captured_loop = _iso_loop
+
+                    def _run_isolated(
+                        *,
+                        _loop: Any = _captured_loop,
+                        _p: str = _captured_prompt,
+                        _jid: str = _captured_job_id,
+                    ) -> str:
+                        r = _loop.run(_p)
+                        _on_sched_complete(r, job_id=_jid)
+                        return r.text if r and r.text else ""
+
+                    _sched_runner.run_async(
+                        _run_isolated,
+                        config=IsolationConfig(
+                            prefix=f"scheduled:{job_id}",
+                            post_to_main=False,
+                            timeout_s=300.0,
+                        ),
+                    )
+                    console.print(f"  [dim]scheduled:{job_id} → dispatched (async)[/dim]")
                 else:
-                    # OpenClaw systemEvent: inject into main session
+                    # OpenClaw systemEvent: inject into main session (blocking by design)
                     console.print(f"\n  [muted]Scheduler: running job {job_id}[/muted]")
                     agentic.run(prompt)
         except _queue_mod.Empty:

--- a/tests/test_scheduler_async_drain.py
+++ b/tests/test_scheduler_async_drain.py
@@ -1,0 +1,196 @@
+"""Tests for async scheduled job execution via IsolatedRunner.
+
+Verifies that the REPL drain loop dispatches isolated scheduled jobs
+to background threads instead of blocking the main REPL thread.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from core.orchestration.isolated_execution import (
+    IsolatedRunner,
+    IsolationConfig,
+)
+
+
+class TestAsyncScheduledDrain:
+    """Verify non-blocking dispatch of isolated scheduled jobs."""
+
+    def test_run_async_returns_immediately(self) -> None:
+        """run_async() should return a session_id without blocking."""
+        runner = IsolatedRunner()
+        started = time.monotonic()
+
+        def slow_job() -> str:
+            time.sleep(2.0)
+            return "done"
+
+        session_id = runner.run_async(slow_job)
+        elapsed = time.monotonic() - started
+
+        assert session_id  # non-empty string
+        assert elapsed < 0.5  # must return immediately, not wait 2s
+
+        # Wait for completion to avoid dangling threads
+        for _ in range(30):
+            if runner.get_result(session_id) is not None:
+                break
+            time.sleep(0.1)
+        result = runner.get_result(session_id)
+        assert result is not None
+        assert result.success
+
+    def test_multiple_async_jobs_concurrent(self) -> None:
+        """Multiple async jobs should run concurrently, not sequentially."""
+        runner = IsolatedRunner()
+        call_times: list[float] = []
+        lock = threading.Lock()
+
+        def timed_job() -> str:
+            with lock:
+                call_times.append(time.monotonic())
+            time.sleep(0.5)
+            return "ok"
+
+        ids = [runner.run_async(timed_job) for _ in range(3)]
+
+        # Wait for all to complete
+        for sid in ids:
+            for _ in range(20):
+                if runner.get_result(sid) is not None:
+                    break
+                time.sleep(0.1)
+
+        # All 3 should have started within 0.2s of each other (concurrent)
+        assert len(call_times) == 3
+        spread = max(call_times) - min(call_times)
+        assert spread < 0.3, f"Jobs started sequentially (spread={spread:.2f}s)"
+
+    def test_async_job_result_available_after_completion(self) -> None:
+        """Completed async job result should be retrievable via get_result()."""
+        runner = IsolatedRunner()
+
+        def quick_job() -> str:
+            return "hello from scheduled job"
+
+        sid = runner.run_async(quick_job)
+        # Poll for result
+        for _ in range(20):
+            result = runner.get_result(sid)
+            if result is not None:
+                break
+            time.sleep(0.05)
+
+        assert result is not None
+        assert result.success
+        assert "hello from scheduled job" in result.output
+
+    def test_async_job_error_captured(self) -> None:
+        """Errors in async jobs should be captured, not crash the runner."""
+        runner = IsolatedRunner()
+
+        def failing_job() -> str:
+            raise ValueError("scheduled job failed")
+
+        sid = runner.run_async(failing_job)
+        for _ in range(20):
+            result = runner.get_result(sid)
+            if result is not None:
+                break
+            time.sleep(0.05)
+
+        assert result is not None
+        assert not result.success
+        assert "scheduled job failed" in (result.error or "")
+
+    def test_async_job_timeout(self) -> None:
+        """Jobs exceeding timeout should be marked as failed."""
+        runner = IsolatedRunner()
+
+        def stuck_job() -> str:
+            time.sleep(10.0)
+            return "never"
+
+        sid = runner.run_async(
+            stuck_job,
+            config=IsolationConfig(timeout_s=0.5),
+        )
+        for _ in range(30):
+            result = runner.get_result(sid)
+            if result is not None:
+                break
+            time.sleep(0.1)
+
+        assert result is not None
+        assert not result.success
+        assert "Timeout" in (result.error or "")
+
+    def test_post_to_main_disabled(self) -> None:
+        """Scheduled jobs should not post to HookSystem when post_to_main=False."""
+        hooks = MagicMock()
+        runner = IsolatedRunner(hooks=hooks)
+
+        def simple_job() -> str:
+            return "result"
+
+        sid = runner.run_async(
+            simple_job,
+            config=IsolationConfig(post_to_main=False),
+        )
+        for _ in range(20):
+            if runner.get_result(sid) is not None:
+                break
+            time.sleep(0.05)
+
+        # HookSystem.trigger should NOT have been called with PIPELINE_END
+        for call in hooks.trigger.call_args_list:
+            # Allow other hook calls but not PIPELINE_END
+            from core.hooks import HookEvent
+
+            if len(call.args) >= 1 and call.args[0] == HookEvent.PIPELINE_END:
+                pytest.fail("post_to_main=False should suppress PIPELINE_END hook")
+
+    def test_queue_drain_nonblocking_pattern(self) -> None:
+        """Simulate the REPL drain pattern: queue → run_async → immediate return."""
+        action_queue: queue.Queue[tuple[str, str, bool]] = queue.Queue()
+        runner = IsolatedRunner()
+
+        # Enqueue 2 scheduled jobs
+        action_queue.put(("job-1", "do something", True))
+        action_queue.put(("job-2", "do another", True))
+
+        dispatched: list[str] = []
+        started = time.monotonic()
+
+        # Simulate drain loop (isolated path only)
+        try:
+            while True:
+                job_id, action, isolated = action_queue.get_nowait()
+                if not action or not isolated:
+                    continue
+
+                def _run(*, _jid: str = job_id) -> str:
+                    time.sleep(1.0)  # simulate LLM call
+                    return f"result-{_jid}"
+
+                runner.run_async(
+                    _run,
+                    config=IsolationConfig(post_to_main=False, timeout_s=10.0),
+                )
+                dispatched.append(job_id)
+        except queue.Empty:
+            pass
+
+        drain_time = time.monotonic() - started
+
+        # Drain should be near-instant (< 0.3s), not 2s (sequential blocking)
+        assert len(dispatched) == 2
+        assert drain_time < 0.5, f"Drain blocked for {drain_time:.2f}s"
+
+        # Jobs still running in background
+        assert runner.active_count >= 1


### PR DESCRIPTION
## Summary
- REPL drain loop의 isolated 스케줄 잡을 동기(`iso_loop.run()`) → 비동기(`IsolatedRunner.run_async()`)로 전환
- 메인 REPL 스레드 블로킹 해소 — 스케줄 잡 실행 중에도 프롬프트 즉시 복귀
- OpenClaw agentTurn 패턴: 데몬 스레드에서 fresh AgenticLoop 실행, 완료 시 dim 상태줄 콜백

## Why
스케줄 잡이 full AgenticLoop(LLM 호출 포함, 30초+)을 실행하는데, 기존 동기 drain이
메인 REPL을 블로킹하여 사용자 프롬프트 지연 유발. 프론티어 3종(Claude Code, OpenClaw, autoresearch)
GAP 조사 결과, OpenClaw Gateway 패턴(자체 스레드 실행)이 가장 적합.

## Changes
- `core/cli/__init__.py` — drain loop isolated 경로를 `_sched_runner.run_async()` 호출로 교체
- `tests/test_scheduler_async_drain.py` — 비동기 즉시 리턴, 동시성, 에러 캡처, 타임아웃, drain 패턴 테스트 7건

## Test plan
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3277 passed
- [x] 신규 테스트 7건 통과 (test_scheduler_async_drain.py)
- [ ] CI 5/5 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)