### PR TITLE
feat: IPC HITL relay — bidirectional approval for WRITE/DANGEROUS tools

### DIFF
--- a/.owner
+++ b/.owner
@@ -1,1 +1,1 @@
-session=2026-03-31T20:00:12+09:00 task_id=hook-system-audit
+session=2026-03-31T21:53:54+09:00 task_id=hitl-ipc-relay

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -98,6 +98,7 @@ class ToolExecutor:
         mcp_manager: Any | None = None,
         hitl_level: int = 2,
         hooks: HookSystem | None = None,
+        approval_callback: Callable[[str, str, str], str] | None = None,
     ) -> None:
         self._handlers: dict[str, Callable[..., dict[str, Any]]] = action_handlers or {}
         self._bash = bash_tool or BashTool()
@@ -107,6 +108,8 @@ class ToolExecutor:
         # HITL level: 0=autonomous, 1=write-only, 2=all prompts
         self._hitl_level = hitl_level
         self._hooks: HookSystem | None = hooks
+        # IPC approval relay: callback(tool_name, detail, safety_level) → 'y'/'n'/'a'
+        self._approval_callback = approval_callback
         # Per-server MCP approval cache — approve once per server per session
         # Thread-safe: ToolExecutor is per-AgenticLoop, but sub-agents may share.
         import threading
@@ -130,16 +133,17 @@ class ToolExecutor:
         except Exception:
             log.debug("Hook fire failed for %s", event_name, exc_info=True)
 
-    def _prompt_with_always(self, label: str, detail: str) -> str:
+    def _prompt_with_always(self, label: str, detail: str, *, safety_level: str = "write") -> str:
         """Show a [Y/n/A] prompt and return 'y', 'n', or 'a'.
 
-        Args:
-            label: Header text (e.g., "Bash command requires approval")
-            detail: Detail text already printed before this call
-
-        Returns:
-            'y' for yes, 'n' for no, 'a' for always (session-level)
+        Uses IPC approval relay callback if available (thin-client mode),
+        otherwise falls back to console.input() (direct terminal).
         """
+        # IPC mode: relay approval to thin client via callback
+        if self._approval_callback is not None:
+            return self._approval_callback(label, detail, safety_level)
+
+        # Direct terminal mode
         from core.cli import _restore_terminal
 
         _restore_terminal()

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -179,6 +179,11 @@ class IPCClient:
                 if on_stream is not None:
                     on_stream(response.get("data", ""))
                 continue
+            # HITL approval relay — serve requests user confirmation
+            if rtype == "approval_request":
+                decision = self._handle_approval_request(response)
+                self._send({"type": "approval_response", "decision": decision})
+                continue
             # Structured events — all non-stream, non-terminal types
             if rtype in (
                 "tool_start",
@@ -218,6 +223,34 @@ class IPCClient:
                     on_event(response)
                 continue
             return response
+
+    def _handle_approval_request(self, msg: dict[str, Any]) -> str:
+        """Display approval prompt to user and return decision."""
+        from rich.console import Console
+
+        c = Console()
+        tool = msg.get("tool_name", "?")
+        detail = msg.get("detail", "")
+        level = msg.get("safety_level", "write")
+
+        c.print()
+        label = "Write" if level == "write" else "Dangerous"
+        c.print(f"  [warning]{label} tool requires approval[/warning]")
+        c.print(f"  [dim]Tool:[/dim] [bold]{tool}[/bold]")
+        if detail:
+            c.print(f"  [dim]{detail}[/dim]")
+        c.print()
+
+        try:
+            resp = c.input("  [header]Allow? [Y/n/A][/header] ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            c.print()
+            return "n"
+        if resp in ("a", "always"):
+            return "a"
+        if resp in ("", "y", "yes"):
+            return "y"
+        return "n"
 
     def request_resume(
         self,

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -71,6 +71,43 @@ class _StreamingWriter:
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass
 
+    def request_approval(
+        self,
+        tool_name: str,
+        detail: str,
+        safety_level: str = "write",
+    ) -> str:
+        """Send approval request to thin CLI and wait for response.
+
+        Returns 'y', 'n', or 'a' (always).
+        """
+        self._send_json(
+            {
+                "type": "approval_request",
+                "tool_name": tool_name,
+                "detail": detail,
+                "safety_level": safety_level,
+            }
+        )
+        # Block until thin client sends approval_response
+        try:
+            self._client.settimeout(120.0)  # 2 min for user decision
+            buf = b""
+            while True:
+                chunk = self._client.recv(4096)
+                if not chunk:
+                    return "n"
+                buf += chunk
+                if b"\n" in buf:
+                    line, _rest = buf.split(b"\n", 1)
+                    msg = json.loads(line.decode("utf-8"))
+                    if msg.get("type") == "approval_response":
+                        return msg.get("decision", "n")
+        except (TimeoutError, OSError, json.JSONDecodeError):
+            return "n"
+        finally:
+            self._client.settimeout(None)
+
     def flush(self) -> None:
         pass
 
@@ -232,11 +269,18 @@ class CLIPoller:
         conversation = ConversationContext()
         session_id = f"cli-{os.urandom(4).hex()}"
 
+        # Build IPC approval relay: WRITE/DANGEROUS tools prompt thin CLI
+        _writer = _StreamingWriter(client)
+
+        def _ipc_approval(tool_name: str, detail: str, safety_level: str) -> str:
+            return _writer.request_approval(tool_name, detail, safety_level)
+
         # Create an IPC session backed by serve's SharedServices
         _executor, loop = self._services.create_session(
             SessionMode.IPC,
             conversation=conversation,
             propagate_context=True,
+            approval_callback=_ipc_approval,
         )
 
         # Send session ID to client

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -102,7 +102,7 @@ class _StreamingWriter:
                     line, _rest = buf.split(b"\n", 1)
                     msg = json.loads(line.decode("utf-8"))
                     if msg.get("type") == "approval_response":
-                        return msg.get("decision", "n")
+                        return str(msg.get("decision", "n"))
         except (TimeoutError, OSError, json.JSONDecodeError):
             return "n"
         finally:

--- a/core/gateway/shared_services.py
+++ b/core/gateway/shared_services.py
@@ -39,8 +39,8 @@ class SessionMode(StrEnum):
     SCHEDULER = "scheduler"  # Cron/scheduled jobs — hitl=0, quiet, time=300s cap
 
 
-# Tools denied for non-terminal execution (IPC, DAEMON, SCHEDULER).
-# DANGEROUS tools require interactive terminal which these modes cannot provide.
+# Tools denied for headless modes (DAEMON, SCHEDULER) — no user to approve.
+# IPC mode has HITL relay, so these tools are available with user approval.
 _HEADLESS_DENIED_TOOLS: frozenset[str] = frozenset(
     {
         "run_bash",
@@ -61,7 +61,7 @@ _MODE_DEFAULTS: dict[SessionMode, dict[str, Any]] = {
         "max_rounds": 0,  # unlimited
     },
     SessionMode.IPC: {
-        "hitl_level": 0,  # auto-approve (WRITE ok, DANGEROUS policy-blocked)
+        "hitl_level": 2,  # full HITL — approval relayed to thin CLI via IPC
         "quiet": True,  # suppress serve-side UI; results sent via IPC JSON
         "time_budget_s": 0.0,  # unlimited (interactive via IPC)
         "max_rounds": 0,
@@ -121,6 +121,7 @@ class SharedServices:
         time_budget_override: float | None = None,
         verbose: bool = False,
         propagate_context: bool = False,
+        **kwargs: Any,
     ) -> tuple[ToolExecutor, AgenticLoop]:
         """Build a fully-wired (ToolExecutor, AgenticLoop) for *mode*.
 
@@ -151,9 +152,10 @@ class SharedServices:
 
             conversation = ConversationContext()
 
-        # Filter DANGEROUS tools for headless modes (PolicyChain enforcement)
+        # Filter DANGEROUS tools for truly headless modes (no user to approve).
+        # IPC mode has HITL relay — tools are gated by approval, not denied.
         handlers = self.tool_handlers
-        if mode in (SessionMode.IPC, SessionMode.SCHEDULER, SessionMode.DAEMON):
+        if mode in (SessionMode.SCHEDULER, SessionMode.DAEMON):
             denied = _HEADLESS_DENIED_TOOLS & set(handlers)
             if denied:
                 log.info("Headless mode %s: denied tools filtered — %s", mode, denied)
@@ -161,12 +163,14 @@ class SharedServices:
 
         # Build sub-agent manager + executor + loop
         sub_mgr = self._build_sub_agent_manager()
+        approval_cb = kwargs.get("approval_callback")
         executor = ToolExecutor(
             action_handlers=handlers,
             mcp_manager=self.mcp_manager,
             sub_agent_manager=sub_mgr,
             hitl_level=hitl,
             hooks=self.hook_system,
+            approval_callback=approval_cb,
         )
         loop = AgenticLoop(
             conversation,

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.41.0"
+version = "0.42.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- IPC hitl_level **0 → 2** (full HITL, CLI 사용자 승인 필수)
- 양방향 IPC approval 프로토콜: `approval_request` → 유저 프롬프트 → `approval_response`
- `run_bash` IPC에서 복원 — HITL gate로 보호 (policy 차단 아님)
- DAEMON/SCHEDULER는 기존대로 hitl_level=0 + run_bash 정책 차단

## Why
IPC(thin CLI) 모드에서 WRITE 도구(edit_file, memory_save 등)가 사용자 승인 없이 자동 실행되는 설계 결함. CLI 사용자는 명시적 opt-out(`--dangerously-skip-permission`) 없이는 HITL 보호를 받아야 함.

## Changes
| File | Change |
|------|--------|
| `core/gateway/shared_services.py` | IPC hitl_level 0→2, IPC에서 run_bash 허용 (HITL 보호) |
| `core/agent/tool_executor.py` | `approval_callback` 파라미터 추가 — IPC relay 또는 console.input() |
| `core/gateway/pollers/cli_poller.py` | `_StreamingWriter.request_approval()` — 소켓 양방향 승인 |
| `core/cli/ipc_client.py` | `_handle_approval_request()` — [Y/n/A] 프롬프트 + 응답 전송 |

## IPC Protocol Extension
```
Serve → Client: {"type": "approval_request", "tool_name": "edit_file", "detail": "...", "safety_level": "write"}
Client → Serve: {"type": "approval_response", "decision": "y"}
```

## Test plan
- [x] 3590 tests pass, 0 failed
- [x] test_hitl_level.py + test_phase3_ipc.py — 42 pass
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)