### PR TITLE
feat: HookSystem audit — 4 new events, 12 loggers, S4 fix, 3 trigger sites

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-31T16:54:56+09:00 task_id=graceful-drain
+session=2026-03-31T20:00:12+09:00 task_id=hook-system-audit

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1719,9 +1719,7 @@ def serve(
             if _gw_services and _gw_services.hook_system:
                 from core.hooks import HookEvent
 
-                _active_count = (
-                    _serve_session_lane.active_count if _serve_session_lane else 0
-                )
+                _active_count = _serve_session_lane.active_count if _serve_session_lane else 0
                 _gw_services.hook_system.trigger(
                     HookEvent.SHUTDOWN_STARTED,
                     {"active_sessions": _active_count},

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -1714,6 +1714,21 @@ def serve(
                 _serve_session_lane.cleanup_idle()
             _time.sleep(1.0)
     finally:
+        # --- Phase 0: notify shutdown hook ---
+        try:
+            if _gw_services and _gw_services.hook_system:
+                from core.hooks import HookEvent
+
+                _active_count = (
+                    _serve_session_lane.active_count if _serve_session_lane else 0
+                )
+                _gw_services.hook_system.trigger(
+                    HookEvent.SHUTDOWN_STARTED,
+                    {"active_sessions": _active_count},
+                )
+        except Exception:
+            log.debug("SHUTDOWN_STARTED hook failed", exc_info=True)
+
         # --- Phase 1: stop accepting new connections ---
         # Close the server socket so no new CLI clients connect during drain.
         # Active client handler threads continue running.

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -97,6 +97,16 @@ class HookEvent(Enum):
     # Pipeline timeout (B3)
     PIPELINE_TIMEOUT = "pipeline_timeout"
 
+    # Serve lifecycle
+    SHUTDOWN_STARTED = "shutdown_started"
+
+    # Config hot-reload
+    CONFIG_RELOADED = "config_reloaded"
+
+    # MCP server lifecycle
+    MCP_SERVER_CONNECTED = "mcp_server_connected"
+    MCP_SERVER_FAILED = "mcp_server_failed"
+
 
 @dataclass
 class HookResult:

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -36,6 +36,28 @@ _GLOBAL_DOTENV_PATH = Path.home() / ".geode" / ".env"
 
 _EMPTY_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
 
+# Hook system injection (same pattern as core/llm/router.py)
+_mcp_hooks: Any = None
+
+
+def set_mcp_hooks(hooks: Any) -> None:
+    """Inject HookSystem for MCP server lifecycle events."""
+    global _mcp_hooks  # noqa: PLW0603
+    _mcp_hooks = hooks
+
+
+def _fire_mcp_hook(event_name: str, data: dict[str, Any]) -> None:
+    """Fire a hook event if HookSystem is available."""
+    if _mcp_hooks is None:
+        return
+    try:
+        from core.hooks import HookEvent
+
+        _mcp_hooks.trigger(HookEvent(event_name), data)
+    except Exception:
+        log.debug("MCP hook fire failed for %s", event_name, exc_info=True)
+
+
 # Singleton instance — prevents duplicate MCP server processes
 _singleton_instance: MCPServerManager | None = None
 _singleton_lock = __import__("threading").Lock()
@@ -422,8 +444,13 @@ class MCPServerManager:
         client = StdioMCPClient(command=command, args=args, env=env)
         if client.connect():
             self._clients[server_name] = client
+            _fire_mcp_hook("mcp_server_connected", {"server_name": server_name})
             return client
 
+        _fire_mcp_hook(
+            "mcp_server_failed",
+            {"server_name": server_name, "error": "Connection failed"},
+        )
         log.debug("MCP server not available (skipped): %s", server_name)
         return None
 

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -42,7 +42,7 @@ _mcp_hooks: Any = None
 
 def set_mcp_hooks(hooks: Any) -> None:
     """Inject HookSystem for MCP server lifecycle events."""
-    global _mcp_hooks  # noqa: PLW0603
+    global _mcp_hooks
     _mcp_hooks = hooks
 
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -253,11 +253,14 @@ class GeodeRuntime:
         tool_registry = infra.build_default_registry()
         profile_store, profile_rotator, cooldown_tracker = infra.build_auth()
         llm_adapter, secondary_adapter = infra.build_llm_adapters(tool_registry, policy_chain)
-        config_watcher = bootstrap.build_config_watcher()
+        config_watcher = bootstrap.build_config_watcher(hooks=hooks)
         lane_queue = infra.build_default_lanes()
 
         # Unified bootstrap: MCP, Skills, Readiness
         mcp_manager = bootstrap.build_mcp_manager()
+        from core.mcp.manager import set_mcp_hooks
+
+        set_mcp_hooks(hooks)
         skill_registry = bootstrap.build_skill_registry()
         readiness = bootstrap.build_readiness()
 
@@ -270,7 +273,7 @@ class GeodeRuntime:
             organization_memory,
             context_assembler,
             user_profile,
-        ) = bootstrap.build_memory(session_store=session_store)
+        ) = bootstrap.build_memory(session_store=session_store, hooks=hooks)
         automation = automation_wiring.build_automation(
             hooks=hooks,
             session_key=session_key,

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -339,12 +339,47 @@ def build_hooks(
 
     _register_plugin("filesystem_hook_plugins", _reg_filesystem_plugins)
 
+    # C9: Audit loggers — handler-less events that had triggers but no dedicated handler.
+    # Table-driven registration (automation.py pattern) for observability.
+    # fmt: off
+    _E = HookEvent
+    _AUDIT_LOGGER_HOOKS: list[tuple[HookEvent, str, str, list[str]]] = [
+        (_E.CONTEXT_CRITICAL,       "ctx_critical",   "Context critical: %.0f%% (%s)",       ["usage_pct", "model"]),
+        (_E.SUBAGENT_STARTED,       "sa_started",     "SubAgent started: %s (%s)",            ["task_id", "task_type"]),
+        (_E.LLM_CALL_START,         "llm_start",      "LLM call: %s (%s)",                   ["model", "function"]),
+        (_E.VERIFICATION_FAIL,      "verif_fail",     "Verification failed: %s — %s",        ["node", "ip_name"]),
+        (_E.TOOL_RECOVERY_ATTEMPTED,"recovery_try",   "Tool recovery attempted: %s",          ["tool_name"]),
+        (_E.TOOL_RECOVERY_FAILED,   "recovery_fail",  "Tool recovery failed: %s — %s",       ["tool_name", "error"]),
+        (_E.FALLBACK_CROSS_PROVIDER,"xprovider_fb",   "Cross-provider fallback: %s → %s",    ["from_model", "to_model"]),
+        (_E.PIPELINE_TIMEOUT,       "pipe_timeout",   "Pipeline timeout: %ss",                ["timeout_s"]),
+        (_E.POST_ANALYSIS,          "post_analysis",  "Post-analysis: %s",                    ["trigger_type"]),
+        (_E.SHUTDOWN_STARTED,       "shutdown",       "Shutdown started: %s active sessions",  ["active_sessions"]),
+        (_E.CONFIG_RELOADED,        "config_reload",  "Config reloaded: %s",                  ["config_path"]),
+        (_E.MCP_SERVER_FAILED,      "mcp_fail",       "MCP server failed: %s — %s",          ["server_name", "error"]),
+    ]
+    # fmt: on
+
+    def _reg_audit_loggers() -> None:
+        for event, name, tmpl, keys in _AUDIT_LOGGER_HOOKS:
+
+            def _make(t: str, ks: list[str]) -> Any:
+                def _handler(_e: HookEvent, d: dict[str, Any]) -> None:
+                    vals = tuple(d.get(k, "") for k in ks)
+                    log.info(t, *vals)
+
+                return _handler
+
+            hooks.register(event, _make(tmpl, keys), name=name, priority=90)
+
+    _register_plugin("audit_loggers", _reg_audit_loggers)
+
     return hooks, run_log, stuck_detector
 
 
 def build_memory(
     *,
     session_store: SessionStorePort,
+    hooks: Any = None,
 ) -> tuple[ProjectMemory, MonoLakeOrganizationMemory, ContextAssembler, FileBasedUserProfile]:
     """Build L2 memory components: project, org, context assembler, user profile."""
     project_memory = ProjectMemory()
@@ -390,10 +425,11 @@ def build_memory(
     set_context_assembler(context_assembler)
 
     # Wire memory into memory tools via contextvars (P1 memory autonomy)
-    from core.tools.memory_tools import set_org_memory, set_project_memory
+    from core.tools.memory_tools import set_memory_hooks, set_org_memory, set_project_memory
 
     set_project_memory(project_memory)
     set_org_memory(organization_memory)
+    set_memory_hooks(hooks)
 
     # Wire user profile into profile tools via contextvars
     from core.tools.profile_tools import set_user_profile
@@ -426,7 +462,7 @@ def build_session_store(*, session_ttl: float) -> SessionStorePort:
     return session_store
 
 
-def build_config_watcher() -> ConfigWatcher:
+def build_config_watcher(*, hooks: HookSystem | None = None) -> ConfigWatcher:
     """Build ConfigWatcher and register .env hot-reload handler if .env exists."""
     config_watcher = ConfigWatcher(debounce_ms=CONFIG_WATCHER_DEBOUNCE_MS)
     env_path = Path(".env")
@@ -474,7 +510,15 @@ def build_config_watcher() -> ConfigWatcher:
         settings.model_registry_dir = new_settings.model_registry_dir
         # L2 Memory
         settings.session_ttl_hours = new_settings.session_ttl_hours
-        log.info("Settings hot-reload complete (12 fields updated)")
+        log.info("Settings hot-reload complete (11 fields updated)")
+        if hooks is not None:
+            try:
+                hooks.trigger(
+                    HookEvent.CONFIG_RELOADED,
+                    {"config_path": str(path), "fields_updated": 11},
+                )
+            except Exception:
+                log.debug("CONFIG_RELOADED hook failed", exc_info=True)
 
     config_watcher.watch(env_path, _on_config_change, name="dotenv")
     config_watcher.start()

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -341,26 +341,39 @@ def build_hooks(
 
     # C9: Audit loggers — handler-less events that had triggers but no dedicated handler.
     # Table-driven registration (automation.py pattern) for observability.
-    # fmt: off
     _E = HookEvent
-    _AUDIT_LOGGER_HOOKS: list[tuple[HookEvent, str, str, list[str]]] = [
-        (_E.CONTEXT_CRITICAL,       "ctx_critical",   "Context critical: %.0f%% (%s)",       ["usage_pct", "model"]),
-        (_E.SUBAGENT_STARTED,       "sa_started",     "SubAgent started: %s (%s)",            ["task_id", "task_type"]),
-        (_E.LLM_CALL_START,         "llm_start",      "LLM call: %s (%s)",                   ["model", "function"]),
-        (_E.VERIFICATION_FAIL,      "verif_fail",     "Verification failed: %s — %s",        ["node", "ip_name"]),
-        (_E.TOOL_RECOVERY_ATTEMPTED,"recovery_try",   "Tool recovery attempted: %s",          ["tool_name"]),
-        (_E.TOOL_RECOVERY_FAILED,   "recovery_fail",  "Tool recovery failed: %s — %s",       ["tool_name", "error"]),
-        (_E.FALLBACK_CROSS_PROVIDER,"xprovider_fb",   "Cross-provider fallback: %s → %s",    ["from_model", "to_model"]),
-        (_E.PIPELINE_TIMEOUT,       "pipe_timeout",   "Pipeline timeout: %ss",                ["timeout_s"]),
-        (_E.POST_ANALYSIS,          "post_analysis",  "Post-analysis: %s",                    ["trigger_type"]),
-        (_E.SHUTDOWN_STARTED,       "shutdown",       "Shutdown started: %s active sessions",  ["active_sessions"]),
-        (_E.CONFIG_RELOADED,        "config_reload",  "Config reloaded: %s",                  ["config_path"]),
-        (_E.MCP_SERVER_FAILED,      "mcp_fail",       "MCP server failed: %s — %s",          ["server_name", "error"]),
+    _AL: list[tuple[HookEvent, str, str, list[str]]] = [
+        (
+            _E.CONTEXT_CRITICAL,
+            "ctx_critical",
+            "Context critical: %.0f%% (%s)",
+            ["usage_pct", "model"],
+        ),
+        (_E.SUBAGENT_STARTED, "sa_started", "SubAgent started: %s (%s)", ["task_id", "task_type"]),
+        (_E.LLM_CALL_START, "llm_start", "LLM call: %s (%s)", ["model", "function"]),
+        (_E.VERIFICATION_FAIL, "verif_fail", "Verification failed: %s — %s", ["node", "ip_name"]),
+        (_E.TOOL_RECOVERY_ATTEMPTED, "recovery_try", "Tool recovery attempted: %s", ["tool_name"]),
+        (
+            _E.TOOL_RECOVERY_FAILED,
+            "recovery_fail",
+            "Tool recovery failed: %s — %s",
+            ["tool_name", "error"],
+        ),
+        (
+            _E.FALLBACK_CROSS_PROVIDER,
+            "xprovider_fb",
+            "Cross-provider fallback: %s → %s",
+            ["from_model", "to_model"],
+        ),
+        (_E.PIPELINE_TIMEOUT, "pipe_timeout", "Pipeline timeout: %ss", ["timeout_s"]),
+        (_E.POST_ANALYSIS, "post_analysis", "Post-analysis: %s", ["trigger_type"]),
+        (_E.SHUTDOWN_STARTED, "shutdown", "Shutdown: %s active sessions", ["active_sessions"]),
+        (_E.CONFIG_RELOADED, "config_reload", "Config reloaded: %s", ["config_path"]),
+        (_E.MCP_SERVER_FAILED, "mcp_fail", "MCP server failed: %s — %s", ["server_name", "error"]),
     ]
-    # fmt: on
 
     def _reg_audit_loggers() -> None:
-        for event, name, tmpl, keys in _AUDIT_LOGGER_HOOKS:
+        for event, name, tmpl, keys in _AL:
 
             def _make(t: str, ks: list[str]) -> Any:
                 def _handler(_e: HookEvent, d: dict[str, Any]) -> None:

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -50,6 +50,28 @@ def set_org_memory(mem: MonoLakeOrganizationMemory | None) -> None:
     _org_memory_ctx.set(mem)
 
 
+# Hook system injection (same pattern as core/llm/router.py)
+_hooks_ctx: ContextVar[Any] = ContextVar("memory_tools_hooks", default=None)
+
+
+def set_memory_hooks(hooks: Any) -> None:
+    """Inject HookSystem so memory tool execute() methods can fire events."""
+    _hooks_ctx.set(hooks)
+
+
+def _fire_hook(event_name: str, data: dict[str, Any]) -> None:
+    """Fire a hook event if HookSystem is available. No-op otherwise."""
+    hooks = _hooks_ctx.get()
+    if hooks is None:
+        return
+    try:
+        from core.hooks import HookEvent
+
+        hooks.trigger(HookEvent(event_name), data)
+    except Exception:
+        log.debug("Hook fire failed for %s", event_name, exc_info=True)
+
+
 def _get_session_store(store: SessionStorePort | None = None) -> SessionStorePort:
     """Get the session store to use, falling back to default."""
     if store is not None:
@@ -319,6 +341,8 @@ class MemorySaveTool:
                     insight = str(data.get("content", data))
                     proj.add_insight(insight)
 
+        _fire_hook("memory_saved", {"key": session_id, "persistent": persistent})
+
         return {
             "result": {
                 "session_id": session_id,
@@ -381,6 +405,8 @@ class RuleCreateTool:
             return {"result": {"created": False, "error": "Project memory not available"}}
 
         success = proj.create_rule(rule_name, paths, content)
+        if success:
+            _fire_hook("rule_created", {"name": rule_name, "paths": paths})
         return {
             "result": {
                 "created": success,
@@ -430,6 +456,8 @@ class RuleUpdateTool:
             return {"result": {"updated": False, "error": "Project memory not available"}}
 
         success = proj.update_rule(rule_name, content)
+        if success:
+            _fire_hook("rule_updated", {"name": rule_name})
         return {
             "result": {
                 "updated": success,
@@ -470,6 +498,8 @@ class RuleDeleteTool:
             return {"result": {"deleted": False, "error": "Project memory not available"}}
 
         success = proj.delete_rule(rule_name)
+        if success:
+            _fire_hook("rule_deleted", {"name": rule_name})
         return {
             "result": {
                 "deleted": success,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -299,7 +299,7 @@ class TestApplyContext:
 class TestHookEventCount:
     def test_events_exist(self) -> None:
         """HookEvent has 40 events after H6 orphan pruning."""
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -411,7 +411,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count after H6 orphan pruning."""
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from core.hooks import HookEvent, HookResult, HookSystem
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"
@@ -19,6 +19,67 @@ class TestHookEvent:
         assert HookEvent.SCORING_COMPLETE.value == "scoring_complete"
         assert HookEvent.VERIFICATION_PASS.value == "verification_pass"
         assert HookEvent.VERIFICATION_FAIL.value == "verification_fail"
+
+    def test_new_audit_events(self):
+        """v0.42.0 audit: 4 new lifecycle events."""
+        assert HookEvent.SHUTDOWN_STARTED.value == "shutdown_started"
+        assert HookEvent.CONFIG_RELOADED.value == "config_reloaded"
+        assert HookEvent.MCP_SERVER_CONNECTED.value == "mcp_server_connected"
+        assert HookEvent.MCP_SERVER_FAILED.value == "mcp_server_failed"
+
+
+class TestAuditLoggers:
+    """Verify table-driven audit loggers register correctly."""
+
+    def test_audit_loggers_registered(self):
+        """build_hooks() registers audit logger handlers."""
+        from unittest.mock import patch
+
+        with patch("core.runtime_wiring.bootstrap.RunLog"), \
+             patch("core.runtime_wiring.bootstrap.StuckDetector"):
+            from core.runtime_wiring.bootstrap import build_hooks
+
+            hooks, _, _ = build_hooks(
+                session_key="test",
+                run_id="test-run",
+                log_dir=None,
+                stuck_timeout_s=60,
+            )
+
+        # Check a representative sample of audit loggers
+        all_hooks = hooks.list_hooks()
+        assert "ctx_critical" in all_hooks.get("context_critical", [])
+        assert "llm_start" in all_hooks.get("llm_call_start", [])
+        assert "shutdown" in all_hooks.get("shutdown_started", [])
+        assert "mcp_fail" in all_hooks.get("mcp_server_failed", [])
+
+
+class TestMemoryToolHooks:
+    """S4 fix: memory tools fire hook events symmetrically with CLI."""
+
+    def test_rule_create_fires_hook(self):
+        """RuleCreateTool.execute() fires RULE_CREATED hook."""
+        from unittest.mock import MagicMock, patch
+
+        from core.tools.memory_tools import RuleCreateTool, set_memory_hooks
+
+        mock_hooks = MagicMock()
+        set_memory_hooks(mock_hooks)
+
+        mock_proj = MagicMock()
+        mock_proj.create_rule.return_value = True
+
+        with patch("core.tools.memory_tools._project_memory_ctx") as ctx:
+            ctx.get.return_value = mock_proj
+            tool = RuleCreateTool()
+            tool.execute(name="test-rule", paths=["*.py"], content="rule body")
+
+        mock_hooks.trigger.assert_called_once()
+        call_args = mock_hooks.trigger.call_args
+        assert call_args[0][0].value == "rule_created"
+        assert call_args[0][1]["name"] == "test-rule"
+
+        set_memory_hooks(None)  # cleanup
 
 
 class TestHookResult:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -35,8 +35,10 @@ class TestAuditLoggers:
         """build_hooks() registers audit logger handlers."""
         from unittest.mock import patch
 
-        with patch("core.runtime_wiring.bootstrap.RunLog"), \
-             patch("core.runtime_wiring.bootstrap.StuckDetector"):
+        with (
+            patch("core.runtime_wiring.bootstrap.RunLog"),
+            patch("core.runtime_wiring.bootstrap.StuckDetector"),
+        ):
             from core.runtime_wiring.bootstrap import build_hooks
 
             hooks, _, _ = build_hooks(

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,7 +356,7 @@ class TestHookEventTypes:
 
     def test_hook_event_count(self):
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -27,7 +27,7 @@ class TestLLMLifecycleEvents:
 
     def test_event_count_includes_llm_events(self) -> None:
         """40 events total after H6 orphan pruning."""
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
 
 class TestFireHook:

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -278,7 +278,7 @@ class TestHookEventCount:
     def test_total_event_count(self) -> None:
         from core.hooks import HookEvent
 
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -35,7 +35,7 @@ class TestMCPHookEvents:
 
     def test_hook_event_count(self) -> None:
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 42
+        assert len(HookEvent) == 46
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.39.0"
+version = "0.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- HookSystem 46 이벤트 전수 audit (42 → 46)
- 초기 진단 수정: dead code 4건 → 실제 0건 (모두 trigger 존재 확인)
- 12개 table-driven audit logger 등록 (handler-less 이벤트 커버)
- S4 fix: memory_tools.py에서 MEMORY_SAVED/RULE_* hook 발화 (CLI와 대칭)
- 3개 새 trigger site: SHUTDOWN_STARTED, CONFIG_RELOADED, MCP_SERVER_CONNECTED/FAILED

## Why
handler-less 이벤트 12건은 run_log만 기록. 전용 handler 없이 관측 불가.
memory_tools의 RULE_* hook은 CLI 경로에서만 발화되어 agentic mode에서 비대칭 동작.
lifecycle event 4건 누락으로 shutdown/config/MCP 상태 변화 관측 불가.

## Changes
| File | Change |
|------|--------|
| `core/hooks/system.py` | +4 enum (SHUTDOWN_STARTED, CONFIG_RELOADED, MCP_SERVER_*) |
| `core/runtime_wiring/bootstrap.py` | 12 table-driven loggers + CONFIG_RELOADED trigger + set_memory_hooks wiring |
| `core/tools/memory_tools.py` | hook ContextVar + 4 trigger sites |
| `core/cli/__init__.py` | SHUTDOWN_STARTED trigger |
| `core/mcp/manager.py` | MCP hook infra + 2 trigger sites |
| `core/runtime.py` | set_mcp_hooks + build_memory(hooks=) + build_config_watcher(hooks=) wiring |
| 7 test files | enum count 42 → 46 + TestAuditLoggers + TestMemoryToolHooks |

## Test plan
- [x] 3552 tests pass, 0 failed
- [x] `ruff check` — 0 errors
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)