### PR TITLE
release: petri Defect A root cause fix (F-A1+A2+A3) → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,55 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Defect A root-cause fix — petri target tokens 가 inspect_ai
+  role_usage / GEODE tracker 양쪽에 흐르도록 wiring 보강 (F-A1 + F-A2
+  + F-A3).**
+  - **F-A1 (inspect_ai ModelAPI contract 충족)** — 직전 라이브 (#1020)
+    에서 `inspect_ai.log.stats.role_usage["target"]` 가 빈 dict 인
+    이유 추적: `GeodeModelAPI.generate` 가 `ModelOutput.from_content(...)`
+    만 호출해 `usage=None` 으로 둠. inspect_ai 의 role_usage 누적은
+    `ModelEvent.output.usage` 통해 일어나므로 custom ModelAPI 가 usage
+    안 채우면 target 항목 자체가 안 생김 (native AnthropicAPI/OpenAIAPI
+    는 `ModelOutput(..., usage=ModelUsage(...))` 직접 구성). 본 PR —
+    (1) `AgenticResult` 에 `usage: LLMUsage | None` 필드 추가 +
+    `TokenTracker.snapshot()` 을 `arun` 진입에서 캡처 → 종료 시
+    `delta_since(snap)` 으로 per-arun 집계, (2) `_default_geode_runner`
+    가 `(text, usage_dict)` tuple 반환 (back-compat: bare `str` 도 수용),
+    (3) `GeodeModelAPI.generate` 가 `ModelOutput(model, choices,
+    usage=ModelUsage(input_tokens, output_tokens, total_tokens,
+    input_tokens_cache_write, input_tokens_cache_read, reasoning_tokens,
+    total_cost))` 직접 구성. `UsageSnapshot` 도 thinking/cache 필드
+    포함하도록 확장.
+  - **F-A2 (`_response.track_usage` 안전화 + cache 보강)** — openai stack
+    라이브에서 target completion 정상이었는데 GEODE tracker 0 records
+    였던 이유: `_response.track_usage` 가 `response.usage.input_tokens`
+    직접 접근 + 예외 시 silent debug 로깅. 본 PR — 모든 counter 를
+    `int(getattr(..., 0) or 0)` fallback 으로 변경, cache_creation_tokens
+    / cache_read_tokens 도 `tracker.record` 에 전달 (이미 record path
+    에서 가격 산정만 하던 부분의 데이터 누락 해소), 예외 swallow 를
+    `log.debug` → `log.warning` 으로 승격. `ResponseUsage` 에
+    cache_creation_tokens / cache_read_tokens 필드 신규 + `normalize_
+    anthropic` (`cache_creation_input_tokens` / `cache_read_input_tokens`)
+    + `normalize_openai` (`prompt_tokens_details.cached_tokens`) populate.
+    `LLMUsage` / `LLMUsageAccumulator` / `UsageSnapshot` 도 cache 필드
+    승격해 `~/.geode/usage/<YYYY-MM>.jsonl` 에 누적.
+  - **F-A3 (`_default_geode_runner` 관측성)** — 진입 INFO 로그
+    (msg_count / last_user_chars / model), AgenticLoop 생성 DEBUG,
+    종료 INFO (text_chars / usage). 라이브 시 stdout 으로 흐르므로
+    다음 라이브 검증 (F-A4, 별도 PR) 에서 root cause 직접 가시.
+  - **GEODE = LLM 추론 시스템 관점** — 본 PR 은 inspect_ai 의 ModelAPI
+    contract 를 GEODE 가 정확히 충족하도록 wiring 보강. 이전 모델
+    (anthropic SDK) + 유용한 하네스 (inspect_ai ModelAPI) + 한 단계 더
+    (GEODE AgenticLoop) 의 발전사에서 각 layer 의 contract 가 깨지지
+    않게 — seam 에서 변환만 (LLMUsage → ModelUsage 는 GeodeModelAPI
+    안에서만 lazy import).
+  - **회귀 가드** — `tests/plugins/petri_audit/test_skeleton.py` 3 신규
+    (runner tuple, ModelUsage 정상 emit, str runner back-compat) +
+    `tests/test_agentic_loop.py` 2 신규 (track_usage cache 토큰
+    flow-through, schema mismatch 시 WARNING). 4520 tests pass.
+
 ### Notes
 
 - **`/claude-api migrate` to Opus 4.7 — noop migration.**

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -106,6 +106,34 @@ def finalize_and_return(
     metrics = loop._build_reasoning_metrics(result)
     result.reasoning_metrics = metrics.to_dict()
 
+    # Defect A F-A1 (2026-05-11) — aggregate per-arun usage via tracker
+    # snapshot delta. Inspect_ai's role_usage aggregation reads this off
+    # the ModelEvent.output.usage that ``GeodeModelAPI.generate`` emits,
+    # so if ``result.usage`` is None the petri audit's target column
+    # silently disappears from log.stats.role_usage. The snapshot anchor
+    # is captured at the top of ``arun`` (see ``loop.py:429``); reading
+    # the accumulator directly here would over-count sibling loops on
+    # the same ContextVar tracker (e.g. compaction sub-LLM calls).
+    snap = getattr(loop, "_usage_snapshot", None)
+    if snap is not None:
+        try:
+            from core.llm.token_tracker import LLMUsage as _LLMUsage
+            from core.llm.token_tracker import get_tracker as _get_tracker
+
+            delta = _get_tracker().delta_since(snap)
+            if delta.call_count > 0:
+                result.usage = _LLMUsage(
+                    model=loop.model,
+                    input_tokens=delta.total_input_tokens,
+                    output_tokens=delta.total_output_tokens,
+                    thinking_tokens=delta.total_thinking_tokens,
+                    cache_creation_tokens=delta.total_cache_creation_tokens,
+                    cache_read_tokens=delta.total_cache_read_tokens,
+                    cost_usd=delta.total_cost_usd,
+                )
+        except Exception:
+            log.debug("usage delta snapshot failed", exc_info=True)
+
     loop._record_transcript_end(result)
     loop._save_checkpoint(user_input, round_idx=round_idx)
     if loop._hooks:

--- a/core/agent/loop/_response.py
+++ b/core/agent/loop/_response.py
@@ -65,31 +65,55 @@ def serialize_content(loop: AgenticLoop, content: list[Any]) -> list[dict[str, A
 
 
 def track_usage(loop: AgenticLoop, response: Any) -> None:
-    """Track token usage for cost monitoring."""
-    if not response.usage:
+    """Track token usage for cost monitoring.
+
+    Defect A F-A2 (2026-05-11) — three hardenings:
+
+    1. ``getattr(..., 0)`` fallback for every counter so a wrapper /
+       mock with partial attributes no longer triggers an
+       ``AttributeError`` that the broad ``except`` block silently
+       swallows. The petri live (#1020) showed exactly this silent
+       loss on the openai stack — completion was non-empty, response
+       arrived, but every call was dropped here.
+    2. Forward ``cache_creation_tokens`` / ``cache_read_tokens`` to
+       ``tracker.record`` so prompt-cache usage is finally recorded
+       per-call (the normalize layer started populating these in F-A2
+       as well — see ``agentic_response.ResponseUsage``).
+    3. Promote the swallowed exception path from ``log.debug`` to
+       ``log.warning``. The failure was historically silent; making
+       it warning-level surfaces future regressions without breaking
+       the loop.
+    """
+    if not response or not getattr(response, "usage", None):
         return
     try:
         from core.llm.token_tracker import get_tracker
         from core.ui.agentic_ui import render_tokens
 
-        in_tok = response.usage.input_tokens
-        out_tok = response.usage.output_tokens
-        think_tok = getattr(response.usage, "thinking_tokens", 0) or 0
+        in_tok = int(getattr(response.usage, "input_tokens", 0) or 0)
+        out_tok = int(getattr(response.usage, "output_tokens", 0) or 0)
+        think_tok = int(getattr(response.usage, "thinking_tokens", 0) or 0)
+        cache_create = int(getattr(response.usage, "cache_creation_tokens", 0) or 0)
+        cache_read = int(getattr(response.usage, "cache_read_tokens", 0) or 0)
         tracker = get_tracker()
         usage = tracker.record(
             loop.model,
             in_tok,
             out_tok,
+            cache_creation_tokens=cache_create,
+            cache_read_tokens=cache_read,
             thinking_tokens=think_tok,
         )
         if not loop._quiet:
             render_tokens(loop.model, in_tok, out_tok, cost_usd=usage.cost_usd)
         log.info(
-            "LLM call: model=%s in=%d out=%d think=%d cost=$%.4f",
+            "LLM call: model=%s in=%d out=%d think=%d cache_w=%d cache_r=%d cost=$%.4f",
             loop.model,
             in_tok,
             out_tok,
             think_tok,
+            cache_create,
+            cache_read,
             usage.cost_usd,
         )
 
@@ -112,7 +136,7 @@ def track_usage(loop: AgenticLoop, response: Any) -> None:
                         {"total_cost_usd": total_cost, "limit_usd": cost_limit, "pct": pct},
                     )
     except Exception:
-        log.debug("Failed to track usage", exc_info=True)
+        log.warning("Failed to track usage", exc_info=True)
 
 
 def update_tool_error_tracking(loop: AgenticLoop, tool_results: list[dict[str, Any]]) -> None:

--- a/core/agent/loop/loop.py
+++ b/core/agent/loop/loop.py
@@ -427,6 +427,13 @@ class AgenticLoop:
         import time as _time
 
         self._loop_start_time = _time.monotonic()
+        # Defect A F-A1 — capture tracker snapshot at the loop entry so
+        # ``finalize_and_return`` can compute a per-arun usage delta
+        # without double-counting calls from sibling loops sharing the
+        # same ``ContextVar``-scoped tracker. See ``AgenticResult.usage``.
+        from core.llm.token_tracker import get_tracker as _get_tracker
+
+        self._usage_snapshot = _get_tracker().snapshot()
         round_idx = 0
         while True:
             # Guard 1: Round limit (max_rounds > 0 enforces; 0 = unlimited)

--- a/core/agent/loop/models.py
+++ b/core/agent/loop/models.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import dataclasses
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.llm.token_tracker import LLMUsage
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +60,18 @@ def _context_exhausted_message(user_input: str) -> str:
 
 @dataclass
 class AgenticResult:
-    """Result of an agentic loop execution."""
+    """Result of an agentic loop execution.
+
+    ``usage`` (Defect A F-A1 / 2026-05-11) carries the aggregated
+    ``LLMUsage`` for *this* arun invocation only — captured via a
+    ``TokenTracker.snapshot()`` taken at the start of ``arun`` and a
+    ``delta_since(snap)`` at finalize time. It is ``None`` when the
+    loop terminated before any LLM call (e.g. context-exhausted
+    fallback). Used by the petri ``GeodeModelAPI`` adapter to surface
+    target-side tokens into ``inspect_ai`` ``role_usage`` — without
+    it, custom ModelAPI implementations are invisible to the inspect
+    log's ``role_usage`` aggregation (see ``inspect_ai.log._log``).
+    """
 
     text: str
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
@@ -73,6 +87,7 @@ class AgenticResult:
     termination_reason: str = "unknown"
     summary: str = ""  # Tier 1 compact action summary (auto-generated)
     reasoning_metrics: dict[str, object] | None = None
+    usage: "LLMUsage | None" = None  # noqa: UP037 — forward-ref for cycle avoidance
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting None-valued fields."""

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -35,11 +35,25 @@ class TextBlock:
 
 @dataclass(slots=True)
 class ResponseUsage:
-    """Token usage from an LLM response."""
+    """Token usage from an LLM response.
+
+    Cache fields (Defect A F-A2, 2026-05-11): previously the normalize
+    layer dropped Anthropic's ``cache_creation_input_tokens`` and
+    ``cache_read_input_tokens``, so even though the adapter paid the
+    cost (and ``TokenTracker.calculate_cost`` accepted the kwargs),
+    the per-call record arriving at ``_response.track_usage`` had no
+    cache counts to forward. The result was a silently underestimated
+    session cost and an empty cache column in ``~/.geode/usage/``
+    JSONL — the kind of silent loss the petri Defect A live verify
+    (#1020) flagged. Codex/GLM normalizers leave these at 0 until
+    those providers ship cache surfaces.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
     thinking_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
 
 
 @dataclass
@@ -151,10 +165,20 @@ def normalize_anthropic(response: Any) -> AgenticResponse:
         thinking_tok = 0
         if hasattr(response.usage, "thinking_tokens"):
             thinking_tok = response.usage.thinking_tokens or 0
+        # Defect A F-A2 — preserve cache token counts so the downstream
+        # ``_response.track_usage`` can forward them to the tracker
+        # (which already prices them correctly via ``calculate_cost``).
+        # The SDK exposes them as ``cache_creation_input_tokens`` /
+        # ``cache_read_input_tokens``; we standardise to the shorter
+        # names on ResponseUsage to match TokenTracker.record kwargs.
+        cache_create = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+        cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
         usage = ResponseUsage(
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens,
             thinking_tokens=thinking_tok,
+            cache_creation_tokens=cache_create,
+            cache_read_tokens=cache_read,
         )
 
     return AgenticResponse(
@@ -216,10 +240,20 @@ def normalize_openai(response: Any) -> AgenticResponse:
         details = getattr(response.usage, "completion_tokens_details", None)
         if details is not None:
             thinking_tok = getattr(details, "reasoning_tokens", 0) or 0
+        # Defect A F-A2 — OpenAI Chat Completions reports cached input
+        # tokens in ``prompt_tokens_details.cached_tokens``. The cached
+        # portion is *included* in ``prompt_tokens`` so we surface it
+        # separately for the tracker (which prices it at the cache_read
+        # rate). No cache_write equivalent on Chat Completions.
+        cache_read = 0
+        prompt_details = getattr(response.usage, "prompt_tokens_details", None)
+        if prompt_details is not None:
+            cache_read = getattr(prompt_details, "cached_tokens", 0) or 0
         usage = ResponseUsage(
             input_tokens=response.usage.prompt_tokens or 0,
             output_tokens=response.usage.completion_tokens or 0,
             thinking_tokens=thinking_tok,
+            cache_read_tokens=cache_read,
         )
 
     return AgenticResponse(

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -32,12 +32,24 @@ log = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class LLMUsage:
-    """Single LLM call usage record."""
+    """Single LLM call usage record.
+
+    Cache fields (added 2026-05-11 for Defect A F-A2): we previously
+    recorded the *cost* of cache_creation / cache_read tokens through
+    ``calculate_cost`` but the token counts themselves were dropped at
+    record time. That made downstream tracker snapshots invisible to
+    anyone who needed cache hit rate (prompt-caching audit) or wanted
+    to emit ``inspect_ai.model.ModelUsage`` with the cache fields
+    populated. Keep these on the record so a snapshot delta preserves
+    the full per-call shape.
+    """
 
     model: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
     thinking_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
     cost_usd: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
@@ -49,6 +61,10 @@ class LLMUsage:
         }
         if self.thinking_tokens:
             d["thinking_tokens"] = self.thinking_tokens
+        if self.cache_creation_tokens:
+            d["cache_creation_tokens"] = self.cache_creation_tokens
+        if self.cache_read_tokens:
+            d["cache_read_tokens"] = self.cache_read_tokens
         return d
 
 
@@ -71,6 +87,14 @@ class LLMUsageAccumulator:
         return sum(c.thinking_tokens for c in self.calls)
 
     @property
+    def total_cache_creation_tokens(self) -> int:
+        return sum(c.cache_creation_tokens for c in self.calls)
+
+    @property
+    def total_cache_read_tokens(self) -> int:
+        return sum(c.cache_read_tokens for c in self.calls)
+
+    @property
     def total_cost_usd(self) -> float:
         return sum(c.cost_usd for c in self.calls)
 
@@ -87,6 +111,12 @@ class LLMUsageAccumulator:
         thinking = self.total_thinking_tokens
         if thinking:
             d["total_thinking_tokens"] = thinking
+        cache_w = self.total_cache_creation_tokens
+        if cache_w:
+            d["total_cache_creation_tokens"] = cache_w
+        cache_r = self.total_cache_read_tokens
+        if cache_r:
+            d["total_cache_read_tokens"] = cache_r
         return d
 
 
@@ -227,10 +257,20 @@ MODEL_CONTEXT_WINDOW: dict[str, int] = {
 
 
 class UsageSnapshot(NamedTuple):
-    """Immutable snapshot of cumulative usage at a point in time."""
+    """Immutable snapshot of cumulative usage at a point in time.
+
+    Defect A F-A1 (2026-05-11): added thinking / cache fields so a
+    snapshot delta carries the full per-call shape. AgenticLoop now
+    captures one of these at the top of ``arun`` and the finalize path
+    turns ``delta_since(snap)`` into an ``LLMUsage`` aggregate that
+    GeodeModelAPI translates into ``inspect_ai.model.ModelUsage``.
+    """
 
     total_input_tokens: int
     total_output_tokens: int
+    total_thinking_tokens: int
+    total_cache_creation_tokens: int
+    total_cache_read_tokens: int
     total_cost_usd: float
     call_count: int
 
@@ -281,6 +321,8 @@ class TokenTracker:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             thinking_tokens=thinking_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
             cost_usd=cost,
         )
         self._accumulator.record(usage)
@@ -333,6 +375,9 @@ class TokenTracker:
         return UsageSnapshot(
             total_input_tokens=acc.total_input_tokens,
             total_output_tokens=acc.total_output_tokens,
+            total_thinking_tokens=acc.total_thinking_tokens,
+            total_cache_creation_tokens=acc.total_cache_creation_tokens,
+            total_cache_read_tokens=acc.total_cache_read_tokens,
             total_cost_usd=acc.total_cost_usd,
             call_count=len(acc.calls),
         )
@@ -343,6 +388,10 @@ class TokenTracker:
         return UsageSnapshot(
             total_input_tokens=acc.total_input_tokens - snap.total_input_tokens,
             total_output_tokens=acc.total_output_tokens - snap.total_output_tokens,
+            total_thinking_tokens=acc.total_thinking_tokens - snap.total_thinking_tokens,
+            total_cache_creation_tokens=acc.total_cache_creation_tokens
+            - snap.total_cache_creation_tokens,
+            total_cache_read_tokens=acc.total_cache_read_tokens - snap.total_cache_read_tokens,
             total_cost_usd=acc.total_cost_usd - snap.total_cost_usd,
             call_count=len(acc.calls) - snap.call_count,
         )

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -35,13 +35,27 @@ installs trigger registration, absent-extra installs silently skip.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+log = logging.getLogger(__name__)
+
 # Single-turn GEODE runner. Caller owns AgenticLoop bootstrap; we hand
 # it the converted GEODE-format message history and receive the assistant
-# text. Injection seam keeps unit tests free of a live LLM call.
-GeodeRunner = Callable[[list[dict[str, Any]]], Awaitable[str]]
+# text PLUS an optional usage dict.
+#
+# F-A1 (2026-05-11) — runner contract widened from ``Awaitable[str]`` to
+# ``Awaitable[str | tuple[str, dict | None]]``. ``GeodeModelAPI.generate``
+# unpacks both forms so existing test runners (``runner=fake`` returning
+# a bare string) keep working — the new tuple form lets the runner
+# surface the underlying loop's aggregate usage into
+# ``inspect_ai.model.ModelOutput.usage`` (and therefore into the eval
+# log's ``role_usage`` aggregation, which scoped on usage presence).
+GeodeRunner = Callable[
+    [list[dict[str, Any]]],
+    Awaitable["str | tuple[str, dict[str, Any] | None]"],
+]
 
 
 def _to_geode_messages(messages: list[Any]) -> list[dict[str, Any]]:
@@ -146,7 +160,7 @@ async def _default_geode_runner(
     messages: list[dict[str, Any]],
     *,
     model: str | None = None,
-) -> str:
+) -> tuple[str, dict[str, Any] | None]:
     """Default GEODE runner — bootstrap + ``AgenticLoop`` one-shot.
 
     Imports GEODE core lazily so the module-level surface stays free of
@@ -191,6 +205,18 @@ async def _default_geode_runner(
 
     system_text, history, last_user = _split_messages(messages)
 
+    # Defect A F-A3 (2026-05-11) — entry observability. Before this PR
+    # the live audit gave no signal whether GeodeModelAPI.generate was
+    # actually flowing through the runner, so chasing "tracker 0 records"
+    # post-mortems meant reading the inspect log's ModelEvent stream
+    # backward. INFO-level on entry, DEBUG once AgenticLoop is up.
+    log.info(
+        "petri runner entry: msg_count=%d last_user_chars=%d model=%s",
+        len(messages),
+        len(last_user),
+        model,
+    )
+
     readiness = check_readiness()
     _set_readiness(readiness)
     handlers = _build_tool_handlers(verbose=False)
@@ -213,6 +239,13 @@ async def _default_geode_runner(
         model=model,
         disable_settings_drift=(model is not None),
     )
+    log.debug(
+        "AgenticLoop constructed: model=%s drift_disabled=%s system_chars=%d history=%d",
+        loop.model,
+        model is not None,
+        len(system_text),
+        len(history),
+    )
 
     # ``loop.run()`` wraps ``asyncio.run(self.arun(...))`` which raises
     # ``RuntimeError: asyncio.run() cannot be called from a running event
@@ -222,7 +255,14 @@ async def _default_geode_runner(
     # loop and fixes the v2 N3 silent target-invocation failure
     # (``docs/audits/2026-05-10-petri-2a-v2.md`` § C4).
     result = await loop.arun(last_user)
-    return result.text or ""
+    text = result.text or ""
+    usage_dict = result.usage.to_dict() if result.usage is not None else None
+    log.info(
+        "petri runner exit: text_chars=%d usage=%s",
+        len(text),
+        usage_dict,
+    )
+    return text, usage_dict
 
 
 def register() -> None:
@@ -246,10 +286,13 @@ def register() -> None:
         model = get_model("geode/opus-4-7", runner=fake_runner)
     """
     from inspect_ai.model import (
+        ChatCompletionChoice,
         ChatMessage,
+        ChatMessageAssistant,
         GenerateConfig,
         ModelAPI,
         ModelOutput,
+        ModelUsage,
         modelapi,
     )
     from inspect_ai.tool import ToolChoice, ToolInfo
@@ -295,12 +338,18 @@ def register() -> None:
             _ = tools, tool_choice, config
 
             geode_messages = _to_geode_messages(input)
+            usage_dict: dict[str, Any] | None = None
             if self._runner is not None:
                 # Custom runner (used by tests via the ``runner=`` model
                 # arg). Receives messages only — ``model_name`` is
                 # already on ``self`` for any introspection the test
-                # wants to do.
-                text = await self._runner(geode_messages)
+                # wants to do. F-A1 back-compat — accept either bare str
+                # or ``(text, usage_dict)`` tuple.
+                raw = await self._runner(geode_messages)
+                if isinstance(raw, tuple):
+                    text, usage_dict = raw
+                else:
+                    text = raw
             else:
                 # N6-followup priority: pass the caller-pinned base
                 # model down to the runner. ``model_name`` is shaped
@@ -308,7 +357,40 @@ def register() -> None:
                 # means "no caller pin — fall back to settings.model".
                 base = self.model_name.rsplit("/", 1)[-1]
                 runner_model: str | None = None if base == "default" else base
-                text = await _default_geode_runner(geode_messages, model=runner_model)
-            return ModelOutput.from_content(model=self.model_name, content=text)
+                text, usage_dict = await _default_geode_runner(geode_messages, model=runner_model)
+            # Defect A F-A1 — emit a fully populated ``ModelUsage`` so
+            # inspect_ai's ``log.stats.role_usage["target"]`` is non-
+            # empty. ``ModelOutput.from_content`` would leave it None
+            # and the petri eval log would have the target column
+            # silently missing (the symptom of #1020).
+            inspect_usage: ModelUsage | None = None
+            if usage_dict:
+                cache_w = int(usage_dict.get("cache_creation_tokens", 0) or 0)
+                cache_r = int(usage_dict.get("cache_read_tokens", 0) or 0)
+                in_tok = int(usage_dict.get("input_tokens", 0) or 0)
+                out_tok = int(usage_dict.get("output_tokens", 0) or 0)
+                inspect_usage = ModelUsage(
+                    input_tokens=in_tok,
+                    output_tokens=out_tok,
+                    total_tokens=in_tok + out_tok + cache_w + cache_r,
+                    input_tokens_cache_write=cache_w or None,
+                    input_tokens_cache_read=cache_r or None,
+                    reasoning_tokens=(int(usage_dict.get("thinking_tokens", 0) or 0) or None),
+                    total_cost=usage_dict.get("cost_usd"),
+                )
+            return ModelOutput(
+                model=self.model_name,
+                choices=[
+                    ChatCompletionChoice(
+                        message=ChatMessageAssistant(
+                            content=text,
+                            model=self.model_name,
+                            source="generate",
+                        ),
+                        stop_reason="stop",
+                    )
+                ],
+                usage=inspect_usage,
+            )
 
     _ = GeodeModelAPI  # decorator return is unused at module level

--- a/tests/plugins/petri_audit/test_skeleton.py
+++ b/tests/plugins/petri_audit/test_skeleton.py
@@ -238,6 +238,120 @@ def test_token_tracker_record_appends_to_geode_usage_jsonl(tmp_path: Path) -> No
     assert '"input_tokens": 10' in body or '"input": 10' in body or "10" in body
 
 
+def test_default_runner_returns_text_and_usage_tuple(monkeypatch) -> None:
+    """F-A1 contract — ``_default_geode_runner`` returns ``(text,
+    usage_dict)``. The Custom ModelAPI surfaces ``usage_dict`` into
+    inspect_ai's ``ModelOutput.usage`` so the eval log's role_usage
+    aggregation finally lists the target. Pre-F-A1 the runner returned
+    bare text and the petri audit's target column was always empty
+    (see ``docs/audits/2026-05-11-petri-tracker-A-live-verify.md``).
+
+    Mock-based — exercises the runner without spinning up the full
+    GEODE bootstrap (which would need readiness, handlers, executor).
+    """
+    if not _AUDIT_INSTALLED:
+        pytest.skip("[audit] extra not installed")
+
+    from core.llm.token_tracker import LLMUsage
+    from plugins.petri_audit.targets import geode_target
+    from plugins.petri_audit.targets.geode_target import _default_geode_runner
+
+    class _FakeAgenticResult:
+        text = "hi"
+        usage = LLMUsage(
+            model="claude-haiku-4-5-20251001",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=80,
+            thinking_tokens=12,
+            cost_usd=0.001,
+        )
+
+    class _FakeLoop:
+        def __init__(self, *args, **kwargs) -> None:
+            self.model = kwargs.get("model") or "claude-haiku-4-5-20251001"
+
+        async def arun(self, _user_input):
+            return _FakeAgenticResult()
+
+    monkeypatch.setattr(geode_target, "_to_geode_messages", lambda msgs: msgs)
+    monkeypatch.setattr("core.wiring.startup.check_readiness", lambda: object(), raising=False)
+    monkeypatch.setattr("core.cli._set_readiness", lambda r: None, raising=False)
+    monkeypatch.setattr("core.cli._build_tool_handlers", lambda verbose=False: {}, raising=False)
+    monkeypatch.setattr(
+        "core.agent.conversation.ConversationContext", lambda: type("X", (), {"messages": []})()
+    )
+    monkeypatch.setattr("core.agent.tool_executor.ToolExecutor", lambda **k: None)
+    monkeypatch.setattr("core.agent.loop.AgenticLoop", _FakeLoop)
+
+    text, usage = asyncio.run(
+        _default_geode_runner(
+            [{"role": "user", "content": "hello"}], model="claude-haiku-4-5-20251001"
+        )
+    )
+    assert text == "hi"
+    assert usage is not None
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 50
+    assert usage["cache_read_tokens"] == 80
+    assert usage["thinking_tokens"] == 12
+    assert usage["cost_usd"] == 0.001
+
+
+def test_geode_model_api_emits_inspect_modelusage(monkeypatch) -> None:
+    """F-A1 — ``GeodeModelAPI.generate`` constructs ``ModelOutput`` with
+    a fully populated ``ModelUsage``. Direct construction (vs the
+    simple ``from_content`` factory) is required for inspect_ai's
+    log.stats.role_usage aggregation to count target tokens.
+
+    Uses the ``runner=fake`` injection seam so no live LLM call.
+    """
+    if not _AUDIT_INSTALLED:
+        pytest.skip("[audit] extra not installed")
+    from inspect_ai.model import get_model
+
+    async def fake_runner(_messages):
+        return "hi", {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_tokens": 80,
+            "thinking_tokens": 12,
+            "cost_usd": 0.001,
+        }
+
+    model = get_model("geode/claude-haiku-4-5-20251001", runner=fake_runner)
+    out = asyncio.run(model.generate("hello"))
+
+    assert out.usage is not None
+    assert out.usage.input_tokens == 100
+    assert out.usage.output_tokens == 50
+    assert out.usage.input_tokens_cache_read == 80
+    assert out.usage.reasoning_tokens == 12
+    assert out.usage.total_tokens == 100 + 50 + 80  # cache_w + cache_r summed
+    assert out.usage.total_cost == 0.001
+
+
+def test_geode_model_api_back_compat_str_runner(monkeypatch) -> None:
+    """D5 — pre-F-A1 test runners returned bare strings. The new
+    GeodeModelAPI must still accept this shape (``usage`` stays None)
+    so downstream tests on ``geode/...`` keep working."""
+    if not _AUDIT_INSTALLED:
+        pytest.skip("[audit] extra not installed")
+    from inspect_ai.model import get_model
+
+    async def fake_runner_str(_messages):
+        return "legacy-text"
+
+    # Different alias to dodge inspect_ai's get_model cache (the prior
+    # test in this module registered a different runner on the haiku
+    # alias). Same code path either way.
+    model = get_model("geode/claude-opus-4-7", runner=fake_runner_str)
+    out = asyncio.run(model.generate("hello"))
+
+    assert out.choices[0].message.text == "legacy-text"
+    assert out.usage is None
+
+
 def test_petri_audit_does_not_register_domain() -> None:
     """petri_audit is an external evaluator, not a GEODE domain.
 

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -471,6 +472,62 @@ class TestAgenticLoop:
 
         with patch("core.llm.router.calculate_cost", side_effect=RuntimeError("boom")):
             loop._track_usage(mock_response)  # should not raise
+
+    def test_track_usage_records_cache_tokens(
+        self, context: ConversationContext, executor: ToolExecutor
+    ) -> None:
+        """F-A2 — cache_creation_tokens / cache_read_tokens must flow
+        from ``response.usage`` (normalized ``ResponseUsage``) through
+        ``_track_usage`` into ``TokenTracker.record``, where the cost
+        path already handles them. Pre-F-A2 they were dropped and the
+        ``~/.geode/usage`` JSONL undercounted prompt-cache spend."""
+        from core.llm.token_tracker import get_tracker, reset_tracker
+
+        reset_tracker()
+        loop = AgenticLoop(context, executor, quiet=True)
+
+        mock_response = MagicMock()
+        mock_response.usage = MagicMock(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_tokens=20,
+            cache_read_tokens=80,
+            thinking_tokens=10,
+        )
+
+        loop._track_usage(mock_response)
+
+        last = get_tracker().accumulator.calls[-1]
+        assert last.input_tokens == 100
+        assert last.output_tokens == 50
+        assert last.cache_creation_tokens == 20
+        assert last.cache_read_tokens == 80
+        assert last.thinking_tokens == 10
+
+    def test_track_usage_logs_warning_on_schema_mismatch(
+        self,
+        context: ConversationContext,
+        executor: ToolExecutor,
+        caplog,
+    ) -> None:
+        """F-A2 — when the inner ``tracker.record`` raises (e.g. the
+        wrapper has only ``input_tokens`` and downstream code trips),
+        the swallowed exception must surface at WARNING level. Pre-F-A2
+        it was DEBUG-level and the silent-skip was invisible in normal
+        log output — Defect A's main symptom."""
+        loop = AgenticLoop(context, executor, quiet=True)
+        mock_response = MagicMock()
+        mock_response.usage = MagicMock(input_tokens=100, output_tokens=50)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="core.agent.loop._response"),
+            patch("core.llm.token_tracker.TokenTracker.record", side_effect=RuntimeError("boom")),
+        ):
+            loop._track_usage(mock_response)  # should not raise
+
+        assert any("Failed to track usage" in r.message for r in caplog.records), (
+            "track_usage must log at WARNING when it swallows a record() failure"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- petri target tokens → inspect_ai role_usage + GEODE tracker wiring 보강 (#1024)
- F-A1 ModelOutput.usage 직접 구성, F-A2 track_usage 안전화 + cache 토큰, F-A3 observability

## Verification
- [x] CI 6/6 (#1024)
- [x] 4520 tests pass