### PR TITLE
fix: /model crash — defer adapter swap to round boundary

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -373,6 +373,27 @@ class AgenticLoop:
         new_count = len(self._tools)
         return max(0, new_count - old_count)
 
+    def _sync_model_from_settings(self) -> None:
+        """Check if settings.model diverged and apply the change safely.
+
+        Called at the top of each agentic round — between LLM calls, never
+        mid-call.  This replaces the old pattern of calling update_model()
+        from inside a tool handler, which swapped the adapter while the
+        current round was still processing tool results.
+        """
+        try:
+            from core.config import settings
+
+            if settings.model != self.model:
+                log.info(
+                    "Model drift detected: loop=%s settings=%s — syncing",
+                    self.model,
+                    settings.model,
+                )
+                self.update_model(settings.model)
+        except Exception:
+            log.debug("Model drift check failed", exc_info=True)
+
     def update_model(self, model: str, provider: str | None = None) -> None:
         """Update model and provider without reconstructing the loop.
 
@@ -540,6 +561,10 @@ class AgenticLoop:
 
             is_last_round = (self.max_rounds > 0) and (round_idx == self.max_rounds - 1)
             self._op_logger.begin_round("AgenticLoop")
+
+            # Model drift check: settings may have changed via switch_model tool
+            # or /model command between rounds. Apply safely before next LLM call.
+            self._sync_model_from_settings()
 
             # Poll for sub-agent announced results (OpenClaw Spawn+Announce)
             self._check_announced_results(messages)

--- a/core/agent/safety_constants.py
+++ b/core/agent/safety_constants.py
@@ -14,7 +14,6 @@ SAFE_TOOLS: frozenset[str] = frozenset(
         "search_ips",
         "show_help",
         "check_status",
-        "switch_model",
         "memory_search",
         "manage_rule",
         "web_fetch",
@@ -47,6 +46,7 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "calendar_create_event",
         "calendar_sync_scheduler",
         "manage_context",
+        "switch_model",
     }
 )
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -330,12 +330,10 @@ def _apply_model(selected: ModelProfile) -> None:
     settings.model = selected.id
     _upsert_env("GEODE_MODEL", selected.id)
 
-    # Hot-swap the active AgenticLoop model (P0 fix: /model mid-session)
-    from core.cli.session_state import get_current_loop
-
-    loop = get_current_loop()
-    if loop is not None:
-        loop.update_model(selected.id)
+    # Model hot-swap is deferred: AgenticLoop._sync_model_from_settings()
+    # checks settings.model at the start of each round and applies
+    # the change safely between LLM calls. Direct loop.update_model()
+    # during tool execution caused adapter swap mid-call → crash.
 
     console.print(
         f"  [success]Model[/success]  {old} → [bold]{selected.label}[/bold]"

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -765,12 +765,16 @@ def _build_system_handlers(
 
     def handle_switch_model(**kwargs: Any) -> dict[str, Any]:
         model_hint = kwargs.get("model_hint", "")
+        # Only update settings — do NOT call loop.update_model() here.
+        # The AgenticLoop checks for model drift at the start of each round
+        # and applies the change safely between LLM calls (not mid-call).
         cmd_model(model_hint)
         return {
             "status": "ok",
-            "action": "model",
+            "action": "model_deferred",
             "current_model": settings.model,
             "ensemble": settings.ensemble_mode,
+            "note": "Model change applied. Will take effect on next round.",
         }
 
     def handle_set_api_key(**kwargs: Any) -> dict[str, Any]:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -268,8 +268,8 @@ class TestApplyModel:
         # Should not write .env when model unchanged
         _apply_model(next(p for p in MODEL_PROFILES if p.id == settings.model))
 
-    def test_apply_model_hot_swaps_active_loop(self, tmp_path: Path, monkeypatch):
-        """P0 fix: _apply_model() should call loop.update_model() on the active loop."""
+    def test_apply_model_defers_hot_swap(self, tmp_path: Path, monkeypatch):
+        """_apply_model() updates settings only — loop sync is deferred to round boundary."""
         from unittest.mock import MagicMock
 
         monkeypatch.chdir(tmp_path)
@@ -287,7 +287,10 @@ class TestApplyModel:
         try:
             target = MODEL_PROFILES[3]  # GPT-5.4
             _apply_model(target)
-            mock_loop.update_model.assert_called_once_with(target.id)
+            # _apply_model no longer calls loop.update_model() directly —
+            # AgenticLoop._sync_model_from_settings() handles it at round start.
+            mock_loop.update_model.assert_not_called()
+            assert settings.model == target.id
         finally:
             settings.model = old
             session_state.set_current_loop(None)

--- a/tests/test_model_switch_guard.py
+++ b/tests/test_model_switch_guard.py
@@ -203,6 +203,39 @@ class TestUpdateModelIntegration:
             loop.update_model("glm-5", "zhipuai")
         # No crash
 
+    def test_sync_model_from_settings_detects_drift(self):
+        """_sync_model_from_settings picks up settings.model change."""
+        ctx = ConversationContext()
+        loop = _make_loop(ctx, model="claude-opus-4-6")
+        assert loop.model == "claude-opus-4-6"
+
+        from core.config import settings
+
+        old = settings.model
+        try:
+            settings.model = "glm-5"
+            with patch("core.cli.ui.agentic_ui.update_session_model"):
+                loop._sync_model_from_settings()
+            assert loop.model == "glm-5"
+        finally:
+            settings.model = old
+
+    def test_sync_model_from_settings_noop_when_same(self):
+        """No update when settings.model matches loop.model."""
+        ctx = ConversationContext()
+        loop = _make_loop(ctx, model="claude-opus-4-6")
+
+        from core.config import settings
+
+        old = settings.model
+        try:
+            settings.model = "claude-opus-4-6"
+            with patch.object(loop, "update_model") as mock_update:
+                loop._sync_model_from_settings()
+                mock_update.assert_not_called()
+        finally:
+            settings.model = old
+
 
 # ---------------------------------------------------------------------------
 # usage_pct cap removed


### PR DESCRIPTION
## Summary
- `/model` 변경 시 CLI exit 버그 수정
- 근본 원인: `switch_model` tool이 agentic loop **내부**에서 `loop.update_model()` 호출 → adapter가 mid-call 교체 → provider 불일치 → connection crash → thin CLI exit

## Root Cause Analysis (explore-reason-act)
1. **Explore**: 유저가 "opus 4.6으로 변경해" 자연어 입력 → glm-5가 `switch_model` tool_use 반환
2. **Reason**: `handle_switch_model` → `cmd_model` → `_apply_model` → `loop.update_model()` — **같은 agentic round 안**에서 adapter 교체. 다음 round의 LLM call이 교체된 adapter로 시도되지만 message format/context가 이전 provider용
3. **Act**: deferred model sync — settings만 변경, adapter 교체는 round boundary에서 수행

## Changes
| File | Change |
|------|--------|
| `core/cli/commands.py` | `_apply_model()`에서 `loop.update_model()` 직접 호출 제거 |
| `core/agent/agentic_loop.py` | `_sync_model_from_settings()` 추가 — 라운드 시작 시 settings.model drift 감지 → 안전하게 적용 |
| `core/agent/safety_constants.py` | `switch_model` SAFE → WRITE 이동 |
| `core/cli/tool_handlers.py` | deferred 모델 변경 주석 추가 |
| `tests/test_commands.py` | hot-swap 테스트 → deferred 동작 검증으로 변경 |
| `tests/test_model_switch_guard.py` | drift detection 테스트 2건 추가 |

## Test plan
- [x] 3549 tests pass, 0 failed
- [x] `ruff check` + `ruff format` — 0 errors
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)