### PR TITLE
fix: thin-only IPC — sys.executable mismatch + serve-side UI leak

### DIFF
--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -55,8 +55,13 @@ def start_serve_if_needed(socket_path: Path | None = None, timeout_s: float = 10
             return True
 
         log.info("Starting geode serve in background...")
+        # Use 'geode' CLI binary (not sys.executable which may point to wrong Python)
+        import shutil
+
+        geode_bin = shutil.which("geode")
+        cmd = [geode_bin, "serve"] if geode_bin else [sys.executable, "-m", "geode.cli", "serve"]
         subprocess.Popen(  # noqa: S603  # nosec B603 — fixed args, no untrusted input
-            [sys.executable, "-m", "geode.cli", "serve"],
+            cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -62,7 +62,7 @@ _MODE_DEFAULTS: dict[SessionMode, dict[str, Any]] = {
     },
     SessionMode.IPC: {
         "hitl_level": 0,  # auto-approve (WRITE ok, DANGEROUS policy-blocked)
-        "quiet": False,
+        "quiet": True,  # suppress serve-side UI; results sent via IPC JSON
         "time_budget_s": 0.0,  # unlimited (interactive via IPC)
         "max_rounds": 0,
     },


### PR DESCRIPTION
## Fixes
1. `sys.executable` → `shutil.which("geode")` (uv tool venv 불일치)
2. `SessionMode.IPC: quiet=True` (serve 터미널 UI 누출 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)