### PR TITLE
docs: v0.37-0.38 blog posts + plan archives

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-30T18:22:35+09:00 task_id=llm-resilience
+session=2026-03-31T00:04:15+09:00 task_id=blog-posts

--- a/docs/blog/01-llm-resilience-hardening.md
+++ b/docs/blog/01-llm-resilience-hardening.md
@@ -1,0 +1,225 @@
+# LLM이 죽어도 파이프라인은 살아야 한다 — LangGraph 파이프라인의 Graceful Degradation 설계
+
+> Date: 2026-03-30 | Author: geode-team | Tags: LangGraph, resilience, graceful-degradation, LLM, pipeline
+
+## 목차
+1. 문제 정의
+2. GAP 분석: Happy Path와 Total Outage 사이
+3. Phase 1 — Degraded Fallback
+4. Phase 2 — Verification Enrichment Loop
+5. Phase 3 — Cost Control과 Timeout
+6. 실전 적용: Scoring Penalty
+7. 정리
+
+---
+
+## 1. 문제 정의
+
+LLM 기반 파이프라인은 두 가지 극단에 대한 대비가 잘 되어 있습니다. 정상 경로(Happy Path)는 테스트로 검증하고, 전면 장애(Total Outage)는 fallback chain과 circuit breaker로 처리합니다. 문제는 그 사이입니다.
+
+- Analyst 4명 중 1명만 timeout
+- Evaluator가 validation error를 반환
+- Verification의 guardrails가 실패했지만 confidence는 충분
+
+이런 **중간 지점의 실패**가 파이프라인을 통째로 crash시키거나, 반대로 조용히 나쁜 결과를 통과시킵니다. GEODE v0.38.0에서는 14개 GAP 항목을 식별하고, 3-Phase로 구현했습니다.
+
+## 2. GAP 분석: Happy Path와 Total Outage 사이
+
+기존 인프라를 먼저 정리합니다. 이미 동작하는 것과 빠진 것을 분리하는 것이 핵심입니다.
+
+| 계층 | 이미 있는 것 | 빠진 것 (GAP) |
+|------|-------------|---------------|
+| **Shared (LLM)** | Fallback chain, Retry + backoff, Circuit breaker | Jitter 없음, Cross-provider 미연결, 비용 제어 없음 |
+| **Agentic Loop** | Model escalation, Context 3-phase 관리 | Cost budget bare except, Checkpoint resume 미통합 |
+| **Domain DAG** | Node-level retry (1회), SqliteSaver checkpoint | Retry 소진 시 crash, Verification 실패 무시 |
+
+GAP 항목 14개를 P0(장애 방지) / P1(품질/비용) / P2(다듬기) 3단계로 분류했습니다.
+
+## 3. Phase 1 — Degraded Fallback
+
+가장 치명적인 GAP: retry가 소진되면 `raise`로 파이프라인 전체가 중단됩니다.
+
+**설계 원칙**: crash 대신 degraded 결과를 반환하고, 후속 노드가 이를 인지하게 합니다.
+
+```python
+# core/graph.py
+_RETRYABLE_NODES = frozenset({"analyst", "evaluator", "scoring", "gather"})
+_DEGRADABLE_NODES = frozenset({"analyst", "evaluator", "scoring"})
+```
+
+> `_RETRYABLE_NODES`는 retry를 시도할 노드, `_DEGRADABLE_NODES`는 retry 소진 후 degraded 결과를 반환할 노드입니다. `gather`는 retry하지만 degraded 반환은 하지 않습니다 — 상태 취합 노드이므로 부분 결과를 만들어낼 수 없기 때문입니다.
+
+retry 소진 시 분기 로직:
+
+```python
+# core/graph.py — _make_hooked_node 내부
+except Exception as exc:
+    if retries_left > 0:
+        retries_left -= 1
+        last_exc = exc
+        continue
+    hook_data["error"] = str(exc)
+    hooks.trigger(HookEvent.NODE_ERROR, hook_data)
+
+    # B1: degradable nodes return degraded results instead of crashing
+    if node_name in _DEGRADABLE_NODES:
+        return _make_degraded_result(node_name, exc, effective_state)
+
+    hooks.trigger(HookEvent.PIPELINE_ERROR, hook_data)
+    raise
+```
+
+> 핵심은 `PIPELINE_ERROR` 이전에 분기한다는 점입니다. degradable 노드는 PIPELINE_ERROR를 발생시키지 않으므로, downstream 노드가 정상적으로 실행됩니다.
+
+`_make_degraded_result`는 노드 타입별로 안전한 기본값을 반환합니다:
+
+```python
+# core/graph.py
+def _make_degraded_result(
+    node_name: str, exc: Exception, state: Any
+) -> dict[str, Any]:
+    if node_name == "analyst":
+        return {
+            "analyses": [AnalysisResult(
+                analyst_type=atype,
+                score=1.0,
+                key_finding="[DEGRADED] Node retry exhausted",
+                confidence=0.0,
+                is_degraded=True,
+            )],
+            "errors": [err_msg],
+        }
+    if node_name == "evaluator":
+        return {
+            "evaluations": {etype: EvaluatorResult(
+                evaluator_type=etype,
+                axes=_default_axes.get(etype, _hidden),
+                composite_score=0.0,
+                is_degraded=True,
+            )},
+            "errors": [err_msg],
+        }
+    if node_name == "scoring":
+        return {"final_score": 0.0, "tier": "C", "errors": [err_msg]}
+```
+
+> `is_degraded=True` 플래그가 핵심입니다. downstream의 scoring 노드가 이 플래그를 읽어 confidence를 낮춥니다. crash가 아닌 "신뢰도가 낮은 결과"로 전파되는 것입니다.
+
+## 4. Phase 2 — Verification Enrichment Loop
+
+기존에는 verification 노드의 guardrails가 실패해도 confidence만 체크했습니다. guardrails 실패와 biasbuster 실패는 별도 조건으로 loopback을 트리거해야 합니다.
+
+```python
+# core/graph.py — _configured_should_continue
+verification_failed = (
+    (guardrails and not guardrails.all_passed)
+    or (biasbuster and not biasbuster.overall_pass)
+)
+if verification_failed and iteration < max_iter:
+    return "gather"  # loopback to signals
+```
+
+> confidence 체크보다 **앞에** 위치합니다. confidence가 0.9로 충분해도 guardrails가 실패했다면 결과를 신뢰할 수 없기 때문입니다. `max_iter` 안전 밸브는 유지합니다.
+
+LangGraph의 `iteration_history`는 `operator.add` reducer로 무한 증가할 수 있으므로, 커스텀 reducer로 cap을 겁니다:
+
+```python
+# core/state.py
+_ITERATION_HISTORY_MAX = 10
+
+def _add_and_trim_history(
+    left: list[dict[str, Any]], right: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    merged = left + right
+    return merged[-_ITERATION_HISTORY_MAX:]
+
+class GeodeState(TypedDict):
+    iteration_history: Annotated[list[dict[str, Any]], _add_and_trim_history]
+```
+
+> LangGraph의 `Annotated[list, operator.add]` 패턴은 편리하지만, feedback loop에서는 무한 증가 위험이 있습니다. 커스텀 reducer로 교체하면 동일한 append 동작 + 상한 제어를 얻을 수 있습니다.
+
+## 5. Phase 3 — Cost Control과 Timeout
+
+**Backoff Jitter**: 결정론적 delay는 thundering herd를 유발합니다. 한 줄 수정이지만 효과는 큽니다.
+
+```python
+# core/llm/fallback.py — BEFORE
+delay = min(retry_base_delay * (2 ** attempt), retry_max_delay)
+
+# AFTER (full jitter)
+delay = random.uniform(0, min(retry_base_delay * (2 ** attempt), retry_max_delay))
+```
+
+**Cost Ratio Guard**: haiku에서 opus로 fallback할 때 비용이 5배 뛸 수 있습니다. 사전에 필터링합니다.
+
+```python
+# core/llm/fallback.py
+if _cfg.llm_max_fallback_cost_ratio > 0:
+    primary_price = MODEL_PRICING.get(model)
+    for fb_model in models_to_try[1:]:
+        fb_price = MODEL_PRICING.get(fb_model)
+        ratio = fb_price.input / primary_price.input
+        if ratio > _cfg.llm_max_fallback_cost_ratio:
+            continue  # skip expensive fallback
+        filtered.append(fb_model)
+    models_to_try = filtered
+```
+
+> `models_to_try` 리스트를 루프 진입 전에 필터링합니다. 루프 중간에 체크하면 `continue`의 스코프 문제가 발생합니다 — 실제로 첫 구현에서 이 버그를 겪었습니다.
+
+**Pipeline Timeout**: LangGraph의 `invoke()`는 기본적으로 timeout이 없습니다. `ThreadPoolExecutor`로 래핑합니다.
+
+```python
+# core/graph.py
+def invoke_with_timeout(graph, state, config=None, timeout_s=0.0, hooks=None):
+    if timeout_s <= 0:
+        return graph.invoke(state, config=config)
+
+    def _run():
+        return graph.invoke(state, config=config)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_run)
+        try:
+            return future.result(timeout=timeout_s)
+        except concurrent.futures.TimeoutError:
+            if hooks:
+                hooks.trigger(HookEvent.PIPELINE_TIMEOUT, {"timeout_s": timeout_s})
+            raise PipelineTimeoutError(...) from None
+```
+
+## 6. 실전 적용: Scoring Penalty
+
+degraded 결과가 scoring에 도달하면, 단순히 무시하지 않고 confidence에 penalty를 적용합니다.
+
+```python
+# core/domains/game_ip/nodes/scoring.py
+degraded_analysts = sum(1 for a in analyses if getattr(a, "is_degraded", False))
+degraded_evals = sum(1 for e in evaluations.values() if getattr(e, "is_degraded", False))
+total_sources = len(analyses) + len(evaluations)
+degraded_count = degraded_analysts + degraded_evals
+if degraded_count > 0 and total_sources > 0:
+    penalty = 1.0 - (degraded_count / total_sources) * 0.5
+    confidence = confidence * penalty
+```
+
+> 4명 중 2명 degraded → penalty = 1.0 - (2/7) * 0.5 = 0.857 → confidence 14% 감소. crash도 아니고 무시도 아닌, 비례적 감쇄입니다.
+
+## 7. 정리
+
+| 항목 | 변경 | 효과 |
+|------|------|------|
+| Degraded fallback | retry 소진 → `is_degraded=True` 반환 | 파이프라인 중단 → 계속 |
+| Verification loop | guardrails/biasbuster 실패 → gather loopback | 검증 실패 무시 → 재시도 |
+| Scoring penalty | degraded 비율 → confidence 감쇄 | 나쁜 결과 통과 → 신뢰도 반영 |
+| Backoff jitter | `random.uniform` full jitter | thundering herd 방지 |
+| Cost ratio | fallback 전 비용 비율 체크 | 비용 폭주 방지 |
+| Pipeline timeout | `ThreadPoolExecutor` + hook | 무한 실행 방지 |
+| History trimming | 커스텀 reducer (cap 10) | 메모리 무한 증가 방지 |
+| Cross-provider | `_cross_provider_dispatch()` | 단일 프로바이더 의존 제거 |
+
+- 14개 GAP 식별 → 3-Phase 구현 → 34개 테스트 추가
+- 기존 3,461 → 3,496 테스트 (전체 통과)
+- 설정 2개 추가: `pipeline_timeout_s` (600s), `llm_max_fallback_cost_ratio` (0=무제한)
+- Hook 이벤트 2개 추가: `FALLBACK_CROSS_PROVIDER`, `PIPELINE_TIMEOUT` (40 → 42)

--- a/docs/blog/02-race-condition-hunting.md
+++ b/docs/blog/02-race-condition-hunting.md
@@ -1,0 +1,177 @@
+# Race Condition 사냥기 — 멀티스레드 에이전트 시스템에서 발견한 6개의 동시성 버그
+
+> Date: 2026-03-30 | Author: geode-team | Tags: concurrency, race-condition, threading, Python, agent-system
+
+## 목차
+1. 배경: 왜 에이전트 시스템에 Race Condition이 생기는가
+2. Bug 1: Announce Double-Publish
+3. Bug 2: Semaphore Leak
+4. Bug 3: TaskGraph 이중 실행
+5. Bug 4: acquire_all() 부분 실패
+6. Bug 5: Zombie Thread 잔류
+7. Bug 6: PIPELINE_END 이벤트 오용
+8. 정리: 패턴 카탈로그
+
+---
+
+## 1. 배경: 왜 에이전트 시스템에 Race Condition이 생기는가
+
+단일 LLM 호출은 동시성 문제가 없습니다. 하지만 **sub-agent 병렬 실행**, **scheduler 백그라운드 작업**, **Gateway 폴링**이 동시에 돌아가는 시스템에서는 공유 상태가 곳곳에 생깁니다.
+
+GEODE의 실행 경로는 3개입니다:
+- **CLIPoller**: 사용자 입력 처리 (IPC)
+- **Gateway**: Slack/Discord 폴링 (daemon thread)
+- **Scheduler**: cron 작업 (daemon thread)
+
+이 3개가 동일한 `LaneQueue`, `HookSystem`, `announce_queue`를 공유합니다. v0.35.1에서 6개의 동시성 버그를 수정했습니다.
+
+## 2. Bug 1: Announce Double-Publish
+
+**증상**: sub-agent 결과가 parent AgenticLoop에 2번 주입되어 LLM이 동일 정보를 중복 처리.
+
+**원인**: `_announce_result()`에 lock이 없었습니다. 두 스레드가 동시에 같은 `child_result`를 큐에 push할 수 있었습니다.
+
+```python
+# BEFORE (race condition)
+def _announce_result(self, parent_key, child_result):
+    _announce_queue.setdefault(parent_key, []).append(child_result)
+    child_result.announced = True
+```
+
+```python
+# AFTER — core/agent/sub_agent.py
+def _announce_result(self, parent_session_key: str, child_result: SubAgentResult) -> None:
+    with _announce_lock:
+        if child_result.announced:
+            return
+        child_result.announced = True
+        _announce_queue.setdefault(parent_session_key, []).append(child_result)
+        _announce_timestamps[parent_session_key] = time.time()
+```
+
+> **Check-and-set 패턴**: `announced` 플래그 확인과 설정이 동일 lock 안에 있어야 합니다. lock 밖에서 `if not announced` → lock 안에서 `announced = True`를 하면 TOCTOU(Time-of-Check-Time-of-Use) race가 발생합니다.
+
+추가로 `_announce_timestamps`에 TTL(300s)을 설정하여, parent가 비정상 종료해도 stale 큐 엔트리가 자동 정리됩니다.
+
+## 3. Bug 2: Semaphore Leak
+
+**증상**: 시간이 지나면 sub-agent 병렬 실행이 점점 줄어들다 멈춤.
+
+**원인**: `_acquire_slot()`에서 semaphore를 획득한 후 실행 중 예외가 발생하면, finally에서 해제되지 않는 경로가 있었습니다.
+
+```python
+# BEFORE (leak path)
+def _execute_thread(self, config):
+    self._acquire_slot(config)      # semaphore acquired
+    try:
+        result = self._run(config)  # exception here...
+    finally:
+        self._release_slot(config)  # ...but _release_slot checks _active dict
+                                    # which wasn't updated on acquire
+```
+
+```python
+# AFTER — core/orchestration/isolated_execution.py
+def _execute_thread(self, config):
+    acquired = False
+    try:
+        slot_err = self._acquire_slot(config)
+        if slot_err:
+            return slot_err
+        acquired = True
+        result = self._run(config)
+    finally:
+        if acquired:
+            self._release_slot(config)
+```
+
+> **acquired flag 패턴**: semaphore를 획득했는지 여부를 별도 변수로 추적합니다. `_acquire_slot`이 timeout으로 실패한 경우에는 `acquired=False`이므로 해제하지 않습니다. 이 패턴은 `contextlib.ExitStack`보다 명확합니다.
+
+## 4. Bug 3: TaskGraph 이중 실행
+
+**증상**: 같은 task가 2개 worker에서 동시에 실행됨.
+
+**원인**: `get_ready_tasks()` → `mark_running()` 사이에 다른 스레드가 같은 task를 ready 상태로 가져감.
+
+```python
+# AFTER — core/orchestration/task_system.py
+def __init__(self) -> None:
+    self._tasks: dict[str, Task] = {}
+    self._lock = threading.Lock()
+
+def add_task(self, task: Task) -> None:
+    with self._lock:
+        if task.task_id in self._tasks:
+            raise ValueError(f"Task '{task.task_id}' already exists")
+        self._tasks[task.task_id] = task
+
+def mark_running(self, task_id: str) -> None:
+    with self._lock:
+        task = self._require_task(task_id)
+        if task.status not in (TaskStatus.PENDING, TaskStatus.READY):
+            raise ValueError(f"Cannot start '{task_id}' in '{task.status.value}'")
+        task.status = TaskStatus.RUNNING
+        task.started_at = time.time()
+```
+
+> **상태 전이 guard**: `mark_running()`이 lock 안에서 현재 상태를 재확인합니다. `READY → RUNNING` 전이만 허용하므로, 두 번째 스레드가 같은 task를 시작하려 하면 `ValueError`가 발생합니다.
+
+## 5. Bug 4: acquire_all() 부분 실패
+
+**증상**: session lane은 획득했지만 global lane 획득에 실패 → session lane이 해제되지 않아 해당 session key가 영구 잠김.
+
+```python
+# AFTER — core/orchestration/lane_queue.py
+@contextmanager
+def acquire_all(self, key: str, lane_names: list[str]):
+    acquired: list[Lane | SessionLane] = []
+    try:
+        for name in lane_names:
+            lane = self._resolve_lane(name)
+            if not lane._raw_acquire(key):
+                raise TimeoutError(f"Lane '{name}' timeout for '{key}'")
+            acquired.append(lane)
+        yield
+    finally:
+        for item in reversed(acquired):
+            item._raw_release(key)
+```
+
+> **역순 해제**: 획득한 순서의 역순으로 해제합니다 (stack unwinding). `acquired` 리스트에는 실제로 획득에 성공한 lane만 들어있으므로, 부분 실패 시에도 정확히 획득한 것만 해제합니다.
+
+## 6. Bug 5: Zombie Thread 잔류
+
+**증상**: timeout된 sub-agent 스레드가 `_active` dict에 남아 `active_count`가 실제보다 높게 보고됨.
+
+**수정**: timeout 시 `_active`와 `_cancel_flags`에서 제거하는 cleanup 로직 추가. 간단하지만 놓치기 쉬운 부분입니다.
+
+## 7. Bug 6: PIPELINE_END 이벤트 오용
+
+**증상**: `[Berserk] tier=?, score=0.00` stub 데이터가 메모리에 기록됨.
+
+**원인**: `isolated_execution.py`의 `_post_to_main()`이 sub-agent 완료 시 `PIPELINE_END`를 fire. 이 이벤트에 등록된 memory write-back 핸들러가 `ip_name`, `tier`, `final_score`가 없는 데이터를 기본값으로 기록.
+
+```python
+# BEFORE — core/orchestration/isolated_execution.py
+self._hooks.trigger(HookEvent.PIPELINE_END, data)  # data has no ip_name/tier/score
+
+# AFTER
+self._hooks.trigger(HookEvent.SUBAGENT_COMPLETED, data)
+```
+
+> **이벤트 시맨틱 분리**: `PIPELINE_END`는 "분석 파이프라인 완료"이고 `SUBAGENT_COMPLETED`는 "sub-agent 실행 완료"입니다. 같은 "완료"지만 컨텍스트가 다릅니다. HookSystem의 이벤트를 재사용하면 의도하지 않은 핸들러가 실행됩니다.
+
+## 8. 정리: 패턴 카탈로그
+
+| Bug | 패턴 | 핵심 원칙 |
+|-----|------|-----------|
+| Double-publish | Lock 안에서 check-and-set | TOCTOU 방지 |
+| Semaphore leak | `acquired` flag + finally | 획득 여부 명시적 추적 |
+| 이중 실행 | Lock 안에서 상태 전이 guard | 상태 머신 원자성 |
+| 부분 실패 | `acquired` 리스트 + 역순 해제 | Stack unwinding |
+| Zombie thread | timeout 시 tracking dict cleanup | 리소스 생명주기 일치 |
+| 이벤트 오용 | 시맨틱이 다른 이벤트 분리 | Single Responsibility |
+
+공통 원칙은 하나입니다: **"공유 상태 접근은 항상 보호하고, 보호 범위는 최소한으로."**
+
+Lock 범위가 넓으면 deadlock 위험이 커지고, 좁으면 race가 남습니다. GEODE에서는 각 공유 자원(announce_queue, TaskGraph, LaneQueue)마다 독립된 fine-grained lock을 사용합니다.

--- a/docs/blog/03-session-lane-per-key.md
+++ b/docs/blog/03-session-lane-per-key.md
@@ -1,0 +1,170 @@
+# SessionLane: OpenClaw에서 배운 Per-Key Serialization — 4-Lane에서 Per-Session 직렬화로
+
+> Date: 2026-03-30 | Author: geode-team | Tags: concurrency, session-management, OpenClaw, LaneQueue, semaphore
+
+## 목차
+1. 문제: 4-Lane 시스템의 한계
+2. OpenClaw의 Session Key 패턴
+3. SessionLane 설계
+4. acquire_all(): 통합 진입점
+5. Idle Cleanup
+6. 정리
+
+---
+
+## 1. 문제: 4-Lane 시스템의 한계
+
+v0.36 이전 GEODE는 4개의 Named Lane으로 동시성을 제어했습니다:
+
+```
+session_lane  (max=1)   — REPL 세션
+global_lane   (max=8)   — 전체 병렬 실행
+gateway_lane  (max=4)   — Slack/Discord
+scheduler_lane(max=2)   — Cron 작업
+```
+
+문제는 **session_lane이 전체 시스템에 1개**라는 점입니다. 사용자 A의 IPC 세션이 실행 중이면 사용자 B의 세션은 대기합니다. 실제로는 서로 다른 세션이므로 병렬 실행이 가능해야 합니다.
+
+gateway_lane과 scheduler_lane도 마찬가지입니다. "Slack 메시지 4개까지 동시 처리"라는 제약은 있지만, 같은 채널의 메시지가 순서를 지켜야 하는지에 대한 보장이 없었습니다.
+
+## 2. OpenClaw의 Session Key 패턴
+
+OpenClaw(오픈소스 에이전트 프레임워크)는 이 문제를 Session Key 기반 직렬화로 해결합니다:
+
+- **같은 session key** → 직렬 실행 (한 세션 내 요청은 순서대로)
+- **다른 session key** → 병렬 실행 (독립 세션은 동시에)
+
+GEODE에서 session key는 자연스럽게 존재합니다:
+- IPC: `ipc:{pid}` (클라이언트 프로세스 ID)
+- Gateway: `slack:{channel_id}` (채널 단위 직렬)
+- Scheduler: `sched:{job_id}` (작업 단위 직렬)
+
+## 3. SessionLane 설계
+
+```
+┌─ SessionLane (per-key Semaphore(1)) ──────────────────┐
+│  ipc:1234 ──── Sem(1) ──── [executing]                │
+│  ipc:5678 ──── Sem(1) ──── [executing]    ← 병렬     │
+│  slack:C01 ─── Sem(1) ──── [waiting]                  │
+│  slack:C01 ─── Sem(1) ──── [blocked]      ← 직렬     │
+│  max_sessions = 256                                   │
+└───────────────────────────────────────────────────────┘
+          │
+          ▼
+┌─ Lane("global", max=8) ──────────────────────────────┐
+│  전체 시스템 병렬 실행 상한                              │
+└───────────────────────────────────────────────────────┘
+```
+
+핵심 구현:
+
+```python
+# core/orchestration/lane_queue.py
+
+@dataclass
+class _SessionEntry:
+    semaphore: threading.Semaphore  # Semaphore(1) — per-key serial
+    held: bool = False
+    last_used: float = 0.0
+
+class SessionLane:
+    def __init__(self, max_sessions: int = 256, idle_timeout_s: float = 300.0):
+        self._sessions: dict[str, _SessionEntry] = {}
+        self._lock = threading.Lock()
+        self.max_sessions = max_sessions
+        self.idle_timeout_s = idle_timeout_s
+```
+
+> `Semaphore(1)`은 `Lock`과 동일한 효과이지만, `acquire(timeout=N)` 지원과 `LaneQueue` API 일관성을 위해 Semaphore를 사용합니다.
+
+`_raw_acquire`는 세션이 없으면 생성하고, `max_sessions` 초과 시 idle 세션을 정리합니다:
+
+```python
+def _raw_acquire(self, key: str) -> bool:
+    with self._lock:
+        entry = self._sessions.get(key)
+        if entry is None:
+            if len(self._sessions) >= self.max_sessions:
+                self._evict_idle_locked()
+                if len(self._sessions) >= self.max_sessions:
+                    return False  # still full after eviction
+            entry = _SessionEntry(semaphore=threading.Semaphore(1))
+            self._sessions[key] = entry
+    acquired = entry.semaphore.acquire(timeout=self._acquire_timeout)
+    if acquired:
+        with self._lock:
+            entry.held = True
+            entry.last_used = time.time()
+    return acquired
+```
+
+> lock 범위가 **세션 조회/생성**에만 한정됩니다. semaphore acquire는 lock 밖에서 수행합니다. lock 안에서 blocking acquire를 하면 다른 세션 키의 생성까지 차단되기 때문입니다.
+
+## 4. acquire_all(): 통합 진입점
+
+모든 실행 경로(CLI, Gateway, Scheduler)가 동일한 진입점을 사용합니다:
+
+```python
+# core/orchestration/lane_queue.py
+@contextmanager
+def acquire_all(self, key: str, lane_names: list[str]):
+    acquired: list[Lane | SessionLane] = []
+    try:
+        for name in lane_names:
+            lane = self._resolve_lane(name)
+            if not lane._raw_acquire(key):
+                raise TimeoutError(f"Lane '{name}' timeout for '{key}'")
+            acquired.append(lane)
+        yield
+    finally:
+        for item in reversed(acquired):
+            item._raw_release(key)
+```
+
+호출 측:
+
+```python
+# CLI, Gateway, Scheduler 모두 동일
+async with lane_queue.acquire_all(session_key, ["session", "global"]):
+    session = create_session(mode)
+    await session.execute(prompt)
+```
+
+> `["session", "global"]` 순서가 중요합니다. session lane을 먼저 획득하여 같은 세션의 동시 요청을 차단하고, 그 다음 global lane으로 전체 병렬도를 제한합니다. 역순으로 하면 global 슬롯을 점유한 채 session 대기하는 비효율이 발생합니다.
+
+## 5. Idle Cleanup
+
+세션이 300초간 사용되지 않으면 자동 정리됩니다:
+
+```python
+def cleanup_idle(self) -> int:
+    with self._lock:
+        return self._evict_idle_locked()
+
+def _evict_idle_locked(self) -> int:
+    now = time.time()
+    to_remove = [
+        k for k, e in self._sessions.items()
+        if not e.held and (now - e.last_used) > self.idle_timeout_s
+    ]
+    for k in to_remove:
+        del self._sessions[k]
+    return len(to_remove)
+```
+
+> `e.held` 체크가 핵심입니다. 실행 중인 세션은 idle 시간과 무관하게 보존됩니다. 정리 대상은 "semaphore가 해제된 상태에서 300초 이상 미사용"인 세션입니다.
+
+## 6. 정리
+
+| 항목 | 4-Lane (v0.36) | SessionLane (v0.37) |
+|------|----------------|---------------------|
+| 세션 간 관계 | 전체 직렬 (session_lane max=1) | 같은 key만 직렬, 다른 key 병렬 |
+| 최대 병렬 세션 | 1 | 256 (max_sessions) |
+| Gateway/Scheduler | 전용 lane (hardcoded max) | session key 기반 동적 |
+| 진입점 | lane별 개별 acquire | `acquire_all(key, ["session", "global"])` |
+| Idle 관리 | 없음 | 300s auto-eviction |
+| 코드 라인 | 4개 Semaphore 선언 | SessionLane 180줄 + Lane 120줄 |
+
+**삭제한 것**: `CoalescingQueue` (148줄, 0 trigger), standalone REPL `_interactive_loop` (~487줄), gateway/scheduler 전용 lane.
+
+**설계 교훈**: "고정 슬롯 수"로 동시성을 제어하면 단순하지만, 독립적인 요청까지 직렬화됩니다. "요청의 identity(세션 키)"를 기준으로 직렬/병렬을 분리하면 더 자연스러운 동시성 모델이 됩니다.

--- a/docs/blog/04-cross-batch-repeat-counter.md
+++ b/docs/blog/04-cross-batch-repeat-counter.md
@@ -1,0 +1,167 @@
+# 터미널 폭주 방지 — 순차 도구 호출의 Cross-Batch Repeat Counter
+
+> Date: 2026-03-30 | Author: geode-team | Tags: CLI, UX, event-rendering, tool-tracker, ANSI
+
+## 목차
+1. 문제: 같은 도구가 19번 찍힌다
+2. 원인 분석: Batch 단위 렌더링의 한계
+3. Repeat Counter 설계
+4. 상태 머신: onset → accumulate → flush
+5. 정리
+
+---
+
+## 1. 문제: 같은 도구가 19번 찍힌다
+
+AgenticLoop가 "현재 상태를 점검하라"는 요청을 받으면, 여러 라운드에 걸쳐 `check_status`, `memory_search`, `task_list`를 반복 호출합니다. 각 호출은 독립된 tool_start → tool_end 배치입니다.
+
+```
+  ✓ check_status → ok (0.2s)
+  ✢ claude-opus-4-6 · ↓47.8k ↑148 · $0.2425
+  ✓ check_status → ok (0.2s)
+  ✢ claude-opus-4-6 · ↓48.1k ↑152 · $0.2430
+  ✓ memory_search → # GEODE Project Memory... (0.2s)
+  ✢ claude-opus-4-6 · ↓48.5k ↑160 · $0.2445
+  ✓ memory_search → # GEODE Project Memory... (0.2s)
+  ... (19회 반복)
+```
+
+도구 이름, 결과, 토큰 사용량이 모두 같은데 19줄이 찍힙니다. 정보량은 제로에 가깝지만 터미널 스크롤은 빠르게 소진됩니다.
+
+## 2. 원인 분석: Batch 단위 렌더링의 한계
+
+GEODE의 tool 렌더링은 `ToolCallTracker`(배치 내)와 `EventRenderer`(배치 간)로 나뉩니다.
+
+**ToolCallTracker**: 하나의 배치 안에서 병렬 도구를 spinner + in-place update로 렌더링합니다. v0.38.0에서 batch clearing을 추가하여 이전 배치의 잔상(stale line)은 해결했습니다.
+
+```python
+# core/cli/ui/tool_tracker.py — on_tool_start()
+if not self._running and self._tools and all(t["done"] for t in self._tools):
+    self._tools.clear()
+    self._line_count = 0
+```
+
+> 이 수정으로 `sequentialthinking`의 중복 spinner 문제는 해결됐지만, **각 배치가 완료된 후 독립적으로 출력되는 문제**는 남았습니다. 배치 1의 `✓ check_status`와 배치 2의 `✓ check_status`는 별개의 완료 라인입니다.
+
+**EventRenderer**: 배치 간 이벤트(tool_start/end, tokens, thinking)를 순차 처리합니다. "이전 배치와 같은 도구가 다시 시작됐다"는 인지가 없었습니다.
+
+## 3. Repeat Counter 설계
+
+핵심 아이디어: **단일 도구 배치가 연속되면, 중간 이벤트를 억제하고 최종 요약만 출력합니다.**
+
+Before:
+```
+  ✓ memory_search → ok (0.2s)
+  ✢ claude-opus-4-6 · ↓48.1k ↑152
+  ✓ memory_search → ok (0.2s)
+  ✢ claude-opus-4-6 · ↓48.5k ↑160
+  ✓ memory_search → ok (0.2s)
+```
+
+After:
+```
+  ✓ memory_search ×3 → ok (0.6s)
+```
+
+억제 대상 이벤트:
+
+```python
+# core/cli/ui/event_renderer.py
+_REPEAT_SUPPRESSIBLE = frozenset(
+    {"tool_start", "tool_end", "tokens", "thinking_start", "thinking_end", "round_start"}
+)
+```
+
+> `tokens` 이벤트도 억제합니다. 반복 호출 사이의 토큰 사용량은 개별적으로 의미가 없으며, turn_end에서 합산 요약이 출력되기 때문입니다.
+
+## 4. 상태 머신: onset → accumulate → flush
+
+repeat counter는 3단계 상태 전이로 동작합니다.
+
+```
+                    ┌──────────────────────┐
+ tool_end           │                      │
+ (single batch) ──► │  _last_batch_tool    │
+                    │  = tool_name         │
+                    └──────────┬───────────┘
+                               │
+                    tool_start (same name)
+                               │
+                    ┌──────────▼───────────┐
+                    │  _in_repeat = True   │ ◄─── tool_end (same name)
+                    │  accumulate          │      _repeat_count += 1
+                    │  count, dur, summary │      _repeat_dur += dur
+                    └──────────┬───────────┘
+                               │
+                    tool_start (different) / stop()
+                               │
+                    ┌──────────▼───────────┐
+                    │  _flush_repeat()     │
+                    │  emit: ✓ tool ×N     │
+                    └──────────────────────┘
+```
+
+**Onset**: `_handle_tool_end`에서 단일 도구 배치(배치 크기 1)가 완료되면 `_last_batch_tool`을 기록합니다.
+
+```python
+# core/cli/ui/event_renderer.py — _handle_tool_end
+if all_done:
+    if is_single:
+        self._last_batch_tool = name
+        self._repeat_count = 1
+        self._repeat_dur = float(str(dur)) if dur else 0.0
+        self._repeat_summary = str(event.get("summary", "ok"))
+    else:
+        self._last_batch_tool = ""  # 병렬 배치는 repeat 대상 아님
+```
+
+> 병렬 배치(2개 이상 도구)는 repeat 대상이 아닙니다. `web_search` + `read_file`이 동시에 끝나는 배치와, 같은 조합의 다음 배치를 같다고 볼 수 없기 때문입니다.
+
+**Accumulate**: 다음 `tool_start`에서 같은 이름이면 repeat 모드 진입. 이벤트를 억제하고 카운터만 증가합니다.
+
+```python
+# core/cli/ui/event_renderer.py — _handle_tool_start
+if self._last_batch_tool and name == self._last_batch_tool:
+    self._in_repeat = True
+    self._repeat_name = name
+    return  # suppress this tool_start
+```
+
+**Flush**: 다른 도구가 시작되거나, `stop()`이 호출되면 누적된 요약을 출력합니다.
+
+```python
+# core/cli/ui/event_renderer.py
+def _flush_repeat(self) -> None:
+    if not self._in_repeat:
+        return
+    name = self._repeat_name
+    count = self._repeat_count
+    dur = self._repeat_dur
+    summary = self._repeat_summary
+    self._in_repeat = False
+    self._repeat_name = ""
+    self._last_batch_tool = ""
+    if count <= 1:
+        return
+    dur_str = f" ({dur:.1f}s)" if dur > 0 else ""
+    self._out.write(f"  \033[32m\u2713 {name}\033[0m \u00d7{count} \u2192 {summary}{dur_str}\n")
+    self._out.flush()
+```
+
+> `count <= 1`이면 출력하지 않습니다. 첫 번째 호출은 이미 ToolCallTracker에 의해 정상 렌더링됐기 때문입니다. 2번째부터가 repeat입니다.
+
+## 5. 정리
+
+| 항목 | Before | After |
+|------|--------|-------|
+| `check_status` ×11 | 11줄 + 11 tokens 줄 = 22줄 | 1줄: `✓ check_status ×11 → ok (1.1s)` |
+| `memory_search` ×19 | 19줄 + 19 tokens 줄 = 38줄 | 1줄: `✓ memory_search ×19 → ok (3.8s)` |
+| 병렬 배치 (3 tools) | 3줄 (정상) | 3줄 (변경 없음) |
+| `delegate_task` ×5 | 5줄 개별 표시 | 1줄: `✓ delegate_task ×5 → ok (12.3s)` |
+
+**동작하지 않는 경우** (의도적):
+- 병렬 배치: `_last_batch_tool = ""`으로 리셋
+- 다른 도구 끼어들기: flush 후 정상 렌더링
+- 첫 번째 호출: 정상 출력 (repeat는 2번째부터)
+
+**테스트 6건**: sequential repeat 진입, flush 출력 확인, 다른 도구 flush 트리거, 병렬 배치 미트리거, stop() flush, tokens 억제.

--- a/docs/plans/llm-resilience-hardening.md
+++ b/docs/plans/llm-resilience-hardening.md
@@ -1,0 +1,223 @@
+# LLM Resilience Hardening Plan
+
+## Context
+
+GEODE는 두 개의 LLM 실행 경로를 가진다:
+1. **Agentic Loop** — `while(tool_use)` 자율 실행 루프 (범용, 모든 요청)
+2. **Domain DAG** — LangGraph StateGraph 파이프라인 (도메인 분석, 8-node)
+
+두 경로 모두 happy path는 탄탄하지만, failure recovery의 중간 지점에 GAP이 있다. 이 플랜은 양측을 분할 분석하여 resilience를 보강한다.
+
+---
+
+## Current State — What Already Works
+
+### Shared Infrastructure (core/llm/)
+
+| Mechanism | Implementation | File |
+|-----------|---------------|------|
+| Fallback chain (per-provider) | Anthropic 2, OpenAI 3, GLM 3 | `core/llm/fallback.py`, `core/config.py:308-316` |
+| Retry + exponential backoff | 3 retries, 2-30s | `core/llm/fallback.py:71-165` |
+| Circuit breaker | 5 failures → 60s open → half-open | `core/llm/fallback.py:23-69` |
+| Cost tracking | Per-call cost_usd, accumulator | `core/llm/token_tracker.py` |
+| Observability hooks | LLM_CALL_START/END, MODEL_SWITCHED | `core/hooks/system.py` |
+
+### Agentic Loop (core/agent/agentic_loop.py)
+
+| Mechanism | Implementation | Lines |
+|-----------|---------------|-------|
+| Model escalation | 2 consecutive failures → next model → cross-provider | 1174-1213 |
+| Context window mgmt | 3-phase: compact→prune→exhaust (80%/95%) | 750-866 |
+| Convergence detection | 3 identical errors → escalate → 4 → break | 1265-1305 |
+| Tool error backpressure | 3+ consecutive → 1s delay + hint to LLM | 606-668 |
+| Cost budget guard | Per-round check, terminate on exceed | 564-587 |
+| Time budget guard | Karpathy P3, monotonic clock | 460-466 |
+| Session checkpoint | Per-round save (20 msg, 50 tools) | 230-248 |
+| Max rounds + wrap-up headroom | Last 2 rounds forced text-only | 462-463, 1097 |
+
+### Domain DAG (core/graph.py)
+
+| Mechanism | Implementation | Lines |
+|-----------|---------------|-------|
+| Node-level retry | 1 retry, temperature 0.5→0.3 | 146-242 |
+| SqliteSaver checkpoint | Full state persisted per-node | 552-632 |
+| Partial failure (Send API) | errors reducer, pipeline continues | state.py:269 |
+| Feedback loop | confidence < 0.7 → gather → signals (max 5 iter) | 455-509 |
+| Analyst partial retry | iteration ≥ 2: skip non-degraded | analysts.py:448-459 |
+| Graceful degradation | is_degraded=True + neutral defaults | analysts.py:222, evaluators.py:340 |
+| Dynamic graph | Extreme score → skip verification | scoring.py:549-558 |
+
+---
+
+## GAP Analysis — Two-Track
+
+### Track A: Agentic Loop GAPs
+
+| # | GAP | Severity | Root Cause |
+|---|-----|----------|-----------|
+| A1 | Backoff jitter 없음 — thundering herd risk | P0 | `fallback.py:126` deterministic delay |
+| A2 | Cost budget check advisory — exception 삼킴 | P1 | `agentic_loop.py:564` bare except |
+| A3 | Checkpoint resume 미통합 — load 경로 불명확 | P1 | CLI layer에서 호출하나 loop 내 resume 로직 없음 |
+| A4 | Sub-agent 실패 미전파 — parent 모르고 계속 | P2 | announce queue 비동기, 실패 결과 무시 |
+
+### Track B: Domain DAG GAPs
+
+| # | GAP | Severity | Root Cause |
+|---|-----|----------|-----------|
+| B1 | Node retry 소진 후 graph-level recovery 없음 | P0 | `graph.py:227` raise 후 파이프라인 중단 |
+| B2 | Node errors caller에 미전달 | P0 | `mcp_server.py:69-94` state.errors 미포함 |
+| B3 | Per-pipeline timeout 없음 | P1 | compile_graph에 timeout 파라미터 없음 |
+| B4 | Degraded 결과 스코어링 미반영 | P1 | scoring.py에서 is_degraded 미체크 |
+| B5 | Verification 실패 시 enrichment 미트리거 | P1 | `graph.py:291` 항상 confidence만 체크 |
+| B6 | Evaluator partial retry 없음 | P2 | analyst만 skip 로직 있음 |
+| B7 | iteration_history 무한 증가 | P2 | state.py:279 trimming 없음 |
+| B8 | Gather node not retryable | P2 | _RETRYABLE_NODES에 미포함 |
+
+### Track C: Shared Infrastructure GAPs
+
+| # | GAP | Severity | Root Cause |
+|---|-----|----------|-----------|
+| C1 | Cross-provider failover 미구현 (router.py level) | P0 | per-provider chain만 존재 |
+| C2 | Fallback 비용 제어 없음 | P1 | Haiku→Opus 5x 비용 상승 무제어 |
+| C3 | Test coverage 미흡 (failure scenarios) | P2 | 기존 테스트에 resilience 시나리오 부족 |
+
+---
+
+## Implementation Plan — 3 Phases
+
+### Phase 1: P0 — Outage Prevention (4 items)
+
+#### C1. Backoff Jitter (Shared)
+- **File**: `core/llm/fallback.py:126`
+- **Change**: `delay = min(base * 2^attempt, max)` → `delay = random.uniform(0, min(base * 2^attempt, max))`
+- **Effort**: 1 line
+
+#### A1 = C1 (동일 파일, jitter는 Agentic Loop과 DAG 모두에 적용)
+
+#### C1-b. Cross-Provider Failover (Shared — router.py level)
+- **File**: `core/llm/router.py` call_llm() 레벨
+- **Note**: Agentic Loop은 이미 `_try_model_escalation()`에서 `CROSS_PROVIDER_FALLBACK` 사용. 하지만 DAG의 `call_with_failover()`는 per-provider only.
+- **Change**: `retry_with_backoff_generic()`에서 per-provider chain 소진 시, `llm_cross_provider_order` 다음 프로바이더로 재시도
+- **Config**: `llm_cross_provider_failover: bool = False` (opt-in)
+- **Hook**: `FALLBACK_CROSS_PROVIDER` 이벤트
+
+#### B1. Node Retry 소진 후 Degraded Fallback (DAG)
+- **File**: `core/graph.py:227-242`
+- **Change**: retry 소진 후 `raise` 대신, degraded 결과 반환 (analyst: score=1.0, evaluator: neutral axes)
+- **Pattern**: 기존 analysts.py의 degraded fallback 패턴 재사용
+- **Effect**: 파이프라인 중단 → 파이프라인 계속 (degraded 표시)
+
+#### B2. Node Errors Caller 전달 (DAG)
+- **File**: `core/mcp_server.py` (또는 tool handler)
+- **Change**: `state["errors"]`를 output dict에 포함
+- **Format**: `"errors": ["analyst: timeout", "evaluator: validation"]`
+
+### Phase 2: P1 — Quality/Cost (5 items)
+
+#### A2. Cost Budget 강화 (Agentic Loop)
+- **File**: `core/agent/agentic_loop.py:564-587`
+- **Change**: bare except → specific exception + log.warning. Budget 초과 시 hard termination 보장.
+
+#### B3. Per-Pipeline Timeout (DAG)
+- **File**: `core/graph.py` compile_graph() / invoke()
+- **Change**: `threading.Timer` 또는 `signal.alarm`으로 invoke() 래핑
+- **Config**: `pipeline_timeout_s: float = 600.0`
+- **Fallback**: timeout 시 현재 state 스냅샷 반환 (partial result)
+
+#### B4. Degraded 결과 스코어링 페널티 (DAG)
+- **File**: `core/domains/game_ip/nodes/scoring.py`
+- **Change**: `is_degraded=True` 카운트 → confidence 페널티
+- **Formula**: `penalty = 1.0 - (degraded_count / total_count) * 0.5`
+- **Effect**: 4명 중 2명 degraded → confidence 75%
+
+#### B5. Verification 실패 → Enrichment Loop (DAG)
+- **File**: `core/graph.py:455-502` `_configured_should_continue()`
+- **Change**: `guardrails.all_passed=False OR biasbuster.overall_pass=False` → `"gather"` 반환
+- **Guard**: max_iterations 안전 밸브 유지
+
+#### C2. Fallback 비용 비율 제한 (Shared)
+- **File**: `core/llm/fallback.py`
+- **Change**: fallback 전 `next_model_price / current_model_price > ratio` 체크
+- **Config**: `llm_max_fallback_cost_ratio: float = 0.0` (0=무제한)
+
+### Phase 3: P2 — Polish (5 items)
+
+#### A3. Checkpoint Resume 통합 (Agentic Loop)
+- **File**: `core/agent/agentic_loop.py`
+- **Change**: `arun()` 진입 시 `checkpoint.load(session_id)` → messages 복원 → round_idx 이어서
+- **Guard**: checkpoint age > 72h면 무시
+
+#### A4. Sub-agent 실패 전파 (Agentic Loop)
+- **File**: `core/agent/sub_agent.py`
+- **Change**: 실패 결과에 `"error"` 필드 포함 → parent에 tool_result로 전달 → LLM이 인지
+
+#### B6. Evaluator Partial Retry (DAG)
+- **File**: `core/domains/game_ip/nodes/evaluators.py` `make_evaluator_sends()`
+- **Change**: iteration ≥ 2에서 non-degraded evaluator 스킵 (analyst 패턴 미러)
+
+#### B7. iteration_history Trimming (DAG)
+- **File**: `core/graph.py` `_gather_node()`
+- **Change**: `iteration_history[-10:]` trimming (최근 10개만 유지)
+
+#### C3. Resilience Test Suite
+- **New file**: `tests/test_llm_resilience.py`
+- **Agentic Loop tests**: model escalation, convergence break, cost budget
+- **DAG tests**: node degraded fallback, partial Send API failure, verification loop
+- **Shared tests**: jitter range, cross-provider failover, cost ratio
+
+---
+
+## Configuration Summary (core/config.py)
+
+```python
+# Shared
+llm_cross_provider_failover: bool = False
+llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
+llm_max_fallback_cost_ratio: float = 0.0  # 0 = unlimited
+
+# DAG
+pipeline_timeout_s: float = 600.0
+```
+
+## Hook Events (core/hooks/system.py)
+
+```python
+FALLBACK_CROSS_PROVIDER = "fallback_cross_provider"
+PIPELINE_TIMEOUT = "pipeline_timeout"
+COST_BUDGET_EXCEEDED = "cost_budget_exceeded"  # (기존 agentic loop에서 사용, hook으로 승격)
+```
+
+## Execution Order
+
+```
+Phase 1 (P0): C1 jitter → C1-b cross-provider → B1 degraded fallback → B2 error propagation
+Phase 2 (P1): A2 cost budget → B3 pipeline timeout → B4 degraded scoring → B5 verification loop → C2 cost ratio
+Phase 3 (P2): A3 checkpoint resume → A4 sub-agent propagation → B6 evaluator retry → B7 history trim → C3 tests
+```
+
+## Verification
+
+```bash
+uv run pytest tests/test_llm_resilience.py -v          # New tests
+uv run pytest tests/test_model_failover.py -v           # Existing regression
+uv run pytest tests/ -m "not live" -q                   # Full suite (3369+)
+uv run ruff check core/ tests/ && uv run ruff format --check core/ tests/
+uv run mypy core/
+uv run bandit -r core/ -c pyproject.toml
+```
+
+## Files Modified
+
+| Track | File | Changes |
+|-------|------|---------|
+| **Shared** | `core/llm/fallback.py` | Jitter, cross-provider, cost ratio |
+| **Shared** | `core/llm/router.py` | Cross-provider dispatch |
+| **Shared** | `core/config.py` | 4 new settings |
+| **Shared** | `core/hooks/system.py` | 3 new events |
+| **Agentic** | `core/agent/agentic_loop.py` | Cost budget hardening, checkpoint resume |
+| **Agentic** | `core/agent/sub_agent.py` | Failure propagation |
+| **DAG** | `core/graph.py` | Degraded fallback, pipeline timeout, verification loop, history trim |
+| **DAG** | `core/domains/game_ip/nodes/scoring.py` | Degraded downweighting |
+| **DAG** | `core/domains/game_ip/nodes/evaluators.py` | Partial retry |
+| **DAG** | `core/mcp_server.py` | Error propagation to caller |
+| **Test** | `tests/test_llm_resilience.py` | New — 3 tracks × 3+ tests |

--- a/docs/plans/structured-ipc-events.md
+++ b/docs/plans/structured-ipc-events.md
@@ -1,0 +1,63 @@
+# Plan: Structured IPC Events — Client-Side Direct Rendering
+
+## Frontier Research Summary
+
+| System | Pattern | Adoption |
+|--------|---------|----------|
+| Claude Code | Direct terminal rendering (no IPC) | Adapt — client renders from structured events |
+| Codex | Item-based streaming (typed events) | Adopt — each UI element is a discrete event |
+| OpenClaw | System Events Queue (coalescing) | Adapt — event protocol over Unix socket |
+
+## Problem
+
+Current thin client mixes two rendering modes:
+1. **Raw stream** (`{"type":"stream","data":"ANSI..."}`) — serve console output piped to client
+2. **Structured events** (`tool_start/tool_end`) — client renders with spinners
+
+Raw stream has no semantic structure — client can't distinguish token usage from headers from spinner frames. Client-side rendering (spinners, in-place updates, timing) is impossible for raw-streamed elements.
+
+## Design
+
+Replace raw stream for ALL agentic UI elements with typed events. Keep raw stream ONLY for Rich Panels/Tables (pipeline output).
+
+### Event Protocol
+
+| Event | Fields | Client Renders |
+|-------|--------|---------------|
+| `round_start` | `round: int` | `● AgenticLoop` header (first round only) |
+| `thinking_start` | `model: str, round: int` | Spinner: `✢ Thinking... (round N)` |
+| `thinking_end` | | Stop spinner |
+| `tool_start` | `id, name, args_preview` | `▸ name(args) ⠋` with spinner |
+| `tool_end` | `name, summary, error, duration_s` | In-place `✓ name → summary (Ns)` |
+| `tokens` | `model, input, output, cost` | `✢ model · ↓in ↑out · $cost` |
+| `turn_end` | `rounds, tools, elapsed_s, cost` | `──── 3 rounds · 8 tools · 4.2s ────` |
+| `context_event` | `action, before, after` | `⟳ Context compacted: 45 → 12` |
+| `subagent_dispatch` | `task_id, description` | `▸ delegate_task(desc)` |
+| `subagent_progress` | `completed, total, name, duration_s` | `✓ name (Ns) [1/3]` |
+| `subagent_complete` | `count, elapsed_s` | `✓ N sub-agents completed (Ns)` |
+| `session_cost` | `calls, input, output, cost, breakdown` | Cost summary on /quit |
+| `stream` | `data` | Raw ANSI passthrough (Pipeline panels) |
+| `result` | `text, rounds, ...` | Final Markdown response |
+
+### Changes
+
+**Serve side** (`core/agent/`, `core/cli/ui/agentic_ui.py`):
+- OperationLogger: all methods send events via `_ipc_writer_local` when set
+- AgenticLoop: wrap spinner start/stop, LLM token recording as events
+- Session cost: send `session_cost` event on disconnect
+
+**Client side** (`core/cli/ui/event_renderer.py` — NEW):
+- `EventRenderer` class: handles all event types
+- Manages ToolCallTracker (existing), thinking spinner, token line, turn summary
+- `_on_event(event)` dispatcher replaces current `_on_stream` + `_on_event` split
+
+**IPC** (`core/cli/ipc_client.py`):
+- `send_prompt(on_event=)` — already supports structured events
+
+## Phases
+
+1. Serve: emit structured events for C1-C7, D1-D3
+2. Client: EventRenderer with all event handlers
+3. Serve: emit events for E1-E3 (sub-agent)
+4. Serve: emit session_cost on disconnect (G1)
+5. Tests + E2E


### PR DESCRIPTION
## Summary

- 4 blog posts covering v0.37.0-v0.38.0 (LLM resilience, race conditions, SessionLane, repeat counter)
- 2 plan documents archived (llm-resilience-hardening, structured-ipc-events)

## Why

Technical blog posts documenting key architectural decisions and implementation patterns from the v0.37-v0.38 development cycle.

## Test plan
- [x] Docs only — no code changes
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)