### PR TITLE
fix: G3 learning — UserProfile as single source (LEARNING.md deprecated)

### DIFF
--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -321,62 +321,24 @@ def _build_geode_memory_context() -> str:
 
 
 def _build_learning_context() -> str:
-    """G3: Load .geode/LEARNING.md agent learning records.
+    """G3: Load learned patterns from UserProfile.
 
-    Extracts only Patterns, Corrections, and Domain Knowledge sections
-    that have actual content (not just placeholder text).
+    Sources: ~/.geode/user_profile/learned.md (auto_learn hook output).
+    LEARNING.md is deprecated — UserProfile is the single source of truth.
     Capped at ``_MAX_SECTION_LINES`` lines.
     """
     try:
-        learning_path = _PROJECT_ROOT / ".geode" / "LEARNING.md"
-        if not learning_path.exists():
+        from core.tools.profile_tools import get_user_profile
+
+        profile = get_user_profile()
+        if profile is None:
             return ""
 
-        content = learning_path.read_text(encoding="utf-8")
-
-        # Extract sections with real content (not placeholders)
-        target_sections = {"## Patterns", "## Corrections", "## Domain Knowledge"}
-        extracted_lines: list[str] = []
-        current_in_target = False
-
-        for line in content.split("\n"):
-            stripped = line.strip()
-
-            if stripped.startswith("## "):
-                current_in_target = stripped in target_sections
-                if current_in_target:
-                    extracted_lines.append(stripped)
-                continue
-
-            if current_in_target and stripped:
-                # Skip placeholder lines
-                if stripped.startswith("(") and stripped.endswith(")"):
-                    continue
-                extracted_lines.append(stripped)
-
-        # Remove section headers that ended up with no content
-        cleaned: list[str] = []
-        i = 0
-        while i < len(extracted_lines):
-            line = extracted_lines[i]
-            if line.startswith("## "):
-                # Check if next non-header line exists
-                has_body = False
-                for j in range(i + 1, len(extracted_lines)):
-                    if extracted_lines[j].startswith("## "):
-                        break
-                    has_body = True
-                    break
-                if has_body:
-                    cleaned.append(line)
-            else:
-                cleaned.append(line)
-            i += 1
-
-        if not cleaned:
+        patterns = profile.get_learned_patterns()
+        if not patterns:
             return ""
 
-        capped = cleaned[:_MAX_SECTION_LINES]
+        capped = patterns[:_MAX_SECTION_LINES]
         return "## Agent Learning\n" + "\n".join(capped)
     except Exception:
         log.debug("Failed to build learning context (G3)", exc_info=True)


### PR DESCRIPTION
## Summary
- G3 system_prompt 슬롯: LEARNING.md → UserProfile learned_patterns로 변경
- LEARNING.md는 항상 비어있던 dead file → 폐기

## Why
auto_learn hook이 UserProfile.learned.md에 저장하는데, _build_learning_context()는
.geode/LEARNING.md를 읽어서 항상 빈 값 반환. 읽기/쓰기 경로 불일치.

## Changes
| File | Change |
|------|--------|
| \`core/agent/system_prompt.py\` | \`_build_learning_context()\`: LEARNING.md 파싱 → \`profile.get_learned_patterns()\` |

## Verification
- [x] ruff check clean
- [x] tests pass
- [x] ~/.geode/user_profile/learned.md에 3건 패턴 확인

## Reference
- Claude Code memoryTypes.ts — 양방향 학습 (correction + validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)