### PR TITLE
fix: _ConsoleProxy __enter__/__exit__ for Rich context manager

### DIFF
--- a/core/cli/ui/console.py
+++ b/core/cli/ui/console.py
@@ -119,6 +119,15 @@ class _ConsoleProxy:
     def __setattr__(self, name: str, value: Any) -> None:
         setattr(self._current(), name, value)
 
+    # Dunder methods are looked up on the type, not the instance, so
+    # __getattr__ doesn't intercept them. Rich's FileProxy calls
+    # `with console:` which requires explicit __enter__/__exit__.
+    def __enter__(self) -> Console:
+        return self._current().__enter__()
+
+    def __exit__(self, *args: Any) -> None:
+        self._current().__exit__(*args)
+
 
 console: Any = _ConsoleProxy(_default_console)
 


### PR DESCRIPTION
## Summary
- \`_ConsoleProxy\`에 \`__enter__\`/\`__exit__\` 명시적 정의

## Why
Rich의 \`FileProxy.write()\`가 \`with console:\`를 호출하지만, Python의 implicit dunder lookup은
type에서만 수행되어 \`__getattr__\`로 위임 불가 → TypeError: missed __exit__ method.

## Changes
| File | Change |
|------|--------|
| \`core/cli/ui/console.py\` | \`__enter__\`/\`__exit__\` → thread-local Console에 위임 |

## Verification
- [x] tests/test_startup.py pass
- [x] CI 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)