### PR TITLE
develop → main (v0.37.2: IPC UX fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.37.2] — 2026-03-30
+
+### Fixed
+- **`/model` hot-swap (P0)** — `_apply_model()` now calls `loop.update_model()` on the active AgenticLoop. Model changes take effect immediately in the current IPC session without reconnecting.
+- **`/quit` session cost (P1)** — `/quit` and `/exit` now relay to serve instead of running locally. Session cost summary renders with real accumulator data from the serve process.
+
+### Added
+- **`--continue` / `--resume` (P2)** — IPC resume protocol wired end-to-end. `geode --continue` resumes the most recent session; `geode --resume <id>` resumes a specific session. Checkpoint messages and model are restored into the conversation context.
+- **IPC `resume` message type** — CLIPoller handles `{"type": "resume"}` messages, loads checkpoint via `SessionCheckpoint`, and restores conversation context + loop session ID.
+- **`IPCClient.request_resume()`** — thin client method to request session resume from serve.
+
 ## [0.37.1] — 2026-03-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.37.1
+- **Version**: 0.37.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 190
-- **Tests**: 3422+
+- **Tests**: 3429+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -144,7 +144,7 @@ uv run mypy core/
 
 ### Expected Test Results
 
-3422+ tests pass. 3 IP fixtures produce tier spread:
+3429+ tests pass. 3 IP fixtures produce tier spread:
 - Berserk: **S** (81.2) — conversion_failure
 - Cowboy Bebop: **A** (68.4) — undermarketed
 - Ghost in the Shell: **B** (51.7) — discovery_failure
@@ -369,7 +369,7 @@ Code changes → repeat 3 quality gates. Fix on failure.
 ```bash
 uv run ruff check core/ tests/      # Lint: 0 errors
 uv run mypy core/                    # Type: 0 errors
-uv run pytest tests/ -m "not live"   # Test: 3422+ pass
+uv run pytest tests/ -m "not live"   # Test: 3429+ pass
 ```
 
 #### 4. E2E Verify
@@ -440,7 +440,7 @@ Update `docs/progress.md` only from main. Backlog → In Progress → Done.
 |------|---------|----------|
 | Lint | `uv run ruff check core/ tests/` | 0 errors |
 | Type | `uv run mypy core/` | 0 errors |
-| Test | `uv run pytest tests/ -m "not live"` | 3422+ pass |
+| Test | `uv run pytest tests/ -m "not live"` | 3429+ pass |
 | E2E | `uv run geode analyze "Cowboy Bebop" --dry-run` | A (68.4) |
 
 ## Custom Skills (Scaffold)

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 
 [English](README.md)
 
-# GEODE v0.37.1 — Autonomous Execution Harness
+# GEODE v0.37.2 — Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.37.1 — Long-running Autonomous Execution Harness
+# GEODE v0.37.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -827,17 +827,21 @@ def _read_multiline_input(prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-_LOCAL_COMMANDS = frozenset({"/help", "/exit", "/quit", "/clear"})
+_LOCAL_COMMANDS = frozenset({"/help", "/clear"})
 
 # Commands that need TTY interaction locally, then relay the result to serve
 _TTY_LOCAL_COMMANDS = frozenset({"/model", "/auth"})
 
 
-def _thin_interactive_loop() -> None:
+def _thin_interactive_loop(
+    *,
+    resume_session: str = "",
+    continue_latest: bool = False,
+) -> None:
     """Thin CLI client — all execution delegated to geode serve via IPC.
 
-    Local commands: /help, /exit, /quit, /clear
-    Everything else: relayed to serve (prompts + slash commands)
+    Local commands: /help, /clear
+    Everything else (including /quit, /exit): relayed to serve
     """
     from core.cli.ipc_client import IPCClient
 
@@ -847,6 +851,24 @@ def _thin_interactive_loop() -> None:
         return
 
     console.print(f"  [success]Session: {client.session_id}[/success]")
+
+    # Resume a previous session if requested
+    if resume_session or continue_latest:
+        result = client.request_resume(
+            session_id=resume_session,
+            continue_latest=continue_latest,
+        )
+        if result.get("type") == "resumed":
+            sid = result.get("session_id", "")
+            rnd = result.get("round_idx", 0)
+            msgs = result.get("message_count", 0)
+            model = result.get("model", "")
+            console.print(
+                f"  [success]Resumed:[/success] {sid}"
+                f"  [muted](round {rnd}, {msgs} messages, {model})[/muted]"
+            )
+        else:
+            console.print(f"  [warning]{result.get('message', 'Resume failed')}[/warning]")
     console.print()
 
     try:
@@ -862,7 +884,14 @@ def _thin_interactive_loop() -> None:
                 continue
 
             if user_input.strip().lower() in ("exit", "quit", "q"):
-                console.print("  [muted]Goodbye.[/muted]\n")
+                # Relay /quit to serve for session cost summary
+                response = client.send_command("/quit", "")
+                output = response.get("output", "")
+                if output:
+                    import sys as _sys
+
+                    _sys.stdout.write(output)
+                    _sys.stdout.flush()
                 break
 
             # Slash commands
@@ -1039,7 +1068,10 @@ def main(
                 raise typer.Exit(1)
 
         console.print("  [muted]Connected to serve via IPC[/muted]")
-        _thin_interactive_loop()
+        _thin_interactive_loop(
+            resume_session=resume,
+            continue_latest=continue_session,
+        )
 
 
 @app.command()

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -329,6 +329,14 @@ def _apply_model(selected: ModelProfile) -> None:
 
     settings.model = selected.id
     _upsert_env("GEODE_MODEL", selected.id)
+
+    # Hot-swap the active AgenticLoop model (P0 fix: /model mid-session)
+    from core.cli.session_state import get_current_loop
+
+    loop = get_current_loop()
+    if loop is not None:
+        loop.update_model(selected.id)
+
     console.print(
         f"  [success]Model[/success]  {old} → [bold]{selected.label}[/bold]"
         f"  [muted]({selected.id})[/muted]"

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -199,6 +199,33 @@ class IPCClient:
                 continue
             return response
 
+    def request_resume(
+        self,
+        session_id: str = "",
+        *,
+        continue_latest: bool = False,
+    ) -> dict[str, Any]:
+        """Request session resume from serve.
+
+        Args:
+            session_id: Specific session ID to resume (--resume <id>).
+            continue_latest: Resume the most recent session (--continue).
+
+        Returns {"type": "resumed", ...} or {"type": "resume_error", ...}.
+        """
+        if not self._sock:
+            return {"type": "resume_error", "message": "Not connected"}
+        payload: dict[str, Any] = {"type": "resume"}
+        if continue_latest:
+            payload["continue"] = True
+        elif session_id:
+            payload["session_id"] = session_id
+        self._send(payload)
+        response = self._recv()
+        if response is None:
+            return {"type": "resume_error", "message": "Connection lost"}
+        return response
+
     def send_command(self, cmd: str, args: str = "") -> dict[str, Any]:
         """Send a slash command to serve and wait for result.
 

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -263,6 +263,9 @@ class CLIPoller:
         if msg_type == "command":
             return self._handle_command_on_server(msg, loop)
 
+        if msg_type == "resume":
+            return self._handle_resume(msg, loop, conversation)
+
         return {"type": "error", "message": f"Unknown message type: {msg_type}"}
 
     def _run_prompt_streaming(
@@ -383,6 +386,59 @@ class CLIPoller:
                 "status": "error",
                 "message": str(exc),
             }
+
+    def _handle_resume(
+        self,
+        msg: dict[str, Any],
+        loop: Any,
+        conversation: Any,
+    ) -> dict[str, Any]:
+        """Load a session checkpoint and restore conversation context."""
+        try:
+            from core.cli.session_checkpoint import SessionCheckpoint
+
+            cp = SessionCheckpoint()
+
+            state = None
+            if msg.get("continue"):
+                sessions = cp.list_resumable()
+                if sessions:
+                    state = sessions[0]
+            else:
+                sid = msg.get("session_id", "")
+                if sid:
+                    state = cp.load(sid)
+            if state is None:
+                return {"type": "resume_error", "message": "No resumable session found"}
+
+            # Restore conversation messages
+            conversation.messages.clear()
+            conversation.messages.extend(state.messages)
+
+            # Sync loop session_id for checkpoint continuity
+            loop._session_id = state.session_id
+
+            # Restore model if different
+            if state.model and state.model != loop.model:
+                loop.update_model(state.model)
+
+            log.info(
+                "Session resumed: %s (round=%d, messages=%d)",
+                state.session_id,
+                state.round_idx,
+                len(state.messages),
+            )
+            return {
+                "type": "resumed",
+                "session_id": state.session_id,
+                "round_idx": state.round_idx,
+                "model": state.model,
+                "user_input": state.user_input,
+                "message_count": len(state.messages),
+            }
+        except Exception as exc:
+            log.warning("Session resume failed", exc_info=True)
+            return {"type": "resume_error", "message": str(exc)}
 
     def _propagate_contextvars(self) -> None:
         """Set ContextVars needed by slash command handlers in this thread.

--- a/docs/plans/ipc-ux-fixes.md
+++ b/docs/plans/ipc-ux-fixes.md
@@ -1,0 +1,131 @@
+# Plan: IPC UX Fixes — /model hot-swap + session cost + checkpoint resume
+
+## Socratic Gate
+
+### P0: /model hot-swap
+
+| # | Question | Answer | Verdict |
+|---|----------|--------|---------|
+| Q1 | Already exists? | `update_model()` exists on AgenticLoop (L322-357). Wire-up missing. | Partial |
+| Q2 | What breaks without? | User changes model, thinks it switched, but all LLM calls use old model. Silent failure. | Critical |
+| Q3 | Measurable? | Test: call `_apply_model()`, assert `get_current_loop().model` changed. | Yes |
+| Q4 | Simplest? | Add 4 lines in `_apply_model()` to call loop.update_model(). | Minimal |
+| Q5 | Frontier pattern? | Claude Code /model switches immediately. Standard. | Yes |
+
+### P1: /quit session cost relay
+
+| # | Question | Answer | Verdict |
+|---|----------|--------|---------|
+| Q1 | Already exists? | Client handler `_handle_session_cost()` exists. Server never sends event. | Partial |
+| Q2 | What breaks without? | User never sees cost summary on thin client /quit. Can't track spending. | Visible |
+| Q3 | Measurable? | Test: /quit returns cost data. Verify event sent. | Yes |
+| Q4 | Simplest? | Move /quit from _LOCAL_COMMANDS to server relay. Server already renders cost. | Minimal |
+| Q5 | Frontier pattern? | Claude Code shows cost on exit. Standard. | Yes |
+
+### P2: --continue/--resume
+
+| # | Question | Answer | Verdict |
+|---|----------|--------|---------|
+| Q1 | Already exists? | Save works. Load works. CLI flags defined. All disconnected. | Partial |
+| Q2 | What breaks without? | User loses context on disconnect. Can't resume multi-step work. | Important |
+| Q3 | Measurable? | Test: save checkpoint → load → verify messages restored. | Yes |
+| Q4 | Simplest? | Wire CLI flags → IPC resume message → CLIPoller checkpoint load. | Moderate |
+| Q5 | Frontier pattern? | Claude Code --continue/--resume. Exact pattern. | Yes |
+
+All 3 pass.
+
+---
+
+## Implementation Plan
+
+### Fix 1: /model hot-swap (P0)
+
+**Root Cause**: `_apply_model()` updates `settings.model` + `.env` but never calls `loop.update_model()`.
+
+**Files Modified**:
+- `core/cli/commands.py` — `_apply_model()` (L293-336)
+
+**Change**:
+After line 331 (`_upsert_env(...)`), add:
+```python
+from core.cli.session_state import get_current_loop
+loop = get_current_loop()
+if loop is not None:
+    loop.update_model(selected.id)
+```
+
+**Why this is sufficient**:
+- `update_model()` already handles: model sync, provider resolution, adapter refresh, ToolCallProcessor sync, UI update, hook firing, context adaptation
+- `settings.model` is already updated (L330) — new sessions via reconnect will inherit
+- `.env` is already updated (L331) — serve restart will inherit
+
+### Fix 2: /quit session cost relay (P1)
+
+**Root Cause**: `/quit` is in `_LOCAL_COMMANDS` → runs locally on thin client → `get_usage_accumulator()` returns empty client-side accumulator (real data is on serve).
+
+**Files Modified**:
+- `core/cli/__init__.py` — `_LOCAL_COMMANDS` set + `_thin_interactive_loop()` exit paths
+
+**Change**:
+1. Remove `/quit` from `_LOCAL_COMMANDS` (L830)
+2. In the "bare exit/quit/q" path (L864-866): relay `/quit` to serve before breaking
+3. Add `should_break` handling in the server relay section
+
+**Flow after fix**:
+```
+User types /quit (or "quit")
+→ Thin client relays /quit to serve
+→ Server: _handle_command("/quit") → render_session_cost_summary() (real data) + "Goodbye"
+→ Server: capture_output() captures ANSI cost summary
+→ Thin client: receives command_result with output + should_break=true
+→ Thin client: prints output, breaks loop
+```
+
+### Fix 3: --continue/--resume (P2)
+
+**Root Cause**: CLI flags captured but unused. No resume path from thin client → serve.
+
+**Files Modified**:
+- `core/cli/__init__.py` — `main()` + `_thin_interactive_loop()` signature
+- `core/cli/ipc_client.py` — `IPCClient.connect()` + new `request_resume()` method
+- `core/gateway/pollers/cli_poller.py` — `_handle_client()` + `_process_message()` resume handler
+
+**Protocol Extension**:
+```json
+// Client → Server (after connect, as first message)
+{"type": "resume", "session_id": "s-xxxx"}        // --resume <id>
+{"type": "resume", "continue": true}               // --continue (latest)
+
+// Server → Client (response)
+{"type": "resumed", "session_id": "s-xxxx", "round_idx": 5, "model": "...", "user_input": "..."}
+{"type": "resume_error", "message": "Session not found"}
+```
+
+**Server-side resume logic** (CLIPoller._process_message):
+1. Load checkpoint via `SessionCheckpoint.load(session_id)` or `.list_resumable()[0]`
+2. Populate `conversation.messages` from checkpoint
+3. Respond with resumed session info
+4. Set AgenticLoop session_id to match checkpoint
+
+**AgenticLoop change**:
+- Add `session_id` parameter to `__init__()` (optional, overrides auto-generated)
+- When provided, skip generating new `s-{uuid}` and use the given ID
+- `create_session()` in SharedServices: pass `session_id` kwarg
+
+---
+
+## Test Plan
+
+| Fix | Test | Method |
+|-----|------|--------|
+| P0 | `/model` updates live loop.model | Unit: mock loop, call _apply_model, assert model changed |
+| P1 | `/quit` returns cost data via IPC | Unit: mock accumulator with data, verify output contains cost |
+| P2 | Resume loads checkpoint messages | Unit: save checkpoint, resume, verify messages in context |
+| P2 | --continue picks latest session | Unit: save 2 sessions, --continue loads most recent |
+| All | Full suite regression | `pytest tests/ -m "not live"` — 3422+ pass |
+
+## Execution Order
+
+```
+P0 (model hot-swap) → P1 (session cost) → P2 (resume) → Tests → Docs
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.37.1"
+version = "0.37.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -295,9 +295,8 @@ class TestApplyModel:
     def test_apply_model_no_loop_does_not_crash(self, tmp_path: Path, monkeypatch):
         """When no active loop, _apply_model should still work (no crash)."""
         monkeypatch.chdir(tmp_path)
-        from core.config import settings
-
         from core.cli import session_state
+        from core.config import settings
 
         session_state.set_current_loop(None)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -268,6 +268,46 @@ class TestApplyModel:
         # Should not write .env when model unchanged
         _apply_model(next(p for p in MODEL_PROFILES if p.id == settings.model))
 
+    def test_apply_model_hot_swaps_active_loop(self, tmp_path: Path, monkeypatch):
+        """P0 fix: _apply_model() should call loop.update_model() on the active loop."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.chdir(tmp_path)
+        from core.config import settings
+
+        mock_loop = MagicMock()
+        mock_loop.model = settings.model
+
+        from core.cli import session_state
+
+        monkeypatch.setattr(session_state, "_current_loop_ctx", session_state._current_loop_ctx)
+        session_state.set_current_loop(mock_loop)
+
+        old = settings.model
+        try:
+            target = MODEL_PROFILES[3]  # GPT-5.4
+            _apply_model(target)
+            mock_loop.update_model.assert_called_once_with(target.id)
+        finally:
+            settings.model = old
+            session_state.set_current_loop(None)
+
+    def test_apply_model_no_loop_does_not_crash(self, tmp_path: Path, monkeypatch):
+        """When no active loop, _apply_model should still work (no crash)."""
+        monkeypatch.chdir(tmp_path)
+        from core.config import settings
+
+        from core.cli import session_state
+
+        session_state.set_current_loop(None)
+
+        old = settings.model
+        try:
+            _apply_model(MODEL_PROFILES[3])
+            assert settings.model == OPENAI_PRIMARY
+        finally:
+            settings.model = old
+
 
 class TestCmdBatch:
     def test_batch_command_registered(self):

--- a/tests/test_phase3_ipc.py
+++ b/tests/test_phase3_ipc.py
@@ -41,6 +41,13 @@ def _test_sock() -> Path:
 class TestIPCClient:
     """Test the thin CLI IPC client."""
 
+    def test_request_resume_not_connected(self) -> None:
+        from core.cli.ipc_client import IPCClient
+
+        client = IPCClient()
+        result = client.request_resume(continue_latest=True)
+        assert result["type"] == "resume_error"
+
     def test_is_serve_running_no_socket(self, tmp_path: Path) -> None:
         from core.cli.ipc_client import is_serve_running
 
@@ -301,3 +308,152 @@ class TestCLIChannelIntegration:
             poller.stop()
 
         assert not is_serve_running(sock_path)
+
+    def test_quit_relayed_returns_should_break(self) -> None:
+        """P1 fix: /quit should relay to serve and return should_break=True."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        mock_loop = MagicMock()
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.send_command("/quit", "")
+            assert result["type"] == "command_result"
+            assert result.get("should_break") is True
+            # Output should contain "Goodbye" from _handle_command
+            assert "Goodbye" in result.get("output", "")
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_resume_with_checkpoint(self) -> None:
+        """P2 fix: resume message should load checkpoint into conversation."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop.model = "claude-opus-4-6"
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            # Save a checkpoint first
+            from core.cli.session_checkpoint import SessionCheckpoint, SessionState
+
+            cp = SessionCheckpoint()
+            state = SessionState(
+                session_id="s-test123",
+                round_idx=3,
+                model="claude-opus-4-6",
+                status="active",
+                messages=[
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi there"},
+                ],
+                user_input="hello",
+            )
+            cp.save(state)
+
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.request_resume(session_id="s-test123")
+            assert result["type"] == "resumed"
+            assert result["session_id"] == "s-test123"
+            assert result["round_idx"] == 3
+            assert result["message_count"] == 2
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_resume_continue_latest(self) -> None:
+        """P2 fix: --continue should resume the most recent session."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop.model = "claude-opus-4-6"
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            from core.cli.session_checkpoint import SessionCheckpoint, SessionState
+
+            cp = SessionCheckpoint()
+            cp.save(SessionState(
+                session_id="s-old",
+                round_idx=1,
+                model="claude-opus-4-6",
+                status="active",
+                messages=[{"role": "user", "content": "old"}],
+                user_input="old",
+            ))
+            time.sleep(0.01)  # ensure different updated_at
+            cp.save(SessionState(
+                session_id="s-latest",
+                round_idx=5,
+                model="claude-opus-4-6",
+                status="active",
+                messages=[{"role": "user", "content": "latest"}],
+                user_input="latest",
+            ))
+
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.request_resume(continue_latest=True)
+            assert result["type"] == "resumed"
+            assert result["session_id"] == "s-latest"
+            assert result["round_idx"] == 5
+
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_resume_no_sessions(self) -> None:
+        """Resume should return error when no sessions exist."""
+        from core.cli.ipc_client import IPCClient
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+        mock_loop = MagicMock()
+        mock_loop.model = "claude-opus-4-6"
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            client.connect()
+
+            result = client.request_resume(session_id="s-nonexistent")
+            assert result["type"] == "resume_error"
+
+            client.close()
+        finally:
+            poller.stop()

--- a/tests/test_phase3_ipc.py
+++ b/tests/test_phase3_ipc.py
@@ -402,23 +402,27 @@ class TestCLIChannelIntegration:
             from core.cli.session_checkpoint import SessionCheckpoint, SessionState
 
             cp = SessionCheckpoint()
-            cp.save(SessionState(
-                session_id="s-old",
-                round_idx=1,
-                model="claude-opus-4-6",
-                status="active",
-                messages=[{"role": "user", "content": "old"}],
-                user_input="old",
-            ))
+            cp.save(
+                SessionState(
+                    session_id="s-old",
+                    round_idx=1,
+                    model="claude-opus-4-6",
+                    status="active",
+                    messages=[{"role": "user", "content": "old"}],
+                    user_input="old",
+                )
+            )
             time.sleep(0.01)  # ensure different updated_at
-            cp.save(SessionState(
-                session_id="s-latest",
-                round_idx=5,
-                model="claude-opus-4-6",
-                status="active",
-                messages=[{"role": "user", "content": "latest"}],
-                user_input="latest",
-            ))
+            cp.save(
+                SessionState(
+                    session_id="s-latest",
+                    round_idx=5,
+                    model="claude-opus-4-6",
+                    status="active",
+                    messages=[{"role": "user", "content": "latest"}],
+                    user_input="latest",
+                )
+            )
 
             client = IPCClient(socket_path=sock_path)
             client.connect()


### PR DESCRIPTION
## Summary

- **Structured IPC events** (#551) — 12 typed event protocol with client-side direct rendering (EventRenderer)
- **Per-tool spinner** — braille spinner with ANSI cursor-up in-place checkmark updates
- **IPC UX fixes** (#553) — /model hot-swap, /quit session cost relay, --continue/--resume wiring

## Why

Accumulating 5 commits on develop since last main sync. IPC subsystem stabilized with structured events and 3 UX bug fixes.

## Test plan

- [x] CI 5/5 on #553
- [x] 3429 tests pass (was 3422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)