### PR TITLE
chore(hygiene): excise 3 dead-code sites flagged by post-v0.66.0 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+- **Dead code excised post-v0.66.0 audit (3 sites).** `core/llm/router.py` `_maybe_traceable = maybe_traceable` backward-compat alias deleted (zero call-sites; only docstring/comment mentions in two test files updated to use `maybe_traceable`). `core/agent/system_prompt.py` `_build_memory_context()` deleted (~28 LOC; superseded by inlined G2-G4 calls in `build_system_prompt`, no external or internal caller; one stale docstring reference in `_build_project_memory_context` cleaned). `core/cli/pipeline_executor.py:_render_streaming_evaluator` and `_render_streaming_analyst` now call `plugins.game_ip.scoring_constants.score_style` instead of duplicating the threshold-styled-string ladder inline (the analyst path rescales 0-5 → 0-100 with `score * 20` so both renderers share the 80/60-tier styler). Findings sourced from the post-release dead/duplicate/zombie code scan; sub-agent flagged 0 critical, 2 moderate, 3 minor — all 3 minor + 1 moderate addressed here. (`core/llm/router.py`, `core/agent/system_prompt.py`, `core/cli/pipeline_executor.py`, `tests/conftest.py`, `tests/test_agentic_loop.py`)
+
 ## [0.66.0] — 2026-05-06
 
 > **Domain-free core refactor — steps 1-3 of 8.** First wave of the architectural pivot

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -7,7 +7,7 @@ Memory hierarchy injected into the system prompt (G1-G3):
   G1: GEODE.md  — Agent identity (Core Principles + CANNOT + Defaults, ~20 lines)
   G2: .geode/MEMORY.md — Project meta-index (architecture, pipelines, key files)
   G3: .geode/LEARNING.md — Agent learning (patterns, corrections, domain knowledge)
-  G4: .geode/memory/PROJECT.md — Runtime insights + rules (existing _build_memory_context)
+  G4: .geode/memory/PROJECT.md — Runtime insights + rules
 
 Extracted from ``nl_router.py`` so that the AgenticLoop can use the system
 prompt without depending on the NL Router module.
@@ -279,35 +279,6 @@ def _build_user_context() -> str:
         return ""
 
 
-def _build_memory_context() -> str:
-    """Build memory context string from the 4-tier memory hierarchy.
-
-    G1 (identity) is now injected in the STATIC section of build_system_prompt()
-    for prompt cache optimization.  This function assembles G2-G4 only.
-
-    Each section is capped at ``_MAX_SECTION_LINES`` lines.
-    Missing files are silently skipped (graceful degradation).
-    """
-    parts: list[str] = []
-
-    # --- G2: Project Memory Index (.geode/MEMORY.md) ---
-    geode_memory_ctx = _build_geode_memory_context()
-    if geode_memory_ctx:
-        parts.append(geode_memory_ctx)
-
-    # --- G3: Agent Learning (.geode/LEARNING.md) ---
-    learning_ctx = _build_learning_context()
-    if learning_ctx:
-        parts.append(learning_ctx)
-
-    # --- G4: Runtime Project Memory (.geode/memory/PROJECT.md) ---
-    project_ctx = _build_project_memory_context()
-    if project_ctx:
-        parts.append(project_ctx)
-
-    return "\n\n".join(parts)
-
-
 def _build_identity_context() -> str:
     """G1: Extract core identity from GEODE.md (Core Principles + CANNOT + Defaults).
 
@@ -416,8 +387,7 @@ def _build_learning_context() -> str:
 def _build_project_memory_context() -> str:
     """G4: Build runtime project memory (insights + rules) from ProjectMemory.
 
-    This is the original _build_memory_context logic, now isolated as G4.
-    Note: G4 needs full rule details (name + paths), so it calls
+    G4 needs full rule details (name + paths), so it calls
     ``mem.list_rules()`` directly rather than ``get_active_rule_names()``.
     """
     try:

--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -12,6 +12,8 @@ import re as _re
 import shutil
 from typing import Any
 
+from plugins.game_ip.scoring_constants import score_style
+
 from core.config import settings
 from core.runtime import GeodeRuntime
 from core.state import AnalysisResult, EvaluatorResult, GeodeState
@@ -282,12 +284,11 @@ def _execute_pipeline(
 
 def _render_streaming_analyst(analysis: AnalysisResult) -> None:
     """Render a single analyst result row immediately in streaming mode."""
-    score_style = (
-        "bold green" if analysis.score >= 4.0 else "yellow" if analysis.score >= 3.0 else "red"
-    )
+    # Analyst scale is 0-5, not 0-100; rescale 4.0/3.0 → 80/60 for shared styler.
+    style = score_style(analysis.score * 20)
     console.print(
         f"  [label]{analysis.analyst_type.capitalize():14s}[/label] "
-        f"[{score_style}]{analysis.score:.1f}[/{score_style}]  "
+        f"[{style}]{analysis.score:.1f}[/{style}]  "
         f"{analysis.key_finding}"
     )
 
@@ -302,11 +303,11 @@ def _render_streaming_evaluator(key: str, ev: EvaluatorResult) -> None:
     }
     label = labels.get(key, key)
     score = ev.composite_score
-    score_style = "bold green" if score >= 80 else "yellow" if score >= 60 else "red"
+    style = score_style(score)
     rationale_snippet = ev.rationale.split(".")[0] + "." if ev.rationale else ""
     console.print(
         f"  [label]{label:14s}[/label] "
-        f"[{score_style}]{score:.0f}/100[/{score_style}]  "
+        f"[{style}]{score:.0f}/100[/{style}]  "
         f"{rationale_snippet}"
     )
 

--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -306,9 +306,7 @@ def _render_streaming_evaluator(key: str, ev: EvaluatorResult) -> None:
     style = score_style(score)
     rationale_snippet = ev.rationale.split(".")[0] + "." if ev.rationale else ""
     console.print(
-        f"  [label]{label:14s}[/label] "
-        f"[{style}]{score:.0f}/100[/{style}]  "
-        f"{rationale_snippet}"
+        f"  [label]{label:14s}[/label] [{style}]{score:.0f}/100[/{style}]  {rationale_snippet}"
     )
 
 

--- a/core/llm/router.py
+++ b/core/llm/router.py
@@ -181,10 +181,6 @@ def maybe_traceable(
     return _identity
 
 
-# Backward compatibility alias (deprecated — use maybe_traceable)
-_maybe_traceable = maybe_traceable
-
-
 # ---------------------------------------------------------------------------
 # Token usage recording helpers
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """pytest configuration — load .env before any module imports.
 
 This ensures LANGCHAIN_* environment variables are in os.environ
-BEFORE @_maybe_traceable decorators are evaluated at import time.
+BEFORE @maybe_traceable decorators are evaluated at import time.
 
 LangSmith tracing is disabled by default during tests to avoid
 burning monthly trace quota. Live tests (``-m live``) that need

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -678,7 +678,7 @@ class TestSubAgentOrchestration:
 
 
 class TestAgenticLoopTracing:
-    """Tests for _maybe_traceable integration in AgenticLoop."""
+    """Tests for maybe_traceable integration in AgenticLoop."""
 
     def test_run_has_traceable_attribute(self) -> None:
         """Verify that run() method exists and is callable (tracing is a decorator)."""
@@ -695,7 +695,7 @@ class TestAgenticLoopTracing:
         assert callable(loop._call_llm)
 
     def test_tracing_passthrough_without_langsmith(self) -> None:
-        """Without LANGCHAIN_TRACING_V2/API_KEY, _maybe_traceable is a no-op."""
+        """Without LANGCHAIN_TRACING_V2/API_KEY, maybe_traceable is a no-op."""
         context = ConversationContext(max_turns=5)
         executor = ToolExecutor()
         loop = AgenticLoop(context, executor, quiet=True)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.65.0"
+version = "0.66.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Delete `_maybe_traceable` backward-compat alias in `core/llm/router.py` (zero call-sites; test docstrings updated to use `maybe_traceable`)
- Delete `_build_memory_context()` (~28 LOC) in `core/agent/system_prompt.py` (no caller; superseded by inlined G2-G4 calls in `build_system_prompt`)
- Replace inline `"bold green/yellow/red"` threshold ladder in `core/cli/pipeline_executor.py` with `plugins.game_ip.scoring_constants.score_style` (consolidates 2 sites; analyst-path rescales 0-5 → 0-100 to share the 80/60-tier styler)

## Why
Post-v0.66.0 dead/duplicate/zombie code scan (sub-agent run on the released main HEAD) flagged 0 critical, 2 moderate, 3 minor findings. This PR addresses the 3 minor + 1 moderate findings — small, no-behavior-change cleanup that keeps the post-release codebase honest and reduces friction for the upcoming step 4-8 refactor cycles.

The two moderate findings sub-agent identified:
1. `score_style` 3-way duplication ✅ addressed (this PR consolidates 2 of 3 sites; the third is in `core/ui/event_renderer.py` which already uses the related `score_ansi_color` from the same module — left as-is)
2. `_generic_static_prefix` "is it actually reachable?" — left-as-is per audit (defensive fallback for the bootstrap try/except branch; intentional)

## Changes
| File | Change |
|------|--------|
| `core/llm/router.py` | Delete `_maybe_traceable = maybe_traceable` alias + its preceding comment (4 lines removed) |
| `core/agent/system_prompt.py` | Delete `_build_memory_context()` body (28 lines), plus 1 stale docstring reference at top of file and 1 stale docstring reference in `_build_project_memory_context` |
| `core/cli/pipeline_executor.py` | Add `from plugins.game_ip.scoring_constants import score_style`. Replace inline ternary in `_render_streaming_evaluator` (line 305) with `style = score_style(score)`. Replace inline ternary in `_render_streaming_analyst` (line 286) with `style = score_style(analysis.score * 20)` (rescale 0-5 → 0-100 so the 80/60 styler applies) |
| `tests/conftest.py` | Docstring `_maybe_traceable` → `maybe_traceable` |
| `tests/test_agentic_loop.py` | Two docstring mentions `_maybe_traceable` → `maybe_traceable` |
| `CHANGELOG.md` | New `[Unreleased] / Removed` entry |
| `uv.lock` | Lock-file refresh (geode 0.65.0 → 0.66.0; from develop's existing v0.66.0 release) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Delete `_maybe_traceable` alias + update test refs | Implemented | grep verifies zero remaining references in core/, tests/, plugins/ |
| Delete `_build_memory_context()` + clean docstring refs | Implemented | grep verifies zero remaining references |
| Consolidate `score_style` duplication | Implemented (2 of 3 sites; third is in event_renderer.py and uses the related ANSI variant — left for a later cycle) | Both pipeline_executor.py renderers now share `score_style` |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed (1 import-sort auto-fix applied during development)
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 243 source files
- [x] `uv run pytest tests/ -m \"not live\"` — **4386 passed, 1 skipped, 24 deselected**
- [x] `uv run geode analyze \"Cowboy Bebop\" --dry-run` — **A (68.4) undermarketed** unchanged

## Reference
- Post-v0.66.0 dead-code scan (sub-agent): findings logged in conversation transcript
- Audit doc: `docs/architecture/domain-free-core-audit.md` (PR #869)

🤖 Generated with [Claude Code](https://claude.com/claude-code)