### PR TITLE
chore(release): cut v0.91.0 — Defect B 전체 4 items 해소

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.91.0] — 2026-05-11
+
 ### Fixed
 
 - **Defect B-4 — `inspect_ai` 의 scoring path 의 judge usage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.90.0
+- **Version**: 0.91.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 310 core + 41 plugins = 351
-- **Tests**: 4559 (+24 live)
+- **Tests**: 4563 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.90.0"
+version = "0.91.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.90.0"
+version = "0.91.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- v0.91.0 release cut. CHANGELOG `[Unreleased]` (3 entries) → `[0.91.0] — 2026-05-11`.
- version 4 위치 동기 (pyproject 0.91.0 + CLAUDE.md + uv.lock).
- 본 PR 머지 후 develop → main PR 진행.

## Why

CLAUDE.md release 정책 — "No leaving [Unreleased] on main". Defect B 의 4 items 모두 해소 (B-1 하위/상위 + B-3 + B-4) + 자연 검증 라이브 결과 docs. PATCH (0.90.0 → 0.91.0) 적합 — 사용자 보이는 결함 해결 + 회귀 가드.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | 0.90.0 → 0.91.0 |
| `CLAUDE.md` | Version 0.90.0 → 0.91.0, Tests 4559 → 4563 |
| `uv.lock` | version 변경 반영 (auto) |
| `CHANGELOG.md` | `[Unreleased]` 3 entries → `[0.91.0] — 2026-05-11` |

## 본 release 의 3 entries

- **#1034 (B-3)** — `plugins.petri_audit.*` namespace setLevel(INFO) 로 INFO log → inspect_ai LoggerEvent transcript propagate
- **#1036 (B-4)** — inspect_ai scoring race 의 GEODE-측 우회. `eval_to_jsonl` + `manifest` 양쪽 event-walk fallback
- **#1035 (B-1+B-3 검증)** — anthropic 1 sample 라이브 (~$0.25) + cache hit 부작용 발견

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [ ] CI 5/5 — 본 PR
- [x] CHANGELOG entries 3 모두 [0.91.0] 안 (manual review)
- [x] version 4 위치 동기