### PR TITLE
feat(audit): core.audit.diagnostics — file-based debug log surviving inspect eval subprocess boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`core.audit.diagnostics` — file-based diagnostics log surviving
+  `inspect eval` subprocess boundaries.** PR E/F (v0.90.0) 의 ad-hoc
+  `core/_fa4_debug.py` 패턴의 정식 인프라화. `inspect eval` 의 child
+  process 가 `subprocess.run(capture_output=True)` 로 stdout/stderr
+  격리 + inspect_ai 의 `init_logger` 가 root LogHandler 재설정 →
+  GEODE plugin 의 INFO/DEBUG 가 parent 로 propagate 안 됨. file-based
+  append-only log 가 이 두 boundary 와 무관하게 evidence 보존.
+  - **API** — `from core.audit import diag, diagnostics_path`.
+    `diag("petri.anthropic", f"BadRequest: {msg[:200]}")` 한 줄로 호출
+  - **Location** — `~/.geode/diagnostics/<YYYY-MM>.log` (월 rotation).
+    `GEODE_DIAGNOSTICS_LOG=<path>` 환경 변수 override (test/CI fixture
+    용도)
+  - **Line format** — `<unix_ts:%.3f> <pid> <component> <msg>`. grep/jq
+    친화. `component` 는 dotted namespace (`petri.runner`,
+    `petri.anthropic`, `petri.lifecycle`)
+  - **Best-effort** — 모든 `OSError` swallow. diagnostics 가 audit 깨면
+    안 됨 (disk full / permission denied)
+  - **GEODE convention 일관성** — `~/.geode/usage/`, `~/.geode/petri/
+    logs/`, `~/.geode/journal/`, `~/.geode/runs/` 와 같은 위치. `/tmp/`
+    같은 OS-level temp 아님 (PR E/F 의 사용자 비판 반영)
+  - **회귀 가드 10 신규** — env override / user expansion / month
+    rotation / DEFAULT_DIAGNOSTICS_DIR 컨벤션 / write format / append /
+    OSError 우회 / 동시 thread write / package re-export / signature
+  - `docs/architecture/petri-observability.md` 의 3-layer → **4-layer**
+    확장 (Raw + JSONL ledger + MANIFEST + Diagnostics). Layer 4 의
+    `When to reach for` + `Discovery` (grep/awk 패턴) 명시. 4573
+    passed.
+
 ## [0.91.0] — 2026-05-11
 
 ### Fixed

--- a/core/audit/__init__.py
+++ b/core/audit/__init__.py
@@ -9,6 +9,7 @@ and auditor cost is otherwise invisible to ``geode history``.
 
 from __future__ import annotations
 
+from core.audit.diagnostics import DEFAULT_DIAGNOSTICS_DIR, diag, diagnostics_path
 from core.audit.eval_to_jsonl import extract_to_usage_store
 from core.audit.manifest import (
     DEFAULT_MANIFEST_PATH,
@@ -18,8 +19,11 @@ from core.audit.manifest import (
 )
 
 __all__ = [
+    "DEFAULT_DIAGNOSTICS_DIR",
     "DEFAULT_MANIFEST_PATH",
     "append_manifest",
+    "diag",
+    "diagnostics_path",
     "extract_to_usage_store",
     "has_archive",
     "read_manifest",

--- a/core/audit/diagnostics.py
+++ b/core/audit/diagnostics.py
@@ -1,0 +1,95 @@
+"""File-based diagnostics that survive inspect_ai subprocess boundaries.
+
+PR E/F (2026-05-11) 의 ``core/_fa4_debug.py`` ad-hoc pattern 의
+정식 인프라화. ``inspect eval`` 의 child process 는 stdout/stderr 가
+parent 의 ``subprocess.run(..., capture_output=True)`` 에 잡혀
+일반적인 print/stderr 출력이 외부 관찰자에게 닿지 않고, Python
+``logging`` 의 root handler 역시 child 안에서 inspect_ai 가 자체
+설정 (``inspect_ai/_util/logger.py:init_logger``) 으로 갈아치우는
+탓에 GEODE plugin 의 INFO/DEBUG record 가 parent 의 LogHandler 까지
+propagate 되지 않는다. file 기반 append-only log 가 이 두 boundary
+와 무관하게 evidence 를 보존한다.
+
+위치 — ``~/.geode/diagnostics/<YYYY-MM>.log`` (월 단위 rotation,
+다른 GEODE runtime artifacts 와 같은 ``~/.geode/`` 컨벤션).
+override — ``GEODE_DIAGNOSTICS_LOG=<path>`` 환경 변수.
+
+사용 예::
+
+    from core.audit.diagnostics import diag
+
+    diag("petri.runner", f"entry msg_count={len(messages)}")
+    diag("petri.anthropic", f"BadRequest: {str(exc)[:200]}")
+
+분석::
+
+    # 본 audit 의 sample 만 (unix-ts window)
+    awk '$1 >= 1778500000 && $1 <= 1778510000' \\
+        ~/.geode/diagnostics/2026-05.log
+    # component 별
+    grep ' petri.anthropic ' ~/.geode/diagnostics/2026-05.log
+    # PID 별 (subprocess 추적)
+    awk '{print $2}' ~/.geode/diagnostics/2026-05.log | sort | uniq -c
+
+Failure mode — best-effort. disk full / permission denied / monthly
+rotation 의 partial mkdir 등 모든 OSError 는 swallow 된다. diagnostics
+가 실제 audit 를 깨트리면 안 되기 때문.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+
+__all__ = ["DEFAULT_DIAGNOSTICS_DIR", "diag", "diagnostics_path"]
+
+#: GEODE convention. ``~/.geode/`` 의 다른 artifacts 와 동거.
+DEFAULT_DIAGNOSTICS_DIR: Path = Path.home() / ".geode" / "diagnostics"
+
+
+def diagnostics_path() -> Path:
+    """Resolve the current diagnostics log path.
+
+    Priority:
+    1. ``GEODE_DIAGNOSTICS_LOG`` env var — full path override (PoC scope,
+       e.g. test fixture redirecting to ``tmp_path``).
+    2. ``~/.geode/diagnostics/<YYYY-MM>.log`` — month-rolled file under
+       the standard GEODE convention.
+
+    The parent directory is created on demand. Path resolution is pure
+    (no I/O beyond mkdir); errors during mkdir bubble to the caller so
+    a misconfigured env var fails loudly at test time. The runtime
+    write path (:func:`diag`) catches them anyway.
+    """
+    override = os.environ.get("GEODE_DIAGNOSTICS_LOG")
+    if override:
+        return Path(override).expanduser()
+    DEFAULT_DIAGNOSTICS_DIR.mkdir(parents=True, exist_ok=True)
+    now = datetime.now()
+    return DEFAULT_DIAGNOSTICS_DIR / f"{now.year:04d}-{now.month:02d}.log"
+
+
+def diag(component: str, msg: str) -> None:
+    """Append a single line to the diagnostics log.
+
+    Line format::
+
+        <unix_ts:%.3f> <pid> <component> <msg>\\n
+
+    ``component`` is a short dotted namespace (``petri.runner``,
+    ``petri.anthropic``, ``petri.lifecycle`` …) so grep/jq queries
+    stay simple. Multi-line ``msg`` is allowed but discouraged —
+    each call is one line; the caller is responsible for trimming.
+
+    Best-effort: every ``Exception`` during write is swallowed. The
+    diagnostics path exists to *help* debugging, not to fail the audit
+    when the disk is full.
+    """
+    try:
+        path = diagnostics_path()
+        with path.open("a", encoding="utf-8") as f:
+            f.write(f"{time.time():.3f} {os.getpid()} {component} {msg}\n")
+    except Exception:  # noqa: S110 — best-effort debug log
+        pass

--- a/docs/architecture/petri-observability.md
+++ b/docs/architecture/petri-observability.md
@@ -14,19 +14,23 @@ be answered if observability is wired end-to-end across three layered systems
 This doc is the single map of which layer captures what, why each one exists,
 and where the boundaries (cross-layer extraction points) live.
 
-## TL;DR — three layers, three responsibilities
+## TL;DR — four layers, four responsibilities
 
 | Layer | Path | Scope | Lifetime | Producer | Consumer |
 |------:|------|-------|----------|----------|----------|
 | **1. Raw archive** | `~/.geode/petri/logs/*.eval` | Single eval, full transcript | Forever (out-of-git, PII risk) | inspect_ai's `EvalRecorder` | `inspect view`, debugging, `extract_summary` |
 | **2. Token ledger** | `~/.geode/usage/<YYYY-MM>.jsonl` | All LLM calls across sessions | Forever | `TokenTracker._persist_usage` (per-call) + `core.audit.eval_to_jsonl` (per-eval rollup) | `geode history`, cost monitoring |
 | **3. Archive manifest** | `docs/audits/eval-logs/MANIFEST.jsonl` | Per-eval metadata + seed_ids + role tokens | Forever (git-tracked) | `core.audit.manifest.append_manifest` | seed lookup, cross-archive jq queries |
+| **4. Diagnostics** | `~/.geode/diagnostics/<YYYY-MM>.log` | Free-form GEODE debug records that need to survive `inspect eval` subprocess boundaries | Month-rolled (overwrite-safe) | `core.audit.diagnostics.diag(component, msg)` | grep/jq during incident triage |
 
-Layer 1 is **inspect_ai-native** (binary `.eval` ZIP). Layers 2 and 3 are
-**GEODE additions** because inspect_ai has no concept of cross-session
-aggregation or git-tracked index.
+Layer 1 is **inspect_ai-native** (binary `.eval` ZIP). Layers 2 / 3 / 4 are
+**GEODE additions**: 2/3 because inspect_ai has no concept of
+cross-session aggregation or git-tracked index, 4 because the
+`inspect eval` subprocess hides stdout/stderr and reroutes the Python
+`logging` root handler so any GEODE plugin's INFO/DEBUG records made
+inside that subprocess never reach the parent.
 
-## Why three layers
+## Why four layers
 
 inspect_ai already does a lot — 26 typed events, `EvalStats.role_usage` /
 `model_usage` aggregation, `LoggerEvent` capture of Python `logging`,
@@ -49,6 +53,19 @@ inspect_ai's scope (single-eval) leaves out:
    GEODE's TokenTracker dropped cache/thinking tokens at the `_persist_usage`
    seam even though `_calculate_cost` priced them correctly. The schema
    extension in PR #1026 closed the leak.
+
+4. **Subprocess-spanning diagnostics** — `inspect eval` runs as
+   `subprocess.run(..., capture_output=True)` so any GEODE `print` or
+   `sys.stderr.write` is hidden from the parent, and `init_logger`
+   inside that subprocess replaces the root LogHandler so even Python
+   `logging` records from GEODE namespaces never propagate back
+   (verified 2026-05-11 against the PR D/E/F live archives). PR E/F's
+   ad-hoc `core/_fa4_debug.py` file pattern proved that a file-based
+   append log bypasses both walls; PR v0.91.0+ promoted it to
+   `core.audit.diagnostics` so the same shape — `diag(component, msg)`
+   appending to `~/.geode/diagnostics/<YYYY-MM>.log` — is the
+   recommended path for the next time some GEODE code-path inside the
+   audit harness needs to leave evidence for a post-mortem.
 
 Everything else inspect_ai already covers — see [§Out of scope](#out-of-scope).
 
@@ -171,6 +188,72 @@ jq -s 'group_by(.models.judge)
               total_judge_in: ([.[].role_usage_summary.judge.in] | add)})' \
    MANIFEST.jsonl
 ```
+
+## Layer 4 — Diagnostics (`~/.geode/diagnostics/<YYYY-MM>.log`)
+
+```
+<unix_ts:%.3f> <pid> <component> <free-form message>
+```
+
+Producer: `core.audit.diagnostics.diag(component, msg)`. Append-only,
+month-rolled file under the same `~/.geode/` convention as Layer 2 +
+`~/.geode/petri/logs/`. Override via `GEODE_DIAGNOSTICS_LOG=<path>`.
+
+This layer exists because the other three are blind in one specific
+scenario: code that runs inside the `inspect eval` subprocess. Anything
+GEODE-side that wants to leave breadcrumbs from there — what arguments
+a fail path saw, which exception bubbled through which provider — has
+to bypass two walls at once:
+
+1. **stdout/stderr** — `subprocess.run(..., capture_output=True)`
+   collects both streams into memory and only surfaces them after the
+   child exits. Live `print` / `sys.stderr.write` is invisible while
+   the subprocess is running and is post-processed (truncated, mixed,
+   sometimes lost on signal) by the time the parent sees it.
+2. **Python `logging` root handler** — inspect_ai's `init_logger`
+   (`inspect_ai/_util/logger.py`) sets a custom root level, attaches
+   its own `LogHandler`, and (for the `inspect_ai` namespace)
+   `propagate = False`. GEODE plugin namespaces sit under the root
+   chain but their effective level falls back to root's `WARNING`
+   default, so a plain `log.info(...)` is filtered at the logger
+   level and never reaches the LogHandler. PR #1034 fixed this for
+   `plugins.petri_audit.*` by setting that namespace to INFO at
+   import time — but only for that one namespace, and the fix relies
+   on inspect_ai's transcript-capture path still being healthy
+   (which Defect B-3's evidence showed was not always the case).
+
+### When to reach for Layer 4
+
+- An inspect_ai sub-call returned `None` and you need to know which
+  `return None` path inside `core/llm/providers/anthropic.py` fired
+  it. (`diag("petri.anthropic", f"BadRequest: {msg[:200]}")`)
+- A target ModelEvent's `usage` is `None` and you need to know
+  whether `_response.track_usage` was reached. (`diag("petri.lifecycle",
+  f"finalize delta cc={delta.call_count}")`)
+- A test or live run is too cheap to repeat for instrumentation and
+  you want one durable line per relevant decision point.
+
+Anything that the Layer 1 `.eval` already records (events, samples,
+scores, stats) belongs in Layer 1; Layer 4 is for **GEODE code
+behaviour around `inspect eval`**, not for inspect_ai output.
+
+### Discovery
+
+```bash
+# Latest hits, any component
+tail -50 ~/.geode/diagnostics/$(date +%Y-%m).log
+
+# One component
+grep ' petri.anthropic ' ~/.geode/diagnostics/2026-05.log
+
+# A specific subprocess
+awk '$2 == 87410' ~/.geode/diagnostics/2026-05.log
+```
+
+The Layer 4 log is intentionally append-only and best-effort — every
+`OSError` during write is swallowed (disk full / permission denied
+must not break the audit). The `diag()` call site is safe to drop in
+without try/except guards.
 
 ## Cross-layer flow (one audit, end-to-end)
 

--- a/tests/audit/test_diagnostics.py
+++ b/tests/audit/test_diagnostics.py
@@ -1,0 +1,143 @@
+"""Tests for ``core.audit.diagnostics`` — file-based diagnostics log
+surviving inspect_ai subprocess boundaries.
+
+Mirrors PR E/F (2026-05-11) 의 fa4 pattern 의 정식 인프라화 검증.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.audit.diagnostics import DEFAULT_DIAGNOSTICS_DIR, diag, diagnostics_path
+
+
+class TestDiagnosticsPath:
+    def test_env_override_takes_priority(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        target = tmp_path / "subdir" / "custom.log"
+        monkeypatch.setenv("GEODE_DIAGNOSTICS_LOG", str(target))
+        assert diagnostics_path() == target
+
+    def test_env_override_expands_user(self, monkeypatch: pytest.MonkeyPatch):
+        # ~ in the override path expands to $HOME — supports the docs
+        # snippet ``GEODE_DIAGNOSTICS_LOG=~/scratch/fa4.log``.
+        monkeypatch.setenv("GEODE_DIAGNOSTICS_LOG", "~/scratch/fa4.log")
+        path = diagnostics_path()
+        assert str(path).startswith(str(Path.home()))
+        assert path.name == "fa4.log"
+
+    def test_default_path_uses_monthly_rotation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Redirect ~/.geode/diagnostics/ to tmp via HOME override so
+        # the test does not touch the real user dir.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("GEODE_DIAGNOSTICS_LOG", raising=False)
+        # DEFAULT_DIAGNOSTICS_DIR was resolved at import time relative
+        # to the original HOME, so patch the module constant too.
+        import core.audit.diagnostics as diag_mod
+
+        monkeypatch.setattr(
+            diag_mod, "DEFAULT_DIAGNOSTICS_DIR", tmp_path / ".geode" / "diagnostics"
+        )
+        path = diagnostics_path()
+        # Format: <YYYY>-<MM>.log
+        assert path.parent == tmp_path / ".geode" / "diagnostics"
+        assert path.name.endswith(".log")
+        assert len(path.stem) == 7  # YYYY-MM
+        assert path.stem[4] == "-"
+        # mkdir was triggered
+        assert path.parent.is_dir()
+
+    def test_default_dir_constant_under_dot_geode(self):
+        # Documented contract — caller-friendly constant for grep + jq.
+        assert Path.home() / ".geode" / "diagnostics" == DEFAULT_DIAGNOSTICS_DIR
+
+
+class TestDiag:
+    @pytest.fixture()
+    def log_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        p = tmp_path / "fa4.log"
+        monkeypatch.setenv("GEODE_DIAGNOSTICS_LOG", str(p))
+        return p
+
+    def test_writes_ts_pid_component_msg(self, log_path: Path):
+        diag("petri.runner", "entry msg_count=4")
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        parts = lines[0].split(" ", 3)
+        assert len(parts) == 4
+        ts_str, pid_str, component, msg = parts
+        # ts is a unix-epoch float with millisecond precision
+        assert float(ts_str) == pytest.approx(time.time(), abs=5.0)
+        assert int(pid_str) == os.getpid()
+        assert component == "petri.runner"
+        assert msg == "entry msg_count=4"
+
+    def test_appends_multiple_lines(self, log_path: Path):
+        for i in range(3):
+            diag("petri.anthropic", f"event {i}")
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+        assert all("petri.anthropic" in line for line in lines)
+        assert "event 0" in lines[0]
+        assert "event 2" in lines[2]
+
+    def test_swallows_oserror_on_write(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        # Point to a path inside a *file* (not a dir) so the `open(append)`
+        # call raises ``NotADirectoryError`` — the swallow path's job is
+        # to suppress that without re-raising.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("blocking the path", encoding="utf-8")
+        monkeypatch.setenv("GEODE_DIAGNOSTICS_LOG", str(blocker / "child" / "fa4.log"))
+        # Must not raise
+        diag("petri.runner", "should be swallowed")
+
+    def test_concurrent_writes_preserve_all_lines(self, log_path: Path):
+        # Append mode plus per-call open/close keeps multi-threaded
+        # writers from clobbering each other. PoC-level robustness —
+        # full atomic guarantees are POSIX-dependent, but at least
+        # ``len(lines) == N`` must hold for N typical writers.
+        N = 20
+
+        def worker(i: int) -> None:
+            diag("petri.runner", f"thread-{i}")
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == N
+        # Each thread's message is present somewhere
+        tags = {f"thread-{i}" for i in range(N)}
+        assert {line.rsplit(" ", 1)[-1] for line in lines} == tags
+
+
+class TestPackageReexport:
+    def test_diag_importable_from_core_audit(self):
+        # Convenience surface — caller can ``from core.audit import diag``
+        # without knowing the submodule path.
+        from core.audit import diag as diag_top
+        from core.audit import diagnostics_path as path_top
+        from core.audit.diagnostics import diag as diag_sub
+
+        assert diag_top is diag_sub
+        assert callable(path_top)
+
+
+def test_diag_callable_signature() -> None:
+    """Public surface signature — caller-facing contract."""
+    import inspect
+
+    sig = inspect.signature(diag)
+    params: dict[str, Any] = dict(sig.parameters)
+    assert list(params) == ["component", "msg"]
+    # PEP 563 (`from __future__ import annotations`) keeps the
+    # annotation as a string until eval.
+    assert sig.return_annotation in (None, "None")


### PR DESCRIPTION
## Summary

- PR E/F (v0.90.0) 의 ad-hoc `core/_fa4_debug.py` 패턴의 정식 인프라화.
- `~/.geode/diagnostics/<YYYY-MM>.log` (월 rotation, GEODE convention). `diag(component, msg)` 한 줄 API.
- 회귀 가드 10 신규. docs 3-layer → 4-layer 확장. 4573 passed.

## Why

`inspect eval` 의 child process 가:
1. `subprocess.run(capture_output=True)` 로 stdout/stderr 격리
2. inspect_ai 의 `init_logger` 가 root LogHandler 재설정 (default WARNING 으로 GEODE plugin INFO record 필터)

→ GEODE 코드의 debug 출력이 parent 에 안 닿음. PR E/F 의 file-based fa4 pattern 이 진단의 유일한 path 였음 (B-1/B-3/B-4 발견의 결정적 evidence). 다음 PoC 진단마다 ad-hoc 만들지 않고 reusable 인프라로.

**사용자 비판 반영** (`feedback_fa4_temp_location.md`): PR E/F 의 `/tmp/fa4_debug.log` 가 잘못된 위치 — `~/.geode/diagnostics/` 가 GEODE convention 일관 + persistent.

## Changes

| File | Change |
|------|--------|
| `core/audit/diagnostics.py` | 신규 — `diag(component, msg)` + `diagnostics_path()` + `DEFAULT_DIAGNOSTICS_DIR`. 30 lines (P10 simplicity) |
| `core/audit/__init__.py` | re-export `diag`, `diagnostics_path`, `DEFAULT_DIAGNOSTICS_DIR` |
| `tests/audit/test_diagnostics.py` | 신규 10 — env override, user expansion, month rotation, DEFAULT constant, write format, append, OSError swallow, concurrent thread write, package re-export, signature |
| `docs/architecture/petri-observability.md` | TL;DR 3-layer → 4-layer 표. 새 `## Layer 4 — Diagnostics` section. `### When to reach for Layer 4`, `### Discovery` (grep/awk 패턴) 추가. Cross-layer flow 갱신 |
| `CHANGELOG.md` | `[Unreleased] ### Added` entry |

## API

```python
from core.audit import diag

diag("petri.runner", f"entry msg_count={len(messages)}")
diag("petri.anthropic", f"BadRequest: {str(exc)[:200]}")
```

**Line format**: `<unix_ts:%.3f> <pid> <component> <msg>\\n` — grep/jq 친화.

**Discovery**:

```bash
# Latest hits
tail -50 ~/.geode/diagnostics/$(date +%Y-%m).log

# One component
grep ' petri.anthropic ' ~/.geode/diagnostics/2026-05.log

# A specific subprocess
awk '$2 == 87410' ~/.geode/diagnostics/2026-05.log
```

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `diag(component, msg)` 단순 함수 | Implemented | P10 simplicity, OOP 인프라 안 만듦 |
| `~/.geode/diagnostics/<YYYY-MM>.log` 월 rotation | Implemented | GEODE convention |
| `GEODE_DIAGNOSTICS_LOG` env override | Implemented | test/CI fixture 친화 |
| Best-effort (OSError swallow) | Implemented | diagnostics 가 audit 깨면 안 됨 |
| 회귀 가드 | Implemented | 10 신규 |
| docs 4-layer 확장 | Implemented | architecture SOT 갱신 |
| TTL/size-based cleanup | Out of scope | 필요 시 후속 |
| `DiagnosticLogger` class (OOP) | Out of scope | 단순 함수 우선 |
| 본 세션의 historical `/tmp/fa4_debug.log` 인용 정정 | Out of scope | docs sweep 후속 |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success in 352 source files (310 → 311 core + 41 plugins)
- [x] `uv run pytest tests/ -m "not live"` — **4573 passed**, 9 skipped, 24 deselected
- [x] 신규 test 10 모두 pass (env override, format, concurrent, etc)
- [ ] 자연 검증 — 다음 PoC 진단 시 본 인프라 재사용 (fa4 ad-hoc 안 만들고 `diag()` 사용)

## Reference

- PR E/F (v0.90.0) 의 fa4 evidence (`docs/audits/2026-05-11-petri-observability-audit.md` §9.4) — 본 인프라의 ground truth
- `feedback_fa4_temp_location.md` (memory) — `/tmp/` 위치 비판 + 권장 위치 결정
- 본 PR 은 v0.91.0 의 잔존 backlog 해소. 다음 PoC 진단 (e.g. inspect_ai upstream race 추적, 새 anthropic fail path) 시 즉시 재사용.