### PR TITLE
feat: geode skill CLI + 3-tier visibility system

### DIFF
--- a/.geode/skills/TEMPLATE.md
+++ b/.geode/skills/TEMPLATE.md
@@ -8,11 +8,20 @@
 ```yaml
 name: skill-name
 description: One-line description of what this skill does
+visibility: public          # public | private | unlisted
 triggers:
   - keyword1
   - keyword2
   - keyword3
 ```
+
+### Visibility Levels
+
+| Level | Storage | Git | `geode skill list` |
+|-------|---------|-----|---------------------|
+| `public` | `.geode/skills/` | committed | visible |
+| `unlisted` | `.geode/skills/` | committed | hidden |
+| `private` | `~/.geode/skills/` | never committed | visible (local) |
 
 ## Purpose
 

--- a/.geode/skills/arxiv-digest/SKILL.md
+++ b/.geode/skills/arxiv-digest/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: arxiv-digest
+visibility: public
 description: Auto-search and summarize latest AI/agent papers. Triggers: 'paper', '논문', 'arxiv', 'research', '연구', '최신 연구', '학회'.
 tools: web_search, web_fetch, memory_save
 risk: safe

--- a/.geode/skills/deep-researcher/SKILL.md
+++ b/.geode/skills/deep-researcher/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: deep-researcher
+visibility: public
 description: Systematic web search, collection, analysis, and report generation on a topic. Triggers: 'research', '리서치', '조사해', '알아봐', '찾아봐', '트렌드', '동향'.
 tools: web_search, web_fetch, memory_save
 risk: safe

--- a/.geode/skills/geode-context/SKILL.md
+++ b/.geode/skills/geode-context/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: geode-context
+visibility: public
+description: GEODE 프로젝트 핵심 기술 증류. 6-Layer Architecture, AgenticLoop, HookSystem, Memory, Verification, Fault Tolerance, Prompt Engineering, Sub-Agent, Automation. 이력서/커버레터 작성 시 기술 근거 참조. "geode", "harness", "에이전트", "agent", "파이프라인", "pipeline" 키워드로 트리거.
+---
+
+# GEODE — 범용 자율 실행 에이전트 (기술 증류)
+
+## 프로젝트 개요
+
+| 항목 | 내용 |
+|------|------|
+| 기간 | 2026.02 - 현재 |
+| 목적 | LangGraph 기반 범용 자율 실행 에이전트 |
+| 규모 | ~54K LOC, 192 모듈, 3,540+ tests, 592 PR |
+| 도구 | Python 3.12+, uv, ruff, mypy strict, pytest |
+| LLM | Claude Opus 4.6 (Primary) + OpenAI GPT-5.4 (Cross-LLM) |
+| 하네스 | Claude Code (Opus 4.6) — 전체 설계·구현·테스트 단독 수행 |
+
+---
+
+## 1. Architecture
+
+### 4-Layer Stack (Model → Runtime → Harness → Agent)
+
+```
+AGENT:    AgenticLoop (while tool_use), SubAgentManager, CLIPoller, Gateway
+HARNESS:  SessionLane, LaneQueue(global:8), PolicyChain, TaskGraph, HookSystem(42 events)
+RUNTIME:  ToolRegistry(52), MCP Catalog(44), Skills, Memory(4-Tier), Reports
+MODEL:    ClaudeAdapter, OpenAIAdapter, GLMAdapter (3-provider fallback)
+─────────────────────────────────────────────────────────────────
+⊥ DOMAIN: DomainPort Protocol, GameIPDomain (cross-cutting, binds to Runtime + Harness via Port)
+```
+
+### Hexagonal Architecture (Port/Adapter)
+
+- **Port**: `@runtime_checkable Protocol` — LLMClientPort, HookSystemPort, SessionStorePort, DomainPort
+- **Adapter**: ClaudeAdapter, OpenAIAdapter, MockAdapter
+- **효과**: 비즈니스 로직이 Provider를 모름 → 런타임 어댑터 교체로 모델/인프라 전환
+
+### Runtime Factory Pattern
+
+- `AgentRuntime.create()` — 20+ 컴포넌트 결정론적 조립
+- 6 Sub-builders: hooks, memory, automation, task_graph, prompt_assembler, auth
+- 명시적 의존성 순서 보장
+
+---
+
+## 2. Agentic Loop & Orchestration
+
+### AgenticLoop — while(tool_use) 자율 실행
+
+- LLM `stop_reason == "tool_use"` 동안 도구 호출 → 결과 피드백 → 자기수정 반복
+- `max_rounds=15`, `ConversationContext` 20턴 슬라이딩 윈도우
+- NL Router의 시스템 프롬프트를 AgenticLoop이 상속
+
+### Plan-and-Execute DAG (vs ReAct)
+
+- 고정 토폴로지 DAG + Send API 병렬 (analysts×4, evaluators×3)
+- ReAct 대비: O(nodes) vs O(steps), 예측 가능, 도메인 지식 재발견 불필요
+- Confidence Gate < 0.7 → gather → signals 루프백 (최대 5회)
+
+### Goal Decomposition
+
+- 복합 요청 → 2단계 휴리스틱(70-80% LLM 미호출) → Haiku $0.01 DAG 생성
+- 시스템 프롬프트 주입 방식 (서브에이전트 생성 없이 실행)
+
+### PlanMode State Machine
+
+- DRAFT → PRESENTED → APPROVED → EXECUTING → COMPLETED
+- 6-Route Classification: SCRIPT($0.05) ~ FULL_PIPELINE($1.50)
+
+### NL Router 3-Stage Fallback
+
+- LLM Tool Use(0.95) → Scored Pattern Matching(0.5-0.8) → Help(0.3)
+- Hybrid: startswith("/") → 결정론적 COMMAND_MAP 28종, 나머지 → AgenticLoop
+
+---
+
+## 3. Memory Systems
+
+### 3-Tier Hierarchical Memory
+
+- Organization(전사 불변) → Project(MEMORY.md, 규칙/인사이트) → Session(인메모리 TTL)
+- ContextAssembler: dict.update() 순서 override + freshness threshold(3600s)
+- Clean Context: 병렬 분석자에게 analyses 필드 제거 전달 (앵커링 방지)
+
+### Write-Through Hybrid L1/L2 Session Store
+
+- L1: 인메모리 dict(TTL + lazy eviction)
+- L2: 파일 기반(checkpoint)
+- Write-through 일관성
+
+### ContextVar-Based DI
+
+- `contextvars.ContextVar`로 인프라 주입 — LangGraph 노드 시그니처 오염 없이 DI
+- Thread-safe, async-safe
+
+---
+
+## 4. Prompt Engineering
+
+### PromptAssembler 6-Phase (ADR-007)
+
+1. Prompt Override (append-only)
+2. Skill Fragment Injection
+3. Memory Context (300char 상한)
+4. Bootstrap Instructions
+5. Token Budget (6000char hard, 4000char warning)
+6. Hash + Event (SHA-256 무결성 + 캐시 키)
+
+### Prompt Caching
+
+- SHA-256 해시 안정성 → Anthropic prompt caching 활성화
+- 반복 호출 시 90% 비용 절감 (cache read = input × 0.10)
+
+### Structured Output
+
+- Anthropic `messages.parse()` + 평가자별 Pydantic 모델 → 14-axis rubric 강제
+- Generation-time 스키마 검증
+
+---
+
+## 5. Verification & Evaluation
+
+### Swiss Cheese 다층 검증 (5-Layer)
+
+1. **Guardrails G1-G4**: Schema, Range, Grounding, 2σ Consistency
+2. **BiasBuster 6-Bias**: Recency, Extremity, Anchoring, Egocentric, Availability, Certainty (CV < 0.05 감지)
+3. **Cross-LLM**: Anthropic vs OpenAI 병렬 → Krippendorff's α ≥ 0.67
+4. **Confidence Gate**: ≥ 0.7 통과, else 약한 축 선별 재분석 (max 5)
+5. **Rights Risk**: CLEAR / NEGOTIABLE / RESTRICTED / EXPIRED / UNKNOWN
+
+### Scoring
+
+- 6-Weighted Composite: 25% PSM + 20% Quality + 18% Recovery + 12% Growth + 20% Momentum + 5% Dev
+- Confidence Multiplier: `final = base × (0.7 + 0.3 × confidence/100)`
+- Decision Tree: D-E-F 축 code-only 원인 분류 (LLM 미사용)
+
+---
+
+## 6. Fault Tolerance
+
+### Circuit Breaker 3-State
+
+- Closed → Open(5회 실패) → Half-Open(60s 후 프로브)
+
+### 4-Stage Failover
+
+- Retry(exponential+jitter) → Fallback Chain(Opus→Sonnet→Haiku) → Circuit Break → Recovery
+
+### Degraded Response
+
+- `is_degraded=True` + 최소 점수 주입 → 단일 노드 실패 시 파이프라인 유지
+
+### Error Recovery Strategy
+
+- Retry → Alternative Tool → Fallback → Escalate (도구별 정책)
+
+---
+
+## 7. Observability
+
+### 42-Event Hook Observer
+
+- Pipeline(3), Node(4), Analysis(3), Verification(2), Automation(6), Memory(4), SubAgent(5), ToolRecovery(2), Context(4), Session(2), LLM(3), ToolApproval(2), ModelSwitch(1), TurnComplete(1)
+- Hooked Node Wrapper: 순수 노드 함수를 데코레이터로 감싸 자동 이벤트 발행
+- Priority-Based Handler: 낮은 priority 먼저 실행 (30→50→90)
+
+### Task Graph DAG
+
+- 13-task DAG + 6-state machine (PENDING→READY→RUNNING→COMPLETED→FAILED→SKIPPED)
+- Observer over Controller: Hook 수신만, StateGraph 제어 안 함
+- propagate_failure() BFS → 하류 SKIP
+
+### RunLog JSONL Audit Trail
+
+- per-run JSONL, 2000-line/2MB auto-pruning
+
+### Stuck Detection
+
+- 7200s 타임아웃, 60s 체크 간격, auto-release + PIPELINE_ERROR
+
+---
+
+## 8. Concurrency & Queue
+
+### CoalescingQueue
+
+- 250ms debounce, Timer 리셋, 동일 task_id 중복 병합
+
+### Lane Queue 2-Level
+
+- SessionLane(per-key serial, max_sessions=256) + Lane("global", max=8, 병렬)
+- Ordered acquire(session→global), reverse release → 데드락 방지
+
+---
+
+## 9. Tool & Skill Management
+
+### 3-Source Tool Registry
+
+- definitions.json(47) + ToolRegistry(52) + MCP Catalog(44), name dedup
+
+### Deferred Tool Loading
+
+- >5 tools → tool_search 메타 도구 → 85% 토큰 절감
+
+### PolicyChain
+
+- AND-combined, NodeScopePolicy(노드별 화이트리스트), Dry-Run Cost Protection
+- PolicyAuditResult로 차단 사유 추적
+
+### Tool Safety 4-Tier
+
+- SAFE → STANDARD → DANGEROUS(HITL 필수) → MCP_FALLBACK
+
+### Progressive Disclosure
+
+- 스킬 메타데이터만 초기 인지 → 의도 파악 후 전체 프롬프트 주입
+- SkillRegistry 8000char 버짓
+
+---
+
+## 10. Sub-Agent System
+
+### SubAgentManager
+
+- Lane("global", max=8), timeout 120s, max_depth=1, max_total=15
+- 부모 tools/MCP/skills/memory 전체 상속
+
+### Token Guard
+
+- SubAgentResult 출력 토큰 초과 시 summary + 경량 필드만 보존
+- 부모 컨텍스트 폭발 방지
+
+---
+
+## 11. Automation
+
+### CUSUM Drift Detection
+
+- WARNING=2.5, CRITICAL=4.0, slack parameter k
+- DRIFT_DETECTED Hook → 스냅샷 캡처
+
+### 4-Phase RLHF Feedback Loop
+
+- Collection(n≥30) → Analysis(Spearman ρ) → Improvement(가중치 조정) → Validation
+
+### Model Registry
+
+- Staging → Canary → Production, MODEL_PROMOTED Hook
+
+---
+
+## 12. 하네스 워크플로우 인프라 (.claude/ 디렉토리 체계)
+
+GEODE의 .claude/ 디렉토리 전체가 하네스의 "컨텍스트 뼈대"이며, 이 구조 자체가 하네스 엔지니어링의 실체.
+
+### .claude/ 디렉토리 구조
+
+```
+.claude/
+├── MEMORY.md          # 프로젝트 메모리 (3-Tier 최상위, 분석 인사이트 자동 기록)
+├── SOUL.md            # 조직 아이덴티티 (미션, 5대 원칙, Guardrails, 도메인 플러그인 목록)
+├── settings.json      # 도구 권한 (Bash uv run 허용 등)
+├── mcp_servers.json   # 5개 MCP 어댑터 (brave-search, steam, arxiv, playwright, linkedin)
+├── rules/             # 도메인 규칙 (anime-ip, dark-fantasy, indie-steam, schedule-date-aware)
+├── skills/            # 12개 스킬 + 4개 분석자 프롬프트
+│   ├── geode-pipeline/         # StateGraph 토폴로지, Send API, Reducer
+│   ├── geode-scoring/          # PSM Engine, 14-axis rubric, 최종 스코어 공식
+│   ├── geode-analysis/         # 4 Analysts + 3 Evaluators, Clean Context
+│   ├── geode-verification/     # G1-G4, BiasBuster, Decision Tree
+│   ├── geode-e2e/              # Mock/Live 테스트 티어, LangSmith 검증
+│   ├── geode-gitflow/          # feature→develop→main, Pre-PR 5-Step Quality Gate
+│   ├── geode-changelog/        # Keep a Changelog, SemVer
+│   ├── agent-ops-debugging/    # 5 디버깅 패턴 (Safe Default, ContextVar 생명주기 등)
+│   ├── karpathy-patterns/      # autoresearch/AgentHub 10대 설계 원칙
+│   ├── openclaw-patterns/      # Gateway, Session Key, Lane Queue, Policy Chain
+│   ├── architecture-patterns/  # Clean Architecture, Hexagonal, DDD
+│   ├── tech-blog-writer/       # 기술 블로그 작성 가이드
+│   └── geode-analysts/         # 4개 분석자별 프롬프트 (discovery, mechanics, experience, growth)
+└── worktrees/         # Git worktree 격리 작업 공간 (.gitignored)
+```
+
+### Worktree 기반 병렬 개발
+
+- `git worktree add .claude/worktrees/<name> -b feature/<branch>` 로 격리된 작업 공간 생성
+- main 저장소 오염 없이 병렬 실험/개발 가능
+- `.claude/worktrees/`는 .gitignore에 포함, 원격 푸시 안 됨
+- 작업 완료 후: push → worktree remove → branch delete
+
+### 시스템 프롬프트 템플릿 (core/llm/prompts/)
+
+| 파일 | 역할 | 핵심 설계 |
+|------|------|----------|
+| router.md | NL 의도 분류 + 20 tools | Tool Priority Matrix, Clarification rules |
+| analyst.md | 4종 분석자 (Send API 병렬) | "Do NOT reference other analysts" (Clean Context) |
+| evaluator.md | 3종 평가자 (14-axis rubric) | "Missing evidence = score 3.0, not 1.0" |
+| biasbuster.md | 편향 감지 | Confirmation, Recency, Anchoring |
+| cross_llm.md | Cross-LLM 합의 검증 | Agreement ≥ 0.67 |
+| synthesizer.md | 최종 판정 + 내러티브 | Decision Tree + cause→action |
+| decomposer.md | 복합 요청 분해 | Goal Decomposition DAG |
+| commentary.md | 사용자 피드백 생성 | — |
+| tool_augmented.md | 도구 사용 가이드 | — |
+
+### Progressive Disclosure 실체
+
+1. Skills는 YAML frontmatter의 triggers로 자동 감지
+2. LLM이 처음엔 스킬 이름만 인지 (SkillRegistry 8000char 요약 블록)
+3. 사용자 의도 파악 후 전체 프롬프트가 주입
+4. SOUL.md가 조직 수준 원칙을 항상 주입, MEMORY.md가 프로젝트 컨텍스트 주입
+5. Rules/가 엔티티별 조건부 규칙을 YAML glob 매칭으로 자동 로딩
+
+### Self-Improving Loop 실체 (재귀 개선 워크플로우)
+
+```
+Research → Plan → Implement → Unit Verify(ruff/mypy/pytest)
+                                    ↓ 실패 시 ↑ 복귀
+                               E2E Verify(Mock→CLI→Live→LangSmith)
+                                    ↓ 실패 시 ↑ 복귀
+                               Docs-Sync(CHANGELOG+README+CLAUDE.md 동일 커밋)
+                                    ↓
+                               PR & Merge(feature→develop→main, 5-Job CI)
+```
+
+- **매 단계에서 실패/품질 저하 시 이전 단계로 즉시 복귀**
+- CLAUDE.md가 이 워크플로우를 시스템 프롬프트로 주입 → 에이전트가 이 루프를 자율 실행
+- .claude/skills가 각 단계의 도메인 지식을 on-demand로 제공
+
+### 이력서 불릿 활용 포인트
+
+이 워크플로우 인프라는 다음 직무에서 어필 가능:
+- **Backend**: Worktree 병렬 개발 → 마이크로서비스 독립 배포 경험과 유사
+- **Platform**: .claude/ 디렉토리 체계 → 플랫폼 수준의 컨텍스트 관리 설계
+- **Agent**: Progressive Disclosure + 9개 시스템 프롬프트 → Prompt Engineering 체계
+- **DevOps/SRE**: 5-Step Quality Gate + CI 파이프라인 → 배포 자동화 역량
+
+---
+
+## 13. Development Metrics
+
+| 지표 | 수치 |
+|------|------|
+| LOC | ~54,000 |
+| 모듈 | 192 |
+| 테스트 | 3,540+ |
+| PR | 592 |
+| 도구 | 52 (ToolRegistry) + 44 (MCP Catalog) |
+| Hook 이벤트 | 42 |
+| Skills | 21 (.claude/skills/) |
+| 버전 | v0.40.0 |
+
+---
+
+## 직무별 핵심 매칭
+
+| 직무 | 핵심 기법 |
+|------|----------|
+| **Backend** | Hexagonal, Runtime Factory, Circuit Breaker, Lane Queue, Degraded Response |
+| **Performance** | CoalescingQueue, 4-Stage Failover, Task Graph, Prompt Caching |
+| **AI Platform** | AgenticLoop, PlanMode, PromptAssembler, 3-Tier Memory, Progressive Disclosure |
+| **AI Agent** | Goal Decomposition, NL Router, Swiss Cheese, Sub-Agent, Hook Observer |
+| **Infra/SRE** | 42-Event Hook, Stuck Detection, CUSUM Drift, RunLog JSONL |
+| **Data/ML** | Cross-LLM, BiasBuster, RLHF Feedback Loop, Decision Tree |
+
+---
+
+## 검증된 이력서 불릿 (2026.03 세션 확정)
+
+### 불릿 1: 고정 DAG에서 자율 실행 엔진으로
+- 8-Node 파이프라인이 새 도메인 수용 불가 → Claude Code while(tool_use) + OpenClaw Binding Router 탐색
+- 결정론적 슬래시 커맨드(28종) + LLM 자율 판단을 하나의 루프로 결합한 AgenticLoop 설계
+- 파이프라인을 도구 중 하나로 재배치, 52 tools × unlimited rounds 자율 실행 달성
+
+### 불릿 2: Sub-Agent 병렬 위임 — 분산 동시성 제어
+- CoalescingQueue(250ms dedup) 중복 제거 + Lane Queue 2-Level(세션 직렬 max=1 + 글로벌 병렬 max=4, ordered acquire 데드락 방지)
+- SubAgentManager: 부모 tools/MCP/skills/memory 전체 상속, MAX_CONCURRENT=5, timeout 120s, max_depth=2
+- Token Guard(출력 토큰 초과 시 summary만 보존) 컨텍스트 폭발 방지
+- TaskGraph DAG topological_sort + propagate_failure() BFS 실패 격리
+
+### 불릿 3: 비결정성 통제 — 프롬프트 레벨 가드레일과 검증 파이프라인
+- PromptAssembler 6-Phase가 Token Budget + SHA-256 Hash로 입력 고정 → 비결정성 진입점 축소
+- Confidence Gate(<0.7 약한 축 선별 재분석) → 적응형 루프로 품질 수렴
+- 코드 기반 Decision Tree → LLM 오버라이드 불가 결정론적 최종 판정
+
+### 불릿 4: Hexagonal + Hook Observer — 레이어별 독립 교체
+- Port/Adapter Protocol(30 Ports) 비즈니스 로직-Provider 완전 분리
+- 42-Event Hook Observer: 노드 코드 수정 없이 관측/로깅/드리프트 감지 플러그인
+- Circuit Breaker 3-State + 4-Stage Failover + Degraded Response → fault-tolerant
+
+### 불릿 5: DomainPort Plugin + MCP — 파이프라인과 외부 통합의 플러그인화
+- DomainPort Protocol로 파이프라인 자체를 플러그인 교체 가능
+- MCP 양방향(44개 카탈로그 클라이언트 + FastMCP 서버 6 tools) 외부 통합 표준화
+- REODE 포크에서 GameIP 분리 + Migration Pipeline 등록으로 확장성 실증
+
+### 불릿 6: Prompt Engineering 체계화 — 6-Phase 조립 + Caching
+- PromptAssembler 6단계(Override / Skill Injection / Memory / Bootstrap / Token Budget / SHA-256 Hash)
+- 3-Tier Memory(Organization > Project > Session) 에이전트 간 컨텍스트 일관성
+- SHA-256 핀닝 → Anthropic Prompt Caching 자동 활성화 → 반복 호출 90% 비용 절감

--- a/.geode/skills/geode-frontend/SKILL.md
+++ b/.geode/skills/geode-frontend/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: geode-frontend
+visibility: unlisted
+description: GEODE 포트폴리오 프론트엔드 개발 플러그인. 페이지 흐름, 디자인 시스템, 컴포넌트 인벤토리, GAP 분석 가이드. "geode", "frontend", "리뉴얼", "디자인", "페이지", "flow", "component" 키워드로 트리거.
+---
+
+# GEODE Frontend Development Plugin
+
+> Target: `public/geode.html` (single-file portfolio, ~9400 lines)
+> Theme: Deep Sea Discovery — Ocean Gem Palette
+> Mascot: Geodi (Pink Axolotl Explorer)
+> Design DNA: `plans/geode-design-dna.md`, `plans/geode-design-concept-v2.md`
+
+---
+
+## 1. Page Architecture
+
+### Section Flow (Current)
+```
+Hero (#overview)
+  └─ Geodi hero illustration + badge + GEODE v0.8.0 + 4 stats
+
+Agentic Engineering (#agentic) — 6 pillar cards (3×2)
+  └─ Autonomous Reasoning, Goal-Driven Planning, Self-Correction,
+     Multi-Agent Coordination, Dynamic Tool Selection, Confidence-Gated Learning
+
+[Mascot Divider: idle — "심해로 안내합니다"]
+
+Section 00: Agent Reasoning Flow (#pipeline)
+  └─ 8-node pipeline flow + 4-analyst fan-out + agent loop SVG
+
+Section 01: Agent Architecture (#architecture)
+  └─ 6-layer cards (L1-L6) + Expert Panel (4 cards) + C2-C5 Flexibility grid
+
+[Mascot Divider: focus — "IP 데이터 분석 중"]
+
+Section 02: Causal Scoring & Diagnosis (#scoring)
+  └─ PSM radar chart SVG + 6-cause decision tree + fixture results
+
+Section 03: Self-Correction & Guardrails (#verification)
+  └─ G1-G4 cards + BiasBuster + Cross-LLM + Rights Risk
+
+[Mascot Divider: discover — "보석 발견!"]
+
+Section 04: Multi-Agent Coordination (#orchestration)
+  └─ 3-tier memory + Plan Mode FSM SVG + SubAgent DAG + HITL Safety
+
+Section 05: Self-Improvement & Runtime (#automation)
+  └─ CUSUM drift + Feedback 5-phase + Graceful Degradation
+  └─ G2: LangSmith Observability + G3: Auto-Learning Loop
+
+Section 06: Multi-LLM Ensemble (#tech)
+  └─ Claude Client + Multi-LLM + Tool Registry + Prompts + CLI + Rich Display
+  └─ G1: Claude Code-style UI + G5: Report Generation
+
+[Mascot Divider: idle — "지금까지의 여정"]
+
+Section 07: Timeline (#timeline)
+  └─ v0.6.0 → v0.6.1 → v0.7.0 → v0.8.0 (current) → v0.9.0 (next)
+
+Footer
+  └─ GitHub link + "Discovered by Geodi" + copyright
+```
+
+### Nav Links
+Overview, Agentic, Reasoning, Architecture, Scoring, Guardrails, Coordination, Self-Improve, LLM Ensemble, Timeline
+
+---
+
+## 2. Design System — Deep Sea Discovery
+
+### Color Tokens
+```css
+/* Ocean Backgrounds */
+--bg-deep: #0B1628        /* abyss */
+--bg-primary: #0F1F3A     /* deep sea */
+--bg-secondary: #162D50   /* mid ocean */
+--bg-card: rgba(26,61,110,0.4)      /* glass card */
+--bg-card-hover: rgba(31,61,94,0.6) /* glass hover */
+
+/* Accent System */
+--accent-primary: #818CF8   /* indigo — primary UI */
+--accent-secondary: #C084FC /* purple — secondary */
+--bubble-teal: #4ECDC4      /* teal — interaction, router, CLI */
+--mascot-pink: #F4B8C8      /* soft pink — agent, L3 */
+--gem-gold: #F5C542         /* warm gold — discovery, L5 */
+--sand-warm: #D4A574        /* warm tan — tool belt, labels */
+--coral-pink: #E87080       /* coral — error, critical */
+--kelp-green: #34D399       /* emerald — success, L1 */
+
+/* 6-Layer Colors */
+L1 Foundation:   #34D399 (emerald/kelp)
+L2 Memory:       #60A5FA (blue/ocean)
+L3 Agentic Core: #F4B8C8 (mascot pink)
+L4 Orchestration: #818CF8 (indigo/deep)
+L5 Automation:   #F5C542 (gem gold)
+L6 Extensibility: #C084FC (purple/bubble)
+
+/* Borders */
+--border-subtle: rgba(78,205,196,0.08)   /* teal hint */
+--border-glow: rgba(78,205,196,0.2)      /* teal glow */
+Card hover border: rgba(244,184,200,0.25) /* pink on hover */
+Card hover shadow: rgba(245,197,66,0.06)  /* gold glow */
+```
+
+### Typography
+```
+Hero Title:  Inter 800, clamp(3rem,8vw,6rem), -0.03em, text-shadow pink glow
+Stat Value:  Inter 800, 2.5rem, gem-gold color
+Section:     Inter 700, 2.5rem, -0.02em
+Category:    Inter 700, 1.5rem, -0.01em, category-color
+Body:        Inter/NotoSansKR 400-500, 0.85-0.9rem, line-height 1.7
+Code Badge:  Fira Code 400, 0.65-0.75rem
+Micro Label: Fira Code 400, 0.65rem, uppercase, 0.1em tracking
+```
+
+### Component Patterns
+```css
+/* Glass Card */
+background: var(--bg-card);
+border: 1px solid var(--border-subtle);
+border-radius: 20px;
+backdrop-filter: blur(8px);
+/* hover: */
+border-color: rgba(244,184,200,0.25);
+box-shadow: 0 20px 60px var(--glow), 0 8px 32px rgba(245,197,66,0.06);
+transform: translateY(-5px);
+
+/* Modal */
+background: rgba(15,31,58,0.95);
+border: 1px solid rgba(78,205,196,0.15);
+backdrop-filter: blur(20px);
+box-shadow: 0 25px 80px rgba(0,0,0,0.5), 0 0 60px rgba(244,184,200,0.04);
+
+/* Table Header */
+color: var(--bubble-teal);
+background: rgba(78,205,196,0.06);
+
+/* Explanation Block */
+background: rgba(78,205,196,0.04);
+border-left: 3px solid var(--bubble-teal);
+
+/* Code Block */
+background: rgba(11,22,40,0.5);
+```
+
+### Animations
+```css
+@keyframes mascot-float   { 0%,100% { translateY(0) } 50% { translateY(-10px) } }  /* 6s */
+@keyframes float-gem       { 0%,100% { translateY(0) rotate(0) opacity:0.25 } 50% { translateY(-20px) rotate(12deg) opacity:0.5 } }  /* 8s */
+@keyframes fadeInUp        { from { opacity:0; translateY(30px) } to { opacity:1; translateY(0) } }
+@keyframes pulse           { 0%,100% { opacity:1; scale(1) } 50% { opacity:0.5; scale(1.2) } }
+```
+
+---
+
+## 3. Mascot Integration Points
+
+| Location | Image | Size | Purpose |
+|----------|-------|------|---------|
+| Hero | `geode-hero.png` (800×533, 738KB) | max-width 480px | 풀 일러스트, float animation + glow |
+| Section divider ×4 | `geode-idle/focus/discover.png` (~128px) | 64px display | 포즈별 가이드 캐릭터 |
+| Footer | `geode-idle.png` | 48px | "Discovered by Geodi" 크레딧 |
+| (Reserved) Empty state | `geode-focus.png` | 80px | 로딩/검색 중 상태 |
+| (Reserved) Error | `geode-discover.png` | 80px | 404/에러 페이지 |
+
+---
+
+## 4. Modal Architecture (47 total)
+
+### Structure Template (모든 모달 통일)
+```html
+<div class="modal-overlay" id="modal-geode-{name}">
+  <div class="modal-content" style="max-width: {800-900}px;">
+    <button class="modal-close" onclick="closeModal('modal-geode-{name}')">×</button>
+    <h2 class="modal-title">{emoji} {Title KO/EN}</h2>
+    <div class="modal-explanation">{2-3줄 에이전트 관점 설명}</div>
+    <div class="modal-metrics">{3 metric cards}</div>
+    <div class="modal-code"><pre><code>{실제 코드 기반}</code></pre></div>
+    <div class="modal-section">{Details Table (optional)}</div>
+  </div>
+</div>
+```
+
+### Modal Quality Tiers (Completed)
+- **P0 (8)**: router, scoring, guardrails, biasbuster, planner, task-system, hooks, adaptive-loop
+- **P1 (8)**: cortex, signals, analyst-detail, evaluator-detail, scoring-overview, synthesizer, cross-llm, clean-context, decision-tree, confidence-calc
+- **P2 (12)**: stategraph, send-api, reducer, node-contract, expert-panel, feedback, org/project/session-context, settings, bootstrap, factory
+- **P3 (13)**: claude-client, structured-output, prompts, cli, rich-display, nl-router, di, cusum, drift-monitor, model-registry, triggers, verification-flow, rights-risk
+
+---
+
+## 5. JavaScript API
+
+```javascript
+setLang(lang)              // 'ko' | 'en' — body.classList.toggle('en')
+switchTab(btn, tabId)      // Modal tab switching
+openModal(modalId)         // Display modal overlay
+closeModal(modalId)        // Hide modal overlay
+
+// Observers
+IntersectionObserver       // Scroll-triggered fade-in animations
+timelineObserver           // Timeline item state: viewed → current → next
+scrollObserver             // Nav active state tracking
+```
+
+### Bilingual System
+```html
+<span class="lang-ko">한국어 텍스트</span>
+<span class="lang-en">English text</span>
+<!-- body.en → .lang-ko { display: none } .lang-en { display: inline } -->
+```
+
+---
+
+## 6. GAP Analysis — 리뉴얼 체크리스트
+
+### Flow & Structure Gaps
+- [ ] Section 00 (Agent Reasoning Flow) 이 너무 밀도 높음 — pipeline + agent loop + summary stats 분리 고려
+- [ ] Agentic Engineering 섹션이 Hero 바로 아래인데 Section 00과 역할 중복
+- [ ] Section 05-06의 G1-G3, G4-G5 카드들이 기존 섹션에 append 형태 — 네이티브 통합 필요
+- [ ] 47 모달 중 P2/P3 (25개)는 아직 에이전트 프레이밍 미적용
+
+### Visual Gaps
+- [ ] SVG 다이어그램 6개의 스타일이 통일되지 않음 (일부 old void-black 색감 잔존)
+- [ ] 일부 인라인 카드 그리드가 CSS 클래스 대신 style="" 사용 — 유지보수 어려움
+- [ ] 반응형(모바일) 미최적화 — 768px 이하에서 pipeline flow 깨짐 가능
+- [ ] LangSmith/Auto-Learning/Report Generation 카드가 기존 섹션 하단에 부록 느낌
+
+### Content Gaps
+- [ ] Section 07 Timeline에 v0.9.0+ 로드맵 미표시
+- [ ] Hero 4개 stats 외에 "Key Achievement" 하이라이트 부재
+- [ ] Cross-reference: 모달 간 관련 링크 시스템 미구현
+- [ ] 코드 예시의 syntax highlighting이 일부 모달에서 불완전
+
+### Technical Debt
+- [ ] CSS 커스텀 프로퍼티 사용률 낮음 — 인라인 rgba() 직접 사용 다수
+- [ ] onmouseover/onmouseout 인라인 핸들러 → CSS :hover 또는 JS delegation 으로 전환 필요
+- [ ] 9400줄 단일 HTML → CSS/JS 분리 또는 빌드 시스템 도입 고려
+- [ ] 이미지 lazy loading 미적용 (hero 제외)
+
+---
+
+## 7. Renewal Implementation Guide
+
+### Phase 0: Audit & Plan
+1. Read `plans/geode-design-concept-v2.md` for design direction
+2. Read `.claude/skills/geode-portfolio/SKILL.md` for SOT numbers
+3. Verify current page against SOT (run verification checklist)
+
+### Phase 1: Page Flow Restructure
+1. 섹션 순서/그루핑 재설계 — narrative flow 기준
+2. Agentic Engineering + Section 00 통합/분리 결정
+3. G1-G5 갭 카드들을 네이티브 섹션 내 위치로 이동
+4. 네비게이션 구조 업데이트
+
+### Phase 2: Component Standardization
+1. 인라인 style → CSS 클래스 전환 (특히 카드 그리드, 호버 효과)
+2. 모달 P2/P3 에이전트 프레이밍 적용
+3. SVG 다이어그램 스타일 통일 (ocean theme)
+4. 반응형 breakpoint 최적화
+
+### Phase 3: Visual Polish
+1. 섹션 간 depth zone 배경색 변화 (수심 증가 효과)
+2. 마스코트 인터랙션 강화 (스크롤 반응, 상태 변화)
+3. 코드 블록 syntax highlighting 통일
+4. 모달 간 관련 링크 네트워크
+
+### Phase 4: Performance & DX
+1. CSS/JS 외부 파일 분리 (optional)
+2. 이미지 lazy loading + WebP 전환
+3. Critical CSS 인라인 + defer non-critical
+4. Lighthouse audit → Core Web Vitals 최적화
+
+---
+
+## 8. File References
+
+| File | Purpose |
+|------|---------|
+| `public/geode.html` | 메인 포트폴리오 페이지 (~9400 lines) |
+| `public/images/geode-hero.png` | 히어로 풀 일러스트 (800×533) |
+| `public/images/geode-idle.png` | 픽셀아트 기본 포즈 (149×128) |
+| `public/images/geode-focus.png` | 픽셀아트 분석 포즈 (158×128) |
+| `public/images/geode-discover.png` | 픽셀아트 발견 포즈 (145×128) |
+| `plans/geode-design-dna.md` | v1 디자인 DNA (Crystal from Chaos) |
+| `plans/geode-design-concept-v2.md` | v2 디자인 컨셉 (Deep Sea Discovery) |
+| `plans/geode-modal-overhaul.md` | 모달 오버홀 계획 + 실행 현황 |
+| `plans/geode-agent-rebrand.md` | 에이전트 리브랜딩 기록 |
+| `plans/geode-portfolio-sot-fix.md` | SOT 정합성 수정 기록 |
+| `.claude/skills/geode-portfolio/SKILL.md` | SOT 정합성 가이드 (수치/공식) |

--- a/.geode/skills/geode-portfolio/SKILL.md
+++ b/.geode/skills/geode-portfolio/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: geode-portfolio
+visibility: unlisted
+description: GEODE 포트폴리오 페이지 SOT 정합성 가이드. architecture-v6.md 및 submit/task2_GEODE.pdf를 기준으로 categories, modals 데이터의 정확성을 보장. "geode", "categories", "modal", "정합성", "SOT", "accuracy" 키워드로 트리거.
+---
+
+# GEODE Portfolio SOT Accuracy Guide
+
+> SOT 문서:
+> - `ppt-workspace/task2/docs/architecture-v6.md` — Full spec (§13.8 Scoring, §13.9 Judgment, §13.11 Rubric, §13.12 Expert, §13.13 Feedback)
+> - `submit/task2_GEODE.pdf` — 3-slide submission (Slide 1: PSM+Rubric, Slide 2: Agent System, Slide 3: Feedback Loop)
+> - `ppt-workspace/task2/slides/FINAL-SLIDES.md` — Slide content spec
+
+## Portfolio File Map
+
+| File | Content | SOT Sections |
+|------|---------|--------------|
+| `src/data/geode/categories.ts` | 8 category cards | All layers |
+| `src/data/modals/geode-modals.ts` | 27 detail modals | §13.8-§13.13 |
+| `src/data/geode/stats.ts` | Hero metrics | Summary |
+| `src/data/geode/pipeline-nodes.ts` | XyFlow diagram | §4 L3 Agentic Core |
+| `src/data/geode/tech-stack.ts` | Tech stack | §2 Foundation |
+
+## SOT Critical Numbers (Always verify against these)
+
+### Scoring (§13.8.1)
+```
+Final = (0.25×PSM + 0.20×Quality + 0.18×Recovery + 0.12×Growth + 0.20×Momentum + 0.05×Dev)
+        × (0.7 + 0.3 × Confidence/100)
+Tier: S≥80, A≥60, B≥40, C<40
+```
+
+### 14-Axis Rubric (§13.11.1)
+- Quality: A, B, C, B.1, C.1, C.2, M, N (8 axes)
+- Hidden Value: D, E, F (3 axes) — D excluded from recovery
+- Momentum: J, K, L (3 axes)
+
+### 6 Causes (§13.9.2) — Code-based, NOT LLM
+| Cause | D-E-F | Action |
+|-------|-------|--------|
+| timing_mismatch | D≥3 + timing_issue | timing_optimization |
+| conversion_failure | D≥3, E≥3 | marketing_boost |
+| undermarketed | D≥3, E<3 | marketing_boost |
+| monetization_misfit | D≤2, E≥3 | monetization_pivot |
+| niche_gem | D≤2, E≤2, F≥3 | platform_expansion |
+| discovery_failure | D≤2, E≤2, F≤2 | community_activation |
+
+### LLM Deployment (현행)
+| Model | Role |
+|-------|------|
+| Claude Opus 4.6 (1M) | Primary — Pipeline + AgenticLoop |
+| Claude Sonnet 4.6 (1M) | Fallback |
+| Claude Haiku 4.5 (200K) | Budget — Guardrail, i18n |
+| GPT-5.4 (1M) | Cross-LLM Secondary |
+
+### 42 Hook Events (SOT HookEvent enum)
+Pipeline(3), Node(4), Analysis(3), Verification(2), Automation(6), Memory(4), SubAgent(5), ToolRecovery(2), Context(4), Session(2), LLM(3), ToolApproval(2), ModelSwitch(1), TurnComplete(1)
+
+### PSM Engine (§13.8)
+- 14 covariates: IP속성(5) + 시장환경(4) + IP특성(5)
+- ATT estimand, SMD<0.1, Z>1.645, Γ≤2.0, Caliper=0.2×SD(PS)
+
+### Feedback Loop (§13.13)
+- 5 phases: PREDICTION(T+0) → OUTCOME(T+30/90/180d) → CORRELATION → TUNE → RLAIF
+- KPI: ρ≥0.50, τ≥0.45, P@10≥0.60, S-Tier Lift≥1.5x, α≥0.80
+
+### Expert Panel (§13.12)
+- Tier 3: Score≥0.85, ρ≥0.50, ≥30건 (3-5명)
+- Tier 2: Score≥0.70, ρ≥0.40, ≥10건 (5-10명)
+- Tier 1: Score≥0.50, 경력≥3년 (무제한)
+
+### Fixture Results
+| IP | Score | Tier | Cause |
+|----|-------|------|-------|
+| Berserk | 81.2 | S | conversion_failure |
+| Cowboy Bebop | 68.4 | A | undermarketed |
+| Ghost in the Shell | 51.7 | B | discovery_failure |
+
+## Verification Checklist
+
+When updating GEODE portfolio content, always verify:
+1. [ ] All formulas match SOT §13.8 exactly
+2. [ ] Tier thresholds: S≥80, A≥60, B≥40, C<40
+3. [ ] 6 causes complete (including timing_mismatch)
+4. [ ] D-axis excluded from recovery_potential
+5. [ ] 42 hook events — full enum in core/hooks/system.py
+6. [ ] Cross-LLM metric: Krippendorff's α (not Cohen's κ)
+7. [ ] Feedback phases include T+180d
+8. [ ] 4 models — Claude Opus/Sonnet/Haiku + GPT-5.4
+9. [ ] PSM: 14 covariates, not 12 or 15
+10. [ ] Clean Context: analyses field removed (not other fields)
+
+## Slide ↔ Modal Mapping
+
+| Slide | Content | Modal IDs |
+|-------|---------|-----------|
+| Slide 1 (WHY) | PSM, Rubric, Decision Tree, Final Score | modal-geode-scoring, modal-geode-prompts, modal-geode-decision-tree, modal-geode-structured-output |
+| Slide 2 (HOW) | Agent Loop, Tool System, Orchestration | modal-geode-stategraph, modal-geode-send-api, modal-geode-hooks, modal-geode-cli |
+| Slide 3 (WHAT) | Feedback Loop, Expert Panel, Guardrails, CUSUM | modal-geode-feedback, modal-geode-expert-panel, modal-geode-guardrails, modal-geode-outcome-tracking |

--- a/.geode/skills/geode-portfolio/references/slide-content.md
+++ b/.geode/skills/geode-portfolio/references/slide-content.md
@@ -1,0 +1,184 @@
+# GEODE Submit Slides Content Reference
+
+> Source: `submit/task2_GEODE.pdf` (3 slides)
+> SOT: `ppt-workspace/task2/docs/architecture-v6.md`
+
+## Slide 1: PSM 인과 추정과 다차원 가치 평가 기준 (WHY)
+
+### PSM 6-Step Pipeline
+1. INPUT: IP + 14 Covariates
+2. PS 추정: Logistic Regression → PS(X) = P(T=1|X)
+3. Matching: Nearest Neighbor, Caliper = 0.2 × SD(PS)
+4. Balance: SMD Check → SMD < 0.1 (all covariates)
+5. ATT: Abadie-Imbens SE, Var Ratio [0.5, 2.0], Z > 1.645 (p<0.05)
+6. HG_Score: 0-100
+
+### HG_Score Formula
+```
+HG_Score = E[Y₁ - Y₀ | T=1, PS(X)]
+T=1: 마케팅 노출 상위 50%
+Y: DAU×0.3 + Revenue×0.4 + Retention(D1/D7/D30)×0.3
+Residual(잔차)와 실질 격차를 동시에 포착하는 PSM 모듈경계
+```
+
+### 14 Covariates
+- IP 속성 (5): genre, ip_age, media_origin, developer_tier, franchise_history
+- 품질 (5): core_gameplay, content_depth, narrative, review, social
+- 시장 (4): launch_timing, market_segment, price_tier, competitor_density
+
+### Sensitivity Analysis (Rosenbaum Bounds)
+- PASS: Γ ≤ 2.0 → "미관측 교란 변수가 있더라도 결과가 유효한가?"
+- WARN: 2.0 < Γ ≤ 3.0
+- FAIL: Γ > 3.0
+
+### Quality Evaluator (8축) — Quality_Score = (축 합산 - 8) / 32 × 100
+A. Core Mechanics | B. IP Integration | C. Engagement | B.1 Trailer | C.1 Conversion | C.2 Experience | M. Polish | N. Fun
+
+### Hidden Evaluator (3축) — (D+E+F-3)/12 × 100
+D. Discovery Gap | E. Execution Gap | F. Expansion
+
+### Momentum Evaluator (3축) — (J+K+L-3)/12 × 100
+J. Growth Velocity | K. Social Resonance | L. Platform
+
+### Route 2: 미게임화 IP (9축)
+Fit: G Genre | H IP Power | I Timing
+Feasibility: O Technical | P Innovation
+Momentum: Q Awareness | R Fan | S Content
+
+### Decision Tree (코드 기반, LLM 미사용)
+```
+IF timing_issue & D≥3 → timing_mismatch
+IF D≥3 & E≥3 → conversion_failure
+IF D≥3 & E<3 → undermarketed
+IF D≤2 & E≥3 → monetization_misfit
+IF D≤2 & E≤2 & F≥3 → niche_gem
+ELSE → discovery_failure (복합 요인)
+```
+
+### DECISION : ACTION MAPPING
+| Cause | Action |
+|-------|--------|
+| undermarketed | → 마케팅 강화 |
+| conversion_failure | → 마케팅+과금 개선 |
+| monetization_misfit | → 과금 재설계 |
+| niche_gem | → 플랫폼 확장 |
+| timing_mismatch | → 리런치 타이밍 최적화 |
+| discovery_failure | → 종합 전략 |
+
+### FINAL SCORE: 6가지 가중 합산
+```
+.25 HG(PSM) + .20 Quality + .18 Recovery + .12 Growth + .20 Community + .05 Dev
+× CM (0.7 + 0.3 × Confidence/100)
+
+S ≥ 80 | A ≥ 60 | B ≥ 40 | C < 40
+```
+
+---
+
+## Slide 2: GEODE 저평가 IP 발굴 에이전트 시스템 (HOW)
+
+### Agent Layer Architecture (6 layers)
+- L5: EXTENSIBILITY — Custom Agents, Plugins, Reports
+- L4.5: AUTOMATION — Pre-defined Automation, Trigger Manager, Snapshot Manager (peekaboo)
+- L4: ORCHESTRATION — Plan Mode, Task System, Hooks
+- L3: AGENTIC CORE — Agent Loop, Analysts, Evaluators
+- L2: MEMORY — Org > Project > Session
+- L1: FOUNDATION — MonoLake, LLM, APIs, Skills
+
+### Agent Loop (Core)
+```
+START → GATHER(데이터 수집) → ACTION(분석+종합) → Verify(confidence≥0.7?)
+  ↑ NO ─────────────────────────────────────────────────┘
+  YES → FINALIZE(결과 반환)
+Loop Back (max_iterations=3)
+```
+
+### GATHER Phase
+1. Memory Context 조회
+2. Snowflake Cortex Agent(SQL) 수집
+3. 외부 Signal 4종 수집
+4. 데이터 신뢰도 체크
+
+### ACTION+SYNTHESIZE Phase
+- Phase 1: Analysts ×4 (병렬) — Clean Context 원칙
+- Phase 2: Evaluators ×3
+- Phase 3: PSM Engine
+- Phase 4: Synthesizer — Decision Tree 기반 원인 분류
+
+### Orchestration Layer
+- PLANNER: 사용자 요청 → 6가지 Route 결정 (Model: Gemini 3.0 Flash)
+- TASK SYSTEM: Task Decomposition, Dependency Graph, 상태 변환/추적
+- HOOK SYSTEM: Session Start/End, Error, OnError/OnComplete
+
+### Tool System — 17 Tools × 5 Categories
+| Category | Tools |
+|----------|-------|
+| DATA | query_monolake, cortex_analyst, cortex_search |
+| SIGNAL | youtube_search, reddit_sentiment, twitch_stats, steam_info, google_trends |
+| ANALYSIS | run_analyst, run_evaluator, psm_calculate |
+| MEMORY | memory_search, memory_get, memory_save |
+| OUTPUT | generate_report, export_json, send_notification |
+
+---
+
+## Slide 3: Multi-Agent 시스템 재귀 개선 루프 (WHAT)
+
+### Core Question
+"LLM이 평가한 결과를 믿어도 되는가?"
+
+### LLM-as-Judge의 리스크
+- 확증편향: 기존 인식 강화 → BiasBuster(Verify) 결과 무결성 검증
+- 최근성편향: 최신 정보 과대평가 → Clean Context 적용
+- 앵커링: 지표에 과도한 편향 → 평가자별 글로벌평 가중치
+- 결과 무시: 라이선스 미검토 → Rights Check 의무화
+
+### Feedback Loop 5-Phase Architecture (RLHF + RLAIF)
+
+| Phase | Content |
+|-------|---------|
+| 1. PREDICTION (T+0) | Agent Loop → Final_Score → Tier → Snapshot 저장 |
+| 2. OUTCOME TRACKING (T+30/90/180d) | Scheduled Automation → 실제 성과 수집 → Delta 계산 |
+| 3. CORRELATION ANALYSIS (Quarterly) | Spearman ρ, Kendall τ, Precision@K 산출 |
+| 4. MODEL IMPROVEMENT (Bi-annual) | A. Rubric / B. Weight / C. Prompt tuning |
+| 5. RLAIF INTEGRATION (Advanced) | AI Feedback으로 Human Feedback 보완 |
+
+### KPI Targets
+| Metric | Target | Warning | Critical |
+|--------|--------|---------|----------|
+| ρ ≥ 0.50 | Spearman Correlation | Final_Score vs Revenue Delta |
+| τ ≥ 0.45 | Kendall Tau | 순위 일관성 (τ ≈ 0.9×ρ) |
+| P@10≥0.6 | Precision at 10 | 상위 10개 중 6+ 정확 |
+| α ≥ 0.80 | Krippendorff's Alpha | Human-LLM 신뢰도 |
+
+### Expert Panel Hierarchy (NDC25 기반)
+- Tier 3 Verified: ρ≥0.50, 30+개 예측, 핵심 검증
+- Tier 2 Provisional: 실적 누적 중, 리뷰 참여
+- Tier 1 Candidate: 기초 인증 참가
+
+### CUSUM Calibration Drift 탐지
+```
+S_n = Σ (μ − x_i) / σ
+누적합이 임계값 초과 시 Drift 경고
+```
+- NONE: CUSUM ≤ 2.5 (정상)
+- WARNING: 2.5 < CUSUM ≤ 4.0
+- CRITICAL: CUSUM > 4.0 (즉시 조치)
+
+### Guardrail (G1-G4)
+- G1: Schema — JSON 스키마 검증 (구조)
+- G2: Range — 점수 범위 검증 (1-5)
+- G3: Ground — 근거 데이터 검증 (사실)
+- G4: Consistency — 일관성 검증 (논리)
+
+### Model Versioning & Registry (MLflow/W&B)
+```python
+version_id: "v6.0.1"
+parent: "v5.5.0"
+rubric_hash: SHA256
+weight_hash: SHA256
+prompt_hash: SHA256
+```
+Promotion Pipeline: DEV → STAGING → PROD
+
+### Pairwise Ranking (RLHF 핵심 가치)
+IP A vs IP B → Elo Rating → Reward Signal

--- a/.geode/skills/pdf/LICENSE.txt
+++ b/.geode/skills/pdf/LICENSE.txt
@@ -1,0 +1,30 @@
+© 2025 Anthropic, PBC. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files,
+and other components of this Skill) is governed by your agreement with
+Anthropic regarding use of Anthropic's services. If no separate agreement
+exists, use is governed by Anthropic's Consumer Terms of Service or
+Commercial Terms of Service, as applicable:
+https://www.anthropic.com/legal/consumer-terms
+https://www.anthropic.com/legal/commercial-terms
+Your applicable agreement is referred to as the "Agreement." "Services" are
+as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the
+contrary, users may not:
+
+- Extract these materials from the Services or retain copies of these
+  materials outside the Services
+- Reproduce or copy these materials, except for temporary copies created
+  automatically during authorized use of the Services
+- Create derivative works based on these materials
+- Distribute, sublicense, or transfer these materials to any third party
+- Make, offer to sell, sell, or import any inventions embodied in these
+  materials
+- Reverse engineer, decompile, or disassemble these materials
+
+The receipt, viewing, or possession of these materials does not convey or
+imply any license or right beyond those expressly granted above.
+
+Anthropic retains all right, title, and interest in these materials,
+including all copyrights, patents, and other intellectual property rights.

--- a/.geode/skills/pdf/SKILL.md
+++ b/.geode/skills/pdf/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: pdf
+visibility: public
+description: Comprehensive PDF manipulation toolkit for extracting text and tables, creating new PDFs, merging/splitting documents, and handling forms. When Claude needs to fill in a PDF form or programmatically process, generate, or analyze PDF documents at scale.
+license: Proprietary. LICENSE.txt has complete terms
+---
+
+# PDF Processing Guide
+
+## Overview
+
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see reference.md. If you need to fill out a PDF form, read forms.md and follow its instructions.
+
+## Quick Start
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Read a PDF
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+# Extract text
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```
+
+## Python Libraries
+
+### pypdf - Basic Operations
+
+#### Merge PDFs
+```python
+from pypdf import PdfWriter, PdfReader
+
+writer = PdfWriter()
+for pdf_file in ["doc1.pdf", "doc2.pdf", "doc3.pdf"]:
+    reader = PdfReader(pdf_file)
+    for page in reader.pages:
+        writer.add_page(page)
+
+with open("merged.pdf", "wb") as output:
+    writer.write(output)
+```
+
+#### Split PDF
+```python
+reader = PdfReader("input.pdf")
+for i, page in enumerate(reader.pages):
+    writer = PdfWriter()
+    writer.add_page(page)
+    with open(f"page_{i+1}.pdf", "wb") as output:
+        writer.write(output)
+```
+
+#### Extract Metadata
+```python
+reader = PdfReader("document.pdf")
+meta = reader.metadata
+print(f"Title: {meta.title}")
+print(f"Author: {meta.author}")
+print(f"Subject: {meta.subject}")
+print(f"Creator: {meta.creator}")
+```
+
+#### Rotate Pages
+```python
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+page = reader.pages[0]
+page.rotate(90)  # Rotate 90 degrees clockwise
+writer.add_page(page)
+
+with open("rotated.pdf", "wb") as output:
+    writer.write(output)
+```
+
+### pdfplumber - Text and Table Extraction
+
+#### Extract Text with Layout
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        print(text)
+```
+
+#### Extract Tables
+```python
+with pdfplumber.open("document.pdf") as pdf:
+    for i, page in enumerate(pdf.pages):
+        tables = page.extract_tables()
+        for j, table in enumerate(tables):
+            print(f"Table {j+1} on page {i+1}:")
+            for row in table:
+                print(row)
+```
+
+#### Advanced Table Extraction
+```python
+import pandas as pd
+
+with pdfplumber.open("document.pdf") as pdf:
+    all_tables = []
+    for page in pdf.pages:
+        tables = page.extract_tables()
+        for table in tables:
+            if table:  # Check if table is not empty
+                df = pd.DataFrame(table[1:], columns=table[0])
+                all_tables.append(df)
+
+# Combine all tables
+if all_tables:
+    combined_df = pd.concat(all_tables, ignore_index=True)
+    combined_df.to_excel("extracted_tables.xlsx", index=False)
+```
+
+### reportlab - Create PDFs
+
+#### Basic PDF Creation
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+c = canvas.Canvas("hello.pdf", pagesize=letter)
+width, height = letter
+
+# Add text
+c.drawString(100, height - 100, "Hello World!")
+c.drawString(100, height - 120, "This is a PDF created with reportlab")
+
+# Add a line
+c.line(100, height - 140, 400, height - 140)
+
+# Save
+c.save()
+```
+
+#### Create PDF with Multiple Pages
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
+from reportlab.lib.styles import getSampleStyleSheet
+
+doc = SimpleDocTemplate("report.pdf", pagesize=letter)
+styles = getSampleStyleSheet()
+story = []
+
+# Add content
+title = Paragraph("Report Title", styles['Title'])
+story.append(title)
+story.append(Spacer(1, 12))
+
+body = Paragraph("This is the body of the report. " * 20, styles['Normal'])
+story.append(body)
+story.append(PageBreak())
+
+# Page 2
+story.append(Paragraph("Page 2", styles['Heading1']))
+story.append(Paragraph("Content for page 2", styles['Normal']))
+
+# Build PDF
+doc.build(story)
+```
+
+## Command-Line Tools
+
+### pdftotext (poppler-utils)
+```bash
+# Extract text
+pdftotext input.pdf output.txt
+
+# Extract text preserving layout
+pdftotext -layout input.pdf output.txt
+
+# Extract specific pages
+pdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5
+```
+
+### qpdf
+```bash
+# Merge PDFs
+qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
+
+# Split pages
+qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
+qpdf input.pdf --pages . 6-10 -- pages6-10.pdf
+
+# Rotate pages
+qpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees
+
+# Remove password
+qpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf
+```
+
+### pdftk (if available)
+```bash
+# Merge
+pdftk file1.pdf file2.pdf cat output merged.pdf
+
+# Split
+pdftk input.pdf burst
+
+# Rotate
+pdftk input.pdf rotate 1east output rotated.pdf
+```
+
+## Common Tasks
+
+### Extract Text from Scanned PDFs
+```python
+# Requires: pip install pytesseract pdf2image
+import pytesseract
+from pdf2image import convert_from_path
+
+# Convert PDF to images
+images = convert_from_path('scanned.pdf')
+
+# OCR each page
+text = ""
+for i, image in enumerate(images):
+    text += f"Page {i+1}:\n"
+    text += pytesseract.image_to_string(image)
+    text += "\n\n"
+
+print(text)
+```
+
+### Add Watermark
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Create watermark (or load existing)
+watermark = PdfReader("watermark.pdf").pages[0]
+
+# Apply to all pages
+reader = PdfReader("document.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    page.merge_page(watermark)
+    writer.add_page(page)
+
+with open("watermarked.pdf", "wb") as output:
+    writer.write(output)
+```
+
+### Extract Images
+```bash
+# Using pdfimages (poppler-utils)
+pdfimages -j input.pdf output_prefix
+
+# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.
+```
+
+### Password Protection
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    writer.add_page(page)
+
+# Add password
+writer.encrypt("userpassword", "ownerpassword")
+
+with open("encrypted.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Quick Reference
+
+| Task | Best Tool | Command/Code |
+|------|-----------|--------------|
+| Merge PDFs | pypdf | `writer.add_page(page)` |
+| Split PDFs | pypdf | One page per file |
+| Extract text | pdfplumber | `page.extract_text()` |
+| Extract tables | pdfplumber | `page.extract_tables()` |
+| Create PDFs | reportlab | Canvas or Platypus |
+| Command line merge | qpdf | `qpdf --empty --pages ...` |
+| OCR scanned PDFs | pytesseract | Convert to image first |
+| Fill PDF forms | pdf-lib or pypdf (see forms.md) | See forms.md |
+
+## Next Steps
+
+- For advanced pypdfium2 usage, see reference.md
+- For JavaScript libraries (pdf-lib), see reference.md
+- If you need to fill out a PDF form, follow the instructions in forms.md
+- For troubleshooting guides, see reference.md

--- a/.geode/skills/pdf/forms.md
+++ b/.geode/skills/pdf/forms.md
@@ -1,0 +1,205 @@
+**CRITICAL: You MUST complete these steps in order. Do not skip ahead to writing code.**
+
+If you need to fill out a PDF form, first check to see if the PDF has fillable form fields. Run this script from this file's directory:
+ `python scripts/check_fillable_fields <file.pdf>`, and depending on the result go to either the "Fillable fields" or "Non-fillable fields" and follow those instructions.
+
+# Fillable fields
+If the PDF has fillable form fields:
+- Run this script from this file's directory: `python scripts/extract_form_field_info.py <input.pdf> <field_info.json>`. It will create a JSON file with a list of fields in this format:
+```
+[
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "rect": ([left, bottom, right, top] bounding box in PDF coordinates, y=0 is the bottom of the page),
+    "type": ("text", "checkbox", "radio_group", or "choice"),
+  },
+  // Checkboxes have "checked_value" and "unchecked_value" properties:
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "type": "checkbox",
+    "checked_value": (Set the field to this value to check the checkbox),
+    "unchecked_value": (Set the field to this value to uncheck the checkbox),
+  },
+  // Radio groups have a "radio_options" list with the possible choices.
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "type": "radio_group",
+    "radio_options": [
+      {
+        "value": (set the field to this value to select this radio option),
+        "rect": (bounding box for the radio button for this option)
+      },
+      // Other radio options
+    ]
+  },
+  // Multiple choice fields have a "choice_options" list with the possible choices:
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "type": "choice",
+    "choice_options": [
+      {
+        "value": (set the field to this value to select this option),
+        "text": (display text of the option)
+      },
+      // Other choice options
+    ],
+  }
+]
+```
+- Convert the PDF to PNGs (one image for each page) with this script (run from this file's directory):
+`python scripts/convert_pdf_to_images.py <file.pdf> <output_directory>`
+Then analyze the images to determine the purpose of each form field (make sure to convert the bounding box PDF coordinates to image coordinates).
+- Create a `field_values.json` file in this format with the values to be entered for each field:
+```
+[
+  {
+    "field_id": "last_name", // Must match the field_id from `extract_form_field_info.py`
+    "description": "The user's last name",
+    "page": 1, // Must match the "page" value in field_info.json
+    "value": "Simpson"
+  },
+  {
+    "field_id": "Checkbox12",
+    "description": "Checkbox to be checked if the user is 18 or over",
+    "page": 1,
+    "value": "/On" // If this is a checkbox, use its "checked_value" value to check it. If it's a radio button group, use one of the "value" values in "radio_options".
+  },
+  // more fields
+]
+```
+- Run the `fill_fillable_fields.py` script from this file's directory to create a filled-in PDF:
+`python scripts/fill_fillable_fields.py <input pdf> <field_values.json> <output pdf>`
+This script will verify that the field IDs and values you provide are valid; if it prints error messages, correct the appropriate fields and try again.
+
+# Non-fillable fields
+If the PDF doesn't have fillable form fields, you'll need to visually determine where the data should be added and create text annotations. Follow the below steps *exactly*. You MUST perform all of these steps to ensure that the the form is accurately completed. Details for each step are below.
+- Convert the PDF to PNG images and determine field bounding boxes.
+- Create a JSON file with field information and validation images showing the bounding boxes.
+- Validate the the bounding boxes.
+- Use the bounding boxes to fill in the form.
+
+## Step 1: Visual Analysis (REQUIRED)
+- Convert the PDF to PNG images. Run this script from this file's directory:
+`python scripts/convert_pdf_to_images.py <file.pdf> <output_directory>`
+The script will create a PNG image for each page in the PDF.
+- Carefully examine each PNG image and identify all form fields and areas where the user should enter data. For each form field where the user should enter text, determine bounding boxes for both the form field label, and the area where the user should enter text. The label and entry bounding boxes MUST NOT INTERSECT; the text entry box should only include the area where data should be entered. Usually this area will be immediately to the side, above, or below its label. Entry bounding boxes must be tall and wide enough to contain their text.
+
+These are some examples of form structures that you might see:
+
+*Label inside box*
+```
+┌────────────────────────┐
+│ Name:                  │
+└────────────────────────┘
+```
+The input area should be to the right of the "Name" label and extend to the edge of the box.
+
+*Label before line*
+```
+Email: _______________________
+```
+The input area should be above the line and include its entire width.
+
+*Label under line*
+```
+_________________________
+Name
+```
+The input area should be above the line and include the entire width of the line. This is common for signature and date fields.
+
+*Label above line*
+```
+Please enter any special requests:
+________________________________________________
+```
+The input area should extend from the bottom of the label to the line, and should include the entire width of the line.
+
+*Checkboxes*
+```
+Are you a US citizen? Yes □  No □
+```
+For checkboxes:
+- Look for small square boxes (□) - these are the actual checkboxes to target. They may be to the left or right of their labels.
+- Distinguish between label text ("Yes", "No") and the clickable checkbox squares.
+- The entry bounding box should cover ONLY the small square, not the text label.
+
+### Step 2: Create fields.json and validation images (REQUIRED)
+- Create a file named `fields.json` with information for the form fields and bounding boxes in this format:
+```
+{
+  "pages": [
+    {
+      "page_number": 1,
+      "image_width": (first page image width in pixels),
+      "image_height": (first page image height in pixels),
+    },
+    {
+      "page_number": 2,
+      "image_width": (second page image width in pixels),
+      "image_height": (second page image height in pixels),
+    }
+    // additional pages
+  ],
+  "form_fields": [
+    // Example for a text field.
+    {
+      "page_number": 1,
+      "description": "The user's last name should be entered here",
+      // Bounding boxes are [left, top, right, bottom]. The bounding boxes for the label and text entry should not overlap.
+      "field_label": "Last name",
+      "label_bounding_box": [30, 125, 95, 142],
+      "entry_bounding_box": [100, 125, 280, 142],
+      "entry_text": {
+        "text": "Johnson", // This text will be added as an annotation at the entry_bounding_box location
+        "font_size": 14, // optional, defaults to 14
+        "font_color": "000000", // optional, RRGGBB format, defaults to 000000 (black)
+      }
+    },
+    // Example for a checkbox. TARGET THE SQUARE for the entry bounding box, NOT THE TEXT
+    {
+      "page_number": 2,
+      "description": "Checkbox that should be checked if the user is over 18",
+      "entry_bounding_box": [140, 525, 155, 540],  // Small box over checkbox square
+      "field_label": "Yes",
+      "label_bounding_box": [100, 525, 132, 540],  // Box containing "Yes" text
+      // Use "X" to check a checkbox.
+      "entry_text": {
+        "text": "X",
+      }
+    }
+    // additional form field entries
+  ]
+}
+```
+
+Create validation images by running this script from this file's directory for each page:
+`python scripts/create_validation_image.py <page_number> <path_to_fields.json> <input_image_path> <output_image_path>
+
+The validation images will have red rectangles where text should be entered, and blue rectangles covering label text.
+
+### Step 3: Validate Bounding Boxes (REQUIRED)
+#### Automated intersection check
+- Verify that none of bounding boxes intersect and that the entry bounding boxes are tall enough by checking the fields.json file with the `check_bounding_boxes.py` script (run from this file's directory):
+`python scripts/check_bounding_boxes.py <JSON file>`
+
+If there are errors, reanalyze the relevant fields, adjust the bounding boxes, and iterate until there are no remaining errors. Remember: label (blue) bounding boxes should contain text labels, entry (red) boxes should not.
+
+#### Manual image inspection
+**CRITICAL: Do not proceed without visually inspecting validation images**
+- Red rectangles must ONLY cover input areas
+- Red rectangles MUST NOT contain any text
+- Blue rectangles should contain label text
+- For checkboxes:
+  - Red rectangle MUST be centered on the checkbox square
+  - Blue rectangle should cover the text label for the checkbox
+
+- If any rectangles look wrong, fix fields.json, regenerate the validation images, and verify again. Repeat this process until the bounding boxes are fully accurate.
+
+
+### Step 4: Add annotations to the PDF
+Run this script from this file's directory to create a filled-out PDF using the information in fields.json:
+`python scripts/fill_pdf_form_with_annotations.py <input_pdf_path> <path_to_fields.json> <output_pdf_path>

--- a/.geode/skills/pdf/reference.md
+++ b/.geode/skills/pdf/reference.md
@@ -1,0 +1,612 @@
+# PDF Processing Advanced Reference
+
+This document contains advanced PDF processing features, detailed examples, and additional libraries not covered in the main skill instructions.
+
+## pypdfium2 Library (Apache/BSD License)
+
+### Overview
+pypdfium2 is a Python binding for PDFium (Chromium's PDF library). It's excellent for fast PDF rendering, image generation, and serves as a PyMuPDF replacement.
+
+### Render PDF to Images
+```python
+import pypdfium2 as pdfium
+from PIL import Image
+
+# Load PDF
+pdf = pdfium.PdfDocument("document.pdf")
+
+# Render page to image
+page = pdf[0]  # First page
+bitmap = page.render(
+    scale=2.0,  # Higher resolution
+    rotation=0  # No rotation
+)
+
+# Convert to PIL Image
+img = bitmap.to_pil()
+img.save("page_1.png", "PNG")
+
+# Process multiple pages
+for i, page in enumerate(pdf):
+    bitmap = page.render(scale=1.5)
+    img = bitmap.to_pil()
+    img.save(f"page_{i+1}.jpg", "JPEG", quality=90)
+```
+
+### Extract Text with pypdfium2
+```python
+import pypdfium2 as pdfium
+
+pdf = pdfium.PdfDocument("document.pdf")
+for i, page in enumerate(pdf):
+    text = page.get_text()
+    print(f"Page {i+1} text length: {len(text)} chars")
+```
+
+## JavaScript Libraries
+
+### pdf-lib (MIT License)
+
+pdf-lib is a powerful JavaScript library for creating and modifying PDF documents in any JavaScript environment.
+
+#### Load and Manipulate Existing PDF
+```javascript
+import { PDFDocument } from 'pdf-lib';
+import fs from 'fs';
+
+async function manipulatePDF() {
+    // Load existing PDF
+    const existingPdfBytes = fs.readFileSync('input.pdf');
+    const pdfDoc = await PDFDocument.load(existingPdfBytes);
+
+    // Get page count
+    const pageCount = pdfDoc.getPageCount();
+    console.log(`Document has ${pageCount} pages`);
+
+    // Add new page
+    const newPage = pdfDoc.addPage([600, 400]);
+    newPage.drawText('Added by pdf-lib', {
+        x: 100,
+        y: 300,
+        size: 16
+    });
+
+    // Save modified PDF
+    const pdfBytes = await pdfDoc.save();
+    fs.writeFileSync('modified.pdf', pdfBytes);
+}
+```
+
+#### Create Complex PDFs from Scratch
+```javascript
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
+import fs from 'fs';
+
+async function createPDF() {
+    const pdfDoc = await PDFDocument.create();
+
+    // Add fonts
+    const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const helveticaBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+    // Add page
+    const page = pdfDoc.addPage([595, 842]); // A4 size
+    const { width, height } = page.getSize();
+
+    // Add text with styling
+    page.drawText('Invoice #12345', {
+        x: 50,
+        y: height - 50,
+        size: 18,
+        font: helveticaBold,
+        color: rgb(0.2, 0.2, 0.8)
+    });
+
+    // Add rectangle (header background)
+    page.drawRectangle({
+        x: 40,
+        y: height - 100,
+        width: width - 80,
+        height: 30,
+        color: rgb(0.9, 0.9, 0.9)
+    });
+
+    // Add table-like content
+    const items = [
+        ['Item', 'Qty', 'Price', 'Total'],
+        ['Widget', '2', '$50', '$100'],
+        ['Gadget', '1', '$75', '$75']
+    ];
+
+    let yPos = height - 150;
+    items.forEach(row => {
+        let xPos = 50;
+        row.forEach(cell => {
+            page.drawText(cell, {
+                x: xPos,
+                y: yPos,
+                size: 12,
+                font: helveticaFont
+            });
+            xPos += 120;
+        });
+        yPos -= 25;
+    });
+
+    const pdfBytes = await pdfDoc.save();
+    fs.writeFileSync('created.pdf', pdfBytes);
+}
+```
+
+#### Advanced Merge and Split Operations
+```javascript
+import { PDFDocument } from 'pdf-lib';
+import fs from 'fs';
+
+async function mergePDFs() {
+    // Create new document
+    const mergedPdf = await PDFDocument.create();
+
+    // Load source PDFs
+    const pdf1Bytes = fs.readFileSync('doc1.pdf');
+    const pdf2Bytes = fs.readFileSync('doc2.pdf');
+
+    const pdf1 = await PDFDocument.load(pdf1Bytes);
+    const pdf2 = await PDFDocument.load(pdf2Bytes);
+
+    // Copy pages from first PDF
+    const pdf1Pages = await mergedPdf.copyPages(pdf1, pdf1.getPageIndices());
+    pdf1Pages.forEach(page => mergedPdf.addPage(page));
+
+    // Copy specific pages from second PDF (pages 0, 2, 4)
+    const pdf2Pages = await mergedPdf.copyPages(pdf2, [0, 2, 4]);
+    pdf2Pages.forEach(page => mergedPdf.addPage(page));
+
+    const mergedPdfBytes = await mergedPdf.save();
+    fs.writeFileSync('merged.pdf', mergedPdfBytes);
+}
+```
+
+### pdfjs-dist (Apache License)
+
+PDF.js is Mozilla's JavaScript library for rendering PDFs in the browser.
+
+#### Basic PDF Loading and Rendering
+```javascript
+import * as pdfjsLib from 'pdfjs-dist';
+
+// Configure worker (important for performance)
+pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.js';
+
+async function renderPDF() {
+    // Load PDF
+    const loadingTask = pdfjsLib.getDocument('document.pdf');
+    const pdf = await loadingTask.promise;
+
+    console.log(`Loaded PDF with ${pdf.numPages} pages`);
+
+    // Get first page
+    const page = await pdf.getPage(1);
+    const viewport = page.getViewport({ scale: 1.5 });
+
+    // Render to canvas
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    canvas.height = viewport.height;
+    canvas.width = viewport.width;
+
+    const renderContext = {
+        canvasContext: context,
+        viewport: viewport
+    };
+
+    await page.render(renderContext).promise;
+    document.body.appendChild(canvas);
+}
+```
+
+#### Extract Text with Coordinates
+```javascript
+import * as pdfjsLib from 'pdfjs-dist';
+
+async function extractText() {
+    const loadingTask = pdfjsLib.getDocument('document.pdf');
+    const pdf = await loadingTask.promise;
+
+    let fullText = '';
+
+    // Extract text from all pages
+    for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const textContent = await page.getTextContent();
+
+        const pageText = textContent.items
+            .map(item => item.str)
+            .join(' ');
+
+        fullText += `\n--- Page ${i} ---\n${pageText}`;
+
+        // Get text with coordinates for advanced processing
+        const textWithCoords = textContent.items.map(item => ({
+            text: item.str,
+            x: item.transform[4],
+            y: item.transform[5],
+            width: item.width,
+            height: item.height
+        }));
+    }
+
+    console.log(fullText);
+    return fullText;
+}
+```
+
+#### Extract Annotations and Forms
+```javascript
+import * as pdfjsLib from 'pdfjs-dist';
+
+async function extractAnnotations() {
+    const loadingTask = pdfjsLib.getDocument('annotated.pdf');
+    const pdf = await loadingTask.promise;
+
+    for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const annotations = await page.getAnnotations();
+
+        annotations.forEach(annotation => {
+            console.log(`Annotation type: ${annotation.subtype}`);
+            console.log(`Content: ${annotation.contents}`);
+            console.log(`Coordinates: ${JSON.stringify(annotation.rect)}`);
+        });
+    }
+}
+```
+
+## Advanced Command-Line Operations
+
+### poppler-utils Advanced Features
+
+#### Extract Text with Bounding Box Coordinates
+```bash
+# Extract text with bounding box coordinates (essential for structured data)
+pdftotext -bbox-layout document.pdf output.xml
+
+# The XML output contains precise coordinates for each text element
+```
+
+#### Advanced Image Conversion
+```bash
+# Convert to PNG images with specific resolution
+pdftoppm -png -r 300 document.pdf output_prefix
+
+# Convert specific page range with high resolution
+pdftoppm -png -r 600 -f 1 -l 3 document.pdf high_res_pages
+
+# Convert to JPEG with quality setting
+pdftoppm -jpeg -jpegopt quality=85 -r 200 document.pdf jpeg_output
+```
+
+#### Extract Embedded Images
+```bash
+# Extract all embedded images with metadata
+pdfimages -j -p document.pdf page_images
+
+# List image info without extracting
+pdfimages -list document.pdf
+
+# Extract images in their original format
+pdfimages -all document.pdf images/img
+```
+
+### qpdf Advanced Features
+
+#### Complex Page Manipulation
+```bash
+# Split PDF into groups of pages
+qpdf --split-pages=3 input.pdf output_group_%02d.pdf
+
+# Extract specific pages with complex ranges
+qpdf input.pdf --pages input.pdf 1,3-5,8,10-end -- extracted.pdf
+
+# Merge specific pages from multiple PDFs
+qpdf --empty --pages doc1.pdf 1-3 doc2.pdf 5-7 doc3.pdf 2,4 -- combined.pdf
+```
+
+#### PDF Optimization and Repair
+```bash
+# Optimize PDF for web (linearize for streaming)
+qpdf --linearize input.pdf optimized.pdf
+
+# Remove unused objects and compress
+qpdf --optimize-level=all input.pdf compressed.pdf
+
+# Attempt to repair corrupted PDF structure
+qpdf --check input.pdf
+qpdf --fix-qdf damaged.pdf repaired.pdf
+
+# Show detailed PDF structure for debugging
+qpdf --show-all-pages input.pdf > structure.txt
+```
+
+#### Advanced Encryption
+```bash
+# Add password protection with specific permissions
+qpdf --encrypt user_pass owner_pass 256 --print=none --modify=none -- input.pdf encrypted.pdf
+
+# Check encryption status
+qpdf --show-encryption encrypted.pdf
+
+# Remove password protection (requires password)
+qpdf --password=secret123 --decrypt encrypted.pdf decrypted.pdf
+```
+
+## Advanced Python Techniques
+
+### pdfplumber Advanced Features
+
+#### Extract Text with Precise Coordinates
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    page = pdf.pages[0]
+    
+    # Extract all text with coordinates
+    chars = page.chars
+    for char in chars[:10]:  # First 10 characters
+        print(f"Char: '{char['text']}' at x:{char['x0']:.1f} y:{char['y0']:.1f}")
+    
+    # Extract text by bounding box (left, top, right, bottom)
+    bbox_text = page.within_bbox((100, 100, 400, 200)).extract_text()
+```
+
+#### Advanced Table Extraction with Custom Settings
+```python
+import pdfplumber
+import pandas as pd
+
+with pdfplumber.open("complex_table.pdf") as pdf:
+    page = pdf.pages[0]
+    
+    # Extract tables with custom settings for complex layouts
+    table_settings = {
+        "vertical_strategy": "lines",
+        "horizontal_strategy": "lines",
+        "snap_tolerance": 3,
+        "intersection_tolerance": 15
+    }
+    tables = page.extract_tables(table_settings)
+    
+    # Visual debugging for table extraction
+    img = page.to_image(resolution=150)
+    img.save("debug_layout.png")
+```
+
+### reportlab Advanced Features
+
+#### Create Professional Reports with Tables
+```python
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib import colors
+
+# Sample data
+data = [
+    ['Product', 'Q1', 'Q2', 'Q3', 'Q4'],
+    ['Widgets', '120', '135', '142', '158'],
+    ['Gadgets', '85', '92', '98', '105']
+]
+
+# Create PDF with table
+doc = SimpleDocTemplate("report.pdf")
+elements = []
+
+# Add title
+styles = getSampleStyleSheet()
+title = Paragraph("Quarterly Sales Report", styles['Title'])
+elements.append(title)
+
+# Add table with advanced styling
+table = Table(data)
+table.setStyle(TableStyle([
+    ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
+    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+    ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+    ('FONTSIZE', (0, 0), (-1, 0), 14),
+    ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+    ('BACKGROUND', (0, 1), (-1, -1), colors.beige),
+    ('GRID', (0, 0), (-1, -1), 1, colors.black)
+]))
+elements.append(table)
+
+doc.build(elements)
+```
+
+## Complex Workflows
+
+### Extract Figures/Images from PDF
+
+#### Method 1: Using pdfimages (fastest)
+```bash
+# Extract all images with original quality
+pdfimages -all document.pdf images/img
+```
+
+#### Method 2: Using pypdfium2 + Image Processing
+```python
+import pypdfium2 as pdfium
+from PIL import Image
+import numpy as np
+
+def extract_figures(pdf_path, output_dir):
+    pdf = pdfium.PdfDocument(pdf_path)
+    
+    for page_num, page in enumerate(pdf):
+        # Render high-resolution page
+        bitmap = page.render(scale=3.0)
+        img = bitmap.to_pil()
+        
+        # Convert to numpy for processing
+        img_array = np.array(img)
+        
+        # Simple figure detection (non-white regions)
+        mask = np.any(img_array != [255, 255, 255], axis=2)
+        
+        # Find contours and extract bounding boxes
+        # (This is simplified - real implementation would need more sophisticated detection)
+        
+        # Save detected figures
+        # ... implementation depends on specific needs
+```
+
+### Batch PDF Processing with Error Handling
+```python
+import os
+import glob
+from pypdf import PdfReader, PdfWriter
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def batch_process_pdfs(input_dir, operation='merge'):
+    pdf_files = glob.glob(os.path.join(input_dir, "*.pdf"))
+    
+    if operation == 'merge':
+        writer = PdfWriter()
+        for pdf_file in pdf_files:
+            try:
+                reader = PdfReader(pdf_file)
+                for page in reader.pages:
+                    writer.add_page(page)
+                logger.info(f"Processed: {pdf_file}")
+            except Exception as e:
+                logger.error(f"Failed to process {pdf_file}: {e}")
+                continue
+        
+        with open("batch_merged.pdf", "wb") as output:
+            writer.write(output)
+    
+    elif operation == 'extract_text':
+        for pdf_file in pdf_files:
+            try:
+                reader = PdfReader(pdf_file)
+                text = ""
+                for page in reader.pages:
+                    text += page.extract_text()
+                
+                output_file = pdf_file.replace('.pdf', '.txt')
+                with open(output_file, 'w', encoding='utf-8') as f:
+                    f.write(text)
+                logger.info(f"Extracted text from: {pdf_file}")
+                
+            except Exception as e:
+                logger.error(f"Failed to extract text from {pdf_file}: {e}")
+                continue
+```
+
+### Advanced PDF Cropping
+```python
+from pypdf import PdfWriter, PdfReader
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+# Crop page (left, bottom, right, top in points)
+page = reader.pages[0]
+page.mediabox.left = 50
+page.mediabox.bottom = 50
+page.mediabox.right = 550
+page.mediabox.top = 750
+
+writer.add_page(page)
+with open("cropped.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Performance Optimization Tips
+
+### 1. For Large PDFs
+- Use streaming approaches instead of loading entire PDF in memory
+- Use `qpdf --split-pages` for splitting large files
+- Process pages individually with pypdfium2
+
+### 2. For Text Extraction
+- `pdftotext -bbox-layout` is fastest for plain text extraction
+- Use pdfplumber for structured data and tables
+- Avoid `pypdf.extract_text()` for very large documents
+
+### 3. For Image Extraction
+- `pdfimages` is much faster than rendering pages
+- Use low resolution for previews, high resolution for final output
+
+### 4. For Form Filling
+- pdf-lib maintains form structure better than most alternatives
+- Pre-validate form fields before processing
+
+### 5. Memory Management
+```python
+# Process PDFs in chunks
+def process_large_pdf(pdf_path, chunk_size=10):
+    reader = PdfReader(pdf_path)
+    total_pages = len(reader.pages)
+    
+    for start_idx in range(0, total_pages, chunk_size):
+        end_idx = min(start_idx + chunk_size, total_pages)
+        writer = PdfWriter()
+        
+        for i in range(start_idx, end_idx):
+            writer.add_page(reader.pages[i])
+        
+        # Process chunk
+        with open(f"chunk_{start_idx//chunk_size}.pdf", "wb") as output:
+            writer.write(output)
+```
+
+## Troubleshooting Common Issues
+
+### Encrypted PDFs
+```python
+# Handle password-protected PDFs
+from pypdf import PdfReader
+
+try:
+    reader = PdfReader("encrypted.pdf")
+    if reader.is_encrypted:
+        reader.decrypt("password")
+except Exception as e:
+    print(f"Failed to decrypt: {e}")
+```
+
+### Corrupted PDFs
+```bash
+# Use qpdf to repair
+qpdf --check corrupted.pdf
+qpdf --replace-input corrupted.pdf
+```
+
+### Text Extraction Issues
+```python
+# Fallback to OCR for scanned PDFs
+import pytesseract
+from pdf2image import convert_from_path
+
+def extract_text_with_ocr(pdf_path):
+    images = convert_from_path(pdf_path)
+    text = ""
+    for i, image in enumerate(images):
+        text += pytesseract.image_to_string(image)
+    return text
+```
+
+## License Information
+
+- **pypdf**: BSD License
+- **pdfplumber**: MIT License
+- **pypdfium2**: Apache/BSD License
+- **reportlab**: BSD License
+- **poppler-utils**: GPL-2 License
+- **qpdf**: Apache License
+- **pdf-lib**: MIT License
+- **pdfjs-dist**: Apache License

--- a/.geode/skills/pdf/scripts/check_bounding_boxes.py
+++ b/.geode/skills/pdf/scripts/check_bounding_boxes.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+import json
+import sys
+
+
+# Script to check that the `fields.json` file that Claude creates when analyzing PDFs
+# does not have overlapping bounding boxes. See forms.md.
+
+
+@dataclass
+class RectAndField:
+    rect: list[float]
+    rect_type: str
+    field: dict
+
+
+# Returns a list of messages that are printed to stdout for Claude to read.
+def get_bounding_box_messages(fields_json_stream) -> list[str]:
+    messages = []
+    fields = json.load(fields_json_stream)
+    messages.append(f"Read {len(fields['form_fields'])} fields")
+
+    def rects_intersect(r1, r2):
+        disjoint_horizontal = r1[0] >= r2[2] or r1[2] <= r2[0]
+        disjoint_vertical = r1[1] >= r2[3] or r1[3] <= r2[1]
+        return not (disjoint_horizontal or disjoint_vertical)
+
+    rects_and_fields = []
+    for f in fields["form_fields"]:
+        rects_and_fields.append(RectAndField(f["label_bounding_box"], "label", f))
+        rects_and_fields.append(RectAndField(f["entry_bounding_box"], "entry", f))
+
+    has_error = False
+    for i, ri in enumerate(rects_and_fields):
+        # This is O(N^2); we can optimize if it becomes a problem.
+        for j in range(i + 1, len(rects_and_fields)):
+            rj = rects_and_fields[j]
+            if ri.field["page_number"] == rj.field["page_number"] and rects_intersect(ri.rect, rj.rect):
+                has_error = True
+                if ri.field is rj.field:
+                    messages.append(f"FAILURE: intersection between label and entry bounding boxes for `{ri.field['description']}` ({ri.rect}, {rj.rect})")
+                else:
+                    messages.append(f"FAILURE: intersection between {ri.rect_type} bounding box for `{ri.field['description']}` ({ri.rect}) and {rj.rect_type} bounding box for `{rj.field['description']}` ({rj.rect})")
+                if len(messages) >= 20:
+                    messages.append("Aborting further checks; fix bounding boxes and try again")
+                    return messages
+        if ri.rect_type == "entry":
+            if "entry_text" in ri.field:
+                font_size = ri.field["entry_text"].get("font_size", 14)
+                entry_height = ri.rect[3] - ri.rect[1]
+                if entry_height < font_size:
+                    has_error = True
+                    messages.append(f"FAILURE: entry bounding box height ({entry_height}) for `{ri.field['description']}` is too short for the text content (font size: {font_size}). Increase the box height or decrease the font size.")
+                    if len(messages) >= 20:
+                        messages.append("Aborting further checks; fix bounding boxes and try again")
+                        return messages
+
+    if not has_error:
+        messages.append("SUCCESS: All bounding boxes are valid")
+    return messages
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: check_bounding_boxes.py [fields.json]")
+        sys.exit(1)
+    # Input file should be in the `fields.json` format described in forms.md.
+    with open(sys.argv[1]) as f:
+        messages = get_bounding_box_messages(f)
+    for msg in messages:
+        print(msg)

--- a/.geode/skills/pdf/scripts/check_bounding_boxes_test.py
+++ b/.geode/skills/pdf/scripts/check_bounding_boxes_test.py
@@ -1,0 +1,226 @@
+import unittest
+import json
+import io
+from check_bounding_boxes import get_bounding_box_messages
+
+
+# Currently this is not run automatically in CI; it's just for documentation and manual checking.
+class TestGetBoundingBoxMessages(unittest.TestCase):
+    
+    def create_json_stream(self, data):
+        """Helper to create a JSON stream from data"""
+        return io.StringIO(json.dumps(data))
+    
+    def test_no_intersections(self):
+        """Test case with no bounding box intersections"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 30]
+                },
+                {
+                    "description": "Email",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 40, 50, 60],
+                    "entry_bounding_box": [60, 40, 150, 60]
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("SUCCESS" in msg for msg in messages))
+        self.assertFalse(any("FAILURE" in msg for msg in messages))
+    
+    def test_label_entry_intersection_same_field(self):
+        """Test intersection between label and entry of the same field"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 60, 30],
+                    "entry_bounding_box": [50, 10, 150, 30]  # Overlaps with label
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("FAILURE" in msg and "intersection" in msg for msg in messages))
+        self.assertFalse(any("SUCCESS" in msg for msg in messages))
+    
+    def test_intersection_between_different_fields(self):
+        """Test intersection between bounding boxes of different fields"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 30]
+                },
+                {
+                    "description": "Email",
+                    "page_number": 1,
+                    "label_bounding_box": [40, 20, 80, 40],  # Overlaps with Name's boxes
+                    "entry_bounding_box": [160, 10, 250, 30]
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("FAILURE" in msg and "intersection" in msg for msg in messages))
+        self.assertFalse(any("SUCCESS" in msg for msg in messages))
+    
+    def test_different_pages_no_intersection(self):
+        """Test that boxes on different pages don't count as intersecting"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 30]
+                },
+                {
+                    "description": "Email",
+                    "page_number": 2,
+                    "label_bounding_box": [10, 10, 50, 30],  # Same coordinates but different page
+                    "entry_bounding_box": [60, 10, 150, 30]
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("SUCCESS" in msg for msg in messages))
+        self.assertFalse(any("FAILURE" in msg for msg in messages))
+    
+    def test_entry_height_too_small(self):
+        """Test that entry box height is checked against font size"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 20],  # Height is 10
+                    "entry_text": {
+                        "font_size": 14  # Font size larger than height
+                    }
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("FAILURE" in msg and "height" in msg for msg in messages))
+        self.assertFalse(any("SUCCESS" in msg for msg in messages))
+    
+    def test_entry_height_adequate(self):
+        """Test that adequate entry box height passes"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 30],  # Height is 20
+                    "entry_text": {
+                        "font_size": 14  # Font size smaller than height
+                    }
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("SUCCESS" in msg for msg in messages))
+        self.assertFalse(any("FAILURE" in msg for msg in messages))
+    
+    def test_default_font_size(self):
+        """Test that default font size is used when not specified"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 20],  # Height is 10
+                    "entry_text": {}  # No font_size specified, should use default 14
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("FAILURE" in msg and "height" in msg for msg in messages))
+        self.assertFalse(any("SUCCESS" in msg for msg in messages))
+    
+    def test_no_entry_text(self):
+        """Test that missing entry_text doesn't cause height check"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [60, 10, 150, 20]  # Small height but no entry_text
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("SUCCESS" in msg for msg in messages))
+        self.assertFalse(any("FAILURE" in msg for msg in messages))
+    
+    def test_multiple_errors_limit(self):
+        """Test that error messages are limited to prevent excessive output"""
+        fields = []
+        # Create many overlapping fields
+        for i in range(25):
+            fields.append({
+                "description": f"Field{i}",
+                "page_number": 1,
+                "label_bounding_box": [10, 10, 50, 30],  # All overlap
+                "entry_bounding_box": [20, 15, 60, 35]   # All overlap
+            })
+        
+        data = {"form_fields": fields}
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        # Should abort after ~20 messages
+        self.assertTrue(any("Aborting" in msg for msg in messages))
+        # Should have some FAILURE messages but not hundreds
+        failure_count = sum(1 for msg in messages if "FAILURE" in msg)
+        self.assertGreater(failure_count, 0)
+        self.assertLess(len(messages), 30)  # Should be limited
+    
+    def test_edge_touching_boxes(self):
+        """Test that boxes touching at edges don't count as intersecting"""
+        data = {
+            "form_fields": [
+                {
+                    "description": "Name",
+                    "page_number": 1,
+                    "label_bounding_box": [10, 10, 50, 30],
+                    "entry_bounding_box": [50, 10, 150, 30]  # Touches at x=50
+                }
+            ]
+        }
+        
+        stream = self.create_json_stream(data)
+        messages = get_bounding_box_messages(stream)
+        self.assertTrue(any("SUCCESS" in msg for msg in messages))
+        self.assertFalse(any("FAILURE" in msg for msg in messages))
+    
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.geode/skills/pdf/scripts/check_fillable_fields.py
+++ b/.geode/skills/pdf/scripts/check_fillable_fields.py
@@ -1,0 +1,12 @@
+import sys
+from pypdf import PdfReader
+
+
+# Script for Claude to run to determine whether a PDF has fillable form fields. See forms.md.
+
+
+reader = PdfReader(sys.argv[1])
+if (reader.get_fields()):
+    print("This PDF has fillable form fields")
+else:
+    print("This PDF does not have fillable form fields; you will need to visually determine where to enter data")

--- a/.geode/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/.geode/skills/pdf/scripts/convert_pdf_to_images.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+from pdf2image import convert_from_path
+
+
+# Converts each page of a PDF to a PNG image.
+
+
+def convert(pdf_path, output_dir, max_dim=1000):
+    images = convert_from_path(pdf_path, dpi=200)
+
+    for i, image in enumerate(images):
+        # Scale image if needed to keep width/height under `max_dim`
+        width, height = image.size
+        if width > max_dim or height > max_dim:
+            scale_factor = min(max_dim / width, max_dim / height)
+            new_width = int(width * scale_factor)
+            new_height = int(height * scale_factor)
+            image = image.resize((new_width, new_height))
+        
+        image_path = os.path.join(output_dir, f"page_{i+1}.png")
+        image.save(image_path)
+        print(f"Saved page {i+1} as {image_path} (size: {image.size})")
+
+    print(f"Converted {len(images)} pages to PNG images")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: convert_pdf_to_images.py [input pdf] [output directory]")
+        sys.exit(1)
+    pdf_path = sys.argv[1]
+    output_directory = sys.argv[2]
+    convert(pdf_path, output_directory)

--- a/.geode/skills/pdf/scripts/create_validation_image.py
+++ b/.geode/skills/pdf/scripts/create_validation_image.py
@@ -1,0 +1,41 @@
+import json
+import sys
+
+from PIL import Image, ImageDraw
+
+
+# Creates "validation" images with rectangles for the bounding box information that
+# Claude creates when determining where to add text annotations in PDFs. See forms.md.
+
+
+def create_validation_image(page_number, fields_json_path, input_path, output_path):
+    # Input file should be in the `fields.json` format described in forms.md.
+    with open(fields_json_path, 'r') as f:
+        data = json.load(f)
+
+        img = Image.open(input_path)
+        draw = ImageDraw.Draw(img)
+        num_boxes = 0
+        
+        for field in data["form_fields"]:
+            if field["page_number"] == page_number:
+                entry_box = field['entry_bounding_box']
+                label_box = field['label_bounding_box']
+                # Draw red rectangle over entry bounding box and blue rectangle over the label.
+                draw.rectangle(entry_box, outline='red', width=2)
+                draw.rectangle(label_box, outline='blue', width=2)
+                num_boxes += 2
+        
+        img.save(output_path)
+        print(f"Created validation image at {output_path} with {num_boxes} bounding boxes")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("Usage: create_validation_image.py [page number] [fields.json file] [input image path] [output image path]")
+        sys.exit(1)
+    page_number = int(sys.argv[1])
+    fields_json_path = sys.argv[2]
+    input_image_path = sys.argv[3]
+    output_image_path = sys.argv[4]
+    create_validation_image(page_number, fields_json_path, input_image_path, output_image_path)

--- a/.geode/skills/pdf/scripts/extract_form_field_info.py
+++ b/.geode/skills/pdf/scripts/extract_form_field_info.py
@@ -1,0 +1,152 @@
+import json
+import sys
+
+from pypdf import PdfReader
+
+
+# Extracts data for the fillable form fields in a PDF and outputs JSON that
+# Claude uses to fill the fields. See forms.md.
+
+
+# This matches the format used by PdfReader `get_fields` and `update_page_form_field_values` methods.
+def get_full_annotation_field_id(annotation):
+    components = []
+    while annotation:
+        field_name = annotation.get('/T')
+        if field_name:
+            components.append(field_name)
+        annotation = annotation.get('/Parent')
+    return ".".join(reversed(components)) if components else None
+
+
+def make_field_dict(field, field_id):
+    field_dict = {"field_id": field_id}
+    ft = field.get('/FT')
+    if ft == "/Tx":
+        field_dict["type"] = "text"
+    elif ft == "/Btn":
+        field_dict["type"] = "checkbox"  # radio groups handled separately
+        states = field.get("/_States_", [])
+        if len(states) == 2:
+            # "/Off" seems to always be the unchecked value, as suggested by
+            # https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf#page=448
+            # It can be either first or second in the "/_States_" list.
+            if "/Off" in states:
+                field_dict["checked_value"] = states[0] if states[0] != "/Off" else states[1]
+                field_dict["unchecked_value"] = "/Off"
+            else:
+                print(f"Unexpected state values for checkbox `${field_id}`. Its checked and unchecked values may not be correct; if you're trying to check it, visually verify the results.")
+                field_dict["checked_value"] = states[0]
+                field_dict["unchecked_value"] = states[1]
+    elif ft == "/Ch":
+        field_dict["type"] = "choice"
+        states = field.get("/_States_", [])
+        field_dict["choice_options"] = [{
+            "value": state[0],
+            "text": state[1],
+        } for state in states]
+    else:
+        field_dict["type"] = f"unknown ({ft})"
+    return field_dict
+
+
+# Returns a list of fillable PDF fields:
+# [
+#   {
+#     "field_id": "name",
+#     "page": 1,
+#     "type": ("text", "checkbox", "radio_group", or "choice")
+#     // Per-type additional fields described in forms.md
+#   },
+# ]
+def get_field_info(reader: PdfReader):
+    fields = reader.get_fields()
+
+    field_info_by_id = {}
+    possible_radio_names = set()
+
+    for field_id, field in fields.items():
+        # Skip if this is a container field with children, except that it might be
+        # a parent group for radio button options.
+        if field.get("/Kids"):
+            if field.get("/FT") == "/Btn":
+                possible_radio_names.add(field_id)
+            continue
+        field_info_by_id[field_id] = make_field_dict(field, field_id)
+
+    # Bounding rects are stored in annotations in page objects.
+
+    # Radio button options have a separate annotation for each choice;
+    # all choices have the same field name.
+    # See https://westhealth.github.io/exploring-fillable-forms-with-pdfrw.html
+    radio_fields_by_id = {}
+
+    for page_index, page in enumerate(reader.pages):
+        annotations = page.get('/Annots', [])
+        for ann in annotations:
+            field_id = get_full_annotation_field_id(ann)
+            if field_id in field_info_by_id:
+                field_info_by_id[field_id]["page"] = page_index + 1
+                field_info_by_id[field_id]["rect"] = ann.get('/Rect')
+            elif field_id in possible_radio_names:
+                try:
+                    # ann['/AP']['/N'] should have two items. One of them is '/Off',
+                    # the other is the active value.
+                    on_values = [v for v in ann["/AP"]["/N"] if v != "/Off"]
+                except KeyError:
+                    continue
+                if len(on_values) == 1:
+                    rect = ann.get("/Rect")
+                    if field_id not in radio_fields_by_id:
+                        radio_fields_by_id[field_id] = {
+                            "field_id": field_id,
+                            "type": "radio_group",
+                            "page": page_index + 1,
+                            "radio_options": [],
+                        }
+                    # Note: at least on macOS 15.7, Preview.app doesn't show selected
+                    # radio buttons correctly. (It does if you remove the leading slash
+                    # from the value, but that causes them not to appear correctly in
+                    # Chrome/Firefox/Acrobat/etc).
+                    radio_fields_by_id[field_id]["radio_options"].append({
+                        "value": on_values[0],
+                        "rect": rect,
+                    })
+
+    # Some PDFs have form field definitions without corresponding annotations,
+    # so we can't tell where they are. Ignore these fields for now.
+    fields_with_location = []
+    for field_info in field_info_by_id.values():
+        if "page" in field_info:
+            fields_with_location.append(field_info)
+        else:
+            print(f"Unable to determine location for field id: {field_info.get('field_id')}, ignoring")
+
+    # Sort by page number, then Y position (flipped in PDF coordinate system), then X.
+    def sort_key(f):
+        if "radio_options" in f:
+            rect = f["radio_options"][0]["rect"] or [0, 0, 0, 0]
+        else:
+            rect = f.get("rect") or [0, 0, 0, 0]
+        adjusted_position = [-rect[1], rect[0]]
+        return [f.get("page"), adjusted_position]
+    
+    sorted_fields = fields_with_location + list(radio_fields_by_id.values())
+    sorted_fields.sort(key=sort_key)
+
+    return sorted_fields
+
+
+def write_field_info(pdf_path: str, json_output_path: str):
+    reader = PdfReader(pdf_path)
+    field_info = get_field_info(reader)
+    with open(json_output_path, "w") as f:
+        json.dump(field_info, f, indent=2)
+    print(f"Wrote {len(field_info)} fields to {json_output_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: extract_form_field_info.py [input pdf] [output json]")
+        sys.exit(1)
+    write_field_info(sys.argv[1], sys.argv[2])

--- a/.geode/skills/pdf/scripts/fill_fillable_fields.py
+++ b/.geode/skills/pdf/scripts/fill_fillable_fields.py
@@ -1,0 +1,114 @@
+import json
+import sys
+
+from pypdf import PdfReader, PdfWriter
+
+from extract_form_field_info import get_field_info
+
+
+# Fills fillable form fields in a PDF. See forms.md.
+
+
+def fill_pdf_fields(input_pdf_path: str, fields_json_path: str, output_pdf_path: str):
+    with open(fields_json_path) as f:
+        fields = json.load(f)
+    # Group by page number.
+    fields_by_page = {}
+    for field in fields:
+        if "value" in field:
+            field_id = field["field_id"]
+            page = field["page"]
+            if page not in fields_by_page:
+                fields_by_page[page] = {}
+            fields_by_page[page][field_id] = field["value"]
+    
+    reader = PdfReader(input_pdf_path)
+
+    has_error = False
+    field_info = get_field_info(reader)
+    fields_by_ids = {f["field_id"]: f for f in field_info}
+    for field in fields:
+        existing_field = fields_by_ids.get(field["field_id"])
+        if not existing_field:
+            has_error = True
+            print(f"ERROR: `{field['field_id']}` is not a valid field ID")
+        elif field["page"] != existing_field["page"]:
+            has_error = True
+            print(f"ERROR: Incorrect page number for `{field['field_id']}` (got {field['page']}, expected {existing_field['page']})")
+        else:
+            if "value" in field:
+                err = validation_error_for_field_value(existing_field, field["value"])
+                if err:
+                    print(err)
+                    has_error = True
+    if has_error:
+        sys.exit(1)
+
+    writer = PdfWriter(clone_from=reader)
+    for page, field_values in fields_by_page.items():
+        writer.update_page_form_field_values(writer.pages[page - 1], field_values, auto_regenerate=False)
+
+    # This seems to be necessary for many PDF viewers to format the form values correctly.
+    # It may cause the viewer to show a "save changes" dialog even if the user doesn't make any changes.
+    writer.set_need_appearances_writer(True)
+    
+    with open(output_pdf_path, "wb") as f:
+        writer.write(f)
+
+
+def validation_error_for_field_value(field_info, field_value):
+    field_type = field_info["type"]
+    field_id = field_info["field_id"]
+    if field_type == "checkbox":
+        checked_val = field_info["checked_value"]
+        unchecked_val = field_info["unchecked_value"]
+        if field_value != checked_val and field_value != unchecked_val:
+            return f'ERROR: Invalid value "{field_value}" for checkbox field "{field_id}". The checked value is "{checked_val}" and the unchecked value is "{unchecked_val}"'
+    elif field_type == "radio_group":
+        option_values = [opt["value"] for opt in field_info["radio_options"]]
+        if field_value not in option_values:
+            return f'ERROR: Invalid value "{field_value}" for radio group field "{field_id}". Valid values are: {option_values}' 
+    elif field_type == "choice":
+        choice_values = [opt["value"] for opt in field_info["choice_options"]]
+        if field_value not in choice_values:
+            return f'ERROR: Invalid value "{field_value}" for choice field "{field_id}". Valid values are: {choice_values}'
+    return None
+
+
+# pypdf (at least version 5.7.0) has a bug when setting the value for a selection list field.
+# In _writer.py around line 966:
+#
+# if field.get(FA.FT, "/Tx") == "/Ch" and field_flags & FA.FfBits.Combo == 0:
+#     txt = "\n".join(annotation.get_inherited(FA.Opt, []))
+#
+# The problem is that for selection lists, `get_inherited` returns a list of two-element lists like
+# [["value1", "Text 1"], ["value2", "Text 2"], ...]
+# This causes `join` to throw a TypeError because it expects an iterable of strings.
+# The horrible workaround is to patch `get_inherited` to return a list of the value strings.
+# We call the original method and adjust the return value only if the argument to `get_inherited`
+# is `FA.Opt` and if the return value is a list of two-element lists.
+def monkeypatch_pydpf_method():
+    from pypdf.generic import DictionaryObject
+    from pypdf.constants import FieldDictionaryAttributes
+
+    original_get_inherited = DictionaryObject.get_inherited
+
+    def patched_get_inherited(self, key: str, default = None):
+        result = original_get_inherited(self, key, default)
+        if key == FieldDictionaryAttributes.Opt:
+            if isinstance(result, list) and all(isinstance(v, list) and len(v) == 2 for v in result):
+                result = [r[0] for r in result]
+        return result
+
+    DictionaryObject.get_inherited = patched_get_inherited
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: fill_fillable_fields.py [input pdf] [field_values.json] [output pdf]")
+        sys.exit(1)
+    monkeypatch_pydpf_method()
+    input_pdf = sys.argv[1]
+    fields_json = sys.argv[2]
+    output_pdf = sys.argv[3]
+    fill_pdf_fields(input_pdf, fields_json, output_pdf)

--- a/.geode/skills/pdf/scripts/fill_pdf_form_with_annotations.py
+++ b/.geode/skills/pdf/scripts/fill_pdf_form_with_annotations.py
@@ -1,0 +1,108 @@
+import json
+import sys
+
+from pypdf import PdfReader, PdfWriter
+from pypdf.annotations import FreeText
+
+
+# Fills a PDF by adding text annotations defined in `fields.json`. See forms.md.
+
+
+def transform_coordinates(bbox, image_width, image_height, pdf_width, pdf_height):
+    """Transform bounding box from image coordinates to PDF coordinates"""
+    # Image coordinates: origin at top-left, y increases downward
+    # PDF coordinates: origin at bottom-left, y increases upward
+    x_scale = pdf_width / image_width
+    y_scale = pdf_height / image_height
+    
+    left = bbox[0] * x_scale
+    right = bbox[2] * x_scale
+    
+    # Flip Y coordinates for PDF
+    top = pdf_height - (bbox[1] * y_scale)
+    bottom = pdf_height - (bbox[3] * y_scale)
+    
+    return left, bottom, right, top
+
+
+def fill_pdf_form(input_pdf_path, fields_json_path, output_pdf_path):
+    """Fill the PDF form with data from fields.json"""
+    
+    # `fields.json` format described in forms.md.
+    with open(fields_json_path, "r") as f:
+        fields_data = json.load(f)
+    
+    # Open the PDF
+    reader = PdfReader(input_pdf_path)
+    writer = PdfWriter()
+    
+    # Copy all pages to writer
+    writer.append(reader)
+    
+    # Get PDF dimensions for each page
+    pdf_dimensions = {}
+    for i, page in enumerate(reader.pages):
+        mediabox = page.mediabox
+        pdf_dimensions[i + 1] = [mediabox.width, mediabox.height]
+    
+    # Process each form field
+    annotations = []
+    for field in fields_data["form_fields"]:
+        page_num = field["page_number"]
+        
+        # Get page dimensions and transform coordinates.
+        page_info = next(p for p in fields_data["pages"] if p["page_number"] == page_num)
+        image_width = page_info["image_width"]
+        image_height = page_info["image_height"]
+        pdf_width, pdf_height = pdf_dimensions[page_num]
+        
+        transformed_entry_box = transform_coordinates(
+            field["entry_bounding_box"],
+            image_width, image_height,
+            pdf_width, pdf_height
+        )
+        
+        # Skip empty fields
+        if "entry_text" not in field or "text" not in field["entry_text"]:
+            continue
+        entry_text = field["entry_text"]
+        text = entry_text["text"]
+        if not text:
+            continue
+        
+        font_name = entry_text.get("font", "Arial")
+        font_size = str(entry_text.get("font_size", 14)) + "pt"
+        font_color = entry_text.get("font_color", "000000")
+
+        # Font size/color seems to not work reliably across viewers:
+        # https://github.com/py-pdf/pypdf/issues/2084
+        annotation = FreeText(
+            text=text,
+            rect=transformed_entry_box,
+            font=font_name,
+            font_size=font_size,
+            font_color=font_color,
+            border_color=None,
+            background_color=None,
+        )
+        annotations.append(annotation)
+        # page_number is 0-based for pypdf
+        writer.add_annotation(page_number=page_num - 1, annotation=annotation)
+        
+    # Save the filled PDF
+    with open(output_pdf_path, "wb") as output:
+        writer.write(output)
+    
+    print(f"Successfully filled PDF form and saved to {output_pdf_path}")
+    print(f"Added {len(annotations)} text annotations")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: fill_pdf_form_with_annotations.py [input pdf] [fields.json] [output pdf]")
+        sys.exit(1)
+    input_pdf = sys.argv[1]
+    fields_json = sys.argv[2]
+    output_pdf = sys.argv[3]
+    
+    fill_pdf_form(input_pdf, fields_json, output_pdf)

--- a/.geode/skills/pr-reviewer/SKILL.md
+++ b/.geode/skills/pr-reviewer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pr-reviewer
+visibility: public
 description: Automated Git PR review — diff analysis + quality checks. Triggers: 'review', 'PR 리뷰', '코드 리뷰', 'diff', '풀리퀘스트 검토'.
 tools: run_bash, memory_save
 risk: safe

--- a/.geode/skills/wiki-sync/SKILL.md
+++ b/.geode/skills/wiki-sync/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: wiki-sync
+visibility: public
+description: GEODE 리서치/지식을 mango-wiki (Obsidian vault)에 인제스트. Triggers: 'wiki', '위키', 'vault', 'wiki-sync', '위키 동기화', 'wiki render', '위키 렌더링'.
+tools: web_search, web_fetch, memory_save
+risk: safe
+---
+
+# Wiki Sync — GEODE to mango-wiki
+
+GEODE에서 생성된 리서치, 분석 결과, 아키텍처 문서를 mango-wiki Obsidian vault에 인제스트.
+
+## Target Vault
+
+```
+/Users/mango/workspace/mango-wiki/vault/
+```
+
+## Workflow
+
+### 1. Source Identification
+
+GEODE 내 인제스트 대상 소스 탐지:
+- `docs/research/*.md` — 리서치 문서
+- `docs/architecture/*.md` — 아키텍처 문서
+- `docs/plans/_done/*.md` — 완료된 계획
+- `.geode/memory/PROJECT.md` — 프로젝트 메모리
+
+### 2. Delta Check
+
+mango-wiki의 `.manifest.json`을 읽어 이미 인제스트된 소스를 확인.
+이미 있는 소스는 스킵하거나 업데이트 판단.
+
+### 3. Page Generation
+
+Obsidian wiki 포맷으로 변환. 반드시 아래 구조를 따른다:
+
+```yaml
+---
+title: Page Title
+type: concept | reference | entity
+category: topic-area
+tags: [tag1, tag2, tag3]
+related:
+  - "[[other-page]]"
+sources:
+  - "source reference"
+created: 2026-01-01T00:00:00Z
+updated: 2026-01-01T00:00:00Z
+summary: "1-2 sentence summary for tiered retrieval"
+---
+```
+
+### Page Type Routing
+
+| Source Type | Vault Location | Page Type |
+|------------|---------------|-----------|
+| Research paper analysis | `vault/concepts/` | concept |
+| Architecture doc | `vault/projects/geode/concepts/` | concept |
+| Blog post | `vault/projects/geode/references/blog/` | reference |
+| Tool/library review | `vault/references/` | reference |
+| Person/org profile | `vault/entities/` | entity |
+
+### 4. Cross-Linking
+
+- 기존 vault 페이지와 `[[wikilinks]]`로 연결
+- 최소 2개 이상의 related 링크 포함
+- GEODE 관련 페이지는 반드시 `[[geode-architecture]]` 또는 `[[geode-agentic-loop]]` 등 기존 GEODE 페이지와 연결
+
+### 5. Manifest & Index Update
+
+인제스트 후 반드시 업데이트:
+1. `vault/.manifest.json` — 소스 항목 + stats 카운트
+2. `vault/index.md` — 새 페이지를 적절한 섹션에 추가
+3. `vault/log.md` — 인제스트 로그 한 줄 추가
+
+### 6. Blog Post Generation (Optional)
+
+`/wiki-sync blog` 또는 "블로그도 써줘"라고 요청하면:
+- vault의 concept 페이지 기반으로 기술 블로그 포스트 작성
+- `vault/projects/geode/references/blog/` 에 저장
+- rooftopsnow.tistory.com 스타일: 한국어 기술 산문, 코드 블록 + 설계 의도 코멘트
+
+## Rules
+
+- **Compile, don't retrieve**: 원본 복사가 아닌 지식 압축
+- **Merge over create**: 기존 페이지가 있으면 업데이트
+- **Provenance tracking**: 모든 claim에 source attribution
+- **No placeholders**: 측정된 값만 기록

--- a/.gitignore
+++ b/.gitignore
@@ -40,12 +40,19 @@ geode_checkpoints.db
 !.geode/skills/
 
 # Personal skills — never commit (use .geode/skills/TEMPLATE.md as guide)
+# These belong in ~/.geode/skills/ (personal tier), not .geode/skills/ (project tier)
 .geode/skills/job-hunter/
 .geode/skills/expense-tracker/
 .geode/skills/youtube-planner/
 .geode/skills/daily-briefing/
 .geode/skills/weekly-retro/
 .geode/skills/slack-digest/
+.geode/skills/anthropic-philosophy/
+.geode/skills/coverletter-patterns/
+.geode/skills/eco2-context/
+.geode/skills/engineer-profile/
+.geode/skills/resume-tailoring/
+.geode/skills/resume-writer/
 
 # Personal memory — never commit
 .geode/memory/PROJECT.md

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -135,6 +135,11 @@ app = typer.Typer(
     invoke_without_command=True,
 )
 
+# Subcommand groups
+from core.cli.cmd_skill import app as skill_app  # noqa: E402
+
+app.add_typer(skill_app, name="skill")
+
 # ---------------------------------------------------------------------------
 # Interactive welcome screen
 # ---------------------------------------------------------------------------

--- a/core/cli/cmd_skill.py
+++ b/core/cli/cmd_skill.py
@@ -51,9 +51,7 @@ def _discover_skills() -> list[dict[str, str]]:
 
 @app.command(name="list")
 def skill_list(
-    all_: Annotated[
-        bool, typer.Option("--all", "-a", help="Include unlisted skills")
-    ] = False,
+    all_: Annotated[bool, typer.Option("--all", "-a", help="Include unlisted skills")] = False,
 ) -> None:
     """List available skills with visibility and tier."""
     skills = _discover_skills()

--- a/core/cli/cmd_skill.py
+++ b/core/cli/cmd_skill.py
@@ -1,0 +1,168 @@
+"""CLI subcommand: geode skill — manage skills (list/create/install).
+
+3-tier skill storage:
+  tier 1: core/skills/        — builtin (repo)
+  tier 2: .geode/skills/      — project (team)
+  tier 3: ~/.geode/skills/    — personal (local only)
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from core.skills._frontmatter import parse_yaml_frontmatter
+
+app = typer.Typer(name="skill", help="Manage GEODE skills (list/create/install).")
+
+_PROJECT_SKILLS = Path(".geode/skills")
+_PERSONAL_SKILLS = Path.home() / ".geode" / "skills"
+
+
+def _discover_skills() -> list[dict[str, str]]:
+    """Discover all skills across 3 tiers."""
+    results: list[dict[str, str]] = []
+
+    for tier, base in [("project", _PROJECT_SKILLS), ("personal", _PERSONAL_SKILLS)]:
+        if not base.exists():
+            continue
+        for skill_dir in sorted(base.iterdir()):
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            text = skill_md.read_text(encoding="utf-8")
+            meta, _body = parse_yaml_frontmatter(text)
+            if not meta:
+                continue
+            results.append(
+                {
+                    "name": meta.get("name", skill_dir.name),
+                    "description": meta.get("description", "")[:60],
+                    "visibility": meta.get("visibility", "public"),
+                    "tier": tier,
+                    "path": str(skill_dir),
+                }
+            )
+    return results
+
+
+@app.command(name="list")
+def skill_list(
+    all_: Annotated[
+        bool, typer.Option("--all", "-a", help="Include unlisted skills")
+    ] = False,
+) -> None:
+    """List available skills with visibility and tier."""
+    skills = _discover_skills()
+    if not all_:
+        skills = [s for s in skills if s["visibility"] != "unlisted"]
+
+    if not skills:
+        typer.echo("No skills found.")
+        raise typer.Exit()
+
+    # Header
+    typer.echo(f"{'NAME':<25} {'VISIBILITY':<12} {'TIER':<10} DESCRIPTION")
+    typer.echo("-" * 80)
+    for s in skills:
+        typer.echo(f"{s['name']:<25} {s['visibility']:<12} {s['tier']:<10} {s['description']}")
+    typer.echo(f"\n{len(skills)} skills found.")
+
+
+@app.command()
+def create(
+    name: Annotated[str, typer.Argument(help="Skill name (e.g. 'my-tool')")],
+    private: Annotated[
+        bool, typer.Option("--private", "-p", help="Create in personal tier (~/.geode/skills/)")
+    ] = False,
+    description: Annotated[str, typer.Option("--desc", "-d", help="Skill description")] = "",
+) -> None:
+    """Create a new skill from template."""
+    base = _PERSONAL_SKILLS if private else _PROJECT_SKILLS
+    skill_dir = base / name
+    if skill_dir.exists():
+        typer.echo(f"Skill '{name}' already exists at {skill_dir}", err=True)
+        raise typer.Exit(1)
+
+    visibility = "private" if private else "public"
+    desc = description or f"{name} skill"
+
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        f"""---
+name: {name}
+description: {desc}
+visibility: {visibility}
+---
+
+# {name}
+
+Add your skill instructions here.
+""",
+        encoding="utf-8",
+    )
+
+    tier = "personal" if private else "project"
+    typer.echo(f"Created skill '{name}' ({visibility}) at {skill_dir}")
+
+    # Auto-add to .gitignore if private and in project dir
+    if private:
+        typer.echo(f"  tier: {tier} (not committed to git)")
+    else:
+        typer.echo(f"  tier: {tier}")
+        _ensure_gitignore_if_private(name, visibility)
+
+
+@app.command()
+def remove(
+    name: Annotated[str, typer.Argument(help="Skill name to remove")],
+) -> None:
+    """Remove a skill."""
+    for base in [_PROJECT_SKILLS, _PERSONAL_SKILLS]:
+        skill_dir = base / name
+        if skill_dir.exists():
+            shutil.rmtree(skill_dir)
+            typer.echo(f"Removed skill '{name}' from {base}")
+            return
+    typer.echo(f"Skill '{name}' not found.", err=True)
+    raise typer.Exit(1)
+
+
+@app.command()
+def show(
+    name: Annotated[str, typer.Argument(help="Skill name to inspect")],
+) -> None:
+    """Show skill details and content."""
+    for base in [_PROJECT_SKILLS, _PERSONAL_SKILLS]:
+        skill_dir = base / name
+        skill_md = skill_dir / "SKILL.md"
+        if skill_md.exists():
+            text = skill_md.read_text(encoding="utf-8")
+            meta, body = parse_yaml_frontmatter(text)
+            typer.echo(f"Name:        {meta.get('name', name)}")
+            typer.echo(f"Visibility:  {meta.get('visibility', 'public')}")
+            typer.echo(f"Path:        {skill_dir}")
+            typer.echo(f"Description: {meta.get('description', '')[:100]}")
+            if body.strip():
+                typer.echo(f"\n--- Content ---\n{body.strip()[:500]}")
+            return
+    typer.echo(f"Skill '{name}' not found.", err=True)
+    raise typer.Exit(1)
+
+
+def _ensure_gitignore_if_private(name: str, visibility: str) -> None:
+    """Add private skill to .gitignore if needed."""
+    if visibility != "private":
+        return
+    gitignore = Path(".gitignore")
+    if not gitignore.exists():
+        return
+    pattern = f".geode/skills/{name}/"
+    content = gitignore.read_text(encoding="utf-8")
+    if pattern not in content:
+        with gitignore.open("a", encoding="utf-8") as f:
+            f.write(f"\n{pattern}\n")

--- a/core/skills/skills.py
+++ b/core/skills/skills.py
@@ -52,6 +52,7 @@ class SkillDefinition(BaseModel):
     source: str = ""
     risk: str = "safe"
     # --- Skill 2.0 fields (Agent Skills spec extensions) ---
+    visibility: str = "public"  # public | private | unlisted
     user_invocable: bool = True  # False = background knowledge, hidden from /skills
     context_fork: bool = False  # True = run in isolated subagent
     argument_hint: str = ""  # autocomplete hint, e.g. "[issue-number]"

--- a/tests/test_cmd_skill.py
+++ b/tests/test_cmd_skill.py
@@ -1,0 +1,83 @@
+"""Tests for geode skill CLI (core/cli/cmd_skill.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.cli.cmd_skill import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestSkillList:
+    def test_list_returns_success(self, tmp_path: Path, monkeypatch: object):
+        result = runner.invoke(app, ["list"])
+        # Should not crash — may have 0 or more skills
+        assert result.exit_code == 0
+
+    def test_list_all_includes_unlisted(self, tmp_path: Path):
+        result = runner.invoke(app, ["list", "--all"])
+        assert result.exit_code == 0
+
+
+class TestSkillCreate:
+    def test_create_public(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".geode" / "skills").mkdir(parents=True)
+        result = runner.invoke(app, ["create", "test-skill", "--desc", "A test skill"])
+        assert result.exit_code == 0
+        assert "Created skill" in result.output
+        skill_md = tmp_path / ".geode" / "skills" / "test-skill" / "SKILL.md"
+        assert skill_md.exists()
+        content = skill_md.read_text()
+        assert "visibility: public" in content
+
+    def test_create_private(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        personal = tmp_path / "personal_skills"
+        monkeypatch.setattr("core.cli.cmd_skill._PERSONAL_SKILLS", personal)
+        result = runner.invoke(app, ["create", "secret-skill", "--private", "--desc", "Private"])
+        assert result.exit_code == 0
+        assert "private" in result.output
+        assert (personal / "secret-skill" / "SKILL.md").exists()
+
+    def test_create_duplicate_fails(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        skill_dir = tmp_path / ".geode" / "skills" / "existing"
+        skill_dir.mkdir(parents=True)
+        result = runner.invoke(app, ["create", "existing"])
+        assert result.exit_code == 1
+
+
+class TestSkillShow:
+    def test_show_existing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        skill_dir = tmp_path / ".geode" / "skills" / "demo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: demo\ndescription: Demo skill\nvisibility: public\n---\n\n# Demo\nHello",
+        )
+        result = runner.invoke(app, ["show", "demo"])
+        assert result.exit_code == 0
+        assert "demo" in result.output
+        assert "public" in result.output
+
+    def test_show_not_found(self):
+        result = runner.invoke(app, ["show", "nonexistent-skill-xyz"])
+        assert result.exit_code == 1
+
+
+class TestSkillRemove:
+    def test_remove_existing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        skill_dir = tmp_path / ".geode" / "skills" / "to-delete"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: to-delete\n---\n")
+        result = runner.invoke(app, ["remove", "to-delete"])
+        assert result.exit_code == 0
+        assert not skill_dir.exists()
+
+    def test_remove_not_found(self):
+        result = runner.invoke(app, ["remove", "nonexistent-xyz"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- `geode skill list/create/show/remove` CLI 서브커맨드 추가
- SKILL.md `visibility` 필드 규격 (public/private/unlisted)
- 개인 skills 6개를 ~/.geode/skills/ (tier 3)로 이동

## Why
개인정보 포함 skills (이력서, 경력 등)과 공개 가능 skills이 같은 디렉토리에 혼재.
유저가 skill을 관리/생성/탐색할 CLI 인터페이스 부재.

## Changes
| File | Change |
|------|--------|
| `core/cli/cmd_skill.py` | 신규 — list/create/show/remove 4개 서브커맨드 |
| `core/cli/__init__.py` | `app.add_typer(skill_app)` 등록 |
| `core/skills/skills.py` | `SkillDefinition.visibility` 필드 추가 |
| `.geode/skills/TEMPLATE.md` | visibility 가이드 테이블 추가 |
| `.geode/skills/*/SKILL.md` | 8개 skill에 visibility 필드 추가 |
| `.gitignore` | 6개 개인 skill 차단 패턴 추가 |

## Verification
- [x] ruff check clean
- [x] mypy clean
- [x] `geode skill list` 정상 (11 skills)
- [x] `geode skill list --all` 정상 (13 skills, unlisted 포함)
- [x] `geode skill create test --private` + `geode skill remove test` 정상
- [x] `geode skill show pdf` 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)