### PR TITLE
fix: sandbox project root — CWD 기반 get_project_root() 전환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Sandbox project root CWD 기반으로 전환** — `_PROJECT_ROOT = Path(__file__).parent³` 하드코딩 → `get_project_root()` (CWD 캡처). 외부 워크스페이스에서 `geode` 실행 시 파일 도구가 "path outside project directory" 오류 발생하던 버그 수정. Claude Code `originalCwd` 패턴 이식
+
 ## [0.46.0] — 2026-04-06
 
 ### Added

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -17,15 +17,12 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from pathlib import Path
 
 from core.cli.ip_names import get_ip_name_map
 from core.llm.prompts import ROUTER_SYSTEM
+from core.paths import get_project_root
 
 log = logging.getLogger(__name__)
-
-# Project root resolved from __file__ (CWD-independent)
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Max lines per memory hierarchy section to control context budget
 _MAX_SECTION_LINES = 20
@@ -293,7 +290,7 @@ def _build_geode_memory_context() -> str:
     placeholder sections). Capped at ``_MAX_SECTION_LINES`` lines.
     """
     try:
-        memory_path = _PROJECT_ROOT / ".geode" / "MEMORY.md"
+        memory_path = get_project_root() / ".geode" / "MEMORY.md"
         if not memory_path.exists():
             return ""
 

--- a/core/cli/report_renderer.py
+++ b/core/cli/report_renderer.py
@@ -16,6 +16,7 @@ from typing import Any
 from core.cli.ui.console import console
 from core.cli.ui.status import GeodeStatus
 from core.config import settings
+from core.paths import get_project_root
 from core.skills.reports import ReportFormat, ReportGenerator, ReportTemplate
 
 log = logging.getLogger(__name__)
@@ -26,9 +27,6 @@ log = logging.getLogger(__name__)
 
 _FORMAT_KEYWORDS = {"html", "json", "md", "markdown"}
 _TEMPLATE_KEYWORDS = {"summary", "detailed", "executive"}
-
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-_REPORT_DIR = _PROJECT_ROOT / ".geode" / "reports"
 
 # Skills relevant for report quality enhancement
 _REPORT_SKILL_NAMES = ["geode-scoring", "geode-analysis", "geode-verification"]
@@ -243,8 +241,9 @@ def _generate_report(
     if output:
         save_path = Path(output)
     else:
-        _REPORT_DIR.mkdir(parents=True, exist_ok=True)
-        save_path = _REPORT_DIR / f"{safe_name}-{template}.{ext}"
+        report_dir = get_project_root() / ".geode" / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        save_path = report_dir / f"{safe_name}-{template}.{ext}"
 
     save_path.parent.mkdir(parents=True, exist_ok=True)
     save_path.write_text(content, encoding="utf-8")

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -26,12 +26,10 @@ from typing import Any
 from dotenv import dotenv_values
 
 from core.mcp.stdio_client import StdioMCPClient
+from core.paths import get_project_root
 
 log = logging.getLogger(__name__)
 
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-_CONFIG_PATH = _PROJECT_ROOT / ".claude" / "mcp_servers.json"
-_DOTENV_PATH = _PROJECT_ROOT / ".env"
 _GLOBAL_DOTENV_PATH = Path.home() / ".geode" / ".env"
 
 _EMPTY_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
@@ -115,7 +113,7 @@ class MCPServerManager:
     """
 
     def __init__(self, config_path: Path | None = None) -> None:
-        self._config_path = config_path or _CONFIG_PATH
+        self._config_path = config_path or (get_project_root() / ".claude" / "mcp_servers.json")
         self._servers: dict[str, dict[str, Any]] = {}
         self._clients: dict[str, StdioMCPClient] = {}
         self._dotenv_cache: dict[str, str | None] = {}
@@ -299,7 +297,7 @@ class MCPServerManager:
         # Layer 1 & 2: Global then project config.toml [mcp.servers]
         config_toml_paths = [
             GLOBAL_CONFIG_TOML,
-            _PROJECT_ROOT / ".geode" / "config.toml",
+            get_project_root() / ".geode" / "config.toml",
         ]
         for config_toml in config_toml_paths:
             if not config_toml.exists():
@@ -365,8 +363,9 @@ class MCPServerManager:
         if not self._dotenv_cache:
             if _GLOBAL_DOTENV_PATH.exists():
                 self._dotenv_cache.update(dotenv_values(str(_GLOBAL_DOTENV_PATH)))
-            if _DOTENV_PATH.exists():
-                for k, v in dotenv_values(str(_DOTENV_PATH)).items():
+            project_dotenv = get_project_root() / ".env"
+            if project_dotenv.exists():
+                for k, v in dotenv_values(str(project_dotenv)).items():
                     if v:  # skip empty/None — must not clobber global keys
                         self._dotenv_cache[k] = v
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -60,6 +60,23 @@ PROJECT_MEMORY_INDEX = PROJECT_GEODE_DIR / "MEMORY.md"
 
 
 # ---------------------------------------------------------------------------
+# Project root — CWD at startup (Claude Code's originalCwd pattern)
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_project_root() -> Path:
+    """Return the resolved CWD captured at first call.
+
+    Follows Claude Code's ``originalCwd`` pattern: the sandbox boundary is
+    the directory where the CLI was invoked, **not** the package installation
+    path.  ``lru_cache`` ensures the value is frozen after the first call,
+    which happens during CLI startup.
+    """
+    return Path.cwd().resolve()
+
+
+# ---------------------------------------------------------------------------
 # Project ID — Claude Code-style path encoding
 # ---------------------------------------------------------------------------
 

--- a/core/tools/document_tools.py
+++ b/core/tools/document_tools.py
@@ -10,10 +10,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
-log = logging.getLogger(__name__)
+from core.paths import get_project_root
 
-# Security: restrict file access to project directory
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+log = logging.getLogger(__name__)
 
 
 class ReadDocumentTool:
@@ -48,10 +47,10 @@ class ReadDocumentTool:
 
         # Security: ensure path is within project directory
         try:
-            file_path.relative_to(_PROJECT_ROOT)
+            file_path.relative_to(get_project_root())
         except ValueError:
             return tool_error(
-                f"Access denied: path outside project directory ({_PROJECT_ROOT})",
+                f"Access denied: path outside project directory ({get_project_root()})",
                 error_type="permission",
                 recoverable=False,
                 hint=(

--- a/core/tools/file_tools.py
+++ b/core/tools/file_tools.py
@@ -15,9 +15,9 @@ import re
 from pathlib import Path
 from typing import Any
 
-log = logging.getLogger(__name__)
+from core.paths import get_project_root
 
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+log = logging.getLogger(__name__)
 
 
 def _check_sandbox(path: Path) -> dict[str, Any] | None:
@@ -37,10 +37,10 @@ def _check_sandbox(path: Path) -> dict[str, Any] | None:
         )
     resolved = path.resolve()
     try:
-        resolved.relative_to(_PROJECT_ROOT)
+        resolved.relative_to(get_project_root())
     except ValueError:
         return tool_error(
-            f"Access denied: path outside project directory ({_PROJECT_ROOT})",
+            f"Access denied: path outside project directory ({get_project_root()})",
             error_type="permission",
             recoverable=False,
             hint=(
@@ -93,7 +93,7 @@ class GlobTool:
         search_dir = Path(kwargs.get("path", "."))
 
         if not search_dir.is_absolute():
-            search_dir = _PROJECT_ROOT / search_dir
+            search_dir = get_project_root() / search_dir
 
         err = _check_sandbox(search_dir)
         if err:
@@ -110,7 +110,7 @@ class GlobTool:
         for path in search_dir.rglob(pattern) if "**" in pattern else search_dir.glob(pattern):
             if path.is_file() and not path.is_symlink():
                 try:
-                    rel = path.relative_to(_PROJECT_ROOT)
+                    rel = path.relative_to(get_project_root())
                     mtime = path.stat().st_mtime
                     matches.append((mtime, str(rel)))
                 except (ValueError, OSError):
@@ -185,7 +185,7 @@ class GrepTool:
         max_results: int = min(kwargs.get("max_results", 50), 100)
 
         if not search_path.is_absolute():
-            search_path = _PROJECT_ROOT / search_path
+            search_path = get_project_root() / search_path
 
         err = _check_sandbox(search_path)
         if err:
@@ -239,7 +239,7 @@ class GrepTool:
 
             if matches_in_file:
                 try:
-                    rel = str(fpath.relative_to(_PROJECT_ROOT))
+                    rel = str(fpath.relative_to(get_project_root()))
                 except ValueError:
                     continue
                 entry: dict[str, Any] = {"file": rel, "match_count": len(matches_in_file)}
@@ -308,7 +308,7 @@ class EditFileTool:
         replace_all: bool = kwargs.get("replace_all", False)
 
         if not file_path.is_absolute():
-            file_path = _PROJECT_ROOT / file_path
+            file_path = get_project_root() / file_path
 
         err = _check_sandbox(file_path)
         if err:
@@ -405,7 +405,7 @@ class WriteFileTool:
         content: str = kwargs["content"]
 
         if not file_path.is_absolute():
-            file_path = _PROJECT_ROOT / file_path
+            file_path = get_project_root() / file_path
 
         err = _check_sandbox(file_path)
         if err:

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from core.tools import file_tools
 from core.tools.file_tools import EditFileTool, GlobTool, GrepTool, WriteFileTool
 
 
 @pytest.fixture(autouse=True)
 def _sandbox_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Redirect sandbox root to tmp_path for all tests."""
-    monkeypatch.setattr(file_tools, "_PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("core.tools.file_tools.get_project_root", lambda: tmp_path)
 
 
 class TestGlobTool:


### PR DESCRIPTION
## Summary
- `_PROJECT_ROOT` 하드코딩(패키지 설치 경로)을 `get_project_root()` (CWD 캡처)로 전환
- 외부 워크스페이스에서 `geode` 실행 시 파일 도구 "path outside project directory" 오류 수정

## Why
`_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent`가 editable install 패키지 경로(`/workspace/geode`)를 가리켜,
`/workspace/blog`에서 `geode`를 실행해도 샌드박스가 geode 디렉토리로 고정됨.
Claude Code는 `originalCwd` 패턴으로 CLI 실행 시점의 CWD를 샌드박스 경계로 사용.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `get_project_root()` 추가 — `lru_cache`, `Path.cwd().resolve()` 캡처 |
| `core/tools/file_tools.py` | `_PROJECT_ROOT` → `get_project_root()` (glob/grep/edit/write) |
| `core/tools/document_tools.py` | `_PROJECT_ROOT` → `get_project_root()` (read_document) |
| `core/agent/system_prompt.py` | `_PROJECT_ROOT` → `get_project_root()` (MEMORY.md 로드) |
| `core/cli/report_renderer.py` | `_PROJECT_ROOT` → `get_project_root()` (리포트 저장) |
| `core/mcp/manager.py` | `_PROJECT_ROOT` → `get_project_root()` (config/dotenv 로드) |
| `tests/test_file_tools.py` | monkeypatch 대상 업데이트 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 3701 passed

## Reference
Claude Code `originalCwd` 패턴: `bootstrap/state.ts` → `setOriginalCwd(getCwd())` at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)