### PR TITLE
feat: /model selector — Opus 4.7 + GLM-5.1 label fix

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -45,11 +45,12 @@ class ModelProfile:
 
 
 MODEL_PROFILES: list[ModelProfile] = [
-    ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.6", "$$$"),
+    ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.7", "$$$"),
+    ModelProfile("claude-opus-4-6", "Anthropic", "Opus 4.6", "$$$"),
     ModelProfile(ANTHROPIC_SECONDARY, "Anthropic", "Sonnet 4.6", "$$"),
     ModelProfile(ANTHROPIC_BUDGET, "Anthropic", "Haiku 4.5", "$"),
     ModelProfile(OPENAI_PRIMARY, "OpenAI", "GPT-5.4", "$$"),
-    ModelProfile(GLM_PRIMARY, "ZhipuAI", "GLM-5", "$"),
+    ModelProfile(GLM_PRIMARY, "ZhipuAI", "GLM-5.1", "$"),
     ModelProfile("glm-5-turbo", "ZhipuAI", "GLM-5 Turbo", "$"),
     ModelProfile("glm-4.7-flash", "ZhipuAI", "GLM-4.7 Flash", "$"),
 ]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -259,7 +259,7 @@ class TestApplyModel:
 
         old = settings.model
         try:
-            _apply_model(MODEL_PROFILES[3])  # GPT-5.4
+            _apply_model(next(p for p in MODEL_PROFILES if p.id == OPENAI_PRIMARY))  # GPT-5.4
             assert settings.model == OPENAI_PRIMARY
         finally:
             settings.model = old
@@ -289,7 +289,7 @@ class TestApplyModel:
 
         old = settings.model
         try:
-            target = MODEL_PROFILES[3]  # GPT-5.4
+            target = next(p for p in MODEL_PROFILES if p.id == OPENAI_PRIMARY)  # GPT-5.4
             _apply_model(target)
             # _apply_model no longer calls loop.update_model() directly —
             # AgenticLoop._sync_model_from_settings() handles it at round start.
@@ -309,7 +309,7 @@ class TestApplyModel:
 
         old = settings.model
         try:
-            _apply_model(MODEL_PROFILES[3])
+            _apply_model(next(p for p in MODEL_PROFILES if p.id == OPENAI_PRIMARY))
             assert settings.model == OPENAI_PRIMARY
         finally:
             settings.model = old


### PR DESCRIPTION
## Summary
- /model 선택기에 Opus 4.7 추가 (1순위), Opus 4.6 유지 (2순위)
- GLM-5 라벨 → GLM-5.1 (GLM_PRIMARY와 일치)
- 테스트 인덱스 하드코딩 → 이름 기반 lookup

## Why
/model UI에 Opus 4.7이 없고 GLM 라벨이 outdated

## Changes
| File | Change |
|------|--------|
| `core/cli/commands.py` | MODEL_PROFILES 업데이트 |
| `tests/test_commands.py` | MODEL_PROFILES[3] → name-based lookup |

## Verification
- [x] 67 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)