### PR TITLE
test(shared_services): v0.82.0 staleness 회귀 테스트 추가

### DIFF
--- a/tests/test_shared_services.py
+++ b/tests/test_shared_services.py
@@ -167,6 +167,34 @@ class TestBuildSharedServices:
         _, loop = services.create_session(SessionMode.DAEMON)
         assert loop.model == settings.model
 
+    def test_model_switch_propagates_across_sessions(self) -> None:
+        """v0.82.0 staleness regression — mid-flight `settings.model`
+        mutation must reach the next session.
+
+        Initial single-session check (``test_model_resolved_per_session``)
+        only proves boot-time consistency. The original v0.82.0 bug
+        survived that check because the cached ``_model`` field happened
+        to match ``settings.model`` at boot — divergence only emerged
+        after ``cmd_model`` mutated ``settings.model`` mid-flight. This
+        test reproduces that scenario without invoking the LLM.
+        """
+        from core.config import ANTHROPIC_PRIMARY, OPENAI_PRIMARY, settings
+        from core.server.supervised.services import SessionMode
+
+        services = build_shared_services()
+        original = settings.model
+        try:
+            settings.model = ANTHROPIC_PRIMARY
+            _, loop_a = services.create_session(SessionMode.DAEMON)
+            assert loop_a.model == ANTHROPIC_PRIMARY
+
+            settings.model = OPENAI_PRIMARY
+            _, loop_b = services.create_session(SessionMode.DAEMON)
+            assert loop_b.model == OPENAI_PRIMARY
+            assert loop_a.model == ANTHROPIC_PRIMARY
+        finally:
+            settings.model = original
+
     def test_no_agentic_ref_attribute(self) -> None:
         """SharedServices should not have agentic_ref (removed in system-hardening)."""
         services = build_shared_services()


### PR DESCRIPTION
## Summary
- v0.82.0 fix(`SharedServices`의 frozen `_model` 제거)의 회귀 회피용 단위 테스트 1건 추가.
- mid-flight `settings.model` 변경 → 다음 세션 fresh-read 시나리오를 LLM 호출 없이 재현.

## Why
세션 53 핸드오프에 남아 있던 manual verify pending 두 항목 중 **M2 (`/model` switch verdict 정확성)** 정합 잠금. 기존 `test_model_resolved_per_session`은 boot-time 일관성만 확인하므로 v0.82.0 인시던트(daemon 부팅 후 `cmd_model`로 mutation → 이후 IPC 세션이 stale 모델 사용)의 정확한 재현 시나리오가 비어 있었다.

## Changes
| File | Change |
|------|--------|
| `tests/test_shared_services.py` | `test_model_switch_propagates_across_sessions` 추가 (28 LOC) — `ANTHROPIC_PRIMARY → OPENAI_PRIMARY` 교체 후 두 세션이 각자 시점 값을 fresh-read 하는지 검증 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| M2 (verdict 정확성) | Implemented | 단위 테스트로 staleness 회귀 영구 잠금 |
| M1 (OAuth Codex Plus 라우팅) | Deferred to manual run | 자동화 불가 leg(실제 HTTP) — 다음 세션에서 사용자가 1-prompt + log grep으로 확인 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 332 source files, 0 errors
- [x] `uv run pytest tests/test_shared_services.py -m "not live"` — 28 passed (27 → 28)
- [x] selective regression: `tests/test_commands.py + tests/test_codex_provider.py + tests/test_routing_policy.py + tests/test_provider_switching.py` — 134 passed

## Reference
- 회귀 대상 fix: v0.82.0 (`SharedServices` frozen `_model` 제거, CHANGELOG `## [0.82.0]`)
- 세션 53 핸드오프 `Manual verify pending` 항목 중 M2 자동화 부분
- Codebase grounding: `core/server/supervised/services.py:108-118` (v0.82.0 주석), `core/cli/commands/model.py:36-47` (`cmd_model` mutation 경로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)