### PR TITLE
refactor: unified bootstrap — serve uses GeodeRuntime only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - **Scheduler in serve mode** — `SchedulerService` extracted from REPL into `geode serve`. Scheduled jobs now fire in headless mode. Shared `_drain_scheduler_queue()` helper eliminates duplication between REPL and serve paths.
 
+### Changed
+- **Unified bootstrap** — `serve()` no longer calls `bootstrap_geode()`. Uses `setup_contextvars()` + `GeodeRuntime.create()` directly. ONE HookSystem, ONE MCP manager, ONE SkillRegistry across all entry points. Resolves C1/C2/H1/H4/H5 from structural audit.
+
 ### Fixed
 - **Scheduler drain exception safety** — semaphore leak on `create_session()` failure fixed. `main_loop.run()` exception no longer kills the drain loop. Init failure in serve promoted to `log.warning`.
 - **P1 batch (5 fixes)** — C3/C4 regression tests, WorkerRequest `time_budget_s` pass-through, thread-mode `denied_tools` raises (was warn), announce TTL reset (`setdefault` → assignment), subprocess env whitelist +2 vars.

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1749,10 +1749,10 @@ def serve(
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
-    # Unified bootstrap (same init as REPL: domain, memory, readiness, MCP, skills, handlers)
-    from core.cli.bootstrap import bootstrap_geode
+    # ContextVars only (domain, memory, profile, env) — no resource creation
+    from core.cli.bootstrap import setup_contextvars
 
-    boot = bootstrap_geode(load_env=True)
+    setup_contextvars(load_env=True)
 
     from core.config import settings
 
@@ -1801,9 +1801,14 @@ def serve(
         gateway.gateway_time_budget_s if hasattr(gateway, "gateway_time_budget_s") else 120.0
     )
     _gw_services = build_shared_services(
-        mcp_manager=boot.mcp_manager,
-        skill_registry=boot.skill_registry,
+        mcp_manager=runtime.mcp_manager,
+        skill_registry=runtime.skill_registry,
+        hook_system=runtime.hooks,
     )
+
+    # Wire module-level hooks so _fire_hook() works in serve mode
+    global _hooks_ctx
+    _hooks_ctx = _gw_services.hook_system
 
     # --- Scheduler daemon (same SchedulerService as REPL, drain in main loop) ---
     import queue as _queue_mod
@@ -1930,6 +1935,12 @@ def serve(
             _sched_svc.save()
             _sched_svc.stop()
             log.info("Scheduler stopped, state saved")
+        # MCP cleanup
+        if runtime and runtime.mcp_manager:
+            try:
+                runtime.mcp_manager.shutdown()
+            except Exception:
+                log.debug("MCP shutdown error", exc_info=True)
         if _webhook_server is not None:
             _webhook_server.shutdown()
         gateway.stop()

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -85,17 +85,11 @@ class GeodeBootstrap:
             log.debug("User profile propagation skipped", exc_info=True)
 
 
-def bootstrap_geode(
-    *,
-    verbose: bool = False,
-    load_env: bool = False,
-) -> GeodeBootstrap:
-    """Single initialization for both REPL and serve.
+def setup_contextvars(*, load_env: bool = False) -> None:
+    """Initialize ContextVars only (domain, memory, profile, env).
 
-    Args:
-        verbose: Enable verbose logging.
-        load_env: Load .env files into ``os.environ``
-            (serve needs this; REPL typically does not).
+    No resource creation. Call before GeodeRuntime.create() so that
+    domain adapter and memory ContextVars are available to all layers.
     """
     if load_env:
         import os
@@ -155,6 +149,19 @@ def bootstrap_geode(
         set_user_profile(user_profile)
     except Exception:
         log.debug("User profile context skipped", exc_info=True)
+
+
+def bootstrap_geode(
+    *,
+    verbose: bool = False,
+    load_env: bool = False,
+) -> GeodeBootstrap:
+    """REPL bootstrap — ContextVars + MCP + Skills + Handlers.
+
+    For serve mode, use ``setup_contextvars()`` + ``GeodeRuntime.create()``
+    directly instead.
+    """
+    setup_contextvars(load_env=load_env)
 
     # 3. Readiness
     from core.cli import _set_readiness

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -115,6 +115,10 @@ class RuntimeCoreConfig:
     profile_store: ProfileStore | None = None
     profile_rotator: ProfileRotator | None = None
     cooldown_tracker: CooldownTracker | None = None
+    # Unified bootstrap: resources previously in bootstrap_geode() only
+    mcp_manager: Any = None
+    skill_registry: Any = None
+    readiness: Any = None
 
 
 @dataclass
@@ -181,6 +185,10 @@ class GeodeRuntime:
         self.ip_name = core.ip_name
         self.run_id = ""
         self.is_subagent: bool = False
+        # Unified bootstrap resources
+        self.mcp_manager = core.mcp_manager
+        self.skill_registry = core.skill_registry
+        self.readiness = core.readiness
         self._compiled_graph: CompiledStateGraph[Any, None, Any, Any] | None = None
         # Unpack automation (L4.5)
         auto = automation or RuntimeAutomationConfig()
@@ -254,6 +262,11 @@ class GeodeRuntime:
         config_watcher = bootstrap.build_config_watcher()
         lane_queue = infra.build_default_lanes()
 
+        # Unified bootstrap: MCP, Skills, Readiness
+        mcp_manager = bootstrap.build_mcp_manager()
+        skill_registry = bootstrap.build_skill_registry()
+        readiness = bootstrap.build_readiness()
+
         # Plugin wiring (MCP adapters + Gateway)
         adapter_wiring.build_plugins()
 
@@ -305,6 +318,9 @@ class GeodeRuntime:
             profile_store=profile_store,
             profile_rotator=profile_rotator,
             cooldown_tracker=cooldown_tracker,
+            mcp_manager=mcp_manager,
+            skill_registry=skill_registry,
+            readiness=readiness,
         )
         automation_config = RuntimeAutomationConfig(**automation)
         memory_config = RuntimeMemoryConfig(

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -506,3 +506,36 @@ def build_prompt_assembler(
         skill_registry=skill_registry,
         hooks=hooks,
     )
+
+
+# ---------------------------------------------------------------------------
+# Unified bootstrap: MCP, Skills, Readiness (moved from cli/bootstrap.py)
+# ---------------------------------------------------------------------------
+
+
+def build_mcp_manager() -> Any:
+    """Load MCP server config (lazy — no subprocess connections yet)."""
+    from core.mcp.manager import get_mcp_manager
+
+    mgr = get_mcp_manager()
+    mgr.load_config()
+    return mgr
+
+
+def build_skill_registry() -> Any:
+    """Load all skill definitions from 4-tier priority directories."""
+    from core.skills.skills import SkillLoader, SkillRegistry
+
+    registry = SkillRegistry()
+    try:
+        SkillLoader().load_all(registry=registry)
+    except Exception:
+        log.debug("Skill loading skipped", exc_info=True)
+    return registry
+
+
+def build_readiness() -> Any:
+    """Check API key availability for all configured providers."""
+    from core.cli.startup import check_readiness
+
+    return check_readiness()


### PR DESCRIPTION
## Summary
- **Why**: REPL and serve had independent bootstrap paths, creating duplicate HookSystem/Scheduler/Memory. OpenClaw violation: "Gateway owns the process, one singleton per resource."
- GeodeRuntime.create() now builds MCP, Skills, Readiness (3 new builders in runtime_wiring/bootstrap.py)
- serve() uses setup_contextvars() + GeodeRuntime directly (no more bootstrap_geode())
- ONE HookSystem wired to module-level _hooks_ctx in serve
- MCP shutdown added to serve's finally block
- REPL unchanged (backward compat via bootstrap_geode())

## Structural defects resolved
| ID | Defect | Fix |
|----|--------|-----|
| C1 | Dual HookSystem | serve reuses runtime.hooks via build_shared_services(hook_system=) |
| C2 | Dual bootstrap paths | serve uses GeodeRuntime only |
| H1 | serve _hooks_ctx not wired | _hooks_ctx = _gw_services.hook_system after build |
| H4 | Memory double-creation | setup_contextvars() sets once, GeodeRuntime reuses |
| H5 | serve MCP no shutdown | runtime.mcp_manager.shutdown() in finally |

## Quality Gates
- Lint: 0 errors
- Type: 0 errors
- Test: 3386 passed (ratchet maintained)

## Test plan
- [x] `uv run pytest tests/test_runtime.py tests/test_bootstrap.py tests/test_gateway.py tests/test_scheduler_serve.py` — 113 pass
- [x] Full suite: 3386 passed
- [x] `uv run ruff check` + `uv run mypy` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)