### PR TITLE
fix: test isolation — settings.model contamination

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -244,11 +244,12 @@ class TestCmdModel:
 
     def test_same_model_noop(self, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        from core.config import settings
+        from core.config import ANTHROPIC_PRIMARY, settings
 
-        old = settings.model
-        cmd_model(old)
-        assert settings.model == old
+        # Use explicit model to avoid cross-test settings.model contamination
+        monkeypatch.setattr(settings, "model", ANTHROPIC_PRIMARY)
+        cmd_model(ANTHROPIC_PRIMARY)
+        assert settings.model == ANTHROPIC_PRIMARY
 
 
 class TestApplyModel:
@@ -265,10 +266,11 @@ class TestApplyModel:
 
     def test_apply_same_model(self, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        from core.config import settings
+        from core.config import ANTHROPIC_PRIMARY, settings
 
-        # Should not write .env when model unchanged
-        _apply_model(next(p for p in MODEL_PROFILES if p.id == settings.model))
+        # Use explicit model to avoid cross-test contamination
+        monkeypatch.setattr(settings, "model", ANTHROPIC_PRIMARY)
+        _apply_model(next(p for p in MODEL_PROFILES if p.id == ANTHROPIC_PRIMARY))
 
     def test_apply_model_defers_hot_swap(self, tmp_path: Path, monkeypatch):
         """_apply_model() updates settings only — loop sync is deferred to round boundary."""


### PR DESCRIPTION
## Summary
- `test_same_model_noop`, `test_apply_same_model` — `monkeypatch.setattr` 로 명시적 모델 설정

## Why
GLM_PRIMARY가 `glm-5` → `glm-5.1`로 변경된 후, 다른 테스트에서 `settings.model`을 `glm-5`로 설정하고 복원하지 않아 전체 스위트에서만 fail 발생.

## Changes
| File | Change |
|------|--------|
| `tests/test_commands.py` | 2개 테스트에서 `monkeypatch.setattr(settings, "model", ANTHROPIC_PRIMARY)` 적용 |

## Verification
- [x] 3994 passed, 0 failed (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)