### PR TITLE
feat(v0.51.0): Eligibility 관측성 + LLM-readable credential breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.51.0] — 2026-04-25
+
+### Added
+- **`ProfileRejectReason` + `EligibilityResult`** — `ProfileStore.evaluate_eligibility(provider)`가 모든 profile에 대해 (무엇이/왜) 거부됐는지 구조화된 verdict를 반환합니다. 이전에는 `list_available()`이 silent skip으로 처리해서 "왜 이 profile이 안 잡히지?" 추적이 불가능했습니다. 5종 이유: `provider_mismatch`, `disabled`, `expired`, `cooling_down`, `missing_key`. (`core/gateway/auth/profiles.py`)
+- **Rotator 진단 로깅** — `ProfileRotator.resolve()`가 매칭 실패 시 모든 거부 사유를 한 줄에 요약 로그로 남깁니다 (예: `No eligible profiles for provider=openai (evaluated 2, rejected 2): openai:expired=expired(...) ; openai:cooldown=cooling_down(...)`). 마지막 verdict는 provider별로 캐시되어 LLM breadcrumb이 같은 정보를 참조합니다. (`core/gateway/auth/rotation.py`)
+- **LLM-readable credential breadcrumb** — auth 에러로 LLM 호출이 실패하면 다음 agentic round에 `[system] credential note: ...` 시스템 메시지가 자동 주입됩니다. 거부된 profile별 reason + 다음 액션(예: `manage_login(subcommand='use', args='<other-plan>')`)이 포함되어 모델이 자가 복구하거나 사용자에게 의미 있는 메시지를 줄 수 있습니다. Claude Code `createModelSwitchBreadcrumbs` 패턴 차용. (`core/gateway/auth/credential_breadcrumb.py`, `core/agent/agentic_loop.py:_inject_credential_breadcrumb`)
+- **`/login` dashboard reject badges** — Profiles 섹션의 각 행에 ✓/✗ 배지 + reason + detail 표시 (예: `✗ cooling_down (47s remaining, error_count=3)`). OpenClaw `auth-health.ts`의 `AuthProfileHealth.reasonCode` 패턴 차용. (`core/cli/commands.py:_login_show_status`)
+- **`manage_login` 도구 응답에 eligibility verdict 포함** — `profiles[].eligible / reason / reason_detail` 필드 추가. LLM이 status 한 번 호출로 모든 거부 사유를 보고 후속 결정 가능. (`core/cli/tool_handlers.py:handle_manage_login`)
+
+### Changed
+- `ProfileRotator.resolve()`가 내부적으로 `list_available` 대신 `evaluate_eligibility`를 호출 (시그니처/반환 타입 보존, 동작 동일).
+
 ## [0.50.2] — 2026-04-25
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.50.2
+- **Version**: 0.51.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 227
-- **Tests**: 4051+
+- **Modules**: 228
+- **Tests**: 4065+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.50.2 — Long-running Autonomous Execution Harness
+# GEODE v0.51.0 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.50.2 — Long-running Autonomous Execution Harness
+# GEODE v0.51.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -817,6 +817,10 @@ class AgenticLoop:
                             from core.cli.ui.agentic_ui import emit_llm_error
 
                             emit_llm_error(_et, _sev, _hint, self.model, self._provider)
+                        # v0.51.0: inject LLM-readable credential breadcrumb so
+                        # the next round sees structured eligibility verdicts
+                        # (Claude Code createModelSwitchBreadcrumbs pattern).
+                        self._inject_credential_breadcrumb()
                         old_model = self.model
                         escalated = self._try_cross_provider_escalation()
                         if escalated:
@@ -1601,6 +1605,29 @@ class AgenticLoop:
                     )
                 return True
         return False
+
+    def _inject_credential_breadcrumb(self) -> None:
+        """Append an LLM-readable credential note after auth failure (v0.51.0).
+
+        The next agentic round sees a structured rejection breakdown so
+        the model can self-recover (call ``manage_login``) or surface a
+        meaningful message to the user instead of a generic 'LLM call
+        failed' line.
+        """
+        try:
+            from core.gateway.auth.credential_breadcrumb import format as fmt_breadcrumb
+            from core.gateway.auth.rotation import get_last_eligibility_verdicts
+
+            verdicts = get_last_eligibility_verdicts(self._provider)
+            note = fmt_breadcrumb(
+                verdicts,
+                attempted_provider=self._provider,
+                attempted_model=self.model,
+            )
+            if note and not self.context.is_empty:
+                self.context.add_user_message(note)
+        except Exception:
+            log.debug("credential breadcrumb injection failed", exc_info=True)
 
     # ---------------------------------------------------------------------------
     # Feature 5: Backpressure on tool failures

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -2004,6 +2004,14 @@ def _login_show_status() -> None:
         by_provider: dict[str, list[AuthProfile]] = {}
         for p in profiles:
             by_provider.setdefault(p.provider, []).append(p)
+        # v0.51.0 — pre-compute eligibility per provider so each profile row
+        # carries an inline reject badge (cooldown / expired / disabled / etc).
+        verdicts_by_name: dict[str, str] = {}
+        details_by_name: dict[str, str] = {}
+        for prov in by_provider:
+            for v in store.evaluate_eligibility(prov):
+                verdicts_by_name[v.profile_name] = v.reason_code
+                details_by_name[v.profile_name] = v.detail
         for provider in sorted(by_provider.keys()):
             for p in by_provider[provider]:
                 badge = {
@@ -2019,8 +2027,17 @@ def _login_show_status() -> None:
 
                     rem = int(p.expires_at - _t.time())
                     expiry = f" · expires {rem // 60}m" if rem > 0 else " · [error]expired[/error]"
+                # Eligibility badge — green ✓ when ok, yellow/red with reason otherwise.
+                reason = verdicts_by_name.get(p.name, "ok")
+                if reason == "ok":
+                    badge_str = "[success]✓[/success]"
+                else:
+                    detail = details_by_name.get(p.name, "")
+                    badge_str = f"[warning]✗ {reason}[/warning]"
+                    if detail:
+                        badge_str += f" [muted]({detail})[/muted]"
                 console.print(
-                    f"  [muted]•[/muted] {p.name:<28} "
+                    f"  {badge_str}  {p.name:<28} "
                     f"[muted]{badge:<7}[/muted] {p.masked_key} "
                     f"plan={plan_id}{managed}{expiry}"
                 )

--- a/core/cli/tool_handlers.py
+++ b/core/cli/tool_handlers.py
@@ -839,16 +839,36 @@ def _build_system_handlers(
                         "quota_used": int(usage.weighted_calls),
                     }
                 )
-            profiles_payload = [
-                {
-                    "name": p.name,
-                    "provider": p.provider,
-                    "type": p.credential_type.value,
-                    "plan_id": p.plan_id or None,
-                    "managed_by": p.managed_by or None,
-                }
-                for p in store.list_all()
-            ]
+            # v0.51.0 — annotate each profile with its current eligibility
+            # verdict per the profile's own provider. This lets the LLM see
+            # *why* a credential is unusable (cooldown / expired / disabled
+            # / missing key) without needing a second tool call.
+            verdict_index: dict[tuple[str, str], tuple[bool, str, str]] = {}
+            for prov in {p.provider for p in store.list_all()}:
+                for v in store.evaluate_eligibility(prov):
+                    verdict_index[(v.profile_name, v.provider)] = (
+                        v.eligible,
+                        v.reason_code,
+                        v.detail,
+                    )
+
+            profiles_payload = []
+            for p in store.list_all():
+                eligible, reason, detail = verdict_index.get(
+                    (p.name, p.provider), (False, "unknown", "")
+                )
+                profiles_payload.append(
+                    {
+                        "name": p.name,
+                        "provider": p.provider,
+                        "type": p.credential_type.value,
+                        "plan_id": p.plan_id or None,
+                        "managed_by": p.managed_by or None,
+                        "eligible": eligible,
+                        "reason": reason,
+                        "reason_detail": detail,
+                    }
+                )
             routing_payload = registry.all_routing()
         except Exception:
             plans_payload = []

--- a/core/gateway/auth/credential_breadcrumb.py
+++ b/core/gateway/auth/credential_breadcrumb.py
@@ -1,0 +1,103 @@
+"""LLM-readable credential breadcrumb (Claude Code ``createModelSwitchBreadcrumbs`` pattern).
+
+When an LLM call fails because no profile is eligible (or after a
+``mark_failure`` puts a profile into cooldown), we want the *next*
+agentic round to see a structured note explaining what happened — so
+the model can surface it to the user, call ``manage_login`` to
+remediate, or fall back to an alternative plan.
+
+This is the LLM-side counterpart of:
+  * the operator-side detailed log (``ProfileRotator.resolve``)
+  * the user-side dashboard reject badges (``/login`` rendering)
+
+All three feed off the same ``EligibilityResult`` verdicts produced by
+``ProfileStore.evaluate_eligibility``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from core.gateway.auth.profiles import EligibilityResult, ProfileRejectReason
+
+# Hint sentence per reason — what the LLM should say or do next.
+_NEXT_ACTION: dict[ProfileRejectReason, str] = {
+    ProfileRejectReason.PROVIDER_MISMATCH: (
+        "this profile belongs to a different provider; ignore for current call"
+    ),
+    ProfileRejectReason.DISABLED: ("user explicitly disabled this profile; do not auto-re-enable"),
+    ProfileRejectReason.EXPIRED: (
+        "OAuth token expired — call manage_login(subcommand='oauth', args='openai') "
+        "to refresh, or surface to the user"
+    ),
+    ProfileRejectReason.COOLING_DOWN: (
+        "rate-limited or upstream rejected — wait until cooldown clears, "
+        "or call manage_login(subcommand='use', args='<other-plan>') to switch"
+    ),
+    ProfileRejectReason.MISSING_KEY: (
+        "no API key registered — call manage_login(subcommand='set-key', "
+        "args='<plan-id> <key>') after asking the user for one"
+    ),
+}
+
+
+def format(
+    verdicts: Iterable[EligibilityResult],
+    *,
+    attempted_provider: str,
+    attempted_model: str = "",
+) -> str:
+    """Build the ``[system] credential note: ...`` line injected into context.
+
+    Returns an empty string when there's nothing actionable to say
+    (e.g. all profiles eligible). Caller should skip injection in that
+    case to avoid context bloat.
+    """
+    verdicts = list(verdicts)
+    if not verdicts:
+        return (
+            f"[system] credential note: no profiles registered for provider "
+            f"'{attempted_provider}'. Call manage_login(subcommand='add') "
+            "to register one, or surface this to the user."
+        )
+
+    eligible = [v for v in verdicts if v.eligible]
+    rejected = [v for v in verdicts if not v.eligible]
+
+    # Nothing to report if all profiles are usable for the active provider.
+    relevant_rejected = [
+        v for v in rejected if v.reason is not ProfileRejectReason.PROVIDER_MISMATCH
+    ]
+    if not relevant_rejected and eligible:
+        return ""
+
+    header = (
+        f"[system] credential note for {attempted_provider}"
+        + (f" model={attempted_model}" if attempted_model else "")
+        + ":"
+    )
+    lines: list[str] = [header]
+
+    if eligible:
+        lines.append(
+            "  eligible: "
+            + ", ".join(f"{v.profile_name}({v.credential_type.value})" for v in eligible)
+        )
+    else:
+        lines.append("  eligible: (none)")
+
+    if relevant_rejected:
+        lines.append("  rejected:")
+        for v in relevant_rejected:
+            assert v.reason is not None  # guarded by relevant_rejected filter
+            action = _NEXT_ACTION.get(v.reason, "review profile state")
+            lines.append(f"    - {v.profile_name} [{v.reason_code}] {v.detail} → {action}")
+
+    if not eligible:
+        lines.append(
+            "  next step: call manage_login(subcommand='status') to inspect, "
+            "then either remediate or report to the user. Do not loop on the "
+            "same failing tool call."
+        )
+
+    return "\n".join(lines)

--- a/core/gateway/auth/profiles.py
+++ b/core/gateway/auth/profiles.py
@@ -2,6 +2,12 @@
 
 OpenClaw Auth Profile pattern: three credential types with
 type-priority rotation (oauth > token > api_key).
+
+v0.51.0 — Eligibility observability: every rejection emits a structured
+``EligibilityResult`` with a ``ProfileRejectReason`` enum so silent skips
+are eliminated. Rotator logs the full breakdown when no profile matches,
+and the same verdicts feed both the ``/login`` dashboard and the
+LLM-readable credential breadcrumb (``credential_breadcrumb.format``).
 """
 
 from __future__ import annotations
@@ -26,6 +32,44 @@ TYPE_PRIORITY: dict[CredentialType, int] = {
     CredentialType.TOKEN: 1,
     CredentialType.API_KEY: 2,
 }
+
+
+class ProfileRejectReason(Enum):
+    """Why a profile was filtered out by eligibility evaluation.
+
+    Mirrors OpenClaw ``AuthCredentialReasonCode`` so external observers
+    can map verdicts cross-system.
+    """
+
+    PROVIDER_MISMATCH = "provider_mismatch"
+    DISABLED = "disabled"
+    EXPIRED = "expired"
+    COOLING_DOWN = "cooling_down"
+    MISSING_KEY = "missing_key"
+
+
+@dataclass(frozen=True)
+class EligibilityResult:
+    """Per-profile verdict from ``ProfileStore.evaluate_eligibility``.
+
+    Every profile in the store gets exactly one verdict — either
+    ``eligible=True`` (no reason) or ``eligible=False`` with a structured
+    reason + human-readable detail.
+    """
+
+    profile_name: str
+    provider: str
+    credential_type: CredentialType
+    eligible: bool
+    reason: ProfileRejectReason | None = None
+    detail: str = ""
+    expires_at: float = 0.0
+    cooldown_until: float = 0.0
+    error_count: int = 0
+
+    @property
+    def reason_code(self) -> str:
+        return self.reason.value if self.reason else "ok"
 
 
 @dataclass
@@ -128,6 +172,93 @@ class ProfileStore:
         if provider:
             all_profiles = [p for p in all_profiles if p.provider == provider]
         return [p for p in all_profiles if p.is_available]
+
+    def evaluate_eligibility(
+        self,
+        provider: str,
+        *,
+        now: float | None = None,
+    ) -> list[EligibilityResult]:
+        """Return one ``EligibilityResult`` per profile in the store.
+
+        Unlike ``list_available``, this surfaces *why* each profile is
+        out of consideration — provider mismatch, expired, in cooldown,
+        disabled, or missing a key. Used by:
+          * ``ProfileRotator.resolve()`` for diagnostic logging when no
+            profile matches.
+          * The ``/login`` dashboard to show inline reject badges.
+          * ``credential_breadcrumb.format()`` to inject an LLM-readable
+            note into the agentic loop after auth failures.
+        """
+        ts = now if now is not None else time.time()
+        results: list[EligibilityResult] = []
+        for p in self._profiles.values():
+
+            def make(
+                eligible: bool,
+                reason: ProfileRejectReason | None = None,
+                detail: str = "",
+                _p: AuthProfile = p,
+            ) -> EligibilityResult:
+                return EligibilityResult(
+                    profile_name=_p.name,
+                    provider=_p.provider,
+                    credential_type=_p.credential_type,
+                    expires_at=_p.expires_at,
+                    cooldown_until=_p.cooldown_until,
+                    error_count=_p.error_count,
+                    eligible=eligible,
+                    reason=reason,
+                    detail=detail,
+                )
+
+            if p.provider != provider:
+                results.append(
+                    make(
+                        False,
+                        ProfileRejectReason.PROVIDER_MISMATCH,
+                        f"profile.provider={p.provider!r} != requested={provider!r}",
+                    )
+                )
+                continue
+            if p.disabled:
+                results.append(
+                    make(
+                        False,
+                        ProfileRejectReason.DISABLED,
+                        p.disabled_reason or "no reason given",
+                    )
+                )
+                continue
+            if not p.key:
+                results.append(
+                    make(
+                        False,
+                        ProfileRejectReason.MISSING_KEY,
+                        "profile has no key set — run /login set-key",
+                    )
+                )
+                continue
+            if p.expires_at and ts > p.expires_at:
+                results.append(
+                    make(
+                        False,
+                        ProfileRejectReason.EXPIRED,
+                        f"expired {int(ts - p.expires_at)}s ago (at {p.expires_at:.0f})",
+                    )
+                )
+                continue
+            if ts < p.cooldown_until:
+                results.append(
+                    make(
+                        False,
+                        ProfileRejectReason.COOLING_DOWN,
+                        f"{int(p.cooldown_until - ts)}s remaining (error_count={p.error_count})",
+                    )
+                )
+                continue
+            results.append(make(True))
+        return results
 
     def group_by_provider(self) -> dict[str, list[AuthProfile]]:
         groups: dict[str, list[AuthProfile]] = {}

--- a/core/gateway/auth/rotation.py
+++ b/core/gateway/auth/rotation.py
@@ -16,7 +16,22 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-from core.gateway.auth.profiles import AuthProfile, ProfileStore
+from core.gateway.auth.profiles import AuthProfile, EligibilityResult, ProfileStore
+
+# Module-level cache of the most recent eligibility breakdown per provider.
+# Read by ``credential_breadcrumb.format()`` so the LLM-facing system
+# message reflects the same verdicts the rotator just considered.
+_LAST_VERDICTS: dict[str, list[EligibilityResult]] = {}
+
+
+def get_last_eligibility_verdicts(provider: str) -> list[EligibilityResult]:
+    """Return the verdicts captured by the last ``ProfileRotator.resolve(provider)`` call.
+
+    Used by ``credential_breadcrumb.format()`` to inject an LLM-readable
+    note after auth failures. Empty list if nothing has been resolved yet.
+    """
+    return list(_LAST_VERDICTS.get(provider, ()))
+
 
 log = logging.getLogger(__name__)
 
@@ -58,19 +73,42 @@ class ProfileRotator:
     def resolve(self, provider: str) -> AuthProfile | None:
         """Resolve the best available profile for a provider.
 
+        v0.51.0 — Calls ``ProfileStore.evaluate_eligibility`` so every
+        rejection emits a structured reason. The full verdict list is
+        cached per-provider for ``credential_breadcrumb.format()`` and
+        the ``/login`` dashboard to render.
+
         If the selected profile is managed and expires within 120s,
         proactively re-reads from external storage before returning.
-
-        Returns None if no profiles are available.
+        Returns None if no profiles are eligible.
         """
-        available = self._store.list_available(provider)
-        if not available:
-            log.warning("No available profiles for provider=%s", provider)
+        verdicts = self._store.evaluate_eligibility(provider)
+        _LAST_VERDICTS[provider] = verdicts
+
+        eligible_profiles: list[AuthProfile] = []
+        for verdict in verdicts:
+            if verdict.eligible:
+                profile = self._store.get(verdict.profile_name)
+                if profile is not None:
+                    eligible_profiles.append(profile)
+
+        if not eligible_profiles:
+            rejected = [v for v in verdicts if not v.eligible]
+            if rejected:
+                log.warning(
+                    "No eligible profiles for provider=%s (evaluated %d, rejected %d): %s",
+                    provider,
+                    len(verdicts),
+                    len(rejected),
+                    "; ".join(f"{v.profile_name}={v.reason_code}({v.detail})" for v in rejected),
+                )
+            else:
+                log.warning("No profiles registered for provider=%s", provider)
             return None
 
         # Sort: type priority first, then LRU
-        available.sort(key=lambda p: p.sort_key())
-        selected = available[0]
+        eligible_profiles.sort(key=lambda p: p.sort_key())
+        selected = eligible_profiles[0]
 
         # Proactive refresh: re-read if managed + expiring within skew
         if selected.managed_by and selected.expires_at > 0:
@@ -83,7 +121,7 @@ class ProfileRotator:
             selected.name,
             selected.credential_type.value,
             provider,
-            len(available),
+            len(eligible_profiles),
         )
         return selected
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.50.2"
+version = "0.51.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_profile_eligibility.py
+++ b/tests/test_profile_eligibility.py
@@ -1,0 +1,258 @@
+"""Phase v0.51.0 — ProfileStore.evaluate_eligibility + breadcrumb tests."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from core.gateway.auth.credential_breadcrumb import format as fmt_breadcrumb
+from core.gateway.auth.profiles import (
+    AuthProfile,
+    CredentialType,
+    EligibilityResult,
+    ProfileRejectReason,
+    ProfileStore,
+)
+
+
+def _store_with(*profiles: AuthProfile) -> ProfileStore:
+    s = ProfileStore()
+    for p in profiles:
+        s.add(p)
+    return s
+
+
+class TestEvaluateEligibility:
+    def test_provider_mismatch(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                name="anthropic:work",
+                provider="anthropic",
+                credential_type=CredentialType.API_KEY,
+                key="sk-ant-x",
+            )
+        )
+        verdicts = s.evaluate_eligibility("openai")
+        assert len(verdicts) == 1
+        v = verdicts[0]
+        assert not v.eligible
+        assert v.reason is ProfileRejectReason.PROVIDER_MISMATCH
+        assert "anthropic" in v.detail and "openai" in v.detail
+
+    def test_disabled_profile(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                name="openai:work",
+                provider="openai",
+                credential_type=CredentialType.API_KEY,
+                key="sk-x",
+                disabled=True,
+                disabled_reason="revoked by user",
+            )
+        )
+        v = s.evaluate_eligibility("openai")[0]
+        assert not v.eligible
+        assert v.reason is ProfileRejectReason.DISABLED
+        assert "revoked by user" in v.detail
+
+    def test_missing_key(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                name="openai:work",
+                provider="openai",
+                credential_type=CredentialType.API_KEY,
+                key="",
+            )
+        )
+        v = s.evaluate_eligibility("openai")[0]
+        assert not v.eligible
+        assert v.reason is ProfileRejectReason.MISSING_KEY
+
+    def test_expired_token(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                name="openai-codex:cli",
+                provider="openai-codex",
+                credential_type=CredentialType.OAUTH,
+                key="tok",
+                expires_at=time.time() - 60,
+            )
+        )
+        v = s.evaluate_eligibility("openai-codex")[0]
+        assert not v.eligible
+        assert v.reason is ProfileRejectReason.EXPIRED
+        assert "expired" in v.detail and "ago" in v.detail
+
+    def test_cooling_down(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                name="openai:work",
+                provider="openai",
+                credential_type=CredentialType.API_KEY,
+                key="sk-x",
+                cooldown_until=time.time() + 30,
+                error_count=4,
+            )
+        )
+        v = s.evaluate_eligibility("openai")[0]
+        assert not v.eligible
+        assert v.reason is ProfileRejectReason.COOLING_DOWN
+        assert "remaining" in v.detail
+        assert "error_count=4" in v.detail
+
+    def test_eligible_profile_has_no_reason(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                name="openai:work",
+                provider="openai",
+                credential_type=CredentialType.API_KEY,
+                key="sk-x",
+            )
+        )
+        v = s.evaluate_eligibility("openai")[0]
+        assert v.eligible
+        assert v.reason is None
+        assert v.reason_code == "ok"
+
+    def test_every_profile_gets_a_verdict(self) -> None:
+        """No silent skips — verdicts list length always equals store size."""
+        s = _store_with(
+            AuthProfile("a:1", "a", CredentialType.API_KEY, key="k"),
+            AuthProfile("b:1", "b", CredentialType.API_KEY, key="k"),
+            AuthProfile("a:2", "a", CredentialType.API_KEY, key="k", disabled=True),
+        )
+        verdicts = s.evaluate_eligibility("a")
+        assert len(verdicts) == 3  # all three, not just "a"-provider profiles
+        names = {v.profile_name for v in verdicts}
+        assert names == {"a:1", "b:1", "a:2"}
+
+
+class TestRotatorLoggingAndCache:
+    def test_resolve_caches_verdicts_for_breadcrumb(self) -> None:
+        from core.gateway.auth.rotation import (
+            ProfileRotator,
+            get_last_eligibility_verdicts,
+        )
+
+        s = _store_with(
+            AuthProfile(
+                name="openai:work",
+                provider="openai",
+                credential_type=CredentialType.API_KEY,
+                key="sk-x",
+                cooldown_until=time.time() + 60,
+                error_count=2,
+            )
+        )
+        rotator = ProfileRotator(s)
+        assert rotator.resolve("openai") is None
+
+        cached = get_last_eligibility_verdicts("openai")
+        assert len(cached) == 1
+        assert cached[0].reason is ProfileRejectReason.COOLING_DOWN
+
+    def test_resolve_logs_rejection_breakdown(self, caplog) -> None:
+        from core.gateway.auth.rotation import ProfileRotator
+
+        s = _store_with(
+            AuthProfile(
+                name="openai:expired",
+                provider="openai",
+                credential_type=CredentialType.OAUTH,
+                key="tok",
+                expires_at=time.time() - 30,
+            )
+        )
+        rotator = ProfileRotator(s)
+        with caplog.at_level("WARNING", logger="core.gateway.auth.rotation"):
+            assert rotator.resolve("openai") is None
+        joined = "\n".join(rec.message for rec in caplog.records)
+        assert "openai:expired=expired" in joined
+
+
+class TestBreadcrumbFormatter:
+    def test_silent_when_eligible_present_and_no_relevant_rejections(self) -> None:
+        s = _store_with(AuthProfile("openai:work", "openai", CredentialType.API_KEY, key="sk-x"))
+        verdicts = s.evaluate_eligibility("openai")
+        note = fmt_breadcrumb(verdicts, attempted_provider="openai")
+        assert note == ""
+
+    def test_includes_reason_and_action_for_cooldown(self) -> None:
+        s = _store_with(
+            AuthProfile(
+                "openai:work",
+                "openai",
+                CredentialType.API_KEY,
+                key="sk-x",
+                cooldown_until=time.time() + 90,
+                error_count=3,
+            )
+        )
+        verdicts = s.evaluate_eligibility("openai")
+        note = fmt_breadcrumb(verdicts, attempted_provider="openai", attempted_model="gpt-5.4")
+        assert "[system] credential note" in note
+        assert "openai:work" in note
+        assert "cooling_down" in note
+        assert "manage_login" in note
+        assert "gpt-5.4" in note
+
+    def test_empty_verdicts_emits_no_profiles_message(self) -> None:
+        note = fmt_breadcrumb([], attempted_provider="openai")
+        assert "no profiles registered" in note
+        assert "manage_login" in note
+
+    def test_excludes_provider_mismatch_noise(self) -> None:
+        # Only an anthropic profile present, but we asked for openai.
+        # The provider_mismatch verdict should NOT appear in the note.
+        s = _store_with(
+            AuthProfile("anthropic:work", "anthropic", CredentialType.API_KEY, key="sk-x")
+        )
+        verdicts = s.evaluate_eligibility("openai")
+        note = fmt_breadcrumb(verdicts, attempted_provider="openai")
+        assert "provider_mismatch" not in note
+        # But it should still tell the LLM there are no eligible profiles
+        assert "(none)" in note
+
+
+class TestAgenticLoopBreadcrumbInjection:
+    def test_inject_credential_breadcrumb_appends_user_message(self) -> None:
+        # Light smoke — exercises the wiring without spinning up a real loop.
+        from core.agent.agentic_loop import AgenticLoop
+
+        loop = AgenticLoop.__new__(AgenticLoop)
+        loop._provider = "openai"  # type: ignore[attr-defined]
+        loop.model = "gpt-5.4"  # type: ignore[attr-defined]
+
+        class _FakeContext:
+            def __init__(self) -> None:
+                self.messages: list[dict[str, str]] = [{"role": "user", "content": "hi"}]
+                self.is_empty = False
+
+            def add_user_message(self, content: str) -> None:
+                self.messages.append({"role": "user", "content": content})
+
+        loop.context = _FakeContext()  # type: ignore[attr-defined]
+
+        # Simulate a cached cooldown verdict for openai
+        with patch(
+            "core.gateway.auth.rotation._LAST_VERDICTS",
+            {
+                "openai": [
+                    EligibilityResult(
+                        profile_name="openai:work",
+                        provider="openai",
+                        credential_type=CredentialType.API_KEY,
+                        eligible=False,
+                        reason=ProfileRejectReason.COOLING_DOWN,
+                        detail="60s remaining (error_count=3)",
+                        cooldown_until=time.time() + 60,
+                        error_count=3,
+                    )
+                ]
+            },
+        ):
+            loop._inject_credential_breadcrumb()
+
+        injected = [m for m in loop.context.messages if "credential note" in m["content"]]
+        assert injected, "breadcrumb was not appended to context"
+        assert "cooling_down" in injected[0]["content"]


### PR DESCRIPTION
## Summary
- 자격증명 거부 사유를 운영자 로그·UI dashboard·LLM context **3-way로 동시 노출**
- `ProfileRejectReason` enum + `EligibilityResult` dataclass — silent skip 제거
- `credential_breadcrumb.format()` — auth 실패 후 LLM이 자가 복구할 수 있도록 다음 round context에 reason+action 주입

## Why
이전 점검에서 식별된 silent-skip 약점(`list_available()`이 거부 사유 노출 안 함)을 메우면서, 동시에 LLM 측 가시성 결핍(auth 에러 시 generic "LLM call failed"만 받음)도 함께 해소합니다.

레퍼런스 패턴 융합:
- **OpenClaw `auth-health.ts`** — `AuthProfileHealth.reasonCode` (5종 enum) + `auth-profiles/order.ts` `provider_mismatch` reason
- **Claude Code `utils/messages.ts:590`** — `createModelSwitchBreadcrumbs` (synthetic UserMessage 주입으로 LLM이 mid-conversation 변경 인지)

이 두 패턴을 합쳐서 사용자(dashboard)·운영자(로그)·LLM(context breadcrumb) 모두 같은 `EligibilityResult` verdict 데이터를 다른 형식으로 보게 됩니다 (single source 원칙).

## Changes
| File | Change |
|------|--------|
| `core/gateway/auth/profiles.py` | `ProfileRejectReason` enum (5종), `EligibilityResult` frozen dataclass, `ProfileStore.evaluate_eligibility(provider)` 메서드. 모든 profile에 정확히 1개 verdict, silent skip 0. |
| `core/gateway/auth/rotation.py` | `ProfileRotator.resolve()`가 `evaluate_eligibility` 사용. 매칭 실패 시 모든 reason 한 줄 요약 warning 로그. `_LAST_VERDICTS[provider]` 모듈 캐시 + `get_last_eligibility_verdicts(provider)` 신규 API. |
| `core/gateway/auth/credential_breadcrumb.py` (신설) | `format(verdicts, attempted_provider, attempted_model) → str` — `[system] credential note: ...` 메시지 생성. reason별 `_NEXT_ACTION` 힌트 (manage_login subcommand 직접 안내). all-eligible이면 "" 반환 (context bloat 방지). |
| `core/agent/agentic_loop.py` | `_inject_credential_breadcrumb()` 메서드 신규. `_et == "auth"` 분기에서 cross-provider escalation **이전에** 호출하여 다음 round context에 breadcrumb 주입. |
| `core/cli/commands.py:_login_show_status` | Profiles 섹션에 ✓/✗ + reason + detail 배지. 한 줄에 "왜 이 profile이 안 잡히는지" 즉시 가시화. |
| `core/cli/tool_handlers.py:handle_manage_login` | 응답 `profiles[]`에 `eligible / reason / reason_detail` 필드 추가. LLM이 status 한 번 호출로 모든 거부 사유를 봄. |
| `tests/test_profile_eligibility.py` (신설) | 14개 — 5종 reason 매칭, every-profile-gets-verdict 불변, rotator 캐시·로깅, breadcrumb formatter 4종, AgenticLoop 주입 smoke. |
| `CHANGELOG.md` `CLAUDE.md` `README.md` `README.ko.md` `pyproject.toml` | 0.50.2 → 0.51.0, modules 227→228, tests 4051→4065 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Silent skip 제거 (모든 profile에 verdict) | Implemented | evaluate_eligibility 불변 테스트로 보장 |
| Operator 로그 — reason 한 줄 요약 | Implemented | rotation.py warning |
| Operator 로그 — caplog 검증 | Implemented | test_resolve_logs_rejection_breakdown |
| LLM breadcrumb — context 주입 | Implemented | _inject_credential_breadcrumb |
| LLM breadcrumb — actionable hint per reason | Implemented | _NEXT_ACTION dict (5종) |
| LLM breadcrumb — silent when all OK | Implemented | format() returns "" |
| User dashboard — reject badges | Implemented | _login_show_status |
| Tool snapshot — verdict 포함 | Implemented | handle_manage_login |
| 호환성 (list_available 보존) | Implemented | 시그니처 유지, 추가만 |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (228 modules, strict)
- [x] pytest 4065 passed (1 skipped, 19 deselected) — 14개 신설 통과
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) unchanged

## Reference
- 사용자 GAP 지적: "list_available silent skip 보강 + LLM breadcrumb도 고려"
- OpenClaw `src/agents/auth-health.ts` (AuthProfileHealth.reasonCode 5종)
- Claude Code `utils/messages.ts:590` (createModelSwitchBreadcrumbs 패턴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)