### PR TITLE
fix: Gateway context overflow recovery + UI polish

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -102,6 +102,44 @@ class _ContextExhaustedError(Exception):
     """Raised when context remains critical after pruning — unrecoverable."""
 
 
+_EXHAUSTED_FALLBACK = (
+    "Context window exhausted. "
+    "This conversation has been automatically reset — "
+    "please start a new thread or send a new message to continue."
+)
+
+_EXHAUSTED_SYSTEM = (
+    "The conversation context has been exhausted and automatically reset. "
+    "Reply ONLY with a short notice (1-2 sentences) in the SAME language as the user's message. "
+    "Tell them the conversation was reset and they should start a new thread or send a new message."
+)
+
+
+def _context_exhausted_message(user_input: str) -> str:
+    """Generate context-exhausted message in the user's language via lightweight LLM call."""
+    try:
+        import anthropic
+
+        from core.config import ANTHROPIC_BUDGET, settings
+
+        if not settings.anthropic_api_key:
+            return _EXHAUSTED_FALLBACK
+
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        resp = client.messages.create(
+            model=ANTHROPIC_BUDGET,
+            max_tokens=150,
+            system=_EXHAUSTED_SYSTEM,
+            messages=[{"role": "user", "content": user_input[:200]}],
+        )
+        block = resp.content[0] if resp.content else None
+        text = block.text if block and hasattr(block, "text") else ""
+        return text or _EXHAUSTED_FALLBACK
+    except Exception:
+        log.debug("Exhausted message LLM call failed, using fallback", exc_info=True)
+        return _EXHAUSTED_FALLBACK
+
+
 @dataclass
 class AgenticResult:
     """Result of an agentic loop execution."""
@@ -502,11 +540,7 @@ class AgenticLoop:
                     )
                     self._sync_messages_to_context(messages)
                     result = AgenticResult(
-                        text=(
-                            "Context window exhausted. "
-                            "This conversation has been automatically reset — "
-                            "please start a new thread or send a new message to continue."
-                        ),
+                        text=_context_exhausted_message(user_input),
                         tool_calls=self._tool_processor.tool_log,
                         rounds=round_idx + 1,
                         error="context_exhausted",
@@ -569,11 +603,7 @@ class AgenticLoop:
                 )
                 self._sync_messages_to_context(messages)
                 result = AgenticResult(
-                    text=(
-                        "Context window exhausted after aggressive pruning. "
-                        "This conversation has been automatically reset — "
-                        "please start a new thread or send a new message to continue."
-                    ),
+                    text=_context_exhausted_message(user_input),
                     tool_calls=self._tool_processor.tool_log,
                     rounds=round_idx + 1,
                     error="context_exhausted",

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -481,6 +481,39 @@ class AgenticLoop:
             # Poll for sub-agent announced results (OpenClaw Spawn+Announce)
             self._check_announced_results(messages)
 
+            # Pre-call context check — proactive compress/prune (prevents 400)
+            try:
+                self._check_context_overflow(system_prompt, messages)
+            except _ContextExhaustedError:
+                log.warning("Pre-call context exhausted — attempting aggressive recovery")
+                recovered = self._aggressive_context_recovery(system_prompt, messages)
+                if recovered:
+                    self._notify_context_event(
+                        "prune",
+                        original_count=len(messages) + recovered,
+                        new_count=len(messages),
+                    )
+                    log.info("Pre-call recovery succeeded — proceeding with pruned context")
+                else:
+                    self._notify_context_event(
+                        "exhausted",
+                        original_count=len(messages),
+                        new_count=len(messages),
+                    )
+                    self._sync_messages_to_context(messages)
+                    result = AgenticResult(
+                        text=(
+                            "Context window exhausted before LLM call. "
+                            "Your conversation is preserved — start a new request "
+                            "or use /compact to manually reduce context."
+                        ),
+                        tool_calls=self._tool_processor.tool_log,
+                        rounds=round_idx + 1,
+                        error="context_exhausted",
+                        termination_reason="context_exhausted",
+                    )
+                    return self._finalize_and_return(result, user_input, round_idx + 1)
+
             # Show spinner while waiting for LLM response
             # IPC mode: send structured event; direct mode: TextSpinner
             from core.cli.ui.agentic_ui import _ipc_writer_local
@@ -563,6 +596,22 @@ class AgenticLoop:
                     from core.llm.errors import classify_llm_error
 
                     _et, _sev, _hint = classify_llm_error(adapter_exc)
+
+                    # Context overflow from 400 → attempt recovery + retry
+                    if _et == "context_overflow":
+                        log.warning("Context overflow detected from 400 — attempting recovery")
+                        recovered = self._aggressive_context_recovery(
+                            system_prompt, messages
+                        )
+                        if recovered:
+                            self._notify_context_event(
+                                "prune",
+                                original_count=len(messages) + recovered,
+                                new_count=len(messages),
+                            )
+                            log.info("Context overflow recovery succeeded — retrying LLM call")
+                            continue  # retry with pruned context
+
                     if not self._quiet:
                         from core.cli.ui.agentic_ui import emit_llm_error
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -630,9 +630,7 @@ class AgenticLoop:
                     # Context overflow from 400 → attempt recovery + retry
                     if _et == "context_overflow":
                         log.warning("Context overflow detected from 400 — attempting recovery")
-                        recovered = self._aggressive_context_recovery(
-                            system_prompt, messages
-                        )
+                        recovered = self._aggressive_context_recovery(system_prompt, messages)
                         if recovered:
                             self._notify_context_event(
                                 "prune",

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -503,9 +503,9 @@ class AgenticLoop:
                     self._sync_messages_to_context(messages)
                     result = AgenticResult(
                         text=(
-                            "Context window exhausted before LLM call. "
-                            "Your conversation is preserved — start a new request "
-                            "or use /compact to manually reduce context."
+                            "Context window exhausted. "
+                            "This conversation has been automatically reset — "
+                            "please start a new thread or send a new message to continue."
                         ),
                         tool_calls=self._tool_processor.tool_log,
                         rounds=round_idx + 1,
@@ -571,8 +571,8 @@ class AgenticLoop:
                 result = AgenticResult(
                     text=(
                         "Context window exhausted after aggressive pruning. "
-                        "Your conversation is preserved — start a new request "
-                        "or use /compact to manually reduce context."
+                        "This conversation has been automatically reset — "
+                        "please start a new thread or send a new message to continue."
                     ),
                     tool_calls=self._tool_processor.tool_log,
                     rounds=round_idx + 1,

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1634,14 +1634,19 @@ def serve(
 
             # --- Persist conversation for next turn ---
             if session_key:
-                runtime.session_store.set(
-                    session_key,
-                    {
-                        "messages": ctx.messages,
-                        "thread_id": metadata.get("thread_id", ""),
-                        "channel": metadata.get("channel", ""),
-                    },
-                )
+                if result and result.termination_reason == "context_exhausted":
+                    # Context exhausted → clear session so next message starts fresh
+                    runtime.session_store.delete(session_key)
+                    log.info("Session cleared after context exhaustion: %s", session_key)
+                else:
+                    runtime.session_store.set(
+                        session_key,
+                        {
+                            "messages": ctx.messages,
+                            "thread_id": metadata.get("thread_id", ""),
+                            "channel": metadata.get("channel", ""),
+                        },
+                    )
 
             return result.text if result else ""
         except Exception as exc:

--- a/core/cli/ui/tool_tracker.py
+++ b/core/cli/ui/tool_tracker.py
@@ -19,6 +19,19 @@ from __future__ import annotations
 import sys
 import threading
 import time
+import unicodedata
+
+
+def _truncate_display(text: str, max_width: int) -> str:
+    """Truncate text by display width, accounting for CJK wide characters."""
+    width = 0
+    for i, ch in enumerate(text):
+        w = 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+        if width + w > max_width - 3:  # room for "..."
+            return text[:i] + "..."
+        width += w
+    return text
+
 
 # Braille spinner frames (same as TextSpinner)
 _FRAMES = [
@@ -126,15 +139,16 @@ class ToolCallTracker:
             if t["done"]:
                 dur = f" ({float(t['duration']):.1f}s)"
                 if t["error"]:
-                    lines.append(f"\033[2K  \033[31m\u2717 {name}\033[0m — {t['error']}{dur}")
+                    err = _truncate_display(str(t["error"]), 60)
+                    lines.append(f"\033[2K  \033[31m\u2717 {name}\033[0m — {err}{dur}")
                 else:
-                    summary = t["summary"]
+                    summary = _truncate_display(str(t["summary"]), 60)
                     lines.append(f"\033[2K  \033[32m\u2713 {name}\033[0m → {summary}{dur}")
             else:
                 args = str(t["args"]).replace("\n", " ")
-                if len(args) > 60:
-                    args = args[:57] + "..."
-                lines.append(f"\033[2K  \033[35m\u25b8 {name}\033[0m({args}) {frame}")
+                # Truncate by display width — CJK chars occupy 2 columns
+                args = _truncate_display(args, 50)
+                lines.append(f"\033[2K  {frame} \033[35m{name}\033[0m({args})")
 
         output = "\n".join(lines)
         if lines:

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -294,7 +294,16 @@ async def call_with_failover(
                 result = await call_fn(current_model)
                 return result, current_model
             except _NON_RETRYABLE_ERRORS as exc:
-                # Non-retryable: fail immediately, do not try other models
+                # Context overflow → re-raise so adapter can set last_error
+                error_msg = str(exc).lower()
+                if "token" in error_msg or "context" in error_msg:
+                    log.warning(
+                        "Context overflow on model=%s: %s — propagating to adapter",
+                        current_model,
+                        type(exc).__name__,
+                    )
+                    raise
+                # Other non-retryable: fail immediately, do not try other models
                 log.warning(
                     "Non-retryable error on model=%s: %s — aborting failover",
                     current_model,


### PR DESCRIPTION
## Summary
- Gateway 멀티턴 컨텍스트 오버플로우 복구: pre-call check + 400 error propagation + auto session clear
- ToolCallTracker CJK-aware truncation + spinner 왼쪽 배치
- context exhaustion 안내 메시지 LLM 다국어 생성

## Why
Slack Gateway에서 729k 토큰까지 누적 후 다음 턴 400 Bad Request → 복구 없이 실패.
사용자가 대화를 이어갈 수 없는 치명적 UX 문제.

## Changes
| 파일 | 변경 |
|------|------|
| `core/llm/router.py` | context-overflow BadRequestError re-raise (삼키지 않음) |
| `core/agent/agentic_loop.py` | Pre-call context check + 400 recovery + LLM 다국어 안내 |
| `core/cli/__init__.py` | Gateway session auto-clear on exhaustion |
| `core/cli/ui/tool_tracker.py` | CJK display-width truncation + spinner 왼쪽 |

## Test plan
- [x] 3504 tests passed locally
- [x] ruff lint 0 errors
- [x] mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)