### PR TITLE
fix: wire mark_success/mark_failure + 8 missing audit loggers

### DIFF
--- a/core/llm/credentials.py
+++ b/core/llm/credentials.py
@@ -2,17 +2,36 @@
 
 Centralizes the OAuth-preferred → API-key-fallback pattern used
 by Anthropic and OpenAI providers.
+
+Profile tracking: stores the last-resolved profile per provider
+so that success/failure callbacks can notify the ProfileRotator
+without re-resolving (OpenClaw ``markAuthProfileGood``/``markAuthProfileFailure`` pattern).
 """
 
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.gateway.auth.profiles import AuthProfile
 
 log = logging.getLogger(__name__)
+
+# Last-resolved profile per provider (set in resolve_provider_key, read in callbacks).
+_last_profile: dict[str, AuthProfile] = {}
+
+
+def get_last_profile(provider: str) -> Any:
+    """Return the last profile resolved for *provider*, or None."""
+    return _last_profile.get(provider)
 
 
 def resolve_provider_key(provider: str, settings_fallback: str) -> str:
     """Resolve API key via ProfileRotator (OAuth preferred) or settings fallback.
+
+    Stores the resolved profile in ``_last_profile`` for downstream
+    ``on_llm_success``/``on_llm_failure`` callbacks.
 
     Args:
         provider: Provider name for rotator lookup ("anthropic", "openai").
@@ -28,8 +47,46 @@ def resolve_provider_key(provider: str, settings_fallback: str) -> str:
         if rotator:
             profile = rotator.resolve(provider)
             if profile and profile.key:
+                _last_profile[provider] = profile
                 rotator.mark_used(profile)
                 return profile.key
     except Exception:
         log.debug("ProfileRotator not available for %s, falling back to settings", provider)
     return settings_fallback
+
+
+def notify_llm_success(provider: str) -> None:
+    """Notify ProfileRotator of a successful LLM call.
+
+    Resets error count and cooldown for the last-resolved profile (OpenClaw pattern).
+    """
+    profile = _last_profile.get(provider)
+    if profile is None:
+        return
+    try:
+        from core.runtime_wiring.infra import get_profile_rotator
+
+        rotator = get_profile_rotator()
+        if rotator:
+            rotator.mark_success(profile)
+    except Exception:
+        log.debug("notify_llm_success failed for %s", provider)
+
+
+def notify_llm_failure(provider: str, exc: Exception) -> None:
+    """Notify ProfileRotator of a failed LLM call.
+
+    Classifies auth errors (401/403) to trigger managed token refresh.
+    """
+    profile = _last_profile.get(provider)
+    if profile is None:
+        return
+    try:
+        from core.llm.fallback import _is_auth_error
+        from core.runtime_wiring.infra import get_profile_rotator
+
+        rotator = get_profile_rotator()
+        if rotator:
+            rotator.mark_failure(profile, is_auth_error=_is_auth_error(exc))
+    except Exception:
+        log.debug("notify_llm_failure failed for %s", provider)

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -67,6 +67,38 @@ def _try_oauth_refresh(provider_label: str) -> bool:
     return False
 
 
+def _resolve_rotator_provider(provider_label: str) -> str:
+    """Map provider_label (e.g. 'LLM', 'OpenAI', 'GLM') to rotator provider name."""
+    label = provider_label.lower()
+    if label in ("llm", "anthropic"):
+        return "anthropic"
+    if label in ("openai",):
+        return "openai"
+    if label in ("glm", "zhipuai"):
+        return "glm"
+    return label
+
+
+def _notify_success(provider: str) -> None:
+    """Notify ProfileRotator of LLM call success (non-blocking)."""
+    try:
+        from core.llm.credentials import notify_llm_success
+
+        notify_llm_success(provider)
+    except Exception:
+        log.debug("Profile notify_success failed for %s", provider, exc_info=True)
+
+
+def _notify_failure(provider: str, exc: Exception) -> None:
+    """Notify ProfileRotator of LLM call failure (non-blocking)."""
+    try:
+        from core.llm.credentials import notify_llm_failure
+
+        notify_llm_failure(provider, exc)
+    except Exception:
+        log.debug("Profile notify_failure failed for %s", provider, exc_info=True)
+
+
 class CircuitBreaker:
     """Thread-safe circuit breaker for LLM API calls.
 
@@ -190,11 +222,15 @@ def retry_with_backoff_generic(
     last_error: Exception | None = None
     t0_retry = time.monotonic()
 
+    # Resolve provider name for rotator notification (strip "LLM"/"OpenAI" labels)
+    _provider_for_rotator = _resolve_rotator_provider(provider_label)
+
     for model_idx, current_model in enumerate(models_to_try):
         for attempt in range(max_retries):
             try:
                 result = fn(model=current_model)
                 circuit_breaker.record_success()
+                _notify_success(_provider_for_rotator)
                 return result
             except retryable_errors as exc:
                 last_error = exc
@@ -260,5 +296,6 @@ def retry_with_backoff_generic(
     if last_error is None:
         raise RuntimeError("All retries exhausted with no error recorded")
     circuit_breaker.record_failure()
+    _notify_failure(_provider_for_rotator, last_error)
     log.error("All %s models and retries exhausted. Last error: %s", provider_label, last_error)
     raise last_error

--- a/core/runtime_wiring/bootstrap.py
+++ b/core/runtime_wiring/bootstrap.py
@@ -428,6 +428,25 @@ def build_hooks(
             ["total_cost_usd", "limit_usd"],
         ),
         (_E.EXECUTION_CANCELLED, "exec_cancel", "Execution cancelled: %s", ["session_id"]),
+        # Asymmetry fixes — events that had triggers but no audit logger
+        (_E.LLM_CALL_FAILED, "llm_failed", "LLM call FAILED: %s — %s", ["model", "error_type"]),
+        (_E.LLM_CALL_RETRY, "llm_retry", "LLM call retry: %s (attempt %s)", ["model", "attempt"]),
+        (
+            _E.TOOL_RECOVERY_SUCCEEDED,
+            "recovery_ok",
+            "Tool recovery OK: %s",
+            ["tool_name"],
+        ),
+        (_E.MCP_SERVER_CONNECTED, "mcp_ok", "MCP server connected: %s", ["server_name"]),
+        (_E.TOOL_RESULT_OFFLOADED, "tool_offload", "Tool result offloaded: %s", ["tool_name"]),
+        (_E.TOOL_APPROVAL_REQUESTED, "approval_req", "Tool approval requested: %s", ["tool_name"]),
+        (_E.MEMORY_SAVED, "memory_saved", "Memory saved: %s", ["key"]),
+        (
+            _E.REASONING_METRICS,
+            "reasoning_metrics",
+            "Reasoning: %s rounds, %s tools",
+            ["rounds", "tool_call_count"],
+        ),
     ]
 
     def _reg_audit_loggers() -> None:

--- a/docs/architecture/wiring-audit-matrix.md
+++ b/docs/architecture/wiring-audit-matrix.md
@@ -1,0 +1,101 @@
+# GEODE Hook/Auth Wiring Audit Matrix
+
+> 58 HookEvent 전수 감사 + Auth Profile 와이어링 점검 결과
+
+## 1. HookEvent Audit Logger Coverage (58개)
+
+| # | Event | Trigger Mode | Audit Logger | Dedicated Handler | Status |
+|---|---|---|---|---|---|
+| 1 | `PIPELINE_START` | trigger | run_log | stuck_tracker, metrics | OK |
+| 2 | `PIPELINE_END` | trigger | run_log | stuck, journal, notification, snapshot, outcomes | OK |
+| 3 | `PIPELINE_ERROR` | trigger | run_log | stuck, journal, notification | OK |
+| 4 | `NODE_BOOTSTRAP` | trigger | run_log | - | OK |
+| 5 | `NODE_ENTER` | trigger | run_log | task_bridge, stuck_detector | OK |
+| 6 | `NODE_EXIT` | trigger | run_log | task_bridge, stuck_detector | OK |
+| 7 | `NODE_ERROR` | trigger | run_log | task_bridge, stuck_detector | OK |
+| 8 | `ANALYST_COMPLETE` | trigger | run_log | - | OK |
+| 9 | `EVALUATOR_COMPLETE` | trigger | run_log | - | OK |
+| 10 | `SCORING_COMPLETE` | trigger | run_log | drift_scan, scoring_drift | OK |
+| 11 | `VERIFICATION_PASS` | trigger | run_log | - | OK |
+| 12 | `VERIFICATION_FAIL` | trigger | run_log, verif_fail | - | OK |
+| 13 | `DRIFT_DETECTED` | trigger | run_log, drift_logger | snapshot, pipeline_trigger, notification | OK |
+| 14 | `OUTCOME_COLLECTED` | trigger | run_log, outcome_logger | outcome_feedback_cycle | OK |
+| 15 | `MODEL_PROMOTED` | trigger | run_log, model_promotion_logger | - | OK |
+| 16 | `SNAPSHOT_CAPTURED` | trigger | run_log, snapshot_logger | - | OK |
+| 17 | `TRIGGER_FIRED` | trigger | run_log, trigger_logger | - | OK |
+| 18 | `POST_ANALYSIS` | trigger | run_log, post_analysis | - | OK |
+| 19 | `MEMORY_SAVED` | trigger | run_log, **memory_saved** | - | FIXED |
+| 20 | `RULE_CREATED` | trigger | run_log | - | OK |
+| 21 | `RULE_UPDATED` | trigger | run_log | - | OK |
+| 22 | `RULE_DELETED` | trigger | run_log | - | OK |
+| 23 | `PROMPT_ASSEMBLED` | trigger | run_log | - | OK |
+| 24 | `SUBAGENT_STARTED` | trigger | run_log, sa_started | - | OK |
+| 25 | `SUBAGENT_COMPLETED` | trigger | run_log | journal_subagent | OK |
+| 26 | `SUBAGENT_FAILED` | trigger | run_log | notification | OK |
+| 27 | `TOOL_RECOVERY_ATTEMPTED` | trigger | run_log, recovery_try | - | OK |
+| 28 | `TOOL_RECOVERY_SUCCEEDED` | trigger | run_log, **recovery_ok** | metrics | FIXED |
+| 29 | `TOOL_RECOVERY_FAILED` | trigger | run_log, recovery_fail | - | OK |
+| 30 | `TURN_COMPLETE` | trigger | run_log | auto_memory, auto_learn, llm_extract | OK |
+| 31 | `CONTEXT_CRITICAL` | trigger | run_log, ctx_critical | - | OK |
+| 32 | `CONTEXT_OVERFLOW_ACTION` | with_result | run_log | context_action_hook | OK |
+| 33 | `SESSION_START` | trigger | run_log | session_start_logger | OK |
+| 34 | `SESSION_END` | trigger | run_log | session_end_logger, tool_offload_cleanup | OK |
+| 35 | `MODEL_SWITCHED` | trigger | run_log | model_switch_logger | OK |
+| 36 | `LLM_CALL_START` | trigger | run_log, llm_start | - | OK |
+| 37 | `LLM_CALL_END` | trigger | run_log | llm_slow_logger, metrics | OK |
+| 38 | `LLM_CALL_FAILED` | trigger | run_log, **llm_failed** | - | FIXED |
+| 39 | `LLM_CALL_RETRY` | trigger | run_log, **llm_retry** | - | FIXED |
+| 40 | `TOOL_APPROVAL_REQUESTED` | trigger | run_log, **approval_req** | - | FIXED |
+| 41 | `TOOL_APPROVAL_GRANTED` | trigger | run_log | approval_tracker | OK |
+| 42 | `TOOL_APPROVAL_DENIED` | trigger | run_log | approval_tracker_denied | OK |
+| 43 | `FALLBACK_CROSS_PROVIDER` | trigger | run_log, xprovider_fb | - | OK |
+| 44 | `PIPELINE_TIMEOUT` | trigger | run_log, pipe_timeout | - | OK |
+| 45 | `SHUTDOWN_STARTED` | trigger | run_log, shutdown | - | OK |
+| 46 | `CONFIG_RELOADED` | trigger | run_log, config_reload | - | OK |
+| 47 | `TOOL_RESULT_OFFLOADED` | trigger | run_log, **tool_offload** | - | FIXED |
+| 48 | `MCP_SERVER_CONNECTED` | trigger | run_log, **mcp_ok** | - | FIXED |
+| 49 | `MCP_SERVER_FAILED` | trigger | run_log, mcp_fail | - | OK |
+| 50 | `USER_INPUT_RECEIVED` | interceptor | run_log, user_input | - | OK |
+| 51 | `TOOL_EXEC_START` | interceptor | run_log, tool_start | - | OK |
+| 52 | `TOOL_EXEC_END` | with_result | run_log, tool_end | - | OK |
+| 53 | `TOOL_EXEC_FAILED` | trigger | run_log, tool_failed | - | OK |
+| 54 | `TOOL_RESULT_TRANSFORM` | with_result | run_log, tool_transform | - | OK |
+| 55 | `COST_WARNING` | trigger | run_log, cost_warn | - | OK |
+| 56 | `COST_LIMIT_EXCEEDED` | trigger | run_log, cost_exceeded | - | OK |
+| 57 | `EXECUTION_CANCELLED` | trigger | run_log, exec_cancel | - | OK |
+| 58 | `REASONING_METRICS` | trigger | run_log, **reasoning_metrics** | - | FIXED |
+
+**FIXED** = 이번 PR에서 추가된 audit logger (8건)
+
+## 2. Auth Profile Wiring
+
+| 항목 | 이전 | 이후 | 참조 |
+|------|------|------|------|
+| `mark_used()` | `credentials.py:31` | 동일 | - |
+| `mark_success()` | **미호출** | `fallback.py` 성공 시 호출 | OpenClaw `markAuthProfileGood` |
+| `mark_failure()` | **미호출** | `fallback.py` 실패 시 호출 | OpenClaw `markAuthProfileFailure` |
+| `mark_failure(is_auth_error=True)` | **미호출** | auth 에러 분류 후 호출 | Hermes `_is_auth_error` |
+| Profile 추적 | 없음 | `_last_profile[provider]` | OpenClaw `lastGood[provider]` |
+| 401 auto-refresh | 정의만 | `_try_managed_refresh()` via `mark_failure` | Hermes `handle_401` |
+| Proactive refresh | 정의만 | `resolve()` 내 만료 120s 전 re-read | Hermes `REFRESH_SKEW` |
+
+## 3. Credential Scrubbing
+
+| 패턴 | 예시 | 적용 위치 |
+|------|------|-----------|
+| `sk-*` | `sk-proj-abc123...` | `tool_error()`, LLM router |
+| `ghp_*` | `ghp_1234567890abcdef` | 동일 |
+| `Bearer` | `Bearer eyJhbG...` | 동일 |
+| `xoxb-*` | `xoxb-1234-5678-abc...` | 동일 |
+| `token=`, `key=`, `password=` | URL query params | 동일 |
+
+## 4. Cross-Codebase Grounding
+
+| GEODE 구현 | Hermes Agent 참조 | OpenClaw 참조 |
+|---|---|---|
+| `_notify_success()` | `_reset_server_error()` | `markAuthProfileGood()` |
+| `_notify_failure()` | `_bump_server_error()` | `markAuthProfileFailure()` |
+| `_is_auth_error()` | `_is_auth_error()` | `classifyFailoverReason()` |
+| `_resolve_rotator_provider()` | N/A | `resolveAuthProfileOrder()` |
+| `scrub_credentials()` | `_CREDENTIAL_PATTERN` | N/A |
+| `register_refresher()` | `handle_401()` | `refreshProviderOAuthCredentialWithPlugin()` |

--- a/tests/test_profile_wiring.py
+++ b/tests/test_profile_wiring.py
@@ -190,7 +190,9 @@ class TestFallbackIntegration:
             "core.llm.fallback._notify_failure",
             side_effect=lambda p, e: calls.append(f"fail:{p}"),
         ):
-            try:
+            import contextlib
+
+            with contextlib.suppress(ConnectionError):
                 retry_with_backoff_generic(
                     failing_fn,
                     model="test-model",
@@ -202,8 +204,6 @@ class TestFallbackIntegration:
                     retry_base_delay=0.0,
                     retry_max_delay=0.0,
                 )
-            except ConnectionError:
-                pass
 
         assert calls == ["fail:anthropic"]  # "LLM" maps to "anthropic"
 

--- a/tests/test_profile_wiring.py
+++ b/tests/test_profile_wiring.py
@@ -164,7 +164,9 @@ class TestFallbackIntegration:
         cb = CircuitBreaker()
         calls: list[str] = []
 
-        with patch("core.llm.fallback._notify_success", side_effect=lambda p: calls.append(f"ok:{p}")):
+        with patch(
+            "core.llm.fallback._notify_success", side_effect=lambda p: calls.append(f"ok:{p}")
+        ):
             result = retry_with_backoff_generic(
                 lambda model: "response",
                 model="test-model",

--- a/tests/test_profile_wiring.py
+++ b/tests/test_profile_wiring.py
@@ -1,0 +1,264 @@
+"""Tests for ProfileRotator wiring — mark_success/mark_failure integration.
+
+Verifies that the LLM call chain notifies ProfileRotator on
+success/failure via notify_llm_success/notify_llm_failure
+(OpenClaw markAuthProfileGood/markAuthProfileFailure pattern).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from core.gateway.auth.profiles import AuthProfile, CredentialType, ProfileStore
+from core.gateway.auth.rotation import ProfileRotator
+from core.llm.credentials import (
+    _last_profile,
+    get_last_profile,
+    notify_llm_failure,
+    notify_llm_success,
+    resolve_provider_key,
+)
+
+
+class TestProfileTracking:
+    """get_last_profile() tracks the profile resolved by resolve_provider_key()."""
+
+    def setup_method(self):
+        _last_profile.clear()
+
+    def test_resolve_stores_last_profile(self):
+        store = ProfileStore()
+        profile = AuthProfile(
+            name="openai:codex",
+            provider="openai",
+            credential_type=CredentialType.OAUTH,
+            key="test-token",
+        )
+        store.add(profile)
+        rotator = ProfileRotator(store)
+
+        with patch("core.runtime_wiring.infra.get_profile_rotator", return_value=rotator):
+            key = resolve_provider_key("openai", "fallback-key")
+
+        assert key == "test-token"
+        assert get_last_profile("openai") is profile
+
+    def test_resolve_fallback_no_profile(self):
+        with patch("core.runtime_wiring.infra.get_profile_rotator", return_value=None):
+            key = resolve_provider_key("openai", "fallback-key")
+
+        assert key == "fallback-key"
+        assert get_last_profile("openai") is None
+
+    def test_get_last_profile_returns_none_for_unknown(self):
+        assert get_last_profile("nonexistent") is None
+
+
+class TestNotifySuccess:
+    """notify_llm_success() calls rotator.mark_success()."""
+
+    def setup_method(self):
+        _last_profile.clear()
+
+    def test_success_resets_error_count(self):
+        store = ProfileStore()
+        profile = AuthProfile(
+            name="openai:codex",
+            provider="openai",
+            credential_type=CredentialType.OAUTH,
+            key="token",
+            error_count=3,
+            cooldown_until=time.time() + 3600,
+        )
+        store.add(profile)
+        rotator = ProfileRotator(store)
+        _last_profile["openai"] = profile
+
+        with patch("core.runtime_wiring.infra.get_profile_rotator", return_value=rotator):
+            notify_llm_success("openai")
+
+        assert profile.error_count == 0
+        assert profile.cooldown_until == 0.0
+
+    def test_success_noop_without_profile(self):
+        """No crash when no profile was resolved."""
+        with patch("core.runtime_wiring.infra.get_profile_rotator", return_value=MagicMock()):
+            notify_llm_success("openai")  # should not raise
+
+    def test_success_noop_without_rotator(self):
+        """No crash when rotator is not available."""
+        _last_profile["openai"] = MagicMock()
+        with patch("core.runtime_wiring.infra.get_profile_rotator", return_value=None):
+            notify_llm_success("openai")  # should not raise
+
+
+class TestNotifyFailure:
+    """notify_llm_failure() calls rotator.mark_failure() with auth classification."""
+
+    def setup_method(self):
+        _last_profile.clear()
+
+    def test_auth_error_triggers_auth_failure(self):
+        store = ProfileStore()
+        profile = AuthProfile(
+            name="openai:codex",
+            provider="openai",
+            credential_type=CredentialType.OAUTH,
+            key="expired-token",
+            managed_by="codex-cli",
+        )
+        store.add(profile)
+        rotator = ProfileRotator(store)
+        _last_profile["openai"] = profile
+
+        mock_refresher = MagicMock(return_value=True)
+        rotator.register_refresher("codex-cli", mock_refresher)
+
+        # Simulate auth error (401)
+        exc = Exception("401 Unauthorized")
+        with (
+            patch("core.runtime_wiring.infra.get_profile_rotator", return_value=rotator),
+            patch("core.llm.fallback._is_auth_error", return_value=True),
+        ):
+            notify_llm_failure("openai", exc)
+
+        # 401 auto-refresh should have been triggered
+        mock_refresher.assert_called_once_with(profile)
+
+    def test_non_auth_error_applies_cooldown(self):
+        store = ProfileStore()
+        profile = AuthProfile(
+            name="openai:default",
+            provider="openai",
+            credential_type=CredentialType.API_KEY,
+            key="sk-test",
+        )
+        store.add(profile)
+        rotator = ProfileRotator(store)
+        _last_profile["openai"] = profile
+
+        exc = Exception("Connection timeout")
+        with (
+            patch("core.runtime_wiring.infra.get_profile_rotator", return_value=rotator),
+            patch("core.llm.fallback._is_auth_error", return_value=False),
+        ):
+            notify_llm_failure("openai", exc)
+
+        assert profile.error_count == 1
+        assert profile.cooldown_until > time.time()
+
+    def test_failure_noop_without_profile(self):
+        """No crash when no profile was resolved."""
+        exc = Exception("error")
+        with patch("core.runtime_wiring.infra.get_profile_rotator", return_value=MagicMock()):
+            notify_llm_failure("openai", exc)  # should not raise
+
+
+class TestFallbackIntegration:
+    """Verify _notify_success/_notify_failure are called from retry_with_backoff_generic."""
+
+    def test_success_path_calls_notify(self):
+        from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
+
+        cb = CircuitBreaker()
+        calls: list[str] = []
+
+        with patch("core.llm.fallback._notify_success", side_effect=lambda p: calls.append(f"ok:{p}")):
+            result = retry_with_backoff_generic(
+                lambda model: "response",
+                model="test-model",
+                fallback_models=[],
+                circuit_breaker=cb,
+                retryable_errors=(ConnectionError,),
+                provider_label="openai",
+            )
+
+        assert result == "response"
+        assert calls == ["ok:openai"]
+
+    def test_failure_path_calls_notify(self):
+        from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
+
+        cb = CircuitBreaker()
+        calls: list[str] = []
+
+        def failing_fn(model: str) -> None:
+            raise ConnectionError("timeout")
+
+        with patch(
+            "core.llm.fallback._notify_failure",
+            side_effect=lambda p, e: calls.append(f"fail:{p}"),
+        ):
+            try:
+                retry_with_backoff_generic(
+                    failing_fn,
+                    model="test-model",
+                    fallback_models=[],
+                    circuit_breaker=cb,
+                    retryable_errors=(ConnectionError,),
+                    provider_label="LLM",
+                    max_retries=1,
+                    retry_base_delay=0.0,
+                    retry_max_delay=0.0,
+                )
+            except ConnectionError:
+                pass
+
+        assert calls == ["fail:anthropic"]  # "LLM" maps to "anthropic"
+
+
+class TestProviderLabelMapping:
+    """_resolve_rotator_provider maps labels correctly."""
+
+    def test_llm_maps_to_anthropic(self):
+        from core.llm.fallback import _resolve_rotator_provider
+
+        assert _resolve_rotator_provider("LLM") == "anthropic"
+
+    def test_openai_maps_to_openai(self):
+        from core.llm.fallback import _resolve_rotator_provider
+
+        assert _resolve_rotator_provider("OpenAI") == "openai"
+
+    def test_glm_maps_to_glm(self):
+        from core.llm.fallback import _resolve_rotator_provider
+
+        assert _resolve_rotator_provider("GLM") == "glm"
+
+    def test_unknown_passthrough(self):
+        from core.llm.fallback import _resolve_rotator_provider
+
+        assert _resolve_rotator_provider("custom") == "custom"
+
+
+class TestAuditLoggerCompleteness:
+    """All 8 previously missing audit loggers are now registered."""
+
+    def test_all_asymmetry_loggers_registered(self):
+        from unittest.mock import patch as _patch
+
+        with (
+            _patch("core.runtime_wiring.bootstrap.RunLog"),
+            _patch("core.runtime_wiring.bootstrap.StuckDetector"),
+        ):
+            from core.runtime_wiring.bootstrap import build_hooks
+
+            hooks, _, _, _ = build_hooks(
+                session_key="test",
+                run_id="test-run",
+                log_dir=None,
+                stuck_timeout_s=60,
+            )
+
+        all_hooks = hooks.list_hooks()
+
+        # Previously missing — now should exist
+        assert "llm_failed" in all_hooks.get("llm_call_failed", [])
+        assert "llm_retry" in all_hooks.get("llm_call_retry", [])
+        assert "recovery_ok" in all_hooks.get("tool_recovery_succeeded", [])
+        assert "mcp_ok" in all_hooks.get("mcp_server_connected", [])
+        assert "tool_offload" in all_hooks.get("tool_result_offloaded", [])
+        assert "approval_req" in all_hooks.get("tool_approval_requested", [])
+        assert "memory_saved" in all_hooks.get("memory_saved", [])
+        assert "reasoning_metrics" in all_hooks.get("reasoning_metrics", [])


### PR DESCRIPTION
## Summary
- P0: ProfileRotator mark_success/mark_failure를 LLM 호출 체인에 와이어링
- P1: 8개 비대칭 audit logger 추가 (LLM_CALL_FAILED, TOOL_RECOVERY_SUCCEEDED 등)

## Why
58개 HookEvent 전수 감사 결과:
- mark_success/mark_failure가 정의만 되고 호출 코드 없음 → cooldown/retry 시스템 전체 비활성
- 8개 이벤트에 audit logger 미등록 → 비대칭 관측성

## Changes
| File | Change |
|------|--------|
| `core/llm/credentials.py` | `_last_profile` 추적, `get_last_profile()`, `notify_llm_success/failure()` |
| `core/llm/fallback.py` | `_resolve_rotator_provider()`, `_notify_success/_failure()`, retry 성공/실패 시 호출 |
| `core/runtime_wiring/bootstrap.py` | 8개 audit logger 추가 (_AL 테이블) |
| `tests/test_profile_wiring.py` | 16개 테스트 (추적/성공/실패/콜백/매핑/감사) |

## GAP Audit
| Item | Status |
|------|--------|
| mark_success() 와이어링 | Implemented |
| mark_failure(is_auth_error=) 와이어링 | Implemented |
| LLM_CALL_FAILED audit | Implemented |
| LLM_CALL_RETRY audit | Implemented |
| TOOL_RECOVERY_SUCCEEDED audit | Implemented |
| MCP_SERVER_CONNECTED audit | Implemented |
| TOOL_RESULT_OFFLOADED audit | Implemented |
| TOOL_APPROVAL_REQUESTED audit | Implemented |
| MEMORY_SAVED audit | Implemented |
| REASONING_METRICS audit | Implemented |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] 141 related tests passed

## Reference
- OpenClaw: `run.ts:1378` (markAuthProfileGood), `usage.ts:118` (cooldown)
- Hermes: `mcp_tool.py:1654` (_reset_server_error/_bump_server_error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)