### PR TITLE
fix: sandbox hardening — OSError defense, regex, thread safety, cache removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Sandbox hardening** — 4 crash/safety fixes:
+  - `path.resolve()` OSError defense in `add/remove_working_directory()`
+  - macOS `/private/var` regex: `r"^/private/var/"` → `r"^/private/var(/|$)"` — trailing slash no longer required
+  - `_additional_dirs` thread safety with `threading.Lock` — concurrent sub-agent safety
+  - Symlink LRU cache removed — prevents stale resolution in long-running sessions
+
 ### Added
 - **Lazy directory creation** — `ensure_directories()` in `core/paths.py` creates all `~/.geode/` and `.geode/` directories at bootstrap. Follows Claude Code's lazy `mkdir(recursive)` pattern. Fresh `uv run geode` on clean install now works without manual setup
 - `.gitignore` auto-entry for `.geode/` on first run

--- a/core/tools/sandbox.py
+++ b/core/tools/sandbox.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import re
-from functools import lru_cache
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -63,7 +63,7 @@ _TILDE_VARIANT = re.compile(r"^~[^/\\]")  # ~user, ~+, ~-, ~N (only ~ and ~/ all
 _GLOB_CHARS = re.compile(r"[*?\[\]{}]")
 
 # macOS /private normalization
-_PRIVATE_VAR_RE = re.compile(r"^/private/var/")
+_PRIVATE_VAR_RE = re.compile(r"^/private/var(/|$)")
 _PRIVATE_TMP_RE = re.compile(r"^/private/tmp(/|$)")
 
 # ---------------------------------------------------------------------------
@@ -71,27 +71,39 @@ _PRIVATE_TMP_RE = re.compile(r"^/private/tmp(/|$)")
 # ---------------------------------------------------------------------------
 
 _additional_dirs: list[Path] = []
+_additional_dirs_lock = threading.Lock()
 
 
 def add_working_directory(path: Path) -> None:
     """Add a session-scoped working directory to the sandbox allowlist."""
-    resolved = path.resolve()
-    if resolved not in _additional_dirs:
-        _additional_dirs.append(resolved)
-        log.info("Sandbox: added working directory %s", resolved)
+    try:
+        resolved = path.resolve()
+    except OSError:
+        log.warning("Sandbox: cannot resolve %s, skipping", path)
+        return
+    with _additional_dirs_lock:
+        if resolved not in _additional_dirs:
+            _additional_dirs.append(resolved)
+            log.info("Sandbox: added working directory %s", resolved)
 
 
 def remove_working_directory(path: Path) -> None:
     """Remove a session-scoped working directory from the sandbox allowlist."""
-    resolved = path.resolve()
-    if resolved in _additional_dirs:
-        _additional_dirs.remove(resolved)
-        log.info("Sandbox: removed working directory %s", resolved)
+    try:
+        resolved = path.resolve()
+    except OSError:
+        log.warning("Sandbox: cannot resolve %s, skipping", path)
+        return
+    with _additional_dirs_lock:
+        if resolved in _additional_dirs:
+            _additional_dirs.remove(resolved)
+            log.info("Sandbox: removed working directory %s", resolved)
 
 
 def get_all_working_directories() -> list[Path]:
     """Return all allowed working directories (project root + additional)."""
-    return [get_project_root(), *_additional_dirs]
+    with _additional_dirs_lock:
+        return [get_project_root(), *_additional_dirs]
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +117,7 @@ def normalize_macos_path(path_str: str) -> str:
     Applied bilaterally (to both input paths and working directories) to ensure
     symmetric comparison.  Follows Claude Code filesystem.ts pathInWorkingPath().
     """
-    result = _PRIVATE_VAR_RE.sub("/var/", path_str)
+    result = _PRIVATE_VAR_RE.sub(lambda m: f"/var{m.group(1)}", path_str)
     result = _PRIVATE_TMP_RE.sub(lambda m: f"/tmp{m.group(1)}", result)  # noqa: S108  # nosec B108 — intentional macOS normalization
     return result
 
@@ -195,11 +207,11 @@ def check_glob_in_write(path_str: str) -> dict[str, Any] | None:
     return None
 
 
-@lru_cache(maxsize=1024)
 def _resolve_symlink_cached(path_str: str) -> tuple[str, str | None]:
     """Resolve a symlink path and return (resolved_str, error_msg_or_none).
 
-    Cached to avoid repeated filesystem calls for the same path.
+    Not cached — symlink targets can change within a session, and the
+    per-call cost is negligible (tool calls are already I/O-bound).
     """
     path = Path(path_str)
     if not path.exists() and not path.is_symlink():

--- a/tests/test_document_tools.py
+++ b/tests/test_document_tools.py
@@ -20,7 +20,6 @@ def _sandbox_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(paths_mod, "get_project_root", _root)
     monkeypatch.setattr("core.tools.sandbox.get_project_root", _root)
     sandbox._additional_dirs.clear()
-    sandbox._resolve_symlink_cached.cache_clear()
 
 
 class TestReadBasic:

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -22,7 +22,6 @@ def _sandbox_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("core.tools.sandbox.get_project_root", _root)
     monkeypatch.setattr("core.tools.file_tools.get_project_root", _root)
     sandbox._additional_dirs.clear()
-    sandbox._resolve_symlink_cached.cache_clear()
 
 
 class TestGlobTool:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -20,7 +20,6 @@ def _sandbox_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(paths_mod, "get_project_root", _root)
     monkeypatch.setattr("core.tools.sandbox.get_project_root", _root)
     sandbox._additional_dirs.clear()
-    sandbox._resolve_symlink_cached.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -276,3 +275,111 @@ class TestValidatePath:
         sandbox.add_working_directory(extra)
         result = sandbox.validate_path(str(target), write=False)
         assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# OSError defense (sandbox hardening v0.47.2)
+# ---------------------------------------------------------------------------
+
+
+class TestOSErrorDefense:
+    """add/remove_working_directory should not crash on OSError."""
+
+    def test_add_working_dir_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError during path.resolve() should be caught, not crash."""
+        import core.paths as paths_mod
+
+        monkeypatch.setattr(paths_mod, "get_project_root", lambda: Path("/tmp"))  # noqa: S108
+        monkeypatch.setattr("core.tools.sandbox.get_project_root", lambda: Path("/tmp"))  # noqa: S108
+        sandbox._additional_dirs.clear()
+
+        bad_path = Path("/nonexistent/mount/point/dir")
+        # Patch resolve to raise
+        original_resolve = Path.resolve
+
+        def _raising_resolve(self: Path, *_a: object, **_kw: object) -> Path:
+            if str(self) == str(bad_path):
+                raise OSError("mount point unavailable")
+            return original_resolve(self)
+
+        monkeypatch.setattr(Path, "resolve", _raising_resolve)
+        sandbox.add_working_directory(bad_path)  # Should NOT raise
+        assert len(sandbox._additional_dirs) == 0  # Not added
+
+    def test_remove_working_dir_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError during remove_working_directory should be caught."""
+        sandbox._additional_dirs.clear()
+        bad_path = Path("/nonexistent/mount/gone")
+        original_resolve = Path.resolve
+
+        def _raising_resolve(self: Path, *_a: object, **_kw: object) -> Path:
+            if str(self) == str(bad_path):
+                raise OSError("mount gone")
+            return original_resolve(self)
+
+        monkeypatch.setattr(Path, "resolve", _raising_resolve)
+        sandbox.remove_working_directory(bad_path)  # Should NOT raise
+
+
+# ---------------------------------------------------------------------------
+# macOS /private/var normalization edge case
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateVarEdge:
+    """Regex should match /private/var without trailing slash."""
+
+    def test_private_var_no_trailing_slash(self) -> None:
+        assert sandbox.normalize_macos_path("/private/var") == "/var"
+
+    def test_private_var_with_trailing_slash(self) -> None:
+        assert sandbox.normalize_macos_path("/private/var/") == "/var/"
+
+    def test_private_var_subpath(self) -> None:
+        assert sandbox.normalize_macos_path("/private/var/folders/xyz") == "/var/folders/xyz"
+
+
+# ---------------------------------------------------------------------------
+# Thread safety (_additional_dirs)
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    """Concurrent add/remove should not corrupt _additional_dirs."""
+
+    def test_concurrent_add_remove(self, tmp_path: Path) -> None:
+        import threading
+
+        sandbox._additional_dirs.clear()
+        errors: list[Exception] = []
+
+        def _add_dirs(start: int) -> None:
+            try:
+                for i in range(start, start + 20):
+                    d = tmp_path / f"dir_{i}"
+                    d.mkdir(exist_ok=True)
+                    sandbox.add_working_directory(d)
+            except Exception as e:
+                errors.append(e)
+
+        def _remove_dirs(start: int) -> None:
+            try:
+                for i in range(start, start + 10):
+                    d = tmp_path / f"dir_{i}"
+                    sandbox.remove_working_directory(d)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=_add_dirs, args=(0,)),
+            threading.Thread(target=_add_dirs, args=(20,)),
+            threading.Thread(target=_remove_dirs, args=(0,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        assert not errors, f"Thread errors: {errors}"
+        # Should not crash — actual count may vary due to timing
+        sandbox._additional_dirs.clear()


### PR DESCRIPTION
## Summary
- Sandbox 크래시 방지 4건 + 6 new tests

## Why
코드 감사 결과 sandbox에서 크래시 위험 3건(OSError, regex 미매칭, race condition) + 방어 부족 1건(stale cache) 발견. 실제 크래시 발생 전 예방.

## Changes
| File | Change |
|------|--------|
| `core/tools/sandbox.py` | OSError try/except, `_PRIVATE_VAR_RE` regex fix, `_additional_dirs_lock`, `@lru_cache` 제거 |
| `tests/test_sandbox.py` | +6 tests (OSError, regex edge, concurrent), `cache_clear()` 제거 |
| `tests/test_file_tools.py` | `cache_clear()` 제거 |
| `tests/test_document_tools.py` | `cache_clear()` 제거 |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (209 files)
- [x] pytest 3845 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)