### PR TITLE
release(v0.89.3): cold-start −53 % (type-only / late-binding lazy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.89.3] — 2026-05-09
+
+> **Cold-start 추가 −53 % (warm median 70 → 33 ms) via type-only / late-binding lazy.**
+>
+> v0.89.3 는 v0.89.2 의 pydantic / asyncio / importlib.metadata lazy 위에서
+> `core.runtime` + `core.wiring.bootstrap` 의 14+11 개 type-only import 를
+> `TYPE_CHECKING` / 함수-로컬 lazy 로 추가 분리한다. cold-start
+> `import core.runtime`: **70 → 33 ms median (warm), 201 → 167 modules**.
+> v0.89.0 → v0.89.3 누적: cold first-run **240 → ~33 ms = −86 %**.
+
 ### Architecture
 
 - **`core.runtime` + `core.wiring.bootstrap` 의 type-only / late-binding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Architecture
+
+- **`core.runtime` + `core.wiring.bootstrap` 의 type-only / late-binding
+  import 를 cold-start 에서 제거.**
+  - `core/runtime.py`: 14 개 클래스 (CUSUMDetector / ExpertPanel /
+    FeedbackLoop / ModelRegistry / OutcomeTracker / SnapshotManager /
+    ContextAssembler / MonoLakeOrganizationMemory / ProjectMemory /
+    ConfigWatcher / TaskGraphHookBridge / TaskGraph / TriggerManager /
+    CorrelationAnalyzer) 가 dataclass field annotation 으로만 쓰임
+    (`from __future__ import annotations` 로 string 평가) — top-level
+    import → `if TYPE_CHECKING:` 블록으로 이전.
+  - `core/wiring/bootstrap.py`: 동일 클래스들 (ContextAssembler /
+    MonoLake / ProjectMemory / FileBasedUserProfile / ConfigWatcher /
+    RunLog / RunLogEntry / StuckDetector / TaskGraph / TaskGraphHookBridge /
+    InMemorySessionStore) 도 함수-로컬 import 로 이전 + `TYPE_CHECKING`
+    type stub.  build_* 함수가 호출될 때만 instantiate.
+  - 5 모듈 (`config-lazy` PR 패턴) 의 module-level `settings` alias 와
+    동일하게 `bootstrap.py` 에 PEP 562 `__getattr__` 추가 (RunLog /
+    StuckDetector / RunLogEntry) — legacy `patch("core.wiring.bootstrap.X")`
+    테스트 사이트 호환 유지.
+- 측정 (`import core.runtime`):
+  - v0.89.2 baseline: 54-94 ms warm (median ≈ 70 ms), 201 modules
+  - 이 PR: **26-47 ms warm (median ≈ 33 ms), 167 modules** = warm
+    median **−37 ms / −53 %** vs v0.89.2.
+  - v0.89.0 → 이 PR 누적: cold first-run 240 → ~33 ms = **−86 %**.
+  - cold-start `sys.modules` 에서 추가로 빠짐: `core.memory.context`,
+    `core.memory.organization`, `core.memory.project`,
+    `core.automation.{drift,feedback_loop,model_registry,outcome_tracking,snapshot,expert_panel}`,
+    `core.scheduler.triggers`, `core.orchestration.{hot_reload,task_bridge,task_system,run_log,stuck_detection}`.
+
 ## [0.89.2] — 2026-05-09
 
 > **Cold-start 추가 −20 % (warm median 88 → 70 ms) via pydantic / asyncio / importlib.metadata lazy.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.2
+- **Version**: 0.89.3
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [한국어](README.ko.md)
 
-# GEODE v0.89.2 — Long-running Autonomous Execution Harness
+# GEODE v0.89.3 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -31,43 +31,43 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
 
-    # v0.88.1 — CorrelationAnalyzer pulls numpy (~31 ms) at module
-    # load. ``runtime.py`` only references it as a dataclass field
-    # type annotation (``correlation_analyzer: CorrelationAnalyzer | None``);
-    # ``from __future__ import annotations`` makes the annotation a
-    # string at runtime, so no real import is needed unless the
-    # caller actually instantiates the analyzer.  Wiring builders
-    # (``core.wiring.automation``) and ``feedback_loop`` keep their
-    # own eager imports — those modules only load when automation
-    # actually runs, well after CLI cold-start.
+    # ``from __future__ import annotations`` defers evaluation of all
+    # type annotations to strings, so the classes referenced only in
+    # field / variable annotations below do not need to be imported at
+    # runtime.  Pushing them into ``TYPE_CHECKING`` removes their entire
+    # module trees (numpy via ``correlation``, the L4.5 automation graph,
+    # the L2 memory graph, scheduler.triggers, langgraph hot-reload,
+    # task system) from the cold-start path.  Each tree is loaded lazily
+    # by the wiring builders (``core.wiring.{bootstrap,automation}``)
+    # only when the matching component actually fires.
     from core.automation.correlation import CorrelationAnalyzer
+    from core.automation.drift import CUSUMDetector
+    from core.automation.expert_panel import ExpertPanel
+    from core.automation.feedback_loop import FeedbackLoop
+    from core.automation.model_registry import ModelRegistry
+    from core.automation.outcome_tracking import OutcomeTracker
+    from core.automation.snapshot import SnapshotManager
     from core.llm.prompt_assembler import PromptAssembler
+    from core.memory.context import ContextAssembler
+    from core.memory.organization import MonoLakeOrganizationMemory
+    from core.memory.project import ProjectMemory
+    from core.orchestration.hot_reload import ConfigWatcher
+    from core.orchestration.task_bridge import TaskGraphHookBridge
+    from core.orchestration.task_system import TaskGraph
+    from core.scheduler.triggers import TriggerManager
 
 from core.auth.cooldown import CooldownTracker
 from core.auth.profiles import ProfileStore
 from core.auth.rotation import ProfileRotator
-from core.automation.drift import CUSUMDetector
-from core.automation.expert_panel import ExpertPanel
-from core.automation.feedback_loop import FeedbackLoop
-from core.automation.model_registry import ModelRegistry
-from core.automation.outcome_tracking import OutcomeTracker
-from core.automation.snapshot import SnapshotManager
 from core.domains.loader import load_domain_adapter
 from core.domains.port import set_domain
 from core.hooks import HookSystem
 from core.llm.router import LLMClientPort
-from core.memory.context import ContextAssembler
-from core.memory.organization import MonoLakeOrganizationMemory
 from core.memory.port import SessionStorePort
-from core.memory.project import ProjectMemory
 from core.memory.session_key import build_session_key, build_thread_config
-from core.orchestration.hot_reload import ConfigWatcher
 from core.orchestration.lane_queue import LaneQueue
 from core.orchestration.run_log import RunLog
 from core.orchestration.stuck_detection import StuckDetector
-from core.orchestration.task_bridge import TaskGraphHookBridge
-from core.orchestration.task_system import TaskGraph
-from core.scheduler.triggers import TriggerManager
 from core.tools.policy import NodeScopePolicy, PolicyChain
 from core.tools.registry import ToolRegistry
 from core.wiring.bootstrap import (  # noqa: F401  — backward compat

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -51,6 +51,7 @@ def __getattr__(name: str) -> Any:
         return _RunLogEntry
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 # ---------------------------------------------------------------------------
 # Default configuration (re-exported from runtime.py constants)
 # ---------------------------------------------------------------------------

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -10,22 +10,46 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    # Type-only references — kept out of cold-start via PEP 563 string
+    # annotations (``from __future__ import annotations``).  Each class
+    # is imported lazily inside its build_* function below; this block
+    # exists solely so mypy / IDEs can resolve the annotations.
     from core.llm.prompt_assembler import PromptAssembler
+    from core.memory.context import ContextAssembler
+    from core.memory.organization import MonoLakeOrganizationMemory
+    from core.memory.port import SessionStorePort
+    from core.memory.project import ProjectMemory
+    from core.memory.user_profile import FileBasedUserProfile
+    from core.orchestration.hot_reload import ConfigWatcher
+    from core.orchestration.run_log import RunLog
+    from core.orchestration.stuck_detection import StuckDetector
+    from core.orchestration.task_bridge import TaskGraphHookBridge
+    from core.orchestration.task_system import TaskGraph
 
 from core.hooks import HookEvent, HookSystem
-from core.memory.context import ContextAssembler
-from core.memory.organization import MonoLakeOrganizationMemory
-from core.memory.port import SessionStorePort
-from core.memory.project import ProjectMemory
-from core.memory.session import InMemorySessionStore
-from core.memory.user_profile import FileBasedUserProfile
-from core.orchestration.hot_reload import ConfigWatcher
-from core.orchestration.run_log import RunLog, RunLogEntry
-from core.orchestration.stuck_detection import StuckDetector
-from core.orchestration.task_bridge import TaskGraphHookBridge
-from core.orchestration.task_system import TaskGraph
 
 log = logging.getLogger(__name__)
+
+
+# Module-level PEP 562 alias for legacy ``patch("core.wiring.bootstrap.X")``
+# sites (test_hooks / test_auto_learn / test_profile_wiring).  The classes
+# themselves live in their own modules and are imported lazily inside the
+# build_* functions; resolving them only on attribute access means cold-start
+# never pays for the orchestration / memory / hot-reload trees.
+def __getattr__(name: str) -> Any:
+    if name == "RunLog":
+        from core.orchestration.run_log import RunLog as _RunLog
+
+        return _RunLog
+    if name == "StuckDetector":
+        from core.orchestration.stuck_detection import StuckDetector as _StuckDetector
+
+        return _StuckDetector
+    if name == "RunLogEntry":
+        from core.orchestration.run_log import RunLogEntry as _RunLogEntry
+
+        return _RunLogEntry
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # ---------------------------------------------------------------------------
 # Default configuration (re-exported from runtime.py constants)
@@ -44,6 +68,7 @@ def _make_run_log_handler(
     run_id: str,
 ) -> tuple[str, Any]:
     """Create a hook handler that writes events to RunLog."""
+    from core.orchestration.run_log import RunLogEntry
 
     def _log_event(event: HookEvent, data: dict[str, Any]) -> None:
         entry = RunLogEntry(
@@ -130,6 +155,9 @@ def build_hooks(
     stuck_timeout_s: float,
 ) -> tuple[HookSystem, RunLog, StuckDetector, Any]:
     """Build HookSystem with RunLog, StuckDetector, and SessionMetrics."""
+    from core.orchestration.run_log import RunLog
+    from core.orchestration.stuck_detection import StuckDetector
+
     hooks: HookSystem = HookSystem()
 
     # Run log + hook handler
@@ -484,6 +512,10 @@ def build_memory(
 ) -> tuple[ProjectMemory, MonoLakeOrganizationMemory, ContextAssembler, FileBasedUserProfile]:
     """Build L2 memory components: project, org, context assembler, user profile."""
     from core.config import settings
+    from core.memory.context import ContextAssembler
+    from core.memory.organization import MonoLakeOrganizationMemory
+    from core.memory.project import ProjectMemory
+    from core.memory.user_profile import FileBasedUserProfile
     from core.paths import ensure_directories
 
     ensure_directories()
@@ -557,6 +589,7 @@ def build_memory(
 def build_session_store(*, session_ttl: float) -> SessionStorePort:
     """Build session store — InMemory default, HybridSessionStore if URLs configured."""
     from core.config import settings
+    from core.memory.session import InMemorySessionStore
 
     session_storage_dir: Path | None = None
     if settings.session_storage_dir:
@@ -581,6 +614,8 @@ def build_session_store(*, session_ttl: float) -> SessionStorePort:
 
 def build_config_watcher(*, hooks: HookSystem | None = None) -> ConfigWatcher:
     """Build ConfigWatcher and register .env hot-reload handler if .env exists."""
+    from core.orchestration.hot_reload import ConfigWatcher
+
     config_watcher = ConfigWatcher(debounce_ms=CONFIG_WATCHER_DEBOUNCE_MS)
     env_path = Path(".env")
     if not env_path.exists():
@@ -657,6 +692,8 @@ def build_task_graph(
     per-task transitions.
     """
     from core.domains.port import get_domain_or_none
+    from core.orchestration.task_bridge import TaskGraphHookBridge
+    from core.orchestration.task_system import TaskGraph
 
     prefix = ip_name.lower().replace(" ", "_")
     domain = get_domain_or_none()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.2"
+version = "0.89.3"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.89.1"
+version = "0.89.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
v0.89.3 — `core.runtime` + `core.wiring.bootstrap` 의 14+11 type-only / late-binding import 를 `TYPE_CHECKING` / 함수-로컬 lazy 로 분리. cold-start `import core.runtime` warm median **70 → 33 ms (−53 %)**, modules **201 → 167 (−174 vs v0.89.0 341)**. v0.89.0 → v0.89.3 누적 cold first-run **240 → ~33 ms = −86 %**.

## Verification
- [x] PR #955 (runtime + bootstrap type-only lazy) merged
- [x] PR #956 (release stamp) merged
- [x] cold-start −53 % vs v0.89.2
- [x] 4330 tests pass / E2E A (68.4) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)