### PR TITLE
release: v0.39.0 — IPC parity + cursor-up fix + context overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.39.0] — 2026-03-31
+
+### Added
+- **IPC pipeline event parity** — thin client now receives all pipeline data that direct CLI renders:
+  - Signals (YouTube views, Reddit subscribers, FanArt YoY%) in `pipeline_gather` event
+  - PSM causal inference (ATT%, Z-value, Rosenbaum Gamma) in `pipeline_score` event with significance indicators
+  - Pipeline warnings/errors in `pipeline_result` event
+  - Guardrail failure details in `pipeline_verification` event
+- **ToolCallTracker.suspend()** — erases rendered spinner lines and resets cursor position, preventing ANSI cursor-up from corrupting interleaved pipeline/stream output
+- **Pipeline ip_name tagging** — `set_pipeline_ip()` thread-local for forward-compatible parallel UI (Option B: IP-sequential queueing)
+- **Gateway context overflow recovery** — pre-call context check prevents 400 errors; auto-clear session on context exhaustion; i18n exhaustion messages via Haiku
+- **CJK-aware tool tracker** — `_truncate_display()` uses `unicodedata.east_asian_width` for correct CJK character width; spinner moved to left side
+
+### Fixed
+- **list_ips spinner duplication** — `stop()` called per stream chunk reprinted spinner each time; now uses `suspend()` with position reset
+- **analyze_ip spinner/panel collision** — 9 pipeline event handlers changed from `_clear_activity_line()` to `_suppress_all_spinners()`, stopping tracker before writing
+- **Rich Panel cursor-up interference** — stale `_line_count` caused cursor-up to erase interleaved pipeline event output
+- **400 error silent swallow** — `call_with_failover` now re-raises context-overflow BadRequestError instead of returning None
+
+### Removed
+- **Stub insight generator** — `PIPELINE_END→add_insight` hook removed; generated broken `tier=?/score=0.00` entries because synthesizer input state didn't reliably contain scoring results. Pipeline results are recorded in journal (`runs.jsonl`) via JournalHook.
+
 ## [0.38.0] — 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.38.0
+- **Version**: 0.39.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 192
-- **Tests**: 3496+
+- **Tests**: 3509+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -144,7 +144,7 @@ uv run mypy core/
 
 ### Expected Test Results
 
-3496+ tests pass. 3 IP fixtures produce tier spread:
+3509+ tests pass. 3 IP fixtures produce tier spread:
 - Berserk: **S** (81.2) — conversion_failure
 - Cowboy Bebop: **A** (68.4) — undermarketed
 - Ghost in the Shell: **B** (51.7) — discovery_failure

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.38.0 — Long-running Autonomous Execution Harness
+# GEODE v0.39.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.38.0"
+version = "0.39.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- v0.38.0 → v0.39.0 (MINOR: 새 기능)
- CHANGELOG, CLAUDE.md, README.md, pyproject.toml 4곳 동시 업데이트
- Tests: 3509+, Modules: 192

## Why

Session 51 변경사항 (8 PRs #568-576) 릴리스. IPC 이벤트 패리티, ToolCallTracker cursor-up fix, Gateway context overflow recovery, CJK spinner fix.

## Test plan

- [x] 4-location version sync verified (0.39.0)
- [x] Measured values: Tests=3509, Modules=192

🤖 Generated with [Claude Code](https://claude.com/claude-code)