### PR TITLE
refactor: quality audit P0 — dedup + stale metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,12 +200,12 @@ Decision Tree on D-E-F axes:
 
 ## Tool Routing (AgenticLoop Direct)
 
-All free-text input goes directly to AgenticLoop. Claude sees all 47 tool definitions and autonomously selects via tool_use.
+All free-text input goes directly to AgenticLoop. Claude sees all 56 tool definitions and autonomously selects via tool_use.
 
 - `/command` -> commands.py slash command dispatch
 - Free text -> AgenticLoop.run() (while tool_use loop)
 
-Tool definitions are centrally managed in `core/tools/definitions.json` (47 tools).
+Tool definitions are centrally managed in `core/tools/definitions.json` (56 tools).
 
 **Tool Permission Levels** (spanning PolicyChain 6 layers):
 - **STANDARD**: Read/analysis tools — eligible for Sub-Agent auto_approve

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -21,7 +21,6 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from core.agent.worker import WorkerRequest
@@ -32,6 +31,7 @@ from core.orchestration.isolated_execution import (
     IsolationResult,
 )
 from core.orchestration.task_system import Task, TaskGraph
+from core.tools.base import load_tool_definition
 
 if TYPE_CHECKING:
     from core.skills.agents import AgentRegistry
@@ -808,17 +808,4 @@ def _extract_analysis_summary(result: dict[str, Any], ip_name: str) -> dict[str,
     }
 
 
-# Tool definition loaded from centralized JSON
-_TOOLS_JSON_PATH = Path(__file__).resolve().parent.parent / "tools" / "definitions.json"
-
-
-def _load_tool_definition(name: str) -> dict[str, Any]:
-    """Load a single tool definition by name from definitions.json."""
-    all_tools: list[dict[str, Any]] = json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8"))
-    for t in all_tools:
-        if t["name"] == name:
-            return t
-    raise KeyError(f"Tool '{name}' not found in {_TOOLS_JSON_PATH}")
-
-
-DELEGATE_TOOL_DEFINITION: dict[str, Any] = _load_tool_definition("delegate_task")
+DELEGATE_TOOL_DEFINITION: dict[str, Any] = load_tool_definition("delegate_task")

--- a/core/cli/bash_tool.py
+++ b/core/cli/bash_tool.py
@@ -11,15 +11,15 @@ Sandbox hardening (v0.22.0):
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
 import resource
 import subprocess  # nosec B404 — intentional: BashTool requires shell execution
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
+
+from core.tools.base import load_tool_definition
 
 log = logging.getLogger(__name__)
 
@@ -155,17 +155,4 @@ class BashTool:
         return out
 
 
-# Tool definition loaded from centralized JSON
-_TOOLS_JSON_PATH = Path(__file__).resolve().parent.parent / "tools" / "definitions.json"
-
-
-def _load_tool_definition(name: str) -> dict[str, Any]:
-    """Load a single tool definition by name from definitions.json."""
-    all_tools: list[dict[str, Any]] = json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8"))
-    for t in all_tools:
-        if t["name"] == name:
-            return t
-    raise KeyError(f"Tool '{name}' not found in {_TOOLS_JSON_PATH}")
-
-
-BASH_TOOL_DEFINITION: dict[str, Any] = _load_tool_definition("run_bash")
+BASH_TOOL_DEFINITION: dict[str, Any] = load_tool_definition("run_bash")

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from core.cli.ui.console import console
+from core.cli.ui.event_renderer import _fmt_tokens
 
 # Thread-local IPC writer for structured tool events.
 # When set (by CLIPoller._run_prompt_streaming), OperationLogger sends
@@ -953,8 +954,3 @@ def emit_node_skipped(node: str, reason: str) -> None:
     console.print(f"  [dim]⤳ Node skipped: {node} ({reason})[/dim]")
 
 
-def _fmt_tokens(n: int) -> str:
-    """Format token count: 1200 → 1.2k, 500 → 500."""
-    if n >= 1000:
-        return f"{n / 1000:.1f}k"
-    return str(n)

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -952,5 +952,3 @@ def emit_node_skipped(node: str, reason: str) -> None:
         writer.send_event("node_skipped", node=node, reason=reason)
         return
     console.print(f"  [dim]⤳ Node skipped: {node} ({reason})[/dim]")
-
-

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -179,9 +179,7 @@ _TOOLS_JSON_PATH = Path(__file__).resolve().parent / "definitions.json"
 
 def load_tool_definition(name: str) -> dict[str, Any]:
     """Load a single tool definition by name from definitions.json."""
-    all_tools: list[dict[str, Any]] = json.loads(
-        _TOOLS_JSON_PATH.read_text(encoding="utf-8")
-    )
+    all_tools: list[dict[str, Any]] = json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8"))
     for t in all_tools:
         if t["name"] == name:
             return t

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -6,6 +6,8 @@ tool_use API or autonomous agent patterns.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any, Literal, Protocol, runtime_checkable
 
 # Valid values for tool metadata fields.
@@ -166,3 +168,21 @@ def classify_tool_exception(exc: Exception, tool_name: str = "") -> dict[str, An
         error_type="internal",
         hint=f"Unexpected error in {tool_name}." if tool_name else "",
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared tool definition loader (was duplicated in sub_agent.py + bash_tool.py)
+# ---------------------------------------------------------------------------
+
+_TOOLS_JSON_PATH = Path(__file__).resolve().parent / "definitions.json"
+
+
+def load_tool_definition(name: str) -> dict[str, Any]:
+    """Load a single tool definition by name from definitions.json."""
+    all_tools: list[dict[str, Any]] = json.loads(
+        _TOOLS_JSON_PATH.read_text(encoding="utf-8")
+    )
+    for t in all_tools:
+        if t["name"] == name:
+            return t
+    raise KeyError(f"Tool '{name}' not found in {_TOOLS_JSON_PATH}")


### PR DESCRIPTION
## Summary
- CLAUDE.md tool count 47 → 56 (실측 불일치)
- `_load_tool_definition()` 2곳 중복 → `core/tools/base.py` 단일 소스
- `_fmt_tokens()` 2곳 중복 → event_renderer.py import

## Why
품질 감사 결과 3건의 중복/stale 데이터 발견. 10줄 감소, 코드 중복 제거.

## Deferred
- `_fire_hook()` 5곳 통합 — 인터페이스 변경 필요 (별도 PR)
- automation/ dead code — 피드백 루프 스캐폴딩 보존

## Test plan
- [x] 3580 passed
- [x] Lint/Type: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)