### PR TITLE
hardening(v0.88.4): union-attr ignore 10건 전부 제거 (assert invariant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.4] — 2026-05-09
+
+> **Hardening — `# type: ignore[union-attr]` 10 건 전부 제거 (B2 batch-2).**
+> 10 개 사이트 모두 ``Optional[X]`` 타입 attribute 접근 — 호출 측에서
+> 이미 None 가드 (`is_available()`, `_check_mcp_health`) 를 통과한 invariant
+> 을 mypy 가 spread 하지 못해 발생.  `assert ... is not None` 로 invariant
+> 을 localise 해 ignore 제거 + 런타임 안전성 ↑ (None dereference 발생 시
+> 명시적 AssertionError 로 즉시 발견).
+>
+> v0.88.3 (no-any-return) 에 이은 B2 두 번째 배치.  외부 SDK 의존이
+> 아닌, 우리 코드의 invariant 를 명시화하면 깔끔히 잡히는 카테고리.
+
+### Changed
+- **`core/server/supervised/{slack,discord,telegram}_poller.py`** — 3 개 poller 모두 `_poll_channel` / `_poll_once` 가 `_check_mcp_health` 통과 후 호출되는 invariant 를 `assert self._mcp is not None` 로 localise.
+- **`core/mcp/base_calendar.py`** — 4 개 메서드(`delete_event`, `list_events`, `create_event`, `list_calendars`) 모두 `is_available()` 가드 직후에 `assert self._manager is not None` 추가.
+- **`core/mcp/base_notification.py`** — `send` 의 동일 패턴.
+- **`core/mcp/stdio_client.py`** — `subprocess.Popen.stdin: Optional[IO[bytes]]` 의 None 가능성을 `if self._process.stdin is not None:` 로 처리 (assert 가 아니라 가드 — stdin 미파이프 시 silently skip).
+- **`core/llm/providers/anthropic.py`** — `ClaudeAgenticAdapter.agentic_call` 의 nested `_do_call` closure 에서 `self._client` invariant 를 assert 로 명시 (closure 가 outer scope 의 None 체크를 mypy 입장에서 못 봄).
+
+### Hardening Metrics
+- `# type: ignore` 총합: 63 → **53** (−10, −15.9 %)
+- `[union-attr]` 카테고리: **10 → 0** (완전 소멸)
+- pytest 4346 passed (변동 없음); ruff/mypy clean (332 source files); E2E A (68.4) 동일.
+
 ## [0.88.3] — 2026-05-09
 
 > **Hardening — `# type: ignore[no-any-return]` 6 건 제거 (B2 mini-batch).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.88.3
+- **Version**: 0.88.4
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.88.3 — Long-running Autonomous Execution Harness
+# GEODE v0.88.4 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -467,6 +467,11 @@ class ClaudeAgenticAdapter:
         failover_models = [model] + [m for m in ANTHROPIC_FALLBACK_CHAIN if m != model]
 
         async def _do_call(m: str) -> Any:
+            # ``self._client`` is initialised right before this nested
+            # function in the outer scope (line 448-449); the assert
+            # localises the invariant for mypy across the closure.
+            assert self._client is not None
+
             # Server-side context management only for models that support it.
             # Haiku 4.5 rejects the compact beta → 400 misclassified as overflow.
             extra_h: dict[str, str] = {}
@@ -575,7 +580,7 @@ class ClaudeAgenticAdapter:
             if extra_b:
                 create_kwargs["extra_body"] = extra_b
 
-            return await self._client.messages.create(**create_kwargs)  # type: ignore[union-attr]
+            return await self._client.messages.create(**create_kwargs)
 
         try:
             response, used_model = await call_with_failover(failover_models, _do_call)

--- a/core/mcp/base_calendar.py
+++ b/core/mcp/base_calendar.py
@@ -53,8 +53,10 @@ class BaseCalendarAdapter:
     def delete_event(self, event_id: str) -> bool:
         if not self.is_available():
             return False
+        # ``is_available()`` returned True ⇒ ``_manager is not None``.
+        assert self._manager is not None
         try:
-            result = self._manager.call_tool(  # type: ignore[union-attr]
+            result = self._manager.call_tool(
                 self._server_name, "delete_event", {self._delete_id_key: event_id}
             )
             return "error" not in result
@@ -72,12 +74,13 @@ class BaseCalendarAdapter:
     ) -> list[CalendarEvent]:
         if not self.is_available():
             return []
+        assert self._manager is not None
         now = datetime.now(UTC)
         time_min = (start or now).isoformat()
         time_max = (end or now + timedelta(days=7)).isoformat()
         try:
             args = self._build_list_args(time_min, time_max, max_results, calendar_name)
-            result = self._manager.call_tool(  # type: ignore[union-attr]
+            result = self._manager.call_tool(
                 self._server_name, "list_events", args
             )
             if "error" in result:
@@ -100,8 +103,9 @@ class BaseCalendarAdapter:
     ) -> CalendarEvent:
         if not self.is_available():
             raise RuntimeError(f"{self._source.title()} MCP server not available")
+        assert self._manager is not None
         args = self._build_create_args(title, start, end, description, location, calendar_name)
-        result = self._manager.call_tool(  # type: ignore[union-attr]
+        result = self._manager.call_tool(
             self._server_name, "create_event", args
         )
         if "error" in result:
@@ -121,8 +125,9 @@ class BaseCalendarAdapter:
     def list_calendars(self) -> list[str]:
         if not self.is_available():
             return []
+        assert self._manager is not None
         try:
-            result = self._manager.call_tool(  # type: ignore[union-attr]
+            result = self._manager.call_tool(
                 self._server_name, "list_calendars", {}
             )
             return self._extract_calendar_names(result)

--- a/core/mcp/base_calendar.py
+++ b/core/mcp/base_calendar.py
@@ -80,9 +80,7 @@ class BaseCalendarAdapter:
         time_max = (end or now + timedelta(days=7)).isoformat()
         try:
             args = self._build_list_args(time_min, time_max, max_results, calendar_name)
-            result = self._manager.call_tool(
-                self._server_name, "list_events", args
-            )
+            result = self._manager.call_tool(self._server_name, "list_events", args)
             if "error" in result:
                 log.warning("%s list_events error: %s", self._source.title(), result["error"])
                 return []
@@ -105,9 +103,7 @@ class BaseCalendarAdapter:
             raise RuntimeError(f"{self._source.title()} MCP server not available")
         assert self._manager is not None
         args = self._build_create_args(title, start, end, description, location, calendar_name)
-        result = self._manager.call_tool(
-            self._server_name, "create_event", args
-        )
+        result = self._manager.call_tool(self._server_name, "create_event", args)
         if "error" in result:
             raise RuntimeError(f"{self._source.title()} create_event failed: {result['error']}")
         return CalendarEvent(
@@ -127,9 +123,7 @@ class BaseCalendarAdapter:
             return []
         assert self._manager is not None
         try:
-            result = self._manager.call_tool(
-                self._server_name, "list_calendars", {}
-            )
+            result = self._manager.call_tool(self._server_name, "list_calendars", {})
             return self._extract_calendar_names(result)
         except Exception:
             return []

--- a/core/mcp/base_notification.py
+++ b/core/mcp/base_notification.py
@@ -73,13 +73,14 @@ class BaseNotificationAdapter:
             return NotificationResult(
                 success=False, channel=ch, error=f"{ch.title()} MCP server not available"
             )
+        assert self._manager is not None
         try:
             args: dict[str, Any] = {self._recipient_key: recipient, self._message_key: message}
             for key in self._forward_keys:
                 if key in kwargs:
                     args[key] = kwargs[key]
 
-            raw = self._manager.call_tool(  # type: ignore[union-attr]
+            raw = self._manager.call_tool(
                 self._server_name,
                 self._tool_name,
                 args,

--- a/core/mcp/stdio_client.py
+++ b/core/mcp/stdio_client.py
@@ -154,7 +154,11 @@ class StdioMCPClient:
         if self._process is not None:
             pid = self._pid
             try:
-                self._process.stdin.close()  # type: ignore[union-attr]
+                # subprocess.Popen.stdin is Optional[IO[bytes]] (None when
+                # ``stdin`` was not piped); only close if we actually own a
+                # writable handle.
+                if self._process.stdin is not None:
+                    self._process.stdin.close()
                 self._process.terminate()
                 self._process.wait(timeout=_CLOSE_TIMEOUT_S)
                 log.debug("MCP subprocess terminated gracefully (PID %s)", pid)

--- a/core/server/supervised/discord_poller.py
+++ b/core/server/supervised/discord_poller.py
@@ -51,13 +51,17 @@ class DiscordPoller(BasePoller):
 
     def _poll_channel(self, channel_id: str) -> None:
         """Poll a single Discord channel for new messages."""
+        # ``_poll_once`` (caller) gates this method behind
+        # ``_check_mcp_health`` which already guarantees ``_mcp is not None``.
+        assert self._mcp is not None
+
         try:
             args: dict[str, Any] = {"channel_id": channel_id, "limit": 5}
             after = self._last_id.get(channel_id)
             if after:
                 args["after"] = after
 
-            result = self._mcp.call_tool("discord", "get_messages", args)  # type: ignore[union-attr]
+            result = self._mcp.call_tool("discord", "get_messages", args)
             if "error" in result:
                 return
 

--- a/core/server/supervised/slack_poller.py
+++ b/core/server/supervised/slack_poller.py
@@ -67,13 +67,18 @@ class SlackPoller(BasePoller):
         """
         import json as _json
 
+        # ``_poll_once`` (caller) gates this method behind
+        # ``_check_mcp_health`` which already guarantees ``_mcp is not None``;
+        # the assert localises that invariant for mypy.
+        assert self._mcp is not None
+
         try:
             args: dict[str, Any] = {"channel_id": channel_id, "limit": 5}
             oldest = self._last_ts.get(channel_id)
             if oldest:
                 args["oldest"] = oldest
 
-            result = self._mcp.call_tool("slack", "slack_get_channel_history", args)  # type: ignore[union-attr]
+            result = self._mcp.call_tool("slack", "slack_get_channel_history", args)
 
             # MCP returns {"content": [{"text": "{\"ok\":true,\"messages\":[...]}"}]}
             parsed = result

--- a/core/server/supervised/telegram_poller.py
+++ b/core/server/supervised/telegram_poller.py
@@ -45,13 +45,16 @@ class TelegramPoller(BasePoller):
     def _poll_once(self) -> None:
         if not self._check_mcp_health():
             return
+        # ``_check_mcp_health`` returned True ⇒ ``_mcp is not None``;
+        # localise the invariant for mypy.
+        assert self._mcp is not None
 
         try:
             args: dict[str, Any] = {"limit": 10}
             if self._last_update_id:
                 args["offset"] = self._last_update_id + 1
 
-            result = self._mcp.call_tool("telegram", "get_updates", args)  # type: ignore[union-attr]
+            result = self._mcp.call_tool("telegram", "get_updates", args)
             if "error" in result:
                 return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.88.3"
+version = "0.88.4"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.88.3"
+version = "0.88.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `# type: ignore[union-attr]` 10 건 **전부 제거** (배치 100 % 정리).
- type:ignore 총합 63 → **53** (−10, −15.9 %).
- `[union-attr]` 카테고리: **10 → 0** (완전 소멸).
- 패턴: 호출 측 None 가드 invariant 를 mypy 에 명시(`assert ... is not None`).  Anti-deception 체크 통과 (신규 ignore 추가 0).

## Why
v0.88.3 (no-any-return) 에 이은 B2 두 번째 배치.  10 개 사이트 모두 `Optional[X]` attribute 접근으로, 호출 측에서는 `is_available()` / `_check_mcp_health()` 등 헬퍼로 None 가드를 이미 통과한 invariant 인데 mypy 가 그 가드 함수를 거쳐 narrowing 을 spread 못해 발생.  `assert ... is not None` 한 줄이면 (1) mypy 가 narrow, (2) 런타임에 None 발생 시 silently 죽지 않고 AssertionError 로 즉시 발견, (3) 의도(invariant)가 코드에 명시됨 — 3 마리 토끼.

## Changes
| File | Change |
|------|--------|
| `core/server/supervised/slack_poller.py` | `_poll_channel` 진입부에 `assert self._mcp is not None` (caller `_poll_once` 가 `_check_mcp_health` 가드) |
| `core/server/supervised/discord_poller.py` | 동일 패턴 (`_poll_channel` 진입부 assert) |
| `core/server/supervised/telegram_poller.py` | `_poll_once` 의 health 가드 직후 assert |
| `core/mcp/base_calendar.py` | `delete_event`, `list_events`, `create_event`, `list_calendars` 4 메서드 모두 `is_available()` 가드 직후 `assert self._manager is not None` |
| `core/mcp/base_notification.py` | `send` 의 동일 패턴 |
| `core/mcp/stdio_client.py` | `subprocess.Popen.stdin: Optional[IO[bytes]]` 의 None 가능성을 `if ... is not None:` 가드로 처리 (assert 가 아니라 if — stdin 미파이프 시 silently skip 이 의도) |
| `core/llm/providers/anthropic.py` | `ClaudeAgenticAdapter.agentic_call` 의 nested `_do_call` closure 진입부에 `assert self._client is not None` (closure 가 outer scope None 체크를 mypy 입장에서 capture 못함) |
| `CHANGELOG.md` | `[0.88.4]` 섹션 신설 (Hardening + Metrics) |
| `CLAUDE.md` / `README.md` / `pyproject.toml` | Version 0.88.3 → 0.88.4 |
| `uv.lock` | self-package 자동 동기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 10 union-attr 사이트 식별 | Implemented | grep 카테고리 100 % 매칭 |
| Poller 3 사이트 (slack/discord/telegram) | Implemented | `_check_mcp_health` 후 `_mcp` invariant |
| MCP base_calendar 4 사이트 | Implemented | `is_available()` 후 `_manager` invariant |
| MCP base_notification 1 사이트 | Implemented | 동일 패턴 |
| stdio_client 1 사이트 | Implemented | `Popen.stdin` 가드 (개별 케이스, if 패턴) |
| anthropic.py 1 사이트 | Implemented | closure invariant assert |
| 신규 ignore 추가 | None | anti-deception 통과 |
| 런타임 동작 변화 | None | assert 는 invariant 명시, None 발생 시 silent dereference 대신 명시적 에러 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed, 1 skipped, 24 deselected
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` A (68.4) unchanged
- [x] `grep -rn "# type: ignore\[union-attr\]" core/` — 0 (originally 10)
- [x] `grep -rn "# type: ignore" core/ plugins/` — 53 (originally 63)

## Reference
- 세션 53 핸드오프 backlog B2 항목
- v0.88.3 (#940) 의 cast 패턴과 짝을 이루는 invariant 패턴
- Mypy `--strict` 모범 사례 (Pydantic, FastAPI 코드베이스 동일 패턴 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)