### PR TITLE
feat(v0.50.1): manage_login 자연어 도구 — /login 자연어 호출 경로 활성화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.50.1] — 2026-04-25
+
+### Added
+- **`manage_login` agentic tool** — natural-language access to the unified `/login` command. Supports the same subcommands as the slash command (`status`, `add`, `oauth`, `set-key`, `use`, `route`, `remove`, `quota`, `help`). Returns a structured snapshot (plans, profiles, routing) so the LLM can reason about credential state without re-rendering the Rich dashboard. (`core/tools/definitions.json`, `core/cli/tool_handlers.py`)
+- **Safety/policy registration** — `manage_login` is in `WRITE_TOOLS`, blocked for sub-agents (`SUBAGENT_DENIED_TOOLS`), excluded from auto-recovery (`error_recovery._EXCLUDED_TOOLS`), denied for read-only profiles, and emits an HITL approval card with `subcommand`/`args` summary. (`core/agent/safety_constants.py`, `core/agent/sub_agent.py`, `core/agent/error_recovery.py`, `core/tools/policy.py`, `core/agent/approval.py`)
+
+### Changed
+- **`set_api_key` and `manage_auth` tool descriptions** — both now point users (and the model) at `manage_login` as the preferred path. Approval denial messages updated to reference `/login` instead of the legacy `/key` and `/auth` commands.
+
 ## [0.50.0] — 2026-04-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.50.0
+- **Version**: 0.50.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 227
-- **Tests**: 4037+
+- **Tests**: 4047+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.50.0 — Long-running Autonomous Execution Harness
+# GEODE v0.50.1 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.50.0 — Long-running Autonomous Execution Harness
+# GEODE v0.50.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/approval.py
+++ b/core/agent/approval.py
@@ -304,13 +304,8 @@ class ApprovalWorkflow:
             elif tool_name == "manage_auth":
                 summary = f"action={tool_input.get('action', '?')}"
             elif tool_name == "manage_login":
-                summary = (
-                    f"sub={tool_input.get('subcommand', 'status')}"
-                    + (
-                        f" args={tool_input.get('args', '')[:60]}"
-                        if tool_input.get("args")
-                        else ""
-                    )
+                summary = f"sub={tool_input.get('subcommand', 'status')}" + (
+                    f" args={tool_input.get('args', '')[:60]}" if tool_input.get("args") else ""
                 )
             elif tool_name == "profile_update":
                 fields = [k for k in ("role", "expertise", "name", "team") if tool_input.get(k)]

--- a/core/agent/approval.py
+++ b/core/agent/approval.py
@@ -36,8 +36,9 @@ def _write_denial_with_fallback(tool_name: str) -> dict[str, Any]:
     _WRITE_FALLBACK_HINTS: dict[str, str] = {
         "memory_save": "Try memory_search to read existing data instead.",
         "note_save": "Try reading existing notes or suggest the content to the user.",
-        "set_api_key": "Show the user the /key command to set it themselves.",
-        "manage_auth": "Show the user the /auth command to manage auth profiles.",
+        "set_api_key": "Show the user the /login command to set it themselves.",
+        "manage_auth": "Show the user the /login command to manage credentials.",
+        "manage_login": "Show the user the /login command to register plans / keys / OAuth.",
         "profile_update": "Show current profile with profile_get instead.",
         "profile_preference": "Show current preferences with profile_get instead.",
         "profile_learn": "Show current learning patterns with profile_get instead.",
@@ -302,6 +303,15 @@ class ApprovalWorkflow:
                 summary = f"provider={tool_input.get('provider', '?')}"
             elif tool_name == "manage_auth":
                 summary = f"action={tool_input.get('action', '?')}"
+            elif tool_name == "manage_login":
+                summary = (
+                    f"sub={tool_input.get('subcommand', 'status')}"
+                    + (
+                        f" args={tool_input.get('args', '')[:60]}"
+                        if tool_input.get("args")
+                        else ""
+                    )
+                )
             elif tool_name == "profile_update":
                 fields = [k for k in ("role", "expertise", "name", "team") if tool_input.get(k)]
                 summary = f"fields={','.join(fields)}" if fields else "profile update"

--- a/core/agent/error_recovery.py
+++ b/core/agent/error_recovery.py
@@ -33,6 +33,7 @@ _EXCLUDED_TOOLS: frozenset[str] = frozenset(
         "note_save",
         "set_api_key",
         "manage_auth",
+        "manage_login",
     }
 )
 

--- a/core/agent/safety_constants.py
+++ b/core/agent/safety_constants.py
@@ -43,6 +43,7 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "note_save",
         "set_api_key",
         "manage_auth",
+        "manage_login",
         "profile_update",
         "profile_preference",
         "profile_learn",

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -107,6 +107,7 @@ _TYPE_AGENT_MAP: dict[str, str] = {
 SUBAGENT_DENIED_TOOLS: set[str] = {
     "set_api_key",  # credential changes — parent only
     "manage_auth",  # auth profile management — parent only
+    "manage_login",  # plans + credentials + routing — parent only
     "profile_update",  # user profile changes — parent only
     "calendar_create_event",  # external system mutation — parent only
     "calendar_sync_scheduler",  # external system mutation — parent only

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -809,6 +809,61 @@ def _build_system_handlers(
             "profiles": profiles,
         }
 
+    def handle_manage_login(**kwargs: Any) -> dict[str, Any]:
+        """Natural-language entry to /login (Plans + Profiles + OAuth + Routing)."""
+        from core.cli.commands import cmd_login
+
+        sub = (kwargs.get("subcommand") or "status").strip().lower()
+        args = (kwargs.get("args") or "").strip()
+        login_input = "" if sub in ("", "status", "list", "ls") else f"{sub} {args}".strip()
+        cmd_login(login_input)
+
+        try:
+            from core.gateway.auth.plan_registry import get_plan_registry
+            from core.runtime_wiring.infra import ensure_profile_store
+
+            store = ensure_profile_store()
+            registry = get_plan_registry()
+            plans_payload = []
+            for plan in registry.list_all():
+                usage = registry.usage_for(plan.id)
+                plans_payload.append(
+                    {
+                        "id": plan.id,
+                        "provider": plan.provider,
+                        "kind": plan.kind.value,
+                        "display_name": plan.display_name,
+                        "base_url": plan.base_url,
+                        "subscription_tier": plan.subscription_tier,
+                        "quota_max": (plan.quota.max_calls if plan.quota else None),
+                        "quota_used": int(usage.weighted_calls),
+                    }
+                )
+            profiles_payload = [
+                {
+                    "name": p.name,
+                    "provider": p.provider,
+                    "type": p.credential_type.value,
+                    "plan_id": p.plan_id or None,
+                    "managed_by": p.managed_by or None,
+                }
+                for p in store.list_all()
+            ]
+            routing_payload = registry.all_routing()
+        except Exception:
+            plans_payload = []
+            profiles_payload = []
+            routing_payload = {}
+
+        return {
+            "status": "ok",
+            "action": "login",
+            "subcommand": sub or "status",
+            "plans": plans_payload,
+            "profiles": profiles_payload,
+            "routing": routing_payload,
+        }
+
     def handle_doctor_slack(**_kwargs: Any) -> dict[str, Any]:
         from core.cli.doctor import format_doctor_report, run_doctor_slack
 
@@ -821,6 +876,7 @@ def _build_system_handlers(
         "switch_model": handle_switch_model,
         "set_api_key": handle_set_api_key,
         "manage_auth": handle_manage_auth,
+        "manage_login": handle_manage_login,
         "doctor_slack": handle_doctor_slack,
     }
 

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -257,7 +257,7 @@
   },
   {
     "name": "set_api_key",
-    "description": "Sets an API key. Use when the user requests API key setup or change.",
+    "description": "Sets a single PAYG API key. Prefer manage_login for richer flows (subscription plans, OAuth, routing). Use this only when the user pastes a raw key without context.",
     "category": "model",
     "cost_tier": "cheap",
     "input_schema": {
@@ -273,7 +273,7 @@
   },
   {
     "name": "manage_auth",
-    "description": "Manages authentication profiles. Use when the user wants to manage authentication, profiles, or credentials.",
+    "description": "Legacy auth-profile manager. Prefer manage_login. Retained for the existing /auth interactive add path.",
     "category": "model",
     "cost_tier": "cheap",
     "input_schema": {
@@ -282,6 +282,37 @@
         "sub_action": {
           "type": "string",
           "description": "Action to perform (add, remove, list). If omitted, displays status."
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "manage_login",
+    "description": "Unified credentials/plans command — Plans + API keys + OAuth + routing in one tool. Use whenever the user says login/logout, sets up a subscription (GLM Coding Lite/Pro/Max, ChatGPT Plus, Claude Pro), changes credentials, asks about quota, switches active plan, or pastes an API key with intent. Mirrors the /login slash command (see `core.cli.commands.cmd_login`).",
+    "category": "model",
+    "cost_tier": "cheap",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "subcommand": {
+          "type": "string",
+          "description": "One of: status (default — show plans/profiles/routing/quota), add (interactive wizard), oauth (Codex OAuth device flow), set-key, use, route, remove, quota, help.",
+          "enum": [
+            "status",
+            "add",
+            "oauth",
+            "set-key",
+            "use",
+            "route",
+            "remove",
+            "quota",
+            "help"
+          ]
+        },
+        "args": {
+          "type": "string",
+          "description": "Optional positional arguments for the subcommand. Examples: oauth → 'openai'; set-key → 'glm-coding-lite zai-xxxx'; use → 'glm-coding-lite'; route → 'glm-5.1 glm-coding-lite glm-payg'; remove → 'glm-coding-lite'."
         }
       },
       "required": []

--- a/core/tools/policy.py
+++ b/core/tools/policy.py
@@ -201,6 +201,7 @@ class ProfilePolicy:
                         "memory_save",
                         "note_save",
                         "set_api_key",
+                        "manage_login",
                         "profile_update",
                         "calendar_create_event",
                         "calendar_sync_scheduler",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.50.0"
+version = "0.50.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_agentic_response.py
+++ b/tests/test_agentic_response.py
@@ -280,7 +280,9 @@ class TestWriteDenialWithFallback:
 
     def test_set_api_key(self):
         result = _write_denial_with_fallback("set_api_key")
-        assert "/key" in result["fallback_hint"]
+        # v0.50.1: denial hint now points users at the unified /login command
+        # (set_api_key is a thin alias for the legacy /key paste path).
+        assert "/login" in result["fallback_hint"]
 
     def test_all_write_tools_have_fallbacks(self):
         from core.agent.tool_executor import WRITE_TOOLS

--- a/tests/test_manage_login_tool.py
+++ b/tests/test_manage_login_tool.py
@@ -1,0 +1,104 @@
+"""Phase v0.50.1 — manage_login agentic tool tests.
+
+Verifies the tool definition is registered, the handler is wired, and
+calling it produces a structured snapshot the LLM can reason over.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from core.cli.tool_handlers import _build_system_handlers
+
+
+def _handler():
+    handlers = _build_system_handlers(
+        force_dry=True, readiness=MagicMock(), mcp_manager=None
+    )
+    return handlers["manage_login"]
+
+
+class TestToolDefinition:
+    def test_manage_login_in_definitions_json(self) -> None:
+        path = Path(__file__).resolve().parents[1] / "core" / "tools" / "definitions.json"
+        data = json.loads(path.read_text())
+        names = [t["name"] for t in data]
+        assert "manage_login" in names, "manage_login missing from definitions.json"
+
+        entry = next(t for t in data if t["name"] == "manage_login")
+        assert entry["category"] == "model"
+        # Subcommand enum must include the user-facing actions
+        sub_enum = entry["input_schema"]["properties"]["subcommand"]["enum"]
+        for required in ("status", "add", "oauth", "set-key", "use", "route", "remove", "quota"):
+            assert required in sub_enum, required
+
+
+class TestHandlerWired:
+    def test_handler_is_registered(self) -> None:
+        handlers = _build_system_handlers(
+            force_dry=True, readiness=MagicMock(), mcp_manager=None
+        )
+        assert "manage_login" in handlers
+
+    def test_status_returns_structured_snapshot(self) -> None:
+        result = _handler()(subcommand="status")
+        assert result["status"] == "ok"
+        assert result["action"] == "login"
+        # Snapshot fields — never None, always lists/dicts
+        assert isinstance(result["plans"], list)
+        assert isinstance(result["profiles"], list)
+        assert isinstance(result["routing"], dict)
+
+    def test_help_subcommand_runs_without_mutation(self) -> None:
+        result = _handler()(subcommand="help")
+        assert result["status"] == "ok"
+        assert result["subcommand"] == "help"
+
+    def test_quota_subcommand_returns_payload(self) -> None:
+        result = _handler()(subcommand="quota")
+        assert result["status"] == "ok"
+        assert result["subcommand"] == "quota"
+
+
+class TestSafetyRegistration:
+    def test_manage_login_in_write_tools(self) -> None:
+        from core.agent.safety_constants import WRITE_TOOLS
+
+        assert "manage_login" in WRITE_TOOLS
+
+    def test_manage_login_blocked_for_subagents(self) -> None:
+        from core.agent.sub_agent import SUBAGENT_DENIED_TOOLS
+
+        assert "manage_login" in SUBAGENT_DENIED_TOOLS
+
+    def test_manage_login_excluded_from_auto_recovery(self) -> None:
+        from core.agent.error_recovery import _EXCLUDED_TOOLS
+
+        assert "manage_login" in _EXCLUDED_TOOLS
+
+    def test_approval_message_points_at_login(self) -> None:
+        from core.agent.approval import _write_denial_with_fallback
+
+        out = _write_denial_with_fallback("manage_login")
+        assert "/login" in out["error"] or "/login" in out.get("fallback_hint", "")
+
+
+class TestRouting:
+    def test_set_key_via_tool_persists(self, tmp_path: Path, monkeypatch) -> None:
+        # Redirect auth.toml to tmp so the test never touches ~/.geode
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(tmp_path / "auth.toml"))
+
+        # Pre-register a plan via the registry so set-key has a target
+        from core.gateway.auth.plan_registry import get_plan_registry
+        from core.gateway.auth.plans import GLM_CODING_TIERS
+
+        registry = get_plan_registry()
+        registry.add(GLM_CODING_TIERS["lite"])
+
+        result = _handler()(subcommand="set-key", args="glm-coding-lite zai-xx-1234567890")
+        assert result["status"] == "ok"
+
+        bound = [p for p in result["profiles"] if p["plan_id"] == "glm-coding-lite"]
+        assert bound, "set-key did not bind a profile to the plan"

--- a/tests/test_manage_login_tool.py
+++ b/tests/test_manage_login_tool.py
@@ -14,9 +14,7 @@ from core.cli.tool_handlers import _build_system_handlers
 
 
 def _handler():
-    handlers = _build_system_handlers(
-        force_dry=True, readiness=MagicMock(), mcp_manager=None
-    )
+    handlers = _build_system_handlers(force_dry=True, readiness=MagicMock(), mcp_manager=None)
     return handlers["manage_login"]
 
 
@@ -37,9 +35,7 @@ class TestToolDefinition:
 
 class TestHandlerWired:
     def test_handler_is_registered(self) -> None:
-        handlers = _build_system_handlers(
-            force_dry=True, readiness=MagicMock(), mcp_manager=None
-        )
+        handlers = _build_system_handlers(force_dry=True, readiness=MagicMock(), mcp_manager=None)
         assert "manage_login" in handlers
 
     def test_status_returns_structured_snapshot(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.50.0"
+version = "0.50.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `/login` 슬래시 명령어를 자연어 호출용 `manage_login` 도구로 노출
- 기존 `set_api_key`/`manage_auth` 도구는 alias로 유지 + description에서 manage_login 권장

## Why
v0.50.0에서 `/login` 통합 명령어를 만들었지만 자연어 입력에는
연결되지 않아, 사용자가 "GLM Coding Lite 등록해줘" 같은 자연어로
요청했을 때 LLM이 호출할 도구가 없었습니다 (set_api_key는 단일 키만,
manage_auth는 legacy 경로). 단일 SOT 원칙을 자연어 경로에서도
유지하기 위한 GAP 보충입니다.

## Changes
| File | Change |
|------|--------|
| `core/tools/definitions.json` | `manage_login` 추가 (subcommand enum + args) |
| `core/cli/tool_handlers.py` | `handle_manage_login` — `cmd_login` 위임 + 구조화 snapshot 응답 |
| `core/tools/definitions.json` | set_api_key/manage_auth description에 "prefer manage_login" 명시 |
| `core/agent/safety_constants.py` | WRITE_TOOLS에 등록 |
| `core/agent/sub_agent.py` | SUBAGENT_DENIED_TOOLS에 등록 |
| `core/agent/error_recovery.py` | _EXCLUDED_TOOLS에 등록 |
| `core/agent/approval.py` | HITL 카드 요약 + denial fallback hint를 `/login`으로 통일 |
| `core/tools/policy.py` | read-only profile 차단 목록에 추가 |
| `tests/test_manage_login_tool.py` (신설) | 10개 — 정의/배선/snapshot/안전 레이어/set-key 통합 |
| `tests/test_agentic_response.py` | set_api_key 거부 hint 검증을 `/login`으로 갱신 |
| `CHANGELOG.md` `CLAUDE.md` `README.md` `README.ko.md` `pyproject.toml` `uv.lock` | 0.50.0 → 0.50.1 |

## Verification
- [x] ruff check clean
- [x] mypy clean (227 modules)
- [x] pytest 4047 passed (1 skipped, 19 deselected)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) unchanged
- [x] handler smoke (status / help / quota / set-key)

## Reference
사용자 GAP 지적 — "자연어로도 호출이 가능해? tool에 올려뒀어?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)