### PR TITLE
release(v0.89.3): cold-start 추가 −53 % (type-only / late-binding lazy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.89.3] — 2026-05-09
+
+> **Cold-start 추가 −53 % (warm median 70 → 33 ms) via type-only / late-binding lazy.**
+>
+> v0.89.3 는 v0.89.2 의 pydantic / asyncio / importlib.metadata lazy 위에서
+> `core.runtime` + `core.wiring.bootstrap` 의 14+11 개 type-only import 를
+> `TYPE_CHECKING` / 함수-로컬 lazy 로 추가 분리한다. cold-start
+> `import core.runtime`: **70 → 33 ms median (warm), 201 → 167 modules**.
+> v0.89.0 → v0.89.3 누적: cold first-run **240 → ~33 ms = −86 %**.
+
 ### Architecture
 
 - **`core.runtime` + `core.wiring.bootstrap` 의 type-only / late-binding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.2
+- **Version**: 0.89.3
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.89.2 — Long-running Autonomous Execution Harness
+# GEODE v0.89.3 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.2"
+version = "0.89.3"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- v0.89.3 = PR #955 (runtime + bootstrap type-only / late-binding lazy) 합본 릴리즈.
- Version stamp 4 위치 동기.

## Verification
- [x] 4 위치 version: 0.89.3
- [x] cold-start `import core.runtime`: 70 → 33 ms warm median (−53 %)
- [x] modules: 201 → 167 (−174 vs v0.89.0 baseline 341)
- [x] v0.89.0 → v0.89.3 누적 cold first-run: 240 → ~33 ms = −86 %
- [x] 4330 tests pass / E2E A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)