### PR TITLE
fix: web search 401 — Codex OAuth lacks web_search permission

### DIFF
--- a/core/tools/web_tools.py
+++ b/core/tools/web_tools.py
@@ -191,7 +191,7 @@ class GeneralWebSearchTool:
                         ),
                     }
                 ],
-                timeout=30.0,
+                timeout=60.0,
             )
             text_parts: list[str] = []
             source_urls: list[str] = []
@@ -216,16 +216,21 @@ class GeneralWebSearchTool:
             return None
 
     def _openai_search(self, query: str, max_results: int) -> dict[str, Any] | None:
-        """OpenAI native web search via Responses API."""
+        """OpenAI native web search via Responses API.
+
+        Uses settings.openai_api_key directly (not ProfileRotator) because
+        Codex CLI OAuth tokens lack web_search permission → 401.
+        """
         try:
+            import openai
+
             from core.config import OPENAI_PRIMARY, settings
-            from core.llm.providers.openai import _get_openai_client
 
             if not settings.openai_api_key:
                 return None
 
             today = date.today()
-            client = _get_openai_client()
+            client = openai.OpenAI(api_key=settings.openai_api_key)
             response = client.responses.create(
                 model=OPENAI_PRIMARY,
                 tools=[{"type": "web_search"}],
@@ -283,7 +288,7 @@ class GeneralWebSearchTool:
                         ),
                     }
                 ],
-                timeout=30.0,
+                timeout=60.0,
             )
             choice = response.choices[0] if response.choices else None
             if choice and choice.message.content:


### PR DESCRIPTION
## Summary
- `_openai_search`가 Codex CLI OAuth 토큰(ChatGPT 구독)으로 Responses API web_search 호출 → 401 Unauthorized
- Anthropic/GLM web search timeout 30→60s

## Why
Codex CLI OAuth 토큰은 ChatGPT 구독용이며 Responses API `web_search` native tool 권한 없음.
ProfileRotator가 OAUTH(priority 0) > API_KEY(priority 2)로 Codex 토큰을 선택하여 401 발생.
serve 로그: `POST https://api.openai.com/v1/responses "HTTP/1.1 401 Unauthorized"` x4

## Changes
| File | Change |
|------|--------|
| `core/tools/web_tools.py` | `_openai_search`: `_get_openai_client()` → `openai.OpenAI(api_key=settings.openai_api_key)` (ProfileRotator 우회) |
| `core/tools/web_tools.py` | Anthropic + GLM web search timeout 30→60s |

## Verification
- [x] ruff check clean
- [x] 직접 테스트: `openai.OpenAI(api_key=settings.openai_api_key).responses.create(web_search)` → OK

## Reference
- serve 로그 05:41:25 — 4건 401 Unauthorized
- `_resolve_openai_key()` → Codex OAuth (eyJ...) vs `settings.openai_api_key` → API key (sk-proj-...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)