### PR TITLE
feat: add Claude Opus 4.7 — promote to ANTHROPIC_PRIMARY

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -349,10 +349,10 @@ settings = _get_settings()
 # ---------------------------------------------------------------------------
 
 # Anthropic models
-ANTHROPIC_PRIMARY = "claude-opus-4-6"
+ANTHROPIC_PRIMARY = "claude-opus-4-7"
 ANTHROPIC_SECONDARY = "claude-sonnet-4-6"
 ANTHROPIC_BUDGET = "claude-haiku-4-5-20251001"
-ANTHROPIC_FALLBACK_CHAIN: list[str] = [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY]
+ANTHROPIC_FALLBACK_CHAIN: list[str] = [ANTHROPIC_PRIMARY, "claude-opus-4-6", ANTHROPIC_SECONDARY]
 
 # OpenAI models
 OPENAI_PRIMARY = "gpt-5.4"

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -150,8 +150,9 @@ def _oai(
 
 # fmt: off
 MODEL_PRICING: dict[str, ModelPrice] = {
-    # ── Anthropic (verified 2026-03-19) ────────────────────────────────
+    # ── Anthropic (verified 2026-04-23) ────────────────────────────────
     # Source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    "claude-opus-4-7":            _ant(5.00,  25.00),
     "claude-opus-4-6":            _ant(5.00,  25.00),
     "claude-opus-4-5":            _ant(5.00,  25.00),
     "claude-opus-4-1":            _ant(15.00, 75.00),
@@ -198,6 +199,7 @@ MODEL_PRICING: dict[str, ModelPrice] = {
 
 # fmt: off
 MODEL_CONTEXT_WINDOW: dict[str, int] = {
+    "claude-opus-4-7":          1_000_000,
     "claude-opus-4-6":          1_000_000,
     "claude-opus-4-5":            200_000,
     "claude-opus-4-1":            200_000,

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -19,7 +19,6 @@ from core.agent.tool_executor import ToolExecutor
 from core.config import (
     ANTHROPIC_FALLBACK_CHAIN,
     ANTHROPIC_PRIMARY,
-    ANTHROPIC_SECONDARY,
     GLM_FALLBACK_CHAIN,
     OPENAI_FALLBACK_CHAIN,
     OPENAI_PRIMARY,

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -58,13 +58,14 @@ class TestModelEscalation:
         assert loop._ESCALATION_THRESHOLD == 2
 
     def test_try_model_escalation_anthropic_chain(self) -> None:
-        """Escalate from primary to secondary within Anthropic chain."""
+        """Escalate from primary to next in fallback chain."""
         loop = _make_loop(model=ANTHROPIC_PRIMARY, provider="anthropic")
         assert loop.model == ANTHROPIC_PRIMARY
 
         result = loop._try_model_escalation()
         assert result is True
-        assert loop.model == ANTHROPIC_SECONDARY
+        # Fallback chain: opus-4-7 → opus-4-6 → sonnet-4-6
+        assert loop.model == "claude-opus-4-6"
         assert loop._provider == "anthropic"
 
     def test_try_model_escalation_openai_chain(self) -> None:


### PR DESCRIPTION
## Summary
- Claude Opus 4.7 추가 (2026-04-16 출시), ANTHROPIC_PRIMARY 승격
- Fallback chain: opus-4-7 → opus-4-6 → sonnet-4-6

## Why
Opus 4.7이 4/16 GA. SW 엔지니어링 성능 향상 + 고해상도 비전 + task budgets.

## Changes
| File | Change |
|------|--------|
| `core/config.py` | ANTHROPIC_PRIMARY → claude-opus-4-7, fallback chain 업데이트 |
| `core/llm/token_tracker.py` | 가격($5/$25) + 컨텍스트(1M) 추가 |

## Verification
- [x] ruff + mypy clean
- [x] 153 related tests passed

## Reference
- https://www.anthropic.com/news/claude-opus-4-7
- https://platform.claude.com/docs/en/about-claude/pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)