### PR TITLE
feat: auto-learn v2 — bidirectional learning + LLM extraction

### DIFF
--- a/core/hooks/auto_learn.py
+++ b/core/hooks/auto_learn.py
@@ -119,8 +119,8 @@ def _detect_correction(user_input: str) -> tuple[str, str] | None:
 
 _INPUT_DETECTORS: list[Callable[[str], tuple[str, str] | None]] = [
     _detect_language_pref,  # highest priority — short inputs like "한국어로 답변해줘"
-    _detect_correction,     # bidirectional: corrections first (stronger signal)
-    _detect_validation,     # bidirectional: then validations (quieter signal)
+    _detect_correction,  # bidirectional: corrections first (stronger signal)
+    _detect_validation,  # bidirectional: then validations (quieter signal)
     _detect_self_intro,
     _detect_explicit_pref,
     _detect_domain_interest,
@@ -208,9 +208,7 @@ def make_auto_learn_handler() -> tuple[str, Callable[..., None]]:
                 break
             # Append context so future recall includes "why"
             if assistant_text and category in ("validation", "correction"):
-                pattern_with_why = (
-                    f"{pattern_text} [context: {assistant_text[:100]}]"
-                )
+                pattern_with_why = f"{pattern_text} [context: {assistant_text[:100]}]"
             else:
                 pattern_with_why = pattern_text
             try:

--- a/core/hooks/auto_learn.py
+++ b/core/hooks/auto_learn.py
@@ -64,6 +64,21 @@ _RE_DOMAIN_INTEREST = re.compile(
     r"|focused\s+on|specializ\w+\s+in|관심\s*분야|연구\s*중)",
 )
 
+# Validation detector: user confirms a non-obvious approach
+# Claude Code pattern: "confirmations are quieter — watch for them"
+_RE_VALIDATION = re.compile(
+    r"(?i)\b(exactly|perfect|that'?s? (?:right|correct|it)|keep doing"
+    r"|good (?:call|approach|choice)|nice|잘했|맞아|좋아|그대로|딱 맞|괜찮)"
+    r"(?!.*\b(but|however|except|다만|근데)\b)",
+)
+
+# Correction detector: user corrects approach
+_RE_CORRECTION = re.compile(
+    r"(?i)\b(don'?t|stop doing|not like that|wrong|하지\s*마"
+    r"|그렇게\s*말고|아니야|잘못|틀렸)"
+    r"(?!.*\bjust\s+kidding\b)",
+)
+
 
 def _detect_self_intro(user_input: str) -> tuple[str, str] | None:
     if _RE_SELF_INTRO.search(user_input):
@@ -90,8 +105,22 @@ def _detect_domain_interest(user_input: str) -> tuple[str, str] | None:
     return None
 
 
+def _detect_validation(user_input: str) -> tuple[str, str] | None:
+    if _RE_VALIDATION.search(user_input):
+        return (f"Validated: {user_input[:120]}", "validation")
+    return None
+
+
+def _detect_correction(user_input: str) -> tuple[str, str] | None:
+    if _RE_CORRECTION.search(user_input):
+        return (f"Corrected: {user_input[:120]}", "correction")
+    return None
+
+
 _INPUT_DETECTORS: list[Callable[[str], tuple[str, str] | None]] = [
     _detect_language_pref,  # highest priority — short inputs like "한국어로 답변해줘"
+    _detect_correction,     # bidirectional: corrections first (stronger signal)
+    _detect_validation,     # bidirectional: then validations (quieter signal)
     _detect_self_intro,
     _detect_explicit_pref,
     _detect_domain_interest,
@@ -171,11 +200,21 @@ def make_auto_learn_handler() -> tuple[str, Callable[..., None]]:
         if now - last_learn_ts < _COOLDOWN_S:
             return
 
+        # P2: Include conversation context for "Why" reasoning
+        assistant_text: str = data.get("text", "")[:200]
+
         for pattern_text, category in patterns:
             if session_count >= _MAX_PER_SESSION:
                 break
+            # Append context so future recall includes "why"
+            if assistant_text and category in ("validation", "correction"):
+                pattern_with_why = (
+                    f"{pattern_text} [context: {assistant_text[:100]}]"
+                )
+            else:
+                pattern_with_why = pattern_text
             try:
-                saved = profile.add_learned_pattern(pattern_text, category)
+                saved = profile.add_learned_pattern(pattern_with_why, category)
                 if saved:
                     session_count += 1
                     last_learn_ts = now

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -1,0 +1,196 @@
+"""LLM-based learning extraction — Claude Code extractMemories pattern.
+
+Runs on TURN_COMPLETE (low priority, after auto_learn regex detectors).
+Sends recent conversation context to a budget model (Haiku/GLM-flash)
+to extract learning items that regex detectors would miss.
+
+Fires at most once per 5 turns to control cost.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from core.hooks.system import HookEvent
+
+log = logging.getLogger(__name__)
+
+_TURN_INTERVAL = 5  # extract every N turns
+_MAX_CONTEXT_CHARS = 3000  # recent conversation to send to LLM
+_MAX_PER_SESSION = 5  # LLM extractions per session
+
+_EXTRACT_PROMPT = """\
+You are a learning extraction agent. Analyze the recent conversation
+and identify what should be remembered for future sessions.
+
+Extract ONLY items that are:
+- User corrections ("don't do X", "that's wrong")
+- User validations ("yes exactly", "good approach", accepting without pushback)
+- Stated preferences (tools, style, workflow)
+- Domain knowledge learned during this exchange
+
+For each item, output ONE LINE in this format:
+[category] pattern text. Why: reason
+
+Categories: correction, validation, preference, domain
+
+Rules:
+- Max 3 items per extraction
+- Skip obvious/trivial items
+- Include "Why:" with specific context
+- If nothing noteworthy, output: NONE
+
+Recent conversation:
+---
+{context}
+---
+
+Extract learning items:"""
+
+
+def _build_context(data: dict[str, Any]) -> str:
+    """Build recent conversation context from turn data."""
+    parts: list[str] = []
+    user_input = data.get("user_input", "")
+    assistant_text = data.get("text", "")
+    tool_calls = data.get("tool_calls", [])
+
+    if user_input:
+        parts.append(f"User: {user_input[:500]}")
+    if tool_calls:
+        parts.append(f"Tools used: {', '.join(tool_calls[:5])}")
+    if assistant_text:
+        parts.append(f"Assistant: {assistant_text[:1500]}")
+
+    return "\n".join(parts)[:_MAX_CONTEXT_CHARS]
+
+
+def _call_budget_llm(prompt: str) -> str | None:
+    """Call a budget model for extraction. Returns text or None on failure."""
+    try:
+        from core.config import settings
+
+        # Try GLM-flash first (free), then Haiku
+        if settings.zai_api_key:
+            return _call_glm_flash(prompt, settings.zai_api_key)
+        if settings.anthropic_api_key:
+            return _call_haiku(prompt, settings.anthropic_api_key)
+        return None
+    except Exception:
+        log.debug("LLM extract call failed", exc_info=True)
+        return None
+
+
+def _call_glm_flash(prompt: str, api_key: str) -> str | None:
+    """Call GLM-4.7-flash (free tier)."""
+    import openai
+
+    client = openai.OpenAI(
+        api_key=api_key,
+        base_url="https://open.bigmodel.cn/api/paas/v4/",
+    )
+    resp = client.chat.completions.create(
+        model="glm-4.7-flash",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=300,
+        temperature=0.0,
+        timeout=10.0,
+    )
+    return resp.choices[0].message.content if resp.choices else None
+
+
+def _call_haiku(prompt: str, api_key: str) -> str | None:
+    """Call Claude Haiku (budget tier)."""
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+    resp = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=300,
+        messages=[{"role": "user", "content": prompt}],
+        timeout=10.0,
+    )
+    return resp.content[0].text if resp.content else None
+
+
+def _parse_extractions(text: str) -> list[tuple[str, str]]:
+    """Parse LLM output into (pattern_text, category) pairs."""
+    if not text or "NONE" in text.upper():
+        return []
+
+    results: list[tuple[str, str]] = []
+    valid_categories = {"correction", "validation", "preference", "domain"}
+
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Parse: [category] pattern text. Why: reason
+        if line.startswith("["):
+            bracket_end = line.find("]")
+            if bracket_end > 0:
+                category = line[1:bracket_end].strip().lower()
+                pattern = line[bracket_end + 1 :].strip()
+                if category in valid_categories and len(pattern) > 10:
+                    results.append((pattern, category))
+
+    return results[:3]  # max 3 per extraction
+
+
+def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
+    """Create TURN_COMPLETE handler for LLM-based learning extraction."""
+    turn_count = 0
+    session_extractions = 0
+    last_extract_ts = 0.0
+
+    def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
+        nonlocal turn_count, session_extractions, last_extract_ts
+
+        turn_count += 1
+
+        # Fire every N turns
+        if turn_count % _TURN_INTERVAL != 0:
+            return
+
+        if session_extractions >= _MAX_PER_SESSION:
+            return
+
+        # 60s cooldown
+        now = time.monotonic()
+        if now - last_extract_ts < 60.0:
+            return
+
+        from core.tools.profile_tools import get_user_profile
+
+        profile = get_user_profile()
+        if profile is None:
+            return
+
+        context = _build_context(data)
+        if len(context) < 50:
+            return
+
+        prompt = _EXTRACT_PROMPT.format(context=context)
+        llm_output = _call_budget_llm(prompt)
+        if not llm_output:
+            return
+
+        extractions = _parse_extractions(llm_output)
+        for pattern_text, category in extractions:
+            try:
+                saved = profile.add_learned_pattern(pattern_text, category)
+                if saved:
+                    session_extractions += 1
+                    last_extract_ts = now
+                    log.info(
+                        "LLM extract: [%s] %s",
+                        category,
+                        pattern_text[:80],
+                    )
+            except Exception:
+                log.debug("LLM extract save failed", exc_info=True)
+
+    return ("turn_llm_extract", _on_turn_complete)

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -113,7 +113,8 @@ def _call_haiku(prompt: str, api_key: str) -> str | None:
         messages=[{"role": "user", "content": prompt}],
         timeout=10.0,
     )
-    return resp.content[0].text if resp.content else None
+    block = resp.content[0] if resp.content else None
+    return block.text if block and hasattr(block, "text") else None
 
 
 def _parse_extractions(text: str) -> list[tuple[str, str]]:

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -231,6 +231,20 @@ def build_hooks(
 
     _register_plugin("turn_auto_learn", _reg_auto_learn)
 
+    # C3c: LLM-based learning extraction (Claude Code extractMemories pattern)
+    def _reg_llm_extract() -> None:
+        from core.hooks.llm_extract_learning import make_llm_extract_handler
+
+        name, handler = make_llm_extract_handler()
+        hooks.register(
+            HookEvent.TURN_COMPLETE,
+            handler,
+            name=name,
+            priority=82,  # lower priority than auto_learn (84)
+        )
+
+    _register_plugin("turn_llm_extract", _reg_llm_extract)
+
     # C4: Session lifecycle hooks (OpenClaw agent:bootstrap pattern)
     def _reg_session_lifecycle() -> None:
         def _on_session_start(event: HookEvent, data: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- **P1**: 검증(validation) + 교정(correction) 양방향 감지 detector
- **P2**: Why context — validation/correction에 assistant 발화 context 추가
- **P3**: LLM subagent 추출 — 5턴마다 budget LLM이 대화 분석

## Why
GEODE auto_learn이 교정만 기록(단방향) → 과도 보수적 drift.
Claude Code: "Record from failure AND success" — 검증도 기록해야 판단 범위 유지.
또한 regex 기반 감지는 맥락적 패턴을 놓침 → LLM 기반 추출 필요.

## Changes
| File | Change |
|------|--------|
| \`core/hooks/auto_learn.py\` | \`_detect_validation\` + \`_detect_correction\` detector, \`[context:]\` Why 추가 |
| \`core/hooks/llm_extract_learning.py\` | NEW — budget LLM (GLM-flash/Haiku) 기반 학습 추출 |
| \`core/runtime_wiring/bootstrap.py\` | \`_reg_llm_extract\` hook 등록 (TURN_COMPLETE, priority 82) |

## Wiring Verification
| Check | Status |
|-------|--------|
| Read path: system_prompt G3 → profile.get_learned_patterns() | OK (PR #681) |
| Write path (regex): auto_learn → add_learned_pattern() | OK |
| Write path (LLM): llm_extract_learning → add_learned_pattern() | OK |
| Hook registration: bootstrap.py _reg_llm_extract | OK |
| ContextVar: get_user_profile() set in bootstrap | OK |

## Verification
- [x] ruff check clean
- [x] 98 tests pass (auto_learn + startup + hooks)
- [x] No dead code / stub

## Reference
- claude-code/memdir/memoryTypes.ts:60-72 — bidirectional feedback
- claude-code/services/extractMemories/ — LLM subagent extraction pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)