### PR TITLE
feat: IPC pipeline event parity + stub insight removal

### DIFF
--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from core.cli.ui.console import console
 from core.cli.ui.panels import (
+    _is_ipc,
     analyst_panel,
     evaluator_panel,
     gather_panel,
@@ -444,7 +445,10 @@ def _render_verification(result: dict[str, Any], *, verbose: bool) -> None:
     biasbuster = result.get("biasbuster")
     g_pass = guardrails.all_passed if guardrails else False
     b_pass = biasbuster.overall_pass if biasbuster else False
-    verify_panel(g_pass, b_pass)
+    fail_details: list[str] = []
+    if guardrails and not g_pass:
+        fail_details = [d for d in guardrails.details if "FAIL" in d]
+    verify_panel(g_pass, b_pass, details=fail_details)
     if guardrails and not g_pass:
         for detail in guardrails.details:
             if "FAIL" in detail:
@@ -463,11 +467,16 @@ def _render_result(result: dict[str, Any], *, skip_verification: bool, verbose: 
     _render_data_panels(result)
     if not skip_verification:
         _render_verification(result, verbose=verbose)
-    if result.get("synthesis"):
-        result_panel(result.get("tier", "?"), result.get("final_score", 0), result["synthesis"])
-    # Surface accumulated pipeline errors
     errors = result.get("errors", [])
-    if errors:
+    if result.get("synthesis"):
+        result_panel(
+            result.get("tier", "?"),
+            result.get("final_score", 0),
+            result["synthesis"],
+            errors=errors,
+        )
+    # Surface accumulated pipeline errors (direct mode only — IPC receives via event)
+    if errors and not _is_ipc():
         console.print(f"  [warning]Pipeline warnings ({len(errors)}):[/warning]")
         for err in errors:
             console.print(f"    [warning]- {err}[/warning]")
@@ -547,6 +556,11 @@ def _run_analysis(
 
     # Use the resolved fixture key for downstream operations
     ip_name = resolved
+
+    # Tag pipeline events with IP name (thread-safe, for future parallel UI)
+    from core.cli.ui.agentic_ui import set_pipeline_ip
+
+    set_pipeline_ip(ip_name)
 
     model = "dry-run (no LLM)" if dry_run else settings.model
     pipeline_mode = "full_pipeline"

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -48,6 +48,7 @@ def _get_pipeline_ip() -> str:
     """Get the current pipeline's IP name."""
     return getattr(_pipeline_ip_local, "ip_name", "")
 
+
 # ───────────────────────────────────────────────────────────────────────────
 # SessionMeter — session-level timing for status line
 # ───────────────────────────────────────────────────────────────────────────

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -33,6 +33,21 @@ from core.cli.ui.console import console
 # thin client to render per-tool spinners with in-place ✓ updates.
 _ipc_writer_local = threading.local()
 
+# Thread-local pipeline IP name for forward-compatible event tagging.
+# Set by _run_analysis() before pipeline execution; read by emit_pipeline_*
+# functions to tag events with the originating IP (for future parallel UI).
+_pipeline_ip_local = threading.local()
+
+
+def set_pipeline_ip(ip_name: str) -> None:
+    """Set the current pipeline's IP name (thread-safe)."""
+    _pipeline_ip_local.ip_name = ip_name
+
+
+def _get_pipeline_ip() -> str:
+    """Get the current pipeline's IP name."""
+    return getattr(_pipeline_ip_local, "ip_name", "")
+
 # ───────────────────────────────────────────────────────────────────────────
 # SessionMeter — session-level timing for status line
 # ───────────────────────────────────────────────────────────────────────────
@@ -814,11 +829,16 @@ def emit_checkpoint_saved(session_id: str, round_idx: int) -> None:
 # ───────────────────────────────────────────────────────────────────────────
 
 
-def emit_pipeline_gather(ip_info: dict[str, Any], monolake: dict[str, Any]) -> None:
-    """Emit pipeline_gather event with structured IP metadata."""
+def emit_pipeline_gather(
+    ip_info: dict[str, Any],
+    monolake: dict[str, Any],
+    signals: dict[str, Any] | None = None,
+) -> None:
+    """Emit pipeline_gather event with structured IP metadata + signals."""
     writer = getattr(_ipc_writer_local, "writer", None)
     if writer is None:
         return
+    sig = signals or {}
     writer.send_event(
         "pipeline_gather",
         ip_name=ip_info.get("ip_name", ""),
@@ -827,6 +847,9 @@ def emit_pipeline_gather(ip_info: dict[str, Any], monolake: dict[str, Any]) -> N
         studio=ip_info.get("studio", ""),
         dau=monolake.get("dau_current", 0),
         revenue=monolake.get("revenue_ltm", 0),
+        youtube_views=sig.get("youtube_views", 0),
+        reddit_subscribers=sig.get("reddit_subscribers", 0),
+        fan_art_yoy_pct=sig.get("fan_art_yoy_pct", 0),
     )
 
 
@@ -866,6 +889,8 @@ def emit_pipeline_score(
     subscores: dict[str, float],
     confidence: float,
     tier: str,
+    *,
+    psm: Any | None = None,
 ) -> None:
     """Emit pipeline_score event with PSM results."""
     writer = getattr(_ipc_writer_local, "writer", None)
@@ -877,11 +902,19 @@ def emit_pipeline_score(
         subscores=subscores,
         confidence=confidence,
         tier=tier,
+        att_pct=getattr(psm, "att_pct", 0) if psm else 0,
+        z_value=getattr(psm, "z_value", 0) if psm else 0,
+        rosenbaum_gamma=getattr(psm, "rosenbaum_gamma", 0) if psm else 0,
     )
 
 
-def emit_pipeline_verification(guardrails_pass: bool, biasbuster_pass: bool) -> None:
-    """Emit pipeline_verification event."""
+def emit_pipeline_verification(
+    guardrails_pass: bool,
+    biasbuster_pass: bool,
+    *,
+    details: list[str] | None = None,
+) -> None:
+    """Emit pipeline_verification event with optional failure details."""
     writer = getattr(_ipc_writer_local, "writer", None)
     if writer is None:
         return
@@ -889,6 +922,7 @@ def emit_pipeline_verification(guardrails_pass: bool, biasbuster_pass: bool) -> 
         "pipeline_verification",
         guardrails_pass=guardrails_pass,
         biasbuster_pass=biasbuster_pass,
+        details=details or [],
     )
 
 

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -404,6 +404,15 @@ class EventRenderer:
             dau_s = f"{dau:,}" if dau else "n/a"
             rev_s = f"${rev:,}" if rev else "n/a"
             self._out.write(f"    \033[2mDAU={dau_s} | Revenue={rev_s}\033[0m\n")
+        yt = int(event.get("youtube_views", 0))
+        rd = int(event.get("reddit_subscribers", 0))
+        fa = float(event.get("fan_art_yoy_pct", 0))
+        if yt or rd:
+            yt_s = f"{yt // 1_000_000}M" if yt >= 1_000_000 else f"{yt:,}"
+            rd_s = f"{rd // 1000}K" if rd >= 1000 else f"{rd:,}"
+            self._out.write(
+                f"    \033[2mYouTube {yt_s} | Reddit {rd_s} | FanArt {fa:+.0f}%\033[0m\n"
+            )
         self._out.flush()
 
     def _handle_pipeline_analysis(self, event: dict[str, Any]) -> None:
@@ -452,6 +461,17 @@ class EventRenderer:
         if conf > 0:
             self._out.write(f" \u00b7 confidence {conf:.1f}%")
         self._out.write("\n")
+        # PSM causal inference
+        att = float(event.get("att_pct", 0))
+        z = float(event.get("z_value", 0))
+        gamma = float(event.get("rosenbaum_gamma", 0))
+        if att or z:
+            z_ok = "\033[32m\u2713\033[0m" if z > 1.645 else "\033[31m\u2717\033[0m"
+            g_ok = "\033[32m\u2713\033[0m" if gamma <= 2.0 else "\033[31m\u2717\033[0m"
+            self._out.write(
+                f"    \033[2mPSM: ATT={att:+.1f}% | Z={z:.2f} ({z_ok}>1.645)"
+                f" | \u0393={gamma:.1f} ({g_ok}\u22642.0)\033[0m\n"
+            )
         # Subscores
         if isinstance(subscores, dict) and subscores:
             parts = [f"{k}={v:.1f}" for k, v in subscores.items()]
@@ -463,6 +483,9 @@ class EventRenderer:
         g = "\033[32m\u2713\033[0m" if event.get("guardrails_pass") else "\033[31m\u2717\033[0m"
         b = "\033[32m\u2713\033[0m" if event.get("biasbuster_pass") else "\033[31m\u2717\033[0m"
         self._out.write(f"  \033[36;1m\u25b8 VERIFY\033[0m Guardrails {g} | BiasBuster {b}\n")
+        details = event.get("details", [])
+        for d in details[:3]:
+            self._out.write(f"    \033[33m- {d}\033[0m\n")
         self._out.flush()
 
     def _handle_feedback_loop(self, event: dict[str, Any]) -> None:
@@ -500,6 +523,11 @@ class EventRenderer:
             self._out.write(f"    \033[2mTarget:\033[0m {segment}\n")
         if action:
             self._out.write(f"    \033[2mAction:\033[0m {action}\n")
+        errors = event.get("errors", [])
+        if errors:
+            self._out.write(f"    \033[1;33m\u26a0 {len(errors)} warnings\033[0m\n")
+            for err in errors[:5]:
+                self._out.write(f"      \033[33m- {err}\033[0m\n")
         self._out.write("\n")
         self._out.flush()
 

--- a/core/cli/ui/panels.py
+++ b/core/cli/ui/panels.py
@@ -65,7 +65,7 @@ def gather_panel(
     from core.cli.ui.agentic_ui import emit_pipeline_gather
 
     if _is_ipc():
-        emit_pipeline_gather(ip_info, monolake)
+        emit_pipeline_gather(ip_info, monolake, signals)
         return
 
     console.print("[step]\u25b8 [GATHER][/step] Loading IP data from MonoLake...")
@@ -166,7 +166,7 @@ def score_panel(
     )
 
     if _is_ipc():
-        emit_pipeline_score(final_score, subscores, confidence, tier)
+        emit_pipeline_score(final_score, subscores, confidence, tier, psm=psm)
         return
 
     console.print("[step]\u25b8 [SCORE][/step] PSM + Final Calculation")
@@ -195,11 +195,16 @@ def score_panel(
     console.print()
 
 
-def verify_panel(guardrails_pass: bool, biasbuster_pass: bool) -> None:
+def verify_panel(
+    guardrails_pass: bool,
+    biasbuster_pass: bool,
+    *,
+    details: list[str] | None = None,
+) -> None:
     from core.cli.ui.agentic_ui import emit_pipeline_verification
 
     if _is_ipc():
-        emit_pipeline_verification(guardrails_pass, biasbuster_pass)
+        emit_pipeline_verification(guardrails_pass, biasbuster_pass, details=details)
         return
 
     g_mark = "[success]\u2713[/success]" if guardrails_pass else "[error]\u2717[/error]"
@@ -212,6 +217,8 @@ def result_panel(
     tier: str,
     final_score: float,
     synthesis: SynthesisResult,
+    *,
+    errors: list[str] | None = None,
 ) -> None:
     if _is_ipc():
         from core.cli.ui.agentic_ui import _ipc_writer_local
@@ -226,6 +233,7 @@ def result_panel(
                 narrative=synthesis.value_narrative[:200],
                 target_segment=synthesis.target_segment,
                 action=synthesis.action_type,
+                errors=errors or [],
             )
         return
 

--- a/core/runtime_wiring/automation.py
+++ b/core/runtime_wiring/automation.py
@@ -229,28 +229,7 @@ def wire_automation_hooks(
         priority=80,
     )
 
-    # Memory write-back: pipeline end -> add_insight to MEMORY.md (P0 auto-learning)
-    def _on_pipeline_end_memory(event: HookEvent, data: dict[str, Any]) -> None:
-        if project_memory is None:
-            return
-        if data.get("dry_run", False):
-            return  # dry_run은 기록하지 않음
-        ip = data.get("ip_name") or "unknown"
-        tier = data.get("tier") or "?"
-        score = data.get("final_score") or 0.0
-        cause = data.get("synthesis_cause", "")
-        action = data.get("synthesis_action", "")
-        insight = f"[{ip}] tier={tier}, score={score:.2f}"
-        if cause:
-            insight += f", cause={cause}"
-        if action:
-            insight += f", action={action}"
-        if not project_memory.add_insight(insight):
-            log.warning("Failed to write insight for IP=%s", ip)
-
-    hooks.register(
-        HookEvent.PIPELINE_END,
-        _on_pipeline_end_memory,
-        name="memory_write_back",
-        priority=85,
-    )
+    # Memory write-back removed: PIPELINE_END hook produced broken stub entries
+    # (tier=?, score=0.00) because effective_state in synthesizer node didn't
+    # reliably contain scoring results. Pipeline results are already recorded
+    # in journal (runs.jsonl) via journal_hooks.

--- a/tests/test_event_schema_v2.py
+++ b/tests/test_event_schema_v2.py
@@ -161,6 +161,9 @@ class TestPipelineEmitters:
             subscores={"psm": 85.0},
             confidence=92.0,
             tier="S",
+            att_pct=0,
+            z_value=0,
+            rosenbaum_gamma=0,
         )
 
     def test_emit_feedback_loop(self) -> None:
@@ -192,6 +195,7 @@ class TestPipelineEmitters:
             "pipeline_verification",
             guardrails_pass=True,
             biasbuster_pass=False,
+            details=[],
         )
 
     def test_no_writer_no_crash(self) -> None:
@@ -259,6 +263,22 @@ class TestEventRendererV2:
         renderer.on_event({"type": "pipeline_gather", "ip_name": "Berserk", "release_year": 1989})
         assert "Berserk" in renderer._out.getvalue()
 
+    def test_pipeline_gather_signals(self, renderer) -> None:
+        """G1: Signals (YouTube/Reddit/FanArt) rendered in gather event."""
+        renderer.on_event(
+            {
+                "type": "pipeline_gather",
+                "ip_name": "Berserk",
+                "youtube_views": 15_000_000,
+                "reddit_subscribers": 89_000,
+                "fan_art_yoy_pct": 12.5,
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "YouTube 15M" in out
+        assert "Reddit 89K" in out
+        assert "+12%" in out
+
     def test_pipeline_analysis(self, renderer) -> None:
         renderer.on_event(
             {
@@ -286,13 +306,44 @@ class TestEventRendererV2:
         )
         assert "S" in renderer._out.getvalue()
 
+    def test_pipeline_score_psm(self, renderer) -> None:
+        """G2: PSM details (ATT/Z/Gamma) rendered in score event."""
+        renderer.on_event(
+            {
+                "type": "pipeline_score",
+                "final_score": 81.2,
+                "tier": "S",
+                "att_pct": 31.2,
+                "z_value": 2.45,
+                "rosenbaum_gamma": 1.8,
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "ATT=+31.2%" in out
+        assert "Z=2.45" in out
+        assert "1.8" in out
+
     def test_pipeline_verification(self, renderer) -> None:
         renderer.on_event(
             {"type": "pipeline_verification", "guardrails_pass": True, "biasbuster_pass": False}
         )
         out = renderer._out.getvalue()
-        assert "✓" in out
-        assert "✗" in out
+        assert "\u2713" in out
+        assert "\u2717" in out
+
+    def test_pipeline_verification_details(self, renderer) -> None:
+        """G4: Guardrail failure details rendered in verification event."""
+        renderer.on_event(
+            {
+                "type": "pipeline_verification",
+                "guardrails_pass": False,
+                "biasbuster_pass": True,
+                "details": ["G2 FAIL: score out of range", "G3 FAIL: grounding < 0.5"],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "G2 FAIL" in out
+        assert "G3 FAIL" in out
 
     def test_feedback_loop(self, renderer) -> None:
         renderer.on_event(
@@ -303,6 +354,21 @@ class TestEventRendererV2:
     def test_node_skipped(self, renderer) -> None:
         renderer.on_event({"type": "node_skipped", "node": "verification", "reason": "skip"})
         assert "verification" in renderer._out.getvalue()
+
+    def test_pipeline_result_errors(self, renderer) -> None:
+        """G3: Pipeline errors rendered in result event."""
+        renderer.on_event(
+            {
+                "type": "pipeline_result",
+                "tier": "A",
+                "final_score": 68.4,
+                "cause": "undermarketed",
+                "errors": ["Analyst timeout: growth_potential", "Evaluator retry: quality_judge"],
+            }
+        )
+        out = renderer._out.getvalue()
+        assert "2 warnings" in out
+        assert "Analyst timeout" in out
 
     def test_pipeline_event_suspends_tracker(self, renderer) -> None:
         """Pipeline events suspend the tool tracker to prevent cursor-up interference."""

--- a/tests/test_memory_writeback.py
+++ b/tests/test_memory_writeback.py
@@ -21,66 +21,13 @@ def _make_hooks_and_memory(
 
 
 class TestPipelineEndMemoryWrite:
-    def test_pipeline_end_triggers_memory_write(self, tmp_path: Path):
-        """PIPELINE_END handler calls add_insight() with enriched data."""
-        hooks, mem = _make_hooks_and_memory(tmp_path)
-
-        build_automation(
-            hooks=hooks,
-            session_key="test-session",
-            ip_name="Berserk",
-            project_memory=mem,
-        )
-
-        # Simulate PIPELINE_END with enriched data
-        hooks.trigger(
-            HookEvent.PIPELINE_END,
-            {
-                "node": "synthesizer",
-                "ip_name": "Berserk",
-                "final_score": 0.85,
-                "tier": "S",
-                "synthesis_cause": "conversion_failure",
-                "synthesis_action": "marketing_push",
-                "dry_run": False,
-            },
-        )
-
-        content = mem.memory_file.read_text(encoding="utf-8")
-        assert "Berserk" in content
-        assert "tier=S" in content
-        assert "score=0.85" in content
-        assert "cause=conversion_failure" in content
-        assert "action=marketing_push" in content
-
-    def test_dry_run_skips_memory_write(self, tmp_path: Path):
-        """dry_run=True → add_insight() is NOT called."""
-        hooks, mem = _make_hooks_and_memory(tmp_path)
-
-        build_automation(
-            hooks=hooks,
-            session_key="test-session",
-            ip_name="Berserk",
-            project_memory=mem,
-        )
-
-        hooks.trigger(
-            HookEvent.PIPELINE_END,
-            {
-                "node": "synthesizer",
-                "ip_name": "Berserk",
-                "final_score": 0.85,
-                "tier": "S",
-                "dry_run": True,
-            },
-        )
-
-        content = mem.memory_file.read_text(encoding="utf-8")
-        # The insight section should be empty (only the header from ensure_structure)
-        assert "tier=S" not in content
+    """Memory write-back hook was removed (generated broken tier=?/score=0.00 entries).
+    Pipeline results are recorded in journal (runs.jsonl) via journal_hooks.
+    Remaining tests verify the hook registration doesn't crash without the callback.
+    """
 
     def test_no_project_memory_does_not_crash(self, tmp_path: Path):
-        """project_memory=None → handler is a no-op, no error."""
+        """project_memory=None → no error."""
         hooks = HookSystem()
 
         build_automation(
@@ -101,30 +48,6 @@ class TestPipelineEndMemoryWrite:
                 "dry_run": False,
             },
         )
-
-    def test_minimal_hook_data_still_writes(self, tmp_path: Path):
-        """Missing optional fields → insight still written with defaults."""
-        hooks, mem = _make_hooks_and_memory(tmp_path)
-
-        build_automation(
-            hooks=hooks,
-            session_key="test-session",
-            ip_name="TestIP",
-            project_memory=mem,
-        )
-
-        hooks.trigger(
-            HookEvent.PIPELINE_END,
-            {
-                "node": "synthesizer",
-                "ip_name": "TestIP",
-            },
-        )
-
-        content = mem.memory_file.read_text(encoding="utf-8")
-        assert "TestIP" in content
-        assert "tier=?" in content
-        assert "score=0.00" in content
 
 
 class TestEnrichedHookData:


### PR DESCRIPTION
## Summary

- **G1**: `pipeline_gather` 이벤트에 signals 추가 (YouTube/Reddit/FanArt)
- **G2**: `pipeline_score` 이벤트에 PSM 추가 (ATT%/Z-value/Rosenbaum Gamma)
- **G3**: `pipeline_result` 이벤트에 errors 추가 (pipeline warnings)
- **G4**: `pipeline_verification` 이벤트에 details 추가 (guardrail failure messages)
- **Stub 삭제**: `PIPELINE_END→add_insight` hook 제거 — `tier=?/score=0.00` 더미 데이터 생성 원인
- **ip_name 태깅**: `threading.local()` 기반 `set_pipeline_ip()` 추가 — 병렬 UI(Option B) 준비

## Why

IPC thin client에서 Direct CLI 대비 4가지 정보 누락. 동일 파이프라인에서 Direct CLI는 signals/PSM/errors/verify details를 표시하지만 IPC 이벤트에서는 전송하지 않아 thin client 사용자에게 정보 손실 발생.

Stub insight hook은 synthesizer 노드 입력 state에서 scoring 결과를 못 읽어 `tier=?/score=0.00` 엔트리를 계속 생성.

## Test plan

- [x] `test_pipeline_gather_signals` — YouTube 15M, Reddit 89K, FanArt +12% 렌더링
- [x] `test_pipeline_score_psm` — ATT=+31.2%, Z=2.45, Γ=1.8 렌더링
- [x] `test_pipeline_result_errors` — ⚠ 2 warnings 렌더링
- [x] `test_pipeline_verification_details` — G2/G3 FAIL 상세 렌더링
- [x] 기존 emit 테스트 업데이트 (새 필드 반영)
- [x] memory_writeback 테스트 정리 (제거된 hook 반영)
- [x] 전체 3509 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)