### PR TITLE
fix: MCP tool name dedup — 400 'Tool names must be unique'

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -74,16 +74,19 @@ def get_agentic_tools(
         mcp_tools: Optional MCP tool definitions to include.
     """
     tools = list(_BASE_TOOLS)
+    existing_names = {t["name"] for t in tools}
     if registry:
-        existing_names = {t["name"] for t in tools}
         for tool_def in registry.to_anthropic_tools():
             if tool_def["name"] not in existing_names:
+                existing_names.add(tool_def["name"])
                 tools.append(tool_def)
-    # Merge MCP tools into the unified list
+    # Merge MCP tools into the unified list (dedup across servers)
     if mcp_tools:
         existing_names = {t["name"] for t in tools}
         for mcp_tool in mcp_tools:
-            if mcp_tool.get("name") not in existing_names:
+            name = mcp_tool.get("name")
+            if name and name not in existing_names:
+                existing_names.add(name)
                 tools.append(mcp_tool)
     return tools
 


### PR DESCRIPTION
## Summary
- `get_agentic_tools()`에서 MCP 도구 머지 시 `existing_names.add()` 누락
- `playwright` + `playwriter` 두 MCP 서버가 동일 도구명 노출 → 중복 → Anthropic API 400

## Why
GEODE serve IPC 세션에서 첫 LLM 호출 즉시 `bad_request` 에러 발생. 사용자가 아무 명령도 실행할 수 없는 상태.

## Changes
`core/agent/agentic_loop.py` — `existing_names` set을 루프 전에 한 번 구축하고, append 시마다 `.add()` 호출

## Test plan
- [x] `uv run ruff check core/agent/agentic_loop.py` — passed
- [x] `uv run pytest tests/test_hooks.py -q` — passed
- [ ] CI 5/5 pass
- [ ] serve 재시작 후 IPC 세션에서 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)