### PR TITLE
fix: separate GEODE identity from user profile in system prompt

### DIFF
--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -231,6 +231,9 @@ def _build_user_context() -> str:
       ~/.geode/user_profile/preferences.json — language, output format
       ~/.geode/user_profile/learned.md   — learned patterns
       ~/.geode/identity/career.toml      — career summary
+
+    IMPORTANT: This is the USER's profile, not GEODE's identity.
+    GEODE's identity comes from GEODE.md (G1 layer).
     """
     try:
         from core.memory.user_profile import FileBasedUserProfile
@@ -257,7 +260,17 @@ def _build_user_context() -> str:
         if not parts:
             return ""
 
-        return "## User Context\n" + "\n".join(parts)
+        header = (
+            "## User Context (NOT your identity)\n"
+            "The following describes the USER who is talking to you.\n"
+            "This is NOT your self-description. Your identity is GEODE "
+            "(defined in GEODE.md). When asked to introduce yourself, "
+            "describe GEODE's capabilities — never present the user's "
+            "profile as your own.\n"
+            "Use this context to tailor responses to the user's expertise "
+            "and preferences."
+        )
+        return header + "\n" + "\n".join(parts)
     except Exception:
         log.debug("Failed to build user context", exc_info=True)
         return ""
@@ -386,7 +399,12 @@ def _build_learning_context() -> str:
             return ""
 
         capped = patterns[:_MAX_SECTION_LINES]
-        return "## Agent Learning\n" + "\n".join(capped)
+        return (
+            "## Agent Learning (user preferences, NOT your identity)\n"
+            "These are patterns learned from the user's behavior. "
+            "Apply them to tailor responses, but never adopt them as your own traits.\n"
+            + "\n".join(capped)
+        )
     except Exception:
         log.debug("Failed to build learning context (G3)", exc_info=True)
         return ""


### PR DESCRIPTION
## Summary
- 시스템 프롬프트에서 GEODE 자신의 정체성(GEODE.md)과 유저 프로필을 명시적으로 분리

## Why
"자기소개 해줘"에 GEODE가 유저의 경력/이름을 자신의 것으로 소개하는 문제.
`_build_user_context()`와 `_build_learning_context()`에 경계 표시 없이 유저 프로필이 주입되어 LLM이 혼동.

## Changes
| File | Change |
|------|--------|
| `core/agent/system_prompt.py` | User Context 헤더에 "NOT your identity" 가드레일, Agent Learning에 "user preferences" 경계 추가 |

## Verification
- [x] ruff + mypy clean
- [x] 83 prompt-related tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)