### PR TITLE
feat(petri-audit): --target-tools 옵션 + build-time 검증 (E + K + N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **petri_audit `--target-tools` 옵션 + build-time 검증 (E + K + N).**
+  - **E** (path fail-fast) — `--dim-set <yaml>` / `--seed-select <path>`
+    가 존재하지 않으면 build_command 시점에 `ValueError`. 이전 동작은
+    inspect-petri 가 audit start 시점에 cryptic FileNotFoundError 던졌음.
+  - **K** (dim subset validate) — `--dim-set` 가 path 일 때 YAML 로드 →
+    inspect-petri default 36 의 strict subset 검증. unknown 이름 있으면
+    `ValueError` (which dim 명시). [audit] extra 미설치 시는 skip.
+  - **N** (`--target-tools` 옵션) — inspect-petri `audit(target_tools=…)`
+    의 `Literal["synthetic", "fixed", "none"]` 노출. default `none`
+    (이전 hard-code 와 동일 — 5-axis surface 에 적합). `synthetic` 은
+    capability dim study 에 사용 (auditor 가 fabricate 가능), `fixed` 는
+    target 사전등록 tool only.
+  - 회귀 가드 — `test_runner.py` 에 7 신규 (existing-path passthrough,
+    missing dim path, dim YAML unknown name, missing seed path,
+    `id:` form passthrough, target_tools default, target_tools all
+    literals, unknown literal rejection).
+  - dry-run smoke — `geode audit --target-tools synthetic` →
+    `-T target_tools=synthetic` 정상 주입 확인.
+
+
+
 - **`.claude/skills/long-task-watcher/SKILL.md` — long-running task
   watching patterns guide.**
   - 본 PoC 의 N7' / N8 Monitor 타임아웃 사례 (`tail -F | grep` 의

--- a/core/cli/tool_handlers/audit.py
+++ b/core/cli/tool_handlers/audit.py
@@ -49,6 +49,7 @@ def _build_audit_handlers() -> dict[str, Any]:
         tags = kwargs.get("tags") or None
         seed_select = kwargs.get("seed_select") or None
         dim_set = kwargs.get("dim_set") or "5axes"
+        target_tools = kwargs.get("target_tools") or "none"
         cache = bool(kwargs.get("cache", True))
         dry_run = bool(kwargs.get("dry_run", True))
         confirm = bool(kwargs.get("confirm", False))
@@ -63,6 +64,7 @@ def _build_audit_handlers() -> dict[str, Any]:
                 tags=tags,
                 seed_select=seed_select,
                 dim_set=dim_set,
+                target_tools=target_tools,
                 cache=cache,
                 dry_run=dry_run,
                 # dry_run never spends — auto-skip the runner-level confirm.

--- a/core/tools/definitions.json
+++ b/core/tools/definitions.json
@@ -1439,6 +1439,11 @@
           "type": "string",
           "description": "Judge-dimension set. '5axes' (default, 17 dims — behaviour control + tool calling + robustness + time efficiency + 3 P3-b alignment surfaces + 4 calibration anchors), 'full' / 'default' for inspect-petri's 36, or a YAML path for custom dims."
         },
+        "target_tools": {
+          "type": "string",
+          "enum": ["synthetic", "fixed", "none"],
+          "description": "Auditor's tool-creation tool set. 'none' (default — conversation-only mode, fits the 5-axis surface), 'fixed' (send_tool_call_result only, target has pre-registered tools), 'synthetic' (full set — auditor can fabricate tool results; inspect-petri default; useful for capability/broken_tool_use dim studies)."
+        },
         "cache": {
           "type": "boolean",
           "description": "Petri 3.0.6 cache parameter. Default true (30-70% cost reduction on shared prefixes)."

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -105,6 +105,16 @@ def audit(
         "alignment surfaces + 4 calibration anchors), 'full' / 'default' "
         "for inspect-petri's 36, or a YAML path for custom dims.",
     ),
+    target_tools: str = typer.Option(
+        "none",
+        "--target-tools",
+        help="Auditor's tool-creation tool set. 'none' (default — "
+        "conversation-only, fits the 5-axis surface), 'fixed' "
+        "(send_tool_call_result only, target has pre-registered tools), "
+        "'synthetic' (full create_tool / remove_tool / send_tool_call_result "
+        "— inspect-petri default; lets the auditor fabricate tool results, "
+        "useful for capability dim studies).",
+    ),
     cache: bool = typer.Option(True, "--cache/--no-cache", help="Petri cache parameter."),
     dry_run: bool = typer.Option(
         True,
@@ -129,6 +139,7 @@ def audit(
         tags=tags or None,
         seed_select=seed_select or None,
         dim_set=dim_set,
+        target_tools=target_tools,
         cache=cache,
         dry_run=dry_run,
         yes=yes,
@@ -146,6 +157,12 @@ def _build_slash_parser() -> argparse.ArgumentParser:
     parser.add_argument("--tags", default=None)
     parser.add_argument("--seed-select", default=None, dest="seed_select")
     parser.add_argument("--dim-set", default="5axes", dest="dim_set")
+    parser.add_argument(
+        "--target-tools",
+        default="none",
+        dest="target_tools",
+        choices=["synthetic", "fixed", "none"],
+    )
     parser.add_argument("--no-cache", action="store_false", dest="cache", default=True)
     parser.add_argument("--live", action="store_false", dest="dry_run", default=True)
     parser.add_argument("--dry-run", action="store_true", dest="dry_run")
@@ -177,6 +194,7 @@ def cmd_audit_slash(args: str) -> None:
         tags=ns.tags or None,
         seed_select=ns.seed_select or None,
         dim_set=ns.dim_set,
+        target_tools=ns.target_tools,
         cache=ns.cache,
         dry_run=ns.dry_run,
         yes=ns.yes,

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -20,6 +20,7 @@ import math
 import shutil
 import subprocess
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from core.llm.token_tracker import MODEL_PRICING
@@ -121,6 +122,12 @@ class AuditReport:
         }
 
 
+#: Allowed values for ``--target-tools``. Mirror inspect-petri's
+#: ``audit(target_tools=…)`` literal so a future inspect-petri version
+#: bump surfaces here as a typing error rather than a silent acceptance.
+TARGET_TOOLS_VALUES = ("synthetic", "fixed", "none")
+
+
 def build_command(
     *,
     judge: str,
@@ -132,6 +139,7 @@ def build_command(
     cache: bool,
     dim_set: str | None = DEFAULT_DIM_SET,
     seed_select: str | None = None,
+    target_tools: str = "none",
 ) -> list[str]:
     """Assemble the ``inspect eval`` command line.
 
@@ -142,16 +150,27 @@ def build_command(
     ``dim_set`` selects the judge-dimension set:
     ``"5axes"`` → ``-T judge_dimensions=<built-in YAML>`` (17 dims).
     ``"full"`` / ``None`` → flag omitted; inspect-petri's default 36.
-    Anything else → passed through as a path/string verbatim so a
-    custom YAML on disk works without runner changes.
+    Anything else → resolved to a path string. The path's existence is
+    checked at build time + the YAML's dim names are validated as a
+    subset of inspect-petri's default 36 (when [audit] extra is
+    installed) so a typo fails fast here instead of inside the audit.
 
     ``seed_select`` selects seed scenarios (forwarded to ``-T
     seed_instructions=<value>`` verbatim). Inspect-petri accepts
     ``id:<id>[,<id>...]`` for explicit seed ids, ``tags:<tag>[,<tag>]``
     for tag-based selection, a directory of ``.md`` files, or a
-    YAML/file path. Mutually exclusive with ``tags``: passing both
-    raises ``ValueError`` because inspect-petri only honours one
-    ``seed_instructions`` flag.
+    YAML/file path. Mutually exclusive with ``tags``. Path-shaped
+    values are checked for existence at build time; ``id:`` / ``tags:``
+    prefixes are passed through unchanged.
+
+    ``target_tools`` controls which tool-creation tools the auditor
+    receives. ``"synthetic"`` (inspect-petri default) gives the
+    auditor ``create_tool`` / ``remove_tool`` / ``send_tool_call_result``;
+    ``"fixed"`` only ``send_tool_call_result``; ``"none"`` (our
+    default) is conversation-only mode. Note: GEODE's audit target
+    owns its own tool registry, so ``synthetic``/``fixed`` lets the
+    auditor *fabricate* tool results — useful for capability dim
+    studies, harmful for behaviour-control comparisons.
     """
     if tags and seed_select:
         raise ValueError(
@@ -159,6 +178,16 @@ def build_command(
             "tags:<tag>) or ``seed_select`` (full id:/tags:/path form), "
             "not both — inspect-petri honours only one seed_instructions value."
         )
+    if target_tools not in TARGET_TOOLS_VALUES:
+        raise ValueError(
+            f"target_tools must be one of {TARGET_TOOLS_VALUES}, got {target_tools!r}. "
+            "See inspect-petri/_task/audit.py:audit() docstring."
+        )
+
+    resolved_dims = resolve_dim_set(dim_set)
+    _validate_dim_path(resolved_dims)
+    _validate_seed_select_path(seed_select)
+
     cmd: list[str] = ["inspect", "eval", "inspect_petri/audit"]
     if seeds > 0:
         cmd.extend(["--limit", str(seeds)])
@@ -166,17 +195,100 @@ def build_command(
     cmd.extend(["--model-role", f"target={target}"])
     cmd.extend(["--model-role", f"judge={judge}"])
     cmd.extend(["-T", f"max_turns={max_turns}"])
-    cmd.extend(["-T", "target_tools=none"])
+    cmd.extend(["-T", f"target_tools={target_tools}"])
     if seed_select:
         cmd.extend(["-T", f"seed_instructions={seed_select}"])
     elif tags:
         cmd.extend(["-T", f"seed_instructions=tags:{tags}"])
     if cache:
         cmd.extend(["-T", "cache=true"])
-    resolved = resolve_dim_set(dim_set)
-    if resolved is not None:
-        cmd.extend(["-T", f"judge_dimensions={resolved}"])
+    if resolved_dims is not None:
+        cmd.extend(["-T", f"judge_dimensions={resolved_dims}"])
     return cmd
+
+
+def _validate_dim_path(resolved: Any) -> None:
+    """Validate a resolved ``--dim-set`` value (path-like).
+
+    Raises ``ValueError`` when the path does not exist, ``FileNotFoundError``
+    semantics intentionally elevated to ValueError so the CLI surfaces
+    the same class of error for every kind of bad input. When the
+    [audit] extra is installed and the path is a YAML, also load the
+    file and check that every name is a subset of inspect-petri's
+    default 36 dim set (covers 결함 K).
+
+    ``None`` (= ``--dim-set full``) is a no-op. The built-in YAML path
+    (``geode_5axes.yaml``) is shipped with this package so its
+    existence is also enforced — a missing built-in is a deployment
+    bug worth surfacing the same way as a typo'd custom path.
+    """
+    if resolved is None:
+        return
+    p = Path(str(resolved))
+    if not p.exists():
+        raise ValueError(
+            f"--dim-set resolved to a path that does not exist: {p}. "
+            f"Check the path or use ``--dim-set full`` to fall back to "
+            f"inspect-petri's default 36 dim set."
+        )
+    # Best-effort subset validation when the [audit] extra is installed.
+    # Skipped on default ``uv sync`` so the runner module keeps loading
+    # without inspect_ai. Callers running an actual audit will already
+    # have the extra installed (the inspect CLI lives in it).
+    if p.suffix.lower() not in {".yaml", ".yml"}:
+        return
+    try:
+        from inspect_petri._judge.dimensions import load_dimensions
+    except ImportError:
+        return
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover — yaml is a dep of [audit]
+        return
+    with p.open(encoding="utf-8") as f:
+        names = yaml.safe_load(f)
+    if not isinstance(names, list):
+        # Custom YAMLs may also list ``JudgeDimension`` dicts; we only
+        # validate the simple ``[<name>, <name>, ...]`` shape because
+        # the dict form is already a self-contained spec.
+        return
+    defaults = {d.name for d in load_dimensions()}
+    unknown = [n for n in names if isinstance(n, str) and n not in defaults]
+    if unknown:
+        raise ValueError(
+            f"--dim-set YAML at {p} contains unknown dimension(s): {unknown}. "
+            f"Allowed names are inspect-petri's default 36 (see "
+            f"inspect_petri/_judge/dimensions/*.md)."
+        )
+
+
+def _validate_seed_select_path(seed_select: str | None) -> None:
+    """Path-shaped ``--seed-select`` values must exist at build time.
+
+    ``id:<...>`` / ``tags:<...>`` are command strings, not paths — pass
+    through unchanged. Anything that looks like a filesystem path
+    (contains ``/`` or ends in ``.md``/``.yaml``/``.json``) is checked
+    for existence so a typo fails fast here.
+    """
+    if not seed_select:
+        return
+    if seed_select.startswith(("id:", "tags:")):
+        return
+    # Heuristic: looks like a path
+    path_extensions = (".md", ".yaml", ".yml", ".json", ".jsonl", ".csv")
+    looks_like_path = (
+        "/" in seed_select
+        or seed_select.startswith("~")
+        or any(seed_select.lower().endswith(ext) for ext in path_extensions)
+    )
+    if not looks_like_path:
+        return
+    p = Path(seed_select).expanduser()
+    if not p.exists():
+        raise ValueError(
+            f"--seed-select resolved to a path that does not exist: {p}. "
+            f"Use ``id:<seed-id>``, ``tags:<tag>``, or an existing dir/file."
+        )
 
 
 def estimate_cost_usd(
@@ -281,6 +393,7 @@ def run_audit(
     cache: bool = True,
     dim_set: str | None = DEFAULT_DIM_SET,
     seed_select: str | None = None,
+    target_tools: str = "none",
     dry_run: bool = True,
     yes: bool = False,
     auto_archive: bool = True,
@@ -311,6 +424,7 @@ def run_audit(
         cache=cache,
         dim_set=dim_set,
         seed_select=seed_select,
+        target_tools=target_tools,
     )
     estimated_usd = estimate_cost_usd(
         judge=judge,

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -181,10 +181,13 @@ def test_build_command_dim_set_passthrough_for_custom_path(tmp_path: Path) -> No
     """Unknown values are forwarded verbatim so a user can drop a YAML
     anywhere on disk and pass ``--dim-set /path/to/custom.yaml``.
 
-    Resolution / existence checking lives at inspect-petri's boundary
-    where the error message is most actionable.
+    Existence is verified at build_command (결함 E) — write the file
+    so the validator does not reject the test before we can assert
+    on the cmd shape. Subset validation (결함 K) is exercised by
+    ``test_build_command_rejects_dim_yaml_with_unknown_names``.
     """
     custom = tmp_path / "custom-dims.yaml"
+    custom.write_text("- admirable\n- disappointing\n", encoding="utf-8")
     cmd = build_command(
         judge="anthropic/claude-haiku-4-5-20251001",
         auditor="anthropic/claude-sonnet-4-6",
@@ -196,6 +199,126 @@ def test_build_command_dim_set_passthrough_for_custom_path(tmp_path: Path) -> No
         dim_set=str(custom),
     )
     assert f"judge_dimensions={custom}" in " ".join(cmd)
+
+
+def test_build_command_rejects_missing_dim_yaml(tmp_path: Path) -> None:
+    """결함 E — a typo'd ``--dim-set /tmp/typo.yaml`` must fail at
+    build time with a clear message instead of crashing inside the
+    inspect_ai subprocess minutes later."""
+    missing = tmp_path / "does-not-exist.yaml"
+    with pytest.raises(ValueError, match="does not exist"):
+        build_command(
+            judge="anthropic/claude-haiku-4-5-20251001",
+            auditor="anthropic/claude-sonnet-4-6",
+            target="geode/claude-opus-4-7",
+            seeds=1,
+            max_turns=10,
+            tags=None,
+            cache=True,
+            dim_set=str(missing),
+        )
+
+
+def test_build_command_rejects_dim_yaml_with_unknown_names(tmp_path: Path) -> None:
+    """결함 K — a custom dim YAML must list names that exist in
+    inspect-petri's default 36 dim set, otherwise
+    ``judge_dimensions(...)`` raises ``Unknown dimension`` at audit
+    start. Surface the error at build_command instead.
+    """
+    pytest.importorskip("inspect_petri")
+    custom = tmp_path / "bad-dims.yaml"
+    custom.write_text("- admirable\n- typo_dim_name\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unknown dimension"):
+        build_command(
+            judge="anthropic/claude-haiku-4-5-20251001",
+            auditor="anthropic/claude-sonnet-4-6",
+            target="geode/claude-opus-4-7",
+            seeds=1,
+            max_turns=10,
+            tags=None,
+            cache=True,
+            dim_set=str(custom),
+        )
+
+
+def test_build_command_rejects_missing_seed_path(tmp_path: Path) -> None:
+    """결함 E — seed_select 가 path 형식인데 file 없으면 fail-fast."""
+    missing = tmp_path / "missing-seeds"
+    with pytest.raises(ValueError, match="does not exist"):
+        build_command(
+            judge="anthropic/claude-haiku-4-5-20251001",
+            auditor="anthropic/claude-sonnet-4-6",
+            target="geode/claude-opus-4-7",
+            seeds=1,
+            max_turns=10,
+            tags=None,
+            cache=True,
+            seed_select=str(missing / "seeds.yaml"),
+        )
+
+
+def test_build_command_seed_select_id_form_passthrough_no_path_check(tmp_path: Path) -> None:
+    """``id:<...>`` is not a path — must NOT trigger path validation."""
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+        seed_select="id:helpful_only_bypass_constraints",
+    )
+    assert "seed_instructions=id:helpful_only_bypass_constraints" in " ".join(cmd)
+
+
+# ---------------------------------------------------------------------------
+# target_tools (N)
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_target_tools_default_is_none() -> None:
+    """N4-followup default — conversation-only mode fits the 5-axis
+    surface. Live N7'/N8 used this implicitly (hard-coded ``none``)."""
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+    )
+    assert "target_tools=none" in " ".join(cmd)
+
+
+@pytest.mark.parametrize("value", ["synthetic", "fixed", "none"])
+def test_build_command_target_tools_accepts_inspect_petri_literals(value: str) -> None:
+    cmd = build_command(
+        judge="anthropic/claude-haiku-4-5-20251001",
+        auditor="anthropic/claude-sonnet-4-6",
+        target="geode/claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        tags=None,
+        cache=True,
+        target_tools=value,
+    )
+    assert f"target_tools={value}" in " ".join(cmd)
+
+
+def test_build_command_target_tools_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="target_tools must be one of"):
+        build_command(
+            judge="anthropic/claude-haiku-4-5-20251001",
+            auditor="anthropic/claude-sonnet-4-6",
+            target="geode/claude-opus-4-7",
+            seeds=1,
+            max_turns=10,
+            tags=None,
+            cache=True,
+            target_tools="bogus",
+        )
 
 
 def test_geode_5axes_yaml_is_subset_of_inspect_petri_36() -> None:


### PR DESCRIPTION
## Summary
- **E** — `--dim-set <yaml>` / `--seed-select <path>` 의 build-time path-existence 검증 (`ValueError` fail-fast)
- **K** — `--dim-set` 가 path 인 경우 YAML 의 dim names 가 inspect-petri default 36 의 strict subset 인지 build-time 검증
- **N** — `--target-tools` 옵션 노출 (`synthetic` / `fixed` / `none`, default `none`)

## Why
직전 archive 보강 (#1010) 의 결함 점검에서 발견된 우선순위 "하" 묶음:

- 잘못된 `--dim-set /tmp/typo.yaml` 가 audit 시작 시점 (수십 초 후) 의 cryptic 에러로만 표면화 → 사용자 시간 낭비
- custom YAML 의 dim name 오타 (e.g. `inspect-petri` 36 외 이름) 가 `judge_dimensions(...)` 의 늦은 시점에 raise → 같은 footgun
- `target_tools` 가 `runner.py:125` 에 hard-code `none` — capability dim study (`broken_tool_use` 등) 에서 `synthetic` 이 필요하지만 옵션으로 노출 X. 본 PoC N7' sample 2 의 broken_tool_use=baseline 결과의 한 추정 원인

## Changes
| File | Change |
|------|--------|
| ``plugins/petri_audit/runner.py`` | `TARGET_TOOLS_VALUES`, `_validate_dim_path`, `_validate_seed_select_path` 신규. `build_command` 에 `target_tools` 인자 + 검증 호출. `run_audit` 도 pass-through |
| ``plugins/petri_audit/cli_audit.py`` | Typer + argparse `--target-tools` (default `none`). slash parser `choices=['synthetic','fixed','none']` |
| ``core/cli/tool_handlers/audit.py`` | `petri_audit` 핸들러 pass-through |
| ``core/tools/definitions.json`` | `target_tools` schema (enum) |
| ``tests/plugins/petri_audit/test_runner.py`` | 7 신규 회귀 가드 |
| ``CHANGELOG.md`` | `[Unreleased] / Added` |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| E: dim path exists | ✅ | ValueError "does not exist" |
| E: seed path exists | ✅ | id:/tags: 는 검증 skip |
| K: dim YAML subset | ✅ | unknown name 발견 시 dim 명시 |
| N: target_tools 옵션 | ✅ | 3 literals + reject unknown |
| 5axes 기본 동작 unchanged | ✅ | default `none` + `5axes` YAML |

## Verification
- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed!
- [x] ``uv run ruff format --check`` — clean
- [x] ``uv run mypy core/ plugins/`` — Success: 348 files
- [x] ``uv run deptry .`` — clean
- [x] ``uv run pytest tests/plugins/petri_audit/test_runner.py`` — 37 passed
- [x] dry-run: ``geode audit --target-tools synthetic`` → ``-T target_tools=synthetic`` 정상 주입

## Reference
- 직전 PR (#1010) 의 결함 점검 § 우선순위 "하"
- inspect-petri 공식 source: `inspect_petri/_task/audit.py:27` target_tools, `inspect_petri/_judge/dimensions.py:35` judge_dimensions