### PR TITLE
refactor(v0.85.0): cli/_helpers IO/key utilities → core/utils/env_io.py (A5a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.85.0] — 2026-05-08
+
+> **A5a — `cli/_helpers` IO/key utilities → `core/utils/env_io.py`.** First
+> of two PRs that resume the v0.82.0-deferred A5 work (move `cli/startup.py`
+> out of the CLI layer). The blocker was that `startup.py` imports
+> `mask_key`, `upsert_env`, `is_glm_key` from `cli/_helpers` — moving
+> startup alone created `lifecycle.startup → cli._helpers` violations.
+> This PR extracts the four IO/key utilities (`mask_key`, `upsert_env`,
+> `upsert_config_toml`, `is_glm_key`) to `core/utils/env_io.py` because
+> they have no CLI semantics — they read/write `.env`,
+> `.geode/config.toml`, and detect API key shapes. `parse_dry_run_flag`
+> stays in `core/cli/_helpers.py` because it parses CLI argument
+> strings, which is genuinely a CLI concern. After this PR,
+> `cli/_helpers.py` shrinks from 113 LOC to 21 LOC. Five caller files
+> updated. E2E `geode analyze "Cowboy Bebop" --dry-run` unchanged at
+> A (68.4); pytest 4345 passed.
+
+### Changed
+- **`core/cli/_helpers.py` (113 LOC → 21 LOC) split into `core/utils/env_io.py` + `core/cli/_helpers.py`.** Four utilities move to `core/utils/env_io.py` (107 LOC): `mask_key(key)` (display masking, no CLI dep), `upsert_env(var_name, value)` (writes `.env` + syncs `os.environ`, no CLI dep), `upsert_config_toml(section, key, value)` (writes `.geode/config.toml`, no CLI dep), `is_glm_key(value)` (regex-based ZhipuAI key detection, no CLI dep). `parse_dry_run_flag(args)` stays in `core/cli/_helpers.py` because it parses CLI argument strings — CLI-layer concern. Caller updates (5 files): `core/cli/startup.py:18-19,284`, `core/cli/commands/__init__.py:46-48`, `core/cli/commands/model.py:79`, `tests/test_config_effort_knob.py:18` switch their imports from `core.cli._helpers` to `core.utils.env_io`. `core/cli/dispatcher.py:48` keeps its `parse_dry_run_flag` import unchanged. No `ignore_imports` change yet — those happen in A5b when `cli/startup.py` itself moves to `core/lifecycle/startup.py`. (`core/utils/env_io.py` *new*, `core/cli/_helpers.py`, `core/cli/startup.py`, `core/cli/commands/__init__.py`, `core/cli/commands/model.py`, `tests/test_config_effort_knob.py`)
+
 ## [0.84.0] — 2026-05-08
 
 > **OAuth point-check trilogy completion — IPC TTY capability propagation.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.84.0
+- **Version**: 0.85.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 301 core + 29 plugins = 330
+- **Modules**: 302 core + 29 plugins = 331
 - **Tests**: 4345 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.84.0 — Long-running Autonomous Execution Harness
+# GEODE v0.85.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.84.0 — Long-running Autonomous Execution Harness
+# GEODE v0.85.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/cli/_helpers.py
+++ b/core/cli/_helpers.py
@@ -1,97 +1,13 @@
-"""Shared CLI helpers — DRY utility functions used by startup.py and commands.py."""
+"""CLI-specific argument parsing helpers.
+
+The four IO/key utilities (``mask_key``, ``upsert_env``, ``upsert_config_toml``,
+``is_glm_key``) used to live here too; v0.85.0 moved them to
+``core/utils/env_io.py`` so non-CLI layers (e.g. ``core/lifecycle``) can use
+them without crossing the CLI boundary. ``parse_dry_run_flag`` stays here
+because it is genuinely CLI-specific — it parses CLI argument strings.
+"""
 
 from __future__ import annotations
-
-import os
-import re
-from pathlib import Path
-
-
-def mask_key(key: str) -> str:
-    """Mask an API key for display: show first 10 + last 4 chars."""
-    if len(key) <= 14:
-        return "***"
-    return key[:10] + "..." + key[-4:]
-
-
-def upsert_env(var_name: str, value: str) -> None:
-    """Insert or update a variable in .env file. Creates .env if absent."""
-    env_path = Path(".env")
-    lines: list[str] = []
-    found = False
-
-    if env_path.exists():
-        raw = env_path.read_text(encoding="utf-8")
-        for line in raw.splitlines():
-            if re.match(rf"^{re.escape(var_name)}\s*=", line):
-                lines.append(f"{var_name}={value}")
-                found = True
-            else:
-                lines.append(line)
-
-    if not found:
-        lines.append(f"{var_name}={value}")
-
-    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    # Keep os.environ in sync so Settings() re-instantiation picks up
-    # the new value (Pydantic reads os.environ before .env file).
-    os.environ[var_name] = value
-
-
-def upsert_config_toml(section: str, key: str, value: str) -> None:
-    """Insert or update ``[section] key = "value"`` in ``.geode/config.toml``.
-
-    Creates the file (and ``[section]`` heading) if absent. Mirrors the
-    write semantics of ``upsert_env``: durable layer for picker choices
-    so the next session starts from the same effort / model after the
-    user clears ``.env``. 3-codebase consensus pattern (Hermes
-    ``~/.hermes/config.json``, Codex ``~/.codex/config.toml``, Claude
-    Code project + global config) — chosen settings persist to the
-    config layer, not just the env layer.
-
-    Section headings use ``[section.subsection]`` notation per TOML.
-    """
-    config_path = Path(".geode") / "config.toml"
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-
-    target_line = f'{key} = "{value}"'
-    section_heading = f"[{section}]"
-
-    raw = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
-    lines = raw.splitlines()
-
-    in_section = False
-    found_section = False
-    found_key = False
-    new_lines: list[str] = []
-    for line in lines:
-        stripped = line.strip()
-        if stripped == section_heading:
-            in_section = True
-            found_section = True
-            new_lines.append(line)
-            continue
-        if in_section and stripped.startswith("["):
-            # Hit the next section without finding the key — insert before it
-            if not found_key:
-                new_lines.append(target_line)
-                found_key = True
-            in_section = False
-        if in_section and re.match(rf"^\s*#?\s*{re.escape(key)}\s*=", line):
-            new_lines.append(target_line)
-            found_key = True
-            continue
-        new_lines.append(line)
-
-    if found_section and not found_key:
-        new_lines.append(target_line)
-    elif not found_section:
-        if new_lines and new_lines[-1] != "":
-            new_lines.append("")
-        new_lines.append(section_heading)
-        new_lines.append(target_line)
-
-    config_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
 
 
 def parse_dry_run_flag(args: str) -> tuple[bool, str]:
@@ -103,21 +19,3 @@ def parse_dry_run_flag(args: str) -> tuple[bool, str]:
     has_flag = "--dry-run" in args or "--dry_run" in args
     cleaned = args.replace("--dry-run", "").replace("--dry_run", "").strip()
     return has_flag, cleaned
-
-
-def is_glm_key(value: str) -> bool:
-    """Detect ZhipuAI API key pattern: {id}.{secret} (e.g. abc12345.def67890).
-
-    GLM keys consist of two dot-separated ASCII alphanumeric segments,
-    each at least 4 chars. Rejects emails, URLs, and natural-language text.
-    """
-    if "." not in value:
-        return False
-    # GLM keys are pure ASCII alphanumeric + dot — reject @, non-ASCII, etc.
-    if "@" in value or not value.isascii():
-        return False
-    parts = value.split(".", 1)
-    if len(parts) != 2 or not all(len(p) >= 4 for p in parts):
-        return False
-    # Each segment must be alphanumeric with at least one digit (machine-generated)
-    return all(p.isalnum() and any(c.isdigit() for c in p) for p in parts)

--- a/core/cli/commands/__init__.py
+++ b/core/cli/commands/__init__.py
@@ -39,17 +39,17 @@ mirroring the pattern used by ``core/ui/agentic_ui``.
 
 from __future__ import annotations
 
+# Bridge module for /schedule (a separate file at core/cli/cmd_schedule.py)
+from core.cli.cmd_schedule import cmd_schedule as cmd_schedule
+from core.ui.console import console as console
+
 # Helpers + Rich console must be addressable at the package level so
 # monkeypatched test references (``patch("core.cli.commands.console")``,
 # ``patch("core.cli.commands._upsert_env")``, etc.) hit the same object
 # the submodules consume through the deferred ``_pkg.X`` lookup.
-from core.cli._helpers import is_glm_key as _is_glm_key
-from core.cli._helpers import mask_key as _mask_key
-from core.cli._helpers import upsert_env as _upsert_env
-
-# Bridge module for /schedule (a separate file at core/cli/cmd_schedule.py)
-from core.cli.cmd_schedule import cmd_schedule as cmd_schedule
-from core.ui.console import console as console
+from core.utils.env_io import is_glm_key as _is_glm_key
+from core.utils.env_io import mask_key as _mask_key
+from core.utils.env_io import upsert_env as _upsert_env
 
 from ._state import (
     _MODEL_INDEX,

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -76,7 +76,7 @@ def _apply_model(selected: ModelProfile, *, effort: str | None = None) -> None:
     # happens to survive — wiping .env would lose the choice silently.
     # 3-codebase consensus (Hermes/Codex/Claude Code all persist picker
     # choices to durable config).
-    from core.cli._helpers import upsert_config_toml
+    from core.utils.env_io import upsert_config_toml
 
     if not same_model:
         settings.model = selected.id

--- a/core/cli/startup.py
+++ b/core/cli/startup.py
@@ -15,11 +15,11 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from core.cli._helpers import mask_key as _mask_key
-from core.cli._helpers import upsert_env as _upsert_env
 from core.config import settings
 from core.memory.project import ProjectMemory
 from core.ui.console import console
+from core.utils.env_io import mask_key as _mask_key
+from core.utils.env_io import upsert_env as _upsert_env
 
 log = logging.getLogger(__name__)
 
@@ -281,7 +281,7 @@ def detect_api_key(text: str) -> tuple[str, str, str] | None:
     Returns (provider, env_var, key_value) if detected, else None.
     Only matches single-token inputs (no spaces except leading/trailing).
     """
-    from core.cli._helpers import is_glm_key
+    from core.utils.env_io import is_glm_key
 
     stripped = text.strip()
     if " " in stripped or "\n" in stripped:

--- a/core/utils/env_io.py
+++ b/core/utils/env_io.py
@@ -1,0 +1,119 @@
+"""Environment + config IO helpers — pure utilities with no CLI dependencies.
+
+Extracted from ``core/cli/_helpers.py`` (v0.85.0) so that ``core/lifecycle/``
+modules and other layers can use them without crossing into the CLI layer.
+
+The CLI-specific helper ``parse_dry_run_flag`` stays in ``core/cli/_helpers.py``
+because it parses CLI arguments — that's a CLI concern, not a utility one.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def mask_key(key: str) -> str:
+    """Mask an API key for display: show first 10 + last 4 chars."""
+    if len(key) <= 14:
+        return "***"
+    return key[:10] + "..." + key[-4:]
+
+
+def upsert_env(var_name: str, value: str) -> None:
+    """Insert or update a variable in .env file. Creates .env if absent."""
+    env_path = Path(".env")
+    lines: list[str] = []
+    found = False
+
+    if env_path.exists():
+        raw = env_path.read_text(encoding="utf-8")
+        for line in raw.splitlines():
+            if re.match(rf"^{re.escape(var_name)}\s*=", line):
+                lines.append(f"{var_name}={value}")
+                found = True
+            else:
+                lines.append(line)
+
+    if not found:
+        lines.append(f"{var_name}={value}")
+
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Keep os.environ in sync so Settings() re-instantiation picks up
+    # the new value (Pydantic reads os.environ before .env file).
+    os.environ[var_name] = value
+
+
+def upsert_config_toml(section: str, key: str, value: str) -> None:
+    """Insert or update ``[section] key = "value"`` in ``.geode/config.toml``.
+
+    Creates the file (and ``[section]`` heading) if absent. Mirrors the
+    write semantics of ``upsert_env``: durable layer for picker choices
+    so the next session starts from the same effort / model after the
+    user clears ``.env``. 3-codebase consensus pattern (Hermes
+    ``~/.hermes/config.json``, Codex ``~/.codex/config.toml``, Claude
+    Code project + global config) — chosen settings persist to the
+    config layer, not just the env layer.
+
+    Section headings use ``[section.subsection]`` notation per TOML.
+    """
+    config_path = Path(".geode") / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    target_line = f'{key} = "{value}"'
+    section_heading = f"[{section}]"
+
+    raw = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    lines = raw.splitlines()
+
+    in_section = False
+    found_section = False
+    found_key = False
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == section_heading:
+            in_section = True
+            found_section = True
+            new_lines.append(line)
+            continue
+        if in_section and stripped.startswith("["):
+            # Hit the next section without finding the key — insert before it
+            if not found_key:
+                new_lines.append(target_line)
+                found_key = True
+            in_section = False
+        if in_section and re.match(rf"^\s*#?\s*{re.escape(key)}\s*=", line):
+            new_lines.append(target_line)
+            found_key = True
+            continue
+        new_lines.append(line)
+
+    if found_section and not found_key:
+        new_lines.append(target_line)
+    elif not found_section:
+        if new_lines and new_lines[-1] != "":
+            new_lines.append("")
+        new_lines.append(section_heading)
+        new_lines.append(target_line)
+
+    config_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
+def is_glm_key(value: str) -> bool:
+    """Detect ZhipuAI API key pattern: {id}.{secret} (e.g. abc12345.def67890).
+
+    GLM keys consist of two dot-separated ASCII alphanumeric segments,
+    each at least 4 chars. Rejects emails, URLs, and natural-language text.
+    """
+    if "." not in value:
+        return False
+    # GLM keys are pure ASCII alphanumeric + dot — reject @, non-ASCII, etc.
+    if "@" in value or not value.isascii():
+        return False
+    parts = value.split(".", 1)
+    if len(parts) != 2 or not all(len(p) >= 4 for p in parts):
+        return False
+    # Each segment must be alphanumeric with at least one digit (machine-generated)
+    return all(p.isalnum() and any(c.isdigit() for c in p) for p in parts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.84.0"
+version = "0.85.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_config_effort_knob.py
+++ b/tests/test_config_effort_knob.py
@@ -15,7 +15,7 @@ import inspect
 import tomllib
 from pathlib import Path
 
-from core.cli._helpers import upsert_config_toml
+from core.utils.env_io import upsert_config_toml
 
 
 class TestUpsertConfigToml:

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.83.0"
+version = "0.84.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **A5a — A5 deferred 작업 재개의 첫 번째 PR.** `cli/_helpers`의 4개 IO/key utility(`mask_key`, `upsert_env`, `upsert_config_toml`, `is_glm_key`) → `core/utils/env_io.py`. `parse_dry_run_flag`는 cli specific이라 유지.
- 호출자 5 파일 import 변경. `cli/_helpers.py` 113L → 21L.
- E2E Cowboy Bebop A (68.4) 변동 없음. pytest 4345 passed.

## Why
v0.82.0 점검에서 `startup.py`를 `core/lifecycle/`로 옮기려 했으나, startup이 `cli/_helpers`의 `mask_key`/`upsert_env`/`is_glm_key`를 import하므로 단순 mv 시 `lifecycle.startup → cli._helpers` 위반이 새로 발생. 그래서 A5 폐기됐음. 이번 PR이 그 blocker 해소.

이 4개 함수는 진짜 cli specific이 아님:
- `mask_key`: API 키 display 마스킹 (regex 기반)
- `upsert_env`: `.env` 파일 read/write + os.environ 동기화
- `upsert_config_toml`: `.geode/config.toml` read/write
- `is_glm_key`: ZhipuAI API 키 형식 detect

`core/utils/`(redaction.py, project_detect.py, atomic_io.py 등)와 동일 카테고리 — pure utility, CLI 의존성 0.

`parse_dry_run_flag`는 진짜 CLI argument string parser → `core/cli/_helpers.py`에 유지.

## Changes
| File | Change |
|------|--------|
| `core/utils/env_io.py` | **신규** (107L) — 4 utilities byte-identical 이동 |
| `core/cli/_helpers.py` | **축소** (113L → 21L) — `parse_dry_run_flag`만 유지 |
| `core/cli/startup.py:18-19,284` | 3 imports `core.cli._helpers` → `core.utils.env_io` |
| `core/cli/commands/__init__.py:46-48` | 3 imports 동일 변경 |
| `core/cli/commands/model.py:79` | `upsert_config_toml` import 변경 |
| `tests/test_config_effort_knob.py:18` | 동일 변경 |
| `CHANGELOG.md` / `pyproject.toml` / `CLAUDE.md` / `README.md` / `README.ko.md` | 0.84.0 → 0.85.0, 모듈 카운트 301 → 302 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 4 utility 추출 | Implemented | byte-identical 이동, 호출자 5 파일 import 변경 |
| `parse_dry_run_flag` cli 유지 | Verified | CLI argument parsing은 cli specific |
| `cli/_helpers.py` shrink | Verified | 113L → 21L (-92L) |
| import-linter 4 contracts | Verified | 4/4 kept (이번 PR은 위반 신규 발생 0) |

## Verification
- [x] ruff check / ruff format 통과 (550 files)
- [x] mypy 통과 (331 source files, +1)
- [x] pytest 4345 passed, 1 skipped, 24 deselected — v0.84.0 직후와 동일
- [x] import-linter `lint-imports`: 4/4 contracts kept
- [x] E2E Cowboy Bebop A (68.4) 변동 없음

## 다음 PR (A5b)
`core/cli/startup.py` (520L) 책임 분리:
- lifecycle 부분 (~340L: `check_readiness`, `auto_generate_env`, `detect_subscription_oauth`, `Capability`, `ReadinessReport`, `setup_project_memory`, `setup_user_profile`) → `core/lifecycle/startup.py`
- cli interactive 부분 (~180L: `env_setup_wizard`, `_wizard_*`, `key_registration_gate`, `render_readiness`) → `core/cli/onboarding.py`

A5b PR이 `lifecycle.bootstrap → cli.startup`, `server.poller → cli.startup` 등 다수 ignore_imports 제거.

## Reference
- v0.82.0 trilogy 점검 (PR #919/#921/#923)
- A5 폐기 사유 분석 (this session 이전 turn)