### PR TITLE
release: v0.88.5 — graph.py call-overload ignore 9건 제거 (B2 batch-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.88.5] — 2026-05-09
+
+> **Hardening — `core/graph.py` `# type: ignore[call-overload]` 9 건 제거
+> (B2 batch-3).**  9 개 langgraph `add_node()` 호출의 ignore 모두 제거.
+> 원인: 우리 `_node()` wrapper 의 반환 타입 `Callable[[GeodeState], dict[str, Any]]`
+> 이 langgraph 의 `_Node[NodeInputT_contra]` Protocol 과 mypy 입장에서
+> 자동 매칭되지 않음 (mypy 가 generic Callable 을 Protocol member 로
+> 자동 coerce 하지 않음).  Solution: ``_node`` 의 반환을 langgraph 의
+> ``_Node[GeodeState]`` Protocol 로 명시 + 반환값을 `cast()` 로 localise.
+> 9 개 ignore → 0, mypy 가 `add_node` overload 를 깨끗이 resolve.
+
+### Changed
+- **`core/graph.py:_node`** — return 타입 `Callable[[GeodeState], dict[str, Any]]` → `_Node[GeodeState]` (langgraph internal Protocol).  내부에서 `cast(_Node[GeodeState], _make_hooked_node(...))` / `cast(_Node[GeodeState], fn)` 로 wrapped/raw fn 모두 Protocol 로 localise.  Runtime 동작 변화 0 (langgraph 는 dict-shape return 을 그대로 받음).
+- **9 개 `add_node` 호출 (line 514–522)** — `# type: ignore[call-overload]` 제거.  `router`, `signals`, `analyst`, `evaluator`, `scoring`, `skip_check`, `verification`, `synthesizer`, `gather` 9 노드 모두.
+
+### Hardening Metrics
+- `# type: ignore` 총합: 53 → **44** (active count, −9, −17 %)
+- `[call-overload]` 카테고리: 13 → 4 (graph.py 9 → 0; tracing/tools/pipeline_executor 4 잔존 — root-cause 다른 SDK 한계)
+- pytest 4346 passed (변동 없음); ruff/mypy clean (332 source files); E2E A (68.4) 동일.
+
 ## [0.88.4] — 2026-05-09
 
 > **Hardening — `# type: ignore[union-attr]` 10 건 전부 제거 (B2 batch-2).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.88.4
+- **Version**: 0.88.5
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.88.4 — Long-running Autonomous Execution Harness
+# GEODE v0.88.5 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/graph.py
+++ b/core/graph.py
@@ -34,7 +34,7 @@ import sqlite3
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from core.llm.prompt_assembler import PromptAssembler
@@ -485,32 +485,46 @@ def build_graph(
     """
     graph = StateGraph(GeodeState)
 
-    # Optionally wrap nodes with hook triggers
+    # Optionally wrap nodes with hook triggers.
+    #
+    # v0.88.5 — return type uses langgraph's ``_Node`` Protocol so the 9
+    # downstream ``add_node`` call sites can drop their
+    # ``# type: ignore[call-overload]`` markers.  ``cast`` localises the
+    # ``Callable[[GeodeState], dict[str, Any]] → _Node[GeodeState]``
+    # structural cast (mypy refuses to auto-coerce generic ``Callable``
+    # into a Protocol member without an explicit hint).  Runtime is
+    # unchanged — langgraph already accepts the dict-returning shape.
+    from langgraph.graph._node import _Node as _LangGraphNode
+
     def _node(
         fn: Callable[[GeodeState], dict[str, Any]],
         name: str,
-    ) -> Callable[[GeodeState], dict[str, Any]]:
+    ) -> _LangGraphNode[GeodeState]:
         if hooks is not None:
-            return _make_hooked_node(
-                fn,
-                name,
-                hooks,
-                bootstrap_mgr,
-                prompt_assembler,
-                node_scope_policy,
+            return cast(
+                _LangGraphNode[GeodeState],
+                _make_hooked_node(
+                    fn,
+                    name,
+                    hooks,
+                    bootstrap_mgr,
+                    prompt_assembler,
+                    node_scope_policy,
+                ),
             )
-        return fn
+        return cast(_LangGraphNode[GeodeState], fn)
 
-    # Add nodes (type: ignore needed — LangGraph type stubs don't match runtime)
-    graph.add_node("router", _node(router_node, "router"))  # type: ignore[call-overload]
-    graph.add_node("signals", _node(signals_node, "signals"))  # type: ignore[call-overload]
-    graph.add_node("analyst", _node(analyst_node, "analyst"))  # type: ignore[call-overload]
-    graph.add_node("evaluator", _node(evaluator_node, "evaluator"))  # type: ignore[call-overload]
-    graph.add_node("scoring", _node(scoring_node, "scoring"))  # type: ignore[call-overload]
-    graph.add_node("skip_check", _node(_skip_check_node, "skip_check"))  # type: ignore[call-overload]
-    graph.add_node("verification", _node(_verification_node, "verification"))  # type: ignore[call-overload]
-    graph.add_node("synthesizer", _node(synthesizer_node, "synthesizer"))  # type: ignore[call-overload]
-    graph.add_node("gather", _node(_gather_node, "gather"))  # type: ignore[call-overload]
+    # ``_node`` returns ``_LangGraphNode[GeodeState]`` (cast inside),
+    # so mypy resolves ``add_node`` overloads cleanly without ignore.
+    graph.add_node("router", _node(router_node, "router"))
+    graph.add_node("signals", _node(signals_node, "signals"))
+    graph.add_node("analyst", _node(analyst_node, "analyst"))
+    graph.add_node("evaluator", _node(evaluator_node, "evaluator"))
+    graph.add_node("scoring", _node(scoring_node, "scoring"))
+    graph.add_node("skip_check", _node(_skip_check_node, "skip_check"))
+    graph.add_node("verification", _node(_verification_node, "verification"))
+    graph.add_node("synthesizer", _node(synthesizer_node, "synthesizer"))
+    graph.add_node("gather", _node(_gather_node, "gather"))
 
     # Edges: START → router
     graph.add_edge(START, "router")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.88.4"
+version = "0.88.5"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.88.4"
+version = "0.88.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
v0.88.5 PATCH 릴리스 (hardening). `core/graph.py` 의 `# type: ignore[call-overload]` 9 건 전부 제거. type:ignore 활성 카운트 53 → 44 (−9).

포함 PR:
- #944 — `_node()` wrapper 반환 타입을 langgraph 의 `_Node[GeodeState]` Protocol 로 명시 + `cast()` localise. 9 개 `add_node()` 호출 ignore 일괄 해소.

## Verification
- [x] develop CI 5/5 pass on #944
- [x] 4 location 버전 일치: 0.88.5
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` 332 source files, 0 errors
- [x] `uv run pytest tests/ -m "not live"` — 4346 passed
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` A (68.4) unchanged
- [x] type:ignore 활성: 53 → 44 (−9); `[call-overload]` 13 → 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)