### PR TITLE
fix: HITL IPC 3-bug fix — ack leak, Console theme, output TypeError

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -937,7 +937,7 @@ def _thin_interactive_loop(
                 if output:
                     import sys as _sys
 
-                    _sys.stdout.write(output)
+                    _sys.stdout.write(str(output))
                     _sys.stdout.flush()
                 if response.get("status") == "error":
                     console.print(f"  [error]{response.get('message', 'Command failed')}[/error]")
@@ -1020,6 +1020,10 @@ def _render_ipc_response(response: dict[str, Any], *, streamed: bool = False) ->
                 parts.append(f"{len(tool_calls)} tools")
             if parts:
                 console.print(f"  [dim]{' · '.join(parts)}[/dim]")
+        return
+
+    # Silently drop internal protocol acks
+    if rtype in ("ack", "exit_ack"):
         return
 
     # Fallback: unexpected response type

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -218,6 +218,9 @@ class IPCClient:
                 "pipeline_result",
                 "feedback_loop",
                 "node_skipped",
+                # Internal protocol acks — silently drop
+                "ack",
+                "exit_ack",
             ):
                 if on_event is not None:
                     on_event(response)
@@ -226,9 +229,8 @@ class IPCClient:
 
     def _handle_approval_request(self, msg: dict[str, Any]) -> str:
         """Display approval prompt to user and return decision."""
-        from rich.console import Console
+        from core.cli.ui.console import console as c
 
-        c = Console()
         tool = msg.get("tool_name", "?")
         detail = msg.get("detail", "")
         level = msg.get("safety_level", "write")


### PR DESCRIPTION
## Summary
- `{'type': 'ack'}` raw dict가 사용자에게 노출되던 버그 수정 (structured events에 ack/exit_ack 추가)
- HITL 승인 프롬프트 입력칸이 최좌측으로 밀리던 버그 수정 (bare Console → GEODE global console)
- `/quit` 명령 응답의 output이 int일 때 TypeError crash 수정 (str() 방어)

## Why
PR #630 HITL 수정 이후 stale approval_response가 `{"type": "ack"}`로 반환되나, 클라이언트에서 이를 처리하지 않아 raw dict가 출력됨. 또한 ipc_client의 approval UI가 테마 없는 Console을 사용해 스타일/정렬 깨짐.

## Test plan
- [x] `pytest -k "hitl or ipc_client"` — 28 passed
- [ ] geode CLI에서 HITL 승인 프롬프트 스타일 확인
- [ ] stale ack 시 raw dict 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)