### PR TITLE
release: v0.52.6 — Codex max_output_tokens hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.6] — 2026-04-27
+
+### Fixed
+- **Codex backend rejected every call with 400 — `max_output_tokens` not allowed** (production hotfix). Every call to `https://chatgpt.com/backend-api/codex/responses` returned `{'detail': 'Unsupported parameter: max_output_tokens'}`, hitting all 3 fallback Codex models × 5 retries × exp-backoff for ~30s before the circuit breaker opened. Plus subscription manages output limits server-side; client cap is forbidden. Removed the kwarg from `CodexAgenticAdapter.agentic_call`'s `client.responses.stream(...)` call. (`core/llm/providers/codex.py:228`)
+- **400 "Unsupported parameter" / "Invalid value" retried** — same fail-fast shape as the v0.52.3 billing-fatal storm. Added `is_request_fatal(exc)` in `core/llm/errors.py` that recognises 4xx (non-429) bodies with markers `unsupported parameter`, `invalid parameter`, `invalid value for parameter`, `unknown parameter`, `missing required parameter`. `fallback.retry_with_backoff_generic`'s `bad_request` branch re-raises immediately so the same backend rejection cannot cascade across retries + fallback models.
+
+### Added
+- **`docs/research/codex-oauth-request-spec.md`** — definitive Codex OAuth request spec grounded in 3 reference codebases (Hermes Agent `agent/transports/codex.py`, OpenClaw `src/agents/openai-transport-stream.ts`, Codex CLI Rust `codex-rs/codex-api/src/common.rs`). Documents required headers, required body fields, and a FORBIDDEN list (`max_output_tokens`, `max_tokens`, `top_p`, `presence_penalty`, `frequency_penalty`, `seed`, `n`, `stop`, `logprobs`). Future-proofs against Codex backend spec changes.
+- **`tests/test_codex_request_shape.py`** — 13 invariant cases covering Codex adapter source-level (no `max_output_tokens` in `responses.stream` call) + functional (`is_request_fatal` recognises 5 marker shapes, ignores 429/500, fallback loop re-raises without retry).
+
+### Backlog (v0.52.7 — separate scope)
+- Per the new spec doc, GEODE Codex adapter still has 3 gaps (NOT cause of the 400 incident, but real):
+  - `tools` / `tool_choice` / `parallel_tool_calls` never sent → function calling broken on Codex
+  - `include=["reasoning.encrypted_content"]` + `reasoning={effort, summary}` never sent → encrypted reasoning lost across turns on gpt-5.x-codex
+  - `temperature` sent unconditionally; Hermes uses `_fixed_temperature_for_model` to OMIT for gpt-5.x-codex
+
+### Reference
+- Production daemon log 2026-04-27 (every Codex call → 400 → circuit breaker OPEN within ~30s)
+- Hermes Agent `agent/transports/codex.py:123-125` — `if max_tokens is not None and not is_codex_backend: kwargs["max_output_tokens"] = max_tokens`
+- Codex CLI Rust `codex-rs/codex-api/src/common.rs:117-133` — `ResponsesApiRequest` struct has no `max_output_tokens` field
+- OpenClaw `src/agents/openai-transport-stream.ts:751-753` — `buildOpenAIResponsesParams` only adds `max_output_tokens` when caller passes `options.maxTokens`; Codex callers don't
+
 ## [0.52.5] — 2026-04-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.5
+- **Version**: 0.52.6
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4144+
+- **Tests**: 4157+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.5 — Long-running Autonomous Execution Harness
+# GEODE v0.52.6 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.5 — Long-running Autonomous Execution Harness
+# GEODE v0.52.6 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -176,6 +176,55 @@ def is_billing_fatal(exc: Exception) -> bool:
     )
 
 
+def is_request_fatal(exc: Exception) -> bool:
+    """Return True if exc is a 400-class permanent error that cannot be cured by retry.
+
+    v0.52.6 — extends the v0.52.3 ``is_billing_fatal`` shape to cover
+    request-shape errors that the same backend will reject on every
+    attempt. Production trigger: Codex backend rejected
+    ``max_output_tokens`` with 400 ``"Unsupported parameter: max_output_tokens"``;
+    the retry loop hammered the same 400 across 5 attempts × 3 fallback
+    models = ~30s wasted before the circuit breaker opened.
+
+    We match on a small allow-list of HTTP status / detail substrings so
+    a transient 400 (e.g. malformed JSON in a streamed body) doesn't
+    accidentally short-circuit. The caller should raise the original
+    exception (no separate exception type) — the loop's outer handler
+    treats it as terminal because the retryable_errors filter excludes
+    BadRequestError already.
+    """
+    # Status check first — only true 400-class shapes qualify.
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        if response is not None:
+            status = getattr(response, "status_code", None)
+    if status is not None and not (400 <= int(status) < 500 and int(status) != 429):
+        return False
+
+    body = _extract_error_body(exc) or {}
+    detail = str(body.get("detail") or body.get("message") or "").lower()
+    err_obj = body.get("error")
+    if isinstance(err_obj, dict):
+        detail = detail or str(err_obj.get("message") or "").lower()
+    if not detail:
+        # No structured detail — fall back to the exception text. Codex
+        # backend uses ``{'detail': '...'}`` so this branch handles
+        # custom shapes from other providers too.
+        detail = str(exc).lower()
+
+    return any(
+        marker in detail
+        for marker in (
+            "unsupported parameter",
+            "unknown parameter",
+            "invalid parameter",
+            "invalid value for parameter",
+            "missing required parameter",
+        )
+    )
+
+
 def extract_billing_message(exc: Exception) -> str:
     """Extract a human-readable billing message from the SDK exception."""
     body = _extract_error_body(exc) or {}

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -280,6 +280,24 @@ def retry_with_backoff_generic(
                 time.sleep(delay)
             except Exception as exc:
                 if bad_request_error is not None and isinstance(exc, bad_request_error):
+                    # v0.52.6 — short-circuit "Unsupported parameter" /
+                    # "Invalid value" 400-class errors. Same backend will
+                    # reject every retry with the same body; the v0.52.5
+                    # incident burned 30s on Codex's
+                    # ``Unsupported parameter: max_output_tokens`` before
+                    # the circuit breaker tripped. Re-raise so the
+                    # outer except (non-retryable_errors) catches and
+                    # surfaces the original message.
+                    from core.llm.errors import is_request_fatal
+
+                    if is_request_fatal(exc):
+                        log.error(
+                            "Request-fatal 400 on %s (model=%s) — no retry: %s",
+                            provider_label,
+                            current_model,
+                            str(exc)[:200],
+                        )
+                        raise
                     error_msg = str(exc)
                     if "billing" in error_msg.lower() or "credit" in error_msg.lower():
                         from core.llm.errors import BillingError

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -211,12 +211,25 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
 
         async def _do_call(m: str) -> Any:
             def _sync_call() -> Any:
+                # v0.52.6 hotfix — chatgpt.com/backend-api/codex/responses
+                # rejects ``max_output_tokens`` with 400 ("Unsupported
+                # parameter"). The Plus subscription manages output limits
+                # server-side via the user's quota, so passing a client
+                # cap is both unnecessary and fatal here. Removing it
+                # resolves a 100% Codex-call failure observed in
+                # production logs (every request → 400, all 4 retries +
+                # all 3 fallback models hit the same error → circuit
+                # breaker OPEN within ~30s).
+                #
+                # Standard OpenAI Responses API still accepts the
+                # parameter, but this adapter is Codex-only — it never
+                # talks to api.openai.com. The PAYG `OpenAIAgenticAdapter`
+                # still sends max_output_tokens for its own endpoint.
                 with client.responses.stream(
                     model=m,
                     instructions=system or "You are a helpful assistant.",
                     input=resp_input or [{"role": "user", "content": "hello"}],
                     store=False,
-                    max_output_tokens=max_tokens,
                     temperature=temperature,
                 ) as stream:
                     for _event in stream:

--- a/docs/research/codex-oauth-request-spec.md
+++ b/docs/research/codex-oauth-request-spec.md
@@ -1,0 +1,216 @@
+# Codex OAuth Request Spec — chatgpt.com/backend-api/codex/responses
+
+> Production incident 2026-04-27: GEODE sent `max_output_tokens` and Codex returned 400 `"Unsupported parameter: max_output_tokens"`. This doc grounds the correct request shape against 3 reference implementations.
+
+## Endpoint
+
+- URL: `POST https://chatgpt.com/backend-api/codex/responses`
+  - Base: `https://chatgpt.com/backend-api/codex` (Hermes `DEFAULT_CODEX_BASE_URL`, OpenClaw `OPENAI_CODEX_BASE_URL` minus `/codex`, Codex Rust `default_base_url` for `AuthMode::Chatgpt`).
+  - Path suffix `/responses` (Codex Rust `RESPONSES_ENDPOINT`).
+- Auth: `Authorization: Bearer <oauth_access_token>` from `~/.codex/auth.json` (or GEODE-issued profile). Token is the **raw** bearer access token; not prefixed.
+- Refresh: long-lived `refresh_token` in same JSON; provider-side refresh on 401 (OpenClaw `refreshOpenAICodexOAuthCredential`, Hermes `auth.py`).
+
+## Required headers
+
+| Header | Value | Source |
+|--------|-------|--------|
+| `Authorization` | `Bearer <access_token>` | Codex Rust `AgentIdentityAuthProvider::add_auth_headers`; OpenClaw `provider-attribution.ts:357-361` |
+| `originator` | `codex_cli_rs` (or vendor-specific) | Codex Rust `default_client.rs` `headers.insert("originator", originator().header_value)`; OpenClaw `OPENCLAW_ATTRIBUTION_ORIGINATOR`; GEODE already sets `"codex_cli_rs"` (`core/llm/providers/codex.py:119`) |
+| `ChatGPT-Account-ID` | UUID from JWT `https://api.openai.com/auth.chatgpt_account_id` | Codex Rust `model-provider/src/auth.rs` `headers.insert("ChatGPT-Account-ID", header)`; GEODE `_extract_account_id` (`codex.py:37-51`) |
+| `User-Agent` | `<originator>/<version> (<os> <ver>; <arch>) <suffix>` | Codex Rust `get_codex_user_agent()`; OpenClaw `formatOpenClawUserAgent` |
+| `version` | client version string | OpenClaw `provider-attribution.ts:359`; Codex Rust derives from cargo |
+| `OpenAI-Beta` | `responses_websockets=2026-02-06` (only for WS transport) | Codex Rust `RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE` — **not required** for plain SSE |
+| `x-openai-internal-codex-residency` | `us` (Codex CLI sets it; not required by server) | Codex Rust `RESIDENCY_HEADER_NAME` |
+
+Optional Codex CLI-only: `x-codex-installation-id`, `x-codex-window-id`, `x-codex-turn-state`, `x-codex-parent-thread-id`, `x-openai-subagent`. Server tolerates absence.
+
+## Request body
+
+Schema is `ResponsesApiRequest` in Codex Rust (`codex-rs/codex-api/src/common.rs:117-133`).
+
+| Field | Type | Status | Notes | Source |
+|-------|------|--------|-------|--------|
+| `model` | string | REQUIRED | e.g. `gpt-5.3-codex`. Slug list maintained by OpenClaw `openai-codex-provider.ts:57-83`. | Rust `common.rs:118`; OpenClaw catalog |
+| `instructions` | string | REQUIRED (skip if empty) | System prompt. Hermes extracts from `messages[0]` if not given (`agent/transports/codex.py:66-73`). `#[serde(skip_serializing_if = "String::is_empty")]`. | Rust `common.rs:119`; Hermes `codex.py:94` |
+| `input` | array | REQUIRED | `Vec<ResponseItem>` — Responses-API input items (NOT Chat Completions messages). | Rust `common.rs:120`; Hermes `_chat_messages_to_responses_input` (`codex_responses_adapter.py`); OpenClaw `convertResponsesMessages` (`openai-transport-stream.ts:733`) |
+| `tools` | array | REQUIRED (may be `[]`) | Responses function-tool schema, NOT Chat Completions schema. | Rust `common.rs:121`; Hermes `_responses_tools` |
+| `tool_choice` | string | REQUIRED | Always `"auto"` in Codex Rust (`client.rs:851-923`); Hermes also hard-codes `"auto"` (`codex.py:97`). | Rust `client.rs`; Hermes `codex.py:97` |
+| `parallel_tool_calls` | bool | REQUIRED | `true` per Hermes default (`codex.py:98`); Codex Rust forwards `prompt.parallel_tool_calls`. | Rust `client.rs`; Hermes `codex.py:98` |
+| `store` | bool | REQUIRED | **`false`** for Codex backend (Plus quota does not support server-side state). Hermes `codex.py:99`; Codex Rust `provider.is_azure_responses_endpoint()` (false for chatgpt.com); OpenClaw `payloadPolicy.storeMode = "disable"` (`openai-transport-stream.ts:741`). | All 3 |
+| `stream` | bool | REQUIRED | **`true`** — Codex backend rejects non-streaming. Hermes uses `client.responses.stream()` (`run_agent.py:4713`); GEODE already does `client.responses.stream(...)` (`codex.py:228`). | All 3 |
+| `include` | array<string> | REQUIRED | `["reasoning.encrypted_content"]` when reasoning enabled, else `[]`. | Rust `common.rs:127`; Hermes `codex.py:107-117` |
+| `reasoning` | object \| null | OPTIONAL | `{effort: "low"\|"medium"\|"high", summary: "auto"}`. Omitted when reasoning disabled. Hermes maps `effort=minimal -> low`. | Rust `common.rs:124`; Hermes `codex.py:80-90,114` |
+| `prompt_cache_key` | string | OPTIONAL | Session/conversation id. `#[serde(skip_serializing_if = "Option::is_none")]`. | Rust `common.rs:129`; Hermes `codex.py:102-104` |
+| `service_tier` | string | OPTIONAL | Only when `payloadPolicy.allowsServiceTier` (OpenClaw gates by Codex endpoint). | Rust `common.rs:128`; OpenClaw `provider-attribution.ts:575-579` |
+| `text` | object | OPTIONAL | `TextControls` (verbosity / schema). | Rust `common.rs:130` |
+| `client_metadata` | map<string,string> | OPTIONAL | e.g. `{installation_id: ...}`. | Rust `common.rs:131` |
+| `metadata` | object | OPTIONAL | OpenClaw forwards turn-state metadata when present (`openai-transport-stream.ts:749`). | OpenClaw |
+| `temperature` | float | OPTIONAL | Codex models commonly omit (Hermes consults `_fixed_temperature_for_model` and may strip — `run_agent.py:7228`). Safe to send if model accepts. | Hermes `codex.py:124-125` (only for non-Codex backend) — Hermes does NOT add temperature inside `build_kwargs` for codex backend either; it is set later only when not omitted. |
+| `max_output_tokens` | int | **FORBIDDEN on chatgpt.com/backend-api/codex** | Hermes explicitly skips it: `if max_tokens is not None and not is_codex_backend: kwargs["max_output_tokens"] = max_tokens` (`agent/transports/codex.py:123-125`). Codex Rust `ResponsesApiRequest` has no such field at all (`codex-api/src/common.rs:117-133`). Production 2026-04-27: every request → 400 `"Unsupported parameter: max_output_tokens"`. | Hermes `transports/codex.py:124`; Codex Rust struct; production logs |
+| `max_tokens` | int | FORBIDDEN | Not a Responses-API field on any backend. | Codex Rust struct (absent) |
+| `top_p`, `presence_penalty`, `frequency_penalty`, `seed`, `n`, `stop`, `logprobs` | — | FORBIDDEN | None appear in `ResponsesApiRequest`; Plus backend rejects Chat-Completions-only fields. | Codex Rust struct |
+
+Hermes `codex_responses_adapter._preflight_codex_api_kwargs` (`agent/codex_responses_adapter.py:466-565`) keeps an explicit allowlist: `{model, input, instructions, tools, tool_choice, parallel_tool_calls, store, stream, reasoning, include, max_output_tokens, temperature, ...}` — but the `max_output_tokens` branch is reachable only for non-Codex Responses endpoints because `build_kwargs` strips it before reaching the preflight when `is_codex_backend=True`.
+
+## Reference implementations
+
+### Hermes Agent — `agent/transports/codex.py`
+
+Source: `/Users/mango/workspace/hermes-agent/agent/transports/codex.py:92-130`
+
+```python
+kwargs = {
+    "model": model,
+    "instructions": instructions,
+    "input": _chat_messages_to_responses_input(payload_messages),
+    "tools": _responses_tools(tools),
+    "tool_choice": "auto",
+    "parallel_tool_calls": True,
+    "store": False,
+}
+if not is_github_responses and session_id:
+    kwargs["prompt_cache_key"] = session_id
+if reasoning_enabled and is_xai_responses:
+    kwargs["include"] = ["reasoning.encrypted_content"]
+elif reasoning_enabled:
+    if is_github_responses:
+        ...
+    else:
+        kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
+        kwargs["include"] = ["reasoning.encrypted_content"]
+elif not is_github_responses and not is_xai_responses:
+    kwargs["include"] = []
+max_tokens = params.get("max_tokens")
+if max_tokens is not None and not is_codex_backend:   # <-- the gate
+    kwargs["max_output_tokens"] = max_tokens
+```
+
+`stream=True` is implicit via `client.responses.stream(**kwargs)` in `run_agent.py:4713` / `:4827`.
+
+### OpenClaw — `src/agents/openai-transport-stream.ts`
+
+Source: `/Users/mango/workspace/openclaw/src/agents/openai-transport-stream.ts:724-778` (`buildOpenAIResponsesParams`).
+
+```ts
+const params: OpenAIResponsesRequestParams = {
+  model: model.id,
+  input: messages,
+  stream: true,
+  prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
+  prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
+  ...(metadata ? { metadata } : {}),
+};
+if (options?.maxTokens) { params.max_output_tokens = options.maxTokens; }   // PAYG path
+...
+applyOpenAIResponsesPayloadPolicy(params, payloadPolicy);   // sets store:false for Codex
+```
+
+`payloadPolicy.storeMode = "disable"` (line 741) → `applyOpenAIResponsesPayloadPolicy` writes `store: false` (`openai-responses-payload-policy.ts:141-143`). Codex callers pass `options.maxTokens = undefined`, leaving `max_output_tokens` unset. Headers come from `provider-attribution.ts:365-383` (`originator`, `version`, `User-Agent`).
+
+The plugin descriptor `extensions/openai/openai-codex-provider.ts:38` defines `OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api"`; transport appends `/codex/responses`.
+
+### Codex CLI (Rust) — `codex-rs/codex-api/src/common.rs:117-133`
+
+```rust
+#[derive(Serialize, Debug)]
+pub struct ResponsesApiRequest {
+    pub model: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub instructions: String,
+    pub input: Vec<ResponseItem>,
+    pub tools: Vec<serde_json::Value>,
+    pub tool_choice: String,
+    pub parallel_tool_calls: bool,
+    pub reasoning: Option<Reasoning>,
+    pub store: bool,
+    pub stream: bool,
+    pub include: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<TextControls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_metadata: Option<HashMap<String, String>>,
+}
+```
+
+Build site: `codex-rs/core/src/client.rs:851-923` (`build_responses_request`). **No `max_output_tokens` / `max_tokens` field exists in the struct.** Headers: `default_client.rs` inserts `originator`, `User-Agent`; `model-provider/src/auth.rs` inserts `Authorization: Bearer …` and `ChatGPT-Account-ID`.
+
+## GEODE current state
+
+`core/llm/providers/codex.py:228-234` (post-hotfix v0.52.6):
+
+```python
+with client.responses.stream(
+    model=m,
+    instructions=system or "You are a helpful assistant.",
+    input=resp_input or [{"role": "user", "content": "hello"}],
+    store=False,
+    temperature=temperature,
+) as stream:
+```
+
+Identified gaps versus the 3 references:
+
+| Field | Hermes | OpenClaw | Codex Rust | GEODE | Action |
+|-------|--------|----------|------------|-------|--------|
+| `tools` | sent | sent | sent | NOT sent (agentic loop calls without tool list) | Forward `tools` arg → convert to Responses tool schema |
+| `tool_choice` | `"auto"` | (sdk default) | `"auto"` | not sent | Send `"auto"` when tools present |
+| `parallel_tool_calls` | `True` | (sdk default) | from prompt | not sent | Send `True` |
+| `include` | `["reasoning.encrypted_content"]` when reasoning | conditional | conditional | not sent | Send `["reasoning.encrypted_content"]` for reasoning models |
+| `reasoning` | `{effort, summary:"auto"}` | same | same | not sent | Send for `gpt-5.x-codex` per `effort` arg |
+| `prompt_cache_key` | session_id | session_id | conv_id | not sent | Optional: session_id from agentic loop context |
+| `stream` | True (via `.stream()`) | True (explicit) | True | True (via `.stream()`) | OK |
+| `store` | False | False | False (non-Azure) | False | OK |
+| `instructions` | sent | sent | sent | sent | OK |
+| `max_output_tokens` | stripped for codex | not set for codex | absent | removed in v0.52.6 | OK |
+
+Also: GEODE drops `tools`/`tool_choice` arguments inside `agentic_call` — the agentic tool loop receives no Codex-side tool dispatch. This is a separate bug (function calling broken) but not the cause of the 400.
+
+## Recommended request shape for GEODE
+
+Minimum viable (matches Codex Rust struct):
+
+```python
+client.responses.stream(
+    model=model,
+    instructions=system or DEFAULT_INSTRUCTIONS,
+    input=resp_input,
+    tools=_to_responses_tools(tools),
+    tool_choice="auto" if tools else "none",
+    parallel_tool_calls=True,
+    store=False,
+    stream=True,                                    # implicit via .stream()
+    include=["reasoning.encrypted_content"] if _is_reasoning(model) else [],
+    reasoning={"effort": effort, "summary": "auto"} if _is_reasoning(model) else None,
+    # Optional: prompt_cache_key=session_id,
+    # NEVER: max_output_tokens, max_tokens, top_p, frequency_penalty, seed
+)
+```
+
+Reasoning per field:
+
+- `tools`/`tool_choice`/`parallel_tool_calls`: required by Codex agentic loop; absent → no function calling.
+- `include`+`reasoning`: gpt-5.x-codex models return reasoning blocks; without `include` the encrypted reasoning is dropped, breaking multi-turn continuity.
+- `store=False`: Plus backend has no server-state; `store=True` returns 400.
+- `stream=True`: backend rejects non-streaming responses for Plus quota.
+- omit `max_output_tokens`: server-managed quota; param triggers 400.
+- omit `temperature` for `gpt-5.x-codex` (Hermes `_fixed_temperature_for_model` returns `OMIT_TEMPERATURE` for these). GEODE currently sends `temperature` unconditionally — low priority but should be model-gated.
+
+## Sources
+
+All retrieved 2026-04-27.
+
+- Hermes Agent (local): `/Users/mango/workspace/hermes-agent/agent/transports/codex.py:14-130`, `/Users/mango/workspace/hermes-agent/agent/codex_responses_adapter.py:466-565`, `/Users/mango/workspace/hermes-agent/run_agent.py:4698-4827`, `/Users/mango/workspace/hermes-agent/hermes_cli/auth.py:70` (`DEFAULT_CODEX_BASE_URL`), `/Users/mango/workspace/hermes-agent/hermes_cli/providers.py:61`.
+- OpenClaw (local): `/Users/mango/workspace/openclaw/extensions/openai/openai-codex-provider.ts:1-373`, `/Users/mango/workspace/openclaw/src/agents/openai-transport-stream.ts:724-778`, `/Users/mango/workspace/openclaw/src/agents/openai-responses-payload-policy.ts:91-162`, `/Users/mango/workspace/openclaw/src/agents/provider-attribution.ts:340-383, 460-606`.
+- Codex CLI (Rust, GitHub `openai/codex@main`):
+  - `codex-rs/codex-api/src/common.rs:117-133` — `ResponsesApiRequest` struct (https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/common.rs)
+  - `codex-rs/core/src/client.rs:851-923` — `build_responses_request` (https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs)
+  - `codex-rs/login/src/auth/default_client.rs` — `originator`, `User-Agent` headers (https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/default_client.rs)
+  - `codex-rs/model-provider/src/auth.rs` — `Authorization` + `ChatGPT-Account-ID` headers (https://github.com/openai/codex/blob/main/codex-rs/model-provider/src/auth.rs)
+  - `codex-rs/model-provider-info/src/lib.rs` — `default_base_url = "https://chatgpt.com/backend-api/codex"` for `AuthMode::Chatgpt` (https://github.com/openai/codex/blob/main/codex-rs/model-provider-info/src/lib.rs)
+  - `codex-rs/codex-api/src/endpoint/responses.rs` — `RESPONSES_ENDPOINT = "/responses"` (https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/endpoint/responses.rs)
+- GEODE current (this repo): `core/llm/providers/codex.py:104-244`, `core/config.py:383-386`.
+- Production incident: GEODE serve logs 2026-04-27 — every Codex call → 400 `"Unsupported parameter: max_output_tokens"`, all 4 retries × 3 fallback models → circuit breaker OPEN ~30s.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.5"
+version = "0.52.6"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_codex_request_shape.py
+++ b/tests/test_codex_request_shape.py
@@ -1,0 +1,201 @@
+"""v0.52.6 hotfix — Codex backend request shape + 400 fail-fast.
+
+Production incident (2026-04-27): every Codex backend call to
+``chatgpt.com/backend-api/codex/responses`` returned 400 Bad Request:
+``{'detail': 'Unsupported parameter: max_output_tokens'}``. The Plus
+subscription manages output limits server-side; sending a client cap
+breaks every request. The retry loop then hammered the same 400 across
+all fallback models for ~30s before the circuit breaker tripped — same
+shape as the v0.52.3 billing-fatal storm but for request-shape errors.
+
+Two invariants pinned here:
+
+  1. ``CodexAgenticAdapter.agentic_call`` MUST NOT pass
+     ``max_output_tokens`` to ``client.responses.stream`` — Codex
+     backend rejects it. ``OpenAIAgenticAdapter`` (PAYG, talks to
+     ``api.openai.com``) still passes it; the PAYG endpoint accepts it.
+
+  2. ``is_request_fatal()`` recognises the 400 shape ("Unsupported
+     parameter", "Invalid value", "Missing required parameter") and
+     ``fallback.retry_with_backoff_generic`` re-raises immediately
+     instead of retrying — saves the ~30s × 5 attempts × 3 fallback
+     models cascade observed in production.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import core.llm.fallback as _fallback
+import core.llm.providers.codex as _codex_mod
+import pytest
+from core.llm.errors import is_request_fatal
+
+# ---------------------------------------------------------------------------
+# Contract 1 — Codex adapter must not send max_output_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_codex_agentic_call_does_not_send_max_output_tokens() -> None:
+    """Source-level: the Codex Responses API call must not include
+    ``max_output_tokens``. Codex backend rejects it with 400."""
+    src = inspect.getsource(_codex_mod.CodexAgenticAdapter.agentic_call)
+    # The literal kwarg must not appear inside the ``responses.stream(`` call.
+    stream_block_start = src.find("responses.stream(")
+    assert stream_block_start >= 0, "responses.stream call missing"
+    stream_block_end = src.find(")", stream_block_start)
+    stream_block = src[stream_block_start:stream_block_end]
+    assert "max_output_tokens" not in stream_block, (
+        "max_output_tokens must NOT be in the Codex Responses API call. "
+        "Codex backend (chatgpt.com/backend-api/codex) rejects it with 400. "
+        "Plus subscription manages output limits server-side."
+    )
+
+
+def test_codex_adapter_inherits_max_tokens_signature() -> None:
+    """Signature compatibility — even though we don't pass max_tokens to
+    the Codex call, the method signature must keep the kwarg so the
+    abstract base class contract is honoured (siblings still need it)."""
+    sig = inspect.signature(_codex_mod.CodexAgenticAdapter.agentic_call)
+    assert "max_tokens" in sig.parameters, (
+        "max_tokens kwarg removed from method signature — would break "
+        "OpenAIAgenticAdapter parent class contract / call sites"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — is_request_fatal recognises 400 "Unsupported parameter"
+# ---------------------------------------------------------------------------
+
+
+def _make_400(detail: str, *, attr: str = "body") -> Exception:
+    """Build an exception with status_code=400 and the given detail body."""
+    exc = Exception(detail)
+    if attr == "body":
+        exc.body = {"detail": detail}  # type: ignore[attr-defined]
+    elif attr == "response":
+        response = MagicMock()
+        response.json.return_value = {"detail": detail}
+        response.status_code = 400
+        exc.response = response  # type: ignore[attr-defined]
+    exc.status_code = 400  # type: ignore[attr-defined]
+    return exc
+
+
+def test_unsupported_parameter_is_request_fatal() -> None:
+    """The actual production trigger — Codex backend's exact response."""
+    exc = _make_400("Unsupported parameter: max_output_tokens")
+    assert is_request_fatal(exc) is True
+
+
+def test_invalid_value_for_parameter_is_request_fatal() -> None:
+    """Common OpenAI 400 — wrong enum value, wrong type, etc."""
+    exc = _make_400("Invalid value for parameter 'tool_choice'")
+    assert is_request_fatal(exc) is True
+
+
+def test_missing_required_parameter_is_request_fatal() -> None:
+    exc = _make_400("Missing required parameter: 'model'")
+    assert is_request_fatal(exc) is True
+
+
+def test_unknown_parameter_is_request_fatal() -> None:
+    """Anthropic/GLM variant phrasing."""
+    exc = _make_400("Unknown parameter 'thinking_budget'")
+    assert is_request_fatal(exc) is True
+
+
+def test_generic_400_without_marker_is_not_request_fatal() -> None:
+    """A 400 that doesn't match any marker (e.g. context overflow) must
+    NOT be classified as request-fatal — it has its own handling path."""
+    exc = _make_400("This model's maximum context length is 200000 tokens")
+    assert is_request_fatal(exc) is False
+
+
+def test_429_is_not_request_fatal() -> None:
+    """Rate limits go through is_billing_fatal / retry, not this path."""
+    exc = Exception("rate limited")
+    exc.status_code = 429  # type: ignore[attr-defined]
+    exc.body = {"detail": "Unsupported parameter: foo"}  # type: ignore[attr-defined]
+    assert is_request_fatal(exc) is False, (
+        "429 must not be classified as request-fatal — only 4xx (non-429)"
+    )
+
+
+def test_500_is_not_request_fatal() -> None:
+    """Server errors are retryable, never request-fatal."""
+    exc = Exception("internal error")
+    exc.status_code = 500  # type: ignore[attr-defined]
+    exc.body = {"detail": "Unsupported parameter: foo"}  # type: ignore[attr-defined]
+    assert is_request_fatal(exc) is False
+
+
+def test_response_attr_fallback() -> None:
+    """SDK that exposes .response.json() rather than .body."""
+    exc = _make_400("Unsupported parameter: max_output_tokens", attr="response")
+    assert is_request_fatal(exc) is True
+
+
+def test_unparseable_exc_defaults_to_not_fatal() -> None:
+    """Unknown shape ⇒ return False so legitimate retries aren't blocked."""
+    exc = Exception("network blip")
+    assert is_request_fatal(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — fallback.retry_with_backoff_generic short-circuits 400s
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_loop_calls_is_request_fatal_in_bad_request_branch() -> None:
+    """Source-level: the bad_request branch must call is_request_fatal
+    BEFORE the billing/context-overflow checks so the production-trigger
+    shape (400 + Unsupported parameter) re-raises immediately."""
+    src = inspect.getsource(_fallback.retry_with_backoff_generic)
+    fatal_pos = src.find("is_request_fatal(exc)")
+    sleep_pos = src.find("time.sleep(delay)")
+    assert fatal_pos >= 0, "fallback.py must import + call is_request_fatal"
+    assert sleep_pos >= 0
+    # Same constraint as v0.52.3 billing-fatal — fail before the next sleep.
+    assert fatal_pos > sleep_pos or fatal_pos < src.find("except Exception as exc"), (
+        "is_request_fatal call must live in the bad_request branch, not "
+        "before the retryable_errors classification"
+    )
+
+
+def test_fallback_loop_reraises_on_unsupported_parameter() -> None:
+    """End-to-end: a fake openai.BadRequestError-style exception with
+    400 + ``Unsupported parameter`` body must NOT trigger any retries."""
+    from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
+
+    call_count = 0
+
+    class FakeBadRequestError(Exception):
+        pass
+
+    def fn(*, model: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        exc = FakeBadRequestError("400")
+        exc.status_code = 400  # type: ignore[attr-defined]
+        exc.body = {"detail": "Unsupported parameter: max_output_tokens"}  # type: ignore[attr-defined]
+        raise exc
+
+    cb = CircuitBreaker()
+    with pytest.raises(FakeBadRequestError):
+        retry_with_backoff_generic(
+            fn,
+            model="gpt-5.5",
+            fallback_models=["gpt-5.4-mini", "gpt-5.3-codex"],
+            circuit_breaker=cb,
+            retryable_errors=(),  # 400 not in this tuple — falls into bad_request branch
+            bad_request_error=FakeBadRequestError,
+            billing_message="OpenAI billing exhausted",
+            max_retries=5,
+            provider_label="OpenAI Codex",
+        )
+    assert call_count == 1, (
+        f"Request-fatal 400 must not retry. Got {call_count} attempts. "
+        "v0.52.5 incident: 5×3=15 attempts wasted ~30s on the same 400."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.4"
+version = "0.52.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Production hotfix: 100% Codex backend calls failed with 400 ``Unsupported parameter: max_output_tokens``.
- Fix: drop the param + add `is_request_fatal` 400 fail-fast classification.
- Grounded against Hermes / OpenClaw / Codex CLI Rust (3 reference codebases).
- 13 invariant tests + spec doc.

## Verification
- [x] Lint & Format: pass (12s)
- [x] Type Check: pass (35s)
- [x] Security Scan: pass (16s)
- [x] Test: pass (3m22s)
- [x] Gate: pass

PR #818 (feature → develop) — all 5/5 green.