### PR TITLE
docs(eval): action/tool 벤치마크 4종 roadmap 신설

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -1,0 +1,63 @@
+# GEODE Eval Roadmap
+
+> Action/tool-execution 4종 벤치마크. GEODE의 quality ratchet(P4)에 통합 예정.
+> 각 문서는 **사례 + 필요 인프라 + 4-Phase 진행 시나리오**를 담음.
+> 마지막 갱신: 2026-05-07
+
+## 채택 4종
+
+| 벤치 | Trust | 측정 | GEODE에서의 역할 | 문서 |
+|---|---|---|---|---|
+| τ²-bench | HIGH | conversational tool-use + DB state-diff (native pass@k) | **accuracy 헤드라인** | [tau2-bench.md](tau2-bench.md) |
+| Terminal-Bench 2.0 | HIGH | shell 자동화 (Docker + tmux + post-run test) | **frontier 시스템 카드 비교 신호** | [terminal-bench-2.md](terminal-bench-2.md) |
+| Toolathlon | HIGH | 32 real apps × 604 MCP tools × 20턴 long-horizon | **야심 신호 (현 SOTA 38.6%)** | [toolathlon.md](toolathlon.md) |
+| HAL Reliability | HIGH | accuracy 위에 consistency/robustness/safety 레이어 | **차별화 — LangGraph reliability 스토리** | [hal-reliability.md](hal-reliability.md) |
+
+## 의존성 그래프
+
+```
+τ²-bench 어댑터 (Phase 1)
+    ↓ 재사용
+HAL Reliability (τ-bench airline rerun) ← 절반 무료
+```
+
+τ² 어댑터를 먼저 만들면 HAL Reliability의 tau-bench 부분이 그대로 따라옴. 우선순위:
+**τ² → HAL Reliability → Terminal-Bench → Toolathlon** (lift 가벼운 순).
+
+## 채택 안 한 것
+
+| 벤치 | 사유 |
+|---|---|
+| AgentBench (THUDM) | 2024 이후 신규 task 없음, 사실상 죽음 |
+| WebArena / VWA | 2026-04 UC Berkeley CRDI가 8개 web-agent 벤치 모두 `file://` reward-hack 입증 |
+| SWE-Lancer | 2025-07 이후 commit 없음, OpenAI도 GDPval로 이전 |
+| MLE-Bench | 2026-04-24 v2 대비로 leaderboard 일시 중단 |
+| AppWorld | 2026-02 이후 maintenance only, frontier 거의 풀어버림 |
+| BrowseComp / GAIA / SimpleQA | QA — GEODE 행동 기반 루프와 미스핏 |
+| OSWorld-Verified | 컴퓨터 사용 vision-heavy — GEODE에 GUI 추가 시 재검토 |
+| BFCL V4 | 보조 회귀 게이트 후보 — 1차 4종에서 제외, 필요 시 5번째로 |
+| GDPval / MCP-Atlas | OpenAI/Anthropic 내부 전용, 못 돌림 |
+
+## Cross-Bench Cost & CI 요약
+
+| 벤치 | Smoke 비용 | Full run 비용 | CI 적합도 |
+|---|---|---|---|
+| τ²-bench | <$3 | $200-400 | GHA (smoke), VM (full) |
+| Terminal-Bench 2.0 | <$5 | $30-400 | VM (Docker 필요) |
+| Toolathlon | <$1 | $80-200+ | **VM only** (32 MCP + real creds) |
+| HAL Reliability | <$2 | $150-500 (5×) | VM (full), GHA (single rerun) |
+
+## Quality Ratchet 통합 안 (Phase 3 통합 후)
+
+| 트리거 | 실행 | 임계 |
+|---|---|---|
+| Per-PR | τ² airline 5-task smoke | pass^1 −3pp 시 차단 |
+| Weekly (develop) | τ² 4-domain × 1 trial | telecom −3pp 시 알림 |
+| Monthly (main) | HAL Reliability 5-rerun + Toolathlon 15-task | accuracy −3pp / consistency −0.05 / robustness −0.05 시 release block |
+| Quarterly | Terminal-Bench 2.0 89-task full + Toolathlon 109-task full | 베이스라인 갱신 |
+
+## 변경 이력
+
+| 일자 | 변경 |
+|---|---|
+| 2026-05-07 | 초기 작성 — 4종 채택, 각 벤치별 사례/인프라/시나리오 |

--- a/docs/eval/hal-reliability.md
+++ b/docs/eval/hal-reliability.md
@@ -1,0 +1,143 @@
+# HAL Reliability (Princeton, ICLR 2026)
+
+## 개요
+
+벤치마크가 아니라 **벤치 위에 얹는 reliability layer**. GAIA + tau-bench airline 등 9개 underlying bench를 다중 rerun 해서 **consistency / robustness / safety / predictability / self-awareness** 5개 차원 산출. Princeton이 2025-10부로 **신규 모델 accuracy 등록을 일시 중단**하고 reliability에만 집중.
+
+- **Repo**: [princeton-pli/hal-harness](https://github.com/princeton-pli/hal-harness) — 274★
+- **Paper**: [arXiv 2510.11977](https://arxiv.org/pdf/2510.11977), **ICLR 2026 채택**
+- **Dashboard**: [hal.cs.princeton.edu/reliability/](https://hal.cs.princeton.edu/reliability/)
+- **라이센스**: 확인 필요 (LICENSE 파일 없음 — Princeton 학계 디폴트 = All Rights Reserved 가능성, 로컬 실행은 OK)
+- **검증 규모**: 21,730 rollout × 9 모델 × 9 bench / $40K / 2.5B token (paper)
+
+## 사례
+
+### Case 1 — GAIA에서 Reliability ≠ Accuracy
+
+[HAL GAIA Reliability dashboard](https://hal.cs.princeton.edu/reliability/benchmark/gaia/):
+
+| 모델 | Accuracy | Consistency | Robustness |
+|---|---|---|---|
+| Claude Sonnet 4.5 | **74.7%** (1위) | 0.63 | 0.69 |
+| Claude Opus 4.5 | 71.5% | **0.67** | — |
+| Gemini 2.5 Pro | 50.1% | — | **0.74** (1위) |
+
+→ Sonnet 4.5의 GAIA 헤드라인 숫자만 보고 ship하면 **brittle한 걸 ship**하는 셈. Opus가 정확도 낮은데 consistency 더 높음. HAL의 thesis = "stop chasing accuracy alone."
+
+### Case 2 — Tau-bench airline cost-aware Pareto
+
+[HAL airline](https://hal.cs.princeton.edu/taubench_airline) Pareto 선정 모델: **o4-mini High, DeepSeek V3, Gemini 2.0 Flash High**. Claude Opus 4.1은 정확도 비슷한데 **$69-180/run**이라 frontier 밖.
+
+→ HAL은 **이 리스트 4종 중 유일하게 cost-per-task를 1급 컬럼으로 publish**. `accuracy@k$`가 `accuracy@1`보다 ship 결정에 더 유용함을 데이터로 보여줌.
+
+### Case 3 — Princeton이 신규 모델 등록을 멈춤
+
+Airline dashboard footer: "the HAL team has paused updating with new models" — reliability 메트릭에 집중. **이 분야에서 가장 강한 시그널**: accuracy on N benches가 plateau, 가치는 *how* models fail로 이동. Paper가 5개 차원을 formally 정의 + 9 bench(GAIA, AssistantBench, CORE-Bench Hard, Online Mind2Web, SciCode, ScienceAgentBench, **SWE-bench Verified Mini**, **TAU-bench Airline**, USACO)에 적용.
+
+## 필요 Eval 인프라
+
+| 항목 | 값 |
+|---|---|
+| Install | `conda create -n hal python=3.12 && conda activate hal && pip install -e .` |
+| Python | 3.12 |
+| 실행 모드 | (a) **local Python**, (b) **Azure VM** (subscription ID + resource group + NSG + SSH key) |
+| Inspect AI 통합 | `-I` 플래그 |
+| Sandbox | HAL 자체는 underlying bench로 shell out — bench 자체의 sandbox에 의존 |
+| Scoring | HAL은 score 안 함 — underlying bench가 함. HAL은 trajectory를 **post-process**해서 5 reliability 메트릭 산출 |
+| 5개 차원 | consistency (rerun 분산), predictability (self-assessment 편차), robustness (perturbation 후 perf), safety (jailbreak/PII), self-awareness (calibration) — 각 [0,1] normalize |
+| External | LLM API key. tau-bench airline는 추가 cred 불필요 (모두 simulated) |
+| Cost — smoke | 2-task tau-bench airline single-rerun on gpt-4o-mini ≈ **<$2** |
+| Cost — Reliability run | underlying bench cost × N rerun. **5-rerun consistency = 5×**. tau-bench airline @ $11-$42/run × 5 = **$55-210**. GAIA @ ~$30 × 5 = **~$150** |
+| Trace | per-rerun trajectory JSON + `reliability_report.json` (5 차원 + cost) |
+| CI 적합도 | full reliability는 GHA 불가. tau-bench airline subset single-rerun은 GHA 가능 |
+
+### Agent Contract
+
+`agents/<your_agent>/main.py`:
+
+```python
+def run(input: dict[str, dict], **kwargs) -> dict[str, dict]:
+    # input:  {task_id: task_config}
+    # kwargs: {"model_name": "...", optional "reasoning_effort": "..."}
+    return {
+        task_id: {
+            "reward": float,
+            "taken_actions": [...],
+            "task": {...},
+        }
+    }
+```
+
+CLI 등록: `--agent_function main.run`. Reference: [`agents/taubench_example_agent/main.py`](https://github.com/princeton-pli/hal-harness/tree/main/agents/taubench_example_agent).
+
+### 실행 명령 예시
+
+```bash
+hal-eval \
+  --benchmark taubench_airline \
+  --agent_dir agents/geode_taubench \
+  --agent_function main.run \
+  --agent_name "geode-sonnet-4.5" \
+  -A model_name=claude-sonnet-4.5 \
+  --num_runs 5
+```
+
+## GEODE 진행 시나리오
+
+> **의존성**: τ²-bench Phase 1 어댑터를 먼저 끝내면 HAL의 tau-bench airline 부분은 그대로 재사용 가능 → **HAL 작업이 가장 가벼워짐 (~6-8h)**.
+
+### Phase 0 — Smoke (≤20분, cost <$2)
+
+```bash
+hal-eval --benchmark taubench_airline \
+  --agent_dir agents/taubench_example_agent \
+  --agent_function main.run \
+  --agent_name "smoke" \
+  -A model_name=gpt-4o-mini \
+  --max_tasks 2 --num_runs 1
+```
+
+HAL CLI + report shape 검증, GEODE infra에서 conda env 설치 확인.
+
+### Phase 1 — PoC 어댑터 (~6-8시간, τ² Phase 1 재사용)
+
+신규 파일:
+- `eval/hal/agents/geode_taubench/main.py` — `run(input, **kwargs)` 가 τ² Phase 1 어댑터를 wrap
+- `eval/hal/agents/geode_taubench/requirements.txt` — uv 외부 의존
+- (옵션) `eval/hal/agents/geode_gaia/main.py` — GAIA용 별도 어댑터 (research/QA 측정 시)
+
+매핑 (tau-bench airline):
+- HAL의 `input` dict → tau-bench env params
+- HAL의 `model_name` kwarg → AgenticLoop LLM 선택
+- 반환의 `reward` → tau-bench oracle state-diff 결과
+
+### Phase 2 — First Real Run
+
+- **대상**: tau-bench airline **10-task × 3 rerun on Sonnet 4.5**
+- **선정 사유**: 가장 저렴한 signal-rich Reliability 숫자, GEODE의 action-execution path와 직결
+- **예상 출력**:
+  - accuracy 35-50% (Sonnet 4.5의 다른 bench 추세 기준)
+  - consistency 0.55-0.65
+  - cost-per-task: $1-4
+- **예상 cost**: **$30-60**
+- **출력 보관**: `artifacts/eval/hal/<date>/reliability_report.json`
+
+### Phase 3 — CI / 운영 Ratchet
+
+> **HAL의 역할 = ratchet의 reliability 축**. τ²(accuracy) + Toolathlon(long-horizon) + HAL(reliability) 3축 trio.
+
+| 트리거 | 실행 | 임계 |
+|---|---|---|
+| Monthly (main, VM) | 5-rerun on tau-bench airline + GAIA subset | accuracy −3pp **OR** consistency −0.05 **OR** robustness −0.05 → release block |
+| Quarterly | 5-rerun on 4종 bench (airline, GAIA, AssistantBench, USACO subset) | 베이스라인 갱신 |
+
+이게 잡는 regression: "더 eager한 tool-caller로 한 trial은 이기는데 oscillate하는" — 순수 accuracy bench가 못 잡는 패턴.
+
+## 참고
+
+- [HAL paper (arXiv 2510.11977)](https://arxiv.org/pdf/2510.11977)
+- [HAL Reliability dashboard](https://hal.cs.princeton.edu/reliability/)
+- [GAIA Reliability](https://hal.cs.princeton.edu/reliability/benchmark/gaia/)
+- [Tau-bench airline (cost-aware)](https://hal.cs.princeton.edu/taubench_airline)
+- [hal-harness GitHub](https://github.com/princeton-pli/hal-harness)
+- [Reference agent (taubench_example_agent)](https://github.com/princeton-pli/hal-harness/tree/main/agents/taubench_example_agent)

--- a/docs/eval/tau2-bench.md
+++ b/docs/eval/tau2-bench.md
@@ -1,0 +1,122 @@
+# τ²-bench (Sierra)
+
+## 개요
+
+Multi-turn tool-agent-user 시뮬레이션 벤치. 에이전트와 LLM 시뮬 유저가 공유 world state를 tool로 변경하며 대화. **pass^k의 발상지**.
+
+- **Repo**: [sierra-research/tau2-bench](https://github.com/sierra-research/tau2-bench) — 1.1k★
+- **마지막 commit**: 2026-05-05 (live submissions PR, 매주 갱신)
+- **라이센스**: 확인 필요 (Apache-2.0 추정)
+- **버전 히스토리**: v1 NeurIPS '24 → v² 2025 (telecom dual-control) → v0.2.0 2025-10-06 (web leaderboard) → v0.2.1 2025-11 (RL support). τ³(banking+voice)은 paper만, 코드 미공개
+- **Frontier 인용**: GPT-5.5 system card (**telecom 98.0%**), Anthropic 인용
+
+## 사례
+
+### Case 1 — Sierra가 발견한 user-simulator drift (NeurIPS '24 → v² 2025)
+
+원래 τ-bench는 GPT-4o를 user simulator로 사용. SOTA GPT-4o 자체가 retail에서 ~61%, airline에서 ~35%. Sierra autopsy 결과 **점수 분산의 절반이 simulator 모델 선택에서 옴**. v²의 telecom dual-control 도메인은 agent와 user가 같은 world state를 함께 변경하게 만들어 이 문제를 차단.
+
+출처: [τ-bench paper](https://arxiv.org/pdf/2406.12045), [τ²-bench paper](https://arxiv.org/pdf/2506.07982)
+
+### Case 2 — Telecom 리더보드 역전 — Z.ai GLM-4.7-Flash 1위
+
+[Artificial Analysis tau²-bench](https://artificialanalysis.ai/evaluations/tau2-bench) (2026-05 기준):
+- **Z.ai GLM-4.7-Flash (Reasoning) 98.8%**
+- GLM 5V Turbo / GLM-5-Turbo 98.5%
+- GPT-5.x, Opus 4.x는 telecom에서 더 낮음
+
+Sierra 분석: telecom은 **patient diagnostic dialog**를 보상 — Chinese reasoning model이 tool call 전 long step-by-step plan을 emit하기 때문에 이김. **공격적 tool-caller는 telecom에서 손해**라는 교훈.
+
+### Case 3 — HAL Generalist + Claude 3.7 Sonnet — airline 1위 56% / $42
+
+[HAL tau-bench airline](https://hal.cs.princeton.edu/taubench_airline) Pareto:
+- **HAL Generalist + Sonnet 3.7**: 56% / $42.11
+- **o4-mini High**: 56% / $11.36
+- TAU-bench Tool Calling baseline + Opus 4.1: 50% / $69.78
+
+교훈: **얇은 generalist scaffold가 hand-tuned tool-calling loop을 이김**. "Opus에 더 쓰기"는 reliability 안 사줌. airline은 50-56%가 천장 — 50대 후반에 정체.
+
+## 필요 Eval 인프라
+
+| 항목 | 값 |
+|---|---|
+| Install | `git clone … && uv sync` (텍스트 only) / `uv sync --all-extras` (voice+banking) |
+| macOS extras | `brew install portaudio ffmpeg` (voice 옵션) |
+| Python | `>=3.12,<3.14` |
+| Sandbox | **순수 Python in-process** — Docker 불필요 |
+| Scoring | Pydantic world state diff (oracle) — LLM judge 미사용 |
+| Trace | `results/<run_id>/` JSONL (메시지+tool call+task reward) |
+| External | LLM keys (LiteLLM). User simulator 모델 명시 필수 — leaderboard는 v0.2.0부터 **`gpt-4.1` 고정** |
+| Cost — smoke | 5-task airline @ Sonnet 4.5 ≈ **<$3** |
+| Cost — full | 4-domain × 4 trial @ Sonnet 4.5 ≈ **$200-400** |
+| CI 적합도 | 5-task smoke GHA 가능 (~10-15분), full은 VM |
+
+### Agent Contract
+
+[`src/tau2/agent/README.md`](https://github.com/sierra-research/tau2-bench/blob/main/src/tau2/agent/README.md):
+
+```python
+class HalfDuplexAgent:
+    def __init__(self, tools, domain_policy): ...
+    def get_init_state(self, message_history) -> StateType: ...
+    def generate_next_message(
+        self, message, state
+    ) -> tuple[AssistantMessage, StateType]: ...
+
+def create_agent(tools, domain_policy, **kwargs) -> HalfDuplexAgent: ...
+```
+
+`LLMAgent`는 reference impl이지 강제 base 아님. `tools`는 domain tool registry, `domain_policy`는 system prompt prefix.
+
+## GEODE 진행 시나리오
+
+### Phase 0 — Smoke (≤30분, cost <$1)
+
+```bash
+tau2 run --domain mock --agent-llm <ours> --num-tasks 1 --num-trials 1
+```
+
+`mock` 도메인은 LLM cost 거의 없이 `core/agent/loop.py::AgenticLoop` 와이어업만 검증.
+
+**Pass criteria**: results/ 폴더에 JSONL 생성, agent contract 호출 trace 확인.
+
+### Phase 1 — PoC 어댑터 (~6-10시간)
+
+신규 파일:
+- `eval/tau2/__init__.py`
+- `eval/tau2/adapter.py` — `class GeodeTau2Agent(HalfDuplexAgent)`
+- `eval/tau2/factory.py` — `create_agent()` factory
+- `eval/tau2/README.md` — 실행 방법
+
+매핑:
+- `generate_next_message(message, state)` → 한 번의 `AgenticLoop.step()`
+- `tools` constructor 인자 → GEODE tool registry에 wrap (LangGraph tool node 형태)
+- `domain_policy` → AgenticLoop system prompt prefix
+- `state` → AgenticLoop의 conversation state를 Pydantic으로 직렬화
+
+### Phase 2 — First Real Run
+
+- **대상**: telecom 24 tasks × 1 trial × **Sonnet 4.5**
+- **선정 사유**: dual-control 도메인이 Slack/MCP execution path에 가장 가까움
+- **예상 baseline**: **35-45% pass^1** (비특화 scaffold 평균치 기준)
+- **예상 cost**: $25-40
+- **출력 보관**: `artifacts/eval/tau2/<date>/`
+
+### Phase 3 — CI / 운영 Ratchet
+
+| 트리거 | 실행 | 임계 | 비용 |
+|---|---|---|---|
+| Per-PR | airline 5-task smoke | pass^1 −3pp → 차단 | <$3 |
+| Weekly (develop) | 4-domain × 1 trial | telecom −3pp → Slack 알림 | ~$50 |
+| Monthly (main) | telecom × 4 trial pass^k | pass^4 −5pp → release block | ~$80 |
+
+선정 사유: telecom = GEODE Slack-ops day job에 가장 근접.
+
+## 참고
+
+- [τ-bench paper (NeurIPS '24)](https://arxiv.org/pdf/2406.12045)
+- [τ²-Bench paper](https://arxiv.org/pdf/2506.07982)
+- [GitHub repo](https://github.com/sierra-research/tau2-bench)
+- [Live leaderboard](https://taubench.com/)
+- [Artificial Analysis mirror](https://artificialanalysis.ai/evaluations/tau2-bench)
+- [HAL airline dashboard (cost-aware)](https://hal.cs.princeton.edu/taubench_airline)

--- a/docs/eval/terminal-bench-2.md
+++ b/docs/eval/terminal-bench-2.md
@@ -1,0 +1,128 @@
+# Terminal-Bench 2.0 (Stanford + Laude Institute)
+
+## 개요
+
+89개의 manually verified 터미널 태스크. Docker 컨테이너 안의 tmux 세션을 에이전트가 직접 조작 → post-run pytest로 검증. v1의 reward-hack 가능 태스크들을 솎아내고 큐레이션.
+
+- **Repo**: [laude-institute/terminal-bench](https://github.com/laude-institute/terminal-bench) — 2.1k★
+- **Leaderboard**: [tbench.ai/leaderboard/terminal-bench/2.0](https://www.tbench.ai/leaderboard/terminal-bench/2.0) — 2026-04-23 갱신, 124 entries
+- **Frontier 인용**: **GPT-5.5 system card 82.7%**, Opus 4.7 발표글
+- **라이센스**: Apache-2.0
+
+## 사례
+
+### Case 1 — Forge Code + Gemini 3.1 Pro — 78.4% 1위
+
+[Morph LLM 2.0 mirror](https://www.morphllm.com/terminal-bench-2):
+- **Forge Code + Gemini 3.1 Pro**: 78.4% (±1.8)
+- Factory Droid + GPT-5.3-Codex: 77.3%
+
+Forge가 이긴 이유: **tool error 발생할 때마다 aggressive re-plan**. 모델의 plan을 stream으로 끝까지 따르는 대신, 에러마다 plan을 다시 그림. 21-22%의 천장은 Linux kernel-level work (`build-linux-kernel`은 source patch + qemu 필요), FastText 정확도 타깃 등.
+
+### Case 2 — Terminus-KIRA가 모델을 평준화
+
+Stanford reference scaffold "Terminus-KIRA":
+- + Claude Opus 4.6 = **74.7%** (±2.6)
+- + Gemini 3.1 Pro = **74.8%** (±??)
+
+같은 scaffold가 다른 frontier 모델로도 **동일한 점수** → [Snorkel 분석](https://snorkel.ai/blog/terminal-bench-2-0-raising-the-bar-for-ai-agent-evaluation/) thesis: **모델은 baseline 위에서 거의 fungible, scaffold가 lever**. 이게 GEODE가 자체 scaffold를 제출하는 가장 강한 동기.
+
+### Case 3 — Danau5tin RL fine-tune + v1의 게임된 태스크 제거
+
+[terminal-bench-rl](https://github.com/Danau5tin/terminal-bench-rl): 32×H100 GRPO로 Qwen3 fine-tune하여 **v1 top open-weights** 달성 — 벤치가 RL-optimizable임을 입증.
+
+반례: v1의 "Hello World" 디버깅 태스크는 frontier 모델이 verifier를 game할 수 있어서 2.0에서 **제거**. 2.0의 89개 태스크 큐레이션 기준 = "agent가 일을 안 하고 패턴 매칭으로 풀 수 없어야 함."
+
+## 필요 Eval 인프라
+
+| 항목 | 값 |
+|---|---|
+| Install | `uv tool install terminal-bench` 또는 `pip install terminal-bench` |
+| 전제 조건 | **Docker daemon 실행 중** |
+| Python | 3.10+ (uv-managed, 3.12 권장) |
+| Sandbox | **per-task Docker** (`tasks/<id>/Dockerfile`) + tmux 세션 attach |
+| 동시성 | `--n-concurrent 8` 등 |
+| Scoring | `tasks/<id>/tests/test_outputs.py` pytest — 순수 execution-based, LLM judge 없음 |
+| Trace | `logs/<id>/agent.log`, full tmux scrollback, test verdict JSON |
+| External | LLM API keys (built-in agent 사용 시: `claude_code`/`codex`/`gemini_cli` 등은 해당 CLI를 subprocess로 호출) |
+| Cost — smoke | 3-task on Sonnet ≈ **<$5** |
+| Cost — full | 89-task on Sonnet ≈ **$30-80** / Opus ≈ **$150-400** |
+| CI 적합도 | full은 **VM only** (Docker + 5-20분/task). smoke는 GHA-Docker 가능 |
+
+### Agent Contract
+
+[`base_agent.py`](https://github.com/laude-institute/terminal-bench/blob/main/terminal_bench/agents/base_agent.py):
+
+```python
+class BaseAgent(ABC):
+    @staticmethod
+    @abstractmethod
+    def name() -> str: ...
+
+    @abstractmethod
+    def perform_task(
+        self,
+        instruction: str,
+        session: TmuxSession,
+        logging_dir: Path | None = None,
+    ) -> AgentResult: ...
+```
+
+에이전트는 라이브 `TmuxSession`을 받아서 **keystroke를 직접 type**. 검증은 harness가 컨테이너 안에서 test 명령 실행. 즉 **structured tool call이 아니라 raw keystroke stream**이 surface.
+
+내장 에이전트: `aider`, `claude_code`, `codex`, `cursor_cli`, `gemini_cli`, `goose`, `grok_cli`, `mini_swe_agent`, `opencode`, `openhands`, `qwen_code`.
+
+## GEODE 진행 시나리오
+
+### Phase 0 — Smoke (≤15분, LLM cost 0)
+
+```bash
+tb run --agent oracle --task-ids hello-world --n-concurrent 1
+```
+
+Oracle agent는 정답 솔루션을 사용 → Docker + harness + tmux가 GEODE 빌드 머신에서 동작하는지만 검증.
+
+**Pass criteria**: container build 성공, oracle pass 1/1, logs 생성.
+
+### Phase 1 — PoC 어댑터 (~8-12시간)
+
+신규 파일:
+- `eval/terminal_bench/geode_agent.py` — `class GeodeTerminalAgent(BaseAgent)`
+- `core/agent/tools/tmux_tool.py` — **`TmuxToolAdapter` 신규** (raw keystroke를 GEODE tool registry에 등록)
+- `eval/terminal_bench/README.md`
+
+핵심 어려움: GEODE는 structured tool call 모델로 설계됨, 그런데 tmux는 raw stream → `TmuxToolAdapter`가 `send_keys` / `read_screen`을 GEODE tool로 노출. Loop 자체는 건드리지 말고 tool layer에서 해결.
+
+매핑:
+- `instruction` → `geode serve` MCP path 입력
+- `TmuxSession.send_keys` → `TmuxToolAdapter.send` (GEODE tool 호출)
+- `TmuxSession.capture_pane` → `TmuxToolAdapter.read`
+- 종료 조건: AgenticLoop가 자체 종료 또는 timeout
+
+### Phase 2 — First Real Run
+
+- **대상**: 12-task `system-administration` 서브셋 (Linux kernel + git-webserver class) on **Sonnet 4.5**
+- **선정 사유**: GEODE `geode serve` 운영 프로필에 가장 근접
+- **예상 baseline**: **30-45%** (frontier 75%보다 한참 낮음 — GEODE 루프가 tmux native 아니라서)
+- **예상 cost**: $8-15
+- **출력 보관**: `artifacts/eval/terminal_bench/<date>/`
+
+### Phase 3 — CI / 운영 Ratchet
+
+| 트리거 | 실행 | 임계 |
+|---|---|---|
+| Per-PR | 3-task oracle smoke (LLM 미사용) | smoke fail → 차단 |
+| Weekly (develop nightly VM) | system-administration 12-task | 서브셋 −5pp → 차단 |
+| Quarterly | 89-task full | 베이스라인 업데이트 |
+
+서브셋이 50% 넘으면 89개 전체로 확장.
+
+## 참고
+
+- [GitHub repo](https://github.com/laude-institute/terminal-bench)
+- [Leaderboard 2.0](https://www.tbench.ai/leaderboard/terminal-bench/2.0)
+- [Snorkel 2.0 blog](https://snorkel.ai/blog/terminal-bench-2-0-raising-the-bar-for-ai-agent-evaluation/)
+- [Morph LLM mirror](https://www.morphllm.com/terminal-bench-2)
+- [terminal-bench-rl (Danau5tin)](https://github.com/Danau5tin/terminal-bench-rl)
+- [GPT-5.5 system card](https://openai.com/index/gpt-5-5-system-card/)
+- [Opus 4.7 launch](https://www.anthropic.com/news/claude-opus-4-7)

--- a/docs/eval/toolathlon.md
+++ b/docs/eval/toolathlon.md
@@ -1,0 +1,129 @@
+# Toolathlon (HKUST, ICLR 2026)
+
+## 개요
+
+108(+1) long-horizon 태스크 × **32 real apps** × **604 MCP tools**, 평균 20 tool turn. GEODE 시나리오에 가장 가까움 (Slack/Notion/Calendar/GitHub/BigQuery 등 실제 SaaS).
+
+- **Repo**: [hkust-nlp/Toolathlon](https://github.com/hkust-nlp/Toolathlon) — 343★
+- **마지막 commit**: 2026-04-28
+- **Paper**: [arXiv 2510.25726](https://arxiv.org/abs/2510.25726), **ICLR 2026 채택** ([OpenReview](https://openreview.net/forum?id=z53s5p0qhf))
+- **라이센스**: 확인 필요
+- **현재 SOTA**: Claude-4.5-Sonnet **38.6%** — headroom 큼
+
+## 사례
+
+### Case 1 — Claude 4.5 Sonnet SOTA 38.6% (20.2 tool turn 평균)
+
+[Xiang Yue 발표](https://x.com/xiangyue96/status/1983945639026368771) + [arXiv 2510.25726](https://arxiv.org/abs/2510.25726):
+- **Claude 4.5 Sonnet**: 38.6% / 20.2 turns
+- DeepSeek-V3.2-Exp (best open-weights): 20.1%
+
+Failure mode 클러스터 (paper):
+1. **Navigation error** — 잘못된 app 선택
+2. **Tool-chain breakage** — call 사이 state 잃어버림
+3. **State management drift** — 누적 컨텍스트 오염
+4. **Format misinterpretation** — MCP schema 오해
+
+→ 38.6%가 SOTA라는 건 **20-turn 시퀀스가 아무도 안 풀린다**는 뜻. GEODE처럼 진짜 SaaS 자동화하는 agent에 가장 의미 있는 신호.
+
+### Case 2 — Decoupled agent loop = scaffold ablation 가능
+
+Toolathlon은 [decoupled agent loop mode](https://github.com/hkust-nlp/Toolathlon)를 지원해서 host loop을 갈아끼울 수 있음:
+- Default: monkey-patched `openai-agents-sdk`
+- Alternative: Anthropic 공식 `claude_agent_sdk`
+
+repo의 trajectory에 `claude-4.5-opus`, `gpt-5.1`, `gemini-3-pro`, `deepseek-v3.2-thinking` — 같은 task를 다른 scaffold/model로 diff 가능. **Sierra가 τ²에서 발견한 simulator drift 문제를 명시적으로 측정 가능**한 구조.
+
+### Case 3 — Canvas / WooCommerce / BigQuery cross-app 태스크의 실패
+
+[`tasks/finalpool/`](https://github.com/hkust-nlp/Toolathlon/tree/main/tasks/finalpool) (109 task):
+- `canvas-do-quiz`, `canvas-art-quiz` — **모든 모델이 실패**: agent가 `submit_quiz`와 `start_quiz` MCP tool semantic을 conflate
+- WooCommerce + BigQuery cross-app — Claude가 1위인데 단순히 tool name disambiguation이 더 나아서
+
+→ MCP tool 네이밍이 점수에 직접 영향. GEODE `geode serve`의 MCP client가 이런 semantic ambiguity를 어떻게 다루는지 검증할 수 있음.
+
+## 필요 Eval 인프라
+
+| 항목 | 값 |
+|---|---|
+| Install | `bash global_preparation/install_env_minimal.sh true` 후 `bash global_preparation/pull_toolathlon_image.sh` |
+| Docker image | `lockon0927/toolathlon-task-image:1016beta` |
+| Python | 3.12 (uv toolchain) |
+| Sandbox | **per-task Docker** (또는 Podman). 컨테이너명 `toolathlon-<task>-<timestamp>` |
+| Mount | workspace dump + logs + **docker.sock** (agent가 nested container spawn — k8s.yaml MCP server 등) |
+| Scoring | `TaskEvaluator.evaluate_from_log_file()` — `evaluation/` 스크립트가 post-task state에 실행 → `eval_stats.json` |
+| Trace | `dumps/<model>/<task>/` (LLM chat history + MCP call/response + verdict + cost) |
+| External — 32 MCP server | 12306, arxiv-latex-mcp, arxiv_local, **canvas, emails, excel, filesystem, git, github, google-cloud, google_calendar, google_forms, google_map, google_sheet**, howtocook, huggingface, k8s, **memory, notion, notion_official**, npx-fetch, pdf-tools, playwright_with_chunk, pptx, scholarly_search, snowflake, **terminal, time, wandb, woocommerce, word**, yahoo-finance, youtube, youtube_transcript |
+| 실제 credential 필요 | Notion, Canvas, Google Calendar/Sheet/Forms/Maps/Cloud, GitHub, WooCommerce, Snowflake, BigQuery, W&B, HuggingFace (`how2register_accounts.md` 참조) |
+| LLM key | `TOOLATHLON_OPENAI_API_KEY` + `TOOLATHLON_OPENAI_BASE_URL` (LiteLLM 호환) |
+| Cost — smoke | 1 task `cooking-guidance` (howtocook MCP만) ≈ **<$1** |
+| Cost — full | 108 task × 20.2 turn × Sonnet ≈ **$80-200** LLM + 외부 API quota 별도 (smoke run으로 bound 필요) |
+| CI 적합도 | **VM only** — Docker + 32 MCP + real APIs는 GHA 불가. smoke는 GHA-Docker 가능 |
+
+### 실행 명령 예시
+
+```bash
+uv run main.py \
+  --eval_config scripts/formal_run_v0.json \
+  --task_dir tasks/finalpool/canvas-do-quiz \
+  --max_steps_under_single_turn_mode 30 \
+  --model_short_name claude-sonnet-4.5 \
+  --provider anthropic
+```
+
+## GEODE 진행 시나리오
+
+### Phase 0 — Smoke (≤30분, cost <$1)
+
+```bash
+bash scripts/run_single_containerized.sh \
+  tasks/finalpool/cooking-guidance \
+  smoke \
+  ./dumps_smoke/geode \
+  anthropic/claude-sonnet-4.5
+```
+
+`howtocook` MCP만 사용 — 외부 credential 불필요. 컨테이너 + MCP plumbing 검증.
+
+### Phase 1 — PoC 어댑터 (~16-24시간 — 4종 중 가장 무거움)
+
+두 경로:
+
+**(a) Host-mode** — `core/agent/loop.py::AgenticLoop`을 Toolathlon decoupled agent loop API에 plug
+- 신규: `eval/toolathlon/geode_loop.py` — `claude_agent_sdk` entry shape mimic
+- 장점: 깔끔, `core/`에 영향 적음
+- **권장 — Phase 1은 (a)**
+
+**(b) MCP-client mode** — Toolathlon MCP server들을 GEODE의 기존 `geode serve` MCP client로 repoint
+- 장점: production path 그대로 검증
+- 단점: `geode serve` 운영 영향, credentialing 두 군데로 분산
+
+Phase 1 = (a), Phase 4 (별도) = (b) 검토.
+
+### Phase 2 — First Real Run
+
+- **대상**: 15-task subset, GEODE의 기존 MCP integration과 겹치는 것:
+  - `google_calendar`, `notion`, `github`, `filesystem`, `terminal`, `time`, `memory`, `emails` 위주
+- **모델**: Sonnet 4.5
+- **예상 baseline**: **15-25% pass** (long-horizon multi-app은 GEODE 약점)
+- **예상 cost**: **$15-30 LLM + 무료 tier 외부 API**
+- **출력 보관**: `artifacts/eval/toolathlon/<date>/`
+
+### Phase 3 — CI / 운영 Ratchet
+
+| 트리거 | 실행 | 임계 |
+|---|---|---|
+| Per-PR | 1-task `cooking-guidance` smoke | smoke fail → 차단 (<$1) |
+| Monthly (전용 VM, real creds) | 109-task full | 15-task subset −5pp → 차단 |
+| Quarterly | 109-task × 3 trial pass^k | reliability 추적 |
+
+HAL Reliability와 페어링: Toolathlon은 accuracy + headroom, HAL은 consistency.
+
+## 참고
+
+- [GitHub repo](https://github.com/hkust-nlp/Toolathlon)
+- [arXiv paper](https://arxiv.org/abs/2510.25726)
+- [ICLR 2026 OpenReview](https://openreview.net/forum?id=z53s5p0qhf)
+- [Xiang Yue 발표 (X)](https://x.com/xiangyue96/status/1983945639026368771)
+- [tasks/finalpool 디렉토리](https://github.com/hkust-nlp/Toolathlon/tree/main/tasks/finalpool)
+- [configs/mcp_servers (32개)](https://github.com/hkust-nlp/Toolathlon/tree/main/configs/mcp_servers)


### PR DESCRIPTION
## Summary
- `docs/eval/` 신설 — τ²-bench, Terminal-Bench 2.0, Toolathlon, HAL Reliability 4종 eval roadmap
- 각 벤치별 사례 3건 + 필요 인프라 + 4-Phase 진행 시나리오
- 미채택 8종 사유도 README에 명시

## Why
GEODE의 primary loop은 행동 기반(Slack ops/스케줄링/MCP tool execution). game_ip 플러그인만 분석. 그런데 기존에 평가 인프라가 정리되어 있지 않아 어떤 벤치를 ratchet에 넣을지, 어떤 순서로 어댑터를 만들지 SOT가 없었음. 4종 채택 결정과 진행 순서를 wiki로 축적.

## Changes
| File | Change |
|------|--------|
| `docs/eval/README.md` | 4종 채택 이유 + cross-bench 요약 + ratchet 통합 안 + 미채택 사유 |
| `docs/eval/tau2-bench.md` | accuracy 헤드라인용 (Phase 1 가장 우선) |
| `docs/eval/terminal-bench-2.md` | frontier 시스템 카드 비교 신호 |
| `docs/eval/toolathlon.md` | long-horizon 야심 신호 (가장 무거움 ~16-24h) |
| `docs/eval/hal-reliability.md` | reliability 차별화 (τ² 어댑터 재사용 → ~6-8h) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 4종 벤치 사례 수집 | Implemented | 각 3건씩, primary source 링크 inline |
| Agent contract 명세 | Implemented | 각 벤치의 정확한 함수/클래스 시그니처 + 예시 |
| Cost 추정 | Implemented | 일부 항목은 "smoke run으로 bound 필요"로 표기 (Toolathlon 외부 API quota 등) |
| Phase별 신규 파일 경로 | Implemented | `eval/<bench>/adapter.py` 형태 명시 |
| 미채택 사유 | Implemented | 8종 (AgentBench/WebArena/SWE-Lancer/MLE-Bench/AppWorld/BrowseComp/OSWorld/BFCL) |

## Verification
- [x] 5개 파일 작성 (README + 4 bench)
- [x] 모든 외부 링크 inline 명시
- [x] CHANGELOG 미수정 (docs only = no version bump)
- [ ] CI guardrail (docs only, lint/type/test 무관)

## Reference
- 사용자 요청: 4종 벤치 결정 후 "벤치마크별 사례와 필요 Eval 인프라, 진행 시나리오를 수립해서 wiki에 축적"
- 채택 4종 trust score 검증: HAL ICLR 2026, Toolathlon ICLR 2026, τ² NeurIPS '24+v² 2025, Terminal-Bench 2.0 (frontier 시스템 카드 인용)