### PR TITLE
fix: /clear resets TokenTracker

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -1592,6 +1592,12 @@ def cmd_clear(args: str) -> None:
             return
 
     ctx.clear()
+
+    # Reset token tracker so stale cost/token counts don't persist
+    from core.llm.token_tracker import reset_tracker
+
+    reset_tracker()
+
     console.print(f"  [success]Conversation cleared[/success] ({msg_count} messages removed)")
     console.print()
 


### PR DESCRIPTION
## Summary
- `/clear` 후 TokenTracker accumulator에 이전 세션 비용/토큰이 잔존 → `reset_tracker()` 호출 추가

## Why
`/clear`가 messages만 비우고 TokenTracker를 초기화하지 않아 stale 상태 잔존. context overflow 체크가 이전 누적 토큰으로 오동작할 수 있고, 비용 표시도 부정확.

## Test plan
- [x] 3589 passed (1 flaky: subprocess timing)
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)