### PR TITLE
style: ruff format test_gateway.py — Linux/macOS parity

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -329,7 +329,9 @@ class TestGatewaySessionKey:
     def test_build_gateway_session_key_with_thread_id(self):
         from core.memory.session_key import build_gateway_session_key
 
-        key = build_gateway_session_key("slack", "C12345", "U67890", thread_id="1234567890.123456")
+        key = build_gateway_session_key(
+            "slack", "C12345", "U67890", thread_id="1234567890.123456"
+        )
         assert "1234567890_123456" in key
         # Without thread_id should be shorter
         key_no_thread = build_gateway_session_key("slack", "C12345", "U67890")
@@ -437,8 +439,16 @@ class TestBindingConfigReload:
             "gateway": {
                 "bindings": {
                     "rules": [
-                        {"channel": "slack", "channel_id": "C123", "auto_respond": True},
-                        {"channel": "discord", "channel_id": "D456", "require_mention": True},
+                        {
+                            "channel": "slack",
+                            "channel_id": "C123",
+                            "auto_respond": True,
+                        },
+                        {
+                            "channel": "discord",
+                            "channel_id": "D456",
+                            "require_mention": True,
+                        },
                     ]
                 }
             }


### PR DESCRIPTION
## Summary
- test_gateway.py ruff format: macOS vs Linux 차이 수정

## Why
CI (Linux ruff)에서 format 실패. macOS ruff는 pass하지만 Linux ruff는 긴 줄을 다르게 분할.

## Changes
| File | Change |
|------|--------|
| `tests/test_gateway.py` | 3곳 line wrapping (Linux ruff 기준) |

## Verification
- [x] Docker ruff:0.15.2 (Linux) 기준 format check pass