### PR TITLE
feat: reasoning depth infrastructure — DTR-inspired adaptive compute

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -155,6 +155,7 @@ class AgenticResult:
     # | "llm_error" | "context_exhausted" | "cost_budget_exceeded"
     termination_reason: str = "unknown"
     summary: str = ""  # Tier 1 compact action summary (auto-generated)
+    reasoning_metrics: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting None-valued fields."""
@@ -180,6 +181,7 @@ class AgenticLoop:
         *,
         max_rounds: int = DEFAULT_MAX_ROUNDS,
         max_tokens: int = DEFAULT_MAX_TOKENS,
+        thinking_budget: int = 0,  # 0 = disabled; >0 = Extended Thinking tokens
         time_budget_s: float = 0.0,  # 0 = no time limit (OpenClaw pattern)
         cost_budget: float = 0.0,  # 0 = no cost limit (Karpathy P3)
         model: str | None = None,
@@ -200,7 +202,12 @@ class AgenticLoop:
         self._quiet = quiet  # suppress spinner (sub-agent, headless)
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens
+        self._thinking_budget = thinking_budget
         self._time_budget_s = time_budget_s
+        # Adaptive compute: track consecutive text-only rounds for overthinking detection
+        self._consecutive_text_only_rounds = 0
+        self._total_thinking_tokens = 0
+        self._total_empty_rounds = 0
         self._cost_budget = cost_budget
         self._loop_start_time: float = 0.0
         self.model = model or ANTHROPIC_PRIMARY
@@ -349,6 +356,11 @@ class AgenticLoop:
             self.max_rounds,
             len(result.tool_calls),
         )
+
+        # Reasoning metrics (DTR-inspired observability)
+        metrics = self._build_reasoning_metrics(result)
+        result.reasoning_metrics = metrics.to_dict()
+
         self._record_transcript_end(result)
         self._save_checkpoint(user_input, round_idx=round_idx)
         if self._hooks:
@@ -374,7 +386,40 @@ class AgenticLoop:
                     "termination_reason": result.termination_reason,
                 },
             )
+            self._hooks.trigger(
+                HookEvent.REASONING_METRICS,
+                result.reasoning_metrics,
+            )
         return result
+
+    def _build_reasoning_metrics(self, result: AgenticResult) -> Any:
+        """Collect reasoning efficiency metrics for this turn."""
+        from core.agent.reasoning_metrics import ReasoningMetrics
+
+        try:
+            from core.llm.token_tracker import get_tracker
+
+            tracker = get_tracker()
+            acc = tracker.accumulator
+            thinking_tok = int(acc.total_thinking_tokens)
+            output_tok = int(acc.total_output_tokens)
+            cost = float(acc.total_cost_usd)
+        except Exception:
+            thinking_tok = 0
+            output_tok = 0
+            cost = 0.0
+
+        metrics = ReasoningMetrics(
+            total_rounds=result.rounds,
+            thinking_tokens=self._total_thinking_tokens + thinking_tok,
+            output_tokens=output_tok,
+            tool_calls_total=len(result.tool_calls),
+            empty_rounds=self._total_empty_rounds,
+            cost_usd=cost,
+            overthinking_detected=self._consecutive_text_only_rounds >= 2,
+        )
+        metrics.compute_derived()
+        return metrics
 
     def refresh_tools(self) -> int:
         """Reload MCP tools into the tool list without reconstructing the loop.
@@ -957,6 +1002,23 @@ class AgenticLoop:
                 except Exception:
                     log.debug("Cost budget check failed", exc_info=True)
 
+            # Adaptive compute: overthinking detection (DTR insight)
+            # Consecutive rounds with long text but no tool calls = overthinking signal
+            if response.stop_reason != "tool_use":
+                out_tok = getattr(response.usage, "output_tokens", 0) if response.usage else 0
+                if out_tok > 2000:
+                    self._consecutive_text_only_rounds += 1
+                else:
+                    self._consecutive_text_only_rounds = 0
+                if self._consecutive_text_only_rounds >= 2:
+                    self._total_empty_rounds += self._consecutive_text_only_rounds
+                    log.warning(
+                        "Overthinking detected: %d consecutive text-only rounds (>2000 tok each)",
+                        self._consecutive_text_only_rounds,
+                    )
+            else:
+                self._consecutive_text_only_rounds = 0
+
             if response.stop_reason != "tool_use":
                 # end_turn or max_tokens → extract text, done
                 self._op_logger.finalize()
@@ -1275,14 +1337,27 @@ class AgenticLoop:
             force_text = remaining_time <= self._WRAP_UP_TIME_HEADROOM_S
         tool_choice: dict[str, str] = {"type": "none"} if force_text else {"type": "auto"}
 
+        # Adaptive compute allocation (DTR insight: match budget to round purpose)
+        adaptive_max_tokens = self.max_tokens
+        adaptive_thinking = self._thinking_budget
+        if force_text:
+            # Wrap-up: minimal budget — summarize, don't reason
+            adaptive_max_tokens = min(self.max_tokens, 4096)
+            adaptive_thinking = 0
+        elif self._consecutive_text_only_rounds >= 2:
+            # Overthinking: reduce budget to curb verbose non-actionable output
+            adaptive_max_tokens = min(self.max_tokens, 16384)
+            adaptive_thinking = min(adaptive_thinking, adaptive_thinking // 2)
+
         response = await self._adapter.agentic_call(
             model=self.model,
             system=system,
             messages=messages,
             tools=self._tools,
             tool_choice=tool_choice,
-            max_tokens=self.max_tokens,
+            max_tokens=adaptive_max_tokens,
             temperature=0.0,
+            thinking_budget=adaptive_thinking,
         )
 
         if response is None:
@@ -1329,15 +1404,19 @@ class AgenticLoop:
 
             in_tok = response.usage.input_tokens
             out_tok = response.usage.output_tokens
+            think_tok = getattr(response.usage, "thinking_tokens", 0) or 0
             tracker = get_tracker()
-            usage = tracker.record(self.model, in_tok, out_tok)
+            usage = tracker.record(
+                self.model, in_tok, out_tok, thinking_tokens=think_tok,
+            )
             if not self._quiet:
                 render_tokens(self.model, in_tok, out_tok, cost_usd=usage.cost_usd)
             log.info(
-                "LLM call: model=%s in=%d out=%d cost=$%.4f",
+                "LLM call: model=%s in=%d out=%d think=%d cost=$%.4f",
                 self.model,
                 in_tok,
                 out_tok,
+                think_tok,
                 usage.cost_usd,
             )
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -1407,7 +1407,10 @@ class AgenticLoop:
             think_tok = getattr(response.usage, "thinking_tokens", 0) or 0
             tracker = get_tracker()
             usage = tracker.record(
-                self.model, in_tok, out_tok, thinking_tokens=think_tok,
+                self.model,
+                in_tok,
+                out_tok,
+                thinking_tokens=think_tok,
             )
             if not self._quiet:
                 render_tokens(self.model, in_tok, out_tok, cost_usd=usage.cost_usd)

--- a/core/agent/reasoning_metrics.py
+++ b/core/agent/reasoning_metrics.py
@@ -1,0 +1,50 @@
+"""Reasoning efficiency metrics — DTR-inspired observability.
+
+Tracks per-session reasoning quality signals:
+- Thinking token ratio (thinking / total output)
+- Empty rounds (text-only, no tool calls)
+- Overthinking detection
+- Cost per tool call
+
+Reference: "Think Deep, Not Just Long" (arXiv 2602.13517)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ReasoningMetrics:
+    """Per-session reasoning efficiency snapshot."""
+
+    total_rounds: int = 0
+    thinking_tokens: int = 0
+    output_tokens: int = 0
+    thinking_ratio: float = 0.0
+    tool_calls_total: int = 0
+    empty_rounds: int = 0
+    cost_usd: float = 0.0
+    cost_per_tool_call: float = 0.0
+    overthinking_detected: bool = False
+
+    def compute_derived(self) -> None:
+        """Recompute derived fields from raw counters."""
+        total = self.thinking_tokens + self.output_tokens
+        self.thinking_ratio = self.thinking_tokens / total if total > 0 else 0.0
+        self.cost_per_tool_call = (
+            self.cost_usd / self.tool_calls_total if self.tool_calls_total > 0 else 0.0
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total_rounds": self.total_rounds,
+            "thinking_tokens": self.thinking_tokens,
+            "output_tokens": self.output_tokens,
+            "thinking_ratio": round(self.thinking_ratio, 4),
+            "tool_calls_total": self.tool_calls_total,
+            "empty_rounds": self.empty_rounds,
+            "cost_usd": round(self.cost_usd, 6),
+            "cost_per_tool_call": round(self.cost_per_tool_call, 6),
+            "overthinking_detected": self.overthinking_detected,
+        }

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -507,6 +507,14 @@ class SubAgentManager:
         domain = get_domain_or_none()
         denied = list(self._denied_tools | {"delegate_task"})
 
+        # Adaptive thinking budget based on task difficulty hint
+        task_thinking = settings.agentic_thinking_budget
+        difficulty = getattr(task, "difficulty", "medium")
+        if difficulty == "low":
+            task_thinking = 0
+        elif difficulty == "high":
+            task_thinking = max(task_thinking, 8192)
+
         return WorkerRequest(
             task_id=task.task_id,
             task_type=task.task_type,
@@ -517,6 +525,7 @@ class SubAgentManager:
             provider=_resolve_provider(settings.model),
             timeout_s=self._timeout_s,
             time_budget_s=self._time_budget_s,
+            thinking_budget=task_thinking,
             domain=domain.name if domain else "",
         )
 

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -46,6 +46,7 @@ class WorkerRequest:
     provider: str = "anthropic"
     timeout_s: float = 120.0
     time_budget_s: float = 0.0  # 0 = inherit parent's budget
+    thinking_budget: int = 0  # 0 = disabled; >0 = thinking tokens per call
     domain: str = ""  # Domain adapter name (e.g. "game_ip") or ""
     isolation: str = ""  # Reserved for Phase 3: "worktree" etc.
 

--- a/core/config.py
+++ b/core/config.py
@@ -44,6 +44,7 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "pipeline.confidence_threshold": "confidence_threshold",
     "pipeline.max_iterations": "max_iterations",
     "agentic.time_budget": "agentic_loop_time_budget",
+    "agentic.thinking_budget": "agentic_thinking_budget",
     "sandbox.max_file_size_bytes": "sandbox_max_file_size_bytes",
     "sandbox.max_read_tokens": "sandbox_max_read_tokens",
     "sandbox.max_glob_results": "sandbox_max_glob_results",
@@ -242,6 +243,9 @@ class Settings(BaseSettings):
 
     # Agentic Loop — time budget (Karpathy P3, OpenClaw Attempt Loop)
     agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
+
+    # Agentic Loop — thinking budget (DTR: Extended Thinking / reasoning tokens)
+    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call
 
     # Cost guard — session-level cost limit (0 = no limit)
     cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -126,6 +126,9 @@ class HookEvent(Enum):
     COST_LIMIT_EXCEEDED = "cost_limit_exceeded"
     EXECUTION_CANCELLED = "execution_cancelled"
 
+    # Reasoning metrics (DTR-inspired observability)
+    REASONING_METRICS = "reasoning_metrics"
+
 
 @dataclass
 class HookResult:

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -188,6 +188,7 @@ class AgenticLLMPort(Protocol):
         tool_choice: dict[str, str] | str,
         max_tokens: int,
         temperature: float,
+        thinking_budget: int = 0,
     ) -> AgenticResponse | None: ...
 
     def reset_client(self) -> None: ...

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -39,6 +39,7 @@ class ResponseUsage:
 
     input_tokens: int = 0
     output_tokens: int = 0
+    thinking_tokens: int = 0
 
 
 @dataclass
@@ -72,9 +73,14 @@ def normalize_anthropic(response: Any) -> AgenticResponse:
 
     usage = ResponseUsage()
     if response.usage:
+        # Anthropic Extended Thinking: thinking tokens tracked separately
+        thinking_tok = 0
+        if hasattr(response.usage, "thinking_tokens"):
+            thinking_tok = response.usage.thinking_tokens or 0
         usage = ResponseUsage(
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens,
+            thinking_tokens=thinking_tok,
         )
 
     return AgenticResponse(
@@ -120,9 +126,15 @@ def normalize_openai(response: Any) -> AgenticResponse:
 
     usage = ResponseUsage()
     if response.usage:
+        # OpenAI reasoning models: reasoning_tokens in completion_tokens_details
+        thinking_tok = 0
+        details = getattr(response.usage, "completion_tokens_details", None)
+        if details is not None:
+            thinking_tok = getattr(details, "reasoning_tokens", 0) or 0
         usage = ResponseUsage(
             input_tokens=response.usage.prompt_tokens or 0,
             output_tokens=response.usage.completion_tokens or 0,
+            thinking_tokens=thinking_tok,
         )
 
     return AgenticResponse(
@@ -176,9 +188,15 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
 
     usage = ResponseUsage()
     if hasattr(response, "usage") and response.usage is not None:
+        # OpenAI Responses API: reasoning_tokens in output_tokens_details
+        thinking_tok = 0
+        details = getattr(response.usage, "output_tokens_details", None)
+        if details is not None:
+            thinking_tok = getattr(details, "reasoning_tokens", 0) or 0
         usage = ResponseUsage(
             input_tokens=getattr(response.usage, "input_tokens", 0) or 0,
             output_tokens=getattr(response.usage, "output_tokens", 0) or 0,
+            thinking_tokens=thinking_tok,
         )
 
     return AgenticResponse(

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -297,6 +297,7 @@ class ClaudeAgenticAdapter:
         tool_choice: dict[str, str] | str,
         max_tokens: int,
         temperature: float,
+        thinking_budget: int = 0,
     ) -> Any | None:
         from core.llm.agentic_response import normalize_anthropic
         from core.llm.errors import LLMBadRequestError, UserCancelledError
@@ -354,17 +355,37 @@ class ClaudeAgenticAdapter:
                     ]
                 }
 
-            return await self._client.messages.create(  # type: ignore[union-attr]
-                model=m,
-                system=system,
-                messages=messages,
-                tools=api_tools,
-                tool_choice=tool_choice,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                extra_headers=extra_h if extra_h else None,
-                extra_body=extra_b if extra_b else None,
-            )
+            # Extended Thinking: budget_tokens > 0 enables thinking mode
+            call_temperature = temperature
+            call_max_tokens = max_tokens
+            thinking_param: dict[str, Any] | None = None
+            if thinking_budget > 0:
+                thinking_param = {
+                    "type": "enabled",
+                    "budget_tokens": thinking_budget,
+                }
+                # Anthropic API requires temperature=1 with Extended Thinking
+                call_temperature = 1.0
+                # max_tokens must accommodate both thinking + output
+                call_max_tokens = max(max_tokens, thinking_budget + max_tokens)
+
+            create_kwargs: dict[str, Any] = {
+                "model": m,
+                "system": system,
+                "messages": messages,
+                "tools": api_tools,
+                "tool_choice": tool_choice,
+                "max_tokens": call_max_tokens,
+                "temperature": call_temperature,
+            }
+            if thinking_param is not None:
+                create_kwargs["thinking"] = thinking_param
+            if extra_h:
+                create_kwargs["extra_headers"] = extra_h
+            if extra_b:
+                create_kwargs["extra_body"] = extra_b
+
+            return await self._client.messages.create(**create_kwargs)  # type: ignore[union-attr]
 
         try:
             response, used_model = await call_with_failover(failover_models, _do_call)

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -110,6 +110,7 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
         tool_choice: dict[str, str] | str,
         max_tokens: int,
         temperature: float,
+        thinking_budget: int = 0,
     ) -> Any | None:
         """GLM agentic call with native web_search injection."""
         client = self._ensure_client(model)

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -465,6 +465,7 @@ class OpenAIAgenticAdapter:
         tool_choice: dict[str, str] | str,
         max_tokens: int,
         temperature: float,
+        thinking_budget: int = 0,
     ) -> Any | None:
         from core.llm.errors import UserCancelledError
         from core.llm.router import call_with_failover
@@ -503,16 +504,27 @@ class OpenAIAgenticAdapter:
         responses_input = _convert_messages_to_responses(system, messages)
         failover_models = [model] + [m for m in self.fallback_chain if m != model]
 
+        # OpenAI reasoning models that support reasoning effort
+        _REASONING_MODELS = {"o3", "o4-mini", "o3-mini"}
+
         async def _do_call(m: str) -> Any:
-            return await asyncio.to_thread(
-                client.responses.create,
-                model=m,
-                input=responses_input,
-                tools=oai_tools if oai_tools else None,
-                tool_choice=tc_val if oai_tools else None,
-                max_output_tokens=max_tokens,
-                temperature=temperature,
-            )
+            create_kwargs: dict[str, Any] = {
+                "model": m,
+                "input": responses_input,
+                "tools": oai_tools if oai_tools else None,
+                "tool_choice": tc_val if oai_tools else None,
+                "max_output_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            # Map thinking_budget to reasoning effort for reasoning models
+            if thinking_budget > 0 and m in _REASONING_MODELS:
+                if thinking_budget <= 4096:
+                    create_kwargs["reasoning"] = {"effort": "low"}
+                elif thinking_budget <= 16384:
+                    create_kwargs["reasoning"] = {"effort": "medium"}
+                else:
+                    create_kwargs["reasoning"] = {"effort": "high"}
+            return await asyncio.to_thread(client.responses.create, **create_kwargs)
 
         try:
             response, used_model = await call_with_failover(failover_models, _do_call)

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -38,15 +38,19 @@ class LLMUsage:
     model: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
+    thinking_tokens: int = 0
     cost_usd: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "model": self.model,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cost_usd": self.cost_usd,
         }
+        if self.thinking_tokens:
+            d["thinking_tokens"] = self.thinking_tokens
+        return d
 
 
 @dataclass
@@ -64,6 +68,10 @@ class LLMUsageAccumulator:
         return sum(c.output_tokens for c in self.calls)
 
     @property
+    def total_thinking_tokens(self) -> int:
+        return sum(c.thinking_tokens for c in self.calls)
+
+    @property
     def total_cost_usd(self) -> float:
         return sum(c.cost_usd for c in self.calls)
 
@@ -71,12 +79,16 @@ class LLMUsageAccumulator:
         self.calls.append(usage)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "call_count": len(self.calls),
             "total_input_tokens": self.total_input_tokens,
             "total_output_tokens": self.total_output_tokens,
             "total_cost_usd": self.total_cost_usd,
         }
+        thinking = self.total_thinking_tokens
+        if thinking:
+            d["total_thinking_tokens"] = thinking
+        return d
 
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -89,23 +101,31 @@ class ModelPrice:
     """Per-token pricing for a single model.
 
     Anthropic: cache_write = input × 1.25, cache_read = input × 0.1
+               thinking = output price (Extended Thinking billed as output)
     OpenAI:    cache_read = provider-specific fixed price (no write cost)
+               thinking = output price (reasoning tokens billed as output)
     """
 
     input: float
     output: float
     cache_write: float = 0.0
     cache_read: float = 0.0
+    thinking: float = 0.0
 
 
 def _ant(input_mtok: float, output_mtok: float) -> ModelPrice:
-    """Anthropic pricing with standard 5-min cache multipliers (1.25× / 0.1×)."""
+    """Anthropic pricing with standard 5-min cache multipliers (1.25× / 0.1×).
+
+    Extended Thinking tokens are billed at the same rate as output tokens.
+    """
     inp = input_mtok / 1_000_000
+    out = output_mtok / 1_000_000
     return ModelPrice(
         input=inp,
-        output=output_mtok / 1_000_000,
+        output=out,
         cache_write=inp * 1.25,
         cache_read=inp * 0.1,
+        thinking=out,
     )
 
 
@@ -113,12 +133,18 @@ def _oai(
     input_mtok: float,
     output_mtok: float,
     cached_mtok: float = 0.0,
+    reasoning: bool = False,
 ) -> ModelPrice:
-    """OpenAI pricing with optional cached-input price."""
+    """OpenAI pricing with optional cached-input price.
+
+    Reasoning models (o3, o4-mini): reasoning tokens billed as output tokens.
+    """
+    out = output_mtok / 1_000_000
     return ModelPrice(
         input=input_mtok / 1_000_000,
-        output=output_mtok / 1_000_000,
+        output=out,
         cache_read=cached_mtok / 1_000_000 if cached_mtok else 0.0,
+        thinking=out if reasoning else 0.0,
     )
 
 
@@ -150,8 +176,8 @@ MODEL_PRICING: dict[str, ModelPrice] = {
     "gpt-4.1-nano": _oai(0.20,  0.80, cached_mtok=0.05),
 
     # ── OpenAI Reasoning (verified 2026-03-19) ─────────────────────────
-    "o3":       _oai(2.00,  8.00),
-    "o4-mini":  _oai(1.10,  4.40, cached_mtok=0.275),
+    "o3":       _oai(2.00,  8.00, reasoning=True),
+    "o4-mini":  _oai(1.10,  4.40, cached_mtok=0.275, reasoning=True),
 
     # ── ZhipuAI GLM (verified 2026-03-19) ──────────────────────────────
     # Source: https://open.bigmodel.cn/pricing + https://docs.z.ai
@@ -236,6 +262,7 @@ class TokenTracker:
         *,
         cache_creation_tokens: int = 0,
         cache_read_tokens: int = 0,
+        thinking_tokens: int = 0,
     ) -> LLMUsage:
         """Record one LLM call: cost → accumulator → optional LangSmith."""
         cost = self.calculate_cost(
@@ -244,11 +271,13 @@ class TokenTracker:
             output_tokens,
             cache_creation_tokens=cache_creation_tokens,
             cache_read_tokens=cache_read_tokens,
+            thinking_tokens=thinking_tokens,
         )
         usage = LLMUsage(
             model=model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            thinking_tokens=thinking_tokens,
             cost_usd=cost,
         )
         self._accumulator.record(usage)
@@ -264,6 +293,7 @@ class TokenTracker:
         *,
         cache_creation_tokens: int = 0,
         cache_read_tokens: int = 0,
+        thinking_tokens: int = 0,
     ) -> float:
         """Calculate cost in USD for a single LLM call."""
         price = self._pricing.get(model)
@@ -275,6 +305,8 @@ class TokenTracker:
             cost += cache_creation_tokens * price.cache_write
         if cache_read_tokens:
             cost += cache_read_tokens * price.cache_read
+        if thinking_tokens and price.thinking:
+            cost += thinking_tokens * price.thinking
         return cost
 
     def reset(self) -> None:

--- a/core/orchestration/goal_decomposer.py
+++ b/core/orchestration/goal_decomposer.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -42,6 +42,10 @@ class SubGoal(BaseModel):
     tool_args: dict[str, Any] = Field(default_factory=dict, description="Arguments for the tool")
     depends_on: list[str] = Field(
         default_factory=list, description="IDs of sub-goals that must complete first"
+    )
+    difficulty: Literal["low", "medium", "high"] = Field(
+        default="medium",
+        description="Complexity: low=lookup, medium=analysis, high=reasoning",
     )
 
 

--- a/tests/test_agentic_ui.py
+++ b/tests/test_agentic_ui.py
@@ -300,19 +300,26 @@ class TestRenderStatusLine:
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_renders_with_session_meter(self, mock_console) -> None:  # type: ignore[no-untyped-def]
-        init_session_meter(model="claude-opus-4-6")
-        # Record some usage so tracker has data
-        from core.llm.token_tracker import get_tracker
+        import core.cli.ui.agentic_ui as _ui_mod
+        from core.llm.token_tracker import get_tracker, reset_tracker
 
-        tracker = get_tracker()
-        tracker.record("claude-opus-4-6", 1200, 350)
+        # Isolate: clear stale _turn_snapshot from other tests
+        old_snap = _ui_mod._turn_snapshot
+        _ui_mod._turn_snapshot = None
+        reset_tracker()
+        try:
+            init_session_meter(model="claude-opus-4-6")
+            tracker = get_tracker()
+            tracker.record("claude-opus-4-6", 1200, 350)
 
-        render_status_line()
-        printed = str(mock_console.print.call_args)
-        assert "✢" in printed
-        assert "Worked for" in printed
-        assert "claude-opus-4-6" in printed
-        assert "context" in printed
+            render_status_line()
+            printed = str(mock_console.print.call_args)
+            assert "✢" in printed
+            assert "Worked for" in printed
+            assert "claude-opus-4-6" in printed
+            assert "context" in printed
+        finally:
+            _ui_mod._turn_snapshot = old_snap
 
     @patch("core.cli.ui.agentic_ui.console")
     def test_noop_without_meter(self, mock_console) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -299,7 +299,7 @@ class TestApplyContext:
 class TestHookEventCount:
     def test_events_exist(self) -> None:
         """HookEvent has 40 events after H6 orphan pruning."""
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
     def test_node_bootstrap_event_value(self) -> None:
         assert HookEvent.NODE_BOOTSTRAP.value == "node_bootstrap"

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -411,7 +411,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count after H6 orphan pruning."""
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -7,7 +7,7 @@ from core.hooks import HookEvent, HookResult, HookSystem, InterceptResult
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_START.value == "pipeline_start"

--- a/tests/test_karpathy_prompt_hardening.py
+++ b/tests/test_karpathy_prompt_hardening.py
@@ -356,7 +356,7 @@ class TestHookEventTypes:
 
     def test_hook_event_count(self):
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -27,7 +27,7 @@ class TestLLMLifecycleEvents:
 
     def test_event_count_includes_llm_events(self) -> None:
         """40 events total after H6 orphan pruning."""
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
 
 class TestFireHook:

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -278,7 +278,7 @@ class TestHookEventCount:
     def test_total_event_count(self) -> None:
         from core.hooks import HookEvent
 
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -35,7 +35,7 @@ class TestMCPHookEvents:
 
     def test_hook_event_count(self) -> None:
         """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 55
+        assert len(HookEvent) == 56
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_injection.py
+++ b/tests/test_system_injection.py
@@ -53,9 +53,7 @@ class TestBuildSystemReminder:
         assert len(result) <= _MAX_REMINDER_CHARS + 10  # +10 for "..." and tag
         assert result.endswith("...")
 
-    @patch(
-        "core.agent.system_prompt.get_active_rule_names", return_value=["rule_a", "rule_b"]
-    )
+    @patch("core.agent.system_prompt.get_active_rule_names", return_value=["rule_a", "rule_b"])
     def test_active_rules_included(self, _mock: object) -> None:
         """Active rules summary injected when available."""
         result = build_system_reminder()


### PR DESCRIPTION
## Summary
- DTR 논문(arXiv 2602.13517)의 핵심 교훈을 GEODE에 적용: thinking 토큰 인식/추적/과금 + 적응적 compute 할당 + reasoning 관측성
- Anthropic Extended Thinking + OpenAI reasoning_effort 3사 통합 지원

## Why
현재 GEODE AgenticLoop는 모든 라운드에 동일한 compute 예산을 할당. DTR 논문이 보여준 것처럼 "깊게 생각하는 것"과 "오래 생각하는 것"은 다르다. 쉬운 태스크에 reasoning 토큰을 낭비하거나, 연속 text-only 라운드에서 overthinking이 발생해도 감지할 수단이 없었음.

## Changes
| File | Change |
|------|--------|
| `core/agent/agentic_loop.py` | thinking_budget 파라미터 + overthinking 감지 + adaptive budget 축소 + ReasoningMetrics 수집 |
| `core/agent/reasoning_metrics.py` | NEW — thinking_ratio, cost_per_tool_call, overthinking_detected |
| `core/agent/sub_agent.py` | SubGoal.difficulty 기반 thinking 할당 (low=0, high=8192+) |
| `core/agent/worker.py` | WorkerRequest에 thinking_budget 필드 추가 |
| `core/config.py` | agentic_thinking_budget 설정 + config.toml 매핑 |
| `core/hooks/system.py` | REASONING_METRICS hook 이벤트 (55→56) |
| `core/llm/adapters.py` | AgenticLLMPort 프로토콜에 thinking_budget 추가 |
| `core/llm/agentic_response.py` | ResponseUsage.thinking_tokens + 3사 normalizer |
| `core/llm/providers/anthropic.py` | Extended Thinking API 통합 (thinking param, temp=1) |
| `core/llm/providers/openai.py` | reasoning_effort 매핑 (budget→low/medium/high) |
| `core/llm/providers/glm.py` | 시그니처 동기화 |
| `core/llm/token_tracker.py` | thinking_tokens 추적 + ModelPrice.thinking 과금 + o3/o4-mini reasoning=True |
| `core/orchestration/goal_decomposer.py` | SubGoal.difficulty 필드 (low/medium/high) |
| tests (6 files) | HookEvent count 55→56 |

## Verification
- [x] ruff check clean
- [x] mypy clean (211 source files)
- [x] pytest 3869 passed (1 flaky — test ordering, passes in isolation)

## Reference
- DTR 논문: arXiv 2602.13517 "Think Deep, Not Just Long"
- `docs/research/deep-thinking-ratio-research.md`
- `docs/research/deep-thinking-ratio-explained.md`