### PR TITLE
feat(petri-audit): inspect_ai entry-point discovery 등록 (P3-b-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`pyproject.toml` `[project.entry-points.inspect_ai]` 추가 (P3-b-1).**
+  - `geode_audit = "plugins.petri_audit"` — `inspect_ai` 의 entry-point
+    discovery (`importlib.metadata.entry_points(group="inspect_ai")` +
+    `ep.load()` — `inspect_ai/_util/entrypoints.py:ensure_entry_points`)
+    가 `inspect eval` 실행 시 우리 plugin 을 자동 import → `register()`
+    자동 호출 → `GeodeModelAPI` 자동 등록.
+  - 결과: `--model-role target=geode/<base-model>` 만 지정하면 별도
+    명시 import 또는 wrapper 스크립트 없이 작동.
+
 - **`plugins/petri_audit/targets/geode_target.py` — `_default_geode_runner`
   실 구현 + `_split_messages` 헬퍼 (P3-a).**
   - `_split_messages(messages) -> (system_suffix, history, last_user)`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,17 @@ dependencies = [
 [project.scripts]
 geode = "core.cli:app"
 
+# inspect_ai discovers third-party model providers via the `inspect_ai`
+# entry-point group (importlib.metadata). When the [audit] extra is
+# installed and `inspect eval` runs, inspect_ai loads each entry-point
+# in this group (`ep.load()`) — that import triggers our
+# `plugins/petri_audit/__init__.py:register()`, which registers
+# `GeodeModelAPI` so `--model-role target=geode/<base>` resolves.
+#
+# Reference: inspect_ai/_util/entrypoints.py:ensure_entry_points
+[project.entry-points.inspect_ai]
+geode_audit = "plugins.petri_audit"
+
 [project.optional-dependencies]
 mcp = ["mcp>=1.0.0"]
 desktop = ["pyautogui>=0.9.54", "Pillow>=10.0.0"]


### PR DESCRIPTION
## Summary

- `pyproject.toml` 에 `[project.entry-points.inspect_ai]` 추가 —
  `geode_audit = "plugins.petri_audit"`. `inspect_ai` 의 entry-point
  discovery 가 `inspect eval` 실행 시 우리 plugin 을 자동 import →
  `register()` 자동 호출 → `GeodeModelAPI` 자동 등록.
- 사용자가 `--model-role target=geode/<base-model>` 만 지정하면 별도
  명시 import 또는 wrapper 스크립트 없이 작동.

## Why

P2-d / P3-a 까지 `GeodeModelAPI` 등록 함수 (`register()`) 는 만들었지만
호출자가 없으면 등록 안 됨. `inspect_ai` 의 standard discovery 패턴
(`importlib.metadata.entry_points(group="inspect_ai")` — 참조:
`inspect_ai/_util/entrypoints.py:ensure_entry_points`) 에 우리 plugin
을 등록해 user 가 `inspect eval` 한 번으로 자동 작동하게 함. P3-b-2
(라이브 audit run) 의 전제 조건.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `[project.entry-points.inspect_ai] geode_audit = "plugins.petri_audit"` 신설 |
| `CHANGELOG.md` | Unreleased 에 P3-b-1 entry 추가 |

## Verification

- [x] ruff check + ruff format --check clean
- [x] mypy core/ plugins/ — 335 source files, 0 errors
- [x] pytest tests/plugins/petri_audit/ — 12 passed
- 라이브 검증 (inspect_ai 가 실제로 우리 entry-point 를 load 하는지)
  은 P3-b-2 첫 dry-run 에서 (사용자 비용 승인 후).

## Reference

- `inspect_ai/_util/entrypoints.py:ensure_entry_points` — `entry_points(group="inspect_ai")` 호출 위치.
- Plan: `docs/plans/eval-petri-integration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)