### PR TITLE
fix: GLM cost tracking — wire get_tracker().record()

### DIFF
--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -156,6 +156,15 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
 
         self._circuit_breaker.record_success()
 
+        # Track token usage/cost (was missing — GLM calls were $0.00)
+        if hasattr(response, "usage") and response.usage:
+            from core.llm.token_tracker import get_tracker
+
+            actual_model = used_model or model
+            in_tok = response.usage.prompt_tokens or 0
+            out_tok = response.usage.completion_tokens or 0
+            get_tracker().record(actual_model, in_tok, out_tok)
+
         if used_model and used_model != model:
             log.warning("Model failover: %s -> %s", model, used_model)
 

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -216,6 +216,32 @@ class TestGlmNativeWebSearch:
         # And it should be different from the parent
         assert GlmAgenticAdapter.agentic_call is not OpenAIAgenticAdapter.agentic_call
 
+    def test_glm_agentic_call_tracks_cost(self) -> None:
+        """GlmAgenticAdapter.agentic_call must call get_tracker().record()."""
+        import inspect
+
+        from core.llm.providers.glm import GlmAgenticAdapter
+
+        source = inspect.getsource(GlmAgenticAdapter.agentic_call)
+        assert "get_tracker" in source, "GLM agentic_call must call get_tracker().record()"
+        assert ".record(" in source, "GLM agentic_call must record token usage"
+
+    def test_glm_cost_is_nonzero(self) -> None:
+        """GLM models with non-free pricing must produce non-zero cost."""
+        from core.llm.token_tracker import TokenTracker
+
+        tracker = TokenTracker()
+        cost = tracker.calculate_cost("glm-5", 1000, 500)
+        assert cost > 0, "glm-5 should have non-zero cost"
+
+    def test_glm_free_tier_zero_cost(self) -> None:
+        """glm-4.7-flash (free tier) should produce zero cost."""
+        from core.llm.token_tracker import TokenTracker
+
+        tracker = TokenTracker()
+        cost = tracker.calculate_cost("glm-4.7-flash", 1000, 500)
+        assert cost == 0.0, "glm-4.7-flash is free tier"
+
 
 # ---------------------------------------------------------------------------
 # OpenAI: Responses API migration


### PR DESCRIPTION
## Summary
- `GlmAgenticAdapter.agentic_call()`에서 `get_tracker().record()` 호출 누락 수정
- GLM API 호출 비용이 항상 $0.00으로 표시되던 버그 해결

## Why
OpenAI adapter는 `get_tracker().record()` 호출 4곳, GLM adapter는 0곳. GLM 사용 시 TokenTracker에 비용이 기록되지 않아 세션 비용 집계에서 GLM 호출분이 누락됨.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/glm.py` | `response.usage` → `get_tracker().record(actual_model, in_tok, out_tok)` 추가 |
| `tests/test_native_tools.py` | 3 tests: source inspection, glm-5 non-zero cost, glm-4.7-flash free tier |

## Test plan
- [x] 3 new GLM cost tests pass
- [x] Full suite: 3552 passed
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)