### PR TITLE
release: v0.83.0 — init_session_meter footer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.83.0] — 2026-05-08
+
+> **Footer model display follow-up to v0.82.0.** v0.82.0 fixed the
+> *actual LLM call routing* (frozen `SharedServices._model` was
+> overriding `/model` switches), but the per-turn footer
+> (`✢ Worked for Xs · model · ↓in ↑out · $cost`) still hard-coded
+> `claude-opus-4-7` whenever a session started without an explicit
+> model argument. Root cause: `init_session_meter(model="")` defaulted
+> to `ANTHROPIC_PRIMARY` instead of `settings.model`, and the only
+> caller (`core/server/ipc_server/poller.py:305`) calls it with no
+> arguments. Now defaults to `settings.model or ANTHROPIC_PRIMARY` so
+> what the user sees in the footer matches the live user-selected
+> model. E2E `geode analyze "Cowboy Bebop" --dry-run` unchanged at
+> A (68.4); full pytest 4344 passed.
+
+### Fixed
+- **`core/ui/agentic_ui/_state.py:init_session_meter` — default to live `settings.model`.** When the optional `model` argument is empty, fall back to `settings.model` (the value `_apply_model` mutates on `/model` switches) before falling back to `ANTHROPIC_PRIMARY` as a final safety net. Pairs with v0.82.0's `SharedServices` fix: that change made the *actual* LLM call route to the live model, this change makes the *displayed* model in the per-turn footer match. The single caller (`core/server/ipc_server/poller.py:305`) already passes no argument, so this fix lights up automatically — no caller changes needed. (`core/ui/agentic_ui/_state.py`)
+
 ## [0.82.0] — 2026-05-08
 
 > **Critical fix — `SharedServices` no longer freezes the active LLM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.82.0
+- **Version**: 0.83.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.82.0 — Long-running Autonomous Execution Harness
+# GEODE v0.83.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.82.0 — Long-running Autonomous Execution Harness
+# GEODE v0.83.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/ui/agentic_ui/_state.py
+++ b/core/ui/agentic_ui/_state.py
@@ -102,11 +102,20 @@ def init_session_meter(model: str = "") -> SessionMeter:
     own ``SessionMeter`` instance via ``threading.local``, preventing
     cross-session contamination of model names, elapsed times, and
     token counters.
+
+    v0.83.0 — when ``model`` is omitted, fall back to the live
+    ``settings.model`` (which `_apply_model` mutates on `/model`
+    switches) instead of the hard-coded ``ANTHROPIC_PRIMARY``. The old
+    shape always defaulted to anthropic, so callers like ``poller.py``
+    that did ``init_session_meter()`` left the per-turn footer
+    hard-stuck on ``claude-opus-4-7`` even after the user switched to
+    ``gpt-5.5``. Pairs with v0.82.0 which fixed the *actual* call
+    routing — this fixes the *displayed* model so the footer matches.
     """
     if not model:
-        from core.config import ANTHROPIC_PRIMARY
+        from core.config import ANTHROPIC_PRIMARY, settings
 
-        model = ANTHROPIC_PRIMARY
+        model = settings.model or ANTHROPIC_PRIMARY
     meter = SessionMeter(model=model)
     _meter_local.meter = meter
     return meter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.82.0"
+version = "0.83.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.81.0"
+version = "0.82.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **v0.83.0 follow-up to v0.82.0** — `init_session_meter()` ANTHROPIC_PRIMARY hard-default을 `settings.model or ANTHROPIC_PRIMARY`로. 매 턴 footer가 live model 표시.
- 사용자가 보는 모든 model 표시 (헤더 + footer + serve.log)가 일관되게 동일 model.
- E2E Cowboy Bebop A (68.4) 변동 없음.

## Verification
- [x] CI 5/5 통과 (PR #921)
- [x] pytest 4344 passed, 1 skipped, 24 deselected
- [x] import-linter 4/4 contracts kept