### PR TITLE
release(v0.87.1): v0.82.0 staleness 회귀 단위 테스트 릴리스

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.87.1] — 2026-05-08
+
+> **Hardening — v0.82.0 staleness 인시던트의 재발 방지용 단위 테스트 추가.**
+> v0.82.0에서 `SharedServices`의 frozen `_model` 필드를 제거해 `cmd_model`
+> 변경이 다음 IPC 세션에 즉시 반영되도록 고쳤지만, 기존 단위 테스트
+> `test_model_resolved_per_session`은 boot-time 일관성만 검사할 뿐
+> mid-flight `settings.model` 변경 → 다음 세션 fresh-read 시나리오를
+> 직접 재현하지 않았다. 이번 패치는 정확히 그 staleness 시나리오를 LLM
+> 호출 없이 강제(ANTHROPIC_PRIMARY ↔ OPENAI_PRIMARY 교체)해 v0.82.0
+> 인시던트의 provider 교차(Anthropic API ↔ Codex Plus OAuth) 패턴까지
+> 회귀로 영구 잠근다. 동작·스키마 변경 0; tests/ 전용 변경. pytest
+> 4346 passed (4345→4346); E2E `geode analyze "Cowboy Bebop" --dry-run`
+> A (68.4) unchanged.
+
+### Added
+- **`tests/test_shared_services.py::test_model_switch_propagates_across_sessions`** — v0.82.0 회귀 잠금. `settings.model`을 `ANTHROPIC_PRIMARY`로 설정 후 `create_session(DAEMON)` → `loop_a.model == ANTHROPIC_PRIMARY` 확인. 그 직후 `settings.model = OPENAI_PRIMARY`로 변경하고 `create_session(DAEMON)` → `loop_b.model == OPENAI_PRIMARY`까지 검증해 `SharedServices`가 매 세션마다 `settings.model`을 fresh-read 함을 증명. 두 세션 인스턴스가 독립적인지 (`loop_a.model`은 첫 시점 값 유지) 도 함께 어서트.
+
 ## [0.87.0] — 2026-05-08
 
 > **`core/lifecycle/` → `core/wiring/` rename — `startup` 흡수 후에도 모호하던 폴더 이름을 의도가 명확한 이름으로 교체.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.87.0
+- **Version**: 0.87.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 303 core + 29 plugins = 332
-- **Tests**: 4345 (+24 live)
+- **Tests**: 4346 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.87.0 — Long-running Autonomous Execution Harness
+# GEODE v0.87.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.87.0"
+version = "0.87.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.87.0"
+version = "0.87.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.87.1 PATCH 릴리스. PR #931에서 develop에 머지된 `test_model_switch_propagates_across_sessions` 회귀 테스트를 main에 반영.
- 4 location 동기: CHANGELOG (v0.87.1 신규 entry), CLAUDE.md (Version + Tests count 4345→4346), README.md, pyproject.toml + uv.lock 자동 동기.

## Why
세션 53 핸드오프의 `Manual verify pending` 두 항목 중 자동화 가능 부분(M2)을 v0.82.0 staleness 잠금으로 마무리. PR #931이 develop에 머지된 만큼 main으로 흘려보내려면 PATCH 릴리스가 필요하고 (CANNOT: "No version mismatch across 4 locations"), 그 동기 작업이 본 PR의 전부.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | `[0.87.1] — 2026-05-08` 섹션 신설 + Hardening 서술 + Added 엔트리 |
| `CLAUDE.md` | Version `0.87.0 → 0.87.1`, Tests `4345 → 4346` |
| `README.md` | 헤더 `GEODE v0.87.0 → v0.87.1` |
| `pyproject.toml` | `version = "0.87.0" → "0.87.1"` |
| `uv.lock` | geode self-package 버전 0.87.0 → 0.87.1 (자동 동기) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 332 source files, 0 errors
- [x] `uv run pytest tests/test_shared_services.py -m "not live"` — 28 passed
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4) unchanged
- [x] 4 location 버전 일치 grep 확인 (`pyproject.toml:3`, `CLAUDE.md:11`, `README.md:21`, `CHANGELOG.md:31`)

## Reference
- 본체 변경 PR: #931 (이미 develop 머지)
- 회귀 대상 fix: v0.82.0 (`SharedServices` frozen `_model` 제거)
- 세션 53 핸드오프 M2 → 본 릴리스로 닫힘. M1 (live OAuth Codex 라우팅 verify)은 메모리 `m1_oauth_codex_routing_verify.md`에 5단계 절차로 핸드오프.

🤖 Generated with [Claude Code](https://claude.com/claude-code)