### PR TITLE
refactor(v0.86.0): cli/startup.py 책임 분리 → lifecycle/startup + cli/onboarding (A5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.86.0] — 2026-05-08
+
+> **A5b — `cli/startup.py` 책임 분리: `lifecycle/startup.py` + `cli/onboarding.py`.**
+> v0.82.0 OAuth 점검에서 발견했으나 단일 mv로 풀리지 않아 폐기됐던 결함의
+> 진짜 해결. v0.85.0 (A5a)이 `cli/_helpers`의 IO/key utility를 `utils`로
+> 추출해 의존성 blocker를 제거한 뒤, 이번 PR에서 `cli/startup.py` (520L)
+> 자체를 책임별로 두 모듈로 갈라냄. lifecycle 부분 (data inspection +
+> readiness data classes + file IO) 은 `core/lifecycle/startup.py`
+> (287L)으로, interactive 부분 (console.input wizard, slash command
+> dispatch, console.print display) 은 `core/cli/onboarding.py` (272L)
+> 로 분리. 함수 본문 byte-identical, 호출자 15+ 사이트가 책임에 따라
+> import를 분기. **2개 ignore_imports 영구 제거**:
+> `core.lifecycle.bootstrap → core.cli.startup` (이젠 lifecycle →
+> lifecycle internal), `core.server.ipc_server.poller → core.cli.startup`
+> (이젠 server → lifecycle, contract에서 허용). 22 → 19 (-2 from this
+> PR + 1 무관). E2E `geode analyze "Cowboy Bebop" --dry-run` unchanged
+> at A (68.4); pytest 4345 passed.
+
+### Changed
+- **`core/cli/startup.py` (520L) split into `core/lifecycle/startup.py` (287L) + `core/cli/onboarding.py` (272L).** Function placement by responsibility (interactive vs data):
+  - **Lifecycle (9 functions + 2 dataclasses)**: `auto_generate_env`, `_is_placeholder`, `_has_any_llm_key`, `detect_subscription_oauth`, `Capability`, `ReadinessReport`, `check_readiness`, `setup_project_memory`, `setup_user_profile` — all pure data inspection / file IO with no `console.input` calls.
+  - **CLI/onboarding (6 functions)**: `env_setup_wizard`, `_wizard_subscription_path`, `_wizard_api_key_path`, `detect_api_key`, `key_registration_gate`, `render_readiness` — all `console.input` wizards or `console.print` display, plus `key_registration_gate`'s `cmd_login` / `cmd_key` slash dispatch.
+  - The `_KEY_PATTERNS` constant lives with `detect_api_key` in `cli/onboarding.py` since that function is its only consumer.
+  - 15+ caller sites updated. Single-name imports route to one module; multi-name imports (e.g. `from core.cli.startup import check_readiness, render_readiness` in `dispatcher.py`, `tool_handlers/system.py`) split into two `from … import …` lines, one per layer.
+  - Test patches (especially `tests/test_startup.py:80+`, `tests/test_agentic_loop.py:357-373`, `tests/test_e2e_live_llm.py:48,536-538`) re-point `core.cli.startup.{settings,console,detect_subscription_oauth,log,_upsert_env}` to `core.cli.onboarding.*` (wizard module) or `core.lifecycle.startup.*` (data path) per the function whose state they patch.
+- **`pyproject.toml` `[tool.importlinter.contracts]` — 2 entries removed.** `core.lifecycle.bootstrap → core.cli.startup` from the `Server may host agent but never CLI` contract: now `lifecycle.bootstrap → lifecycle.startup`, internal lifecycle import. `core.server.ipc_server.poller → core.cli.startup` from the same contract: now `server.poller → lifecycle.startup`, allowed because that contract only forbids `core.cli`. ignore_imports total drops from 22 → 19. (`core/cli/startup.py` *deleted*, `core/lifecycle/startup.py` *new*, `core/cli/onboarding.py` *new*, 11 caller files, 5 test files, `pyproject.toml`)
+
 ## [0.85.0] — 2026-05-08
 
 > **A5a — `cli/_helpers` IO/key utilities → `core/utils/env_io.py`.** First

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.85.0
+- **Version**: 0.86.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 302 core + 29 plugins = 331
+- **Modules**: 303 core + 29 plugins = 332
 - **Tests**: 4345 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.85.0 — Long-running Autonomous Execution Harness
+# GEODE v0.86.0 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.85.0 — Long-running Autonomous Execution Harness
+# GEODE v0.86.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -187,7 +187,7 @@ def bootstrap_geode(
 
     # 3. Readiness
     from core.cli import _set_readiness
-    from core.cli.startup import check_readiness
+    from core.lifecycle.startup import check_readiness
 
     readiness = check_readiness()
     _set_readiness(readiness)

--- a/core/cli/commands/key.py
+++ b/core/cli/commands/key.py
@@ -175,8 +175,8 @@ def _persist_auth_state() -> None:
 def _check_provider_key(selected: ModelProfile) -> None:
     """Warn if the provider's API key is not set for the selected model."""
     from core.cli import commands as _pkg
-    from core.cli.startup import _is_placeholder
     from core.config import settings
+    from core.lifecycle.startup import _is_placeholder
 
     provider_key_map: dict[str, tuple[str, str]] = {
         "Anthropic": (settings.anthropic_api_key, "ANTHROPIC_API_KEY"),

--- a/core/cli/dispatcher.py
+++ b/core/cli/dispatcher.py
@@ -23,6 +23,7 @@ from core.cli.commands import (
     resolve_action,
     show_help,
 )
+from core.cli.onboarding import render_readiness
 from core.cli.pipeline_executor import _run_analysis
 from core.cli.report_renderer import _generate_report, _parse_report_args
 from core.cli.search_render import _render_search_results
@@ -31,8 +32,8 @@ from core.cli.session_state import (
     _get_search_engine,
     _scheduler_service_ctx,
 )
-from core.cli.startup import check_readiness, render_readiness
 from core.config import settings
+from core.lifecycle.startup import check_readiness
 from core.ui.console import console
 
 

--- a/core/cli/onboarding.py
+++ b/core/cli/onboarding.py
@@ -1,149 +1,32 @@
-"""Startup checks — OpenClaw gateway:startup + hook eligibility pattern.
+"""Interactive onboarding surfaces — CLI half of the v0.86.0 split.
 
-Detects environment readiness:
-  ANY provider key present → full mode (LLM calls enabled)
-  No provider key         → .env setup wizard → key registration gate
-  .env missing            → interactive wizard to create .env
+Originally lived in ``core/cli/startup.py``. v0.86.0 split that module by
+responsibility: pure inspection / IO / dataclasses (now in
+``core/lifecycle/startup.py``) versus the interactive wizard surfaces
+(this file). Functions here drive ``console.input``/``console.print``
+loops and dispatch to ``/login`` and ``/key`` slash commands, so they
+must NOT be called from headless processes (serve, IPC poller).
 
-Reports capability status like OpenClaw's `hooks check --json`.
+Public surface:
+  * ``env_setup_wizard`` — top-level three-branch menu (subscription/key/skip)
+  * ``detect_api_key`` — natural-language API-key sniffer
+  * ``key_registration_gate`` — blocking prompt that accepts ``/login`` /
+    ``/key`` / direct paste until a credential is set or the user quits
+  * ``render_readiness`` — pretty-printer for ``ReadinessReport``
 """
 
 from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass, field
-from pathlib import Path
 
 from core.config import settings
-from core.memory.project import ProjectMemory
+from core.lifecycle.startup import ReadinessReport, _has_any_llm_key, detect_subscription_oauth
 from core.ui.console import console
 from core.utils.env_io import mask_key as _mask_key
 from core.utils.env_io import upsert_env as _upsert_env
 
 log = logging.getLogger(__name__)
-
-
-def auto_generate_env(project_root: Path | None = None) -> bool:
-    """Auto-generate .env from .env.example if .env is absent.
-
-    Copies .env.example to .env, replacing placeholder values
-    (like ``sk-ant-...`` or ``...``) with empty strings so that
-    the Settings loader does not treat them as real keys.
-
-    Returns True if .env was generated, False otherwise.
-    """
-    root = project_root or Path(".")
-    env_path = root / ".env"
-    example_path = root / ".env.example"
-
-    if env_path.exists():
-        return False
-    if not example_path.exists():
-        return False
-
-    raw = example_path.read_text(encoding="utf-8")
-    lines: list[str] = []
-    for line in raw.splitlines():
-        # Skip commented-out lines — keep as-is
-        stripped = line.lstrip()
-        if stripped.startswith("#") or "=" not in stripped:
-            lines.append(line)
-            continue
-        # Split on first '='
-        key, _, value = line.partition("=")
-        value = value.strip()
-        # Replace placeholder values with empty string
-        if _is_placeholder(value):
-            lines.append(f"{key}=")
-        else:
-            lines.append(line)
-
-    tmp_path = env_path.with_suffix(".tmp")
-    tmp_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    tmp_path.chmod(0o600)
-    tmp_path.replace(env_path)
-    log.info(".env auto-generated from .env.example")
-    return True
-
-
-def _is_placeholder(value: str) -> bool:
-    """Check if a .env value is a placeholder (not a real credential)."""
-    # Exact ellipsis
-    if value == "...":
-        return True
-    # Patterns like sk-ant-..., sk-..., lsv2_pt_..., BSA..., etc.
-    return bool(value.endswith("..."))
-
-
-def _has_any_llm_key() -> bool:
-    """Check if ANY LLM provider API key is configured."""
-    if settings.anthropic_api_key and not _is_placeholder(settings.anthropic_api_key):
-        return True
-    if settings.openai_api_key and not _is_placeholder(settings.openai_api_key):
-        return True
-    return bool(settings.zai_api_key and not _is_placeholder(settings.zai_api_key))
-
-
-# ---------------------------------------------------------------------------
-# Proactive subscription OAuth detection (v0.54.0)
-# ---------------------------------------------------------------------------
-
-
-def detect_subscription_oauth() -> str | None:
-    """Detect a usable subscription-OAuth credential before any wizard runs.
-
-    Currently supports Codex CLI OAuth (ChatGPT Plus / Pro / Business / Edu /
-    Enterprise). Anthropic OAuth is intentionally excluded — Anthropic's
-    terms of service (effective 2026-01-09) prohibit third-party tools from
-    reusing the Claude Code OAuth token; ``core/lifecycle/container.py:271``
-    documents the policy decision.
-
-    Returns the provider id (``"openai-codex"``) if a fresh, non-expired
-    credential is found and the matching profile is registered in the
-    ProfileStore. Returns ``None`` otherwise.
-    """
-    try:
-        from core.auth.codex_cli_oauth import read_codex_cli_credentials
-    except ImportError:
-        return None
-
-    try:
-        creds = read_codex_cli_credentials()
-    except Exception:
-        log.debug("Codex CLI OAuth probe failed", exc_info=True)
-        return None
-    if not creds or not creds.get("access_token"):
-        return None
-
-    # The Codex CLI credential is real; ensure ProfileStore knows about it.
-    # ``build_auth()`` already registers it at startup, but on first run we
-    # may need to seed an empty store right after detection.
-    try:
-        from core.auth.profiles import AuthProfile, CredentialType
-        from core.lifecycle.container import ensure_profile_store
-
-        store = ensure_profile_store()
-        existing = next(
-            (p for p in store.list_all() if p.provider == "openai-codex" and p.key),
-            None,
-        )
-        if existing is None:
-            store.add(
-                AuthProfile(
-                    name="openai-codex:codex-cli",
-                    provider="openai-codex",
-                    credential_type=CredentialType.OAUTH,
-                    key=creds["access_token"],
-                    refresh_token=creds.get("refresh_token", ""),
-                    expires_at=creds.get("expires_at", 0.0),
-                    managed_by="codex-cli",
-                )
-            )
-    except Exception:
-        log.debug("Profile registration after OAuth detection failed", exc_info=True)
-
-    return "openai-codex"
 
 
 # ---------------------------------------------------------------------------
@@ -369,115 +252,8 @@ def key_registration_gate() -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Readiness Report
+# Readiness Display
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class Capability:
-    """A single system capability with eligibility status."""
-
-    name: str
-    available: bool
-    reason: str = ""
-
-
-@dataclass
-class ReadinessReport:
-    """System readiness report (OpenClaw hook eligibility pattern)."""
-
-    capabilities: list[Capability] = field(default_factory=list)
-    has_api_key: bool = False
-    has_env_file: bool = False
-    has_memory: bool = False
-    has_profile: bool = False
-    blocked: bool = False
-    force_dry_run: bool = False  # backward-compat alias
-
-    @property
-    def all_ready(self) -> bool:
-        return all(c.available for c in self.capabilities)
-
-
-def check_readiness(project_root: Path | None = None) -> ReadinessReport:
-    """Check system readiness (OpenClaw gateway:startup pattern).
-
-    ANY provider key (Anthropic/OpenAI/ZhipuAI) unblocks full mode.
-    """
-    root = project_root or Path(".")
-    report = ReadinessReport()
-
-    # 1. API Key check — any provider key suffices
-    has_key = _has_any_llm_key()
-    report.has_api_key = has_key
-    if has_key:
-        report.capabilities.append(Capability(name="LLM Analysis", available=True))
-    else:
-        report.capabilities.append(
-            Capability(
-                name="LLM Analysis",
-                available=False,
-                reason="No LLM API key set (Anthropic/OpenAI/ZhipuAI)",
-            )
-        )
-
-    # 2. .env file check
-    env_path = root / ".env"
-    env_example_path = root / ".env.example"
-    report.has_env_file = env_path.exists()
-    if not env_path.exists() and env_example_path.exists():
-        report.capabilities.append(
-            Capability(
-                name="Environment",
-                available=False,
-                reason="cp .env.example .env",
-            )
-        )
-
-    # 3. Project Memory check
-    mem = ProjectMemory(root)
-    report.has_memory = mem.exists()
-    report.capabilities.append(
-        Capability(
-            name="Project Memory",
-            available=mem.exists(),
-            reason="" if mem.exists() else ".geode/memory/PROJECT.md not found",
-        )
-    )
-
-    # 4. User Profile check (Tier 0.5)
-    try:
-        from core.memory.user_profile import FileBasedUserProfile
-
-        profile = FileBasedUserProfile()
-        profile_exists = profile.exists()
-        report.has_profile = profile_exists
-        report.capabilities.append(
-            Capability(
-                name="User Profile",
-                available=profile_exists,
-                reason="" if profile_exists else "run /profile to set up",
-            )
-        )
-    except Exception:
-        report.has_profile = False
-        report.capabilities.append(
-            Capability(
-                name="User Profile",
-                available=False,
-                reason="load failed",
-            )
-        )
-
-    # 5. Always-available capabilities
-    report.capabilities.append(Capability(name="Dry-Run Analysis", available=True))
-    report.capabilities.append(Capability(name="IP Search", available=True))
-
-    # 5. Block if no LLM key at all
-    report.blocked = not has_key
-    report.force_dry_run = not has_key  # backward-compat
-
-    return report
 
 
 def render_readiness(report: ReadinessReport) -> None:
@@ -494,27 +270,3 @@ def render_readiness(report: ReadinessReport) -> None:
     if report.blocked:
         console.print("  [warning]No LLM key configured — key registration required[/warning]")
         console.print()
-
-
-def setup_project_memory(project_root: Path | None = None) -> bool:
-    """Initialize project memory if not present (OpenClaw boot-md pattern)."""
-    mem = ProjectMemory(project_root)
-    if mem.exists():
-        return False
-
-    created = mem.ensure_structure()
-    if created:
-        log.info("Project memory initialized at %s", mem.memory_file)
-    return created
-
-
-def setup_user_profile() -> bool:
-    """Initialize user profile if not present (~/.geode/user_profile/)."""
-    try:
-        from core.memory.user_profile import FileBasedUserProfile
-
-        profile = FileBasedUserProfile()
-        return profile.ensure_structure()
-    except Exception as e:
-        log.warning("User profile setup failed: %s", e)
-        return False

--- a/core/cli/session_state.py
+++ b/core/cli/session_state.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from plugins.game_ip.cli.search import IPSearchEngine
 
-    from core.cli.startup import ReadinessReport
+    from core.lifecycle.startup import ReadinessReport
 
 log = logging.getLogger(__name__)
 

--- a/core/cli/tool_handlers/system.py
+++ b/core/cli/tool_handlers/system.py
@@ -19,7 +19,8 @@ def _build_system_handlers(
     """Build system management tool handlers."""
     from core.cli import _set_readiness
     from core.cli.commands import cmd_auth, cmd_key, cmd_model, show_help
-    from core.cli.startup import check_readiness, render_readiness
+    from core.cli.onboarding import render_readiness
+    from core.lifecycle.startup import check_readiness
 
     def handle_show_help(**_kwargs: Any) -> dict[str, Any]:
         show_help()

--- a/core/cli/typer_commands.py
+++ b/core/cli/typer_commands.py
@@ -161,11 +161,8 @@ def setup(
     prompting for API keys. Use ``--reset`` to clear existing
     credentials and start over.
     """
-    from core.cli.startup import (
-        _has_any_llm_key,
-        detect_subscription_oauth,
-        env_setup_wizard,
-    )
+    from core.cli.onboarding import env_setup_wizard
+    from core.lifecycle.startup import _has_any_llm_key, detect_subscription_oauth
 
     if reset:
         env_path = Path("~/.geode/.env").expanduser()

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -15,7 +15,7 @@ from typing import Any
 import typer
 
 from core.cli.session_state import _scheduler_service_ctx, _set_readiness
-from core.cli.startup import check_readiness
+from core.lifecycle.startup import check_readiness
 from core.ui.console import console
 
 log = logging.getLogger(__name__)

--- a/core/cli/welcome.py
+++ b/core/cli/welcome.py
@@ -8,16 +8,16 @@ from __future__ import annotations
 from pathlib import Path
 
 from core import __version__
+from core.cli.onboarding import env_setup_wizard
 from core.cli.session_state import _set_readiness
-from core.cli.startup import (
+from core.config import settings
+from core.lifecycle.startup import (
     ReadinessReport,
     auto_generate_env,
     check_readiness,
-    env_setup_wizard,
     setup_project_memory,
     setup_user_profile,
 )
-from core.config import settings
 from core.ui.console import console
 
 
@@ -86,7 +86,7 @@ def _welcome_screen() -> None:
     # ``~/.codex/auth.json`` and skips the wizard entirely. Anthropic OAuth
     # is intentionally excluded (Anthropic ToS prohibits third-party
     # reuse — see ``core/lifecycle/container.py:271``).
-    from core.cli.startup import _has_any_llm_key, detect_subscription_oauth
+    from core.lifecycle.startup import _has_any_llm_key, detect_subscription_oauth
 
     if not _has_any_llm_key():
         oauth_provider = detect_subscription_oauth()

--- a/core/lifecycle/bootstrap.py
+++ b/core/lifecycle/bootstrap.py
@@ -718,7 +718,7 @@ def build_skill_registry() -> Any:
 
 def build_readiness() -> Any:
     """Check API key availability for all configured providers."""
-    from core.cli.startup import check_readiness
+    from core.lifecycle.startup import check_readiness
 
     return check_readiness()
 

--- a/core/lifecycle/startup.py
+++ b/core/lifecycle/startup.py
@@ -1,0 +1,287 @@
+"""Startup data inspection — lifecycle-pure half of the v0.86.0 split.
+
+Originally lived in ``core/cli/startup.py``. v0.86.0 split that module by
+responsibility: pure inspection / IO / dataclasses (this file) versus the
+interactive wizard surfaces (``core/cli/onboarding.py``). Lifecycle code
+must remain free of ``console.input``/``console.print`` so that headless
+processes (serve, IPC poller) can call it without an attached TTY.
+
+Public surface:
+  * ``auto_generate_env`` — copy ``.env.example`` to ``.env`` (placeholder safe)
+  * ``detect_subscription_oauth`` — Codex CLI OAuth probe
+  * ``check_readiness`` / ``ReadinessReport`` / ``Capability`` — gateway:startup data
+  * ``setup_project_memory`` / ``setup_user_profile`` — first-run scaffolding
+
+Detects environment readiness:
+  ANY provider key present → full mode (LLM calls enabled)
+  No provider key         → caller surfaces the wizard
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from core.config import settings
+from core.memory.project import ProjectMemory
+
+log = logging.getLogger(__name__)
+
+
+def auto_generate_env(project_root: Path | None = None) -> bool:
+    """Auto-generate .env from .env.example if .env is absent.
+
+    Copies .env.example to .env, replacing placeholder values
+    (like ``sk-ant-...`` or ``...``) with empty strings so that
+    the Settings loader does not treat them as real keys.
+
+    Returns True if .env was generated, False otherwise.
+    """
+    root = project_root or Path(".")
+    env_path = root / ".env"
+    example_path = root / ".env.example"
+
+    if env_path.exists():
+        return False
+    if not example_path.exists():
+        return False
+
+    raw = example_path.read_text(encoding="utf-8")
+    lines: list[str] = []
+    for line in raw.splitlines():
+        # Skip commented-out lines — keep as-is
+        stripped = line.lstrip()
+        if stripped.startswith("#") or "=" not in stripped:
+            lines.append(line)
+            continue
+        # Split on first '='
+        key, _, value = line.partition("=")
+        value = value.strip()
+        # Replace placeholder values with empty string
+        if _is_placeholder(value):
+            lines.append(f"{key}=")
+        else:
+            lines.append(line)
+
+    tmp_path = env_path.with_suffix(".tmp")
+    tmp_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    tmp_path.chmod(0o600)
+    tmp_path.replace(env_path)
+    log.info(".env auto-generated from .env.example")
+    return True
+
+
+def _is_placeholder(value: str) -> bool:
+    """Check if a .env value is a placeholder (not a real credential)."""
+    # Exact ellipsis
+    if value == "...":
+        return True
+    # Patterns like sk-ant-..., sk-..., lsv2_pt_..., BSA..., etc.
+    return bool(value.endswith("..."))
+
+
+def _has_any_llm_key() -> bool:
+    """Check if ANY LLM provider API key is configured."""
+    if settings.anthropic_api_key and not _is_placeholder(settings.anthropic_api_key):
+        return True
+    if settings.openai_api_key and not _is_placeholder(settings.openai_api_key):
+        return True
+    return bool(settings.zai_api_key and not _is_placeholder(settings.zai_api_key))
+
+
+# ---------------------------------------------------------------------------
+# Proactive subscription OAuth detection (v0.54.0)
+# ---------------------------------------------------------------------------
+
+
+def detect_subscription_oauth() -> str | None:
+    """Detect a usable subscription-OAuth credential before any wizard runs.
+
+    Currently supports Codex CLI OAuth (ChatGPT Plus / Pro / Business / Edu /
+    Enterprise). Anthropic OAuth is intentionally excluded — Anthropic's
+    terms of service (effective 2026-01-09) prohibit third-party tools from
+    reusing the Claude Code OAuth token; ``core/lifecycle/container.py:271``
+    documents the policy decision.
+
+    Returns the provider id (``"openai-codex"``) if a fresh, non-expired
+    credential is found and the matching profile is registered in the
+    ProfileStore. Returns ``None`` otherwise.
+    """
+    try:
+        from core.auth.codex_cli_oauth import read_codex_cli_credentials
+    except ImportError:
+        return None
+
+    try:
+        creds = read_codex_cli_credentials()
+    except Exception:
+        log.debug("Codex CLI OAuth probe failed", exc_info=True)
+        return None
+    if not creds or not creds.get("access_token"):
+        return None
+
+    # The Codex CLI credential is real; ensure ProfileStore knows about it.
+    # ``build_auth()`` already registers it at startup, but on first run we
+    # may need to seed an empty store right after detection.
+    try:
+        from core.auth.profiles import AuthProfile, CredentialType
+        from core.lifecycle.container import ensure_profile_store
+
+        store = ensure_profile_store()
+        existing = next(
+            (p for p in store.list_all() if p.provider == "openai-codex" and p.key),
+            None,
+        )
+        if existing is None:
+            store.add(
+                AuthProfile(
+                    name="openai-codex:codex-cli",
+                    provider="openai-codex",
+                    credential_type=CredentialType.OAUTH,
+                    key=creds["access_token"],
+                    refresh_token=creds.get("refresh_token", ""),
+                    expires_at=creds.get("expires_at", 0.0),
+                    managed_by="codex-cli",
+                )
+            )
+    except Exception:
+        log.debug("Profile registration after OAuth detection failed", exc_info=True)
+
+    return "openai-codex"
+
+
+# ---------------------------------------------------------------------------
+# Readiness Report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Capability:
+    """A single system capability with eligibility status."""
+
+    name: str
+    available: bool
+    reason: str = ""
+
+
+@dataclass
+class ReadinessReport:
+    """System readiness report (OpenClaw hook eligibility pattern)."""
+
+    capabilities: list[Capability] = field(default_factory=list)
+    has_api_key: bool = False
+    has_env_file: bool = False
+    has_memory: bool = False
+    has_profile: bool = False
+    blocked: bool = False
+    force_dry_run: bool = False  # backward-compat alias
+
+    @property
+    def all_ready(self) -> bool:
+        return all(c.available for c in self.capabilities)
+
+
+def check_readiness(project_root: Path | None = None) -> ReadinessReport:
+    """Check system readiness (OpenClaw gateway:startup pattern).
+
+    ANY provider key (Anthropic/OpenAI/ZhipuAI) unblocks full mode.
+    """
+    root = project_root or Path(".")
+    report = ReadinessReport()
+
+    # 1. API Key check — any provider key suffices
+    has_key = _has_any_llm_key()
+    report.has_api_key = has_key
+    if has_key:
+        report.capabilities.append(Capability(name="LLM Analysis", available=True))
+    else:
+        report.capabilities.append(
+            Capability(
+                name="LLM Analysis",
+                available=False,
+                reason="No LLM API key set (Anthropic/OpenAI/ZhipuAI)",
+            )
+        )
+
+    # 2. .env file check
+    env_path = root / ".env"
+    env_example_path = root / ".env.example"
+    report.has_env_file = env_path.exists()
+    if not env_path.exists() and env_example_path.exists():
+        report.capabilities.append(
+            Capability(
+                name="Environment",
+                available=False,
+                reason="cp .env.example .env",
+            )
+        )
+
+    # 3. Project Memory check
+    mem = ProjectMemory(root)
+    report.has_memory = mem.exists()
+    report.capabilities.append(
+        Capability(
+            name="Project Memory",
+            available=mem.exists(),
+            reason="" if mem.exists() else ".geode/memory/PROJECT.md not found",
+        )
+    )
+
+    # 4. User Profile check (Tier 0.5)
+    try:
+        from core.memory.user_profile import FileBasedUserProfile
+
+        profile = FileBasedUserProfile()
+        profile_exists = profile.exists()
+        report.has_profile = profile_exists
+        report.capabilities.append(
+            Capability(
+                name="User Profile",
+                available=profile_exists,
+                reason="" if profile_exists else "run /profile to set up",
+            )
+        )
+    except Exception:
+        report.has_profile = False
+        report.capabilities.append(
+            Capability(
+                name="User Profile",
+                available=False,
+                reason="load failed",
+            )
+        )
+
+    # 5. Always-available capabilities
+    report.capabilities.append(Capability(name="Dry-Run Analysis", available=True))
+    report.capabilities.append(Capability(name="IP Search", available=True))
+
+    # 5. Block if no LLM key at all
+    report.blocked = not has_key
+    report.force_dry_run = not has_key  # backward-compat
+
+    return report
+
+
+def setup_project_memory(project_root: Path | None = None) -> bool:
+    """Initialize project memory if not present (OpenClaw boot-md pattern)."""
+    mem = ProjectMemory(project_root)
+    if mem.exists():
+        return False
+
+    created = mem.ensure_structure()
+    if created:
+        log.info("Project memory initialized at %s", mem.memory_file)
+    return created
+
+
+def setup_user_profile() -> bool:
+    """Initialize user profile if not present (~/.geode/user_profile/)."""
+    try:
+        from core.memory.user_profile import FileBasedUserProfile
+
+        profile = FileBasedUserProfile()
+        return profile.ensure_structure()
+    except Exception as e:
+        log.warning("User profile setup failed: %s", e)
+        return False

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -615,7 +615,7 @@ class CLIPoller:
         try:
             from core.cli import _set_readiness
             from core.cli.session_state import _scheduler_service_ctx
-            from core.cli.startup import check_readiness
+            from core.lifecycle.startup import check_readiness
 
             _set_readiness(check_readiness())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.85.0"
+version = "0.86.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"
@@ -117,14 +117,12 @@ ignore_imports = [
     "core.server.supervised.services -> core.cli.session_state",
     "core.server.supervised.services -> core.cli.tool_handlers",
     "core.server.supervised.services -> core.cli.bootstrap",
-    "core.lifecycle.bootstrap -> core.cli.startup",
     "core.agent.worker -> core.cli.tool_handlers",
     # Tier 3 #7 — loop.py was split into core/agent/loop/ package
     "core.agent.loop.loop -> core.cli.commands",
     "core.agent.approval -> core.cli",
     "core.server.ipc_server.poller -> core.cli",
     "core.server.ipc_server.poller -> core.cli.session_state",
-    "core.server.ipc_server.poller -> core.cli.startup",
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/_live_audit_runner.py
+++ b/tests/_live_audit_runner.py
@@ -23,7 +23,7 @@ from core.agent.conversation import ConversationContext  # noqa: E402
 from core.agent.loop import AgenticLoop  # noqa: E402
 from core.agent.tool_executor import ToolExecutor  # noqa: E402
 from core.cli import _build_tool_handlers, _set_readiness  # noqa: E402
-from core.cli.startup import check_readiness  # noqa: E402
+from core.lifecycle.startup import check_readiness  # noqa: E402
 
 readiness = check_readiness()
 readiness.force_dry_run = True

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -354,9 +354,9 @@ class TestAgenticLoop:
         """Test key_registration_gate returns None on /quit."""
         from unittest.mock import patch as _patch
 
-        from core.cli.startup import key_registration_gate
+        from core.cli.onboarding import key_registration_gate
 
-        with _patch("core.cli.startup.console") as mock_console:
+        with _patch("core.cli.onboarding.console") as mock_console:
             mock_console.input.return_value = "/quit"
             result = key_registration_gate()
             assert result is None
@@ -365,12 +365,12 @@ class TestAgenticLoop:
         """Test key_registration_gate accepts pasted API key."""
         from unittest.mock import patch as _patch
 
-        from core.cli.startup import key_registration_gate
+        from core.cli.onboarding import key_registration_gate
 
         with (
-            _patch("core.cli.startup.console") as mock_console,
-            _patch("core.cli.startup._upsert_env"),
-            _patch("core.cli.startup.settings") as mock_settings,
+            _patch("core.cli.onboarding.console") as mock_console,
+            _patch("core.cli.onboarding._upsert_env"),
+            _patch("core.cli.onboarding.settings") as mock_settings,
         ):
             mock_settings.anthropic_api_key = ""
             mock_settings.openai_api_key = ""

--- a/tests/test_e2e_live_llm.py
+++ b/tests/test_e2e_live_llm.py
@@ -45,7 +45,7 @@ def _make_loop(
         _build_tool_handlers,
         _set_readiness,
     )
-    from core.cli.startup import check_readiness
+    from core.lifecycle.startup import check_readiness
 
     readiness = check_readiness()
     if not force_dry_run:
@@ -533,8 +533,8 @@ class TestKeyRegistrationGateLive:
         """Key gate returns None on /quit."""
         from unittest.mock import patch
 
-        from core.cli.startup import key_registration_gate
+        from core.cli.onboarding import key_registration_gate
 
-        with patch("core.cli.startup.console") as mock_console:
+        with patch("core.cli.onboarding.console") as mock_console:
             mock_console.input.return_value = "/quit"
             assert key_registration_gate() is None

--- a/tests/test_plan_mode.py
+++ b/tests/test_plan_mode.py
@@ -354,7 +354,7 @@ class TestHandleCreatePlanAutoExecute:
     def _setup_readiness(self) -> None:
         """Ensure readiness is set so handler builders work."""
         from core.cli import _set_readiness
-        from core.cli.startup import ReadinessReport
+        from core.lifecycle.startup import ReadinessReport
 
         readiness = ReadinessReport()
         readiness.force_dry_run = True
@@ -480,7 +480,7 @@ class TestPlanCacheInvariants:
     @pytest.fixture(autouse=True)
     def _setup_readiness(self, tmp_path: Any, monkeypatch: Any) -> None:
         from core.cli import _set_readiness
-        from core.cli.startup import ReadinessReport
+        from core.lifecycle.startup import ReadinessReport
 
         readiness = ReadinessReport()
         readiness.force_dry_run = True

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from core.cli.startup import (
+from core.cli.onboarding import detect_api_key, env_setup_wizard
+from core.config import ANTHROPIC_PRIMARY, GLM_PRIMARY, OPENAI_PRIMARY
+from core.lifecycle.startup import (
     Capability,
     ReadinessReport,
     check_readiness,
-    detect_api_key,
-    env_setup_wizard,
     setup_project_memory,
 )
-from core.config import ANTHROPIC_PRIMARY, GLM_PRIMARY, OPENAI_PRIMARY
 
 
 def _no_keys_mock(mock_settings):
@@ -61,7 +60,7 @@ class TestReadinessReport:
 
 class TestCheckReadiness:
     def test_without_api_key(self, tmp_path: Path):
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             report = check_readiness(tmp_path)
 
@@ -73,7 +72,7 @@ class TestCheckReadiness:
         assert llm_cap.available is False
 
     def test_with_anthropic_key(self, tmp_path: Path):
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             mock_settings.anthropic_api_key = "sk-ant-real-key-here"
             report = check_readiness(tmp_path)
@@ -86,7 +85,7 @@ class TestCheckReadiness:
 
     def test_with_openai_key_only(self, tmp_path: Path):
         """ANY provider key unblocks — OpenAI alone should suffice."""
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             mock_settings.openai_api_key = "sk-proj-real-key-here"
             report = check_readiness(tmp_path)
@@ -96,7 +95,7 @@ class TestCheckReadiness:
 
     def test_with_glm_key_only(self, tmp_path: Path):
         """ANY provider key unblocks — GLM alone should suffice."""
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             mock_settings.zai_api_key = "abc12345.def67890"
             report = check_readiness(tmp_path)
@@ -105,7 +104,7 @@ class TestCheckReadiness:
         assert report.blocked is False
 
     def test_placeholder_key_treated_as_missing(self, tmp_path: Path):
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             mock_settings.anthropic_api_key = "sk-ant-..."
             mock_settings.openai_api_key = "sk-..."
             mock_settings.zai_api_key = "..."
@@ -115,7 +114,7 @@ class TestCheckReadiness:
         assert report.force_dry_run is True
 
     def test_env_file_check(self, tmp_path: Path):
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
 
             # No .env, no .env.example
@@ -136,7 +135,7 @@ class TestCheckReadiness:
             assert report.has_env_file is True
 
     def test_project_memory_check(self, tmp_path: Path):
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
 
             # No .geode/memory/PROJECT.md → unavailable
@@ -155,7 +154,7 @@ class TestCheckReadiness:
             assert mem_cap.available is True
 
     def test_always_available_capabilities(self, tmp_path: Path):
-        with patch("core.cli.startup.settings") as mock_settings:
+        with patch("core.lifecycle.startup.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             report = check_readiness(tmp_path)
 
@@ -216,8 +215,8 @@ class TestEnvSetupWizard:
     def test_wizard_skips_on_enter_after_choosing_path_b(self, tmp_path):
         """User picks Path B then presses Enter for every key → no keys set."""
         with (
-            patch("core.cli.startup.console") as mock_console,
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.cli.onboarding.console") as mock_console,
+            patch("core.cli.onboarding.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["2", "", "", ""]
@@ -227,9 +226,9 @@ class TestEnvSetupWizard:
     def test_wizard_sets_key_via_path_b(self, tmp_path):
         """User picks Path B and enters an Anthropic key."""
         with (
-            patch("core.cli.startup.console") as mock_console,
-            patch("core.cli.startup._upsert_env"),
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.cli.onboarding.console") as mock_console,
+            patch("core.cli.onboarding._upsert_env"),
+            patch("core.cli.onboarding.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = [
@@ -244,8 +243,8 @@ class TestEnvSetupWizard:
     def test_wizard_handles_ctrl_c(self, tmp_path):
         """Ctrl+C at the menu prompt gracefully stops."""
         with (
-            patch("core.cli.startup.console") as mock_console,
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.cli.onboarding.console") as mock_console,
+            patch("core.cli.onboarding.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = KeyboardInterrupt
@@ -255,9 +254,9 @@ class TestEnvSetupWizard:
     def test_wizard_path_a_subscription(self, tmp_path):
         """Path A — user chose subscription; OAuth detected on probe."""
         with (
-            patch("core.cli.startup.console") as mock_console,
-            patch("core.cli.startup.detect_subscription_oauth", return_value="openai-codex"),
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.cli.onboarding.console") as mock_console,
+            patch("core.cli.onboarding.detect_subscription_oauth", return_value="openai-codex"),
+            patch("core.cli.onboarding.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["1", ""]  # menu, then Enter on prompt
@@ -267,9 +266,9 @@ class TestEnvSetupWizard:
     def test_wizard_path_a_no_oauth_found(self, tmp_path):
         """Path A — user chose subscription but no token at ~/.codex/auth.json."""
         with (
-            patch("core.cli.startup.console") as mock_console,
-            patch("core.cli.startup.detect_subscription_oauth", return_value=None),
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.cli.onboarding.console") as mock_console,
+            patch("core.cli.onboarding.detect_subscription_oauth", return_value=None),
+            patch("core.cli.onboarding.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["1", ""]
@@ -280,8 +279,8 @@ class TestEnvSetupWizard:
         """Path C — user chose skip (dry-run). Returns True so wizard
         won't re-prompt on next launch."""
         with (
-            patch("core.cli.startup.console") as mock_console,
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.cli.onboarding.console") as mock_console,
+            patch("core.cli.onboarding.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["3"]
@@ -294,12 +293,12 @@ class TestDetectSubscriptionOAuth:
 
     def test_no_credentials_returns_none(self):
         with patch("core.auth.codex_cli_oauth.read_codex_cli_credentials", return_value=None):
-            from core.cli.startup import detect_subscription_oauth
+            from core.lifecycle.startup import detect_subscription_oauth
 
             assert detect_subscription_oauth() is None
 
     def test_returns_provider_id_on_success(self):
-        from core.cli.startup import detect_subscription_oauth
+        from core.lifecycle.startup import detect_subscription_oauth
 
         fake_creds = {"access_token": "tok-abc", "refresh_token": "rt", "expires_at": 9999999999.0}
         with (
@@ -307,7 +306,7 @@ class TestDetectSubscriptionOAuth:
                 "core.auth.codex_cli_oauth.read_codex_cli_credentials",
                 return_value=fake_creds,
             ),
-            patch("core.cli.startup.log"),
+            patch("core.lifecycle.startup.log"),
         ):
             result = detect_subscription_oauth()
         assert result == "openai-codex"
@@ -317,7 +316,7 @@ class TestDetectSubscriptionOAuth:
             "core.auth.codex_cli_oauth.read_codex_cli_credentials",
             side_effect=OSError("nope"),
         ):
-            from core.cli.startup import detect_subscription_oauth
+            from core.lifecycle.startup import detect_subscription_oauth
 
             assert detect_subscription_oauth() is None
 
@@ -326,12 +325,12 @@ class TestIsPlaceholder:
     """Test _is_placeholder helper."""
 
     def test_ellipsis_exact(self):
-        from core.cli.startup import _is_placeholder
+        from core.lifecycle.startup import _is_placeholder
 
         assert _is_placeholder("...") is True
 
     def test_prefixed_ellipsis(self):
-        from core.cli.startup import _is_placeholder
+        from core.lifecycle.startup import _is_placeholder
 
         assert _is_placeholder("sk-ant-...") is True
         assert _is_placeholder("sk-...") is True
@@ -339,7 +338,7 @@ class TestIsPlaceholder:
         assert _is_placeholder("BSA...") is True
 
     def test_real_value_not_placeholder(self):
-        from core.cli.startup import _is_placeholder
+        from core.lifecycle.startup import _is_placeholder
 
         assert _is_placeholder("sk-ant-api03-realkey123456789") is False
         assert _is_placeholder("") is False
@@ -347,7 +346,7 @@ class TestIsPlaceholder:
         assert _is_placeholder("true") is False
 
     def test_trailing_dots_not_three(self):
-        from core.cli.startup import _is_placeholder
+        from core.lifecycle.startup import _is_placeholder
 
         # Only exactly "..." at end counts
         assert _is_placeholder("value..") is False
@@ -358,7 +357,7 @@ class TestAutoGenerateEnv:
     """Test auto_generate_env function."""
 
     def test_creates_env_from_example(self, tmp_path: Path):
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         example = tmp_path / ".env.example"
         example.write_text("ANTHROPIC_API_KEY=sk-ant-...\nDEBUG=true\n")
@@ -377,7 +376,7 @@ class TestAutoGenerateEnv:
 
     def test_env_file_permissions(self, tmp_path: Path):
         """P0-1: .env must have 0o600 permissions (owner read/write only)."""
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         example = tmp_path / ".env.example"
         example.write_text("KEY=sk-ant-...\n")
@@ -389,7 +388,7 @@ class TestAutoGenerateEnv:
 
     def test_atomic_write_no_partial(self, tmp_path: Path):
         """P0-2: .env should not exist as .tmp after successful write."""
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         example = tmp_path / ".env.example"
         example.write_text("KEY=value\n")
@@ -399,7 +398,7 @@ class TestAutoGenerateEnv:
         assert (tmp_path / ".env").exists()
 
     def test_skips_existing_env(self, tmp_path: Path):
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         example = tmp_path / ".env.example"
         example.write_text("KEY=sk-...\n")
@@ -412,7 +411,7 @@ class TestAutoGenerateEnv:
         assert env.read_text() == "KEY=my-real-key\n"
 
     def test_no_example_file(self, tmp_path: Path):
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         # Neither .env nor .env.example exist
         result = auto_generate_env(tmp_path)
@@ -420,7 +419,7 @@ class TestAutoGenerateEnv:
         assert not (tmp_path / ".env").exists()
 
     def test_replaces_placeholders(self, tmp_path: Path):
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         example = tmp_path / ".env.example"
         example.write_text(
@@ -449,7 +448,7 @@ class TestAutoGenerateEnv:
         assert "GEODE_MODEL=claude-opus-4-6" in content
 
     def test_preserves_comments(self, tmp_path: Path):
-        from core.cli.startup import auto_generate_env
+        from core.lifecycle.startup import auto_generate_env
 
         example = tmp_path / ".env.example"
         example.write_text(
@@ -596,7 +595,7 @@ class TestSetupUserProfileWarning:
         """setup_user_profile() should log.warning on failure, not log.debug."""
         from unittest.mock import MagicMock
 
-        from core.cli.startup import setup_user_profile
+        from core.lifecycle.startup import setup_user_profile
 
         mock_profile = MagicMock()
         mock_profile.ensure_structure.side_effect = RuntimeError("boom")
@@ -606,7 +605,7 @@ class TestSetupUserProfileWarning:
                 "core.memory.user_profile.FileBasedUserProfile",
                 return_value=mock_profile,
             ),
-            patch("core.cli.startup.log") as mock_log,
+            patch("core.lifecycle.startup.log") as mock_log,
         ):
             result = setup_user_profile()
             assert result is False
@@ -616,7 +615,7 @@ class TestSetupUserProfileWarning:
     def test_returns_false_on_failure(self):
         from unittest.mock import MagicMock
 
-        from core.cli.startup import setup_user_profile
+        from core.lifecycle.startup import setup_user_profile
 
         mock_profile = MagicMock()
         mock_profile.ensure_structure.side_effect = OSError("denied")
@@ -639,7 +638,7 @@ class TestReadinessProfileStatus:
         mock_profile_instance.exists.return_value = True
 
         with (
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.lifecycle.startup.settings") as mock_settings,
             patch(
                 "core.memory.user_profile.FileBasedUserProfile",
                 return_value=mock_profile_instance,
@@ -660,7 +659,7 @@ class TestReadinessProfileStatus:
         mock_profile_instance.exists.return_value = False
 
         with (
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.lifecycle.startup.settings") as mock_settings,
             patch(
                 "core.memory.user_profile.FileBasedUserProfile",
                 return_value=mock_profile_instance,
@@ -677,7 +676,7 @@ class TestReadinessProfileStatus:
     def test_profile_load_exception_handled(self, tmp_path: Path):
         """If FileBasedUserProfile raises, profile shows as unavailable."""
         with (
-            patch("core.cli.startup.settings") as mock_settings,
+            patch("core.lifecycle.startup.settings") as mock_settings,
             patch(
                 "core.memory.user_profile.FileBasedUserProfile",
                 side_effect=RuntimeError("broken"),

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.84.0"
+version = "0.85.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **A5 deferred 작업 완성** — A5a(v0.85.0)이 만든 발판 위에서 startup.py 자체를 책임별로 분리.
- **2 ignore_imports 영구 제거**: `lifecycle.bootstrap → cli.startup` (이젠 internal lifecycle), `server.poller → cli.startup` (이젠 server → lifecycle, allowed).
- 호출자 15+ 사이트가 책임 따라 import 분기. 함수 본문 byte-identical.
- E2E A (68.4) 변동 없음. pytest 4345 passed.

## Why
v0.82.0 OAuth 점검 중 발견한 architectural 결함. `startup.py`가 lifecycle data inspection (check_readiness, ReadinessReport, etc.) + interactive console wizard (env_setup_wizard, key_registration_gate) + slash command dispatch (cmd_login, cmd_key) 3가지 책임을 한 파일에 묶고 있어 layer 위반.

단순 mv로 안 풀린 이유: startup이 cli._helpers + commands.cmd_login/cmd_key를 호출 → lifecycle로 가면 새 위반 발생.

A5a (v0.85.0)이 _helpers의 IO util을 utils로 추출 → 의존성 blocker 제거. 이번 PR이 startup 본체를 책임별로 분리.

## Changes

### 핵심 분배
| 책임 | 모듈 | 함수/클래스 |
|---|---|---|
| **Data inspection** | `core/lifecycle/startup.py` (287L) | `auto_generate_env`, `_is_placeholder`, `_has_any_llm_key`, `detect_subscription_oauth`, `Capability`, `ReadinessReport`, `check_readiness`, `setup_project_memory`, `setup_user_profile` |
| **Interactive UI** | `core/cli/onboarding.py` (272L) | `env_setup_wizard`, `_wizard_subscription_path`, `_wizard_api_key_path`, `detect_api_key` (+`_KEY_PATTERNS`), `key_registration_gate`, `render_readiness` |

### 호출자 업데이트 (15+ 사이트)
| File | Change |
|------|--------|
| `core/lifecycle/bootstrap.py:721` | `cli.startup` → `lifecycle.startup` |
| `core/server/ipc_server/poller.py:581` | 동일 |
| `core/cli/dispatcher.py:34` | `check_readiness, render_readiness` 두 줄로 분리 (lifecycle + onboarding) |
| `core/cli/session_state.py:19` | `ReadinessReport` → lifecycle |
| `core/cli/typer_serve.py:18` | `check_readiness` → lifecycle |
| `core/cli/welcome.py:12,89` | multi-line import 분기 |
| `core/cli/bootstrap.py:190` | `check_readiness` → lifecycle |
| `core/cli/typer_commands.py:164` | multi-line 분기 |
| `core/cli/commands/key.py:178` | `_is_placeholder` → lifecycle |
| `core/cli/tool_handlers/system.py:22` | 두 줄 분리 |
| `tests/test_startup.py` | 80+ 라인 patch 분기 |
| `tests/test_agentic_loop.py:357,359,368,371-373` | wizard 관련 → onboarding |
| `tests/test_e2e_live_llm.py:48,536-538` | 분기 |
| `tests/test_plan_mode.py:357,483` | `ReadinessReport` → lifecycle |
| `tests/_live_audit_runner.py:26` | lifecycle |

### pyproject.toml
- `core.lifecycle.bootstrap → core.cli.startup` 제거 (이젠 lifecycle internal)
- `core.server.ipc_server.poller → core.cli.startup` 제거 (이젠 server → lifecycle, allowed)

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 책임 매핑 정확성 | Implemented | 15 함수/클래스 모두 console.input/print 의존 여부에 따라 분류 |
| 함수 본문 byte-identical | Verified | 본문 변경 0, import만 변경 |
| 호출자 15+ 사이트 분기 | Verified | grep `core\.cli\.startup` 0 hit |
| ignore_imports 2 entries 제거 | Implemented | lifecycle.bootstrap + server.poller |
| 새 위반 발생 0 | Verified | import-linter 4/4 contracts kept |
| underscore-prefixed local var | Verified | 0건 (사용자 정책 준수) |

## Verification
- [x] ruff check / ruff format 통과
- [x] mypy 통과 (332 source files, +1)
- [x] pytest 4345 passed, 1 skipped, 24 deselected — v0.85.0 직후와 동일
- [x] startup + onboarding + agentic_loop + e2e 215+ 테스트 통과
- [x] **import-linter `lint-imports`**: 4/4 contracts kept (22→19 entries)
- [x] E2E Cowboy Bebop A (68.4) 변동 없음

## A5 누적 진척
| PR | 변경 | ignore_imports |
|---|---|---|
| v0.85.0 (A5a) | _helpers 4 util → utils | 22 (변동 없음) |
| **v0.86.0 (A5b, this)** | startup.py 책임 분리 | **22 → 19** (-2) |

## Reference
- v0.82.0 점검 trilogy (PR #919/#921/#923)
- A5 폐기 사유 분석 (이번 세션 이전 turn)