### PR TITLE
feat: persistent activity spinner + pipeline client-side rendering

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-30T15:36:07+09:00 task_id=structured-events
+session=2026-03-30T18:57:12+09:00 task_id=persistent-spinner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.37.2] — 2026-03-30
 
+### Added
+- **Persistent activity spinner** — thin client shows animated `Working...` spinner from prompt send until result arrives. Thinking/tool spinners override it; resumes between events.
+- **Pipeline client-side rendering** — `panels.py` detects IPC mode → emits structured event + returns early (no duplicate raw ANSI stream). Thin client renders all pipeline milestones from structured events.
+- **`pipeline_header` / `pipeline_result` events** — 2 new event types (28 → 30 total).
+
 ### Fixed
 - **Thinking spinner frozen** — `EventRenderer` thinking spinner was rendering 1 frame then freezing until next event. Now uses daemon thread animation (80ms per frame), matching `ToolCallTracker` pattern.
 - **Tool duration inaccurate** — `tool_end` event now includes server-measured `duration_s`. Client prefers server duration over client-side measurement (excludes IPC transport latency).

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -972,6 +972,7 @@ def _thin_interactive_loop(
                 _stream_started = True
                 _rr.on_event(event)
 
+            _renderer.start_activity()  # persistent spinner until result
             response = client.send_prompt(
                 user_input,
                 on_stream=_on_stream,

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -204,11 +204,13 @@ class IPCClient:
                 "model_switched",
                 "checkpoint_saved",
                 # Pipeline milestone events
+                "pipeline_header",
                 "pipeline_gather",
                 "pipeline_analysis",
                 "pipeline_evaluation",
                 "pipeline_score",
                 "pipeline_verification",
+                "pipeline_result",
                 "feedback_loop",
                 "node_skipped",
             ):

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -1,10 +1,12 @@
 """Client-side event renderer — direct terminal rendering for all IPC events.
 
 Handles structured events from serve (tool_start/end, tokens, thinking,
-round_start, context_event, subagent, turn_end) and renders them with
-spinners, in-place ✓ updates, and ANSI styling.
+round_start, context_event, subagent, turn_end, pipeline milestones)
+and renders them with spinners, in-place updates, and ANSI styling.
 
-Replaces raw console stream for agentic UI — client owns all rendering.
+Persistent activity spinner runs from prompt send until result arrives.
+Thinking/tool spinners override it; it resumes between events.
+Pipeline panels render client-side from structured events (no raw stream).
 """
 
 from __future__ import annotations
@@ -24,7 +26,19 @@ def _fmt_tokens(n: int) -> str:
 
 
 class EventRenderer:
-    """Dispatches IPC events to appropriate rendering handlers."""
+    """Dispatches IPC events to appropriate rendering handlers.
+
+    Lifecycle::
+
+        renderer = EventRenderer()
+        renderer.start_activity()            # persistent spinner ON
+        result = client.send_prompt(
+            text,
+            on_stream=renderer.on_stream,
+            on_event=renderer.on_event,      # events override spinner
+        )
+        renderer.stop()                      # everything OFF
+    """
 
     def __init__(self) -> None:
         self._tool_tracker = ToolCallTracker()
@@ -34,6 +48,19 @@ class EventRenderer:
         self._thinking_round = 0
         self._round_header_printed = False
         self._out = sys.stdout
+        # Persistent activity spinner state
+        self._activity = False
+        self._activity_suppressed = False
+        self._activity_thread: threading.Thread | None = None
+
+    # -- Public API -----------------------------------------------------------
+
+    def start_activity(self) -> None:
+        """Start persistent activity spinner. Call before send_prompt()."""
+        self._activity = True
+        self._activity_suppressed = False
+        self._activity_thread = threading.Thread(target=self._animate_activity, daemon=True)
+        self._activity_thread.start()
 
     def on_event(self, event: dict[str, Any]) -> None:
         """Handle a structured event from serve."""
@@ -44,25 +71,34 @@ class EventRenderer:
 
     def on_stream(self, data: str) -> None:
         """Handle raw console stream (Rich panels, pipeline output)."""
-        self._stop_thinking()
-        self._tool_tracker.stop()
+        self._suppress_all_spinners()
         self._out.write(data)
         self._out.flush()
 
     def stop(self) -> None:
-        """Flush all pending state."""
+        """Stop all spinners. Call when result arrives."""
+        self._activity = False
+        self._activity_suppressed = True
         self._stop_thinking()
         self._tool_tracker.stop()
+        if self._activity_thread:
+            self._activity_thread.join(timeout=0.3)
+            self._activity_thread = None
+        # Clear any leftover spinner line
+        self._out.write("\r\033[2K")
+        self._out.flush()
 
-    # -- Event handlers -------------------------------------------------------
+    # -- Core event handlers --------------------------------------------------
 
     def _handle_round_start(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         if not self._round_header_printed:
             self._round_header_printed = True
-            self._out.write("\n\033[1m● AgenticLoop\033[0m\n")
+            self._out.write("\n\033[1m\u25cf AgenticLoop\033[0m\n")
             self._out.flush()
 
     def _handle_thinking_start(self, event: dict[str, Any]) -> None:
+        self._activity_suppressed = True
         self._tool_tracker.stop()
         self._thinking = True
         self._thinking_model = str(event.get("model", ""))
@@ -72,26 +108,34 @@ class EventRenderer:
 
     def _handle_thinking_end(self, _event: dict[str, Any]) -> None:
         self._stop_thinking()
+        self._activity_suppressed = False  # resume activity spinner
 
     def _handle_tool_start(self, event: dict[str, Any]) -> None:
+        self._activity_suppressed = True
         self._stop_thinking()
         self._tool_tracker.on_tool_start(event)
 
     def _handle_tool_end(self, event: dict[str, Any]) -> None:
         self._tool_tracker.on_tool_end(event)
+        # Resume activity when all tools done
+        with self._tool_tracker._lock:
+            if all(t["done"] for t in self._tool_tracker._tools):
+                self._activity_suppressed = False
 
     def _handle_tokens(self, event: dict[str, Any]) -> None:
-        self._stop_thinking()
-        self._tool_tracker.stop()
+        self._suppress_all_spinners()
         model = str(event.get("model", ""))
         in_tok = int(event.get("input", 0))
         out_tok = int(event.get("output", 0))
         cost = float(event.get("cost", 0))
         in_str = _fmt_tokens(in_tok)
         out_str = _fmt_tokens(out_tok)
-        cost_str = f" · ${cost:.4f}" if cost > 0 else ""
-        self._out.write(f"  \033[2m✢ {model} · ↓{in_str} ↑{out_str}{cost_str}\033[0m\n")
+        cost_str = f" \u00b7 ${cost:.4f}" if cost > 0 else ""
+        self._out.write(
+            f"  \033[2m\u2722 {model} \u00b7 \u2193{in_str} \u2191{out_str}{cost_str}\033[0m\n"
+        )
         self._out.flush()
+        self._activity_suppressed = False  # resume after tokens line
 
     def _handle_turn_end(self, event: dict[str, Any]) -> None:
         rounds = int(event.get("rounds", 0))
@@ -103,24 +147,29 @@ class EventRenderer:
         parts = [f"{rounds} rounds", f"{tools} tools", f"{elapsed:.1f}s"]
         if cost > 0:
             parts.append(f"${cost:.3f}")
-        summary = " · ".join(parts)
-        self._out.write(f"\n  \033[2m──── {summary} ────\033[0m\n")
+        summary = " \u00b7 ".join(parts)
+        line = f"\u2500\u2500\u2500\u2500 {summary} \u2500\u2500\u2500\u2500"
+        self._out.write(f"\n  \033[2m{line}\033[0m\n")
         self._out.flush()
 
     def _handle_context_event(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         action = str(event.get("action", ""))
         before = int(event.get("before", 0))
         after = int(event.get("after", 0))
         if action == "exhausted":
-            self._out.write("  \033[1;33m⟳ Context exhausted\033[0m\n")
+            self._out.write("  \033[1;33m\u27f3 Context exhausted\033[0m\n")
         else:
             label = "compacted" if action == "compact" else "pruned"
-            self._out.write(f"  \033[2m⟳ Context {label}: {before} → {after} messages\033[0m\n")
+            self._out.write(
+                f"  \033[2m\u27f3 Context {label}: {before} \u2192 {after} messages\033[0m\n"
+            )
         self._out.flush()
 
     def _handle_subagent_dispatch(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         desc = str(event.get("description", ""))
-        self._out.write(f'  \033[34;1m▸ delegate_task\033[0m("{desc}")\n')
+        self._out.write(f'  \033[34;1m\u25b8 delegate_task\033[0m("{desc}")\n')
         self._out.flush()
 
     def _handle_subagent_progress(self, event: dict[str, Any]) -> None:
@@ -128,15 +177,14 @@ class EventRenderer:
         total = int(event.get("total", 0))
         name = str(event.get("name", ""))
         dur = float(event.get("duration_s", 0))
-        self._out.write(
-            f"  \033[2m⎿\033[0m \033[32m✓\033[0m {name} ({dur:.1f}s)  [{completed}/{total}]\n"
-        )
+        mark = "\033[2m\u23bf\033[0m \033[32m\u2713\033[0m"
+        self._out.write(f"  {mark} {name} ({dur:.1f}s)  [{completed}/{total}]\n")
         self._out.flush()
 
     def _handle_subagent_complete(self, event: dict[str, Any]) -> None:
         count = int(event.get("count", 0))
         elapsed = float(event.get("elapsed_s", 0))
-        self._out.write(f"  \033[32m✓ {count} sub-agents completed\033[0m ({elapsed:.1f}s)\n")
+        self._out.write(f"  \033[32m\u2713 {count} sub-agents completed\033[0m ({elapsed:.1f}s)\n")
         self._out.flush()
 
     def _handle_session_cost(self, event: dict[str, Any]) -> None:
@@ -148,7 +196,9 @@ class EventRenderer:
             return
         self._out.write("\n  \033[1mSession Cost Summary\033[0m\n")
         self._out.write(f"  \033[2mCalls:\033[0m {calls}\n")
-        self._out.write(f"  \033[2mTokens:\033[0m ↓{_fmt_tokens(in_tok)} ↑{_fmt_tokens(out_tok)}\n")
+        self._out.write(
+            f"  \033[2mTokens:\033[0m \u2193{_fmt_tokens(in_tok)} \u2191{_fmt_tokens(out_tok)}\n"
+        )
         self._out.write(f"  \033[1;33mTotal: ${cost:.4f}\033[0m\n")
         breakdown = event.get("breakdown", {})
         if isinstance(breakdown, dict) and len(breakdown) > 1:
@@ -160,15 +210,17 @@ class EventRenderer:
     # -- AgenticLoop state change events --------------------------------------
 
     def _handle_model_escalation(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         frm = str(event.get("from_model", ""))
         to = str(event.get("to_model", ""))
         n = int(event.get("failures", 0))
         self._out.write(
-            f"  \033[1;33m⚡ Model escalated: {frm} → {to} (after {n} failures)\033[0m\n"
+            f"  \033[1;33m\u26a1 Model escalated: {frm} \u2192 {to} (after {n} failures)\033[0m\n"
         )
         self._out.flush()
 
     def _handle_cost_budget_exceeded(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         budget = float(event.get("budget", 0))
         actual = float(event.get("actual", 0))
         self._out.write(
@@ -177,117 +229,206 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_time_budget_expired(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         budget = float(event.get("budget_s", 0))
         elapsed = float(event.get("elapsed_s", 0))
         rounds = int(event.get("rounds", 0))
         self._out.write(
-            f"  \033[1;33m⏱ Time expired: {elapsed:.0f}s / {budget:.0f}s ({rounds} rounds)\033[0m\n"
+            f"  \033[1;33m\u23f1 Time expired: {elapsed:.0f}s / {budget:.0f}s"
+            f" ({rounds} rounds)\033[0m\n"
         )
         self._out.flush()
 
     def _handle_convergence_detected(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         rounds = int(event.get("rounds", 0))
         self._out.write(
-            f"  \033[1;31m⟳ Convergence: repeating failure after {rounds} rounds\033[0m\n"
+            f"  \033[1;31m\u27f3 Convergence: repeating failure after {rounds} rounds\033[0m\n"
         )
         self._out.flush()
 
     def _handle_goal_decomposition(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         steps = event.get("steps", [])
-        self._out.write(f"  \033[2m● Goal decomposed into {len(steps)} steps\033[0m\n")
+        self._out.write(f"  \033[2m\u25cf Goal decomposed into {len(steps)} steps\033[0m\n")
         for i, s in enumerate(steps[:5], 1):
             self._out.write(f"    \033[2m{i}. {s}\033[0m\n")
         self._out.flush()
 
     def _handle_tool_backpressure(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         n = int(event.get("consecutive_errors", 0))
-        self._out.write(f"  \033[1;33m⏸ Backpressure: {n} consecutive tool errors\033[0m\n")
+        self._out.write(f"  \033[1;33m\u23f8 Backpressure: {n} consecutive tool errors\033[0m\n")
         self._out.flush()
 
     def _handle_tool_diversity_forced(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         tool = str(event.get("tool", ""))
         count = int(event.get("count", 0))
         self._out.write(
-            f"  \033[1;33m⟳ Diversity: {tool} called {count}x — forcing alternative\033[0m\n"
+            f"  \033[1;33m\u27f3 Diversity: {tool} called {count}x"
+            " \u2014 forcing alternative\033[0m\n"
         )
         self._out.flush()
 
     def _handle_model_switched(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         frm = str(event.get("from_model", ""))
         to = str(event.get("to_model", ""))
-        self._out.write(f"  \033[2m⇄ Model: {frm} → {to}\033[0m\n")
+        self._out.write(f"  \033[2m\u21c4 Model: {frm} \u2192 {to}\033[0m\n")
         self._out.flush()
 
     def _handle_checkpoint_saved(self, event: dict[str, Any]) -> None:
         pass  # silent — no user-visible output needed
 
-    # -- Pipeline milestone events --------------------------------------------
+    # -- Pipeline milestone events (client-side rendering) --------------------
+
+    def _handle_pipeline_header(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
+        ip = str(event.get("ip_name", ""))
+        mode = str(event.get("pipeline_mode", ""))
+        model = str(event.get("model", ""))
+        ver = str(event.get("version", ""))
+        self._out.write(f"\n  \033[1;36mGEODE v{ver}\033[0m\n")
+        self._out.write(f"  Analyzing: \033[1m{ip}\033[0m\n")
+        self._out.write(f"  Pipeline: {mode} | Model: {model}\n\n")
+        self._out.flush()
 
     def _handle_pipeline_gather(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         name = str(event.get("ip_name", ""))
         year = event.get("release_year", "")
+        media = str(event.get("media_type", ""))
+        studio = str(event.get("studio", ""))
         dau = int(event.get("dau", 0))
         rev = int(event.get("revenue", 0))
-        self._out.write(f"  \033[36m▸ GATHER\033[0m {name} ({year}) — DAU={dau:,} Rev=${rev:,}\n")
+        self._out.write(f"  \033[36;1m\u25b8 GATHER\033[0m {name}")
+        if media or year:
+            self._out.write(f" ({media}, {year})")
+        if studio:
+            self._out.write(f" \u2014 {studio}")
+        self._out.write("\n")
+        if dau or rev:
+            dau_s = f"{dau:,}" if dau else "n/a"
+            rev_s = f"${rev:,}" if rev else "n/a"
+            self._out.write(f"    \033[2mDAU={dau_s} | Revenue={rev_s}\033[0m\n")
         self._out.flush()
 
     def _handle_pipeline_analysis(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         analysts = event.get("analysts", [])
-        self._out.write(f"  \033[36m▸ ANALYZE\033[0m {len(analysts)} analysts\n")
+        self._out.write(f"  \033[36;1m\u25b8 ANALYZE\033[0m {len(analysts)} analysts\n")
         for a in analysts:
             name = str(a.get("analyst", ""))
             score = float(a.get("score", 0))
-            finding = str(a.get("finding", ""))[:40]
-            self._out.write(f"    {name}: {score:.1f} — {finding}\n")
+            finding = str(a.get("finding", ""))[:50]
+            color = "32" if score >= 4.0 else "33" if score >= 3.0 else "31"
+            self._out.write(
+                f"    {name:<18} \033[{color}m{score:.1f}\033[0m  {finding}\n"
+            )
         self._out.flush()
 
     def _handle_pipeline_evaluation(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         evals = event.get("evaluators", {})
-        self._out.write(f"  \033[36m▸ EVALUATE\033[0m {len(evals)} evaluators\n")
+        self._out.write(f"  \033[36;1m\u25b8 EVALUATE\033[0m {len(evals)} evaluators\n")
         if isinstance(evals, dict):
-            for key, val in evals.items():
+            labels = {
+                "quality_judge": "Quality",
+                "hidden_value": "Hidden",
+                "community_momentum": "Momentum",
+            }
+            for key, val in sorted(evals.items()):
+                label = labels.get(key, key.replace("_", " ").title())
                 score = float(val.get("score", 0)) if isinstance(val, dict) else 0
-                self._out.write(f"    {key}: {score:.0f}/100\n")
+                rationale = str(val.get("rationale", ""))[:50] if isinstance(val, dict) else ""
+                color = "32" if score >= 80 else "33" if score >= 60 else "31"
+                self._out.write(
+                    f"    {label:<18} \033[{color}m{score:.0f}/100\033[0m  {rationale}\n"
+                )
         self._out.flush()
 
     def _handle_pipeline_score(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         score = float(event.get("final_score", 0))
         tier = str(event.get("tier", "?"))
         conf = float(event.get("confidence", 0))
-        self._out.write(f"  \033[36m▸ SCORE\033[0m {tier} ({score:.1f})")
+        subscores = event.get("subscores", {})
+        # Tier color
+        tier_color = {"S": "1;35", "A": "1;32", "B": "1;33", "C": "1;31"}.get(tier, "1")
+        self._out.write(
+            f"  \033[36;1m\u25b8 SCORE\033[0m "
+            f"\033[{tier_color}m{tier}\033[0m ({score:.1f}/100)"
+        )
         if conf > 0:
-            self._out.write(f" · confidence {conf:.1f}%")
+            self._out.write(f" \u00b7 confidence {conf:.1f}%")
         self._out.write("\n")
+        # Subscores
+        if isinstance(subscores, dict) and subscores:
+            parts = [f"{k}={v:.1f}" for k, v in subscores.items()]
+            self._out.write(f"    \033[2m{' | '.join(parts)}\033[0m\n")
         self._out.flush()
 
     def _handle_pipeline_verification(self, event: dict[str, Any]) -> None:
-        g = "✓" if event.get("guardrails_pass") else "✗"
-        b = "✓" if event.get("biasbuster_pass") else "✗"
-        self._out.write(f"  \033[36m▸ VERIFY\033[0m Guardrails {g} | BiasBuster {b}\n")
+        self._clear_activity_line()
+        g = "\033[32m\u2713\033[0m" if event.get("guardrails_pass") else "\033[31m\u2717\033[0m"
+        b = "\033[32m\u2713\033[0m" if event.get("biasbuster_pass") else "\033[31m\u2717\033[0m"
+        self._out.write(f"  \033[36;1m\u25b8 VERIFY\033[0m Guardrails {g} | BiasBuster {b}\n")
         self._out.flush()
 
     def _handle_feedback_loop(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         iteration = int(event.get("iteration", 0))
         conf = float(event.get("confidence", 0))
         threshold = float(event.get("threshold", 0))
         self._out.write(
-            f"  \033[2m⟳ Feedback loop #{iteration}:"
+            f"  \033[2m\u27f3 Feedback loop #{iteration}:"
             f" confidence {conf:.1f}% < {threshold:.1f}%\033[0m\n"
         )
         self._out.flush()
 
     def _handle_node_skipped(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
         node = str(event.get("node", ""))
         reason = str(event.get("reason", ""))
-        self._out.write(f"  \033[2m⤳ Skipped: {node} ({reason})\033[0m\n")
+        self._out.write(f"  \033[2m\u2933 Skipped: {node} ({reason})\033[0m\n")
+        self._out.flush()
+
+    def _handle_pipeline_result(self, event: dict[str, Any]) -> None:
+        self._clear_activity_line()
+        tier = str(event.get("tier", "?"))
+        score = float(event.get("final_score", 0))
+        cause = str(event.get("cause", ""))
+        narrative = str(event.get("narrative", ""))
+        segment = str(event.get("target_segment", ""))
+        action = str(event.get("action", "")).replace("_", " ").title()
+        tier_color = {"S": "1;35", "A": "1;32", "B": "1;33", "C": "1;31"}.get(tier, "1")
+        self._out.write("\n  \033[36;1m\u25b8 RESULT\033[0m\n")
+        self._out.write(f"    \033[{tier_color}m{tier}\033[0m  {score:.1f} pts  |  {cause}\n")
+        if narrative:
+            self._out.write(f"    {narrative}\n")
+        if segment:
+            self._out.write(f"    \033[2mTarget:\033[0m {segment}\n")
+        if action:
+            self._out.write(f"    \033[2mAction:\033[0m {action}\n")
+        self._out.write("\n")
         self._out.flush()
 
     # -- Internal helpers -----------------------------------------------------
 
-    _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    _FRAMES = "\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f"
+
+    def _animate_activity(self) -> None:
+        """Persistent activity spinner — runs until stop() is called."""
+        while self._activity:
+            if not self._activity_suppressed:
+                frame = self._FRAMES[int(time.monotonic() * 12) % len(self._FRAMES)]
+                self._out.write(f"\r\033[2K  {frame} \033[2mWorking...\033[0m")
+                self._out.flush()
+            time.sleep(0.08)
 
     def _animate_thinking(self) -> None:
-        """Background animation loop for thinking spinner (80ms per frame)."""
+        """Thinking spinner — overrides activity spinner."""
         while self._thinking:
             self._render_thinking_frame()
             time.sleep(0.08)
@@ -298,7 +439,7 @@ class EventRenderer:
         frame = self._FRAMES[int(time.monotonic() * 12) % len(self._FRAMES)]
         r = self._thinking_round
         label = "Thinking..." if r <= 1 else f"Thinking... (round {r})"
-        self._out.write(f"\r\033[2K  {frame} \033[2m✢ {label}\033[0m")
+        self._out.write(f"\r\033[2K  {frame} \033[2m\u2722 {label}\033[0m")
         self._out.flush()
 
     def _stop_thinking(self) -> None:
@@ -307,5 +448,19 @@ class EventRenderer:
             if self._thinking_thread:
                 self._thinking_thread.join(timeout=0.3)
                 self._thinking_thread = None
+            self._out.write("\r\033[2K")
+            self._out.flush()
+
+    def _suppress_all_spinners(self) -> None:
+        """Stop thinking + tool spinners, clear line for new content."""
+        self._activity_suppressed = True
+        self._stop_thinking()
+        self._tool_tracker.stop()
+        self._out.write("\r\033[2K")
+        self._out.flush()
+
+    def _clear_activity_line(self) -> None:
+        """Clear the activity spinner line before writing a permanent line."""
+        if self._activity and not self._activity_suppressed:
             self._out.write("\r\033[2K")
             self._out.flush()

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -323,9 +323,7 @@ class EventRenderer:
             score = float(a.get("score", 0))
             finding = str(a.get("finding", ""))[:50]
             color = "32" if score >= 4.0 else "33" if score >= 3.0 else "31"
-            self._out.write(
-                f"    {name:<18} \033[{color}m{score:.1f}\033[0m  {finding}\n"
-            )
+            self._out.write(f"    {name:<18} \033[{color}m{score:.1f}\033[0m  {finding}\n")
         self._out.flush()
 
     def _handle_pipeline_evaluation(self, event: dict[str, Any]) -> None:
@@ -357,8 +355,7 @@ class EventRenderer:
         # Tier color
         tier_color = {"S": "1;35", "A": "1;32", "B": "1;33", "C": "1;31"}.get(tier, "1")
         self._out.write(
-            f"  \033[36;1m\u25b8 SCORE\033[0m "
-            f"\033[{tier_color}m{tier}\033[0m ({score:.1f}/100)"
+            f"  \033[36;1m\u25b8 SCORE\033[0m \033[{tier_color}m{tier}\033[0m ({score:.1f}/100)"
         )
         if conf > 0:
             self._out.write(f" \u00b7 confidence {conf:.1f}%")

--- a/core/cli/ui/panels.py
+++ b/core/cli/ui/panels.py
@@ -1,4 +1,9 @@
-"""Rich panel rendering for each pipeline step."""
+"""Rich panel rendering for each pipeline step.
+
+In IPC mode (thin client), structured events are emitted and panel
+functions return early — the client renders from events, not raw ANSI.
+In local mode, Rich panels render to console as before.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +19,27 @@ from core.cli.ui.console import console
 from core.state import AnalysisResult, EvaluatorResult, PSMResult, SynthesisResult
 
 
+def _is_ipc() -> bool:
+    """Check if we're in IPC mode (thin client rendering)."""
+    from core.cli.ui.agentic_ui import _ipc_writer_local
+
+    return getattr(_ipc_writer_local, "writer", None) is not None
+
+
 def header_panel(ip_name: str, pipeline_mode: str, model: str) -> None:
+    if _is_ipc():
+        from core.cli.ui.agentic_ui import _ipc_writer_local
+
+        writer = getattr(_ipc_writer_local, "writer", None)
+        if writer is not None:
+            writer.send_event(
+                "pipeline_header",
+                ip_name=ip_name,
+                pipeline_mode=pipeline_mode,
+                model=model,
+                version=__version__,
+            )
+        return
     content = Text()
     content.append("  Analyzing: ", style="label")
     content.append(f"{ip_name}\n", style="value")
@@ -39,8 +64,11 @@ def gather_panel(
 ) -> None:
     from core.cli.ui.agentic_ui import emit_pipeline_gather
 
-    emit_pipeline_gather(ip_info, monolake)
-    console.print("[step]▸ [GATHER][/step] Loading IP data from MonoLake...")
+    if _is_ipc():
+        emit_pipeline_gather(ip_info, monolake)
+        return
+
+    console.print("[step]\u25b8 [GATHER][/step] Loading IP data from MonoLake...")
     tree = Tree("", guide_style="dim")
     tree.add(
         f"[label]IP:[/label] {ip_info['ip_name']} "
@@ -66,8 +94,11 @@ def gather_panel(
 def analyst_panel(analyses: list[AnalysisResult]) -> None:
     from core.cli.ui.agentic_ui import emit_pipeline_analysis
 
-    emit_pipeline_analysis(analyses)  # type: ignore[arg-type]
-    console.print("[step]▸ [ANALYZE][/step] Running 4 Analysts (Clean Context)...")
+    if _is_ipc():
+        emit_pipeline_analysis(analyses)  # type: ignore[arg-type]
+        return
+
+    console.print("[step]\u25b8 [ANALYZE][/step] Running 4 Analysts (Clean Context)...")
     table = Table(show_header=True, header_style="bold", border_style="dim")
     table.add_column("Analyst", style="label", width=14)
     table.add_column("Score", justify="center", width=7)
@@ -87,8 +118,11 @@ def analyst_panel(analyses: list[AnalysisResult]) -> None:
 def evaluator_panel(evaluations: dict[str, EvaluatorResult]) -> None:
     from core.cli.ui.agentic_ui import emit_pipeline_evaluation
 
-    emit_pipeline_evaluation(evaluations)
-    console.print("[step]▸ [EVALUATE][/step] 14-Axis Rubric Scoring...")
+    if _is_ipc():
+        emit_pipeline_evaluation(evaluations)
+        return
+
+    console.print("[step]\u25b8 [EVALUATE][/step] 14-Axis Rubric Scoring...")
     labels = {
         "quality_judge": "Quality",
         "hidden_value": "Hidden",
@@ -103,7 +137,6 @@ def evaluator_panel(evaluations: dict[str, EvaluatorResult]) -> None:
         label = labels.get(key, key.replace("_", " ").title())
         score = ev.composite_score
         score_style = "bold green" if score >= 80 else "yellow" if score >= 60 else "red"
-        # Truncate rationale to first sentence for table readability
         rationale = ev.rationale.split(".")[0] + "." if ev.rationale else ""
         table.add_row(
             label,
@@ -131,8 +164,12 @@ def score_panel(
         if final_score >= 40
         else "C"
     )
-    emit_pipeline_score(final_score, subscores, confidence, tier)
-    console.print("[step]▸ [SCORE][/step] PSM + Final Calculation")
+
+    if _is_ipc():
+        emit_pipeline_score(final_score, subscores, confidence, tier)
+        return
+
+    console.print("[step]\u25b8 [SCORE][/step] PSM + Final Calculation")
 
     z_mark = "[success]\u2713[/success]" if psm.z_value > 1.645 else "[error]\u2717[/error]"
     g_mark = "[success]\u2713[/success]" if psm.rosenbaum_gamma <= 2.0 else "[error]\u2717[/error]"
@@ -142,7 +179,8 @@ def score_panel(
         f"\u0393={psm.rosenbaum_gamma:.1f} ({g_mark}\u22642.0)"
     )
     console.print(
-        "  [muted]ATT=IP 노출 효과, Z>1.645=95% 유의, \u0393\u22642.0=인과 강건성 확인[/muted]"
+        "  [muted]ATT=IP effect, Z>1.645=95% significant,"
+        " \u0393\u22642.0=causal robustness[/muted]"
     )
 
     filled = int(final_score / 100 * 40)
@@ -161,10 +199,13 @@ def score_panel(
 def verify_panel(guardrails_pass: bool, biasbuster_pass: bool) -> None:
     from core.cli.ui.agentic_ui import emit_pipeline_verification
 
-    emit_pipeline_verification(guardrails_pass, biasbuster_pass)
+    if _is_ipc():
+        emit_pipeline_verification(guardrails_pass, biasbuster_pass)
+        return
+
     g_mark = "[success]\u2713[/success]" if guardrails_pass else "[error]\u2717[/error]"
     b_mark = "[success]\u2713[/success]" if biasbuster_pass else "[error]\u2717[/error]"
-    console.print(f"[step]▸ [VERIFY][/step] Guardrails G1-G4 {g_mark} | BiasBuster {b_mark}")
+    console.print(f"[step]\u25b8 [VERIFY][/step] Guardrails G1-G4 {g_mark} | BiasBuster {b_mark}")
     console.print()
 
 
@@ -173,6 +214,22 @@ def result_panel(
     final_score: float,
     synthesis: SynthesisResult,
 ) -> None:
+    if _is_ipc():
+        from core.cli.ui.agentic_ui import _ipc_writer_local
+
+        writer = getattr(_ipc_writer_local, "writer", None)
+        if writer is not None:
+            writer.send_event(
+                "pipeline_result",
+                tier=tier,
+                final_score=final_score,
+                cause=synthesis.undervaluation_cause,
+                narrative=synthesis.value_narrative[:200],
+                target_segment=synthesis.target_segment,
+                action=synthesis.action_type,
+            )
+        return
+
     tier_info = {
         "S": ("tier_s", "\u226580"),
         "A": ("tier_a", "60-79"),

--- a/core/cli/ui/panels.py
+++ b/core/cli/ui/panels.py
@@ -179,8 +179,7 @@ def score_panel(
         f"\u0393={psm.rosenbaum_gamma:.1f} ({g_mark}\u22642.0)"
     )
     console.print(
-        "  [muted]ATT=IP effect, Z>1.645=95% significant,"
-        " \u0393\u22642.0=causal robustness[/muted]"
+        "  [muted]ATT=IP effect, Z>1.645=95% significant, \u0393\u22642.0=causal robustness[/muted]"
     )
 
     filled = int(final_score / 100 * 40)

--- a/tests/test_event_schema_v2.py
+++ b/tests/test_event_schema_v2.py
@@ -275,7 +275,10 @@ class TestEventRendererV2:
                 "evaluators": {"quality": {"score": 85}},
             }
         )
-        assert "quality" in renderer._out.getvalue()
+        # Renderer maps quality_judge→Quality, but "quality" key becomes "Quality" via labels
+        out = renderer._out.getvalue()
+        assert "EVALUATE" in out
+        assert "85" in out
 
     def test_pipeline_score(self, renderer) -> None:
         renderer.on_event(

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.37.1"
+version = "0.37.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- **Persistent activity spinner** — `EventRenderer.start_activity()` runs animated `Working...` from prompt send until result. Thinking/tool spinners override it; resumes between events.
- **Pipeline client-side rendering** — `panels.py` checks `_is_ipc()` → emits structured event + returns early. No duplicate raw ANSI stream. Thin client renders all pipeline milestones from structured events.
- **2 new events**: `pipeline_header` (IP/mode/model), `pipeline_result` (tier/score/narrative/action). Total: 28 → 30.

## Why

Thin client had dead gaps (no visual feedback) between events. Pipeline panels were double-rendered: structured event + raw ANSI stream.

Before: `thinking_end ── 5s blank ── tool_start`
After: `thinking_end ── ⠋ Working... ── tool_start`

## Changes

| File | Change |
|------|--------|
| `event_renderer.py` | +`start_activity()`/`_animate_activity()` persistent spinner, `_clear_activity_line()` helper, `_handle_pipeline_header/result`, enhanced pipeline handlers |
| `panels.py` | `_is_ipc()` check → emit event + return early for all 7 panels |
| `ipc_client.py` | +`pipeline_header`, `pipeline_result` in event whitelist |
| `__init__.py` | `_renderer.start_activity()` before `send_prompt()` |

## Test plan

- [x] `uv run ruff check + format` — 0 errors
- [x] `uv run mypy` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3461 passed
- [ ] CI 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)