### PR TITLE
docs: v0.40.0 release — CHANGELOG + 4b sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.40.0] — 2026-03-31
+
+### Added
+- **200K 절대 토큰 가드** — 1M 컨텍스트 모델에서 200K 토큰 초과 시 rate limit pool 분리 방지. 퍼센트 기반 임계값(80%=800K)과 별개로 `ABSOLUTE_TOKEN_CEILING`이 tool result 요약 → compact 2단계 압축 실행
+- **LLM 친화적 에러 메시지** — `tool_error()` 헬퍼 + `classify_tool_exception()` 도입. `error_type` (validation/auth/rate_limit/network/timeout/internal), `recoverable` 플래그, `hints` 리스트로 구조화. tool_executor, MCP, web_tools, document_tools, analysis tools 적용
+
 ## [0.39.0] — 2026-03-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.39.0
+- **Version**: 0.40.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 192
-- **Tests**: 3509+
+- **Tests**: 3540+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -144,7 +144,7 @@ uv run mypy core/
 
 ### Expected Test Results
 
-3509+ tests pass. 3 IP fixtures produce tier spread:
+3540+ tests pass. 3 IP fixtures produce tier spread:
 - Berserk: **S** (81.2) — conversion_failure
 - Cowboy Bebop: **A** (68.4) — undermarketed
 - Ghost in the Shell: **B** (51.7) — discovery_failure
@@ -369,7 +369,7 @@ Code changes → repeat 3 quality gates. Fix on failure.
 ```bash
 uv run ruff check core/ tests/      # Lint: 0 errors
 uv run mypy core/                    # Type: 0 errors
-uv run pytest tests/ -m "not live"   # Test: 3496+ pass
+uv run pytest tests/ -m "not live"   # Test: 3540+ pass
 ```
 
 #### 4. E2E Verify
@@ -440,7 +440,7 @@ Update `docs/progress.md` only from main. Backlog → In Progress → Done.
 |------|---------|----------|
 | Lint | `uv run ruff check core/ tests/` | 0 errors |
 | Type | `uv run mypy core/` | 0 errors |
-| Test | `uv run pytest tests/ -m "not live"` | 3496+ pass |
+| Test | `uv run pytest tests/ -m "not live"` | 3540+ pass |
 | E2E | `uv run geode analyze "Cowboy Bebop" --dry-run` | A (68.4) |
 
 ## Custom Skills (Scaffold)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.39.0 — Long-running Autonomous Execution Harness
+# GEODE v0.40.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.39.0"
+version = "0.40.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- v0.39.0 → v0.40.0 version bump (4 locations: pyproject.toml, CLAUDE.md, README.md, CHANGELOG.md)
- CHANGELOG에 #584 (200K 토큰 가드) + #585 (LLM 친화적 에러) 엔트리 추가
- 실측값 갱신: Tests 3509+ → 3540+

## Why
2개 feature PR (#584, #585) merge 후 docs-sync 필요. New feature = MINOR bump.

## Test plan
- [x] 4b 버전 동기화 확인 (0.40.0)
- [x] 실측값 (3540 tests, 192 modules) 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)