### PR TITLE
fix(llm): GAP-E1 — retry policy SOT 회복 (settings.llm_*)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **LLM retry policy SOT — GAP-E1.** `OpenAIAdapter._retry_with_backoff`
+  pinned `max_retries=3`, `retry_base_delay=1.0`, `retry_max_delay=30.0`
+  via module-local `_MAX_RETRIES` / `_RETRY_BASE_DELAY` / `_RETRY_MAX_DELAY`
+  constants, ignoring `settings.llm_max_retries` /
+  `settings.llm_retry_base_delay` / `settings.llm_retry_max_delay`.
+  GLM (via `OpenAIAgenticAdapter` inheritance) inherited the same drift.
+  Adapter now leaves these arguments unset so `retry_with_backoff_generic`
+  resolves them lazily from settings — restoring the single source of
+  truth shared with Anthropic. Regression test:
+  `tests/test_retry_policy_sot.py`.
+
 - **Petri seeds flat-layout (G-A1).** Discovery (post-merge of PR #1044):
   `inspect_petri/_seeds/_markdown.py:read_seed_directory` uses
   `directory.glob("*.md")` — **non-recursive**. The 13 curated GEODE

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -30,10 +30,12 @@ T = TypeVar("T", bound="BaseModel")
 
 log = logging.getLogger(__name__)
 
-# OpenAI retryable errors
-_MAX_RETRIES = 3
-_RETRY_BASE_DELAY = 1.0
-_RETRY_MAX_DELAY = 30.0
+# Retry policy values (max_retries / retry_base_delay / retry_max_delay) are
+# resolved lazily from ``core.config.settings.llm_*`` inside
+# ``retry_with_backoff_generic`` (fallback.py).  Keeping a single source of
+# truth ensures runtime ``settings.llm_max_retries`` tuning reaches every
+# provider — previously OpenAI/GLM passed module-local constants that pinned
+# them to ``3`` regardless of configuration.
 
 # Default OpenAI model — from config.py single source of truth
 DEFAULT_OPENAI_MODEL = OPENAI_PRIMARY
@@ -360,9 +362,6 @@ class OpenAIAdapter:
             billing_message=(
                 "OpenAI API billing/credit error. Check your OpenAI account billing settings."
             ),
-            max_retries=_MAX_RETRIES,
-            retry_base_delay=_RETRY_BASE_DELAY,
-            retry_max_delay=_RETRY_MAX_DELAY,
             provider_label="OpenAI",
         )
 

--- a/tests/test_retry_policy_sot.py
+++ b/tests/test_retry_policy_sot.py
@@ -1,0 +1,52 @@
+"""Regression — single SOT for retry policy across providers (GAP-E1).
+
+Pre-fix: ``core/llm/providers/openai.py`` defined ``_MAX_RETRIES`` /
+``_RETRY_BASE_DELAY`` / ``_RETRY_MAX_DELAY`` and passed them explicitly to
+``retry_with_backoff_generic``, which pinned OpenAI/GLM retry behavior to
+the hardcoded ``3`` regardless of ``settings.llm_max_retries`` /
+``settings.llm_retry_base_delay`` / ``settings.llm_retry_max_delay``.
+
+Post-fix: the adapter no longer pins these arguments. ``retry_with_backoff_generic``
+resolves them from ``core.config.settings`` lazily, restoring the single
+source of truth shared with the Anthropic path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import core.llm.providers.openai as openai_provider
+from core.llm.providers.openai import OpenAIAdapter
+
+
+def test_openai_adapter_does_not_pin_retry_constants(monkeypatch: Any) -> None:
+    """OpenAIAdapter._retry_with_backoff must leave retry knobs unset so
+    fallback.py resolves them from ``settings.llm_*``.
+    """
+    captured: dict[str, Any] = {}
+
+    def _fake_generic(fn: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return fn(model=kwargs["model"])
+
+    monkeypatch.setattr(openai_provider, "retry_with_backoff_generic", _fake_generic)
+
+    adapter = OpenAIAdapter()
+    result = adapter._retry_with_backoff(lambda model: "ok", model="gpt-5.5")
+
+    assert result == "ok"
+    # GAP-E1 regression: None → fallback.py reads ``settings.llm_*``
+    assert captured.get("max_retries") is None
+    assert captured.get("retry_base_delay") is None
+    assert captured.get("retry_max_delay") is None
+
+
+def test_module_no_local_retry_constants() -> None:
+    """The local retry constants must not return — they bypass the SOT.
+
+    If a future refactor reintroduces module-local retry knobs, this
+    regression test will fail before the issue ships.
+    """
+    assert not hasattr(openai_provider, "_MAX_RETRIES")
+    assert not hasattr(openai_provider, "_RETRY_BASE_DELAY")
+    assert not hasattr(openai_provider, "_RETRY_MAX_DELAY")


### PR DESCRIPTION
## Summary
- `OpenAIAdapter._retry_with_backoff` 가 모듈 로컬 상수 `_MAX_RETRIES` / `_RETRY_BASE_DELAY` / `_RETRY_MAX_DELAY` 를 명시 전달해 `settings.llm_*` 운영 튜닝이 OpenAI/GLM 에 반영되지 않던 SOT 위반 수정.
- 상수 + 명시 인자 제거 → `retry_with_backoff_generic` 의 `None` default → `core.config.settings.llm_*` lazy 해석 경로 활용.
- 회귀 방지 테스트 1개 신규 (`tests/test_retry_policy_sot.py`).

## Why
3-프로바이더 매트릭스 감사(`.audit/llm_provider_matrix_gaps.md`) 결과 발견된 17 GAP 중 **GAP-E1 (Critical)**. Anthropic 측은 `fallback.py:323` 에서 `MAX_RETRIES` 를 lazy 해석해 settings 와 일원화되어 있었으나, OpenAI/GLM 은 하드코딩 `3` 에 고정. 운영자가 `settings.llm_max_retries=10` 으로 튜닝해도 OpenAI/GLM 호출엔 무영향 → 일관성 결함 + 사일런트 비용/회복력 문제.

agentic path(`call_with_failover`) 는 이미 `None` 디폴트 + settings lazy 해석 으로 SOT 준수 중. **non-agentic `OpenAIAdapter._retry_with_backoff` 1곳** 만 위반.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/openai.py` | `_MAX_RETRIES`/`_RETRY_BASE_DELAY`/`_RETRY_MAX_DELAY` 모듈 로컬 상수 제거 + `_retry_with_backoff` 의 `max_retries`/`retry_base_delay`/`retry_max_delay` 명시 전달 제거. 의도 주석 보강. |
| `tests/test_retry_policy_sot.py` (신규) | 어댑터 가 retry 인자 를 `None` 으로 유지 하는지, 모듈 로컬 상수 가 재도입 되지 않는지 회귀 검증 (2 tests). |
| `CHANGELOG.md` | `[Unreleased]` 의 `Fixed` 섹션 에 GAP-E1 항목 추가. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| GAP-E1 (retry SOT 일원화) | **Implemented** | OpenAIAdapter only. agentic path 는 이미 준수. |
| GAP-M1 (fallback chain 2단계) | **Dropped** | Socratic Q1: chain 은 list 라 길이 제한 없음. config 에서 늘리면 그만. |
| GAP-E2 (GLM billing 어댑터 내 미사용) | **Dropped** | Socratic Q1: `errors.is_billing_fatal` + `fallback.retry_with_backoff_generic:286-313` 이 이미 1113/1114/1301 매핑 + `BillingError` 변환. 어댑터 내 중복 처리 불필요. |

## Verification
- [x] `uv run ruff check core/llm/providers/openai.py tests/test_retry_policy_sot.py` — All checks passed
- [x] `uv run mypy core/llm/providers/openai.py` — Success: no issues found
- [x] `uv run pytest tests/test_retry_policy_sot.py tests/test_llm_resilience.py tests/test_failover.py tests/test_provider_parity_v0532.py tests/test_billing_fatal.py tests/test_provider_switching.py` — **122 passed**
- [x] 외부 동작 변화 없음 — `settings.llm_max_retries` 기본값 `3` 와 기존 하드코딩 `3` 일치 → 회귀 없음 / 운영 튜닝 활성화.

## Reference
3-프로바이더 매트릭스 감사 plan: `.audit/llm_provider_matrix_gaps.md` (PR-1 / 17 GAP 중 첫 묶음).