### PR TITLE
feat: model switch breadcrumb (Claude Code pattern)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Model switch breadcrumb** — `/model` 전환 시 대화에 전환 마커 주입하여 새 모델이 이전 모델의 응답을 현재 상태로 착각하지 않도록 방지 (Claude Code SDK `createModelSwitchBreadcrumbs` 패턴)
+
 ### Fixed
 - **Haiku model switch 3-bug fix** — (B3) `compact-2026-01-12` beta header를 Haiku에 전송하여 400 에러 → 모델별 조건부 주입, (B1) `/model` context guard dead code — `set_conversation_context()` caller 0개 → `arun()` 진입 시 wire, (B2) `check_context()` overhead 500 하드코딩 → 실측 10K 기반 `_DEFAULT_TOOLS_OVERHEAD` 적용
 - **Haiku native tool 400 error** — Anthropic server tools(`web_search`, `web_fetch`)에 `allowed_callers=["direct"]` 미설정으로 Haiku 4.5에서 "programmatic tool calling not supported" 400 에러 발생. 모든 Anthropic 모델 호환되도록 수정

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -450,6 +450,18 @@ class AgenticLoop:
                     },
                 )
 
+            # Inject model-switch breadcrumb so the new model knows the switch
+            # happened (Claude Code SDK pattern: createModelSwitchBreadcrumbs).
+            if not self.context.is_empty:
+                self.context.add_user_message(
+                    f"[system] Model switched: {old_model} -> {model}. "
+                    "You are now the new model. Do not reference the previous "
+                    "model's responses as current state."
+                )
+                self.context.add_assistant_message(
+                    f"Understood. I am now {model}."
+                )
+
         # Proactively adapt context for the new model's context window
         self._adapt_context_for_model(model)
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -458,9 +458,7 @@ class AgenticLoop:
                     "You are now the new model. Do not reference the previous "
                     "model's responses as current state."
                 )
-                self.context.add_assistant_message(
-                    f"Understood. I am now {model}."
-                )
+                self.context.add_assistant_message(f"Understood. I am now {model}.")
 
         # Proactively adapt context for the new model's context window
         self._adapt_context_for_model(model)


### PR DESCRIPTION
## Summary
- `/model` 전환 시 대화에 breadcrumb(user+assistant pair) 주입
- 새 모델이 이전 모델의 응답을 현재 상태로 착각하지 않도록 방지

## Why
Haiku → Opus 전환 후 Opus가 "모델: claude-haiku-4-5"라고 이전 모델 정보를 현재 상태로 응답하는 문제. Claude Code SDK의 `createModelSwitchBreadcrumbs()` 패턴 적용.

## Changes
| File | Change |
|------|--------|
| `core/agent/agentic_loop.py` | `update_model()` 내 breadcrumb 주입 |
| `CHANGELOG.md` | Added 기록 |

## Test plan
- [x] test_model_switch_guard.py 18/18 pass
- [x] Full suite: 3615 passed
- [x] Lint + Type: 0 errors
- [ ] Live: Haiku → Opus → "지금 모델은?" → Opus로 정확히 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)