### PR TITLE
release: anthropic SDK floor 0.84 → 0.96

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "anthropic>=0.84.0",
+    "anthropic>=0.96.0",
     "beautifulsoup4>=4.12.0",
     "markdownify>=0.14.1",
     "httpx>=0.27.0",

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.84.0"
+version = "0.100.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -221,9 +221,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
 ]
 
 [[package]]
@@ -898,7 +898,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.84.0" },
+    { name = "anthropic", specifier = ">=0.96.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "inspect-ai", marker = "extra == 'audit'", specifier = ">=0.3.211" },
@@ -4015,7 +4015,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- `feature/anthropic-bump-096` (#970) 머지본을 main 으로 sync.
- `pyproject.toml`: `anthropic>=0.84.0` → `>=0.96.0` 으로 minimum floor 상향.
- `uv.lock`: 실제 해결 버전 **0.100.0** (`>=0.96` spec 만족).
- 부수 변경: `zipfile-zstd` 의 `zstandard` 의존을 `python_full_version < '3.14'` marker 로 한정 (lock 재해결 산출).

## Verification
- [x] PR #970 CI 7/7 pass (Lint, Type, Test, Security, macos install, ubuntu install, Gate)
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` clean (335 files)
- [x] `uv run pytest` — 4342 passed, 1 skipped, 24 deselected (test count 4343 ≥ 2900 ratchet)
- [x] `uv run deptry .` clean / `uv run bandit -r core/` 0 issues
- [x] legacy-import ratchet + repo-hygiene ratchet pass
- [x] anthropic 사용 타입 (`Message`, `TextBlock`, `ToolUseBlock`, `MessageStream`) 0.100 호환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)