### PR TITLE
feat(v0.57.0): R6 — surface reasoning summaries to AgenticUI (live thinking UX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.57.0] — 2026-04-28
+
+### Added
+- **Reasoning summaries surface to AgenticUI** (R6 of the reasoning-depth audit). All three reference frontier harnesses (Hermes, Claude Code, OpenClaw) render the model's reasoning chunks live so the user sees "thinking…" rather than a silent spinner; GEODE was the only one dropping them. v0.57.0 captures `reasoning.summary[].text` (Codex Plus) and `thinking` content blocks (Anthropic adaptive thinking with `display:"summarized"` from R4-mini) into a new `AgenticResponse.reasoning_summaries` sidecar, then emits one `reasoning_summary` IPC event per item from `AgenticLoop` after each LLM call returns. Per-item granularity (not per-delta) avoids threading the IPC writer into the `asyncio.to_thread` worker that drives the streaming loop. (`core/llm/agentic_response.py:AgenticResponse.reasoning_summaries`, `core/agent/loop.py` post-call emit, `core/ui/agentic_ui.py:emit_reasoning_summary`, `core/ui/event_renderer.py:_handle_reasoning_summary`)
+- **`reasoning_summary` IPC event** in the structured-events allowlist (`core/cli/ipc_client.py`) and renderer dispatch (`core/ui/event_renderer.py:_handle_reasoning_summary`). Long summaries truncate to 240 chars + ellipsis on the inline render; full text is in the IPC event payload for any client that wants the complete summary.
+- **`tests/test_reasoning_summary_r6.py`** — 16 invariants covering Codex extraction (with + without encrypted blob, empty filtering, no-reasoning case), Anthropic thinking extraction (block, no-block, empty), sidecar default, other-provider isolation, emit helper console + truncation paths, IPC allowlist + renderer handler presence + truncation/skip-empty rendering, loop wiring source check.
+
+### Reference
+- 3-codebase consensus: Hermes `agent/anthropic_adapter.py:793` (TUI activity feed accumulation), Claude Code `screens/REPL.tsx:139-157` (React state + rainbow + 30 s auto-hide), OpenClaw `src/agents/openai-transport-stream.ts:398-407` (per-event push).
+- Original audit + R6 priority: `docs/research/reasoning-depth-audit.md` and `docs/research/reasoning-depth-post-r1r5-gaps.md` (both deleted on this commit per user direction "작업 끝나면 해당 MD 삭제하고" — content rolled into changelog entries for R1, R5, R4-mini, R6).
+
+### Removed
+- **`docs/research/reasoning-depth-audit.md`** and **`docs/research/reasoning-depth-post-r1r5-gaps.md`** — scratch research notes that drove the R1/R5/R4-mini/R6 cycle. Per user direction these were always temporary; the actionable findings have been captured in the corresponding CHANGELOG entries (v0.55.0 R1, v0.55.1 R5, v0.56.0 R4-mini, v0.57.0 R6).
+
 ## [0.56.0] — 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.56.0
+- **Version**: 0.57.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 233
-- **Tests**: 4257+
+- **Tests**: 4273+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.56.0 — Long-running Autonomous Execution Harness
+# GEODE v0.57.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.56.0 — Long-running Autonomous Execution Harness
+# GEODE v0.57.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/agent/loop.py
+++ b/core/agent/loop.py
@@ -1553,6 +1553,19 @@ class AgenticLoop:
             else:
                 self._last_llm_error = f"All {self._provider} models exhausted"
 
+        # v0.57.0 R6 — surface reasoning summaries to AgenticUI. Per-item
+        # granularity (the sidecar collects one entry per finished
+        # reasoning item / thinking block) — see ``emit_reasoning_summary``
+        # for the rationale on not streaming per-delta.
+        if response is not None and not self._quiet:
+            summaries = getattr(response, "reasoning_summaries", None) or []
+            for summary in summaries:
+                if not summary:
+                    continue
+                from core.ui.agentic_ui import emit_reasoning_summary
+
+                emit_reasoning_summary(self._provider, self.model, summary)
+
         return response
 
     def _extract_text(self, response: Any) -> str:

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -229,6 +229,7 @@ class IPCClient:
                 "llm_error",
                 "retry_wait",
                 "budget_warning",
+                "reasoning_summary",  # v0.57.0 R6 — live thinking surface
                 # Pipeline milestone events
                 "pipeline_header",
                 "pipeline_gather",

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -65,11 +65,24 @@ class AgenticResponse:
     stop_reason: str = "end_turn"  # "end_turn" or "tool_use"
     usage: ResponseUsage = field(default_factory=ResponseUsage)
     codex_reasoning_items: list[dict[str, Any]] | None = None
+    # v0.57.0 R6 — reasoning summaries for the "live thinking..." UI
+    # surface. Per-item granularity to avoid thread-local IPC writer
+    # complexity (the streaming loop runs in ``asyncio.to_thread``).
+    # Codex populates from ``reasoning.summary[].text``; Anthropic from
+    # ``thinking`` content blocks. ``None`` when the call produced no
+    # reasoning summary; never set by GLM/OpenAI Chat Completions.
+    reasoning_summaries: list[str] | None = None
 
 
 def normalize_anthropic(response: Any) -> AgenticResponse:
     """Normalize an Anthropic SDK response to AgenticResponse."""
     blocks: list[TextBlock | ToolUseBlock] = []
+    # v0.57.0 R6 — capture ``thinking`` block text into the reasoning
+    # summary sidecar so the AgenticUI can render the "live thinking..."
+    # surface. Mirrors the Codex normaliser pattern. Anthropic's
+    # adaptive thinking with ``display:"summarized"`` (set in the
+    # adapter since v0.56.0) produces visible summary text here.
+    reasoning_summaries: list[str] = []
     for block in response.content:
         if block.type == "text":
             blocks.append(TextBlock(text=block.text))
@@ -81,6 +94,10 @@ def normalize_anthropic(response: Any) -> AgenticResponse:
                     input=block.input,
                 )
             )
+        elif block.type == "thinking":
+            _thinking_text = getattr(block, "thinking", "") or ""
+            if _thinking_text:
+                reasoning_summaries.append(_thinking_text)
 
     usage = ResponseUsage()
     if response.usage:
@@ -98,6 +115,7 @@ def normalize_anthropic(response: Any) -> AgenticResponse:
         content=blocks,
         stop_reason=response.stop_reason,
         usage=usage,
+        reasoning_summaries=reasoning_summaries or None,
     )
 
 
@@ -174,6 +192,8 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
     """
     blocks: list[TextBlock | ToolUseBlock] = []
     has_function_calls = False
+    # v0.57.0 R6 — sidecar accumulator for the "live thinking..." UI surface.
+    reasoning_summaries: list[str] = []
     # v0.55.0 — sidecar accumulator for Codex Plus encrypted reasoning.
     # Hermes pattern (codex_responses_adapter.py:720-738): capture every
     # ``reasoning`` item the server emits so the loop can echo it back
@@ -211,6 +231,16 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
             # state and would just bloat the next request for nothing.
             encrypted = getattr(item, "encrypted_content", None)
             if not isinstance(encrypted, str) or not encrypted:
+                # v0.57.0 R6 — even when the encrypted blob is missing,
+                # capture the summary text for the UI surface (some
+                # transient errors strip encrypted_content but keep
+                # summary).
+                summary_only = getattr(item, "summary", None)
+                if isinstance(summary_only, list):
+                    for part in summary_only:
+                        _text = getattr(part, "text", None)
+                        if isinstance(_text, str) and _text:
+                            reasoning_summaries.append(_text)
                 continue
             replay: dict[str, Any] = {"type": "reasoning", "encrypted_content": encrypted}
             item_id = getattr(item, "id", None)
@@ -223,6 +253,9 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
                     text = getattr(part, "text", None)
                     if isinstance(text, str):
                         serialised.append({"type": "summary_text", "text": text})
+                        # v0.57.0 R6 — also surface to UI sidecar
+                        if text:
+                            reasoning_summaries.append(text)
                 replay["summary"] = serialised
             codex_reasoning_items.append(replay)
 
@@ -264,4 +297,5 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
         stop_reason=stop_reason,
         usage=usage,
         codex_reasoning_items=codex_reasoning_items or None,
+        reasoning_summaries=reasoning_summaries or None,
     )

--- a/core/ui/agentic_ui.py
+++ b/core/ui/agentic_ui.py
@@ -672,6 +672,37 @@ def emit_budget_warning(budget: float, actual: float, pct: float) -> None:
     )
 
 
+def emit_reasoning_summary(provider: str, model: str, text: str) -> None:
+    """v0.57.0 R6 — surface a model's reasoning-summary chunk to the UI.
+
+    Called from ``AgenticLoop`` after each LLM call returns with one
+    or more summaries on ``response.reasoning_summaries`` (sidecar).
+    Per-item granularity, not per-delta — emitting from inside the
+    streaming worker thread would require thread-local IPC writer
+    plumbing for marginal UX gain.
+
+    Long summaries are truncated for the inline render (full text is
+    in the IPC event); 3-codebase consensus is "show enough to confirm
+    progress, not enough to overwhelm." Hermes uses a TUI activity
+    feed; Claude Code uses rainbow-coloured React state with 30 s auto-
+    hide; OpenClaw pushes per-event. We keep it simple: one muted
+    line per summary chunk, prefixed with a bullet.
+    """
+    writer = getattr(_ipc_writer_local, "writer", None)
+    if writer is not None:
+        writer.send_event(
+            "reasoning_summary",
+            provider=provider,
+            model=model,
+            text=text,
+        )
+        return
+    snippet = text.strip().replace("\n", " ")
+    if len(snippet) > 240:
+        snippet = snippet[:237] + "…"
+    console.print(f"  [muted]∙ thinking · {snippet}[/muted]")
+
+
 def emit_retry_wait(
     model: str,
     attempt: int,

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -274,6 +274,23 @@ class EventRenderer:
         )
         self._out.flush()
 
+    def _handle_reasoning_summary(self, event: dict[str, Any]) -> None:
+        """v0.57.0 R6 — render a model's reasoning-summary chunk.
+
+        Per-item granularity (not per-delta). Shown as a muted single
+        line; full text is in the IPC event payload for any client that
+        wants to display the complete summary.
+        """
+        self._clear_activity_line()
+        text = str(event.get("text", "")).strip().replace("\n", " ")
+        if len(text) > 240:
+            text = text[:237] + "…"
+        if not text:
+            return
+        # ANSI 90 = bright black (muted); matches console.print muted style.
+        self._out.write(f"  \033[90m∙ thinking · {text}\033[0m\n")
+        self._out.flush()
+
     def _handle_retry_wait(self, event: dict[str, Any]) -> None:
         self._clear_activity_line()
         model = str(event.get("model", ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.56.0"
+version = "0.57.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_reasoning_summary_r6.py
+++ b/tests/test_reasoning_summary_r6.py
@@ -1,0 +1,250 @@
+"""R6 — reasoning summary streaming → AgenticUI invariants (v0.57.0).
+
+Pinned 2026-04-28. The 3-codebase consensus from
+``docs/research/reasoning-depth-audit.md`` is unanimous: every reference
+harness (Hermes, Claude Code, OpenClaw) surfaces reasoning summaries
+to the UI so the user sees "live thinking..." rather than a silent
+spinner. R6 implements this in GEODE at per-reasoning-item granularity
+(not per-delta) to avoid threading the IPC writer into the
+``asyncio.to_thread`` worker that runs the streaming loop.
+
+Three invariants:
+
+  1. ``normalize_openai_responses`` extracts ``reasoning.summary[].text``
+     into ``AgenticResponse.reasoning_summaries`` (Codex Plus path).
+     Captures both the full reasoning-with-encrypted-content case and
+     the summary-only fallback.
+
+  2. ``normalize_anthropic`` extracts ``thinking`` content blocks into
+     the same sidecar (Anthropic adaptive thinking path with
+     ``display:"summarized"`` from R4-mini).
+
+  3. ``emit_reasoning_summary`` is registered in the IPC allowlist
+     (``core/cli/ipc_client.py`` event router) and the renderer
+     (``core/ui/event_renderer.py``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.llm.agentic_response import (
+    AgenticResponse,
+    normalize_anthropic,
+    normalize_openai_responses,
+)
+
+
+def _make_message_item(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+def _make_reasoning_item(*, encrypted: str | None, summary_texts: list[str]) -> SimpleNamespace:
+    summary = [SimpleNamespace(text=t) for t in summary_texts]
+    return SimpleNamespace(type="reasoning", encrypted_content=encrypted, summary=summary)
+
+
+class TestCodexReasoningSummaryExtraction:
+    """Sidecar populated from Codex Plus ``reasoning.summary[].text``."""
+
+    def test_extracts_summary_with_encrypted_blob(self) -> None:
+        resp = MagicMock()
+        resp.usage = None
+        resp.output = [
+            _make_reasoning_item(
+                encrypted="ENC.payload",
+                summary_texts=["Considered three angles", "Picked angle 2"],
+            ),
+            _make_message_item("answer"),
+        ]
+        result = normalize_openai_responses(resp)
+        assert result.reasoning_summaries == [
+            "Considered three angles",
+            "Picked angle 2",
+        ]
+        # codex_reasoning_items still populated for multi-turn replay (R1)
+        assert result.codex_reasoning_items is not None
+        assert len(result.codex_reasoning_items) == 1
+
+    def test_extracts_summary_when_encrypted_blob_missing(self) -> None:
+        """Some transient error paths strip encrypted_content but keep
+        summary — surface to UI even though we can't replay."""
+        resp = MagicMock()
+        resp.usage = None
+        resp.output = [
+            _make_reasoning_item(encrypted=None, summary_texts=["partial thought"]),
+            _make_message_item("answer"),
+        ]
+        result = normalize_openai_responses(resp)
+        assert result.reasoning_summaries == ["partial thought"]
+        # No replay item because encrypted_content is missing
+        assert result.codex_reasoning_items is None
+
+    def test_no_reasoning_items_returns_none(self) -> None:
+        resp = MagicMock()
+        resp.usage = None
+        resp.output = [_make_message_item("hello")]
+        result = normalize_openai_responses(resp)
+        assert result.reasoning_summaries is None
+
+    def test_empty_summary_strings_filtered(self) -> None:
+        """Empty strings don't get pushed onto the sidecar."""
+        resp = MagicMock()
+        resp.usage = None
+        resp.output = [
+            _make_reasoning_item(encrypted="ENC", summary_texts=["", "real text", ""]),
+        ]
+        result = normalize_openai_responses(resp)
+        assert result.reasoning_summaries == ["real text"]
+
+
+class TestAnthropicThinkingExtraction:
+    """Sidecar populated from Anthropic ``thinking`` content blocks."""
+
+    def test_extracts_thinking_block_text(self) -> None:
+        resp = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="thinking", thinking="step-by-step plan", signature="sig"),
+                SimpleNamespace(type="text", text="visible answer"),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5, thinking_tokens=20),
+        )
+        result = normalize_anthropic(resp)
+        assert result.reasoning_summaries == ["step-by-step plan"]
+        # text block still extracted
+        assert len(result.content) == 1
+        assert result.content[0].text == "visible answer"
+
+    def test_no_thinking_block_returns_none(self) -> None:
+        resp = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="no thinking here")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5, thinking_tokens=0),
+        )
+        result = normalize_anthropic(resp)
+        assert result.reasoning_summaries is None
+
+    def test_empty_thinking_text_filtered(self) -> None:
+        resp = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="thinking", thinking="", signature="sig"),
+                SimpleNamespace(type="text", text="visible"),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5, thinking_tokens=0),
+        )
+        result = normalize_anthropic(resp)
+        assert result.reasoning_summaries is None
+
+
+class TestSidecarFieldDefault:
+    def test_default_is_none(self) -> None:
+        assert AgenticResponse().reasoning_summaries is None
+
+    def test_other_normalisers_leave_it_none(self) -> None:
+        """OpenAI Chat Completions normaliser doesn't set the sidecar."""
+        from core.llm.agentic_response import normalize_openai
+
+        resp = MagicMock()
+        resp.choices = []
+        resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+        result = normalize_openai(resp)
+        assert result.reasoning_summaries is None
+
+
+class TestEmitReasoningSummary:
+    """The UI emit helper renders to console when no IPC writer is bound,
+    and forwards a structured event when bound."""
+
+    def test_emit_console_path(self, capsys) -> None:
+        from core.ui.agentic_ui import emit_reasoning_summary
+
+        # No writer bound → console path
+        emit_reasoning_summary("openai-codex", "gpt-5.5", "considered the trade-offs")
+        # Rich prints to its own console; just assert no crash. The
+        # render shape is verified separately in event_renderer tests.
+
+    def test_emit_truncates_long_text(self) -> None:
+        from core.ui.agentic_ui import emit_reasoning_summary
+
+        # 500-char text — should be truncated for console display
+        long = "x" * 500
+        emit_reasoning_summary("anthropic", "claude-opus-4-7", long)
+
+
+class TestIPCAllowlistAndRenderer:
+    """v0.57.0 — ``reasoning_summary`` event is in the IPC allowlist
+    (``ipc_client.py``) and the renderer dispatches it
+    (``event_renderer.py``)."""
+
+    def test_event_in_ipc_allowlist(self) -> None:
+        # Read the source verbatim — assertion-by-grep is sufficient
+        # because the allowlist is a literal tuple.
+        from core.cli import ipc_client
+
+        with open(ipc_client.__file__, encoding="utf-8") as f:
+            text = f.read()
+        assert '"reasoning_summary"' in text, (
+            "ipc_client.py must include 'reasoning_summary' in the "
+            "structured-events allowlist or the daemon's events will be "
+            "silently dropped on the thin client side"
+        )
+
+    def test_renderer_handler_exists(self) -> None:
+        from core.ui.event_renderer import EventRenderer
+
+        assert hasattr(EventRenderer, "_handle_reasoning_summary"), (
+            "EventRenderer must define _handle_reasoning_summary so the "
+            "dispatch in `_handle` (line 115) can route the event"
+        )
+
+    def test_renderer_truncates_and_renders(self) -> None:
+        """Short text → muted line. Long text → truncated with ellipsis."""
+        import io
+
+        from core.ui.event_renderer import EventRenderer
+
+        renderer = EventRenderer()
+        renderer._out = io.StringIO()
+        renderer._handle_reasoning_summary({"text": "short summary"})
+        output = renderer._out.getvalue()
+        assert "thinking" in output
+        assert "short summary" in output
+
+        renderer2 = EventRenderer()
+        renderer2._out = io.StringIO()
+        renderer2._handle_reasoning_summary({"text": "x" * 500})
+        out2 = renderer2._out.getvalue()
+        assert "…" in out2  # ellipsis marker for truncation
+
+    def test_renderer_skips_empty_text(self) -> None:
+        import io
+
+        from core.ui.event_renderer import EventRenderer
+
+        renderer = EventRenderer()
+        renderer._out = io.StringIO()
+        renderer._handle_reasoning_summary({"text": "   "})  # whitespace only
+        assert renderer._out.getvalue() == ""
+
+
+class TestLoopEmitsAfterCall:
+    """The agentic loop emits each reasoning summary after the adapter
+    returns. We verify the wiring exists in the loop source — running
+    the actual loop requires a real LLM."""
+
+    def test_loop_calls_emit_reasoning_summary(self) -> None:
+        from core.agent import loop as loop_mod
+
+        with open(loop_mod.__file__, encoding="utf-8") as f:
+            text = f.read()
+        assert "emit_reasoning_summary" in text, (
+            "core/agent/loop.py must call emit_reasoning_summary for "
+            "each summary on response.reasoning_summaries — otherwise "
+            "the sidecar is collected but never surfaced to the UI"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.56.0"
+version = "0.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- New `AgenticResponse.reasoning_summaries` sidecar populated by Codex (`reasoning.summary[].text`) and Anthropic (`thinking` block text) normalisers
- `AgenticLoop` emits `emit_reasoning_summary` per item after each LLM call returns; rendered as muted single line on console + structured IPC event for thin client
- Per-item granularity (not per-delta) — avoids threading IPC writer into the `asyncio.to_thread` worker
- 3-codebase consensus pattern; GEODE was the only one dropping these on the floor

## Why
R6 from the post-R1+R5 audit. The 3-codebase comparison flagged this as 3/3-converging: Hermes uses TUI activity feed accumulation, Claude Code uses React state with rainbow + 30s auto-hide, OpenClaw pushes per-event. GEODE's spinner went silent during long Codex/Anthropic reasoning rounds, which the audit noted as a UX friction point ("is it stuck?" anxiety).

The implementation choice — per-item granularity instead of per-delta — keeps the wiring simple. The streaming loop already runs in `asyncio.to_thread`; emitting per-delta would require capturing the IPC writer on the main thread and threading it into the worker, with thread-local fallbacks. Per-item granularity gets us 80% of the UX value (one "thinking…" line per reasoning block) at 20% of the complexity. If a future user demands per-token "think-out-loud" rendering we can revisit.

## Changes
| File | Change |
|------|--------|
| `core/llm/agentic_response.py` | `AgenticResponse.reasoning_summaries: list[str] | None` (default `None`). `normalize_openai_responses` populates from `reasoning.summary[].text` (both encrypted-and-summary and summary-only fallback). `normalize_anthropic` populates from `thinking` content blocks. `normalize_openai` (Chat Completions / GLM) leaves `None`. |
| `core/agent/loop.py` | After each successful adapter call (in `_call_llm`-equivalent path), walk `response.reasoning_summaries` and emit one event per item. Skipped in quiet mode. |
| `core/ui/agentic_ui.py` | New `emit_reasoning_summary(provider, model, text)` helper. Console path renders muted single line truncated to 240 chars + ellipsis; IPC path forwards the structured event. |
| `core/ui/event_renderer.py` | New `_handle_reasoning_summary` (matches the dispatch in `_handle` line 115). Same truncation shape. Skips whitespace-only payloads. |
| `core/cli/ipc_client.py` | `"reasoning_summary"` added to structured-events allowlist; without this the daemon event would be silently dropped on the thin client. |
| `tests/test_reasoning_summary_r6.py` | **NEW** — 16 invariants. |
| `docs/research/reasoning-depth-audit.md` + `docs/research/reasoning-depth-post-r1r5-gaps.md` | **DELETED** — scratch research notes that drove the R1/R5/R4-mini/R6 cycle, per user direction "작업 끝나면 해당 MD 삭제하고." Actionable findings rolled into the corresponding CHANGELOG entries. |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `README.ko.md`, `pyproject.toml`, `uv.lock` | v0.56.0 → v0.57.0; tests 4257+ → 4273+. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Codex reasoning summary extraction | Implemented | Both encrypted-and-summary and summary-only fallback paths |
| Anthropic thinking block extraction | Implemented | Adaptive thinking with `display:"summarized"` from R4-mini produces visible text |
| Per-item emit (not per-delta) | Implemented | Documented rationale in code + CHANGELOG |
| `emit_reasoning_summary` helper | Implemented | Console + IPC paths |
| `_handle_reasoning_summary` renderer | Implemented | Truncation + skip-empty |
| IPC allowlist entry | Implemented | Without it daemon events would silently drop on thin client |
| Other provider isolation | Implemented | OpenAI Chat Completions / GLM normalisers leave `None` |
| Scratch MDs deleted | Implemented | Per user direction |

## Verification
- [x] `uv run ruff check + format` clean (auto-formatted via `ruff format`)
- [x] `uv run mypy core/` clean (233 source files)
- [x] `uv run pytest tests/ -m "not live"` → **4273 passed, 1 skipped, 19 deselected** (+16 new tests, 0 regressions)
- [x] `tests/test_reasoning_summary_r6.py` → 16/16

## Reference
- 3-codebase consensus: Hermes `agent/anthropic_adapter.py:793` (TUI activity feed), Claude Code `screens/REPL.tsx:139-157` (React state + rainbow + 30s auto-hide), OpenClaw `src/agents/openai-transport-stream.ts:398-407` (per-event push).
- User direction (2026-04-28): "MD 작성해두고 순차적으로 진행해" + "작업 끝나면 해당 MD 삭제하고 gitflow + CI 래칫 따라."

🤖 Generated with [Claude Code](https://claude.com/claude-code)