### PR TITLE
fix(llm): provider agentic_call dual-record 제거 (codex + glm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`core/llm/providers/codex.py` + `core/llm/providers/glm.py` —
+  `agentic_call` dual-record 제거.**
+  - Provider layer 의 `get_tracker().record(...)` 호출 제거. 동일 응답이
+    agent loop 의 ``_track_usage`` (`core/agent/loop/_response.track_usage`)
+    에서도 record 되어 모든 codex / glm agentic 호출이
+    `~/.geode/usage/*.jsonl` 에 이중 기록되고 있었음.
+  - Production usage trace 영향 측정 (2026-05-09 ~ 05-10):
+    - `gpt-5.5`: **50.5 %** paired duplicates
+    - `gpt-5.3-codex`: **64 %** paired duplicates
+  - Single-record rule 명문화: `agentic_call` 경로는 agent loop 의
+    `_track_usage` 가 유일 writer. Provider `LLMClientPort.generate*`
+    (cross-LLM verification — `generate`, `generate_parsed`,
+    `generate_stream`, `generate_with_tools`) 경로는 loop 가 응답을 보지
+    않으므로 자체 `record()` 유지.
+  - `tests/test_native_tools.py::test_glm_agentic_call_defers_record_to_agent_loop`
+    가 `GlmAgenticAdapter` + `CodexAgenticAdapter` 둘 다에 대해
+    "agentic_call source must NOT contain `get_tracker`" 를 보장
+    (regression guard).
+
 ### Added
 
 - **`pyproject.toml` `[project.entry-points.inspect_ai]` 추가 (P3-b-1).**

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -371,17 +371,12 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
 
         _codex_circuit_breaker.record_success()
 
-        # Track token usage at the provider layer for the per-provider
-        # cost ledger. The agentic loop's _track_usage runs separately on
-        # the normalized AgenticResponse below; both paths read the same
-        # underlying response.usage so the numbers match.
-        if hasattr(response, "usage") and response.usage:
-            from core.llm.token_tracker import get_tracker
-
-            actual_model = used_model or model
-            in_tok = response.usage.input_tokens or 0
-            out_tok = response.usage.output_tokens or 0
-            get_tracker().record(actual_model, in_tok, out_tok)
+        # Token usage is recorded once by the agentic loop's ``_track_usage``
+        # on the normalized AgenticResponse below — recording here as well
+        # double-counted every codex call into ``~/.geode/usage/*.jsonl``
+        # (gpt-5.5: 50.5 % paired duplicates, gpt-5.3-codex: 64 %).  The
+        # agent loop reads the same ``response.usage`` so the numbers
+        # match without the second persist write.
 
         if used_model and used_model != model:
             log.warning("Model failover: %s -> %s", model, used_model)

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -243,14 +243,11 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
 
         self._circuit_breaker.record_success()
 
-        # Track token usage/cost (was missing — GLM calls were $0.00)
-        if hasattr(response, "usage") and response.usage:
-            from core.llm.token_tracker import get_tracker
-
-            actual_model = used_model or model
-            in_tok = response.usage.prompt_tokens or 0
-            out_tok = response.usage.completion_tokens or 0
-            get_tracker().record(actual_model, in_tok, out_tok)
+        # Token usage is recorded once by the agentic loop's ``_track_usage``
+        # on the normalized AgenticResponse below — recording here as well
+        # would double-count every GLM call into ``~/.geode/usage/*.jsonl``
+        # (matches the codex.py fix; agent loop reads the same
+        # ``response.usage`` so the numbers match without a second persist).
 
         if used_model and used_model != model:
             log.warning("Model failover: %s -> %s", model, used_model)

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -228,15 +228,33 @@ class TestGlmNativeWebSearch:
         # And it should be different from the parent
         assert GlmAgenticAdapter.agentic_call is not OpenAIAgenticAdapter.agentic_call
 
-    def test_glm_agentic_call_tracks_cost(self) -> None:
-        """GlmAgenticAdapter.agentic_call must call get_tracker().record()."""
+    def test_glm_agentic_call_defers_record_to_agent_loop(self) -> None:
+        """GlmAgenticAdapter.agentic_call must NOT call ``get_tracker().record()``.
+
+        The agent loop's ``_track_usage`` records on the normalized
+        ``AgenticResponse`` returned below — recording at the provider
+        layer too caused every GLM / Codex / OpenAI agentic call to
+        double-count into ``~/.geode/usage/*.jsonl`` (gpt-5.5 saw
+        50.5 % paired duplicates, gpt-5.3-codex 64 %).  Single-record
+        rule: the agent loop is the sole writer for ``agentic_call``
+        invocations; provider ``LLMClientPort.generate*`` paths
+        (cross-LLM verification) keep their own record() because the
+        loop never sees those responses.
+        """
         import inspect
 
+        from core.llm.providers.codex import CodexAgenticAdapter
         from core.llm.providers.glm import GlmAgenticAdapter
 
-        source = inspect.getsource(GlmAgenticAdapter.agentic_call)
-        assert "get_tracker" in source, "GLM agentic_call must call get_tracker().record()"
-        assert ".record(" in source, "GLM agentic_call must record token usage"
+        for adapter_cls, name in (
+            (GlmAgenticAdapter, "GLM"),
+            (CodexAgenticAdapter, "Codex"),
+        ):
+            source = inspect.getsource(adapter_cls.agentic_call)
+            assert "get_tracker" not in source, (
+                f"{name} agentic_call must defer record() to agent loop's "
+                f"_track_usage to avoid double-counting"
+            )
 
     def test_glm_cost_is_nonzero(self) -> None:
         """GLM models with non-free pricing must produce non-zero cost."""


### PR DESCRIPTION
## Summary
- `core/llm/providers/codex.py` + `core/llm/providers/glm.py` 의 `agentic_call` 에서 provider-layer `get_tracker().record(...)` 호출 제거.
- Agent loop `_track_usage` 가 동일 응답을 한 번 더 기록하여 모든 codex / glm agentic 호출이 `~/.geode/usage/*.jsonl` 에 이중 기록되던 버그 해결.
- regression guard: `tests/test_native_tools.py::test_glm_agentic_call_defers_record_to_agent_loop` 를 GLM + Codex 둘 다 커버하도록 반전.

## Why
Production usage trace (2026-05-09 ~ 05-10) 에서 paired duplicate 비율 측정:

| Model | Paired Duplicates |
|-------|-------------------|
| `gpt-5.5` | **50.5 %** |
| `gpt-5.3-codex` | **64 %** |

Provider layer 와 agent loop `_track_usage` 가 동일 `response.usage` 를 각각 record 하면서 cost ledger / `total_cost_usd` / cost-limit hook 이 모두 부풀려짐. v0.53.1 에서 codex 가 `normalize_openai_responses` 로 표준 `AgenticResponse` 를 반환하도록 통일된 이후 `_track_usage` 와 provider record 가 동시에 동작하면서 발생한 회귀.

**Single-record rule** 명문화:
- `agentic_call` 경로 → agent loop `_track_usage` 가 **유일** writer
- `LLMClientPort.generate*` (`generate`, `generate_parsed`, `generate_stream`, `generate_with_tools`) — cross-LLM verification 경로. agent loop 가 응답을 보지 않으므로 기존 자체 `record()` 유지.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/codex.py` | `agentic_call` 의 `get_tracker().record(...)` 블록 제거 + 사유 주석 |
| `core/llm/providers/glm.py` | 동일 (codex.py fix 와 짝) |
| `tests/test_native_tools.py` | `test_glm_agentic_call_tracks_cost` → `test_glm_agentic_call_defers_record_to_agent_loop` 로 반전. `GlmAgenticAdapter` + `CodexAgenticAdapter` 둘 다에 대해 source 에 `get_tracker` 가 **없어야** 함을 검증. |
| `CHANGELOG.md` | `[Unreleased] / Fixed` 항목 추가 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Parent `OpenAIAgenticAdapter.agentic_call` (line 479+) dual-record | Verified clean | record() 4곳 (line 136/199/241/292) 모두 `generate*` 경로에 위치 |
| `_track_usage` ↔ codex/glm normalize 호환 | Verified | `normalize_openai` / `normalize_openai_responses` 모두 `ResponseUsage(input_tokens, output_tokens)` 반환 — `_response.track_usage` 가 읽는 attribute 와 일치 |
| Inline `test_glm_cost_is_nonzero` 영향 | None | pricing-only 검증, record() 제거와 무관 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed!
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 335 source files
- [x] `uv run pytest tests/test_native_tools.py tests/test_provider_parity_v0532.py tests/test_codex_multiturn_reasoning.py tests/test_provider_switching.py tests/test_llm_resilience.py tests/test_codex_normalize_parity.py tests/test_cost_command.py tests/test_codex_request_shape.py tests/test_status.py tests/test_llm_client.py tests/test_reasoning_metrics.py tests/test_glm_thinking_r2.py tests/test_agentic_loop.py tests/test_usage_store.py tests/test_codex_responses_shape.py tests/test_project_journal.py tests/test_autonomous_safety.py tests/test_compact_clear.py tests/test_ipc_output_parity.py tests/test_codex_provider.py tests/test_agentic_ui.py -m "not live"` — 450+ pass (full suite gated by CI)
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4) unchanged

## Reference
- Production usage trace 2026-05-09 ~ 05-10 (`~/.geode/usage/*.jsonl`)
- v0.53.1 codex normalize parity (`core/llm/providers/codex.py:384-394` 주석)
- Single-record rule docstring: `core/llm/token_tracker.py:3`