### PR TITLE
ci: cross-OS install smoke test workflow (ubuntu + macos)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,74 @@
+name: Install Smoke Test
+
+# Cross-OS install / update / uninstall regression gate.  Runs the same
+# four phases a new contributor would hit on a fresh machine:
+#
+#   1. INSTALL   — `uv sync` + `uv tool install -e . --force`
+#   2. VERSION   — `geode version` matches pyproject.toml
+#   3. UPDATE    — `uv tool install -e . --force` is idempotent
+#   4. UNINSTALL — `uv tool uninstall geode` leaves no residue
+#
+# A failure here means the README setup steps no longer work on a clean
+# machine — block the merge and fix the install path before shipping.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-smoke:
+    name: ${{ matrix.os }} — install / update / uninstall
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --quiet
+
+      - name: 1) INSTALL — uv tool install -e .
+        run: |
+          uv tool install -e . --force
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: 2) VERSION — geode version matches pyproject.toml
+        run: |
+          expected=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          actual_full=$(geode version)
+          actual=$(printf '%s' "$actual_full" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          echo "expected=$expected"
+          echo "actual=$actual ($actual_full)"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::version mismatch — pyproject.toml=$expected vs CLI=$actual"
+            exit 1
+          fi
+
+      - name: 3) UPDATE — re-install is idempotent
+        run: |
+          uv tool install -e . --force
+          geode version
+
+      - name: 4) UNINSTALL — uv tool uninstall geode
+        run: |
+          uv tool uninstall geode
+          if command -v geode >/dev/null 2>&1; then
+            echo "::error::geode binary still on PATH after uninstall: $(command -v geode)"
+            exit 1
+          fi
+          if uv tool list | grep -q '^geode\b'; then
+            echo "::error::uv tool list still contains geode after uninstall"
+            uv tool list
+            exit 1
+          fi
+          echo "uninstall verified — no residue"


### PR DESCRIPTION
## Summary
- 새 workflow `.github/workflows/install-smoke.yml` 추가 — 매 PR / push (main + develop) 마다 ubuntu-latest + macos-latest 양쪽에서 install / update / uninstall 4단계 검증.

## Why
세션 55 에서 사용자가 "다른 머신에서도 동일하게 설치/업데이트/삭제가 되는지 어떻게 검증해?" 라고 물었고, Docker 로컬 검증 (linux/arm64 python:3.12-slim) 으로 한 번 확인했다. 이를 영구 회귀 차단하기 위한 CI ratchet. README 의 setup 절차 (PR #958 / #959 에서 docs 보강) 가 코드 변경에 의해 깨지면 매 PR 에서 즉시 잡힌다.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/install-smoke.yml` (NEW) | Job `install-smoke` (matrix: ubuntu-latest + macos-latest, fail-fast: false). Steps: checkout → setup-uv → `uv sync` → `uv tool install -e . --force` → version match assertion vs pyproject.toml → re-install (update path 멱등성) → `uv tool uninstall geode` → `which geode` / `uv tool list` 잔존 검증. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Linux install path | Implemented | matrix `ubuntu-latest` |
| macOS install path | Implemented | matrix `macos-latest` (Homebrew interaction / Apple Silicon symlink 차이 catch) |
| update idempotency | Implemented | step 3 — `uv tool install --force` 두 번째 실행 |
| uninstall residue check | Implemented | `command -v geode` + `uv tool list \| grep geode` 둘 다 검증 |
| version stamp drift | Implemented | step 2 — `pyproject.toml` 의 `version` 과 `geode version` 출력 비교, mismatch 시 `::error::` |

## Verification
- [x] YAML 구조: 1 job (install-smoke), matrix 2 OS, 5 검증 step
- [x] 로컬 Docker 사전 검증 (python:3.12-slim linux/arm64): INSTALL / UPDATE / UNINSTALL 4단계 모두 PASS, `geode v0.89.3` 확인
- [x] 기존 `ci.yml` 의 `astral-sh/setup-uv@v5` 패턴 재사용 (일관성)
- [ ] CI 첫 run 결과 확인 (이 PR 이 첫 trigger)

## Reference
- 사용자 요청 (세션 55): "Docker 로컬 검증 PASS 후 영구 회귀 차단을 위한 CI smoke-test workflow 추가" — B 안.
- 로컬 Docker 검증 결과 (참고):
  - INSTALL: `uv tool install -e . --force` → `geode v0.89.3`
  - UPDATE: `uv tool install --force` 재실행 → 동일
  - UNINSTALL: `uv tool uninstall geode` → `which geode` 비어있음, `uv tool list` 0 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)