### PR TITLE
style: simplify CLI UI/UX — Claude Code-style status line

### DIFF
--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -264,18 +264,16 @@ class OperationLogger:
         return " · ".join(summary_parts) if summary_parts else "ok"
 
     def finalize(self) -> None:
-        """Print collapsed count or grouped summary.
+        """Print collapsed count summary.
 
-        When total tool count >= GROUPING_THRESHOLD (6), renders a grouped
-        summary by tool type (e.g., ``web_search (3) · memory (2) · bash (1)``).
-        Otherwise, falls back to the simple collapsed count message.
+        In IPC mode: skip (client renders individual tool lines via ToolCallTracker).
+        In direct mode: show compact aggregate count when tools exceed threshold.
         """
+        # IPC mode — client already renders per-tool ✓ lines
+        writer = getattr(_ipc_writer_local, "writer", None)
+        if writer is not None:
+            return
         if self._total_tool_count >= self.GROUPING_THRESHOLD:
-            # Grouped summary: tool_type (count) sorted by count descending
-            sorted_types = sorted(self._tool_type_counts.items(), key=lambda x: -x[1])
-            type_parts = [f"{name} ({count})" for name, count in sorted_types]
-            group_line = " · ".join(type_parts)
-            console.print(f"  ⎿ [dim]{group_line}[/dim]")
             rounds = max(self._round_count, 1)
             console.print(f"  ⎿ [dim]{self._total_tool_count} tools · {rounds} rounds[/dim]")
         elif self._collapsed_count > 0:

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -25,6 +25,14 @@ def _fmt_tokens(n: int) -> str:
     return str(n)
 
 
+def _fmt_elapsed(seconds: float) -> str:
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s"
+    m, sec = divmod(s, 60)
+    return f"{m}m {sec}s"
+
+
 class EventRenderer:
     """Dispatches IPC events to appropriate rendering handlers.
 
@@ -64,6 +72,12 @@ class EventRenderer:
         self._repeat_summary: str = ""
         self._in_repeat: bool = False
         self._last_batch_tool: str = ""  # tool name from last single-tool batch
+        # Accumulated turn metrics — rendered once at stop()
+        self._turn_start: float = time.monotonic()
+        self._turn_model: str = ""
+        self._turn_in_tokens: int = 0
+        self._turn_out_tokens: int = 0
+        self._turn_cost: float = 0.0
 
     # -- Public API -----------------------------------------------------------
 
@@ -109,7 +123,7 @@ class EventRenderer:
         self._out.flush()
 
     def stop(self) -> None:
-        """Stop all spinners. Call when result arrives."""
+        """Stop all spinners and render turn status. Call when result arrives."""
         self._flush_repeat()
         self._activity = False
         self._activity_suppressed = True
@@ -121,6 +135,8 @@ class EventRenderer:
         # Clear any leftover spinner line
         self._out.write("\r\033[2K")
         self._out.flush()
+        # Render accumulated turn status (Claude Code style)
+        self._render_turn_status()
 
     # -- Core event handlers --------------------------------------------------
 
@@ -180,34 +196,15 @@ class EventRenderer:
                 self._last_batch_tool = ""
 
     def _handle_tokens(self, event: dict[str, Any]) -> None:
-        self._suppress_all_spinners()
-        model = str(event.get("model", ""))
-        in_tok = int(event.get("input", 0))
-        out_tok = int(event.get("output", 0))
-        cost = float(event.get("cost", 0))
-        in_str = _fmt_tokens(in_tok)
-        out_str = _fmt_tokens(out_tok)
-        cost_str = f" \u00b7 ${cost:.4f}" if cost > 0 else ""
-        self._out.write(
-            f"  \033[2m\u2722 {model} \u00b7 \u2193{in_str} \u2191{out_str}{cost_str}\033[0m\n"
-        )
-        self._out.flush()
-        self._activity_suppressed = False  # resume after tokens line
+        # Accumulate per-turn — rendered once at stop() as a single status line
+        self._turn_model = str(event.get("model", "")) or self._turn_model
+        self._turn_in_tokens += int(event.get("input", 0))
+        self._turn_out_tokens += int(event.get("output", 0))
+        self._turn_cost += float(event.get("cost", 0))
 
     def _handle_turn_end(self, event: dict[str, Any]) -> None:
-        rounds = int(event.get("rounds", 0))
-        tools = int(event.get("tools", 0))
-        elapsed = float(event.get("elapsed_s", 0))
-        cost = float(event.get("cost", 0))
-        if tools == 0:
-            return
-        parts = [f"{rounds} rounds", f"{tools} tools", f"{elapsed:.1f}s"]
-        if cost > 0:
-            parts.append(f"${cost:.3f}")
-        summary = " \u00b7 ".join(parts)
-        line = f"\u2500\u2500\u2500\u2500 {summary} \u2500\u2500\u2500\u2500"
-        self._out.write(f"\n  \033[2m{line}\033[0m\n")
-        self._out.flush()
+        # Render accumulated status line (Claude Code style)
+        self._render_turn_status()
 
     def _handle_context_event(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
@@ -255,17 +252,13 @@ class EventRenderer:
         cost = float(event.get("cost", 0))
         if calls == 0:
             return
-        self._out.write("\n  \033[1mSession Cost Summary\033[0m\n")
-        self._out.write(f"  \033[2mCalls:\033[0m {calls}\n")
+        in_str = _fmt_tokens(in_tok)
+        out_str = _fmt_tokens(out_tok)
         self._out.write(
-            f"  \033[2mTokens:\033[0m \u2193{_fmt_tokens(in_tok)} \u2191{_fmt_tokens(out_tok)}\n"
+            f"\n  \033[2mSession: {calls} calls \u00b7 "
+            f"\u2193{in_str} \u2191{out_str} \u00b7 "
+            f"\033[0m\033[1;33m${cost:.4f}\033[0m\n\n"
         )
-        self._out.write(f"  \033[1;33mTotal: ${cost:.4f}\033[0m\n")
-        breakdown = event.get("breakdown", {})
-        if isinstance(breakdown, dict) and len(breakdown) > 1:
-            for m, c in sorted(breakdown.items(), key=lambda x: -x[1]):
-                self._out.write(f"    \033[2m{m}:\033[0m ${c:.4f}\n")
-        self._out.write("\n")
         self._out.flush()
 
     # -- AgenticLoop state change events --------------------------------------
@@ -509,6 +502,29 @@ class EventRenderer:
             self._out.write(f"    \033[2mAction:\033[0m {action}\n")
         self._out.write("\n")
         self._out.flush()
+
+    # -- Turn status -----------------------------------------------------------
+
+    def _render_turn_status(self) -> None:
+        """Render Claude Code-style status line: ✢ Worked for Xs · model · ↓Nk ↑Nk · $X.XX"""
+        if self._turn_in_tokens == 0 and self._turn_out_tokens == 0:
+            return
+        elapsed = time.monotonic() - self._turn_start
+        in_str = _fmt_tokens(self._turn_in_tokens)
+        out_str = _fmt_tokens(self._turn_out_tokens)
+        parts = [f"\u2722 Worked for {_fmt_elapsed(elapsed)}"]
+        if self._turn_model:
+            parts.append(self._turn_model)
+        parts.append(f"\u2193{in_str} \u2191{out_str}")
+        if self._turn_cost > 0:
+            parts.append(f"${self._turn_cost:.4f}")
+        line = " \u00b7 ".join(parts)
+        self._out.write(f"\n  \033[2m{line}\033[0m\n")
+        self._out.flush()
+        # Reset so duplicate stop() calls don't double-render
+        self._turn_in_tokens = 0
+        self._turn_out_tokens = 0
+        self._turn_cost = 0.0
 
     # -- Repeat mode helpers ---------------------------------------------------
 

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -488,7 +488,7 @@ class TestToolTypeGrouping:
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_grouping_with_mixed_types(self, mock_console) -> None:  # type: ignore[no-untyped-def]
-        """8 tool calls of mixed types produce grouped summary in finalize()."""
+        """8 tool calls of mixed types produce compact aggregate summary."""
         logger = OperationLogger()
         logger.begin_round()
         # 3 web_search + 2 memory_search + 2 bash + 1 analyze_ip = 8
@@ -505,17 +505,13 @@ class TestToolTypeGrouping:
         calls = [str(c) for c in mock_console.print.call_args_list]
         combined = " ".join(calls)
 
-        # Should show grouped summary
-        assert "web_search (3)" in combined
-        assert "memory_search (2)" in combined
-        assert "run_bash (2)" in combined
-        assert "analyze_ip (1)" in combined
+        # Should show compact aggregate (no per-type breakdown)
         assert "8 tools" in combined
         assert "1 rounds" in combined
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_grouping_sorted_by_count(self, mock_console) -> None:  # type: ignore[no-untyped-def]
-        """Grouped types are sorted by count descending."""
+        """6+ tools produce compact aggregate summary."""
         logger = OperationLogger()
         logger.begin_round()
         # 1 alpha + 4 beta + 1 gamma = 6
@@ -529,11 +525,9 @@ class TestToolTypeGrouping:
         calls = [str(c) for c in mock_console.print.call_args_list]
         combined = " ".join(calls)
 
-        # beta should come first (4 > 1)
-        assert "beta (4)" in combined
-        beta_pos = combined.index("beta (4)")
-        alpha_pos = combined.index("alpha (1)")
-        assert beta_pos < alpha_pos
+        # Compact: just total count
+        assert "6 tools" in combined
+        assert "1 rounds" in combined
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_below_grouping_threshold_no_summary(self, mock_console) -> None:  # type: ignore[no-untyped-def]
@@ -549,7 +543,7 @@ class TestToolTypeGrouping:
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_exactly_6_tools_triggers_grouping(self, mock_console) -> None:  # type: ignore[no-untyped-def]
-        """Exactly 6 tools (GROUPING_THRESHOLD) triggers grouping."""
+        """Exactly 6 tools (GROUPING_THRESHOLD) triggers compact summary."""
         logger = OperationLogger()
         logger.begin_round()
         for i in range(6):
@@ -560,7 +554,6 @@ class TestToolTypeGrouping:
         calls = [str(c) for c in mock_console.print.call_args_list]
         combined = " ".join(calls)
 
-        assert "web_search (6)" in combined
         assert "6 tools" in combined
 
     @patch("core.cli.ui.agentic_ui.console")


### PR DESCRIPTION
## Summary
- tokens 표시를 매 라운드 출력에서 턴 종료 시 단일 status line으로 통합
- OperationLogger.finalize()에 IPC 가드 추가 + per-tool type breakdown 제거
- session_cost를 4줄 breakdown에서 1줄 compact format으로 간소화

## Why
기존 UI가 tool 실행 중 빈 화면(spinner만) 후 마지막에 장황한 사용 내역을 나열하는 패턴. Claude Code UI/UX 참고하여 심플하게 정리.

## Changes
| 항목 | Before | After |
|------|--------|-------|
| 토큰 | 매 라운드 `✢ model · ↓1.2k ↑350` | 턴 끝 1줄 `✢ Worked for 4s · model · ↓5.2k ↑1.8k · $0.12` |
| 턴 종료 | `──── rounds · tools · time ────` | status line으로 통합 |
| 도구 요약 | per-tool type breakdown 2줄 | IPC: 제거, Direct: 1줄 aggregate |
| 세션 비용 | 4줄 + 모델별 breakdown | 1줄 compact |

## Test plan
- [x] `uv run pytest tests/test_agentic_ui.py tests/test_event_schema_v2.py` — 102 passed
- [x] `uv run pytest tests/ -m "not live"` — 3501 passed
- [x] `uv run ruff check` — 0 errors
- [x] `uv run mypy` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)