### PR TITLE
hardening(v0.88.3): no-any-return ignore 6건 제거 (cast 패턴)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.3] — 2026-05-09
+
+> **Hardening — `# type: ignore[no-any-return]` 6 건 제거 (B2 mini-batch).**
+> 8 개 `[no-any-return]` ignore 중 6 개를 `cast()` 패턴으로 정리.  나머지
+> 2 개는 ``@maybe_traceable`` (LangSmith) 데코레이터의 type erasure 가
+> 원인이라 root-cause 가 외부 SDK 에 있어, 이 PR 에서는 anchor 코멘트만
+> 갱신하고 ignore 유지(향후 LangSmith 타입 stub 개선 후 일괄 제거).
+>
+> 정리 대상 — 모두 SDK 반환값(`json.loads(...) → Any`,
+> `choice.message.parsed → BaseModel | None`)을 함수의 명시적 반환 타입
+> (`list[dict[str, Any]]`, `dict[str, Any]`, TypeVar `T`)으로 변환하는
+> 곳.  `cast()` 는 무코스트 hint, 런타임 동작 변경 0.
+
+### Changed
+- **`core/tools/base.py`** — `load_all_tool_definitions()` 의 `json.loads(...)` 반환값을 `cast(list[dict[str, Any]], ...)` 로 명시.
+- **`core/memory/vault.py`** — `JobApplicationVault._load()` 의 `json.loads(...)` 반환값을 `cast(list[dict[str, Any]], ...)` 로 명시.
+- **`core/memory/user_profile.py`** — `_load_preferences()` 의 `json.loads(raw)` 반환값을 `cast(dict[str, Any], ...)` 로 명시.
+- **`core/verification/calibration.py`** — `load_golden_set()` 의 `json.loads(...)` 반환값을 `cast(dict[str, Any], ...)` 로 명시.
+- **`core/llm/router/calls/parsed.py`** — OpenAI 구조화 출력 `choice.message.parsed` 를 `cast(T, ...)` 로 명시 (TypeVar `T` bound BaseModel).
+- **`core/llm/providers/openai.py`** — 동일 패턴(`OpenAIAdapter.generate_parsed` 의 `cast(T, ...)`).
+- **`core/llm/adapters.py`** — 두 곳(`generate_parsed`, `generate_stream`)의 ignore 는 root-cause 가 ``@maybe_traceable`` 의 untyped-decorator 임을 명시하는 anchor 코멘트로 갱신; LangSmith 타입 stub 개선 후 제거 예정.
+
+### Hardening Metrics
+- `# type: ignore` 총합: 69 → **63** (−6, −8.7 %)
+- `[no-any-return]` 카테고리: 8 → 2 (남은 2 는 LangSmith decorator 한계)
+- pytest 4346 passed (변동 없음); ruff/mypy clean; E2E A (68.4) 동일.
+
 ## [0.88.2] — 2026-05-09
 
 > **Cleanup — httpx 모듈-레벨 lazy loading (B1/v0.88.1 패턴 일관성).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.88.2
+- **Version**: 0.88.3
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.88.2 — Long-running Autonomous Execution Harness
+# GEODE v0.88.3 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -307,6 +307,11 @@ class ClaudeAdapter:
     ) -> T:
         from core.llm.router import call_llm_parsed
 
+        # ``call_llm_parsed`` is wrapped by ``@maybe_traceable`` (LangSmith
+        # decorator with ``untyped-decorator`` ignore upstream), so mypy
+        # sees the return as ``Any`` regardless of the underlying ``-> T``
+        # signature.  The ignore is anchored to the decorator limitation,
+        # not the value flow.
         return call_llm_parsed(  # type: ignore[no-any-return]
             system,
             user,
@@ -327,6 +332,8 @@ class ClaudeAdapter:
     ) -> Iterator[str]:
         from core.llm.router import call_llm_streaming
 
+        # See note on ``call_llm_parsed`` above — ``@maybe_traceable``
+        # erases the ``-> Iterator[str]`` return type.
         return call_llm_streaming(  # type: ignore[no-any-return]
             system, user, model=model, max_tokens=max_tokens, temperature=temperature
         )

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -11,7 +11,7 @@ import re
 import threading
 import time
 from collections.abc import Callable, Iterator
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -196,7 +196,7 @@ class OpenAIAdapter:
             choice = response.choices[0]
             if choice.message.parsed is None:
                 raise ValueError("OpenAI returned null parsed output")
-            return choice.message.parsed  # type: ignore[no-any-return]
+            return cast(T, choice.message.parsed)
 
         result: T = self._retry_with_backoff(_do_call, model=target)
         return result

--- a/core/llm/router/calls/parsed.py
+++ b/core/llm/router/calls/parsed.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -80,7 +80,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
                             "Verify the prompt constrains the response format "
                             "and the Pydantic model matches the schema."
                         )
-                    return choice.message.parsed  # type: ignore[no-any-return]
+                    return cast(T, choice.message.parsed)
 
                 result: T = _retry_provider_aware(_do_call_openai, model=m, provider=p)
             else:

--- a/core/memory/user_profile.py
+++ b/core/memory/user_profile.py
@@ -21,7 +21,7 @@ import logging
 import tomllib
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from core.skills._frontmatter import _FRONTMATTER_RE
 from core.utils.atomic_io import atomic_write_text
@@ -433,7 +433,7 @@ Write your bio, background, or any context you want GEODE to remember here.
             return {}
         try:
             raw = prefs_path.read_text(encoding="utf-8")
-            return json.loads(raw)  # type: ignore[no-any-return]
+            return cast(dict[str, Any], json.loads(raw))
         except (json.JSONDecodeError, OSError) as e:
             log.warning("Failed to load preferences from %s: %s", prefs_path, e)
             return {}

--- a/core/memory/vault.py
+++ b/core/memory/vault.py
@@ -22,7 +22,7 @@ import time
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from core.utils.atomic_io import atomic_write_text
 
@@ -335,7 +335,7 @@ class ApplicationTracker:
         if not self._path.exists():
             return []
         try:
-            return json.loads(self._path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+            return cast(list[dict[str, Any]], json.loads(self._path.read_text(encoding="utf-8")))
         except (json.JSONDecodeError, OSError):
             return []
 

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 # Valid values for tool metadata fields.
 VALID_CATEGORIES = frozenset(
@@ -185,7 +185,7 @@ def load_all_tool_definitions() -> list[dict[str, Any]]:
     Other modules should import this instead of independently reading
     the JSON file to avoid path duplication.
     """
-    return json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+    return cast(list[dict[str, Any]], json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8")))
 
 
 def load_tool_definition(name: str) -> dict[str, Any]:

--- a/core/verification/calibration.py
+++ b/core/verification/calibration.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -79,7 +79,7 @@ def load_golden_set(path: Path | None = None) -> dict[str, Any]:
     gs_path = path or _GOLDEN_SET_PATH
     if not gs_path.exists():
         raise FileNotFoundError(f"Golden set not found: {gs_path}")
-    return json.loads(gs_path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+    return cast(dict[str, Any], json.loads(gs_path.read_text(encoding="utf-8")))
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.88.2"
+version = "0.88.3"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.88.2"
+version = "0.88.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `# type: ignore[no-any-return]` 8개 중 **6개를 `cast()` 패턴으로 정리**.
- type:ignore 총합 69 → **63** (−6, −8.7 %).
- 나머지 2 개(`core/llm/adapters.py:310, 330`)는 `@maybe_traceable` (LangSmith) decorator 의 type erasure 가 root-cause — anchor 코멘트만 갱신, ignore 유지.

## Why
세션 53/54 backlog 의 B2 (type:ignore 단계적 정리) 미니-배치 1차.  `[no-any-return]` 카테고리는 SDK 반환값(`json.loads → Any`, `openai choice.message.parsed → BaseModel | None`) 이 함수의 명시적 반환 타입(`list[dict]`, `dict[str, Any]`, TypeVar `T`)으로 좁혀지지 않아 mypy 가 경고하던 케이스.  `cast()` 는 무코스트 hint 라 런타임 동작 변화 0, 가독성 + mypy 신뢰도 ↑.

LangSmith ``@maybe_traceable`` 가 데코레이트한 `call_llm_parsed` / `call_llm_streaming` 은 mypy 입장에서 반환 타입이 erase 되어 `Any` 로 보임.  이 부분은 LangSmith 타입 stub 개선 (또는 LangSmith 측 PEP 612 ParamSpec 도입) 후에 일괄 제거 가능.  현 PR 에서는 ignore 를 유지하되 anchor 코멘트로 root-cause 를 명시 (향후 작업 시 빠르게 발견 가능).

## Changes
| File | Change |
|------|--------|
| `core/tools/base.py` | `load_all_tool_definitions()` 의 `json.loads(...)` → `cast(list[dict[str, Any]], ...)` |
| `core/memory/vault.py` | `JobApplicationVault._load()` 의 `json.loads(...)` → `cast(list[dict[str, Any]], ...)` |
| `core/memory/user_profile.py` | `_load_preferences()` 의 `json.loads(raw)` → `cast(dict[str, Any], ...)` |
| `core/verification/calibration.py` | `load_golden_set()` 의 `json.loads(...)` → `cast(dict[str, Any], ...)` |
| `core/llm/router/calls/parsed.py` | OpenAI 구조화 출력 `choice.message.parsed` → `cast(T, ...)` |
| `core/llm/providers/openai.py` | `OpenAIAdapter.generate_parsed` 의 `cast(T, ...)` (동일 패턴) |
| `core/llm/adapters.py` | 두 ignore (line 310, 330) 에 root-cause anchor 코멘트 추가 (`@maybe_traceable` 의 untyped-decorator 한계 명시) |
| `CHANGELOG.md` | `[0.88.3]` 섹션 신설 (Hardening + Metrics) |
| `CLAUDE.md` / `README.md` / `pyproject.toml` | Version 0.88.2 → 0.88.3 |
| `uv.lock` | self-package 자동 동기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| no-any-return 8건 식별 | Implemented | grep 으로 카테고리 100 % 매칭 |
| json.loads 4건 cast | Implemented | base / vault / user_profile / calibration |
| openai SDK parsed 2건 cast | Implemented | router/parsed + providers/openai |
| LangSmith decorator 2건 | Documented | root-cause anchor 추가, 향후 작업으로 이월 |
| 새 type:ignore 추가 | None | 신규 ignore 0 (anti-deception 체크 통과) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed, 1 skipped, 24 deselected
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` A (68.4) unchanged
- [x] `grep -rn "# type: ignore\[no-any-return\]" core/` — 2 (originally 8, decoder-blocked)
- [x] `grep -rn "# type: ignore" core/ plugins/` — 63 (originally 69)

## Reference
- 세션 53 핸드오프 backlog B2 항목
- mypy `--no-implicit-reexport` 와 `cast()` 의 무코스트 hint 패턴 (PEP 484)

🤖 Generated with [Claude Code](https://claude.com/claude-code)