### PR TITLE
docs: release v0.48.0 — hook interceptor + cost guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [0.48.0] — 2026-04-11
+
+### Added
+- **Hook interceptor pattern** — `trigger_interceptor()` method with block/modify chain semantics. Hooks can now block execution (`{"block": True}`) or modify event data (`{"modify": {...}}`), transitioning from pure observer to observer + interceptor. Per-hook timeout via `ThreadPoolExecutor`
+- **6 new HookEvents (49 → 55)**: `USER_INPUT_RECEIVED` (interceptor-capable), `TOOL_EXEC_START/END` (tool execution observability), `COST_WARNING/LIMIT_EXCEEDED` (cost guard at 80%/100%), `EXECUTION_CANCELLED` (cancel audit trail)
+- **Session cost guard** — `cost_limit_usd` config field. Fires `COST_WARNING` at 80% and `COST_LIMIT_EXCEEDED` at 100% of budget
 
 ### Fixed
 - **Sandbox hardening** — 4 crash/safety fixes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.47.1
+- **Version**: 0.48.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 205
-- **Tests**: 3749+
+- **Modules**: 215
+- **Tests**: 3939+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start
@@ -42,7 +42,7 @@ uv run geode analyze "Cowboy Bebop" --verbose
 | Document | Path | Content |
 |----------|------|---------|
 | Agent Identity | `GEODE.md` | Runtime architecture, domain rules, LLM models, conventions |
-| Hook System | `docs/architecture/hook-system.md` | HookSystem 48 events |
+| Hook System | `docs/architecture/hook-system.md` | HookSystem 55 events |
 | Scaffold | `CLAUDE.md` | Development workflow, quality gates, CANNOT/CAN (this file) |
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.47.1 — Long-running Autonomous Execution Harness
+# GEODE v0.48.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
 # GEODE Progress Board
 
 > 멀티 에이전트 공유 칸반 보드. 모든 세션/에이전트가 이 파일을 읽고 갱신한다.
-> 마지막 갱신: 2026-04-08 (세션 60 cont. — structural defects phase 2)
+> 마지막 갱신: 2026-04-08 (세션 59 cont. — sandbox hardening)
 > **규칙**: progress.md는 main에서만 수정. feature/develop 수정 금지.
 
 ---
@@ -63,6 +63,12 @@
 
 | task_id | 작업 내용 | PR | 담당 | CI | 비고 |
 |---------|----------|-----|------|-----|------|
+
+### Done (2026-04-08 — 세션 59 cont.)
+
+| task_id | 작업 내용 | PR | 담당 | 완료일 |
+|---------|----------|----|------|--------|
+| sandbox-hardening | Sandbox hardening — OSError defense, regex fix, thread safety, LRU cache 제거 | #702→#703 | @mangowhoiscloud | 2026-04-08 |
 
 ### Done (2026-04-08 — 세션 60 cont.)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.47.1"
+version = "0.48.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Version 0.47.1 → 0.48.0 across 4 locations (CHANGELOG, CLAUDE.md, README.md, pyproject.toml)
- CHANGELOG [Unreleased] → [0.48.0] with hook interceptor + cost guard entries
- Metrics: 215 modules, 3939+ tests, 55 HookEvents

## Why
Accumulated unreleased changes (sandbox hardening, layer violations, hook interceptor) need a versioned release.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | [Unreleased] → [0.48.0], added interceptor/cost guard entries |
| `pyproject.toml` | 0.47.1 → 0.48.0 |
| `CLAUDE.md` | Version, Modules (215), Tests (3939+), HookSystem (55 events) |
| `README.md` | v0.47.1 → v0.48.0 |

## Verification
- [x] 4 locations version match: 0.48.0
- [x] CHANGELOG date: 2026-04-11