### PR TITLE
fix: Slack poller message loss + app mention detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Slack poller message loss on processing failure** — ts was updated BEFORE processing, so if LLM call failed mid-batch, remaining messages were permanently skipped. Now uses deferred-ts pattern: advance only AFTER successful processing, break on failure for retry next cycle
+- **Slack app mention not detected** — `<@A...>` (app mention format) was not matched by `_is_mentioned()` regex, causing `require_mention=true` channels to silently ignore app mentions. Added `A` to the `[UBA]` character class in both `_is_mentioned` and `_strip_mentions`
+
 ### Added
 - **Lazy directory creation** — `ensure_directories()` in `core/paths.py` creates all `~/.geode/` and `.geode/` directories at bootstrap. Follows Claude Code's lazy `mkdir(recursive)` pattern. Fresh `uv run geode` on clean install now works without manual setup
 - `.gitignore` auto-entry for `.geode/` on first run

--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -186,15 +186,17 @@ class ChannelManager:
     def _is_mentioned(message: InboundMessage) -> bool:
         """Check if GEODE is mentioned in the message.
 
-        Detects:
-        - Slack user mention format: ``<@U...>`` (bot's actual user ID)
+        Detects all Slack mention formats:
+        - ``<@U...>`` — user mention (human or bot user)
+        - ``<@B...>`` — legacy bot mention
+        - ``<@A...>`` — app mention (Slack apps installed in workspace)
         - Display name variants: ``@geode``, ``geode``, ``@GEODE``
         """
         import re
 
         content = message.content
-        # Slack encodes @mentions as <@USER_ID> or <@BOT_ID>
-        if re.search(r"<@[UB][A-Z0-9]+>", content):
+        # Slack encodes @mentions as <@USER_ID>, <@BOT_ID>, or <@APP_ID>
+        if re.search(r"<@[UBA][A-Z0-9]+>", content):
             return True
         content_lower = content.lower()
         return any(mention in content_lower for mention in ("@geode", "geode"))
@@ -204,8 +206,8 @@ class ChannelManager:
         """Remove mention tags so the LLM receives clean user intent."""
         import re
 
-        # Remove Slack-style <@USER_ID> and <@BOT_ID> mentions
-        cleaned = re.sub(r"<@[UB][A-Z0-9]+>\s*", "", content)
+        # Remove Slack-style <@USER_ID>, <@BOT_ID>, and <@APP_ID> mentions
+        cleaned = re.sub(r"<@[UBA][A-Z0-9]+>\s*", "", content)
         # Remove @geode / @GEODE prefix
         cleaned = re.sub(r"@geode\s*", "", cleaned, flags=re.IGNORECASE)
         return cleaned.strip()

--- a/core/gateway/pollers/slack_poller.py
+++ b/core/gateway/pollers/slack_poller.py
@@ -63,7 +63,12 @@ class SlackPoller(BasePoller):
             self._poll_channel(channel_id)
 
     def _poll_channel(self, channel_id: str) -> None:
-        """Poll a single Slack channel for new messages."""
+        """Poll a single Slack channel for new messages.
+
+        Deferred-ts pattern: timestamp is updated AFTER each message is
+        successfully processed. If processing fails mid-batch, unprocessed
+        messages will be re-fetched on the next poll cycle.
+        """
         import json as _json
 
         try:
@@ -103,29 +108,29 @@ class SlackPoller(BasePoller):
                 )
                 return
 
-            # Process only new messages (newer than oldest)
-            # Update ts BEFORE processing to prevent duplicate reads
-            # (processing takes 5-30s, next poll is 3s)
-            all_ts = [m.get("ts", "0") for m in messages if m.get("ts", "0") > oldest]
-            if all_ts:
-                self._last_ts[channel_id] = max(all_ts)
+            # Collect new messages, sorted by timestamp (oldest first)
+            new_messages = sorted(
+                [m for m in messages if m.get("ts", "0") > oldest],
+                key=lambda m: m.get("ts", "0"),
+            )
+            if not new_messages:
+                return
 
-            new_max_ts = self._last_ts[channel_id]
-            for msg in messages:
+            # Process each message; advance ts only AFTER successful processing.
+            # On failure, break — unprocessed messages re-fetched next cycle.
+            for msg in new_messages:
                 ts = msg.get("ts", "")
-                if not ts or ts <= oldest:
+                if not ts:
                     continue
+
                 # Skip bot messages (own messages + other bots)
                 if msg.get("subtype") == "bot_message" or "bot_id" in msg:
-                    if ts > new_max_ts:
-                        new_max_ts = ts
+                    self._last_ts[channel_id] = ts
                     continue
-
-                if ts > new_max_ts:
-                    new_max_ts = ts
 
                 content = msg.get("text", "").strip()
                 if not content:
+                    self._last_ts[channel_id] = ts
                     continue
 
                 log.info("Slack message from %s: %s", msg.get("user", "?"), content[:80])
@@ -140,19 +145,28 @@ class SlackPoller(BasePoller):
                     thread_id=msg.get("thread_ts", ""),
                 )
 
-                # 리액션은 @멘션 메시지에만 (일반 메시지는 리액션 없이 처리)
                 is_mention = "<@" in content
                 if is_mention:
                     self._add_reaction(channel_id, ts, "eyes")
-                response = self._manager.route_message(inbound)
-                log.info("Processor returned: %s", (response or "")[:80])
-                if is_mention:
-                    self._add_reaction(channel_id, ts, "white_check_mark")
 
-                if response:
-                    self._send_response(channel_id, response, thread_ts=inbound.thread_id or ts)
+                try:
+                    response = self._manager.route_message(inbound)
+                    log.info("Processor returned: %s", (response or "")[:80])
+                    if is_mention:
+                        self._add_reaction(channel_id, ts, "white_check_mark")
 
-            self._last_ts[channel_id] = new_max_ts
+                    if response:
+                        self._send_response(
+                            channel_id, response, thread_ts=inbound.thread_id or ts
+                        )
+                except Exception:
+                    log.warning(
+                        "Failed to process message ts=%s, will retry next poll", ts
+                    )
+                    break
+
+                # Advance ts only after successful processing
+                self._last_ts[channel_id] = ts
 
         except Exception:
             log.warning("Slack poll error for %s", channel_id, exc_info=True)

--- a/core/gateway/pollers/slack_poller.py
+++ b/core/gateway/pollers/slack_poller.py
@@ -156,13 +156,9 @@ class SlackPoller(BasePoller):
                         self._add_reaction(channel_id, ts, "white_check_mark")
 
                     if response:
-                        self._send_response(
-                            channel_id, response, thread_ts=inbound.thread_id or ts
-                        )
+                        self._send_response(channel_id, response, thread_ts=inbound.thread_id or ts)
                 except Exception:
-                    log.warning(
-                        "Failed to process message ts=%s, will retry next poll", ts
-                    )
+                    log.warning("Failed to process message ts=%s, will retry next poll", ts)
                     break
 
                 # Advance ts only after successful processing


### PR DESCRIPTION
## Summary
- Deferred-ts pattern prevents message loss on processing failure
- App mention (`<@A...>`) detection added to `_is_mentioned` + `_strip_mentions`

## Why
Slack messages were intermittently dropped because:
1. `_last_ts` was advanced BEFORE processing — if LLM call failed mid-batch, remaining messages were permanently skipped
2. `<@A...>` (Slack app mention format) was not matched by the `[UB]` regex — channels with `require_mention=true` silently ignored app mentions

## Changes
| File | Change |
|------|--------|
| `core/gateway/pollers/slack_poller.py` | Deferred-ts: advance ts only after each successful message processing. On failure, break for retry next cycle. Sorted new_messages by ts (oldest first). |
| `core/gateway/channel_manager.py` | `_is_mentioned`: regex `[UB]` → `[UBA]` to match app mentions. `_strip_mentions`: same regex fix. |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest pass (rc=0)

## Reference
User report: "새 채널에서 응답이 오다가도 오지 않는 경우"

🤖 Generated with [Claude Code](https://claude.com/claude-code)