### PR TITLE
fix(v0.55.1): R5 — sub-agent reasoning depth wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.55.1] — 2026-04-28
+
+### Fixed
+- **Sub-agent reasoning depth never reached the spawned loop** (R5 of the reasoning-depth audit). `WorkerRequest` declared `effort`, `thinking_budget`, `time_budget_s` since v0.50.x but `WorkerRequest.from_dict` silently dropped them and `_run_agentic` never passed them to `AgenticLoop()`. Every sub-agent ran at the dataclass defaults — `effort="high"`, `thinking_budget=0`, `time_budget_s=0.0` — regardless of what the parent intended. Hermes Agent (`agent/delegate_tool.py:607-636`, parent-inherit + per-child config override) and Claude Code (`utils/AgentTool/loadAgentsDir.ts:116`, agent-level effort frontmatter) both wire this correctly. v0.55.1 mirrors that: `from_dict` deserialises the three fields and `_run_agentic` threads them as `AgenticLoop()` ctor kwargs. (`core/agent/worker.py:WorkerRequest.from_dict, _run_agentic`)
+
+### Tests
+- `tests/test_worker.py:TestWorkerRequest::test_reasoning_depth_roundtrip` + `test_reasoning_depth_defaults` — pin the deserialiser invariant.
+- `tests/test_worker.py:TestSubAgentReasoningWiring::test_loop_receives_reasoning_kwargs` — verifies `_run_agentic` actually plumbs the kwargs into `AgenticLoop()` (uses `MagicMock` to capture the ctor call).
+
+### Reference
+- `docs/research/reasoning-depth-audit.md` — R5 in the cross-codebase comparison; 2/3 references implement parent-inherit, GEODE was the outlier.
+- Hermes: `agent/delegate_tool.py:607-636`.
+- Claude Code: `utils/AgentTool/loadAgentsDir.ts:116`.
+
 ## [0.55.0] — 2026-04-28
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.55.0
+- **Version**: 0.55.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 233
-- **Tests**: 4243+
+- **Tests**: 4246+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.55.0 — Long-running Autonomous Execution Harness
+# GEODE v0.55.1 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.55.0 — Long-running Autonomous Execution Harness
+# GEODE v0.55.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -65,6 +65,15 @@ class WorkerRequest:
             model=data.get("model", "claude-opus-4-6"),
             provider=data.get("provider", "anthropic"),
             timeout_s=data.get("timeout_s", 120.0),
+            # v0.55.0 R5 — reasoning depth fields were declared on the
+            # dataclass since v0.50.x but never deserialised, so every
+            # sub-agent ran at the dataclass defaults regardless of
+            # what the parent put on the wire. Hermes / Claude Code
+            # both inherit reasoning depth into spawned children
+            # (delegate_tool.py:608, loadAgentsDir.ts:116).
+            time_budget_s=data.get("time_budget_s", 0.0),
+            thinking_budget=data.get("thinking_budget", 0),
+            effort=data.get("effort", "high"),
             domain=data.get("domain", ""),
             isolation=data.get("isolation", ""),
         )
@@ -164,6 +173,17 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
         max_tokens=32768,
         model=request.model,
         provider=request.provider,
+        # v0.55.0 R5 — propagate reasoning depth + time budget into the
+        # sub-agent's loop. Pre-fix every sub-agent ran at the
+        # AgenticLoop defaults (effort="high", thinking_budget=0,
+        # time_budget_s=0.0) because the kwargs were never threaded
+        # through, even though WorkerRequest carried them. Mirrors
+        # Hermes ``delegate_tool.py:607-636`` (parent-inherit + per-child
+        # config override) and Claude Code ``loadAgentsDir.ts:116``
+        # (agent-level effort frontmatter).
+        thinking_budget=request.thinking_budget,
+        effort=request.effort,
+        time_budget_s=request.time_budget_s,
         quiet=True,  # Suppress spinner — parent handles UI
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.55.0"
+version = "0.55.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -49,6 +49,32 @@ class TestWorkerRequest:
         parsed = json.loads(raw)
         assert parsed["task_id"] == "t-003"
 
+    def test_reasoning_depth_roundtrip(self) -> None:
+        """v0.55.0 R5 — pre-fix ``from_dict`` silently dropped ``effort``,
+        ``thinking_budget``, ``time_budget_s`` so every sub-agent ran at
+        the dataclass defaults. Wired in v0.55.0 to mirror Hermes
+        (``delegate_tool.py:608`` parent-inherit) + Claude Code
+        (``loadAgentsDir.ts:116`` agent-level effort frontmatter)."""
+        req = WorkerRequest(
+            task_id="t-r5",
+            description="reasoning-heavy subtask",
+            effort="max",
+            thinking_budget=8192,
+            time_budget_s=180.0,
+        )
+        data = req.to_dict()
+        restored = WorkerRequest.from_dict(data)
+        assert restored.effort == "max"
+        assert restored.thinking_budget == 8192
+        assert restored.time_budget_s == 180.0
+
+    def test_reasoning_depth_defaults(self) -> None:
+        """Defaults preserved when fields omitted from dict."""
+        req = WorkerRequest.from_dict({"task_id": "t-default"})
+        assert req.effort == "high"
+        assert req.thinking_budget == 0
+        assert req.time_budget_s == 0.0
+
 
 class TestWorkerResult:
     def test_roundtrip(self) -> None:
@@ -143,3 +169,46 @@ class TestWorkerSubprocess:
         assert backup.exists()
         data = json.loads(backup.read_text())
         assert data["task_id"] == "bk-001"
+
+
+class TestSubAgentReasoningWiring:
+    """v0.55.0 R5 — verify ``_run_agentic`` actually plumbs the
+    request's reasoning depth fields into ``AgenticLoop()``. Pre-fix
+    these kwargs were never threaded through, so every sub-agent ran
+    at the dataclass defaults (effort='high', thinking_budget=0,
+    time_budget_s=0.0) regardless of what the parent put on the wire.
+    """
+
+    def test_loop_receives_reasoning_kwargs(self, monkeypatch, tmp_path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        captured: dict = {}
+
+        def _fake_loop(*args, **kwargs):
+            captured.update(kwargs)
+            mock_loop = MagicMock()
+            mock_loop.run.return_value = MagicMock(text="ok", tool_calls=[], rounds=1)
+            return mock_loop
+
+        # Stub out everything _run_agentic touches except the bit we test.
+        monkeypatch.setattr("core.agent.worker.WORKER_DIR", tmp_path)
+        with (
+            patch("core.cli.tool_handlers._build_tool_handlers", return_value={}),
+            patch("core.agent.tool_executor.ToolExecutor"),
+            patch("core.agent.conversation.ConversationContext"),
+            patch("core.agent.loop.AgenticLoop", side_effect=_fake_loop),
+        ):
+            from core.agent.worker import WorkerRequest, _run_agentic
+
+            request = WorkerRequest(
+                task_id="r5-test",
+                description="reasoning subtask",
+                effort="max",
+                thinking_budget=8192,
+                time_budget_s=240.0,
+            )
+            _run_agentic(request)
+
+        assert captured.get("effort") == "max"
+        assert captured.get("thinking_budget") == 8192
+        assert captured.get("time_budget_s") == 240.0

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.55.0"
+version = "0.55.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Sub-agents now actually receive the `effort` / `thinking_budget` / `time_budget_s` the parent puts on the wire
- `WorkerRequest.from_dict` deserialises the three fields (was silently dropping them)
- `_run_agentic` threads them into the `AgenticLoop()` ctor (was using AgenticLoop defaults regardless)
- 2/3-converging pattern (Hermes + Claude Code); GEODE was the outlier

## Why
R5 of the reasoning-depth audit (`docs/research/reasoning-depth-audit.md`). The fields were declared on `WorkerRequest` since v0.50.x but neither end of the wire used them — `from_dict` ignored them on read, `_run_agentic` ignored them on use. So a parent doing a low-effort scratchpad delegate got max-effort reasoning anyway, and a parent throttling a long sub-agent got no time-budget enforcement.

Hermes `agent/delegate_tool.py:607-636` (parent-inherit + per-child config override) and Claude Code `utils/AgentTool/loadAgentsDir.ts:116` (agent-level effort frontmatter) both wire this correctly. GEODE is the outlier of the three. Two-line fix.

## Changes
| File | Change |
|------|--------|
| `core/agent/worker.py` | `WorkerRequest.from_dict` deserialises `effort`, `thinking_budget`, `time_budget_s` with matching defaults. `_run_agentic` passes them as `AgenticLoop()` ctor kwargs. |
| `tests/test_worker.py` | `TestWorkerRequest::test_reasoning_depth_roundtrip` + `test_reasoning_depth_defaults` (deserialiser invariant) + `TestSubAgentReasoningWiring::test_loop_receives_reasoning_kwargs` (MagicMock captures `AgenticLoop()` ctor to verify wiring). |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `README.ko.md`, `pyproject.toml`, `uv.lock` | v0.55.0 → v0.55.1; tests 4243+ → 4246+. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `from_dict` deserialises reasoning fields | Implemented | Defaults match dataclass |
| `_run_agentic` plumbs to AgenticLoop | Implemented | All three kwargs |
| Roundtrip invariant test | Implemented | `test_reasoning_depth_roundtrip` |
| Defaults invariant test | Implemented | `test_reasoning_depth_defaults` |
| Wiring invariant test | Implemented | `test_loop_receives_reasoning_kwargs` (MagicMock capture) |

## Verification
- [x] `uv run ruff check + format` clean (auto-formatted)
- [x] `uv run mypy core/` clean (233 source files)
- [x] `uv run pytest tests/ -m "not live"` → **4246 passed, 1 skipped, 19 deselected** (+3 new tests, 0 regressions)

## Reference
- `docs/research/reasoning-depth-audit.md` — R5 in cross-codebase comparison.
- Hermes: `agent/delegate_tool.py:607-636` (parent-inherit + per-child config override).
- Claude Code: `utils/AgentTool/loadAgentsDir.ts:116` (agent-level effort frontmatter).
- User direction (2026-04-28): "구현 부탁해. 순차적으로 진행해. 코드베이스 + 브랜치 분리 적용해서 말이야."

🤖 Generated with [Claude Code](https://claude.com/claude-code)