### PR TITLE
fix: vault write path — output tools auto-save to .geode/vault/

### DIFF
--- a/core/tools/output_tools.py
+++ b/core/tools/output_tools.py
@@ -4,14 +4,38 @@ Layer 5 tools for output generation:
 - GenerateReportTool: Generate analysis report (stub for ReportGenerator)
 - ExportJsonTool: Export analysis result as JSON file
 - SendNotificationTool: Stub notification sender
+
+All artifact-producing tools auto-save to Vault (.geode/vault/).
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def _save_to_vault(
+    filename: str,
+    content: str,
+    *,
+    category: str | None = None,
+) -> None:
+    """Best-effort save artifact to vault. Never raises."""
+    try:
+        from core.memory.vault import Vault
+
+        vault = Vault()
+        vault.ensure_structure()
+        path = vault.save(filename, content, category=category)
+        if path:
+            log.info("Vault: saved %s", path)
+    except Exception:
+        log.debug("Vault save failed (best-effort)", exc_info=True)
 
 
 class GenerateReportTool:
@@ -78,6 +102,13 @@ class GenerateReportTool:
             },
         }
 
+        # Auto-save to vault
+        _save_to_vault(
+            f"analysis-{ip_name.lower().replace(' ', '-')}.json",
+            json.dumps(report, indent=2, ensure_ascii=False, default=str),
+            category="research",
+        )
+
         return {"result": report}
 
 
@@ -128,10 +159,12 @@ class ExportJsonTool:
 
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(
-                json.dumps(data, indent=2, ensure_ascii=False, default=str),
-                encoding="utf-8",
-            )
+            content_str = json.dumps(data, indent=2, ensure_ascii=False, default=str)
+            output_path.write_text(content_str, encoding="utf-8")
+
+            # Auto-save to vault
+            _save_to_vault(filename, content_str)
+
             return {
                 "result": {
                     "exported": True,


### PR DESCRIPTION
## Summary
- \`generate_report\`: 분석 리포트 → \`vault/research/\` 자동 저장
- \`export_json\`: JSON 파일 → vault 자동 분류 저장
- \`_save_to_vault()\`: best-effort 헬퍼 (실패 시 tool 동작 무영향)

## Why
Vault 읽기 경로(ContextAssembler → LLM context 주입)는 구현되어 있지만,
쓰기 경로(tool → \`vault.save()\`)가 없어서 vault이 항상 비어있는 구조적 결함.
\`vault.save()\`를 호출하는 코드가 docstring 예시 외에 전무.

## Changes
| File | Change |
|------|--------|
| \`core/tools/output_tools.py\` | \`_save_to_vault()\` 헬퍼 + \`generate_report\`/\`export_json\`에서 호출 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)