### PR TITLE
fix(v0.51.1): IPC output parity — OAuth device-code, billing, /clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.51.1] — 2026-04-25
+
+### Fixed
+- **OAuth device-code flow invisible in IPC mode** — `/login oauth openai`이 daemon 안에서 실행되며 native `print()`로 출력해서 thin-client REPL이 verification URL과 user code를 받지 못하던 버그. 사용자가 브라우저에 입력할 코드를 볼 수 없어 OAuth 등록 자체가 막혔습니다. (`core/gateway/auth/oauth_login.py`)
+- **Billing error 메시지가 thin client에 도달 못 함** — `agentic_loop.py`가 `rich.console.Console()`을 직접 인스턴스화해서 `print()`로 출력. IPC 모드에서 daemon stdout(`/tmp/geode_serve.log`)에만 기록됐습니다.
+- **`/clear` 확인 프롬프트 daemon hang** — `input()`이 daemon stdin을 블록하지만 thin client는 그것을 모름. 사용자가 무한 대기 상태에 빠질 수 있었음.
+
+### Added
+- **IPC OAuth events** — `oauth_login_started`, `oauth_login_pending`, `oauth_login_success`, `oauth_login_failed` (4종). thin-client renderer가 in-place 진행 표시(`Waiting... (5s)`) + URL/code highlight + 성공 metadata(account_id, plan, stored path) 렌더링. (`core/cli/ui/agentic_ui.py`, `core/cli/ui/event_renderer.py`, `core/cli/ipc_client.py`)
+- **`billing_error` IPC event** — agentic loop의 `BillingError` catch 양 지점이 모두 `emit_billing_error(message)`로 전환.
+- **IPC mode `/clear` 가드** — IPC mode 감지 시 interactive 확인 차단, `--force` 명시 요구. 사용자에게 명확한 안내 메시지 표시.
+
+### Architecture
+- **Daemon-side print/input ban** — daemon 코드 경로에서 native `print()` / `input()` / `rich.console.Console()` 직접 인스턴스화 사용 금지. 모든 사용자 가시 출력은 IPC event를 거쳐야 함. `tests/test_ipc_event_parity.py`가 신규 event 모두 `ipc_client.py` allowlist에 등록됐는지 검증.
+
 ## [0.51.0] — 2026-04-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.51.0
+- **Version**: 0.51.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 228
-- **Tests**: 4065+
+- **Tests**: 4074+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.51.0 — Long-running Autonomous Execution Harness
+# GEODE v0.51.1 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.51.0 — Long-running Autonomous Execution Harness
+# GEODE v0.51.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/agentic_loop.py
+++ b/core/agent/agentic_loop.py
@@ -595,9 +595,9 @@ class AgenticLoop:
         try:
             decomposition_hint = self._try_decompose(user_input)
         except BillingError as exc:
-            from rich.console import Console as _Con
+            from core.cli.ui.agentic_ui import emit_billing_error
 
-            _Con().print(f"\n  [bold red]✗ Billing error[/bold red] — {exc}")
+            emit_billing_error(str(exc))
             return AgenticResult(
                 text=str(exc),
                 rounds=0,
@@ -717,9 +717,9 @@ class AgenticLoop:
                 response = await self._call_llm(system_prompt, messages, round_idx=round_idx)
             except BillingError as exc:
                 _spinner.stop()
-                from rich.console import Console as _Con
+                from core.cli.ui.agentic_ui import emit_billing_error
 
-                _Con().print(f"\n  [bold red]✗ Billing error[/bold red] — {exc}")
+                emit_billing_error(str(exc))
                 return AgenticResult(
                     text=str(exc),
                     rounds=round_idx + 1,

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -1776,6 +1776,22 @@ def cmd_clear(args: str) -> None:
     console.print()
 
     if "--force" not in args:
+        # v0.51.1: in IPC mode, native input() blocks the daemon and never
+        # reaches the thin client REPL. Detect via the IPC writer thread-local
+        # and require an explicit --force flag instead.
+        from core.cli.ui.agentic_ui import _ipc_writer_local
+
+        in_ipc_mode = getattr(_ipc_writer_local, "writer", None) is not None
+        if in_ipc_mode:
+            console.print(
+                f"  [warning]Refusing to clear {msg_count} messages without --force.[/warning]"
+            )
+            console.print(
+                "  [muted]Run /clear --force to confirm "
+                "(IPC mode disables interactive prompts).[/muted]"
+            )
+            console.print()
+            return
         console.print(f"  Clear all {msg_count} messages? (y/N): ", end="")
         try:
             answer = input().strip().lower()

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -216,6 +216,13 @@ class IPCClient:
                 "tool_diversity_forced",
                 "model_switched",
                 "checkpoint_saved",
+                # OAuth device-code lifecycle (v0.51.1 IPC parity)
+                "oauth_login_started",
+                "oauth_login_pending",
+                "oauth_login_success",
+                "oauth_login_failed",
+                # Daemon-side error surfaces (v0.51.1 IPC parity)
+                "billing_error",
                 # LLM lifecycle events
                 "llm_retry",
                 "llm_error",

--- a/core/cli/ui/agentic_ui.py
+++ b/core/cli/ui/agentic_ui.py
@@ -850,6 +850,121 @@ def emit_checkpoint_saved(session_id: str, round_idx: int) -> None:
 
 
 # ───────────────────────────────────────────────────────────────────────────
+# OAuth device-code flow events (v0.51.1 IPC parity)
+# ───────────────────────────────────────────────────────────────────────────
+#
+# Pre-v0.51.1 the OAuth login flow printed directly to daemon stdout, so
+# thin-client REPLs never saw the verification URL or user code. The flow
+# now emits structured events that ``event_renderer`` translates into
+# rich, in-place terminal output for both modes (IPC + direct).
+
+
+def emit_oauth_login_started(provider: str, verification_uri: str, user_code: str) -> None:
+    """Surface the device-code prompt to the user.
+
+    The thin client renders this as the highlighted "Open URL → Enter
+    code" pair. In direct mode (no IPC writer), falls back to console.
+    """
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "oauth_login_started",
+            provider=provider,
+            verification_uri=verification_uri,
+            user_code=user_code,
+        )
+        return
+    console.print()
+    console.print(f"  [header]{provider} OAuth Login[/header]")
+    console.print()
+    console.print("  1. Open this URL in your browser:")
+    console.print(f"     [link]{verification_uri}[/link]")
+    console.print()
+    console.print("  2. Enter this code:")
+    console.print(f"     [bold yellow]{user_code}[/bold yellow]")
+    console.print()
+    console.print("  [muted]Waiting for sign-in... (Ctrl+C to cancel)[/muted]")
+    console.print()
+
+
+def emit_oauth_login_pending(provider: str, elapsed_s: int) -> None:
+    """Periodic heartbeat while polling the token endpoint."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "oauth_login_pending",
+            provider=provider,
+            elapsed_s=elapsed_s,
+        )
+
+
+def emit_oauth_login_success(
+    provider: str,
+    *,
+    account_id: str = "",
+    email: str = "",
+    plan_type: str = "",
+    stored_at: str = "",
+) -> None:
+    """Surface successful token receipt + storage location."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "oauth_login_success",
+            provider=provider,
+            account_id=account_id,
+            email=email,
+            plan_type=plan_type,
+            stored_at=stored_at,
+        )
+        return
+    console.print()
+    console.print(f"  [success]✓ {provider} login successful[/success]")
+    if email or account_id:
+        console.print(f"  [muted]  Account:[/muted] {email or account_id}")
+    if plan_type:
+        console.print(f"  [muted]  Plan:[/muted] {plan_type}")
+    if stored_at:
+        console.print(f"  [muted]  Stored:[/muted] {stored_at}")
+    console.print()
+
+
+def emit_oauth_login_failed(provider: str, reason: str) -> None:
+    """Surface a failed/cancelled login flow."""
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "oauth_login_failed",
+            provider=provider,
+            reason=reason,
+        )
+        return
+    console.print()
+    console.print(f"  [error]✗ {provider} login failed:[/error] {reason}")
+    console.print()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Billing error event (v0.51.1 IPC parity)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def emit_billing_error(message: str) -> None:
+    """Surface a billing/credit error from the agentic loop.
+
+    Pre-v0.51.1 used a raw ``rich.console.Console`` print that bypassed
+    the thin-client renderer.
+    """
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event("billing_error", message=message)
+        return
+    console.print()
+    console.print(f"  [error]✗ Billing error[/error] — {message}")
+    console.print()
+
+
+# ───────────────────────────────────────────────────────────────────────────
 # Structured IPC event emitters — Pipeline milestones
 # ───────────────────────────────────────────────────────────────────────────
 

--- a/core/cli/ui/event_renderer.py
+++ b/core/cli/ui/event_renderer.py
@@ -379,6 +379,65 @@ class EventRenderer:
     def _handle_checkpoint_saved(self, event: dict[str, Any]) -> None:
         pass  # silent — no user-visible output needed
 
+    # -- OAuth device-code events (v0.51.1 IPC parity) ------------------------
+
+    def _handle_oauth_login_started(self, event: dict[str, Any]) -> None:
+        """Render the device-code prompt with URL + user code highlighted."""
+        self._suppress_all_spinners()
+        provider = str(event.get("provider", ""))
+        uri = str(event.get("verification_uri", ""))
+        code = str(event.get("user_code", ""))
+        self._out.write("\n")
+        self._out.write(f"  \033[1;36m{provider} OAuth Login\033[0m\n")
+        self._out.write("\n")
+        self._out.write("  1. Open this URL in your browser:\n")
+        self._out.write(f"     \033[94m{uri}\033[0m\n")
+        self._out.write("\n")
+        self._out.write("  2. Enter this code:\n")
+        self._out.write(f"     \033[1;93m{code}\033[0m\n")
+        self._out.write("\n")
+        self._out.write("  \033[2mWaiting for sign-in... (Ctrl+C to cancel)\033[0m\n")
+        self._out.flush()
+
+    def _handle_oauth_login_pending(self, event: dict[str, Any]) -> None:
+        """Heartbeat — overwrite a single 'Waiting…' line in place."""
+        elapsed = int(event.get("elapsed_s", 0))
+        self._out.write(f"\r  \033[2mWaiting... ({elapsed}s)\033[0m\033[K")
+        self._out.flush()
+
+    def _handle_oauth_login_success(self, event: dict[str, Any]) -> None:
+        provider = str(event.get("provider", ""))
+        email = str(event.get("email", ""))
+        account_id = str(event.get("account_id", ""))
+        plan_type = str(event.get("plan_type", ""))
+        stored_at = str(event.get("stored_at", ""))
+        # Wipe the heartbeat line, then announce success.
+        self._out.write("\r\033[2K\n")
+        self._out.write(f"  \033[1;32m✓ {provider} login successful\033[0m\n")
+        if email or account_id:
+            self._out.write(f"  \033[2m  Account:\033[0m {email or account_id}\n")
+        if plan_type:
+            self._out.write(f"  \033[2m  Plan:\033[0m {plan_type}\n")
+        if stored_at:
+            self._out.write(f"  \033[2m  Stored:\033[0m {stored_at}\n")
+        self._out.write("\n")
+        self._out.flush()
+
+    def _handle_oauth_login_failed(self, event: dict[str, Any]) -> None:
+        provider = str(event.get("provider", ""))
+        reason = str(event.get("reason", ""))
+        self._out.write("\r\033[2K\n")
+        self._out.write(f"  \033[1;31m✗ {provider} login failed:\033[0m {reason}\n\n")
+        self._out.flush()
+
+    # -- Billing error (v0.51.1 IPC parity) -----------------------------------
+
+    def _handle_billing_error(self, event: dict[str, Any]) -> None:
+        message = str(event.get("message", ""))
+        self._clear_activity_line()
+        self._out.write(f"\n  \033[1;31m✗ Billing error\033[0m — {message}\n\n")
+        self._out.flush()
+
     # -- Pipeline milestone events (client-side rendering) --------------------
 
     def _handle_pipeline_header(self, event: dict[str, Any]) -> None:

--- a/core/gateway/auth/oauth_login.py
+++ b/core/gateway/auth/oauth_login.py
@@ -218,13 +218,20 @@ def login_openai() -> dict[str, Any]:
     if not user_code or not device_auth_id:
         raise RuntimeError("Device code response missing required fields")
 
-    # Step 2: Show user the code
-    print("\n  OpenAI Codex OAuth Login\n")
-    print("  1. Open this URL in your browser:")
-    print(f"     \033[94m{_DEVICE_PAGE}\033[0m\n")
-    print("  2. Enter this code:")
-    print(f"     \033[1;93m{user_code}\033[0m\n")
-    print("  Waiting for sign-in... (press Ctrl+C to cancel)\n")
+    # Step 2: Surface the code to the user via IPC events (v0.51.1).
+    # The thin-client renderer translates these into an in-place rich prompt.
+    from core.cli.ui.agentic_ui import (
+        emit_oauth_login_failed,
+        emit_oauth_login_pending,
+        emit_oauth_login_started,
+    )
+
+    _PROVIDER_LABEL = "OpenAI Codex"
+    emit_oauth_login_started(
+        provider=_PROVIDER_LABEL,
+        verification_uri=_DEVICE_PAGE,
+        user_code=user_code,
+    )
 
     # Step 3: Poll for authorization
     start = time.monotonic()
@@ -244,14 +251,15 @@ def login_openai() -> dict[str, Any]:
                     break
                 if poll_resp.status_code in (403, 404):
                     elapsed = int(time.monotonic() - start)
-                    print(f"\r  Waiting... ({elapsed}s)", end="", flush=True)
+                    emit_oauth_login_pending(_PROVIDER_LABEL, elapsed)
                     continue
                 raise RuntimeError(f"Polling returned status {poll_resp.status_code}")
     except KeyboardInterrupt:
-        print("\n\n  Login cancelled.")
+        emit_oauth_login_failed(_PROVIDER_LABEL, "cancelled by user")
         return {}
 
     if code_resp is None:
+        emit_oauth_login_failed(_PROVIDER_LABEL, "timed out after 15 minutes")
         raise RuntimeError("Login timed out after 15 minutes")
 
     # Step 4: Exchange authorization code for tokens
@@ -320,16 +328,22 @@ def login_openai() -> dict[str, Any]:
         "source": "geode-device-code",
     }
 
-    # Save to ~/.geode/auth.json
+    # Save to ~/.geode/auth.toml (v0.50.2 SOT — _save_auth_store internally
+    # routes via auth_toml.save_auth_toml + plan registry).
     store = _load_auth_store()
     store.setdefault("providers", {})
     store["providers"]["openai"] = creds
     _save_auth_store(store)
 
-    print("\n  \033[92mLogin successful!\033[0m")
-    print(f"  Account: {email or account_id}")
-    print(f"  Plan: {plan_type or 'unknown'}")
-    print(f"  Stored: {AUTH_STORE_PATH}\n")
+    from core.cli.ui.agentic_ui import emit_oauth_login_success
+
+    emit_oauth_login_success(
+        provider=_PROVIDER_LABEL,
+        account_id=account_id,
+        email=email,
+        plan_type=plan_type or "unknown",
+        stored_at=str(AUTH_STORE_PATH),
+    )
 
     return creds
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.51.0"
+version = "0.51.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_ipc_output_parity.py
+++ b/tests/test_ipc_output_parity.py
@@ -1,0 +1,188 @@
+"""v0.51.1 — IPC output parity tests.
+
+Daemon-side flows that prompt the user (OAuth device-code, billing
+errors, /clear confirmation) must surface through the IPC event channel
+so thin-client REPLs see them. Pre-v0.51.1 these used native ``print()``
+or ``rich.console.Console()`` which only reached daemon stdout.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.cli.ui import agentic_ui
+from core.cli.ui.event_renderer import EventRenderer
+
+
+class _CapturingWriter:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def send_event(self, event_type: str, **payload: Any) -> None:
+        self.events.append({"type": event_type, **payload})
+
+
+def _swap_writer(writer: _CapturingWriter | None) -> _CapturingWriter | None:
+    prior = getattr(agentic_ui._ipc_writer_local, "writer", None)
+    if writer is None:
+        agentic_ui._ipc_writer_local.writer = None  # type: ignore[attr-defined]
+    else:
+        agentic_ui._ipc_writer_local.writer = writer  # type: ignore[attr-defined]
+    return prior
+
+
+class TestOAuthIpcEvents:
+    def test_started_event_includes_uri_and_code(self) -> None:
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            agentic_ui.emit_oauth_login_started(
+                provider="OpenAI Codex",
+                verification_uri="https://example.test/device",
+                user_code="ABCD-1234",
+            )
+        finally:
+            _swap_writer(prior)
+        assert w.events == [
+            {
+                "type": "oauth_login_started",
+                "provider": "OpenAI Codex",
+                "verification_uri": "https://example.test/device",
+                "user_code": "ABCD-1234",
+            }
+        ]
+
+    def test_pending_event_carries_elapsed_seconds(self) -> None:
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            agentic_ui.emit_oauth_login_pending("OpenAI Codex", 5)
+            agentic_ui.emit_oauth_login_pending("OpenAI Codex", 10)
+        finally:
+            _swap_writer(prior)
+        assert [e["elapsed_s"] for e in w.events] == [5, 10]
+
+    def test_success_event_includes_metadata(self) -> None:
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            agentic_ui.emit_oauth_login_success(
+                provider="OpenAI Codex",
+                account_id="acct-123",
+                email="user@example.test",
+                plan_type="plus",
+                stored_at="/var/folders/test/auth.toml",
+            )
+        finally:
+            _swap_writer(prior)
+        assert w.events[0]["type"] == "oauth_login_success"
+        assert w.events[0]["email"] == "user@example.test"
+        assert w.events[0]["plan_type"] == "plus"
+        assert w.events[0]["stored_at"] == "/var/folders/test/auth.toml"
+
+    def test_failed_event_carries_reason(self) -> None:
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            agentic_ui.emit_oauth_login_failed("OpenAI Codex", "cancelled by user")
+        finally:
+            _swap_writer(prior)
+        assert w.events == [
+            {
+                "type": "oauth_login_failed",
+                "provider": "OpenAI Codex",
+                "reason": "cancelled by user",
+            }
+        ]
+
+    def test_emitters_fall_back_to_console_in_direct_mode(self, capsys) -> None:
+        prior = _swap_writer(None)
+        try:
+            agentic_ui.emit_oauth_login_started(
+                "OpenAI Codex", "https://example.test/device", "XYZ-1"
+            )
+        finally:
+            _swap_writer(prior)
+        captured = capsys.readouterr()
+        # Rich strips ANSI when not attached to a terminal — the URL and
+        # code should appear in the captured output.
+        assert "OpenAI Codex" in captured.out
+        assert "https://example.test/device" in captured.out
+        assert "XYZ-1" in captured.out
+
+
+class TestBillingErrorEvent:
+    def test_billing_error_event_carries_message(self) -> None:
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            agentic_ui.emit_billing_error("Insufficient credits")
+        finally:
+            _swap_writer(prior)
+        assert w.events == [{"type": "billing_error", "message": "Insufficient credits"}]
+
+
+class TestRendererHandlersExist:
+    def test_oauth_event_handlers_dispatch(self) -> None:
+        # Prove EventRenderer routes the new event types to handlers.
+        renderer = EventRenderer()
+        for etype in (
+            "oauth_login_started",
+            "oauth_login_pending",
+            "oauth_login_success",
+            "oauth_login_failed",
+            "billing_error",
+        ):
+            assert hasattr(renderer, f"_handle_{etype}"), etype
+
+
+class TestClearForceGate:
+    def test_clear_in_ipc_mode_requires_force(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from core.cli.commands import cmd_clear
+
+        ctx = MagicMock()
+        ctx.messages = [{"role": "user", "content": "hi"}]
+        ctx.clear = MagicMock()
+
+        # Pretend we are in IPC mode by attaching a writer.
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            with (
+                patch("core.cli.commands.get_conversation_context", return_value=ctx),
+                patch("core.cli.commands.console") as mock_console,
+            ):
+                cmd_clear("")
+                # Should NOT have cleared messages in IPC mode without --force
+                ctx.clear.assert_not_called()
+                # Should have surfaced a refusal message
+                printed = " ".join(
+                    str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+                )
+                assert "--force" in printed
+        finally:
+            _swap_writer(prior)
+
+    def test_clear_force_flag_proceeds_in_ipc_mode(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from core.cli.commands import cmd_clear
+
+        ctx = MagicMock()
+        ctx.messages = [{"role": "user", "content": "hi"}]
+        ctx.clear = MagicMock()
+
+        w = _CapturingWriter()
+        prior = _swap_writer(w)
+        try:
+            with (
+                patch("core.cli.commands.get_conversation_context", return_value=ctx),
+                patch("core.cli.commands.console"),
+                patch("core.llm.token_tracker.reset_tracker"),
+            ):
+                cmd_clear("--force")
+                ctx.clear.assert_called_once()
+        finally:
+            _swap_writer(prior)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.50.2"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `/login oauth openai`이 IPC mode에서 verification URL/user code를 thin client에 표시 못 하던 버그 수정
- OAuth device-code flow를 4개 IPC event(`oauth_login_started/pending/success/failed`)로 전환
- 동일 패턴의 잠재 버그 2건 일괄 교정 (billing error, `/clear` 확인 프롬프트)

## Why
사용자가 직접 `/login oauth openai` 실행 시 daemon에서 device code(`1PUK-106C5`)를 발급받았지만 thin client REPL에는 아무 출력이 없어서 브라우저에 입력할 코드를 볼 수 없었습니다 (`oauth_login.py`가 native `print()` 사용 → daemon stdout(`/tmp/geode_serve.log`)에만 도달).

근본 원인 audit 결과 동일 패턴 3개 발견:
1. `oauth_login.py` 9개 `print()` (보고된 버그)
2. `agentic_loop.py:600, 722` `rich.console.Console()` 직접 인스턴스화 (billing error)
3. `commands.py:1781` `input()` for `/clear` (daemon stdin 블록)

## Changes
| File | Change |
|------|--------|
| `core/cli/ui/agentic_ui.py` | 5개 신규 emitter — `emit_oauth_login_started/pending/success/failed` + `emit_billing_error`. IPC writer 우선, 부재 시 console fallback. |
| `core/cli/ui/event_renderer.py` | 5개 `_handle_*` 핸들러. `pending`은 `\r`로 in-place "Waiting... (Ns)" 갱신. `success/failed`는 `\033[2K`로 heartbeat 줄 지움. |
| `core/cli/ipc_client.py` | `rtype` allowlist에 5개 신규 event 추가. `tests/test_ipc_event_parity.py`가 자동 검증. |
| `core/gateway/auth/oauth_login.py` | 9개 `print()` → 4개 `emit_oauth_login_*` 호출로 압축. KeyboardInterrupt/timeout 시 `emit_oauth_login_failed`. 헤더의 SOT 주석도 v0.50.2 정합 갱신. |
| `core/agent/agentic_loop.py` | `BillingError` catch 두 지점이 `emit_billing_error(str(exc))`로 전환 — `from rich.console import Console as _Con` import 제거. |
| `core/cli/commands.py:cmd_clear` | IPC mode 감지(`_ipc_writer_local.writer`) 시 `input()` 차단, `--force` 요구. 직접 mode는 기존 동작. |
| `tests/test_ipc_output_parity.py` (신설) | 9개 — emitter 4종 IPC 캡처, pending 누적, direct fallback, billing event, renderer dispatch, /clear gate 양 분기. |
| `CHANGELOG.md` `CLAUDE.md` `README.md` `README.ko.md` `pyproject.toml` | 0.51.0 → 0.51.1, tests 4065→4074 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| OAuth device-code IPC event 4종 | Implemented | started/pending/success/failed |
| event_renderer dispatch handler 4종 | Implemented | in-place heartbeat 포함 |
| ipc_client rtype allowlist 등록 | Implemented | event_parity test로 검증 |
| billing_error IPC event | Implemented | agentic_loop 양 지점 |
| /clear input() IPC mode 차단 | Implemented | --force 안내 |
| 신규 event 모두 fallback path | Implemented | direct mode capsys 검증 |

## Verification
- [x] ruff check + format clean
- [x] mypy strict clean (228 modules)
- [x] pytest **4074 passed** (1 skipped, 19 deselected) — +9 신설
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) unchanged
- [x] tests/test_ipc_event_parity.py 통과 — 신규 event 누락 시 자동 실패

## Reference
사용자 직접 보고 — `/login oauth openai` 실행 후 "여기에 나오지 않아"
Audit 키워드: native print() / input() / rich.console.Console() in daemon paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)