### PR TITLE
release(v0.89.1): cold-start −46 % (core.config lazy + 19 callsite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.89.1] — 2026-05-09
+
+> **Cold-start −46 % via `core.config` lazy + 19 callsite 함수-로컬 import.**
+>
+> v0.89.1 은 cold-start path 의 무거운 `pydantic_settings` 트리 (~150 ms cumulative,
+> 144 modules) 를 lazy 화한다. `core/config.py` (567 lines) 를 `core/config/`
+> 패키지로 분리해 `Settings(BaseSettings)` 클래스를 격리하고, 19 사이트의
+> top-level `from core.config import settings` 을 함수-로컬 import 로 이전.
+> 측정 — `import core.runtime` cold-start: **240 ms → 128 ms first-run / 80–110 ms warm**
+> (median ≈ 88 ms) = **−112 ms / −46 %**. 0 regression: 4330 tests pass,
+> E2E A (68.4) unchanged.
+
 ### Architecture
 
 - **`core.config` 모듈을 패키지로 분리, pydantic_settings 트리 lazy 화**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.0
+- **Version**: 0.89.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.89.0 — Long-running Autonomous Execution Harness
+# GEODE v0.89.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.0"
+version = "0.89.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Version stamp 4 위치 동기 (pyproject / CLAUDE.md / README.md / CHANGELOG).
- v0.89.1 = PR #948 (단계 1) + PR #949 (단계 2) 합본 cold-start 최적화 릴리즈.

## Verification
- [x] 4 위치 version: 0.89.1
- [x] CHANGELOG `[Unreleased]` → `[0.89.1] — 2026-05-09` stamp
- [x] cold-start `import core.runtime`: 240 ms → 128 ms first-run / 80–110 ms warm = −112 ms / −46 %
- [x] 4330 tests pass / E2E A (68.4) (PR #948 + #949 머지 후 develop 기준 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)