### PR TITLE
release: v0.82.0 — SharedServices model freeze critical fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.82.0] — 2026-05-08
+
+> **Critical fix — `SharedServices` no longer freezes the active LLM
+> model at daemon boot.** Discovered while live-testing OAuth-OpenAI
+> codex routing. Symptom (extremely subtle, silently swaps providers):
+> after a long-running daemon was started under `GEODE_MODEL=claude-opus-4-7`,
+> a subsequent user `/model gpt-5.5` correctly mutated `settings.model`
+> + `.env` and the prompt header rendered `gpt-5.5 · autonomous
+> execution agent`, **but every actual LLM call still routed to
+> `claude-opus-4-7`** — `serve.log` confirmed `Session started:
+> model=claude-opus-4-7` for sessions opened after the switch. The
+> turn footer printed `claude-opus-4-7` (correctly reflecting the
+> real model), and `/model gpt-5.5` reported `Already using GPT-5.5`
+> from the daemon-side handler, both contradicting the prompt header.
+> Net effect: a user expecting OAuth-borrowed Codex Plus (free, hosted
+> at `chatgpt.com/backend-api/codex`) silently paid Anthropic API for
+> Opus 4.7 calls, with their prompts also flowing to Anthropic instead
+> of OpenAI/ChatGPT. Root cause: `SharedServices` cached `_model` and
+> `_provider` as dataclass fields populated once in
+> `build_shared_services()` from boot-time `settings.model`. Each new
+> `create_session()` passed `self._model` to the freshly built
+> `AgenticLoop`, so the boot-time value won every time. The drift-sync
+> path (`_sync_model_from_settings()`) only triggers when an active
+> loop runs another round — useless for new sessions in the same
+> daemon. **Fix**: remove `_model` / `_provider` dataclass fields;
+> `create_session()` now reads `settings.model` directly and resolves
+> the provider per call. The 4 `SharedServices(...)` test fixtures
+> drop those kwargs; `test_model_resolved` becomes
+> `test_model_resolved_per_session` asserting `loop.model ==
+> settings.model` after `create_session`. E2E `geode analyze "Cowboy
+> Bebop" --dry-run` unchanged at A (68.4); full pytest 4344 passed.
+
+### Fixed
+- **`core/server/supervised/services.py` — drop boot-frozen `_model` / `_provider` fields.** `SharedServices` previously held `_model: str = ""` and `_provider: str = "anthropic"` populated once at `build_shared_services()` from `settings.model`. `create_session()` passed those frozen values into every new `AgenticLoop`. After a `/model` switch, the daemon's `settings.model` changed but `self._model` was untouched, so the next session was built with the boot-time model — including its provider — even though the prompt header read the live `settings.model`. The drift-sync path doesn't run for fresh sessions, only for in-flight loops. The fix is a single change in `create_session()`: read `settings.model` and call `_resolve_provider(settings.model)` inline at the `AgenticLoop(...)` construction site, and delete the two dataclass fields plus the `_model=`, `_provider=` kwargs at `build_shared_services()`'s `SharedServices(...)` return. Tests updated: `tests/test_shared_services.py` drops `_model="claude-sonnet-4-6"` / `_provider="anthropic"` from both `services` fixtures (lines 53-60 and 167-175); `test_model_resolved` is rewritten as `test_model_resolved_per_session` to assert that a freshly built `loop.model` matches the live `settings.model` after `create_session(SessionMode.DAEMON)` — the new invariant. (`core/server/supervised/services.py`, `tests/test_shared_services.py`)
+
 ## [0.81.0] — 2026-05-08
 
 > **Dependency cleanup A4 — `core/cli/{session_checkpoint,transcript}.py` → `core/runtime_state/`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.81.0
+- **Version**: 0.82.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.81.0 — Long-running Autonomous Execution Harness
+# GEODE v0.82.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.81.0 — Long-running Autonomous Execution Harness
+# GEODE v0.82.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -105,9 +105,17 @@ class SharedServices:
     lane_queue: Any = None  # Unified LaneQueue — single concurrency gate
     tool_handlers: dict[str, Any] = field(default_factory=dict)
 
-    # Resolved once at bootstrap
-    _model: str = ""
-    _provider: str = "anthropic"
+    # v0.82.0 — Model + provider resolved fresh per session, NOT frozen at
+    # bootstrap. The previous shape (`_model: str = ""` cached at
+    # `SharedServices.create()` from `_settings.model`) caused a critical
+    # user-facing bug: a long-running daemon would honour `/model gpt-5.5`
+    # in `cmd_model` (mutates `settings.model` + .env), but every new
+    # IPC session still received the boot-time model via `self._model`.
+    # User saw "Already using GPT-5.5" in the prompt header but every
+    # LLM call still routed to `claude-opus-4-7` — silently using a
+    # different provider (paid Anthropic API instead of OAuth-borrowed
+    # Codex Plus). `create_session()` now reads `settings.model` directly
+    # so each session reflects the latest user intent.
     _cost_budget: float = 0.0
 
     # --- public API -----------------------------------------------------------
@@ -172,14 +180,20 @@ class SharedServices:
             hooks=self.hook_system,
             approval_callback=approval_cb,
         )
+        # v0.82.0 — read settings.model FRESH per session so /model command
+        # mutations propagate to every new AgenticLoop. Previously the
+        # boot-time `self._model` was used and `/model gpt-5.5` was
+        # silently ignored by every subsequent session.
+        from core.config import _resolve_provider, settings
+
         loop = AgenticLoop(
             conversation,
             executor,
             max_rounds=max_rounds,
             time_budget_s=time_budget,
             cost_budget=self._cost_budget,
-            model=self._model,
-            provider=self._provider,
+            model=settings.model,
+            provider=_resolve_provider(settings.model),
             mcp_manager=self.mcp_manager,
             skill_registry=self.skill_registry,
             hooks=self.hook_system,
@@ -241,7 +255,6 @@ def build_shared_services(
     (per-thread, no shared mutable ref).  If *hook_system* is None, a default
     HookSystem is built via ``build_hooks()``.
     """
-    from core.config import _resolve_provider
     from core.config import settings as _settings
 
     # Build hooks if not provided
@@ -293,7 +306,5 @@ def build_shared_services(
         hook_system=hook_system,
         lane_queue=lane_queue,
         tool_handlers=tool_handlers,
-        _model=_settings.model,
-        _provider=_resolve_provider(_settings.model),
         _cost_budget=cost_budget,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.81.0"
+version = "0.82.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -49,14 +49,17 @@ class TestSharedServicesCreateSession:
 
     @pytest.fixture()
     def services(self) -> SharedServices:
-        """Minimal SharedServices with mocked hook_system."""
+        """Minimal SharedServices with mocked hook_system.
+
+        v0.82.0 — `_model` / `_provider` fields removed; `create_session()`
+        reads ``settings.model`` directly so a long-running daemon
+        honours ``/model`` switches across IPC sessions.
+        """
         return SharedServices(
             mcp_manager=MagicMock(),
             skill_registry=MagicMock(),
             hook_system=MagicMock(),
             tool_handlers={"test_tool": lambda **kw: {"ok": True}},
-            _model="claude-sonnet-4-6",
-            _provider="anthropic",
             _cost_budget=5.0,
         )
 
@@ -149,9 +152,20 @@ class TestBuildSharedServices:
         services = build_shared_services()
         assert len(services.tool_handlers) > 0
 
-    def test_model_resolved(self) -> None:
+    def test_model_resolved_per_session(self) -> None:
+        """v0.82.0 — `SharedServices` no longer freezes `_model` at boot.
+
+        `create_session()` reads ``settings.model`` directly so a
+        long-running daemon honours user-driven `/model` switches.
+        Verify that the freshly constructed AgenticLoop carries the
+        live ``settings.model`` rather than a stale boot-time value.
+        """
+        from core.config import settings
+        from core.server.supervised.services import SessionMode
+
         services = build_shared_services()
-        assert services._model != ""
+        _, loop = services.create_session(SessionMode.DAEMON)
+        assert loop.model == settings.model
 
     def test_no_agentic_ref_attribute(self) -> None:
         """SharedServices should not have agentic_ref (removed in system-hardening)."""
@@ -169,8 +183,6 @@ class TestSchedulerREPLIsolation:
             skill_registry=MagicMock(),
             hook_system=MagicMock(),
             tool_handlers={"test_tool": lambda **kw: {"ok": True}},
-            _model="claude-sonnet-4-6",
-            _provider="anthropic",
             _cost_budget=5.0,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.80.0"
+version = "0.81.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **v0.82.0 critical fix** — `SharedServices`가 daemon 부팅 시 `_model`/`_provider`를 frozen field로 보유, `/model` 변경이 새 session에 반영 안 되던 silent provider mismatch 결함 해소.
- 사용자 영향: OAuth-borrowed Codex Plus (free) 의도 → 실제는 Anthropic API. prompt가 ChatGPT 대신 Anthropic으로 흐름.
- 8 files, +78/-20. E2E Cowboy Bebop A (68.4) 변동 없음.

## Verification
- [x] CI 5/5 통과 (PR #919)
- [x] pytest 4344 passed, 1 skipped, 24 deselected
- [x] test_shared_services 27/27
- [x] import-linter 4/4 contracts kept