### PR TITLE
feat: auto-learn hook — TURN_COMPLETE pattern detection

### DIFF
--- a/core/hooks/auto_learn.py
+++ b/core/hooks/auto_learn.py
@@ -1,0 +1,186 @@
+"""Auto-learn hook — detects user patterns from turn data and persists to profile.
+
+Runs on TURN_COMPLETE. Deterministic regex detectors extract self-introductions,
+explicit preferences, language preferences, domain interests, and tool-usage
+frequency. Writes directly to FileBasedUserProfile.add_learned_pattern(),
+bypassing the WRITE tool gate.
+
+Noise control: min input length, slash-command exclusion, 60s cooldown,
+10-pattern-per-session cap, built-in dedup in FileBasedUserProfile.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from collections import Counter
+from collections.abc import Callable
+from typing import Any
+
+from core.hooks.system import HookEvent
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MIN_INPUT_LEN = 15
+_COOLDOWN_S = 60.0
+_MAX_PER_SESSION = 10
+_TOOL_USAGE_THRESHOLD = 5
+
+# ---------------------------------------------------------------------------
+# Detectors — each returns (pattern_text, category) or None
+# ---------------------------------------------------------------------------
+
+_RE_SELF_INTRO = re.compile(
+    r"(?i)\b(i\s+am|i'm|my\s+name\s+is|call\s+me|i\s+work\b|나는|저는|제\s*이름은)",
+)
+
+_RE_EXPLICIT_PREF = re.compile(
+    r"(?i)\b(i\s+prefer|i\s+like\s+to|always\s+use|don't\s+use|never\s+use"
+    r"|i\s+hate|please\s+always|from\s+now\s+on|앞으로|항상)",
+)
+
+_RE_LANG_PREF = re.compile(
+    r"(?i)(korean|english|japanese|chinese|한국어|영어|일본어|중국어)"
+    r"\s*"
+    r"(로|으로|in\s+|으로\s*)"
+    r"\s*"
+    r"(답변|응답|대답|respond|answer|reply|write)",
+)
+
+_RE_LANG_PREF_REV = re.compile(
+    r"(?i)(답변|응답|대답|respond|answer|reply|write)"
+    r".{0,20}"
+    r"(in\s+|using\s+)"
+    r"(korean|english|japanese|chinese|한국어|영어|일본어|중국어)",
+)
+
+_RE_DOMAIN_INTEREST = re.compile(
+    r"(?i)\b(interested\s+in|working\s+on|researching|studying"
+    r"|focused\s+on|specializ\w+\s+in|관심\s*분야|연구\s*중)",
+)
+
+
+def _detect_self_intro(user_input: str) -> tuple[str, str] | None:
+    if _RE_SELF_INTRO.search(user_input):
+        return (f"User self-intro: {user_input[:120]}", "preference")
+    return None
+
+
+def _detect_explicit_pref(user_input: str) -> tuple[str, str] | None:
+    if _RE_EXPLICIT_PREF.search(user_input):
+        return (f"User preference: {user_input[:120]}", "preference")
+    return None
+
+
+def _detect_language_pref(user_input: str) -> tuple[str, str] | None:
+    m = _RE_LANG_PREF.search(user_input) or _RE_LANG_PREF_REV.search(user_input)
+    if m:
+        return (f"Language preference: {user_input[:120]}", "preference")
+    return None
+
+
+def _detect_domain_interest(user_input: str) -> tuple[str, str] | None:
+    if _RE_DOMAIN_INTEREST.search(user_input):
+        return (f"Domain interest: {user_input[:120]}", "domain")
+    return None
+
+
+_INPUT_DETECTORS: list[Callable[[str], tuple[str, str] | None]] = [
+    _detect_language_pref,  # highest priority — short inputs like "한국어로 답변해줘"
+    _detect_self_intro,
+    _detect_explicit_pref,
+    _detect_domain_interest,
+]
+
+
+def detect_patterns(
+    user_input: str,
+    tool_calls: list[str],
+    tool_counter: Counter[str],
+) -> list[tuple[str, str]]:
+    """Run all detectors and return matched (pattern_text, category) pairs.
+
+    At most one input-based pattern and one tool-usage pattern per call.
+    """
+    results: list[tuple[str, str]] = []
+
+    # Input-based detectors (first match wins)
+    stripped = user_input.strip()
+    if stripped and not stripped.startswith("/"):
+        for detector in _INPUT_DETECTORS:
+            # Language preference can be short ("한국어로 답변해줘"); others need more context
+            min_len = 8 if detector is _detect_language_pref else _MIN_INPUT_LEN
+            if len(stripped) < min_len:
+                continue
+            hit = detector(stripped)
+            if hit is not None:
+                results.append(hit)
+                break  # first match only
+
+    # Tool-usage frequency detector
+    tool_counter.update(tool_calls)
+    for tool_name, count in tool_counter.items():
+        if count == _TOOL_USAGE_THRESHOLD:  # emit exactly once at threshold
+            results.append(
+                (f"Frequently uses {tool_name}", "tool_usage"),
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Hook handler factory
+# ---------------------------------------------------------------------------
+
+
+def make_auto_learn_handler() -> tuple[str, Callable[..., None]]:
+    """Create a TURN_COMPLETE handler that auto-learns user patterns.
+
+    Returns (handler_name, handler_fn) for hook registration.
+    """
+    # Per-session state (resets on process restart)
+    session_count = 0
+    last_learn_ts = 0.0
+    tool_counter: Counter[str] = Counter()
+
+    def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
+        nonlocal session_count, last_learn_ts
+
+        if session_count >= _MAX_PER_SESSION:
+            return
+
+        from core.tools.profile_tools import get_user_profile
+
+        profile = get_user_profile()
+        if profile is None:
+            return
+
+        user_input: str = data.get("user_input", "")
+        tool_calls: list[str] = data.get("tool_calls", [])
+
+        patterns = detect_patterns(user_input, tool_calls, tool_counter)
+        if not patterns:
+            return
+
+        now = time.monotonic()
+        if now - last_learn_ts < _COOLDOWN_S:
+            return
+
+        for pattern_text, category in patterns:
+            if session_count >= _MAX_PER_SESSION:
+                break
+            try:
+                saved = profile.add_learned_pattern(pattern_text, category)
+                if saved:
+                    session_count += 1
+                    last_learn_ts = now
+                    log.debug("auto-learn: saved [%s] %s", category, pattern_text[:60])
+            except Exception:
+                log.debug("auto-learn: failed to save pattern", exc_info=True)
+
+    return ("turn_auto_learn", _on_turn_complete)

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -217,6 +217,20 @@ def build_hooks(
 
     _register_plugin("turn_memory_hook", _reg_turn_memory)
 
+    # C3b: Auto-learn user patterns on turn complete (Tier 0.5 cross-session memory)
+    def _reg_auto_learn() -> None:
+        from core.hooks.auto_learn import make_auto_learn_handler
+
+        name, handler = make_auto_learn_handler()
+        hooks.register(
+            HookEvent.TURN_COMPLETE,
+            handler,
+            name=name,
+            priority=84,
+        )
+
+    _register_plugin("turn_auto_learn", _reg_auto_learn)
+
     # C4: Session lifecycle hooks (OpenClaw agent:bootstrap pattern)
     def _reg_session_lifecycle() -> None:
         def _on_session_start(event: HookEvent, data: dict[str, Any]) -> None:

--- a/tests/test_auto_learn.py
+++ b/tests/test_auto_learn.py
@@ -1,0 +1,265 @@
+"""Tests for auto-learn hook (core/hooks/auto_learn.py)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from unittest.mock import MagicMock, patch
+
+from core.hooks.auto_learn import (
+    _MAX_PER_SESSION,
+    _TOOL_USAGE_THRESHOLD,
+    detect_patterns,
+    make_auto_learn_handler,
+)
+from core.hooks.system import HookEvent
+
+# ── detect_patterns tests ────────────────────────────────────────────────
+
+
+class TestDetectSelfIntro:
+    def test_english_i_am(self):
+        r = detect_patterns("I am a game designer at Nexon", [], Counter())
+        assert len(r) == 1
+        assert r[0][1] == "preference"
+        assert "self-intro" in r[0][0].lower()
+
+    def test_english_im(self):
+        r = detect_patterns("I'm a backend developer focused on Go", [], Counter())
+        assert len(r) == 1
+        assert "self-intro" in r[0][0].lower()
+
+    def test_korean_naneun(self):
+        r = detect_patterns("나는 데이터 사이언티스트야, ML 쪽 전문이야", [], Counter())
+        assert len(r) == 1
+        assert r[0][1] == "preference"
+
+    def test_korean_jeoneun(self):
+        r = detect_patterns("저는 프론트엔드 개발자입니다", [], Counter())
+        assert len(r) == 1
+
+
+class TestDetectExplicitPref:
+    def test_i_prefer(self):
+        r = detect_patterns("I prefer concise answers without fluff", [], Counter())
+        assert len(r) == 1
+        assert "preference" in r[0][0].lower()
+
+    def test_dont_use(self):
+        r = detect_patterns("don't use emojis in your responses please", [], Counter())
+        assert len(r) == 1
+
+    def test_from_now_on(self):
+        r = detect_patterns("from now on always answer in bullet points", [], Counter())
+        assert len(r) == 1
+
+    def test_korean_apuro(self):
+        r = detect_patterns("앞으로 코드 리뷰할 때 타입 체크도 같이 해줘", [], Counter())
+        assert len(r) == 1
+
+
+class TestDetectLanguagePref:
+    def test_korean_ro(self):
+        r = detect_patterns("한국어로 답변해줘 앞으로는", [], Counter())
+        assert len(r) == 1
+        assert "language" in r[0][0].lower()
+
+    def test_english_respond_in(self):
+        r = detect_patterns("please respond in english from now on", [], Counter())
+        assert len(r) == 1
+        assert "language" in r[0][0].lower()
+
+    def test_answer_in_japanese(self):
+        r = detect_patterns("can you answer in japanese for this session", [], Counter())
+        assert len(r) == 1
+
+
+class TestDetectDomainInterest:
+    def test_interested_in(self):
+        r = detect_patterns("I'm interested in dark fantasy game IPs", [], Counter())
+        # self-intro ("I'm") wins over domain interest (first-match)
+        assert len(r) == 1
+        assert "self-intro" in r[0][0].lower()
+
+    def test_working_on(self):
+        r = detect_patterns("currently working on a recommendation engine for Steam", [], Counter())
+        assert len(r) == 1
+        assert r[0][1] == "domain"
+
+    def test_researching(self):
+        r = detect_patterns("we are researching autonomous agent architectures", [], Counter())
+        assert len(r) == 1
+        assert r[0][1] == "domain"
+
+
+class TestDetectToolUsage:
+    def test_threshold_emits_once(self):
+        counter: Counter[str] = Counter()
+        # Below threshold — no emission
+        for _ in range(_TOOL_USAGE_THRESHOLD - 1):
+            r = detect_patterns("short", ["web_fetch"], counter)
+            tool_hits = [p for p in r if p[1] == "tool_usage"]
+            assert tool_hits == []
+
+        # At threshold — emits
+        r = detect_patterns("short", ["web_fetch"], counter)
+        tool_hits = [p for p in r if p[1] == "tool_usage"]
+        assert len(tool_hits) == 1
+        assert "web_fetch" in tool_hits[0][0]
+
+        # Above threshold — no re-emission
+        r = detect_patterns("short", ["web_fetch"], counter)
+        tool_hits = [p for p in r if p[1] == "tool_usage"]
+        assert tool_hits == []
+
+
+class TestNoiseControl:
+    def test_short_input_ignored(self):
+        r = detect_patterns("hi", [], Counter())
+        assert r == []
+
+    def test_slash_command_ignored(self):
+        r = detect_patterns("/help I am a developer", [], Counter())
+        assert r == []
+
+    def test_no_match_returns_empty(self):
+        r = detect_patterns("what is the weather today in Seoul?", [], Counter())
+        assert r == []
+
+    def test_first_match_wins(self):
+        # Contains both self-intro and domain interest, self-intro wins
+        r = detect_patterns(
+            "I'm focused on researching game IP potential",
+            [],
+            Counter(),
+        )
+        assert len(r) == 1
+        assert "self-intro" in r[0][0].lower()
+
+    def test_truncation_at_120(self):
+        long_input = "I am a " + "x" * 200
+        r = detect_patterns(long_input, [], Counter())
+        assert len(r) == 1
+        assert len(r[0][0]) <= len("User self-intro: ") + 120
+
+
+# ── Hook handler tests ──────────────────────────────────────────────────
+
+
+class TestAutoLearnHandler:
+    def _make_mock_profile(self) -> MagicMock:
+        profile = MagicMock()
+        profile.add_learned_pattern.return_value = True
+        return profile
+
+    def test_saves_pattern_on_match(self):
+        _, handler = make_auto_learn_handler()
+        mock_profile = self._make_mock_profile()
+
+        with patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile):
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I am a game designer at Nexon", "tool_calls": []},
+            )
+
+        mock_profile.add_learned_pattern.assert_called_once()
+        args = mock_profile.add_learned_pattern.call_args
+        assert "self-intro" in args[0][0].lower()
+        assert args[0][1] == "preference"
+
+    def test_no_profile_is_noop(self):
+        _, handler = make_auto_learn_handler()
+
+        with patch("core.tools.profile_tools.get_user_profile", return_value=None):
+            # Should not raise
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I am a game designer at Nexon", "tool_calls": []},
+            )
+
+    def test_cooldown_prevents_rapid_fire(self):
+        _, handler = make_auto_learn_handler()
+        mock_profile = self._make_mock_profile()
+
+        with patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile):
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I am a game designer at Nexon", "tool_calls": []},
+            )
+            # Second call within cooldown — should be suppressed
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I prefer concise answers always", "tool_calls": []},
+            )
+
+        assert mock_profile.add_learned_pattern.call_count == 1
+
+    def test_session_cap(self):
+        _, handler = make_auto_learn_handler()
+        mock_profile = self._make_mock_profile()
+
+        with (
+            patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile),
+            patch("core.hooks.auto_learn._COOLDOWN_S", 0),  # disable cooldown for this test
+        ):
+            for i in range(_MAX_PER_SESSION + 5):
+                handler(
+                    HookEvent.TURN_COMPLETE,
+                    {"user_input": f"I am developer number {i} at company", "tool_calls": []},
+                )
+
+        assert mock_profile.add_learned_pattern.call_count == _MAX_PER_SESSION
+
+    def test_dedup_not_counted(self):
+        """Dedup (add_learned_pattern returns False) doesn't increment session count."""
+        _, handler = make_auto_learn_handler()
+        mock_profile = self._make_mock_profile()
+        mock_profile.add_learned_pattern.return_value = False  # dedup
+
+        with (
+            patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile),
+            patch("core.hooks.auto_learn._COOLDOWN_S", 0),
+        ):
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I am a game designer at Nexon", "tool_calls": []},
+            )
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I prefer dark fantasy game IPs", "tool_calls": []},
+            )
+
+        # Both attempted, neither counted toward session cap
+        assert mock_profile.add_learned_pattern.call_count == 2
+
+    def test_exception_in_profile_is_swallowed(self):
+        _, handler = make_auto_learn_handler()
+        mock_profile = self._make_mock_profile()
+        mock_profile.add_learned_pattern.side_effect = OSError("disk full")
+
+        with patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile):
+            # Should not raise
+            handler(
+                HookEvent.TURN_COMPLETE,
+                {"user_input": "I am a game designer at Nexon", "tool_calls": []},
+            )
+
+
+class TestHookRegistration:
+    def test_auto_learn_registered_in_build_hooks(self):
+        from unittest.mock import patch
+
+        with (
+            patch("core.runtime_wiring.bootstrap.RunLog"),
+            patch("core.runtime_wiring.bootstrap.StuckDetector"),
+        ):
+            from core.runtime_wiring.bootstrap import build_hooks
+
+            hooks, _, _, _ = build_hooks(
+                session_key="test",
+                run_id="test-run",
+                log_dir=None,
+                stuck_timeout_s=60,
+            )
+
+        all_hooks = hooks.list_hooks()
+        assert "turn_auto_learn" in all_hooks.get("turn_complete", [])


### PR DESCRIPTION
## Summary
- `profile_learn` 도구가 WRITE 승인 + LLM 자발적 호출 이중 게이트로 500+ 세션 동안 학습 패턴 0건
- `TURN_COMPLETE` Hook에 5개 regex 디텍터 추가하여 사용자 패턴 자동 감지 → `FileBasedUserProfile.add_learned_pattern()` 직접 호출
- 노이즈 제어: min length, slash-command 제외, 60s 쿨다운, 세션 캡 10건, 내장 dedup

## Why
크로스세션 메모리 연속성의 핵심인 `learned.md`가 비활성 상태. E2E 데모에서 "기억하는 에이전트"를 보여주려면 자동 학습이 필수.

## Changes
| File | Change |
|------|--------|
| `core/hooks/auto_learn.py` | NEW — 5 detectors + `make_auto_learn_handler()` factory |
| `core/runtime_wiring/bootstrap.py` | `turn_auto_learn` hook 등록 (priority=84) |
| `tests/test_auto_learn.py` | 27 tests — detectors, noise control, hook integration |

## Test plan
- [x] `uv run pytest tests/test_auto_learn.py -v` — 27 passed
- [x] `uv run ruff check core/hooks/auto_learn.py` — All checks passed
- [x] `uv run mypy core/hooks/auto_learn.py` — no issues found
- [x] `uv run pytest tests/test_hooks.py -v` — 46 passed (registration 확인)
- [ ] CI 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)