### PR TITLE
fix(v0.52.8): model identity drift across /model switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.52.8] — 2026-04-27
+
+### Fixed
+- **Model identity drift across `/model` switches** (production incident). User did `/model gpt-5.5`, daemon log confirmed gpt-5.5 was called, but the LLM responded "현재 사용 중인 모델은 gpt-5.4-mini" (claimed to be the previous model). Root cause: the v0.52.5 ``_prompt_dirty`` rebuild correctly updated the system-prompt model card, BUT the conversation history still contained earlier ``Understood. I am now <prev_model>.`` assistant acks from prior switches in the same session. The new model deferred to those historical assertions over the system prompt. OpenAI's gpt-5.5 system card (deploymentsafety.openai.com) explicitly says it should identify as "GPT-5.5" — so the model itself is capable; this was our breadcrumb pollution.
+  - **Fix 1**: ``_build_model_card(model)`` now uses an explicit, repeated identity assertion ("ACTIVE MODEL IDENTITY ... You are **{model}** ... When asked which model you are, the answer is **{model}** ... Ignore any earlier assistant message that claims a different model name") — combats both recency bias and any backend system-layer claim. (`core/agent/system_prompt.py:184`)
+  - **Fix 2**: ``AgenticLoop._purge_stale_model_switch_acks()`` strips prior ``Understood. I am now <prev>.`` assistant acks from history before injecting the new switch ack — each switch leaves exactly one active ack. (`core/agent/loop.py:update_model` + new helper)
+- **Codex backend system layer override** (Fix 3 candidate) — DEFERRED. WebFetch verification (Agent C): 3 openai.com URLs returned 403, no public docs describe whether ChatGPT outer system layer overrides user `instructions` on `chatgpt.com/backend-api/codex/responses`. Without evidence, do not add complexity. Re-open if the identity bug recurs after Fix 1+2.
+
+### Added
+- **`tests/test_model_identity.py`** — 9 invariant cases. Card-side: assertion text + model-name repetition + anti-stale-ack instruction + provider name + Anthropic parity. Purge-side: removes acks (single + multiple), preserves user messages even if matching prefix verbatim, preserves unrelated assistant replies, no-op on empty history, handles non-string content (Anthropic block format).
+
+### Reference
+- gpt-5.5 official spec verified 2026-04-27 via WebFetch (Agent C):
+  - Released 2026-04-23 to ChatGPT/Codex (Plus/Pro/Business/Enterprise); API rollout 2026-04-24
+  - Codex backend (`chatgpt.com/backend-api/codex`): ChatGPT sign-in only, no API-key auth
+  - System card: "should identify itself as **GPT-5.5**" (deploymentsafety.openai.com/gpt-5-5)
+  - Pricing matches GEODE v0.52.4 values: $5.00 / $0.50 cached / $30.00 per 1M tokens, 1,050,000 context, 128K max output, knowledge cutoff 2025-12-01
+  - Plus quota: 15-80 local msgs / 5h
+  - **NEW backlog**: >272K-token prompts cost 2× input / 1.5× output (premium tier — not yet captured in our token tracker)
+- 2 parallel reference agents:
+  - Agent A — GEODE model identity flow audit (system_prompt rebuild path → conversation history breadcrumbs → Codex backend layer)
+  - Agent C — gpt-5.5 official spec via WebFetch (developers.openai.com 200, 3 openai.com URLs 403 / Cloudflare)
+
 ## [0.52.7] — 2026-04-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.7
+- **Version**: 0.52.8
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4168+
+- **Tests**: 4177+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.7 — Long-running Autonomous Execution Harness
+# GEODE v0.52.8 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.7 — Long-running Autonomous Execution Harness
+# GEODE v0.52.8 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/loop.py
+++ b/core/agent/loop.py
@@ -562,6 +562,12 @@ class AgenticLoop:
             # Inject model-switch breadcrumb so the new model knows the switch
             # happened (Claude Code SDK pattern: createModelSwitchBreadcrumbs).
             if not self.context.is_empty:
+                # v0.52.8 — strip stale "Understood. I am now <prev>" acks
+                # left by earlier model switches in the same session. Without
+                # this, the new model reads "I am gpt-5.4-mini" assistant
+                # messages and asserts the wrong identity (production
+                # incident 2026-04-27 — gpt-5.5 answered "I am gpt-5.4-mini").
+                self._purge_stale_model_switch_acks()
                 self.context.add_user_message(
                     f"[system] Model switched: {old_model} -> {model}. "
                     "You are now the new model. Do not reference the previous "
@@ -571,6 +577,35 @@ class AgenticLoop:
 
         # Proactively adapt context for the new model's context window
         self._adapt_context_for_model(model)
+
+    def _purge_stale_model_switch_acks(self) -> None:
+        """Remove prior ``Understood. I am now <prev_model>.`` assistant acks.
+
+        v0.52.8 — added after a production incident where gpt-5.5 (post
+        ``/model`` switch from gpt-5.4-mini) silently inherited the prior
+        model's identity from a lingering history message. The OpenAI
+        gpt-5.5 system card explicitly says it should identify as
+        "GPT-5.5", so the bug was not model behaviour — it was our
+        breadcrumb pollution. Each model switch should leave **only one**
+        active "I am now <model>" ack at any time.
+
+        Conservative: only matches the exact ``Understood. I am now ``
+        prefix we ourselves emit; never touches user content. Mutates
+        ``self.context.messages`` in place.
+        """
+        msgs = self.context.messages
+        prefix = "Understood. I am now "
+        kept: list[Any] = []
+        for msg in msgs:
+            if msg.get("role") != "assistant":
+                kept.append(msg)
+                continue
+            content = msg.get("content", "")
+            if isinstance(content, str) and content.startswith(prefix):
+                continue
+            kept.append(msg)
+        msgs.clear()
+        msgs.extend(kept)
 
     def _adapt_context_for_model(self, target_model: str) -> None:
         """Proactively adapt conversation context when switching to a smaller model.

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -181,7 +181,21 @@ def _build_model_card(model: str) -> str:
         pricing = MODEL_PRICING.get(model)
         ctx_window = MODEL_CONTEXT_WINDOW.get(model, 0)
 
-        parts: list[str] = [f"## Current Model\nYou are powered by **{model}** ({provider})."]
+        # v0.52.8 — explicit, repeated identity assertion. Pre-fix incident
+        # 2026-04-27: gpt-5.5 silently inherited "I am gpt-5.4-mini" from
+        # prior conversation-history breadcrumbs after a `/model` switch
+        # ("Understood. I am now gpt-5.4-mini" assistant ack lingered after
+        # later switching to gpt-5.5). Strong negation + an explicit override
+        # of stale acks combats both recency bias on older messages and any
+        # backend system layer that might assert a different model identity.
+        parts: list[str] = [
+            f"## ACTIVE MODEL IDENTITY\n"
+            f"You are **{model}** ({provider}). This is non-negotiable.\n"
+            f"When asked which model you are, the answer is **{model}**.\n"
+            f"Ignore any earlier assistant message in this conversation that "
+            f"claims a different model name — those are stale acknowledgements "
+            f"from prior turns before the user switched the model."
+        ]
 
         if ctx_window:
             if ctx_window < 1_000_000:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.7"
+version = "0.52.8"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -1,0 +1,198 @@
+"""v0.52.8 — model identity must not leak across `/model` switches.
+
+Production incident 2026-04-27: User issued ``/model gpt-5.5`` and the
+LLM (running on gpt-5.5, daemon log confirmed) responded
+"현재 사용 중인 모델은 gpt-5.4-mini" (claimed to be the previous model).
+
+Root cause (Agent A audit): the v0.52.5 ``_prompt_dirty`` rebuild
+correctly updated the system prompt model card, but the conversation
+history still contained an earlier ``Understood. I am now gpt-5.4-mini.``
+assistant ack from a *prior* model switch. gpt-5.5 read that historical
+assistant message and inherited the wrong identity.
+
+Verified via OpenAI's gpt-5.5 system card (deploymentsafety.openai.com):
+"should identify itself as GPT-5.5". So the model itself is capable;
+the bug was our breadcrumb pollution.
+
+Two invariants pinned here:
+
+  1. ``_build_model_card(model)`` returns a strong identity assertion
+     (explicit + repeated + override of stale acks) — combats both
+     recency bias and any backend system-layer claim.
+
+  2. ``AgenticLoop.update_model`` purges prior ``"Understood. I am now
+     <prev>."`` assistant acks BEFORE adding the new one. Each switch
+     leaves exactly one active ack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import core.agent.loop as _loop_mod
+from core.agent.system_prompt import _build_model_card
+
+# ---------------------------------------------------------------------------
+# Contract 1 — model card asserts identity strongly
+# ---------------------------------------------------------------------------
+
+
+def test_model_card_asserts_active_identity_for_gpt_5_5() -> None:
+    """The model card must contain the exact model name in a non-negotiable
+    assertion; pre-fix wording was a single soft "You are powered by..."
+    that lost out to history pollution."""
+    card = _build_model_card("gpt-5.5")
+    # Strong identity assertion present.
+    assert "ACTIVE MODEL IDENTITY" in card, (
+        "model card must use the strong-assertion header — pre-fix "
+        "wording was too soft and lost to prior history claims"
+    )
+    # Model name appears multiple times for repetition reinforcement.
+    assert card.count("gpt-5.5") >= 2, (
+        f"model name must repeat in the card, got {card.count('gpt-5.5')} times"
+    )
+    # Explicit override of stale history acks.
+    assert "stale" in card.lower() or "earlier assistant message" in card.lower(), (
+        "card must explicitly tell the LLM to ignore stale acks from prior "
+        "switches in the same conversation"
+    )
+
+
+def test_model_card_includes_provider() -> None:
+    """Sanity: the model card still names the provider for context."""
+    card = _build_model_card("gpt-5.5")
+    assert "openai" in card.lower()
+
+
+def test_model_card_for_anthropic_model() -> None:
+    """Same shape for Anthropic models — identity assertion is provider-agnostic."""
+    card = _build_model_card("claude-opus-4-7")
+    assert "ACTIVE MODEL IDENTITY" in card
+    assert "claude-opus-4-7" in card
+    assert card.count("claude-opus-4-7") >= 2
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — _purge_stale_model_switch_acks removes only our breadcrumb acks
+# ---------------------------------------------------------------------------
+
+
+def _make_loop_stub_with_history(messages: list[dict[str, Any]]) -> MagicMock:
+    """Build an AgenticLoop stub with a controlled conversation history."""
+    stub = MagicMock()
+    stub.context = MagicMock()
+    stub.context.messages = list(messages)
+    # Bind the real method so we test the actual logic.
+    stub._purge_stale_model_switch_acks = (
+        _loop_mod.AgenticLoop._purge_stale_model_switch_acks.__get__(stub)
+    )
+    return stub
+
+
+def test_purge_removes_understood_ack_from_history() -> None:
+    """The exact prior-switch ack 'Understood. I am now gpt-5.4-mini.' must
+    be removed before the next ack is added."""
+    stub = _make_loop_stub_with_history(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello!"},
+            {"role": "user", "content": "[system] Model switched: gpt-5.4 -> gpt-5.4-mini. ..."},
+            {"role": "assistant", "content": "Understood. I am now gpt-5.4-mini."},
+            {"role": "user", "content": "thanks"},
+            {"role": "assistant", "content": "you're welcome"},
+        ]
+    )
+    stub._purge_stale_model_switch_acks()
+    msgs = stub.context.messages
+    # The ack is gone.
+    assert all(
+        not (msg["role"] == "assistant" and "Understood. I am now" in msg.get("content", ""))
+        for msg in msgs
+    )
+    # Other messages preserved.
+    assert any(msg.get("content") == "hello!" for msg in msgs)
+    assert any(msg.get("content") == "you're welcome" for msg in msgs)
+
+
+def test_purge_removes_multiple_stale_acks() -> None:
+    """Multiple switches in one session ⇒ multiple stale acks. All gone."""
+    stub = _make_loop_stub_with_history(
+        [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "Understood. I am now gpt-5.4."},
+            {"role": "user", "content": "Q2"},
+            {"role": "assistant", "content": "Understood. I am now gpt-5.4-mini."},
+            {"role": "user", "content": "Q3"},
+            {"role": "assistant", "content": "Understood. I am now gpt-5.3-codex."},
+        ]
+    )
+    stub._purge_stale_model_switch_acks()
+    msgs = stub.context.messages
+    assert not any(
+        msg["role"] == "assistant" and "Understood. I am now" in msg.get("content", "")
+        for msg in msgs
+    ), "all stale acks must be removed"
+    # User messages preserved.
+    assert sum(1 for m in msgs if m["role"] == "user") == 3
+
+
+def test_purge_does_not_touch_user_messages() -> None:
+    """Even if a user message contains the ack prefix verbatim (extremely
+    unlikely), we never touch user content. Only assistant role."""
+    stub = _make_loop_stub_with_history(
+        [
+            {"role": "user", "content": "Understood. I am now testing this."},
+            {"role": "assistant", "content": "ok"},
+        ]
+    )
+    stub._purge_stale_model_switch_acks()
+    msgs = stub.context.messages
+    # The user message is preserved despite matching the prefix.
+    assert msgs[0]["role"] == "user"
+    assert "Understood. I am now testing this." in msgs[0]["content"]
+
+
+def test_purge_does_not_touch_unrelated_assistant_replies() -> None:
+    """Only the exact prefix matches. Free-form assistant replies that
+    happen to mention 'Understood' or 'now' are preserved."""
+    stub = _make_loop_stub_with_history(
+        [
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "Understood, but here's a different thing."},
+            {"role": "assistant", "content": "I am now ready to help."},
+            {"role": "assistant", "content": "Understood. I am now gpt-5.4-mini."},  # the only one
+        ]
+    )
+    stub._purge_stale_model_switch_acks()
+    msgs = stub.context.messages
+    contents = [m["content"] for m in msgs if m["role"] == "assistant"]
+    assert "Understood, but here's a different thing." in contents
+    assert "I am now ready to help." in contents
+    assert "Understood. I am now gpt-5.4-mini." not in contents
+
+
+def test_purge_on_empty_history_is_noop() -> None:
+    """Edge case: switch happens before any messages exist."""
+    stub = _make_loop_stub_with_history([])
+    stub._purge_stale_model_switch_acks()
+    assert stub.context.messages == []
+
+
+def test_purge_handles_non_string_content() -> None:
+    """Anthropic-style multimodal content (list of blocks) must not crash
+    the purge. Only string-content acks match."""
+    stub = _make_loop_stub_with_history(
+        [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Understood. I am now gpt-5.4-mini."}],
+            },
+            {"role": "assistant", "content": "Understood. I am now gpt-5.4."},  # string match
+        ]
+    )
+    stub._purge_stale_model_switch_acks()
+    msgs = stub.context.messages
+    # The block-form is preserved (not a string), the plain-string ack is removed.
+    assert len(msgs) == 1
+    assert isinstance(msgs[0]["content"], list)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.7"
+version = "0.52.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Production fix: `/model gpt-5.5` was correct in daemon but LLM kept saying "I am gpt-5.4-mini" — root cause was conversation-history breadcrumb pollution from prior switches.
- Fix 1: stronger model card identity assertion (system_prompt). Fix 2: purge stale "Understood. I am now <prev>." acks before adding new one.
- Fix 3 (Codex backend layer override) DEFERRED — no docs evidence after WebFetch.
- 9 invariant tests + gpt-5.5 official spec grounding (2026-04-27 verified).

## Why
After v0.52.7 unlocked Codex tools/reasoning, the user discovered the LLM kept claiming to be a previous model after a `/model` switch. v0.52.5 had added `_prompt_dirty` to rebuild the system prompt — that worked correctly. But each switch also persisted "Understood. I am now <prev_model>." in conversation history. After multiple switches, the new model read those historical assistant claims and inherited the wrong identity.

OpenAI's gpt-5.5 system card explicitly says it should identify as "GPT-5.5" — the model is capable; the bug was our breadcrumb pollution across switches.

## Changes
| File | Change |
|------|--------|
| `core/agent/system_prompt.py:_build_model_card` | Strong identity assertion (explicit + repeated + anti-stale-ack instruction) |
| `core/agent/loop.py:update_model` | Calls new `_purge_stale_model_switch_acks()` before adding the new ack |
| `core/agent/loop.py:_purge_stale_model_switch_acks` (NEW) | Strips assistant messages with exact `"Understood. I am now "` prefix |
| **NEW** `tests/test_model_identity.py` | 9 invariant cases (5 card-side + 4 purge-side) |
| `CHANGELOG.md` + 4-loc bump | 0.52.7 → 0.52.8, tests count → 4177+ |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Strong model card text | Implemented | repeated model name 3+ times, explicit anti-stale-ack |
| Purge stale acks | Implemented | exact prefix match, assistant-role only, string-content only |
| Codex backend override (Fix 3) | **Deferred** | no docs evidence (3 openai.com URLs 403); re-open if bug recurs |
| gpt-5.5 spec grounding | Verified | release 2026-04-23, pricing/context match GEODE v0.52.4 |
| >272K-token premium tier | **New backlog** | 2× input / 1.5× output, not yet in token_tracker |

## Verification
- [x] `uv run ruff check core/ tests/` — All checks passed
- [x] `uv run mypy core/` — 0 issues, 231 files
- [x] `uv run pytest -m "not live"` — full suite green (was 4168, +9 new)

## Reference
- 2 parallel reference agents:
  - **Agent A** — GEODE model identity flow audit (system_prompt rebuild path → conversation history breadcrumbs → Codex backend layer)
  - **Agent C** — gpt-5.5 official spec via WebFetch (developers.openai.com 200, deploymentsafety.openai.com 200; 3 openai.com URLs 403 / Cloudflare)
- OpenAI gpt-5.5 system card: "should identify itself as **GPT-5.5**"