### PR TITLE
fix: P1 verification findings — TOCTOU, depth guard, docstring

### DIFF
--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -274,6 +274,24 @@ class SubAgentManager:
         if not tasks:
             return []
 
+        # Explicit depth guard (defense-in-depth alongside denied_tools)
+        if self._depth >= self._max_depth:
+            log.warning(
+                "Sub-agent depth limit reached (%d/%d), rejecting %d tasks",
+                self._depth,
+                self._max_depth,
+                len(tasks),
+            )
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=False,
+                    error=f"Depth limit exceeded ({self._depth}/{self._max_depth})",
+                )
+                for t in tasks
+            ]
+
         tasks = self._deduplicate(tasks)
         if not tasks:
             log.info("All tasks coalesced — nothing to execute")

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -21,29 +21,55 @@ DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
 
 
 def start_serve_if_needed(socket_path: Path | None = None, timeout_s: float = 10.0) -> bool:
-    """Start serve in background if not running. Returns True when ready."""
+    """Start serve in background if not running. Returns True when ready.
+
+    Uses a pidfile lock to prevent TOCTOU race when multiple thin clients
+    attempt to start serve simultaneously.
+    """
+    import fcntl
     import subprocess  # nosec B404 — used for controlled serve daemon spawn
     import sys
+    import time
 
     if is_serve_running(socket_path):
         return True
 
-    log.info("Starting geode serve in background...")
-    subprocess.Popen(  # noqa: S603  # nosec B603 — fixed args, no untrusted input
-        [sys.executable, "-m", "geode.cli", "serve"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+    # Pidfile lock prevents duplicate serve spawn (TOCTOU fix)
+    lock_path = (socket_path or DEFAULT_SOCKET_PATH).with_suffix(".startup.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        lock_fd = open(lock_path, "w")  # noqa: SIM115
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        # Another client is already starting serve — just wait
+        log.debug("Another client is starting serve, waiting...")
+        for _ in range(int(timeout_s * 10)):
+            if is_serve_running(socket_path):
+                return True
+            time.sleep(0.1)
+        return False
 
-    # Wait for socket to appear
-    import time
-
-    for _ in range(int(timeout_s * 10)):
+    try:
+        # Re-check after acquiring lock (serve may have started while waiting)
         if is_serve_running(socket_path):
             return True
-        time.sleep(0.1)
-    return False
+
+        log.info("Starting geode serve in background...")
+        subprocess.Popen(  # noqa: S603  # nosec B603 — fixed args, no untrusted input
+            [sys.executable, "-m", "geode.cli", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+        for _ in range(int(timeout_s * 10)):
+            if is_serve_running(socket_path):
+                return True
+            time.sleep(0.1)
+        return False
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        lock_fd.close()
 
 
 def is_serve_running(socket_path: Path | None = None) -> bool:

--- a/core/orchestration/lane_queue.py
+++ b/core/orchestration/lane_queue.py
@@ -30,7 +30,7 @@ class Lane:
     """A single concurrency lane with semaphore-based limiting.
 
     Usage:
-        lane = Lane("global", max_concurrent=4)
+        lane = Lane("global", max_concurrent=8)
         with lane.acquire("ip:berserk:analysis"):
             # ... do work ...
     """


### PR DESCRIPTION
## Summary
5-persona 검증팀 P1 3건 수정.

## Fixes
1. **TOCTOU race** (Steinberger P1): `start_serve_if_needed()`에 `fcntl.flock` pidfile lock 추가. 두 thin client가 동시에 serve를 시작하려 할 때 중복 spawn 방지.
2. **Depth guard** (Karpathy+Cherny P1): `SubAgentManager.delegate()`에 명시적 `if depth >= max_depth` 체크 추가. 기존 `denied_tools` 암묵적 제어에 defense-in-depth 보강.
3. **Stale docstring** (Beck P1): Lane 예제 `max_concurrent=4` → `8` (실제 DEFAULT_GLOBAL_CONCURRENCY 반영).

## Test plan
- [x] 3433 tests pass, 0 failures
- [x] Lint: 0 errors
- [x] Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)