### PR TITLE
feat: sandbox breadcrumb — 3-layer LLM steering for path errors

### DIFF
--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -848,12 +848,15 @@ class ToolCallProcessor:
 
         # Per-run mutable state — reset via reset()
         self._consecutive_failures: dict[str, int] = {}
+        # Breadcrumb: skip recovery chain for non-recoverable errors (e.g. permission)
+        self._last_error_recoverable: dict[str, bool] = {}
         self._tool_log: list[dict[str, Any]] = []
         self._clarification_count: int = 0
 
     def reset(self) -> None:
         """Reset per-run tracking state. Call at the start of each agentic run."""
         self._consecutive_failures.clear()
+        self._last_error_recoverable.clear()
         self._tool_log.clear()
         self._clarification_count = 0
 
@@ -947,7 +950,8 @@ class ToolCallProcessor:
         # Check consecutive failure count
         fail_count = self._consecutive_failures.get(tool_name, 0)
 
-        if fail_count >= self.MAX_CONSECUTIVE_FAILURES:
+        last_recoverable = self._last_error_recoverable.get(tool_name, True)
+        if fail_count >= self.MAX_CONSECUTIVE_FAILURES and last_recoverable:
             # Adaptive recovery: try recovery chain instead of auto-skip
             result = await self._attempt_recovery(tool_name, tool_input, fail_count)
             visible = self._op_logger.log_tool_call(tool_name, tool_input)
@@ -959,12 +963,14 @@ class ToolCallProcessor:
             # Execute via ToolExecutor (sync handlers wrapped in to_thread)
             result = await asyncio.to_thread(self._executor.execute, tool_name, tool_input)
 
-        # Track consecutive failures
+        # Track consecutive failures + recoverability breadcrumb
         if isinstance(result, dict) and result.get("error"):
             if not result.get("recovery_attempted"):
                 self._consecutive_failures[tool_name] = fail_count + 1
+                self._last_error_recoverable[tool_name] = result.get("recoverable", True)
         else:
             self._consecutive_failures[tool_name] = 0
+            self._last_error_recoverable.pop(tool_name, None)
 
         # Track clarification rounds to prevent infinite loops
         if isinstance(result, dict) and result.get("clarification_needed"):

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -317,7 +317,15 @@
       "properties": {
         "sub_action": {
           "type": "string",
-          "enum": ["list", "create", "delete", "status", "enable", "disable", "run"],
+          "enum": [
+            "list",
+            "create",
+            "delete",
+            "status",
+            "enable",
+            "disable",
+            "run"
+          ],
           "description": "Action to perform."
         },
         "target_id": {
@@ -333,7 +341,9 @@
           "description": "What to do when fired — a natural language prompt. Example: 'Search AI papers and create digest'. REQUIRED for create."
         }
       },
-      "required": ["sub_action"]
+      "required": [
+        "sub_action"
+      ]
     }
   },
   {
@@ -450,7 +460,9 @@
         },
         "steps": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "description": "List of plan steps (e.g. ['web search', 'data collection', 'analysis', 'report writing']). Auto-generated if omitted."
         },
         "ip_name": {
@@ -653,10 +665,12 @@
         },
         "path": {
           "type": "string",
-          "description": "Directory to search in (default: project root)"
+          "description": "Directory to search in (default: project root) Must be within the project directory — absolute paths outside the project are blocked."
         }
       },
-      "required": ["pattern"]
+      "required": [
+        "pattern"
+      ]
     }
   },
   {
@@ -673,7 +687,7 @@
         },
         "path": {
           "type": "string",
-          "description": "File or directory to search (default: project root)"
+          "description": "File or directory to search (default: project root) Must be within the project directory — absolute paths outside the project are blocked."
         },
         "glob": {
           "type": "string",
@@ -688,7 +702,9 @@
           "description": "Max files to return (default: 50)"
         }
       },
-      "required": ["pattern"]
+      "required": [
+        "pattern"
+      ]
     }
   },
   {
@@ -701,7 +717,7 @@
       "properties": {
         "file_path": {
           "type": "string",
-          "description": "Path to the file to edit"
+          "description": "Path to the file to edit Must be within the project directory."
         },
         "old_string": {
           "type": "string",
@@ -716,7 +732,11 @@
           "description": "Replace all occurrences (default: false)"
         }
       },
-      "required": ["file_path", "old_string", "new_string"]
+      "required": [
+        "file_path",
+        "old_string",
+        "new_string"
+      ]
     }
   },
   {
@@ -729,14 +749,17 @@
       "properties": {
         "file_path": {
           "type": "string",
-          "description": "Path to the file to create or overwrite"
+          "description": "Path to the file to create or overwrite Must be within the project directory."
         },
         "content": {
           "type": "string",
           "description": "Complete file content"
         }
       },
-      "required": ["file_path", "content"]
+      "required": [
+        "file_path",
+        "content"
+      ]
     }
   },
   {
@@ -1188,7 +1211,11 @@
       "properties": {
         "action": {
           "type": "string",
-          "enum": ["compact", "clear", "status"],
+          "enum": [
+            "compact",
+            "clear",
+            "status"
+          ],
           "description": "compact: compress conversation, clear: full reset, status: check current token usage"
         },
         "force": {
@@ -1196,7 +1223,9 @@
           "description": "If true, executes without confirmation (applies to clear). Default: false."
         }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     }
   },
   {
@@ -1220,7 +1249,9 @@
           "description": "Additional metadata (optional) — {priority, source, tool_name, tool_args}"
         }
       },
-      "required": ["subject"]
+      "required": [
+        "subject"
+      ]
     }
   },
   {
@@ -1237,7 +1268,11 @@
         },
         "status": {
           "type": "string",
-          "enum": ["in_progress", "completed", "failed"],
+          "enum": [
+            "in_progress",
+            "completed",
+            "failed"
+          ],
           "description": "New status (in_progress: start task, completed: done, failed: failed)"
         },
         "subject": {
@@ -1257,7 +1292,9 @@
           "description": "Metadata to merge (optional, use null values to delete keys)"
         }
       },
-      "required": ["task_id"]
+      "required": [
+        "task_id"
+      ]
     }
   },
   {
@@ -1273,7 +1310,9 @@
           "description": "Task ID to retrieve"
         }
       },
-      "required": ["task_id"]
+      "required": [
+        "task_id"
+      ]
     }
   },
   {
@@ -1286,7 +1325,13 @@
       "properties": {
         "status_filter": {
           "type": "string",
-          "enum": ["pending", "in_progress", "completed", "failed", "all"],
+          "enum": [
+            "pending",
+            "in_progress",
+            "completed",
+            "failed",
+            "all"
+          ],
           "description": "Status filter (default: all)"
         }
       },
@@ -1310,7 +1355,9 @@
           "description": "Cancellation reason (optional)"
         }
       },
-      "required": ["task_id"]
+      "required": [
+        "task_id"
+      ]
     }
   }
 ]

--- a/core/tools/document_tools.py
+++ b/core/tools/document_tools.py
@@ -54,6 +54,10 @@ class ReadDocumentTool:
                 f"Access denied: path outside project directory ({_PROJECT_ROOT})",
                 error_type="permission",
                 recoverable=False,
+                hint=(
+                    "All file tools are sandboxed to the project directory. "
+                    "Use a relative path or omit the path parameter."
+                ),
                 context={"file_path": str(file_path)},
             )
 

--- a/core/tools/file_tools.py
+++ b/core/tools/file_tools.py
@@ -189,7 +189,7 @@ class GrepTool:
 
         err = _check_sandbox(search_path)
         if err:
-            return tool_error(err, error_type="permission", recoverable=False)
+            return err
 
         try:
             regex = re.compile(pattern_str)
@@ -280,8 +280,7 @@ class EditFileTool:
                 "file_path": {
                     "type": "string",
                     "description": (
-                        "Path to the file to edit. "
-                        "Must be within the project directory."
+                        "Path to the file to edit. Must be within the project directory."
                     ),
                 },
                 "old_string": {

--- a/core/tools/file_tools.py
+++ b/core/tools/file_tools.py
@@ -20,15 +20,35 @@ log = logging.getLogger(__name__)
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def _check_sandbox(path: Path) -> str | None:
-    """Return error message if path is outside sandbox or is a symlink."""
+def _check_sandbox(path: Path) -> dict[str, Any] | None:
+    """Return tool_error dict if path is outside sandbox, None if OK.
+
+    Breadcrumb pattern: the hint field steers the LLM to self-correct
+    on the very first failure instead of retrying with another bad path.
+    """
+    from core.tools.base import tool_error
+
     if path.is_symlink():
-        return f"Symlinks not allowed: {path}"
+        return tool_error(
+            f"Symlinks not allowed: {path}",
+            error_type="permission",
+            recoverable=False,
+            hint="Resolve the symlink target and use the real path.",
+        )
     resolved = path.resolve()
     try:
         resolved.relative_to(_PROJECT_ROOT)
     except ValueError:
-        return f"Access denied: path outside project directory ({_PROJECT_ROOT})"
+        return tool_error(
+            f"Access denied: path outside project directory ({_PROJECT_ROOT})",
+            error_type="permission",
+            recoverable=False,
+            hint=(
+                "All file tools are sandboxed to the project directory. "
+                "Use a relative path (e.g. 'core/tools/') or omit the path "
+                "parameter to search from the project root."
+            ),
+        )
     return None
 
 
@@ -57,7 +77,10 @@ class GlobTool:
                 },
                 "path": {
                     "type": "string",
-                    "description": "Directory to search in (default: project root)",
+                    "description": (
+                        "Directory to search in (default: project root). "
+                        "Must be within the project directory."
+                    ),
                 },
             },
             "required": ["pattern"],
@@ -74,7 +97,7 @@ class GlobTool:
 
         err = _check_sandbox(search_dir)
         if err:
-            return tool_error(err, error_type="permission", recoverable=False)
+            return err
 
         if not search_dir.is_dir():
             return tool_error(
@@ -131,7 +154,10 @@ class GrepTool:
                 },
                 "path": {
                     "type": "string",
-                    "description": "File or directory to search (default: project root)",
+                    "description": (
+                        "File or directory to search (default: project root). "
+                        "Must be within the project directory."
+                    ),
                 },
                 "glob": {
                     "type": "string",
@@ -253,7 +279,10 @@ class EditFileTool:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path to the file to edit",
+                    "description": (
+                        "Path to the file to edit. "
+                        "Must be within the project directory."
+                    ),
                 },
                 "old_string": {
                     "type": "string",
@@ -284,7 +313,7 @@ class EditFileTool:
 
         err = _check_sandbox(file_path)
         if err:
-            return tool_error(err, error_type="permission", recoverable=False)
+            return err
 
         if not file_path.exists():
             return tool_error(
@@ -357,7 +386,10 @@ class WriteFileTool:
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path to the file to create or overwrite",
+                    "description": (
+                        "Path to the file to create or overwrite. "
+                        "Must be within the project directory."
+                    ),
                 },
                 "content": {
                     "type": "string",
@@ -378,7 +410,7 @@ class WriteFileTool:
 
         err = _check_sandbox(file_path)
         if err:
-            return tool_error(err, error_type="permission", recoverable=False)
+            return err
 
         try:
             file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_project_memory.py
+++ b/tests/test_project_memory.py
@@ -369,9 +369,7 @@ class TestPurgeBadInsights:
             "- 2026-03-29: [unknown] tier=?, score=0.00\n"
             "- 2026-03-29: [Berserk] tier=S, score=0.85\n"
         )
-        content = content.replace(
-            "## Recent Insights\n", f"## 최근 인사이트\n{bad_entries}"
-        )
+        content = content.replace("## Recent Insights\n", f"## 최근 인사이트\n{bad_entries}")
         mem.memory_file.write_text(content, encoding="utf-8")
 
         removed = mem.purge_bad_insights()


### PR DESCRIPTION
## Summary
- Tool description에 sandbox 제약 명시 (Prevention breadcrumb)
- _check_sandbox 에러에 actionable hint 추가 (Correction breadcrumb)
- Non-recoverable 에러 시 recovery chain skip (Fast exit)

## Why
LLM이 프로젝트 외부 경로로 grep_files를 반복 호출 → Access denied 에러 2회 노출 → recovery chain이 무의미하게 RETRY.
Claude Code의 tool description constraint + system-reminder smoosh 패턴 차용.

## Changes
| File | Change |
|------|--------|
| \`core/tools/file_tools.py\` | _check_sandbox → dict 반환 + hint 포함, tool description에 sandbox 명시 |
| \`core/tools/document_tools.py\` | sandbox hint 추가 |
| \`core/tools/definitions.json\` | 5 tools path description에 sandbox 제약 추가 |
| \`core/agent/tool_executor.py\` | _last_error_recoverable 추적, non-recoverable 시 recovery skip |

## Verification
- [x] CI 5/5 pass

## Reference
- claude-code/tools/FileReadTool/prompt.ts — path constraint in tool description

🤖 Generated with [Claude Code](https://claude.com/claude-code)