### PR TITLE
feat: structured IPC events — client-side direct rendering

### DIFF
--- a/.geode/memory/PROJECT.md
+++ b/.geode/memory/PROJECT.md
@@ -56,3 +56,7 @@
 - https://huggingface.co/blog/huggingface/state-of-os-hf-spring-2026
 - https://huggingface-paper-explorer.vercel.app/
 - https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/what-is-trending-in-hugging-face-on-microsoft-foundry-feb-2-2026/4490602
+
+## 최근 인사이트
+- 2026-03-30: [Berserk] tier=?, score=0.00
+- 2026-03-30: [unknown] tier=?, score=0.00

--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-29T04:06:08+09:00 task_id=skill-2.0
+session=2026-03-30T15:36:07+09:00 task_id=structured-events

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -474,8 +474,16 @@ class AgenticLoop:
             self._check_announced_results(messages)
 
             # Show spinner while waiting for LLM response
-            label = "Thinking..." if round_idx == 0 else f"Thinking... (round {round_idx + 1})"
-            _spinner = TextSpinner(f"✢ {label}", quiet=self._quiet)
+            # IPC mode: send structured event; direct mode: TextSpinner
+            from core.cli.ui.agentic_ui import _ipc_writer_local
+
+            _ipc_writer = getattr(_ipc_writer_local, "writer", None)
+            if _ipc_writer is not None and not self._quiet:
+                _ipc_writer.send_event("thinking_start", model=self.model, round=round_idx + 1)
+                _spinner = TextSpinner("", quiet=True)  # no-op spinner
+            else:
+                label = "Thinking..." if round_idx == 0 else f"Thinking... (round {round_idx + 1})"
+                _spinner = TextSpinner(f"✢ {label}", quiet=self._quiet)
             _spinner.start()
             try:
                 response = await self._call_llm(system_prompt, messages, round_idx=round_idx)
@@ -524,6 +532,8 @@ class AgenticLoop:
                 )
             finally:
                 _spinner.stop()
+                if _ipc_writer is not None and not self._quiet:
+                    _ipc_writer.send_event("thinking_end")
 
             if response is None:
                 # Feature 3/4: Model escalation on consecutive LLM failures

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -926,33 +926,29 @@ def _thin_interactive_loop() -> None:
                     break
                 continue
 
-            # Free text → relay as prompt (streaming agentic UI)
-            import sys as _sys
+            # Free text → relay as prompt (client-side direct rendering)
+            from core.cli.ui.event_renderer import EventRenderer
 
-            from core.cli.ui.tool_tracker import ToolCallTracker
-
+            _renderer = EventRenderer()
             _stream_started = False
-            _tracker = ToolCallTracker()
-            _tr = _tracker  # bind for closures (B023)
+            _r = _renderer  # bind for closures (B023)
 
-            def _on_stream(data: str, *, _t: Any = _tr) -> None:
+            def _on_stream(data: str, *, _rr: Any = _r) -> None:
                 nonlocal _stream_started
                 _stream_started = True
-                _t.stop()
-                _sys.stdout.write(data)
-                _sys.stdout.flush()
+                _rr.on_stream(data)
 
-            def _on_event(event: dict[str, object], *, _t: Any = _tr) -> None:
+            def _on_event(event: dict[str, object], *, _rr: Any = _r) -> None:
                 nonlocal _stream_started
                 _stream_started = True
-                etype = event.get("type", "")
-                if etype == "tool_start":
-                    _t.on_tool_start(event)
-                elif etype == "tool_end":
-                    _t.on_tool_end(event)
+                _rr.on_event(event)
 
-            response = client.send_prompt(user_input, on_stream=_on_stream, on_event=_on_event)
-            _tracker.stop()
+            response = client.send_prompt(
+                user_input,
+                on_stream=_on_stream,
+                on_event=_on_event,
+            )
+            _renderer.stop()
             if response.get("type") == "error" and "Connection lost" in response.get("message", ""):
                 console.print("\n  [error]Connection to serve lost[/error]\n")
                 break

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -181,10 +181,17 @@ class IPCClient:
                 continue
             # Structured events — all non-stream, non-terminal types
             if rtype in (
-                "tool_start", "tool_end", "tokens", "round_start",
-                "thinking_start", "thinking_end", "turn_end",
-                "context_event", "subagent_dispatch",
-                "subagent_progress", "subagent_complete",
+                "tool_start",
+                "tool_end",
+                "tokens",
+                "round_start",
+                "thinking_start",
+                "thinking_end",
+                "turn_end",
+                "context_event",
+                "subagent_dispatch",
+                "subagent_progress",
+                "subagent_complete",
                 "session_cost",
             ):
                 if on_event is not None:

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -179,7 +179,14 @@ class IPCClient:
                 if on_stream is not None:
                     on_stream(response.get("data", ""))
                 continue
-            if rtype in ("tool_start", "tool_end"):
+            # Structured events — all non-stream, non-terminal types
+            if rtype in (
+                "tool_start", "tool_end", "tokens", "round_start",
+                "thinking_start", "thinking_end", "turn_end",
+                "context_event", "subagent_dispatch",
+                "subagent_progress", "subagent_complete",
+                "session_cost",
+            ):
                 if on_event is not None:
                     on_event(response)
                 continue

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -140,10 +140,17 @@ class OperationLogger:
 
     def begin_round(self, label: str = "AgenticLoop") -> None:
         """Start a new agentic round — print header if not yet shown."""
-        if not self._header_printed and not self._quiet:
-            console.print(f"\n[bold]● {label}[/bold]")
-            self._header_printed = True
         self._round_count += 1
+        if self._quiet:
+            return
+        if self._header_printed:
+            return
+        self._header_printed = True
+        writer = getattr(_ipc_writer_local, "writer", None)
+        if writer is not None:
+            writer.send_event("round_start", round=self._round_count)
+        else:
+            console.print(f"\n[bold]● {label}[/bold]")
 
     def log_tool_call(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
         """Log a tool call. Returns True if visible, False if collapsed."""
@@ -322,6 +329,16 @@ def render_tokens(
     cost_usd: float | None = None,
 ) -> None:
     """Render token usage line (Claude Code ✢ style)."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "tokens",
+            model=model,
+            input=input_tokens,
+            output=output_tokens,
+            cost=cost_usd or 0.0,
+        )
+        return
     in_str = _fmt_tokens(input_tokens)
     out_str = _fmt_tokens(output_tokens)
     time_str = f" · {elapsed_s:.1f}s" if elapsed_s else ""
@@ -371,30 +388,39 @@ def render_plan_steps(ip_name: str, steps: list[str]) -> None:
 
 def render_subagent_dispatch(task_id: str, task_type: str, description: str) -> None:
     """Render a sub-agent delegation line."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event("subagent_dispatch", task_id=task_id, description=description)
+        return
     console.print(f'  [subagent]▸ delegate_task[/subagent]({task_type}, "{description}")')
 
 
 def render_subagent_progress(
     completed: int, total: int, latest_name: str, latest_time: float
 ) -> None:
-    """Render sub-agent progress with counter.
-
-    Shows progressive ``[completed/total]`` counter as each sub-agent finishes.
-    """
-    if completed < total:
-        console.print(
-            f"  [dim]⎿[/dim] [success]✓[/success] {latest_name} ({latest_time:.1f}s)"
-            f"  [{completed}/{total}]"
+    """Render sub-agent progress with counter."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "subagent_progress",
+            completed=completed,
+            total=total,
+            name=latest_name,
+            duration_s=round(latest_time, 1),
         )
-    else:
-        console.print(
-            f"  [dim]⎿[/dim] [success]✓[/success] {latest_name} ({latest_time:.1f}s)"
-            f"  [{completed}/{total}]"
-        )
+        return
+    console.print(
+        f"  [dim]⎿[/dim] [success]✓[/success] {latest_name} ({latest_time:.1f}s)"
+        f"  [{completed}/{total}]"
+    )
 
 
 def render_subagent_complete(count: int, elapsed_s: float) -> None:
     """Render sub-agent batch completion."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event("subagent_complete", count=count, elapsed_s=round(elapsed_s, 1))
+        return
     console.print(f"  [success]✓ {count} sub-agents completed[/success] ({elapsed_s:.1f}s)")
     console.print()
 
@@ -454,16 +480,13 @@ def render_context_event(
     original_count: int = 0,
     new_count: int = 0,
 ) -> None:
-    """Render context compression notification.
-
-    Shows a dim notification when context is auto-compacted or pruned,
-    so the user knows conversation history was compressed.
-
-    Format::
-
-        ⟳ Context compacted: 45 → 12 messages
-        ⟳ Context pruned: 30 → 10 messages
-    """
+    """Render context compression notification."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "context_event", action=event_type, before=original_count, after=new_count
+        )
+        return
     if event_type == "exhausted":
         console.print(
             "  [warning]⟳ Context exhausted — pruning could not free enough space[/warning]"

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -1,0 +1,175 @@
+"""Client-side event renderer — direct terminal rendering for all IPC events.
+
+Handles structured events from serve (tool_start/end, tokens, thinking,
+round_start, context_event, subagent, turn_end) and renders them with
+spinners, in-place ✓ updates, and ANSI styling.
+
+Replaces raw console stream for agentic UI — client owns all rendering.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Any
+
+from core.cli.ui.tool_tracker import ToolCallTracker
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1000:
+        return f"{n / 1000:.1f}k"
+    return str(n)
+
+
+class EventRenderer:
+    """Dispatches IPC events to appropriate rendering handlers."""
+
+    def __init__(self) -> None:
+        self._tool_tracker = ToolCallTracker()
+        self._thinking = False
+        self._spinner_frame_idx = 0
+        self._thinking_model = ""
+        self._thinking_round = 0
+        self._round_header_printed = False
+        self._out = sys.stdout
+
+    def on_event(self, event: dict[str, Any]) -> None:
+        """Handle a structured event from serve."""
+        etype = str(event.get("type", ""))
+        handler = getattr(self, f"_handle_{etype}", None)
+        if handler:
+            handler(event)
+
+    def on_stream(self, data: str) -> None:
+        """Handle raw console stream (Rich panels, pipeline output)."""
+        self._stop_thinking()
+        self._tool_tracker.stop()
+        self._out.write(data)
+        self._out.flush()
+
+    def stop(self) -> None:
+        """Flush all pending state."""
+        self._stop_thinking()
+        self._tool_tracker.stop()
+
+    # -- Event handlers -------------------------------------------------------
+
+    def _handle_round_start(self, event: dict[str, Any]) -> None:
+        if not self._round_header_printed:
+            self._round_header_printed = True
+            self._out.write("\n\033[1m● AgenticLoop\033[0m\n")
+            self._out.flush()
+
+    def _handle_thinking_start(self, event: dict[str, Any]) -> None:
+        self._tool_tracker.stop()
+        self._thinking = True
+        self._thinking_model = str(event.get("model", ""))
+        self._thinking_round = int(event.get("round", 1))
+        self._render_thinking_frame()
+
+    def _handle_thinking_end(self, _event: dict[str, Any]) -> None:
+        self._stop_thinking()
+
+    def _handle_tool_start(self, event: dict[str, Any]) -> None:
+        self._stop_thinking()
+        self._tool_tracker.on_tool_start(event)
+
+    def _handle_tool_end(self, event: dict[str, Any]) -> None:
+        self._tool_tracker.on_tool_end(event)
+
+    def _handle_tokens(self, event: dict[str, Any]) -> None:
+        self._stop_thinking()
+        self._tool_tracker.stop()
+        model = str(event.get("model", ""))
+        in_tok = int(event.get("input", 0))
+        out_tok = int(event.get("output", 0))
+        cost = float(event.get("cost", 0))
+        in_str = _fmt_tokens(in_tok)
+        out_str = _fmt_tokens(out_tok)
+        cost_str = f" · ${cost:.4f}" if cost > 0 else ""
+        self._out.write(f"  \033[2m✢ {model} · ↓{in_str} ↑{out_str}{cost_str}\033[0m\n")
+        self._out.flush()
+
+    def _handle_turn_end(self, event: dict[str, Any]) -> None:
+        rounds = int(event.get("rounds", 0))
+        tools = int(event.get("tools", 0))
+        elapsed = float(event.get("elapsed_s", 0))
+        cost = float(event.get("cost", 0))
+        if tools == 0:
+            return
+        parts = [f"{rounds} rounds", f"{tools} tools", f"{elapsed:.1f}s"]
+        if cost > 0:
+            parts.append(f"${cost:.3f}")
+        summary = " · ".join(parts)
+        self._out.write(f"\n  \033[2m──── {summary} ────\033[0m\n")
+        self._out.flush()
+
+    def _handle_context_event(self, event: dict[str, Any]) -> None:
+        action = str(event.get("action", ""))
+        before = int(event.get("before", 0))
+        after = int(event.get("after", 0))
+        if action == "exhausted":
+            self._out.write("  \033[1;33m⟳ Context exhausted\033[0m\n")
+        else:
+            label = "compacted" if action == "compact" else "pruned"
+            self._out.write(f"  \033[2m⟳ Context {label}: {before} → {after} messages\033[0m\n")
+        self._out.flush()
+
+    def _handle_subagent_dispatch(self, event: dict[str, Any]) -> None:
+        desc = str(event.get("description", ""))
+        self._out.write(f'  \033[34;1m▸ delegate_task\033[0m("{desc}")\n')
+        self._out.flush()
+
+    def _handle_subagent_progress(self, event: dict[str, Any]) -> None:
+        completed = int(event.get("completed", 0))
+        total = int(event.get("total", 0))
+        name = str(event.get("name", ""))
+        dur = float(event.get("duration_s", 0))
+        self._out.write(
+            f"  \033[2m⎿\033[0m \033[32m✓\033[0m {name} ({dur:.1f}s)  [{completed}/{total}]\n"
+        )
+        self._out.flush()
+
+    def _handle_subagent_complete(self, event: dict[str, Any]) -> None:
+        count = int(event.get("count", 0))
+        elapsed = float(event.get("elapsed_s", 0))
+        self._out.write(f"  \033[32m✓ {count} sub-agents completed\033[0m ({elapsed:.1f}s)\n")
+        self._out.flush()
+
+    def _handle_session_cost(self, event: dict[str, Any]) -> None:
+        calls = int(event.get("calls", 0))
+        in_tok = int(event.get("input", 0))
+        out_tok = int(event.get("output", 0))
+        cost = float(event.get("cost", 0))
+        if calls == 0:
+            return
+        self._out.write("\n  \033[1mSession Cost Summary\033[0m\n")
+        self._out.write(f"  \033[2mCalls:\033[0m {calls}\n")
+        self._out.write(f"  \033[2mTokens:\033[0m ↓{_fmt_tokens(in_tok)} ↑{_fmt_tokens(out_tok)}\n")
+        self._out.write(f"  \033[1;33mTotal: ${cost:.4f}\033[0m\n")
+        breakdown = event.get("breakdown", {})
+        if isinstance(breakdown, dict) and len(breakdown) > 1:
+            for m, c in sorted(breakdown.items(), key=lambda x: -x[1]):
+                self._out.write(f"    \033[2m{m}:\033[0m ${c:.4f}\n")
+        self._out.write("\n")
+        self._out.flush()
+
+    # -- Internal helpers -----------------------------------------------------
+
+    _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def _render_thinking_frame(self) -> None:
+        if not self._thinking:
+            return
+        frame = self._FRAMES[int(time.monotonic() * 12) % len(self._FRAMES)]
+        r = self._thinking_round
+        label = "Thinking..." if r <= 1 else f"Thinking... (round {r})"
+        self._out.write(f"\r\033[2K  {frame} \033[2m✢ {label}\033[0m")
+        self._out.flush()
+
+    def _stop_thinking(self) -> None:
+        if self._thinking:
+            self._thinking = False
+            self._out.write("\r\033[2K")
+            self._out.flush()

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.34.0"
+version = "0.37.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **12 structured event types**: round_start, thinking_start/end, tool_start/end, tokens, turn_end, context_event, subagent_dispatch/progress/complete, session_cost
- **EventRenderer** (client): dispatches all events to rendering handlers — spinners, ✓, ANSI styling
- **OperationLogger** (serve): sends typed events via IPC writer instead of console.print
- **AgenticLoop** (serve): thinking_start/end events for LLM call spinner
- Raw stream preserved for Rich Panels/Tables (pipeline output)

## Test plan
- [x] 3422 tests passed
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)