### PR TITLE
infra: CI runner self-hosted → ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ concurrency:
 jobs:
   lint:
     name: Lint & Format
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
       - run: uv sync
       - run: uv run ruff check core/ tests/
       - run: uv run ruff format --check core/ tests/
@@ -26,9 +27,10 @@ jobs:
 
   typecheck:
     name: Type Check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
       - run: uv sync
       - run: uv run mypy core/
       - name: Prompt integrity check
@@ -36,9 +38,10 @@ jobs:
 
   test:
     name: Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
       - run: uv sync
       - name: Run tests with coverage
         run: uv run pytest --cov=core --cov-report=term-missing
@@ -53,15 +56,16 @@ jobs:
 
   security:
     name: Security Scan
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
       - run: uv sync
       - run: uv run bandit -r core/ -c pyproject.toml
 
   gate:
     name: Gate
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [lint, typecheck, test, security]
     steps:
       - run: echo "All checks passed"


### PR DESCRIPTION
## Summary
- `runs-on: self-hosted` → `runs-on: ubuntu-latest` (전 job)
- `astral-sh/setup-uv@v5` step 추가 (hosted runner에 uv 미설치)

## Why
Self-hosted runner 3대 전부 offline (등록 만료).
GitHub hosted runner로 전환하여 CI 즉시 복구.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 5 jobs: `self-hosted` → `ubuntu-latest` + `setup-uv@v5` |

## Verification
- [ ] CI 실행 확인 (이 PR 자체가 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)