### PR TITLE
fix: Slack hardening — bot ID mention filter + dedup + error reaction

### DIFF
--- a/core/gateway/channel_manager.py
+++ b/core/gateway/channel_manager.py
@@ -45,13 +45,14 @@ class ChannelManager:
     3. No match → message ignored
     """
 
-    def __init__(self, *, lane_queue: Any = None) -> None:
+    def __init__(self, *, lane_queue: Any = None, bot_user_id: str = "") -> None:
         self._bindings: list[ChannelBinding] = []
         self._pollers: list[BasePoller] = []
         self._processor: MessageProcessor | None = None
         self._lane_queue = lane_queue  # LaneQueue for concurrency control
         self._lock = threading.Lock()
         self._stats: dict[str, int] = {"received": 0, "processed": 0, "ignored": 0}
+        self._bot_user_id = bot_user_id  # Slack bot user ID for mention matching
         # Gateway-level defaults (overridden by config.toml [gateway])
         self.gateway_time_budget_s: float = 120.0  # default 2 min per message
         self.gateway_max_turns: int = 20
@@ -182,32 +183,34 @@ class ChannelManager:
 
         return None
 
-    @staticmethod
-    def _is_mentioned(message: InboundMessage) -> bool:
+    def _is_mentioned(self, message: InboundMessage) -> bool:
         """Check if GEODE is mentioned in the message.
 
-        Detects all Slack mention formats:
-        - ``<@U...>`` — user mention (human or bot user)
-        - ``<@B...>`` — legacy bot mention
-        - ``<@A...>`` — app mention (Slack apps installed in workspace)
-        - Display name variants: ``@geode``, ``geode``, ``@GEODE``
+        Matches only GEODE's own bot user ID (from auth.test ``user_id``)
+        or display name variants. Does NOT match arbitrary ``<@U...>``
+        mentions — those are mentions of other users.
         """
-        import re
-
         content = message.content
-        # Slack encodes @mentions as <@USER_ID>, <@BOT_ID>, or <@APP_ID>
-        if re.search(r"<@[UBA][A-Z0-9]+>", content):
+        # Match GEODE's specific bot user ID (e.g. <@U0ABCDEF123>)
+        if self._bot_user_id and f"<@{self._bot_user_id}>" in content:
             return True
         content_lower = content.lower()
         return any(mention in content_lower for mention in ("@geode", "geode"))
 
-    @staticmethod
-    def _strip_mentions(content: str) -> str:
-        """Remove mention tags so the LLM receives clean user intent."""
+    def _strip_mentions(self, content: str) -> str:
+        """Remove GEODE's own mention tags so the LLM receives clean user intent.
+
+        Only strips GEODE's bot user ID mention and display name variants.
+        Preserves mentions of other users (e.g. ``<@U_OTHER>``).
+        """
         import re
 
-        # Remove Slack-style <@USER_ID>, <@BOT_ID>, and <@APP_ID> mentions
-        cleaned = re.sub(r"<@[UBA][A-Z0-9]+>\s*", "", content)
+        # Remove GEODE's specific bot mention (e.g. <@U0ABCDEF123>)
+        if self._bot_user_id:
+            cleaned = content.replace(f"<@{self._bot_user_id}>", "").strip()
+        else:
+            # Fallback: remove all Slack mentions (legacy behavior)
+            cleaned = re.sub(r"<@[UBA][A-Z0-9]+>\s*", "", content)
         # Remove @geode / @GEODE prefix
         cleaned = re.sub(r"@geode\s*", "", cleaned, flags=re.IGNORECASE)
         return cleaned.strip()
@@ -271,13 +274,21 @@ class ChannelManager:
         for rule in rules:
             if not isinstance(rule, dict) or "channel" not in rule:
                 continue
+            channel_id = rule.get("channel_id", "").strip()
+            if not channel_id:
+                log.warning(
+                    "Skipping binding: channel=%s has no channel_id — "
+                    "empty channel_id would create unsafe catch-all",
+                    rule.get("channel"),
+                )
+                continue
             # Support both time_budget_s and legacy max_rounds
             tb = rule.get("time_budget_s")
             if tb is None and "max_rounds" in rule:
                 tb = float(int(rule["max_rounds"]) * 10)
             binding = ChannelBinding(
                 channel=rule["channel"],
-                channel_id=rule.get("channel_id", ""),
+                channel_id=channel_id,
                 auto_respond=rule.get("auto_respond", True),
                 require_mention=rule.get("require_mention", False),
                 allowed_tools=rule.get("allowed_tools", []),

--- a/core/gateway/pollers/slack_poller.py
+++ b/core/gateway/pollers/slack_poller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import TYPE_CHECKING, Any
 
 from core.gateway.models import InboundMessage
@@ -24,6 +25,8 @@ class SlackPoller(BasePoller):
     Sends responses back via NotificationPort.
     """
 
+    DEDUP_TTL_S = 300  # 5 minutes — matches Kiki's event dedup window
+
     def __init__(
         self,
         channel_manager: ChannelManager,
@@ -36,6 +39,7 @@ class SlackPoller(BasePoller):
         self._mcp = mcp_manager
         self._notification = notification
         self._last_ts: dict[str, str] = {}  # channel_id → last message ts
+        self._seen_events: dict[str, float] = {}  # "channel:ts" → seen_at (dedup)
 
     @property
     def channel_name(self) -> str:
@@ -51,6 +55,9 @@ class SlackPoller(BasePoller):
         health = self._mcp.check_health()
         if not health.get("slack", False):
             return
+
+        # Evict expired dedup entries
+        self._evict_stale_dedup()
 
         # Get channels to monitor from bindings
         bindings = self._manager.list_bindings()
@@ -123,6 +130,13 @@ class SlackPoller(BasePoller):
                 if not ts:
                     continue
 
+                # Dedup: skip already-processed messages (prevents re-processing
+                # on crash/restart within TTL window)
+                dedup_key = f"{channel_id}:{ts}"
+                if dedup_key in self._seen_events:
+                    self._last_ts[channel_id] = ts
+                    continue
+
                 # Skip bot messages (own messages + other bots)
                 if msg.get("subtype") == "bot_message" or "bot_id" in msg:
                     self._last_ts[channel_id] = ts
@@ -145,7 +159,7 @@ class SlackPoller(BasePoller):
                     thread_id=msg.get("thread_ts", ""),
                 )
 
-                is_mention = "<@" in content
+                is_mention = self._manager._is_mentioned(inbound)
                 if is_mention:
                     self._add_reaction(channel_id, ts, "eyes")
 
@@ -159,13 +173,24 @@ class SlackPoller(BasePoller):
                         self._send_response(channel_id, response, thread_ts=inbound.thread_id or ts)
                 except Exception:
                     log.warning("Failed to process message ts=%s, will retry next poll", ts)
+                    # Error reaction: X emoji for visible failure feedback
+                    if is_mention:
+                        self._add_reaction(channel_id, ts, "x")
                     break
 
-                # Advance ts only after successful processing
+                # Advance ts + mark as seen (dedup) only after success
                 self._last_ts[channel_id] = ts
+                self._seen_events[dedup_key] = time.monotonic()
 
         except Exception:
             log.warning("Slack poll error for %s", channel_id, exc_info=True)
+
+    def _evict_stale_dedup(self) -> None:
+        """Remove dedup entries older than TTL."""
+        now = time.monotonic()
+        stale = [k for k, v in self._seen_events.items() if now - v > self.DEDUP_TTL_S]
+        for k in stale:
+            del self._seen_events[k]
 
     def _add_reaction(self, channel_id: str, message_ts: str, emoji: str) -> None:
         """Add a reaction emoji to a message (best-effort, non-blocking)."""

--- a/core/runtime_wiring/adapters.py
+++ b/core/runtime_wiring/adapters.py
@@ -147,6 +147,32 @@ def _load_poller_class(dotted_path: str) -> type:
     return cls
 
 
+def _resolve_slack_bot_user_id() -> str:
+    """Resolve GEODE's Slack bot user ID via auth.test API (best-effort)."""
+    import os
+
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        return ""
+    try:
+        import httpx
+
+        resp = httpx.get(
+            "https://slack.com/api/auth.test",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5.0,
+        )
+        data = resp.json()
+        if data.get("ok"):
+            uid: str = data.get("user_id", "")
+            if uid:
+                log.info("Resolved Slack bot user ID: %s", uid)
+            return uid
+    except Exception as exc:
+        log.debug("Failed to resolve Slack bot user ID: %s", exc)
+    return ""
+
+
 def build_gateway() -> None:
     """Build and inject Gateway with config-driven channel pollers.
 
@@ -173,7 +199,15 @@ def build_gateway() -> None:
         log.warning("Plugin gateway_lane_queue: %s", exc)
         lane_queue = None
 
-    manager = ChannelManager(lane_queue=lane_queue)
+    # Resolve GEODE's Slack bot user ID for accurate mention detection.
+    # Prefers SLACK_BOT_USER_ID env var; falls back to auth.test API call.
+    import os
+
+    bot_user_id = os.environ.get("SLACK_BOT_USER_ID", "")
+    if not bot_user_id and os.environ.get("SLACK_BOT_TOKEN"):
+        bot_user_id = _resolve_slack_bot_user_id()
+
+    manager = ChannelManager(lane_queue=lane_queue, bot_user_id=bot_user_id)
     notification = get_notification()
     poll_interval = settings.gateway_poll_interval_s
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -438,7 +438,7 @@ class TestBindingConfigReload:
                 "bindings": {
                     "rules": [
                         {"channel": "slack", "channel_id": "C123", "auto_respond": True},
-                        {"channel": "discord", "require_mention": True},
+                        {"channel": "discord", "channel_id": "D456", "require_mention": True},
                     ]
                 }
             }
@@ -456,14 +456,14 @@ class TestBindingConfigReload:
 
     def test_reload_replaces_bindings(self):
         manager = ChannelManager()
-        manager.add_binding(ChannelBinding(channel="telegram"))
+        manager.add_binding(ChannelBinding(channel="telegram", channel_id="T999"))
         assert len(manager.list_bindings()) == 1
 
         config = {
             "gateway": {
                 "bindings": {
                     "rules": [
-                        {"channel": "slack"},
+                        {"channel": "slack", "channel_id": "C789"},
                     ]
                 }
             }
@@ -472,6 +472,23 @@ class TestBindingConfigReload:
         bindings = manager.list_bindings()
         assert len(bindings) == 1
         assert bindings[0]["channel"] == "slack"
+
+    def test_empty_channel_id_skipped(self):
+        """Bindings without channel_id are rejected (prevents catch-all)."""
+        config = {
+            "gateway": {
+                "bindings": {
+                    "rules": [
+                        {"channel": "slack"},  # no channel_id
+                        {"channel": "slack", "channel_id": ""},  # empty channel_id
+                        {"channel": "slack", "channel_id": "C123"},  # valid
+                    ]
+                }
+            }
+        }
+        manager = ChannelManager()
+        loaded = manager.load_bindings_from_config(config)
+        assert loaded == 1  # only the valid one
 
 
 class TestMultiTurnMetadata:


### PR DESCRIPTION
## Summary
- Fix all-channel response bug: mention detection now matches only GEODE's own bot user ID
- Block catch-all bindings (empty channel_id rejected in config loading)
- Add event deduplication (5min TTL) and error X emoji reaction

## Why
GEODE was responding in all workspace channels because `_is_mentioned()` matched any `<@U...>` Slack mention (including other users) as a GEODE mention. Combined with the catch-all binding fallback, any message mentioning any user triggered a response.

## Changes
| File | Change |
|------|--------|
| `core/gateway/channel_manager.py` | `_is_mentioned()`: match only `_bot_user_id` instead of all `<@U...>`. `_strip_mentions()`: preserve other users' mentions. `__init__`: accept `bot_user_id` param. `load_bindings_from_config()`: reject empty `channel_id` |
| `core/gateway/pollers/slack_poller.py` | Add `_seen_events` dedup dict (5min TTL). Add X emoji on processing failure. Use `_manager._is_mentioned()` instead of raw `<@` check |
| `core/runtime_wiring/adapters.py` | `_resolve_slack_bot_user_id()`: resolve via auth.test API at startup. Pass `bot_user_id` to `ChannelManager` |
| `tests/test_gateway.py` | Fix tests using empty channel_id. Add `test_empty_channel_id_skipped` |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 3871 passed, 0 failed

## Reference
- Kiki Slack handler: 3-phase reaction UX (eyes → check/X), event dedup (5min TTL)
- Slack auth.test API: returns `user_id` for bot token