### PR TITLE
chore(release): cut v0.92.0 — core.audit.diagnostics 인프라

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.92.0] — 2026-05-12
+
 ### Added
 
 - **`core.audit.diagnostics` — file-based diagnostics log surviving

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.91.0
+- **Version**: 0.92.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 310 core + 41 plugins = 351
-- **Tests**: 4563 (+24 live)
+- **Modules**: 311 core + 41 plugins = 352
+- **Tests**: 4573 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.91.0"
+version = "0.92.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.91.0"
+version = "0.92.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- v0.92.0 release cut. CHANGELOG `[Unreleased]` (1 entry — diagnostics) → `[0.92.0] — 2026-05-12`.
- version 4 위치 동기 (pyproject 0.92.0 + CLAUDE.md + uv.lock).
- 본 PR 머지 후 develop → main PR 진행.

## Why

CLAUDE.md release 정책 — "No leaving [Unreleased] on main". diagnostics 인프라 (#1039) 는 새 module + public API → MINOR (0.91.x → 0.92.0).

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | 0.91.0 → 0.92.0 |
| `CLAUDE.md` | Version 0.91.0 → 0.92.0, Modules 351 → 352, Tests 4563 → 4573 |
| `uv.lock` | version 변경 반영 (auto) |
| `CHANGELOG.md` | `[Unreleased]` 1 entry → `[0.92.0] — 2026-05-12` |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [ ] CI 5/5 — 본 PR
- [x] CHANGELOG 1 entry 정확히 [0.92.0] 안
- [x] version 4 위치 동기