### PR TITLE
feat: 200K absolute token guard — prevent rate limit pool separation

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -970,6 +970,12 @@ class AgenticLoop:
         - OpenAI/GLM: no server-side compaction. Client triggers LLM-based compaction
           at 80% and emergency prune at 95%.
 
+        Absolute ceiling (200K tokens):
+        - Large-context models (1M) hit rate limit pool separation at >200K tokens.
+          Percentage thresholds (80%=800K) are too distant to catch this.
+          When estimated > 200K on a >200K-window model, force tool result
+          summarization + compact to stay under the ceiling.
+
         Compression strategy is delegated to the CONTEXT_OVERFLOW_ACTION hook handler.
         If no handler is registered or all fail, falls back to hardcoded defaults.
         """
@@ -1020,6 +1026,35 @@ class AgenticLoop:
                             metrics.usage_pct,
                             summarized,
                         )
+
+            elif metrics.is_ceiling_exceeded:
+                # Absolute 200K ceiling breached on a large-context model.
+                # Percentage is low (e.g. 20-30%) but tokens exceed the rate limit
+                # pool boundary. Summarize tool results first (lightest), then
+                # compact if still over.
+                from core.orchestration.context_monitor import (
+                    ABSOLUTE_TOKEN_CEILING,
+                    summarize_tool_results,
+                )
+
+                log.info(
+                    "Context ceiling: %d tokens > %dK ceiling (%.0f%% of %dK window) "
+                    "— compressing to avoid rate limit pool separation",
+                    metrics.estimated_tokens,
+                    ABSOLUTE_TOKEN_CEILING // 1000,
+                    metrics.usage_pct,
+                    metrics.context_window // 1000,
+                )
+
+                # Phase 1: summarize large tool results
+                summarized = summarize_tool_results(messages, ABSOLUTE_TOKEN_CEILING)
+                post = check_context(messages, self.model, system_prompt=system)
+
+                if post.is_ceiling_exceeded:
+                    # Phase 2: compact conversation
+                    strategy = {"strategy": "compact", "keep_recent": settings.compact_keep_recent}
+                    self._apply_overflow_strategy(strategy, messages, settings)
+
         except Exception:
             log.debug("Context monitor check failed", exc_info=True)
 

--- a/core/orchestration/context_monitor.py
+++ b/core/orchestration/context_monitor.py
@@ -20,6 +20,12 @@ log = logging.getLogger(__name__)
 WARNING_THRESHOLD = 80.0
 CRITICAL_THRESHOLD = 95.0
 
+# Absolute token ceiling — prevents rate limit pool separation on large-context models.
+# Anthropic (and others) assign requests >200K tokens to a separate, more restrictive
+# rate limit pool. This guard triggers compression before crossing that boundary,
+# even when the percentage-based thresholds (80%/95%) are far away (e.g. 200K/1M = 20%).
+ABSOLUTE_TOKEN_CEILING = 200_000
+
 # Approximate chars per token (conservative estimate)
 CHARS_PER_TOKEN = 4
 
@@ -34,6 +40,7 @@ class ContextMetrics:
     remaining_tokens: int
     is_warning: bool
     is_critical: bool
+    is_ceiling_exceeded: bool = False
 
 
 def estimate_message_tokens(messages: list[dict[str, Any]]) -> int:
@@ -92,6 +99,12 @@ def check_context(
     usage_pct = estimated / context_window * 100
     remaining = max(context_window - estimated, 0)
 
+    # Ceiling exceeded: only relevant for large-context models where percentage
+    # thresholds are too distant (e.g. 200K/1M = 20%, but 80% threshold = 800K).
+    ceiling_exceeded = (
+        estimated > ABSOLUTE_TOKEN_CEILING and context_window > ABSOLUTE_TOKEN_CEILING
+    )
+
     return ContextMetrics(
         estimated_tokens=estimated,
         context_window=context_window,
@@ -99,6 +112,7 @@ def check_context(
         remaining_tokens=remaining,
         is_warning=usage_pct >= WARNING_THRESHOLD,
         is_critical=usage_pct >= CRITICAL_THRESHOLD,
+        is_ceiling_exceeded=ceiling_exceeded,
     )
 
 

--- a/tests/test_context_monitor.py
+++ b/tests/test_context_monitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from core.orchestration.context_monitor import (
+    ABSOLUTE_TOKEN_CEILING,
     WARNING_THRESHOLD,
     ContextMetrics,
     adaptive_prune,
@@ -144,6 +145,41 @@ class TestCheckContext:
         metrics = check_context([{"role": "user", "content": huge_msg}], "glm-5")
         # 2M chars / 4 = 500K tokens vs 80K window → well above 100%
         assert metrics.usage_pct > 100.0
+
+    def test_ceiling_exceeded_on_large_model(self):
+        """200K+ tokens on a 1M model should set is_ceiling_exceeded."""
+        # 250K tokens → 1M chars
+        big_msg = "x" * 1_000_000
+        msgs = [{"role": "user", "content": big_msg}]
+        metrics = check_context(msgs, "claude-opus-4-6")
+        assert metrics.estimated_tokens > ABSOLUTE_TOKEN_CEILING
+        assert metrics.is_ceiling_exceeded
+        # But not warning/critical (250K/1M = 25%)
+        assert not metrics.is_warning
+        assert not metrics.is_critical
+
+    def test_ceiling_not_exceeded_small_context(self):
+        """Small messages on 1M model should not trigger ceiling."""
+        msgs = [{"role": "user", "content": "hello"}]
+        metrics = check_context(msgs, "claude-opus-4-6")
+        assert not metrics.is_ceiling_exceeded
+
+    def test_ceiling_not_triggered_for_200k_model(self):
+        """200K-window models are excluded — percentage thresholds handle them."""
+        # Even if tokens > 200K, the model's window IS 200K, so ceiling
+        # should not apply (percentage thresholds already fire).
+        big_msg = "x" * 1_000_000
+        msgs = [{"role": "user", "content": big_msg}]
+        metrics = check_context(msgs, "glm-5")
+        # context_window == 200K, NOT > 200K → ceiling should be False
+        assert not metrics.is_ceiling_exceeded
+        # But percentage thresholds should fire
+        assert metrics.is_warning or metrics.is_critical
+
+    def test_ceiling_field_exists(self):
+        """ContextMetrics includes is_ceiling_exceeded field."""
+        metrics = check_context([{"role": "user", "content": "hi"}], "claude-opus-4-6")
+        assert isinstance(metrics.is_ceiling_exceeded, bool)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 1M 윈도우 모델에서 Anthropic의 200K rate limit pool 경계를 넘지 않도록 절대 토큰 가드 추가
- 퍼센트 기반 임계값(80%=800K)으로는 200K 경계를 감지 불가 — 별도 `is_ceiling_exceeded` 플래그 도입
- 2-phase 압축: tool result summarization → conversation compaction 순서로 200K 이하로 유지

## Changes
- `core/orchestration/context_monitor.py`: `ABSOLUTE_TOKEN_CEILING=200_000` 상수, `ContextMetrics.is_ceiling_exceeded` 필드, `check_context()` ceiling 감지 로직
- `core/agent/agentic_loop.py`: `_check_context_overflow()`에 ceiling 분기 추가 (Phase 1: summarize, Phase 2: compact)
- `tests/test_context_monitor.py`: ceiling 테스트 4건 (대형 모델 초과, 소형 메시지 미초과, 200K 모델 미적용, 필드 존재)

## Test plan
- [x] `uv run pytest tests/test_context_monitor.py` — 41 tests pass (기존 37 + ceiling 4)
- [x] `uv run ruff check` — 0 errors
- [x] `uv run mypy core/orchestration/context_monitor.py` — 0 errors
- [ ] Full test suite pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)