### PR TITLE
feat: add GLM-5.1, GLM-5V-Turbo models

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -359,8 +359,8 @@ OPENAI_PRIMARY = "gpt-5.4"
 OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.4", "gpt-5.2", "gpt-4.1"]
 
 # ZhipuAI (GLM) models — OpenAI-compatible API, separate provider
-GLM_PRIMARY = "glm-5"
-GLM_FALLBACK_CHAIN: list[str] = ["glm-5", "glm-5-turbo", "glm-4.7-flash"]
+GLM_PRIMARY = "glm-5.1"
+GLM_FALLBACK_CHAIN: list[str] = ["glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7-flash"]
 GLM_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
 
 

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -1,8 +1,9 @@
 """ZhipuAI GLM provider — OpenAI-compatible API with custom base_url.
 
-Separate provider for GLM models (glm-5, glm-5-turbo, glm-4.7-flash).
-Uses OpenAI SDK but managed as an independent provider with its own
-client lifecycle, circuit breaker, and failover chain.
+Separate provider for GLM models (glm-5.1, glm-5, glm-5-turbo,
+glm-5v-turbo, glm-4.7-flash).  Uses OpenAI SDK but managed as an
+independent provider with its own client lifecycle, circuit breaker,
+and failover chain.
 """
 
 from __future__ import annotations
@@ -84,7 +85,7 @@ _GLM_NATIVE_WEB_SEARCH: dict[str, Any] = {
 
 
 class GlmAgenticAdapter(OpenAIAgenticAdapter):
-    """ZhipuAI GLM adapter (glm-5, glm-5-turbo, glm-4.7-flash).
+    """ZhipuAI GLM adapter (glm-5.1, glm-5, glm-5-turbo, glm-5v-turbo, glm-4.7-flash).
 
     Injects GLM native web_search tool alongside function tools.
     """

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -179,10 +179,12 @@ MODEL_PRICING: dict[str, ModelPrice] = {
     "o3":       _oai(2.00,  8.00, reasoning=True),
     "o4-mini":  _oai(1.10,  4.40, cached_mtok=0.275, reasoning=True),
 
-    # ── ZhipuAI GLM (verified 2026-03-19) ──────────────────────────────
+    # ── ZhipuAI GLM (verified 2026-04-15) ──────────────────────────────
     # Source: https://open.bigmodel.cn/pricing + https://docs.z.ai
+    "glm-5.1":         _oai(0.95,  3.15),
     "glm-5":           _oai(0.72,  2.30),
-    "glm-5-turbo":     _oai(0.96,  3.20),
+    "glm-5-turbo":     _oai(1.20,  4.00),
+    "glm-5v-turbo":    _oai(1.20,  4.00),
     "glm-4.7":         _oai(0.40,  1.75),
     "glm-4.7-flash":   _oai(0.00,  0.00),  # free tier
 }
@@ -215,8 +217,10 @@ MODEL_CONTEXT_WINDOW: dict[str, int] = {
     "gpt-4.1-nano":             1_047_576,
     "o3":                         200_000,
     "o4-mini":                    200_000,
+    "glm-5.1":                    202_752,
     "glm-5":                      200_000,
-    "glm-5-turbo":                200_000,
+    "glm-5-turbo":                202_752,
+    "glm-5v-turbo":               202_752,
     "glm-4.7":                    200_000,
     "glm-4.7-flash":              200_000,
 }


### PR DESCRIPTION
## Summary
- GLM-5.1 (SWE-Bench Pro 1위, MIT 오픈소스) 추가 및 GLM_PRIMARY 승격
- GLM-5V-Turbo (멀티모달 에이전트) 추가
- GLM-5-Turbo 가격 업데이트 ($0.96→$1.20 / $3.20→$4.00)

## Why
Z.AI가 2026-04-07 GLM-5.1을 공식 릴리스. SWE-Bench Pro 58.4로 1위 달성.
GLM-5V-Turbo도 04-01 출시. GEODE 제공 모델에 반영 필요.

## Changes
| File | Change |
|------|--------|
| `core/config.py` | GLM_PRIMARY → glm-5.1, fallback chain 업데이트 |
| `core/llm/token_tracker.py` | glm-5.1, glm-5v-turbo 가격/컨텍스트 추가, glm-5-turbo 가격 갱신 |
| `core/llm/providers/glm.py` | docstring 모델 목록 반영 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] 111 tests passed (glm/token_tracker/provider_dispatch/config)

## Reference
- https://huggingface.co/zai-org/GLM-5.1
- https://docs.z.ai/guides/llm/glm-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)