### PR TITLE
fix: HITL IPC approval 5-bug fix (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **HITL IPC approval 5-bug fix** — (1) `request_approval()` buf 미갱신으로 non-approval 메시지 무한 재파싱 → 타임아웃, (2) stale `approval_response` "Unknown message type" 에러 → 무시 처리, (3) `_prompt_with_always()` label("Allow?")이 tool_name으로 전달 → 실제 도구명 전달, (4) bash safety_level "write" 기본값 → "dangerous" 전달, (5) IPC 이중 프롬프트 → callback 모드에서 서버측 console.print 억제
+
 ## [0.45.0] — 2026-04-01
 
 ### Added

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -491,7 +491,10 @@ class ToolExecutor:
 
         t0 = time.monotonic()
         response = self._prompt_with_always(
-            "Allow?", f"{server}/{tool_name}", safety_level="mcp", tool_name=tool_name,
+            "Allow?",
+            f"{server}/{tool_name}",
+            safety_level="mcp",
+            tool_name=tool_name,
         )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
@@ -569,7 +572,10 @@ class ToolExecutor:
 
         t0 = time.monotonic()
         response = self._prompt_with_always(
-            "Allow?", tool_name, safety_level="write", tool_name=tool_name,
+            "Allow?",
+            tool_name,
+            safety_level="write",
+            tool_name=tool_name,
         )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
@@ -635,7 +641,10 @@ class ToolExecutor:
 
         t0 = time.monotonic()
         response = self._prompt_with_always(
-            "Proceed?", tool_name, safety_level="cost", tool_name=tool_name,
+            "Proceed?",
+            tool_name,
+            safety_level="cost",
+            tool_name=tool_name,
         )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
@@ -698,7 +707,10 @@ class ToolExecutor:
 
         t0 = time.monotonic()
         response = self._prompt_with_always(
-            "Allow?", command, safety_level="dangerous", tool_name="run_bash",
+            "Allow?",
+            command,
+            safety_level="dangerous",
+            tool_name="run_bash",
         )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -143,7 +143,14 @@ class ToolExecutor:
         except Exception:
             log.debug("Hook fire failed for %s", event_name, exc_info=True)
 
-    def _prompt_with_always(self, label: str, detail: str, *, safety_level: str = "write") -> str:
+    def _prompt_with_always(
+        self,
+        label: str,
+        detail: str,
+        *,
+        safety_level: str = "write",
+        tool_name: str = "",
+    ) -> str:
         """Show a [Y/n/A] prompt and return 'y', 'n', or 'a'.
 
         Uses IPC approval relay callback if available (thin-client mode),
@@ -151,7 +158,7 @@ class ToolExecutor:
         """
         # IPC mode: relay approval to thin client via callback
         if self._approval_callback is not None:
-            return self._approval_callback(label, detail, safety_level)
+            return self._approval_callback(tool_name or label, detail, safety_level)
 
         # Direct terminal mode
         from core.cli import _restore_terminal
@@ -463,14 +470,15 @@ class ToolExecutor:
 
     def _confirm_mcp(self, server: str, tool_name: str) -> bool:
         """Prompt user for MCP tool confirmation with A=Always option."""
-        from core.cli import _restore_terminal
+        if self._approval_callback is None:
+            from core.cli import _restore_terminal
 
-        _restore_terminal()
-        console.print()
-        console.print("  [warning]MCP tool requires approval[/warning]")
-        console.print(f"  [dim]Server:[/dim] [bold]{server}[/bold]")
-        console.print(f"  [dim]Tool:[/dim]   [bold]{tool_name}[/bold]")
-        console.print()
+            _restore_terminal()
+            console.print()
+            console.print("  [warning]MCP tool requires approval[/warning]")
+            console.print(f"  [dim]Server:[/dim] [bold]{server}[/bold]")
+            console.print(f"  [dim]Tool:[/dim]   [bold]{tool_name}[/bold]")
+            console.print()
 
         self._fire_hook(
             "tool_approval_requested",
@@ -482,7 +490,9 @@ class ToolExecutor:
         )
 
         t0 = time.monotonic()
-        response = self._prompt_with_always("Allow?", f"{server}/{tool_name}")
+        response = self._prompt_with_always(
+            "Allow?", f"{server}/{tool_name}", safety_level="mcp", tool_name=tool_name,
+        )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
             self._always_approved_categories.add(f"mcp:{server}")
@@ -520,32 +530,33 @@ class ToolExecutor:
 
     def _confirm_write(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
         """Prompt user for write operation confirmation."""
-        from core.cli import _restore_terminal
+        if self._approval_callback is None:
+            from core.cli import _restore_terminal
 
-        _restore_terminal()
-        summary = ""
-        if tool_name == "memory_save":
-            summary = tool_input.get("content", tool_input.get("value", ""))[:80]
-        elif tool_name == "note_save":
-            summary = tool_input.get("content", "")[:80]
-        elif tool_name == "set_api_key":
-            summary = f"provider={tool_input.get('provider', '?')}"
-        elif tool_name == "manage_auth":
-            summary = f"action={tool_input.get('action', '?')}"
-        elif tool_name == "profile_update":
-            fields = [k for k in ("role", "expertise", "name", "team") if tool_input.get(k)]
-            summary = f"fields={','.join(fields)}" if fields else "profile update"
-        elif tool_name == "profile_preference":
-            summary = f"{tool_input.get('key', '?')}={tool_input.get('value', '?')}"
-        elif tool_name == "profile_learn":
-            summary = tool_input.get("pattern", "")[:80]
+            _restore_terminal()
+            summary = ""
+            if tool_name == "memory_save":
+                summary = tool_input.get("content", tool_input.get("value", ""))[:80]
+            elif tool_name == "note_save":
+                summary = tool_input.get("content", "")[:80]
+            elif tool_name == "set_api_key":
+                summary = f"provider={tool_input.get('provider', '?')}"
+            elif tool_name == "manage_auth":
+                summary = f"action={tool_input.get('action', '?')}"
+            elif tool_name == "profile_update":
+                fields = [k for k in ("role", "expertise", "name", "team") if tool_input.get(k)]
+                summary = f"fields={','.join(fields)}" if fields else "profile update"
+            elif tool_name == "profile_preference":
+                summary = f"{tool_input.get('key', '?')}={tool_input.get('value', '?')}"
+            elif tool_name == "profile_learn":
+                summary = tool_input.get("pattern", "")[:80]
 
-        console.print()
-        console.print("  [warning]Write operation requires approval[/warning]")
-        console.print(f"  [dim]Tool:[/dim]    [bold]{tool_name}[/bold]")
-        if summary:
-            console.print(f"  [dim]Summary:[/dim] {summary}")
-        console.print()
+            console.print()
+            console.print("  [warning]Write operation requires approval[/warning]")
+            console.print(f"  [dim]Tool:[/dim]    [bold]{tool_name}[/bold]")
+            if summary:
+                console.print(f"  [dim]Summary:[/dim] {summary}")
+            console.print()
 
         self._fire_hook(
             "tool_approval_requested",
@@ -557,7 +568,9 @@ class ToolExecutor:
         )
 
         t0 = time.monotonic()
-        response = self._prompt_with_always("Allow?", tool_name)
+        response = self._prompt_with_always(
+            "Allow?", tool_name, safety_level="write", tool_name=tool_name,
+        )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
             self._always_approved_categories.add("write")
@@ -595,20 +608,21 @@ class ToolExecutor:
 
     def _confirm_cost(self, tool_name: str, estimated_cost: float) -> bool:
         """Prompt user for cost confirmation on expensive tools with A=Always option."""
-        from core.cli import _restore_terminal
+        if self._approval_callback is None:
+            from core.cli import _restore_terminal
 
-        _restore_terminal()
-        console.print()
-        console.print("  [warning]$ Cost confirmation[/warning]")
-        console.print(f"  [dim]Tool:[/dim] [bold]{tool_name}[/bold]")
-        console.print(f"  [dim]Estimated cost:[/dim] ~${estimated_cost:.2f}")
-        # Show pipeline model info for analysis tools
-        if tool_name in ("analyze_ip", "compare_ips", "batch_analyze"):
-            from core.config import ANTHROPIC_PRIMARY, get_node_model
+            _restore_terminal()
+            console.print()
+            console.print("  [warning]$ Cost confirmation[/warning]")
+            console.print(f"  [dim]Tool:[/dim] [bold]{tool_name}[/bold]")
+            console.print(f"  [dim]Estimated cost:[/dim] ~${estimated_cost:.2f}")
+            # Show pipeline model info for analysis tools
+            if tool_name in ("analyze_ip", "compare_ips", "batch_analyze"):
+                from core.config import ANTHROPIC_PRIMARY, get_node_model
 
-            primary = get_node_model("analyst") or ANTHROPIC_PRIMARY
-            console.print(f"  [dim]Pipeline model:[/dim] {primary}")
-        console.print()
+                primary = get_node_model("analyst") or ANTHROPIC_PRIMARY
+                console.print(f"  [dim]Pipeline model:[/dim] {primary}")
+            console.print()
 
         self._fire_hook(
             "tool_approval_requested",
@@ -620,7 +634,9 @@ class ToolExecutor:
         )
 
         t0 = time.monotonic()
-        response = self._prompt_with_always("Proceed?", tool_name)
+        response = self._prompt_with_always(
+            "Proceed?", tool_name, safety_level="cost", tool_name=tool_name,
+        )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
             self._always_approved_categories.add("cost")
@@ -658,15 +674,18 @@ class ToolExecutor:
 
     def _request_approval(self, command: str, reason: str) -> bool:
         """Prompt user for bash command approval with A=Always option."""
-        from core.cli import _restore_terminal
+        # In IPC mode, the thin CLI renders its own approval prompt from
+        # the approval_request message — skip duplicate console output.
+        if self._approval_callback is None:
+            from core.cli import _restore_terminal
 
-        _restore_terminal()
-        console.print()
-        console.print("  [warning]Bash command requires approval[/warning]")
-        console.print(f"  [dim]Command:[/dim] [value]{command}[/value]")
-        if reason:
-            console.print(f"  [dim]Reason:[/dim]  {reason}")
-        console.print()
+            _restore_terminal()
+            console.print()
+            console.print("  [warning]Bash command requires approval[/warning]")
+            console.print(f"  [dim]Command:[/dim] [value]{command}[/value]")
+            if reason:
+                console.print(f"  [dim]Reason:[/dim]  {reason}")
+            console.print()
 
         self._fire_hook(
             "tool_approval_requested",
@@ -678,7 +697,9 @@ class ToolExecutor:
         )
 
         t0 = time.monotonic()
-        response = self._prompt_with_always("Allow?", command)
+        response = self._prompt_with_always(
+            "Allow?", command, safety_level="dangerous", tool_name="run_bash",
+        )
         latency_ms = (time.monotonic() - t0) * 1000
         if response == "a":
             self._always_approved_categories.add("bash")

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -233,8 +233,15 @@ class IPCClient:
         detail = msg.get("detail", "")
         level = msg.get("safety_level", "write")
 
+        _LEVEL_LABELS = {
+            "write": "Write",
+            "dangerous": "Dangerous",
+            "mcp": "MCP",
+            "cost": "Cost",
+        }
+        label = _LEVEL_LABELS.get(level, level.title())
+
         c.print()
-        label = "Write" if level == "write" else "Dangerous"
         c.print(f"  [warning]{label} tool requires approval[/warning]")
         c.print(f"  [dim]Tool:[/dim] [bold]{tool}[/bold]")
         if detail:

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -98,8 +98,8 @@ class _StreamingWriter:
                 if not chunk:
                     return "n"
                 buf += chunk
-                if b"\n" in buf:
-                    line, _rest = buf.split(b"\n", 1)
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
                     msg = json.loads(line.decode("utf-8"))
                     if msg.get("type") == "approval_response":
                         return str(msg.get("decision", "n"))
@@ -350,6 +350,11 @@ class CLIPoller:
 
         if msg_type == "resume":
             return self._handle_resume(msg, loop, conversation)
+
+        # Stale approval_response from a timed-out request — silently drop
+        if msg_type == "approval_response":
+            log.debug("Dropping stale approval_response: %s", msg.get("decision"))
+            return {"type": "ack"}
 
         return {"type": "error", "message": f"Unknown message type: {msg_type}"}
 


### PR DESCRIPTION
## Summary
- **HITL IPC 승인 시스템 5개 버그 수정** — "A"(Always) 옵션이 거부로 처리되는 문제와 관련 IPC 결함

## Why
thin CLI에서 HITL 승인 시 "A" 입력이 120초 타임아웃 후 거부(denied)로 처리됨. 근본 원인 5개 동시 수정.

## Changes

| Bug | File | Fix |
|-----|------|-----|
| `request_approval()` buf 미갱신 | `cli_poller.py:102` | `_rest` → `buf` 할당, `if` → `while` 루프 |
| stale `approval_response` 에러 | `cli_poller.py:354` | "Unknown message type" → silent drop + debug log |
| label("Allow?") → tool_name 오전달 | `tool_executor.py` | `_prompt_with_always`에 `tool_name` 파라미터 추가 |
| bash safety_level "write" 기본값 | `tool_executor.py` | 호출 사이트 4곳에 명시적 safety_level 전달 |
| IPC 이중 프롬프트 | `tool_executor.py` | callback 모드에서 서버측 console.print 억제 |

## Test plan
- [x] ruff check: 0 errors
- [x] mypy: 0 errors  
- [x] pytest: 3607 passed (관련 60건 포함)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>