### PR TITLE
feat(core): domain-free core step 1 — axes defusing + loader 2-pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Architecture
+- **Domain-free core, step 1 of 8 (`docs/architecture/domain-free-core-audit.md`).** Eager IP-YAML load lifted out of `core/llm/prompts/axes.py` so `core/` can be imported without `plugins/game_ip/` present (REODE-fork prerequisite). The 14-axis rubric data now lives in `plugins/game_ip/axes.py`; `core/llm/prompts/axes.py` re-exports those constants when the plugin is installed and falls back to empty dicts otherwise (preserves existing GEODE callers; pin hashes unchanged). Domain registry decoupled: `core/domains/loader.py:_BUILTIN_DOMAINS` no longer seeds `game_ip`; the loader gains a 2-pass discovery (registry → convention `import plugins.<name>` → re-check) and `plugins/game_ip/__init__.py` self-registers via `register_domain(...)` at import time. New `DomainPort.get_prospect_evaluator_axes()` v2 method exposes the prospect-track axes that previously lived only as a module-level `PROSPECT_EVALUATOR_AXES` constant. Six new tests in `tests/test_domain_port_step1.py` cover loader 2-pass, plugin self-registration, and the new method. (`core/llm/prompts/axes.py`, `core/domains/loader.py`, `core/domains/port.py`, `plugins/game_ip/axes.py`, `plugins/game_ip/__init__.py`, `plugins/game_ip/adapter.py`, `tests/test_domain_port_step1.py`)
+
 ## [0.65.0] — 2026-05-02
 
 ### Fixed

--- a/core/domains/loader.py
+++ b/core/domains/loader.py
@@ -1,5 +1,18 @@
 """Domain adapter loader — discovers and instantiates domain adapters.
 
+Discovery is two-pass:
+
+1. Direct registry lookup. Plugins typically pre-register themselves at
+   import time via ``register_domain(...)`` from their package
+   ``__init__.py``.
+2. Convention fallback. If the requested name is not in the registry, we
+   try to import ``plugins.<name>`` so its ``__init__.py`` runs and
+   self-registers, then re-check the registry.
+
+This keeps ``core/`` free of plugin import paths: the registry seeds itself
+at runtime when a plugin is imported, and consumers (CLI bootstrap, tests)
+can call ``load_domain_adapter(name)`` without first importing the plugin.
+
 Usage:
     adapter = load_domain_adapter("game_ip")
     set_domain(adapter)
@@ -7,16 +20,16 @@ Usage:
 
 from __future__ import annotations
 
+import importlib
 import logging
 
 from core.domains.port import DomainPort
 
 log = logging.getLogger(__name__)
 
-# Registry of built-in domain adapters (lazy-loaded)
-_BUILTIN_DOMAINS: dict[str, str] = {
-    "game_ip": "plugins.game_ip.adapter:GameIPDomain",
-}
+# Registry of domain adapters. Populated at runtime by ``register_domain``,
+# typically from ``plugins/<name>/__init__.py`` at import time.
+_BUILTIN_DOMAINS: dict[str, str] = {}
 
 
 def load_domain_adapter(name: str) -> DomainPort:
@@ -29,17 +42,24 @@ def load_domain_adapter(name: str) -> DomainPort:
         Instantiated DomainPort implementation.
 
     Raises:
-        ValueError: If domain name is not found.
+        ValueError: If domain name is not found after both registry and
+            convention-fallback lookup.
         ImportError: If adapter module cannot be imported.
     """
     if name not in _BUILTIN_DOMAINS:
-        available = ", ".join(sorted(_BUILTIN_DOMAINS.keys()))
+        # Convention fallback: importing plugins.<name> triggers the plugin's
+        # __init__.py, which is expected to call register_domain(...).
+        try:
+            importlib.import_module(f"plugins.{name}")
+        except ImportError:
+            log.debug("plugins.%s not importable for self-registration", name)
+
+    if name not in _BUILTIN_DOMAINS:
+        available = ", ".join(sorted(_BUILTIN_DOMAINS.keys())) or "<none registered>"
         raise ValueError(f"Unknown domain: {name!r}. Available: {available}")
 
     module_path = _BUILTIN_DOMAINS[name]
     module_name, class_name = module_path.rsplit(":", 1)
-
-    import importlib
 
     module = importlib.import_module(module_name)
     cls = getattr(module, class_name)
@@ -49,12 +69,12 @@ def load_domain_adapter(name: str) -> DomainPort:
 
 
 def list_domains() -> list[str]:
-    """Return list of available domain names."""
+    """Return list of currently registered domain names."""
     return sorted(_BUILTIN_DOMAINS.keys())
 
 
 def register_domain(name: str, adapter_path: str) -> None:
-    """Register a custom domain adapter at runtime.
+    """Register a domain adapter at runtime.
 
     Args:
         name: Domain identifier.

--- a/core/domains/port.py
+++ b/core/domains/port.py
@@ -59,6 +59,13 @@ class DomainPort(Protocol):
         """Return evaluator_type → axes config (with descriptions, ranges)."""
         ...
 
+    def get_prospect_evaluator_axes(self) -> dict[str, dict[str, Any]]:
+        """Return prospect_evaluator_type → axes config.
+
+        Domains without a prospect-evaluation track may return an empty dict.
+        """
+        ...
+
     def get_valid_axes_map(self) -> dict[str, set[str]]:
         """Return evaluator_type → set of valid axis key names."""
         ...

--- a/core/llm/prompts/axes.py
+++ b/core/llm/prompts/axes.py
@@ -1,43 +1,60 @@
-"""Structured scoring axes and rubric data for evaluators and analysts.
+"""Structured scoring axes — domain-data sourced from active plugin.
 
-Loads configuration from core/config/evaluator_axes.yaml.
-Prompt templates live in .md files loaded by the prompts package.
+For backwards compatibility, module-level constants ANALYST_SPECIFIC,
+EVALUATOR_AXES, PROSPECT_EVALUATOR_AXES, VALID_AXES_MAP, AXES_VERSIONS
+remain importable. They are populated at import time by reading from
+``plugins.game_ip.axes`` if installed, or set to empty defaults so that
+``core/`` can be imported in non-game_ip contexts (e.g. REODE forks).
+
+For domain-aware lookups at runtime, prefer ``get_valid_axes_map()`` —
+it delegates to the active ``DomainPort`` and works for any domain.
+
+Step 1 of the domain-free-core refactor:
+  see docs/architecture/domain-free-core-audit.md (§4, §6).
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-from pathlib import Path
+import logging
 from typing import Any
 
-import yaml
+log = logging.getLogger(__name__)
 
-_YAML_PATH = (
-    Path(__file__).resolve().parents[3] / "plugins" / "game_ip" / "config" / "evaluator_axes.yaml"
-)
-_data = yaml.safe_load(_YAML_PATH.read_text(encoding="utf-8"))
+ANALYST_SPECIFIC: dict[str, str]
+EVALUATOR_AXES: dict[str, dict[str, Any]]
+PROSPECT_EVALUATOR_AXES: dict[str, dict[str, Any]]
+VALID_AXES_MAP: dict[str, set[str]]
 
-ANALYST_SPECIFIC: dict[str, str] = _data["analyst_specific"]
+try:
+    from plugins.game_ip.axes import (
+        ANALYST_SPECIFIC as _PLUGIN_ANALYST_SPECIFIC,
+    )
+    from plugins.game_ip.axes import (
+        EVALUATOR_AXES as _PLUGIN_EVALUATOR_AXES,
+    )
+    from plugins.game_ip.axes import (
+        PROSPECT_EVALUATOR_AXES as _PLUGIN_PROSPECT_EVALUATOR_AXES,
+    )
+    from plugins.game_ip.axes import (
+        VALID_AXES_MAP as _PLUGIN_VALID_AXES_MAP,
+    )
 
-EVALUATOR_AXES: dict[str, dict[str, Any]] = _data["evaluator_axes"]
-
-PROSPECT_EVALUATOR_AXES: dict[str, dict[str, Any]] = _data["prospect_evaluator_axes"]
-
-
-def _derive_valid_axes_map() -> dict[str, set[str]]:
-    """Derive valid axes keys from EVALUATOR_AXES + PROSPECT_EVALUATOR_AXES (SSOT)."""
-    result: dict[str, set[str]] = {}
-    for eval_type, spec in {**EVALUATOR_AXES, **PROSPECT_EVALUATOR_AXES}.items():
-        result[eval_type] = set(spec["axes"].keys())
-    return result
-
-
-VALID_AXES_MAP: dict[str, set[str]] = _derive_valid_axes_map()
+    ANALYST_SPECIFIC = _PLUGIN_ANALYST_SPECIFIC
+    EVALUATOR_AXES = _PLUGIN_EVALUATOR_AXES
+    PROSPECT_EVALUATOR_AXES = _PLUGIN_PROSPECT_EVALUATOR_AXES
+    VALID_AXES_MAP = _PLUGIN_VALID_AXES_MAP
+except ImportError:
+    log.debug("game_ip plugin axes not present; axes constants set to empty defaults")
+    ANALYST_SPECIFIC = {}
+    EVALUATOR_AXES = {}
+    PROSPECT_EVALUATOR_AXES = {}
+    VALID_AXES_MAP = {}
 
 
 def get_valid_axes_map() -> dict[str, set[str]]:
-    """Get valid axes map from domain adapter if available, else static."""
+    """Get valid axes map from active domain adapter, else module-level fallback."""
     from core.domains.port import get_domain_or_none
 
     domain = get_domain_or_none()

--- a/plugins/game_ip/__init__.py
+++ b/plugins/game_ip/__init__.py
@@ -1,5 +1,15 @@
-"""Game IP domain adapter — undervalued game IP evaluation."""
+"""Game IP domain adapter — undervalued game IP evaluation.
 
-from plugins.game_ip.adapter import GameIPDomain
+Self-registers with ``core.domains.loader`` on import (Step 1 of the
+domain-free-core refactor). The loader's convention-fallback can now
+discover this plugin by importing ``plugins.game_ip`` without needing
+a hard-coded registry seed in core.
+"""
+
+from core.domains.loader import register_domain
+
+register_domain("game_ip", "plugins.game_ip.adapter:GameIPDomain")
+
+from plugins.game_ip.adapter import GameIPDomain  # noqa: E402
 
 __all__ = ["GameIPDomain"]

--- a/plugins/game_ip/adapter.py
+++ b/plugins/game_ip/adapter.py
@@ -97,6 +97,9 @@ class GameIPDomain:
     def get_evaluator_axes(self) -> dict[str, dict[str, Any]]:
         return dict(self._axes_data["evaluator_axes"])
 
+    def get_prospect_evaluator_axes(self) -> dict[str, dict[str, Any]]:
+        return dict(self._axes_data.get("prospect_evaluator_axes", {}))
+
     def get_valid_axes_map(self) -> dict[str, set[str]]:
         result: dict[str, set[str]] = {}
         for eval_type, spec in self._axes_data["evaluator_axes"].items():

--- a/plugins/game_ip/axes.py
+++ b/plugins/game_ip/axes.py
@@ -1,0 +1,37 @@
+"""Game IP rubric axes — eager-loaded from evaluator_axes.yaml.
+
+This is the canonical source for game-IP-specific scoring axes. Previously
+this data lived in `core/llm/prompts/axes.py`, where its eager YAML load at
+import time hard-coupled `core/` to `plugins/game_ip/`. Step 1 of the
+domain-free-core refactor (see docs/architecture/domain-free-core-audit.md)
+moves the load here so that `core/` can be imported without a game_ip plugin
+present (e.g. REODE forks).
+
+Backwards-compatible: `core/llm/prompts/axes.py` re-exports these names
+when this plugin is installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_YAML_PATH = Path(__file__).resolve().parent / "config" / "evaluator_axes.yaml"
+_data = yaml.safe_load(_YAML_PATH.read_text(encoding="utf-8"))
+
+ANALYST_SPECIFIC: dict[str, str] = _data["analyst_specific"]
+EVALUATOR_AXES: dict[str, dict[str, Any]] = _data["evaluator_axes"]
+PROSPECT_EVALUATOR_AXES: dict[str, dict[str, Any]] = _data["prospect_evaluator_axes"]
+
+
+def _derive_valid_axes_map() -> dict[str, set[str]]:
+    """Derive valid axes keys from EVALUATOR_AXES + PROSPECT_EVALUATOR_AXES."""
+    result: dict[str, set[str]] = {}
+    for eval_type, spec in {**EVALUATOR_AXES, **PROSPECT_EVALUATOR_AXES}.items():
+        result[eval_type] = set(spec["axes"].keys())
+    return result
+
+
+VALID_AXES_MAP: dict[str, set[str]] = _derive_valid_axes_map()

--- a/tests/test_domain_port_step1.py
+++ b/tests/test_domain_port_step1.py
@@ -1,0 +1,106 @@
+"""Step 1 of domain-free-core refactor: tests.
+
+See docs/architecture/domain-free-core-audit.md (§6 step 1).
+
+Verifies:
+1. axes.py defusing — module-level constants populate from plugin (if present),
+   default to empty dicts otherwise (REODE-fork compatibility).
+2. Loader 2-pass discovery — empty `_BUILTIN_DOMAINS` is recovered by
+   convention-fallback `import plugins.<name>` triggering self-registration.
+3. New v2 method on DomainPort: `get_prospect_evaluator_axes()`.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_loader_loads_game_ip() -> None:
+    """Game IP plugin loads via either pre-registration or convention fallback."""
+    from core.domains.loader import load_domain_adapter
+
+    adapter = load_domain_adapter("game_ip")
+    assert adapter.name == "game_ip"
+    assert adapter.version
+
+
+def test_loader_unknown_domain_raises_value_error() -> None:
+    """Unknown domain name surfaces a clear ValueError after both lookup passes."""
+    from core.domains.loader import load_domain_adapter
+
+    with pytest.raises(ValueError, match="Unknown domain: 'definitely_not_a_real_domain'"):
+        load_domain_adapter("definitely_not_a_real_domain")
+
+
+def test_loader_2pass_self_registration() -> None:
+    """If `_BUILTIN_DOMAINS` is missing the entry, loader imports `plugins.<name>`,
+    which triggers the plugin's `__init__.py` to call `register_domain(...)`,
+    after which the registry has the entry."""
+    from core.domains import loader
+
+    # Simulate fresh state by clearing the registry entry. The plugin module
+    # itself is still cached in sys.modules, so simulate reload by also
+    # dropping that cache so the convention-fallback re-imports it.
+    saved = loader._BUILTIN_DOMAINS.pop("game_ip", None)
+    saved_module = sys.modules.pop("plugins.game_ip", None)
+    try:
+        adapter = loader.load_domain_adapter("game_ip")
+        assert adapter.name == "game_ip"
+        # Plugin self-registration should have re-populated the registry.
+        assert "game_ip" in loader._BUILTIN_DOMAINS
+    finally:
+        # Restore whatever state existed before the test.
+        if saved is not None:
+            loader._BUILTIN_DOMAINS["game_ip"] = saved
+        if saved_module is not None:
+            sys.modules["plugins.game_ip"] = saved_module
+
+
+def test_get_prospect_evaluator_axes_returns_axes() -> None:
+    """GameIPDomain exposes the v2 `get_prospect_evaluator_axes` method,
+    returning a non-empty mapping (game_ip has prospect_evaluator_axes in YAML)."""
+    from plugins.game_ip.adapter import GameIPDomain
+
+    domain = GameIPDomain()
+    axes = domain.get_prospect_evaluator_axes()
+
+    assert isinstance(axes, dict)
+    assert len(axes) > 0  # game_ip ships with prospect axes
+    # Each entry is itself a dict spec
+    for spec in axes.values():
+        assert isinstance(spec, dict)
+
+
+def test_axes_module_constants_populated_with_plugin() -> None:
+    """When plugins.game_ip is installed, core/llm/prompts/axes.py re-exports
+    populated constants (current GEODE behavior preserved)."""
+    from core.llm.prompts.axes import (
+        ANALYST_SPECIFIC,
+        AXES_VERSIONS,
+        EVALUATOR_AXES,
+        PROSPECT_EVALUATOR_AXES,
+        VALID_AXES_MAP,
+    )
+
+    assert isinstance(ANALYST_SPECIFIC, dict) and len(ANALYST_SPECIFIC) > 0
+    assert isinstance(EVALUATOR_AXES, dict) and len(EVALUATOR_AXES) > 0
+    assert isinstance(PROSPECT_EVALUATOR_AXES, dict) and len(PROSPECT_EVALUATOR_AXES) > 0
+    assert isinstance(VALID_AXES_MAP, dict) and len(VALID_AXES_MAP) > 0
+    assert set(AXES_VERSIONS.keys()) == {
+        "EVALUATOR_AXES",
+        "PROSPECT_EVALUATOR_AXES",
+        "ANALYST_SPECIFIC",
+    }
+
+
+def test_axes_data_matches_plugin_source() -> None:
+    """`core.llm.prompts.axes` constants are the same objects (or equal data)
+    as `plugins.game_ip.axes` — proves the data moved without duplication."""
+    from core.llm.prompts.axes import EVALUATOR_AXES as CORE_EVAL
+    from plugins.game_ip.axes import EVALUATOR_AXES as PLUGIN_EVAL
+
+    assert CORE_EVAL == PLUGIN_EVAL
+    # Same identity confirms the import re-export, not a deep copy
+    assert CORE_EVAL is PLUGIN_EVAL


### PR DESCRIPTION
## Summary
- Lift the eager 14-axis YAML load out of `core/llm/prompts/axes.py` into `plugins/game_ip/axes.py` so `core/` can be imported without `plugins/game_ip/` present
- Replace hard-coded `_BUILTIN_DOMAINS` seed with a 2-pass loader (registry → convention `import plugins.<name>` → re-check); plugin self-registers in its `__init__.py`
- Add `DomainPort.get_prospect_evaluator_axes()` v2 method + GameIP impl, exposing data that previously leaked only as a module-level constant

## Why
Step 1 of 8 in the domain-free-core refactor planned in `docs/architecture/domain-free-core-audit.md` (#869). The audit identified `core/llm/prompts/axes.py` as the **highest-priority latent coupling**: its module-level eager YAML load means any `import core.llm.prompts.axes` in a context without `plugins/game_ip/` (e.g. a REODE fork) **fails at import time**. This step defuses that without changing any runtime behavior on GEODE.

It also decouples the domain registry: today `core/domains/loader.py` hard-codes `{"game_ip": "plugins.game_ip.adapter:GameIPDomain"}`. After this PR the registry starts empty and plugins seed themselves at import — REODE forks no longer have to edit core to drop game_ip out of the registry.

## Changes
| File | Change |
|------|--------|
| `plugins/game_ip/axes.py` | **NEW**. Eager YAML load + ANALYST_SPECIFIC / EVALUATOR_AXES / PROSPECT_EVALUATOR_AXES / VALID_AXES_MAP constants relocate here. |
| `core/llm/prompts/axes.py` | REWRITE. Try-imports the constants from `plugins.game_ip.axes`; falls back to empty dicts on ImportError so REODE-fork scenarios don't break. `get_valid_axes_map()` (already domain-aware) preserved. AXES_VERSIONS still computed (over the populated constants). |
| `core/domains/loader.py` | `_BUILTIN_DOMAINS = {}` (was `{"game_ip": …}`). New 2-pass `load_domain_adapter`: if name isn't in registry, try `importlib.import_module(f"plugins.{name}")` to trigger plugin self-registration, then re-check. |
| `core/domains/port.py` | Add `get_prospect_evaluator_axes()` v2 method to the `DomainPort` Protocol. |
| `plugins/game_ip/adapter.py` | Implement `get_prospect_evaluator_axes()` reading from `_axes_data["prospect_evaluator_axes"]`. |
| `plugins/game_ip/__init__.py` | Call `register_domain(\"game_ip\", \"plugins.game_ip.adapter:GameIPDomain\")` at module import so the convention-fallback discovers the adapter. |
| `tests/test_domain_port_step1.py` | **NEW**. 6 cases covering loader 2-pass after registry clear, unknown-domain error path, prospect axes accessor, axes data identity (`is` check proves re-export not deep-copy), and the populated-with-plugin invariant. |
| `CHANGELOG.md` | New `[Unreleased] / Architecture` entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Move axes data out of `core/` | Implemented | `plugins/game_ip/axes.py` is the new home |
| Empty `_BUILTIN_DOMAINS` | Implemented | Loader 2-pass recovers via convention |
| Plugin self-registration | Implemented | `register_domain` called in `plugins/game_ip/__init__.py` |
| `get_prospect_evaluator_axes` v2 method | Implemented | Method on Protocol + impl in GameIPDomain |
| `bootstrap.py` config indirection (`settings.default_domain`) | **Dropped from step 1** | The 2-pass loader makes it unnecessary for the refactor's stated goal — `bootstrap.py:setup_contextvars` calling `load_domain_adapter(\"game_ip\")` continues to work. Defer to a later PR (likely step 4 or 8) when settings-driven domain selection actually unblocks something |
| Other v2 method stubs (build_graph, get_state_class, register_event_handlers, etc.) | **Dropped from step 1** | Not consumed yet by `core/`. Will land alongside the steps that actually invert the call direction (step 7 for state, step 8 for graph) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 237 source files, no issues
- [x] `uv run pytest tests/ -m \"not live\"` — **4386 passed, 1 skipped, 24 deselected** (was 4380 before; +6 from new test file)
- [x] `uv run geode analyze \"Cowboy Bebop\" --dry-run` — **A (68.4)** unchanged

## Reference
- Design doc: `docs/architecture/domain-free-core-audit.md` (merged via #869)
- Audit \"highest priority\" finding §4 item 3: \"`core/llm/prompts/axes.py` does eager IP-YAML loading at import time. Worst latent coupling; highest priority to fix because it gates can REODE even import core/?\" → addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)