### PR TITLE
develop → main (workload-specific gateway lane)

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-31T00:04:15+09:00 task_id=blog-posts
+session=2026-03-31T01:00:26+09:00 task_id=workload-lanes

--- a/core/config.py
+++ b/core/config.py
@@ -282,6 +282,9 @@ class Settings(BaseSettings):
     # Pipeline — timeout in seconds (B3: 0 = no timeout)
     pipeline_timeout_s: float = 600.0
 
+    # Concurrency — workload lane limits
+    gateway_max_concurrent: int = 4  # max simultaneous Gateway messages
+
 
 _settings_instance: Settings | None = None
 

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -150,9 +150,9 @@ class ChannelManager:
             content = f"[allowed_tools: {tools_hint}] {content}"
 
         try:
-            # Route through SessionLane → Global Lane (OpenClaw pattern)
+            # Route through SessionLane → Gateway Lane → Global Lane
             if self._lane_queue is not None:
-                with self._lane_queue.acquire_all(session_key, ["session", "global"]):
+                with self._lane_queue.acquire_all(session_key, ["session", "gateway", "global"]):
                     response = self._processor(content, metadata)
             else:
                 response = self._processor(content, metadata)

--- a/core/runtime_wiring/infra.py
+++ b/core/runtime_wiring/infra.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 # Default configuration
 # ---------------------------------------------------------------------------
 DEFAULT_GLOBAL_CONCURRENCY = 8
+DEFAULT_GATEWAY_CONCURRENCY = 4
 
 
 # ---------------------------------------------------------------------------
@@ -115,11 +116,23 @@ def build_default_registry() -> ToolRegistry:
 
 
 def build_default_lanes() -> LaneQueue:
-    """Build the unified LaneQueue — single concurrency gate for the entire process.
+    """Build the unified LaneQueue with workload-specific lanes.
 
-    OpenClaw pattern: SessionLane → Global Lane → Execute.
-    SessionLane provides per-key serialization (same session key → serial).
-    Global Lane provides total system capacity (max 8 concurrent).
+    OpenClaw pattern: SessionLane → Workload Lane → Global Lane → Execute.
+
+    Lane hierarchy::
+
+        SessionLane (per-key serial, max=256)
+            ↓
+        Workload Lanes (per-workload cap)
+        ├── "gateway"  (max=4)  — Slack/Discord/Telegram messages
+        └── (CLI/sub-agent use global only)
+            ↓
+        "global" (max=8) — total system capacity
+
+    Gateway messages acquire ["session", "gateway", "global"].
+    CLI/sub-agents acquire ["session", "global"] (no workload lane).
+    This prevents Gateway from starving CLI when busy.
     """
     from core.orchestration.lane_queue import SessionLane
 
@@ -131,6 +144,14 @@ def build_default_lanes() -> LaneQueue:
             timeout_s=300.0,
         )
     )
+    from core.config import settings
+
+    gw_max = (
+        settings.gateway_max_concurrent
+        if settings.gateway_max_concurrent > 0
+        else DEFAULT_GATEWAY_CONCURRENCY
+    )
+    queue.add_lane("gateway", max_concurrent=gw_max, timeout_s=30.0)
     queue.add_lane("global", max_concurrent=DEFAULT_GLOBAL_CONCURRENCY, timeout_s=30.0)
     return queue
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -396,6 +396,7 @@ class TestLaneQueueIntegration:
 
         lq = LaneQueue()
         lq.set_session_lane(SessionLane(max_sessions=10))
+        lq.add_lane("gateway", max_concurrent=4)
         lq.add_lane("global", max_concurrent=8)
 
         manager = ChannelManager(lane_queue=lq)

--- a/tests/test_lane_queue.py
+++ b/tests/test_lane_queue.py
@@ -110,6 +110,64 @@ class TestLaneQueue:
         gl = q.get_lane("global")
         assert gl is not None and gl.active_count == 0
 
+    def test_acquire_all_session_gateway_global(self):
+        """Gateway path acquires session → gateway → global (3 lanes)."""
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=10))
+        q.add_lane("gateway", max_concurrent=4)
+        q.add_lane("global", max_concurrent=8)
+
+        with q.acquire_all("slack:C01:U01", ["session", "gateway", "global"]):
+            assert q.session_lane is not None and q.session_lane.active_count == 1
+            gw = q.get_lane("gateway")
+            assert gw is not None and gw.active_count == 1
+            gl = q.get_lane("global")
+            assert gl is not None and gl.active_count == 1
+
+        # All released
+        assert q.session_lane.active_count == 0
+        gw = q.get_lane("gateway")
+        assert gw is not None and gw.active_count == 0
+        gl = q.get_lane("global")
+        assert gl is not None and gl.active_count == 0
+
+    def test_gateway_lane_caps_concurrent(self):
+        """Gateway lane (max=2) blocks 3rd concurrent gateway request."""
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=10, timeout_s=1.0))
+        q.add_lane("gateway", max_concurrent=2, timeout_s=0.1)
+        q.add_lane("global", max_concurrent=8, timeout_s=1.0)
+
+        # Fill gateway lane with 2 requests
+        with (
+            q.acquire_all("gw:1", ["session", "gateway", "global"]),
+            q.acquire_all("gw:2", ["session", "gateway", "global"]),
+        ):
+            gw = q.get_lane("gateway")
+            assert gw is not None and gw.active_count == 2
+            # 3rd gateway request should timeout
+            with (
+                pytest.raises(TimeoutError, match="gateway"),
+                q.acquire_all("gw:3", ["session", "gateway", "global"]),
+            ):
+                pass  # should not reach
+
+    def test_cli_bypasses_gateway_lane(self):
+        """CLI path uses only session + global, not gateway."""
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=10, timeout_s=1.0))
+        q.add_lane("gateway", max_concurrent=2, timeout_s=0.1)
+        q.add_lane("global", max_concurrent=8, timeout_s=1.0)
+
+        # Fill gateway lane, then prove CLI still works (bypasses gateway)
+        with (  # noqa: SIM117
+            q.acquire_all("gw:1", ["session", "gateway", "global"]),
+            q.acquire_all("gw:2", ["session", "gateway", "global"]),
+        ):
+            with q.acquire_all("cli:1", ["session", "global"]):
+                gl = q.get_lane("global")
+                assert gl is not None and gl.active_count == 3  # 2 gw + 1 cli
+
     def test_acquire_all_unknown_lane(self):
         q = LaneQueue()
         with pytest.raises(KeyError, match="not found"), q.acquire_all("job-1", ["nonexistent"]):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -223,6 +223,7 @@ class TestDefaultBuilders:
         queue = _build_default_lanes()
         assert "session" in queue.list_lanes()
         assert "global" in queue.list_lanes()
+        assert "gateway" in queue.list_lanes()
         # SessionLane (per-key serialization)
         sl = queue.session_lane
         assert sl is not None
@@ -230,9 +231,9 @@ class TestDefaultBuilders:
         # Global Lane (total capacity)
         global_lane = queue.get_lane("global")
         assert global_lane is not None and global_lane.max_concurrent == 8
-        # gateway/scheduler lanes removed (SessionLane replaces them)
-        assert queue.get_lane("gateway") is None
-        assert queue.get_lane("scheduler") is None
+        # Gateway Lane (workload-specific cap)
+        gw_lane = queue.get_lane("gateway")
+        assert gw_lane is not None and gw_lane.max_concurrent == 4
 
 
 class TestRuntimeNewComponents:


### PR DESCRIPTION
## Summary
- #566: Gateway lane (max=4) prevents CLI starvation under Gateway load

🤖 Generated with [Claude Code](https://claude.com/claude-code)