### PR TITLE
fix: thinking spinner animation + server-side tool duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.37.2] — 2026-03-30
 
 ### Fixed
+- **Thinking spinner frozen** — `EventRenderer` thinking spinner was rendering 1 frame then freezing until next event. Now uses daemon thread animation (80ms per frame), matching `ToolCallTracker` pattern.
+- **Tool duration inaccurate** — `tool_end` event now includes server-measured `duration_s`. Client prefers server duration over client-side measurement (excludes IPC transport latency).
 - **`/model` hot-swap (P0)** — `_apply_model()` now calls `loop.update_model()` on the active AgenticLoop. Model changes take effect immediately in the current IPC session without reconnecting.
 - **`/quit` session cost (P1)** — `/quit` and `/exit` now relay to serve instead of running locally. Session cost summary renders with real accumulator data from the serve process.
 

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -137,6 +137,8 @@ class OperationLogger:
         self._tool_type_last_summary: dict[str, str] = {}
         self._total_tool_count = 0
         self._round_count = 0
+        # Per-tool start time for accurate server-side duration
+        self._tool_start_times: dict[str, float] = {}
 
     def begin_round(self, label: str = "AgenticLoop") -> None:
         """Start a new agentic round — print header if not yet shown."""
@@ -172,6 +174,9 @@ class OperationLogger:
             else:
                 args_parts.append(f"{k}={v}")
         args_str = ", ".join(args_parts)
+
+        # Track start time for server-side duration measurement
+        self._tool_start_times[tool_name] = time.monotonic()
 
         # IPC mode: send structured event (client renders spinner + ✓)
         writer = getattr(_ipc_writer_local, "writer", None)
@@ -210,14 +215,17 @@ class OperationLogger:
 
         is_error = bool(result.get("error"))
 
-        # IPC mode: send structured event
+        # IPC mode: send structured event with server-measured duration
         writer = getattr(_ipc_writer_local, "writer", None)
         if writer is not None:
+            start = self._tool_start_times.pop(tool_name, 0.0)
+            duration_s = round(time.monotonic() - start, 1) if start else 0.0
             writer.send_event(
                 "tool_end",
                 name=tool_name,
                 summary=summary[:80],
                 error=result.get("error", "") if is_error else "",
+                duration_s=duration_s,
             )
             return
 

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -10,6 +10,7 @@ Replaces raw console stream for agentic UI — client owns all rendering.
 from __future__ import annotations
 
 import sys
+import threading
 import time
 from typing import Any
 
@@ -28,7 +29,7 @@ class EventRenderer:
     def __init__(self) -> None:
         self._tool_tracker = ToolCallTracker()
         self._thinking = False
-        self._spinner_frame_idx = 0
+        self._thinking_thread: threading.Thread | None = None
         self._thinking_model = ""
         self._thinking_round = 0
         self._round_header_printed = False
@@ -66,7 +67,8 @@ class EventRenderer:
         self._thinking = True
         self._thinking_model = str(event.get("model", ""))
         self._thinking_round = int(event.get("round", 1))
-        self._render_thinking_frame()
+        self._thinking_thread = threading.Thread(target=self._animate_thinking, daemon=True)
+        self._thinking_thread.start()
 
     def _handle_thinking_end(self, _event: dict[str, Any]) -> None:
         self._stop_thinking()
@@ -284,6 +286,12 @@ class EventRenderer:
 
     _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
+    def _animate_thinking(self) -> None:
+        """Background animation loop for thinking spinner (80ms per frame)."""
+        while self._thinking:
+            self._render_thinking_frame()
+            time.sleep(0.08)
+
     def _render_thinking_frame(self) -> None:
         if not self._thinking:
             return
@@ -296,5 +304,8 @@ class EventRenderer:
     def _stop_thinking(self) -> None:
         if self._thinking:
             self._thinking = False
+            if self._thinking_thread:
+                self._thinking_thread.join(timeout=0.3)
+                self._thinking_thread = None
             self._out.write("\r\033[2K")
             self._out.flush()

--- a/core/cli/ui/tool_tracker.py
+++ b/core/cli/ui/tool_tracker.py
@@ -74,7 +74,12 @@ class ToolCallTracker:
                     t["done"] = True
                     t["summary"] = str(event.get("summary", "ok"))
                     t["error"] = str(event.get("error", ""))
-                    t["duration"] = time.monotonic() - float(t["start_time"])
+                    # Prefer server-measured duration (excludes IPC latency)
+                    server_dur = event.get("duration_s")
+                    if server_dur is not None and float(server_dur) > 0:
+                        t["duration"] = float(server_dur)
+                    else:
+                        t["duration"] = time.monotonic() - float(t["start_time"])
                     break
             self._redraw()
             if all(t["done"] for t in self._tools):

--- a/core/cli/ui/tool_tracker.py
+++ b/core/cli/ui/tool_tracker.py
@@ -76,8 +76,8 @@ class ToolCallTracker:
                     t["error"] = str(event.get("error", ""))
                     # Prefer server-measured duration (excludes IPC latency)
                     server_dur = event.get("duration_s")
-                    if server_dur is not None and float(server_dur) > 0:
-                        t["duration"] = float(server_dur)
+                    if server_dur is not None and float(str(server_dur)) > 0:
+                        t["duration"] = float(str(server_dur))
                     else:
                         t["duration"] = time.monotonic() - float(t["start_time"])
                     break


### PR DESCRIPTION
## Summary

- **Thinking spinner frozen** — `EventRenderer._render_thinking_frame()` was called once on `thinking_start`, then frame froze until next event. Added `_animate_thinking()` daemon thread (80ms loop), same pattern as `ToolCallTracker._animate()`.
- **Tool duration inaccurate** — `tool_end` now includes server-measured `duration_s` from `OperationLogger`. Client `ToolCallTracker` prefers server duration over client-measured time, excluding IPC transport latency.

## Why

User reported `⠼ ✢ Thinking... (round 3)` freezing on one frame for 10-60s during LLM response wait. Tool timing showed IPC latency instead of actual execution time.

## Changes

| File | Change |
|------|--------|
| `core/cli/ui/event_renderer.py` | +`_animate_thinking()` daemon thread, `_stop_thinking()` joins thread |
| `core/cli/ui/agentic_ui.py` | `OperationLogger._tool_start_times` dict, `tool_end` event includes `duration_s` |
| `core/cli/ui/tool_tracker.py` | Prefer `event.duration_s` over client `time.monotonic()` delta |

## Test plan

- [x] `uv run ruff check + format` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3461 passed
- [ ] CI 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)