### PR TITLE
fix: stub data origin + cross-batch repeat counter

### DIFF
--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -40,6 +40,11 @@ class EventRenderer:
         renderer.stop()                      # everything OFF
     """
 
+    # Events suppressed during repeat mode (same tool called sequentially)
+    _REPEAT_SUPPRESSIBLE = frozenset(
+        {"tool_start", "tool_end", "tokens", "thinking_start", "thinking_end", "round_start"}
+    )
+
     def __init__(self) -> None:
         self._tool_tracker = ToolCallTracker()
         self._thinking = False
@@ -52,6 +57,13 @@ class EventRenderer:
         self._activity = False
         self._activity_suppressed = False
         self._activity_thread: threading.Thread | None = None
+        # Cross-batch repeat counter: collapses sequential same-tool calls
+        self._repeat_name: str = ""
+        self._repeat_count: int = 0
+        self._repeat_dur: float = 0.0
+        self._repeat_summary: str = ""
+        self._in_repeat: bool = False
+        self._last_batch_tool: str = ""  # tool name from last single-tool batch
 
     # -- Public API -----------------------------------------------------------
 
@@ -65,6 +77,27 @@ class EventRenderer:
     def on_event(self, event: dict[str, Any]) -> None:
         """Handle a structured event from serve."""
         etype = str(event.get("type", ""))
+
+        # Repeat mode: suppress intermediate events for sequential same-tool calls
+        if self._in_repeat and etype in self._REPEAT_SUPPRESSIBLE:
+            if etype == "tool_start":
+                name = str(event.get("name", ""))
+                if name == self._repeat_name:
+                    return  # same tool again, stay in repeat mode
+                self._flush_repeat()  # different tool, flush and handle normally
+            elif etype == "tool_end":
+                name = str(event.get("name", ""))
+                if name == self._repeat_name:
+                    self._repeat_count += 1
+                    dur = event.get("duration_s")
+                    if dur is not None:
+                        self._repeat_dur += float(str(dur))
+                    self._repeat_summary = str(event.get("summary", "ok"))
+                    return  # accumulated, stay in repeat mode
+                self._flush_repeat()
+            else:
+                return  # suppress tokens/thinking/round_start during repeat
+
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
             handler(event)
@@ -77,6 +110,7 @@ class EventRenderer:
 
     def stop(self) -> None:
         """Stop all spinners. Call when result arrives."""
+        self._flush_repeat()
         self._activity = False
         self._activity_suppressed = True
         self._stop_thinking()
@@ -111,16 +145,39 @@ class EventRenderer:
         self._activity_suppressed = False  # resume activity spinner
 
     def _handle_tool_start(self, event: dict[str, Any]) -> None:
+        name = str(event.get("name", ""))
+
+        # Detect repeat onset: same tool as last single-tool batch
+        if self._last_batch_tool and name == self._last_batch_tool:
+            # Enter repeat mode — suppress this tool_start
+            self._in_repeat = True
+            self._repeat_name = name
+            # count/dur/summary already set from last batch's tool_end
+            return
+
         self._activity_suppressed = True
         self._stop_thinking()
         self._tool_tracker.on_tool_start(event)
 
     def _handle_tool_end(self, event: dict[str, Any]) -> None:
+        name = str(event.get("name", ""))
         self._tool_tracker.on_tool_end(event)
         # Resume activity when all tools done
         with self._tool_tracker._lock:
-            if all(t["done"] for t in self._tool_tracker._tools):
-                self._activity_suppressed = False
+            tools = self._tool_tracker._tools
+            all_done = all(t["done"] for t in tools)
+            is_single = len(tools) == 1
+        if all_done:
+            self._activity_suppressed = False
+            # Track last single-tool batch for repeat detection
+            if is_single:
+                dur = event.get("duration_s")
+                self._last_batch_tool = name
+                self._repeat_count = 1
+                self._repeat_dur = float(str(dur)) if dur is not None else 0.0
+                self._repeat_summary = str(event.get("summary", "ok"))
+            else:
+                self._last_batch_tool = ""
 
     def _handle_tokens(self, event: dict[str, Any]) -> None:
         self._suppress_all_spinners()
@@ -451,6 +508,29 @@ class EventRenderer:
         if action:
             self._out.write(f"    \033[2mAction:\033[0m {action}\n")
         self._out.write("\n")
+        self._out.flush()
+
+    # -- Repeat mode helpers ---------------------------------------------------
+
+    def _flush_repeat(self) -> None:
+        """Emit accumulated repeat summary and exit repeat mode."""
+        if not self._in_repeat:
+            return
+        name = self._repeat_name
+        count = self._repeat_count
+        dur = self._repeat_dur
+        summary = self._repeat_summary
+        self._in_repeat = False
+        self._repeat_name = ""
+        self._last_batch_tool = ""
+        if count <= 1:
+            return
+        self._clear_activity_line()
+        dur_str = f" ({dur:.1f}s)" if dur > 0 else ""
+        self._out.write(
+            f"  \033[32m\u2713 {name}\033[0m"
+            f" \u00d7{count} \u2192 {summary}{dur_str}\n"
+        )
         self._out.flush()
 
     # -- Internal helpers -----------------------------------------------------

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -527,10 +527,7 @@ class EventRenderer:
             return
         self._clear_activity_line()
         dur_str = f" ({dur:.1f}s)" if dur > 0 else ""
-        self._out.write(
-            f"  \033[32m\u2713 {name}\033[0m"
-            f" \u00d7{count} \u2192 {summary}{dur_str}\n"
-        )
+        self._out.write(f"  \033[32m\u2713 {name}\033[0m \u00d7{count} \u2192 {summary}{dur_str}\n")
         self._out.flush()
 
     # -- Internal helpers -----------------------------------------------------

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -549,7 +549,7 @@ class IsolatedRunner:
         }
 
         try:
-            self._hooks.trigger(HookEvent.PIPELINE_END, data)
+            self._hooks.trigger(HookEvent.SUBAGENT_COMPLETED, data)
             log.debug(
                 "PostToMain delivered for session %s (mode=%s)",
                 result.session_id,

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from typing import Any
 from unittest.mock import patch
 
 from core.cli.ui.agentic_ui import (
@@ -677,3 +678,101 @@ class TestBuildResultSummary:
         s = OperationLogger._build_result_summary("t", {"output": long_text})
         assert len(s) <= 80
         assert s.endswith("...")
+
+
+# ───────────────────────────────────────────────────────────────────
+# Cross-batch repeat counter (P2)
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestRepeatCounter:
+    """Tests for EventRenderer cross-batch repeat counter."""
+
+    def _make_renderer(self) -> Any:
+        from core.cli.ui.event_renderer import EventRenderer
+
+        r = EventRenderer()
+        # Redirect output to avoid terminal noise in tests
+        import io
+
+        r._out = io.StringIO()
+        return r
+
+    def test_sequential_same_tool_enters_repeat(self) -> None:
+        """Two sequential single-tool batches with same name enter repeat mode."""
+        r = self._make_renderer()
+        # First batch
+        r.on_event({"type": "tool_start", "name": "memory_search", "args_preview": "q=test"})
+        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.2})
+        assert r._last_batch_tool == "memory_search"
+
+        # Second batch — same tool → repeat mode
+        r.on_event({"type": "tool_start", "name": "memory_search", "args_preview": "q=test2"})
+        assert r._in_repeat is True
+
+        # Third end
+        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.3})
+        assert r._repeat_count == 2
+
+    def test_flush_emits_summary_line(self) -> None:
+        """Flushing repeat mode emits ✓ tool ×N summary."""
+        r = self._make_renderer()
+        # Simulate 3 sequential calls
+        for _i in range(3):
+            r.on_event({"type": "tool_start", "name": "check_status", "args_preview": ""})
+            r.on_event({"type": "tool_end", "name": "check_status", "summary": "ok", "duration_s": 0.1})
+
+        assert r._in_repeat is True
+        assert r._repeat_count == 3
+        r._flush_repeat()
+        output = r._out.getvalue()
+        assert "\u00d73" in output  # ×3
+        assert "check_status" in output
+        assert r._in_repeat is False
+
+    def test_different_tool_flushes_repeat(self) -> None:
+        """Starting a different tool flushes the repeat accumulation."""
+        r = self._make_renderer()
+        # 2x memory_search
+        r.on_event({"type": "tool_start", "name": "memory_search"})
+        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.1})
+        r.on_event({"type": "tool_start", "name": "memory_search"})
+        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.1})
+        assert r._in_repeat is True
+
+        # Different tool → flush
+        r.on_event({"type": "tool_start", "name": "web_search", "args_preview": "q=new"})
+        assert r._in_repeat is False
+        output = r._out.getvalue()
+        assert "\u00d72" in output  # ×2 from flush
+
+    def test_parallel_batch_does_not_trigger_repeat(self) -> None:
+        """Multi-tool batches don't set _last_batch_tool."""
+        r = self._make_renderer()
+        r.on_event({"type": "tool_start", "name": "web_search"})
+        r.on_event({"type": "tool_start", "name": "read_file"})
+        r.on_event({"type": "tool_end", "name": "web_search", "summary": "ok", "duration_s": 0.1})
+        r.on_event({"type": "tool_end", "name": "read_file", "summary": "ok", "duration_s": 0.1})
+        assert r._last_batch_tool == ""
+
+    def test_stop_flushes_repeat(self) -> None:
+        """stop() flushes any pending repeat accumulation."""
+        r = self._make_renderer()
+        for _ in range(4):
+            r.on_event({"type": "tool_start", "name": "task_list"})
+            r.on_event({"type": "tool_end", "name": "task_list", "summary": "0 items", "duration_s": 0.05})
+        assert r._in_repeat is True
+        r.stop()
+        output = r._out.getvalue()
+        assert "\u00d74" in output  # ×4
+
+    def test_tokens_suppressed_during_repeat(self) -> None:
+        """Token events between repeated tools are suppressed."""
+        r = self._make_renderer()
+        r.on_event({"type": "tool_start", "name": "check_status"})
+        r.on_event({"type": "tool_end", "name": "check_status", "summary": "ok", "duration_s": 0.1})
+        r.on_event({"type": "tool_start", "name": "check_status"})
+        # Now in repeat mode — tokens should be suppressed
+        r.on_event({"type": "tokens", "model": "claude-opus-4-6", "input": 1000, "output": 50})
+        output = r._out.getvalue()
+        assert "claude-opus-4-6" not in output  # tokens line suppressed

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -703,7 +703,9 @@ class TestRepeatCounter:
         r = self._make_renderer()
         # First batch
         r.on_event({"type": "tool_start", "name": "memory_search", "args_preview": "q=test"})
-        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.2})
+        r.on_event(
+            {"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.2}
+        )
         assert r._last_batch_tool == "memory_search"
 
         # Second batch — same tool → repeat mode
@@ -711,7 +713,9 @@ class TestRepeatCounter:
         assert r._in_repeat is True
 
         # Third end
-        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.3})
+        r.on_event(
+            {"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.3}
+        )
         assert r._repeat_count == 2
 
     def test_flush_emits_summary_line(self) -> None:
@@ -720,7 +724,9 @@ class TestRepeatCounter:
         # Simulate 3 sequential calls
         for _i in range(3):
             r.on_event({"type": "tool_start", "name": "check_status", "args_preview": ""})
-            r.on_event({"type": "tool_end", "name": "check_status", "summary": "ok", "duration_s": 0.1})
+            r.on_event(
+                {"type": "tool_end", "name": "check_status", "summary": "ok", "duration_s": 0.1}
+            )
 
         assert r._in_repeat is True
         assert r._repeat_count == 3
@@ -735,9 +741,13 @@ class TestRepeatCounter:
         r = self._make_renderer()
         # 2x memory_search
         r.on_event({"type": "tool_start", "name": "memory_search"})
-        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.1})
+        r.on_event(
+            {"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.1}
+        )
         r.on_event({"type": "tool_start", "name": "memory_search"})
-        r.on_event({"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.1})
+        r.on_event(
+            {"type": "tool_end", "name": "memory_search", "summary": "ok", "duration_s": 0.1}
+        )
         assert r._in_repeat is True
 
         # Different tool → flush
@@ -760,7 +770,9 @@ class TestRepeatCounter:
         r = self._make_renderer()
         for _ in range(4):
             r.on_event({"type": "tool_start", "name": "task_list"})
-            r.on_event({"type": "tool_end", "name": "task_list", "summary": "0 items", "duration_s": 0.05})
+            r.on_event(
+                {"type": "tool_end", "name": "task_list", "summary": "0 items", "duration_s": 0.05}
+            )
         assert r._in_repeat is True
         r.stop()
         output = r._out.getvalue()

--- a/tests/test_isolated_execution.py
+++ b/tests/test_isolated_execution.py
@@ -198,7 +198,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         cfg = IsolationConfig(post_mode=PostToMainMode.SUMMARY, prefix="TestRun")
         result = runner.run(lambda: "some output", config=cfg)
@@ -219,7 +219,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         cfg = IsolationConfig(post_mode=PostToMainMode.FULL)
         runner.run(lambda: "full output text", config=cfg)
@@ -235,7 +235,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         cfg = IsolationConfig(post_mode=PostToMainMode.FULL, max_chars=100)
         runner.run(_large_output, args=(500,), config=cfg)
@@ -251,7 +251,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         cfg = IsolationConfig(post_to_main=False)
         runner.run(lambda: "no posting", config=cfg)
@@ -272,7 +272,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         cfg = IsolationConfig(prefix="AnalysisTask")
         runner.run(lambda: "ok", config=cfg)
@@ -286,7 +286,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         runner.run(lambda: "ok")
 
@@ -300,7 +300,7 @@ class TestPostToMain:
         def handler(event: Any, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.PIPELINE_END, handler, name="capture")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, handler, name="capture")
         runner = IsolatedRunner(hooks=hooks)
         runner.run(_exploding)
 
@@ -581,7 +581,7 @@ class TestEdgeCases:
         def bad_handler(event: Any, data: dict[str, Any]) -> None:
             raise ValueError("hook exploded")
 
-        hooks.register(HookEvent.PIPELINE_END, bad_handler, name="bad")
+        hooks.register(HookEvent.SUBAGENT_COMPLETED, bad_handler, name="bad")
         runner = IsolatedRunner(hooks=hooks)
 
         # Should not raise


### PR DESCRIPTION
## Summary

- **Stub data root cause**: `isolated_execution._post_to_main()` was firing `PIPELINE_END` for sub-agent completions → memory write-back recorded `tier=?, score=0.00`. Fixed to use `SUBAGENT_COMPLETED`.
- **Cross-batch repeat counter**: Sequential same-tool calls (e.g. `check_status` ×11, `memory_search` ×19) collapsed into single summary line instead of flooding terminal.

## Why

Users reported `[Berserk] tier=?, score=0.00` stub entries in memory and duplicate tool rendering lines when AgenticLoop calls the same tool sequentially across rounds.

## Changes

| File | Change |
|------|--------|
| `core/orchestration/isolated_execution.py` | `PIPELINE_END` → `SUBAGENT_COMPLETED` |
| `core/cli/ui/event_renderer.py` | Repeat counter: detect, accumulate, flush |
| `tests/test_isolated_execution.py` | Updated hook event assertions |
| `tests/test_agentic_ui.py` | +6 repeat counter tests |

## Test plan
- [x] `ruff check core/ tests/` — 0 errors
- [x] `mypy` — 0 errors
- [x] `pytest tests/ -m "not live"` — 3501 passed
- [ ] CI 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)