### PR TITLE
fix(v0.84.0): IPC TTY capability propagation — OAuth 점검 trilogy 완성

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,38 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.84.0] — 2026-05-08
+
+> **OAuth point-check trilogy completion — IPC TTY capability propagation.**
+> Third and final fix in the OAuth-OpenAI live-test inspection. v0.82.0
+> fixed the *actual LLM call routing* (frozen `SharedServices._model`).
+> v0.83.0 fixed the *footer model display* (`init_session_meter` hard
+> default). v0.84.0 fixes the *output noise* — when the thin CLI's
+> stdout/stdin is not a terminal (heredoc, pipe, CI), the daemon was
+> still emitting Rich braille spinner frames `⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼` and ANSI
+> cursor sequences into the socket because `make_session_console`
+> hard-coded `force_terminal=True`. Per-turn output got polluted with
+> 200+ spinner frames. The thin CLI just wrote the bytes to stdout
+> as-is. Fix: thin CLI sends a `client_capability` message right
+> after `connect()` carrying its own `is_tty` (= `stdin.isatty() and
+> stdout.isatty()`) and `width` (`shutil.get_terminal_size().columns`).
+> The daemon stores this in a thread-local; the per-thread Console
+> built for that IPC handler thread inherits the client's TTY state
+> and width. `_tool_spinner` also got a second non-TTY guard for
+> direct (non-IPC) REPL piping to a file. Backward compatible: old
+> thin clients that don't send the message keep the previous behavior
+> (`is_tty=True, width=120`). E2E `geode analyze "Cowboy Bebop"
+> --dry-run` unchanged at A (68.4); pytest **4345 passed** (+1 new
+> IPC test asserting the daemon-side Console mirrors a non-TTY
+> client's state).
+
+### Fixed
+- **`core/cli/ipc_client.py` — send `client_capability` on connect.** New helper `_send_client_capability()` runs after the session greeting is read in `connect()`. Reads `sys.stdin.isatty() and sys.stdout.isatty()` for `is_tty` and `shutil.get_terminal_size().columns` (clamped) for `width`. Sends `{"type": "client_capability", "is_tty": ..., "width": ...}` and drains the daemon's `ack` so subsequent one-shot commands (`send_command`, `request_resume`) see their actual response, not the stale capability ack. (`core/cli/ipc_client.py` +47L)
+- **`core/server/ipc_server/poller.py` — accept and apply `client_capability`.** New module-level `_client_capability_local` `threading.local()` with a `_get_client_capability()` accessor that defaults to `(is_tty=True, width=120)` for backward compat. New `client_capability` message handler in `_process_message`. `_run_prompt_streaming` reads the stored capability at session-start and passes it through to `make_session_console(writer, force_terminal=is_tty, width=width)`. (`core/server/ipc_server/poller.py` +39L)
+- **`core/ui/console.py:make_session_console` — accept `force_terminal` + `width` kwargs.** Both have backward-compatible defaults (`True`, `120`). Truecolor color system is only forced when `force_terminal=True` so non-TTY sessions don't get the ANSI escape soup either. (`core/ui/console.py` +24/-6L)
+- **`core/agent/tool_executor/_spinner.py:_tool_spinner` — non-TTY guard for direct REPL piping.** The IPC-mode early-return is unchanged. Added a second guard that checks `_pkg.console.is_terminal` after the IPC check so a *local* REPL piped to a file or running under CI also skips the spinner instead of emitting braille frames + cursor controls. (`core/agent/tool_executor/_spinner.py` +14L)
+- **`tests/test_phase3_ipc.py` — new test `test_client_capability_non_tty_disables_ansi`.** Patches `sys.stdin.isatty`/`sys.stdout.isatty` to return False and `shutil.get_terminal_size` to return `(80, 24)`, connects via `IPCClient`, then asserts the daemon-side per-thread Rich Console has `is_terminal == False` and `width == 80`. (`tests/test_phase3_ipc.py` +62L, +1 test → 4345 total passing)
+
 ## [0.83.0] — 2026-05-08
 
 > **Footer model display follow-up to v0.82.0.** v0.82.0 fixed the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.83.0
+- **Version**: 0.84.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 301 core + 29 plugins = 330
-- **Tests**: 4344 (+24 live)
+- **Tests**: 4345 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.83.0 — Long-running Autonomous Execution Harness
+# GEODE v0.84.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.83.0 — Long-running Autonomous Execution Harness
+# GEODE v0.84.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/agent/tool_executor/_spinner.py
+++ b/core/agent/tool_executor/_spinner.py
@@ -15,6 +15,10 @@ def _tool_spinner(label: str) -> Iterator[None]:
 
     Skipped in IPC mode — thin CLI has its own ToolCallTracker spinner.
     Running both causes ANSI cursor-up race → UI corruption.
+
+    Also skipped when the active console is non-TTY (e.g. local REPL
+    piped to a file, CI). v0.84.0 — prevents braille spinner frames
+    from polluting non-terminal output.
     """
     # IPC mode: ToolCallTracker on thin CLI handles the spinner
     from core.ui.agentic_ui import _ipc_writer_local
@@ -26,6 +30,12 @@ def _tool_spinner(label: str) -> Iterator[None]:
     # Lookup `console` via the package namespace so tests patching
     # `core.agent.tool_executor.console` affect this code path.
     from core.agent import tool_executor as _pkg
+
+    # Non-TTY path (local REPL piped, CI). Rich's spinner emits cursor
+    # control + braille frames that look like garbage in a log file.
+    if not getattr(_pkg.console, "is_terminal", True):
+        yield
+        return
 
     status = _pkg.console.status(f"  [dim]✢ {label}[/dim]", spinner="dots", spinner_style="cyan")
     status.start()

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -120,7 +120,15 @@ class IPCClient:
         self.session_id: str = ""
 
     def connect(self) -> bool:
-        """Connect to serve. Returns True on success."""
+        """Connect to serve. Returns True on success.
+
+        Right after the session greeting is received, sends a
+        ``client_capability`` message describing the thin CLI's actual
+        terminal state (TTY-ness, width). The daemon uses these values
+        when constructing the per-thread Rich Console so that ANSI
+        escape sequences and spinner frames are suppressed when the
+        thin CLI's stdout is not a terminal (heredoc, pipe, CI).
+        """
         try:
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self._sock.connect(str(self._socket_path))
@@ -129,11 +137,48 @@ class IPCClient:
             if msg and msg.get("type") == "session":
                 self.session_id = msg.get("session_id", "")
                 log.info("Connected to serve (session=%s)", self.session_id)
+            # Send terminal capability so the daemon knows whether to
+            # emit ANSI / spinner output (v0.84.0). The daemon replies
+            # with an ``ack`` which we drain here so subsequent
+            # one-shot reads (``send_command`` / ``request_resume``)
+            # see their actual response, not the stale ack.
+            self._send_client_capability()
+            ack = self._recv()
+            if ack and ack.get("type") != "ack":
+                log.debug("Unexpected response to client_capability: %s", ack)
             return True
         except (ConnectionRefusedError, OSError) as exc:
             log.debug("IPC connect failed: %s", exc)
             self._sock = None
             return False
+
+    def _send_client_capability(self) -> None:
+        """Send terminal capability to the daemon.
+
+        Reports ``is_tty`` (both stdin and stdout are terminals) and
+        ``width`` (terminal columns, falling back to 120). The daemon
+        ignores unknown fields, so old daemons stay compatible.
+        """
+        import shutil
+        import sys
+
+        try:
+            is_tty = bool(sys.stdin.isatty() and sys.stdout.isatty())
+        except (ValueError, OSError):
+            is_tty = False
+        try:
+            width = int(shutil.get_terminal_size().columns)
+        except (ValueError, OSError):
+            width = 120
+        if width <= 0:
+            width = 120
+        self._send(
+            {
+                "type": "client_capability",
+                "is_tty": is_tty,
+                "width": width,
+            }
+        )
 
     def close(self) -> None:
         """Disconnect from serve."""

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -37,6 +37,26 @@ if TYPE_CHECKING:
 
 DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
 
+# Thread-local terminal capability advertised by the connected thin CLI.
+# v0.84.0 — populated when the daemon receives a ``client_capability``
+# message. Read by ``_run_prompt_streaming`` to construct the per-thread
+# Rich Console with the client's actual TTY-ness and width, so ANSI /
+# spinner output is suppressed when the thin CLI's stdout is not a TTY.
+_client_capability_local = threading.local()
+
+
+def _get_client_capability() -> tuple[bool, int]:
+    """Return ``(is_tty, width)`` for the current handler thread.
+
+    Defaults to ``(True, 120)`` for backward compatibility with thin
+    clients that don't send a ``client_capability`` message.
+    """
+    is_tty = bool(getattr(_client_capability_local, "is_tty", True))
+    width = int(getattr(_client_capability_local, "width", 120))
+    if width <= 0:
+        width = 120
+    return is_tty, width
+
 
 class _StreamingWriter:
     """File-like object that relays console writes to a client socket.
@@ -391,6 +411,22 @@ class CLIPoller:
         if msg_type == "resume":
             return self._handle_resume(msg, loop, conversation)
 
+        # v0.84.0 — thin CLI advertises terminal capability so the daemon
+        # can suppress ANSI / spinner output when stdout is not a TTY.
+        if msg_type == "client_capability":
+            is_tty = bool(msg.get("is_tty", True))
+            width_raw = msg.get("width", 120)
+            try:
+                width = int(width_raw)
+            except (TypeError, ValueError):
+                width = 120
+            if width <= 0:
+                width = 120
+            _client_capability_local.is_tty = is_tty
+            _client_capability_local.width = width
+            log.debug("client_capability: is_tty=%s width=%d", is_tty, width)
+            return {"type": "ack"}
+
         # Stale approval_response from a timed-out request — silently drop
         if msg_type == "approval_response":
             log.debug("Dropping stale approval_response: %s", msg.get("decision"))
@@ -430,7 +466,8 @@ class CLIPoller:
         # Thread-local console: all console.print() in this thread → client socket
         writer = _StreamingWriter(client) if client else None
         if writer:
-            set_thread_console(make_session_console(writer))
+            is_tty, width = _get_client_capability()
+            set_thread_console(make_session_console(writer, force_terminal=is_tty, width=width))
             _ipc_writer_local.writer = writer
 
         try:

--- a/core/ui/console.py
+++ b/core/ui/console.py
@@ -147,16 +147,30 @@ def reset_thread_console() -> None:
     _ConsoleProxy._local.__dict__.pop("console", None)
 
 
-def make_session_console(file: Any) -> Console:
+def make_session_console(
+    file: Any,
+    *,
+    force_terminal: bool = True,
+    width: int = 120,
+) -> Console:
     """Create a session-scoped Console writing to *file*.
 
-    Returns a fully configured Console with the GEODE theme, forced
-    ANSI output, and truecolor — suitable for IPC streaming writers.
+    Returns a fully configured Console with the GEODE theme — suitable
+    for IPC streaming writers.
+
+    v0.84.0 — ``force_terminal`` and ``width`` are now propagated from
+    the thin CLI via the ``client_capability`` IPC message. When the
+    thin client's stdout is not a TTY (heredoc, pipe, CI), the daemon
+    constructs the per-thread Console with ``force_terminal=False`` so
+    Rich emits plain text instead of ANSI cursor-up / spinner braille
+    frames. The truecolor color-system override is still applied when
+    ANSI output is requested, mirroring the previous behavior.
     """
     from rich.color import ColorSystem
 
-    c = Console(theme=GEODE_THEME, file=file, force_terminal=True, width=120)
-    c._color_system = ColorSystem.TRUECOLOR
+    c = Console(theme=GEODE_THEME, file=file, force_terminal=force_terminal, width=width)
+    if force_terminal:
+        c._color_system = ColorSystem.TRUECOLOR
     return c
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.83.0"
+version = "0.84.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_phase3_ipc.py
+++ b/tests/test_phase3_ipc.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -458,6 +459,67 @@ class TestCLIChannelIntegration:
             result = client.request_resume(session_id="s-nonexistent")
             assert result["type"] == "resume_error"
 
+            client.close()
+        finally:
+            poller.stop()
+
+    def test_client_capability_non_tty_disables_ansi(self) -> None:
+        """v0.84.0 — non-TTY client capability propagates to daemon-side Console.
+
+        When the thin CLI advertises ``is_tty=False`` at connect time,
+        the daemon's per-thread Rich Console for that session must be
+        constructed with ``force_terminal=False`` so spinners and ANSI
+        cursor-control codes don't pollute the client's stdout.
+        """
+        from unittest.mock import patch
+
+        from core.cli.ipc_client import IPCClient
+        from core.server.ipc_server.poller import CLIPoller
+        from core.ui.console import _ConsoleProxy
+
+        sock_path = _test_sock()
+        mock_services = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.text = "ok"
+        mock_result.rounds = 1
+        mock_result.tool_calls = []
+        mock_result.termination_reason = "natural"
+        mock_result.summary = ""
+
+        captured: dict[str, Any] = {}
+
+        def capture_console(prompt: str) -> Any:
+            console_at_runtime = getattr(_ConsoleProxy._local, "console", None)
+            captured["is_terminal"] = console_at_runtime.is_terminal if console_at_runtime else None
+            captured["width"] = console_at_runtime.width if console_at_runtime else None
+            return mock_result
+
+        mock_loop = MagicMock()
+        mock_loop.run.side_effect = capture_console
+        mock_loop.model = "test-model"
+        mock_services.create_session.return_value = (MagicMock(), mock_loop)
+        mock_services.lane_queue = None  # bypass lane queue
+
+        poller = CLIPoller(mock_services, socket_path=sock_path)
+        poller.start()
+        time.sleep(0.1)
+
+        try:
+            client = IPCClient(socket_path=sock_path)
+            # Patch isatty/terminal-size so capability reports non-TTY
+            with (
+                patch("sys.stdin.isatty", return_value=False),
+                patch("sys.stdout.isatty", return_value=False),
+                patch("shutil.get_terminal_size") as size_mock,
+            ):
+                size_mock.return_value = type("S", (), {"columns": 80, "lines": 24})()
+                assert client.connect()
+            time.sleep(0.05)  # let daemon process client_capability
+
+            client.send_prompt("hello")
+            assert captured.get("is_terminal") is False
+            assert captured.get("width") == 80
             client.close()
         finally:
             poller.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.82.0"
+version = "0.83.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **OAuth-OpenAI 점검 trilogy 마지막 fix.** v0.82.0(call routing) + v0.83.0(footer) + v0.84.0(output noise)으로 3개 결함 모두 처리.
- thin CLI가 connect 시 `is_tty`/`width` 송신 → daemon이 thread-local 저장 → per-thread Rich Console에 반영 → spinner/ANSI 오염 해소.
- 4 production files + 1 test file. Backward compat 보장 (옛 thin clients도 동작).
- E2E Cowboy Bebop A (68.4) 변동 없음. **pytest 4345 passed (+1 new)**.

## Why
사용자 OAuth 점검 요청 중 발견한 결함 trilogy 마지막. heredoc REPL 입력 시 daemon이 다음과 같은 출력을 socket으로 흘려 보냄:

```
[2K  ⠴ Working...[2K  ⠦ Working...[2K  ⠧ Working...[2K  ⠇ Working...[2K  ⠏ Working...
[2K  ⠋ Working...[2K  ⠙ Working...[2K  ⠹ Working...[2K  ⠸ Working...[2K  ⠼ Working...
... (200+회 반복)
```

thin CLI는 raw bytes 그대로 stdout으로 write — non-TTY일 때 braille frames + ANSI cursor sequences가 그대로 노출됨.

Root cause: `core/ui/console.py:make_session_console`이 `force_terminal=True`로 hard-code. thin CLI의 TTY 상태를 daemon이 인지할 경로 없음.

## Changes
| File | Change |
|------|--------|
| `core/cli/ipc_client.py` (+47L) | `_send_client_capability()` 헬퍼 추가. `connect()`에서 session greeting 수신 후 `{"type": "client_capability", "is_tty": ..., "width": ...}` 송신 + daemon ack 드레인 |
| `core/server/ipc_server/poller.py` (+39L) | `_client_capability_local` thread-local + `_get_client_capability()` accessor (default `(True, 120)`). `client_capability` 메시지 핸들러. `_run_prompt_streaming` 가 capability 읽어 `make_session_console(force_terminal=is_tty, width=width)` 전달 |
| `core/ui/console.py` (+24/-6L) | `make_session_console(file, *, force_terminal=True, width=120)` kwargs 추가. truecolor도 force_terminal=True일 때만 |
| `core/agent/tool_executor/_spinner.py` (+14L) | local REPL 직접 piped/CI 시나리오용 추가 guard — `_pkg.console.is_terminal == False`이면 yield only |
| `tests/test_phase3_ipc.py` (+62L) | `test_client_capability_non_tty_disables_ansi` — `sys.stdin/stdout.isatty` patch + `shutil.get_terminal_size` patch + `IPCClient.connect()` 후 daemon-side Console.is_terminal == False & width == 80 검증 |
| `CHANGELOG.md` / `pyproject.toml` / `CLAUDE.md` / `README.md` / `README.ko.md` | 0.83.0 → 0.84.0, tests 4344 → 4345 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| client_capability IPC 프로토콜 추가 | Implemented | thin → daemon 1방향, ack 드레인 처리 |
| daemon thread-local capability | Implemented | `_client_capability_local` + accessor + 핸들러 |
| make_session_console kwargs | Implemented | backward-compat defaults (True, 120) |
| spinner non-TTY guard | Implemented | `_tool_spinner` 두 번째 guard |
| backward compat | Verified | 옛 thin client는 capability 안 보냄 → daemon default (True, 120) 사용 |
| underscore 변수 정책 준수 | Verified | function-local helper var 0건 |
| 테스트 추가 | Implemented | 4345 passed (+1 new) |
| import-linter 4 contracts | Verified | 4/4 kept |

## Verification
- [x] ruff check / ruff format 통과
- [x] mypy 통과 (330 source files, 0 issues)
- [x] pytest 4345 passed (4344 + 1 new), 1 skipped, 24 deselected
- [x] IPC + e2e 30+ 테스트 통과
- [x] **import-linter `lint-imports`**: 4/4 contracts kept
- [x] E2E Cowboy Bebop A (68.4) 변동 없음

## OAuth 점검 trilogy 종합

| 결함 | 증상 | Fix |
|---|---|---|
| 1. LLM call routing | header가 gpt-5.5 표시지만 실제는 claude-opus-4-7 호출 | v0.82.0 PR #919 |
| 2. footer model 표시 | turn footer가 claude-opus-4-7 hard-stuck | v0.83.0 PR #921 |
| 3. 출력 오염 | non-TTY일 때 spinner braille frames + ANSI 200+회 출력 | **이번 PR** |

trilogy 모두 머지되면 user가 보는 모든 model 정보 (헤더 + footer + serve.log)와 모든 출력이 live `settings.model` + `is_tty` 상태와 일관성 있음.

## Reference
- 점검 trigger: 사용자 "oauth openai를 기반으로 실제 콜과 user가 볼 수 있는 출력을 살피면서 점검해"
- 사용자 추가 지시: "serve에서 스피닝 혹은 cli ui가 출력이 되는 상황도 존재해. 이런 파트도 감안해서 진행해."
- v0.82.0 PR #919 (call routing fix), v0.83.0 PR #921 (footer fix)