### PR TITLE
fix(v0.82.0): SharedServices가 daemon 부팅 시 model freeze하던 critical 버그 (OAuth 점검 중 발견)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.82.0] — 2026-05-08
+
+> **Critical fix — `SharedServices` no longer freezes the active LLM
+> model at daemon boot.** Discovered while live-testing OAuth-OpenAI
+> codex routing. Symptom (extremely subtle, silently swaps providers):
+> after a long-running daemon was started under `GEODE_MODEL=claude-opus-4-7`,
+> a subsequent user `/model gpt-5.5` correctly mutated `settings.model`
+> + `.env` and the prompt header rendered `gpt-5.5 · autonomous
+> execution agent`, **but every actual LLM call still routed to
+> `claude-opus-4-7`** — `serve.log` confirmed `Session started:
+> model=claude-opus-4-7` for sessions opened after the switch. The
+> turn footer printed `claude-opus-4-7` (correctly reflecting the
+> real model), and `/model gpt-5.5` reported `Already using GPT-5.5`
+> from the daemon-side handler, both contradicting the prompt header.
+> Net effect: a user expecting OAuth-borrowed Codex Plus (free, hosted
+> at `chatgpt.com/backend-api/codex`) silently paid Anthropic API for
+> Opus 4.7 calls, with their prompts also flowing to Anthropic instead
+> of OpenAI/ChatGPT. Root cause: `SharedServices` cached `_model` and
+> `_provider` as dataclass fields populated once in
+> `build_shared_services()` from boot-time `settings.model`. Each new
+> `create_session()` passed `self._model` to the freshly built
+> `AgenticLoop`, so the boot-time value won every time. The drift-sync
+> path (`_sync_model_from_settings()`) only triggers when an active
+> loop runs another round — useless for new sessions in the same
+> daemon. **Fix**: remove `_model` / `_provider` dataclass fields;
+> `create_session()` now reads `settings.model` directly and resolves
+> the provider per call. The 4 `SharedServices(...)` test fixtures
+> drop those kwargs; `test_model_resolved` becomes
+> `test_model_resolved_per_session` asserting `loop.model ==
+> settings.model` after `create_session`. E2E `geode analyze "Cowboy
+> Bebop" --dry-run` unchanged at A (68.4); full pytest 4344 passed.
+
+### Fixed
+- **`core/server/supervised/services.py` — drop boot-frozen `_model` / `_provider` fields.** `SharedServices` previously held `_model: str = ""` and `_provider: str = "anthropic"` populated once at `build_shared_services()` from `settings.model`. `create_session()` passed those frozen values into every new `AgenticLoop`. After a `/model` switch, the daemon's `settings.model` changed but `self._model` was untouched, so the next session was built with the boot-time model — including its provider — even though the prompt header read the live `settings.model`. The drift-sync path doesn't run for fresh sessions, only for in-flight loops. The fix is a single change in `create_session()`: read `settings.model` and call `_resolve_provider(settings.model)` inline at the `AgenticLoop(...)` construction site, and delete the two dataclass fields plus the `_model=`, `_provider=` kwargs at `build_shared_services()`'s `SharedServices(...)` return. Tests updated: `tests/test_shared_services.py` drops `_model="claude-sonnet-4-6"` / `_provider="anthropic"` from both `services` fixtures (lines 53-60 and 167-175); `test_model_resolved` is rewritten as `test_model_resolved_per_session` to assert that a freshly built `loop.model` matches the live `settings.model` after `create_session(SessionMode.DAEMON)` — the new invariant. (`core/server/supervised/services.py`, `tests/test_shared_services.py`)
+
 ## [0.81.0] — 2026-05-08
 
 > **Dependency cleanup A4 — `core/cli/{session_checkpoint,transcript}.py` → `core/runtime_state/`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.81.0
+- **Version**: 0.82.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.81.0 — Long-running Autonomous Execution Harness
+# GEODE v0.82.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.81.0 — Long-running Autonomous Execution Harness
+# GEODE v0.82.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -105,9 +105,17 @@ class SharedServices:
     lane_queue: Any = None  # Unified LaneQueue — single concurrency gate
     tool_handlers: dict[str, Any] = field(default_factory=dict)
 
-    # Resolved once at bootstrap
-    _model: str = ""
-    _provider: str = "anthropic"
+    # v0.82.0 — Model + provider resolved fresh per session, NOT frozen at
+    # bootstrap. The previous shape (`_model: str = ""` cached at
+    # `SharedServices.create()` from `_settings.model`) caused a critical
+    # user-facing bug: a long-running daemon would honour `/model gpt-5.5`
+    # in `cmd_model` (mutates `settings.model` + .env), but every new
+    # IPC session still received the boot-time model via `self._model`.
+    # User saw "Already using GPT-5.5" in the prompt header but every
+    # LLM call still routed to `claude-opus-4-7` — silently using a
+    # different provider (paid Anthropic API instead of OAuth-borrowed
+    # Codex Plus). `create_session()` now reads `settings.model` directly
+    # so each session reflects the latest user intent.
     _cost_budget: float = 0.0
 
     # --- public API -----------------------------------------------------------
@@ -172,14 +180,20 @@ class SharedServices:
             hooks=self.hook_system,
             approval_callback=approval_cb,
         )
+        # v0.82.0 — read settings.model FRESH per session so /model command
+        # mutations propagate to every new AgenticLoop. Previously the
+        # boot-time `self._model` was used and `/model gpt-5.5` was
+        # silently ignored by every subsequent session.
+        from core.config import _resolve_provider, settings
+
         loop = AgenticLoop(
             conversation,
             executor,
             max_rounds=max_rounds,
             time_budget_s=time_budget,
             cost_budget=self._cost_budget,
-            model=self._model,
-            provider=self._provider,
+            model=settings.model,
+            provider=_resolve_provider(settings.model),
             mcp_manager=self.mcp_manager,
             skill_registry=self.skill_registry,
             hooks=self.hook_system,
@@ -241,7 +255,6 @@ def build_shared_services(
     (per-thread, no shared mutable ref).  If *hook_system* is None, a default
     HookSystem is built via ``build_hooks()``.
     """
-    from core.config import _resolve_provider
     from core.config import settings as _settings
 
     # Build hooks if not provided
@@ -293,7 +306,5 @@ def build_shared_services(
         hook_system=hook_system,
         lane_queue=lane_queue,
         tool_handlers=tool_handlers,
-        _model=_settings.model,
-        _provider=_resolve_provider(_settings.model),
         _cost_budget=cost_budget,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.81.0"
+version = "0.82.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -49,14 +49,17 @@ class TestSharedServicesCreateSession:
 
     @pytest.fixture()
     def services(self) -> SharedServices:
-        """Minimal SharedServices with mocked hook_system."""
+        """Minimal SharedServices with mocked hook_system.
+
+        v0.82.0 — `_model` / `_provider` fields removed; `create_session()`
+        reads ``settings.model`` directly so a long-running daemon
+        honours ``/model`` switches across IPC sessions.
+        """
         return SharedServices(
             mcp_manager=MagicMock(),
             skill_registry=MagicMock(),
             hook_system=MagicMock(),
             tool_handlers={"test_tool": lambda **kw: {"ok": True}},
-            _model="claude-sonnet-4-6",
-            _provider="anthropic",
             _cost_budget=5.0,
         )
 
@@ -149,9 +152,20 @@ class TestBuildSharedServices:
         services = build_shared_services()
         assert len(services.tool_handlers) > 0
 
-    def test_model_resolved(self) -> None:
+    def test_model_resolved_per_session(self) -> None:
+        """v0.82.0 — `SharedServices` no longer freezes `_model` at boot.
+
+        `create_session()` reads ``settings.model`` directly so a
+        long-running daemon honours user-driven `/model` switches.
+        Verify that the freshly constructed AgenticLoop carries the
+        live ``settings.model`` rather than a stale boot-time value.
+        """
+        from core.config import settings
+        from core.server.supervised.services import SessionMode
+
         services = build_shared_services()
-        assert services._model != ""
+        _, loop = services.create_session(SessionMode.DAEMON)
+        assert loop.model == settings.model
 
     def test_no_agentic_ref_attribute(self) -> None:
         """SharedServices should not have agentic_ref (removed in system-hardening)."""
@@ -169,8 +183,6 @@ class TestSchedulerREPLIsolation:
             skill_registry=MagicMock(),
             hook_system=MagicMock(),
             tool_handlers={"test_tool": lambda **kw: {"ok": True}},
-            _model="claude-sonnet-4-6",
-            _provider="anthropic",
             _cost_budget=5.0,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.80.0"
+version = "0.81.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **Critical fix** — `SharedServices`가 daemon 부팅 시 `_model`/`_provider` field로 freeze해서, `/model gpt-5.5` 변경 후에도 모든 새 session이 boot-time 모델로 시작되는 silent 버그.
- 사용자 영향: OAuth-borrowed Codex Plus (free) 의도 → 실제는 paid Anthropic API. prompt가 ChatGPT 대신 Anthropic으로 흐름.
- 1-2줄 fix: `_model`/`_provider` dataclass field 제거 + `create_session()`이 `settings.model` inline 조회.
- E2E Cowboy Bebop A (68.4) 변동 없음.

## Why
**OAuth OpenAI 점검 작업 중 user-facing 출력 살피며 발견.** 증상:

```
prompt 헤더:    gpt-5.5 · autonomous execution agent
turn footer:    ✢ Worked for 1s · claude-opus-4-7 · ↓6 ↑6 · $0.0002
serve.log:      Session started: model=claude-opus-4-7 (반복)
/model gpt-5.5 → "Already using GPT-5.5" (daemon 응답)
```

3가지 증거가 동일 결론:
1. 헤더는 `settings.model` 직접 읽음 → live 값 (gpt-5.5)
2. footer는 `meter.model` 읽음 → 실제 호출된 모델
3. serve.log는 daemon-side 호출 시점 model 기록

→ daemon이 `settings.model` 변경을 인지함에도 불구하고 모든 새 session은 frozen claude로 시작.

## Root cause
`core/server/supervised/services.py`:
```python
@dataclass
class SharedServices:
    ...
    _model: str = ""           # ← daemon 부팅 시 frozen
    _provider: str = "anthropic"

# build_shared_services():
return SharedServices(
    ...
    _model=_settings.model,                   # 부팅 시 한 번
    _provider=_resolve_provider(_settings.model),
)

# create_session():
loop = AgenticLoop(
    ...
    model=self._model,                        # ← 매 session boot-time 값
    provider=self._provider,
)
```

`/model gpt-5.5`은 `settings.model`을 변경하지만 `SharedServices._model`은 dataclass field라 그대로. drift-sync 메커니즘(`_sync_model_from_settings`)은 in-flight loop에만 적용 — 새 session은 이미 stale 값으로 init됨.

## Changes
| File | Change |
|------|--------|
| `core/server/supervised/services.py` | `_model` / `_provider` dataclass field 제거 (10 LOC 주석 추가, 코멘트로 결함 설명). `create_session()`에서 `from core.config import _resolve_provider, settings` 후 `model=settings.model, provider=_resolve_provider(settings.model)` inline. `build_shared_services()`의 `_model=_settings.model` / `_provider=_resolve_provider(_settings.model)` kwarg 2줄 제거 |
| `tests/test_shared_services.py` | 2개 fixture에서 `_model="claude-sonnet-4-6"` / `_provider="anthropic"` kwargs 제거. `test_model_resolved` → `test_model_resolved_per_session`으로 갱신: `loop.model == settings.model` after `create_session(DAEMON)` 검증 |
| `CHANGELOG.md` / `pyproject.toml` / `CLAUDE.md` / `README.md` / `README.ko.md` | 0.81.0 → 0.82.0 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `_model`/`_provider` field 제거 | Implemented | dataclass declaration 2줄 제거, 자세한 주석으로 v0.82.0 결정 기록 |
| `create_session()` inline 조회 | Implemented | function-local helper var 없이 `settings.model` 직접 사용 (사용자 underscore 정책 준수) |
| `build_shared_services()` kwarg 제거 | Implemented | `_model=` `_provider=` 2줄 제거. 미사용 import 자동 정리 |
| 테스트 fixture 갱신 | Implemented | 2개 fixture 갱신 + `test_model_resolved_per_session` 신규 invariant |
| 함수 signature 보존 | Verified | AgenticLoop.__init__ signature 그대로 — model/provider 인자 같음 |

## Verification
- [x] ruff check / ruff format 통과 (330 source files)
- [x] mypy 통과 (0 issues)
- [x] pytest 4344 passed, 1 skipped, 24 deselected — A4 직후와 동일
- [x] test_shared_services 27/27 통과
- [x] import-linter 4/4 contracts kept
- [x] E2E Cowboy Bebop A (68.4) 변동 없음

## 후속 점검 필요 (별도 PR)
이번 점검 중 발견된 다른 user-facing 결함:
- `init_session_meter()`가 `model` 인자 없이 호출되면 `ANTHROPIC_PRIMARY` hard-default → footer 모델 표시가 GEODE_MODEL 환경 변수 무시
- stdin이 non-TTY일 때 spinner `⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼` 200+회 출력 (CI 로그 오염)
이 PR 범위는 핵심 silent provider mismatch만. 부수 결함은 별도 issue/PR.

## Reference
- 점검 trigger: 사용자 "oauth openai를 기반으로 실제 콜과 user가 볼 수 있는 출력을 살피면서 점검해"
- v0.49 model hot-swap 작업의 design gap이 이 시점까지 발견 안 됨