### PR TITLE
hardening(v0.88.5): graph.py call-overload ignore 9건 제거 (langgraph _Node Protocol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.5] — 2026-05-09
+
+> **Hardening — `core/graph.py` `# type: ignore[call-overload]` 9 건 제거
+> (B2 batch-3).**  9 개 langgraph `add_node()` 호출의 ignore 모두 제거.
+> 원인: 우리 `_node()` wrapper 의 반환 타입 `Callable[[GeodeState], dict[str, Any]]`
+> 이 langgraph 의 `_Node[NodeInputT_contra]` Protocol 과 mypy 입장에서
+> 자동 매칭되지 않음 (mypy 가 generic Callable 을 Protocol member 로
+> 자동 coerce 하지 않음).  Solution: ``_node`` 의 반환을 langgraph 의
+> ``_Node[GeodeState]`` Protocol 로 명시 + 반환값을 `cast()` 로 localise.
+> 9 개 ignore → 0, mypy 가 `add_node` overload 를 깨끗이 resolve.
+
+### Changed
+- **`core/graph.py:_node`** — return 타입 `Callable[[GeodeState], dict[str, Any]]` → `_Node[GeodeState]` (langgraph internal Protocol).  내부에서 `cast(_Node[GeodeState], _make_hooked_node(...))` / `cast(_Node[GeodeState], fn)` 로 wrapped/raw fn 모두 Protocol 로 localise.  Runtime 동작 변화 0 (langgraph 는 dict-shape return 을 그대로 받음).
+- **9 개 `add_node` 호출 (line 514–522)** — `# type: ignore[call-overload]` 제거.  `router`, `signals`, `analyst`, `evaluator`, `scoring`, `skip_check`, `verification`, `synthesizer`, `gather` 9 노드 모두.
+
+### Hardening Metrics
+- `# type: ignore` 총합: 53 → **44** (active count, −9, −17 %)
+- `[call-overload]` 카테고리: 13 → 4 (graph.py 9 → 0; tracing/tools/pipeline_executor 4 잔존 — root-cause 다른 SDK 한계)
+- pytest 4346 passed (변동 없음); ruff/mypy clean (332 source files); E2E A (68.4) 동일.
+
 ## [0.88.4] — 2026-05-09
 
 > **Hardening — `# type: ignore[union-attr]` 10 건 전부 제거 (B2 batch-2).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.88.4
+- **Version**: 0.88.5
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.88.4 — Long-running Autonomous Execution Harness
+# GEODE v0.88.5 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/graph.py
+++ b/core/graph.py
@@ -34,7 +34,7 @@ import sqlite3
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from core.llm.prompt_assembler import PromptAssembler
@@ -485,32 +485,46 @@ def build_graph(
     """
     graph = StateGraph(GeodeState)
 
-    # Optionally wrap nodes with hook triggers
+    # Optionally wrap nodes with hook triggers.
+    #
+    # v0.88.5 — return type uses langgraph's ``_Node`` Protocol so the 9
+    # downstream ``add_node`` call sites can drop their
+    # ``# type: ignore[call-overload]`` markers.  ``cast`` localises the
+    # ``Callable[[GeodeState], dict[str, Any]] → _Node[GeodeState]``
+    # structural cast (mypy refuses to auto-coerce generic ``Callable``
+    # into a Protocol member without an explicit hint).  Runtime is
+    # unchanged — langgraph already accepts the dict-returning shape.
+    from langgraph.graph._node import _Node as _LangGraphNode
+
     def _node(
         fn: Callable[[GeodeState], dict[str, Any]],
         name: str,
-    ) -> Callable[[GeodeState], dict[str, Any]]:
+    ) -> _LangGraphNode[GeodeState]:
         if hooks is not None:
-            return _make_hooked_node(
-                fn,
-                name,
-                hooks,
-                bootstrap_mgr,
-                prompt_assembler,
-                node_scope_policy,
+            return cast(
+                _LangGraphNode[GeodeState],
+                _make_hooked_node(
+                    fn,
+                    name,
+                    hooks,
+                    bootstrap_mgr,
+                    prompt_assembler,
+                    node_scope_policy,
+                ),
             )
-        return fn
+        return cast(_LangGraphNode[GeodeState], fn)
 
-    # Add nodes (type: ignore needed — LangGraph type stubs don't match runtime)
-    graph.add_node("router", _node(router_node, "router"))  # type: ignore[call-overload]
-    graph.add_node("signals", _node(signals_node, "signals"))  # type: ignore[call-overload]
-    graph.add_node("analyst", _node(analyst_node, "analyst"))  # type: ignore[call-overload]
-    graph.add_node("evaluator", _node(evaluator_node, "evaluator"))  # type: ignore[call-overload]
-    graph.add_node("scoring", _node(scoring_node, "scoring"))  # type: ignore[call-overload]
-    graph.add_node("skip_check", _node(_skip_check_node, "skip_check"))  # type: ignore[call-overload]
-    graph.add_node("verification", _node(_verification_node, "verification"))  # type: ignore[call-overload]
-    graph.add_node("synthesizer", _node(synthesizer_node, "synthesizer"))  # type: ignore[call-overload]
-    graph.add_node("gather", _node(_gather_node, "gather"))  # type: ignore[call-overload]
+    # ``_node`` returns ``_LangGraphNode[GeodeState]`` (cast inside),
+    # so mypy resolves ``add_node`` overloads cleanly without ignore.
+    graph.add_node("router", _node(router_node, "router"))
+    graph.add_node("signals", _node(signals_node, "signals"))
+    graph.add_node("analyst", _node(analyst_node, "analyst"))
+    graph.add_node("evaluator", _node(evaluator_node, "evaluator"))
+    graph.add_node("scoring", _node(scoring_node, "scoring"))
+    graph.add_node("skip_check", _node(_skip_check_node, "skip_check"))
+    graph.add_node("verification", _node(_verification_node, "verification"))
+    graph.add_node("synthesizer", _node(synthesizer_node, "synthesizer"))
+    graph.add_node("gather", _node(_gather_node, "gather"))
 
     # Edges: START → router
     graph.add_edge(START, "router")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.88.4"
+version = "0.88.5"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.88.4"
+version = "0.88.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `core/graph.py` 의 `# type: ignore[call-overload]` **9 건 전부 제거**.
- `_node()` wrapper 반환 타입을 langgraph 의 `_Node[GeodeState]` Protocol 로 명시 + `cast()` 로 localise.
- type:ignore 활성 카운트 53 → **44** (−9, −17 %); `[call-overload]` 13 → 4 (graph.py 100 % 제거, 잔존 4 는 root-cause 외부 SDK).

## Why
v0.88.4 (union-attr) 에 이은 B2 세 번째 배치.  9 개 `add_node()` 호출에 ignore 가 박혀 있었음:

```python
graph.add_node("router", _node(router_node, "router"))  # type: ignore[call-overload]
```

진단 (mypy 메시지 직접 인용):
```
error: No overload variant of "add_node" of "StateGraph" matches argument types
       "str", "Callable[[GeodeState], dict[str, Any]]"  [call-overload]
note:  Possible overload variants:
       def add_node(self, node: str, action: _Node[NodeInputT] | _NodeWith*[...] | ...
```

`_node()` 가 반환하는 `Callable[[GeodeState], dict[str, Any]]` 는 langgraph 의 `_Node[NodeInputT_contra]` Protocol(`__call__(state) -> Any`) 과 **runtime 호환 가능**하지만 mypy 가 generic `Callable` 을 Protocol member 로 자동 coerce 하지 않아 실패.

## Solution
1. `_node()` 반환 타입을 `_Node[GeodeState]` Protocol 로 명시:
   ```python
   from langgraph.graph._node import _Node as _LangGraphNode

   def _node(...) -> _LangGraphNode[GeodeState]:
       if hooks is not None:
           return cast(_LangGraphNode[GeodeState], _make_hooked_node(...))
       return cast(_LangGraphNode[GeodeState], fn)
   ```
2. 이로써 `add_node()` overload resolution 이 깨끗하게 풀려 9 개 ignore 모두 mypy 가 "Unused" 로 보고 → 일괄 제거.

Cast 는 무코스트 hint 라 런타임 동작 변화 0.  langgraph 는 dict-shape return 을 그대로 받아들이므로 의미 변화 없음 — 단지 mypy 의 정적 view 만 일관화.

## Changes
| File | Change |
|------|--------|
| `core/graph.py` | (1) `from typing import cast` 추가. (2) `_node()` 내부에서 `from langgraph.graph._node import _Node as _LangGraphNode` 임포트. (3) `_node()` 반환 타입 → `_LangGraphNode[GeodeState]`. (4) wrapped/raw fn 모두 `cast()` 로 localise. (5) 9 개 `add_node()` 호출의 `# type: ignore[call-overload]` 제거. (6) docstring 코멘트 갱신. |
| `CHANGELOG.md` | `[0.88.5]` 섹션 신설 (Hardening + Metrics) |
| `CLAUDE.md` / `README.md` / `pyproject.toml` | Version 0.88.4 → 0.88.5 |
| `uv.lock` | self-package 자동 동기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| graph.py 9 ignores 모두 제거 | Implemented | `_Node[GeodeState]` Protocol + cast |
| 잔여 call-overload 4건 (tracing.py, tools.py, pipeline_executor.py x2) | Out of scope | root-cause: LangSmith `@traceable` decorator type erasure / langgraph stream() Send API overload — 외부 SDK |
| 신규 ignore 추가 | None | 정상 (anti-deception 통과) |
| Cast 1 → ignore 9 trade | Net win | 1 cast 위치 ↔ 9 사이트 ignore 제거 = 코드 surface 감소 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed, 1 skipped, 24 deselected
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` A (68.4) unchanged
- [x] `# type: ignore` 활성 카운트: 53 → 44 (−9)
- [x] `[call-overload]` graph.py 부분: 9 → 0

## Reference
- v0.88.3 / v0.88.4 (#940 / #942) 의 cast / assert 패턴과 짝을 이루는 Protocol 명시 패턴
- langgraph 1.x `_Node[NodeInputT_contra]` Protocol surface (`langgraph/graph/_node.py`)
- mypy `--strict` 의 Protocol vs Callable 이슈 (PEP 544 한계 — generic Callable 은 자동 coerce 안 됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)