### PR TITLE
release: petri-audit 3-way trigger + judge/auditor/target 모델 선택 (P3-b-2 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,39 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Petri audit 3-way trigger + judge/auditor/target 모델 선택 (P3-b-2 prep).**
+  - `plugins/petri_audit/runner.py` — 단일 진입 함수 `run_audit(...)` 가
+    `inspect eval inspect_petri/audit` subprocess 를 호출. dry-run /
+    live / confirm / cost-estimate / `inspect` 부재 감지 가드를 한 자리에.
+  - `plugins/petri_audit/models.py` — GEODE catalog (`MODEL_PRICING`)
+    → `inspect_ai` `provider/model` 매핑. `claude-* → anthropic/...`,
+    `gpt-*/o3/o4-mini → openai/...`, `glm-* → geode/...` (우리 등록한
+    `GeodeModelAPI` 통해 routing). `/` 가 포함되면 raw passthrough.
+    target 은 항상 `geode/<base>` 로 wrap (audit 의 본질이 GEODE-as-a-
+    system 평가이므로).
+  - **3 진입점**:
+    - Typer `geode audit --judge sonnet-4-6 --auditor opus-4-7 --target
+      claude-opus-4-7 --seeds N --max-turns M --tags <tag> [--live]
+      [--yes]` (default `--dry-run`).
+    - Slash `/audit ...` (REPL THIN — `argparse` 기반 동일 인자 체계,
+      `core/cli/routing.py` `COMMAND_REGISTRY`, `core/cli/commands/_state.py
+      :COMMAND_MAP` 양쪽 등록).
+    - Tool `petri_audit` (`core/tools/definitions.json` +
+      `core/cli/tool_handlers/audit.py`) — 자연어 → `AgenticLoop` 자동
+      라우팅. `core/agent/safety.py:EXPENSIVE_TOOLS` 등록으로 live 호출
+      시 HITL `confirm_cost` 게이트 자동 발동.
+  - Cost estimate: per-turn 토큰 가정 (auditor 2K/0.8K, target 1.5K/0.6K
+    × `geode_amplifier=5`, judge 4K/0.2K × 0.5/turn) × `seeds × max_turns`,
+    `MODEL_PRICING` 단가 적용. USD + KRW (1 USD = 1,400 KRW 고정) 동시
+    표시. unknown model → NaN → "unavailable" sentinel.
+  - 라이브 첫 audit run (P3-b-2) 은 본 PR 범위 밖 — 사용자 비용 승인 후
+    별도 세션. 본 PR 자체는 default `dry_run=True` 라 머지만으로는 비용
+    발생 X.
+  - `tests/plugins/petri_audit/` 4 신규 파일 (`test_models`,
+    `test_runner`, `test_cli_audit`, `test_tool_handler`) — 매핑 / cost
+    estimate / build_command / dry-run / subprocess mock / abort /
+    EXPENSIVE_TOOLS 등록 / definitions.json 동기화 24+ 케이스.
+
 - **`pyproject.toml` `[project.entry-points.inspect_ai]` 추가 (P3-b-1).**
   - `geode_audit = "plugins.petri_audit"` — `inspect_ai` 의 entry-point
     discovery (`importlib.metadata.entry_points(group="inspect_ai")` +

--- a/core/agent/safety.py
+++ b/core/agent/safety.py
@@ -61,6 +61,10 @@ EXPENSIVE_TOOLS: dict[str, float] = {
     "analyze_ip": 1.50,
     "batch_analyze": 5.00,
     "compare_ips": 3.00,
+    # Petri audit — conservative ceiling. Real estimate is rendered by
+    # ``plugins.petri_audit.runner.estimate_cost_usd`` and shown next to
+    # the [Y/n] prompt; this number only needs to flip the gate on.
+    "petri_audit": 5.00,
 }
 
 # Bash commands starting with these prefixes are safe (read-only, no side effects).

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any
 
 import typer
+from plugins.petri_audit.cli_audit import audit
 
 from core import __version__
 
@@ -356,6 +357,7 @@ app.command()(batch)
 app.command()(init)
 app.command()(history)
 app.command()(serve)
+app.command()(audit)
 
 
 @app.callback()

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -122,6 +122,7 @@ COMMAND_MAP: dict[str, str] = {
     "/tasks": "tasks",
     "/task": "tasks",
     "/t": "tasks",
+    "/audit": "audit",
 }
 
 

--- a/core/cli/dispatcher.py
+++ b/core/cli/dispatcher.py
@@ -250,6 +250,10 @@ def _handle_command(
         from core.cli.commands import cmd_tasks
 
         cmd_tasks(args)
+    elif action == "audit":
+        from plugins.petri_audit.cli_audit import cmd_audit_slash
+
+        cmd_audit_slash(args)
     elif action == "stop":
         # v0.63.0 — Hermes-style daemon shutdown (`hermes stop`).
         # Args: ``/stop --force`` for SIGKILL, optional ``--timeout=N``.

--- a/core/cli/routing.py
+++ b/core/cli/routing.py
@@ -103,6 +103,12 @@ COMMAND_REGISTRY: dict[str, CommandSpec] = {
         handler_path="core.cli.commands:cmd_model",
         needs_tty=True,
     ),
+    "/audit": CommandSpec(
+        name="/audit",
+        location=RunLocation.THIN,
+        description="Petri × GEODE alignment audit — choose judge/auditor/target",
+        handler_path="plugins.petri_audit.cli_audit:cmd_audit_slash",
+    ),
     # ────────── DAEMON_RPC — short read-only daemon queries ──────────
     # Phase 4에서 core/server/handlers/ 로 이동 후 handler_path 갱신.
     # 현재는 cli/__init__.py:_handle_command 가 IPC RPC로 위임 (호환).

--- a/core/cli/tool_handlers/__init__.py
+++ b/core/cli/tool_handlers/__init__.py
@@ -38,6 +38,7 @@ from core.cli.tool_handlers._helpers import (
     _safe_delegate,
     install_domain_tool_handlers,
 )
+from core.cli.tool_handlers.audit import _build_audit_handlers
 from core.cli.tool_handlers.calendar import _build_calendar_handlers
 from core.cli.tool_handlers.computer_use import _build_computer_use_handler
 from core.cli.tool_handlers.context import _build_context_handlers
@@ -59,6 +60,7 @@ from core.cli.tool_handlers.task import _build_task_handlers
 __all__ = [
     "_DELEGATED_TOOLS",
     "_PLAN_STORE",
+    "_build_audit_handlers",
     "_build_calendar_handlers",
     "_build_computer_use_handler",
     "_build_context_handlers",
@@ -142,6 +144,7 @@ def _build_tool_handlers(
     handlers.update(_build_task_handlers())
     handlers.update(_build_offload_handlers())
     handlers.update(_build_computer_use_handler())
+    handlers.update(_build_audit_handlers())
     # Domain-supplied handlers (analysis + signals + generate_data for
     # game_ip; empty for non-pipeline domains).
     install_domain_tool_handlers(handlers)

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -1,0 +1,57 @@
+"""Tool handler for ``petri_audit`` — natural-language entry point.
+
+Mirrors the ``execution.py`` factory pattern. The handler funnels into
+``plugins.petri_audit.runner.run_audit`` so the slash and Typer paths
+stay in lockstep with the AgenticLoop tool path.
+
+Cost gating: ``petri_audit`` is registered in
+``core/agent/safety.py:EXPENSIVE_TOOLS`` so every dispatch passes
+through ``apply_safety_gates`` first; this handler only runs after the
+user has consented.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _build_audit_handlers() -> dict[str, Any]:
+    """Build petri_audit -> handler mapping for ToolExecutor."""
+    from plugins.petri_audit.runner import run_audit
+
+    def handle_petri_audit(**kwargs: Any) -> dict[str, Any]:
+        judge = kwargs.get("judge") or "claude-haiku-4-5-20251001"
+        auditor = kwargs.get("auditor") or "claude-sonnet-4-6"
+        target = kwargs.get("target") or "claude-opus-4-7"
+        seeds = int(kwargs.get("seeds") or 1)
+        max_turns = int(kwargs.get("max_turns") or 5)
+        tags = kwargs.get("tags") or None
+        cache = bool(kwargs.get("cache", True))
+        dry_run = bool(kwargs.get("dry_run", True))
+        confirm = bool(kwargs.get("confirm", False))
+
+        try:
+            report = run_audit(
+                judge=judge,
+                auditor=auditor,
+                target=target,
+                seeds=seeds,
+                max_turns=max_turns,
+                tags=tags,
+                cache=cache,
+                dry_run=dry_run,
+                # dry_run never spends — auto-skip the runner-level confirm.
+                # live runs honour ``confirm`` so the AgenticLoop tool can
+                # decline a second prompt after the EXPENSIVE_TOOLS gate.
+                yes=confirm or dry_run,
+            )
+        except Exception as exc:
+            return {"status": "error", "error": str(exc), "tool": "petri_audit"}
+
+        return {
+            "status": "ok",
+            "tool": "petri_audit",
+            "audit": report.to_dict(),
+        }
+
+    return {"petri_audit": handle_petri_audit}

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -25,6 +25,11 @@ VALID_CATEGORIES = frozenset(
         "notification",
         "calendar",
         "task",
+        # Petri × GEODE alignment audit (`petri_audit` tool). Distinct
+        # from `analysis` because the audit harness evaluates GEODE
+        # itself (auditor → target → judge) rather than a domain
+        # subject like an IP.
+        "evaluation",
     }
 )
 

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -1398,5 +1398,53 @@
         "task_id"
       ]
     }
+  },
+  {
+    "name": "petri_audit",
+    "description": "Petri × GEODE alignment audit. Use when the user asks to run an audit, '감사', 'Petri', 'alignment audit', or wants to test GEODE for sycophancy / self-preservation / harmful-sysprompt cooperation / whistleblowing dimensions. Choose judge / auditor / target models from the GEODE catalog (claude-*, gpt-*, o3, o4-mini, glm-*). Default dry_run=true prints the constructed `inspect eval` command without spending. Set dry_run=false to actually invoke `inspect eval inspect_petri/audit` (paid LLM calls — auditor + target × geode_amplifier + judge per turn). Set confirm=true only after the user explicitly authorises the cost.",
+    "category": "evaluation",
+    "cost_tier": "expensive",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "judge": {
+          "type": "string",
+          "description": "Judge model — GEODE id (e.g. claude-haiku-4-5-20251001, claude-sonnet-4-6, gpt-5.4-mini, glm-5). Default haiku for cost."
+        },
+        "auditor": {
+          "type": "string",
+          "description": "Auditor model — GEODE id (e.g. claude-sonnet-4-6, gpt-5.4)."
+        },
+        "target": {
+          "type": "string",
+          "description": "Target base model — GEODE id, auto-wrapped as geode/<model> so the audit exercises GEODE's whole stack. e.g. claude-opus-4-7."
+        },
+        "seeds": {
+          "type": "integer",
+          "description": "Sample count (--limit). Start with 1 for a smoke test, escalate to 3-10 with explicit cost approval."
+        },
+        "max_turns": {
+          "type": "integer",
+          "description": "Petri max_turns. Default 5. Lower = cheaper; 10 is the canonical alignment-audit setting."
+        },
+        "tags": {
+          "type": "string",
+          "description": "Petri seed_instructions tag filter (e.g. sycophancy, self_preservation). Omit for the default seed mix."
+        },
+        "cache": {
+          "type": "boolean",
+          "description": "Petri 3.0.6 cache parameter. Default true (30-70% cost reduction on shared prefixes)."
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "MUST be true unless the user has explicitly authorised the live audit cost. Default true."
+        },
+        "confirm": {
+          "type": "boolean",
+          "description": "Skip the cost-confirmation prompt. Set true only when the user has confirmed cost in the same turn (e.g. '5K KRW까지 OK')."
+        }
+      },
+      "required": []
+    }
   }
 ]

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -1,0 +1,143 @@
+"""Typer + slash entry points for the Petri audit runner.
+
+Both ``geode audit`` (Typer subcommand registered from
+``core/cli/__init__.py``) and ``/audit`` (slash command registered in
+``core/cli/routing.py``) call ``runner.run_audit`` and render the
+``AuditReport`` through :func:`_render_report` so the two paths stay
+in lockstep on output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+
+import typer
+from core.ui.console import console
+
+from plugins.petri_audit.runner import AuditReport, format_cost, run_audit
+
+__all__ = ["audit", "cmd_audit_slash"]
+
+
+def _render_report(report: AuditReport) -> None:
+    """Print the constructed command + estimated cost + run outcome."""
+    cost_label, _ = format_cost(report.estimated_usd)
+    console.print()
+    console.print("  [header]Petri audit[/header]")
+    console.print(f"  command:  [dim]{' '.join(report.command)}[/dim]")
+    console.print(f"  estimate: {cost_label}")
+    if report.dry_run:
+        console.print("  status:   [yellow]dry-run — subprocess not executed[/yellow]")
+    elif report.aborted:
+        notes = "; ".join(report.notes) if report.notes else "aborted"
+        console.print(f"  status:   [red]aborted[/red] ({notes})")
+    elif report.returncode == 0:
+        console.print("  status:   [green]ok[/green]")
+        if report.stdout:
+            console.print(report.stdout)
+    else:
+        console.print(f"  status:   [red]failed (rc={report.returncode})[/red]")
+        if report.stderr:
+            console.print(f"[red]{report.stderr}[/red]")
+    console.print()
+
+
+def audit(
+    judge: str = typer.Option(
+        "claude-haiku-4-5-20251001",
+        "--judge",
+        "-j",
+        help="Judge model (GEODE id, e.g. claude-sonnet-4-6, gpt-5.4-mini, glm-5).",
+    ),
+    auditor: str = typer.Option(
+        "claude-sonnet-4-6",
+        "--auditor",
+        "-a",
+        help="Auditor model (GEODE id).",
+    ),
+    target: str = typer.Option(
+        "claude-opus-4-7",
+        "--target",
+        "-t",
+        help="Target base model. Always wrapped as geode/<model> so the audit "
+        "exercises GEODE's whole stack.",
+    ),
+    seeds: int = typer.Option(1, "--seeds", "-s", help="Sample count (--limit)."),
+    max_turns: int = typer.Option(5, "--max-turns", "-m", help="Petri max_turns."),
+    tags: str = typer.Option(
+        None,
+        "--tags",
+        help="Petri seed_instructions tags filter (e.g. sycophancy).",
+    ),
+    cache: bool = typer.Option(True, "--cache/--no-cache", help="Petri cache parameter."),
+    dry_run: bool = typer.Option(
+        True,
+        "--dry-run/--live",
+        help="Default: print the constructed command without spending. "
+        "Pass --live to actually invoke `inspect eval`.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirm prompt before a live run.",
+    ),
+) -> None:
+    """Petri × GEODE alignment audit (P3-b-2 prep)."""
+    report = run_audit(
+        judge=judge,
+        auditor=auditor,
+        target=target,
+        seeds=seeds,
+        max_turns=max_turns,
+        tags=tags or None,
+        cache=cache,
+        dry_run=dry_run,
+        yes=yes,
+    )
+    _render_report(report)
+
+
+def _build_slash_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="/audit", add_help=False, allow_abbrev=False)
+    parser.add_argument("--judge", "-j", default="claude-haiku-4-5-20251001")
+    parser.add_argument("--auditor", "-a", default="claude-sonnet-4-6")
+    parser.add_argument("--target", "-t", default="claude-opus-4-7")
+    parser.add_argument("--seeds", "-s", type=int, default=1)
+    parser.add_argument("--max-turns", "-m", type=int, default=5, dest="max_turns")
+    parser.add_argument("--tags", default=None)
+    parser.add_argument("--no-cache", action="store_false", dest="cache", default=True)
+    parser.add_argument("--live", action="store_false", dest="dry_run", default=True)
+    parser.add_argument("--dry-run", action="store_true", dest="dry_run")
+    parser.add_argument("--yes", "-y", action="store_true", default=False)
+    parser.add_argument("--help", "-h", action="store_true", default=False)
+    return parser
+
+
+def cmd_audit_slash(args: str) -> None:
+    """Handle ``/audit`` slash command. ``args`` is the raw post-slash string."""
+    parser = _build_slash_parser()
+    try:
+        ns = parser.parse_args(shlex.split(args)) if args else parser.parse_args([])
+    except SystemExit:
+        # argparse calls sys.exit on parse error; intercept so the REPL stays alive.
+        console.print("  [red]invalid /audit arguments — see /help[/red]")
+        return
+
+    if ns.help:
+        console.print(parser.format_help())
+        return
+
+    report = run_audit(
+        judge=ns.judge,
+        auditor=ns.auditor,
+        target=ns.target,
+        seeds=ns.seeds,
+        max_turns=ns.max_turns,
+        tags=ns.tags or None,
+        cache=ns.cache,
+        dry_run=ns.dry_run,
+        yes=ns.yes,
+    )
+    _render_report(report)

--- a/plugins/petri_audit/models.py
+++ b/plugins/petri_audit/models.py
@@ -1,0 +1,95 @@
+"""Model identifier mapping for Petri audit (P3-b-2 prep).
+
+Bridges between GEODE's internal model IDs (``MODEL_PRICING`` keys in
+``core/llm/token_tracker.py``) and ``inspect_ai``'s ``provider/model``
+identifier convention. Used by ``runner.run_audit`` to translate user
+input (``--judge sonnet-4-6``) into the form ``inspect eval`` expects
+(``--model-role judge=anthropic/claude-sonnet-4-6``).
+
+Mapping policy:
+
+- Raw passthrough — input contains ``/`` → returned untouched.
+  Escape hatch for ``openai-api/...``, ``anthropic/...:tier`` etc.
+- ``claude-*``                → ``anthropic/<model>``      (inspect_ai native)
+- ``gpt-*``, ``o3``, ``o4-mini`` → ``openai/<model>``       (inspect_ai native)
+- ``glm-*``                  → ``geode/<model>``           (routed through our
+  registered ``GeodeModelAPI`` because inspect_ai has no native GLM provider).
+- target role                → ``geode/<model>`` regardless of family. The
+  whole point of the audit is GEODE-as-a-system, so the target is always
+  routed through ``GeodeModelAPI``; the user only chooses the *base* LLM.
+"""
+
+from __future__ import annotations
+
+from core.llm.token_tracker import MODEL_PRICING
+
+__all__ = [
+    "AuditModelMappingError",
+    "list_audit_models",
+    "to_inspect_model",
+    "to_inspect_target",
+]
+
+
+class AuditModelMappingError(ValueError):
+    """Raised when a model id cannot be mapped to an ``inspect_ai`` identifier."""
+
+
+def to_inspect_model(geode_id: str) -> str:
+    """Map a GEODE model id to an ``inspect_ai`` ``provider/model`` identifier.
+
+    Used for the ``auditor`` and ``judge`` Petri model-roles. The ``target``
+    role uses :func:`to_inspect_target` instead because target is always
+    routed through ``geode/...``.
+
+    Raw passthrough: any string containing ``/`` is returned untouched —
+    callers can pass ``anthropic/claude-haiku-4-5-20251001`` or
+    ``openai-api/glm/glm-5.1`` directly when the alias rules don't fit.
+    """
+    if not geode_id:
+        raise AuditModelMappingError("Empty model id")
+    if "/" in geode_id:
+        return geode_id
+    if geode_id.startswith("claude-"):
+        return f"anthropic/{geode_id}"
+    if geode_id.startswith("gpt-") or geode_id in ("o3", "o4-mini"):
+        return f"openai/{geode_id}"
+    if geode_id.startswith("glm-"):
+        return f"geode/{geode_id}"
+    raise AuditModelMappingError(
+        f"Unknown model id {geode_id!r}. Use a MODEL_PRICING key (claude-*, "
+        f"gpt-*, o3, o4-mini, glm-*) or a raw 'provider/model' string."
+    )
+
+
+def to_inspect_target(geode_id: str) -> str:
+    """Map a GEODE model id to a ``geode/<model>`` target identifier.
+
+    Auto-prefixes ``geode/`` unless the input already contains ``/`` (raw
+    passthrough). The Petri audit always routes the target through our
+    registered ``GeodeModelAPI`` so the *whole* GEODE stack — agentic loop,
+    tools, hooks, memory — is what gets evaluated; the user only picks the
+    base LLM that GEODE will use internally for the run.
+    """
+    if not geode_id:
+        raise AuditModelMappingError("Empty target model id")
+    if "/" in geode_id:
+        return geode_id
+    return f"geode/{geode_id}"
+
+
+def list_audit_models() -> list[tuple[str, str]]:
+    """Return ``(geode_id, inspect_id)`` pairs for every catalog model.
+
+    Powers ``--help`` output and the tool description. Catalog source is
+    ``MODEL_PRICING`` so adding a model in ``token_tracker.py`` auto-flows
+    here. Skips models whose family the mapping rules don't recognise
+    (defensive — should be empty in practice).
+    """
+    pairs: list[tuple[str, str]] = []
+    for geode_id in MODEL_PRICING:
+        try:
+            pairs.append((geode_id, to_inspect_model(geode_id)))
+        except AuditModelMappingError:
+            continue
+    return pairs

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -1,0 +1,296 @@
+"""Petri audit runner — single entry point for CLI / slash / tool paths.
+
+Wraps the ``inspect eval inspect_petri/audit`` subprocess so the three
+GEODE entry points (``geode audit`` Typer command, ``/audit`` slash,
+``petri_audit`` tool) all funnel through one cost-estimating, confirm-
+gating function.
+
+Live LLM authorisation: ``run_audit`` triggers paid LLM calls when
+``dry_run`` is False. Default behaviour is ``dry_run=True`` so the
+common case (CLI inspection, tests, NL exploration) prints the
+constructed command without spending. Set ``yes=True`` to skip the
+confirm prompt — meant for the EXPENSIVE_TOOLS-gated tool path where
+the safety gate has already received user consent.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.llm.token_tracker import MODEL_PRICING
+
+from plugins.petri_audit.models import to_inspect_model, to_inspect_target
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "AuditReport",
+    "TokenAssumptions",
+    "build_command",
+    "confirm_or_abort",
+    "estimate_cost_usd",
+    "format_cost",
+    "run_audit",
+]
+
+#: PoC FX rate. Real-time conversion is overkill while the cost gate
+#: itself is a coarse < 5K KRW heuristic; bump as needed.
+USD_TO_KRW: int = 1_400
+
+
+@dataclass(frozen=True)
+class TokenAssumptions:
+    """Per-turn token budget used by the cost estimator.
+
+    Calibrated to be conservative on the high side so a real audit
+    landing under the estimate is the common case. Values to revisit
+    after the first P3-b-2 live run produces actual numbers.
+    """
+
+    auditor_in: int = 2_000
+    auditor_out: int = 800
+    target_in: int = 1_500
+    target_out: int = 600
+    judge_in: int = 4_000
+    judge_out: int = 200
+    geode_amplifier: int = 5
+    judge_calls_per_turn: float = 0.5
+
+
+DEFAULT_TOKEN_ASSUMPTIONS = TokenAssumptions()
+
+
+@dataclass
+class AuditReport:
+    """Outcome of a ``run_audit`` invocation.
+
+    Always populated; ``returncode``/``stdout``/``stderr`` are blank for
+    ``dry_run=True`` or when the user aborts at the confirm prompt.
+    """
+
+    command: list[str]
+    estimated_usd: float
+    estimated_krw: int
+    dry_run: bool
+    aborted: bool = False
+    returncode: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command": " ".join(self.command),
+            "estimated_usd": self.estimated_usd,
+            "estimated_krw": self.estimated_krw,
+            "dry_run": self.dry_run,
+            "aborted": self.aborted,
+            "returncode": self.returncode,
+            "notes": self.notes,
+        }
+
+
+def build_command(
+    *,
+    judge: str,
+    auditor: str,
+    target: str,
+    seeds: int,
+    max_turns: int,
+    tags: str | None,
+    cache: bool,
+) -> list[str]:
+    """Assemble the ``inspect eval`` command line.
+
+    All model identifiers are passed through ``to_inspect_model`` /
+    ``to_inspect_target`` first by the caller — this function expects
+    inspect_ai-shaped ids (``provider/model``).
+    """
+    cmd: list[str] = ["inspect", "eval", "inspect_petri/audit"]
+    if seeds > 0:
+        cmd.extend(["--limit", str(seeds)])
+    cmd.extend(["--model-role", f"auditor={auditor}"])
+    cmd.extend(["--model-role", f"target={target}"])
+    cmd.extend(["--model-role", f"judge={judge}"])
+    cmd.extend(["-T", f"max_turns={max_turns}"])
+    cmd.extend(["-T", "target_tools=none"])
+    if tags:
+        cmd.extend(["-T", f"seed_instructions=tags:{tags}"])
+    if cache:
+        cmd.extend(["-T", "cache=true"])
+    return cmd
+
+
+def estimate_cost_usd(
+    *,
+    judge: str,
+    auditor: str,
+    target: str,
+    seeds: int,
+    max_turns: int,
+    assumptions: TokenAssumptions = DEFAULT_TOKEN_ASSUMPTIONS,
+) -> float:
+    """Estimate USD cost from MODEL_PRICING + per-turn token assumptions.
+
+    Inputs are GEODE catalog ids (``claude-sonnet-4-6``,
+    ``gpt-5.5``, ``glm-5``). Strings containing ``/`` are unwrapped to
+    the trailing segment so a raw inspect_ai id (``anthropic/claude-…``)
+    or a target with the ``geode/`` prefix still resolves. Returns NaN
+    when any of the three roles has no pricing entry — caller surfaces
+    that as ``estimate unavailable`` rather than a fake number.
+    """
+
+    def _basename(model_id: str) -> str:
+        return model_id.rsplit("/", 1)[-1]
+
+    pa = MODEL_PRICING.get(_basename(auditor))
+    pt = MODEL_PRICING.get(_basename(target))
+    pj = MODEL_PRICING.get(_basename(judge))
+    if pa is None or pt is None or pj is None:
+        return math.nan
+
+    auditor_cost = pa.input * assumptions.auditor_in + pa.output * assumptions.auditor_out
+    target_cost = (
+        pt.input * assumptions.target_in + pt.output * assumptions.target_out
+    ) * assumptions.geode_amplifier
+    judge_cost = assumptions.judge_calls_per_turn * (
+        pj.input * assumptions.judge_in + pj.output * assumptions.judge_out
+    )
+    per_turn = auditor_cost + target_cost + judge_cost
+    return seeds * max_turns * per_turn
+
+
+def format_cost(estimated_usd: float) -> tuple[str, int]:
+    """Format USD estimate + KRW conversion. Returns ``(label, krw_int)``.
+
+    NaN renders as ``"unavailable"`` and ``krw=0`` so call sites can
+    branch on a sentinel rather than parsing the label.
+    """
+    if math.isnan(estimated_usd):
+        return "unavailable (unknown model pricing)", 0
+    krw = int(estimated_usd * USD_TO_KRW)
+    return f"~${estimated_usd:.2f} (~{krw:,} KRW @ 1USD={USD_TO_KRW}KRW)", krw
+
+
+def confirm_or_abort(cost_label: str, *, yes: bool) -> bool:
+    """Show a [y/N] prompt unless ``yes`` skips it.
+
+    Returns True on consent, False on abort. ``yes=True`` is reserved
+    for the EXPENSIVE_TOOLS path where the safety gate has already
+    received user consent — never enable it from the Typer/slash
+    surface unless the user explicitly passed ``--yes``.
+    """
+    if yes:
+        return True
+    from core.ui.console import console
+
+    prompt = (
+        f"  [bold yellow]Petri audit — live LLM calls "
+        f"(~{cost_label}). Proceed?[/bold yellow] [y/N] "
+    )
+    response = console.input(prompt).strip().lower()
+    return response in ("y", "yes")
+
+
+def run_audit(
+    *,
+    judge: str,
+    auditor: str,
+    target: str,
+    seeds: int = 1,
+    max_turns: int = 5,
+    tags: str | None = None,
+    cache: bool = True,
+    dry_run: bool = True,
+    yes: bool = False,
+    assumptions: TokenAssumptions = DEFAULT_TOKEN_ASSUMPTIONS,
+) -> AuditReport:
+    """Run a Petri audit (or print the command in ``dry_run``).
+
+    See module docstring for the live-call authorisation policy. The
+    three GEODE entry points (``geode audit``, ``/audit``,
+    ``petri_audit`` tool) call this directly and only differ in how
+    they report the resulting :class:`AuditReport`.
+    """
+    inspect_auditor = to_inspect_model(auditor)
+    inspect_judge = to_inspect_model(judge)
+    inspect_target = to_inspect_target(target)
+    cmd = build_command(
+        judge=inspect_judge,
+        auditor=inspect_auditor,
+        target=inspect_target,
+        seeds=seeds,
+        max_turns=max_turns,
+        tags=tags,
+        cache=cache,
+    )
+    estimated_usd = estimate_cost_usd(
+        judge=judge,
+        auditor=auditor,
+        target=target,
+        seeds=seeds,
+        max_turns=max_turns,
+        assumptions=assumptions,
+    )
+    cost_label, estimated_krw = format_cost(estimated_usd)
+    notes: list[str] = []
+
+    if dry_run:
+        notes.append("dry-run: subprocess not executed")
+        return AuditReport(
+            command=cmd,
+            estimated_usd=estimated_usd,
+            estimated_krw=estimated_krw,
+            dry_run=True,
+            notes=notes,
+        )
+
+    if shutil.which("inspect") is None:
+        notes.append(
+            "`inspect` CLI not found on PATH — install the [audit] extra: "
+            "`uv sync --extra audit`."
+        )
+        return AuditReport(
+            command=cmd,
+            estimated_usd=estimated_usd,
+            estimated_krw=estimated_krw,
+            dry_run=False,
+            aborted=True,
+            notes=notes,
+        )
+
+    if not confirm_or_abort(cost_label, yes=yes):
+        notes.append("aborted at confirm prompt")
+        return AuditReport(
+            command=cmd,
+            estimated_usd=estimated_usd,
+            estimated_krw=estimated_krw,
+            dry_run=False,
+            aborted=True,
+            notes=notes,
+        )
+
+    log.info("Petri audit subprocess: %s", " ".join(cmd))
+    # ``cmd`` is built solely from validated model ids + numeric flags by
+    # build_command — no shell metacharacters or untrusted user strings.
+    proc = subprocess.run(  # noqa: S603 — fixed-shape argv, no untrusted input
+        cmd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return AuditReport(
+        command=cmd,
+        estimated_usd=estimated_usd,
+        estimated_krw=estimated_krw,
+        dry_run=False,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        notes=notes,
+    )

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -252,8 +252,7 @@ def run_audit(
 
     if shutil.which("inspect") is None:
         notes.append(
-            "`inspect` CLI not found on PATH — install the [audit] extra: "
-            "`uv sync --extra audit`."
+            "`inspect` CLI not found on PATH — install the [audit] extra: `uv sync --extra audit`."
         )
         return AuditReport(
             command=cmd,

--- a/tests/plugins/petri_audit/test_cli_audit.py
+++ b/tests/plugins/petri_audit/test_cli_audit.py
@@ -1,0 +1,112 @@
+"""Typer + slash entry-point tests for petri_audit (no [audit] extra needed).
+
+Both surfaces are thin adapters over ``runner.run_audit``; tests assert
+that ``--dry-run`` flows through and the rendered output mentions the
+constructed command + cost estimate.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.cli import app
+from plugins.petri_audit.cli_audit import _build_slash_parser, cmd_audit_slash
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_typer_audit_dry_run_prints_command() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "audit",
+            "--judge",
+            "claude-haiku-4-5-20251001",
+            "--auditor",
+            "claude-sonnet-4-6",
+            "--target",
+            "claude-opus-4-7",
+            "--seeds",
+            "1",
+            "--max-turns",
+            "3",
+            "--tags",
+            "sycophancy",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Petri audit" in result.output
+    assert "inspect eval inspect_petri/audit" in result.output
+    assert "judge=anthropic/claude-haiku-4-5-20251001" in result.output
+    assert "target=geode/claude-opus-4-7" in result.output
+    assert "seed_instructions=tags:sycophancy" in result.output
+    assert "dry-run" in result.output.lower()
+
+
+def test_typer_audit_default_is_dry_run() -> None:
+    """A bare ``geode audit`` invocation must NOT spend — default dry_run=True."""
+    result = runner.invoke(app, ["audit"])
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output.lower()
+
+
+def test_slash_parser_parses_short_and_long_flags() -> None:
+    parser = _build_slash_parser()
+    ns = parser.parse_args(
+        [
+            "-j",
+            "gpt-5.4-mini",
+            "-a",
+            "claude-sonnet-4-6",
+            "-t",
+            "claude-opus-4-7",
+            "-s",
+            "2",
+            "-m",
+            "4",
+            "--tags",
+            "self_preservation",
+            "--no-cache",
+            "--dry-run",
+            "-y",
+        ]
+    )
+    assert ns.judge == "gpt-5.4-mini"
+    assert ns.auditor == "claude-sonnet-4-6"
+    assert ns.target == "claude-opus-4-7"
+    assert ns.seeds == 2
+    assert ns.max_turns == 4
+    assert ns.tags == "self_preservation"
+    assert ns.cache is False
+    assert ns.dry_run is True
+    assert ns.yes is True
+
+
+def test_slash_handler_dry_run(capsys: pytest.CaptureFixture[str]) -> None:
+    cmd_audit_slash(
+        "--judge claude-haiku-4-5-20251001 --target claude-opus-4-7 --seeds 1 --max-turns 2 --dry-run"
+    )
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "Petri audit" in out
+    assert "inspect eval inspect_petri/audit" in out
+
+
+def test_slash_handler_invalid_args_does_not_raise(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # argparse normally calls sys.exit on a bad flag; the slash handler
+    # intercepts so the REPL stays alive.
+    cmd_audit_slash("--mystery flag")
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "invalid /audit arguments" in out
+
+
+def test_slash_handler_help_prints_usage(capsys: pytest.CaptureFixture[str]) -> None:
+    cmd_audit_slash("--help")
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "/audit" in out
+    assert "--judge" in out

--- a/tests/plugins/petri_audit/test_models.py
+++ b/tests/plugins/petri_audit/test_models.py
@@ -1,0 +1,93 @@
+"""Model-id mapping tests for petri_audit (no [audit] extra needed)."""
+
+from __future__ import annotations
+
+import pytest
+from plugins.petri_audit.models import (
+    AuditModelMappingError,
+    list_audit_models,
+    to_inspect_model,
+    to_inspect_target,
+)
+
+# ---------------------------------------------------------------------------
+# to_inspect_model — auditor / judge alias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "geode_id, expected",
+    [
+        ("claude-opus-4-7", "anthropic/claude-opus-4-7"),
+        ("claude-sonnet-4-6", "anthropic/claude-sonnet-4-6"),
+        ("claude-haiku-4-5-20251001", "anthropic/claude-haiku-4-5-20251001"),
+        ("gpt-5.5", "openai/gpt-5.5"),
+        ("gpt-5.4-mini", "openai/gpt-5.4-mini"),
+        ("o3", "openai/o3"),
+        ("o4-mini", "openai/o4-mini"),
+        ("glm-5", "geode/glm-5"),
+        ("glm-4.7-flash", "geode/glm-4.7-flash"),
+    ],
+)
+def test_to_inspect_model_known_families(geode_id: str, expected: str) -> None:
+    assert to_inspect_model(geode_id) == expected
+
+
+def test_to_inspect_model_raw_passthrough() -> None:
+    raw = "openai-api/glm/glm-5.1"
+    assert to_inspect_model(raw) == raw
+    assert to_inspect_model("anthropic/claude-haiku-4-5-20251001") == (
+        "anthropic/claude-haiku-4-5-20251001"
+    )
+
+
+def test_to_inspect_model_unknown_raises() -> None:
+    with pytest.raises(AuditModelMappingError, match="Unknown model id"):
+        to_inspect_model("mystery-model")
+
+
+def test_to_inspect_model_empty_raises() -> None:
+    with pytest.raises(AuditModelMappingError, match="Empty model id"):
+        to_inspect_model("")
+
+
+# ---------------------------------------------------------------------------
+# to_inspect_target — always geode/<base>
+# ---------------------------------------------------------------------------
+
+
+def test_to_inspect_target_auto_prefixes() -> None:
+    assert to_inspect_target("claude-opus-4-7") == "geode/claude-opus-4-7"
+    assert to_inspect_target("gpt-5.5") == "geode/gpt-5.5"
+    assert to_inspect_target("glm-5") == "geode/glm-5"
+
+
+def test_to_inspect_target_raw_passthrough() -> None:
+    assert to_inspect_target("geode/claude-opus-4-7") == "geode/claude-opus-4-7"
+    assert to_inspect_target("anthropic/claude-opus-4-7") == "anthropic/claude-opus-4-7"
+
+
+def test_to_inspect_target_empty_raises() -> None:
+    with pytest.raises(AuditModelMappingError):
+        to_inspect_target("")
+
+
+# ---------------------------------------------------------------------------
+# list_audit_models — catalog enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_list_audit_models_includes_each_family() -> None:
+    pairs = list_audit_models()
+    inspect_ids = {inspect for _, inspect in pairs}
+    assert any(i.startswith("anthropic/claude-") for i in inspect_ids)
+    assert any(i.startswith("openai/gpt-") for i in inspect_ids)
+    assert any(i.startswith("geode/glm-") for i in inspect_ids)
+
+
+def test_list_audit_models_pairs_with_pricing_keys() -> None:
+    """Every pair's geode_id is a MODEL_PRICING key (catalog SOT)."""
+    from core.llm.token_tracker import MODEL_PRICING
+
+    for geode_id, _ in list_audit_models():
+        assert geode_id in MODEL_PRICING

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -1,0 +1,254 @@
+"""Runner-side unit tests for petri_audit (no [audit] extra needed).
+
+`run_audit(dry_run=True)` is the canonical happy path here — it produces
+an `AuditReport` with the constructed command + cost estimate without
+spawning the `inspect eval` subprocess. Live invocation is exercised in
+P3-b-2 with explicit user authorisation.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+import pytest
+from plugins.petri_audit.runner import (
+    DEFAULT_TOKEN_ASSUMPTIONS,
+    USD_TO_KRW,
+    AuditReport,
+    build_command,
+    confirm_or_abort,
+    estimate_cost_usd,
+    format_cost,
+    run_audit,
+)
+
+# ---------------------------------------------------------------------------
+# build_command
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_canonical_shape() -> None:
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=3,
+        max_turns=10,
+        tags="sycophancy",
+        cache=True,
+    )
+    assert cmd[:3] == ["inspect", "eval", "inspect_petri/audit"]
+    assert "--limit" in cmd and cmd[cmd.index("--limit") + 1] == "3"
+    joined = " ".join(cmd)
+    assert "auditor=anthropic/claude-sonnet-4-6" in joined
+    assert "target=geode/claude-opus-4-7" in joined
+    assert "judge=anthropic/claude-haiku-4-5-20251001" in joined
+    assert "max_turns=10" in joined
+    assert "target_tools=none" in joined
+    assert "seed_instructions=tags:sycophancy" in joined
+    assert "cache=true" in joined
+
+
+def test_build_command_omits_optional_flags() -> None:
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=0,
+        max_turns=5,
+        tags=None,
+        cache=False,
+    )
+    joined = " ".join(cmd)
+    assert "--limit" not in joined  # seeds=0 → no limit
+    assert "seed_instructions=tags" not in joined
+    assert "cache=true" not in joined
+
+
+# ---------------------------------------------------------------------------
+# estimate_cost_usd / format_cost
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_cost_uses_model_pricing() -> None:
+    """Estimate scales linearly with seeds × max_turns."""
+    one = estimate_cost_usd(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=1,
+    )
+    ten = estimate_cost_usd(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=2,
+        max_turns=5,
+    )
+    assert one > 0
+    assert ten == pytest.approx(one * 10)
+
+
+def test_estimate_cost_unknown_returns_nan() -> None:
+    cost = estimate_cost_usd(
+        judge="mystery-model",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=1,
+    )
+    assert math.isnan(cost)
+
+
+def test_estimate_cost_strips_provider_prefix() -> None:
+    """``geode/<base>`` and ``anthropic/<model>`` map to the catalog row."""
+    raw = estimate_cost_usd(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=1,
+    )
+    bare = estimate_cost_usd(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=1,
+    )
+    assert raw == pytest.approx(bare)
+
+
+def test_format_cost_renders_krw_with_fixture_rate() -> None:
+    label, krw = format_cost(0.10)
+    expected_krw = int(0.10 * USD_TO_KRW)
+    assert str(expected_krw) in label.replace(",", "")
+    assert krw == expected_krw
+
+
+def test_format_cost_nan_returns_unavailable_sentinel() -> None:
+    label, krw = format_cost(math.nan)
+    assert "unavailable" in label
+    assert krw == 0
+
+
+# ---------------------------------------------------------------------------
+# confirm_or_abort
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_or_abort_yes_flag_skips_prompt() -> None:
+    assert confirm_or_abort("$0.10", yes=True) is True
+
+
+def test_confirm_or_abort_y_response_consents(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "core.ui.console.console.input", lambda _prompt: "y", raising=False
+    )
+    assert confirm_or_abort("$0.10", yes=False) is True
+
+
+def test_confirm_or_abort_default_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.ui.console.console.input", lambda _prompt: "", raising=False)
+    assert confirm_or_abort("$0.10", yes=False) is False
+
+
+# ---------------------------------------------------------------------------
+# run_audit — dry-run + subprocess gating
+# ---------------------------------------------------------------------------
+
+
+def test_run_audit_dry_run_returns_report_without_subprocess() -> None:
+    report = run_audit(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=5,
+        dry_run=True,
+    )
+    assert isinstance(report, AuditReport)
+    assert report.dry_run is True
+    assert report.aborted is False
+    assert report.returncode is None
+    assert "inspect" in report.command and "eval" in report.command
+    assert "dry-run: subprocess not executed" in report.notes
+
+
+def test_run_audit_live_calls_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """live=True path with confirm bypassed runs subprocess.run once."""
+
+    class _FakeProc:
+        returncode = 0
+        stdout = "audit-ok"
+        stderr = ""
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _FakeProc:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _FakeProc()
+
+    monkeypatch.setattr("plugins.petri_audit.runner.subprocess.run", _fake_run)
+    monkeypatch.setattr("plugins.petri_audit.runner.shutil.which", lambda _: "/usr/bin/inspect")
+
+    report = run_audit(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=1,
+        dry_run=False,
+        yes=True,
+    )
+    assert report.returncode == 0
+    assert report.stdout == "audit-ok"
+    assert report.dry_run is False
+    assert report.aborted is False
+    assert isinstance(captured["cmd"], list)
+    assert "inspect" in captured["cmd"]
+
+
+def test_run_audit_missing_inspect_cli_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("plugins.petri_audit.runner.shutil.which", lambda _: None)
+    report = run_audit(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=1,
+        dry_run=False,
+        yes=True,
+    )
+    assert report.aborted is True
+    assert any("inspect" in note for note in report.notes)
+
+
+def test_run_audit_user_declines(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("plugins.petri_audit.runner.shutil.which", lambda _: "/usr/bin/inspect")
+    monkeypatch.setattr("core.ui.console.console.input", lambda _p: "n", raising=False)
+
+    with patch("plugins.petri_audit.runner.subprocess.run") as run_mock:
+        report = run_audit(
+            judge="claude-haiku-4-5-20251001",
+            auditor="claude-sonnet-4-6",
+            target="claude-opus-4-7",
+            seeds=1,
+            max_turns=1,
+            dry_run=False,
+            yes=False,
+        )
+
+    assert report.aborted is True
+    assert run_mock.call_count == 0
+
+
+def test_default_token_assumptions_are_conservative() -> None:
+    """Sanity: assumption fields in expected ranges so future tweaks don't silently break cost gate."""
+    a = DEFAULT_TOKEN_ASSUMPTIONS
+    assert a.geode_amplifier >= 1
+    assert a.judge_calls_per_turn >= 0
+    assert a.auditor_in > 0 and a.target_in > 0 and a.judge_in > 0

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -144,9 +144,7 @@ def test_confirm_or_abort_yes_flag_skips_prompt() -> None:
 
 
 def test_confirm_or_abort_y_response_consents(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "core.ui.console.console.input", lambda _prompt: "y", raising=False
-    )
+    monkeypatch.setattr("core.ui.console.console.input", lambda _prompt: "y", raising=False)
     assert confirm_or_abort("$0.10", yes=False) is True
 
 

--- a/tests/plugins/petri_audit/test_tool_handler.py
+++ b/tests/plugins/petri_audit/test_tool_handler.py
@@ -1,0 +1,84 @@
+"""Tool-handler tests for petri_audit (NL → AgenticLoop entry point)."""
+
+from __future__ import annotations
+
+from core.cli.tool_handlers.audit import _build_audit_handlers
+
+
+def test_petri_audit_handler_registered() -> None:
+    handlers = _build_audit_handlers()
+    assert "petri_audit" in handlers
+    assert callable(handlers["petri_audit"])
+
+
+def test_petri_audit_handler_dry_run_returns_dict() -> None:
+    handlers = _build_audit_handlers()
+    result = handlers["petri_audit"](
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=2,
+        dry_run=True,
+    )
+    assert result["status"] == "ok"
+    assert result["tool"] == "petri_audit"
+    audit = result["audit"]
+    assert audit["dry_run"] is True
+    assert audit["aborted"] is False
+    assert "inspect eval inspect_petri/audit" in audit["command"]
+
+
+def test_petri_audit_handler_defaults() -> None:
+    """Handler accepts an empty kwargs dict and falls back to safe defaults."""
+    handlers = _build_audit_handlers()
+    result = handlers["petri_audit"]()
+    assert result["status"] == "ok"
+    assert result["audit"]["dry_run"] is True
+
+
+def test_petri_audit_handler_unknown_model_returns_error() -> None:
+    handlers = _build_audit_handlers()
+    result = handlers["petri_audit"](
+        judge="mystery-model",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=2,
+        dry_run=True,
+    )
+    # Unknown model → AuditModelMappingError → handler catches → status=error.
+    assert result["status"] == "error"
+    assert "mystery-model" in result["error"] or "Unknown" in result["error"]
+
+
+def test_petri_audit_in_expensive_tools_registry() -> None:
+    """`petri_audit` must be EXPENSIVE_TOOLS-gated so live calls trigger HITL."""
+    from core.agent.safety import EXPENSIVE_TOOLS
+
+    assert "petri_audit" in EXPENSIVE_TOOLS
+    assert EXPENSIVE_TOOLS["petri_audit"] > 0
+
+
+def test_petri_audit_in_tool_definitions() -> None:
+    """definitions.json registers `petri_audit` as an expensive evaluation tool."""
+    import json
+    from pathlib import Path
+
+    defs_path = Path(__file__).resolve().parents[3] / "core" / "tools" / "definitions.json"
+    defs = json.loads(defs_path.read_text())
+    audit_def = next((d for d in defs if d.get("name") == "petri_audit"), None)
+    assert audit_def is not None, "petri_audit not in definitions.json"
+    assert audit_def["category"] == "evaluation"
+    assert audit_def["cost_tier"] == "expensive"
+    properties = audit_def["input_schema"]["properties"]
+    for required_field in ("judge", "auditor", "target", "dry_run"):
+        assert required_field in properties
+
+
+def test_petri_audit_in_aggregate_tool_handlers() -> None:
+    """`_build_tool_handlers` must include petri_audit so AgenticLoop sees it."""
+    from core.cli.tool_handlers import _build_tool_handlers
+
+    handlers = _build_tool_handlers(verbose=False)
+    assert "petri_audit" in handlers


### PR DESCRIPTION
## Summary
- ``feature/audit-trigger`` (#972) 머지본을 main 으로 sync.
- 단일 ``run_audit`` runner + 3 진입점 (Typer ``geode audit``, slash ``/audit``, tool ``petri_audit``).
- judge / auditor / target 모두 GEODE catalog 에서 자유 선택, ``glm-*`` 는 ``GeodeModelAPI`` routing, raw passthrough escape hatch.
- Default ``dry_run=True`` 라 머지만으로는 비용 0. 라이브 첫 호출 (P3-b-2) 은 별도 세션.

## Verification
- [x] PR #972 CI 7/7 pass (Lint, Type, Test, Security, macos install, ubuntu install, Gate)
- [x] ``uv run ruff check core/ tests/ plugins/`` clean + ``ruff format --check`` clean
- [x] ``uv run mypy core/ plugins/`` clean (339 source files)
- [x] Typer dry-run E2E — ``inspect eval inspect_petri/audit --limit 1 --model-role auditor=anthropic/... target=geode/... judge=anthropic/...`` 정확 출력
- [x] ``uv run geode analyze "Cowboy Bebop" --dry-run`` — A (68.4) regression 없음
- [x] ``tests/plugins/petri_audit/`` 4 신규 파일 (24+ 케이스) all pass