### PR TITLE
feat: SharedServices Gateway — single factory + time-based + ContextVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.35.0] — 2026-03-29
+
+### Added
+- **SharedServices Gateway** — single factory for all session modes (REPL/DAEMON/SCHEDULER/FORK). Codex CLI `ThreadManagerState` + OpenClaw Gateway pattern. `create_session(mode)` guarantees identical shared resources across all entry points.
+- **SessionMode enum** — `REPL` (hitl=2, interactive), `DAEMON` (hitl=0, Slack/Discord), `SCHEDULER` (hitl=0, 300s cap), `FORK` (hitl=0, 60s cap).
+
+### Changed
+- **Time-based constraints** — `DEFAULT_MAX_ROUNDS=0` (unlimited) for all modes. `time_budget_s` is the sole execution constraint. `ChannelBinding.max_rounds` replaced by `time_budget_s` (120s default). Legacy `max_rounds` config auto-converted.
+- **GATEWAY → DAEMON** — external channel poller mode renamed to `DAEMON`. "Gateway" now refers to the SharedServices layer.
+
+### Fixed
+- **HookSystem wired** — `build_hooks()` called at bootstrap, injected into every `create_session()`. `_fire_hook()` now works (was permanently None).
+- **Globals → ContextVar** — `_project_memory`, `_user_profile`, `_readiness` converted from module-level globals to `ContextVar`. Thread-safe across DAEMON/SCHEDULER threads.
+- **Scheduler ContextVar propagation** — `propagate_context=True` in `create_session(SCHEDULER)` re-injects domain/memory/profile before job execution.
+
+### Architecture
+- **5 Shared Services GAPs resolved** — HookSystem(CRITICAL→fixed), globals(HIGH→fixed), scheduler propagation(HIGH→fixed), _readiness(MEDIUM→fixed), _result_cache(LOW→already had Lock).
+
 ## [0.34.0] — 2026-03-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.34.0
+- **Version**: 0.35.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 188
+- **Modules**: 189
 - **Tests**: 3344+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
@@ -50,7 +50,7 @@ L5: DOMAIN PLUGINS   — DomainPort Protocol, GameIPDomain, LangGraph StateGraph
 
 Sub-agents inherit parent tools/MCP/skills/memory and execute in parallel within independent contexts.
 `SubAgentManager` → `CoalescingQueue`(250ms dedup) → `TaskGraph`(DAG) → `IsolatedRunner`(MAX_CONCURRENT=5).
-Controls: max_depth=1 (no recursion), max_total=15, timeout=120s, auto_approve=True(STANDARD only), max_rounds=50, max_tokens=32768, time_budget_s=0 (same as parent).
+Controls: max_depth=1 (no recursion), max_total=15, timeout=120s, auto_approve=True(STANDARD only), max_rounds=0 (unlimited), max_tokens=32768, time_budget_s=0 (same as parent, time-based control).
 
 **Memory Isolation Rules:**
 - Sub-agents inherit parent memory snapshots as read-only

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
 
-# GEODE v0.34.0 — Autonomous Execution Harness
+# GEODE v0.35.0 — Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -127,7 +127,7 @@ class AgenticLoop:
         execute tools → feed results back → continue
     """
 
-    DEFAULT_MAX_ROUNDS = 50
+    DEFAULT_MAX_ROUNDS = 0  # 0 = unlimited (time-based control via time_budget_s)
     DEFAULT_MAX_TOKENS = 32768
     WRAP_UP_HEADROOM = 2  # force text response N rounds before max
     _WRAP_UP_TIME_HEADROOM_S = 30.0  # force text 30s before time budget expires

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -157,7 +157,7 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     loop = AgenticLoop(
         conversation,
         executor,
-        max_rounds=50,
+        max_rounds=0,  # unlimited — controlled by timeout_s from parent
         max_tokens=32768,
         model=request.model,
         provider=request.provider,

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -958,12 +958,23 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
     console.print()  # blank line before prompt
 
-    # Build tool handlers, executor, and AgenticLoop (shared factory)
-    _last_verbose = verbose
-    agentic_ref, executor, agentic = _build_agentic_stack(
-        conversation,
+    # Build SharedServices gateway (single factory for all modes)
+    from core.gateway.shared_services import SessionMode, build_shared_services
+
+    services = build_shared_services(
         mcp_manager=mcp_mgr,
         skill_registry=skill_registry,
+        verbose=verbose,
+    )
+
+    # Wire module-level hooks for _fire_hook() callers
+    global _hooks_ctx
+    _hooks_ctx = services.hook_system
+
+    _last_verbose = verbose
+    executor, agentic = services.create_session(
+        SessionMode.REPL,
+        conversation=conversation,
         verbose=verbose,
     )
 
@@ -1038,16 +1049,10 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                         continue
 
                     _iso_conv = ConversationContext()
-                    _, _, _iso_loop = _build_agentic_stack(
-                        _iso_conv,
-                        mcp_manager=mcp_mgr,
-                        skill_registry=skill_registry,
-                        verbose=False,
-                        quiet=True,
-                        hitl_level=0,
-                        cost_budget=agentic._cost_budget,
-                        time_budget_s=min(agentic._time_budget_s or 300.0, 300.0),
-                        hooks=agentic._hooks if hasattr(agentic, "_hooks") else None,
+                    _, _iso_loop = services.create_session(
+                        SessionMode.SCHEDULER,
+                        conversation=_iso_conv,
+                        propagate_context=True,
                     )
                     _captured_job_id = job_id
                     _captured_prompt = prompt
@@ -1136,7 +1141,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
                 verbose,
                 skill_registry=skill_registry,
                 mcp_manager=mcp_mgr,
-                agentic_ref=agentic_ref,
+                agentic_ref=services.agentic_ref,
             )
             if should_break:
                 break
@@ -1156,10 +1161,9 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
             # Update handlers if verbose changed
             if verbose != _last_verbose:
                 _last_verbose = verbose
-                agentic_ref, executor, agentic = _build_agentic_stack(
-                    conversation,
-                    mcp_manager=mcp_mgr,
-                    skill_registry=skill_registry,
+                executor, agentic = services.create_session(
+                    SessionMode.REPL,
+                    conversation=conversation,
                     verbose=verbose,
                 )
         else:
@@ -1730,18 +1734,21 @@ def serve(
         "- Format responses for messaging: use short paragraphs, avoid excessive markdown."
     )
 
-    # Read gateway config from ChannelManager (loaded from config.toml)
-    _gw_max_rounds = gateway.gateway_max_rounds if hasattr(gateway, "gateway_max_rounds") else 30
+    # Build SharedServices for serve mode (same factory as REPL)
+    from core.gateway.shared_services import SessionMode, build_shared_services
+
     _gw_max_turns = gateway.gateway_max_turns if hasattr(gateway, "gateway_max_turns") else 20
+    _gw_services = build_shared_services(
+        mcp_manager=boot.mcp_manager,
+        skill_registry=boot.skill_registry,
+    )
 
     def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:
         """Process a gateway message with multi-turn context.
 
-        Uses the same _build_agentic_stack() factory as REPL — only
-        system_suffix, hitl_level, and quiet differ.
+        Uses SharedServices.create_session(DAEMON) — same shared resources
+        as REPL, only mode-specific behavior differs.
         """
-        boot.propagate_to_thread()  # Fix ContextVar propagation for daemon thread
-
         session_key = metadata.get("session_key", "")
 
         # --- Load prior conversation from session store ---
@@ -1756,15 +1763,12 @@ def serve(
                     session_key,
                 )
 
-        # Same factory as REPL — only output behavior differs
-        _ref, _executor, loop = _build_agentic_stack(
-            ctx,
-            mcp_manager=boot.mcp_manager,
-            skill_registry=boot.skill_registry,
-            hitl_level=0,
-            max_rounds=_gw_max_rounds,
+        # Single factory — DAEMON mode (hitl=0, quiet, time-based)
+        _executor, loop = _gw_services.create_session(
+            SessionMode.DAEMON,
+            conversation=ctx,
             system_suffix=_GATEWAY_SUFFIX,
-            quiet=True,
+            propagate_context=True,
         )
         try:
             result = loop.run(content)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1738,6 +1738,9 @@ def serve(
     from core.gateway.shared_services import SessionMode, build_shared_services
 
     _gw_max_turns = gateway.gateway_max_turns if hasattr(gateway, "gateway_max_turns") else 20
+    _gw_time_budget = (
+        gateway.gateway_time_budget_s if hasattr(gateway, "gateway_time_budget_s") else 120.0
+    )
     _gw_services = build_shared_services(
         mcp_manager=boot.mcp_manager,
         skill_registry=boot.skill_registry,
@@ -1768,6 +1771,7 @@ def serve(
             SessionMode.DAEMON,
             conversation=ctx,
             system_suffix=_GATEWAY_SUFFIX,
+            time_budget_override=_gw_time_budget,
             propagate_context=True,
         )
         try:

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -199,26 +199,36 @@ def bootstrap_geode(
 def _build_agentic_stack_minimal(prompt: str, *, quiet: bool = True) -> Any:
     """Build a minimal isolated AgenticLoop and run a prompt (for context:fork skills).
 
-    Returns AgenticResult. No MCP (prevent subprocess leak), hitl_level=0.
+    Returns AgenticResult.  Uses SharedServices.create_session(FORK) when
+    available, falls back to inline construction for import-time safety.
     """
-    from core.agent.agentic_loop import AgenticLoop
-    from core.agent.conversation import ConversationContext
-    from core.agent.tool_executor import ToolExecutor
-    from core.config import _resolve_provider
-    from core.config import settings as _stk_settings
+    try:
+        from core.gateway.shared_services import SessionMode, build_shared_services
 
-    conversation = ConversationContext()
-    handlers = _build_tool_handlers_for_fork()
-    executor = ToolExecutor(action_handlers=handlers, hitl_level=0)
-    loop = AgenticLoop(
-        conversation,
-        executor,
-        model=_stk_settings.model,
-        provider=_resolve_provider(_stk_settings.model),
-        quiet=quiet,
-        max_rounds=20,
-    )
-    return loop.run(prompt)
+        services = build_shared_services()
+        _executor, loop = services.create_session(SessionMode.FORK)
+        return loop.run(prompt)
+    except Exception:
+        # Fallback: inline construction (no SharedServices available)
+        from core.agent.agentic_loop import AgenticLoop
+        from core.agent.conversation import ConversationContext
+        from core.agent.tool_executor import ToolExecutor
+        from core.config import _resolve_provider
+        from core.config import settings as _stk_settings
+
+        conversation = ConversationContext()
+        handlers = _build_tool_handlers_for_fork()
+        executor = ToolExecutor(action_handlers=handlers, hitl_level=0)
+        loop = AgenticLoop(
+            conversation,
+            executor,
+            model=_stk_settings.model,
+            provider=_resolve_provider(_stk_settings.model),
+            quiet=quiet,
+            time_budget_s=60.0,
+            max_rounds=0,
+        )
+        return loop.run(prompt)
 
 
 def _build_tool_handlers_for_fork() -> dict[str, Any]:

--- a/core/cli/session_state.py
+++ b/core/cli/session_state.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 # Thread-safe singletons for REPL session via contextvars
 _search_engine_ctx: ContextVar[Any] = ContextVar("search_engine", default=None)
-_readiness: Any = None
+_readiness_ctx: ContextVar[Any] = ContextVar("readiness", default=None)
 _scheduler_service_ctx: ContextVar[Any] = ContextVar("scheduler_service", default=None)
 _user_task_graph_ctx: ContextVar[Any] = ContextVar("user_task_graph", default=None)
 
@@ -121,14 +121,13 @@ def _get_search_engine() -> IPSearchEngine:
 
 
 def _get_readiness() -> ReadinessReport | None:
-    """Get the module-level ReadinessReport."""
-    return cast("ReadinessReport | None", _readiness)
+    """Get the context-local ReadinessReport."""
+    return cast("ReadinessReport | None", _readiness_ctx.get())
 
 
 def _set_readiness(report: ReadinessReport) -> None:
-    """Set the module-level ReadinessReport."""
-    global _readiness
-    _readiness = report
+    """Set the context-local ReadinessReport."""
+    _readiness_ctx.set(report)
 
 
 def _get_last_result() -> dict[str, Any] | None:

--- a/core/config.py
+++ b/core/config.py
@@ -222,7 +222,7 @@ class Settings(BaseSettings):
     # Sub-Agent Orchestration (P2)
     max_subagent_depth: int = 1  # 최대 재귀 깊이 (depth=1 강제, Claude Code 패턴)
     max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
-    subagent_max_rounds: int = 50  # 서브에이전트 agentic loop 라운드 제한 (부모와 동일)
+    subagent_max_rounds: int = 0  # 0 = unlimited (time-based control)
     subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
 
     # Token Guard — tool result truncation threshold (0 = unlimited)

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -53,7 +53,7 @@ class ChannelManager:
         self._lock = threading.Lock()
         self._stats: dict[str, int] = {"received": 0, "processed": 0, "ignored": 0}
         # Gateway-level defaults (overridden by config.toml [gateway])
-        self.gateway_max_rounds: int = 30
+        self.gateway_time_budget_s: float = 120.0  # default 2 min per message
         self.gateway_max_turns: int = 20
 
     def register_poller(self, poller: BasePoller) -> None:
@@ -227,7 +227,7 @@ class ChannelManager:
                     "channel_id": b.channel_id or "*",
                     "auto_respond": b.auto_respond,
                     "require_mention": b.require_mention,
-                    "max_rounds": b.max_rounds,
+                    "time_budget_s": b.time_budget_s,
                 }
                 for b in self._bindings
             ]
@@ -251,8 +251,11 @@ class ChannelManager:
         gw = config.get("gateway", {})
 
         # Gateway-level defaults
-        if "max_rounds" in gw:
-            self.gateway_max_rounds = int(gw["max_rounds"])
+        if "time_budget_s" in gw:
+            self.gateway_time_budget_s = float(gw["time_budget_s"])
+        elif "max_rounds" in gw:
+            # Legacy: convert max_rounds to approximate time budget (10s/round)
+            self.gateway_time_budget_s = float(int(gw["max_rounds"]) * 10)
         if "max_turns" in gw:
             self.gateway_max_turns = int(gw["max_turns"])
 
@@ -263,28 +266,32 @@ class ChannelManager:
         with self._lock:
             self._bindings.clear()
 
-        # Per-binding max_rounds falls back to gateway-level default
-        default_max_rounds = self.gateway_max_rounds
+        # Per-binding time_budget_s falls back to gateway-level default
+        default_time_budget = self.gateway_time_budget_s
 
         loaded = 0
         for rule in rules:
             if not isinstance(rule, dict) or "channel" not in rule:
                 continue
+            # Support both time_budget_s and legacy max_rounds
+            tb = rule.get("time_budget_s")
+            if tb is None and "max_rounds" in rule:
+                tb = float(int(rule["max_rounds"]) * 10)
             binding = ChannelBinding(
                 channel=rule["channel"],
                 channel_id=rule.get("channel_id", ""),
                 auto_respond=rule.get("auto_respond", True),
                 require_mention=rule.get("require_mention", False),
                 allowed_tools=rule.get("allowed_tools", []),
-                max_rounds=rule.get("max_rounds", default_max_rounds),
+                time_budget_s=float(tb) if tb is not None else default_time_budget,
             )
             self.add_binding(binding)
             loaded += 1
 
         log.info(
-            "Loaded %d gateway bindings from config (max_rounds=%d, max_turns=%d)",
+            "Loaded %d gateway bindings from config (time_budget=%.0fs, max_turns=%d)",
             loaded,
-            self.gateway_max_rounds,
+            self.gateway_time_budget_s,
             self.gateway_max_turns,
         )
         return loaded

--- a/core/gateway/models.py
+++ b/core/gateway/models.py
@@ -33,5 +33,4 @@ class ChannelBinding:
     auto_respond: bool = True  # Auto-send response back to channel
     require_mention: bool = False  # Only respond when @mentioned
     allowed_tools: list[str] = field(default_factory=list)  # Empty = all tools
-    max_rounds: int = 5  # AgenticLoop round limit for gateway messages
-    time_budget_s: float = 0.0  # Wall-clock timeout (0 = use max_rounds only)
+    time_budget_s: float = 120.0  # Wall-clock timeout per message (seconds)

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -1,0 +1,261 @@
+"""SharedServices — single factory for all session modes.
+
+Owns process-level singletons (MCP, skills, hooks, tool handlers).
+Each entry point (REPL, daemon, scheduler, fork) calls ``create_session()``
+with a ``SessionMode`` to get identically-wired ``(ToolExecutor, AgenticLoop)``.
+
+Inspired by:
+- Codex CLI ``ThreadManagerState`` + ``SessionServices`` (two-tier ownership)
+- OpenClaw Gateway (single owner, all paths converge)
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.agent.agentic_loop import AgenticLoop
+    from core.agent.tool_executor import ToolExecutor
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Session mode enum
+# ---------------------------------------------------------------------------
+
+
+class SessionMode(StrEnum):
+    """Execution mode — determines behavior defaults, not shared resources."""
+
+    REPL = "repl"  # Interactive — hitl=2, verbose=user, time=unlimited
+    DAEMON = "daemon"  # Slack/Discord poller — hitl=0, quiet, time=config
+    SCHEDULER = "scheduler"  # Cron/scheduled jobs — hitl=0, quiet, time=300s cap
+    FORK = "fork"  # Skill context:fork — hitl=0, quiet, time=60s
+
+
+# ---------------------------------------------------------------------------
+# Mode-specific defaults (no max_rounds — time only)
+# ---------------------------------------------------------------------------
+
+_MODE_DEFAULTS: dict[SessionMode, dict[str, Any]] = {
+    SessionMode.REPL: {
+        "hitl_level": 2,
+        "quiet": False,
+        "time_budget_s": 0.0,  # unlimited (interactive)
+        "max_rounds": 0,  # unlimited
+    },
+    SessionMode.DAEMON: {
+        "hitl_level": 0,
+        "quiet": True,
+        "time_budget_s": 0.0,  # resolved from config at runtime
+        "max_rounds": 0,
+    },
+    SessionMode.SCHEDULER: {
+        "hitl_level": 0,
+        "quiet": True,
+        "time_budget_s": 300.0,  # 5 min cap
+        "max_rounds": 0,
+    },
+    SessionMode.FORK: {
+        "hitl_level": 0,
+        "quiet": True,
+        "time_budget_s": 60.0,
+        "max_rounds": 0,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# SharedServices
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SharedServices:
+    """Process-level singleton owning all shared resources.
+
+    Constructed once at bootstrap time.  Every ``create_session()`` call
+    returns a fully-wired ``(ToolExecutor, AgenticLoop)`` pair that
+    automatically receives hooks, MCP, skills, cost budget, and time budget.
+
+    The ``agentic_ref`` is a mutable ``[loop]`` list shared across handler
+    closures — ``create_session()`` updates ``ref[0]`` to the latest loop,
+    so tool handlers (e.g. ``install_mcp_server``) always see the current one.
+    """
+
+    mcp_manager: Any = None
+    skill_registry: Any = None
+    hook_system: Any = None  # HookSystem — never None after init
+    tool_handlers: dict[str, Any] = field(default_factory=dict)
+    agentic_ref: list[Any] = field(default_factory=lambda: [None])
+
+    # Resolved once at bootstrap
+    _model: str = ""
+    _provider: str = "anthropic"
+    _cost_budget: float = 0.0
+
+    # --- public API -----------------------------------------------------------
+
+    def create_session(
+        self,
+        mode: SessionMode,
+        *,
+        conversation: Any | None = None,
+        system_suffix: str = "",
+        time_budget_override: float | None = None,
+        verbose: bool = False,
+        propagate_context: bool = False,
+    ) -> tuple[ToolExecutor, AgenticLoop]:
+        """Build a fully-wired (ToolExecutor, AgenticLoop) for *mode*.
+
+        Every call receives identical shared resources (hooks, MCP, skills,
+        cost_budget).  Only mode-specific behavior differs.
+        """
+        from core.agent.agentic_loop import AgenticLoop
+        from core.agent.tool_executor import ToolExecutor
+
+        if propagate_context:
+            self._propagate_contextvars()
+
+        # Resolve defaults for this mode
+        defaults = _MODE_DEFAULTS[mode]
+        hitl = defaults["hitl_level"]
+        quiet = defaults["quiet"]
+        time_budget = (
+            time_budget_override if time_budget_override is not None else defaults["time_budget_s"]
+        )
+        max_rounds = defaults["max_rounds"]
+
+        if mode == SessionMode.REPL:
+            quiet = not verbose
+
+        # Conversation context
+        if conversation is None:
+            from core.agent.conversation import ConversationContext
+
+            conversation = ConversationContext()
+
+        # Build sub-agent manager + executor + loop
+        sub_mgr = self._build_sub_agent_manager()
+        executor = ToolExecutor(
+            action_handlers=self.tool_handlers,
+            mcp_manager=self.mcp_manager,
+            sub_agent_manager=sub_mgr,
+            hitl_level=hitl,
+            hooks=self.hook_system,
+        )
+        loop = AgenticLoop(
+            conversation,
+            executor,
+            max_rounds=max_rounds,
+            time_budget_s=time_budget,
+            cost_budget=self._cost_budget,
+            model=self._model,
+            provider=self._provider,
+            mcp_manager=self.mcp_manager,
+            skill_registry=self.skill_registry,
+            hooks=self.hook_system,
+            system_suffix=system_suffix,
+            quiet=quiet,
+        )
+        # Update mutable ref so tool handler closures see the latest loop
+        self.agentic_ref[0] = loop
+        return executor, loop
+
+    # --- internal helpers -----------------------------------------------------
+
+    def _build_sub_agent_manager(self) -> Any:
+        """Build SubAgentManager with shared resources."""
+        from core.agent.sub_agent import SubAgentManager
+        from core.config import settings
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        return SubAgentManager(
+            IsolatedRunner(hooks=self.hook_system),
+            action_handlers=self.tool_handlers,
+            mcp_manager=self.mcp_manager,
+            skill_registry=self.skill_registry,
+            hooks=self.hook_system,
+            max_depth=settings.max_subagent_depth,
+        )
+
+    def _propagate_contextvars(self) -> None:
+        """Re-inject ContextVars for daemon/scheduler threads."""
+        from core.cli.bootstrap import GeodeBootstrap
+
+        boot = GeodeBootstrap(
+            mcp_manager=self.mcp_manager,
+            skill_registry=self.skill_registry,
+            readiness=None,
+        )
+        boot.propagate_to_thread()
+
+
+# ---------------------------------------------------------------------------
+# Factory — build SharedServices from bootstrap
+# ---------------------------------------------------------------------------
+
+
+def build_shared_services(
+    *,
+    mcp_manager: Any = None,
+    skill_registry: Any = None,
+    hook_system: Any = None,
+    verbose: bool = False,
+) -> SharedServices:
+    """Construct SharedServices with resolved config values.
+
+    Builds tool handlers with a shared ``agentic_ref`` so handler closures
+    always see the current AgenticLoop.  If *hook_system* is None, a default
+    HookSystem is built via ``build_hooks()``.
+    """
+    from core.config import _resolve_provider
+    from core.config import settings as _settings
+
+    # Build hooks if not provided
+    if hook_system is None:
+        from core.runtime_wiring.bootstrap import build_hooks
+
+        hook_system, _run_log, _stuck = build_hooks(
+            session_key=f"geode-{uuid.uuid4().hex[:8]}",
+            run_id=uuid.uuid4().hex[:12],
+            log_dir=Path.home() / ".geode" / "runs",
+            stuck_timeout_s=getattr(_settings, "stuck_timeout_s", 600.0),
+        )
+
+    # Build tool handlers with shared agentic_ref
+    agentic_ref: list[Any] = [None]
+    from core.cli.tool_handlers import _build_tool_handlers
+
+    tool_handlers = _build_tool_handlers(
+        verbose=verbose,
+        mcp_manager=mcp_manager,
+        agentic_ref=agentic_ref,
+        skill_registry=skill_registry,
+    )
+
+    # Resolve cost budget
+    cost_budget = 0.0
+    try:
+        from core.cli.commands import _get_cost_budget
+
+        cost_budget = _get_cost_budget()
+    except Exception:
+        log.debug("Cost budget resolution failed, using 0 (unlimited)")
+
+    return SharedServices(
+        mcp_manager=mcp_manager,
+        skill_registry=skill_registry,
+        hook_system=hook_system,
+        tool_handlers=tool_handlers,
+        agentic_ref=agentic_ref,
+        _model=_settings.model,
+        _provider=_resolve_provider(_settings.model),
+        _cost_budget=cost_budget,
+    )

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -195,7 +195,7 @@ def build_hooks(
         from core.tools import memory_tools
 
         def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
-            pm = memory_tools._project_memory
+            pm = memory_tools._project_memory_ctx.get()
             if pm is None:
                 return
             text = data.get("text", "")

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -27,7 +27,9 @@ log = logging.getLogger(__name__)
 _default_session_store_ctx: ContextVar[SessionStorePort | None] = ContextVar(
     "default_session_store", default=None
 )
-_project_memory: ProjectMemory | None = None
+_project_memory_ctx: ContextVar[ProjectMemory | None] = ContextVar(
+    "project_memory_tools", default=None
+)
 _org_memory_ctx: ContextVar[MonoLakeOrganizationMemory | None] = ContextVar(
     "org_memory_tools", default=None
 )
@@ -39,9 +41,8 @@ def set_default_session_store(store: SessionStorePort) -> None:
 
 
 def set_project_memory(mem: ProjectMemory | None) -> None:
-    """Set the module-level project memory for memory tools."""
-    global _project_memory
-    _project_memory = mem
+    """Set the context-local project memory for memory tools."""
+    _project_memory_ctx.set(mem)
 
 
 def set_org_memory(mem: MonoLakeOrganizationMemory | None) -> None:
@@ -135,7 +136,7 @@ class MemorySearchTool:
 
         # Project tier (MEMORY.md + rules)
         if tier in ("project", "all") and len(matches) < limit:
-            proj = _project_memory
+            proj = _project_memory_ctx.get()
             if proj is not None:
                 # Search MEMORY.md content
                 memory_text = proj.load_memory()
@@ -310,7 +311,7 @@ class MemorySaveTool:
 
         # Persistent write to MEMORY.md (P1.5)
         if persistent:
-            proj = _project_memory
+            proj = _project_memory_ctx.get()
             if proj is not None:
                 from core.memory.project import ProjectMemory
 
@@ -375,7 +376,7 @@ class RuleCreateTool:
         paths: list[str] = kwargs["paths"]
         content: str = kwargs["content"]
 
-        proj = _project_memory
+        proj = _project_memory_ctx.get()
         if proj is None:
             return {"result": {"created": False, "error": "Project memory not available"}}
 
@@ -424,7 +425,7 @@ class RuleUpdateTool:
         rule_name: str = kwargs["name"]
         content: str = kwargs["content"]
 
-        proj = _project_memory
+        proj = _project_memory_ctx.get()
         if proj is None:
             return {"result": {"updated": False, "error": "Project memory not available"}}
 
@@ -464,7 +465,7 @@ class RuleDeleteTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         rule_name: str = kwargs["name"]
 
-        proj = _project_memory
+        proj = _project_memory_ctx.get()
         if proj is None:
             return {"result": {"deleted": False, "error": "Project memory not available"}}
 
@@ -499,7 +500,7 @@ class RuleListTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        proj = _project_memory
+        proj = _project_memory_ctx.get()
         if proj is None:
             return {"result": {"rules": [], "error": "Project memory not available"}}
 
@@ -530,7 +531,7 @@ class NoteSaveTool:
         key: str = kwargs["key"]
         content: str = kwargs["content"]
 
-        proj = _project_memory
+        proj = _project_memory_ctx.get()
         if proj is None:
             return {"error": "Project memory not available"}
 
@@ -561,7 +562,7 @@ class NoteReadTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         query: str = kwargs.get("query", "")
 
-        proj = _project_memory
+        proj = _project_memory_ctx.get()
         if proj is None:
             return {"error": "Project memory not available"}
 

--- a/core/tools/profile_tools.py
+++ b/core/tools/profile_tools.py
@@ -10,25 +10,27 @@ Tools for viewing, updating, and learning from user interactions:
 from __future__ import annotations
 
 import logging
+from contextvars import ContextVar
 from typing import Any
 
 from core.memory.user_profile import FileBasedUserProfile
 
 log = logging.getLogger(__name__)
 
-# Module-level user profile singleton
-_user_profile: FileBasedUserProfile | None = None
+# Thread-safe user profile via ContextVar
+_user_profile_ctx: ContextVar[FileBasedUserProfile | None] = ContextVar(
+    "user_profile_tools", default=None
+)
 
 
 def set_user_profile(profile: FileBasedUserProfile | None) -> None:
-    """Set the module-level user profile for profile tools."""
-    global _user_profile
-    _user_profile = profile
+    """Set the context-local user profile for profile tools."""
+    _user_profile_ctx.set(profile)
 
 
 def get_user_profile() -> FileBasedUserProfile | None:
-    """Get the module-level user profile."""
-    return _user_profile
+    """Get the context-local user profile."""
+    return _user_profile_ctx.get()
 
 
 class ProfileShowTool:
@@ -54,7 +56,7 @@ class ProfileShowTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile
+        profile = _user_profile_ctx.get()
         if profile is None:
             return {"error": "User profile not configured"}
 
@@ -120,7 +122,7 @@ class ProfileUpdateTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile
+        profile = _user_profile_ctx.get()
         if profile is None:
             return {"error": "User profile not configured"}
 
@@ -171,7 +173,7 @@ class ProfilePreferenceTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile
+        profile = _user_profile_ctx.get()
         if profile is None:
             return {"error": "User profile not configured"}
 
@@ -233,7 +235,7 @@ class ProfileLearnTool:
         }
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
-        profile = _user_profile
+        profile = _user_profile_ctx.get()
         if profile is None:
             return {"error": "User profile not configured"}
 

--- a/docs/plans/shared-services-gateway.md
+++ b/docs/plans/shared-services-gateway.md
@@ -1,0 +1,16 @@
+# Plan: SharedServices Gateway
+
+> Single factory for REPL/DAEMON/SCHEDULER/FORK sessions.
+> All entry points share the same resources, differ only in mode-specific behavior.
+
+## Phases
+
+- Phase 1: Gateway Foundation — SharedServices + SessionMode + create_session()
+- Phase 2: Time-Based Constraints — max_rounds=0, time_budget_s per mode
+- Phase 3: ContextVar + Thread Safety — globals→ContextVar, _readiness Lock
+
+## Frontier Evidence
+
+Codex ThreadManagerState + SessionServices, OpenClaw Gateway, Claude Code f8 + AppState.
+
+## Validation: 5-persona (Beck/Karpathy/Steinberger/Cherny/GAP Detective)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.34.0"
+version = "0.35.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -287,8 +287,8 @@ class TestAgenticLoop:
         assert context.turn_count >= 1
 
     def test_default_max_rounds(self) -> None:
-        """Verify DEFAULT_MAX_ROUNDS is 50 (1M context + clear_tool_uses)."""
-        assert AgenticLoop.DEFAULT_MAX_ROUNDS == 50
+        """Verify DEFAULT_MAX_ROUNDS is 0 (unlimited — time-based control)."""
+        assert AgenticLoop.DEFAULT_MAX_ROUNDS == 0
 
     def test_forced_text_on_last_round(
         self, context: ConversationContext, executor: ToolExecutor

--- a/tests/test_cli_bootstrap.py
+++ b/tests/test_cli_bootstrap.py
@@ -54,7 +54,7 @@ class TestPropagateToThread:
         def worker() -> None:
             try:
                 boot.propagate_to_thread()
-                results["project"] = _mem_mod._project_memory
+                results["project"] = _mem_mod._project_memory_ctx.get()
                 results["org"] = _org_memory_ctx.get()
             except Exception as exc:
                 errors.append(exc)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -45,7 +45,7 @@ class TestChannelBinding:
         binding = ChannelBinding(channel="slack")
         assert binding.auto_respond is True
         assert binding.require_mention is False
-        assert binding.max_rounds == 5
+        assert binding.time_budget_s == 120.0
         assert binding.channel_id == ""
 
     def test_specific_binding(self):
@@ -53,7 +53,7 @@ class TestChannelBinding:
             channel="discord",
             channel_id="123456",
             require_mention=True,
-            max_rounds=3,
+            time_budget_s=60.0,
         )
         assert binding.channel_id == "123456"
         assert binding.require_mention is True
@@ -104,7 +104,7 @@ class TestChannelManager:
         # Add generic binding
         manager.add_binding(ChannelBinding(channel="slack"))
         # Add specific binding
-        manager.add_binding(ChannelBinding(channel="slack", channel_id="C12345", max_rounds=10))
+        manager.add_binding(ChannelBinding(channel="slack", channel_id="C12345", time_budget_s=60.0))
 
         msg = InboundMessage(
             channel="slack",

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from core.gateway.shared_services import (
+    _MODE_DEFAULTS,
     SessionMode,
     SharedServices,
-    _MODE_DEFAULTS,
     build_shared_services,
 )
 

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -1,0 +1,173 @@
+"""Tests for core.gateway.shared_services — SharedServices + SessionMode."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.gateway.shared_services import (
+    SessionMode,
+    SharedServices,
+    _MODE_DEFAULTS,
+    build_shared_services,
+)
+
+
+class TestSessionMode:
+    """SessionMode enum values and completeness."""
+
+    def test_four_modes_exist(self) -> None:
+        assert set(SessionMode) == {"repl", "daemon", "scheduler", "fork"}
+
+    def test_all_modes_have_defaults(self) -> None:
+        for mode in SessionMode:
+            assert mode in _MODE_DEFAULTS, f"Missing defaults for {mode}"
+
+    def test_repl_is_interactive(self) -> None:
+        d = _MODE_DEFAULTS[SessionMode.REPL]
+        assert d["hitl_level"] == 2
+        assert d["quiet"] is False
+
+    def test_daemon_is_headless(self) -> None:
+        d = _MODE_DEFAULTS[SessionMode.DAEMON]
+        assert d["hitl_level"] == 0
+        assert d["quiet"] is True
+
+    def test_scheduler_has_time_cap(self) -> None:
+        d = _MODE_DEFAULTS[SessionMode.SCHEDULER]
+        assert d["time_budget_s"] == 300.0
+        assert d["max_rounds"] == 0  # unlimited rounds, time-based only
+
+    def test_fork_has_short_timeout(self) -> None:
+        d = _MODE_DEFAULTS[SessionMode.FORK]
+        assert d["time_budget_s"] == 60.0
+
+    def test_no_mode_uses_nonzero_max_rounds(self) -> None:
+        """All modes use time-based constraints, not round limits."""
+        for mode, defaults in _MODE_DEFAULTS.items():
+            assert defaults["max_rounds"] == 0, f"{mode} has max_rounds={defaults['max_rounds']}"
+
+
+class TestSharedServicesCreateSession:
+    """SharedServices.create_session() wiring guarantees."""
+
+    @pytest.fixture()
+    def services(self) -> SharedServices:
+        """Minimal SharedServices with mocked hook_system."""
+        return SharedServices(
+            mcp_manager=MagicMock(),
+            skill_registry=MagicMock(),
+            hook_system=MagicMock(),
+            tool_handlers={"test_tool": lambda **kw: {"ok": True}},
+            agentic_ref=[None],
+            _model="claude-sonnet-4-6",
+            _provider="anthropic",
+            _cost_budget=5.0,
+        )
+
+    def test_hooks_always_non_none(self, services: SharedServices) -> None:
+        """Every mode receives hook_system — never None."""
+        for mode in SessionMode:
+            executor, loop = services.create_session(mode)
+            assert loop._hooks is not None
+            assert loop._hooks is services.hook_system
+
+    def test_mcp_shared_across_modes(self, services: SharedServices) -> None:
+        """All modes receive the same MCP manager instance."""
+        _, loop_repl = services.create_session(SessionMode.REPL)
+        _, loop_daemon = services.create_session(SessionMode.DAEMON)
+        assert loop_repl._mcp_manager is loop_daemon._mcp_manager
+        assert loop_repl._mcp_manager is services.mcp_manager
+
+    def test_cost_budget_shared(self, services: SharedServices) -> None:
+        """All modes receive the same cost budget."""
+        _, loop = services.create_session(SessionMode.SCHEDULER)
+        assert loop._cost_budget == 5.0
+
+    def test_repl_hitl_2(self, services: SharedServices) -> None:
+        executor, _ = services.create_session(SessionMode.REPL)
+        assert executor._hitl_level == 2
+
+    def test_daemon_hitl_0(self, services: SharedServices) -> None:
+        executor, _ = services.create_session(SessionMode.DAEMON)
+        assert executor._hitl_level == 0
+
+    def test_scheduler_time_budget(self, services: SharedServices) -> None:
+        _, loop = services.create_session(SessionMode.SCHEDULER)
+        assert loop._time_budget_s == 300.0
+
+    def test_fork_time_budget(self, services: SharedServices) -> None:
+        _, loop = services.create_session(SessionMode.FORK)
+        assert loop._time_budget_s == 60.0
+
+    def test_time_budget_override(self, services: SharedServices) -> None:
+        _, loop = services.create_session(
+            SessionMode.DAEMON, time_budget_override=120.0
+        )
+        assert loop._time_budget_s == 120.0
+
+    def test_system_suffix_passed(self, services: SharedServices) -> None:
+        _, loop = services.create_session(
+            SessionMode.DAEMON, system_suffix="gateway instructions"
+        )
+        assert "gateway instructions" in loop._system_suffix
+
+    def test_agentic_ref_updated(self, services: SharedServices) -> None:
+        """create_session updates the shared agentic_ref."""
+        _, loop1 = services.create_session(SessionMode.REPL)
+        assert services.agentic_ref[0] is loop1
+        _, loop2 = services.create_session(SessionMode.DAEMON)
+        assert services.agentic_ref[0] is loop2
+
+    def test_conversation_injected(self, services: SharedServices) -> None:
+        from core.agent.conversation import ConversationContext
+
+        ctx = ConversationContext()
+        _, loop = services.create_session(SessionMode.REPL, conversation=ctx)
+        assert loop.context is ctx
+
+    def test_fresh_conversation_when_none(self, services: SharedServices) -> None:
+        _, loop = services.create_session(SessionMode.SCHEDULER)
+        assert loop.context is not None
+
+    def test_max_rounds_zero_for_all_modes(self, services: SharedServices) -> None:
+        """No mode caps rounds — time is the only constraint."""
+        for mode in SessionMode:
+            _, loop = services.create_session(mode)
+            assert loop.max_rounds == 0, f"{mode} has max_rounds={loop.max_rounds}"
+
+    def test_propagate_context_calls_propagate(self, services: SharedServices) -> None:
+        with patch.object(services, "_propagate_contextvars") as mock_prop:
+            services.create_session(SessionMode.SCHEDULER, propagate_context=True)
+            mock_prop.assert_called_once()
+
+    def test_no_propagate_by_default(self, services: SharedServices) -> None:
+        with patch.object(services, "_propagate_contextvars") as mock_prop:
+            services.create_session(SessionMode.REPL)
+            mock_prop.assert_not_called()
+
+
+class TestBuildSharedServices:
+    """build_shared_services() factory integration."""
+
+    def test_returns_shared_services(self) -> None:
+        services = build_shared_services()
+        assert isinstance(services, SharedServices)
+
+    def test_hook_system_auto_created(self) -> None:
+        services = build_shared_services()
+        assert services.hook_system is not None
+
+    def test_tool_handlers_populated(self) -> None:
+        services = build_shared_services()
+        assert len(services.tool_handlers) > 0
+
+    def test_model_resolved(self) -> None:
+        services = build_shared_services()
+        assert services._model != ""
+
+    def test_explicit_hook_system_used(self) -> None:
+        mock_hooks = MagicMock()
+        services = build_shared_services(hook_system=mock_hooks)
+        assert services.hook_system is mock_hooks

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **SharedServices Gateway** — single `create_session(mode)` factory for REPL/DAEMON/SCHEDULER/FORK. Codex CLI `ThreadManagerState` + OpenClaw Gateway pattern.
- **Time-based constraints** — `DEFAULT_MAX_ROUNDS=0`. `time_budget_s` is the sole execution constraint. `ChannelBinding.max_rounds` → `time_budget_s`.
- **HookSystem wired** — `build_hooks()` at bootstrap, injected into every session. `_fire_hook()` now works.
- **Globals → ContextVar** — `_project_memory`, `_user_profile`, `_readiness`. Thread-safe across DAEMON/SCHEDULER.
- **5 Shared Services GAPs resolved** — all CRITICAL/HIGH items from v0.34.0 audit.

## Why
3 entry points (REPL/serve/scheduler) called `_build_agentic_stack()` with manually specified params. hooks=None in 3/4 sites, cost_budget missing in 2/4, ContextVar not propagated in 1/4. Frontier research confirmed 3/3 harnesses (Codex/OpenClaw/Claude Code) have single-factory pattern.

## Test plan
- [x] 3371 tests pass (3344 existing + 27 new SharedServices tests)
- [x] E2E: `Cowboy Bebop --dry-run` → A (68.4) unchanged
- [x] lint (ruff) + type (mypy) clean
- [ ] Verification team 5-persona review (Beck/Karpathy/Steinberger/Cherny/GAP Detective)

🤖 Generated with [Claude Code](https://claude.com/claude-code)