### PR TITLE
release: dual-record-fix (codex + glm agentic_call)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`core/llm/providers/codex.py` + `core/llm/providers/glm.py` —
+  `agentic_call` dual-record 제거.**
+  - Provider layer 의 `get_tracker().record(...)` 호출 제거. 동일 응답이
+    agent loop 의 ``_track_usage`` (`core/agent/loop/_response.track_usage`)
+    에서도 record 되어 모든 codex / glm agentic 호출이
+    `~/.geode/usage/*.jsonl` 에 이중 기록되고 있었음.
+  - Production usage trace 영향 측정 (2026-05-09 ~ 05-10):
+    - `gpt-5.5`: **50.5 %** paired duplicates
+    - `gpt-5.3-codex`: **64 %** paired duplicates
+  - Single-record rule 명문화: `agentic_call` 경로는 agent loop 의
+    `_track_usage` 가 유일 writer. Provider `LLMClientPort.generate*`
+    (cross-LLM verification — `generate`, `generate_parsed`,
+    `generate_stream`, `generate_with_tools`) 경로는 loop 가 응답을 보지
+    않으므로 자체 `record()` 유지.
+  - `tests/test_native_tools.py::test_glm_agentic_call_defers_record_to_agent_loop`
+    가 `GlmAgenticAdapter` + `CodexAgenticAdapter` 둘 다에 대해
+    "agentic_call source must NOT contain `get_tracker`" 를 보장
+    (regression guard).
+
 ### Added
 
 - **`pyproject.toml` `[project.entry-points.inspect_ai]` 추가 (P3-b-1).**

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -371,17 +371,12 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
 
         _codex_circuit_breaker.record_success()
 
-        # Track token usage at the provider layer for the per-provider
-        # cost ledger. The agentic loop's _track_usage runs separately on
-        # the normalized AgenticResponse below; both paths read the same
-        # underlying response.usage so the numbers match.
-        if hasattr(response, "usage") and response.usage:
-            from core.llm.token_tracker import get_tracker
-
-            actual_model = used_model or model
-            in_tok = response.usage.input_tokens or 0
-            out_tok = response.usage.output_tokens or 0
-            get_tracker().record(actual_model, in_tok, out_tok)
+        # Token usage is recorded once by the agentic loop's ``_track_usage``
+        # on the normalized AgenticResponse below — recording here as well
+        # double-counted every codex call into ``~/.geode/usage/*.jsonl``
+        # (gpt-5.5: 50.5 % paired duplicates, gpt-5.3-codex: 64 %).  The
+        # agent loop reads the same ``response.usage`` so the numbers
+        # match without the second persist write.
 
         if used_model and used_model != model:
             log.warning("Model failover: %s -> %s", model, used_model)

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -243,14 +243,11 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
 
         self._circuit_breaker.record_success()
 
-        # Track token usage/cost (was missing — GLM calls were $0.00)
-        if hasattr(response, "usage") and response.usage:
-            from core.llm.token_tracker import get_tracker
-
-            actual_model = used_model or model
-            in_tok = response.usage.prompt_tokens or 0
-            out_tok = response.usage.completion_tokens or 0
-            get_tracker().record(actual_model, in_tok, out_tok)
+        # Token usage is recorded once by the agentic loop's ``_track_usage``
+        # on the normalized AgenticResponse below — recording here as well
+        # would double-count every GLM call into ``~/.geode/usage/*.jsonl``
+        # (matches the codex.py fix; agent loop reads the same
+        # ``response.usage`` so the numbers match without a second persist).
 
         if used_model and used_model != model:
             log.warning("Model failover: %s -> %s", model, used_model)

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -228,15 +228,33 @@ class TestGlmNativeWebSearch:
         # And it should be different from the parent
         assert GlmAgenticAdapter.agentic_call is not OpenAIAgenticAdapter.agentic_call
 
-    def test_glm_agentic_call_tracks_cost(self) -> None:
-        """GlmAgenticAdapter.agentic_call must call get_tracker().record()."""
+    def test_glm_agentic_call_defers_record_to_agent_loop(self) -> None:
+        """GlmAgenticAdapter.agentic_call must NOT call ``get_tracker().record()``.
+
+        The agent loop's ``_track_usage`` records on the normalized
+        ``AgenticResponse`` returned below — recording at the provider
+        layer too caused every GLM / Codex / OpenAI agentic call to
+        double-count into ``~/.geode/usage/*.jsonl`` (gpt-5.5 saw
+        50.5 % paired duplicates, gpt-5.3-codex 64 %).  Single-record
+        rule: the agent loop is the sole writer for ``agentic_call``
+        invocations; provider ``LLMClientPort.generate*`` paths
+        (cross-LLM verification) keep their own record() because the
+        loop never sees those responses.
+        """
         import inspect
 
+        from core.llm.providers.codex import CodexAgenticAdapter
         from core.llm.providers.glm import GlmAgenticAdapter
 
-        source = inspect.getsource(GlmAgenticAdapter.agentic_call)
-        assert "get_tracker" in source, "GLM agentic_call must call get_tracker().record()"
-        assert ".record(" in source, "GLM agentic_call must record token usage"
+        for adapter_cls, name in (
+            (GlmAgenticAdapter, "GLM"),
+            (CodexAgenticAdapter, "Codex"),
+        ):
+            source = inspect.getsource(adapter_cls.agentic_call)
+            assert "get_tracker" not in source, (
+                f"{name} agentic_call must defer record() to agent loop's "
+                f"_track_usage to avoid double-counting"
+            )
 
     def test_glm_cost_is_nonzero(self) -> None:
         """GLM models with non-free pricing must produce non-zero cost."""


### PR DESCRIPTION
## Summary
- `feature/dual-record-fix` (#968) 머지본을 main 으로 sync.
- codex / glm `agentic_call` 의 provider-layer `get_tracker().record(...)` 제거 — agent loop `_track_usage` 와 중복되어 발생하던 cost ledger 이중 기록 (gpt-5.5 50.5 % / gpt-5.3-codex 64 % paired duplicates) 해결.

## Verification
- [x] PR #968 CI 7/7 pass (Lint, Type, Test, Security, macos install, ubuntu install, Gate)
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` clean (335 files)
- [x] `uv run geode analyze "Cowboy Bebop" --dry-run` — A (68.4) unchanged
- [x] regression guard: `tests/test_native_tools.py::test_glm_agentic_call_defers_record_to_agent_loop` 가 `GlmAgenticAdapter` + `CodexAgenticAdapter` 둘 다 cover