### PR TITLE
fix: OAuth cache thread-safety + ProfileStore sync after login

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -449,9 +449,6 @@ def _auth_login_status() -> None:
     claude_ok = False
     try:
         from core.gateway.auth.claude_code_oauth import (
-            invalidate_cache as _cc_invalidate,
-        )
-        from core.gateway.auth.claude_code_oauth import (
             read_claude_code_credentials,
         )
 
@@ -471,9 +468,6 @@ def _auth_login_status() -> None:
     # OpenAI
     codex_ok = False
     try:
-        from core.gateway.auth.codex_cli_oauth import (
-            invalidate_cache as _cx_invalidate,
-        )
         from core.gateway.auth.codex_cli_oauth import (
             read_codex_cli_credentials,
         )
@@ -537,13 +531,8 @@ def _auth_login_status() -> None:
             )
             if result.returncode == 0:
                 console.print(f"  [success]{p['name']} login successful![/success]")
-                # Re-read credentials immediately
-                if cli_name == "claude":
-                    _cc_invalidate()
-                    read_claude_code_credentials(force_refresh=True)
-                elif cli_name == "codex":
-                    _cx_invalidate()
-                    read_codex_cli_credentials(force_refresh=True)
+                # Re-read credentials + update ProfileStore
+                _sync_oauth_profile_after_login(cli_name)
             else:
                 console.print(
                     f"  [warning]{p['name']} login failed (exit code {result.returncode})[/warning]"
@@ -554,6 +543,67 @@ def _auth_login_status() -> None:
             console.print(f"  [warning]{p['name']} login error: {exc}[/warning]")
 
     console.print()
+
+
+def _sync_oauth_profile_after_login(cli_name: str) -> None:
+    """Re-read OAuth credentials and update ProfileStore after login."""
+    from core.gateway.auth.profiles import AuthProfile, CredentialType
+
+    store = _get_profile_store()
+
+    if cli_name == "claude":
+        from core.gateway.auth.claude_code_oauth import (
+            invalidate_cache,
+            read_claude_code_credentials,
+        )
+
+        invalidate_cache()
+        creds = read_claude_code_credentials(force_refresh=True)
+        if creds:
+            profile = AuthProfile(
+                name="anthropic:claude-code",
+                provider="anthropic",
+                credential_type=CredentialType.OAUTH,
+                key=creds["access_token"],
+                refresh_token=creds.get("refresh_token", ""),
+                expires_at=creds.get("expires_at", 0.0),
+                managed_by="claude-code",
+                metadata={
+                    **(
+                        {"subscription_type": creds["subscription_type"]}
+                        if "subscription_type" in creds
+                        else {}
+                    ),
+                    **(
+                        {"rate_limit_tier": creds["rate_limit_tier"]}
+                        if "rate_limit_tier" in creds
+                        else {}
+                    ),
+                },
+            )
+            store.add(profile)
+
+    elif cli_name == "codex":
+        from core.gateway.auth.codex_cli_oauth import (
+            invalidate_cache as codex_invalidate,
+        )
+        from core.gateway.auth.codex_cli_oauth import (
+            read_codex_cli_credentials,
+        )
+
+        codex_invalidate()
+        codex_creds = read_codex_cli_credentials(force_refresh=True)
+        if codex_creds:
+            profile = AuthProfile(
+                name="openai:codex-cli",
+                provider="openai",
+                credential_type=CredentialType.OAUTH,
+                key=codex_creds["access_token"],
+                refresh_token=codex_creds.get("refresh_token", ""),
+                expires_at=codex_creds.get("expires_at", 0.0),
+                managed_by="codex-cli",
+            )
+            store.add(profile)
 
 
 def cmd_auth(args: str) -> None:

--- a/core/gateway/auth/claude_code_oauth.py
+++ b/core/gateway/auth/claude_code_oauth.py
@@ -20,6 +20,7 @@ import json
 import logging
 import subprocess  # nosec B404
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any, TypedDict
@@ -43,6 +44,7 @@ class ClaudeCodeCredentials(TypedDict, total=False):
 
 
 # -- Cache (with mtime fingerprint — OpenClaw sourceFingerprint pattern) --
+_cache_lock = threading.Lock()
 _cache: dict[str, Any] = {
     "value": None,
     "read_at": 0.0,
@@ -59,20 +61,21 @@ def _get_file_mtime() -> float:
 
 
 def _is_cache_valid() -> bool:
+    # Called under _cache_lock
     if _cache["value"] is None:
         return False
     if (time.time() - _cache["read_at"]) >= _CACHE_TTL_S:
         return False
-    # Invalidate if file changed externally (e.g. Claude Code refreshed token)
     current_mtime = _get_file_mtime()
     return not (current_mtime > 0 and current_mtime != _cache["mtime"])
 
 
 def invalidate_cache() -> None:
     """Force next read to bypass cache."""
-    _cache["value"] = None
-    _cache["read_at"] = 0.0
-    _cache["mtime"] = 0.0
+    with _cache_lock:
+        _cache["value"] = None
+        _cache["read_at"] = 0.0
+        _cache["mtime"] = 0.0
 
 
 # -- Keychain Reader (macOS only) --
@@ -171,35 +174,30 @@ def read_claude_code_credentials(
     Priority: macOS Keychain → file fallback.
     Returns None if Claude Code is not logged in.
     """
-    if not force_refresh and _is_cache_valid():
-        cached: ClaudeCodeCredentials | None = _cache["value"]
-        return cached
+    with _cache_lock:
+        if not force_refresh and _is_cache_valid():
+            cached: ClaudeCodeCredentials | None = _cache["value"]
+            return cached
 
-    # Try Keychain first (macOS only)
+    # Read outside lock (I/O — Keychain/file)
     raw: dict[str, Any] | None = None
     if sys.platform == "darwin":
         raw = _read_from_keychain()
         if raw:
             log.debug("Claude Code credentials read from Keychain")
 
-    # File fallback
     if raw is None:
         raw = _read_from_file()
         if raw:
             log.debug("Claude Code credentials read from file")
 
     mtime = _get_file_mtime()
+    parsed = _parse_oauth(raw) if raw else None
 
-    if raw is None:
-        _cache["value"] = None
+    with _cache_lock:
+        _cache["value"] = parsed
         _cache["read_at"] = time.time()
         _cache["mtime"] = mtime
-        return None
-
-    parsed = _parse_oauth(raw)
-    _cache["value"] = parsed
-    _cache["read_at"] = time.time()
-    _cache["mtime"] = mtime
 
     if parsed:
         is_expired = time.time() > parsed["expires_at"]

--- a/core/gateway/auth/codex_cli_oauth.py
+++ b/core/gateway/auth/codex_cli_oauth.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 from pathlib import Path
 from typing import Any, TypedDict
@@ -34,6 +35,7 @@ class CodexCliCredentials(TypedDict, total=False):
 
 
 # -- Cache (with mtime fingerprint — OpenClaw sourceFingerprint pattern) --
+_cache_lock = threading.Lock()
 _cache: dict[str, Any] = {"value": None, "read_at": 0.0, "mtime": 0.0}
 
 
@@ -45,6 +47,7 @@ def _get_file_mtime() -> float:
 
 
 def _is_cache_valid() -> bool:
+    # Called under _cache_lock
     if _cache["value"] is None:
         return False
     if (time.time() - _cache["read_at"]) >= _CACHE_TTL_S:
@@ -55,9 +58,10 @@ def _is_cache_valid() -> bool:
 
 def invalidate_cache() -> None:
     """Force next read to bypass cache."""
-    _cache["value"] = None
-    _cache["read_at"] = 0.0
-    _cache["mtime"] = 0.0
+    with _cache_lock:
+        _cache["value"] = None
+        _cache["read_at"] = 0.0
+        _cache["mtime"] = 0.0
 
 
 def _decode_jwt_expiry(token: str) -> float | None:
@@ -145,23 +149,20 @@ def read_codex_cli_credentials(
 
     Returns None if Codex CLI is not logged in.
     """
-    if not force_refresh and _is_cache_valid():
-        cached: CodexCliCredentials | None = _cache["value"]
-        return cached
+    with _cache_lock:
+        if not force_refresh and _is_cache_valid():
+            cached: CodexCliCredentials | None = _cache["value"]
+            return cached
 
+    # Read outside lock (file I/O)
     data = _read_from_file()
     mtime = _get_file_mtime()
+    parsed = _parse_codex_credentials(data) if data else None
 
-    if data is None:
-        _cache["value"] = None
+    with _cache_lock:
+        _cache["value"] = parsed
         _cache["read_at"] = time.time()
         _cache["mtime"] = mtime
-        return None
-
-    parsed = _parse_codex_credentials(data)
-    _cache["value"] = parsed
-    _cache["read_at"] = time.time()
-    _cache["mtime"] = mtime
 
     if parsed:
         is_expired = time.time() > parsed["expires_at"]


### PR DESCRIPTION
## Summary
- OAuth 캐시 dict에 \`threading.Lock\` 보호 추가
- \`/auth login\` 성공 후 ProfileStore 즉시 갱신

## Why
AgenticLoop + Gateway가 다른 스레드에서 \`_cache\` dict 동시 접근 가능 → race condition.
\`/auth login\` 후 토큰 re-read는 하지만 ProfileStore/ProfileRotator에 미반영 → 다음 세션까지 stale.

## Changes
| File | Change |
|------|--------|
| \`core/gateway/auth/claude_code_oauth.py\` | \`_cache_lock = threading.Lock()\` + cache 접근 lock 보호 |
| \`core/gateway/auth/codex_cli_oauth.py\` | 동일 lock 패턴 적용 |
| \`core/cli/commands.py\` | \`_sync_oauth_profile_after_login()\` — 로그인 후 ProfileStore 즉시 갱신 |

## Verification
- [x] 14 + 13 OAuth tests pass
- [x] CI 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)