### PR TITLE
feat: P0 hook production hardening — interceptor + 6 events

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -559,6 +559,17 @@ class AgenticLoop:
                 termination_reason="billing_error",
             )
 
+        # Hook: USER_INPUT_RECEIVED (interceptor — can block input)
+        if self._hooks:
+            intercept = self._hooks.trigger_interceptor(
+                HookEvent.USER_INPUT_RECEIVED,
+                {"user_input": user_input, "session_id": self._session_id},
+            )
+            if intercept.blocked:
+                return AgenticResult(
+                    text=intercept.reason, rounds=0, termination_reason="input_blocked"
+                )
+
         # Add user message to conversation context
         self.context.add_user_message(user_input)
 
@@ -1313,7 +1324,8 @@ class AgenticLoop:
 
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens
-            usage = get_tracker().record(self.model, in_tok, out_tok)
+            tracker = get_tracker()
+            usage = tracker.record(self.model, in_tok, out_tok)
             if not self._quiet:
                 render_tokens(self.model, in_tok, out_tok, cost_usd=usage.cost_usd)
             log.info(
@@ -1323,6 +1335,25 @@ class AgenticLoop:
                 out_tok,
                 usage.cost_usd,
             )
+
+            # Hook: COST_WARNING / COST_LIMIT_EXCEEDED
+            if self._hooks:
+                from core.config import settings
+
+                cost_limit = getattr(settings, "cost_limit_usd", 0.0)
+                if cost_limit > 0:
+                    total_cost = tracker.accumulator.total_cost_usd
+                    pct = total_cost / cost_limit
+                    if pct >= 1.0:
+                        self._hooks.trigger(
+                            HookEvent.COST_LIMIT_EXCEEDED,
+                            {"total_cost_usd": total_cost, "limit_usd": cost_limit},
+                        )
+                    elif pct >= 0.8:
+                        self._hooks.trigger(
+                            HookEvent.COST_WARNING,
+                            {"total_cost_usd": total_cost, "limit_usd": cost_limit, "pct": pct},
+                        )
         except Exception:
             log.debug("Failed to track usage", exc_info=True)
 

--- a/core/agent/tool_executor.py
+++ b/core/agent/tool_executor.py
@@ -1090,8 +1090,24 @@ class ToolCallProcessor:
             # Progressive log: show tool call before execution
             visible = self._op_logger.log_tool_call(tool_name, tool_input)
 
+            # Hook: TOOL_EXEC_START
+            self._fire_hook("tool_exec_start", {"tool_name": tool_name, "tool_input": tool_input})
+
             # Execute via ToolExecutor (sync handlers wrapped in to_thread)
+            _t0 = time.monotonic()
             result = await asyncio.to_thread(self._executor.execute, tool_name, tool_input)
+            _elapsed_ms = (time.monotonic() - _t0) * 1000
+
+            # Hook: TOOL_EXEC_END
+            self._fire_hook(
+                "tool_exec_end",
+                {
+                    "tool_name": tool_name,
+                    "tool_input": tool_input,
+                    "duration_ms": _elapsed_ms,
+                    "has_error": isinstance(result, dict) and bool(result.get("error")),
+                },
+            )
 
         # Track consecutive failures + recoverability breadcrumb
         if isinstance(result, dict) and result.get("error"):

--- a/core/config.py
+++ b/core/config.py
@@ -243,6 +243,9 @@ class Settings(BaseSettings):
     # Agentic Loop — time budget (Karpathy P3, OpenClaw Attempt Loop)
     agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
 
+    # Cost guard — session-level cost limit (0 = no limit)
+    cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%
+
     # Computer Use — desktop automation (requires pyautogui)
     computer_use_enabled: bool = False  # opt-in; set GEODE_COMPUTER_USE_ENABLED=true
 

--- a/core/hooks/__init__.py
+++ b/core/hooks/__init__.py
@@ -6,6 +6,6 @@ without depending on core.orchestration:
     from core.hooks import HookSystem, HookEvent
 """
 
-from core.hooks.system import HookEvent, HookResult, HookSystem
+from core.hooks.system import HookEvent, HookResult, HookSystem, InterceptResult
 
-__all__ = ["HookEvent", "HookResult", "HookSystem"]
+__all__ = ["HookEvent", "HookResult", "HookSystem", "InterceptResult"]

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -3,10 +3,16 @@
 Cross-cutting infrastructure accessible by all layers.
 Allows registering callbacks for pipeline events (pre/post node execution,
 errors, sub-agent lifecycle, etc.).
+
+Supports three trigger modes:
+- trigger()              — fire-and-forget observer (L1 Observe)
+- trigger_with_result()  — capture handler return values (L3 Decide)
+- trigger_interceptor()  — block/modify execution (Interceptor pattern)
 """
 
 from __future__ import annotations
 
+import concurrent.futures
 import dataclasses
 import logging
 import threading
@@ -19,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 class HookEvent(Enum):
-    """Pipeline lifecycle events (40 events)."""
+    """Pipeline lifecycle events."""
 
     # Pipeline level
     PIPELINE_START = "pipeline_start"
@@ -112,6 +118,14 @@ class HookEvent(Enum):
     MCP_SERVER_CONNECTED = "mcp_server_connected"
     MCP_SERVER_FAILED = "mcp_server_failed"
 
+    # Production hooks (P0) — interceptor + cost enforcement + audit
+    USER_INPUT_RECEIVED = "user_input_received"
+    TOOL_EXEC_START = "tool_exec_start"
+    TOOL_EXEC_END = "tool_exec_end"
+    COST_WARNING = "cost_warning"
+    COST_LIMIT_EXCEEDED = "cost_limit_exceeded"
+    EXECUTION_CANCELLED = "execution_cancelled"
+
 
 @dataclass
 class HookResult:
@@ -126,6 +140,20 @@ class HookResult:
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting None-valued fields."""
         return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}
+
+
+@dataclass
+class InterceptResult:
+    """Result from an interceptor hook chain.
+
+    Interceptor hooks can block execution or modify the event data.
+    Handlers return ``{"block": True, "reason": "..."}`` to stop the chain,
+    or ``{"modify": {"key": "val"}}`` to merge updates into the data dict.
+    """
+
+    blocked: bool = False
+    reason: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 # Type alias for hook handlers.
@@ -258,6 +286,78 @@ class HookSystem:
                 )
 
         return results
+
+    def trigger_interceptor(
+        self, event: HookEvent, data: dict[str, Any] | None = None, *, timeout_s: float = 0
+    ) -> InterceptResult:
+        """Trigger hooks as an interceptor chain (block/modify semantics).
+
+        Runs handlers sequentially in priority order. Each handler may return:
+        - ``{"block": True, "reason": "..."}`` → stop chain, return blocked
+        - ``{"modify": {"key": "val"}}`` → merge into data, continue chain
+        - ``None`` or ``{}`` → continue chain unchanged
+
+        Args:
+            event: The hook event to trigger.
+            data: Mutable event data dict passed to all handlers.
+            timeout_s: Per-handler timeout in seconds (0 = no timeout).
+
+        Returns:
+            InterceptResult with blocked status, reason, and final data.
+        """
+        data = dict(data) if data else {}  # defensive copy
+        with self._lock:
+            hooks = list(self._hooks.get(event, []))
+
+        for hook in hooks:
+            try:
+                ret = self._call_handler(hook, event, data, timeout_s=timeout_s)
+                if isinstance(ret, dict):
+                    if ret.get("block"):
+                        return InterceptResult(
+                            blocked=True,
+                            reason=ret.get("reason", f"Blocked by {hook.name}"),
+                            data=data,
+                        )
+                    modifications = ret.get("modify")
+                    if isinstance(modifications, dict):
+                        data.update(modifications)
+            except Exception as exc:
+                log.warning("Interceptor '%s' failed on %s: %s", hook.name, event.value, exc)
+                # Interceptor errors are non-blocking — continue chain
+
+        return InterceptResult(blocked=False, data=data)
+
+    # -- Internal helpers ------------------------------------------------------
+
+    @staticmethod
+    def _call_handler(
+        hook: _RegisteredHook,
+        event: HookEvent,
+        data: dict[str, Any],
+        *,
+        timeout_s: float = 0,
+    ) -> dict[str, Any] | None:
+        """Call a hook handler with optional timeout.
+
+        When timeout_s > 0, the handler runs in a thread pool with a deadline.
+        On timeout, logs a warning and returns None (non-blocking skip).
+        """
+        if timeout_s <= 0:
+            return hook.handler(event, data)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(hook.handler, event, data)
+            try:
+                return future.result(timeout=timeout_s)
+            except concurrent.futures.TimeoutError:
+                log.warning(
+                    "Hook '%s' timed out on %s (%.1fs limit)",
+                    hook.name,
+                    event.value,
+                    timeout_s,
+                )
+                return None
 
     def list_hooks(self, event: HookEvent | None = None) -> dict[str, list[str]]:
         """List registered hook names, optionally filtered by event."""

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -211,6 +211,11 @@ class IsolatedRunner:
 
         if cancelled:
             log.info("Cancel requested for session %s", session_id)
+            if self._hooks:
+                self._hooks.trigger(
+                    HookEvent.EXECUTION_CANCELLED,
+                    {"session_id": session_id},
+                )
         return cancelled
 
     @property

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -399,6 +399,23 @@ def build_hooks(
         (_E.SHUTDOWN_STARTED, "shutdown", "Shutdown: %s active sessions", ["active_sessions"]),
         (_E.CONFIG_RELOADED, "config_reload", "Config reloaded: %s", ["config_path"]),
         (_E.MCP_SERVER_FAILED, "mcp_fail", "MCP server failed: %s — %s", ["server_name", "error"]),
+        # P0 production hooks
+        (_E.USER_INPUT_RECEIVED, "user_input", "User input received: session=%s", ["session_id"]),
+        (_E.TOOL_EXEC_START, "tool_start", "Tool exec start: %s", ["tool_name"]),
+        (_E.TOOL_EXEC_END, "tool_end", "Tool exec end: %s (%.0fms)", ["tool_name", "duration_ms"]),
+        (
+            _E.COST_WARNING,
+            "cost_warn",
+            "Cost warning: $%.4f / $%.2f",
+            ["total_cost_usd", "limit_usd"],
+        ),
+        (
+            _E.COST_LIMIT_EXCEEDED,
+            "cost_exceeded",
+            "Cost EXCEEDED: $%.4f / $%.2f",
+            ["total_cost_usd", "limit_usd"],
+        ),
+        (_E.EXECUTION_CANCELLED, "exec_cancel", "Execution cancelled: %s", ["session_id"]),
     ]
 
     def _reg_audit_loggers() -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -299,7 +299,7 @@ class TestApplyContext:
 class TestHookEventCount:
     def test_events_exist(self) -> None:
         """HookEvent has 40 events after H6 orphan pruning."""
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -411,7 +411,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count after H6 orphan pruning."""
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,11 +1,13 @@
 """Tests for L4 HookSystem."""
 
-from core.hooks import HookEvent, HookResult, HookSystem
+import time
+
+from core.hooks import HookEvent, HookResult, HookSystem, InterceptResult
 
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"
@@ -26,6 +28,15 @@ class TestHookEvent:
         assert HookEvent.CONFIG_RELOADED.value == "config_reloaded"
         assert HookEvent.MCP_SERVER_CONNECTED.value == "mcp_server_connected"
         assert HookEvent.MCP_SERVER_FAILED.value == "mcp_server_failed"
+
+    def test_production_p0_events(self):
+        """P0 production hooks: interceptor + cost enforcement + audit."""
+        assert HookEvent.USER_INPUT_RECEIVED.value == "user_input_received"
+        assert HookEvent.TOOL_EXEC_START.value == "tool_exec_start"
+        assert HookEvent.TOOL_EXEC_END.value == "tool_exec_end"
+        assert HookEvent.COST_WARNING.value == "cost_warning"
+        assert HookEvent.COST_LIMIT_EXCEEDED.value == "cost_limit_exceeded"
+        assert HookEvent.EXECUTION_CANCELLED.value == "execution_cancelled"
 
 
 class TestAuditLoggers:
@@ -54,6 +65,31 @@ class TestAuditLoggers:
         assert "llm_start" in all_hooks.get("llm_call_start", [])
         assert "shutdown" in all_hooks.get("shutdown_started", [])
         assert "mcp_fail" in all_hooks.get("mcp_server_failed", [])
+
+    def test_p0_audit_loggers_registered(self):
+        """P0 production audit loggers are registered."""
+        from unittest.mock import patch
+
+        with (
+            patch("core.runtime_wiring.bootstrap.RunLog"),
+            patch("core.runtime_wiring.bootstrap.StuckDetector"),
+        ):
+            from core.runtime_wiring.bootstrap import build_hooks
+
+            hooks, _, _, _ = build_hooks(
+                session_key="test",
+                run_id="test-run",
+                log_dir=None,
+                stuck_timeout_s=60,
+            )
+
+        all_hooks = hooks.list_hooks()
+        assert "user_input" in all_hooks.get("user_input_received", [])
+        assert "tool_start" in all_hooks.get("tool_exec_start", [])
+        assert "tool_end" in all_hooks.get("tool_exec_end", [])
+        assert "cost_warn" in all_hooks.get("cost_warning", [])
+        assert "cost_exceeded" in all_hooks.get("cost_limit_exceeded", [])
+        assert "exec_cancel" in all_hooks.get("execution_cancelled", [])
 
 
 class TestMemoryToolHooks:
@@ -99,6 +135,19 @@ class TestHookResult:
         )
         assert r.success is False
         assert r.error == "something broke"
+
+
+class TestInterceptResult:
+    def test_default_not_blocked(self):
+        r = InterceptResult()
+        assert r.blocked is False
+        assert r.reason == ""
+        assert r.data == {}
+
+    def test_blocked_with_reason(self):
+        r = InterceptResult(blocked=True, reason="input rejected")
+        assert r.blocked is True
+        assert r.reason == "input rejected"
 
 
 class TestHookSystem:
@@ -229,3 +278,156 @@ class TestHookSystem:
         hooks.register(HookEvent.PIPELINE_START, handler)
         hooks.trigger(HookEvent.PIPELINE_START)  # No data arg
         assert received == [{}]
+
+
+class TestInterceptor:
+    """Tests for trigger_interceptor() — block/modify semantics."""
+
+    def test_interceptor_pass_through(self):
+        """Handler returns None → not blocked."""
+        hooks = HookSystem()
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, lambda e, d: None, name="noop")
+
+        result = hooks.trigger_interceptor(
+            HookEvent.USER_INPUT_RECEIVED, {"user_input": "hello"}
+        )
+        assert result.blocked is False
+        assert result.data["user_input"] == "hello"
+
+    def test_interceptor_block(self):
+        """Handler returns {"block": True} → blocked with reason."""
+        hooks = HookSystem()
+
+        def blocker(_event, _data):
+            return {"block": True, "reason": "profanity detected"}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, blocker, name="filter")
+
+        result = hooks.trigger_interceptor(
+            HookEvent.USER_INPUT_RECEIVED, {"user_input": "bad words"}
+        )
+        assert result.blocked is True
+        assert result.reason == "profanity detected"
+
+    def test_interceptor_block_stops_chain(self):
+        """Once a handler blocks, subsequent handlers do not run."""
+        hooks = HookSystem()
+        calls: list[str] = []
+
+        def blocker(_event, _data):
+            calls.append("blocker")
+            return {"block": True, "reason": "blocked"}
+
+        def after_blocker(_event, _data):
+            calls.append("after")
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, blocker, name="b", priority=10)
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, after_blocker, name="a", priority=20)
+
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {})
+        assert result.blocked is True
+        assert calls == ["blocker"]
+
+    def test_interceptor_modify(self):
+        """Handler returns {"modify": {...}} → data updated."""
+        hooks = HookSystem()
+
+        def modifier(_event, _data):
+            return {"modify": {"sanitized": True, "user_input": "cleaned"}}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, modifier, name="sanitizer")
+
+        result = hooks.trigger_interceptor(
+            HookEvent.USER_INPUT_RECEIVED, {"user_input": "raw"}
+        )
+        assert result.blocked is False
+        assert result.data["sanitized"] is True
+        assert result.data["user_input"] == "cleaned"
+
+    def test_interceptor_chained_modifications(self):
+        """Multiple handlers can chain modifications."""
+        hooks = HookSystem()
+
+        def add_flag(_event, _data):
+            return {"modify": {"flag_a": True}}
+
+        def add_another_flag(_event, _data):
+            return {"modify": {"flag_b": True}}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, add_flag, name="a", priority=10)
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, add_another_flag, name="b", priority=20)
+
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {"base": 1})
+        assert result.data["base"] == 1
+        assert result.data["flag_a"] is True
+        assert result.data["flag_b"] is True
+
+    def test_interceptor_error_continues_chain(self):
+        """Handler exception is non-blocking — chain continues."""
+        hooks = HookSystem()
+
+        def failing(_event, _data):
+            raise ValueError("oops")
+
+        def good(_event, _data):
+            return {"modify": {"ok": True}}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, failing, name="bad", priority=10)
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, good, name="good", priority=20)
+
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {})
+        assert result.blocked is False
+        assert result.data["ok"] is True
+
+    def test_interceptor_no_handlers(self):
+        """No handlers registered → pass through."""
+        hooks = HookSystem()
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {"x": 1})
+        assert result.blocked is False
+        assert result.data == {"x": 1}
+
+    def test_interceptor_defensive_copy(self):
+        """Input data dict is not mutated."""
+        hooks = HookSystem()
+
+        def modifier(_event, _data):
+            return {"modify": {"added": True}}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, modifier, name="m")
+
+        original = {"key": "val"}
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, original)
+        assert "added" in result.data
+        assert "added" not in original  # original unchanged
+
+
+class TestHookTimeout:
+    """Tests for per-hook timeout via _call_handler."""
+
+    def test_timeout_skips_slow_handler(self):
+        """Slow handler is skipped when timeout_s is set."""
+        hooks = HookSystem()
+
+        def slow_handler(_event, _data):
+            time.sleep(5)
+            return {"modify": {"slow": True}}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, slow_handler, name="slow")
+
+        result = hooks.trigger_interceptor(
+            HookEvent.USER_INPUT_RECEIVED, {"x": 1}, timeout_s=0.1
+        )
+        assert result.blocked is False
+        assert "slow" not in result.data  # handler was skipped
+
+    def test_no_timeout_runs_normally(self):
+        """Without timeout, handler runs to completion."""
+        hooks = HookSystem()
+
+        def fast_handler(_event, _data):
+            return {"modify": {"fast": True}}
+
+        hooks.register(HookEvent.USER_INPUT_RECEIVED, fast_handler, name="fast")
+
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {})
+        assert result.data["fast"] is True

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -288,9 +288,7 @@ class TestInterceptor:
         hooks = HookSystem()
         hooks.register(HookEvent.USER_INPUT_RECEIVED, lambda e, d: None, name="noop")
 
-        result = hooks.trigger_interceptor(
-            HookEvent.USER_INPUT_RECEIVED, {"user_input": "hello"}
-        )
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {"user_input": "hello"})
         assert result.blocked is False
         assert result.data["user_input"] == "hello"
 
@@ -337,9 +335,7 @@ class TestInterceptor:
 
         hooks.register(HookEvent.USER_INPUT_RECEIVED, modifier, name="sanitizer")
 
-        result = hooks.trigger_interceptor(
-            HookEvent.USER_INPUT_RECEIVED, {"user_input": "raw"}
-        )
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {"user_input": "raw"})
         assert result.blocked is False
         assert result.data["sanitized"] is True
         assert result.data["user_input"] == "cleaned"
@@ -414,9 +410,7 @@ class TestHookTimeout:
 
         hooks.register(HookEvent.USER_INPUT_RECEIVED, slow_handler, name="slow")
 
-        result = hooks.trigger_interceptor(
-            HookEvent.USER_INPUT_RECEIVED, {"x": 1}, timeout_s=0.1
-        )
+        result = hooks.trigger_interceptor(HookEvent.USER_INPUT_RECEIVED, {"x": 1}, timeout_s=0.1)
         assert result.blocked is False
         assert "slow" not in result.data  # handler was skipped
 

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,7 +356,7 @@ class TestHookEventTypes:
 
     def test_hook_event_count(self):
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -27,7 +27,7 @@ class TestLLMLifecycleEvents:
 
     def test_event_count_includes_llm_events(self) -> None:
         """40 events total after H6 orphan pruning."""
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
 
 class TestFireHook:

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -278,7 +278,7 @@ class TestHookEventCount:
     def test_total_event_count(self) -> None:
         from core.hooks import HookEvent
 
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -35,7 +35,7 @@ class TestMCPHookEvents:
 
     def test_hook_event_count(self) -> None:
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 49
+        assert len(HookEvent) == 55
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -82,7 +82,7 @@ class TestRuntimeHooksRunLog:
         for event in HookEvent:
             runtime.hooks.trigger(event, {"node": "test"})
 
-        entries = runtime.run_log.read(limit=50)
+        entries = runtime.run_log.read(limit=100)
         # All direct events + cascading hooks (e.g. SNAPSHOT_CAPTURED from drift→auto-snapshot)
         assert len(entries) >= len(HookEvent)
 


### PR DESCRIPTION
## Summary
- Add 6 new HookEvents (55 total): USER_INPUT_RECEIVED, TOOL_EXEC_START/END, COST_WARNING/LIMIT_EXCEEDED, EXECUTION_CANCELLED
- Introduce `trigger_interceptor()` — block/modify chain semantics (Observer → Interceptor transition)
- Add per-hook timeout via ThreadPoolExecutor + `cost_limit_usd` config field

## Why
GEODE hook system was observer-only (49 events): hooks could watch but not block or modify execution. Production requires input validation, cost enforcement, and execution control. Claude Code comparison revealed the interceptor pattern gap — CC has PreToolUse with updatedInput/block, GEODE had nothing equivalent.

## Changes
| File | Change |
|------|--------|
| `core/hooks/system.py` | +6 events, +InterceptResult dataclass, +trigger_interceptor(), +_call_handler() with timeout |
| `core/hooks/__init__.py` | Export InterceptResult |
| `core/agent/agentic_loop.py` | USER_INPUT_RECEIVED interceptor trigger, COST_WARNING/LIMIT_EXCEEDED in _track_usage() |
| `core/agent/tool_executor.py` | TOOL_EXEC_START/END triggers in _execute_single() |
| `core/orchestration/isolated_execution.py` | EXECUTION_CANCELLED trigger in cancel() |
| `core/runtime_wiring/bootstrap.py` | 6 new audit logger entries in _AL table |
| `core/config.py` | +cost_limit_usd setting (0 = no limit) |
| `tests/test_hooks.py` | +14 tests: InterceptResult, interceptor block/modify/chain/error/timeout |
| `tests/test_*.py` (6 files) | Event count 49 → 55 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 3853 passed, 0 failed
- [x] 33 hook-specific tests (including 14 new interceptor/timeout tests)

## Reference
- Claude Code hook system analysis (utils/hooks.ts — interceptor pattern, PreToolUse/PostToolUse)
- Karpathy P1 (constraints first), P4 (ratchet)