### PR TITLE
feat(llm): GAP-17 — OpenAI HTML data URL 가드 + postprocess decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **OpenAI HTML data-URL guard — GAP-17.** OpenAI/Codex models, when
+  asked to author HTML, frequently emit the entire document as a single
+  `data:text/html(;base64)?,...` URL meant to be pasted into a browser's
+  address bar — a shape that silently breaks GEODE's downstream
+  consumers (slide build, report PDF, artifact archiving) and inflates
+  `output_tokens` 30–50% from base64 overhead.
+  - Primary guard: `core/agent/system_prompt._build_model_card` now
+    injects a provider-gated instruction for `openai` / `openai-codex`
+    forbidding the address-bar shape and demanding raw `<!DOCTYPE html>`
+    source. Anthropic / GLM cards are unchanged — they do not exhibit
+    this drift.
+  - Safety net: new `core/llm/postprocess/html_output.py` exposes
+    `detect_data_url` / `decode_html` / `extract_artifact_to` so callers
+    can recover the HTML when a model emits the shape anyway.
+    Idempotent (hash-derived filename), handles base64 + percent-encoded
+    payloads + malformed-base64 fallback.
+  - 18 regression tests: `tests/test_html_output_guard.py` covering
+    5 detection shapes, 3 decode round-trips, 2 disk extraction cases,
+    OpenAI/Codex guard presence (3 models), Anthropic/GLM guard absence
+    (4 models).
+
 ### Fixed
 
 - **Petri seeds flat-layout (G-A1).** Discovery (post-merge of PR #1044):

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -290,6 +290,23 @@ def _build_model_card(model: str) -> str:
             "Do NOT call check_status for model info."
         )
 
+        # GAP-17 — OpenAI / Codex tendency to emit HTML as a single
+        # ``data:text/html(;base64)?`` URL ('paste into address bar' shape)
+        # silently breaks every downstream GEODE consumer (slide build,
+        # report PDF, artifact archiving) and inflates output_tokens 30-50%.
+        # Anthropic + GLM do not exhibit this drift, so the guard is
+        # provider-gated.  ``core.llm.postprocess.html_output`` is the
+        # safety-net decoder when the guard fails.
+        if provider in ("openai", "openai-codex"):
+            parts.append(
+                "HTML output: NEVER emit ``data:text/html`` URLs or "
+                "base64-encoded single-string blobs (the 'paste into address "
+                "bar' shape). Always write raw ``<!DOCTYPE html>...`` source "
+                "and propose a file path for storage. The address-bar shape "
+                "is unreadable to the GEODE pipeline and inflates output "
+                "tokens by 30-50%."
+            )
+
         return "<model_card>\n" + "\n".join(parts) + "\n</model_card>"
     except Exception:
         log.debug("Failed to build model card", exc_info=True)

--- a/core/llm/postprocess/__init__.py
+++ b/core/llm/postprocess/__init__.py
@@ -1,0 +1,22 @@
+"""LLM response post-processing helpers.
+
+Currently exposes ``html_output`` — detects OpenAI/Codex's tendency to emit
+HTML as a single ``data:text/html`` URL (the 'paste-into-address-bar'
+shape) and converts it back into a regular HTML artifact (GAP-17).
+"""
+
+from __future__ import annotations
+
+from core.llm.postprocess.html_output import (
+    DataUrlMatch,
+    decode_html,
+    detect_data_url,
+    extract_artifact_to,
+)
+
+__all__ = [
+    "DataUrlMatch",
+    "decode_html",
+    "detect_data_url",
+    "extract_artifact_to",
+]

--- a/core/llm/postprocess/html_output.py
+++ b/core/llm/postprocess/html_output.py
@@ -1,0 +1,123 @@
+"""Detect + decode OpenAI-style HTML data URLs (GAP-17).
+
+OpenAI / Codex models, when asked to author HTML, frequently emit the
+entire document as a single ``data:text/html(;base64)?,...`` URL meant to
+be pasted into a browser's address bar.  GEODE pipelines expect HTML to
+land on disk as a regular file (slide builds, report PDF pipelines,
+artifact archiving), so the address-bar shape silently breaks downstream
+consumers AND inflates ``output_tokens`` 30–50% from base64 overhead.
+
+This module provides three pure-function helpers:
+
+- ``detect_data_url(text)`` — scan text for a leading ``data:text/html``
+  URL and return a structured match (or ``None`` if absent).
+- ``decode_html(match)`` — recover the original HTML string (percent- or
+  base64-decoded as appropriate).
+- ``extract_artifact_to(match, dest_dir)`` — write the recovered HTML
+  to a unique file under ``dest_dir`` and return the path.
+
+The system prompt (``core.agent.system_prompt._build_model_card``) carries
+the primary guard — instructing OpenAI models to emit raw ``<!DOCTYPE
+html>`` source.  These helpers are the safety net for the cases where
+the model emits the address-bar form anyway.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import re
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+
+# Permissive regex — matches the address-bar shape regardless of optional
+# parameters (``charset=utf-8``, ``;base64``).  The payload is captured
+# greedily until end-of-string because a data URL is typically the
+# entire response when the model adopts this shape.
+_DATA_URL_RE = re.compile(
+    r"data:text/html(?P<params>(?:;[\w=-]+)*),(?P<payload>.+)",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class DataUrlMatch:
+    """Structured result of ``detect_data_url``.
+
+    Attributes:
+        params: Raw parameter segment (``;charset=utf-8;base64``) without
+            the leading semicolon split — used to decide decoding strategy.
+        payload: The raw payload after the comma. Still encoded — call
+            ``decode_html`` to recover the original HTML string.
+        is_base64: True when the URL declared ``;base64``.
+        raw: The entire matched substring, including the ``data:`` prefix.
+    """
+
+    params: str
+    payload: str
+    is_base64: bool
+    raw: str
+
+
+def detect_data_url(text: str) -> DataUrlMatch | None:
+    """Return a ``DataUrlMatch`` if *text* contains a ``data:text/html`` URL.
+
+    The matcher is intentionally permissive — it does not anchor at start
+    of string because some models prefix the URL with explanatory prose
+    ("Here is the HTML: data:text/html;base64,...").  When the URL is
+    not at the very start, the leading prose is *not* preserved in the
+    match; callers wanting to drop both the URL and the lead-in should
+    operate on ``match.raw``.
+    """
+    if not text or "data:text/html" not in text:
+        return None
+    m = _DATA_URL_RE.search(text)
+    if m is None:
+        return None
+    params = m.group("params") or ""
+    payload = m.group("payload") or ""
+    return DataUrlMatch(
+        params=params,
+        payload=payload,
+        is_base64=";base64" in params.lower(),
+        raw=m.group(0),
+    )
+
+
+def decode_html(match: DataUrlMatch) -> str:
+    """Recover the original HTML string from *match*.
+
+    Base64 payloads round-trip through ``base64.b64decode`` (UTF-8
+    decoded). Non-base64 payloads go through ``urllib.parse.unquote``
+    to undo percent-encoding (``%3C`` → ``<``).  Malformed base64
+    falls back to percent-decoding so the helper never raises on
+    real-world model output.
+    """
+    payload = match.payload.strip()
+    if match.is_base64:
+        try:
+            return base64.b64decode(payload, validate=False).decode("utf-8", errors="replace")
+        except (binascii.Error, ValueError):
+            # Some models emit a base64 declaration but plain-encoded
+            # content.  Fall through to percent-decoding.
+            pass
+    return urllib.parse.unquote(payload)
+
+
+def extract_artifact_to(match: DataUrlMatch, dest_dir: Path) -> Path:
+    """Write the recovered HTML to a unique file under *dest_dir*.
+
+    The filename is derived from a short hash of the payload so repeated
+    extraction of the same content stays idempotent — useful when the
+    helper is wired into a retry loop.  Returns the resulting path.
+
+    *dest_dir* is created if missing (``parents=True``).
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    body = decode_html(match)
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()[:12]
+    target = dest_dir / f"openai_html_{digest}.html"
+    target.write_text(body, encoding="utf-8")
+    return target

--- a/tests/test_html_output_guard.py
+++ b/tests/test_html_output_guard.py
@@ -194,6 +194,4 @@ def test_guard_absent_for_non_openai(non_openai_model: str) -> None:
 
     _build_model_card.cache_clear()
     card = _build_model_card(non_openai_model)
-    assert _GUARD_NEEDLE not in card, (
-        f"GAP-17 guard leaked into {non_openai_model} model card"
-    )
+    assert _GUARD_NEEDLE not in card, f"GAP-17 guard leaked into {non_openai_model} model card"

--- a/tests/test_html_output_guard.py
+++ b/tests/test_html_output_guard.py
@@ -1,0 +1,199 @@
+"""GAP-17 — OpenAI HTML ``data:text/html`` URL guard.
+
+Two layers:
+
+1. ``core.llm.postprocess.html_output`` recovers HTML when a model emits
+   the address-bar shape anyway.
+2. ``core.agent.system_prompt._build_model_card`` prepends a provider-gated
+   guard that tells OpenAI/Codex models not to emit the shape in the
+   first place.
+"""
+
+from __future__ import annotations
+
+import base64
+import urllib.parse
+from pathlib import Path
+
+import pytest
+from core.llm.postprocess.html_output import (
+    decode_html,
+    detect_data_url,
+    extract_artifact_to,
+)
+
+# ---------------------------------------------------------------------------
+# detect_data_url — recognize the address-bar shape
+# ---------------------------------------------------------------------------
+
+
+def test_detect_plain_percent_encoded() -> None:
+    html = "<html><body>Hello world</body></html>"
+    url = f"data:text/html,{urllib.parse.quote(html)}"
+    match = detect_data_url(url)
+    assert match is not None
+    assert not match.is_base64
+    assert match.params == ""
+    assert match.raw == url
+
+
+def test_detect_charset_only() -> None:
+    """``;charset=utf-8`` declared but no base64 → percent-decoded payload."""
+    url = "data:text/html;charset=utf-8,%3Cdiv%3Ehi%3C/div%3E"
+    match = detect_data_url(url)
+    assert match is not None
+    assert not match.is_base64
+    assert "charset" in match.params
+
+
+def test_detect_base64() -> None:
+    html = "<h1>multiline\nbody</h1>"
+    payload = base64.b64encode(html.encode("utf-8")).decode("ascii")
+    url = f"data:text/html;base64,{payload}"
+    match = detect_data_url(url)
+    assert match is not None
+    assert match.is_base64
+    assert match.payload == payload
+
+
+def test_detect_base64_with_charset() -> None:
+    """Both ``;charset=...`` and ``;base64`` declared — order varies."""
+    payload = base64.b64encode(b"<p>x</p>").decode("ascii")
+    url = f"data:text/html;charset=utf-8;base64,{payload}"
+    match = detect_data_url(url)
+    assert match is not None
+    assert match.is_base64
+
+
+def test_detect_embedded_in_prose() -> None:
+    """Some models prefix the URL with a sentence — still detect."""
+    payload = base64.b64encode(b"<html/>").decode("ascii")
+    text = f"Here is the slide:\n\ndata:text/html;base64,{payload}\n\nPaste this."
+    match = detect_data_url(text)
+    assert match is not None
+    assert match.is_base64
+    # The lead-in prose is NOT part of ``match.raw``
+    assert not match.raw.startswith("Here")
+    assert match.raw.startswith("data:text/html")
+
+
+def test_detect_missing_returns_none() -> None:
+    assert detect_data_url("") is None
+    assert detect_data_url("<html>plain</html>") is None
+    assert detect_data_url("https://example.com/page.html") is None
+
+
+# ---------------------------------------------------------------------------
+# decode_html — round-trip through both encoding strategies
+# ---------------------------------------------------------------------------
+
+
+def test_decode_base64_roundtrip() -> None:
+    body = "<!DOCTYPE html><body>한글 + emoji 🎉</body>"
+    payload = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    match = detect_data_url(f"data:text/html;base64,{payload}")
+    assert match is not None
+    assert decode_html(match) == body
+
+
+def test_decode_percent_encoded_roundtrip() -> None:
+    body = "<div class='x'>café</div>"
+    match = detect_data_url(f"data:text/html,{urllib.parse.quote(body)}")
+    assert match is not None
+    assert decode_html(match) == body
+
+
+def test_decode_malformed_base64_falls_back() -> None:
+    """When ``;base64`` is declared but the payload isn't valid base64,
+    fall back to percent-decoding so the helper never raises.
+    """
+    url = "data:text/html;base64,%3Ch1%3Ehi%3C/h1%3E"
+    match = detect_data_url(url)
+    assert match is not None
+    decoded = decode_html(match)
+    # Either base64 garbage or percent-decoded HTML — must not raise
+    assert isinstance(decoded, str)
+
+
+# ---------------------------------------------------------------------------
+# extract_artifact_to — disk round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_extract_writes_to_dest(tmp_path: Path) -> None:
+    body = "<!DOCTYPE html><body>chart</body>"
+    payload = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    match = detect_data_url(f"data:text/html;base64,{payload}")
+    assert match is not None
+
+    out = extract_artifact_to(match, tmp_path / "artifacts")
+    assert out.exists()
+    assert out.parent == tmp_path / "artifacts"
+    assert out.suffix == ".html"
+    assert out.read_text(encoding="utf-8") == body
+
+
+def test_extract_idempotent_filename(tmp_path: Path) -> None:
+    """Same payload → same filename (hash-derived), so repeat calls
+    overwrite-not-duplicate.
+    """
+    body = "<p>stable</p>"
+    payload = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    match = detect_data_url(f"data:text/html;base64,{payload}")
+    assert match is not None
+
+    p1 = extract_artifact_to(match, tmp_path)
+    p2 = extract_artifact_to(match, tmp_path)
+    assert p1 == p2
+
+
+# ---------------------------------------------------------------------------
+# system_prompt guard — provider-gated injection
+# ---------------------------------------------------------------------------
+
+
+_GUARD_NEEDLE = "data:text/html"
+
+
+@pytest.mark.parametrize("openai_model", ["gpt-5.5", "gpt-5.4-mini"])
+def test_guard_present_for_openai(monkeypatch: pytest.MonkeyPatch, openai_model: str) -> None:
+    """OpenAI models must receive the data-URL ban in their model card."""
+    from core.agent.system_prompt import _build_model_card
+
+    _build_model_card.cache_clear()
+    card = _build_model_card(openai_model)
+    assert _GUARD_NEEDLE in card, f"Missing GAP-17 guard for {openai_model}"
+    assert "address bar" in card.lower()
+
+
+def test_guard_present_for_codex() -> None:
+    """Codex shares the OpenAI tendency — guard should apply via provider
+    routing (Codex resolves to ``openai`` or ``codex`` depending on config).
+    """
+    from core.agent.system_prompt import _build_model_card
+
+    _build_model_card.cache_clear()
+    # Codex Plus model id from CODEX_PRIMARY
+    card = _build_model_card("gpt-5.3-codex")
+    # Codex routes through OpenAI provider in _resolve_provider; check the
+    # guard fires.  If the resolver renames codex models later this test
+    # still asserts the address-bar phrase is present for any OpenAI-family
+    # model card.
+    assert _GUARD_NEEDLE in card
+
+
+@pytest.mark.parametrize(
+    "non_openai_model",
+    ["claude-opus-4-7", "claude-sonnet-4-6", "glm-5.1", "glm-4.7"],
+)
+def test_guard_absent_for_non_openai(non_openai_model: str) -> None:
+    """Anthropic / GLM do not exhibit the data-URL drift — guard must not
+    bleed into their cards (cache pressure + irrelevant instructions).
+    """
+    from core.agent.system_prompt import _build_model_card
+
+    _build_model_card.cache_clear()
+    card = _build_model_card(non_openai_model)
+    assert _GUARD_NEEDLE not in card, (
+        f"GAP-17 guard leaked into {non_openai_model} model card"
+    )


### PR DESCRIPTION
## Summary
- **1차 가드** — `core/agent/system_prompt._build_model_card` 가 OpenAI/Codex (`openai` / `openai-codex` provider) 모델 카드 에 ``data:text/html`` URL 금지 + raw ``<!DOCTYPE html>...`` 작성 + 파일 경로 제안 지침 을 prepend. Anthropic / GLM 카드 는 그대로 (provider-gated).
- **2차 안전망** — 신규 `core/llm/postprocess/html_output.py` 가 `detect_data_url` / `decode_html` / `extract_artifact_to` 순수 함수 제공. base64 + percent-encoding 양쪽 round-trip, malformed base64 graceful fallback, sha256 prefix 로 idempotent 파일명.
- 18 회귀 테스트.

## Why
3-프로바이더 매트릭스 감사(`.audit/llm_provider_matrix_gaps.md`) 결과 발견된 17 GAP 중 **GAP-17 (Critical, 신규)**. 사용자 직접 보고:
> "openai의 경우 html을 작성할 때 주소창에 넣는 경우가 많아"

OpenAI/Codex 모델 의 행동 특성: HTML 산출 요청 시 전체 문서 를 `data:text/html(;base64)?,...` 단일 URL ("주소창 붙여넣기" 형식) 로 응답.  Anthropic 계열 은 raw HTML 전문 으로 응답 — provider 별 행동 차이 가 다운스트림 파이프라인 일관성 을 무너뜨림.

영향:
1. **산출물 손실** — GEODE 슬라이드 빌드 / 리포트 PDF / 산출물 archiving 이 단일 문자열 을 파일 로 받지 못해 회로 끊김.
2. **비용 손실** — base64 인코딩 으로 output_tokens 30~50% 폭증.
3. **일관성 결함** — 동일 prompt 가 라우팅 된 provider 에 따라 다른 형태 출력 → 라우터 갈라짐 시 silent fail.

이 GAP 은 system prompt 가드 만 으로 90% 방어 가능 (모델 이 애초에 안 만들면 됨). decoder 는 가드 가 실패 했을 때 의 안전망.

## Changes
| File | Change |
|------|--------|
| `core/agent/system_prompt.py` | `_build_model_card` 의 parts 누적 끝 에 `provider in ("openai", "openai-codex")` 분기 1개 추가. 가드 문구 — "NEVER emit data:text/html URLs ... write raw <!DOCTYPE html> ..." |
| `core/llm/postprocess/__init__.py` (신규) | 공개 API export — `DataUrlMatch` / `detect_data_url` / `decode_html` / `extract_artifact_to`. |
| `core/llm/postprocess/html_output.py` (신규) | `_DATA_URL_RE` 정규식 (DOTALL + IGNORECASE), `DataUrlMatch` dataclass (frozen), 3 helper 함수. base64 / percent 양쪽 round-trip, malformed base64 fallback, sha256 prefix 파일명. |
| `tests/test_html_output_guard.py` (신규) | 18 cases — 5 detection + 1 missing + 3 decode + 2 disk + 3 guard present + 4 guard absent. |
| `CHANGELOG.md` | `[Unreleased]` 의 `Added` 섹션 에 GAP-17 항목. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| GAP-17 (OpenAI HTML data URL 가드) | **Implemented** | system_prompt 1차 가드 + postprocess 2차 안전망 + 18 tests. |

## Verification
- [x] `ruff check core/llm/postprocess/ core/agent/system_prompt.py tests/test_html_output_guard.py` — clean
- [x] `mypy core/llm/postprocess/ core/agent/system_prompt.py` — 3 source files, no issues
- [x] `pytest tests/test_html_output_guard.py` — **18 passed**
- [x] `pytest tests/test_agentic_loop.py` — **74 passed**
- [x] `pytest tests/ -m "not live"` (core, excl audit/observability/plugins) — all pass
- [x] system prompt 분기 가 provider-gated — Anthropic/GLM 카드 에 가드 누출 없음 (test_guard_absent_for_non_openai 4 cases)

## Reference
3-프로바이더 매트릭스 감사 plan: `.audit/llm_provider_matrix_gaps.md` (PR-7 / 17 GAP 중 세 번째 묶음 — Critical, 사용자 직접 보고). PR-1 (#1056) + PR-2 (#1057) 머지 후 develop 갱신 자동 시도.