### PR TITLE
fix: IPC streaming colors + spinner rendering

### DIFF
--- a/core/cli/ui/console.py
+++ b/core/cli/ui/console.py
@@ -15,6 +15,7 @@ import sys
 from collections.abc import Generator
 from contextlib import contextmanager
 from io import StringIO
+from typing import Any
 
 from rich.console import Console
 from rich.theme import Theme
@@ -79,9 +80,9 @@ def capture_output() -> Generator[StringIO, None, None]:
     """Capture console output with ANSI styling preserved.
 
     Temporarily redirects the global console to a StringIO buffer with
-    ``force_terminal=True`` so that Rich markup is rendered as ANSI escape
-    codes.  The caller receives the buffer; after the block exits the
-    console is restored to its original state.
+    ``force_terminal=True`` and a valid color system so that Rich markup
+    is rendered as ANSI escape codes — even when the process's stdout is
+    not a TTY (e.g. ``geode serve`` started with ``stdout=DEVNULL``).
 
     Usage::
 
@@ -89,13 +90,45 @@ def capture_output() -> Generator[StringIO, None, None]:
             console.print("[bold]hello[/bold]")
         text = buf.getvalue()   # contains ANSI-styled text
     """
+    from rich.color import ColorSystem
+
     buf = StringIO()
     old_file = console._file
     old_force = console._force_terminal
+    old_color = console._color_system
     console._file = buf
     console._force_terminal = True
+    if old_color is None:
+        console._color_system = ColorSystem.TRUECOLOR
     try:
         yield buf
     finally:
         console._file = old_file
         console._force_terminal = old_force
+        console._color_system = old_color
+
+
+@contextmanager
+def redirect_console(target: Any) -> Generator[None, None, None]:
+    """Redirect console output to *target* with ANSI styling preserved.
+
+    Like ``capture_output`` but writes to an arbitrary file-like object
+    (e.g. ``_StreamingWriter``) instead of a ``StringIO`` buffer.
+    Ensures ``_color_system`` is set so styles render even when the
+    process stdout is DEVNULL.
+    """
+    from rich.color import ColorSystem
+
+    old_file = console._file
+    old_force = console._force_terminal
+    old_color = console._color_system
+    console._file = target
+    console._force_terminal = True
+    if old_color is None:
+        console._color_system = ColorSystem.TRUECOLOR
+    try:
+        yield
+    finally:
+        console._file = old_file
+        console._force_terminal = old_force
+        console._color_system = old_color

--- a/core/cli/ui/status.py
+++ b/core/cli/ui/status.py
@@ -17,13 +17,19 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
+from typing import Any
 
 from core.cli.ui.console import console
 from core.llm.router import LLMUsageAccumulator, get_usage_accumulator
 
 
 class TextSpinner:
-    """Non-invasive text spinner. No raw mode, no cursor hiding."""
+    """Non-invasive text spinner. No raw mode, no cursor hiding.
+
+    Output target is resolved at write-time: if the global console has
+    been redirected (e.g. via ``redirect_console()`` for IPC streaming),
+    the spinner writes through that redirect instead of ``sys.stdout``.
+    """
 
     FRAMES = [
         "\u280b",
@@ -44,6 +50,14 @@ class TextSpinner:
         self._thread: threading.Thread | None = None
         self._quiet = quiet  # suppress output (sub-agent, headless)
 
+    @staticmethod
+    def _out() -> Any:
+        """Resolve the output target — follows console redirect if active."""
+        target = console.file
+        if target is not None and target is not sys.__stdout__:
+            return target
+        return sys.stdout
+
     def start(self) -> None:
         if self._quiet:
             return
@@ -59,8 +73,9 @@ class TextSpinner:
         idx = 0
         while self._running:
             frame = self.FRAMES[idx % len(self.FRAMES)]
-            sys.stdout.write(f"\r\x1b[2K  {frame} {self._message}")
-            sys.stdout.flush()
+            out = self._out()
+            out.write(f"\r\x1b[2K  {frame} {self._message}")
+            out.flush()
             time.sleep(0.08)
             idx += 1
 
@@ -70,10 +85,11 @@ class TextSpinner:
             return
         if self._thread:
             self._thread.join(timeout=0.2)
-        sys.stdout.write("\r\x1b[2K")
+        out = self._out()
+        out.write("\r\x1b[2K")
         if final_message:
-            sys.stdout.write(f"  {final_message}\n")
-        sys.stdout.flush()
+            out.write(f"  {final_message}\n")
+        out.flush()
 
 
 @dataclass(frozen=True)

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -275,7 +275,7 @@ class CLIPoller:
         experience.  After completion, the console is restored and a
         final ``result`` message is sent.
         """
-        from core.cli.ui.console import console
+        from core.cli.ui.console import redirect_console
 
         # Enable agentic UI for this run (same as old REPL)
         old_quiet = getattr(loop, "_quiet", True)
@@ -284,15 +284,13 @@ class CLIPoller:
         if old_op_quiet is not None:
             loop._op_logger._quiet = False
 
-        # Redirect console to streaming writer (thread-local: only this thread)
+        # Redirect console + spinner output to streaming writer
         writer = _StreamingWriter(client) if client else None
-        old_file = console._file
-        old_force = console._force_terminal
-        if writer:
-            console._file = writer  # type: ignore[assignment]
-            console._force_terminal = True
+        _redirect = redirect_console(writer) if writer else None
 
         try:
+            if _redirect:
+                _redirect.__enter__()
             lane_queue = self._services.lane_queue
             if lane_queue is not None:
                 with lane_queue.acquire_all(f"cli:{session_id}", ["session", "global"]):
@@ -300,9 +298,8 @@ class CLIPoller:
             else:
                 result = loop.run(text)
         finally:
-            # Restore console and quiet state
-            console._file = old_file
-            console._force_terminal = old_force
+            if _redirect:
+                _redirect.__exit__(None, None, None)
             loop._quiet = old_quiet
             if old_op_quiet is not None:
                 loop._op_logger._quiet = old_quiet


### PR DESCRIPTION
## Summary
- **Colors**: serve의 `stdout=DEVNULL` → `_color_system=None` → ANSI 스타일 전부 제거됨. `redirect_console()`에서 `ColorSystem.TRUECOLOR`로 override
- **Spinner**: `TextSpinner`가 `sys.stdout` 직접 사용 → DEVNULL로 소실. `console.file` 따라가도록 `_out()` 메서드 추가

## Test plan
- [x] 3422 tests passed
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)