### PR TITLE
feat(llm): cache_control on last 3 messages (Hermes system_and_3 parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Messages-level cache_control breakpoints in Anthropic agentic adapter (Hermes `system_and_3` parity).** New `apply_messages_cache_control(messages, n_breakpoints=3)` helper in `core/llm/providers/anthropic.py` adds `cache_control: {"type": "ephemeral"}` to the last 3 non-system messages' final content block, filling Anthropic's remaining cache-control slots after the existing system block (STATIC + DYNAMIC split). Combined cap is 4 breakpoints — 1 on the system block, up to 3 on rolling history. Reduces input-token cost in long multi-turn agentic loops where the message history would otherwise be re-billed every turn. Non-mutating (returns new list with shallow-copied targeted messages); handles both `str` and `list[block]` content shapes. Wired in `ClaudeAgenticAdapter.agentic_call._do_call` immediately before `messages.create`. New test module `tests/test_anthropic_messages_cache.py` (19 cases): empty/short/long lists, system skip, str→block conversion, list-block last-only marking, idempotency, parametrized n_breakpoints bound. `MAX_MESSAGE_CACHE_BREAKPOINTS = 3` exported. (`core/llm/providers/anthropic.py`, `tests/test_anthropic_messages_cache.py`)
+
 ## [0.64.0] — 2026-04-29
 
 ### Changed

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -166,6 +166,70 @@ def system_with_cache(system: str) -> list[TextBlockParam]:
     ]
 
 
+# Anthropic allows up to 4 cache_control breakpoints per request.  The agentic
+# adapter already uses 1-2 on the system block (STATIC/DYNAMIC split).  Keep 3
+# slots for the messages array — Hermes "system_and_3" strategy.
+MAX_MESSAGE_CACHE_BREAKPOINTS = 3
+
+
+def apply_messages_cache_control(
+    messages: list[dict[str, Any]],
+    *,
+    n_breakpoints: int = MAX_MESSAGE_CACHE_BREAKPOINTS,
+) -> list[dict[str, Any]]:
+    """Return a copy of *messages* with ephemeral cache_control on the last
+    *n_breakpoints* non-system messages' final content block.
+
+    Mirrors Hermes ``apply_anthropic_cache_control`` (system_and_3) and
+    OpenClaw ``applyAnthropicCacheControlToMessages``.  Used by the agentic
+    adapter to extend prompt caching from the system block to the rolling
+    history window, reducing cost in long multi-turn loops.
+
+    The function is non-mutating: returns a new list with shallow copies of
+    the targeted messages and their last block.  String-content messages are
+    materialised into a single text block before the marker is attached.
+
+    Args:
+        messages: Anthropic-format messages list (role + content).
+        n_breakpoints: Max number of trailing non-system messages to mark.
+            Default 3 (Anthropic's 4-breakpoint cap minus 1 for system).
+
+    Returns:
+        New messages list ready for ``messages.create``.
+    """
+    if not messages or n_breakpoints <= 0:
+        return list(messages)
+
+    out: list[dict[str, Any]] = list(messages)
+    targets = [
+        i for i, m in enumerate(out) if m.get("role") != "system"
+    ][-n_breakpoints:]
+
+    for i in targets:
+        msg = dict(out[i])
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = [
+                {
+                    "type": "text",
+                    "text": content,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+        elif isinstance(content, list) and content:
+            new_content = list(content)
+            last_block = dict(new_content[-1])
+            last_block["cache_control"] = {"type": "ephemeral"}
+            new_content[-1] = last_block
+            msg["content"] = new_content
+        else:
+            # Empty or unexpected content — skip silently.
+            continue
+        out[i] = msg
+
+    return out
+
+
 def get_circuit_breaker() -> CircuitBreaker:
     """Return the module-level Anthropic circuit breaker."""
     return _circuit_breaker
@@ -432,10 +496,16 @@ class ClaudeAgenticAdapter:
                     }
                 ]
 
+            # Rolling messages-level cache breakpoints (Hermes system_and_3).
+            # Combined with the system block above, this fills up to 4 of
+            # Anthropic's cache_control slots and caches the long history
+            # window in multi-turn agentic loops.
+            cached_messages = apply_messages_cache_control(messages)
+
             create_kwargs: dict[str, Any] = {
                 "model": m,
                 "system": sys_blocks,
-                "messages": messages,
+                "messages": cached_messages,
                 "tools": api_tools,
                 "tool_choice": tool_choice,
                 "max_tokens": call_max_tokens,

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -201,9 +201,7 @@ def apply_messages_cache_control(
         return list(messages)
 
     out: list[dict[str, Any]] = list(messages)
-    targets = [
-        i for i, m in enumerate(out) if m.get("role") != "system"
-    ][-n_breakpoints:]
+    targets = [i for i, m in enumerate(out) if m.get("role") != "system"][-n_breakpoints:]
 
     for i in targets:
         msg = dict(out[i])

--- a/tests/test_anthropic_messages_cache.py
+++ b/tests/test_anthropic_messages_cache.py
@@ -1,0 +1,168 @@
+"""Tests for ``apply_messages_cache_control`` — Hermes system_and_3 strategy.
+
+Verifies rolling message-level cache_control breakpoints, non-mutation,
+edge cases (empty/short message lists), and content-shape handling
+(str vs list[block]).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from core.llm.providers.anthropic import (
+    MAX_MESSAGE_CACHE_BREAKPOINTS,
+    apply_messages_cache_control,
+)
+
+
+class TestApplyMessagesCacheControl:
+    def test_empty_messages_returns_empty(self):
+        assert apply_messages_cache_control([]) == []
+
+    def test_zero_breakpoints_returns_copy_without_marks(self):
+        original = [{"role": "user", "content": "hi"}]
+        out = apply_messages_cache_control(original, n_breakpoints=0)
+        assert out == original
+        assert out is not original  # copied, not aliased
+
+    def test_does_not_mutate_input(self):
+        original: list[dict[str, Any]] = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+        snapshot = [dict(m) for m in original]
+        apply_messages_cache_control(original)
+        assert original == snapshot, "input must be unchanged"
+
+    def test_single_user_message_string_content(self):
+        out = apply_messages_cache_control([{"role": "user", "content": "hello"}])
+        assert len(out) == 1
+        content = out[0]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 1
+        assert content[0] == {
+            "type": "text",
+            "text": "hello",
+            "cache_control": {"type": "ephemeral"},
+        }
+
+    def test_marks_last_three_messages_only(self):
+        msgs = [
+            {"role": "user", "content": "m1"},
+            {"role": "assistant", "content": "m2"},
+            {"role": "user", "content": "m3"},
+            {"role": "assistant", "content": "m4"},
+            {"role": "user", "content": "m5"},
+        ]
+        out = apply_messages_cache_control(msgs)
+        # First two messages: untouched (still string)
+        assert out[0]["content"] == "m1"
+        assert out[1]["content"] == "m2"
+        # Last three: marked
+        for i in (2, 3, 4):
+            content = out[i]["content"]
+            assert isinstance(content, list)
+            assert content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_list_content_marks_last_block_only(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "abc", "content": "ok"},
+                    {"type": "text", "text": "follow-up"},
+                ],
+            }
+        ]
+        out = apply_messages_cache_control(msgs)
+        blocks = out[0]["content"]
+        assert "cache_control" not in blocks[0]
+        assert blocks[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_skips_system_role(self):
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "u1"},
+        ]
+        out = apply_messages_cache_control(msgs)
+        # System untouched
+        assert out[0]["content"] == "sys"
+        # User marked (still within last-3 window)
+        assert isinstance(out[1]["content"], list)
+        assert out[1]["content"][0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_skips_empty_content(self):
+        msgs = [
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": []},
+        ]
+        out = apply_messages_cache_control(msgs)
+        # Empty string falls through string path: gets converted to one block
+        assert isinstance(out[0]["content"], list)
+        # Empty list content: skipped silently (still empty list)
+        assert out[1]["content"] == []
+
+    def test_max_breakpoints_constant(self):
+        # Anthropic 4-cap minus 1 for system → 3 for messages
+        assert MAX_MESSAGE_CACHE_BREAKPOINTS == 3
+
+    def test_fewer_messages_than_breakpoints(self):
+        msgs = [{"role": "user", "content": "only"}]
+        out = apply_messages_cache_control(msgs, n_breakpoints=3)
+        assert isinstance(out[0]["content"], list)
+        assert out[0]["content"][0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_custom_breakpoints(self):
+        msgs = [
+            {"role": "user", "content": f"m{i}"} for i in range(5)
+        ]
+        out = apply_messages_cache_control(msgs, n_breakpoints=1)
+        # Only the last one should be marked
+        for i in range(4):
+            assert out[i]["content"] == f"m{i}"
+        last = out[4]["content"]
+        assert isinstance(last, list)
+        assert last[0].get("cache_control") == {"type": "ephemeral"}
+
+
+class TestNonMutation:
+    """Defensive: re-applying does not double up."""
+
+    def test_idempotent_on_already_cached(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}},
+                ],
+            }
+        ]
+        out = apply_messages_cache_control(msgs)
+        block = out[0]["content"][0]
+        # Marker stays exactly one
+        assert block["cache_control"] == {"type": "ephemeral"}
+
+    def test_repeated_calls_independent(self):
+        msgs = [{"role": "user", "content": "m"}]
+        first = apply_messages_cache_control(msgs)
+        second = apply_messages_cache_control(msgs)
+        # Both produce equivalent result, neither mutates the input
+        assert first == second
+        assert msgs == [{"role": "user", "content": "m"}]
+
+
+@pytest.mark.parametrize(
+    "n",
+    [0, 1, 2, 3, 5, 10],
+)
+def test_n_breakpoints_bound(n: int):
+    msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    out = apply_messages_cache_control(msgs, n_breakpoints=n)
+    marked = sum(
+        1
+        for m in out
+        if isinstance(m["content"], list)
+        and m["content"] and m["content"][-1].get("cache_control")
+    )
+    assert marked == min(n, 20)

--- a/tests/test_anthropic_messages_cache.py
+++ b/tests/test_anthropic_messages_cache.py
@@ -114,9 +114,7 @@ class TestApplyMessagesCacheControl:
         assert out[0]["content"][0].get("cache_control") == {"type": "ephemeral"}
 
     def test_custom_breakpoints(self):
-        msgs = [
-            {"role": "user", "content": f"m{i}"} for i in range(5)
-        ]
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(5)]
         out = apply_messages_cache_control(msgs, n_breakpoints=1)
         # Only the last one should be marked
         for i in range(4):
@@ -162,7 +160,6 @@ def test_n_breakpoints_bound(n: int):
     marked = sum(
         1
         for m in out
-        if isinstance(m["content"], list)
-        and m["content"] and m["content"][-1].get("cache_control")
+        if isinstance(m["content"], list) and m["content"] and m["content"][-1].get("cache_control")
     )
     assert marked == min(n, 20)


### PR DESCRIPTION
## Summary
- Anthropic agentic adapter now applies `cache_control: ephemeral` to the **last 3 non-system messages** in addition to the existing system-block caching.
- Fills Anthropic's 4-breakpoint cap (1 system + 3 messages) — Hermes `system_and_3` parity.
- Non-mutating helper `apply_messages_cache_control()` in `core/llm/providers/anthropic.py`.

## Why
The agentic adapter already implements STATIC/DYNAMIC system caching via `__GEODE_PROMPT_CACHE_BOUNDARY__`, but the `messages` array is sent uncached. In long multi-turn agentic loops (30+ rounds is common for analyze/research flows) the entire history is re-billed every turn even though the prefix is byte-identical. Hermes (`agent/prompt_caching.py:apply_anthropic_cache_control`) and OpenClaw (`agents/anthropic-payload-policy.ts:applyAnthropicCacheControlToMessages`) both close this gap; GEODE was the outlier.

GAP discovered while writing the prompt-system docs series — original wiki claim "Anthropic ephemeral cache 미구현" was a research error (system block already cached), but messages-array caching was genuinely absent.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/anthropic.py` | New `apply_messages_cache_control(messages, n_breakpoints=3)` (pure, non-mutating) + `MAX_MESSAGE_CACHE_BREAKPOINTS = 3`. Wired into `ClaudeAgenticAdapter.agentic_call._do_call` immediately before `self._client.messages.create`. |
| `tests/test_anthropic_messages_cache.py` | New test module — 19 cases covering empty list, zero/custom n_breakpoints, str-content materialization, list-block last-only marking, system-role skip, idempotency, parametrized n_breakpoints bound. |
| `CHANGELOG.md` | Unreleased — Added entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| System block caching | Already exists | `system_with_cache()` (router) + STATIC/DYNAMIC (adapter) — unchanged |
| Boundary marker | Already exists | `__GEODE_PROMPT_CACHE_BOUNDARY__` in `core/agent/system_prompt.py:35` |
| Messages-array caching | Implemented (this PR) | Last 3 non-system, ephemeral |
| OpenAI / GLM caching | Out of scope | Provider auto-caches server-side; no GEODE-side wiring needed |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 236 source files
- [x] `uv run pytest tests/ -m "not live"` — 4379 passed, 1 skipped, 24 deselected
- [x] `uv run pytest tests/test_anthropic_messages_cache.py -q` — 19 passed
- [x] E2E `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4) unchanged

## Reference
- Hermes Agent: `agent/prompt_caching.py:apply_anthropic_cache_control` (`system_and_3` strategy, marker on system + last 3 non-system).
- OpenClaw: `src/agents/anthropic-payload-policy.ts:applyAnthropicCacheControlToMessages` (last user message, 1h TTL on long-retention).
- Anthropic docs: ephemeral prompt caching, max 4 `cache_control` breakpoints per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)