### PR TITLE
perf(v0.88.0): anthropic SDK module-level lazy loading (-184ms cold start, -49%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.0] — 2026-05-08
+
+> **Performance — anthropic SDK module-level lazy loading.**
+> CLI 콜드 스타트 경로(`geode about` / `geode doctor` / `geode --help`)는
+> 그동안 `core.runtime` import 한 번만으로 **anthropic SDK 248 ms 그래프
+> 전체**를 끌어왔다. anthropic을 한 번도 호출하지 않는 user 도(예: Codex
+> Plus 단독, GLM 단독)도 매 invocation 마다 이 비용을 지불해 왔으며,
+> `python -X importtime -c "import core.runtime"` 으로 측정 시 anthropic
+> 트리(`anthropic.types.*`, `httpx.*`, `anyio.*`)가 cumulative 248 ms 를
+> 차지. 이번 PR 은 anthropic 을 **PEP 562 모듈-레벨 `__getattr__`** 로
+> defer 해, 진짜로 anthropic 을 만지는 코드(에이전틱 호출, 에러 분류,
+> failover) 가 처음 실행될 때까지 SDK 로드를 미룬다.
+>
+> **측정 (warm cache, `import core.runtime`):**
+> - Before (main): 354–386 ms (median ~370 ms)
+> - After (B1):   183–190 ms (median ~186 ms)
+> - **Δ: −184 ms / −49 %** (3-run median)
+>
+> 검증: `import core.runtime` 후 `'anthropic' in sys.modules` 가 `False`.
+> 첫 ``classify_llm_error`` / failover dispatch / agentic 호출이 일어나면
+> 그 시점에 `__getattr__` 이 anthropic 을 1 회 로드.  pytest 4346 passed
+> (변동 없음); E2E `geode analyze "Cowboy Bebop" --dry-run` A (68.4) 동일.
+
+### Changed
+- **`core/llm/errors.py`** — top-level `import anthropic` 제거.  7 개 `LLM*Error` 별칭(`LLMTimeoutError`, `LLMConnectionError`, `LLMRateLimitError`, `LLMAuthenticationError`, `LLMBadRequestError`, `LLMAPIStatusError`, `LLMInternalServerError`)은 module-level `__getattr__` 으로 lazy 해석.  `_ANTHROPIC_ALIAS_MAP` 로 anthropic SDK 의 실제 클래스 이름을 추적; 첫 접근 시 `globals()` 에 캐시.  `__all__` 추가로 mypy `--no-implicit-reexport` 통과.  `classify_llm_error` 는 함수-로컬 `import anthropic` 후 `anthropic.RateLimitError` 등 SDK 클래스를 직접 참조 (in-module 레퍼런스는 `__getattr__` 을 거치지 않으므로).
+- **`core/llm/provider_dispatch.py`** — 모듈-레벨 `import anthropic` 제거.  Dispatch table 의 `_anthropic_retryable` / `_anthropic_bad_request` / `_anthropic_get_client` 헬퍼 도입(기존 `_openai_retryable` / `_openai_bad_request` 의 anthropic 카운터파트).  Lambda capture 가 아닌 함수 레퍼런스로 dispatch table 등록 → 정의가 모듈 import 시점에 이루어지지 않음.
+- **`core/llm/providers/anthropic.py`** — top-level `import anthropic` + `from anthropic.types import TextBlockParam` 제거.  `RETRYABLE_ERRORS` / `NON_RETRYABLE_ERRORS` / `TextBlockParam` 은 `__getattr__` 로 lazy.  Type annotation 은 `TYPE_CHECKING` 블록에 보존(IDE / mypy 정적 surface 유지).  Function 본체에서 anthropic SDK 를 만지는 부분(`get_anthropic_client`, `get_async_anthropic_client`, `system_with_cache`, `retry_with_backoff`)은 함수-로컬 `import anthropic`.  자기 모듈 내부에서 lazy 이름을 참조해야 하는 `retry_with_backoff` 는 `sys.modules[__name__].RETRYABLE_ERRORS` 로 PEP 562 우회.
+- **`core/llm/router/__init__.py`** — `from core.llm.errors import LLM*Error as LLM*Error` 7 개 eager 재-export 제거(파일 위치 1 곳, 240 ms 절약 핵심).  Public API 는 모듈-레벨 `__getattr__` 으로 보존(`from core.llm.router import LLMRateLimitError` 가 첫 접근 시 lazy 해석).  TYPE_CHECKING 블록은 mypy 정적 view 유지용.
+- **`core/llm/client.py`** — router/__init__.py 와 동일 패턴(LLM*Error 7 개를 lazy `__getattr__` 로 전환).
+- **`core/llm/router/calls/_failover.py`** — module-level `from core.llm.providers.anthropic import RETRYABLE_ERRORS, NON_RETRYABLE_ERRORS` 를 `call_with_failover` 함수 본체 안으로 이동.  Cold-start path 에서 `providers.anthropic.__getattr__` 호출 차단.
+- **`core/llm/router/calls/streaming.py`** — `RETRYABLE_ERRORS` import 를 `call_llm_streaming` 함수-로컬로 이동.  같은 이유.
+
+### Performance
+- **CLI 콜드 스타트 −184 ms / −49 %** (warm cache, 3-run median).  `import core.runtime` 후 `'anthropic' in sys.modules == False`.  Anthropic 을 안 쓰는 셋업(Codex Plus only, GLM only)은 anthropic SDK 를 영원히 로드하지 않을 수 있게 됨.
+
 ## [0.87.1] — 2026-05-08
 
 > **Hardening — v0.82.0 staleness 인시던트의 재발 방지용 단위 테스트 추가.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.87.1
+- **Version**: 0.88.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.87.1 — Long-running Autonomous Execution Harness
+# GEODE v0.88.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -14,28 +14,37 @@ Prefer importing from the specific modules directly.
 
 from __future__ import annotations
 
-# Re-export from errors
-from core.llm.errors import (
-    LLMAPIStatusError as LLMAPIStatusError,
-)
-from core.llm.errors import (
-    LLMAuthenticationError as LLMAuthenticationError,
-)
-from core.llm.errors import (
-    LLMBadRequestError as LLMBadRequestError,
-)
-from core.llm.errors import (
-    LLMConnectionError as LLMConnectionError,
-)
-from core.llm.errors import (
-    LLMInternalServerError as LLMInternalServerError,
-)
-from core.llm.errors import (
-    LLMRateLimitError as LLMRateLimitError,
-)
-from core.llm.errors import (
-    LLMTimeoutError as LLMTimeoutError,
-)
+from typing import TYPE_CHECKING, Any
+
+# v0.88.0 — LLM*Error re-exports lazy-resolved through ``__getattr__`` at
+# the bottom of this module to keep the cold-start path off the 248 ms
+# anthropic SDK graph.  Same pattern as ``core.llm.router`` (sister
+# re-export module).  TYPE_CHECKING block below preserves IDE / mypy
+# visibility without paying the runtime ``from core.llm.errors import …``
+# cost — those imports go through ``errors.__getattr__`` which loads
+# anthropic.
+if TYPE_CHECKING:
+    from core.llm.errors import (
+        LLMAPIStatusError as LLMAPIStatusError,
+    )
+    from core.llm.errors import (
+        LLMAuthenticationError as LLMAuthenticationError,
+    )
+    from core.llm.errors import (
+        LLMBadRequestError as LLMBadRequestError,
+    )
+    from core.llm.errors import (
+        LLMConnectionError as LLMConnectionError,
+    )
+    from core.llm.errors import (
+        LLMInternalServerError as LLMInternalServerError,
+    )
+    from core.llm.errors import (
+        LLMRateLimitError as LLMRateLimitError,
+    )
+    from core.llm.errors import (
+        LLMTimeoutError as LLMTimeoutError,
+    )
 
 # Re-export from fallback
 from core.llm.fallback import (
@@ -133,3 +142,30 @@ from core.llm.router import (
 from core.llm.router import (
     track_token_usage as track_token_usage,
 )
+
+# v0.88.0 — module-level ``__getattr__`` for lazy LLM*Error re-exports.
+# Placed after all eager imports so ruff E402 stays happy.  The
+# ``_LAZY_ERROR_NAMES`` set is the runtime mirror of the TYPE_CHECKING
+# block at the top of the file.
+_LAZY_ERROR_NAMES = frozenset(
+    {
+        "LLMAPIStatusError",
+        "LLMAuthenticationError",
+        "LLMBadRequestError",
+        "LLMConnectionError",
+        "LLMInternalServerError",
+        "LLMRateLimitError",
+        "LLMTimeoutError",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 hook — resolve lazy LLM*Error re-exports on first access."""
+    if name in _LAZY_ERROR_NAMES:
+        from core.llm import errors
+
+        cls = getattr(errors, name)
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -6,9 +6,86 @@ so that no consumer needs to import provider SDKs directly.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import anthropic
+if TYPE_CHECKING:
+    # v0.88.0 — these names resolve through ``__getattr__`` below on first use;
+    # the static SDK reference table lives in ``_ANTHROPIC_ALIAS_MAP``.  The
+    # TYPE_CHECKING re-exports give mypy / IDEs a static view of the public
+    # surface (``from core.llm.errors import LLMRateLimitError``) without
+    # re-introducing the eager ``import anthropic``.  These names never
+    # execute at runtime — runtime lookups go through ``__getattr__``.
+    from anthropic import (
+        APIConnectionError as LLMConnectionError,
+    )
+    from anthropic import (
+        APIStatusError as LLMAPIStatusError,
+    )
+    from anthropic import (
+        APITimeoutError as LLMTimeoutError,
+    )
+    from anthropic import (
+        AuthenticationError as LLMAuthenticationError,
+    )
+    from anthropic import (
+        BadRequestError as LLMBadRequestError,
+    )
+    from anthropic import (
+        InternalServerError as LLMInternalServerError,
+    )
+    from anthropic import (
+        RateLimitError as LLMRateLimitError,
+    )
+
+# v0.88.0 — explicit ``__all__`` re-export list.  Mypy's
+# ``--no-implicit-reexport`` rule otherwise fails on
+# ``from core.llm.errors import LLMRateLimitError`` because the alias is
+# bound only inside ``TYPE_CHECKING`` + ``__getattr__``.  Listing the
+# names here promises the module *will* expose them, giving mypy a green
+# light without re-introducing the eager ``import anthropic``.
+__all__ = [
+    "BillingError",
+    "LLMAPIStatusError",
+    "LLMAuthenticationError",
+    "LLMBadRequestError",
+    "LLMConnectionError",
+    "LLMInternalServerError",
+    "LLMRateLimitError",
+    "LLMTimeoutError",
+    "UserCancelledError",
+    "classify_llm_error",
+    "extract_billing_message",
+    "is_billing_fatal",
+    "is_request_fatal",
+]
+
+# v0.88.0 — anthropic SDK is module-level lazy.  Importing this module no
+# longer pulls 248 ms of ``anthropic`` graph at startup; the seven
+# ``LLM*Error`` aliases below are resolved on first attribute access via
+# the module-level ``__getattr__`` hook (PEP 562).  Cold-start path (CLI
+# ``geode about`` / ``geode doctor``) never imports anthropic; it loads
+# only when the agentic loop or fallback classifier touches an alias.
+_ANTHROPIC_ALIAS_MAP: dict[str, str] = {
+    "LLMTimeoutError": "APITimeoutError",
+    "LLMConnectionError": "APIConnectionError",
+    "LLMRateLimitError": "RateLimitError",
+    "LLMAuthenticationError": "AuthenticationError",
+    "LLMBadRequestError": "BadRequestError",
+    "LLMAPIStatusError": "APIStatusError",
+    "LLMInternalServerError": "InternalServerError",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 module-level lazy attribute — resolves anthropic aliases on demand."""
+    if name in _ANTHROPIC_ALIAS_MAP:
+        import anthropic
+
+        cls = getattr(anthropic, _ANTHROPIC_ALIAS_MAP[name])
+        globals()[name] = cls  # cache for future lookups
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # v0.52.2 — billing-fatal error codes by provider SDK shape.
 # Retrying these wastes 40s per call (5 attempts × exponential backoff)
@@ -109,16 +186,9 @@ class BillingError(Exception):
 
 
 # ---------------------------------------------------------------------------
-# LLM error type aliases — re-exported so CLI layer does NOT import anthropic
-# directly.  Keeps the Port/Adapter boundary clean.
+# LLM error type aliases — see TYPE_CHECKING block at top of module for
+# the static surface; ``__getattr__`` resolves the names lazily at runtime.
 # ---------------------------------------------------------------------------
-LLMTimeoutError = anthropic.APITimeoutError
-LLMConnectionError = anthropic.APIConnectionError
-LLMRateLimitError = anthropic.RateLimitError
-LLMAuthenticationError = anthropic.AuthenticationError
-LLMBadRequestError = anthropic.BadRequestError
-LLMAPIStatusError = anthropic.APIStatusError
-LLMInternalServerError = anthropic.InternalServerError
 
 
 # ---------------------------------------------------------------------------
@@ -180,17 +250,22 @@ def classify_llm_error(exc: Exception) -> tuple[str, str, str]:
     # --- Anthropic SDK errors ---
     if isinstance(exc, BillingError):
         return _ERROR_CLASSIFICATION["billing"]
-    if isinstance(exc, LLMRateLimitError):
+    # v0.88.0 — fetch the lazy aliases via the module-level ``__getattr__``
+    # at first use so this function still works when ``classify_llm_error``
+    # runs as the first anthropic-touching code in the process.
+    import anthropic
+
+    if isinstance(exc, anthropic.RateLimitError):
         return _ERROR_CLASSIFICATION["rate_limit"]
-    if isinstance(exc, LLMTimeoutError):
+    if isinstance(exc, anthropic.APITimeoutError):
         return _ERROR_CLASSIFICATION["timeout"]
-    if isinstance(exc, LLMConnectionError):
+    if isinstance(exc, anthropic.APIConnectionError):
         return _ERROR_CLASSIFICATION["connection"]
-    if isinstance(exc, LLMAuthenticationError):
+    if isinstance(exc, anthropic.AuthenticationError):
         return _ERROR_CLASSIFICATION["auth"]
-    if isinstance(exc, LLMInternalServerError):
+    if isinstance(exc, anthropic.InternalServerError):
         return _ERROR_CLASSIFICATION["server"]
-    if isinstance(exc, LLMBadRequestError):
+    if isinstance(exc, anthropic.BadRequestError):
         msg = str(exc).lower()
         if "token" in msg or "context" in msg or "prompt exceeds" in msg or "max length" in msg:
             return _ERROR_CLASSIFICATION["context_overflow"]

--- a/core/llm/provider_dispatch.py
+++ b/core/llm/provider_dispatch.py
@@ -12,8 +12,6 @@ import time
 from collections.abc import Callable
 from typing import Any, TypeVar
 
-import anthropic
-
 from core.config import (
     ANTHROPIC_FALLBACK_CHAIN,
     GLM_FALLBACK_CHAIN,
@@ -23,12 +21,13 @@ from core.config import (
 )
 from core.hooks.utils import fire_hook
 from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
-from core.llm.providers.anthropic import (
-    RETRYABLE_ERRORS as _RETRYABLE_ERRORS,
-)
-from core.llm.providers.anthropic import (
-    get_anthropic_client,
-)
+
+# v0.88.0 — anthropic SDK is module-level lazy.  ``import anthropic`` and
+# the cross-module ``RETRYABLE_ERRORS`` / ``get_anthropic_client`` pulls
+# happen lazily inside the dispatch table lambdas / helper functions
+# below, mirroring the existing ``_openai_retryable`` /
+# ``_openai_bad_request`` pattern.  Cold-start path no longer pulls the
+# 248 ms anthropic graph through this module.
 
 log = logging.getLogger(__name__)
 
@@ -72,13 +71,40 @@ def _openai_bad_request() -> type[Exception]:
     return openai.BadRequestError
 
 
+def _anthropic_retryable() -> tuple[type[Exception], ...]:
+    """v0.88.0 — defer anthropic SDK + provider module load until first call.
+
+    Mirrors ``_openai_retryable``.  The lambda-only previous shape
+    captured ``_RETRYABLE_ERRORS`` from ``core.llm.providers.anthropic``
+    at module load, eagerly pulling 248 ms of anthropic.* into the
+    cold-start path even when no Anthropic call ever runs.
+    """
+    from core.llm.providers.anthropic import RETRYABLE_ERRORS
+
+    return RETRYABLE_ERRORS
+
+
+def _anthropic_bad_request() -> type[Exception]:
+    """v0.88.0 — lazy counterpart to ``_openai_bad_request``."""
+    import anthropic
+
+    return anthropic.BadRequestError
+
+
+def _anthropic_get_client() -> Any:
+    """v0.88.0 — defer ``get_anthropic_client`` import until first call."""
+    from core.llm.providers.anthropic import get_anthropic_client
+
+    return get_anthropic_client()
+
+
 # Lazy dispatch table — callables to avoid import-time side effects
 _PROVIDER_DISPATCH: dict[str, dict[str, Any]] = {
     "anthropic": {
-        "get_client": lambda: get_anthropic_client(),
+        "get_client": _anthropic_get_client,
         "fallback_chain": lambda: list(ANTHROPIC_FALLBACK_CHAIN),
-        "retryable_errors": lambda: _RETRYABLE_ERRORS,
-        "bad_request_error": lambda: anthropic.BadRequestError,
+        "retryable_errors": _anthropic_retryable,
+        "bad_request_error": _anthropic_bad_request,
         "circuit_breaker": lambda: __import__(
             "core.llm.providers.anthropic", fromlist=["get_circuit_breaker"]
         ).get_circuit_breaker(),

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import anthropic
 import httpx
-from anthropic.types import TextBlockParam
 
 from core.config import ANTHROPIC_FALLBACK_CHAIN, is_model_allowed, settings
 from core.llm.fallback import (
@@ -20,6 +18,48 @@ from core.llm.fallback import (
     retry_with_backoff_generic,
 )
 from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
+
+if TYPE_CHECKING:
+    import anthropic
+    from anthropic.types import TextBlockParam
+
+    # v0.88.0 — declare the lazy module-level tuples so mypy / IDEs see a
+    # concrete type for ``except RETRYABLE_ERRORS:`` etc.  Runtime values
+    # come from ``__getattr__`` below.  Use ``Exception`` (not
+    # ``BaseException``) to match the ``retry_with_backoff_generic``
+    # signature + ``except`` blocks in failover/streaming.
+    RETRYABLE_ERRORS: tuple[type[Exception], ...]
+    NON_RETRYABLE_ERRORS: tuple[type[Exception], ...]
+
+# v0.88.0 — anthropic SDK is module-level lazy.  Eager top-level
+# ``import anthropic`` + ``from anthropic.types import TextBlockParam``
+# pulled 248 ms of SDK graph at startup even when no Anthropic call ever
+# fired (cold-start path: ``geode about`` / ``doctor``).  Module-level
+# tuples ``RETRYABLE_ERRORS`` / ``NON_RETRYABLE_ERRORS`` and any direct
+# ``anthropic.X`` references inside function bodies now resolve through
+# the PEP 562 ``__getattr__`` hook below; type annotations use the
+# ``TYPE_CHECKING`` block above so mypy still sees them.
+_ANTHROPIC_LAZY_TUPLES: dict[str, tuple[str, ...]] = {
+    "RETRYABLE_ERRORS": ("RateLimitError", "APIConnectionError", "InternalServerError"),
+    "NON_RETRYABLE_ERRORS": ("AuthenticationError", "BadRequestError"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 module attribute hook — resolve anthropic-derived names lazily."""
+    if name in _ANTHROPIC_LAZY_TUPLES:
+        import anthropic
+
+        value = tuple(getattr(anthropic, n) for n in _ANTHROPIC_LAZY_TUPLES[name])
+        globals()[name] = value
+        return value
+    if name == "TextBlockParam":
+        from anthropic.types import TextBlockParam
+
+        globals()[name] = TextBlockParam
+        return TextBlockParam
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 log = logging.getLogger(__name__)
 
@@ -60,15 +100,11 @@ _async_client_lock = threading.Lock()
 # Circuit breaker for Anthropic API calls
 _circuit_breaker = CircuitBreaker()
 
-# Retryable error types
-RETRYABLE_ERRORS = (
-    anthropic.RateLimitError,
-    anthropic.APIConnectionError,
-    anthropic.InternalServerError,
-)
-
-# Non-retryable errors
-NON_RETRYABLE_ERRORS = (anthropic.AuthenticationError, anthropic.BadRequestError)
+# v0.88.0 — RETRYABLE_ERRORS / NON_RETRYABLE_ERRORS resolve through the
+# module-level ``__getattr__`` hook (defined above) on first use.  Their
+# concrete tuples used to live here as eager module-level expressions
+# (``RETRYABLE_ERRORS = (anthropic.RateLimitError, …)``), which forced
+# the anthropic SDK import at module load.
 
 # Fallback models
 FALLBACK_MODELS = ANTHROPIC_FALLBACK_CHAIN
@@ -89,6 +125,8 @@ def get_anthropic_client() -> anthropic.Anthropic:
     SDK-level retries are disabled (max_retries=0) to avoid conflict with
     app-level retry logic in ``_retry_with_backoff()``.
     """
+    import anthropic
+
     global _sync_client
     if _sync_client is not None:
         return _sync_client
@@ -117,6 +155,8 @@ def get_async_anthropic_client(api_key: str | None = None) -> anthropic.AsyncAnt
     Args:
         api_key: Optional API key override. If None, uses settings.
     """
+    import anthropic
+
     global _async_client
     if _async_client is not None:
         return _async_client
@@ -157,8 +197,10 @@ def system_with_cache(system: str) -> list[TextBlockParam]:
     system prompt (e.g., 4 analysts or 3 evaluators) get cache hits and
     reduced latency/cost.
     """
+    from anthropic.types import TextBlockParam as _TextBlockParam
+
     return [
-        TextBlockParam(
+        _TextBlockParam(
             type="text",
             text=system,
             cache_control={"type": "ephemeral"},
@@ -243,6 +285,8 @@ def retry_with_backoff(
 
     Delegates to ``retry_with_backoff_generic`` with Anthropic-specific config.
     """
+    import anthropic
+
     from core.llm.fallback import MAX_RETRIES as _DEFAULT_MAX_RETRIES
 
     _max_retries = max_retries if max_retries is not None else _DEFAULT_MAX_RETRIES
@@ -252,12 +296,19 @@ def retry_with_backoff(
     if not models_to_try:
         raise RuntimeError(f"All models blocked by policy: {candidates}")
 
+    # v0.88.0 — same-module ``__getattr__`` is bypassed for unqualified
+    # references, so we resolve ``RETRYABLE_ERRORS`` via direct attribute
+    # lookup on the module object (which DOES go through ``__getattr__``).
+    import sys
+
+    _retryable_errors = sys.modules[__name__].RETRYABLE_ERRORS
+
     return retry_with_backoff_generic(
         fn,
         model=models_to_try[0],
         fallback_models=models_to_try[1:],
         circuit_breaker=_circuit_breaker,
-        retryable_errors=RETRYABLE_ERRORS,
+        retryable_errors=_retryable_errors,
         bad_request_error=anthropic.BadRequestError,
         billing_message=(
             "Anthropic API credit balance too low. "

--- a/core/llm/router/__init__.py
+++ b/core/llm/router/__init__.py
@@ -15,6 +15,35 @@ internals that one call function uses to dispatch to another.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # v0.88.0 — re-exports preserved through the lazy ``__getattr__`` at the
+    # end of this module.  ``from core.llm.router import LLMRateLimitError``
+    # keeps working without paying the 248 ms anthropic load at module
+    # import — only IDE / mypy use this branch.
+    from core.llm.errors import (
+        LLMAPIStatusError as LLMAPIStatusError,
+    )
+    from core.llm.errors import (
+        LLMAuthenticationError as LLMAuthenticationError,
+    )
+    from core.llm.errors import (
+        LLMBadRequestError as LLMBadRequestError,
+    )
+    from core.llm.errors import (
+        LLMConnectionError as LLMConnectionError,
+    )
+    from core.llm.errors import (
+        LLMInternalServerError as LLMInternalServerError,
+    )
+    from core.llm.errors import (
+        LLMRateLimitError as LLMRateLimitError,
+    )
+    from core.llm.errors import (
+        LLMTimeoutError as LLMTimeoutError,
+    )
+
 # Re-export the resolver fallback for backwards compatibility — legacy uses of
 # ``monkeypatch.setattr("core.llm.router._resolve_provider", ...)`` still find a
 # name on the package. ``calls._route_provider`` calls the leaf binding from
@@ -29,27 +58,19 @@ from core.llm.adapters import LLMParsedCallable as LLMParsedCallable
 from core.llm.adapters import LLMTextCallable as LLMTextCallable
 from core.llm.adapters import LLMToolCallable as LLMToolCallable
 from core.llm.adapters import resolve_agentic_adapter as resolve_agentic_adapter
-from core.llm.errors import (
-    LLMAPIStatusError as LLMAPIStatusError,
-)
-from core.llm.errors import (
-    LLMAuthenticationError as LLMAuthenticationError,
-)
-from core.llm.errors import (
-    LLMBadRequestError as LLMBadRequestError,
-)
-from core.llm.errors import (
-    LLMConnectionError as LLMConnectionError,
-)
-from core.llm.errors import (
-    LLMInternalServerError as LLMInternalServerError,
-)
-from core.llm.errors import (
-    LLMRateLimitError as LLMRateLimitError,
-)
-from core.llm.errors import (
-    LLMTimeoutError as LLMTimeoutError,
-)
+
+# v0.88.0 — LLM*Error re-exports (LLMAPIStatusError, LLMAuthenticationError,
+# LLMBadRequestError, LLMConnectionError, LLMInternalServerError,
+# LLMRateLimitError, LLMTimeoutError) used to live here as eager
+# ``from core.llm.errors import X as X`` lines.  Each one ran
+# ``core.llm.errors.__getattr__`` at module load and pulled the 248 ms
+# anthropic SDK graph into the cold-start path, even though nothing in
+# the codebase imports these names from ``core.llm.router`` (verified
+# 2026-05-08 grep — only ``LLMClientPort`` / ``LLM*Callable`` /
+# ``LLMUsageAccumulator`` are pulled from this package).  Public API
+# preserved via the module-level ``__getattr__`` hook below: any future
+# ``from core.llm.router import LLMRateLimitError`` still resolves on
+# demand, deferring the SDK load until first access.
 from core.llm.fallback import MAX_RETRIES as MAX_RETRIES
 from core.llm.fallback import RETRY_BASE_DELAY as RETRY_BASE_DELAY
 from core.llm.fallback import RETRY_MAX_DELAY as RETRY_MAX_DELAY
@@ -167,3 +188,30 @@ from .tracing import (
 from .tracing import (
     maybe_traceable as maybe_traceable,
 )
+
+# v0.88.0 — module-level ``__getattr__`` for lazy LLM*Error re-exports.
+# Placed after all eager imports so ruff E402 stays happy.  The
+# ``_LAZY_ERROR_NAMES`` set is the runtime mirror of the TYPE_CHECKING
+# block at the top of the file.
+_LAZY_ERROR_NAMES = frozenset(
+    {
+        "LLMAPIStatusError",
+        "LLMAuthenticationError",
+        "LLMBadRequestError",
+        "LLMConnectionError",
+        "LLMInternalServerError",
+        "LLMRateLimitError",
+        "LLMTimeoutError",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 hook — resolve lazy LLM*Error re-exports on first access."""
+    if name in _LAZY_ERROR_NAMES:
+        from core.llm import errors
+
+        cls = getattr(errors, name)
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/core/llm/router/calls/_failover.py
+++ b/core/llm/router/calls/_failover.py
@@ -14,13 +14,13 @@ from typing import Any
 
 from core.config import is_model_allowed
 from core.llm.fallback import MAX_RETRIES, RETRY_BASE_DELAY, RETRY_MAX_DELAY
-from core.llm.providers.anthropic import (
-    NON_RETRYABLE_ERRORS as _NON_RETRYABLE_ERRORS,
-)
-from core.llm.providers.anthropic import (
-    RETRYABLE_ERRORS as _RETRYABLE_ERRORS,
-)
 from core.llm.router._hooks import _fire_hook
+
+# v0.88.0 — RETRYABLE_ERRORS / NON_RETRYABLE_ERRORS are lazy-resolved
+# inside ``call_with_failover`` so the cold-start path through
+# ``core.llm.router.calls._failover`` no longer triggers the 248 ms
+# anthropic SDK import.  The ``providers.anthropic.__getattr__`` lookup
+# is paid once on first failover dispatch, well after CLI bootstrap.
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +55,16 @@ async def call_with_failover(
         returns ``(None, None)``.
     """
     import asyncio as _asyncio
+
+    # v0.88.0 — defer anthropic SDK load until first failover.  Module-level
+    # tuple imports used to pull 248 ms anthropic graph at startup via
+    # ``providers.anthropic.__getattr__``.
+    from core.llm.providers.anthropic import (
+        NON_RETRYABLE_ERRORS as _NON_RETRYABLE_ERRORS,
+    )
+    from core.llm.providers.anthropic import (
+        RETRYABLE_ERRORS as _RETRYABLE_ERRORS,
+    )
 
     _max_retries = max_retries if max_retries is not None else MAX_RETRIES
     _base_delay = retry_base_delay if retry_base_delay is not None else RETRY_BASE_DELAY

--- a/core/llm/router/calls/streaming.py
+++ b/core/llm/router/calls/streaming.py
@@ -13,11 +13,12 @@ from core.llm.providers.anthropic import (
     get_anthropic_client,
 )
 from core.llm.providers.anthropic import (
-    RETRYABLE_ERRORS as _RETRYABLE_ERRORS,
-)
-from core.llm.providers.anthropic import (
     system_with_cache as _system_with_cache,
 )
+
+# v0.88.0 — RETRYABLE_ERRORS resolves through providers/anthropic
+# ``__getattr__`` (lazy SDK load).  Defer to function scope so the
+# cold-start path does not pull anthropic at module import.
 from core.llm.router._hooks import _fire_hook
 from core.llm.router._usage import _record_response_usage
 from core.llm.router.tracing import maybe_traceable
@@ -37,6 +38,9 @@ def call_llm_streaming(
     temperature: float = 0.3,
 ) -> Iterator[str]:
     """Streaming Claude call with failover. Yields text deltas."""
+    from core.llm.providers.anthropic import (
+        RETRYABLE_ERRORS as _RETRYABLE_ERRORS,
+    )
     from core.llm.providers.anthropic import get_circuit_breaker
 
     client = get_anthropic_client()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.87.1"
+version = "0.88.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.87.1"
+version = "0.88.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- CLI 콜드 스타트 −184 ms / −49 % (warm cache, 3-run median: 370 → 186 ms).
- `import core.runtime` 후 `'anthropic' in sys.modules == False` — anthropic 을 한 번도 호출 안 하는 셋업(Codex Plus only, GLM only)은 SDK 를 영원히 로드하지 않음.
- 7 개 파일에서 module-level `import anthropic` / `from anthropic.X import Y` 제거 + PEP 562 ``__getattr__`` 패턴으로 defer.

## Why
`python -X importtime -c "import core.runtime"` 측정 시 anthropic 그래프(types, httpx, anyio) 가 cumulative 248 ms — runtime 총 import 의 ~55 %. 이 비용은 anthropic 을 만지지 않는 invocation(`geode about`, `geode doctor`, `geode --help`, `geode version`) 에서도 매번 지불되어 왔다. 세션 53 핸드오프 backlog 의 P0 항목.

진단 방법:
1. `python -X importtime -c "import core.runtime" 2> it.log` → anthropic = 248 ms cumulative 확인
2. `sys.meta_path` Tracer 로 anthropic import call stack 추적 → 4 개 trigger path 식별
   - `core/runtime.py:50` → `core.llm.router/__init__.py` → `from core.llm.errors import LLM*Error` × 7
   - `core.llm.router/calls/_failover.py:17` → `from providers.anthropic import RETRYABLE_ERRORS`
   - `core.llm.router/calls/streaming.py:15` → 동일
   - `core.llm.providers.anthropic` 의 module-level `import anthropic` + `RETRYABLE_ERRORS = (anthropic.X, ...)`

## Changes
| File | Change |
|------|--------|
| `core/llm/errors.py` | top-level `import anthropic` 제거 → `__getattr__` + `_ANTHROPIC_ALIAS_MAP` 7 개 별칭 lazy.  `__all__` 추가(mypy `--no-implicit-reexport`).  `classify_llm_error` 함수-로컬 `import anthropic` |
| `core/llm/provider_dispatch.py` | top-level `import anthropic` + `from providers.anthropic import RETRYABLE_ERRORS, get_anthropic_client` 제거.  Dispatch table 의 `_anthropic_retryable` / `_anthropic_bad_request` / `_anthropic_get_client` 헬퍼 도입(`_openai_*` 카운터파트) |
| `core/llm/providers/anthropic.py` | top-level `import anthropic` + `from anthropic.types import TextBlockParam` 제거.  `RETRYABLE_ERRORS` / `NON_RETRYABLE_ERRORS` / `TextBlockParam` lazy via `__getattr__`.  Function 본체는 함수-로컬 `import anthropic`.  자기 모듈 내부 lazy 이름 참조는 `sys.modules[__name__].RETRYABLE_ERRORS` 로 PEP 562 우회 |
| `core/llm/router/__init__.py` | `from core.llm.errors import LLM*Error as LLM*Error` 7 개 eager 재-export 제거(이게 240 ms 절약 핵심).  Public API 는 module-level `__getattr__` 로 보존 |
| `core/llm/client.py` | router/__init__.py 와 동일 패턴 |
| `core/llm/router/calls/_failover.py` | `RETRYABLE_ERRORS` / `NON_RETRYABLE_ERRORS` import 를 `call_with_failover` 함수-로컬로 이동 |
| `core/llm/router/calls/streaming.py` | `RETRYABLE_ERRORS` import 를 `call_llm_streaming` 함수-로컬로 이동 |
| `CHANGELOG.md` | `[0.88.0]` 섹션 신설(Performance + Changed) |
| `CLAUDE.md` / `README.md` / `pyproject.toml` | Version 0.87.1 → 0.88.0 |
| `uv.lock` | self-package 버전 자동 동기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| anthropic 트리거 4 path 식별 | Implemented | sys.meta_path Tracer 로 모두 검증 |
| 함수-로컬 import 전환 | Implemented | `_failover` / `streaming` / `provider_dispatch` / `providers/anthropic` 4 곳 |
| `__getattr__` 보존 (LLM*Error API) | Implemented | router/`__init__`.py + client.py 둘 다 |
| 자기-모듈 lazy 참조 | Implemented | `sys.modules[__name__].X` 패턴 (PEP 562 in-module 한계) |
| openai SDK lazy | Already exists | function-local 이미 적용됨 (변경 없음) |
| langgraph SDK lazy | Deferred | core/graph.py 만 module-level import 사용; 별도 PR 에서 처리 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed, 1 skipped, 24 deselected (변동 없음)
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4) unchanged
- [x] `python -c "import sys; import core.runtime; print('anthropic' in sys.modules)"` — `False`
- [x] Cold start 3-run median: 186 ms (baseline ~370 ms, −49 %)

## Reference
- 세션 53 핸드오프 backlog P0
- PEP 562 (Module __getattr__): https://peps.python.org/pep-0562/
- Frontier 선례: Claude Code (lazy SDK loading), LangChain (lazy adapters), Pydantic AI (lazy provider modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)