### PR TITLE
feat: graceful serve drain — SIGTERM waits for active sessions

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-31T16:26:18+09:00 task_id=llm-friendly-errors
+session=2026-03-31T16:54:56+09:00 task_id=graceful-drain

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1746,7 +1746,8 @@ def serve(
                 )
                 log.warning(
                     "Drain timeout: %d sessions still active after %ds",
-                    _remaining, _drain_timeout_s,
+                    _remaining,
+                    _drain_timeout_s,
                 )
             else:
                 console.print("  [dim]All sessions drained.[/dim]")

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1714,6 +1714,45 @@ def serve(
                 _serve_session_lane.cleanup_idle()
             _time.sleep(1.0)
     finally:
+        # --- Phase 1: stop accepting new connections ---
+        # Close the server socket so no new CLI clients connect during drain.
+        # Active client handler threads continue running.
+        if _cli_poller is not None:
+            _cli_poller.stop_accepting()
+
+        # --- Phase 2: drain active sessions ---
+        _drain_timeout_s = 30  # max seconds to wait for active sessions
+        _drain_poll_s = 0.5
+        _active = 0
+        if _serve_session_lane:
+            _active = _serve_session_lane.active_count
+        if _active > 0:
+            console.print()
+            console.print(
+                f"  [dim]Draining {_active} active session(s) "
+                f"(timeout {_drain_timeout_s}s)...[/dim]"
+            )
+            _deadline = _time.monotonic() + _drain_timeout_s
+            while _time.monotonic() < _deadline:
+                _active = _serve_session_lane.active_count if _serve_session_lane else 0
+                if _active == 0:
+                    break
+                _time.sleep(_drain_poll_s)
+            _remaining = _serve_session_lane.active_count if _serve_session_lane else 0
+            if _remaining > 0:
+                console.print(
+                    f"  [warning]Drain timeout: {_remaining} session(s) still active "
+                    f"— forcing shutdown[/warning]"
+                )
+                log.warning(
+                    "Drain timeout: %d sessions still active after %ds",
+                    _remaining, _drain_timeout_s,
+                )
+            else:
+                console.print("  [dim]All sessions drained.[/dim]")
+                log.info("Graceful drain completed")
+
+        # --- Phase 3: component shutdown ---
         # Scheduler graceful shutdown (save state before stopping)
         if _sched_svc is not None:
             _sched_svc.save()

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -139,8 +139,27 @@ class CLIPoller:
         self._thread.start()
         log.info("CLI channel listening on %s", self._socket_path)
 
+    def stop_accepting(self) -> None:
+        """Stop accepting new connections but let active handlers finish.
+
+        Closes the server socket and sets the stop event so the accept loop
+        exits. Active client handler threads continue running until their
+        current request completes.
+        """
+        import contextlib
+
+        self._stop_event.set()
+        if self._server:
+            with contextlib.suppress(OSError):
+                self._server.close()
+            self._server = None
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        log.info("CLI channel stopped accepting new connections")
+
     def stop(self) -> None:
-        """Stop the socket server and clean up."""
+        """Stop the socket server and clean up all clients."""
         import contextlib
 
         self._stop_event.set()

--- a/tests/test_graceful_drain.py
+++ b/tests/test_graceful_drain.py
@@ -1,0 +1,161 @@
+"""Tests for graceful serve drain — SIGTERM → active session completion wait."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from core.orchestration.lane_queue import Lane, SessionLane
+
+
+class TestGracefulDrainLogic:
+    """Test the drain polling logic used by serve shutdown."""
+
+    def test_drain_completes_when_no_active(self):
+        """Drain loop exits immediately when no sessions are active."""
+        sl = SessionLane(max_sessions=10)
+        assert sl.active_count == 0
+
+        # Simulate drain loop
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if sl.active_count == 0:
+                break
+            time.sleep(0.1)
+        assert sl.active_count == 0
+
+    def test_drain_waits_for_active_session(self):
+        """Drain loop waits until active session releases."""
+        sl = SessionLane(max_sessions=10)
+        released = threading.Event()
+
+        def _hold_session():
+            with sl.acquire("test-session"):
+                time.sleep(0.3)
+            released.set()
+
+        t = threading.Thread(target=_hold_session)
+        t.start()
+        time.sleep(0.05)  # let thread acquire
+
+        assert sl.active_count == 1
+
+        # Drain loop
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if sl.active_count == 0:
+                break
+            time.sleep(0.1)
+
+        assert sl.active_count == 0
+        assert released.is_set()
+        t.join()
+
+    def test_drain_timeout_with_stuck_session(self):
+        """Drain loop respects timeout when session is stuck."""
+        sl = SessionLane(max_sessions=10)
+        stop = threading.Event()
+
+        def _hold_forever():
+            with sl.acquire("stuck-session"):
+                stop.wait()  # hold until test says stop
+
+        t = threading.Thread(target=_hold_forever, daemon=True)
+        t.start()
+        time.sleep(0.05)
+
+        assert sl.active_count == 1
+
+        # Drain with short timeout
+        drain_timeout = 0.3
+        deadline = time.monotonic() + drain_timeout
+        timed_out = True
+        while time.monotonic() < deadline:
+            if sl.active_count == 0:
+                timed_out = False
+                break
+            time.sleep(0.05)
+
+        assert timed_out
+        assert sl.active_count == 1
+
+        # Cleanup
+        stop.set()
+        t.join(timeout=2.0)
+
+    def test_global_lane_active_count(self):
+        """Lane.active_count reflects held slots."""
+        lane = Lane("test", max_concurrent=4)
+        assert lane.active_count == 0
+
+        acquired = threading.Event()
+        release = threading.Event()
+
+        def _hold():
+            with lane.acquire("w1"):
+                acquired.set()
+                release.wait()
+
+        t = threading.Thread(target=_hold, daemon=True)
+        t.start()
+        acquired.wait(timeout=2.0)
+        assert lane.active_count == 1
+
+        release.set()
+        t.join(timeout=2.0)
+        assert lane.active_count == 0
+
+    def test_multiple_sessions_drain(self):
+        """Drain waits for all concurrent sessions to complete."""
+        sl = SessionLane(max_sessions=10)
+        threads: list[threading.Thread] = []
+        completed = {"count": 0}
+        lock = threading.Lock()
+
+        def _hold(key: str, hold_time: float):
+            with sl.acquire(key):
+                time.sleep(hold_time)
+            with lock:
+                completed["count"] += 1
+
+        # Start 3 sessions with different hold times
+        for i, hold in enumerate([0.1, 0.2, 0.3]):
+            t = threading.Thread(target=_hold, args=(f"s{i}", hold))
+            t.start()
+            threads.append(t)
+        time.sleep(0.05)
+        assert sl.active_count == 3
+
+        # Drain
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if sl.active_count == 0:
+                break
+            time.sleep(0.05)
+
+        assert sl.active_count == 0
+        assert completed["count"] == 3
+        for t in threads:
+            t.join()
+
+
+class TestCLIPollerStopAccepting:
+    """Test CLIPoller.stop_accepting() method."""
+
+    def test_stop_accepting_exists(self):
+        """CLIPoller has stop_accepting method."""
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        assert hasattr(CLIPoller, "stop_accepting")
+
+    def test_stop_accepting_idempotent(self):
+        """Calling stop_accepting on non-started poller does not crash."""
+        from unittest.mock import MagicMock
+
+        from core.gateway.pollers.cli_poller import CLIPoller
+
+        services = MagicMock()
+        poller = CLIPoller(services)
+        # Should not raise
+        poller.stop_accepting()
+        poller.stop_accepting()  # second call also safe


### PR DESCRIPTION
## Summary
- SIGTERM/SIGINT 수신 시 3-phase graceful shutdown 구현
- Phase 1: `stop_accepting()` — 새 CLI 연결 차단 (server socket close)
- Phase 2: `SessionLane.active_count` 폴링 (30s timeout, 0.5s interval) — active session 완료 대기
- Phase 3: 기존 component shutdown (scheduler save, MCP cleanup, gateway stop)

## Why
기존 serve는 SIGTERM 시 active session을 무시하고 즉시 종료. LLM 호출 중단 + 데이터 손실 발생 가능. Graceful drain으로 진행중인 세션이 자연스럽게 완료된 후 종료.

## Changes
| File | Change |
|------|--------|
| `core/cli/__init__.py` | 3-phase shutdown: stop_accepting → drain poll → component shutdown |
| `core/gateway/pollers/cli_poller.py` | `stop_accepting()` 메서드 추가 — accept loop만 중지, active handlers 유지 |
| `tests/test_graceful_drain.py` | 7개 테스트 (no-active, wait, timeout, concurrent, stop_accepting) |

## Test plan
- [x] `tests/test_graceful_drain.py` — 7 tests pass
- [x] Full suite: 3519 passed, 0 failed
- [x] `ruff check` — 0 errors
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)