### PR TITLE
chore(release): v0.66.1 — hygiene + static analysis ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.66.1] — 2026-05-06
+
+> **Hygiene + static analysis ratchet.** Post-v0.66.0 cleanup wave: 3
+> dead-code sites excised, full static-analysis stack added
+> (ruff PLR/C901 + deptry + codespell + pre-commit), ruff TID family
+> enabled with a banned-api ledger for step-2 relocations, and naming
+> conventions codified as `docs/architecture/naming-conventions.md`.
+> No production-behavior change; CI gate strengthened from 4 tools to
+> 8 (ruff, ruff-format, mypy, bandit, import-linter, deptry, codespell,
+> 4 ratchet scripts). E2E anchor `geode analyze "Cowboy Bebop" --dry-run`
+> unchanged at A (68.4) across all 4 PRs (#878, #880, #881, #882).
+> CLAUDE.md `Key entry points` corrected from stale `core/cli/agentic_loop.py`
+> to `core/agent/loop.py` (renamed in v0.66.0).
+
 ### Documentation
 - **Naming conventions codified — RESTful resource orientation (`docs/architecture/naming-conventions.md`).** Audit of v0.66.0 step-1/2/3 artifacts surfaced an *implicit* rule that had been applied consistently but never written down: when a multi-file core subpackage gets domain-extracted, mirror the path inside the plugin (`core/cli/{batch,ip_names,search}.py` → `plugins/game_ip/cli/{...}`); when a single file or fragment gets extracted (or the artifact is a plugin-specific aggregation with no obvious single-file core counterpart), use a flat intent-named module at the plugin root (`plugins/game_ip/{adapter,axes,wiring,prompt,scoring_constants}.py`). The new doc also codifies the `DomainPort` method verb taxonomy (`get_*` / `list_*` / `wire_*` / `build_*` / `compose_*` / `register_*` mapped to GET/PUT/POST semantics), the TID251 `banned-api` message format (`"Moved to <new.path> (v<X.Y.Z> step <N>)."`), PR-title / branch-name / tool-class / hook-event conventions. No code change — captures rules already followed so future contributors and step-4-through-8 PRs apply them deliberately.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.66.0
+- **Version**: 0.66.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
@@ -52,7 +52,7 @@ Production code splits into two top-level Python packages:
 - `plugins/` — domain-specific extensions. v0.64.0 contains `plugins/game_ip/` (originally `core/domains/game_ip/`); future research/ops domains land here as separate sub-packages. Wired through `core/domains/loader.py` registry.
 
 Check module count: `find core/ -name "*.py" | wc -l` for core, `find plugins/ -name "*.py" | wc -l` for plugins.
-Key entry points: `core/cli/agentic_loop.py`(AgenticLoop), `core/graph.py`(StateGraph), `core/runtime.py`(bootstrap).
+Key entry points: `core/agent/loop.py`(AgenticLoop), `core/graph.py`(StateGraph), `core/runtime.py`(bootstrap).
 
 ## Development
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.66.0 — Long-running Autonomous Execution Harness
+# GEODE v0.66.1 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.66.0 — Long-running Autonomous Execution Harness
+# GEODE v0.66.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.66.0"
+version = "0.66.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.66.0"
+version = "0.66.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Version bump 0.66.0 → 0.66.1 (PATCH — hygiene + infrastructure only, no production behavior change)
- Promote `[Unreleased]` CHANGELOG entries to `[0.66.1] — 2026-05-06` with release intro covering all 4 PRs (#878, #880, #881, #882)
- Fix CLAUDE.md `Key entry points` path: `core/cli/agentic_loop.py` → `core/agent/loop.py` (the file was renamed in v0.66.0; the reference was missed)

## Why
4 PRs landed on develop since v0.66.0 was released to main:
- **#878** hygiene — 3 dead-code sites excised (`_maybe_traceable` alias, `_build_memory_context()` function, `score_style` consolidation)
- **#880** static analysis stack — ruff PLR/C901 + deptry + codespell + pre-commit
- **#881** ruff TID family — banned-api ledger for v0.66.0 step-2 relocations
- **#882** RESTful naming conventions doc + TID251 message uniformity

PATCH bump per SemVer — all changes are hygienic or infrastructure (CI tooling + docs), no breaking API or runtime behavior change. CI gate strengthened from 4 tools to 8.

## Changes
| File | Change |
|------|--------|
| `pyproject.toml` | `version = "0.66.1"` |
| `README.md`, `README.ko.md` | Header version bump |
| `CLAUDE.md` | Version bump + `Key entry points` path correction (`core/cli/agentic_loop.py` → `core/agent/loop.py`) |
| `CHANGELOG.md` | `[Unreleased]` (Documentation + 3× Infrastructure + Removed) promoted to `[0.66.1] — 2026-05-06` with release intro paragraph |
| `uv.lock` | Lock-file refresh (geode 0.66.0 → 0.66.1) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 243 source files, no issues
- [x] `uv run deptry .` — Success! No dependency issues found.
- [x] `uv run codespell ...` — clean
- [x] `uv run pytest tests/ -m \"not live\"` — **4386 passed, 1 skipped, 24 deselected**
- [x] `uv run geode version` — **GEODE v0.66.1**
- [x] E2E `geode analyze \"Cowboy Bebop\" --dry-run` — **A (68.4) undermarketed** unchanged

## Reference
- v0.66.0 release: PR #874
- Hygiene PR: #878
- Static analysis PR: #880
- Ruff TID PR: #881
- Naming conventions PR: #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)