### PR TITLE
feat: thin-only architecture — standalone REPL eliminated, serve mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- **Thin-only architecture** — standalone REPL eliminated (~487 lines deleted). `geode` always connects to serve via IPC; auto-starts serve if not running. Single code path for all execution: CLI, Slack/Discord, Scheduler all route through `acquire_all(key, ["session", "global"])`.
+- **SessionMode.IPC** — new session mode for thin CLI client. `hitl=0` (WRITE allowed, DANGEROUS policy-blocked). Replaces `SessionMode.REPL` for IPC connections.
+- **CLIPoller hardened** — `acquire_all()` gating, `chmod 0o600` on Unix socket, `command` type in IPC protocol for slash command relay.
 - **SessionLane — per-key serialization** — replaced 4-lane system (session/global/gateway/scheduler) with OpenClaw pattern: `SessionLane` (per-session-key `Semaphore(1)`) + `Lane("global", max=8)`. Same session key serializes, different keys parallel. `acquire_all(key, ["session", "global"])` unifies all execution paths. OpenClaw defect fixes: `max_sessions=256` cap, `cleanup_idle()` eviction.
 
 ### Added

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -890,7 +890,7 @@ def _thin_interactive_loop() -> None:
         client.close()
 
 
-def _render_ipc_response(response: dict) -> None:
+def _render_ipc_response(response: dict[str, Any]) -> None:
     """Render an IPC response from serve."""
     rtype = response.get("type", "")
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -18,7 +18,6 @@ from typing import Any
 import typer
 
 from core import __version__
-from core.agent.agentic_loop import AgenticResult
 from core.agent.conversation import ConversationContext
 from core.cli.commands import (
     cmd_apply,
@@ -68,7 +67,6 @@ from core.cli.startup import (
     auto_generate_env,
     check_readiness,
     env_setup_wizard,
-    key_registration_gate,
     render_readiness,
     setup_project_memory,
     setup_user_profile,
@@ -713,177 +711,6 @@ def _handle_memory_action(intent: Any, user_text: str, is_offline: bool) -> None
         console.print()
 
 
-def _build_agentic_stack(
-    conversation: Any,
-    *,
-    mcp_manager: Any = None,
-    skill_registry: Any = None,
-    verbose: bool = False,
-    hitl_level: int = 2,
-    max_rounds: int = 50,
-    time_budget_s: float = 0.0,
-    cost_budget: float = 0.0,
-    model: str | None = None,
-    provider: str | None = None,
-    system_suffix: str = "",
-    quiet: bool = False,
-    hooks: Any = None,
-) -> tuple[Any, Any, Any]:
-    """Build ToolExecutor + AgenticLoop stack. Single source for REPL, Gateway, Batch.
-
-    Returns (agentic_ref, executor, loop).  The ``agentic_ref`` is a mutable
-    list whose [0] element is set to the created AgenticLoop — callers that
-    need it for handler closures can pass the same list to ``_build_tool_handlers``.
-    """
-    from core.agent.agentic_loop import AgenticLoop
-    from core.agent.tool_executor import ToolExecutor
-    from core.config import _resolve_provider
-    from core.config import settings as _stk_settings
-
-    _model = model or _stk_settings.model
-    _provider = provider or _resolve_provider(_model)
-
-    # Resolve cost budget: explicit param > config/env setting
-    if cost_budget <= 0:
-        from core.cli.commands import _get_cost_budget
-
-        cost_budget = _get_cost_budget()
-
-    agentic_ref: list[Any] = [None]
-    handlers = _build_tool_handlers(
-        verbose=verbose,
-        mcp_manager=mcp_manager,
-        agentic_ref=agentic_ref,
-        skill_registry=skill_registry,
-    )
-    sub_mgr = _build_sub_agent_manager(
-        verbose=verbose,
-        action_handlers=handlers,
-        mcp_manager=mcp_manager,
-        skill_registry=skill_registry,
-    )
-    executor = ToolExecutor(
-        action_handlers=handlers,
-        mcp_manager=mcp_manager,
-        sub_agent_manager=sub_mgr,
-        hitl_level=hitl_level,
-        hooks=hooks,
-    )
-    loop = AgenticLoop(
-        conversation,
-        executor,
-        max_rounds=max_rounds,
-        time_budget_s=time_budget_s,
-        cost_budget=cost_budget,
-        model=_model,
-        provider=_provider,
-        mcp_manager=mcp_manager,
-        skill_registry=skill_registry,
-        system_suffix=system_suffix,
-        quiet=quiet,
-    )
-    agentic_ref[0] = loop
-    return agentic_ref, executor, loop
-
-
-def _build_sub_agent_manager(
-    verbose: bool = False,
-    *,
-    action_handlers: dict[str, Any] | None = None,
-    mcp_manager: Any = None,
-    skill_registry: Any = None,
-) -> Any:
-    """Build a SubAgentManager wired to real pipeline functions.
-
-    P2-B: When ``action_handlers`` is provided, sub-agents receive a full
-    AgenticLoop with the same tool set, MCP servers, and skills as the parent.
-    Falls back to legacy ``make_pipeline_handler`` if handlers are not provided.
-    """
-    from core.agent.sub_agent import (
-        SUBAGENT_DENIED_TOOLS,
-        SubAgentManager,
-        make_pipeline_handler,
-    )
-    from core.config import settings
-    from core.orchestration.isolated_execution import IsolatedRunner
-    from core.skills.agents import AgentRegistry
-
-    readiness = _get_readiness()
-    force_dry = readiness.force_dry_run if readiness else True
-
-    # Legacy fallback handler (used when action_handlers is not provided)
-    handler = make_pipeline_handler(
-        run_analysis_fn=lambda ip_name, dry_run=force_dry, **_kw: _run_analysis(
-            ip_name, dry_run=dry_run, verbose=verbose
-        ),
-        search_fn=lambda query="", **_kw: {
-            "status": "ok",
-            "action": "search",
-            "query": query,
-            "results": [
-                {"name": r.ip_name, "score": r.score} for r in _get_search_engine().search(query)
-            ],
-        },
-        report_fn=lambda ip_name, **kw: _generate_report(
-            ip_name,
-            dry_run=kw.get("dry_run", force_dry),
-            verbose=verbose,
-            fmt=kw.get("fmt", "markdown"),
-            template=kw.get("template", "summary"),
-        ),
-        force_dry_run=readiness.force_dry_run if readiness else True,
-    )
-    runner = IsolatedRunner()
-    registry = AgentRegistry()
-    registry.load_defaults()
-    return SubAgentManager(
-        runner,
-        handler,
-        timeout_s=300.0,
-        agent_registry=registry,
-        # P2-B: Full AgenticLoop inheritance
-        action_handlers=action_handlers,
-        mcp_manager=mcp_manager,
-        skill_registry=skill_registry,
-        depth=0,
-        max_depth=settings.max_subagent_depth,
-        # Sandbox hardening: restrict sub-agent tool scope
-        denied_tools=SUBAGENT_DENIED_TOOLS,
-    )
-
-
-def _render_agentic_result(result: AgenticResult) -> None:
-    """Render the final result from an agentic loop execution."""
-    if result.error == "llm_call_failed":
-        console.print()
-        console.print("  [warning]LLM call failed. Try again or check your API key.[/warning]")
-        console.print("  [muted]Use /help for available commands.[/muted]")
-        console.print()
-        return
-
-    if result.text:
-        console.print()
-        # Render markdown if the response contains markdown indicators
-        if any(md in result.text for md in ("## ", "| ", "```", "**", "- [")):
-            from rich.markdown import Markdown
-            from rich.padding import Padding
-
-            md = Markdown(result.text)
-            console.print(Padding(md, (0, 2)))
-        else:
-            console.print(f"  {result.text}")
-        console.print()
-
-    if result.tool_calls:
-        tool_names = [tc["tool"] for tc in result.tool_calls]
-        log.debug(
-            "Agentic loop: %d rounds, %d tool calls (%s)",
-            result.rounds,
-            len(result.tool_calls),
-            ", ".join(tool_names),
-        )
-
-
 def _restore_terminal() -> None:
     """Restore terminal to sane cooked mode.
 
@@ -995,349 +822,28 @@ def _read_multiline_input(prompt: str) -> str:
     return text
 
 
-def _interactive_loop(resume_session_id: str | None = None) -> None:
-    """Claude Code / OpenClaw-style interactive REPL.
-
-    Three routing paths:
-      /command  → deterministic dispatch (commands.py)
-      free-text → agentic loop (AgenticLoop, multi-turn + multi-intent)
-      fallback  → single-shot NL Router (when agentic unavailable)
-
-    Args:
-        resume_session_id: If provided, auto-resume this session at startup.
-            Use "__latest__" to resume the most recent session (--continue flag).
-    """
-    verbose = False
-    conversation = ConversationContext()
-
-    # Inject ConversationContext for slash commands (/compact, /clear, /model guard)
-    from core.cli.commands import set_conversation_context
-
-    set_conversation_context(conversation)
-
-    # --- Unified bootstrap (domain, memory, readiness, MCP, skills) ---
-    from core.cli.bootstrap import bootstrap_geode
-    from core.cli.ui.status import TextSpinner
-
-    spinner = TextSpinner("Initializing...")
-    spinner.start()
-
-    boot = bootstrap_geode()
-    mcp_mgr = boot.mcp_manager
-    skill_registry = boot.skill_registry
-
-    # Eagerly connect MCP servers with live progress
-    n_total = len(mcp_mgr._servers) if mcp_mgr and hasattr(mcp_mgr, "_servers") else 0
-    n_connected = 0
-    if mcp_mgr and n_total > 0:
-        spinner.update(f"Loading MCP (0/{n_total})...")
-
-        def _on_mcp_progress(done: int, total: int, name: str) -> None:
-            spinner.update(f"Loading MCP ({done}/{total})...")
-
-        n_connected = mcp_mgr.startup(on_progress=_on_mcp_progress)
-
-    n_skills = len(skill_registry._skills) if hasattr(skill_registry, "_skills") else 0
-    parts = [f"MCP {n_connected}/{n_total}"]
-    if n_skills > 0:
-        parts.append(f"Skills {n_skills}")
-    spinner.stop(f"\x1b[1;32mok\x1b[0m Bootstrap ({', '.join(parts)})")
-
-    # Key gate (REPL-only: interactive prompt if API key missing)
-    readiness = boot.readiness
-    if readiness is None or readiness.blocked:
-        key = key_registration_gate()
-        if key is None:
-            return  # user quit
-        readiness = check_readiness()
-        _set_readiness(readiness)
-
-    # Scheduler (REPL-only: cron + /schedule command)
-    import queue as _queue_mod
-
-    _action_queue: _queue_mod.Queue[tuple[str, str, bool]] = _queue_mod.Queue()
-    try:
-        from core.automation.scheduler import SchedulerService
-
-        _sched_svc = SchedulerService(action_queue=_action_queue)
-        _sched_svc.load()
-        _sched_svc.start()
-        _scheduler_service_ctx.set(_sched_svc)
-    except Exception:
-        log.debug("SchedulerService initialization skipped", exc_info=True)
-
-    # Isolated runner for async scheduled job execution (OpenClaw agentTurn)
-    from core.orchestration.isolated_execution import (
-        IsolatedRunner,
-    )
-
-    _sched_runner = IsolatedRunner()
-
-    console.print()  # blank line before prompt
-
-    # Build SharedServices gateway (single factory for all modes)
-    # Unified LaneQueue created inside build_shared_services() if not provided.
-    from core.gateway.shared_services import SessionMode, build_shared_services
-
-    services = build_shared_services(
-        mcp_manager=mcp_mgr,
-        skill_registry=skill_registry,
-        verbose=verbose,
-    )
-    _session_lane = services.lane_queue.session_lane
-    _global_lane = services.lane_queue.get_lane("global")
-
-    # Wire module-level hooks for _fire_hook() callers
-    global _hooks_ctx
-    _hooks_ctx = services.hook_system
-
-    _last_verbose = verbose
-    executor, agentic = services.create_session(
-        SessionMode.REPL,
-        conversation=conversation,
-        verbose=verbose,
-    )
-
-    # Initialize session meter for status line
-    from core.cli.ui.agentic_ui import init_session_meter
-
-    init_session_meter(model=agentic.model)
-
-    # Fire SESSION_START for dynamic context injection (OpenClaw agent:bootstrap)
-    _fire_hook(
-        HookEvent.SESSION_START,
-        {
-            "model": agentic.model,
-            "session_id": getattr(agentic, "_session_id", ""),
-            "resumed": resume_session_id is not None,
-        },
-    )
-
-    # Auto-resume: --continue (latest) or --resume <id>
-    if resume_session_id is not None:
-        from core.cli.session_checkpoint import SessionCheckpoint
-
-        _cp = SessionCheckpoint()
-        if resume_session_id == "__latest__":
-            _resumable = _cp.list_resumable()
-            _state = _resumable[0] if _resumable else None
-        else:
-            _state = _cp.load(resume_session_id)
-        if _state is not None and _state.status in ("active", "paused"):
-            conversation.messages = list(_state.messages)
-            agentic._session_id = _state.session_id
-            console.print(f"  [success]Session restored: {_state.session_id}[/success]")
-            if _state.user_input:
-                console.print(f"  [muted]Last input: {_state.user_input[:80]}[/muted]")
-            console.print(f"  [muted]{len(_state.messages)} messages restored[/muted]")
-            console.print()
-        elif resume_session_id != "__latest__":
-            console.print(
-                f"  [warning]Session not found or not resumable: {resume_session_id}[/warning]"
-            )
-            console.print()
-
-    # Completion callback for async scheduled jobs (prints dim status on finish)
-    def _on_sched_complete(result: Any, *, job_id: str) -> None:
-        from core.orchestration.isolated_execution import IsolationResult
-
-        if isinstance(result, IsolationResult):
-            status = "ok" if result.success else "err"
-            summary = result.summary or result.output[:120] or "(no output)"
-        else:
-            status = "ok"
-            summary = str(result)[:120] if result else "(no output)"
-        console.print(f"  [dim]scheduled:{job_id} → {status} — {summary}[/dim]")
-
-    while True:
-        # Drain scheduled actions before prompting (scheduler fires in background thread)
-        _drain_scheduler_queue(
-            action_queue=_action_queue,
-            services=services,
-            runner=_sched_runner,
-            session_lane=_session_lane,
-            global_lane=_global_lane,
-            force_isolated=False,
-            main_loop=agentic,
-            on_complete=_on_sched_complete,
-            on_dispatch=lambda jid: console.print(
-                f"  [dim]scheduled:{jid} → dispatched (async)[/dim]"
-            ),
-            on_skip=lambda jid: console.print(
-                f"  [dim]scheduled:{jid} → skipped (slots full)[/dim]"
-            ),
-            on_main_run=lambda jid: console.print(
-                f"\n  [muted]Scheduler: running job {jid}[/muted]"
-            ),
-        )
-
-        # Defensive: restore terminal state before each prompt
-        # (Rich Status/Live may leave cursor hidden or echo off)
-        console.show_cursor(True)
-
-        try:
-            user_input = _read_multiline_input("[header]>[/header] ")
-        except (KeyboardInterrupt, EOFError):
-            from core.cli.ui.agentic_ui import render_session_cost_summary
-
-            _fire_hook(
-                HookEvent.SESSION_END,
-                {
-                    "model": agentic.model,
-                    "session_id": getattr(agentic, "_session_id", ""),
-                },
-            )
-            agentic.mark_session_completed()
-            render_session_cost_summary()
-            console.print("\n  [muted]Goodbye.[/muted]\n")
-            break
-
-        if not user_input:
-            continue
-
-        # Bare exit/quit → immediate shutdown (no LLM round-trip)
-        if user_input.strip().lower() in ("exit", "quit", "q"):
-            from core.cli.ui.agentic_ui import render_session_cost_summary
-
-            _fire_hook(
-                HookEvent.SESSION_END,
-                {
-                    "model": agentic.model,
-                    "session_id": getattr(agentic, "_session_id", ""),
-                },
-            )
-            agentic.mark_session_completed()
-            render_session_cost_summary()
-            console.print("  [muted]Goodbye.[/muted]\n")
-            break
-
-        # Multi-line paste → always route to agentic (never slash-dispatch)
-        is_multiline = "\n" in user_input
-        if not is_multiline and user_input.startswith("/"):
-            # Slash command → deterministic routing (OpenClaw Binding)
-            cmd = user_input.split()[0].lower()
-            args = user_input[len(cmd) :].strip()
-            should_break, verbose, resume_state = _handle_command(
-                cmd,
-                args,
-                verbose,
-                skill_registry=skill_registry,
-                mcp_manager=mcp_mgr,
-            )
-            if should_break:
-                break
-            # /resume: inject saved messages into ConversationContext
-            if resume_state is not None:
-                conversation.messages = list(resume_state.messages)
-                agentic._session_id = resume_state.session_id
-                log.info(
-                    "Session restored: %s (%d messages)",
-                    resume_state.session_id,
-                    len(resume_state.messages),
-                )
-            # Sync model/provider to AgenticLoop after /model command
-            # (fixes model caching bug: /model changes were not reflected)
-            if settings.model != agentic.model:
-                agentic.update_model(settings.model)
-            # Update handlers if verbose changed
-            if verbose != _last_verbose:
-                _last_verbose = verbose
-                executor, agentic = services.create_session(
-                    SessionMode.REPL,
-                    conversation=conversation,
-                    verbose=verbose,
-                )
-        else:
-            # Agentic loop: multi-turn + multi-intent (online) or offline regex
-            # Key management is handled via /key command or set_api_key tool.
-            try:
-                # Snapshot cumulative metrics before this turn
-                from core.cli.ui.agentic_ui import mark_turn_start
-
-                mark_turn_start()
-
-                result = agentic.run(user_input)
-                _render_agentic_result(result)
-                # Claude Code-style status line after each result
-                from core.cli.ui.agentic_ui import render_status_line
-
-                render_status_line()
-
-                # Turn-end action summary (per-tool detail + header)
-                if result and result.tool_calls:
-                    from core.cli.ui.agentic_ui import get_session_meter, render_action_summary
-
-                    _meter = get_session_meter()
-                    _turn_elapsed = _meter.turn_elapsed_s if _meter else 0.0
-                    _turn_cost = 0.0
-                    try:
-                        from core.llm.token_tracker import get_tracker as _get_tk
-
-                        _tk = _get_tk()
-                        import core.cli.ui.agentic_ui as _ui_mod
-
-                        _snap = _ui_mod._turn_snapshot
-                        if _snap is not None:
-                            _delta = _tk.delta_since(_snap)
-                            _turn_cost = _delta.total_cost_usd
-                        else:
-                            _turn_cost = _tk.accumulator.total_cost_usd
-                    except Exception:
-                        log.debug("Turn cost calculation failed", exc_info=True)
-                    result.summary = render_action_summary(
-                        result.tool_calls,
-                        result.rounds,
-                        _turn_elapsed,
-                        _turn_cost,
-                    )
-            except KeyboardInterrupt:
-                console.show_cursor(True)
-                console.print("\n  [dim]Interrupted.[/dim]\n")
-            except Exception as exc:
-                console.show_cursor(True)
-                log.error("Agentic loop error: %s", exc, exc_info=True)
-                console.print(f"\n  [error]Error: {exc}[/error]\n")
-
-    # Clean shutdown: MCP servers → SchedulerService
-    if mcp_mgr is not None:
-        try:
-            mcp_mgr.shutdown()
-        except Exception:
-            log.debug("MCP shutdown error", exc_info=True)
-
-    _sched = _scheduler_service_ctx.get(None)
-    if _sched is not None:
-        try:
-            _sched.save()
-            _sched.stop()
-        except Exception:
-            log.debug("SchedulerService shutdown error", exc_info=True)
-
-
 # ---------------------------------------------------------------------------
 # Thin REPL — delegates to geode serve via IPC
 # ---------------------------------------------------------------------------
 
 
-def _thin_interactive_loop() -> None:
-    """Thin CLI client that relays prompts to geode serve via IPC.
+_LOCAL_COMMANDS = frozenset({"/help", "/exit", "/quit", "/clear"})
 
-    Called when serve is detected running. Skips heavy bootstrap (MCP,
-    skills, memory) — serve owns all shared resources.  Local slash
-    commands (/help, /exit, /clear, /model) are handled locally.
+
+def _thin_interactive_loop() -> None:
+    """Thin CLI client — all execution delegated to geode serve via IPC.
+
+    Local commands: /help, /exit, /quit, /clear
+    Everything else: relayed to serve (prompts + slash commands)
     """
     from core.cli.ipc_client import IPCClient
 
     client = IPCClient()
     if not client.connect():
-        console.print(
-            "  [warning]Failed to connect to serve — falling back to standalone[/warning]"
-        )
-        _interactive_loop()
+        console.print("  [error]Failed to connect to serve[/error]")
         return
 
-    console.print(f"  [success]Connected to serve (session: {client.session_id})[/success]")
-    console.print("  [muted]Thin mode — MCP/skills/memory managed by serve[/muted]")
+    console.print(f"  [success]Session: {client.session_id}[/success]")
     console.print()
 
     try:
@@ -1356,46 +862,57 @@ def _thin_interactive_loop() -> None:
                 console.print("  [muted]Goodbye.[/muted]\n")
                 break
 
-            # Local-only slash commands
-            if user_input.startswith("/"):
+            # Slash commands
+            if "\n" not in user_input and user_input.startswith("/"):
                 cmd = user_input.split()[0].lower()
-                if cmd in ("/help", "/exit", "/quit", "/clear"):
+                args = user_input[len(cmd) :].strip()
+
+                # Local-only commands
+                if cmd in _LOCAL_COMMANDS:
                     try:
-                        _handle_command(
-                            cmd,
-                            user_input[len(cmd) :].strip(),
-                            False,
-                        )
+                        _handle_command(cmd, args, False)
                     except (SystemExit, EOFError):
                         break
                     continue
 
-            # Relay to serve via IPC
-            response = client.send_prompt(user_input)
-
-            if response.get("type") == "error":
-                console.print(f"\n  [error]{response.get('message', 'Unknown error')}[/error]\n")
+                # All other commands → relay to serve
+                response = client.send_command(cmd, args)
+                if response.get("status") == "error":
+                    console.print(f"  [error]{response.get('message', 'Command failed')}[/error]")
+                elif response.get("should_break"):
+                    break
                 continue
 
-            if response.get("type") == "result":
-                # Render tool calls
-                for tc in response.get("tool_calls", []):
-                    console.print(f"  [dim]\u25b8 {tc.get('name', '?')}[/dim]")
-
-                # Render text
-                text = response.get("text", "")
-                if text:
-                    from rich.markdown import Markdown
-
-                    console.print()
-                    console.print(Markdown(text))
-                    console.print()
-
-                rounds = response.get("rounds", 0)
-                if rounds > 1:
-                    console.print(f"  [dim]{rounds} rounds[/dim]")
+            # Free text → relay as prompt
+            response = client.send_prompt(user_input)
+            _render_ipc_response(response)
     finally:
         client.close()
+
+
+def _render_ipc_response(response: dict) -> None:
+    """Render an IPC response from serve."""
+    rtype = response.get("type", "")
+
+    if rtype == "error":
+        console.print(f"\n  [error]{response.get('message', 'Unknown error')}[/error]\n")
+        return
+
+    if rtype == "result":
+        for tc in response.get("tool_calls", []):
+            console.print(f"  [dim]\u25b8 {tc.get('name', '?')}[/dim]")
+
+        text = response.get("text", "")
+        if text:
+            from rich.markdown import Markdown
+
+            console.print()
+            console.print(Markdown(text))
+            console.print()
+
+        rounds = response.get("rounds", 0)
+        if rounds > 1:
+            console.print(f"  [dim]{rounds} rounds[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -1415,19 +932,16 @@ def main(
     if ctx.invoked_subcommand is None:
         _welcome_screen()
 
-        # Auto-detect serve: use thin IPC client when available
-        from core.cli.ipc_client import is_serve_running
+        # Ensure serve is running (auto-start if needed)
+        from core.cli.ipc_client import start_serve_if_needed
 
-        if is_serve_running() and not continue_session and not resume:
-            console.print("  [muted]Detected geode serve — connecting via IPC...[/muted]")
-            _thin_interactive_loop()
-        else:
-            resume_id: str | None = None
-            if continue_session:
-                resume_id = "__latest__"
-            elif resume:
-                resume_id = resume
-            _interactive_loop(resume_session_id=resume_id)
+        if not start_serve_if_needed():
+            console.print("  [error]Failed to start geode serve[/error]")
+            console.print("  [dim]Try manually: geode serve &[/dim]")
+            raise typer.Exit(1)
+
+        console.print("  [muted]Connected to serve via IPC[/muted]")
+        _thin_interactive_loop()
 
 
 @app.command()

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -22,7 +22,7 @@ DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
 
 def start_serve_if_needed(socket_path: Path | None = None, timeout_s: float = 10.0) -> bool:
     """Start serve in background if not running. Returns True when ready."""
-    import subprocess
+    import subprocess  # nosec B404 — used for controlled serve daemon spawn
     import sys
 
     if is_serve_running(socket_path):

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -20,6 +20,32 @@ log = logging.getLogger(__name__)
 DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
 
 
+def start_serve_if_needed(socket_path: Path | None = None, timeout_s: float = 10.0) -> bool:
+    """Start serve in background if not running. Returns True when ready."""
+    import subprocess
+    import sys
+
+    if is_serve_running(socket_path):
+        return True
+
+    log.info("Starting geode serve in background...")
+    subprocess.Popen(  # noqa: S603 — fixed args, no untrusted input
+        [sys.executable, "-m", "geode.cli", "serve"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    # Wait for socket to appear
+    import time
+
+    for _ in range(int(timeout_s * 10)):
+        if is_serve_running(socket_path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
 def is_serve_running(socket_path: Path | None = None) -> bool:
     """Check if geode serve is running by probing the socket."""
     path = socket_path or DEFAULT_SOCKET_PATH
@@ -93,6 +119,19 @@ class IPCClient:
         if not self._sock:
             return {"type": "error", "message": "Not connected"}
         self._send({"type": "prompt", "text": text})
+        response = self._recv()
+        if response is None:
+            return {"type": "error", "message": "Connection lost"}
+        return response
+
+    def send_command(self, cmd: str, args: str = "") -> dict[str, Any]:
+        """Send a slash command to serve and wait for result.
+
+        Returns {"type": "command_result", "cmd": ..., "status": "ok"/"error"}.
+        """
+        if not self._sock:
+            return {"type": "error", "message": "Not connected"}
+        self._send({"type": "command", "cmd": cmd, "args": args})
         response = self._recv()
         if response is None:
             return {"type": "error", "message": "Connection lost"}

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -29,7 +29,7 @@ def start_serve_if_needed(socket_path: Path | None = None, timeout_s: float = 10
         return True
 
     log.info("Starting geode serve in background...")
-    subprocess.Popen(  # noqa: S603 — fixed args, no untrusted input
+    subprocess.Popen(  # noqa: S603  # nosec B603 — fixed args, no untrusted input
         [sys.executable, "-m", "geode.cli", "serve"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -77,6 +77,7 @@ class CLIPoller:
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
         self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._server.bind(str(self._socket_path))
+        os.chmod(str(self._socket_path), 0o600)  # User-only access
         self._server.listen(1)
         self._server.settimeout(1.0)
 
@@ -127,7 +128,11 @@ class CLIPoller:
                 self._active_client = None
 
     def _handle_client(self, client: socket.socket) -> None:
-        """Handle a connected CLI client session."""
+        """Handle a connected CLI client session.
+
+        Creates an IPC-mode session (DANGEROUS blocked, WRITE allowed)
+        gated by SessionLane + Global Lane via acquire_all().
+        """
         from core.agent.conversation import ConversationContext
         from core.gateway.shared_services import SessionMode
 
@@ -136,9 +141,9 @@ class CLIPoller:
         conversation = ConversationContext()
         session_id = f"cli-{os.urandom(4).hex()}"
 
-        # Create a REPL session backed by serve's SharedServices
+        # Create an IPC session backed by serve's SharedServices
         _executor, loop = self._services.create_session(
-            SessionMode.REPL,
+            SessionMode.IPC,
             conversation=conversation,
             propagate_context=True,
         )
@@ -157,7 +162,7 @@ class CLIPoller:
                 while b"\n" in buf:
                     line, buf = buf.split(b"\n", 1)
                     msg = json.loads(line.decode("utf-8"))
-                    response = self._process_message(msg, loop, conversation)
+                    response = self._process_message(msg, loop, conversation, session_id)
                     if response is None:
                         # Exit signal
                         self._send(client, {"type": "exit_ack"})
@@ -180,6 +185,7 @@ class CLIPoller:
         msg: dict[str, Any],
         loop: Any,
         conversation: Any,
+        session_id: str,
     ) -> dict[str, Any] | None:
         """Process a single client message. Returns response dict or None for exit."""
         msg_type = msg.get("type", "")
@@ -193,7 +199,14 @@ class CLIPoller:
                 return {"type": "error", "message": "Empty prompt"}
 
             try:
-                result = loop.run(text)
+                # Gate through SessionLane + Global Lane
+                lane_queue = self._services.lane_queue
+                if lane_queue is not None:
+                    with lane_queue.acquire_all(f"cli:{session_id}", ["session", "global"]):
+                        result = loop.run(text)
+                else:
+                    result = loop.run(text)
+
                 tool_calls = []
                 if result and result.tool_calls:
                     tool_calls = [
@@ -212,7 +225,39 @@ class CLIPoller:
                 log.warning("CLI prompt execution error", exc_info=True)
                 return {"type": "error", "message": str(exc)}
 
+        if msg_type == "command":
+            return self._handle_command_on_server(msg, loop)
+
         return {"type": "error", "message": f"Unknown message type: {msg_type}"}
+
+    def _handle_command_on_server(self, msg: dict[str, Any], loop: Any) -> dict[str, Any]:
+        """Execute a slash command on the server side."""
+        cmd = msg.get("cmd", "")
+        args = msg.get("args", "")
+        try:
+            from core.cli import _handle_command
+
+            should_break, _verbose, _resume = _handle_command(
+                cmd,
+                args,
+                False,
+                skill_registry=self._services.skill_registry,
+                mcp_manager=self._services.mcp_manager,
+            )
+            return {
+                "type": "command_result",
+                "cmd": cmd,
+                "status": "ok",
+                "should_break": should_break,
+            }
+        except Exception as exc:
+            log.warning("CLI command error: %s %s", cmd, exc, exc_info=True)
+            return {
+                "type": "command_result",
+                "cmd": cmd,
+                "status": "error",
+                "message": str(exc),
+            }
 
     @staticmethod
     def _send(client: socket.socket, data: dict[str, Any]) -> None:

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -33,13 +33,14 @@ log = logging.getLogger(__name__)
 class SessionMode(StrEnum):
     """Execution mode — determines behavior defaults, not shared resources."""
 
-    REPL = "repl"  # Interactive — hitl=2, verbose=user, time=unlimited
+    REPL = "repl"  # Interactive terminal — hitl=2, verbose=user, time=unlimited
+    IPC = "ipc"  # Thin CLI via Unix socket — hitl=0, WRITE ok, DANGEROUS blocked
     DAEMON = "daemon"  # Slack/Discord poller — hitl=0, quiet, time=config
     SCHEDULER = "scheduler"  # Cron/scheduled jobs — hitl=0, quiet, time=300s cap
 
 
-# Tools denied for headless execution (SCHEDULER, DAEMON).
-# DANGEROUS tools require HITL approval which headless modes cannot provide.
+# Tools denied for non-terminal execution (IPC, DAEMON, SCHEDULER).
+# DANGEROUS tools require interactive terminal which these modes cannot provide.
 _HEADLESS_DENIED_TOOLS: frozenset[str] = frozenset(
     {
         "run_bash",
@@ -58,6 +59,12 @@ _MODE_DEFAULTS: dict[SessionMode, dict[str, Any]] = {
         "quiet": False,
         "time_budget_s": 0.0,  # unlimited (interactive)
         "max_rounds": 0,  # unlimited
+    },
+    SessionMode.IPC: {
+        "hitl_level": 0,  # auto-approve (WRITE ok, DANGEROUS policy-blocked)
+        "quiet": False,
+        "time_budget_s": 0.0,  # unlimited (interactive via IPC)
+        "max_rounds": 0,
     },
     SessionMode.DAEMON: {
         "hitl_level": 0,
@@ -146,7 +153,7 @@ class SharedServices:
 
         # Filter DANGEROUS tools for headless modes (PolicyChain enforcement)
         handlers = self.tool_handlers
-        if mode in (SessionMode.SCHEDULER, SessionMode.DAEMON):
+        if mode in (SessionMode.IPC, SessionMode.SCHEDULER, SessionMode.DAEMON):
             denied = _HEADLESS_DENIED_TOOLS & set(handlers)
             if denied:
                 log.info("Headless mode %s: denied tools filtered — %s", mode, denied)

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -16,8 +16,8 @@ from core.gateway.shared_services import (
 class TestSessionMode:
     """SessionMode enum values and completeness."""
 
-    def test_three_modes_exist(self) -> None:
-        assert set(SessionMode) == {"repl", "daemon", "scheduler"}
+    def test_four_modes_exist(self) -> None:
+        assert set(SessionMode) == {"repl", "ipc", "daemon", "scheduler"}
 
     def test_all_modes_have_defaults(self) -> None:
         for mode in SessionMode:


### PR DESCRIPTION
## Summary
- Standalone REPL 폐기 (-487 lines), thin IPC client만 유지
- `geode` → 항상 serve 연결 (미실행 시 background daemon 자동 시작)
- 모든 실행 경로: thin CLI → IPC → serve → SessionLane → Global → execute

## Why
standalone REPL과 thin IPC client 두 코드 경로가 공존하면서 cleanup_idle 누락, CLIPoller lane bypass, socket 권한 미설정 등 검증팀 P1 4건 발생. 근본 원인 = "2개 코드 경로 존재". 목표 아키텍처("프로세스 1개, 리소스 1세트") 완성.

## Changes
| Component | Before | After |
|-----------|--------|-------|
| `geode` (REPL) | 2개 경로 (standalone + thin) | thin IPC only |
| serve 필수 여부 | 선택적 | **필수** (auto-start) |
| SessionMode | REPL/DAEMON/SCHEDULER | REPL/**IPC**/DAEMON/SCHEDULER |
| CLIPoller | lane bypass, no chmod | `acquire_all()` + `chmod 0o600` |
| IPC protocol | prompt/exit only | + **command** type (slash relay) |
| _interactive_loop | ~300줄 | **삭제** |

## Test plan
- [x] 3433 tests pass, 0 failures
- [x] Lint: ruff check 0 errors
- [x] Type: mypy 0 errors
- [x] Format: ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)