### PR TITLE
feat(llm): GAP-S1 — Anthropic agentic_call streaming 전환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Anthropic agentic_call streaming — GAP-S1.**
+  `ClaudeAgenticAdapter.agentic_call._do_call` now wraps the request in
+  `async with self._client.messages.stream(**create_kwargs) as s:` and
+  returns `await s.get_final_message()` instead of the previous
+  non-streaming `await self._client.messages.create(**create_kwargs)`.
+  The final message is the same `anthropic.types.Message` schema, so
+  `normalize_anthropic` and the token-tracker path are unchanged — the
+  benefit is chunk-level network delivery and an SDK-level surface for
+  partial state (not yet wired into the agentic loop's UI). OpenAI / GLM
+  streaming is deferred (separate PR — Responses API has a stricter
+  stream contract with reasoning replay). Regression test:
+  `tests/test_anthropic_agentic_stream.py` (2 cases — stream-vs-create,
+  kwargs passthrough). `tests/test_anthropic_sampling_params.py` helper
+  updated to mock both transports.
+
 ## [0.94.0] — 2026-05-12
 
 ### Added

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -644,7 +644,13 @@ class ClaudeAgenticAdapter:
             if extra_b:
                 create_kwargs["extra_body"] = extra_b
 
-            return await self._client.messages.create(**create_kwargs)
+            # GAP-S1 — stream API 로 TTFB 단축 + chunk-level 수신.
+            # ``get_final_message()`` 가 stream 을 완전 소비 한 뒤
+            # ``anthropic.types.Message`` 를 반환 — ``messages.create`` 와
+            # 동일 schema 이므로 ``normalize_anthropic`` / 회계 path 가
+            # 변경 없이 작동. agentic 소비자 interface 불변.
+            async with self._client.messages.stream(**create_kwargs) as _stream:
+                return await _stream.get_final_message()
 
         try:
             response, used_model = await call_with_failover(failover_models, _do_call)

--- a/tests/test_anthropic_agentic_stream.py
+++ b/tests/test_anthropic_agentic_stream.py
@@ -1,0 +1,184 @@
+"""GAP-S1 — Anthropic agentic_call uses ``messages.stream`` (not ``.create``).
+
+Pre-fix: ``ClaudeAgenticAdapter.agentic_call._do_call`` called
+``await self._client.messages.create(**create_kwargs)`` — non-streaming, so
+the user / pipeline only received the response after the full body was
+generated, and the SDK held the connection open without TTFB benefit.
+
+Post-fix: same adapter now wraps the call in an
+``async with self._client.messages.stream(**create_kwargs) as s`` block and
+returns ``await s.get_final_message()``. Same response schema
+(``anthropic.types.Message``) — so the downstream normalizer + token
+accounting paths are unchanged — but the network now delivers chunks
+incrementally and the SDK can surface partial state if the agentic loop
+ever wires it up (out of scope for this PR).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from core.llm.providers.anthropic import ClaudeAgenticAdapter
+
+
+class _StubMessage:
+    """Mimic the subset of ``anthropic.types.Message`` that
+    ``normalize_anthropic`` reads.
+    """
+
+    def __init__(self) -> None:
+        self.id = "msg_stub"
+        self.role = "assistant"
+        self.content: list[Any] = []
+        self.stop_reason = "end_turn"
+        self.usage = type(
+            "U",
+            (),
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        )()
+        self.model = "claude-opus-4-7"
+
+
+class _StubStream:
+    """Async context manager mirroring the Anthropic SDK's
+    ``AsyncMessageStreamManager`` → ``AsyncMessageStream`` contract.
+    """
+
+    def __init__(self) -> None:
+        self._final = _StubMessage()
+
+    async def __aenter__(self) -> _StubStream:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    async def get_final_message(self) -> _StubMessage:
+        return self._final
+
+
+class _StubMessages:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self._sink = sink
+        self.stream_called = False
+        self.create_called = False
+
+    def stream(self, **kwargs: Any) -> _StubStream:
+        self.stream_called = True
+        self._sink.update(kwargs)
+        return _StubStream()
+
+    async def create(self, **kwargs: Any) -> _StubMessage:
+        # GAP-S1 regression — adapter must NOT call ``create`` any more.
+        self.create_called = True
+        self._sink.update(kwargs)
+        return _StubMessage()
+
+
+class _StubClient:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.messages = _StubMessages(sink)
+
+
+@pytest.fixture
+def stub_client(monkeypatch: pytest.MonkeyPatch) -> tuple[_StubClient, dict[str, Any]]:
+    """Patch ``get_async_anthropic_client`` so the adapter picks up the stub."""
+    captured: dict[str, Any] = {}
+    client = _StubClient(captured)
+    monkeypatch.setattr(
+        "core.llm.providers.anthropic.get_async_anthropic_client",
+        lambda _api_key: client,
+    )
+    # Bypass the real auth path — pretend a key is configured.
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-stub", raising=False)
+    return client, captured
+
+
+def test_agentic_call_uses_stream_not_create(
+    stub_client: tuple[_StubClient, dict[str, Any]],
+) -> None:
+    """The adapter must invoke ``messages.stream`` (not ``messages.create``)
+    so the network connection benefits from chunk-level delivery.
+    """
+    client, captured = stub_client
+    # Bypass normalize_anthropic so we can pass through the stub message.
+    import core.llm.agentic_response as _ar
+
+    original_normalize = _ar.normalize_anthropic
+    try:
+        _ar.normalize_anthropic = lambda r: r  # type: ignore[assignment]
+        adapter = ClaudeAgenticAdapter()
+        result = asyncio.run(
+            adapter.agentic_call(
+                model="claude-opus-4-7",
+                system="S",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                tool_choice="auto",
+                max_tokens=64,
+                temperature=0.3,
+            )
+        )
+    finally:
+        _ar.normalize_anthropic = original_normalize
+
+    assert client.messages.stream_called, "GAP-S1: agentic_call must use messages.stream"
+    assert not client.messages.create_called, (
+        "GAP-S1 regression: agentic_call still calling messages.create"
+    )
+    assert result is not None
+    # Stream kwargs include the core fields — exact shape verified by other tests.
+    assert captured.get("model") == "claude-opus-4-7"
+    assert captured.get("max_tokens") == 64
+    assert captured.get("system") is not None  # non-empty sys_blocks
+    assert captured.get("messages") is not None
+
+
+def test_stream_kwargs_preserve_payload(
+    stub_client: tuple[_StubClient, dict[str, Any]],
+) -> None:
+    """Streaming must carry the same kwargs as the prior ``messages.create``
+    payload (tools, tool_choice, thinking, system, etc.) — switching the
+    transport must not silently drop a parameter.
+    """
+    client, captured = stub_client
+    import core.llm.agentic_response as _ar
+
+    original_normalize = _ar.normalize_anthropic
+    try:
+        _ar.normalize_anthropic = lambda r: r  # type: ignore[assignment]
+        adapter = ClaudeAgenticAdapter()
+        asyncio.run(
+            adapter.agentic_call(
+                model="claude-opus-4-7",
+                system="System prompt",
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[
+                    {
+                        "name": "test_tool",
+                        "description": "x",
+                        "input_schema": {"type": "object"},
+                    }
+                ],
+                tool_choice={"type": "auto"},
+                max_tokens=128,
+                temperature=0.5,
+            )
+        )
+    finally:
+        _ar.normalize_anthropic = original_normalize
+
+    # Tools, tool_choice, system, max_tokens all reached the stream call
+    assert "tools" in captured
+    assert "tool_choice" in captured
+    assert "system" in captured
+    assert captured["max_tokens"] == 128

--- a/tests/test_anthropic_sampling_params.py
+++ b/tests/test_anthropic_sampling_params.py
@@ -18,7 +18,12 @@ import pytest
 
 
 def _run_agentic_call(model: str) -> dict[str, Any]:
-    """Invoke ClaudeAgenticAdapter.agentic_call once and capture create kwargs."""
+    """Invoke ClaudeAgenticAdapter.agentic_call once and capture create kwargs.
+
+    Post GAP-S1 (v0.95+) the adapter calls ``messages.stream`` instead of
+    ``messages.create``; we mock both to stay compatible with future
+    re-wirings and to capture kwargs whichever transport ships.
+    """
     from core.llm.providers.anthropic import ClaudeAgenticAdapter
 
     adapter = ClaudeAgenticAdapter()
@@ -35,9 +40,24 @@ def _run_agentic_call(model: str) -> dict[str, Any]:
         captured.update(kwargs)
         return response
 
+    class _StubStream:
+        async def __aenter__(self) -> Any:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def get_final_message(self) -> Any:
+            return response
+
+    def fake_stream(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _StubStream()
+
     client = MagicMock()
     client.messages = MagicMock()
     client.messages.create = AsyncMock(side_effect=fake_create)
+    client.messages.stream = MagicMock(side_effect=fake_stream)
     adapter._client = client
 
     async def fake_failover(models: list[str], do_call: Any) -> tuple[Any, str]:


### PR DESCRIPTION
## Summary
- `ClaudeAgenticAdapter.agentic_call._do_call` 이 `client.messages.create` non-streaming → `async with client.messages.stream(...) as s: return await s.get_final_message()` 로 전환.
- final message 는 `anthropic.types.Message` 동일 schema → `normalize_anthropic` + token_tracker 회계 path 불변. 소비자 interface 변화 없음.
- OpenAI / GLM agentic streaming 은 별도 PR 로 defer (Responses API stream 의 reasoning.encrypted_content replay + store=False 제약).

## Why
3-프로바이더 매트릭스 감사(`.audit/llm_provider_matrix_gaps.md`) 결과 17 GAP 중 **GAP-S1 (High)**. 매트릭스 초기 우선순위 에서 회귀 위험 + 측정 어려움 으로 Defer 상태 였으나, 사용자 의 "순차 진행" 결정 으로 활성화. Anthropic 측은 streaming wrapper 인프라 (`core/llm/router/calls/streaming.py:58`) 가 이미 존재 했고 agentic 만 비활성 — 가장 작은 위험 으로 시작.

긴 응답 의 TTFB (Time-To-First-Byte) 가 전체 생성 완료 까지 지연 + 네트워크 연결 이 chunk 없이 단발 응답 으로만 회수 → 사용자 가 응답 대기 동안 진행 신호 없음 + 중단 시 토큰 회수 불가.

stream 전환 으로 (1) network chunk-level 수신, (2) SDK-surface 의 partial state (현 PR 은 agentic 측 UI wiring 미연결 — 후속 PR), (3) `get_final_message()` 가 stream 을 완전 소비 한 후 동일 schema 반환 보장.

## Changes
| File | Change |
|------|--------|
| `core/llm/providers/anthropic.py` (~5 lines @ `agentic_call._do_call`) | `return await self._client.messages.create(**create_kwargs)` → `async with self._client.messages.stream(**create_kwargs) as _stream: return await _stream.get_final_message()`. 의도 주석 추가. |
| `tests/test_anthropic_agentic_stream.py` (신규, 184 lines) | 2 cases — `stream_called` ∧ `not create_called`, kwargs payload 보존 (`model`/`system`/`messages`/`tools`/`tool_choice`/`max_tokens`). `_StubStream` async context manager mock. |
| `tests/test_anthropic_sampling_params.py` (helper 갱신) | `_run_agentic_call` 의 `client.messages.create` AsyncMock 만 등록 하던 코드 가 stream 전환 후 5 fail. `fake_stream` + `_StubStream` 추가 등록 으로 양쪽 transport mock. |
| `CHANGELOG.md` | `[Unreleased]` 의 `Changed` 섹션 에 GAP-S1 항목. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| GAP-S1 (Anthropic agentic streaming) | **Implemented** | messages.stream wiring + 2 신규 tests + 1 회귀 helper 갱신. |
| OpenAI / GLM agentic streaming | **Deferred** | Responses API stream 의 reasoning replay 계약 이 더 복잡 — 별도 후속 PR. |

## Verification
- [x] `ruff check core/llm/providers/anthropic.py tests/test_anthropic_*.py` — clean
- [x] `ruff format` — unchanged
- [x] `mypy core/llm/providers/anthropic.py` — no issues
- [x] `pytest tests/test_anthropic_agentic_stream.py tests/test_anthropic_sampling_params.py tests/test_anthropic_reasoning_v056.py tests/test_anthropic_messages_cache.py tests/test_agentic_loop.py tests/test_agentic_response.py` — **137 passed**
- [x] `pytest tests/test_tool_use.py tests/test_failover.py tests/test_llm_client.py` — **58 passed** (ClaudeAdapter non-agentic path 영향 없음)
- [x] `pytest tests/ -m "not live"` (core, excl audit/observability/plugins) — all pass

## Reference
매트릭스 감사 plan: `.audit/llm_provider_matrix_gaps.md` Section 3 (Defer → 사용자 명시 진행 으로 활성화). 직전 v0.94.0 release (PR #1061) 이후 첫 후속 feature PR.