### PR TITLE
release(v0.89.1): cold-start −46 % (core.config lazy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Architecture
+
+- **`core.config` 모듈을 패키지로 분리, pydantic_settings 트리 lazy 화**
+  (cold-start 회수 토대). 기존 `core/config.py` (567 lines) 를 `core/config/`
+  패키지로 변환:
+  - `core/config/_settings.py` (NEW) — `Settings(BaseSettings)` 클래스만 격리
+    하여 pydantic / pydantic_settings 풀 import 트리 (~150 ms cumulative,
+    144 modules) 가 첫 settings 인스턴스 요청 시점까지 미뤄지도록 함.
+  - `core/config/__init__.py` — 상수 (`*_PRIMARY`, `*_BASE_URL` 등),
+    TOML 로직, `ModelPolicy`, `RoutingConfig`, `_resolve_provider` 만 유지.
+    `settings` / `Settings` 는 PEP 562 `__getattr__` 로 lazy 해석.
+- 측정: `import core.config` 단독 cold = **189 ms → 34 ms (−82 %)**;
+  modules **308 → 164**; pydantic_settings 가 sys.modules 에 들어가지
+  않음 (`settings` 첫 access 시점에만 로드). 단독으로 cold-start path
+  전체 회수는 작음 (240 → 226 ms) — `from core.config import settings`
+  를 함수-로컬로 옮기는 callsite 변환이 다음 단계에서 핵심 회수를 만듦.
+
 ## [0.89.0] — 2026-05-09
 
 > **Removed — LangSmith 의존 100 % 제거.  관측성은 hook system + RunLog 로 일원화.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.89.1] — 2026-05-09
+
+> **Cold-start −46 % via `core.config` lazy + 19 callsite 함수-로컬 import.**
+>
+> v0.89.1 은 cold-start path 의 무거운 `pydantic_settings` 트리 (~150 ms cumulative,
+> 144 modules) 를 lazy 화한다. `core/config.py` (567 lines) 를 `core/config/`
+> 패키지로 분리해 `Settings(BaseSettings)` 클래스를 격리하고, 19 사이트의
+> top-level `from core.config import settings` 을 함수-로컬 import 로 이전.
+> 측정 — `import core.runtime` cold-start: **240 ms → 128 ms first-run / 80–110 ms warm**
+> (median ≈ 88 ms) = **−112 ms / −46 %**. 0 regression: 4330 tests pass,
+> E2E A (68.4) unchanged.
+
 ### Architecture
 
 - **`core.config` 모듈을 패키지로 분리, pydantic_settings 트리 lazy 화**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,39 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   전체 회수는 작음 (240 → 226 ms) — `from core.config import settings`
   를 함수-로컬로 옮기는 callsite 변환이 다음 단계에서 핵심 회수를 만듦.
 
+- **`from core.config import settings` 의 cold-start path callsite 19 곳을
+  함수-로컬 import 로 이전** (단계 1 의 PEP 562 lazy 후속). 변환 대상:
+  - 4-Layer wiring: `core/wiring/{bootstrap,automation,container,startup}.py`
+  - LLM 라우터/제공자: `core/runtime.py`, `core/graph.py`,
+    `core/llm/{adapters,fallback,provider_dispatch}.py`,
+    `core/llm/router/calls/{tools,streaming,text,parsed,_failover}.py`,
+    `core/llm/providers/{anthropic,openai,glm}.py`
+  - CLI thin client: `core/cli/{__init__,dispatcher,pipeline_executor,onboarding,
+    welcome,report_renderer}.py`, `core/cli/tool_handlers/system.py`
+  - 도메인 플러그인: `plugins/game_ip/cli/batch.py`
+- `core/llm/fallback.py` 의 module-level `MAX_RETRIES` / `RETRY_BASE_DELAY` /
+  `RETRY_MAX_DELAY` (settings 즉시 평가) 도 PEP 562 `__getattr__` 로 lazy
+  해석. `retry_with_backoff_generic` 함수 default 도 None 으로 바꾸고
+  body 에서 settings 에서 해석 — module load 시점 settings 트리거 차단.
+- `core/llm/router/__init__.py` 의 `MAX_RETRIES` 등 re-export 는 PEP 562
+  fallback constants lazy 분기로 이전 (외부 `from core.llm.router import
+  MAX_RETRIES` 호환 유지).
+- 5 모듈 (`wiring/{startup,container}`, `cli/onboarding`,
+  `llm/provider_dispatch`, `llm/providers/anthropic`) 에 module-level
+  `__getattr__` 의 `settings` lazy alias 를 추가해 legacy patch 사이트
+  (`patch("core.X.settings")`) 호환 유지.
+- 영향 테스트 (`patch("core.X.settings")` 24 사이트) 는 `core.config.settings`
+  단일 patch 로 통일. settings 가 singleton 이라 동등.
+
+- **측정 (cold-start, `import core.runtime`)**:
+  - v0.89.0 baseline: **240 ms** (single run, clean cache)
+  - 단계 1 (`config` 패키지 분리) 단독: 226 ms (−14 ms / −6 %)
+  - 단계 1+2 합산 (이 PR): **128 ms cold (first run) / 80–110 ms warm
+    (median ≈ 88 ms)** — 누적 −112 ms / **−46 %**
+  - `pydantic_settings` / `core.config._settings` 가 더 이상 cold-start 의
+    `sys.modules` 에 들어가지 않음 (첫 settings access 시점까지 미뤄짐).
+  - modules count: 382 → 341 (−41 modules) on cold-start path.
+
 ## [0.89.0] — 2026-05-09
 
 > **Removed — LangSmith 의존 100 % 제거.  관측성은 hook system + RunLog 로 일원화.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.0
+- **Version**: 0.89.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.89.0 — Long-running Autonomous Execution Harness
+# GEODE v0.89.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -89,7 +89,6 @@ from core.cli.welcome import _render_readiness_compact as _render_readiness_comp
 from core.cli.welcome import _render_welcome_brand as _render_welcome_brand
 from core.cli.welcome import _suppress_noisy_warnings as _suppress_noisy_warnings
 from core.cli.welcome import _welcome_screen as _welcome_screen
-from core.config import settings
 from core.hooks import HookEvent, HookSystem
 from core.hooks.utils import fire_hook
 from core.llm.commentary import generate_commentary
@@ -113,6 +112,8 @@ def _show_commentary(
     """Generate and display LLM commentary after tool call results."""
     if is_offline:
         return
+    from core.config import settings
+
     with GeodeStatus("Generating response...", model=settings.model) as status:
         text = generate_commentary(user_query=user_text, action=action, context=context)
         status.stop("response" if text else "response (skipped)")

--- a/core/cli/dispatcher.py
+++ b/core/cli/dispatcher.py
@@ -32,7 +32,6 @@ from core.cli.session_state import (
     _get_search_engine,
     _scheduler_service_ctx,
 )
-from core.config import settings
 from core.ui.console import console
 from core.wiring.startup import check_readiness
 
@@ -152,6 +151,8 @@ def _handle_command(
     elif action == "trigger":
         cmd_trigger(args)
     elif action == "status":
+        from core.config import settings
+
         console.print()
         console.print("  [header]GEODE System Status[/header]")
         console.print(f"  Model: [bold]{settings.model}[/bold]")

--- a/core/cli/onboarding.py
+++ b/core/cli/onboarding.py
@@ -19,14 +19,23 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
-from core.config import settings
 from core.ui.console import console
 from core.utils.env_io import mask_key as _mask_key
 from core.utils.env_io import upsert_env as _upsert_env
 from core.wiring.startup import ReadinessReport, _has_any_llm_key, detect_subscription_oauth
 
 log = logging.getLogger(__name__)
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy ``settings`` alias for legacy patch sites."""
+    if name == "settings":
+        from core.config import settings as _settings
+
+        return _settings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +115,8 @@ def _wizard_subscription_path() -> bool:
 
 def _wizard_api_key_path() -> bool:
     """Path B — paste API keys for any of the three providers."""
+    from core.config import settings
+
     any_set = False
     providers = [
         (
@@ -189,6 +200,8 @@ def detect_api_key(text: str) -> tuple[str, str, str] | None:
 def key_registration_gate() -> str | None:
     """Block until user provides API key or quits. Returns key or None."""
     from rich.panel import Panel
+
+    from core.config import settings
 
     console.print(
         Panel(

--- a/core/cli/pipeline_executor.py
+++ b/core/cli/pipeline_executor.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from plugins.game_ip.scoring_constants import score_style
 
-from core.config import settings
 from core.runtime import GeodeRuntime
 from core.state import AnalysisResult, EvaluatorResult, GeodeState
 from core.ui.console import console
@@ -574,6 +573,7 @@ def _run_analysis(
     ip_name = resolved
 
     # Tag pipeline events with IP name (thread-safe, for future parallel UI)
+    from core.config import settings
     from core.ui.agentic_ui import set_pipeline_ip
 
     set_pipeline_ip(ip_name)
@@ -664,6 +664,7 @@ def _build_initial_state(
     runtime: GeodeRuntime,
 ) -> GeodeState:
     """Build initial pipeline state for batch mode."""
+    from core.config import settings
     from core.memory.session_key import build_session_key
 
     session_id = build_session_key(ip_name, "pipeline")

--- a/core/cli/report_renderer.py
+++ b/core/cli/report_renderer.py
@@ -13,7 +13,6 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from core.config import settings
 from core.paths import get_project_root
 from core.skills.reports import ReportFormat, ReportGenerator, ReportTemplate
 from core.ui.console import console
@@ -223,6 +222,8 @@ def _generate_report(
     # Skill-enhanced narrative (skip in dry-run to avoid LLM call)
     enhanced_narrative = ""
     if skill_registry is not None and not dry_run:
+        from core.config import settings
+
         with GeodeStatus("Generating expert analysis...", model=settings.model) as st:
             enhanced_narrative = _build_skill_narrative(report_dict, skill_registry)
             st.stop("expert analysis" if enhanced_narrative else "expert analysis (skipped)")

--- a/core/cli/tool_handlers/system.py
+++ b/core/cli/tool_handlers/system.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from core.config import settings
 from core.ui.console import console
 
 log = logging.getLogger(__name__)
@@ -36,6 +35,7 @@ def _build_system_handlers(
     def handle_check_status(**_kwargs: Any) -> dict[str, Any]:
         from importlib.metadata import version as _pkg_version
 
+        from core.config import settings
         from core.domains.port import get_domain_or_none
 
         # Fixture count is domain-specific — sourced via DomainPort.
@@ -96,6 +96,8 @@ def _build_system_handlers(
         }
 
     def handle_switch_model(**kwargs: Any) -> dict[str, Any]:
+        from core.config import settings
+
         model_hint = kwargs.get("model_hint", "")
         # Only update settings — do NOT call loop.update_model() here.
         # The AgenticLoop checks for model drift at the start of each round
@@ -110,6 +112,8 @@ def _build_system_handlers(
         }
 
     def handle_set_api_key(**kwargs: Any) -> dict[str, Any]:
+        from core.config import settings
+
         key_value = kwargs.get("key_value", "")
         changed = cmd_key(key_value)
         if changed:

--- a/core/cli/welcome.py
+++ b/core/cli/welcome.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from core import __version__
 from core.cli.onboarding import env_setup_wizard
 from core.cli.session_state import _set_readiness
-from core.config import settings
 from core.ui.console import console
 from core.wiring.startup import (
     ReadinessReport,
@@ -23,6 +22,7 @@ from core.wiring.startup import (
 
 def _render_welcome_brand() -> None:
     """Render animated Claude Code-style branding with axolotl mascot."""
+    from core.config import settings
     from core.ui.mascot import play_mascot_animation
 
     cwd = str(Path.cwd())

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -6,6 +6,12 @@ Config Cascade (priority high → low):
   3. Project TOML: .geode/config.toml
   4. Global TOML: ~/.geode/config.toml
   5. Code defaults
+
+The :class:`Settings` class lives in :mod:`core.config._settings` so the heavy
+``pydantic_settings`` import tree only loads when an instance is actually
+requested. Module-level constants (``ANTHROPIC_PRIMARY`` etc.) and lightweight
+dataclasses (:class:`ModelPolicy`, :class:`RoutingConfig`) stay here so cold
+import paths that only need them avoid pydantic entirely.
 """
 
 from __future__ import annotations
@@ -16,12 +22,19 @@ import threading
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
-
-from pydantic import AliasChoices, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import TYPE_CHECKING, Any
 
 from core.paths import GLOBAL_CONFIG_TOML, GLOBAL_ENV_FILE, PROJECT_CONFIG_TOML
+
+if TYPE_CHECKING:
+    # Re-export ``Settings`` as a module attribute so ``from core.config
+    # import Settings`` type-checks while runtime keeps the heavy import
+    # lazy (see ``__getattr__`` below).
+    from core.config._settings import Settings as Settings
+
+    # Declare the lazily-resolved ``settings`` singleton for mypy. The actual
+    # value is produced by ``__getattr__`` on first access.
+    settings: Settings
 
 log = logging.getLogger(__name__)
 
@@ -145,208 +158,17 @@ def _apply_toml_overlay(s: Settings) -> None:
 GLOBAL_ENV_PATH = GLOBAL_ENV_FILE
 
 
-class Settings(BaseSettings):
-    model_config = SettingsConfigDict(
-        env_prefix="GEODE_",
-        env_file=(".env", str(Path.home() / ".geode" / ".env")),
-        extra="ignore",
-    )
-
-    anthropic_api_key: str = Field(
-        default="",
-        validation_alias=AliasChoices("anthropic_api_key", "ANTHROPIC_API_KEY"),
-    )
-    openai_api_key: str = Field(
-        default="",
-        validation_alias=AliasChoices("openai_api_key", "OPENAI_API_KEY"),
-    )
-    zai_api_key: str = Field(
-        default="",
-        validation_alias=AliasChoices("zai_api_key", "ZAI_API_KEY"),
-    )
-    model: str = "claude-opus-4-6"  # overridden by GEODE_MODEL env var; see ANTHROPIC_PRIMARY
-    verbose: bool = False
-    checkpoint_db: str = "geode_checkpoints.db"
-
-    # L4.5 Automation — Drift Detection
-    drift_scan_cron: str = "0 */6 * * *"  # Every 6 hours
-    drift_warning_threshold: float = 2.5
-    drift_critical_threshold: float = 4.0
-
-    # L4.5 Automation — Outcome Tracking
-    outcome_tracking_enabled: bool = True
-
-    # L4.5 Automation — Snapshot Manager
-    snapshot_dir: str = ""  # empty = auto-resolve via paths.resolve_snapshots_dir()
-    snapshot_max_recent: int = 30
-    snapshot_gc_threshold: int = 60  # auto-prune when count exceeds this
-
-    # L4.5 Automation — Trigger Manager
-    trigger_scheduler_interval_s: float = 60.0
-
-    # L4.5 Automation — Advanced Scheduler
-    scheduler_interval_s: float = 1.0  # 1s check interval (claude-code pattern)
-    scheduler_auto_start: bool = True
-    scheduler_jitter_enabled: bool = True  # Deterministic per-job jitter
-    scheduler_max_jitter_ms: float = 900_000.0  # 15 min cap
-
-    # L2 Memory — Session
-    session_ttl_hours: float = 4.0
-    session_storage_dir: str = ""  # file-backed persistence dir (empty = in-memory only)
-
-    # L2 Memory — Redis/PostgreSQL (simulation URLs)
-    redis_url: str = ""
-    postgres_url: str = ""
-
-    # L2 Memory — Organization
-    organization_fixture_dir: str = ""
-
-    # Tier 0.5 — User Profile
-    user_profile_dir: str = ""  # global dir override (default: ~/.geode/user_profile)
-
-    # L4.5 Automation — Model Registry
-    model_registry_dir: str = ""  # empty = auto-resolve via paths.resolve_models_dir()
-
-    # MCP Server URLs
-    steam_mcp_url: str = ""
-    brave_mcp_url: str = ""
-    brave_api_key: str = ""
-    kg_memory_mcp_url: str = ""
-
-    # Ensemble — Multi-LLM mode
-    ensemble_mode: str = "single"  # single | cross
-    secondary_analysts: str = "player_experience,discovery"
-    primary_analysts: str = "game_mechanics,growth_potential"
-
-    # Graph — Feedback Loop
-    confidence_threshold: float = 0.7
-    max_iterations: int = 5
-    interrupt_nodes: str = ""  # comma-separated node names, e.g. "verification,scoring"
-
-    # LLM — Router & Verification
-    router_model: str = "claude-opus-4-6"  # see ANTHROPIC_PRIMARY
-    default_secondary_model: str = "gpt-5.4"  # see OPENAI_PRIMARY
-    agreement_threshold: float = 0.67
-
-    # Sub-Agent Orchestration (P2)
-    max_subagent_depth: int = 1  # 최대 재귀 깊이 (depth=1 강제, Claude Code 패턴)
-    max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
-    subagent_max_rounds: int = 0  # 0 = unlimited (time-based control)
-    subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
-
-    # Token Guard — tool result truncation threshold (0 = unlimited)
-    max_tool_result_tokens: int = 25000  # 0 = no limit; clear_tool_uses handles overflow
-
-    # Tool Result Offloading — store large results to filesystem (P0 token optimization)
-    tool_offload_threshold: int = 15000  # tokens; 0 = disabled
-    tool_offload_ttl_hours: float = 4.0  # TTL for offloaded results
-    observation_mask_keep_rounds: int = 3  # keep recent N rounds unmasked
-
-    # Agentic Loop — time budget (Karpathy P3, OpenClaw Attempt Loop)
-    agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
-
-    # Agentic Loop — thinking budget (DTR: Extended Thinking / reasoning tokens)
-    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call (legacy)
-
-    # Agentic Loop — effort level (replaces thinking_budget for Opus 4.6+ / Sonnet 4.6+)
-    # Maps to Anthropic output_config.effort + OpenAI reasoning.effort.
-    # v0.56.0 R4-mini — ``xhigh`` added; Opus 4.7-only (the adapter
-    # downgrades to ``"max"`` on Opus 4.6 / Sonnet 4.6).
-    agentic_effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh"
-
-    # Cost guard — session-level cost limit (0 = no limit)
-    cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%
-
-    # Computer Use — desktop automation (requires pyautogui)
-    computer_use_enabled: bool = True  # default on; pyautogui import guard handles missing dep
-
-    # Context Compaction — overflow prevention
-    compact_keep_recent: int = 10  # messages to preserve during compaction/prune
-
-    # Notification — external messaging
-    notification_channel: str = "slack"  # default notification channel
-    notification_recipient: str = "#geode-alerts"  # default recipient
-    notification_on_pipeline_end: bool = True
-    notification_on_pipeline_error: bool = True
-    notification_on_drift: bool = True
-
-    # Gateway — inbound messaging
-    gateway_enabled: bool = False  # GEODE_GATEWAY_ENABLED=true to enable
-    gateway_poll_interval_s: float = 3.0
-
-    # L4 Gateway Hooks — external webhook endpoint
-    webhook_enabled: bool = False  # GEODE_WEBHOOK_ENABLED=true to enable
-    webhook_port: int = 8765
-
-    # Calendar — external calendar sync
-    calendar_sync_on_trigger: bool = False  # auto-sync on TRIGGER_FIRED
-
-    # Sandbox — file tool path validation (Claude Code parity)
-    sandbox_max_file_size_bytes: int = 262_144  # 256KB pre-read guard
-    sandbox_max_read_tokens: int = 25_000  # post-read token estimate guard
-    sandbox_max_glob_results: int = 100  # GlobTool max results
-    sandbox_max_grep_results: int = 50  # GrepTool max files
-    sandbox_max_grep_line_chars: int = 200  # GrepTool match line truncation
-
-    # HITL Level — Human-in-the-loop control
-    # 0 = autonomous (skip all prompts), 1 = write-only (prompt only for writes),
-    # 2 = all prompts (default, ask everything)
-    hitl_level: int = 2
-
-    # Plan Mode — Autonomous Execution
-    plan_auto_execute: bool = False  # GEODE_PLAN_AUTO_EXECUTE=true to enable
-
-    # LLM Connection — httpx pool & timeout tuning
-    llm_max_connections: int = 20  # httpx pool: max total connections
-    llm_max_keepalive_connections: int = 5  # httpx pool: max idle keep-alive connections
-    llm_keepalive_expiry: float = 30.0  # idle conn TTL (match API server timeout)
-    llm_connect_timeout: float = 5.0  # TCP connect timeout (fail fast)
-    llm_read_timeout: float = 300.0  # response read timeout (5min for 1M context)
-    llm_write_timeout: float = 30.0  # request write timeout (seconds)
-    llm_pool_timeout: float = 10.0  # wait for available connection from pool (seconds)
-    llm_retry_base_delay: float = 2.0  # base delay for exponential backoff (seconds)
-    llm_retry_max_delay: float = 30.0  # max delay cap for retries (seconds)
-    llm_max_retries: int = 3  # max retry attempts per model
-
-    # LLM — Cross-Provider Failover (opt-in).
-    # When True, the router walks ``llm_cross_provider_order`` after all
-    # retries+fallbacks within the active provider exhaust. v0.52.2 keeps
-    # this opt-in (it auto-switches *silently*, which is a behaviour
-    # change with broader surface than the resilience patch should own).
-    # The B5 cross-provider breadcrumb (``credential_breadcrumb.format``)
-    # already surfaces alternative providers to the LLM so the model can
-    # ask the user to run ``/model <slug>`` — a transparent path.
-    llm_cross_provider_failover: bool = False
-    llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
-
-    # v0.52.4 — per-provider auth-mode escape hatch (Codex CLI parity).
-    # Default routing prefers SUBSCRIPTION/OAUTH plans over PAYG when both
-    # can serve the requested model (matches openai/codex CLI default).
-    # Override per provider when the user deliberately wants metered PAYG:
-    #   forced_login_method = {"openai": "apikey"}    # use OPENAI_API_KEY even
-    #                                                  # if Codex Plus OAuth is registered
-    # Valid values: "subscription" (default), "apikey", "auto" (alias).
-    # Reference: openai/codex#2733, #3286.
-    forced_login_method: dict[str, str] = {}
-
-    # LLM — Fallback cost ratio control (C2: 0 = unlimited)
-    llm_max_fallback_cost_ratio: float = 0.0
-
-    # Pipeline — timeout in seconds (B3: 0 = no timeout)
-    pipeline_timeout_s: float = 600.0
-
-    # Concurrency — workload lane limits
-    gateway_max_concurrent: int = 4  # max simultaneous Gateway messages
-
-
 _settings_instance: Settings | None = None
 
 
 def _get_settings() -> Settings:
     """Get or create the Settings singleton in a thread-safe manner.
 
-    After Pydantic loads from env/.env, overlays TOML config values
-    for fields not explicitly set via environment variables.
+    The :class:`Settings` class is imported lazily so that callers requesting
+    only constants from :mod:`core.config` (e.g. ``ANTHROPIC_PRIMARY``) avoid
+    pulling pydantic_settings into the cold-start tree. After Pydantic loads
+    from env/.env, overlays TOML config values for fields not explicitly set
+    via environment variables.
     """
     global _settings_instance
     if _settings_instance is not None:
@@ -354,13 +176,31 @@ def _get_settings() -> Settings:
     with _settings_lock:
         # Double-checked locking
         if _settings_instance is None:
-            s = Settings()
+            from core.config._settings import Settings as _Settings
+
+            s = _Settings()
             _apply_toml_overlay(s)
             _settings_instance = s
         return _settings_instance
 
 
-settings = _get_settings()
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy attribute access for ``settings`` and ``Settings``.
+
+    Attribute access here defers the heavy ``pydantic_settings`` import until
+    the caller actually uses it. Modules that only need constants such as
+    ``ANTHROPIC_PRIMARY`` or ``CODEX_BASE_URL`` therefore avoid the pydantic
+    tree entirely. Anything else falls through to the standard
+    ``AttributeError`` so typos surface immediately.
+    """
+    if name == "settings":
+        return _get_settings()
+    if name == "Settings":
+        from core.config._settings import Settings as _Settings
+
+        return _Settings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # ---------------------------------------------------------------------------
 # Model constants — single source of truth for model names & pricing

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -1,0 +1,208 @@
+"""Pydantic Settings class — isolated module so the heavy pydantic_settings
+import tree only loads when a Settings instance is actually requested.
+
+This module is loaded lazily via ``core.config.__getattr__``. Direct callers
+should import ``settings`` (not the class) from ``core.config``; the class is
+exposed only for type hints and test fixtures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="GEODE_",
+        env_file=(".env", str(Path.home() / ".geode" / ".env")),
+        extra="ignore",
+    )
+
+    anthropic_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("anthropic_api_key", "ANTHROPIC_API_KEY"),
+    )
+    openai_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("openai_api_key", "OPENAI_API_KEY"),
+    )
+    zai_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("zai_api_key", "ZAI_API_KEY"),
+    )
+    model: str = "claude-opus-4-6"  # overridden by GEODE_MODEL env var; see ANTHROPIC_PRIMARY
+    verbose: bool = False
+    checkpoint_db: str = "geode_checkpoints.db"
+
+    # L4.5 Automation — Drift Detection
+    drift_scan_cron: str = "0 */6 * * *"  # Every 6 hours
+    drift_warning_threshold: float = 2.5
+    drift_critical_threshold: float = 4.0
+
+    # L4.5 Automation — Outcome Tracking
+    outcome_tracking_enabled: bool = True
+
+    # L4.5 Automation — Snapshot Manager
+    snapshot_dir: str = ""  # empty = auto-resolve via paths.resolve_snapshots_dir()
+    snapshot_max_recent: int = 30
+    snapshot_gc_threshold: int = 60  # auto-prune when count exceeds this
+
+    # L4.5 Automation — Trigger Manager
+    trigger_scheduler_interval_s: float = 60.0
+
+    # L4.5 Automation — Advanced Scheduler
+    scheduler_interval_s: float = 1.0  # 1s check interval (claude-code pattern)
+    scheduler_auto_start: bool = True
+    scheduler_jitter_enabled: bool = True  # Deterministic per-job jitter
+    scheduler_max_jitter_ms: float = 900_000.0  # 15 min cap
+
+    # L2 Memory — Session
+    session_ttl_hours: float = 4.0
+    session_storage_dir: str = ""  # file-backed persistence dir (empty = in-memory only)
+
+    # L2 Memory — Redis/PostgreSQL (simulation URLs)
+    redis_url: str = ""
+    postgres_url: str = ""
+
+    # L2 Memory — Organization
+    organization_fixture_dir: str = ""
+
+    # Tier 0.5 — User Profile
+    user_profile_dir: str = ""  # global dir override (default: ~/.geode/user_profile)
+
+    # L4.5 Automation — Model Registry
+    model_registry_dir: str = ""  # empty = auto-resolve via paths.resolve_models_dir()
+
+    # MCP Server URLs
+    steam_mcp_url: str = ""
+    brave_mcp_url: str = ""
+    brave_api_key: str = ""
+    kg_memory_mcp_url: str = ""
+
+    # Ensemble — Multi-LLM mode
+    ensemble_mode: str = "single"  # single | cross
+    secondary_analysts: str = "player_experience,discovery"
+    primary_analysts: str = "game_mechanics,growth_potential"
+
+    # Graph — Feedback Loop
+    confidence_threshold: float = 0.7
+    max_iterations: int = 5
+    interrupt_nodes: str = ""  # comma-separated node names, e.g. "verification,scoring"
+
+    # LLM — Router & Verification
+    router_model: str = "claude-opus-4-6"  # see ANTHROPIC_PRIMARY
+    default_secondary_model: str = "gpt-5.4"  # see OPENAI_PRIMARY
+    agreement_threshold: float = 0.67
+
+    # Sub-Agent Orchestration (P2)
+    max_subagent_depth: int = 1  # 최대 재귀 깊이 (depth=1 강제, Claude Code 패턴)
+    max_total_subagents: int = 15  # 세션 내 최대 서브에이전트 수
+    subagent_max_rounds: int = 0  # 0 = unlimited (time-based control)
+    subagent_max_tokens: int = 32768  # 서브에이전트 출력 토큰 제한 (부모와 동일)
+
+    # Token Guard — tool result truncation threshold (0 = unlimited)
+    max_tool_result_tokens: int = 25000  # 0 = no limit; clear_tool_uses handles overflow
+
+    # Tool Result Offloading — store large results to filesystem (P0 token optimization)
+    tool_offload_threshold: int = 15000  # tokens; 0 = disabled
+    tool_offload_ttl_hours: float = 4.0  # TTL for offloaded results
+    observation_mask_keep_rounds: int = 3  # keep recent N rounds unmasked
+
+    # Agentic Loop — time budget (Karpathy P3, OpenClaw Attempt Loop)
+    agentic_loop_time_budget: float = 0.0  # 0 = no time limit; >0 = wall-clock seconds
+
+    # Agentic Loop — thinking budget (DTR: Extended Thinking / reasoning tokens)
+    agentic_thinking_budget: int = 0  # 0 = disabled; >0 = thinking token budget per call (legacy)
+
+    # Agentic Loop — effort level (replaces thinking_budget for Opus 4.6+ / Sonnet 4.6+)
+    # Maps to Anthropic output_config.effort + OpenAI reasoning.effort.
+    # v0.56.0 R4-mini — ``xhigh`` added; Opus 4.7-only (the adapter
+    # downgrades to ``"max"`` on Opus 4.6 / Sonnet 4.6).
+    agentic_effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh"
+
+    # Cost guard — session-level cost limit (0 = no limit)
+    cost_limit_usd: float = 0.0  # fires COST_WARNING at 80%, COST_LIMIT_EXCEEDED at 100%
+
+    # Computer Use — desktop automation (requires pyautogui)
+    computer_use_enabled: bool = True  # default on; pyautogui import guard handles missing dep
+
+    # Context Compaction — overflow prevention
+    compact_keep_recent: int = 10  # messages to preserve during compaction/prune
+
+    # Notification — external messaging
+    notification_channel: str = "slack"  # default notification channel
+    notification_recipient: str = "#geode-alerts"  # default recipient
+    notification_on_pipeline_end: bool = True
+    notification_on_pipeline_error: bool = True
+    notification_on_drift: bool = True
+
+    # Gateway — inbound messaging
+    gateway_enabled: bool = False  # GEODE_GATEWAY_ENABLED=true to enable
+    gateway_poll_interval_s: float = 3.0
+
+    # L4 Gateway Hooks — external webhook endpoint
+    webhook_enabled: bool = False  # GEODE_WEBHOOK_ENABLED=true to enable
+    webhook_port: int = 8765
+
+    # Calendar — external calendar sync
+    calendar_sync_on_trigger: bool = False  # auto-sync on TRIGGER_FIRED
+
+    # Sandbox — file tool path validation (Claude Code parity)
+    sandbox_max_file_size_bytes: int = 262_144  # 256KB pre-read guard
+    sandbox_max_read_tokens: int = 25_000  # post-read token estimate guard
+    sandbox_max_glob_results: int = 100  # GlobTool max results
+    sandbox_max_grep_results: int = 50  # GrepTool max files
+    sandbox_max_grep_line_chars: int = 200  # GrepTool match line truncation
+
+    # HITL Level — Human-in-the-loop control
+    # 0 = autonomous (skip all prompts), 1 = write-only (prompt only for writes),
+    # 2 = all prompts (default, ask everything)
+    hitl_level: int = 2
+
+    # Plan Mode — Autonomous Execution
+    plan_auto_execute: bool = False  # GEODE_PLAN_AUTO_EXECUTE=true to enable
+
+    # LLM Connection — httpx pool & timeout tuning
+    llm_max_connections: int = 20  # httpx pool: max total connections
+    llm_max_keepalive_connections: int = 5  # httpx pool: max idle keep-alive connections
+    llm_keepalive_expiry: float = 30.0  # idle conn TTL (match API server timeout)
+    llm_connect_timeout: float = 5.0  # TCP connect timeout (fail fast)
+    llm_read_timeout: float = 300.0  # response read timeout (5min for 1M context)
+    llm_write_timeout: float = 30.0  # request write timeout (seconds)
+    llm_pool_timeout: float = 10.0  # wait for available connection from pool (seconds)
+    llm_retry_base_delay: float = 2.0  # base delay for exponential backoff (seconds)
+    llm_retry_max_delay: float = 30.0  # max delay cap for retries (seconds)
+    llm_max_retries: int = 3  # max retry attempts per model
+
+    # LLM — Cross-Provider Failover (opt-in).
+    # When True, the router walks ``llm_cross_provider_order`` after all
+    # retries+fallbacks within the active provider exhaust. v0.52.2 keeps
+    # this opt-in (it auto-switches *silently*, which is a behaviour
+    # change with broader surface than the resilience patch should own).
+    # The B5 cross-provider breadcrumb (``credential_breadcrumb.format``)
+    # already surfaces alternative providers to the LLM so the model can
+    # ask the user to run ``/model <slug>`` — a transparent path.
+    llm_cross_provider_failover: bool = False
+    llm_cross_provider_order: list[str] = ["anthropic", "openai", "glm"]
+
+    # v0.52.4 — per-provider auth-mode escape hatch (Codex CLI parity).
+    # Default routing prefers SUBSCRIPTION/OAUTH plans over PAYG when both
+    # can serve the requested model (matches openai/codex CLI default).
+    # Override per provider when the user deliberately wants metered PAYG:
+    #   forced_login_method = {"openai": "apikey"}    # use OPENAI_API_KEY even
+    #                                                  # if Codex Plus OAuth is registered
+    # Valid values: "subscription" (default), "apikey", "auto" (alias).
+    # Reference: openai/codex#2733, #3286.
+    forced_login_method: dict[str, str] = {}
+
+    # LLM — Fallback cost ratio control (C2: 0 = unlimited)
+    llm_max_fallback_cost_ratio: float = 0.0
+
+    # Pipeline — timeout in seconds (B3: 0 = no timeout)
+    pipeline_timeout_s: float = 600.0
+
+    # Concurrency — workload lane limits
+    gateway_max_concurrent: int = 4  # max simultaneous Gateway messages

--- a/core/graph.py
+++ b/core/graph.py
@@ -51,7 +51,6 @@ from plugins.game_ip.nodes.scoring import scoring_node
 from plugins.game_ip.nodes.signals import signals_node
 from plugins.game_ip.nodes.synthesizer import synthesizer_node
 
-from core.config import settings
 from core.hooks import HookEvent, HookSystem
 from core.orchestration.bootstrap import BootstrapManager
 from core.state import (
@@ -374,6 +373,8 @@ def _verification_node(state: GeodeState) -> dict[str, Any]:
             ),
             "biasbuster": BiasBusterResult(explanation="Skipped"),
         }
+    from core.config import settings
+
     guardrails = run_guardrails(state, signal_data=state.get("signals"))
     biasbuster = run_biasbuster(state)
     cross_llm = run_cross_llm_check(state, agreement_threshold=settings.agreement_threshold)
@@ -765,6 +766,8 @@ def invoke_with_timeout(
     import contextvars
 
     if timeout_s == 0.0:
+        from core.config import settings
+
         timeout_s = settings.pipeline_timeout_s
     if timeout_s <= 0:
         return graph.invoke(state, config=config)

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -14,7 +14,6 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel
 
-from core.config import settings
 from core.llm.agentic_response import AgenticResponse
 
 log = logging.getLogger(__name__)
@@ -261,6 +260,8 @@ class ClaudeAdapter:
     @property
     def model_name(self) -> str:
         """Return the default model name for cross-LLM verification."""
+        from core.config import settings
+
         return settings.model
 
     def generate(

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -9,16 +9,31 @@ import logging
 import random
 import threading
 import time
-from typing import Any
-
-from core.config import settings
+from typing import TYPE_CHECKING, Any
 
 log = logging.getLogger(__name__)
 
-# Failover configuration — sourced from settings with backward-compat defaults
-MAX_RETRIES = settings.llm_max_retries
-RETRY_BASE_DELAY = settings.llm_retry_base_delay
-RETRY_MAX_DELAY = settings.llm_retry_max_delay
+if TYPE_CHECKING:
+    # Module-level retry constants are exposed as ``MAX_RETRIES`` etc. for
+    # backward compatibility (5+ external import sites). The values are
+    # actually resolved lazily via ``__getattr__`` so module load no longer
+    # forces a Settings instance — and therefore the heavy pydantic_settings
+    # tree — into the cold-start path.
+    MAX_RETRIES: int
+    RETRY_BASE_DELAY: float
+    RETRY_MAX_DELAY: float
+
+
+def __getattr__(name: str) -> Any:
+    if name in ("MAX_RETRIES", "RETRY_BASE_DELAY", "RETRY_MAX_DELAY"):
+        from core.config import settings
+
+        if name == "MAX_RETRIES":
+            return settings.llm_max_retries
+        if name == "RETRY_BASE_DELAY":
+            return settings.llm_retry_base_delay
+        return settings.llm_retry_max_delay
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _is_auth_error(exc: Exception) -> bool:
@@ -181,9 +196,9 @@ def retry_with_backoff_generic(
     retryable_errors: tuple[type[Exception], ...],
     bad_request_error: type[Exception] | None = None,
     billing_message: str = "API billing/credit error.",
-    max_retries: int = MAX_RETRIES,
-    retry_base_delay: float = RETRY_BASE_DELAY,
-    retry_max_delay: float = RETRY_MAX_DELAY,
+    max_retries: int | None = None,
+    retry_base_delay: float | None = None,
+    retry_max_delay: float | None = None,
     provider_label: str = "LLM",
     on_retry: Any | None = None,
 ) -> Any:
@@ -219,9 +234,18 @@ def retry_with_backoff_generic(
 
     models_to_try = [model] + [m for m in fallback_models if m != model]
 
-    # C2: filter out fallback models that exceed cost ratio limit
+    # Resolve None defaults from settings (function defaults stay lazy so the
+    # cold-start path doesn't pull pydantic_settings).
     from core.config import settings as _cfg
 
+    if max_retries is None:
+        max_retries = _cfg.llm_max_retries
+    if retry_base_delay is None:
+        retry_base_delay = _cfg.llm_retry_base_delay
+    if retry_max_delay is None:
+        retry_max_delay = _cfg.llm_retry_max_delay
+
+    # C2: filter out fallback models that exceed cost ratio limit
     if _cfg.llm_max_fallback_cost_ratio > 0 and len(models_to_try) > 1:
         from core.llm.token_tracker import MODEL_PRICING
 

--- a/core/llm/provider_dispatch.py
+++ b/core/llm/provider_dispatch.py
@@ -30,6 +30,7 @@ def __getattr__(name: str) -> Any:
         return _settings
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 # v0.88.0 — anthropic SDK is module-level lazy.  ``import anthropic`` and
 # the cross-module ``RETRYABLE_ERRORS`` / ``get_anthropic_client`` pulls
 # happen lazily inside the dispatch table lambdas / helper functions

--- a/core/llm/provider_dispatch.py
+++ b/core/llm/provider_dispatch.py
@@ -17,10 +17,18 @@ from core.config import (
     GLM_FALLBACK_CHAIN,
     OPENAI_FALLBACK_CHAIN,
     is_model_allowed,
-    settings,
 )
 from core.hooks.utils import fire_hook
 from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy ``settings`` alias for legacy patch sites."""
+    if name == "settings":
+        from core.config import settings as _settings
+
+        return _settings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # v0.88.0 — anthropic SDK is module-level lazy.  ``import anthropic`` and
 # the cross-module ``RETRYABLE_ERRORS`` / ``get_anthropic_client`` pulls
@@ -223,6 +231,8 @@ def _cross_provider_dispatch(  # noqa: UP047 — PEP695 syntax requires Python 3
     provider chain is exhausted, iterates through ``llm_cross_provider_order``
     trying each remaining provider's primary model.
     """
+    from core.config import settings
+
     providers: list[tuple[str, str]] = [(primary_provider, primary_model)]
     if settings.llm_cross_provider_failover:
         for p in settings.llm_cross_provider_order:

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -10,7 +10,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any
 
-from core.config import ANTHROPIC_FALLBACK_CHAIN, is_model_allowed, settings
+from core.config import ANTHROPIC_FALLBACK_CHAIN, is_model_allowed
 from core.llm.fallback import (
     CircuitBreaker,
     retry_with_backoff_generic,
@@ -57,6 +57,13 @@ def __getattr__(name: str) -> Any:
 
         globals()[name] = TextBlockParam
         return TextBlockParam
+    if name == "settings":
+        # Preserve legacy patch surface (tests monkeypatch
+        # ``core.llm.providers.anthropic.settings``) without paying the
+        # pydantic_settings cost at module import.
+        from core.config import settings as _settings
+
+        return _settings
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -72,6 +79,8 @@ def _build_httpx_timeout() -> httpx.Timeout:
     """Build httpx Timeout from settings."""
     import httpx
 
+    from core.config import settings
+
     return httpx.Timeout(
         connect=settings.llm_connect_timeout,
         read=settings.llm_read_timeout,
@@ -83,6 +92,8 @@ def _build_httpx_timeout() -> httpx.Timeout:
 def _build_httpx_limits() -> httpx.Limits:
     """Build httpx connection pool Limits from settings."""
     import httpx
+
+    from core.config import settings
 
     return httpx.Limits(
         max_connections=settings.llm_max_connections,
@@ -115,6 +126,7 @@ FALLBACK_MODELS = ANTHROPIC_FALLBACK_CHAIN
 
 def _resolve_anthropic_key() -> str:
     """Resolve Anthropic API key from ProfileRotator (OAuth preferred) or settings."""
+    from core.config import settings
     from core.llm.credentials import resolve_provider_key
 
     return resolve_provider_key("anthropic", settings.anthropic_api_key)
@@ -389,6 +401,8 @@ _COMPUTER_USE_TOOL: dict[str, Any] = {
 
 def is_computer_use_enabled() -> bool:
     """Check if computer-use is enabled (requires pyautogui + opt-in)."""
+    from core.config import settings
+
     if not getattr(settings, "computer_use_enabled", False):
         return False
     try:
@@ -435,6 +449,7 @@ class ClaudeAgenticAdapter:
         thinking_budget: int = 0,
         effort: str = "high",
     ) -> Any | None:
+        from core.config import settings
         from core.llm.agentic_response import normalize_anthropic
         from core.llm.errors import LLMBadRequestError, UserCancelledError
         from core.llm.router import call_with_failover

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -12,7 +12,7 @@ import logging
 import threading
 from typing import Any
 
-from core.config import GLM_BASE_URL, GLM_FALLBACK_CHAIN, GLM_PRIMARY, settings
+from core.config import GLM_BASE_URL, GLM_FALLBACK_CHAIN, GLM_PRIMARY
 from core.llm.fallback import CircuitBreaker
 
 log = logging.getLogger(__name__)
@@ -38,6 +38,8 @@ def _resolve_glm_endpoint() -> tuple[str, str]:
     calls the coding endpoint). Falls back to settings.zai_api_key +
     GLM_BASE_URL for legacy .env-only setups.
     """
+    from core.config import settings
+
     try:
         from core.auth.plan_registry import resolve_routing
 

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -15,7 +15,7 @@ from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel
 
-from core.config import OPENAI_FALLBACK_CHAIN, OPENAI_PRIMARY, settings
+from core.config import OPENAI_FALLBACK_CHAIN, OPENAI_PRIMARY
 from core.llm.fallback import (
     CircuitBreaker,
     retry_with_backoff_generic,
@@ -47,6 +47,7 @@ _openai_circuit_breaker = CircuitBreaker()
 
 def _resolve_openai_key() -> str:
     """Resolve OpenAI API key from ProfileRotator (OAuth preferred) or settings."""
+    from core.config import settings
     from core.llm.credentials import resolve_provider_key
 
     return resolve_provider_key("openai", settings.openai_api_key)
@@ -437,6 +438,8 @@ class OpenAIAgenticAdapter:
 
     def _resolve_config(self, model: str) -> tuple[str, str | None]:
         """Return (api_key, base_url) for this provider. Override in subclasses."""
+        from core.config import settings
+
         return settings.openai_api_key, None
 
     def _ensure_client(self, model: str) -> Any:

--- a/core/llm/router/__init__.py
+++ b/core/llm/router/__init__.py
@@ -70,9 +70,6 @@ from core.llm.adapters import resolve_agentic_adapter as resolve_agentic_adapter
 # preserved via the module-level ``__getattr__`` hook below: any future
 # ``from core.llm.router import LLMRateLimitError`` still resolves on
 # demand, deferring the SDK load until first access.
-from core.llm.fallback import MAX_RETRIES as MAX_RETRIES
-from core.llm.fallback import RETRY_BASE_DELAY as RETRY_BASE_DELAY
-from core.llm.fallback import RETRY_MAX_DELAY as RETRY_MAX_DELAY
 from core.llm.fallback import CircuitBreaker as CircuitBreaker
 from core.llm.fallback import retry_with_backoff_generic as retry_with_backoff_generic
 from core.llm.provider_dispatch import _cross_provider_dispatch as _cross_provider_dispatch
@@ -197,14 +194,26 @@ _LAZY_ERROR_NAMES = frozenset(
         "LLMTimeoutError",
     }
 )
+# Backward-compat retry constants — preserved here so existing tests and
+# legacy callers (``from core.llm.router import MAX_RETRIES``) keep working
+# while module load avoids the pydantic_settings tree.  Each access pays a
+# single attribute lookup against ``core.llm.fallback``, which itself
+# resolves the value lazily from ``core.config.settings``.
+_LAZY_FALLBACK_CONSTANTS = frozenset(
+    {"MAX_RETRIES", "RETRY_BASE_DELAY", "RETRY_MAX_DELAY"}
+)
 
 
 def __getattr__(name: str) -> Any:
-    """PEP 562 hook — resolve lazy LLM*Error re-exports on first access."""
+    """PEP 562 hook — resolve lazy LLM*Error re-exports + fallback constants."""
     if name in _LAZY_ERROR_NAMES:
         from core.llm import errors
 
         cls = getattr(errors, name)
         globals()[name] = cls
         return cls
+    if name in _LAZY_FALLBACK_CONSTANTS:
+        from core.llm import fallback
+
+        return getattr(fallback, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/core/llm/router/__init__.py
+++ b/core/llm/router/__init__.py
@@ -199,9 +199,7 @@ _LAZY_ERROR_NAMES = frozenset(
 # while module load avoids the pydantic_settings tree.  Each access pays a
 # single attribute lookup against ``core.llm.fallback``, which itself
 # resolves the value lazily from ``core.config.settings``.
-_LAZY_FALLBACK_CONSTANTS = frozenset(
-    {"MAX_RETRIES", "RETRY_BASE_DELAY", "RETRY_MAX_DELAY"}
-)
+_LAZY_FALLBACK_CONSTANTS = frozenset({"MAX_RETRIES", "RETRY_BASE_DELAY", "RETRY_MAX_DELAY"})
 
 
 def __getattr__(name: str) -> Any:

--- a/core/llm/router/calls/_failover.py
+++ b/core/llm/router/calls/_failover.py
@@ -13,7 +13,6 @@ import time
 from typing import Any
 
 from core.config import is_model_allowed
-from core.llm.fallback import MAX_RETRIES, RETRY_BASE_DELAY, RETRY_MAX_DELAY
 from core.llm.router._hooks import _fire_hook
 
 # v0.88.0 — RETRYABLE_ERRORS / NON_RETRYABLE_ERRORS are lazy-resolved
@@ -59,6 +58,7 @@ async def call_with_failover(
     # v0.88.0 — defer anthropic SDK load until first failover.  Module-level
     # tuple imports used to pull 248 ms anthropic graph at startup via
     # ``providers.anthropic.__getattr__``.
+    from core.llm.fallback import MAX_RETRIES, RETRY_BASE_DELAY, RETRY_MAX_DELAY
     from core.llm.providers.anthropic import (
         NON_RETRYABLE_ERRORS as _NON_RETRYABLE_ERRORS,
     )

--- a/core/llm/router/calls/parsed.py
+++ b/core/llm/router/calls/parsed.py
@@ -8,7 +8,6 @@ from typing import TypeVar, cast
 
 from pydantic import BaseModel
 
-from core.config import settings
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
     _get_provider_client,
@@ -44,6 +43,8 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
 
     Supports cross-provider fallback when enabled.
     """
+    from core.config import settings
+
     target_model = model or settings.model
     provider = _route_provider(target_model)
 

--- a/core/llm/router/calls/streaming.py
+++ b/core/llm/router/calls/streaming.py
@@ -6,8 +6,6 @@ import logging
 import time
 from collections.abc import Iterator
 
-from core.config import settings
-from core.llm.fallback import MAX_RETRIES, RETRY_BASE_DELAY, RETRY_MAX_DELAY
 from core.llm.providers.anthropic import (
     FALLBACK_MODELS,
     get_anthropic_client,
@@ -36,6 +34,8 @@ def call_llm_streaming(
     temperature: float = 0.3,
 ) -> Iterator[str]:
     """Streaming Claude call with failover. Yields text deltas."""
+    from core.config import settings
+    from core.llm.fallback import MAX_RETRIES, RETRY_BASE_DELAY, RETRY_MAX_DELAY
     from core.llm.providers.anthropic import (
         RETRYABLE_ERRORS as _RETRYABLE_ERRORS,
     )

--- a/core/llm/router/calls/text.py
+++ b/core/llm/router/calls/text.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import time
 
-from core.config import settings
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
     _get_provider_client,
@@ -40,6 +39,8 @@ def call_llm(
     Routes to Anthropic, OpenAI, or GLM SDK based on the model name.
     Returns text content. Supports cross-provider fallback when enabled.
     """
+    from core.config import settings
+
     target_model = model or settings.model
     provider = _route_provider(target_model)
 

--- a/core/llm/router/calls/tools.py
+++ b/core/llm/router/calls/tools.py
@@ -7,7 +7,6 @@ import logging
 import time
 from typing import Any
 
-from core.config import settings
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
     _get_provider_client,
@@ -44,6 +43,8 @@ def call_llm_with_tools(
 
     Supports cross-provider fallback when enabled.
     """
+    from core.config import settings
+
     target_model = model or settings.model
     provider = _route_provider(target_model)
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -52,7 +52,6 @@ from core.automation.feedback_loop import FeedbackLoop
 from core.automation.model_registry import ModelRegistry
 from core.automation.outcome_tracking import OutcomeTracker
 from core.automation.snapshot import SnapshotManager
-from core.config import settings
 from core.domains.loader import load_domain_adapter
 from core.domains.port import set_domain
 from core.hooks import HookSystem
@@ -442,6 +441,8 @@ class GeodeRuntime:
         Returns None for empty strings so the MemorySaver fallback
         in compile_graph kicks in.
         """
+        from core.config import settings
+
         db = settings.checkpoint_db
         return db if db and db.strip() else None
 
@@ -461,6 +462,7 @@ class GeodeRuntime:
         if self._compiled_graph is not None:
             return self._compiled_graph
 
+        from core.config import settings
         from core.graph import compile_graph
 
         # Subagents use MemorySaver for thread safety (G7 fix)

--- a/core/wiring/automation.py
+++ b/core/wiring/automation.py
@@ -16,7 +16,6 @@ from core.automation.feedback_loop import FeedbackLoop
 from core.automation.model_registry import ModelRegistry
 from core.automation.outcome_tracking import OutcomeTracker
 from core.automation.snapshot import SnapshotManager
-from core.config import settings
 from core.hooks import HookEvent, HookSystem
 from core.memory.project import ProjectMemory
 from core.scheduler.triggers import TriggerManager, TriggerType
@@ -35,6 +34,8 @@ def build_automation(
 
     Returns a dict of component name -> instance for passing to the constructor.
     """
+    from core.config import settings
+
     # Drift detector (CUSUM)
     drift_detector = CUSUMDetector()
 

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from core.llm.prompt_assembler import PromptAssembler
 
-from core.config import settings
 from core.hooks import HookEvent, HookSystem
 from core.memory.context import ContextAssembler
 from core.memory.organization import MonoLakeOrganizationMemory
@@ -161,6 +160,7 @@ def build_hooks(
 
     # Notification hook plugin (events -> external messaging)
     def _reg_notification() -> None:
+        from core.config import settings
         from core.hooks.plugins.notification_hook.hook import (
             register_notification_hooks,
         )
@@ -483,6 +483,7 @@ def build_memory(
     hooks: Any = None,
 ) -> tuple[ProjectMemory, MonoLakeOrganizationMemory, ContextAssembler, FileBasedUserProfile]:
     """Build L2 memory components: project, org, context assembler, user profile."""
+    from core.config import settings
     from core.paths import ensure_directories
 
     ensure_directories()
@@ -555,6 +556,8 @@ def build_memory(
 
 def build_session_store(*, session_ttl: float) -> SessionStorePort:
     """Build session store — InMemory default, HybridSessionStore if URLs configured."""
+    from core.config import settings
+
     session_storage_dir: Path | None = None
     if settings.session_storage_dir:
         session_storage_dir = Path(settings.session_storage_dir)
@@ -585,7 +588,7 @@ def build_config_watcher(*, hooks: HookSystem | None = None) -> ConfigWatcher:
 
     def _on_config_change(path: Path, mtime: float) -> None:
         log.info("Config file changed: %s — reloading settings", path)
-        from core.config import Settings
+        from core.config import Settings, settings
 
         new_settings = Settings()
 
@@ -729,10 +732,12 @@ def build_tool_offload(
     hooks: HookSystem | None = None,
 ) -> Any:
     """Build P0 tool result offload store and wire cleanup on SESSION_END."""
+    from core.config import settings
+    from core.orchestration.tool_offload import ToolResultOffloadStore, set_offload_store
+
     if settings.tool_offload_threshold <= 0:
         return None
 
-    from core.orchestration.tool_offload import ToolResultOffloadStore, set_offload_store
 
     store = ToolResultOffloadStore(
         session_id=session_id,

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -738,7 +738,6 @@ def build_tool_offload(
     if settings.tool_offload_threshold <= 0:
         return None
 
-
     store = ToolResultOffloadStore(
         session_id=session_id,
         threshold=settings.tool_offload_threshold,

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -11,7 +11,6 @@ from typing import Any
 from core.auth.cooldown import CooldownTracker
 from core.auth.profiles import ProfileStore
 from core.auth.rotation import ProfileRotator
-from core.config import settings
 from core.llm.providers.openai import OpenAIAdapter
 from core.llm.router import ClaudeAdapter, LLMClientPort
 from core.orchestration.lane_queue import LaneQueue
@@ -19,6 +18,16 @@ from core.tools.policy import PolicyChain, ToolPolicy
 from core.tools.registry import ToolRegistry, ToolSearchTool
 
 log = logging.getLogger(__name__)
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy ``settings`` alias for legacy patch sites."""
+    if name == "settings":
+        from core.config import settings as _settings
+
+        return _settings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # ---------------------------------------------------------------------------
 # Default configuration
@@ -274,6 +283,7 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
         return _profile_store, _profile_rotator, CooldownTracker()
 
     from core.auth.profiles import AuthProfile, CredentialType
+    from core.config import settings
 
     profile_store = ProfileStore()
 
@@ -371,6 +381,7 @@ def build_llm_adapters(
     policy_chain: PolicyChain,
 ) -> tuple[LLMClientPort, LLMClientPort | None]:
     """Build LLM adapters and inject callables into contextvars."""
+    from core.config import settings
     from core.llm.router import set_llm_callable
 
     llm_adapter: LLMClientPort = ClaudeAdapter()

--- a/core/wiring/startup.py
+++ b/core/wiring/startup.py
@@ -22,11 +22,24 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
-from core.config import settings
 from core.memory.project import ProjectMemory
 
 log = logging.getLogger(__name__)
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy ``settings`` alias.
+
+    Tests historically patch ``core.wiring.startup.settings``; preserve that
+    surface without paying the pydantic_settings cost at module import.
+    """
+    if name == "settings":
+        from core.config import settings as _settings
+
+        return _settings
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def auto_generate_env(project_root: Path | None = None) -> bool:
@@ -83,6 +96,8 @@ def _is_placeholder(value: str) -> bool:
 
 def _has_any_llm_key() -> bool:
     """Check if ANY LLM provider API key is configured."""
+    from core.config import settings
+
     if settings.anthropic_api_key and not _is_placeholder(settings.anthropic_api_key):
         return True
     if settings.openai_api_key and not _is_placeholder(settings.openai_api_key):

--- a/plugins/game_ip/cli/batch.py
+++ b/plugins/game_ip/cli/batch.py
@@ -7,7 +7,6 @@ import statistics
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-from core.config import settings
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
@@ -69,6 +68,7 @@ def _run_analysis_standalone(ip_name: str, *, dry_run: bool = False) -> dict[str
 
     This is thread-safe: each call creates its own GeodeRuntime.
     """
+    from core.config import settings
     from core.runtime import GeodeRuntime
 
     key = ip_name.lower().strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.0"
+version = "0.89.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_anthropic_sampling_params.py
+++ b/tests/test_anthropic_sampling_params.py
@@ -44,7 +44,7 @@ def _run_agentic_call(model: str) -> dict[str, Any]:
         return await do_call(models[0]), models[0]
 
     with (
-        patch("core.llm.providers.anthropic.settings") as mock_settings,
+        patch("core.config.settings") as mock_settings,
         patch("core.llm.router.call_with_failover", side_effect=fake_failover),
     ):
         mock_settings.anthropic_api_key = "test-key"

--- a/tests/test_auth_profiles.py
+++ b/tests/test_auth_profiles.py
@@ -665,7 +665,7 @@ class TestBuildAuthZAI:
     def test_zai_profile_registered(self):
         from unittest.mock import patch
 
-        with patch("core.wiring.container.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             mock_settings.anthropic_api_key = ""
             mock_settings.openai_api_key = ""
             mock_settings.zai_api_key = "test-zai-key"
@@ -683,7 +683,7 @@ class TestBuildAuthZAI:
     def test_zai_profile_not_registered_when_empty(self):
         from unittest.mock import patch
 
-        with patch("core.wiring.container.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             mock_settings.anthropic_api_key = ""
             mock_settings.openai_api_key = ""
             mock_settings.zai_api_key = ""

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -106,7 +106,7 @@ class TestCrossProviderDispatch:
             calls.append((p, m))
             return "ok"
 
-        with patch("core.llm.provider_dispatch.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             mock_settings.llm_cross_provider_failover = False
             result = _cross_provider_dispatch("anthropic", "claude-opus-4-6", _dispatch, "test")
 
@@ -127,7 +127,7 @@ class TestCrossProviderDispatch:
             return "fallback_ok"
 
         with (
-            patch("core.llm.provider_dispatch.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
             patch("core.llm.provider_dispatch._get_fallback_chain") as mock_chain,
             patch("core.llm.provider_dispatch._fire_hook"),
         ):
@@ -150,7 +150,7 @@ class TestCrossProviderDispatch:
             raise RuntimeError(f"{p} down")
 
         with (
-            patch("core.llm.provider_dispatch.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
             patch("core.llm.provider_dispatch._get_fallback_chain", return_value=["m1"]),
             patch("core.llm.provider_dispatch._fire_hook"),
             pytest.raises(RuntimeError, match="glm down"),
@@ -744,6 +744,9 @@ class TestCostRatioGuard:
 
         mock_settings = MagicMock()
         mock_settings.llm_max_fallback_cost_ratio = 2.0
+        mock_settings.llm_max_retries = 1
+        mock_settings.llm_retry_base_delay = 0.0
+        mock_settings.llm_retry_max_delay = 0.0
         mock_pricing = {
             "cheap": ModelPrice(input=1e-6, output=5e-6),
             "expensive": ModelPrice(input=10e-6, output=50e-6),

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -139,7 +139,7 @@ class TestAnthropicNativeToolInjection:
         mock_response.model = "claude-opus-4-6"
 
         with (
-            patch("core.llm.providers.anthropic.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
             patch("core.llm.router.call_with_failover") as mock_failover,
         ):
             mock_settings.anthropic_api_key = "test-key"

--- a/tests/test_provider_switching.py
+++ b/tests/test_provider_switching.py
@@ -186,8 +186,18 @@ def _register_glm_payg() -> Plan:
 @pytest.fixture
 def isolated_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Reset singletons + redirect auth.toml to a tmp path so plan
-    registrations don't leak across tests."""
+    registrations don't leak across tests.
+
+    Also clears ``settings.*_api_key`` so other tests that exercise
+    ``cmd_key`` (test_commands.py) cannot leak a non-empty key into
+    ``build_auth`` and seed an unexpected ``anthropic:default`` profile.
+    """
+    from core.config import settings
+
     monkeypatch.setenv("GEODE_AUTH_TOML", str(tmp_path / "auth.toml"))
+    monkeypatch.setattr(settings, "anthropic_api_key", "")
+    monkeypatch.setattr(settings, "openai_api_key", "")
+    monkeypatch.setattr(settings, "zai_api_key", "")
     _reset_singletons()
     yield
     _reset_singletons()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -60,7 +60,7 @@ class TestReadinessReport:
 
 class TestCheckReadiness:
     def test_without_api_key(self, tmp_path: Path):
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             report = check_readiness(tmp_path)
 
@@ -72,7 +72,7 @@ class TestCheckReadiness:
         assert llm_cap.available is False
 
     def test_with_anthropic_key(self, tmp_path: Path):
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             mock_settings.anthropic_api_key = "sk-ant-real-key-here"
             report = check_readiness(tmp_path)
@@ -85,7 +85,7 @@ class TestCheckReadiness:
 
     def test_with_openai_key_only(self, tmp_path: Path):
         """ANY provider key unblocks — OpenAI alone should suffice."""
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             mock_settings.openai_api_key = "sk-proj-real-key-here"
             report = check_readiness(tmp_path)
@@ -95,7 +95,7 @@ class TestCheckReadiness:
 
     def test_with_glm_key_only(self, tmp_path: Path):
         """ANY provider key unblocks — GLM alone should suffice."""
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             mock_settings.zai_api_key = "abc12345.def67890"
             report = check_readiness(tmp_path)
@@ -104,7 +104,7 @@ class TestCheckReadiness:
         assert report.blocked is False
 
     def test_placeholder_key_treated_as_missing(self, tmp_path: Path):
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             mock_settings.anthropic_api_key = "sk-ant-..."
             mock_settings.openai_api_key = "sk-..."
             mock_settings.zai_api_key = "..."
@@ -114,7 +114,7 @@ class TestCheckReadiness:
         assert report.force_dry_run is True
 
     def test_env_file_check(self, tmp_path: Path):
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
 
             # No .env, no .env.example
@@ -135,7 +135,7 @@ class TestCheckReadiness:
             assert report.has_env_file is True
 
     def test_project_memory_check(self, tmp_path: Path):
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
 
             # No .geode/memory/PROJECT.md → unavailable
@@ -154,7 +154,7 @@ class TestCheckReadiness:
             assert mem_cap.available is True
 
     def test_always_available_capabilities(self, tmp_path: Path):
-        with patch("core.wiring.startup.settings") as mock_settings:
+        with patch("core.config.settings") as mock_settings:
             _no_keys_mock(mock_settings)
             report = check_readiness(tmp_path)
 
@@ -216,7 +216,7 @@ class TestEnvSetupWizard:
         """User picks Path B then presses Enter for every key → no keys set."""
         with (
             patch("core.cli.onboarding.console") as mock_console,
-            patch("core.cli.onboarding.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["2", "", "", ""]
@@ -228,7 +228,7 @@ class TestEnvSetupWizard:
         with (
             patch("core.cli.onboarding.console") as mock_console,
             patch("core.cli.onboarding._upsert_env"),
-            patch("core.cli.onboarding.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = [
@@ -244,7 +244,7 @@ class TestEnvSetupWizard:
         """Ctrl+C at the menu prompt gracefully stops."""
         with (
             patch("core.cli.onboarding.console") as mock_console,
-            patch("core.cli.onboarding.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = KeyboardInterrupt
@@ -256,7 +256,7 @@ class TestEnvSetupWizard:
         with (
             patch("core.cli.onboarding.console") as mock_console,
             patch("core.cli.onboarding.detect_subscription_oauth", return_value="openai-codex"),
-            patch("core.cli.onboarding.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["1", ""]  # menu, then Enter on prompt
@@ -268,7 +268,7 @@ class TestEnvSetupWizard:
         with (
             patch("core.cli.onboarding.console") as mock_console,
             patch("core.cli.onboarding.detect_subscription_oauth", return_value=None),
-            patch("core.cli.onboarding.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["1", ""]
@@ -280,7 +280,7 @@ class TestEnvSetupWizard:
         won't re-prompt on next launch."""
         with (
             patch("core.cli.onboarding.console") as mock_console,
-            patch("core.cli.onboarding.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
         ):
             _no_keys_mock(mock_settings)
             mock_console.input.side_effect = ["3"]
@@ -544,7 +544,7 @@ class TestGlmClient:
         with (
             _p.dict("sys.modules", {"openai": mock_openai_mod}),
             _p("core.llm.providers.glm._glm_client", None),
-            _p("core.llm.providers.glm.settings") as ms,
+            _p("core.config.settings") as ms,
         ):
             ms.zai_api_key = "test-key"
             from core.llm.providers.glm import _get_glm_client
@@ -638,7 +638,7 @@ class TestReadinessProfileStatus:
         mock_profile_instance.exists.return_value = True
 
         with (
-            patch("core.wiring.startup.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
             patch(
                 "core.memory.user_profile.FileBasedUserProfile",
                 return_value=mock_profile_instance,
@@ -659,7 +659,7 @@ class TestReadinessProfileStatus:
         mock_profile_instance.exists.return_value = False
 
         with (
-            patch("core.wiring.startup.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
             patch(
                 "core.memory.user_profile.FileBasedUserProfile",
                 return_value=mock_profile_instance,
@@ -676,7 +676,7 @@ class TestReadinessProfileStatus:
     def test_profile_load_exception_handled(self, tmp_path: Path):
         """If FileBasedUserProfile raises, profile shows as unavailable."""
         with (
-            patch("core.wiring.startup.settings") as mock_settings,
+            patch("core.config.settings") as mock_settings,
             patch(
                 "core.memory.user_profile.FileBasedUserProfile",
                 side_effect=RuntimeError("broken"),


### PR DESCRIPTION
## Summary
v0.89.1 — `core.config` 패키지 분리 + PEP 562 lazy + 19 cold-start callsite 함수-로컬 import 이전. cold-start `import core.runtime`: **240 ms → 128 ms first-run / 80-110 ms warm (median ~88 ms) = −112 ms / −46 %**. 0 regression.

## Verification
- [x] PR #948 (단계 1: config 패키지 분리) merged
- [x] PR #949 (단계 2: 19 callsite lazy + fallback PEP 562 + 5 모듈 alias) merged
- [x] PR #950 (release stamp 4 위치) merged
- [x] cold-start −46 % 측정 (warm cache median ~88 ms)
- [x] 4330 tests pass, E2E A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)