### PR TITLE
fix: CI guardrail 정상화 — ruff format + bandit nosec

### DIFF
--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -13,7 +13,7 @@ import dataclasses
 import json
 import logging
 import os
-import subprocess
+import subprocess  # nosec B404 — subprocess used for controlled worker process spawn only
 import sys
 import threading
 import time
@@ -98,9 +98,17 @@ class IsolatedRunner:
     # Subprocess env whitelist — only these vars are forwarded to child processes.
     # Prevents accidental leakage of secrets or shell-specific vars.
     _SUBPROCESS_ENV_WHITELIST: set[str] = {
-        "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM",
-        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "ZHIPUAI_API_KEY",
-        "PYTHONPATH", "VIRTUAL_ENV",
+        "PATH",
+        "HOME",
+        "USER",
+        "LANG",
+        "LC_ALL",
+        "TERM",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "ZHIPUAI_API_KEY",
+        "PYTHONPATH",
+        "VIRTUAL_ENV",
     }
 
     def __init__(self, hooks: HookSystem | None = None) -> None:
@@ -390,11 +398,8 @@ class IsolatedRunner:
         proc: subprocess.Popen[bytes] | None = None
 
         try:
-            safe_env = {
-                k: v for k, v in os.environ.items()
-                if k in self._SUBPROCESS_ENV_WHITELIST
-            }
-            proc = subprocess.Popen(  # noqa: S603 — fixed args, no untrusted input
+            safe_env = {k: v for k, v in os.environ.items() if k in self._SUBPROCESS_ENV_WHITELIST}
+            proc = subprocess.Popen(  # noqa: S603  # nosec B603 — fixed args, no untrusted input
                 [sys.executable, "-m", "core.agent.worker"],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -104,7 +104,9 @@ class TestChannelManager:
         # Add generic binding
         manager.add_binding(ChannelBinding(channel="slack"))
         # Add specific binding
-        manager.add_binding(ChannelBinding(channel="slack", channel_id="C12345", time_budget_s=60.0))
+        manager.add_binding(
+            ChannelBinding(channel="slack", channel_id="C12345", time_budget_s=60.0)
+        )
 
         msg = InboundMessage(
             channel="slack",

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -92,15 +92,11 @@ class TestSharedServicesCreateSession:
         assert loop._time_budget_s == 300.0
 
     def test_time_budget_override(self, services: SharedServices) -> None:
-        _, loop = services.create_session(
-            SessionMode.DAEMON, time_budget_override=120.0
-        )
+        _, loop = services.create_session(SessionMode.DAEMON, time_budget_override=120.0)
         assert loop._time_budget_s == 120.0
 
     def test_system_suffix_passed(self, services: SharedServices) -> None:
-        _, loop = services.create_session(
-            SessionMode.DAEMON, system_suffix="gateway instructions"
-        )
+        _, loop = services.create_session(SessionMode.DAEMON, system_suffix="gateway instructions")
         assert "gateway instructions" in loop._system_suffix
 
     def test_current_loop_ctx_set(self, services: SharedServices) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -129,7 +129,9 @@ class TestWorkerSubprocess:
         assert result["success"] is False
         assert "task_id" in result.get("error", "").lower() or result["task_id"] == "unknown"
 
-    def test_result_backup_file_created(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_result_backup_file_created(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Worker should save a backup result file."""
         monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
         # Import and call main directly to test backup


### PR DESCRIPTION
## 요약

PR #523~#526에서 CI Lint & Format / Security Scan이 FAILURE 상태에서 머지된 래칫 위반 수정.
ruff format 미적용 파일 5개 포맷팅 + bandit B404/B603 nosec 주석 추가.

## 변경 사항

### 핵심 변경 (코드)
- `core/orchestration/isolated_execution.py:16`: `import subprocess` — `# nosec B404` 주석 추가
  - 근거: 제어된 worker 프로세스 spawn 전용, 외부 입력 없음
- `core/orchestration/isolated_execution.py:377`: `subprocess.Popen` — `# nosec B603` 주석 추가
  - 근거: 고정 인자(`sys.executable`, `"-m"`, `"core.agent.worker"`)만 사용

### 부수 변경 (코드)
- `tests/test_gateway.py`: ruff format (line-length)
- `tests/test_shared_services.py`: ruff format (line-length)
- `tests/test_worker.py`: ruff format (line-length)

### 문서/설정 변경
- 없음 (PATCH 수준 수정, CHANGELOG 해당 없음)

## 영향 범위
- **영향받는 모듈**: `core/orchestration/isolated_execution.py` (주석만), `tests/` (포맷만)
- **하위 호환성**: 유지
- **테스트 변경**: 포맷 변경만, 로직 변경 없음

## 설계 판단
- 단순 수정, 설계 판단 불필요.

## Pre-PR Quality Gate (실제 실행 결과)
- [x] `ruff check` — 0 errors
- [x] `ruff format --check` — 352 files OK
- [x] `mypy core/` — Success (189 source files)
- [x] `bandit -r core/` — 0 issues
- [x] `pytest -m "not live"` — **3369 passed** in 61s

🤖 Generated with [Claude Code](https://claude.com/claude-code)