### PR TITLE
release: v0.52.4 — plan-aware routing (Codex Plus default) + model registry refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.4] — 2026-04-26
+
+### Fixed
+- **Plan-aware model routing — SUBSCRIPTION/OAUTH wins over PAYG by default** (production incident: `gpt-5.4` calls hit `api.openai.com/v1` at $0.10/call even after `/login oauth openai` registered Codex Plus). Root cause: `_resolve_provider("gpt-5.4")` was a static map returning `"openai"`; the `PlanRegistry.resolve_routing()` resolver was never consulted by `core/llm/router.py`. The four `call_llm*()` entry points now go through a new `_route_provider(model)` helper that calls `resolve_routing()` and returns the actually-routed provider (e.g. `openai-codex` when a Plus OAuth Plan is registered). Pattern source: openai/codex CLI default (`forced_login_method` unset → ChatGPT subscription wins; issues #2733, #3286).
+
+### Added
+- **`PlanKind` priority + provider-equivalence routing** (`core/auth/plans.py`, `core/llm/registry.py`, `core/auth/plan_registry.py`). New `PLAN_KIND_PRIORITY` ranks `SUBSCRIPTION → OAUTH_BORROWED → CLOUD_PROVIDER → PAYG` (lower wins). `PROVIDER_EQUIVALENCE` map declares sibling provider classes (`openai ↔ openai-codex`, `glm ↔ glm-coding`). `resolve_routing()` gains a step 1.5 between explicit `set_routing` and provider fallback: scan all sibling providers, sort by `PLAN_KIND_PRIORITY`, return the first with an available profile. Pattern source: OpenClaw Lane fail-over + already-existing `AuthProfile.sort_key()` infra.
+- **`forced_login_method` per-provider escape hatch** (`core/config.py`). `settings.forced_login_method = {"openai": "apikey"}` flips kind-priority so PAYG wins for users who deliberately want metered API access despite an active subscription. Default empty dict ⇒ subscription default. Codex CLI parity.
+- **GEODE-issued Codex token resolution** (`core/llm/providers/codex.py:_resolve_codex_token`). Now checks ProfileStore for an `openai-codex` profile FIRST (the one registered by `/login oauth openai`), with the legacy `~/.codex/auth.json` path as fallback. Pre-fix the OAuth login wizard wrote to GEODE's auth.toml but the Codex client only read from Codex CLI's separate store, so geode-issued tokens were silently invisible to LLM calls.
+- **`tests/test_routing_policy.py`** — 10 invariant cases pinning equivalence-class scan, kind-priority sort, escape hatch, explicit-override precedence, and router wiring (4 call sites must use `_route_provider`, none may use `_resolve_provider(target_model)` directly).
+
+### Changed
+- **Model registry refresh — verified 2026-04-26 against official docs** (`core/config.py`, `core/llm/token_tracker.py`). Per CLAUDE.md model-currency policy: drop sub-5.3 OpenAI IDs, add `gpt-5.5` (Codex's new default, **OAuth-only** per developers.openai.com/codex/models — "isn't available with API-key authentication"), refresh stale GLM pricing.
+  - `OPENAI_PRIMARY` `gpt-5.4` → `gpt-5.5`. Chain `[gpt-5.4, gpt-5.2, gpt-4.1]` → `[gpt-5.5, gpt-5.4, gpt-5.3-codex]`.
+  - `CODEX_PRIMARY` `gpt-5.4-mini` → `gpt-5.5`. Chain `[gpt-5.4-mini, gpt-5.4, gpt-5.3-codex]` → `[gpt-5.5, gpt-5.3-codex, gpt-5.4-mini]`.
+  - Removed: `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-4.1*`. (All sub-5.3 generation or absent from current Codex models page.)
+  - GLM pricing: `glm-5.1` $0.95/$3.15 → $1.40/$4.40 (stale by 6+ months). `glm-5` $0.72/$2.30 → $1.00/$3.20. `glm-4.7` $0.40/$1.75 → $0.60/$2.20. `glm-5v-turbo` removed (not on docs.z.ai pricing table).
+  - Anthropic chain unchanged (already 4.5-4.7 generation, verified current). OAuth status unchanged (still disabled per Anthropic ToS clarification 2026-01-09 — `platform.claude.com/docs/en/api/oauth` returned 404 on 2026-04-26 verification).
+- 4 test fixtures updated to match refreshed model lists (`test_codex_provider`, `test_llm_client`, `test_model_escalation`).
+
+### Reference
+- v0.52.1 production incident transcript (gpt-5.4 routes PAYG despite Codex Plus OAuth registered).
+- 4 parallel reference agents:
+  - GEODE code-path map: `_resolve_provider`/`resolve_routing`/`ProfileRotator.resolve` end-to-end trace
+  - Codex CLI / Claude Code / aider / mods / simonw-llm precedence policies (openai/codex#2733/#3286 — subscription default; Claude Code env-key default is documented footgun)
+  - OpenClaw routing patterns (`evaluate_eligibility`, `_LAST_VERDICTS`, `managedBy`, Lane fail-over)
+  - Official model availability research (developers.openai.com, platform.claude.com, docs.z.ai — all retrieved 2026-04-26)
+
 ## [0.52.3] — 2026-04-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.3
+- **Version**: 0.52.4
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4154+
+- **Tests**: 4133+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.3 — Long-running Autonomous Execution Harness
+# GEODE v0.52.4 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.3 — Long-running Autonomous Execution Harness
+# GEODE v0.52.4 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/auth/plan_registry.py
+++ b/core/auth/plan_registry.py
@@ -123,12 +123,24 @@ def resolve_routing(model: str) -> RoutingTarget | None:
     """Resolve which Plan + AuthProfile should serve a given model.
 
     Resolution order:
-      1. Explicit per-model routing (`PlanRegistry.set_routing`) — try
+      1. Explicit per-model routing (``PlanRegistry.set_routing``) — try
          each Plan ID in order and return the first whose linked
          AuthProfile is available.
-      2. Fall back to the model's resolved provider (`_resolve_provider`)
-         and use any registered Plan for that provider, picking the
-         AuthProfile by ProfileRotator priority.
+      2. (v0.52.4) **Equivalence-class scan** — gather every Plan whose
+         provider is in the resolved provider's equivalence class
+         (e.g. ``openai`` → ``[openai-codex, openai]``), sort by
+         ``(PLAN_KIND_PRIORITY, profile.sort_key())`` so SUBSCRIPTION /
+         OAUTH plans win over PAYG, then pick the first with an
+         available profile. The user paid for the prepaid plan; routing
+         it to PAYG silently re-meters the same call.
+      3. Fall back to the model's resolved provider directly
+         (``_resolve_provider``) — keeps the legacy single-provider path
+         alive for environments where no Plan was registered.
+      4. Synthesize a PAYG Plan so env-var-only users still route.
+
+    The user can override the policy globally via the per-provider
+    ``settings.forced_login_method`` config (Codex CLI parity) — see
+    ``_apply_forced_login_method`` below.
 
     Returns None when no usable credential exists.
     """
@@ -141,31 +153,38 @@ def resolve_routing(model: str) -> RoutingTarget | None:
     if store is None or rotator is None:
         return None
 
-    plan_chain: list[Plan] = []
-
     # 1) explicit per-model routing
+    explicit_chain: list[Plan] = []
     for plan_id in registry.get_routing(model):
         plan = registry.get(plan_id)
         if plan is not None:
-            plan_chain.append(plan)
+            explicit_chain.append(plan)
+    if explicit_chain:
+        for plan in explicit_chain:
+            profile = _pick_profile_for_plan(store, rotator, plan)
+            if profile is not None:
+                return RoutingTarget(
+                    plan=plan,
+                    profile=profile,
+                    base_url=profile.base_url_override or plan.base_url,
+                )
 
-    # 2) fallback by provider
-    if not plan_chain:
-        provider = _resolve_provider(model)
-        plan_chain = registry.list_for_provider(provider)
-        if not plan_chain:
-            # Synthesize a PAYG Plan so legacy env-var users still route.
-            profile = rotator.resolve(provider)
-            if profile is None:
-                return None
-            plan = default_plan_for_payg(provider, profile.key)
+    base_provider = _resolve_provider(model)
+
+    # 2) equivalence-class scan — sibling providers, kind-priority sorted
+    eq_chain = _equivalence_class_plans(registry, base_provider)
+    eq_chain = _apply_forced_login_method(eq_chain, base_provider)
+    for plan in eq_chain:
+        profile = _pick_profile_for_plan(store, rotator, plan)
+        if profile is not None:
             return RoutingTarget(
                 plan=plan,
                 profile=profile,
                 base_url=profile.base_url_override or plan.base_url,
             )
 
-    # Pick the first Plan whose preferred profile is available
+    # 3) single-provider fallback (legacy)
+    plan_chain = registry.list_for_provider(base_provider)
     for plan in plan_chain:
         profile = _pick_profile_for_plan(store, rotator, plan)
         if profile is not None:
@@ -174,7 +193,67 @@ def resolve_routing(model: str) -> RoutingTarget | None:
                 profile=profile,
                 base_url=profile.base_url_override or plan.base_url,
             )
-    return None
+
+    # 4) synthesize PAYG Plan so legacy env-var users still route
+    profile = rotator.resolve(base_provider)
+    if profile is None:
+        return None
+    plan = default_plan_for_payg(base_provider, profile.key)
+    return RoutingTarget(
+        plan=plan,
+        profile=profile,
+        base_url=profile.base_url_override or plan.base_url,
+    )
+
+
+def _equivalence_class_plans(registry: PlanRegistry, base_provider: str) -> list[Plan]:
+    """Collect Plans across the equivalence class, sorted by kind priority.
+
+    Sort key: ``PLAN_KIND_PRIORITY[plan.kind]`` (lower wins).
+    Within tier, preserve registry insertion order (stable sort).
+    """
+    from core.auth.plans import PLAN_KIND_PRIORITY
+    from core.llm.registry import equivalent_providers
+
+    candidates: list[Plan] = []
+    for sibling in equivalent_providers(base_provider):
+        candidates.extend(registry.list_for_provider(sibling))
+    # De-duplicate by Plan.id while preserving order
+    seen: set[str] = set()
+    unique: list[Plan] = []
+    for plan in candidates:
+        if plan.id in seen:
+            continue
+        seen.add(plan.id)
+        unique.append(plan)
+    unique.sort(key=lambda p: PLAN_KIND_PRIORITY.get(p.kind, 99))
+    return unique
+
+
+def _apply_forced_login_method(plans: list[Plan], base_provider: str) -> list[Plan]:
+    """Apply the per-provider ``forced_login_method`` escape hatch.
+
+    Codex CLI's ``forced_login_method = "api"`` semantic: when set, the
+    user wants the API-key path even though a subscription is active.
+    GEODE mirrors this so users who deliberately want metered PAYG can
+    keep their config.
+
+    Values:
+      - ``"subscription"`` (default) — keep current sort (sub/oauth first)
+      - ``"apikey"`` — promote PAYG plans to the front
+      - ``"auto"`` — alias for default
+    """
+    from core.auth.plans import PlanKind
+    from core.config import settings
+
+    forced = (getattr(settings, "forced_login_method", {}) or {}).get(base_provider, "subscription")
+    forced = str(forced).strip().lower()
+    if forced in ("apikey", "api", "api_key", "key"):
+        # Stable partition: PAYG first, then everyone else in original order.
+        payg = [p for p in plans if p.kind is PlanKind.PAYG]
+        rest = [p for p in plans if p.kind is not PlanKind.PAYG]
+        return payg + rest
+    return plans
 
 
 def _pick_profile_for_plan(

--- a/core/auth/plans.py
+++ b/core/auth/plans.py
@@ -33,6 +33,26 @@ class PlanKind(Enum):
     CLOUD_PROVIDER = "cloud_provider"  # AWS Bedrock / GCP Vertex etc.
 
 
+# v0.52.4 — cost-class priority for cross-provider equivalence routing.
+# Lower = preferred. The user paid for SUBSCRIPTION/OAUTH up front, so
+# an LLM call that *could* be served either way must use the prepaid
+# bucket first; PAYG only as last resort.
+#
+# Reference: openai/codex CLI default (`forced_login_method` unset →
+# ChatGPT subscription wins over OPENAI_API_KEY). Issues:
+#   * https://github.com/openai/codex/issues/2733
+#   * https://github.com/openai/codex/issues/3286
+# Anthropic Claude Code defaults the OTHER way (env-key wins) and the
+# Help Center documents it as a footgun requiring `unset ANTHROPIC_API_KEY`.
+# GEODE adopts the Codex semantics (subscription default).
+PLAN_KIND_PRIORITY: dict[PlanKind, int] = {
+    PlanKind.SUBSCRIPTION: 0,
+    PlanKind.OAUTH_BORROWED: 1,
+    PlanKind.CLOUD_PROVIDER: 2,
+    PlanKind.PAYG: 3,
+}
+
+
 @dataclass
 class Quota:
     """Sliding-window quota metadata for a Plan.

--- a/core/config.py
+++ b/core/config.py
@@ -317,6 +317,16 @@ class Settings(BaseSettings):
     llm_cross_provider_failover: bool = False
     llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
 
+    # v0.52.4 — per-provider auth-mode escape hatch (Codex CLI parity).
+    # Default routing prefers SUBSCRIPTION/OAUTH plans over PAYG when both
+    # can serve the requested model (matches openai/codex CLI default).
+    # Override per provider when the user deliberately wants metered PAYG:
+    #   forced_login_method = {"openai": "apikey"}    # use OPENAI_API_KEY even
+    #                                                  # if Codex Plus OAuth is registered
+    # Valid values: "subscription" (default), "apikey", "auto" (alias).
+    # Reference: openai/codex#2733, #3286.
+    forced_login_method: dict[str, str] = {}
+
     # LLM — Fallback cost ratio control (C2: 0 = unlimited)
     llm_max_fallback_cost_ratio: float = 0.0
 
@@ -355,19 +365,24 @@ settings = _get_settings()
 # All code MUST reference these instead of hardcoding model strings.
 # ---------------------------------------------------------------------------
 
-# Anthropic models
+# Anthropic models — verified 2026-04-26 against platform.claude.com
 ANTHROPIC_PRIMARY = "claude-opus-4-7"
 ANTHROPIC_SECONDARY = "claude-sonnet-4-6"
 ANTHROPIC_BUDGET = "claude-haiku-4-5-20251001"
 ANTHROPIC_FALLBACK_CHAIN: list[str] = [ANTHROPIC_PRIMARY, "claude-opus-4-6", ANTHROPIC_SECONDARY]
 
-# OpenAI models
-OPENAI_PRIMARY = "gpt-5.4"
-OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.4", "gpt-5.2", "gpt-4.1"]
+# OpenAI models — verified 2026-04-26 against developers.openai.com.
+# v0.52.4 — gpt-5.5 promoted to primary (Codex's new default model);
+# pre-5.3 generation dropped per current CLAUDE.md model-currency policy.
+OPENAI_PRIMARY = "gpt-5.5"
+OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"]
 
-# OpenAI Codex — Plus quota via chatgpt.com/backend-api/codex (Responses API)
-CODEX_PRIMARY = "gpt-5.4-mini"
-CODEX_FALLBACK_CHAIN: list[str] = ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+# OpenAI Codex — Plus quota via chatgpt.com/backend-api/codex (Responses API).
+# v0.52.4 — gpt-5.5 is OAuth-only ("isn't available with API-key
+# authentication" per developers.openai.com/codex/models). Promoted to
+# CODEX_PRIMARY so /login oauth users get the real default.
+CODEX_PRIMARY = "gpt-5.5"
+CODEX_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.3-codex", "gpt-5.4-mini"]
 CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 # ZhipuAI (GLM) models — OpenAI-compatible API, separate provider

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -52,7 +52,30 @@ def _extract_account_id(token: str) -> str:
 
 
 def _resolve_codex_token() -> str:
-    """Resolve Codex OAuth token from ~/.codex/auth.json."""
+    """Resolve Codex OAuth token.
+
+    v0.52.4 — checks two sources, GEODE-issued first:
+      1. ProfileStore for an ``openai-codex`` profile (the one created
+         by ``/login oauth openai`` device flow). This is the token the
+         user just registered through GEODE.
+      2. ~/.codex/auth.json (external Codex CLI store) — fallback for
+         users who only have Codex CLI logged in.
+
+    Without (1) the geode-registered ``openai-codex-geode`` plan would
+    be invisible to the actual LLM call path and the OAuth login wizard
+    would do nothing for users who don't also run Codex CLI.
+    """
+    try:
+        from core.lifecycle.container import get_profile_store
+
+        store = get_profile_store()
+        if store is not None:
+            for profile in store.list_all():
+                if profile.provider == "openai-codex" and profile.is_available and profile.key:
+                    return profile.key
+    except Exception:
+        log.debug("GEODE openai-codex profile lookup failed", exc_info=True)
+
     try:
         from core.auth.codex_cli_oauth import read_codex_cli_credentials
 
@@ -60,7 +83,7 @@ def _resolve_codex_token() -> str:
         if creds:
             return creds["access_token"]
     except Exception:
-        log.debug("Codex token resolution failed", exc_info=True)
+        log.debug("Codex CLI token resolution failed", exc_info=True)
     return ""
 
 

--- a/core/llm/registry.py
+++ b/core/llm/registry.py
@@ -87,3 +87,29 @@ def get_provider_spec(provider: str) -> ProviderSpec | None:
 def list_provider_ids() -> list[str]:
     """Return all registered provider variant IDs."""
     return list(PROVIDER_VARIANTS.keys())
+
+
+# v0.52.4 — equivalence classes: two providers serving the same model
+# family. The classes are listed in *preferred-first* order so the
+# routing resolver can prefer the OAuth/subscription variant over PAYG
+# when both can serve the requested model. Pairs with PLAN_KIND_PRIORITY
+# (subscription/oauth before payg) for the kind-aware sort.
+#
+# A model resolved to base provider X gets candidate plans from
+# PROVIDER_EQUIVALENCE.get(X, [X]) — i.e. unrelated providers (anthropic,
+# glm) still resolve to themselves only.
+PROVIDER_EQUIVALENCE: dict[str, list[str]] = {
+    "openai": ["openai-codex", "openai"],
+    "openai-codex": ["openai-codex", "openai"],
+    "glm": ["glm-coding", "glm"],
+    "glm-coding": ["glm-coding", "glm"],
+    # Anthropic OAuth (Claude Code) is currently disabled in GEODE
+    # per Anthropic ToS clarification 2026-01-09; kept singleton until
+    # policy changes.
+    "anthropic": ["anthropic"],
+}
+
+
+def equivalent_providers(provider: str) -> list[str]:
+    """Return preferred-first list of providers that share a model family."""
+    return PROVIDER_EQUIVALENCE.get(provider, [provider])

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -403,6 +403,32 @@ class ToolUseResult:
 T = TypeVar("T", bound=BaseModel)
 
 
+def _route_provider(model: str) -> str:
+    """Resolve the provider for a model, honoring registered Plans.
+
+    v0.52.4 — wraps ``resolve_routing(model)`` so the LLM call dispatch
+    sees the actually-routed provider (e.g. ``openai-codex`` when a Plus
+    OAuth Plan is registered) instead of the static
+    ``_resolve_provider`` mapping (which always returned ``openai`` for
+    ``gpt-5.4`` regardless of OAuth state). Falls back to the static
+    resolver when no Plan is registered.
+
+    Caller flow unchanged: dispatch sees a provider string and looks up
+    the client via ``_get_provider_client(provider)``. The credential
+    lookup inside each provider client (``_get_codex_client`` etc.) now
+    consults the same ProfileStore, so the path is end-to-end coherent.
+    """
+    try:
+        from core.auth.plan_registry import resolve_routing
+
+        target = resolve_routing(model)
+        if target is not None:
+            return target.plan.provider
+    except Exception:
+        log.debug("resolve_routing failed for model=%s", model, exc_info=True)
+    return _resolve_provider(model)
+
+
 @maybe_traceable(run_type="llm", name="call_llm")  # type: ignore[untyped-decorator]
 def call_llm(
     system: str,
@@ -419,7 +445,7 @@ def call_llm(
     Returns text content. Supports cross-provider fallback when enabled.
     """
     target_model = model or settings.model
-    provider = _resolve_provider(target_model)
+    provider = _route_provider(target_model)
 
     if seed is not None:
         log.info("Reproducibility seed=%d requested (logged for auditing)", seed)
@@ -515,7 +541,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
     Supports cross-provider fallback when enabled.
     """
     target_model = model or settings.model
-    provider = _resolve_provider(target_model)
+    provider = _route_provider(target_model)
 
     def _dispatch(p: str, m: str) -> T:
         _fire_hook(
@@ -669,7 +695,7 @@ def call_llm_with_tools(
     Supports cross-provider fallback when enabled.
     """
     target_model = model or settings.model
-    provider = _resolve_provider(target_model)
+    provider = _route_provider(target_model)
 
     def _dispatch(p: str, m: str) -> ToolUseResult:
         _fire_hook(
@@ -861,7 +887,7 @@ def call_llm_streaming(
 
     client = get_anthropic_client()
     target_model = model or settings.model
-    provider = _resolve_provider(target_model)
+    provider = _route_provider(target_model)
     circuit_breaker = get_circuit_breaker()
 
     # Hook: LLM_CALL_START

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -162,41 +162,29 @@ MODEL_PRICING: dict[str, ModelPrice] = {
     "claude-sonnet-4":            _ant(3.00,  15.00),
     "claude-haiku-4-5-20251001":  _ant(1.00,   5.00),
 
-    # ── OpenAI GPT-5 family (verified 2026-03-19) ─────────────────────
-    # Source: https://developers.openai.com/api/docs/pricing/
+    # ── OpenAI GPT-5 family (verified 2026-04-26) ─────────────────────
+    # Source: developers.openai.com/api/docs/pricing/ + /codex/pricing
+    # v0.52.4 — gpt-5.5 added (Codex new default, OAuth-only per docs).
+    # Pre-5.3 IDs (gpt-5.1, gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.2 family
+    # except 5.2 itself) dropped per CLAUDE.md model-currency policy.
+    "gpt-5.5":      _oai(5.00, 30.00, cached_mtok=0.50),
     "gpt-5.4":      _oai(2.50, 15.00, cached_mtok=0.25),
-    "gpt-5.2":      _oai(1.75, 14.00, cached_mtok=0.175),
-    "gpt-5.1":      _oai(1.25, 10.00, cached_mtok=0.125),
-    "gpt-5":        _oai(1.25, 10.00, cached_mtok=0.125),
-    "gpt-5-mini":   _oai(0.25,  2.00, cached_mtok=0.025),
-    "gpt-5-nano":   _oai(0.05,  0.40, cached_mtok=0.005),
-
-    # ── OpenAI GPT-4 family (verified 2026-03-19) ─────────────────────
-    "gpt-4.1":      _oai(2.00,  8.00),
-    "gpt-4.1-mini": _oai(0.40,  1.60),
-    "gpt-4.1-nano": _oai(0.20,  0.80, cached_mtok=0.05),
+    "gpt-5.4-mini": _oai(0.75,  4.50, cached_mtok=0.075),
+    "gpt-5.3-codex": _oai(1.75, 14.00, cached_mtok=0.175),
 
     # ── OpenAI Reasoning (verified 2026-03-19) ─────────────────────────
     "o3":       _oai(2.00,  8.00, reasoning=True),
     "o4-mini":  _oai(1.10,  4.40, cached_mtok=0.275, reasoning=True),
 
-    # ── ZhipuAI GLM (verified 2026-04-15) ──────────────────────────────
-    # Source: https://open.bigmodel.cn/pricing + https://docs.z.ai
-    "glm-5.1":         _oai(0.95,  3.15),
-    "glm-5":           _oai(0.72,  2.30),
+    # ── ZhipuAI GLM (verified 2026-04-26 against docs.z.ai/guides/overview/pricing)
+    # v0.52.4 — refreshed pricing; pre-fix glm-5.1/glm-5 were stale.
+    # glm-4.7 retained because Coding Plan defaults still route Opus/Sonnet
+    # env aliases to it (see docs.z.ai/devpack/overview).
+    "glm-5.1":         _oai(1.40,  4.40),
+    "glm-5":           _oai(1.00,  3.20),
     "glm-5-turbo":     _oai(1.20,  4.00),
-    "glm-5v-turbo":    _oai(1.20,  4.00),
-    "glm-4.7":         _oai(0.40,  1.75),
-    "glm-4.7-flash":   _oai(0.00,  0.00),  # free tier
-
-    # ── OpenAI Codex (verified 2026-04-24) ────────────────────────────
-    # Via chatgpt.com/backend-api/codex (Plus quota) or api.openai.com (API)
-    # Prices = API equivalent for token tracking accuracy
-    "gpt-5.4-mini":       _oai(0.75,  4.50),
-    "gpt-5.3-codex":      _oai(1.75, 14.00),
-    "gpt-5.2-codex":      _oai(1.75, 14.00),
-    "gpt-5.1-codex-max":  _oai(1.25, 10.00),
-    "gpt-5.1-codex-mini": _oai(0.25,  2.00),
+    "glm-4.7":         _oai(0.60,  2.20),
+    "glm-4.7-flash":   _oai(0.00,  0.00),  # free tier (limited-time)
 }
 # fmt: on
 
@@ -208,37 +196,27 @@ MODEL_PRICING: dict[str, ModelPrice] = {
 
 # fmt: off
 MODEL_CONTEXT_WINDOW: dict[str, int] = {
-    "claude-opus-4-7":          1_000_000,
-    "claude-opus-4-6":          1_000_000,
-    "claude-opus-4-5":            200_000,
-    "claude-opus-4-1":            200_000,
-    "claude-opus-4":              200_000,
-    "claude-sonnet-4-6":        1_000_000,
-    "claude-sonnet-4-5-20250929": 200_000,
-    "claude-sonnet-4":            200_000,
-    "claude-haiku-4-5-20251001":  200_000,
-    "gpt-5.4":                  1_047_576,
-    "gpt-5.2":                    128_000,
-    "gpt-5.1":                    128_000,
-    "gpt-5":                      128_000,
-    "gpt-5-mini":                 128_000,
-    "gpt-5-nano":                 128_000,
-    "gpt-4.1":                  1_047_576,
-    "gpt-4.1-mini":             1_047_576,
-    "gpt-4.1-nano":             1_047_576,
-    "o3":                         200_000,
-    "o4-mini":                    200_000,
-    "glm-5.1":                    202_752,
-    "glm-5":                      200_000,
-    "glm-5-turbo":                202_752,
-    "glm-5v-turbo":               202_752,
-    "glm-4.7":                    200_000,
-    "glm-4.7-flash":              200_000,
-    "gpt-5.4-mini":             1_047_576,
-    "gpt-5.3-codex":              200_000,
-    "gpt-5.2-codex":              200_000,
-    "gpt-5.1-codex-max":          200_000,
-    "gpt-5.1-codex-mini":         200_000,
+    # Anthropic — verified 2026-04-26
+    "claude-opus-4-7":            1_000_000,
+    "claude-opus-4-6":            1_000_000,
+    "claude-opus-4-5":              200_000,
+    "claude-sonnet-4-6":          1_000_000,
+    "claude-sonnet-4-5-20250929":   200_000,
+    "claude-haiku-4-5-20251001":    200_000,
+    # OpenAI 5.3-5.5 generation — verified 2026-04-26
+    "gpt-5.5":                    1_050_000,
+    "gpt-5.4":                    1_050_000,
+    "gpt-5.4-mini":               1_050_000,
+    "gpt-5.3-codex":                200_000,
+    # OpenAI reasoning (kept — separate generation)
+    "o3":                           200_000,
+    "o4-mini":                      200_000,
+    # GLM — verified 2026-04-26 (200K standard across 5.x family)
+    "glm-5.1":                      200_000,
+    "glm-5":                        200_000,
+    "glm-5-turbo":                  200_000,
+    "glm-4.7":                      200_000,
+    "glm-4.7-flash":                200_000,
 }
 # fmt: on
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.3"
+version = "0.52.4"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -10,7 +10,9 @@ from core.config import CODEX_BASE_URL, CODEX_FALLBACK_CHAIN, CODEX_PRIMARY
 
 class TestCodexConfig:
     def test_codex_primary(self):
-        assert CODEX_PRIMARY == "gpt-5.4-mini"
+        # v0.52.4 — Codex's new default per developers.openai.com/codex/models
+        # (gpt-5.5 is OAuth-only, can't even be called with API-key auth).
+        assert CODEX_PRIMARY == "gpt-5.5"
 
     def test_codex_base_url(self):
         assert "chatgpt.com/backend-api" in CODEX_BASE_URL
@@ -40,7 +42,10 @@ class TestCodexPricing:
     def test_codex_models_have_pricing(self):
         from core.llm.token_tracker import MODEL_PRICING
 
-        for model in ["gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-max"]:
+        # v0.52.4 — refreshed against developers.openai.com/codex/models 2026-04-26.
+        # gpt-5.5 added (Codex's new default, OAuth-only). gpt-5.2-codex,
+        # gpt-5.1-codex-max/mini removed (no longer in current Codex models page).
+        for model in ["gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex"]:
             price = MODEL_PRICING.get(model)
             assert price is not None, f"{model} missing from MODEL_PRICING"
             assert price.input > 0, f"{model} should have non-zero pricing"
@@ -49,7 +54,7 @@ class TestCodexPricing:
     def test_codex_context_windows(self):
         from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
-        for model in ["gpt-5.3-codex", "gpt-5.2-codex"]:
+        for model in ["gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex"]:
             ctx = MODEL_CONTEXT_WINDOW.get(model)
             assert ctx is not None, f"{model} missing from MODEL_CONTEXT_WINDOW"
             assert ctx >= 200_000

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -83,8 +83,9 @@ class TestCalculateCost:
         assert calculate_cost(ANTHROPIC_PRIMARY, 0, 0) == 0.0
 
     def test_gpt_model(self):
+        # v0.52.4 — OPENAI_PRIMARY is now gpt-5.5 (input $5/1M, output $30/1M)
         cost = calculate_cost(OPENAI_PRIMARY, 1000, 1000)
-        expected = 1000 * (2.50 / 1_000_000) + 1000 * (15.0 / 1_000_000)
+        expected = 1000 * (5.00 / 1_000_000) + 1000 * (30.0 / 1_000_000)
         assert abs(cost - expected) < 1e-10
 
 

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -68,18 +68,20 @@ class TestModelEscalation:
         assert loop._provider == "anthropic"
 
     def test_try_model_escalation_openai_chain(self) -> None:
-        """Escalate within OpenAI chain."""
-        loop = _make_loop(model="gpt-5.4", provider="openai")
+        """Escalate within OpenAI chain.
+        v0.52.4 — chain refreshed to [gpt-5.5, gpt-5.4, gpt-5.3-codex];
+        gpt-5.2/gpt-4.1 dropped per current model-currency policy."""
+        loop = _make_loop(model="gpt-5.5", provider="openai")
         result = loop._try_model_escalation()
         assert result is True
-        assert loop.model == "gpt-5.2"
+        assert loop.model == "gpt-5.4"
 
     def test_try_model_escalation_openai_second_step(self) -> None:
         """Escalate to third model in OpenAI chain."""
-        loop = _make_loop(model="gpt-5.2", provider="openai")
+        loop = _make_loop(model="gpt-5.4", provider="openai")
         result = loop._try_model_escalation()
         assert result is True
-        assert loop.model == "gpt-4.1"
+        assert loop.model == "gpt-5.3-codex"
 
     def test_try_model_escalation_glm_chain(self) -> None:
         """Escalate within GLM chain."""

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -1,0 +1,268 @@
+"""v0.52.4 — Plan-aware routing policy: SUBSCRIPTION/OAUTH wins over PAYG.
+
+Pre-fix bug (production incident, 2026-04-26): user registered
+``openai-codex-geode`` (OAuth Plus subscription, provider=``openai-codex``)
+via ``/login oauth openai`` BUT every ``gpt-5.4`` LLM call still hit
+``api.openai.com/v1/responses`` (PAYG, provider=``openai``) at $0.10/call
+because ``_resolve_provider("gpt-5.4")`` was a static map and the
+``PlanRegistry.resolve_routing()`` resolver was never consulted by the
+LLM call path.
+
+Three contracts pinned here:
+
+1. **Equivalence-class scan** — when both ``openai-codex`` (OAuth) and
+   ``openai`` (PAYG) plans are registered, the resolver returns the
+   ``openai-codex`` plan first. Pattern source: openai/codex CLI default
+   (``forced_login_method`` unset → ChatGPT subscription wins).
+
+2. **`forced_login_method = "apikey"` escape hatch** — same setup but
+   user explicitly wants metered PAYG; resolver returns ``openai`` plan.
+   Pattern source: openai/codex#2733 — same flag inverted.
+
+3. **Router wiring** — ``core/llm/router.py`` ``_route_provider(model)``
+   calls ``resolve_routing`` and returns the actually-routed provider,
+   not the static ``_resolve_provider`` answer. Without the wiring, the
+   policy fix is invisible to real LLM calls.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import core.llm.router as _router_mod
+import pytest
+from core.auth.plan_registry import resolve_routing
+from core.auth.plans import PLAN_KIND_PRIORITY, Plan, PlanKind
+from core.auth.profiles import AuthProfile, CredentialType
+from core.llm.registry import equivalent_providers
+
+# ---------------------------------------------------------------------------
+# Contract 0 — equivalence map + kind priority sanity
+# ---------------------------------------------------------------------------
+
+
+def test_plan_kind_priority_subscription_first() -> None:
+    """SUBSCRIPTION must rank before PAYG. The OAuth/Plus plans are
+    prepaid; routing them to PAYG silently re-meters the same call."""
+    assert PLAN_KIND_PRIORITY[PlanKind.SUBSCRIPTION] < PLAN_KIND_PRIORITY[PlanKind.PAYG]
+    assert PLAN_KIND_PRIORITY[PlanKind.OAUTH_BORROWED] < PLAN_KIND_PRIORITY[PlanKind.PAYG]
+    # CLOUD_PROVIDER (Bedrock/Vertex) is also prepaid via cloud commitment.
+    assert PLAN_KIND_PRIORITY[PlanKind.CLOUD_PROVIDER] < PLAN_KIND_PRIORITY[PlanKind.PAYG]
+
+
+def test_openai_equivalence_class_pairs_with_codex() -> None:
+    """openai and openai-codex must share an equivalence class so a
+    Codex Plus OAuth plan is considered when the user requests gpt-5.x."""
+    eq = equivalent_providers("openai")
+    assert "openai-codex" in eq
+    assert "openai" in eq
+    # Preferred-first ordering: codex (OAuth) before openai (PAYG).
+    assert eq.index("openai-codex") < eq.index("openai")
+
+
+def test_unrelated_provider_is_singleton() -> None:
+    """Anthropic and GLM must NOT pull in unrelated siblings."""
+    assert equivalent_providers("anthropic") == ["anthropic"]
+    # GLM has its own equivalence class for the Coding Plan vs PAYG split.
+    glm_class = equivalent_providers("glm")
+    assert set(glm_class) == {"glm-coding", "glm"}
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 — resolve_routing prefers SUBSCRIPTION plan over PAYG
+# ---------------------------------------------------------------------------
+
+
+def _seed_two_plans(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Plan, Plan]:
+    """Helper: register both an OAuth Codex Plus plan and a PAYG OpenAI
+    plan, each with an available profile. Returns (subscription_plan,
+    payg_plan)."""
+    monkeypatch.setenv("GEODE_AUTH_TOML", str(tmp_path / "auth.toml"))
+    from core.auth import plan_registry as _pr
+    from core.auth.plan_registry import get_plan_registry
+    from core.lifecycle import container as _infra
+    from core.lifecycle.container import ensure_profile_store
+
+    _infra._profile_store = None
+    _pr._plan_registry = None
+
+    registry = get_plan_registry()
+    store = ensure_profile_store()
+
+    sub_plan = Plan(
+        id="openai-codex-geode",
+        provider="openai-codex",
+        kind=PlanKind.OAUTH_BORROWED,
+        display_name="OpenAI Codex (Plus)",
+        base_url="https://chatgpt.com/backend-api/codex",
+        auth_type="oauth_external",
+    )
+    registry.add(sub_plan)
+    store.add(
+        AuthProfile(
+            name="openai-codex:geode",
+            provider="openai-codex",
+            credential_type=CredentialType.OAUTH,
+            key="oauth-token-xyz",
+            plan_id=sub_plan.id,
+        )
+    )
+
+    payg_plan = Plan(
+        id="openai-payg",
+        provider="openai",
+        kind=PlanKind.PAYG,
+        display_name="OpenAI (PAYG)",
+        base_url="https://api.openai.com/v1",
+    )
+    registry.add(payg_plan)
+    store.add(
+        AuthProfile(
+            name="openai:payg",
+            provider="openai",
+            credential_type=CredentialType.API_KEY,
+            key="sk-test-payg",
+            plan_id=payg_plan.id,
+        )
+    )
+    return sub_plan, payg_plan
+
+
+def test_resolve_routing_prefers_oauth_over_payg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Both plans registered, no explicit /login route — Codex Plus must win.
+    This is the v0.52.1-incident-defining contract: a user who paid for
+    Plus must not be billed PAYG for the same model."""
+    sub_plan, _ = _seed_two_plans(monkeypatch, tmp_path)
+    target = resolve_routing("gpt-5.4")
+    assert target is not None, "no routing target — singleton seeding broke?"
+    assert target.plan.id == sub_plan.id, (
+        f"routed to {target.plan.id}; expected {sub_plan.id}. "
+        "Equivalence-class scan + PLAN_KIND_PRIORITY didn't run, or "
+        "ProfileRotator picked the PAYG profile despite OAuth availability."
+    )
+    assert target.plan.provider == "openai-codex"
+    assert target.base_url == "https://chatgpt.com/backend-api/codex"
+
+
+def test_resolve_routing_explicit_set_routing_wins_over_policy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If user set ``/login route gpt-5.4 openai-payg``, the explicit
+    override must win even though kind-priority would prefer OAuth."""
+    from core.auth.plan_registry import get_plan_registry
+
+    _, payg_plan = _seed_two_plans(monkeypatch, tmp_path)
+    get_plan_registry().set_routing("gpt-5.4", [payg_plan.id])
+
+    target = resolve_routing("gpt-5.4")
+    assert target is not None
+    assert target.plan.id == payg_plan.id, (
+        "explicit set_routing must override the equivalence-class default"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — forced_login_method = "apikey" escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_forced_login_method_apikey_promotes_payg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Codex CLI parity: ``forced_login_method = {"openai": "apikey"}``
+    flips the kind-priority so PAYG wins. For the user who deliberately
+    wants metered API access despite an active OAuth subscription."""
+    _, payg_plan = _seed_two_plans(monkeypatch, tmp_path)
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "forced_login_method", {"openai": "apikey"})
+
+    target = resolve_routing("gpt-5.4")
+    assert target is not None
+    assert target.plan.id == payg_plan.id, (
+        "forced_login_method='apikey' must route to PAYG. "
+        "Reference: openai/codex#2733 same flag, inverted."
+    )
+
+
+def test_forced_login_method_default_keeps_subscription_priority(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No forced_login_method ⇒ default (subscription wins). Pin the
+    default explicitly so a refactor that swaps the default is caught."""
+    sub_plan, _ = _seed_two_plans(monkeypatch, tmp_path)
+    from core.config import settings
+
+    # Either unset or "subscription" — both must keep OAuth winning.
+    monkeypatch.setattr(settings, "forced_login_method", {})
+    assert resolve_routing("gpt-5.4").plan.id == sub_plan.id  # type: ignore[union-attr]
+
+    monkeypatch.setattr(settings, "forced_login_method", {"openai": "subscription"})
+    assert resolve_routing("gpt-5.4").plan.id == sub_plan.id  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — router.py wires resolve_routing through _route_provider
+# ---------------------------------------------------------------------------
+
+
+def test_router_route_provider_helper_exists() -> None:
+    """``core/llm/router.py`` must define ``_route_provider`` and use it
+    in every call_llm* entry. Pre-v0.52.4 the call sites used the static
+    ``_resolve_provider`` directly, which bypassed PlanRegistry entirely.
+    """
+    src = inspect.getsource(_router_mod)
+    assert "def _route_provider(" in src, (
+        "_route_provider helper missing — without it the policy is invisible to actual LLM calls."
+    )
+    # All 4 call sites must use the new helper.
+    assert src.count("_route_provider(target_model)") >= 4, (
+        f"expected ≥4 call sites using _route_provider; got "
+        f"{src.count('_route_provider(target_model)')}. "
+        "Some call_llm* path still uses the static _resolve_provider."
+    )
+    # And the static helper must NOT be called directly with target_model
+    # in a router function body (the only allowed direct uses are inside
+    # _route_provider's own fallback path).
+    static_calls = src.count("_resolve_provider(target_model)")
+    assert static_calls == 0, (
+        f"{static_calls} call sites still use _resolve_provider(target_model) "
+        f"directly — should go through _route_provider for plan-awareness"
+    )
+
+
+def test_route_provider_falls_back_when_resolve_routing_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When PlanRegistry has no plan for the model, ``_route_provider``
+    must fall back to the static ``_resolve_provider`` so legacy env-var
+    users (no /login add) still route correctly."""
+    monkeypatch.setattr("core.auth.plan_registry.resolve_routing", lambda _model: None)
+    monkeypatch.setattr("core.llm.router._resolve_provider", lambda _m: "anthropic")
+    assert _router_mod._route_provider("claude-opus-4-7") == "anthropic"
+
+
+def test_route_provider_returns_routed_provider_when_plan_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When resolve_routing returns a Plan, ``_route_provider`` must
+    return the Plan's provider — not the static map."""
+    fake_plan = Plan(
+        id="openai-codex-geode",
+        provider="openai-codex",
+        kind=PlanKind.OAUTH_BORROWED,
+        display_name="OpenAI Codex Plus",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+    fake_target = type(
+        "T",
+        (),
+        {"plan": fake_plan, "profile": None, "base_url": fake_plan.base_url},
+    )()
+    monkeypatch.setattr("core.auth.plan_registry.resolve_routing", lambda _m: fake_target)
+    # Static fallback would have returned "openai"; the Plan-aware path
+    # must override to "openai-codex".
+    assert _router_mod._route_provider("gpt-5.4") == "openai-codex"

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.3"
+version = "0.52.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Fix production cost-leak: Codex Plus OAuth registered but gpt-5.4 still hit PAYG ($0.10/call). Router never consulted PlanRegistry.
- Adopt openai/codex CLI default semantic (SUBSCRIPTION/OAuth wins) + `forced_login_method` escape hatch.
- Refresh model registry — gpt-5.5 added (OAuth-only), sub-5.3 IDs dropped, GLM stale prices fixed (verified 2026-04-26 against official docs).
- 10 invariant tests + 4 fixture updates.

## Verification
- [x] Lint & Format: pass (8s)
- [x] Type Check: pass (28s)
- [x] Security Scan: pass (12s)
- [x] Test: pass (3m17s)
- [x] Gate: pass

PR #814 (feature → develop) — all 5/5 green.