### PR TITLE
feat(v0.61.0): durable picker persistence + PAYG store=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.61.0] — 2026-04-28
+
+### Added
+- **Picker effort + model now persist to `.geode/config.toml`** (durable layer), not just `.env`. Previously `_apply_model` wrote `GEODE_AGENTIC_EFFORT` / `GEODE_MODEL` to `.env` only — a stale comment claimed config.toml sync, but the config-toml write never happened. Sessions worked in practice because `.env` survives, but wiping `.env` silently lost the picker choice. New shared helper `upsert_config_toml(section, key, value)` in `core/cli/_helpers.py` performs minimal-diff TOML upserts (creates file + section if absent, replaces existing keys including commented defaults like `# effort = "high"`, inserts before next section heading). Called from `_apply_model` for both `[agentic] effort` and `[llm] primary_model`. 3-codebase consensus pattern (Hermes `~/.hermes/config.json`, Codex `~/.codex/config.toml`, Claude Code project + global config) — chosen settings persist to the config layer. (`core/cli/_helpers.py:upsert_config_toml`, `core/cli/commands.py:_apply_model`)
+- **Explicit `store=False` on PAYG OpenAI Responses calls** (R3-mini follow-up). The PAYG `OpenAIAgenticAdapter` now sends `store=False` for parity with the Codex Plus path (`codex.py:331`). We feed conversations via the `input` array + the v0.60.0 encrypted-content replay walker, never via `previous_response_id`, so server-side response storage is unused on our side; opting out matches Codex Plus behaviour and avoids OpenAI-side retention of every response. SDK default is `True`. (`core/llm/providers/openai.py:OpenAIAgenticAdapter._do_call`)
+- **`tests/test_config_effort_knob.py`** — 8 invariants. `upsert_config_toml` (creates file with section, updates existing key, inserts into existing section preserving siblings + other sections, uncomments commented defaults exactly once, appends section when missing), picker persistence (`_apply_model` round-trips effort + model into `.geode/config.toml`), source-pin (`store=False` literal in both `openai.py` and `codex.py`).
+
+### Reference
+- 3-codebase config persistence: Hermes `hermes_cli/main.py:cmd_model` (writes to `~/.hermes/config.json`), Codex CLI `codex-rs/cli/src/config.rs` (writes to `~/.codex/config.toml`), Claude Code `screens/REPL.tsx` (project + global JSON config write).
+- openai-python Stainless SDK `responses/response_create_params.py` — `store: Optional[bool]` defaults to `True`; `store=False` is the supported opt-out for ZDR / privacy-conscious flows.
+
 ## [0.60.0] — 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.60.0
+- **Version**: 0.61.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 234
-- **Tests**: 4322+
+- **Tests**: 4330+
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.60.0 — Long-running Autonomous Execution Harness
+# GEODE v0.61.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.60.0 — Long-running Autonomous Execution Harness
+# GEODE v0.61.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/cli/_helpers.py
+++ b/core/cli/_helpers.py
@@ -38,6 +38,62 @@ def upsert_env(var_name: str, value: str) -> None:
     os.environ[var_name] = value
 
 
+def upsert_config_toml(section: str, key: str, value: str) -> None:
+    """Insert or update ``[section] key = "value"`` in ``.geode/config.toml``.
+
+    Creates the file (and ``[section]`` heading) if absent. Mirrors the
+    write semantics of ``upsert_env``: durable layer for picker choices
+    so the next session starts from the same effort / model after the
+    user clears ``.env``. 3-codebase consensus pattern (Hermes
+    ``~/.hermes/config.json``, Codex ``~/.codex/config.toml``, Claude
+    Code project + global config) — chosen settings persist to the
+    config layer, not just the env layer.
+
+    Section headings use ``[section.subsection]`` notation per TOML.
+    """
+    config_path = Path(".geode") / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    target_line = f'{key} = "{value}"'
+    section_heading = f"[{section}]"
+
+    raw = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    lines = raw.splitlines()
+
+    in_section = False
+    found_section = False
+    found_key = False
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == section_heading:
+            in_section = True
+            found_section = True
+            new_lines.append(line)
+            continue
+        if in_section and stripped.startswith("["):
+            # Hit the next section without finding the key — insert before it
+            if not found_key:
+                new_lines.append(target_line)
+                found_key = True
+            in_section = False
+        if in_section and re.match(rf"^\s*#?\s*{re.escape(key)}\s*=", line):
+            new_lines.append(target_line)
+            found_key = True
+            continue
+        new_lines.append(line)
+
+    if found_section and not found_key:
+        new_lines.append(target_line)
+    elif not found_section:
+        if new_lines and new_lines[-1] != "":
+            new_lines.append("")
+        new_lines.append(section_heading)
+        new_lines.append(target_line)
+
+    config_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
 def parse_dry_run_flag(args: str) -> tuple[bool, str]:
     """Extract --dry-run / --dry_run flag from CLI args.
 

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -428,20 +428,26 @@ def _apply_model(selected: ModelProfile, *, effort: str | None = None) -> None:
             console.print()
             return
 
+    # v0.61.0 — picker choices now persist to BOTH .env (session) and
+    # .geode/config.toml (durable). Previously the comment claimed
+    # config.toml sync but only .env was actually written; on next
+    # session the user got the env-loaded value, but only because .env
+    # happens to survive — wiping .env would lose the choice silently.
+    # 3-codebase consensus (Hermes/Codex/Claude Code all persist picker
+    # choices to durable config).
+    from core.cli._helpers import upsert_config_toml
+
     if not same_model:
         settings.model = selected.id
         _upsert_env("GEODE_MODEL", selected.id)
+        upsert_config_toml("llm", "primary_model", selected.id)
     if effort is not None and effort != old_effort:
-        # Persist effort separately so config.toml + env var stay in sync
-        # with the picker's choice. The AgenticLoop's adaptive-compute
-        # path reads ``self._effort`` (set at ctor time) — model-hot-swap
-        # path picks up the new value on the next round via the same
-        # settings.model deferred-apply mechanism.
         try:
             object.__setattr__(settings, "agentic_effort", effort)
         except Exception:
             log.debug("Could not persist agentic_effort to settings", exc_info=True)
         _upsert_env("GEODE_AGENTIC_EFFORT", effort)
+        upsert_config_toml("agentic", "effort", effort)
 
     # Model hot-swap is deferred: AgenticLoop._sync_model_from_settings()
     # checks settings.model at the start of each round and applies

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -526,10 +526,17 @@ class OpenAIAgenticAdapter:
                 "tool_choice": tc_val if oai_tools else None,
                 "max_output_tokens": max_tokens,
                 "temperature": temperature,
+                # v0.61.0 — explicit ``store=False`` for parity with the
+                # Codex Plus path (``codex.py:331``). We feed conversations
+                # via the ``input`` array + encrypted-content replay rather
+                # than ``previous_response_id``, so server-side storage is
+                # unused; opting out avoids unnecessary OpenAI-side
+                # retention of every response. SDK default is ``True``.
+                "store": False,
             }
             # v0.60.0 R3-mini — Responses-API reasoning kwargs.
             # ``include=["reasoning.encrypted_content"]`` is required when
-            # ``store=False`` (default) so the server returns the opaque
+            # ``store=False`` so the server returns the opaque
             # continuation blob; ``summary="auto"`` opts the response into
             # reasoning summaries so the R6 surfacing path can render
             # "live thinking..." for PAYG users (Codex Plus already had this).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.60.0"
+version = "0.61.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_config_effort_knob.py
+++ b/tests/test_config_effort_knob.py
@@ -1,0 +1,118 @@
+"""Cycle B — durable picker persistence + PAYG store=False (v0.61.0).
+
+Verifies:
+  1. ``upsert_config_toml`` writes new files, updates existing keys,
+     handles section boundaries.
+  2. ``_apply_model`` from the picker persists effort + model to
+     ``.geode/config.toml`` (durable layer), not just ``.env``.
+  3. PAYG ``openai.py`` adapter sends ``store=False`` (parity with
+     Codex Plus, R3-mini follow-up).
+"""
+
+from __future__ import annotations
+
+import inspect
+import tomllib
+from pathlib import Path
+
+from core.cli._helpers import upsert_config_toml
+
+
+class TestUpsertConfigToml:
+    def test_creates_file_with_section(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        upsert_config_toml("agentic", "effort", "max")
+        config_path = tmp_path / ".geode" / "config.toml"
+        assert config_path.exists()
+        loaded = tomllib.loads(config_path.read_text())
+        assert loaded == {"agentic": {"effort": "max"}}
+
+    def test_updates_existing_key(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / ".geode" / "config.toml"
+        config_path.parent.mkdir()
+        config_path.write_text('[agentic]\neffort = "low"\n')
+        upsert_config_toml("agentic", "effort", "high")
+        loaded = tomllib.loads(config_path.read_text())
+        assert loaded["agentic"]["effort"] == "high"
+
+    def test_inserts_into_existing_section_with_other_keys(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / ".geode" / "config.toml"
+        config_path.parent.mkdir()
+        config_path.write_text('[agentic]\ntime_budget = 600\n\n[llm]\nprimary_model = "x"\n')
+        upsert_config_toml("agentic", "effort", "max")
+        loaded = tomllib.loads(config_path.read_text())
+        assert loaded["agentic"]["effort"] == "max"
+        assert loaded["agentic"]["time_budget"] == 600
+        assert loaded["llm"]["primary_model"] == "x"
+
+    def test_uncomments_existing_commented_key(self, tmp_path: Path, monkeypatch) -> None:
+        """Default config.toml ships with ``# effort = "high"`` — picker
+        choice should overwrite the comment, not duplicate the key."""
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / ".geode" / "config.toml"
+        config_path.parent.mkdir()
+        config_path.write_text('[agentic]\n# effort = "high"\n')
+        upsert_config_toml("agentic", "effort", "xhigh")
+        loaded = tomllib.loads(config_path.read_text())
+        assert loaded["agentic"]["effort"] == "xhigh"
+        # Key appears exactly once
+        text = config_path.read_text()
+        assert text.count("effort =") == 1
+
+    def test_appends_section_when_missing(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / ".geode" / "config.toml"
+        config_path.parent.mkdir()
+        config_path.write_text('[llm]\nprimary_model = "claude-opus-4-7"\n')
+        upsert_config_toml("agentic", "effort", "high")
+        loaded = tomllib.loads(config_path.read_text())
+        assert loaded["agentic"]["effort"] == "high"
+        assert loaded["llm"]["primary_model"] == "claude-opus-4-7"
+
+
+class TestPickerPersistence:
+    def test_apply_model_writes_effort_to_config_toml(self, tmp_path: Path, monkeypatch) -> None:
+        """After picker confirms an effort, .geode/config.toml must
+        carry it so the next session re-loads from the durable layer."""
+        monkeypatch.chdir(tmp_path)
+        from core.cli.commands import MODEL_PROFILES, _apply_model
+        from core.config import settings
+
+        old_model = settings.model
+        old_effort = getattr(settings, "agentic_effort", "high")
+        try:
+            settings.model = MODEL_PROFILES[0].id
+            object.__setattr__(settings, "agentic_effort", "low")
+            # Pick a different model AND a different effort so both branches fire
+            target = MODEL_PROFILES[1]
+            _apply_model(target, effort="max")
+            config_path = tmp_path / ".geode" / "config.toml"
+            assert config_path.exists()
+            loaded = tomllib.loads(config_path.read_text())
+            assert loaded["agentic"]["effort"] == "max"
+            assert loaded["llm"]["primary_model"] == target.id
+        finally:
+            settings.model = old_model
+            object.__setattr__(settings, "agentic_effort", old_effort)
+
+
+class TestPaygStoreFalse:
+    def test_store_false_in_openai_kwargs(self) -> None:
+        """Source-pin: the PAYG adapter must send ``store=False`` so it
+        matches Codex Plus and avoids server-side response retention."""
+        from core.llm.providers import openai as openai_mod
+
+        src = inspect.getsource(openai_mod)
+        assert '"store": False' in src
+
+    def test_codex_plus_still_uses_store_false(self) -> None:
+        """Regression guard — extracting the shared replay walker
+        in v0.60.0 must not have dropped Codex Plus's store=False."""
+        from core.llm.providers import codex as codex_mod
+
+        src = inspect.getsource(codex_mod)
+        assert '"store": False' in src

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Picker effort + model now persist to `.geode/config.toml` (durable layer), not just `.env`. Previously `_apply_model` wrote env-only despite a comment claiming config.toml sync.
- New shared `upsert_config_toml(section, key, value)` helper in `core/cli/_helpers.py` — minimal-diff TOML upsert, handles file creation, commented defaults, and existing-section insertion.
- R3-mini follow-up: explicit `store=False` on PAYG `OpenAIAgenticAdapter.create_kwargs` for parity with Codex Plus (`codex.py:331`).

## Why
**R8 (durable persistence)** — comment on `core/cli/commands.py:435` claimed effort persists to `config.toml + env var` but only `.env` was actually written. Sessions worked in practice because `.env` survives, but wiping it (or running from a different working directory) silently lost the picker choice. 3-codebase consensus (Hermes/Codex/Claude Code all persist picker choices to durable config); GEODE was the lone outlier.

**R3-mini follow-up (`store=False`)** — the v0.60.0 R3-mini cycle wired `include=["reasoning.encrypted_content"]` for the PAYG path, but left `store` at the SDK default of `True`. Since we feed conversations via the `input` array + the encrypted-content replay walker (never `previous_response_id`), server-side storage is unused on our side; opting out matches Codex Plus and avoids OpenAI-side retention of every response.

## Changes
| File | Change |
|------|--------|
| `core/cli/_helpers.py` | NEW `upsert_config_toml(section, key, value)`. Reads `.geode/config.toml`, walks lines tracking section context, replaces matching key (uncommenting if needed), or inserts before next section heading / appends new section + key + line. Creates file if absent. |
| `core/cli/commands.py` | `_apply_model` now calls `upsert_config_toml("agentic", "effort", effort)` and `upsert_config_toml("llm", "primary_model", selected.id)` in addition to `_upsert_env`. Removed the misleading comment that previously claimed config.toml sync. |
| `core/llm/providers/openai.py` | Added `"store": False` to PAYG `create_kwargs` with reference to `codex.py:331` parity. Stale comment (`store=False (default)`) updated to drop the "(default)" wording since SDK default is `True`. |
| `tests/test_config_effort_knob.py` | NEW. 8 invariants — `upsert_config_toml` (5: file creation, key update, sibling preservation across sections, uncommented exactly once, section append), picker persistence (1: round-trip effort + model), source-pin (2: `store=False` literal in `openai.py` + `codex.py`). |
| `CHANGELOG.md` / `CLAUDE.md` / `README.md` / `README.ko.md` / `pyproject.toml` / `uv.lock` | v0.60.0 → v0.61.0. CLAUDE.md tests 4322 → 4330. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Picker effort → `.geode/config.toml` | Implemented | Durable across `.env` wipe / cwd change |
| Picker model → `.geode/config.toml` | Implemented | Same write path; pre-existing `[llm] primary_model` key |
| `upsert_config_toml` shared helper | Implemented | Generic enough for future `[cost]`, `[sandbox]`, etc. callers |
| PAYG `store=False` | Implemented | Codex Plus parity |
| Stale comment cleanup | Implemented | `commands.py` no longer claims something it doesn't do |
| `/effort` slash command | Dropped | Failed Socratic Q5 (0/3 frontier consensus — Hermes/Codex/Claude Code all bundle effort into `/model`-equivalent) |
| `_write_monthly_budget` migration | Deferred | Could call `upsert_config_toml` but not in scope; refactor next time a 3rd toml-write site shows up |

## Verification
- [x] `ruff check core/ tests/` — clean
- [x] `mypy core/` — clean (234 source files)
- [x] `pytest tests/ -m "not live"` — 4330 passed (was 4322)
- [x] Cycle B tests (`test_config_effort_knob.py`) — 8/8 green

## Reference
- 3-codebase config persistence: Hermes `hermes_cli/main.py:cmd_model` (writes to `~/.hermes/config.json`), Codex CLI `codex-rs/cli/src/config.rs` (writes to `~/.codex/config.toml`), Claude Code `screens/REPL.tsx` (project + global JSON config write).
- openai-python Stainless SDK `responses/response_create_params.py` — `store: Optional[bool]` defaults to `True`; `store=False` is the supported opt-out for ZDR / privacy-conscious flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)