### PR TITLE
release: v0.50.0 — auth plans + /login 통합

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.50.0] — 2026-04-25
+
+### Added
+- **Plan + ProviderSpec credential model** — first-class `Plan` entity with `PlanKind` (PAYG / SUBSCRIPTION / OAUTH_BORROWED / CLOUD_PROVIDER), per-Plan endpoint binding, and optional `Quota(window_s, max_calls, model_weights)`. Built-in templates for GLM Coding Lite/Pro/Max. (`core/gateway/auth/plans.py`, `core/llm/registry.py`)
+- **`/login` unified credentials command** — replaces split `/key` + `/auth` + `/login` UX with a single dashboard + verb hierarchy modeled on Hermes (`hermes auth ...`) and Claude Code (`/login` / `/status`). Subcommands: `add` (interactive wizard), `oauth openai`, `set-key`, `use`, `route`, `remove`, `quota`, `status`. The bare `/login` shows a unified view of Plans + Profiles + Routing + OAuth credentials. (`core/cli/commands.py`)
+- **`~/.geode/auth.toml` persistence** — Plans and bound profiles survive process restarts in a single TOML file (0600 perms). First boot auto-migrates `.env` PAYG keys into PAYG plans. `GEODE_AUTH_TOML` env var redirects the path for testing/sandboxing. (`core/gateway/auth/auth_toml.py`)
+- **Mascot plan line** — startup brand block shows the active subscription quota: `Plan: GLM Coding Lite (used 23/80 · 57 left · resets 134m)`. Hidden when no quota-bearing plan is registered. (`core/cli/ui/mascot.py`)
+- **`AuthError` + `ERROR_HINTS`** — structured auth errors map to user-actionable hints (subscription upgrade URLs, `/login set-key` invocations, OAuth refresh prompts). Hermes `format_auth_error` pattern. (`core/gateway/auth/errors.py`)
+- **Model-switch reason in IPC events** — `MODEL_SWITCHED` events now surface the trigger (`rate_limit`, `auth_cross_provider`, `failure_escalation`) inline so users can tell quota exhaustion apart from auth errors at a glance. (`core/cli/ui/event_renderer.py`)
+
 ### Fixed
 - **Anthropic sampling parameters on adaptive-thinking models** — `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` rejected requests with `temperature` set ("temperature is deprecated for this model" → 400 BadRequest). Sampling parameters are now omitted on adaptive-thinking models per Anthropic's Opus 4.7 breaking change. `claude-opus-4-7` also registered for the context-management + compaction beta. Fixes the `/model` hot-swap to Opus 4.7. Source: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+- **Codex OAuth poisoning general OpenAI calls** — Codex CLI OAuth was registered as `provider="openai"`, so `ProfileRotator.resolve("openai")` returned the Codex token for every GPT call. Codex tokens lack `model.request` scope on `api.openai.com`, causing 403 + slow API-key fallback. The provider variant is now `openai-codex` with its own endpoint (`chatgpt.com/backend-api/codex`). (`core/runtime_wiring/infra.py`, `core/llm/providers/codex.py`)
+- **GLM Coding Plan endpoint** — `GLM_BASE_URL` pointed at the metered PAYG endpoint (`api.z.ai/api/paas/v4`), so Coding Plan keys silently bypassed the subscription quota. Default flipped to `api.z.ai/api/coding/paas/v4`; PAYG endpoint preserved as `GLM_PAYG_BASE_URL`. (`core/config.py`, `core/llm/providers/glm.py`)
+- **Dual ProfileStore drift** — CLI (`/auth`) and runtime LLM dispatch held separate `ProfileStore` instances. Credentials added through `/auth add` were invisible to `ProfileRotator.resolve()`. Single singleton via `runtime_wiring.infra.ensure_profile_store()`. (`core/runtime_wiring/infra.py`, `core/cli/commands.py`)
+- **Provider label fragmentation (`zhipuai` vs `glm`)** — UI store used `provider="zhipuai"` while dispatch keyed off `provider="glm"`. Profile rotator could never find UI-added GLM keys. Normalized to `glm`. (`core/cli/commands.py`)
+- **`MODEL_PROFILES` mislabel** — `gpt-5.4-mini` was advertised as `Codex (Plus)` even though it routes to plain `openai` (PAYG). Users believed they were on the Plus subscription while being billed metered. Now labeled `OpenAI`. (`core/cli/commands.py`)
+
+### Changed
+- **Cross-provider auto-escalation disabled for `glm` and `openai-codex`** — `CROSS_PROVIDER_FALLBACK["glm"]` and `["openai-codex"]` are now empty. A GLM Coding Plan auth error no longer silently diverts traffic to a metered OpenAI key. Cross-plan jumps will return as an explicit user-confirmed action in a future release. (`core/llm/adapters.py`)
+- **`/key` and `/auth` are aliases that surface the unified `/login` dashboard** — bare `/key` redirects to `/login`. Setting an API key still works (`/key sk-...`) and now also seeds a PAYG plan into the registry so the credential is visible in `/login`.
+
+### Architecture
+- **Provider variant registry** — `core/llm/registry.py` introduces `ProviderSpec(id, display_name, default_base_url, auth_type, extra_headers_factory)` modeled on Hermes' `ProviderConfig`. Five variants registered: `anthropic`, `openai`, `openai-codex`, `glm`, `glm-coding`. The Codex variant carries the Cloudflare-bypass header factory.
+- **`AuthProfile.plan_id`** — additive FK linking a profile to a Plan. `base_url_override` allows per-profile endpoint overrides (China-mainland mirrors etc.). Backward compatible — env-loaded profiles default to a synthetic PAYG Plan.
 
 ## [0.49.1] — 2026-04-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.49.1
+- **Version**: 0.50.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 226
-- **Tests**: 3995+
+- **Modules**: 227
+- **Tests**: 4037+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.49.0 — Long-running Autonomous Execution Harness
+# GEODE v0.50.0 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.49.1 — Long-running Autonomous Execution Harness
+# GEODE v0.50.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -5,6 +5,7 @@ OpenClaw-inspired Binding Router pattern: static command → handler mapping.
 
 from __future__ import annotations
 
+import logging
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +29,8 @@ from core.config import (
     OPENAI_PRIMARY,
 )
 from core.gateway.auth.profiles import ProfileStore
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Model Registry (OpenClaw Auth Profile Rotation pattern)
@@ -136,12 +139,12 @@ def show_help() -> None:
     console.print("  [label]/search[/label] <query>     — Search IPs by keyword")
     console.print("  [label]/list[/label]               — Show available IPs")
     console.print("  [label]/verbose[/label]            — Toggle verbose mode")
-    console.print("  [label]/key[/label] <value>        — Set API key (auto-detect provider)")
-    console.print("  [label]/key openai[/label] <value> — Set OpenAI API key")
-    console.print("  [label]/key glm[/label] <value>    — Set ZhipuAI API key")
-    console.print("  [label]/login[/label] <provider>   — OAuth login (openai, status)")
+    console.print("  [label]/login[/label]              — Plans + credentials dashboard (unified)")
+    console.print("  [label]/login add[/label]          — Interactive plan/key wizard")
+    console.print("  [label]/login oauth openai[/label] — Codex OAuth (Plus quota)")
+    console.print("  [label]/key[/label] <value>        — Quick PAYG API key (legacy alias)")
     console.print("  [label]/model[/label]              — Show & switch LLM model")
-    console.print("  [label]/auth[/label]               — Manage auth profiles")
+    console.print("  [label]/auth[/label]               — Auth profile rotator (legacy)")
     console.print("  [label]/generate[/label] [count]   — Generate synthetic demo data")
     console.print("  [label]/report[/label] <IP> [fmt]  — Generate report (md/html/json)")
     console.print("  [label]/batch[/label] <IP1> <IP2>  — Batch analyze multiple IPs")
@@ -178,31 +181,20 @@ def cmd_list() -> None:
 
 
 def cmd_key(args: str) -> bool:
-    """Handle /key command. Returns True if readiness should be rechecked."""
+    """Handle /key command (legacy; prefer /login).
+
+    Returns True if readiness should be rechecked.
+    """
     from core.config import settings
 
     parts = args.split(None, 1) if args else []
 
-    # /key (no args) → show current status
+    # /key (no args) → defer to the unified /login dashboard
     if not parts:
-        anthro = (
-            _mask_key(settings.anthropic_api_key)
-            if settings.anthropic_api_key
-            else "[muted]not set[/muted]"
+        console.print(
+            "\n  [muted]/key now redirects to the unified /login dashboard.[/muted]"
         )
-        openai = (
-            _mask_key(settings.openai_api_key)
-            if settings.openai_api_key
-            else "[muted]not set[/muted]"
-        )
-        zhipu = (
-            _mask_key(settings.zai_api_key) if settings.zai_api_key else "[muted]not set[/muted]"
-        )
-        console.print()
-        console.print(f"  [label]Anthropic[/label]  {anthro}")
-        console.print(f"  [label]OpenAI[/label]    {openai}")
-        console.print(f"  [label]ZhipuAI[/label]   {zhipu}")
-        console.print()
+        cmd_login("")
         return False
 
     # /key openai <value>
@@ -246,6 +238,7 @@ def cmd_key(args: str) -> bool:
     if value.startswith("sk-ant-"):
         settings.anthropic_api_key = value
         _upsert_env("ANTHROPIC_API_KEY", value)
+        _seed_payg_plan_from_key("anthropic", value)
         console.print(f"  [success]Anthropic API key set[/success]  {_mask_key(value)}")
     elif value.startswith("sk-proj-") or value.startswith("sk-"):
         settings.openai_api_key = value
@@ -256,6 +249,7 @@ def cmd_key(args: str) -> bool:
             reset_openai_client()
         except ImportError:
             pass
+        _seed_payg_plan_from_key("openai", value)
         console.print(f"  [success]OpenAI API key set[/success]  {_mask_key(value)}")
     elif _is_glm_key(value):
         settings.zai_api_key = value
@@ -266,18 +260,62 @@ def cmd_key(args: str) -> bool:
             reset_glm_client()
         except ImportError:
             pass
-        console.print(f"  [success]ZhipuAI API key set[/success]  {_mask_key(value)}")
+        _seed_payg_plan_from_key("glm", value)
+        console.print(f"  [success]GLM API key set[/success]  {_mask_key(value)}")
     else:
         console.print(
             "  [warning]Unrecognized key prefix. Use:[/warning]\n"
             "  [muted]/key <sk-ant-...>          → Anthropic[/muted]\n"
             "  [muted]/key openai <sk-proj-...>  → OpenAI[/muted]\n"
-            "  [muted]/key glm <key>             → ZhipuAI[/muted]"
+            "  [muted]/key glm <key>             → GLM[/muted]\n"
+            "  [muted]Tip: use /login add for subscription plans (Coding Lite/Pro/Max).[/muted]"
         )
         console.print()
         return False
+    console.print(
+        "  [muted]Tip: /login add to register a Coding Plan "
+        "(cheaper than PAYG for heavy use).[/muted]"
+    )
     console.print()
     return True
+
+
+def _seed_payg_plan_from_key(provider: str, key: str) -> None:
+    """Mirror a freshly-set env API key into the Plan registry as PAYG.
+
+    Keeps `/login` dashboard in sync with `/key` writes so users see the
+    same credential in both views (Phase 1 single-store + Phase 2 plans).
+    """
+    try:
+        from core.gateway.auth.plan_registry import get_plan_registry
+        from core.gateway.auth.plans import default_plan_for_payg
+        from core.gateway.auth.profiles import AuthProfile, CredentialType
+        from core.runtime_wiring.infra import ensure_profile_store
+
+        registry = get_plan_registry()
+        plan = registry.get(f"{provider}-payg") or default_plan_for_payg(provider, key)
+        registry.add(plan)
+        store = ensure_profile_store()
+        name = f"{plan.id}:env"
+        existing = store.get(name)
+        if existing is not None:
+            existing.key = key
+            existing.plan_id = plan.id
+            existing.error_count = 0
+            existing.cooldown_until = 0.0
+        else:
+            store.add(
+                AuthProfile(
+                    name=name,
+                    provider=plan.provider,
+                    credential_type=CredentialType.API_KEY,
+                    key=key,
+                    plan_id=plan.id,
+                )
+            )
+    except Exception:
+        # The legacy /key path must not fail because of plan-seeding.
+        log.debug("Plan seed from /key failed", exc_info=True)
 
 
 def _check_provider_key(selected: ModelProfile) -> None:
@@ -1822,65 +1860,553 @@ def cmd_tasks(args: str) -> None:
 
 
 def cmd_login(args: str) -> None:
-    """Handle /login command — OAuth login for LLM providers.
+    """Handle /login — unified credentials/plans command (v0.50.0+).
 
-    /login openai    → OpenAI Codex device code OAuth flow
-    /login status    → Show all auth credentials status
-    /login           → Show usage help
+    Subcommands (mirrors Hermes `auth` + Claude Code `/login`/`/status`):
+
+      /login                — show plans, profiles, routing, quota
+      /login add            — interactive wizard (kind → provider → key/OAuth)
+      /login oauth <prov>   — OAuth device flow (currently: openai/codex)
+      /login set-key <plan> <key>
+      /login use <plan>     — pin a plan as the active one for its provider
+      /login remove <plan>
+      /login route <model> <plan> [<plan>...]
+      /login quota          — per-plan usage breakdown
+      /login status         — legacy alias of bare /login
     """
-    arg = args.strip().lower()
-
-    if not arg:
-        console.print("\n  [label]/login[/label] — OAuth login for LLM providers\n")
-        console.print("  [label]/login openai[/label]   — OpenAI Codex OAuth (Plus quota)")
-        console.print("  [label]/login status[/label]   — Show auth credentials status\n")
+    raw = args.strip()
+    if not raw:
+        _login_show_status()
         return
 
-    if arg == "status":
-        from core.gateway.auth.oauth_login import get_auth_status
+    parts = raw.split(None, 1)
+    sub = parts[0].lower()
+    rest = parts[1] if len(parts) > 1 else ""
 
-        statuses = get_auth_status()
-        if not statuses:
-            console.print("\n  No OAuth credentials found.\n")
-            console.print("  Run [label]/login openai[/label] to authenticate.\n")
-            return
+    if sub in ("status", "list", "ls"):
+        _login_show_status()
+        return
+    if sub in ("add", "new"):
+        _login_add_interactive(rest)
+        return
+    if sub in ("oauth", "openai"):
+        # `/login openai` is preserved for backwards compatibility — it always
+        # ran the Codex device-code flow even before v0.50.0.
+        target = rest.strip().lower() or "openai"
+        _login_oauth(target)
+        return
+    if sub in ("set-key", "setkey", "key"):
+        _login_set_key(rest)
+        return
+    if sub == "use":
+        _login_use(rest)
+        return
+    if sub in ("remove", "rm", "delete"):
+        _login_remove(rest)
+        return
+    if sub == "route":
+        _login_route(rest)
+        return
+    if sub == "quota":
+        _login_quota()
+        return
+    if sub in ("help", "?"):
+        _login_help()
+        return
 
-        console.print("\n  [label]Auth Credentials[/label]\n")
-        for s in statuses:
-            status_color = "green" if s["status"] == "active" else "red"
+    console.print(
+        f"\n  [warning]Unknown /login subcommand:[/warning] {sub}\n"
+        "  Run [label]/login help[/label] for the full menu.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /login subcommands — implementation
+# ---------------------------------------------------------------------------
+
+
+def _login_help() -> None:
+    console.print(
+        "\n  [header]/login[/header] — credentials & subscription plans\n"
+        "\n"
+        "  [label]/login[/label]                       Show all plans, profiles, routing\n"
+        "  [label]/login add[/label]                   Interactive wizard\n"
+        "  [label]/login oauth openai[/label]          OAuth device flow (Codex Plus)\n"
+        "  [label]/login set-key[/label] <plan> <key>  Update a plan's API key\n"
+        "  [label]/login use[/label] <plan>            Pin a plan as active for its provider\n"
+        "  [label]/login route[/label] <model> <plan>… Bind a model to plan(s) in priority order\n"
+        "  [label]/login remove[/label] <plan>         Delete a plan\n"
+        "  [label]/login quota[/label]                 Per-plan quota / usage\n"
+    )
+
+
+def _login_show_status() -> None:
+    """Render the unified plans + profiles + routing dashboard.
+
+    Combines OpenClaw `/status` (auth-mode badge), Hermes `hermes status`
+    (per-provider expiry + subscription line), and Claude Code Settings
+    Status tab (plan + token source + provider).
+    """
+    from core.gateway.auth.oauth_login import get_auth_status as get_oauth_status
+    from core.gateway.auth.plan_registry import get_plan_registry
+    from core.gateway.auth.profiles import CredentialType
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    store = ensure_profile_store()
+    registry = get_plan_registry()
+    plans = registry.list_all()
+    profiles = store.list_all()
+
+    console.print()
+    console.print("  [header]Plans[/header]")
+    if not plans and not profiles:
+        console.print("  [muted]No plans or credentials registered yet.[/muted]")
+        console.print("  [muted]Run /login add to register a plan, or paste an API key.[/muted]")
+        console.print()
+        return
+
+    if plans:
+        for plan in plans:
+            usage = registry.usage_for(plan.id)
+            tier_label = f" · {plan.subscription_tier}" if plan.subscription_tier else ""
+            quota_label = ""
+            if plan.quota is not None:
+                remaining = usage.remaining_in_window(plan)
+                quota_label = (
+                    f"  [muted]used {int(usage.weighted_calls)}/{plan.quota.max_calls}"
+                    f" ({plan.quota.window_s // 3600}h window, {remaining} left)[/muted]"
+                )
+            bound = [p for p in profiles if p.plan_id == plan.id]
+            mark = "[success]✓[/success]" if bound else "[warning]?[/warning]"
             console.print(
-                f"  [{status_color}]{s['status']:8s}[/{status_color}] "
-                f"{s['provider']:20s} "
-                f"{s['email'] or '-':25s} "
-                f"{s['expires_in']:10s} "
-                f"[muted]({s['source']})[/muted]"
+                f"  {mark} [bold]{plan.id}[/bold]  "
+                f"[muted]{plan.kind.value}[/muted]  {plan.base_url}{tier_label}{quota_label}"
+            )
+    else:
+        console.print("  [muted]No Plans registered. Profiles below run via PAYG defaults.[/muted]")
+    console.print()
+
+    # Profiles section — aggregates env-loaded keys + interactively added
+    console.print("  [header]Profiles[/header]")
+    if not profiles:
+        console.print("  [muted]No credentials. Run /login add or set provider env vars.[/muted]")
+    else:
+        # Group by provider for readability
+        from core.gateway.auth.profiles import AuthProfile as _AP
+
+        by_provider: dict[str, list[_AP]] = {}
+        for p in profiles:
+            by_provider.setdefault(p.provider, []).append(p)
+        for provider in sorted(by_provider.keys()):
+            for p in by_provider[provider]:
+                badge = {
+                    CredentialType.OAUTH: "oauth",
+                    CredentialType.TOKEN: "token",
+                    CredentialType.API_KEY: "api-key",
+                }.get(p.credential_type, "?")
+                plan_id = p.plan_id or "[muted](none)[/muted]"
+                managed = f" · managed:{p.managed_by}" if p.managed_by else ""
+                expiry = ""
+                if p.expires_at:
+                    import time as _t
+
+                    rem = int(p.expires_at - _t.time())
+                    expiry = (
+                        f" · expires {rem // 60}m"
+                        if rem > 0
+                        else " · [error]expired[/error]"
+                    )
+                console.print(
+                    f"  [muted]•[/muted] {p.name:<28} "
+                    f"[muted]{badge:<7}[/muted] {p.masked_key} "
+                    f"plan={plan_id}{managed}{expiry}"
+                )
+    console.print()
+
+    # Routing section
+    routing = registry.all_routing()
+    if routing:
+        console.print("  [header]Routing[/header]")
+        for model, plan_ids in sorted(routing.items()):
+            chain = " → ".join(plan_ids) if plan_ids else "[muted](none)[/muted]"
+            console.print(f"  {model:<24} → {chain}")
+        console.print()
+
+    # OAuth status (shows expiry + email when available)
+    try:
+        oauth = get_oauth_status()
+    except Exception:
+        oauth = []
+    if oauth:
+        console.print("  [header]OAuth (external CLIs)[/header]")
+        for s in oauth:
+            colour = "success" if s.get("status") == "active" else "warning"
+            console.print(
+                f"  [{colour}]{s.get('status', '?'):<8}[/{colour}] "
+                f"{s.get('provider', ''):<20} "
+                f"{s.get('email') or '-':<24} "
+                f"{s.get('expires_in', ''):<10} "
+                f"[muted]({s.get('source', '')})[/muted]"
             )
         console.print()
+
+    console.print(
+        "  [muted]Tip: /login add to register a plan · /login quota for usage detail[/muted]\n"
+    )
+
+
+def _login_add_interactive(_args: str) -> None:
+    """Interactive wizard — Plan kind → Provider → endpoint/key/OAuth.
+
+    Mirrors OpenClaw setup wizard (`prompter.select` levels) collapsed
+    into a single CLI command so existing users can run it any time.
+    """
+    import sys
+
+    from core.gateway.auth.plan_registry import get_plan_registry
+    from core.gateway.auth.plans import (
+        GLM_CODING_TIERS,
+        default_plan_for_payg,
+    )
+    from core.gateway.auth.profiles import AuthProfile, CredentialType
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    if not sys.stdin.isatty():
+        console.print(
+            "  [warning]/login add requires an interactive terminal.[/warning]\n"
+            "  [muted]Set keys via env vars (ZAI_API_KEY, OPENAI_API_KEY, "
+            "ANTHROPIC_API_KEY) for non-interactive setup.[/muted]"
+        )
         return
 
-    if arg == "openai":
-        console.print()
+    kinds = [
+        ("subscription", "Subscription (GLM Coding Plan, ChatGPT Plus, Claude Pro)"),
+        ("payg", "Pay-as-you-go API key (Anthropic, OpenAI, GLM PAYG)"),
+        ("oauth", "OAuth borrowed (Codex CLI / Claude Code)"),
+    ]
+    menu = TerminalMenu(
+        [label for _, label in kinds],
+        title="\n  Plan kind?  (↑↓ select, Enter confirm, q cancel)\n",
+        menu_cursor="  > ",
+        menu_cursor_style=("fg_cyan", "bold"),
+    )
+    idx = menu.show()
+    if idx is None:
+        console.print("  [muted]Cancelled[/muted]\n")
+        return
+    kind_id = kinds[idx][0]
+
+    registry = get_plan_registry()
+    store = ensure_profile_store()
+
+    if kind_id == "subscription":
+        # Currently only GLM Coding Plan tiers are templated
+        tier_entries = [
+            "GLM Coding Lite  ($6/mo · 80 calls/5h · 3× weight on glm-5.1)",
+            "GLM Coding Pro   ($30/mo · 240 calls/5h)",
+            "GLM Coding Max   ($80/mo · 600 calls/5h)",
+        ]
+        tier_keys = ["lite", "pro", "max"]
+        tmenu = TerminalMenu(
+            tier_entries,
+            title="\n  Subscription tier?\n",
+            menu_cursor="  > ",
+        )
+        tidx = tmenu.show()
+        if tidx is None:
+            console.print("  [muted]Cancelled[/muted]\n")
+            return
+        plan = GLM_CODING_TIERS[tier_keys[tidx]]
         try:
-            from core.gateway.auth.oauth_login import login_openai
+            key = console.input(f"  [label]{plan.display_name} API key:[/label] ").strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n  [muted]Cancelled[/muted]\n")
+            return
+        if not key:
+            console.print("  [warning]No key provided.[/warning]\n")
+            return
+        registry.add(plan)
+        registry.set_routing(
+            "glm-5.1", [plan.id, *registry.get_routing("glm-5.1")]
+        )
+        for m in ("glm-5", "glm-5-turbo", "glm-4.7-flash"):
+            registry.set_routing(m, [plan.id, *registry.get_routing(m)])
+        store.add(
+            AuthProfile(
+                name=f"{plan.id}:user",
+                provider=plan.provider,
+                credential_type=CredentialType.API_KEY,
+                key=key,
+                plan_id=plan.id,
+            )
+        )
+        # Reset the GLM client so the next call picks up the new endpoint+key
+        try:
+            from core.llm.providers.glm import reset_glm_client
 
-            creds = login_openai()
-            if creds:
-                # Invalidate cached Codex client so next call picks up new token
-                import contextlib
-
-                with contextlib.suppress(Exception):
-                    from core.llm.providers.codex import reset_codex_client
-
-                    reset_codex_client()
-        except Exception as exc:
-            console.print(f"  [red]Login failed: {exc}[/red]\n")
+            reset_glm_client()
+        except Exception:  # noqa: S110 — best-effort cache invalidation
+            pass
+        console.print(
+            f"  [success]Registered[/success] {plan.display_name}  "
+            f"[muted]({plan.base_url})[/muted]\n"
+        )
         return
 
-    # Unknown provider — prompt user to specify
-    known = ["openai"]
-    console.print(f"\n  Unknown provider: [label]{arg}[/label]")
-    console.print(f"  Available: {', '.join(known)}")
-    console.print("  Which provider did you mean? Run [label]/login <provider>[/label]\n")
+    if kind_id == "payg":
+        providers = [
+            ("anthropic", "Anthropic"),
+            ("openai", "OpenAI"),
+            ("glm", "GLM (z.ai PAYG)"),
+        ]
+        pmenu = TerminalMenu(
+            [label for _, label in providers],
+            title="\n  Provider?\n",
+            menu_cursor="  > ",
+        )
+        pidx = pmenu.show()
+        if pidx is None:
+            console.print("  [muted]Cancelled[/muted]\n")
+            return
+        provider = providers[pidx][0]
+        try:
+            key = console.input(
+                f"  [label]{providers[pidx][1]} API key:[/label] "
+            ).strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n  [muted]Cancelled[/muted]\n")
+            return
+        if not key:
+            console.print("  [warning]No key provided.[/warning]\n")
+            return
+        plan = default_plan_for_payg(provider, key)
+        registry.add(plan)
+        store.add(
+            AuthProfile(
+                name=f"{plan.id}:user",
+                provider=provider,
+                credential_type=CredentialType.API_KEY,
+                key=key,
+                plan_id=plan.id,
+            )
+        )
+        # Mirror to settings + .env so legacy fallbacks keep working
+        from core.config import settings
+
+        env_field_map = {
+            "anthropic": ("anthropic_api_key", "ANTHROPIC_API_KEY"),
+            "openai": ("openai_api_key", "OPENAI_API_KEY"),
+            "glm": ("zai_api_key", "ZAI_API_KEY"),
+        }
+        if provider in env_field_map:
+            field_name, env_var = env_field_map[provider]
+            object.__setattr__(settings, field_name, key)
+            _upsert_env(env_var, key)
+        console.print(
+            f"  [success]Registered[/success] {plan.display_name}  "
+            f"[muted](key {_mask_key(key)})[/muted]\n"
+        )
+        return
+
+    if kind_id == "oauth":
+        oauth_entries = [
+            "OpenAI Codex CLI (chatgpt.com/backend-api/codex)",
+            "Claude Code (currently disabled — Anthropic ToS)",
+        ]
+        omenu = TerminalMenu(
+            oauth_entries,
+            title="\n  OAuth source?\n",
+            menu_cursor="  > ",
+        )
+        oidx = omenu.show()
+        if oidx is None:
+            console.print("  [muted]Cancelled[/muted]\n")
+            return
+        if oidx == 1:
+            console.print(
+                "  [warning]Claude Code OAuth is disabled (Anthropic ToS, "
+                "see core/runtime_wiring/infra.py).[/warning]\n"
+            )
+            return
+        _login_oauth("openai")
+        return
+
+
+def _login_oauth(target: str) -> None:
+    """Run the OAuth device-code flow for an external CLI provider."""
+    target = target.lower().strip()
+    if target not in ("openai", "codex"):
+        console.print(
+            f"  [warning]OAuth not implemented for '{target}'.[/warning]\n"
+            "  [muted]Available: openai (Codex CLI Plus quota)[/muted]\n"
+        )
+        return
+    console.print()
+    try:
+        from core.gateway.auth.oauth_login import login_openai
+
+        creds = login_openai()
+        if creds:
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                from core.llm.providers.codex import reset_codex_client
+
+                reset_codex_client()
+            console.print(
+                "  [success]Codex OAuth registered.[/success]  "
+                "[muted]Provider: openai-codex[/muted]\n"
+            )
+    except Exception as exc:
+        console.print(f"  [red]Login failed: {exc}[/red]\n")
+
+
+def _login_set_key(rest: str) -> None:
+    parts = rest.split(None, 1)
+    if len(parts) < 2:
+        console.print("  [warning]Usage: /login set-key <plan-id> <api-key>[/warning]\n")
+        return
+    plan_id, key = parts[0], parts[1].strip()
+
+    from core.gateway.auth.plan_registry import get_plan_registry
+    from core.gateway.auth.profiles import AuthProfile, CredentialType
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    registry = get_plan_registry()
+    plan = registry.get(plan_id)
+    if plan is None:
+        console.print(
+            f"  [warning]Unknown plan: {plan_id}[/warning]  "
+            "[muted](use /login add first)[/muted]\n"
+        )
+        return
+    store = ensure_profile_store()
+    name = f"{plan.id}:user"
+    existing = store.get(name)
+    if existing is not None:
+        existing.key = key
+        existing.error_count = 0
+        existing.cooldown_until = 0.0
+    else:
+        store.add(
+            AuthProfile(
+                name=name,
+                provider=plan.provider,
+                credential_type=CredentialType.API_KEY,
+                key=key,
+                plan_id=plan.id,
+            )
+        )
+    if plan.provider == "glm-coding":
+        from core.llm.providers.glm import reset_glm_client
+
+        reset_glm_client()
+    console.print(
+        f"  [success]Updated key[/success] for {plan.display_name}  "
+        f"[muted]({_mask_key(key)})[/muted]\n"
+    )
+
+
+def _login_use(rest: str) -> None:
+    plan_id = rest.strip()
+    if not plan_id:
+        console.print("  [warning]Usage: /login use <plan-id>[/warning]\n")
+        return
+    from core.gateway.auth.plan_registry import get_plan_registry
+
+    registry = get_plan_registry()
+    plan = registry.get(plan_id)
+    if plan is None:
+        console.print(f"  [warning]Unknown plan: {plan_id}[/warning]\n")
+        return
+    # Pin this plan ahead of any other for a few common models in its provider
+    model_hints = {
+        "glm-coding": ["glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7-flash"],
+        "glm": ["glm-5.1", "glm-5", "glm-5-turbo"],
+        "openai": ["gpt-5.4", "gpt-5.4-mini"],
+        "openai-codex": ["gpt-5.3-codex", "gpt-5.4-mini"],
+        "anthropic": ["claude-opus-4-7", "claude-sonnet-4-6"],
+    }
+    for model in model_hints.get(plan.provider, []):
+        existing = [pid for pid in registry.get_routing(model) if pid != plan.id]
+        registry.set_routing(model, [plan.id, *existing])
+    console.print(
+        f"  [success]Activated[/success] {plan.display_name} for {plan.provider} models.\n"
+    )
+
+
+def _login_remove(rest: str) -> None:
+    plan_id = rest.strip()
+    if not plan_id:
+        console.print("  [warning]Usage: /login remove <plan-id>[/warning]\n")
+        return
+    from core.gateway.auth.plan_registry import get_plan_registry
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    registry = get_plan_registry()
+    if not registry.remove(plan_id):
+        console.print(f"  [warning]Plan not found: {plan_id}[/warning]\n")
+        return
+    store = ensure_profile_store()
+    for p in list(store.list_all()):
+        if p.plan_id == plan_id:
+            store.remove(p.name)
+    console.print(f"  [success]Removed plan and its profiles:[/success] {plan_id}\n")
+
+
+def _login_route(rest: str) -> None:
+    parts = rest.split()
+    if len(parts) < 2:
+        console.print(
+            "  [warning]Usage: /login route <model> <plan-id> [<plan-id>...][/warning]\n"
+        )
+        return
+    model, plan_ids = parts[0], parts[1:]
+    from core.gateway.auth.plan_registry import get_plan_registry
+
+    registry = get_plan_registry()
+    unknown = [pid for pid in plan_ids if registry.get(pid) is None]
+    if unknown:
+        console.print(f"  [warning]Unknown plan(s): {', '.join(unknown)}[/warning]\n")
+        return
+    registry.set_routing(model, plan_ids)
+    console.print(
+        f"  [success]Routing[/success] {model} → "
+        + " → ".join(plan_ids)
+        + "\n"
+    )
+
+
+def _login_quota() -> None:
+    from core.gateway.auth.plan_registry import get_plan_registry
+
+    registry = get_plan_registry()
+    plans = registry.list_all()
+    quoted = [p for p in plans if p.quota is not None]
+    if not quoted:
+        console.print("  [muted]No quota-bearing plans registered.[/muted]\n")
+        return
+    console.print("\n  [header]Plan Quota[/header]")
+    for plan in quoted:
+        usage = registry.usage_for(plan.id)
+        assert plan.quota is not None
+        reset_in = usage.seconds_until_reset()
+        reset_label = f"{reset_in // 60}m" if reset_in > 0 else "ready"
+        console.print(
+            f"  {plan.id:<24} "
+            f"used {int(usage.weighted_calls):>4}/{plan.quota.max_calls} "
+            f"· resets in {reset_label}"
+            + (
+                "  [muted](weights: "
+                + ", ".join(
+                    f"{m}×{int(w)}" for m, w in plan.quota.model_weights.items()
+                )
+                + ")[/muted]"
+                if plan.quota.model_weights
+                else ""
+            )
+        )
+    console.print()
 
 
 def resolve_action(cmd: str) -> str | None:

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -748,52 +748,16 @@ def _auth_add_interactive(store: ProfileStore, add_args: str) -> None:
     console.print()
 
 
-# Module-level profile store singleton
-_profile_store: ProfileStore | None = None
-
-
 def _get_profile_store() -> ProfileStore:
-    """Get or create the module-level profile store, seeded from settings."""
-    global _profile_store
-    from core.gateway.auth.profiles import AuthProfile, CredentialType
+    """Return the runtime ProfileStore singleton.
 
-    if _profile_store is not None:
-        return _profile_store
+    Pre-v0.50.0 the CLI maintained its own parallel store, so credentials
+    added through `/auth add` were invisible to the LLM dispatch layer.
+    Both layers now read from `runtime_wiring.infra` directly.
+    """
+    from core.runtime_wiring.infra import ensure_profile_store
 
-    store = ProfileStore()
-
-    # Seed from existing settings
-    from core.config import settings
-
-    if settings.anthropic_api_key:
-        store.add(
-            AuthProfile(
-                name="anthropic:default",
-                provider="anthropic",
-                credential_type=CredentialType.API_KEY,
-                key=settings.anthropic_api_key,
-            )
-        )
-    if settings.openai_api_key:
-        store.add(
-            AuthProfile(
-                name="openai:default",
-                provider="openai",
-                credential_type=CredentialType.API_KEY,
-                key=settings.openai_api_key,
-            )
-        )
-    if settings.zai_api_key:
-        store.add(
-            AuthProfile(
-                name="glm:default",
-                provider="glm",
-                credential_type=CredentialType.API_KEY,
-                key=settings.zai_api_key,
-            )
-        )
-    _profile_store = store
-    return store
+    return ensure_profile_store()
 
 
 def cmd_generate(args: str) -> None:

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -50,11 +50,14 @@ MODEL_PROFILES: list[ModelProfile] = [
     ModelProfile(ANTHROPIC_SECONDARY, "Anthropic", "Sonnet 4.6", "$$"),
     ModelProfile(ANTHROPIC_BUDGET, "Anthropic", "Haiku 4.5", "$"),
     ModelProfile(OPENAI_PRIMARY, "OpenAI", "GPT-5.4", "$$"),
-    ModelProfile("gpt-5.4-mini", "Codex (Plus)", "GPT-5.4 Mini", "$"),
+    # `gpt-5.4-mini` has no `-codex` suffix → routes to "openai" provider
+    # (PAYG API key), not Codex Plus quota. Labelling it "Codex (Plus)" misled
+    # users into thinking it consumed their subscription.
+    ModelProfile("gpt-5.4-mini", "OpenAI", "GPT-5.4 Mini", "$"),
     ModelProfile("gpt-5.3-codex", "Codex (Plus)", "GPT-5.3 Codex", "$$"),
-    ModelProfile(GLM_PRIMARY, "ZhipuAI", "GLM-5.1", "$"),
-    ModelProfile("glm-5-turbo", "ZhipuAI", "GLM-5 Turbo", "$"),
-    ModelProfile("glm-4.7-flash", "ZhipuAI", "GLM-4.7 Flash", "$"),
+    ModelProfile(GLM_PRIMARY, "GLM", "GLM-5.1", "$"),
+    ModelProfile("glm-5-turbo", "GLM", "GLM-5 Turbo", "$"),
+    ModelProfile("glm-4.7-flash", "GLM", "GLM-4.7 Flash", "$"),
 ]
 
 _MODEL_INDEX: dict[str, ModelProfile] = {m.id: m for m in MODEL_PROFILES}
@@ -285,7 +288,7 @@ def _check_provider_key(selected: ModelProfile) -> None:
     provider_key_map: dict[str, tuple[str, str]] = {
         "Anthropic": (settings.anthropic_api_key, "ANTHROPIC_API_KEY"),
         "OpenAI": (settings.openai_api_key, "OPENAI_API_KEY"),
-        "ZhipuAI": (settings.zai_api_key, "ZAI_API_KEY"),
+        "GLM": (settings.zai_api_key, "ZAI_API_KEY"),
     }
 
     # Codex (Plus) requires OAuth — check token availability
@@ -578,8 +581,8 @@ def _sync_oauth_profile_after_login(cli_name: str) -> None:
         codex_creds = read_codex_cli_credentials(force_refresh=True)
         if codex_creds:
             profile = AuthProfile(
-                name="openai:codex-cli",
-                provider="openai",
+                name="openai-codex:codex-cli",
+                provider="openai-codex",
                 credential_type=CredentialType.OAUTH,
                 key=codex_creds["access_token"],
                 refresh_token=codex_creds.get("refresh_token", ""),
@@ -684,8 +687,8 @@ def _auth_add_interactive(store: ProfileStore, add_args: str) -> None:
     from core.gateway.auth.profiles import AuthProfile, CredentialType
 
     # Level 1: Provider selection
-    providers = ["anthropic", "openai", "zhipuai"]
-    entries = ["Anthropic", "OpenAI", "ZhipuAI"]
+    providers = ["anthropic", "openai", "glm"]
+    entries = ["Anthropic", "OpenAI", "GLM"]
 
     menu = TerminalMenu(
         entries,
@@ -783,8 +786,8 @@ def _get_profile_store() -> ProfileStore:
     if settings.zai_api_key:
         store.add(
             AuthProfile(
-                name="zhipuai:default",
-                provider="zhipuai",
+                name="glm:default",
+                provider="glm",
                 credential_type=CredentialType.API_KEY,
                 key=settings.zai_api_key,
             )

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -191,9 +191,7 @@ def cmd_key(args: str) -> bool:
 
     # /key (no args) → defer to the unified /login dashboard
     if not parts:
-        console.print(
-            "\n  [muted]/key now redirects to the unified /login dashboard.[/muted]"
-        )
+        console.print("\n  [muted]/key now redirects to the unified /login dashboard.[/muted]")
         cmd_login("")
         return False
 
@@ -2020,11 +2018,7 @@ def _login_show_status() -> None:
                     import time as _t
 
                     rem = int(p.expires_at - _t.time())
-                    expiry = (
-                        f" · expires {rem // 60}m"
-                        if rem > 0
-                        else " · [error]expired[/error]"
-                    )
+                    expiry = f" · expires {rem // 60}m" if rem > 0 else " · [error]expired[/error]"
                 console.print(
                     f"  [muted]•[/muted] {p.name:<28} "
                     f"[muted]{badge:<7}[/muted] {p.masked_key} "
@@ -2135,9 +2129,7 @@ def _login_add_interactive(_args: str) -> None:
             console.print("  [warning]No key provided.[/warning]\n")
             return
         registry.add(plan)
-        registry.set_routing(
-            "glm-5.1", [plan.id, *registry.get_routing("glm-5.1")]
-        )
+        registry.set_routing("glm-5.1", [plan.id, *registry.get_routing("glm-5.1")])
         for m in ("glm-5", "glm-5-turbo", "glm-4.7-flash"):
             registry.set_routing(m, [plan.id, *registry.get_routing(m)])
         store.add(
@@ -2180,9 +2172,7 @@ def _login_add_interactive(_args: str) -> None:
             return
         provider = providers[pidx][0]
         try:
-            key = console.input(
-                f"  [label]{providers[pidx][1]} API key:[/label] "
-            ).strip()
+            key = console.input(f"  [label]{providers[pidx][1]} API key:[/label] ").strip()
         except (KeyboardInterrupt, EOFError):
             console.print("\n  [muted]Cancelled[/muted]\n")
             return
@@ -2287,8 +2277,7 @@ def _login_set_key(rest: str) -> None:
     plan = registry.get(plan_id)
     if plan is None:
         console.print(
-            f"  [warning]Unknown plan: {plan_id}[/warning]  "
-            "[muted](use /login add first)[/muted]\n"
+            f"  [warning]Unknown plan: {plan_id}[/warning]  [muted](use /login add first)[/muted]\n"
         )
         return
     store = ensure_profile_store()
@@ -2371,9 +2360,7 @@ def _login_remove(rest: str) -> None:
 def _login_route(rest: str) -> None:
     parts = rest.split()
     if len(parts) < 2:
-        console.print(
-            "  [warning]Usage: /login route <model> <plan-id> [<plan-id>...][/warning]\n"
-        )
+        console.print("  [warning]Usage: /login route <model> <plan-id> [<plan-id>...][/warning]\n")
         return
     model, plan_ids = parts[0], parts[1:]
     from core.gateway.auth.plan_registry import get_plan_registry
@@ -2385,11 +2372,7 @@ def _login_route(rest: str) -> None:
         return
     registry.set_routing(model, plan_ids)
     _persist_auth_state()
-    console.print(
-        f"  [success]Routing[/success] {model} → "
-        + " → ".join(plan_ids)
-        + "\n"
-    )
+    console.print(f"  [success]Routing[/success] {model} → " + " → ".join(plan_ids) + "\n")
 
 
 def _login_quota() -> None:
@@ -2413,9 +2396,7 @@ def _login_quota() -> None:
             f"· resets in {reset_label}"
             + (
                 "  [muted](weights: "
-                + ", ".join(
-                    f"{m}×{int(w)}" for m, w in plan.quota.model_weights.items()
-                )
+                + ", ".join(f"{m}×{int(w)}" for m, w in plan.quota.model_weights.items())
                 + ")[/muted]"
                 if plan.quota.model_weights
                 else ""

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -28,7 +28,7 @@ from core.config import (
     GLM_PRIMARY,
     OPENAI_PRIMARY,
 )
-from core.gateway.auth.profiles import ProfileStore
+from core.gateway.auth.profiles import AuthProfile, ProfileStore
 
 log = logging.getLogger(__name__)
 
@@ -313,9 +313,20 @@ def _seed_payg_plan_from_key(provider: str, key: str) -> None:
                     plan_id=plan.id,
                 )
             )
+        _persist_auth_state()
     except Exception:
         # The legacy /key path must not fail because of plan-seeding.
         log.debug("Plan seed from /key failed", exc_info=True)
+
+
+def _persist_auth_state() -> None:
+    """Persist Plan + Profile state to ~/.geode/auth.toml (best-effort)."""
+    try:
+        from core.gateway.auth.auth_toml import save_auth_toml
+
+        save_auth_toml()
+    except Exception:
+        log.debug("auth.toml save failed", exc_info=True)
 
 
 def _check_provider_key(selected: ModelProfile) -> None:
@@ -1992,9 +2003,7 @@ def _login_show_status() -> None:
         console.print("  [muted]No credentials. Run /login add or set provider env vars.[/muted]")
     else:
         # Group by provider for readability
-        from core.gateway.auth.profiles import AuthProfile as _AP
-
-        by_provider: dict[str, list[_AP]] = {}
+        by_provider: dict[str, list[AuthProfile]] = {}
         for p in profiles:
             by_provider.setdefault(p.provider, []).append(p)
         for provider in sorted(by_provider.keys()):
@@ -2147,6 +2156,7 @@ def _login_add_interactive(_args: str) -> None:
             reset_glm_client()
         except Exception:  # noqa: S110 — best-effort cache invalidation
             pass
+        _persist_auth_state()
         console.print(
             f"  [success]Registered[/success] {plan.display_name}  "
             f"[muted]({plan.base_url})[/muted]\n"
@@ -2202,6 +2212,7 @@ def _login_add_interactive(_args: str) -> None:
             field_name, env_var = env_field_map[provider]
             object.__setattr__(settings, field_name, key)
             _upsert_env(env_var, key)
+        _persist_auth_state()
         console.print(
             f"  [success]Registered[/success] {plan.display_name}  "
             f"[muted](key {_mask_key(key)})[/muted]\n"
@@ -2301,6 +2312,7 @@ def _login_set_key(rest: str) -> None:
         from core.llm.providers.glm import reset_glm_client
 
         reset_glm_client()
+    _persist_auth_state()
     console.print(
         f"  [success]Updated key[/success] for {plan.display_name}  "
         f"[muted]({_mask_key(key)})[/muted]\n"
@@ -2330,6 +2342,7 @@ def _login_use(rest: str) -> None:
     for model in model_hints.get(plan.provider, []):
         existing = [pid for pid in registry.get_routing(model) if pid != plan.id]
         registry.set_routing(model, [plan.id, *existing])
+    _persist_auth_state()
     console.print(
         f"  [success]Activated[/success] {plan.display_name} for {plan.provider} models.\n"
     )
@@ -2351,6 +2364,7 @@ def _login_remove(rest: str) -> None:
     for p in list(store.list_all()):
         if p.plan_id == plan_id:
             store.remove(p.name)
+    _persist_auth_state()
     console.print(f"  [success]Removed plan and its profiles:[/success] {plan_id}\n")
 
 
@@ -2370,6 +2384,7 @@ def _login_route(rest: str) -> None:
         console.print(f"  [warning]Unknown plan(s): {', '.join(unknown)}[/warning]\n")
         return
     registry.set_routing(model, plan_ids)
+    _persist_auth_state()
     console.print(
         f"  [success]Routing[/success] {model} → "
         + " → ".join(plan_ids)

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -190,13 +190,16 @@ def key_registration_gate() -> str | None:
 
     console.print(
         Panel(
-            "[bold]GEODE requires at least one LLM API key to operate.[/bold]\n\n"
-            "  [cyan]/key <sk-ant-...>[/cyan]        — Anthropic\n"
-            "  [cyan]/key openai <sk-...>[/cyan]     — OpenAI\n"
-            "  [cyan]/key glm <key>[/cyan]           — ZhipuAI (GLM)\n"
+            "[bold]GEODE needs a credential to talk to an LLM.[/bold]\n\n"
+            "  [cyan]/login add[/cyan]                — Interactive wizard "
+            "(plans + keys + OAuth)\n"
+            "  [cyan]/login oauth openai[/cyan]      — Codex OAuth (Plus quota)\n"
+            "  [cyan]/key <sk-ant-...>[/cyan]        — Quick paste (Anthropic)\n"
+            "  [cyan]/key openai <sk-...>[/cyan]     — Quick paste (OpenAI)\n"
+            "  [cyan]/key glm <key>[/cyan]           — Quick paste (GLM PAYG)\n"
             "  [cyan]/quit[/cyan]                    — exit\n\n"
             "[muted]Or just paste an API key directly.[/muted]",
-            title="API Key Required",
+            title="Credentials Required",
             border_style="yellow",
         )
     )
@@ -207,6 +210,15 @@ def key_registration_gate() -> str | None:
             return None
         if user_input.lower() in ("/quit", "quit", "exit"):
             return None
+
+        # /login add — full wizard takes precedence
+        if user_input.lower().startswith("/login"):
+            from core.cli.commands import cmd_login
+
+            cmd_login(user_input[len("/login"):].strip())
+            if _has_any_llm_key():
+                return "configured"
+            continue
 
         # /key command
         if user_input.startswith("/key "):

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -215,7 +215,7 @@ def key_registration_gate() -> str | None:
         if user_input.lower().startswith("/login"):
             from core.cli.commands import cmd_login
 
-            cmd_login(user_input[len("/login"):].strip())
+            cmd_login(user_input[len("/login") :].strip())
             if _has_any_llm_key():
                 return "configured"
             continue

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -367,7 +367,13 @@ class EventRenderer:
         self._clear_activity_line()
         frm = str(event.get("from_model", ""))
         to = str(event.get("to_model", ""))
-        self._out.write(f"  \033[2m\u21c4 Model: {frm} \u2192 {to}\033[0m\n")
+        # v0.50.0: surface the reason so users can tell quota exhaustion
+        # ("rate_limit") apart from auth errors ("auth_cross_provider") and
+        # context overflow ("failure_escalation"). Pre-0.50 the bare arrow
+        # left users guessing why the model changed mid-turn.
+        reason = str(event.get("reason", ""))
+        suffix = f"  ({reason})" if reason else ""
+        self._out.write(f"  \033[2m\u21c4 Model: {frm} \u2192 {to}{suffix}\033[0m\n")
         self._out.flush()
 
     def _handle_checkpoint_saved(self, event: dict[str, Any]) -> None:

--- a/core/cli/ui/mascot.py
+++ b/core/cli/ui/mascot.py
@@ -80,7 +80,14 @@ def _brand_line(
     model: str,
     cwd: str,
 ) -> Text:
-    """Build the full 3-line brand block."""
+    """Build the full 3-line brand block.
+
+    A 4th line is appended when an active plan is registered for the
+    current model (Phase 5 v0.50.0): ``Plan: GLM Coding Lite (used 23/80,
+    resets 2h 14m)`` so users see how much subscription quota they have
+    left at a glance — the same role Claude Code's account/Usage tab
+    plays.
+    """
     pad = "                     "  # align lines 2-3 under text start
 
     t = Text()
@@ -100,7 +107,43 @@ def _brand_line(
     # Line 3: cwd
     t.append(f"  {pad}{cwd}", "dim")
 
+    # Line 4 (optional): active plan summary
+    plan_summary = _resolve_active_plan_summary(model)
+    if plan_summary:
+        t.append("\n")
+        t.append(f"  {pad}{plan_summary}", "dim")
+
     return t
+
+
+def _resolve_active_plan_summary(model: str) -> str:
+    """Render a one-line plan/quota label for the mascot block.
+
+    Returns "" when no plan is registered or routing isn't initialised.
+    """
+    try:
+        from core.gateway.auth.plan_registry import resolve_routing
+
+        target = resolve_routing(model)
+        if target is None:
+            return ""
+        plan = target.plan
+        label = f"Plan: {plan.display_name}"
+        if plan.quota is None:
+            return label
+        from core.gateway.auth.plan_registry import get_plan_registry
+
+        usage = get_plan_registry().usage_for(plan.id)
+        remaining = usage.remaining_in_window(plan)
+        used = int(usage.weighted_calls)
+        if usage.next_reset_at > 0:
+            mins = max(0, usage.seconds_until_reset() // 60)
+            reset_label = f"resets {mins}m"
+        else:
+            reset_label = f"window {plan.quota.window_s // 3600}h"
+        return f"{label} (used {used}/{plan.quota.max_calls} · {remaining} left · {reset_label})"
+    except Exception:
+        return ""
 
 
 # -- Public API -----------------------------------------------------------

--- a/core/config.py
+++ b/core/config.py
@@ -366,7 +366,11 @@ CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 # ZhipuAI (GLM) models — OpenAI-compatible API, separate provider
 GLM_PRIMARY = "glm-5.1"
 GLM_FALLBACK_CHAIN: list[str] = ["glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7-flash"]
-GLM_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
+# Coding Plan endpoint (subscription-billed). PAYG endpoint is api/paas/v4 — a
+# Coding Plan key called against PAYG path silently bypasses the subscription
+# quota and incurs metered billing instead.
+GLM_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+GLM_PAYG_BASE_URL = "https://api.z.ai/api/paas/v4"
 
 
 def _resolve_provider(model: str) -> str:
@@ -388,7 +392,7 @@ def _resolve_provider(model: str) -> str:
     if model.startswith("glm-"):
         return "glm"
     if model.endswith("-codex") or model.endswith("-codex-max") or model.endswith("-codex-mini"):
-        return "codex"
+        return "openai-codex"
     if model.startswith(("gpt-", "o3-", "o4-")):
         return "openai"
     if model.startswith("gemini-"):

--- a/core/gateway/auth/auth_toml.py
+++ b/core/gateway/auth/auth_toml.py
@@ -1,0 +1,345 @@
+"""Persistence for Plans + Profile bindings → ~/.geode/auth.toml.
+
+In-memory PlanRegistry / ProfileStore singletons (Phases 1-2) restart
+empty on every process boot. This module persists user-registered Plans
+and their bound credentials to a single TOML file so `/login add` is a
+one-time action.
+
+Schema:
+
+    [[plans]]
+    id = "glm-coding-lite"
+    provider = "glm-coding"
+    kind = "subscription"
+    display_name = "GLM Coding Lite"
+    base_url = "https://api.z.ai/api/coding/paas/v4"
+    auth_type = "bearer"
+    subscription_tier = "Lite"
+    upgrade_url = "https://z.ai/subscribe"
+
+    [plans.quota]
+    window_s = 18000
+    max_calls = 80
+    model_weights = { "glm-5.1" = 3.0 }
+
+    [[profiles]]
+    name = "glm-coding-lite:user"
+    provider = "glm-coding"
+    plan_id = "glm-coding-lite"
+    credential_type = "api_key"
+    key = "..."
+
+    [routing]
+    "glm-5.1" = ["glm-coding-lite", "glm-payg"]
+
+API keys live in this file in plaintext just like .env. The file is
+created with mode 0600 so other users on the host can't read it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from core.gateway.auth.plan_registry import PlanRegistry, get_plan_registry
+from core.gateway.auth.plans import Plan, PlanKind, Quota
+from core.gateway.auth.profiles import AuthProfile, CredentialType, ProfileStore
+
+log = logging.getLogger(__name__)
+
+DEFAULT_AUTH_TOML = Path.home() / ".geode" / "auth.toml"
+
+
+def auth_toml_path() -> Path:
+    """Resolve auth.toml location, honoring `GEODE_AUTH_TOML` env override."""
+    override = os.environ.get("GEODE_AUTH_TOML")
+    return Path(override) if override else DEFAULT_AUTH_TOML
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def _plan_to_dict(plan: Plan) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "id": plan.id,
+        "provider": plan.provider,
+        "kind": plan.kind.value,
+        "display_name": plan.display_name,
+        "base_url": plan.base_url,
+        "auth_type": plan.auth_type,
+    }
+    if plan.subscription_tier:
+        out["subscription_tier"] = plan.subscription_tier
+    if plan.upgrade_url:
+        out["upgrade_url"] = plan.upgrade_url
+    if plan.quota is not None:
+        out["quota"] = {
+            "window_s": plan.quota.window_s,
+            "max_calls": plan.quota.max_calls,
+            "model_weights": plan.quota.model_weights,
+        }
+    return out
+
+
+def _plan_from_dict(d: dict[str, Any]) -> Plan:
+    quota = None
+    if "quota" in d:
+        q = d["quota"]
+        quota = Quota(
+            window_s=int(q.get("window_s", 0)),
+            max_calls=int(q.get("max_calls", 0)),
+            model_weights={k: float(v) for k, v in q.get("model_weights", {}).items()},
+        )
+    return Plan(
+        id=str(d["id"]),
+        provider=str(d["provider"]),
+        kind=PlanKind(d.get("kind", "payg")),
+        display_name=str(d.get("display_name", d["id"])),
+        base_url=str(d.get("base_url", "")),
+        auth_type=str(d.get("auth_type", "bearer")),
+        quota=quota,
+        subscription_tier=d.get("subscription_tier"),
+        upgrade_url=d.get("upgrade_url"),
+    )
+
+
+def _profile_to_dict(p: AuthProfile) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "name": p.name,
+        "provider": p.provider,
+        "credential_type": p.credential_type.value,
+        "key": p.key,
+    }
+    if p.plan_id:
+        out["plan_id"] = p.plan_id
+    if p.refresh_token:
+        out["refresh_token"] = p.refresh_token
+    if p.expires_at:
+        out["expires_at"] = p.expires_at
+    if p.managed_by:
+        out["managed_by"] = p.managed_by
+    if p.base_url_override:
+        out["base_url_override"] = p.base_url_override
+    return out
+
+
+def _profile_from_dict(d: dict[str, Any]) -> AuthProfile:
+    return AuthProfile(
+        name=str(d["name"]),
+        provider=str(d["provider"]),
+        credential_type=CredentialType(d.get("credential_type", "api_key")),
+        key=str(d.get("key", "")),
+        refresh_token=str(d.get("refresh_token", "")),
+        expires_at=float(d.get("expires_at", 0.0)),
+        managed_by=str(d.get("managed_by", "")),
+        plan_id=str(d.get("plan_id", "")),
+        base_url_override=d.get("base_url_override"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read / write
+# ---------------------------------------------------------------------------
+
+
+def save_auth_toml(
+    *,
+    registry: PlanRegistry | None = None,
+    store: ProfileStore | None = None,
+    path: Path | None = None,
+) -> Path:
+    """Serialise the current Plan + Profile state to TOML.
+
+    Only profiles that are user-managed (no `managed_by`) are persisted.
+    Codex CLI OAuth and similar borrowed credentials live in their CLI's
+    own store and are re-read on every boot.
+    """
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    registry = registry or get_plan_registry()
+    store = store or ensure_profile_store()
+    path = path or auth_toml_path()
+
+    payload: dict[str, Any] = {
+        "plans": [_plan_to_dict(p) for p in registry.list_all()],
+        "profiles": [
+            _profile_to_dict(p) for p in store.list_all() if not p.managed_by
+        ],
+        "routing": registry.all_routing(),
+    }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = _to_toml(payload)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        log.debug("Could not chmod %s to 0600", path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled TOML writer — schema is small + fixed, no third-party dep.
+# ---------------------------------------------------------------------------
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, str):
+        return _toml_string(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(v) for v in value) + "]"
+    if isinstance(value, dict):
+        return (
+            "{ "
+            + ", ".join(f"{_toml_key(k)} = {_toml_value(v)}" for k, v in value.items())
+            + " }"
+        )
+    raise TypeError(f"Unsupported TOML value type: {type(value)!r}")
+
+
+_BARE_KEY_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+
+def _toml_key(key: str) -> str:
+    if key and all(ch in _BARE_KEY_CHARS for ch in key):
+        return key
+    return _toml_string(key)
+
+
+def _to_toml(payload: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for plan in payload.get("plans", []):
+        lines.append("[[plans]]")
+        nested: dict[str, dict[str, Any]] = {}
+        for k, v in plan.items():
+            if isinstance(v, dict):
+                nested[k] = v
+            else:
+                lines.append(f"{_toml_key(k)} = {_toml_value(v)}")
+        for nk, nested_dict in nested.items():
+            lines.append(f"\n[plans.{_toml_key(nk)}]")
+            for k, v in nested_dict.items():
+                lines.append(f"{_toml_key(k)} = {_toml_value(v)}")
+        lines.append("")
+    for profile in payload.get("profiles", []):
+        lines.append("[[profiles]]")
+        for k, v in profile.items():
+            lines.append(f"{_toml_key(k)} = {_toml_value(v)}")
+        lines.append("")
+    routing = payload.get("routing") or {}
+    if routing:
+        lines.append("[routing]")
+        for model, plan_ids in routing.items():
+            lines.append(f"{_toml_key(model)} = {_toml_value(plan_ids)}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def load_auth_toml(
+    *,
+    registry: PlanRegistry | None = None,
+    store: ProfileStore | None = None,
+    path: Path | None = None,
+) -> bool:
+    """Hydrate Plan + Profile singletons from TOML.
+
+    Returns True if the file existed and was parsed. Profiles already in
+    the store (e.g. from .env / managed CLIs) are NOT removed.
+    """
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    registry = registry or get_plan_registry()
+    store = store or ensure_profile_store()
+    path = path or auth_toml_path()
+
+    if not path.exists():
+        return False
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except Exception as exc:
+        log.warning("Failed to parse %s: %s", path, exc)
+        return False
+
+    for raw in data.get("plans", []):
+        try:
+            registry.add(_plan_from_dict(raw))
+        except Exception:
+            log.warning("Skipping malformed plan entry: %r", raw, exc_info=True)
+    for raw in data.get("profiles", []):
+        try:
+            store.add(_profile_from_dict(raw))
+        except Exception:
+            log.warning("Skipping malformed profile entry: %r", raw, exc_info=True)
+    for model, plan_ids in (data.get("routing") or {}).items():
+        if isinstance(plan_ids, list):
+            registry.set_routing(str(model), [str(pid) for pid in plan_ids])
+    return True
+
+
+def migrate_env_to_toml(
+    *,
+    registry: PlanRegistry | None = None,
+    store: ProfileStore | None = None,
+    path: Path | None = None,
+) -> int:
+    """Snapshot any env-loaded PAYG keys into auth.toml on first run.
+
+    Returns the number of plans persisted. Idempotent — re-running after
+    the file exists is a no-op (data is loaded but not duplicated).
+    """
+    from core.gateway.auth.plans import default_plan_for_payg
+    from core.runtime_wiring.infra import ensure_profile_store
+
+    registry = registry or get_plan_registry()
+    store = store or ensure_profile_store()
+    path = path or auth_toml_path()
+
+    if path.exists():
+        # Already migrated. Just hydrate.
+        load_auth_toml(registry=registry, store=store, path=path)
+        return 0
+
+    from core.config import settings
+
+    seeded = 0
+    for provider, key in (
+        ("anthropic", settings.anthropic_api_key),
+        ("openai", settings.openai_api_key),
+        ("glm", settings.zai_api_key),
+    ):
+        if not key:
+            continue
+        plan = default_plan_for_payg(provider, key)
+        registry.add(plan)
+        profile_name = f"{plan.id}:env"
+        if profile_name not in store:
+            store.add(
+                AuthProfile(
+                    name=profile_name,
+                    provider=provider,
+                    credential_type=CredentialType.API_KEY,
+                    key=key,
+                    plan_id=plan.id,
+                )
+            )
+        seeded += 1
+    if seeded:
+        save_auth_toml(registry=registry, store=store, path=path)
+    return seeded

--- a/core/gateway/auth/auth_toml.py
+++ b/core/gateway/auth/auth_toml.py
@@ -167,9 +167,7 @@ def save_auth_toml(
 
     payload: dict[str, Any] = {
         "plans": [_plan_to_dict(p) for p in registry.list_all()],
-        "profiles": [
-            _profile_to_dict(p) for p in store.list_all() if not p.managed_by
-        ],
+        "profiles": [_profile_to_dict(p) for p in store.list_all() if not p.managed_by],
         "routing": registry.all_routing(),
     }
 
@@ -207,9 +205,7 @@ def _toml_value(value: Any) -> str:
         return "[" + ", ".join(_toml_value(v) for v in value) + "]"
     if isinstance(value, dict):
         return (
-            "{ "
-            + ", ".join(f"{_toml_key(k)} = {_toml_value(v)}" for k, v in value.items())
-            + " }"
+            "{ " + ", ".join(f"{_toml_key(k)} = {_toml_value(v)}" for k, v in value.items()) + " }"
         )
     raise TypeError(f"Unsupported TOML value type: {type(value)!r}")
 

--- a/core/gateway/auth/errors.py
+++ b/core/gateway/auth/errors.py
@@ -60,11 +60,7 @@ ERROR_HINTS: dict[AuthErrorCode, _HintFactory] = {
     ),
     AuthErrorCode.QUOTA_EXHAUSTED: lambda plan, provider: (
         f"{plan.display_name if plan else 'Plan'} quota exhausted in the current window. "
-        + (
-            f"Upgrade or switch tier: {plan.upgrade_url}. "
-            if plan and plan.upgrade_url
-            else ""
-        )
+        + (f"Upgrade or switch tier: {plan.upgrade_url}. " if plan and plan.upgrade_url else "")
         + "Use /login use <other-plan> to fail over."
     ),
     AuthErrorCode.SUBSCRIPTION_EXPIRED: lambda plan, provider: (

--- a/core/gateway/auth/errors.py
+++ b/core/gateway/auth/errors.py
@@ -1,0 +1,87 @@
+"""Structured auth errors with actionable user hints.
+
+Pre-v0.50.0 GEODE wrapped every credential failure as a generic
+``[warning]`` Rich string. Hermes' `AuthError(code=...)` pattern shows
+how to map machine-readable codes to *what the user can do next* —
+either a /login subcommand or an upgrade URL — so the UI doesn't have
+to guess.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import Enum
+
+from core.gateway.auth.plans import Plan
+
+
+class AuthErrorCode(Enum):
+    PLAN_NOT_REGISTERED = "plan_not_registered"
+    KEY_INVALID = "key_invalid"  # 401/403 from provider
+    OAUTH_REFRESH_FAILED = "oauth_refresh_failed"
+    QUOTA_EXHAUSTED = "quota_exhausted"  # 5h sliding window hit
+    SUBSCRIPTION_EXPIRED = "subscription_expired"  # billing lapsed
+    ENDPOINT_MISMATCH = "endpoint_mismatch"  # PAYG key on Coding endpoint, etc.
+
+
+class AuthError(RuntimeError):
+    """A credential-layer failure with structured context for UI mapping."""
+
+    def __init__(
+        self,
+        code: AuthErrorCode,
+        *,
+        plan: Plan | None = None,
+        provider: str = "",
+        message: str = "",
+    ) -> None:
+        super().__init__(message or code.value)
+        self.code = code
+        self.plan = plan
+        self.provider = provider
+
+
+# Hint factories — kept as lambdas so they capture the live Plan state.
+_HintFactory = Callable[[Plan | None, str], str]
+
+ERROR_HINTS: dict[AuthErrorCode, _HintFactory] = {
+    AuthErrorCode.PLAN_NOT_REGISTERED: lambda plan, provider: (
+        f"No plan registered for provider '{provider or '?'}'. "
+        "Run /login add to register a plan, or /key <api-key> for a quick PAYG setup."
+    ),
+    AuthErrorCode.KEY_INVALID: lambda plan, provider: (
+        f"Provider '{provider or (plan.provider if plan else '?')}' rejected the credential. "
+        f"Run /login set-key {plan.id if plan else '<plan>'} <new-key> "
+        "or /login oauth openai to refresh."
+    ),
+    AuthErrorCode.OAUTH_REFRESH_FAILED: lambda plan, provider: (
+        f"OAuth token for {plan.display_name if plan else provider} could not be refreshed. "
+        "Re-run /login oauth openai (Codex CLI) to obtain a new token."
+    ),
+    AuthErrorCode.QUOTA_EXHAUSTED: lambda plan, provider: (
+        f"{plan.display_name if plan else 'Plan'} quota exhausted in the current window. "
+        + (
+            f"Upgrade or switch tier: {plan.upgrade_url}. "
+            if plan and plan.upgrade_url
+            else ""
+        )
+        + "Use /login use <other-plan> to fail over."
+    ),
+    AuthErrorCode.SUBSCRIPTION_EXPIRED: lambda plan, provider: (
+        f"Subscription for {plan.display_name if plan else provider} has expired. "
+        + (f"Renew: {plan.upgrade_url}. " if plan and plan.upgrade_url else "")
+        + "After renewal run /login set-key <plan> <new-key>."
+    ),
+    AuthErrorCode.ENDPOINT_MISMATCH: lambda plan, provider: (
+        f"This API key targets a different endpoint than plan '{plan.id if plan else '?'}'. "
+        "Re-register via /login add and pick the correct subscription tier."
+    ),
+}
+
+
+def format_auth_error(error: AuthError) -> str:
+    """Map an AuthError to a single-line user-facing hint."""
+    factory = ERROR_HINTS.get(error.code)
+    if factory is None:
+        return str(error)
+    return factory(error.plan, error.provider)

--- a/core/gateway/auth/plan_registry.py
+++ b/core/gateway/auth/plan_registry.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass
-
 from typing import TYPE_CHECKING
 
 from core.gateway.auth.plans import Plan, PlanUsage, default_plan_for_payg
@@ -179,8 +178,8 @@ def resolve_routing(model: str) -> RoutingTarget | None:
 
 
 def _pick_profile_for_plan(
-    store: "ProfileStore",
-    rotator: "ProfileRotator",
+    store: ProfileStore,
+    rotator: ProfileRotator,
     plan: Plan,
 ) -> AuthProfile | None:
     """Find an available AuthProfile bound to this Plan, or fall back

--- a/core/gateway/auth/plan_registry.py
+++ b/core/gateway/auth/plan_registry.py
@@ -11,8 +11,14 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass
 
+from typing import TYPE_CHECKING
+
 from core.gateway.auth.plans import Plan, PlanUsage, default_plan_for_payg
 from core.gateway.auth.profiles import AuthProfile
+
+if TYPE_CHECKING:
+    from core.gateway.auth.profiles import ProfileStore
+    from core.gateway.auth.rotation import ProfileRotator
 
 
 @dataclass
@@ -172,10 +178,16 @@ def resolve_routing(model: str) -> RoutingTarget | None:
     return None
 
 
-def _pick_profile_for_plan(store, rotator, plan: Plan) -> AuthProfile | None:
+def _pick_profile_for_plan(
+    store: "ProfileStore",
+    rotator: "ProfileRotator",
+    plan: Plan,
+) -> AuthProfile | None:
     """Find an available AuthProfile bound to this Plan, or fall back
     to any available profile for the Plan's provider."""
-    bound = [p for p in store.list_all() if p.plan_id == plan.id and p.is_available]
+    bound: list[AuthProfile] = [
+        p for p in store.list_all() if p.plan_id == plan.id and p.is_available
+    ]
     if bound:
         bound.sort(key=lambda p: p.sort_key())
         return bound[0]

--- a/core/gateway/auth/plan_registry.py
+++ b/core/gateway/auth/plan_registry.py
@@ -1,0 +1,182 @@
+"""PlanRegistry — runtime store for Plan instances + routing resolution.
+
+Sits next to ProfileStore. The CLI (`/login`) creates Plans here and
+binds AuthProfiles to them via `plan_id`. Provider modules query this
+registry through `resolve_routing(model)` to pick the active endpoint
+and credential.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+from core.gateway.auth.plans import Plan, PlanUsage, default_plan_for_payg
+from core.gateway.auth.profiles import AuthProfile
+
+
+@dataclass
+class RoutingTarget:
+    """Output of resolve_routing(): which Plan + Profile to use for a model."""
+
+    plan: Plan
+    profile: AuthProfile
+    base_url: str  # final endpoint (Plan.base_url respecting profile override)
+
+
+class PlanRegistry:
+    """In-memory Plan store with model-routing resolution.
+
+    Keyed by Plan.id. A separate `_routing` map records the preferred
+    Plan ID order for each model name (set by the user via
+    `/login route`).
+    """
+
+    def __init__(self) -> None:
+        self._plans: dict[str, Plan] = {}
+        self._usage: dict[str, PlanUsage] = {}
+        # model_pattern -> ordered list of plan_ids
+        self._routing: dict[str, list[str]] = {}
+        self._lock = threading.Lock()
+
+    # --- Plan CRUD ---
+
+    def add(self, plan: Plan) -> None:
+        with self._lock:
+            self._plans[plan.id] = plan
+            self._usage.setdefault(plan.id, PlanUsage(plan_id=plan.id))
+
+    def get(self, plan_id: str) -> Plan | None:
+        return self._plans.get(plan_id)
+
+    def remove(self, plan_id: str) -> bool:
+        with self._lock:
+            existed = self._plans.pop(plan_id, None) is not None
+            self._usage.pop(plan_id, None)
+            for model, ids in list(self._routing.items()):
+                self._routing[model] = [i for i in ids if i != plan_id]
+                if not self._routing[model]:
+                    del self._routing[model]
+            return existed
+
+    def list_all(self) -> list[Plan]:
+        return list(self._plans.values())
+
+    def list_for_provider(self, provider: str) -> list[Plan]:
+        return [p for p in self._plans.values() if p.provider == provider]
+
+    def usage_for(self, plan_id: str) -> PlanUsage:
+        return self._usage.setdefault(plan_id, PlanUsage(plan_id=plan_id))
+
+    # --- Routing ---
+
+    def set_routing(self, model: str, plan_ids: list[str]) -> None:
+        with self._lock:
+            self._routing[model] = list(plan_ids)
+
+    def get_routing(self, model: str) -> list[str]:
+        return list(self._routing.get(model, ()))
+
+    def all_routing(self) -> dict[str, list[str]]:
+        return {k: list(v) for k, v in self._routing.items()}
+
+    def clear(self) -> None:
+        with self._lock:
+            self._plans.clear()
+            self._usage.clear()
+            self._routing.clear()
+
+
+# Module-level singleton (mirrors ProfileStore lifecycle)
+_plan_registry: PlanRegistry | None = None
+_registry_lock = threading.Lock()
+
+
+def get_plan_registry() -> PlanRegistry:
+    """Return the singleton PlanRegistry, building it if necessary."""
+    global _plan_registry
+    if _plan_registry is None:
+        with _registry_lock:
+            if _plan_registry is None:
+                _plan_registry = PlanRegistry()
+    return _plan_registry
+
+
+def reset_plan_registry() -> None:
+    """Test helper — clear the singleton between tests."""
+    global _plan_registry
+    with _registry_lock:
+        _plan_registry = None
+
+
+# ---------------------------------------------------------------------------
+# Routing resolution — model → (Plan, AuthProfile, base_url)
+# ---------------------------------------------------------------------------
+
+
+def resolve_routing(model: str) -> RoutingTarget | None:
+    """Resolve which Plan + AuthProfile should serve a given model.
+
+    Resolution order:
+      1. Explicit per-model routing (`PlanRegistry.set_routing`) — try
+         each Plan ID in order and return the first whose linked
+         AuthProfile is available.
+      2. Fall back to the model's resolved provider (`_resolve_provider`)
+         and use any registered Plan for that provider, picking the
+         AuthProfile by ProfileRotator priority.
+
+    Returns None when no usable credential exists.
+    """
+    from core.config import _resolve_provider
+    from core.runtime_wiring.infra import get_profile_rotator, get_profile_store
+
+    registry = get_plan_registry()
+    store = get_profile_store()
+    rotator = get_profile_rotator()
+    if store is None or rotator is None:
+        return None
+
+    plan_chain: list[Plan] = []
+
+    # 1) explicit per-model routing
+    for plan_id in registry.get_routing(model):
+        plan = registry.get(plan_id)
+        if plan is not None:
+            plan_chain.append(plan)
+
+    # 2) fallback by provider
+    if not plan_chain:
+        provider = _resolve_provider(model)
+        plan_chain = registry.list_for_provider(provider)
+        if not plan_chain:
+            # Synthesize a PAYG Plan so legacy env-var users still route.
+            profile = rotator.resolve(provider)
+            if profile is None:
+                return None
+            plan = default_plan_for_payg(provider, profile.key)
+            return RoutingTarget(
+                plan=plan,
+                profile=profile,
+                base_url=profile.base_url_override or plan.base_url,
+            )
+
+    # Pick the first Plan whose preferred profile is available
+    for plan in plan_chain:
+        profile = _pick_profile_for_plan(store, rotator, plan)
+        if profile is not None:
+            return RoutingTarget(
+                plan=plan,
+                profile=profile,
+                base_url=profile.base_url_override or plan.base_url,
+            )
+    return None
+
+
+def _pick_profile_for_plan(store, rotator, plan: Plan) -> AuthProfile | None:
+    """Find an available AuthProfile bound to this Plan, or fall back
+    to any available profile for the Plan's provider."""
+    bound = [p for p in store.list_all() if p.plan_id == plan.id and p.is_available]
+    if bound:
+        bound.sort(key=lambda p: p.sort_key())
+        return bound[0]
+    return rotator.resolve(plan.provider)

--- a/core/gateway/auth/plans.py
+++ b/core/gateway/auth/plans.py
@@ -1,0 +1,164 @@
+"""Plan — first-class subscription/credential entity.
+
+Pre-v0.50.0 GEODE collapsed three concepts into a single (provider, key)
+tuple: PAYG API keys, time-boxed subscriptions (GLM Coding Plan, ChatGPT
+Plus), and OAuth borrowed from external CLIs (Codex). This made it
+impossible to express "this key targets the Coding Plan endpoint with an
+80-call/5h quota". Plan adds the missing axis.
+
+Each Plan binds:
+  - a provider variant (openai, openai-codex, glm, glm-coding, ...)
+  - an endpoint base URL (override of ProviderSpec.default_base_url)
+  - an auth method (bearer / x-api-key / oauth_external)
+  - optional quota metadata (window + max calls + per-model weights)
+  - optional subscription tier + upgrade URL for UX
+
+AuthProfile.plan_id references a Plan; the Plan's provider becomes the
+authoritative provider for routing.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class PlanKind(Enum):
+    """How the user obtained this credential."""
+
+    PAYG = "payg"  # pay-as-you-go API key (default for env-var seeded keys)
+    SUBSCRIPTION = "subscription"  # flat-fee plan with quota (GLM Coding, ChatGPT Plus)
+    OAUTH_BORROWED = "oauth_borrowed"  # token sourced from an external CLI (Codex CLI)
+    CLOUD_PROVIDER = "cloud_provider"  # AWS Bedrock / GCP Vertex etc.
+
+
+@dataclass
+class Quota:
+    """Sliding-window quota metadata for a Plan.
+
+    Used to display "used N/M, resets in T" and to drive Phase 6 quota
+    awareness (sub-pacing). model_weights captures z.ai's "GLM-5.1
+    counts as 3× during peak hours" pattern.
+    """
+
+    window_s: int  # sliding window length, e.g. 18000 for 5h
+    max_calls: int  # soft cap within the window
+    model_weights: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class Plan:
+    """A single subscription / credential bundle."""
+
+    id: str  # user-facing label, e.g. "glm-coding-lite", "openai-payg"
+    provider: str  # ProviderSpec.id — must match PROVIDER_VARIANTS
+    kind: PlanKind
+    display_name: str  # e.g. "GLM Coding Lite"
+    base_url: str  # endpoint (may override ProviderSpec.default_base_url)
+    auth_type: str = "bearer"
+    quota: Quota | None = None
+    subscription_tier: str | None = None  # "Lite", "Pro", "Max", "ChatGPT Plus"
+    upgrade_url: str | None = None  # surfaced in error hints when quota hits
+
+
+@dataclass
+class PlanUsage:
+    """Runtime usage tracker — populated by Phase 6 quota awareness.
+
+    Carried as a sibling to Plan rather than mutating Plan so Plans
+    remain immutable configuration.
+    """
+
+    plan_id: str
+    calls_in_window: int = 0
+    weighted_calls: float = 0.0
+    next_reset_at: float = 0.0
+    last_call_at: float = 0.0
+
+    def is_quota_exhausted(self, plan: Plan) -> bool:
+        if plan.quota is None:
+            return False
+        return self.weighted_calls >= plan.quota.max_calls
+
+    def remaining_in_window(self, plan: Plan) -> int:
+        if plan.quota is None:
+            return -1  # unlimited / unknown
+        return max(0, plan.quota.max_calls - int(self.weighted_calls))
+
+    def seconds_until_reset(self) -> int:
+        return max(0, int(self.next_reset_at - time.time()))
+
+
+# ---------------------------------------------------------------------------
+# Built-in plan templates
+# ---------------------------------------------------------------------------
+
+# These let the CLI offer "you said 'GLM Coding Lite' — here are the values
+# we'll pre-fill" without forcing the user to know the endpoint or quota.
+
+GLM_CODING_TIERS: dict[str, Plan] = {
+    "lite": Plan(
+        id="glm-coding-lite",
+        provider="glm-coding",
+        kind=PlanKind.SUBSCRIPTION,
+        display_name="GLM Coding Lite",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        subscription_tier="Lite",
+        upgrade_url="https://z.ai/subscribe",
+        quota=Quota(
+            window_s=18_000,
+            max_calls=80,
+            model_weights={"glm-5.1": 3.0, "glm-5-turbo": 3.0, "glm-4.7": 1.0},
+        ),
+    ),
+    "pro": Plan(
+        id="glm-coding-pro",
+        provider="glm-coding",
+        kind=PlanKind.SUBSCRIPTION,
+        display_name="GLM Coding Pro",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        subscription_tier="Pro",
+        upgrade_url="https://z.ai/subscribe",
+        quota=Quota(
+            window_s=18_000,
+            max_calls=240,
+            model_weights={"glm-5.1": 3.0, "glm-5-turbo": 3.0, "glm-4.7": 1.0},
+        ),
+    ),
+    "max": Plan(
+        id="glm-coding-max",
+        provider="glm-coding",
+        kind=PlanKind.SUBSCRIPTION,
+        display_name="GLM Coding Max",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        subscription_tier="Max",
+        upgrade_url="https://z.ai/subscribe",
+        quota=Quota(
+            window_s=18_000,
+            max_calls=600,
+            model_weights={"glm-5.1": 3.0, "glm-5-turbo": 3.0, "glm-4.7": 1.0},
+        ),
+    ),
+}
+
+
+def default_plan_for_payg(provider: str, key: str) -> Plan:
+    """Build a default PAYG Plan from a bare API key + provider.
+
+    Used by .env auto-migration so legacy users keep working without
+    explicit `/login add` calls.
+    """
+    from core.llm.registry import get_provider_spec
+
+    spec = get_provider_spec(provider)
+    base_url = spec.default_base_url if spec else ""
+    display = spec.display_name if spec else provider
+    return Plan(
+        id=f"{provider}-payg",
+        provider=provider,
+        kind=PlanKind.PAYG,
+        display_name=f"{display} (PAYG)",
+        base_url=base_url,
+        auth_type=spec.auth_type if spec else "bearer",
+    )

--- a/core/gateway/auth/profiles.py
+++ b/core/gateway/auth/profiles.py
@@ -33,6 +33,14 @@ class AuthProfile:
     """A single authentication profile.
 
     Naming convention: {provider}:{identifier} e.g. 'anthropic:work'.
+
+    plan_id (v0.50.0+) optionally links the profile to a Plan in
+    `core.gateway.auth.plans`, which carries the endpoint, auth type,
+    quota, and subscription metadata. When unset, the profile defaults
+    to a synthetic PAYG Plan derived from `provider`.
+
+    base_url_override (v0.50.0+) lets a profile point at a non-default
+    endpoint without modifying the Plan (e.g. China-mainland mirror).
     """
 
     name: str  # e.g. "anthropic:work"
@@ -48,6 +56,8 @@ class AuthProfile:
     disabled: bool = False
     disabled_reason: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
+    plan_id: str = ""  # FK into PlanRegistry (Phase 4)
+    base_url_override: str | None = None  # overrides Plan.base_url for this profile
 
     @property
     def is_expired(self) -> bool:

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -204,15 +204,19 @@ _ADAPTER_MAP: dict[str, str] = {
     "anthropic": "core.llm.providers.anthropic:ClaudeAgenticAdapter",
     "openai": "core.llm.providers.openai:OpenAIAgenticAdapter",
     "glm": "core.llm.providers.glm:GlmAgenticAdapter",
-    "codex": "core.llm.providers.codex:CodexAgenticAdapter",
+    "openai-codex": "core.llm.providers.codex:CodexAgenticAdapter",
 }
 
 # Cross-provider fallback: when a provider's chain is exhausted, try these.
+# Plan-aware fallback (Phase 5) replaces this; for v0.50.0 Phase 0 we drop
+# implicit GLM↔OpenAI jumps so a Coding Plan auth error doesn't silently
+# spill onto a metered OpenAI key. openai-codex shares OAuth scope with no
+# other provider, so its Anthropic fallback is removed too.
 CROSS_PROVIDER_FALLBACK: dict[str, list[tuple[str, str]]] = {
     "anthropic": [("openai", OPENAI_PRIMARY)],
     "openai": [("anthropic", ANTHROPIC_PRIMARY)],
-    "glm": [("openai", OPENAI_PRIMARY), ("anthropic", ANTHROPIC_PRIMARY)],
-    "codex": [("openai", OPENAI_PRIMARY), ("anthropic", ANTHROPIC_PRIMARY)],
+    "glm": [],
+    "openai-codex": [],
 }
 
 

--- a/core/llm/provider_dispatch.py
+++ b/core/llm/provider_dispatch.py
@@ -109,7 +109,7 @@ _PROVIDER_DISPATCH: dict[str, dict[str, Any]] = {
         "bad_request_error": _openai_bad_request,
         "circuit_breaker": lambda: _glm_cb,
     },
-    "codex": {
+    "openai-codex": {
         "get_client": lambda: __import__(
             "core.llm.providers.codex", fromlist=["_get_codex_client"]
         )._get_codex_client(),

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -126,7 +126,7 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
 
     @property
     def provider_name(self) -> str:
-        return "codex"
+        return "openai-codex"
 
     @property
     def fallback_chain(self) -> list[str]:

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -30,6 +30,25 @@ _glm_lock = threading.Lock()
 _glm_circuit_breaker = CircuitBreaker()
 
 
+def _resolve_glm_endpoint() -> tuple[str, str]:
+    """Pick (api_key, base_url) for GLM, preferring a Plan-bound profile.
+
+    When the user registered a `glm-coding-*` Plan via /login, that Plan's
+    base_url + bound API key are used (so a Coding Plan key actually
+    calls the coding endpoint). Falls back to settings.zai_api_key +
+    GLM_BASE_URL for legacy .env-only setups.
+    """
+    try:
+        from core.gateway.auth.plan_registry import resolve_routing
+
+        target = resolve_routing("glm-5.1")
+        if target is not None and target.profile.key:
+            return target.profile.key, target.base_url
+    except Exception:
+        log.debug("GLM Plan-aware endpoint resolution failed", exc_info=True)
+    return settings.zai_api_key, GLM_BASE_URL
+
+
 def _get_glm_client() -> Any:
     """Lazy import and return cached GLM client (OpenAI-compatible, thread-safe).
 
@@ -41,9 +60,10 @@ def _get_glm_client() -> Any:
             if _glm_client is None:
                 import openai
 
+                api_key, base_url = _resolve_glm_endpoint()
                 _glm_client = openai.OpenAI(
-                    api_key=settings.zai_api_key,
-                    base_url=GLM_BASE_URL,
+                    api_key=api_key,
+                    base_url=base_url,
                 )
     return _glm_client
 
@@ -99,7 +119,7 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
         return list(GLM_FALLBACK_CHAIN)
 
     def _resolve_config(self, model: str) -> tuple[str, str | None]:
-        return settings.zai_api_key, GLM_BASE_URL
+        return _resolve_glm_endpoint()
 
     async def agentic_call(
         self,

--- a/core/llm/registry.py
+++ b/core/llm/registry.py
@@ -1,0 +1,89 @@
+"""Provider Variant Registry — endpoint + auth-type per provider variant.
+
+Hermes-style ProviderConfig: each variant binds (id, default base URL,
+auth header convention, optional extra headers factory). Used by Plan to
+resolve runtime endpoints and by AuthProfile validation to ensure a
+credential's provider matches a registered variant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal
+
+AuthType = Literal["bearer", "x-api-key", "oauth_external", "aws-sdk"]
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Static metadata for a provider variant."""
+
+    id: str  # canonical provider variant ID, e.g. "openai-codex"
+    display_name: str
+    default_base_url: str
+    auth_type: AuthType = "bearer"
+    # Optional callable: (access_token: str) -> dict[str, str]
+    # Used by openai-codex for Cloudflare/account headers.
+    extra_headers_factory: Callable[[str], dict[str, str]] | None = field(
+        default=None, hash=False, compare=False
+    )
+
+
+def _codex_extra_headers(_access_token: str) -> dict[str, str]:
+    """Cloudflare bypass headers for chatgpt.com/backend-api/codex.
+
+    Mirrors Hermes agent/auxiliary_client.py:_codex_cloudflare_headers.
+    The ChatGPT-Account-ID claim extraction is handled by the codex
+    provider module itself (it already parses the JWT for the account_id
+    field), so we keep this factory header-only.
+    """
+    return {
+        "User-Agent": "codex_cli_rs/0.0.0 (GEODE)",
+        "originator": "codex_cli_rs",
+    }
+
+
+PROVIDER_VARIANTS: dict[str, ProviderSpec] = {
+    "anthropic": ProviderSpec(
+        id="anthropic",
+        display_name="Anthropic",
+        default_base_url="https://api.anthropic.com",
+        auth_type="x-api-key",
+    ),
+    "openai": ProviderSpec(
+        id="openai",
+        display_name="OpenAI",
+        default_base_url="https://api.openai.com/v1",
+        auth_type="bearer",
+    ),
+    "openai-codex": ProviderSpec(
+        id="openai-codex",
+        display_name="OpenAI Codex (Plus)",
+        default_base_url="https://chatgpt.com/backend-api/codex",
+        auth_type="oauth_external",
+        extra_headers_factory=_codex_extra_headers,
+    ),
+    "glm": ProviderSpec(
+        id="glm",
+        display_name="GLM (PAYG)",
+        default_base_url="https://api.z.ai/api/paas/v4",
+        auth_type="bearer",
+    ),
+    "glm-coding": ProviderSpec(
+        id="glm-coding",
+        display_name="GLM Coding Plan",
+        default_base_url="https://api.z.ai/api/coding/paas/v4",
+        auth_type="bearer",
+    ),
+}
+
+
+def get_provider_spec(provider: str) -> ProviderSpec | None:
+    """Look up the ProviderSpec for a provider variant ID."""
+    return PROVIDER_VARIANTS.get(provider)
+
+
+def list_provider_ids() -> list[str]:
+    """Return all registered provider variant IDs."""
+    return list(PROVIDER_VARIANTS.keys())

--- a/core/runtime_wiring/infra.py
+++ b/core/runtime_wiring/infra.py
@@ -333,6 +333,19 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
     _profile_store = profile_store
     cooldown_tracker = CooldownTracker()
 
+    # v0.50.0 — hydrate Plans + user-defined Profiles from ~/.geode/auth.toml.
+    # On first run we migrate any env-loaded API keys into the file so the
+    # next startup sees them as PAYG plans.
+    try:
+        from core.gateway.auth.auth_toml import auth_toml_path, load_auth_toml, migrate_env_to_toml
+
+        if auth_toml_path().exists():
+            load_auth_toml()
+        else:
+            migrate_env_to_toml()
+    except Exception:  # pragma: no cover — bootstrap must never fail on auth I/O
+        log.debug("auth.toml hydration skipped", exc_info=True)
+
     # Register managed token refreshers
     try:
         from core.gateway.auth.codex_cli_oauth import refresh_codex_cli_token

--- a/core/runtime_wiring/infra.py
+++ b/core/runtime_wiring/infra.py
@@ -253,8 +253,8 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
         if codex_creds:
             profile_store.add(
                 AuthProfile(
-                    name="openai:codex-cli",
-                    provider="openai",
+                    name="openai-codex:codex-cli",
+                    provider="openai-codex",
                     credential_type=CredentialType.OAUTH,
                     key=codex_creds["access_token"],
                     refresh_token=codex_creds.get("refresh_token", ""),

--- a/core/runtime_wiring/infra.py
+++ b/core/runtime_wiring/infra.py
@@ -27,13 +27,35 @@ log = logging.getLogger(__name__)
 DEFAULT_GLOBAL_CONCURRENCY = 8
 DEFAULT_GATEWAY_CONCURRENCY = 4
 
-# Module-level accessor for ProfileRotator (set by build_auth, used by providers)
+# Module-level accessors set by build_auth().
+# Both runtime LLM dispatch and the CLI (`/login`, `/auth`) read from the
+# same singletons so a credential added through the UI is immediately seen
+# by ProfileRotator.resolve(). Pre-v0.50.0 there were two parallel
+# ProfileStore instances and they drifted out of sync.
+_profile_store: ProfileStore | None = None
 _profile_rotator: ProfileRotator | None = None
 
 
 def get_profile_rotator() -> ProfileRotator | None:
     """Return the ProfileRotator built by build_auth(), or None if not yet initialized."""
     return _profile_rotator
+
+
+def get_profile_store() -> ProfileStore | None:
+    """Return the ProfileStore built by build_auth(), or None if not yet initialized."""
+    return _profile_store
+
+
+def ensure_profile_store() -> ProfileStore:
+    """Return the singleton ProfileStore, building it if necessary.
+
+    Used by CLI commands that may run before the runtime bootstrap (e.g.
+    `/login` invoked at startup). Idempotent.
+    """
+    if _profile_store is None:
+        build_auth()
+    assert _profile_store is not None  # build_auth populates the singleton
+    return _profile_store
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +255,15 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
     Claude Code OAuth tokens are auto-detected from macOS Keychain or
     ~/.claude/.credentials.json (OpenClaw managedBy pattern).
     ProfileRotator selects OAUTH over API_KEY by type priority.
+
+    Idempotent: returns the cached singleton on subsequent calls so the
+    CLI and runtime bootstrap can both reach for the store without
+    creating duplicate instances (pre-v0.50.0 caused dispatch/UI drift).
     """
+    global _profile_store, _profile_rotator
+    if _profile_store is not None and _profile_rotator is not None:
+        return _profile_store, _profile_rotator, CooldownTracker()
+
     from core.gateway.auth.profiles import AuthProfile, CredentialType
 
     profile_store = ProfileStore()
@@ -298,9 +328,9 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
                 key=settings.zai_api_key,
             )
         )
-    global _profile_rotator
     profile_rotator = ProfileRotator(profile_store)
     _profile_rotator = profile_rotator
+    _profile_store = profile_store
     cooldown_tracker = CooldownTracker()
 
     # Register managed token refreshers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.49.1"
+version = "0.50.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,13 @@ _tx_mod.DEFAULT_TRANSCRIPT_DIR = Path(_test_transcript_dir)
 
 # v0.50.0 — auth-plans singletons (ProfileStore, ProfileRotator, PlanRegistry)
 # leak between tests. Reset them around every test so state from one suite
-# (e.g. seeding a Coding Plan profile) doesn't influence another.
+# (e.g. seeding a Coding Plan profile) doesn't influence another. Also
+# redirect ~/.geode/auth.toml writes to a temp file so tests can never
+# clobber a developer's real credentials.
 import pytest  # noqa: E402
+
+_test_auth_toml = os.path.join(tempfile.gettempdir(), "geode_test_auth.toml")
+os.environ.setdefault("GEODE_AUTH_TOML", _test_auth_toml)
 
 
 @pytest.fixture(autouse=True)
@@ -48,7 +53,12 @@ def _reset_auth_singletons():
     _infra._profile_store = None
     _infra._profile_rotator = None
     _pr._plan_registry = None
+    # Make sure no leftover auth.toml from a prior test run influences this one
+    if os.path.exists(_test_auth_toml):
+        os.remove(_test_auth_toml)
     yield
     _infra._profile_store = None
     _infra._profile_rotator = None
     _pr._plan_registry = None
+    if os.path.exists(_test_auth_toml):
+        os.remove(_test_auth_toml)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,23 @@ import core.cli.transcript as _tx_mod  # noqa: E402
 
 _cp_mod.DEFAULT_SESSION_DIR = Path(_test_session_dir)
 _tx_mod.DEFAULT_TRANSCRIPT_DIR = Path(_test_transcript_dir)
+
+
+# v0.50.0 — auth-plans singletons (ProfileStore, ProfileRotator, PlanRegistry)
+# leak between tests. Reset them around every test so state from one suite
+# (e.g. seeding a Coding Plan profile) doesn't influence another.
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_singletons():
+    from core.gateway.auth import plan_registry as _pr
+    from core.runtime_wiring import infra as _infra
+
+    _infra._profile_store = None
+    _infra._profile_rotator = None
+    _pr._plan_registry = None
+    yield
+    _infra._profile_store = None
+    _infra._profile_rotator = None
+    _pr._plan_registry = None

--- a/tests/test_auth_errors.py
+++ b/tests/test_auth_errors.py
@@ -1,0 +1,48 @@
+"""Phase 5 — AuthError + ERROR_HINTS user-facing message tests."""
+
+from __future__ import annotations
+
+from core.gateway.auth.errors import (
+    AuthError,
+    AuthErrorCode,
+    format_auth_error,
+)
+from core.gateway.auth.plans import GLM_CODING_TIERS, default_plan_for_payg
+
+
+class TestErrorHints:
+    def test_plan_not_registered_directs_to_login_add(self) -> None:
+        err = AuthError(AuthErrorCode.PLAN_NOT_REGISTERED, provider="openai")
+        msg = format_auth_error(err)
+        assert "/login add" in msg
+        assert "openai" in msg
+
+    def test_quota_exhausted_includes_upgrade_url_when_present(self) -> None:
+        plan = GLM_CODING_TIERS["lite"]
+        err = AuthError(AuthErrorCode.QUOTA_EXHAUSTED, plan=plan)
+        msg = format_auth_error(err)
+        assert plan.upgrade_url in msg
+        assert "/login use" in msg
+
+    def test_key_invalid_suggests_set_key(self) -> None:
+        plan = default_plan_for_payg("openai", "sk-stale")
+        err = AuthError(AuthErrorCode.KEY_INVALID, plan=plan, provider="openai")
+        msg = format_auth_error(err)
+        assert f"/login set-key {plan.id}" in msg
+
+    def test_oauth_refresh_directs_to_oauth_command(self) -> None:
+        err = AuthError(AuthErrorCode.OAUTH_REFRESH_FAILED, provider="openai-codex")
+        msg = format_auth_error(err)
+        assert "/login oauth openai" in msg
+
+    def test_subscription_expired_falls_back_when_no_upgrade_url(self) -> None:
+        plan = default_plan_for_payg("openai", "")
+        err = AuthError(AuthErrorCode.SUBSCRIPTION_EXPIRED, plan=plan)
+        msg = format_auth_error(err)
+        assert "/login set-key" in msg
+
+    def test_endpoint_mismatch_references_login_add(self) -> None:
+        plan = GLM_CODING_TIERS["lite"]
+        err = AuthError(AuthErrorCode.ENDPOINT_MISMATCH, plan=plan)
+        msg = format_auth_error(err)
+        assert "/login add" in msg

--- a/tests/test_auth_store_singleton.py
+++ b/tests/test_auth_store_singleton.py
@@ -1,0 +1,71 @@
+"""Single ProfileStore invariant — Phase 1 of v0.50.0.
+
+Pre-v0.50.0 the CLI (`/auth`) and the runtime LLM dispatch held two
+separate ProfileStore instances. A credential added via the UI was not
+visible to ProfileRotator.resolve(), so the user's mental model
+("I added the key, why does it still say 'not configured'?") diverged
+from reality. These tests pin the single-store invariant.
+"""
+
+from __future__ import annotations
+
+from core.gateway.auth.profiles import AuthProfile, CredentialType
+
+
+def _reset_singletons() -> None:
+    """Force build_auth() to re-seed for isolated test runs."""
+    from core.runtime_wiring import infra
+
+    infra._profile_store = None
+    infra._profile_rotator = None
+
+
+class TestSingleStore:
+    def test_ensure_profile_store_is_idempotent(self) -> None:
+        _reset_singletons()
+        from core.runtime_wiring.infra import ensure_profile_store
+
+        s1 = ensure_profile_store()
+        s2 = ensure_profile_store()
+        assert s1 is s2
+
+    def test_cli_and_runtime_share_store(self) -> None:
+        _reset_singletons()
+        from core.cli.commands import _get_profile_store
+        from core.runtime_wiring.infra import ensure_profile_store
+
+        runtime_store = ensure_profile_store()
+        cli_store = _get_profile_store()
+        assert runtime_store is cli_store
+
+    def test_credential_added_via_cli_is_visible_to_rotator(self) -> None:
+        _reset_singletons()
+        from core.cli.commands import _get_profile_store
+        from core.runtime_wiring.infra import get_profile_rotator
+
+        store = _get_profile_store()
+        store.add(
+            AuthProfile(
+                name="anthropic:test-singleton",
+                provider="anthropic",
+                credential_type=CredentialType.API_KEY,
+                key="sk-ant-test",
+            )
+        )
+
+        rotator = get_profile_rotator()
+        assert rotator is not None
+        resolved = rotator.resolve("anthropic")
+        assert resolved is not None
+        assert resolved.name == "anthropic:test-singleton" or any(
+            p.name == "anthropic:test-singleton" for p in store.list_by_provider("anthropic")
+        )
+
+    def test_build_auth_returns_same_singleton(self) -> None:
+        _reset_singletons()
+        from core.runtime_wiring.infra import build_auth
+
+        s1, r1, _ = build_auth()
+        s2, r2, _ = build_auth()
+        assert s1 is s2
+        assert r1 is r2

--- a/tests/test_auth_toml.py
+++ b/tests/test_auth_toml.py
@@ -72,9 +72,7 @@ class TestRoundtrip:
         assert registry2.get("glm-coding-lite") is not None
         assert registry2.get_routing("glm-5.1") == ["glm-coding-lite"]
         store2 = ensure_profile_store()
-        prof = next(
-            (p for p in store2.list_all() if p.name == "glm-coding-lite:user"), None
-        )
+        prof = next((p for p in store2.list_all() if p.name == "glm-coding-lite:user"), None)
         assert prof is not None
         assert prof.key == "zai-test-key"
         path.unlink()

--- a/tests/test_auth_toml.py
+++ b/tests/test_auth_toml.py
@@ -1,0 +1,158 @@
+"""Phase 4 — auth.toml persistence + .env migration tests."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from core.gateway.auth.auth_toml import (
+    auth_toml_path,
+    load_auth_toml,
+    migrate_env_to_toml,
+    save_auth_toml,
+)
+from core.gateway.auth.plan_registry import (
+    get_plan_registry,
+    reset_plan_registry,
+)
+from core.gateway.auth.plans import GLM_CODING_TIERS
+from core.gateway.auth.profiles import AuthProfile, CredentialType
+
+
+def _fresh_path() -> Path:
+    fd, name = tempfile.mkstemp(suffix=".toml")
+    os.close(fd)
+    p = Path(name)
+    p.unlink()  # save_auth_toml will recreate
+    return p
+
+
+def _reset_state() -> None:
+    from core.runtime_wiring import infra as _infra
+
+    _infra._profile_store = None
+    _infra._profile_rotator = None
+    reset_plan_registry()
+
+
+class TestRoundtrip:
+    def test_save_then_load_preserves_plan(self) -> None:
+        _reset_state()
+        from core.runtime_wiring.infra import ensure_profile_store
+
+        store = ensure_profile_store()
+        registry = get_plan_registry()
+        plan = GLM_CODING_TIERS["lite"]
+        registry.add(plan)
+        store.add(
+            AuthProfile(
+                name="glm-coding-lite:user",
+                provider="glm-coding",
+                credential_type=CredentialType.API_KEY,
+                key="zai-test-key",
+                plan_id=plan.id,
+            )
+        )
+        registry.set_routing("glm-5.1", [plan.id])
+
+        path = _fresh_path()
+        save_auth_toml(path=path)
+        assert path.exists()
+        text = path.read_text()
+        assert "glm-coding-lite" in text
+        assert "zai-test-key" in text
+        assert "[plans.quota]" in text
+        assert "max_calls = 80" in text
+
+        # Reload into a fresh state
+        _reset_state()
+        load_auth_toml(path=path)
+        registry2 = get_plan_registry()
+        assert registry2.get("glm-coding-lite") is not None
+        assert registry2.get_routing("glm-5.1") == ["glm-coding-lite"]
+        store2 = ensure_profile_store()
+        prof = next(
+            (p for p in store2.list_all() if p.name == "glm-coding-lite:user"), None
+        )
+        assert prof is not None
+        assert prof.key == "zai-test-key"
+        path.unlink()
+
+    def test_managed_profiles_are_not_persisted(self) -> None:
+        _reset_state()
+        from core.runtime_wiring.infra import ensure_profile_store
+
+        store = ensure_profile_store()
+        store.add(
+            AuthProfile(
+                name="openai-codex:codex-cli",
+                provider="openai-codex",
+                credential_type=CredentialType.OAUTH,
+                key="oauth-token-borrowed",
+                managed_by="codex-cli",
+            )
+        )
+        path = _fresh_path()
+        save_auth_toml(path=path)
+        text = path.read_text()
+        assert "oauth-token-borrowed" not in text
+        path.unlink()
+
+
+class TestMigrateEnvToToml:
+    def test_migration_seeds_payg_plans_for_env_keys(self) -> None:
+        _reset_state()
+        from unittest.mock import patch
+
+        path = _fresh_path()
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "sk-ant-test"
+            mock_settings.openai_api_key = "sk-proj-test"
+            mock_settings.zai_api_key = ""
+
+            seeded = migrate_env_to_toml(path=path)
+            assert seeded == 2
+            assert path.exists()
+
+            registry = get_plan_registry()
+            ids = {p.id for p in registry.list_all()}
+            assert "anthropic-payg" in ids
+            assert "openai-payg" in ids
+            assert "glm-payg" not in ids
+        path.unlink()
+
+    def test_migration_is_idempotent(self) -> None:
+        _reset_state()
+        from unittest.mock import patch
+
+        path = _fresh_path()
+        with patch("core.config.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "sk-ant-test"
+            mock_settings.openai_api_key = ""
+            mock_settings.zai_api_key = ""
+
+            migrate_env_to_toml(path=path)
+
+            # Second call sees the file exists → just loads, doesn't double-seed
+            _reset_state()
+            seeded = migrate_env_to_toml(path=path)
+            assert seeded == 0
+
+            registry = get_plan_registry()
+            assert sum(1 for p in registry.list_all() if p.id == "anthropic-payg") == 1
+        path.unlink()
+
+
+class TestEnvOverride:
+    def test_geode_auth_toml_env_var_redirects_path(self) -> None:
+        custom = _fresh_path()
+        old = os.environ.get("GEODE_AUTH_TOML")
+        try:
+            os.environ["GEODE_AUTH_TOML"] = str(custom)
+            assert auth_toml_path() == custom
+        finally:
+            if old is None:
+                os.environ.pop("GEODE_AUTH_TOML", None)
+            else:
+                os.environ["GEODE_AUTH_TOML"] = old

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -22,10 +22,12 @@ class TestCodexConfig:
     def test_resolve_provider_codex_models(self):
         from core.config import _resolve_provider
 
-        assert _resolve_provider("gpt-5.3-codex") == "codex"
-        assert _resolve_provider("gpt-5.2-codex") == "codex"
-        assert _resolve_provider("gpt-5.1-codex-max") == "codex"
-        assert _resolve_provider("gpt-5.1-codex-mini") == "codex"
+        # v0.50.0: Codex OAuth is a distinct provider variant ("openai-codex")
+        # so its credentials never leak into general OpenAI calls.
+        assert _resolve_provider("gpt-5.3-codex") == "openai-codex"
+        assert _resolve_provider("gpt-5.2-codex") == "openai-codex"
+        assert _resolve_provider("gpt-5.1-codex-max") == "openai-codex"
+        assert _resolve_provider("gpt-5.1-codex-mini") == "openai-codex"
 
     def test_resolve_provider_non_codex(self):
         from core.config import _resolve_provider
@@ -94,7 +96,7 @@ class TestCodexAdapterProperties:
         from core.llm.providers.codex import CodexAgenticAdapter
 
         adapter = CodexAgenticAdapter()
-        assert adapter.provider_name == "codex"
+        assert adapter.provider_name == "openai-codex"
 
     def test_fallback_chain(self):
         from core.llm.providers.codex import CodexAgenticAdapter
@@ -156,21 +158,26 @@ class TestAdapterMap:
     def test_codex_in_adapter_map(self):
         from core.llm.adapters import _ADAPTER_MAP
 
-        assert "codex" in _ADAPTER_MAP
-        assert "CodexAgenticAdapter" in _ADAPTER_MAP["codex"]
+        assert "openai-codex" in _ADAPTER_MAP
+        assert "CodexAgenticAdapter" in _ADAPTER_MAP["openai-codex"]
 
     def test_codex_cross_provider_fallback(self):
         from core.llm.adapters import CROSS_PROVIDER_FALLBACK
 
-        assert "codex" in CROSS_PROVIDER_FALLBACK
-        providers = [p for p, _ in CROSS_PROVIDER_FALLBACK["codex"]]
-        assert "openai" in providers
+        # v0.50.0: openai-codex no longer auto-falls back across providers.
+        # OAuth scope is provider-specific (chatgpt.com/backend-api/codex),
+        # so silent jumps to PAYG OpenAI/Anthropic would surprise users.
+        assert "openai-codex" in CROSS_PROVIDER_FALLBACK
+        assert CROSS_PROVIDER_FALLBACK["openai-codex"] == []
 
 
 class TestModelSelector:
     def test_codex_in_model_profiles(self):
         from core.cli.commands import MODEL_PROFILES
 
+        # v0.50.0: only models with the "-codex" suffix actually route to
+        # Codex (Plus). gpt-5.4-mini was relabelled to plain OpenAI because
+        # it routes to PAYG.
         codex_profiles = [p for p in MODEL_PROFILES if "Codex" in p.provider]
-        assert len(codex_profiles) >= 2
-        assert any("Codex" in p.provider for p in codex_profiles)
+        assert len(codex_profiles) >= 1
+        assert any(p.id.endswith("-codex") for p in codex_profiles)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -518,10 +518,10 @@ class TestCheckProviderKey:
             settings.openai_api_key = old
 
     def test_warns_missing_glm_key(self):
-        """Switching to ZhipuAI model without key should warn."""
+        """Switching to GLM model without key should warn."""
         from core.config import GLM_PRIMARY, settings
 
-        profile = ModelProfile(GLM_PRIMARY, "ZhipuAI", "GLM-5", "$")
+        profile = ModelProfile(GLM_PRIMARY, "GLM", "GLM-5", "$")
         old = settings.zai_api_key
         try:
             settings.zai_api_key = ""

--- a/tests/test_login_command.py
+++ b/tests/test_login_command.py
@@ -1,0 +1,133 @@
+"""Phase 3 — /login unified command UX tests.
+
+Smoke-tests for the subcommand router and the side effects on
+ProfileStore + PlanRegistry. UI rendering is covered by snapshot tests
+of the dashboard string output.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.cli.commands import cmd_login
+from core.gateway.auth.plan_registry import (
+    get_plan_registry,
+    reset_plan_registry,
+)
+from core.gateway.auth.plans import GLM_CODING_TIERS, default_plan_for_payg
+
+
+def _reset_state() -> None:
+    from core.runtime_wiring import infra
+
+    infra._profile_store = None
+    infra._profile_rotator = None
+    reset_plan_registry()
+
+
+class TestSubcommandRouter:
+    def test_bare_login_renders_dashboard(self) -> None:
+        _reset_state()
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_login("")
+            assert mock_console.print.called
+
+    def test_help_subcommand(self) -> None:
+        _reset_state()
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_login("help")
+            text = " ".join(
+                str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+            )
+            assert "/login add" in text
+            assert "/login oauth" in text
+
+    def test_unknown_subcommand_warns(self) -> None:
+        _reset_state()
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_login("nonsense")
+            text = " ".join(
+                str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+            )
+            assert "Unknown" in text
+
+
+class TestSetKeyAndUse:
+    def test_set_key_updates_existing_plan(self) -> None:
+        _reset_state()
+        registry = get_plan_registry()
+        plan = default_plan_for_payg("openai", "")
+        registry.add(plan)
+        cmd_login(f"set-key {plan.id} sk-fresh-key-1234567890")
+        from core.runtime_wiring.infra import ensure_profile_store
+
+        store = ensure_profile_store()
+        bound = [p for p in store.list_all() if p.plan_id == plan.id]
+        assert bound and bound[0].key == "sk-fresh-key-1234567890"
+
+    def test_set_key_unknown_plan_warns(self) -> None:
+        _reset_state()
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_login("set-key ghost sk-key")
+            text = " ".join(
+                str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+            )
+            assert "Unknown plan" in text
+
+    def test_use_pins_plan_for_provider(self) -> None:
+        _reset_state()
+        registry = get_plan_registry()
+        plan = GLM_CODING_TIERS["lite"]
+        registry.add(plan)
+        cmd_login(f"use {plan.id}")
+        chain = registry.get_routing("glm-5.1")
+        assert chain[0] == plan.id
+
+
+class TestRouteAndQuota:
+    def test_route_requires_known_plan(self) -> None:
+        _reset_state()
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_login("route glm-5.1 ghost-plan")
+            text = " ".join(
+                str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+            )
+            assert "Unknown plan" in text
+
+    def test_route_records_chain(self) -> None:
+        _reset_state()
+        registry = get_plan_registry()
+        a = default_plan_for_payg("glm", "")
+        a.id = "glm-a"
+        registry.add(a)
+        b = GLM_CODING_TIERS["lite"]
+        registry.add(b)
+        cmd_login(f"route glm-5.1 {b.id} {a.id}")
+        assert registry.get_routing("glm-5.1") == [b.id, a.id]
+
+    def test_quota_shows_subscription_plans(self) -> None:
+        _reset_state()
+        registry = get_plan_registry()
+        plan = GLM_CODING_TIERS["lite"]
+        registry.add(plan)
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_login("quota")
+            text = " ".join(
+                str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+            )
+            assert plan.id in text
+            assert "80" in text  # max_calls
+
+
+class TestLegacyKeyAlias:
+    def test_bare_key_redirects_to_login(self) -> None:
+        _reset_state()
+        from core.cli.commands import cmd_key
+
+        with patch("core.cli.commands.console") as mock_console:
+            cmd_key("")
+            text = " ".join(
+                str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+            )
+            # Either the deprecation hint or the dashboard "Plans" header must show
+            assert "Plans" in text or "redirects" in text

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -113,15 +113,16 @@ class TestModelEscalation:
         assert loop.model == ANTHROPIC_PRIMARY
         assert loop._provider == "anthropic"
 
-    def test_cross_provider_glm_to_openai(self) -> None:
-        """When GLM chain is exhausted, escalate to OpenAI."""
+    def test_glm_does_not_auto_escalate_cross_provider(self) -> None:
+        """v0.50.0: GLM Coding Plan auth errors must not silently divert to a
+        metered OpenAI key. CROSS_PROVIDER_FALLBACK['glm'] is now empty;
+        cross-plan jumps require explicit user confirmation (Phase 5)."""
         last_glm = GLM_FALLBACK_CHAIN[-1]
         loop = _make_loop(model=last_glm, provider="glm")
 
         result = loop._try_model_escalation()
-        assert result is True
-        assert loop.model == OPENAI_PRIMARY
-        assert loop._provider == "openai"
+        assert result is False
+        assert loop._provider == "glm"
 
     def test_escalation_returns_false_when_fully_exhausted(self) -> None:
         """Returns False when both intra-chain and cross-provider are exhausted."""

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -13,7 +13,6 @@ from core.gateway.auth.plans import (
     Plan,
     PlanKind,
     PlanUsage,
-    Quota,
     default_plan_for_payg,
 )
 from core.gateway.auth.profiles import AuthProfile, CredentialType

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,160 @@
+"""Phase 2 — Plan + ProviderSpec + PlanRegistry data model tests."""
+
+from __future__ import annotations
+
+from core.gateway.auth.plan_registry import (
+    PlanRegistry,
+    get_plan_registry,
+    reset_plan_registry,
+    resolve_routing,
+)
+from core.gateway.auth.plans import (
+    GLM_CODING_TIERS,
+    Plan,
+    PlanKind,
+    PlanUsage,
+    Quota,
+    default_plan_for_payg,
+)
+from core.gateway.auth.profiles import AuthProfile, CredentialType
+from core.llm.registry import PROVIDER_VARIANTS, get_provider_spec
+
+
+class TestProviderRegistry:
+    def test_required_variants_registered(self) -> None:
+        for v in ("anthropic", "openai", "openai-codex", "glm", "glm-coding"):
+            assert v in PROVIDER_VARIANTS, v
+
+    def test_codex_variant_targets_chatgpt_backend(self) -> None:
+        spec = get_provider_spec("openai-codex")
+        assert spec is not None
+        assert "chatgpt.com/backend-api" in spec.default_base_url
+        assert spec.auth_type == "oauth_external"
+
+    def test_glm_coding_variant_uses_coding_endpoint(self) -> None:
+        spec = get_provider_spec("glm-coding")
+        assert spec is not None
+        assert "coding/paas/v4" in spec.default_base_url
+
+    def test_glm_payg_variant_uses_paas_endpoint(self) -> None:
+        spec = get_provider_spec("glm")
+        assert spec is not None
+        assert "/paas/v4" in spec.default_base_url
+        assert "/coding/" not in spec.default_base_url
+
+
+class TestGlmCodingTiers:
+    def test_lite_pro_max_present(self) -> None:
+        for tier in ("lite", "pro", "max"):
+            assert tier in GLM_CODING_TIERS
+
+    def test_lite_quota_matches_published_limits(self) -> None:
+        # 5h window, 80 calls (post-2026-02-12 reduction)
+        plan = GLM_CODING_TIERS["lite"]
+        assert plan.quota is not None
+        assert plan.quota.window_s == 18_000
+        assert plan.quota.max_calls == 80
+        assert plan.quota.model_weights["glm-5.1"] == 3.0
+
+    def test_subscription_kind(self) -> None:
+        for plan in GLM_CODING_TIERS.values():
+            assert plan.kind == PlanKind.SUBSCRIPTION
+            assert plan.upgrade_url
+
+
+class TestPlanRegistry:
+    def test_add_get_remove(self) -> None:
+        reg = PlanRegistry()
+        plan = Plan(
+            id="t1",
+            provider="openai",
+            kind=PlanKind.PAYG,
+            display_name="Test PAYG",
+            base_url="https://example.test/v1",
+        )
+        reg.add(plan)
+        assert reg.get("t1") is plan
+        assert reg.remove("t1") is True
+        assert reg.get("t1") is None
+
+    def test_routing_chain(self) -> None:
+        reg = PlanRegistry()
+        reg.set_routing("glm-5.1", ["glm-coding-lite", "glm-payg"])
+        assert reg.get_routing("glm-5.1") == ["glm-coding-lite", "glm-payg"]
+
+    def test_remove_clears_routing_for_plan(self) -> None:
+        reg = PlanRegistry()
+        plan = GLM_CODING_TIERS["lite"]
+        reg.add(plan)
+        reg.set_routing("glm-5.1", [plan.id])
+        reg.remove(plan.id)
+        assert reg.get_routing("glm-5.1") == []
+
+
+class TestPlanUsage:
+    def test_quota_unset_means_unlimited(self) -> None:
+        plan = default_plan_for_payg("openai", "sk-...")
+        usage = PlanUsage(plan_id=plan.id)
+        assert usage.is_quota_exhausted(plan) is False
+        assert usage.remaining_in_window(plan) == -1
+
+    def test_quota_exhausted_after_max_calls(self) -> None:
+        plan = GLM_CODING_TIERS["lite"]
+        usage = PlanUsage(plan_id=plan.id, weighted_calls=80.0)
+        assert usage.is_quota_exhausted(plan) is True
+        assert usage.remaining_in_window(plan) == 0
+
+
+class TestResolveRouting:
+    def test_falls_back_to_payg_when_no_plan_registered(self) -> None:
+        # Reset state for a clean test
+        from core.runtime_wiring.infra import build_auth
+
+        reset_plan_registry()
+        store, _, _ = build_auth()
+
+        # Ensure at least an anthropic profile exists for the fallback path
+        store.add(
+            AuthProfile(
+                name="anthropic:test-routing",
+                provider="anthropic",
+                credential_type=CredentialType.API_KEY,
+                key="sk-ant-test-routing",
+            )
+        )
+
+        target = resolve_routing("claude-opus-4-7")
+        assert target is not None
+        assert target.plan.provider == "anthropic"
+        assert target.plan.kind == PlanKind.PAYG
+
+    def test_explicit_plan_routing_takes_precedence(self) -> None:
+        from core.runtime_wiring.infra import build_auth
+
+        reset_plan_registry()
+        store, _, _ = build_auth()
+
+        registry = get_plan_registry()
+        plan = GLM_CODING_TIERS["lite"]
+        registry.add(plan)
+
+        store.add(
+            AuthProfile(
+                name="glm-coding:test",
+                provider="glm-coding",
+                credential_type=CredentialType.API_KEY,
+                key="zai-coding-test",
+                plan_id=plan.id,
+            )
+        )
+        registry.set_routing("glm-5.1", [plan.id])
+
+        target = resolve_routing("glm-5.1")
+        assert target is not None
+        assert target.plan.id == "glm-coding-lite"
+        assert "coding/paas/v4" in target.base_url
+
+    def test_quota_models_are_aware_of_weights(self) -> None:
+        plan = GLM_CODING_TIERS["lite"]
+        assert plan.quota is not None
+        assert plan.quota.model_weights["glm-5.1"] >= 3.0

--- a/tests/test_provider_label_consistency.py
+++ b/tests/test_provider_label_consistency.py
@@ -1,0 +1,83 @@
+"""Provider-label invariants — the bug class that motivated v0.50.0.
+
+Before v0.50.0 the provider string was spelled four different ways across
+runtime/UI/dispatch (`"openai"` for both API keys and Codex OAuth, `"glm"`
+in the dispatch but `"zhipuai"` in the UI store). The Codex OAuth token
+therefore matched `ProfileRotator.resolve("openai")` and poisoned every
+plain GPT call. These tests pin the labels so a future rename can't
+silently re-open the cross-provider leak.
+"""
+
+from __future__ import annotations
+
+from core.cli.commands import MODEL_PROFILES
+from core.config import _resolve_provider
+from core.llm.adapters import _ADAPTER_MAP, CROSS_PROVIDER_FALLBACK
+
+
+class TestProviderRouting:
+    def test_codex_models_route_to_openai_codex(self) -> None:
+        for model in ("gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini"):
+            assert _resolve_provider(model) == "openai-codex", model
+
+    def test_general_openai_models_do_not_route_to_codex(self) -> None:
+        for model in ("gpt-5.4", "gpt-5.4-mini", "gpt-4.1", "o3-mini"):
+            assert _resolve_provider(model) == "openai", model
+
+    def test_glm_models_route_to_glm(self) -> None:
+        for model in ("glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7-flash"):
+            assert _resolve_provider(model) == "glm", model
+
+    def test_anthropic_models_route_to_anthropic(self) -> None:
+        for model in ("claude-opus-4-7", "claude-sonnet-4-6"):
+            assert _resolve_provider(model) == "anthropic", model
+
+
+class TestAdapterMapAlignment:
+    def test_every_resolver_target_has_an_adapter(self) -> None:
+        targets = {
+            _resolve_provider(m)
+            for m in (
+                "claude-opus-4-7",
+                "gpt-5.4",
+                "gpt-5.3-codex",
+                "glm-5.1",
+            )
+        }
+        for provider in targets:
+            assert provider in _ADAPTER_MAP, provider
+
+
+class TestCrossProviderFallbackSafety:
+    def test_glm_does_not_auto_fall_back(self) -> None:
+        # GLM Coding Plan auth errors must not silently divert to a metered
+        # OpenAI key. Cross-plan jumps are an explicit user choice in v0.50+.
+        assert CROSS_PROVIDER_FALLBACK.get("glm") == []
+
+    def test_openai_codex_does_not_auto_fall_back(self) -> None:
+        # Codex OAuth scope is unique to chatgpt.com/backend-api; silently
+        # retrying on a PAYG provider would surprise the user with billing.
+        assert CROSS_PROVIDER_FALLBACK.get("openai-codex") == []
+
+
+class TestModelProfileLabels:
+    def test_gpt_5_4_mini_is_not_labelled_codex(self) -> None:
+        # Pre-0.50 the UI showed "Codex (Plus)" for gpt-5.4-mini even though
+        # it routes to plain "openai". Users were billed PAYG while believing
+        # they were on the Plus subscription.
+        for profile in MODEL_PROFILES:
+            if profile.id == "gpt-5.4-mini":
+                assert "Codex" not in profile.provider, (
+                    "gpt-5.4-mini routes to PAYG OpenAI, must not advertise Codex"
+                )
+                return
+        raise AssertionError("gpt-5.4-mini missing from MODEL_PROFILES")
+
+    def test_glm_models_use_glm_provider_label(self) -> None:
+        # The UI label must match the dispatch provider (`glm`); pre-0.50
+        # the UI said "ZhipuAI" while dispatch keyed off "glm" so the
+        # /auth interactive add path stored credentials the rotator never
+        # found.
+        for profile in MODEL_PROFILES:
+            if profile.id.startswith("glm-"):
+                assert profile.provider == "GLM", profile.id

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -492,7 +492,9 @@ class TestModelProfiles:
     def test_glm_profiles_provider(self):
         from core.cli.commands import MODEL_PROFILES
 
-        glm_profiles = [p for p in MODEL_PROFILES if p.provider == "ZhipuAI"]
+        # v0.50.0: provider label normalised to "GLM" so the UI store
+        # matches the dispatch key (was "ZhipuAI" / "glm" mismatch).
+        glm_profiles = [p for p in MODEL_PROFILES if p.provider == "GLM"]
         assert len(glm_profiles) == 3
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.47.1"
+version = "0.49.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -449,6 +449,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+desktop = [
+    { name = "pillow" },
+    { name = "pyautogui" },
+]
 mcp = [
     { name = "mcp" },
 ]
@@ -477,7 +481,9 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "openai", specifier = ">=2.26.0" },
     { name = "openai-agents", specifier = ">=0.13.0" },
+    { name = "pillow", marker = "extra == 'desktop'", specifier = ">=10.0.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
+    { name = "pyautogui", marker = "extra == 'desktop'", specifier = ">=0.9.54" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -485,7 +491,7 @@ requires-dist = [
     { name = "simple-term-menu", specifier = ">=1.6.0" },
     { name = "typer", specifier = ">=0.15.0" },
 ]
-provides-extras = ["mcp"]
+provides-extras = ["mcp", "desktop"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -925,6 +931,17 @@ wheels = [
 ]
 
 [[package]]
+name = "mouseinfo"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyperclip" },
+    { name = "python3-xlib", marker = "sys_platform == 'linux'" },
+    { name = "rubicon-objc", marker = "sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/fa/b2ba8229b9381e8f6381c1dcae6f4159a7f72349e414ed19cfbbd1817173/MouseInfo-0.1.3.tar.gz", hash = "sha256:2c62fb8885062b8e520a3cce0a297c657adcc08c60952eb05bc8256ef6f7f6e7", size = 10850, upload-time = "2020-03-27T21:20:10.136Z" }
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,6 +1201,75 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1228,6 +1314,22 @@ sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
+
+[[package]]
+name = "pyautogui"
+version = "0.9.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mouseinfo" },
+    { name = "pygetwindow" },
+    { name = "pymsgbox" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyscreeze" },
+    { name = "python3-xlib", marker = "sys_platform == 'linux'" },
+    { name = "pytweening" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/ff/cdae0a8c2118a0de74b6cf4cbcdcaf8fd25857e6c3f205ce4b1794b27814/PyAutoGUI-0.9.54.tar.gz", hash = "sha256:dd1d29e8fd118941cb193f74df57e5c6ff8e9253b99c7b04f39cfc69f3ae04b2", size = 61236, upload-time = "2023-05-24T20:11:32.972Z" }
 
 [[package]]
 name = "pycparser"
@@ -1339,6 +1441,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygetwindow"
+version = "0.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyrect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/70/c7a4f46dbf06048c6d57d9489b8e0f9c4c3d36b7479f03c5ca97eaa2541d/PyGetWindow-0.0.9.tar.gz", hash = "sha256:17894355e7d2b305cd832d717708384017c1698a90ce24f6f7fbf0242dd0a688", size = 9699, upload-time = "2020-10-04T02:12:50.806Z" }
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1360,6 +1471,82 @@ wheels = [
 crypto = [
     { name = "cryptography" },
 ]
+
+[[package]]
+name = "pymsgbox"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/6a/e80da7594ee598a776972d09e2813df2b06b3bc29218f440631dfa7c78a8/pymsgbox-2.0.1.tar.gz", hash = "sha256:98d055c49a511dcc10fa08c3043e7102d468f5e4b3a83c6d3c61df722c7d798d", size = 20768, upload-time = "2025-09-09T00:38:56.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/3e/08c8cac81b2b2f7502746e6b9c8e5b0ec6432cd882c605560fc409aaf087/pymsgbox-2.0.1-py3-none-any.whl", hash = "sha256:5de8ec19bca2ca7e6c09d39c817c83f17c75cee80275235f43a9931db699f73b", size = 9994, upload-time = "2025-09-09T00:38:55.672Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d2/29e5e536adc07bc3d33dd09f3f7cf844bf7b4981820dc2a91dd810f3c782/pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a", size = 677370, upload-time = "2025-11-14T09:33:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f0/4b4ed8924cd04e425f2a07269943018d43949afad1c348c3ed4d9d032787/pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc", size = 719586, upload-time = "2025-11-14T09:33:53.302Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/9f4ed07162de69603144ff480be35cd021808faa7f730d082b92f7ebf2b5/pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43", size = 670164, upload-time = "2025-11-14T09:34:37.458Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/dc076965c96c7f0de25c0a32b7f8aa98133ed244deaeeacfc758783f1f30/pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882", size = 712204, upload-time = "2025-11-14T09:35:24.148Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/31/0c2e734165abb46215797bd830c4bdcb780b699854b15f2b6240515edcc6/pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118", size = 384689, upload-time = "2025-11-14T09:41:41.478Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/b9f61be7b9f9b4e0a6db18b3c35c4c4d589f2d04e963e2174d38c6555a92/pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44", size = 388843, upload-time = "2025-11-14T09:42:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/f777cc9e775fc7dae77b569254570fe46eb842516b3e4fe383ab49eab598/pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a", size = 384932, upload-time = "2025-11-14T09:42:29.771Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/b457b7b37089cad692c8aada90119162dfb4c4a16f513b79a8b2b022b33b/pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc", size = 388970, upload-time = "2025-11-14T09:42:53.964Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7730cdce46c7e985535b5a42c31381af4aa6556e5642dc55b5e6597595e57a16", size = 218798, upload-time = "2025-11-14T10:00:01.236Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/e8f495328101898c16c32ac10e7b14b08ff2c443a756a76fd1271915f097/pyobjc_framework_quartz-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:629b7971b1b43a11617f1460cd218bd308dfea247cd4ee3842eb40ca6f588860", size = 219206, upload-time = "2025-11-14T10:00:15.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/43/b1f0ad3b842ab150a7e6b7d97f6257eab6af241b4c7d14cb8e7fde9214b8/pyobjc_framework_quartz-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:53b84e880c358ba1ddcd7e8d5ea0407d760eca58b96f0d344829162cda5f37b3", size = 224317, upload-time = "2025-11-14T10:00:30.703Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/00/96249c5c7e5aaca5f688ca18b8d8ad05cd7886ebd639b3c71a6a4cadbe75/pyobjc_framework_quartz-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:42d306b07f05ae7d155984503e0fb1b701fecd31dcc5c79fe8ab9790ff7e0de0", size = 219558, upload-time = "2025-11-14T10:00:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a6/708a55f3ff7a18c403b30a29a11dccfed0410485a7548c60a4b6d4cc0676/pyobjc_framework_quartz-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0cc08fddb339b2760df60dea1057453557588908e42bdc62184b6396ce2d6e9a", size = 224580, upload-time = "2025-11-14T10:01:00.091Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pyrect"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/04/2ba023d5f771b645f7be0c281cdacdcd939fe13d1deb331fc5ed1a6b3a98/PyRect-0.2.0.tar.gz", hash = "sha256:f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78", size = 17219, upload-time = "2022-03-16T04:45:52.36Z" }
+
+[[package]]
+name = "pyscreeze"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/f0/cb456ac4f1a73723d5b866933b7986f02bacea27516629c00f8e7da94c2d/pyscreeze-1.0.1.tar.gz", hash = "sha256:cf1662710f1b46aa5ff229ee23f367da9e20af4a78e6e365bee973cad0ead4be", size = 27826, upload-time = "2024-08-20T23:03:07.291Z" }
 
 [[package]]
 name = "pytest"
@@ -1421,6 +1608,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
+
+[[package]]
+name = "python3-xlib"
+version = "0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/c6/2c5999de3bb1533521f1101e8fe56fd9c266732f4d48011c7c69b29d12ae/python3-xlib-0.15.tar.gz", hash = "sha256:dc4245f3ae4aa5949c1d112ee4723901ade37a96721ba9645f2bfa56e5b383f8", size = 132828, upload-time = "2014-05-31T12:28:59.603Z" }
+
+[[package]]
+name = "pytweening"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/0c/c16bc93ac2755bac0066a8ecbd2a2931a1735a6fffd99a2b9681c7e83e90/pytweening-1.2.0.tar.gz", hash = "sha256:243318b7736698066c5f362ec5c2b6434ecf4297c3c8e7caa8abfe6af4cac71b", size = 171241, upload-time = "2024-02-20T03:37:56.809Z" }
 
 [[package]]
 name = "pywin32"
@@ -1617,6 +1816,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "rubicon-objc"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d2/d39ecd205661a5c14c90dbd92a722a203848a3621785c9783716341de427/rubicon_objc-0.5.3.tar.gz", hash = "sha256:74c25920c5951a05db9d3a1aac31d23816ec7dacc841a5b124d911b99ea71b9a", size = 171512, upload-time = "2025-12-03T03:51:10.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ab/e834c01138c272fb2e37d2f3c7cba708bc694dbc7b3f03b743f29ceb92d5/rubicon_objc-0.5.3-py3-none-any.whl", hash = "sha256:31dedcda9be38435f5ec067906e1eea5d0ddb790330e98a22e94ff424758b415", size = 64414, upload-time = "2025-12-03T03:51:09.082Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.49.1"
+version = "0.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
v0.50.0 release: 자격증명 + 구독 플랜 1급 분리, /login 통합 UX, ~/.geode/auth.toml 영구 저장.

#796의 6단계(Phase 0–5) feature/auth-plans-v050를 develop에 머지한 결과를 main으로 끌어올립니다.

## Verification
- [x] feature/auth-plans-v050 → develop CI 5/5 (Lint, Type, Security, Test, Gate)
- [x] pytest 4037 passed (1 skipped, 19 deselected)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)