### PR TITLE
fix: transcript total_cost always $0

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -313,7 +313,19 @@ class AgenticLoop:
             if text:
                 self._transcript.record_assistant_message(text)
             rounds = getattr(result, "rounds", 0)
-            self._transcript.record_session_end(rounds=rounds)
+
+            # Read accumulated cost from TokenTracker (was missing → always $0)
+            total_cost = 0.0
+            try:
+                from core.llm.token_tracker import get_tracker
+
+                total_cost = get_tracker().accumulator.total_cost_usd
+            except Exception:
+                log.debug("Could not read session cost from TokenTracker")
+
+            self._transcript.record_session_end(
+                rounds=rounds, total_cost=total_cost
+            )
         except Exception:
             log.debug("Transcript end recording failed", exc_info=True)
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -323,9 +323,7 @@ class AgenticLoop:
             except Exception:
                 log.debug("Could not read session cost from TokenTracker")
 
-            self._transcript.record_session_end(
-                rounds=rounds, total_cost=total_cost
-            )
+            self._transcript.record_session_end(rounds=rounds, total_cost=total_cost)
         except Exception:
             log.debug("Transcript end recording failed", exc_info=True)
 


### PR DESCRIPTION
## Summary
- `_record_transcript_end()`에서 `total_cost` 인자를 전달하지 않아 transcript session_end가 항상 `$0` 기록
- `get_tracker().accumulator.total_cost_usd`에서 실제 비용 읽어 전달

## Why
transcript `s-f3dc95bde365.jsonl`에서 GLM 세션 역추적:
```json
{"event": "session_end", "duration_s": 0, "total_cost": 0, "rounds": 1}
```
usage store(`~/.geode/usage/2026-03.jsonl`)에는 `cost: 0.0070628` 기록됨 → 추적은 되지만 transcript에 전달 안 됨. 모든 provider 공통 문제이나 GLM에서 먼저 발견.

## Test plan
- [x] 3552 passed
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)