### PR TITLE
release: v0.52.7 — Codex tools/reasoning/temperature parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.7] — 2026-04-27
+
+### Fixed
+- **Codex function-calling broken** — `tools` / `tool_choice` / `parallel_tool_calls` were never forwarded to the Codex Responses API. The Codex agentic loop received no native tool dispatch path on Plus subscriptions; LLM saw "no tools available" on every turn. Forward all three per Codex Rust `ResponsesApiRequest` struct + Hermes `agent/transports/codex.py` shape. (`core/llm/providers/codex.py:CodexAgenticAdapter.agentic_call`)
+- **Encrypted reasoning lost across turns on gpt-5.x-codex** — `include=["reasoning.encrypted_content"]` + `reasoning={effort, summary}` were never sent. Codex backend strips encrypted reasoning blocks from non-include responses, breaking multi-turn reasoning continuity (each turn re-discovers what it already worked out). Sent for all gpt-5.x models. (Same file)
+- **Temperature sent to gpt-5.x-codex unconditionally** — Hermes `_fixed_temperature_for_model` returns OMIT for these models; sending it can return 400 or skew the reasoning sampler. Now omitted for gpt-5.x; preserved for non-reasoning models. (Same file)
+
+### Added
+- **`_is_codex_reasoning_model(model)` classifier** — gates the include / reasoning / temperature behaviour. Currently `model.startswith("gpt-5")` covers gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex (the entire CODEX_FALLBACK_CHAIN). Future Codex additions inherit the same handling without code changes.
+- **`tests/test_codex_responses_shape.py`** — 11 invariant cases covering: tools forwarded with correct Responses-API flat schema; tool_choice="auto" + parallel_tool_calls=True when tools present; both omitted when tools empty; include + reasoning + temperature-omit for gpt-5.x; temperature preserved + reasoning skipped for non-gpt-5.x; v0.52.6 max_output_tokens absence still pinned post-refactor.
+
+### Reference
+- `docs/research/codex-oauth-request-spec.md` — definitive spec grounded in Hermes Agent + OpenClaw + Codex CLI Rust (introduced in v0.52.6). v0.52.7 closes the 3 remaining gaps the doc identified.
+
 ## [0.52.6] — 2026-04-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.6
+- **Version**: 0.52.7
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4157+
+- **Tests**: 4168+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.6 — Long-running Autonomous Execution Harness
+# GEODE v0.52.7 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.6 — Long-running Autonomous Execution Harness
+# GEODE v0.52.7 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -151,8 +151,20 @@ from core.llm.errors import UserCancelledError  # noqa: E402
 from core.llm.providers.openai import (  # noqa: E402
     OpenAIAgenticAdapter,
     _convert_messages_to_openai,
+    _tools_to_openai,
 )
 from core.llm.router import call_with_failover  # noqa: E402
+
+
+# v0.52.7 — gpt-5.x family supports reasoning + omits temperature on Codex
+# backend. Pattern from Hermes ``_fixed_temperature_for_model`` (which returns
+# OMIT for these models) + Codex Rust ``Reasoning`` field on ResponsesApiRequest.
+# All current Codex-routed models (gpt-5.5, gpt-5.4, gpt-5.4-mini,
+# gpt-5.3-codex) are gpt-5.x — we gate by prefix so future spec additions
+# (gpt-5.6, gpt-5.x-codex-spark, etc.) inherit the same handling.
+def _is_codex_reasoning_model(model: str) -> bool:
+    """Return True for Codex models that accept ``reasoning`` + omit temperature."""
+    return model.startswith("gpt-5")
 
 
 class CodexAgenticAdapter(OpenAIAgenticAdapter):
@@ -209,29 +221,47 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
 
         failover_models = [model] + [m for m in self.fallback_chain if m != model]
 
+        # v0.52.7 — build kwargs to match Codex Rust ``ResponsesApiRequest``
+        # struct + Hermes ``agent/transports/codex.py`` shape. Spec doc:
+        # ``docs/research/codex-oauth-request-spec.md`` (3-codebase grounded).
+        oai_tools = _tools_to_openai(tools)
+        tc_val = tool_choice.get("type", "auto") if isinstance(tool_choice, dict) else tool_choice
+        is_reasoning = _is_codex_reasoning_model(model)
+
         async def _do_call(m: str) -> Any:
             def _sync_call() -> Any:
                 # v0.52.6 hotfix — chatgpt.com/backend-api/codex/responses
                 # rejects ``max_output_tokens`` with 400 ("Unsupported
                 # parameter"). The Plus subscription manages output limits
-                # server-side via the user's quota, so passing a client
-                # cap is both unnecessary and fatal here. Removing it
-                # resolves a 100% Codex-call failure observed in
-                # production logs (every request → 400, all 4 retries +
-                # all 3 fallback models hit the same error → circuit
-                # breaker OPEN within ~30s).
-                #
-                # Standard OpenAI Responses API still accepts the
-                # parameter, but this adapter is Codex-only — it never
-                # talks to api.openai.com. The PAYG `OpenAIAgenticAdapter`
-                # still sends max_output_tokens for its own endpoint.
-                with client.responses.stream(
-                    model=m,
-                    instructions=system or "You are a helpful assistant.",
-                    input=resp_input or [{"role": "user", "content": "hello"}],
-                    store=False,
-                    temperature=temperature,
-                ) as stream:
+                # server-side; client cap is forbidden. PAYG
+                # ``OpenAIAgenticAdapter`` still sends it for api.openai.com.
+                kwargs: dict[str, Any] = {
+                    "model": m,
+                    "instructions": system or "You are a helpful assistant.",
+                    "input": resp_input or [{"role": "user", "content": "hello"}],
+                    "store": False,
+                }
+                # v0.52.7 — function-calling parity with Hermes / Codex Rust.
+                # Pre-fix ``tools`` was dropped silently → Codex agentic loop
+                # had no way to invoke any tool, breaking the entire native
+                # tool dispatch path on Plus subscriptions.
+                if oai_tools:
+                    kwargs["tools"] = oai_tools
+                    kwargs["tool_choice"] = tc_val or "auto"
+                    # Hermes default; Codex Rust forwards prompt setting.
+                    kwargs["parallel_tool_calls"] = True
+                # v0.52.7 — encrypted reasoning passthrough. Without
+                # ``include`` + ``reasoning`` the gpt-5.x-codex models lose
+                # their reasoning state across turns (Codex backend strips
+                # the encrypted block from non-include responses).
+                if is_reasoning:
+                    kwargs["include"] = ["reasoning.encrypted_content"]
+                    kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
+                    # gpt-5.x-codex omits temperature per Hermes
+                    # ``_fixed_temperature_for_model``.
+                else:
+                    kwargs["temperature"] = temperature
+                with client.responses.stream(**kwargs) as stream:
                     for _event in stream:
                         pass
                     return stream.get_final_response()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.6"
+version = "0.52.7"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_codex_responses_shape.py
+++ b/tests/test_codex_responses_shape.py
@@ -1,0 +1,240 @@
+"""v0.52.7 — Codex Responses API request shape (tools + reasoning + temperature).
+
+Followup to v0.52.6 hotfix. The spec doc (``docs/research/codex-oauth-request-spec.md``)
+identified 3 gaps NOT caused by the 400-on-max_output_tokens incident but real:
+
+  1. ``tools`` / ``tool_choice`` / ``parallel_tool_calls`` were never sent.
+     Codex agentic loop had no way to invoke any tool — function-calling
+     entirely broken on Plus subscription.
+  2. ``include=["reasoning.encrypted_content"]`` + ``reasoning={effort, summary}``
+     never sent. gpt-5.x-codex returns encrypted reasoning blocks; without
+     ``include`` the backend strips them, breaking multi-turn continuity.
+  3. ``temperature`` sent unconditionally. Hermes uses
+     ``_fixed_temperature_for_model`` which OMITs the field for gpt-5.x-codex.
+
+Reference: 3 codebases agree on the shape (see spec doc):
+  - Hermes Agent ``agent/transports/codex.py``
+  - OpenClaw ``src/agents/openai-transport-stream.ts``
+  - Codex CLI Rust ``codex-rs/codex-api/src/common.rs``
+
+These tests use mocks for the SDK call and inspect the kwargs passed to
+``client.responses.stream(...)`` — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.llm.providers.codex import (
+    CodexAgenticAdapter,
+    _is_codex_reasoning_model,
+)
+
+# ---------------------------------------------------------------------------
+# Contract 0 — _is_codex_reasoning_model classifier
+# ---------------------------------------------------------------------------
+
+
+def test_gpt5_models_are_reasoning() -> None:
+    """All currently-routed Codex models (gpt-5.5, 5.4, 5.4-mini, 5.3-codex)
+    are gpt-5.x and must be classified as reasoning models."""
+    for model in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"):
+        assert _is_codex_reasoning_model(model) is True, (
+            f"{model} must be classified as a Codex reasoning model — "
+            "without this, the include + reasoning fields are dropped and "
+            "encrypted reasoning is lost across turns."
+        )
+
+
+def test_legacy_models_are_not_reasoning() -> None:
+    """Legacy (gpt-4.x and below) models do NOT support the reasoning
+    field — sending it would 400."""
+    for model in ("gpt-4.1", "gpt-4o", "gpt-3.5-turbo"):
+        assert _is_codex_reasoning_model(model) is False
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 — tools / tool_choice / parallel_tool_calls passthrough
+# ---------------------------------------------------------------------------
+
+
+def _capture_codex_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = "auto",
+    model: str = "gpt-5.5",
+    temperature: float = 0.7,
+    effort: str = "high",
+) -> dict[str, Any]:
+    """Run agentic_call with mocked SDK + capture the stream() kwargs."""
+    captured: dict[str, Any] = {}
+
+    fake_stream_ctx = MagicMock()
+    fake_stream_ctx.__enter__ = MagicMock(return_value=iter([]))
+    fake_stream_ctx.__exit__ = MagicMock(return_value=False)
+    fake_stream_ctx.get_final_response = MagicMock(return_value=MagicMock())
+
+    fake_client = MagicMock()
+
+    def _fake_stream(**kwargs: Any) -> MagicMock:
+        captured.update(kwargs)
+        # Build a fresh context each call so iteration / __exit__ work.
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=iter([]))
+        ctx.__exit__ = MagicMock(return_value=False)
+        ctx.get_final_response = MagicMock(return_value=MagicMock())
+        return ctx
+
+    fake_client.responses.stream = _fake_stream
+
+    monkeypatch.setattr("core.llm.providers.codex._get_codex_client", lambda: fake_client)
+    # Bypass circuit breaker for the test.
+    monkeypatch.setattr(
+        "core.llm.providers.codex._codex_circuit_breaker",
+        MagicMock(
+            can_execute=lambda: True, record_success=lambda: None, record_failure=lambda: None
+        ),
+    )
+
+    async def _run() -> None:
+        adapter = CodexAgenticAdapter()
+
+        # Patch call_with_failover so it just calls _do_call once for `model`
+        async def _direct(failover_models: list[str], do_call: Any) -> tuple[Any, str]:
+            result = await do_call(failover_models[0])
+            return result, failover_models[0]
+
+        with patch("core.llm.providers.codex.call_with_failover", _direct):
+            await adapter.agentic_call(
+                model=model,
+                system="hi",
+                messages=[{"role": "user", "content": "test"}],
+                tools=tools or [],
+                tool_choice=tool_choice,
+                max_tokens=4096,
+                temperature=temperature,
+                effort=effort,
+            )
+
+    asyncio.run(_run())
+    return captured
+
+
+def test_tools_are_forwarded_to_codex(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pre-fix bug: tools list was silently dropped — function calling broken
+    on Codex Plus. Post-fix: must appear in stream() kwargs in Responses API
+    flat-tool format ({type, name, description, parameters})."""
+    tools = [
+        {
+            "name": "get_weather",
+            "description": "Look up weather for a location.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    kwargs = _capture_codex_kwargs(monkeypatch, tools=tools)
+    assert "tools" in kwargs, (
+        "tools missing from Codex stream() call — function calling is broken on Plus subscription"
+    )
+    assert kwargs["tools"][0]["name"] == "get_weather"
+    assert kwargs["tools"][0]["type"] == "function"
+    # Responses API uses flat schema (no nested "function" key).
+    assert "function" not in kwargs["tools"][0]
+
+
+def test_tool_choice_defaults_to_auto_when_tools_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex Rust hardcodes ``tool_choice = "auto"``; Hermes too. Match it."""
+    tools = [{"name": "x", "description": "x", "input_schema": {"type": "object"}}]
+    kwargs = _capture_codex_kwargs(monkeypatch, tools=tools, tool_choice="auto")
+    assert kwargs["tool_choice"] == "auto"
+
+
+def test_parallel_tool_calls_true_when_tools_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hermes default; Codex Rust forwards. Required by Codex spec."""
+    tools = [{"name": "x", "description": "x", "input_schema": {"type": "object"}}]
+    kwargs = _capture_codex_kwargs(monkeypatch, tools=tools)
+    assert kwargs["parallel_tool_calls"] is True
+
+
+def test_no_tools_omits_tool_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Don't send tool_choice / parallel_tool_calls when tools list is empty —
+    avoids the OpenAI SDK validation that requires tools when tool_choice set."""
+    kwargs = _capture_codex_kwargs(monkeypatch, tools=[])
+    assert "tools" not in kwargs
+    assert "tool_choice" not in kwargs
+    assert "parallel_tool_calls" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — include + reasoning for gpt-5.x reasoning models
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_model_sends_include_and_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-fix bug: gpt-5.x-codex returns encrypted reasoning blocks the
+    backend strips when ``include`` is absent. Multi-turn reasoning
+    continuity broken. Spec: Hermes + Codex Rust both send these fields."""
+    kwargs = _capture_codex_kwargs(monkeypatch, model="gpt-5.5", effort="high")
+    assert kwargs.get("include") == ["reasoning.encrypted_content"], (
+        "include=['reasoning.encrypted_content'] must be sent for gpt-5.x — "
+        "without it the backend drops encrypted reasoning across turns"
+    )
+    assert kwargs.get("reasoning") == {"effort": "high", "summary": "auto"}
+
+
+def test_reasoning_model_omits_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermes ``_fixed_temperature_for_model`` returns OMIT for gpt-5.x-codex.
+    Sending ``temperature`` to a reasoning model can return 400 or skew the
+    reasoning sampler — match Hermes."""
+    kwargs = _capture_codex_kwargs(monkeypatch, model="gpt-5.3-codex", temperature=0.5)
+    assert "temperature" not in kwargs, (
+        "temperature must be omitted for gpt-5.x-codex per Hermes _fixed_temperature_for_model"
+    )
+
+
+def test_non_reasoning_model_sends_temperature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hypothetical non-reasoning model (e.g. legacy gpt-4) DOES accept
+    temperature. The classifier must keep this path open for any future
+    non-gpt-5 model that gets added to the Codex chain."""
+    kwargs = _capture_codex_kwargs(monkeypatch, model="gpt-4.1-legacy", temperature=0.3)
+    assert kwargs.get("temperature") == 0.3
+    # And the reasoning fields must NOT appear.
+    assert "include" not in kwargs
+    assert "reasoning" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — invariants from v0.52.6 still hold
+# ---------------------------------------------------------------------------
+
+
+def test_max_output_tokens_still_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """v0.52.6 invariant: max_output_tokens is FORBIDDEN on Codex backend.
+    Re-pinned here because v0.52.7 refactored the kwargs construction —
+    this test would fail loudly if a regression accidentally re-added it."""
+    kwargs = _capture_codex_kwargs(monkeypatch, model="gpt-5.5")
+    assert "max_output_tokens" not in kwargs, (
+        "max_output_tokens regressed — Codex backend will return 400"
+    )
+    assert "max_tokens" not in kwargs
+
+
+def test_store_false_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spec: Plus backend has no server-side state; ``store=True`` returns 400."""
+    kwargs = _capture_codex_kwargs(monkeypatch, model="gpt-5.5")
+    assert kwargs["store"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.5"
+version = "0.52.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Closes 3 Codex Responses API gaps identified by v0.52.6 spec doc.
- Forwards tools/tool_choice/parallel_tool_calls (function-calling restored).
- Sends include+reasoning for gpt-5.x (encrypted reasoning continuity).
- Omits temperature for gpt-5.x (Hermes parity).
- 11 invariant tests.

## Verification
- [x] Lint & Format: pass (12s)
- [x] Type Check: pass (29s)
- [x] Security Scan: pass (15s)
- [x] Test: pass (3m38s)
- [x] Gate: pass

PR #820 (feature → develop) — 5/5 green.