### PR TITLE
docs: expand Codex OAuth setup guide (EN + KO)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -53,7 +53,19 @@ chmod 600 ~/.geode/.env
 
 키 발급: [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys) (무료 티어 가능)
 
-> **Codex CLI 사용자**: `codex auth login`을 실행했다면, GEODE가 `~/.codex/auth.json`에서 OAuth 토큰을 자동 감지합니다. OpenAI 모델용 `.env` 설정 불필요 — proactive refresh와 401 자동 재시도 내장.
+> **OpenAI 모델 (GPT-5.4) 사용하려면?** 두 가지 방법:
+>
+> **옵션 A — Codex CLI OAuth (권장)**
+> ```bash
+> brew install codex          # 또는: npm install -g @openai/codex
+> codex auth login            # 브라우저에서 Google/OpenAI OAuth 인증
+> ```
+> 로그인 후 GEODE가 `~/.codex/auth.json`에서 OAuth 토큰을 자동 감지합니다. `.env` 불필요 — 만료 120초 전 자동 갱신 + 401 자동 재시도 내장.
+>
+> **옵션 B — API 키 직접 등록**
+> ```bash
+> echo 'OPENAI_API_KEY=sk-proj-여기에-키-입력' >> ~/.geode/.env
+> ```
 
 > API 키가 없어도 **dry-run 모드**로 동작합니다 — 파이프라인 전체가 fixture 데이터로 실행됩니다.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ chmod 600 ~/.geode/.env
 
 Get your key at [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys) (free tier available).
 
-> **Codex CLI users**: If you've run `codex auth login`, GEODE auto-detects your OAuth token from `~/.codex/auth.json`. No `.env` needed for OpenAI models — proactive refresh and 401 auto-retry are built in.
+> **Want to use OpenAI models (GPT-5.4)?** Two options:
+>
+> **Option A — Codex CLI OAuth (recommended)**
+> ```bash
+> brew install codex          # or: npm install -g @openai/codex
+> codex auth login            # opens browser for Google/OpenAI OAuth
+> ```
+> After login, GEODE auto-detects your OAuth token from `~/.codex/auth.json`. No `.env` needed — proactive refresh (120s before expiry) and 401 auto-retry are built in.
+>
+> **Option B — API key**
+> ```bash
+> echo 'OPENAI_API_KEY=sk-proj-your-key-here' >> ~/.geode/.env
+> ```
 
 > No API key? GEODE still works in **dry-run mode** — all pipeline features run with fixture data, no LLM calls.
 


### PR DESCRIPTION
## Summary
- README Step 2에 Codex OAuth 2-옵션 가이드 확장 (EN + KO)

## Why
Codex 설치/로그인 안내가 한 줄로 부족. 유저가 실제로 따라할 수 있는 구체적 명령어 필요.

## Verification
- [x] Docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)