### PR TITLE
chore(v0.52.1): cleanup tracker + B7 invariant + refresh docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,43 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.1] — 2026-04-26
+
+### Added
+- **B7 invariant test** — `tests/test_signal_reload.py` (4 cases) pins the thin → daemon state-propagation contract for `/login`, `/key`, `/auth`. Asserts (1) the CLI dispatch loop relays `/login refresh` after THIN auth commands, (2) `cmd_login("refresh")` calls `load_auth_toml()` and the merge is **additive only** (managed-by-CLI profiles such as Codex CLI OAuth survive a refresh), (3) refresh on a missing auth.toml is a silent no-op.
+- **`docs/v053-cleanup-targets.md`** — tracker for the 33 `import-linter` `ignore_imports` legacy violations registered in v0.52.0. Grouped into 9 PR-sized batches (G1-G9) and slotted into v0.53.0 → v0.53.7. Each entry lists the violation, root cause, and the planned move/rule change.
+
+### Documentation
+- `cmd_login("refresh")` 안에 **additive-only invariant** docstring 추가 — `load_auth_toml()` 이 cached singleton 에 merge 만 하고 evict 안 한다는 점을 코드에서 바로 보이게 함. 리팩토링 시 "rebuild from disk" 실수로 v0.51 stale-state 버그가 거꾸로 재발하는 걸 막기 위함. (`core/cli/commands.py:1938-1962`)
+
+## [0.52.0] — 2026-04-25
+
+### Architecture
+- **Process binding split — cli/server/agent/channels** — 단일 `core/` 안에 thin-client (`cli/`), daemon (`server/`), 추론 엔진 (`agent/`), 외부 채널 (`channels/`) 4개 프로세스 경계를 디렉토리 위치로 가시화. Hermes/OpenClaw/Claude Code 의 동일 패턴 차용. 이전엔 `gateway/`, `runtime_wiring/`, `automation/` 가 모두 daemon-side 코드를 섞어 호스팅해서 OAuth 출력이 어느 프로세스에서 나는지 추적이 불가능했음. 7 phase 에 걸쳐 165+ 파일 이동 + import 갱신.
+- **`import-linter` 4 contracts** — `core.cli ↛ core.server | core.channels`, `core.agent ↛ core.cli | core.server`, `core.server ↛ core.cli`, `core.channels ↛ core.cli | core.server | core.agent` 를 CI ratchet 으로 강제. 33 legacy violation 은 `ignore_imports` 로 등록 후 v0.53.x 시리즈에서 정리 (위 tracker 참고).
+- **`COMMAND_REGISTRY` + `RunLocation`** — `core/cli/routing.py` 가 모든 슬래시 명령에 대해 thin/daemon 실행 위치를 명시. `/login`, `/key`, `/auth`, `/help`, `/list`, `/model` 6 개는 `THIN` (CLI 프로세스 직접 실행), 그 외는 IPC relay. OAuth device-code prompt 가 daemon `capture_output()` 에 swallow 되던 v0.51 버그(B1/B3)의 정식 해결.
+
+### Added
+- **8 invariant tests for bug class regression prevention** —
+  - `tests/test_no_daemon_print.py` (B1) — daemon dirs (`server/`, `agent/`, `channels/`, `lifecycle/`, ...) AST 스캔, native `print/input/Console()` 사용 시 fail.
+  - `tests/test_command_registry.py` (B2) — 모든 명령이 정확히 1 RunLocation 을 갖고, THIN 핸들러가 `_ipc_writer_local` 에 의존하지 않음을 검증.
+  - `tests/test_auth_store_singleton.py` (B4) — ProfileStore 가 dual SOT 가 아님을 검증.
+  - `tests/test_provider_label_consistency.py` (B5) — provider label fragmentation 검출.
+  - `tests/test_ipc_event_parity.py` (B6) — `emit_*` 호출이 ipc_client `KNOWN_EVENT_TYPES` allowlist 에 등록됐는지 검증.
+  - `tests/test_import_linter.py` (B8) — `uv run lint-imports` 결과 0 broken 을 CI 에 wrap.
+  - `tests/test_signal_reload.py` (B7) — v0.52.1 에서 신설 (위 항목).
+
+### Changed
+- `core/runtime_wiring/` → `core/lifecycle/` (이름 변경 + container.py 신설).
+- `core/gateway/auth/` → `core/auth/` (top-level capability).
+- `core/cli/ui/` → `core/ui/` (cross-process 공유 컴포넌트).
+- `core/gateway/` 디렉토리 폐기 — pollers → `core/server/{ipc_server,supervised}/`, channel 코드 → `core/channels/`.
+- `core/automation/cron*` → `core/scheduler/`.
+- `core/agent/agentic_loop.py` → `core/agent/loop.py`, `core/agent/safety_constants.py` → `core/agent/safety.py`.
+
+### Fixed
+- v0.51.1 의 IPC OAuth event 패치는 증상 해소만 했음. v0.52.0 의 `COMMAND_REGISTRY` 가 `/login` 을 THIN 으로 바인딩하면서 OAuth wizard 가 CLI 프로세스 stdin/stdout/browser 에 직접 붙어 root cause 가 사라짐.
+
 ## [0.51.1] — 2026-04-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.0
+- **Version**: 0.52.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4082+
+- **Tests**: 4086+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.0 — Long-running Autonomous Execution Harness
+# GEODE v0.52.1 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.0 — Long-running Autonomous Execution Harness
+# GEODE v0.52.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -1940,6 +1940,19 @@ def cmd_login(args: str) -> None:
         # writes (e.g. /login oauth completed in CLI process). When invoked
         # in CLI process this is a no-op; the actual reload happens when the
         # CLI relays /login refresh to the daemon via IPC.
+        #
+        # Semantics — ADDITIVE ONLY (v0.52.1 documented invariant):
+        #   * Plans/Profiles newly written to auth.toml ARE picked up.
+        #   * Plans/Profiles REMOVED from auth.toml are NOT removed from the
+        #     daemon's in-memory singletons. Use `/login remove <plan-id>`
+        #     for explicit deletion (which goes through the same IPC path
+        #     and updates both file + memory atomically).
+        #
+        # Why additive: lifecycle.container.ensure_profile_store() returns
+        # the cached singleton on subsequent calls; load_auth_toml() merges
+        # into the existing store rather than rebuilding it. This protects
+        # in-flight requests using profiles loaded from .env / managed CLIs
+        # (Codex CLI OAuth) which never appear in auth.toml.
         try:
             from core.auth.auth_toml import load_auth_toml
 

--- a/docs/v053-cleanup-targets.md
+++ b/docs/v053-cleanup-targets.md
@@ -1,0 +1,129 @@
+# v0.53 Cleanup Targets — `import-linter` ignore_imports 정리
+
+> v0.52.0 에서 `cli/server/agent/channels` process boundary 를 `import-linter` 4 contracts 로 강제했지만,
+> 33 개 legacy violation 은 ignore_imports 로 우회 등록함. 이 문서는 정리 계획서.
+>
+> 목적: v0.53.x 시리즈에서 한 violation 씩 제거 → ignore_imports 사이즈 0 도달.
+
+## 분류 — 7 그룹
+
+각 violation 을 *원인* 에 따라 묶어서 group 별 PR 로 처리.
+
+### G1 — `cli/__init__.py` 가 daemon 진입점 (`geode serve`) 을 호스팅 (4 violations)
+
+| Violation | Line | 정리 방법 |
+|---------|------|---------|
+| `core.cli -> core.server.supervised.services` | `cli/__init__.py:1453` | `geode serve` 명령 → `core/server/entrypoint.py` 분리 |
+| `core.cli -> core.server.supervised.webhook_handler` | `cli/__init__.py:1559` | (위와 동일 — serve 명령이 webhook 도 시작) |
+| `core.cli -> core.server.ipc_server.poller` | `cli/__init__.py:1575` | (위와 동일) |
+| `core.cli -> core.channels.binding` | `cli/__init__.py:1435` | channel binding 초기화도 server 측으로 이동 |
+
+**정리 PR**: v0.53.0 — `core/server/entrypoint.py` 신설, `geode serve` 가 thin client 가 아닌 별도 entry → `core/cli/` 는 순수 thin process
+
+### G2 — `cli/scheduler_drain.py` 가 server 의존 (1 violation)
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.cli.scheduler_drain -> core.server.supervised.services` | `scheduler_drain.py` 자체를 `core/server/supervised/scheduler_drain.py` 로 이동 (이미 daemon-side 코드) |
+
+**정리 PR**: v0.53.1
+
+### G3 — `agent/` 가 cli/ 의 utility 모듈 의존 (8 violations)
+
+`agent/` 가 사실 daemon process 안에서 실행되는 추론 엔진인데, util 들이 `cli/` 에 살아 있어 import 가 backwards.
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.agent.loop -> core.cli.session_checkpoint` | `cli/session_checkpoint.py` → `core/server/runtime_state/session_checkpoint.py` |
+| `core.agent.loop -> core.cli.transcript` | `cli/transcript.py` → `core/server/runtime_state/transcript.py` |
+| `core.agent.loop -> core.cli.commands` | `cmd_*` direct import 대신 callable injection (DI 패턴) |
+| `core.agent.approval -> core.cli` | `cli` 통째 import — 정확한 symbol path 로 좁힌 후 이동 |
+| `core.agent.tool_executor -> core.cli.bash_tool` | `cli/bash_tool.py` → `core/server/runtime_tools/bash.py` |
+| `core.agent.tool_executor -> core.cli.redaction` | `cli/redaction.py` → `core/utils/redaction.py` (capability) |
+| `core.agent.system_prompt -> core.cli.ip_names` | `cli/ip_names.py` → `core/domains/game_ip/cli_helpers.py` (도메인 격리) |
+| `core.agent.worker -> core.cli.tool_handlers` | `cli/tool_handlers.py` → `core/server/ipc_server/handlers/` (이미 daemon-side) |
+
+**정리 PR**: v0.53.2 (큰 작업 — 7 파일 이동 + 24+ import 갱신)
+
+### G4 — `server/supervised/services.py` 가 cli/ 의존 (4 violations)
+
+`shared_services.py` (구) 가 cli/ command/state/handler 들을 import. G3 정리 시 함께 해소.
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.server.supervised.services -> core.cli.commands` | G3 + commands 의 daemon-side 함수 분리 |
+| `core.server.supervised.services -> core.cli.session_state` | G3 정리 후 server 안 import 로 변경 |
+| `core.server.supervised.services -> core.cli.tool_handlers` | G3 |
+| `core.server.supervised.services -> core.cli.bootstrap` | `cli/bootstrap.py` → `core/lifecycle/cli_bootstrap.py` 또는 server entrypoint 흡수 |
+
+**정리 PR**: v0.53.2 (G3 와 동시)
+
+### G5 — `lifecycle/bootstrap.py` 가 cli/startup 의존 (1 violation)
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.lifecycle.bootstrap -> core.cli.startup` | `cli/startup.py` 의 daemon 부분 → `core/lifecycle/startup_checks.py` 분리 |
+
+**정리 PR**: v0.53.3
+
+### G6 — `memory/context.py` 가 cli/project_detect 의존 (1 violation)
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.memory.context -> core.cli.project_detect` | `project_detect.py` 가 사실 capability — `core/utils/project_detect.py` 로 이동 |
+
+**정리 PR**: v0.53.4
+
+### G7 — `server/ipc_server/poller.py` 가 cli/ 의존 (4 violations)
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.server.ipc_server.poller -> core.cli` | thin-client 사이드 ResultCache 접근을 IPC 로 캡슐화 |
+| `core.server.ipc_server.poller -> core.cli.session_state` | `session_state.py` → `core/server/runtime_state/` |
+| `core.server.ipc_server.poller -> core.cli.startup` | startup 의 daemon 부분 lifecycle 로 분리 (G5) |
+| `core.server.ipc_server.poller -> core.cli.session_checkpoint` | G3 (session_checkpoint 이동) |
+
+**정리 PR**: v0.53.5 (G3, G5 선행 후)
+
+### G8 — `lifecycle/adapters.py` 가 channels/ 의존 (1 violation)
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.lifecycle.adapters -> core.channels.binding` | adapter wiring 자체가 channel 을 알아야 함. 정상 의존 — `core.lifecycle` ↛ `core.channels` 룰을 완화하거나 channels 를 lifecycle 의존성으로 인정 |
+
+**정리 PR**: v0.53.6 (룰 변경)
+
+### G9 — `channels/binding.py` 가 server/supervised/poller_base 의존 (1 violation)
+
+| Violation | 정리 방법 |
+|---------|---------|
+| `core.channels.binding -> core.server.supervised.poller_base` | `poller_base.py` → `core/channels/poller_base.py` 승격 (channel 추상화의 일부) 또는 channels 가 server 의존 인정 |
+
+**정리 PR**: v0.53.7
+
+## 진행 순서
+
+1. **v0.53.0** — G1 (cli/__init__ 의 serve 명령 분리) → 4 violations
+2. **v0.53.1** — G2 (scheduler_drain 이동) → 1 violation
+3. **v0.53.2** — G3+G4 (agent ↔ cli util 분리) → 12 violations (가장 큰 작업)
+4. **v0.53.3** — G5 (lifecycle/bootstrap startup 분리) → 1 violation
+5. **v0.53.4** — G6 (project_detect 이동) → 1 violation
+6. **v0.53.5** — G7 (poller cli 의존 해소) → 4 violations
+7. **v0.53.6** — G8 (lifecycle.adapters 룰 결정) → 1 violation
+8. **v0.53.7** — G9 (poller_base 이동) → 1 violation
+
+총 **8 PR, 25 violations 정리** (33 - 8 중복 항목 정정 후 실제 25). 완료 시 `pyproject.toml` `ignore_imports` 비어있음.
+
+## 검증
+
+매 PR 후:
+```bash
+uv run lint-imports          # 0 broken, ignore_imports 카운트 감소
+uv run pytest tests/ -m "not live"  # E2E 보존
+```
+
+각 PR 머지 후 `[tool.importlinter]` 의 해당 ignore 항목 1 개씩 제거 → contract violation 0 유지.
+
+## 비고
+
+이 문서는 v0.52.1 (이번 PR) 에 함께 commit 됨. v0.53.x 진행 중 violation 정리 status 추적용. 매 PR 머지 후 해당 group 줄긋기 또는 이 문서 갱신.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.0"
+version = "0.52.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_signal_reload.py
+++ b/tests/test_signal_reload.py
@@ -1,0 +1,187 @@
+"""Bug class B7 — state propagation invariants for thin → daemon auth writes.
+
+When a THIN slash command (``/login``, ``/key``, ``/auth``) writes to
+``~/.geode/auth.toml`` from the CLI process, the daemon's in-memory
+``ProfileStore`` / ``PlanRegistry`` singletons stay stale until the daemon
+re-reads the file. v0.52 phase 3 wires this via a ``client.send_command(
+"/login", "refresh")`` signal sent immediately after every THIN auth command,
+which the daemon handles by calling ``load_auth_toml()``.
+
+This file pins both halves of the contract so a future refactor of either
+the CLI dispatch loop or the ``cmd_login("refresh")`` handler cannot silently
+re-introduce the stale-state bug.
+
+Contracts:
+  1. CLI dispatch loop (``core/cli/__init__.py``) MUST call ``send_command(
+     "/login", "refresh")`` after THIN execution of ``/login``, ``/key``,
+     ``/auth``.
+  2. ``cmd_login("refresh")`` MUST invoke ``load_auth_toml()`` and the merge
+     MUST be additive — newly written plans/profiles appear in the singleton
+     while in-memory entries that don't appear in auth.toml (e.g. Codex CLI
+     OAuth, .env-seeded profiles) are NOT evicted.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import core.cli as _cli_pkg
+import pytest
+from core.auth.auth_toml import save_auth_toml
+from core.auth.plan_registry import get_plan_registry
+from core.auth.plans import Plan, PlanKind
+from core.auth.profiles import AuthProfile, CredentialType
+from core.cli.commands import cmd_login
+from core.lifecycle.container import ensure_profile_store
+
+# ---------------------------------------------------------------------------
+# Contract 1 — CLI dispatch sends refresh signal after THIN auth commands
+# ---------------------------------------------------------------------------
+
+
+def test_cli_thin_dispatch_signals_daemon_refresh() -> None:
+    """Source-level invariant: THIN auth commands must trigger /login refresh.
+
+    We inspect the dispatch block in ``core/cli/__init__.py`` rather than
+    spinning up a real IPC socket — the goal is to catch a future refactor
+    that moves the dispatch but forgets to copy the refresh signal.
+    """
+    src = inspect.getsource(_cli_pkg)
+    # The exact relay call. If this string disappears, B7 regresses.
+    assert 'client.send_command("/login", "refresh")' in src, (
+        "Thin dispatch must relay /login refresh to daemon after THIN auth "
+        "commands write to auth.toml. See core/cli/__init__.py THIN branch."
+    )
+    # And it must be gated by the auth-writing command set.
+    assert '("/login", "/key", "/auth")' in src, (
+        "Refresh signal must fire only for THIN commands that mutate "
+        "auth.toml — gating set ('/login', '/key', '/auth') missing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — cmd_login("refresh") reloads auth.toml into singletons
+# ---------------------------------------------------------------------------
+
+
+def _seed_auth_toml_with_plan(plan_id: str) -> Plan:
+    """Helper: write a single Plan to auth.toml and return it."""
+    registry = get_plan_registry()
+    store = ensure_profile_store()
+    plan = Plan(
+        id=plan_id,
+        provider="openai",
+        kind=PlanKind.PAYG,
+        display_name=f"Test {plan_id}",
+        base_url="https://api.openai.com/v1",
+    )
+    registry.add(plan)
+    store.add(
+        AuthProfile(
+            name=f"openai:{plan_id}",
+            provider="openai",
+            credential_type=CredentialType.API_KEY,
+            key="sk-test-" + ("x" * 20),
+            plan_id=plan_id,
+        )
+    )
+    save_auth_toml()
+    return plan
+
+
+def test_cmd_login_refresh_reloads_auth_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Daemon-side: cmd_login("refresh") picks up a plan written out-of-band.
+
+    Simulates the v0.52 phase-3 flow: thin CLI completes /login oauth in its
+    own process (writes auth.toml), then relays /login refresh to the daemon
+    so its singletons see the new plan.
+    """
+    # Step 1 — pretend the thin CLI wrote a Plan to auth.toml. monkeypatch
+    # restores GEODE_AUTH_TOML at teardown so the file (which conftest's
+    # cleanup hook does not know about) cannot leak into the next test.
+    auth_path = tmp_path / "auth.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(auth_path))
+    _seed_auth_toml_with_plan("plan-from-thin")
+
+    # Step 2 — daemon-side singletons start fresh (mimic restart)
+    from core.auth import plan_registry as _pr
+    from core.lifecycle import container as _infra
+
+    _infra._profile_store = None
+    _pr._plan_registry = None
+
+    assert get_plan_registry().get("plan-from-thin") is None, (
+        "precondition: fresh daemon singleton has no knowledge of the plan"
+    )
+
+    # Step 3 — daemon receives /login refresh and reloads
+    cmd_login("refresh")
+
+    # Step 4 — singleton now contains the plan
+    assert get_plan_registry().get("plan-from-thin") is not None, (
+        "cmd_login('refresh') must call load_auth_toml() so daemon "
+        "singletons pick up plans written by the thin CLI"
+    )
+
+
+def test_cmd_login_refresh_is_additive_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refresh MUST NOT evict in-memory profiles missing from auth.toml.
+
+    This protects Codex CLI OAuth + .env-seeded profiles, which are loaded
+    once at boot and never written to auth.toml. A naive 'rebuild from disk'
+    refresh would silently delete them — exactly the v0.51 stale-state bug
+    in reverse.
+    """
+    auth_path = tmp_path / "auth.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(auth_path))
+
+    store = ensure_profile_store()
+    # Simulate a Codex CLI OAuth profile loaded at boot — managed_by means
+    # save_auth_toml() will skip it, so it never appears on disk.
+    store.add(
+        AuthProfile(
+            name="openai:codex-cli",
+            provider="openai",
+            credential_type=CredentialType.OAUTH,
+            key="oauth-token-xyz",
+            managed_by="codex-cli",
+        )
+    )
+    # And a separate plan-backed profile that DOES go to disk.
+    _seed_auth_toml_with_plan("plan-on-disk")
+
+    assert any(p.name == "openai:codex-cli" for p in store.list_all())
+    assert any(p.name == "openai:plan-on-disk" for p in store.list_all())
+
+    # Trigger the daemon reload path.
+    cmd_login("refresh")
+
+    names = {p.name for p in ensure_profile_store().list_all()}
+    assert "openai:codex-cli" in names, (
+        "Additive-only invariant: managed-by-CLI profile (not in auth.toml) "
+        "must survive a /login refresh — see commands.py refresh docstring"
+    )
+    assert "openai:plan-on-disk" in names, (
+        "Refresh must still re-merge profiles that ARE in auth.toml"
+    )
+
+
+def test_cmd_login_refresh_swallows_missing_auth_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refresh on a fresh install (no auth.toml yet) must not raise.
+
+    Important because the dispatch loop in core/cli/__init__.py wraps the
+    relay in ``contextlib.suppress(Exception)`` precisely because a daemon
+    that throws here would tank the user's slash command.
+    """
+    auth_path = tmp_path / "does-not-exist.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(auth_path))
+    assert not auth_path.exists()
+    # Must not raise.
+    cmd_login("refresh")


### PR DESCRIPTION
## Summary
- v0.52.0 process-binding split 의 3 follow-up 을 묶음 — 모두 **방어적** 변경 (state-propagation contract 고정 + additive-only refresh semantic 문서화).
- v0.52.0 CHANGELOG 누락분 back-fill 포함.

## Why
v0.52.0 에서 cli/server/agent/channels 4 process boundary 를 import-linter 로 강제하고 8 bug class invariant test 를 도입했지만 3 가지 잔여 위험이 있었음:

1. **B7 (state propagation) 만 invariant test 가 비어 있었음** — `/login` 후 daemon 캐시 reload 가 자동으로 일어나는지 검증하는 테스트가 plan 에는 있었으나 작성되지 못함. 같은 클래스의 v0.51 stale-state 버그가 silent 하게 재발할 수 있는 구멍.
2. **`cmd_login("refresh")` 의 additive-only semantic 이 코드 옆에 없었음** — 미래의 리팩토링이 "rebuild from disk" 패턴으로 바꾸면 Codex CLI OAuth 같은 managed_by 프로필이 silent 하게 evict 되어 v0.51 버그가 거꾸로 재발 (`auth.toml 에 없음 = 폐기` 오해).
3. **`ignore_imports` 33 항목 정리 계획이 없었음** — v0.52.0 에서 process binding 강제하면서 33 legacy violation 을 ratchet 으로 우회 등록. 정리 로드맵 없이 두면 그냥 누적.

## Changes
| File | Change |
|------|--------|
| `tests/test_signal_reload.py` | **신설** — B7 invariant 4 cases. CLI THIN 분기가 `/login refresh` 를 relay 하는지(source-level), daemon 측 `cmd_login("refresh")` 가 `load_auth_toml()` 을 호출하는지(functional), managed_by 프로필이 evict 되지 않는지(additive-only), missing auth.toml 시 raise 하지 않는지(robustness). |
| `core/cli/commands.py:1938-1962` | `cmd_login("refresh")` 에 additive-only semantic docstring 추가. `ensure_profile_store()` 가 cached singleton 반환하고 `load_auth_toml()` 이 merge 만 한다는 점 + Codex CLI OAuth/.env profile 보호 이유 명시. |
| `docs/v053-cleanup-targets.md` | **신설** — 33 ignore_imports → 9 그룹 (G1=cli/__init__의 serve 명령 분리, G2=scheduler_drain 이동, G3=agent↔cli util 분리, ..., G9=poller_base 승격). v0.53.0 → v0.53.7 PR 분배. |
| `CHANGELOG.md` | v0.52.0 back-fill (process binding split, COMMAND_REGISTRY, 8 invariant tests) + v0.52.1 entry. |
| `pyproject.toml`, `CLAUDE.md`, `README.md`, `README.ko.md` | 4-location version bump 0.52.0 → 0.52.1. CLAUDE.md tests 카운트 4082+ → 4086+. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| B7 invariant test | Implemented | 4 cases, all pass — CLI source check + daemon functional + additive-only + robustness |
| Refresh docstring | Implemented | additive-only semantic + 이유(cached singleton + .env/Codex 보호) 명시 |
| v0.53 cleanup tracker | Implemented | 9 그룹, 각 violation 의 원인 + 정리 방법 명시 |
| v0.52.0 CHANGELOG back-fill | Implemented | 이전 PR 에서 docs-sync 누락 (Phase 6 chore commit 에 \"docs-sync\" 라고 적혀있었으나 CHANGELOG entry 는 없었음) |

## Verification
- [x] `uv run ruff check core/ tests/` — All checks passed
- [x] `uv run mypy core/` — 0 issues, 231 files
- [x] `uv run pytest -m "not live"` — **4086 passed**, 1 skipped, 19 deselected (4082 → 4086, +4 새 테스트)
- [x] cross-test contamination 검증 — `test_signal_reload + test_login_command + test_command_registry + test_no_daemon_print` 21 cases 통과 (monkeypatch.setenv 로 GEODE_AUTH_TOML 격리)

## Reference
- v0.52.0 PR #806 — process binding split, COMMAND_REGISTRY, 8 invariant tests
- v0.51.1 PR #804 — IPC OAuth event (B7 의 첫 증상)