### PR TITLE
chore(release): v0.65.0 — manage_login verdict fix + Anthropic messages cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.65.0] — 2026-05-02
+
 ### Fixed
 - **`manage_login` verdict reporting collapses healthy PAYG profiles to `provider_mismatch`.** The verdict-aggregation loop in `core/cli/tool_handlers.py:handle_manage_login` keyed `verdict_index[(name, profile.provider)]` while iterating `evaluate_eligibility(prov)` once per unique provider in the store. Each iteration evaluates *every* profile, returning a `PROVIDER_MISMATCH` verdict for profiles whose provider != prov; those mismatch verdicts share the same dict key as the real verdict and the last-iterated provider's write wins. Set iteration order is hash-dependent, so on a typical multi-provider store (e.g. `openai-codex`, `openai`, `anthropic`) every profile except the one whose provider iterates last surfaces as `eligible=False / reason=provider_mismatch` to both the LLM (via the `manage_login` tool result) and the `/login` dashboard — even though the underlying credential is healthy and `resolve_routing` would happily use it via the equivalence-class fallback. Fix: skip cross-provider iterations (`if v.reason is ProfileRejectReason.PROVIDER_MISMATCH: continue`) so each profile's verdict comes from its *own* provider's evaluation, mirroring the same filter already applied in `core/auth/credential_breadcrumb.format`. Regression test: `tests/test_manage_login_tool.py::TestVerdictPerOwnProvider` registers three profiles across three providers and asserts none are reported as `provider_mismatch`. (`core/cli/tool_handlers.py`, `tests/test_manage_login_tool.py`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.64.0
+- **Version**: 0.65.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 223 core + 13 plugins = 236
-- **Tests**: 4360+ (+5 live)
+- **Tests**: 4380+ (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.64.0 — Long-running Autonomous Execution Harness
+# GEODE v0.65.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.64.0 — Long-running Autonomous Execution Harness
+# GEODE v0.65.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.64.0"
+version = "0.65.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.64.0"
+version = "0.65.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `[Unreleased]`을 `[0.65.0] — 2026-05-02`으로 확정.
- 4-loc 버전 동기화: CHANGELOG / CLAUDE / README(en, ko) / pyproject.
- Tests 메트릭 4360+ → 4380+ 갱신.

## Why
develop에 두 변경(#864 Anthropic messages cache_control, #866 manage_login verdict fix)이 누적되어 [Unreleased] 항목으로 대기. 새 feature가 포함됐으므로 SemVer MINOR (0.64.0 → 0.65.0). 4-loc 버전 미스매치 방지를 위해 release-prep 단일 커밋으로 일괄 동기화.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | `[Unreleased]` 헤더 위쪽에 `[0.65.0] — 2026-05-02` 절 신설, 기존 Unreleased 본문(Fixed + Added) 이동 |
| `CLAUDE.md` | Version 0.64.0 → 0.65.0, Tests 4360+ → 4380+ |
| `README.md` | 헤더 v0.64.0 → v0.65.0 |
| `README.ko.md` | 헤더 v0.64.0 → v0.65.0 |
| `pyproject.toml` | version 0.64.0 → 0.65.0 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 236 source files
- [x] `uv run pytest tests/ -m "not live"` — 4380 passed, 1 skipped (develop 시점 측정)
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4) unchanged

## Reference
- Bundles: #866 (login fix), #864 (messages cache_control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)