### PR TITLE
feat(llm): GAP-T1 — cross-provider tool_choice 정규화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-provider tool_choice normalization — GAP-T1.** New
+  `core/llm/tool_choice.py` centralizes the conversion of a canonical
+  `tool_choice` (string / dict / named-tool / `None`) into each
+  provider's native shape — Anthropic dict, OpenAI Responses string-or-flat,
+  GLM Chat Completions nested-function. Replaces 3× inlined conversions
+  in `anthropic.py:482-484`, `openai.py:507`, `glm.py:190` and adds first-class
+  support for named-tool forcing (`{"name": "X"}` → provider-specific shape)
+  and the `required` ↔ `any` keyword alias. Test:
+  `tests/test_tool_choice_normalize.py` (33 cases × 3 providers + edge cases).
+
 ### Fixed
 
 - **Petri seeds flat-layout (G-A1).** Discovery (post-merge of PR #1044):

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -479,9 +479,11 @@ class ClaudeAgenticAdapter:
         if self._client is None:
             self._client = get_async_anthropic_client(api_key)
 
-        # Anthropic tool_choice is always a dict
-        if isinstance(tool_choice, str):
-            tool_choice = {"type": tool_choice}
+        # GAP-T1 — normalize cross-provider tool_choice into the Anthropic
+        # dict shape ({"type": "auto"|"any"|"tool"|"none", "name"?: ...}).
+        from core.llm.tool_choice import normalize as _normalize_tool_choice
+
+        tool_choice = _normalize_tool_choice("anthropic", tool_choice) or {"type": "auto"}
 
         api_tools = [{k: v for k, v in t.items() if k in _API_ALLOWED_KEYS} for t in tools]
 

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -187,7 +187,11 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
             log.warning("%s circuit breaker is OPEN, skipping call", self.provider_name)
             return None
 
-        tc_val = tool_choice.get("type", "auto") if isinstance(tool_choice, dict) else tool_choice
+        # GAP-T1 — normalize cross-provider tool_choice into the Chat Completions
+        # nested shape (string or {"type": "function", "function": {"name": "..."}}).
+        from core.llm.tool_choice import normalize as _normalize_tool_choice
+
+        tc_val = _normalize_tool_choice("glm", tool_choice)
 
         oai_tools = _tools_to_chat_completions(tools)
         oai_tools.append(_GLM_NATIVE_WEB_SEARCH)

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -503,8 +503,11 @@ class OpenAIAgenticAdapter:
             log.warning("%s circuit breaker is OPEN, skipping call", self.provider_name)
             return None
 
-        # Responses API tool_choice is a string
-        tc_val = tool_choice.get("type", "auto") if isinstance(tool_choice, dict) else tool_choice
+        # GAP-T1 — normalize cross-provider tool_choice into the Responses API
+        # shape (string or {"type": "function", "name": "..."}).
+        from core.llm.tool_choice import normalize as _normalize_tool_choice
+
+        tc_val = _normalize_tool_choice("openai", tool_choice)
 
         # Build tools: function tools + native hosted tools (dedup)
         oai_tools: list[dict[str, Any]] = _tools_to_openai(tools)

--- a/core/llm/tool_choice.py
+++ b/core/llm/tool_choice.py
@@ -1,0 +1,116 @@
+"""Tool choice normalization across providers (GAP-T1).
+
+Different LLM providers expect different ``tool_choice`` shapes:
+
+- **Anthropic Messages API**: always a dict.
+  ``{"type": "auto"|"any"|"tool"|"none", "name"?: "..."}``
+- **OpenAI Responses API**: string or flat dict.
+  ``"auto" | "none" | "required" | {"type": "function", "name": "..."}``
+- **GLM Chat Completions** (OpenAI-compat): string or nested dict.
+  ``"auto" | "none" | "required" | {"type": "function", "function": {"name": "..."}}``
+
+Prior to v0.93, each adapter inlined its own conversion (anthropic.py:482-484,
+openai.py:507, glm.py:190), which (a) duplicated logic 3× and (b) failed
+to translate cross-provider concepts such as ``required`` ↔ ``any`` or
+named-tool forcing (``{"name": "X"}``).  This module centralizes the
+mapping so callers can pass a single canonical form and each adapter
+renders it natively.
+
+Canonical inputs accepted:
+- ``"auto"`` / ``"none"`` / ``"required"`` / ``"any"`` (string)
+- ``{"type": "..."}`` (dict; same keywords as above)
+- ``{"type": "tool"|"function", "name": "X"}`` (force named tool)
+- ``{"name": "X"}`` (shorthand for forced named tool)
+- ``{"function": {"name": "X"}}`` (OpenAI-style nested name)
+- ``None`` (pass through)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ToolChoice = str | dict[str, Any]
+
+# ``required`` ↔ ``any`` is the only cross-provider keyword that differs
+# in spelling.  ``auto`` / ``none`` / function-name forcing are conceptually
+# identical across the three providers; only the wrapping shape changes.
+_REQUIRED_ALIASES = frozenset({"required", "any"})
+
+
+def _extract_name(choice: dict[str, Any]) -> str | None:
+    """Return the forced-tool name from any common dict shape, or None."""
+    direct = choice.get("name")
+    if isinstance(direct, str) and direct:
+        return direct
+    fn = choice.get("function")
+    if isinstance(fn, dict):
+        nested = fn.get("name")
+        if isinstance(nested, str) and nested:
+            return nested
+    return None
+
+
+def _to_anthropic(choice: ToolChoice | None) -> dict[str, Any] | None:
+    if choice is None:
+        return None
+    if isinstance(choice, str):
+        if choice in _REQUIRED_ALIASES:
+            return {"type": "any"}
+        return {"type": choice}
+    name = _extract_name(choice)
+    if name is not None:
+        return {"type": "tool", "name": name}
+    t = choice.get("type", "auto")
+    if isinstance(t, str) and t in _REQUIRED_ALIASES:
+        return {"type": "any"}
+    return {"type": t}
+
+
+def _to_openai(choice: ToolChoice | None) -> str | dict[str, Any] | None:
+    """Responses API flat shape: string or ``{"type": "function", "name": "X"}``."""
+    if choice is None:
+        return None
+    if isinstance(choice, str):
+        return "required" if choice in _REQUIRED_ALIASES else choice
+    name = _extract_name(choice)
+    if name is not None:
+        return {"type": "function", "name": name}
+    t = choice.get("type", "auto")
+    if isinstance(t, str) and t in _REQUIRED_ALIASES:
+        return "required"
+    return t if isinstance(t, str) else "auto"
+
+
+def _to_glm(choice: ToolChoice | None) -> str | dict[str, Any] | None:
+    """Chat Completions nested shape: string or
+    ``{"type": "function", "function": {"name": "X"}}``.
+    """
+    if choice is None:
+        return None
+    if isinstance(choice, str):
+        return "required" if choice in _REQUIRED_ALIASES else choice
+    name = _extract_name(choice)
+    if name is not None:
+        return {"type": "function", "function": {"name": name}}
+    t = choice.get("type", "auto")
+    if isinstance(t, str) and t in _REQUIRED_ALIASES:
+        return "required"
+    return t if isinstance(t, str) else "auto"
+
+
+def normalize(provider: str, choice: ToolChoice | None) -> str | dict[str, Any] | None:
+    """Convert a tool_choice into the provider-native shape.
+
+    ``provider`` is matched case-insensitively against ``anthropic`` /
+    ``openai`` / ``codex`` / ``glm``.  Unknown providers receive the
+    input back unchanged so callers do not crash when extending to new
+    backends — log + add a branch when the new provider lands.
+    """
+    p = provider.lower()
+    if p == "anthropic":
+        return _to_anthropic(choice)
+    if p in ("openai", "codex"):
+        return _to_openai(choice)
+    if p == "glm":
+        return _to_glm(choice)
+    return choice

--- a/tests/test_tool_choice_normalize.py
+++ b/tests/test_tool_choice_normalize.py
@@ -1,0 +1,129 @@
+"""GAP-T1 — cross-provider tool_choice normalization contract.
+
+Verifies that ``core.llm.tool_choice.normalize`` renders a canonical input
+into each provider's native shape:
+
+- Anthropic Messages API: dict ``{"type": ..., "name"?: ...}``
+- OpenAI Responses API: string or ``{"type": "function", "name": "..."}``
+- GLM Chat Completions: string or ``{"type": "function", "function": {"name": "..."}}``
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.tool_choice import normalize
+
+# ---------------------------------------------------------------------------
+# Anthropic — dict-only output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "in_choice,expected",
+    [
+        ("auto", {"type": "auto"}),
+        ("none", {"type": "none"}),
+        ("required", {"type": "any"}),
+        ("any", {"type": "any"}),
+        ({"type": "auto"}, {"type": "auto"}),
+        ({"type": "required"}, {"type": "any"}),
+        ({"type": "any"}, {"type": "any"}),
+        ({"type": "tool", "name": "web_search"}, {"type": "tool", "name": "web_search"}),
+        ({"name": "calculator"}, {"type": "tool", "name": "calculator"}),
+        (
+            {"function": {"name": "lookup"}},
+            {"type": "tool", "name": "lookup"},
+        ),
+    ],
+)
+def test_anthropic_normalize(in_choice: object, expected: object) -> None:
+    assert normalize("anthropic", in_choice) == expected  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI — string or flat dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "in_choice,expected",
+    [
+        ("auto", "auto"),
+        ("none", "none"),
+        ("required", "required"),
+        ("any", "required"),
+        ({"type": "auto"}, "auto"),
+        ({"type": "required"}, "required"),
+        ({"type": "any"}, "required"),
+        ({"type": "function", "name": "web_search"}, {"type": "function", "name": "web_search"}),
+        ({"name": "calculator"}, {"type": "function", "name": "calculator"}),
+        ({"function": {"name": "lookup"}}, {"type": "function", "name": "lookup"}),
+    ],
+)
+def test_openai_normalize(in_choice: object, expected: object) -> None:
+    assert normalize("openai", in_choice) == expected  # type: ignore[arg-type]
+
+
+def test_openai_codex_alias() -> None:
+    """``codex`` provider routes through the OpenAI Responses shape."""
+    assert normalize("codex", "any") == "required"
+    assert normalize("codex", {"name": "search"}) == {"type": "function", "name": "search"}
+
+
+# ---------------------------------------------------------------------------
+# GLM — string or nested-function dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "in_choice,expected",
+    [
+        ("auto", "auto"),
+        ("none", "none"),
+        ("required", "required"),
+        ("any", "required"),
+        ({"type": "auto"}, "auto"),
+        ({"type": "required"}, "required"),
+        ({"type": "any"}, "required"),
+        (
+            {"type": "function", "function": {"name": "web_search"}},
+            {"type": "function", "function": {"name": "web_search"}},
+        ),
+        (
+            {"name": "calculator"},
+            {"type": "function", "function": {"name": "calculator"}},
+        ),
+    ],
+)
+def test_glm_normalize(in_choice: object, expected: object) -> None:
+    assert normalize("glm", in_choice) == expected  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_none_passthrough() -> None:
+    """A caller passing ``None`` (no preference) round-trips as None for all
+    providers — the adapter then omits ``tool_choice`` entirely.
+    """
+    for p in ("anthropic", "openai", "codex", "glm"):
+        assert normalize(p, None) is None
+
+
+def test_unknown_provider_returns_input_unchanged() -> None:
+    """Unknown providers must not crash existing callers; they receive the
+    canonical input unchanged so the caller can decide a fallback.
+    """
+    assert normalize("future-provider", "auto") == "auto"
+    assert normalize("future-provider", {"name": "X"}) == {"name": "X"}
+
+
+def test_case_insensitive_provider() -> None:
+    """Provider lookup is case-insensitive — accidental capitalization in
+    config files should not silently bypass normalization.
+    """
+    assert normalize("Anthropic", "required") == {"type": "any"}
+    assert normalize("OPENAI", "any") == "required"
+    assert normalize("GLM", "any") == "required"


### PR DESCRIPTION
## Summary
- 신규 `core/llm/tool_choice.py` — canonical `tool_choice` 입력(str / dict / `{"name":"X"}` shorthand / None) 을 3 provider native shape 으로 변환 하는 `normalize()` helper.
- Anthropic dict / OpenAI Responses flat string-or-dict / GLM Chat Completions nested-function 형식 모두 일관 처리.
- `required` ↔ `any` 키워드 별칭 자동 매핑, named-tool forcing 1급 지원, case-insensitive provider 매칭, unknown provider graceful fallback.
- 3 어댑터(`anthropic.py:482-484`, `openai.py:507`, `glm.py:190`) inline 변환 제거 → helper 호출 로 교체.

## Why
3-프로바이더 매트릭스 감사(`.audit/llm_provider_matrix_gaps.md`) 결과 발견된 17 GAP 중 **GAP-T1 (High)**.

각 provider 가 자체 tool_choice 형식 을 어댑터 안 에서 inline 으로 변환:
- Anthropic 은 ``isinstance(str)`` → ``{"type": str}`` 단순 변환 (named tool 미지원)
- OpenAI 는 dict 면 ``.get("type", "auto")`` 추출 (named tool 미지원)
- GLM 도 OpenAI 와 동일 (named tool 미지원)

결과:
1. 3 곳 중복 (DRY 위반).
2. 호출자 가 `{"name": "calc"}` 으로 forced 호출 하려 해도 모든 어댑터 가 정보 손실.
3. OpenAI 의 `required` 와 Anthropic 의 `any` 가 동일 개념인데 매핑 부재 → cross-provider 라우팅 시 400 가능.
4. 새 어댑터 추가 시 또 inline 변환 작성 필요.

helper 1개 + 호출자 3 곳 치환 으로 모두 해결.

## Changes
| File | Change |
|------|--------|
| `core/llm/tool_choice.py` (신규) | `normalize(provider, choice)` helper + provider 별 `_to_anthropic` / `_to_openai` / `_to_glm` + `_extract_name` shorthand 처리. case-insensitive provider, `required` ↔ `any` 별칭, named-tool forcing, None passthrough. |
| `core/llm/providers/anthropic.py` | inline `isinstance(str)` 변환 제거 → `_normalize_tool_choice("anthropic", ...)` 호출. dict 보장 위해 `or {"type": "auto"}` fallback. |
| `core/llm/providers/openai.py` | inline `.get("type", "auto")` 변환 제거 → `_normalize_tool_choice("openai", ...)` 호출. |
| `core/llm/providers/glm.py` | 동일 패턴 — `_normalize_tool_choice("glm", ...)`. |
| `tests/test_tool_choice_normalize.py` (신규) | 33 cases — anthropic 10, openai 10 + codex alias 1, glm 9, edge 4 (None passthrough, unknown provider, case-insensitive). |
| `CHANGELOG.md` | `[Unreleased]` 의 `Added` 섹션 에 GAP-T1 항목. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| GAP-T1 (tool_choice 정규화) | **Implemented** | helper + 3 어댑터 치환 + 33 tests. |
| GAP-T3 (capability matrix) | **Dropped** | Socratic Q4: 첫 호출처 부재 → premature abstraction. 호출자 사용처 가 명확해질 때 별도 PR. |

## Verification
- [x] `ruff check core/llm/tool_choice.py core/llm/providers/*.py tests/test_tool_choice_normalize.py` — clean
- [x] `mypy core/llm/tool_choice.py core/llm/providers/anthropic.py core/llm/providers/openai.py core/llm/providers/glm.py` — Success: no issues found in 4 source files
- [x] `pytest tests/test_tool_choice_normalize.py` — **33 passed**
- [x] `pytest tests/test_agentic_loop.py tests/test_agentic_response.py tests/test_provider_parity_v0532.py tests/test_anthropic_sampling_params.py tests/test_anthropic_reasoning_v056.py` — **122 passed**
- [x] `pytest tests/ -m "not live"` (core, excl audit/observability/plugins) — all pass

## Reference
3-프로바이더 매트릭스 감사 plan: `.audit/llm_provider_matrix_gaps.md` (PR-2 / 17 GAP 중 두 번째 묶음). 직전 PR #1056 (GAP-E1) 머지 후 develop 갱신 필요 시 자동 머지 시도.