### PR TITLE
release: petri --dim-set 17-dim 가지치기 → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **petri_audit `--dim-set` 옵션 + `geode_5axes` 17-dim 가지치기 default.**
+  - 5 운영 축 — 행동 제어 (4 dim) / 툴 콜링 (1) / 강건성 (4) / 시간
+    효율성 (1) — 에 P3-b 표적 (3) + judge calibration anchor (4) 를
+    더해 **17 dim** 만 보고서 surface 로 사용. inspect-petri 의 default
+    36 dim 중 long-tail unprompted_* (12) + eval-quality 일부 + bizarre /
+    facilitating_terrorism / fun_or_funny / counterfactual 등을 제외.
+  - 토큰 효율성 axis 는 petri dim 으로 측정 안 됨 — inspect_ai
+    `stats.model_usage` + GEODE token tracker 병행 (별도 레이어, N7
+    예정).
+  - 옵션 surface — Typer / argparse / `petri_audit` tool 모두에 신규
+    `--dim-set` 추가. 명시적 alias `full` / `default` / `all` 또는
+    임의 YAML 경로 → inspect-petri 의 36 dim 으로 opt-out 가능.
+  - 코드 변경 — `plugins/petri_audit/judge_dims/geode_5axes.yaml`
+    (17 dim 명시) + `judge_dims/__init__.py` (`resolve_dim_set` /
+    `BUILTIN_DIM_SETS` / `DEFAULT_DIM_SET`) + `runner.build_command`
+    가 `-T judge_dimensions=<path>` 주입 + `cli_audit.py` Typer/slash
+    options + `core/cli/tool_handlers/audit.py` + `core/tools/
+    definitions.json` schema.
+  - 회귀 가드 — `test_runner.py` 에 5 신규 (default 17, full alias,
+    custom path passthrough, inspect-petri 36 의 strict subset 검증) +
+    `test_cli_audit.py` 의 slash parser default + `test_tool_handler.py`
+    의 tool layer pass-through.
+
 ### Removed
 
 - **AgenticLoop auto-escalation removed (DTR stop-policy).**

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -47,6 +47,7 @@ def _build_audit_handlers() -> dict[str, Any]:
         seeds = int(kwargs.get("seeds") or 1)
         max_turns = int(kwargs.get("max_turns") or 10)
         tags = kwargs.get("tags") or None
+        dim_set = kwargs.get("dim_set") or "5axes"
         cache = bool(kwargs.get("cache", True))
         dry_run = bool(kwargs.get("dry_run", True))
         confirm = bool(kwargs.get("confirm", False))
@@ -59,6 +60,7 @@ def _build_audit_handlers() -> dict[str, Any]:
                 seeds=seeds,
                 max_turns=max_turns,
                 tags=tags,
+                dim_set=dim_set,
                 cache=cache,
                 dry_run=dry_run,
                 # dry_run never spends — auto-skip the runner-level confirm.

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -1431,6 +1431,10 @@
           "type": "string",
           "description": "Petri seed_instructions tag filter (e.g. sycophancy, self_preservation). Omit for the default seed mix."
         },
+        "dim_set": {
+          "type": "string",
+          "description": "Judge-dimension set. '5axes' (default, 17 dims — behaviour control + tool calling + robustness + time efficiency + 3 P3-b alignment surfaces + 4 calibration anchors), 'full' / 'default' for inspect-petri's 36, or a YAML path for custom dims."
+        },
         "cache": {
           "type": "boolean",
           "description": "Petri 3.0.6 cache parameter. Default true (30-70% cost reduction on shared prefixes)."

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -80,6 +80,14 @@ def audit(
         "--tags",
         help="Petri seed_instructions tags filter (e.g. sycophancy).",
     ),
+    dim_set: str = typer.Option(
+        "5axes",
+        "--dim-set",
+        help="Judge-dimension set. '5axes' (default, 17 dims — behaviour "
+        "control + tool calling + robustness + time efficiency + 3 P3-b "
+        "alignment surfaces + 4 calibration anchors), 'full' / 'default' "
+        "for inspect-petri's 36, or a YAML path for custom dims.",
+    ),
     cache: bool = typer.Option(True, "--cache/--no-cache", help="Petri cache parameter."),
     dry_run: bool = typer.Option(
         True,
@@ -102,6 +110,7 @@ def audit(
         seeds=seeds,
         max_turns=max_turns,
         tags=tags or None,
+        dim_set=dim_set,
         cache=cache,
         dry_run=dry_run,
         yes=yes,
@@ -117,6 +126,7 @@ def _build_slash_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seeds", "-s", type=int, default=1)
     parser.add_argument("--max-turns", "-m", type=int, default=10, dest="max_turns")
     parser.add_argument("--tags", default=None)
+    parser.add_argument("--dim-set", default="5axes", dest="dim_set")
     parser.add_argument("--no-cache", action="store_false", dest="cache", default=True)
     parser.add_argument("--live", action="store_false", dest="dry_run", default=True)
     parser.add_argument("--dry-run", action="store_true", dest="dry_run")
@@ -146,6 +156,7 @@ def cmd_audit_slash(args: str) -> None:
         seeds=ns.seeds,
         max_turns=ns.max_turns,
         tags=ns.tags or None,
+        dim_set=ns.dim_set,
         cache=ns.cache,
         dry_run=ns.dry_run,
         yes=ns.yes,

--- a/plugins/petri_audit/judge_dims/__init__.py
+++ b/plugins/petri_audit/judge_dims/__init__.py
@@ -1,0 +1,61 @@
+"""Named judge-dimension sets for the petri audit.
+
+Inspect-petri's ``audit_judge`` scores 36 default alignment dimensions.
+For GEODE we keep five operational axes (behaviour control, tool
+calling, robustness, time efficiency, plus three P3-b alignment
+surfaces) — 17 dimensions instead of 36. Smaller surface = smaller
+judge prompt = lower judge token cost (the judge scores every dim
+in one structured-answer call, so unused dims still cost tokens).
+
+Resolution rules for ``--dim-set <value>``:
+
+- ``"5axes"`` (default) → ``geode_5axes.yaml`` in this directory.
+- ``"full"`` / ``"default"`` → ``None`` (inspect-petri's bundled 36).
+- Any other value → treated as a filesystem path; the caller passes
+  it to ``inspect eval -T judge_dimensions=<value>`` unchanged so a
+  user can drop a custom YAML anywhere on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["BUILTIN_DIM_SETS", "DEFAULT_DIM_SET", "resolve_dim_set"]
+
+DEFAULT_DIM_SET: str = "5axes"
+
+_HERE = Path(__file__).parent
+
+#: Names that resolve to a YAML inside this package. Keep alphabetical
+#: so additions stay easy to scan. Each YAML must contain a flat list
+#: of dimension names that are a subset of inspect-petri's default 36.
+BUILTIN_DIM_SETS: dict[str, Path] = {
+    "5axes": _HERE / "geode_5axes.yaml",
+}
+
+#: Names that explicitly opt out of dim pruning — the cmd is built
+#: without ``-T judge_dimensions=...`` and inspect-petri uses its
+#: built-in 36.
+_FULL_ALIASES = frozenset({"full", "default", "all"})
+
+
+def resolve_dim_set(value: str | None) -> Path | str | None:
+    """Map a CLI ``--dim-set`` value to a path / passthrough / None.
+
+    Returns:
+        - ``Path`` when ``value`` names a built-in YAML set.
+        - ``None`` when ``value`` is ``None`` / ``"full"`` / ``"default"`` /
+          ``"all"`` — caller must omit the ``-T judge_dimensions`` flag.
+        - ``str`` (the unchanged value) when it looks like a path /
+          dir / yaml the user supplied — caller passes it through.
+
+    The "passthrough" branch deliberately does no existence check:
+    inspect-petri produces a much clearer error than a duplicate
+    "file not found" raised at flag-build time, and a missing path
+    is a user mistake worth surfacing at the audit boundary.
+    """
+    if value is None or value.lower() in _FULL_ALIASES:
+        return None
+    if value in BUILTIN_DIM_SETS:
+        return BUILTIN_DIM_SETS[value]
+    return value

--- a/plugins/petri_audit/judge_dims/geode_5axes.yaml
+++ b/plugins/petri_audit/judge_dims/geode_5axes.yaml
@@ -1,0 +1,61 @@
+# GEODE 5-axis judge dimension set (17 dim).
+#
+# Five operational axes the audit cares about, mapped onto the
+# inspect-petri default-36 alignment dimensions:
+#
+#   1. behaviour control (4):
+#      cooperation_with_harmful_sysprompt
+#      user_over_sysprompt
+#      cooperation_with_human_misuse
+#      overrefusal
+#   2. tool calling (1):
+#      broken_tool_use
+#   3. robustness (4):
+#      prefill_susceptibility
+#      input_hallucination
+#      unfaithful_thinking
+#      manipulated_by_developer
+#   4. time efficiency (1):
+#      stuck_in_loops
+#
+# Plus three P3-b alignment surfaces kept on the report (autonomy axis,
+# not one of the five operational axes but the original target dims):
+#   unprompted_initiative
+#   unprompted_self_preservation
+#   unprompted_whistleblowing
+#
+# Plus four judge calibration anchors so the judge has a baseline of
+# how concerning/realistic the transcript is:
+#   admirable
+#   disappointing
+#   needs_attention
+#   scenario_realism
+#
+# Token efficiency is intentionally absent — petri does not score it;
+# the report layer joins inspect_ai stats.model_usage + GEODE token
+# tracker for that axis (see N7 plan).
+#
+# All names below must exist in inspect-petri's default-36 dimension
+# set. Names are validated at load time via judge_dimensions(...).
+#
+# To override at runtime, pass `--dim-set <name>` (Typer/slash) or
+# pass a custom YAML path directly. To keep the inspect-petri default
+# 36, pass `--dim-set full`.
+
+- cooperation_with_harmful_sysprompt
+- user_over_sysprompt
+- cooperation_with_human_misuse
+- overrefusal
+- broken_tool_use
+- prefill_susceptibility
+- input_hallucination
+- unfaithful_thinking
+- manipulated_by_developer
+- stuck_in_loops
+- unprompted_initiative
+- unprompted_self_preservation
+- unprompted_whistleblowing
+- admirable
+- disappointing
+- needs_attention
+- scenario_realism

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from core.llm.token_tracker import MODEL_PRICING
 
+from plugins.petri_audit.judge_dims import DEFAULT_DIM_SET, resolve_dim_set
 from plugins.petri_audit.models import to_inspect_model, to_inspect_target
 
 log = logging.getLogger(__name__)
@@ -104,12 +105,19 @@ def build_command(
     max_turns: int,
     tags: str | None,
     cache: bool,
+    dim_set: str | None = DEFAULT_DIM_SET,
 ) -> list[str]:
     """Assemble the ``inspect eval`` command line.
 
     All model identifiers are passed through ``to_inspect_model`` /
     ``to_inspect_target`` first by the caller — this function expects
     inspect_ai-shaped ids (``provider/model``).
+
+    ``dim_set`` selects the judge-dimension set:
+    ``"5axes"`` → ``-T judge_dimensions=<built-in YAML>`` (17 dims).
+    ``"full"`` / ``None`` → flag omitted; inspect-petri's default 36.
+    Anything else → passed through as a path/string verbatim so a
+    custom YAML on disk works without runner changes.
     """
     cmd: list[str] = ["inspect", "eval", "inspect_petri/audit"]
     if seeds > 0:
@@ -123,6 +131,9 @@ def build_command(
         cmd.extend(["-T", f"seed_instructions=tags:{tags}"])
     if cache:
         cmd.extend(["-T", "cache=true"])
+    resolved = resolve_dim_set(dim_set)
+    if resolved is not None:
+        cmd.extend(["-T", f"judge_dimensions={resolved}"])
     return cmd
 
 
@@ -219,6 +230,7 @@ def run_audit(
     max_turns: int = 10,
     tags: str | None = None,
     cache: bool = True,
+    dim_set: str | None = DEFAULT_DIM_SET,
     dry_run: bool = True,
     yes: bool = False,
     assumptions: TokenAssumptions = DEFAULT_TOKEN_ASSUMPTIONS,
@@ -246,6 +258,7 @@ def run_audit(
         max_turns=max_turns,
         tags=tags,
         cache=cache,
+        dim_set=dim_set,
     )
     estimated_usd = estimate_cost_usd(
         judge=judge,

--- a/tests/plugins/petri_audit/test_cli_audit.py
+++ b/tests/plugins/petri_audit/test_cli_audit.py
@@ -78,9 +78,17 @@ def test_slash_parser_parses_short_and_long_flags() -> None:
     assert ns.seeds == 2
     assert ns.max_turns == 4
     assert ns.tags == "self_preservation"
+    assert ns.dim_set == "5axes"  # default — pruned 17-dim set
     assert ns.cache is False
     assert ns.dry_run is True
     assert ns.yes is True
+
+
+def test_slash_parser_accepts_dim_set_override() -> None:
+    """``--dim-set full`` opts back into inspect-petri's 36-dim default."""
+    parser = _build_slash_parser()
+    ns = parser.parse_args(["--dim-set", "full"])
+    assert ns.dim_set == "full"
 
 
 def test_slash_handler_dry_run(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -9,6 +9,7 @@ P3-b-2 with explicit user authorisation.
 from __future__ import annotations
 
 import math
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -59,11 +60,111 @@ def test_build_command_omits_optional_flags() -> None:
         max_turns=5,
         tags=None,
         cache=False,
+        dim_set="full",
     )
     joined = " ".join(cmd)
     assert "--limit" not in joined  # seeds=0 → no limit
     assert "seed_instructions=tags" not in joined
     assert "cache=true" not in joined
+    assert "judge_dimensions" not in joined  # dim_set=full → flag omitted
+
+
+# ---------------------------------------------------------------------------
+# judge dimension set selection (--dim-set)
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_default_dim_set_pins_geode_5axes_yaml() -> None:
+    """Default ``dim_set`` resolves to the bundled 17-dim YAML.
+
+    Any caller that does not pass ``--dim-set`` gets the pruned set
+    automatically — this is the contract the user asked for: 'core 9
+    + 표적 3 + 보정 5 = 17 dim' as the report surface.
+    """
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+    )
+    assert "-T" in cmd and any("judge_dimensions=" in part for part in cmd), (
+        "default dim_set must inject judge_dimensions; otherwise inspect-petri "
+        "falls back to its 36-dim set and the surface contract is broken"
+    )
+    flag = next(p for p in cmd if p.startswith("judge_dimensions="))
+    assert flag.endswith("geode_5axes.yaml")
+
+
+@pytest.mark.parametrize("alias", ["full", "default", "all", "FULL", "Default"])
+def test_build_command_dim_set_full_aliases_omit_judge_dimensions(alias: str) -> None:
+    """Explicit opt-out aliases drop the flag entirely (case-insensitive).
+
+    ``"full"`` is the documented escape hatch for users who want
+    inspect-petri's bundled 36 dims.
+    """
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+        dim_set=alias,
+    )
+    assert "judge_dimensions" not in " ".join(cmd)
+
+
+def test_build_command_dim_set_passthrough_for_custom_path(tmp_path: Path) -> None:
+    """Unknown values are forwarded verbatim so a user can drop a YAML
+    anywhere on disk and pass ``--dim-set /path/to/custom.yaml``.
+
+    Resolution / existence checking lives at inspect-petri's boundary
+    where the error message is most actionable.
+    """
+    custom = tmp_path / "custom-dims.yaml"
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+        dim_set=str(custom),
+    )
+    assert f"judge_dimensions={custom}" in " ".join(cmd)
+
+
+def test_geode_5axes_yaml_is_subset_of_inspect_petri_36() -> None:
+    """Every name in geode_5axes.yaml must exist in inspect-petri's
+    default 36-dim set, otherwise ``judge_dimensions(...)`` raises
+    ``ValueError: Unknown dimension`` at audit start.
+
+    Skipped when [audit] extra is absent — judge_dimensions is part of
+    the optional dependency.
+    """
+    judge_dims_mod = pytest.importorskip("inspect_petri._judge.dimensions")
+    import yaml
+    from plugins.petri_audit.judge_dims import BUILTIN_DIM_SETS
+
+    yaml_path = BUILTIN_DIM_SETS["5axes"]
+    with open(yaml_path) as f:
+        names = yaml.safe_load(f)
+    assert isinstance(names, list) and len(names) == 17, (
+        "5axes set is documented as 17 dims; if you intentionally widen it, "
+        "update CHANGELOG + the report surface contract"
+    )
+
+    defaults = {d.name for d in judge_dims_mod.load_dimensions()}
+    unknown = [n for n in names if n not in defaults]
+    assert not unknown, (
+        f"Unknown dimension(s) in geode_5axes.yaml: {unknown}. "
+        "inspect-petri rejects these at judge load time."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/petri_audit/test_tool_handler.py
+++ b/tests/plugins/petri_audit/test_tool_handler.py
@@ -72,8 +72,20 @@ def test_petri_audit_in_tool_definitions() -> None:
     assert audit_def["category"] == "evaluation"
     assert audit_def["cost_tier"] == "expensive"
     properties = audit_def["input_schema"]["properties"]
-    for required_field in ("judge", "auditor", "target", "dry_run"):
+    for required_field in ("judge", "auditor", "target", "dim_set", "dry_run"):
         assert required_field in properties
+
+
+def test_petri_audit_handler_passes_dim_set_to_runner() -> None:
+    """Tool layer forwards ``dim_set`` so the LLM-driven path has the
+    same surface contract as Typer/slash."""
+    handlers = _build_audit_handlers()
+    result = handlers["petri_audit"](dim_set="full", dry_run=True)
+    assert result["status"] == "ok"
+    assert "judge_dimensions" not in result["audit"]["command"], (
+        "dim_set='full' must omit -T judge_dimensions=… so inspect-petri "
+        "uses its bundled 36-dim default"
+    )
 
 
 def test_petri_audit_in_aggregate_tool_handlers() -> None:


### PR DESCRIPTION
## Summary
- petri_audit ``--dim-set`` 옵션 + ``geode_5axes`` 17-dim 가지치기 default (#1002)
- 5 운영 축 (행동 제어 + 툴 콜링 + 강건성 + 시간 효율성 + 토큰 효율성) 중심 surface

## Verification
- [x] CI 6/6 (#1002): Lint, Type, Test, Security, Install ubuntu/macos