### PR TITLE
fix: GLM context overflow detection — Prompt exceeds max length

### DIFF
--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -83,7 +83,7 @@ def classify_llm_error(exc: Exception) -> tuple[str, str, str]:
         return _ERROR_CLASSIFICATION["server"]
     if isinstance(exc, LLMBadRequestError):
         msg = str(exc).lower()
-        if "token" in msg or "context" in msg:
+        if "token" in msg or "context" in msg or "prompt exceeds" in msg or "max length" in msg:
             return _ERROR_CLASSIFICATION["context_overflow"]
         return _ERROR_CLASSIFICATION["bad_request"]
     return _ERROR_CLASSIFICATION["unknown"]

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -237,7 +237,10 @@ def retry_with_backoff_generic(
                         from core.llm.errors import BillingError
 
                         raise BillingError(billing_message) from exc
-                    if "token" in error_msg.lower() or "context" in error_msg.lower():
+                    if any(
+                        k in error_msg.lower()
+                        for k in ("token", "context", "prompt exceeds", "max length")
+                    ):
                         log.error(
                             "Context overflow detected (model=%s): %s",
                             current_model,


### PR DESCRIPTION
## Summary
- GLM \`"Prompt exceeds max length"\` (code 1261) 에러를 context_overflow로 즉시 분류

## Why
GLM 400 에러가 context_overflow로 미분류 → blind retry 5회 → 턴 끊김.
serve 로그: \`all models exhausted: 'Prompt exceeds max length'\` → \`LLM call failed (unknown)\`.
\`"token"\`/\`"context"\` 패턴만 감지하고 \`"prompt exceeds"\`/\`"max length"\` 미포함.

## Changes
| File | Change |
|------|--------|
| \`core/llm/errors.py\` | classify_llm_error에 \`"prompt exceeds"\`, \`"max length"\` 패턴 추가 |
| \`core/llm/fallback.py\` | retry_with_backoff_generic에 동일 패턴 추가 |

## Verification
- [x] CI 5/5 pass

## Reference
- serve 로그 04:31:22 — \`Error code: 400 {'code': '1261', 'message': 'Prompt exceeds max length'}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)