### PR TITLE
fix: BashTool runs in user's cwd instead of GEODE install path

### DIFF
--- a/core/cli/bash_tool.py
+++ b/core/cli/bash_tool.py
@@ -78,6 +78,10 @@ class BashTool:
     """Execute shell commands with safety checks and HITL approval."""
 
     def __init__(self, *, working_dir: str | None = None) -> None:
+        if working_dir is None:
+            from core.paths import get_project_root
+
+            working_dir = str(get_project_root())
         self._working_dir = working_dir
 
     def validate(self, command: str) -> BashResult | None:


### PR DESCRIPTION
## Summary
- BashTool의 working_dir 기본값을 None → get_project_root()로 변경
- GEODE가 사용자의 작업 공간에서 bash 명령을 실행하도록 수정

## Why
`geode`를 사용자의 프로젝트 디렉토리에서 실행해도, bash 명령이 GEODE 설치 경로에서 실행됨. Claude Code의 originalCwd 패턴과 불일치.

## Changes
| File | Change |
|------|--------|
| `core/cli/bash_tool.py` | `__init__`에서 `working_dir=None`일 때 `get_project_root()` 사용 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 118 passed (bash_tool, bash, sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)