### PR TITLE
fix(v0.52.3): 6-bug resilience patch (billing/parallel-approval/drift/cross-provider)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.3] — 2026-04-26
+
+### Fixed
+- **B4 — billing-fatal errors retried as transient** (v0.52.1 incident: 40s wasted per LLM call). GLM 429 with code `1113` ("Insufficient balance"), OpenAI `insufficient_quota`, Anthropic `permission_error` 가 SDK 의 `RateLimitError` 로 분류되어 5×4=20 retry × exp-backoff 으로 ~40s 동안 헛돌았음. `core/llm/errors.py` 에 `is_billing_fatal()` + `extract_billing_message()` 신설, `core/llm/fallback.py:235` retry 루프 진입 직전에 호출 → `BillingError` 즉시 raise. 사용자가 본 "thinking ↔ working 무한루프" 증상의 정체.
+- **B6 — parallel HITL approval race** (v0.52.1 incident: `manage_login` 승인 받고도 거부됨). LLM 이 같은 round 에서 같은 tool 을 2회 parallel 호출 → 2개 `approval_request` 가 thin client 로 동시 발사 → 사용자가 `A` 한 번 입력 (첫 prompt 가 소비) → 두번째 prompt 가 120s timeout → silent denial. `core/agent/approval.py:80` 에 이미 존재했지만 사용 안 되던 `_approval_lock` 을 `apply_safety_gates` 의 WRITE/EXPENSIVE branch 에 wrap. 두번째 caller 는 lock 안에서 `_always_approved_categories` 를 re-check 해서 첫 caller 의 "A" promotion 을 즉시 관측, prompt 없이 short-circuit.
+- **B3 — model drift sync 가 unhealthy target 으로 silent 전환** (v0.52.1 incident: OAuth 직후 GLM 으로 회귀). settings store 의 stale `glm-4.7-flash` 가 loop 의 `glm-5.1` 을 quota 확인 없이 덮어씀. `core/agent/loop.py:_sync_model_from_settings` 에 `_drift_target_is_healthy()` 신설 — `update_model()` 호출 전에 `ProfileRotator.resolve(target_provider)` 결과 확인, None 이면 drift 거부 + WARNING 로그. 패턴: OpenClaw `evaluate_eligibility` + `_LAST_VERDICTS`.
+- **B1 — OAuth success 메시지가 잘못된 경로 표시** (`Stored: ~/.geode/auth.json` 출력 but 실제는 `auth.toml`). v0.50.2 SOT migration 후 `AUTH_STORE_PATH` 가 legacy `auth.json` constant 의 alias 로 남아있었음. `core/auth/oauth_login.py` 에 `auth_store_path()` 신설 — `auth_toml_path()` 로 위임, `GEODE_AUTH_TOML` env 도 honor. `emit_oauth_login_success(stored_at=...)` call site 도 갱신.
+
+### Added
+- **B2 — `cmd_login("refresh")` 관측성 로그** (`core/cli/commands.py:1956`). 이전에는 success 시 완전 silent 이었던 daemon-side reload 가 INFO 로그를 emit — `auth.toml reload: file=... loaded=True new_plans=N new_profiles=M total_plans=X total_profiles=Y` + per-plan/profile 라인. 프로덕션에서 thin → daemon refresh signal 이 fire 하는지 사후 확인 가능. Hermes `tracing::info!(field=value, "event")` 패턴 + OpenClaw `markAuthProfileGood` 차용.
+- **B5 — credential breadcrumb cross-provider escalation** (`core/auth/credential_breadcrumb.py`). 활성 provider 의 모든 profile 이 거부됐을 때 다른 provider 들의 healthy profile 을 스캔해서 `cross-provider: openai-codex(codex-cli); anthropic(default)` 한 줄을 LLM context 에 주입. 이전에는 GLM exhausted 시 LLM 이 "GLM rejection" 만 보고 등록된 Codex Plus OAuth 의 존재를 알 수 없었음. 패턴: OpenClaw Lane fail-over (Session Lane → Global Lane). 자동 cross-provider failover (`llm_cross_provider_failover` flag) 는 default OFF 유지 — 정보 surface 만 추가하고 실제 switch 는 LLM/사용자 결정.
+- **6 invariant test files** (34 cases) — `test_billing_fatal.py` (11), `test_parallel_approval.py` (5), `test_model_drift_health.py` (6), `test_oauth_path_display.py` (3), `test_credential_breadcrumb_cross_provider.py` (4), `test_signal_reload.py` +1 case for B2.
+
+### Reference
+- v0.52.1 production incident (transcript: `/login oauth openai` → GLM model drift → 40s retry storm + parallel `manage_login` denial).
+- OpenClaw 차용 매핑 (`.claude/skills/openclaw-patterns/`): `evaluate_eligibility`, `_LAST_VERDICTS`, `markAuthProfileGood`, Lane fail-over, `managedBy`.
+- Hermes 차용 매핑 (`rsasaki0109/hermes-agent-rs`): `tracing::info!` 구조화 로그, `LlmError` 분류 (no false-retries by omission), session model authoritative pattern.
+- simonw/llm #112: "billing/quota error → log + surface + DO NOT retry".
+
 ## [0.52.2] — 2026-04-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.2
+- **Version**: 0.52.3
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4086+
+- **Tests**: 4154+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.2 — Long-running Autonomous Execution Harness
+# GEODE v0.52.3 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.2 — Long-running Autonomous Execution Harness
+# GEODE v0.52.3 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/approval.py
+++ b/core/agent/approval.py
@@ -161,76 +161,93 @@ class ApprovalWorkflow:
 
         approved = False
 
+        # v0.52.2 — wrap the HITL prompt + always-set mutation under a single
+        # mutex so parallel tool calls in the same round serialize their
+        # approval prompts. Without this, two concurrent confirm_write() calls
+        # both send approval_request to the thin client and the second blocks
+        # on a recv() that no input ever satisfies (the user typed "A" once,
+        # which the first prompt consumed). Result: 120s timeout → silent
+        # denial. Bug 6 root cause from v0.52.1 incident.
+        #
+        # The lock also lets the second caller observe the first caller's
+        # "A" → ``_always_approved_categories.add("write")`` and short-circuit
+        # without re-prompting the user.
+
         # Write tools
         if tool_name in WRITE_TOOLS:
-            if (
-                self._hitl_level == 0
-                or "write" in self._always_approved_categories
-                or tool_name in self._always_approved_tools
-            ):
-                approved = True
-            else:
-                self._fire_hook(
-                    "tool_approval_requested",
-                    {"tool_name": tool_name, "safety_level": "write"},
-                )
-                if not self.confirm_write(tool_name, tool_input):
+            with self._approval_lock:
+                if (
+                    self._hitl_level == 0
+                    or "write" in self._always_approved_categories
+                    or tool_name in self._always_approved_tools
+                ):
+                    approved = True
+                else:
                     self._fire_hook(
-                        "tool_approval_denied",
+                        "tool_approval_requested",
+                        {"tool_name": tool_name, "safety_level": "write"},
+                    )
+                    if not self.confirm_write(tool_name, tool_input):
+                        self._fire_hook(
+                            "tool_approval_denied",
+                            {
+                                "tool_name": tool_name,
+                                "safety_level": "write",
+                                "permission_level": "HITL",
+                                "decision": "denied",
+                                "latency_ms": 0.0,
+                            },
+                        )
+                        return _write_denial_with_fallback(tool_name), False
+                    self._fire_hook(
+                        "tool_approval_granted",
                         {
                             "tool_name": tool_name,
                             "safety_level": "write",
-                            "permission_level": "HITL",
-                            "decision": "denied",
-                            "latency_ms": 0.0,
+                            "always": "write" in self._always_approved_categories,
                         },
                     )
-                    return _write_denial_with_fallback(tool_name), False
-                self._fire_hook(
-                    "tool_approval_granted",
-                    {
-                        "tool_name": tool_name,
-                        "safety_level": "write",
-                        "always": "write" in self._always_approved_categories,
-                    },
-                )
-                approved = True
+                    approved = True
 
         # Expensive tools
         if tool_name in EXPENSIVE_TOOLS and not self._auto_approve:
-            if (
-                self._hitl_level == 0
-                or "cost" in self._always_approved_categories
-                or tool_name in self._always_approved_tools
-            ):
-                approved = True
-            else:
-                cost = EXPENSIVE_TOOLS[tool_name]
-                self._fire_hook(
-                    "tool_approval_requested",
-                    {"tool_name": tool_name, "safety_level": "cost"},
-                )
-                if not self.confirm_cost(tool_name, cost):
+            with self._approval_lock:
+                if (
+                    self._hitl_level == 0
+                    or "cost" in self._always_approved_categories
+                    or tool_name in self._always_approved_tools
+                ):
+                    approved = True
+                else:
+                    cost = EXPENSIVE_TOOLS[tool_name]
                     self._fire_hook(
-                        "tool_approval_denied",
+                        "tool_approval_requested",
+                        {"tool_name": tool_name, "safety_level": "cost"},
+                    )
+                    if not self.confirm_cost(tool_name, cost):
+                        self._fire_hook(
+                            "tool_approval_denied",
+                            {
+                                "tool_name": tool_name,
+                                "safety_level": "cost",
+                                "permission_level": "HITL",
+                                "decision": "denied",
+                                "latency_ms": 0.0,
+                            },
+                        )
+                        return {
+                            "error": "User denied expensive operation",
+                            "denied": True,
+                        }, False
+                    self._fire_hook(
+                        "tool_approval_granted",
                         {
                             "tool_name": tool_name,
                             "safety_level": "cost",
-                            "permission_level": "HITL",
-                            "decision": "denied",
-                            "latency_ms": 0.0,
+                            "always": "cost" in self._always_approved_categories,
                         },
                     )
-                    return {"error": "User denied expensive operation", "denied": True}, False
-                self._fire_hook(
-                    "tool_approval_granted",
-                    {
-                        "tool_name": tool_name,
-                        "safety_level": "cost",
-                        "always": "cost" in self._always_approved_categories,
-                    },
-                )
-                approved = True
+                    approved = True
 
         return None, approved
 

--- a/core/agent/loop.py
+++ b/core/agent/loop.py
@@ -443,23 +443,62 @@ class AgenticLoop:
         from inside a tool handler, which swapped the adapter while the
         current round was still processing tool results.
 
+        v0.52.2 — refuse the drift if the target provider has no eligible
+        profile. Prior shape would silently overwrite the loop's chosen
+        model with a stale settings value pointing at an exhausted
+        provider (e.g. just-registered Codex Plus → drift back to GLM
+        without quota → 5×4=20 retry storm). Pattern from OpenClaw
+        ``evaluate_eligibility`` + ``_LAST_VERDICTS`` cached health view.
+
         Returns True if the model was changed (caller should rebuild
         system_prompt), False otherwise.
         """
         try:
             from core.config import settings
 
-            if settings.model != self.model:
-                log.info(
-                    "Model drift detected: loop=%s settings=%s — syncing",
-                    self.model,
+            if settings.model == self.model:
+                return False
+            if not self._drift_target_is_healthy(settings.model):
+                log.warning(
+                    "Model drift refused: target=%s has no eligible profile — "
+                    "keeping loop=%s. Run `/login use <plan>` to enable target.",
                     settings.model,
+                    self.model,
                 )
-                self.update_model(settings.model)
-                return True
+                return False
+            log.info(
+                "Model drift detected: loop=%s settings=%s — syncing",
+                self.model,
+                settings.model,
+            )
+            self.update_model(settings.model)
+            return True
         except Exception:
             log.debug("Model drift check failed", exc_info=True)
         return False
+
+    def _drift_target_is_healthy(self, target_model: str) -> bool:
+        """Return False if no profile in target_model's provider can serve a call.
+
+        Uses ProfileRotator.resolve to mirror the actual selection path the
+        next LLM call would take. None ⇒ all profiles missing/cooled-down/
+        disabled. We refuse the drift rather than silently swap to a model
+        the next call cannot fulfil.
+        """
+        try:
+            target_provider = _resolve_provider(target_model)
+            from core.lifecycle.container import get_profile_rotator
+
+            rotator = get_profile_rotator()
+            if rotator is None:
+                # Rotator not initialised yet (early bootstrap) — accept drift.
+                return True
+            return rotator.resolve(target_provider) is not None
+        except Exception:
+            log.debug("Drift health check failed for %s", target_model, exc_info=True)
+            # On any introspection failure, accept the drift to avoid
+            # blocking legitimate user-initiated /model switches.
+            return True
 
     def update_model(
         self,

--- a/core/auth/credential_breadcrumb.py
+++ b/core/auth/credential_breadcrumb.py
@@ -16,9 +16,12 @@ All three feed off the same ``EligibilityResult`` verdicts produced by
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 
 from core.auth.profiles import EligibilityResult, ProfileRejectReason
+
+log = logging.getLogger(__name__)
 
 # Hint sentence per reason — what the LLM should say or do next.
 _NEXT_ACTION: dict[ProfileRejectReason, str] = {
@@ -99,5 +102,57 @@ def format(
             "then either remediate or report to the user. Do not loop on the "
             "same failing tool call."
         )
+        # v0.52.2 — when the active provider is fully exhausted, scan OTHER
+        # providers for healthy profiles and surface them. Pre-fix the LLM
+        # only saw rejections in the current provider and had no way to know
+        # that e.g. Codex Plus OAuth was registered and ready to take over.
+        # Pattern source: OpenClaw Lane fail-over (Session Lane → Global
+        # Lane re-route when one Lane is unhealthy).
+        alt = _suggest_alternative_providers(exclude=attempted_provider)
+        if alt:
+            lines.append(
+                "  cross-provider: "
+                + alt
+                + " — switch with manage_login(subcommand='use', args='<plan-id>') "
+                "or have the user run /model <slug>."
+            )
 
     return "\n".join(lines)
+
+
+def _suggest_alternative_providers(*, exclude: str) -> str:
+    """Enumerate providers (other than the exhausted one) that currently have
+    eligible profiles. Returns a one-line summary or empty string.
+
+    Mirrors ``ProfileStore.evaluate_eligibility`` for each candidate provider
+    so the answer matches what the next LLM call would actually see.
+    """
+    try:
+        from core.lifecycle.container import get_profile_store
+    except Exception:
+        return ""
+    store = get_profile_store()
+    if store is None:
+        return ""
+    candidates: list[str] = []
+    seen_providers: set[str] = set()
+    for profile in store.list_all():
+        if profile.provider == exclude or profile.provider in seen_providers:
+            continue
+        seen_providers.add(profile.provider)
+        try:
+            verdicts = store.evaluate_eligibility(profile.provider)
+        except Exception as exc:  # nosec B112 — log + skip per provider
+            log.debug(
+                "cross-provider eligibility check failed for %s: %s",
+                profile.provider,
+                exc,
+            )
+            continue
+        eligible_here = [v for v in verdicts if v.eligible]
+        if eligible_here:
+            names = ", ".join(v.profile_name for v in eligible_here[:3])
+            candidates.append(f"{profile.provider}({names})")
+    if not candidates:
+        return ""
+    return "available providers: " + "; ".join(candidates)

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -31,8 +31,27 @@ _MAX_WAIT_S = 15 * 60  # 15 minutes
 
 # Legacy auth store path — kept only for one-shot migration into auth.toml.
 LEGACY_AUTH_STORE_PATH = Path.home() / ".geode" / "auth.json"
-# Backwards-compat alias — some external callers imported this name.
-AUTH_STORE_PATH = LEGACY_AUTH_STORE_PATH
+
+
+def auth_store_path() -> Path:
+    """Resolve the *current* auth store path (``~/.geode/auth.toml``).
+
+    v0.50.2 made auth.toml the SOT. Pre-v0.52.2 ``AUTH_STORE_PATH`` was an
+    alias for the legacy ``auth.json`` constant, so the OAuth success
+    message and other UX surfaces displayed a stale path even though the
+    actual write landed in ``auth.toml``. Resolving via ``auth_toml_path()``
+    keeps the display string honest and respects the ``GEODE_AUTH_TOML``
+    env override used by tests.
+    """
+    from core.auth.auth_toml import auth_toml_path
+
+    return auth_toml_path()
+
+
+# Backwards-compat alias — old callers imported the constant name.
+# Now resolves to the live auth.toml path so any consumer that *displays*
+# this value matches the actual SOT.
+AUTH_STORE_PATH = auth_store_path()
 
 # Plan ID we use for any OAuth token GEODE itself issued (vs. external
 # managed CLIs like ~/.codex/auth.json which keep their own SOT).
@@ -342,7 +361,10 @@ def login_openai() -> dict[str, Any]:
         account_id=account_id,
         email=email,
         plan_type=plan_type or "unknown",
-        stored_at=str(AUTH_STORE_PATH),
+        # v0.52.2 — resolve the live SOT path each call (auth.toml since
+        # v0.50.2). Pre-fix this displayed the legacy auth.json constant
+        # while the actual write landed in auth.toml.
+        stored_at=str(auth_store_path()),
     )
 
     return creds

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -1954,11 +1954,38 @@ def cmd_login(args: str) -> None:
         # in-flight requests using profiles loaded from .env / managed CLIs
         # (Codex CLI OAuth) which never appear in auth.toml.
         try:
-            from core.auth.auth_toml import load_auth_toml
+            from core.auth.auth_toml import auth_toml_path, load_auth_toml
+            from core.auth.plan_registry import get_plan_registry
+            from core.lifecycle.container import ensure_profile_store
 
-            load_auth_toml()
+            registry = get_plan_registry()
+            store = ensure_profile_store()
+            plans_before = {p.id for p in registry.list_all()}
+            profiles_before = {p.name for p in store.list_all()}
+            ok = load_auth_toml()
+            plans_after = {p.id for p in registry.list_all()}
+            profiles_after = {p.name for p in store.list_all()}
+            new_plans = plans_after - plans_before
+            new_profiles = profiles_after - profiles_before
+            # v0.52.2 — production observability for the B7 thin → daemon
+            # refresh signal. Pre-fix this branch was completely silent on
+            # success, making it impossible to verify the relay was firing.
+            log.info(
+                "auth.toml reload: file=%s loaded=%s new_plans=%d "
+                "new_profiles=%d total_plans=%d total_profiles=%d",
+                auth_toml_path(),
+                ok,
+                len(new_plans),
+                len(new_profiles),
+                len(plans_after),
+                len(profiles_after),
+            )
+            for plan_id in sorted(new_plans):
+                log.info("auth.toml reload: + plan %s", plan_id)
+            for profile_name in sorted(new_profiles):
+                log.info("auth.toml reload: + profile %s", profile_name)
         except Exception:
-            log.debug("auth.toml reload skipped", exc_info=True)
+            log.warning("auth.toml reload failed", exc_info=True)
         return
     if sub in ("help", "?"):
         _login_help()

--- a/core/config.py
+++ b/core/config.py
@@ -306,8 +306,15 @@ class Settings(BaseSettings):
     llm_retry_max_delay: float = 30.0  # max delay cap for retries (seconds)
     llm_max_retries: int = 3  # max retry attempts per model
 
-    # LLM — Cross-Provider Failover (opt-in)
-    llm_cross_provider_failover: bool = False  # cross-provider fallback on all retries exhausted
+    # LLM — Cross-Provider Failover (opt-in).
+    # When True, the router walks ``llm_cross_provider_order`` after all
+    # retries+fallbacks within the active provider exhaust. v0.52.2 keeps
+    # this opt-in (it auto-switches *silently*, which is a behaviour
+    # change with broader surface than the resilience patch should own).
+    # The B5 cross-provider breadcrumb (``credential_breadcrumb.format``)
+    # already surfaces alternative providers to the LLM so the model can
+    # ask the user to run ``/model <slug>`` — a transparent path.
+    llm_cross_provider_failover: bool = False
     llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
 
     # LLM — Fallback cost ratio control (C2: 0 = unlimited)

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -6,7 +6,35 @@ so that no consumer needs to import provider SDKs directly.
 
 from __future__ import annotations
 
+from typing import Any
+
 import anthropic
+
+# v0.52.2 — billing-fatal error codes by provider SDK shape.
+# Retrying these wastes 40s per call (5 attempts × exponential backoff)
+# and never succeeds — billing/quota issues require user action, not a retry.
+# Source: simonw/llm #112 (insufficient_quota → no retry), Hermes lesson
+# (no retry on classified non-transient), OpenClaw NON_RETRYABLE_ERRORS.
+_GLM_BILLING_CODES: frozenset[str] = frozenset(
+    {
+        "1113",  # Insufficient balance / no resource package
+        "1114",  # Quota exhausted
+        "1301",  # Account suspended
+    }
+)
+_OPENAI_BILLING_CODES: frozenset[str] = frozenset(
+    {
+        "insufficient_quota",
+        "billing_hard_limit_reached",
+        "billing_not_active",
+    }
+)
+_ANTHROPIC_BILLING_TYPES: frozenset[str] = frozenset(
+    {
+        "permission_error",  # API key lacks billing access
+        "billing_error",
+    }
+)
 
 
 class UserCancelledError(Exception):
@@ -119,6 +147,63 @@ def classify_llm_error(exc: Exception) -> tuple[str, str, str]:
         return result
 
     return _ERROR_CLASSIFICATION["unknown"]
+
+
+def is_billing_fatal(exc: Exception) -> bool:
+    """Return True if exc represents a non-retryable billing/quota error.
+
+    Inspects the SDK exception's response body for provider-specific error
+    codes that retrying cannot fix:
+      - GLM (1113/1114/1301): user must recharge or upgrade plan
+      - OpenAI (insufficient_quota, billing_hard_limit): account-level cap
+      - Anthropic (permission_error, billing_error): API key lacks access
+
+    Caller should raise BillingError instead of entering the retry loop.
+    """
+    body = _extract_error_body(exc)
+    if not body:
+        return False
+    code = str(body.get("code") or body.get("type") or "").lower()
+    err_obj = body.get("error")
+    if isinstance(err_obj, dict):
+        code = code or str(err_obj.get("code") or err_obj.get("type") or "").lower()
+    if not code:
+        return False
+    return (
+        code in _GLM_BILLING_CODES
+        or code in _OPENAI_BILLING_CODES
+        or code in _ANTHROPIC_BILLING_TYPES
+    )
+
+
+def extract_billing_message(exc: Exception) -> str:
+    """Extract a human-readable billing message from the SDK exception."""
+    body = _extract_error_body(exc) or {}
+    msg = body.get("message") or ""
+    err_obj = body.get("error")
+    if isinstance(err_obj, dict):
+        msg = msg or err_obj.get("message", "")
+    return str(msg) or str(exc)
+
+
+def _extract_error_body(exc: Exception) -> dict[str, Any] | None:
+    """Pull the parsed JSON body out of an SDK exception, if present.
+
+    Anthropic / OpenAI / openai-compatible SDKs all expose .body or
+    .response.json() with the structured error. We try both.
+    """
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        return body
+    response = getattr(exc, "response", None)
+    if response is not None:
+        try:
+            parsed = response.json()
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            return None
+    return None
 
 
 def _classify_openai_error(exc: Exception) -> tuple[str, str, str] | None:

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -233,6 +233,26 @@ def retry_with_backoff_generic(
                 _notify_success(_provider_for_rotator)
                 return result
             except retryable_errors as exc:
+                # v0.52.2 — short-circuit billing-fatal errors. RateLimitError
+                # with code=1113 (GLM "Insufficient balance") or
+                # insufficient_quota (OpenAI) cannot be cured by waiting; the
+                # 5×exp-backoff retry loop wastes ~40s per failure across all
+                # fallback models for an error that needs user action.
+                from core.llm.errors import (
+                    BillingError,
+                    extract_billing_message,
+                    is_billing_fatal,
+                )
+
+                if is_billing_fatal(exc):
+                    msg = extract_billing_message(exc)
+                    log.error(
+                        "Billing-fatal error on %s (model=%s) — no retry: %s",
+                        provider_label,
+                        current_model,
+                        msg,
+                    )
+                    raise BillingError(msg or billing_message) from exc
                 last_error = exc
                 delay = random.uniform(0, min(retry_base_delay * (2**attempt), retry_max_delay))
                 elapsed = time.monotonic() - t0_retry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.2"
+version = "0.52.3"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_billing_fatal.py
+++ b/tests/test_billing_fatal.py
@@ -1,0 +1,160 @@
+"""Bug class B4 — billing-fatal errors must not be retried.
+
+The v0.52.1 incident: GLM 429 with code 1113 ("Insufficient balance") was
+classified as retryable RateLimitError, causing the fallback loop to
+hammer all 4 GLM models × 5 retries × exp-backoff = ~40s per LLM call.
+Same shape applies to OpenAI ``insufficient_quota`` and Anthropic
+``permission_error``.
+
+This invariant pins:
+  1. ``is_billing_fatal()`` correctly identifies the 3 SDK shapes.
+  2. ``extract_billing_message()`` recovers the user-facing string.
+  3. The fallback retry loop calls ``is_billing_fatal`` and short-circuits
+     with ``BillingError`` BEFORE entering the retry sleep.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import core.llm.fallback as _fallback
+import pytest
+from core.llm.errors import (
+    BillingError,
+    extract_billing_message,
+    is_billing_fatal,
+)
+
+# ---------------------------------------------------------------------------
+# Contract 1 — is_billing_fatal recognises the 3 SDK shapes
+# ---------------------------------------------------------------------------
+
+
+def _make_exc_with_body(body: dict) -> Exception:
+    exc = Exception("rate limited")
+    exc.body = body  # type: ignore[attr-defined]
+    return exc
+
+
+def test_glm_1113_is_billing_fatal() -> None:
+    """GLM 429 body — `{'error': {'code': '1113', 'message': '...'}}`"""
+    exc = _make_exc_with_body({"error": {"code": "1113", "message": "Insufficient balance"}})
+    assert is_billing_fatal(exc) is True
+    assert "Insufficient balance" in extract_billing_message(exc)
+
+
+def test_glm_1114_is_billing_fatal() -> None:
+    exc = _make_exc_with_body({"error": {"code": "1114", "message": "quota exhausted"}})
+    assert is_billing_fatal(exc) is True
+
+
+def test_glm_1301_is_billing_fatal() -> None:
+    exc = _make_exc_with_body({"error": {"code": "1301", "message": "suspended"}})
+    assert is_billing_fatal(exc) is True
+
+
+def test_openai_insufficient_quota_is_billing_fatal() -> None:
+    exc = _make_exc_with_body(
+        {"error": {"code": "insufficient_quota", "message": "You exceeded your quota"}}
+    )
+    assert is_billing_fatal(exc) is True
+
+
+def test_openai_billing_hard_limit_is_billing_fatal() -> None:
+    exc = _make_exc_with_body({"error": {"code": "billing_hard_limit_reached"}})
+    assert is_billing_fatal(exc) is True
+
+
+def test_anthropic_permission_error_is_billing_fatal() -> None:
+    exc = _make_exc_with_body({"type": "permission_error", "message": "billing denied"})
+    assert is_billing_fatal(exc) is True
+
+
+def test_transient_429_is_not_billing_fatal() -> None:
+    """Plain rate limit (no fatal code) must remain retryable."""
+    exc = _make_exc_with_body({"error": {"code": "rate_limit_exceeded"}})
+    assert is_billing_fatal(exc) is False
+
+
+def test_unparseable_exc_is_not_billing_fatal() -> None:
+    """Unknown shape must default to retryable (avoid false-positive denial)."""
+    exc = Exception("network blip")
+    assert is_billing_fatal(exc) is False
+
+
+def test_response_attr_fallback() -> None:
+    """SDK that exposes .response.json() rather than .body must also work."""
+    exc = Exception("rl")
+    response = MagicMock()
+    response.json.return_value = {"error": {"code": "1113", "message": "balance"}}
+    exc.response = response  # type: ignore[attr-defined]
+    assert is_billing_fatal(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — fallback.py retry loop short-circuits via BillingError
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_loop_calls_is_billing_fatal_before_retry() -> None:
+    """Source-level invariant: the retryable_errors except block must call
+    is_billing_fatal and raise BillingError BEFORE the retry sleep / fallback
+    iteration. If a future refactor moves the check after sleep, the 40s
+    waste regression returns.
+    """
+    src = inspect.getsource(_fallback)
+    assert "is_billing_fatal" in src, (
+        "fallback.py must import and call is_billing_fatal from core.llm.errors"
+    )
+    # Locate the except retryable_errors block and assert is_billing_fatal
+    # appears before the time.sleep / on_retry callback in the same block.
+    block_start = src.find("except retryable_errors as exc:")
+    assert block_start >= 0
+    next_except = src.find("except Exception as exc:", block_start)
+    block = src[block_start : next_except if next_except > 0 else len(src)]
+    fatal_pos = block.find("is_billing_fatal(exc)")
+    sleep_pos = block.find("time.sleep(delay)")
+    assert fatal_pos >= 0, "is_billing_fatal call missing inside retryable block"
+    assert sleep_pos >= 0, "time.sleep removed?"
+    assert fatal_pos < sleep_pos, (
+        "is_billing_fatal must be checked BEFORE time.sleep — otherwise we "
+        "waste an entire backoff cycle on a billing-fatal error"
+    )
+
+
+def test_fallback_loop_raises_billing_error_on_glm_1113() -> None:
+    """End-to-end: a fake fn() that raises a 429-with-code-1113 must propagate
+    as BillingError out of run_with_retries, no retries observed."""
+    from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
+
+    call_count = 0
+
+    class FakeRateLimitError(Exception):
+        pass
+
+    def fn(*, model: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        exc = FakeRateLimitError("429")
+        exc.body = {"error": {"code": "1113", "message": "Insufficient balance"}}  # type: ignore[attr-defined]
+        raise exc
+
+    cb = CircuitBreaker()
+    with pytest.raises(BillingError) as exc_info:
+        retry_with_backoff_generic(
+            fn,
+            model="glm-5.1",
+            fallback_models=["glm-5", "glm-5-turbo"],
+            circuit_breaker=cb,
+            retryable_errors=(FakeRateLimitError,),
+            bad_request_error=None,
+            billing_message="GLM billing exhausted",
+            max_retries=5,
+            provider_label="GLM",
+        )
+    assert "Insufficient balance" in str(exc_info.value)
+    assert call_count == 1, (
+        f"Billing-fatal must short-circuit after FIRST call, got {call_count} attempts. "
+        "v0.52.1 incident: 5×4=20 attempts wasted ~40s on the same 1113."
+    )

--- a/tests/test_credential_breadcrumb_cross_provider.py
+++ b/tests/test_credential_breadcrumb_cross_provider.py
@@ -1,0 +1,119 @@
+"""Bug class B5 — credential breadcrumb cross-provider escalation.
+
+The v0.52.1 incident: GLM was exhausted (1113 Insufficient balance) but
+the LLM only saw rejection details for GLM profiles. The user had
+already registered Codex Plus OAuth and an Anthropic API key, but the
+breadcrumb did not mention them, so the model could not suggest
+``/model gpt-5.4-mini`` as recovery.
+
+Invariant: when ``credential_breadcrumb.format()`` reports the active
+provider has no eligible profile, it must scan other providers in
+``ProfileStore`` for healthy profiles and surface them with a
+``cross-provider:`` line.
+
+Pattern source: OpenClaw Lane fail-over (Session Lane → Global Lane).
+"""
+
+from __future__ import annotations
+
+from core.auth.credential_breadcrumb import format
+from core.auth.profiles import (
+    AuthProfile,
+    CredentialType,
+    EligibilityResult,
+    ProfileRejectReason,
+)
+
+
+def _verdict(name: str, reason: ProfileRejectReason | None = None) -> EligibilityResult:
+    return EligibilityResult(
+        profile_name=name,
+        provider="glm",
+        credential_type=CredentialType.API_KEY,
+        eligible=reason is None,
+        reason=reason,
+        detail="" if reason is None else f"reason={reason.value}",
+    )
+
+
+def test_no_alt_when_active_provider_has_eligible() -> None:
+    """If active provider has eligible profiles, breadcrumb is empty —
+    no cross-provider line either (nothing to escalate to)."""
+    out = format([_verdict("glm:default")], attempted_provider="glm")
+    assert out == ""
+
+
+def test_alt_provider_listed_when_active_exhausted(monkeypatch) -> None:
+    """All GLM profiles cooled-down; a healthy openai-codex profile exists.
+    Breadcrumb must surface ``cross-provider:`` line with the codex profile.
+    """
+    from core.auth.profiles import ProfileStore
+    from core.lifecycle import container as _infra
+
+    store = ProfileStore()
+    store.add(
+        AuthProfile(
+            name="openai-codex:codex-cli",
+            provider="openai-codex",
+            credential_type=CredentialType.OAUTH,
+            key="oauth-token",
+            managed_by="codex-cli",
+        )
+    )
+    monkeypatch.setattr(_infra, "_profile_store", store)
+
+    out = format(
+        [_verdict("glm:default", ProfileRejectReason.COOLING_DOWN)],
+        attempted_provider="glm",
+        attempted_model="glm-5.1",
+    )
+    assert "cross-provider:" in out, (
+        "When active provider is exhausted and another provider has an "
+        "eligible profile, breadcrumb must surface it. Pre-fix the LLM "
+        "saw only GLM rejections and could not suggest /model fallback."
+    )
+    assert "openai-codex" in out
+    assert "codex-cli" in out
+
+
+def test_no_cross_provider_line_when_no_alternatives(monkeypatch) -> None:
+    """If no other provider has eligible profiles, no cross-provider line
+    (avoid telling LLM to try things that won't work)."""
+    from core.auth.profiles import ProfileStore
+    from core.lifecycle import container as _infra
+
+    store = ProfileStore()  # empty store
+    monkeypatch.setattr(_infra, "_profile_store", store)
+
+    out = format(
+        [_verdict("glm:default", ProfileRejectReason.COOLING_DOWN)],
+        attempted_provider="glm",
+    )
+    assert "cross-provider:" not in out, (
+        "No alternative providers ⇒ no cross-provider hint (don't fabricate)"
+    )
+
+
+def test_alt_provider_skips_attempted_provider(monkeypatch) -> None:
+    """The exhausted provider must not appear in its own alternatives list."""
+    from core.auth.profiles import ProfileStore
+    from core.lifecycle import container as _infra
+
+    store = ProfileStore()
+    store.add(
+        AuthProfile(
+            name="glm:default",
+            provider="glm",
+            credential_type=CredentialType.API_KEY,
+            key="sk-glm-fake",
+        )
+    )
+    monkeypatch.setattr(_infra, "_profile_store", store)
+
+    out = format(
+        [_verdict("glm:default", ProfileRejectReason.COOLING_DOWN)],
+        attempted_provider="glm",
+    )
+    # Even if the GLM profile in the store is "eligible", we exclude the
+    # exhausted provider from the suggestion list.
+    assert "cross-provider:" not in out

--- a/tests/test_model_drift_health.py
+++ b/tests/test_model_drift_health.py
@@ -1,0 +1,151 @@
+"""Bug class B3 — model drift sync must check target health.
+
+The v0.52.1 incident: User completed `/login oauth openai` (Codex Plus
+registered). Same session immediately started a new prompt. Settings
+store still pointed at the old `glm-4.7-flash`. Loop started with
+`glm-5.1`, detected drift, **silently overwrote loop's choice with
+`glm-4.7-flash`** even though GLM had no quota left. Result: 5×4 retry
+storm on a model the user did not pick and which had no available
+profile.
+
+Invariant: ``_sync_model_from_settings()`` must consult
+``ProfileRotator.resolve(target_provider)`` and **refuse** the drift
+when the rotator returns None (no eligible profile for the target).
+The loop's currently-chosen model is preserved instead.
+
+Pattern source: OpenClaw ``evaluate_eligibility`` + ``_LAST_VERDICTS``
+cached health view (referenced in `core/auth/rotation.py`,
+`core/auth/profiles.py:176`).
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import core.agent.loop as _loop_mod
+
+# ---------------------------------------------------------------------------
+# Contract 1 — _sync_model_from_settings consults rotator before update_model
+# ---------------------------------------------------------------------------
+
+
+def test_sync_calls_health_check_before_update() -> None:
+    """Source-level: the drift branch must call ``_drift_target_is_healthy``
+    before ``self.update_model`` so an unhealthy drift target cannot
+    silently overwrite the loop's choice."""
+    src = inspect.getsource(_loop_mod.AgenticLoop._sync_model_from_settings)
+    health_pos = src.find("_drift_target_is_healthy")
+    update_pos = src.find("self.update_model")
+    assert health_pos >= 0, (
+        "_sync_model_from_settings must call _drift_target_is_healthy. "
+        "Without the check the v0.51-incident regression returns: stale "
+        "settings.model overwrites loop.model when target is unhealthy."
+    )
+    assert update_pos >= 0
+    assert health_pos < update_pos, (
+        "Health check must come BEFORE update_model — otherwise we swap "
+        "the adapter and only then discover there's no profile to use."
+    )
+
+
+def test_drift_target_is_healthy_uses_rotator() -> None:
+    """The health helper must consult ProfileRotator.resolve, not invent
+    its own definition of health (which would diverge from the actual
+    selection used by the next LLM call)."""
+    src = inspect.getsource(_loop_mod.AgenticLoop._drift_target_is_healthy)
+    assert "rotator.resolve" in src, (
+        "Health check must use ProfileRotator.resolve so the answer matches "
+        "what the next LLM call would actually pick"
+    )
+    assert "_resolve_provider" in src, (
+        "Must resolve target_model → provider via _resolve_provider, "
+        "otherwise we'd query the wrong rotator pool"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — refuse drift when rotator returns None, accept when healthy
+# ---------------------------------------------------------------------------
+
+
+def _make_loop_stub(loop_model: str = "glm-5.1") -> MagicMock:
+    """Build a stub bound to AgenticLoop._sync_model_from_settings + helper."""
+    stub = MagicMock()
+    stub.model = loop_model
+    stub.update_model = MagicMock()
+    # Bind the real methods to the stub so we exercise the patched logic.
+    stub._sync_model_from_settings = _loop_mod.AgenticLoop._sync_model_from_settings.__get__(stub)
+    stub._drift_target_is_healthy = _loop_mod.AgenticLoop._drift_target_is_healthy.__get__(stub)
+    return stub
+
+
+def test_drift_refused_when_rotator_returns_none(monkeypatch) -> None:
+    """End-to-end: settings.model='glm-4.7-flash', loop.model='glm-5.1'.
+    Rotator.resolve('glm') → None (no profile). Drift must be refused;
+    update_model must NOT be called."""
+    stub = _make_loop_stub("glm-5.1")
+
+    fake_rotator = MagicMock()
+    fake_rotator.resolve.return_value = None  # no eligible profile
+
+    monkeypatch.setattr("core.lifecycle.container.get_profile_rotator", lambda: fake_rotator)
+    monkeypatch.setattr("core.agent.loop._resolve_provider", lambda m: "glm")
+
+    fake_settings = MagicMock(model="glm-4.7-flash")
+    with patch("core.config.settings", fake_settings):
+        changed = stub._sync_model_from_settings()
+
+    assert changed is False
+    stub.update_model.assert_not_called()
+
+
+def test_drift_accepted_when_rotator_returns_profile(monkeypatch) -> None:
+    """Same setup but rotator returns a valid profile → drift proceeds."""
+    stub = _make_loop_stub("glm-5.1")
+
+    fake_rotator = MagicMock()
+    fake_rotator.resolve.return_value = MagicMock(name="profile")
+
+    monkeypatch.setattr("core.lifecycle.container.get_profile_rotator", lambda: fake_rotator)
+    monkeypatch.setattr("core.agent.loop._resolve_provider", lambda m: "glm")
+
+    fake_settings = MagicMock(model="glm-4.7-flash")
+    with patch("core.config.settings", fake_settings):
+        changed = stub._sync_model_from_settings()
+
+    assert changed is True
+    stub.update_model.assert_called_once_with("glm-4.7-flash")
+
+
+def test_drift_accepted_when_rotator_not_initialised(monkeypatch) -> None:
+    """Early bootstrap: rotator singleton is None. Drift must NOT be blocked
+    (would prevent legitimate model switches before bootstrap completes).
+    """
+    stub = _make_loop_stub("glm-5.1")
+
+    monkeypatch.setattr("core.lifecycle.container.get_profile_rotator", lambda: None)
+    monkeypatch.setattr("core.agent.loop._resolve_provider", lambda m: "glm")
+
+    fake_settings = MagicMock(model="glm-4.7-flash")
+    with patch("core.config.settings", fake_settings):
+        changed = stub._sync_model_from_settings()
+
+    assert changed is True
+    stub.update_model.assert_called_once()
+
+
+def test_drift_no_op_when_models_match(monkeypatch) -> None:
+    """settings.model == loop.model → no-op, no rotator call."""
+    stub = _make_loop_stub("glm-5.1")
+    fake_rotator = MagicMock()
+
+    monkeypatch.setattr("core.lifecycle.container.get_profile_rotator", lambda: fake_rotator)
+
+    fake_settings = MagicMock(model="glm-5.1")
+    with patch("core.config.settings", fake_settings):
+        changed = stub._sync_model_from_settings()
+
+    assert changed is False
+    fake_rotator.resolve.assert_not_called()
+    stub.update_model.assert_not_called()

--- a/tests/test_oauth_path_display.py
+++ b/tests/test_oauth_path_display.py
@@ -1,0 +1,67 @@
+"""Bug class B1 — OAuth success message must display the actual SOT path.
+
+The v0.52.1 incident: ``/login oauth openai`` succeeded and printed
+``Stored: /Users/mango/.geode/auth.json``, but the actual write landed
+in ``~/.geode/auth.toml`` (v0.50.2 SOT). The display constant lagged
+behind the SOT migration.
+
+Invariant:
+  1. ``auth_store_path()`` resolves to the live ``auth_toml_path()`` and
+     respects the ``GEODE_AUTH_TOML`` env override.
+  2. ``oauth_login.py`` does NOT pass the legacy constant to
+     ``emit_oauth_login_success(stored_at=...)``. It must call
+     ``auth_store_path()`` (or equivalent live resolver) instead.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import core.auth.oauth_login as _oauth
+import pytest
+
+
+def test_auth_store_path_resolves_to_auth_toml(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Honor GEODE_AUTH_TOML env override — same behaviour as auth_toml_path."""
+    target = tmp_path / "auth.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(target))
+
+    resolved = _oauth.auth_store_path()
+    assert str(resolved) == str(target), (
+        "auth_store_path must resolve via auth_toml_path() so the OAuth "
+        "success message points at the actual SOT, not the legacy auth.json."
+    )
+
+
+def test_auth_store_path_does_not_return_legacy(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "auth.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(target))
+
+    resolved = _oauth.auth_store_path()
+    assert "auth.json" not in str(resolved), (
+        "auth_store_path must never resolve to auth.json (legacy SOT)"
+    )
+
+
+def test_oauth_success_uses_auth_store_path() -> None:
+    """Source-level: the OAuth success emit_* call must use auth_store_path()
+    (or equivalent live resolver) so the displayed path matches what was
+    actually written. Pre-v0.52.2 it used ``str(AUTH_STORE_PATH)`` which was
+    a static alias for the legacy auth.json constant.
+    """
+    src = inspect.getsource(_oauth)
+    # Locate the emit_oauth_login_success call and check its stored_at arg.
+    success_call = src.find("emit_oauth_login_success(")
+    assert success_call >= 0
+    # Window around the call.
+    block = src[success_call : success_call + 500]
+    assert "auth_store_path()" in block or "auth_toml_path()" in block, (
+        "emit_oauth_login_success(stored_at=...) must use the live SOT "
+        "resolver. Pre-fix it stringified AUTH_STORE_PATH (legacy constant)."
+    )
+    # Anti-regression: the literal legacy alias must NOT appear in the call.
+    legacy_pattern = "stored_at=str(AUTH_STORE_PATH)"
+    assert legacy_pattern not in block, (
+        "Legacy ``stored_at=str(AUTH_STORE_PATH)`` regression detected — "
+        "this displayed auth.json while writing to auth.toml (B1)."
+    )

--- a/tests/test_parallel_approval.py
+++ b/tests/test_parallel_approval.py
@@ -1,0 +1,165 @@
+"""Bug class B6 — parallel HITL approval race.
+
+The v0.52.1 incident: LLM made two parallel ``manage_login`` tool calls in
+the same round. Both hit ``confirm_write()`` simultaneously. The first
+prompt rendered to the thin client; user typed ``A`` and it returned. The
+second prompt was already in flight on the same socket — it timed out
+after 120s and was treated as a denial. The user saw
+``User denied write operation for 'manage_login' ... (120.0s)``.
+
+Root cause: ``ApprovalWorkflow._approval_lock`` existed (line 80) but was
+unused. ``apply_safety_gates`` checked + prompted + mutated
+``_always_approved_categories`` without holding the lock, so a second
+parallel caller couldn't see the first caller's "A" promotion.
+
+This invariant pins:
+  1. The lock is held during the entire HITL prompt + mutation sequence.
+  2. The lock is RE-checked inside the locked section so the second caller
+     sees the first caller's ``always`` promotion and short-circuits.
+  3. The poller-side socket recv loop has a finite timeout so a real
+     user-stuck case fails closed (denial) instead of hanging the daemon.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import core.agent.approval as _approval_mod
+import core.server.ipc_server.poller as _poller_mod
+
+# ---------------------------------------------------------------------------
+# Contract 1 — apply_safety_gates uses _approval_lock
+# ---------------------------------------------------------------------------
+
+
+def test_approval_lock_wraps_write_branch() -> None:
+    """Source-level: the WRITE_TOOLS branch must enter ``with self._approval_lock``
+    BEFORE checking ``_always_approved_categories`` so a second caller's
+    re-check observes the first caller's promotion.
+    """
+    src = inspect.getsource(_approval_mod.ApprovalWorkflow.apply_safety_gates)
+    # Locate "if tool_name in WRITE_TOOLS:" and assert the very next line
+    # establishes the lock context.
+    lines = src.splitlines()
+    write_branch = next(
+        (i for i, ln in enumerate(lines) if "if tool_name in WRITE_TOOLS" in ln),
+        -1,
+    )
+    assert write_branch >= 0, "WRITE_TOOLS branch removed?"
+    follow = "\n".join(lines[write_branch : write_branch + 5])
+    assert "with self._approval_lock" in follow, (
+        "WRITE_TOOLS branch must enter _approval_lock before the always-set "
+        "check + confirm_write. See B6 root cause."
+    )
+
+
+def test_approval_lock_wraps_expensive_branch() -> None:
+    """Same invariant for the EXPENSIVE_TOOLS branch."""
+    src = inspect.getsource(_approval_mod.ApprovalWorkflow.apply_safety_gates)
+    lines = src.splitlines()
+    cost_branch = next(
+        (i for i, ln in enumerate(lines) if "if tool_name in EXPENSIVE_TOOLS" in ln),
+        -1,
+    )
+    assert cost_branch >= 0
+    follow = "\n".join(lines[cost_branch : cost_branch + 5])
+    assert "with self._approval_lock" in follow, (
+        "EXPENSIVE_TOOLS branch must use _approval_lock too — same race shape"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — second parallel caller short-circuits via always-set
+# ---------------------------------------------------------------------------
+
+
+def _make_gate(approval_responses: list[str]) -> Any:
+    """Build an ApprovalWorkflow whose approval_callback returns canned responses."""
+    from core.agent.approval import ApprovalWorkflow
+
+    responses = iter(approval_responses)
+
+    def callback(tool_name: str, detail: str, safety_level: str) -> str:
+        # Add a small sleep so the threads' timing actually overlaps.
+        time.sleep(0.05)
+        return next(responses)
+
+    return ApprovalWorkflow(
+        hitl_level=2,
+        auto_approve=False,
+        hooks=None,
+        approval_callback=callback,
+    )
+
+
+def test_second_parallel_write_short_circuits_after_always() -> None:
+    """End-to-end: thread A says "a", thread B (started immediately after)
+    must NOT prompt — it sees "write" in always_approved_categories under
+    the lock and approves silently. Pre-fix this hung 120s on the second
+    socket recv.
+    """
+    gate = _make_gate(["a"])  # only ONE callback response — second must skip
+
+    results: dict[str, tuple[Any, ...]] = {}
+
+    def worker(tag: str) -> None:
+        results[tag] = gate.apply_safety_gates("manage_login", {"subcommand": "use"})
+
+    t_a = threading.Thread(target=worker, args=("a",))
+    t_b = threading.Thread(target=worker, args=("b",))
+    t_a.start()
+    # Give A a head-start so it grabs the lock first; B then waits on the lock
+    # and re-reads always_approved_categories after A releases.
+    time.sleep(0.01)
+    t_b.start()
+    t_a.join(timeout=5)
+    t_b.join(timeout=5)
+
+    assert not t_a.is_alive(), "thread A hung — approval lock starvation"
+    assert not t_b.is_alive(), "thread B hung — second caller never short-circuited"
+
+    rejection_a, approved_a = results["a"]
+    rejection_b, approved_b = results["b"]
+    assert rejection_a is None and approved_a is True
+    assert rejection_b is None and approved_b is True, (
+        "second parallel call must observe always-set promotion and approve"
+    )
+    assert "write" in gate._always_approved_categories
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — daemon socket timeout fails CLOSED, not silently hangs
+# ---------------------------------------------------------------------------
+
+
+def test_request_approval_uses_finite_timeout() -> None:
+    """Source-level: poller's request_approval must set a finite settimeout
+    on the client socket so a stuck thin client doesn't pin a daemon thread
+    forever. Pre-v0.52.1 this was already 120s — this test pins it to
+    prevent a future refactor from removing the timeout.
+    """
+    src = inspect.getsource(_poller_mod._StreamingWriter.request_approval)
+    assert "settimeout" in src, (
+        "poller.request_approval must set a socket timeout — otherwise a "
+        "stuck thin client (e.g. user walked away) hangs the daemon thread."
+    )
+    # The timeout returns "n" (denial) on timeout — fail closed for HITL.
+    assert 'return "n"' in src, (
+        "TimeoutError path must return 'n' (deny) — never default-allow on hang"
+    )
+
+
+def test_request_approval_returns_decision_on_socket_close() -> None:
+    """End-to-end: simulate a thin client that disconnects mid-prompt.
+    The daemon must return "n" (denial), not raise, not block forever.
+    """
+    fake_sock = MagicMock()
+    # recv returns empty bytes → connection closed
+    fake_sock.recv.return_value = b""
+    writer = _poller_mod._StreamingWriter(fake_sock)
+    decision = writer.request_approval("manage_login", "subcommand=use", "write")
+    assert decision == "n", "closed connection during HITL must default to denial (fail-closed)"

--- a/tests/test_signal_reload.py
+++ b/tests/test_signal_reload.py
@@ -185,3 +185,42 @@ def test_cmd_login_refresh_swallows_missing_auth_toml(
     assert not auth_path.exists()
     # Must not raise.
     cmd_login("refresh")
+
+
+def test_cmd_login_refresh_emits_observability_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """B2 v0.52.2 — refresh must emit an INFO log on success.
+
+    Pre-fix the success path was completely silent. Production
+    observability black hole — no way to verify the thin → daemon refresh
+    signal was firing in the field.
+    """
+    import logging
+
+    auth_path = tmp_path / "auth.toml"
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(auth_path))
+    _seed_auth_toml_with_plan("plan-observability")
+
+    # Reset singletons so the reload actually merges new entries.
+    from core.auth import plan_registry as _pr
+    from core.lifecycle import container as _infra
+
+    _infra._profile_store = None
+    _pr._plan_registry = None
+
+    with caplog.at_level(logging.INFO, logger="core.cli.commands"):
+        cmd_login("refresh")
+
+    messages = [rec.message for rec in caplog.records]
+    assert any("auth.toml reload" in m for m in messages), (
+        "cmd_login('refresh') must emit an INFO log on success — pre-v0.52.2 "
+        "this branch was silent and B7 fires were undetectable in production"
+    )
+    # The summary line must include count fields so SREs can see at a glance
+    # whether a refresh was a no-op vs. actually merged something.
+    summary = next(m for m in messages if "auth.toml reload" in m and "loaded=" in m)
+    assert "total_plans=" in summary
+    assert "total_profiles=" in summary
+    assert "new_plans=" in summary
+    assert "new_profiles=" in summary

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.2"
+version = "0.52.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.52.1 production incident (`/login oauth openai` → "안녕" → 40s thinking↔working loop + manage_login denied despite "A") 의 6 root cause 일괄 fix.
- 3 parallel reference research (defect scan + Hermes + OpenClaw) 결과 종합.
- 34 invariant test cases 동반.

## Why
사용자 transcript 에서 관찰된 incident:
1. OAuth flow 가 정상 완료 (Codex Plus 등록) — 그런데 "Stored: ~/.geode/auth.json" 표시 (실제는 auth.toml)
2. 다음 prompt "안녕" 보냈는데 model 이 GLM 으로 silent 회귀
3. GLM 잔액 부족 → 40초 동안 thinking↔working 무한 loop 처럼 보임 (실제 5×4 retry storm)
4. 별도로 manage_login 도구 호출 시 "A" 입력했는데도 120s 후 denial
5. GLM 거부 메시지에서 등록된 Codex Plus / Anthropic 사용 가능 여부 안 보임

각 증상이 독립된 root cause:
- **B6 (P0)**: `_approval_lock` 가 정의돼있는데 사용 안 됨 → parallel approval race
- **B4 (P0)**: 1113/insufficient_quota 가 retryable RateLimitError 로 분류 → 40s 헛돌이
- **B3 (P0)**: drift sync 가 quota 확인 없이 settings 의 stale 값 적용
- **B1 (P1)**: `AUTH_STORE_PATH` 가 v0.50.2 후에도 legacy `auth.json` constant alias
- **B2 (P1)**: cmd_login(refresh) 가 success 시 silent → production 검증 불가
- **B5 (P1)**: breadcrumb 가 활성 provider 만 보고함 → cross-provider 정보 0

## Changes
| File | Change |
|------|--------|
| `core/llm/errors.py` | **+79 lines** — `is_billing_fatal()`, `extract_billing_message()`, `_extract_error_body()`. GLM 1113/1114/1301, OpenAI insufficient_quota/billing_hard_limit, Anthropic permission_error. |
| `core/llm/fallback.py` | retryable_errors except block 진입 시점에 `is_billing_fatal()` 호출 → BillingError 즉시 raise (retry sleep 우회). |
| `core/agent/approval.py` | `apply_safety_gates` 의 WRITE/EXPENSIVE branch 를 `with self._approval_lock:` 로 wrap. 두번째 caller 가 lock 안에서 always-set re-check → "A" promotion 즉시 관측. |
| `core/agent/loop.py` | `_drift_target_is_healthy()` 신설 — `update_model()` 호출 전 `ProfileRotator.resolve(target_provider)` 결과 확인. None 이면 drift 거부 + WARNING. |
| `core/auth/oauth_login.py` | `auth_store_path()` 신설 — `auth_toml_path()` 위임. `emit_oauth_login_success(stored_at=...)` call site 갱신. `AUTH_STORE_PATH` 백워드 호환 alias 는 live resolve 결과로 초기화. |
| `core/cli/commands.py` | `cmd_login("refresh")` 가 reload 결과 INFO 로그 emit (file/loaded/new_plans/new_profiles/total counts + per-plan/profile lines). |
| `core/auth/credential_breadcrumb.py` | `_suggest_alternative_providers()` 신설 — 활성 provider 의 모든 profile 거부 시 다른 provider 의 healthy profile 스캔 → "cross-provider: ..." 라인 주입. |
| `core/config.py` | `llm_cross_provider_failover` default 명시적으로 False 유지 (자동 switch 는 v0.52.2 scope 외 — 정보 surface 만 추가). |
| **6 new test files** | `test_billing_fatal.py` (11), `test_parallel_approval.py` (5), `test_model_drift_health.py` (6), `test_oauth_path_display.py` (3), `test_credential_breadcrumb_cross_provider.py` (4), `test_signal_reload.py` +1 case for B2. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| B1 path lie | Implemented | auth_store_path() resolves via auth_toml_path() |
| B2 silent refresh | Implemented | INFO log + per-plan/profile lines |
| B3 drift health | Implemented | _drift_target_is_healthy() before update_model |
| B4 billing-fatal | Implemented | is_billing_fatal() + BillingError short-circuit |
| B5 cross-provider | Implemented | breadcrumb cross-provider line (auto-failover deferred to future patch) |
| B6 parallel approval | Implemented | _approval_lock wrap + always-set re-check |
| B7 MCP per-server health | Deferred | 별도 v0.52.3 patch 로 분리 — 17 MCP server connect 시점 status emit |

## Verification
- [x] `uv run ruff check core/ tests/` — All checks passed
- [x] `uv run mypy core/` — 0 issues, 231 files
- [x] `uv run pytest -m "not live"` — 4120 passed, 1 skipped (was 4086, +34 new)
- [x] regression check: 2 tests broke from initial cross_provider default flip → reverted (정보 surface 만 추가, auto-switch 는 future scope)

## Reference
- v0.52.1 production incident transcript (사용자 OAuth → GLM drift → 40s storm + parallel manage_login denial)
- 3 parallel reference agents:
  - OpenClaw: evaluate_eligibility, _LAST_VERDICTS, markAuthProfileGood, Lane fail-over, managedBy
  - Hermes (rsasaki0109/hermes-agent-rs): tracing::info!, error classification (no-false-retries by omission)
  - simonw/llm #112: billing/quota → log + surface + DO NOT retry