### PR TITLE
feat: HITL approval spinner UI

### DIFF
--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -256,7 +256,12 @@ class IPCClient:
             pass
 
     def _handle_approval_request(self, msg: dict[str, Any]) -> str:
-        """Display approval prompt to user and return decision."""
+        """Display approval prompt to user with animated spinner."""
+        import sys
+        import threading
+        import time
+        import unicodedata
+
         from core.cli.ui.console import console as c
 
         self._restore_terminal()
@@ -272,12 +277,55 @@ class IPCClient:
             "cost": "Cost",
         }
         label = _LEVEL_LABELS.get(level, level.title())
+        _LEVEL_COLORS = {
+            "write": "33",  # yellow
+            "dangerous": "31",  # red
+            "mcp": "36",  # cyan
+            "cost": "33",  # yellow
+        }
+        color = _LEVEL_COLORS.get(level, "33")
 
-        c.print()
-        c.print(f"  [warning]{label} tool requires approval[/warning]")
-        c.print(f"  [dim]Tool:[/dim] [bold]{tool}[/bold]")
-        if detail:
-            c.print(f"  [dim]{detail}[/dim]")
+        # Truncate detail for display (CJK-aware)
+        def _trunc(text: str, width: int = 50) -> str:
+            w = 0
+            for i, ch in enumerate(text):
+                w += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+                if w > width - 3:
+                    return text[:i] + "..."
+            return text
+
+        detail_short = _trunc(detail.replace("\n", " ")) if detail else ""
+        args_display = f"({detail_short})" if detail_short else ""
+
+        # Animated spinner while waiting for input
+        _FRAMES = "\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f"
+        out = sys.stdout
+        spinning = True
+
+        def _spin() -> None:
+            while spinning:
+                frame = _FRAMES[int(time.monotonic() * 12) % len(_FRAMES)]
+                out.write(
+                    f"\r\033[2K  {frame} \033[{color}m{tool}\033[0m"
+                    f"{args_display}"
+                    f" \033[2m\u2014 {label} approval\033[0m"
+                )
+                out.flush()
+                time.sleep(0.08)
+
+        spinner_thread = threading.Thread(target=_spin, daemon=True)
+        spinner_thread.start()
+
+        # Brief pause so spinner is visible before prompt replaces it
+        time.sleep(0.3)
+        spinning = False
+        spinner_thread.join(timeout=0.3)
+
+        # Replace spinner line with static prompt
+        out.write("\r\033[2K")
+        out.flush()
+        c.print(f"  \033[{color}m\u25b8 {tool}\033[0m{args_display}")
+        c.print(f"    \033[2m{label} tool requires approval\033[0m")
         c.print()
 
         try:


### PR DESCRIPTION
## Summary
- HITL 승인 프롬프트에 braille spinner 애니메이션 추가
- Before: bare "MCP tool requires approval" + empty prompt
- After: `⠴ search_files(filesystem) — MCP approval` spinner → static prompt
- ToolCallTracker 스타일과 통일된 UI

## Why
- 승인 대기 중 빈 화면 → 사용자가 시스템 멈춤으로 오인
- 모든 도구 호출에 spinner가 있지만 승인 프롬프트만 빠져있었음
- MCP/Write/Cost/Dangerous 4가지 승인 유형 모두 IPC 경로 `_handle_approval_request()` 하나를 통과

## Test plan
- [x] `ruff check` + `ruff format --check` — pass
- [x] `mypy` — 0 errors
- [x] `pytest` — 3637 passed
- [ ] 수동: MCP 도구 승인 시 spinner 표시 확인
- [ ] 수동: Write/Bash 승인 시 동일한 UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)