### PR TITLE
fix: /clear relay to serve — context actually cleared

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -827,7 +827,7 @@ def _read_multiline_input(prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-_LOCAL_COMMANDS = frozenset({"/help", "/clear"})
+_LOCAL_COMMANDS = frozenset({"/help"})
 
 # Commands that need TTY interaction locally, then relay the result to serve
 _TTY_LOCAL_COMMANDS = frozenset({"/model", "/auth"})
@@ -840,8 +840,8 @@ def _thin_interactive_loop(
 ) -> None:
     """Thin CLI client — all execution delegated to geode serve via IPC.
 
-    Local commands: /help, /clear
-    Everything else (including /quit, /exit): relayed to serve
+    Local commands: /help
+    Everything else (including /quit, /exit, /clear, /compact): relayed to serve
     """
     from core.cli.ipc_client import IPCClient
 
@@ -939,6 +939,10 @@ def _thin_interactive_loop(
                             _sys.stdout.write(output)
                             _sys.stdout.flush()
                     continue
+
+                # /clear: auto-force in IPC mode (no stdin for confirmation on serve)
+                if cmd == "/clear" and "--force" not in args:
+                    args = (args + " --force").strip()
 
                 # All other commands → relay to serve
                 response = client.send_command(cmd, args)


### PR DESCRIPTION
## Summary
- /clear를 _LOCAL_COMMANDS에서 제거 → serve로 relay
- IPC 모드에서 자동 --force 추가 (서버 stdin 없음)

## Why
/clear가 thin 클라이언트 로컬 실행 → 클라이언트에 context 없음 → "already empty" → serve 측 context 그대로 → 다음 프롬프트 overflow.

## Test plan
- [x] 3509 tests passed
- [x] ruff + mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)