### PR TITLE
feat: Gateway Runtime Phase 2+3 — 6 structural defects resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **H3: CLIChannel IPC** — Unix domain socket (`~/.geode/cli.sock`) connects thin CLI client to `geode serve`. `CLIPoller` accepts local connections, creates REPL sessions via SharedServices. `IPCClient` auto-detects serve and delegates agentic execution over line-delimited JSON protocol. Fallback to standalone when serve is not running.
 - **Scheduler in serve mode** — `SchedulerService` extracted from REPL into `geode serve`. Scheduled jobs now fire in headless mode. Shared `_drain_scheduler_queue()` helper eliminates duplication between REPL and serve paths.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Unified bootstrap** — `serve()` no longer calls `bootstrap_geode()`. Uses `setup_contextvars()` + `GeodeRuntime.create()` directly. ONE HookSystem, ONE MCP manager, ONE SkillRegistry across all entry points. Resolves C1/C2/H1/H4/H5 from structural audit.
 
 ### Fixed
-- **Scheduler drain exception safety** — semaphore leak on `create_session()` failure fixed. `main_loop.run()` exception no longer kills the drain loop. Init failure in serve promoted to `log.warning`.
+- **C3: Dual Scheduler race** — `fcntl.flock(LOCK_EX/LOCK_SH)` on `jobs.json` save/load. REPL and serve can no longer corrupt shared job store via concurrent file access.
+- **H2: Scheduler → LaneQueue** — replaced ad-hoc `Semaphore(2)` with `Lane.try_acquire()`/`manual_release()`. Scheduler concurrency now routes through the central LaneQueue system.
+- **M2: Scheduler PolicyChain** — `create_session(SCHEDULER/DAEMON)` filters DANGEROUS tools (`run_bash`, `delegate_task`). Headless modes can no longer invoke tools requiring HITL approval.
+- **M3: Stuck job detection** — `running_since_ms` field tracks active jobs. `detect_stuck_jobs()` runs each tick, marks jobs exceeding 10min threshold as `stuck`, fires hook.
+- **Scheduler drain exception safety** — lane slot leak on `create_session()` failure fixed. `main_loop.run()` exception no longer kills the drain loop. Init failure in serve promoted to `log.warning`.
 - **P1 batch (5 fixes)** — C3/C4 regression tests, WorkerRequest `time_budget_s` pass-through, thread-mode `denied_tools` raises (was warn), announce TTL reset (`setdefault` → assignment), subprocess env whitelist +2 vars.
+
+### Architecture
+- **M1: Config-driven pollers** — `build_gateway()` reads `[gateway] pollers` from `config.toml`. Dynamic `_POLLER_REGISTRY` replaces hardcoded `register_poller()` calls. Default: all three (slack, discord, telegram).
 
 ## [0.35.1] — 2026-03-29
 

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -58,10 +58,7 @@ def _cleanup_stale_announces() -> None:
     """Remove announce queue entries older than TTL."""
     now = time.time()
     with _announce_lock:
-        stale_keys = [
-            k for k, ts in _announce_timestamps.items()
-            if now - ts > _ANNOUNCE_TTL_S
-        ]
+        stale_keys = [k for k, ts in _announce_timestamps.items() if now - ts > _ANNOUNCE_TTL_S]
         for k in stale_keys:
             _announce_queue.pop(k, None)
             _announce_timestamps.pop(k, None)
@@ -331,9 +328,7 @@ class SubAgentManager:
                 fn_or_request = self._build_worker_request(task)
                 sid = self._runner.run_async(fn_or_request, config=config)
             else:
-                sid = self._runner.run_async(
-                    self._execute_subtask, args=(task,), config=config
-                )
+                sid = self._runner.run_async(self._execute_subtask, args=(task,), config=config)
             session_ids.append((task, sid))
             log.debug(
                 "SubAgent launched: %s (%s) key=%s",

--- a/core/automation/scheduler.py
+++ b/core/automation/scheduler.py
@@ -13,6 +13,7 @@ Architecture-v6 SS4.5: Automation Layer -- Advanced Scheduler (P4).
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
@@ -95,8 +96,9 @@ class ScheduledJob:
     created_at_ms: float = 0.0
     next_run_at_ms: float | None = None
     last_run_at_ms: float | None = None
-    last_status: str = ""  # "ok" | "error" | "skipped"
+    last_status: str = ""  # "ok" | "error" | "skipped" | "stuck"
     last_duration_ms: float = 0.0
+    running_since_ms: float | None = None  # Set when executing, cleared on completion
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +130,7 @@ def _job_to_dict(job: ScheduledJob) -> dict[str, Any]:
         "last_run_at_ms": job.last_run_at_ms,
         "last_status": job.last_status,
         "last_duration_ms": job.last_duration_ms,
+        "running_since_ms": job.running_since_ms,
     }
 
 
@@ -161,6 +164,7 @@ def _job_from_dict(data: dict[str, Any]) -> ScheduledJob:
         last_run_at_ms=data.get("last_run_at_ms"),
         last_status=data.get("last_status", ""),
         last_duration_ms=data.get("last_duration_ms", 0.0),
+        running_since_ms=data.get("running_since_ms"),
     )
 
 
@@ -563,6 +567,8 @@ class SchedulerService:
         status = "ok"
         error = ""
 
+        job.running_since_ms = start
+
         try:
             if job.callback is not None:
                 job.callback({"job_id": job.job_id, "name": job.name, **job.metadata})
@@ -580,6 +586,7 @@ class SchedulerService:
             log.warning("Job '%s' failed: %s", job.job_id, exc)
 
         duration = time.time() * 1000 - start
+        job.running_since_ms = None
 
         # Update job state
         job.last_run_at_ms = now
@@ -627,25 +634,45 @@ class SchedulerService:
     # -- Persistence --------------------------------------------------------
 
     def save(self) -> None:
-        """Atomically persist the job store to disk (tmp + rename)."""
+        """Atomically persist the job store to disk (tmp + rename).
+
+        Uses ``fcntl.flock(LOCK_EX)`` to prevent inter-process race when
+        REPL and serve both access the same ``jobs.json``.
+        """
         path = Path(self._store_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {jid: _job_to_dict(j) for jid, j in self._jobs.items()}
         payload = json.dumps(data, ensure_ascii=False, indent=2)
-        tmp_path = path.with_suffix(".json.tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write(payload)
-        os.replace(str(tmp_path), str(path))
+        lock_path = path.with_suffix(".json.lock")
+        with open(lock_path, "w") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            try:
+                tmp_path = path.with_suffix(".json.tmp")
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                os.replace(str(tmp_path), str(path))
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
         log.debug("Scheduler state saved to %s (%d jobs)", path, len(data))
 
     def load(self) -> None:
-        """Load job store from disk."""
+        """Load job store from disk.
+
+        Uses ``fcntl.flock(LOCK_SH)`` to coordinate with concurrent saves.
+        """
         path = Path(self._store_path)
         if not path.exists():
             log.debug("No scheduler store at %s", path)
             return
-        with open(path, encoding="utf-8") as f:
-            data: dict[str, Any] = json.load(f)
+        lock_path = path.with_suffix(".json.lock")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(lock_path, "w") as lf:
+            fcntl.flock(lf, fcntl.LOCK_SH)
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data: dict[str, Any] = json.load(f)
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
         loaded = 0
         for _jid, jdata in data.items():
             try:
@@ -690,11 +717,48 @@ class SchedulerService:
         """Number of registered jobs."""
         return len(self._jobs)
 
+    # -- Stuck job detection ---------------------------------------------------
+
+    STUCK_TIMEOUT_MS: float = 600_000.0  # 10 minutes
+
+    def detect_stuck_jobs(self, now_ms: float | None = None) -> list[str]:
+        """Detect and mark jobs that have been running longer than STUCK_TIMEOUT_MS.
+
+        Returns a list of stuck job IDs.
+        """
+        now = now_ms if now_ms is not None else time.time() * 1000
+        stuck: list[str] = []
+        with self._lock:
+            for job in self._jobs.values():
+                if (
+                    job.running_since_ms is not None
+                    and (now - job.running_since_ms) > self.STUCK_TIMEOUT_MS
+                ):
+                    elapsed_s = (now - job.running_since_ms) / 1000
+                    log.warning(
+                        "Stuck job detected: '%s' running for %.0fs (threshold %.0fs)",
+                        job.job_id,
+                        elapsed_s,
+                        self.STUCK_TIMEOUT_MS / 1000,
+                    )
+                    job.last_status = "stuck"
+                    job.running_since_ms = None
+                    stuck.append(job.job_id)
+        if stuck and self._hooks:
+            from core.hooks import HookEvent
+
+            self._hooks.trigger(
+                HookEvent.TRIGGER_FIRED,
+                {"stuck_jobs": stuck, "source": "scheduler_stuck_detection"},
+            )
+        return stuck
+
     def _loop(self, interval_s: float) -> None:
         """Background tick loop."""
         while not self._stop_event.is_set():
             try:
                 self.check_due_jobs()
+                self.detect_stuck_jobs()
             except Exception as exc:
                 log.warning("Scheduler tick error: %s", exc)
             self._stop_event.wait(interval_s)

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1305,6 +1305,88 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Thin REPL — delegates to geode serve via IPC
+# ---------------------------------------------------------------------------
+
+
+def _thin_interactive_loop() -> None:
+    """Thin CLI client that relays prompts to geode serve via IPC.
+
+    Called when serve is detected running. Skips heavy bootstrap (MCP,
+    skills, memory) — serve owns all shared resources.  Local slash
+    commands (/help, /exit, /clear, /model) are handled locally.
+    """
+    from core.cli.ipc_client import IPCClient
+
+    client = IPCClient()
+    if not client.connect():
+        console.print(
+            "  [warning]Failed to connect to serve — falling back to standalone[/warning]"
+        )
+        _interactive_loop()
+        return
+
+    console.print(f"  [success]Connected to serve (session: {client.session_id})[/success]")
+    console.print("  [muted]Thin mode — MCP/skills/memory managed by serve[/muted]")
+    console.print()
+
+    try:
+        while True:
+            console.show_cursor(True)
+            try:
+                user_input = _read_multiline_input("[header]>[/header] ")
+            except (KeyboardInterrupt, EOFError):
+                console.print("\n  [muted]Goodbye.[/muted]\n")
+                break
+
+            if not user_input:
+                continue
+
+            if user_input.strip().lower() in ("exit", "quit", "q"):
+                console.print("  [muted]Goodbye.[/muted]\n")
+                break
+
+            # Local-only slash commands
+            if user_input.startswith("/"):
+                cmd = user_input.split()[0].lower()
+                if cmd in ("/help", "/exit", "/quit", "/clear"):
+                    from core.cli.commands import handle_command as _hcmd
+
+                    try:
+                        _hcmd(cmd, user_input[len(cmd):].strip())
+                    except SystemExit:
+                        break
+                    continue
+
+            # Relay to serve via IPC
+            response = client.send_prompt(user_input)
+
+            if response.get("type") == "error":
+                console.print(f"\n  [error]{response.get('message', 'Unknown error')}[/error]\n")
+                continue
+
+            if response.get("type") == "result":
+                # Render tool calls
+                for tc in response.get("tool_calls", []):
+                    console.print(f"  [dim]\u25b8 {tc.get('name', '?')}[/dim]")
+
+                # Render text
+                text = response.get("text", "")
+                if text:
+                    from rich.markdown import Markdown
+
+                    console.print()
+                    console.print(Markdown(text))
+                    console.print()
+
+                rounds = response.get("rounds", 0)
+                if rounds > 1:
+                    console.print(f"  [dim]{rounds} rounds[/dim]")
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
 # Typer commands
 # ---------------------------------------------------------------------------
 
@@ -1320,12 +1402,20 @@ def main(
     """GEODE — Autonomous Research Harness."""
     if ctx.invoked_subcommand is None:
         _welcome_screen()
-        resume_id: str | None = None
-        if continue_session:
-            resume_id = "__latest__"
-        elif resume:
-            resume_id = resume
-        _interactive_loop(resume_session_id=resume_id)
+
+        # Auto-detect serve: use thin IPC client when available
+        from core.cli.ipc_client import is_serve_running
+
+        if is_serve_running() and not continue_session and not resume:
+            console.print("  [muted]Detected geode serve — connecting via IPC...[/muted]")
+            _thin_interactive_loop()
+        else:
+            resume_id: str | None = None
+            if continue_session:
+                resume_id = "__latest__"
+            elif resume:
+                resume_id = resume
+            _interactive_loop(resume_session_id=resume_id)
 
 
 @app.command()
@@ -1916,6 +2006,18 @@ def serve(
     # Start pollers
     gateway.start()
     console.print("  [success]Gateway started. Listening...[/success]")
+
+    # CLI Channel — Unix socket for thin CLI client IPC
+    _cli_poller = None
+    try:
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        _cli_poller = CLIPoller(_gw_services)
+        _cli_poller.start()
+        console.print(f"  [success]CLI channel: {_cli_poller.socket_path}[/success]")
+    except Exception:
+        log.warning("CLI channel init failed", exc_info=True)
+
     console.print()
 
     # Block until Ctrl+C
@@ -1956,6 +2058,8 @@ def serve(
                 runtime.mcp_manager.shutdown()
             except Exception:
                 log.debug("MCP shutdown error", exc_info=True)
+        if _cli_poller is not None:
+            _cli_poller.stop()
         if _webhook_server is not None:
             _webhook_server.shutdown()
         gateway.stop()

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -12,7 +12,6 @@ import logging
 import signal
 import sys
 import termios
-import threading
 from pathlib import Path
 from typing import Any
 
@@ -106,7 +105,7 @@ def _drain_scheduler_queue(
     action_queue: Any,
     services: Any,
     runner: Any,
-    semaphore: threading.Semaphore,
+    scheduler_lane: Any,
     force_isolated: bool = False,
     main_loop: Any | None = None,
     on_complete: Any | None = None,
@@ -118,6 +117,9 @@ def _drain_scheduler_queue(
 
     Shared by both REPL and serve modes.  In serve mode ``force_isolated``
     is True because there is no interactive main session to inject into.
+
+    Uses ``Lane.try_acquire`` / ``manual_release`` for concurrency control
+    through the central LaneQueue (replacing ad-hoc Semaphore).
 
     Returns the number of jobs drained.
     """
@@ -135,13 +137,18 @@ def _drain_scheduler_queue(
             prompt = f"[scheduled-job:{job_id}] {fired_action}"
 
             if isolated or force_isolated:
-                if not semaphore.acquire(timeout=0):
-                    log.warning("Scheduler slots full (max 2), skipping job %s", job_id)
+                lane_key = f"scheduled:{job_id}"
+                if not scheduler_lane.try_acquire(lane_key):
+                    log.warning(
+                        "Scheduler lane full (max %d), skipping job %s",
+                        scheduler_lane.max_concurrent,
+                        job_id,
+                    )
                     if on_skip:
                         on_skip(job_id)
                     continue
 
-                _sem_acquired = True
+                _lane_acquired = True
                 try:
                     _iso_conv = ConversationContext()
                     from core.gateway.shared_services import SessionMode
@@ -154,7 +161,8 @@ def _drain_scheduler_queue(
                     _cap_loop = _iso_loop
                     _cap_prompt = prompt
                     _cap_jid = job_id
-                    _cap_sem = semaphore
+                    _cap_lane = scheduler_lane
+                    _cap_key = lane_key
                     _cap_cb = on_complete
 
                     def _run_isolated(
@@ -162,7 +170,8 @@ def _drain_scheduler_queue(
                         _loop: Any = _cap_loop,
                         _p: str = _cap_prompt,
                         _jid: str = _cap_jid,
-                        _sem: threading.Semaphore = _cap_sem,
+                        _lane: Any = _cap_lane,
+                        _key: str = _cap_key,
                         _cb: Any = _cap_cb,
                     ) -> str:
                         try:
@@ -171,7 +180,7 @@ def _drain_scheduler_queue(
                                 _cb(r, job_id=_jid)
                             return r.text if r and r.text else ""
                         finally:
-                            _sem.release()
+                            _lane.manual_release(_key)
 
                     runner.run_async(
                         _run_isolated,
@@ -181,12 +190,12 @@ def _drain_scheduler_queue(
                             timeout_s=300.0,
                         ),
                     )
-                    _sem_acquired = False  # ownership transferred to _run_isolated
+                    _lane_acquired = False  # ownership transferred to _run_isolated
                     if on_dispatch:
                         on_dispatch(job_id)
                 except Exception:
-                    if _sem_acquired:
-                        semaphore.release()
+                    if _lane_acquired:
+                        scheduler_lane.manual_release(lane_key)
                     log.warning("Scheduler job %s dispatch failed", job_id, exc_info=True)
             else:
                 # Non-isolated: inject into main session (REPL only)
@@ -1053,7 +1062,10 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
     )
 
     _sched_runner = IsolatedRunner()
-    _sched_semaphore = threading.Semaphore(2)  # Max 2 concurrent scheduled jobs
+    from core.orchestration.lane_queue import LaneQueue
+
+    _sched_lane_queue = LaneQueue()
+    _sched_lane = _sched_lane_queue.add_lane("scheduler", max_concurrent=2, timeout_s=300.0)
 
     console.print()  # blank line before prompt
 
@@ -1134,7 +1146,7 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
             action_queue=_action_queue,
             services=services,
             runner=_sched_runner,
-            semaphore=_sched_semaphore,
+            scheduler_lane=_sched_lane,
             force_isolated=False,
             main_loop=agentic,
             on_complete=_on_sched_complete,
@@ -1834,7 +1846,10 @@ def serve(
         console.print("  [warning]Scheduler init failed — running without scheduler[/warning]")
 
     _sched_runner = IsolatedRunner()
-    _sched_semaphore = threading.Semaphore(2)
+    from core.orchestration.lane_queue import LaneQueue as _ServeLaneQueue
+
+    _serve_lane_queue = _ServeLaneQueue()
+    _serve_sched_lane = _serve_lane_queue.add_lane("scheduler", max_concurrent=2, timeout_s=300.0)
 
     def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:
         """Process a gateway message with multi-turn context.
@@ -1920,7 +1935,7 @@ def serve(
                 action_queue=_sched_queue,
                 services=_gw_services,
                 runner=_sched_runner,
-                semaphore=_sched_semaphore,
+                scheduler_lane=_serve_sched_lane,
                 force_isolated=True,
                 on_complete=lambda result, *, job_id: log.info(
                     "scheduled:%s completed", job_id

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1350,11 +1350,13 @@ def _thin_interactive_loop() -> None:
             if user_input.startswith("/"):
                 cmd = user_input.split()[0].lower()
                 if cmd in ("/help", "/exit", "/quit", "/clear"):
-                    from core.cli.commands import handle_command as _hcmd
-
                     try:
-                        _hcmd(cmd, user_input[len(cmd) :].strip())
-                    except SystemExit:
+                        _handle_command(
+                            cmd,
+                            user_input[len(cmd) :].strip(),
+                            False,
+                        )
+                    except (SystemExit, EOFError):
                         break
                     continue
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1353,7 +1353,7 @@ def _thin_interactive_loop() -> None:
                     from core.cli.commands import handle_command as _hcmd
 
                     try:
-                        _hcmd(cmd, user_input[len(cmd):].strip())
+                        _hcmd(cmd, user_input[len(cmd) :].strip())
                     except SystemExit:
                         break
                     continue
@@ -2039,9 +2039,7 @@ def serve(
                 runner=_sched_runner,
                 scheduler_lane=_serve_sched_lane,
                 force_isolated=True,
-                on_complete=lambda result, *, job_id: log.info(
-                    "scheduled:%s completed", job_id
-                ),
+                on_complete=lambda result, *, job_id: log.info("scheduled:%s completed", job_id),
                 on_dispatch=lambda jid: log.info("scheduled:%s dispatched", jid),
                 on_skip=lambda jid: log.warning("scheduled:%s skipped (slots full)", jid),
             )

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -1,0 +1,120 @@
+"""IPC Client — thin CLI client for connecting to geode serve.
+
+When ``geode serve`` is running, the REPL can delegate agentic execution
+to the server over a Unix domain socket, sharing MCP/skills/memory/hooks
+instead of duplicating them.
+
+Protocol: line-delimited JSON over Unix socket (matches CLIPoller server).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
+
+
+def is_serve_running(socket_path: Path | None = None) -> bool:
+    """Check if geode serve is running by probing the socket."""
+    path = socket_path or DEFAULT_SOCKET_PATH
+    if not path.exists():
+        return False
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(1.0)
+        sock.connect(str(path))
+        sock.close()
+        return True
+    except (ConnectionRefusedError, OSError):
+        return False
+
+
+class IPCClient:
+    """Thin client that relays prompts to geode serve via Unix socket.
+
+    Usage::
+
+        client = IPCClient()
+        client.connect()
+        result = client.send_prompt("analyze Berserk")
+        client.close()
+    """
+
+    def __init__(self, socket_path: Path | None = None) -> None:
+        self._socket_path = socket_path or DEFAULT_SOCKET_PATH
+        self._sock: socket.socket | None = None
+        self._buf = b""
+        self.session_id: str = ""
+
+    def connect(self) -> bool:
+        """Connect to serve. Returns True on success."""
+        try:
+            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.connect(str(self._socket_path))
+            # Read session greeting
+            msg = self._recv()
+            if msg and msg.get("type") == "session":
+                self.session_id = msg.get("session_id", "")
+                log.info("Connected to serve (session=%s)", self.session_id)
+            return True
+        except (ConnectionRefusedError, OSError) as exc:
+            log.debug("IPC connect failed: %s", exc)
+            self._sock = None
+            return False
+
+    def close(self) -> None:
+        """Disconnect from serve."""
+        if self._sock:
+            import contextlib
+
+            with contextlib.suppress(OSError):
+                self._send({"type": "exit"})
+                self._recv()
+            with contextlib.suppress(OSError):
+                self._sock.close()
+            self._sock = None
+
+    @property
+    def connected(self) -> bool:
+        return self._sock is not None
+
+    def send_prompt(self, text: str) -> dict[str, Any]:
+        """Send a prompt and wait for the result.
+
+        Returns a dict with keys: type, text, rounds, tool_calls, termination.
+        On error, returns {"type": "error", "message": "..."}.
+        """
+        if not self._sock:
+            return {"type": "error", "message": "Not connected"}
+        self._send({"type": "prompt", "text": text})
+        response = self._recv()
+        if response is None:
+            return {"type": "error", "message": "Connection lost"}
+        return response
+
+    def _send(self, data: dict[str, Any]) -> None:
+        """Send line-delimited JSON."""
+        assert self._sock is not None
+        payload = json.dumps(data, ensure_ascii=False) + "\n"
+        self._sock.sendall(payload.encode("utf-8"))
+
+    def _recv(self) -> dict[str, Any] | None:
+        """Receive one line-delimited JSON message."""
+        assert self._sock is not None
+        while b"\n" not in self._buf:
+            try:
+                chunk = self._sock.recv(65536)
+                if not chunk:
+                    return None
+                self._buf += chunk
+            except (ConnectionResetError, OSError):
+                return None
+        line, self._buf = self._buf.split(b"\n", 1)
+        result: dict[str, Any] = json.loads(line.decode("utf-8"))
+        return result

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -1,0 +1,226 @@
+"""CLI Poller — Unix domain socket server for thin CLI client IPC.
+
+Accepts a single CLI client connection at a time. Each connected client
+gets a REPL-mode session backed by serve's SharedServices (same MCP,
+skills, hooks, memory as Slack/Discord pollers).
+
+Protocol: line-delimited JSON over Unix domain socket.
+
+Client → Server:
+    {"type": "prompt", "text": "analyze Berserk", "session_id": "..."}
+    {"type": "command", "cmd": "/model", "args": "sonnet"}
+    {"type": "exit"}
+
+Server → Client:
+    {"type": "result", "text": "...", "rounds": 3, "tool_calls": [...]}
+    {"type": "error", "message": "..."}
+    {"type": "session", "session_id": "cli-abc123"}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from core.gateway.shared_services import SharedServices
+
+DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
+
+
+class CLIPoller:
+    """Unix domain socket server for CLI thin-client IPC.
+
+    Unlike BasePoller subclasses (which poll external APIs), CLIPoller
+    *listens* for a local CLI client connection. It does not inherit
+    BasePoller because the lifecycle is fundamentally different:
+    accept-loop vs poll-loop.
+    """
+
+    def __init__(
+        self,
+        services: SharedServices,
+        *,
+        socket_path: Path | None = None,
+    ) -> None:
+        self._services = services
+        self._socket_path = socket_path or DEFAULT_SOCKET_PATH
+        self._server: socket.socket | None = None
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._active_client: socket.socket | None = None
+
+    @property
+    def channel_name(self) -> str:
+        return "cli"
+
+    @property
+    def socket_path(self) -> Path:
+        return self._socket_path
+
+    def start(self) -> None:
+        """Start listening on Unix domain socket."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        # Clean up stale socket file
+        if self._socket_path.exists():
+            self._socket_path.unlink()
+
+        self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(self._socket_path))
+        self._server.listen(1)
+        self._server.settimeout(1.0)
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._accept_loop,
+            name="geode-cli-poller",
+            daemon=True,
+        )
+        self._thread.start()
+        log.info("CLI channel listening on %s", self._socket_path)
+
+    def stop(self) -> None:
+        """Stop the socket server and clean up."""
+        import contextlib
+
+        self._stop_event.set()
+        if self._active_client:
+            with contextlib.suppress(OSError):
+                self._active_client.close()
+        if self._server:
+            with contextlib.suppress(OSError):
+                self._server.close()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        if self._socket_path.exists():
+            with contextlib.suppress(OSError):
+                self._socket_path.unlink()
+        log.info("CLI channel stopped")
+
+    def _accept_loop(self) -> None:
+        """Accept loop — one client at a time."""
+        while not self._stop_event.is_set():
+            try:
+                assert self._server is not None
+                client, _ = self._server.accept()
+                self._active_client = client
+                log.info("CLI client connected")
+                self._handle_client(client)
+            except TimeoutError:
+                continue
+            except OSError:
+                if not self._stop_event.is_set():
+                    log.warning("CLI accept error", exc_info=True)
+                break
+            finally:
+                self._active_client = None
+
+    def _handle_client(self, client: socket.socket) -> None:
+        """Handle a connected CLI client session."""
+        from core.agent.conversation import ConversationContext
+        from core.gateway.shared_services import SessionMode
+
+        client.settimeout(None)  # blocking reads
+        buf = b""
+        conversation = ConversationContext()
+        session_id = f"cli-{os.urandom(4).hex()}"
+
+        # Create a REPL session backed by serve's SharedServices
+        _executor, loop = self._services.create_session(
+            SessionMode.REPL,
+            conversation=conversation,
+            propagate_context=True,
+        )
+
+        # Send session ID to client
+        self._send(client, {"type": "session", "session_id": session_id})
+
+        while not self._stop_event.is_set():
+            try:
+                chunk = client.recv(65536)
+                if not chunk:
+                    log.info("CLI client disconnected")
+                    break
+                buf += chunk
+
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    msg = json.loads(line.decode("utf-8"))
+                    response = self._process_message(msg, loop, conversation)
+                    if response is None:
+                        # Exit signal
+                        self._send(client, {"type": "exit_ack"})
+                        return
+                    self._send(client, response)
+            except (ConnectionResetError, BrokenPipeError):
+                log.info("CLI client connection lost")
+                break
+            except json.JSONDecodeError:
+                self._send(client, {"type": "error", "message": "Invalid JSON"})
+            except Exception:
+                log.warning("CLI handler error", exc_info=True)
+                self._send(
+                    client,
+                    {"type": "error", "message": "Internal error"},
+                )
+
+    def _process_message(
+        self,
+        msg: dict[str, Any],
+        loop: Any,
+        conversation: Any,
+    ) -> dict[str, Any] | None:
+        """Process a single client message. Returns response dict or None for exit."""
+        msg_type = msg.get("type", "")
+
+        if msg_type == "exit":
+            return None
+
+        if msg_type == "prompt":
+            text = msg.get("text", "").strip()
+            if not text:
+                return {"type": "error", "message": "Empty prompt"}
+
+            try:
+                result = loop.run(text)
+                tool_calls = []
+                if result and result.tool_calls:
+                    tool_calls = [
+                        {"name": tc.name, "args": tc.arguments}
+                        for tc in result.tool_calls
+                        if hasattr(tc, "name")
+                    ]
+                return {
+                    "type": "result",
+                    "text": result.text if result else "",
+                    "rounds": result.rounds if result else 0,
+                    "tool_calls": tool_calls,
+                    "termination": (
+                        result.termination_reason if result else "unknown"
+                    ),
+                }
+            except Exception as exc:
+                log.warning("CLI prompt execution error", exc_info=True)
+                return {"type": "error", "message": str(exc)}
+
+        return {"type": "error", "message": f"Unknown message type: {msg_type}"}
+
+    @staticmethod
+    def _send(client: socket.socket, data: dict[str, Any]) -> None:
+        """Send a JSON message to the client (line-delimited)."""
+        try:
+            payload = json.dumps(data, ensure_ascii=False) + "\n"
+            client.sendall(payload.encode("utf-8"))
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            log.debug("CLI send failed — client disconnected")

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -206,9 +206,7 @@ class CLIPoller:
                     "text": result.text if result else "",
                     "rounds": result.rounds if result else 0,
                     "tool_calls": tool_calls,
-                    "termination": (
-                        result.termination_reason if result else "unknown"
-                    ),
+                    "termination": (result.termination_reason if result else "unknown"),
                 }
             except Exception as exc:
                 log.warning("CLI prompt execution error", exc_info=True)

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -38,6 +38,14 @@ class SessionMode(StrEnum):
     SCHEDULER = "scheduler"  # Cron/scheduled jobs — hitl=0, quiet, time=300s cap
 
 
+# Tools denied for headless execution (SCHEDULER, DAEMON).
+# DANGEROUS tools require HITL approval which headless modes cannot provide.
+_HEADLESS_DENIED_TOOLS: frozenset[str] = frozenset({
+    "run_bash",
+    "delegate_task",
+})
+
+
 # ---------------------------------------------------------------------------
 # Mode-specific defaults (no max_rounds — time only)
 # ---------------------------------------------------------------------------
@@ -133,10 +141,15 @@ class SharedServices:
 
             conversation = ConversationContext()
 
+        # Filter DANGEROUS tools for headless modes (PolicyChain enforcement)
+        handlers = self.tool_handlers
+        if mode in (SessionMode.SCHEDULER, SessionMode.DAEMON):
+            handlers = {k: v for k, v in handlers.items() if k not in _HEADLESS_DENIED_TOOLS}
+
         # Build sub-agent manager + executor + loop
         sub_mgr = self._build_sub_agent_manager()
         executor = ToolExecutor(
-            action_handlers=self.tool_handlers,
+            action_handlers=handlers,
             mcp_manager=self.mcp_manager,
             sub_agent_manager=sub_mgr,
             hitl_level=hitl,

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -40,10 +40,12 @@ class SessionMode(StrEnum):
 
 # Tools denied for headless execution (SCHEDULER, DAEMON).
 # DANGEROUS tools require HITL approval which headless modes cannot provide.
-_HEADLESS_DENIED_TOOLS: frozenset[str] = frozenset({
-    "run_bash",
-    "delegate_task",
-})
+_HEADLESS_DENIED_TOOLS: frozenset[str] = frozenset(
+    {
+        "run_bash",
+        "delegate_task",
+    }
+)
 
 
 # ---------------------------------------------------------------------------

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -144,6 +144,9 @@ class SharedServices:
         # Filter DANGEROUS tools for headless modes (PolicyChain enforcement)
         handlers = self.tool_handlers
         if mode in (SessionMode.SCHEDULER, SessionMode.DAEMON):
+            denied = _HEADLESS_DENIED_TOOLS & set(handlers)
+            if denied:
+                log.info("Headless mode %s: denied tools filtered — %s", mode, denied)
             handlers = {k: v for k, v in handlers.items() if k not in _HEADLESS_DENIED_TOOLS}
 
         # Build sub-agent manager + executor + loop

--- a/core/orchestration/lane_queue.py
+++ b/core/orchestration/lane_queue.py
@@ -97,6 +97,36 @@ class Lane:
             self._semaphore.release()
             log.debug("Lane '%s' released by %s", self.name, key)
 
+    def try_acquire(self, key: str) -> bool:
+        """Non-blocking acquire for async patterns (e.g. scheduler).
+
+        Returns True if a slot was acquired, False if lane is full.
+        Caller must call :meth:`manual_release` when done.
+        """
+        acquired = self._semaphore.acquire(timeout=0)
+        if not acquired:
+            self._stats.inc_timeouts()
+            return False
+        with self._lock:
+            self._active[key] = time.time()
+        self._stats.inc_acquired()
+        log.debug(
+            "Lane '%s' try_acquire by %s (%d/%d active)",
+            self.name,
+            key,
+            self.active_count,
+            self.max_concurrent,
+        )
+        return True
+
+    def manual_release(self, key: str) -> None:
+        """Release a slot acquired via :meth:`try_acquire`."""
+        with self._lock:
+            self._active.pop(key, None)
+        self._stats.inc_released()
+        self._semaphore.release()
+        log.debug("Lane '%s' manual_release by %s", self.name, key)
+
     def get_active(self) -> dict[str, float]:
         """Get active work items with elapsed time."""
         now = time.time()

--- a/core/runtime_wiring/adapters.py
+++ b/core/runtime_wiring/adapters.py
@@ -131,6 +131,7 @@ _POLLER_REGISTRY: dict[str, str] = {
     "slack": "core.gateway.pollers.slack_poller:SlackPoller",
     "discord": "core.gateway.pollers.discord_poller:DiscordPoller",
     "telegram": "core.gateway.pollers.telegram_poller:TelegramPoller",
+    # CLI poller is registered separately in serve() (not config-driven)
 }
 
 _DEFAULT_POLLERS: list[str] = ["slack", "discord", "telegram"]

--- a/core/runtime_wiring/adapters.py
+++ b/core/runtime_wiring/adapters.py
@@ -206,9 +206,7 @@ def build_gateway() -> None:
         return
 
     # Config-driven poller registration
-    enabled_pollers: list[str] = toml_config.get("gateway", {}).get(
-        "pollers", _DEFAULT_POLLERS
-    )
+    enabled_pollers: list[str] = toml_config.get("gateway", {}).get("pollers", _DEFAULT_POLLERS)
 
     for poller_name in enabled_pollers:
         dotted = _POLLER_REGISTRY.get(poller_name)

--- a/core/runtime_wiring/adapters.py
+++ b/core/runtime_wiring/adapters.py
@@ -127,18 +127,34 @@ def build_calendar_adapter() -> None:
     set_calendar(composite)
 
 
-def build_gateway() -> None:
-    """Build and inject Gateway with channel pollers.
+_POLLER_REGISTRY: dict[str, str] = {
+    "slack": "core.gateway.pollers.slack_poller:SlackPoller",
+    "discord": "core.gateway.pollers.discord_poller:DiscordPoller",
+    "telegram": "core.gateway.pollers.telegram_poller:TelegramPoller",
+}
 
-    Creates ChannelManager with Slack/Discord/Telegram pollers.
-    Pollers only start if their credentials are configured and
-    gateway_enabled=True in settings.
+_DEFAULT_POLLERS: list[str] = ["slack", "discord", "telegram"]
+
+
+def _load_poller_class(dotted_path: str) -> type:
+    """Dynamically import a poller class from 'module.path:ClassName'."""
+    import importlib
+
+    module_path, class_name = dotted_path.rsplit(":", 1)
+    module = importlib.import_module(module_path)
+    cls: type = getattr(module, class_name)
+    return cls
+
+
+def build_gateway() -> None:
+    """Build and inject Gateway with config-driven channel pollers.
+
+    Reads ``[gateway] pollers`` from ``.geode/config.toml`` to determine
+    which pollers to register. Defaults to all three (slack, discord,
+    telegram) when the config key is absent.
     """
     from core.config import settings
     from core.gateway.channel_manager import ChannelManager, set_gateway
-    from core.gateway.pollers.discord_poller import DiscordPoller
-    from core.gateway.pollers.slack_poller import SlackPoller
-    from core.gateway.pollers.telegram_poller import TelegramPoller
     from core.mcp.notification_port import get_notification
 
     if not settings.gateway_enabled:
@@ -161,7 +177,9 @@ def build_gateway() -> None:
     notification = get_notification()
     poll_interval = settings.gateway_poll_interval_s
 
-    # Load bindings from TOML config (hot-reloadable)
+    # Load config from TOML
+    toml_config: dict[str, Any] = {}
+    config_path = None
     try:
         import tomllib
         from pathlib import Path
@@ -186,33 +204,34 @@ def build_gateway() -> None:
         set_gateway(None)
         return
 
-    manager.register_poller(
-        SlackPoller(
-            manager,
-            mcp_manager=mcp,
-            notification=notification,
-            poll_interval_s=poll_interval,
-        )
+    # Config-driven poller registration
+    enabled_pollers: list[str] = toml_config.get("gateway", {}).get(
+        "pollers", _DEFAULT_POLLERS
     )
-    manager.register_poller(
-        DiscordPoller(
-            manager,
-            mcp_manager=mcp,
-            notification=notification,
-            poll_interval_s=poll_interval,
-        )
-    )
-    manager.register_poller(
-        TelegramPoller(
-            manager,
-            mcp_manager=mcp,
-            notification=notification,
-            poll_interval_s=poll_interval,
-        )
-    )
+
+    for poller_name in enabled_pollers:
+        dotted = _POLLER_REGISTRY.get(poller_name)
+        if dotted is None:
+            log.warning("Unknown poller '%s' in config — skipped", poller_name)
+            continue
+        try:
+            poller_cls = _load_poller_class(dotted)
+            manager.register_poller(
+                poller_cls(
+                    manager,
+                    mcp_manager=mcp,
+                    notification=notification,
+                    poll_interval_s=poll_interval,
+                )
+            )
+        except Exception as exc:
+            log.warning("Poller '%s' init failed: %s", poller_name, exc)
 
     # Hot-reload bindings on config.toml change
     try:
+        import tomllib
+        from pathlib import Path
+
         from core.orchestration.hot_reload import ConfigWatcher
 
         def _reload_bindings(path: Any, mtime: float) -> None:
@@ -226,7 +245,7 @@ def build_gateway() -> None:
             except Exception as reload_exc:
                 log.warning("Gateway binding reload failed: %s", reload_exc)
 
-        if config_path.exists():
+        if config_path and config_path.exists():
             _binding_watcher = ConfigWatcher()
             _binding_watcher.watch(config_path, _reload_bindings, name="gateway-bindings")
             _binding_watcher.start()
@@ -235,7 +254,9 @@ def build_gateway() -> None:
         log.debug("Gateway binding hot-reload not available: %s", exc)
 
     set_gateway(manager)
-    log.info("Gateway built with %d pollers", len(manager._pollers))
+    log.info(
+        "Gateway built with %d pollers (configured: %s)", len(manager._pollers), enabled_pollers
+    )
 
 
 def build_plugins() -> None:

--- a/core/runtime_wiring/adapters.py
+++ b/core/runtime_wiring/adapters.py
@@ -247,9 +247,11 @@ def build_gateway() -> None:
                 log.warning("Gateway binding reload failed: %s", reload_exc)
 
         if config_path and config_path.exists():
-            _binding_watcher = ConfigWatcher()
-            _binding_watcher.watch(config_path, _reload_bindings, name="gateway-bindings")
-            _binding_watcher.start()
+            _watcher = ConfigWatcher()
+            _watcher.watch(config_path, _reload_bindings, name="gateway-bindings")
+            _watcher.start()
+            # Attach to manager to prevent GC (daemon thread lifetime)
+            manager._binding_watcher = _watcher  # type: ignore[attr-defined]
     except Exception as exc:
         _plugin_status["gateway_hot_reload"] = "unavailable"
         log.debug("Gateway binding hot-reload not available: %s", exc)

--- a/tests/test_phase2_hardening.py
+++ b/tests/test_phase2_hardening.py
@@ -1,0 +1,350 @@
+"""Tests for Phase 2 structural defect fixes (C3, H2, M1, M2, M3).
+
+C3: File lock on jobs.json (fcntl.flock)
+H2: Scheduler → LaneQueue (try_acquire / manual_release)
+M1: Config-driven poller registration
+M2: Scheduler PolicyChain (DANGEROUS tool filtering)
+M3: Stuck job detection
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# C3: File lock on jobs.json
+# ---------------------------------------------------------------------------
+
+
+class TestC3FileLock:
+    """Verify inter-process file lock on scheduler save/load."""
+
+    def test_save_creates_lock_file(self, tmp_path: Path) -> None:
+        """save() should create a .lock file alongside jobs.json."""
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        store = tmp_path / "jobs.json"
+        svc = SchedulerService(store_path=store)
+        svc.add_job(
+            ScheduledJob(
+                job_id="c3-1",
+                name="Lock test",
+                schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+                action="test",
+            )
+        )
+        svc.save()
+
+        assert store.exists()
+        assert store.with_suffix(".json.lock").exists()
+
+    def test_load_with_lock(self, tmp_path: Path) -> None:
+        """load() should work correctly with file locking."""
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        store = tmp_path / "jobs.json"
+        svc1 = SchedulerService(store_path=store)
+        svc1.add_job(
+            ScheduledJob(
+                job_id="c3-2",
+                name="Lock load test",
+                schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+                action="test",
+            )
+        )
+        svc1.save()
+
+        svc2 = SchedulerService(store_path=store)
+        svc2.load()
+        assert svc2.job_count == 1
+        assert svc2.get_job("c3-2") is not None
+
+    def test_save_load_roundtrip_with_running_since(self, tmp_path: Path) -> None:
+        """running_since_ms should persist through save/load."""
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        store = tmp_path / "jobs.json"
+        svc = SchedulerService(store_path=store)
+        job = ScheduledJob(
+            job_id="c3-3",
+            name="Running test",
+            schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+            action="test",
+            running_since_ms=1000.0,
+        )
+        svc.add_job(job)
+        svc.save()
+
+        svc2 = SchedulerService(store_path=store)
+        svc2.load()
+        loaded = svc2.get_job("c3-3")
+        assert loaded is not None
+        assert loaded.running_since_ms == 1000.0
+
+
+# ---------------------------------------------------------------------------
+# H2: Lane try_acquire / manual_release
+# ---------------------------------------------------------------------------
+
+
+class TestH2LaneQueue:
+    """Verify Lane.try_acquire() / manual_release() for scheduler."""
+
+    def test_try_acquire_success(self) -> None:
+        from core.orchestration.lane_queue import Lane
+
+        lane = Lane("scheduler", max_concurrent=2)
+        assert lane.try_acquire("job-1")
+        assert lane.active_count == 1
+
+    def test_try_acquire_full_returns_false(self) -> None:
+        from core.orchestration.lane_queue import Lane
+
+        lane = Lane("scheduler", max_concurrent=1)
+        assert lane.try_acquire("job-1")
+        assert not lane.try_acquire("job-2")  # full
+
+    def test_manual_release_frees_slot(self) -> None:
+        from core.orchestration.lane_queue import Lane
+
+        lane = Lane("scheduler", max_concurrent=1)
+        assert lane.try_acquire("job-1")
+        assert not lane.try_acquire("job-2")  # full
+        lane.manual_release("job-1")
+        assert lane.try_acquire("job-2")  # freed
+
+    def test_active_tracking(self) -> None:
+        from core.orchestration.lane_queue import Lane
+
+        lane = Lane("scheduler", max_concurrent=3)
+        lane.try_acquire("a")
+        lane.try_acquire("b")
+        active = lane.get_active()
+        assert "a" in active
+        assert "b" in active
+        lane.manual_release("a")
+        active = lane.get_active()
+        assert "a" not in active
+        assert "b" in active
+
+    def test_stats_tracked(self) -> None:
+        from core.orchestration.lane_queue import Lane
+
+        lane = Lane("scheduler", max_concurrent=2)
+        lane.try_acquire("j1")
+        lane.manual_release("j1")
+        stats = lane.stats.to_dict()
+        assert stats["acquired"] == 1
+        assert stats["released"] == 1
+
+    def test_try_acquire_zero_capacity_tracks_timeout(self) -> None:
+        from core.orchestration.lane_queue import Lane
+
+        lane = Lane("scheduler", max_concurrent=0)
+        assert not lane.try_acquire("j1")
+        assert lane.stats.to_dict()["timeouts"] == 1
+
+
+# ---------------------------------------------------------------------------
+# M1: Config-driven poller registration
+# ---------------------------------------------------------------------------
+
+
+class TestM1ConfigDrivenPollers:
+    """Verify config-driven poller registration."""
+
+    def test_poller_registry_has_three_defaults(self) -> None:
+        from core.runtime_wiring.adapters import _DEFAULT_POLLERS, _POLLER_REGISTRY
+
+        assert set(_DEFAULT_POLLERS) == {"slack", "discord", "telegram"}
+        for name in _DEFAULT_POLLERS:
+            assert name in _POLLER_REGISTRY
+
+    def test_load_poller_class_resolves(self) -> None:
+        from core.runtime_wiring.adapters import _load_poller_class
+
+        cls = _load_poller_class("core.gateway.pollers.slack_poller:SlackPoller")
+        from core.gateway.pollers.slack_poller import SlackPoller
+
+        assert cls is SlackPoller
+
+    def test_load_poller_class_invalid_raises(self) -> None:
+        from core.runtime_wiring.adapters import _load_poller_class
+
+        with pytest.raises(ModuleNotFoundError):
+            _load_poller_class("nonexistent.module:Cls")
+
+
+# ---------------------------------------------------------------------------
+# M2: Scheduler PolicyChain (DANGEROUS tool filtering)
+# ---------------------------------------------------------------------------
+
+
+class TestM2SchedulerPolicyChain:
+    """Verify DANGEROUS tools are filtered in headless modes."""
+
+    def test_headless_denied_tools_defined(self) -> None:
+        from core.gateway.shared_services import _HEADLESS_DENIED_TOOLS
+
+        assert "run_bash" in _HEADLESS_DENIED_TOOLS
+        assert "delegate_task" in _HEADLESS_DENIED_TOOLS
+
+    def test_scheduler_mode_filters_dangerous(self) -> None:
+        """create_session(SCHEDULER) should exclude DANGEROUS tools."""
+        from core.gateway.shared_services import SessionMode, SharedServices
+
+        services = SharedServices(
+            tool_handlers={
+                "web_search": MagicMock(),
+                "run_bash": MagicMock(),
+                "delegate_task": MagicMock(),
+                "memory_search": MagicMock(),
+            },
+            hook_system=MagicMock(),
+        )
+
+        with (
+            patch("core.gateway.shared_services.SharedServices._build_sub_agent_manager"),
+            patch("core.agent.agentic_loop.AgenticLoop.__init__", return_value=None),
+            patch("core.agent.tool_executor.ToolExecutor.__init__", return_value=None) as te_init,
+            patch("core.cli.session_state.set_current_loop"),
+        ):
+            services.create_session(SessionMode.SCHEDULER)
+            # ToolExecutor should receive filtered handlers
+            call_kwargs = te_init.call_args
+            handlers = call_kwargs.kwargs.get("action_handlers", call_kwargs.args[0] if call_kwargs.args else {})
+            assert "run_bash" not in handlers
+            assert "delegate_task" not in handlers
+            assert "web_search" in handlers
+            assert "memory_search" in handlers
+
+    def test_repl_mode_keeps_all_tools(self) -> None:
+        """create_session(REPL) should NOT filter tools."""
+        from core.gateway.shared_services import SessionMode, SharedServices
+
+        services = SharedServices(
+            tool_handlers={
+                "web_search": MagicMock(),
+                "run_bash": MagicMock(),
+                "memory_search": MagicMock(),
+            },
+            hook_system=MagicMock(),
+        )
+
+        with (
+            patch("core.gateway.shared_services.SharedServices._build_sub_agent_manager"),
+            patch("core.agent.agentic_loop.AgenticLoop.__init__", return_value=None),
+            patch("core.agent.tool_executor.ToolExecutor.__init__", return_value=None) as te_init,
+            patch("core.cli.session_state.set_current_loop"),
+        ):
+            services.create_session(SessionMode.REPL)
+            call_kwargs = te_init.call_args
+            handlers = call_kwargs.kwargs.get("action_handlers", call_kwargs.args[0] if call_kwargs.args else {})
+            assert "run_bash" in handlers
+
+
+# ---------------------------------------------------------------------------
+# M3: Stuck job detection
+# ---------------------------------------------------------------------------
+
+
+class TestM3StuckJobDetection:
+    """Verify stuck job detection in scheduler tick loop."""
+
+    def test_detect_stuck_marks_status(self) -> None:
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        svc = SchedulerService()
+        job = ScheduledJob(
+            job_id="stuck-1",
+            name="Stuck Job",
+            schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+            action="test",
+            running_since_ms=1.0,  # started at epoch + 1ms
+        )
+        svc.add_job(job)
+
+        # Simulate 20 minutes later
+        now_ms = 1.0 + 1_200_000
+        stuck = svc.detect_stuck_jobs(now_ms=now_ms)
+
+        assert stuck == ["stuck-1"]
+        assert job.last_status == "stuck"
+        assert job.running_since_ms is None
+
+    def test_not_stuck_below_threshold(self) -> None:
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        svc = SchedulerService()
+        now = time.time() * 1000
+        job = ScheduledJob(
+            job_id="ok-1",
+            name="OK Job",
+            schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+            action="test",
+            running_since_ms=now - 1000,  # started 1s ago
+        )
+        svc.add_job(job)
+
+        stuck = svc.detect_stuck_jobs(now_ms=now)
+        assert stuck == []
+        assert job.running_since_ms is not None  # unchanged
+
+    def test_no_running_jobs_returns_empty(self) -> None:
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        svc = SchedulerService()
+        job = ScheduledJob(
+            job_id="idle-1",
+            name="Idle Job",
+            schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+            action="test",
+            running_since_ms=None,  # not running
+        )
+        svc.add_job(job)
+
+        stuck = svc.detect_stuck_jobs()
+        assert stuck == []
+
+    def test_execute_job_tracks_running_since(self) -> None:
+        """_execute_job should set and clear running_since_ms."""
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        svc = SchedulerService()
+        job = ScheduledJob(
+            job_id="track-1",
+            name="Track Job",
+            schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+            callback=lambda d: None,
+        )
+        svc.add_job(job)
+        svc._execute_job(job)
+
+        # After execution, running_since_ms should be cleared
+        assert job.running_since_ms is None
+        assert job.last_status == "ok"
+
+    def test_stuck_timeout_configurable(self) -> None:
+        from core.automation.scheduler import Schedule, ScheduledJob, ScheduleKind, SchedulerService
+
+        svc = SchedulerService()
+        svc.STUCK_TIMEOUT_MS = 5000  # 5 seconds
+
+        now = time.time() * 1000
+        job = ScheduledJob(
+            job_id="short-1",
+            name="Short Timeout",
+            schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60000),
+            action="test",
+            running_since_ms=now - 10_000,  # started 10s ago
+        )
+        svc.add_job(job)
+
+        stuck = svc.detect_stuck_jobs(now_ms=now)
+        assert stuck == ["short-1"]

--- a/tests/test_phase2_hardening.py
+++ b/tests/test_phase2_hardening.py
@@ -9,13 +9,11 @@ M3: Stuck job detection
 
 from __future__ import annotations
 
-import json
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # C3: File lock on jobs.json

--- a/tests/test_phase2_hardening.py
+++ b/tests/test_phase2_hardening.py
@@ -218,7 +218,9 @@ class TestM2SchedulerPolicyChain:
             services.create_session(SessionMode.SCHEDULER)
             # ToolExecutor should receive filtered handlers
             call_kwargs = te_init.call_args
-            handlers = call_kwargs.kwargs.get("action_handlers", call_kwargs.args[0] if call_kwargs.args else {})
+            handlers = call_kwargs.kwargs.get(
+                "action_handlers", call_kwargs.args[0] if call_kwargs.args else {}
+            )
             assert "run_bash" not in handlers
             assert "delegate_task" not in handlers
             assert "web_search" in handlers
@@ -245,7 +247,9 @@ class TestM2SchedulerPolicyChain:
         ):
             services.create_session(SessionMode.REPL)
             call_kwargs = te_init.call_args
-            handlers = call_kwargs.kwargs.get("action_handlers", call_kwargs.args[0] if call_kwargs.args else {})
+            handlers = call_kwargs.kwargs.get(
+                "action_handlers", call_kwargs.args[0] if call_kwargs.args else {}
+            )
             assert "run_bash" in handlers
 
 

--- a/tests/test_phase3_ipc.py
+++ b/tests/test_phase3_ipc.py
@@ -1,0 +1,303 @@
+"""Tests for Phase 3: CLIChannel IPC (H3 resolution).
+
+Tests the Unix domain socket protocol between CLIPoller (server) and
+IPCClient (client), including connection, prompt relay, and error handling.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Unix domain socket paths must be < 104 chars on macOS.
+# pytest tmp_path is too long, so we use /tmp/ directly.
+_SOCK_PREFIX = Path("/tmp/geode-test-ipc")
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_sockets() -> None:
+    """Clean up test sockets before and after each test."""
+    import glob
+
+    for f in glob.glob(str(_SOCK_PREFIX) + "*"):
+        Path(f).unlink(missing_ok=True)
+    yield  # type: ignore[misc]
+    for f in glob.glob(str(_SOCK_PREFIX) + "*"):
+        Path(f).unlink(missing_ok=True)
+
+
+def _test_sock() -> Path:
+    return _SOCK_PREFIX.with_suffix(f".{time.monotonic_ns()}.sock")
+
+
+# ---------------------------------------------------------------------------
+# IPC Client unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIPCClient:
+    """Test the thin CLI IPC client."""
+
+    def test_is_serve_running_no_socket(self, tmp_path: Path) -> None:
+        from core.cli.ipc_client import is_serve_running
+
+        assert not is_serve_running(tmp_path / "nonexistent.sock")
+
+    def test_is_serve_running_stale_socket(self, tmp_path: Path) -> None:
+        from core.cli.ipc_client import is_serve_running
+
+        sock_path = tmp_path / "stale.sock"
+        sock_path.touch()  # file exists but no server
+        assert not is_serve_running(sock_path)
+
+    def test_client_connect_no_server(self, tmp_path: Path) -> None:
+        from core.cli.ipc_client import IPCClient
+
+        client = IPCClient(socket_path=tmp_path / "noserver.sock")
+        assert not client.connect()
+        assert not client.connected
+
+    def test_client_send_prompt_not_connected(self) -> None:
+        from core.cli.ipc_client import IPCClient
+
+        client = IPCClient()
+        result = client.send_prompt("test")
+        assert result["type"] == "error"
+        assert "Not connected" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# CLIPoller unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIPoller:
+    """Test the Unix socket server for CLI IPC."""
+
+    def test_start_creates_socket(self) -> None:
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+
+        poller.start()
+        try:
+            assert sock_path.exists()
+            assert poller.channel_name == "cli"
+        finally:
+            poller.stop()
+
+    def test_stop_removes_socket(self) -> None:
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+
+        poller.start()
+        assert sock_path.exists()
+        poller.stop()
+        assert not sock_path.exists()
+
+    def test_cleans_stale_socket(self) -> None:
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        sock_path.touch()  # stale file from previous run
+        mock_services = MagicMock()
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+
+        poller.start()
+        try:
+            # Should have cleaned up stale and created new
+            assert sock_path.exists()
+        finally:
+            poller.stop()
+
+
+# ---------------------------------------------------------------------------
+# Integration: CLIPoller ↔ IPCClient
+# ---------------------------------------------------------------------------
+
+
+class TestCLIChannelIntegration:
+    """End-to-end tests for CLIPoller ↔ IPCClient IPC."""
+
+    def test_connect_and_receive_session(self) -> None:
+        """Client should receive session ID on connect."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+
+        # Mock create_session to return a mock loop
+        mock_loop = MagicMock()
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)  # wait for accept loop
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            assert client.connect()
+            assert client.session_id.startswith("cli-")
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_send_prompt_and_receive_result(self) -> None:
+        """Client sends prompt, server runs loop, client gets result."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.text = "Berserk scored S tier (81.2)"
+        mock_result.rounds = 3
+        mock_result.tool_calls = []
+        mock_result.termination_reason = "natural"
+
+        mock_loop = MagicMock()
+        mock_loop.run.return_value = mock_result
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.send_prompt("analyze Berserk")
+            assert result["type"] == "result"
+            assert "Berserk" in result["text"]
+            assert result["rounds"] == 3
+            assert result["tool_calls"] == []
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_send_prompt_error_handling(self) -> None:
+        """Server should return error when loop.run() raises."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+
+        mock_loop = MagicMock()
+        mock_loop.run.side_effect = RuntimeError("API key missing")
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.send_prompt("do something")
+            assert result["type"] == "error"
+            assert "API key" in result["message"]
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_empty_prompt_rejected(self) -> None:
+        """Empty prompt should return error without calling loop."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        mock_loop = MagicMock()
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.send_prompt("")
+            assert result["type"] == "error"
+            assert "Empty" in result["message"]
+            mock_loop.run.assert_not_called()
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_multiple_prompts_same_session(self) -> None:
+        """Multiple prompts on same connection should use same session."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.text = "response"
+        mock_result.rounds = 1
+        mock_result.tool_calls = []
+        mock_result.termination_reason = "natural"
+
+        mock_loop = MagicMock()
+        mock_loop.run.return_value = mock_result
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            client.send_prompt("first")
+            client.send_prompt("second")
+            client.send_prompt("third")
+
+            assert mock_loop.run.call_count == 3
+            # create_session called once (same session for all prompts)
+            mock_services.create_session.assert_called_once()
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_is_serve_running_with_real_server(self) -> None:
+        """is_serve_running should detect a live CLIPoller."""
+        from core.cli.ipc_client import is_serve_running
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        mock_services.create_session.return_value = (MagicMock(), MagicMock())
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            assert is_serve_running(sock_path)
+        finally:
+            poller.stop()
+
+        assert not is_serve_running(sock_path)

--- a/tests/test_phase3_ipc.py
+++ b/tests/test_phase3_ipc.py
@@ -6,17 +6,15 @@ IPCClient (client), including connection, prompt relay, and error handling.
 
 from __future__ import annotations
 
-import json
-import socket
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 # Unix domain socket paths must be < 104 chars on macOS.
 # pytest tmp_path is too long, so we use /tmp/ directly.
-_SOCK_PREFIX = Path("/tmp/geode-test-ipc")
+_SOCK_PREFIX = Path("/tmp/geode-test-ipc")  # noqa: S108
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_scheduler_serve.py
+++ b/tests/test_scheduler_serve.py
@@ -8,12 +8,12 @@ that the SchedulerService lifecycle (init/load/save/stop) is correct.
 from __future__ import annotations
 
 import queue
-import threading
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from core.cli import _drain_scheduler_queue
+from core.orchestration.lane_queue import Lane
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -42,8 +42,8 @@ def mock_runner() -> MagicMock:
 
 
 @pytest.fixture()
-def semaphore() -> threading.Semaphore:
-    return threading.Semaphore(2)
+def scheduler_lane() -> Lane:
+    return Lane("scheduler", max_concurrent=2, timeout_s=300.0)
 
 
 # ---------------------------------------------------------------------------
@@ -59,14 +59,14 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        semaphore: threading.Semaphore,
+        scheduler_lane: Lane,
     ) -> None:
         """Empty queue should drain nothing and return 0."""
         count = _drain_scheduler_queue(
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=semaphore,
+            scheduler_lane=scheduler_lane,
             force_isolated=True,
         )
         assert count == 0
@@ -77,7 +77,7 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        semaphore: threading.Semaphore,
+        scheduler_lane: Lane,
     ) -> None:
         """Isolated job should be dispatched via runner.run_async()."""
         action_queue.put(("job-1", "do something", True))
@@ -87,7 +87,7 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=semaphore,
+            scheduler_lane=scheduler_lane,
             force_isolated=False,
             on_dispatch=lambda jid: dispatched.append(jid),
         )
@@ -101,7 +101,7 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        semaphore: threading.Semaphore,
+        scheduler_lane: Lane,
     ) -> None:
         """In serve mode (force_isolated=True), non-isolated jobs run isolated."""
         action_queue.put(("job-2", "run report", False))  # isolated=False
@@ -110,7 +110,7 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=semaphore,
+            scheduler_lane=scheduler_lane,
             force_isolated=True,  # serve mode
         )
 
@@ -123,7 +123,7 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        semaphore: threading.Semaphore,
+        scheduler_lane: Lane,
     ) -> None:
         """Non-isolated job in REPL mode should use main_loop.run()."""
         action_queue.put(("job-3", "check status", False))
@@ -134,7 +134,7 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=semaphore,
+            scheduler_lane=scheduler_lane,
             force_isolated=False,
             main_loop=main_loop,
             on_main_run=lambda jid: main_runs.append(jid),
@@ -146,14 +146,14 @@ class TestDrainSchedulerQueue:
         assert "[scheduled-job:job-3]" in main_loop.run.call_args[0][0]
         assert main_runs == ["job-3"]
 
-    def test_semaphore_full_skips_job(
+    def test_lane_full_skips_job(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
     ) -> None:
-        """Jobs should be skipped when semaphore is exhausted."""
-        sem = threading.Semaphore(0)  # zero capacity — always full
+        """Jobs should be skipped when scheduler lane is full."""
+        full_lane = Lane("scheduler", max_concurrent=0)  # zero capacity — always full
         action_queue.put(("job-4", "important task", True))
         skipped: list[str] = []
 
@@ -161,7 +161,7 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=sem,
+            scheduler_lane=full_lane,
             force_isolated=True,
             on_skip=lambda jid: skipped.append(jid),
         )
@@ -175,7 +175,7 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        semaphore: threading.Semaphore,
+        scheduler_lane: Lane,
     ) -> None:
         """Jobs with empty fired_action should be silently skipped."""
         action_queue.put(("job-5", "", True))
@@ -184,7 +184,7 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=semaphore,
+            scheduler_lane=scheduler_lane,
             force_isolated=True,
         )
 
@@ -201,13 +201,13 @@ class TestDrainSchedulerQueue:
         action_queue.put(("j1", "task one", True))
         action_queue.put(("j2", "task two", True))
         action_queue.put(("j3", "task three", True))
-        big_sem = threading.Semaphore(5)
+        big_lane = Lane("scheduler", max_concurrent=5, timeout_s=300.0)
 
         count = _drain_scheduler_queue(
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=big_sem,
+            scheduler_lane=big_lane,
             force_isolated=True,
         )
 
@@ -224,37 +224,37 @@ class TestDrainSchedulerQueue:
 class TestDrainErrorPaths:
     """Verify exception safety in drain loop."""
 
-    def test_create_session_failure_releases_semaphore(
+    def test_create_session_failure_releases_lane(
         self,
         action_queue: queue.Queue,
         mock_runner: MagicMock,
     ) -> None:
-        """Semaphore must be released if create_session() raises."""
+        """Lane slot must be released if create_session() raises."""
         failing_services = MagicMock()
         failing_services.create_session.side_effect = RuntimeError("MCP down")
-        sem = threading.Semaphore(2)
+        lane = Lane("scheduler", max_concurrent=2, timeout_s=300.0)
         action_queue.put(("job-err", "fail task", True))
 
         count = _drain_scheduler_queue(
             action_queue=action_queue,
             services=failing_services,
             runner=mock_runner,
-            semaphore=sem,
+            scheduler_lane=lane,
             force_isolated=True,
         )
 
         assert count == 1
         mock_runner.run_async.assert_not_called()
-        # Semaphore should NOT be leaked — verify by acquiring both slots
-        assert sem.acquire(timeout=0)
-        assert sem.acquire(timeout=0)
+        # Lane should NOT be leaked — verify by acquiring both slots
+        assert lane.try_acquire("check-1")
+        assert lane.try_acquire("check-2")
 
     def test_main_loop_exception_continues_drain(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        semaphore: threading.Semaphore,
+        scheduler_lane: Lane,
     ) -> None:
         """main_loop.run() exception should not kill the drain loop."""
         failing_loop = MagicMock()
@@ -266,7 +266,7 @@ class TestDrainErrorPaths:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            semaphore=semaphore,
+            scheduler_lane=scheduler_lane,
             force_isolated=False,
             main_loop=failing_loop,
         )


### PR DESCRIPTION
## Summary
- **Phase 2 (5 defects)**: C3 file lock, H2 LaneQueue, M1 config pollers, M2 PolicyChain, M3 stuck detection
- **Phase 3 (1 defect)**: H3 CLIChannel IPC — REPL → serve thin client via Unix domain socket
- **Verification**: 4-persona review (Beck/Karpathy/Steinberger/Cherny), P1 findings fixed

## Why
Session 47 identified 6 remaining structural defects (C3/H2/H3/M1/M2/M3) blocking the Gateway Runtime target architecture. Phase 2 hardens the scheduler and poller subsystems. Phase 3 introduces IPC so the REPL can delegate to serve instead of duplicating resources.

## Changes

### Phase 2: Scheduler Hardening
| Defect | Fix |
|--------|-----|
| C3: Dual Scheduler race | `fcntl.flock(LOCK_EX/LOCK_SH)` on jobs.json |
| H2: LaneQueue bypass | `Lane.try_acquire()`/`manual_release()` replaces ad-hoc Semaphore(2) |
| M1: Poller hardcoding | `_POLLER_REGISTRY` + config.toml `[gateway] pollers` |
| M2: PolicyChain missing | `_HEADLESS_DENIED_TOOLS` filters run_bash/delegate_task in SCHEDULER/DAEMON |
| M3: Stuck job detection | `running_since_ms` + `detect_stuck_jobs()` in tick loop (10min threshold) |

### Phase 3: CLIChannel IPC
- `CLIPoller`: Unix domain socket server (`~/.geode/cli.sock`)
- `IPCClient`: thin client with auto-detect + standalone fallback
- Line-delimited JSON protocol (prompt/result/error/exit)
- serve() registers CLIPoller, REPL auto-connects when serve detected

### Verification P1 Fixes
- Steinberger: `_binding_watcher` attached to manager (prevent GC)
- Cherny/Beck: headless denied tools logged on filtering

## Test plan
- [x] 3419 tests pass (3386 → 3419, +33)
- [x] Lint: `ruff check` 0 errors
- [x] Type: `mypy` 0 errors
- [x] Format: `ruff format --check` clean
- [x] 4-persona verification team review

🤖 Generated with [Claude Code](https://claude.com/claude-code)