### PR TITLE
chore: OSS templates + gitignore guardrails

### DIFF
--- a/.geode/skills/TEMPLATE.md
+++ b/.geode/skills/TEMPLATE.md
@@ -1,0 +1,55 @@
+# Skill: [Skill Name]
+
+> Copy this template to `.geode/skills/<skill-name>/SKILL.md` to create a custom skill.
+> Skills extend GEODE's capabilities with domain-specific knowledge and workflows.
+
+## Metadata
+
+```yaml
+name: skill-name
+description: One-line description of what this skill does
+triggers:
+  - keyword1
+  - keyword2
+  - keyword3
+```
+
+## Purpose
+
+What does this skill do? When should it be activated?
+
+## Instructions
+
+<!-- Write the skill's system instructions here. -->
+<!-- GEODE will inject this content when the skill is triggered. -->
+
+### Input Format
+
+Describe what input the skill expects.
+
+### Output Format
+
+Describe what output the skill produces.
+
+### Rules
+
+1. Rule one
+2. Rule two
+3. Rule three
+
+## Examples
+
+### Example 1: [Scenario]
+
+**Input**: `geode "trigger keyword with context"`
+
+**Expected Output**:
+```
+Skill output here
+```
+
+## Notes
+
+- Any caveats, limitations, or configuration requirements.
+- Skills are loaded from `.geode/skills/` at runtime via `SkillRegistry`.
+- Trigger keywords are matched against user input for auto-activation.

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,31 @@ geode_checkpoints.db
 !.geode/memory/
 !.geode/config.toml.example
 !.geode/skills/
+
+# Personal skills — never commit (use .geode/skills/TEMPLATE.md as guide)
+.geode/skills/job-hunter/
+.geode/skills/expense-tracker/
+.geode/skills/youtube-planner/
+.geode/skills/daily-briefing/
+.geode/skills/weekly-retro/
+.geode/skills/slack-digest/
+
+# Personal memory — never commit
+.geode/memory/PROJECT.md
+
+# Scaffold harness — local-only
+.claude/commands/
+.claude/hooks/
+.claude/skills/
+.claude/workflow-state.json
+.claude/worktrees/
+.claude/MEMORY.md
+
+# Temporary artifacts
+tmp/
+reports/
+*.png
+*.html
+!docs/**/*.html
+
 # CI trigger

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,0 +1,55 @@
+# Plan: [Feature Name]
+
+> Copy this template to `docs/plans/<feature-name>.md` when planning a new feature.
+> Move to `docs/plans/_done/` when implementation is complete.
+
+## Problem
+
+What problem does this solve? What breaks without it?
+
+## Socratic Gate
+
+| # | Question | Answer |
+|---|----------|--------|
+| Q1 | Does it already exist in code? | |
+| Q2 | What breaks if we don't do this? | |
+| Q3 | How do we measure the effect? | |
+| Q4 | What is the simplest implementation? | |
+| Q5 | Is this pattern in 3+ frontier systems? | |
+
+## Design
+
+### Approach
+
+Describe the implementation approach.
+
+### Affected Files
+
+| File | Change |
+|------|--------|
+| `core/...` | |
+
+### Alternatives Considered
+
+What other approaches were evaluated and why they were rejected.
+
+## Implementation Checklist
+
+- [ ] Implementation
+- [ ] Tests
+- [ ] Lint + Type check
+- [ ] Documentation update (if applicable)
+- [ ] CHANGELOG entry
+
+## Verification
+
+```bash
+uv run ruff check core/ tests/
+uv run mypy core/
+uv run pytest tests/ -m "not live"
+```
+
+## References
+
+- Related issue: #
+- Frontier precedent: (Claude Code / Codex / OpenClaw / autoresearch)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,23 @@
+# GEODE Progress Board
+
+> Multi-agent shared kanban. Updated from `main` only.
+> Each item maps 1:1 to a GitHub Issue or TaskCreate ID.
+
+## Backlog
+
+<!-- Add items here when identified. Format: -->
+<!-- - [ ] #issue-number — Short description (@assignee) -->
+
+## In Progress
+
+<!-- Move items here when work begins. -->
+<!-- 3-Checkpoint: (1) alloc → (2) merge (CI 5/5) → (3) verify -->
+
+## In Review
+
+<!-- PRs submitted, awaiting CI + review. -->
+
+## Done
+
+<!-- Completed items. Keep recent 10, archive older ones. -->
+<!-- - [x] #issue-number — Short description (PR #N) -->

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,88 @@
+# GEODE Development Workflow
+
+> Public-facing guide for contributors. For detailed scaffold rules, see `CLAUDE.md`.
+
+## Branch Strategy (GitFlow)
+
+```
+feature/<name> ──> develop ──> main
+```
+
+- **feature/**: All new work branches from `develop`
+- **develop**: Integration branch, CI must pass before merge
+- **main**: Production, only receives merges from `develop`
+
+No direct pushes to `main` or `develop`. Always PR with CI 5/5.
+
+## Worktree Isolation
+
+Each task runs in its own git worktree:
+
+```bash
+git fetch origin
+git worktree add .claude/worktrees/<task-name> -b feature/<branch-name> develop
+echo "session=$(date -Iseconds) task_id=<task-name>" > .claude/worktrees/<task-name>/.owner
+```
+
+On completion: `git push` then `git worktree remove`.
+
+## Quality Gates
+
+Every PR must pass all gates before merge:
+
+| Gate | Command | Criteria |
+|------|---------|----------|
+| Lint | `uv run ruff check core/ tests/` | 0 errors |
+| Format | `uv run ruff format --check core/ tests/` | 0 diffs |
+| Type | `uv run mypy core/` | 0 errors |
+| Test | `uv run pytest tests/ -m "not live"` | All pass |
+| E2E | `uv run geode analyze "Cowboy Bebop" --dry-run` | A (68.4) |
+
+## Workflow Steps
+
+```
+0. Issue + Worktree
+1. GAP Audit (does it already exist?)
+2. Plan + Socratic Gate (is it needed?)
+3. Implement + Test (iterate)
+4. Verify (plan vs diff cross-check)
+5. Docs Sync (CHANGELOG, version)
+6. PR + CI (feature -> develop -> main)
+7. Rebuild + Restart
+```
+
+### Socratic Gate (for non-trivial features)
+
+Before implementing, answer these 5 questions:
+
+1. **Does it already exist in code?** (grep/explore verification)
+2. **What breaks if we don't do this?** (failure scenario)
+3. **How do we measure the effect?** (tests, metrics)
+4. **What is the simplest implementation?** (minimum changes)
+5. **Is this the same pattern in 3+ frontier systems?** (validation)
+
+### PR Body (Required Sections)
+
+```markdown
+## Summary
+## Why
+## Changes
+## Verification
+```
+
+See `.github/PULL_REQUEST_TEMPLATE.md` for the full template.
+
+## Versioning
+
+- New feature: MINOR bump (0.X.0)
+- Bug fix: PATCH bump (0.0.X)
+- Docs only: No version change
+
+Version must match across: `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `pyproject.toml`.
+
+## Conventions
+
+- **Commit messages**: Conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`, `style:`)
+- **Language**: Korean or English (maintain consistency within a PR)
+- **No emojis** in code or prompts (allowed in reports only)
+- **Line length**: 100 characters (ruff enforced)


### PR DESCRIPTION
## Summary
- 삭제된 워크플로우 파일의 공개용 템플릿 4종 추가
- .gitignore에 개인/스캐폴드 파일 가드레일 추가

## Why
OSS 공개 시 삭제한 progress.md, plans/, workflow.md, skills/ 중 기여자에게 필요한 패턴은 템플릿으로 제공해야 함. 또한 향후 커밋에서 개인 파일이 실수로 올라가지 않도록 .gitignore 가드레일 필요.

## Changes
| File | Change |
|------|--------|
| `docs/progress.md` | NEW — 빈 칸반 보드 템플릿 |
| `docs/plans/TEMPLATE.md` | NEW — 기획서 양식 (Socratic Gate 포함) |
| `docs/workflow.md` | NEW — 공개용 개발 워크플로우 가이드 |
| `.geode/skills/TEMPLATE.md` | NEW — 커스텀 스킬 작성 가이드 |
| `.gitignore` | 개인 스킬, 메모리, 스캐폴드, 임시 파일 차단 추가 |

## Verification
- [x] 템플릿 내용이 CLAUDE.md/CONTRIBUTING.md와 일관성 유지
- [x] .gitignore 패턴이 기존 tracked 파일과 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)