### PR TITLE
release: petri estimator cache_read_ratio 반영 → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **petri_audit estimator B 보정 — `cache_read_ratio` 반영.**
+  - 기존 estimator 가 `pa.input` 만 사용 (cache_read 무시) → anthropic /
+    openai 의 cache-heavy stack 에서 estimator over-estimate 의 큰 부분
+    을 차지. `MODEL_PRICING` 은 이미 `cache_read = input × 0.1` (90%
+    할인) 보유 (token_tracker.py:126).
+  - 새 필드 — `auditor_cache_read_ratio: float = 0.85`,
+    `target_cache_read_ratio: float = 0.0` (GEODE tracker 0 records 라
+    미관측, 보수적), `judge_cache_read_ratio: float = 0.45`. N6-followup
+    + N7' + N8 실측 (auditor cache_ratio 88-94%, judge 33-48%) 의
+    conservative side.
+  - 새 helper `_effective_in_price(price, ratio)` —
+    `(1-r) × input + r × cache_read`. ratio 무시 시 (cache_read=0 인
+    exotic provider) input 으로 fallback.
+  - 검증 — N6-followup ratio 1.04 ★ landing zone 안 (`actual $0.55 /
+    estimate $0.53`), N7' first 3 sample 0.31 ★, N8 (openai 5 sample,
+    cache 94%/48%) 는 0.13 — under-estimate side 지만 사용자 입장에선
+    over-budget 안 가는 conservative 방향.
+  - inspect-petri ``audit_judge`` 의 `cache=True` 옵션은 이미 우리
+    build_command 의 ``-T cache=true`` 통해 적용 중. 별도 옵션 노출
+    불필요 (M 은 scope 외).
+  - 회귀 가드 — `test_runner.py` 에 `test_estimator_cache_ratio_lowers_in_token_cost`
+    + `test_default_token_assumptions_are_conservative` 의 ratio 범위
+    검증 추가.
+
 ### Added
 
 - **petri_audit `--target-tools` 옵션 + build-time 검증 (E + K + N).**

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -78,6 +78,18 @@ class TokenAssumptions:
     geode_amplifier: int = 1
     judge_calls_per_sample: float = 1.0
 
+    # B (cache cost reflection) — anthropic / openai 모두 cache_read 가
+    # 90% 할인 (`pa.cache_read = pa.input × 0.1` in
+    # core/llm/token_tracker.py:126). 이전 estimator 는 ``pa.input``
+    # 만 사용해 anthropic / openai 의 cache-heavy stack 에서 5-15× over.
+    #
+    # 본 비율은 N6-followup + N8 의 실측 (auditor cache_ratio 88-94%,
+    # judge 33-48%) 의 conservative side. 가능하면 estimator 가 over-
+    # estimate side 에 머물도록 ratio 를 실측보다 살짝 낮게 잡음.
+    auditor_cache_read_ratio: float = 0.85
+    target_cache_read_ratio: float = 0.0  # GEODE tracker 0 records 라 미관측, 보수적 0
+    judge_cache_read_ratio: float = 0.45
+
 
 DEFAULT_TOKEN_ASSUMPTIONS = TokenAssumptions()
 
@@ -336,18 +348,46 @@ def estimate_cost_usd(
     # Pre-N4 estimator multiplied judge by max_turns × judge_calls_per_turn
     # which over-estimated 5× (inspect-petri's audit_judge fires once per
     # sample on the full transcript, not per turn).
+    #
+    # B (cache cost reflection) — input tokens 의 일부가 prompt cache
+    # read (90% 할인) 로 청구된다는 사실을 반영. ``effective_in_price``
+    # = (1 - r) × full_input_price + r × cache_read_price 로 계산.
+    # ``r=0`` 은 기존 (pre-B) 행동.
+    auditor_eff_in = _effective_in_price(pa, assumptions.auditor_cache_read_ratio)
+    target_eff_in = _effective_in_price(pt, assumptions.target_cache_read_ratio)
+    judge_eff_in = _effective_in_price(pj, assumptions.judge_cache_read_ratio)
+
     auditor_per_turn = (
-        pa.input * assumptions.auditor_in_per_turn + pa.output * assumptions.auditor_out_per_turn
+        auditor_eff_in * assumptions.auditor_in_per_turn
+        + pa.output * assumptions.auditor_out_per_turn
     )
     target_per_turn = (
-        pt.input * assumptions.target_in_per_turn + pt.output * assumptions.target_out_per_turn
+        target_eff_in * assumptions.target_in_per_turn + pt.output * assumptions.target_out_per_turn
     ) * assumptions.geode_amplifier
     per_sample_turn_cost = (auditor_per_turn + target_per_turn) * max_turns
     judge_per_sample = assumptions.judge_calls_per_sample * (
-        pj.input * assumptions.judge_in_per_sample + pj.output * assumptions.judge_out_per_sample
+        judge_eff_in * assumptions.judge_in_per_sample
+        + pj.output * assumptions.judge_out_per_sample
     )
     per_sample = per_sample_turn_cost + judge_per_sample
     return seeds * per_sample
+
+
+def _effective_in_price(price: Any, cache_read_ratio: float) -> float:
+    """Blend full input price + cache_read price by the given ratio.
+
+    ``ModelPrice.cache_read`` is populated for both anthropic and
+    openai catalogue entries (see core/llm/token_tracker.py). When
+    ``cache_read = 0`` (rare — exotic provider), the function silently
+    falls back to ``input`` so the estimator does not zero-out the
+    auditor / judge cost.
+    """
+    cr = float(getattr(price, "cache_read", 0.0) or 0.0)
+    inp = float(price.input)
+    if cr <= 0.0:
+        return inp
+    ratio = max(0.0, min(1.0, cache_read_ratio))
+    return (1.0 - ratio) * inp + ratio * cr
 
 
 def format_cost(estimated_usd: float) -> tuple[str, int]:

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -570,6 +570,53 @@ def test_default_token_assumptions_are_conservative() -> None:
     assert a.judge_in_per_sample > 0
     assert a.auditor_out_per_turn > 0 and a.target_out_per_turn > 0
     assert a.judge_out_per_sample > 0
+    # B (cache cost reflection) — ratios must be in [0, 1] and the
+    # auditor / judge defaults reflect the live-run telemetry (cache-
+    # heavy on the auditor side, mid on the judge side).
+    assert 0.0 <= a.auditor_cache_read_ratio <= 1.0
+    assert 0.0 <= a.target_cache_read_ratio <= 1.0
+    assert 0.0 <= a.judge_cache_read_ratio <= 1.0
+
+
+def test_estimator_cache_ratio_lowers_in_token_cost() -> None:
+    """B contract: increasing cache_read_ratio must lower the
+    estimate (cache_read price ≈ input × 0.1). Pre-B estimator was
+    invariant to cache_ratio because the field did not exist."""
+    from dataclasses import replace
+
+    base = DEFAULT_TOKEN_ASSUMPTIONS
+    cold = replace(
+        base,
+        auditor_cache_read_ratio=0.0,
+        judge_cache_read_ratio=0.0,
+        target_cache_read_ratio=0.0,
+    )
+    warm = replace(
+        base,
+        auditor_cache_read_ratio=0.9,
+        judge_cache_read_ratio=0.9,
+        target_cache_read_ratio=0.0,  # target stays 0 — GEODE tracker not observed
+    )
+    cold_estimate = estimate_cost_usd(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        assumptions=cold,
+    )
+    warm_estimate = estimate_cost_usd(
+        judge="claude-haiku-4-5-20251001",
+        auditor="claude-sonnet-4-6",
+        target="claude-opus-4-7",
+        seeds=1,
+        max_turns=10,
+        assumptions=warm,
+    )
+    assert warm_estimate < cold_estimate, (
+        f"warm cache estimate {warm_estimate:.4f} should be lower than "
+        f"cold {cold_estimate:.4f} — cache_read price is ≈ input × 0.1"
+    )
 
 
 def test_n4_estimator_lands_within_landing_zone_for_known_runs() -> None:


### PR DESCRIPTION
## Summary
- petri_audit estimator 에 cache_read_ratio 반영 (#1016) — auditor 0.85 / target 0.0 / judge 0.45

## Verification
- [x] CI 6/6 (#1016)
- [x] N6-followup ratio 1.04 ★ landing zone