### PR TITLE
fix: Responses API tool format — flat instead of nested

### DIFF
--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -69,7 +69,7 @@ from core.llm.errors import UserCancelledError  # noqa: E402
 from core.llm.providers.openai import (  # noqa: E402
     OpenAIAgenticAdapter,
     _convert_messages_to_openai,
-    _tools_to_openai,
+    _tools_to_chat_completions,
 )
 from core.llm.router import call_with_failover  # noqa: E402
 
@@ -123,7 +123,7 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
 
         tc_val = tool_choice.get("type", "auto") if isinstance(tool_choice, dict) else tool_choice
 
-        oai_tools = _tools_to_openai(tools)
+        oai_tools = _tools_to_chat_completions(tools)
         oai_tools.append(_GLM_NATIVE_WEB_SEARCH)
 
         oai_messages = _convert_messages_to_openai(system, messages)

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -627,7 +627,34 @@ def _convert_user_to_responses(content: Any) -> list[dict[str, Any]]:
 
 
 def _tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Convert Anthropic tool definitions to OpenAI function-calling format."""
+    """Convert Anthropic tool definitions to OpenAI Responses API format.
+
+    Responses API uses flat structure: {type, name, description, parameters}
+    (NOT the nested Chat Completions format {type, function: {name, ...}}).
+    """
+    result: list[dict[str, Any]] = []
+    for t in tools:
+        name = t.get("name", "")
+        if not name:
+            continue
+        tool_def: dict[str, Any] = {
+            "type": "function",
+            "name": name,
+            "description": t.get("description", ""),
+        }
+        schema = t.get("input_schema")
+        if schema:
+            tool_def["parameters"] = schema
+        result.append(tool_def)
+    return result
+
+
+def _tools_to_chat_completions(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert Anthropic tool definitions to OpenAI Chat Completions format.
+
+    Chat Completions uses nested structure: {type: "function", function: {name, ...}}.
+    Used by GLM adapter which calls chat.completions.create.
+    """
     result: list[dict[str, Any]] = []
     for t in tools:
         name = t.get("name", "")


### PR DESCRIPTION
## Summary
- `_tools_to_openai()`가 Chat Completions nested format 생성 → Responses API(`client.responses.create`)에서 400 에러
- Responses API flat format으로 수정: `{type, name, description, parameters}` (NOT `{type, function: {name, ...}}`)
- GLM adapter는 `chat.completions.create` 사용 → 별도 `_tools_to_chat_completions()` 분리

## Why
GPT 모델 전환 후 "All openai models exhausted" 에러. 원인: Responses API가 `tools[0].name` 최상위 요구하지만 nested `function` wrapper로 전달. 공식 문서 교차검증 완료.

## Verification
```
56 tools + gpt-5.4 Responses API = OK (in=4299 out=6)
```

## Test plan
- [x] 3590 passed
- [x] Lint/Type: 0 errors
- [x] E2E: Responses API 직접 호출 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)