### PR TITLE
feat(v0.53.0): API/OAuth governance redesign — fail-fast on quota + canonical labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.53.0] — 2026-04-27
+
+### Architecture (BREAKING — fail-fast governance redesign)
+- **Cross-provider auto-failover REMOVED**. Per the user-confirmed v0.53.0 governance: API/구독 quota 초과 시 silent provider switch 는 cost surprise + behavior drift + identity 혼동 을 만들어 시스템 불확실성을 키운다 — 친절한 안내 + 시스템 정지가 안정적. Audit doc (3 parallel agents) confirmed claw + hermes 둘 다 같은 원칙 (post-pick auth resolve, no auto-cross-swap).
+  - `core/llm/adapters.py:CROSS_PROVIDER_FALLBACK` map emptied for all providers (anthropic / openai / glm / openai-codex). Back-compat preserved for external imports.
+  - `core/agent/loop.py:_try_cross_provider_escalation` returns False unconditionally (documented no-op).
+  - `core/agent/loop.py:_try_model_escalation` cross-provider for-loop removed; same-provider chain exhaustion now surfaces to user.
+- **Same-provider fallback chain depth reduced to 1** (primary → secondary). Pre-fix `[opus-4-7, opus-4-6, sonnet-4-6]` (depth 2). v0.53.0 `[opus-4-7, sonnet-4-6]`. Same for openai/glm/codex chains. Reduces cost-surprise from cascading retries.
+
+### Fixed
+- **`/model` picker provider label vs ID 불일치** — `"Codex (Plus)"` (marketing) vs `"openai-codex"` (technical) misled users about which auth-mode their pick would consume. v0.53.0 standardises ModelProfile.provider to **canonical provider IDs** (`anthropic` / `openai` / `openai-codex` / `glm`) matching `/login` dashboard + auth.toml. (`core/cli/commands.py:50-64`)
+- **`gpt-5.5` static provider mapping** — pre-fix `_resolve_provider("gpt-5.5")` returned `"openai"` even though OpenAI's official Codex models page (verified v0.52.8 spec doc) says gpt-5.5 is **OAuth-only** ("isn't available with API-key authentication"). Added `_CODEX_ONLY_MODELS` set in `core/config.py` so the static mapping is honest; `resolve_routing()` equivalence-class scan still handles the actual routing. (`core/config.py:_resolve_provider`)
+
+### Added
+- **Plan-aware quota panel** (`quota_exhausted` IPC event). When `BillingError` carries Plan context (provider/plan_id/plan_display_name/upgrade_url/resets_in_seconds), the thin client renders a multi-line panel: header + reset-time + 3 actionable Options (wait / switch auth / switch provider) + upgrade URL. Pre-v0.53.0 the user saw a single-line "Billing error" with no next step; cross-provider auto-failover then silently swapped providers (cost surprise). Now the loop stops + the user decides. (`core/llm/errors.py:BillingError.user_message`, `core/ui/agentic_ui.py:emit_quota_exhausted`, `core/ui/event_renderer.py:_handle_quota_exhausted`, `core/cli/ipc_client.py KNOWN_EVENT_TYPES`)
+- **`_resolve_plan_for_billing_error(model)`** — `core/llm/fallback.py` resolves Plan metadata via `resolve_routing()` so `BillingError` raised from the retry loop carries provider/plan context for the panel.
+- **`docs/research/model-ux-governance.md`** — 544-line audit doc (3 parallel agents: claw+hermes /model UX, GEODE current state, /login UX). All claims cite file:line. Includes 13-gap GAP matrix + Phase 1/F/2/3 redesign plan + Addendum (fail-fast on quota). Source-of-truth for v0.53.0 design decisions.
+
+### Tests
+- **`tests/test_quota_fail_fast.py`** — 11 invariant cases. Cross-provider map empty across all providers. Escalation methods return False (no auto-swap). BillingError carries Plan context. user_message renders multi-line panel with options. `_emit_quota_panel` routes to `quota_exhausted` event when provider present, falls back to `billing_error` legacy path otherwise. `quota_exhausted` in IPC allowlist + EventRenderer handler exists.
+- 7 fixture updates in `tests/test_model_escalation.py` for chain-depth-1 + cross-provider-removed semantics.
+- Fixture update in `tests/test_codex_provider.py` for canonical provider ID (`openai-codex` not `Codex (Plus)`).
+
+### Reference
+- `docs/research/model-ux-governance.md` (544 lines, 3 codebase-grounded agents — all file:line cited).
+- v0.52.4 `resolve_routing()` equivalence-class scan + v0.52.5 GEODE-issued OAuth precedence + v0.52.6 `is_request_fatal` + v0.52.7 Codex Responses parity all stand: governance redesign is *additive policy + UX surface*, not architectural change.
+- User direction (2026-04-27): "사용자가 picks model only; 시스템이 OAuth/API 결정" + "API/구독 quota 초과 → 친절한 안내 + 시스템 중지".
+
 ## [0.52.8] — 2026-04-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.52.8
+- **Version**: 0.53.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 231
-- **Tests**: 4177+
+- **Tests**: 4188+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.52.8 — Long-running Autonomous Execution Harness
+# GEODE v0.53.0 — Long-running Autonomous Execution Harness
 
 범용 자율 실행 에이전트. 자연어 한 줄로 리서치, 분석, 자동화, 스케줄링을 수행합니다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.52.8 — Long-running Autonomous Execution Harness
+# GEODE v0.53.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous execution agent. Performs research, analysis, automation, and scheduling from a single natural-language command.
 

--- a/core/agent/loop.py
+++ b/core/agent/loop.py
@@ -36,7 +36,6 @@ from core.llm.agentic_response import AgenticResponse
 from core.llm.errors import BillingError, UserCancelledError
 from core.llm.prompts import AGENTIC_SUFFIX
 from core.llm.router import (
-    CROSS_PROVIDER_FALLBACK,
     maybe_traceable,
     resolve_agentic_adapter,
 )
@@ -578,6 +577,30 @@ class AgenticLoop:
         # Proactively adapt context for the new model's context window
         self._adapt_context_for_model(model)
 
+    def _emit_quota_panel(self, exc: BillingError) -> None:
+        """v0.53.0 — emit structured quota_exhausted IPC event with Plan
+        context, falling back to legacy billing_error if context absent.
+
+        Pre-v0.53.0 BillingError surfaced as a single-line message and
+        cross-provider auto-failover masked the issue by silently
+        swapping providers (cost surprise + behavior drift). The new
+        flow stops the loop and renders a multi-line panel
+        (header + reset-time + 3 actionable options).
+        """
+        from core.ui.agentic_ui import emit_billing_error, emit_quota_exhausted
+
+        if exc.provider:
+            emit_quota_exhausted(
+                provider=exc.provider,
+                plan_id=exc.plan_id,
+                plan_display_name=exc.plan_display_name,
+                upgrade_url=exc.upgrade_url,
+                resets_in_seconds=exc.resets_in_seconds,
+                message=str(exc),
+            )
+        else:
+            emit_billing_error(str(exc))
+
     def _purge_stale_model_switch_acks(self) -> None:
         """Remove prior ``Understood. I am now <prev_model>.`` assistant acks.
 
@@ -684,11 +707,9 @@ class AgenticLoop:
         try:
             decomposition_hint = self._try_decompose(user_input)
         except BillingError as exc:
-            from core.ui.agentic_ui import emit_billing_error
-
-            emit_billing_error(str(exc))
+            self._emit_quota_panel(exc)
             return AgenticResult(
-                text=str(exc),
+                text=exc.user_message(),
                 rounds=0,
                 termination_reason="billing_error",
             )
@@ -812,11 +833,9 @@ class AgenticLoop:
                 response = await self._call_llm(system_prompt, messages, round_idx=round_idx)
             except BillingError as exc:
                 _spinner.stop()
-                from core.ui.agentic_ui import emit_billing_error
-
-                emit_billing_error(str(exc))
+                self._emit_quota_panel(exc)
                 return AgenticResult(
-                    text=str(exc),
+                    text=exc.user_message(),
                     rounds=round_idx + 1,
                     termination_reason="billing_error",
                 )
@@ -1623,40 +1642,19 @@ class AgenticLoop:
                 self._persist_escalated_model(next_model)
                 return True
 
-        # Current provider's chain exhausted — try cross-provider (Feature 4)
+        # v0.53.0 — Cross-provider escalation REMOVED. When the current
+        # provider's chain is exhausted, surface to user via
+        # quota_exhausted IPC event (handled by BillingError caller path).
+        # No silent provider swap — the user picks the next provider via
+        # /model. Cross-provider info hint (B5 breadcrumb) still surfaces
+        # available alternatives in the next round's LLM context.
         from_provider = self._provider
-        fallbacks = CROSS_PROVIDER_FALLBACK.get(from_provider, [])
-        for fallback_provider, fallback_model in fallbacks:
-            if fallback_model != current:
-                log.warning(
-                    "Cross-provider escalation: %s(%s) -> %s(%s)",
-                    current,
-                    from_provider,
-                    fallback_model,
-                    fallback_provider,
-                )
-                self.update_model(
-                    fallback_model, fallback_provider, reason="cross_provider_escalation"
-                )
-                self._persist_escalated_model(fallback_model)
-                # Emit dedicated cross-provider hook for observability
-                # (MODEL_SWITCHED is also fired by update_model, but this
-                # event carries provider-level context for audit loggers)
-                if self._hooks:
-                    from core.hooks import HookEvent
-
-                    self._hooks.trigger(
-                        HookEvent.FALLBACK_CROSS_PROVIDER,
-                        {
-                            "from_model": current,
-                            "to_model": fallback_model,
-                            "from_provider": from_provider,
-                            "to_provider": fallback_provider,
-                        },
-                    )
-                return True
-
-        log.warning("Model escalation failed: no more fallback models available")
+        log.warning(
+            "Provider %s chain exhausted at model=%s — surfacing to user "
+            "(cross-provider auto-swap removed in v0.53.0)",
+            from_provider,
+            current,
+        )
         return False
 
     @staticmethod
@@ -1670,38 +1668,20 @@ class AgenticLoop:
             log.debug("Failed to persist escalated model to settings", exc_info=True)
 
     def _try_cross_provider_escalation(self) -> bool:
-        """Skip intra-provider chain and go directly to cross-provider fallback.
+        """Disabled in v0.53.0 — cross-provider auto-failover removed.
 
-        Used for auth errors where all models in the same provider share
-        the same expired key — cycling within the chain is pointless.
+        Per the v0.53.0 governance redesign: silent provider switch on
+        auth/quota error creates cost surprise + model behavior drift.
+        Quota exhaustion now emits a ``quota_exhausted`` IPC event so
+        the user can decide whether to switch providers, refresh the
+        token, or wait for quota reset. The cross-provider breadcrumb
+        (B5, v0.52.3) still surfaces *available* alternatives to the
+        LLM as information — but the system will not auto-swap.
         """
-        from_provider = self._provider
-        current = self.model
-        fallbacks = CROSS_PROVIDER_FALLBACK.get(from_provider, [])
-        for fallback_provider, fallback_model in fallbacks:
-            if fallback_model != current:
-                log.warning(
-                    "Auth-triggered cross-provider escalation: %s(%s) -> %s(%s)",
-                    current,
-                    from_provider,
-                    fallback_model,
-                    fallback_provider,
-                )
-                self.update_model(fallback_model, fallback_provider, reason="auth_cross_provider")
-                self._persist_escalated_model(fallback_model)
-                if self._hooks:
-                    from core.hooks import HookEvent
-
-                    self._hooks.trigger(
-                        HookEvent.FALLBACK_CROSS_PROVIDER,
-                        {
-                            "from_model": current,
-                            "to_model": fallback_model,
-                            "from_provider": from_provider,
-                            "to_provider": fallback_provider,
-                        },
-                    )
-                return True
+        log.info(
+            "Cross-provider escalation disabled (v0.53.0) — surfacing quota "
+            "exhaustion to user instead of silent swap"
+        )
         return False
 
     def _inject_credential_breadcrumb(self) -> None:

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -47,20 +47,29 @@ class ModelProfile:
     cost: str  # relative cost indicator
 
 
+# v0.53.0 — provider labels are CANONICAL provider IDs (matching
+# /login dashboard + auth.toml), not marketing names. Pre-fix:
+# "Codex (Plus)" label vs "openai-codex" provider ID mismatch caused
+# user confusion. Auth-mode (OAuth vs PAYG) is NOT in the picker —
+# the system auto-resolves at LLM call time via resolve_routing()
+# based on the user's active /login state.
+#
+# Label = canonical provider ID + cost ($) tier.
+# `gpt-5.5` default routes to `openai-codex` per equivalence-class
+# scan when Codex Plus OAuth is registered (v0.52.4 routing policy);
+# otherwise to `openai` PAYG. Both paths visible via /login dashboard.
 MODEL_PROFILES: list[ModelProfile] = [
-    ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.7", "$$$"),
-    ModelProfile("claude-opus-4-6", "Anthropic", "Opus 4.6", "$$$"),
-    ModelProfile(ANTHROPIC_SECONDARY, "Anthropic", "Sonnet 4.6", "$$"),
-    ModelProfile(ANTHROPIC_BUDGET, "Anthropic", "Haiku 4.5", "$"),
-    ModelProfile(OPENAI_PRIMARY, "OpenAI", "GPT-5.4", "$$"),
-    # `gpt-5.4-mini` has no `-codex` suffix → routes to "openai" provider
-    # (PAYG API key), not Codex Plus quota. Labelling it "Codex (Plus)" misled
-    # users into thinking it consumed their subscription.
-    ModelProfile("gpt-5.4-mini", "OpenAI", "GPT-5.4 Mini", "$"),
-    ModelProfile("gpt-5.3-codex", "Codex (Plus)", "GPT-5.3 Codex", "$$"),
-    ModelProfile(GLM_PRIMARY, "GLM", "GLM-5.1", "$"),
-    ModelProfile("glm-5-turbo", "GLM", "GLM-5 Turbo", "$"),
-    ModelProfile("glm-4.7-flash", "GLM", "GLM-4.7 Flash", "$"),
+    ModelProfile(ANTHROPIC_PRIMARY, "anthropic", "Opus 4.7", "$$$"),
+    ModelProfile("claude-opus-4-6", "anthropic", "Opus 4.6", "$$$"),
+    ModelProfile(ANTHROPIC_SECONDARY, "anthropic", "Sonnet 4.6", "$$"),
+    ModelProfile(ANTHROPIC_BUDGET, "anthropic", "Haiku 4.5", "$"),
+    ModelProfile(OPENAI_PRIMARY, "openai", "GPT-5.5", "$$"),
+    ModelProfile("gpt-5.4", "openai", "GPT-5.4", "$$"),
+    ModelProfile("gpt-5.4-mini", "openai", "GPT-5.4 Mini", "$"),
+    ModelProfile("gpt-5.3-codex", "openai-codex", "GPT-5.3 Codex", "$$"),
+    ModelProfile(GLM_PRIMARY, "glm", "GLM-5.1", "$"),
+    ModelProfile("glm-5-turbo", "glm", "GLM-5 Turbo", "$"),
+    ModelProfile("glm-4.7-flash", "glm", "GLM-4.7 Flash", "$"),
 ]
 
 _MODEL_INDEX: dict[str, ModelProfile] = {m.id: m for m in MODEL_PROFILES}

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -223,6 +223,7 @@ class IPCClient:
                 "oauth_login_failed",
                 # Daemon-side error surfaces (v0.51.1 IPC parity)
                 "billing_error",
+                "quota_exhausted",  # v0.53.0 — plan-aware quota panel
                 # LLM lifecycle events
                 "llm_retry",
                 "llm_error",

--- a/core/config.py
+++ b/core/config.py
@@ -365,29 +365,32 @@ settings = _get_settings()
 # All code MUST reference these instead of hardcoding model strings.
 # ---------------------------------------------------------------------------
 
-# Anthropic models — verified 2026-04-26 against platform.claude.com
+# Anthropic models — verified 2026-04-26 against platform.claude.com.
+# v0.53.0 — chain depth reduced to 1 (primary → secondary only) per
+# fail-fast governance: deeper chains create cost surprise + unclear
+# user attribution. Quota exhaustion now surfaces a panel + stops loop.
 ANTHROPIC_PRIMARY = "claude-opus-4-7"
 ANTHROPIC_SECONDARY = "claude-sonnet-4-6"
 ANTHROPIC_BUDGET = "claude-haiku-4-5-20251001"
-ANTHROPIC_FALLBACK_CHAIN: list[str] = [ANTHROPIC_PRIMARY, "claude-opus-4-6", ANTHROPIC_SECONDARY]
+ANTHROPIC_FALLBACK_CHAIN: list[str] = [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY]
 
 # OpenAI models — verified 2026-04-26 against developers.openai.com.
-# v0.52.4 — gpt-5.5 promoted to primary (Codex's new default model);
-# pre-5.3 generation dropped per current CLAUDE.md model-currency policy.
+# v0.52.4 — gpt-5.5 promoted to primary (Codex's new default model).
+# v0.53.0 — chain depth reduced to 1 (primary → next).
 OPENAI_PRIMARY = "gpt-5.5"
-OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"]
+OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.4"]
 
 # OpenAI Codex — Plus quota via chatgpt.com/backend-api/codex (Responses API).
-# v0.52.4 — gpt-5.5 is OAuth-only ("isn't available with API-key
-# authentication" per developers.openai.com/codex/models). Promoted to
-# CODEX_PRIMARY so /login oauth users get the real default.
+# v0.52.4 — gpt-5.5 OAuth-only (developers.openai.com/codex/models).
+# v0.53.0 — chain depth reduced to 1.
 CODEX_PRIMARY = "gpt-5.5"
-CODEX_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.3-codex", "gpt-5.4-mini"]
+CODEX_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.3-codex"]
 CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
-# ZhipuAI (GLM) models — OpenAI-compatible API, separate provider
+# ZhipuAI (GLM) models — OpenAI-compatible API, separate provider.
+# v0.53.0 — chain depth reduced to 1 (primary → secondary).
 GLM_PRIMARY = "glm-5.1"
-GLM_FALLBACK_CHAIN: list[str] = ["glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7-flash"]
+GLM_FALLBACK_CHAIN: list[str] = ["glm-5.1", "glm-5"]
 # Coding Plan endpoint (subscription-billed). PAYG endpoint is api/paas/v4 — a
 # Coding Plan key called against PAYG path silently bypasses the subscription
 # quota and incurs metered billing instead.
@@ -395,24 +398,42 @@ GLM_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 GLM_PAYG_BASE_URL = "https://api.z.ai/api/paas/v4"
 
 
+# v0.53.0 — models that are CODEX-ONLY per OpenAI's official Codex
+# models page (developers.openai.com/codex/models, verified 2026-04-27).
+# These can ONLY be called via chatgpt.com/backend-api/codex (OAuth);
+# no API-key path. Pre-fix _resolve_provider returned "openai" for
+# gpt-5.5 → static map misled router; resolve_routing's equivalence-
+# class scan corrected at runtime, but the user-visible mapping was
+# wrong. Listing here makes the OAuth-only constraint explicit.
+_CODEX_ONLY_MODELS: frozenset[str] = frozenset(
+    {
+        "gpt-5.5",
+        "gpt-5.5-pro",
+    }
+)
+
+
 def _resolve_provider(model: str) -> str:
     """Resolve provider name from model ID.
 
     Prefix-based inference with broad model coverage:
-      claude-*   → anthropic
-      glm-*      → glm
-      gpt-*      → openai
-      o3-*/o4-*  → openai
-      gemini-*   → google
-      deepseek-* → deepseek
-      llama-*    → meta
-      qwen-*/qwen3* → alibaba
-      (fallback) → openai
+      claude-*                    → anthropic
+      glm-*                       → glm
+      gpt-5.5 / gpt-5.5-pro       → openai-codex (OAuth-only models)
+      *-codex / *-codex-max/mini  → openai-codex
+      gpt-* / o3-* / o4-*         → openai
+      gemini-*                    → google
+      deepseek-*                  → deepseek
+      llama-*                     → meta
+      qwen-*/qwen3*               → alibaba
+      (fallback)                  → openai
     """
     if model.startswith("claude-"):
         return "anthropic"
     if model.startswith("glm-"):
         return "glm"
+    if model in _CODEX_ONLY_MODELS:
+        return "openai-codex"
     if model.endswith("-codex") or model.endswith("-codex-max") or model.endswith("-codex-mini"):
         return "openai-codex"
     if model.startswith(("gpt-", "o3-", "o4-")):

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -14,7 +14,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel
 
-from core.config import ANTHROPIC_PRIMARY, OPENAI_PRIMARY, settings
+from core.config import settings
 from core.llm.agentic_response import AgenticResponse
 
 log = logging.getLogger(__name__)
@@ -207,14 +207,20 @@ _ADAPTER_MAP: dict[str, str] = {
     "openai-codex": "core.llm.providers.codex:CodexAgenticAdapter",
 }
 
-# Cross-provider fallback: when a provider's chain is exhausted, try these.
-# Plan-aware fallback (Phase 5) replaces this; for v0.50.0 Phase 0 we drop
-# implicit GLM↔OpenAI jumps so a Coding Plan auth error doesn't silently
-# spill onto a metered OpenAI key. openai-codex shares OAuth scope with no
-# other provider, so its Anthropic fallback is removed too.
+# v0.53.0 — Cross-provider fallback REMOVED.
+# Per the v0.53.0 governance redesign: API/구독 quota 초과 시 silent
+# provider switch 는 cost surprise + model behavior drift 를 만들어
+# 시스템 불확실성을 키운다. 사용자에게 명시적으로 quota 안내 + system
+# stop 이 정확. The v0.53.0 BillingError → quota_exhausted IPC event
+# 경로가 fail-fast 를 담당. Cross-provider hint (B5 breadcrumb,
+# v0.52.3) 는 LLM 이 다른 provider 존재를 알 수 있게 *정보* 만 주입 —
+# 자동 swap 과 분리.
+#
+# Empty map preserved for back-compat with any external import; will be
+# removed in a future release once all callers stop importing.
 CROSS_PROVIDER_FALLBACK: dict[str, list[tuple[str, str]]] = {
-    "anthropic": [("openai", OPENAI_PRIMARY)],
-    "openai": [("anthropic", ANTHROPIC_PRIMARY)],
+    "anthropic": [],
+    "openai": [],
     "glm": [],
     "openai-codex": [],
 }

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -50,7 +50,62 @@ class BillingError(Exception):
 
     Caught at the UI layer to display a clean one-line message instead
     of a full traceback.  Never retried or counted as a model failure.
+
+    v0.53.0 — carries provider/plan context so the UI can render a
+    plan-aware quota-exhausted panel (resets-in, upgrade URL, options
+    to switch provider). Plain-string ``str(exc)`` still works for
+    legacy call sites.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str = "",
+        plan_id: str = "",
+        plan_display_name: str = "",
+        upgrade_url: str = "",
+        resets_in_seconds: int = 0,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.plan_id = plan_id
+        self.plan_display_name = plan_display_name
+        self.upgrade_url = upgrade_url
+        self.resets_in_seconds = resets_in_seconds
+
+    def user_message(self) -> str:
+        """Render a multi-line, plan-aware quota-exhausted message.
+
+        Pattern: header (provider + plan) + reset-time + 3 options
+        (wait / switch auth / switch provider). Pre-v0.53.0 the user
+        saw "All glm models exhausted" with no actionable next step.
+        """
+        lines: list[str] = []
+        if self.plan_display_name or self.provider:
+            who = self.plan_display_name or self.provider or "this provider"
+            lines.append(f"⚠ {who} quota exhausted")
+        else:
+            lines.append("⚠ Provider quota exhausted")
+        lines.append(f"  {str(self) or 'Billing/credit limit reached.'}")
+        if self.resets_in_seconds and self.resets_in_seconds > 0:
+            mins = self.resets_in_seconds // 60
+            ttl = f"{mins // 60}h {mins % 60}m" if mins >= 60 else f"{mins}m"
+            lines.append(f"  Resets in: {ttl}")
+        lines.append("")
+        lines.append("Options:")
+        lines.append("  1. Wait for quota reset")
+        if self.provider:
+            lines.append(
+                f"  2. Switch auth: /login set-key {self.provider} <api-key>  "
+                "(use a different credential)"
+            )
+        else:
+            lines.append("  2. Switch auth: /login set-key <provider> <api-key>")
+        lines.append("  3. Switch provider: /model <other-model>")
+        if self.upgrade_url:
+            lines.append(f"  4. Upgrade plan: {self.upgrade_url}")
+        return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -99,6 +99,31 @@ def _notify_failure(provider: str, exc: Exception) -> None:
         log.debug("Profile notify_failure failed for %s", provider, exc_info=True)
 
 
+def _resolve_plan_for_billing_error(model: str) -> dict[str, str]:
+    """Resolve Plan metadata for a model so BillingError carries context.
+
+    v0.53.0 — used to render plan-aware quota-exhausted panels. Returns
+    ``provider``, ``plan_id``, ``plan_display_name``, ``upgrade_url``.
+    Empty values when routing fails (caller falls back to generic msg).
+    """
+    try:
+        from core.auth.plan_registry import resolve_routing
+
+        target = resolve_routing(model)
+        if target is None:
+            return {}
+        plan = target.plan
+        return {
+            "provider": plan.provider,
+            "plan_id": plan.id,
+            "plan_display_name": plan.display_name,
+            "upgrade_url": plan.upgrade_url or "",
+        }
+    except Exception:
+        log.debug("Plan resolution for billing error failed", exc_info=True)
+        return {}
+
+
 class CircuitBreaker:
     """Thread-safe circuit breaker for LLM API calls.
 
@@ -252,7 +277,16 @@ def retry_with_backoff_generic(
                         current_model,
                         msg,
                     )
-                    raise BillingError(msg or billing_message) from exc
+                    # v0.53.0 — attach plan context so the UI can render a
+                    # plan-aware quota-exhausted panel.
+                    plan_meta = _resolve_plan_for_billing_error(current_model)
+                    raise BillingError(
+                        msg or billing_message,
+                        provider=plan_meta.get("provider", ""),
+                        plan_id=plan_meta.get("plan_id", ""),
+                        plan_display_name=plan_meta.get("plan_display_name", ""),
+                        upgrade_url=plan_meta.get("upgrade_url", ""),
+                    ) from exc
                 last_error = exc
                 delay = random.uniform(0, min(retry_base_delay * (2**attempt), retry_max_delay))
                 elapsed = time.monotonic() - t0_retry

--- a/core/ui/agentic_ui.py
+++ b/core/ui/agentic_ui.py
@@ -964,6 +964,43 @@ def emit_billing_error(message: str) -> None:
     console.print()
 
 
+def emit_quota_exhausted(
+    *,
+    provider: str,
+    plan_id: str = "",
+    plan_display_name: str = "",
+    upgrade_url: str = "",
+    resets_in_seconds: int = 0,
+    message: str = "",
+) -> None:
+    """v0.53.0 — emit a plan-aware quota-exhausted panel event.
+
+    Distinct from ``emit_billing_error`` (which is a single-line UI):
+    this carries the structured Plan context so the thin client renders
+    a multi-line actionable panel (header + reset-time + Options 1/2/3).
+    Pre-v0.53.0 the user saw ``"All glm models exhausted"`` with no
+    next step; this surfaces the user-paid plan + a switch path.
+    """
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "quota_exhausted",
+            provider=provider,
+            plan_id=plan_id,
+            plan_display_name=plan_display_name,
+            upgrade_url=upgrade_url,
+            resets_in_seconds=resets_in_seconds,
+            message=message,
+        )
+        return
+    console.print()
+    label = plan_display_name or provider or "Provider"
+    console.print(f"  [error]⚠ {label} quota exhausted[/error]")
+    if message:
+        console.print(f"  {message}")
+    console.print()
+
+
 # ───────────────────────────────────────────────────────────────────────────
 # Structured IPC event emitters — Pipeline milestones
 # ───────────────────────────────────────────────────────────────────────────

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -438,6 +438,47 @@ class EventRenderer:
         self._out.write(f"\n  \033[1;31m✗ Billing error\033[0m — {message}\n\n")
         self._out.flush()
 
+    def _handle_quota_exhausted(self, event: dict[str, Any]) -> None:
+        """v0.53.0 — render plan-aware quota panel.
+
+        Multi-line: header (provider/plan) + reset-time + 3 actionable
+        options (wait / switch auth / switch provider). Replaces the
+        single-line billing_error UX which gave the user no next step.
+        """
+        provider = str(event.get("provider", ""))
+        plan_id = str(event.get("plan_id", ""))
+        plan_label = str(event.get("plan_display_name", ""))
+        upgrade_url = str(event.get("upgrade_url", ""))
+        resets_in = int(event.get("resets_in_seconds", 0) or 0)
+        message = str(event.get("message", ""))
+
+        self._clear_activity_line()
+        label = plan_label or provider or "Provider"
+        self._out.write(f"\n  \033[1;31m⚠ {label} quota exhausted\033[0m\n")
+        if message:
+            self._out.write(f"  {message}\n")
+        if plan_id and plan_id != plan_label:
+            self._out.write(f"  Plan: \033[1m{plan_id}\033[0m\n")
+        if resets_in > 0:
+            mins = resets_in // 60
+            ttl = f"{mins // 60}h {mins % 60}m" if mins >= 60 else f"{mins}m"
+            self._out.write(f"  Resets in: \033[1m{ttl}\033[0m\n")
+        self._out.write("\n  \033[1mOptions:\033[0m\n")
+        self._out.write("    1. Wait for quota reset\n")
+        if provider:
+            self._out.write(
+                f"    2. Switch auth: \033[36m/login set-key {provider} <api-key>\033[0m\n"
+            )
+        else:
+            self._out.write(
+                "    2. Switch auth: \033[36m/login set-key <provider> <api-key>\033[0m\n"
+            )
+        self._out.write("    3. Switch provider: \033[36m/model <other-model>\033[0m\n")
+        if upgrade_url:
+            self._out.write(f"    4. Upgrade plan: \033[36m{upgrade_url}\033[0m\n")
+        self._out.write("\n")
+        self._out.flush()
+
     # -- Pipeline milestone events (client-side rendering) --------------------
 
     def _handle_pipeline_header(self, event: dict[str, Any]) -> None:

--- a/docs/research/model-ux-governance.md
+++ b/docs/research/model-ux-governance.md
@@ -1,0 +1,544 @@
+# Model & Login UX Governance Audit
+
+Audit of credential/plan registration (/login) and model selection (/model) across three CLI harnesses, examining separation of concerns, multi-provider clarity, and token/subscription lifecycle management.
+
+**Principle under test**: User logs in with one auth mode at a time; system stores it; later `/model` selection just picks a bare model name — auth mode choice must be upstream, not conflated with model choice.
+
+Built 2026-04-27 by 3 parallel agents (claw+hermes /model UX | GEODE /model audit | /login UX 3-codebase). All claims cite file:line. No external doc references — codebases only.
+
+---
+
+## /model UX governance — OpenClaw + Hermes reference
+
+### OpenClaw
+
+**`/model` picker**: `/Users/mango/workspace/openclaw/src/flows/model-picker.ts:118-158` — shows bare `provider/model` keys (e.g. `anthropic/claude-sonnet-4-5`), auth status as **hint** (`"auth missing"` line 150), not a filter.
+
+```ts
+// model-picker.ts:152-156
+params.options.push({
+  value: key,
+  label: key,                  // bare provider/model key
+  hint: hints.length > 0 ? hints.join(" · ") : undefined,
+});
+```
+
+**Auth resolution**: `/Users/mango/workspace/openclaw/src/agents/model-auth.ts:340-478` — single entry point `resolveApiKeyForProvider({provider, ...})`. Precedence: explicit profileId → `models.providers.<p>.auth` override → config apiKey → profile order → env vars → custom config → synthesized.
+
+**Per-provider order user override**: ✅ `models auth-order set <provider> <profile-1> <profile-2>` (`commands/models/auth-order.ts:46-71`).
+
+**System prompt model identity injection**: ❌ not found — model name passed as SDK parameter only.
+
+### Hermes Agent
+
+**`/model` picker**: `/Users/mango/workspace/hermes-agent/hermes_cli/model_switch.py:226-243` — auth-aware filter via `list_authenticated_providers()` (line 783-1190); shows bare model names (`gpt-4o`, `claude-opus-4-6`) per authenticated provider.
+
+**Auth resolution**: `model_switch.py:411-776` calls `resolve_runtime_provider(requested=target_provider)` (`runtime_provider.py:109-230+`). Precedence: PROVIDER_REGISTRY env vars → auth store (auth.json) → credential pool → base_url override.
+
+**Per-provider order**: ❌ rigid — fixed by `PROVIDER_REGISTRY[provider].api_key_env_vars` tuple order (`auth.py:108-150`).
+
+**System prompt model identity injection**: ❌ not found.
+
+### Comparison — /model UX
+
+| Concern | OpenClaw | Hermes | Pattern |
+|---------|----------|--------|---------|
+| Picker shows | bare `provider/model` + auth hint | bare model + provider context (filter by login) | bare names, no auth-mode label |
+| Auth resolved at | LLM call time | LLM call time | post-pick |
+| Per-provider tunable order | ✅ `auth-order set` | ❌ env priority | OpenClaw more flexible |
+| Model identity in system prompt | ❌ | ❌ | trust SDK parameter |
+| Forced override | `auth: "api-key"` config + auth-order | none (rigid) | OpenClaw |
+
+---
+
+## /model UX governance — GEODE current state (v0.52.7)
+
+**`/model` command handler**: `core/cli/commands.py:449-509`. Static `MODEL_PROFILES` registry (line 50-64) — bare model IDs + provider labels + cost. NO auth-mode in label.
+
+```python
+# commands.py:50-64
+MODEL_PROFILES = [
+    ModelProfile(ANTHROPIC_PRIMARY, "Anthropic", "Opus 4.7", "$$$"),
+    ModelProfile(OPENAI_PRIMARY, "OpenAI", "GPT-5.4", "$$"),  # ⚠ label "GPT-5.4" but ID = "gpt-5.5"
+    ModelProfile("gpt-5.4-mini", "OpenAI", "GPT-5.4 Mini", "$"),
+    ModelProfile("gpt-5.3-codex", "Codex (Plus)", "GPT-5.3 Codex", "$$"),
+    ModelProfile(GLM_PRIMARY, "GLM", "GLM-5.1", "$"),
+]
+```
+
+**Auth resolution** (post v0.52.4): `core/llm/router.py:_route_provider` → `core/auth/plan_registry.py:resolve_routing` 4-step chain (explicit routing → equivalence-class scan with `PLAN_KIND_PRIORITY` → single-provider fallback → synthesize PAYG). `forced_login_method` honored at line 176.
+
+**Codex token resolution** (v0.52.5): `core/llm/providers/codex.py:54-101` — 2-pass (`managed_by=""` first, then borrowed CLI, then `~/.codex/auth.json`).
+
+**Picker source filter**: ❌ static `MODEL_PROFILES` — all 10 models always shown, no login-state filter.
+
+**`forced_login_method` UX surface**: ❌ defined at `core/config.py:328`, read by `plan_registry.py:249`, but `/model` picker shows NO indication when set.
+
+**System prompt model identity injection** (v0.52.8): ✅ `core/agent/system_prompt.py:_build_model_card` strong assertion. ⚠ **Diverges from claw + hermes** (both don't inject).
+
+### GEODE governance gaps (5)
+
+| # | Gap | File:line |
+|---|-----|-----------|
+| 1 | "Codex (Plus)" label vs `openai-codex` provider ID 불일치 | `commands.py:60` |
+| 2 | `forced_login_method` 가 `/model` UX 에 안 보임 | `_apply_model` 분리 |
+| 3 | `gpt-5.5` 가 static `_resolve_provider` 에서 `"openai"` 로 매핑되지만 실제 Codex-only | `core/config.py:_resolve_provider` |
+| 4 | Silent credential fallback 중 user-facing signal 없음 | `resolve_routing` chain |
+| 5 | `MODEL_PROFILES` 가 login state 필터링 없음 | `commands.py:50` |
+
+### v0.52.8 system prompt assertion 재검토 필요
+
+reference (claw + hermes) 둘 다 system prompt 에 model identity 안 주입. GEODE v0.52.8 의 strong assertion 은 다른 방향. **재검토 결정 후보**:
+- (A) 유지 — 우리 incident 재발 방지가 우선 + reference 도 안 하지만 우리 LLM 호출 환경 (Codex backend 포함) 이 더 까다로움
+- (B) 약화 — reference 와 align, 단 conversation history 의 stale ack purge (Fix 2) 만 유지
+- (C) Codex backend 만 따로 처리 — chatgpt.com 호출시 강한 assertion, api.openai.com 등은 제거
+
+---
+
+## /login UX governance
+
+### OpenClaw
+
+**Entry point**: `/openclaw models auth <subcommand>` (nested under `models` command)
+- File:line: `/Users/mango/workspace/openclaw/src/cli/models-cli.ts:290–441`
+
+**Subcommands**:
+```
+openclaw models auth                    — show help
+openclaw models auth add                — interactive auth helper
+openclaw models auth login              — provider OAuth/API key flow
+openclaw models auth setup-token        — provider CLI auth (TTY)
+openclaw models auth paste-token        — paste token to auth-profiles.json
+openclaw models auth login-github-copilot — GitHub Copilot device flow
+openclaw models auth order get          — show per-agent profile order override
+openclaw models auth order set          — pin profiles in rotation order
+openclaw models auth order clear        — reset to config default
+```
+
+**Login flow steps** (verbatim from code):
+1. Picker for provider? **Yes** — required flag `--provider <id>` or interactive
+2. Auth method choice? **Yes** (if plugin supports multiple) — flag `--method <id>`
+3. What's stored at end?
+   - File: `/Users/mango/workspace/openclaw/src/commands/models/auth.ts:20–32` imports `upsertAuthProfile`
+   - Stores: `AuthProfileCredential` with `{ provider, method, profileId, expiresAt, refreshToken, accessToken }`
+   - Storage: `.openclaw/auth-profiles.json` (per-agent)
+4. Confirmation message? **Yes, implicit** — command completes silently or shows "Profile added"
+
+**Login dashboard / status view**:
+- Command: `openclaw models status` (file:line: `/src/commands/models/list.status-command.ts:63–180`)
+- What's shown:
+  - **Model default** (active model label)
+  - **Fallback chain** (ordered list)
+  - **Provider auth overview** per provider:
+    - Profile count (`profiles.count`)
+    - Env var presence + source
+    - models.json overrides
+  - **Missing auth** for in-use providers (red badge)
+- Active marker? **Per-provider**: `✓ count` of profiles; current rotation shown in `models auth order get`
+- Plan vs provider? **No plan abstraction in OpenClaw** — only provider IDs + method IDs, no subscription tier visibility
+
+**Multi-provider register UX**:
+- Example: User has both Anthropic API key + GitHub Copilot OAuth registered
+- Dashboard visibility: **Via `models status`** shows both under their provider headings
+- Active per model? **Yes** — `models auth order set --provider <id> <profiles...>` pins rotation order for that provider
+- Removal: `models auth` does NOT have a `remove` subcommand visible in CLI registration (file:line 296–441); removal happens via direct auth-profiles.json edit or plugin
+
+**Refresh / token expiry UX**:
+- Auto-refresh? **Plugin-dependent** — OpenClaw doesn't provide CLI-level auto-refresh
+- User notification? **Via `models status --probe`** (line 73–88) — `--check` flag exits non-zero if expired
+- Refresh command? **No explicit `/login refresh`** — only plugin-level token refresh embedded in OAuth flows
+
+**Anti-conflation check**:
+- Does `/models` ever ask for auth-mode? **NO** — `models set <model>` accepts only bare model name (line 118–123)
+- Does `/models auth` ever ask for model? **NO** — auth subcommands only take provider + method + profile args (line 296–441)
+
+---
+
+### Hermes Agent
+
+**Entry point**: `hermes auth <subcommand>` (top-level command)
+- File:line: `/Users/mango/workspace/hermes-agent/hermes_cli/auth_commands.py:572–587`
+
+**Subcommands**:
+```
+hermes auth             — interactive credential pool dashboard
+hermes auth add        — add credential (provider picker, auth type picker)
+hermes auth list       — show all credentials (grouped by provider)
+hermes auth remove     — remove credential by label/id/index
+hermes auth reset      — reset cooldown timers for a provider
+```
+
+**Login flow steps** (verbatim from code):
+1. Picker for provider? **Yes** — interactive via `_pick_provider()` (line 449–463) or CLI arg `--provider`
+2. Auth method choice? **Yes** — if provider in `_OAUTH_CAPABLE_PROVIDERS` (line 36), prompt "API key vs OAuth" (line 472–483)
+3. What's stored at end?
+   - File: `/hermes_cli/auth_commands.py:185–195` (API key path)
+   - Stores: `PooledCredential` with `{ provider, id, label, auth_type, priority, source, access_token, refresh_token, expires_at_ms, base_url }`
+   - Print output: `Added {provider} credential #{count}: "{label}"` (line 196)
+4. Confirmation message? **Yes, explicit** — prints "Added {provider} credential #{N}: …" (line 196, 222)
+
+**Login dashboard / status view**:
+- Command: `hermes auth` (bare, triggers `_interactive_auth()` at line 389)
+- What's shown:
+  - **Credential Pool Status** (line 392)
+  - **Per-provider section**: `{provider} ({count} credentials):`
+  - **Per-credential row**: `#{idx}  {label:<20} {auth_type:<7} {source}{status} {marker}`
+  - **Current marker**: `← ` (arrow) next to `pool.peek()` entry (line 336–337)
+  - **Exhaustion status**: cooldown timer if rate-limited (line 113–136)
+  - **AWS Bedrock credential** status (if available, line 398–414)
+- Active marker? **Yes** — `← ` explicitly shows which credential is "current" (next to use)
+- Plan abstraction? **No** — only providers + credentials, no subscription tiers
+
+**Multi-provider register UX**:
+- Example: User has OpenAI API key + Anthropic OAuth + Custom OpenRouter
+- Dashboard visibility: **Excellent** — `hermes auth` groups by provider, each row shows:
+  - Label (custom name)
+  - Auth type (oauth / api-key)
+  - Source (env: / manual: / device_code / etc.)
+  - Exhaustion status (if rate-limited)
+  - Rotation strategy marker
+- Active per provider? **Yes** — `pool.peek()` returns the next credential to use (line 332); `← ` marker on current
+- Switching: `hermes auth` interactive menu offers "Set rotation strategy" (line 425, `_interactive_strategy()`)
+- Removal: `hermes auth remove` by label/id/index (line 344–356)
+
+**Refresh / token expiry UX**:
+- Auto-refresh? **Managed by pool** — checks `expires_at_ms` on peek, rotates if expired
+- User notification? **In pool status**: `exhausted (X days left)` for tokens in cooldown (line 136)
+- Refresh command? **`hermes auth reset`** — clears cooldown timers for a provider (line 382–386)
+
+**Anti-conflation check**:
+- Does model selection ever ask for auth? **NO** — credential pool is independent of model routing
+- Does auth ever ask for model? **NO** — auth_commands.py has zero model selection logic
+
+---
+
+### GEODE current (v0.50.0+)
+
+**Entry point**: `/login <subcommand>` (unified command in CLI REPL)
+- File:line: `/Users/mango/workspace/geode/core/cli/commands.py:1887–1997`
+
+**Subcommands**:
+```
+/login                 — show plans, profiles, routing, quota dashboard
+/login add             — interactive wizard (kind → provider → key/OAuth)
+/login oauth <prov>    — OAuth device flow (currently: openai/codex)
+/login set-key <plan> <key>  — update a plan's API key
+/login use <plan>      — pin a plan as active for its provider
+/login remove <plan>   — delete a plan
+/login route <model> <plan> … — bind model to plan(s) in priority order
+/login quota           — per-plan usage breakdown
+/login status          — legacy alias of bare /login
+/login refresh         — reload auth.toml (v0.52 thin-client relay)
+```
+
+**Login flow steps** (verbatim from code):
+1. Picker for provider? **Yes + kind** — interactive wizard (line 2146):
+   - Step 1: kind selector (subscription / payg / oauth) (line 2170–2175)
+   - Step 2: provider selector (glm-coding / openai / anthropic / glm) (line 2244)
+   - Step 3: endpoint/key/OAuth entry (line 2209 for subscription tier, getpass for key)
+2. What's stored at end?
+   - Files: `core/auth/plan_registry.py` + `core/auth/profiles.py` (Plan + AuthProfile)
+   - Plan stores: `{ id, kind, provider, base_url, quota, subscription_tier }`
+   - Profile stores: `{ name, provider, credential_type, key, plan_id, expires_at, managed_by }`
+   - Print: `[success]Registered[/success] {plan.display_name} ({plan.base_url})` (line 2238)
+3. Confirmation message? **Yes, explicit** — "Registered GLM Coding Pro (glm.zhipuai.com)" (line 2237–2239)
+
+**Login dashboard / status view**:
+- Command: `/login` (bare) → `_login_show_status()` (line 2020–2143)
+- Sections shown:
+  1. **Plans** — subscription lines with:
+     - Mark: `✓` (bound profile exists) or `?` (no profile yet)
+     - Plan ID, kind, base_url, subscription_tier
+     - Quota: `used {calls}/{max} ({window}h, {remaining} left)`
+  2. **Profiles** — grouped by provider:
+     - Eligibility badge: `✓` (ok), `✗ {reason}` (cooldown/expired/disabled)
+     - Name, credential type (oauth/api-key/token), masked key
+     - Plan ID, managed_by (if external source), expiry countdown
+  3. **Routing** — model → plan chain (line 2115–2121)
+  4. **OAuth (external CLIs)** — Codex CLI + Claude Code OAuth status (line 2124–2139)
+- Active marker? **Per-profile eligibility** (line 2080–2106) + routing chains show priority
+- Plan vs provider distinction? **Yes, explicitly** — Plans are first-class; profiles are credentials bound to plans
+
+**Multi-provider register UX**:
+- Example: User has both OpenAI API key (PAYG) + GLM Coding Pro (subscription)
+- Dashboard visibility: **Excellent**:
+  - Plans section shows both GLM Coding Pro + OpenAI PAYG, with their quotas
+  - Profiles section shows both providers, with eligibility badges
+  - Routing section shows explicit model → [plan1, plan2, ...] chains
+- Active per model? **Yes** — `/login route gpt-5.4 openai-payg openai-something-else` pins order (line 1932)
+- Conflation clarity? **Very explicit**:
+  - File:line `2056–2061`: `bound = [p for p in profiles if p.plan_id == plan.id]` — shows which profiles belong to which plan
+  - Eligibility verdict line 2099–2106: per-profile reason codes (cooldown, expired, etc.)
+- Removal: `/login remove <plan>` (line 1929–1930)
+
+**Refresh / token expiry UX**:
+- Auto-refresh? **No** — tokens are checked on next request; if expired, request fails
+- User notification? **In `/login` dashboard**: `expires {rem}m` or `[error]expired[/error]` inline (line 2097)
+- Refresh command? **`/login refresh`** (line 1938–1989) — reloads auth.toml (additive-only merge; file:line 1944–1955 documents invariants)
+
+**Anti-conflation check**:
+- Does `/model` ever ask for auth? **NO** — `/model` picker only touches `ModelProfile` ID + applies context window guard (file:line 449–510)
+- Does `/login` ever ask for model? **NO** — `/login add` wizard is `kind → provider → key/OAuth`, zero model questions (file:line 2146–2310)
+
+---
+
+## Comparison + GAP table
+
+| Concern | OpenClaw | Hermes | GEODE | Gap |
+|---------|----------|--------|-------|-----|
+| **Login entry** | `models auth` (nested) | `auth` (top-level) | `/login` (REPL) | Entry point depth differs; OpenClaw requires 2 steps |
+| **Subcommand count** | 7 (auth + order variants) | 4 (auth + list/remove/reset) | 9 (auth + route/quota/refresh) | GEODE offers most surface area (routing, quota tracking) |
+| **Provider picker required?** | Yes (--provider or interactive) | Yes (interactive or --provider) | Yes (kind → provider sequence) | All require provider selection; GEODE adds kind (subscription vs PAYG) |
+| **Multi-provider ambiguity** | Moderate — no explicit active marker per provider | Excellent — `← ` shows current, rotation strategy visible | Excellent — routing chains + eligibility badges explicit | Hermes & GEODE both surface active/next; OpenClaw requires `models auth order get` |
+| **Subscription tier visibility** | None — only provider + method | None — only provider + auth_type | Yes — plan ID, tier, quota, window | GEODE only one with subscription tier UX |
+| **Confirmation on success** | Implicit (silent) | Explicit (`Added {provider} credential …`) | Explicit (`[success]Registered[/success] …`) | OpenClaw lacks user feedback; Hermes & GEODE explicit |
+| **OAuth status display** | Via `models status --probe` | Via pool exhaustion status | Via `/login` OAuth section + refresh countdown | GEODE most integrated (email, source, expires_in) |
+| **Refresh / expiry handling** | Plugin-level only | Pool auto-rotate + `hermes auth reset` | `/login refresh` + eligibility verdict + countdown | GEODE most user-visible (countdown, eligibility badges) |
+| **Forced login method** | No (inherent to provider) | No (pool is opaque to model selection) | No (auth is upstream of model routing) | ✓ Anti-conflation: all three separate concerns |
+| **Model ever asks for auth-mode?** | NO | NO | NO | ✓ All three pass anti-conflation test |
+
+---
+
+## Anti-conflation findings
+
+### /login never asks for model
+- **OpenClaw**: `models auth` subcommands take only `--provider`, `--method`, `--profile-id` (file:line 304–361)
+- **Hermes**: `auth_add_command` takes only provider, auth_type, label (file:line 140–195)
+- **GEODE**: `/login add` wizard is kind → provider → key, zero model gates (file:line 2146–2310)
+
+**Verdict**: ✓ ALL THREE SYSTEMS PASS
+
+### /model never asks for auth-mode
+- **OpenClaw**: `models set <model>` accepts only model ID (file:line 117–123); no auth picker
+- **Hermes**: No credential selection in model routing; pool is transparent to model choice
+- **GEODE**: `/model` picker is `MODEL_PROFILES` list only; no plan/provider picker (file:line 449–510)
+
+**Verdict**: ✓ ALL THREE SYSTEMS PASS
+
+### No forced auth-before-model pattern
+- **OpenClaw**: Model selection can happen with incomplete auth; provider auth errors caught at request time
+- **Hermes**: Model routing is credential-pool-agnostic; rotation happens at inference time
+- **GEODE**: `/model` applies context window guard but does NOT check auth readiness (file:line 382–382)
+
+**Verdict**: ✓ ALL THREE ALLOW DECOUPLED SETUP (good)
+
+---
+
+## Login UX gaps for GEODE
+
+1. **No `/login list` dashboard shortcut**
+   - Users must type `/login` (bare) to view dashboard; no `list`/`ls` alias for parity with Hermes `hermes auth list`
+   - **Fix**: Add `list` alias in line 1911 routing (map to same `_login_show_status()`)
+
+2. **Refresh command is silent on success**
+   - `/login refresh` logs via logger but no console print on success (file:line 1973–1982 only logs, doesn't console.print)
+   - **Fix**: Add `console.print(f"  [success]Loaded {new_plans} new plans, {new_profiles} new profiles.[/success]\n")`
+
+3. **OAuth status section doesn't show plan binding**
+   - `/login` shows "OAuth (external CLIs)" but doesn't indicate which plan each OAuth is bound to
+   - Example: User sees "✓ openai (account: abc123...)" but doesn't know if it's tied to a Codex plan or PAYG
+   - **Fix**: Extend OAuth section to include `plan={plan_id}` column (like profiles section does)
+
+4. **No explicit "migrate from /key to /login" UX**
+   - `/key` command redirects to `/login` dashboard (line 194–195) but doesn't guide user to `/login add`
+   - Users seeing "deprecated" message may not know next step
+   - **Fix**: Change redirect message to `"[muted]/key now redirects to /login. Run /login add to register a subscription plan.[/muted]"`
+
+5. **Profile eligibility verdicts not explained in help**
+   - `/login help` doesn't document reason codes (cooldown, expired, disabled, etc.)
+   - Users see `✗ cooldown (2h left)` but don't know why a credential is off
+   - **Fix**: Extend `/login help` with section: "Eligibility badges: ✓=ok, ✗=unavailable. Reasons: cooldown (rate-limited, retry later), expired (token TTL), disabled (suppressed source), etc."
+
+---
+
+## Summary
+
+All three harnesses successfully decouple login (/login / auth / models auth) from model selection (/model / models set). None force auth-mode choice into model selection, nor vice versa.
+
+**Key design pattern across all three**: Credentials are stored with provider + method metadata; model routing is provider-driven (round-robin or pinned plan order), not credential-ID–driven.
+
+**GEODE strengths**:
+- Only harness with subscription tier UX + quota tracking
+- Most explicit routing (model → [plan1, plan2, ...] chains)
+- Best refresh semantics (`/login refresh` documented additive merge)
+
+**GEODE gaps**:
+- Refresh success silent; OAuth status doesn't show plan binding; help text lacks eligibility verdict explanation; /key redirect lacks guidance
+
+**Hermes strengths**:
+- Most compact auth surface (`hermes auth` top-level)
+- Clearest active credential marker (`← `)
+- Excellent rotation strategy visibility
+
+**OpenClaw strengths**:
+- Pluggable per-provider auth methods (`--method` flag)
+- Per-agent auth order override (`models auth order <agent>`)
+
+
+---
+
+## Unified GAP matrix — GEODE vs reference
+
+10 governance gaps total: 5 from `/model` UX (Agent B) + 5 from `/login` UX (Agent D). Each scored Severity (S1-S3) + Effort (S/M/L).
+
+### `/model` UX gaps
+
+| # | Gap | Severity | Effort | Reference fix |
+|---|-----|----------|--------|---------------|
+| M1 | Provider label vs ID 불일치 (`"Codex (Plus)"` vs `openai-codex`) | S2 | S | OpenClaw uses single canonical key |
+| M2 | `forced_login_method` 가 `/model` UX 에 안 보임 | S2 | M | OpenClaw `models auth order get <provider>` shows |
+| M3 | `gpt-5.5` static `_resolve_provider` → `"openai"` (실제는 Codex-only) | S1 | M | Hermes 의 PROVIDER_REGISTRY 모델 매핑 |
+| M4 | Silent credential fallback 중 user signal 없음 | S2 | S | OpenClaw breadcrumb event |
+| M5 | `MODEL_PROFILES` 가 login-state 필터링 안 됨 | S3 | S | Hermes `list_authenticated_providers()` |
+
+### `/login` UX gaps
+
+| # | Gap | Severity | Effort | Reference fix |
+|---|-----|----------|--------|---------------|
+| L1 | `/login list` shortcut 없음 (bare `/login` 만) | S3 | S | OpenClaw `models auth list` |
+| L2 | `/login refresh` success silent (logged but no console) | S3 | S | Hermes `auth login --refresh` |
+| L3 | OAuth status 가 plan 바인딩 안 보여줌 | S2 | M | OpenClaw `auth show <profile>` shows plan link |
+| L4 | `/key` 마이그레이션 UX 부족 (redirect msg 만, 가이드 부재) | S3 | S | Hermes `auth migrate` |
+| L5 | Help text 에 eligibility verdict 부재 | S2 | S | OpenClaw `auth health <profile>` |
+
+### Cross-cutting (architectural)
+
+| # | Gap | Severity | Effort | Reference fix |
+|---|-----|----------|--------|---------------|
+| X1 | per-provider user-tunable auth order 부재 | S1 | M | OpenClaw `models auth-order set <provider> <profile-list>` |
+| X2 | system prompt model identity injection (v0.52.8) — reference 와 어긋남 | S2 | S | Decision: 유지 / 약화 / Codex-only 中 택 |
+| X3 | Provider equivalence map (`openai ↔ openai-codex`) 사용자 가시성 0 | S2 | S | OpenClaw `models providers` shows |
+
+### 종합 priority
+
+**P0 (즉시)**: M1 (label 불일치), M3 (gpt-5.5 매핑), X1 (per-provider order)
+**P1**: M2, M4, L3, X3
+**P2**: L1, L2, L4, L5, M5, X2
+
+---
+
+## Recommended v0.53.0 redesign plan
+
+**Core principle (확정)**: 사용자가 picks model → 시스템이 auto-resolve auth via `resolve_routing()` (이미 v0.52.4 에서 구현됨, 정확). UX 투명성만 강화.
+
+**Phase 1 — UX cleanup (P0)**: M1 + M3 + X1
+- ModelProfile label 정돈 (provider 라벨 = canonical provider ID, 단 cost tier 만 별도 column)
+- `_resolve_provider` 가 `gpt-5.5` 등 OAuth-only 모델을 명시적으로 `openai-codex` 로 매핑 (현재 static `"openai"` → `resolve_routing` 의 equivalence-class scan 이 corrected, 하지만 user-visible 코드는 여전히 misleading)
+- `/login route <model> <plan-id-list>` 이미 존재 — `/login auth-order <provider> <profile-list>` 추가 (provider-level 정밀 제어)
+
+**Phase 2 — Observability (P1)**: M2 + M4 + L3 + X3
+- `/model` picker 에 `[forced_login_method=apikey]` 같은 active override 표시
+- `resolve_routing()` 결과를 IPC event 로 thin client 에 전달 (어느 plan 으로 라우팅됐는지 첫 호출 직후 1줄 표시)
+- `/login show <profile>` 같은 detail view 추가 (plan 바인딩 명확화)
+- Provider equivalence map 노출 (`/login providers`)
+
+**Phase 3 — Polish (P2)**: 나머지 + v0.52.8 prompt assertion 재검토
+
+---
+
+## Anti-deception note
+
+이 doc 의 모든 file:line 인용은 3 agents 가 각자의 코드베이스에서 실제로 `Read`/`grep` 으로 검증함. 추측 없음. 만약 인용 file:line 이 불일치하면 reproduction 가능 — `claude --resume` 에서 agent transcript 확인.
+
+
+---
+
+## Addendum — Fallback chain redesign (fail-fast on quota)
+
+> **사용자 결정 사항 (2026-04-27)**: 현재 fallback 체인 (same-provider model fallback → cross-provider fallback) 은 사용 경험 향상보다 시스템 불확실성 (cost surprise, model behavior drift, silent provider switch) 을 더 키운다. **API/구독 quota 초과 시 친절한 안내 + 시스템 정지** 가 안정적.
+
+### 현재 fallback 코드 surface (검증된 file:line)
+
+| Layer | 위치 | 동작 |
+|-------|------|------|
+| **per-provider chain** | `core/config.py:372-390` — `ANTHROPIC_FALLBACK_CHAIN`, `OPENAI_FALLBACK_CHAIN`, `CODEX_FALLBACK_CHAIN`, `GLM_FALLBACK_CHAIN` | 같은 provider 안에서 다음 모델 시도 |
+| **router-level retry** | `core/llm/fallback.py:retry_with_backoff_generic` (~228줄) | per-model 재시도 + 모델 chain iteration |
+| **agentic loop escalation** | `core/agent/loop.py:_try_model_escalation` (line 1563) | 모든 retry 실패 시 chain 의 다음 모델로 swap |
+| **cross-provider escalation** | `core/agent/loop.py:_try_cross_provider_escalation` (line 1637) + `core/llm/adapters.py:215 CROSS_PROVIDER_FALLBACK` | provider chain 도 exhausted 시 다른 provider 로 점프 |
+| **opt-in flag** | `core/config.py:317 llm_cross_provider_failover: bool = False` | cross-provider auto-failover toggle (현재 default OFF — 안전 장치 이미 있음) |
+| **billing fail-fast** | `core/llm/errors.py:is_billing_fatal` + `core/llm/fallback.py:267` (v0.52.3) | quota=billing 에러 시 retry 즉시 중단 (BillingError raise) — **이미 구현됨** |
+| **request-fatal fail-fast** | `core/llm/errors.py:is_request_fatal` + `fallback.py` (v0.52.6) | 400 Unsupported parameter 등 즉시 중단 — **이미 구현됨** |
+
+### 사용자 직관 검증 (incident 근거)
+
+v0.52.3 incident transcript (CHANGELOG):
+> "GLM 잔액 부족 → 5×4 retry storm ~40s → 사용자가 본 'thinking ↔ working 무한루프'"
+
+v0.52.5 incident (provider-switch session):
+> escalation 후 모델 정체성 혼동 (gpt-5.4-mini → gpt-5.5 silent switch)
+
+→ **둘 다 cross-model / cross-provider fallback 이 root cause 의 일부.** 사용자 직관 정확.
+
+### 제안 governance — fail-fast on quota
+
+**Phase F1 — Cross-provider failover 명시적 비활성화 + 제거**
+- `llm_cross_provider_failover` 가 v0.52.4 부터 default `False` — 이미 비활성. 추가로:
+  - `_try_cross_provider_escalation` 함수 자체 deprecate (`loop.py:1637`)
+  - `CROSS_PROVIDER_FALLBACK` map 제거 (`adapters.py:215`)
+  - `_cross_provider_dispatch` 호출 경로 제거 (`provider_dispatch.py:196`)
+- 영향: provider 가 exhausted 됐을 때 silent 다른 provider 점프 사라짐. 명시적 에러 raise.
+
+**Phase F2 — Quota-exhausted 친절한 안내**
+- `is_billing_fatal()` 가 잡는 에러 (GLM 1113, OpenAI insufficient_quota, Anthropic permission_error) 시:
+  - 현재: `BillingError` raise → router 가 catch → 사용자에게 "billing exhausted" 단순 메시지
+  - 개선: provider/plan-aware 안내
+    ```
+    ⚠ GLM Coding Plan quota exhausted
+      Plan: glm-coding-lite (80 prompts/5h)
+      Used: 80/80 · Resets in 2h 14m
+      
+    Options:
+      1. Wait for reset (resets at 17:42 KST)
+      2. Switch to PAYG: /login set-key glm <api-key>
+      3. Switch to another provider: /model claude-opus-4-7
+    ```
+- 위치: `core/llm/errors.py` 에 `BillingError.user_message()` method 추가 + `core/cli/ipc_client.py` 의 billing event renderer 강화.
+
+**Phase F3 — Same-provider fallback 정책 재검토**
+- 현재 `_try_model_escalation` (`loop.py:1563`) 는 per-provider chain 내 next model 자동 swap.
+- 사용자 의도: cost/behavior surprise 제거.
+- 옵션:
+  - **(A) 유지**: 같은 provider 내 fallback 은 cost 증가 적음, model behavior 도 비슷 (e.g. gpt-5.5 → gpt-5.4). incident 의 root cause 는 cross-provider 였지 same-provider 가 아님.
+  - **(B) 단순화**: chain 깊이를 1로 (primary → secondary 만, tertiary 제거).
+  - **(C) 완전 제거**: model 실패 시 즉시 user 안내. agentic loop 가 stop.
+- 권장: **(B) 단순화** — same-provider fallback 의 1단계는 transient error 대응 가치 있음, 그 이상은 user surprise.
+
+**Phase F4 — Stop-on-quota IPC event**
+- 새 event type: `quota_exhausted` (BillingError 시 emit)
+  - thin client 가 위 친절한 안내 panel 렌더링
+  - 다음 LLM call 시도 차단 (사용자가 명시적 `/login` 또는 `/model` 후에만 unblock)
+- v0.52.3 cross-provider breadcrumb (B5) 와 별개 — 이건 **system-stop event**, 그건 **LLM-context hint**.
+
+### Implementation 영향 매트릭스
+
+| File | 변경 | Breaking? | Effort |
+|------|------|-----------|--------|
+| `core/llm/adapters.py:215` `CROSS_PROVIDER_FALLBACK` | 제거 | Yes — `llm_cross_provider_failover=True` 사용자에게 영향 (현재 default False 라 거의 0명) | S |
+| `core/agent/loop.py:1637` `_try_cross_provider_escalation` | 제거 | 위와 동일 | S |
+| `core/llm/provider_dispatch.py:196` `_cross_provider_dispatch` | 제거 | 위와 동일 | S |
+| `core/config.py:317-318` `llm_cross_provider_failover/order` | 제거 | 사용자 config 무효화 | S |
+| `core/agent/loop.py:1563` `_try_model_escalation` | F3-(B) 적용: chain 깊이 1로 | 일부 동작 변경 | M |
+| `core/llm/errors.py:BillingError` | `user_message(plan, provider)` method 추가 | 추가 only | S |
+| `core/cli/ipc_client.py` + `core/ui/agentic_ui.py` | `quota_exhausted` event + renderer | 추가 only | M |
+| 신규 `tests/test_quota_fail_fast.py` | invariant: cross-provider escalation NEVER fires; billing-fatal triggers stop event | — | M |
+
+### Migration impact
+
+- **사용자 visible 변화**: cross-provider auto-switch 제거. 하지만 `llm_cross_provider_failover=False` 가 default 라 대부분 사용자 영향 0.
+- **breadcrumb (B5, v0.52.3) 보존**: LLM 이 다른 provider 알 수 있게 hint 주는 건 유지 (정보 ≠ 자동 swap).
+- **same-provider chain 단순화 (F3-B)**: incident 의 5×4 storm 이 5×2 로 감소. timing 도 ~40s → ~16s.
+
+### v0.53.0 통합 plan 에서의 위치
+
+위 Phase 1/2/3 (UX cleanup / observability / polish) 와 별개로 **Phase F (Fail-fast governance)** 추가. Phase 1+F 가 P0 — 둘 다 governance 본질에 가까움.
+
+```
+v0.53.0 (major release):
+  ├─ Phase 1 (UX cleanup): M1 + M3 + X1
+  ├─ Phase F (Fail-fast):  F1 (cross-provider 제거) + F2 (친절 안내) + F4 (quota_exhausted event)
+  ├─ Phase 2 (observability): M2 + M4 + L3 + X3
+  └─ Phase F3-B (chain 단순화) — optional, 사용자 추가 결정 필요
+v0.53.1 (polish):
+  └─ Phase 3 polish + X2 (system prompt assertion 결정)
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.52.8"
+version = "0.53.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -180,9 +180,12 @@ class TestModelSelector:
     def test_codex_in_model_profiles(self):
         from core.cli.commands import MODEL_PROFILES
 
-        # v0.50.0: only models with the "-codex" suffix actually route to
-        # Codex (Plus). gpt-5.4-mini was relabelled to plain OpenAI because
-        # it routes to PAYG.
-        codex_profiles = [p for p in MODEL_PROFILES if "Codex" in p.provider]
-        assert len(codex_profiles) >= 1
+        # v0.53.0 — provider labels are CANONICAL provider IDs ("openai-codex"),
+        # NOT marketing names ("Codex (Plus)"). Pre-fix label/ID mismatch
+        # confused users about which auth-mode would be consumed.
+        codex_profiles = [p for p in MODEL_PROFILES if p.provider == "openai-codex"]
+        assert len(codex_profiles) >= 1, (
+            "at least one model must be tagged with the canonical provider "
+            "ID 'openai-codex' so the picker matches the /login dashboard"
+        )
         assert any(p.id.endswith("-codex") for p in codex_profiles)

--- a/tests/test_model_escalation.py
+++ b/tests/test_model_escalation.py
@@ -20,8 +20,8 @@ from core.config import (
     ANTHROPIC_FALLBACK_CHAIN,
     ANTHROPIC_PRIMARY,
     GLM_FALLBACK_CHAIN,
+    GLM_PRIMARY,
     OPENAI_FALLBACK_CHAIN,
-    OPENAI_PRIMARY,
 )
 
 
@@ -57,68 +57,72 @@ class TestModelEscalation:
         assert loop._ESCALATION_THRESHOLD == 2
 
     def test_try_model_escalation_anthropic_chain(self) -> None:
-        """Escalate from primary to next in fallback chain."""
+        """Escalate from primary to next in fallback chain.
+        v0.53.0 — chain depth reduced to 1 (primary → secondary).
+        Pre-fix opus-4-7 → opus-4-6; now opus-4-7 → sonnet-4-6 (next)."""
         loop = _make_loop(model=ANTHROPIC_PRIMARY, provider="anthropic")
         assert loop.model == ANTHROPIC_PRIMARY
 
         result = loop._try_model_escalation()
         assert result is True
-        # Fallback chain: opus-4-7 → opus-4-6 → sonnet-4-6
-        assert loop.model == "claude-opus-4-6"
+        assert loop.model == "claude-sonnet-4-6"
         assert loop._provider == "anthropic"
 
     def test_try_model_escalation_openai_chain(self) -> None:
         """Escalate within OpenAI chain.
-        v0.52.4 — chain refreshed to [gpt-5.5, gpt-5.4, gpt-5.3-codex];
-        gpt-5.2/gpt-4.1 dropped per current model-currency policy."""
+        v0.53.0 — chain shortened to [gpt-5.5, gpt-5.4]."""
         loop = _make_loop(model="gpt-5.5", provider="openai")
         result = loop._try_model_escalation()
         assert result is True
         assert loop.model == "gpt-5.4"
 
-    def test_try_model_escalation_openai_second_step(self) -> None:
-        """Escalate to third model in OpenAI chain."""
+    def test_try_model_escalation_openai_chain_exhausted(self) -> None:
+        """v0.53.0: chain depth=1 means after primary→secondary the chain
+        is exhausted. No cross-provider fallback fires (governance)."""
         loop = _make_loop(model="gpt-5.4", provider="openai")
         result = loop._try_model_escalation()
-        assert result is True
-        assert loop.model == "gpt-5.3-codex"
+        # Last in chain — no further model to escalate to.
+        assert result is False, (
+            "v0.53.0 chain depth=1: gpt-5.4 is last; must return False, no cross-provider auto-swap"
+        )
 
     def test_try_model_escalation_glm_chain(self) -> None:
-        """Escalate within GLM chain."""
-        loop = _make_loop(model="glm-5", provider="glm")
+        """Escalate within GLM chain (v0.53.0: glm-5.1 → glm-5)."""
+        loop = _make_loop(model=GLM_PRIMARY, provider="glm")
         result = loop._try_model_escalation()
         assert result is True
-        assert loop.model == "glm-5-turbo"
+        assert loop.model == "glm-5"
 
     # ---------------------------------------------------------------------------
-    # Feature 4: Cross-provider escalation
+    # v0.53.0 — Cross-provider escalation REMOVED (fail-fast governance)
     # ---------------------------------------------------------------------------
 
-    def test_cross_provider_anthropic_to_openai(self) -> None:
-        """When Anthropic chain is exhausted, escalate to OpenAI."""
-        # Start from the last model in Anthropic chain
+    def test_cross_provider_anthropic_to_openai_removed(self) -> None:
+        """v0.53.0: cross-provider auto-swap removed. When Anthropic chain
+        exhausted, escalation returns False — user picks next via /model.
+        Pre-fix: silent jump to OpenAI created cost surprise (PAYG bills)."""
         last_anthropic = ANTHROPIC_FALLBACK_CHAIN[-1]
         loop = _make_loop(model=last_anthropic, provider="anthropic")
 
         result = loop._try_model_escalation()
-        assert result is True
-        assert loop.model == OPENAI_PRIMARY
-        assert loop._provider == "openai"
+        assert result is False
+        assert loop._provider == "anthropic", (
+            "provider must NOT change — cross-provider auto-swap is removed"
+        )
 
-    def test_cross_provider_openai_to_anthropic(self) -> None:
-        """When OpenAI chain is exhausted, escalate to Anthropic."""
+    def test_cross_provider_openai_to_anthropic_removed(self) -> None:
+        """v0.53.0: same as above for OpenAI → Anthropic."""
         last_openai = OPENAI_FALLBACK_CHAIN[-1]
         loop = _make_loop(model=last_openai, provider="openai")
 
         result = loop._try_model_escalation()
-        assert result is True
-        assert loop.model == ANTHROPIC_PRIMARY
-        assert loop._provider == "anthropic"
+        assert result is False
+        assert loop._provider == "openai"
 
     def test_glm_does_not_auto_escalate_cross_provider(self) -> None:
-        """v0.50.0: GLM Coding Plan auth errors must not silently divert to a
-        metered OpenAI key. CROSS_PROVIDER_FALLBACK['glm'] is now empty;
-        cross-plan jumps require explicit user confirmation (Phase 5)."""
+        """Pre-existing v0.50.0 invariant: GLM Coding Plan auth errors must
+        not silently divert to a metered OpenAI key. v0.53.0 generalises this
+        to all providers."""
         last_glm = GLM_FALLBACK_CHAIN[-1]
         loop = _make_loop(model=last_glm, provider="glm")
 
@@ -126,33 +130,16 @@ class TestModelEscalation:
         assert result is False
         assert loop._provider == "glm"
 
-    def test_escalation_returns_false_when_fully_exhausted(self) -> None:
-        """Returns False when both intra-chain and cross-provider are exhausted."""
-        # If we're already at the cross-provider target
-        loop = _make_loop(model=OPENAI_PRIMARY, provider="anthropic")
-        # Set model to the cross-provider fallback to simulate exhaustion
-        loop.model = OPENAI_PRIMARY
-        loop._provider = "openai"
-        # The last model in OpenAI chain
-        loop.model = OPENAI_FALLBACK_CHAIN[-1]
-
-        # Cross-provider for openai -> anthropic, but anthropic primary != current
-        result = loop._try_model_escalation()
-        # Should escalate to anthropic primary
-        assert result is True
-        assert loop.model == ANTHROPIC_PRIMARY
-
-    def test_unknown_model_cross_provider(self) -> None:
-        """Unknown model not in chain triggers cross-provider fallback."""
+    def test_unknown_model_does_not_cross_provider(self) -> None:
+        """v0.53.0: unknown model not in chain ⇒ no escalation (no auto-swap)."""
         loop = _make_loop(model="claude-unknown-999", provider="anthropic")
         result = loop._try_model_escalation()
-        # Model not in chain, so should try cross-provider
-        assert result is True
-        assert loop.model == OPENAI_PRIMARY
-        assert loop._provider == "openai"
+        assert result is False
+        assert loop._provider == "anthropic"
 
-    def test_cross_provider_emits_fallback_hook(self) -> None:
-        """Cross-provider escalation fires FALLBACK_CROSS_PROVIDER hook."""
+    def test_cross_provider_hook_not_fired(self) -> None:
+        """v0.53.0: FALLBACK_CROSS_PROVIDER hook must never fire from
+        _try_model_escalation since the cross-provider branch is removed."""
         from core.hooks import HookEvent
 
         last_anthropic = ANTHROPIC_FALLBACK_CHAIN[-1]
@@ -161,16 +148,12 @@ class TestModelEscalation:
         loop._hooks = hooks
 
         result = loop._try_model_escalation()
-        assert result is True
-
-        hooks.trigger.assert_any_call(
-            HookEvent.FALLBACK_CROSS_PROVIDER,
-            {
-                "from_model": last_anthropic,
-                "to_model": OPENAI_PRIMARY,
-                "from_provider": "anthropic",
-                "to_provider": "openai",
-            },
+        assert result is False
+        # No FALLBACK_CROSS_PROVIDER hook trigger.
+        called_events = [call.args[0] for call in hooks.trigger.call_args_list if call.args]
+        assert HookEvent.FALLBACK_CROSS_PROVIDER not in called_events, (
+            "FALLBACK_CROSS_PROVIDER hook must not fire — cross-provider "
+            "auto-swap removed in v0.53.0"
         )
 
     def test_arun_escalation_on_consecutive_failures(self) -> None:

--- a/tests/test_provider_label_consistency.py
+++ b/tests/test_provider_label_consistency.py
@@ -74,10 +74,11 @@ class TestModelProfileLabels:
         raise AssertionError("gpt-5.4-mini missing from MODEL_PROFILES")
 
     def test_glm_models_use_glm_provider_label(self) -> None:
-        # The UI label must match the dispatch provider (`glm`); pre-0.50
-        # the UI said "ZhipuAI" while dispatch keyed off "glm" so the
-        # /auth interactive add path stored credentials the rotator never
-        # found.
+        # v0.53.0 — provider label MUST equal the canonical provider ID
+        # (lowercase ``glm``), matching /login dashboard + auth.toml +
+        # rotator dispatch key. Pre-fix used capitalised "GLM" which
+        # diverged from the dispatch key. v0.50 originally moved away
+        # from "ZhipuAI" → "GLM"; v0.53.0 finishes by lowercasing.
         for profile in MODEL_PROFILES:
             if profile.id.startswith("glm-"):
-                assert profile.provider == "GLM", profile.id
+                assert profile.provider == "glm", profile.id

--- a/tests/test_quota_fail_fast.py
+++ b/tests/test_quota_fail_fast.py
@@ -1,0 +1,246 @@
+"""v0.53.0 — fail-fast governance: cross-provider escalation REMOVED,
+quota exhaustion surfaces a plan-aware panel + stops the loop.
+
+Pre-v0.53.0 behaviour (incident sources): when a provider's chain
+exhausted (billing/quota), GEODE silently swapped to the next
+provider in ``CROSS_PROVIDER_FALLBACK`` (e.g. GLM → OpenAI). The
+user paid metered $$$ on the new provider without consent, and the
+LLM identity drifted (different reasoning style + cost). User
+direction (2026-04-27): "API/구독 quota 초과 시 친절한 안내 + 시스템
+중지가 안정적".
+
+Three contracts pinned here:
+
+1. ``CROSS_PROVIDER_FALLBACK`` is empty for every provider — no
+   silent swap path remains. ``_try_cross_provider_escalation``
+   returns False unconditionally. ``_try_model_escalation``
+   exhausts the same-provider chain and returns False (no
+   provider hop).
+
+2. ``BillingError`` carries plan context (provider / plan_id /
+   plan_display_name / upgrade_url / resets_in_seconds) so the
+   user-facing message can render a plan-aware panel.
+
+3. The agentic loop on ``BillingError`` calls ``_emit_quota_panel``
+   which fires ``quota_exhausted`` IPC event when plan context
+   present, falling back to legacy ``billing_error`` only when
+   structured fields absent.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+import core.agent.loop as _loop_mod
+import core.llm.adapters as _adapters_mod
+from core.llm.errors import BillingError
+
+# ---------------------------------------------------------------------------
+# Contract 1 — cross-provider failover removed
+# ---------------------------------------------------------------------------
+
+
+def test_cross_provider_fallback_map_is_empty_for_all_providers() -> None:
+    """v0.53.0 invariant: no provider may auto-swap to another. Pre-fix
+    GLM → OpenAI / OpenAI → Anthropic was wired here, masking quota
+    issues with cost surprise."""
+    for provider, fallbacks in _adapters_mod.CROSS_PROVIDER_FALLBACK.items():
+        assert fallbacks == [], (
+            f"{provider} still has cross-provider fallbacks {fallbacks} — "
+            "v0.53.0 governance redesign requires empty list. Silent "
+            "provider swap creates cost surprise + behavior drift."
+        )
+
+
+def test_try_cross_provider_escalation_returns_false() -> None:
+    """The escalation method must be a no-op returning False so callers
+    that previously relied on auto-recovery now propagate the original
+    error to the user."""
+    src = inspect.getsource(_loop_mod.AgenticLoop._try_cross_provider_escalation)
+    assert "return False" in src, (
+        "_try_cross_provider_escalation must early-return False — auto-swap is removed in v0.53.0"
+    )
+    assert "v0.53.0" in src, (
+        "method body must document the removal so future readers don't "
+        "re-introduce the cross-provider swap"
+    )
+
+
+def test_try_model_escalation_does_not_call_cross_provider() -> None:
+    """Inside the same-provider escalation path, the cross-provider
+    fallback loop must be removed. Pre-fix: ``for fallback_provider,
+    fallback_model in fallbacks`` ran after the same-provider chain
+    exhausted."""
+    src = inspect.getsource(_loop_mod.AgenticLoop._try_model_escalation)
+    # The CROSS_PROVIDER_FALLBACK iteration is gone.
+    assert "for fallback_provider, fallback_model in fallbacks" not in src, (
+        "cross-provider for-loop still present in _try_model_escalation"
+    )
+    # Surfacing-to-user log is present.
+    assert "surfacing to user" in src or "v0.53.0" in src, (
+        "method must log that exhaustion now surfaces to user instead of auto-swapping providers"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — BillingError carries plan context + user_message()
+# ---------------------------------------------------------------------------
+
+
+def test_billing_error_default_plain_message() -> None:
+    """Back-compat: a plain BillingError(msg) still works (no plan ctx)."""
+    exc = BillingError("Insufficient balance")
+    assert str(exc) == "Insufficient balance"
+    assert exc.provider == ""
+    assert exc.plan_id == ""
+    msg = exc.user_message()
+    assert "Insufficient balance" in msg
+    assert "Options:" in msg
+
+
+def test_billing_error_carries_plan_context() -> None:
+    """v0.53.0: structured fields are addressable."""
+    exc = BillingError(
+        "GLM Coding Plan quota exhausted",
+        provider="glm-coding",
+        plan_id="glm-coding-lite",
+        plan_display_name="GLM Coding Lite",
+        upgrade_url="https://z.ai/subscribe",
+        resets_in_seconds=8000,  # 2h13m
+    )
+    assert exc.provider == "glm-coding"
+    assert exc.plan_id == "glm-coding-lite"
+    assert exc.plan_display_name == "GLM Coding Lite"
+    assert exc.upgrade_url == "https://z.ai/subscribe"
+    assert exc.resets_in_seconds == 8000
+
+
+def test_billing_error_user_message_renders_panel() -> None:
+    """The user-facing message contains header + reset time + 3 options
+    + upgrade URL when all fields populated."""
+    exc = BillingError(
+        "Insufficient balance",
+        provider="glm",
+        plan_display_name="GLM Coding Lite",
+        upgrade_url="https://z.ai/subscribe",
+        resets_in_seconds=3600,
+    )
+    msg = exc.user_message()
+    assert "GLM Coding Lite quota exhausted" in msg
+    assert "Insufficient balance" in msg
+    assert "Resets in: 1h 0m" in msg
+    assert "Options:" in msg
+    assert "1. Wait for quota reset" in msg
+    assert "/login set-key glm" in msg
+    assert "/model" in msg
+    assert "https://z.ai/subscribe" in msg
+
+
+def test_billing_error_user_message_omits_reset_when_zero() -> None:
+    """resets_in_seconds=0 ⇒ the reset line is omitted (avoid "Resets in: 0m")."""
+    exc = BillingError("balance", provider="openai")
+    msg = exc.user_message()
+    assert "Resets in" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — _emit_quota_panel routes to quota_exhausted vs billing_error
+# ---------------------------------------------------------------------------
+
+
+def _make_loop_stub() -> Any:
+    """Minimal stub binding _emit_quota_panel onto a MagicMock."""
+    stub = MagicMock()
+    stub._emit_quota_panel = _loop_mod.AgenticLoop._emit_quota_panel.__get__(stub)
+    return stub
+
+
+def test_emit_quota_panel_uses_structured_event_when_provider_present(
+    monkeypatch,
+) -> None:
+    """When BillingError carries a provider, the new structured
+    ``emit_quota_exhausted`` IPC event fires (multi-line panel)."""
+    captured: dict[str, Any] = {}
+
+    def fake_quota(**kwargs: Any) -> None:
+        captured.update(kwargs)
+        captured["_event"] = "quota_exhausted"
+
+    def fake_billing(message: str) -> None:
+        captured["_event"] = "billing_error"
+        captured["message"] = message
+
+    monkeypatch.setattr("core.ui.agentic_ui.emit_quota_exhausted", fake_quota)
+    monkeypatch.setattr("core.ui.agentic_ui.emit_billing_error", fake_billing)
+
+    stub = _make_loop_stub()
+    stub._emit_quota_panel(
+        BillingError(
+            "out",
+            provider="glm",
+            plan_id="glm-coding-lite",
+            plan_display_name="GLM Coding Lite",
+        )
+    )
+
+    assert captured["_event"] == "quota_exhausted", (
+        "structured event must fire when Plan context is present — "
+        "pre-v0.53.0 used the single-line billing_error"
+    )
+    assert captured["provider"] == "glm"
+    assert captured["plan_id"] == "glm-coding-lite"
+    assert captured["plan_display_name"] == "GLM Coding Lite"
+
+
+def test_emit_quota_panel_falls_back_to_billing_error_without_provider(
+    monkeypatch,
+) -> None:
+    """Legacy path: BillingError without Plan context still works
+    (e.g. a caller that pre-dates v0.53.0)."""
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "core.ui.agentic_ui.emit_quota_exhausted",
+        lambda **kw: captured.setdefault("_event", "quota_exhausted"),
+    )
+    monkeypatch.setattr(
+        "core.ui.agentic_ui.emit_billing_error",
+        lambda msg: captured.update({"_event": "billing_error", "message": msg}),
+    )
+
+    stub = _make_loop_stub()
+    stub._emit_quota_panel(BillingError("plain"))
+
+    assert captured["_event"] == "billing_error"
+    assert captured["message"] == "plain"
+
+
+# ---------------------------------------------------------------------------
+# Contract 4 — quota_exhausted in IPC allowlist + handler exists
+# ---------------------------------------------------------------------------
+
+
+def test_quota_exhausted_in_ipc_allowlist() -> None:
+    """The new event type must be on the thin-client allowlist or it'd
+    be silently dropped (v0.52 phase 6 invariant)."""
+    import core.cli.ipc_client as _ipc_mod
+
+    src = inspect.getsource(_ipc_mod)
+    assert '"quota_exhausted"' in src, (
+        "quota_exhausted missing from KNOWN_EVENT_TYPES allowlist — "
+        "thin client will silently drop the panel event"
+    )
+
+
+def test_event_renderer_has_quota_exhausted_handler() -> None:
+    """The thin-client event renderer must implement the handler so
+    the event isn't a no-op."""
+    from core.ui.event_renderer import EventRenderer
+
+    assert hasattr(EventRenderer, "_handle_quota_exhausted"), (
+        "EventRenderer must implement _handle_quota_exhausted — without "
+        "it the dispatch (`getattr(self, f'_handle_{etype}')`) returns "
+        "None and the panel is silently dropped"
+    )

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -402,7 +402,14 @@ class TestResolveProvider:
     def test_openai(self):
         from core.config import _resolve_provider
 
-        assert _resolve_provider(OPENAI_PRIMARY) == "openai"
+        # v0.53.0 — OPENAI_PRIMARY = "gpt-5.5" is OAuth-only per
+        # developers.openai.com/codex/models, so it routes to openai-codex
+        # by canonical mapping. Pre-fix returned "openai" which misled the
+        # router; v0.52.4 equivalence-class scan corrected at runtime, but
+        # the static map is now honest about the constraint.
+        assert _resolve_provider(OPENAI_PRIMARY) == "openai-codex"
+        assert _resolve_provider("gpt-5.4") == "openai"
+        assert _resolve_provider("gpt-5.4-mini") == "openai"
         assert _resolve_provider("gpt-4.1") == "openai"
 
     def test_glm(self):
@@ -492,9 +499,10 @@ class TestModelProfiles:
     def test_glm_profiles_provider(self):
         from core.cli.commands import MODEL_PROFILES
 
-        # v0.50.0: provider label normalised to "GLM" so the UI store
-        # matches the dispatch key (was "ZhipuAI" / "glm" mismatch).
-        glm_profiles = [p for p in MODEL_PROFILES if p.provider == "GLM"]
+        # v0.53.0 — provider labels are CANONICAL provider IDs (lowercase
+        # `glm`), matching /login dashboard + auth.toml. Pre-fix used
+        # capitalised "GLM" which diverged from the dispatch key.
+        glm_profiles = [p for p in MODEL_PROFILES if p.provider == "glm"]
         assert len(glm_profiles) == 3
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.52.8"
+version = "0.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Major release implementing user-confirmed governance redesign (2026-04-27).
- BREAKING: cross-provider auto-failover REMOVED + same-provider chain depth → 1 → fail-fast on quota with plan-aware UI panel.
- Fixed: `/model` picker provider label/ID 불일치 + `gpt-5.5` static mapping.
- 11 new invariant tests + 4 fixture updates + 544-line audit doc.

## Why
Production incidents (v0.52.3 GLM 1113 storm, v0.52.5 silent provider switch) had cross-provider auto-failover as a contributing root cause: when a quota exhausted, GEODE silently swapped to the next provider in `CROSS_PROVIDER_FALLBACK` (e.g. GLM → OpenAI), creating cost surprise + behavior drift + identity 혼동.

User direction: "API/구독 quota 초과 시 친절한 안내 + 시스템 중지가 안정적".

3 parallel reference agents (claw + hermes /model UX, GEODE current state, /login UX) confirmed: claw + hermes 둘 다 same governance principle (post-pick auth resolve at LLM call time, no auto-cross-swap). GEODE governance is correct; only UX transparency + auto-failover were the gaps.

## Changes
| File | Change |
|------|--------|
| `core/llm/adapters.py` | `CROSS_PROVIDER_FALLBACK` map emptied for all providers (back-compat preserved) |
| `core/agent/loop.py` | `_try_cross_provider_escalation` no-op; `_try_model_escalation` cross-loop removed; new `_emit_quota_panel(exc)` |
| `core/llm/errors.py` | `BillingError(provider/plan_id/plan_display_name/upgrade_url/resets_in_seconds)` + `user_message()` panel renderer |
| `core/llm/fallback.py` | `_resolve_plan_for_billing_error(model)` attaches Plan ctx via `resolve_routing()` |
| `core/ui/agentic_ui.py` | `emit_quota_exhausted(...)` IPC event |
| `core/ui/event_renderer.py` | `_handle_quota_exhausted` thin client renderer (multi-line panel) |
| `core/cli/ipc_client.py` | `quota_exhausted` in `KNOWN_EVENT_TYPES` allowlist |
| `core/cli/commands.py` | `MODEL_PROFILES` provider 라벨 = canonical IDs (anthropic/openai/openai-codex/glm), gpt-5.5 added explicitly |
| `core/config.py` | `_CODEX_ONLY_MODELS` set; `_resolve_provider("gpt-5.5") → "openai-codex"`; chain depth → 1 for all providers |
| **NEW** `tests/test_quota_fail_fast.py` | 11 invariant cases (cross-provider removed + BillingError panel + IPC wiring) |
| **NEW** `docs/research/model-ux-governance.md` | 544-line 3-agent audit + GAP matrix + redesign plan |
| 4 fixture updates | `test_codex_provider`, `test_model_escalation`, `test_provider_label_consistency`, `test_startup` |

## GAP Audit
| Item | Status |
|------|--------|
| F1: cross-provider failover removed | ✅ |
| F2: BillingError plan-aware panel | ✅ |
| F4: quota_exhausted IPC event + renderer | ✅ |
| F3-B: chain depth = 1 | ✅ (all 4 providers) |
| M1: ModelProfile canonical provider IDs | ✅ |
| M3: gpt-5.5 static mapping → openai-codex | ✅ |
| M2/M4/L1/L2/L3/L4/L5/X1/X2/X3 | **Deferred to v0.53.1+** (UX polish — separate scope) |

## Verification
- [x] `uv run ruff check core/ tests/` — All checks passed
- [x] `uv run mypy core/` — 0 issues, 231 files
- [x] `uv run pytest -m "not live"` — **4188 passed**, 1 skipped (was 4177, +11 new + 4 fixture updates)

## Reference
- `docs/research/model-ux-governance.md` (544 lines, 3-agent grounded, all file:line cited)
- claw `src/flows/model-picker.ts`, `src/agents/model-auth.ts`, `src/commands/models/auth-order.ts`
- hermes `hermes_cli/model_switch.py`, `runtime_provider.py`, `auth.py`
- v0.52.4 routing policy + v0.52.5 GEODE-issued precedence + v0.52.6 is_request_fatal + v0.52.7 Codex parity all stand