### PR TITLE
feat: LLM failure resilience — backoff retry, context-first recovery

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -248,6 +248,7 @@ class AgenticLoop:
         # Feature 3: Model escalation on consecutive LLM failures
         self._consecutive_llm_failures: int = 0
         self._ESCALATION_THRESHOLD: int = 2
+        self._LLM_RETRY_CAP: int = 5  # max retries before giving up
 
         # Feature 5: Backpressure on consecutive tool failures
         self._total_consecutive_tool_errors: int = 0
@@ -412,7 +413,12 @@ class AgenticLoop:
             log.debug("Model drift check failed", exc_info=True)
         return False
 
-    def update_model(self, model: str, provider: str | None = None) -> None:
+    def update_model(
+        self,
+        model: str,
+        provider: str | None = None,
+        reason: str = "user_switch",
+    ) -> None:
         """Update model and provider without reconstructing the loop.
 
         Resolves a fresh adapter when the provider changes. Within the
@@ -437,7 +443,7 @@ class AgenticLoop:
         if old_model != model:
             from core.cli.ui.agentic_ui import emit_model_switched
 
-            emit_model_switched(old_model, model, "user_switch")
+            emit_model_switched(old_model, model, reason)
             if self._hooks:
                 from core.hooks import HookEvent
 
@@ -446,7 +452,7 @@ class AgenticLoop:
                     {
                         "from_model": old_model,
                         "to_model": model,
-                        "reason": "user_switch",
+                        "reason": reason,
                     },
                 )
 
@@ -707,8 +713,9 @@ class AgenticLoop:
                     _ipc_writer.send_event("thinking_end")
 
             if response is None:
-                # Emit classified error for UX (severity + actionable hint)
+                # Classify error for type-specific retry strategy
                 adapter_exc = getattr(self._adapter, "last_error", None)
+                _et = "unknown"
                 if adapter_exc is not None:
                     from core.llm.errors import classify_llm_error
 
@@ -726,6 +733,36 @@ class AgenticLoop:
                             )
                             log.info("Context overflow recovery succeeded — retrying LLM call")
                             continue  # retry with pruned context
+                        # Recovery failed — context is unrecoverably large
+                        self._notify_context_event(
+                            "exhausted",
+                            original_count=len(messages),
+                            new_count=len(messages),
+                        )
+                        self._sync_messages_to_context(messages)
+                        result = AgenticResult(
+                            text=_context_exhausted_message(user_input),
+                            tool_calls=self._tool_processor.tool_log,
+                            rounds=round_idx + 1,
+                            error="context_exhausted",
+                            termination_reason="context_exhausted",
+                        )
+                        return self._finalize_and_return(result, user_input, round_idx + 1)
+
+                    # Non-retryable errors → immediate exit (no retry budget waste)
+                    if _et in ("auth", "bad_request"):
+                        if not self._quiet:
+                            from core.cli.ui.agentic_ui import emit_llm_error
+
+                            emit_llm_error(_et, _sev, _hint, self.model, self._provider)
+                        detail = self._last_llm_error or str(adapter_exc)
+                        result = AgenticResult(
+                            text=f"LLM call failed ({detail}).",
+                            rounds=round_idx + 1,
+                            error="llm_call_failed",
+                            termination_reason="llm_error",
+                        )
+                        return self._finalize_and_return(result, user_input, round_idx + 1)
 
                     if not self._quiet:
                         from core.cli.ui.agentic_ui import emit_llm_error
@@ -739,30 +776,106 @@ class AgenticLoop:
                             attempt=self._consecutive_llm_failures + 1,
                         )
 
-                # Auto-checkpoint before escalation/failure so user can resume
+                    if self._hooks:
+                        self._hooks.trigger(
+                            HookEvent.LLM_CALL_FAILED,
+                            {
+                                "model": self.model,
+                                "provider": self._provider,
+                                "error_type": _et,
+                                "severity": _sev,
+                                "attempt": self._consecutive_llm_failures + 1,
+                            },
+                        )
+
+                # Auto-checkpoint before escalation/retry so user can resume
                 self._sync_messages_to_context(messages)
                 self._save_checkpoint(user_input, round_idx=round_idx)
 
-                # Feature 3/4: Model escalation on consecutive LLM failures
                 self._consecutive_llm_failures += 1
-                if self._consecutive_llm_failures >= self._ESCALATION_THRESHOLD:
+
+                # Rate limit → immediate model escalation (different model = different quota)
+                if _et == "rate_limit":
                     old_model = self.model
                     escalated = self._try_model_escalation()
                     if escalated:
-                        # Emit structured event for thin client
                         from core.cli.ui.agentic_ui import emit_model_escalation
 
-                        emit_model_escalation(
-                            old_model,
-                            self.model,
-                            self._consecutive_llm_failures,
+                        emit_model_escalation(old_model, self.model, self._consecutive_llm_failures)
+                        self._consecutive_llm_failures = 0
+                        messages[:] = self.context.messages  # re-sync adapted context
+                        continue
+
+                # Non-rate-limit errors: compact context + same model retry first,
+                # model switch only as last resort (downgrade loses quality).
+                if self._consecutive_llm_failures >= self._ESCALATION_THRESHOLD:
+                    recovered = self._aggressive_context_recovery(system_prompt, messages)
+                    if recovered:
+                        self._notify_context_event(
+                            "prune",
+                            original_count=len(messages) + recovered,
+                            new_count=len(messages),
                         )
                         log.info(
-                            "Model escalated after %d consecutive failures, retrying",
+                            "Context compacted after %d failures — retrying same model (%s)",
                             self._consecutive_llm_failures,
+                            self.model,
                         )
                         self._consecutive_llm_failures = 0
                         continue
+
+                    # Context compaction failed — model switch as last resort
+                    old_model = self.model
+                    escalated = self._try_model_escalation()
+                    if escalated:
+                        from core.cli.ui.agentic_ui import emit_model_escalation
+
+                        emit_model_escalation(old_model, self.model, self._consecutive_llm_failures)
+                        log.info(
+                            "Context compaction insufficient, model escalated: %s → %s",
+                            old_model,
+                            self.model,
+                        )
+                        self._consecutive_llm_failures = 0
+                        messages[:] = self.context.messages  # re-sync adapted context
+                        continue
+
+                # Below retry cap: backoff and retry (don't break the loop)
+                if self._consecutive_llm_failures < self._LLM_RETRY_CAP:
+                    import asyncio as _asyncio
+
+                    delay = min(2**self._consecutive_llm_failures, 30)
+                    log.info(
+                        "LLM call failed (%s) — retrying in %ds (attempt %d/%d)",
+                        _et,
+                        delay,
+                        self._consecutive_llm_failures,
+                        self._LLM_RETRY_CAP,
+                    )
+                    if not self._quiet:
+                        from core.cli.ui.agentic_ui import emit_llm_retry
+
+                        emit_llm_retry(
+                            delay,
+                            self._consecutive_llm_failures,
+                            self._LLM_RETRY_CAP,
+                        )
+                    if self._hooks:
+                        self._hooks.trigger(
+                            HookEvent.LLM_CALL_RETRY,
+                            {
+                                "model": self.model,
+                                "provider": self._provider,
+                                "error_type": _et,
+                                "delay_s": delay,
+                                "attempt": self._consecutive_llm_failures,
+                                "max_attempts": self._LLM_RETRY_CAP,
+                            },
+                        )
+                    await _asyncio.sleep(delay)
+                    continue  # retry without incrementing round_idx
+
+                # All retries exhausted — surface error
                 detail = self._last_llm_error or "unknown error"
                 text = (
                     f"LLM call failed ({detail}). "
@@ -1572,7 +1685,7 @@ class AgenticLoop:
                     next_model,
                     self._provider,
                 )
-                self.update_model(next_model, self._provider)
+                self.update_model(next_model, self._provider, reason="failure_escalation")
                 return True
 
         # Current provider's chain exhausted — try cross-provider (Feature 4)
@@ -1586,7 +1699,9 @@ class AgenticLoop:
                     fallback_model,
                     fallback_provider,
                 )
-                self.update_model(fallback_model, fallback_provider)
+                self.update_model(
+                    fallback_model, fallback_provider, reason="cross_provider_escalation"
+                )
                 return True
 
         log.warning("Model escalation failed: no more fallback models available")

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -751,8 +751,7 @@ def emit_llm_retry(delay_s: int, attempt: int, max_attempts: int) -> None:
         )
         return
     console.print(
-        f"  [warning]~ LLM retry in {delay_s}s"
-        f" (attempt {attempt}/{max_attempts})[/warning]"
+        f"  [warning]~ LLM retry in {delay_s}s (attempt {attempt}/{max_attempts})[/warning]"
     )
 
 

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -739,6 +739,23 @@ def emit_model_escalation(from_model: str, to_model: str, failures: int) -> None
     )
 
 
+def emit_llm_retry(delay_s: int, attempt: int, max_attempts: int) -> None:
+    """Emit llm_retry event when retrying after LLM failure with backoff."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "llm_retry",
+            delay_s=delay_s,
+            attempt=attempt,
+            max_attempts=max_attempts,
+        )
+        return
+    console.print(
+        f"  [warning]~ LLM retry in {delay_s}s"
+        f" (attempt {attempt}/{max_attempts})[/warning]"
+    )
+
+
 def emit_cost_budget_exceeded(budget: float, actual: float) -> None:
     """Emit cost_budget_exceeded event when session cost hits limit."""
     writer = getattr(_ipc_writer_local, "writer", None)

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -85,6 +85,8 @@ class HookEvent(Enum):
     # LLM call lifecycle (model-level latency/cost observability)
     LLM_CALL_START = "llm_call_start"
     LLM_CALL_END = "llm_call_end"
+    LLM_CALL_FAILED = "llm_call_failed"
+    LLM_CALL_RETRY = "llm_call_retry"
 
     # Tool approval HITL lifecycle
     TOOL_APPROVAL_REQUESTED = "tool_approval_requested"

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -157,7 +157,7 @@ class TestAgenticLoop:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test that a text-only response returns immediately."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         # Mock LLM returning text only (no tool_use)
         mock_response = MagicMock()
@@ -184,7 +184,7 @@ class TestAgenticLoop:
 
     def test_run_with_tool_use(self, context: ConversationContext, executor: ToolExecutor) -> None:
         """Test tool_use → tool_result → text response flow."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         # Round 1: LLM calls list_ips tool
         tool_response = MagicMock()
@@ -226,7 +226,7 @@ class TestAgenticLoop:
 
     def test_run_max_rounds(self, context: ConversationContext, executor: ToolExecutor) -> None:
         """Test max rounds limit."""
-        loop = AgenticLoop(context, executor, max_rounds=2)
+        loop = AgenticLoop(context, executor, max_rounds=2, quiet=True)
 
         # Always return tool_use → never ends
         tool_response = MagicMock()
@@ -253,10 +253,17 @@ class TestAgenticLoop:
         assert result.termination_reason == "max_rounds"
 
     def test_run_llm_failure(self, context: ConversationContext, executor: ToolExecutor) -> None:
-        """Test graceful handling of LLM call failure."""
-        loop = AgenticLoop(context, executor)
+        """Test graceful handling of LLM call failure (exhausts retry cap)."""
+        from unittest.mock import AsyncMock
 
-        with patch.object(loop, "_call_llm", return_value=None):
+        loop = AgenticLoop(context, executor, quiet=True)
+
+        with (
+            patch.object(loop, "_call_llm", return_value=None),
+            patch.object(loop, "_aggressive_context_recovery", return_value=0),
+            patch.object(loop, "_try_model_escalation", return_value=False),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)),
+        ):
             result = loop.run("test")
 
         assert result.error == "llm_call_failed"
@@ -264,7 +271,7 @@ class TestAgenticLoop:
 
     def test_context_preserved(self, context: ConversationContext, executor: ToolExecutor) -> None:
         """Test that conversation context is maintained across runs."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         mock_response = MagicMock()
         mock_response.stop_reason = "end_turn"
@@ -293,7 +300,7 @@ class TestAgenticLoop:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """On the last round, tool_choice=none forces text output."""
-        loop = AgenticLoop(context, executor, max_rounds=3)
+        loop = AgenticLoop(context, executor, max_rounds=3, quiet=True)
 
         call_kwargs: list[dict[str, Any]] = []
 
@@ -415,7 +422,7 @@ class TestAgenticLoop:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test _build_system_prompt returns non-empty string."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
         prompt = loop._build_system_prompt()
         assert isinstance(prompt, str)
         assert len(prompt) > 100
@@ -427,7 +434,7 @@ class TestAgenticLoop:
         from core.llm.client import get_usage_accumulator, reset_usage_accumulator
 
         reset_usage_accumulator()
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         mock_response = MagicMock()
         mock_response.usage = MagicMock(input_tokens=500, output_tokens=200)
@@ -444,7 +451,7 @@ class TestAgenticLoop:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test _track_usage with no usage data."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
         mock_response = MagicMock()
         mock_response.usage = None
         loop._track_usage(mock_response)  # should not raise
@@ -453,7 +460,7 @@ class TestAgenticLoop:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test _track_usage swallows exceptions."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
         mock_response = MagicMock()
         mock_response.usage = MagicMock(input_tokens=100, output_tokens=50)
 
@@ -677,21 +684,21 @@ class TestAgenticLoopTracing:
         """Verify that run() method exists and is callable (tracing is a decorator)."""
         context = ConversationContext(max_turns=5)
         executor = ToolExecutor()
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
         assert callable(loop.run)
 
     def test_call_llm_has_traceable_attribute(self) -> None:
         """Verify that _call_llm() method exists and is callable."""
         context = ConversationContext(max_turns=5)
         executor = ToolExecutor()
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
         assert callable(loop._call_llm)
 
     def test_tracing_passthrough_without_langsmith(self) -> None:
         """Without LANGCHAIN_TRACING_V2/API_KEY, _maybe_traceable is a no-op."""
         context = ConversationContext(max_turns=5)
         executor = ToolExecutor()
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         # run() should still work normally
         mock_response = MagicMock()
@@ -737,7 +744,7 @@ class TestAgenticLoopEdgeCases:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test response with 2+ tool_use blocks processed in one round."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         # Round 1: LLM calls 2 tools simultaneously
         tool_response = MagicMock()
@@ -782,7 +789,7 @@ class TestAgenticLoopEdgeCases:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test _serialize_content with mixed text + tool_use blocks."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         text_block = MagicMock()
         text_block.type = "text"
@@ -806,7 +813,7 @@ class TestAgenticLoopEdgeCases:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test _extract_text with no text blocks (only tool_use blocks)."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         tool_block = MagicMock()
         tool_block.type = "tool_use"
@@ -819,7 +826,7 @@ class TestAgenticLoopEdgeCases:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Test _extract_text joins multiple text blocks."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
 
         block1 = MagicMock()
         block1.type = "text"
@@ -836,7 +843,7 @@ class TestAgenticLoopEdgeCases:
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """Verify agentic adapter is created at construction time."""
-        loop = AgenticLoop(context, executor)
+        loop = AgenticLoop(context, executor, quiet=True)
         assert loop._adapter is not None
         assert loop._adapter.provider_name == "anthropic"
 
@@ -967,7 +974,7 @@ class TestAgenticLoopToolCallRendering:
         ctx = ConversationContext()
         handler = MagicMock(return_value={"status": "ok", "tier": "S", "score": 81.3})
         executor = ToolExecutor(action_handlers={"analyze_ip": handler}, auto_approve=True)
-        loop = AgenticLoop(ctx, executor)
+        loop = AgenticLoop(ctx, executor, quiet=True)
 
         # Build a response with tool_use
         tool_block = MagicMock()
@@ -992,7 +999,7 @@ class TestAgenticLoopToolCallRendering:
         ctx = ConversationContext()
         handler = MagicMock(return_value={"tier": "S", "score": 81.3})
         executor = ToolExecutor(action_handlers={"analyze_ip": handler}, auto_approve=True)
-        loop = AgenticLoop(ctx, executor)
+        loop = AgenticLoop(ctx, executor, quiet=True)
 
         tool_block = MagicMock()
         tool_block.type = "tool_use"
@@ -1050,7 +1057,7 @@ class TestMessagePruning:
     def _make_loop(self) -> AgenticLoop:
         ctx = ConversationContext()
         executor = ToolExecutor(action_handlers={}, auto_approve=True)
-        return AgenticLoop(ctx, executor)
+        return AgenticLoop(ctx, executor, quiet=True)
 
     def test_no_prune_under_threshold(self) -> None:
         """Messages <= 10 should not be pruned."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -299,7 +299,7 @@ class TestApplyContext:
 class TestHookEventCount:
     def test_events_exist(self) -> None:
         """HookEvent has 40 events after H6 orphan pruning."""
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -411,7 +411,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count after H6 orphan pruning."""
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from core.hooks import HookEvent, HookResult, HookSystem
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,7 +356,7 @@ class TestHookEventTypes:
 
     def test_hook_event_count(self):
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -27,7 +27,7 @@ class TestLLMLifecycleEvents:
 
     def test_event_count_includes_llm_events(self) -> None:
         """40 events total after H6 orphan pruning."""
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
 
 class TestFireHook:

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -278,7 +278,7 @@ class TestHookEventCount:
     def test_total_event_count(self) -> None:
         from core.hooks import HookEvent
 
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -35,7 +35,7 @@ class TestMCPHookEvents:
 
     def test_hook_event_count(self) -> None:
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 46
+        assert len(HookEvent) == 48
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -11,7 +11,7 @@ Feature 4: Cross-provider escalation
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from core.agent.agentic_loop import AgenticLoop
 from core.agent.conversation import ConversationContext
@@ -39,6 +39,7 @@ def _make_loop(
         model=model,
         provider=provider,
         max_rounds=10,
+        quiet=True,
     )
     return loop
 
@@ -186,8 +187,8 @@ class TestModelEscalation:
         assert result.text == "Hello from escalated model"
         assert result.termination_reason == "natural"
 
-    def test_arun_no_escalation_on_single_failure(self) -> None:
-        """arun() does NOT escalate after a single failure (below threshold)."""
+    def test_arun_retries_on_single_failure_then_succeeds(self) -> None:
+        """arun() retries with backoff on single failure (below threshold), no escalation."""
         import asyncio
 
         loop = _make_loop()
@@ -209,13 +210,14 @@ class TestModelEscalation:
             patch.object(loop, "_try_model_escalation") as mock_esc,
             patch.object(loop, "_build_system_prompt", return_value="system"),
             patch.object(loop, "_try_decompose", return_value=None),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)),
         ):
             result = asyncio.run(loop.arun("test prompt"))
 
-        # Single failure = below threshold, no escalation
+        # Single failure → backoff retry → success on 2nd call
         mock_esc.assert_not_called()
-        # Should have returned error after 1st failure (didn't hit threshold)
-        assert result.termination_reason == "llm_error"
+        assert result.termination_reason == "natural"
+        assert call_count == 2
 
     def test_arun_resets_failure_counter_on_success(self) -> None:
         """Successful LLM response resets the consecutive failure counter."""


### PR DESCRIPTION
## Summary

- LLM 호출 실패 시 루프 즉시 종료 → backoff retry + error-type routing으로 루프 유지
- 모델 다운그레이드 대신 context 축소 우선 (상위 모델 품질 유지)
- 모델 교체 후 adapted context가 실제 루프에 반영되지 않던 버그 수정
- `LLM_CALL_FAILED`/`LLM_CALL_RETRY` hook 이벤트 추가 (46 → 48 events)

## Why

AgenticLoop에서 LLM 호출이 1회 실패하면 즉시 루프가 종료되어 "All anthropic models exhausted" 에러로 세션이 사망함. Claude Code는 같은 상황에서 backoff retry + model fallback으로 루프를 유지. 또한 모델 교체 시 `update_model()` → `_adapt_context_for_model()`이 `self.context.messages`를 수정하지만, 루프의 local `messages` 변수는 stale 상태로 남아 adaptation이 무효화되는 구조적 버그 존재.

## Changes

| 영역 | Before | After |
|------|--------|-------|
| 첫 실패 | `return` (루프 종료) | backoff 2s → `continue` (재시도) |
| auth/bad_request | retry 시도 → 예산 낭비 | 즉시 종료 (non-retryable) |
| rate_limit | threshold 대기 | 즉시 모델 교체 (다른 quota) |
| threshold 도달 | 모델 다운그레이드 | context 축소 → 같은 모델 재시도 → 실패 시 모델 교체 |
| 모델 교체 후 context | stale local messages | `messages[:] = self.context.messages` re-sync |
| context_overflow 실패 | silent fallthrough | 명시적 `context_exhausted` 종료 |
| MODEL_SWITCHED reason | 항상 `"user_switch"` | `failure_escalation` / `cross_provider_escalation` 구분 |
| Hook 이벤트 | LLM 실패/재시도 blind spot | `LLM_CALL_FAILED` + `LLM_CALL_RETRY` 추가 |

## Recovery Pipeline (최종)

```
LLM 실패
  ├─ context_overflow → aggressive recovery → continue / exhausted 종료
  ├─ auth/bad_request → 즉시 종료
  ├─ rate_limit → 모델 교체 + context re-sync
  └─ server/timeout/connection/unknown
       ├─ 1회차: backoff 2s → 같은 모델 재시도
       ├─ 2회차: context 축소 → 같은 모델 재시도
       │         축소 실패 → 모델 교체 (last resort)
       ├─ 3~4회차: backoff → 재시도
       └─ 5회차: 포기
```

## Test plan

- [x] `tests/test_model_escalation.py` — 13/13 pass
- [x] `tests/test_agentic_loop.py` — 75/75 pass
- [x] `ruff check` — 0 errors
- [x] `mypy` — 0 errors
- [ ] E2E: `uv run geode analyze "Cowboy Bebop" --dry-run` → A (68.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)