### PR TITLE
feat: LLM-friendly tool errors — structured classification + recovery hints

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-31T02:10:00+09:00 task_id=multi-cli
+session=2026-03-31T16:26:18+09:00 task_id=llm-friendly-errors

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -277,7 +277,9 @@ class ToolExecutor:
             return raw
         except Exception as exc:
             log.error("Tool %s failed: %s", tool_name, exc, exc_info=True)
-            return {"error": str(exc)}
+            from core.tools.base import classify_tool_exception
+
+            return classify_tool_exception(exc, tool_name=tool_name)
 
     def _execute_delegate(self, tool_input: dict[str, Any]) -> dict[str, Any]:
         """Delegate task(s) to sub-agent. Supports single and batch."""

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -466,23 +466,30 @@ class MCPServerManager:
 
     def call_tool(self, server_name: str, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
         """Call a tool on a specific MCP server."""
+        from core.tools.base import tool_error
+
         client = self._get_client(server_name)
         if client is None:
-            msg = f"MCP server '{server_name}' not available"
             hint = self._FALLBACK_HINTS.get(server_name, "")
-            if hint:
-                msg += f". Fallback: use {hint} instead"
-            return {"error": msg}
+            return tool_error(
+                f"MCP server '{server_name}' not available",
+                error_type="connection",
+                hint=f"Use {hint} instead" if hint else "Check server configuration.",
+                context={"server": server_name, "tool": tool_name},
+            )
 
         try:
             return client.call_tool(tool_name, args)
         except Exception as exc:
             log.error("MCP tool call failed: %s/%s: %s", server_name, tool_name, exc)
-            msg = f"MCP tool call failed: {tool_name}"
             hint = self._FALLBACK_HINTS.get(server_name, "")
-            if hint:
-                msg += f". Fallback: use {hint} instead"
-            return {"error": msg}
+            is_timeout = "timeout" in str(exc).lower()
+            return tool_error(
+                f"MCP tool call failed: {tool_name}",
+                error_type="timeout" if is_timeout else "connection",
+                hint=f"Use {hint} instead" if hint else "Retry or use an alternative tool.",
+                context={"server": server_name, "tool": tool_name},
+            )
 
     def find_server_for_tool(self, tool_name: str) -> str | None:
         """Find which server provides a given tool."""

--- a/core/tools/analysis.py
+++ b/core/tools/analysis.py
@@ -76,7 +76,14 @@ class RunAnalystTool:
         ip_name = kwargs["ip_name"]
 
         if analyst_type not in ANALYST_TYPES:
-            return {"error": f"Unknown analyst_type: {analyst_type}"}
+            from core.tools.base import tool_error
+
+            return tool_error(
+                f"Unknown analyst_type: {analyst_type}",
+                error_type="validation",
+                hint=f"Valid types: {', '.join(ANALYST_TYPES)}",
+                context={"analyst_type": analyst_type},
+            )
 
         result = get_dry_run_result(analyst_type, ip_name)
         return {
@@ -118,7 +125,14 @@ class RunEvaluatorTool:
             data = load_fixture(ip_name)
             expected = data.get("expected_results", {})
         except ValueError:
-            return {"error": f"Unknown IP: {ip_name}"}
+            from core.tools.base import tool_error
+
+            return tool_error(
+                f"Unknown IP: {ip_name}",
+                error_type="not_found",
+                hint="Use list_data_sources to see available IPs.",
+                context={"ip_name": ip_name},
+            )
 
         # Build evaluator-specific result from expected data
         if evaluator_type == "quality_judge":
@@ -145,7 +159,14 @@ class RunEvaluatorTool:
                     "ip_name": ip_name,
                 }
             }
-        return {"error": f"Unknown evaluator_type: {evaluator_type}"}
+        from core.tools.base import tool_error
+
+        return tool_error(
+            f"Unknown evaluator_type: {evaluator_type}",
+            error_type="validation",
+            hint="Valid types: quality_judge, hidden_value, community_momentum",
+            context={"evaluator_type": evaluator_type},
+        )
 
 
 class PSMCalculateTool:
@@ -180,7 +201,14 @@ class PSMCalculateTool:
                 }
             }
         except ValueError:
-            return {"error": f"Unknown IP: {ip_name}"}
+            from core.tools.base import tool_error
+
+            return tool_error(
+                f"Unknown IP: {ip_name}",
+                error_type="not_found",
+                hint="Use list_data_sources to see available IPs.",
+                context={"ip_name": ip_name},
+            )
 
 
 class ExplainScoreTool:
@@ -206,7 +234,14 @@ class ExplainScoreTool:
         try:
             data = load_fixture(ip_name)
         except ValueError:
-            return {"error": f"Unknown IP: {ip_name}"}
+            from core.tools.base import tool_error
+
+            return tool_error(
+                f"Unknown IP: {ip_name}",
+                error_type="not_found",
+                hint="Use list_data_sources to see available IPs.",
+                context={"ip_name": ip_name},
+            )
 
         expected = data.get("expected_results", {})
         ip_info = data.get("ip_info", {})

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -71,13 +71,13 @@ class Tool(Protocol):
 
 # Error types that tools can return
 ToolErrorType = Literal[
-    "validation",   # bad input / missing required params
-    "not_found",    # resource not found
-    "permission",   # access denied / policy blocked
-    "connection",   # network / external service failure
-    "timeout",      # operation timed out
-    "dependency",   # missing library / unconfigured service
-    "internal",     # unexpected internal error
+    "validation",  # bad input / missing required params
+    "not_found",  # resource not found
+    "permission",  # access denied / policy blocked
+    "connection",  # network / external service failure
+    "timeout",  # operation timed out
+    "dependency",  # missing library / unconfigured service
+    "internal",  # unexpected internal error
 ]
 
 

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -6,7 +6,7 @@ tool_use API or autonomous agent patterns.
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 # Valid values for tool metadata fields.
 VALID_CATEGORIES = frozenset(
@@ -63,3 +63,106 @@ class Tool(Protocol):
             Result dict with at minimum a "result" key.
         """
         ...
+
+
+# ---------------------------------------------------------------------------
+# Standardized tool error helper
+# ---------------------------------------------------------------------------
+
+# Error types that tools can return
+ToolErrorType = Literal[
+    "validation",   # bad input / missing required params
+    "not_found",    # resource not found
+    "permission",   # access denied / policy blocked
+    "connection",   # network / external service failure
+    "timeout",      # operation timed out
+    "dependency",   # missing library / unconfigured service
+    "internal",     # unexpected internal error
+]
+
+
+def tool_error(
+    message: str,
+    *,
+    error_type: ToolErrorType = "internal",
+    recoverable: bool = True,
+    hint: str = "",
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a standardized tool error dict for LLM consumption.
+
+    Returns a dict with ``error`` (message string for backward-compat)
+    plus structured metadata that helps the LLM classify and recover.
+
+    Args:
+        message: Human-readable error description.
+        error_type: Machine-readable category (validation, not_found, ...).
+        recoverable: Whether the LLM should retry or try alternatives.
+        hint: Actionable suggestion for the LLM (e.g. "use list_ips first").
+        context: Extra key-value pairs (parameter name, value, etc.).
+    """
+    result: dict[str, Any] = {
+        "error": message,
+        "error_type": error_type,
+        "recoverable": recoverable,
+    }
+    if hint:
+        result["hint"] = hint
+    if context:
+        result["context"] = context
+    return result
+
+
+def classify_tool_exception(exc: Exception, tool_name: str = "") -> dict[str, Any]:
+    """Classify an unhandled tool exception into a standardized error dict.
+
+    Called at the executor level to wrap unexpected exceptions before
+    they reach the LLM as raw stack traces.
+    """
+    msg = str(exc)
+    exc_type = type(exc).__name__
+
+    # Order matters: check specific OSError subclasses before generic OSError
+    if isinstance(exc, TimeoutError):
+        return tool_error(
+            f"Operation timed out: {msg}",
+            error_type="timeout",
+            hint="Retry or try a simpler query.",
+        )
+    if isinstance(exc, PermissionError):
+        return tool_error(
+            f"Permission denied: {msg}",
+            error_type="permission",
+            recoverable=False,
+        )
+    if isinstance(exc, FileNotFoundError):
+        return tool_error(
+            f"File not found: {msg}",
+            error_type="not_found",
+            hint="Verify the file path exists.",
+        )
+    if isinstance(exc, (ConnectionError, OSError)):
+        return tool_error(
+            f"Connection failed: {msg}",
+            error_type="connection",
+            hint="Check network connectivity or retry.",
+        )
+    if isinstance(exc, (ValueError, TypeError, KeyError)):
+        return tool_error(
+            f"Invalid input: {msg}",
+            error_type="validation",
+            hint="Check parameter types and values.",
+        )
+    if isinstance(exc, ImportError):
+        return tool_error(
+            f"Missing dependency: {msg}",
+            error_type="dependency",
+            recoverable=False,
+            hint="Required library is not installed.",
+        )
+    # Generic fallback
+    return tool_error(
+        f"{exc_type}: {msg}" if tool_name else msg,
+        error_type="internal",
+        hint=f"Unexpected error in {tool_name}." if tool_name else "",
+    )

--- a/core/tools/document_tools.py
+++ b/core/tools/document_tools.py
@@ -33,17 +33,34 @@ class ReadDocumentTool:
 
         file_path = Path(file_path_str).resolve()
 
+        from core.tools.base import tool_error
+
         # Security: ensure path is within project directory
         try:
             file_path.relative_to(_PROJECT_ROOT)
         except ValueError:
-            return {"error": f"Access denied: path outside project directory ({_PROJECT_ROOT})"}
+            return tool_error(
+                f"Access denied: path outside project directory ({_PROJECT_ROOT})",
+                error_type="permission",
+                recoverable=False,
+                context={"file_path": str(file_path)},
+            )
 
         if not file_path.exists():
-            return {"error": f"File not found: {file_path}"}
+            return tool_error(
+                f"File not found: {file_path}",
+                error_type="not_found",
+                hint="Check the file path or use a different file.",
+                context={"file_path": str(file_path)},
+            )
 
         if not file_path.is_file():
-            return {"error": f"Not a file: {file_path}"}
+            return tool_error(
+                f"Not a file: {file_path}",
+                error_type="validation",
+                hint="Provide a path to a file, not a directory.",
+                context={"file_path": str(file_path)},
+            )
 
         try:
             lines = file_path.read_text(encoding="utf-8").splitlines()
@@ -58,4 +75,8 @@ class ReadDocumentTool:
                 }
             }
         except Exception as exc:
-            return {"error": f"Failed to read {file_path}: {exc}"}
+            return tool_error(
+                f"Failed to read {file_path}: {exc}",
+                error_type="internal",
+                context={"file_path": str(file_path)},
+            )

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -32,7 +32,14 @@ class WebFetchTool:
         try:
             import httpx
         except ImportError:
-            return {"error": "httpx not installed"}
+            from core.tools.base import tool_error
+
+            return tool_error(
+                "httpx not installed",
+                error_type="dependency",
+                recoverable=False,
+                hint="Install httpx: pip install httpx",
+            )
 
         try:
             try:
@@ -56,9 +63,25 @@ class WebFetchTool:
                 }
             }
         except httpx.HTTPStatusError as exc:
-            return {"error": f"HTTP {exc.response.status_code}: {url}"}
+            from core.tools.base import tool_error
+
+            status = exc.response.status_code
+            return tool_error(
+                f"HTTP {status}: {url}",
+                error_type="connection",
+                recoverable=status in (429, 500, 502, 503, 504),
+                hint="Retry later." if status == 429 else "Check URL or try a different source.",
+                context={"url": url, "status_code": status},
+            )
         except Exception as exc:
-            return {"error": f"Failed to fetch {url}: {exc}"}
+            from core.tools.base import tool_error
+
+            return tool_error(
+                f"Failed to fetch {url}: {exc}",
+                error_type="connection",
+                hint="Check URL validity or network connectivity.",
+                context={"url": url},
+            )
 
     @staticmethod
     def _html_to_text(html: str) -> str:
@@ -117,7 +140,15 @@ class GeneralWebSearchTool:
         if result:
             return result
 
-        return {"error": "All web search providers failed"}
+        from core.tools.base import tool_error
+
+        return tool_error(
+            "All web search providers failed",
+            error_type="connection",
+            recoverable=True,
+            hint="Retry or rephrase the query.",
+            context={"query": query},
+        )
 
     def _anthropic_search(self, query: str, max_results: int) -> dict[str, Any] | None:
         """Anthropic native web search via Messages API."""

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -393,15 +393,16 @@ class TestMCPFallbackHints:
         mgr = MCPServerManager()
         result = mgr.call_tool("playwriter", "navigate", {"url": "https://example.com"})
         assert "error" in result
-        assert "playwright" in result["error"]
-        assert "Fallback" in result["error"]
+        # Hint is in dedicated field (LLM-friendly structured error)
+        assert "playwright" in result.get("hint", "")
 
     def test_unavailable_server_without_hint(self) -> None:
         """Unknown server unavailable → no fallback hint."""
         mgr = MCPServerManager()
         result = mgr.call_tool("unknown_server", "some_tool", {})
         assert "error" in result
-        assert "Fallback" not in result["error"]
+        # No fallback server → hint should not mention fallback
+        assert "instead" not in result.get("hint", "").lower() or "playwright" not in result.get("hint", "")
 
     def test_failed_call_with_hint(self) -> None:
         """playwriter call fails → error includes playwright fallback hint."""
@@ -412,5 +413,5 @@ class TestMCPFallbackHints:
         with patch.object(mgr, "_get_client", return_value=mock_client):
             result = mgr.call_tool("playwriter", "navigate", {"url": "https://example.com"})
         assert "error" in result
-        assert "playwright" in result["error"]
-        assert "Fallback" in result["error"]
+        # Hint is in dedicated field (LLM-friendly structured error)
+        assert "playwright" in result.get("hint", "")

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -402,7 +402,9 @@ class TestMCPFallbackHints:
         result = mgr.call_tool("unknown_server", "some_tool", {})
         assert "error" in result
         # No fallback server → hint should not mention fallback
-        assert "instead" not in result.get("hint", "").lower() or "playwright" not in result.get("hint", "")
+        assert "instead" not in result.get("hint", "").lower() or "playwright" not in result.get(
+            "hint", ""
+        )
 
     def test_failed_call_with_hint(self) -> None:
         """playwriter call fails → error includes playwright fallback hint."""

--- a/tests/test_tool_error.py
+++ b/tests/test_tool_error.py
@@ -1,0 +1,119 @@
+"""Tests for tool_error() helper and classify_tool_exception()."""
+
+from __future__ import annotations
+
+import pytest
+from core.tools.base import classify_tool_exception, tool_error
+
+
+class TestToolError:
+    """Test the standardized tool_error() helper."""
+
+    def test_minimal_error(self):
+        result = tool_error("Something went wrong")
+        assert result["error"] == "Something went wrong"
+        assert result["error_type"] == "internal"
+        assert result["recoverable"] is True
+        assert "hint" not in result
+        assert "context" not in result
+
+    def test_with_all_fields(self):
+        result = tool_error(
+            "File not found: foo.txt",
+            error_type="not_found",
+            recoverable=False,
+            hint="Check the path.",
+            context={"file_path": "foo.txt"},
+        )
+        assert result["error"] == "File not found: foo.txt"
+        assert result["error_type"] == "not_found"
+        assert result["recoverable"] is False
+        assert result["hint"] == "Check the path."
+        assert result["context"]["file_path"] == "foo.txt"
+
+    def test_validation_error(self):
+        result = tool_error(
+            "Unknown analyst_type: foo",
+            error_type="validation",
+            hint="Valid types: a, b, c",
+        )
+        assert result["error_type"] == "validation"
+        assert result["hint"] == "Valid types: a, b, c"
+
+    def test_connection_error(self):
+        result = tool_error(
+            "Server unavailable",
+            error_type="connection",
+            recoverable=True,
+        )
+        assert result["error_type"] == "connection"
+        assert result["recoverable"] is True
+
+    @pytest.mark.parametrize(
+        "error_type",
+        ["validation", "not_found", "permission", "connection", "timeout", "dependency", "internal"],
+    )
+    def test_all_error_types_accepted(self, error_type: str):
+        result = tool_error("test", error_type=error_type)
+        assert result["error_type"] == error_type
+
+    def test_backward_compat_error_key(self):
+        """The 'error' key must always be a string for backward compatibility."""
+        result = tool_error("msg")
+        assert isinstance(result["error"], str)
+
+
+class TestClassifyToolException:
+    """Test classify_tool_exception() for automatic exception classification."""
+
+    def test_connection_error(self):
+        result = classify_tool_exception(ConnectionError("refused"))
+        assert result["error_type"] == "connection"
+
+    def test_os_error(self):
+        result = classify_tool_exception(OSError("disk full"))
+        assert result["error_type"] == "connection"
+
+    def test_timeout_error(self):
+        result = classify_tool_exception(TimeoutError("timed out"))
+        assert result["error_type"] == "timeout"
+
+    def test_value_error(self):
+        result = classify_tool_exception(ValueError("bad input"))
+        assert result["error_type"] == "validation"
+
+    def test_type_error(self):
+        result = classify_tool_exception(TypeError("wrong type"))
+        assert result["error_type"] == "validation"
+
+    def test_key_error(self):
+        result = classify_tool_exception(KeyError("missing"))
+        assert result["error_type"] == "validation"
+
+    def test_permission_error(self):
+        result = classify_tool_exception(PermissionError("denied"))
+        assert result["error_type"] == "permission"
+        assert result["recoverable"] is False
+
+    def test_file_not_found_error(self):
+        result = classify_tool_exception(FileNotFoundError("no such file"))
+        assert result["error_type"] == "not_found"
+
+    def test_import_error(self):
+        result = classify_tool_exception(ImportError("no module"))
+        assert result["error_type"] == "dependency"
+        assert result["recoverable"] is False
+
+    def test_generic_exception(self):
+        result = classify_tool_exception(RuntimeError("unexpected"))
+        assert result["error_type"] == "internal"
+
+    def test_tool_name_in_hint(self):
+        result = classify_tool_exception(RuntimeError("boom"), tool_name="web_fetch")
+        assert "web_fetch" in result.get("hint", "")
+
+    def test_backward_compat(self):
+        """All classified errors must have 'error' key as string."""
+        result = classify_tool_exception(ValueError("bad"))
+        assert isinstance(result["error"], str)
+        assert "error_type" in result

--- a/tests/test_tool_error.py
+++ b/tests/test_tool_error.py
@@ -51,7 +51,15 @@ class TestToolError:
 
     @pytest.mark.parametrize(
         "error_type",
-        ["validation", "not_found", "permission", "connection", "timeout", "dependency", "internal"],
+        [
+            "validation",
+            "not_found",
+            "permission",
+            "connection",
+            "timeout",
+            "dependency",
+            "internal",
+        ],
     )
     def test_all_error_types_accepted(self, error_type: str):
         result = tool_error("test", error_type=error_type)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.37.2"
+version = "0.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `tool_error()` 헬퍼 + `classify_tool_exception()` — 7개 error_type(validation, not_found, permission, connection, timeout, dependency, internal) + recoverable 플래그 + hint
- tool_executor.py의 catch-all에서 자동 분류 (기존 `{"error": str(exc)}` → 구조화된 에러)
- MCP manager의 에러에 error_type/hint/context 추가
- web_tools, document_tools, analysis tools 적용 (가장 빈번한 에러 패턴)
- 하위 호환: `error` 키는 여전히 string

## Why
LLM이 tool error를 받았을 때 retryable vs permanent을 구분할 수 없고, 복구 방법을 알 수 없었음. 분류 + 힌트로 자율 복구 능력 향상.

## Changes
| File | Change |
|------|--------|
| `core/tools/base.py` | `tool_error()`, `classify_tool_exception()`, `ToolErrorType` |
| `core/agent/tool_executor.py` | catch-all에서 `classify_tool_exception()` 사용 |
| `core/mcp/manager.py` | `call_tool()` 에러에 구조화된 포맷 적용 |
| `core/tools/web_tools.py` | httpx, HTTP status, search 에러 분류 |
| `core/tools/document_tools.py` | permission, not_found, validation 에러 분류 |
| `core/tools/analysis.py` | validation, not_found 에러 분류 + valid values hint |
| `tests/test_tool_error.py` | 24개 테스트 (helper + classifier) |
| `tests/test_mcp_lifecycle.py` | fallback hint 테스트 업데이트 |

## Test plan
- [x] `tests/test_tool_error.py` — 24 tests pass
- [x] `tests/test_mcp_lifecycle.py` — fallback hint tests pass
- [x] Full suite: 3536 passed, 0 failed
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)