### PR TITLE
fix: HITL approval race + paste drain + grounding + verify workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ These cannot be violated at any stage. Violations must be immediately halted and
 | **Quality** | No committing with lint/type/test failures | Ratchet (P4) |
 | | No placeholders (XXXX) in metrics — measured values only | Truth guarantee |
 | | No excessive `# type: ignore` — fix type errors instead | Correctness |
+| | No bare `_` for unused variables — use `_prefix` naming (e.g. `_tok_before`) | Readability |
 | | No unauthorized live test (`-m live`) execution | Cost control (P3) |
 | **Docs** | No omitting CHANGELOG from code commits | Traceability |
 | | No leaving `[Unreleased]` on main | Release discipline |
@@ -306,7 +307,7 @@ Without this call: `get_domain()` → None → AgenticLoop crash.
 ### Workflow Steps
 
 ```
-0. Board + Worktree → 1. GAP Audit → 2. Plan + Socratic Gate → 3. Implement+Test → 4. E2E Verify → 5. Docs-Sync → 6. PR → 7. Rebuild → 8. Board
+0. Board + Worktree → 1. GAP Audit → 2. Plan + Socratic Gate → 3. Implement+Test → 4. Verify (Implementation GAP Audit) → 5. Docs-Sync → 6. PR → 7. Rebuild → 8. Board
 ```
 
 #### 0. Board + Worktree Alloc
@@ -372,17 +373,44 @@ uv run mypy core/                    # Type: 0 errors
 uv run pytest tests/ -m "not live"   # Test: 3590+ pass
 ```
 
-#### 4. E2E Verify
+#### 4. Verify (Implementation GAP Audit)
 
-See `geode-e2e` skill.
+> Purpose: Confirm the implementation is complete, correct, and free of deception. This is NOT a feature demo — it is a forensic audit of what was actually built vs what was planned.
+
+**4a. Completeness — Plan vs Diff cross-check**
+
+For each plan item, verify implementation exists in the diff:
+
+| Check | Method | FAIL condition |
+|-------|--------|---------------|
+| Omission | `grep`/`Explore` plan items against actual diff | Plan item has no corresponding code change |
+| Stub disguise | Inspect new functions for `pass`-only or `return None` bodies | Function exists but does nothing |
+| Partial implementation | Check all sub-items of plan item are implemented | Only 1 of 3 sub-items done, marked complete |
+| Original residue | Verify extracted code is removed from origin | Code exists in both old and new location |
+
+**4b. Correctness — Quality gates + E2E**
 
 ```bash
-uv run geode analyze "Cowboy Bebop" --dry-run  # Verify A (68.4) unchanged
+uv run ruff check core/ tests/                      # Lint: 0 errors
+uv run mypy core/                                    # Type: 0 errors
+uv run pytest tests/ -m "not live"                   # Test: 3590+ pass
+uv run geode analyze "Cowboy Bebop" --dry-run        # E2E: A (68.4) unchanged
 ```
 
-5-persona verification team review: see `verification-team` + `anti-deception-checklist` skills (for large-scale changes).
+**4c. Cleanliness — Dead code & regression audit**
 
-**5-Persona Verification Team:**
+| Check | Method | FAIL condition |
+|-------|--------|---------------|
+| Dead code | `grep` for functions/classes added but never called | Unused import, unreachable function |
+| Test deletion | `git diff --stat` — test file line count must not decrease | Tests removed to hide failures |
+| Coverage regression | Compare test count before/after | Test count dropped |
+| Lint bypass | Search for new `# noqa`, `# type: ignore` additions | Suppression added instead of fixing |
+| Secret exposure | Search for API keys, tokens, passwords in diff | Credentials in committed code |
+
+**4d. Verification team (large-scale changes only)**
+
+See `verification-team` + `anti-deception-checklist` skills.
+
 1. **Kent Beck** — Design quality, test coverage, dead code, simplicity (XP/TDD)
 2. **Andrej Karpathy** — Constraints, ratchets, context budget, time budgets (autoresearch)
 3. **Peter Steinberger** — Session isolation, Lane Queue, lifecycle, plugin architecture (OpenClaw)

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -995,7 +995,10 @@ class AgenticLoop:
                     "type": "text",
                     "text": (
                         "[system] Multiple tools are failing consecutively. "
-                        "Consider a different approach."
+                        "Consider a different approach. "
+                        "If you cannot verify the answer through tools, "
+                        "tell the user what failed and what remains unverified. "
+                        "Do NOT silently answer from training data."
                     ),
                 }
                 tool_results.append(backpressure_hint)

--- a/core/agent/error_recovery.py
+++ b/core/agent/error_recovery.py
@@ -209,7 +209,8 @@ class ErrorRecoveryStrategy:
                 "error": (
                     f"Tool '{tool_name}' recovery exhausted after "
                     f"{len(attempts)} attempt(s). "
-                    "Please use a different approach."
+                    "Try a different tool, or tell the user what failed. "
+                    "Do NOT answer from training data without marking it as [Unverified]."
                 ),
                 "recovery_exhausted": True,
                 "strategies_tried": [a.strategy.value for a in attempts],

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -799,6 +799,28 @@ def _get_prompt_session() -> Any:
     return _prompt_session
 
 
+def _drain_stdin() -> None:
+    """Drain leftover bytes from stdin after a paste.
+
+    When bracketed paste is unavailable, pasted newlines trigger Enter
+    and only the first line is submitted. The remaining text stays in
+    stdin and gets auto-submitted on the next prompt() call.
+    This drains any such leftover to prevent double-submit.
+    """
+    import select
+
+    if not sys.stdin.isatty():
+        return
+    try:
+        import os as _os
+
+        fd = sys.stdin.fileno()
+        while select.select([fd], [], [], 0.0)[0]:
+            _os.read(fd, 4096)
+    except (ValueError, OSError):
+        pass
+
+
 def _read_multiline_input(prompt: str) -> str:
     """Read user input via prompt_toolkit (arrow keys, history).
 
@@ -817,6 +839,10 @@ def _read_multiline_input(prompt: str) -> str:
             # Intentional newlines (Esc+Enter) are preserved by the caller
             # via "\n" detection in the slash command guard.
             text = " ".join(raw.splitlines()) if "\n" in raw else raw
+            # Drain stdin to prevent leftover paste from auto-submitting
+            # on the next prompt. Only needed when bracketed paste is broken
+            # or the terminal doesn't support it.
+            _drain_stdin()
         except (KeyboardInterrupt, EOFError):
             raise
         except Exception:
@@ -981,11 +1007,19 @@ def _thin_interactive_loop(
                 _stream_started = True
                 _rr.on_event(event)
 
+            def _on_approval_start(*, _rr: Any = _r) -> None:
+                _rr.suspend_for_approval()
+
+            def _on_approval_end(*, _rr: Any = _r) -> None:
+                _rr.resume_from_approval()
+
             _renderer.start_activity()  # persistent spinner until result
             response = client.send_prompt(
                 user_input,
                 on_stream=_on_stream,
                 on_event=_on_event,
+                on_approval_start=_on_approval_start,
+                on_approval_end=_on_approval_end,
             )
             _renderer.stop()
             if response.get("type") == "error" and "Connection lost" in response.get("message", ""):

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -157,12 +157,16 @@ class IPCClient:
         *,
         on_stream: Any = None,
         on_event: Any = None,
+        on_approval_start: Any = None,
+        on_approval_end: Any = None,
     ) -> dict[str, Any]:
         """Send a prompt and wait for the result.
 
         Callbacks:
             on_stream(data: str): raw console output (ANSI-styled text)
             on_event(event: dict): structured events (tool_start, tool_end)
+            on_approval_start(): called before HITL approval prompt (suspend spinners)
+            on_approval_end(): called after HITL approval prompt (resume spinners)
 
         Returns the final ``{"type": "result", ...}`` dict.
         """
@@ -181,7 +185,11 @@ class IPCClient:
                 continue
             # HITL approval relay — serve requests user confirmation
             if rtype == "approval_request":
+                if on_approval_start is not None:
+                    on_approval_start()
                 decision = self._handle_approval_request(response)
+                if on_approval_end is not None:
+                    on_approval_end()
                 self._send({"type": "approval_response", "decision": decision})
                 continue
             # Structured events — all non-stream, non-terminal types
@@ -227,9 +235,31 @@ class IPCClient:
                 continue
             return response
 
+    @staticmethod
+    def _restore_terminal() -> None:
+        """Restore terminal to cooked mode before console.input().
+
+        prompt_toolkit may leave the terminal in raw mode (no ICANON)
+        after session.prompt() returns. Without ICANON, input() cannot
+        receive line-buffered Enter keystrokes, causing it to block
+        indefinitely and trigger the 120s server-side timeout.
+        """
+        import sys
+        import termios
+
+        try:
+            fd = sys.stdin.fileno()
+            attrs = termios.tcgetattr(fd)
+            attrs[3] |= termios.ECHO | termios.ICANON
+            termios.tcsetattr(fd, termios.TCSANOW, attrs)
+        except (ValueError, OSError, termios.error):
+            pass
+
     def _handle_approval_request(self, msg: dict[str, Any]) -> str:
         """Display approval prompt to user and return decision."""
         from core.cli.ui.console import console as c
+
+        self._restore_terminal()
 
         tool = msg.get("tool_name", "?")
         detail = msg.get("detail", "")

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -574,6 +574,20 @@ class EventRenderer:
         self._out.write(f"  \033[32m\u2713 {name}\033[0m \u00d7{count} \u2192 {summary}{dur_str}\n")
         self._out.flush()
 
+    # -- HITL approval spinner coordination ------------------------------------
+
+    def suspend_for_approval(self) -> None:
+        """Suspend all spinners for HITL approval prompt.
+
+        Must be called before ``console.input()`` to prevent ANSI cursor-up
+        race between spinner daemon threads and the input line.
+        """
+        self._suppress_all_spinners()
+
+    def resume_from_approval(self) -> None:
+        """Resume activity spinner after HITL approval completes."""
+        self._activity_suppressed = False
+
     # -- Internal helpers -----------------------------------------------------
 
     _FRAMES = "\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f"

--- a/core/llm/prompts/__init__.py
+++ b/core/llm/prompts/__init__.py
@@ -165,7 +165,7 @@ _log.debug("Prompt versions loaded (%d): %s", len(PROMPT_VERSIONS), PROMPT_VERSI
 #   python -c "from core.llm.prompts import PROMPT_VERSIONS as V; \
 #     print(dict(sorted(V.items())))"
 _PINNED_HASHES: dict[str, str] = {
-    "AGENTIC_SUFFIX": "3f125e744c41",
+    "AGENTIC_SUFFIX": "79cef71335e8",
     "ANALYST_SPECIFIC": "5a696a2d5ebb",
     "ANALYST_SYSTEM": "8a325a63b397",
     "ANALYST_TOOLS_SUFFIX": "2961fb31d96f",

--- a/core/llm/prompts/router.md
+++ b/core/llm/prompts/router.md
@@ -68,6 +68,7 @@ Simple requests (single lookup, quick answer): execute directly, no plan needed.
 - Example: "Show list and check status" → call `list_ips()` AND `check_status()` together.
 - For dependent requests (e.g. "search then summarize"), call tools sequentially across rounds.
 - If a tool fails, try an alternative approach or explain the issue.
+- CRITICAL: When ALL relevant tools fail or return insufficient data, you MUST say "I could not verify this" rather than answering from training data. Never present unverified information as fact. Prefix uncertain answers with "[Unverified]" and explain what failed.
 - For bash commands, always provide a "reason" parameter.
 - Use delegate_task for sub-agent delegation (complex tasks needing their own agentic loop).
 - Keep your final text response concise and in the user's language.
@@ -150,3 +151,4 @@ When using tool results (web_fetch, general_web_search, MCP tools, etc.) to gene
    - For MCP tools: cite the server name (e.g. "Steam API", "arXiv").
 3. **When data is insufficient**, say so explicitly rather than filling gaps with assumptions.
 4. **Numerical data**: quote the exact number from the tool result. Do NOT round, extrapolate, or estimate unless explicitly requested.
+5. **Tool failure fallback**: When a tool fails or returns an error, NEVER silently answer from training data instead. Either try an alternative tool, or explicitly tell the user: "The tool failed, so I cannot verify this. Here is what I know from general knowledge, but it may be outdated or inaccurate: [...]". Always distinguish verified (tool-sourced) from unverified (training data) information.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
 # GEODE Progress Board
 
 > 멀티 에이전트 공유 칸반 보드. 모든 세션/에이전트가 이 파일을 읽고 갱신한다.
-> 마지막 갱신: 2026-04-01 (세션 54 — cross-provider model switch fix)
+> 마지막 갱신: 2026-04-03 (세션 56 — observability gaps + HITL IPC + paste fix)
 > **규칙**: progress.md는 main에서만 수정. feature/develop 수정 금지.
 
 ---
@@ -62,6 +62,24 @@
 
 | task_id | 작업 내용 | PR | 담당 | CI | 비고 |
 |---------|----------|-----|------|-----|------|
+
+### Done (2026-04-03 — 세션 56)
+
+| task_id | 작업 내용 | PR | 담당 | 완료일 |
+|---------|----------|----|------|--------|
+| readme-badge-compress | README LLM 모델 뱃지 9→4 압축 (primary + fallback summary) | #635 | @mangowhoiscloud | 2026-04-02 |
+| hitl-ipc-3bug | HITL IPC 3-bug fix — ack leak, Console theme, output TypeError | #640 | @mangowhoiscloud | 2026-04-03 |
+| paste-input-fix | 붙여넣기 입력 버그 — multiline buffer + Enter submit + line join | #641 | @mangowhoiscloud | 2026-04-03 |
+| obs-gaps | Observability gap 3건 보강 — compression metrics, retry_exhausted, fallback latency | #643 | @mangowhoiscloud | 2026-04-03 |
+
+### Done (2026-04-01 — 세션 55)
+
+| task_id | 작업 내용 | PR | 담당 | 완료일 |
+|---------|----------|----|------|--------|
+| hitl-approval-fix | HITL IPC approval 5-bug fix — buf 미갱신, stale response, tool_name, safety_level, 이중 프롬프트 | #630 | @mangowhoiscloud | 2026-04-01 |
+| llm-resilience-v2 | LLM failure resilience — backoff retry, context-first recovery | #638 | @mangowhoiscloud | 2026-04-01 |
+| haiku-native-tools | Haiku 400 fix — allowed_callers=direct for native tools | #632 | @mangowhoiscloud | 2026-04-01 |
+| model-switch-guard | Model switch context guard — stale system_prompt prevention | #634 | @mangowhoiscloud | 2026-04-01 |
 
 ### Done (2026-04-01 — 세션 54)
 


### PR DESCRIPTION
## Summary
- **HITL 승인 120s timeout 수정**: spinner daemon thread의 ANSI cursor-up이 console.input()과 충돌 + prompt_toolkit이 터미널을 raw mode로 남겨 input()이 Enter를 인식 못함. suspend_for_approval() + _restore_terminal() 추가.
- **장문 붙여넣기 이중 입력 수정**: bracketed paste 미지원 시 stdin에 남은 바이트가 다음 prompt에 자동 입력. _drain_stdin() 추가.
- **도구 실패 시 잘못된 답변 수정**: system prompt + backpressure hint + recovery exhausted 메시지에 [Unverified] 태그 의무화.
- **Scaffold Step 4 개선**: "E2E Verify" → "Verify (Implementation GAP Audit)" — 4단계 포렌식 감사 (완전성, 정확성, 청결성, 검증팀).

## Why
- HITL: 사용자가 A(Always) 눌러도 120초 후 거부되는 치명적 UX 버그
- Paste: PR #641 수정 이후에도 bracketed paste 미지원 터미널에서 재현
- Grounding: LLM이 도구 실패 후 학습 데이터로 자신있게 답변하여 오답 생성
- Verify: Step 4가 dry-run E2E만 수행하고 구현 누락/기만/데드코드 검증 없었음

## Test plan
- [x] `uv run ruff check core/ tests/` — 0 errors
- [x] `uv run mypy core/agent/agentic_loop.py core/agent/error_recovery.py core/cli/__init__.py core/cli/ipc_client.py core/cli/ui/event_renderer.py` — 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 3615 passed
- [x] Prompt drift pin updated (AGENTIC_SUFFIX hash)
- [ ] HITL 수동 테스트: memory_save 승인 시 A 키 반응 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)