### PR TITLE
style: ruff format test_gateway.py — merge-missed hunk

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -129,7 +129,9 @@ class TestChannelManager:
     def test_require_mention_filter(self):
         manager = ChannelManager()
         manager.set_processor(lambda content, meta: "processed")
-        manager.add_binding(ChannelBinding(channel="discord", channel_id="D1", require_mention=True))
+        manager.add_binding(
+            ChannelBinding(channel="discord", channel_id="D1", require_mention=True)
+        )
 
         # Without mention — should be ignored
         msg = InboundMessage(


### PR DESCRIPTION
## Summary
- 3-way merge(develop→main)에서 누락된 format hunk 1건 수정 (line 129)

## Why
PR #735 format fix가 develop에서는 완전했으나 main merge 시 line 129 hunk 누락.
CI Lint & Format 지속 실패 원인.

## Verification
- [x] ruff format --check pass