### PR TITLE
release(v0.52.2): reasoning metrics correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.2] — 2026-04-26
+
+### Fixed
+- **REASONING_METRICS audit logger silently emitted blank rows** — the audit-logger keys list (`["rounds", "tool_call_count"]`) never matched `ReasoningMetrics.to_dict()` field names (`total_rounds`, `tool_calls_total`), so every reasoning_metrics audit log line rendered with empty `%s` substitutions. Realigned the keys list and added a contract test in `tests/test_reasoning_metrics.py` that asserts both ends agree. (`core/lifecycle/bootstrap.py:448`)
+- **`_total_empty_rounds` quadratic inflation** — every overthinking round added the running consecutive-counter (`+= self._consecutive_text_only_rounds`), so 3 flagged rounds reported as `2+3+4=9`. Now increments by 1 per flagged round, matching the metric's documented meaning. (`core/agent/loop.py:1046`)
+- **`min(adaptive_thinking, adaptive_thinking // 2)` no-op** — collapsed to `max(0, adaptive_thinking // 2)`, which is what the comment ("reduce budget") actually implies. Adds a 0 floor in case the legacy budget ever goes negative. (`core/agent/loop.py:1395`)
+- **`cost_per_tool_call` zero-tool-call ambiguity** — sessions with zero tool calls reported `0.0`, indistinguishable from "very cheap per tool call." Now `None`, and omitted from `to_dict()` so downstream alerting can detect "not measured" cleanly. (`core/agent/reasoning_metrics.py:35-50`)
+
+### Removed
+- **Dead `_total_thinking_tokens` instance variable** — initialized to 0 and never mutated; `_build_reasoning_metrics` always added 0 to the tracker value. Removed both. (`core/agent/loop.py:209,413`)
+
+### Documentation
+- **`reasoning_metrics.py` module docstring** — clarified that `thinking_ratio` is `thinking / output` (input excluded), a GEODE variant rather than the layer-wise JSD ratio from the original DTR paper. Prevents future contributors from inferring paper-equivalent semantics.
+
 ## [0.52.1] — 2026-04-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.1
+- **Version**: 0.52.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.1 — Long-running Autonomous Execution Harness
+# GEODE v0.52.2 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.1 — Long-running Autonomous Execution Harness
+# GEODE v0.52.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/loop.py
+++ b/core/agent/loop.py
@@ -206,7 +206,6 @@ class AgenticLoop:
         self._time_budget_s = time_budget_s
         # Adaptive compute: track consecutive text-only rounds for overthinking detection
         self._consecutive_text_only_rounds = 0
-        self._total_thinking_tokens = 0
         self._total_empty_rounds = 0
         self._cost_budget = cost_budget
         self._loop_start_time: float = 0.0
@@ -411,7 +410,7 @@ class AgenticLoop:
 
         metrics = ReasoningMetrics(
             total_rounds=result.rounds,
-            thinking_tokens=self._total_thinking_tokens + thinking_tok,
+            thinking_tokens=thinking_tok,
             output_tokens=output_tok,
             tool_calls_total=len(result.tool_calls),
             empty_rounds=self._total_empty_rounds,
@@ -1044,7 +1043,10 @@ class AgenticLoop:
                 else:
                     self._consecutive_text_only_rounds = 0
                 if self._consecutive_text_only_rounds >= 2:
-                    self._total_empty_rounds += self._consecutive_text_only_rounds
+                    # Count this round once (the running consec is reported in the warning).
+                    # Previous code added the running counter every round, inflating the total
+                    # quadratically (consec=2,3,4 → +2+3+4=9 instead of 3 actual flagged rounds).
+                    self._total_empty_rounds += 1
                     log.warning(
                         "Overthinking detected: %d consecutive text-only rounds (>2000 tok each)",
                         self._consecutive_text_only_rounds,
@@ -1392,7 +1394,7 @@ class AgenticLoop:
             # Overthinking: reduce budget — curb verbose non-actionable output
             # Context-proportional: 2% of window, floor 8192
             adaptive_max_tokens = max(8192, min(self.max_tokens, ctx_window // 50))
-            adaptive_thinking = min(adaptive_thinking, adaptive_thinking // 2)
+            adaptive_thinking = max(0, adaptive_thinking // 2)
             # Downgrade effort by one level
             idx = _EFFORT_LEVELS.index(adaptive_effort) if adaptive_effort in _EFFORT_LEVELS else 2
             adaptive_effort = _EFFORT_LEVELS[max(0, idx - 1)]

--- a/core/agent/reasoning_metrics.py
+++ b/core/agent/reasoning_metrics.py
@@ -1,12 +1,15 @@
 """Reasoning efficiency metrics — DTR-inspired observability.
 
 Tracks per-session reasoning quality signals:
-- Thinking token ratio (thinking / total output)
-- Empty rounds (text-only, no tool calls)
+- Thinking token ratio (thinking / output, input excluded — GEODE variant,
+  not the layer-wise JSD ratio from the original DTR paper)
+- Empty rounds (text-only rounds flagged as overthinking, counted once each)
 - Overthinking detection
-- Cost per tool call
+- Cost per tool call (None when no tool was called)
 
-Reference: "Think Deep, Not Just Long" (arXiv 2602.13517)
+Inspired by "Think Deep, Not Just Long" (arXiv 2602.13517) — depth-aware
+budgeting. The metric definitions here diverge from the paper; see field
+docstrings for exact semantics.
 """
 
 from __future__ import annotations
@@ -25,7 +28,7 @@ class ReasoningMetrics:
     tool_calls_total: int = 0
     empty_rounds: int = 0
     cost_usd: float = 0.0
-    cost_per_tool_call: float = 0.0
+    cost_per_tool_call: float | None = None
     overthinking_detected: bool = False
 
     def compute_derived(self) -> None:
@@ -33,11 +36,11 @@ class ReasoningMetrics:
         total = self.thinking_tokens + self.output_tokens
         self.thinking_ratio = self.thinking_tokens / total if total > 0 else 0.0
         self.cost_per_tool_call = (
-            self.cost_usd / self.tool_calls_total if self.tool_calls_total > 0 else 0.0
+            self.cost_usd / self.tool_calls_total if self.tool_calls_total > 0 else None
         )
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        d: dict[str, object] = {
             "total_rounds": self.total_rounds,
             "thinking_tokens": self.thinking_tokens,
             "output_tokens": self.output_tokens,
@@ -45,6 +48,8 @@ class ReasoningMetrics:
             "tool_calls_total": self.tool_calls_total,
             "empty_rounds": self.empty_rounds,
             "cost_usd": round(self.cost_usd, 6),
-            "cost_per_tool_call": round(self.cost_per_tool_call, 6),
             "overthinking_detected": self.overthinking_detected,
         }
+        if self.cost_per_tool_call is not None:
+            d["cost_per_tool_call"] = round(self.cost_per_tool_call, 6)
+        return d

--- a/core/lifecycle/bootstrap.py
+++ b/core/lifecycle/bootstrap.py
@@ -445,7 +445,7 @@ def build_hooks(
             _E.REASONING_METRICS,
             "reasoning_metrics",
             "Reasoning: %s rounds, %s tools",
-            ["rounds", "tool_call_count"],
+            ["total_rounds", "tool_calls_total"],
         ),
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.1"
+version = "0.52.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_reasoning_metrics.py
+++ b/tests/test_reasoning_metrics.py
@@ -1,0 +1,68 @@
+"""Unit tests for ReasoningMetrics + audit-logger key contract."""
+
+from __future__ import annotations
+
+from core.agent.reasoning_metrics import ReasoningMetrics
+
+
+class TestReasoningMetrics:
+    def test_thinking_ratio_normal(self) -> None:
+        m = ReasoningMetrics(thinking_tokens=300, output_tokens=700)
+        m.compute_derived()
+        assert m.thinking_ratio == 0.3
+
+    def test_thinking_ratio_zero_total(self) -> None:
+        m = ReasoningMetrics(thinking_tokens=0, output_tokens=0)
+        m.compute_derived()
+        assert m.thinking_ratio == 0.0
+
+    def test_cost_per_tool_call_with_tools(self) -> None:
+        m = ReasoningMetrics(cost_usd=0.50, tool_calls_total=4)
+        m.compute_derived()
+        assert m.cost_per_tool_call == 0.125
+
+    def test_cost_per_tool_call_no_tools_is_none(self) -> None:
+        """Sentinel: 0 tool calls → None (distinguishes from 'very cheap per call')."""
+        m = ReasoningMetrics(cost_usd=1.00, tool_calls_total=0)
+        m.compute_derived()
+        assert m.cost_per_tool_call is None
+
+    def test_to_dict_omits_cost_per_tool_when_none(self) -> None:
+        m = ReasoningMetrics(cost_usd=1.00, tool_calls_total=0)
+        m.compute_derived()
+        d = m.to_dict()
+        assert "cost_per_tool_call" not in d
+
+    def test_to_dict_includes_cost_per_tool_when_set(self) -> None:
+        m = ReasoningMetrics(cost_usd=0.50, tool_calls_total=2)
+        m.compute_derived()
+        d = m.to_dict()
+        assert d["cost_per_tool_call"] == 0.25
+
+
+class TestAuditLoggerKeyContract:
+    """Lock the bootstrap REASONING_METRICS audit-logger keys to to_dict() schema.
+
+    Drift between the two would silently empty the audit log (logs render '').
+    """
+
+    def test_audit_logger_keys_present_in_to_dict(self) -> None:
+        import inspect
+
+        from core.lifecycle import bootstrap
+
+        # Pull the audit-logger spec table by source inspection — the table
+        # is defined inside _register_default_plugins as a local list, so we
+        # don't have a clean module-level handle to it.
+        src = inspect.getsource(bootstrap)
+        # Confirm the keys list now matches ReasoningMetrics.to_dict().
+        assert '["total_rounds", "tool_calls_total"]' in src, (
+            "REASONING_METRICS audit logger keys must match ReasoningMetrics.to_dict() field names. "
+            "See core/agent/reasoning_metrics.py."
+        )
+
+        m = ReasoningMetrics(total_rounds=5, tool_calls_total=3)
+        m.compute_derived()
+        d = m.to_dict()
+        assert "total_rounds" in d
+        assert "tool_calls_total" in d

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.0"
+version = "0.52.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.52.2 release: reasoning metrics correctness pass (PR #810)
- 6 low-risk fixes in the `reasoning_metrics` observability path (audit-logger key contract, counter inflation, no-op `min()`, dead field, `cost_per_tool_call` sentinel, DTR docstring)

## Verification
- [x] CI 5/5 pass on PR #810 (Lint, Type Check, Security, Test, Gate)
- [x] pytest -m "not live" — 4093 passed, 1 skipped
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` — A (68.4) undermarketed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)