### PR TITLE
release: fix Anthropic Opus 4.7 sampling-param 400 (PR #782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Anthropic sampling parameters on adaptive-thinking models** — `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` rejected requests with `temperature` set ("temperature is deprecated for this model" → 400 BadRequest). Sampling parameters are now omitted on adaptive-thinking models per Anthropic's Opus 4.7 breaking change. `claude-opus-4-7` also registered for the context-management + compaction beta. Fixes the `/model` hot-swap to Opus 4.7. Source: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+
 ## [0.49.0] — 2026-04-23
 
 ### Architecture

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -219,10 +219,24 @@ _API_ALLOWED_KEYS = frozenset({"name", "description", "input_schema", "cache_con
 # context_overflow.  Only 1M-context models are known to support it.
 _CONTEXT_MGMT_MODELS: frozenset[str] = frozenset(
     {
+        "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-opus-4-5",
         "claude-sonnet-4-6",
         "claude-sonnet-4-5",
+    }
+)
+
+# Adaptive thinking models (Opus 4.6+).  Sampling parameters
+# (temperature/top_p/top_k) are rejected with 400 starting from Opus 4.7
+# (https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+# #sampling-parameters-removed) and are also rejected by Opus 4.6 when
+# adaptive thinking is on.  Omit them entirely on these models.
+_ADAPTIVE_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
     }
 )
 
@@ -345,18 +359,17 @@ class ClaudeAgenticAdapter:
                 }
 
             # Thinking mode: adaptive (4.6+) or legacy budget (older models)
-            _ADAPTIVE_MODELS = {"claude-opus-4-6", "claude-sonnet-4-6"}
-            call_temperature = temperature
+            call_temperature: float | None = temperature
             call_max_tokens = max_tokens
             thinking_param: dict[str, Any] | None = None
             output_config: dict[str, str] | None = None
 
             if m in _ADAPTIVE_MODELS:
-                # Adaptive thinking (recommended for 4.6+): effort controls depth
+                # Adaptive thinking (Opus 4.6+ and Sonnet 4.6): effort controls depth.
+                # Sampling parameters (temperature/top_p/top_k) are rejected — omit.
                 thinking_param = {"type": "adaptive"}
                 output_config = {"effort": effort}
-                # Anthropic API requires temperature=1 with thinking
-                call_temperature = 1.0
+                call_temperature = None
             elif thinking_budget > 0:
                 # Legacy: manual budget_tokens for older models
                 thinking_param = {
@@ -397,8 +410,9 @@ class ClaudeAgenticAdapter:
                 "tools": api_tools,
                 "tool_choice": tool_choice,
                 "max_tokens": call_max_tokens,
-                "temperature": call_temperature,
             }
+            if call_temperature is not None:
+                create_kwargs["temperature"] = call_temperature
             if thinking_param is not None:
                 create_kwargs["thinking"] = thinking_param
             if output_config is not None:

--- a/tests/test_anthropic_sampling_params.py
+++ b/tests/test_anthropic_sampling_params.py
@@ -1,0 +1,101 @@
+"""Regression tests for Anthropic sampling-parameter handling.
+
+Anthropic deprecated `temperature`, `top_p`, and `top_k` for Opus 4.7
+(and the same constraint applies to Opus 4.6 / Sonnet 4.6 when adaptive
+thinking is on). Sending those parameters returns a 400 BadRequest with
+"temperature is deprecated for this model."
+
+Source: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _run_agentic_call(model: str) -> dict[str, Any]:
+    """Invoke ClaudeAgenticAdapter.agentic_call once and capture create kwargs."""
+    from core.llm.providers.anthropic import ClaudeAgenticAdapter
+
+    adapter = ClaudeAgenticAdapter()
+
+    response = MagicMock()
+    response.content = [MagicMock(type="text", text="ok")]
+    response.stop_reason = "end_turn"
+    response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    response.model = model
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return response
+
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=fake_create)
+    adapter._client = client
+
+    async def fake_failover(models: list[str], do_call: Any) -> tuple[Any, str]:
+        return await do_call(models[0]), models[0]
+
+    with (
+        patch("core.llm.providers.anthropic.settings") as mock_settings,
+        patch("core.llm.router.call_with_failover", side_effect=fake_failover),
+    ):
+        mock_settings.anthropic_api_key = "test-key"
+        asyncio.run(
+            adapter.agentic_call(
+                model=model,
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[
+                    {
+                        "name": "noop",
+                        "description": "noop",
+                        "input_schema": {"type": "object"},
+                    }
+                ],
+                tool_choice={"type": "auto"},
+                max_tokens=1024,
+                temperature=0.0,
+            )
+        )
+
+    return captured
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
+)
+def test_adaptive_models_omit_sampling_params(model: str) -> None:
+    """Opus 4.6+ / Sonnet 4.6 reject temperature; it must not be sent."""
+    kwargs = _run_agentic_call(model)
+    assert "temperature" not in kwargs, (
+        f"{model} must not receive `temperature` (rejected with 400). Got: {sorted(kwargs)}"
+    )
+    assert kwargs.get("thinking") == {"type": "adaptive"}
+
+
+def test_opus_4_7_registered_for_context_management() -> None:
+    """Opus 4.7 must enable the context-management + compaction beta header."""
+    kwargs = _run_agentic_call("claude-opus-4-7")
+    headers = kwargs.get("extra_headers") or {}
+    beta = headers.get("anthropic-beta", "")
+    assert "context-management-2025-06-27" in beta
+    assert "compact-2026-01-12" in beta
+
+
+def test_legacy_model_keeps_temperature() -> None:
+    """Older models (no adaptive thinking) still accept temperature."""
+    kwargs = _run_agentic_call("claude-haiku-4-5-20251001")
+    assert "temperature" in kwargs
+    assert kwargs["temperature"] == 0.0
+    # Haiku 4.5 must not receive the context-management beta header
+    headers = kwargs.get("extra_headers") or {}
+    assert "anthropic-beta" not in headers


### PR DESCRIPTION
## Summary
- PR #782: Anthropic adaptive-thinking 모델(Opus 4.7 / 4.6 / Sonnet 4.6)에서 `temperature` 전송으로 발생하던 400 BadRequest 수정. `claude-opus-4-7` 을 `_ADAPTIVE_MODELS`/`_CONTEXT_MGMT_MODELS` 에 등록.

## Verification
- [x] PR #782 develop 머지 완료
- [x] 5 신규 테스트 + 83 인접 회귀 통과
- [x] ruff / mypy clean