### PR TITLE
refactor(config): core.config 패키지 분리 + PEP 562 lazy (단계 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Architecture
+
+- **`core.config` 모듈을 패키지로 분리, pydantic_settings 트리 lazy 화**
+  (cold-start 회수 토대). 기존 `core/config.py` (567 lines) 를 `core/config/`
+  패키지로 변환:
+  - `core/config/_settings.py` (NEW) — `Settings(BaseSettings)` 클래스만 격리
+    하여 pydantic / pydantic_settings 풀 import 트리 (~150 ms cumulative,
+    144 modules) 가 첫 settings 인스턴스 요청 시점까지 미뤄지도록 함.
+  - `core/config/__init__.py` — 상수 (`*_PRIMARY`, `*_BASE_URL` 등),
+    TOML 로직, `ModelPolicy`, `RoutingConfig`, `_resolve_provider` 만 유지.
+    `settings` / `Settings` 는 PEP 562 `__getattr__` 로 lazy 해석.
+- 측정: `import core.config` 단독 cold = **189 ms → 34 ms (−82 %)**;
+  modules **308 → 164**; pydantic_settings 가 sys.modules 에 들어가지
+  않음 (`settings` 첫 access 시점에만 로드). 단독으로 cold-start path
+  전체 회수는 작음 (240 → 226 ms) — `from core.config import settings`
+  를 함수-로컬로 옮기는 callsite 변환이 다음 단계에서 핵심 회수를 만듦.
+
 ## [0.89.0] — 2026-05-09
 
 > **Removed — LangSmith 의존 100 % 제거.  관측성은 hook system + RunLog 로 일원화.**

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -6,6 +6,12 @@ Config Cascade (priority high → low):
   3. Project TOML: .geode/config.toml
   4. Global TOML: ~/.geode/config.toml
   5. Code defaults
+
+The :class:`Settings` class lives in :mod:`core.config._settings` so the heavy
+``pydantic_settings`` import tree only loads when an instance is actually
+requested. Module-level constants (``ANTHROPIC_PRIMARY`` etc.) and lightweight
+dataclasses (:class:`ModelPolicy`, :class:`RoutingConfig`) stay here so cold
+import paths that only need them avoid pydantic entirely.
 """
 
 from __future__ import annotations
@@ -16,12 +22,19 @@ import threading
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
-
-from pydantic import AliasChoices, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import TYPE_CHECKING, Any
 
 from core.paths import GLOBAL_CONFIG_TOML, GLOBAL_ENV_FILE, PROJECT_CONFIG_TOML
+
+if TYPE_CHECKING:
+    # Re-export ``Settings`` as a module attribute so ``from core.config
+    # import Settings`` type-checks while runtime keeps the heavy import
+    # lazy (see ``__getattr__`` below).
+    from core.config._settings import Settings as Settings
+
+    # Declare the lazily-resolved ``settings`` singleton for mypy. The actual
+    # value is produced by ``__getattr__`` on first access.
+    settings: Settings
 
 log = logging.getLogger(__name__)
 
@@ -145,208 +158,17 @@ def _apply_toml_overlay(s: Settings) -> None:
 GLOBAL_ENV_PATH = GLOBAL_ENV_FILE
 
 
-class Settings(BaseSettings):
-    model_config = SettingsConfigDict(
-        env_prefix="GEODE_",
-        env_file=(".env", str(Path.home() / ".geode" / ".env")),
-        extra="ignore",
-    )
-
-    anthropic_api_key: str = Field(
-        default="",
-        validation_alias=AliasChoices("anthropic_api_key", "ANTHROPIC_API_KEY"),
-    )
-    openai_api_key: str = Field(
-        default="",
-        validation_alias=AliasChoices("openai_api_key", "OPENAI_API_KEY"),
-    )
-    zai_api_key: str = Field(
-        default="",
-        validation_alias=AliasChoices("zai_api_key", "ZAI_API_KEY"),
-    )
-    model: str = "claude-opus-4-6"  # overridden by GEODE_MODEL env var; see ANTHROPIC_PRIMARY
-    verbose: bool = False
-    checkpoint_db: str = "geode_checkpoints.db"
-
-    # L4.5 Automation — Drift Detection
-    drift_scan_cron: str = "0 */6 * * *"  # Every 6 hours
-    drift_warning_threshold: float = 2.5
-    drift_critical_threshold: float = 4.0
-
-    # L4.5 Automation — Outcome Tracking
-    outcome_tracking_enabled: bool = True
-
-    # L4.5 Automation — Snapshot Manager
-    snapshot_dir: str = ""  # empty = auto-resolve via paths.resolve_snapshots_dir()
-    snapshot_max_recent: int = 30
-    snapshot_gc_threshold: int = 60  # auto-prune when count exceeds this
-
-    # L4.5 Automation — Trigger Manager
-    trigger_scheduler_interval_s: float = 60.0
-
-    # L4.5 Automation — Advanced Scheduler
-    scheduler_interval_s: float = 1.0  # 1s check interval (claude-code pattern)
-    scheduler_auto_start: bool = True
-    scheduler_jitter_enabled: bool = True  # Deterministic per-job jitter
-    scheduler_max_jitter_ms: float = 900_000.0  # 15 min cap
-
-    # L2 Memory — Session
-    session_ttl_hours: float = 4.0
-    session_storage_dir: str = ""  # file-backed persistence dir (empty = in-memory only)
-
-    # L2 Memory — Redis/PostgreSQL (simulation URLs)
-    redis_url: str = ""
-    postgres_url: str = ""
-
-    # L2 Memory — Organization
-    organization_fixture_dir: str = ""
-
-    # Tier 0.5 — User Profile
-    user_profile_dir: str = ""  # global dir override (default: ~/.geode/user_profile)
-
-    # L4.5 Automation — Model Registry
-    model_registry_dir: str = ""  # empty = auto-resolve via paths.resolve_models_dir()
-
-    # MCP Server URLs
-    steam_mcp_url: str = ""
-    brave_mcp_url: str = ""
-    brave_api_key: str = ""
-    kg_memory_mcp_url: str = ""
-
-    # Ensemble — Multi-LLM mode
-    ensemble_mode: str = "single"  # single | cross
-    secondary_analysts: str = "player_experience,discovery"
-    primary_analysts: str = "game_mechanics,growth_potential"
-
-    # Graph — Feedback Loop
-    confidence_threshold: float = 0.7
-    max_iterations: int = 5
-    interrupt_nodes: str = ""  # comma-separated node names, e.g. "verification,scoring"
-
-    # LLM — Router & Verification
-    router_model: str = "claude-opus-4-6"  # see ANTHROPIC_PRIMARY
-    default_secondary_model: str = "gpt-5.4"  # see OPENAI_PRIMARY
-    agreement_threshold: float = 0.67
-
-    # Sub-Agent Orchestration (P2)
-    max_subagent_depth: int = 1  # 최대 재귀 깊이 (depth=1 강제, Claude Code 패턴)
-    max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
-    subagent_max_rounds: int = 0  # 0 = unlimited (time-based control)
-    subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
-
-    # Token Guard — tool result truncation threshold (0 = unlimited)
-    max_tool_result_tokens: int = 25000  # 0 = no limit; clear_tool_uses handles overflow
-
-    # Tool Result Offloading — store large results to filesystem (P0 token optimization)
-    tool_offload_threshold: int = 15000  # tokens; 0 = disabled
-    tool_offload_ttl_hours: float = 4.0  # TTL for offloaded results
-    observation_mask_keep_rounds: int = 3  # keep recent N rounds unmasked
-
-    # Agentic Loop — time budget (Karpathy P3, OpenClaw Attempt Loop)
-    agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
-
-    # Agentic Loop — thinking budget (DTR: Extended Thinking / reasoning tokens)
-    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call (legacy)
-
-    # Agentic Loop — effort level (replaces thinking_budget for Opus 4.6+ / Sonnet 4.6+)
-    # Maps to Anthropic output_config.effort + OpenAI reasoning.effort.
-    # v0.56.0 R4-mini — ``xhigh`` added; Opus 4.7-only (the adapter
-    # downgrades to ``"max"`` on Opus 4.6 / Sonnet 4.6).
-    agentic_effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh"
-
-    # Cost guard — session-level cost limit (0 = no limit)
-    cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%
-
-    # Computer Use — desktop automation (requires pyautogui)
-    computer_use_enabled: bool = True  # default on; pyautogui import guard handles missing dep
-
-    # Context Compaction — overflow prevention
-    compact_keep_recent: int = 10  # messages to preserve during compaction/prune
-
-    # Notification — external messaging
-    notification_channel: str = "slack"  # default notification channel
-    notification_recipient: str = "#geode-alerts"  # default recipient
-    notification_on_pipeline_end: bool = True
-    notification_on_pipeline_error: bool = True
-    notification_on_drift: bool = True
-
-    # Gateway — inbound messaging
-    gateway_enabled: bool = False  # GEODE_GATEWAY_ENABLED=true to enable
-    gateway_poll_interval_s: float = 3.0
-
-    # L4 Gateway Hooks — external webhook endpoint
-    webhook_enabled: bool = False  # GEODE_WEBHOOK_ENABLED=true to enable
-    webhook_port: int = 8765
-
-    # Calendar — external calendar sync
-    calendar_sync_on_trigger: bool = False  # auto-sync on TRIGGER_FIRED
-
-    # Sandbox — file tool path validation (Claude Code parity)
-    sandbox_max_file_size_bytes: int = 262_144  # 256KB pre-read guard
-    sandbox_max_read_tokens: int = 25_000  # post-read token estimate guard
-    sandbox_max_glob_results: int = 100  # GlobTool max results
-    sandbox_max_grep_results: int = 50  # GrepTool max files
-    sandbox_max_grep_line_chars: int = 200  # GrepTool match line truncation
-
-    # HITL Level — Human-in-the-loop control
-    # 0 = autonomous (skip all prompts), 1 = write-only (prompt only for writes),
-    # 2 = all prompts (default, ask everything)
-    hitl_level: int = 2
-
-    # Plan Mode — Autonomous Execution
-    plan_auto_execute: bool = False  # GEODE_PLAN_AUTO_EXECUTE=true to enable
-
-    # LLM Connection — httpx pool & timeout tuning
-    llm_max_connections: int = 20  # httpx pool: max total connections
-    llm_max_keepalive_connections: int = 5  # httpx pool: max idle keep-alive connections
-    llm_keepalive_expiry: float = 30.0  # idle conn TTL (match API server timeout)
-    llm_connect_timeout: float = 5.0  # TCP connect timeout (fail fast)
-    llm_read_timeout: float = 300.0  # response read timeout (5min for 1M context)
-    llm_write_timeout: float = 30.0  # request write timeout (seconds)
-    llm_pool_timeout: float = 10.0  # wait for available connection from pool (seconds)
-    llm_retry_base_delay: float = 2.0  # base delay for exponential backoff (seconds)
-    llm_retry_max_delay: float = 30.0  # max delay cap for retries (seconds)
-    llm_max_retries: int = 3  # max retry attempts per model
-
-    # LLM — Cross-Provider Failover (opt-in).
-    # When True, the router walks ``llm_cross_provider_order`` after all
-    # retries+fallbacks within the active provider exhaust. v0.52.2 keeps
-    # this opt-in (it auto-switches *silently*, which is a behaviour
-    # change with broader surface than the resilience patch should own).
-    # The B5 cross-provider breadcrumb (``credential_breadcrumb.format``)
-    # already surfaces alternative providers to the LLM so the model can
-    # ask the user to run ``/model <slug>`` — a transparent path.
-    llm_cross_provider_failover: bool = False
-    llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
-
-    # v0.52.4 — per-provider auth-mode escape hatch (Codex CLI parity).
-    # Default routing prefers SUBSCRIPTION/OAUTH plans over PAYG when both
-    # can serve the requested model (matches openai/codex CLI default).
-    # Override per provider when the user deliberately wants metered PAYG:
-    #   forced_login_method = {"openai": "apikey"}    # use OPENAI_API_KEY even
-    #                                                  # if Codex Plus OAuth is registered
-    # Valid values: "subscription" (default), "apikey", "auto" (alias).
-    # Reference: openai/codex#2733, #3286.
-    forced_login_method: dict[str, str] = {}
-
-    # LLM — Fallback cost ratio control (C2: 0 = unlimited)
-    llm_max_fallback_cost_ratio: float = 0.0
-
-    # Pipeline — timeout in seconds (B3: 0 = no timeout)
-    pipeline_timeout_s: float = 600.0
-
-    # Concurrency — workload lane limits
-    gateway_max_concurrent: int = 4  # max simultaneous Gateway messages
-
-
 _settings_instance: Settings | None = None
 
 
 def _get_settings() -> Settings:
     """Get or create the Settings singleton in a thread-safe manner.
 
-    After Pydantic loads from env/.env, overlays TOML config values
-    for fields not explicitly set via environment variables.
+    The :class:`Settings` class is imported lazily so that callers requesting
+    only constants from :mod:`core.config` (e.g. ``ANTHROPIC_PRIMARY``) avoid
+    pulling pydantic_settings into the cold-start tree. After Pydantic loads
+    from env/.env, overlays TOML config values for fields not explicitly set
+    via environment variables.
     """
     global _settings_instance
     if _settings_instance is not None:
@@ -354,13 +176,31 @@ def _get_settings() -> Settings:
     with _settings_lock:
         # Double-checked locking
         if _settings_instance is None:
-            s = Settings()
+            from core.config._settings import Settings as _Settings
+
+            s = _Settings()
             _apply_toml_overlay(s)
             _settings_instance = s
         return _settings_instance
 
 
-settings = _get_settings()
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy attribute access for ``settings`` and ``Settings``.
+
+    Attribute access here defers the heavy ``pydantic_settings`` import until
+    the caller actually uses it. Modules that only need constants such as
+    ``ANTHROPIC_PRIMARY`` or ``CODEX_BASE_URL`` therefore avoid the pydantic
+    tree entirely. Anything else falls through to the standard
+    ``AttributeError`` so typos surface immediately.
+    """
+    if name == "settings":
+        return _get_settings()
+    if name == "Settings":
+        from core.config._settings import Settings as _Settings
+
+        return _Settings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # ---------------------------------------------------------------------------
 # Model constants — single source of truth for model names & pricing

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -1,0 +1,208 @@
+"""Pydantic Settings class — isolated module so the heavy pydantic_settings
+import tree only loads when a Settings instance is actually requested.
+
+This module is loaded lazily via ``core.config.__getattr__``. Direct callers
+should import ``settings`` (not the class) from ``core.config``; the class is
+exposed only for type hints and test fixtures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="GEODE_",
+        env_file=(".env", str(Path.home() / ".geode" / ".env")),
+        extra="ignore",
+    )
+
+    anthropic_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("anthropic_api_key", "ANTHROPIC_API_KEY"),
+    )
+    openai_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("openai_api_key", "OPENAI_API_KEY"),
+    )
+    zai_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("zai_api_key", "ZAI_API_KEY"),
+    )
+    model: str = "claude-opus-4-6"  # overridden by GEODE_MODEL env var; see ANTHROPIC_PRIMARY
+    verbose: bool = False
+    checkpoint_db: str = "geode_checkpoints.db"
+
+    # L4.5 Automation — Drift Detection
+    drift_scan_cron: str = "0 */6 * * *"  # Every 6 hours
+    drift_warning_threshold: float = 2.5
+    drift_critical_threshold: float = 4.0
+
+    # L4.5 Automation — Outcome Tracking
+    outcome_tracking_enabled: bool = True
+
+    # L4.5 Automation — Snapshot Manager
+    snapshot_dir: str = ""  # empty = auto-resolve via paths.resolve_snapshots_dir()
+    snapshot_max_recent: int = 30
+    snapshot_gc_threshold: int = 60  # auto-prune when count exceeds this
+
+    # L4.5 Automation — Trigger Manager
+    trigger_scheduler_interval_s: float = 60.0
+
+    # L4.5 Automation — Advanced Scheduler
+    scheduler_interval_s: float = 1.0  # 1s check interval (claude-code pattern)
+    scheduler_auto_start: bool = True
+    scheduler_jitter_enabled: bool = True  # Deterministic per-job jitter
+    scheduler_max_jitter_ms: float = 900_000.0  # 15 min cap
+
+    # L2 Memory — Session
+    session_ttl_hours: float = 4.0
+    session_storage_dir: str = ""  # file-backed persistence dir (empty = in-memory only)
+
+    # L2 Memory — Redis/PostgreSQL (simulation URLs)
+    redis_url: str = ""
+    postgres_url: str = ""
+
+    # L2 Memory — Organization
+    organization_fixture_dir: str = ""
+
+    # Tier 0.5 — User Profile
+    user_profile_dir: str = ""  # global dir override (default: ~/.geode/user_profile)
+
+    # L4.5 Automation — Model Registry
+    model_registry_dir: str = ""  # empty = auto-resolve via paths.resolve_models_dir()
+
+    # MCP Server URLs
+    steam_mcp_url: str = ""
+    brave_mcp_url: str = ""
+    brave_api_key: str = ""
+    kg_memory_mcp_url: str = ""
+
+    # Ensemble — Multi-LLM mode
+    ensemble_mode: str = "single"  # single | cross
+    secondary_analysts: str = "player_experience,discovery"
+    primary_analysts: str = "game_mechanics,growth_potential"
+
+    # Graph — Feedback Loop
+    confidence_threshold: float = 0.7
+    max_iterations: int = 5
+    interrupt_nodes: str = ""  # comma-separated node names, e.g. "verification,scoring"
+
+    # LLM — Router & Verification
+    router_model: str = "claude-opus-4-6"  # see ANTHROPIC_PRIMARY
+    default_secondary_model: str = "gpt-5.4"  # see OPENAI_PRIMARY
+    agreement_threshold: float = 0.67
+
+    # Sub-Agent Orchestration (P2)
+    max_subagent_depth: int = 1  # 최대 재귀 깊이 (depth=1 강제, Claude Code 패턴)
+    max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
+    subagent_max_rounds: int = 0  # 0 = unlimited (time-based control)
+    subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
+
+    # Token Guard — tool result truncation threshold (0 = unlimited)
+    max_tool_result_tokens: int = 25000  # 0 = no limit; clear_tool_uses handles overflow
+
+    # Tool Result Offloading — store large results to filesystem (P0 token optimization)
+    tool_offload_threshold: int = 15000  # tokens; 0 = disabled
+    tool_offload_ttl_hours: float = 4.0  # TTL for offloaded results
+    observation_mask_keep_rounds: int = 3  # keep recent N rounds unmasked
+
+    # Agentic Loop — time budget (Karpathy P3, OpenClaw Attempt Loop)
+    agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
+
+    # Agentic Loop — thinking budget (DTR: Extended Thinking / reasoning tokens)
+    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call (legacy)
+
+    # Agentic Loop — effort level (replaces thinking_budget for Opus 4.6+ / Sonnet 4.6+)
+    # Maps to Anthropic output_config.effort + OpenAI reasoning.effort.
+    # v0.56.0 R4-mini — ``xhigh`` added; Opus 4.7-only (the adapter
+    # downgrades to ``"max"`` on Opus 4.6 / Sonnet 4.6).
+    agentic_effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh"
+
+    # Cost guard — session-level cost limit (0 = no limit)
+    cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%
+
+    # Computer Use — desktop automation (requires pyautogui)
+    computer_use_enabled: bool = True  # default on; pyautogui import guard handles missing dep
+
+    # Context Compaction — overflow prevention
+    compact_keep_recent: int = 10  # messages to preserve during compaction/prune
+
+    # Notification — external messaging
+    notification_channel: str = "slack"  # default notification channel
+    notification_recipient: str = "#geode-alerts"  # default recipient
+    notification_on_pipeline_end: bool = True
+    notification_on_pipeline_error: bool = True
+    notification_on_drift: bool = True
+
+    # Gateway — inbound messaging
+    gateway_enabled: bool = False  # GEODE_GATEWAY_ENABLED=true to enable
+    gateway_poll_interval_s: float = 3.0
+
+    # L4 Gateway Hooks — external webhook endpoint
+    webhook_enabled: bool = False  # GEODE_WEBHOOK_ENABLED=true to enable
+    webhook_port: int = 8765
+
+    # Calendar — external calendar sync
+    calendar_sync_on_trigger: bool = False  # auto-sync on TRIGGER_FIRED
+
+    # Sandbox — file tool path validation (Claude Code parity)
+    sandbox_max_file_size_bytes: int = 262_144  # 256KB pre-read guard
+    sandbox_max_read_tokens: int = 25_000  # post-read token estimate guard
+    sandbox_max_glob_results: int = 100  # GlobTool max results
+    sandbox_max_grep_results: int = 50  # GrepTool max files
+    sandbox_max_grep_line_chars: int = 200  # GrepTool match line truncation
+
+    # HITL Level — Human-in-the-loop control
+    # 0 = autonomous (skip all prompts), 1 = write-only (prompt only for writes),
+    # 2 = all prompts (default, ask everything)
+    hitl_level: int = 2
+
+    # Plan Mode — Autonomous Execution
+    plan_auto_execute: bool = False  # GEODE_PLAN_AUTO_EXECUTE=true to enable
+
+    # LLM Connection — httpx pool & timeout tuning
+    llm_max_connections: int = 20  # httpx pool: max total connections
+    llm_max_keepalive_connections: int = 5  # httpx pool: max idle keep-alive connections
+    llm_keepalive_expiry: float = 30.0  # idle conn TTL (match API server timeout)
+    llm_connect_timeout: float = 5.0  # TCP connect timeout (fail fast)
+    llm_read_timeout: float = 300.0  # response read timeout (5min for 1M context)
+    llm_write_timeout: float = 30.0  # request write timeout (seconds)
+    llm_pool_timeout: float = 10.0  # wait for available connection from pool (seconds)
+    llm_retry_base_delay: float = 2.0  # base delay for exponential backoff (seconds)
+    llm_retry_max_delay: float = 30.0  # max delay cap for retries (seconds)
+    llm_max_retries: int = 3  # max retry attempts per model
+
+    # LLM — Cross-Provider Failover (opt-in).
+    # When True, the router walks ``llm_cross_provider_order`` after all
+    # retries+fallbacks within the active provider exhaust. v0.52.2 keeps
+    # this opt-in (it auto-switches *silently*, which is a behaviour
+    # change with broader surface than the resilience patch should own).
+    # The B5 cross-provider breadcrumb (``credential_breadcrumb.format``)
+    # already surfaces alternative providers to the LLM so the model can
+    # ask the user to run ``/model <slug>`` — a transparent path.
+    llm_cross_provider_failover: bool = False
+    llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
+
+    # v0.52.4 — per-provider auth-mode escape hatch (Codex CLI parity).
+    # Default routing prefers SUBSCRIPTION/OAUTH plans over PAYG when both
+    # can serve the requested model (matches openai/codex CLI default).
+    # Override per provider when the user deliberately wants metered PAYG:
+    #   forced_login_method = {"openai": "apikey"}    # use OPENAI_API_KEY even
+    #                                                  # if Codex Plus OAuth is registered
+    # Valid values: "subscription" (default), "apikey", "auto" (alias).
+    # Reference: openai/codex#2733, #3286.
+    forced_login_method: dict[str, str] = {}
+
+    # LLM — Fallback cost ratio control (C2: 0 = unlimited)
+    llm_max_fallback_cost_ratio: float = 0.0
+
+    # Pipeline — timeout in seconds (B3: 0 = no timeout)
+    pipeline_timeout_s: float = 600.0
+
+    # Concurrency — workload lane limits
+    gateway_max_concurrent: int = 4  # max simultaneous Gateway messages


### PR DESCRIPTION
## Summary
- `core/config.py` (567 lines) → `core/config/` 패키지로 분리.
- `Settings(BaseSettings)` 클래스를 `_settings.py` 로 격리 + PEP 562 `__getattr__` 로 `settings` / `Settings` lazy 해석.
- 상수만 import 하는 사이트는 pydantic 트리 회피 (구조 토대).

## Why
세션 54 핸드오프 backlog #2 — `core.config` 80 ms cumulative 추정 개선 측정 결과 **180 ms (cold-start 318 ms 중 56 %)** 이 pydantic_settings 트리. 회수 잠재 큼. 회수는 두 단계로 분해:
1. 구조 분리 + lazy 패턴 도입 (이 PR) → 상수 사이트 pydantic 회피
2. cold-start path top-level `from core.config import settings` 의 함수-로컬 이동 (다음 PR) → 진짜 cold-start 회수

이 PR 단독으로는 cold-start 회수 −14 ms (`core.runtime` 240 → 226 ms) 이지만 단계 2 의 토대를 만든다.

## Changes
| File | Change |
|------|--------|
| `core/config.py` → `core/config/__init__.py` | rename + pydantic top-level import 제거 + Settings 클래스 본문 제거 + `__getattr__` lazy 추가. `_apply_toml_overlay` / `_get_settings` 의 type hint 는 `TYPE_CHECKING` block 으로 처리. |
| `core/config/_settings.py` | NEW — `Settings(BaseSettings)` 클래스 (191 lines) 만 격리. pydantic / pydantic_settings 풀 import 트리는 이 모듈 첫 import 시점에만 로드. |
| `CHANGELOG.md` | `[Unreleased] / Architecture` 항목 추가. |

## Verification
- [x] ruff check clean (core/ tests/ plugins/)
- [x] mypy clean — 332 source files (이전 331; `_settings.py` 추가)
- [x] pytest 4330 passed / 1 skipped / 24 deselected — baseline 정확히 일치 (0 regression)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) unchanged
- [x] Lazy 검증: `import core.config` 후 `pydantic_settings not in sys.modules == True` (PEP 562 작동 확인)
- [x] `import core.config` 단독 cold: **189 ms → 34 ms (−82 %)**, modules **308 → 164**
- [x] `settings` / `Settings` 첫 access 시 정상 lazy 로드 + singleton 동작 + `isinstance(s, Settings)` True

## Reference
- 측정 베이스: 세션 54 (`v0.89.0`) `import core.runtime` cold = 318 ms cumulative; `core.config` 트리 180 ms self+cumulative.
- 패턴: PEP 562 `__getattr__` (Python 3.7+) — Codex CLI / Claude Code / langgraph 모두 config lazy 패턴 사용.
- 다음: 단계 2 — `core/runtime.py:55`, `core/graph.py:54`, `core/llm/router/calls/*.py`, `core/llm/providers/*.py` 등 top-level `from core.config import settings` 를 함수-로컬로 이동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)