### PR TITLE
feat(llm): GAP-R1 — GLM thinking effort 게이팅

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **GLM thinking effort gate — GAP-R1.** `GlmAgenticAdapter.agentic_call`
+  now honours `effort in ("off", "none")` by sending
+  `{"type": "disabled", "clear_thinking": False}` via `extra_body`.
+  GLM-5.x / 4.7 ignore the `disabled` value (thinking is compulsory per
+  the upstream contract — harmless) but GLM-4.5 / 4.6 hybrid models
+  honour it and recover the (typically large) reasoning-token cost when
+  the caller asks for cheap, non-thinking output. Any non-off effort
+  keeps the v0.58.0 enabled-with-context-preserve shape. Test:
+  `tests/test_glm_thinking_control.py` (9 cases — 3 hybrid models × off,
+  none alias, 4 non-off efforts, pre-4.5 omission).
+
 ### Fixed
 
 - **Petri seeds flat-layout (G-A1).** Discovery (post-merge of PR #1044):

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -195,6 +195,15 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
         oai_messages = _convert_messages_to_openai(system, messages)
         failover_models = [model] + [m for m in self.fallback_chain if m != model]
 
+        # GAP-R1 — effort=off / none explicitly disables GLM ``thinking``.
+        # GLM-5.x / 4.7 ignore the ``disabled`` value (thinking is compulsory
+        # per the upstream contract — harmless), but GLM-4.5 / 4.6 hybrid
+        # models honour it and recover the (typically large) reasoning-token
+        # cost when the caller asks for cheap non-thinking output.  Any other
+        # effort value keeps the v0.58.0 enabled-with-context-preserve shape.
+        _thinking_off = effort in ("off", "none")
+        _thinking_type = "disabled" if _thinking_off else "enabled"
+
         async def _do_call(m: str) -> Any:
             # v0.58.0 R2 — GLM ``thinking`` field (passed via ``extra_body``
             # because openai-python's ``ChatCompletion.create`` doesn't know
@@ -205,7 +214,10 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
             # models so the request is accepted.
             local_extra: dict[str, Any] = {}
             if _glm_thinking_supported(m):
-                local_extra["thinking"] = {"type": "enabled", "clear_thinking": False}
+                local_extra["thinking"] = {
+                    "type": _thinking_type,
+                    "clear_thinking": False,
+                }
             return await asyncio.to_thread(
                 client.chat.completions.create,
                 model=m,

--- a/tests/test_glm_thinking_control.py
+++ b/tests/test_glm_thinking_control.py
@@ -1,0 +1,125 @@
+"""GAP-R1 — GLM thinking field is gated by the ``effort`` argument.
+
+Pre-fix: ``GlmAgenticAdapter.agentic_call`` always sent ``{"type":
+"enabled", "clear_thinking": False}`` whenever ``_glm_thinking_supported(m)``
+was true, ignoring the caller's ``effort`` hint.  GLM-5.x / 4.7 are
+compulsorily-thinking so this was a no-op there, but GLM-4.5 / 4.6 hybrid
+models DO honour ``"disabled"`` — and we were paying for reasoning tokens
+on every cheap-output call regardless.
+
+Post-fix: ``effort in ("off", "none")`` → ``{"type": "disabled"}``;
+anything else → unchanged ``"enabled"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from core.llm.providers.glm import GlmAgenticAdapter
+
+
+class _StubMessage:
+    role = "assistant"
+    content = ""
+    tool_calls: list[Any] = []
+
+
+class _StubChoice:
+    message = _StubMessage()
+    finish_reason = "stop"
+
+
+class _StubResponse:
+    choices = [_StubChoice()]
+    usage = None
+
+
+class _StubCompletions:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self._sink = sink
+
+    def create(self, **kwargs: Any) -> Any:
+        self._sink.update(kwargs)
+        return _StubResponse()
+
+
+class _StubChat:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.completions = _StubCompletions(sink)
+
+
+class _StubClient:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.chat = _StubChat(sink)
+
+    def close(self) -> None:
+        pass
+
+
+def _run(adapter: GlmAgenticAdapter, effort: str, model: str = "glm-4.5") -> dict[str, Any]:
+    """Invoke ``agentic_call`` with stub client and return captured kwargs."""
+    captured: dict[str, Any] = {}
+    client = _StubClient(captured)
+    adapter._ensure_client = lambda m: client  # type: ignore[method-assign]
+    asyncio.run(
+        adapter.agentic_call(
+            model=model,
+            system="S",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            tool_choice="auto",
+            max_tokens=64,
+            temperature=0.3,
+            effort=effort,
+        )
+    )
+    return captured
+
+
+@pytest.mark.parametrize("hybrid_model", ["glm-4.5", "glm-4.6", "glm-4.5-flash"])
+def test_effort_off_disables_thinking_on_hybrid(hybrid_model: str) -> None:
+    """Hybrid models accept ``disabled`` — caller asks ``effort=off``,
+    adapter must send ``type: disabled`` to recover the reasoning cost.
+    """
+    adapter = GlmAgenticAdapter()
+    captured = _run(adapter, effort="off", model=hybrid_model)
+    extra = captured.get("extra_body") or {}
+    thinking = extra.get("thinking") or {}
+    assert thinking.get("type") == "disabled", (
+        f"GAP-R1: effort=off must disable thinking on {hybrid_model}"
+    )
+
+
+def test_effort_none_also_disables() -> None:
+    """``effort=none`` is treated as ``off`` (interchangeable in the
+    callers).  Both must produce ``disabled``.
+    """
+    adapter = GlmAgenticAdapter()
+    captured = _run(adapter, effort="none", model="glm-4.5")
+    thinking = (captured.get("extra_body") or {}).get("thinking") or {}
+    assert thinking.get("type") == "disabled"
+
+
+@pytest.mark.parametrize("effort", ["high", "medium", "low", "max"])
+def test_non_off_effort_keeps_thinking_enabled(effort: str) -> None:
+    """Any non-off effort preserves the v0.58.0 behaviour."""
+    adapter = GlmAgenticAdapter()
+    captured = _run(adapter, effort=effort, model="glm-5.1")
+    thinking = (captured.get("extra_body") or {}).get("thinking") or {}
+    assert thinking.get("type") == "enabled"
+    assert thinking.get("clear_thinking") is False
+
+
+def test_pre_glm45_model_omits_thinking_field() -> None:
+    """Pre-GLM-4.5 models reject the field — must not be sent regardless
+    of effort.  The whitelist gate (`_glm_thinking_supported`) is the
+    primary guard; effort gating is layered on top.
+    """
+    adapter = GlmAgenticAdapter()
+    captured = _run(adapter, effort="high", model="glm-4-air")  # not in whitelist
+    extra = captured.get("extra_body")
+    assert extra is None or "thinking" not in extra, (
+        "GLM-4.x pre-4.5 models must not receive the thinking field"
+    )


### PR DESCRIPTION
## Summary
- `GlmAgenticAdapter.agentic_call` 이 `effort in ("off", "none")` 시 `extra_body.thinking={"type": "disabled", "clear_thinking": False}` 를 보내도록 게이팅 추가.
- GLM-4.5 / 4.6 hybrid 모델 에서 cheap-output 시나리오 의 reasoning-token 비용 절감.
- GLM-5.x / 4.7 의 compulsory thinking 은 그대로 (upstream contract — `disabled` 값을 silently 무시).

## Why
3-프로바이더 매트릭스 감사(`.audit/llm_provider_matrix_gaps.md`) 결과 발견된 17 GAP 중 **GAP-R1 (High)**. 어댑터 가 `effort` 인자 를 받고도 GLM thinking 분기 에 흘려보내지 않아, 매 호출 마다 무조건 `enabled` 를 송신. 

GLM-5.x / 4.7 family 는 thinking compulsory (코드 주석 `glm.py:113-114` 명시) 라 어차피 영향 없음. 그러나 GLM-4.5 / 4.6 hybrid 는 `disabled` 를 정상 인식 — 매 호출 reasoning_tokens 부담. 호출자 가 `effort="off"` 를 명시 했음에도 무시 되어 비용 통제 불가.

OpenAI 의 `reasoning.effort=low` 와 Anthropic 의 thinking budget 게이트 와 비교 시 GLM 만 게이팅 누락. 일관성 결함.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/glm.py` | `agentic_call` 내 `_thinking_off = effort in ("off", "none")` + `_thinking_type` 변수 결정 추가 (closure capture). `_do_call` 의 `local_extra["thinking"]` dict 가 `type=_thinking_type` 사용. `_glm_thinking_supported(m)` whitelist 게이트 는 유지 (pre-GLM-4.5 omission). |
| `tests/test_glm_thinking_control.py` (신규) | 9 cases — 3 hybrid × effort=off, none alias, 4 non-off efforts, pre-4.5 omission. stub `chat.completions.create` 로 `extra_body` 캡처. |
| `CHANGELOG.md` | `[Unreleased]` 의 `Added` 섹션 에 GAP-R1 항목. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| GAP-R1 (GLM thinking effort 게이팅) | **Implemented** | effort=off → disabled, 9 tests. |
| GAP-C1 (GLM thinking 단가 미등록) | **Dropped** | Socratic Q1 — GLM 은 `reasoning_content` 를 `output_tokens` 에 포함 시키는 Chinese LLM 컨벤션. 별도 `thinking_tokens` 필드 없음 → `ModelPrice.thinking=0` (default) 가 정상 회계. |
| GAP-R2 (GLM thinking_tokens 회계 미검증) | **Dropped** | Socratic Q3 — live test 없이 측정 불가, C1 의 drop 이유 와 동일. |

## Verification
- [x] `ruff check core/llm/providers/glm.py tests/test_glm_thinking_control.py` — clean
- [x] `mypy core/llm/providers/glm.py` — no issues
- [x] `pytest tests/test_glm_thinking_control.py` — **9 passed**
- [x] `pytest tests/ -m "not live"` (core, excl audit/observability/plugins) — all pass
- [x] v0.58.0 multi-turn reasoning preserve 동작 유지 — `clear_thinking=False` 가 enabled 분기 에서 그대로.

## Reference
3-프로바이더 매트릭스 감사 plan: `.audit/llm_provider_matrix_gaps.md` (PR-4 / 17 GAP 중 다섯 번째 묶음). 직전 PR-1 #1056 · PR-2 #1057 · PR-7 #1058 · PR-3 #1059.

GLM 공식 thinking 스펙: `glm.py:108-118` 주석 ("Spec re-verified 2026-04-28") — GLM-5.x / 4.7 compulsory, 4.5 / 4.6 hybrid honors enabled/disabled, pre-4.5 rejects.