### PR TITLE
refactor: structural defect resolution — 6 phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Architecture
+- **AgenticLoop SRP decomposition** — context window management extracted to `context_manager.py` (410 lines), convergence detection to `convergence.py` (114 lines). agentic_loop.py 1818 → 1405 lines (-23%)
+- **CLI __init__.py module extraction** — memory_handler, scheduler_drain, terminal extracted to dedicated modules. cli/__init__.py 1892 → 1641 lines (-13%)
+- **Runtime.create() staged builders** — monolithic 122-line factory split into 4 staged private methods (_build_core, _build_tools, _build_memory_and_automation)
+- **Hook layer violation fix** — auto_learn.py L6→L5 dependency eliminated via profile_provider DI injection at bootstrap
+
+### Fixed
+- **FALLBACK_CROSS_PROVIDER hook never emitted** — cross-provider model escalation now fires the dedicated observability hook with provider-level context
+- **signal_adapter ContextVar encapsulation** — added `get_signal_adapter()` public getter, replaced private `_signal_adapter_ctx.get()` access
+
 ## [0.47.0] — 2026-04-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A general-purpose autonomous execution agent built on LangGraph. Autonomously pe
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 204
+- **Modules**: 205
 - **Tests**: 3737+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A general-purpose autonomous execution agent built on LangGraph. Autonomously pe
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 195
+- **Modules**: 204
 - **Tests**: 3737+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
@@ -65,7 +65,7 @@ uv run mypy core/
 
 ### Expected Test Results
 
-3525+ tests pass. 3 IP fixtures produce tier spread:
+3700+ tests pass. 3 IP fixtures produce tier spread:
 - Berserk: **S** (81.2) — conversion_failure
 - Cowboy Bebop: **A** (68.4) — undermarketed
 - Ghost in the Shell: **B** (51.7) — discovery_failure
@@ -187,7 +187,7 @@ Code changes → repeat 3 quality gates. Fix on failure.
 ```bash
 uv run ruff check core/ tests/      # Lint: 0 errors
 uv run mypy core/                    # Type: 0 errors
-uv run pytest tests/ -m "not live"   # Test: 3525+ pass
+uv run pytest tests/ -m "not live"   # Test: 3700+ pass
 ```
 
 #### 4. Verify (Implementation GAP Audit)
@@ -208,7 +208,7 @@ uv run pytest tests/ -m "not live"   # Test: 3525+ pass
 ```bash
 uv run ruff check core/ tests/                      # Lint: 0 errors
 uv run mypy core/                                    # Type: 0 errors
-uv run pytest tests/ -m "not live"                   # Test: 3525+ pass
+uv run pytest tests/ -m "not live"                   # Test: 3700+ pass
 uv run geode analyze "Cowboy Bebop" --dry-run        # E2E: A (68.4) unchanged
 ```
 
@@ -305,7 +305,7 @@ Update `docs/progress.md` only from main. Backlog → In Progress → Done.
 |------|---------|----------|
 | Lint | `uv run ruff check core/ tests/` | 0 errors |
 | Type | `uv run mypy core/` | 0 errors |
-| Test | `uv run pytest tests/ -m "not live"` | 3525+ pass |
+| Test | `uv run pytest tests/ -m "not live"` | 3700+ pass |
 | E2E | `uv run geode analyze "Cowboy Bebop" --dry-run` | A (68.4) |
 
 ## Custom Skills (Scaffold)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ There are two control layers.
 
 ```
 geode/
-├── core/                          # 204 modules, 4-Layer Stack
+├── core/                          # 205 modules, 4-Layer Stack
 │   ├── agent/                     # Agent: AgenticLoop, ToolCallProcessor, SubAgentManager
 │   ├── cli/                       # Agent: Commands, UI
 │   ├── llm/                       # Model: Claude/OpenAI/GLM Adapters, Router, Prompts

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ There are two control layers.
 
 ```
 geode/
-├── core/                          # 195 modules, 4-Layer Stack
+├── core/                          # 204 modules, 4-Layer Stack
 │   ├── agent/                     # Agent: AgenticLoop, ToolCallProcessor, SubAgentManager
 │   ├── cli/                       # Agent: Commands, UI
 │   ├── llm/                       # Model: Claude/OpenAI/GLM Adapters, Router, Prompts
@@ -359,7 +359,7 @@ See the [Workflow](docs/workflow.md) document for full details.
 |------|---------|--------|
 | Lint | `uv run ruff check core/ tests/` | 0 errors |
 | Type | `uv run mypy core/` | 0 errors |
-| Test | `uv run pytest tests/ -q` | 3525+ pass |
+| Test | `uv run pytest tests/ -q` | 3700+ pass |
 | E2E | `uv run geode analyze "Cowboy Bebop" --dry-run` | A (68.4) |
 
 </details>

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -259,9 +259,7 @@ class AgenticLoop:
         from core.agent.convergence import ConvergenceDetector
 
         # Late-binding lambda so test patches on _try_model_escalation propagate
-        self._convergence = ConvergenceDetector(
-            escalation_fn=lambda: self._try_model_escalation()
-        )
+        self._convergence = ConvergenceDetector(escalation_fn=lambda: self._try_model_escalation())
 
         # Feature 8: Diversity forcing — prevent same tool 5x consecutively
         self._consecutive_tool_tracker: list[str] = []
@@ -1398,9 +1396,7 @@ class AgenticLoop:
 
     def _update_tool_error_tracking(self, tool_results: list[dict[str, Any]]) -> None:
         """Update tool error tracking. Delegates to ConvergenceDetector."""
-        self._convergence.update_tool_error_tracking(
-            tool_results, self._tool_processor.tool_log
-        )
+        self._convergence.update_tool_error_tracking(tool_results, self._tool_processor.tool_log)
 
     def _check_convergence_break(self) -> bool:
         """Check for stuck loop. Delegates to ConvergenceDetector."""

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -250,12 +250,18 @@ class AgenticLoop:
         self._ESCALATION_THRESHOLD: int = 2
         self._LLM_RETRY_CAP: int = 5  # max retries before giving up
 
-        # Feature 5: Backpressure on consecutive tool failures
-        self._total_consecutive_tool_errors: int = 0
+        # Context window management (extracted — SRP)
+        from core.agent.context_manager import ContextWindowManager
 
-        # Feature 6: Convergence detection (stuck loop)
-        self._recent_errors: list[str] = []
-        self._convergence_escalated: bool = False
+        self._ctx_mgr = ContextWindowManager(hooks=hooks, quiet=quiet)
+
+        # Convergence detection + tool error tracking (extracted — SRP)
+        from core.agent.convergence import ConvergenceDetector
+
+        # Late-binding lambda so test patches on _try_model_escalation propagate
+        self._convergence = ConvergenceDetector(
+            escalation_fn=lambda: self._try_model_escalation()
+        )
 
         # Feature 8: Diversity forcing — prevent same tool 5x consecutively
         self._consecutive_tool_tracker: list[str] = []
@@ -968,10 +974,12 @@ class AgenticLoop:
             if self._check_convergence_break():
                 from core.cli.ui.agentic_ui import emit_convergence_detected
 
-                emit_convergence_detected(
-                    self._recent_errors[-1] if self._recent_errors else "unknown",
-                    round_idx + 1,
+                last_err = (
+                    self._convergence.recent_errors[-1]
+                    if self._convergence.recent_errors
+                    else "unknown"
                 )
+                emit_convergence_detected(last_err, round_idx + 1)
                 self._op_logger.finalize()
                 self._sync_messages_to_context(messages)
                 result = AgenticResult(
@@ -985,11 +993,11 @@ class AgenticLoop:
                 )
                 return self._finalize_and_return(result, user_input, round_idx + 1)
 
-            if self._total_consecutive_tool_errors >= 3:
+            if self._convergence.total_consecutive_tool_errors >= 3:
                 # Backpressure: inject a cooldown hint
                 from core.cli.ui.agentic_ui import emit_tool_backpressure
 
-                emit_tool_backpressure(self._total_consecutive_tool_errors)
+                emit_tool_backpressure(self._convergence.total_consecutive_tool_errors)
                 await asyncio.sleep(1.0)
                 backpressure_hint = {
                     "type": "text",
@@ -1093,390 +1101,32 @@ class AgenticLoop:
         """
         self.context.messages = list(messages)
 
+    def _notify_context_event(
+        self, event_type: str, *, original_count: int, new_count: int
+    ) -> None:
+        """Notify user of context compression. Delegates to ContextWindowManager."""
+        self._ctx_mgr._notify_context_event(
+            event_type, original_count=original_count, new_count=new_count
+        )
+
     def _maybe_prune_messages(self, messages: list[dict[str, Any]]) -> None:
-        """Prune old messages when conversation exceeds 5 rounds (10 msgs).
-
-        Keeps first user message + bridge + recent messages for context budget.
-        Ensures:
-        1. user/assistant alternation is preserved
-        2. No orphaned tool_result messages (each tool_result must follow
-           an assistant message containing the matching tool_use block)
-        """
-        if len(messages) <= 30:
-            return
-        first = messages[0]
-        # Walk backward to find a safe cut point:
-        # - Must be a "user" role message
-        # - Must NOT be a tool_result message (those need a preceding tool_use)
-        # Start from -4 and go back until we find a plain user text message
-        safe_cut = None
-        for candidate in range(-4, -(len(messages)), -1):
-            idx = len(messages) + candidate
-            if idx <= 0:
-                break
-            msg = messages[idx]
-            if msg["role"] != "user":
-                continue
-            # Check if this is a tool_result message
-            content = msg.get("content")
-            if isinstance(content, list) and any(
-                isinstance(b, dict) and b.get("type") == "tool_result" for b in content
-            ):
-                continue  # Skip — orphaned tool_result after pruning
-            safe_cut = candidate
-            break
-
-        if safe_cut is None:
-            # No safe cut found — don't prune to avoid corruption
-            return
-
-        recent = messages[safe_cut:]
-        bridge: dict[str, Any] = {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "(earlier rounds omitted)"}],
-        }
-        messages.clear()
-        messages.extend([first, bridge, *recent])
-        log.debug("Pruned messages: kept first + bridge + %d recent", len(recent))
+        """Prune old messages. Delegates to ContextWindowManager."""
+        self._ctx_mgr.maybe_prune_messages(messages)
 
     def _check_context_overflow(self, system: str, messages: list[dict[str, Any]]) -> None:
-        """Check context window usage and apply provider-aware compression.
-
-        Strategy by provider:
-        - Anthropic: server-side compaction (compact_20260112) handles 80%+ automatically.
-          Client only intervenes at 95% as emergency prune safety net.
-        - OpenAI/GLM: no server-side compaction. Client triggers LLM-based compaction
-          at 80% and emergency prune at 95%.
-
-        Absolute ceiling (200K tokens):
-        - Large-context models (1M) hit rate limit pool separation at >200K tokens.
-          Percentage thresholds (80%=800K) are too distant to catch this.
-          When estimated > 200K on a >200K-window model, force tool result
-          summarization + compact to stay under the ceiling.
-
-        Compression strategy is delegated to the CONTEXT_OVERFLOW_ACTION hook handler.
-        If no handler is registered or all fail, falls back to hardcoded defaults.
-        """
-        try:
-            from core.config import settings
-            from core.orchestration.context_monitor import check_context
-
-            metrics = check_context(messages, self.model, system_prompt=system)
-
-            if metrics.is_critical:
-                log.warning(
-                    "Context CRITICAL: %.0f%% (%d/%d tokens) — emergency action",
-                    metrics.usage_pct,
-                    metrics.estimated_tokens,
-                    metrics.context_window,
-                )
-                if self._hooks:
-                    self._hooks.trigger(
-                        HookEvent.CONTEXT_CRITICAL,
-                        {"metrics": dataclasses.asdict(metrics), "model": self.model},
-                    )
-
-                strategy = self._resolve_overflow_strategy(metrics, settings)
-                self._apply_overflow_strategy(strategy, messages, settings)
-
-                # Re-check: if still critical after pruning, context is exhausted
-                post = check_context(messages, self.model, system_prompt=system)
-                if post.is_critical:
-                    raise _ContextExhaustedError(
-                        f"Context exhausted: {post.usage_pct:.0f}% after pruning"
-                    )
-
-            elif metrics.is_warning:
-                # Step 1: mask stale observations (cheapest — no LLM call)
-                from core.orchestration.context_monitor import mask_stale_observations
-
-                mask_keep = settings.observation_mask_keep_rounds
-                masked = mask_stale_observations(messages, keep_recent_rounds=mask_keep)
-                if masked > 0:
-                    log.info(
-                        "Context at %.0f%%: masked %d stale observations",
-                        metrics.usage_pct,
-                        masked,
-                    )
-
-                # Step 2: compact or summarize
-                strategy = self._resolve_overflow_strategy(metrics, settings)
-                if strategy.get("strategy") == "compact":
-                    self._apply_overflow_strategy(strategy, messages, settings)
-                else:
-                    from core.orchestration.context_monitor import summarize_tool_results
-
-                    summarized, _tok_before, _tok_after = summarize_tool_results(
-                        messages,
-                        metrics.context_window,
-                    )
-                    if summarized > 0:
-                        log.info(
-                            "Context at %.0f%%: summarized %d large tool results",
-                            metrics.usage_pct,
-                            summarized,
-                        )
-
-            elif metrics.is_ceiling_exceeded:
-                # Absolute 200K ceiling breached on a large-context model.
-                # Percentage is low (e.g. 20-30%) but tokens exceed the rate limit
-                # pool boundary. Summarize tool results first (lightest), then
-                # compact if still over.
-                from core.orchestration.context_monitor import (
-                    ABSOLUTE_TOKEN_CEILING,
-                    summarize_tool_results,
-                )
-
-                log.info(
-                    "Context ceiling: %d tokens > %dK ceiling (%.0f%% of %dK window) "
-                    "— compressing to avoid rate limit pool separation",
-                    metrics.estimated_tokens,
-                    ABSOLUTE_TOKEN_CEILING // 1000,
-                    metrics.usage_pct,
-                    metrics.context_window // 1000,
-                )
-
-                # Phase 1: summarize large tool results
-                summarized, _tok_before, _tok_after = summarize_tool_results(
-                    messages,
-                    ABSOLUTE_TOKEN_CEILING,
-                )
-                post = check_context(messages, self.model, system_prompt=system)
-
-                if post.is_ceiling_exceeded:
-                    # Phase 2: compact conversation
-                    strategy = {"strategy": "compact", "keep_recent": settings.compact_keep_recent}
-                    self._apply_overflow_strategy(strategy, messages, settings)
-
-        except Exception:
-            log.debug("Context monitor check failed", exc_info=True)
-
-    def _apply_overflow_strategy(
-        self,
-        strategy: dict[str, Any],
-        messages: list[dict[str, Any]],
-        settings: Any,
-    ) -> None:
-        """Execute the overflow strategy (prune or compact)."""
-        from core.orchestration.context_monitor import prune_oldest_messages
-
-        action = strategy.get("strategy", "none")
-        keep_recent = strategy.get("keep_recent", settings.compact_keep_recent)
-
-        if action == "compact":
-            import asyncio
-
-            from core.orchestration.compaction import compact_conversation
-
-            try:
-                new_msgs, did_compact = asyncio.get_event_loop().run_until_complete(
-                    compact_conversation(
-                        messages,
-                        provider=self._provider,
-                        model=self.model,
-                        keep_recent=keep_recent,
-                    )
-                )
-                if did_compact:
-                    original_count = len(messages)
-                    messages.clear()
-                    messages.extend(new_msgs)
-                    self._notify_context_event(
-                        "compact",
-                        original_count=original_count,
-                        new_count=len(new_msgs),
-                    )
-                    return
-            except Exception:
-                log.warning("Client compaction failed — falling back to prune", exc_info=True)
-            # Fall through to prune on failure
-            action = "prune"
-
-        if action == "prune":
-            pruned = prune_oldest_messages(messages, keep_recent=keep_recent)
-            original_count = len(messages)
-            if len(pruned) < original_count:
-                messages.clear()
-                messages.extend(pruned)
-                log.info(
-                    "Emergency pruned: %d → %d messages (keep_recent=%d)",
-                    original_count,
-                    len(pruned),
-                    keep_recent,
-                )
-                self._notify_context_event(
-                    "prune",
-                    original_count=original_count,
-                    new_count=len(pruned),
-                )
+        """Check context window usage. Delegates to ContextWindowManager."""
+        self._ctx_mgr.check_context_overflow(system, messages, self.model, self._provider)
 
     def _aggressive_context_recovery(self, system: str, messages: list[dict[str, Any]]) -> int:
-        """Last-resort context recovery: aggressive prune + tool result summarization.
-
-        Called when normal compaction/prune at 95% still leaves context critical.
-        Two-phase approach:
-          1. Summarize large tool results (>2% of window) to compact summaries
-          2. Prune with halved keep_recent (keep fewer messages)
-        Returns number of messages freed, or 0 if recovery failed.
-        """
-        try:
-            from core.config import settings
-            from core.orchestration.context_monitor import (
-                check_context,
-                prune_oldest_messages,
-                summarize_tool_results,
-            )
-
-            original_count = len(messages)
-
-            # Phase 1: summarize large tool_result blocks in-place
-            ctx_window = getattr(
-                check_context(messages, self.model, system_prompt=system),
-                "context_window",
-                200_000,
-            )
-            summarized, _tok_before, _tok_after = summarize_tool_results(messages, ctx_window)
-            if summarized > 0:
-                log.info("Aggressive recovery: summarized %d tool results", summarized)
-
-            # Check if summarization alone resolved it
-            post = check_context(messages, self.model, system_prompt=system)
-            if not post.is_critical:
-                return original_count - len(messages) + summarized
-
-            # Phase 2: prune with halved keep_recent
-            aggressive_keep = max(3, settings.compact_keep_recent // 2)
-            pruned = prune_oldest_messages(messages, keep_recent=aggressive_keep)
-            if len(pruned) < len(messages):
-                messages.clear()
-                messages.extend(pruned)
-                log.info(
-                    "Aggressive prune: %d → %d messages (keep_recent=%d)",
-                    original_count,
-                    len(pruned),
-                    aggressive_keep,
-                )
-
-            # Final check
-            post2 = check_context(messages, self.model, system_prompt=system)
-            if not post2.is_critical:
-                return original_count - len(messages)
-
-            return 0  # recovery failed
-        except Exception:
-            log.warning("Aggressive context recovery failed", exc_info=True)
-            return 0
-
-    def _notify_context_event(
-        self,
-        event_type: str,
-        *,
-        original_count: int,
-        new_count: int,
-    ) -> None:
-        """Notify user of automatic context compression via UI."""
-        if self._quiet:
-            return
-        try:
-            from core.cli.ui.agentic_ui import render_context_event
-
-            render_context_event(event_type, original_count=original_count, new_count=new_count)
-        except Exception:
-            log.debug("Context event notification failed", exc_info=True)
-
-    def _resolve_overflow_strategy(self, metrics: Any, settings: Any) -> dict[str, Any]:
-        """Ask CONTEXT_OVERFLOW_ACTION hook for compression strategy, with fallback.
-
-        Returns a dict with at least ``strategy`` key. If no handler responds
-        or all handlers fail, returns the hardcoded default strategy.
-
-        Provider-aware: passes self._provider so the hook can differentiate
-        between Anthropic (server-side compaction) and others (client-side).
-        """
-        if self._hooks:
-            results = self._hooks.trigger_with_result(
-                HookEvent.CONTEXT_OVERFLOW_ACTION,
-                {
-                    "metrics": dataclasses.asdict(metrics),
-                    "model": self.model,
-                    "provider": self._provider,
-                },
-            )
-            for result in results:
-                if result.success and result.data.get("strategy"):
-                    return result.data
-
-        # Fallback: hardcoded default (no handler registered or all failed)
-        keep_recent = settings.compact_keep_recent
-        if self._provider == "anthropic":
-            # Anthropic: server-side handles it, only emergency prune at 95%
-            if metrics.usage_pct >= 95:
-                return {"strategy": "prune", "keep_recent": keep_recent}
-            return {"strategy": "none"}
-
-        # Non-Anthropic: compact at 80%, prune at 95%
-        if metrics.context_window < 200_000:
-            keep_recent = min(keep_recent, 5)
-        if metrics.usage_pct >= 95:
-            return {"strategy": "prune", "keep_recent": keep_recent}
-        elif metrics.usage_pct >= 80:
-            return {"strategy": "compact", "keep_recent": keep_recent}
-        return {"strategy": "none"}
+        """Last-resort context recovery. Delegates to ContextWindowManager."""
+        return self._ctx_mgr.aggressive_context_recovery(system, messages, self.model)
 
     @staticmethod
     def _repair_messages(messages: list[dict[str, Any]]) -> None:
-        """Remove orphaned tool_result messages that lack a preceding tool_use.
+        """Remove orphaned tool_result messages. Delegates to ContextWindowManager."""
+        from core.agent.context_manager import ContextWindowManager
 
-        Scans backward and removes any user message whose content is entirely
-        tool_result blocks without matching tool_use in the prior assistant msg.
-        Also syncs the repair back to context via mutation in place.
-        """
-        i = len(messages) - 1
-        while i >= 1:
-            msg = messages[i]
-            if msg["role"] != "user":
-                i -= 1
-                continue
-            content = msg.get("content")
-            if not isinstance(content, list):
-                i -= 1
-                continue
-            # Check if ALL blocks are tool_result
-            tr_ids = {
-                b["tool_use_id"]
-                for b in content
-                if isinstance(b, dict) and b.get("type") == "tool_result"
-            }
-            if not tr_ids:
-                i -= 1
-                continue
-            # Check preceding assistant message for matching tool_use
-            if i > 0 and messages[i - 1]["role"] == "assistant":
-                prev_content = messages[i - 1].get("content", [])
-                if isinstance(prev_content, list):
-                    tu_ids = {
-                        b.get("id")
-                        for b in prev_content
-                        if isinstance(b, dict) and b.get("type") == "tool_use"
-                    }
-                    if tr_ids <= tu_ids:
-                        i -= 1
-                        continue  # All tool_results have matching tool_use — OK
-            # Orphaned — remove this tool_result message and its preceding
-            # assistant message (which also lost its tool_use context)
-            log.debug("Removing orphaned tool_result at index %d", i)
-            messages.pop(i)
-            # Also remove the preceding assistant message if it's a bridge/text
-            if i > 0 and messages[i - 1]["role"] == "assistant":
-                prev_c = messages[i - 1].get("content", [])
-                if isinstance(prev_c, list):
-                    has_tool_use = any(
-                        isinstance(b, dict) and b.get("type") == "tool_use" for b in prev_c
-                    )
-                    if not has_tool_use:
-                        messages.pop(i - 1)
-                        i -= 1
-            i -= 1
+        ContextWindowManager.repair_messages(messages)
 
     def _build_system_prompt(self) -> str:
         """Build the system prompt with skill context and agentic suffix."""
@@ -1707,19 +1357,35 @@ class AgenticLoop:
                 return True
 
         # Current provider's chain exhausted — try cross-provider (Feature 4)
-        fallbacks = CROSS_PROVIDER_FALLBACK.get(self._provider, [])
+        from_provider = self._provider
+        fallbacks = CROSS_PROVIDER_FALLBACK.get(from_provider, [])
         for fallback_provider, fallback_model in fallbacks:
             if fallback_model != current:
                 log.warning(
                     "Cross-provider escalation: %s(%s) -> %s(%s)",
                     current,
-                    self._provider,
+                    from_provider,
                     fallback_model,
                     fallback_provider,
                 )
                 self.update_model(
                     fallback_model, fallback_provider, reason="cross_provider_escalation"
                 )
+                # Emit dedicated cross-provider hook for observability
+                # (MODEL_SWITCHED is also fired by update_model, but this
+                # event carries provider-level context for audit loggers)
+                if self._hooks:
+                    from core.hooks import HookEvent
+
+                    self._hooks.trigger(
+                        HookEvent.FALLBACK_CROSS_PROVIDER,
+                        {
+                            "from_model": current,
+                            "to_model": fallback_model,
+                            "from_provider": from_provider,
+                            "to_provider": fallback_provider,
+                        },
+                    )
                 return True
 
         log.warning("Model escalation failed: no more fallback models available")
@@ -1731,88 +1397,11 @@ class AgenticLoop:
     # ---------------------------------------------------------------------------
 
     def _update_tool_error_tracking(self, tool_results: list[dict[str, Any]]) -> None:
-        """Update consecutive tool error tracking and recent error history.
-
-        Processes a batch of tool results from the current round.
-        Resets the consecutive counter on any success, increments on all-error rounds.
-        Appends normalized error keys to _recent_errors for convergence detection.
-        """
-        has_success = False
-        has_error = False
-
-        for tr in tool_results:
-            # Parse content JSON to check for errors
-            content = tr.get("content", "")
-            if isinstance(content, str):
-                try:
-                    parsed = json.loads(content)
-                except (json.JSONDecodeError, ValueError):
-                    parsed = {}
-            else:
-                parsed = content if isinstance(content, dict) else {}
-
-            if isinstance(parsed, dict) and parsed.get("error"):
-                has_error = True
-                # Feature 6: append normalized error key
-                tool_use_id = tr.get("tool_use_id", "")
-                error_str = str(parsed.get("error", ""))[:50]
-                # Extract tool name from tool_log (most recent entries)
-                tool_name = "unknown"
-                for entry in reversed(self._tool_processor.tool_log):
-                    if tool_use_id and entry.get("tool") and isinstance(entry.get("result"), dict):
-                        tool_name = entry["tool"]
-                        break
-                error_key = f"{tool_name}:{error_str}"
-                self._recent_errors.append(error_key)
-                # Keep last 6 entries max
-                if len(self._recent_errors) > 6:
-                    self._recent_errors = self._recent_errors[-6:]
-            else:
-                has_success = True
-
-        if has_success:
-            self._total_consecutive_tool_errors = 0
-        elif has_error:
-            self._total_consecutive_tool_errors += 1
+        """Update tool error tracking. Delegates to ConvergenceDetector."""
+        self._convergence.update_tool_error_tracking(
+            tool_results, self._tool_processor.tool_log
+        )
 
     def _check_convergence_break(self) -> bool:
-        """Check if the loop is stuck in a repeating failure pattern.
-
-        On first detection of 3 identical errors, attempts model escalation
-        (runtime ratchet — Karpathy P4) instead of breaking immediately.
-        Only breaks after escalation has been tried and errors persist.
-        """
-        if len(self._recent_errors) < 3:
-            return False
-
-        # Check last 3 entries for identical pattern
-        last_3 = self._recent_errors[-3:]
-        if last_3[0] == last_3[1] == last_3[2]:
-            # Runtime ratchet: try model escalation before giving up
-            if not self._convergence_escalated:
-                self._convergence_escalated = True
-                log.warning(
-                    "Convergence detected (%s x3) — escalating model",
-                    last_3[0],
-                )
-                escalated = self._try_model_escalation()
-                if escalated:
-                    self._recent_errors.clear()
-                    return False  # Give escalated model a chance
-                # Escalation failed (no fallback) — fall through to break check
-
-            # Already escalated and still stuck — check for 4+ identical
-            if len(self._recent_errors) >= 4:
-                last_4 = self._recent_errors[-4:]
-                if last_4[0] == last_4[1] == last_4[2] == last_4[3]:
-                    log.warning(
-                        "Convergence detected after escalation: 4+ identical errors '%s'",
-                        last_4[0],
-                    )
-                    return True
-            # 3 identical post-escalation — log warning, don't break yet
-            log.warning(
-                "Convergence warning (post-escalation): 3 identical errors '%s'",
-                last_3[0],
-            )
-        return False
+        """Check for stuck loop. Delegates to ConvergenceDetector."""
+        return self._convergence.check_convergence_break()

--- a/core/agent/context_manager.py
+++ b/core/agent/context_manager.py
@@ -1,0 +1,410 @@
+"""Context window management — extracted from AgenticLoop for SRP.
+
+Handles context overflow detection, message pruning, compaction,
+aggressive recovery, and strategy resolution.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+from core.hooks import HookEvent, HookSystem
+
+log = logging.getLogger(__name__)
+
+
+class ContextWindowManager:
+    """Manages context window overflow detection and compression.
+
+    Extracted from AgenticLoop to isolate context budget concerns.
+    Uses composition: AgenticLoop creates and owns this instance.
+    """
+
+    def __init__(
+        self,
+        *,
+        hooks: HookSystem | None,
+        quiet: bool,
+    ) -> None:
+        self._hooks = hooks
+        self._quiet = quiet
+
+    def maybe_prune_messages(self, messages: list[dict[str, Any]]) -> None:
+        """Prune old messages when conversation exceeds 5 rounds (10 msgs).
+
+        Keeps first user message + bridge + recent messages for context budget.
+        Ensures:
+        1. user/assistant alternation is preserved
+        2. No orphaned tool_result messages (each tool_result must follow
+           an assistant message containing the matching tool_use block)
+        """
+        if len(messages) <= 30:
+            return
+        first = messages[0]
+        # Walk backward to find a safe cut point:
+        # - Must be a "user" role message
+        # - Must NOT be a tool_result message (those need a preceding tool_use)
+        safe_cut = None
+        for candidate in range(-4, -(len(messages)), -1):
+            idx = len(messages) + candidate
+            if idx <= 0:
+                break
+            msg = messages[idx]
+            if msg["role"] != "user":
+                continue
+            content = msg.get("content")
+            if isinstance(content, list) and any(
+                isinstance(b, dict) and b.get("type") == "tool_result" for b in content
+            ):
+                continue  # Skip — orphaned tool_result after pruning
+            safe_cut = candidate
+            break
+
+        if safe_cut is None:
+            return
+
+        recent = messages[safe_cut:]
+        bridge: dict[str, Any] = {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "(earlier rounds omitted)"}],
+        }
+        messages.clear()
+        messages.extend([first, bridge, *recent])
+        log.debug("Pruned messages: kept first + bridge + %d recent", len(recent))
+
+    def check_context_overflow(
+        self,
+        system: str,
+        messages: list[dict[str, Any]],
+        model: str,
+        provider: str,
+    ) -> None:
+        """Check context window usage and apply provider-aware compression.
+
+        Strategy by provider:
+        - Anthropic: server-side compaction (compact_20260112) handles 80%+ automatically.
+          Client only intervenes at 95% as emergency prune safety net.
+        - OpenAI/GLM: no server-side compaction. Client triggers LLM-based compaction
+          at 80% and emergency prune at 95%.
+
+        Absolute ceiling (200K tokens):
+        - Large-context models (1M) hit rate limit pool separation at >200K tokens.
+          Percentage thresholds (80%=800K) are too distant to catch this.
+          When estimated > 200K on a >200K-window model, force tool result
+          summarization + compact to stay under the ceiling.
+
+        Compression strategy is delegated to the CONTEXT_OVERFLOW_ACTION hook handler.
+        If no handler is registered or all fail, falls back to hardcoded defaults.
+        """
+        try:
+            from core.config import settings
+            from core.orchestration.context_monitor import check_context
+
+            metrics = check_context(messages, model, system_prompt=system)
+
+            if metrics.is_critical:
+                log.warning(
+                    "Context CRITICAL: %.0f%% (%d/%d tokens) — emergency action",
+                    metrics.usage_pct,
+                    metrics.estimated_tokens,
+                    metrics.context_window,
+                )
+                if self._hooks:
+                    self._hooks.trigger(
+                        HookEvent.CONTEXT_CRITICAL,
+                        {"metrics": dataclasses.asdict(metrics), "model": model},
+                    )
+
+                strategy = self._resolve_overflow_strategy(metrics, settings, model, provider)
+                self._apply_overflow_strategy(strategy, messages, settings, model, provider)
+
+                # Re-check: if still critical after pruning, context is exhausted
+                post = check_context(messages, model, system_prompt=system)
+                if post.is_critical:
+                    from core.agent.agentic_loop import _ContextExhaustedError
+
+                    raise _ContextExhaustedError(
+                        f"Context exhausted: {post.usage_pct:.0f}% after pruning"
+                    )
+
+            elif metrics.is_warning:
+                # Step 1: mask stale observations (cheapest — no LLM call)
+                from core.orchestration.context_monitor import mask_stale_observations
+
+                mask_keep = settings.observation_mask_keep_rounds
+                masked = mask_stale_observations(messages, keep_recent_rounds=mask_keep)
+                if masked > 0:
+                    log.info(
+                        "Context at %.0f%%: masked %d stale observations",
+                        metrics.usage_pct,
+                        masked,
+                    )
+
+                # Step 2: compact or summarize
+                strategy = self._resolve_overflow_strategy(metrics, settings, model, provider)
+                if strategy.get("strategy") == "compact":
+                    self._apply_overflow_strategy(strategy, messages, settings, model, provider)
+                else:
+                    from core.orchestration.context_monitor import summarize_tool_results
+
+                    summarized, _tok_before, _tok_after = summarize_tool_results(
+                        messages,
+                        metrics.context_window,
+                    )
+                    if summarized > 0:
+                        log.info(
+                            "Context at %.0f%%: summarized %d large tool results",
+                            metrics.usage_pct,
+                            summarized,
+                        )
+
+            elif metrics.is_ceiling_exceeded:
+                from core.orchestration.context_monitor import (
+                    ABSOLUTE_TOKEN_CEILING,
+                    summarize_tool_results,
+                )
+
+                log.info(
+                    "Context ceiling: %d tokens > %dK ceiling (%.0f%% of %dK window) "
+                    "— compressing to avoid rate limit pool separation",
+                    metrics.estimated_tokens,
+                    ABSOLUTE_TOKEN_CEILING // 1000,
+                    metrics.usage_pct,
+                    metrics.context_window // 1000,
+                )
+
+                # Phase 1: summarize large tool results
+                summarized, _tok_before, _tok_after = summarize_tool_results(
+                    messages,
+                    ABSOLUTE_TOKEN_CEILING,
+                )
+                post = check_context(messages, model, system_prompt=system)
+
+                if post.is_ceiling_exceeded:
+                    # Phase 2: compact conversation
+                    strategy = {"strategy": "compact", "keep_recent": settings.compact_keep_recent}
+                    self._apply_overflow_strategy(strategy, messages, settings, model, provider)
+
+        except Exception:
+            log.debug("Context monitor check failed", exc_info=True)
+
+    def _apply_overflow_strategy(
+        self,
+        strategy: dict[str, Any],
+        messages: list[dict[str, Any]],
+        settings: Any,
+        model: str,
+        provider: str,
+    ) -> None:
+        """Execute the overflow strategy (prune or compact)."""
+        from core.orchestration.context_monitor import prune_oldest_messages
+
+        action = strategy.get("strategy", "none")
+        keep_recent = strategy.get("keep_recent", settings.compact_keep_recent)
+
+        if action == "compact":
+            import asyncio
+
+            from core.orchestration.compaction import compact_conversation
+
+            try:
+                new_msgs, did_compact = asyncio.get_event_loop().run_until_complete(
+                    compact_conversation(
+                        messages,
+                        provider=provider,
+                        model=model,
+                        keep_recent=keep_recent,
+                    )
+                )
+                if did_compact:
+                    original_count = len(messages)
+                    messages.clear()
+                    messages.extend(new_msgs)
+                    self._notify_context_event(
+                        "compact",
+                        original_count=original_count,
+                        new_count=len(new_msgs),
+                    )
+                    return
+            except Exception:
+                log.warning("Client compaction failed — falling back to prune", exc_info=True)
+            # Fall through to prune on failure
+            action = "prune"
+
+        if action == "prune":
+            pruned = prune_oldest_messages(messages, keep_recent=keep_recent)
+            original_count = len(messages)
+            if len(pruned) < original_count:
+                messages.clear()
+                messages.extend(pruned)
+                log.info(
+                    "Emergency pruned: %d → %d messages (keep_recent=%d)",
+                    original_count,
+                    len(pruned),
+                    keep_recent,
+                )
+                self._notify_context_event(
+                    "prune",
+                    original_count=original_count,
+                    new_count=len(pruned),
+                )
+
+    def aggressive_context_recovery(
+        self, system: str, messages: list[dict[str, Any]], model: str
+    ) -> int:
+        """Last-resort context recovery: aggressive prune + tool result summarization.
+
+        Returns number of messages freed, or 0 if recovery failed.
+        """
+        try:
+            from core.config import settings
+            from core.orchestration.context_monitor import (
+                check_context,
+                prune_oldest_messages,
+                summarize_tool_results,
+            )
+
+            original_count = len(messages)
+
+            # Phase 1: summarize large tool_result blocks in-place
+            ctx_window = getattr(
+                check_context(messages, model, system_prompt=system),
+                "context_window",
+                200_000,
+            )
+            summarized, _tok_before, _tok_after = summarize_tool_results(messages, ctx_window)
+            if summarized > 0:
+                log.info("Aggressive recovery: summarized %d tool results", summarized)
+
+            # Check if summarization alone resolved it
+            post = check_context(messages, model, system_prompt=system)
+            if not post.is_critical:
+                return original_count - len(messages) + summarized
+
+            # Phase 2: prune with halved keep_recent
+            aggressive_keep = max(3, settings.compact_keep_recent // 2)
+            pruned = prune_oldest_messages(messages, keep_recent=aggressive_keep)
+            if len(pruned) < len(messages):
+                messages.clear()
+                messages.extend(pruned)
+                log.info(
+                    "Aggressive prune: %d → %d messages (keep_recent=%d)",
+                    original_count,
+                    len(pruned),
+                    aggressive_keep,
+                )
+
+            # Final check
+            post2 = check_context(messages, model, system_prompt=system)
+            if not post2.is_critical:
+                return original_count - len(messages)
+
+            return 0  # recovery failed
+        except Exception:
+            log.warning("Aggressive context recovery failed", exc_info=True)
+            return 0
+
+    def _notify_context_event(
+        self,
+        event_type: str,
+        *,
+        original_count: int,
+        new_count: int,
+    ) -> None:
+        """Notify user of automatic context compression via UI."""
+        if self._quiet:
+            return
+        try:
+            from core.cli.ui.agentic_ui import render_context_event
+
+            render_context_event(event_type, original_count=original_count, new_count=new_count)
+        except Exception:
+            log.debug("Context event notification failed", exc_info=True)
+
+    def _resolve_overflow_strategy(
+        self, metrics: Any, settings: Any, model: str, provider: str
+    ) -> dict[str, Any]:
+        """Ask CONTEXT_OVERFLOW_ACTION hook for compression strategy, with fallback."""
+        if self._hooks:
+            results = self._hooks.trigger_with_result(
+                HookEvent.CONTEXT_OVERFLOW_ACTION,
+                {
+                    "metrics": dataclasses.asdict(metrics),
+                    "model": model,
+                    "provider": provider,
+                },
+            )
+            for result in results:
+                if result.success and result.data.get("strategy"):
+                    return result.data
+
+        # Fallback: hardcoded default (no handler registered or all failed)
+        keep_recent = settings.compact_keep_recent
+        if provider == "anthropic":
+            if metrics.usage_pct >= 95:
+                return {"strategy": "prune", "keep_recent": keep_recent}
+            return {"strategy": "none"}
+
+        # Non-Anthropic: compact at 80%, prune at 95%
+        if metrics.context_window < 200_000:
+            keep_recent = min(keep_recent, 5)
+        if metrics.usage_pct >= 95:
+            return {"strategy": "prune", "keep_recent": keep_recent}
+        elif metrics.usage_pct >= 80:
+            return {"strategy": "compact", "keep_recent": keep_recent}
+        return {"strategy": "none"}
+
+    @staticmethod
+    def repair_messages(messages: list[dict[str, Any]]) -> None:
+        """Remove orphaned tool_result messages that lack a preceding tool_use.
+
+        Scans backward and removes any user message whose content is entirely
+        tool_result blocks without matching tool_use in the prior assistant msg.
+        """
+        i = len(messages) - 1
+        while i >= 1:
+            msg = messages[i]
+            if msg["role"] != "user":
+                i -= 1
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                i -= 1
+                continue
+            # Check if ALL blocks are tool_result
+            tr_ids = {
+                b["tool_use_id"]
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "tool_result"
+            }
+            if not tr_ids:
+                i -= 1
+                continue
+            # Check preceding assistant message for matching tool_use
+            if i > 0 and messages[i - 1]["role"] == "assistant":
+                prev_content = messages[i - 1].get("content", [])
+                if isinstance(prev_content, list):
+                    tu_ids = {
+                        b.get("id")
+                        for b in prev_content
+                        if isinstance(b, dict) and b.get("type") == "tool_use"
+                    }
+                    if tr_ids <= tu_ids:
+                        i -= 1
+                        continue  # All tool_results have matching tool_use — OK
+            # Orphaned — remove this tool_result message and its preceding
+            # assistant message (which also lost its tool_use context)
+            log.debug("Removing orphaned tool_result at index %d", i)
+            messages.pop(i)
+            if i > 0 and messages[i - 1]["role"] == "assistant":
+                prev_c = messages[i - 1].get("content", [])
+                if isinstance(prev_c, list):
+                    has_tool_use = any(
+                        isinstance(b, dict) and b.get("type") == "tool_use" for b in prev_c
+                    )
+                    if not has_tool_use:
+                        messages.pop(i - 1)
+                        i -= 1
+            i -= 1

--- a/core/agent/convergence.py
+++ b/core/agent/convergence.py
@@ -1,0 +1,114 @@
+"""Convergence detection — extracted from AgenticLoop for SRP.
+
+Tracks tool errors and detects stuck loop patterns (repeated identical failures).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class ConvergenceDetector:
+    """Detects stuck loops and tracks tool error patterns.
+
+    Extracted from AgenticLoop to isolate error tracking concerns.
+    Uses composition: AgenticLoop creates and owns this instance.
+    """
+
+    def __init__(self, *, escalation_fn: Callable[[], bool] | None = None) -> None:
+        self.total_consecutive_tool_errors: int = 0
+        self.recent_errors: list[str] = []
+        self.convergence_escalated: bool = False
+        self._escalation_fn = escalation_fn
+
+    def update_tool_error_tracking(
+        self, tool_results: list[dict[str, Any]], tool_log: list[dict[str, Any]]
+    ) -> None:
+        """Update consecutive tool error tracking and recent error history.
+
+        Processes a batch of tool results from the current round.
+        Resets the consecutive counter on any success, increments on all-error rounds.
+        Appends normalized error keys to recent_errors for convergence detection.
+        """
+        has_success = False
+        has_error = False
+
+        for tr in tool_results:
+            content = tr.get("content", "")
+            if isinstance(content, str):
+                try:
+                    parsed = json.loads(content)
+                except (json.JSONDecodeError, ValueError):
+                    parsed = {}
+            else:
+                parsed = content if isinstance(content, dict) else {}
+
+            if isinstance(parsed, dict) and parsed.get("error"):
+                has_error = True
+                tool_use_id = tr.get("tool_use_id", "")
+                error_str = str(parsed.get("error", ""))[:50]
+                tool_name = "unknown"
+                for entry in reversed(tool_log):
+                    if tool_use_id and entry.get("tool") and isinstance(entry.get("result"), dict):
+                        tool_name = entry["tool"]
+                        break
+                error_key = f"{tool_name}:{error_str}"
+                self.recent_errors.append(error_key)
+                # Keep last 6 entries max
+                if len(self.recent_errors) > 6:
+                    self.recent_errors = self.recent_errors[-6:]
+            else:
+                has_success = True
+
+        if has_success:
+            self.total_consecutive_tool_errors = 0
+        elif has_error:
+            self.total_consecutive_tool_errors += 1
+
+    def check_convergence_break(self) -> bool:
+        """Check if the loop is stuck in a repeating failure pattern.
+
+        On first detection of 3 identical errors, attempts model escalation
+        (runtime ratchet — Karpathy P4) instead of breaking immediately.
+        Only breaks after escalation has been tried and errors persist.
+        """
+        if len(self.recent_errors) < 3:
+            return False
+
+        # Check last 3 entries for identical pattern
+        last_3 = self.recent_errors[-3:]
+        if last_3[0] == last_3[1] == last_3[2]:
+            # Runtime ratchet: try model escalation before giving up
+            if not self.convergence_escalated:
+                self.convergence_escalated = True
+                log.warning(
+                    "Convergence detected (%s x3) — escalating model",
+                    last_3[0],
+                )
+                if self._escalation_fn:
+                    escalated = self._escalation_fn()
+                    if escalated:
+                        self.recent_errors.clear()
+                        return False  # Give escalated model a chance
+                # Escalation failed (no fallback) — fall through to break check
+
+            # Already escalated and still stuck — check for 4+ identical
+            if len(self.recent_errors) >= 4:
+                last_4 = self.recent_errors[-4:]
+                if last_4[0] == last_4[1] == last_4[2] == last_4[3]:
+                    log.warning(
+                        "Convergence detected after escalation: 4+ identical errors '%s'",
+                        last_4[0],
+                    )
+                    return True
+            # 3 identical post-escalation — log warning, don't break yet
+            log.warning(
+                "Convergence warning (post-escalation): 3 identical errors '%s'",
+                last_3[0],
+            )
+        return False

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -11,14 +11,12 @@ from __future__ import annotations
 import logging
 import signal
 import sys
-import termios
 from pathlib import Path
 from typing import Any
 
 import typer
 
 from core import __version__
-from core.agent.conversation import ConversationContext
 from core.cli.commands import (
     cmd_apply,
     cmd_auth,
@@ -112,111 +110,22 @@ def _drain_scheduler_queue(
     on_skip: Any | None = None,
     on_main_run: Any | None = None,
 ) -> int:
-    """Drain pending scheduled jobs from the action queue.
+    """Drain pending scheduled jobs. Delegates to scheduler_drain module."""
+    from core.cli.scheduler_drain import drain_scheduler_queue
 
-    Shared by both REPL and serve modes.  In serve mode ``force_isolated``
-    is True because there is no interactive main session to inject into.
-
-    Uses SessionLane (per-key serial) + Global Lane (capacity) for
-    concurrency control through the unified LaneQueue.
-
-    Returns the number of jobs drained.
-    """
-    import queue as _q
-
-    from core.orchestration.isolated_execution import IsolationConfig
-
-    count = 0
-    try:
-        while True:
-            job_id, fired_action, isolated = action_queue.get_nowait()
-            if not fired_action:
-                continue
-            count += 1
-            prompt = f"[scheduled-job:{job_id}] {fired_action}"
-
-            if isolated or force_isolated:
-                lane_key = f"sched:{job_id}"
-
-                # Dual acquire: session (per-key serial) + global (capacity)
-                if not session_lane.try_acquire(lane_key):
-                    log.warning("Session key busy, skipping job %s", job_id)
-                    if on_skip:
-                        on_skip(job_id)
-                    continue
-
-                if not global_lane.try_acquire(lane_key):
-                    session_lane.manual_release(lane_key)
-                    log.warning("Global lane full, skipping job %s", job_id)
-                    if on_skip:
-                        on_skip(job_id)
-                    continue
-
-                _lanes_acquired = True
-                try:
-                    _iso_conv = ConversationContext()
-                    from core.gateway.shared_services import SessionMode
-
-                    _, _iso_loop = services.create_session(
-                        SessionMode.SCHEDULER,
-                        conversation=_iso_conv,
-                        propagate_context=True,
-                    )
-                    _cap_loop = _iso_loop
-                    _cap_prompt = prompt
-                    _cap_jid = job_id
-                    _cap_sess = session_lane
-                    _cap_glob = global_lane
-                    _cap_key = lane_key
-                    _cap_cb = on_complete
-
-                    def _run_isolated(
-                        *,
-                        _loop: Any = _cap_loop,
-                        _p: str = _cap_prompt,
-                        _jid: str = _cap_jid,
-                        _sess: Any = _cap_sess,
-                        _glob: Any = _cap_glob,
-                        _key: str = _cap_key,
-                        _cb: Any = _cap_cb,
-                    ) -> str:
-                        try:
-                            r = _loop.run(_p)
-                            if _cb:
-                                _cb(r, job_id=_jid)
-                            return r.text if r and r.text else ""
-                        finally:
-                            _glob.manual_release(_key)
-                            _sess.manual_release(_key)
-
-                    runner.run_async(
-                        _run_isolated,
-                        config=IsolationConfig(
-                            prefix=f"scheduled:{job_id}",
-                            post_to_main=False,
-                            timeout_s=300.0,
-                        ),
-                    )
-                    _lanes_acquired = False  # ownership transferred to _run_isolated
-                    if on_dispatch:
-                        on_dispatch(job_id)
-                except Exception:
-                    if _lanes_acquired:
-                        global_lane.manual_release(lane_key)
-                        session_lane.manual_release(lane_key)
-                    log.warning("Scheduler job %s dispatch failed", job_id, exc_info=True)
-            else:
-                # Non-isolated: inject into main session (REPL only)
-                if main_loop is not None:
-                    if on_main_run:
-                        on_main_run(job_id)
-                    try:
-                        main_loop.run(prompt)
-                    except Exception:
-                        log.warning("Scheduler job %s main-loop failed", job_id, exc_info=True)
-    except _q.Empty:
-        pass
-    return count
+    return drain_scheduler_queue(
+        action_queue=action_queue,
+        services=services,
+        runner=runner,
+        session_lane=session_lane,
+        global_lane=global_lane,
+        force_isolated=force_isolated,
+        main_loop=main_loop,
+        on_complete=on_complete,
+        on_dispatch=on_dispatch,
+        on_skip=on_skip,
+        on_main_run=on_main_run,
+    )
 
 
 app = typer.Typer(
@@ -277,21 +186,10 @@ def _render_readiness_compact(report: ReadinessReport) -> None:
 
 
 def _suppress_noisy_warnings() -> None:
-    """Suppress known noisy warnings from dependencies."""
-    import warnings
+    """Suppress known noisy warnings. Delegates to terminal module."""
+    from core.cli.terminal import suppress_noisy_warnings
 
-    # Pydantic V1 deprecation from langchain_core on Python 3.14+
-    warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")
-    # LangGraph msgpack deserialization warning (warnings.warn path)
-    warnings.filterwarnings("ignore", message="Deserializing unregistered type")
-
-    # LangGraph checkpoint deserialization also logs via logging.warning —
-    # suppress those at the logging level.
-    for noisy_logger in (
-        "langgraph.checkpoint.serde.jsonplus",
-        "langgraph.checkpoint.serde.base",
-    ):
-        logging.getLogger(noisy_logger).setLevel(logging.ERROR)
+    suppress_noisy_warnings()
 
 
 def _welcome_screen() -> None:
@@ -572,151 +470,17 @@ def _show_commentary(
 
 
 def _handle_memory_action(intent: Any, user_text: str, is_offline: bool) -> None:
-    """Handle memory-related actions (P0-A + P1-B).
+    """Handle memory-related actions (P0-A + P1-B). Delegates to memory_handler module."""
+    from core.cli.memory_handler import handle_memory_action
 
-    Accepts either an object with an `args` dict attribute, or a plain dict.
-    """
-    args = intent if isinstance(intent, dict) else intent.args
-
-    # Determine sub-action from tool routing
-    rule_action = args.get("rule_action")
-    query = args.get("query")
-    key = args.get("key")
-    content = args.get("content")
-
-    if rule_action:
-        # manage_rule tool
-        from core.memory.project import ProjectMemory
-
-        mem = ProjectMemory()
-        if rule_action == "list":
-            rules = mem.list_rules()
-            console.print()
-            console.print("  [header]Active Analysis Rules[/header]")
-            if not rules:
-                console.print("  [muted]No rules found.[/muted]")
-            for r in rules:
-                paths_str = ", ".join(r.get("paths", []))
-                console.print(f"  - [value]{r['name']}[/value] ({paths_str})")
-                if r.get("preview"):
-                    console.print(f"    [muted]{r['preview'][:80]}...[/muted]")
-            console.print()
-        elif rule_action == "create":
-            name = args.get("name", "")
-            paths = args.get("paths", [])
-            rule_content = content or ""
-            if not name:
-                console.print("  [warning]Rule name is required.[/warning]")
-                return
-            ok = mem.create_rule(name, paths, rule_content)
-            if ok:
-                console.print(f"  [success]Rule '{name}' created.[/success]")
-                from core.hooks import HookEvent
-
-                _fire_hook(HookEvent.RULE_CREATED, {"name": name, "paths": paths})
-            else:
-                console.print(
-                    f"  [warning]Failed to create rule '{name}' (may already exist).[/warning]"
-                )
-            console.print()
-        elif rule_action == "update":
-            name = args.get("name", "")
-            rule_content = content or ""
-            if not name:
-                console.print("  [warning]Rule name is required.[/warning]")
-                return
-            ok = mem.update_rule(name, rule_content)
-            if ok:
-                console.print(f"  [success]Rule '{name}' updated.[/success]")
-                from core.hooks import HookEvent
-
-                _fire_hook(HookEvent.RULE_UPDATED, {"name": name})
-            else:
-                console.print(f"  [warning]Failed to update rule '{name}'.[/warning]")
-            console.print()
-        elif rule_action == "delete":
-            name = args.get("name", "")
-            if not name:
-                console.print("  [warning]Rule name is required.[/warning]")
-                return
-            ok = mem.delete_rule(name)
-            if ok:
-                console.print(f"  [success]Rule '{name}' deleted.[/success]")
-                from core.hooks import HookEvent
-
-                _fire_hook(HookEvent.RULE_DELETED, {"name": name})
-            else:
-                console.print(f"  [warning]Rule '{name}' not found.[/warning]")
-            console.print()
-
-    elif query:
-        # memory_search tool
-        from core.tools.memory_tools import MemorySearchTool
-
-        search_tool = MemorySearchTool()
-        tier = args.get("tier", "all")
-        search_result = search_tool.execute(query=query, tier=tier)
-        matches = search_result.get("result", {}).get("matches", [])
-        console.print()
-        console.print(f"  [header]Memory Search: '{query}'[/header]")
-        if not matches:
-            console.print("  [muted]No matches found.[/muted]")
-        for m in matches:
-            tier_label = m.get("tier", "?")
-            source = m.get("source", m.get("session_id", ""))
-            console.print(f"  - [{tier_label}] {source}")
-            if "matching_lines" in m:
-                for line in m["matching_lines"][:3]:
-                    console.print(f"    [muted]{line}[/muted]")
-            if "preview" in m:
-                console.print(f"    [muted]{m['preview'][:80]}...[/muted]")
-        console.print()
-
-    elif key and content:
-        # memory_save tool
-        from core.tools.memory_tools import MemorySaveTool
-
-        save_tool = MemorySaveTool()
-        save_result = save_tool.execute(
-            session_id=key,
-            data={"content": content},
-            persistent=True,
-        )
-        saved = save_result.get("result", {}).get("saved", False)
-        if saved:
-            console.print(f"  [success]Saved to memory: '{key}'[/success]")
-            from core.hooks import HookEvent
-
-            _fire_hook(HookEvent.MEMORY_SAVED, {"key": key})
-        else:
-            console.print("  [warning]Failed to save to memory.[/warning]")
-        console.print()
-
-    else:
-        console.print()
-        console.print("  [muted]Memory command not recognized. Try:[/muted]")
-        console.print("  [muted]  '이전 분석 결과 검색해' — search memory[/muted]")
-        console.print("  [muted]  '규칙 목록 보여줘' — list rules[/muted]")
-        console.print("  [muted]  '이 결과 기억해' — save to memory[/muted]")
-        console.print()
+    handle_memory_action(intent, user_text, is_offline, fire_hook=_fire_hook)
 
 
 def _restore_terminal() -> None:
-    """Restore terminal to sane cooked mode.
+    """Restore terminal to sane cooked mode. Delegates to terminal module."""
+    from core.cli.terminal import restore_terminal
 
-    Rich Status/Live can leave the terminal in raw mode (echo off, no
-    line-editing) if interrupted or if an exception escapes their context
-    manager.  This ensures the terminal is usable before reading input.
-    """
-    try:
-        fd = sys.stdin.fileno()
-        attrs = termios.tcgetattr(fd)
-        # Ensure ECHO and ICANON (cooked mode) are enabled
-        attrs[3] |= termios.ECHO | termios.ICANON
-        termios.tcsetattr(fd, termios.TCSANOW, attrs)
-    except (ValueError, OSError, termios.error):
-        # Non-TTY or stdin not available — nothing to restore
-        pass
+    restore_terminal()
 
 
 _original_sigint = signal.getsignal(signal.SIGINT)
@@ -838,25 +602,10 @@ def _get_prompt_session() -> Any:
 
 
 def _drain_stdin() -> None:
-    """Drain leftover bytes from stdin after a paste.
+    """Drain leftover bytes from stdin. Delegates to terminal module."""
+    from core.cli.terminal import drain_stdin
 
-    When bracketed paste is unavailable, pasted newlines trigger Enter
-    and only the first line is submitted. The remaining text stays in
-    stdin and gets auto-submitted on the next prompt() call.
-    This drains any such leftover to prevent double-submit.
-    """
-    import select
-
-    if not sys.stdin.isatty():
-        return
-    try:
-        import os as _os
-
-        fd = sys.stdin.fileno()
-        while select.select([fd], [], [], 0.0)[0]:
-            _os.read(fd, 4096)
-    except (ValueError, OSError):
-        pass
+    drain_stdin()
 
 
 def _read_multiline_input(prompt: str) -> str:

--- a/core/cli/memory_handler.py
+++ b/core/cli/memory_handler.py
@@ -1,0 +1,165 @@
+"""CLI memory action handler — extracted from cli/__init__.py for SRP.
+
+Handles memory-related slash commands: rule CRUD, memory search, memory save.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from rich.console import Console
+
+from core.hooks.system import HookEvent
+
+log = logging.getLogger(__name__)
+console = Console()
+
+
+def handle_memory_action(
+    intent: Any,
+    user_text: str,
+    is_offline: bool,
+    *,
+    fire_hook: Any = None,
+) -> None:
+    """Handle memory-related actions (P0-A + P1-B).
+
+    Accepts either an object with an `args` dict attribute, or a plain dict.
+
+    Args:
+        intent: Routing intent with args dict or a plain dict.
+        user_text: Original user input text.
+        is_offline: Whether running in offline mode.
+        fire_hook: Callable(event, data) to fire hook events.
+    """
+    args = intent if isinstance(intent, dict) else intent.args
+
+    # Determine sub-action from tool routing
+    rule_action = args.get("rule_action")
+    query = args.get("query")
+    key = args.get("key")
+    content = args.get("content")
+
+    if rule_action:
+        _handle_rule_action(rule_action, args, content, fire_hook)
+    elif query:
+        _handle_memory_search(query, args)
+    elif key and content:
+        _handle_memory_save(key, content, fire_hook)
+    else:
+        console.print()
+        console.print("  [muted]Memory command not recognized. Try:[/muted]")
+        console.print("  [muted]  '이전 분석 결과 검색해' — search memory[/muted]")
+        console.print("  [muted]  '규칙 목록 보여줘' — list rules[/muted]")
+        console.print("  [muted]  '이 결과 기억해' — save to memory[/muted]")
+        console.print()
+
+
+def _handle_rule_action(
+    rule_action: str,
+    args: dict[str, Any],
+    content: str | None,
+    fire_hook: Any,
+) -> None:
+    from core.memory.project import ProjectMemory
+
+    mem = ProjectMemory()
+    if rule_action == "list":
+        rules = mem.list_rules()
+        console.print()
+        console.print("  [header]Active Analysis Rules[/header]")
+        if not rules:
+            console.print("  [muted]No rules found.[/muted]")
+        for r in rules:
+            paths_str = ", ".join(r.get("paths", []))
+            console.print(f"  - [value]{r['name']}[/value] ({paths_str})")
+            if r.get("preview"):
+                console.print(f"    [muted]{r['preview'][:80]}...[/muted]")
+        console.print()
+    elif rule_action == "create":
+        name = args.get("name", "")
+        paths = args.get("paths", [])
+        rule_content = content or ""
+        if not name:
+            console.print("  [warning]Rule name is required.[/warning]")
+            return
+        ok = mem.create_rule(name, paths, rule_content)
+        if ok:
+            console.print(f"  [success]Rule '{name}' created.[/success]")
+            if fire_hook:
+                fire_hook(HookEvent.RULE_CREATED, {"name": name, "paths": paths})
+        else:
+            console.print(
+                f"  [warning]Failed to create rule '{name}' (may already exist).[/warning]"
+            )
+        console.print()
+    elif rule_action == "update":
+        name = args.get("name", "")
+        rule_content = content or ""
+        if not name:
+            console.print("  [warning]Rule name is required.[/warning]")
+            return
+        ok = mem.update_rule(name, rule_content)
+        if ok:
+            console.print(f"  [success]Rule '{name}' updated.[/success]")
+            if fire_hook:
+                fire_hook(HookEvent.RULE_UPDATED, {"name": name})
+        else:
+            console.print(f"  [warning]Failed to update rule '{name}'.[/warning]")
+        console.print()
+    elif rule_action == "delete":
+        name = args.get("name", "")
+        if not name:
+            console.print("  [warning]Rule name is required.[/warning]")
+            return
+        ok = mem.delete_rule(name)
+        if ok:
+            console.print(f"  [success]Rule '{name}' deleted.[/success]")
+            if fire_hook:
+                fire_hook(HookEvent.RULE_DELETED, {"name": name})
+        else:
+            console.print(f"  [warning]Rule '{name}' not found.[/warning]")
+        console.print()
+
+
+def _handle_memory_search(query: str, args: dict[str, Any]) -> None:
+    from core.tools.memory_tools import MemorySearchTool
+
+    search_tool = MemorySearchTool()
+    tier = args.get("tier", "all")
+    search_result = search_tool.execute(query=query, tier=tier)
+    matches = search_result.get("result", {}).get("matches", [])
+    console.print()
+    console.print(f"  [header]Memory Search: '{query}'[/header]")
+    if not matches:
+        console.print("  [muted]No matches found.[/muted]")
+    for m in matches:
+        tier_label = m.get("tier", "?")
+        source = m.get("source", m.get("session_id", ""))
+        console.print(f"  - [{tier_label}] {source}")
+        if "matching_lines" in m:
+            for line in m["matching_lines"][:3]:
+                console.print(f"    [muted]{line}[/muted]")
+        if "preview" in m:
+            console.print(f"    [muted]{m['preview'][:80]}...[/muted]")
+    console.print()
+
+
+def _handle_memory_save(key: str, content: str, fire_hook: Any) -> None:
+    from core.tools.memory_tools import MemorySaveTool
+
+    save_tool = MemorySaveTool()
+    save_result = save_tool.execute(
+        session_id=key,
+        data={"content": content},
+        persistent=True,
+    )
+    saved = save_result.get("result", {}).get("saved", False)
+    if saved:
+        console.print(f"  [success]Saved to memory: '{key}'[/success]")
+        if fire_hook:
+            fire_hook(HookEvent.MEMORY_SAVED, {"key": key})
+    else:
+        console.print("  [warning]Failed to save to memory.[/warning]")
+    console.print()

--- a/core/cli/scheduler_drain.py
+++ b/core/cli/scheduler_drain.py
@@ -1,0 +1,134 @@
+"""Scheduler queue drain — extracted from cli/__init__.py for SRP.
+
+Drains pending scheduled jobs from the action queue, shared by REPL and serve modes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.agent.conversation import ConversationContext
+
+log = logging.getLogger(__name__)
+
+
+def drain_scheduler_queue(
+    *,
+    action_queue: Any,
+    services: Any,
+    runner: Any,
+    session_lane: Any,
+    global_lane: Any,
+    force_isolated: bool = False,
+    main_loop: Any | None = None,
+    on_complete: Any | None = None,
+    on_dispatch: Any | None = None,
+    on_skip: Any | None = None,
+    on_main_run: Any | None = None,
+) -> int:
+    """Drain pending scheduled jobs from the action queue.
+
+    Shared by both REPL and serve modes.  In serve mode ``force_isolated``
+    is True because there is no interactive main session to inject into.
+
+    Uses SessionLane (per-key serial) + Global Lane (capacity) for
+    concurrency control through the unified LaneQueue.
+
+    Returns the number of jobs drained.
+    """
+    import queue as _q
+
+    from core.orchestration.isolated_execution import IsolationConfig
+
+    count = 0
+    try:
+        while True:
+            job_id, fired_action, isolated = action_queue.get_nowait()
+            if not fired_action:
+                continue
+            count += 1
+            prompt = f"[scheduled-job:{job_id}] {fired_action}"
+
+            if isolated or force_isolated:
+                lane_key = f"sched:{job_id}"
+
+                # Dual acquire: session (per-key serial) + global (capacity)
+                if not session_lane.try_acquire(lane_key):
+                    log.warning("Session key busy, skipping job %s", job_id)
+                    if on_skip:
+                        on_skip(job_id)
+                    continue
+
+                if not global_lane.try_acquire(lane_key):
+                    session_lane.manual_release(lane_key)
+                    log.warning("Global lane full, skipping job %s", job_id)
+                    if on_skip:
+                        on_skip(job_id)
+                    continue
+
+                _lanes_acquired = True
+                try:
+                    _iso_conv = ConversationContext()
+                    from core.gateway.shared_services import SessionMode
+
+                    _, _iso_loop = services.create_session(
+                        SessionMode.SCHEDULER,
+                        conversation=_iso_conv,
+                        propagate_context=True,
+                    )
+                    _cap_loop = _iso_loop
+                    _cap_prompt = prompt
+                    _cap_jid = job_id
+                    _cap_sess = session_lane
+                    _cap_glob = global_lane
+                    _cap_key = lane_key
+                    _cap_cb = on_complete
+
+                    def _run_isolated(
+                        *,
+                        _loop: Any = _cap_loop,
+                        _p: str = _cap_prompt,
+                        _jid: str = _cap_jid,
+                        _sess: Any = _cap_sess,
+                        _glob: Any = _cap_glob,
+                        _key: str = _cap_key,
+                        _cb: Any = _cap_cb,
+                    ) -> str:
+                        try:
+                            r = _loop.run(_p)
+                            if _cb:
+                                _cb(r, job_id=_jid)
+                            return r.text if r and r.text else ""
+                        finally:
+                            _glob.manual_release(_key)
+                            _sess.manual_release(_key)
+
+                    runner.run_async(
+                        _run_isolated,
+                        config=IsolationConfig(
+                            prefix=f"scheduled:{job_id}",
+                            post_to_main=False,
+                            timeout_s=300.0,
+                        ),
+                    )
+                    _lanes_acquired = False  # ownership transferred to _run_isolated
+                    if on_dispatch:
+                        on_dispatch(job_id)
+                except Exception:
+                    if _lanes_acquired:
+                        global_lane.manual_release(lane_key)
+                        session_lane.manual_release(lane_key)
+                    log.warning("Scheduler job %s dispatch failed", job_id, exc_info=True)
+            else:
+                # Non-isolated: inject into main session (REPL only)
+                if main_loop is not None:
+                    if on_main_run:
+                        on_main_run(job_id)
+                    try:
+                        main_loop.run(prompt)
+                    except Exception:
+                        log.warning("Scheduler job %s main-loop failed", job_id, exc_info=True)
+    except _q.Empty:
+        pass
+    return count

--- a/core/cli/terminal.py
+++ b/core/cli/terminal.py
@@ -1,0 +1,82 @@
+"""Terminal utilities — extracted from cli/__init__.py for SRP.
+
+Functions for terminal state management: restore cooked mode, suppress warnings,
+drain leftover stdin bytes, SIGINT handling.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import termios
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def restore_terminal() -> None:
+    """Restore terminal to sane cooked mode.
+
+    Rich Status/Live can leave the terminal in raw mode (echo off, no
+    line-editing) if interrupted or if an exception escapes their context
+    manager.  This ensures the terminal is usable before reading input.
+    """
+    try:
+        fd = sys.stdin.fileno()
+        attrs = termios.tcgetattr(fd)
+        # Ensure ECHO and ICANON (cooked mode) are enabled
+        attrs[3] |= termios.ECHO | termios.ICANON
+        termios.tcsetattr(fd, termios.TCSANOW, attrs)
+    except (ValueError, OSError, termios.error):
+        # Non-TTY or stdin not available — nothing to restore
+        pass
+
+
+def make_sigint_handler() -> Any:
+    """Create a SIGINT handler that restores terminal before raising."""
+
+    def _sigint_handler(signum: int, frame: Any) -> None:
+        restore_terminal()
+        raise KeyboardInterrupt
+
+    return _sigint_handler
+
+
+def suppress_noisy_warnings() -> None:
+    """Suppress known noisy warnings from dependencies."""
+    import warnings
+
+    # Pydantic V1 deprecation from langchain_core on Python 3.14+
+    warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")
+    # LangGraph msgpack deserialization warning (warnings.warn path)
+    warnings.filterwarnings("ignore", message="Deserializing unregistered type")
+
+    # LangGraph checkpoint deserialization also logs via logging.warning —
+    # suppress those at the logging level.
+    for noisy_logger in (
+        "langgraph.checkpoint.serde.jsonplus",
+        "langgraph.checkpoint.serde.base",
+    ):
+        logging.getLogger(noisy_logger).setLevel(logging.ERROR)
+
+
+def drain_stdin() -> None:
+    """Drain leftover bytes from stdin after a paste.
+
+    When bracketed paste is unavailable, pasted newlines trigger Enter
+    and only the first line is submitted. The remaining text stays in
+    stdin and gets auto-submitted on the next prompt() call.
+    This drains any such leftover to prevent double-submit.
+    """
+    import select
+
+    if not sys.stdin.isatty():
+        return
+    try:
+        import os as _os
+
+        fd = sys.stdin.fileno()
+        while select.select([fd], [], [], 0.0)[0]:
+            _os.read(fd, 4096)
+    except (ValueError, OSError):
+        pass

--- a/core/domains/game_ip/nodes/signals.py
+++ b/core/domains/game_ip/nodes/signals.py
@@ -38,6 +38,11 @@ def set_signal_adapter(adapter: SignalEnrichmentPort | None) -> None:
     _signal_adapter_ctx.set(adapter)
 
 
+def get_signal_adapter() -> SignalEnrichmentPort | None:
+    """Retrieve the currently injected signal adapter."""
+    return _signal_adapter_ctx.get()
+
+
 def _fetch_web_signals(ip_name: str) -> dict[str, Any]:
     """Last-resort: web search for signal data on unknown IPs.
 
@@ -95,7 +100,7 @@ def signals_node(state: GeodeState) -> dict[str, Any]:
         live_signals: dict[str, Any] = {}
 
         # 1. Try injected MCP adapter first (CompositeSignalAdapter in production)
-        adapter = _signal_adapter_ctx.get()
+        adapter = get_signal_adapter()
         if adapter is not None and adapter.is_available():
             try:
                 live_signals = adapter.fetch_signals(ip_name)

--- a/core/hooks/auto_learn.py
+++ b/core/hooks/auto_learn.py
@@ -167,8 +167,15 @@ def detect_patterns(
 # ---------------------------------------------------------------------------
 
 
-def make_auto_learn_handler() -> tuple[str, Callable[..., None]]:
+def make_auto_learn_handler(
+    profile_provider: Callable[[], Any] | None = None,
+) -> tuple[str, Callable[..., None]]:
     """Create a TURN_COMPLETE handler that auto-learns user patterns.
+
+    Args:
+        profile_provider: Callable returning the current user profile.
+            Injected at registration to avoid L6→L5 layer violation.
+            Falls back to lazy import if not provided (backwards compat).
 
     Returns (handler_name, handler_fn) for hook registration.
     """
@@ -177,15 +184,21 @@ def make_auto_learn_handler() -> tuple[str, Callable[..., None]]:
     last_learn_ts = 0.0
     tool_counter: Counter[str] = Counter()
 
+    def _get_profile() -> Any:
+        if profile_provider is not None:
+            return profile_provider()
+        # Fallback for backwards compat (tests that don't inject)
+        from core.tools.profile_tools import get_user_profile
+
+        return get_user_profile()
+
     def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
         nonlocal session_count, last_learn_ts
 
         if session_count >= _MAX_PER_SESSION:
             return
 
-        from core.tools.profile_tools import get_user_profile
-
-        profile = get_user_profile()
+        profile = _get_profile()
         if profile is None:
             return
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -239,9 +239,12 @@ class GeodeRuntime:
 
         # Stage 1: Core sub-systems
         core = cls._build_core(
-            bootstrap, infra,
-            session_key=session_key, run_id=run_id,
-            log_dir=log_dir, session_ttl=session_ttl,
+            bootstrap,
+            infra,
+            session_key=session_key,
+            run_id=run_id,
+            log_dir=log_dir,
+            session_ttl=session_ttl,
             stuck_timeout_s=stuck_timeout_s,
         )
 
@@ -250,14 +253,19 @@ class GeodeRuntime:
 
         # Stage 3: Memory + Automation
         memory, automation = cls._build_memory_and_automation(
-            bootstrap, core["hooks"], core["session_store"],
-            session_key=session_key, ip_name=ip_name,
+            bootstrap,
+            core["hooks"],
+            core["session_store"],
+            session_key=session_key,
+            ip_name=ip_name,
         )
 
         log.info(
             "GeodeRuntime created: ip=%s, key=%s, tools=%d, lanes=%s",
-            ip_name, session_key,
-            len(core["tool_registry"]), core["lane_queue"].list_lanes(),
+            ip_name,
+            session_key,
+            len(core["tool_registry"]),
+            core["lane_queue"].list_lanes(),
         )
 
         # Stage 4: Assembly
@@ -307,20 +315,24 @@ class GeodeRuntime:
     ) -> dict[str, Any]:
         """Stage 1: Build core infrastructure (hooks, auth, LLM, lanes)."""
         hooks, run_log, stuck_detector, _session_metrics = bootstrap.build_hooks(
-            session_key=session_key, run_id=run_id,
-            log_dir=log_dir, stuck_timeout_s=stuck_timeout_s,
+            session_key=session_key,
+            run_id=run_id,
+            log_dir=log_dir,
+            stuck_timeout_s=stuck_timeout_s,
         )
         session_store = bootstrap.build_session_store(session_ttl=session_ttl)
         policy_chain = infra.build_default_policies()
         tool_registry = infra.build_default_registry()
         profile_store, profile_rotator, cooldown_tracker = infra.build_auth()
         llm_adapter, secondary_adapter = infra.build_llm_adapters(
-            tool_registry, policy_chain,
+            tool_registry,
+            policy_chain,
         )
         config_watcher = bootstrap.build_config_watcher(hooks=hooks)
         lane_queue = infra.build_default_lanes()
         return {
-            "hooks": hooks, "run_log": run_log,
+            "hooks": hooks,
+            "run_log": run_log,
             "stuck_detector": stuck_detector,
             "session_store": session_store,
             "policy_chain": policy_chain,
@@ -371,13 +383,17 @@ class GeodeRuntime:
         from core.runtime_wiring import automation as automation_wiring
 
         (
-            project_memory, organization_memory,
-            context_assembler, _user_profile,
+            project_memory,
+            organization_memory,
+            context_assembler,
+            _user_profile,
         ) = bootstrap.build_memory(session_store=session_store, hooks=hooks)
 
         automation = automation_wiring.build_automation(
-            hooks=hooks, session_key=session_key,
-            ip_name=ip_name, project_memory=project_memory,
+            hooks=hooks,
+            session_key=session_key,
+            ip_name=ip_name,
+            project_memory=project_memory,
         )
 
         try:
@@ -386,7 +402,8 @@ class GeodeRuntime:
             log.debug("ADR-007 prompt_assembler not yet available — skipping")
             prompt_assembler = None
         task_graph, task_bridge = bootstrap.build_task_graph(
-            hooks=hooks, ip_name=ip_name,
+            hooks=hooks,
+            ip_name=ip_name,
         )
 
         memory = {

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -223,115 +223,181 @@ class GeodeRuntime:
     ) -> GeodeRuntime:
         """Factory method — create a fully wired runtime for an IP analysis.
 
-        Delegates to sub-modules in core.runtime_wiring:
-        - bootstrap: hooks, session, memory, config_watcher, task_graph, prompt
-        - infra: policies, tools, LLM, auth, lanes
-        - automation: L4.5 9 components + hook wiring
-        - adapters: MCP signal/notification/calendar/gateway
+        Staged initialization (Claude Code entrypoints/init.ts pattern):
+        1. _build_core: domain, sessions, hooks, config, auth, LLM, lanes
+        2. _build_tools: MCP, skills, readiness, plugins, tool offload
+        3. _build_memory: project/org memory, context assembler, automation
+        4. Assembly: pack configs, create instance, attach optional components
         """
-        from core.runtime_wiring import adapters as adapter_wiring
-        from core.runtime_wiring import automation as automation_wiring
         from core.runtime_wiring import bootstrap, infra
 
-        # Domain adapter — wire before anything that reads domain config
+        # Stage 0: Domain + session identity
         domain = load_domain_adapter(domain_name)
         set_domain(domain)
-
-        # Session key + run ID
         session_key = build_session_key(ip_name, phase)
         run_id = uuid.uuid4().hex[:12]
 
-        # Core sub-systems
-        hooks, run_log, stuck_detector, session_metrics = bootstrap.build_hooks(
-            session_key=session_key,
-            run_id=run_id,
-            log_dir=log_dir,
+        # Stage 1: Core sub-systems
+        core = cls._build_core(
+            bootstrap, infra,
+            session_key=session_key, run_id=run_id,
+            log_dir=log_dir, session_ttl=session_ttl,
             stuck_timeout_s=stuck_timeout_s,
+        )
+
+        # Stage 2: Tools, MCP, Skills
+        tools = cls._build_tools(bootstrap, core["hooks"], session_key=session_key)
+
+        # Stage 3: Memory + Automation
+        memory, automation = cls._build_memory_and_automation(
+            bootstrap, core["hooks"], core["session_store"],
+            session_key=session_key, ip_name=ip_name,
+        )
+
+        log.info(
+            "GeodeRuntime created: ip=%s, key=%s, tools=%d, lanes=%s",
+            ip_name, session_key,
+            len(core["tool_registry"]), core["lane_queue"].list_lanes(),
+        )
+
+        # Stage 4: Assembly
+        core_config = RuntimeCoreConfig(
+            hooks=core["hooks"],
+            session_store=core["session_store"],
+            policy_chain=core["policy_chain"],
+            tool_registry=core["tool_registry"],
+            run_log=core["run_log"],
+            llm_adapter=core["llm_adapter"],
+            config_watcher=core["config_watcher"],
+            stuck_detector=core["stuck_detector"],
+            lane_queue=core["lane_queue"],
+            project_memory=memory["project_memory"],
+            session_key=session_key,
+            ip_name=ip_name,
+            secondary_adapter=core["secondary_adapter"],
+            profile_store=core["profile_store"],
+            profile_rotator=core["profile_rotator"],
+            cooldown_tracker=core["cooldown_tracker"],
+            mcp_manager=tools["mcp_manager"],
+            skill_registry=tools["skill_registry"],
+            readiness=tools["readiness"],
+        )
+        automation_config = RuntimeAutomationConfig(**automation)
+        memory_config = RuntimeMemoryConfig(
+            organization_memory=memory["organization_memory"],
+            context_assembler=memory["context_assembler"],
+            prompt_assembler=memory["prompt_assembler"],
+        )
+        instance = cls(core_config, automation_config, memory_config)
+        instance.run_id = run_id
+        instance.task_graph = memory["task_graph"]
+        instance._task_bridge = memory["task_bridge"]
+        return instance
+
+    @staticmethod
+    def _build_core(
+        bootstrap: Any,
+        infra: Any,
+        *,
+        session_key: str,
+        run_id: str,
+        log_dir: Path | str | None,
+        session_ttl: float,
+        stuck_timeout_s: float,
+    ) -> dict[str, Any]:
+        """Stage 1: Build core infrastructure (hooks, auth, LLM, lanes)."""
+        hooks, run_log, stuck_detector, _session_metrics = bootstrap.build_hooks(
+            session_key=session_key, run_id=run_id,
+            log_dir=log_dir, stuck_timeout_s=stuck_timeout_s,
         )
         session_store = bootstrap.build_session_store(session_ttl=session_ttl)
         policy_chain = infra.build_default_policies()
         tool_registry = infra.build_default_registry()
         profile_store, profile_rotator, cooldown_tracker = infra.build_auth()
-        llm_adapter, secondary_adapter = infra.build_llm_adapters(tool_registry, policy_chain)
+        llm_adapter, secondary_adapter = infra.build_llm_adapters(
+            tool_registry, policy_chain,
+        )
         config_watcher = bootstrap.build_config_watcher(hooks=hooks)
         lane_queue = infra.build_default_lanes()
+        return {
+            "hooks": hooks, "run_log": run_log,
+            "stuck_detector": stuck_detector,
+            "session_store": session_store,
+            "policy_chain": policy_chain,
+            "tool_registry": tool_registry,
+            "profile_store": profile_store,
+            "profile_rotator": profile_rotator,
+            "cooldown_tracker": cooldown_tracker,
+            "llm_adapter": llm_adapter,
+            "secondary_adapter": secondary_adapter,
+            "config_watcher": config_watcher,
+            "lane_queue": lane_queue,
+        }
 
-        # Unified bootstrap: MCP, Skills, Readiness
+    @staticmethod
+    def _build_tools(
+        bootstrap: Any,
+        hooks: Any,
+        *,
+        session_key: str,
+    ) -> dict[str, Any]:
+        """Stage 2: Build MCP, skills, readiness, plugins, tool offload."""
+        from core.runtime_wiring import adapters as adapter_wiring
+
         mcp_manager = bootstrap.build_mcp_manager()
         from core.mcp.manager import set_mcp_hooks
 
         set_mcp_hooks(hooks)
         skill_registry = bootstrap.build_skill_registry()
         readiness = bootstrap.build_readiness()
-
-        # P0: Tool result offloading
         bootstrap.build_tool_offload(session_id=session_key, hooks=hooks)
-
-        # Plugin wiring (MCP adapters + Gateway)
         adapter_wiring.build_plugins()
+        return {
+            "mcp_manager": mcp_manager,
+            "skill_registry": skill_registry,
+            "readiness": readiness,
+        }
 
-        # Memory + Automation
+    @staticmethod
+    def _build_memory_and_automation(
+        bootstrap: Any,
+        hooks: Any,
+        session_store: Any,
+        *,
+        session_key: str,
+        ip_name: str,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Stage 3: Build memory, automation, and optional components."""
+        from core.runtime_wiring import automation as automation_wiring
+
         (
-            project_memory,
-            organization_memory,
-            context_assembler,
-            user_profile,
+            project_memory, organization_memory,
+            context_assembler, _user_profile,
         ) = bootstrap.build_memory(session_store=session_store, hooks=hooks)
+
         automation = automation_wiring.build_automation(
-            hooks=hooks,
-            session_key=session_key,
-            ip_name=ip_name,
-            project_memory=project_memory,
+            hooks=hooks, session_key=session_key,
+            ip_name=ip_name, project_memory=project_memory,
         )
 
-        # Optional components
         try:
             prompt_assembler = bootstrap.build_prompt_assembler(hooks=hooks)
         except ImportError:
-            log.debug("ADR-007 prompt_assembler/skill_registry not yet available — skipping")
+            log.debug("ADR-007 prompt_assembler not yet available — skipping")
             prompt_assembler = None
-        task_graph, task_bridge = bootstrap.build_task_graph(hooks=hooks, ip_name=ip_name)
-
-        log.info(
-            "GeodeRuntime created: ip=%s, key=%s, tools=%d, lanes=%s",
-            ip_name,
-            session_key,
-            len(tool_registry),
-            lane_queue.list_lanes(),
+        task_graph, task_bridge = bootstrap.build_task_graph(
+            hooks=hooks, ip_name=ip_name,
         )
 
-        core_config = RuntimeCoreConfig(
-            hooks=hooks,
-            session_store=session_store,
-            policy_chain=policy_chain,
-            tool_registry=tool_registry,
-            run_log=run_log,
-            llm_adapter=llm_adapter,
-            config_watcher=config_watcher,
-            stuck_detector=stuck_detector,
-            lane_queue=lane_queue,
-            project_memory=project_memory,
-            session_key=session_key,
-            ip_name=ip_name,
-            secondary_adapter=secondary_adapter,
-            profile_store=profile_store,
-            profile_rotator=profile_rotator,
-            cooldown_tracker=cooldown_tracker,
-            mcp_manager=mcp_manager,
-            skill_registry=skill_registry,
-            readiness=readiness,
-        )
-        automation_config = RuntimeAutomationConfig(**automation)
-        memory_config = RuntimeMemoryConfig(
-            organization_memory=organization_memory,
-            context_assembler=context_assembler,
-            prompt_assembler=prompt_assembler,
-        )
-        instance = cls(core_config, automation_config, memory_config)
-        instance.run_id = run_id
-        instance.task_graph = task_graph
-        instance._task_bridge = task_bridge
-        return instance
+        memory = {
+            "project_memory": project_memory,
+            "organization_memory": organization_memory,
+            "context_assembler": context_assembler,
+            "prompt_assembler": prompt_assembler,
+            "task_graph": task_graph,
+            "task_bridge": task_bridge,
+        }
+        return memory, automation
 
     # ------------------------------------------------------------------
     # Properties

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -220,8 +220,9 @@ def build_hooks(
     # C3b: Auto-learn user patterns on turn complete (Tier 0.5 cross-session memory)
     def _reg_auto_learn() -> None:
         from core.hooks.auto_learn import make_auto_learn_handler
+        from core.tools.profile_tools import get_user_profile
 
-        name, handler = make_auto_learn_handler()
+        name, handler = make_auto_learn_handler(profile_provider=get_user_profile)
         hooks.register(
             HookEvent.TURN_COMPLETE,
             handler,

--- a/tests/test_autonomous_safety.py
+++ b/tests/test_autonomous_safety.py
@@ -154,25 +154,25 @@ class TestConvergenceEscalation:
         loop = AgenticLoop(context, executor)
 
         # Simulate 3 identical errors
-        loop._recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
+        loop._convergence.recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
 
         with patch.object(loop, "_try_model_escalation", return_value=True) as mock_escalate:
             result = loop._check_convergence_break()
 
         assert result is False  # Should NOT break (escalation succeeded)
         mock_escalate.assert_called_once()
-        assert loop._convergence_escalated is True
-        assert loop._recent_errors == []  # Cleared after escalation
+        assert loop._convergence.convergence_escalated is True
+        assert loop._convergence.recent_errors == []  # Cleared after escalation
 
     def test_convergence_breaks_after_failed_escalation(
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """If escalation fails and 4 identical errors persist, should break."""
         loop = AgenticLoop(context, executor)
-        loop._convergence_escalated = True  # Already tried escalation
+        loop._convergence.convergence_escalated = True  # Already tried escalation
 
         # 4 identical errors post-escalation
-        loop._recent_errors = [
+        loop._convergence.recent_errors = [
             "web_search:timeout",
             "web_search:timeout",
             "web_search:timeout",
@@ -187,7 +187,7 @@ class TestConvergenceEscalation:
     ) -> None:
         """If no fallback model is available, escalation returns False."""
         loop = AgenticLoop(context, executor)
-        loop._recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
+        loop._convergence.recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
 
         with patch.object(loop, "_try_model_escalation", return_value=False):
             # First call: tries escalation, fails, then checks for 4+
@@ -195,16 +195,16 @@ class TestConvergenceEscalation:
 
         # Only 3 errors, escalation failed — doesn't break yet (needs 4)
         assert result is False
-        assert loop._convergence_escalated is True
+        assert loop._convergence.convergence_escalated is True
 
     def test_convergence_3_errors_post_escalation_warns_no_break(
         self, context: ConversationContext, executor: ToolExecutor
     ) -> None:
         """After escalation, 3 identical errors should warn but not break."""
         loop = AgenticLoop(context, executor)
-        loop._convergence_escalated = True
+        loop._convergence.convergence_escalated = True
 
-        loop._recent_errors = [
+        loop._convergence.recent_errors = [
             "web_search:timeout",
             "web_search:timeout",
             "web_search:timeout",
@@ -218,7 +218,7 @@ class TestConvergenceEscalation:
     ) -> None:
         """_convergence_escalated should start as False."""
         loop = AgenticLoop(context, executor)
-        assert loop._convergence_escalated is False
+        assert loop._convergence.convergence_escalated is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_autonomous_safety.py
+++ b/tests/test_autonomous_safety.py
@@ -154,7 +154,11 @@ class TestConvergenceEscalation:
         loop = AgenticLoop(context, executor)
 
         # Simulate 3 identical errors
-        loop._convergence.recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
+        loop._convergence.recent_errors = [
+            "web_search:timeout",
+            "web_search:timeout",
+            "web_search:timeout",
+        ]
 
         with patch.object(loop, "_try_model_escalation", return_value=True) as mock_escalate:
             result = loop._check_convergence_break()
@@ -187,7 +191,11 @@ class TestConvergenceEscalation:
     ) -> None:
         """If no fallback model is available, escalation returns False."""
         loop = AgenticLoop(context, executor)
-        loop._convergence.recent_errors = ["web_search:timeout", "web_search:timeout", "web_search:timeout"]
+        loop._convergence.recent_errors = [
+            "web_search:timeout",
+            "web_search:timeout",
+            "web_search:timeout",
+        ]
 
         with patch.object(loop, "_try_model_escalation", return_value=False):
             # First call: tries escalation, fails, then checks for 4+

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -46,7 +46,7 @@ class TestBackpressure:
 
     def test_backpressure_fields_initialized(self) -> None:
         loop = _make_loop()
-        assert loop._total_consecutive_tool_errors == 0
+        assert loop._convergence.total_consecutive_tool_errors == 0
 
     def test_update_tool_error_tracking_counts_errors(self) -> None:
         """All-error round increments consecutive counter."""
@@ -63,12 +63,12 @@ class TestBackpressure:
             {"tool": "test_tool", "input": {}, "result": {"error": "Not found"}}
         )
         loop._update_tool_error_tracking(tool_results)
-        assert loop._total_consecutive_tool_errors == 1
+        assert loop._convergence.total_consecutive_tool_errors == 1
 
     def test_update_tool_error_tracking_resets_on_success(self) -> None:
         """Any success in a round resets the counter."""
         loop = _make_loop()
-        loop._total_consecutive_tool_errors = 5
+        loop._convergence.total_consecutive_tool_errors = 5
         tool_results = [
             {
                 "type": "tool_result",
@@ -77,12 +77,12 @@ class TestBackpressure:
             },
         ]
         loop._update_tool_error_tracking(tool_results)
-        assert loop._total_consecutive_tool_errors == 0
+        assert loop._convergence.total_consecutive_tool_errors == 0
 
     def test_update_tool_error_tracking_mixed_resets(self) -> None:
         """Mixed success+error in same round resets counter (success wins)."""
         loop = _make_loop()
-        loop._total_consecutive_tool_errors = 3
+        loop._convergence.total_consecutive_tool_errors = 3
         tool_results = [
             {
                 "type": "tool_result",
@@ -99,7 +99,7 @@ class TestBackpressure:
             {"tool": "test_tool", "input": {}, "result": {"error": "fail"}}
         )
         loop._update_tool_error_tracking(tool_results)
-        assert loop._total_consecutive_tool_errors == 0
+        assert loop._convergence.total_consecutive_tool_errors == 0
 
     def test_consecutive_errors_accumulate(self) -> None:
         """Multiple all-error rounds accumulate the counter."""
@@ -116,7 +116,7 @@ class TestBackpressure:
                 {"tool": "test_tool", "input": {}, "result": {"error": "timeout"}}
             )
             loop._update_tool_error_tracking(tool_results)
-        assert loop._total_consecutive_tool_errors == 4
+        assert loop._convergence.total_consecutive_tool_errors == 4
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +129,7 @@ class TestConvergenceDetection:
 
     def test_recent_errors_initialized_empty(self) -> None:
         loop = _make_loop()
-        assert loop._recent_errors == []
+        assert loop._convergence.recent_errors == []
 
     def test_check_convergence_no_errors(self) -> None:
         """No errors → no convergence."""
@@ -139,23 +139,23 @@ class TestConvergenceDetection:
     def test_check_convergence_few_errors(self) -> None:
         """Fewer than 3 errors → no convergence."""
         loop = _make_loop()
-        loop._recent_errors = ["tool_a:timeout", "tool_a:timeout"]
+        loop._convergence.recent_errors = ["tool_a:timeout", "tool_a:timeout"]
         assert loop._check_convergence_break() is False
 
     def test_check_convergence_3_identical_escalates(self) -> None:
         """3 identical errors → model escalation, errors cleared, no break."""
         loop = _make_loop()
-        loop._recent_errors = ["tool_a:timeout", "tool_a:timeout", "tool_a:timeout"]
+        loop._convergence.recent_errors = ["tool_a:timeout", "tool_a:timeout", "tool_a:timeout"]
         with patch.object(loop, "_try_model_escalation", return_value=True):
             assert loop._check_convergence_break() is False
-        assert loop._convergence_escalated is True
-        assert loop._recent_errors == []  # Cleared after escalation
+        assert loop._convergence.convergence_escalated is True
+        assert loop._convergence.recent_errors == []  # Cleared after escalation
 
     def test_check_convergence_4_identical_breaks_after_escalation(self) -> None:
         """4 identical errors after escalation already tried → force break."""
         loop = _make_loop()
-        loop._convergence_escalated = True  # Already escalated
-        loop._recent_errors = [
+        loop._convergence.convergence_escalated = True  # Already escalated
+        loop._convergence.recent_errors = [
             "tool_a:timeout",
             "tool_a:timeout",
             "tool_a:timeout",
@@ -166,8 +166,8 @@ class TestConvergenceDetection:
     def test_check_convergence_5_identical_breaks_after_escalation(self) -> None:
         """5+ identical errors after escalation already tried → force break."""
         loop = _make_loop()
-        loop._convergence_escalated = True  # Already escalated
-        loop._recent_errors = [
+        loop._convergence.convergence_escalated = True  # Already escalated
+        loop._convergence.recent_errors = [
             "tool_a:timeout",
             "tool_a:timeout",
             "tool_a:timeout",
@@ -179,7 +179,7 @@ class TestConvergenceDetection:
     def test_check_convergence_mixed_errors_no_break(self) -> None:
         """Different errors → no convergence."""
         loop = _make_loop()
-        loop._recent_errors = [
+        loop._convergence.recent_errors = [
             "tool_a:timeout",
             "tool_b:not_found",
             "tool_a:timeout",
@@ -190,7 +190,7 @@ class TestConvergenceDetection:
     def test_check_convergence_4_with_different_prefix_no_break(self) -> None:
         """4 errors where last 4 aren't all identical → no break."""
         loop = _make_loop()
-        loop._recent_errors = [
+        loop._convergence.recent_errors = [
             "tool_a:timeout",
             "tool_b:error",
             "tool_a:timeout",
@@ -213,7 +213,7 @@ class TestConvergenceDetection:
                 {"tool": f"tool_{i}", "input": {}, "result": {"error": f"error_{i}"}}
             )
             loop._update_tool_error_tracking(tool_results)
-        assert len(loop._recent_errors) <= 6
+        assert len(loop._convergence.recent_errors) <= 6
 
     def test_error_key_format(self) -> None:
         """Error keys follow 'tool_name:error_message' format."""
@@ -229,10 +229,10 @@ class TestConvergenceDetection:
             },
         ]
         loop._update_tool_error_tracking(tool_results)
-        assert len(loop._recent_errors) == 1
+        assert len(loop._convergence.recent_errors) == 1
         # Should contain tool name and error
-        assert "run_bash" in loop._recent_errors[0] or "unknown" in loop._recent_errors[0]
-        assert "command not found" in loop._recent_errors[0]
+        assert "run_bash" in loop._convergence.recent_errors[0] or "unknown" in loop._convergence.recent_errors[0]
+        assert "command not found" in loop._convergence.recent_errors[0]
 
     def test_arun_convergence_terminates_loop(self) -> None:
         """arun() terminates with convergence_detected when stuck."""
@@ -242,7 +242,7 @@ class TestConvergenceDetection:
         call_count = 0
 
         # Pre-populate with 3 identical errors (one more triggers break)
-        loop._recent_errors = [
+        loop._convergence.recent_errors = [
             "test_tool:always fails",
             "test_tool:always fails",
             "test_tool:always fails",

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -231,7 +231,10 @@ class TestConvergenceDetection:
         loop._update_tool_error_tracking(tool_results)
         assert len(loop._convergence.recent_errors) == 1
         # Should contain tool name and error
-        assert "run_bash" in loop._convergence.recent_errors[0] or "unknown" in loop._convergence.recent_errors[0]
+        assert (
+            "run_bash" in loop._convergence.recent_errors[0]
+            or "unknown" in loop._convergence.recent_errors[0]
+        )
         assert "command not found" in loop._convergence.recent_errors[0]
 
     def test_arun_convergence_terminates_loop(self) -> None:

--- a/tests/test_cli_extracted.py
+++ b/tests/test_cli_extracted.py
@@ -1,0 +1,73 @@
+"""Tests for CLI extracted modules — memory_handler, scheduler_drain, terminal."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestTerminal:
+    """Test terminal utility functions."""
+
+    def test_suppress_noisy_warnings(self) -> None:
+        from core.cli.terminal import suppress_noisy_warnings
+
+        # Should not raise
+        suppress_noisy_warnings()
+
+    def test_drain_stdin_non_tty(self) -> None:
+        from core.cli.terminal import drain_stdin
+
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            drain_stdin()  # Should return immediately
+
+    def test_restore_terminal_non_tty(self) -> None:
+        from core.cli.terminal import restore_terminal
+
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.fileno.side_effect = ValueError("not a tty")
+            restore_terminal()  # Should not raise
+
+    def test_make_sigint_handler(self) -> None:
+        from core.cli.terminal import make_sigint_handler
+
+        handler = make_sigint_handler()
+        assert callable(handler)
+
+
+class TestMemoryHandler:
+    """Test memory action handler."""
+
+    def test_unrecognized_action(self, capsys: object) -> None:
+        from core.cli.memory_handler import handle_memory_action
+
+        handle_memory_action(
+            {"query": None, "key": None, "content": None, "rule_action": None}, "", False
+        )
+        # Should print help text without raising
+
+    def test_rule_list_empty(self) -> None:
+        from core.cli.memory_handler import handle_memory_action
+
+        with patch("core.memory.project.ProjectMemory") as mock_pm:
+            mock_pm.return_value.list_rules.return_value = []
+            handle_memory_action({"rule_action": "list"}, "", False)
+
+
+class TestSchedulerDrain:
+    """Test scheduler drain function."""
+
+    def test_empty_queue(self) -> None:
+        import queue
+
+        from core.cli.scheduler_drain import drain_scheduler_queue
+
+        q: queue.Queue = queue.Queue()
+        result = drain_scheduler_queue(
+            action_queue=q,
+            services=MagicMock(),
+            runner=MagicMock(),
+            session_lane=MagicMock(),
+            global_lane=MagicMock(),
+        )
+        assert result == 0

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,122 @@
+"""Tests for ContextWindowManager — extracted from AgenticLoop."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent.context_manager import ContextWindowManager
+
+
+class TestContextWindowManager:
+    """Test context window management logic."""
+
+    def _make_mgr(self, *, quiet: bool = True) -> ContextWindowManager:
+        return ContextWindowManager(hooks=None, quiet=quiet)
+
+    # -- maybe_prune_messages --
+
+    def test_no_prune_under_threshold(self) -> None:
+        mgr = self._make_mgr()
+        msgs: list[dict[str, Any]] = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+        mgr.maybe_prune_messages(msgs)
+        assert len(msgs) == 10
+
+    def test_no_prune_at_threshold(self) -> None:
+        mgr = self._make_mgr()
+        msgs: list[dict[str, Any]] = [{"role": "user", "content": f"m{i}"} for i in range(30)]
+        mgr.maybe_prune_messages(msgs)
+        assert len(msgs) == 30
+
+    def test_prune_above_threshold(self) -> None:
+        mgr = self._make_mgr()
+        msgs: list[dict[str, Any]] = [{"role": "user", "content": "first"}]
+        for i in range(1, 32):
+            role = "assistant" if i % 2 else "user"
+            msgs.append({"role": role, "content": f"m{i}"})
+        mgr.maybe_prune_messages(msgs)
+        assert msgs[0]["content"] == "first"
+        assert "(earlier rounds omitted)" in str(msgs[1]["content"])
+
+    # -- repair_messages --
+
+    def test_repair_no_orphans(self) -> None:
+        msgs: list[dict[str, Any]] = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "t1", "name": "x", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+            },
+        ]
+        original_len = len(msgs)
+        ContextWindowManager.repair_messages(msgs)
+        assert len(msgs) == original_len
+
+    def test_repair_removes_orphan(self) -> None:
+        msgs: list[dict[str, Any]] = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t99", "content": "orphan"}],
+            },
+        ]
+        ContextWindowManager.repair_messages(msgs)
+        # Orphaned tool_result should be removed
+        assert len(msgs) < 3
+
+    # -- _notify_context_event --
+
+    def test_notify_quiet_mode_no_error(self) -> None:
+        """Quiet mode should not raise even with no UI available."""
+        mgr = self._make_mgr(quiet=True)
+        mgr._notify_context_event("prune", original_count=10, new_count=5)
+
+    # -- _resolve_overflow_strategy --
+
+    def test_resolve_strategy_anthropic_no_action(self) -> None:
+        """Anthropic below 95% should return 'none'."""
+
+        class FakeMetrics:
+            usage_pct = 60.0
+            context_window = 200_000
+
+        class FakeSettings:
+            compact_keep_recent = 8
+
+        mgr = self._make_mgr()
+        result = mgr._resolve_overflow_strategy(
+            FakeMetrics(), FakeSettings(), "claude-3", "anthropic"
+        )
+        assert result["strategy"] == "none"
+
+    def test_resolve_strategy_openai_compact(self) -> None:
+        """OpenAI at 85% should trigger compact."""
+
+        class FakeMetrics:
+            usage_pct = 85.0
+            context_window = 200_000
+
+        class FakeSettings:
+            compact_keep_recent = 8
+
+        mgr = self._make_mgr()
+        result = mgr._resolve_overflow_strategy(FakeMetrics(), FakeSettings(), "gpt-4o", "openai")
+        assert result["strategy"] == "compact"
+
+    def test_resolve_strategy_prune_at_95(self) -> None:
+        """Any provider at 95%+ should trigger prune."""
+
+        class FakeMetrics:
+            usage_pct = 96.0
+            context_window = 200_000
+
+        class FakeSettings:
+            compact_keep_recent = 8
+
+        mgr = self._make_mgr()
+        result = mgr._resolve_overflow_strategy(FakeMetrics(), FakeSettings(), "gpt-4o", "openai")
+        assert result["strategy"] == "prune"

--- a/tests/test_convergence_detector.py
+++ b/tests/test_convergence_detector.py
@@ -1,0 +1,91 @@
+"""Tests for ConvergenceDetector — extracted from AgenticLoop."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.agent.convergence import ConvergenceDetector
+
+
+class TestConvergenceDetector:
+    """Test convergence detection logic."""
+
+    def test_init_defaults(self) -> None:
+        det = ConvergenceDetector()
+        assert det.total_consecutive_tool_errors == 0
+        assert det.recent_errors == []
+        assert det.convergence_escalated is False
+
+    # -- update_tool_error_tracking --
+
+    def test_error_increments_counter(self) -> None:
+        det = ConvergenceDetector()
+        results = [
+            {"tool_use_id": "t1", "content": json.dumps({"error": "fail"})},
+        ]
+        tool_log: list[dict[str, Any]] = [
+            {"tool": "test_tool", "input": {}, "result": {"error": "fail"}},
+        ]
+        det.update_tool_error_tracking(results, tool_log)
+        assert det.total_consecutive_tool_errors == 1
+
+    def test_success_resets_counter(self) -> None:
+        det = ConvergenceDetector()
+        det.total_consecutive_tool_errors = 5
+        results = [
+            {"tool_use_id": "t1", "content": json.dumps({"status": "ok"})},
+        ]
+        det.update_tool_error_tracking(results, [])
+        assert det.total_consecutive_tool_errors == 0
+
+    def test_recent_errors_capped_at_6(self) -> None:
+        det = ConvergenceDetector()
+        for i in range(10):
+            results = [
+                {"tool_use_id": f"t{i}", "content": json.dumps({"error": f"e{i}"})},
+            ]
+            det.update_tool_error_tracking(results, [])
+        assert len(det.recent_errors) <= 6
+
+    # -- check_convergence_break --
+
+    def test_no_convergence_few_errors(self) -> None:
+        det = ConvergenceDetector()
+        det.recent_errors = ["a:1", "a:1"]
+        assert det.check_convergence_break() is False
+
+    def test_3_identical_triggers_escalation(self) -> None:
+        escalated = False
+
+        def fake_escalate() -> bool:
+            nonlocal escalated
+            escalated = True
+            return True
+
+        det = ConvergenceDetector(escalation_fn=fake_escalate)
+        det.recent_errors = ["a:timeout", "a:timeout", "a:timeout"]
+        result = det.check_convergence_break()
+        assert result is False  # Escalation succeeded, don't break
+        assert escalated is True
+        assert det.convergence_escalated is True
+        assert det.recent_errors == []
+
+    def test_4_identical_after_escalation_breaks(self) -> None:
+        det = ConvergenceDetector()
+        det.convergence_escalated = True
+        det.recent_errors = ["a:timeout"] * 4
+        assert det.check_convergence_break() is True
+
+    def test_mixed_errors_no_break(self) -> None:
+        det = ConvergenceDetector()
+        det.recent_errors = ["a:1", "b:2", "a:1", "c:3"]
+        assert det.check_convergence_break() is False
+
+    def test_escalation_failure_no_break_on_3(self) -> None:
+        """If escalation fails, 3 errors should NOT break (needs 4)."""
+        det = ConvergenceDetector(escalation_fn=lambda: False)
+        det.recent_errors = ["a:timeout", "a:timeout", "a:timeout"]
+        result = det.check_convergence_break()
+        assert result is False
+        assert det.convergence_escalated is True

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -667,26 +667,25 @@ class TestSynthesizerBoundaryLogging:
 class TestAgenticLoopPruning:
     """Karpathy P10 — message pruning for context budget."""
 
-    def test_no_pruning_under_threshold(self):
-        from core.agent.agentic_loop import AgenticLoop
+    def _make_ctx_mgr(self):
+        from core.agent.context_manager import ContextWindowManager
 
-        loop = AgenticLoop.__new__(AgenticLoop)
+        return ContextWindowManager(hooks=None, quiet=True)
+
+    def test_no_pruning_under_threshold(self):
+        mgr = self._make_ctx_mgr()
         messages: list[dict[str, Any]] = [{"role": "user", "content": f"msg{i}"} for i in range(8)]
-        loop._maybe_prune_messages(messages)
+        mgr.maybe_prune_messages(messages)
         assert len(messages) == 8  # No change
 
     def test_pruning_at_threshold(self):
-        from core.agent.agentic_loop import AgenticLoop
-
-        loop = AgenticLoop.__new__(AgenticLoop)
+        mgr = self._make_ctx_mgr()
         messages: list[dict[str, Any]] = [{"role": "user", "content": f"msg{i}"} for i in range(30)]
-        loop._maybe_prune_messages(messages)
+        mgr.maybe_prune_messages(messages)
         assert len(messages) == 30  # Exactly 30 = no prune
 
     def test_pruning_above_threshold(self):
-        from core.agent.agentic_loop import AgenticLoop
-
-        loop = AgenticLoop.__new__(AgenticLoop)
+        mgr = self._make_ctx_mgr()
         # Build alternating user/assistant (32 msgs = 16 rounds)
         messages: list[dict[str, Any]] = [{"role": "user", "content": "first message"}]
         for i in range(1, 32):
@@ -694,7 +693,7 @@ class TestAgenticLoopPruning:
             messages.append({"role": role, "content": f"msg{i}"})
         assert len(messages) == 32
 
-        loop._maybe_prune_messages(messages)
+        mgr.maybe_prune_messages(messages)
 
         # first(user) + bridge(assistant) + recent(user-start) = 7
         assert messages[0]["content"] == "first message"
@@ -708,9 +707,7 @@ class TestAgenticLoopPruning:
             )
 
     def test_pruning_preserves_recent_and_alternation(self):
-        from core.agent.agentic_loop import AgenticLoop
-
-        loop = AgenticLoop.__new__(AgenticLoop)
+        mgr = self._make_ctx_mgr()
         # Build proper alternating conversation (13 msgs: 6 turns + current user)
         messages: list[dict[str, Any]] = [{"role": "user", "content": "original"}]
         for i in range(1, 11):
@@ -724,7 +721,7 @@ class TestAgenticLoopPruning:
         )
         assert len(messages) == 13
 
-        loop._maybe_prune_messages(messages)
+        mgr.maybe_prune_messages(messages)
 
         contents = [m["content"] for m in messages]
         assert "original" in contents

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -148,6 +148,28 @@ class TestModelEscalation:
         assert loop.model == OPENAI_PRIMARY
         assert loop._provider == "openai"
 
+    def test_cross_provider_emits_fallback_hook(self) -> None:
+        """Cross-provider escalation fires FALLBACK_CROSS_PROVIDER hook."""
+        from core.hooks import HookEvent
+
+        last_anthropic = ANTHROPIC_FALLBACK_CHAIN[-1]
+        loop = _make_loop(model=last_anthropic, provider="anthropic")
+        hooks = MagicMock()
+        loop._hooks = hooks
+
+        result = loop._try_model_escalation()
+        assert result is True
+
+        hooks.trigger.assert_any_call(
+            HookEvent.FALLBACK_CROSS_PROVIDER,
+            {
+                "from_model": last_anthropic,
+                "to_model": OPENAI_PRIMARY,
+                "from_provider": "anthropic",
+                "to_provider": "openai",
+            },
+        )
+
     def test_arun_escalation_on_consecutive_failures(self) -> None:
         """arun() auto-escalates when failures reach threshold and retries."""
         import asyncio


### PR DESCRIPTION
## Summary
- 구조적 감사 결과 발견된 6개 결함을 독립 Phase로 순차 해결
- Claude Code frontier GAP 비교를 통한 리팩토링 방향 설계

## Why
구조적 감사에서 God Object 3건, wiring bug 1건, layer violation 1건, encapsulation 결함 1건 발견. 변경 시 side-effect 리스크가 높은 핵심 파일들(agentic_loop.py 1818줄, cli/__init__.py 1892줄)의 책임 분리가 필요.

## Changes
| File | Change |
|------|--------|
| `core/agent/context_manager.py` | **NEW** — context overflow, pruning, recovery, strategy resolution (410줄) |
| `core/agent/convergence.py` | **NEW** — tool error tracking, convergence detection (114줄) |
| `core/cli/memory_handler.py` | **NEW** — memory action handling (rule CRUD, search, save) |
| `core/cli/scheduler_drain.py` | **NEW** — scheduler queue drain logic |
| `core/cli/terminal.py` | **NEW** — terminal restore, suppress warnings, drain stdin |
| `core/agent/agentic_loop.py` | 7 context methods + 2 convergence methods → delegation (1818→1405줄) |
| `core/cli/__init__.py` | 4 functions → delegation to extracted modules (1892→1641줄) |
| `core/runtime.py` | `create()` 122줄 → 4 staged builders (~30줄 orchestrator) |
| `core/hooks/auto_learn.py` | `profile_provider` DI 파라미터 추가 (layer violation 해소) |
| `core/runtime_wiring/bootstrap.py` | auto_learn 등록 시 `get_user_profile` 주입 |
| `core/domains/game_ip/nodes/signals.py` | `get_signal_adapter()` public getter 추가 |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (0 errors, 204 files)
- [x] pytest 3702 passed, 0 failed (local)

## Reference
Claude Code frontier 비교: QueryEngine + query.ts 2-layer 분리, query/deps.ts DI 패턴, entrypoints/init.ts staged init