### PR TITLE
refactor: SessionLane — per-key serialization (OpenClaw pattern)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
-- **Unified LaneQueue (Option B)** — 3 independent LaneQueue instances + IsolatedRunner Semaphore(5) consolidated into single LaneQueue with 4 named lanes: `session`(1), `global`(5), `gateway`(2), `scheduler`(2). IsolatedRunner is now a pure executor — concurrency gated by `Lane("global")` instead of internal semaphore. SharedServices owns the unified LaneQueue.
+- **SessionLane — per-key serialization** — replaced 4-lane system (session/global/gateway/scheduler) with OpenClaw pattern: `SessionLane` (per-session-key `Semaphore(1)`) + `Lane("global", max=8)`. Same session key serializes, different keys parallel. `acquire_all(key, ["session", "global"])` unifies all execution paths. OpenClaw defect fixes: `max_sessions=256` cap, `cleanup_idle()` eviction.
 
 ### Added
 - **H3: CLIChannel IPC** — Unix domain socket (`~/.geode/cli.sock`) connects thin CLI client to `geode serve`. `CLIPoller` accepts local connections, creates REPL sessions via SharedServices. `IPCClient` auto-detects serve and delegates agentic execution over line-delimited JSON protocol. Fallback to standalone when serve is not running.

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -105,7 +105,8 @@ def _drain_scheduler_queue(
     action_queue: Any,
     services: Any,
     runner: Any,
-    scheduler_lane: Any,
+    session_lane: Any,
+    global_lane: Any,
     force_isolated: bool = False,
     main_loop: Any | None = None,
     on_complete: Any | None = None,
@@ -118,8 +119,8 @@ def _drain_scheduler_queue(
     Shared by both REPL and serve modes.  In serve mode ``force_isolated``
     is True because there is no interactive main session to inject into.
 
-    Uses ``Lane.try_acquire`` / ``manual_release`` for concurrency control
-    through the central LaneQueue (replacing ad-hoc Semaphore).
+    Uses SessionLane (per-key serial) + Global Lane (capacity) for
+    concurrency control through the unified LaneQueue.
 
     Returns the number of jobs drained.
     """
@@ -137,18 +138,23 @@ def _drain_scheduler_queue(
             prompt = f"[scheduled-job:{job_id}] {fired_action}"
 
             if isolated or force_isolated:
-                lane_key = f"scheduled:{job_id}"
-                if not scheduler_lane.try_acquire(lane_key):
-                    log.warning(
-                        "Scheduler lane full (max %d), skipping job %s",
-                        scheduler_lane.max_concurrent,
-                        job_id,
-                    )
+                lane_key = f"sched:{job_id}"
+
+                # Dual acquire: session (per-key serial) + global (capacity)
+                if not session_lane.try_acquire(lane_key):
+                    log.warning("Session key busy, skipping job %s", job_id)
                     if on_skip:
                         on_skip(job_id)
                     continue
 
-                _lane_acquired = True
+                if not global_lane.try_acquire(lane_key):
+                    session_lane.manual_release(lane_key)
+                    log.warning("Global lane full, skipping job %s", job_id)
+                    if on_skip:
+                        on_skip(job_id)
+                    continue
+
+                _lanes_acquired = True
                 try:
                     _iso_conv = ConversationContext()
                     from core.gateway.shared_services import SessionMode
@@ -161,7 +167,8 @@ def _drain_scheduler_queue(
                     _cap_loop = _iso_loop
                     _cap_prompt = prompt
                     _cap_jid = job_id
-                    _cap_lane = scheduler_lane
+                    _cap_sess = session_lane
+                    _cap_glob = global_lane
                     _cap_key = lane_key
                     _cap_cb = on_complete
 
@@ -170,7 +177,8 @@ def _drain_scheduler_queue(
                         _loop: Any = _cap_loop,
                         _p: str = _cap_prompt,
                         _jid: str = _cap_jid,
-                        _lane: Any = _cap_lane,
+                        _sess: Any = _cap_sess,
+                        _glob: Any = _cap_glob,
                         _key: str = _cap_key,
                         _cb: Any = _cap_cb,
                     ) -> str:
@@ -180,7 +188,8 @@ def _drain_scheduler_queue(
                                 _cb(r, job_id=_jid)
                             return r.text if r and r.text else ""
                         finally:
-                            _lane.manual_release(_key)
+                            _glob.manual_release(_key)
+                            _sess.manual_release(_key)
 
                     runner.run_async(
                         _run_isolated,
@@ -190,12 +199,13 @@ def _drain_scheduler_queue(
                             timeout_s=300.0,
                         ),
                     )
-                    _lane_acquired = False  # ownership transferred to _run_isolated
+                    _lanes_acquired = False  # ownership transferred to _run_isolated
                     if on_dispatch:
                         on_dispatch(job_id)
                 except Exception:
-                    if _lane_acquired:
-                        scheduler_lane.manual_release(lane_key)
+                    if _lanes_acquired:
+                        global_lane.manual_release(lane_key)
+                        session_lane.manual_release(lane_key)
                     log.warning("Scheduler job %s dispatch failed", job_id, exc_info=True)
             else:
                 # Non-isolated: inject into main session (REPL only)
@@ -1074,7 +1084,8 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
         skill_registry=skill_registry,
         verbose=verbose,
     )
-    _sched_lane = services.lane_queue.get_lane("scheduler")
+    _session_lane = services.lane_queue.session_lane
+    _global_lane = services.lane_queue.get_lane("global")
 
     # Wire module-level hooks for _fire_hook() callers
     global _hooks_ctx
@@ -1144,7 +1155,8 @@ def _interactive_loop(resume_session_id: str | None = None) -> None:
             action_queue=_action_queue,
             services=services,
             runner=_sched_runner,
-            scheduler_lane=_sched_lane,
+            session_lane=_session_lane,
+            global_lane=_global_lane,
             force_isolated=False,
             main_loop=agentic,
             on_complete=_on_sched_complete,
@@ -1937,7 +1949,8 @@ def serve(
         console.print("  [warning]Scheduler init failed — running without scheduler[/warning]")
 
     _sched_runner = IsolatedRunner()
-    _serve_sched_lane = _gw_services.lane_queue.get_lane("scheduler")
+    _serve_session_lane = _gw_services.lane_queue.session_lane
+    _serve_global_lane = _gw_services.lane_queue.get_lane("global")
 
     def _gateway_processor(content: str, metadata: dict[str, Any]) -> str:
         """Process a gateway message with multi-turn context.
@@ -2035,12 +2048,16 @@ def serve(
                 action_queue=_sched_queue,
                 services=_gw_services,
                 runner=_sched_runner,
-                scheduler_lane=_serve_sched_lane,
+                session_lane=_serve_session_lane,
+                global_lane=_serve_global_lane,
                 force_isolated=True,
                 on_complete=lambda result, *, job_id: log.info("scheduled:%s completed", job_id),
                 on_dispatch=lambda jid: log.info("scheduled:%s dispatched", jid),
                 on_skip=lambda jid: log.warning("scheduled:%s skipped (slots full)", jid),
             )
+            # Periodic idle session cleanup
+            if _serve_session_lane:
+                _serve_session_lane.cleanup_idle()
             _time.sleep(1.0)
     finally:
         # Scheduler graceful shutdown (save state before stopping)

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -150,13 +150,9 @@ class ChannelManager:
             content = f"[allowed_tools: {tools_hint}] {content}"
 
         try:
-            # Route through Lane Queue if available (OpenClaw pattern)
+            # Route through SessionLane → Global Lane (OpenClaw pattern)
             if self._lane_queue is not None:
-                gateway_lane = self._lane_queue.get_lane("gateway")
-                if gateway_lane is not None:
-                    with gateway_lane.acquire(session_key):
-                        response = self._processor(content, metadata)
-                else:
+                with self._lane_queue.acquire_all(session_key, ["session", "global"]):
                     response = self._processor(content, metadata)
             else:
                 response = self._processor(content, metadata)

--- a/core/orchestration/lane_queue.py
+++ b/core/orchestration/lane_queue.py
@@ -1,9 +1,13 @@
 """Lane Queue — concurrency control with named lanes.
 
 Inspired by OpenClaw's Lane Queue system:
-- Session Lane: serial per session (same session requests queued)
-- Global Lane: max N concurrent across all sessions
-- Named lanes with independent maxConcurrent and timeout settings
+- SessionLane: per-session-key serialization (same key → serial, different keys → parallel)
+- Lane (Global): max N concurrent across all sessions
+- All execution paths: SessionLane.acquire(key) → Global.acquire(key) → Execute
+
+OpenClaw defect fixes:
+- max_sessions cap prevents unbounded session key creation
+- cleanup_idle() evicts sessions idle beyond timeout
 """
 
 from __future__ import annotations
@@ -13,6 +17,7 @@ import threading
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -156,21 +161,235 @@ class Lane:
         with self._lock:
             return {k: now - v for k, v in self._active.items()}
 
+    # --- Internal: for LaneQueue.acquire_all() duck-typing ----
+
+    def _raw_acquire(self, key: str) -> bool:
+        """Acquire slot using lane's default timeout. For acquire_all()."""
+        acquired = self._semaphore.acquire(timeout=self.timeout_s)
+        if not acquired:
+            self._stats.inc_timeouts()
+            return False
+        with self._lock:
+            self._active[key] = time.time()
+        self._stats.inc_acquired()
+        return True
+
+    def _raw_release(self, key: str) -> None:
+        """Release slot. For acquire_all()."""
+        self._semaphore.release()
+        with self._lock:
+            self._active.pop(key, None)
+        self._stats.inc_released()
+
+
+# ---------------------------------------------------------------------------
+# SessionLane — per-key serialization (OpenClaw Session Lane pattern)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SessionEntry:
+    """Per-session-key state: a Semaphore(1) + metadata."""
+
+    semaphore: threading.Semaphore = field(default_factory=lambda: threading.Semaphore(1))
+    last_used: float = field(default_factory=time.time)
+    held: bool = False
+
+
+class SessionLane:
+    """Per-session-key serialization lane.
+
+    Each unique session key gets its own ``Semaphore(1)``.  Same key →
+    serial.  Different keys → fully parallel.  Bounded by *max_sessions*
+    to prevent unbounded memory growth (OpenClaw defect fix).
+
+    API matches :class:`Lane` for duck-typing in :meth:`LaneQueue.acquire_all`.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_sessions: int = 256,
+        idle_timeout_s: float = 300.0,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self.name = "session"
+        self.max_sessions = max_sessions
+        self.idle_timeout_s = idle_timeout_s
+        self.timeout_s = timeout_s
+        self._sessions: dict[str, _SessionEntry] = {}
+        self._lock = threading.Lock()
+        self._stats = _LaneStats()
+
+    @property
+    def stats(self) -> _LaneStats:
+        return self._stats
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return sum(1 for e in self._sessions.values() if e.held)
+
+    @property
+    def session_count(self) -> int:
+        with self._lock:
+            return len(self._sessions)
+
+    # --- Context manager (matches Lane.acquire) ---
+
+    @contextmanager
+    def acquire(self, key: str) -> Generator[None, None, None]:
+        """Acquire the per-key semaphore. Blocks if same key is active."""
+        entry = self._get_or_create(key)
+        acquired = entry.semaphore.acquire(timeout=self.timeout_s)
+        if not acquired:
+            self._stats.inc_timeouts()
+            raise TimeoutError(f"SessionLane timeout for key '{key}' after {self.timeout_s}s")
+        entry.held = True
+        entry.last_used = time.time()
+        self._stats.inc_acquired()
+        try:
+            yield
+        finally:
+            entry.held = False
+            entry.last_used = time.time()
+            entry.semaphore.release()
+            self._stats.inc_released()
+
+    # --- Non-blocking (matches Lane.try_acquire) ---
+
+    def try_acquire(self, key: str) -> bool:
+        """Non-blocking acquire. Returns True if acquired."""
+        entry = self._get_or_create(key)
+        acquired = entry.semaphore.acquire(timeout=0)
+        if not acquired:
+            self._stats.inc_timeouts()
+            return False
+        entry.held = True
+        entry.last_used = time.time()
+        self._stats.inc_acquired()
+        return True
+
+    # --- Blocking with timeout (matches Lane.acquire_timeout) ---
+
+    def acquire_timeout(self, key: str, timeout_s: float) -> bool:
+        """Blocking acquire with explicit timeout."""
+        entry = self._get_or_create(key)
+        acquired = entry.semaphore.acquire(timeout=timeout_s)
+        if not acquired:
+            self._stats.inc_timeouts()
+            return False
+        entry.held = True
+        entry.last_used = time.time()
+        self._stats.inc_acquired()
+        return True
+
+    # --- Manual release (matches Lane.manual_release) ---
+
+    def manual_release(self, key: str) -> None:
+        """Release after try_acquire/acquire_timeout."""
+        with self._lock:
+            entry = self._sessions.get(key)
+        if entry is not None:
+            entry.held = False
+            entry.last_used = time.time()
+            entry.semaphore.release()
+            self._stats.inc_released()
+
+    # --- Observability ---
+
+    def get_active(self) -> dict[str, float]:
+        """Return held sessions with elapsed time since last use."""
+        now = time.time()
+        with self._lock:
+            return {k: now - e.last_used for k, e in self._sessions.items() if e.held}
+
+    # --- Idle cleanup (OpenClaw defect fix) ---
+
+    def cleanup_idle(self) -> int:
+        """Evict sessions idle beyond *idle_timeout_s*. Returns count evicted."""
+        with self._lock:
+            return self._evict_idle_locked()
+
+    # --- Internal: for LaneQueue.acquire_all() duck-typing ---
+
+    def _raw_acquire(self, key: str) -> bool:
+        entry = self._get_or_create(key)
+        acquired = entry.semaphore.acquire(timeout=self.timeout_s)
+        if not acquired:
+            self._stats.inc_timeouts()
+            return False
+        entry.held = True
+        entry.last_used = time.time()
+        self._stats.inc_acquired()
+        return True
+
+    def _raw_release(self, key: str) -> None:
+        with self._lock:
+            entry = self._sessions.get(key)
+        if entry is not None:
+            entry.held = False
+            entry.last_used = time.time()
+            entry.semaphore.release()
+            self._stats.inc_released()
+
+    # --- Internal helpers ---
+
+    def _get_or_create(self, key: str) -> _SessionEntry:
+        with self._lock:
+            entry = self._sessions.get(key)
+            if entry is not None:
+                return entry
+            if len(self._sessions) >= self.max_sessions:
+                self._evict_idle_locked()
+            if len(self._sessions) >= self.max_sessions:
+                raise RuntimeError(
+                    f"SessionLane full ({self.max_sessions} sessions, no idle sessions to evict)"
+                )
+            entry = _SessionEntry()
+            self._sessions[key] = entry
+            return entry
+
+    def _evict_idle_locked(self) -> int:
+        """Evict idle sessions. Must hold self._lock."""
+        now = time.time()
+        to_remove = [
+            k
+            for k, e in self._sessions.items()
+            if not e.held and (now - e.last_used) > self.idle_timeout_s
+        ]
+        for k in to_remove:
+            del self._sessions[k]
+        if to_remove:
+            log.debug("SessionLane: evicted %d idle sessions", len(to_remove))
+        return len(to_remove)
+
 
 class LaneQueue:
-    """Multi-lane concurrency control system.
+    """Multi-lane concurrency control system with per-key session serialization.
 
-    Usage:
+    Usage (OpenClaw pattern: SessionLane → Global Lane → Execute)::
+
         queue = LaneQueue()
-        queue.add_lane("session", max_concurrent=1)  # Serial per session
-        queue.add_lane("global", max_concurrent=4)    # Max 4 concurrent
+        queue.set_session_lane(SessionLane(max_sessions=256))
+        queue.add_lane("global", max_concurrent=8)
 
-        with queue.acquire_all("ip:berserk:analysis", ["session", "global"]):
-            # ... do work (holds both lanes) ...
+        with queue.acquire_all("gateway:slack:C123:U456", ["session", "global"]):
+            # ... do work (session serialized + global gated) ...
     """
 
     def __init__(self) -> None:
         self._lanes: dict[str, Lane] = {}
+        self._session_lane: SessionLane | None = None
+
+    def set_session_lane(self, session_lane: SessionLane) -> None:
+        """Register the SessionLane for per-key serialization."""
+        self._session_lane = session_lane
+
+    @property
+    def session_lane(self) -> SessionLane | None:
+        """The SessionLane, if registered."""
+        return self._session_lane
 
     def add_lane(
         self,
@@ -188,7 +407,10 @@ class LaneQueue:
         return self._lanes.get(name)
 
     def list_lanes(self) -> list[str]:
-        return list(self._lanes.keys())
+        names = list(self._lanes.keys())
+        if self._session_lane is not None:
+            names.insert(0, "session")
+        return names
 
     @contextmanager
     def acquire_all(
@@ -198,46 +420,56 @@ class LaneQueue:
     ) -> Generator[None, None, None]:
         """Acquire slots in multiple lanes (in order). Releases all on exit.
 
+        Supports both :class:`Lane` and :class:`SessionLane` via duck-typed
+        ``_raw_acquire`` / ``_raw_release`` methods.
+
         Args:
-            key: Work item identifier.
+            key: Work item identifier (session key).
             lane_names: Lane names to acquire in order.
+                Use ``"session"`` for the SessionLane.
         """
-        acquired_sems: list[Lane] = []
+        acquired: list[Lane | SessionLane] = []
         try:
             for name in lane_names:
-                lane = self._lanes.get(name)
-                if lane is None:
-                    raise KeyError(f"Lane '{name}' not found")
-                if not lane._semaphore.acquire(timeout=lane.timeout_s):
-                    raise TimeoutError(
-                        f"Lane '{name}' timeout after {lane.timeout_s}s "
-                        f"(max_concurrent={lane.max_concurrent})"
-                    )
-                acquired_sems.append(lane)
-                with lane._lock:
-                    lane._active[key] = time.time()
-                lane._stats.inc_acquired()
+                if name == "session":
+                    if self._session_lane is None:
+                        continue  # no session lane registered, skip
+                    if not self._session_lane._raw_acquire(key):
+                        raise TimeoutError(f"SessionLane timeout for key '{key}'")
+                    acquired.append(self._session_lane)
+                else:
+                    lane = self._lanes.get(name)
+                    if lane is None:
+                        raise KeyError(f"Lane '{name}' not found")
+                    if not lane._raw_acquire(key):
+                        raise TimeoutError(
+                            f"Lane '{name}' timeout after {lane.timeout_s}s "
+                            f"(max_concurrent={lane.max_concurrent})"
+                        )
+                    acquired.append(lane)
 
             yield
 
         finally:
-            for lane in reversed(acquired_sems):
-                lane._semaphore.release()
-            for lane in reversed(acquired_sems):
-                with lane._lock:
-                    lane._active.pop(key, None)
-                lane._stats.inc_released()
+            for item in reversed(acquired):
+                item._raw_release(key)
 
     def status(self) -> dict[str, Any]:
         """Get status of all lanes."""
-        return {
-            name: {
+        result: dict[str, Any] = {}
+        if self._session_lane is not None:
+            result["session"] = {
+                "active": self._session_lane.active_count,
+                "sessions": self._session_lane.session_count,
+                "max_sessions": self._session_lane.max_sessions,
+            }
+        for name, lane in self._lanes.items():
+            result[name] = {
                 "active": lane.active_count,
                 "max": lane.max_concurrent,
                 "available": lane.available,
             }
-            for name, lane in self._lanes.items()
-        }
+        return result
 
 
 class _LaneStats:

--- a/core/runtime_wiring/infra.py
+++ b/core/runtime_wiring/infra.py
@@ -124,11 +124,13 @@ def build_default_lanes() -> LaneQueue:
     from core.orchestration.lane_queue import SessionLane
 
     queue = LaneQueue()
-    queue.set_session_lane(SessionLane(
-        max_sessions=256,
-        idle_timeout_s=300.0,
-        timeout_s=300.0,
-    ))
+    queue.set_session_lane(
+        SessionLane(
+            max_sessions=256,
+            idle_timeout_s=300.0,
+            timeout_s=300.0,
+        )
+    )
     queue.add_lane("global", max_concurrent=DEFAULT_GLOBAL_CONCURRENCY, timeout_s=30.0)
     return queue
 

--- a/core/runtime_wiring/infra.py
+++ b/core/runtime_wiring/infra.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Default configuration
 # ---------------------------------------------------------------------------
-DEFAULT_GLOBAL_CONCURRENCY = 4
+DEFAULT_GLOBAL_CONCURRENCY = 8
 
 
 # ---------------------------------------------------------------------------
@@ -117,15 +117,19 @@ def build_default_registry() -> ToolRegistry:
 def build_default_lanes() -> LaneQueue:
     """Build the unified LaneQueue — single concurrency gate for the entire process.
 
-    All execution paths (gateway, scheduler, sub-agents) route through this
-    LaneQueue.  IsolatedRunner uses the ``global`` lane instead of its own
-    internal Semaphore.
+    OpenClaw pattern: SessionLane → Global Lane → Execute.
+    SessionLane provides per-key serialization (same session key → serial).
+    Global Lane provides total system capacity (max 8 concurrent).
     """
+    from core.orchestration.lane_queue import SessionLane
+
     queue = LaneQueue()
-    queue.add_lane("session", max_concurrent=1)  # Serial per session
-    queue.add_lane("global", max_concurrent=5, timeout_s=30.0)  # IsolatedRunner cap
-    queue.add_lane("gateway", max_concurrent=2, timeout_s=120.0)  # Gateway messages
-    queue.add_lane("scheduler", max_concurrent=2, timeout_s=300.0)  # Scheduled jobs
+    queue.set_session_lane(SessionLane(
+        max_sessions=256,
+        idle_timeout_s=300.0,
+        timeout_s=300.0,
+    ))
+    queue.add_lane("global", max_concurrent=DEFAULT_GLOBAL_CONCURRENCY, timeout_s=30.0)
     return queue
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -391,11 +391,12 @@ class TestAllowedToolsEnforcement:
 
 class TestLaneQueueIntegration:
     def test_route_with_lane_queue(self):
-        """Messages should flow through gateway lane when available."""
-        from core.orchestration.lane_queue import LaneQueue
+        """Messages should flow through session + global lanes."""
+        from core.orchestration.lane_queue import LaneQueue, SessionLane
 
         lq = LaneQueue()
-        lq.add_lane("gateway", max_concurrent=2)
+        lq.set_session_lane(SessionLane(max_sessions=10))
+        lq.add_lane("global", max_concurrent=8)
 
         manager = ChannelManager(lane_queue=lq)
         manager.set_processor(lambda c, m: f"processed: {c}")

--- a/tests/test_lane_queue.py
+++ b/tests/test_lane_queue.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import threading
+import time
 
 import pytest
-from core.orchestration.lane_queue import Lane, LaneQueue
+from core.orchestration.lane_queue import Lane, LaneQueue, SessionLane
 
 
 class TestLane:
@@ -67,9 +68,15 @@ class TestLane:
 class TestLaneQueue:
     def test_add_and_list_lanes(self):
         q = LaneQueue()
-        q.add_lane("session", max_concurrent=1)
-        q.add_lane("global", max_concurrent=4)
-        assert q.list_lanes() == ["session", "global"]
+        q.add_lane("global", max_concurrent=8)
+        assert q.list_lanes() == ["global"]
+
+    def test_list_lanes_with_session(self):
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=10))
+        q.add_lane("global", max_concurrent=8)
+        assert "session" in q.list_lanes()
+        assert "global" in q.list_lanes()
 
     def test_get_lane(self):
         q = LaneQueue()
@@ -82,58 +89,67 @@ class TestLaneQueue:
         q = LaneQueue()
         assert q.get_lane("nope") is None
 
-    def test_acquire_all(self):
+    def test_session_lane_property(self):
         q = LaneQueue()
-        q.add_lane("session", max_concurrent=1)
-        q.add_lane("global", max_concurrent=4)
+        assert q.session_lane is None
+        sl = SessionLane(max_sessions=10)
+        q.set_session_lane(sl)
+        assert q.session_lane is sl
 
-        with q.acquire_all("job-1", ["session", "global"]):
-            session = q.get_lane("session")
-            global_lane = q.get_lane("global")
-            assert session is not None and session.active_count == 1
-            assert global_lane is not None and global_lane.active_count == 1
+    def test_acquire_all_session_and_global(self):
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=10))
+        q.add_lane("global", max_concurrent=8)
 
-        assert session is not None and session.active_count == 0
-        assert global_lane is not None and global_lane.active_count == 0
+        with q.acquire_all("gateway:slack:C123", ["session", "global"]):
+            assert q.session_lane is not None and q.session_lane.active_count == 1
+            gl = q.get_lane("global")
+            assert gl is not None and gl.active_count == 1
+
+        assert q.session_lane.active_count == 0
+        gl = q.get_lane("global")
+        assert gl is not None and gl.active_count == 0
 
     def test_acquire_all_unknown_lane(self):
         q = LaneQueue()
         with pytest.raises(KeyError, match="not found"), q.acquire_all("job-1", ["nonexistent"]):
             pass
 
-    def test_status(self):
+    def test_acquire_all_no_session_lane_skips(self):
+        """If no session lane registered, 'session' in lane_names is skipped."""
         q = LaneQueue()
-        q.add_lane("session", max_concurrent=1)
-        q.add_lane("global", max_concurrent=4)
+        q.add_lane("global", max_concurrent=8)
+        with q.acquire_all("key", ["session", "global"]):
+            gl = q.get_lane("global")
+            assert gl is not None and gl.active_count == 1
+
+    def test_acquire_all_partial_failure_releases_session(self):
+        """If global times out, session lane must be released."""
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=10))
+        q.add_lane("global", max_concurrent=1, timeout_s=0.1)
+
+        # Exhaust global
+        gl = q.get_lane("global")
+        assert gl is not None
+        gl._semaphore.acquire()
+
+        with pytest.raises(TimeoutError), q.acquire_all("key", ["session", "global"]):
+            pass
+
+        # Session lane must be released
+        assert q.session_lane is not None and q.session_lane.active_count == 0
+        gl._semaphore.release()
+
+    def test_status_with_session_lane(self):
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=256))
+        q.add_lane("global", max_concurrent=8)
 
         status = q.status()
-        assert status["session"]["max"] == 1
-        assert status["global"]["max"] == 4
-        assert status["session"]["active"] == 0
-
-    def test_session_lane_serial(self):
-        """Session lane (max_concurrent=1) ensures serial execution."""
-        q = LaneQueue()
-        q.add_lane("session", max_concurrent=1, timeout_s=0.1)
-
-        acquired = threading.Event()
-        release = threading.Event()
-
-        def hold():
-            with q.acquire_all("job-1", ["session"]):
-                acquired.set()
-                release.wait(timeout=2.0)
-
-        t = threading.Thread(target=hold, daemon=True)
-        t.start()
-        acquired.wait(timeout=1.0)
-
-        # Second session acquire should block/timeout
-        session = q.get_lane("session")
-        assert session is not None and session.active_count == 1
-
-        release.set()
-        t.join(timeout=1.0)
+        assert "session" in status
+        assert status["session"]["max_sessions"] == 256
+        assert status["global"]["max"] == 8
 
 
 # ---------------------------------------------------------------------------
@@ -142,33 +158,159 @@ class TestLaneQueue:
 
 
 class TestAcquireAllPartialFailure:
-    """Verify partial failure releases only acquired semaphores."""
+    """Verify partial failure releases only acquired lanes."""
 
     def test_second_lane_timeout_releases_first(self) -> None:
-        """If 2nd lane times out, 1st lane semaphore must be released.
-
-        Regression for C4: without tracking acquired sems separately,
-        a partial failure could leak the first lane's semaphore.
-        """
+        """If 2nd lane times out, 1st lane must be released."""
         q = LaneQueue()
         q.add_lane("fast", max_concurrent=1, timeout_s=5.0)
         q.add_lane("slow", max_concurrent=1, timeout_s=0.1)
 
-        # Exhaust the slow lane
         slow = q.get_lane("slow")
         assert slow is not None
         slow._semaphore.acquire()
 
-        # acquire_all should fail on slow lane, but release fast lane
         fast = q.get_lane("fast")
         assert fast is not None
-        initial_fast = fast._semaphore._value  # type: ignore[attr-defined]
 
         with pytest.raises(TimeoutError, match="slow"), q.acquire_all("job-x", ["fast", "slow"]):
-            pass  # should not reach here
+            pass
 
-        # Fast lane semaphore must be released (no leak)
-        assert fast._semaphore._value == initial_fast  # type: ignore[attr-defined]
-
-        # Cleanup
+        # Fast lane must be released (no leak)
+        assert fast.active_count == 0
         slow._semaphore.release()
+
+
+# ---------------------------------------------------------------------------
+# SessionLane — per-key serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSessionLane:
+    """Verify per-session-key serialization (OpenClaw pattern)."""
+
+    def test_same_key_serializes(self) -> None:
+        """Two threads with same key — second blocks until first releases."""
+        sl = SessionLane(timeout_s=0.2)
+        acquired = threading.Event()
+        release = threading.Event()
+        blocked = threading.Event()
+
+        def holder():
+            with sl.acquire("key-A"):
+                acquired.set()
+                release.wait(timeout=2.0)
+
+        def waiter():
+            acquired.wait(timeout=1.0)
+            ok = sl.try_acquire("key-A")
+            if not ok:
+                blocked.set()
+
+        t1 = threading.Thread(target=holder, daemon=True)
+        t2 = threading.Thread(target=waiter, daemon=True)
+        t1.start()
+        t2.start()
+        t2.join(timeout=1.0)
+
+        assert blocked.is_set(), "Second acquire should fail (same key held)"
+        release.set()
+        t1.join(timeout=1.0)
+
+    def test_different_keys_parallel(self) -> None:
+        """Two threads with different keys — both proceed immediately."""
+        sl = SessionLane()
+        assert sl.try_acquire("key-A")
+        assert sl.try_acquire("key-B")
+        assert sl.active_count == 2
+        sl.manual_release("key-A")
+        sl.manual_release("key-B")
+
+    def test_try_acquire_and_manual_release(self) -> None:
+        sl = SessionLane()
+        assert sl.try_acquire("k1")
+        assert not sl.try_acquire("k1")  # same key, held
+        sl.manual_release("k1")
+        assert sl.try_acquire("k1")  # re-acquired after release
+        sl.manual_release("k1")
+
+    def test_acquire_timeout(self) -> None:
+        sl = SessionLane()
+        sl.try_acquire("k1")
+        assert not sl.acquire_timeout("k1", timeout_s=0.05)
+        sl.manual_release("k1")
+
+    def test_context_manager_release(self) -> None:
+        sl = SessionLane()
+        with sl.acquire("k1"):
+            assert sl.active_count == 1
+        assert sl.active_count == 0
+
+    def test_max_sessions_cap(self) -> None:
+        sl = SessionLane(max_sessions=3, idle_timeout_s=0.0)
+        sl.try_acquire("a")
+        sl.try_acquire("b")
+        sl.try_acquire("c")
+        # All 3 held, no idle to evict
+        with pytest.raises(RuntimeError, match="SessionLane full"):
+            sl.try_acquire("d")
+        sl.manual_release("a")
+        sl.manual_release("b")
+        sl.manual_release("c")
+
+    def test_idle_eviction_on_cap(self) -> None:
+        sl = SessionLane(max_sessions=2, idle_timeout_s=0.0)
+        sl.try_acquire("a")
+        sl.manual_release("a")  # now idle
+        sl.try_acquire("b")
+        sl.manual_release("b")  # now idle
+        # Both idle — next create triggers eviction
+        sl.try_acquire("c")  # evicts a and/or b, creates c
+        assert sl.session_count <= 2
+        sl.manual_release("c")
+
+    def test_cleanup_idle(self) -> None:
+        sl = SessionLane(idle_timeout_s=0.0)
+        sl.try_acquire("a")
+        sl.manual_release("a")
+        time.sleep(0.01)
+        evicted = sl.cleanup_idle()
+        assert evicted == 1
+        assert sl.session_count == 0
+
+    def test_held_session_not_evicted(self) -> None:
+        sl = SessionLane(idle_timeout_s=0.0)
+        sl.try_acquire("held")
+        time.sleep(0.01)
+        evicted = sl.cleanup_idle()
+        assert evicted == 0
+        assert sl.session_count == 1
+        sl.manual_release("held")
+
+    def test_get_active(self) -> None:
+        sl = SessionLane()
+        sl.try_acquire("a")
+        sl.try_acquire("b")
+        active = sl.get_active()
+        assert "a" in active
+        assert "b" in active
+        sl.manual_release("a")
+        active = sl.get_active()
+        assert "a" not in active
+        assert "b" in active
+        sl.manual_release("b")
+
+    def test_stats_tracking(self) -> None:
+        sl = SessionLane()
+        sl.try_acquire("a")
+        sl.manual_release("a")
+        assert sl.stats.acquired == 1
+        assert sl.stats.released == 1
+
+        assert not sl.try_acquire("x") or True  # acquire x
+        sl.manual_release("x")
+        # try_acquire on held key
+        sl.try_acquire("z")
+        assert not sl.try_acquire("z")
+        assert sl.stats.timeouts == 1
+        sl.manual_release("z")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -224,16 +224,16 @@ class TestDefaultBuilders:
         queue = _build_default_lanes()
         assert "session" in queue.list_lanes()
         assert "global" in queue.list_lanes()
-        assert "gateway" in queue.list_lanes()
-        assert "scheduler" in queue.list_lanes()
-        session = queue.get_lane("session")
-        assert session is not None and session.max_concurrent == 1
+        # SessionLane (per-key serialization)
+        sl = queue.session_lane
+        assert sl is not None
+        assert sl.max_sessions == 256
+        # Global Lane (total capacity)
         global_lane = queue.get_lane("global")
-        assert global_lane is not None and global_lane.max_concurrent == 5
-        gateway = queue.get_lane("gateway")
-        assert gateway is not None and gateway.max_concurrent == 2
-        scheduler = queue.get_lane("scheduler")
-        assert scheduler is not None and scheduler.max_concurrent == 2
+        assert global_lane is not None and global_lane.max_concurrent == 8
+        # gateway/scheduler lanes removed (SessionLane replaces them)
+        assert queue.get_lane("gateway") is None
+        assert queue.get_lane("scheduler") is None
 
 
 class TestRuntimeNewComponents:

--- a/tests/test_scheduler_serve.py
+++ b/tests/test_scheduler_serve.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from core.cli import _drain_scheduler_queue
-from core.orchestration.lane_queue import Lane
+from core.orchestration.lane_queue import Lane, SessionLane
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -42,8 +42,13 @@ def mock_runner() -> MagicMock:
 
 
 @pytest.fixture()
-def scheduler_lane() -> Lane:
-    return Lane("scheduler", max_concurrent=2, timeout_s=300.0)
+def session_lane() -> SessionLane:
+    return SessionLane(max_sessions=10)
+
+
+@pytest.fixture()
+def global_lane() -> Lane:
+    return Lane("global", max_concurrent=8, timeout_s=30.0)
 
 
 # ---------------------------------------------------------------------------
@@ -59,14 +64,16 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        scheduler_lane: Lane,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
         """Empty queue should drain nothing and return 0."""
         count = _drain_scheduler_queue(
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=scheduler_lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=True,
         )
         assert count == 0
@@ -77,7 +84,8 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        scheduler_lane: Lane,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
         """Isolated job should be dispatched via runner.run_async()."""
         action_queue.put(("job-1", "do something", True))
@@ -87,7 +95,8 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=scheduler_lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=False,
             on_dispatch=lambda jid: dispatched.append(jid),
         )
@@ -101,7 +110,8 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        scheduler_lane: Lane,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
         """In serve mode (force_isolated=True), non-isolated jobs run isolated."""
         action_queue.put(("job-2", "run report", False))  # isolated=False
@@ -110,7 +120,8 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=scheduler_lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=True,  # serve mode
         )
 
@@ -123,7 +134,8 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        scheduler_lane: Lane,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
         """Non-isolated job in REPL mode should use main_loop.run()."""
         action_queue.put(("job-3", "check status", False))
@@ -134,7 +146,8 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=scheduler_lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=False,
             main_loop=main_loop,
             on_main_run=lambda jid: main_runs.append(jid),
@@ -146,14 +159,15 @@ class TestDrainSchedulerQueue:
         assert "[scheduled-job:job-3]" in main_loop.run.call_args[0][0]
         assert main_runs == ["job-3"]
 
-    def test_lane_full_skips_job(
+    def test_global_full_skips_job(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
+        session_lane: SessionLane,
     ) -> None:
-        """Jobs should be skipped when scheduler lane is full."""
-        full_lane = Lane("scheduler", max_concurrent=0)  # zero capacity — always full
+        """Jobs should be skipped when global lane is full."""
+        full_global = Lane("global", max_concurrent=0)  # zero capacity
         action_queue.put(("job-4", "important task", True))
         skipped: list[str] = []
 
@@ -161,7 +175,8 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=full_lane,
+            session_lane=session_lane,
+            global_lane=full_global,
             force_isolated=True,
             on_skip=lambda jid: skipped.append(jid),
         )
@@ -175,7 +190,8 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        scheduler_lane: Lane,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
         """Jobs with empty fired_action should be silently skipped."""
         action_queue.put(("job-5", "", True))
@@ -184,7 +200,8 @@ class TestDrainSchedulerQueue:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=scheduler_lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=True,
         )
 
@@ -196,18 +213,20 @@ class TestDrainSchedulerQueue:
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
+        session_lane: SessionLane,
     ) -> None:
         """Multiple queued jobs should all be drained in one call."""
         action_queue.put(("j1", "task one", True))
         action_queue.put(("j2", "task two", True))
         action_queue.put(("j3", "task three", True))
-        big_lane = Lane("scheduler", max_concurrent=5, timeout_s=300.0)
+        big_global = Lane("global", max_concurrent=8, timeout_s=30.0)
 
         count = _drain_scheduler_queue(
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=big_lane,
+            session_lane=session_lane,
+            global_lane=big_global,
             force_isolated=True,
         )
 
@@ -224,37 +243,40 @@ class TestDrainSchedulerQueue:
 class TestDrainErrorPaths:
     """Verify exception safety in drain loop."""
 
-    def test_create_session_failure_releases_lane(
+    def test_create_session_failure_releases_lanes(
         self,
         action_queue: queue.Queue,
         mock_runner: MagicMock,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
-        """Lane slot must be released if create_session() raises."""
+        """Both lanes must be released if create_session() raises."""
         failing_services = MagicMock()
         failing_services.create_session.side_effect = RuntimeError("MCP down")
-        lane = Lane("scheduler", max_concurrent=2, timeout_s=300.0)
         action_queue.put(("job-err", "fail task", True))
 
         count = _drain_scheduler_queue(
             action_queue=action_queue,
             services=failing_services,
             runner=mock_runner,
-            scheduler_lane=lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=True,
         )
 
         assert count == 1
         mock_runner.run_async.assert_not_called()
-        # Lane should NOT be leaked — verify by acquiring both slots
-        assert lane.try_acquire("check-1")
-        assert lane.try_acquire("check-2")
+        # Lanes should NOT be leaked
+        assert session_lane.active_count == 0
+        assert global_lane.active_count == 0
 
     def test_main_loop_exception_continues_drain(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
         mock_runner: MagicMock,
-        scheduler_lane: Lane,
+        session_lane: SessionLane,
+        global_lane: Lane,
     ) -> None:
         """main_loop.run() exception should not kill the drain loop."""
         failing_loop = MagicMock()
@@ -266,13 +288,14 @@ class TestDrainErrorPaths:
             action_queue=action_queue,
             services=mock_services,
             runner=mock_runner,
-            scheduler_lane=scheduler_lane,
+            session_lane=session_lane,
+            global_lane=global_lane,
             force_isolated=False,
             main_loop=failing_loop,
         )
 
         assert count == 2
-        assert failing_loop.run.call_count == 2  # both attempted despite error
+        assert failing_loop.run.call_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 4-lane system → **2 components**: SessionLane (per-key) + Lane("global", max=8)
- OpenClaw "Session Lane → Global Lane → Execute" 패턴 정합
- gateway(2)/scheduler(2)/session(1) lane 삭제 → SessionLane으로 통합

## Why
기존 Lane은 단일 Semaphore라 per-session-key 직렬화 불가. Slack 같은 스레드의 메시지 2개가 동시 처리 가능했음. SessionLane은 같은 key → serial, 다른 key → parallel로 근본 해결.

## Changes
| Before | After |
|--------|-------|
| session(1) — 미사용 | **SessionLane** per-key Semaphore(1) |
| global(5) | global(**8**) — 여유 확보 |
| gateway(2) | 삭제 → SessionLane이 대체 |
| scheduler(2) | 삭제 → SessionLane이 대체 |

## OpenClaw defect fixes
- `max_sessions=256` — 무한 session key 생성 방지
- `cleanup_idle(300s)` — 메모리 누수 방지
- `held: bool` flag — `semaphore._value` 접근 대신 안전한 상태 추적

## Test plan
- [x] 3433 tests pass (+13 SessionLane tests)
- [x] Lint: ruff check 0 errors
- [x] Type: mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)