### PR TITLE
fix: prompt_toolkit Python 3.14 crash — fallback to console.input

### DIFF
--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -798,7 +798,7 @@ def _get_prompt_session() -> Any:
             _prompt_session = _build_prompt_session()
         except Exception:
             log.warning("prompt_toolkit init failed, falling back to console.input", exc_info=True)
-            _prompt_session = False  # type: ignore[assignment]
+            _prompt_session = False  # sentinel: disabled
     return _prompt_session
 
 
@@ -852,7 +852,7 @@ def _read_multiline_input(prompt: str) -> str:
             log.warning("prompt_toolkit failed, falling back to console.input", exc_info=True)
             # Invalidate session to avoid retrying prompt_toolkit on every input
             global _prompt_session
-            _prompt_session = False  # type: ignore[assignment]  # sentinel: disabled
+            _prompt_session = False  # sentinel: permanently disabled
             _restore_terminal()
             text = str(console.input("> ")).strip()
         finally:

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -791,11 +791,14 @@ _prompt_session: Any = None
 
 def _get_prompt_session() -> Any:
     global _prompt_session
+    if _prompt_session is False:
+        return None  # permanently disabled after runtime failure
     if _prompt_session is None:
         try:
             _prompt_session = _build_prompt_session()
         except Exception:
             log.warning("prompt_toolkit init failed, falling back to console.input", exc_info=True)
+            _prompt_session = False  # type: ignore[assignment]
     return _prompt_session
 
 
@@ -847,6 +850,10 @@ def _read_multiline_input(prompt: str) -> str:
             raise
         except Exception:
             log.warning("prompt_toolkit failed, falling back to console.input", exc_info=True)
+            # Invalidate session to avoid retrying prompt_toolkit on every input
+            global _prompt_session
+            _prompt_session = False  # type: ignore[assignment]  # sentinel: disabled
+            _restore_terminal()
             text = str(console.input("> ")).strip()
         finally:
             # Re-install our handler for the non-input phase (spinner, tool execution)


### PR DESCRIPTION
## Summary
- Python 3.14 + prompt_toolkit 3.0.52에서 kqueue OSError crash 수정
- prompt_toolkit 실패 시 \`_prompt_session = False\` sentinel → console.input() fallback

## Why
Python 3.14의 asyncio kqueue selector가 prompt_toolkit의 add_reader(fd)에서
\`OSError: [Errno 22] Invalid argument\` 발생 → geode CLI 연결 직후 크래시.
serve 로그: \`CLI client connected → 1초 내 disconnected\` (3회 반복).

## Changes
| File | Change |
|------|--------|
| \`core/cli/__init__.py\` | \`_get_prompt_session()\`에 False sentinel + \`_read_multiline_input()\` fallback 강화 |

## Verification
- [x] tests/test_startup.py pass
- [x] CI 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)