### PR TITLE
feat: context hierarchy gaps — cursor extraction + prompt cache split

### DIFF
--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -29,6 +29,11 @@ _MAX_SECTION_LINES = 20
 
 _SYSTEM_PROMPT_TEMPLATE = ROUTER_SYSTEM
 
+# Prompt caching boundary marker (Claude Code pattern).
+# Content BEFORE this marker is stable across turns → cache hit.
+# Content AFTER changes per turn (memory, date, model card) → no cache.
+PROMPT_CACHE_BOUNDARY = "__GEODE_PROMPT_CACHE_BOUNDARY__"
+
 # Well-known IPs to include as examples (recognizable across languages)
 _NOTABLE_IPS = {
     "berserk",
@@ -51,7 +56,12 @@ _NOTABLE_IPS = {
 
 
 def build_system_prompt(model: str = "") -> str:
-    """Build system prompt with model card, IP examples, and memory context."""
+    """Build system prompt with model card, IP examples, and memory context.
+
+    Inserts PROMPT_CACHE_BOUNDARY between static (template + identity) and
+    dynamic (date, model card, memory, user context) sections.  Anthropic
+    adapter splits at this boundary to maximize prompt cache hits.
+    """
     from core.domains.game_ip.fixtures import FIXTURE_MAP, load_fixture
 
     name_map = get_ip_name_map()
@@ -67,31 +77,45 @@ def build_system_prompt(model: str = "") -> str:
             except Exception:
                 examples.append(fk.title())
 
-    base = _SYSTEM_PROMPT_TEMPLATE.format(
+    # ── STATIC section (stable across turns → cache hit) ──
+    static = _SYSTEM_PROMPT_TEMPLATE.format(
         ip_count=ip_count,
         ip_examples=", ".join(sorted(examples)),
     )
 
-    # Model card: inject current model info so LLM can answer model questions directly
+    # G1: Agent identity (from GEODE.md — stable per session)
+    identity_ctx = _build_identity_context()
+    if identity_ctx:
+        static += "\n\n" + identity_ctx
+
+    # ── DYNAMIC section (changes per turn → no cache) ──
+    dynamic_parts: list[str] = []
+
     if model:
         model_card = _build_model_card(model)
         if model_card:
-            base += "\n\n" + model_card
+            dynamic_parts.append(model_card)
 
-    # Inject current date so LLM uses the correct year for searches
-    base += "\n\n" + _build_date_context()
+    dynamic_parts.append(_build_date_context())
 
-    # P1-C: Inject memory context (recent insights + active rules)
-    memory_ctx = _build_memory_context()
-    if memory_ctx:
-        base += "\n\n" + memory_ctx
+    # G2-G4: Memory hierarchy (may change between turns)
+    g2 = _build_geode_memory_context()
+    if g2:
+        dynamic_parts.append(g2)
+    g3 = _build_learning_context()
+    if g3:
+        dynamic_parts.append(g3)
+    g4 = _build_project_memory_context()
+    if g4:
+        dynamic_parts.append(g4)
 
-    # User context: profile + career identity
     user_ctx = _build_user_context()
     if user_ctx:
-        base += "\n\n" + user_ctx
+        dynamic_parts.append(user_ctx)
 
-    return base
+    dynamic = "\n\n".join(dynamic_parts)
+
+    return static + "\n\n" + PROMPT_CACHE_BOUNDARY + "\n\n" + dynamic
 
 
 def format_current_date() -> str:
@@ -242,21 +266,13 @@ def _build_user_context() -> str:
 def _build_memory_context() -> str:
     """Build memory context string from the 4-tier memory hierarchy.
 
-    Injects G1-G4 into the system prompt:
-      G1: GEODE.md identity (Core Principles + CANNOT + Defaults)
-      G2: .geode/MEMORY.md project meta-index
-      G3: .geode/LEARNING.md agent learning records
-      G4: .geode/memory/PROJECT.md runtime insights + rules (existing)
+    G1 (identity) is now injected in the STATIC section of build_system_prompt()
+    for prompt cache optimization.  This function assembles G2-G4 only.
 
     Each section is capped at ``_MAX_SECTION_LINES`` lines.
     Missing files are silently skipped (graceful degradation).
     """
     parts: list[str] = []
-
-    # --- G1: Agent Identity (GEODE.md) ---
-    identity_ctx = _build_identity_context()
-    if identity_ctx:
-        parts.append(identity_ctx)
 
     # --- G2: Project Memory Index (.geode/MEMORY.md) ---
     geode_memory_ctx = _build_geode_memory_context()

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -4,7 +4,9 @@ Runs on TURN_COMPLETE (low priority, after auto_learn regex detectors).
 Sends recent conversation context to a budget model (Haiku/GLM-flash)
 to extract learning items that regex detectors would miss.
 
-Fires at most once per 5 turns to control cost.
+Cursor-based incremental extraction: only processes messages since the
+last extraction, skipping already-seen content.  Mutual exclusion skips
+extraction if the main agent already wrote to memory this turn.
 """
 
 from __future__ import annotations
@@ -18,9 +20,9 @@ from core.hooks.system import HookEvent
 
 log = logging.getLogger(__name__)
 
-_TURN_INTERVAL = 5  # extract every N turns
+_TURN_INTERVAL = 1  # extract every N turns (cursor-based, so safe at 1)
 _MAX_CONTEXT_CHARS = 3000  # recent conversation to send to LLM
-_MAX_PER_SESSION = 5  # LLM extractions per session
+_MAX_PER_SESSION = 10  # LLM extractions per session (raised from 5)
 
 _EXTRACT_PROMPT = """\
 You are a learning extraction agent. Analyze the recent conversation
@@ -88,9 +90,11 @@ def _call_glm_flash(prompt: str, api_key: str) -> str | None:
     """Call GLM-4.7-flash (free tier)."""
     import openai
 
+    from core.config import GLM_BASE_URL
+
     client = openai.OpenAI(
         api_key=api_key,
-        base_url="https://open.bigmodel.cn/api/paas/v4/",
+        base_url=GLM_BASE_URL,
     )
     try:
         resp = client.chat.completions.create(
@@ -150,10 +154,15 @@ def _parse_extractions(text: str) -> list[tuple[str, str]]:
 
 
 def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
-    """Create TURN_COMPLETE handler for LLM-based learning extraction."""
+    """Create TURN_COMPLETE handler for LLM-based learning extraction.
+
+    Claude Code extractMemories pattern: cursor-based incremental extraction
+    with mutual exclusion (skip if main agent wrote to memory this turn).
+    """
     turn_count = 0
     session_extractions = 0
     last_extract_ts = 0.0
+    _seen_inputs: set[int] = set()  # hash of already-extracted user inputs
 
     def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:
         nonlocal turn_count, session_extractions, last_extract_ts
@@ -167,9 +176,24 @@ def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
         if session_extractions >= _MAX_PER_SESSION:
             return
 
-        # 60s cooldown
+        # 30s cooldown (reduced from 60s for cursor-based extraction)
         now = time.monotonic()
-        if now - last_extract_ts < 60.0:
+        if now - last_extract_ts < 30.0:
+            return
+
+        # Mutual exclusion: skip if main agent already wrote to memory this turn
+        # (Claude Code pattern — avoid duplicate extraction)
+        tool_calls = data.get("tool_calls", [])
+        _MEMORY_TOOLS = {"memory_save", "note_save", "profile_learn", "manage_rule"}
+        if _MEMORY_TOOLS & set(tool_calls):
+            log.debug("LLM extract: skipping — main agent wrote to memory")
+            return
+
+        # Cursor-based: skip if we already extracted from this user input
+        user_input = data.get("user_input", "")
+        input_hash = hash(user_input)
+        if input_hash in _seen_inputs:
+            log.debug("LLM extract: skipping — already extracted from this input")
             return
 
         from core.tools.profile_tools import get_user_profile
@@ -186,6 +210,9 @@ def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
         llm_output = _call_budget_llm(prompt)
         if not llm_output:
             return
+
+        # Mark as seen regardless of extraction result
+        _seen_inputs.add(input_hash)
 
         extractions = _parse_extractions(llm_output)
         for pattern_text, category in extractions:

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -366,9 +366,33 @@ class ClaudeAgenticAdapter:
                 call_temperature = 1.0
                 call_max_tokens = max(max_tokens, thinking_budget + max_tokens)
 
+            # Prompt caching split: static content before boundary gets
+            # cache_control for reuse across turns; dynamic content after
+            # boundary is ephemeral.  (Claude Code STATIC/DYNAMIC pattern)
+            from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
+
+            if PROMPT_CACHE_BOUNDARY in system:
+                static_part, dynamic_part = system.split(PROMPT_CACHE_BOUNDARY, 1)
+                sys_blocks: list[dict[str, Any]] = [
+                    {
+                        "type": "text",
+                        "text": static_part.rstrip(),
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {"type": "text", "text": dynamic_part.lstrip()},
+                ]
+            else:
+                sys_blocks = [
+                    {
+                        "type": "text",
+                        "text": system,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
+
             create_kwargs: dict[str, Any] = {
                 "model": m,
-                "system": system,
+                "system": sys_blocks,
                 "messages": messages,
                 "tools": api_tools,
                 "tool_choice": tool_choice,


### PR DESCRIPTION
## Summary
- P0: 메모리 추출을 cursor 기반 증분으로 전환 (Claude Code extractMemories 패턴)
- P1: system prompt에 STATIC/DYNAMIC boundary 도입, Anthropic adapter에서 cache split

## Why
Context hierarchy 감사에서 Claude Code 대비 4개 GAP 발견:
1. Background memory extraction 부재 → cursor 기반으로 개선 (P0)
2. Prompt caching 미최적화 → STATIC/DYNAMIC split (P1)
3. Delta attachment 없음 → P2 (이번 PR 범위 외)
4. Enterprise policy cascade → Skip (개인 에이전트)

## Changes
| File | Change |
|------|--------|
| `core/hooks/llm_extract_learning.py` | cursor hash set, mutual exclusion, interval 5→1, cap 5→10, GLM_BASE_URL |
| `core/agent/system_prompt.py` | PROMPT_CACHE_BOUNDARY 상수, G1→static, build_system_prompt 재구조화 |
| `core/llm/providers/anthropic.py` | boundary 기준 2-block system prompt split, cache_control 분리 |

## Reference
- Claude Code: `constants/prompts.ts` SYSTEM_PROMPT_DYNAMIC_BOUNDARY
- Claude Code: `services/extractMemories/extractMemories.ts` cursor + coalescing
- Claude Code: `utils/api.ts` splitSysPromptPrefix()

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] pytest 3885 passed (1 flaky — test_same_model_noop, 단독 pass 확인)