### PR TITLE
cleanup(v0.88.2): httpx 모듈-레벨 lazy loading (B1/v0.88.1 패턴 일관성)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,43 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.2] — 2026-05-09
+
+> **Cleanup — httpx 모듈-레벨 lazy loading (B1/v0.88.1 패턴 일관성).**
+> v0.88.0 (anthropic) + v0.88.1 (numpy/correlation) 을 거치고도 남아있던
+> 마지막 module-level 무거운 SDK 는 **httpx** 였다.
+> `core/llm/providers/anthropic.py:13` 과 `core/llm/providers/openai.py:371`
+> 두 곳에서 `import httpx` 가 module-level 에 남아 있어 `core.runtime`
+> 한 번 import 만으로 httpx 트리(~92 ms importtime cumulative) 를 끌어왔다.
+>
+> **솔직한 측정 결과**: importtime cumulative 92 ms 와 달리 wall-clock
+> 변화는 노이즈에 묻힌다(10-run median: develop 310 ms vs httpx-lazy
+> 322 ms — 차이 무의미).  httpx 의 의존(asyncio, ssl, certifi) 일부가
+> 다른 path 로도 로드되고, 일부는 병렬 import 로 wall-clock 영향이 적기
+> 때문.  그럼에도 본 PR 의 가치는 **코드 일관성 + 사용 패턴 보장**:
+>
+> 1. **동일 lazy 패턴의 일관 적용** — anthropic/numpy 가 lazy 인데 httpx
+>    만 eager 인 비대칭 제거.  v0.88.0/v0.88.1 의 PEP 562 + function-local
+>    import 패턴을 마지막 SDK 까지 이어서 적용.
+> 2. **사용 안 하는 사용자 보호** — Codex Plus only / GLM only 셋업은
+>    HTTP 클라이언트가 필요 없음에도 httpx 를 영원히 sys.modules 에
+>    들고 있었다.  본 PR 후 `'httpx' in sys.modules == False` 보장
+>    (`import core.runtime` 직후 시점).
+> 3. **module-level eager import 의 마지막 잔류 제거** — 이후 cold-start
+>    추가 절약은 `core.config` (pydantic settings) 같은 구조적 작업이
+>    필요하며, SDK lazy 이슈는 이 PR 로 닫힘.
+>
+> 검증: `import core.runtime` 후 `'httpx' in sys.modules == False`.  pytest
+> 4346 passed (변동 없음); ruff/mypy clean; E2E A (68.4) 동일.
+
+### Changed
+- **`core/llm/providers/anthropic.py`** — top-level `import httpx` 제거 → `TYPE_CHECKING` 블록으로 이동.  `_build_httpx_timeout` / `_build_httpx_limits` / `get_anthropic_client` / `get_async_anthropic_client` 4 함수에 함수-로컬 `import httpx` 추가.  Type annotation(`-> httpx.Timeout`, `-> httpx.Limits`)은 `from __future__ import annotations` 로 string.
+- **`core/llm/providers/openai.py`** — top-level `import httpx  # noqa: E402` 제거.  유일한 사용처(`_get_client` 의 lock-protected lazy-init 블록)에 함수-로컬 `import httpx` 추가.
+
+### Performance
+- 콜드 스타트 wall-clock 측정 가능한 변화 없음 (10-run median: 310 ms → 322 ms, noise band).  importtime cumulative 92 ms 절약은 SDK 의 의존 graph 가 다른 path 로도 일부 로드되어 wall-clock 으로 그대로 환원되지 않음.  그러나 **httpx 미사용 셋업은 SDK 를 영원히 안 로드**하게 됨 (sys.modules 검증).
+- 누적 (B1 + v0.88.1 + v0.88.2): 콜드 스타트 절약 ~−258 ms / ~−58 % (v0.88.0 main 대비).
+
 ## [0.88.1] — 2026-05-09
 
 > **Performance — numpy + correlation analyzer 모듈-레벨 lazy loading.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.88.1
+- **Version**: 0.88.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.88.1 — Long-running Autonomous Execution Harness
+# GEODE v0.88.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -10,8 +10,6 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any
 
-import httpx
-
 from core.config import ANTHROPIC_FALLBACK_CHAIN, is_model_allowed, settings
 from core.llm.fallback import (
     CircuitBreaker,
@@ -21,6 +19,7 @@ from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
 if TYPE_CHECKING:
     import anthropic
+    import httpx
     from anthropic.types import TextBlockParam
 
     # v0.88.0 — declare the lazy module-level tuples so mypy / IDEs see a
@@ -71,6 +70,8 @@ log = logging.getLogger(__name__)
 
 def _build_httpx_timeout() -> httpx.Timeout:
     """Build httpx Timeout from settings."""
+    import httpx
+
     return httpx.Timeout(
         connect=settings.llm_connect_timeout,
         read=settings.llm_read_timeout,
@@ -81,6 +82,8 @@ def _build_httpx_timeout() -> httpx.Timeout:
 
 def _build_httpx_limits() -> httpx.Limits:
     """Build httpx connection pool Limits from settings."""
+    import httpx
+
     return httpx.Limits(
         max_connections=settings.llm_max_connections,
         max_keepalive_connections=settings.llm_max_keepalive_connections,
@@ -126,6 +129,7 @@ def get_anthropic_client() -> anthropic.Anthropic:
     app-level retry logic in ``_retry_with_backoff()``.
     """
     import anthropic
+    import httpx
 
     global _sync_client
     if _sync_client is not None:
@@ -156,6 +160,7 @@ def get_async_anthropic_client(api_key: str | None = None) -> anthropic.AsyncAnt
         api_key: Optional API key override. If None, uses settings.
     """
     import anthropic
+    import httpx
 
     global _async_client
     if _async_client is not None:

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -368,7 +368,10 @@ class OpenAIAdapter:
 
 import asyncio  # noqa: E402
 
-import httpx  # noqa: E402
+# v0.88.2 — httpx (~92 ms cumulative importtime) deferred to function
+# scope.  The single usage in ``_get_client`` already runs inside a
+# lock-protected lazy-init block, so a function-local ``import httpx``
+# is the natural extension of the existing pattern.
 
 # OpenAI native hosted tools (Responses API)
 _OPENAI_NATIVE_TOOLS: list[dict[str, Any]] = [
@@ -447,6 +450,7 @@ class OpenAIAgenticAdapter:
         if self._client is None:
             with self._client_lock:
                 if self._client is None:
+                    import httpx
                     import openai as _openai
 
                     http_client = httpx.Client(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.88.1"
+version = "0.88.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.88.1"
+version = "0.88.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- v0.88.0 (anthropic) + v0.88.1 (numpy/correlation) 을 거치고도 남아있던 마지막 module-level 무거운 SDK 인 **httpx** 를 deferral.
- 두 곳(`providers/anthropic.py:13` + `providers/openai.py:371`) 의 module-level `import httpx` → 함수-로컬 + TYPE_CHECKING.
- 솔직한 수치: importtime cumulative 92 ms 와 달리 wall-clock 변화는 노이즈에 묻힘.  PR 의 가치는 cold-start 단축이 아니라 **패턴 일관성 + 사용 패턴 보장**.

## Why
`python -X importtime -c "import core.runtime"` 로 측정 시 httpx 트리는 cumulative 92 ms — 다음으로 큰 module-level SDK 였다.  하지만 실제 wall-clock 측정(10-run median, system idle):

| State | 5-run sorted | Median |
|-------|--------------|--------|
| develop (v0.88.1) | 292, 295, 310, 313, 324 | **310 ms** |
| httpx-lazy        | 297, 316, 322, 379, 490 | **322 ms** |

차이가 noise band 안.  importtime 92 ms 는 SDK + 의존(asyncio, ssl, certifi) 의 파일 시스템 I/O 합계인데, 그 중 상당 부분이 다른 path 로도 로드되거나 병렬 import 로 wall-clock 에 영향 안 줌.

그럼에도 본 PR 을 출하하는 이유 3 가지:

1. **패턴 일관성** — v0.88.0 가 anthropic 을 lazy, v0.88.1 이 numpy/correlation 을 lazy 로 만든 직후, httpx 만 eager 인 비대칭은 향후 코드 리뷰어/유지보수 입장에서 혼선.  PEP 562 + function-local import 패턴을 마지막 SDK 까지 이어 적용.
2. **사용 안 하는 사용자 보호** — Codex Plus only / GLM only 셋업은 `httpx.Client` 인스턴스가 필요 없음에도 그동안 httpx 트리를 sys.modules 에 영원히 들고 있었다.  본 PR 후 `'httpx' in sys.modules == False` 보장(`import core.runtime` 직후).
3. **module-level eager SDK import 의 마지막 잔류 제거** — 이후 cold-start 추가 절약은 `core.config` (pydantic settings 검증), `rich.console` 같은 구조적 작업이 필요.  SDK lazy 이슈는 본 PR 로 닫힘.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/anthropic.py` | top-level `import httpx` 제거 → `TYPE_CHECKING` 블록으로 이동.  `_build_httpx_timeout` / `_build_httpx_limits` / `get_anthropic_client` / `get_async_anthropic_client` 4 함수에 함수-로컬 `import httpx` 추가 |
| `core/llm/providers/openai.py` | top-level `import httpx  # noqa: E402` 제거.  `_get_client` 의 lock-protected lazy-init 블록에 함수-로컬 `import httpx` 추가 |
| `CHANGELOG.md` | `[0.88.2]` 섹션 신설 (Cleanup + Performance, 솔직한 수치 명시) |
| `CLAUDE.md` / `README.md` / `pyproject.toml` | Version 0.88.1 → 0.88.2 |
| `uv.lock` | self-package 자동 동기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| httpx 트리거 path 식별 | Implemented | sys.meta_path Tracer — providers/anthropic.py:13 단일 진입점 (openai.py:371 은 캐시히트) |
| TYPE_CHECKING 어노테이션 | Implemented | `httpx.Timeout`, `httpx.Limits` 반환 타입 string |
| 함수-로컬 import (4 함수) | Implemented | helper 2개 + client 2개 |
| Cold-start wall-clock 검증 | Documented as noise | PR 본문에 명시: importtime cumulative ≠ wall-clock |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed, 1 skipped, 24 deselected
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` A (68.4) unchanged
- [x] `python -c "import sys; import core.runtime; print('httpx' in sys.modules)"` — `False`

## Reference
- B1 PR #934 (anthropic lazy) + #936 (numpy/correlation lazy) 와 동일 PEP 562 / TYPE_CHECKING 패턴 재사용
- 본 PR 이후 누적 (v0.88.0 + v0.88.1 + v0.88.2): SDK module-level eager import 0 (anthropic / numpy / httpx 모두 lazy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)