### PR TITLE
docs: branch-sync verification rule (CANNOT/Git)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ These cannot be violated at any stage. Violations must be immediately halted and
 | | No `git checkout` switching within a worktree | Isolation maintenance |
 | | No modifying tracking documents from feature/develop | Single source of truth on main |
 | | No branch creation when remote is out of sync | Conflict prevention |
+| | No claiming "branch needs sync" from commit count alone — verify content with `git diff A B --stat` first | Graph asymmetry ≠ content asymmetry (gitflow merge commits) |
 | **Planning** | No starting implementation without Socratic Gate (except bugs/docs) | Prevent over-engineering |
 | **Quality** | No committing with lint/type/test failures | Ratchet (P4) |
 | | No placeholders (XXXX) in metrics — measured values only | Truth guarantee |


### PR DESCRIPTION
## Summary
- CANNOT/Git 테이블에 "커밋 수로 sync 여부 판단 금지 — `git diff A B --stat` 먼저" 규칙 1줄 추가

## Why
직전 세션에서 `main`이 `develop`보다 6커밋 앞서 있다는 이유로 "back-merge 필요"를 사용자에게 보고했으나, 해당 6커밋은 전부 `Merge pull request #... from develop` 머지 커밋이었고 `git diff main develop` 결과는 빈 출력이었음. 커밋 수 비대칭과 내용 비대칭을 구분하지 못한 보고는 사용자에게 불필요한 작업을 유도할 수 있음. 규칙을 CANNOT에 명시해 같은 실수가 재발하지 않도록 함.

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | CANNOT Git 행 1개 추가: `No claiming "branch needs sync" from commit count alone — verify content with git diff A B --stat first` |

## Verification
- [x] CLAUDE.md 편집만 (Python 변경 없음 → lint/type/test 무영향)
- [x] 규칙 표현이 기존 Git 행 스타일(명사구 + rationale)과 일관

## Reference
2026-04-21 세션에서 사용자 피드백("이런 불찰이 안 생기게 하려면 어떤 조치가 필요해?")으로 도출된 규칙.