### PR TITLE
fix: P1 batch — 5 verification findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Scheduler drain exception safety** — semaphore leak on `create_session()` failure fixed. `main_loop.run()` exception no longer kills the drain loop. Init failure in serve promoted to `log.warning`.
+- **P1 batch (5 fixes)** — C3/C4 regression tests, WorkerRequest `time_budget_s` pass-through, thread-mode `denied_tools` raises (was warn), announce TTL reset (`setdefault` → assignment), subprocess env whitelist +2 vars.
 
 ## [0.35.1] — 2026-03-29
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -236,10 +236,12 @@ class SubAgentManager:
         max_depth: int = 1,  # Depth=1 enforced (Claude Code pattern: sub-agents cannot recurse)
         # Sandbox hardening: tool scope restriction
         denied_tools: set[str] | None = None,
+        time_budget_s: float = 0.0,
     ) -> None:
         self._runner = runner
         self._task_handler = task_handler
         self._timeout_s = timeout_s
+        self._time_budget_s = time_budget_s
         self._hooks = hooks
         self._coalescing = coalescing
         self._agent_registry = agent_registry
@@ -451,7 +453,7 @@ class SubAgentManager:
                 return
             child_result.announced = True
             _announce_queue.setdefault(parent_session_key, []).append(child_result)
-            _announce_timestamps.setdefault(parent_session_key, time.time())
+            _announce_timestamps[parent_session_key] = time.time()
         log.debug(
             "Announced result: task_id=%s to parent=%s (status=%s)",
             child_result.task_id,
@@ -481,6 +483,7 @@ class SubAgentManager:
             model=settings.model,
             provider=_resolve_provider(settings.model),
             timeout_s=self._timeout_s,
+            time_budget_s=self._time_budget_s,
             domain=domain.name if domain else "",
         )
 
@@ -598,10 +601,9 @@ class SubAgentManager:
         callback is opaque. Use subprocess mode (action_handlers) for security.
         """
         if self._denied_tools:
-            log.warning(
-                "Thread mode does not enforce denied_tools for task %s. "
-                "Use subprocess mode (action_handlers) for security.",
-                task.task_id,
+            raise RuntimeError(
+                f"Thread mode cannot enforce denied_tools for task {task.task_id}. "
+                "Use subprocess mode (action_handlers) for security."
             )
 
         from core.memory.session_key import build_subagent_session_key

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -45,6 +45,7 @@ class WorkerRequest:
     model: str = "claude-opus-4-6"
     provider: str = "anthropic"
     timeout_s: float = 120.0
+    time_budget_s: float = 0.0  # 0 = inherit parent's budget
     domain: str = ""  # Domain adapter name (e.g. "game_ip") or ""
     isolation: str = ""  # Reserved for Phase 3: "worktree" etc.
 

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -109,6 +109,8 @@ class IsolatedRunner:
         "ZHIPUAI_API_KEY",
         "PYTHONPATH",
         "VIRTUAL_ENV",
+        "GEODE_CONFIG_PATH",
+        "GEODE_DATA_DIR",
     }
 
     def __init__(self, hooks: HookSystem | None = None) -> None:

--- a/tests/test_isolated_execution.py
+++ b/tests/test_isolated_execution.py
@@ -584,3 +584,41 @@ class TestEdgeCases:
         # Should not raise
         result = runner.run(lambda: "ok")
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# C3 Regression: Semaphore leak on timeout (v0.35.1 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestSemaphoreLeakRegression:
+    """Verify the `acquired` flag prevents double-release on timeout."""
+
+    def test_timeout_releases_semaphore_exactly_once(self) -> None:
+        """After a timeout, the semaphore must be released exactly once.
+
+        Regression for C3: without the `acquired` flag, a timeout could
+        cause extra permits on the semaphore.
+        """
+        runner = IsolatedRunner()
+        initial_value = runner._semaphore._value  # type: ignore[attr-defined]
+
+        # Run a function that exceeds the timeout
+        result = runner.run(
+            lambda: time.sleep(5.0),
+            config=IsolationConfig(timeout_s=0.1),
+        )
+
+        assert not result.success
+        # Semaphore should return to its initial value (no leak)
+        assert runner._semaphore._value == initial_value  # type: ignore[attr-defined]
+
+    def test_normal_completion_releases_semaphore(self) -> None:
+        """Normal completion should also release exactly once."""
+        runner = IsolatedRunner()
+        initial_value = runner._semaphore._value  # type: ignore[attr-defined]
+
+        result = runner.run(lambda: "fast")
+
+        assert result.success
+        assert runner._semaphore._value == initial_value  # type: ignore[attr-defined]

--- a/tests/test_lane_queue.py
+++ b/tests/test_lane_queue.py
@@ -134,3 +134,41 @@ class TestLaneQueue:
 
         release.set()
         t.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# C4 Regression: acquire_all partial failure (v0.35.1 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestAcquireAllPartialFailure:
+    """Verify partial failure releases only acquired semaphores."""
+
+    def test_second_lane_timeout_releases_first(self) -> None:
+        """If 2nd lane times out, 1st lane semaphore must be released.
+
+        Regression for C4: without tracking acquired sems separately,
+        a partial failure could leak the first lane's semaphore.
+        """
+        q = LaneQueue()
+        q.add_lane("fast", max_concurrent=1, timeout_s=5.0)
+        q.add_lane("slow", max_concurrent=1, timeout_s=0.1)
+
+        # Exhaust the slow lane
+        slow = q.get_lane("slow")
+        assert slow is not None
+        slow._semaphore.acquire()
+
+        # acquire_all should fail on slow lane, but release fast lane
+        fast = q.get_lane("fast")
+        assert fast is not None
+        initial_fast = fast._semaphore._value  # type: ignore[attr-defined]
+
+        with pytest.raises(TimeoutError, match="slow"), q.acquire_all("job-x", ["fast", "slow"]):
+            pass  # should not reach here
+
+        # Fast lane semaphore must be released (no leak)
+        assert fast._semaphore._value == initial_fast  # type: ignore[attr-defined]
+
+        # Cleanup
+        slow._semaphore.release()


### PR DESCRIPTION
## Summary
- **Why**: 5 P1 items deferred from v0.35.1 verification team. All are safety/correctness fixes.
- C3/C4 regression tests (semaphore leak, acquire_all partial failure)
- WorkerRequest `time_budget_s` pass-through to subprocess workers
- Thread-mode `denied_tools` → raise RuntimeError (was warn-and-continue)
- Announce TTL reset bug (setdefault → assignment)
- Subprocess env whitelist: +GEODE_CONFIG_PATH, +GEODE_DATA_DIR
- P1-6 (fork set_current_loop) SKIPPED — already handled by `propagate_context=True`

## Quality Gates
- Lint: 0 errors
- Type: 0 errors
- Test: 3386 passed (+6 net)

## Test plan
- [x] `uv run pytest tests/test_isolated_execution.py tests/test_lane_queue.py tests/test_worker.py tests/test_sub_agent_scope.py tests/test_subagent_announce.py` — 108 pass
- [x] Full suite: 3386 passed
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/agent/sub_agent.py core/agent/worker.py core/orchestration/isolated_execution.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)