### PR TITLE
feat: sandwich-style system injection for multi-turn conversations

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -1255,6 +1255,11 @@ class AgenticLoop:
         Returns a normalized ``AgenticResponse`` or None on failure.
         Raises ``UserCancelledError`` on Ctrl+C (caught by ``arun()``).
         """
+        # Sandwich injection: prepend system reminder to messages (Claude Code pattern)
+        from core.agent.system_injection import prepend_system_reminder
+
+        prepend_system_reminder(messages, model=self.model, round_idx=round_idx)
+
         # Context overflow detection (Karpathy P6 Context Budget)
         self._check_context_overflow(system, messages)
 

--- a/core/agent/system_injection.py
+++ b/core/agent/system_injection.py
@@ -1,0 +1,160 @@
+"""System injection — sandwich-style context reinforcement for multi-turn conversations.
+
+Inspired by Claude Code's ``prependUserContext()`` pattern (utils/api.ts:449-474),
+this module builds a system reminder that is prepended to the messages array
+before each LLM call. This creates a "sandwich" where the user's messages are
+wrapped between the system prompt (above) and the system reminder (inline).
+
+Why: In long multi-turn conversations, instructions in the system prompt drift
+out of the model's attention window. The system reminder reinforces critical
+context (date, active rules, key constraints) at a position closer to the
+latest user message, improving instruction following.
+
+The reminder is injected into a deep-copied messages list (never into the
+stored ConversationContext), so it is ephemeral and regenerated each round.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Tag format for system-injected messages (mirrors Claude Code's <system-reminder>)
+_REMINDER_TAG = "system-reminder"
+
+# Max chars for the reminder to stay within a reasonable token budget
+_MAX_REMINDER_CHARS = 800
+
+
+def build_system_reminder(
+    *,
+    model: str = "",
+    round_idx: int = 0,
+    extra_context: dict[str, str] | None = None,
+) -> str:
+    """Build a system reminder string for sandwich injection.
+
+    Assembles a concise context block containing:
+      - Current date/time (prevents year hallucination in tool calls)
+      - Active analysis rules (from ProjectMemory, if any)
+      - Round index (helps the model track progress)
+      - Extra context (caller-provided key-value pairs)
+
+    Returns empty string if nothing meaningful to inject.
+    """
+    parts: list[str] = []
+
+    # 1. Date context (always useful — prevents stale year in searches)
+    now = datetime.now()
+    parts.append(f"Current date: {now.strftime('%Y-%m-%d (%A)')}")
+
+    # 2. Round awareness
+    if round_idx > 0:
+        parts.append(f"Current round: {round_idx + 1}")
+
+    # 3. Active analysis rules (lightweight — names only)
+    rules_summary = _get_active_rules_summary()
+    if rules_summary:
+        parts.append(f"Active rules: {rules_summary}")
+
+    # 4. Extra context from caller
+    if extra_context:
+        for key, value in extra_context.items():
+            parts.append(f"{key}: {value}")
+
+    if not parts:
+        return ""
+
+    body = "\n".join(parts)
+
+    # Enforce budget
+    if len(body) > _MAX_REMINDER_CHARS:
+        body = body[:_MAX_REMINDER_CHARS] + "..."
+        log.warning("System reminder truncated to %d chars", _MAX_REMINDER_CHARS)
+
+    return body
+
+
+def prepend_system_reminder(
+    messages: list[dict[str, Any]],
+    *,
+    model: str = "",
+    round_idx: int = 0,
+    extra_context: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Prepend a system reminder to the messages list (sandwich injection).
+
+    Creates a user message with the system reminder and inserts it at
+    position 0 of the messages list. The messages list is modified
+    **in-place** (caller should pass a deep copy from ``get_messages()``).
+
+    If the first message is already a system-reminder from a previous
+    injection (e.g., stale from a retry), it is replaced rather than
+    stacked.
+
+    Args:
+        messages: Deep-copied message list (will be modified in-place).
+        model: Current model name (for context).
+        round_idx: Current round index in the agentic loop.
+        extra_context: Additional key-value pairs to include.
+
+    Returns:
+        The same messages list (for chaining convenience).
+    """
+    reminder = build_system_reminder(
+        model=model,
+        round_idx=round_idx,
+        extra_context=extra_context,
+    )
+
+    if not reminder:
+        return messages
+
+    reminder_message: dict[str, Any] = {
+        "role": "user",
+        "content": f"[{_REMINDER_TAG}]\n{reminder}\n[/{_REMINDER_TAG}]",
+    }
+
+    # Replace stale reminder if present (idempotent injection)
+    if messages and _is_system_reminder(messages[0]):
+        messages[0] = reminder_message
+    else:
+        messages.insert(0, reminder_message)
+
+    return messages
+
+
+def _is_system_reminder(message: dict[str, Any]) -> bool:
+    """Check if a message is a system reminder (for dedup)."""
+    if message.get("role") != "user":
+        return False
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content.startswith(f"[{_REMINDER_TAG}]")
+    return False
+
+
+def _get_active_rules_summary() -> str:
+    """Get a one-line summary of active analysis rules from ProjectMemory.
+
+    Returns empty string on any failure (graceful degradation).
+    """
+    try:
+        from core.memory.project import ProjectMemory
+
+        mem = ProjectMemory()
+        if not mem.exists():
+            return ""
+
+        rules = mem.list_rules()
+        if not rules:
+            return ""
+
+        names = [r["name"] for r in rules[:5]]
+        return ", ".join(names)
+    except Exception:
+        log.debug("Failed to get active rules for system reminder", exc_info=True)
+        return ""

--- a/tests/test_system_injection.py
+++ b/tests/test_system_injection.py
@@ -1,0 +1,170 @@
+"""Tests for core.agent.system_injection — sandwich-style context reinforcement.
+
+Covers:
+  1. build_system_reminder: content assembly, budget enforcement
+  2. prepend_system_reminder: injection, idempotency, empty-case
+  3. _is_system_reminder: tag detection
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.agent.system_injection import (
+    _MAX_REMINDER_CHARS,
+    _REMINDER_TAG,
+    _is_system_reminder,
+    build_system_reminder,
+    prepend_system_reminder,
+)
+
+# ---------------------------------------------------------------------------
+# build_system_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSystemReminder:
+    """Tests for build_system_reminder()."""
+
+    def test_includes_date(self) -> None:
+        """Reminder always includes current date."""
+        result = build_system_reminder()
+        assert "Current date:" in result
+
+    def test_includes_round_when_nonzero(self) -> None:
+        """Round index included when > 0."""
+        result = build_system_reminder(round_idx=3)
+        assert "Current round: 4" in result
+
+    def test_excludes_round_when_zero(self) -> None:
+        """Round index excluded at round 0."""
+        result = build_system_reminder(round_idx=0)
+        assert "Current round" not in result
+
+    def test_extra_context_included(self) -> None:
+        """Extra context key-value pairs are included."""
+        result = build_system_reminder(extra_context={"task": "analyze Berserk"})
+        assert "task: analyze Berserk" in result
+
+    def test_budget_enforcement(self) -> None:
+        """Reminder truncated when exceeding budget."""
+        huge_ctx = {"data": "x" * (_MAX_REMINDER_CHARS + 500)}
+        result = build_system_reminder(extra_context=huge_ctx)
+        assert len(result) <= _MAX_REMINDER_CHARS + 10  # +10 for "..." and tag
+        assert result.endswith("...")
+
+    @patch("core.agent.system_injection._get_active_rules_summary", return_value="rule_a, rule_b")
+    def test_active_rules_included(self, _mock: object) -> None:
+        """Active rules summary injected when available."""
+        result = build_system_reminder()
+        assert "Active rules: rule_a, rule_b" in result
+
+    @patch("core.agent.system_injection._get_active_rules_summary", return_value="")
+    def test_no_rules_graceful(self, _mock: object) -> None:
+        """No crash when no active rules."""
+        result = build_system_reminder()
+        assert "Active rules" not in result
+
+
+# ---------------------------------------------------------------------------
+# prepend_system_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestPrependSystemReminder:
+    """Tests for prepend_system_reminder()."""
+
+    def test_prepends_to_empty_messages(self) -> None:
+        """Injection into empty messages list."""
+        messages: list[dict] = []
+        result = prepend_system_reminder(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert f"[{_REMINDER_TAG}]" in result[0]["content"]
+
+    def test_prepends_before_user_message(self) -> None:
+        """Reminder appears before the first user message."""
+        messages = [{"role": "user", "content": "Hello"}]
+        result = prepend_system_reminder(messages)
+        assert len(result) == 2
+        assert _is_system_reminder(result[0])
+        assert result[1]["content"] == "Hello"
+
+    def test_idempotent_no_stacking(self) -> None:
+        """Calling twice replaces rather than stacking reminders."""
+        messages = [{"role": "user", "content": "Hello"}]
+        prepend_system_reminder(messages, round_idx=0)
+        assert len(messages) == 2
+
+        prepend_system_reminder(messages, round_idx=1)
+        assert len(messages) == 2  # replaced, not stacked
+        assert "Current round: 2" in messages[0]["content"]
+
+    def test_modifies_in_place(self) -> None:
+        """Messages list modified in-place (returns same reference)."""
+        messages = [{"role": "user", "content": "test"}]
+        result = prepend_system_reminder(messages)
+        assert result is messages
+
+    def test_preserves_existing_messages(self) -> None:
+        """Original messages preserved after injection."""
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ]
+        prepend_system_reminder(messages)
+        assert len(messages) == 4
+        assert messages[1]["content"] == "first"
+        assert messages[2]["content"] == "reply"
+        assert messages[3]["content"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# _is_system_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestIsSystemReminder:
+    """Tests for _is_system_reminder()."""
+
+    def test_detects_reminder(self) -> None:
+        msg = {"role": "user", "content": f"[{_REMINDER_TAG}]\nsome context\n[/{_REMINDER_TAG}]"}
+        assert _is_system_reminder(msg) is True
+
+    def test_rejects_assistant(self) -> None:
+        msg = {"role": "assistant", "content": f"[{_REMINDER_TAG}]\nfoo"}
+        assert _is_system_reminder(msg) is False
+
+    def test_rejects_normal_user(self) -> None:
+        msg = {"role": "user", "content": "Hello, please analyze Berserk"}
+        assert _is_system_reminder(msg) is False
+
+    def test_rejects_list_content(self) -> None:
+        """Tool result messages (list content) are not reminders."""
+        msg = {"role": "user", "content": [{"type": "tool_result", "content": "ok"}]}
+        assert _is_system_reminder(msg) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: AgenticLoop wiring (mock-based)
+# ---------------------------------------------------------------------------
+
+
+class TestAgenticLoopIntegration:
+    """Verify that system injection is wired into the agentic loop."""
+
+    def test_import_succeeds(self) -> None:
+        """Module imports cleanly from the agentic loop's call site."""
+        from core.agent.system_injection import prepend_system_reminder
+
+        assert callable(prepend_system_reminder)
+
+    def test_injection_in_call_path(self) -> None:
+        """Verify _call_llm source references system_injection."""
+        import inspect
+
+        from core.agent.agentic_loop import AgenticLoop
+
+        source = inspect.getsource(AgenticLoop._call_llm)
+        assert "prepend_system_reminder" in source


### PR DESCRIPTION
## Summary
- AgenticLoop에 sandwich-style system injection 추가 — 매 LLM 호출마다 `[system-reminder]` 메시지를 messages 앞에 주입
- Claude Code의 `prependUserContext()` 패턴을 GEODE에 적용

## Why
긴 multi-turn 대화에서 system prompt이 context window 상단에만 존재하면 instruction following이 약화됨. 핵심 컨텍스트(날짜, 라운드, 활성 룰)를 user message 바로 앞에 sandwich 주입하여 모델 attention 범위 내에 유지.

## Changes
| File | Change |
|------|--------|
| `core/agent/system_injection.py` | NEW — build_system_reminder + prepend_system_reminder + dedup |
| `core/agent/agentic_loop.py` | `_call_llm()`에 prepend_system_reminder 호출 추가 (3줄) |
| `tests/test_system_injection.py` | NEW — 18 test cases |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Pre-user system reminder injection | Implemented | Claude Code prependUserContext 패턴 |
| Per-round context refresh | Implemented | round_idx + date + active rules |
| Pipeline node injection | Dropped | 단일 턴 호출이라 sandwich 실효성 낮음 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 18/18 pass (+ 15 assembler = 33 total)
- [x] E2E: Cowboy Bebop A (68.4) unchanged

## Reference
- Claude Code `prependUserContext()`: `utils/api.ts:449-474`
- Frontier pattern: Claude Code, OpenAI Assistants, Anthropic cookbook sandwich prompting