### PR TITLE
release(v0.89.2): cold-start 추가 −20 % (runtime path lazy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.89.2] — 2026-05-09
+
+> **Cold-start 추가 −20 % (warm median 88 → 70 ms) via pydantic / asyncio / importlib.metadata lazy.**
+>
+> v0.89.2 는 v0.89.1 의 settings lazy 위에 `core.runtime` 트리에 잔존했던
+> 무거운 import 셋을 추가로 cold-start 에서 제거한다. `pydantic` (BaseModel
+> TypeVar bound) 3 사이트, `asyncio` + `email.message` mid-module, `core/__init__.py`
+> 의 eager `__version__` resolve 모두 lazy 화. cold-start `import core.runtime`:
+> **88 ms → 70 ms median (warm), 341 → 201 modules (−140 vs v0.89.0)**.
+> v0.89.0 → v0.89.2 누적: cold first-run **240 → ~85 ms = −65 %**.
+
 ### Architecture
 
 - **`core.runtime` cold-start path 추가 lazy 화 (pydantic / asyncio / importlib.metadata).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.1
+- **Version**: 0.89.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.89.1 — Long-running Autonomous Execution Harness
+# GEODE v0.89.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.1"
+version = "0.89.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- v0.89.2 = PR #952 (runtime path 추가 lazy: pydantic / asyncio / importlib.metadata) 합본 릴리즈.
- Version stamp 4 위치 동기.

## Verification
- [x] 4 위치 version: 0.89.2
- [x] cold-start `import core.runtime`: 88 ms → 70 ms warm median (−20 %)
- [x] modules: 341 → 201 (−140 vs v0.89.0 baseline)
- [x] v0.89.0 → v0.89.2 누적 cold first-run: 240 → ~85 ms = −65 %
- [x] 4330 tests pass / E2E A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)