### PR TITLE
fix: omit sampling params on Anthropic adaptive-thinking models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Anthropic sampling parameters on adaptive-thinking models** — `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` rejected requests with `temperature` set ("temperature is deprecated for this model" → 400 BadRequest). Sampling parameters are now omitted on adaptive-thinking models per Anthropic's Opus 4.7 breaking change. `claude-opus-4-7` also registered for the context-management + compaction beta. Fixes the `/model` hot-swap to Opus 4.7. Source: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+
 ## [0.49.0] — 2026-04-23
 
 ### Architecture

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -219,10 +219,24 @@ _API_ALLOWED_KEYS = frozenset({"name", "description", "input_schema", "cache_con
 # context_overflow.  Only 1M-context models are known to support it.
 _CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
     {
+        "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-opus-4-5",
         "claude-sonnet-4-6",
         "claude-sonnet-4-5",
+    }
+)
+
+# Adaptive thinking models (Opus 4.6+).  Sampling parameters
+# (temperature/top_p/top_k) are rejected with 400 starting from Opus 4.7
+# (https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+# #sampling-parameters-removed) and are also rejected by Opus 4.6 when
+# adaptive thinking is on.  Omit them entirely on these models.
+_ADAPTIVE_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
     }
 )
 
@@ -345,18 +359,17 @@ class ClaudeAgenticAdapter:
                 }
 
             # Thinking mode: adaptive (4.6+) or legacy budget (older models)
-            _ADAPTIVE_MODELS = {"claude-opus-4-6", "claude-sonnet-4-6"}
-            call_temperature = temperature
+            call_temperature: float | None = temperature
             call_max_tokens = max_tokens
             thinking_param: dict[str, Any] | None = None
             output_config: dict[str, str] | None = None
 
             if m in _ADAPTIVE_MODELS:
-                # Adaptive thinking (recommended for 4.6+): effort controls depth
+                # Adaptive thinking (Opus 4.6+ and Sonnet 4.6): effort controls depth.
+                # Sampling parameters (temperature/top_p/top_k) are rejected — omit.
                 thinking_param = {"type": "adaptive"}
                 output_config = {"effort": effort}
-                # Anthropic API requires temperature=1 with thinking
-                call_temperature = 1.0
+                call_temperature = None
             elif thinking_budget > 0:
                 # Legacy: manual budget_tokens for older models
                 thinking_param = {
@@ -397,8 +410,9 @@ class ClaudeAgenticAdapter:
                 "tools": api_tools,
                 "tool_choice": tool_choice,
                 "max_tokens": call_max_tokens,
-                "temperature": call_temperature,
             }
+            if call_temperature is not None:
+                create_kwargs["temperature"] = call_temperature
             if thinking_param is not None:
                 create_kwargs["thinking"] = thinking_param
             if output_config is not None:

--- a/tests/test_anthropic_sampling_params.py
+++ b/tests/test_anthropic_sampling_params.py
@@ -77,8 +77,7 @@ def test_adaptive_models_omit_sampling_params(model: str) -> None:
     """Opus 4.6+ / Sonnet 4.6 reject temperature; it must not be sent."""
     kwargs = _run_agentic_call(model)
     assert "temperature" not in kwargs, (
-        f"{model} must not receive `temperature` (rejected with 400). "
-        f"Got: {sorted(kwargs)}"
+        f"{model} must not receive `temperature` (rejected with 400). Got: {sorted(kwargs)}"
     )
     assert kwargs.get("thinking") == {"type": "adaptive"}
 

--- a/tests/test_anthropic_sampling_params.py
+++ b/tests/test_anthropic_sampling_params.py
@@ -1,0 +1,102 @@
+"""Regression tests for Anthropic sampling-parameter handling.
+
+Anthropic deprecated `temperature`, `top_p`, and `top_k` for Opus 4.7
+(and the same constraint applies to Opus 4.6 / Sonnet 4.6 when adaptive
+thinking is on). Sending those parameters returns a 400 BadRequest with
+"temperature is deprecated for this model."
+
+Source: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _run_agentic_call(model: str) -> dict[str, Any]:
+    """Invoke ClaudeAgenticAdapter.agentic_call once and capture create kwargs."""
+    from core.llm.providers.anthropic import ClaudeAgenticAdapter
+
+    adapter = ClaudeAgenticAdapter()
+
+    response = MagicMock()
+    response.content = [MagicMock(type="text", text="ok")]
+    response.stop_reason = "end_turn"
+    response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    response.model = model
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return response
+
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=fake_create)
+    adapter._client = client
+
+    async def fake_failover(models: list[str], do_call: Any) -> tuple[Any, str]:
+        return await do_call(models[0]), models[0]
+
+    with (
+        patch("core.llm.providers.anthropic.settings") as mock_settings,
+        patch("core.llm.router.call_with_failover", side_effect=fake_failover),
+    ):
+        mock_settings.anthropic_api_key = "test-key"
+        asyncio.run(
+            adapter.agentic_call(
+                model=model,
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[
+                    {
+                        "name": "noop",
+                        "description": "noop",
+                        "input_schema": {"type": "object"},
+                    }
+                ],
+                tool_choice={"type": "auto"},
+                max_tokens=1024,
+                temperature=0.0,
+            )
+        )
+
+    return captured
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
+)
+def test_adaptive_models_omit_sampling_params(model: str) -> None:
+    """Opus 4.6+ / Sonnet 4.6 reject temperature; it must not be sent."""
+    kwargs = _run_agentic_call(model)
+    assert "temperature" not in kwargs, (
+        f"{model} must not receive `temperature` (rejected with 400). "
+        f"Got: {sorted(kwargs)}"
+    )
+    assert kwargs.get("thinking") == {"type": "adaptive"}
+
+
+def test_opus_4_7_registered_for_context_management() -> None:
+    """Opus 4.7 must enable the context-management + compaction beta header."""
+    kwargs = _run_agentic_call("claude-opus-4-7")
+    headers = kwargs.get("extra_headers") or {}
+    beta = headers.get("anthropic-beta", "")
+    assert "context-management-2025-06-27" in beta
+    assert "compact-2026-01-12" in beta
+
+
+def test_legacy_model_keeps_temperature() -> None:
+    """Older models (no adaptive thinking) still accept temperature."""
+    kwargs = _run_agentic_call("claude-haiku-4-5-20251001")
+    assert "temperature" in kwargs
+    assert kwargs["temperature"] == 0.0
+    # Haiku 4.5 must not receive the context-management beta header
+    headers = kwargs.get("extra_headers") or {}
+    assert "anthropic-beta" not in headers


### PR DESCRIPTION
## Summary
- `/model` 으로 `claude-opus-4-7` (또는 4.6 / sonnet-4-6) 으로 전환하면 매 요청이 즉시 `400 BadRequest` ("temperature is deprecated for this model" / "Invalid request. Check tool schemas or input.") 로 실패하던 버그 수정.
- 적응형 사고(adaptive thinking) 모델 호출에서 `temperature` 를 더 이상 보내지 않음. `claude-opus-4-7` 을 컨텍스트 관리/컴팩션 베타 모델 셋과 적응형 사고 모델 셋에 등록.

## Why
Anthropic 은 Opus 4.7 (그리고 adaptive thinking 이 켜진 4.6 / Sonnet 4.6) 에서 `temperature` / `top_p` / `top_k` 비기본값 전송을 400 으로 거부하기 시작했습니다.
> Sampling parameters removed — Starting with Claude Opus 4.7, setting `temperature`, `top_p`, or `top_k` to any non-default value will return a 400 error. The safest migration path is to omit these parameters entirely from requests.
> — https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7

기존 코드는 adaptive 분기에서 `call_temperature = 1.0` 을 강제 주입하고 있었기 때문에, Opus 4.7 출시 이후 모든 요청이 즉시 400 으로 실패했습니다. 또한 신규 모델 `claude-opus-4-7` 이 `_ADAPTIVE_MODELS` / `_CONTEXT_MGMT_MODELS` 에 미등록 상태였습니다.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/anthropic.py` | `_CONTEXT_MGMT_MODELS` 에 `claude-opus-4-7` 추가. `_ADAPTIVE_MODELS` 를 모듈 스코프 `frozenset` 으로 승격하고 `claude-opus-4-7` 추가. `agentic_call` 에서 adaptive 모델 호출 시 `temperature` 를 `create_kwargs` 에서 제외 (None sentinel + 조건부 삽입). |
| `tests/test_anthropic_sampling_params.py` | 신규. 5건. Adaptive 모델 3종(opus-4-7, opus-4-6, sonnet-4-6) 에서 `temperature` 미포함 + `thinking={"type":"adaptive"}` 전송 검증, opus-4-7 의 context-management 베타 헤더 부착 검증, haiku-4-5 (비-adaptive) 회귀 — `temperature` 유지 + 베타 헤더 미부착. |
| `CHANGELOG.md` | `[Unreleased] / Fixed` 항목 추가. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Opus 4.7 adapter 등록 (`_ADAPTIVE_MODELS`, `_CONTEXT_MGMT_MODELS`) | Implemented | 두 셋 모두 추가 |
| Adaptive 호출에서 sampling 파라미터 omit | Implemented | `call_temperature: float \| None`, 조건부 삽입 |
| Legacy `thinking_budget` 분기 영향 | No change | 옛 모델은 `temperature=1.0` 그대로 (문서상 deprecation 비대상) |
| `top_p` / `top_k` | Not applicable | 현 코드 어디서도 전송하지 않음 |

## Verification
- [x] `uv run ruff check core/ tests/` — clean
- [x] `uv run mypy core/` — Success: no issues found in 220 source files
- [x] 신규 테스트: `uv run pytest tests/test_anthropic_sampling_params.py` → 5 passed
- [x] 인접 회귀 묶음: `tests/test_native_tools.py tests/test_llm_resilience.py tests/test_model_switch_guard.py tests/test_claude_adapter.py tests/test_anthropic_sampling_params.py` → 83 passed
- [x] 풀 슈트 (`-m "not live"`) → 1 unrelated 환경 실패: `test_concurrent_writers_no_corruption` 가 `OSError(28, 'No space left on device')` 으로 실패 (디스크 99% 가득). 단독 재실행 시 12/12 통과 — 본 PR 과 무관.
- [ ] E2E `geode analyze "Cowboy Bebop" --dry-run` — dry-run 은 LLM 미호출이므로 본 fix 영향권 밖. 회귀 가능성 없음.

## Reference
- Anthropic 공식: [What's new in Claude Opus 4.7 — Sampling parameters removed](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)
- 런타임 에러 로그(사용자 세션):
  - `claude-opus-4-7` → `Invalid request. Check tool schemas or input.` (분류기 일반화)
  - `claude-opus-4-6` → `400 ... 'temperature is deprecated for this model.'` (정확 메시지)