### PR TITLE
fix: auto-start serve Exit(1) indentation bug

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -997,7 +997,7 @@ def main(
             if not ready:
                 console.print("  [error]Failed to start geode serve[/error]")
                 console.print("  [dim]Try manually: geode serve &[/dim]")
-            raise typer.Exit(1)
+                raise typer.Exit(1)
 
         console.print("  [muted]Connected to serve via IPC[/muted]")
         _thin_interactive_loop()


### PR DESCRIPTION
## Summary
- `raise typer.Exit(1)`가 `if not ready:` 블록 밖에 있어 auto-start 성공 시에도 종료되던 버그 수정
- Anti-deception checklist에서 발견

## Test plan
- [x] Lint/Type: 0 errors
- [x] 3422 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)