### PR TITLE
fix(audit): Defect B-3 — plugins.petri_audit.* INFO log propagate to inspect_ai LoggerEvent transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,43 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Defect B-3 — `plugins.petri_audit.*` 의 INFO log 가 inspect_ai
+  의 `.eval` LoggerEvent transcript 로 propagate 되도록 namespace
+  setLevel 추가.** v0.90.0 시점 PR D/E/F 의 5 live archives 모두
+  sample LoggerEvent 0 — `_default_geode_runner` 의 `log.info("petri
+  runner entry: ...")` 와 `_response.track_usage` 의 진단 log 가
+  transcript 에 안 잡힘.
+
+  **root cause**: Python `logging` 의 effective level chain. inspect_ai
+  `_util/logger.py:init_logger` 가 root level 을 ``warning`` (default
+  `DEFAULT_LOG_LEVEL`) 으로 두고 transcript writer 는 INFO+ 캡처
+  (`DEFAULT_LOG_LEVEL_TRANSCRIPT='info'`). `plugins.petri_audit.*`
+  logger 들의 level=NOTSET → parent chain 통해 root WARNING 으로
+  fallback → INFO record 가 logger 단계에서 filter out 되어 root
+  LogHandler 의 emit 호출 자체가 없음 → LoggerEvent 생성 안 됨.
+
+  **fix** (`plugins/petri_audit/__init__.py`):
+  ```python
+  _logging.getLogger("plugins.petri_audit").setLevel(_logging.INFO)
+  ```
+  namespace 의 effective level 을 INFO 로 강제 → 모든 child logger
+  (`targets.geode_target`, `runner` 등) 의 INFO record 가 process →
+  propagate=True 통해 root 의 LogHandler 받음 → `transcript_levelno
+  >= INFO` 체크 통과 → `log_to_transcript(record)` 호출 → sample 의
+  events 에 LoggerEvent append.
+
+  **회귀 가드** (1 신규):
+  - `test_petri_audit_namespace_logger_level_is_info` — namespace
+    level=INFO, child `isEnabledFor(INFO)`=True, propagate=True
+    (default 유지) 검증. namespace 의 propagate 가 False 로 바뀌면
+    record 가 root 까지 못 가니까 명시적 guard.
+
+  4522 passed (default env, audit extra 환경에선 4559). 자연 검증 —
+  다음 audit 의 `.eval` 의 sample.events 에 LoggerEvent 가 non-zero
+  여야 함 (petri runner entry/exit + track_usage 의 INFO log).
+
 ## [0.90.0] — 2026-05-11
 
 ### Fixed

--- a/plugins/petri_audit/__init__.py
+++ b/plugins/petri_audit/__init__.py
@@ -18,6 +18,25 @@ from __future__ import annotations
 
 import logging as _logging
 
+# Defect B-3 fix (2026-05-11) — namespace-wide ``INFO`` level so that
+# ``log.info(...)`` calls inside ``plugins.petri_audit.*`` (notably
+# ``_default_geode_runner``'s entry/exit observability and the F-A2
+# track_usage diagnostics) propagate up to inspect_ai's root
+# ``LogHandler`` and land in the eval's ``LoggerEvent`` stream.
+#
+# Background — inspect_ai's ``init_logger`` (``_util/logger.py``) sets
+# the root level to ``warning`` (default ``DEFAULT_LOG_LEVEL`` from
+# ``_util/constants.py``) but configures the transcript writer to
+# capture ``info`` and above (``DEFAULT_LOG_LEVEL_TRANSCRIPT='info'``).
+# Python ``logging`` rejects records below the effective level of
+# their logger chain, so without this setLevel the INFO record never
+# reaches the root LogHandler and therefore never makes it into the
+# ``.eval`` transcript. The 5/11 archives (PR D/E/F) all carried zero
+# ``LoggerEvent`` entries from ``plugins.petri_audit`` for exactly
+# this reason — verified post-fix via file-based fa4 evidence in
+# ``docs/audits/2026-05-11-petri-observability-audit.md`` §9.6.
+_logging.getLogger("plugins.petri_audit").setLevel(_logging.INFO)
+
 # Audit-extra hookup: invoking ``register()`` triggers the
 # ``@modelapi(name="geode")`` decorator inside that function, which
 # registers ``GeodeModelAPI`` with ``inspect_ai``'s registry. The

--- a/tests/plugins/petri_audit/test_skeleton.py
+++ b/tests/plugins/petri_audit/test_skeleton.py
@@ -43,6 +43,31 @@ def test_petri_audit_package_imports() -> None:
     import plugins.petri_audit  # noqa: F401
 
 
+def test_petri_audit_namespace_logger_level_is_info() -> None:
+    """Defect B-3 fix (2026-05-11) — ``plugins.petri_audit`` namespace
+    must be at INFO so ``log.info(...)`` inside the audit code path
+    propagates to inspect_ai's root LogHandler (which captures INFO+
+    into the eval transcript). The 5/11 PR D/E/F live archives had
+    zero LoggerEvent entries from petri_audit because the effective
+    level fell through to the root default (WARNING)."""
+    import logging
+
+    import plugins.petri_audit  # noqa: F401 — trigger setLevel
+
+    ns = logging.getLogger("plugins.petri_audit")
+    assert ns.level == logging.INFO
+
+    # Child loggers inherit via effective level (their own level stays
+    # NOTSET, which lets the namespace setLevel govern). Verify the
+    # actually-used target logger is INFO-enabled.
+    child = logging.getLogger("plugins.petri_audit.targets.geode_target")
+    assert child.isEnabledFor(logging.INFO)
+    # propagate=True (default) is required for the root LogHandler to
+    # see the record — fail loudly if a future change disables it.
+    assert ns.propagate is True
+    assert child.propagate is True
+
+
 def test_geode_target_module_imports_without_audit_extra() -> None:
     """Module-level surface has no ``inspect_ai`` dependency.
 


### PR DESCRIPTION
## Summary

- v0.90.0 의 PR D/E/F 5 live archives 모두 sample LoggerEvent 0 — `_default_geode_runner` INFO log 가 transcript 에 미캡처. Defect B 인벤토리의 B-3.
- 1-line fix: `plugins/petri_audit/__init__.py` 에 namespace setLevel(INFO). 회귀 1 신규. cost 0.

## Why

inspect_ai 의 `init_logger` (`_util/logger.py`) 는 root level 을 `warning` (default `DEFAULT_LOG_LEVEL`) 으로 설정. transcript writer 는 INFO+ 캡처 (`DEFAULT_LOG_LEVEL_TRANSCRIPT='info'`). Python `logging` 의 effective level chain 에서:

- `plugins.petri_audit.targets.geode_target` logger level = NOTSET
- parent chain (`plugins.petri_audit.targets` → `plugins.petri_audit` → `plugins` → root) 모두 NOTSET
- root level = WARNING

→ INFO record 가 `logger.isEnabledFor(INFO)` 단계에서 False → record process 자체 안 됨 → root LogHandler 의 emit 호출 0 → transcript LoggerEvent 0.

5/11 PR D/E/F 의 archive 들 (총 6 개) 모두 sample.events 의 LoggerEvent 카운트가 0 — 본 B-3 의 직접 evidence.

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/__init__.py` | `_logging.getLogger("plugins.petri_audit").setLevel(_logging.INFO)` 추가. namespace effective level=INFO → child logger 들의 INFO record process → root LogHandler 통해 transcript 도달 |
| `tests/plugins/petri_audit/test_skeleton.py` | `test_petri_audit_namespace_logger_level_is_info` 신규 — namespace level=INFO, child `isEnabledFor(INFO)`=True, propagate=True 검증 |
| `CHANGELOG.md` | `[Unreleased]` 에 `### Fixed` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| B-3 root cause 식별 | Implemented | Python logging effective level chain |
| namespace setLevel fix | Implemented | 1-line, import-time |
| 회귀 가드 | Implemented | level + isEnabledFor + propagate 3-axis |
| 자연 검증 (다음 audit) | Pending | 다음 audit 의 sample.events 에 LoggerEvent non-zero 확인 |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success in 351 source files
- [x] `uv run pytest tests/ -m "not live"` — **4522 passed** (default env, 23 skipped audit-extra-gated)
- [x] 신규 test 정상 — namespace level + child isEnabledFor + propagate
- [ ] 자연 검증 — 다음 정상 audit 의 archive 에서 sample LoggerEvent count > 0

## Reference

- 5/11 archive evidence: `~/.geode/petri/logs/2026-05-11T*.eval` 6 개 모두 sample LoggerEvent 0
- `docs/audits/2026-05-11-petri-observability-audit.md` §9.6 (Defect B-3 잔존 정의)
- inspect_ai source: `.venv/lib/python3.12/site-packages/inspect_ai/_util/logger.py` (init_logger + LogHandler.emit)
- `_util/constants.py`: `DEFAULT_LOG_LEVEL='warning'`, `DEFAULT_LOG_LEVEL_TRANSCRIPT='info'`