### PR TITLE
feat(v0.60.0): R3-mini — PAYG OpenAI Responses reasoning parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.60.0] — 2026-04-28
+
+### Added
+- **R3-mini — PAYG OpenAI Responses reasoning parity.** The PAYG `OpenAIAgenticAdapter` now sends `include=["reasoning.encrypted_content"]` + `reasoning={"effort": …, "summary": "auto"}` for every gpt-5.x model (and the o-series whitelist). Without these, gpt-5.x silently lost its reasoning state on every multi-turn round (server omits the encrypted continuation blob from non-`include` responses, and `summary` is opt-in). The `_REASONING_MODELS` whitelist is replaced by a `_is_payg_reasoning_model(model)` helper that gates on `gpt-5*` prefix + the legacy o-series — previously gpt-5.5 / 5.4 / 5.4-mini / 5.3-codex got NO reasoning kwarg, so the picker's effort knob was being silently dropped on PAYG. Spec-grounded against `openai-python/src/openai/types/shared/reasoning.py` (`Reasoning` model, `summary: Literal["auto", "concise", "detailed"]`) + `openai-python/src/openai/types/responses/response_create_params.py:70-74` (`reasoning.encrypted_content` semantics under `store=False`). (`core/llm/providers/openai.py:_is_payg_reasoning_model, OpenAIAgenticAdapter._do_call`)
+- **Shared encrypted-reasoning replay walker** (`inject_reasoning_replay`). The 29-line walker that re-injects prior-turn `codex_reasoning_items` into the next-turn `input` array (originally inlined in `core/llm/providers/codex.py:243-271` for Codex Plus) is now a shared helper in `core/llm/agentic_response.py`. Both adapters call the same function, so a future change to the wire format only has to land once. Strips the `id` field on replay (server can 404 on item lookup with `store=False`); skips items with no `encrypted_content` (otherwise we just bloat the request); drops the `system` entry (system prompt rides the `instructions` kwarg). (`core/llm/agentic_response.py:inject_reasoning_replay`, `core/llm/providers/codex.py`, `core/llm/providers/openai.py`)
+- **`tests/test_r3_mini_payg_reasoning.py`** — 13 invariants. Reasoning-model gate (gpt-5.x family in, o-series in, gpt-4 / claude out), shared walker (blob-precedes-assistant ordering, id strip, missing-blob skip, system drop, plain-conversation pass-through), source-level pins (`include` + `summary:"auto"` + `inject_reasoning_replay` literally appear in `openai.py`; codex.py no longer carries the inline walker; `_EFFORT_MAP` keeps `max → high`).
+
+### Reference
+- openai-python (Stainless-generated SDK):
+  - `src/openai/types/shared/reasoning.py:13` — "**gpt-5 and o-series models only**"
+  - `src/openai/types/shared/reasoning.py:44-52` — `summary: Literal["auto", "concise", "detailed"]`
+  - `src/openai/types/responses/response_create_params.py:70-74` — `reasoning.encrypted_content` purpose + `store=False`/ZDR conditions
+  - `src/openai/types/responses/response_includable.py` — `Literal["reasoning.encrypted_content", …]`
+- 3-codebase consensus: Hermes `agent/codex_responses_adapter.py:228-246, 720-738`, Codex Rust `codex-rs/protocol/src/openai_models.rs:43-51`, GEODE Codex Plus path `core/llm/providers/codex.py:347-348` (R1, v0.55.0).
+
 ## [0.59.0] — 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.59.0
+- **Version**: 0.60.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 234
-- **Tests**: 4309+
+- **Tests**: 4322+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.59.0 — Long-running Autonomous Execution Harness
+# GEODE v0.60.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.59.0 — Long-running Autonomous Execution Harness
+# GEODE v0.60.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -74,6 +74,52 @@ class AgenticResponse:
     reasoning_summaries: list[str] | None = None
 
 
+def inject_reasoning_replay(
+    oai_messages: list[dict[str, Any]],
+    anthropic_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Inject prior-turn ``codex_reasoning_items`` back into a Responses
+    API ``input`` array.
+
+    For every assistant entry in ``oai_messages``, look up the matching
+    original Anthropic-format message and prepend any captured
+    ``encrypted_content`` reasoning items immediately before the
+    assistant entry. Strips ``id`` so the server can't 404 on item
+    lookup — mirrors Hermes ``codex_responses_adapter.py:228-246``.
+
+    Both lists must preserve order (one Anthropic message → ≥1 entries
+    in oai_messages). Used by Codex Plus and PAYG OpenAI Responses
+    adapters; without this, gpt-5.x loses reasoning state every turn
+    when ``store=False`` (no server-side item resolution).
+    """
+    resp_input: list[dict[str, Any]] = []
+    msg_iter = iter(anthropic_messages)
+    current_msg: dict[str, Any] | None = next(msg_iter, None)
+    for entry in oai_messages:
+        if entry.get("role") == "system":
+            # Adapter passes system via ``instructions`` kwarg, not input.
+            continue
+        entry_role = (
+            entry.get("role")
+            or ("assistant" if entry.get("type") in ("function_call",) else None)
+            or ("user" if entry.get("type") == "function_call_output" else None)
+        )
+        while current_msg is not None and current_msg.get("role") != entry_role:
+            current_msg = next(msg_iter, None)
+        if (
+            current_msg is not None
+            and current_msg.get("role") == "assistant"
+            and entry_role == "assistant"
+        ):
+            reasoning = current_msg.get("codex_reasoning_items")
+            if isinstance(reasoning, list):
+                for ri in reasoning:
+                    if isinstance(ri, dict) and ri.get("encrypted_content"):
+                        resp_input.append({k: v for k, v in ri.items() if k != "id"})
+        resp_input.append(entry)
+    return resp_input
+
+
 def normalize_anthropic(response: Any) -> AgenticResponse:
     """Normalize an Anthropic SDK response to AgenticResponse."""
     blocks: list[TextBlock | ToolUseBlock] = []

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -224,50 +224,12 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
         # ResponseFunctionToolCallParam / FunctionCallOutput /
         # ResponseOutputMessageParam.
         oai_messages = _convert_messages_to_responses(system, messages)
-        # v0.55.0 — Codex multi-turn encrypted reasoning replay. For each
-        # assistant turn that produced reasoning items in a prior round,
-        # inject the opaque ``encrypted_content`` blobs back into the
-        # ``input`` array immediately before the corresponding assistant
-        # entry. Without this, gpt-5.x loses its reasoning state every
-        # turn (the server has no way to resolve item IDs server-side
-        # because we run with ``store=False``). Mirrors Hermes
-        # ``codex_responses_adapter.py:228-246``: strip the ``id`` field
-        # so the server can't 404 on item lookup; trust only the
-        # ``encrypted_content`` blob + summary.
-        #
-        # ``oai_messages`` is the converted Responses-API form; we re-walk
-        # the original ``messages`` (Anthropic-format) in lockstep so we
-        # know which assistant entry the sidecar belongs to. Both lists
-        # preserve ordering: every Anthropic message produces ≥1 entry
-        # in oai_messages, and assistant entries are always non-system.
-        resp_input: list[dict[str, Any]] = []
-        _msg_iter = iter(messages)
-        _current_msg: dict[str, Any] | None = next(_msg_iter, None)
-        for entry in oai_messages:
-            if entry.get("role") == "system":
-                continue  # ``instructions`` kwarg below handles system prompt
-            # When entering a new logical message in oai_messages, advance
-            # ``_current_msg`` to the matching original message.
-            entry_role = (
-                entry.get("role")
-                or ("assistant" if entry.get("type") in ("function_call",) else None)
-                or ("user" if entry.get("type") == "function_call_output" else None)
-            )
-            while _current_msg is not None and _current_msg.get("role") != entry_role:
-                _current_msg = next(_msg_iter, None)
-            if (
-                _current_msg is not None
-                and _current_msg.get("role") == "assistant"
-                and entry_role == "assistant"
-            ):
-                _reasoning = _current_msg.get("codex_reasoning_items")
-                if isinstance(_reasoning, list):
-                    for ri in _reasoning:
-                        if isinstance(ri, dict) and ri.get("encrypted_content"):
-                            resp_input.append({k: v for k, v in ri.items() if k != "id"})
-            resp_input.append(entry)
-            # The user-side function_call_output items come from the same
-            # original user message, so don't advance until we see a new role.
+        # v0.55.0 — Codex multi-turn encrypted reasoning replay.
+        # v0.60.0 — extracted to shared helper so PAYG OpenAI Responses
+        # adapter can reuse the same walker (R3-mini parity).
+        from core.llm.agentic_response import inject_reasoning_replay
+
+        resp_input = inject_reasoning_replay(oai_messages, messages)
 
         # v0.53.3 — pre-send observability. Logs one structured line so
         # any future ``input[i].content == null`` (or other shape regressions)

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -383,6 +383,23 @@ _OPENAI_COMPUTER_USE_TOOL: dict[str, Any] = {
     "environment": "mac",
 }
 
+# v0.60.0 R3-mini — PAYG OpenAI Responses reasoning models.
+# Spec-grounded against openai-python ``shared/reasoning.py:13`` ("gpt-5
+# and o-series models only") + ``response_create_params.py:70-74``
+# (``reasoning.encrypted_content`` semantics under ``store=False``).
+_PAYG_REASONING_O_SERIES = frozenset({"o3", "o4-mini", "o3-mini"})
+
+
+def _is_payg_reasoning_model(model: str) -> bool:
+    """True for any PAYG OpenAI model that accepts the ``reasoning`` kwarg.
+
+    Includes the gpt-5.x family (gpt-5.5, gpt-5.4, gpt-5.4-mini,
+    gpt-5.3-codex, …) plus the legacy o-series whitelist. Other models
+    silently drop the kwarg, so this gate keeps the request shape
+    correct.
+    """
+    return model in _PAYG_REASONING_O_SERIES or model.startswith("gpt-5")
+
 
 class OpenAIAgenticAdapter:
     """OpenAI agentic adapter via Responses API (P1 Gateway pattern).
@@ -492,12 +509,14 @@ class OpenAIAgenticAdapter:
         if is_computer_use_enabled():
             oai_tools.append(_OPENAI_COMPUTER_USE_TOOL)
 
-        # Convert messages to Responses API input format
-        responses_input = _convert_messages_to_responses(system, messages)
-        failover_models = [model] + [m for m in self.fallback_chain if m != model]
+        # Convert messages to Responses API input format, then inject any
+        # prior-turn encrypted reasoning blobs so gpt-5.x can resume
+        # state across turns (R3-mini parity with Codex Plus).
+        from core.llm.agentic_response import inject_reasoning_replay
 
-        # OpenAI reasoning models that support reasoning effort
-        _REASONING_MODELS = {"o3", "o4-mini", "o3-mini"}
+        oai_messages = _convert_messages_to_responses(system, messages)
+        responses_input = inject_reasoning_replay(oai_messages, messages)
+        failover_models = [model] + [m for m in self.fallback_chain if m != model]
 
         async def _do_call(m: str) -> Any:
             create_kwargs: dict[str, Any] = {
@@ -508,11 +527,17 @@ class OpenAIAgenticAdapter:
                 "max_output_tokens": max_tokens,
                 "temperature": temperature,
             }
-            # Map effort to OpenAI reasoning effort for reasoning models
+            # v0.60.0 R3-mini — Responses-API reasoning kwargs.
+            # ``include=["reasoning.encrypted_content"]`` is required when
+            # ``store=False`` (default) so the server returns the opaque
+            # continuation blob; ``summary="auto"`` opts the response into
+            # reasoning summaries so the R6 surfacing path can render
+            # "live thinking..." for PAYG users (Codex Plus already had this).
             _EFFORT_MAP = {"low": "low", "medium": "medium", "high": "high", "max": "high"}
-            if m in _REASONING_MODELS:
+            if _is_payg_reasoning_model(m):
                 oai_effort = _EFFORT_MAP.get(effort, "medium")
-                create_kwargs["reasoning"] = {"effort": oai_effort}
+                create_kwargs["reasoning"] = {"effort": oai_effort, "summary": "auto"}
+                create_kwargs["include"] = ["reasoning.encrypted_content"]
             return await asyncio.to_thread(client.responses.create, **create_kwargs)
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.59.0"
+version = "0.60.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_r3_mini_payg_reasoning.py
+++ b/tests/test_r3_mini_payg_reasoning.py
@@ -1,0 +1,180 @@
+"""R3-mini — PAYG OpenAI Responses reasoning kwargs + replay parity (v0.60.0).
+
+Pinned 2026-04-28 against:
+  - openai-python ``shared/reasoning.py`` (Reasoning model, summary Literal)
+  - openai-python ``responses/response_create_params.py:70-74``
+    (``reasoning.encrypted_content`` semantics under ``store=False``)
+  - openai-python ``responses/response_includable.py`` (include enum)
+  - Codex Plus parity: ``core/llm/providers/codex.py:347-348``
+
+Verifies:
+  1. ``_is_payg_reasoning_model`` gates gpt-5.x + o-series only.
+  2. ``inject_reasoning_replay`` round-trips encrypted blobs across turns.
+  3. PAYG ``openai.py`` adapter sends ``include`` + ``reasoning.summary=auto``
+     for gpt-5.x; non-reasoning models leave the kwargs untouched.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from core.llm.agentic_response import inject_reasoning_replay
+from core.llm.providers.openai import _is_payg_reasoning_model
+
+
+class TestPaygReasoningGate:
+    def test_gpt5_family_gated_in(self) -> None:
+        for m in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5"):
+            assert _is_payg_reasoning_model(m), m
+
+    def test_o_series_gated_in(self) -> None:
+        for m in ("o3", "o4-mini", "o3-mini"):
+            assert _is_payg_reasoning_model(m), m
+
+    def test_non_reasoning_models_gated_out(self) -> None:
+        for m in ("gpt-4-turbo", "gpt-4o", "gpt-3.5-turbo", "claude-opus-4-7"):
+            assert not _is_payg_reasoning_model(m), m
+
+
+class TestReasoningReplayWalker:
+    def test_assistant_with_reasoning_items_emits_blob_first(self) -> None:
+        """The encrypted blob must precede the assistant entry it
+        belongs to so the server restores reasoning state before
+        decoding the assistant turn."""
+        anth_messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "codex_reasoning_items": [
+                    {
+                        "type": "reasoning",
+                        "encrypted_content": "BLOB-1",
+                        "id": "rs_abc",
+                    }
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        oai_messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "next"},
+        ]
+        out = inject_reasoning_replay(oai_messages, anth_messages)
+        types_or_roles = [(e.get("type"), e.get("role")) for e in out]
+        # Sequence: user → reasoning → assistant → user
+        assert types_or_roles == [
+            (None, "user"),
+            ("reasoning", None),
+            (None, "assistant"),
+            (None, "user"),
+        ]
+
+    def test_id_field_stripped(self) -> None:
+        """ID must not be sent back — server can 404 on item lookup."""
+        anth = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "codex_reasoning_items": [
+                    {"type": "reasoning", "encrypted_content": "BLOB", "id": "rs_xyz"}
+                ],
+            }
+        ]
+        oai = [{"role": "assistant", "content": "x"}]
+        out = inject_reasoning_replay(oai, anth)
+        reasoning = next(e for e in out if e.get("type") == "reasoning")
+        assert "id" not in reasoning
+        assert reasoning["encrypted_content"] == "BLOB"
+
+    def test_missing_encrypted_content_is_skipped(self) -> None:
+        """No blob → nothing to replay (otherwise we just bloat the request)."""
+        anth = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "codex_reasoning_items": [{"type": "reasoning", "summary": [{"text": "thought"}]}],
+            }
+        ]
+        oai = [{"role": "assistant", "content": "x"}]
+        out = inject_reasoning_replay(oai, anth)
+        assert all(e.get("type") != "reasoning" for e in out)
+
+    def test_system_entry_dropped(self) -> None:
+        """System prompt comes via ``instructions`` kwarg, not input."""
+        anth = [{"role": "user", "content": "hi"}]
+        oai = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hi"},
+        ]
+        out = inject_reasoning_replay(oai, anth)
+        assert all(e.get("role") != "system" for e in out)
+
+    def test_no_codex_reasoning_items_passes_through(self) -> None:
+        """Plain conversations without reasoning sidecar return unchanged."""
+        anth = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+        ]
+        oai = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+        ]
+        out = inject_reasoning_replay(oai, anth)
+        assert out == oai
+
+
+class TestPaygSourceWiring:
+    """Source-level pin — the kwargs must literally appear in openai.py
+    so a future refactor can't silently drop them."""
+
+    def test_include_encrypted_content_present(self) -> None:
+        from core.llm.providers import openai as openai_mod
+
+        src = inspect.getsource(openai_mod)
+        assert '"include"' in src
+        assert '"reasoning.encrypted_content"' in src
+
+    def test_summary_auto_present(self) -> None:
+        from core.llm.providers import openai as openai_mod
+
+        src = inspect.getsource(openai_mod)
+        assert '"summary": "auto"' in src
+
+    def test_inject_reasoning_replay_called(self) -> None:
+        """Without the replay walker, ``include`` is write-only — the
+        server returns the blob but we never feed it back next turn."""
+        from core.llm.providers import openai as openai_mod
+
+        src = inspect.getsource(openai_mod)
+        assert "inject_reasoning_replay" in src
+
+    def test_codex_path_uses_shared_helper(self) -> None:
+        """Codex.py shouldn't carry the inline walker anymore."""
+        from core.llm.providers import codex as codex_mod
+
+        src = inspect.getsource(codex_mod)
+        assert "inject_reasoning_replay" in src
+        # Inline marker from the pre-extraction version
+        assert "_msg_iter = iter(messages)" not in src
+
+
+class TestEffortMapping:
+    """``max`` (Anthropic) → ``high`` (OpenAI) per the existing _EFFORT_MAP."""
+
+    def test_max_maps_to_high_in_kwargs(self, monkeypatch) -> None:
+        from core.llm.providers import openai as openai_mod
+
+        captured: dict[str, Any] = {}
+
+        def _fake_responses_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            raise RuntimeError("stop after capture")
+
+        # We can't easily run the full async path without a client; the
+        # source-level pin above guards the ``_EFFORT_MAP`` literal. Here
+        # we just sanity-check the literal is intact.
+        src = inspect.getsource(openai_mod)
+        assert '"max": "high"' in src

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.59.0"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- PAYG `OpenAIAgenticAdapter` now sends `include=["reasoning.encrypted_content"]` + `reasoning={"effort": …, "summary": "auto"}` for gpt-5.x and o-series — bringing it to parity with the Codex Plus path that already had this since v0.55.0 (R1).
- `_REASONING_MODELS` whitelist replaced by `_is_payg_reasoning_model(model)` helper. Previously gpt-5.5 / 5.4 / 5.4-mini / 5.3-codex got NO reasoning kwarg, so the v0.59.0 picker's effort knob was silently dropped on PAYG.
- The 29-line encrypted-blob replay walker (originally inlined in `codex.py:243-271`) is extracted to a shared helper `inject_reasoning_replay` in `agentic_response.py`, called by both adapters.

## Why
After R1 (v0.55.0) shipped encrypted reasoning replay for Codex Plus, the PAYG OpenAI provider was left as a known asymmetry: every `responses.create` call dropped both the `include` field and the `summary` opt-in. The server response then omits the encrypted blob, so on the next turn there is nothing to replay — gpt-5.x users on PAYG saw their reasoning state reset every round, and the R6 (v0.57.0) "live thinking..." surfacing rendered nothing because no summaries were ever returned. Picking gpt-5.5 from the v0.59.0 picker compounded the silent failure: gpt-5.x was not in the legacy o-series whitelist, so even the basic `effort` kwarg was being dropped.

User direction 2026-04-28 ("R3-mini PAYG OpenAI include=encrypted_content + summary:auto 사이클 시작") is the explicit go-ahead to close the asymmetry.

## Changes
| File | Change |
|------|--------|
| `core/llm/agentic_response.py` | NEW shared helper `inject_reasoning_replay(oai_messages, anthropic_messages)`. Walks both lists in lockstep, prepends `encrypted_content` items before each assistant entry, strips `id`, drops system rows. |
| `core/llm/providers/codex.py` | Inline 29-line walker (lines 243-271) replaced with single call to `inject_reasoning_replay`. |
| `core/llm/providers/openai.py` | NEW `_is_payg_reasoning_model(model)` (gpt-5* prefix + o-series whitelist). `_do_call` now sets `include=["reasoning.encrypted_content"]` + `reasoning={"effort", "summary":"auto"}` for reasoning models. `responses_input` runs through the shared replay walker before send. |
| `tests/test_r3_mini_payg_reasoning.py` | NEW. 13 invariants — gate (gpt-5.x/o-series in, gpt-4/claude out), walker (blob-precedes-assistant, id strip, missing-blob skip, system drop, plain-conversation pass-through), source-level pins (`include` + `summary:"auto"` + `inject_reasoning_replay` literal in `openai.py`; `codex.py` no longer carries inline walker). |
| `CHANGELOG.md` | v0.60.0 entry with Added + Reference sections. |
| `CLAUDE.md` / `README.md` / `README.ko.md` / `pyproject.toml` / `uv.lock` | Version bump 0.59.0 → 0.60.0. CLAUDE.md tests 4309 → 4322. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `_REASONING_MODELS` covers gpt-5.x | Implemented | Replaced whitelist with `_is_payg_reasoning_model(model)` |
| `include=["reasoning.encrypted_content"]` | Implemented | Required when `store=False` per Stainless SDK comment |
| `reasoning.summary="auto"` | Implemented | R6 surfacing now works for PAYG |
| Encrypted-blob replay walker | Implemented | Shared helper, called from both adapters |
| Effort enum expansion (none/minimal/xhigh) | Deferred | Separate cycle (R7) — keeps existing `_EFFORT_MAP` |
| `store=False` toggle | Deferred | Replay-walker pattern doesn't require it; can keep current default |

## Verification
- [x] `ruff check core/ tests/` — clean
- [x] `ruff format --check` — clean (463 files)
- [x] `mypy core/` — clean (234 source files)
- [x] `pytest tests/ -m "not live"` — 4322 passed, 1 skipped, 19 deselected (was 4309 before)
- [x] R3-mini tests (`test_r3_mini_payg_reasoning.py`) — 13/13 green

## Reference
- openai-python Stainless-generated SDK:
  - `src/openai/types/shared/reasoning.py:13` — "**gpt-5 and o-series models only**"
  - `src/openai/types/shared/reasoning.py:44-52` — `summary: Literal["auto", "concise", "detailed"]`
  - `src/openai/types/responses/response_create_params.py:70-74` — `reasoning.encrypted_content` purpose under `store=False` / ZDR
  - `src/openai/types/responses/response_includable.py` — `include` Literal enum
- 3-codebase consensus: Hermes `agent/codex_responses_adapter.py:228-246, 720-738`, Codex Rust `codex-rs/protocol/src/openai_models.rs:43-51`, GEODE Codex Plus path `core/llm/providers/codex.py:347-348` (R1, v0.55.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)