### PR TITLE
refactor: codebase quality audit — dedup, constants, resource leaks

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -1341,7 +1341,7 @@ def _get_cost_budget() -> float:
             with open(config_path, "rb") as f:
                 data = tomllib.load(f)
             return float(data.get("cost", {}).get("monthly_budget", 0))
-        except Exception:
+        except (OSError, ValueError, KeyError):
             return 0.0
     return 0.0
 
@@ -1610,8 +1610,9 @@ def cmd_context(args: str) -> None:
             console.print(f"  [label]T0 SOUL:[/label] {preview}")
         else:
             console.print("  [label]T0 SOUL:[/label] [muted]not found[/muted]")
-    except Exception:
-        console.print("  [label]T0 SOUL:[/label] [muted]unavailable[/muted]")
+    except Exception as exc:
+        err = type(exc).__name__
+        console.print(f"  [label]T0 SOUL:[/label] [muted]unavailable ({err})[/muted]")
 
     # Tier 0.5: User Profile
     try:
@@ -1623,8 +1624,9 @@ def cmd_context(args: str) -> None:
         career_summary = profile.get_career_summary()
         if career_summary:
             console.print(f"  [label]T0.5 Career:[/label] {career_summary}")
-    except Exception:
-        console.print("  [label]T0.5 Profile:[/label] [muted]unavailable[/muted]")
+    except Exception as exc:
+        err = type(exc).__name__
+        console.print(f"  [label]T0.5 Profile:[/label] [muted]unavailable ({err})[/muted]")
 
     # Tier 1: Project Memory
     try:
@@ -1636,8 +1638,9 @@ def cmd_context(args: str) -> None:
             console.print(f"  [label]T1 Project:[/label] {len(rules)} rules")
         else:
             console.print("  [label]T1 Project:[/label] [muted]not initialized[/muted]")
-    except Exception:
-        console.print("  [label]T1 Project:[/label] [muted]unavailable[/muted]")
+    except Exception as exc:
+        err = type(exc).__name__
+        console.print(f"  [label]T1 Project:[/label] [muted]unavailable ({err})[/muted]")
 
     # Vault
     try:
@@ -1646,8 +1649,9 @@ def cmd_context(args: str) -> None:
         vault = Vault()
         vs = vault.get_context_summary()
         console.print(f"  [label]V0 Vault:[/label] {vs or '[muted]empty[/muted]'}")
-    except Exception:
-        console.print("  [label]V0 Vault:[/label] [muted]unavailable[/muted]")
+    except Exception as exc:
+        err = type(exc).__name__
+        console.print(f"  [label]V0 Vault:[/label] [muted]unavailable ({err})[/muted]")
 
     console.print()
     console.print("  [muted]Subcommands: /context career | /context profile[/muted]")

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -441,7 +441,9 @@ class EventRenderer:
                 label = labels.get(key, key.replace("_", " ").title())
                 score = float(val.get("score", 0)) if isinstance(val, dict) else 0
                 rationale = str(val.get("rationale", ""))[:50] if isinstance(val, dict) else ""
-                color = "32" if score >= 80 else "33" if score >= 60 else "31"
+                from core.domains.game_ip.scoring_constants import score_ansi_color
+
+                color = score_ansi_color(score)
                 self._out.write(
                     f"    {label:<18} \033[{color}m{score:.0f}/100\033[0m  {rationale}\n"
                 )

--- a/core/cli/ui/panels.py
+++ b/core/cli/ui/panels.py
@@ -136,7 +136,9 @@ def evaluator_panel(evaluations: dict[str, EvaluatorResult]) -> None:
     for key, ev in sorted(evaluations.items()):
         label = labels.get(key, key.replace("_", " ").title())
         score = ev.composite_score
-        score_style = "bold green" if score >= 80 else "yellow" if score >= 60 else "red"
+        from core.domains.game_ip.scoring_constants import score_style as _score_style
+
+        score_style = _score_style(score)
         rationale = ev.rationale.split(".")[0] + "." if ev.rationale else ""
         table.add_row(
             label,
@@ -154,16 +156,9 @@ def score_panel(
     confidence: float = 0.0,
 ) -> None:
     from core.cli.ui.agentic_ui import emit_pipeline_score
+    from core.domains.game_ip.scoring_constants import classify_tier
 
-    tier = (
-        "S"
-        if final_score >= 80
-        else "A"
-        if final_score >= 60
-        else "B"
-        if final_score >= 40
-        else "C"
-    )
+    tier = classify_tier(final_score)
 
     if _is_ipc():
         emit_pipeline_score(final_score, subscores, confidence, tier, psm=psm)

--- a/core/domains/game_ip/adapter.py
+++ b/core/domains/game_ip/adapter.py
@@ -109,24 +109,24 @@ class GameIPDomain:
     # --- Scoring ---
 
     def get_scoring_weights(self) -> dict[str, float]:
+        from core.domains.game_ip.scoring_constants import DEFAULT_WEIGHTS
+
         cfg = _load_scoring_config()
-        weights: dict[str, float] = cfg.get(
-            "weights",
-            {
-                "exposure_lift": 0.25,
-                "quality": 0.20,
-                "recovery": 0.18,
-                "growth": 0.12,
-                "momentum": 0.20,
-                "developer": 0.05,
-            },
-        )
+        weights: dict[str, float] = cfg.get("weights", DEFAULT_WEIGHTS)
         return weights
 
     def get_confidence_multiplier_params(self) -> tuple[float, float]:
+        from core.domains.game_ip.scoring_constants import (
+            CONFIDENCE_BASE_FACTOR,
+            CONFIDENCE_SCALE_FACTOR,
+        )
+
         cfg = _load_scoring_config()
         cm: dict[str, float] = cfg.get("confidence_multiplier", {})
-        return (cm.get("base_factor", 0.7), cm.get("scale_factor", 0.3))
+        return (
+            cm.get("base_factor", CONFIDENCE_BASE_FACTOR),
+            cm.get("scale_factor", CONFIDENCE_SCALE_FACTOR),
+        )
 
     def get_tier_thresholds(self) -> list[tuple[float, str]]:
         cfg = _load_scoring_config()

--- a/core/domains/game_ip/fixtures/generator.py
+++ b/core/domains/game_ip/fixtures/generator.py
@@ -118,14 +118,9 @@ def generate_ip(
     # Tier calculation
     final_score = round(avg_score * 20 + random.uniform(-5, 5), 1)
     final_score = max(0, min(100, final_score))
-    if final_score >= 80:
-        tier = "S"
-    elif final_score >= 60:
-        tier = "A"
-    elif final_score >= 40:
-        tier = "B"
-    else:
-        tier = "C"
+    from core.domains.game_ip.scoring_constants import classify_tier
+
+    tier = classify_tier(final_score)
 
     ltv_min, ltv_max = params["ltv_mult_range"]
 

--- a/core/domains/game_ip/nodes/scoring.py
+++ b/core/domains/game_ip/nodes/scoring.py
@@ -337,15 +337,14 @@ def _calc_final_score(
         weights = domain.get_scoring_weights()
         base_m, scale_m = domain.get_confidence_multiplier_params()
     else:
-        weights = {
-            "exposure_lift": 0.25,
-            "quality": 0.20,
-            "recovery": 0.18,
-            "growth": 0.12,
-            "momentum": 0.20,
-            "developer": 0.05,
-        }
-        base_m, scale_m = 0.7, 0.3
+        from core.domains.game_ip.scoring_constants import (
+            CONFIDENCE_BASE_FACTOR,
+            CONFIDENCE_SCALE_FACTOR,
+            DEFAULT_WEIGHTS,
+        )
+
+        weights = dict(DEFAULT_WEIGHTS)
+        base_m, scale_m = CONFIDENCE_BASE_FACTOR, CONFIDENCE_SCALE_FACTOR
 
     # Validate weights sum to ~1.0; normalize if off
     weight_sum = sum(weights.values())
@@ -413,14 +412,12 @@ def _determine_tier(score: float) -> str:
                 return tier_name
         return domain.get_tier_fallback()
     # Fallback: hardcoded game IP thresholds
-    if score >= 80:
-        return "S"
-    elif score >= 60:
-        return "A"
-    elif score >= 40:
-        return "B"
-    else:
-        return "C"
+    from core.domains.game_ip.scoring_constants import TIER_FALLBACK, TIER_THRESHOLDS
+
+    for threshold, tier_name in TIER_THRESHOLDS:
+        if score >= threshold:
+            return tier_name
+    return TIER_FALLBACK
 
 
 # ---------------------------------------------------------------------------

--- a/core/domains/game_ip/scoring_constants.py
+++ b/core/domains/game_ip/scoring_constants.py
@@ -68,4 +68,3 @@ def score_ansi_color(score: float) -> str:
     if score >= TIER_A_THRESHOLD:
         return "33"
     return "31"
-

--- a/core/domains/game_ip/scoring_constants.py
+++ b/core/domains/game_ip/scoring_constants.py
@@ -1,0 +1,71 @@
+"""Scoring formula constants — Python fallbacks for scoring_weights.yaml.
+
+Single source of truth for hardcoded game-IP scoring defaults.
+DomainPort adapters load from YAML at runtime; these constants are
+the fallback when no domain or YAML is available.
+"""
+
+from __future__ import annotations
+
+# --- Tier thresholds (descending order) ---
+TIER_S_THRESHOLD = 80.0
+TIER_A_THRESHOLD = 60.0
+TIER_B_THRESHOLD = 40.0
+TIER_FALLBACK = "C"
+
+TIER_THRESHOLDS: list[tuple[float, str]] = [
+    (TIER_S_THRESHOLD, "S"),
+    (TIER_A_THRESHOLD, "A"),
+    (TIER_B_THRESHOLD, "B"),
+]
+
+# --- Subscore weights (must sum to 1.0) ---
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "exposure_lift": 0.25,
+    "quality": 0.20,
+    "recovery": 0.18,
+    "growth": 0.12,
+    "momentum": 0.20,
+    "developer": 0.05,
+}
+
+# For report formatting (key names differ slightly: "psm" instead of "exposure_lift")
+REPORT_WEIGHTS: list[tuple[str, float]] = [
+    ("psm", 0.25),
+    ("quality", 0.20),
+    ("recovery", 0.18),
+    ("growth", 0.12),
+    ("momentum", 0.20),
+    ("dev", 0.05),
+]
+
+# --- Confidence multiplier ---
+CONFIDENCE_BASE_FACTOR = 0.7
+CONFIDENCE_SCALE_FACTOR = 0.3
+
+
+def classify_tier(score: float) -> str:
+    """Classify a final score into a tier label (S/A/B/C)."""
+    for threshold, label in TIER_THRESHOLDS:
+        if score >= threshold:
+            return label
+    return TIER_FALLBACK
+
+
+def score_style(score: float) -> str:
+    """Return a Rich style string for a score value."""
+    if score >= TIER_S_THRESHOLD:
+        return "bold green"
+    if score >= TIER_A_THRESHOLD:
+        return "yellow"
+    return "red"
+
+
+def score_ansi_color(score: float) -> str:
+    """Return ANSI color code for a score value (32=green, 33=yellow, 31=red)."""
+    if score >= TIER_S_THRESHOLD:
+        return "32"
+    if score >= TIER_A_THRESHOLD:
+        return "33"
+    return "31"
+

--- a/core/gateway/auth/claude_code_oauth.py
+++ b/core/gateway/auth/claude_code_oauth.py
@@ -20,17 +20,18 @@ import json
 import logging
 import subprocess  # nosec B404
 import sys
-import threading
-import time
 from pathlib import Path
 from typing import Any, TypedDict
+
+from core.gateway.auth.credential_cache import CredentialCache, refresh_managed_token
 
 log = logging.getLogger(__name__)
 
 # -- Constants (match Claude Code & OpenClaw cli-credentials.ts) --
 _KEYCHAIN_SERVICE = "Claude Code-credentials"
 _CREDENTIALS_RELATIVE_PATH = ".claude/.credentials.json"
-_CACHE_TTL_S = 900  # 15 min (OpenClaw EXTERNAL_CLI_SYNC_TTL_MS)
+
+_cache = CredentialCache(_CREDENTIALS_RELATIVE_PATH)
 
 
 class ClaudeCodeCredentials(TypedDict, total=False):
@@ -43,39 +44,9 @@ class ClaudeCodeCredentials(TypedDict, total=False):
     rate_limit_tier: str
 
 
-# -- Cache (with mtime fingerprint — OpenClaw sourceFingerprint pattern) --
-_cache_lock = threading.Lock()
-_cache: dict[str, Any] = {
-    "value": None,
-    "read_at": 0.0,
-    "mtime": 0.0,
-}
-
-
-def _get_file_mtime() -> float:
-    """Get mtime of credentials file (0.0 if not found)."""
-    try:
-        return (Path.home() / _CREDENTIALS_RELATIVE_PATH).stat().st_mtime
-    except OSError:
-        return 0.0
-
-
-def _is_cache_valid() -> bool:
-    # Called under _cache_lock
-    if _cache["value"] is None:
-        return False
-    if (time.time() - _cache["read_at"]) >= _CACHE_TTL_S:
-        return False
-    current_mtime = _get_file_mtime()
-    return not (current_mtime > 0 and current_mtime != _cache["mtime"])
-
-
 def invalidate_cache() -> None:
     """Force next read to bypass cache."""
-    with _cache_lock:
-        _cache["value"] = None
-        _cache["read_at"] = 0.0
-        _cache["mtime"] = 0.0
+    _cache.invalidate()
 
 
 # -- Keychain Reader (macOS only) --
@@ -174,10 +145,12 @@ def read_claude_code_credentials(
     Priority: macOS Keychain → file fallback.
     Returns None if Claude Code is not logged in.
     """
-    with _cache_lock:
-        if not force_refresh and _is_cache_valid():
-            cached: ClaudeCodeCredentials | None = _cache["value"]
-            return cached
+    import time
+
+    hit, cached = _cache.get_if_valid(force_refresh=force_refresh)
+    if hit:
+        result_cached: ClaudeCodeCredentials | None = cached
+        return result_cached
 
     # Read outside lock (I/O — Keychain/file)
     raw: dict[str, Any] | None = None
@@ -191,13 +164,9 @@ def read_claude_code_credentials(
         if raw:
             log.debug("Claude Code credentials read from file")
 
-    mtime = _get_file_mtime()
+    mtime = _cache.get_file_mtime()
     parsed = _parse_oauth(raw) if raw else None
-
-    with _cache_lock:
-        _cache["value"] = parsed
-        _cache["read_at"] = time.time()
-        _cache["mtime"] = mtime
+    _cache.update(parsed, mtime)
 
     if parsed:
         is_expired = time.time() > parsed["expires_at"]
@@ -210,24 +179,5 @@ def read_claude_code_credentials(
 
 
 def refresh_claude_code_token(profile: Any) -> bool:
-    """Re-read token from Claude Code's storage (managed refresh).
-
-    Claude Code handles its own token refresh via OAuth. We just re-read
-    from Keychain/file to pick up the refreshed token.
-
-    Returns True if the token was updated, False otherwise.
-    """
-    creds = read_claude_code_credentials(force_refresh=True)
-    if not creds:
-        log.warning("Claude Code credentials unavailable for refresh")
-        return False
-
-    new_token = creds["access_token"]
-    if new_token != profile.key:
-        profile.key = new_token
-        profile.expires_at = creds.get("expires_at", 0.0)
-        log.info("Claude Code OAuth token refreshed (managed)")
-        return True
-
-    log.debug("Claude Code token unchanged after re-read")
-    return False
+    """Re-read token from Claude Code's storage (managed refresh)."""
+    return refresh_managed_token("Claude Code", read_claude_code_credentials, profile)

--- a/core/gateway/auth/codex_cli_oauth.py
+++ b/core/gateway/auth/codex_cli_oauth.py
@@ -14,15 +14,17 @@ from __future__ import annotations
 
 import json
 import logging
-import threading
 import time
 from pathlib import Path
 from typing import Any, TypedDict
 
+from core.gateway.auth.credential_cache import CredentialCache, refresh_managed_token
+
 log = logging.getLogger(__name__)
 
 _CODEX_AUTH_PATH = ".codex/auth.json"
-_CACHE_TTL_S = 900  # 15 min
+
+_cache = CredentialCache(_CODEX_AUTH_PATH)
 
 
 class CodexCliCredentials(TypedDict, total=False):
@@ -34,34 +36,9 @@ class CodexCliCredentials(TypedDict, total=False):
     account_id: str
 
 
-# -- Cache (with mtime fingerprint — OpenClaw sourceFingerprint pattern) --
-_cache_lock = threading.Lock()
-_cache: dict[str, Any] = {"value": None, "read_at": 0.0, "mtime": 0.0}
-
-
-def _get_file_mtime() -> float:
-    try:
-        return (Path.home() / _CODEX_AUTH_PATH).stat().st_mtime
-    except OSError:
-        return 0.0
-
-
-def _is_cache_valid() -> bool:
-    # Called under _cache_lock
-    if _cache["value"] is None:
-        return False
-    if (time.time() - _cache["read_at"]) >= _CACHE_TTL_S:
-        return False
-    current_mtime = _get_file_mtime()
-    return not (current_mtime > 0 and current_mtime != _cache["mtime"])
-
-
 def invalidate_cache() -> None:
     """Force next read to bypass cache."""
-    with _cache_lock:
-        _cache["value"] = None
-        _cache["read_at"] = 0.0
-        _cache["mtime"] = 0.0
+    _cache.invalidate()
 
 
 def _decode_jwt_expiry(token: str) -> float | None:
@@ -149,20 +126,16 @@ def read_codex_cli_credentials(
 
     Returns None if Codex CLI is not logged in.
     """
-    with _cache_lock:
-        if not force_refresh and _is_cache_valid():
-            cached: CodexCliCredentials | None = _cache["value"]
-            return cached
+    hit, cached = _cache.get_if_valid(force_refresh=force_refresh)
+    if hit:
+        result_cached: CodexCliCredentials | None = cached
+        return result_cached
 
     # Read outside lock (file I/O)
     data = _read_from_file()
-    mtime = _get_file_mtime()
+    mtime = _cache.get_file_mtime()
     parsed = _parse_codex_credentials(data) if data else None
-
-    with _cache_lock:
-        _cache["value"] = parsed
-        _cache["read_at"] = time.time()
-        _cache["mtime"] = mtime
+    _cache.update(parsed, mtime)
 
     if parsed:
         is_expired = time.time() > parsed["expires_at"]
@@ -175,21 +148,5 @@ def read_codex_cli_credentials(
 
 
 def refresh_codex_cli_token(profile: Any) -> bool:
-    """Re-read token from Codex CLI's storage (managed refresh).
-
-    Returns True if the token was updated, False otherwise.
-    """
-    creds = read_codex_cli_credentials(force_refresh=True)
-    if not creds:
-        log.warning("Codex CLI credentials unavailable for refresh")
-        return False
-
-    new_token = creds["access_token"]
-    if new_token != profile.key:
-        profile.key = new_token
-        profile.expires_at = creds.get("expires_at", 0.0)
-        log.info("Codex CLI OAuth token refreshed (managed)")
-        return True
-
-    log.debug("Codex CLI token unchanged after re-read")
-    return False
+    """Re-read token from Codex CLI's storage (managed refresh)."""
+    return refresh_managed_token("Codex CLI", read_codex_cli_credentials, profile)

--- a/core/gateway/auth/credential_cache.py
+++ b/core/gateway/auth/credential_cache.py
@@ -1,0 +1,103 @@
+"""Managed credential cache — shared TTL + mtime fingerprint pattern.
+
+Both Claude Code and Codex CLI credential readers use an identical
+cache pattern: thread-safe, TTL-based, with file mtime invalidation.
+This module extracts that shared infrastructure.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TTL_S = 900  # 15 min (OpenClaw EXTERNAL_CLI_SYNC_TTL_MS)
+
+
+class CredentialCache:
+    """Thread-safe credential cache with TTL and file mtime fingerprint.
+
+    Args:
+        file_path: Path relative to $HOME for mtime tracking.
+        ttl_s: Cache lifetime in seconds (default 15 min).
+    """
+
+    def __init__(self, file_path: str, ttl_s: float = _DEFAULT_TTL_S) -> None:
+        self._file_path = file_path
+        self._ttl_s = ttl_s
+        self._lock = threading.Lock()
+        self._value: Any = None
+        self._read_at: float = 0.0
+        self._mtime: float = 0.0
+
+    def get_file_mtime(self) -> float:
+        """Get mtime of the tracked file (0.0 if not found)."""
+        try:
+            return (Path.home() / self._file_path).stat().st_mtime
+        except OSError:
+            return 0.0
+
+    def is_valid(self) -> bool:
+        """Check if cached value is still valid. Must be called under lock."""
+        if self._value is None:
+            return False
+        if (time.time() - self._read_at) >= self._ttl_s:
+            return False
+        current_mtime = self.get_file_mtime()
+        return not (current_mtime > 0 and current_mtime != self._mtime)
+
+    def get_if_valid(self, *, force_refresh: bool = False) -> tuple[bool, Any]:
+        """Return (hit, value). If hit=True, value is the cached credential."""
+        with self._lock:
+            if not force_refresh and self.is_valid():
+                return True, self._value
+        return False, None
+
+    def update(self, value: Any, mtime: float) -> None:
+        """Store a new value in cache."""
+        with self._lock:
+            self._value = value
+            self._read_at = time.time()
+            self._mtime = mtime
+
+    def invalidate(self) -> None:
+        """Force next read to bypass cache."""
+        with self._lock:
+            self._value = None
+            self._read_at = 0.0
+            self._mtime = 0.0
+
+
+def refresh_managed_token(
+    provider_name: str,
+    read_fn: Any,
+    profile: Any,
+) -> bool:
+    """Re-read token from managed storage and update profile if changed.
+
+    Args:
+        provider_name: Display name for logging ("Claude Code", "Codex CLI").
+        read_fn: Callable that returns credentials dict with "access_token" key.
+        profile: Profile object with .key and .expires_at attributes.
+
+    Returns:
+        True if token was updated, False otherwise.
+    """
+    creds = read_fn(force_refresh=True)
+    if not creds:
+        log.warning("%s credentials unavailable for refresh", provider_name)
+        return False
+
+    new_token = creds["access_token"]
+    if new_token != profile.key:
+        profile.key = new_token
+        profile.expires_at = creds.get("expires_at", 0.0)
+        log.info("%s OAuth token refreshed (managed)", provider_name)
+        return True
+
+    log.debug("%s token unchanged after re-read", provider_name)
+    return False

--- a/core/gateway/pollers/base.py
+++ b/core/gateway/pollers/base.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from core.gateway.channel_manager import ChannelManager
+    from core.mcp.manager import MCPServerManager
+    from core.mcp.notification_port import NotificationPort
 
 log = logging.getLogger(__name__)
 
@@ -18,15 +21,24 @@ class BasePoller(ABC):
 
     Subclasses implement _poll_once() to fetch new messages from
     their channel and route them through the ChannelManager.
+
+    Subclasses MAY define:
+        _env_config_var: str  — env var name for is_configured() check
     """
+
+    _env_config_var: str = ""  # Override in subclass for auto is_configured()
 
     def __init__(
         self,
         channel_manager: ChannelManager,
         *,
+        mcp_manager: MCPServerManager | None = None,
+        notification: NotificationPort | None = None,
         poll_interval_s: float = 2.0,
     ) -> None:
         self._manager = channel_manager
+        self._mcp = mcp_manager
+        self._notification = notification
         self._poll_interval = poll_interval_s
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -42,10 +54,32 @@ class BasePoller(ABC):
         """Fetch new messages and route them via self._manager."""
         ...
 
-    @abstractmethod
     def is_configured(self) -> bool:
         """Check if the poller has necessary credentials/config."""
-        ...
+        if self._env_config_var:
+            return bool(os.environ.get(self._env_config_var))
+        return False
+
+    # --- Shared helpers ---
+
+    def _check_mcp_health(self) -> bool:
+        """Return True if MCP manager is available and this channel is healthy."""
+        if self._mcp is None:
+            return False
+        health = self._mcp.check_health()
+        return health.get(self.channel_name, False)
+
+    def _get_channel_bindings(self) -> list[dict[str, Any]]:
+        """Return bindings for this channel with valid channel IDs."""
+        bindings = self._manager.list_bindings()
+        return [
+            b
+            for b in bindings
+            if b["channel"] == self.channel_name
+            and b.get("channel_id", "") not in ("", "*")
+        ]
+
+    # --- Lifecycle ---
 
     def start(self) -> None:
         """Start the polling daemon thread."""

--- a/core/gateway/pollers/base.py
+++ b/core/gateway/pollers/base.py
@@ -75,8 +75,7 @@ class BasePoller(ABC):
         return [
             b
             for b in bindings
-            if b["channel"] == self.channel_name
-            and b.get("channel_id", "") not in ("", "*")
+            if b["channel"] == self.channel_name and b.get("channel_id", "") not in ("", "*")
         ]
 
     # --- Lifecycle ---

--- a/core/gateway/pollers/discord_poller.py
+++ b/core/gateway/pollers/discord_poller.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +20,8 @@ if TYPE_CHECKING:
 class DiscordPoller(BasePoller):
     """Poll Discord for new messages via MCP server."""
 
+    _env_config_var = "DISCORD_BOT_TOKEN"
+
     def __init__(
         self,
         channel_manager: ChannelManager,
@@ -29,34 +30,24 @@ class DiscordPoller(BasePoller):
         notification: NotificationPort | None = None,
         poll_interval_s: float = 3.0,
     ) -> None:
-        super().__init__(channel_manager, poll_interval_s=poll_interval_s)
-        self._mcp = mcp_manager
-        self._notification = notification
+        super().__init__(
+            channel_manager,
+            mcp_manager=mcp_manager,
+            notification=notification,
+            poll_interval_s=poll_interval_s,
+        )
         self._last_id: dict[str, str] = {}  # channel_id → last message id
 
     @property
     def channel_name(self) -> str:
         return "discord"
 
-    def is_configured(self) -> bool:
-        return bool(os.environ.get("DISCORD_BOT_TOKEN"))
-
     def _poll_once(self) -> None:
-        if self._mcp is None:
+        if not self._check_mcp_health():
             return
 
-        health = self._mcp.check_health()
-        if not health.get("discord", False):
-            return
-
-        bindings = self._manager.list_bindings()
-        discord_bindings = [b for b in bindings if b["channel"] == "discord"]
-
-        for binding in discord_bindings:
-            channel_id = binding.get("channel_id", "")
-            if not channel_id or channel_id == "*":
-                continue
-            self._poll_channel(channel_id)
+        for binding in self._get_channel_bindings():
+            self._poll_channel(binding["channel_id"])
 
     def _poll_channel(self, channel_id: str) -> None:
         """Poll a single Discord channel for new messages."""

--- a/core/gateway/pollers/slack_poller.py
+++ b/core/gateway/pollers/slack_poller.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +25,7 @@ class SlackPoller(BasePoller):
     """
 
     DEDUP_TTL_S = 300  # 5 minutes — matches Kiki's event dedup window
+    _env_config_var = "SLACK_BOT_TOKEN"
 
     def __init__(
         self,
@@ -35,9 +35,12 @@ class SlackPoller(BasePoller):
         notification: NotificationPort | None = None,
         poll_interval_s: float = 3.0,
     ) -> None:
-        super().__init__(channel_manager, poll_interval_s=poll_interval_s)
-        self._mcp = mcp_manager
-        self._notification = notification
+        super().__init__(
+            channel_manager,
+            mcp_manager=mcp_manager,
+            notification=notification,
+            poll_interval_s=poll_interval_s,
+        )
         self._last_ts: dict[str, str] = {}  # channel_id → last message ts
         self._seen_events: dict[str, float] = {}  # "channel:ts" → seen_at (dedup)
 
@@ -45,29 +48,15 @@ class SlackPoller(BasePoller):
     def channel_name(self) -> str:
         return "slack"
 
-    def is_configured(self) -> bool:
-        return bool(os.environ.get("SLACK_BOT_TOKEN"))
-
     def _poll_once(self) -> None:
-        if self._mcp is None:
-            return
-
-        health = self._mcp.check_health()
-        if not health.get("slack", False):
+        if not self._check_mcp_health():
             return
 
         # Evict expired dedup entries
         self._evict_stale_dedup()
 
-        # Get channels to monitor from bindings
-        bindings = self._manager.list_bindings()
-        slack_bindings = [b for b in bindings if b["channel"] == "slack"]
-
-        for binding in slack_bindings:
-            channel_id = binding.get("channel_id", "")
-            if not channel_id or channel_id == "*":
-                continue
-            self._poll_channel(channel_id)
+        for binding in self._get_channel_bindings():
+            self._poll_channel(binding["channel_id"])
 
     def _poll_channel(self, channel_id: str) -> None:
         """Poll a single Slack channel for new messages.
@@ -171,8 +160,8 @@ class SlackPoller(BasePoller):
 
                     if response:
                         self._send_response(channel_id, response, thread_ts=inbound.thread_id or ts)
-                except Exception:
-                    log.warning("Failed to process message ts=%s, will retry next poll", ts)
+                except Exception as exc:
+                    log.warning("Failed to process message ts=%s: %s", ts, exc)
                     # Error reaction: X emoji for visible failure feedback
                     if is_mention:
                         self._add_reaction(channel_id, ts, "x")

--- a/core/gateway/pollers/telegram_poller.py
+++ b/core/gateway/pollers/telegram_poller.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +20,8 @@ if TYPE_CHECKING:
 class TelegramPoller(BasePoller):
     """Poll Telegram for new messages via MCP server (getUpdates)."""
 
+    _env_config_var = "TELEGRAM_BOT_TOKEN"
+
     def __init__(
         self,
         channel_manager: ChannelManager,
@@ -29,24 +30,20 @@ class TelegramPoller(BasePoller):
         notification: NotificationPort | None = None,
         poll_interval_s: float = 2.0,
     ) -> None:
-        super().__init__(channel_manager, poll_interval_s=poll_interval_s)
-        self._mcp = mcp_manager
-        self._notification = notification
+        super().__init__(
+            channel_manager,
+            mcp_manager=mcp_manager,
+            notification=notification,
+            poll_interval_s=poll_interval_s,
+        )
         self._last_update_id: int = 0
 
     @property
     def channel_name(self) -> str:
         return "telegram"
 
-    def is_configured(self) -> bool:
-        return bool(os.environ.get("TELEGRAM_BOT_TOKEN"))
-
     def _poll_once(self) -> None:
-        if self._mcp is None:
-            return
-
-        health = self._mcp.check_health()
-        if not health.get("telegram", False):
+        if not self._check_mcp_health():
             return
 
         try:
@@ -54,7 +51,7 @@ class TelegramPoller(BasePoller):
             if self._last_update_id:
                 args["offset"] = self._last_update_id + 1
 
-            result = self._mcp.call_tool("telegram", "get_updates", args)
+            result = self._mcp.call_tool("telegram", "get_updates", args)  # type: ignore[union-attr]
             if "error" in result:
                 return
 

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -92,29 +92,37 @@ def _call_glm_flash(prompt: str, api_key: str) -> str | None:
         api_key=api_key,
         base_url="https://open.bigmodel.cn/api/paas/v4/",
     )
-    resp = client.chat.completions.create(
-        model="glm-4.7-flash",
-        messages=[{"role": "user", "content": prompt}],
-        max_tokens=300,
-        temperature=0.0,
-        timeout=10.0,
-    )
-    return resp.choices[0].message.content if resp.choices else None
+    try:
+        resp = client.chat.completions.create(
+            model="glm-4.7-flash",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.0,
+            timeout=10.0,
+        )
+        return resp.choices[0].message.content if resp.choices else None
+    finally:
+        client.close()
 
 
 def _call_haiku(prompt: str, api_key: str) -> str | None:
     """Call Claude Haiku (budget tier)."""
     import anthropic
 
+    from core.config import ANTHROPIC_BUDGET
+
     client = anthropic.Anthropic(api_key=api_key)
-    resp = client.messages.create(
-        model="claude-haiku-4-5-20251001",
-        max_tokens=300,
-        messages=[{"role": "user", "content": prompt}],
-        timeout=10.0,
-    )
-    block = resp.content[0] if resp.content else None
-    return block.text if block and hasattr(block, "text") else None
+    try:
+        resp = client.messages.create(
+            model=ANTHROPIC_BUDGET,
+            max_tokens=300,
+            messages=[{"role": "user", "content": prompt}],
+            timeout=10.0,
+        )
+        block = resp.content[0] if resp.content else None
+        return block.text if block and hasattr(block, "text") else None
+    finally:
+        client.close()
 
 
 def _parse_extractions(text: str) -> list[tuple[str, str]]:

--- a/core/llm/credentials.py
+++ b/core/llm/credentials.py
@@ -1,0 +1,35 @@
+"""LLM credential resolution — shared ProfileRotator key lookup.
+
+Centralizes the OAuth-preferred → API-key-fallback pattern used
+by Anthropic and OpenAI providers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def resolve_provider_key(provider: str, settings_fallback: str) -> str:
+    """Resolve API key via ProfileRotator (OAuth preferred) or settings fallback.
+
+    Args:
+        provider: Provider name for rotator lookup ("anthropic", "openai").
+        settings_fallback: API key string from settings (used when rotator unavailable).
+
+    Returns:
+        Resolved API key string.
+    """
+    try:
+        from core.runtime_wiring.infra import get_profile_rotator
+
+        rotator = get_profile_rotator()
+        if rotator:
+            profile = rotator.resolve(provider)
+            if profile and profile.key:
+                rotator.mark_used(profile)
+                return profile.key
+    except Exception:
+        log.debug("ProfileRotator not available for %s, falling back to settings", provider)
+    return settings_fallback

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -75,22 +75,10 @@ FALLBACK_MODELS = ANTHROPIC_FALLBACK_CHAIN
 
 
 def _resolve_anthropic_key() -> str:
-    """Resolve Anthropic API key from ProfileRotator (OAuth preferred) or settings.
+    """Resolve Anthropic API key from ProfileRotator (OAuth preferred) or settings."""
+    from core.llm.credentials import resolve_provider_key
 
-    Priority: OAuth profile (claude-code) → API key profile → settings fallback.
-    """
-    try:
-        from core.runtime_wiring.infra import get_profile_rotator
-
-        rotator = get_profile_rotator()
-        if rotator:
-            profile = rotator.resolve("anthropic")
-            if profile and profile.key:
-                rotator.mark_used(profile)
-                return profile.key
-    except Exception:
-        log.debug("ProfileRotator not available, falling back to settings")
-    return settings.anthropic_api_key
+    return resolve_provider_key("anthropic", settings.anthropic_api_key)
 
 
 def get_anthropic_client() -> anthropic.Anthropic:

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -47,18 +47,9 @@ _openai_circuit_breaker = CircuitBreaker()
 
 def _resolve_openai_key() -> str:
     """Resolve OpenAI API key from ProfileRotator (OAuth preferred) or settings."""
-    try:
-        from core.runtime_wiring.infra import get_profile_rotator
+    from core.llm.credentials import resolve_provider_key
 
-        rotator = get_profile_rotator()
-        if rotator:
-            profile = rotator.resolve("openai")
-            if profile and profile.key:
-                rotator.mark_used(profile)
-                return profile.key
-    except Exception:
-        log.debug("ProfileRotator not available for OpenAI, using settings")
-    return settings.openai_api_key
+    return resolve_provider_key("openai", settings.openai_api_key)
 
 
 def _get_openai_client() -> Any:

--- a/core/mcp/apple_calendar_adapter.py
+++ b/core/mcp/apple_calendar_adapter.py
@@ -6,73 +6,40 @@ Implements CalendarPort for Apple Calendar / any CalDAV server.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from datetime import UTC, datetime
+from typing import Any
 
+from core.mcp.base_calendar import BaseCalendarAdapter
 from core.mcp.calendar_port import CalendarEvent
 
 log = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
-    from core.mcp.manager import MCPServerManager
 
-
-class AppleCalendarAdapter:
+class AppleCalendarAdapter(BaseCalendarAdapter):
     """Calendar operations via CalDAV MCP server (Apple Calendar, Nextcloud, etc.)."""
 
-    def __init__(
-        self,
-        *,
-        manager: MCPServerManager | None = None,
-        server_name: str = "caldav",
-    ) -> None:
-        self._manager = manager
-        self._server_name = server_name
+    _source = "apple"
+    _default_server = "caldav"
+    _delete_id_key = "uid"
+    _default_calendar = "default"
 
-    def list_events(
-        self,
-        *,
-        start: datetime | None = None,
-        end: datetime | None = None,
-        calendar_name: str | None = None,
-        max_results: int = 20,
-    ) -> list[CalendarEvent]:
-        if not self.is_available():
-            return []
-        now = datetime.now(UTC)
-        time_min = (start or now).isoformat()
-        time_max = (end or now + timedelta(days=7)).isoformat()
-        try:
-            args: dict[str, Any] = {
-                "start": time_min,
-                "end": time_max,
-                "limit": max_results,
-            }
-            if calendar_name:
-                args["calendar"] = calendar_name
-            result = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name, "list_events", args
-            )
-            if "error" in result:
-                log.warning("CalDAV list_events error: %s", result["error"])
-                return []
-            return self._parse_events(result.get("events", []))
-        except Exception as exc:
-            log.warning("CalDAV list_events failed: %s", exc)
-            return []
+    def _build_list_args(
+        self, time_min: str, time_max: str, max_results: int, calendar_name: str | None
+    ) -> dict[str, Any]:
+        args: dict[str, Any] = {"start": time_min, "end": time_max, "limit": max_results}
+        if calendar_name:
+            args["calendar"] = calendar_name
+        return args
 
-    def create_event(
+    def _build_create_args(
         self,
         title: str,
         start: datetime,
         end: datetime,
-        *,
-        description: str = "",
-        location: str = "",
-        calendar_name: str | None = None,
-    ) -> CalendarEvent:
-        if not self.is_available():
-            raise RuntimeError("CalDAV MCP server not available")
+        description: str,
+        location: str,
+        calendar_name: str | None,
+    ) -> dict[str, Any]:
         args: dict[str, Any] = {
             "summary": title,
             "start": start.isoformat(),
@@ -84,54 +51,19 @@ class AppleCalendarAdapter:
             args["location"] = location
         if calendar_name:
             args["calendar"] = calendar_name
+        return args
 
-        result = self._manager.call_tool(  # type: ignore[union-attr]
-            self._server_name, "create_event", args
-        )
-        if "error" in result:
-            raise RuntimeError(f"CalDAV create_event failed: {result['error']}")
+    def _extract_event_items(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = result.get("events", [])
+        return items
 
-        return CalendarEvent(
-            event_id=result.get("uid", result.get("id", "")),
-            title=title,
-            start=start,
-            end=end,
-            description=description,
-            location=location,
-            source="apple",
-            calendar_name=calendar_name or "default",
-            is_geode=title.startswith("[GEODE]"),
-        )
+    def _extract_event_id(self, result: dict[str, Any]) -> str:
+        eid: str = result.get("uid", result.get("id", ""))
+        return eid
 
-    def delete_event(self, event_id: str) -> bool:
-        if not self.is_available():
-            return False
-        try:
-            result = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name, "delete_event", {"uid": event_id}
-            )
-            return "error" not in result
-        except Exception as exc:
-            log.warning("CalDAV delete_event failed: %s", exc)
-            return False
-
-    def is_available(self) -> bool:
-        if self._manager is None:
-            return False
-        health = self._manager.check_health()
-        return health.get(self._server_name, False)
-
-    def list_calendars(self) -> list[str]:
-        if not self.is_available():
-            return []
-        try:
-            result = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name, "list_calendars", {}
-            )
-            items = result.get("calendars", [])
-            return [c.get("name", c.get("displayName", "")) for c in items]
-        except Exception:
-            return []
+    def _extract_calendar_names(self, result: dict[str, Any]) -> list[str]:
+        items = result.get("calendars", [])
+        return [c.get("name", c.get("displayName", "")) for c in items]
 
     def _parse_events(self, items: list[dict[str, Any]]) -> list[CalendarEvent]:
         events: list[CalendarEvent] = []

--- a/core/mcp/base_calendar.py
+++ b/core/mcp/base_calendar.py
@@ -105,9 +105,7 @@ class BaseCalendarAdapter:
             self._server_name, "create_event", args
         )
         if "error" in result:
-            raise RuntimeError(
-                f"{self._source.title()} create_event failed: {result['error']}"
-            )
+            raise RuntimeError(f"{self._source.title()} create_event failed: {result['error']}")
         return CalendarEvent(
             event_id=self._extract_event_id(result),
             title=title,

--- a/core/mcp/base_calendar.py
+++ b/core/mcp/base_calendar.py
@@ -1,0 +1,166 @@
+"""Base Calendar Adapter — shared logic for MCP-backed calendar services.
+
+Subclasses override ``_build_list_args``, ``_build_create_args``,
+``_parse_events``, and class attributes for API-specific differences.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from core.mcp.calendar_port import CalendarEvent
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from core.mcp.manager import MCPServerManager
+
+
+class BaseCalendarAdapter:
+    """Abstract base for MCP-backed calendar adapters.
+
+    Subclasses MUST define:
+        _source:          "google" | "apple"
+        _default_server:  Default MCP server name
+        _delete_id_key:   Arg key for event ID in delete calls
+        _default_calendar: Default calendar name when none specified
+    """
+
+    _source: str
+    _default_server: str
+    _delete_id_key: str
+    _default_calendar: str
+
+    def __init__(
+        self,
+        *,
+        manager: MCPServerManager | None = None,
+        server_name: str | None = None,
+    ) -> None:
+        self._manager = manager
+        self._server_name = server_name or self._default_server
+
+    # --- Shared methods ---
+
+    def is_available(self) -> bool:
+        if self._manager is None:
+            return False
+        health = self._manager.check_health()
+        return health.get(self._server_name, False)
+
+    def delete_event(self, event_id: str) -> bool:
+        if not self.is_available():
+            return False
+        try:
+            result = self._manager.call_tool(  # type: ignore[union-attr]
+                self._server_name, "delete_event", {self._delete_id_key: event_id}
+            )
+            return "error" not in result
+        except Exception as exc:
+            log.warning("%s delete_event failed: %s", self._source.title(), exc)
+            return False
+
+    def list_events(
+        self,
+        *,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        calendar_name: str | None = None,
+        max_results: int = 20,
+    ) -> list[CalendarEvent]:
+        if not self.is_available():
+            return []
+        now = datetime.now(UTC)
+        time_min = (start or now).isoformat()
+        time_max = (end or now + timedelta(days=7)).isoformat()
+        try:
+            args = self._build_list_args(time_min, time_max, max_results, calendar_name)
+            result = self._manager.call_tool(  # type: ignore[union-attr]
+                self._server_name, "list_events", args
+            )
+            if "error" in result:
+                log.warning("%s list_events error: %s", self._source.title(), result["error"])
+                return []
+            return self._parse_events(self._extract_event_items(result))
+        except Exception as exc:
+            log.warning("%s list_events failed: %s", self._source.title(), exc)
+            return []
+
+    def create_event(
+        self,
+        title: str,
+        start: datetime,
+        end: datetime,
+        *,
+        description: str = "",
+        location: str = "",
+        calendar_name: str | None = None,
+    ) -> CalendarEvent:
+        if not self.is_available():
+            raise RuntimeError(f"{self._source.title()} MCP server not available")
+        args = self._build_create_args(title, start, end, description, location, calendar_name)
+        result = self._manager.call_tool(  # type: ignore[union-attr]
+            self._server_name, "create_event", args
+        )
+        if "error" in result:
+            raise RuntimeError(
+                f"{self._source.title()} create_event failed: {result['error']}"
+            )
+        return CalendarEvent(
+            event_id=self._extract_event_id(result),
+            title=title,
+            start=start,
+            end=end,
+            description=description,
+            location=location,
+            source=self._source,
+            calendar_name=calendar_name or self._default_calendar,
+            is_geode=title.startswith("[GEODE]"),
+        )
+
+    def list_calendars(self) -> list[str]:
+        if not self.is_available():
+            return []
+        try:
+            result = self._manager.call_tool(  # type: ignore[union-attr]
+                self._server_name, "list_calendars", {}
+            )
+            return self._extract_calendar_names(result)
+        except Exception:
+            return []
+
+    # --- Template methods for subclass overrides ---
+
+    def _build_list_args(
+        self,
+        time_min: str,
+        time_max: str,
+        max_results: int,
+        calendar_name: str | None,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _build_create_args(
+        self,
+        title: str,
+        start: datetime,
+        end: datetime,
+        description: str,
+        location: str,
+        calendar_name: str | None,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _extract_event_items(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def _extract_event_id(self, result: dict[str, Any]) -> str:
+        raise NotImplementedError
+
+    def _extract_calendar_names(self, result: dict[str, Any]) -> list[str]:
+        raise NotImplementedError
+
+    def _parse_events(self, items: list[dict[str, Any]]) -> list[CalendarEvent]:
+        raise NotImplementedError

--- a/core/mcp/base_notification.py
+++ b/core/mcp/base_notification.py
@@ -1,0 +1,108 @@
+"""Base Notification Adapter — shared logic for MCP-backed messaging channels.
+
+Subclasses define channel-specific class attributes; the base handles
+MCP call orchestration, error handling, availability checks, and result parsing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from core.mcp.notification_port import NotificationResult
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from core.mcp.manager import MCPServerManager
+
+
+def parse_mcp_result(raw: dict[str, Any]) -> dict[str, Any]:
+    """Parse MCP content wrapper: {"content":[{"text":"{...}"}]} -> inner dict."""
+    if "content" in raw and isinstance(raw["content"], list):
+        try:
+            text = raw["content"][0].get("text", "")
+            return json.loads(text) if text else raw
+        except (IndexError, json.JSONDecodeError, KeyError):
+            pass
+    return raw
+
+
+class BaseNotificationAdapter:
+    """Abstract base for MCP-backed notification adapters.
+
+    Subclasses MUST define these class attributes:
+        _channel_name:   "slack" | "discord" | "telegram"
+        _default_server: Default MCP server name
+        _tool_name:      MCP tool to call for sending
+        _message_key:    Arg key for message body ("text" or "content")
+        _recipient_key:  Arg key for destination ("channel_id" or "chat_id")
+        _forward_keys:   Tuple of kwargs to forward (e.g. ("thread_ts",))
+        _message_id_key: Result key for sent message ID ("ts", "id", ...)
+    """
+
+    _channel_name: str
+    _default_server: str
+    _tool_name: str
+    _message_key: str
+    _recipient_key: str
+    _forward_keys: tuple[str, ...] = ()
+    _message_id_key: str
+
+    def __init__(
+        self,
+        *,
+        manager: MCPServerManager | None = None,
+        server_name: str | None = None,
+    ) -> None:
+        self._manager = manager
+        self._server_name = server_name or self._default_server
+
+    def send_message(
+        self,
+        channel: str,
+        recipient: str,
+        message: str,
+        *,
+        severity: str = "info",
+        **kwargs: Any,
+    ) -> NotificationResult:
+        ch = self._channel_name
+        if not self.is_available():
+            return NotificationResult(
+                success=False, channel=ch, error=f"{ch.title()} MCP server not available"
+            )
+        try:
+            args: dict[str, Any] = {self._recipient_key: recipient, self._message_key: message}
+            for key in self._forward_keys:
+                if key in kwargs:
+                    args[key] = kwargs[key]
+
+            raw = self._manager.call_tool(  # type: ignore[union-attr]
+                self._server_name,
+                self._tool_name,
+                args,
+            )
+            result = parse_mcp_result(raw)
+            if "error" in result:
+                return NotificationResult(success=False, channel=ch, error=result["error"])
+            msg_id = result.get(self._message_id_key)
+            return NotificationResult(
+                success=True,
+                channel=ch,
+                message_id=str(msg_id) if msg_id is not None else None,
+                metadata={"recipient": recipient},
+            )
+        except Exception as exc:
+            log.warning("%s send_message failed: %s", ch.title(), exc)
+            return NotificationResult(success=False, channel=ch, error=str(exc))
+
+    def is_available(self, channel: str | None = None) -> bool:
+        if self._manager is None:
+            return False
+        health = self._manager.check_health()
+        return health.get(self._server_name, False)
+
+    def list_channels(self) -> list[str]:
+        return [self._channel_name]

--- a/core/mcp/discord_adapter.py
+++ b/core/mcp/discord_adapter.py
@@ -5,84 +5,16 @@ Implements NotificationPort for the "discord" channel.
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any
-
-from core.mcp.notification_port import NotificationResult
-
-log = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from core.mcp.manager import MCPServerManager
+from core.mcp.base_notification import BaseNotificationAdapter
 
 
-class DiscordNotificationAdapter:
+class DiscordNotificationAdapter(BaseNotificationAdapter):
     """Send notifications via Discord MCP server."""
 
-    def __init__(
-        self,
-        *,
-        manager: MCPServerManager | None = None,
-        server_name: str = "discord",
-    ) -> None:
-        self._manager = manager
-        self._server_name = server_name
-
-    def send_message(
-        self,
-        channel: str,
-        recipient: str,
-        message: str,
-        *,
-        severity: str = "info",
-        **kwargs: Any,
-    ) -> NotificationResult:
-        if not self.is_available():
-            return NotificationResult(
-                success=False, channel="discord", error="Discord MCP server not available"
-            )
-        try:
-            args: dict[str, Any] = {"channel_id": recipient, "content": message}
-            for key in ("message_reference",):
-                if key in kwargs:
-                    args[key] = kwargs[key]
-
-            raw = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name,
-                "send_message",
-                args,
-            )
-            result = self._parse_mcp_result(raw)
-            if "error" in result:
-                return NotificationResult(success=False, channel="discord", error=result["error"])
-            return NotificationResult(
-                success=True,
-                channel="discord",
-                message_id=result.get("id"),
-                metadata={"recipient": recipient},
-            )
-        except Exception as exc:
-            log.warning("Discord send_message failed: %s", exc)
-            return NotificationResult(success=False, channel="discord", error=str(exc))
-
-    def is_available(self, channel: str | None = None) -> bool:
-        if self._manager is None:
-            return False
-        health = self._manager.check_health()
-        return health.get(self._server_name, False)
-
-    def list_channels(self) -> list[str]:
-        return ["discord"]
-
-    @staticmethod
-    def _parse_mcp_result(raw: dict[str, Any]) -> dict[str, Any]:
-        """Parse MCP content wrapper."""
-        import json
-
-        if "content" in raw and isinstance(raw["content"], list):
-            try:
-                text = raw["content"][0].get("text", "")
-                return json.loads(text) if text else raw
-            except (IndexError, json.JSONDecodeError, KeyError):
-                pass
-        return raw
+    _channel_name = "discord"
+    _default_server = "discord"
+    _tool_name = "send_message"
+    _message_key = "content"
+    _recipient_key = "channel_id"
+    _forward_keys = ("message_reference",)
+    _message_id_key = "id"

--- a/core/mcp/google_calendar_adapter.py
+++ b/core/mcp/google_calendar_adapter.py
@@ -6,73 +6,44 @@ Implements CalendarPort for Google Calendar.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from datetime import UTC, datetime
+from typing import Any
 
+from core.mcp.base_calendar import BaseCalendarAdapter
 from core.mcp.calendar_port import CalendarEvent
 
 log = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
-    from core.mcp.manager import MCPServerManager
 
-
-class GoogleCalendarAdapter:
+class GoogleCalendarAdapter(BaseCalendarAdapter):
     """Calendar operations via Google Calendar MCP server."""
 
-    def __init__(
-        self,
-        *,
-        manager: MCPServerManager | None = None,
-        server_name: str = "google-calendar",
-    ) -> None:
-        self._manager = manager
-        self._server_name = server_name
+    _source = "google"
+    _default_server = "google-calendar"
+    _delete_id_key = "eventId"
+    _default_calendar = "primary"
 
-    def list_events(
-        self,
-        *,
-        start: datetime | None = None,
-        end: datetime | None = None,
-        calendar_name: str | None = None,
-        max_results: int = 20,
-    ) -> list[CalendarEvent]:
-        if not self.is_available():
-            return []
-        now = datetime.now(UTC)
-        time_min = (start or now).isoformat()
-        time_max = (end or now + timedelta(days=7)).isoformat()
-        try:
-            args: dict[str, Any] = {
-                "timeMin": time_min,
-                "timeMax": time_max,
-                "maxResults": max_results,
-            }
-            if calendar_name:
-                args["calendarId"] = calendar_name
-            result = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name, "list_events", args
-            )
-            if "error" in result:
-                log.warning("Google Calendar list_events error: %s", result["error"])
-                return []
-            return self._parse_events(result.get("items", result.get("events", [])))
-        except Exception as exc:
-            log.warning("Google Calendar list_events failed: %s", exc)
-            return []
+    def _build_list_args(
+        self, time_min: str, time_max: str, max_results: int, calendar_name: str | None
+    ) -> dict[str, Any]:
+        args: dict[str, Any] = {
+            "timeMin": time_min,
+            "timeMax": time_max,
+            "maxResults": max_results,
+        }
+        if calendar_name:
+            args["calendarId"] = calendar_name
+        return args
 
-    def create_event(
+    def _build_create_args(
         self,
         title: str,
         start: datetime,
         end: datetime,
-        *,
-        description: str = "",
-        location: str = "",
-        calendar_name: str | None = None,
-    ) -> CalendarEvent:
-        if not self.is_available():
-            raise RuntimeError("Google Calendar MCP server not available")
+        description: str,
+        location: str,
+        calendar_name: str | None,
+    ) -> dict[str, Any]:
         args: dict[str, Any] = {
             "summary": title,
             "start": {"dateTime": start.isoformat()},
@@ -84,54 +55,19 @@ class GoogleCalendarAdapter:
             args["location"] = location
         if calendar_name:
             args["calendarId"] = calendar_name
+        return args
 
-        result = self._manager.call_tool(  # type: ignore[union-attr]
-            self._server_name, "create_event", args
-        )
-        if "error" in result:
-            raise RuntimeError(f"Google Calendar create_event failed: {result['error']}")
+    def _extract_event_items(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = result.get("items", result.get("events", []))
+        return items
 
-        return CalendarEvent(
-            event_id=result.get("id", ""),
-            title=title,
-            start=start,
-            end=end,
-            description=description,
-            location=location,
-            source="google",
-            calendar_name=calendar_name or "primary",
-            is_geode=title.startswith("[GEODE]"),
-        )
+    def _extract_event_id(self, result: dict[str, Any]) -> str:
+        eid: str = result.get("id", "")
+        return eid
 
-    def delete_event(self, event_id: str) -> bool:
-        if not self.is_available():
-            return False
-        try:
-            result = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name, "delete_event", {"eventId": event_id}
-            )
-            return "error" not in result
-        except Exception as exc:
-            log.warning("Google Calendar delete_event failed: %s", exc)
-            return False
-
-    def is_available(self) -> bool:
-        if self._manager is None:
-            return False
-        health = self._manager.check_health()
-        return health.get(self._server_name, False)
-
-    def list_calendars(self) -> list[str]:
-        if not self.is_available():
-            return []
-        try:
-            result = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name, "list_calendars", {}
-            )
-            items = result.get("items", result.get("calendars", []))
-            return [c.get("summary", c.get("id", "")) for c in items]
-        except Exception:
-            return []
+    def _extract_calendar_names(self, result: dict[str, Any]) -> list[str]:
+        items = result.get("items", result.get("calendars", []))
+        return [c.get("summary", c.get("id", "")) for c in items]
 
     def _parse_events(self, items: list[dict[str, Any]]) -> list[CalendarEvent]:
         events: list[CalendarEvent] = []

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -217,6 +217,7 @@ class MCPServerManager:
                 log.debug("MCP signal handlers skipped (not main thread)")
                 return
         except Exception:
+            log.debug("MCP signal handler thread check failed", exc_info=True)
             return
 
         def _signal_shutdown(signum: int, frame: Any) -> None:

--- a/core/mcp/slack_adapter.py
+++ b/core/mcp/slack_adapter.py
@@ -5,86 +5,16 @@ Implements NotificationPort for the "slack" channel.
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any
-
-from core.mcp.notification_port import NotificationResult
-
-log = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from core.mcp.manager import MCPServerManager
+from core.mcp.base_notification import BaseNotificationAdapter
 
 
-class SlackNotificationAdapter:
+class SlackNotificationAdapter(BaseNotificationAdapter):
     """Send notifications via Slack MCP server."""
 
-    def __init__(
-        self,
-        *,
-        manager: MCPServerManager | None = None,
-        server_name: str = "slack",
-    ) -> None:
-        self._manager = manager
-        self._server_name = server_name
-
-    def send_message(
-        self,
-        channel: str,
-        recipient: str,
-        message: str,
-        *,
-        severity: str = "info",
-        **kwargs: Any,
-    ) -> NotificationResult:
-        if not self.is_available():
-            return NotificationResult(
-                success=False, channel="slack", error="Slack MCP server not available"
-            )
-        try:
-            args: dict[str, Any] = {"channel_id": recipient, "text": message}
-            # Forward channel-specific kwargs (thread_ts, etc.)
-            for key in ("thread_ts",):
-                if key in kwargs:
-                    args[key] = kwargs[key]
-
-            raw = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name,
-                "slack_post_message",
-                args,
-            )
-            # Parse MCP content wrapper: {"content": [{"text": "{...}"}]}
-            result = self._parse_mcp_result(raw)
-            if "error" in result:
-                return NotificationResult(success=False, channel="slack", error=result["error"])
-            return NotificationResult(
-                success=True,
-                channel="slack",
-                message_id=result.get("ts"),
-                metadata={"recipient": recipient},
-            )
-        except Exception as exc:
-            log.warning("Slack send_message failed: %s", exc)
-            return NotificationResult(success=False, channel="slack", error=str(exc))
-
-    def is_available(self, channel: str | None = None) -> bool:
-        if self._manager is None:
-            return False
-        health = self._manager.check_health()
-        return health.get(self._server_name, False)
-
-    def list_channels(self) -> list[str]:
-        return ["slack"]
-
-    @staticmethod
-    def _parse_mcp_result(raw: dict[str, Any]) -> dict[str, Any]:
-        """Parse MCP content wrapper: {"content":[{"text":"{...}"}]} → inner dict."""
-        import json
-
-        if "content" in raw and isinstance(raw["content"], list):
-            try:
-                text = raw["content"][0].get("text", "")
-                return json.loads(text) if text else raw
-            except (IndexError, json.JSONDecodeError, KeyError):
-                pass
-        return raw
+    _channel_name = "slack"
+    _default_server = "slack"
+    _tool_name = "slack_post_message"
+    _message_key = "text"
+    _recipient_key = "channel_id"
+    _forward_keys = ("thread_ts",)
+    _message_id_key = "ts"

--- a/core/mcp/telegram_adapter.py
+++ b/core/mcp/telegram_adapter.py
@@ -5,86 +5,16 @@ Implements NotificationPort for the "telegram" channel.
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any
-
-from core.mcp.notification_port import NotificationResult
-
-log = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from core.mcp.manager import MCPServerManager
+from core.mcp.base_notification import BaseNotificationAdapter
 
 
-class TelegramNotificationAdapter:
+class TelegramNotificationAdapter(BaseNotificationAdapter):
     """Send notifications via Telegram MCP server."""
 
-    def __init__(
-        self,
-        *,
-        manager: MCPServerManager | None = None,
-        server_name: str = "telegram",
-    ) -> None:
-        self._manager = manager
-        self._server_name = server_name
-
-    def send_message(
-        self,
-        channel: str,
-        recipient: str,
-        message: str,
-        *,
-        severity: str = "info",
-        **kwargs: Any,
-    ) -> NotificationResult:
-        if not self.is_available():
-            return NotificationResult(
-                success=False,
-                channel="telegram",
-                error="Telegram MCP server not available",
-            )
-        try:
-            args: dict[str, Any] = {"chat_id": recipient, "text": message}
-            for key in ("reply_to_message_id",):
-                if key in kwargs:
-                    args[key] = kwargs[key]
-
-            raw = self._manager.call_tool(  # type: ignore[union-attr]
-                self._server_name,
-                "send_message",
-                args,
-            )
-            result = self._parse_mcp_result(raw)
-            if "error" in result:
-                return NotificationResult(success=False, channel="telegram", error=result["error"])
-            return NotificationResult(
-                success=True,
-                channel="telegram",
-                message_id=str(result.get("message_id", "")),
-                metadata={"recipient": recipient},
-            )
-        except Exception as exc:
-            log.warning("Telegram send_message failed: %s", exc)
-            return NotificationResult(success=False, channel="telegram", error=str(exc))
-
-    def is_available(self, channel: str | None = None) -> bool:
-        if self._manager is None:
-            return False
-        health = self._manager.check_health()
-        return health.get(self._server_name, False)
-
-    def list_channels(self) -> list[str]:
-        return ["telegram"]
-
-    @staticmethod
-    def _parse_mcp_result(raw: dict[str, Any]) -> dict[str, Any]:
-        """Parse MCP content wrapper."""
-        import json
-
-        if "content" in raw and isinstance(raw["content"], list):
-            try:
-                text = raw["content"][0].get("text", "")
-                return json.loads(text) if text else raw
-            except (IndexError, json.JSONDecodeError, KeyError):
-                pass
-        return raw
+    _channel_name = "telegram"
+    _default_server = "telegram"
+    _tool_name = "send_message"
+    _message_key = "text"
+    _recipient_key = "chat_id"
+    _forward_keys = ("reply_to_message_id",)
+    _message_id_key = "message_id"

--- a/core/skills/reports.py
+++ b/core/skills/reports.py
@@ -421,9 +421,7 @@ def _format_scoring_breakdown_html(
             f"<td>{weighted:.1f}</td></tr>\n"
         )
     multiplier = (
-        CONFIDENCE_BASE_FACTOR + CONFIDENCE_SCALE_FACTOR * confidence / 100
-        if confidence
-        else 1.0
+        CONFIDENCE_BASE_FACTOR + CONFIDENCE_SCALE_FACTOR * confidence / 100 if confidence else 1.0
     )
     final = weighted_sum * multiplier
     return f"""<div class="section">
@@ -462,9 +460,7 @@ def _format_scoring_breakdown_md(
         label = key.upper() if key in ("psm", "dev") else key.capitalize()
         lines.append(f"| {label} | {val:.1f} | {weight:.0%} | {weighted:.1f} |")
     multiplier = (
-        CONFIDENCE_BASE_FACTOR + CONFIDENCE_SCALE_FACTOR * confidence / 100
-        if confidence
-        else 1.0
+        CONFIDENCE_BASE_FACTOR + CONFIDENCE_SCALE_FACTOR * confidence / 100 if confidence else 1.0
     )
     final = weighted_sum * multiplier
     lines.append("")

--- a/core/skills/reports.py
+++ b/core/skills/reports.py
@@ -14,6 +14,12 @@ from pathlib import Path
 from string import Template
 from typing import Any
 
+from core.domains.game_ip.scoring_constants import (
+    CONFIDENCE_BASE_FACTOR,
+    CONFIDENCE_SCALE_FACTOR,
+    REPORT_WEIGHTS,
+)
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -392,14 +398,7 @@ def _format_psm_md(psm: dict[str, Any]) -> str:
 # Scoring weight breakdown formatters
 # ---------------------------------------------------------------------------
 
-_SCORING_WEIGHTS = [
-    ("psm", 0.25),
-    ("quality", 0.20),
-    ("recovery", 0.18),
-    ("growth", 0.12),
-    ("momentum", 0.20),
-    ("dev", 0.05),
-]
+_SCORING_WEIGHTS = REPORT_WEIGHTS
 
 
 def _format_scoring_breakdown_html(
@@ -421,7 +420,11 @@ def _format_scoring_breakdown_html(
             f"<td>{weight:.0%}</td>"
             f"<td>{weighted:.1f}</td></tr>\n"
         )
-    multiplier = 0.7 + 0.3 * confidence / 100 if confidence else 1.0
+    multiplier = (
+        CONFIDENCE_BASE_FACTOR + CONFIDENCE_SCALE_FACTOR * confidence / 100
+        if confidence
+        else 1.0
+    )
     final = weighted_sum * multiplier
     return f"""<div class="section">
     <h2><span class="icon">&#x1F9EE;</span> Scoring Breakdown</h2>
@@ -458,7 +461,11 @@ def _format_scoring_breakdown_md(
         weighted_sum += weighted
         label = key.upper() if key in ("psm", "dev") else key.capitalize()
         lines.append(f"| {label} | {val:.1f} | {weight:.0%} | {weighted:.1f} |")
-    multiplier = 0.7 + 0.3 * confidence / 100 if confidence else 1.0
+    multiplier = (
+        CONFIDENCE_BASE_FACTOR + CONFIDENCE_SCALE_FACTOR * confidence / 100
+        if confidence
+        else 1.0
+    )
     final = weighted_sum * multiplier
     lines.append("")
     lines.append(


### PR DESCRIPTION
## Summary
- 코드베이스 전체 품질 점검 후 중복 제거, 상수 중앙화, 리소스 누수 수정
- 27 files changed, 770 insertions, 721 deletions (순감 +49줄, 구조적 개선)

## Why
5개 관점(중복, 미사용, 설계, 상수, 에러처리)으로 감사한 결과 Notification/Calendar/OAuth 어댑터의 심각한 코드 중복, 스코어링 매직넘버 산재, LLM 클라이언트 리소스 누수 등을 발견

## Changes
| File | Change |
|------|--------|
| `core/mcp/base_notification.py` | NEW — Notification adapter base class + `parse_mcp_result()` |
| `core/mcp/slack_adapter.py` | 91→21줄 — class attrs만 정의 |
| `core/mcp/discord_adapter.py` | 89→21줄 — class attrs만 정의 |
| `core/mcp/telegram_adapter.py` | 91→21줄 — class attrs만 정의 |
| `core/mcp/base_calendar.py` | NEW — Calendar adapter base class (template method) |
| `core/mcp/apple_calendar_adapter.py` | 162→95줄 — subclass override만 |
| `core/mcp/google_calendar_adapter.py` | 164→95줄 — subclass override만 |
| `core/domains/game_ip/scoring_constants.py` | NEW — Tier/Weight/Confidence 상수 SOT + `classify_tier()`, `score_style()` |
| `core/domains/game_ip/nodes/scoring.py` | 하드코딩 가중치/임계값 → 상수 참조 |
| `core/domains/game_ip/adapter.py` | fallback 가중치 → `DEFAULT_WEIGHTS` |
| `core/skills/reports.py` | `_SCORING_WEIGHTS` → `REPORT_WEIGHTS`, `0.7+0.3` → constants |
| `core/cli/ui/panels.py` | `>=80/60/40` → `classify_tier()`, `score_style()` |
| `core/cli/ui/event_renderer.py` | `>=80/60` → `score_ansi_color()` |
| `core/domains/game_ip/fixtures/generator.py` | tier 분류 → `classify_tier()` |
| `core/llm/credentials.py` | NEW — 공유 `resolve_provider_key()` |
| `core/llm/providers/anthropic.py` | 14줄 → 2줄 (delegate to credentials.py) |
| `core/llm/providers/openai.py` | 14줄 → 2줄 (delegate to credentials.py) |
| `core/gateway/auth/credential_cache.py` | NEW — `CredentialCache` + `refresh_managed_token()` |
| `core/gateway/auth/claude_code_oauth.py` | 캐시 코드 제거 → `CredentialCache` 사용 |
| `core/gateway/auth/codex_cli_oauth.py` | 캐시 코드 제거 → `CredentialCache` 사용 |
| `core/gateway/pollers/base.py` | `_check_mcp_health()`, `_get_channel_bindings()`, `_env_config_var` 추가 |
| `core/gateway/pollers/slack_poller.py` | 공통 부분 base 호출로 교체 |
| `core/gateway/pollers/discord_poller.py` | 공통 부분 base 호출로 교체 |
| `core/gateway/pollers/telegram_poller.py` | 공통 부분 base 호출로 교체 |
| `core/hooks/llm_extract_learning.py` | LLM client `try/finally`+`close()`, 모델명 → `ANTHROPIC_BUDGET` |
| `core/mcp/manager.py` | silent `except Exception: return` → `log.debug` |
| `core/cli/commands.py` | `except Exception` → 구체적 타입 + 에러 컨텍스트 |

## Verification
- [x] ruff check clean (27/27 files)
- [x] mypy clean (27/27 files)
- [x] pytest 363+ passed (notification 53, calendar+scoring 230, auth 71, gateway 38, etc.)
- [x] 기존 실패 2건은 변경과 무관 (test_same_model_noop, test_subprocess_async)

## Reference
Codebase audit: 5-dimension parallel analysis (duplication, dead code, design flaws, magic constants, error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)