### PR TITLE
fix(v0.83.0): init_session_meter() default을 settings.model로 (v0.82.0 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.83.0] — 2026-05-08
+
+> **Footer model display follow-up to v0.82.0.** v0.82.0 fixed the
+> *actual LLM call routing* (frozen `SharedServices._model` was
+> overriding `/model` switches), but the per-turn footer
+> (`✢ Worked for Xs · model · ↓in ↑out · $cost`) still hard-coded
+> `claude-opus-4-7` whenever a session started without an explicit
+> model argument. Root cause: `init_session_meter(model="")` defaulted
+> to `ANTHROPIC_PRIMARY` instead of `settings.model`, and the only
+> caller (`core/server/ipc_server/poller.py:305`) calls it with no
+> arguments. Now defaults to `settings.model or ANTHROPIC_PRIMARY` so
+> what the user sees in the footer matches the live user-selected
+> model. E2E `geode analyze "Cowboy Bebop" --dry-run` unchanged at
+> A (68.4); full pytest 4344 passed.
+
+### Fixed
+- **`core/ui/agentic_ui/_state.py:init_session_meter` — default to live `settings.model`.** When the optional `model` argument is empty, fall back to `settings.model` (the value `_apply_model` mutates on `/model` switches) before falling back to `ANTHROPIC_PRIMARY` as a final safety net. Pairs with v0.82.0's `SharedServices` fix: that change made the *actual* LLM call route to the live model, this change makes the *displayed* model in the per-turn footer match. The single caller (`core/server/ipc_server/poller.py:305`) already passes no argument, so this fix lights up automatically — no caller changes needed. (`core/ui/agentic_ui/_state.py`)
+
 ## [0.82.0] — 2026-05-08
 
 > **Critical fix — `SharedServices` no longer freezes the active LLM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.82.0
+- **Version**: 0.83.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.82.0 — Long-running Autonomous Execution Harness
+# GEODE v0.83.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.82.0 — Long-running Autonomous Execution Harness
+# GEODE v0.83.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/ui/agentic_ui/_state.py
+++ b/core/ui/agentic_ui/_state.py
@@ -102,11 +102,20 @@ def init_session_meter(model: str = "") -> SessionMeter:
     own ``SessionMeter`` instance via ``threading.local``, preventing
     cross-session contamination of model names, elapsed times, and
     token counters.
+
+    v0.83.0 — when ``model`` is omitted, fall back to the live
+    ``settings.model`` (which `_apply_model` mutates on `/model`
+    switches) instead of the hard-coded ``ANTHROPIC_PRIMARY``. The old
+    shape always defaulted to anthropic, so callers like ``poller.py``
+    that did ``init_session_meter()`` left the per-turn footer
+    hard-stuck on ``claude-opus-4-7`` even after the user switched to
+    ``gpt-5.5``. Pairs with v0.82.0 which fixed the *actual* call
+    routing — this fixes the *displayed* model so the footer matches.
     """
     if not model:
-        from core.config import ANTHROPIC_PRIMARY
+        from core.config import ANTHROPIC_PRIMARY, settings
 
-        model = ANTHROPIC_PRIMARY
+        model = settings.model or ANTHROPIC_PRIMARY
     meter = SessionMeter(model=model)
     _meter_local.meter = meter
     return meter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.82.0"
+version = "0.83.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.81.0"
+version = "0.82.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **v0.82.0 follow-up.** v0.82.0가 실제 LLM call routing을 fix했지만, 매 턴 footer는 여전히 `claude-opus-4-7`로 고정 표시됨.
- Root cause: `init_session_meter("")` → `ANTHROPIC_PRIMARY` hard-default. `poller.py:305` 호출자가 인자 없이 호출.
- 1줄 변경: default fallback을 `settings.model or ANTHROPIC_PRIMARY`로.
- E2E Cowboy Bebop A (68.4) 변동 없음.

## Why
v0.82.0 점검 중 발견한 결함 트라이어드 중 두 번째. 사용자가 GPT-5.5로 model 변경 후:
- 헤더(`gpt-5.5 · autonomous execution agent`): `settings.model` 직접 읽음 ✓
- 실제 LLM 호출(serve.log): v0.82.0 fix 후 `gpt-5.5` ✓
- 매 턴 footer(`✢ Worked for Xs · model ·`): `init_session_meter()`의 ANTHROPIC_PRIMARY default 때문에 `claude-opus-4-7` 고정 표시 ✗

`poller.py:305`가 `init_session_meter()`를 인자 없이 호출 → 인자 없으면 `_state.py:99`에서 `from core.config import ANTHROPIC_PRIMARY; model = ANTHROPIC_PRIMARY`로 hardcoded.

## Changes
| File | Change |
|------|--------|
| `core/ui/agentic_ui/_state.py:init_session_meter` | `if not model: from core.config import ANTHROPIC_PRIMARY, settings; model = settings.model or ANTHROPIC_PRIMARY` |
| `CHANGELOG.md` / `pyproject.toml` / `CLAUDE.md` / `README.md` / `README.ko.md` | 0.82.0 → 0.83.0 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `ANTHROPIC_PRIMARY` 직접 default 제거 | Implemented | `settings.model or ANTHROPIC_PRIMARY` — 안전 fallback 보존 |
| 호출자 변경 0 | Verified | 단일 호출자 `poller.py:305`가 이미 인자 없이 호출 → 자동 적용 |
| underscore 변수 사용 안 함 | Verified | 사용자 정책 준수 (function-local helper var 없음) |
| import-linter 4 contracts | Verified | 4/4 kept |

## Verification
- [x] ruff check / ruff format 통과
- [x] mypy 통과 (330 source files, 0 issues)
- [x] pytest 4344 passed, 1 skipped, 24 deselected — v0.82.0 직후와 동일
- [x] agentic_ui + e2e 82+ 테스트 통과
- [x] **v0.82.0 + v0.83.0 페어로 헤더/footer/serve.log 모두 동일 model 표시**

## Reference
- v0.82.0 PR #919 (`SharedServices` model freeze fix)
- 점검 trigger: 사용자 "oauth openai를 기반으로 실제 콜과 user가 볼 수 있는 출력을 살피면서 점검해"