### PR TITLE
fix: tool_error() migration — remaining 4 files

### DIFF
--- a/core/tools/calendar_tools.py
+++ b/core/tools/calendar_tools.py
@@ -195,7 +195,7 @@ class CalendarCreateEventTool:
         except Exception as exc:
             return tool_error(
                 f"Failed to create event: {exc}",
-                error_type="network",
+                error_type="connection",
                 hint="Check calendar API connectivity and retry.",
             )
 
@@ -249,7 +249,7 @@ class CalendarSyncSchedulerTool:
         except Exception as exc:
             return tool_error(
                 f"Calendar sync failed: {exc}",
-                error_type="network",
+                error_type="connection",
                 hint="Check calendar API connectivity and retry.",
             )
 

--- a/core/tools/calendar_tools.py
+++ b/core/tools/calendar_tools.py
@@ -12,6 +12,8 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from core.tools.base import tool_error
+
 
 class CalendarListEventsTool:
     """Tool for listing calendar events."""
@@ -150,12 +152,21 @@ class CalendarCreateEventTool:
 
         adapter = get_calendar()
         if adapter is None or not adapter.is_available():
-            return {"error": "No calendar adapter available. Configure credentials."}
+            return tool_error(
+                "No calendar adapter available.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Run /key to configure calendar API credentials.",
+            )
 
         title: str = kwargs["title"]
         start = _parse_datetime(kwargs["start_datetime"])
         if start is None:
-            return {"error": "Invalid start_datetime format. Use ISO format."}
+            return tool_error(
+                "Invalid start_datetime format.",
+                error_type="validation",
+                hint="Use ISO 8601 format, e.g. 2026-04-01T09:00:00.",
+            )
 
         end = _parse_datetime(kwargs.get("end_datetime"))
         if end is None:
@@ -182,7 +193,11 @@ class CalendarCreateEventTool:
                 }
             }
         except Exception as exc:
-            return {"error": f"Failed to create event: {exc}"}
+            return tool_error(
+                f"Failed to create event: {exc}",
+                error_type="network",
+                hint="Check calendar API connectivity and retry.",
+            )
 
 
 class CalendarSyncSchedulerTool:
@@ -220,14 +235,23 @@ class CalendarSyncSchedulerTool:
 
         bridge = get_calendar_bridge()
         if bridge is None:
-            return {"error": "Calendar bridge not available. Configure scheduler + calendar."}
+            return tool_error(
+                "Calendar bridge not available.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Both scheduler and calendar adapters must be configured.",
+            )
 
         direction: str = kwargs.get("direction", "both")
         try:
             result = bridge.sync(direction=direction)
             return {"result": result}
         except Exception as exc:
-            return {"error": f"Calendar sync failed: {exc}"}
+            return tool_error(
+                f"Calendar sync failed: {exc}",
+                error_type="network",
+                hint="Check calendar API connectivity and retry.",
+            )
 
 
 def _parse_datetime(value: str | None) -> datetime | None:

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from core.memory.organization import MonoLakeOrganizationMemory
 from core.memory.port import SessionStorePort
+from core.tools.base import tool_error
 from core.memory.project import ProjectMemory
 from core.memory.session import InMemorySessionStore
 
@@ -563,7 +564,12 @@ class NoteSaveTool:
 
         proj = _project_memory_ctx.get()
         if proj is None:
-            return {"error": "Project memory not available"}
+            return tool_error(
+                "Project memory not available.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Project memory initializes from .geode/memory/. Check directory exists.",
+            )
 
         note_text = f"**{key}**: {content}"
         proj.add_insight(note_text)
@@ -594,7 +600,12 @@ class NoteReadTool:
 
         proj = _project_memory_ctx.get()
         if proj is None:
-            return {"error": "Project memory not available"}
+            return tool_error(
+                "Project memory not available.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Project memory initializes from .geode/memory/. Check directory exists.",
+            )
 
         memory_text = proj.load_memory()
         if not query:

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -18,9 +18,9 @@ from typing import Any
 
 from core.memory.organization import MonoLakeOrganizationMemory
 from core.memory.port import SessionStorePort
-from core.tools.base import tool_error
 from core.memory.project import ProjectMemory
 from core.memory.session import InMemorySessionStore
+from core.tools.base import tool_error
 
 log = logging.getLogger(__name__)
 

--- a/core/tools/profile_tools.py
+++ b/core/tools/profile_tools.py
@@ -13,6 +13,8 @@ import logging
 from contextvars import ContextVar
 from typing import Any
 
+from core.tools.base import tool_error
+
 from core.memory.user_profile import FileBasedUserProfile
 
 log = logging.getLogger(__name__)
@@ -58,7 +60,12 @@ class ProfileShowTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         profile = _user_profile_ctx.get()
         if profile is None:
-            return {"error": "User profile not configured"}
+            return tool_error(
+                "User profile not configured.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Profile initializes on first interaction. Try again after setup.",
+            )
 
         data = profile.load_profile()
         patterns = profile.get_learned_patterns()
@@ -124,7 +131,12 @@ class ProfileUpdateTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         profile = _user_profile_ctx.get()
         if profile is None:
-            return {"error": "User profile not configured"}
+            return tool_error(
+                "User profile not configured.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Profile initializes on first interaction. Try again after setup.",
+            )
 
         # Merge with existing
         existing = profile.load_profile()
@@ -175,7 +187,12 @@ class ProfilePreferenceTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         profile = _user_profile_ctx.get()
         if profile is None:
-            return {"error": "User profile not configured"}
+            return tool_error(
+                "User profile not configured.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Profile initializes on first interaction. Try again after setup.",
+            )
 
         key: str = kwargs["key"]
         value = kwargs.get("value")
@@ -237,7 +254,12 @@ class ProfileLearnTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         profile = _user_profile_ctx.get()
         if profile is None:
-            return {"error": "User profile not configured"}
+            return tool_error(
+                "User profile not configured.",
+                error_type="dependency",
+                recoverable=False,
+                hint="Profile initializes on first interaction. Try again after setup.",
+            )
 
         pattern: str = kwargs["pattern"]
         category: str = kwargs.get("category", "general")

--- a/core/tools/profile_tools.py
+++ b/core/tools/profile_tools.py
@@ -13,9 +13,8 @@ import logging
 from contextvars import ContextVar
 from typing import Any
 
-from core.tools.base import tool_error
-
 from core.memory.user_profile import FileBasedUserProfile
+from core.tools.base import tool_error
 
 log = logging.getLogger(__name__)
 

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
-from core.tools.base import Tool
+from core.tools.base import Tool, tool_error
 
 if TYPE_CHECKING:
     from core.tools.policy import PolicyChain
@@ -85,7 +85,7 @@ class ToolSearchTool:
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         query = kwargs.get("query", "").lower()
         if not query:
-            return {"error": "query is required"}
+            return tool_error("query is required", error_type="validation")
 
         matches: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- calendar_tools(5), profile_tools(4), memory_tools(2), registry(1) — 12개 raw `{"error": "string"}` → `tool_error()` 마이그레이션
- #585에서 시작한 LLM 친화적 에러 구조화 완료 (100% 커버리지)

## Why
#585가 tool_executor, MCP, web_tools, document_tools, analysis에 적용했으나 4개 파일 미적용. LLM이 에러 유형/복구 가능 여부를 판단할 수 없어 무의미한 재시도 발생.

## Test plan
- [x] 3589 passed (1 flaky: test_subprocess_async — 기존 timing issue)
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)