### PR TITLE
feat: effort-based adaptive compute — replace deprecated budget_tokens

### DIFF
--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -179,7 +179,8 @@ class AgenticLoop:
         *,
         max_rounds: int = DEFAULT_MAX_ROUNDS,
         max_tokens: int = DEFAULT_MAX_TOKENS,
-        thinking_budget: int = 0,  # 0 = disabled; >0 = Extended Thinking tokens
+        thinking_budget: int = 0,  # 0 = disabled; >0 = Extended Thinking tokens (legacy)
+        effort: str = "high",  # "low" | "medium" | "high" | "max" (adaptive thinking)
         time_budget_s: float = 0.0,  # 0 = no time limit (OpenClaw pattern)
         cost_budget: float = 0.0,  # 0 = no cost limit (Karpathy P3)
         model: str | None = None,
@@ -201,6 +202,7 @@ class AgenticLoop:
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens
         self._thinking_budget = thinking_budget
+        self._effort = effort
         self._time_budget_s = time_budget_s
         # Adaptive compute: track consecutive text-only rounds for overthinking detection
         self._consecutive_text_only_rounds = 0
@@ -1336,16 +1338,29 @@ class AgenticLoop:
         tool_choice: dict[str, str] = {"type": "none"} if force_text else {"type": "auto"}
 
         # Adaptive compute allocation (DTR insight: match budget to round purpose)
+        # Context-proportional caps derived from model's context window
+        from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
+
+        ctx_window = MODEL_CONTEXT_WINDOW.get(self.model, 200_000)
+        _EFFORT_LEVELS = ["low", "medium", "high", "max"]
+
         adaptive_max_tokens = self.max_tokens
         adaptive_thinking = self._thinking_budget
+        adaptive_effort = self._effort
         if force_text:
             # Wrap-up: minimal budget — summarize, don't reason
-            adaptive_max_tokens = min(self.max_tokens, 4096)
+            # Context-proportional: 0.5% of window, floor 4096
+            adaptive_max_tokens = max(4096, min(self.max_tokens, ctx_window // 200))
             adaptive_thinking = 0
+            adaptive_effort = "low"
         elif self._consecutive_text_only_rounds >= 2:
-            # Overthinking: reduce budget to curb verbose non-actionable output
-            adaptive_max_tokens = min(self.max_tokens, 16384)
+            # Overthinking: reduce budget — curb verbose non-actionable output
+            # Context-proportional: 2% of window, floor 8192
+            adaptive_max_tokens = max(8192, min(self.max_tokens, ctx_window // 50))
             adaptive_thinking = min(adaptive_thinking, adaptive_thinking // 2)
+            # Downgrade effort by one level
+            idx = _EFFORT_LEVELS.index(adaptive_effort) if adaptive_effort in _EFFORT_LEVELS else 2
+            adaptive_effort = _EFFORT_LEVELS[max(0, idx - 1)]
 
         response = await self._adapter.agentic_call(
             model=self.model,
@@ -1356,6 +1371,7 @@ class AgenticLoop:
             max_tokens=adaptive_max_tokens,
             temperature=0.0,
             thinking_budget=adaptive_thinking,
+            effort=adaptive_effort,
         )
 
         if response is None:

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -507,13 +507,10 @@ class SubAgentManager:
         domain = get_domain_or_none()
         denied = list(self._denied_tools | {"delegate_task"})
 
-        # Adaptive thinking budget based on task difficulty hint
-        task_thinking = settings.agentic_thinking_budget
+        # Adaptive effort based on task difficulty hint
+        _DIFFICULTY_TO_EFFORT = {"low": "low", "medium": "medium", "high": "high"}
         difficulty = getattr(task, "difficulty", "medium")
-        if difficulty == "low":
-            task_thinking = 0
-        elif difficulty == "high":
-            task_thinking = max(task_thinking, 8192)
+        task_effort = _DIFFICULTY_TO_EFFORT.get(difficulty, settings.agentic_effort)
 
         return WorkerRequest(
             task_id=task.task_id,
@@ -525,7 +522,8 @@ class SubAgentManager:
             provider=_resolve_provider(settings.model),
             timeout_s=self._timeout_s,
             time_budget_s=self._time_budget_s,
-            thinking_budget=task_thinking,
+            thinking_budget=settings.agentic_thinking_budget,
+            effort=task_effort,
             domain=domain.name if domain else "",
         )
 

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -46,7 +46,8 @@ class WorkerRequest:
     provider: str = "anthropic"
     timeout_s: float = 120.0
     time_budget_s: float = 0.0  # 0 = inherit parent's budget
-    thinking_budget: int = 0  # 0 = disabled; >0 = thinking tokens per call
+    thinking_budget: int = 0  # 0 = disabled; >0 = thinking tokens per call (legacy)
+    effort: str = "high"  # "low" | "medium" | "high" | "max"
     domain: str = ""  # Domain adapter name (e.g. "game_ip") or ""
     isolation: str = ""  # Reserved for Phase 3: "worktree" etc.
 

--- a/core/config.py
+++ b/core/config.py
@@ -45,6 +45,7 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "pipeline.max_iterations": "max_iterations",
     "agentic.time_budget": "agentic_loop_time_budget",
     "agentic.thinking_budget": "agentic_thinking_budget",
+    "agentic.effort": "agentic_effort",
     "sandbox.max_file_size_bytes": "sandbox_max_file_size_bytes",
     "sandbox.max_read_tokens": "sandbox_max_read_tokens",
     "sandbox.max_glob_results": "sandbox_max_glob_results",
@@ -245,7 +246,11 @@ class Settings(BaseSettings):
     agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
 
     # Agentic Loop — thinking budget (DTR: Extended Thinking / reasoning tokens)
-    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call
+    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call (legacy)
+
+    # Agentic Loop — effort level (replaces thinking_budget for Opus 4.6+ / Sonnet 4.6+)
+    # Maps to Anthropic output_config.effort + OpenAI reasoning.effort
+    agentic_effort: str = "high"  # "low" | "medium" | "high" | "max"
 
     # Cost guard — session-level cost limit (0 = no limit)
     cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -189,6 +189,7 @@ class AgenticLLMPort(Protocol):
         max_tokens: int,
         temperature: float,
         thinking_budget: int = 0,
+        effort: str = "high",
     ) -> AgenticResponse | None: ...
 
     def reset_client(self) -> None: ...

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -298,6 +298,7 @@ class ClaudeAgenticAdapter:
         max_tokens: int,
         temperature: float,
         thinking_budget: int = 0,
+        effort: str = "high",
     ) -> Any | None:
         from core.llm.agentic_response import normalize_anthropic
         from core.llm.errors import LLMBadRequestError, UserCancelledError
@@ -355,18 +356,26 @@ class ClaudeAgenticAdapter:
                     ]
                 }
 
-            # Extended Thinking: budget_tokens > 0 enables thinking mode
+            # Thinking mode: adaptive (4.6+) or legacy budget (older models)
+            _ADAPTIVE_MODELS = {"claude-opus-4-6", "claude-sonnet-4-6"}
             call_temperature = temperature
             call_max_tokens = max_tokens
             thinking_param: dict[str, Any] | None = None
-            if thinking_budget > 0:
+            output_config: dict[str, str] | None = None
+
+            if m in _ADAPTIVE_MODELS:
+                # Adaptive thinking (recommended for 4.6+): effort controls depth
+                thinking_param = {"type": "adaptive"}
+                output_config = {"effort": effort}
+                # Anthropic API requires temperature=1 with thinking
+                call_temperature = 1.0
+            elif thinking_budget > 0:
+                # Legacy: manual budget_tokens for older models
                 thinking_param = {
                     "type": "enabled",
                     "budget_tokens": thinking_budget,
                 }
-                # Anthropic API requires temperature=1 with Extended Thinking
                 call_temperature = 1.0
-                # max_tokens must accommodate both thinking + output
                 call_max_tokens = max(max_tokens, thinking_budget + max_tokens)
 
             create_kwargs: dict[str, Any] = {
@@ -380,6 +389,8 @@ class ClaudeAgenticAdapter:
             }
             if thinking_param is not None:
                 create_kwargs["thinking"] = thinking_param
+            if output_config is not None:
+                create_kwargs["output_config"] = output_config
             if extra_h:
                 create_kwargs["extra_headers"] = extra_h
             if extra_b:

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -111,6 +111,7 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
         max_tokens: int,
         temperature: float,
         thinking_budget: int = 0,
+        effort: str = "high",
     ) -> Any | None:
         """GLM agentic call with native web_search injection."""
         client = self._ensure_client(model)

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -466,6 +466,7 @@ class OpenAIAgenticAdapter:
         max_tokens: int,
         temperature: float,
         thinking_budget: int = 0,
+        effort: str = "high",
     ) -> Any | None:
         from core.llm.errors import UserCancelledError
         from core.llm.router import call_with_failover
@@ -516,14 +517,11 @@ class OpenAIAgenticAdapter:
                 "max_output_tokens": max_tokens,
                 "temperature": temperature,
             }
-            # Map thinking_budget to reasoning effort for reasoning models
-            if thinking_budget > 0 and m in _REASONING_MODELS:
-                if thinking_budget <= 4096:
-                    create_kwargs["reasoning"] = {"effort": "low"}
-                elif thinking_budget <= 16384:
-                    create_kwargs["reasoning"] = {"effort": "medium"}
-                else:
-                    create_kwargs["reasoning"] = {"effort": "high"}
+            # Map effort to OpenAI reasoning effort for reasoning models
+            _EFFORT_MAP = {"low": "low", "medium": "medium", "high": "high", "max": "high"}
+            if m in _REASONING_MODELS:
+                oai_effort = _EFFORT_MAP.get(effort, "medium")
+                create_kwargs["reasoning"] = {"effort": oai_effort}
             return await asyncio.to_thread(client.responses.create, **create_kwargs)
 
         try:


### PR DESCRIPTION
## Summary
- Anthropic API 2026-04 기준 `budget_tokens` deprecated → `thinking: {type: "adaptive"}` + `output_config: {effort}` 전환
- context-proportional max_tokens caps (1M/200K 모델별 자동 조정)

## Why
Anthropic Opus 4.6/Sonnet 4.6에서 `budget_tokens`가 deprecated. 하드코딩된 4096/16384 cap이 200K와 1M 컨텍스트에 동일 적용되어 1M 모델에서 지나치게 보수적. Frontier 리서치(Claude Code, OpenAI Codex CLI, DTR 논문) 기반으로 effort-level 방식으로 전환.

## Changes
| File | Change |
|------|--------|
| `core/config.py` | `agentic_effort: str` 설정 추가 + config.toml 매핑 |
| `core/llm/adapters.py` | `AgenticLLMPort` 프로토콜에 `effort` 파라미터 추가 |
| `core/llm/providers/anthropic.py` | 4.6 모델: adaptive thinking + effort, 레거시: budget_tokens 유지 |
| `core/llm/providers/openai.py` | effort → `reasoning.effort` 직접 매핑 (budget_tokens 기반 변환 제거) |
| `core/llm/providers/glm.py` | 시그니처 동기화 |
| `core/agent/agentic_loop.py` | context-proportional caps + effort 단계 조정 |
| `core/agent/sub_agent.py` | difficulty → effort 매핑 (budget_tokens 직접 조작 제거) |
| `core/agent/worker.py` | `effort` 필드 추가 |

## Verification
- [x] ruff check clean
- [x] mypy clean (213 source files)
- [x] pytest 3879 passed, 0 failed

## Reference
- Anthropic docs: adaptive-thinking, effort parameter (2026-04-15 확인)
- OpenAI docs: reasoning models effort levels
- DTR paper (arXiv 2602.13517): 50% token reduction benchmark
- Claude Code: 32K default, 83.5% autocompact