### PR TITLE
release(v0.89.2): cold-start 추가 −20 % (runtime path lazy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Architecture
+
+- **`core.runtime` cold-start path 추가 lazy 화 (pydantic / asyncio / importlib.metadata).**
+  v0.89.1 의 settings lazy 회수 위에서, `core.runtime` 트리에 남아 있던
+  세 무거운 import 를 추가로 cold-start 에서 제거:
+  - `core/llm/adapters.py`, `core/llm/providers/openai.py`,
+    `core/llm/router/calls/parsed.py` 의 `from pydantic import BaseModel`
+    top-level → `if TYPE_CHECKING:` 블록 + `TypeVar(..., bound="BaseModel")`
+    forward-reference. pydantic 풀 트리 (~100 ms cumulative) cold-start
+    에서 빠짐.
+  - `core/llm/providers/openai.py` 의 mid-module `import asyncio` →
+    `_async_call` 메소드 진입부 함수-로컬. asyncio + email.message /
+    email.utils (~13 ms cumulative) cold-start 에서 빠짐.
+  - `core/__init__.py` 의 `from importlib.metadata import ...` (eager
+    `__version__` resolve) → PEP 562 `__getattr__` lazy. importlib.metadata
+    + email tree (~70 ms cumulative) cold-start 에서 빠짐. `__version__`
+    첫 access 시점에 한 번만 resolve + cache.
+- 측정 (`import core.runtime`):
+  - v0.89.1 baseline: 80-110 ms warm (median ≈ 88 ms), 341 modules
+  - 이 PR: **54-94 ms warm (median ≈ 70 ms)**, **201 modules** = warm
+    median **−18 ms / −20 %**, modules **−140 vs v0.89.0 baseline 341**.
+  - v0.89.0 → v0.89.2 누적: cold first-run 240 → ~85 ms = **−65 % cumulative**.
+  - `pydantic` / `pydantic_core` / `pydantic_settings` / `importlib.metadata`
+    / `email.message` 모두 cold-start `sys.modules` 에서 빠짐.
+
 ## [0.89.1] — 2026-05-09
 
 > **Cold-start −46 % via `core.config` lazy + 19 callsite 함수-로컬 import.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.89.2] — 2026-05-09
+
+> **Cold-start 추가 −20 % (warm median 88 → 70 ms) via pydantic / asyncio / importlib.metadata lazy.**
+>
+> v0.89.2 는 v0.89.1 의 settings lazy 위에 `core.runtime` 트리에 잔존했던
+> 무거운 import 셋을 추가로 cold-start 에서 제거한다. `pydantic` (BaseModel
+> TypeVar bound) 3 사이트, `asyncio` + `email.message` mid-module, `core/__init__.py`
+> 의 eager `__version__` resolve 모두 lazy 화. cold-start `import core.runtime`:
+> **88 ms → 70 ms median (warm), 341 → 201 modules (−140 vs v0.89.0)**.
+> v0.89.0 → v0.89.2 누적: cold first-run **240 → ~85 ms = −65 %**.
+
 ### Architecture
 
 - **`core.runtime` cold-start path 추가 lazy 화 (pydantic / asyncio / importlib.metadata).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.1
+- **Version**: 0.89.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.89.1 — Long-running Autonomous Execution Harness
+# GEODE v0.89.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,19 +1,50 @@
 """GEODE — 범용 자율 실행 에이전트."""
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
+from __future__ import annotations
 
-try:
-    __version__: str = _pkg_version("geode")
-except PackageNotFoundError:
-    # Fallback: read from pyproject.toml directly (dev / non-installed env)
-    from pathlib import Path as _Path
+from typing import TYPE_CHECKING, Any
 
-    _pyproject = _Path(__file__).resolve().parent.parent / "pyproject.toml"
-    if _pyproject.exists():
-        import re as _re
+if TYPE_CHECKING:
+    # Declare ``__version__`` for mypy / IDEs.  The runtime value is produced
+    # lazily by ``__getattr__`` below so module import does not pull
+    # ``importlib.metadata`` (~70 ms cumulative including ``email.message`` /
+    # ``email.utils``) into the cold-start path.
+    __version__: str
 
-        _match = _re.search(r'version\s*=\s*"([^"]+)"', _pyproject.read_text())
-        __version__ = _match.group(1) if _match else "0.0.0-dev"
-    else:
-        __version__ = "0.0.0-dev"
+_VERSION_CACHE: str | None = None
+
+
+def _resolve_version() -> str:
+    """Resolve the package version from importlib.metadata, with a
+    pyproject.toml fallback for non-installed dev environments."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        return _pkg_version("geode")
+    except PackageNotFoundError:
+        # Fallback: read from pyproject.toml directly (dev / non-installed env)
+        from pathlib import Path as _Path
+
+        _pyproject = _Path(__file__).resolve().parent.parent / "pyproject.toml"
+        if _pyproject.exists():
+            import re as _re
+
+            _match = _re.search(r'version\s*=\s*"([^"]+)"', _pyproject.read_text())
+            return _match.group(1) if _match else "0.0.0-dev"
+        return "0.0.0-dev"
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy ``__version__`` resolver.
+
+    Cold-start paths that never reference ``core.__version__`` (e.g. the
+    serve daemon's ``import core.runtime`` bootstrap) avoid loading
+    ``importlib.metadata`` entirely.
+    """
+    if name == "__version__":
+        global _VERSION_CACHE
+        if _VERSION_CACHE is None:
+            _VERSION_CACHE = _resolve_version()
+        return _VERSION_CACHE
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/core/llm/adapters.py
+++ b/core/llm/adapters.py
@@ -10,11 +10,17 @@ from __future__ import annotations
 import importlib
 import logging
 from collections.abc import Callable, Iterator
-from typing import Any, Protocol, TypeVar, runtime_checkable
-
-from pydantic import BaseModel
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
 from core.llm.agentic_response import AgenticResponse
+
+if TYPE_CHECKING:
+    # Pydantic is a heavy import (~100 ms cumulative). Push it behind
+    # ``TYPE_CHECKING`` so module load no longer pulls the full pydantic
+    # graph into the cold-start path; ``TypeVar`` ``bound=`` accepts a
+    # forward-reference string at runtime so the annotation still type-
+    # checks under mypy.
+    from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +28,7 @@ log = logging.getLogger(__name__)
 # LLMClientPort — Protocol interface for LLM provider adapters
 # ---------------------------------------------------------------------------
 
-T2 = TypeVar("T2", bound=BaseModel)
+T2 = TypeVar("T2", bound="BaseModel")
 
 
 @runtime_checkable
@@ -247,7 +253,7 @@ def resolve_agentic_adapter(provider: str) -> AgenticLLMPort:
 # ClaudeAdapter — thin wrapper that delegates to router functions
 # ---------------------------------------------------------------------------
 
-T = TypeVar("T", bound=BaseModel)
+T = TypeVar("T", bound="BaseModel")
 
 
 class ClaudeAdapter:

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -11,9 +11,7 @@ import re
 import threading
 import time
 from collections.abc import Callable, Iterator
-from typing import Any, TypeVar, cast
-
-from pydantic import BaseModel
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from core.config import OPENAI_FALLBACK_CHAIN, OPENAI_PRIMARY
 from core.llm.fallback import (
@@ -22,7 +20,13 @@ from core.llm.fallback import (
 )
 from core.llm.token_tracker import LLMUsage, get_tracker
 
-T = TypeVar("T", bound=BaseModel)
+if TYPE_CHECKING:
+    # Pydantic is a heavy import (~100 ms cumulative). The ``BaseModel``
+    # bound is only consumed by mypy so a forward-reference string keeps
+    # runtime free of the pydantic tree.
+    from pydantic import BaseModel
+
+T = TypeVar("T", bound="BaseModel")
 
 log = logging.getLogger(__name__)
 
@@ -367,7 +371,9 @@ class OpenAIAdapter:
 # OpenAIAgenticAdapter — OpenAI-compatible LLM adapter for agentic loop
 # ---------------------------------------------------------------------------
 
-import asyncio  # noqa: E402
+# asyncio (~13 ms cumulative including email.message) deferred to function
+# scope; the single ``await asyncio.to_thread(...)`` lives inside an
+# async method so a function-local import has no cost.
 
 # v0.88.2 — httpx (~92 ms cumulative importtime) deferred to function
 # scope.  The single usage in ``_get_client`` already runs inside a
@@ -552,6 +558,8 @@ class OpenAIAgenticAdapter:
                 oai_effort = _EFFORT_MAP.get(effort, "medium")
                 create_kwargs["reasoning"] = {"effort": oai_effort, "summary": "auto"}
                 create_kwargs["include"] = ["reasoning.encrypted_content"]
+            import asyncio
+
             return await asyncio.to_thread(client.responses.create, **create_kwargs)
 
         try:

--- a/core/llm/router/calls/parsed.py
+++ b/core/llm/router/calls/parsed.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TypeVar, cast
-
-from pydantic import BaseModel
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
@@ -27,7 +25,13 @@ from ._route import _route_provider
 
 log = logging.getLogger(__name__)
 
-T = TypeVar("T", bound=BaseModel)
+if TYPE_CHECKING:
+    # Pydantic is a heavy import (~100 ms cumulative). The ``BaseModel``
+    # bound is only consumed by mypy so a forward-reference string keeps
+    # runtime free of the pydantic tree.
+    from pydantic import BaseModel
+
+T = TypeVar("T", bound="BaseModel")
 
 
 def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.1"
+version = "0.89.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.89.0"
+version = "0.89.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
v0.89.2 — `core.runtime` cold-start 트리 잔존 무거운 import 3 종 추가 lazy 화 (pydantic / asyncio / importlib.metadata). cold-start `import core.runtime`: warm median **88 → 70 ms (−20 %)**, modules **341 → 201 (−140 vs v0.89.0)**. v0.89.0 → v0.89.2 누적 cold first-run **240 → ~85 ms = −65 %**.

## Verification
- [x] PR #952 (runtime path lazy) merged
- [x] PR #953 (release stamp 4 위치) merged
- [x] cold-start −20 % vs v0.89.1
- [x] 4330 tests pass / E2E A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)