### PR TITLE
fix: thread-local console isolation — cross-session output contamination

### DIFF
--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -186,12 +186,11 @@ class ToolExecutor:
         """
         # IPC mode: relay approval to thin client via callback
         if self._approval_callback is not None:
-            decision = self._approval_callback(
-                tool_name or label, detail, safety_level
-            )
+            decision = self._approval_callback(tool_name or label, detail, safety_level)
             log.debug(
                 "HITL: IPC callback returned decision=%s tool=%s",
-                decision, tool_name or label,
+                decision,
+                tool_name or label,
             )
             return decision
 

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -186,7 +186,14 @@ class ToolExecutor:
         """
         # IPC mode: relay approval to thin client via callback
         if self._approval_callback is not None:
-            return self._approval_callback(tool_name or label, detail, safety_level)
+            decision = self._approval_callback(
+                tool_name or label, detail, safety_level
+            )
+            log.debug(
+                "HITL: IPC callback returned decision=%s tool=%s",
+                decision, tool_name or label,
+            )
+            return decision
 
         # Direct terminal mode
         from core.cli import _restore_terminal

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -250,10 +250,13 @@ class IPCClient:
         try:
             fd = sys.stdin.fileno()
             attrs = termios.tcgetattr(fd)
+            had_icanon = bool(attrs[3] & termios.ICANON)
             attrs[3] |= termios.ECHO | termios.ICANON
             termios.tcsetattr(fd, termios.TCSANOW, attrs)
-        except (ValueError, OSError, termios.error):
-            pass
+            if not had_icanon:
+                log.info("HITL: terminal restored (ICANON was missing)")
+        except (ValueError, OSError, termios.error) as exc:
+            log.warning("HITL: _restore_terminal failed: %s", exc)
 
     def _handle_approval_request(self, msg: dict[str, Any]) -> str:
         """Display approval prompt to user with animated spinner."""
@@ -328,16 +331,29 @@ class IPCClient:
         c.print(f"    \033[2m{label} tool requires approval\033[0m")
         c.print()
 
+        t0 = time.monotonic()
         try:
             resp = c.input("  [header]Allow? [Y/n/A][/header] ").strip().lower()
         except (KeyboardInterrupt, EOFError):
             c.print()
+            log.info(
+                "HITL: approval interrupted tool=%s elapsed=%.1fs",
+                tool, time.monotonic() - t0,
+            )
             return "n"
+
+        elapsed = time.monotonic() - t0
         if resp in ("a", "always"):
-            return "a"
-        if resp in ("", "y", "yes"):
-            return "y"
-        return "n"
+            decision = "a"
+        elif resp in ("", "y", "yes"):
+            decision = "y"
+        else:
+            decision = "n"
+        log.info(
+            "HITL: approval tool=%s input=%r decision=%s elapsed=%.1fs",
+            tool, resp, decision, elapsed,
+        )
+        return decision
 
     def request_resume(
         self,

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -338,7 +338,8 @@ class IPCClient:
             c.print()
             log.info(
                 "HITL: approval interrupted tool=%s elapsed=%.1fs",
-                tool, time.monotonic() - t0,
+                tool,
+                time.monotonic() - t0,
             )
             return "n"
 
@@ -351,7 +352,10 @@ class IPCClient:
             decision = "n"
         log.info(
             "HITL: approval tool=%s input=%r decision=%s elapsed=%.1fs",
-            tool, resp, decision, elapsed,
+            tool,
+            resp,
+            decision,
+            elapsed,
         )
         return decision
 

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -101,29 +101,36 @@ class SessionMeter:
         return f"{m}m {sec}s"
 
 
-_session_meter: SessionMeter | None = None
+_meter_local = threading.local()
 
 
 def init_session_meter(model: str = "") -> SessionMeter:
-    """Initialize the session meter singleton."""
-    global _session_meter
+    """Initialize the session meter for the current thread.
+
+    Thread-safe: each IPC handler thread (and the main thread) gets its
+    own ``SessionMeter`` instance via ``threading.local``, preventing
+    cross-session contamination of model names, elapsed times, and
+    token counters.
+    """
     if not model:
         from core.config import ANTHROPIC_PRIMARY
 
         model = ANTHROPIC_PRIMARY
-    _session_meter = SessionMeter(model=model)
-    return _session_meter
+    meter = SessionMeter(model=model)
+    _meter_local.meter = meter
+    return meter
 
 
 def update_session_model(model: str) -> None:
-    """Update the session meter's model after /model switch."""
-    if _session_meter is not None:
-        _session_meter.model = model
+    """Update the current thread's session meter model after /model switch."""
+    meter = getattr(_meter_local, "meter", None)
+    if meter is not None:
+        meter.model = model
 
 
 def get_session_meter() -> SessionMeter | None:
-    """Return the current session meter (None if not initialized)."""
-    return _session_meter
+    """Return the current thread's session meter (None if not initialized)."""
+    return getattr(_meter_local, "meter", None)
 
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/core/cli/ui/console.py
+++ b/core/cli/ui/console.py
@@ -1,4 +1,11 @@
-"""Rich Console singleton — GEODE brand theme.
+"""Rich Console — GEODE brand theme with thread-safe session isolation.
+
+Each IPC handler thread gets its own Rich Console instance via
+``set_thread_console()``.  The module-level ``console`` is a lightweight
+proxy that delegates attribute access to the thread-local Console (or
+falls back to the process-wide default).  This prevents cross-session
+output contamination when multiple thin-CLI clients connect to
+``geode serve`` concurrently.
 
 Brand colors (from axolotl mascot, toned-down for readability):
   Rose (#d4a0a0)     — axolotl body → brand identity (muted coral)
@@ -12,6 +19,7 @@ from __future__ import annotations
 
 import shutil
 import sys
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from io import StringIO
@@ -72,17 +80,88 @@ def _get_terminal_width() -> int | None:
     return max(80, min(cols, 160))
 
 
-console = Console(theme=GEODE_THEME, width=_get_terminal_width())
+# ───────────────────────────────────────────────────────────────────────────
+# Thread-safe Console proxy
+# ───────────────────────────────────────────────────────────────────────────
+
+_default_console = Console(theme=GEODE_THEME, width=_get_terminal_width())
+
+
+class _ConsoleProxy:
+    """Thread-safe proxy delegating to per-thread Console instances.
+
+    IPC handler threads call ``set_thread_console()`` to install a
+    session-scoped Console whose ``file`` writes to the client's socket.
+    All other threads transparently fall back to ``_default_console``.
+
+    Both ``__getattr__`` and ``__setattr__`` are forwarded, so existing
+    code like ``console._file = buf`` in ``capture_output()`` safely
+    mutates the *thread-local* Console — never the shared default.
+    """
+
+    _local = threading.local()
+
+    def __init__(self, default: Console) -> None:
+        # Bypass our __setattr__ to store the default on the instance.
+        object.__setattr__(self, "_default", default)
+
+    def _current(self) -> Console:
+        """Return thread-local Console, or fall back to default."""
+        local: Console | None = getattr(self._local, "console", None)
+        if local is not None:
+            return local
+        default: Console = object.__getattribute__(self, "_default")
+        return default
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._current(), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._current(), name, value)
+
+
+console: Any = _ConsoleProxy(_default_console)
+
+
+def set_thread_console(c: Console) -> None:
+    """Install a thread-local Console for the current thread.
+
+    Called by CLIPoller at the start of each IPC handler thread so that
+    all ``console.print(...)`` calls within that thread route to the
+    session's ``_StreamingWriter`` instead of the shared stdout.
+    """
+    _ConsoleProxy._local.console = c
+
+
+def reset_thread_console() -> None:
+    """Remove thread-local Console, reverting to the default."""
+    _ConsoleProxy._local.__dict__.pop("console", None)
+
+
+def make_session_console(file: Any) -> Console:
+    """Create a session-scoped Console writing to *file*.
+
+    Returns a fully configured Console with the GEODE theme, forced
+    ANSI output, and truecolor — suitable for IPC streaming writers.
+    """
+    from rich.color import ColorSystem
+
+    c = Console(theme=GEODE_THEME, file=file, force_terminal=True, width=120)
+    c._color_system = ColorSystem.TRUECOLOR
+    return c
 
 
 @contextmanager
 def capture_output() -> Generator[StringIO, None, None]:
     """Capture console output with ANSI styling preserved.
 
-    Temporarily redirects the global console to a StringIO buffer with
-    ``force_terminal=True`` and a valid color system so that Rich markup
-    is rendered as ANSI escape codes — even when the process's stdout is
-    not a TTY (e.g. ``geode serve`` started with ``stdout=DEVNULL``).
+    Temporarily redirects the current thread's console to a StringIO
+    buffer with ``force_terminal=True`` and a valid color system so
+    that Rich markup is rendered as ANSI escape codes — even when the
+    process's stdout is not a TTY (e.g. ``geode serve`` with DEVNULL).
+
+    Thread-safe: operates on the thread-local Console (via the proxy),
+    so concurrent IPC sessions don't interfere with each other.
 
     Usage::
 
@@ -114,8 +193,8 @@ def redirect_console(target: Any) -> Generator[None, None, None]:
 
     Like ``capture_output`` but writes to an arbitrary file-like object
     (e.g. ``_StreamingWriter``) instead of a ``StringIO`` buffer.
-    Ensures ``_color_system`` is set so styles render even when the
-    process stdout is DEVNULL.
+
+    Thread-safe: operates on the thread-local Console (via the proxy).
     """
     from rich.color import ColorSystem
 

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -291,6 +291,12 @@ class CLIPoller:
         # ContextVars do NOT propagate to threads — set them explicitly
         self._propagate_contextvars()
 
+        # Thread-local session meter — each IPC session tracks its own
+        # model, elapsed time, and token counts independently.
+        from core.cli.ui.agentic_ui import init_session_meter
+
+        init_session_meter()
+
         client.settimeout(None)  # blocking reads
         buf = b""
         conversation = ConversationContext()
@@ -394,16 +400,18 @@ class CLIPoller:
     ) -> dict[str, Any]:
         """Run a prompt with real-time console streaming to the client.
 
-        Redirects the global console to a ``_StreamingWriter`` so that
-        all agentic UI output (tool calls ▸, results ✓/✗, token usage ✢,
-        context events ⟳) is relayed to the thin client in real-time.
-
-        The loop runs with ``quiet=False`` — identical to the old REPL
-        experience.  After completion, the console is restored and a
-        final ``result`` message is sent.
+        Installs a **thread-local** Rich Console whose ``file`` is the
+        client's ``_StreamingWriter``.  All ``console.print(...)`` calls
+        within this thread are routed to the session's socket — never to
+        the shared default Console — preventing cross-session output
+        contamination when multiple thin-CLI clients connect concurrently.
         """
         from core.cli.ui.agentic_ui import _ipc_writer_local
-        from core.cli.ui.console import redirect_console
+        from core.cli.ui.console import (
+            make_session_console,
+            reset_thread_console,
+            set_thread_console,
+        )
 
         # Enable agentic UI for this run (same as old REPL)
         old_quiet = getattr(loop, "_quiet", True)
@@ -412,16 +420,13 @@ class CLIPoller:
         if old_op_quiet is not None:
             loop._op_logger._quiet = False
 
-        # Redirect console + spinner output to streaming writer
+        # Thread-local console: all console.print() in this thread → client socket
         writer = _StreamingWriter(client) if client else None
-        _redirect = redirect_console(writer) if writer else None
-        # Set IPC writer for OperationLogger structured events
         if writer:
+            set_thread_console(make_session_console(writer))
             _ipc_writer_local.writer = writer
 
         try:
-            if _redirect:
-                _redirect.__enter__()
             lane_queue = self._services.lane_queue
             if lane_queue is not None:
                 with lane_queue.acquire_all(f"cli:{session_id}", ["session", "global"]):
@@ -429,9 +434,8 @@ class CLIPoller:
             else:
                 result = loop.run(text)
         finally:
-            if _redirect:
-                _redirect.__exit__(None, None, None)
             if writer:
+                reset_thread_console()
                 _ipc_writer_local.writer = None
             loop._quiet = old_quiet
             if old_op_quiet is not None:

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -91,6 +91,7 @@ class _StreamingWriter:
         )
         log.debug("HITL: sent approval_request tool=%s level=%s", tool_name, safety_level)
         import time as _time
+
         _t0 = _time.monotonic()
         # Block until thin client sends approval_response
         try:
@@ -101,7 +102,8 @@ class _StreamingWriter:
                 if not chunk:
                     log.warning(
                         "HITL: connection closed waiting for approval tool=%s elapsed=%.1fs",
-                        tool_name, _time.monotonic() - _t0,
+                        tool_name,
+                        _time.monotonic() - _t0,
                     )
                     return "n"
                 buf += chunk
@@ -112,7 +114,9 @@ class _StreamingWriter:
                         decision = str(msg.get("decision", "n"))
                         log.info(
                             "HITL: approval_response tool=%s decision=%s elapsed=%.1fs",
-                            tool_name, decision, _time.monotonic() - _t0,
+                            tool_name,
+                            decision,
+                            _time.monotonic() - _t0,
                         )
                         return decision
                     else:
@@ -123,13 +127,16 @@ class _StreamingWriter:
         except TimeoutError:
             log.warning(
                 "HITL: approval TIMEOUT tool=%s elapsed=%.1fs (120s limit hit)",
-                tool_name, _time.monotonic() - _t0,
+                tool_name,
+                _time.monotonic() - _t0,
             )
             return "n"
         except (OSError, json.JSONDecodeError) as exc:
             log.warning(
                 "HITL: approval error tool=%s elapsed=%.1fs exc=%s",
-                tool_name, _time.monotonic() - _t0, exc,
+                tool_name,
+                _time.monotonic() - _t0,
+                exc,
             )
             return "n"
         finally:

--- a/core/gateway/pollers/cli_poller.py
+++ b/core/gateway/pollers/cli_poller.py
@@ -89,6 +89,9 @@ class _StreamingWriter:
                 "safety_level": safety_level,
             }
         )
+        log.debug("HITL: sent approval_request tool=%s level=%s", tool_name, safety_level)
+        import time as _time
+        _t0 = _time.monotonic()
         # Block until thin client sends approval_response
         try:
             self._client.settimeout(120.0)  # 2 min for user decision
@@ -96,14 +99,38 @@ class _StreamingWriter:
             while True:
                 chunk = self._client.recv(4096)
                 if not chunk:
+                    log.warning(
+                        "HITL: connection closed waiting for approval tool=%s elapsed=%.1fs",
+                        tool_name, _time.monotonic() - _t0,
+                    )
                     return "n"
                 buf += chunk
                 while b"\n" in buf:
                     line, buf = buf.split(b"\n", 1)
                     msg = json.loads(line.decode("utf-8"))
                     if msg.get("type") == "approval_response":
-                        return str(msg.get("decision", "n"))
-        except (TimeoutError, OSError, json.JSONDecodeError):
+                        decision = str(msg.get("decision", "n"))
+                        log.info(
+                            "HITL: approval_response tool=%s decision=%s elapsed=%.1fs",
+                            tool_name, decision, _time.monotonic() - _t0,
+                        )
+                        return decision
+                    else:
+                        log.debug(
+                            "HITL: ignoring non-approval msg type=%s while waiting",
+                            msg.get("type"),
+                        )
+        except TimeoutError:
+            log.warning(
+                "HITL: approval TIMEOUT tool=%s elapsed=%.1fs (120s limit hit)",
+                tool_name, _time.monotonic() - _t0,
+            )
+            return "n"
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning(
+                "HITL: approval error tool=%s elapsed=%.1fs exc=%s",
+                tool_name, _time.monotonic() - _t0, exc,
+            )
             return "n"
         finally:
             self._client.settimeout(None)

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -316,16 +316,17 @@ class TestRenderStatusLine:
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_noop_without_meter(self, mock_console) -> None:  # type: ignore[no-untyped-def]
-        # Force no meter
+        # Force no meter by clearing thread-local
         import core.cli.ui.agentic_ui as mod
 
-        old = mod._session_meter
-        mod._session_meter = None
+        old = getattr(mod._meter_local, "meter", None)
+        mod._meter_local.__dict__.pop("meter", None)
         try:
             render_status_line()
             assert not mock_console.print.called
         finally:
-            mod._session_meter = old
+            if old is not None:
+                mod._meter_local.meter = old
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_status_line_shows_per_turn_delta(self, mock_console) -> None:  # type: ignore[no-untyped-def]
@@ -781,3 +782,94 @@ class TestRepeatCounter:
         r.on_event({"type": "tokens", "model": "claude-opus-4-6", "input": 1000, "output": 50})
         output = r._out.getvalue()
         assert "claude-opus-4-6" not in output  # tokens line suppressed
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Thread-local isolation tests
+# ──��──────────────────────────────────────────────────────────────────────
+
+
+class TestThreadLocalConsoleIsolation:
+    """Verify that console output and session meters are thread-local."""
+
+    def test_console_proxy_isolates_threads(self) -> None:
+        """Two threads with different thread-local consoles don't interfere."""
+        import threading
+        from io import StringIO
+
+        from core.cli.ui.console import console as proxy
+        from core.cli.ui.console import (
+            make_session_console,
+            reset_thread_console,
+            set_thread_console,
+        )
+
+        buf_a = StringIO()
+        buf_b = StringIO()
+        barrier = threading.Barrier(2)
+
+        def thread_a() -> None:
+            set_thread_console(make_session_console(buf_a))
+            barrier.wait()  # sync so both threads are active
+            proxy.print("THREAD_A_OUTPUT", highlight=False)
+            barrier.wait()  # sync before cleanup
+            reset_thread_console()
+
+        def thread_b() -> None:
+            set_thread_console(make_session_console(buf_b))
+            barrier.wait()
+            proxy.print("THREAD_B_OUTPUT", highlight=False)
+            barrier.wait()
+            reset_thread_console()
+
+        ta = threading.Thread(target=thread_a)
+        tb = threading.Thread(target=thread_b)
+        ta.start()
+        tb.start()
+        ta.join(timeout=5)
+        tb.join(timeout=5)
+
+        # Each buffer must contain ONLY its own thread's output
+        assert "THREAD_A_OUTPUT" in buf_a.getvalue()
+        assert "THREAD_B_OUTPUT" not in buf_a.getvalue()
+        assert "THREAD_B_OUTPUT" in buf_b.getvalue()
+        assert "THREAD_A_OUTPUT" not in buf_b.getvalue()
+
+    def test_session_meter_isolates_threads(self) -> None:
+        """Two threads get independent session meters."""
+        import threading
+
+        results: dict[str, str | None] = {}
+        barrier = threading.Barrier(2)
+
+        def thread_a() -> None:
+            init_session_meter(model="model-A")
+            barrier.wait()
+            m = get_session_meter()
+            results["a"] = m.model if m else None
+            barrier.wait()
+
+        def thread_b() -> None:
+            init_session_meter(model="model-B")
+            barrier.wait()
+            m = get_session_meter()
+            results["b"] = m.model if m else None
+            barrier.wait()
+
+        ta = threading.Thread(target=thread_a)
+        tb = threading.Thread(target=thread_b)
+        ta.start()
+        tb.start()
+        ta.join(timeout=5)
+        tb.join(timeout=5)
+
+        assert results["a"] == "model-A"
+        assert results["b"] == "model-B"
+
+    def test_default_console_fallback(self) -> None:
+        """Without set_thread_console(), proxy falls back to default."""
+        from core.cli.ui.console import _default_console
+        from core.cli.ui.console import console as proxy
+
+        # In main thread (no thread-local set), proxy._current() returns default
+        assert proxy._current() is _default_console


### PR DESCRIPTION
## Summary
- **P0 Bug Fix**: `redirect_console()` mutated the global Rich Console `_file` attribute — concurrent IPC sessions overwrote each other's writer, routing Session A's output to Session B's socket
- Introduced `_ConsoleProxy` (transparent thread-safe proxy) that delegates all attribute access to per-thread Console instances via `threading.local()`
- Converted `_session_meter` from global singleton to thread-local, preventing cross-session metric contamination
- Frontier research: Claude Code avoids this via process-per-session; GEODE's thread-per-session daemon needs explicit thread-local isolation

## Changes
| File | Change |
|------|--------|
| `core/cli/ui/console.py` | `_ConsoleProxy` + `set_thread_console()` / `reset_thread_console()` / `make_session_console()` |
| `core/cli/ui/agentic_ui.py` | `_session_meter` → `_meter_local = threading.local()` |
| `core/gateway/pollers/cli_poller.py` | Per-IPC-session Console + SessionMeter initialization |
| `tests/test_agentic_ui.py` | 3 new thread-isolation tests (console proxy, meter, fallback) |

## Test plan
- [x] 3640 tests pass (3 new isolation tests)
- [x] Lint 0 errors, mypy 0 errors
- [x] Thread-local console isolation verified: two threads print to separate buffers with no cross-contamination
- [x] Session meter isolation verified: two threads get independent model/timer state
- [x] Default fallback verified: main thread without set_thread_console() uses _default_console

🤖 Generated with [Claude Code](https://claude.com/claude-code)