### PR TITLE
docs(readme): Updating + Uninstalling 섹션 추가

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -171,6 +171,55 @@ geode setup --reset   # ~/.geode/.env 지우고 wizard 재실행
 
 ---
 
+### 업데이트
+
+최신 코드를 pull 한 뒤 의존성 sync + editable 바이너리 재설치 — 이러면 `geode` 명령이 새 소스를 가리킵니다.
+
+```bash
+git pull                              # geode/ 디렉토리 안에서
+uv sync                               # 의존성 업데이트
+uv tool install -e . --force          # `geode` 콘솔 스크립트 재빌드
+```
+
+`geode serve` 데몬이 떠 있다면 재시작해서 새 코드를 로드하세요:
+
+```bash
+pgrep -f "geode serve" | xargs -r kill   # 데몬 정지
+geode serve &                            # 백그라운드 재시작
+geode version                            # 새 버전 확인
+```
+
+---
+
+### 삭제
+
+`geode` 콘솔 스크립트와 전용 환경을 제거합니다. `geode/` 소스 폴더, `~/.geode/` 설정 디렉토리, `~/.local/share/geode/` 실행 로그는 그대로 남기 — 완전히 지우려면 별도로 삭제하세요.
+
+```bash
+# 1) 데몬 정지 (geode serve 안 띄웠다면 skip)
+pgrep -f "geode serve" | xargs -r kill
+
+# 2) 콘솔 스크립트 + 도구 환경 제거
+uv tool uninstall geode
+
+# 3) (선택) 설정 + 실행 로그 wipe
+rm -rf ~/.geode                                 # 설정: .env, ~/.geode/config.toml, snapshots
+rm -rf ~/.local/share/geode                     # 실행 로그 (~/.geode/runs 와 중복 경로)
+
+# 4) (선택) 소스 clone 도 제거
+rm -rf path/to/geode
+```
+
+제거 확인:
+
+```bash
+which geode               # 출력 없어야 함
+uv tool list | grep geode # 출력 없어야 함
+pgrep -f "geode serve"    # 출력 없어야 함
+```
+
+---
+
 ### Optional — Slack / Discord / Telegram 연결
 
 터미널에서 GEODE 가 동작한 뒤에는, 이미 쓰는 메신저 채널에서도 답하게 할 수 있습니다:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,55 @@ geode setup --reset   # wipe ~/.geode/.env and re-run the wizard
 
 ---
 
+### Updating
+
+Pull the latest code, sync dependencies, then re-install the editable binary so `geode` resolves to the new source:
+
+```bash
+git pull                              # from inside the geode/ directory
+uv sync                               # update dependencies
+uv tool install -e . --force          # rebuild the `geode` console-script
+```
+
+If `geode serve` was running, restart it so the daemon loads the new code:
+
+```bash
+pgrep -f "geode serve" | xargs -r kill   # stop the running daemon
+geode serve &                            # restart in the background
+geode version                            # confirm the new version
+```
+
+---
+
+### Uninstalling
+
+Removes the `geode` console-script and its tool environment. The `geode/` source folder, `~/.geode/` config directory, and `~/.local/share/geode/` runtime data are kept — delete them separately if you want a clean wipe.
+
+```bash
+# 1) Stop the daemon (skip if you never ran `geode serve`)
+pgrep -f "geode serve" | xargs -r kill
+
+# 2) Remove the console-script + tool environment
+uv tool uninstall geode
+
+# 3) (optional) wipe config + runtime data
+rm -rf ~/.geode                                 # config: .env, ~/.geode/config.toml, snapshots
+rm -rf ~/.local/share/geode                     # runtime: run logs (~/.geode/runs duplicate path)
+
+# 4) (optional) drop the source clone
+rm -rf path/to/geode
+```
+
+Verify the removal:
+
+```bash
+which geode               # should print nothing
+uv tool list | grep geode # should print nothing
+pgrep -f "geode serve"    # should print nothing
+```
+
+---
+
 ### Optional — Hook into Slack / Discord / Telegram
 
 Once GEODE works in your terminal, you can let it answer on the messaging channels you already use:


### PR DESCRIPTION
## Summary
- README.md / README.ko.md 양쪽 4단계 (Run) 와 Optional (Slack/Discord) 섹션 사이에 **Updating** + **Uninstalling** 섹션 추가.
- 기능 변경 없음 — 문서만.

## Why
다른 머신에 설치한 사용자가 "최신 코드로 어떻게 갱신?" / "geode 깔끔히 지우려면?" 이라는 질문에 답이 없었다. 기존 README 는 install 만 안내했다. uninstall 명령 (`uv tool uninstall geode`) 자체는 표준이지만, daemon 정지 / `~/.geode` / `~/.local/share/geode` 경로 / 검증 명령은 사용자가 알기 어렵다.

## Changes
| File | Change |
|------|--------|
| `README.md` | "Other useful commands" 다음에 `### Updating` + `### Uninstalling` 두 섹션 추가 (49 lines). |
| `README.ko.md` | 동일 위치에 한글 번역 추가 (49 lines). |

내용:
- **Updating**: `git pull` → `uv sync` → `uv tool install -e . --force` + 데몬 재시작 (`pgrep -f "geode serve" | xargs -r kill` → `geode serve &`).
- **Uninstalling**: daemon 정지 → `uv tool uninstall geode` → optional `~/.geode` / `~/.local/share/geode` wipe → optional clone 삭제 → `which geode` / `uv tool list | grep geode` / `pgrep -f "geode serve"` 제거 검증.

## Verification
- [x] ruff/mypy/pytest: 영향 없음 (문서만)
- [x] README.md / README.ko.md 새 섹션 위치 확인 (line 172 직전, "Other useful commands" 다음)
- [x] CHANGELOG: docs-only 라 skip ([Unreleased] 항목 추가 안 함 — 메모리 룰 "Documentation-only changes" 제외)

## Reference
- 세션 55 사용자 피드백 ("패키징 잘 되어있어?") 에서 install/update 는 검증됐지만 uninstall 문서 gap 식별.

🤖 Generated with [Claude Code](https://claude.com/claude-code)