### PR TITLE
feat: MCP token guard + HTML→MD + offload threshold

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -226,10 +226,10 @@ class Settings(BaseSettings):
     subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
 
     # Token Guard — tool result truncation threshold (0 = unlimited)
-    max_tool_result_tokens: int = 0  # 0 = no limit; clear_tool_uses handles overflow
+    max_tool_result_tokens: int = 25000  # 0 = no limit; clear_tool_uses handles overflow
 
     # Tool Result Offloading — store large results to filesystem (P0 token optimization)
-    tool_offload_threshold: int = 5000  # tokens; 0 = disabled
+    tool_offload_threshold: int = 15000  # tokens; 0 = disabled
     tool_offload_ttl_hours: float = 4.0  # TTL for offloaded results
     observation_mask_keep_rounds: int = 3  # keep recent N rounds unmasked
 

--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -85,21 +85,36 @@ class WebFetchTool:
 
     @staticmethod
     def _html_to_text(html: str) -> str:
-        """Extract text from HTML, stripping tags."""
+        """Convert HTML to Markdown, preserving structure.
+
+        Uses markdownify for structure-preserving conversion (links,
+        headings, code blocks). Falls back to BeautifulSoup text
+        extraction if markdownify unavailable.
+        Claude Code pattern: Turndown HTML→MD before context injection.
+        """
         try:
             from bs4 import BeautifulSoup
 
             soup = BeautifulSoup(html, "html.parser")
-            # Remove script and style elements
             for tag in soup(["script", "style", "nav", "footer", "header"]):
                 tag.decompose()
-            return soup.get_text(separator="\n", strip=True)
+            cleaned = str(soup)
         except ImportError:
-            # Fallback: simple regex strip
-            import re
+            cleaned = html
 
-            text = re.sub(r"<[^>]+>", " ", html)
-            return re.sub(r"\s+", " ", text).strip()
+        try:
+            from markdownify import markdownify as md
+
+            return md(cleaned, heading_style="ATX", strip=["img"])
+        except ImportError:
+            # Fallback: plain text extraction
+            try:
+                return soup.get_text(separator="\n", strip=True)
+            except NameError:
+                import re
+
+                text = re.sub(r"<[^>]+>", " ", html)
+                return re.sub(r"\s+", " ", text).strip()
 
 
 class GeneralWebSearchTool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.84.0",
     "beautifulsoup4>=4.12.0",
+    "markdownify>=0.14.1",
     "httpx>=0.27.0",
     "langgraph>=1.1.0",
     "langgraph-checkpoint>=4.0.1",


### PR DESCRIPTION
## Summary
- MCP tool result 토큰 가드: \`max_tool_result_tokens\` 0→25000
- HTML→MD 변환: \`markdownify\` 도입
- offload threshold 조정: 5000→15000

## Why
GLM 200K context overflow — \`browser_snapshot\`이 90K 토큰 반환 → 전 모델 실패 → 턴 끊김.
Claude Code는 MCP 결과를 25K 토큰으로 제한 (\`mcpValidation.ts:16\`).

## Changes
| File | Change |
|------|--------|
| \`core/config.py\` | max_tool_result_tokens 0→25000, tool_offload_threshold 5000→15000 |
| \`core/tools/web_tools.py\` | _html_to_text → markdownify HTML→MD (구조 보존) |
| \`pyproject.toml\` | markdownify>=0.14.1 의존성 추가 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| T1-1 MCP 토큰 가드 | Implemented | 25000 tokens (Claude Code 동일) |
| T1-3 offload threshold | Implemented | 5000→15000 |
| T2-1 HTML→MD | Implemented | markdownify |
| T2-3 MCP 별도 제한 | Dropped | T1-1과 중복 |
| T4-1 max-columns | Already exists | line 236: [:200] 이미 적용 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] tests pass
- [x] CI 5/5 pass

## Reference
- blog/research/claude-code-search-fetch-pipeline.md
- claude-code/utils/mcpValidation.ts:16 — MAX_MCP_OUTPUT_TOKENS = 25000

🤖 Generated with [Claude Code](https://claude.com/claude-code)