### PR TITLE
release: v0.50.2 — auth.json → auth.toml SOT 통합

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.50.2] — 2026-04-25
+
+### Changed
+- **`~/.geode/auth.json` → `~/.geode/auth.toml` 단일 SOT 통합** — v0.50.0이 도입한 `auth.toml` Plan/Profile 영구 저장소가 OAuth 토큰까지 흡수합니다. `oauth_login.py`의 `_save_auth_store` / `_load_auth_store`가 내부적으로 `auth.toml`로 라우팅됩니다 (호출 시그니처는 호환 유지). `~/.geode/auth.json`이 발견되면 한 번 읽어 OAUTH_BORROWED Plan + Profile 쌍으로 변환한 뒤 `auth.json.migrated.bak`으로 자동 백업합니다. (`core/gateway/auth/oauth_login.py`)
+- **OAuth Plan 표현** — GEODE가 직접 발급한 device-code OAuth는 `kind = "oauth_borrowed"`, `provider = "openai-codex"`, plan id = `openai-codex-geode`로 저장됩니다. 외부 Codex CLI(`~/.codex/auth.json`)는 이전과 동일하게 `managed_by="codex-cli"` Profile로 read-only 미러됩니다.
+
+### Fixed
+- **이중 SOT 혼동 제거** — pre-v0.50.0 시절의 `auth.json`이 v0.50.0 `auth.toml` 도입 후에도 잔존해서 `/login` dashboard가 두 파일을 동시에 참조하던 미세 버그가 해소됩니다. 한 번 마이그레이션 후 `auth.toml`만 SOT로 사용.
+
 ## [0.50.1] — 2026-04-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.50.1
+- **Version**: 0.50.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 227
-- **Tests**: 4047+
+- **Tests**: 4051+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.50.1 — Long-running Autonomous Execution Harness
+# GEODE v0.50.2 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.50.1 — Long-running Autonomous Execution Harness
+# GEODE v0.50.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/gateway/auth/oauth_login.py
+++ b/core/gateway/auth/oauth_login.py
@@ -1,7 +1,11 @@
-"""OAuth login flows — `/login openai` device code flow.
+"""OAuth login flows — `/login oauth openai` device code flow.
 
 Grounded from Hermes Agent hermes_cli/auth.py:3054-3196.
-Stores credentials in ~/.geode/auth.json (unified auth store).
+
+v0.50.2: Stores credentials in ``~/.geode/auth.toml`` (the v0.50.0 SOT)
+as an ``OAUTH_BORROWED`` Plan + Profile pair. The legacy
+``~/.geode/auth.json`` file is auto-absorbed on first read and renamed
+to ``auth.json.migrated.bak`` so we don't keep two stores in sync.
 """
 
 from __future__ import annotations
@@ -25,28 +29,163 @@ _DEVICE_CALLBACK = f"{_ISSUER}/deviceauth/callback"
 _DEVICE_PAGE = f"{_ISSUER}/codex/device"
 _MAX_WAIT_S = 15 * 60  # 15 minutes
 
-# Auth store path
-AUTH_STORE_PATH = Path.home() / ".geode" / "auth.json"
+# Legacy auth store path — kept only for one-shot migration into auth.toml.
+LEGACY_AUTH_STORE_PATH = Path.home() / ".geode" / "auth.json"
+# Backwards-compat alias — some external callers imported this name.
+AUTH_STORE_PATH = LEGACY_AUTH_STORE_PATH
+
+# Plan ID we use for any OAuth token GEODE itself issued (vs. external
+# managed CLIs like ~/.codex/auth.json which keep their own SOT).
+_GEODE_OPENAI_PLAN_ID = "openai-codex-geode"
+
+
+def _migrate_legacy_auth_json_if_present() -> dict[str, Any]:
+    """One-shot migration of pre-v0.50.2 ``~/.geode/auth.json``.
+
+    Returns the parsed legacy payload (so callers can immediately seed the
+    Plan registry with it) and renames the file to ``.migrated.bak`` so
+    subsequent boots skip the work. Empty dict on no-op.
+    """
+    if not LEGACY_AUTH_STORE_PATH.exists():
+        return {}
+    try:
+        raw = json.loads(LEGACY_AUTH_STORE_PATH.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return {}
+    except (json.JSONDecodeError, OSError):
+        log.warning("Legacy auth.json unreadable; skipping migration")
+        return {}
+
+    bak_path = LEGACY_AUTH_STORE_PATH.with_suffix(".json.migrated.bak")
+    try:
+        LEGACY_AUTH_STORE_PATH.rename(bak_path)
+        log.info("Migrated legacy auth.json → %s (one-shot)", bak_path)
+    except OSError:
+        log.warning("Could not rename %s; leaving in place", LEGACY_AUTH_STORE_PATH)
+    return raw
+
+
+def _persist_oauth_to_authtoml(creds: dict[str, Any]) -> None:
+    """Write Codex device-code creds into ``~/.geode/auth.toml`` SOT."""
+    try:
+        from core.gateway.auth.auth_toml import save_auth_toml
+        from core.gateway.auth.plan_registry import get_plan_registry
+        from core.gateway.auth.plans import Plan, PlanKind
+        from core.gateway.auth.profiles import AuthProfile, CredentialType
+        from core.runtime_wiring.infra import ensure_profile_store
+    except Exception:  # pragma: no cover — import-time defensive
+        log.debug("auth.toml persistence skipped — Plan modules unavailable")
+        return
+
+    registry = get_plan_registry()
+    plan = registry.get(_GEODE_OPENAI_PLAN_ID) or Plan(
+        id=_GEODE_OPENAI_PLAN_ID,
+        provider="openai-codex",
+        kind=PlanKind.OAUTH_BORROWED,
+        display_name="OpenAI Codex (GEODE OAuth)",
+        base_url="https://chatgpt.com/backend-api/codex",
+        auth_type="oauth_external",
+        subscription_tier=str(creds.get("plan_type") or "") or None,
+    )
+    registry.add(plan)
+
+    store = ensure_profile_store()
+    profile_name = f"{plan.id}:user"
+    expires_at = float(creds.get("expires_at", 0.0) or 0.0)
+    existing = store.get(profile_name)
+    if existing is not None:
+        existing.key = str(creds.get("access_token", ""))
+        existing.refresh_token = str(creds.get("refresh_token", ""))
+        existing.expires_at = expires_at
+        existing.plan_id = plan.id
+        existing.error_count = 0
+        existing.cooldown_until = 0.0
+        existing.metadata.update(
+            {
+                "account_id": creds.get("account_id", ""),
+                "email": creds.get("email", ""),
+                "plan_type": creds.get("plan_type", ""),
+                "source": "geode-device-code",
+            }
+        )
+    else:
+        store.add(
+            AuthProfile(
+                name=profile_name,
+                provider=plan.provider,
+                credential_type=CredentialType.OAUTH,
+                key=str(creds.get("access_token", "")),
+                refresh_token=str(creds.get("refresh_token", "")),
+                expires_at=expires_at,
+                plan_id=plan.id,
+                metadata={
+                    "account_id": creds.get("account_id", ""),
+                    "email": creds.get("email", ""),
+                    "plan_type": creds.get("plan_type", ""),
+                    "source": "geode-device-code",
+                },
+            )
+        )
+    save_auth_toml()
 
 
 def _load_auth_store() -> dict[str, Any]:
-    """Load ~/.geode/auth.json. Returns empty dict if not found."""
-    if not AUTH_STORE_PATH.exists():
-        return {"version": 1, "providers": {}}
+    """Read OAuth credentials, preferring auth.toml but falling back to legacy.
+
+    On first call after upgrade we still see ``~/.geode/auth.json``: parse
+    it once, write its `providers.openai` entry into auth.toml, and rename
+    the legacy file so the next read goes through the new SOT only.
+    """
+    legacy = _migrate_legacy_auth_json_if_present()
+    if legacy:
+        openai_creds = legacy.get("providers", {}).get("openai")
+        if isinstance(openai_creds, dict) and openai_creds.get("access_token"):
+            try:
+                _persist_oauth_to_authtoml(openai_creds)
+            except Exception:
+                log.warning("Failed to persist legacy OAuth creds to auth.toml", exc_info=True)
+        return legacy if isinstance(legacy, dict) else {"version": 1, "providers": {}}
+
+    # Re-build a json-shaped view from the auth.toml SOT for legacy callers
+    # like get_auth_status().
     try:
-        data = json.loads(AUTH_STORE_PATH.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            return {"version": 1, "providers": {}}
-        return data
-    except (json.JSONDecodeError, OSError):
+        from core.gateway.auth.plan_registry import get_plan_registry
+        from core.runtime_wiring.infra import ensure_profile_store
+    except Exception:  # pragma: no cover
         return {"version": 1, "providers": {}}
+
+    registry = get_plan_registry()
+    plan = registry.get(_GEODE_OPENAI_PLAN_ID)
+    store = ensure_profile_store()
+    profile = store.get(f"{_GEODE_OPENAI_PLAN_ID}:user") if plan else None
+    if profile is None:
+        return {"version": 1, "providers": {}}
+    md = profile.metadata or {}
+    return {
+        "version": 1,
+        "providers": {
+            "openai": {
+                "access_token": profile.key,
+                "refresh_token": profile.refresh_token,
+                "expires_at": profile.expires_at,
+                "account_id": md.get("account_id", ""),
+                "email": md.get("email", ""),
+                "plan_type": md.get("plan_type", ""),
+                "source": md.get("source", "geode-device-code"),
+            }
+        },
+    }
 
 
 def _save_auth_store(data: dict[str, Any]) -> None:
-    """Save ~/.geode/auth.json with 0o600 permissions."""
-    AUTH_STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    AUTH_STORE_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    AUTH_STORE_PATH.chmod(0o600)
+    """Persist Codex OAuth creds via ``~/.geode/auth.toml`` (v0.50.2 SOT).
+
+    Kept for backwards-compatible call sites — extracts the openai entry
+    and routes it through the Plan registry.
+    """
+    creds = (data or {}).get("providers", {}).get("openai") or {}
+    if creds.get("access_token"):
+        _persist_oauth_to_authtoml(creds)
 
 
 def login_openai() -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.50.1"
+version = "0.50.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_auth_json_migration.py
+++ b/tests/test_auth_json_migration.py
@@ -60,9 +60,7 @@ class TestLegacyMigration:
         view = _load_auth_store()
         assert view["providers"] == {}
 
-    def test_migration_is_idempotent_after_second_call(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_migration_is_idempotent_after_second_call(self, tmp_path: Path, monkeypatch) -> None:
         legacy = tmp_path / "auth.json"
         legacy.write_text(
             json.dumps(
@@ -90,9 +88,7 @@ class TestLegacyMigration:
 
 
 class TestSaveRoutesThroughAuthToml:
-    def test_save_auth_store_persists_oauth_to_toml(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_save_auth_store_persists_oauth_to_toml(self, tmp_path: Path, monkeypatch) -> None:
         toml_path = tmp_path / "auth.toml"
         monkeypatch.setenv("GEODE_AUTH_TOML", str(toml_path))
 

--- a/tests/test_auth_json_migration.py
+++ b/tests/test_auth_json_migration.py
@@ -1,0 +1,118 @@
+"""v0.50.2 — legacy auth.json → auth.toml one-shot migration tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class TestLegacyMigration:
+    def test_migration_consumes_legacy_file_and_writes_toml(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        legacy = tmp_path / "auth.json"
+        legacy.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "providers": {
+                        "openai": {
+                            "access_token": "eyJ-test-access-token",
+                            "refresh_token": "eyJ-test-refresh",
+                            "expires_at": 9_999_999_999,
+                            "account_id": "acct-test",
+                            "email": "user@test.example",
+                            "plan_type": "plus",
+                            "source": "geode-device-code",
+                        }
+                    },
+                }
+            )
+        )
+        toml_path = tmp_path / "auth.toml"
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(toml_path))
+        monkeypatch.setattr("core.gateway.auth.oauth_login.LEGACY_AUTH_STORE_PATH", legacy)
+
+        from core.gateway.auth.oauth_login import _load_auth_store
+
+        view = _load_auth_store()
+
+        # 1. Returned view still presents the openai entry for legacy callers
+        assert view["providers"]["openai"]["access_token"] == "eyJ-test-access-token"
+        # 2. Legacy file is gone (renamed to *.migrated.bak)
+        assert not legacy.exists()
+        assert (tmp_path / "auth.json.migrated.bak").exists()
+        # 3. New SOT TOML now contains the OAuth Plan + Profile
+        assert toml_path.exists()
+        text = toml_path.read_text()
+        assert "openai-codex-geode" in text
+        assert "eyJ-test-access-token" in text
+        assert 'kind = "oauth_borrowed"' in text
+
+    def test_no_legacy_file_returns_empty(self, tmp_path: Path, monkeypatch) -> None:
+        legacy = tmp_path / "auth.json"  # never created
+        toml_path = tmp_path / "auth.toml"
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(toml_path))
+        monkeypatch.setattr("core.gateway.auth.oauth_login.LEGACY_AUTH_STORE_PATH", legacy)
+
+        from core.gateway.auth.oauth_login import _load_auth_store
+
+        view = _load_auth_store()
+        assert view["providers"] == {}
+
+    def test_migration_is_idempotent_after_second_call(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        legacy = tmp_path / "auth.json"
+        legacy.write_text(
+            json.dumps(
+                {
+                    "providers": {
+                        "openai": {
+                            "access_token": "abc",
+                            "refresh_token": "",
+                            "expires_at": 9_999_999_999,
+                        }
+                    }
+                }
+            )
+        )
+        toml_path = tmp_path / "auth.toml"
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(toml_path))
+        monkeypatch.setattr("core.gateway.auth.oauth_login.LEGACY_AUTH_STORE_PATH", legacy)
+
+        from core.gateway.auth.oauth_login import _load_auth_store
+
+        _load_auth_store()
+        # Second call: legacy file gone, view rebuilt from auth.toml
+        view = _load_auth_store()
+        assert view["providers"]["openai"]["access_token"] == "abc"
+
+
+class TestSaveRoutesThroughAuthToml:
+    def test_save_auth_store_persists_oauth_to_toml(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        toml_path = tmp_path / "auth.toml"
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(toml_path))
+
+        from core.gateway.auth.oauth_login import _save_auth_store
+
+        _save_auth_store(
+            {
+                "version": 1,
+                "providers": {
+                    "openai": {
+                        "access_token": "new-access-789",
+                        "refresh_token": "rt-456",
+                        "expires_at": 9_999_999_999,
+                        "account_id": "acct-x",
+                        "email": "x@y.z",
+                        "plan_type": "plus",
+                    }
+                },
+            }
+        )
+        text = toml_path.read_text()
+        assert "openai-codex-geode" in text
+        assert "new-access-789" in text

--- a/tests/test_oauth_login.py
+++ b/tests/test_oauth_login.py
@@ -1,8 +1,13 @@
-"""Tests for /login command and OAuth login flow."""
+"""Tests for OAuth login flow + auth.toml SOT (v0.50.2 onwards).
+
+The legacy ``~/.geode/auth.json`` was retired in v0.50.2; these tests
+exercise the new auth.toml-backed save/load path through the public
+``_save_auth_store`` / ``_load_auth_store`` helpers (kept as
+backwards-compatible shims for ``get_auth_status`` etc).
+"""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,50 +19,61 @@ from core.gateway.auth.oauth_login import (
 )
 
 
+def _isolate(tmp_path: Path, monkeypatch) -> Path:
+    """Point GEODE_AUTH_TOML at a temp file + isolate the legacy path."""
+    toml_path = tmp_path / "auth.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(toml_path))
+    monkeypatch.setattr(
+        "core.gateway.auth.oauth_login.LEGACY_AUTH_STORE_PATH",
+        tmp_path / "auth.json",
+    )
+    return toml_path
+
+
 class TestAuthStore:
     def test_load_empty(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", tmp_path / "auth.json")
+        _isolate(tmp_path, monkeypatch)
         store = _load_auth_store()
         assert store["version"] == 1
         assert store["providers"] == {}
 
-    def test_save_and_load(self, tmp_path: Path, monkeypatch):
-        path = tmp_path / "auth.json"
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", path)
+    def test_save_and_load_round_trip(self, tmp_path: Path, monkeypatch):
+        _isolate(tmp_path, monkeypatch)
 
-        data = {"version": 1, "providers": {"openai": {"access_token": "test"}}}
-        _save_auth_store(data)
-
-        assert path.exists()
+        _save_auth_store(
+            {"version": 1, "providers": {"openai": {"access_token": "test-rt"}}}
+        )
         loaded = _load_auth_store()
-        assert loaded["providers"]["openai"]["access_token"] == "test"
+        assert loaded["providers"]["openai"]["access_token"] == "test-rt"
 
-    def test_save_permissions(self, tmp_path: Path, monkeypatch):
-        path = tmp_path / "auth.json"
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", path)
-        _save_auth_store({"version": 1, "providers": {}})
-        assert oct(path.stat().st_mode)[-3:] == "600"
+    def test_save_routes_through_authtoml(self, tmp_path: Path, monkeypatch):
+        toml_path = _isolate(tmp_path, monkeypatch)
+        _save_auth_store(
+            {"version": 1, "providers": {"openai": {"access_token": "abc-perm"}}}
+        )
+        # auth.toml is the new SOT — written with 0600 perms (auth_toml.save_auth_toml).
+        assert toml_path.exists()
+        assert oct(toml_path.stat().st_mode)[-3:] == "600"
 
 
 class TestReadCredentials:
     def test_read_valid(self, tmp_path: Path, monkeypatch):
         import time
 
-        path = tmp_path / "auth.json"
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", path)
-
-        data = {
-            "version": 1,
-            "providers": {
-                "openai": {
-                    "access_token": "test-token",
-                    "refresh_token": "rt-test",
-                    "expires_at": time.time() + 3600,
-                    "account_id": "acc-123",
-                }
-            },
-        }
-        path.write_text(json.dumps(data))
+        _isolate(tmp_path, monkeypatch)
+        _save_auth_store(
+            {
+                "version": 1,
+                "providers": {
+                    "openai": {
+                        "access_token": "test-token",
+                        "refresh_token": "rt-test",
+                        "expires_at": time.time() + 3600,
+                        "account_id": "acc-123",
+                    }
+                },
+            }
+        )
 
         creds = read_geode_openai_credentials()
         assert creds is not None
@@ -66,25 +82,22 @@ class TestReadCredentials:
     def test_read_expired(self, tmp_path: Path, monkeypatch):
         import time
 
-        path = tmp_path / "auth.json"
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", path)
-
-        data = {
-            "version": 1,
-            "providers": {
-                "openai": {
-                    "access_token": "expired-token",
-                    "expires_at": time.time() - 100,
-                }
-            },
-        }
-        path.write_text(json.dumps(data))
-
-        creds = read_geode_openai_credentials()
-        assert creds is None
+        _isolate(tmp_path, monkeypatch)
+        _save_auth_store(
+            {
+                "version": 1,
+                "providers": {
+                    "openai": {
+                        "access_token": "expired-token",
+                        "expires_at": time.time() - 100,
+                    }
+                },
+            }
+        )
+        assert read_geode_openai_credentials() is None
 
     def test_read_missing(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", tmp_path / "nope.json")
+        _isolate(tmp_path, monkeypatch)
         assert read_geode_openai_credentials() is None
 
 
@@ -92,22 +105,21 @@ class TestAuthStatus:
     def test_status_with_credentials(self, tmp_path: Path, monkeypatch):
         import time
 
-        path = tmp_path / "auth.json"
-        monkeypatch.setattr("core.gateway.auth.oauth_login.AUTH_STORE_PATH", path)
-
-        data = {
-            "version": 1,
-            "providers": {
-                "openai": {
-                    "access_token": "tok",
-                    "email": "test@example.com",
-                    "plan_type": "plus",
-                    "source": "geode-device-code",
-                    "expires_at": time.time() + 7200,
-                }
-            },
-        }
-        path.write_text(json.dumps(data))
+        _isolate(tmp_path, monkeypatch)
+        _save_auth_store(
+            {
+                "version": 1,
+                "providers": {
+                    "openai": {
+                        "access_token": "tok",
+                        "email": "test@example.com",
+                        "plan_type": "plus",
+                        "source": "geode-device-code",
+                        "expires_at": time.time() + 7200,
+                    }
+                },
+            }
+        )
 
         with patch(
             "core.gateway.auth.codex_cli_oauth.read_codex_cli_credentials", return_value=None
@@ -115,9 +127,11 @@ class TestAuthStatus:
             statuses = get_auth_status()
 
         assert len(statuses) >= 1
-        assert statuses[0]["provider"] == "openai"
-        assert statuses[0]["email"] == "test@example.com"
-        assert statuses[0]["status"] == "active"
+        # The first status row corresponds to our openai entry
+        openai_rows = [s for s in statuses if s["provider"] == "openai"]
+        assert openai_rows
+        assert openai_rows[0]["email"] == "test@example.com"
+        assert openai_rows[0]["status"] == "active"
 
     def test_status_empty(self, tmp_path: Path, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_oauth_login.py
+++ b/tests/test_oauth_login.py
@@ -40,17 +40,13 @@ class TestAuthStore:
     def test_save_and_load_round_trip(self, tmp_path: Path, monkeypatch):
         _isolate(tmp_path, monkeypatch)
 
-        _save_auth_store(
-            {"version": 1, "providers": {"openai": {"access_token": "test-rt"}}}
-        )
+        _save_auth_store({"version": 1, "providers": {"openai": {"access_token": "test-rt"}}})
         loaded = _load_auth_store()
         assert loaded["providers"]["openai"]["access_token"] == "test-rt"
 
     def test_save_routes_through_authtoml(self, tmp_path: Path, monkeypatch):
         toml_path = _isolate(tmp_path, monkeypatch)
-        _save_auth_store(
-            {"version": 1, "providers": {"openai": {"access_token": "abc-perm"}}}
-        )
+        _save_auth_store({"version": 1, "providers": {"openai": {"access_token": "abc-perm"}}})
         # auth.toml is the new SOT — written with 0600 perms (auth_toml.save_auth_toml).
         assert toml_path.exists()
         assert oct(toml_path.stat().st_mode)[-3:] == "600"

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.50.1"
+version = "0.50.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
v0.50.2: v0.50.0이 도입한 `auth.toml` SOT가 OAuth 토큰까지 흡수.
legacy `~/.geode/auth.json` 첫 부팅 시 자동 마이그레이션 + `*.migrated.bak` 백업.

#800 (feature/auth-json-merge → develop)을 main으로.

## Verification
- [x] feature/auth-json-merge → develop CI 5/5 (Lint, Type, Security, Test, Gate)
- [x] pytest 4051 passed (1 skipped, 19 deselected)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)