### PR TITLE
feat: lazy directory creation at bootstrap (Claude Code pattern)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Lazy directory creation** — `ensure_directories()` in `core/paths.py` creates all `~/.geode/` and `.geode/` directories at bootstrap. Follows Claude Code's lazy `mkdir(recursive)` pattern. Fresh `uv run geode` on clean install now works without manual setup
+- `.gitignore` auto-entry for `.geode/` on first run
+
 ### Architecture
 - **Layer violation fix (3 cross-layer dependency violations resolved)**:
   - `agentic_response.py` moved from `core/cli/` (L5) → `core/llm/` (L2) — eliminates L2→L5 import in LLM providers/router. `core/cli/agentic_response.py` retained as backward-compatible re-export

--- a/core/paths.py
+++ b/core/paths.py
@@ -15,6 +15,7 @@ Project ID encoding follows Claude Code's convention:
 
 from __future__ import annotations
 
+import logging as _logging
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -188,3 +189,95 @@ def _resolve_with_fallback(new_path: Path, old_path: Path) -> Path:
         return old_path
     # Neither has data — use new path (will be created on first write)
     return new_path
+
+
+# ---------------------------------------------------------------------------
+# Lazy directory creation — Claude Code pattern (mkdir recursive on-demand)
+# ---------------------------------------------------------------------------
+
+_paths_log = _logging.getLogger(__name__)
+
+
+def ensure_directories() -> None:
+    """Create all required directories if missing.
+
+    Called once at bootstrap. Follows Claude Code's lazy creation pattern:
+    ``mkdir(parents=True, exist_ok=True)`` — no error if already present,
+    creates full tree if absent.
+
+    Two tiers:
+    - Global (``~/.geode/``): runs, vault, models, usage, projects
+    - Project (``.geode/``): memory, rules, skills, reports, scheduler_logs
+    """
+    created: list[str] = []
+
+    # --- Global tier ---
+    global_dirs = [
+        GEODE_HOME,
+        GLOBAL_RUNS_DIR,
+        GLOBAL_VAULT_DIR,
+        GLOBAL_MODELS_DIR,
+        GLOBAL_USAGE_DIR,
+        GLOBAL_MCP_DIR,
+        GLOBAL_SCHEDULER_DIR,
+        GLOBAL_PROJECTS_DIR,
+        GLOBAL_IDENTITY_DIR,
+        GLOBAL_USER_PROFILE_DIR,
+    ]
+    for d in global_dirs:
+        if not d.exists():
+            d.mkdir(parents=True, exist_ok=True)
+            created.append(str(d))
+
+    # --- Project-scoped user data (under ~/.geode/projects/{id}/) ---
+    project_data = get_project_data_dir()
+    project_user_dirs = [
+        project_data,
+        project_data / "journal",
+        project_data / "sessions",
+        project_data / "snapshots",
+        project_data / "result_cache",
+    ]
+    for d in project_user_dirs:
+        if not d.exists():
+            d.mkdir(parents=True, exist_ok=True)
+            created.append(str(d))
+
+    # --- Project tier (.geode/) ---
+    project_dirs = [
+        PROJECT_GEODE_DIR,
+        PROJECT_MEMORY_DIR,
+        PROJECT_RULES_DIR,
+        PROJECT_SKILLS_DIR,
+        PROJECT_REPORTS_DIR,
+        PROJECT_SCHEDULER_LOG_DIR,
+    ]
+    for d in project_dirs:
+        if not d.exists():
+            d.mkdir(parents=True, exist_ok=True)
+            created.append(str(d))
+
+    # --- .gitignore entry for .geode/ ---
+    _ensure_geode_gitignore()
+
+    if created:
+        _paths_log.info("Created %d directories: %s", len(created), ", ".join(created))
+
+
+def _ensure_geode_gitignore() -> None:
+    """Add .geode/ to .gitignore if not already present."""
+    gitignore = Path(".gitignore")
+    entry = ".geode/"
+    try:
+        if gitignore.exists():
+            content = gitignore.read_text(encoding="utf-8")
+            if entry in content:
+                return
+            if not content.endswith("\n"):
+                content += "\n"
+        else:
+            content = ""
+        content += f"\n# GEODE\n{entry}\n"
+        gitignore.write_text(content, encoding="utf-8")
+    except OSError:
+        pass  # read-only filesystem, CI, etc.

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -435,6 +435,10 @@ def build_memory(
     hooks: Any = None,
 ) -> tuple[ProjectMemory, MonoLakeOrganizationMemory, ContextAssembler, FileBasedUserProfile]:
     """Build L2 memory components: project, org, context assembler, user profile."""
+    from core.paths import ensure_directories
+
+    ensure_directories()
+
     project_memory = ProjectMemory()
 
     org_dir = settings.organization_fixture_dir
@@ -446,7 +450,7 @@ def build_memory(
     project_profile_dir = Path(".geode") / "user_profile"
     user_profile = FileBasedUserProfile(
         global_dir=global_profile_dir,
-        project_dir=project_profile_dir if project_profile_dir.parent.exists() else None,
+        project_dir=project_profile_dir,
     )
 
     # C2: Project Journal — append-only execution history

--- a/tests/test_ensure_dirs.py
+++ b/tests/test_ensure_dirs.py
@@ -1,0 +1,116 @@
+"""Tests for core.paths.ensure_directories — lazy directory creation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.paths import ensure_directories
+
+
+@pytest.fixture()
+def clean_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Patch all GEODE path constants to use tmp_path."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    geode_home = home / ".geode"
+
+    monkeypatch.setattr("core.paths.GEODE_HOME", geode_home)
+    monkeypatch.setattr("core.paths.GLOBAL_RUNS_DIR", geode_home / "runs")
+    monkeypatch.setattr("core.paths.GLOBAL_VAULT_DIR", geode_home / "vault")
+    monkeypatch.setattr("core.paths.GLOBAL_MODELS_DIR", geode_home / "models")
+    monkeypatch.setattr("core.paths.GLOBAL_USAGE_DIR", geode_home / "usage")
+    monkeypatch.setattr("core.paths.GLOBAL_MCP_DIR", geode_home / "mcp")
+    monkeypatch.setattr("core.paths.GLOBAL_SCHEDULER_DIR", geode_home / "scheduler")
+    monkeypatch.setattr("core.paths.GLOBAL_PROJECTS_DIR", geode_home / "projects")
+    monkeypatch.setattr("core.paths.GLOBAL_IDENTITY_DIR", geode_home / "identity")
+    monkeypatch.setattr("core.paths.GLOBAL_USER_PROFILE_DIR", geode_home / "user_profile")
+
+    proj_geode = Path(".geode")
+    monkeypatch.setattr("core.paths.PROJECT_GEODE_DIR", proj_geode)
+    monkeypatch.setattr("core.paths.PROJECT_MEMORY_DIR", proj_geode / "memory")
+    monkeypatch.setattr("core.paths.PROJECT_RULES_DIR", proj_geode / "rules")
+    monkeypatch.setattr("core.paths.PROJECT_SKILLS_DIR", proj_geode / "skills")
+    monkeypatch.setattr("core.paths.PROJECT_REPORTS_DIR", proj_geode / "reports")
+    monkeypatch.setattr("core.paths.PROJECT_SCHEDULER_LOG_DIR", proj_geode / "scheduler_logs")
+
+    # Patch get_project_data_dir to return a temp-based path
+    proj_data = geode_home / "projects" / "test-project"
+    monkeypatch.setattr("core.paths.get_project_data_dir", lambda *_a, **_kw: proj_data)
+
+    return tmp_path
+
+
+class TestEnsureDirectories:
+    def test_creates_global_dirs(self, clean_dirs: Path) -> None:
+        ensure_directories()
+
+        home = clean_dirs / "home" / ".geode"
+        assert home.is_dir()
+        assert (home / "runs").is_dir()
+        assert (home / "vault").is_dir()
+        assert (home / "models").is_dir()
+        assert (home / "usage").is_dir()
+        assert (home / "mcp").is_dir()
+        assert (home / "scheduler").is_dir()
+        assert (home / "projects").is_dir()
+        assert (home / "identity").is_dir()
+        assert (home / "user_profile").is_dir()
+
+    def test_creates_project_dirs(self, clean_dirs: Path) -> None:
+        ensure_directories()
+
+        proj = clean_dirs / "project" / ".geode"
+        assert proj.is_dir()
+        assert (proj / "memory").is_dir()
+        assert (proj / "rules").is_dir()
+        assert (proj / "skills").is_dir()
+        assert (proj / "reports").is_dir()
+        assert (proj / "scheduler_logs").is_dir()
+
+    def test_creates_project_user_dirs(self, clean_dirs: Path) -> None:
+        ensure_directories()
+
+        proj_data = clean_dirs / "home" / ".geode" / "projects" / "test-project"
+        assert proj_data.is_dir()
+        assert (proj_data / "journal").is_dir()
+        assert (proj_data / "sessions").is_dir()
+        assert (proj_data / "snapshots").is_dir()
+        assert (proj_data / "result_cache").is_dir()
+
+    def test_idempotent(self, clean_dirs: Path) -> None:
+        ensure_directories()
+        ensure_directories()  # no error on second call
+
+        home = clean_dirs / "home" / ".geode"
+        assert home.is_dir()
+
+    def test_gitignore_entry_added(self, clean_dirs: Path) -> None:
+        ensure_directories()
+
+        gitignore = clean_dirs / "project" / ".gitignore"
+        assert gitignore.exists()
+        content = gitignore.read_text()
+        assert ".geode/" in content
+
+    def test_gitignore_no_duplicate(self, clean_dirs: Path) -> None:
+        gitignore = Path(".gitignore")
+        gitignore.write_text("# existing\n.geode/\n")
+
+        ensure_directories()
+
+        content = gitignore.read_text()
+        assert content.count(".geode/") == 1
+
+    def test_gitignore_appends_to_existing(self, clean_dirs: Path) -> None:
+        gitignore = Path(".gitignore")
+        gitignore.write_text("node_modules/\n")
+
+        ensure_directories()
+
+        content = gitignore.read_text()
+        assert "node_modules/" in content
+        assert ".geode/" in content


### PR DESCRIPTION
## Summary
- `ensure_directories()` in `core/paths.py` creates all `~/.geode/` + `.geode/` directories at bootstrap
- `.gitignore` auto-entry for `.geode/` on first run
- 7 new tests

## Why
Fresh `uv run geode` on clean install fails with `FileNotFoundError` because no code creates `~/.geode/` root, `.geode/memory/`, `.geode/skills/`, `~/.geode/runs/`, etc. Claude Code uses lazy `mkdir(recursive: true)` at write-time; GEODE adopts the same pattern but calls it once at bootstrap since GEODE has more directory dependencies.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | Added `ensure_directories()` — creates 10 global + 5 project-user + 6 project dirs + `.gitignore` entry |
| `core/runtime_wiring/bootstrap.py` | Call `ensure_directories()` at start of `build_memory()` |
| `tests/test_ensure_dirs.py` | **NEW** — 7 tests (global/project/user dirs, idempotency, gitignore) |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 7/7 pass (test_ensure_dirs)
- [x] Existing tests unaffected

## Reference
Claude Code: `utils/config.ts:1125` — `fs.mkdirSync(dir, { recursive: true })` at write-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)