### PR TITLE
fix: ToolCallTracker cursor-up interference with pipeline events

### DIFF
--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -376,7 +376,7 @@ class EventRenderer:
     # -- Pipeline milestone events (client-side rendering) --------------------
 
     def _handle_pipeline_header(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         ip = str(event.get("ip_name", ""))
         mode = str(event.get("pipeline_mode", ""))
         model = str(event.get("model", ""))
@@ -387,7 +387,7 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_pipeline_gather(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         name = str(event.get("ip_name", ""))
         year = event.get("release_year", "")
         media = str(event.get("media_type", ""))
@@ -407,7 +407,7 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_pipeline_analysis(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         analysts = event.get("analysts", [])
         self._out.write(f"  \033[36;1m\u25b8 ANALYZE\033[0m {len(analysts)} analysts\n")
         for a in analysts:
@@ -419,7 +419,7 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_pipeline_evaluation(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         evals = event.get("evaluators", {})
         self._out.write(f"  \033[36;1m\u25b8 EVALUATE\033[0m {len(evals)} evaluators\n")
         if isinstance(evals, dict):
@@ -439,7 +439,7 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_pipeline_score(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         score = float(event.get("final_score", 0))
         tier = str(event.get("tier", "?"))
         conf = float(event.get("confidence", 0))
@@ -459,14 +459,14 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_pipeline_verification(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         g = "\033[32m\u2713\033[0m" if event.get("guardrails_pass") else "\033[31m\u2717\033[0m"
         b = "\033[32m\u2713\033[0m" if event.get("biasbuster_pass") else "\033[31m\u2717\033[0m"
         self._out.write(f"  \033[36;1m\u25b8 VERIFY\033[0m Guardrails {g} | BiasBuster {b}\n")
         self._out.flush()
 
     def _handle_feedback_loop(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         iteration = int(event.get("iteration", 0))
         conf = float(event.get("confidence", 0))
         threshold = float(event.get("threshold", 0))
@@ -477,14 +477,14 @@ class EventRenderer:
         self._out.flush()
 
     def _handle_node_skipped(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         node = str(event.get("node", ""))
         reason = str(event.get("reason", ""))
         self._out.write(f"  \033[2m\u2933 Skipped: {node} ({reason})\033[0m\n")
         self._out.flush()
 
     def _handle_pipeline_result(self, event: dict[str, Any]) -> None:
-        self._clear_activity_line()
+        self._suppress_all_spinners()
         tier = str(event.get("tier", "?"))
         score = float(event.get("final_score", 0))
         cause = str(event.get("cause", ""))
@@ -587,7 +587,7 @@ class EventRenderer:
         """Stop thinking + tool spinners, clear line for new content."""
         self._activity_suppressed = True
         self._stop_thinking()
-        self._tool_tracker.stop()
+        self._tool_tracker.suspend()
         self._out.write("\r\033[2K")
         self._out.flush()
 

--- a/core/cli/ui/tool_tracker.py
+++ b/core/cli/ui/tool_tracker.py
@@ -106,6 +106,28 @@ class ToolCallTracker:
         with self._lock:
             self._redraw()
 
+    def suspend(self) -> None:
+        """Stop animation and erase rendered lines. Resets cursor position.
+
+        Tools remain tracked. When ``on_tool_end`` is called later,
+        the completion line prints at the current cursor position
+        (no cursor-up) to avoid overwriting interleaved output.
+
+        Idempotent: second call is a no-op.
+        """
+        self._running = False
+        if self._spinner_thread:
+            self._spinner_thread.join(timeout=0.3)
+            self._spinner_thread = None
+        with self._lock:
+            if self._line_count > 0:
+                out = sys.stdout
+                for _ in range(self._line_count):
+                    out.write("\033[A\033[2K")
+                out.write("\r")
+                out.flush()
+            self._line_count = 0
+
     def _animate(self) -> None:
         while self._running:
             with self._lock:

--- a/tests/test_event_schema_v2.py
+++ b/tests/test_event_schema_v2.py
@@ -304,6 +304,41 @@ class TestEventRendererV2:
         renderer.on_event({"type": "node_skipped", "node": "verification", "reason": "skip"})
         assert "verification" in renderer._out.getvalue()
 
+    def test_pipeline_event_suspends_tracker(self, renderer) -> None:
+        """Pipeline events suspend the tool tracker to prevent cursor-up interference."""
+        # Simulate tool_start for analyze_ip
+        renderer._tool_tracker.on_tool_start(
+            {"name": "analyze_ip", "args_preview": 'ip_name="Berserk"'}
+        )
+        assert renderer._tool_tracker._line_count > 0
+
+        # Pipeline event should suspend tracker
+        renderer.on_event(
+            {
+                "type": "pipeline_header",
+                "ip_name": "Berserk",
+                "pipeline_mode": "full_pipeline",
+                "model": "claude-opus-4-6",
+                "version": "0.38.0",
+            }
+        )
+        # Tracker line_count reset — no stale cursor-up
+        assert renderer._tool_tracker._line_count == 0
+        assert not renderer._tool_tracker._running
+        # Pipeline output was written
+        assert "Berserk" in renderer._out.getvalue()
+
+    def test_stream_suspends_tracker(self, renderer) -> None:
+        """on_stream() suspends the tool tracker before writing stream data."""
+        renderer._tool_tracker.on_tool_start(
+            {"name": "list_ips", "args_preview": ""}
+        )
+        assert renderer._tool_tracker._line_count > 0
+
+        renderer.on_stream("  Available IPs\n  - Berserk\n")
+        assert renderer._tool_tracker._line_count == 0
+        assert "Berserk" in renderer._out.getvalue()
+
 
 class TestIPCClientEventWhitelist:
     """All 28 event types are in IPCClient's event whitelist."""

--- a/tests/test_event_schema_v2.py
+++ b/tests/test_event_schema_v2.py
@@ -330,9 +330,7 @@ class TestEventRendererV2:
 
     def test_stream_suspends_tracker(self, renderer) -> None:
         """on_stream() suspends the tool tracker before writing stream data."""
-        renderer._tool_tracker.on_tool_start(
-            {"name": "list_ips", "args_preview": ""}
-        )
+        renderer._tool_tracker.on_tool_start({"name": "list_ips", "args_preview": ""})
         assert renderer._tool_tracker._line_count > 0
 
         renderer.on_stream("  Available IPs\n  - Berserk\n")

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -695,6 +695,41 @@ class TestCostRatioGuard:
         assert len(tracker._tools) == 2
         tracker.stop()
 
+    def test_suspend_resets_line_count(self) -> None:
+        """suspend() erases lines and resets _line_count so on_tool_end prints at cursor."""
+        from core.cli.ui.tool_tracker import ToolCallTracker
+
+        tracker = ToolCallTracker()
+        tracker.on_tool_start({"name": "analyze_ip", "args_preview": 'ip_name="Berserk"'})
+        assert tracker._line_count > 0
+        assert tracker._running
+
+        # Suspend — simulates pipeline event arriving mid-tool
+        tracker.suspend()
+        assert tracker._line_count == 0
+        assert not tracker._running
+        assert tracker._spinner_thread is None
+
+        # on_tool_end after suspend — should not cursor-up (line_count=0)
+        tracker.on_tool_end({"name": "analyze_ip", "summary": "S · 81.2", "duration_s": 3.5})
+        assert tracker._tools[0]["done"] is True
+        # line_count should be 1 (the ✓ line, printed at current position)
+        assert tracker._line_count == 1
+
+    def test_suspend_idempotent(self) -> None:
+        """Second suspend() call is a no-op."""
+        from core.cli.ui.tool_tracker import ToolCallTracker
+
+        tracker = ToolCallTracker()
+        tracker.on_tool_start({"name": "list_ips", "args_preview": ""})
+        tracker.suspend()
+        assert tracker._line_count == 0
+        # Second call — should not raise or change state
+        tracker.suspend()
+        assert tracker._line_count == 0
+        assert tracker._spinner_thread is None
+        tracker.stop()
+
     def test_cost_ratio_skip(self) -> None:
         """When ratio exceeds limit, fallback model is skipped."""
         from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic


### PR DESCRIPTION
## Summary

- `ToolCallTracker.suspend()` 추가 — animation 정지 + 렌더 줄 삭제 + `_line_count` 리셋
- `EventRenderer._suppress_all_spinners()`: `stop()` → `suspend()` 변경으로 stale cursor-up 방지
- 9개 pipeline 핸들러: `_clear_activity_line()` → `_suppress_all_spinners()`로 변경

## Why

ToolCallTracker가 ANSI cursor-up (`\033[{N}A`)으로 spinner를 in-place 업데이트하는데, pipeline events나 stream data가 사이에 끼어들면 `_line_count`가 틀어져서 외부 출력을 파괴합니다.

3가지 사용자 보고 문제:
1. `list_ips` stream: 매 chunk마다 `stop()` → spinner 재출력 (32줄 중복)
2. `analyze_ip` pipeline: spinner thread가 pipeline panel 출력 덮어쓰기
3. Pipeline Rich Panel: stale cursor-up이 interleaved event 출력 삭제

## Test plan

- [x] `test_suspend_resets_line_count` — suspend() 후 `_line_count=0`, `on_tool_end` 정상 동작
- [x] `test_suspend_idempotent` — 이중 호출 안전성
- [x] `test_pipeline_event_suspends_tracker` — pipeline event가 tracker suspend
- [x] `test_stream_suspends_tracker` — `on_stream`이 tracker suspend
- [x] 기존 140 테스트 통과 (agentic_ui + event_schema_v2 + llm_resilience)
- [x] 전체 3508 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)