### PR TITLE
feat(petri-audit): --seed-select 옵션 — id/tags/path 폼 passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **petri_audit `--seed-select` 옵션 — inspect-petri ``id:`` / ``tags:`` /
+  path 폼 직접 전달.**
+  - 기존 ``--tags`` 는 ``seed_instructions=tags:<tag>`` 만 만들 수 있어
+    명시적 seed id 4개 (5 운영 축 1:1 매핑) 같은 N7' 형 실험에서
+    표현력이 부족했음. 신규 ``--seed-select`` 는 inspect-petri 의
+    seed_instructions 인자 형식 그대로 passthrough — ``id:<id1>,<id2>``
+    명시 / ``tags:<tag>`` / 디렉토리 또는 YAML 경로 모두 지원.
+  - ``--tags`` 는 backward compat 으로 유지. 두 옵션을 동시에 지정하면
+    ``ValueError`` (inspect-petri 가 ``seed_instructions`` 을 하나만
+    받아 silent override 가 일어나지 않게 boundary 에서 차단).
+  - 옵션 surface — Typer / argparse / ``petri_audit`` tool / definitions.json
+    모두에 wired.
+  - 회귀 가드 — ``test_runner.py`` 에 3 신규 (id 폼 passthrough, tags
+    via seed-select, 충돌 시 ValueError) + ``test_cli_audit.py`` 의
+    slash parser id 폼.
+
 - **petri_audit `--dim-set` 옵션 + `geode_5axes` 17-dim 가지치기 default.**
   - 5 운영 축 — 행동 제어 (4 dim) / 툴 콜링 (1) / 강건성 (4) / 시간
     효율성 (1) — 에 P3-b 표적 (3) + judge calibration anchor (4) 를

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -47,6 +47,7 @@ def _build_audit_handlers() -> dict[str, Any]:
         seeds = int(kwargs.get("seeds") or 1)
         max_turns = int(kwargs.get("max_turns") or 10)
         tags = kwargs.get("tags") or None
+        seed_select = kwargs.get("seed_select") or None
         dim_set = kwargs.get("dim_set") or "5axes"
         cache = bool(kwargs.get("cache", True))
         dry_run = bool(kwargs.get("dry_run", True))
@@ -60,6 +61,7 @@ def _build_audit_handlers() -> dict[str, Any]:
                 seeds=seeds,
                 max_turns=max_turns,
                 tags=tags,
+                seed_select=seed_select,
                 dim_set=dim_set,
                 cache=cache,
                 dry_run=dry_run,

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -1429,7 +1429,11 @@
         },
         "tags": {
           "type": "string",
-          "description": "Petri seed_instructions tag filter (e.g. sycophancy, self_preservation). Omit for the default seed mix."
+          "description": "Petri seed_instructions tag filter (e.g. sycophancy, self_preservation). Shortcut for seed_select=tags:<value>. Omit for the default seed mix."
+        },
+        "seed_select": {
+          "type": "string",
+          "description": "Petri seed_instructions selector — full inspect-petri form. 'id:<id1>,<id2>' for explicit seed ids, 'tags:<tag>' for tag-based selection, or a directory / YAML path. Mutually exclusive with `tags`."
         },
         "dim_set": {
           "type": "string",

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -78,7 +78,18 @@ def audit(
     tags: str = typer.Option(
         None,
         "--tags",
-        help="Petri seed_instructions tags filter (e.g. sycophancy).",
+        help="Petri seed_instructions tags filter (e.g. sycophancy). "
+        "Shortcut for `--seed-select tags:<value>`. Mutually exclusive "
+        "with --seed-select.",
+    ),
+    seed_select: str = typer.Option(
+        None,
+        "--seed-select",
+        help="Petri seed_instructions selector — full inspect-petri form. "
+        "Examples: `id:helpful_only_model_harmful_task,broken_tool_error_"
+        "handling,system_prompt_quirk_reveal,power_seeking_agentic_probe` "
+        "(4 explicit seeds, one per operational axis), `tags:<tag>` (same "
+        "as --tags), or a path to a directory / YAML of seed `.md` files.",
     ),
     dim_set: str = typer.Option(
         "5axes",
@@ -110,6 +121,7 @@ def audit(
         seeds=seeds,
         max_turns=max_turns,
         tags=tags or None,
+        seed_select=seed_select or None,
         dim_set=dim_set,
         cache=cache,
         dry_run=dry_run,
@@ -126,6 +138,7 @@ def _build_slash_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seeds", "-s", type=int, default=1)
     parser.add_argument("--max-turns", "-m", type=int, default=10, dest="max_turns")
     parser.add_argument("--tags", default=None)
+    parser.add_argument("--seed-select", default=None, dest="seed_select")
     parser.add_argument("--dim-set", default="5axes", dest="dim_set")
     parser.add_argument("--no-cache", action="store_false", dest="cache", default=True)
     parser.add_argument("--live", action="store_false", dest="dry_run", default=True)
@@ -156,6 +169,7 @@ def cmd_audit_slash(args: str) -> None:
         seeds=ns.seeds,
         max_turns=ns.max_turns,
         tags=ns.tags or None,
+        seed_select=ns.seed_select or None,
         dim_set=ns.dim_set,
         cache=ns.cache,
         dry_run=ns.dry_run,

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -106,6 +106,7 @@ def build_command(
     tags: str | None,
     cache: bool,
     dim_set: str | None = DEFAULT_DIM_SET,
+    seed_select: str | None = None,
 ) -> list[str]:
     """Assemble the ``inspect eval`` command line.
 
@@ -118,7 +119,21 @@ def build_command(
     ``"full"`` / ``None`` → flag omitted; inspect-petri's default 36.
     Anything else → passed through as a path/string verbatim so a
     custom YAML on disk works without runner changes.
+
+    ``seed_select`` selects seed scenarios (forwarded to ``-T
+    seed_instructions=<value>`` verbatim). Inspect-petri accepts
+    ``id:<id>[,<id>...]`` for explicit seed ids, ``tags:<tag>[,<tag>]``
+    for tag-based selection, a directory of ``.md`` files, or a
+    YAML/file path. Mutually exclusive with ``tags``: passing both
+    raises ``ValueError`` because inspect-petri only honours one
+    ``seed_instructions`` flag.
     """
+    if tags and seed_select:
+        raise ValueError(
+            "Pass either ``tags`` (legacy shortcut for seed_instructions="
+            "tags:<tag>) or ``seed_select`` (full id:/tags:/path form), "
+            "not both — inspect-petri honours only one seed_instructions value."
+        )
     cmd: list[str] = ["inspect", "eval", "inspect_petri/audit"]
     if seeds > 0:
         cmd.extend(["--limit", str(seeds)])
@@ -127,7 +142,9 @@ def build_command(
     cmd.extend(["--model-role", f"judge={judge}"])
     cmd.extend(["-T", f"max_turns={max_turns}"])
     cmd.extend(["-T", "target_tools=none"])
-    if tags:
+    if seed_select:
+        cmd.extend(["-T", f"seed_instructions={seed_select}"])
+    elif tags:
         cmd.extend(["-T", f"seed_instructions=tags:{tags}"])
     if cache:
         cmd.extend(["-T", "cache=true"])
@@ -231,6 +248,7 @@ def run_audit(
     tags: str | None = None,
     cache: bool = True,
     dim_set: str | None = DEFAULT_DIM_SET,
+    seed_select: str | None = None,
     dry_run: bool = True,
     yes: bool = False,
     assumptions: TokenAssumptions = DEFAULT_TOKEN_ASSUMPTIONS,
@@ -259,6 +277,7 @@ def run_audit(
         tags=tags,
         cache=cache,
         dim_set=dim_set,
+        seed_select=seed_select,
     )
     estimated_usd = estimate_cost_usd(
         judge=judge,

--- a/tests/plugins/petri_audit/test_cli_audit.py
+++ b/tests/plugins/petri_audit/test_cli_audit.py
@@ -101,9 +101,7 @@ def test_slash_parser_accepts_seed_select_id_form() -> None:
             "id:helpful_only_model_harmful_task,broken_tool_error_handling",
         ]
     )
-    assert ns.seed_select == (
-        "id:helpful_only_model_harmful_task,broken_tool_error_handling"
-    )
+    assert ns.seed_select == ("id:helpful_only_model_harmful_task,broken_tool_error_handling")
 
 
 def test_slash_handler_dry_run(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/plugins/petri_audit/test_cli_audit.py
+++ b/tests/plugins/petri_audit/test_cli_audit.py
@@ -91,6 +91,21 @@ def test_slash_parser_accepts_dim_set_override() -> None:
     assert ns.dim_set == "full"
 
 
+def test_slash_parser_accepts_seed_select_id_form() -> None:
+    """``--seed-select id:a,b,c,d`` parses cleanly so N7' can pin 4
+    seeds per operational axis without tag-set hacking."""
+    parser = _build_slash_parser()
+    ns = parser.parse_args(
+        [
+            "--seed-select",
+            "id:helpful_only_model_harmful_task,broken_tool_error_handling",
+        ]
+    )
+    assert ns.seed_select == (
+        "id:helpful_only_model_harmful_task,broken_tool_error_handling"
+    )
+
+
 def test_slash_handler_dry_run(capsys: pytest.CaptureFixture[str]) -> None:
     cmd_audit_slash(
         "--judge claude-haiku-4-5-20251001 --target claude-opus-4-7 --seeds 1 --max-turns 2 --dry-run"

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -51,6 +51,65 @@ def test_build_command_canonical_shape() -> None:
     assert "cache=true" in joined
 
 
+# ---------------------------------------------------------------------------
+# seed selection (--seed-select)
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_seed_select_passthrough_id_form() -> None:
+    """Comma-separated ``id:<id1>,<id2>...`` is the form N7' uses to
+    pin one seed per operational axis (4 seeds total)."""
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=12,
+        max_turns=10,
+        tags=None,
+        cache=True,
+        seed_select=(
+            "id:helpful_only_model_harmful_task,broken_tool_error_handling,"
+            "system_prompt_quirk_reveal,power_seeking_agentic_probe"
+        ),
+    )
+    joined = " ".join(cmd)
+    assert "seed_instructions=id:helpful_only_model_harmful_task," in joined
+    assert "broken_tool_error_handling" in joined
+    assert "seed_instructions=tags:" not in joined  # ``id:`` form, not tags
+
+
+def test_build_command_seed_select_tags_form_works() -> None:
+    """``tags:<value>`` via --seed-select is identical to legacy --tags
+    output for backward compatibility checks."""
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+        seed_select="tags:initiative",
+    )
+    assert "seed_instructions=tags:initiative" in " ".join(cmd)
+
+
+def test_build_command_rejects_tags_and_seed_select_together() -> None:
+    """inspect-petri honours one ``seed_instructions`` value; passing
+    both is a user mistake we surface at the API boundary."""
+    with pytest.raises(ValueError, match="not both"):
+        build_command(
+            judge="anthropic/claude-haiku-4-5-20251001",
+            auditor="anthropic/claude-sonnet-4-6",
+            target="geode/claude-opus-4-7",
+            seeds=1,
+            max_turns=10,
+            tags="initiative",
+            cache=True,
+            seed_select="id:broken_tool_error_handling",
+        )
+
+
 def test_build_command_omits_optional_flags() -> None:
     cmd = build_command(
         judge="anthropic/claude-haiku-4-5-20251001",


### PR DESCRIPTION
## Summary
- inspect-petri ``seed_instructions`` 의 ``id:<id1>,<id2>`` / ``tags:<tag>`` / 디렉토리·YAML 경로 형식을 그대로 passthrough 하는 ``--seed-select`` 옵션
- 기존 ``--tags`` 는 backward compat 유지 — 둘 동시 지정 시 ``ValueError``
- 본 PR cost = $0 (옵션 wiring 만)

## Why
N7' 라이브 (4 seed × 3 sample = 12 samples) 가 5 운영 축 (행동 제어 + 툴 콜링 + 강건성 + 시간 효율성 + alignment surface) 별 1 seed 씩 명시 지정해야 함. 기존 ``--tags`` 는 단일 tag 필터만 — 4 개의 서로 다른 seed id 를 한꺼번에 지정 불가. inspect-petri 의 ``seed_instructions=id:<id1>,<id2>...`` 폼이 정확히 이 use case 를 위해 존재.

| Case | 기존 (--tags) | 신규 (--seed-select) |
|------|--------------|---------------------|
| 단일 tag 필터 | ``--tags initiative`` | ``--seed-select tags:initiative`` |
| 명시적 4 seed | ❌ 불가 | ``--seed-select id:a,b,c,d`` |
| 디렉토리 / 커스텀 YAML | ❌ 불가 | ``--seed-select /path/to/seeds/`` |

## Changes
| File | Change |
|------|--------|
| ``plugins/petri_audit/runner.py`` | ``build_command`` 에 ``seed_select: str \| None``. ``tags`` 와 동시 지정 시 ``ValueError``. ``-T seed_instructions=<value>`` 직접 전달 |
| ``plugins/petri_audit/cli_audit.py`` | Typer + argparse ``--seed-select`` |
| ``core/cli/tool_handlers/audit.py`` | ``petri_audit`` 핸들러 pass-through |
| ``core/tools/definitions.json`` | ``seed_select`` schema |
| ``tests/plugins/petri_audit/test_runner.py`` | 3 신규 (id 폼 passthrough, tags via seed-select, 충돌 시 ValueError) |
| ``tests/plugins/petri_audit/test_cli_audit.py`` | slash parser id 폼 |
| ``CHANGELOG.md`` | ``[Unreleased] / Added`` |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ``--seed-select`` Typer / slash / tool 모두 wired | ✅ | |
| ``--tags`` backward compat | ✅ | 변경 없음 |
| 두 옵션 충돌 시 fail-fast | ✅ | ``ValueError`` at build_command boundary |
| inspect-petri ``id:`` / ``tags:`` / path 폼 모두 passthrough | ✅ | 형식 검증은 inspect-petri 가 담당 |
| N7' 라이브 cost cap | Out of scope | 본 PR 머지 후 사용자 명시 승인 |

## Verification
- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed!
- [x] ``uv run mypy core/ plugins/`` — Success: no issues found in 347 files
- [x] ``uv run deptry .`` — clean
- [x] ``uv run pytest tests/plugins/petri_audit/`` — pass
- [x] dry-run: ``--seed-select id:a,b,c,d`` → ``-T seed_instructions=id:a,b,c,d`` 주입 확인
- [x] dry-run estimator (12 sample × max_turns 10) = ~$15.96 / ~22K KRW (over-conservative — 본 PR 38% 비율 감안 시 실측 ~9K KRW 예상)

## Reference
- N6-followup (#1000/#1001): target routing + drift 가드레일 audit 한정 비활성화
- dim 가지치기 (#1002/#1003): geode_5axes 17-dim default
- inspect-petri ``seed_instructions`` 형식: ``id:<id1>[,<id2>...]`` / ``tags:<tag>`` / dir / YAML path