### PR TITLE
fix: model card price — per-token to per-1M

### DIFF
--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -136,9 +136,10 @@ def _build_model_card(model: str) -> str:
             parts.append(f"Context window: {ctx_str} tokens.")
 
         if pricing:
-            parts.append(
-                f"Cost: ${pricing.input:.2f} input / ${pricing.output:.2f} output per 1M tokens."
-            )
+            # pricing.input/output are per-token; multiply back for per-1M display
+            in_per_m = pricing.input * 1_000_000
+            out_per_m = pricing.output * 1_000_000
+            parts.append(f"Cost: ${in_per_m:.2f} input / ${out_per_m:.2f} output per 1M tokens.")
 
         # Fallback chain
         from core.config import (


### PR DESCRIPTION
## Summary
- `_build_model_card()`에서 per-token 가격을 `:.2f`로 포맷 → 모든 모델 `$0.00`
- `pricing.input * 1_000_000`으로 per-1M 변환 후 표시

## Why
GLM 자기소개에서 "현재 glm-5 모델은 무료입니다" 답변. 시스템 프롬프트 model card에 주입되는 가격이 `$0.00`이라 LLM이 무료로 인식. 모든 provider 공통 문제 (pricing.input = 5.00/1M = 0.000005 → `$0.00`).

## Verification
```
glm-5:           $0.72 input / $2.30 output per 1M tokens  ✓
glm-4.7-flash:   $0.00 input / $0.00 output per 1M tokens  ✓ (free)
claude-opus-4-6: $5.00 input / $25.00 output per 1M tokens ✓
gpt-5.4:         $2.50 input / $15.00 output per 1M tokens ✓
```

## Test plan
- [x] 3555 passed
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)