### PR TITLE
release: v0.58.0 — R2 GLM thinking field activation + reasoning_content extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.58.0] — 2026-04-28
+
+### Added
+- **GLM `thinking` field activation** (R2 of the reasoning-depth audit). All three reference frontier harnesses (Hermes, OpenClaw, Claude Code) leave this dead — Hermes routes GLM through a generic `chat_completions` transport that doesn't know about the field; OpenClaw has no GLM plugin; Claude Code is Anthropic-only. v0.58.0 makes GEODE the **leader** on this dimension. The adapter sends `extra_body={"thinking": {"type": "enabled", "clear_thinking": False}}` for every model in `_GLM_THINKING_MODELS` (GLM-4.5+ family). `clear_thinking=False` preserves prior-turn `reasoning_content` in the model's context — same multi-turn-coherence goal as R1 on Codex Plus. Per-failover-model gate drops the field on pre-GLM-4.5 models that reject it. Spec re-verified 2026-04-28 against `docs.z.ai/api-reference/llm/chat-completion` + `docs.z.ai/guides/capabilities/thinking-mode`. (`core/llm/providers/glm.py:_GLM_THINKING_MODELS, _glm_thinking_supported`)
+- **GLM `message.reasoning_content` extraction** (R2 + R6 integration). The GLM Chat Completion endpoint returns reasoning text on a separate `message.reasoning_content` field (distinct from `message.content`). `normalize_openai` (the Chat Completions normaliser used by GLM) now extracts it into `AgenticResponse.reasoning_summaries` so the R6 surfacing path treats GLM the same as Anthropic + Codex. Empty/whitespace-only payloads are filtered. Other Chat-Completions providers (without `reasoning_content`) leave the sidecar `None` — backward-compat preserved. (`core/llm/agentic_response.py:normalize_openai`)
+- **`tests/test_glm_thinking_r2.py`** — 15 invariants. Per-model gate (GLM-5.1, GLM-5, GLM-4.7, GLM-4.6, GLM-4.5, legacy reject, unknown reject, empty reject, frozenset constraint), reasoning_content extraction (extracted, no-content → None, empty filtered, OpenAI legacy isolation), source-level wiring pins (extra_body, gate, clear_thinking=False default).
+
+### Reference
+- ZhipuAI Z.AI official docs:
+  - `https://docs.z.ai/api-reference/llm/chat-completion` (Chat Completion API reference)
+  - `https://docs.z.ai/guides/capabilities/thinking-mode` (`thinking` field shape + `clear_thinking` semantics)
+  - `https://docs.z.ai/guides/llm/glm-4.5` (GLM-4.5 thinking guide)
+  - `https://docs.z.ai/guides/llm/glm-4.6` (GLM-4.6 hybrid mode)
+  - `https://docs.z.ai/guides/llm/glm-4.7` (GLM-4.7 turn-level thinking)
+  - `https://docs.z.ai/guides/llm/glm-5.1` (GLM-5.1 always-on)
+- Cross-codebase comparison: 0/3 references implement this (audit B2/B4 in the prior reasoning-depth scans), making v0.58.0 the leader.
+
 ## [0.57.0] — 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.57.0
+- **Version**: 0.58.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 233
-- **Tests**: 4273+
+- **Tests**: 4288+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.57.0 — Long-running Autonomous Execution Harness
+# GEODE v0.58.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.57.0 — Long-running Autonomous Execution Harness
+# GEODE v0.58.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -126,6 +126,16 @@ def normalize_openai(response: Any) -> AgenticResponse:
         return AgenticResponse()
 
     blocks: list[TextBlock | ToolUseBlock] = []
+    # v0.58.0 R2 — capture GLM ``message.reasoning_content`` (separate
+    # from ``message.content``) into the R6 sidecar so the AgenticUI
+    # surfaces it like Anthropic ``thinking`` blocks. GLM-4.5+ returns
+    # this field when ``thinking={"type":"enabled"}`` is sent (see
+    # ``core/llm/providers/glm.py``). Other Chat-Completions providers
+    # (OpenAI legacy, etc.) leave it absent → sidecar stays None.
+    reasoning_summaries: list[str] = []
+    _glm_reasoning = getattr(choice.message, "reasoning_content", None)
+    if isinstance(_glm_reasoning, str) and _glm_reasoning.strip():
+        reasoning_summaries.append(_glm_reasoning)
 
     # Text content
     if choice.message.content:
@@ -170,6 +180,7 @@ def normalize_openai(response: Any) -> AgenticResponse:
         content=blocks,
         stop_reason=stop_reason,
         usage=usage,
+        reasoning_summaries=reasoning_summaries or None,
     )
 
 

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -103,6 +103,45 @@ _GLM_NATIVE_WEB_SEARCH: dict[str, Any] = {
     },
 }
 
+# v0.58.0 R2 — GLM ``thinking`` parameter (docs.z.ai/api-reference/llm/
+# chat-completion + docs.z.ai/guides/capabilities/thinking-mode).
+# Spec re-verified 2026-04-28:
+#   - Field shape: ``{"type": "enabled"|"disabled", "clear_thinking": bool}``
+#   - GLM-4.5+ honours the flag (hybrid models — opt in/out)
+#   - GLM-5.x / GLM-5V / GLM-4.7 / GLM-4.5V will think *compulsorily*
+#     (sending ``"disabled"`` is silently ignored — but harmless)
+#   - Pre-GLM-4.5 models reject the field; we omit it for them
+#   - openai-python doesn't know ``thinking`` — must go via ``extra_body``
+# Models that accept the ``thinking`` field. Anything not listed gets the
+# field omitted entirely so the request shape stays compatible with the
+# legacy GLM-4.x endpoints.
+_GLM_THINKING_MODELS: frozenset[str] = frozenset(
+    {
+        # GLM-5 family — thinking always-on, but the field is accepted
+        "glm-5.1",
+        "glm-5",
+        "glm-5-turbo",
+        "glm-5v-turbo",
+        # GLM-4.7 family — thinking always-on
+        "glm-4.7",
+        "glm-4.7-flash",
+        "glm-4.7-flashx",
+        # GLM-4.6 family — hybrid (honors enabled/disabled)
+        "glm-4.6",
+        "glm-4.6v",
+        # GLM-4.5 family — hybrid
+        "glm-4.5",
+        "glm-4.5v",
+        "glm-4.5-air",
+        "glm-4.5-flash",
+    }
+)
+
+
+def _glm_thinking_supported(model: str) -> bool:
+    """Return True if the GLM model accepts the ``thinking`` field."""
+    return model in _GLM_THINKING_MODELS
+
 
 class GlmAgenticAdapter(OpenAIAgenticAdapter):
     """ZhipuAI GLM adapter (glm-5.1, glm-5, glm-5-turbo, glm-5v-turbo, glm-4.7-flash).
@@ -155,6 +194,16 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
         failover_models = [model] + [m for m in self.fallback_chain if m != model]
 
         async def _do_call(m: str) -> Any:
+            # v0.58.0 R2 — GLM ``thinking`` field (passed via ``extra_body``
+            # because openai-python's ``ChatCompletion.create`` doesn't know
+            # about it). Default ``clear_thinking=False`` — keep prior-turn
+            # ``reasoning_content`` in context across rounds (matches the
+            # multi-turn-reasoning-preservation goal of R1 on Codex Plus).
+            # Per-failover-model gate: drop the field on pre-GLM-4.5
+            # models so the request is accepted.
+            local_extra: dict[str, Any] = {}
+            if _glm_thinking_supported(m):
+                local_extra["thinking"] = {"type": "enabled", "clear_thinking": False}
             return await asyncio.to_thread(
                 client.chat.completions.create,
                 model=m,
@@ -163,6 +212,7 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
                 tool_choice=tc_val if oai_tools else None,
                 max_completion_tokens=max_tokens,
                 temperature=temperature,
+                extra_body=local_extra or None,
                 timeout=120.0,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.57.0"
+version = "0.58.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_glm_thinking_r2.py
+++ b/tests/test_glm_thinking_r2.py
@@ -1,0 +1,177 @@
+"""R2 — GLM ``thinking`` field activation invariants (v0.58.0).
+
+Pinned 2026-04-28 against the official ZhipuAI / Z.AI Chat Completion
+API spec (re-verified at this commit):
+
+  - Field shape: ``{"type": "enabled"|"disabled", "clear_thinking": bool}``
+  - GLM-4.5+ honours the flag (hybrid). GLM-5.x / GLM-5V / GLM-4.7 /
+    GLM-4.5V think compulsorily — sending the field is harmless,
+    omitting it is also fine.
+  - Pre-GLM-4.5 models reject the field; we omit entirely.
+  - openai-python doesn't know ``thinking`` — must go via ``extra_body``.
+
+Pre-fix audit (R2): three reference codebases (Hermes, OpenClaw,
+Claude Code) all share this gap. GEODE adopting the field makes us the
+leader on this dimension.
+
+Sources:
+  - https://docs.z.ai/api-reference/llm/chat-completion
+  - https://docs.z.ai/guides/capabilities/thinking-mode
+  - https://docs.z.ai/guides/llm/glm-4.5
+  - https://docs.z.ai/guides/llm/glm-4.6
+  - https://docs.z.ai/guides/llm/glm-4.7
+  - https://docs.z.ai/guides/llm/glm-5.1
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.llm.agentic_response import normalize_openai
+from core.llm.providers.glm import _GLM_THINKING_MODELS, _glm_thinking_supported
+
+
+class TestGlmThinkingModelGate:
+    """Per-model gating mirrors docs.z.ai per-model thinking docs."""
+
+    def test_glm_5_1_supported(self) -> None:
+        assert _glm_thinking_supported("glm-5.1") is True
+
+    def test_glm_5_supported(self) -> None:
+        assert _glm_thinking_supported("glm-5") is True
+
+    def test_glm_4_7_supported(self) -> None:
+        assert _glm_thinking_supported("glm-4.7") is True
+        assert _glm_thinking_supported("glm-4.7-flash") is True
+
+    def test_glm_4_6_supported(self) -> None:
+        assert _glm_thinking_supported("glm-4.6") is True
+
+    def test_glm_4_5_supported(self) -> None:
+        assert _glm_thinking_supported("glm-4.5") is True
+        assert _glm_thinking_supported("glm-4.5-air") is True
+
+    def test_glm_4_legacy_rejected(self) -> None:
+        """Pre-GLM-4.5 models reject the field; we must omit it."""
+        assert _glm_thinking_supported("glm-4") is False
+        assert _glm_thinking_supported("glm-4-flash") is False
+
+    def test_unknown_model_rejected(self) -> None:
+        """Default to off for safety — better to omit a field a model
+        rejects than to send one and get 400."""
+        assert _glm_thinking_supported("unknown-model") is False
+        assert _glm_thinking_supported("") is False
+
+    def test_thinking_models_set_is_frozen(self) -> None:
+        """The model list is intentionally a frozenset to prevent
+        accidental mutation at runtime."""
+        assert isinstance(_GLM_THINKING_MODELS, frozenset)
+
+
+class TestGlmReasoningContentExtraction:
+    """``message.reasoning_content`` (GLM-only) lands in
+    ``AgenticResponse.reasoning_summaries`` so the R6 surfacing path
+    treats GLM the same as Anthropic + Codex."""
+
+    def _make_choice(
+        self, *, content: str | None, reasoning: str | None, tool_calls: list | None = None
+    ) -> SimpleNamespace:
+        message = SimpleNamespace(
+            content=content,
+            tool_calls=tool_calls,
+            reasoning_content=reasoning,
+        )
+        return SimpleNamespace(message=message, finish_reason="stop")
+
+    def test_extracts_glm_reasoning_content(self) -> None:
+        resp = MagicMock()
+        resp.choices = [
+            self._make_choice(
+                content="visible answer",
+                reasoning="step 1 → step 2 → conclusion",
+            )
+        ]
+        resp.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
+        result = normalize_openai(resp)
+        assert result.reasoning_summaries == ["step 1 → step 2 → conclusion"]
+        # Visible content still extracted normally
+        assert len(result.content) == 1
+        assert result.content[0].text == "visible answer"
+
+    def test_no_reasoning_content_returns_none(self) -> None:
+        resp = MagicMock()
+        resp.choices = [self._make_choice(content="hi", reasoning=None)]
+        resp.usage = MagicMock(prompt_tokens=5, completion_tokens=2)
+        result = normalize_openai(resp)
+        assert result.reasoning_summaries is None
+
+    def test_empty_string_reasoning_filtered(self) -> None:
+        """Empty string and whitespace-only reasoning shouldn't pollute
+        the sidecar."""
+        for empty in ("", "   ", "\n"):
+            resp = MagicMock()
+            resp.choices = [self._make_choice(content="x", reasoning=empty)]
+            resp.usage = MagicMock(prompt_tokens=5, completion_tokens=2)
+            assert normalize_openai(resp).reasoning_summaries is None
+
+    def test_provider_isolation_openai_legacy(self) -> None:
+        """Non-GLM Chat Completions responses (without
+        reasoning_content) leave the sidecar None — backward compat."""
+        resp = MagicMock()
+        # No reasoning_content attribute at all
+        message = SimpleNamespace(content="hi", tool_calls=None)
+        resp.choices = [SimpleNamespace(message=message, finish_reason="stop")]
+        resp.usage = MagicMock(prompt_tokens=5, completion_tokens=2)
+        result = normalize_openai(resp)
+        assert result.reasoning_summaries is None
+
+
+class TestGlmAdapterSendsThinkingField:
+    """Source-level pin: ``GlmAgenticAdapter`` must build the
+    ``extra_body={'thinking': ...}`` payload for supported models. We
+    verify by reading the adapter source — running the live request
+    requires a real GLM endpoint."""
+
+    def test_adapter_sends_thinking_via_extra_body(self) -> None:
+        from core.llm.providers import glm as glm_mod
+
+        with open(glm_mod.__file__, encoding="utf-8") as f:
+            text = f.read()
+        # Both the field assembly and the kwarg passthrough must exist.
+        assert '"thinking"' in text and '"clear_thinking"' in text, (
+            "core/llm/providers/glm.py must build the thinking field "
+            "before the chat completions call (per docs.z.ai/guides/"
+            "capabilities/thinking-mode)"
+        )
+        assert "extra_body=" in text, (
+            "thinking field must be passed via extra_body= because "
+            "openai-python does not know about it"
+        )
+
+    def test_adapter_gates_on_supported_models(self) -> None:
+        """The adapter must consult ``_glm_thinking_supported`` (or
+        equivalent gate) so failover to a non-thinking model doesn't
+        send a field the server rejects."""
+        from core.llm.providers import glm as glm_mod
+
+        with open(glm_mod.__file__, encoding="utf-8") as f:
+            text = f.read()
+        assert "_glm_thinking_supported" in text, (
+            "adapter must gate the thinking field per model — sending "
+            "it on pre-GLM-4.5 models is undefined behavior"
+        )
+
+    def test_clear_thinking_default_preserves_history(self) -> None:
+        """``clear_thinking=False`` keeps prior-turn ``reasoning_content``
+        in the model's context — matches R1's multi-turn-reasoning-
+        preservation goal on Codex Plus."""
+        from core.llm.providers import glm as glm_mod
+
+        with open(glm_mod.__file__, encoding="utf-8") as f:
+            text = f.read()
+        assert '"clear_thinking": False' in text, (
+            "clear_thinking must default to False to preserve "
+            "reasoning_content across turns (multi-turn coherence). "
+            "True would strip prior reasoning every turn."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.57.0"
+version = "0.58.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.58.0 release rolling R2 from PR #846
- GLM `thinking` field now sent via `extra_body` for GLM-4.5+ models (per-family gate); `clear_thinking=False` preserves prior-turn reasoning across rounds
- `normalize_openai` extracts GLM `message.reasoning_content` into the R6 `reasoning_summaries` sidecar (single emit pipeline across Anthropic, Codex, GLM)
- 0/3 reference codebases implement this — v0.58.0 makes GEODE the leader on this dimension
- Spec re-verified 2026-04-28 against `docs.z.ai/api-reference/llm/chat-completion` + `docs.z.ai/guides/capabilities/thinking-mode`

## Verification
- [x] feature → develop CI 5/5 green (PR #846)
- [x] `uv run pytest tests/ -m "not live"` → 4288 passed, 1 skipped (+15 new tests)
- [x] `uv run ruff check + format` clean
- [x] `uv run mypy core/` clean (233 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)