### PR TITLE
chore(release): cut v0.90.0 — 6-PR petri observability + Defect B-1 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.90.0] — 2026-05-11
+
 ### Fixed
 
 - **Defect A root-cause fix — petri target tokens 가 inspect_ai

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.89.3
+- **Version**: 0.90.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 303 core + 29 plugins = 332
-- **Tests**: 4346 (+24 live)
+- **Modules**: 310 core + 41 plugins = 351
+- **Tests**: 4559 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.89.3"
+version = "0.90.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.89.3"
+version = "0.90.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- v0.90.0 release cut. CHANGELOG `[Unreleased]` (40 entries) → `[0.90.0] — 2026-05-11`. version 4 위치 동기 (pyproject + CLAUDE.md + uv.lock).
- 본 release 의 6 PR: #1024 (Defect A F-A1/A2/A3) + #1026 (PR A JSONL) + #1027 (PR B MANIFEST) + #1028 (PR C docs) + #1029 (PR D F-A4 live) + #1030 (PR E B-1 하위) + #1031 (PR F B-1 상위).
- 본 PR 머지 후 develop → main PR 진행.

## Why

CLAUDE.md release 정책: "No leaving [Unreleased] on main". develop ahead 6 PRs 의 [Unreleased] entries 40 개가 main 으로 가기 전 정식 release 절차. 본 6 PR 변경의 성격: 신규 module (`core/audit/`) + 신규 contract (AgenticResult.usage, MANIFEST.jsonl) + fixes — MINOR 적합 = **v0.90.0**.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | version 0.89.3 → 0.90.0 |
| `CLAUDE.md` | Version 0.89.3 → 0.90.0, Modules 303+29=332 → 310+41=351, Tests 4346 → 4559 |
| `uv.lock` | pyproject version 변경 반영 (auto) |
| `CHANGELOG.md` | `[Unreleased]` (40 entries) → `[0.90.0] — 2026-05-11`. 새 빈 `[Unreleased]` section 추가 |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success in 351 files
- [ ] CI 5/5 — 본 PR 의 CI 결과로 검증
- [x] CHANGELOG entries 40 개 모두 [0.90.0] 안 (manual review)
- [x] version 4 위치 동기 (pyproject + CLAUDE.md + uv.lock)