### PR TITLE
refactor: deduplicate date/rules between system_injection and system_prompt

### DIFF
--- a/core/agent/system_injection.py
+++ b/core/agent/system_injection.py
@@ -17,7 +17,6 @@ stored ConversationContext), so it is ephemeral and regenerated each round.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -47,18 +46,21 @@ def build_system_reminder(
     """
     parts: list[str] = []
 
-    # 1. Date context (always useful — prevents stale year in searches)
-    now = datetime.now()
-    parts.append(f"Current date: {now.strftime('%Y-%m-%d (%A)')}")
+    # 1. Date context (shared helper — prevents stale year in searches)
+    from core.agent.system_prompt import format_current_date
+
+    parts.append(f"Current date: {format_current_date()}")
 
     # 2. Round awareness
     if round_idx > 0:
         parts.append(f"Current round: {round_idx + 1}")
 
-    # 3. Active analysis rules (lightweight — names only)
-    rules_summary = _get_active_rules_summary()
-    if rules_summary:
-        parts.append(f"Active rules: {rules_summary}")
+    # 3. Active analysis rules (shared helper — names only)
+    from core.agent.system_prompt import get_active_rule_names
+
+    rule_names = get_active_rule_names()
+    if rule_names:
+        parts.append(f"Active rules: {', '.join(rule_names)}")
 
     # 4. Extra context from caller
     if extra_context:
@@ -135,26 +137,3 @@ def _is_system_reminder(message: dict[str, Any]) -> bool:
     if isinstance(content, str):
         return content.startswith(f"[{_REMINDER_TAG}]")
     return False
-
-
-def _get_active_rules_summary() -> str:
-    """Get a one-line summary of active analysis rules from ProjectMemory.
-
-    Returns empty string on any failure (graceful degradation).
-    """
-    try:
-        from core.memory.project import ProjectMemory
-
-        mem = ProjectMemory()
-        if not mem.exists():
-            return ""
-
-        rules = mem.list_rules()
-        if not rules:
-            return ""
-
-        names = [r["name"] for r in rules[:5]]
-        return ", ".join(names)
-    except Exception:
-        log.debug("Failed to get active rules for system reminder", exc_info=True)
-        return ""

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -94,6 +94,39 @@ def build_system_prompt(model: str = "") -> str:
     return base
 
 
+def format_current_date() -> str:
+    """Return the current date as ``YYYY-MM-DD (Weekday)`` string.
+
+    Shared helper used by both the system prompt and system injection
+    to avoid duplicate ``datetime.now()`` formatting.
+    """
+    return datetime.now().strftime("%Y-%m-%d (%A)")
+
+
+def get_active_rule_names(limit: int = 5) -> list[str]:
+    """Return active analysis rule names from ProjectMemory.
+
+    Shared helper used by both the system prompt (G4 detailed view)
+    and system injection (lightweight summary).  Returns empty list
+    on any failure (graceful degradation).
+    """
+    try:
+        from core.memory.project import ProjectMemory
+
+        mem = ProjectMemory()
+        if not mem.exists():
+            return []
+
+        rules = mem.list_rules()
+        if not rules:
+            return []
+
+        return [r["name"] for r in rules[:limit]]
+    except Exception:
+        log.debug("Failed to get active rule names", exc_info=True)
+        return []
+
+
 def _build_date_context() -> str:
     """Build current date string for system prompt injection.
 
@@ -101,9 +134,10 @@ def _build_date_context() -> str:
     searching for recent information.
     """
     now = datetime.now()
+    date_str = format_current_date()
     return (
         f"## Current Date\n"
-        f"Today is {now.strftime('%Y-%m-%d (%A)')}. "
+        f"Today is {date_str}. "
         f"The current year is {now.year}. "
         f"When searching for recent or latest information, use {now.year} as the base year."
     )
@@ -346,6 +380,8 @@ def _build_project_memory_context() -> str:
     """G4: Build runtime project memory (insights + rules) from ProjectMemory.
 
     This is the original _build_memory_context logic, now isolated as G4.
+    Note: G4 needs full rule details (name + paths), so it calls
+    ``mem.list_rules()`` directly rather than ``get_active_rule_names()``.
     """
     try:
         from core.memory.project import ProjectMemory
@@ -364,7 +400,7 @@ def _build_project_memory_context() -> str:
             if lines:
                 parts.append("Recent insights:\n" + "\n".join(lines[:5]))
 
-        # Active rules summary
+        # Active rules summary (detailed — name + paths)
         rules = mem.list_rules()
         if rules:
             rule_summaries = [

--- a/tests/test_system_injection.py
+++ b/tests/test_system_injection.py
@@ -53,13 +53,15 @@ class TestBuildSystemReminder:
         assert len(result) <= _MAX_REMINDER_CHARS + 10  # +10 for "..." and tag
         assert result.endswith("...")
 
-    @patch("core.agent.system_injection._get_active_rules_summary", return_value="rule_a, rule_b")
+    @patch(
+        "core.agent.system_prompt.get_active_rule_names", return_value=["rule_a", "rule_b"]
+    )
     def test_active_rules_included(self, _mock: object) -> None:
         """Active rules summary injected when available."""
         result = build_system_reminder()
         assert "Active rules: rule_a, rule_b" in result
 
-    @patch("core.agent.system_injection._get_active_rules_summary", return_value="")
+    @patch("core.agent.system_prompt.get_active_rule_names", return_value=[])
     def test_no_rules_graceful(self, _mock: object) -> None:
         """No crash when no active rules."""
         result = build_system_reminder()


### PR DESCRIPTION
## Summary
- system_injection과 system_prompt 간 중복 코드 제거
- 공유 헬퍼 `format_current_date()`, `get_active_rule_names()` 추출

## Why
두 모듈이 독립적으로 `datetime.now().strftime()` + `ProjectMemory().list_rules()[:5]`를 호출 — 한쪽만 수정하면 drift 발생 위험

## Changes
| File | Change |
|------|--------|
| `core/agent/system_prompt.py` | `format_current_date()`, `get_active_rule_names()` public 헬퍼 추출 |
| `core/agent/system_injection.py` | 자체 datetime/ProjectMemory 접근 제거 → shared helper import |
| `tests/test_system_injection.py` | mock 경로를 shared helper로 변경 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 33/33 pass
- [x] E2E: Cowboy Bebop A (68.4) unchanged