### PR TITLE
release: v0.88.1 — numpy + correlation lazy loading (-74ms cold start)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,40 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.1] — 2026-05-09
+
+> **Performance — numpy + correlation analyzer 모듈-레벨 lazy loading.**
+> v0.88.0 가 anthropic SDK 248 ms 를 잘라낸 직후, 남은 콜드 스타트의
+> 다음 큰 덩어리는 **numpy** 였다.  `core.automation.correlation` 과
+> `core.verification.stats` 가 module-level `import numpy as np` 로
+> SDK 를 끌어와, 단순히 `import core.runtime` 만으로도 numpy 트리
+> (~31 ms) 가 매번 로드.  `core.automation.expert_panel` 도 같은
+> 패턴으로 직접 `import numpy as np`.
+>
+> 이번 PR 은 **3 곳의 numpy 모듈-레벨 import → 함수-로컬 + TYPE_CHECKING**
+> 으로 옮겨, numpy 를 실제로 사용하는 함수가 처음 호출될 때까지 로드를
+> 미룬다.  `core.runtime` 의 `CorrelationAnalyzer` 어노테이션도
+> `TYPE_CHECKING` 블록으로 이동(B1 의 `LLMClientPort` 와 동일 패턴).
+>
+> **측정 (warm cache, 10-run sorted, median of 5th–6th):**
+> - Before (v0.88.0 main): 314–441 ms (median 356 ms)
+> - After  (v0.88.1):     259–367 ms (median 282 ms)
+> - **Δ: −74 ms / −21 %**
+>
+> 검증: `import core.runtime` 후 `'numpy' in sys.modules == False`.
+> 첫 ``ExpertPanel.compute_consensus`` / ``CorrelationAnalyzer.spearman``
+> / ``calculate_krippendorff_alpha`` 호출이 일어나면 그 시점에 numpy 1
+> 회 로드. pytest 4346 passed (변동 없음); E2E A (68.4) 동일.
+
+### Changed
+- **`core/runtime.py`** — `from core.automation.correlation import CorrelationAnalyzer` (line 39) 를 `TYPE_CHECKING` 블록으로 이동.  `correlation_analyzer: CorrelationAnalyzer | None = None` 데이터클래스 어노테이션은 `from __future__ import annotations` 로 인해 런타임 string 이라 실제 import 불필요.  B1 의 `LLMClientPort` 패턴 재사용.
+- **`core/automation/feedback_loop.py`** — module-level `from core.automation.correlation import CorrelationAnalyzer` 를 `TYPE_CHECKING` 블록으로 이동.  `__init__` factory(line 142, 148) 는 이미 함수-로컬 import 사용 중이라 추가 변경 없음.  Type annotation(line 159) 은 string.
+- **`core/automation/expert_panel.py`** — top-level `import numpy as np` 제거.  `_compute_aggregate` 함수 본체 첫 줄에 `import numpy as np` 추가.  사용처는 그 함수의 3 줄(``np.array`` / ``np.std`` / ``np.mean``) 뿐이라 단일 함수-로컬 import 로 충분.
+- **`core/verification/stats.py`** — top-level `import numpy as np` 제거.  `calculate_krippendorff_alpha` 함수 첫 줄에 `import numpy as np` 추가.  Krippendorff alpha 계산 외에는 numpy 사용처 없음.
+
+### Performance
+- **CLI 콜드 스타트 −74 ms / −21 %** (warm cache, 10-run median).  numpy 를 안 만지는 invocation(`geode about`, `geode doctor`, `geode --help`, `geode version` 등)은 numpy 트리를 영원히 로드하지 않을 수 있게 됨.  v0.88.0 (anthropic lazy) 와 합쳐 콜드 스타트 누적 절약 ~258 ms / ~58 %.
+
 ## [0.88.0] — 2026-05-08
 
 > **Performance — anthropic SDK module-level lazy loading.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.88.0
+- **Version**: 0.88.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.88.0 — Long-running Autonomous Execution Harness
+# GEODE v0.88.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/automation/expert_panel.py
+++ b/core/automation/expert_panel.py
@@ -13,8 +13,10 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-import numpy as np
-
+# v0.88.1 — numpy (~31 ms cold-start) is deferred to the single
+# function that uses it (``_compute_aggregate``).  Top-level
+# ``import numpy as np`` was forcing the eager load through
+# ``core.runtime`` even when no expert-panel call ever ran.
 from core.verification.stats import calculate_krippendorff_alpha
 
 log = logging.getLogger(__name__)
@@ -211,6 +213,9 @@ class ExpertPanel:
         self._stats.consensus_computed += 1
         if not ratings:
             return {"mean_score": 0.0, "weighted_score": 0.0, "n_raters": 0, "spread": 0.0}
+
+        # v0.88.1 — numpy deferred to first consensus computation.
+        import numpy as np
 
         scores = [r.score for r in ratings]
         arr = np.array(scores, dtype=np.float64)

--- a/core/automation/feedback_loop.py
+++ b/core/automation/feedback_loop.py
@@ -17,12 +17,17 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from core.automation.correlation import CorrelationAnalyzer
 from core.automation.drift import CUSUMDetector
 from core.automation.expert_panel import ExpertPanel
 from core.automation.model_registry import ModelRegistry
 
 if TYPE_CHECKING:
+    # v0.88.1 — CorrelationAnalyzer pulls numpy (~31 ms) at module
+    # load. Function bodies that instantiate it already use a
+    # local import (see ``__init__`` factory below); type annotations
+    # become strings via ``from __future__ import annotations``, so
+    # the eager top-level import was pure import-time tax.
+    from core.automation.correlation import CorrelationAnalyzer
     from core.hooks import HookSystem
 
 log = logging.getLogger(__name__)

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -31,12 +31,21 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
 
+    # v0.88.1 — CorrelationAnalyzer pulls numpy (~31 ms) at module
+    # load. ``runtime.py`` only references it as a dataclass field
+    # type annotation (``correlation_analyzer: CorrelationAnalyzer | None``);
+    # ``from __future__ import annotations`` makes the annotation a
+    # string at runtime, so no real import is needed unless the
+    # caller actually instantiates the analyzer.  Wiring builders
+    # (``core.wiring.automation``) and ``feedback_loop`` keep their
+    # own eager imports — those modules only load when automation
+    # actually runs, well after CLI cold-start.
+    from core.automation.correlation import CorrelationAnalyzer
     from core.llm.prompt_assembler import PromptAssembler
 
 from core.auth.cooldown import CooldownTracker
 from core.auth.profiles import ProfileStore
 from core.auth.rotation import ProfileRotator
-from core.automation.correlation import CorrelationAnalyzer
 from core.automation.drift import CUSUMDetector
 from core.automation.expert_panel import ExpertPanel
 from core.automation.feedback_loop import FeedbackLoop

--- a/core/verification/stats.py
+++ b/core/verification/stats.py
@@ -5,7 +5,10 @@ Pure math functions with no infrastructure or config dependencies.
 
 from __future__ import annotations
 
-import numpy as np
+# v0.88.1 — numpy (~31 ms cold-start) deferred to the single function
+# that uses it.  Top-level ``import numpy as np`` was forcing the
+# eager load through every importer of this module
+# (e.g. ``core.automation.expert_panel`` at CLI bootstrap).
 
 
 def calculate_krippendorff_alpha(
@@ -31,6 +34,8 @@ def calculate_krippendorff_alpha(
     Returns:
         Alpha coefficient (-1.0 to 1.0). 1.0 = perfect agreement.
     """
+    import numpy as np
+
     n_raters = len(ratings_matrix)
     if n_raters < 2:
         return 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.88.0"
+version = "0.88.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.88.0"
+version = "0.88.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
v0.88.1 PATCH 릴리스. 콜드 스타트 추가 −74 ms / −21 % (warm cache, 10-run median: 356 → 282 ms). v0.88.0 (B1: anthropic lazy −184 ms) 합쳐 누적 절약 ~258 ms / ~58 %.

포함 PR:
- #936 — numpy + correlation analyzer 모듈-레벨 lazy.  3 곳의 numpy module-level import → 함수-로컬 + TYPE_CHECKING (PEP 562 패턴 재사용).

## Verification
- [x] develop CI 5/5 pass on #936
- [x] 4 location 버전 일치: `pyproject.toml:3`, `CLAUDE.md:11`, `README.md:21`, `CHANGELOG.md:31` 모두 0.88.1
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed, 1 skipped, 24 deselected
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` A (68.4) unchanged
- [x] `python -c "import sys; import core.runtime; print('numpy' in sys.modules)"` — `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)