### PR TITLE
fix: scheduler guardrails — empty-action zombie prevention

### DIFF
--- a/core/automation/scheduler.py
+++ b/core/automation/scheduler.py
@@ -342,9 +342,16 @@ class SchedulerService:
     def add_job(self, job: ScheduledJob) -> None:
         """Add a new scheduled job.
 
-        Raises ValueError if job_id already exists or a job with the same
-        schedule expression and action already exists (dedup).
+        Raises ValueError if:
+        - job_id already exists
+        - job has no action AND no callback (would be a no-op zombie)
+        - a job with the same schedule expression and action already exists (dedup)
         """
+        if not job.action and job.callback is None:
+            raise ValueError(
+                "Job must have an action or callback. "
+                "Empty-action jobs fire as no-ops and waste resources."
+            )
         with self._lock:
             if job.job_id in self._jobs:
                 raise ValueError(f"Job '{job.job_id}' already exists")
@@ -674,13 +681,20 @@ class SchedulerService:
             finally:
                 fcntl.flock(lf, fcntl.LOCK_UN)
         loaded = 0
+        zombies = 0
         for _jid, jdata in data.items():
             try:
                 job = _job_from_dict(jdata)
+                # Skip zombie jobs (no action, no callback) — auto-cleanup
+                if not job.action and job.callback is None:
+                    zombies += 1
+                    continue
                 self._jobs[job.job_id] = job
                 loaded += 1
             except Exception as exc:
                 log.warning("Skipping malformed job entry: %s", exc)
+        if zombies:
+            log.warning("Skipped %d zombie jobs (empty action) on load", zombies)
         log.info("Loaded %d jobs from %s", loaded, path)
 
     # -- Background runner --------------------------------------------------

--- a/core/cli/cmd_schedule.py
+++ b/core/cli/cmd_schedule.py
@@ -40,6 +40,38 @@ def _print_job_status(job: _Any) -> None:
         console.print(f"  Hours: {job.active_hours.start}-{job.active_hours.end}")
 
 
+def _parse_create_args(text: str) -> tuple[str, str]:
+    """Parse create arguments into (schedule_expr, action_text).
+
+    Supports:
+        "every 5m" "check status"   → ("every 5m", "check status")
+        'every 5m' 'check status'   → ("every 5m", "check status")
+        every 5m                    → ("every 5m", "")  — no action
+    """
+    import shlex
+
+    try:
+        parts = shlex.split(text)
+    except ValueError:
+        # Unmatched quotes — treat entire text as schedule
+        return text, ""
+
+    if len(parts) >= 2:
+        # Last part is the action, everything before is the schedule
+        # But if quoted: shlex gives us clean splits
+        # Heuristic: if original text has quotes, respect the split
+        if '"' in text or "'" in text:
+            # shlex split: first part = schedule, second = action
+            return parts[0], " ".join(parts[1:])
+        # Unquoted: try to detect action separator
+        # No good way to tell "every 5 minutes check status" apart
+        # → require quotes for clarity
+        return text, ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return text, ""
+
+
 def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
     """Handle /schedule command — manage scheduled automations.
 
@@ -59,38 +91,32 @@ def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
 
     # --- list -----------------------------------------------------------
     if not arg_lower or arg_lower == "list":
-        console.print()
-        console.print("  [header]Predefined Automations[/header]")
-        for tmpl in PREDEFINED_AUTOMATIONS:
-            state = "[success]ON[/success]" if tmpl.enabled else "[muted]OFF[/muted]"
-            console.print(
-                f"  {state}  [label]{tmpl.id:<30}[/label] "
-                f"[muted]{tmpl.schedule:<16}[/muted] {tmpl.name}"
-            )
-
-        # Dynamic jobs from scheduler_service
+        # Dynamic jobs (active scheduler)
         if scheduler_service is not None:
             jobs = scheduler_service.list_jobs(include_disabled=True)
             if jobs:
                 console.print()
-                console.print("  [header]Dynamic Jobs[/header]")
+                console.print("  [header]Scheduled Jobs[/header]")
                 for job in jobs:
                     state = "[success]ON[/success]" if job.enabled else "[muted]OFF[/muted]"
                     desc = _format_schedule_desc(job)
-                    action_hint = ""
-                    if job.action:
-                        action_hint = f" → {job.action[:40]}"
-                    else:
-                        action_hint = " [warning](no action)[/warning]"
+                    action_hint = f" → {job.action[:40]}" if job.action else ""
                     console.print(
                         f"  {state}  [label]{job.job_id:<30}[/label] "
                         f"[muted]{desc:<16}[/muted] {job.name}{action_hint}"
                     )
+            else:
+                console.print()
+                console.print("  [muted]No scheduled jobs.[/muted]")
+
+        # Predefined templates (domain-specific, reference only)
+        console.print()
+        console.print("  [header]Templates[/header] [muted](domain reference, not active)[/muted]")
+        for tmpl in PREDEFINED_AUTOMATIONS:
+            console.print(f"  [muted]  {tmpl.id:<30} {tmpl.schedule:<16} {tmpl.name}[/muted]")
 
         console.print()
-        console.print(
-            "  [muted]Usage: /schedule [create|delete|status|enable|disable|run] <id>[/muted]"
-        )
+        console.print('  [muted]Usage: /schedule create "<schedule>" "<action>"[/muted]')
         console.print()
         return
 
@@ -101,28 +127,45 @@ def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
 
     # --- create ---------------------------------------------------------
     if sub == "create":
-        if not target_id:
-            console.print("  [warning]Usage: /schedule create <expression>[/warning]")
+        if not rest.strip():
+            console.print('  [warning]Usage: /schedule create "<schedule>" "<action>"[/warning]')
+            console.print('  [muted]Example: /schedule create "every 5m" "check status"[/muted]')
             console.print()
             return
         if scheduler_service is None:
             console.print("  [warning]Scheduler not available[/warning]")
             console.print()
             return
+
+        # Parse quoted args: /schedule create "every 5m" "do something"
+        schedule_expr, action_text = _parse_create_args(rest.strip())
+        if not action_text:
+            console.print(
+                "  [warning]Action is required. What should the job do when it fires?[/warning]"
+            )
+            console.print('  [muted]Usage: /schedule create "<schedule>" "<action>"[/muted]')
+            console.print()
+            return
+
         from core.automation.nl_scheduler import NLScheduleParser
 
         parser = NLScheduleParser()
-        result = parser.parse(target_id)
+        result = parser.parse(schedule_expr)
         if not result.success or result.job is None:
-            console.print(f"  [warning]Failed to parse: {target_id}[/warning]")
+            console.print(f"  [warning]Failed to parse schedule: {schedule_expr}[/warning]")
             console.print()
             return
-        scheduler_service.add_job(result.job)
+        result.job.action = action_text
+        try:
+            scheduler_service.add_job(result.job)
+        except ValueError as exc:
+            console.print(f"  [warning]{exc}[/warning]")
+            console.print()
+            return
         scheduler_service.save()
         console.print(f"  [success]Created: {result.job.job_id}[/success]")
         console.print(f"  Schedule: {_format_schedule_desc(result.job)}")
-        if not result.job.action:
-            console.print("  [warning]Action not set — set via schedule_job tool[/warning]")
+        console.print(f"  Action: {action_text[:80]}")
         console.print()
         return
 
@@ -174,49 +217,46 @@ def cmd_schedule(args: str, *, scheduler_service: _Any = None) -> None:
     if sub in ("enable", "disable"):
         new_state = sub == "enable"
 
-        # Check predefined templates
+        # Reject predefined templates — they're reference only
         found_tmpl = next(
             (t for t in PREDEFINED_AUTOMATIONS if t.id == target_id),
             None,
         )
         if found_tmpl is not None:
-            found_tmpl.enabled = new_state
-            label = "enabled" if new_state else "disabled"
-            console.print(f"  [success]{found_tmpl.name}: {label}[/success]")
+            console.print(f"  [warning]'{target_id}' is a template (not an active job).[/warning]")
+            console.print(
+                '  [muted]Create a job instead: /schedule create "<schedule>" "<action>"[/muted]'
+            )
             console.print()
             return
 
-        # Check dynamic jobs
+        # Dynamic jobs
         if scheduler_service is not None:
             updated = scheduler_service.update_job(target_id, enabled=new_state)
             if updated:
+                scheduler_service.save()
                 label = "enabled" if new_state else "disabled"
                 console.print(f"  [success]{target_id}: {label}[/success]")
                 console.print()
                 return
 
-        console.print(f"  [warning]Unknown template: {target_id}[/warning]")
+        console.print(f"  [warning]Job not found: {target_id}[/warning]")
         console.print()
         return
 
     # --- run ------------------------------------------------------------
     if sub == "run":
-        # Check predefined templates
+        # Reject predefined templates
         found_tmpl = next(
             (t for t in PREDEFINED_AUTOMATIONS if t.id == target_id),
             None,
         )
         if found_tmpl is not None:
-            console.print(f"  [header]Running: {found_tmpl.name}[/header]")
-            console.print(f"  Mode: {found_tmpl.pipeline_config.mode}")
-            console.print(f"  Batch size: {found_tmpl.pipeline_config.batch_size}")
-            console.print(f"  Dry-run: {found_tmpl.pipeline_config.dry_run}")
-            console.print()
-            console.print("  [muted]Template execution dispatched to runtime.[/muted]")
+            console.print(f"  [warning]'{target_id}' is a template (not an active job).[/warning]")
             console.print()
             return
 
-        # Check dynamic jobs
+        # Dynamic jobs
         if scheduler_service is not None:
             result = scheduler_service.run_now(target_id)
             if result.get("status") == "error":

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -54,6 +54,7 @@ def _make_job(
     at_ms: float = 0.0,
     cron_expr: str = "",
     callback: Any = None,
+    action: str = "test prompt",
     enabled: bool = True,
     delete_after_run: bool = False,
     active_hours: ActiveHours | None = None,
@@ -72,6 +73,7 @@ def _make_job(
         enabled=enabled,
         delete_after_run=delete_after_run,
         callback=callback,
+        action=action if callback is None else "",
         active_hours=active_hours,
     )
 

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -47,6 +47,7 @@ class TestNLToSchedulerIntegration:
         result = parser.parse("every 5 minutes")
         assert result.success
         assert result.job is not None
+        result.job.action = "test action"
         svc.add_job(result.job)
         assert svc.get_job(result.job.job_id) is not None
         assert result.job.schedule.kind == ScheduleKind.EVERY
@@ -56,6 +57,7 @@ class TestNLToSchedulerIntegration:
         result = parser.parse("daily at 9:00")
         assert result.success
         assert result.job is not None
+        result.job.action = "test action"
         svc.add_job(result.job)
         job = svc.get_job(result.job.job_id)
         assert job is not None
@@ -65,6 +67,7 @@ class TestNLToSchedulerIntegration:
         result = parser.parse("in 30 minutes")
         assert result.success
         assert result.job is not None
+        result.job.action = "test action"
         svc.add_job(result.job)
         job = svc.get_job(result.job.job_id)
         assert job is not None
@@ -77,6 +80,7 @@ class TestNLToSchedulerIntegration:
         result = parser.parse("every 10 minutes during 09:00-18:00")
         assert result.success
         assert result.job is not None
+        result.job.action = "test action"
         svc.add_job(result.job)
         job = svc.get_job(result.job.job_id)
         assert job is not None
@@ -96,6 +100,7 @@ class TestNLToSchedulerIntegration:
     ) -> None:
         result = parser.parse("every 2 hours")
         assert result.success and result.job
+        result.job.action = "test action"
         svc.add_job(result.job)
         svc.save()
 
@@ -125,6 +130,7 @@ class TestPredefinedToScheduler:
                     name=tmpl.name,
                     schedule=Schedule(kind=ScheduleKind.CRON, cron_expr=tmpl.schedule),
                     enabled=tmpl.enabled,
+                    action=f"run {tmpl.id}",
                     metadata={
                         "source": "predefined",
                         "template_id": tmpl.id,
@@ -143,6 +149,7 @@ class TestPredefinedToScheduler:
             name=tmpl.name,
             schedule=Schedule(kind=ScheduleKind.CRON, cron_expr=tmpl.schedule),
             enabled=True,
+            action=f"run {tmpl.id}",
         )
         svc.add_job(job)
         with pytest.raises(ValueError, match="already exists"):
@@ -161,7 +168,7 @@ class TestCmdScheduleEnhanced:
         with patch("core.cli.cmd_schedule.console") as mock_console:
             cmd_schedule("", scheduler_service=svc)
             output = " ".join(str(c) for c in mock_console.print.call_args_list)
-            assert "Predefined Automations" in output
+            assert "Templates" in output
 
     def test_list_shows_dynamic_jobs(self, svc: SchedulerService) -> None:
         job = ScheduledJob(
@@ -169,18 +176,22 @@ class TestCmdScheduleEnhanced:
             name="Test Job",
             schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60_000),
             enabled=True,
+            action="check status",
         )
         svc.add_job(job)
         with patch("core.cli.cmd_schedule.console") as mock_console:
             cmd_schedule("list", scheduler_service=svc)
             output = " ".join(str(c) for c in mock_console.print.call_args_list)
-            assert "Dynamic Jobs" in output
+            assert "Scheduled Jobs" in output
             assert "dynamic:test1" in output
 
     def test_create_with_nl_expression(self, svc: SchedulerService) -> None:
         initial_count = len(svc.list_jobs(include_disabled=True))
         with patch("core.cli.cmd_schedule.console"):
-            cmd_schedule("create every 5 minutes", scheduler_service=svc)
+            cmd_schedule(
+                'create "every 5 minutes" "check system health"',
+                scheduler_service=svc,
+            )
         assert len(svc.list_jobs(include_disabled=True)) == initial_count + 1
 
     def test_create_invalid_expression(self, svc: SchedulerService) -> None:
@@ -200,6 +211,7 @@ class TestCmdScheduleEnhanced:
             job_id="del-me",
             name="To Delete",
             schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60_000),
+            action="test action",
         )
         svc.add_job(job)
         with patch("core.cli.cmd_schedule.console") as mock_console:
@@ -226,6 +238,7 @@ class TestCmdScheduleEnhanced:
             job_id="status-job",
             name="Status Test",
             schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=300_000),
+            action="check drift",
             last_status="ok",
             last_duration_ms=42.5,
         )
@@ -247,6 +260,7 @@ class TestCmdScheduleEnhanced:
             job_id="toggle-me",
             name="Toggle",
             schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60_000),
+            action="toggle test",
             enabled=False,
         )
         svc.add_job(job)
@@ -261,6 +275,7 @@ class TestCmdScheduleEnhanced:
             job_id="toggle-me2",
             name="Toggle2",
             schedule=Schedule(kind=ScheduleKind.EVERY, every_ms=60_000),
+            action="toggle test 2",
             enabled=True,
         )
         svc.add_job(job)


### PR DESCRIPTION
## Summary
- `add_job()` guardrail: action 또는 callback 필수 (좀비 방지)
- `/schedule create "schedule" "action"` 구문으로 action 필수화
- Predefined template → reference-only (enable/run 거부)
- 좀비 데이터 13개 + orphan log 17개 정리

## Test plan
- [x] 3422 tests passed
- [x] E2E: create with/without action, delete, list, enable predefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)