### PR TITLE
fix: BashTool cwd — run in user's workspace (#748)

### DIFF
--- a/core/cli/bash_tool.py
+++ b/core/cli/bash_tool.py
@@ -78,6 +78,10 @@ class BashTool:
     """Execute shell commands with safety checks and HITL approval."""
 
     def __init__(self, *, working_dir: str | None = None) -> None:
+        if working_dir is None:
+            from core.paths import get_project_root
+
+            working_dir = str(get_project_root())
         self._working_dir = working_dir
 
     def validate(self, command: str) -> BashResult | None:


### PR DESCRIPTION
## Summary
- develop → main 프로모션
- BashTool이 사용자의 cwd에서 실행되도록 수정

## Verification
- [x] CI 5/5 passed on #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)