### PR TITLE
fix(audit): petri judge/auditor usage 가 ~/.geode/usage/ JSONL ledger 에도 흐르도록 cross-session 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,40 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     `tests/test_agentic_loop.py` 2 신규 (track_usage cache 토큰
     flow-through, schema mismatch 시 WARNING). 4520 tests pass.
 
+- **Defect A F-A2 follow-up — petri judge / auditor / target usage 가
+  `~/.geode/usage/<YYYY-MM>.jsonl` 에도 흐르도록 cross-session ledger
+  보강.** 5/11 라이브 anthropic archive `.eval` 의 `role_usage` 는
+  judge `in=21 out=846 cache_w=6740`, auditor `in=7 out=1007 cache_r=
+  34006` 을 정상 기록하는 동안 같은 wall-clock 윈도우 (`2026-05-11
+  08:00-09:00 UTC`) 의 GEODE JSONL 에는 0 record — inspect_ai 의 native
+  `AnthropicAPI` / `OpenAIAPI` 가 GEODE TokenTracker 를 우회해 provider
+  SDK 를 직접 호출하기 때문 (ts 매치로 확정). `geode history` rollup
+  이 모든 petri audit 의 judge + auditor 비용을 빠뜨리고 있었음.
+  본 PR —
+  - `UsageRecord` schema 확장 — `cache_creation_tokens` (serialized
+    `cache_w`), `cache_read_tokens` (`cache_r`), `thinking_tokens`
+    (`think`), `role`, `source`, `eval_id` 필드 추가. `to_json` 이
+    falsy 시 omit, `from_json` 이 `.get(..., 0/"")` fallback —
+    pre-extension JSONL row 가 새 reader 에서 그대로 round-trip.
+  - `TokenTracker._persist_usage` 가 cache / thinking 을 실제로
+    JSONL 까지 흘려보냄 — F-A2 가 in-memory accumulator 까지만
+    채우고 persistent store 에서 drop 하던 잔여 leak 해결.
+  - `core/audit/eval_to_jsonl.py` 신규 — petri eval 종료 후
+    `extract_to_usage_store(.eval)` 가 `EvalStats.model_usage` 를
+    walk + `eval.model_roles` 의 role 태그를 매핑해 per-model row
+    를 `source="petri_eval"` 로 append. ts 는 `eval.created` 의
+    ISO8601 → unix 변환으로 wall-clock 보존. idempotent —
+    `UsageStore.has_eval_id` 로 중복 import 차단.
+  - `plugins.petri_audit.runner._maybe_auto_archive` 가 archive
+    직후 hook 호출 (`_import_usage`). 실패 시 swallow + note 만
+    — audit 자체는 영향 없음.
+  - **회귀 가드** — `tests/test_usage_store.py` 3 클래스 신규
+    (extension fields 직렬화/legacy compat, store record 의 cache
+    forwarding + has_eval_id dedup, TokenTracker.record 의 cache
+    flow-through) + `tests/audit/test_eval_to_jsonl.py` 6 신규
+    (ts 파싱, missing file, empty stats, role 태그 매핑, cost
+    fallback, idempotency, unknown role). 4517 passed.
+
 ### Notes
 
 - **`/claude-api migrate` to Opus 4.7 — noop migration.**

--- a/core/audit/__init__.py
+++ b/core/audit/__init__.py
@@ -1,0 +1,14 @@
+"""Audit-side bookkeeping for inspect_petri runs.
+
+Bridges inspect_ai's per-eval ``.eval`` archive (single-eval scope,
+``EvalStats.role_usage`` / ``model_usage`` in the header) and GEODE's
+cross-session ``~/.geode/usage/`` JSONL ledger. inspect_ai's native
+``AnthropicAPI`` / ``OpenAIAPI`` bypass GEODE's TokenTracker so judge
+and auditor cost is otherwise invisible to ``geode history``.
+"""
+
+from __future__ import annotations
+
+from core.audit.eval_to_jsonl import extract_to_usage_store
+
+__all__ = ["extract_to_usage_store"]

--- a/core/audit/eval_to_jsonl.py
+++ b/core/audit/eval_to_jsonl.py
@@ -1,0 +1,161 @@
+"""Extract token usage from a petri ``.eval`` archive into the GEODE
+``~/.geode/usage/`` JSONL ledger.
+
+inspect_ai's native ``AnthropicAPI`` / ``OpenAIAPI`` reach the provider
+SDK directly — GEODE's TokenTracker sees zero calls when the audit's
+judge / auditor models fire. Verified 2026-05-11 against the 5/11 live
+archive: ``.eval`` ``role_usage`` shows judge + auditor token counts,
+the same wall-clock minute in ``~/.geode/usage/2026-05.jsonl`` has zero
+matching rows.
+
+This module closes the gap by walking ``EvalStats.model_usage`` after
+the eval completes and appending one ``source='petri_eval'`` JSONL row
+per model with the role tag recovered from ``eval.model_roles``. Run
+once per archive and idempotent (duplicate ``eval_id`` inserts are
+skipped via :meth:`core.llm.usage_store.UsageStore.has_eval_id`).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.llm.usage_store import UsageStore
+
+log = logging.getLogger(__name__)
+
+__all__ = ["extract_to_usage_store"]
+
+
+def _basename(model_id: str) -> str:
+    """Strip the inspect_ai provider prefix (``anthropic/`` etc.) so
+    GEODE ``MODEL_PRICING`` lookup hits.
+    """
+    return model_id.rsplit("/", 1)[-1]
+
+
+def _parse_eval_ts(created: Any) -> float | None:
+    """Parse ``eval.created`` ISO8601 string → unix epoch float.
+
+    Returns ``None`` when the string is missing or unparseable so the
+    caller falls back to ``time.time()`` rather than stamping the row
+    with epoch 0.
+    """
+    if not created:
+        return None
+    try:
+        return datetime.fromisoformat(str(created).replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def extract_to_usage_store(
+    eval_path: Path | str,
+    *,
+    store: UsageStore | None = None,
+    skip_if_present: bool = True,
+) -> int:
+    """Read a petri ``.eval`` header and append one row per model.
+
+    Returns the number of rows actually written. Returns ``0`` (silent
+    no-op) when:
+
+    - ``inspect_ai`` is not installed (default ``uv sync`` env)
+    - the eval file does not exist
+    - ``EvalStats.model_usage`` is empty (eval cancelled before any LLM
+      call landed)
+    - ``skip_if_present`` and the ``eval_id`` is already in the JSONL
+
+    Failures inside the read path are caught + logged at WARNING — a
+    bookkeeping error must never fail the audit.
+    """
+    try:
+        from inspect_ai.log import read_eval_log
+    except ImportError:
+        log.debug("inspect_ai not installed — eval_to_jsonl is a no-op")
+        return 0
+
+    from core.llm.token_tracker import get_tracker
+    from core.llm.usage_store import get_usage_store
+
+    path = Path(eval_path).expanduser()
+    if not path.is_file():
+        log.warning("eval_to_jsonl: %s does not exist", path)
+        return 0
+
+    eval_id = path.name
+    target_store: UsageStore = store if store is not None else get_usage_store()
+
+    if skip_if_present and target_store.has_eval_id(eval_id):
+        log.debug("eval_to_jsonl: skipping already-imported %s", eval_id)
+        return 0
+
+    try:
+        elog = read_eval_log(str(path), header_only=True)
+    except Exception:
+        log.warning("eval_to_jsonl: failed to read %s", path, exc_info=True)
+        return 0
+
+    stats = getattr(elog.stats, "model_usage", None) or {}
+    if not stats:
+        log.debug("eval_to_jsonl: %s has empty model_usage", eval_id)
+        return 0
+
+    model_roles = getattr(elog.eval, "model_roles", None) or {}
+    inverted: dict[str, str] = {}
+    for role, cfg in model_roles.items():
+        model_id = getattr(cfg, "model", None) or str(cfg)
+        if model_id:
+            inverted[str(model_id)] = str(role)
+
+    eval_ts = _parse_eval_ts(getattr(elog.eval, "created", None))
+    tracker = get_tracker()
+
+    appended = 0
+    for model_id, usage in stats.items():
+        role = inverted.get(str(model_id), "")
+        basename = _basename(str(model_id))
+        in_tok = int(getattr(usage, "input_tokens", 0) or 0)
+        out_tok = int(getattr(usage, "output_tokens", 0) or 0)
+        cache_w = int(getattr(usage, "input_tokens_cache_write", 0) or 0)
+        cache_r = int(getattr(usage, "input_tokens_cache_read", 0) or 0)
+        think = int(getattr(usage, "reasoning_tokens", 0) or 0)
+        # Prefer inspect_ai's own total_cost when present; fall back to
+        # GEODE MODEL_PRICING when the field is None or 0 (current
+        # behaviour for both anthropic and openai providers as of
+        # inspect_ai 0.3.220 — total_cost is unset in EvalStats).
+        cost = float(getattr(usage, "total_cost", 0.0) or 0.0)
+        if cost <= 0.0:
+            cost = tracker.calculate_cost(
+                basename,
+                in_tok,
+                out_tok,
+                cache_creation_tokens=cache_w,
+                cache_read_tokens=cache_r,
+                thinking_tokens=think,
+            )
+        target_store.record(
+            basename,
+            in_tok,
+            out_tok,
+            cost,
+            cache_creation_tokens=cache_w,
+            cache_read_tokens=cache_r,
+            thinking_tokens=think,
+            role=role,
+            source="petri_eval",
+            eval_id=eval_id,
+            ts=eval_ts,
+        )
+        appended += 1
+
+    log.info(
+        "eval_to_jsonl: imported %d rows from %s (roles=%s)",
+        appended,
+        eval_id,
+        sorted(set(inverted.values())),
+    )
+    return appended

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -326,7 +326,15 @@ class TokenTracker:
             cost_usd=cost,
         )
         self._accumulator.record(usage)
-        self._persist_usage(model, input_tokens, output_tokens, cost)
+        self._persist_usage(
+            model,
+            input_tokens,
+            output_tokens,
+            cost,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
+            thinking_tokens=thinking_tokens,
+        )
         return usage
 
     def calculate_cost(
@@ -409,12 +417,30 @@ class TokenTracker:
         input_tokens: int,
         output_tokens: int,
         cost_usd: float,
+        *,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        thinking_tokens: int = 0,
     ) -> None:
-        """Persist usage to ~/.geode/usage/ JSONL (no-op on failure)."""
+        """Persist usage to ~/.geode/usage/ JSONL (no-op on failure).
+
+        Cache / thinking fields added 2026-05-11 to close the F-A2 leak.
+        ``record`` already populated these on the in-memory accumulator
+        but ``_persist_usage`` dropped them, so the JSONL on disk and
+        ``geode history`` rollups silently zero-rated prompt-cache cost.
+        """
         try:
             from core.llm.usage_store import get_usage_store
 
-            get_usage_store().record(model, input_tokens, output_tokens, cost_usd)
+            get_usage_store().record(
+                model,
+                input_tokens,
+                output_tokens,
+                cost_usd,
+                cache_creation_tokens=cache_creation_tokens,
+                cache_read_tokens=cache_read_tokens,
+                thinking_tokens=thinking_tokens,
+            )
         except Exception:
             log.debug("Usage persistence skipped", exc_info=True)
 

--- a/core/llm/usage_store.py
+++ b/core/llm/usage_store.py
@@ -23,7 +23,29 @@ DEFAULT_USAGE_DIR = Path.home() / ".geode" / "usage"
 
 @dataclass(slots=True)
 class UsageRecord:
-    """Single LLM call usage record for JSONL persistence."""
+    """Single LLM call usage record for JSONL persistence.
+
+    Cache / thinking / role / source fields added 2026-05-11 to close the
+    Defect A F-A2 leak. Pre-extension records (no ``cache_w`` / ``cache_r``
+    / ``think`` / ``role`` / ``source`` / ``eval_id``) round-trip cleanly
+    because ``from_json`` ``.get(...)`` falls back to ``0`` / ``""``.
+
+    ``source`` distinguishes the producer:
+
+    - ``""`` (default) — recorded by ``TokenTracker.record`` at the
+      AgenticLoop seam: one row per LLM call. This is the historical
+      behaviour and how ``geode history`` rolls up monthly cost.
+    - ``"petri_eval"`` — appended by ``core.audit.eval_to_jsonl`` once
+      per ``(model, role)`` pair after an ``inspect_petri`` audit
+      finishes. inspect_ai's native ``AnthropicAPI`` / ``OpenAIAPI``
+      bypass GEODE's TokenTracker (verified 2026-05-11 via the 5/11
+      live archive ts-match), so judge / auditor cost is invisible to
+      ``geode history`` without this extraction path.
+
+    ``role`` is the inspect_ai role tag (``target`` / ``judge`` /
+    ``auditor``) — empty for source ``""``. ``eval_id`` is the eval
+    log basename, used by ``eval_to_jsonl`` to skip duplicate inserts.
+    """
 
     ts: float
     model: str
@@ -32,10 +54,16 @@ class UsageRecord:
     cost_usd: float = field(metadata={"alias": "cost"})
     session: str = ""
     ip_name: str = ""
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    thinking_tokens: int = 0
+    role: str = ""
+    source: str = ""
+    eval_id: str = ""
 
     def to_json(self) -> str:
-        """Serialize to compact JSON line."""
-        d = {
+        """Serialize to compact JSON line. Falsy extension fields omitted."""
+        d: dict[str, Any] = {
             "ts": self.ts,
             "model": self.model,
             "in": self.input_tokens,
@@ -46,11 +74,23 @@ class UsageRecord:
             d["session"] = self.session
         if self.ip_name:
             d["ip"] = self.ip_name
+        if self.cache_creation_tokens:
+            d["cache_w"] = self.cache_creation_tokens
+        if self.cache_read_tokens:
+            d["cache_r"] = self.cache_read_tokens
+        if self.thinking_tokens:
+            d["think"] = self.thinking_tokens
+        if self.role:
+            d["role"] = self.role
+        if self.source:
+            d["source"] = self.source
+        if self.eval_id:
+            d["eval_id"] = self.eval_id
         return json.dumps(d, ensure_ascii=False, separators=(",", ":"))
 
     @classmethod
     def from_json(cls, line: str) -> UsageRecord:
-        """Deserialize from a JSON line."""
+        """Deserialize from a JSON line. Missing extension fields → defaults."""
         data = json.loads(line)
         return cls(
             ts=data.get("ts", 0.0),
@@ -60,6 +100,12 @@ class UsageRecord:
             cost_usd=data.get("cost", 0.0),
             session=data.get("session", ""),
             ip_name=data.get("ip", ""),
+            cache_creation_tokens=data.get("cache_w", 0),
+            cache_read_tokens=data.get("cache_r", 0),
+            thinking_tokens=data.get("think", 0),
+            role=data.get("role", ""),
+            source=data.get("source", ""),
+            eval_id=data.get("eval_id", ""),
         )
 
 
@@ -92,20 +138,50 @@ class UsageStore:
         *,
         session: str = "",
         ip_name: str = "",
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        thinking_tokens: int = 0,
+        role: str = "",
+        source: str = "",
+        eval_id: str = "",
+        ts: float | None = None,
     ) -> UsageRecord:
-        """Append a usage record to the current month's JSONL file."""
-        now = time.time()
+        """Append a usage record to the JSONL file (current month by default).
+
+        ``ts`` may be passed explicitly so :mod:`core.audit.eval_to_jsonl`
+        can stamp extracted records with the eval's start time instead of
+        the (later) extraction time — keeps cross-tier ts-matching intact.
+        """
         entry = UsageRecord(
-            ts=now,
+            ts=ts if ts is not None else time.time(),
             model=model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=cost_usd,
             session=session,
             ip_name=ip_name,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
+            thinking_tokens=thinking_tokens,
+            role=role,
+            source=source,
+            eval_id=eval_id,
         )
         self._append(entry)
         return entry
+
+    def has_eval_id(self, eval_id: str, year: int | None = None, month: int | None = None) -> bool:
+        """Return True if a record with ``source='petri_eval'`` and the
+        given ``eval_id`` already exists in the month file. Used by
+        :mod:`core.audit.eval_to_jsonl` to skip duplicate extractions.
+        """
+        if not eval_id:
+            return False
+        today = date.today()
+        y = year or today.year
+        m = month or today.month
+        records = self._read_month(y, m)
+        return any(r.eval_id == eval_id and r.source == "petri_eval" for r in records)
 
     def get_monthly_summary(
         self,

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -595,4 +595,25 @@ def _maybe_auto_archive(
     except Exception as exc:  # pragma: no cover — defensive: archive must not fail an audit
         notes.append(f"auto-archive failed: {exc}")
         return None, None
+    _import_usage(result.raw_path, notes)
     return str(result.raw_path), str(result.summary_path)
+
+
+def _import_usage(raw_path: Path, notes: list[str]) -> None:
+    """Append judge / auditor / target rows from the archived ``.eval``
+    to ``~/.geode/usage/<YYYY-MM>.jsonl`` (Defect A F-A2 / 2026-05-11).
+
+    Best-effort and decoupled from archive: any failure is recorded as
+    a note on the AuditReport, never raised, so a broken bookkeeping
+    path cannot fail the audit. Idempotent — re-importing the same
+    archive is a no-op.
+    """
+    try:
+        from core.audit.eval_to_jsonl import extract_to_usage_store
+
+        n = extract_to_usage_store(raw_path)
+    except Exception as exc:  # pragma: no cover — defensive
+        notes.append(f"usage-import failed: {exc}")
+        return
+    if n > 0:
+        notes.append(f"usage-import: {n} row(s) appended to ~/.geode/usage/")

--- a/tests/audit/test_eval_to_jsonl.py
+++ b/tests/audit/test_eval_to_jsonl.py
@@ -200,9 +200,7 @@ class TestExtractToUsageStore:
             ),
             stats=FakeStats(
                 model_usage={
-                    "anthropic/claude-opus-4-7": FakeModelUsage(
-                        input_tokens=100, output_tokens=50
-                    )
+                    "anthropic/claude-opus-4-7": FakeModelUsage(input_tokens=100, output_tokens=50)
                 }
             ),
         )

--- a/tests/audit/test_eval_to_jsonl.py
+++ b/tests/audit/test_eval_to_jsonl.py
@@ -1,0 +1,232 @@
+"""Tests for ``core.audit.eval_to_jsonl`` — petri ``.eval`` → JSONL ledger.
+
+The extractor is exercised against a fake ``EvalLog`` (built with simple
+dataclasses) injected via ``monkeypatch`` on ``inspect_ai.log.read_eval_log``.
+This avoids the cost + flake of building a real ``.eval`` ZIP just to
+verify the bookkeeping path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("inspect_ai.log")
+
+from core.audit.eval_to_jsonl import _parse_eval_ts, extract_to_usage_store
+from core.llm.usage_store import UsageStore
+
+
+@dataclass
+class FakeModelUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    input_tokens_cache_write: int | None = None
+    input_tokens_cache_read: int | None = None
+    reasoning_tokens: int | None = None
+    total_cost: float | None = None
+
+
+@dataclass
+class FakeModelCfg:
+    model: str
+
+
+@dataclass
+class FakeEvalMeta:
+    model_roles: dict[str, FakeModelCfg] = field(default_factory=dict)
+    created: str = "2026-05-11T08:21:40+00:00"
+    task: str = "inspect_petri/audit"
+
+
+@dataclass
+class FakeStats:
+    model_usage: dict[str, FakeModelUsage] = field(default_factory=dict)
+
+
+@dataclass
+class FakeEvalLog:
+    eval: FakeEvalMeta
+    stats: FakeStats
+    status: str = "success"
+
+
+def _patch_read(monkeypatch: pytest.MonkeyPatch, fake_log: FakeEvalLog) -> None:
+    """Replace ``inspect_ai.log.read_eval_log`` with a constant return."""
+
+    def fake_read(*_args: Any, **_kwargs: Any) -> FakeEvalLog:
+        return fake_log
+
+    monkeypatch.setattr("inspect_ai.log.read_eval_log", fake_read)
+
+
+def _read_jsonl(tmp_path: Path) -> list[dict[str, Any]]:
+    today = date.today()
+    fpath = tmp_path / f"{today.year:04d}-{today.month:02d}.jsonl"
+    if not fpath.exists():
+        return []
+    return [json.loads(line) for line in fpath.read_text(encoding="utf-8").splitlines() if line]
+
+
+class TestParseEvalTs:
+    def test_iso_with_offset(self):
+        ts = _parse_eval_ts("2026-05-11T08:21:40+00:00")
+        assert ts == pytest.approx(1778573700.0, abs=1.0)
+
+    def test_iso_with_z(self):
+        ts = _parse_eval_ts("2026-05-11T08:21:40Z")
+        assert ts == pytest.approx(1778573700.0, abs=1.0)
+
+    def test_missing_returns_none(self):
+        assert _parse_eval_ts("") is None
+        assert _parse_eval_ts(None) is None
+
+    def test_garbage_returns_none(self):
+        assert _parse_eval_ts("not-a-date") is None
+
+
+class TestExtractToUsageStore:
+    @pytest.fixture()
+    def archive(self, tmp_path: Path) -> Path:
+        """Create a placeholder file that passes ``is_file()``."""
+        p = tmp_path / "2026-05-11T08-21-40-00-00_audit_X.eval"
+        p.write_bytes(b"pretend this is a zip")
+        return p
+
+    @pytest.fixture()
+    def store(self, tmp_path: Path) -> UsageStore:
+        return UsageStore(usage_dir=tmp_path / "usage")
+
+    def test_missing_file_is_silent_noop(self, store: UsageStore, tmp_path: Path):
+        n = extract_to_usage_store(tmp_path / "nope.eval", store=store)
+        assert n == 0
+        assert _read_jsonl(tmp_path / "usage") == []
+
+    def test_empty_model_usage_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch, archive: Path, store: UsageStore
+    ):
+        _patch_read(
+            monkeypatch,
+            FakeEvalLog(eval=FakeEvalMeta(), stats=FakeStats(model_usage={})),
+        )
+        assert extract_to_usage_store(archive, store=store) == 0
+
+    def test_appends_one_row_per_model_with_role_tag(
+        self, monkeypatch: pytest.MonkeyPatch, archive: Path, store: UsageStore, tmp_path: Path
+    ):
+        # Mirror the actual 5/11 anthropic archive shape (judge + auditor)
+        fake_log = FakeEvalLog(
+            eval=FakeEvalMeta(
+                model_roles={
+                    "auditor": FakeModelCfg(model="anthropic/claude-sonnet-4-6"),
+                    "judge": FakeModelCfg(model="anthropic/claude-haiku-4-5-20251001"),
+                },
+                created="2026-05-11T08:21:40+00:00",
+            ),
+            stats=FakeStats(
+                model_usage={
+                    "anthropic/claude-sonnet-4-6": FakeModelUsage(
+                        input_tokens=7,
+                        output_tokens=1007,
+                        input_tokens_cache_write=9169,
+                        input_tokens_cache_read=34006,
+                    ),
+                    "anthropic/claude-haiku-4-5-20251001": FakeModelUsage(
+                        input_tokens=21,
+                        output_tokens=846,
+                        input_tokens_cache_write=6740,
+                    ),
+                }
+            ),
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        n = extract_to_usage_store(archive, store=store)
+        assert n == 2
+
+        rows = _read_jsonl(tmp_path / "usage")
+        assert len(rows) == 2
+        by_role = {r["role"]: r for r in rows}
+        assert set(by_role) == {"auditor", "judge"}
+        # Provider prefix stripped so MODEL_PRICING lookup hits
+        assert by_role["auditor"]["model"] == "claude-sonnet-4-6"
+        assert by_role["judge"]["model"] == "claude-haiku-4-5-20251001"
+        # Cache fields preserved
+        assert by_role["auditor"]["cache_w"] == 9169
+        assert by_role["auditor"]["cache_r"] == 34006
+        assert by_role["judge"]["cache_w"] == 6740
+        # source / eval_id stamped
+        for r in rows:
+            assert r["source"] == "petri_eval"
+            assert r["eval_id"] == archive.name
+        # ts comes from eval.created, not now()
+        assert by_role["auditor"]["ts"] == pytest.approx(1778573700.0, abs=1.0)
+
+    def test_cost_filled_from_pricing_when_total_cost_missing(
+        self, monkeypatch: pytest.MonkeyPatch, archive: Path, store: UsageStore, tmp_path: Path
+    ):
+        fake_log = FakeEvalLog(
+            eval=FakeEvalMeta(
+                model_roles={"judge": FakeModelCfg(model="anthropic/claude-haiku-4-5-20251001")}
+            ),
+            stats=FakeStats(
+                model_usage={
+                    "anthropic/claude-haiku-4-5-20251001": FakeModelUsage(
+                        input_tokens=1000,
+                        output_tokens=200,
+                    ),
+                }
+            ),
+        )
+        _patch_read(monkeypatch, fake_log)
+        extract_to_usage_store(archive, store=store)
+
+        rows = _read_jsonl(tmp_path / "usage")
+        assert len(rows) == 1
+        # haiku-4-5: $1/M in + $5/M out → 1000 * 1e-6 + 200 * 5e-6 = $0.002
+        assert rows[0]["cost"] == pytest.approx(0.002, abs=1e-4)
+
+    def test_idempotent_second_call_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch, archive: Path, store: UsageStore, tmp_path: Path
+    ):
+        fake_log = FakeEvalLog(
+            eval=FakeEvalMeta(
+                model_roles={"target": FakeModelCfg(model="anthropic/claude-opus-4-7")}
+            ),
+            stats=FakeStats(
+                model_usage={
+                    "anthropic/claude-opus-4-7": FakeModelUsage(
+                        input_tokens=100, output_tokens=50
+                    )
+                }
+            ),
+        )
+        _patch_read(monkeypatch, fake_log)
+        assert extract_to_usage_store(archive, store=store) == 1
+        assert extract_to_usage_store(archive, store=store) == 0
+        # Still only one row
+        assert len(_read_jsonl(tmp_path / "usage")) == 1
+
+    def test_unknown_role_model_falls_through_with_empty_role(
+        self, monkeypatch: pytest.MonkeyPatch, archive: Path, store: UsageStore, tmp_path: Path
+    ):
+        # Model in stats but no role mapping (e.g. an unconfigured sub-model)
+        fake_log = FakeEvalLog(
+            eval=FakeEvalMeta(model_roles={}),
+            stats=FakeStats(
+                model_usage={
+                    "anthropic/claude-opus-4-7": FakeModelUsage(input_tokens=10, output_tokens=5)
+                }
+            ),
+        )
+        _patch_read(monkeypatch, fake_log)
+        extract_to_usage_store(archive, store=store)
+        rows = _read_jsonl(tmp_path / "usage")
+        assert len(rows) == 1
+        # role omitted (= "") when no model_roles match
+        assert "role" not in rows[0]

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -192,6 +192,182 @@ class TestUsageStore:
         assert summary["total_calls"] == 0
 
 
+class TestUsageRecordExtensionFields:
+    """Defect A F-A2 / 2026-05-11 — cache/think/role/source/eval_id extension."""
+
+    def test_to_json_omits_falsy_extension_fields(self):
+        rec = UsageRecord(
+            ts=1710000000.0,
+            model="claude-opus-4-6",
+            input_tokens=1000,
+            output_tokens=200,
+            cost_usd=0.01,
+        )
+        data = json.loads(rec.to_json())
+        # Pre-extension keys still present, extension keys omitted when 0/empty
+        assert "cache_w" not in data
+        assert "cache_r" not in data
+        assert "think" not in data
+        assert "role" not in data
+        assert "source" not in data
+        assert "eval_id" not in data
+
+    def test_to_json_emits_extension_fields_when_set(self):
+        rec = UsageRecord(
+            ts=1710000000.0,
+            model="claude-sonnet-4-6",
+            input_tokens=100,
+            output_tokens=200,
+            cost_usd=0.01,
+            cache_creation_tokens=9169,
+            cache_read_tokens=34006,
+            thinking_tokens=12,
+            role="auditor",
+            source="petri_eval",
+            eval_id="2026-05-11T08-21-40-00-00_audit_X.eval",
+        )
+        data = json.loads(rec.to_json())
+        assert data["cache_w"] == 9169
+        assert data["cache_r"] == 34006
+        assert data["think"] == 12
+        assert data["role"] == "auditor"
+        assert data["source"] == "petri_eval"
+        assert data["eval_id"] == "2026-05-11T08-21-40-00-00_audit_X.eval"
+
+    def test_from_json_legacy_record_compat(self):
+        # Pre-extension JSONL row — produced by code before 2026-05-11
+        legacy = (
+            '{"ts":1710000000,"model":"claude-opus-4-6","in":1200,'
+            '"out":350,"cost":0.0148}'
+        )
+        rec = UsageRecord.from_json(legacy)
+        # Pre-extension fields parse as before
+        assert rec.input_tokens == 1200
+        # Extension fields default to 0 / "" — no KeyError, no crash
+        assert rec.cache_creation_tokens == 0
+        assert rec.cache_read_tokens == 0
+        assert rec.thinking_tokens == 0
+        assert rec.role == ""
+        assert rec.source == ""
+        assert rec.eval_id == ""
+
+    def test_from_json_extension_roundtrip(self):
+        original = UsageRecord(
+            ts=1778573700.0,
+            model="claude-haiku-4-5-20251001",
+            input_tokens=21,
+            output_tokens=846,
+            cost_usd=0.045,
+            cache_creation_tokens=6740,
+            cache_read_tokens=0,
+            thinking_tokens=0,
+            role="judge",
+            source="petri_eval",
+            eval_id="2026-05-11T08-21-40-00-00_audit_EfZ32YEeSNkzk5HittH65e.eval",
+        )
+        restored = UsageRecord.from_json(original.to_json())
+        assert restored.cache_creation_tokens == 6740
+        assert restored.role == "judge"
+        assert restored.source == "petri_eval"
+        assert restored.eval_id == original.eval_id
+
+
+class TestUsageStoreCacheFields:
+    """UsageStore.record forwards the new cache / think / role / source kwargs."""
+
+    @pytest.fixture()
+    def store(self, tmp_path: Path) -> UsageStore:
+        return UsageStore(usage_dir=tmp_path)
+
+    def test_record_persists_cache_fields(self, store: UsageStore, tmp_path: Path):
+        store.record(
+            "claude-opus-4-7",
+            1000,
+            200,
+            0.01,
+            cache_creation_tokens=500,
+            cache_read_tokens=2000,
+            thinking_tokens=50,
+        )
+        today = date.today()
+        fpath = tmp_path / f"{today.year:04d}-{today.month:02d}.jsonl"
+        line = fpath.read_text(encoding="utf-8").strip()
+        data = json.loads(line)
+        assert data["cache_w"] == 500
+        assert data["cache_r"] == 2000
+        assert data["think"] == 50
+
+    def test_record_with_explicit_ts(self, store: UsageStore):
+        # Eval extraction stamps rows with the eval's start time, not
+        # the (later) extraction time.
+        target_ts = 1778573700.0
+        rec = store.record(
+            "claude-sonnet-4-6",
+            7,
+            1007,
+            0.05,
+            cache_creation_tokens=9169,
+            cache_read_tokens=34006,
+            role="auditor",
+            source="petri_eval",
+            eval_id="some.eval",
+            ts=target_ts,
+        )
+        assert rec.ts == target_ts
+
+    def test_has_eval_id_skips_already_imported(self, store: UsageStore):
+        eval_id = "2026-05-11T08-21-40-00-00_audit_X.eval"
+        # Initially absent
+        assert store.has_eval_id(eval_id) is False
+        # After import
+        store.record(
+            "claude-haiku-4-5-20251001",
+            21,
+            846,
+            0.045,
+            cache_creation_tokens=6740,
+            role="judge",
+            source="petri_eval",
+            eval_id=eval_id,
+        )
+        assert store.has_eval_id(eval_id) is True
+        # Different source with same id does not register as imported —
+        # ``source != 'petri_eval'`` is a per-call row, not an eval row.
+        store.record("other-model", 1, 1, 0.0, eval_id=eval_id)
+        assert store.has_eval_id(eval_id) is True  # the petri_eval row still counts
+
+
+class TestTokenTrackerPersistsCacheFields:
+    """TokenTracker.record → _persist_usage forwards cache/think to JSONL."""
+
+    def test_record_propagates_cache_fields(self, tmp_path: Path):
+        from core.llm import usage_store as us_mod
+        from core.llm.token_tracker import TokenTracker
+
+        # Redirect the singleton at the JSONL boundary so the tracker
+        # writes into our tmp dir.
+        custom = UsageStore(usage_dir=tmp_path)
+        us_mod._store = custom
+        try:
+            tracker = TokenTracker()
+            tracker.record(
+                "claude-opus-4-7",
+                1000,
+                200,
+                cache_creation_tokens=500,
+                cache_read_tokens=2000,
+                thinking_tokens=10,
+            )
+            today = date.today()
+            fpath = tmp_path / f"{today.year:04d}-{today.month:02d}.jsonl"
+            data = json.loads(fpath.read_text(encoding="utf-8").strip())
+            assert data["cache_w"] == 500
+            assert data["cache_r"] == 2000
+            assert data["think"] == 10
+        finally:
+            us_mod._store = None
+
+
 class TestUsageStoreSingleton:
     """Tests for module-level singleton."""
 

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -236,10 +236,7 @@ class TestUsageRecordExtensionFields:
 
     def test_from_json_legacy_record_compat(self):
         # Pre-extension JSONL row — produced by code before 2026-05-11
-        legacy = (
-            '{"ts":1710000000,"model":"claude-opus-4-6","in":1200,'
-            '"out":350,"cost":0.0148}'
-        )
+        legacy = '{"ts":1710000000,"model":"claude-opus-4-6","in":1200,"out":350,"cost":0.0148}'
         rec = UsageRecord.from_json(legacy)
         # Pre-extension fields parse as before
         assert rec.input_tokens == 1200


### PR DESCRIPTION
## Summary

- petri 의 judge/auditor 가 발생시킨 token usage 가 `~/.geode/usage/<YYYY-MM>.jsonl` 에는 0 record — `geode history` rollup 이 모든 petri audit 의 judge+auditor 비용을 빠뜨리고 있었음 (Defect A F-A2 follow-up).
- 원인: inspect_ai 의 native `AnthropicAPI`/`OpenAIAPI` 가 GEODE TokenTracker 우회. `.eval` 의 `role_usage` 에만 누적되고 cross-session ledger 에 안 흐름. 5/11 라이브 archive 의 ts 매치로 ground truth 확정.
- 해결: (1) UsageRecord schema 확장 (cache/think/role/source/eval_id) + 기존 reader 호환, (2) `_persist_usage` 가 cache/think 을 JSONL 까지 흘려보냄, (3) `core/audit/eval_to_jsonl.py` 신규 — petri eval 종료 후 `.eval` 의 `EvalStats.model_usage` walk + role 태그 매핑 + idempotent insert.

## Why

**Ground truth (5/11 라이브 archive 점검)**:

| Source | judge (haiku) | auditor (sonnet) |
|---|---|---|
| `.eval` `role_usage` | in=21 out=846 cache_w=6740 ✓ | in=7 out=1007 cache_r=34006 ✓ |
| `~/.geode/usage/2026-05.jsonl` (08:00-09:00 UTC) | **0** | **0** |

inspect_ai 가 single-eval `.eval` 안에 모든 관측성을 채워주지만, cross-session 누적 (`geode history`) 은 GEODE 자체의 JSONL ledger 가 truth source. inspect_ai 가 자체적으로 multi-eval aggregation 을 제공하지 않으므로 post-eval extraction 외 다른 경로 없음 — 이게 본 PR 의 raison d'être.

또 부수적으로, F-A2 가 in-memory accumulator 까지 cache 토큰을 채웠지만 `_persist_usage` 단계에서 drop 하던 leak 도 함께 해결.

## Changes

| File | Change |
|------|--------|
| `core/llm/usage_store.py` | `UsageRecord` schema 확장 (cache_w/cache_r/think/role/source/eval_id). `to_json` falsy omit + `from_json` `.get` fallback. `UsageStore.record(...)` signature 확장 + `ts` 직접 지정 허용 (eval extraction 시 wall-clock 보존). `has_eval_id(...)` 신규 (idempotent dedup) |
| `core/llm/token_tracker.py` | `_persist_usage` signature 확장 (cache/think 추가) + `record` 가 이를 전달 |
| `core/audit/__init__.py` | 신규 — sub-package init + `extract_to_usage_store` re-export |
| `core/audit/eval_to_jsonl.py` | 신규 — `extract_to_usage_store(.eval)`. inspect_ai header_only 읽기 + `EvalStats.model_usage` walk + `eval.model_roles` 역매핑 + per-model row append. cost fallback (`ModelUsage.total_cost` 없을 때 GEODE pricing). ts 는 `eval.created` ISO8601 → unix |
| `plugins/petri_audit/runner.py` | `_maybe_auto_archive` 끝에서 `_import_usage(archive_path, notes)` 호출. 실패 swallow + note 만 |
| `tests/test_usage_store.py` | 3 클래스 (`TestUsageRecordExtensionFields` / `TestUsageStoreCacheFields` / `TestTokenTrackerPersistsCacheFields`) — extension 직렬화, legacy compat round-trip, store cache forwarding, `has_eval_id` dedup, TokenTracker → JSONL cache flow-through |
| `tests/audit/test_eval_to_jsonl.py` | 신규 — fake `EvalLog` (monkeypatched `inspect_ai.log.read_eval_log`) 로 ts 파싱, missing file no-op, empty stats no-op, role 매핑 + provider prefix 제거 + cache 보존 + ts 매핑, cost fallback, idempotency, unknown role 6 case |
| `CHANGELOG.md` | `[Unreleased]` 에 entry 추가 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| UsageRecord schema 확장 | Implemented | cache_w/cache_r/think/role/source/eval_id + legacy compat |
| `_persist_usage` cache forwarding | Implemented | F-A2 잔여 leak 해결 |
| `core/audit/eval_to_jsonl.py` | Implemented | header_only 읽기, role 역매핑, idempotent, cost fallback |
| petri runner hook | Implemented | `_maybe_auto_archive` 안 `_import_usage` 호출 |
| 회귀 테스트 | Implemented | 9 신규 (3 + 6) |
| F-A3 logging persistence 별도 file | Dropped | inspect_ai 의 LoggerEvent 가 이미 `.eval` 안에 capture |
| Plain JSON dump tier | Dropped | `.eval` 이 이미 `samples/*.json` + `header.json` 동봉 |
| Retention policy | Out of scope | 별도 PR (MID priority) |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 350 source files
- [x] `uv run pytest tests/ -m "not live"` — 4517 passed, 21 skipped, 24 deselected (103.79s)
- [ ] Live verify (PR D 별도) — F-A4 라이브 1 sample 으로 `~/.geode/usage/2026-05.jsonl` 에 새 `source="petri_eval"` row 가 target/judge/auditor 3 role 모두 추가되는지 확인

## Reference

- 5/11 라이브 archive 점검: `~/.geode/petri/logs/2026-05-11T08-21-40-00-00_audit_EfZ32YEeSNkzk5HittH65e.eval` (anthropic stack) + `2026-05-11T08-24-53-00-00_audit_dR8YEMtkntszrxbntHnVta.eval` (openai stack)
- inspect_ai EvalStats / ModelUsage / model_roles schema — `.venv/lib/python3.12/site-packages/inspect_ai/log/_log.py`, `_model_output.py`
- 직전 PR #1024 (Defect A F-A1+A2+A3 root cause fix) — 본 PR 의 이전 단계
- 본 PR 은 4-PR plan (A/B/C/D) 의 PR A. B = MANIFEST, C = docs, D = F-A4 live 검증