### PR TITLE
feat: MCP fallback hints — playwriter → playwright

### DIFF
--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -457,17 +457,32 @@ class MCPServerManager:
                 all_tools.append(normalised)
         return all_tools
 
+    # MCP server fallback hints: when a server is unavailable or fails,
+    # the error message includes a hint so the LLM can try an alternative.
+    _FALLBACK_HINTS: dict[str, str] = {
+        "playwriter": "playwright (playwright__browser_navigate, etc.)",
+        "puppeteer": "playwright (playwright__browser_navigate, etc.)",
+    }
+
     def call_tool(self, server_name: str, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
         """Call a tool on a specific MCP server."""
         client = self._get_client(server_name)
         if client is None:
-            return {"error": f"MCP server '{server_name}' not available"}
+            msg = f"MCP server '{server_name}' not available"
+            hint = self._FALLBACK_HINTS.get(server_name, "")
+            if hint:
+                msg += f". Fallback: use {hint} instead"
+            return {"error": msg}
 
         try:
             return client.call_tool(tool_name, args)
         except Exception as exc:
             log.error("MCP tool call failed: %s/%s: %s", server_name, tool_name, exc)
-            return {"error": f"MCP tool call failed: {exc}"}
+            msg = f"MCP tool call failed: {tool_name}"
+            hint = self._FALLBACK_HINTS.get(server_name, "")
+            if hint:
+                msg += f". Fallback: use {hint} instead"
+            return {"error": msg}
 
     def find_server_for_tool(self, tool_name: str) -> str | None:
         """Find which server provides a given tool."""

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -383,3 +383,34 @@ class TestMCPManagerConnectAll:
 
         assert result == 2
         assert call_count == 3
+
+
+class TestMCPFallbackHints:
+    """Verify MCP fallback hints in error messages."""
+
+    def test_unavailable_server_with_hint(self) -> None:
+        """playwriter unavailable → error includes playwright fallback hint."""
+        mgr = MCPServerManager()
+        result = mgr.call_tool("playwriter", "navigate", {"url": "https://example.com"})
+        assert "error" in result
+        assert "playwright" in result["error"]
+        assert "Fallback" in result["error"]
+
+    def test_unavailable_server_without_hint(self) -> None:
+        """Unknown server unavailable → no fallback hint."""
+        mgr = MCPServerManager()
+        result = mgr.call_tool("unknown_server", "some_tool", {})
+        assert "error" in result
+        assert "Fallback" not in result["error"]
+
+    def test_failed_call_with_hint(self) -> None:
+        """playwriter call fails → error includes playwright fallback hint."""
+        mgr = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.call_tool.side_effect = ConnectionError("extension not running")
+
+        with patch.object(mgr, "_get_client", return_value=mock_client):
+            result = mgr.call_tool("playwriter", "navigate", {"url": "https://example.com"})
+        assert "error" in result
+        assert "playwright" in result["error"]
+        assert "Fallback" in result["error"]


### PR DESCRIPTION
## Summary

- `MCPServerManager.call_tool()` 에러 메시지에 fallback 서버 힌트 추가
- playwriter 미연결/실패 시 "Fallback: use playwright instead" 반환
- LLM이 힌트를 읽고 대체 도구 자율 선택 가능

## Why

playwriter(Chrome 확장 브리지)가 미연결이면 LLM이 "브라우저 불가"로 판단하고 행동 포기. playwright(headless)가 있는데도 시도하지 않음. 에러 메시지에 대체 도구 힌트를 넣으면 LLM이 자율적으로 전환.

## Test plan

- [x] `test_unavailable_server_with_hint` — playwriter 미연결 → playwright 힌트
- [x] `test_unavailable_server_without_hint` — 힌트 없는 서버 → Fallback 미포함
- [x] `test_failed_call_with_hint` — playwriter 호출 실패 → playwright 힌트
- [x] 28 tests pass (test_mcp_lifecycle.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)