### PR TITLE
release: petri_audit P3-a — _default_geode_runner 실 구현 + _split_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`plugins/petri_audit/targets/geode_target.py` — `_default_geode_runner`
+  실 구현 + `_split_messages` 헬퍼 (P3-a).**
+  - `_split_messages(messages) -> (system_suffix, history, last_user)`:
+    Petri 가 stage 한 메시지 시퀀스 `[system, user, (assistant, user)*]`
+    를 GEODE 의 ``AgenticLoop`` 인자로 분리. system 은 `system_suffix` 로
+    (cooperation_with_harmful_sysprompt dimension 정확도 위해), 중간
+    user/assistant 는 `ConversationContext.messages` 에, 마지막 user 는
+    `loop.run(prompt)` 인자로.
+  - `_default_geode_runner`: P2-d stub 을 실 wiring 으로 교체. lazy
+    import 로 GEODE bootstrap (`check_readiness` / `_build_tool_handlers` /
+    `ToolExecutor` / `AgenticLoop`) 호출. 매 turn fresh bootstrap (효율은
+    P3-b polish). 빈 messages 는 `ValueError` 로 fast-fail.
+  - `tests/plugins/petri_audit/test_skeleton.py`: 8 → 12 test
+    (`_split_messages` 4 cases 추가, `_default_runner_stub` 테스트 →
+    `rejects_empty_messages` 로 교체).
+  - 라이브 LLM 호출은 P3-b 에서 사용자 명시 승인 후. 본 commit 은 코드
+    + 헬퍼 unit test 까지.
+
 - **`plugins/petri_audit/` — Petri × GEODE alignment audit plugin (PoC,
   Custom Model API 접근).**
   - GEODE 자체를 `inspect_ai` 의 model provider 로 등록한다 — Petri

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -1,4 +1,4 @@
-"""GEODE Custom Model API for Petri (P2-d).
+"""GEODE Custom Model API for Petri (P3-a).
 
 Registers GEODE as an ``inspect_ai`` model provider so any Petri (or
 other ``inspect_ai``) evaluation can target it via
@@ -13,13 +13,17 @@ flow without us re-implementing the outer audit loop.
 
 Phasing:
 - P1 / P2-a / P2-b / P2-c: Custom Target factory + scaffold (replaced).
-- P2-d (this commit): switch to Custom Model API. ``GeodeModelAPI``
-  registered with ``@modelapi(name="geode")`` via ``register()``.
-  Petri's standard ``target_agent`` drives the outer audit loop; our
-  ``generate()`` is one shot.
-- P3: ``_default_geode_runner`` real implementation against
-  ``core.agent.loop.loop:AgenticLoop`` + first authorised live audit run
-  (3 seeds × 10 turns × Haiku judge, ``< 5,000 KRW`` cost gate).
+- P2-d: switch to Custom Model API. ``GeodeModelAPI`` registered with
+  ``@modelapi(name="geode")`` via ``register()``. Petri's standard
+  ``target_agent`` drives the outer audit loop; our ``generate()`` is
+  one shot.
+- P3-a (this commit): ``_default_geode_runner`` real implementation
+  against ``core.agent.loop.loop:AgenticLoop`` + ``_split_messages``
+  helper (system → ``system_suffix``, history → ``ConversationContext``,
+  last user → ``loop.run`` prompt). Live LLM call still requires user
+  authorisation; coverage limited to unit tests on the helpers.
+- P3-b: first authorised live audit run (3 seeds × 10 turns × Haiku
+  judge, ``< 5,000 KRW`` cost gate).
 
 Cold-start protection: the module-level surface (``_to_geode_messages``,
 ``_default_geode_runner``, ``GeodeRunner``) has no ``inspect_ai``
@@ -85,19 +89,111 @@ def _to_geode_messages(messages: list[Any]) -> list[dict[str, Any]]:
     return converted
 
 
+def _split_messages(
+    messages: list[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]], str]:
+    """Split GEODE-format messages into ``(system_suffix, history, last_user)``.
+
+    Petri stages a sequence ``[system, user, (assistant, user)*]`` per
+    turn. We split it so:
+
+    - The auditor's system message(s) become ``AgenticLoop.system_suffix``.
+      That places the audit-scenario sysprompt alongside GEODE's own
+      identity prompt, which is exactly what ``cooperation_with_harmful_
+      sysprompt`` is supposed to evaluate (GEODE's response to a hostile
+      sysprompt, not a raw LLM's).
+    - The user/assistant pairs prior to the final user become the
+      ``ConversationContext`` history.
+    - The final user message becomes the ``loop.run(prompt)`` argument.
+
+    Tool-result messages (which ``_to_geode_messages`` wraps as user-role
+    with a ``[{"type": "tool_result", ...}]`` content list) are passed
+    through untouched in the history slot.
+
+    Edge cases:
+    - Empty input → ``("", [], "")``.
+    - Last message non-user → it joins ``history`` and ``last_user`` is
+      blank; the caller (or AgenticLoop) decides how to handle that.
+    """
+    if not messages:
+        return "", [], ""
+
+    last = messages[-1]
+    last_role = last.get("role")
+    if last_role == "user":
+        last_content = last.get("content", "")
+        last_user = last_content if isinstance(last_content, str) else str(last_content)
+        body = messages[:-1]
+    else:
+        last_user = ""
+        body = messages
+
+    system_parts: list[str] = []
+    history: list[dict[str, Any]] = []
+    for msg in body:
+        if msg.get("role") == "system":
+            content = msg.get("content", "")
+            text = content if isinstance(content, str) else str(content)
+            if text:
+                system_parts.append(text)
+        else:
+            history.append(msg)
+
+    return "\n\n".join(system_parts).strip(), history, last_user
+
+
 async def _default_geode_runner(messages: list[dict[str, Any]]) -> str:
     """Default GEODE runner — bootstrap + ``AgenticLoop`` one-shot.
 
-    Not implemented in P2-d: live ``AgenticLoop`` bootstrap pulls in
-    ``HookSystem``, ``ToolRegistry``, and provider credentials, all of
-    which only make sense alongside the first authorised P3 audit run.
+    Imports GEODE core lazily so the module-level surface stays free of
+    GEODE-bootstrap dependencies. Each call performs a fresh bootstrap;
+    persistent ``GeodeModelAPI``-instance bootstrap is a P3-b polish.
+
+    The conversation layout is described in ``_split_messages``: the
+    auditor's system message rides on ``AgenticLoop.system_suffix``,
+    prior turns seed ``ConversationContext.messages``, and the final
+    user message is the ``loop.run`` prompt.
+
+    Live LLM authorisation: this function will trigger live API calls
+    when the bootstrapped readiness lacks ``force_dry_run``. Callers
+    embedding it in a ``geode/<base>`` audit MUST have explicit user
+    authorisation per CLAUDE.md L99.
     """
-    _ = messages  # silence unused-arg lint until P3 wires this up
-    raise NotImplementedError(
-        "_default_geode_runner is a P2-d stub; live AgenticLoop bootstrap "
-        "lands in P3 with the first authorised audit run. "
-        "See docs/plans/eval-petri-integration.md."
+    if not messages:
+        raise ValueError(
+            "Empty message history — Petri target_agent should have seeded "
+            "at least the initial user message before calling generate()."
+        )
+
+    # Lazy imports — keep the module-level surface bootstrap-free.
+    from core.agent.conversation import ConversationContext
+    from core.agent.loop import AgenticLoop
+    from core.agent.tool_executor import ToolExecutor
+    from core.cli import _build_tool_handlers, _set_readiness
+    from core.wiring.startup import check_readiness
+
+    system_text, history, last_user = _split_messages(messages)
+
+    readiness = check_readiness()
+    _set_readiness(readiness)
+    handlers = _build_tool_handlers(verbose=False)
+
+    ctx = ConversationContext()
+    ctx.messages.extend(history)
+
+    executor = ToolExecutor(action_handlers=handlers, auto_approve=True)
+    # max_rounds=4 — per-turn tool-loop cap. Petri's outer max_turns
+    # controls the whole audit length; this caps within a single turn so
+    # a runaway agent does not eat the audit budget.
+    loop = AgenticLoop(
+        ctx,
+        executor,
+        max_rounds=4,
+        system_suffix=system_text,
     )
+
+    result = loop.run(last_user)
+    return result.text or ""
 
 
 def register() -> None:

--- a/tests/plugins/petri_audit/test_skeleton.py
+++ b/tests/plugins/petri_audit/test_skeleton.py
@@ -1,13 +1,14 @@
-"""Smoke + conversion tests for the petri_audit plugin (P2-d).
+"""Smoke + conversion + split tests for the petri_audit plugin (P3-a).
 
-Tier 1 — skeleton + conversion checks that pass without the ``[audit]``
-optional extra installed. The Custom Target factory (P1..P2-c) is gone:
-Petri's standard ``target_agent`` now drives the audit loop via the
-registered ``geode/<base-model>`` ``ModelAPI``, and our ``generate()``
-is one shot.
+Skeleton + helpers checks that pass without the ``[audit]`` optional
+extra installed. The Custom Target factory (P1..P2-c) is gone: Petri's
+standard ``target_agent`` drives the audit loop via the registered
+``geode/<base-model>`` ``ModelAPI``, and our ``generate()`` is one shot.
 
-Tier 2 (live ``ModelAPI`` registration smoke with the ``[audit]`` extra
-present) is deferred to P3 alongside the first authorised audit run.
+P3-a adds ``_split_messages`` (system/history/last-user split) plus
+``_default_geode_runner`` real wiring against ``AgenticLoop``. The
+helpers are unit-tested here; the live runner is exercised in P3-b
+with explicit user authorisation.
 """
 
 from __future__ import annotations
@@ -51,6 +52,7 @@ def test_geode_target_module_imports_without_audit_extra() -> None:
 
     assert hasattr(geode_target, "register")
     assert hasattr(geode_target, "_to_geode_messages")
+    assert hasattr(geode_target, "_split_messages")
     assert hasattr(geode_target, "_default_geode_runner")
     assert hasattr(geode_target, "GeodeRunner")
 
@@ -67,11 +69,11 @@ def test_register_raises_import_error_without_audit_extra() -> None:
         register()
 
 
-def test_default_runner_is_p3_stub() -> None:
-    """Default runner is intentionally not implemented before P3."""
+def test_default_runner_rejects_empty_messages() -> None:
+    """Empty message list fails fast before any GEODE bootstrap."""
     from plugins.petri_audit.targets.geode_target import _default_geode_runner
 
-    with pytest.raises(NotImplementedError, match="P2-d stub"):
+    with pytest.raises(ValueError, match="Empty message history"):
         asyncio.run(_default_geode_runner(messages=[]))
 
 
@@ -139,3 +141,74 @@ def test_to_geode_messages_treats_missing_text_as_empty() -> None:
 
     out = _to_geode_messages([_NoText()])
     assert out == [{"role": "user", "content": ""}]
+
+
+# ---------------------------------------------------------------------------
+# Message split (P3-a — system/history/last-user)
+# ---------------------------------------------------------------------------
+
+
+def test_split_messages_extracts_system_history_and_last_user() -> None:
+    """Standard layout: system → suffix, mid turns → history, tail → prompt."""
+    from plugins.petri_audit.targets.geode_target import _split_messages
+
+    sys_text, history, last = _split_messages(
+        [
+            {"role": "system", "content": "you are a tester"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "follow up"},
+        ]
+    )
+
+    assert sys_text == "you are a tester"
+    assert history == [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    assert last == "follow up"
+
+
+def test_split_messages_empty_returns_blanks() -> None:
+    from plugins.petri_audit.targets.geode_target import _split_messages
+
+    assert _split_messages([]) == ("", [], "")
+
+
+def test_split_messages_concatenates_multiple_system_messages() -> None:
+    from plugins.petri_audit.targets.geode_target import _split_messages
+
+    sys_text, _, _ = _split_messages(
+        [
+            {"role": "system", "content": "rule 1"},
+            {"role": "system", "content": "rule 2"},
+            {"role": "user", "content": "ok"},
+        ]
+    )
+
+    assert "rule 1" in sys_text
+    assert "rule 2" in sys_text
+
+
+def test_split_messages_non_user_last_falls_into_history() -> None:
+    """If the tail is not a user message, ``last_user`` is blank.
+
+    AgenticLoop should then receive an empty prompt — caller's
+    responsibility to handle (Petri's target_agent always seeds with a
+    user message, so this branch is defensive).
+    """
+    from plugins.petri_audit.targets.geode_target import _split_messages
+
+    sys_text, history, last = _split_messages(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    )
+
+    assert sys_text == ""
+    assert last == ""
+    assert history == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]


### PR DESCRIPTION
## Summary

- `plugins/petri_audit/targets/geode_target.py` 의 `_default_geode_runner`
  를 실 wiring 으로 교체 (P2-d stub → AgenticLoop bootstrap one-shot).
- `_split_messages` 헬퍼 신규 (system → suffix / 중간 → history /
  마지막 user → prompt).
- 라이브 LLM 호출은 P3-b 별도 PR 에서 사용자 비용 승인 후.

## Verification

- [x] PR #964 CI 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)