### PR TITLE
feat(llm): GAP-A2 — OpenAI prompt_cache_key 주입

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **OpenAI prompt_cache_key — GAP-A2.** OpenAI's Responses API
+  auto-caches matching prefixes; an optional `prompt_cache_key` routes
+  similar requests to the same cache pool, lifting hit-rate when
+  `(system + tools)` is stable while the user / conversation differs.
+  `OpenAIAgenticAdapter.agentic_call` now derives a 32-hex-char SHA-256
+  key over `(system, sort_keys(tools))` with a `\x00` separator and
+  injects it into `responses.create` kwargs. Token tracking + cost
+  attribution were already wired (`agentic_response.py:251` reads
+  `prompt_tokens_details.cached_tokens`; `token_tracker.py:175` carries
+  per-model `cache_read` pricing), so this PR completes the path.
+  Test: `tests/test_openai_prompt_cache.py` (6 derivation contracts +
+  1 adapter-wiring stub = 7 cases).
+
 ### Fixed
 
 - **Petri seeds flat-layout (G-A1).** Discovery (post-merge of PR #1044):

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -92,6 +92,29 @@ def get_circuit_breaker() -> CircuitBreaker:
     return _openai_circuit_breaker
 
 
+def _build_prompt_cache_key(system: str, tools: list[dict[str, Any]]) -> str:
+    """Derive a stable ``prompt_cache_key`` from system + tools (GAP-A2).
+
+    OpenAI's Responses API auto-caches matching prefixes, but accepts an
+    optional ``prompt_cache_key`` that routes similar requests to the
+    same cache pool — improving hit rate when the system prompt + tools
+    schema are stable across sessions while the user / conversation
+    differs.  Same ``(system, tools)`` → same key → maximally warm cache.
+
+    Tools are serialized with ``sort_keys=True`` so dict-key ordering
+    drift inside schemas does not invalidate the key.  A ``\\x00``
+    separator prevents collisions between system suffixes and tool prefixes.
+    """
+    import hashlib
+    import json as _json
+
+    h = hashlib.sha256()
+    h.update(system.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(_json.dumps(tools, sort_keys=True, default=str).encode("utf-8"))
+    return h.hexdigest()[:32]
+
+
 class OpenAIAdapter:
     """OpenAI GPT adapter implementing LLMClientPort.
 
@@ -546,6 +569,12 @@ class OpenAIAgenticAdapter:
                 # unused; opting out avoids unnecessary OpenAI-side
                 # retention of every response. SDK default is ``True``.
                 "store": False,
+                # GAP-A2 — stable prompt cache key derived from system +
+                # tools schema. OpenAI's Responses API auto-caches matching
+                # prefixes; the optional key routes similar requests to the
+                # same cache pool, lifting hit-rate across user/conversation
+                # variation while system+tools stay constant.
+                "prompt_cache_key": _build_prompt_cache_key(system, oai_tools),
             }
             # v0.60.0 R3-mini — Responses-API reasoning kwargs.
             # ``include=["reasoning.encrypted_content"]`` is required when

--- a/tests/test_openai_prompt_cache.py
+++ b/tests/test_openai_prompt_cache.py
@@ -1,0 +1,144 @@
+"""GAP-A2 — OpenAI prompt_cache_key derivation + agentic_call wiring.
+
+OpenAI's Responses API auto-caches matching prefixes. The optional
+``prompt_cache_key`` routes similar requests to the same cache pool,
+improving hit-rate when system + tools are stable across sessions.
+
+These tests pin the derivation contract (stable across re-orderings of
+tool schema keys, different across material changes) and verify the
+adapter actually injects the key into the ``responses.create`` kwargs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from core.llm.providers.openai import (
+    OpenAIAgenticAdapter,
+    _build_prompt_cache_key,
+    _tools_to_openai,
+)
+
+# ---------------------------------------------------------------------------
+# Derivation contract
+# ---------------------------------------------------------------------------
+
+
+def test_key_is_stable_for_same_inputs() -> None:
+    sys_a = "You are a helpful assistant."
+    tools = [{"type": "function", "name": "search", "parameters": {"q": "string"}}]
+    assert _build_prompt_cache_key(sys_a, tools) == _build_prompt_cache_key(sys_a, tools)
+
+
+def test_key_is_stable_across_dict_key_order() -> None:
+    """``sort_keys=True`` neutralises serialization-order drift inside
+    tool schemas — the cache must not invalidate on cosmetic reordering.
+    """
+    sys_a = "S"
+    t1 = [{"type": "function", "name": "f", "parameters": {"a": 1, "b": 2}}]
+    t2 = [{"parameters": {"b": 2, "a": 1}, "name": "f", "type": "function"}]
+    assert _build_prompt_cache_key(sys_a, t1) == _build_prompt_cache_key(sys_a, t2)
+
+
+def test_key_changes_on_system_change() -> None:
+    tools: list[dict[str, Any]] = []
+    a = _build_prompt_cache_key("S1", tools)
+    b = _build_prompt_cache_key("S2", tools)
+    assert a != b
+
+
+def test_key_changes_on_tools_change() -> None:
+    sys_a = "S"
+    a = _build_prompt_cache_key(sys_a, [{"name": "x"}])
+    b = _build_prompt_cache_key(sys_a, [{"name": "y"}])
+    assert a != b
+
+
+def test_key_separator_prevents_collision() -> None:
+    """``system + tools_json`` collisions: a system suffix that looks like
+    the tools prefix must not collide with the genuine pairing.
+    The ``\\x00`` separator inside ``_build_prompt_cache_key`` is what
+    guarantees this — verify by constructing a near-collision pair.
+    """
+    a = _build_prompt_cache_key("hello", [{"name": "world"}])
+    # Move the boundary one char into the system side
+    b = _build_prompt_cache_key("hell", [{"oname": "world"}])
+    assert a != b
+
+
+def test_key_length_is_32_hex_chars() -> None:
+    k = _build_prompt_cache_key("S", [])
+    assert len(k) == 32
+    int(k, 16)  # must be valid hex
+
+
+# ---------------------------------------------------------------------------
+# Adapter wiring — prompt_cache_key reaches responses.create
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_call_injects_prompt_cache_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The adapter must include ``prompt_cache_key`` in the kwargs sent to
+    ``client.responses.create``.  Capture the kwargs via a stub client.
+
+    The codebase does not depend on pytest-asyncio, so we drive the async
+    method via ``asyncio.run`` directly — matching the pattern used by
+    callers in production.
+    """
+    import asyncio
+
+    captured: dict[str, Any] = {}
+
+    class _StubResponse:
+        usage = None
+        output: list[Any] = []
+        output_text = ""
+
+    class _StubResponses:
+        def create(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _StubResponse()
+
+    class _StubClient:
+        def __init__(self) -> None:
+            self.responses = _StubResponses()
+
+        def close(self) -> None:
+            pass
+
+    adapter = OpenAIAgenticAdapter()
+    monkeypatch.setattr(adapter, "_ensure_client", lambda model: _StubClient())
+    monkeypatch.setattr("core.llm.providers.openai._OPENAI_NATIVE_TOOLS", [])
+    monkeypatch.setattr(
+        "core.llm.providers.anthropic.is_computer_use_enabled",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "core.llm.agentic_response.normalize_openai_responses",
+        lambda r: r,
+    )
+
+    sys_prompt = "system XYZ"
+    tools: list[dict[str, Any]] = [
+        {"type": "function", "name": "lookup", "description": "x", "parameters": {}}
+    ]
+
+    asyncio.run(
+        adapter.agentic_call(
+            model="gpt-5.5",
+            system=sys_prompt,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            tool_choice="auto",
+            max_tokens=128,
+            temperature=0.3,
+        )
+    )
+
+    assert "prompt_cache_key" in captured, "GAP-A2: prompt_cache_key not injected"
+    # The adapter passes the *converted* tools list (post ``_tools_to_openai``)
+    # into the hash — caller's raw tools shape is normalised first.  Mirror
+    # that here so the expected key matches the captured key.
+    expected = _build_prompt_cache_key(sys_prompt, _tools_to_openai(tools))
+    assert captured["prompt_cache_key"] == expected


### PR DESCRIPTION
## Summary
- `OpenAIAgenticAdapter.agentic_call` 이 매 요청 마다 `prompt_cache_key` (sha256 over `(system, sort_keys(tools))` 의 32-hex prefix) 를 `responses.create` kwargs 에 주입.
- 신규 helper `_build_prompt_cache_key(system, tools)` 가 system 동일 + tools schema 동일 시 동일 키 보장 (캐시 hit 극대화), `\\x00` separator 가 system suffix / tools prefix collision 방지.
- 회계 path (`agentic_response.py:251` 의 `cached_tokens` 회수 + `token_tracker.py:175` 의 `cache_read` 단가) 는 이미 완비 → 본 PR 이 키 주입 만 으로 dead-spec 활성화.

## Why
3-프로바이더 매트릭스 감사(`.audit/llm_provider_matrix_gaps.md`) 결과 발견된 17 GAP 중 **GAP-A2 (Critical)**. OpenAI Responses API 는 prompt prefix 가 동일 하면 자동 캐시 hit 를 제공 하나, `prompt_cache_key` 미주입 시 cache pool 라우팅 이 default user-id 기반 → cache 격리 보장 X + hit rate 가 trafic pattern 에 의존. 안정 키 주입 으로 `(system, tools)` 가 동일 한 모든 호출 이 동일 cache pool 로 라우팅 → cache_read tokens / Mtok 절감.

회계 경로 는 이미 작동 중 (`response.usage.input_tokens_details.cached_tokens` 회수 + `MODEL_PRICING.cache_read` 적용), 그래서 본 PR 은 발생 측 (생성 path) 만 활성화 하면 즉시 비용 절감 효과 가 token_tracker 측 으로 흘러 들어옴.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/openai.py` | (1) 신규 module-level `_build_prompt_cache_key(system, tools)` helper. (2) `OpenAIAgenticAdapter.agentic_call._do_call` 의 `create_kwargs` 에 `prompt_cache_key=_build_prompt_cache_key(system, oai_tools)` 1 줄 주입 + 의도 주석. |
| `tests/test_openai_prompt_cache.py` (신규) | 7 cases — 6 derivation contract (stability, dict-order, system/tools 변경, null-byte collision, 32-hex 길이) + 1 adapter wiring stub (monkeypatch stub client 로 `responses.create` kwargs 캡처 → `prompt_cache_key` 주입 확인). |
| `CHANGELOG.md` | `[Unreleased]` 의 `Added` 섹션 에 GAP-A2 항목. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| GAP-A2 (OpenAI prompt_cache_key 주입) | **Implemented** | helper + agentic_call 주입 + 7 tests. |
| GAP-C2 (cache_read 단가 dead-spec) | **Dropped** | Socratic Q1 fail — `token_tracker.py:175` (cached_mtok 단가) + `agentic_response.py:251` (cached_tokens 회수) 모두 이미 작동 중. 매트릭스 감사 가 회수 path 를 못 본 false positive. |

## Verification
- [x] `ruff check core/llm/providers/openai.py tests/test_openai_prompt_cache.py` — clean
- [x] `mypy core/llm/providers/openai.py` — no issues
- [x] `pytest tests/test_openai_prompt_cache.py` — **7 passed**
- [x] `pytest tests/ -m "not live"` (core, excl audit/observability/plugins) — all pass
- [x] GLM 어댑터 미영향 — `prompt_cache_key` 는 OpenAI Responses API 전용 (Chat Completions 호환 X).

## Reference
3-프로바이더 매트릭스 감사 plan: `.audit/llm_provider_matrix_gaps.md` (PR-3 / 17 GAP 중 네 번째 묶음). PR-1 #1056 · PR-2 #1057 · PR-7 #1058 직렬 머지 의 다음 단계.