### PR TITLE
feat: streaming IPC — thin client agentic UI 재현

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -877,29 +877,54 @@ def _thin_interactive_loop() -> None:
 
                 # All other commands → relay to serve
                 response = client.send_command(cmd, args)
+                # Render captured output from serve (ANSI-styled text)
+                output = response.get("output", "")
+                if output:
+                    import sys as _sys
+
+                    _sys.stdout.write(output)
+                    _sys.stdout.flush()
                 if response.get("status") == "error":
                     console.print(f"  [error]{response.get('message', 'Command failed')}[/error]")
                 elif response.get("should_break"):
                     break
                 continue
 
-            # Free text → relay as prompt
+            # Free text → relay as prompt (streaming agentic UI)
+            import sys as _sys
+
             from core.cli.ui.status import TextSpinner
 
             _spinner = TextSpinner("Thinking...")
             _spinner.start()
-            response = client.send_prompt(user_input)
-            _spinner.stop()
+            _stream_ctx: dict[str, bool] = {"started": False}
+
+            def _on_stream(data: str, *, _sp: Any = _spinner, _ctx: Any = _stream_ctx) -> None:
+                if not _ctx["started"]:
+                    _sp.stop()
+                    _ctx["started"] = True
+                _sys.stdout.write(data)
+                _sys.stdout.flush()
+
+            response = client.send_prompt(user_input, on_stream=_on_stream)
+            _stream_started = _stream_ctx["started"]
+            if not _stream_started:
+                _spinner.stop()
             if response.get("type") == "error" and "Connection lost" in response.get("message", ""):
                 console.print("\n  [error]Connection to serve lost[/error]\n")
                 break
-            _render_ipc_response(response)
+            _render_ipc_response(response, streamed=_stream_started)
     finally:
         client.close()
 
 
-def _render_ipc_response(response: dict[str, Any]) -> None:
-    """Render an IPC response from serve."""
+def _render_ipc_response(response: dict[str, Any], *, streamed: bool = False) -> None:
+    """Render an IPC response from serve.
+
+    When *streamed* is True, the agentic UI (tool calls, token usage) was
+    already rendered in real-time via streaming events — only the final
+    text response needs rendering.
+    """
     rtype = response.get("type", "")
 
     if rtype == "error":
@@ -907,12 +932,13 @@ def _render_ipc_response(response: dict[str, Any]) -> None:
         return
 
     if rtype == "result":
-        # Tool calls
-        tool_calls = response.get("tool_calls", [])
-        for tc in tool_calls:
-            console.print(f"  [dim]\u25b8 {tc.get('name', '?')}[/dim]")
+        if not streamed:
+            # Fallback: no streaming happened — show tool call summary
+            tool_calls = response.get("tool_calls", [])
+            for tc in tool_calls:
+                console.print(f"  [dim]\u25b8 {tc.get('name', '?')}[/dim]")
 
-        # Main text
+        # Main text (always render — this is the LLM's final response)
         text = response.get("text", "")
         if text:
             from rich.markdown import Markdown
@@ -921,18 +947,20 @@ def _render_ipc_response(response: dict[str, Any]) -> None:
             console.print(Markdown(text))
             console.print()
 
-        # Status line (model, rounds, tools)
-        model = response.get("model", "")
-        rounds = response.get("rounds", 0)
-        parts = []
-        if model:
-            parts.append(f"\u2722 {model}")
-        if rounds:
-            parts.append(f"{rounds} rounds")
-        if tool_calls:
-            parts.append(f"{len(tool_calls)} tools")
-        if parts:
-            console.print(f"  [dim]{' · '.join(parts)}[/dim]")
+        if not streamed:
+            # Fallback status line when streaming wasn't available
+            model = response.get("model", "")
+            rounds = response.get("rounds", 0)
+            tool_calls = response.get("tool_calls", [])
+            parts = []
+            if model:
+                parts.append(f"\u2722 {model}")
+            if rounds:
+                parts.append(f"{rounds} rounds")
+            if tool_calls:
+                parts.append(f"{len(tool_calls)} tools")
+            if parts:
+                console.print(f"  [dim]{' · '.join(parts)}[/dim]")
         return
 
     # Fallback: unexpected response type
@@ -1426,6 +1454,10 @@ def serve(
     console.print("  [dim]Press Ctrl+C to stop[/dim]")
     console.print()
 
+    # Readiness check — needed by /analyze, /run, /status via IPC
+    readiness = check_readiness()
+    _set_readiness(readiness)
+
     # Build runtime (wires env, notifications, gateway + MCP startup)
     # MCP startup is now inside _build_gateway() via mcp.startup()
     runtime = _build_runtime_for_serve()
@@ -1568,7 +1600,7 @@ def serve(
     try:
         from core.gateway.pollers.cli_poller import CLIPoller
 
-        _cli_poller = CLIPoller(_gw_services)
+        _cli_poller = CLIPoller(_gw_services, scheduler_service=_sched_svc)
         _cli_poller.start()
         console.print(f"  [success]CLI channel: {_cli_poller.socket_path}[/success]")
     except Exception:

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -490,6 +490,14 @@ def cmd_auth(args: str) -> None:
 
 def _auth_add_interactive(store: ProfileStore, add_args: str) -> None:
     """Interactive auth profile addition."""
+    import sys
+
+    if not sys.stdin.isatty():
+        console.print("  [warning]/auth add requires an interactive terminal.[/warning]")
+        console.print("  [muted]Use /key <provider> <value> to set API keys directly.[/muted]")
+        console.print()
+        return
+
     from core.gateway.auth.profiles import AuthProfile, CredentialType
 
     # Level 1: Provider selection

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -10,8 +10,8 @@ Protocol: line-delimited JSON over Unix socket (matches CLIPoller server).
 from __future__ import annotations
 
 import json
-import os
 import logging
+import os
 import socket
 from pathlib import Path
 from typing import Any
@@ -151,19 +151,37 @@ class IPCClient:
     def connected(self) -> bool:
         return self._sock is not None
 
-    def send_prompt(self, text: str) -> dict[str, Any]:
+    def send_prompt(
+        self,
+        text: str,
+        *,
+        on_stream: Any = None,
+    ) -> dict[str, Any]:
         """Send a prompt and wait for the result.
 
-        Returns a dict with keys: type, text, rounds, tool_calls, termination.
-        On error, returns {"type": "error", "message": "..."}.
+        When *on_stream* is provided (callable(str) -> None), intermediate
+        ``{"type": "stream"}`` messages are passed to it in real-time so the
+        thin client can render agentic UI (tool calls, results, tokens)
+        progressively.
+
+        Returns the final ``{"type": "result", ...}`` dict.
+        On error, returns ``{"type": "error", "message": "..."}``.
         """
         if not self._sock:
             return {"type": "error", "message": "Not connected"}
         self._send({"type": "prompt", "text": text})
-        response = self._recv()
-        if response is None:
-            return {"type": "error", "message": "Connection lost"}
-        return response
+
+        # Read messages until the final result arrives
+        while True:
+            response = self._recv()
+            if response is None:
+                return {"type": "error", "message": "Connection lost"}
+            if response.get("type") == "stream":
+                if on_stream is not None:
+                    on_stream(response.get("data", ""))
+                continue
+            # Any non-stream message is the final response
+            return response
 
     def send_command(self, cmd: str, args: str = "") -> dict[str, Any]:
         """Send a slash command to serve and wait for result.

--- a/core/cli/ui/console.py
+++ b/core/cli/ui/console.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 import shutil
 import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+from io import StringIO
 
 from rich.console import Console
 from rich.theme import Theme
@@ -69,3 +72,30 @@ def _get_terminal_width() -> int | None:
 
 
 console = Console(theme=GEODE_THEME, width=_get_terminal_width())
+
+
+@contextmanager
+def capture_output() -> Generator[StringIO, None, None]:
+    """Capture console output with ANSI styling preserved.
+
+    Temporarily redirects the global console to a StringIO buffer with
+    ``force_terminal=True`` so that Rich markup is rendered as ANSI escape
+    codes.  The caller receives the buffer; after the block exits the
+    console is restored to its original state.
+
+    Usage::
+
+        with capture_output() as buf:
+            console.print("[bold]hello[/bold]")
+        text = buf.getvalue()   # contains ANSI-styled text
+    """
+    buf = StringIO()
+    old_file = console._file
+    old_force = console._force_terminal
+    console._file = buf
+    console._force_terminal = True
+    try:
+        yield buf
+    finally:
+        console._file = old_file
+        console._force_terminal = old_force

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -57,9 +57,7 @@ class _StreamingWriter:
         if not text:
             return 0
         try:
-            payload = json.dumps(
-                {"type": "stream", "data": text}, ensure_ascii=False
-            ) + "\n"
+            payload = json.dumps({"type": "stream", "data": text}, ensure_ascii=False) + "\n"
             self._client.sendall(payload.encode("utf-8"))
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass  # client disconnected — silently drop
@@ -246,7 +244,10 @@ class CLIPoller:
 
             try:
                 return self._run_prompt_streaming(
-                    text, loop, session_id, msg.get("_client"),
+                    text,
+                    loop,
+                    session_id,
+                    msg.get("_client"),
                 )
             except Exception as exc:
                 log.warning("CLI prompt execution error", exc_info=True)
@@ -294,9 +295,7 @@ class CLIPoller:
         try:
             lane_queue = self._services.lane_queue
             if lane_queue is not None:
-                with lane_queue.acquire_all(
-                    f"cli:{session_id}", ["session", "global"]
-                ):
+                with lane_queue.acquire_all(f"cli:{session_id}", ["session", "global"]):
                     result = loop.run(text)
             else:
                 result = loop.run(text)
@@ -313,15 +312,19 @@ class CLIPoller:
         if result and result.tool_calls:
             for tc in result.tool_calls:
                 if isinstance(tc, dict):
-                    tool_calls.append({
-                        "name": tc.get("name", "?"),
-                        "args": tc.get("input", {}),
-                    })
+                    tool_calls.append(
+                        {
+                            "name": tc.get("name", "?"),
+                            "args": tc.get("input", {}),
+                        }
+                    )
                 elif hasattr(tc, "name"):
-                    tool_calls.append({
-                        "name": tc.name,
-                        "args": getattr(tc, "arguments", {}),
-                    })
+                    tool_calls.append(
+                        {
+                            "name": tc.name,
+                            "args": getattr(tc, "arguments", {}),
+                        }
+                    )
         model = getattr(loop, "model", "unknown")
         summary = getattr(result, "summary", "") if result else ""
 

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -12,7 +12,9 @@ Client → Server:
     {"type": "exit"}
 
 Server → Client:
+    {"type": "stream", "data": "▸ tool_call(...)\\n"}   (during prompt execution)
     {"type": "result", "text": "...", "rounds": 3, "tool_calls": [...]}
+    {"type": "command_result", "cmd": "...", "output": "..."}
     {"type": "error", "message": "..."}
     {"type": "session", "session_id": "cli-abc123"}
 """
@@ -35,6 +37,44 @@ if TYPE_CHECKING:
 DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
 
 
+class _StreamingWriter:
+    """File-like object that relays console writes to a client socket.
+
+    Each ``write()`` call sends ``{"type": "stream", "data": "..."}`` over
+    the socket, so the thin client can render agentic UI (tool calls,
+    results, token usage) in real-time as the AgenticLoop executes.
+
+    Inspired by:
+    - Codex CLI item-based streaming (discrete events over API)
+    - OpenClaw System Events Queue (event → client relay)
+    - autoresearch P6 L1 capture (capture all stdout)
+    """
+
+    def __init__(self, client: socket.socket) -> None:
+        self._client = client
+
+    def write(self, text: str) -> int:
+        if not text:
+            return 0
+        try:
+            payload = json.dumps(
+                {"type": "stream", "data": text}, ensure_ascii=False
+            ) + "\n"
+            self._client.sendall(payload.encode("utf-8"))
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass  # client disconnected — silently drop
+        return len(text)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return True  # trick Rich into applying ANSI styles
+
+    def fileno(self) -> int:
+        return -1
+
+
 class CLIPoller:
     """Unix domain socket server for CLI thin-client IPC.
 
@@ -49,6 +89,7 @@ class CLIPoller:
         services: SharedServices,
         *,
         socket_path: Path | None = None,
+        scheduler_service: Any = None,
     ) -> None:
         self._services = services
         self._socket_path = socket_path or DEFAULT_SOCKET_PATH
@@ -56,6 +97,7 @@ class CLIPoller:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._active_client: socket.socket | None = None
+        self._scheduler_service = scheduler_service
 
     @property
     def channel_name(self) -> str:
@@ -136,6 +178,9 @@ class CLIPoller:
         from core.agent.conversation import ConversationContext
         from core.gateway.shared_services import SessionMode
 
+        # ContextVars do NOT propagate to threads — set them explicitly
+        self._propagate_contextvars()
+
         client.settimeout(None)  # blocking reads
         buf = b""
         conversation = ConversationContext()
@@ -162,6 +207,7 @@ class CLIPoller:
                 while b"\n" in buf:
                     line, buf = buf.split(b"\n", 1)
                     msg = json.loads(line.decode("utf-8"))
+                    msg["_client"] = client  # pass socket for streaming
                     response = self._process_message(msg, loop, conversation, session_id)
                     if response is None:
                         # Exit signal
@@ -199,34 +245,9 @@ class CLIPoller:
                 return {"type": "error", "message": "Empty prompt"}
 
             try:
-                # Gate through SessionLane + Global Lane
-                lane_queue = self._services.lane_queue
-                if lane_queue is not None:
-                    with lane_queue.acquire_all(f"cli:{session_id}", ["session", "global"]):
-                        result = loop.run(text)
-                else:
-                    result = loop.run(text)
-
-                tool_calls = []
-                if result and result.tool_calls:
-                    for tc in result.tool_calls:
-                        if isinstance(tc, dict):
-                            tool_calls.append({"name": tc.get("name", "?"), "args": tc.get("input", {})})
-                        elif hasattr(tc, "name"):
-                            tool_calls.append({"name": tc.name, "args": getattr(tc, "arguments", {})})
-                # Extract model/cost from last LLM call metadata if available
-                model = getattr(loop, "model", "unknown")
-                summary = getattr(result, "summary", "") if result else ""
-
-                return {
-                    "type": "result",
-                    "text": result.text if result else "",
-                    "rounds": result.rounds if result else 0,
-                    "tool_calls": tool_calls,
-                    "termination": (result.termination_reason if result else "unknown"),
-                    "model": model,
-                    "summary": summary,
-                }
+                return self._run_prompt_streaming(
+                    text, loop, session_id, msg.get("_client"),
+                )
             except Exception as exc:
                 log.warning("CLI prompt execution error", exc_info=True)
                 return {"type": "error", "message": str(exc)}
@@ -236,24 +257,109 @@ class CLIPoller:
 
         return {"type": "error", "message": f"Unknown message type: {msg_type}"}
 
+    def _run_prompt_streaming(
+        self,
+        text: str,
+        loop: Any,
+        session_id: str,
+        client: socket.socket | None,
+    ) -> dict[str, Any]:
+        """Run a prompt with real-time console streaming to the client.
+
+        Redirects the global console to a ``_StreamingWriter`` so that
+        all agentic UI output (tool calls ▸, results ✓/✗, token usage ✢,
+        context events ⟳) is relayed to the thin client in real-time.
+
+        The loop runs with ``quiet=False`` — identical to the old REPL
+        experience.  After completion, the console is restored and a
+        final ``result`` message is sent.
+        """
+        from core.cli.ui.console import console
+
+        # Enable agentic UI for this run (same as old REPL)
+        old_quiet = getattr(loop, "_quiet", True)
+        old_op_quiet = getattr(loop, "_op_logger", None)
+        loop._quiet = False
+        if old_op_quiet is not None:
+            loop._op_logger._quiet = False
+
+        # Redirect console to streaming writer (thread-local: only this thread)
+        writer = _StreamingWriter(client) if client else None
+        old_file = console._file
+        old_force = console._force_terminal
+        if writer:
+            console._file = writer  # type: ignore[assignment]
+            console._force_terminal = True
+
+        try:
+            lane_queue = self._services.lane_queue
+            if lane_queue is not None:
+                with lane_queue.acquire_all(
+                    f"cli:{session_id}", ["session", "global"]
+                ):
+                    result = loop.run(text)
+            else:
+                result = loop.run(text)
+        finally:
+            # Restore console and quiet state
+            console._file = old_file
+            console._force_terminal = old_force
+            loop._quiet = old_quiet
+            if old_op_quiet is not None:
+                loop._op_logger._quiet = old_quiet
+
+        # Build final result (tool_calls already rendered via streaming)
+        tool_calls: list[dict[str, Any]] = []
+        if result and result.tool_calls:
+            for tc in result.tool_calls:
+                if isinstance(tc, dict):
+                    tool_calls.append({
+                        "name": tc.get("name", "?"),
+                        "args": tc.get("input", {}),
+                    })
+                elif hasattr(tc, "name"):
+                    tool_calls.append({
+                        "name": tc.name,
+                        "args": getattr(tc, "arguments", {}),
+                    })
+        model = getattr(loop, "model", "unknown")
+        summary = getattr(result, "summary", "") if result else ""
+
+        return {
+            "type": "result",
+            "text": result.text if result else "",
+            "rounds": result.rounds if result else 0,
+            "tool_calls": tool_calls,
+            "termination": (result.termination_reason if result else "unknown"),
+            "model": model,
+            "summary": summary,
+        }
+
     def _handle_command_on_server(self, msg: dict[str, Any], loop: Any) -> dict[str, Any]:
-        """Execute a slash command on the server side."""
+        """Execute a slash command on the server side.
+
+        Captures all console output (with ANSI styling) so it can be
+        relayed to the thin client for display.
+        """
         cmd = msg.get("cmd", "")
         args = msg.get("args", "")
         try:
             from core.cli import _handle_command
+            from core.cli.ui.console import capture_output
 
-            should_break, _verbose, _resume = _handle_command(
-                cmd,
-                args,
-                False,
-                skill_registry=self._services.skill_registry,
-                mcp_manager=self._services.mcp_manager,
-            )
+            with capture_output() as buf:
+                should_break, _verbose, _resume = _handle_command(
+                    cmd,
+                    args,
+                    False,
+                    skill_registry=self._services.skill_registry,
+                    mcp_manager=self._services.mcp_manager,
+                )
             return {
                 "type": "command_result",
                 "cmd": cmd,
                 "status": "ok",
+                "output": buf.getvalue(),
                 "should_break": should_break,
             }
         except Exception as exc:
@@ -264,6 +370,29 @@ class CLIPoller:
                 "status": "error",
                 "message": str(exc),
             }
+
+    def _propagate_contextvars(self) -> None:
+        """Set ContextVars needed by slash command handlers in this thread.
+
+        Python ContextVars do NOT inherit across threads. The CLI poller
+        thread must explicitly set readiness, scheduler_service, domain,
+        memory, and profile so that ``_handle_command()`` works correctly.
+        """
+        try:
+            from core.cli import _set_readiness
+            from core.cli.session_state import _scheduler_service_ctx
+            from core.cli.startup import check_readiness
+
+            _set_readiness(check_readiness())
+
+            if self._scheduler_service is not None:
+                _scheduler_service_ctx.set(self._scheduler_service)
+
+            # Domain, memory, profile — delegated to SharedServices helper
+            if hasattr(self._services, "_propagate_contextvars"):
+                self._services._propagate_contextvars()
+        except Exception:
+            log.debug("ContextVar propagation skipped", exc_info=True)
 
     @staticmethod
     def _send(client: socket.socket, data: dict[str, Any]) -> None:

--- a/tests/test_phase3_ipc.py
+++ b/tests/test_phase3_ipc.py
@@ -164,9 +164,11 @@ class TestCLIChannelIntegration:
         mock_result.rounds = 3
         mock_result.tool_calls = []
         mock_result.termination_reason = "natural"
+        mock_result.summary = ""
 
         mock_loop = MagicMock()
         mock_loop.run.return_value = mock_result
+        mock_loop.model = "test-model"
         mock_services.create_session.return_value = (MagicMock(), mock_loop)
 
         poller = CLIPoller(mock_services, socket_path=sock_path)


### PR DESCRIPTION
## Summary
- **StreamingWriter**: console write → IPC socket relay로 thin client에서 full agentic UI (▸ tool call, ✓ result, ✢ tokens) 실시간 표시
- **Command output capture**: `capture_output()` context manager로 slash command 출력 ANSI 보존 relay
- **ContextVar propagation**: readiness, scheduler_service를 CLI poller thread에 명시적 전파
- **TTY guard**: `/auth add` non-interactive 환경 crash 방지

## Frontier Research
| System | Pattern | 채택 |
|--------|---------|------|
| Codex | Item-based streaming | Adapt → console streaming |
| OpenClaw | System Events + WS relay | Adapt → StreamingWriter |
| autoresearch | L1 Block capture | Adapt → quiet=False + redirect |

## Test plan
- [x] Lint: 0 errors
- [x] Type: 0 errors
- [x] Test: 3422 passed
- [x] E2E: /status, /model, /list, /schedule, /cost, /mcp, /skills, /key, /auth, /verbose, /trigger, /context, /tasks, /analyze --dry-run
- [x] E2E: free-text prompt with tool calls — streaming ▸/✓/✢ confirmed
- [x] E2E: pipeline analysis with streaming panel UI confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)