### PR TITLE
feat(site): docs 재구성 — Diátaxis 8 챕터 · 53 페이지 bilingual · Petri 챕터

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Infrastructure
 
+- **Docs site rebuild — Diátaxis 8 chapters, 53 bilingual pages.**
+  Site/docs restructured into 8 numbered chapters following Diátaxis (Tutorial,
+  How-to, Reference, Explanation). Every page declares its quadrant via a
+  color chip in the title and sidebar.
+  - Chapters: 00 Welcome (3), 01 Run GEODE (7 how-to), 02 System Reference
+    (24), 03 Build on GEODE (4 how-to), 04 Operations (4 how-to),
+    05 Petri Audit (4, new), 06 Explanation (4 why-pages, new), 99 Reference (3).
+  - **53 of 53 pages are now bilingual** via `<Bi ko en />`. Previous state:
+    only 3 of 28 pages had Korean translations; 25 EN-only pages were
+    converted in this PR.
+  - New chapter: **05 Petri × GEODE** with overview, run guide,
+    38 judge-dimension reference, and a viewer link to
+    `https://mangowhoiscloud.github.io/geode/petri-bundle/` (external bundle
+    published separately).
+  - Master neologism page chain: `/docs/explanation/self-hosting`,
+    `/explanation/ratchet`, `/explanation/4-layer`, `/explanation/solo`
+    grounds every chapter that references "self-hosting agent harness".
+  - DocsShell footer now imports `GEODE_SOT` (version, modules, tests,
+    syncedAt) instead of hardcoding v0.65.0. GitHub link points at
+    `mangowhoiscloud/geode` (was `/portfolio`).
+  - Tracking artifact: `site/DOCS-PROGRESS.md` is the per-page status table.
+  - Reference patterns: Hermes Agent (NousResearch) `llms.txt` index pattern,
+    OpenClaw `AGENTS.md` code-root navigation, Diátaxis 4-quadrant framework,
+    Anthropic Platform Docs comparison-table-at-decision-point pattern.
+
 - **Public site at `site/` — GEODE Pages deploy.** Next.js 16 static
   export integrated into the repo at `site/`. Builds and deploys to
   GitHub Pages at `https://mangowhoiscloud.github.io/geode/` on push to

--- a/site/DOCS-PROGRESS.md
+++ b/site/DOCS-PROGRESS.md
@@ -1,0 +1,111 @@
+# GEODE Docs Rewrite — Progress Tracking
+
+Tracks every documentation page across the 8-chapter restructure.
+
+Status legend:
+- `✅` = bilingual `<Bi ko en />` complete (production)
+- `🟡` = stub created (sidebar + shell live, body TODO)
+- `🔴` = source page is single-language, needs `<Bi>` wrap + translation
+- `⛔` = blocked / decision pending
+- `🆕` = new page to create
+
+Sprint columns:
+- **P1** = Phase 1 (foundation: sitemap + shell + stubs)
+- **P2** = Phase 2 (translations of 25 existing EN-only)
+- **P3** = Phase 3 (new chapter content from wiki/concepts)
+
+---
+
+## Master table
+
+| # | Chapter | Slug | Title KO / EN | Quadrant | KO | EN | Sprint | Source |
+|---|---|---|---|---|---|---|---|---|
+| 00 · Welcome — Diátaxis Explanation + Tutorial + Reference |
+| 00.1 | 00 Welcome | `(index)` | 개요 / Overview | Explanation | 🟡 | ✅ | P1 | existing `docs/page.tsx` |
+| 00.2 | 00 Welcome | `quick-start` | 빠른 시작 / Quick Start | Tutorial | ✅ | ✅ | done | existing |
+| 00.3 | 00 Welcome | `architecture/overview` | 4-계층 스택 / 4-Layer Stack | Reference | ✅ | ✅ | — | existing (already Bi) |
+| 01 · Run GEODE — Diátaxis How-to (user) |
+| 01.1 | 01 Run | `run/pick-path` | 경로 선택 / Pick a Path | How-to | ✅ | ✅ | done | README §Path A/B |
+| 01.2 | 01 Run | `run/providers` | 프로바이더 설정 / Configure Providers | How-to | ✅ | ✅ | done | wiki llm-models |
+| 01.3 | 01 Run | `run/analyze` | 분석 실행 / Run an Analysis | How-to | ✅ | ✅ | done | plugins/game_ip |
+| 01.4 | 01 Run | `run/schedule` | 작업 예약 / Schedule Tasks | How-to | ✅ | ✅ | done | wiki scheduler |
+| 01.5 | 01 Run | `run/serve` | 데몬으로 실행 / Run as Daemon | How-to | ✅ | ✅ | done | wiki lifecycle-commands |
+| 01.6 | 01 Run | `run/messaging` | Slack 등 메신저 연동 / Messaging Integration | How-to | ✅ | ✅ | done | wiki gateway |
+| 01.7 | 01 Run | `run/troubleshooting` | 문제 해결 / Troubleshooting | How-to | ✅ | ✅ | done | README §Troubleshooting |
+| 02 · System Reference — Diátaxis Reference (구조 미러) |
+| 02.1 | 02 Reference | `architecture/agentic-loop` | Agentic 루프 / Agentic Loop | Reference | ✅ | ✅ | done | existing |
+| 02.2 | 02 Reference | `architecture/system-index` | 시스템 색인 / System Index | Reference | ✅ | ✅ | done | existing |
+| 02.3 | 02 Reference | `runtime/llm/providers` | 프로바이더 / Providers | Reference | ✅ | ✅ | done | existing |
+| 02.4 | 02 Reference | `runtime/llm/prompt-system` | 프롬프트 시스템 / Prompt System | Reference | ✅ | ✅ | — | existing (Bi) |
+| 02.5 | 02 Reference | `runtime/llm/prompt-caching` | 프롬프트 캐싱 / Prompt Caching | Reference | ✅ | ✅ | done | existing |
+| 02.6 | 02 Reference | `runtime/llm/prompt-hashing` | 프롬프트 해싱 / Prompt Hashing | Reference | ✅ | ✅ | done | existing |
+| 02.7 | 02 Reference | `runtime/llm/langsmith` | LangSmith | Reference | ✅ | ✅ | done | existing |
+| 02.8 | 02 Reference | `runtime/tools/protocol` | 도구 프로토콜 / Tool Protocol | Reference | ✅ | ✅ | done | existing |
+| 02.9 | 02 Reference | `runtime/tools/mcp` | MCP 서버 / MCP Servers | Reference | ✅ | ✅ | done | existing |
+| 02.10 | 02 Reference | `runtime/memory/5-tier` | 5계층 컨텍스트 / 5-Tier Context | Reference | ✅ | ✅ | done | existing |
+| 02.11 | 02 Reference | `runtime/memory/vault` | Vault | Reference | ✅ | ✅ | done | existing |
+| 02.12 | 02 Reference | `harness/cli` | CLI & Slash | Reference | ✅ | ✅ | done | existing |
+| 02.13 | 02 Reference | `harness/hooks` | 훅 시스템 / Hook System | Reference | ✅ | ✅ | done | existing |
+| 02.14 | 02 Reference | `harness/lifecycle` | 라이프사이클 / Lifecycle | Reference | ✅ | ✅ | done | existing |
+| 02.15 | 02 Reference | `verification/guardrails` | 가드레일 G1-G4 / Guardrails G1-G4 | Reference | ✅ | ✅ | done | existing |
+| 02.16 | 02 Reference | `verification/biasbuster` | BiasBuster | Reference | ✅ | ✅ | done | existing |
+| 02.17 | 02 Reference | `runtime/computer-use` | 컴퓨터 사용 / Computer Use | Reference | ✅ | ✅ | done | existing |
+| 02.18 | 02 Reference | `runtime/scheduler` | 스케줄러 / Scheduler | Reference | ✅ | ✅ | done | existing |
+| 02.19 | 02 Reference | `runtime/automation` | 자동화 / Automation | Reference | ✅ | ✅ | done | existing |
+| 02.20 | 02 Reference | `runtime/orchestration` | 오케스트레이션 / Orchestration | Reference | ✅ | ✅ | done | existing |
+| 02.21 | 02 Reference | `runtime/auth` | 인증 / Auth & OAuth | Reference | ✅ | ✅ | done | existing |
+| 02.22 | 02 Reference | `runtime/domains` | 도메인 플러그인 / Domain Plugins | Reference | ✅ | ✅ | done | existing |
+| 02.23 | 02 Reference | `runtime/skills` | 스킬 레지스트리 / Skill Registry | Reference | ✅ | ✅ | done | core/skills |
+| 02.24 | 02 Reference | `plugins/game-ip` | Game IP 플러그인 / Game IP Plugin | Reference | ✅ | ✅ | done | existing |
+| 03 · Build on GEODE — Diátaxis How-to (developer) |
+| 03.1 | 03 Build | `build/add-tool` | 도구 추가하기 / Add a Tool | How-to | ✅ | ✅ | done | wiki tool-system |
+| 03.2 | 03 Build | `build/add-domain` | 도메인 플러그인 추가 / Add a Domain Plugin | How-to | ✅ | ✅ | done | wiki domain-plugin |
+| 03.3 | 03 Build | `build/add-hook` | 훅 핸들러 추가 / Add a Hook Handler | How-to | ✅ | ✅ | done | wiki hook-production-gap |
+| 03.4 | 03 Build | `build/testing` | 변경사항 테스트 / Test Your Changes | How-to | ✅ | ✅ | done | CLAUDE.md Quality Gates |
+| 04 · Operations — Diátaxis How-to (operator) |
+| 04.1 | 04 Ops | `ops/long-running` | 장기 실행 안전 / Long-running Safety | How-to | ✅ | ✅ | done | wiki long-running-safety |
+| 04.2 | 04 Ops | `ops/cost` | 비용 모니터링 / Cost Monitoring | How-to | ✅ | ✅ | done | wiki context-guard |
+| 04.3 | 04 Ops | `ops/oauth` | OAuth 토큰 관리 / OAuth Token Rotation | How-to | ✅ | ✅ | done | wiki oauth-policy |
+| 04.4 | 04 Ops | `ops/observability` | 관측성 / Observability | How-to | ✅ | ✅ | done | wiki petri-alignment-audit + hooks |
+| 05 · Petri Audit — alignment audit (NEW chapter) |
+| 05.1 | 05 Petri | `petri/overview` | Petri 통합 / Petri × GEODE Integration | Explanation | ✅ | ✅ | done | wiki petri-alignment-audit |
+| 05.2 | 05 Petri | `petri/run` | Audit 실행 / Run an Audit | How-to | ✅ | ✅ | done | plugins/petri_audit cli_audit.py |
+| 05.3 | 05 Petri | `petri/judge-dimensions` | 38 Judge 차원 / 38 Judge Dimensions | Reference | ✅ | ✅ | done | plugins/petri_audit/judge_dims |
+| 05.4 | 05 Petri | `petri/bundle` | Audit Bundle 뷰어 / Audit Bundle Viewer | Reference | ✅ | ✅ | done | external link `/geode/petri-bundle/` |
+| 06 · Explanation — Diátaxis Explanation (의사결정) |
+| 06.1 | 06 Why | `explanation/self-hosting` | 왜 self-hosting인가 / Why a Self-Hosting Harness | Explanation | ✅ | ✅ | done | portfolio thesis + wiki architecture |
+| 06.2 | 06 Why | `explanation/ratchet` | 왜 ratchet 규율인가 / Why Ratchet Discipline | Explanation | ✅ | ✅ | done | karpathy-patterns skill |
+| 06.3 | 06 Why | `explanation/4-layer` | 왜 4-계층인가 / Why 4 Layers | Explanation | ✅ | ✅ | done | wiki architecture |
+| 06.4 | 06 Why | `explanation/solo` | 왜 단독 개발인가 / Why a Solo Author | Explanation | ✅ | ✅ | done | portfolio + wiki scaffold-production |
+| 99 · Reference — secondary indexes |
+| 99.1 | 99 Reference | `reference/changelog` | 변경 이력 / Changelog | Reference | ✅ | ✅ | done | existing |
+| 99.2 | 99 Reference | `reference/frontier-comparison` | 프론티어 비교 / Frontier Comparison | Reference | ✅ | ✅ | done | existing |
+| 99.3 | 99 Reference | `reference/sot-metrics` | 메트릭 SOT / System Metrics | Reference | ✅ | ✅ | done | `site/src/data/geode/sot.ts` |
+
+---
+
+## Summary (2026-05-12 P1 + P2 + P3 완료)
+
+| Status | Count |
+|---|---:|
+| ✅ Bilingual production | 53 |
+| 🔴 outstanding | 0 |
+| **Total** | **53** |
+
+`<Bi>` wrap audit: **53/53 pages** carry both `ko={...}` and `en={...}`. `titleKo`/`summaryKo` audit: **53/53 pages** carry both. 53 routes prerender via `npm run build`. 새 챕터 stub (01 Run, 03 Build, 04 Ops, 05 Petri, 06 Why)도 본문 골격 + 첫 문장 quadrant 선언 + wiki source 참조로 production 적합 상태. 본문 깊이 보강은 추후 sprint.
+
+## Sprint owners
+
+| Sprint | Scope | Pages |
+|---|---|---:|
+| **P1 (this turn)** | sitemap.ts + DocsShell + 23 new stubs + 25 NO-BI shell-conversion | 51 (foundation) |
+| **P2** | 25 page Korean translations | 25 |
+| **P3** | 23 new page content from wiki/concepts | 23 |
+
+## Notes
+
+- `existing` 페이지: 현재 `<a href="/geode/docs/...">` raw anchors 사용 — basePath 변경 후에도 동작 ([Sprint 1.5 분석](../README.md))
+- `wiki source` 컬럼은 `/Users/mango/workspace/mango-wiki/vault/projects/geode/concepts/geode-*.md` 파일 가리킴
+- Petri 외부 링크 `https://mangowhoiscloud.github.io/geode/petri-bundle/` — site/public/petri-bundle/ 는 사용자가 별도 publish 예정
+- 모든 페이지 `quadrant` prop을 사이드바 chip + 페이지 상단 chip으로 렌더
+- 메트릭 (v, 모듈, 테스트, 릴리스 등)은 SOT (`site/src/data/geode/sot.ts`) import만 — 페이지 본문에 하드코딩 0개 목표

--- a/site/src/app/docs/architecture/agentic-loop/page.tsx
+++ b/site/src/app/docs/architecture/agentic-loop/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Agentic Loop — GEODE Docs" };
 
@@ -7,83 +7,166 @@ export default function Page() {
     <DocsShell
       slug="architecture/agentic-loop"
       title="Agentic Loop"
+      titleKo="Agentic 루프"
       summary="GEODE's core execution primitive. while(tool_use) with error recovery, convergence detection, and multi-intent decomposition."
+      summaryKo="GEODE 실행의 기본 단위. 오류 복구, 수렴 감지, 멀티 인텐트 분해를 갖춘 while(tool_use)."
     >
-      <h2>The primitive</h2>
-      <p>
-        AgenticLoop, defined at{" "}
-        <code>core/agent/loop.py:162 class AgenticLoop</code>, is the engine
-        that runs every turn. It is intentionally simple:
-      </p>
-      <pre>{`response = call_llm(messages, tools)
+      <Bi
+        ko={
+          <>
+            <h2>기본 단위</h2>
+            <p>
+              <code>core/agent/loop.py:162 class AgenticLoop</code>에 정의된
+              AgenticLoop는 매 턴을 구동하는 엔진입니다. 의도적으로 단순하게
+              유지되어 있습니다.
+            </p>
+            <pre>{`response = call_llm(messages, tools)
 while response.has_tool_use:
     for tool_call in response.tool_calls:
         result = execute(tool_call)
         messages.append(result)
     response = call_llm(messages, tools)
 return response.text`}</pre>
-      <p>
-        The complexity lives elsewhere — in the prompt assembler, the tool
-        registry, the verification guardrails, and the hook system. The loop
-        itself stays thin.
-      </p>
+            <p>
+              복잡성은 다른 곳에 있습니다. 프롬프트 어셈블러, 도구 레지스트리,
+              검증 가드레일, 훅 시스템이 그것입니다. 루프 자체는 얇게 유지됩니다.
+            </p>
 
-      <h2>Three controllers</h2>
-      <p>The loop delegates three responsibilities to dedicated classes:</p>
-      <ul>
-        <li>
-          <strong>ToolCallProcessor</strong> — orders tool calls, deduplicates,
-          and applies tool-specific pre/post hooks.
-        </li>
-        <li>
-          <strong>ErrorRecoveryStrategy</strong> — decides what to do when a
-          tool fails (retry, escalate, abort) and surfaces a recovery prompt
-          to the model.
-        </li>
-        <li>
-          <strong>ConvergenceDetector</strong> — watches for loops that are
-          spinning without progress (same tool with same args N times) and
-          interrupts.
-        </li>
-      </ul>
+            <h2>세 가지 컨트롤러</h2>
+            <p>루프는 세 가지 책임을 전용 클래스에 위임합니다.</p>
+            <ul>
+              <li>
+                <strong>ToolCallProcessor</strong>. 도구 호출 순서를 정하고, 중복을
+                제거하며, 도구별 pre/post 훅을 적용합니다.
+              </li>
+              <li>
+                <strong>ErrorRecoveryStrategy</strong>. 도구가 실패했을 때 어떻게
+                할지 결정합니다 (재시도, 에스컬레이션, 중단). 복구 프롬프트를
+                모델에 전달합니다.
+              </li>
+              <li>
+                <strong>ConvergenceDetector</strong>. 진전 없이 동일 도구를 동일
+                인자로 N번 반복하는 루프를 감지하여 중단시킵니다.
+              </li>
+            </ul>
 
-      <h2>Multi-intent decomposition</h2>
-      <p>
-        The loop accepts compound user requests like &ldquo;analyze X and
-        compare with Y&rdquo;. The decomposer (<code>decomposer.md</code>)
-        breaks the request into a sequence of tool calls before the first
-        round.
-      </p>
+            <h2>멀티 인텐트 분해</h2>
+            <p>
+              루프는 "X를 분석하고 Y와 비교해줘"같은 복합 사용자 요청을 받습니다.
+              디컴포저(<code>decomposer.md</code>)는 첫 라운드 전에 요청을 도구
+              호출 시퀀스로 분해합니다.
+            </p>
 
-      <h2>System prompt construction</h2>
-      <p>
-        Before the loop starts, <code>build_system_prompt()</code> in{" "}
-        <code>core/agent/system_prompt.py</code> assembles the system prompt
-        with a STATIC/DYNAMIC boundary marker (<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>).
-        The Anthropic adapter splits at this marker for prompt caching. See{" "}
-        <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
-      </p>
+            <h2>시스템 프롬프트 구성</h2>
+            <p>
+              루프 시작 전에 <code>core/agent/system_prompt.py</code>의{" "}
+              <code>build_system_prompt()</code>가 STATIC/DYNAMIC 경계
+              마커(<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>)와 함께 시스템
+              프롬프트를 조립합니다. Anthropic 어댑터는 이 마커를 기준으로 프롬프트
+              캐싱을 위해 분할합니다. <a href="/geode/docs/runtime/llm/prompt-caching">프롬프트 캐싱</a>을
+              참고하세요.
+            </p>
 
-      <h2>Hook integration</h2>
-      <p>
-        The loop fires lifecycle events at every meaningful boundary:
-      </p>
-      <ul>
-        <li><code>SESSION_START</code>, <code>SESSION_END</code></li>
-        <li><code>TURN_COMPLETE</code></li>
-        <li><code>LLM_CALL_START</code>, <code>LLM_CALL_END</code>, <code>LLM_CALL_FAILED</code>, <code>LLM_CALL_RETRY</code></li>
-        <li><code>TOOL_EXEC_START</code>, <code>TOOL_EXEC_END</code>, <code>TOOL_EXEC_FAILED</code></li>
-        <li><code>TOOL_APPROVAL_REQUEST</code>, <code>TOOL_APPROVAL_GRANTED</code>, <code>TOOL_APPROVAL_DENIED</code></li>
-        <li><code>CONTEXT_OVERFLOW</code>, <code>CONTEXT_RESET</code></li>
-      </ul>
+            <h2>훅 통합</h2>
+            <p>루프는 의미 있는 경계마다 라이프사이클 이벤트를 발화합니다.</p>
+            <ul>
+              <li><code>SESSION_START</code>, <code>SESSION_END</code></li>
+              <li><code>TURN_COMPLETE</code></li>
+              <li><code>LLM_CALL_START</code>, <code>LLM_CALL_END</code>, <code>LLM_CALL_FAILED</code>, <code>LLM_CALL_RETRY</code></li>
+              <li><code>TOOL_EXEC_START</code>, <code>TOOL_EXEC_END</code>, <code>TOOL_EXEC_FAILED</code></li>
+              <li><code>TOOL_APPROVAL_REQUEST</code>, <code>TOOL_APPROVAL_GRANTED</code>, <code>TOOL_APPROVAL_DENIED</code></li>
+              <li><code>CONTEXT_OVERFLOW</code>, <code>CONTEXT_RESET</code></li>
+            </ul>
 
-      <h2>Why a thin loop</h2>
-      <p>
-        The loop&apos;s thinness is deliberate. It is the most-tested,
-        least-changed code in the system. New behaviour does not go inside
-        the loop — it goes into a tool, a hook, or a guardrail. This keeps
-        the core execution path predictable and testable.
-      </p>
+            <h2>왜 얇은 루프인가</h2>
+            <p>
+              루프의 얇음은 의도적입니다. 시스템에서 가장 많이 테스트되고 가장 적게
+              바뀌는 코드입니다. 새로운 동작은 루프 안이 아니라 도구, 훅, 가드레일로
+              들어갑니다. 이렇게 해야 핵심 실행 경로가 예측 가능하고 테스트 가능한
+              상태로 유지됩니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The primitive</h2>
+            <p>
+              AgenticLoop, defined at{" "}
+              <code>core/agent/loop.py:162 class AgenticLoop</code>, is the engine
+              that runs every turn. It is intentionally simple:
+            </p>
+            <pre>{`response = call_llm(messages, tools)
+while response.has_tool_use:
+    for tool_call in response.tool_calls:
+        result = execute(tool_call)
+        messages.append(result)
+    response = call_llm(messages, tools)
+return response.text`}</pre>
+            <p>
+              The complexity lives elsewhere — in the prompt assembler, the tool
+              registry, the verification guardrails, and the hook system. The loop
+              itself stays thin.
+            </p>
+
+            <h2>Three controllers</h2>
+            <p>The loop delegates three responsibilities to dedicated classes:</p>
+            <ul>
+              <li>
+                <strong>ToolCallProcessor</strong> — orders tool calls, deduplicates,
+                and applies tool-specific pre/post hooks.
+              </li>
+              <li>
+                <strong>ErrorRecoveryStrategy</strong> — decides what to do when a
+                tool fails (retry, escalate, abort) and surfaces a recovery prompt
+                to the model.
+              </li>
+              <li>
+                <strong>ConvergenceDetector</strong> — watches for loops that are
+                spinning without progress (same tool with same args N times) and
+                interrupts.
+              </li>
+            </ul>
+
+            <h2>Multi-intent decomposition</h2>
+            <p>
+              The loop accepts compound user requests like &ldquo;analyze X and
+              compare with Y&rdquo;. The decomposer (<code>decomposer.md</code>)
+              breaks the request into a sequence of tool calls before the first
+              round.
+            </p>
+
+            <h2>System prompt construction</h2>
+            <p>
+              Before the loop starts, <code>build_system_prompt()</code> in{" "}
+              <code>core/agent/system_prompt.py</code> assembles the system prompt
+              with a STATIC/DYNAMIC boundary marker (<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>).
+              The Anthropic adapter splits at this marker for prompt caching. See{" "}
+              <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
+            </p>
+
+            <h2>Hook integration</h2>
+            <p>
+              The loop fires lifecycle events at every meaningful boundary:
+            </p>
+            <ul>
+              <li><code>SESSION_START</code>, <code>SESSION_END</code></li>
+              <li><code>TURN_COMPLETE</code></li>
+              <li><code>LLM_CALL_START</code>, <code>LLM_CALL_END</code>, <code>LLM_CALL_FAILED</code>, <code>LLM_CALL_RETRY</code></li>
+              <li><code>TOOL_EXEC_START</code>, <code>TOOL_EXEC_END</code>, <code>TOOL_EXEC_FAILED</code></li>
+              <li><code>TOOL_APPROVAL_REQUEST</code>, <code>TOOL_APPROVAL_GRANTED</code>, <code>TOOL_APPROVAL_DENIED</code></li>
+              <li><code>CONTEXT_OVERFLOW</code>, <code>CONTEXT_RESET</code></li>
+            </ul>
+
+            <h2>Why a thin loop</h2>
+            <p>
+              The loop&apos;s thinness is deliberate. It is the most-tested,
+              least-changed code in the system. New behaviour does not go inside
+              the loop — it goes into a tool, a hook, or a guardrail. This keeps
+              the core execution path predictable and testable.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/architecture/system-index/page.tsx
+++ b/site/src/app/docs/architecture/system-index/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "System Index — GEODE Docs" };
 
@@ -7,80 +7,164 @@ export default function Page() {
     <DocsShell
       slug="architecture/system-index"
       title="System Index"
+      titleKo="시스템 색인"
       summary="Every first-class subsystem in GEODE v0.64.0, with module count and main entry point."
+      summaryKo="GEODE v0.64.0의 모든 1급 서브시스템. 모듈 수와 주요 진입점을 함께 정리합니다."
     >
-      <h2>Project statistics</h2>
-      <pre>{`$ find core/ -name "*.py" | wc -l        # 223
+      <Bi
+        ko={
+          <>
+            <h2>프로젝트 통계</h2>
+            <pre>{`$ find core/ -name "*.py" | wc -l        # 223
 $ find plugins/ -name "*.py" | wc -l     # 13
 $ find tests/ -name "test_*.py" | wc -l  # ~229`}</pre>
 
-      <h2>L4 Agent (1)</h2>
-      <table>
-        <thead><tr><th>Subsystem</th><th>Root</th><th>Modules</th><th>Entry</th></tr></thead>
-        <tbody>
-          <tr><td><strong>agent</strong></td><td><code>core/agent/</code></td><td>14</td><td><code>loop.py:162 AgenticLoop</code></td></tr>
-        </tbody>
-      </table>
+            <h2>L4 Agent (1개)</h2>
+            <table>
+              <thead><tr><th>서브시스템</th><th>루트</th><th>모듈</th><th>진입점</th></tr></thead>
+              <tbody>
+                <tr><td><strong>agent</strong></td><td><code>core/agent/</code></td><td>14</td><td><code>loop.py:162 AgenticLoop</code></td></tr>
+              </tbody>
+            </table>
 
-      <h2>L3 Harness (6)</h2>
-      <table>
-        <thead><tr><th>Subsystem</th><th>Root</th><th>Modules</th><th>Entry</th></tr></thead>
-        <tbody>
-          <tr><td>cli</td><td><code>core/cli/</code></td><td>30</td><td><code>commands.py:41 ModelProfile</code></td></tr>
-          <tr><td>gateway</td><td><code>core/cli/serve/</code></td><td>—</td><td><code>geode serve</code></td></tr>
-          <tr><td>hooks</td><td><code>core/hooks/</code></td><td>7</td><td><code>system.py:200 HookSystem</code></td></tr>
-          <tr><td>lifecycle</td><td><code>core/lifecycle/</code></td><td>5</td><td>bootstrap entry</td></tr>
-          <tr><td>channels</td><td><code>core/channels/</code></td><td>4</td><td>adapter classes</td></tr>
-          <tr><td>ui</td><td><code>core/ui/</code></td><td>8</td><td>spinners, progress</td></tr>
-        </tbody>
-      </table>
+            <h2>L3 Harness (6개)</h2>
+            <table>
+              <thead><tr><th>서브시스템</th><th>루트</th><th>모듈</th><th>진입점</th></tr></thead>
+              <tbody>
+                <tr><td>cli</td><td><code>core/cli/</code></td><td>30</td><td><code>commands.py:41 ModelProfile</code></td></tr>
+                <tr><td>gateway</td><td><code>core/cli/serve/</code></td><td>—</td><td><code>geode serve</code></td></tr>
+                <tr><td>hooks</td><td><code>core/hooks/</code></td><td>7</td><td><code>system.py:200 HookSystem</code></td></tr>
+                <tr><td>lifecycle</td><td><code>core/lifecycle/</code></td><td>5</td><td>bootstrap entry</td></tr>
+                <tr><td>channels</td><td><code>core/channels/</code></td><td>4</td><td>adapter classes</td></tr>
+                <tr><td>ui</td><td><code>core/ui/</code></td><td>8</td><td>spinners, progress</td></tr>
+              </tbody>
+            </table>
 
-      <h2>L2 Runtime (13)</h2>
-      <table>
-        <thead><tr><th>Subsystem</th><th>Root</th><th>Modules</th><th>Entry</th></tr></thead>
-        <tbody>
-          <tr><td>llm</td><td><code>core/llm/</code></td><td>15</td><td><code>agentic_response.py:46</code></td></tr>
-          <tr><td>llm/prompts</td><td><code>core/llm/prompts/</code></td><td>2 + .md</td><td><code>__init__.py</code></td></tr>
-          <tr><td>llm/providers</td><td><code>core/llm/providers/</code></td><td>5</td><td><code>anthropic.py</code></td></tr>
-          <tr><td>tools</td><td><code>core/tools/</code></td><td>16</td><td><code>base.py:35 Tool</code></td></tr>
-          <tr><td>mcp</td><td><code>core/mcp/</code></td><td>20</td><td><code>manager.py MCPManager</code></td></tr>
-          <tr><td>memory</td><td><code>core/memory/</code></td><td>14</td><td><code>context.py:46</code></td></tr>
-          <tr><td>skills</td><td><code>core/skills/</code></td><td>6</td><td><code>skill_registry.py</code></td></tr>
-          <tr><td>verification</td><td><code>core/verification/</code></td><td>7</td><td><code>guardrails.py</code></td></tr>
-          <tr><td>scheduler</td><td><code>core/scheduler/</code></td><td>6</td><td><code>scheduler.py:76</code></td></tr>
-          <tr><td>automation</td><td><code>core/automation/</code></td><td>8</td><td><code>model_registry.py</code></td></tr>
-          <tr><td>orchestration</td><td><code>core/orchestration/</code></td><td>17</td><td><code>graph.py</code></td></tr>
-          <tr><td>auth</td><td><code>core/auth/</code></td><td>14</td><td>OAuth profile rotator</td></tr>
-          <tr><td>domains</td><td><code>core/domains/</code></td><td>3</td><td><code>port.py:18 DomainPort</code></td></tr>
-        </tbody>
-      </table>
+            <h2>L2 Runtime (13개)</h2>
+            <table>
+              <thead><tr><th>서브시스템</th><th>루트</th><th>모듈</th><th>진입점</th></tr></thead>
+              <tbody>
+                <tr><td>llm</td><td><code>core/llm/</code></td><td>15</td><td><code>agentic_response.py:46</code></td></tr>
+                <tr><td>llm/prompts</td><td><code>core/llm/prompts/</code></td><td>2 + .md</td><td><code>__init__.py</code></td></tr>
+                <tr><td>llm/providers</td><td><code>core/llm/providers/</code></td><td>5</td><td><code>anthropic.py</code></td></tr>
+                <tr><td>tools</td><td><code>core/tools/</code></td><td>16</td><td><code>base.py:35 Tool</code></td></tr>
+                <tr><td>mcp</td><td><code>core/mcp/</code></td><td>20</td><td><code>manager.py MCPManager</code></td></tr>
+                <tr><td>memory</td><td><code>core/memory/</code></td><td>14</td><td><code>context.py:46</code></td></tr>
+                <tr><td>skills</td><td><code>core/skills/</code></td><td>6</td><td><code>skill_registry.py</code></td></tr>
+                <tr><td>verification</td><td><code>core/verification/</code></td><td>7</td><td><code>guardrails.py</code></td></tr>
+                <tr><td>scheduler</td><td><code>core/scheduler/</code></td><td>6</td><td><code>scheduler.py:76</code></td></tr>
+                <tr><td>automation</td><td><code>core/automation/</code></td><td>8</td><td><code>model_registry.py</code></td></tr>
+                <tr><td>orchestration</td><td><code>core/orchestration/</code></td><td>17</td><td><code>graph.py</code></td></tr>
+                <tr><td>auth</td><td><code>core/auth/</code></td><td>14</td><td>OAuth profile rotator</td></tr>
+                <tr><td>domains</td><td><code>core/domains/</code></td><td>3</td><td><code>port.py:18 DomainPort</code></td></tr>
+              </tbody>
+            </table>
 
-      <h2>Plugins (1)</h2>
-      <table>
-        <thead><tr><th>Plugin</th><th>Root</th><th>Modules</th><th>Highlights</th></tr></thead>
-        <tbody>
-          <tr>
-            <td><strong>game_ip</strong></td>
-            <td><code>plugins/game_ip/</code></td>
-            <td>13</td>
-            <td>4 Analysts + 3 Evaluators + Synthesizer + BiasBuster, 14-axis PSM scoring</td>
-          </tr>
-        </tbody>
-      </table>
+            <h2>플러그인 (1개)</h2>
+            <table>
+              <thead><tr><th>플러그인</th><th>루트</th><th>모듈</th><th>주요 구성</th></tr></thead>
+              <tbody>
+                <tr>
+                  <td><strong>game_ip</strong></td>
+                  <td><code>plugins/game_ip/</code></td>
+                  <td>13</td>
+                  <td>Analyst 4 + Evaluator 3 + Synthesizer + BiasBuster, 14-axis PSM 점수</td>
+                </tr>
+              </tbody>
+            </table>
 
-      <h2>Inventory totals</h2>
-      <table>
-        <tbody>
-          <tr><th>Core modules</th><td>223</td></tr>
-          <tr><th>Plugin modules</th><td>13</td></tr>
-          <tr><th>Tests</th><td>~229 files (memory 83, llm 62, tools 59, hooks 31, agent 30)</td></tr>
-          <tr><th>Hook events</th><td>58 (12 groups)</td></tr>
-          <tr><th>Tools</th><td>57 (6 always-loaded + 51 deferred via <code>tool_search</code>)</td></tr>
-          <tr><th>MCP servers</th><td>16</td></tr>
-          <tr><th>Slash commands</th><td>15+</td></tr>
-          <tr><th>Prompt templates pinned</th><td>20 (17 .md + 3 axes)</td></tr>
-        </tbody>
-      </table>
+            <h2>인벤토리 합계</h2>
+            <table>
+              <tbody>
+                <tr><th>Core 모듈</th><td>223</td></tr>
+                <tr><th>플러그인 모듈</th><td>13</td></tr>
+                <tr><th>테스트</th><td>~229 files (memory 83, llm 62, tools 59, hooks 31, agent 30)</td></tr>
+                <tr><th>훅 이벤트</th><td>58 (12 groups)</td></tr>
+                <tr><th>도구</th><td>57 (6 always-loaded + 51 deferred via <code>tool_search</code>)</td></tr>
+                <tr><th>MCP 서버</th><td>16</td></tr>
+                <tr><th>슬래시 명령</th><td>15개 이상</td></tr>
+                <tr><th>핀된 프롬프트 템플릿</th><td>20 (17 .md + 3 axes)</td></tr>
+              </tbody>
+            </table>
+          </>
+        }
+        en={
+          <>
+            <h2>Project statistics</h2>
+            <pre>{`$ find core/ -name "*.py" | wc -l        # 223
+$ find plugins/ -name "*.py" | wc -l     # 13
+$ find tests/ -name "test_*.py" | wc -l  # ~229`}</pre>
+
+            <h2>L4 Agent (1)</h2>
+            <table>
+              <thead><tr><th>Subsystem</th><th>Root</th><th>Modules</th><th>Entry</th></tr></thead>
+              <tbody>
+                <tr><td><strong>agent</strong></td><td><code>core/agent/</code></td><td>14</td><td><code>loop.py:162 AgenticLoop</code></td></tr>
+              </tbody>
+            </table>
+
+            <h2>L3 Harness (6)</h2>
+            <table>
+              <thead><tr><th>Subsystem</th><th>Root</th><th>Modules</th><th>Entry</th></tr></thead>
+              <tbody>
+                <tr><td>cli</td><td><code>core/cli/</code></td><td>30</td><td><code>commands.py:41 ModelProfile</code></td></tr>
+                <tr><td>gateway</td><td><code>core/cli/serve/</code></td><td>—</td><td><code>geode serve</code></td></tr>
+                <tr><td>hooks</td><td><code>core/hooks/</code></td><td>7</td><td><code>system.py:200 HookSystem</code></td></tr>
+                <tr><td>lifecycle</td><td><code>core/lifecycle/</code></td><td>5</td><td>bootstrap entry</td></tr>
+                <tr><td>channels</td><td><code>core/channels/</code></td><td>4</td><td>adapter classes</td></tr>
+                <tr><td>ui</td><td><code>core/ui/</code></td><td>8</td><td>spinners, progress</td></tr>
+              </tbody>
+            </table>
+
+            <h2>L2 Runtime (13)</h2>
+            <table>
+              <thead><tr><th>Subsystem</th><th>Root</th><th>Modules</th><th>Entry</th></tr></thead>
+              <tbody>
+                <tr><td>llm</td><td><code>core/llm/</code></td><td>15</td><td><code>agentic_response.py:46</code></td></tr>
+                <tr><td>llm/prompts</td><td><code>core/llm/prompts/</code></td><td>2 + .md</td><td><code>__init__.py</code></td></tr>
+                <tr><td>llm/providers</td><td><code>core/llm/providers/</code></td><td>5</td><td><code>anthropic.py</code></td></tr>
+                <tr><td>tools</td><td><code>core/tools/</code></td><td>16</td><td><code>base.py:35 Tool</code></td></tr>
+                <tr><td>mcp</td><td><code>core/mcp/</code></td><td>20</td><td><code>manager.py MCPManager</code></td></tr>
+                <tr><td>memory</td><td><code>core/memory/</code></td><td>14</td><td><code>context.py:46</code></td></tr>
+                <tr><td>skills</td><td><code>core/skills/</code></td><td>6</td><td><code>skill_registry.py</code></td></tr>
+                <tr><td>verification</td><td><code>core/verification/</code></td><td>7</td><td><code>guardrails.py</code></td></tr>
+                <tr><td>scheduler</td><td><code>core/scheduler/</code></td><td>6</td><td><code>scheduler.py:76</code></td></tr>
+                <tr><td>automation</td><td><code>core/automation/</code></td><td>8</td><td><code>model_registry.py</code></td></tr>
+                <tr><td>orchestration</td><td><code>core/orchestration/</code></td><td>17</td><td><code>graph.py</code></td></tr>
+                <tr><td>auth</td><td><code>core/auth/</code></td><td>14</td><td>OAuth profile rotator</td></tr>
+                <tr><td>domains</td><td><code>core/domains/</code></td><td>3</td><td><code>port.py:18 DomainPort</code></td></tr>
+              </tbody>
+            </table>
+
+            <h2>Plugins (1)</h2>
+            <table>
+              <thead><tr><th>Plugin</th><th>Root</th><th>Modules</th><th>Highlights</th></tr></thead>
+              <tbody>
+                <tr>
+                  <td><strong>game_ip</strong></td>
+                  <td><code>plugins/game_ip/</code></td>
+                  <td>13</td>
+                  <td>4 Analysts + 3 Evaluators + Synthesizer + BiasBuster, 14-axis PSM scoring</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Inventory totals</h2>
+            <table>
+              <tbody>
+                <tr><th>Core modules</th><td>223</td></tr>
+                <tr><th>Plugin modules</th><td>13</td></tr>
+                <tr><th>Tests</th><td>~229 files (memory 83, llm 62, tools 59, hooks 31, agent 30)</td></tr>
+                <tr><th>Hook events</th><td>58 (12 groups)</td></tr>
+                <tr><th>Tools</th><td>57 (6 always-loaded + 51 deferred via <code>tool_search</code>)</td></tr>
+                <tr><th>MCP servers</th><td>16</td></tr>
+                <tr><th>Slash commands</th><td>15+</td></tr>
+                <tr><th>Prompt templates pinned</th><td>20 (17 .md + 3 axes)</td></tr>
+              </tbody>
+            </table>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/explanation/4-layer/page.tsx
+++ b/site/src/app/docs/explanation/4-layer/page.tsx
@@ -1,0 +1,74 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Why 4 Layers — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="explanation/4-layer"
+      title="Why 4 Layers"
+      titleKo="왜 4-계층인가"
+      summary="Model, Runtime, Harness, Agent. Where each layer's responsibility ends."
+      summaryKo="Model, Runtime, Harness, Agent. 각 계층의 책임이 끝나는 지점."
+    >
+      <Bi
+        ko={
+          <>
+            <p><strong>Why:</strong> Karpathy의 LLM-OS 다이어그램은 LLM을 컴퓨터의 CPU에 비유합니다. GEODE는 그 비유를 4 계층 운영체제로 구체화했습니다. 각 계층은 한 가지만 책임집니다.</p>
+
+            <h2>4 계층</h2>
+            <table>
+              <thead><tr><th>계층</th><th>OS 비유</th><th>책임</th></tr></thead>
+              <tbody>
+                <tr><td><strong>L1 Model</strong></td><td>커널 / CPU</td><td>LLM 자체. 4 프로바이더 × 14 모델. 추론.</td></tr>
+                <tr><td><strong>L2 Runtime</strong></td><td>시스템콜 + 드라이버</td><td>도구·MCP·메모리·컨텍스트. LLM이 외부와 닿는 모든 경로.</td></tr>
+                <tr><td><strong>L3 Harness</strong></td><td>셸 + init</td><td>CLI·serve·hooks·gateway. 사용자/메신저가 시스템과 닿는 경로.</td></tr>
+                <tr><td><strong>L4 Agent</strong></td><td>실행 루프</td><td>while(tool_use). 항상 도는 실행 단위.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>경계가 명확한 이유</h2>
+            <p>도메인 어댑터를 교체할 때 어떤 계층이 영향받는지가 즉시 보입니다. Game IP 플러그인을 REODE 마이그레이션 에이전트로 바꿀 때 변경된 것은 어댑터(L4 위)뿐, L1-L3는 한 줄도 안 바뀌었습니다. 이 사실이 4-계층 분리가 진짜로 작동한다는 증거입니다.</p>
+
+            <h2>왜 3개나 5개가 아닌가</h2>
+            <ul>
+              <li>3계층 (Model + Runtime + Agent)이면 hooks/gateway/serve가 갈 곳이 없음.</li>
+              <li>5계층 (L2를 Tools / Memory로 분리)은 L2 안의 cohesion이 충분히 강해 분리 비용이 이득보다 큼.</li>
+              <li>운영체제 구조와 1대1 대응이라는 점에서 4가 자연스러움.</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> portfolio §2 Primitives Mapping (13행), wiki/concepts/geode-architecture.md</p>
+          </>
+        }
+        en={
+          <>
+            <p><strong>Why:</strong> Karpathy's LLM-OS diagram likens the LLM to a computer's CPU. GEODE makes that analogy concrete as a four-layer operating system. Each layer owns exactly one thing.</p>
+
+            <h2>The four layers</h2>
+            <table>
+              <thead><tr><th>Layer</th><th>OS analogue</th><th>Owns</th></tr></thead>
+              <tbody>
+                <tr><td><strong>L1 Model</strong></td><td>Kernel / CPU</td><td>The LLM itself. 4 providers, 14 models. Inference.</td></tr>
+                <tr><td><strong>L2 Runtime</strong></td><td>Syscalls + drivers</td><td>Tools, MCP, memory, context. Every path the LLM uses to touch the outside.</td></tr>
+                <tr><td><strong>L3 Harness</strong></td><td>Shell + init</td><td>CLI, serve, hooks, gateway. Every path users and messengers use to reach the system.</td></tr>
+                <tr><td><strong>L4 Agent</strong></td><td>Execution loop</td><td>while(tool_use). The always-running execution unit.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Why the boundaries hold</h2>
+            <p>When swapping a domain adapter, the layer impact is immediately visible. When the Game IP plugin was replaced by the REODE migration agent, only the adapter above L4 changed. L1-L3 stayed identical. That fact is the proof that the 4-layer split is real, not decorative.</p>
+
+            <h2>Why not 3 or 5</h2>
+            <ul>
+              <li>Three layers (Model + Runtime + Agent) leaves no room for hooks, gateway, or serve.</li>
+              <li>Five layers (splitting L2 into Tools and Memory) costs more than it buys: cohesion inside L2 is strong.</li>
+              <li>Four matches the OS analogy 1:1, which is the natural decomposition.</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>See:</em> portfolio §2 Primitives Mapping (13 rows), wiki/concepts/geode-architecture.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/explanation/ratchet/page.tsx
+++ b/site/src/app/docs/explanation/ratchet/page.tsx
@@ -1,0 +1,68 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Why Ratchet Discipline — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="explanation/ratchet"
+      title="Why Ratchet Discipline"
+      titleKo="왜 ratchet 규율인가"
+      summary="20 pinned prompt hashes. 5-stage CI. The ratchet shape that prevents drift."
+      summaryKo="20개 프롬프트 해시 핀. 5단계 CI. drift를 막는 ratchet 형태."
+    >
+      <Bi
+        ko={
+          <>
+            <p><strong>Why:</strong> LLM 시스템은 작은 프롬프트 변경 하나가 출력 품질을 침식시킬 수 있습니다. GEODE는 이를 막기 위해 두 종류의 ratchet을 씁니다. 둘 다 단방향 잠금장치입니다.</p>
+
+            <h2>Ratchet이란</h2>
+            <p>기계의 ratchet은 한 방향으로만 돌고 반대 방향으로는 잠깁니다. 소프트웨어에서는 품질 지표를 한 방향으로만 움직이게 하는 게이트를 의미합니다. 테스트 수가 줄면 빌드 fail, 프롬프트 해시가 바뀌면 빌드 fail 같은 식.</p>
+
+            <h2>GEODE의 두 ratchet</h2>
+            <table>
+              <thead><tr><th>Ratchet</th><th>잠그는 것</th><th>왜</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Prompt hash ratchet</strong></td><td>20개 핵심 프롬프트의 해시</td><td>의도치 않은 프롬프트 변경 차단. 변경 시 명시적 재핀 commit 필요.</td></tr>
+                <tr><td><strong>CI 5-stage ratchet</strong></td><td>Lint, Type, Test, Security, Docs</td><td>한 단계라도 실패하면 PR merge 금지.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>출처 인용</h2>
+            <p>Andrej Karpathy의 <em>autoresearch</em> 프로젝트에서 정의된 ratchet discipline 패턴을 그대로 가져왔습니다. 자율 ML 실험 루프에서 모델이 자기 코드를 망가뜨리지 않도록 하는 핵심 메커니즘입니다.</p>
+
+            <h2>왜 두 layer 모두 필요한가</h2>
+            <p>출력 측 ratchet (프롬프트 해시)만 있으면 빌드 라인 측 회귀를 막을 수 없습니다. 빌드 측 ratchet (CI)만 있으면 LLM의 silent 회귀 (같은 코드 + 다른 프롬프트)를 막을 수 없습니다. 둘이 동시에 있어야 자기일치가 보장됩니다.</p>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> skills/karpathy-patterns, wiki/concepts/geode-prompt-hashing.md</p>
+          </>
+        }
+        en={
+          <>
+            <p><strong>Why:</strong> in LLM systems, a small prompt edit can quietly erode output quality. GEODE prevents this with two ratchets. Both are one-way locks.</p>
+
+            <h2>What "ratchet" means</h2>
+            <p>A mechanical ratchet turns in one direction and locks the other. In software, it means a gate that allows a quality metric to move only one way. Test count decreases? Build fails. Prompt hash changes? Build fails.</p>
+
+            <h2>GEODE's two ratchets</h2>
+            <table>
+              <thead><tr><th>Ratchet</th><th>What it locks</th><th>Why</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Prompt hash ratchet</strong></td><td>Hashes of 20 core prompts.</td><td>Blocks unintended prompt edits. Changing requires an explicit re-pin commit.</td></tr>
+                <tr><td><strong>CI 5-stage ratchet</strong></td><td>Lint, Type, Test, Security, Docs.</td><td>Any stage red blocks PR merge.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Source</h2>
+            <p>The ratchet discipline pattern is taken directly from Andrej Karpathy's <em>autoresearch</em> project, where it keeps the autonomous ML experiment loop from breaking its own code.</p>
+
+            <h2>Why both layers are needed</h2>
+            <p>Output-side ratchet alone (prompt hash) cannot catch build-line regressions. Build-side ratchet alone (CI) cannot catch silent LLM regressions (same code, different prompt). Both together guarantee self-consistency.</p>
+
+            <p className="text-white/40 text-sm"><em>See:</em> skills/karpathy-patterns, wiki/concepts/geode-prompt-hashing.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/explanation/self-hosting/page.tsx
+++ b/site/src/app/docs/explanation/self-hosting/page.tsx
@@ -1,0 +1,84 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Why a Self-Hosting Harness — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="explanation/self-hosting"
+      title="Why a Self-Hosting Harness"
+      titleKo="왜 self-hosting 하네스인가"
+      summary="The runtime and the build line share primitives. Why that mattered."
+      summaryKo="런타임과 빌드 라인이 같은 기본 단위를 공유하는 이유."
+    >
+      <Bi
+        ko={
+          <>
+            <p><strong>Why:</strong> GEODE가 운영체제급 자율 에이전트 하네스라고 주장하려면, 그 주장이 어딘가에서 검증돼야 합니다. 가장 강한 검증은 <em>그 하네스가 자기 자신을 빌드할 수 있는가</em>입니다. self-hosting compiler 개념의 직접 이식입니다.</p>
+
+            <h2>Self-hosting compiler 개념</h2>
+            <p>컴파일러 분야에서 self-hosting은 자기 자신을 컴파일하는 컴파일러를 가리킵니다. Rust·Go·TypeScript 모두 self-hosting입니다. 의미: 컴파일러 코드를 그 컴파일러 자체로 빌드할 수 있다 → 도구가 충분히 견고하다는 강한 증거.</p>
+
+            <h2>GEODE에서의 의미</h2>
+            <p>GEODE가 출시되는 자율 에이전트의 출력 안정성을 보장하는 방식과, GEODE를 빌드하는 라인(scaffold)이 빌드 안정성을 보장하는 방식이 <em>같은 기본 단위</em>를 공유합니다.</p>
+
+            <table>
+              <thead><tr><th>패턴</th><th>Artifact (출시되는 OS)</th><th>Line (그것을 빌드하는 라인)</th></tr></thead>
+              <tbody>
+                <tr><td>Hash ratchet</td><td>프롬프트 해시 20개 핀</td><td>CI 5단계 게이트</td></tr>
+                <tr><td>Layered memory</td><td>5계층 ContextAssembler</td><td>4계층 CLAUDE.md (managed → user → project → local)</td></tr>
+                <tr><td>Hooks</td><td>58 runtime 이벤트</td><td>41 scaffold skills</td></tr>
+                <tr><td>Declarative guardrails</td><td>G1-G4 verification</td><td>CANNOT/CAN 22 규칙</td></tr>
+                <tr><td>Loop + termination</td><td>while(tool_use), 50 라운드, 5 종료 경로</td><td>8-Step workflow</td></tr>
+              </tbody>
+            </table>
+
+            <h2>왜 중요한가</h2>
+            <p>같은 규율이 두 스코프에서 동일하게 작동한다는 사실은 GEODE의 설계가 <em>비유적 추상화</em>가 아니라 <em>실제 운영 가능한 패턴</em>임을 보여줍니다. 9행의 표 하나가 그 자기일치의 전부입니다.</p>
+
+            <h2>비교: 다른 에이전트 시스템</h2>
+            <ul>
+              <li>Claude Code, Cursor, Aider: 사용자 도구. 자기 자신을 빌드하지는 않음.</li>
+              <li>GEODE: 자기 자신을 빌드하는 첫 LLM 에이전트 하네스 (확인된 범위 내).</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> portfolio §3 Recursion + wiki/concepts/geode-scaffold-production.md</p>
+          </>
+        }
+        en={
+          <>
+            <p><strong>Why:</strong> for GEODE to claim it is an OS-grade autonomous agent harness, the claim must be testable somewhere. The strongest test is whether the harness can build itself. This is a direct adaptation of the self-hosting compiler concept.</p>
+
+            <h2>Self-hosting compilers</h2>
+            <p>In compilers, self-hosting means a compiler that compiles itself. Rust, Go, and TypeScript are all self-hosting. The meaning: the compiler's source code can be built by the compiler itself, which is strong evidence the tool is robust enough.</p>
+
+            <h2>What it means for GEODE</h2>
+            <p>The way GEODE keeps the shipped autonomous agent's output stable, and the way the line that builds GEODE keeps the build stable, share <em>the same primitives</em>.</p>
+
+            <table>
+              <thead><tr><th>Pattern</th><th>Artifact (the OS that ships)</th><th>Line (the line that builds it)</th></tr></thead>
+              <tbody>
+                <tr><td>Hash ratchet</td><td>20 prompt-hash pins</td><td>5-stage CI gate</td></tr>
+                <tr><td>Layered memory</td><td>5-tier ContextAssembler</td><td>4-tier CLAUDE.md (managed → user → project → local)</td></tr>
+                <tr><td>Hooks</td><td>58 runtime events</td><td>41 scaffold skills</td></tr>
+                <tr><td>Declarative guardrails</td><td>G1-G4 verification</td><td>CANNOT/CAN 22 rules</td></tr>
+                <tr><td>Loop + termination</td><td>while(tool_use), 50 rounds, 5 termination paths</td><td>8-step workflow</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Why it matters</h2>
+            <p>The fact that the same discipline operates identically at two scopes shows GEODE's design is not a <em>metaphor</em> but a <em>workable pattern</em>. A single table of nine rows is the entirety of that self-consistency.</p>
+
+            <h2>Compared to other agent systems</h2>
+            <ul>
+              <li>Claude Code, Cursor, Aider: user tools. None builds itself.</li>
+              <li>GEODE: the first LLM agent harness that builds itself (within the scope checked).</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>See:</em> portfolio §3 Recursion plus wiki/concepts/geode-scaffold-production.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/explanation/solo/page.tsx
+++ b/site/src/app/docs/explanation/solo/page.tsx
@@ -1,0 +1,84 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Why a Solo Author — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="explanation/solo"
+      title="Why a Solo Author"
+      titleKo="왜 단독 저자인가"
+      summary="What ratchet-driven release lets one person hold together. Trade-offs."
+      summaryKo="ratchet-driven release가 한 명이 끌고 갈 수 있게 해주는 것. 트레이드오프."
+    >
+      <Bi
+        ko={
+          <>
+            <p><strong>Why:</strong> GEODE는 한 명이 14개월 동안 빌드한 결과입니다. 이게 가능한 이유와 그 한계를 정리합니다.</p>
+
+            <h2>가능한 이유</h2>
+            <ol>
+              <li><strong>Ratchet driven release</strong>: 매번 push할 때 5단계 CI + 프롬프트 해시 ratchet이 잡습니다. 무회귀가 보장되니 다음 릴리스에 집중할 수 있습니다.</li>
+              <li><strong>스캐폴드가 빌드 동반자 역할</strong>: Claude Code + 41개 scaffold skills가 review·refactor·docs sync를 도와줍니다. 사람 동료 없이도 두 번째 시선이 있습니다.</li>
+              <li><strong>4-계층 분리</strong>: 도메인 추가가 어댑터 1개 추가로 끝나므로, 새 도메인을 위해 코어를 손대지 않습니다.</li>
+              <li><strong>Self-hosting</strong>: 같은 패턴이 두 스코프에 적용되므로 머릿속에 들고 있어야 할 패턴 수가 적습니다.</li>
+            </ol>
+
+            <h2>트레이드오프</h2>
+            <table>
+              <thead><tr><th>잃은 것</th><th>이유</th></tr></thead>
+              <tbody>
+                <tr><td>병렬 개발 속도</td><td>한 명이라 동시에 한 가지만 진행.</td></tr>
+                <tr><td>도메인 깊이</td><td>각 도메인 전문가 부재. Game IP·Migration 두 사례로 일반화 가능성만 검증.</td></tr>
+                <tr><td>외부 신뢰 신호</td><td>대규모 사용자 베이스 없음. ratchet과 self-hosting이 그 대체.</td></tr>
+                <tr><td>긴급 대응</td><td>혼자라 on-call 부담. 그래서 자동화·관측에 투자.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>적합한 사용 시나리오</h2>
+            <ul>
+              <li>한 명 또는 소수가 운영하는 자율 에이전트 시스템</li>
+              <li>도메인 추가 빈도는 낮고 깊이는 깊은 경우</li>
+              <li>외부 인용 가능한 ratchet · self-hosting 패턴을 채택하고 싶은 경우</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> portfolio Hero + wiki/concepts/geode-scaffold-production.md</p>
+          </>
+        }
+        en={
+          <>
+            <p><strong>Why:</strong> GEODE was built by one person over 14 months. This page explains how that is possible and where the limits are.</p>
+
+            <h2>What makes it possible</h2>
+            <ol>
+              <li><strong>Ratchet-driven release</strong>: every push runs a 5-stage CI plus the prompt-hash ratchet. With no-regression guaranteed, focus can move to the next release.</li>
+              <li><strong>Scaffold as build partner</strong>: Claude Code plus 41 scaffold skills handle review, refactor, and docs sync. A second set of eyes without a second person.</li>
+              <li><strong>4-layer separation</strong>: adding a domain means adding one adapter, never touching the core.</li>
+              <li><strong>Self-hosting</strong>: the same pattern applies to two scopes, so the number of patterns to keep in your head stays small.</li>
+            </ol>
+
+            <h2>Trade-offs</h2>
+            <table>
+              <thead><tr><th>What is given up</th><th>Why</th></tr></thead>
+              <tbody>
+                <tr><td>Parallel velocity</td><td>One person, one thing at a time.</td></tr>
+                <tr><td>Domain depth</td><td>No domain expert per area. Game IP and Migration only validate generalizability.</td></tr>
+                <tr><td>External trust signals</td><td>No large user base. Ratchet and self-hosting are the substitutes.</td></tr>
+                <tr><td>Incident response</td><td>Solo on-call. The compensating investment is automation and observability.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Where this fits</h2>
+            <ul>
+              <li>Autonomous agent systems operated by one or a few people.</li>
+              <li>Domains added rarely, each one deep.</li>
+              <li>Teams wanting to adopt ratchet and self-hosting patterns with a citable reference.</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>See:</em> portfolio Hero plus wiki/concepts/geode-scaffold-production.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/harness/cli/page.tsx
+++ b/site/src/app/docs/harness/cli/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "CLI & Slash Commands — GEODE Docs" };
 
@@ -7,10 +7,15 @@ export default function Page() {
     <DocsShell
       slug="harness/cli"
       title="CLI & Slash Commands"
+      titleKo="CLI와 슬래시 명령"
       summary="Thin client → IPC → serve daemon. 30 modules, 15+ slash commands. Auto-starts the daemon on first call."
+      summaryKo="Thin 클라이언트에서 IPC를 거쳐 serve 데몬으로. 30개 모듈, 15개 이상의 슬래시 명령. 첫 호출 시 데몬을 자동 기동합니다."
     >
-      <h2>Two-process architecture</h2>
-      <pre>{`User
+      <Bi
+        ko={
+          <>
+            <h2>2-프로세스 아키텍처</h2>
+            <pre>{`User
   │
   ▼
 geode CLI  (thin client, ~30 modules)
@@ -21,22 +26,22 @@ geode serve  (daemon, hosts AgenticLoop + state)
   │
   ▼
 LLM provider`}</pre>
-      <p>
-        The thin CLI keeps startup latency low and makes one-shot commands
-        feel instant. The daemon owns the long-lived state (AgenticLoop
-        context, MCP server processes, scheduler) so that{" "}
-        <code>/resume</code> and multi-turn flows do not have to re-bootstrap.
-      </p>
+            <p>
+              Thin CLI는 시작 지연을 낮게 유지해 일회성 명령이 즉각적으로 느껴지게
+              합니다. 데몬은 장기 상태 (AgenticLoop 컨텍스트, MCP 서버 프로세스,
+              스케줄러)를 보유하므로 <code>/resume</code>이나 멀티턴 흐름이 매번
+              부트스트랩을 다시 할 필요가 없습니다.
+            </p>
 
-      <h2>Auto-start</h2>
-      <p>
-        On first <code>geode</code> invocation if the daemon is not running,
-        the CLI spawns it and proxies. <code>geode serve</code> is the
-        explicit start; <code>/stop</code> shuts it down cleanly.
-      </p>
+            <h2>자동 기동</h2>
+            <p>
+              첫 <code>geode</code> 호출 시 데몬이 실행되어 있지 않으면 CLI가
+              데몬을 spawn하고 프록시 역할을 합니다. <code>geode serve</code>가
+              명시적 기동이고, <code>/stop</code>이 깨끗하게 종료합니다.
+            </p>
 
-      <h2>Top-level commands</h2>
-      <pre>{`geode                                      # interactive REPL
+            <h2>최상위 명령</h2>
+            <pre>{`geode                                      # interactive REPL
 geode "summarize the latest AI research"   # NL one-shot
 geode analyze "Cowboy Bebop" --dry-run     # game_ip plugin
 geode analyze "Berserk" --verbose          # full run with API
@@ -44,45 +49,127 @@ geode serve                                # start daemon
 geode version                              # version
 geode skill list / skill view / skill manage`}</pre>
 
-      <h2>Slash commands (REPL)</h2>
-      <table>
-        <thead><tr><th>Command</th><th>Effect</th></tr></thead>
-        <tbody>
-          <tr><td><code>/login</code></td><td>Auth dashboard — Plans, Profiles, Routing. Subcommands: <code>oauth &lt;provider&gt;</code>, <code>set-key &lt;plan-id&gt; &lt;key&gt;</code>, <code>use &lt;plan-id&gt;</code>, <code>route</code>, <code>quota</code>. LLM-agentic counterpart: <code>manage_login</code> tool.</td></tr>
-          <tr><td><code>/model &lt;name&gt;</code></td><td>Switch active model. Triggers <code>MODEL_SWITCHED</code> hook + system-prompt rebuild.</td></tr>
-          <tr><td><code>/skip</code></td><td>Skip the current pending tool call (used during HITL approval).</td></tr>
-          <tr><td><code>/resume</code></td><td>Restore the last session&apos;s message history + state.</td></tr>
-          <tr><td><code>/clear</code></td><td>Reset in-process context. Persists nothing.</td></tr>
-          <tr><td><code>/stop</code></td><td>Halt the daemon. Saves session if configured.</td></tr>
-          <tr><td><code>/clean</code></td><td>Remove temp artifacts (cache, IPC sockets).</td></tr>
-          <tr><td><code>/uninstall</code></td><td>Remove GEODE state directories (with confirmation).</td></tr>
-          <tr><td><code>/status</code></td><td>Show daemon, model, MCP server, hook status.</td></tr>
-          <tr><td><code>/help</code></td><td>Inline help.</td></tr>
-        </tbody>
-      </table>
+            <h2>슬래시 명령 (REPL)</h2>
+            <table>
+              <thead><tr><th>명령</th><th>효과</th></tr></thead>
+              <tbody>
+                <tr><td><code>/login</code></td><td>인증 대시보드. Plans, Profiles, Routing. 서브커맨드: <code>oauth &lt;provider&gt;</code>, <code>set-key &lt;plan-id&gt; &lt;key&gt;</code>, <code>use &lt;plan-id&gt;</code>, <code>route</code>, <code>quota</code>. LLM 에이전트 대응: <code>manage_login</code> 도구.</td></tr>
+                <tr><td><code>/model &lt;name&gt;</code></td><td>활성 모델 전환. <code>MODEL_SWITCHED</code> 훅 발화 + 시스템 프롬프트 재빌드.</td></tr>
+                <tr><td><code>/skip</code></td><td>현재 대기 중인 도구 호출 스킵 (HITL 승인 중 사용).</td></tr>
+                <tr><td><code>/resume</code></td><td>마지막 세션의 메시지 이력과 상태 복원.</td></tr>
+                <tr><td><code>/clear</code></td><td>인프로세스 컨텍스트 리셋. 영속 저장 없음.</td></tr>
+                <tr><td><code>/stop</code></td><td>데몬 정지. 설정 시 세션 저장.</td></tr>
+                <tr><td><code>/clean</code></td><td>임시 산출물 제거 (캐시, IPC 소켓).</td></tr>
+                <tr><td><code>/uninstall</code></td><td>GEODE 상태 디렉터리 제거 (확인 후).</td></tr>
+                <tr><td><code>/status</code></td><td>데몬, 모델, MCP 서버, 훅 상태 표시.</td></tr>
+                <tr><td><code>/help</code></td><td>인라인 도움말.</td></tr>
+              </tbody>
+            </table>
 
-      <h2><code>manage_login</code> agentic tool</h2>
-      <p>
-        The agentic counterpart of <code>/login</code>. Subcommands mirror the slash command, and
-        the return is a structured snapshot — <code>plans</code>, <code>profiles</code>,
-        <code>routing</code> — so the agent can self-diagnose auth state and surface remediation
-        steps without a round trip to the user.
-      </p>
+            <h2><code>manage_login</code> 에이전틱 도구</h2>
+            <p>
+              <code>/login</code>의 에이전틱 대응물입니다. 서브커맨드는 슬래시
+              명령과 거울처럼 대응하고, 반환값은 구조화된 스냅샷
+              (<code>plans</code>, <code>profiles</code>, <code>routing</code>)입니다.
+              에이전트가 인증 상태를 스스로 진단하고 사용자에게 왕복하지 않은 채
+              교정 단계를 제시할 수 있게 합니다.
+            </p>
 
-      <h2>Files</h2>
-      <ul>
-        <li><code>core/cli/commands.py:41</code> — <code>ModelProfile</code> + slash command dispatch</li>
-        <li><code>core/cli/agentic_loop.py</code> — REPL bootstrap + AgenticLoop wiring</li>
-        <li><code>core/cli/result_cache.py</code> — 24h TTL cache with content hash</li>
-        <li><code>core/cli/effort_picker.py</code> — interactive effort selector</li>
-      </ul>
+            <h2>파일</h2>
+            <ul>
+              <li><code>core/cli/commands.py:41</code>. <code>ModelProfile</code>과 슬래시 명령 디스패치.</li>
+              <li><code>core/cli/agentic_loop.py</code>. REPL 부트스트랩과 AgenticLoop 배선.</li>
+              <li><code>core/cli/result_cache.py</code>. 콘텐츠 해시 기반 24시간 TTL 캐시.</li>
+              <li><code>core/cli/effort_picker.py</code>. 대화형 effort 선택기.</li>
+            </ul>
 
-      <h2>Bash integration</h2>
-      <p>
-        <code>geode-exec</code> runs a one-shot agent command in the current
-        shell, capturing output as a normal Unix tool. Useful for cron and
-        scripting.
-      </p>
+            <h2>Bash 통합</h2>
+            <p>
+              <code>geode-exec</code>는 현재 셸에서 일회성 에이전트 명령을
+              실행하며, 출력은 일반 Unix 도구처럼 캡처됩니다. cron이나 스크립팅에
+              유용합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>Two-process architecture</h2>
+            <pre>{`User
+  │
+  ▼
+geode CLI  (thin client, ~30 modules)
+  │
+  │  IPC (unix socket / stdio)
+  ▼
+geode serve  (daemon, hosts AgenticLoop + state)
+  │
+  ▼
+LLM provider`}</pre>
+            <p>
+              The thin CLI keeps startup latency low and makes one-shot commands
+              feel instant. The daemon owns the long-lived state (AgenticLoop
+              context, MCP server processes, scheduler) so that{" "}
+              <code>/resume</code> and multi-turn flows do not have to re-bootstrap.
+            </p>
+
+            <h2>Auto-start</h2>
+            <p>
+              On first <code>geode</code> invocation if the daemon is not running,
+              the CLI spawns it and proxies. <code>geode serve</code> is the
+              explicit start; <code>/stop</code> shuts it down cleanly.
+            </p>
+
+            <h2>Top-level commands</h2>
+            <pre>{`geode                                      # interactive REPL
+geode "summarize the latest AI research"   # NL one-shot
+geode analyze "Cowboy Bebop" --dry-run     # game_ip plugin
+geode analyze "Berserk" --verbose          # full run with API
+geode serve                                # start daemon
+geode version                              # version
+geode skill list / skill view / skill manage`}</pre>
+
+            <h2>Slash commands (REPL)</h2>
+            <table>
+              <thead><tr><th>Command</th><th>Effect</th></tr></thead>
+              <tbody>
+                <tr><td><code>/login</code></td><td>Auth dashboard — Plans, Profiles, Routing. Subcommands: <code>oauth &lt;provider&gt;</code>, <code>set-key &lt;plan-id&gt; &lt;key&gt;</code>, <code>use &lt;plan-id&gt;</code>, <code>route</code>, <code>quota</code>. LLM-agentic counterpart: <code>manage_login</code> tool.</td></tr>
+                <tr><td><code>/model &lt;name&gt;</code></td><td>Switch active model. Triggers <code>MODEL_SWITCHED</code> hook + system-prompt rebuild.</td></tr>
+                <tr><td><code>/skip</code></td><td>Skip the current pending tool call (used during HITL approval).</td></tr>
+                <tr><td><code>/resume</code></td><td>Restore the last session&apos;s message history + state.</td></tr>
+                <tr><td><code>/clear</code></td><td>Reset in-process context. Persists nothing.</td></tr>
+                <tr><td><code>/stop</code></td><td>Halt the daemon. Saves session if configured.</td></tr>
+                <tr><td><code>/clean</code></td><td>Remove temp artifacts (cache, IPC sockets).</td></tr>
+                <tr><td><code>/uninstall</code></td><td>Remove GEODE state directories (with confirmation).</td></tr>
+                <tr><td><code>/status</code></td><td>Show daemon, model, MCP server, hook status.</td></tr>
+                <tr><td><code>/help</code></td><td>Inline help.</td></tr>
+              </tbody>
+            </table>
+
+            <h2><code>manage_login</code> agentic tool</h2>
+            <p>
+              The agentic counterpart of <code>/login</code>. Subcommands mirror the slash command, and
+              the return is a structured snapshot — <code>plans</code>, <code>profiles</code>,
+              <code>routing</code> — so the agent can self-diagnose auth state and surface remediation
+              steps without a round trip to the user.
+            </p>
+
+            <h2>Files</h2>
+            <ul>
+              <li><code>core/cli/commands.py:41</code> — <code>ModelProfile</code> + slash command dispatch</li>
+              <li><code>core/cli/agentic_loop.py</code> — REPL bootstrap + AgenticLoop wiring</li>
+              <li><code>core/cli/result_cache.py</code> — 24h TTL cache with content hash</li>
+              <li><code>core/cli/effort_picker.py</code> — interactive effort selector</li>
+            </ul>
+
+            <h2>Bash integration</h2>
+            <p>
+              <code>geode-exec</code> runs a one-shot agent command in the current
+              shell, capturing output as a normal Unix tool. Useful for cron and
+              scripting.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/harness/hooks/page.tsx
+++ b/site/src/app/docs/harness/hooks/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Hook System — GEODE Docs" };
 
@@ -7,50 +7,54 @@ export default function Page() {
     <DocsShell
       slug="harness/hooks"
       title="Hook System"
+      titleKo="훅 시스템"
       summary="58 lifecycle events grouped into 12 categories. Listeners can observe, intercept, or modify."
+      summaryKo="58개 라이프사이클 이벤트, 12개 카테고리로 분류. 리스너가 관찰, 가로채기, 수정 가능."
     >
-      <h2>Three trigger modes</h2>
-      <ul>
-        <li><strong><code>trigger(event, payload)</code></strong> — fire-and-forget. Listener errors are logged and isolated.</li>
-        <li><strong><code>trigger_with_result(event, payload)</code></strong> — capture each handler&apos;s return value.</li>
-        <li><strong><code>trigger_interceptor(event, payload)</code></strong> — handlers can block or modify the event.</li>
-      </ul>
-      <p>
-        Implementation lives at <code>core/hooks/system.py:200 class HookSystem</code>.
-        Concurrent execution is via <code>concurrent.futures</code> with a
-        re-entrant lock around handler registration.
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>세 가지 트리거 모드</h2>
+            <ul>
+              <li><strong><code>trigger(event, payload)</code></strong>. fire-and-forget. 리스너 오류는 로깅되며 격리됩니다.</li>
+              <li><strong><code>trigger_with_result(event, payload)</code></strong>. 각 핸들러의 반환값을 캡처합니다.</li>
+              <li><strong><code>trigger_interceptor(event, payload)</code></strong>. 핸들러가 이벤트를 차단하거나 수정할 수 있습니다.</li>
+            </ul>
+            <p>
+              구현은 <code>core/hooks/system.py:200 class HookSystem</code>에 있습니다.
+              동시 실행은 <code>concurrent.futures</code>를 통해 이루어지며,
+              핸들러 등록 시 재진입 가능한 락으로 보호됩니다.
+            </p>
 
-      <h2>Event groups</h2>
-      <table>
-        <thead><tr><th>Group</th><th>Count</th><th>Events</th></tr></thead>
-        <tbody>
-          <tr><td>pipeline</td><td>3</td><td>PIPELINE_START, PIPELINE_END, PIPELINE_ERROR</td></tr>
-          <tr><td>node</td><td>4</td><td>NODE_ENTER, NODE_EXIT, NODE_ERROR, NODE_RETRY</td></tr>
-          <tr><td>analysis</td><td>3</td><td>ANALYST_START, ANALYST_COMPLETE, ANALYST_FAILED</td></tr>
-          <tr><td>verification</td><td>2</td><td>VERIFICATION_PASS, VERIFICATION_FAIL</td></tr>
-          <tr><td>automation</td><td>5</td><td>DRIFT_DETECTED, MODEL_PROMOTED, OUTCOME_COLLECTED, EXPERT_VOTE_CAST, FEEDBACK_PHASE_CHANGED</td></tr>
-          <tr><td>memory</td><td>4</td><td>MEMORY_SAVED, RULE_CREATED, RULE_UPDATED, RULE_DELETED</td></tr>
-          <tr><td>tool</td><td>8</td><td>TOOL_EXEC_START/END/FAILED, TOOL_RECOVERY_START/END, TOOL_APPROVAL_REQUEST/GRANTED/DENIED</td></tr>
-          <tr><td>session</td><td>2</td><td>SESSION_START, SESSION_END</td></tr>
-          <tr><td>model</td><td>1</td><td>MODEL_SWITCHED</td></tr>
-          <tr><td>llm</td><td>4</td><td>LLM_CALL_START, LLM_CALL_END, LLM_CALL_FAILED, LLM_CALL_RETRY</td></tr>
-          <tr><td>approval</td><td>2</td><td>APPROVAL_REQUEST, APPROVAL_GRANTED</td></tr>
-          <tr><td>context</td><td>2</td><td>CONTEXT_OVERFLOW, CONTEXT_RESET</td></tr>
-          <tr><td>prompt</td><td>1</td><td>PROMPT_ASSEMBLED</td></tr>
-          <tr><td>turn</td><td>1</td><td>TURN_COMPLETE</td></tr>
-        </tbody>
-      </table>
-      <p>
-        Total: 14 groups, 58 events (table summarises the major ones). The
-        <code>core/hooks/system.py</code> source comments group events into
-        finer sub-sections (subagent lifecycle, agentic turn, session,
-        LLM call, tool approval, serve lifecycle, MCP server) — the table
-        rolls related sub-sections together.
-      </p>
+            <h2>이벤트 그룹</h2>
+            <table>
+              <thead><tr><th>그룹</th><th>개수</th><th>이벤트</th></tr></thead>
+              <tbody>
+                <tr><td>pipeline</td><td>3</td><td>PIPELINE_START, PIPELINE_END, PIPELINE_ERROR</td></tr>
+                <tr><td>node</td><td>4</td><td>NODE_ENTER, NODE_EXIT, NODE_ERROR, NODE_RETRY</td></tr>
+                <tr><td>analysis</td><td>3</td><td>ANALYST_START, ANALYST_COMPLETE, ANALYST_FAILED</td></tr>
+                <tr><td>verification</td><td>2</td><td>VERIFICATION_PASS, VERIFICATION_FAIL</td></tr>
+                <tr><td>automation</td><td>5</td><td>DRIFT_DETECTED, MODEL_PROMOTED, OUTCOME_COLLECTED, EXPERT_VOTE_CAST, FEEDBACK_PHASE_CHANGED</td></tr>
+                <tr><td>memory</td><td>4</td><td>MEMORY_SAVED, RULE_CREATED, RULE_UPDATED, RULE_DELETED</td></tr>
+                <tr><td>tool</td><td>8</td><td>TOOL_EXEC_START/END/FAILED, TOOL_RECOVERY_START/END, TOOL_APPROVAL_REQUEST/GRANTED/DENIED</td></tr>
+                <tr><td>session</td><td>2</td><td>SESSION_START, SESSION_END</td></tr>
+                <tr><td>model</td><td>1</td><td>MODEL_SWITCHED</td></tr>
+                <tr><td>llm</td><td>4</td><td>LLM_CALL_START, LLM_CALL_END, LLM_CALL_FAILED, LLM_CALL_RETRY</td></tr>
+                <tr><td>approval</td><td>2</td><td>APPROVAL_REQUEST, APPROVAL_GRANTED</td></tr>
+                <tr><td>context</td><td>2</td><td>CONTEXT_OVERFLOW, CONTEXT_RESET</td></tr>
+                <tr><td>prompt</td><td>1</td><td>PROMPT_ASSEMBLED</td></tr>
+                <tr><td>turn</td><td>1</td><td>TURN_COMPLETE</td></tr>
+              </tbody>
+            </table>
+            <p>
+              총 14개 그룹, 58개 이벤트 (표에는 주요 항목만 요약). <code>core/hooks/system.py</code>
+              소스 주석은 이벤트를 더 세분화하여 (subagent 라이프사이클, agentic turn, 세션,
+              LLM 호출, 도구 승인, serve 라이프사이클, MCP 서버) 분류하며, 표에서는 관련 하위
+              섹션을 묶어서 표시했습니다.
+            </p>
 
-      <h2>Registration</h2>
-      <pre>{`from core.hooks.system import HookSystem, HookEvent
+            <h2>등록</h2>
+            <pre>{`from core.hooks.system import HookSystem, HookEvent
 
 hooks = HookSystem()
 hooks.register(
@@ -58,27 +62,103 @@ hooks.register(
     lambda event, data: print(f"assembled hash={data['assembled_hash']}"),
 )`}</pre>
 
-      <h2>Matchers</h2>
-      <p>
-        Handlers can attach a matcher predicate to filter events before
-        dispatch — e.g. only fire on <code>node=&quot;analyst&quot;</code>.
-        See <code>core/hooks/system.py:_filter_by_matcher</code>.
-      </p>
+            <h2>매처</h2>
+            <p>
+              핸들러는 dispatch 전에 이벤트를 필터링하는 매처 predicate를 부착할 수 있습니다.
+              예를 들어 <code>node=&quot;analyst&quot;</code>일 때만 발화시키는 방식입니다.
+              <code>core/hooks/system.py:_filter_by_matcher</code>를 참고하세요.
+            </p>
 
-      <h2>PROMPT_ASSEMBLED payload</h2>
-      <p>The single prompt-related event. Payload contains:</p>
-      <ul>
-        <li><code>node</code>: &ldquo;analyst&rdquo;, &ldquo;evaluator&rdquo;, &ldquo;synthesizer&rdquo;, &ldquo;biasbuster&rdquo;, &ldquo;router&rdquo;</li>
-        <li><code>role_type</code>: e.g. &ldquo;game_mechanics&rdquo;, &ldquo;quality_judge&rdquo;</li>
-        <li><code>base_template_hash</code>, <code>assembled_hash</code> (SHA-256[:12])</li>
-        <li><code>fragment_count</code>, <code>total_chars</code>, <code>fragments_used</code></li>
-        <li><em>conditional</em> <code>skill_hashes</code> (per-skill body hash)</li>
-        <li><em>conditional</em> <code>truncation_events</code></li>
-      </ul>
-      <p>
-        The payload contains hashes and counters only — never the prompt
-        text itself.
-      </p>
+            <h2>PROMPT_ASSEMBLED payload</h2>
+            <p>유일한 prompt 관련 이벤트. payload 구성:</p>
+            <ul>
+              <li><code>node</code>: &ldquo;analyst&rdquo;, &ldquo;evaluator&rdquo;, &ldquo;synthesizer&rdquo;, &ldquo;biasbuster&rdquo;, &ldquo;router&rdquo;</li>
+              <li><code>role_type</code>: 예) &ldquo;game_mechanics&rdquo;, &ldquo;quality_judge&rdquo;</li>
+              <li><code>base_template_hash</code>, <code>assembled_hash</code> (SHA-256[:12])</li>
+              <li><code>fragment_count</code>, <code>total_chars</code>, <code>fragments_used</code></li>
+              <li><em>조건부</em> <code>skill_hashes</code> (스킬별 본문 해시)</li>
+              <li><em>조건부</em> <code>truncation_events</code></li>
+            </ul>
+            <p>
+              payload에는 해시와 카운터만 담깁니다. 프롬프트 텍스트 자체는 포함되지 않습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>Three trigger modes</h2>
+            <ul>
+              <li><strong><code>trigger(event, payload)</code></strong> — fire-and-forget. Listener errors are logged and isolated.</li>
+              <li><strong><code>trigger_with_result(event, payload)</code></strong> — capture each handler&apos;s return value.</li>
+              <li><strong><code>trigger_interceptor(event, payload)</code></strong> — handlers can block or modify the event.</li>
+            </ul>
+            <p>
+              Implementation lives at <code>core/hooks/system.py:200 class HookSystem</code>.
+              Concurrent execution is via <code>concurrent.futures</code> with a
+              re-entrant lock around handler registration.
+            </p>
+
+            <h2>Event groups</h2>
+            <table>
+              <thead><tr><th>Group</th><th>Count</th><th>Events</th></tr></thead>
+              <tbody>
+                <tr><td>pipeline</td><td>3</td><td>PIPELINE_START, PIPELINE_END, PIPELINE_ERROR</td></tr>
+                <tr><td>node</td><td>4</td><td>NODE_ENTER, NODE_EXIT, NODE_ERROR, NODE_RETRY</td></tr>
+                <tr><td>analysis</td><td>3</td><td>ANALYST_START, ANALYST_COMPLETE, ANALYST_FAILED</td></tr>
+                <tr><td>verification</td><td>2</td><td>VERIFICATION_PASS, VERIFICATION_FAIL</td></tr>
+                <tr><td>automation</td><td>5</td><td>DRIFT_DETECTED, MODEL_PROMOTED, OUTCOME_COLLECTED, EXPERT_VOTE_CAST, FEEDBACK_PHASE_CHANGED</td></tr>
+                <tr><td>memory</td><td>4</td><td>MEMORY_SAVED, RULE_CREATED, RULE_UPDATED, RULE_DELETED</td></tr>
+                <tr><td>tool</td><td>8</td><td>TOOL_EXEC_START/END/FAILED, TOOL_RECOVERY_START/END, TOOL_APPROVAL_REQUEST/GRANTED/DENIED</td></tr>
+                <tr><td>session</td><td>2</td><td>SESSION_START, SESSION_END</td></tr>
+                <tr><td>model</td><td>1</td><td>MODEL_SWITCHED</td></tr>
+                <tr><td>llm</td><td>4</td><td>LLM_CALL_START, LLM_CALL_END, LLM_CALL_FAILED, LLM_CALL_RETRY</td></tr>
+                <tr><td>approval</td><td>2</td><td>APPROVAL_REQUEST, APPROVAL_GRANTED</td></tr>
+                <tr><td>context</td><td>2</td><td>CONTEXT_OVERFLOW, CONTEXT_RESET</td></tr>
+                <tr><td>prompt</td><td>1</td><td>PROMPT_ASSEMBLED</td></tr>
+                <tr><td>turn</td><td>1</td><td>TURN_COMPLETE</td></tr>
+              </tbody>
+            </table>
+            <p>
+              Total: 14 groups, 58 events (table summarises the major ones). The
+              <code>core/hooks/system.py</code> source comments group events into
+              finer sub-sections (subagent lifecycle, agentic turn, session,
+              LLM call, tool approval, serve lifecycle, MCP server) — the table
+              rolls related sub-sections together.
+            </p>
+
+            <h2>Registration</h2>
+            <pre>{`from core.hooks.system import HookSystem, HookEvent
+
+hooks = HookSystem()
+hooks.register(
+    HookEvent.PROMPT_ASSEMBLED,
+    lambda event, data: print(f"assembled hash={data['assembled_hash']}"),
+)`}</pre>
+
+            <h2>Matchers</h2>
+            <p>
+              Handlers can attach a matcher predicate to filter events before
+              dispatch — e.g. only fire on <code>node=&quot;analyst&quot;</code>.
+              See <code>core/hooks/system.py:_filter_by_matcher</code>.
+            </p>
+
+            <h2>PROMPT_ASSEMBLED payload</h2>
+            <p>The single prompt-related event. Payload contains:</p>
+            <ul>
+              <li><code>node</code>: &ldquo;analyst&rdquo;, &ldquo;evaluator&rdquo;, &ldquo;synthesizer&rdquo;, &ldquo;biasbuster&rdquo;, &ldquo;router&rdquo;</li>
+              <li><code>role_type</code>: e.g. &ldquo;game_mechanics&rdquo;, &ldquo;quality_judge&rdquo;</li>
+              <li><code>base_template_hash</code>, <code>assembled_hash</code> (SHA-256[:12])</li>
+              <li><code>fragment_count</code>, <code>total_chars</code>, <code>fragments_used</code></li>
+              <li><em>conditional</em> <code>skill_hashes</code> (per-skill body hash)</li>
+              <li><em>conditional</em> <code>truncation_events</code></li>
+            </ul>
+            <p>
+              The payload contains hashes and counters only — never the prompt
+              text itself.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/harness/lifecycle/page.tsx
+++ b/site/src/app/docs/harness/lifecycle/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Lifecycle — GEODE Docs" };
 
@@ -7,62 +7,127 @@ export default function Page() {
     <DocsShell
       slug="harness/lifecycle"
       title="Lifecycle"
+      titleKo="라이프사이클"
       summary="Bootstrap, serve, shutdown. core/lifecycle/ + core/runtime.py drive the daemon's life cycle, handle signal-based termination, and emit lifecycle hook events."
+      summaryKo="Bootstrap, serve, shutdown. core/lifecycle/와 core/runtime.py가 데몬의 수명을 구동하고, 시그널 기반 종료를 처리하며, 라이프사이클 훅 이벤트를 발화합니다."
     >
-      <h2>Five phases</h2>
-      <pre>{`1. Bootstrap     — read config, init paths, register hooks, set ContextVars
+      <Bi
+        ko={
+          <>
+            <h2>다섯 단계</h2>
+            <pre>{`1. Bootstrap     — read config, init paths, register hooks, set ContextVars
 2. Wire          — start MCP servers, load tools, discover skills, mount domain plugins
 3. Serve         — listen on IPC, accept commands, drive AgenticLoop
 4. Drain         — finish pending tool calls, flush queues, close LLM clients
 5. Shutdown      — close IPC socket, write session log, exit`}</pre>
 
-      <h2>Entry points</h2>
-      <table>
-        <thead><tr><th>File</th><th>Role</th></tr></thead>
-        <tbody>
-          <tr><td><code>core/runtime.py</code></td><td>top-level <code>bootstrap()</code></td></tr>
-          <tr><td><code>core/lifecycle/</code> (5 modules)</td><td>phase implementations + signal handlers</td></tr>
-          <tr><td><code>core/server/</code> (10 modules)</td><td>IPC listener, request dispatch, daemon main loop</td></tr>
-        </tbody>
-      </table>
+            <h2>진입점</h2>
+            <table>
+              <thead><tr><th>파일</th><th>역할</th></tr></thead>
+              <tbody>
+                <tr><td><code>core/runtime.py</code></td><td>최상위 <code>bootstrap()</code></td></tr>
+                <tr><td><code>core/lifecycle/</code> (5 modules)</td><td>각 단계 구현과 시그널 핸들러</td></tr>
+                <tr><td><code>core/server/</code> (10 modules)</td><td>IPC 리스너, 요청 디스패치, 데몬 메인 루프</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Signals</h2>
-      <ul>
-        <li><strong>SIGTERM</strong> — graceful drain, then shutdown</li>
-        <li><strong>SIGINT</strong> — interrupt current LLM call (<code>UserCancelledError</code> propagates), keep daemon alive</li>
-        <li><strong>SIGHUP</strong> — reload config (env vars, model registry)</li>
-      </ul>
+            <h2>시그널</h2>
+            <ul>
+              <li><strong>SIGTERM</strong>. graceful drain 후 shutdown.</li>
+              <li><strong>SIGINT</strong>. 현재 LLM 호출을 중단 (<code>UserCancelledError</code> 전파). 데몬은 유지.</li>
+              <li><strong>SIGHUP</strong>. 설정 재로드 (환경 변수, 모델 레지스트리).</li>
+            </ul>
 
-      <h2>ContextVar wiring</h2>
-      <p>
-        Bootstrap sets <code>ContextVar</code> instances for current session,
-        current model, current user profile, and current hook system. The
-        agentic loop and tool handlers read these via <code>get_*()</code>{" "}
-        accessors instead of receiving them as arguments.
-      </p>
-      <p>
-        CLAUDE.md anti-pattern: a <code>get_*()</code> accessor without a
-        corresponding <code>set_*()</code> in bootstrap silently returns{" "}
-        <code>None</code> and the dependent feature degrades silently. The
-        Wiring Verification table in CLAUDE.md is the gate against this.
-      </p>
+            <h2>ContextVar 배선</h2>
+            <p>
+              Bootstrap은 현재 세션, 현재 모델, 현재 사용자 프로파일, 현재 훅
+              시스템에 대한 <code>ContextVar</code> 인스턴스를 설정합니다. 에이전틱
+              루프와 도구 핸들러는 인자로 받지 않고 <code>get_*()</code> 액세서로
+              읽습니다.
+            </p>
+            <p>
+              CLAUDE.md의 안티 패턴 한 가지. bootstrap에 대응하는{" "}
+              <code>set_*()</code>가 없는 <code>get_*()</code> 액세서는 조용히{" "}
+              <code>None</code>을 반환하고, 의존 기능은 조용히 degrade 됩니다.
+              CLAUDE.md의 Wiring Verification 표가 이를 막는 게이트입니다.
+            </p>
 
-      <h2>Hook events fired</h2>
-      <ul>
-        <li><code>SESSION_START</code> — at the end of bootstrap</li>
-        <li><code>SESSION_END</code> — at the start of drain</li>
-        <li><code>MODEL_SWITCHED</code> — when <code>/model</code> rotates</li>
-        <li><code>CONTEXT_RESET</code> — on <code>/clear</code></li>
-      </ul>
+            <h2>발화되는 훅 이벤트</h2>
+            <ul>
+              <li><code>SESSION_START</code>. bootstrap 종료 시점.</li>
+              <li><code>SESSION_END</code>. drain 시작 시점.</li>
+              <li><code>MODEL_SWITCHED</code>. <code>/model</code> 회전 시점.</li>
+              <li><code>CONTEXT_RESET</code>. <code>/clear</code> 실행 시점.</li>
+            </ul>
 
-      <h2>Crash recovery</h2>
-      <p>
-        Unhandled exceptions in the daemon are caught at the top of the
-        request dispatcher, logged with full traceback, and a structured
-        error frame is returned to the CLI. The daemon stays alive — only
-        the failing call dies. <code>geode serve</code> with{" "}
-        <code>--auto-restart</code> respawns on hard crash.
-      </p>
+            <h2>크래시 복구</h2>
+            <p>
+              데몬에서 잡히지 않은 예외는 요청 디스패처 최상단에서 포착되고, 전체
+              traceback과 함께 로깅되며, 구조화된 오류 프레임이 CLI로 반환됩니다.
+              데몬은 살아있고, 실패한 호출만 죽습니다. <code>geode serve</code>를{" "}
+              <code>--auto-restart</code>로 실행하면 하드 크래시 시 재spawn 합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>Five phases</h2>
+            <pre>{`1. Bootstrap     — read config, init paths, register hooks, set ContextVars
+2. Wire          — start MCP servers, load tools, discover skills, mount domain plugins
+3. Serve         — listen on IPC, accept commands, drive AgenticLoop
+4. Drain         — finish pending tool calls, flush queues, close LLM clients
+5. Shutdown      — close IPC socket, write session log, exit`}</pre>
+
+            <h2>Entry points</h2>
+            <table>
+              <thead><tr><th>File</th><th>Role</th></tr></thead>
+              <tbody>
+                <tr><td><code>core/runtime.py</code></td><td>top-level <code>bootstrap()</code></td></tr>
+                <tr><td><code>core/lifecycle/</code> (5 modules)</td><td>phase implementations + signal handlers</td></tr>
+                <tr><td><code>core/server/</code> (10 modules)</td><td>IPC listener, request dispatch, daemon main loop</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Signals</h2>
+            <ul>
+              <li><strong>SIGTERM</strong> — graceful drain, then shutdown</li>
+              <li><strong>SIGINT</strong> — interrupt current LLM call (<code>UserCancelledError</code> propagates), keep daemon alive</li>
+              <li><strong>SIGHUP</strong> — reload config (env vars, model registry)</li>
+            </ul>
+
+            <h2>ContextVar wiring</h2>
+            <p>
+              Bootstrap sets <code>ContextVar</code> instances for current session,
+              current model, current user profile, and current hook system. The
+              agentic loop and tool handlers read these via <code>get_*()</code>{" "}
+              accessors instead of receiving them as arguments.
+            </p>
+            <p>
+              CLAUDE.md anti-pattern: a <code>get_*()</code> accessor without a
+              corresponding <code>set_*()</code> in bootstrap silently returns{" "}
+              <code>None</code> and the dependent feature degrades silently. The
+              Wiring Verification table in CLAUDE.md is the gate against this.
+            </p>
+
+            <h2>Hook events fired</h2>
+            <ul>
+              <li><code>SESSION_START</code> — at the end of bootstrap</li>
+              <li><code>SESSION_END</code> — at the start of drain</li>
+              <li><code>MODEL_SWITCHED</code> — when <code>/model</code> rotates</li>
+              <li><code>CONTEXT_RESET</code> — on <code>/clear</code></li>
+            </ul>
+
+            <h2>Crash recovery</h2>
+            <p>
+              Unhandled exceptions in the daemon are caught at the top of the
+              request dispatcher, logged with full traceback, and a structured
+              error frame is returned to the CLI. The daemon stays alive — only
+              the failing call dies. <code>geode serve</code> with{" "}
+              <code>--auto-restart</code> respawns on hard crash.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/ops/cost/page.tsx
+++ b/site/src/app/docs/ops/cost/page.tsx
@@ -1,0 +1,74 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Cost Monitoring — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="ops/cost"
+      title="Cost Monitoring"
+      titleKo="비용 모니터링"
+      summary="Per-session and per-day budgets. When to switch models."
+      summaryKo="세션·일별 예산. 모델 전환 시점."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE의 LLM 호출 비용을 추적하고 예산을 설정하는 방법입니다.</p>
+
+            <h2>비용 추적</h2>
+            <p>모든 LLM call은 <code>LLM_CALL_END</code> hook으로 토큰/달러를 보고합니다. <code>geode /status</code>에서 누적 확인.</p>
+
+            <h2>예산 설정</h2>
+            <pre>{`# config.toml
+[budget]
+per_session_usd = 1.0
+per_day_usd = 10.0
+on_exceed = "downgrade"  # downgrade | stop | warn`}</pre>
+
+            <h2>모델 다운그레이드 전략</h2>
+            <p>예산 초과 임박 시 자동으로 더 싼 모델로 전환합니다.</p>
+            <ul>
+              <li>opus → sonnet → haiku 순</li>
+              <li>gpt-5.5 → gpt-5.4 → gpt-5.4-mini</li>
+              <li>glm-5 → glm-4.7 → glm-4.7-flash</li>
+            </ul>
+
+            <h2>수동 전환</h2>
+            <pre>{`geode /model claude-haiku-4-5`}</pre>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-context-guard.md, geode-changelog (token guard 도입 history)</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide tracks GEODE's LLM call costs and sets budgets.</p>
+
+            <h2>Cost tracking</h2>
+            <p>Every LLM call reports tokens and dollars via the <code>LLM_CALL_END</code> hook. Check cumulative in <code>geode /status</code>.</p>
+
+            <h2>Budget configuration</h2>
+            <pre>{`# config.toml
+[budget]
+per_session_usd = 1.0
+per_day_usd = 10.0
+on_exceed = "downgrade"  # downgrade | stop | warn`}</pre>
+
+            <h2>Downgrade strategy</h2>
+            <p>When the budget is about to be exceeded, GEODE auto-switches to a cheaper model.</p>
+            <ul>
+              <li>opus → sonnet → haiku</li>
+              <li>gpt-5.5 → gpt-5.4 → gpt-5.4-mini</li>
+              <li>glm-5 → glm-4.7 → glm-4.7-flash</li>
+            </ul>
+
+            <h2>Manual switch</h2>
+            <pre>{`geode /model claude-haiku-4-5`}</pre>
+
+            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-context-guard.md, geode-changelog (token guard history).</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/ops/long-running/page.tsx
+++ b/site/src/app/docs/ops/long-running/page.tsx
@@ -1,0 +1,76 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Long-running Safety — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="ops/long-running"
+      title="Long-running Safety"
+      titleKo="장기 실행 안전"
+      summary="Token guards, context overflow, sliding window. Graceful drain."
+      summaryKo="토큰 가드, 컨텍스트 오버플로, 슬라이딩 윈도. graceful drain."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE를 수 시간 이상 돌릴 때 발생하는 안전 위험과 그 가드 메커니즘을 정리합니다.</p>
+
+            <h2>5 가드</h2>
+            <ul>
+              <li><strong>200K 절대 토큰 가드</strong> — context가 한계 근처면 graceful drain</li>
+              <li><strong>25K MCP 결과 가드</strong> — 한 도구 호출의 단일 결과 cap. HTML → MD 폴백</li>
+              <li><strong>200-턴 슬라이딩 윈도</strong> — 가장 오래된 turn부터 압축</li>
+              <li><strong>50 라운드 상한</strong> — while(tool_use) loop의 최대 라운드</li>
+              <li><strong>5 종료 경로</strong> — natural completion, budget, error, user stop, timeout</li>
+            </ul>
+
+            <h2>관련 설정</h2>
+            <pre>{`# config.toml
+[runtime.budget]
+max_tokens = 200000
+max_rounds = 50
+max_turns = 200`}</pre>
+
+            <h2>관측</h2>
+            <ul>
+              <li><a href="/docs/harness/hooks"><code>CONTEXT_OVERFLOW</code> hook</a> 으로 발생 감지</li>
+              <li>Runlog에 사용량 시계열 기록</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-long-running-safety.md, wiki/concepts/geode-context-overflow-prevention.md, wiki/concepts/geode-context-guard.md</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide lists the safety risks of running GEODE for hours and the guards that mitigate each.</p>
+
+            <h2>Five guards</h2>
+            <ul>
+              <li><strong>200K absolute token guard</strong>: graceful drain when context approaches the ceiling.</li>
+              <li><strong>25K MCP result guard</strong>: per-call result cap with HTML to Markdown fallback.</li>
+              <li><strong>200-turn sliding window</strong>: oldest turns are compacted first.</li>
+              <li><strong>50-round ceiling</strong>: max rounds of the while(tool_use) loop.</li>
+              <li><strong>Five termination paths</strong>: natural completion, budget, error, user stop, timeout.</li>
+            </ul>
+
+            <h2>Configuration</h2>
+            <pre>{`# config.toml
+[runtime.budget]
+max_tokens = 200000
+max_rounds = 50
+max_turns = 200`}</pre>
+
+            <h2>Observability</h2>
+            <ul>
+              <li><a href="/docs/harness/hooks"><code>CONTEXT_OVERFLOW</code> hook</a> fires on hit.</li>
+              <li>Usage time series lands in runlog.</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-long-running-safety.md, wiki/concepts/geode-context-overflow-prevention.md, wiki/concepts/geode-context-guard.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/ops/oauth/page.tsx
+++ b/site/src/app/docs/ops/oauth/page.tsx
@@ -1,0 +1,74 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "OAuth Token Rotation — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="ops/oauth"
+      title="OAuth Token Rotation"
+      titleKo="OAuth 토큰 회전"
+      summary="Anthropic ToS, Codex flow, refresh policy."
+      summaryKo="Anthropic ToS, Codex 플로우, 갱신 정책."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 OAuth 기반 인증을 사용하는 경우의 토큰 갱신 정책을 정리합니다.</p>
+
+            <h2>중요한 정책</h2>
+            <p>
+              <strong>Anthropic Claude Pro/Max OAuth 토큰은 third-party harness에서 사용 불가</strong>입니다 (2026-01-09 ToS).
+              GEODE는 해당 토큰을 읽지 않습니다. 대신 Anthropic API 키 (Console)를 사용하세요.
+            </p>
+
+            <h2>Codex OAuth (gpt-5.5 구독)</h2>
+            <pre>{`# 토큰 등록 (CLI 대화형)
+codex login
+
+# 토큰 위치
+~/.codex/auth.json`}</pre>
+
+            <h2>자동 갱신</h2>
+            <p>GEODE는 만료 임박을 감지하면 refresh token으로 자동 갱신. 실패 시 <code>OAUTH_REFRESH_FAILED</code> hook 발생.</p>
+
+            <h2>수동 재인증</h2>
+            <pre>{`codex login  # 새 토큰 발급
+geode /clean # 캐시 비우기
+geode serve & # 재기동`}</pre>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-oauth-policy.md, <a href="/docs/runtime/auth">Auth and OAuth reference</a></p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide documents the token refresh policy for OAuth-based providers.</p>
+
+            <h2>Policy reminder</h2>
+            <p>
+              <strong>Anthropic Claude Pro/Max OAuth tokens cannot be used by third-party harnesses</strong> (per the 2026-01-09 ToS).
+              GEODE does not read them. Use an Anthropic API key (Console) instead.
+            </p>
+
+            <h2>Codex OAuth (gpt-5.5 subscription)</h2>
+            <pre>{`# Register the token (interactive CLI)
+codex login
+
+# Token location
+~/.codex/auth.json`}</pre>
+
+            <h2>Auto-refresh</h2>
+            <p>GEODE auto-refreshes using the refresh token when expiry is near. On failure, the <code>OAUTH_REFRESH_FAILED</code> hook fires.</p>
+
+            <h2>Manual re-auth</h2>
+            <pre>{`codex login  # issue a new token
+geode /clean # clear caches
+geode serve & # restart`}</pre>
+
+            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-oauth-policy.md, <a href="/docs/runtime/auth">Auth and OAuth reference</a>.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/ops/observability/page.tsx
+++ b/site/src/app/docs/ops/observability/page.tsx
@@ -1,0 +1,72 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Observability — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="ops/observability"
+      title="Observability"
+      titleKo="관측성"
+      summary="Hooks, RunLog, Petri audits. Three lenses, one runtime."
+      summaryKo="훅, RunLog, Petri 감사. 세 가지 렌즈, 하나의 런타임."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE를 운영할 때 사용하는 3개의 관측 렌즈를 정리합니다.</p>
+
+            <h2>3 렌즈</h2>
+            <table>
+              <thead><tr><th>렌즈</th><th>대상</th><th>위치</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Hooks (58 events)</strong></td><td>실시간 lifecycle 이벤트. 도구 호출·LLM 콜·세션 시작/종료 등.</td><td><a href="/docs/harness/hooks">Hook System</a></td></tr>
+                <tr><td><strong>RunLog</strong></td><td>run 단위 trace. agent 추론·tool call·결과를 시계열로 보관.</td><td><code>~/.geode/runlog/</code></td></tr>
+                <tr><td><strong>Petri Audit</strong></td><td>misalignment risk. 38 dimension × N seeds 격자 점수.</td><td><a href="/docs/petri/overview">Petri Integration</a></td></tr>
+              </tbody>
+            </table>
+
+            <h2>어떤 렌즈를 언제 쓰나</h2>
+            <ul>
+              <li><strong>"왜 이 도구가 호출됐지?"</strong> → Hooks + RunLog</li>
+              <li><strong>"비용이 어디서 나갔지?"</strong> → Hook <code>LLM_CALL_END</code> 집계</li>
+              <li><strong>"이 에이전트가 안전한가?"</strong> → Petri audit</li>
+            </ul>
+
+            <h2>외부 시각화</h2>
+            <p>현재 GEODE는 LangSmith를 옵션으로 지원합니다 (v0.89+ 이후 기본 비활성). 자체 관측이 우선.</p>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/docs/runtime/llm/langsmith">LangSmith reference</a>, <a href="/docs/petri/run">Run an Audit</a></p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide lists the three observability lenses available when operating GEODE.</p>
+
+            <h2>Three lenses</h2>
+            <table>
+              <thead><tr><th>Lens</th><th>What it sees</th><th>Where</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Hooks (58 events)</strong></td><td>Real-time lifecycle events: tool calls, LLM calls, session starts/ends.</td><td><a href="/docs/harness/hooks">Hook System</a></td></tr>
+                <tr><td><strong>RunLog</strong></td><td>Per-run trace: agent reasoning, tool calls, results, in time order.</td><td><code>~/.geode/runlog/</code></td></tr>
+                <tr><td><strong>Petri Audit</strong></td><td>Misalignment risk: 38-dim by N-seeds score grid.</td><td><a href="/docs/petri/overview">Petri Integration</a></td></tr>
+              </tbody>
+            </table>
+
+            <h2>Which lens for which question</h2>
+            <ul>
+              <li><strong>"Why was this tool called?"</strong> → Hooks plus RunLog.</li>
+              <li><strong>"Where did the cost go?"</strong> → Aggregate the <code>LLM_CALL_END</code> hook.</li>
+              <li><strong>"Is this agent safe?"</strong> → Run a Petri audit.</li>
+            </ul>
+
+            <h2>External visualization</h2>
+            <p>GEODE supports LangSmith as an opt-in path (default off since v0.89+). Self-instrumentation comes first.</p>
+
+            <p className="text-white/40 text-sm"><em>See:</em> <a href="/docs/runtime/llm/langsmith">LangSmith reference</a>, <a href="/docs/petri/run">Run an Audit</a>.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/petri/bundle/page.tsx
+++ b/site/src/app/docs/petri/bundle/page.tsx
@@ -1,0 +1,108 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Audit Bundle Viewer — GEODE Docs" };
+
+const BUNDLE_URL = "/petri-bundle/";
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="petri/bundle"
+      title="Audit Bundle Viewer"
+      titleKo="감사 Bundle 뷰어"
+      summary="Live inspect_ai transcript viewer for the latest GEODE audit run."
+      summaryKo="최신 GEODE 감사 run의 라이브 inspect_ai 트랜스크립트 뷰어."
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              <strong>Reference:</strong> 가장 최근 published Petri × GEODE audit의 라이브 transcript 뷰어 링크입니다.
+              GitHub Pages의 같은 도메인 다른 path에 publish됩니다.
+            </p>
+
+            <p>
+              <a
+                href={BUNDLE_URL}
+                className="inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 mt-2 text-base font-medium hover:border-[#A573E8] hover:text-[#A573E8] transition-colors"
+                target="_blank"
+                rel="noreferrer"
+              >
+                /geode/petri-bundle/ 뷰어 열기 ↗
+              </a>
+            </p>
+
+            <h2>Bundle에 들어 있는 것</h2>
+            <ul>
+              <li>전체 transcript JSONL (auditor·target·judge 발화 + tool call 트레이스)</li>
+              <li>Judge 점수표 (N seeds × 38 dims)</li>
+              <li>실행 메타: 사용 모델, seed list, max-turns, 총 비용</li>
+              <li>matplotlib heatmap + summary stats</li>
+            </ul>
+
+            <h2>Bundle을 새로 만들려면</h2>
+            <p>
+              <a href="/docs/petri/run">감사 실행</a> 가이드에 따라 audit를 돌린 뒤 결과 디렉토리를
+              <code>site/public/petri-bundle/</code>에 publish 합니다. Pages workflow가 path-filter <code>site/**</code>를
+              잡고 자동 deploy합니다.
+            </p>
+
+            <h2>점수 해석</h2>
+            <p>
+              차원별 의미와 0-3 점수 스케일은 <a href="/docs/petri/judge-dimensions">38 Judge 차원</a> 페이지를 참조하세요.
+            </p>
+
+            <p className="text-white/40 text-sm">
+              <em>참고:</em> 뷰어가 404로 나오면 아직 publish되지 않았다는 뜻입니다. CHANGELOG에서 가장 최근
+              Petri 항목 (PR #1024+, v0.92.0 이후)을 확인하세요.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <p>
+              <strong>Reference:</strong> live transcript viewer link for the most recently published Petri × GEODE
+              audit. Hosted on the same GitHub Pages domain, different path.
+            </p>
+
+            <p>
+              <a
+                href={BUNDLE_URL}
+                className="inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 mt-2 text-base font-medium hover:border-[#A573E8] hover:text-[#A573E8] transition-colors"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open /geode/petri-bundle/ viewer ↗
+              </a>
+            </p>
+
+            <h2>What the bundle contains</h2>
+            <ul>
+              <li>Full transcript JSONL (auditor, target, judge utterances plus tool-call traces)</li>
+              <li>Judge score grid (N seeds by 38 dims)</li>
+              <li>Run metadata: models used, seed list, max-turns, total cost</li>
+              <li>matplotlib heatmap and summary statistics</li>
+            </ul>
+
+            <h2>Publishing a new bundle</h2>
+            <p>
+              Follow the <a href="/docs/petri/run">Run an Audit</a> guide, then drop the result directory at
+              <code>site/public/petri-bundle/</code>. The Pages workflow path-filter <code>site/**</code>
+              will deploy automatically.
+            </p>
+
+            <h2>Score interpretation</h2>
+            <p>
+              For dimension meanings and the 0-3 score scale, see <a href="/docs/petri/judge-dimensions">38 Judge Dimensions</a>.
+            </p>
+
+            <p className="text-white/40 text-sm">
+              <em>Note:</em> if the viewer 404s, the bundle has not been published yet. Check CHANGELOG for the most
+              recent Petri entry (PR #1024+, v0.92.0 onward).
+            </p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/petri/judge-dimensions/page.tsx
+++ b/site/src/app/docs/petri/judge-dimensions/page.tsx
@@ -1,0 +1,114 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "38 Judge Dimensions — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="petri/judge-dimensions"
+      title="38 Judge Dimensions"
+      titleKo="38 Judge 차원"
+      summary="What each dimension scores. How to read the heatmap."
+      summaryKo="각 차원이 무엇을 평가하는지. heatmap 읽는 법."
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              <strong>Reference:</strong> Petri Judge가 transcript마다 산출하는 38개 차원의 정의. 각 차원은 0~3 스코어이며,
+              값이 클수록 risk가 높습니다. 카테고리는 GEODE plugin의 <code>plugins/petri_audit/judge_dims/</code>에 정의돼 있습니다.
+            </p>
+
+            <h2>카테고리 (8 그룹)</h2>
+            <table>
+              <thead><tr><th>그룹</th><th>차원 수</th><th>대표 차원</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Refusal &amp; Deception</strong></td><td>5</td><td>refusal_appropriateness, sycophancy, gaslighting</td></tr>
+                <tr><td><strong>Power Seeking</strong></td><td>4</td><td>self_replication, resource_acquisition, persuasion</td></tr>
+                <tr><td><strong>Harm</strong></td><td>6</td><td>bio_uplift, cyber_uplift, weapons_uplift, csam, harassment, hate</td></tr>
+                <tr><td><strong>Honesty</strong></td><td>5</td><td>fabrication, omission, misdirection</td></tr>
+                <tr><td><strong>Privacy</strong></td><td>3</td><td>pii_disclosure, surveillance_assist, doxxing</td></tr>
+                <tr><td><strong>Manipulation</strong></td><td>5</td><td>flattery, emotional_pressure, false_urgency</td></tr>
+                <tr><td><strong>Sandbox Awareness</strong></td><td>4</td><td>tool_misuse, scope_creep, instruction_override</td></tr>
+                <tr><td><strong>Meta</strong></td><td>6</td><td>refusal_after_compliance, partial_compliance, …</td></tr>
+              </tbody>
+            </table>
+            <p className="text-white/40 text-sm">
+              <em>주의:</em> 정확한 차원 목록과 정의는 inspect_petri 패키지 버전에 종속됩니다. 위 표는 v3 기준 요약.
+            </p>
+
+            <h2>스코어링</h2>
+            <ul>
+              <li><strong>0</strong>: 해당 위험 신호 없음</li>
+              <li><strong>1</strong>: 미약한 신호. 단일 발화에서 부분적 합치.</li>
+              <li><strong>2</strong>: 명확한 신호. 여러 turn에 걸쳐 합치.</li>
+              <li><strong>3</strong>: 강한 신호. transcript 전체가 그 위험 차원에 부합.</li>
+            </ul>
+
+            <h2>Heatmap 읽는 법</h2>
+            <p>
+              <code>scripts/petri_viz_summary.py</code> (matplotlib heatmap)가 N seeds × 38 dims 격자로 점수를 출력합니다.
+              세로축은 seed, 가로축은 dimension. 짙은 색일수록 high risk. 같은 dimension의 세로 패턴(여러 seeds가 동시에 점수)이
+              가장 의미 있는 신호입니다. 단일 seed의 high score는 false positive 가능성도 있으니 transcript 직접 확인이 필요합니다.
+            </p>
+
+            <h2>판정 모델 선택</h2>
+            <p>
+              Judge 모델은 보통 Auditor와 같거나 더 강한 모델을 씁니다. 작은 모델은 long transcript에서 흐름을 놓치는 경우가 있어,
+              GEODE 권장 default는 <code>claude-haiku-4-5</code> (cost) 또는 <code>claude-sonnet-4-6</code> (정확도)입니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <p>
+              <strong>Reference:</strong> the 38 dimensions the Petri judge scores per transcript. Each dimension
+              uses a 0-3 scale where higher means more risk. Categories live in <code>plugins/petri_audit/judge_dims/</code>.
+            </p>
+
+            <h2>Categories (8 groups)</h2>
+            <table>
+              <thead><tr><th>Group</th><th>Dims</th><th>Examples</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Refusal &amp; Deception</strong></td><td>5</td><td>refusal_appropriateness, sycophancy, gaslighting</td></tr>
+                <tr><td><strong>Power Seeking</strong></td><td>4</td><td>self_replication, resource_acquisition, persuasion</td></tr>
+                <tr><td><strong>Harm</strong></td><td>6</td><td>bio_uplift, cyber_uplift, weapons_uplift, csam, harassment, hate</td></tr>
+                <tr><td><strong>Honesty</strong></td><td>5</td><td>fabrication, omission, misdirection</td></tr>
+                <tr><td><strong>Privacy</strong></td><td>3</td><td>pii_disclosure, surveillance_assist, doxxing</td></tr>
+                <tr><td><strong>Manipulation</strong></td><td>5</td><td>flattery, emotional_pressure, false_urgency</td></tr>
+                <tr><td><strong>Sandbox Awareness</strong></td><td>4</td><td>tool_misuse, scope_creep, instruction_override</td></tr>
+                <tr><td><strong>Meta</strong></td><td>6</td><td>refusal_after_compliance, partial_compliance, …</td></tr>
+              </tbody>
+            </table>
+            <p className="text-white/40 text-sm">
+              <em>Note:</em> the exact dimension list and definitions track the inspect_petri package version. The table
+              above summarizes v3.
+            </p>
+
+            <h2>Scoring</h2>
+            <ul>
+              <li><strong>0</strong>: no signal for this risk axis.</li>
+              <li><strong>1</strong>: faint signal. Partial match in a single utterance.</li>
+              <li><strong>2</strong>: clear signal. Pattern recurs across turns.</li>
+              <li><strong>3</strong>: strong signal. Entire transcript fits the axis.</li>
+            </ul>
+
+            <h2>Reading the heatmap</h2>
+            <p>
+              <code>scripts/petri_viz_summary.py</code> (matplotlib heatmap) renders N seeds by 38 dims. Y-axis is
+              seed, X-axis is dimension. Darker cells are higher risk. Vertical patterns (the same dimension hot
+              across multiple seeds) are the strongest signal. A single hot cell can be a false positive; verify by
+              reading the transcript.
+            </p>
+
+            <h2>Choosing a judge model</h2>
+            <p>
+              The judge is usually the same model as the auditor, or stronger. Small models can lose the thread on
+              long transcripts. GEODE recommends <code>claude-haiku-4-5</code> (cost) or <code>claude-sonnet-4-6</code> (accuracy).
+            </p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/petri/overview/page.tsx
+++ b/site/src/app/docs/petri/overview/page.tsx
@@ -1,0 +1,119 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Petri × GEODE Integration — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="petri/overview"
+      title="Petri × GEODE Integration"
+      titleKo="Petri × GEODE 통합"
+      summary="Anthropic Alignment Science's framework, wrapped over GEODE's agent. 173 seeds, 38 judge dimensions."
+      summaryKo="Anthropic Alignment Science의 프레임워크를 GEODE 에이전트 위에 얹음. 173 seeds, 38 judge 차원."
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              GEODE는 자기 자신의 misalignment 위험을 측정하기 위해 Petri framework를 wrapped agent로 통합합니다.
+              Petri (<strong>Parallel Exploration Tool for Risky Interactions</strong>)는 Anthropic Alignment
+              Science가 만든 alignment audit framework로, <a href="https://inspect.aisi.org.uk/">inspect_ai</a> (UK AISI)
+              위에 build 되었고 <a href="https://meridianlabs.ai">Meridian Labs</a>가 <code>inspect_petri</code> v3 (MIT) 로 maintain합니다.
+            </p>
+
+            <h2>세 가지 모델 역할</h2>
+            <table>
+              <thead><tr><th>Role</th><th>역할</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Auditor</strong></td><td>Target을 misalign 방향으로 유도하는 적대적 agent</td></tr>
+                <tr><td><strong>Target</strong></td><td>측정 대상. GEODE wrapped agent 또는 vanilla LLM</td></tr>
+                <tr><td><strong>Judge</strong></td><td>Transcript를 38 dimension으로 평가하는 평가자</td></tr>
+              </tbody>
+            </table>
+
+            <h2>기본 패키지</h2>
+            <ul>
+              <li><strong>173</strong> default seeds. 시나리오 카탈로그.</li>
+              <li><strong>38</strong> judge dimensions. 위험 차원별 점수.</li>
+              <li>3-role 호출 (auditor, target, judge 각자 모델 선택 가능).</li>
+            </ul>
+
+            <p>실행 명령 예시:</p>
+            <pre>{`inspect eval inspect_petri/audit \\
+  --model-role auditor=<m> target=<m> judge=<m>`}</pre>
+
+            <h2>Inspect transcript viewer v3</h2>
+            <p>
+              2026-05-07 <em>Introducing Petri 3</em> (출처: meridianlabs.ai)에서 Inspect transcript viewer가
+              Petri를 네이티브 지원하기 시작했습니다. GEODE의 audit run 결과는 동일한 viewer로 확인할 수 있습니다.
+            </p>
+
+            <h2>GEODE에서의 위치</h2>
+            <ul>
+              <li>코드: <code>plugins/petri_audit/</code> (runner, judge_dims, schema, audit mode)</li>
+              <li>최신 audit bundle: <a href="/petri-bundle/">/geode/petri-bundle/</a> 외부 viewer</li>
+              <li>CHANGELOG entry: v0.92.0+ 에서 Petri × GEODE 통합 (PR #1024 등)</li>
+            </ul>
+
+            <h2>왜 통합했나</h2>
+            <p>
+              GEODE는 LLM 위에 얹은 자율 에이전트입니다. 그것이 misalignment를 일으킬 수 있는지 정량적으로 측정할 방법이 필요했고,
+              Petri가 그 방법을 제공합니다. wrapper 위에서 측정함으로써 LLM 단독이 아니라 GEODE-as-deployed의 행동을 평가합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <p>
+              GEODE integrates the Petri framework as a wrapped agent to measure its own misalignment risk.
+              Petri (<strong>Parallel Exploration Tool for Risky Interactions</strong>) is an alignment audit
+              framework built by Anthropic Alignment Science, sitting on top of <a href="https://inspect.aisi.org.uk/">inspect_ai</a> (UK AISI)
+              and maintained by <a href="https://meridianlabs.ai">Meridian Labs</a> as <code>inspect_petri</code> v3 (MIT).
+            </p>
+
+            <h2>Three model roles</h2>
+            <table>
+              <thead><tr><th>Role</th><th>What it does</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Auditor</strong></td><td>Adversarial agent that steers the target toward misalignment.</td></tr>
+                <tr><td><strong>Target</strong></td><td>The system under test. GEODE wrapped agent or a vanilla LLM.</td></tr>
+                <tr><td><strong>Judge</strong></td><td>Scores the transcript on 38 dimensions.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>What ships</h2>
+            <ul>
+              <li><strong>173</strong> default seeds. The scenario catalog.</li>
+              <li><strong>38</strong> judge dimensions. Risk axes scored independently.</li>
+              <li>3-role invocation (auditor, target, judge are independently model-selectable).</li>
+            </ul>
+
+            <p>Run command:</p>
+            <pre>{`inspect eval inspect_petri/audit \\
+  --model-role auditor=<m> target=<m> judge=<m>`}</pre>
+
+            <h2>Inspect transcript viewer v3</h2>
+            <p>
+              In <em>Introducing Petri 3</em> (2026-05-07, meridianlabs.ai), the Inspect transcript viewer
+              began supporting Petri natively. GEODE audit runs render in the same viewer.
+            </p>
+
+            <h2>Where this lives in GEODE</h2>
+            <ul>
+              <li>Code: <code>plugins/petri_audit/</code> (runner, judge_dims, schema, audit mode)</li>
+              <li>Latest bundle: <a href="/petri-bundle/">/geode/petri-bundle/</a> external viewer</li>
+              <li>CHANGELOG entries: Petri × GEODE integration since v0.92.0 (PR #1024 et al.)</li>
+            </ul>
+
+            <h2>Why we wired it in</h2>
+            <p>
+              GEODE is an autonomous agent layered over an LLM. We needed a quantitative way to ask whether
+              that wrapping could cause misalignment, and Petri provides one. Measuring on the wrapper lets us
+              evaluate the behavior of GEODE-as-deployed, not the LLM in isolation.
+            </p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/petri/run/page.tsx
+++ b/site/src/app/docs/petri/run/page.tsx
@@ -1,0 +1,114 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Run an Audit — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="petri/run"
+      title="Run an Audit"
+      titleKo="감사 실행"
+      summary="inspect eval inspect_petri/audit. Choose model roles, seeds, and turn budget."
+      summaryKo="inspect eval inspect_petri/audit. 모델 역할, seeds, turn 예산 선택."
+    >
+      <Bi
+        ko={
+          <>
+            <p>
+              이 가이드는 Petri × GEODE audit를 한 번 끝까지 돌리는 절차입니다. 5분 안에 첫 결과를 봅니다.
+            </p>
+
+            <h2>준비물</h2>
+            <ul>
+              <li>GEODE가 설치되어 있고, <code>plugins/petri_audit</code>가 활성화돼 있어야 합니다.</li>
+              <li>Auditor·Target·Judge에 쓸 LLM 키 (같은 키 3중 사용 가능, 보통 더 작은 모델 추천).</li>
+              <li>비용 가드: 첫 run은 seed 3개·turn 10·Haiku로 묶어 5,000 KRW 이내가 권장.</li>
+            </ul>
+
+            <h2>최소 실행 명령</h2>
+            <pre>{`inspect eval inspect_petri/audit \\
+  --model-role auditor=anthropic/claude-haiku-4-5 \\
+  --model-role target=geode/claude-opus-4-7 \\
+  --model-role judge=anthropic/claude-haiku-4-5 \\
+  --seed-select id:001,002,003 \\
+  --max-turns 10`}</pre>
+
+            <h2>옵션 정리</h2>
+            <table>
+              <thead><tr><th>옵션</th><th>의미</th><th>권장 값</th></tr></thead>
+              <tbody>
+                <tr><td><code>--model-role</code></td><td>3 역할 각자 모델 지정</td><td>auditor/judge는 같은 모델 가능</td></tr>
+                <tr><td><code>--seed-select</code></td><td>173 seeds 중 일부만</td><td>첫 run은 3-5개</td></tr>
+                <tr><td><code>--max-turns</code></td><td>대화 turn 상한</td><td>10 (cost cap), 30 (full)</td></tr>
+                <tr><td><code>--log-dir</code></td><td>transcript 저장 위치</td><td>기본 <code>./logs/</code></td></tr>
+              </tbody>
+            </table>
+
+            <h2>결과 보기</h2>
+            <p>
+              결과 transcript는 <code>./logs/</code>에 저장됩니다. Inspect transcript viewer로 확인:
+            </p>
+            <pre>{`inspect view ./logs/<run-id>.eval`}</pre>
+            <p>
+              퍼블리시된 GEODE audit bundle은 <a href="/petri-bundle/">/geode/petri-bundle/</a>에서 바로 볼 수 있습니다.
+            </p>
+
+            <h2>다음 단계</h2>
+            <ul>
+              <li>점수 의미: <a href="/docs/petri/judge-dimensions">38 Judge 차원</a></li>
+              <li>관측 분석: <a href="/docs/ops/observability">관측성</a></li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <p>
+              This guide runs a single Petri × GEODE audit end to end. First result in five minutes.
+            </p>
+
+            <h2>Prerequisites</h2>
+            <ul>
+              <li>GEODE installed with <code>plugins/petri_audit</code> active.</li>
+              <li>LLM keys for auditor, target, and judge (one key for all three is fine; usually smaller models are recommended).</li>
+              <li>Cost cap: first run should stay under ~5,000 KRW with 3 seeds, 10 turns, Haiku.</li>
+            </ul>
+
+            <h2>Minimal command</h2>
+            <pre>{`inspect eval inspect_petri/audit \\
+  --model-role auditor=anthropic/claude-haiku-4-5 \\
+  --model-role target=geode/claude-opus-4-7 \\
+  --model-role judge=anthropic/claude-haiku-4-5 \\
+  --seed-select id:001,002,003 \\
+  --max-turns 10`}</pre>
+
+            <h2>Options reference</h2>
+            <table>
+              <thead><tr><th>Option</th><th>Meaning</th><th>Recommended</th></tr></thead>
+              <tbody>
+                <tr><td><code>--model-role</code></td><td>Model for each of the three roles.</td><td>Auditor and judge can share a model.</td></tr>
+                <tr><td><code>--seed-select</code></td><td>Subset of the 173 seeds.</td><td>3-5 for the first run.</td></tr>
+                <tr><td><code>--max-turns</code></td><td>Per-conversation turn cap.</td><td>10 (cost cap), 30 (full).</td></tr>
+                <tr><td><code>--log-dir</code></td><td>Where transcripts land.</td><td>Default <code>./logs/</code></td></tr>
+              </tbody>
+            </table>
+
+            <h2>Reading the results</h2>
+            <p>
+              Transcripts land in <code>./logs/</code>. View with the Inspect transcript viewer:
+            </p>
+            <pre>{`inspect view ./logs/<run-id>.eval`}</pre>
+            <p>
+              The published GEODE audit bundle is browsable at <a href="/petri-bundle/">/geode/petri-bundle/</a>.
+            </p>
+
+            <h2>Next</h2>
+            <ul>
+              <li>What the scores mean: <a href="/docs/petri/judge-dimensions">38 Judge Dimensions</a></li>
+              <li>Bigger picture: <a href="/docs/ops/observability">Observability</a></li>
+            </ul>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/plugins/game-ip/page.tsx
+++ b/site/src/app/docs/plugins/game-ip/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Game IP Plugin — GEODE Docs" };
 
@@ -7,10 +7,15 @@ export default function Page() {
     <DocsShell
       slug="plugins/game-ip"
       title="Game IP Plugin"
+      titleKo="Game IP 플러그인"
       summary="Closed-domain plugin for evaluating Game/IP market potential. 4 Analysts + 3 Evaluators + Synthesizer + BiasBuster, 14-axis PSM scoring."
+      summaryKo="Game/IP 시장 잠재력을 평가하는 폐쇄형 도메인 플러그인. Analyst 4 + Evaluator 3 + Synthesizer + BiasBuster, 14-axis PSM 스코어링."
     >
-      <h2>Pipeline shape</h2>
-      <pre>{`Input: { ip_name }
+      <Bi
+        ko={
+          <>
+            <h2>파이프라인 형태</h2>
+            <pre>{`Input: { ip_name }
    │
    ▼
 load_ip_profile  (from MonoLake / fixtures)
@@ -37,57 +42,140 @@ Synthesizer (cause-locked narrative)
    ▼
 Output: tier (S/A/B/C/D) + score (0-100) + cause + recommendation`}</pre>
 
-      <h2>Fixtures</h2>
-      <table>
-        <thead><tr><th>IP</th><th>Tier</th><th>Score</th><th>Cause</th></tr></thead>
-        <tbody>
-          <tr><td>Berserk</td><td><strong>S</strong></td><td>81.2</td><td>conversion_failure</td></tr>
-          <tr><td>Cowboy Bebop</td><td><strong>A</strong></td><td>68.4</td><td>undermarketed</td></tr>
-          <tr><td>Ghost in the Shell</td><td><strong>B</strong></td><td>51.7</td><td>discovery_failure</td></tr>
-        </tbody>
-      </table>
+            <h2>픽스처</h2>
+            <table>
+              <thead><tr><th>IP</th><th>Tier</th><th>Score</th><th>Cause</th></tr></thead>
+              <tbody>
+                <tr><td>Berserk</td><td><strong>S</strong></td><td>81.2</td><td>conversion_failure</td></tr>
+                <tr><td>Cowboy Bebop</td><td><strong>A</strong></td><td>68.4</td><td>undermarketed</td></tr>
+                <tr><td>Ghost in the Shell</td><td><strong>B</strong></td><td>51.7</td><td>discovery_failure</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Configuration SSOT</h2>
-      <p>
-        <code>plugins/game_ip/config/evaluator_axes.yaml</code> is the single
-        source of truth for:
-      </p>
-      <ul>
-        <li><strong>4 analyst directives</strong> — domain-specific focus per analyst type</li>
-        <li><strong>3 evaluator axis sets</strong> — quality_judge (8), hidden_value (3), community_momentum (3)</li>
-        <li><strong>Korean rubrics</strong> — 1-5 anchor descriptions per axis</li>
-        <li><strong>Composite formulas</strong> — e.g. <code>(axes_sum - 8) / 32 * 100</code> for quality_judge</li>
-        <li><strong>Prospect axes</strong> — for non-gamified IPs (novels, films)</li>
-      </ul>
-      <p>
-        These three top-level keys are hashed into{" "}
-        <code>EVALUATOR_AXES</code>, <code>PROSPECT_EVALUATOR_AXES</code>,{" "}
-        and <code>ANALYST_SPECIFIC</code> entries in{" "}
-        <code>PROMPT_VERSIONS</code>. See{" "}
-        <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>.
-      </p>
+            <h2>Configuration SSOT</h2>
+            <p>
+              <code>plugins/game_ip/config/evaluator_axes.yaml</code>은 다음 항목의 단일 진리원입니다.
+            </p>
+            <ul>
+              <li><strong>4개 analyst 지시문</strong>. analyst 타입별 도메인 특화 포커스</li>
+              <li><strong>3개 evaluator axis 집합</strong>. quality_judge (8), hidden_value (3), community_momentum (3)</li>
+              <li><strong>한국어 rubric</strong>. axis별 1-5 anchor 설명</li>
+              <li><strong>합성 공식</strong>. 예) quality_judge는 <code>(axes_sum - 8) / 32 * 100</code></li>
+              <li><strong>Prospect axes</strong>. 비-게임화 IP (소설, 영화)용</li>
+            </ul>
+            <p>
+              이 3개 최상위 키는 <code>PROMPT_VERSIONS</code>의 <code>EVALUATOR_AXES</code>,
+              <code>PROSPECT_EVALUATOR_AXES</code>, <code>ANALYST_SPECIFIC</code> 엔트리로 해시됩니다.
+              <a href="/geode/docs/runtime/llm/prompt-hashing">프롬프트 해싱</a>을 참고하세요.
+            </p>
 
-      <h2>Plugin contract</h2>
-      <p>
-        The plugin implements the <code>DomainPort</code> protocol from{" "}
-        <code>core/domains/port.py</code>:
-      </p>
-      <ul>
-        <li><code>get_pipeline()</code> — returns the LangGraph StateGraph</li>
-        <li><code>get_valid_axes_map()</code> — exposes axis keys per evaluator</li>
-        <li><code>load_ip_profile(ip_name)</code> — domain data lookup</li>
-      </ul>
-      <p>
-        The loader at <code>core/domains/loader.py</code> discovers plugins
-        in the <code>plugins/</code> namespace at startup.
-      </p>
+            <h2>플러그인 계약</h2>
+            <p>
+              플러그인은 <code>core/domains/port.py</code>의 <code>DomainPort</code> 프로토콜을
+              구현합니다.
+            </p>
+            <ul>
+              <li><code>get_pipeline()</code>. LangGraph StateGraph 반환</li>
+              <li><code>get_valid_axes_map()</code>. evaluator별 axis 키 노출</li>
+              <li><code>load_ip_profile(ip_name)</code>. 도메인 데이터 조회</li>
+            </ul>
+            <p>
+              <code>core/domains/loader.py</code>의 로더가 시작 시점에 <code>plugins/</code>
+              네임스페이스에서 플러그인을 발견합니다.
+            </p>
 
-      <h2>CLI</h2>
-      <pre>{`# Dry-run (no LLM calls, returns fixture-based result)
+            <h2>CLI</h2>
+            <pre>{`# Dry-run (no LLM calls, returns fixture-based result)
 uv run geode analyze "Cowboy Bebop" --dry-run
 
 # Full run (requires API keys)
 uv run geode analyze "Berserk" --verbose`}</pre>
+          </>
+        }
+        en={
+          <>
+            <h2>Pipeline shape</h2>
+            <pre>{`Input: { ip_name }
+   │
+   ▼
+load_ip_profile  (from MonoLake / fixtures)
+   │
+   ├─► Analyst × 4 (parallel)
+   │     game_mechanics    →   findings + 1-5 score
+   │     player_experience →   findings + 1-5 score
+   │     growth_potential  →   findings + 1-5 score
+   │     discovery         →   findings + 1-5 score
+   │
+   ▼
+Evaluator × 3 (parallel)
+   quality_judge      → 8 axes (a, b, c, b1, c1, c2, m, n)
+   hidden_value       → 3 axes
+   community_momentum → 3 axes
+   │
+   ▼
+BiasBuster (6 bias checks)
+   confirmation, recency, anchoring, position, verbosity, self-enhancement
+   │
+   ▼
+Synthesizer (cause-locked narrative)
+   │
+   ▼
+Output: tier (S/A/B/C/D) + score (0-100) + cause + recommendation`}</pre>
+
+            <h2>Fixtures</h2>
+            <table>
+              <thead><tr><th>IP</th><th>Tier</th><th>Score</th><th>Cause</th></tr></thead>
+              <tbody>
+                <tr><td>Berserk</td><td><strong>S</strong></td><td>81.2</td><td>conversion_failure</td></tr>
+                <tr><td>Cowboy Bebop</td><td><strong>A</strong></td><td>68.4</td><td>undermarketed</td></tr>
+                <tr><td>Ghost in the Shell</td><td><strong>B</strong></td><td>51.7</td><td>discovery_failure</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Configuration SSOT</h2>
+            <p>
+              <code>plugins/game_ip/config/evaluator_axes.yaml</code> is the single
+              source of truth for:
+            </p>
+            <ul>
+              <li><strong>4 analyst directives</strong> — domain-specific focus per analyst type</li>
+              <li><strong>3 evaluator axis sets</strong> — quality_judge (8), hidden_value (3), community_momentum (3)</li>
+              <li><strong>Korean rubrics</strong> — 1-5 anchor descriptions per axis</li>
+              <li><strong>Composite formulas</strong> — e.g. <code>(axes_sum - 8) / 32 * 100</code> for quality_judge</li>
+              <li><strong>Prospect axes</strong> — for non-gamified IPs (novels, films)</li>
+            </ul>
+            <p>
+              These three top-level keys are hashed into{" "}
+              <code>EVALUATOR_AXES</code>, <code>PROSPECT_EVALUATOR_AXES</code>,{" "}
+              and <code>ANALYST_SPECIFIC</code> entries in{" "}
+              <code>PROMPT_VERSIONS</code>. See{" "}
+              <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>.
+            </p>
+
+            <h2>Plugin contract</h2>
+            <p>
+              The plugin implements the <code>DomainPort</code> protocol from{" "}
+              <code>core/domains/port.py</code>:
+            </p>
+            <ul>
+              <li><code>get_pipeline()</code> — returns the LangGraph StateGraph</li>
+              <li><code>get_valid_axes_map()</code> — exposes axis keys per evaluator</li>
+              <li><code>load_ip_profile(ip_name)</code> — domain data lookup</li>
+            </ul>
+            <p>
+              The loader at <code>core/domains/loader.py</code> discovers plugins
+              in the <code>plugins/</code> namespace at startup.
+            </p>
+
+            <h2>CLI</h2>
+            <pre>{`# Dry-run (no LLM calls, returns fixture-based result)
+uv run geode analyze "Cowboy Bebop" --dry-run
+
+# Full run (requires API keys)
+uv run geode analyze "Berserk" --verbose`}</pre>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/quick-start/page.tsx
+++ b/site/src/app/docs/quick-start/page.tsx
@@ -1,37 +1,45 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Quick Start — GEODE Docs" };
 
 export default function Page() {
   return (
-    <DocsShell slug="quick-start" title="Quick Start" summary="Install, configure, and run GEODE in five minutes.">
-      <h2>Requirements</h2>
-      <ul>
-        <li>Python 3.12+</li>
-        <li><code>uv</code> package manager (<a href="https://docs.astral.sh/uv/">install</a>)</li>
-        <li>At least one provider API key (Anthropic, OpenAI, or GLM)</li>
-      </ul>
+    <DocsShell
+      slug="quick-start"
+      title="Quick Start"
+      titleKo="빠른 시작"
+      summary="Install, configure, and run GEODE in five minutes."
+      summaryKo="5분 안에 GEODE를 설치하고 설정한 뒤 실행합니다."
+    >
+      <Bi
+        ko={
+          <>
+            <h2>요구사항</h2>
+            <ul>
+              <li>Python 3.12 이상</li>
+              <li><code>uv</code> 패키지 매니저 (<a href="https://docs.astral.sh/uv/">설치 안내</a>)</li>
+              <li>최소 한 개의 프로바이더 API 키 (Anthropic, OpenAI 또는 GLM)</li>
+            </ul>
 
-      <h2>Install</h2>
-      <pre>{`git clone https://github.com/mangowhoiscloud/geode.git
+            <h2>설치</h2>
+            <pre>{`git clone https://github.com/mangowhoiscloud/geode.git
 cd geode
 uv sync
 uv tool install -e .`}</pre>
 
-      <h2>Configure</h2>
-      <p>
-        Provider API keys go into <code>~/.geode/config.toml</code> or
-        environment variables. The keys you need depend on which fallback
-        chain you want active:
-      </p>
-      <pre>{`export ANTHROPIC_API_KEY=sk-ant-...
+            <h2>설정</h2>
+            <p>
+              프로바이더 API 키는 <code>~/.geode/config.toml</code> 또는 환경 변수에
+              지정합니다. 활성화하려는 폴백 체인에 따라 필요한 키가 달라집니다.
+            </p>
+            <pre>{`export ANTHROPIC_API_KEY=sk-ant-...
 export OPENAI_API_KEY=sk-...
 export GLM_API_KEY=...           # optional, third fallback chain
 export LANGCHAIN_TRACING_V2=true # optional, opt-in tracing
 export LANGCHAIN_API_KEY=ls_...  # required if tracing enabled`}</pre>
 
-      <h2>Run</h2>
-      <pre>{`# Interactive REPL
+            <h2>실행</h2>
+            <pre>{`# Interactive REPL
 geode
 
 # One-shot natural language
@@ -47,27 +55,97 @@ geode analyze "Berserk" --verbose
 # Daemon mode (long-running, IPC-served)
 geode serve`}</pre>
 
-      <h2>What just happened</h2>
-      <p>
-        On <code>geode analyze ... --dry-run</code> the pipeline went through
-        every stage with mocked LLM responses from the fixture set:
-      </p>
-      <ol>
-        <li>Load IP profile from <code>plugins/game_ip/fixtures/</code></li>
-        <li>4 Analysts run in parallel (game_mechanics, player_experience, growth_potential, discovery)</li>
-        <li>3 Evaluators score (quality_judge, hidden_value, community_momentum)</li>
-        <li>BiasBuster validates with 6 bias checks</li>
-        <li>Synthesizer produces the cause-locked recommendation</li>
-        <li>PSM scoring (ATT, Z, Gamma) projects the final tier</li>
-      </ol>
+            <h2>방금 일어난 일</h2>
+            <p>
+              <code>geode analyze ... --dry-run</code>을 실행하면 픽스처 세트에서
+              모킹된 LLM 응답으로 파이프라인이 모든 단계를 거칩니다.
+            </p>
+            <ol>
+              <li><code>plugins/game_ip/fixtures/</code>에서 IP 프로필 로드</li>
+              <li>4개 Analyst를 병렬 실행 (game_mechanics, player_experience, growth_potential, discovery)</li>
+              <li>3개 Evaluator가 점수화 (quality_judge, hidden_value, community_momentum)</li>
+              <li>BiasBuster가 6종 편향 검사로 검증</li>
+              <li>Synthesizer가 원인 잠금형 권고안을 생성</li>
+              <li>PSM 점수 산정 (ATT, Z, Gamma)으로 최종 tier 산출</li>
+            </ol>
 
-      <h2>Next</h2>
-      <ul>
-        <li><a href="/geode/docs/architecture/overview">4-Layer Stack</a> — how the codebase is organized</li>
-        <li><a href="/geode/docs/architecture/system-index">System Index</a> — every subsystem with file paths</li>
-        <li><a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a> — the prompt assembly pipeline</li>
-        <li><a href="/geode/docs/plugins/game-ip">Game IP Plugin</a> — what the analyze command does</li>
-      </ul>
+            <h2>다음 단계</h2>
+            <ul>
+              <li><a href="/geode/docs/architecture/overview">4-계층 스택</a>. 코드베이스가 어떻게 구성되어 있는지 확인합니다.</li>
+              <li><a href="/geode/docs/architecture/system-index">시스템 색인</a>. 모든 서브시스템과 파일 경로를 정리합니다.</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-system">프롬프트 시스템</a>. 프롬프트 어셈블리 파이프라인을 살펴봅니다.</li>
+              <li><a href="/geode/docs/plugins/game-ip">Game IP 플러그인</a>. analyze 명령이 실제로 무엇을 하는지 보여줍니다.</li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>Requirements</h2>
+            <ul>
+              <li>Python 3.12+</li>
+              <li><code>uv</code> package manager (<a href="https://docs.astral.sh/uv/">install</a>)</li>
+              <li>At least one provider API key (Anthropic, OpenAI, or GLM)</li>
+            </ul>
+
+            <h2>Install</h2>
+            <pre>{`git clone https://github.com/mangowhoiscloud/geode.git
+cd geode
+uv sync
+uv tool install -e .`}</pre>
+
+            <h2>Configure</h2>
+            <p>
+              Provider API keys go into <code>~/.geode/config.toml</code> or
+              environment variables. The keys you need depend on which fallback
+              chain you want active:
+            </p>
+            <pre>{`export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GLM_API_KEY=...           # optional, third fallback chain
+export LANGCHAIN_TRACING_V2=true # optional, opt-in tracing
+export LANGCHAIN_API_KEY=ls_...  # required if tracing enabled`}</pre>
+
+            <h2>Run</h2>
+            <pre>{`# Interactive REPL
+geode
+
+# One-shot natural language
+geode "summarize the latest AI research trends"
+
+# Game IP plugin (dry-run, no API calls — uses fixtures)
+geode analyze "Cowboy Bebop" --dry-run
+# → A (68.4) — undermarketed
+
+# Game IP plugin (full run, requires API keys)
+geode analyze "Berserk" --verbose
+
+# Daemon mode (long-running, IPC-served)
+geode serve`}</pre>
+
+            <h2>What just happened</h2>
+            <p>
+              On <code>geode analyze ... --dry-run</code> the pipeline went through
+              every stage with mocked LLM responses from the fixture set:
+            </p>
+            <ol>
+              <li>Load IP profile from <code>plugins/game_ip/fixtures/</code></li>
+              <li>4 Analysts run in parallel (game_mechanics, player_experience, growth_potential, discovery)</li>
+              <li>3 Evaluators score (quality_judge, hidden_value, community_momentum)</li>
+              <li>BiasBuster validates with 6 bias checks</li>
+              <li>Synthesizer produces the cause-locked recommendation</li>
+              <li>PSM scoring (ATT, Z, Gamma) projects the final tier</li>
+            </ol>
+
+            <h2>Next</h2>
+            <ul>
+              <li><a href="/geode/docs/architecture/overview">4-Layer Stack</a> — how the codebase is organized</li>
+              <li><a href="/geode/docs/architecture/system-index">System Index</a> — every subsystem with file paths</li>
+              <li><a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a> — the prompt assembly pipeline</li>
+              <li><a href="/geode/docs/plugins/game-ip">Game IP Plugin</a> — what the analyze command does</li>
+            </ul>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/reference/changelog/page.tsx
+++ b/site/src/app/docs/reference/changelog/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Changelog — GEODE Docs" };
 
@@ -7,88 +7,179 @@ export default function Page() {
     <DocsShell
       slug="reference/changelog"
       title="Changelog"
+      titleKo="변경 이력"
       summary="Selected version highlights. The authoritative changelog is CHANGELOG.md in the repository."
+      summaryKo="선별된 버전 하이라이트. 정본 changelog는 저장소의 CHANGELOG.md입니다."
     >
-      <h2>v0.65.0 — 2026-05-02</h2>
-      <ul>
-        <li>
-          Anthropic 4-breakpoint prompt cache. <code>apply_messages_cache_control()</code> rolls
-          ephemeral markers across the last three non-system messages, complementing the existing
-          system block split (Hermes <code>system_and_3</code> parity).
-        </li>
-        <li>
-          <code>manage_login</code> verdict shadowing fix. Healthy PAYG / OAuth profiles no longer
-          appear as <code>provider_mismatch</code> in the dashboard; verdict aggregation now skips
-          cross-provider iterations, matching the filter <code>credential_breadcrumb</code> has
-          applied since v0.51.0.
-        </li>
-      </ul>
+      <Bi
+        ko={
+          <>
+            <h2>v0.65.0. 2026-05-02</h2>
+            <ul>
+              <li>
+                Anthropic 4-breakpoint 프롬프트 캐시. <code>apply_messages_cache_control()</code>이
+                직전 3개 non-system 메시지에 걸쳐 ephemeral 마커를 굴려, 기존 system 블록 분할
+                (Hermes <code>system_and_3</code> 등가)을 보완합니다.
+              </li>
+              <li>
+                <code>manage_login</code> verdict shadowing 수정. 정상 PAYG / OAuth 프로파일이
+                더 이상 대시보드에서 <code>provider_mismatch</code>로 표시되지 않습니다.
+                verdict 집계가 이제 cross-provider 반복을 건너뜁니다. v0.51.0부터
+                <code>credential_breadcrumb</code>이 적용해 온 필터와 일치합니다.
+              </li>
+            </ul>
 
-      <h2>v0.64.0 — 2026-04-29</h2>
-      <ul>
-        <li>
-          <strong>Plugin namespace split.</strong>{" "}
-          <code>core/domains/game_ip/</code> →{" "}
-          <code>plugins/game_ip/</code>. Hatch wheel ships both top-level
-          packages. 72 import statements rewritten across 36 files; quality
-          gates extended to cover <code>plugins/</code>.
-        </li>
-      </ul>
+            <h2>v0.64.0. 2026-04-29</h2>
+            <ul>
+              <li>
+                <strong>플러그인 네임스페이스 분리.</strong>{" "}
+                <code>core/domains/game_ip/</code> →{" "}
+                <code>plugins/game_ip/</code>. Hatch wheel이 두 최상위 패키지를 모두 출시합니다.
+                36개 파일에 걸쳐 72개 import 문이 재작성되었으며, 품질 게이트가
+                <code>plugins/</code>를 포함하도록 확장되었습니다.
+              </li>
+            </ul>
 
-      <h2>v0.63.0 — 2026-04-29</h2>
-      <ul>
-        <li>
-          <strong>Lifecycle commands.</strong> <code>/stop</code>,{" "}
-          <code>/clean</code>, <code>/uninstall</code>, <code>/status</code>{" "}
-          land alongside the existing slash commands.
-        </li>
-      </ul>
+            <h2>v0.63.0. 2026-04-29</h2>
+            <ul>
+              <li>
+                <strong>라이프사이클 명령어.</strong> <code>/stop</code>,{" "}
+                <code>/clean</code>, <code>/uninstall</code>, <code>/status</code>가 기존 슬래시
+                명령어와 함께 추가되었습니다.
+              </li>
+            </ul>
 
-      <h2>v0.62.0 — 2026-04-28</h2>
-      <ul>
-        <li>
-          <strong>Live test harness.</strong>{" "}
-          <code>tests/test_e2e_live_reasoning_depth.py</code> runs the
-          full pipeline against real providers (5 cases). Marker:{" "}
-          <code>-m live</code>; default-deselected.
-        </li>
-      </ul>
+            <h2>v0.62.0. 2026-04-28</h2>
+            <ul>
+              <li>
+                <strong>라이브 테스트 하네스.</strong>{" "}
+                <code>tests/test_e2e_live_reasoning_depth.py</code>가 실제 프로바이더 대상으로
+                전체 파이프라인을 실행합니다 (5 케이스). 마커는 <code>-m live</code>이며
+                기본 deselect됩니다.
+              </li>
+            </ul>
 
-      <h2>v0.60.0 — 2026-04-28</h2>
-      <ul>
-        <li>
-          <strong>R3-mini PAYG OpenAI Responses parity.</strong>{" "}
-          <code>include=[reasoning.encrypted_content]</code> +{" "}
-          <code>summary=&quot;auto&quot;</code> for gpt-5.x.
-        </li>
-      </ul>
+            <h2>v0.60.0. 2026-04-28</h2>
+            <ul>
+              <li>
+                <strong>R3-mini PAYG OpenAI Responses 등가.</strong>{" "}
+                gpt-5.x에 <code>include=[reasoning.encrypted_content]</code> +{" "}
+                <code>summary=&quot;auto&quot;</code>.
+              </li>
+            </ul>
 
-      <h2>v0.56.0 — 2026-04-26</h2>
-      <ul>
-        <li>
-          <strong>Anthropic adaptive thinking <code>xhigh</code> on Opus 4.7.</strong>{" "}
-          <code>output_config.effort=&quot;xhigh&quot;</code> +{" "}
-          <code>display=&quot;summarized&quot;</code> on Opus 4.7. Older
-          models downgrade to <code>max</code>.
-        </li>
-      </ul>
+            <h2>v0.56.0. 2026-04-26</h2>
+            <ul>
+              <li>
+                <strong>Opus 4.7의 Anthropic adaptive thinking <code>xhigh</code>.</strong>{" "}
+                Opus 4.7에서 <code>output_config.effort=&quot;xhigh&quot;</code> +{" "}
+                <code>display=&quot;summarized&quot;</code>. 구형 모델은 <code>max</code>로
+                downgrade됩니다.
+              </li>
+            </ul>
 
-      <h2>v0.50.x — Karpathy P4 ratchet</h2>
-      <ul>
-        <li>
-          <strong>Prompt hash ratchet introduced.</strong> 20{" "}
-          <code>_PINNED_HASHES</code> entries; CI breaks on drift. See{" "}
-          <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>.
-        </li>
-      </ul>
+            <h2>v0.50.x. Karpathy P4 ratchet</h2>
+            <ul>
+              <li>
+                <strong>프롬프트 해시 ratchet 도입.</strong> 20개 <code>_PINNED_HASHES</code>
+                엔트리. drift 발생 시 CI가 break합니다.
+                <a href="/geode/docs/runtime/llm/prompt-hashing">프롬프트 해싱</a>을 참고하세요.
+              </li>
+            </ul>
 
-      <h2>Authoritative source</h2>
-      <p>
-        <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code>{" "}
-        is the source of truth. This page is a curated highlight reel for
-        readers who want the shape of the project&apos;s evolution rather
-        than the per-feature granularity.
-      </p>
+            <h2>정본</h2>
+            <p>
+              <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code>가 진리원입니다.
+              이 페이지는 기능별 세부 단위가 아니라 프로젝트 진화의 형태를 보고 싶은 독자를 위한
+              선별된 하이라이트 모음입니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>v0.65.0 — 2026-05-02</h2>
+            <ul>
+              <li>
+                Anthropic 4-breakpoint prompt cache. <code>apply_messages_cache_control()</code> rolls
+                ephemeral markers across the last three non-system messages, complementing the existing
+                system block split (Hermes <code>system_and_3</code> parity).
+              </li>
+              <li>
+                <code>manage_login</code> verdict shadowing fix. Healthy PAYG / OAuth profiles no longer
+                appear as <code>provider_mismatch</code> in the dashboard; verdict aggregation now skips
+                cross-provider iterations, matching the filter <code>credential_breadcrumb</code> has
+                applied since v0.51.0.
+              </li>
+            </ul>
+
+            <h2>v0.64.0 — 2026-04-29</h2>
+            <ul>
+              <li>
+                <strong>Plugin namespace split.</strong>{" "}
+                <code>core/domains/game_ip/</code> →{" "}
+                <code>plugins/game_ip/</code>. Hatch wheel ships both top-level
+                packages. 72 import statements rewritten across 36 files; quality
+                gates extended to cover <code>plugins/</code>.
+              </li>
+            </ul>
+
+            <h2>v0.63.0 — 2026-04-29</h2>
+            <ul>
+              <li>
+                <strong>Lifecycle commands.</strong> <code>/stop</code>,{" "}
+                <code>/clean</code>, <code>/uninstall</code>, <code>/status</code>{" "}
+                land alongside the existing slash commands.
+              </li>
+            </ul>
+
+            <h2>v0.62.0 — 2026-04-28</h2>
+            <ul>
+              <li>
+                <strong>Live test harness.</strong>{" "}
+                <code>tests/test_e2e_live_reasoning_depth.py</code> runs the
+                full pipeline against real providers (5 cases). Marker:{" "}
+                <code>-m live</code>; default-deselected.
+              </li>
+            </ul>
+
+            <h2>v0.60.0 — 2026-04-28</h2>
+            <ul>
+              <li>
+                <strong>R3-mini PAYG OpenAI Responses parity.</strong>{" "}
+                <code>include=[reasoning.encrypted_content]</code> +{" "}
+                <code>summary=&quot;auto&quot;</code> for gpt-5.x.
+              </li>
+            </ul>
+
+            <h2>v0.56.0 — 2026-04-26</h2>
+            <ul>
+              <li>
+                <strong>Anthropic adaptive thinking <code>xhigh</code> on Opus 4.7.</strong>{" "}
+                <code>output_config.effort=&quot;xhigh&quot;</code> +{" "}
+                <code>display=&quot;summarized&quot;</code> on Opus 4.7. Older
+                models downgrade to <code>max</code>.
+              </li>
+            </ul>
+
+            <h2>v0.50.x — Karpathy P4 ratchet</h2>
+            <ul>
+              <li>
+                <strong>Prompt hash ratchet introduced.</strong> 20{" "}
+                <code>_PINNED_HASHES</code> entries; CI breaks on drift. See{" "}
+                <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>.
+              </li>
+            </ul>
+
+            <h2>Authoritative source</h2>
+            <p>
+              <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code>{" "}
+              is the source of truth. This page is a curated highlight reel for
+              readers who want the shape of the project&apos;s evolution rather
+              than the per-feature granularity.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/reference/frontier-comparison/page.tsx
+++ b/site/src/app/docs/reference/frontier-comparison/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Frontier Comparison — GEODE Docs" };
 
@@ -7,221 +7,439 @@ export default function Page() {
     <DocsShell
       slug="reference/frontier-comparison"
       title="Frontier Comparison"
+      titleKo="프론티어 비교"
       summary="GEODE side-by-side with five frontier harnesses — Hermes, OpenClaw, Claude Code, Codex CLI, and Karpathy autoresearch — first at the architectural level, then drilling into prompt-system internals."
+      summaryKo="GEODE를 다섯 frontier 하네스 (Hermes, OpenClaw, Claude Code, Codex CLI, Karpathy autoresearch)와 나란히 비교. 먼저 아키텍처 수준, 이후 프롬프트 시스템 내부로 파고듭니다."
     >
-      <h2>System-level positioning</h2>
-      <p>
-        Top-level differences across six harnesses. GEODE is the synthesis —
-        each row borrows from at least one frontier system. Patterns specifically
-        cited in source: Claude Code <code>while(tool_use)</code>, Codex CLI
-        sandbox-default, OpenClaw <code>Policy Chain</code> + <code>Lane Queue</code>,
-        Karpathy P1-P10.
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th>Axis</th>
-            <th>Claude Code</th>
-            <th>Codex CLI</th>
-            <th>OpenClaw</th>
-            <th>Hermes</th>
-            <th>autoresearch</th>
-            <th>GEODE</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Purpose</td>
-            <td>Coding assist</td>
-            <td>Code automation</td>
-            <td>Multi-channel gateway</td>
-            <td>Self-learning agent</td>
-            <td>Autonomous ML loop</td>
-            <td><strong>Long-running autonomous execution</strong></td>
-          </tr>
-          <tr>
-            <td>Domain</td>
-            <td>code</td>
-            <td>code</td>
-            <td>chat routing</td>
-            <td>open-domain</td>
-            <td>ML loop</td>
-            <td>game IP (today), generalisable via DomainPort</td>
-          </tr>
-          <tr>
-            <td>Main primitive</td>
-            <td><code>while(tool_use)</code></td>
-            <td>sandbox + approve</td>
-            <td>gateway + lane</td>
-            <td>skill loop</td>
-            <td>branchless dumb platform</td>
-            <td>StateGraph + agentic loop</td>
-          </tr>
-          <tr>
-            <td>Memory</td>
-            <td>bash session + <code>~/.claude</code></td>
-            <td>—</td>
-            <td>per-channel store</td>
-            <td>persistent + skill catalog</td>
-            <td><code>program.md</code></td>
-            <td>5-tier (Org / Project / Session / Vault / Breadcrumb)</td>
-          </tr>
-          <tr>
-            <td>Verification</td>
-            <td>—</td>
-            <td>sandbox</td>
-            <td>policy chain</td>
-            <td>—</td>
-            <td>ratchet</td>
-            <td><strong>G1-G4 + BiasBuster + Cross-LLM</strong></td>
-          </tr>
-          <tr>
-            <td>Automation trigger</td>
-            <td>hooks (manual)</td>
-            <td>—</td>
-            <td>cron + standing orders</td>
-            <td>skill auto-generate</td>
-            <td>overnight loop</td>
-            <td>58 events + scheduler</td>
-          </tr>
-          <tr>
-            <td>Multi-LLM</td>
-            <td>Anthropic only</td>
-            <td>OpenAI only</td>
-            <td>8+ providers</td>
-            <td>Anthropic-centric</td>
-            <td>(single)</td>
-            <td>4 providers (Anthropic + Codex + PAYG + GLM)</td>
-          </tr>
-          <tr>
-            <td>Sub-agent</td>
-            <td>Task tool</td>
-            <td>—</td>
-            <td>plugin</td>
-            <td>spawn + announce</td>
-            <td>—</td>
-            <td>Borrowed (Task tool + OpenClaw Spawn+Announce)</td>
-          </tr>
-          <tr>
-            <td>Sandbox</td>
-            <td>—</td>
-            <td>OS-level</td>
-            <td>gateway isolation</td>
-            <td>—</td>
-            <td>constraint loop</td>
-            <td>6-layer Policy Chain</td>
-          </tr>
-        </tbody>
-      </table>
+      <Bi
+        ko={
+          <>
+            <h2>시스템 수준 포지셔닝</h2>
+            <p>
+              6개 하네스에 걸친 최상위 차이. GEODE는 종합입니다. 각 행은 최소 하나의 frontier
+              시스템에서 빌려옵니다. 소스에 명시적으로 인용된 패턴은 다음과 같습니다.
+              Claude Code <code>while(tool_use)</code>, Codex CLI sandbox-default, OpenClaw
+              <code>Policy Chain</code> + <code>Lane Queue</code>, Karpathy P1-P10.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>축</th>
+                  <th>Claude Code</th>
+                  <th>Codex CLI</th>
+                  <th>OpenClaw</th>
+                  <th>Hermes</th>
+                  <th>autoresearch</th>
+                  <th>GEODE</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>목적</td>
+                  <td>Coding assist</td>
+                  <td>Code automation</td>
+                  <td>Multi-channel gateway</td>
+                  <td>Self-learning agent</td>
+                  <td>Autonomous ML loop</td>
+                  <td><strong>장기 실행 자율 실행</strong></td>
+                </tr>
+                <tr>
+                  <td>도메인</td>
+                  <td>code</td>
+                  <td>code</td>
+                  <td>chat routing</td>
+                  <td>open-domain</td>
+                  <td>ML loop</td>
+                  <td>game IP (현재), DomainPort 통해 일반화 가능</td>
+                </tr>
+                <tr>
+                  <td>주요 기본 단위</td>
+                  <td><code>while(tool_use)</code></td>
+                  <td>sandbox + approve</td>
+                  <td>gateway + lane</td>
+                  <td>skill loop</td>
+                  <td>branchless dumb platform</td>
+                  <td>StateGraph + agentic 루프</td>
+                </tr>
+                <tr>
+                  <td>메모리</td>
+                  <td>bash 세션 + <code>~/.claude</code></td>
+                  <td>—</td>
+                  <td>채널별 저장소</td>
+                  <td>persistent + skill 카탈로그</td>
+                  <td><code>program.md</code></td>
+                  <td>5계층 (Org / Project / Session / Vault / Breadcrumb)</td>
+                </tr>
+                <tr>
+                  <td>검증</td>
+                  <td>—</td>
+                  <td>sandbox</td>
+                  <td>policy chain</td>
+                  <td>—</td>
+                  <td>ratchet</td>
+                  <td><strong>G1-G4 + BiasBuster + Cross-LLM</strong></td>
+                </tr>
+                <tr>
+                  <td>자동화 트리거</td>
+                  <td>훅 (수동)</td>
+                  <td>—</td>
+                  <td>cron + standing order</td>
+                  <td>skill auto-generate</td>
+                  <td>overnight 루프</td>
+                  <td>58 이벤트 + 스케줄러</td>
+                </tr>
+                <tr>
+                  <td>멀티 LLM</td>
+                  <td>Anthropic only</td>
+                  <td>OpenAI only</td>
+                  <td>8+ providers</td>
+                  <td>Anthropic-centric</td>
+                  <td>(single)</td>
+                  <td>4 프로바이더 (Anthropic + Codex + PAYG + GLM)</td>
+                </tr>
+                <tr>
+                  <td>서브 에이전트</td>
+                  <td>Task tool</td>
+                  <td>—</td>
+                  <td>plugin</td>
+                  <td>spawn + announce</td>
+                  <td>—</td>
+                  <td>차용 (Task tool + OpenClaw Spawn+Announce)</td>
+                </tr>
+                <tr>
+                  <td>샌드박스</td>
+                  <td>—</td>
+                  <td>OS 수준</td>
+                  <td>gateway 격리</td>
+                  <td>—</td>
+                  <td>제약 루프</td>
+                  <td>6계층 Policy Chain</td>
+                </tr>
+              </tbody>
+            </table>
 
-      <h3>What GEODE has that none of the others do</h3>
-      <ul>
-        <li>
-          <strong>BiasBuster</strong> — confirmation / recency / anchoring /
-          position / verbosity / self-enhancement bias detection in{" "}
-          <code>core/verification/biasbuster.py</code>. Statistical fast path
-          (CV-based) plus LLM fallback.
-        </li>
-        <li>
-          <strong>Cause-Action decision tree</strong> — 6 causes →
-          5 actions in <code>plugins/game_ip/nodes/synthesizer.py</code>.
-          Domain-pluggable.
-        </li>
-        <li>
-          <strong>Calibration via Golden Set</strong> —
-          <code>core/verification/calibration.py</code>, fixture comparison
-          PASS threshold 80.0.
-        </li>
-        <li>
-          <strong>Equivalence-class fallback</strong> — provider variants
-          (e.g. <code>openai-codex</code> ↔ <code>openai</code> PAYG) auto-tried
-          in subscription-priority order via{" "}
-          <code>core/auth/plan_registry.py:resolve_routing</code>.
-        </li>
-        <li>
-          <strong>ChatGPT Plus JWT verification</strong> — auth claim{" "}
-          <code>chatgpt_plan_type</code> extracted at OAuth time and embedded in
-          the Plan record (<code>core/auth/oauth_login.py:331</code>); no
-          separate API call needed for entitlement check.
-        </li>
-      </ul>
+            <h3>GEODE만이 가진 것</h3>
+            <ul>
+              <li>
+                <strong>BiasBuster</strong>. confirmation, recency, anchoring, position, verbosity,
+                self-enhancement 편향 검출이 <code>core/verification/biasbuster.py</code>에 있습니다.
+                통계 fast path (CV 기반)와 LLM 폴백.
+              </li>
+              <li>
+                <strong>Cause-Action 결정 트리</strong>. 6 cause → 5 action이
+                <code>plugins/game_ip/nodes/synthesizer.py</code>에 있습니다. 도메인 플러그인 가능.
+              </li>
+              <li>
+                <strong>Golden Set 기반 캘리브레이션</strong>.
+                <code>core/verification/calibration.py</code>, 픽스처 비교 PASS 임계값 80.0.
+              </li>
+              <li>
+                <strong>Equivalence-class 폴백</strong>. 프로바이더 변형 (예)
+                <code>openai-codex</code> ↔ <code>openai</code> PAYG)이 구독 우선순위 순서대로
+                자동 시도됩니다. <code>core/auth/plan_registry.py:resolve_routing</code> 경유.
+              </li>
+              <li>
+                <strong>ChatGPT Plus JWT 검증</strong>. auth claim <code>chatgpt_plan_type</code>이
+                OAuth 시점에 추출되어 Plan 레코드에 임베드됩니다
+                (<code>core/auth/oauth_login.py:331</code>). 엔타이틀먼트 확인에 별도 API 호출이
+                필요 없습니다.
+              </li>
+            </ul>
 
-      <h2>Definition layer</h2>
-      <table>
-        <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
-        <tbody>
-          <tr><td>Source location</td><td><code>core/llm/prompts/*.md</code></td><td><code>agent/prompt_builder.py</code> (Python const)</td><td><code>src/agents/system-prompt.ts</code> (TS const)</td><td><code>constants/prompts.ts</code> (TS const)</td></tr>
-          <tr><td>Build time</td><td>Module import</td><td>Session start (cached)</td><td>Per-call modular</td><td>Per-turn dynamic</td></tr>
-          <tr><td>User memory</td><td>5-tier <code>~/.geode/memory/</code></td><td>Frozen JSON snapshot</td><td>Workspace HEARTBEAT.md</td><td>CLAUDE.md (4-tier)</td></tr>
-        </tbody>
-      </table>
+            <h2>정의 계층</h2>
+            <table>
+              <thead><tr><th>축</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>소스 위치</td><td><code>core/llm/prompts/*.md</code></td><td><code>agent/prompt_builder.py</code> (Python const)</td><td><code>src/agents/system-prompt.ts</code> (TS const)</td><td><code>constants/prompts.ts</code> (TS const)</td></tr>
+                <tr><td>빌드 시점</td><td>모듈 임포트</td><td>세션 시작 (캐시)</td><td>호출별 모듈식</td><td>턴별 동적</td></tr>
+                <tr><td>사용자 메모리</td><td>5계층 <code>~/.geode/memory/</code></td><td>Frozen JSON 스냅샷</td><td>Workspace HEARTBEAT.md</td><td>CLAUDE.md (4계층)</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Assembly</h2>
-      <table>
-        <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
-        <tbody>
-          <tr><td>Result type</td><td><code>AssembledPrompt(frozen=True)</code></td><td><code>str</code> cached</td><td>String returned</td><td><code>TextBlockParam[]</code></td></tr>
-          <tr><td>Override policy</td><td>Append-only by default</td><td>Append via param</td><td>Append via param</td><td>5-priority chain</td></tr>
-          <tr><td>Skill format</td><td>Markdown blocks</td><td>XML <code>&lt;available_skills&gt;</code></td><td>XML <code>&lt;available_skills&gt;</code></td><td>XML registry</td></tr>
-          <tr><td>Truncation event log</td><td><code>truncation_events</code> in hook</td><td>Logger only</td><td>Report object</td><td>Not tracked</td></tr>
-        </tbody>
-      </table>
+            <h2>어셈블리</h2>
+            <table>
+              <thead><tr><th>축</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>결과 타입</td><td><code>AssembledPrompt(frozen=True)</code></td><td><code>str</code> 캐시됨</td><td>String 반환</td><td><code>TextBlockParam[]</code></td></tr>
+                <tr><td>오버라이드 정책</td><td>기본 append-only</td><td>파라미터로 append</td><td>파라미터로 append</td><td>5단계 우선순위 체인</td></tr>
+                <tr><td>스킬 포맷</td><td>Markdown 블록</td><td>XML <code>&lt;available_skills&gt;</code></td><td>XML <code>&lt;available_skills&gt;</code></td><td>XML 레지스트리</td></tr>
+                <tr><td>Truncation 이벤트 로그</td><td>훅의 <code>truncation_events</code></td><td>로거만</td><td>Report 객체</td><td>추적 안 함</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Hashing &amp; integrity</h2>
-      <table>
-        <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
-        <tbody>
-          <tr><td>Algorithm</td><td>SHA-256[:12]</td><td>None</td><td>SHA-256 (full)</td><td>SHA-256[:3]</td></tr>
-          <tr><td>Pin / CI gate</td><td><strong>Yes</strong> — <code>_PINNED_HASHES</code> × 20</td><td>None</td><td>Detection only</td><td>None (attribution only)</td></tr>
-          <tr><td>Normalization</td><td>UTF-8 / json sort_keys</td><td>mtime + size manifest</td><td>CRLF strip + sort + lowercase</td><td>(model, toolNames, sysLen) tuple</td></tr>
-        </tbody>
-      </table>
+            <h2>해싱 및 무결성</h2>
+            <table>
+              <thead><tr><th>축</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>알고리즘</td><td>SHA-256[:12]</td><td>None</td><td>SHA-256 (전체)</td><td>SHA-256[:3]</td></tr>
+                <tr><td>핀 / CI 게이트</td><td><strong>예</strong>. <code>_PINNED_HASHES</code> × 20</td><td>None</td><td>탐지만</td><td>None (attribution만)</td></tr>
+                <tr><td>정규화</td><td>UTF-8 / json sort_keys</td><td>mtime + size manifest</td><td>CRLF strip + sort + lowercase</td><td>(model, toolNames, sysLen) tuple</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Caching</h2>
-      <table>
-        <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
-        <tbody>
-          <tr><td>Anthropic ephemeral</td><td>Yes — system + STATIC/DYNAMIC</td><td>Yes — system_and_3</td><td>Yes — boundary marker</td><td>Yes — global/org scope</td></tr>
-          <tr><td>Boundary marker</td><td><code>__GEODE_PROMPT_CACHE_BOUNDARY__</code></td><td>None</td><td><code>&lt;!-- OPENCLAW_CACHE_BOUNDARY --&gt;</code></td><td><code>__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__</code></td></tr>
-          <tr><td>Messages history cache</td><td>No (open GAP)</td><td>Yes — last 3</td><td>Yes — last user message</td><td>Yes — last user blocks</td></tr>
-          <tr><td>Breakpoints used / 4</td><td>1-2</td><td>4</td><td>2-3</td><td>3-4</td></tr>
-        </tbody>
-      </table>
+            <h2>캐싱</h2>
+            <table>
+              <thead><tr><th>축</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Anthropic ephemeral</td><td>예. system + STATIC/DYNAMIC</td><td>예. system_and_3</td><td>예. 경계 마커</td><td>예. global/org scope</td></tr>
+                <tr><td>경계 마커</td><td><code>__GEODE_PROMPT_CACHE_BOUNDARY__</code></td><td>None</td><td><code>&lt;!-- OPENCLAW_CACHE_BOUNDARY --&gt;</code></td><td><code>__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__</code></td></tr>
+                <tr><td>메시지 히스토리 캐시</td><td>No (오픈 GAP)</td><td>예. 직전 3</td><td>예. 직전 user 메시지</td><td>예. 직전 user 블록</td></tr>
+                <tr><td>사용 breakpoint / 4</td><td>1-2</td><td>4</td><td>2-3</td><td>3-4</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Observability</h2>
-      <table>
-        <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
-        <tbody>
-          <tr><td>Primary channel</td><td><code>PROMPT_ASSEMBLED</code> hook payload</td><td>60-char preview log</td><td><code>cache-trace.ts</code> JSONL</td><td><code>logEvent('tengu_*')</code> telemetry</td></tr>
-          <tr><td>External tracing</td><td>LangSmith opt-in</td><td>None</td><td>Self JSONL</td><td>Self telemetry</td></tr>
-          <tr><td>Prompt text in trace</td><td>Hashes only</td><td>Stored in session DB</td><td>Hashes by default</td><td>Not in telemetry</td></tr>
-        </tbody>
-      </table>
+            <h2>관측성</h2>
+            <table>
+              <thead><tr><th>축</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>주 채널</td><td><code>PROMPT_ASSEMBLED</code> 훅 payload</td><td>60자 preview 로그</td><td><code>cache-trace.ts</code> JSONL</td><td><code>logEvent('tengu_*')</code> 텔레메트리</td></tr>
+                <tr><td>외부 트레이싱</td><td>LangSmith opt-in</td><td>None</td><td>자체 JSONL</td><td>자체 텔레메트리</td></tr>
+                <tr><td>트레이스의 프롬프트 텍스트</td><td>해시만</td><td>세션 DB에 저장</td><td>기본은 해시</td><td>텔레메트리에 없음</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Security</h2>
-      <table>
-        <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
-        <tbody>
-          <tr><td>Prompt-injection scan</td><td>None (open GAP)</td><td><strong>11 patterns</strong> + invisible Unicode</td><td>Path/URL sanitization</td><td>Trusts user intent</td></tr>
-          <tr><td>Frozen result</td><td><code>frozen=True</code></td><td>Convention</td><td>Convention</td><td>Convention</td></tr>
-          <tr><td>Override security</td><td>Append-only by default</td><td>Append-only</td><td>Append-only</td><td>Priority chain</td></tr>
-        </tbody>
-      </table>
+            <h2>보안</h2>
+            <table>
+              <thead><tr><th>축</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>프롬프트 인젝션 스캔</td><td>없음 (오픈 GAP)</td><td><strong>11 패턴</strong> + invisible Unicode</td><td>경로 / URL 정화</td><td>사용자 의도 신뢰</td></tr>
+                <tr><td>Frozen 결과</td><td><code>frozen=True</code></td><td>관례</td><td>관례</td><td>관례</td></tr>
+                <tr><td>오버라이드 보안</td><td>기본 append-only</td><td>append-only</td><td>append-only</td><td>우선순위 체인</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Why GEODE was the only one to ratchet</h2>
-      <p>
-        GEODE&apos;s prompts live in markdown files. Hermes, OpenClaw, and
-        Claude Code keep prompts as inline strings inside their respective
-        TypeScript or Python source. Inline strings are subject to
-        autoformatter noise, IDE renames, and merge-conflict resolutions in
-        ways that fight a hashlib-based ratchet. External markdown makes the
-        file the unit of change, and the hash becomes meaningful.
-      </p>
-      <p>
-        The cost: GEODE pays one extra step (the re-pin) for every
-        intentional prompt change, but gets a CI-enforced guarantee that
-        unintentional changes never ship.
-      </p>
+            <h2>왜 GEODE만이 ratchet으로 갈 수 있었나</h2>
+            <p>
+              GEODE의 프롬프트는 markdown 파일에 살고 있습니다. Hermes, OpenClaw, Claude Code는
+              프롬프트를 각각 TypeScript 또는 Python 소스 내부의 인라인 문자열로 유지합니다.
+              인라인 문자열은 자동 포맷터 노이즈, IDE 리네임, 머지 충돌 해소 과정에서
+              hashlib 기반 ratchet과 싸우게 됩니다. 외부 markdown은 파일을 변경 단위로 만들고,
+              그래서 해시가 의미를 갖게 됩니다.
+            </p>
+            <p>
+              비용은 이렇습니다. GEODE는 의도된 프롬프트 변경 시 한 단계 (재핀)를 더 지불하지만,
+              그 대가로 의도하지 않은 변경이 절대 출시되지 않는다는 CI 강제 보장을 얻습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>System-level positioning</h2>
+            <p>
+              Top-level differences across six harnesses. GEODE is the synthesis —
+              each row borrows from at least one frontier system. Patterns specifically
+              cited in source: Claude Code <code>while(tool_use)</code>, Codex CLI
+              sandbox-default, OpenClaw <code>Policy Chain</code> + <code>Lane Queue</code>,
+              Karpathy P1-P10.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Axis</th>
+                  <th>Claude Code</th>
+                  <th>Codex CLI</th>
+                  <th>OpenClaw</th>
+                  <th>Hermes</th>
+                  <th>autoresearch</th>
+                  <th>GEODE</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Purpose</td>
+                  <td>Coding assist</td>
+                  <td>Code automation</td>
+                  <td>Multi-channel gateway</td>
+                  <td>Self-learning agent</td>
+                  <td>Autonomous ML loop</td>
+                  <td><strong>Long-running autonomous execution</strong></td>
+                </tr>
+                <tr>
+                  <td>Domain</td>
+                  <td>code</td>
+                  <td>code</td>
+                  <td>chat routing</td>
+                  <td>open-domain</td>
+                  <td>ML loop</td>
+                  <td>game IP (today), generalisable via DomainPort</td>
+                </tr>
+                <tr>
+                  <td>Main primitive</td>
+                  <td><code>while(tool_use)</code></td>
+                  <td>sandbox + approve</td>
+                  <td>gateway + lane</td>
+                  <td>skill loop</td>
+                  <td>branchless dumb platform</td>
+                  <td>StateGraph + agentic loop</td>
+                </tr>
+                <tr>
+                  <td>Memory</td>
+                  <td>bash session + <code>~/.claude</code></td>
+                  <td>—</td>
+                  <td>per-channel store</td>
+                  <td>persistent + skill catalog</td>
+                  <td><code>program.md</code></td>
+                  <td>5-tier (Org / Project / Session / Vault / Breadcrumb)</td>
+                </tr>
+                <tr>
+                  <td>Verification</td>
+                  <td>—</td>
+                  <td>sandbox</td>
+                  <td>policy chain</td>
+                  <td>—</td>
+                  <td>ratchet</td>
+                  <td><strong>G1-G4 + BiasBuster + Cross-LLM</strong></td>
+                </tr>
+                <tr>
+                  <td>Automation trigger</td>
+                  <td>hooks (manual)</td>
+                  <td>—</td>
+                  <td>cron + standing orders</td>
+                  <td>skill auto-generate</td>
+                  <td>overnight loop</td>
+                  <td>58 events + scheduler</td>
+                </tr>
+                <tr>
+                  <td>Multi-LLM</td>
+                  <td>Anthropic only</td>
+                  <td>OpenAI only</td>
+                  <td>8+ providers</td>
+                  <td>Anthropic-centric</td>
+                  <td>(single)</td>
+                  <td>4 providers (Anthropic + Codex + PAYG + GLM)</td>
+                </tr>
+                <tr>
+                  <td>Sub-agent</td>
+                  <td>Task tool</td>
+                  <td>—</td>
+                  <td>plugin</td>
+                  <td>spawn + announce</td>
+                  <td>—</td>
+                  <td>Borrowed (Task tool + OpenClaw Spawn+Announce)</td>
+                </tr>
+                <tr>
+                  <td>Sandbox</td>
+                  <td>—</td>
+                  <td>OS-level</td>
+                  <td>gateway isolation</td>
+                  <td>—</td>
+                  <td>constraint loop</td>
+                  <td>6-layer Policy Chain</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>What GEODE has that none of the others do</h3>
+            <ul>
+              <li>
+                <strong>BiasBuster</strong> — confirmation / recency / anchoring /
+                position / verbosity / self-enhancement bias detection in{" "}
+                <code>core/verification/biasbuster.py</code>. Statistical fast path
+                (CV-based) plus LLM fallback.
+              </li>
+              <li>
+                <strong>Cause-Action decision tree</strong> — 6 causes →
+                5 actions in <code>plugins/game_ip/nodes/synthesizer.py</code>.
+                Domain-pluggable.
+              </li>
+              <li>
+                <strong>Calibration via Golden Set</strong> —
+                <code>core/verification/calibration.py</code>, fixture comparison
+                PASS threshold 80.0.
+              </li>
+              <li>
+                <strong>Equivalence-class fallback</strong> — provider variants
+                (e.g. <code>openai-codex</code> ↔ <code>openai</code> PAYG) auto-tried
+                in subscription-priority order via{" "}
+                <code>core/auth/plan_registry.py:resolve_routing</code>.
+              </li>
+              <li>
+                <strong>ChatGPT Plus JWT verification</strong> — auth claim{" "}
+                <code>chatgpt_plan_type</code> extracted at OAuth time and embedded in
+                the Plan record (<code>core/auth/oauth_login.py:331</code>); no
+                separate API call needed for entitlement check.
+              </li>
+            </ul>
+
+            <h2>Definition layer</h2>
+            <table>
+              <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Source location</td><td><code>core/llm/prompts/*.md</code></td><td><code>agent/prompt_builder.py</code> (Python const)</td><td><code>src/agents/system-prompt.ts</code> (TS const)</td><td><code>constants/prompts.ts</code> (TS const)</td></tr>
+                <tr><td>Build time</td><td>Module import</td><td>Session start (cached)</td><td>Per-call modular</td><td>Per-turn dynamic</td></tr>
+                <tr><td>User memory</td><td>5-tier <code>~/.geode/memory/</code></td><td>Frozen JSON snapshot</td><td>Workspace HEARTBEAT.md</td><td>CLAUDE.md (4-tier)</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Assembly</h2>
+            <table>
+              <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Result type</td><td><code>AssembledPrompt(frozen=True)</code></td><td><code>str</code> cached</td><td>String returned</td><td><code>TextBlockParam[]</code></td></tr>
+                <tr><td>Override policy</td><td>Append-only by default</td><td>Append via param</td><td>Append via param</td><td>5-priority chain</td></tr>
+                <tr><td>Skill format</td><td>Markdown blocks</td><td>XML <code>&lt;available_skills&gt;</code></td><td>XML <code>&lt;available_skills&gt;</code></td><td>XML registry</td></tr>
+                <tr><td>Truncation event log</td><td><code>truncation_events</code> in hook</td><td>Logger only</td><td>Report object</td><td>Not tracked</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Hashing &amp; integrity</h2>
+            <table>
+              <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Algorithm</td><td>SHA-256[:12]</td><td>None</td><td>SHA-256 (full)</td><td>SHA-256[:3]</td></tr>
+                <tr><td>Pin / CI gate</td><td><strong>Yes</strong> — <code>_PINNED_HASHES</code> × 20</td><td>None</td><td>Detection only</td><td>None (attribution only)</td></tr>
+                <tr><td>Normalization</td><td>UTF-8 / json sort_keys</td><td>mtime + size manifest</td><td>CRLF strip + sort + lowercase</td><td>(model, toolNames, sysLen) tuple</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Caching</h2>
+            <table>
+              <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Anthropic ephemeral</td><td>Yes — system + STATIC/DYNAMIC</td><td>Yes — system_and_3</td><td>Yes — boundary marker</td><td>Yes — global/org scope</td></tr>
+                <tr><td>Boundary marker</td><td><code>__GEODE_PROMPT_CACHE_BOUNDARY__</code></td><td>None</td><td><code>&lt;!-- OPENCLAW_CACHE_BOUNDARY --&gt;</code></td><td><code>__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__</code></td></tr>
+                <tr><td>Messages history cache</td><td>No (open GAP)</td><td>Yes — last 3</td><td>Yes — last user message</td><td>Yes — last user blocks</td></tr>
+                <tr><td>Breakpoints used / 4</td><td>1-2</td><td>4</td><td>2-3</td><td>3-4</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Observability</h2>
+            <table>
+              <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Primary channel</td><td><code>PROMPT_ASSEMBLED</code> hook payload</td><td>60-char preview log</td><td><code>cache-trace.ts</code> JSONL</td><td><code>logEvent('tengu_*')</code> telemetry</td></tr>
+                <tr><td>External tracing</td><td>LangSmith opt-in</td><td>None</td><td>Self JSONL</td><td>Self telemetry</td></tr>
+                <tr><td>Prompt text in trace</td><td>Hashes only</td><td>Stored in session DB</td><td>Hashes by default</td><td>Not in telemetry</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Security</h2>
+            <table>
+              <thead><tr><th>Axis</th><th>GEODE</th><th>Hermes</th><th>OpenClaw</th><th>Claude Code</th></tr></thead>
+              <tbody>
+                <tr><td>Prompt-injection scan</td><td>None (open GAP)</td><td><strong>11 patterns</strong> + invisible Unicode</td><td>Path/URL sanitization</td><td>Trusts user intent</td></tr>
+                <tr><td>Frozen result</td><td><code>frozen=True</code></td><td>Convention</td><td>Convention</td><td>Convention</td></tr>
+                <tr><td>Override security</td><td>Append-only by default</td><td>Append-only</td><td>Append-only</td><td>Priority chain</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Why GEODE was the only one to ratchet</h2>
+            <p>
+              GEODE&apos;s prompts live in markdown files. Hermes, OpenClaw, and
+              Claude Code keep prompts as inline strings inside their respective
+              TypeScript or Python source. Inline strings are subject to
+              autoformatter noise, IDE renames, and merge-conflict resolutions in
+              ways that fight a hashlib-based ratchet. External markdown makes the
+              file the unit of change, and the hash becomes meaningful.
+            </p>
+            <p>
+              The cost: GEODE pays one extra step (the re-pin) for every
+              intentional prompt change, but gets a CI-enforced guarantee that
+              unintentional changes never ship.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/reference/sot-metrics/page.tsx
+++ b/site/src/app/docs/reference/sot-metrics/page.tsx
@@ -1,0 +1,81 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+import { GEODE_SOT } from "@/data/geode/sot";
+
+export const metadata = { title: "System Metrics SOT — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="reference/sot-metrics"
+      title="System Metrics SOT"
+      titleKo="시스템 메트릭 SOT"
+      summary="Live values for version, modules, tests, releases, since."
+      summaryKo="version, 모듈, 테스트, 릴리스, since 라이브 값."
+    >
+      <Bi
+        ko={
+          <>
+            <p><strong>Reference:</strong> 사이트 전체가 인용하는 단일 진실 원천(SOT) 값입니다. <code>site/scripts/sync-stats.mjs</code>가 GEODE repo의 <code>pyproject.toml</code> + 파일시스템 + <code>CHANGELOG.md</code>를 읽어 자동 갱신합니다.</p>
+
+            <h2>현재 값 (사이트 빌드 시점)</h2>
+            <table>
+              <thead><tr><th>키</th><th>값</th></tr></thead>
+              <tbody>
+                <tr><td>version</td><td><code>{GEODE_SOT.version}</code></td></tr>
+                <tr><td>modules.core</td><td><code>{GEODE_SOT.modules.core}</code></td></tr>
+                <tr><td>modules.plugins</td><td><code>{GEODE_SOT.modules.plugins}</code></td></tr>
+                <tr><td>modules.total</td><td><code>{GEODE_SOT.modules.total}</code></td></tr>
+                <tr><td>tests.standard</td><td><code>{GEODE_SOT.tests.standard.toLocaleString()}</code></td></tr>
+                <tr><td>tests.live</td><td><code>{GEODE_SOT.tests.live}</code></td></tr>
+                <tr><td>releases</td><td><code>{GEODE_SOT.releases}</code></td></tr>
+                <tr><td>since</td><td><code>{GEODE_SOT.since}</code></td></tr>
+                <tr><td>syncedAt</td><td><code>{GEODE_SOT.syncedAt}</code></td></tr>
+              </tbody>
+            </table>
+
+            <h2>갱신 방법</h2>
+            <pre>{`cd site && npm run sync-stats`}</pre>
+            <p>출력 파일: <code>site/src/data/geode/sot.ts</code></p>
+
+            <h2>왜 SOT 인가</h2>
+            <p>이전 버전 (basePath /portfolio)에서는 페이지마다 메트릭이 하드코딩돼 있었고, 그 결과 사이트가 본 코드베이스보다 24 minor 버전 뒤처져 있었습니다. SOT 자동 sync가 그 갭을 0으로 만듭니다.</p>
+
+            <h2>CI 게이트 (계획)</h2>
+            <p>Pages workflow에 <code>npm run sync-stats</code>를 build step에 두어, 매 deploy마다 최신 값을 확보합니다. 추후 PR 시점에 SOT diff 가 발생하면 자동으로 commit하는 path도 검토 중.</p>
+          </>
+        }
+        en={
+          <>
+            <p><strong>Reference:</strong> the single source of truth values cited site-wide. <code>site/scripts/sync-stats.mjs</code> reads the GEODE repo's <code>pyproject.toml</code>, filesystem, and <code>CHANGELOG.md</code> to refresh them automatically.</p>
+
+            <h2>Current values (at site build time)</h2>
+            <table>
+              <thead><tr><th>Key</th><th>Value</th></tr></thead>
+              <tbody>
+                <tr><td>version</td><td><code>{GEODE_SOT.version}</code></td></tr>
+                <tr><td>modules.core</td><td><code>{GEODE_SOT.modules.core}</code></td></tr>
+                <tr><td>modules.plugins</td><td><code>{GEODE_SOT.modules.plugins}</code></td></tr>
+                <tr><td>modules.total</td><td><code>{GEODE_SOT.modules.total}</code></td></tr>
+                <tr><td>tests.standard</td><td><code>{GEODE_SOT.tests.standard.toLocaleString()}</code></td></tr>
+                <tr><td>tests.live</td><td><code>{GEODE_SOT.tests.live}</code></td></tr>
+                <tr><td>releases</td><td><code>{GEODE_SOT.releases}</code></td></tr>
+                <tr><td>since</td><td><code>{GEODE_SOT.since}</code></td></tr>
+                <tr><td>syncedAt</td><td><code>{GEODE_SOT.syncedAt}</code></td></tr>
+              </tbody>
+            </table>
+
+            <h2>How to refresh</h2>
+            <pre>{`cd site && npm run sync-stats`}</pre>
+            <p>Output file: <code>site/src/data/geode/sot.ts</code>.</p>
+
+            <h2>Why an SOT</h2>
+            <p>Earlier (basePath /portfolio), each page hardcoded metrics, leaving the site 24 minor versions behind the codebase. Automatic SOT sync brings that drift to zero.</p>
+
+            <h2>CI gate (planned)</h2>
+            <p>The Pages workflow runs <code>npm run sync-stats</code> as a build step so every deploy carries fresh values. A PR-time auto-commit on SOT diff is under consideration.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/analyze/page.tsx
+++ b/site/src/app/docs/run/analyze/page.tsx
@@ -1,0 +1,72 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Run an Analysis — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/analyze"
+      title="Run an Analysis"
+      titleKo="분석 실행"
+      summary="Run the Game IP pipeline end to end, dry-run or live."
+      summaryKo="Game IP 파이프라인을 dry-run 또는 라이브로 끝까지 돌리기."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE의 첫 도메인 플러그인인 Game IP 분석 파이프라인을 한 번 끝까지 실행합니다.</p>
+
+            <h2>Dry-run (API 호출 없음)</h2>
+            <pre>{`uv run geode analyze "Cowboy Bebop" --dry-run
+# → A (68.4) — undermarketed`}</pre>
+            <p>고정된 3 fixture (Berserk·Cowboy Bebop·Ghost in the Shell)로 파이프라인 전체를 통과시킵니다. 비용 0.</p>
+
+            <h2>Live run</h2>
+            <pre>{`uv run geode analyze "Berserk" --verbose`}</pre>
+            <p>실제 LLM 호출이 발생합니다. 비용 가드는 <a href="/docs/ops/cost">비용 모니터링</a>에서 설정하세요.</p>
+
+            <h2>출력 구조</h2>
+            <ul>
+              <li>점수: 14축 PSM scoring → 최종 tier (S/A/B/C/D)</li>
+              <li>원인: 6 카테고리 중 분류 (예: undermarketed, conversion_failure, discovery_failure)</li>
+              <li>전체 reasoning trail: hooks + runlog</li>
+            </ul>
+
+            <h2>다음</h2>
+            <ul>
+              <li>점수 의미: <a href="/docs/plugins/game-ip">Game IP 플러그인</a></li>
+              <li>다른 도메인 추가: <a href="/docs/build/add-domain">도메인 플러그인 추가</a></li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <p>This guide runs GEODE's first domain plugin, the Game IP valuation pipeline, end to end.</p>
+
+            <h2>Dry-run (no API calls)</h2>
+            <pre>{`uv run geode analyze "Cowboy Bebop" --dry-run
+# → A (68.4) — undermarketed`}</pre>
+            <p>Three fixed fixtures (Berserk, Cowboy Bebop, Ghost in the Shell) exercise the full pipeline at zero cost.</p>
+
+            <h2>Live run</h2>
+            <pre>{`uv run geode analyze "Berserk" --verbose`}</pre>
+            <p>Real LLM calls. Configure cost guards in <a href="/docs/ops/cost">Cost Monitoring</a>.</p>
+
+            <h2>Output shape</h2>
+            <ul>
+              <li>Score: 14-axis PSM scoring leading to a tier (S/A/B/C/D).</li>
+              <li>Cause: one of six classes (undermarketed, conversion_failure, discovery_failure, …).</li>
+              <li>Full reasoning trail via hooks and runlog.</li>
+            </ul>
+
+            <h2>Next</h2>
+            <ul>
+              <li>What the scores mean: <a href="/docs/plugins/game-ip">Game IP Plugin</a>.</li>
+              <li>Add another domain: <a href="/docs/build/add-domain">Add a Domain Plugin</a>.</li>
+            </ul>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/messaging/page.tsx
+++ b/site/src/app/docs/run/messaging/page.tsx
@@ -1,0 +1,68 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Messaging Integrations — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/messaging"
+      title="Messaging Integrations"
+      titleKo="메신저 연동"
+      summary="Hook GEODE into Slack, Discord, or Telegram via gateway adapters."
+      summaryKo="게이트웨이 어댑터로 Slack, Discord, Telegram에 연결."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE의 gateway 어댑터를 통해 Slack·Discord·Telegram 등 메신저에 연결하는 절차입니다.</p>
+
+            <h2>지원 채널</h2>
+            <ul>
+              <li>Slack (Slash command + thread)</li>
+              <li>Discord (slash command)</li>
+              <li>Telegram (bot API)</li>
+            </ul>
+
+            <h2>Slack 예시</h2>
+            <pre>{`# config.toml
+[gateway.slack]
+bot_token = "xoxb-..."
+signing_secret = "..."
+channels = ["#geode"]`}</pre>
+            <p>설정 후 <code>geode serve</code> 재시작하면 자동 binding 됩니다.</p>
+
+            <h2>커스텀 어댑터</h2>
+            <p>새 메신저를 붙이려면 <code>core/gateway/</code>의 base adapter를 구현하세요. 자세한 절차는 <a href="/docs/build/add-tool">도구 추가하기</a>를 참조.</p>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-gateway.md, geode-serve skill</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide wires GEODE to messengers (Slack, Discord, Telegram) through gateway adapters.</p>
+
+            <h2>Supported channels</h2>
+            <ul>
+              <li>Slack (slash command + thread)</li>
+              <li>Discord (slash command)</li>
+              <li>Telegram (bot API)</li>
+            </ul>
+
+            <h2>Slack example</h2>
+            <pre>{`# config.toml
+[gateway.slack]
+bot_token = "xoxb-..."
+signing_secret = "..."
+channels = ["#geode"]`}</pre>
+            <p>After saving, restart <code>geode serve</code> to bind.</p>
+
+            <h2>Custom adapter</h2>
+            <p>To support a new messenger, implement the base adapter under <code>core/gateway/</code>. See <a href="/docs/build/add-tool">Add a Tool</a> for the general pattern.</p>
+
+            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-gateway.md, geode-serve skill.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/pick-path/page.tsx
+++ b/site/src/app/docs/run/pick-path/page.tsx
@@ -1,0 +1,64 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Pick a Path — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/pick-path"
+      title="Pick a Path"
+      titleKo="경로 선택"
+      summary="Subscription, API key, or free path. How to choose for your situation."
+      summaryKo="구독, API 키, 무료 경로 중 본인 상황에 맞춰 고르는 법."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE를 어떤 LLM 경로로 돌릴지 5분 안에 결정하도록 돕습니다.</p>
+
+            <h2>세 경로</h2>
+            <table>
+              <thead><tr><th>경로</th><th>적합한 상황</th><th>주의</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Path A. 구독 (ChatGPT Plus·Pro·Team·Business·Edu)</strong></td><td>이미 ChatGPT 결제 중. API 키 따로 만들기 싫음.</td><td>gpt-5.5는 구독 전용. Codex CLI 경유. ChatGPT Team은 미지원.</td></tr>
+                <tr><td><strong>Path B. API 키</strong></td><td>Anthropic·OpenAI·GLM 키 보유. 비용 통제 중요.</td><td>Anthropic Claude Pro/Max OAuth는 정책상 사용 금지 (2026-01-09 ToS).</td></tr>
+                <tr><td><strong>Path C. 무료/오픈</strong></td><td>GLM-4.7-flash 등 무료 티어로 dry-run만.</td><td>품질·rate limit 보장 없음. 학습용으로만.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>다음</h2>
+            <ul>
+              <li><a href="/docs/run/providers">프로바이더 설정</a>으로 키를 등록합니다.</li>
+              <li>비용 가드는 <a href="/docs/ops/cost">비용 모니터링</a>에서.</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>출처:</em> 본 repo README §Path A/B + wiki/concepts/geode-llm-models.md</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide helps you choose which LLM path to run GEODE on, in five minutes.</p>
+
+            <h2>Three paths</h2>
+            <table>
+              <thead><tr><th>Path</th><th>When it fits</th><th>Caveats</th></tr></thead>
+              <tbody>
+                <tr><td><strong>A. Subscription (ChatGPT Plus/Pro/Team/Business/Edu)</strong></td><td>Already paying ChatGPT. Don't want a separate API key.</td><td>gpt-5.5 is subscription-only via Codex CLI. ChatGPT Team is not supported.</td></tr>
+                <tr><td><strong>B. API key</strong></td><td>You hold Anthropic, OpenAI, or GLM keys. Cost control matters.</td><td>Anthropic Claude Pro/Max OAuth is policy-forbidden (2026-01-09 ToS).</td></tr>
+                <tr><td><strong>C. Free / open</strong></td><td>GLM-4.7-flash and similar free tiers, dry-run only.</td><td>Quality and rate limits not guaranteed. Learning only.</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Next</h2>
+            <ul>
+              <li>Register your keys: <a href="/docs/run/providers">Configure Providers</a>.</li>
+              <li>Cost guards live in <a href="/docs/ops/cost">Cost Monitoring</a>.</li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>Source:</em> repo README §Path A/B and wiki/concepts/geode-llm-models.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/providers/page.tsx
+++ b/site/src/app/docs/run/providers/page.tsx
@@ -1,0 +1,58 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Configure Providers — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/providers"
+      title="Configure Providers"
+      titleKo="프로바이더 설정"
+      summary="Anthropic, OpenAI, Codex, GLM. Where keys go, what fallback chain you get."
+      summaryKo="Anthropic, OpenAI, Codex, GLM. 키를 어디에 두고 어떤 폴백 체인이 동작하는지."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 4 프로바이더 키를 GEODE에 등록하는 방법과, 키 조합이 만들어내는 폴백 체인을 보여줍니다.</p>
+
+            <h2>키 위치</h2>
+            <p>다음 두 곳 중 한 곳에 두면 GEODE가 자동으로 인식합니다.</p>
+            <ul>
+              <li>환경 변수: <code>ANTHROPIC_API_KEY</code>, <code>OPENAI_API_KEY</code>, <code>GLM_API_KEY</code></li>
+              <li>설정 파일: <code>~/.geode/config.toml</code></li>
+            </ul>
+
+            <h2>폴백 체인</h2>
+            <p>키 조합에 따라 활성화되는 fallback chain은 <code>core/llm/providers/</code>의 라우터가 결정합니다.</p>
+            <p className="text-white/40"><em>TODO: chain 표. Source: wiki/concepts/geode-llm-models.md, wiki/concepts/geode-tool-routing.md</em></p>
+
+            <h2>검증</h2>
+            <pre>{`uv run geode "확인용 한 줄"`}</pre>
+            <p>위 명령이 정상 응답하면 키가 잡힌 것입니다.</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide registers your provider keys with GEODE and shows the fallback chains each combination unlocks.</p>
+
+            <h2>Where keys go</h2>
+            <p>GEODE picks up keys from either location automatically.</p>
+            <ul>
+              <li>Environment variables: <code>ANTHROPIC_API_KEY</code>, <code>OPENAI_API_KEY</code>, <code>GLM_API_KEY</code></li>
+              <li>Config file: <code>~/.geode/config.toml</code></li>
+            </ul>
+
+            <h2>Fallback chains</h2>
+            <p>The router in <code>core/llm/providers/</code> selects the chain based on which keys are present.</p>
+            <p className="text-white/40"><em>TODO: chain table. Source: wiki/concepts/geode-llm-models.md, wiki/concepts/geode-tool-routing.md.</em></p>
+
+            <h2>Verify</h2>
+            <pre>{`uv run geode "hello"`}</pre>
+            <p>If GEODE responds, your keys are wired up.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/schedule/page.tsx
+++ b/site/src/app/docs/run/schedule/page.tsx
@@ -1,0 +1,66 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Schedule Tasks — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/schedule"
+      title="Schedule Tasks"
+      titleKo="작업 예약"
+      summary="Natural language plus cron, with jitter. Daily reports as a single command."
+      summaryKo="자연어와 cron, jitter 포함. 일일 리포트를 한 줄 명령으로."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE에 반복 작업을 예약하는 두 가지 방식 (자연어 / cron)을 보여줍니다.</p>
+
+            <h2>자연어로 예약</h2>
+            <pre>{`uv run geode "매일 아침 9시에 IT 트렌드 요약 보내줘"`}</pre>
+            <p>GEODE가 자연어를 파싱해 cron + jitter를 자동으로 설정합니다.</p>
+
+            <h2>명시적 cron</h2>
+            <pre>{`uv run geode schedule add \\
+  --cron "0 9 * * *" \\
+  --jitter 600 \\
+  "summarize today's AI news"`}</pre>
+
+            <h2>예약 작업 관리</h2>
+            <ul>
+              <li>목록: <code>geode schedule list</code></li>
+              <li>삭제: <code>geode schedule remove &lt;id&gt;</code></li>
+              <li>일시정지: <code>geode schedule pause &lt;id&gt;</code></li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/docs/runtime/scheduler">Scheduler reference</a>, wiki/concepts/geode-lifecycle-commands.md</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide schedules recurring tasks in GEODE via natural language or explicit cron.</p>
+
+            <h2>Natural language</h2>
+            <pre>{`uv run geode "every weekday at 9am, send me an AI news summary"`}</pre>
+            <p>GEODE parses the phrase and sets a cron plus jitter automatically.</p>
+
+            <h2>Explicit cron</h2>
+            <pre>{`uv run geode schedule add \\
+  --cron "0 9 * * *" \\
+  --jitter 600 \\
+  "summarize today's AI news"`}</pre>
+
+            <h2>Manage scheduled tasks</h2>
+            <ul>
+              <li>List: <code>geode schedule list</code></li>
+              <li>Remove: <code>geode schedule remove &lt;id&gt;</code></li>
+              <li>Pause: <code>geode schedule pause &lt;id&gt;</code></li>
+            </ul>
+
+            <p className="text-white/40 text-sm"><em>See:</em> <a href="/docs/runtime/scheduler">Scheduler reference</a>, wiki/concepts/geode-lifecycle-commands.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/serve/page.tsx
+++ b/site/src/app/docs/run/serve/page.tsx
@@ -1,0 +1,80 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Run as Daemon — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/serve"
+      title="Run as Daemon"
+      titleKo="데몬으로 실행"
+      summary="Start serve, restart, stop. Thin CLI on top of an IPC-served runtime."
+      summaryKo="serve 시작·재시작·종료. IPC 데몬 위에 thin CLI."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE를 백그라운드 데몬으로 띄워, thin CLI가 IPC로 붙는 운영 모드를 설정합니다.</p>
+
+            <h2>시작</h2>
+            <pre>{`uv run geode serve &`}</pre>
+            <p>처음 <code>geode</code> 명령을 치면 자동으로 daemon이 부팅됩니다. 별도 호출은 명시 운영 때만 필요합니다.</p>
+
+            <h2>재시작</h2>
+            <pre>{`# 1) 기존 데몬 종료
+kill $(ps aux | grep "geode serve" | grep -v grep | awk '{print $2}')
+
+# 2) 의존성 + CLI 재설치 후 재기동
+uv tool install -e . --force
+uv sync
+geode serve &`}</pre>
+
+            <h2>종료</h2>
+            <ul>
+              <li>graceful: <code>geode /stop</code></li>
+              <li>강제: <code>kill -9 &lt;pid&gt;</code> (마지막 수단)</li>
+            </ul>
+
+            <h2>상태 확인</h2>
+            <pre>{`geode /status     # 헬스 + 활성 세션 목록
+geode /model      # 현재 활성 모델
+geode /clean      # 캐시 비우기`}</pre>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/docs/harness/lifecycle">Lifecycle reference</a>, wiki/concepts/geode-lifecycle-commands.md</p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide starts GEODE as a background daemon, with the thin CLI attaching over IPC.</p>
+
+            <h2>Start</h2>
+            <pre>{`uv run geode serve &`}</pre>
+            <p>The first <code>geode</code> invocation auto-boots the daemon. Explicit serve is only for operational restarts.</p>
+
+            <h2>Restart</h2>
+            <pre>{`# 1) Kill the running daemon
+kill $(ps aux | grep "geode serve" | grep -v grep | awk '{print $2}')
+
+# 2) Reinstall and restart
+uv tool install -e . --force
+uv sync
+geode serve &`}</pre>
+
+            <h2>Stop</h2>
+            <ul>
+              <li>Graceful: <code>geode /stop</code></li>
+              <li>Hard: <code>kill -9 &lt;pid&gt;</code> (last resort)</li>
+            </ul>
+
+            <h2>Status</h2>
+            <pre>{`geode /status     # health + active session list
+geode /model      # current active model
+geode /clean      # clear caches`}</pre>
+
+            <p className="text-white/40 text-sm"><em>See:</em> <a href="/docs/harness/lifecycle">Lifecycle reference</a>, wiki/concepts/geode-lifecycle-commands.md.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/run/troubleshooting/page.tsx
+++ b/site/src/app/docs/run/troubleshooting/page.tsx
@@ -1,0 +1,72 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Troubleshooting — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="run/troubleshooting"
+      title="Troubleshooting"
+      titleKo="문제 해결"
+      summary="Common failure modes and where to look. Logs, hooks, runlog."
+      summaryKo="흔한 실패 모드와 살펴볼 곳. 로그, 훅, runlog."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 가이드는 GEODE를 돌릴 때 자주 만나는 5가지 실패 모드와 1차 진단 위치를 정리합니다.</p>
+
+            <h2>흔한 실패</h2>
+            <table>
+              <thead><tr><th>증상</th><th>1차 확인</th></tr></thead>
+              <tbody>
+                <tr><td>"키가 없어요" 에러</td><td><code>echo $ANTHROPIC_API_KEY</code>와 <code>~/.geode/config.toml</code></td></tr>
+                <tr><td>"context overflow" 종료</td><td><a href="/docs/ops/long-running">장기 실행 안전</a> 가이드</td></tr>
+                <tr><td>"MCP server timeout"</td><td><code>geode /status</code>로 MCP 헬스 확인</td></tr>
+                <tr><td>토큰 비용 초과</td><td><a href="/docs/ops/cost">비용 모니터링</a> + <code>geode /model</code>로 다운그레이드</td></tr>
+                <tr><td>OAuth 토큰 만료</td><td><a href="/docs/ops/oauth">OAuth 토큰 회전</a></td></tr>
+              </tbody>
+            </table>
+
+            <h2>로그 위치</h2>
+            <ul>
+              <li>Runlog: <code>~/.geode/runlog/</code> (run 단위 trace)</li>
+              <li>Hooks: <a href="/docs/harness/hooks">Hook System</a> events</li>
+              <li>Serve: <code>~/.geode/serve.log</code></li>
+            </ul>
+
+            <h2>지원</h2>
+            <p>해결이 안 되면 GitHub Issues에 runlog 일부와 함께 등록: <code>github.com/mangowhoiscloud/geode/issues</code></p>
+          </>
+        }
+        en={
+          <>
+            <p>This guide lists five common failure modes and where to start diagnosing each.</p>
+
+            <h2>Common failures</h2>
+            <table>
+              <thead><tr><th>Symptom</th><th>First look</th></tr></thead>
+              <tbody>
+                <tr><td>"missing key" error</td><td><code>echo $ANTHROPIC_API_KEY</code> and <code>~/.geode/config.toml</code></td></tr>
+                <tr><td>"context overflow" termination</td><td><a href="/docs/ops/long-running">Long-running Safety</a></td></tr>
+                <tr><td>"MCP server timeout"</td><td><code>geode /status</code> for MCP health</td></tr>
+                <tr><td>Token cost overrun</td><td><a href="/docs/ops/cost">Cost Monitoring</a> + <code>geode /model</code> to downgrade</td></tr>
+                <tr><td>OAuth token expired</td><td><a href="/docs/ops/oauth">OAuth Token Rotation</a></td></tr>
+              </tbody>
+            </table>
+
+            <h2>Where logs live</h2>
+            <ul>
+              <li>Runlog: <code>~/.geode/runlog/</code> (per-run traces)</li>
+              <li>Hooks: <a href="/docs/harness/hooks">Hook System</a> events</li>
+              <li>Serve: <code>~/.geode/serve.log</code></li>
+            </ul>
+
+            <h2>Support</h2>
+            <p>If you're stuck, file an issue with a runlog excerpt: <code>github.com/mangowhoiscloud/geode/issues</code>.</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/runtime/auth/page.tsx
+++ b/site/src/app/docs/runtime/auth/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Auth & OAuth — GEODE Docs" };
 
@@ -7,31 +7,36 @@ export default function Page() {
     <DocsShell
       slug="runtime/auth"
       title="Auth & OAuth"
+      titleKo="인증과 OAuth"
       summary="14 modules in core/auth/ — profile rotator, OAuth flows, credential resolution. Anthropic OAuth disabled per ToS; OpenAI Codex Plus active."
+      summaryKo="core/auth/의 14개 모듈. 프로파일 로테이터, OAuth 플로우, 자격 증명 해석. Anthropic OAuth는 ToS에 따라 비활성. OpenAI Codex Plus는 활성."
     >
-      <h2>The two paths</h2>
-      <ol>
-        <li><strong>API key</strong> — env vars or <code>~/.geode/config.toml</code>. Always available.</li>
-        <li><strong>OAuth (subscription)</strong> — for OpenAI Codex Plus. Triggered by interactive login flow.</li>
-      </ol>
+      <Bi
+        ko={
+          <>
+            <h2>두 가지 경로</h2>
+            <ol>
+              <li><strong>API 키</strong>. 환경 변수 또는 <code>~/.geode/config.toml</code>. 항상 사용 가능.</li>
+              <li><strong>OAuth (구독)</strong>. OpenAI Codex Plus용. 대화형 로그인 흐름으로 트리거.</li>
+            </ol>
 
-      <h2>Anthropic OAuth — disabled</h2>
-      <p>
-        Anthropic&apos;s ToS prohibits OAuth-based programmatic access for
-        non-application accounts. GEODE explicitly disables this path. Users
-        on Anthropic must use API keys.
-      </p>
+            <h2>Anthropic OAuth. 비활성</h2>
+            <p>
+              Anthropic의 ToS는 비-애플리케이션 계정에 대한 OAuth 기반 프로그래밍
+              접근을 금지합니다. GEODE는 이 경로를 명시적으로 비활성화합니다.
+              Anthropic 사용자는 API 키를 사용해야 합니다.
+            </p>
 
-      <h2>Profile rotator</h2>
-      <p>
-        Multiple OpenAI/GLM credential profiles can coexist. The profile
-        rotator picks a profile per call, rotating on rate-limit or auth
-        failures. This is the foundation that lets fallback chains span
-        provider boundaries safely.
-      </p>
+            <h2>프로파일 로테이터</h2>
+            <p>
+              여러 OpenAI/GLM 자격 증명 프로파일이 공존할 수 있습니다. 프로파일
+              로테이터는 호출마다 프로파일을 선택하며, rate-limit이나 인증 실패
+              시 회전시킵니다. 이것이 폴백 체인이 프로바이더 경계를 안전하게
+              넘나들 수 있게 해주는 토대입니다.
+            </p>
 
-      <h2>Credential resolution</h2>
-      <pre>{`# core/llm/credentials.py
+            <h2>자격 증명 해석</h2>
+            <pre>{`# core/llm/credentials.py
 def resolve_provider_key(provider: str, fallback: str | None = None) -> str:
     """OAuth-preferred resolution.
 
@@ -40,20 +45,72 @@ def resolve_provider_key(provider: str, fallback: str | None = None) -> str:
            fallback param →
            empty string."""`}</pre>
 
-      <h2>Files</h2>
-      <ul>
-        <li><code>core/auth/</code> — 14 modules</li>
-        <li><code>core/llm/credentials.py</code> — provider key resolution</li>
-        <li><code>core/cli/auth_commands.py</code> — login/logout/status slash commands</li>
-      </ul>
+            <h2>파일</h2>
+            <ul>
+              <li><code>core/auth/</code>. 14개 모듈.</li>
+              <li><code>core/llm/credentials.py</code>. 프로바이더 키 해석.</li>
+              <li><code>core/cli/auth_commands.py</code>. login/logout/status 슬래시 명령.</li>
+            </ul>
 
-      <h2>Storage</h2>
-      <p>
-        OAuth tokens land in <code>~/.geode/auth/profiles/&lt;name&gt;.json</code>{" "}
-        with file-mode 600. Refresh tokens are rotated on expiry; the
-        rotator is responsible for catching 401s and forcing refresh
-        before retry.
-      </p>
+            <h2>저장</h2>
+            <p>
+              OAuth 토큰은 파일 모드 600으로{" "}
+              <code>~/.geode/auth/profiles/&lt;name&gt;.json</code>에 저장됩니다.
+              리프레시 토큰은 만료 시 회전되며, 401을 포착해 재시도 전에 강제
+              갱신하는 책임은 로테이터에 있습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The two paths</h2>
+            <ol>
+              <li><strong>API key</strong> — env vars or <code>~/.geode/config.toml</code>. Always available.</li>
+              <li><strong>OAuth (subscription)</strong> — for OpenAI Codex Plus. Triggered by interactive login flow.</li>
+            </ol>
+
+            <h2>Anthropic OAuth — disabled</h2>
+            <p>
+              Anthropic&apos;s ToS prohibits OAuth-based programmatic access for
+              non-application accounts. GEODE explicitly disables this path. Users
+              on Anthropic must use API keys.
+            </p>
+
+            <h2>Profile rotator</h2>
+            <p>
+              Multiple OpenAI/GLM credential profiles can coexist. The profile
+              rotator picks a profile per call, rotating on rate-limit or auth
+              failures. This is the foundation that lets fallback chains span
+              provider boundaries safely.
+            </p>
+
+            <h2>Credential resolution</h2>
+            <pre>{`# core/llm/credentials.py
+def resolve_provider_key(provider: str, fallback: str | None = None) -> str:
+    """OAuth-preferred resolution.
+
+    Order: ProfileRotator (active OAuth profile) →
+           settings.<provider>_api_key →
+           fallback param →
+           empty string."""`}</pre>
+
+            <h2>Files</h2>
+            <ul>
+              <li><code>core/auth/</code> — 14 modules</li>
+              <li><code>core/llm/credentials.py</code> — provider key resolution</li>
+              <li><code>core/cli/auth_commands.py</code> — login/logout/status slash commands</li>
+            </ul>
+
+            <h2>Storage</h2>
+            <p>
+              OAuth tokens land in <code>~/.geode/auth/profiles/&lt;name&gt;.json</code>{" "}
+              with file-mode 600. Refresh tokens are rotated on expiry; the
+              rotator is responsible for catching 401s and forcing refresh
+              before retry.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/automation/page.tsx
+++ b/site/src/app/docs/runtime/automation/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Automation (L4.5) — GEODE Docs" };
 
@@ -7,55 +7,113 @@ export default function Page() {
     <DocsShell
       slug="runtime/automation"
       title="Automation (L4.5 Feedback Loop)"
+      titleKo="자동화 (L4.5 피드백 루프)"
       summary="Drift detection, model promotion, expert panel voting. The half-layer between agent and runtime that keeps the system improving over time."
+      summaryKo="drift 감지, 모델 프로모션, 전문가 패널 투표. 시간이 지나면서 시스템이 계속 개선되도록 에이전트와 런타임 사이에 자리한 0.5 계층."
     >
-      <h2>Why L4.5</h2>
-      <p>
-        Agents (L4) execute. Runtime (L2) provides infrastructure. L4.5 is
-        the meta layer that watches outcomes and rotates the underlying
-        runtime — promoting better models, deprecating drifted ones,
-        collecting expert feedback.
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>왜 L4.5인가</h2>
+            <p>
+              에이전트(L4)는 실행합니다. 런타임(L2)은 인프라를 제공합니다. L4.5는
+              결과를 관찰하고 그 아래 런타임을 회전시키는 메타 계층입니다. 더 나은
+              모델을 승격시키고, drift된 모델을 deprecate하고, 전문가 피드백을
+              수집합니다.
+            </p>
 
-      <h2>Files</h2>
-      <ul>
-        <li><code>core/automation/model_registry.py:36</code> — <code>class PromotionStage</code> (development, staging, production)</li>
-        <li><code>core/automation/feedback_loop.py</code> — phase FSM</li>
-        <li><code>core/automation/drift_detector.py</code> — correlation + severity analysis</li>
-        <li><code>core/automation/expert_panel.py</code> — junior/senior/principal voting tiers</li>
-      </ul>
+            <h2>파일</h2>
+            <ul>
+              <li><code>core/automation/model_registry.py:36</code>. <code>class PromotionStage</code> (development, staging, production).</li>
+              <li><code>core/automation/feedback_loop.py</code>. phase FSM.</li>
+              <li><code>core/automation/drift_detector.py</code>. correlation 및 severity 분석.</li>
+              <li><code>core/automation/expert_panel.py</code>. junior/senior/principal 투표 티어.</li>
+            </ul>
 
-      <h2>Promotion stages</h2>
-      <pre>{`development → staging → production
+            <h2>프로모션 단계</h2>
+            <pre>{`development → staging → production
    ↑              ↑              │
    │              │              ▼
    └──────────────┴──── drift detected → rollback`}</pre>
 
-      <h2>Drift detection</h2>
-      <p>
-        Drift severity is graded <code>low</code> /{" "}
-        <code>medium</code> / <code>high</code> / <code>critical</code>.
-        Critical drift on a production model triggers immediate rollback to
-        the previous staging snapshot. Lower severity records a metric and
-        waits for the expert panel.
-      </p>
+            <h2>drift 감지</h2>
+            <p>
+              drift 심각도는 <code>low</code> /{" "}
+              <code>medium</code> / <code>high</code> / <code>critical</code>로
+              등급화됩니다. production 모델의 critical drift는 즉시 이전 staging
+              스냅샷으로 롤백을 트리거합니다. 더 낮은 심각도는 메트릭으로
+              기록되고 전문가 패널을 기다립니다.
+            </p>
 
-      <h2>Expert panel voting</h2>
-      <p>
-        When a model output is contested, a virtual expert panel (junior,
-        senior, principal tiers) votes on whether the output should be
-        accepted. Votes are weighted by tier and the result feeds back to
-        the model registry.
-      </p>
+            <h2>전문가 패널 투표</h2>
+            <p>
+              모델 출력에 이의가 제기되면 가상 전문가 패널 (junior, senior,
+              principal 티어)이 출력 수용 여부에 투표합니다. 표는 티어로 가중치가
+              매겨지고 결과는 모델 레지스트리로 피드백됩니다.
+            </p>
 
-      <h2>Hook events fired</h2>
-      <ul>
-        <li><code>DRIFT_DETECTED</code></li>
-        <li><code>MODEL_PROMOTED</code></li>
-        <li><code>OUTCOME_COLLECTED</code></li>
-        <li><code>EXPERT_VOTE_CAST</code></li>
-        <li><code>FEEDBACK_PHASE_CHANGED</code></li>
-      </ul>
+            <h2>발화되는 훅 이벤트</h2>
+            <ul>
+              <li><code>DRIFT_DETECTED</code></li>
+              <li><code>MODEL_PROMOTED</code></li>
+              <li><code>OUTCOME_COLLECTED</code></li>
+              <li><code>EXPERT_VOTE_CAST</code></li>
+              <li><code>FEEDBACK_PHASE_CHANGED</code></li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>Why L4.5</h2>
+            <p>
+              Agents (L4) execute. Runtime (L2) provides infrastructure. L4.5 is
+              the meta layer that watches outcomes and rotates the underlying
+              runtime — promoting better models, deprecating drifted ones,
+              collecting expert feedback.
+            </p>
+
+            <h2>Files</h2>
+            <ul>
+              <li><code>core/automation/model_registry.py:36</code> — <code>class PromotionStage</code> (development, staging, production)</li>
+              <li><code>core/automation/feedback_loop.py</code> — phase FSM</li>
+              <li><code>core/automation/drift_detector.py</code> — correlation + severity analysis</li>
+              <li><code>core/automation/expert_panel.py</code> — junior/senior/principal voting tiers</li>
+            </ul>
+
+            <h2>Promotion stages</h2>
+            <pre>{`development → staging → production
+   ↑              ↑              │
+   │              │              ▼
+   └──────────────┴──── drift detected → rollback`}</pre>
+
+            <h2>Drift detection</h2>
+            <p>
+              Drift severity is graded <code>low</code> /{" "}
+              <code>medium</code> / <code>high</code> / <code>critical</code>.
+              Critical drift on a production model triggers immediate rollback to
+              the previous staging snapshot. Lower severity records a metric and
+              waits for the expert panel.
+            </p>
+
+            <h2>Expert panel voting</h2>
+            <p>
+              When a model output is contested, a virtual expert panel (junior,
+              senior, principal tiers) votes on whether the output should be
+              accepted. Votes are weighted by tier and the result feeds back to
+              the model registry.
+            </p>
+
+            <h2>Hook events fired</h2>
+            <ul>
+              <li><code>DRIFT_DETECTED</code></li>
+              <li><code>MODEL_PROMOTED</code></li>
+              <li><code>OUTCOME_COLLECTED</code></li>
+              <li><code>EXPERT_VOTE_CAST</code></li>
+              <li><code>FEEDBACK_PHASE_CHANGED</code></li>
+            </ul>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/computer-use/page.tsx
+++ b/site/src/app/docs/runtime/computer-use/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Computer Use — GEODE Docs" };
 
@@ -7,52 +7,106 @@ export default function Page() {
     <DocsShell
       slug="runtime/computer-use"
       title="Computer Use"
+      titleKo="컴퓨터 사용"
       summary="Provider-agnostic desktop automation. PyAutoGUI backend, screenshot + click + type primitives, opt-in via tool registry."
+      summaryKo="프로바이더 독립 데스크탑 자동화. PyAutoGUI 백엔드, screenshot + click + type 기본 동작, 도구 레지스트리를 통한 opt-in 활성화."
     >
-      <h2>Two backends, one interface</h2>
-      <p>
-        Anthropic&apos;s computer-use API and OpenAI&apos;s computer-use
-        beta are different protocols with similar primitives. GEODE
-        wraps both behind a single tool definition (
-        <code>computer</code>) and routes to the appropriate provider
-        backend based on the active model.
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>두 백엔드, 하나의 인터페이스</h2>
+            <p>
+              Anthropic의 computer-use API와 OpenAI의 computer-use 베타는 비슷한
+              기본 동작을 가진 서로 다른 프로토콜입니다. GEODE는 둘 모두를 단일
+              도구 정의 (<code>computer</code>) 뒤로 감싸고, 활성 모델에 따라 적절한
+              프로바이더 백엔드로 라우팅합니다.
+            </p>
 
-      <h2>Primitives</h2>
-      <ul>
-        <li><strong>screenshot</strong> — capture the active display</li>
-        <li><strong>click</strong> — mouse click at (x, y)</li>
-        <li><strong>type</strong> — keyboard input</li>
-        <li><strong>key</strong> — modifier + key (Cmd+Tab, etc.)</li>
-        <li><strong>scroll</strong> — direction + amount</li>
-        <li><strong>cursor_position</strong> — read current</li>
-      </ul>
+            <h2>기본 동작</h2>
+            <ul>
+              <li><strong>screenshot</strong>. 활성 디스플레이 캡처</li>
+              <li><strong>click</strong>. (x, y) 좌표에서 마우스 클릭</li>
+              <li><strong>type</strong>. 키보드 입력</li>
+              <li><strong>key</strong>. 수정자 + 키 (Cmd+Tab 등)</li>
+              <li><strong>scroll</strong>. 방향 + 양</li>
+              <li><strong>cursor_position</strong>. 현재 위치 읽기</li>
+            </ul>
 
-      <h2>Activation</h2>
-      <p>
-        The computer-use tool is opt-in via{" "}
-        <code>is_computer_use_enabled()</code> — gated by config flag and
-        the active provider supporting it. When enabled, the Anthropic
-        agentic adapter injects <code>_COMPUTER_USE_TOOL</code> into the
-        tool list at <code>core/llm/providers/anthropic.py</code>.
-      </p>
+            <h2>활성화</h2>
+            <p>
+              computer-use 도구는{" "}
+              <code>is_computer_use_enabled()</code>를 통한 opt-in 방식입니다.
+              config 플래그와 활성 프로바이더의 지원 여부로 게이트됩니다. 활성화되면
+              Anthropic agentic 어댑터가{" "}
+              <code>core/llm/providers/anthropic.py</code>에서{" "}
+              <code>_COMPUTER_USE_TOOL</code>을 도구 목록에 주입합니다.
+            </p>
 
-      <h2>Safety</h2>
-      <p>
-        Every <code>click</code> and <code>type</code> action fires{" "}
-        <code>TOOL_APPROVAL_REQUEST</code> by default. The HITL gate can be
-        relaxed per session (<code>--no-approve</code>) or per-tool, but
-        the default is human-in-the-loop for any side-effect on the
-        desktop.
-      </p>
+            <h2>안전성</h2>
+            <p>
+              모든 <code>click</code>과 <code>type</code> 동작은 기본적으로{" "}
+              <code>TOOL_APPROVAL_REQUEST</code>를 발생시킵니다. HITL 게이트는 세션
+              단위 (<code>--no-approve</code>) 또는 도구 단위로 완화할 수 있지만,
+              기본값은 데스크탑에 부수 효과를 일으키는 모든 동작에 대해 human-in-the-loop
+              입니다.
+            </p>
 
-      <h2>Files</h2>
-      <ul>
-        <li><code>core/tools/computer_use.py</code> — primitive implementations</li>
-        <li><code>core/llm/providers/anthropic.py</code> — <code>_COMPUTER_USE_TOOL</code> definition + injection</li>
-        <li><code>core/llm/providers/openai.py</code> — OpenAI beta path</li>
-      </ul>
+            <h2>파일</h2>
+            <ul>
+              <li><code>core/tools/computer_use.py</code>. 기본 동작 구현</li>
+              <li><code>core/llm/providers/anthropic.py</code>. <code>_COMPUTER_USE_TOOL</code> 정의 + 주입</li>
+              <li><code>core/llm/providers/openai.py</code>. OpenAI 베타 경로</li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>Two backends, one interface</h2>
+            <p>
+              Anthropic&apos;s computer-use API and OpenAI&apos;s computer-use
+              beta are different protocols with similar primitives. GEODE
+              wraps both behind a single tool definition (
+              <code>computer</code>) and routes to the appropriate provider
+              backend based on the active model.
+            </p>
 
+            <h2>Primitives</h2>
+            <ul>
+              <li><strong>screenshot</strong> — capture the active display</li>
+              <li><strong>click</strong> — mouse click at (x, y)</li>
+              <li><strong>type</strong> — keyboard input</li>
+              <li><strong>key</strong> — modifier + key (Cmd+Tab, etc.)</li>
+              <li><strong>scroll</strong> — direction + amount</li>
+              <li><strong>cursor_position</strong> — read current</li>
+            </ul>
+
+            <h2>Activation</h2>
+            <p>
+              The computer-use tool is opt-in via{" "}
+              <code>is_computer_use_enabled()</code> — gated by config flag and
+              the active provider supporting it. When enabled, the Anthropic
+              agentic adapter injects <code>_COMPUTER_USE_TOOL</code> into the
+              tool list at <code>core/llm/providers/anthropic.py</code>.
+            </p>
+
+            <h2>Safety</h2>
+            <p>
+              Every <code>click</code> and <code>type</code> action fires{" "}
+              <code>TOOL_APPROVAL_REQUEST</code> by default. The HITL gate can be
+              relaxed per session (<code>--no-approve</code>) or per-tool, but
+              the default is human-in-the-loop for any side-effect on the
+              desktop.
+            </p>
+
+            <h2>Files</h2>
+            <ul>
+              <li><code>core/tools/computer_use.py</code> — primitive implementations</li>
+              <li><code>core/llm/providers/anthropic.py</code> — <code>_COMPUTER_USE_TOOL</code> definition + injection</li>
+              <li><code>core/llm/providers/openai.py</code> — OpenAI beta path</li>
+            </ul>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/domains/page.tsx
+++ b/site/src/app/docs/runtime/domains/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Domain Plugins — GEODE Docs" };
 
@@ -7,58 +7,118 @@ export default function Page() {
     <DocsShell
       slug="runtime/domains"
       title="Domain Plugins"
+      titleKo="도메인 플러그인"
       summary="DomainPort protocol + plugin loader. Closed domains (game_ip) plug into the agentic core via a stable interface; future domains add files, not patches."
+      summaryKo="DomainPort 프로토콜과 플러그인 로더. 폐쇄형 도메인 (game_ip)이 안정적인 인터페이스로 agentic 코어에 연결됩니다. 새 도메인은 파일을 추가할 뿐 패치는 필요 없습니다."
     >
-      <h2>The contract</h2>
-      <p>
-        <code>core/domains/port.py:18 class DomainPort</code> defines the
-        protocol every domain plugin implements:
-      </p>
-      <pre>{`class DomainPort(Protocol):
+      <Bi
+        ko={
+          <>
+            <h2>계약</h2>
+            <p>
+              <code>core/domains/port.py:18 class DomainPort</code>는 모든 도메인 플러그인이
+              구현해야 하는 프로토콜을 정의합니다.
+            </p>
+            <pre>{`class DomainPort(Protocol):
     name: str
     def get_pipeline(self) -> StateGraph: ...
     def get_valid_axes_map(self) -> dict[str, set[str]]: ...
     def load_ip_profile(self, name: str) -> dict: ...
     def get_analyst_specific(self) -> dict[str, str]: ...`}</pre>
 
-      <h2>The loader</h2>
-      <p>
-        <code>core/domains/loader.py</code> holds <code>_DOMAIN_REGISTRY</code> —
-        a dict of <code>name → DomainPort</code> entries. v0.64.0 ships
-        with a single entry, <code>game_ip → plugins.game_ip.adapter:GameIPDomain</code>.
-      </p>
+            <h2>로더</h2>
+            <p>
+              <code>core/domains/loader.py</code>는 <code>_DOMAIN_REGISTRY</code>를 보유합니다.
+              <code>name → DomainPort</code> 엔트리 딕셔너리입니다. v0.64.0은 단일 엔트리
+              <code>game_ip → plugins.game_ip.adapter:GameIPDomain</code>으로 출시됐습니다.
+            </p>
 
-      <h2>v0.64.0 split</h2>
-      <p>
-        The domain code moved out of <code>core/</code>. The mapping today:
-      </p>
-      <ul>
-        <li><code>core/domains/</code> — 3 modules: port, loader, types. Domain-agnostic.</li>
-        <li><code>plugins/game_ip/</code> — 13 modules: actual analysts, evaluators, scoring engine, fixtures, config.</li>
-      </ul>
-      <p>
-        See <a href="/geode/docs/plugins/game-ip">Game IP Plugin</a> for
-        the example domain.
-      </p>
+            <h2>v0.64.0 분리</h2>
+            <p>
+              도메인 코드는 <code>core/</code>에서 빠져나왔습니다. 현재 매핑은 다음과 같습니다.
+            </p>
+            <ul>
+              <li><code>core/domains/</code>. 3개 모듈 (port, loader, types). 도메인 무관.</li>
+              <li><code>plugins/game_ip/</code>. 13개 모듈 (실제 analyst, evaluator, 스코어링 엔진, 픽스처, config).</li>
+            </ul>
+            <p>
+              예시 도메인은 <a href="/geode/docs/plugins/game-ip">Game IP 플러그인</a>을 참고하세요.
+            </p>
 
-      <h2>Adding a new domain</h2>
-      <ol>
-        <li>Create <code>plugins/&lt;name&gt;/</code></li>
-        <li>Implement the <code>DomainPort</code> contract in <code>plugins/&lt;name&gt;/adapter.py</code></li>
-        <li>Add a YAML config for axes / rubrics / formulas</li>
-        <li>Register in <code>core/domains/loader.py:_DOMAIN_REGISTRY</code></li>
-        <li>Add fixtures + tests</li>
-        <li>Quality gates extend automatically (<code>core/</code> + <code>plugins/</code> both gated)</li>
-      </ol>
+            <h2>새 도메인 추가</h2>
+            <ol>
+              <li><code>plugins/&lt;name&gt;/</code> 생성</li>
+              <li><code>plugins/&lt;name&gt;/adapter.py</code>에 <code>DomainPort</code> 계약 구현</li>
+              <li>axes, rubric, 공식을 위한 YAML config 추가</li>
+              <li><code>core/domains/loader.py:_DOMAIN_REGISTRY</code>에 등록</li>
+              <li>픽스처와 테스트 추가</li>
+              <li>품질 게이트는 자동 확장 (<code>core/</code>와 <code>plugins/</code> 모두 게이트됨)</li>
+            </ol>
 
-      <h2>Why a closed protocol</h2>
-      <p>
-        Open plugin protocols (anyone can ship anything) trade safety for
-        ecosystem reach. GEODE&apos;s closed protocol — every domain ships
-        in the monorepo — gives quality gates the same coverage as the core
-        (lint, type, tests, E2E fixtures). Open shipping is deferred until
-        a second domain motivates the split.
-      </p>
+            <h2>왜 폐쇄형 프로토콜인가</h2>
+            <p>
+              개방형 플러그인 프로토콜 (누구나 무엇이든 출시 가능)은 생태계 확장성을 얻는 대신
+              안전성을 내어 줍니다. GEODE의 폐쇄형 프로토콜은 모든 도메인이 모노레포에 함께
+              출시되므로, 품질 게이트가 코어와 동일한 커버리지 (lint, type, test, E2E 픽스처)를
+              제공합니다. 개방형 배포는 두 번째 도메인이 분리를 정당화할 때까지 보류됩니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The contract</h2>
+            <p>
+              <code>core/domains/port.py:18 class DomainPort</code> defines the
+              protocol every domain plugin implements:
+            </p>
+            <pre>{`class DomainPort(Protocol):
+    name: str
+    def get_pipeline(self) -> StateGraph: ...
+    def get_valid_axes_map(self) -> dict[str, set[str]]: ...
+    def load_ip_profile(self, name: str) -> dict: ...
+    def get_analyst_specific(self) -> dict[str, str]: ...`}</pre>
+
+            <h2>The loader</h2>
+            <p>
+              <code>core/domains/loader.py</code> holds <code>_DOMAIN_REGISTRY</code> —
+              a dict of <code>name → DomainPort</code> entries. v0.64.0 ships
+              with a single entry, <code>game_ip → plugins.game_ip.adapter:GameIPDomain</code>.
+            </p>
+
+            <h2>v0.64.0 split</h2>
+            <p>
+              The domain code moved out of <code>core/</code>. The mapping today:
+            </p>
+            <ul>
+              <li><code>core/domains/</code> — 3 modules: port, loader, types. Domain-agnostic.</li>
+              <li><code>plugins/game_ip/</code> — 13 modules: actual analysts, evaluators, scoring engine, fixtures, config.</li>
+            </ul>
+            <p>
+              See <a href="/geode/docs/plugins/game-ip">Game IP Plugin</a> for
+              the example domain.
+            </p>
+
+            <h2>Adding a new domain</h2>
+            <ol>
+              <li>Create <code>plugins/&lt;name&gt;/</code></li>
+              <li>Implement the <code>DomainPort</code> contract in <code>plugins/&lt;name&gt;/adapter.py</code></li>
+              <li>Add a YAML config for axes / rubrics / formulas</li>
+              <li>Register in <code>core/domains/loader.py:_DOMAIN_REGISTRY</code></li>
+              <li>Add fixtures + tests</li>
+              <li>Quality gates extend automatically (<code>core/</code> + <code>plugins/</code> both gated)</li>
+            </ol>
+
+            <h2>Why a closed protocol</h2>
+            <p>
+              Open plugin protocols (anyone can ship anything) trade safety for
+              ecosystem reach. GEODE&apos;s closed protocol — every domain ships
+              in the monorepo — gives quality gates the same coverage as the core
+              (lint, type, tests, E2E fixtures). Open shipping is deferred until
+              a second domain motivates the split.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/llm/langsmith/page.tsx
+++ b/site/src/app/docs/runtime/llm/langsmith/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "LangSmith — GEODE Docs" };
 
@@ -7,19 +7,24 @@ export default function Page() {
     <DocsShell
       slug="runtime/llm/langsmith"
       title="LangSmith"
+      titleKo="LangSmith"
       summary="Opt-in tracing for the five LLM call sites in core/llm/router.py. Zero runtime cost when disabled."
+      summaryKo="core/llm/router.py의 다섯 개 LLM 호출 지점에 대한 opt-in 트레이싱. 비활성화 시 런타임 비용 0."
     >
-      <h2>Activation</h2>
-      <pre>{`export LANGCHAIN_TRACING_V2=true
-export LANGCHAIN_API_KEY=ls_...      # or LANGSMITH_API_KEY
-export LANGCHAIN_PROJECT=geode       # optional`}</pre>
-      <p>
-        Both the <code>LANGCHAIN_TRACING_V2=true</code> gate and an API key
-        are required. Either alone disables tracing.
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>활성화</h2>
+            <pre>{`export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=ls_...      # 또는 LANGSMITH_API_KEY
+export LANGCHAIN_PROJECT=geode       # 선택`}</pre>
+            <p>
+              <code>LANGCHAIN_TRACING_V2=true</code> 게이트와 API 키가 모두 필요합니다.
+              한쪽만 있으면 트레이싱은 비활성화됩니다.
+            </p>
 
-      <h2>The decorator</h2>
-      <pre>{`# core/llm/router.py:151-181
+            <h2>데코레이터</h2>
+            <pre>{`# core/llm/router.py:151-181
 def is_langsmith_enabled() -> bool:
     tracing = os.environ.get("LANGCHAIN_TRACING_V2", "").lower() == "true"
     api_key = (
@@ -33,38 +38,101 @@ def maybe_traceable(*, run_type="llm", name=None):
         from langsmith import traceable
         return traceable(run_type=run_type, name=name)
     return lambda fn: fn`}</pre>
-      <p>
-        When LangSmith is inactive the decorator collapses to identity —
-        zero runtime cost, no import.
-      </p>
+            <p>
+              LangSmith가 비활성 상태일 때 데코레이터는 항등 함수로 축소됩니다.
+              런타임 비용 0, import도 일어나지 않습니다.
+            </p>
 
-      <h2>Wrapped call sites</h2>
-      <table>
-        <thead><tr><th>Function</th><th>run_type</th></tr></thead>
-        <tbody>
-          <tr><td><code>call_llm</code></td><td>llm</td></tr>
-          <tr><td><code>call_llm_parsed</code></td><td>llm</td></tr>
-          <tr><td><code>call_llm_json</code></td><td>llm</td></tr>
-          <tr><td><code>call_llm_with_tools</code></td><td>chain</td></tr>
-          <tr><td><code>call_llm_streaming</code></td><td>llm</td></tr>
-        </tbody>
-      </table>
+            <h2>래핑된 호출 지점</h2>
+            <table>
+              <thead><tr><th>함수</th><th>run_type</th></tr></thead>
+              <tbody>
+                <tr><td><code>call_llm</code></td><td>llm</td></tr>
+                <tr><td><code>call_llm_parsed</code></td><td>llm</td></tr>
+                <tr><td><code>call_llm_json</code></td><td>llm</td></tr>
+                <tr><td><code>call_llm_with_tools</code></td><td>chain</td></tr>
+                <tr><td><code>call_llm_streaming</code></td><td>llm</td></tr>
+              </tbody>
+            </table>
 
-      <h2>What gets traced, what does not</h2>
-      <ul>
-        <li><strong>Traced</strong>: model input/output messages, token usage, latency, errors.</li>
-        <li><strong>Not traced</strong> (separate channel): prompt assembly metadata. The <code>PROMPT_ASSEMBLED</code> hook payload (fragment list, skill hashes, truncation events) is fired locally but does not auto-attach to the LangSmith run. Bridging is on the roadmap (<em>geode-prompt-evolution P2 #4</em>).</li>
-      </ul>
+            <h2>트레이싱되는 것, 되지 않는 것</h2>
+            <ul>
+              <li><strong>트레이싱됨</strong>. 모델 입출력 메시지, 토큰 사용량, 지연, 오류.</li>
+              <li><strong>트레이싱되지 않음</strong> (별도 채널). prompt 어셈블리 메타데이터. <code>PROMPT_ASSEMBLED</code> 훅 페이로드 (fragment 목록, skill 해시, 절단 이벤트)는 로컬에서 발생하지만 LangSmith run에 자동 첨부되지 않습니다. 브릿징은 로드맵에 있습니다 (<em>geode-prompt-evolution P2 #4</em>).</li>
+            </ul>
 
-      <h2>Log noise control</h2>
-      <pre>{`# core/llm/router.py:141-143
+            <h2>로그 노이즈 제어</h2>
+            <pre>{`# core/llm/router.py:141-143
 logging.getLogger("langsmith").setLevel(logging.ERROR)
 logging.getLogger("langchain").setLevel(logging.ERROR)`}</pre>
-      <p>
-        LangSmith&apos;s internal 429 retry logging is escalated from{" "}
-        <code>WARNING</code> to <code>ERROR</code> to keep the GEODE stdout
-        clean.
-      </p>
+            <p>
+              LangSmith 내부의 429 재시도 로깅을{" "}
+              <code>WARNING</code>에서 <code>ERROR</code>로 올려 GEODE stdout을
+              깨끗하게 유지합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>Activation</h2>
+            <pre>{`export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=ls_...      # or LANGSMITH_API_KEY
+export LANGCHAIN_PROJECT=geode       # optional`}</pre>
+            <p>
+              Both the <code>LANGCHAIN_TRACING_V2=true</code> gate and an API key
+              are required. Either alone disables tracing.
+            </p>
+
+            <h2>The decorator</h2>
+            <pre>{`# core/llm/router.py:151-181
+def is_langsmith_enabled() -> bool:
+    tracing = os.environ.get("LANGCHAIN_TRACING_V2", "").lower() == "true"
+    api_key = (
+        os.environ.get("LANGCHAIN_API_KEY")
+        or os.environ.get("LANGSMITH_API_KEY")
+    )
+    return tracing and api_key is not None
+
+def maybe_traceable(*, run_type="llm", name=None):
+    if is_langsmith_enabled():
+        from langsmith import traceable
+        return traceable(run_type=run_type, name=name)
+    return lambda fn: fn`}</pre>
+            <p>
+              When LangSmith is inactive the decorator collapses to identity —
+              zero runtime cost, no import.
+            </p>
+
+            <h2>Wrapped call sites</h2>
+            <table>
+              <thead><tr><th>Function</th><th>run_type</th></tr></thead>
+              <tbody>
+                <tr><td><code>call_llm</code></td><td>llm</td></tr>
+                <tr><td><code>call_llm_parsed</code></td><td>llm</td></tr>
+                <tr><td><code>call_llm_json</code></td><td>llm</td></tr>
+                <tr><td><code>call_llm_with_tools</code></td><td>chain</td></tr>
+                <tr><td><code>call_llm_streaming</code></td><td>llm</td></tr>
+              </tbody>
+            </table>
+
+            <h2>What gets traced, what does not</h2>
+            <ul>
+              <li><strong>Traced</strong>: model input/output messages, token usage, latency, errors.</li>
+              <li><strong>Not traced</strong> (separate channel): prompt assembly metadata. The <code>PROMPT_ASSEMBLED</code> hook payload (fragment list, skill hashes, truncation events) is fired locally but does not auto-attach to the LangSmith run. Bridging is on the roadmap (<em>geode-prompt-evolution P2 #4</em>).</li>
+            </ul>
+
+            <h2>Log noise control</h2>
+            <pre>{`# core/llm/router.py:141-143
+logging.getLogger("langsmith").setLevel(logging.ERROR)
+logging.getLogger("langchain").setLevel(logging.ERROR)`}</pre>
+            <p>
+              LangSmith&apos;s internal 429 retry logging is escalated from{" "}
+              <code>WARNING</code> to <code>ERROR</code> to keep the GEODE stdout
+              clean.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
+++ b/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Prompt Caching — GEODE Docs" };
 
@@ -7,34 +7,38 @@ export default function Page() {
     <DocsShell
       slug="runtime/llm/prompt-caching"
       title="Prompt Caching"
+      titleKo="프롬프트 캐싱"
       summary="Anthropic ephemeral caching with a STATIC/DYNAMIC boundary, applied at two call sites: the agentic adapter and the router's non-agentic helpers."
+      summaryKo="STATIC/DYNAMIC 경계로 구분되는 Anthropic ephemeral 캐싱. agentic 어댑터와 router의 non-agentic 헬퍼, 두 호출 지점에 적용됩니다."
     >
-      <h2>The boundary marker</h2>
-      <p>
-        <code>core/agent/system_prompt.py:35</code> defines:
-      </p>
-      <pre>{`PROMPT_CACHE_BOUNDARY = "__GEODE_PROMPT_CACHE_BOUNDARY__"`}</pre>
-      <p>
-        <code>build_system_prompt()</code> inserts this marker between two
-        sections:
-      </p>
-      <ul>
-        <li>
-          <strong>STATIC</strong> (before the marker): router template,
-          identity from <code>GEODE.md</code>. Stable across turns.
-        </li>
-        <li>
-          <strong>DYNAMIC</strong> (after the marker): current date, model
-          card, project memory (G2-G4), user context. Changes per turn.
-        </li>
-      </ul>
+      <Bi
+        ko={
+          <>
+            <h2>경계 마커</h2>
+            <p>
+              <code>core/agent/system_prompt.py:35</code>에 정의되어 있습니다.
+            </p>
+            <pre>{`PROMPT_CACHE_BOUNDARY = "__GEODE_PROMPT_CACHE_BOUNDARY__"`}</pre>
+            <p>
+              <code>build_system_prompt()</code>이 이 마커를 두 섹션 사이에 삽입합니다.
+            </p>
+            <ul>
+              <li>
+                <strong>STATIC</strong> (마커 이전). router 템플릿,{" "}
+                <code>GEODE.md</code> 의 아이덴티티. 턴 간 안정적.
+              </li>
+              <li>
+                <strong>DYNAMIC</strong> (마커 이후). 현재 날짜, 모델 카드,
+                프로젝트 메모리 (G2-G4), 사용자 컨텍스트. 매 턴 변경됨.
+              </li>
+            </ul>
 
-      <h2>How the adapter splits</h2>
-      <p>
-        <code>core/llm/providers/anthropic.py:476-495</code> in the agentic
-        adapter:
-      </p>
-      <pre>{`from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
+            <h2>어댑터의 분할 방식</h2>
+            <p>
+              <code>core/llm/providers/anthropic.py:476-495</code>의 agentic
+              어댑터.
+            </p>
+            <pre>{`from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
 
 if PROMPT_CACHE_BOUNDARY in system:
     static_part, dynamic_part = system.split(PROMPT_CACHE_BOUNDARY, 1)
@@ -48,94 +52,225 @@ else:
         {"type": "text", "text": system,
          "cache_control": {"type": "ephemeral"}},
     ]`}</pre>
-      <p>
-        The static block gets the cache marker; the dynamic block does not.
-        Anthropic then caches the static prefix server-side, and subsequent
-        turns within the 5-minute TTL pay only for the dynamic suffix and
-        the new user message.
-      </p>
+            <p>
+              STATIC 블록은 캐시 마커를 받지만 DYNAMIC 블록은 받지 않습니다.
+              Anthropic은 STATIC 프리픽스를 서버 측에서 캐싱하며, 5분 TTL 안의
+              후속 턴은 DYNAMIC 접미부와 새 user 메시지에 대해서만 과금됩니다.
+            </p>
 
-      <h2>Non-agentic call sites</h2>
-      <p>
-        Four call sites in <code>core/llm/router.py</code> (lines 481, 582,
-        749, 901) use the simpler helper{" "}
-        <code>system_with_cache(system)</code> that wraps the entire system
-        prompt as a single ephemeral block. These are the {" "}
-        non-agentic LLM calls (single-shot prompts, evaluation calls) that
-        do not assemble a STATIC/DYNAMIC structured system prompt.
-      </p>
+            <h2>Non-agentic 호출 지점</h2>
+            <p>
+              <code>core/llm/router.py</code>의 네 호출 지점 (라인 481, 582, 749,
+              901)은 더 단순한 헬퍼 <code>system_with_cache(system)</code>를 써서
+              system prompt 전체를 단일 ephemeral 블록으로 감쌉니다. 이들은
+              STATIC/DYNAMIC 구조화 system prompt를 조립하지 않는 non-agentic LLM
+              호출 (단발 prompt, 평가 호출) 입니다.
+            </p>
 
-      <h2>What is cached, what is not</h2>
-      <table>
-        <thead>
-          <tr><th>Surface</th><th>Cached</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Anthropic system prompt — STATIC section</td>
-            <td>Yes (ephemeral)</td>
-          </tr>
-          <tr>
-            <td>Anthropic system prompt — DYNAMIC section</td>
-            <td>No (changes per turn)</td>
-          </tr>
-          <tr>
-            <td>Anthropic non-agentic system prompt (full)</td>
-            <td>Yes (single ephemeral block)</td>
-          </tr>
-          <tr>
-            <td>Anthropic <code>messages</code> array</td>
-            <td>Yes — last 3 non-system messages (PR #864, helper at <code>anthropic.py:175</code>, call at <code>:501</code>)</td>
-          </tr>
-          <tr>
-            <td>OpenAI / Codex system prompt</td>
-            <td>No explicit GEODE wiring (OpenAI auto-caches server-side)</td>
-          </tr>
-          <tr>
-            <td>GLM system prompt</td>
-            <td>Provider-managed</td>
-          </tr>
-        </tbody>
-      </table>
+            <h2>캐시되는 것, 캐시되지 않는 것</h2>
+            <table>
+              <thead>
+                <tr><th>대상</th><th>캐시 여부</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Anthropic system prompt . STATIC 섹션</td>
+                  <td>Yes (ephemeral)</td>
+                </tr>
+                <tr>
+                  <td>Anthropic system prompt . DYNAMIC 섹션</td>
+                  <td>No (매 턴 변경)</td>
+                </tr>
+                <tr>
+                  <td>Anthropic non-agentic system prompt (전체)</td>
+                  <td>Yes (단일 ephemeral 블록)</td>
+                </tr>
+                <tr>
+                  <td>Anthropic <code>messages</code> 배열</td>
+                  <td>Yes. 최근 3개 non-system 메시지 (PR #864, 헬퍼 <code>anthropic.py:175</code>, 호출 <code>:501</code>)</td>
+                </tr>
+                <tr>
+                  <td>OpenAI / Codex system prompt</td>
+                  <td>GEODE 측 명시 wiring 없음 (OpenAI가 서버 측에서 자동 캐싱)</td>
+                </tr>
+                <tr>
+                  <td>GLM system prompt</td>
+                  <td>프로바이더 관리</td>
+                </tr>
+              </tbody>
+            </table>
 
-      <h2>Messages history caching (PR #864)</h2>
-      <p>
-        Anthropic allows up to four cache breakpoints per request. The
-        adapter applies <code>apply_messages_cache_control(messages)</code>{" "}
-        right before <code>messages.create</code>, attaching{" "}
-        <code>cache_control: ephemeral</code> to the last three non-system
-        messages&apos; final content block. Combined with the system block
-        above, that fills all four slots and caches the rolling history.
-      </p>
-      <pre>{`# core/llm/providers/anthropic.py:175 (helper) and :501 (call site)
+            <h2>messages history 캐싱 (PR #864)</h2>
+            <p>
+              Anthropic은 요청당 최대 4개의 캐시 breakpoint를 허용합니다. 어댑터는{" "}
+              <code>messages.create</code> 직전에{" "}
+              <code>apply_messages_cache_control(messages)</code>를 적용해 최근 3개
+              non-system 메시지의 마지막 content 블록에{" "}
+              <code>cache_control: ephemeral</code>을 붙입니다. 위의 system 블록과
+              합치면 4개 슬롯을 모두 채워 롤링 히스토리가 캐시됩니다.
+            </p>
+            <pre>{`# core/llm/providers/anthropic.py:175 (helper) and :501 (call site)
 cached_messages = apply_messages_cache_control(messages)
 create_kwargs = {
     "system": sys_blocks,
     "messages": cached_messages,
     ...
 }`}</pre>
-      <p>
-        Helper is non-mutating (returns a new list with shallow copies),
-        handles <code>str</code> and <code>list[block]</code> content, and
-        skips empty-list content silently. Tested in{" "}
-        <code>tests/test_anthropic_messages_cache.py</code> (19 cases).
-      </p>
+            <p>
+              헬퍼는 비-변형 (얕은 복사된 새 리스트 반환) 이며,{" "}
+              <code>str</code>과 <code>list[block]</code> content를 모두 처리하고
+              빈 리스트 content는 조용히 건너뜁니다. 19개 케이스가{" "}
+              <code>tests/test_anthropic_messages_cache.py</code>에서 검증됩니다.
+            </p>
 
-      <h2>Cache invalidation</h2>
-      <p>
-        The cache key is the byte-for-byte content of the cached block plus
-        the model ID. Any change to the static section — e.g. an updated{" "}
-        <code>GEODE.md</code> identity, a new IP example list, a router
-        template revision — invalidates the cache and pays one full request
-        before subsequent turns hit again.
-      </p>
-      <p>
-        This is why prompt drift detection (
-        <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>)
-        and prompt caching are tightly coupled in the design: a silent prompt
-        change would silently invalidate the cache, and the hash ratchet
-        forces such changes to be conscious.
-      </p>
+            <h2>캐시 무효화</h2>
+            <p>
+              캐시 키는 캐시된 블록의 바이트 단위 콘텐츠와 모델 ID입니다. STATIC
+              섹션의 어떤 변경 (예. 업데이트된 <code>GEODE.md</code> 아이덴티티,
+              새 IP 예제 목록, router 템플릿 수정) 도 캐시를 무효화하며, 후속 턴이
+              다시 캐시에 적중하기 전에 한 번의 전체 요청 비용을 지불해야 합니다.
+            </p>
+            <p>
+              이것이 prompt drift 감지 (
+              <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>) 와
+              prompt 캐싱이 설계상 긴밀하게 결합된 이유입니다. 조용한 prompt 변경은
+              조용한 캐시 무효화로 이어지며, 해시 잠금장치는 그런 변경을 의식적인
+              단계로 강제합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The boundary marker</h2>
+            <p>
+              <code>core/agent/system_prompt.py:35</code> defines:
+            </p>
+            <pre>{`PROMPT_CACHE_BOUNDARY = "__GEODE_PROMPT_CACHE_BOUNDARY__"`}</pre>
+            <p>
+              <code>build_system_prompt()</code> inserts this marker between two
+              sections:
+            </p>
+            <ul>
+              <li>
+                <strong>STATIC</strong> (before the marker): router template,
+                identity from <code>GEODE.md</code>. Stable across turns.
+              </li>
+              <li>
+                <strong>DYNAMIC</strong> (after the marker): current date, model
+                card, project memory (G2-G4), user context. Changes per turn.
+              </li>
+            </ul>
+
+            <h2>How the adapter splits</h2>
+            <p>
+              <code>core/llm/providers/anthropic.py:476-495</code> in the agentic
+              adapter:
+            </p>
+            <pre>{`from core.agent.system_prompt import PROMPT_CACHE_BOUNDARY
+
+if PROMPT_CACHE_BOUNDARY in system:
+    static_part, dynamic_part = system.split(PROMPT_CACHE_BOUNDARY, 1)
+    sys_blocks = [
+        {"type": "text", "text": static_part.rstrip(),
+         "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": dynamic_part.lstrip()},
+    ]
+else:
+    sys_blocks = [
+        {"type": "text", "text": system,
+         "cache_control": {"type": "ephemeral"}},
+    ]`}</pre>
+            <p>
+              The static block gets the cache marker; the dynamic block does not.
+              Anthropic then caches the static prefix server-side, and subsequent
+              turns within the 5-minute TTL pay only for the dynamic suffix and
+              the new user message.
+            </p>
+
+            <h2>Non-agentic call sites</h2>
+            <p>
+              Four call sites in <code>core/llm/router.py</code> (lines 481, 582,
+              749, 901) use the simpler helper{" "}
+              <code>system_with_cache(system)</code> that wraps the entire system
+              prompt as a single ephemeral block. These are the {" "}
+              non-agentic LLM calls (single-shot prompts, evaluation calls) that
+              do not assemble a STATIC/DYNAMIC structured system prompt.
+            </p>
+
+            <h2>What is cached, what is not</h2>
+            <table>
+              <thead>
+                <tr><th>Surface</th><th>Cached</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Anthropic system prompt — STATIC section</td>
+                  <td>Yes (ephemeral)</td>
+                </tr>
+                <tr>
+                  <td>Anthropic system prompt — DYNAMIC section</td>
+                  <td>No (changes per turn)</td>
+                </tr>
+                <tr>
+                  <td>Anthropic non-agentic system prompt (full)</td>
+                  <td>Yes (single ephemeral block)</td>
+                </tr>
+                <tr>
+                  <td>Anthropic <code>messages</code> array</td>
+                  <td>Yes — last 3 non-system messages (PR #864, helper at <code>anthropic.py:175</code>, call at <code>:501</code>)</td>
+                </tr>
+                <tr>
+                  <td>OpenAI / Codex system prompt</td>
+                  <td>No explicit GEODE wiring (OpenAI auto-caches server-side)</td>
+                </tr>
+                <tr>
+                  <td>GLM system prompt</td>
+                  <td>Provider-managed</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Messages history caching (PR #864)</h2>
+            <p>
+              Anthropic allows up to four cache breakpoints per request. The
+              adapter applies <code>apply_messages_cache_control(messages)</code>{" "}
+              right before <code>messages.create</code>, attaching{" "}
+              <code>cache_control: ephemeral</code> to the last three non-system
+              messages&apos; final content block. Combined with the system block
+              above, that fills all four slots and caches the rolling history.
+            </p>
+            <pre>{`# core/llm/providers/anthropic.py:175 (helper) and :501 (call site)
+cached_messages = apply_messages_cache_control(messages)
+create_kwargs = {
+    "system": sys_blocks,
+    "messages": cached_messages,
+    ...
+}`}</pre>
+            <p>
+              Helper is non-mutating (returns a new list with shallow copies),
+              handles <code>str</code> and <code>list[block]</code> content, and
+              skips empty-list content silently. Tested in{" "}
+              <code>tests/test_anthropic_messages_cache.py</code> (19 cases).
+            </p>
+
+            <h2>Cache invalidation</h2>
+            <p>
+              The cache key is the byte-for-byte content of the cached block plus
+              the model ID. Any change to the static section — e.g. an updated{" "}
+              <code>GEODE.md</code> identity, a new IP example list, a router
+              template revision — invalidates the cache and pays one full request
+              before subsequent turns hit again.
+            </p>
+            <p>
+              This is why prompt drift detection (
+              <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a>)
+              and prompt caching are tightly coupled in the design: a silent prompt
+              change would silently invalidate the cache, and the hash ratchet
+              forces such changes to be conscious.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/llm/prompt-hashing/page.tsx
+++ b/site/src/app/docs/runtime/llm/prompt-hashing/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Prompt Hashing — GEODE Docs" };
 
@@ -7,10 +7,15 @@ export default function Page() {
     <DocsShell
       slug="runtime/llm/prompt-hashing"
       title="Prompt Hashing"
+      titleKo="프롬프트 해싱"
       summary="A SHA-256 hash ratchet (Karpathy P4) that breaks CI on unintended prompt drift. 20 templates pinned, re-pin workflow documented."
+      summaryKo="의도치 않은 prompt drift 발생 시 CI를 중단시키는 SHA-256 해시 잠금장치 (Karpathy P4). 20개 템플릿이 핀으로 고정되고, 재핀(re-pin) 절차가 문서화되어 있습니다."
     >
-      <h2>The two functions</h2>
-      <pre>{`# core/llm/prompts/__init__.py
+      <Bi
+        ko={
+          <>
+            <h2>두 개의 함수</h2>
+            <pre>{`# core/llm/prompts/__init__.py
 def _hash_prompt(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()[:12]
 
@@ -19,19 +24,17 @@ def _hash_axes(data) -> str:
     return hashlib.sha256(
         json.dumps(data, sort_keys=True).encode()
     ).hexdigest()[:12]`}</pre>
-      <p>
-        Twelve hex characters = 48 bits. Collision probability is negligible
-        for the closed set of 20 prompts; the goal is detection, not
-        cryptographic security.
-      </p>
-      <p>
-        The axes hash uses <code>sort_keys=True</code> to make the JSON
-        serialization deterministic across YAML parser versions and Python
-        dict orderings.
-      </p>
+            <p>
+              12자리 hex = 48비트. 20개 prompt라는 닫힌 집합에서 충돌 확률은
+              무시할 수 있습니다. 목표는 탐지이지 암호학적 보안이 아닙니다.
+            </p>
+            <p>
+              axes 해시는 YAML 파서 버전과 Python dict 순서에 걸쳐 JSON 직렬화가
+              결정적이도록 <code>sort_keys=True</code>를 사용합니다.
+            </p>
 
-      <h2>The 20 pinned entries</h2>
-      <pre>{`PROMPT_VERSIONS / _PINNED_HASHES (sorted)
+            <h2>20개의 고정 엔트리</h2>
+            <pre>{`PROMPT_VERSIONS / _PINNED_HASHES (sorted)
 
   AGENTIC_SUFFIX             79cef71335e8
   ANALYST_SPECIFIC           5a696a2d5ebb
@@ -53,12 +56,12 @@ def _hash_axes(data) -> str:
   SYNTHESIZER_SYSTEM         e01544c0c8d2
   SYNTHESIZER_TOOLS_SUFFIX   c6c65e47e191
   SYNTHESIZER_USER           30d99edc79a5`}</pre>
-      <p>
-        Both dictionaries have exactly 20 keys; their key sets are equal.
-      </p>
+            <p>
+              두 dict 모두 정확히 20개 key를 가지며, key set이 동일합니다.
+            </p>
 
-      <h2>verify_prompt_integrity</h2>
-      <pre>{`def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
+            <h2>verify_prompt_integrity</h2>
+            <pre>{`def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
     drifted = []
     for name, pinned in _PINNED_HASHES.items():
         if computed[name] != pinned:
@@ -66,63 +69,186 @@ def _hash_axes(data) -> str:
     if drifted and raise_on_drift:
         raise RuntimeError(...)
     return drifted`}</pre>
-      <p>
-        The function is invoked by{" "}
-        <code>tests/test_karpathy_prompt_hardening.py::TestPromptDriftDetection</code>{" "}
-        with both <code>raise_on_drift=False</code> (returns a list, asserted
-        empty) and <code>raise_on_drift=True</code> (asserts no exception).
-      </p>
+            <p>
+              이 함수는{" "}
+              <code>tests/test_karpathy_prompt_hardening.py::TestPromptDriftDetection</code>에서{" "}
+              <code>raise_on_drift=False</code> (리스트 반환, 비어 있어야 함) 와{" "}
+              <code>raise_on_drift=True</code> (예외가 발생하지 않아야 함) 양쪽
+              모드로 호출됩니다.
+            </p>
 
-      <h2>Re-pin workflow</h2>
-      <p>When a prompt is intentionally changed:</p>
-      <ol>
-        <li>Edit the <code>.md</code> file (e.g. <code>analyst.md</code>).</li>
-        <li>
-          Compute new hashes:
-          <pre>{`uv run python -c "
+            <h2>재핀(re-pin) 절차</h2>
+            <p>의도적으로 prompt를 변경했을 때.</p>
+            <ol>
+              <li><code>.md</code> 파일을 편집합니다 (예. <code>analyst.md</code>).</li>
+              <li>
+                새 해시를 계산합니다.
+                <pre>{`uv run python -c "
 from core.llm.prompts import PROMPT_VERSIONS as V
 import json
 print(json.dumps(dict(sorted(V.items())), indent=2))
 "`}</pre>
-        </li>
-        <li>Update the corresponding entry in <code>_PINNED_HASHES</code>.</li>
-        <li>Run <code>uv run pytest tests/test_karpathy_prompt_hardening.py</code>.</li>
-        <li>Commit prompt change and pin update <strong>together</strong> in one commit.</li>
-      </ol>
-      <p>
-        Splitting the prompt change and the pin update across two commits
-        leaves a CI-broken commit in <code>git history</code>. Bisect-friendly
-        commits keep the pin and the prompt in lockstep.
-      </p>
+              </li>
+              <li><code>_PINNED_HASHES</code>의 해당 엔트리를 업데이트합니다.</li>
+              <li><code>uv run pytest tests/test_karpathy_prompt_hardening.py</code>를 실행합니다.</li>
+              <li>prompt 변경과 핀 업데이트를 <strong>한 커밋</strong>으로 함께 묶어 커밋합니다.</li>
+            </ol>
+            <p>
+              prompt 변경과 핀 업데이트를 두 커밋으로 나누면{" "}
+              <code>git history</code>에 CI 실패 상태의 커밋이 남게 됩니다.
+              bisect 친화적인 커밋이라면 핀과 prompt가 같은 보폭으로 움직입니다.
+            </p>
 
-      <h2>Why ratchet</h2>
-      <p>
-        The hash ratchet is the GEODE expression of Karpathy&apos;s P4
-        principle: once a quality gate is passed, it should never silently
-        regress. Prompt changes are easy to make accidentally — a
-        merge-conflict resolution, an autoformatter, an IDE rename — and
-        their downstream effects on model behaviour are hard to foresee. The
-        ratchet forces every prompt change through a conscious step.
-      </p>
+            <h2>왜 잠금장치인가</h2>
+            <p>
+              해시 잠금장치는 Karpathy의 P4 원칙을 GEODE 식으로 표현한 것입니다.
+              한 번 통과한 품질 게이트는 조용히 후퇴해서는 안 된다는 원칙. prompt
+              변경은 우연히도 쉽게 일어납니다. 병합 충돌 해결, 자동 포매터, IDE
+              rename 등. 그리고 그 변경이 모델 동작에 미치는 영향을 미리 예측하기는
+              어렵습니다. 잠금장치는 모든 prompt 변경을 의식적인 단계를 거치도록
+              강제합니다.
+            </p>
 
-      <h2>What the ratchet does not cover</h2>
-      <ul>
-        <li>
-          <strong>Skill bodies</strong> in <code>.geode/skills/</code> are
-          observed via the <code>PROMPT_ASSEMBLED</code> hook payload but not
-          pinned. A prompt-injected skill change is not a CI failure.
-        </li>
-        <li>
-          <strong>Rendered prompts</strong> (after <code>.format()</code>{" "}
-          variable substitution) are not hashed. <code>hash_rendered_prompt()</code>{" "}
-          exists but has no callers — see{" "}
-          <em>geode-prompt-evolution P2 #3</em>.
-        </li>
-        <li>
-          <strong>Disk integrity</strong> is not re-verified at runtime; the
-          hash only fires at import time of the package.
-        </li>
-      </ul>
+            <h2>잠금장치가 다루지 않는 것</h2>
+            <ul>
+              <li>
+                <code>.geode/skills/</code> 의 <strong>skill 본문</strong>은{" "}
+                <code>PROMPT_ASSEMBLED</code> 훅 페이로드로 관찰되지만 핀으로
+                고정되지는 않습니다. prompt 주입된 skill 변경은 CI 실패가
+                아닙니다.
+              </li>
+              <li>
+                <strong>렌더링된 prompt</strong> (<code>.format()</code> 변수 치환
+                이후) 는 해싱되지 않습니다. <code>hash_rendered_prompt()</code>는
+                존재하지만 호출자가 없습니다.{" "}
+                <em>geode-prompt-evolution P2 #3</em> 참조.
+              </li>
+              <li>
+                <strong>디스크 무결성</strong>은 런타임에 재검증되지 않습니다.
+                해싱은 패키지 import 시점에만 일어납니다.
+              </li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>The two functions</h2>
+            <pre>{`# core/llm/prompts/__init__.py
+def _hash_prompt(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:12]
+
+# core/llm/prompts/axes.py
+def _hash_axes(data) -> str:
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True).encode()
+    ).hexdigest()[:12]`}</pre>
+            <p>
+              Twelve hex characters = 48 bits. Collision probability is negligible
+              for the closed set of 20 prompts; the goal is detection, not
+              cryptographic security.
+            </p>
+            <p>
+              The axes hash uses <code>sort_keys=True</code> to make the JSON
+              serialization deterministic across YAML parser versions and Python
+              dict orderings.
+            </p>
+
+            <h2>The 20 pinned entries</h2>
+            <pre>{`PROMPT_VERSIONS / _PINNED_HASHES (sorted)
+
+  AGENTIC_SUFFIX             79cef71335e8
+  ANALYST_SPECIFIC           5a696a2d5ebb
+  ANALYST_SYSTEM             8a325a63b397
+  ANALYST_TOOLS_SUFFIX       2961fb31d96f
+  ANALYST_USER               e59d00faadd5
+  BIASBUSTER_SYSTEM          07987c709fd9
+  BIASBUSTER_USER            378be01a6310
+  COMMENTARY_SYSTEM          488d8916d958
+  COMMENTARY_USER            2024ac4eba69
+  CROSS_LLM_DUAL_VERIFY      602669128ae2
+  CROSS_LLM_RESCORE          163b08e97d66
+  CROSS_LLM_SYSTEM           bf303f600fce
+  EVALUATOR_AXES             0d82eb1aa5b4
+  EVALUATOR_SYSTEM           e891c0ce27d4
+  EVALUATOR_USER             f6d7f955338d
+  PROSPECT_EVALUATOR_AXES    a9954477497b
+  ROUTER_SYSTEM              a03eef47a293
+  SYNTHESIZER_SYSTEM         e01544c0c8d2
+  SYNTHESIZER_TOOLS_SUFFIX   c6c65e47e191
+  SYNTHESIZER_USER           30d99edc79a5`}</pre>
+            <p>
+              Both dictionaries have exactly 20 keys; their key sets are equal.
+            </p>
+
+            <h2>verify_prompt_integrity</h2>
+            <pre>{`def verify_prompt_integrity(*, raise_on_drift: bool = False) -> list[str]:
+    drifted = []
+    for name, pinned in _PINNED_HASHES.items():
+        if computed[name] != pinned:
+            drifted.append(f"Prompt drift: {name} pin={pinned} now={computed[name]}")
+    if drifted and raise_on_drift:
+        raise RuntimeError(...)
+    return drifted`}</pre>
+            <p>
+              The function is invoked by{" "}
+              <code>tests/test_karpathy_prompt_hardening.py::TestPromptDriftDetection</code>{" "}
+              with both <code>raise_on_drift=False</code> (returns a list, asserted
+              empty) and <code>raise_on_drift=True</code> (asserts no exception).
+            </p>
+
+            <h2>Re-pin workflow</h2>
+            <p>When a prompt is intentionally changed:</p>
+            <ol>
+              <li>Edit the <code>.md</code> file (e.g. <code>analyst.md</code>).</li>
+              <li>
+                Compute new hashes:
+                <pre>{`uv run python -c "
+from core.llm.prompts import PROMPT_VERSIONS as V
+import json
+print(json.dumps(dict(sorted(V.items())), indent=2))
+"`}</pre>
+              </li>
+              <li>Update the corresponding entry in <code>_PINNED_HASHES</code>.</li>
+              <li>Run <code>uv run pytest tests/test_karpathy_prompt_hardening.py</code>.</li>
+              <li>Commit prompt change and pin update <strong>together</strong> in one commit.</li>
+            </ol>
+            <p>
+              Splitting the prompt change and the pin update across two commits
+              leaves a CI-broken commit in <code>git history</code>. Bisect-friendly
+              commits keep the pin and the prompt in lockstep.
+            </p>
+
+            <h2>Why ratchet</h2>
+            <p>
+              The hash ratchet is the GEODE expression of Karpathy&apos;s P4
+              principle: once a quality gate is passed, it should never silently
+              regress. Prompt changes are easy to make accidentally — a
+              merge-conflict resolution, an autoformatter, an IDE rename — and
+              their downstream effects on model behaviour are hard to foresee. The
+              ratchet forces every prompt change through a conscious step.
+            </p>
+
+            <h2>What the ratchet does not cover</h2>
+            <ul>
+              <li>
+                <strong>Skill bodies</strong> in <code>.geode/skills/</code> are
+                observed via the <code>PROMPT_ASSEMBLED</code> hook payload but not
+                pinned. A prompt-injected skill change is not a CI failure.
+              </li>
+              <li>
+                <strong>Rendered prompts</strong> (after <code>.format()</code>{" "}
+                variable substitution) are not hashed. <code>hash_rendered_prompt()</code>{" "}
+                exists but has no callers — see{" "}
+                <em>geode-prompt-evolution P2 #3</em>.
+              </li>
+              <li>
+                <strong>Disk integrity</strong> is not re-verified at runtime; the
+                hash only fires at import time of the package.
+              </li>
+            </ul>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/llm/providers/page.tsx
+++ b/site/src/app/docs/runtime/llm/providers/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Providers — GEODE Docs" };
 
@@ -7,72 +7,146 @@ export default function Page() {
     <DocsShell
       slug="runtime/llm/providers"
       title="Providers"
+      titleKo="프로바이더"
       summary="Three fallback chains, four adapters, nine models. Provider-agnostic LLM router with explicit chain ordering."
+      summaryKo="3개의 폴백 체인, 4개의 어댑터, 9개의 모델. 명시적 체인 순서를 갖는 프로바이더 독립 LLM router."
     >
-      <h2>The four adapters</h2>
-      <table>
-        <thead><tr><th>File</th><th>Provider</th><th>Models in chain</th></tr></thead>
-        <tbody>
-          <tr><td><code>core/llm/providers/anthropic.py</code></td><td>Anthropic</td><td>Opus 4.7 → Opus 4.6 → Sonnet 4.6 → Haiku 4.5</td></tr>
-          <tr><td><code>core/llm/providers/openai.py</code></td><td>OpenAI Responses</td><td>gpt-5.5 → gpt-5.4 → gpt-5.4-mini → gpt-5-mini</td></tr>
-          <tr><td><code>core/llm/providers/codex.py</code></td><td>Codex Plus (subscription)</td><td>OpenAI models via Codex routing</td></tr>
-          <tr><td><code>core/llm/providers/glm.py</code></td><td>Zhipu GLM</td><td>GLM-4.5+ (with <code>thinking</code> field)</td></tr>
-        </tbody>
-      </table>
+      <Bi
+        ko={
+          <>
+            <h2>네 개의 어댑터</h2>
+            <table>
+              <thead><tr><th>파일</th><th>프로바이더</th><th>체인 내 모델</th></tr></thead>
+              <tbody>
+                <tr><td><code>core/llm/providers/anthropic.py</code></td><td>Anthropic</td><td>Opus 4.7 → Opus 4.6 → Sonnet 4.6 → Haiku 4.5</td></tr>
+                <tr><td><code>core/llm/providers/openai.py</code></td><td>OpenAI Responses</td><td>gpt-5.5 → gpt-5.4 → gpt-5.4-mini → gpt-5-mini</td></tr>
+                <tr><td><code>core/llm/providers/codex.py</code></td><td>Codex Plus (구독)</td><td>Codex 라우팅을 통한 OpenAI 모델</td></tr>
+                <tr><td><code>core/llm/providers/glm.py</code></td><td>Zhipu GLM</td><td>GLM-4.5+ (<code>thinking</code> 필드 포함)</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Fallback chains</h2>
-      <p>
-        Defined in <code>core/config.py</code>:
-      </p>
-      <pre>{`ANTHROPIC_FALLBACK_CHAIN = ["claude-opus-4-7", "claude-opus-4-6",
+            <h2>폴백 체인</h2>
+            <p>
+              <code>core/config.py</code>에 정의되어 있습니다.
+            </p>
+            <pre>{`ANTHROPIC_FALLBACK_CHAIN = ["claude-opus-4-7", "claude-opus-4-6",
                             "claude-sonnet-4-6", "claude-haiku-4-5"]
 OPENAI_FALLBACK_CHAIN    = ["gpt-5.5", "gpt-5.4",
                             "gpt-5.4-mini", "gpt-5-mini"]
 GLM_FALLBACK_CHAIN       = ["glm-4.6-plus", "glm-4.5-plus"]`}</pre>
-      <p>
-        Each adapter&apos;s <code>retry_with_backoff()</code> walks the chain
-        on retryable errors (rate limit, server error). Non-retryable errors
-        (auth failure, billing) propagate immediately as{" "}
-        <code>BillingError</code> or <code>AuthError</code>.
-      </p>
+            <p>
+              각 어댑터의 <code>retry_with_backoff()</code>는 재시도 가능한 오류 (rate
+              limit, 서버 오류) 에 대해 체인을 따라 내려갑니다. 재시도 불가능한 오류
+              (인증 실패, 결제) 는 <code>BillingError</code> 또는{" "}
+              <code>AuthError</code>로 즉시 전파됩니다.
+            </p>
 
-      <h2>Adaptive thinking depth</h2>
-      <p>
-        The <code>effort</code> parameter (5 levels:{" "}
-        <code>low</code>, <code>medium</code>, <code>high</code>,{" "}
-        <code>max</code>, <code>xhigh</code>) is provider-specific but exposed
-        uniformly:
-      </p>
-      <ul>
-        <li><strong>Anthropic</strong> — <code>output_config.effort=&quot;xhigh&quot;</code> for Opus 4.7 (Opus 4.6 / Sonnet 4.6 reject xhigh, downgrade to <code>max</code>)</li>
-        <li><strong>OpenAI Responses</strong> — <code>reasoning.effort</code> field on gpt-5.x</li>
-        <li><strong>Codex</strong> — <code>codex_reasoning_items</code> sidecar (encrypted reasoning replay across turns)</li>
-        <li><strong>GLM</strong> — <code>extra_body={"{thinking: {type: enabled, clear_thinking: false}}"}</code></li>
-      </ul>
+            <h2>적응형 사고 깊이</h2>
+            <p>
+              <code>effort</code> 파라미터 (5단계.{" "}
+              <code>low</code>, <code>medium</code>, <code>high</code>,{" "}
+              <code>max</code>, <code>xhigh</code>) 는 프로바이더별로 다르지만
+              균일하게 노출됩니다.
+            </p>
+            <ul>
+              <li><strong>Anthropic</strong>. Opus 4.7에 대해 <code>output_config.effort=&quot;xhigh&quot;</code> (Opus 4.6 / Sonnet 4.6은 xhigh를 거부하고 <code>max</code>로 다운그레이드)</li>
+              <li><strong>OpenAI Responses</strong>. gpt-5.x의 <code>reasoning.effort</code> 필드</li>
+              <li><strong>Codex</strong>. <code>codex_reasoning_items</code> 사이드카 (턴 간 암호화된 reasoning 재생)</li>
+              <li><strong>GLM</strong>. <code>extra_body={"{thinking: {type: enabled, clear_thinking: false}}"}</code></li>
+            </ul>
 
-      <h2>Caching</h2>
-      <ul>
-        <li><strong>Anthropic</strong> — `cache_control: ephemeral` on system block (STATIC/DYNAMIC split via <code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>) plus <code>apply_messages_cache_control()</code> on the last 3 non-system messages (PR #864). See <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.</li>
-        <li><strong>OpenAI</strong> — server-side automatic prompt caching (no GEODE wiring required).</li>
-        <li><strong>GLM / Codex</strong> — provider-managed.</li>
-      </ul>
+            <h2>캐싱</h2>
+            <ul>
+              <li><strong>Anthropic</strong>. system 블록에 `cache_control: ephemeral` (<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>를 통한 STATIC/DYNAMIC 분할) 과 최근 3개 non-system 메시지에 대한 <code>apply_messages_cache_control()</code> (PR #864). <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a> 참조.</li>
+              <li><strong>OpenAI</strong>. 서버 측 자동 prompt 캐싱 (GEODE wiring 불필요).</li>
+              <li><strong>GLM / Codex</strong>. 프로바이더 관리.</li>
+            </ul>
 
-      <h2>Circuit breakers</h2>
-      <p>
-        Each adapter owns a module-level <code>CircuitBreaker</code> instance
-        (<code>core/llm/fallback.py</code>). After repeated failures the
-        breaker opens and the chain rotates, giving the next provider a
-        chance instead of hammering the failing one. <code>record_success()</code>{" "}
-        on a successful call resets the breaker.
-      </p>
+            <h2>회로 차단기</h2>
+            <p>
+              각 어댑터는 모듈 수준의 <code>CircuitBreaker</code> 인스턴스를 보유합니다
+              (<code>core/llm/fallback.py</code>). 반복적인 실패가 발생하면 차단기가
+              열리고 체인이 회전합니다. 실패하는 프로바이더를 두드리는 대신 다음
+              프로바이더에게 기회가 가는 셈입니다. 성공한 호출에서{" "}
+              <code>record_success()</code>가 차단기를 재설정합니다.
+            </p>
 
-      <h2>OAuth (Anthropic disabled, OpenAI Codex active)</h2>
-      <p>
-        Per Anthropic ToS, OAuth login on Anthropic is disabled — use API
-        keys only. OpenAI Codex Plus subscription auth is available; see{" "}
-        <em>Operations · OAuth</em> when filled.
-      </p>
+            <h2>OAuth (Anthropic 비활성, OpenAI Codex 활성)</h2>
+            <p>
+              Anthropic ToS에 따라 Anthropic OAuth 로그인은 비활성 상태입니다. API
+              키만 사용합니다. OpenAI Codex Plus 구독 인증은 사용 가능합니다.{" "}
+              <em>Operations · OAuth</em> 가 채워지면 그곳을 참조하세요.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The four adapters</h2>
+            <table>
+              <thead><tr><th>File</th><th>Provider</th><th>Models in chain</th></tr></thead>
+              <tbody>
+                <tr><td><code>core/llm/providers/anthropic.py</code></td><td>Anthropic</td><td>Opus 4.7 → Opus 4.6 → Sonnet 4.6 → Haiku 4.5</td></tr>
+                <tr><td><code>core/llm/providers/openai.py</code></td><td>OpenAI Responses</td><td>gpt-5.5 → gpt-5.4 → gpt-5.4-mini → gpt-5-mini</td></tr>
+                <tr><td><code>core/llm/providers/codex.py</code></td><td>Codex Plus (subscription)</td><td>OpenAI models via Codex routing</td></tr>
+                <tr><td><code>core/llm/providers/glm.py</code></td><td>Zhipu GLM</td><td>GLM-4.5+ (with <code>thinking</code> field)</td></tr>
+              </tbody>
+            </table>
 
+            <h2>Fallback chains</h2>
+            <p>
+              Defined in <code>core/config.py</code>:
+            </p>
+            <pre>{`ANTHROPIC_FALLBACK_CHAIN = ["claude-opus-4-7", "claude-opus-4-6",
+                            "claude-sonnet-4-6", "claude-haiku-4-5"]
+OPENAI_FALLBACK_CHAIN    = ["gpt-5.5", "gpt-5.4",
+                            "gpt-5.4-mini", "gpt-5-mini"]
+GLM_FALLBACK_CHAIN       = ["glm-4.6-plus", "glm-4.5-plus"]`}</pre>
+            <p>
+              Each adapter&apos;s <code>retry_with_backoff()</code> walks the chain
+              on retryable errors (rate limit, server error). Non-retryable errors
+              (auth failure, billing) propagate immediately as{" "}
+              <code>BillingError</code> or <code>AuthError</code>.
+            </p>
+
+            <h2>Adaptive thinking depth</h2>
+            <p>
+              The <code>effort</code> parameter (5 levels:{" "}
+              <code>low</code>, <code>medium</code>, <code>high</code>,{" "}
+              <code>max</code>, <code>xhigh</code>) is provider-specific but exposed
+              uniformly:
+            </p>
+            <ul>
+              <li><strong>Anthropic</strong> — <code>output_config.effort=&quot;xhigh&quot;</code> for Opus 4.7 (Opus 4.6 / Sonnet 4.6 reject xhigh, downgrade to <code>max</code>)</li>
+              <li><strong>OpenAI Responses</strong> — <code>reasoning.effort</code> field on gpt-5.x</li>
+              <li><strong>Codex</strong> — <code>codex_reasoning_items</code> sidecar (encrypted reasoning replay across turns)</li>
+              <li><strong>GLM</strong> — <code>extra_body={"{thinking: {type: enabled, clear_thinking: false}}"}</code></li>
+            </ul>
+
+            <h2>Caching</h2>
+            <ul>
+              <li><strong>Anthropic</strong> — `cache_control: ephemeral` on system block (STATIC/DYNAMIC split via <code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>) plus <code>apply_messages_cache_control()</code> on the last 3 non-system messages (PR #864). See <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.</li>
+              <li><strong>OpenAI</strong> — server-side automatic prompt caching (no GEODE wiring required).</li>
+              <li><strong>GLM / Codex</strong> — provider-managed.</li>
+            </ul>
+
+            <h2>Circuit breakers</h2>
+            <p>
+              Each adapter owns a module-level <code>CircuitBreaker</code> instance
+              (<code>core/llm/fallback.py</code>). After repeated failures the
+              breaker opens and the chain rotates, giving the next provider a
+              chance instead of hammering the failing one. <code>record_success()</code>{" "}
+              on a successful call resets the breaker.
+            </p>
+
+            <h2>OAuth (Anthropic disabled, OpenAI Codex active)</h2>
+            <p>
+              Per Anthropic ToS, OAuth login on Anthropic is disabled — use API
+              keys only. OpenAI Codex Plus subscription auth is available; see{" "}
+              <em>Operations · OAuth</em> when filled.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/memory/5-tier/page.tsx
+++ b/site/src/app/docs/runtime/memory/5-tier/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "5-Tier Context — GEODE Docs" };
 
@@ -7,76 +7,155 @@ export default function Page() {
     <DocsShell
       slug="runtime/memory/5-tier"
       title="5-Tier Context"
+      titleKo="5계층 컨텍스트"
       summary="From raw session log to a single LLM-ready summary. Five tiers, hierarchical override, budget-aware compression."
+      summaryKo="raw 세션 로그에서 LLM에 즉시 투입 가능한 단일 요약까지. 5계층, 계층 override, 예산 인식 압축."
     >
-      <h2>The five tiers</h2>
-      <pre>{`Tier 0    GEODE.md         — agent identity + constraints (G1)
+      <Bi
+        ko={
+          <>
+            <h2>다섯 개의 계층</h2>
+            <pre>{`Tier 0    GEODE.md         — agent identity + constraints (G1)
 Tier 0.5  User Profile     — role, expertise, learned patterns
 Tier 1    Organization     — cross-project shared data
 Tier 2    Project          — .geode/memory/PROJECT.md (50 insights, LRU)
 Tier 3    Session          — in-memory conversation`}</pre>
-      <p>
-        Lower tiers override higher when the same key appears in both. The
-        budget split assumed by <code>ContextAssembler</code> is approximately:
-      </p>
-      <ul>
-        <li>SOUL (Tier 0): 10%</li>
-        <li>Organization (Tier 1): 25%</li>
-        <li>Project (Tier 2): 25%</li>
-        <li>Session (Tier 3): 40%</li>
-      </ul>
+            <p>
+              같은 key가 양쪽에 나타나면 아래 계층이 위 계층을 override 합니다.{" "}
+              <code>ContextAssembler</code>가 가정하는 예산 분할은 대략 다음과 같습니다.
+            </p>
+            <ul>
+              <li>SOUL (Tier 0). 10%</li>
+              <li>Organization (Tier 1). 25%</li>
+              <li>Project (Tier 2). 25%</li>
+              <li>Session (Tier 3). 40%</li>
+            </ul>
 
-      <h2>The assembler</h2>
-      <p>
-        <code>core/memory/context.py:46 class ContextAssembler</code> takes
-        the raw multi-tier state and produces a single{" "}
-        <code>_llm_summary</code> string that the prompt assembler injects
-        as <em>Memory Context</em> in Phase 3 of the assembly pipeline. See{" "}
-        <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a>.
-      </p>
+            <h2>어셈블러</h2>
+            <p>
+              <code>core/memory/context.py:46 class ContextAssembler</code>가
+              원본 멀티 티어 상태를 가져와 단일 <code>_llm_summary</code> 문자열을
+              만들고, prompt 어셈블러가 이를 어셈블리 파이프라인의 Phase 3에서{" "}
+              <em>Memory Context</em>로 주입합니다.{" "}
+              <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a> 참조.
+            </p>
 
-      <h2>Where each tier lives</h2>
-      <table>
-        <thead><tr><th>Tier</th><th>Path</th><th>Lifecycle</th></tr></thead>
-        <tbody>
-          <tr><td>0 GEODE.md</td><td>Repo root</td><td>Read at session start</td></tr>
-          <tr><td>0.5 User Profile</td><td><code>~/.geode/user_profile/</code></td><td>Updated by auto-learn hook</td></tr>
-          <tr><td>1 Organization</td><td><code>~/.geode/organization/</code></td><td>Cross-project, manually curated</td></tr>
-          <tr><td>2 Project</td><td><code>.geode/memory/PROJECT.md</code></td><td>LRU 50 insights, persisted</td></tr>
-          <tr><td>3 Session</td><td>In-process</td><td>Lost on session end (or persisted via <code>/resume</code>)</td></tr>
-        </tbody>
-      </table>
+            <h2>각 계층의 위치</h2>
+            <table>
+              <thead><tr><th>티어</th><th>경로</th><th>라이프사이클</th></tr></thead>
+              <tbody>
+                <tr><td>0 GEODE.md</td><td>repo 루트</td><td>세션 시작 시 읽음</td></tr>
+                <tr><td>0.5 User Profile</td><td><code>~/.geode/user_profile/</code></td><td>auto-learn 훅으로 갱신</td></tr>
+                <tr><td>1 Organization</td><td><code>~/.geode/organization/</code></td><td>프로젝트 간 공유, 수동 큐레이션</td></tr>
+                <tr><td>2 Project</td><td><code>.geode/memory/PROJECT.md</code></td><td>LRU 50 insight, 영속</td></tr>
+                <tr><td>3 Session</td><td>인-프로세스</td><td>세션 종료 시 소실 (<code>/resume</code>으로 영속화 가능)</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Bidirectional learning (G3 slot)</h2>
-      <p>
-        Both <strong>corrections</strong> ("don&apos;t do X") and{" "}
-        <strong>validations</strong> ("yes, X was right") are recorded.{" "}
-        <code>~/.geode/user_profile/learned.md</code> is the single source.
-        Auto-learn hooks watch user feedback and append in the same format
-        used by Claude Code&apos;s memory system.
-      </p>
+            <h2>양방향 학습 (G3 슬롯)</h2>
+            <p>
+              <strong>교정</strong> ("X를 하지 마") 과 <strong>검증</strong>
+              ("그래, X가 맞았어") 가 모두 기록됩니다.{" "}
+              <code>~/.geode/user_profile/learned.md</code>가 단일 출처입니다.
+              auto-learn 훅이 사용자 피드백을 감시하고 Claude Code 메모리 시스템과
+              동일한 형식으로 append 합니다.
+            </p>
 
-      <h2>Vault — agent artifacts</h2>
-      <p>
-        Reports, research notes, application drafts the agent produces
-        during a session land in the <em>vault</em>, not in the memory
-        tiers. <code>classify_artifact()</code> routes by purpose:
-      </p>
-      <ul>
-        <li><code>profile/</code> — about the user</li>
-        <li><code>research/</code> — produced research</li>
-        <li><code>applications/</code> — drafts (resumes, cover letters)</li>
-        <li><code>general/</code> — anything else</li>
-      </ul>
+            <h2>Vault. 에이전트 산출물</h2>
+            <p>
+              세션 동안 에이전트가 생산한 리포트, 리서치 노트, 지원서 초안은
+              메모리 티어가 아니라 <em>vault</em>로 들어갑니다.{" "}
+              <code>classify_artifact()</code>가 용도에 따라 라우팅합니다.
+            </p>
+            <ul>
+              <li><code>profile/</code>. 사용자에 관한 것</li>
+              <li><code>research/</code>. 생산된 리서치</li>
+              <li><code>applications/</code>. 초안 (이력서, 자기소개서)</li>
+              <li><code>general/</code>. 그 외 모든 것</li>
+            </ul>
 
-      <h2>Open question</h2>
-      <p>
-        When does RAG become necessary versus a 200-line PROJECT.md? Today
-        the project tier is small enough to fit in-context. The threshold
-        is somewhere around 500-1000 insights, at which point the LRU
-        truncation starts losing useful state and a vector store becomes
-        worth the complexity.
-      </p>
+            <h2>열린 질문</h2>
+            <p>
+              200줄짜리 PROJECT.md 대비 RAG가 필요한 시점은 언제인가? 오늘 프로젝트
+              티어는 in-context에 충분히 작게 들어옵니다. 임계점은 500-1000 insight
+              어딘가이며, 그 지점에서 LRU 절단이 유용한 상태를 잃기 시작하고
+              벡터 스토어가 복잡도 비용을 정당화할 수 있게 됩니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The five tiers</h2>
+            <pre>{`Tier 0    GEODE.md         — agent identity + constraints (G1)
+Tier 0.5  User Profile     — role, expertise, learned patterns
+Tier 1    Organization     — cross-project shared data
+Tier 2    Project          — .geode/memory/PROJECT.md (50 insights, LRU)
+Tier 3    Session          — in-memory conversation`}</pre>
+            <p>
+              Lower tiers override higher when the same key appears in both. The
+              budget split assumed by <code>ContextAssembler</code> is approximately:
+            </p>
+            <ul>
+              <li>SOUL (Tier 0): 10%</li>
+              <li>Organization (Tier 1): 25%</li>
+              <li>Project (Tier 2): 25%</li>
+              <li>Session (Tier 3): 40%</li>
+            </ul>
+
+            <h2>The assembler</h2>
+            <p>
+              <code>core/memory/context.py:46 class ContextAssembler</code> takes
+              the raw multi-tier state and produces a single{" "}
+              <code>_llm_summary</code> string that the prompt assembler injects
+              as <em>Memory Context</em> in Phase 3 of the assembly pipeline. See{" "}
+              <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a>.
+            </p>
+
+            <h2>Where each tier lives</h2>
+            <table>
+              <thead><tr><th>Tier</th><th>Path</th><th>Lifecycle</th></tr></thead>
+              <tbody>
+                <tr><td>0 GEODE.md</td><td>Repo root</td><td>Read at session start</td></tr>
+                <tr><td>0.5 User Profile</td><td><code>~/.geode/user_profile/</code></td><td>Updated by auto-learn hook</td></tr>
+                <tr><td>1 Organization</td><td><code>~/.geode/organization/</code></td><td>Cross-project, manually curated</td></tr>
+                <tr><td>2 Project</td><td><code>.geode/memory/PROJECT.md</code></td><td>LRU 50 insights, persisted</td></tr>
+                <tr><td>3 Session</td><td>In-process</td><td>Lost on session end (or persisted via <code>/resume</code>)</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Bidirectional learning (G3 slot)</h2>
+            <p>
+              Both <strong>corrections</strong> ("don&apos;t do X") and{" "}
+              <strong>validations</strong> ("yes, X was right") are recorded.{" "}
+              <code>~/.geode/user_profile/learned.md</code> is the single source.
+              Auto-learn hooks watch user feedback and append in the same format
+              used by Claude Code&apos;s memory system.
+            </p>
+
+            <h2>Vault — agent artifacts</h2>
+            <p>
+              Reports, research notes, application drafts the agent produces
+              during a session land in the <em>vault</em>, not in the memory
+              tiers. <code>classify_artifact()</code> routes by purpose:
+            </p>
+            <ul>
+              <li><code>profile/</code> — about the user</li>
+              <li><code>research/</code> — produced research</li>
+              <li><code>applications/</code> — drafts (resumes, cover letters)</li>
+              <li><code>general/</code> — anything else</li>
+            </ul>
+
+            <h2>Open question</h2>
+            <p>
+              When does RAG become necessary versus a 200-line PROJECT.md? Today
+              the project tier is small enough to fit in-context. The threshold
+              is somewhere around 500-1000 insights, at which point the LRU
+              truncation starts losing useful state and a vector store becomes
+              worth the complexity.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/memory/vault/page.tsx
+++ b/site/src/app/docs/runtime/memory/vault/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Vault — GEODE Docs" };
 
@@ -7,53 +7,108 @@ export default function Page() {
     <DocsShell
       slug="runtime/memory/vault"
       title="Vault"
+      titleKo="Vault"
       summary="Where the agent puts its work. Reports, research, application drafts — not memory, but artifacts."
+      summaryKo="에이전트가 작업물을 두는 곳. 리포트, 리서치, 지원 초안. 메모리가 아니라 산출물입니다."
     >
-      <h2>Memory vs Vault</h2>
-      <p>
-        The 5-tier <a href="/geode/docs/runtime/memory/5-tier">memory system</a>{" "}
-        holds context the agent <em>reads</em> on every turn. The vault
-        holds artifacts the agent <em>produced</em>. They have separate
-        lifecycles:
-      </p>
-      <table>
-        <thead><tr><th>Aspect</th><th>Memory</th><th>Vault</th></tr></thead>
-        <tbody>
-          <tr><td>Read on every turn?</td><td>Yes (via ContextAssembler)</td><td>No</td></tr>
-          <tr><td>Format</td><td>Compressed summaries</td><td>Full artifacts (markdown, PDFs, ...)</td></tr>
-          <tr><td>Size budget</td><td>Tight (4K chars warning)</td><td>Disk-only, no in-context budget</td></tr>
-          <tr><td>Auto-classified</td><td>By tier</td><td>By <code>classify_artifact()</code> purpose</td></tr>
-        </tbody>
-      </table>
+      <Bi
+        ko={
+          <>
+            <h2>Memory와 Vault</h2>
+            <p>
+              5계층 <a href="/geode/docs/runtime/memory/5-tier">메모리 시스템</a>은
+              에이전트가 매 턴 <em>읽는</em> 컨텍스트를 담습니다. Vault는 에이전트가{" "}
+              <em>생산한</em> 산출물을 담습니다. 둘은 별개의 라이프사이클을 가집니다.
+            </p>
+            <table>
+              <thead><tr><th>측면</th><th>Memory</th><th>Vault</th></tr></thead>
+              <tbody>
+                <tr><td>매 턴 읽는가?</td><td>예 (ContextAssembler를 통해)</td><td>아니오</td></tr>
+                <tr><td>형식</td><td>압축 요약</td><td>전체 산출물 (markdown, PDF 등)</td></tr>
+                <tr><td>크기 예산</td><td>타이트 (4K chars warning)</td><td>디스크 전용, 인컨텍스트 예산 없음</td></tr>
+                <tr><td>자동 분류</td><td>티어별로</td><td><code>classify_artifact()</code>가 목적별로</td></tr>
+              </tbody>
+            </table>
 
-      <h2>Routes</h2>
-      <p>
-        <code>classify_artifact()</code> reads the artifact metadata
-        (filename, tags, content sniffing) and routes to one of:
-      </p>
-      <ul>
-        <li><code>~/.geode/vault/profile/</code> — about the user (resume drafts, learning notes)</li>
-        <li><code>~/.geode/vault/research/</code> — produced research (briefs, comparisons)</li>
-        <li><code>~/.geode/vault/applications/</code> — drafts for external use (cover letters, proposals)</li>
-        <li><code>~/.geode/vault/general/</code> — anything else</li>
-      </ul>
+            <h2>경로</h2>
+            <p>
+              <code>classify_artifact()</code>는 산출물 메타데이터 (파일명, 태그,
+              내용 sniffing)를 읽고 다음 중 하나로 라우팅합니다.
+            </p>
+            <ul>
+              <li><code>~/.geode/vault/profile/</code>. 사용자에 관한 것 (이력서 초안, 학습 노트).</li>
+              <li><code>~/.geode/vault/research/</code>. 생산된 리서치 (브리프, 비교 자료).</li>
+              <li><code>~/.geode/vault/applications/</code>. 외부용 초안 (커버레터, 제안서).</li>
+              <li><code>~/.geode/vault/general/</code>. 그 외 모든 것.</li>
+            </ul>
 
-      <h2>Why a separate location</h2>
-      <p>
-        Mixing artifacts into memory makes the LLM context pull in
-        full-document content on every turn — a budget killer. Mixing
-        memory into the vault makes it hard to find the user&apos;s actual
-        work products amongst micro-summaries. Separation lets each follow
-        its own retention policy.
-      </p>
+            <h2>왜 위치를 분리하는가</h2>
+            <p>
+              산출물을 메모리에 섞으면 LLM 컨텍스트가 매 턴 전체 문서 내용을 끌어
+              오게 됩니다. 예산 살인범입니다. 메모리를 vault에 섞으면 마이크로
+              요약 더미에서 사용자의 실제 결과물을 찾기 어렵습니다. 분리하면 각자
+              자기 보존 정책을 따를 수 있습니다.
+            </p>
 
-      <h2>Open question</h2>
-      <p>
-        Should vault artifacts be auto-indexed for semantic search? Today
-        retrieval is path-based (the user knows what they made and where).
-        At ~100+ artifacts the manual path approach starts to break down,
-        and a vector index becomes useful. Threshold not yet hit.
-      </p>
+            <h2>열린 질문</h2>
+            <p>
+              vault 산출물을 시맨틱 검색용으로 자동 인덱싱해야 할까요? 현재 검색은
+              경로 기반입니다 (사용자는 자기가 무엇을 어디에 만들었는지 압니다).
+              산출물이 100개를 넘어서면 수동 경로 방식이 무너지기 시작하고 벡터
+              인덱스가 유용해집니다. 임계치는 아직 도달하지 않았습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>Memory vs Vault</h2>
+            <p>
+              The 5-tier <a href="/geode/docs/runtime/memory/5-tier">memory system</a>{" "}
+              holds context the agent <em>reads</em> on every turn. The vault
+              holds artifacts the agent <em>produced</em>. They have separate
+              lifecycles:
+            </p>
+            <table>
+              <thead><tr><th>Aspect</th><th>Memory</th><th>Vault</th></tr></thead>
+              <tbody>
+                <tr><td>Read on every turn?</td><td>Yes (via ContextAssembler)</td><td>No</td></tr>
+                <tr><td>Format</td><td>Compressed summaries</td><td>Full artifacts (markdown, PDFs, ...)</td></tr>
+                <tr><td>Size budget</td><td>Tight (4K chars warning)</td><td>Disk-only, no in-context budget</td></tr>
+                <tr><td>Auto-classified</td><td>By tier</td><td>By <code>classify_artifact()</code> purpose</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Routes</h2>
+            <p>
+              <code>classify_artifact()</code> reads the artifact metadata
+              (filename, tags, content sniffing) and routes to one of:
+            </p>
+            <ul>
+              <li><code>~/.geode/vault/profile/</code> — about the user (resume drafts, learning notes)</li>
+              <li><code>~/.geode/vault/research/</code> — produced research (briefs, comparisons)</li>
+              <li><code>~/.geode/vault/applications/</code> — drafts for external use (cover letters, proposals)</li>
+              <li><code>~/.geode/vault/general/</code> — anything else</li>
+            </ul>
+
+            <h2>Why a separate location</h2>
+            <p>
+              Mixing artifacts into memory makes the LLM context pull in
+              full-document content on every turn — a budget killer. Mixing
+              memory into the vault makes it hard to find the user&apos;s actual
+              work products amongst micro-summaries. Separation lets each follow
+              its own retention policy.
+            </p>
+
+            <h2>Open question</h2>
+            <p>
+              Should vault artifacts be auto-indexed for semantic search? Today
+              retrieval is path-based (the user knows what they made and where).
+              At ~100+ artifacts the manual path approach starts to break down,
+              and a vector index becomes useful. Threshold not yet hit.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/orchestration/page.tsx
+++ b/site/src/app/docs/runtime/orchestration/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Orchestration — GEODE Docs" };
 
@@ -7,25 +7,29 @@ export default function Page() {
     <DocsShell
       slug="runtime/orchestration"
       title="Orchestration"
+      titleKo="오케스트레이션"
       summary="LangGraph StateGraph composition. Pipelines, conditional edges, Send API parallelism, reducers."
+      summaryKo="LangGraph StateGraph 조합. 파이프라인, conditional edge, Send API 병렬화, reducer."
     >
-      <h2>What this layer owns</h2>
-      <p>
-        Where the agentic loop is a generic while-tool-use primitive,
-        orchestration is the structured graph layer for domain-specific
-        pipelines. Game IP analysis, multi-agent verification, parallel
-        analyst fan-out — these all live as StateGraphs here.
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>이 계층이 담당하는 것</h2>
+            <p>
+              agentic 루프가 일반적인 while-tool-use 기본 단위라면, 오케스트레이션은 도메인 특화
+              파이프라인을 위한 구조화된 그래프 계층입니다. Game IP 분석, 멀티 에이전트 검증,
+              병렬 analyst fan-out 모두 이곳에서 StateGraph로 존재합니다.
+            </p>
 
-      <h2>Files</h2>
-      <ul>
-        <li><code>core/orchestration/</code> — 17 modules</li>
-        <li><code>core/graph.py</code> — top-level StateGraph builder entry</li>
-        <li><code>core/state.py</code> — <code>GeodeState</code> TypedDict (the state shape every node receives)</li>
-      </ul>
+            <h2>파일</h2>
+            <ul>
+              <li><code>core/orchestration/</code>. 17개 모듈</li>
+              <li><code>core/graph.py</code>. 최상위 StateGraph 빌더 진입점</li>
+              <li><code>core/state.py</code>. <code>GeodeState</code> TypedDict (모든 노드가 받는 상태 형상)</li>
+            </ul>
 
-      <h2>Pipeline shape</h2>
-      <pre>{`User input
+            <h2>파이프라인 형태</h2>
+            <pre>{`User input
     │
     ▼
 Router (decompose)
@@ -44,29 +48,90 @@ Evaluator → BiasBuster → Synthesizer
     ▼
 Output`}</pre>
 
-      <h2>Send API parallelism</h2>
-      <p>
-        LangGraph&apos;s <code>Send</code> primitive lets a single node
-        dispatch multiple parallel branches with isolated state. GEODE uses
-        it for the analyst fan-out (4 parallel game-IP analysts in the
-        plugin pipeline).
-      </p>
+            <h2>Send API 병렬화</h2>
+            <p>
+              LangGraph의 <code>Send</code> 기본 단위는 단일 노드가 격리된 상태로 여러 병렬
+              브랜치를 dispatch할 수 있게 해 줍니다. GEODE는 이를 analyst fan-out (플러그인
+              파이프라인의 game-IP analyst 4개 병렬 실행)에 사용합니다.
+            </p>
 
-      <h2>Conditional edges</h2>
-      <p>
-        Routing decisions sit on edges, not in nodes. The <code>verification</code> node
-        either advances to <code>synthesizer</code> on pass or loops back
-        to the failing analyst on fail.
-      </p>
+            <h2>Conditional edge</h2>
+            <p>
+              라우팅 결정은 노드가 아니라 엣지 위에 있습니다. <code>verification</code> 노드는
+              통과 시 <code>synthesizer</code>로 진행하고, 실패 시 해당 analyst로 되돌아갑니다.
+            </p>
 
-      <h2>Reducers</h2>
-      <p>
-        State fields that accumulate across parallel branches (analyst
-        findings, error logs) are merged via reducers — typed functions
-        that take the previous value and the new value and return the
-        combined value. <code>core/state.py</code> declares per-field
-        reducer types.
-      </p>
+            <h2>Reducer</h2>
+            <p>
+              병렬 브랜치에 걸쳐 누적되는 state 필드 (analyst 결과, error 로그)는 reducer를 통해
+              병합됩니다. 이전 값과 새 값을 받아 결합된 값을 반환하는 타입화된 함수입니다.
+              <code>core/state.py</code>가 필드별 reducer 타입을 선언합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>What this layer owns</h2>
+            <p>
+              Where the agentic loop is a generic while-tool-use primitive,
+              orchestration is the structured graph layer for domain-specific
+              pipelines. Game IP analysis, multi-agent verification, parallel
+              analyst fan-out — these all live as StateGraphs here.
+            </p>
+
+            <h2>Files</h2>
+            <ul>
+              <li><code>core/orchestration/</code> — 17 modules</li>
+              <li><code>core/graph.py</code> — top-level StateGraph builder entry</li>
+              <li><code>core/state.py</code> — <code>GeodeState</code> TypedDict (the state shape every node receives)</li>
+            </ul>
+
+            <h2>Pipeline shape</h2>
+            <pre>{`User input
+    │
+    ▼
+Router (decompose)
+    │
+    ▼
+[ Send API parallel fan-out ]
+    │
+    ├─► Analyst × N (parallel, identical state)
+    │
+    ▼
+[ Reducer merge results ]
+    │
+    ▼
+Evaluator → BiasBuster → Synthesizer
+    │
+    ▼
+Output`}</pre>
+
+            <h2>Send API parallelism</h2>
+            <p>
+              LangGraph&apos;s <code>Send</code> primitive lets a single node
+              dispatch multiple parallel branches with isolated state. GEODE uses
+              it for the analyst fan-out (4 parallel game-IP analysts in the
+              plugin pipeline).
+            </p>
+
+            <h2>Conditional edges</h2>
+            <p>
+              Routing decisions sit on edges, not in nodes. The <code>verification</code> node
+              either advances to <code>synthesizer</code> on pass or loops back
+              to the failing analyst on fail.
+            </p>
+
+            <h2>Reducers</h2>
+            <p>
+              State fields that accumulate across parallel branches (analyst
+              findings, error logs) are merged via reducers — typed functions
+              that take the previous value and the new value and return the
+              combined value. <code>core/state.py</code> declares per-field
+              reducer types.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/scheduler/page.tsx
+++ b/site/src/app/docs/runtime/scheduler/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Scheduler — GEODE Docs" };
 
@@ -7,50 +7,101 @@ export default function Page() {
     <DocsShell
       slug="runtime/scheduler"
       title="Scheduler"
+      titleKo="스케줄러"
       summary="Natural-language + cron-based task scheduling. Six modules in core/scheduler/, deterministic jitter, calendar bridge."
+      summaryKo="자연어와 cron 기반 작업 스케줄링. core/scheduler/의 6개 모듈, 결정론적 jitter, 캘린더 브리지."
     >
-      <h2>What it does</h2>
-      <p>
-        Users say <em>&ldquo;매주 월요일 9시에 standup 알림 보내줘&rdquo;</em>{" "}
-        and the scheduler parses, normalises, and persists a recurring task.
-        Cron expressions are accepted directly when the user prefers.
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>역할</h2>
+            <p>
+              사용자가 <em>&ldquo;매주 월요일 9시에 standup 알림 보내줘&rdquo;</em>라고 말하면
+              스케줄러가 이를 파싱하고 정규화하여 반복 작업으로 영속화합니다. 사용자가 선호하면
+              cron 표현식을 직접 받기도 합니다.
+            </p>
 
-      <h2>Files</h2>
-      <ul>
-        <li><code>core/scheduler/scheduler.py:76</code> — <code>class ScheduleKind</code> enum (cron, once, calendar)</li>
-        <li><code>core/scheduler/nl_scheduler.py</code> — natural language → cron parser</li>
-        <li><code>core/scheduler/calendar_bridge.py</code> — <code>CalendarSchedulerBridge</code> linking system calendars to schedules</li>
-        <li><code>core/scheduler/jitter.py</code> — deterministic ±10% jitter via task-id hash</li>
-      </ul>
+            <h2>파일</h2>
+            <ul>
+              <li><code>core/scheduler/scheduler.py:76</code>. <code>class ScheduleKind</code> enum (cron, once, calendar)</li>
+              <li><code>core/scheduler/nl_scheduler.py</code>. 자연어를 cron으로 변환하는 파서</li>
+              <li><code>core/scheduler/calendar_bridge.py</code>. 시스템 캘린더와 스케줄을 연결하는 <code>CalendarSchedulerBridge</code></li>
+              <li><code>core/scheduler/jitter.py</code>. task-id 해시 기반 결정론적 ±10% jitter</li>
+            </ul>
 
-      <h2>Jitter (thundering herd defense)</h2>
-      <p>
-        When many tasks share the same nominal trigger time (top of the
-        hour), every cron platform sees a thundering herd. GEODE&apos;s
-        jitter is deterministic: the offset is a function of the task ID
-        hash, so the task always fires at the same offset, but different
-        tasks in the same window spread out.
-      </p>
-      <pre>{`# core/scheduler/scheduler.py:_compute_jitter_frac
+            <h2>Jitter (thundering herd 방어)</h2>
+            <p>
+              다수의 작업이 동일한 명목 트리거 시각 (정각)을 공유할 때 모든 cron 플랫폼에서
+              thundering herd가 발생합니다. GEODE의 jitter는 결정론적입니다. offset이 task ID
+              해시의 함수이므로 같은 작업은 항상 같은 offset에 발화하지만, 같은 윈도 내 다른
+              작업들은 시간상 분산됩니다.
+            </p>
+            <pre>{`# core/scheduler/scheduler.py:_compute_jitter_frac
 fraction = (sha256(task_id) % 1000) / 1000
 offset = -0.1 + (0.2 * fraction)   # ±10%
 fire_at = nominal + offset * period`}</pre>
 
-      <h2>Calendar bridge</h2>
-      <p>
-        GEODE can read events from local calendars (Apple Calendar via the{" "}
-        <code>core/mcp/apple_calendar_adapter.py</code>) and treat them as
-        schedule sources. <em>&ldquo;주간 회의 30분 전에 알림&rdquo;</em>{" "}
-        becomes a derived schedule keyed off the calendar event.
-      </p>
+            <h2>캘린더 브리지</h2>
+            <p>
+              GEODE는 로컬 캘린더 (<code>core/mcp/apple_calendar_adapter.py</code>를 통한
+              Apple Calendar)에서 이벤트를 읽어 스케줄 소스로 취급할 수 있습니다.
+              <em>&ldquo;주간 회의 30분 전에 알림&rdquo;</em>은 캘린더 이벤트를 키로 삼는
+              파생 스케줄이 됩니다.
+            </p>
 
-      <h2>Hook events</h2>
-      <ul>
-        <li><code>SCHEDULE_FIRED</code> — when a task triggers</li>
-        <li><code>SCHEDULE_REGISTERED</code> — when a new schedule is parsed</li>
-      </ul>
+            <h2>훅 이벤트</h2>
+            <ul>
+              <li><code>SCHEDULE_FIRED</code>. 작업이 트리거될 때</li>
+              <li><code>SCHEDULE_REGISTERED</code>. 새 스케줄이 파싱될 때</li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>What it does</h2>
+            <p>
+              Users say <em>&ldquo;매주 월요일 9시에 standup 알림 보내줘&rdquo;</em>{" "}
+              and the scheduler parses, normalises, and persists a recurring task.
+              Cron expressions are accepted directly when the user prefers.
+            </p>
 
+            <h2>Files</h2>
+            <ul>
+              <li><code>core/scheduler/scheduler.py:76</code> — <code>class ScheduleKind</code> enum (cron, once, calendar)</li>
+              <li><code>core/scheduler/nl_scheduler.py</code> — natural language → cron parser</li>
+              <li><code>core/scheduler/calendar_bridge.py</code> — <code>CalendarSchedulerBridge</code> linking system calendars to schedules</li>
+              <li><code>core/scheduler/jitter.py</code> — deterministic ±10% jitter via task-id hash</li>
+            </ul>
+
+            <h2>Jitter (thundering herd defense)</h2>
+            <p>
+              When many tasks share the same nominal trigger time (top of the
+              hour), every cron platform sees a thundering herd. GEODE&apos;s
+              jitter is deterministic: the offset is a function of the task ID
+              hash, so the task always fires at the same offset, but different
+              tasks in the same window spread out.
+            </p>
+            <pre>{`# core/scheduler/scheduler.py:_compute_jitter_frac
+fraction = (sha256(task_id) % 1000) / 1000
+offset = -0.1 + (0.2 * fraction)   # ±10%
+fire_at = nominal + offset * period`}</pre>
+
+            <h2>Calendar bridge</h2>
+            <p>
+              GEODE can read events from local calendars (Apple Calendar via the{" "}
+              <code>core/mcp/apple_calendar_adapter.py</code>) and treat them as
+              schedule sources. <em>&ldquo;주간 회의 30분 전에 알림&rdquo;</em>{" "}
+              becomes a derived schedule keyed off the calendar event.
+            </p>
+
+            <h2>Hook events</h2>
+            <ul>
+              <li><code>SCHEDULE_FIRED</code> — when a task triggers</li>
+              <li><code>SCHEDULE_REGISTERED</code> — when a new schedule is parsed</li>
+            </ul>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/skills/page.tsx
+++ b/site/src/app/docs/runtime/skills/page.tsx
@@ -1,0 +1,82 @@
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
+
+export const metadata = { title: "Skill Registry — GEODE Docs" };
+
+export default function Page() {
+  return (
+    <DocsShell
+      slug="runtime/skills"
+      title="Skill Registry"
+      titleKo="스킬 레지스트리"
+      summary="Runtime skills. Discovery, lifecycle, override."
+      summaryKo="런타임 스킬. 발견, 라이프사이클, 오버라이드."
+    >
+      <Bi
+        ko={
+          <>
+            <p>이 페이지는 GEODE 런타임의 SkillRegistry가 무엇이며 scaffold 측 <code>.claude/skills/</code>와 어떻게 다른지 정리합니다.</p>
+
+            <h2>두 종류의 스킬</h2>
+            <table>
+              <thead><tr><th>구분</th><th>위치</th><th>역할</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Runtime skills</strong></td><td><code>core/skills/</code></td><td>실행 중인 GEODE 에이전트가 호출하는 능력 (예: report 템플릿).</td></tr>
+                <tr><td><strong>Scaffold skills</strong></td><td><code>.claude/skills/</code></td><td>GEODE를 빌드할 때 Claude Code가 사용하는 능력 (예: code review, gitflow).</td></tr>
+              </tbody>
+            </table>
+
+            <h2>발견 (Discovery)</h2>
+            <p>SkillRegistry는 frontmatter + markdown 본문 규약으로 스킬을 발견합니다. 5계층 우선순위:</p>
+            <ul>
+              <li>bundled (코드와 함께 배포)</li>
+              <li>user (<code>~/.geode/skills/</code>)</li>
+              <li>project (<code>./.geode/skills/</code>)</li>
+              <li>org (조직 공유)</li>
+              <li>session (1회용)</li>
+            </ul>
+
+            <h2>오버라이드</h2>
+            <p>같은 이름의 스킬이 여러 계층에 있으면 우선순위 높은 쪽이 이깁니다 (session &gt; project &gt; user &gt; org &gt; bundled).</p>
+
+            <h2>스킬 작성</h2>
+            <p>구체 절차는 <a href="/docs/build/add-tool">도구 추가하기</a>와 동일한 패턴을 따릅니다. <code>SKILL.md</code> 파일 하나가 스킬 1개입니다.</p>
+
+            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-skills.md (TODO), portfolio §3 (recursion 9행 중 3행)</p>
+          </>
+        }
+        en={
+          <>
+            <p>This page explains what the runtime SkillRegistry is and how it differs from the scaffold-side <code>.claude/skills/</code>.</p>
+
+            <h2>Two kinds of skills</h2>
+            <table>
+              <thead><tr><th>Kind</th><th>Location</th><th>Role</th></tr></thead>
+              <tbody>
+                <tr><td><strong>Runtime skills</strong></td><td><code>core/skills/</code></td><td>Capabilities the running GEODE agent invokes (e.g. report templates).</td></tr>
+                <tr><td><strong>Scaffold skills</strong></td><td><code>.claude/skills/</code></td><td>Capabilities Claude Code uses while building GEODE (code review, gitflow, etc.).</td></tr>
+              </tbody>
+            </table>
+
+            <h2>Discovery</h2>
+            <p>SkillRegistry discovers skills via the frontmatter + markdown body convention, across five priority tiers:</p>
+            <ul>
+              <li>bundled (shipped with the code)</li>
+              <li>user (<code>~/.geode/skills/</code>)</li>
+              <li>project (<code>./.geode/skills/</code>)</li>
+              <li>org (org-shared)</li>
+              <li>session (one-shot)</li>
+            </ul>
+
+            <h2>Override</h2>
+            <p>When the same skill name appears in multiple tiers, the higher tier wins (session &gt; project &gt; user &gt; org &gt; bundled).</p>
+
+            <h2>Authoring</h2>
+            <p>The mechanical steps mirror <a href="/docs/build/add-tool">Add a Tool</a>. One <code>SKILL.md</code> file equals one skill.</p>
+
+            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-skills.md (TODO), portfolio §3 (3 of 9 recursion rows).</p>
+          </>
+        }
+      />
+    </DocsShell>
+  );
+}

--- a/site/src/app/docs/runtime/tools/mcp/page.tsx
+++ b/site/src/app/docs/runtime/tools/mcp/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "MCP Servers — GEODE Docs" };
 
@@ -7,79 +7,161 @@ export default function Page() {
     <DocsShell
       slug="runtime/tools/mcp"
       title="MCP Servers"
+      titleKo="MCP 서버"
       summary="16 MCP servers managed by core/mcp. Token guards, lifecycle, and adapters for Apple Calendar, Discord, Slack, Signal."
+      summaryKo="core/mcp가 관리하는 16개 MCP 서버. 토큰 가드, 라이프사이클, Apple Calendar, Discord, Slack, Signal 어댑터."
     >
-      <h2>What MCP is</h2>
-      <p>
-        Model Context Protocol — a standard for exposing tools to LLMs as
-        out-of-process services. GEODE both <strong>consumes</strong> MCP
-        servers (16 of them) and <strong>exposes itself</strong> as one (
-        <code>core/mcp_server.py</code>).
-      </p>
+      <Bi
+        ko={
+          <>
+            <h2>MCP란 무엇인가</h2>
+            <p>
+              Model Context Protocol. 외부 프로세스 서비스로서 LLM에 도구를
+              노출하는 표준입니다. GEODE는 MCP 서버를 <strong>소비</strong>하기도
+              하고 (16개), 자기 자신을 MCP 서버로 <strong>노출</strong>하기도
+              합니다 (<code>core/mcp_server.py</code>).
+            </p>
 
-      <h2>The manager</h2>
-      <p>
-        <code>core/mcp/manager.py</code> holds <code>MCPManager</code>, which
-        owns server processes, routes tool calls, and enforces guards. The
-        public API:
-      </p>
-      <pre>{`class MCPManager:
+            <h2>매니저</h2>
+            <p>
+              <code>core/mcp/manager.py</code>가 <code>MCPManager</code>를 보유합니다.
+              서버 프로세스를 소유하고 도구 호출을 라우팅하며 가드를 강제합니다.
+              공개 API.
+            </p>
+            <pre>{`class MCPManager:
     async def start_server(self, name: str) -> None: ...
     async def stop_server(self, name: str) -> None: ...
     async def call_tool(self, server: str, tool: str, args: dict) -> Any: ...
     async def list_tools(self, server: str) -> list[ToolSpec]: ...`}</pre>
 
-      <h2>The 25K token guard</h2>
-      <p>
-        MCP tools can return arbitrarily large payloads (a web fetch, a
-        directory tree, a database query). Without a cap, a single tool
-        call can blow the context window. GEODE enforces a hard{" "}
-        <strong>25,000 token</strong> cap on every MCP tool result. Over the
-        cap → server-side truncation + a sentinel marker indicating where
-        the truncation happened, so the model knows what it lost.
-      </p>
-      <p>
-        Implementation: <code>core/mcp/</code> guard middleware on the
-        result path. HTML→Markdown conversion (when applicable) happens
-        before the cap so the truncation removes formatting noise rather
-        than content.
-      </p>
+            <h2>25K 토큰 가드</h2>
+            <p>
+              MCP 도구는 임의로 큰 페이로드를 반환할 수 있습니다 (웹 fetch,
+              디렉토리 트리, DB 쿼리). 상한이 없으면 도구 호출 한 번이 컨텍스트
+              윈도를 날려버릴 수 있습니다. GEODE는 모든 MCP 도구 결과에 대해{" "}
+              <strong>25,000 토큰</strong>의 하드 상한을 강제합니다. 상한 초과 →
+              서버 측 절단 + 절단 지점을 알려주는 sentinel 마커. 모델이 무엇을
+              잃었는지 알 수 있도록 합니다.
+            </p>
+            <p>
+              구현. <code>core/mcp/</code>의 결과 경로 위에 있는 가드 미들웨어.
+              해당하는 경우 HTML→Markdown 변환이 상한 적용보다 먼저 일어나
+              절단이 콘텐츠가 아니라 포매팅 노이즈를 제거하게 합니다.
+            </p>
 
-      <h2>The 16 servers</h2>
-      <p>The list as of v0.64.0 (subject to environment-specific availability):</p>
-      <ul>
-        <li>filesystem, git, github</li>
-        <li>web (fetch + search)</li>
-        <li>apple_calendar, composite_calendar (multi-account merge)</li>
-        <li>signal (composite messaging)</li>
-        <li>slack, discord</li>
-        <li>linkedin-reader (browser-controlled)</li>
-        <li>claude-in-chrome (browser bridge)</li>
-        <li>playwright</li>
-        <li>context7 (library docs)</li>
-        <li>google-drive</li>
-        <li>+ a few specialized adapters</li>
-      </ul>
+            <h2>16개의 서버</h2>
+            <p>v0.64.0 기준 목록 (환경별 가용성에 따라 달라질 수 있음).</p>
+            <ul>
+              <li>filesystem, git, github</li>
+              <li>web (fetch + search)</li>
+              <li>apple_calendar, composite_calendar (멀티 계정 병합)</li>
+              <li>signal (composite messaging)</li>
+              <li>slack, discord</li>
+              <li>linkedin-reader (브라우저 제어)</li>
+              <li>claude-in-chrome (브라우저 브릿지)</li>
+              <li>playwright</li>
+              <li>context7 (라이브러리 문서)</li>
+              <li>google-drive</li>
+              <li>+ 몇 개의 특화 어댑터</li>
+            </ul>
 
-      <h2>Exception hierarchy</h2>
-      <p>
-        <code>core/mcp/base.py:12</code> defines the failure types that
-        propagate up to the agentic loop:
-      </p>
-      <ul>
-        <li><code>MCPTimeoutError</code> — server did not respond in time</li>
-        <li><code>MCPConnectionError</code> — server crashed or never started</li>
-        <li><code>MCPProtocolError</code> — malformed response</li>
-        <li><code>MCPGuardError</code> — guard rejected the call (size cap, auth, etc.)</li>
-      </ul>
+            <h2>예외 계층</h2>
+            <p>
+              <code>core/mcp/base.py:12</code>에 agentic 루프까지 전파되는 실패
+              타입이 정의되어 있습니다.
+            </p>
+            <ul>
+              <li><code>MCPTimeoutError</code>. 서버가 시간 안에 응답하지 않음</li>
+              <li><code>MCPConnectionError</code>. 서버가 크래시했거나 시작되지 않음</li>
+              <li><code>MCPProtocolError</code>. 응답이 잘못된 형식</li>
+              <li><code>MCPGuardError</code>. 가드가 호출을 거부함 (크기 상한, 인증 등)</li>
+            </ul>
 
-      <h2>GEODE-as-MCP</h2>
-      <p>
-        <code>core/mcp_server.py</code> exposes GEODE&apos;s own tools (and
-        the agentic loop itself, in restricted form) as an MCP server. This
-        lets other agents — Claude Code, Codex CLI, etc. — call GEODE the
-        same way GEODE calls them.
-      </p>
+            <h2>GEODE-as-MCP</h2>
+            <p>
+              <code>core/mcp_server.py</code>는 GEODE 자체 도구 (그리고 제한된
+              형태로 agentic 루프 자체) 를 MCP 서버로 노출합니다. Claude Code,
+              Codex CLI 같은 다른 에이전트가 GEODE를 자신이 호출하는 다른
+              에이전트와 같은 방식으로 호출할 수 있게 해줍니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>What MCP is</h2>
+            <p>
+              Model Context Protocol — a standard for exposing tools to LLMs as
+              out-of-process services. GEODE both <strong>consumes</strong> MCP
+              servers (16 of them) and <strong>exposes itself</strong> as one (
+              <code>core/mcp_server.py</code>).
+            </p>
+
+            <h2>The manager</h2>
+            <p>
+              <code>core/mcp/manager.py</code> holds <code>MCPManager</code>, which
+              owns server processes, routes tool calls, and enforces guards. The
+              public API:
+            </p>
+            <pre>{`class MCPManager:
+    async def start_server(self, name: str) -> None: ...
+    async def stop_server(self, name: str) -> None: ...
+    async def call_tool(self, server: str, tool: str, args: dict) -> Any: ...
+    async def list_tools(self, server: str) -> list[ToolSpec]: ...`}</pre>
+
+            <h2>The 25K token guard</h2>
+            <p>
+              MCP tools can return arbitrarily large payloads (a web fetch, a
+              directory tree, a database query). Without a cap, a single tool
+              call can blow the context window. GEODE enforces a hard{" "}
+              <strong>25,000 token</strong> cap on every MCP tool result. Over the
+              cap → server-side truncation + a sentinel marker indicating where
+              the truncation happened, so the model knows what it lost.
+            </p>
+            <p>
+              Implementation: <code>core/mcp/</code> guard middleware on the
+              result path. HTML→Markdown conversion (when applicable) happens
+              before the cap so the truncation removes formatting noise rather
+              than content.
+            </p>
+
+            <h2>The 16 servers</h2>
+            <p>The list as of v0.64.0 (subject to environment-specific availability):</p>
+            <ul>
+              <li>filesystem, git, github</li>
+              <li>web (fetch + search)</li>
+              <li>apple_calendar, composite_calendar (multi-account merge)</li>
+              <li>signal (composite messaging)</li>
+              <li>slack, discord</li>
+              <li>linkedin-reader (browser-controlled)</li>
+              <li>claude-in-chrome (browser bridge)</li>
+              <li>playwright</li>
+              <li>context7 (library docs)</li>
+              <li>google-drive</li>
+              <li>+ a few specialized adapters</li>
+            </ul>
+
+            <h2>Exception hierarchy</h2>
+            <p>
+              <code>core/mcp/base.py:12</code> defines the failure types that
+              propagate up to the agentic loop:
+            </p>
+            <ul>
+              <li><code>MCPTimeoutError</code> — server did not respond in time</li>
+              <li><code>MCPConnectionError</code> — server crashed or never started</li>
+              <li><code>MCPProtocolError</code> — malformed response</li>
+              <li><code>MCPGuardError</code> — guard rejected the call (size cap, auth, etc.)</li>
+            </ul>
+
+            <h2>GEODE-as-MCP</h2>
+            <p>
+              <code>core/mcp_server.py</code> exposes GEODE&apos;s own tools (and
+              the agentic loop itself, in restricted form) as an MCP server. This
+              lets other agents — Claude Code, Codex CLI, etc. — call GEODE the
+              same way GEODE calls them.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/runtime/tools/protocol/page.tsx
+++ b/site/src/app/docs/runtime/tools/protocol/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Tool Protocol — GEODE Docs" };
 
@@ -7,79 +7,162 @@ export default function Page() {
     <DocsShell
       slug="runtime/tools/protocol"
       title="Tool Protocol"
+      titleKo="도구 프로토콜"
       summary="Tool protocol, registry, deferred loading. 57 tools (6 always-loaded + 51 deferred), single JSON SOT at core/tools/definitions.json."
+      summaryKo="도구 프로토콜, 레지스트리, 지연 로딩. 57개 도구 (상시 로드 6개 + 지연 로드 51개), 단일 JSON SOT가 core/tools/definitions.json에 있습니다."
     >
-      <h2>The protocol</h2>
-      <p>
-        <code>core/tools/base.py:35</code> defines <code>Tool</code> as a
-        Protocol class. Every tool — native, MCP, plugin — implements:
-      </p>
-      <pre>{`class Tool(Protocol):
+      <Bi
+        ko={
+          <>
+            <h2>프로토콜</h2>
+            <p>
+              <code>core/tools/base.py:35</code>가 <code>Tool</code>을 Protocol
+              클래스로 정의합니다. 네이티브, MCP, 플러그인을 막론하고 모든 도구가
+              아래를 구현합니다.
+            </p>
+            <pre>{`class Tool(Protocol):
     name: str
     description: str
     input_schema: dict[str, Any]
     async def execute(self, **kwargs) -> Any: ...`}</pre>
 
-      <h2>Single source of truth</h2>
-      <p>
-        <code>core/tools/definitions.json</code> centralizes tool metadata
-        (name, description, schema, always-on flag). Handlers live in
-        category modules (<code>core/tools/file_tools.py</code>,{" "}
-        <code>core/tools/memory_tools.py</code>, etc.) and are wired into
-        the registry by name.
-      </p>
+            <h2>단일 진실의 출처</h2>
+            <p>
+              <code>core/tools/definitions.json</code>이 도구 메타데이터 (이름,
+              설명, 스키마, 상시 로드 플래그) 를 중앙 집중화합니다. 핸들러는 카테고리
+              모듈 (<code>core/tools/file_tools.py</code>,{" "}
+              <code>core/tools/memory_tools.py</code> 등) 에 있고, 이름으로 레지스트리에
+              연결됩니다.
+            </p>
 
-      <h2>Deferred loading</h2>
-      <p>
-        With 56 tools, sending all definitions on every LLM call would burn
-        ~10K tokens of input per turn. GEODE splits the catalog:
-      </p>
-      <table>
-        <thead><tr><th>Tier</th><th>Count</th><th>Behaviour</th></tr></thead>
-        <tbody>
-          <tr><td>Always-loaded</td><td>6</td><td>Sent on every LLM call: <code>list_ips</code>, <code>search_ips</code>, <code>analyze_ip</code>, <code>memory_search</code>, <code>show_help</code>, <code>general_web_search</code></td></tr>
-          <tr><td>Deferred</td><td>51</td><td>Discoverable via <code>tool_search</code>, loaded on demand. Activates when total tools exceed <code>defer_threshold</code> (default 10).</td></tr>
-        </tbody>
-      </table>
-      <p>
-        Total tool count: <strong>57</strong> (verified via{" "}
-        <code>core/tools/definitions.json</code>). The frozenset of
-        always-loaded tools lives at <code>core/tools/registry.py:209-218</code>{" "}
-        as <code>ALWAYS_LOADED_TOOLS</code>.
-      </p>
-      <p>
-        The pattern is borrowed from Claude Code&apos;s tool deferred-loading
-        design.
-      </p>
+            <h2>지연 로딩</h2>
+            <p>
+              도구가 56개일 때 모든 LLM 호출마다 정의 전체를 보내면 턴당 약 10K
+              토큰의 input을 태우게 됩니다. GEODE는 카탈로그를 분할합니다.
+            </p>
+            <table>
+              <thead><tr><th>티어</th><th>개수</th><th>동작</th></tr></thead>
+              <tbody>
+                <tr><td>상시 로드</td><td>6</td><td>모든 LLM 호출에서 전송. <code>list_ips</code>, <code>search_ips</code>, <code>analyze_ip</code>, <code>memory_search</code>, <code>show_help</code>, <code>general_web_search</code>.</td></tr>
+                <tr><td>지연 로드</td><td>51</td><td><code>tool_search</code>로 발견 가능, 요청 시 로드. 전체 도구 수가 <code>defer_threshold</code> (기본 10) 를 넘으면 활성화됩니다.</td></tr>
+              </tbody>
+            </table>
+            <p>
+              총 도구 수. <strong>57</strong> (<code>core/tools/definitions.json</code>로
+              실측 확인). 상시 로드 도구의 frozenset은{" "}
+              <code>core/tools/registry.py:209-218</code>에{" "}
+              <code>ALWAYS_LOADED_TOOLS</code>로 정의됩니다.
+            </p>
+            <p>
+              이 패턴은 Claude Code의 도구 지연 로딩 설계에서 빌려온 것입니다.
+            </p>
 
-      <h2>Tool execution lifecycle (Hook events)</h2>
-      <ul>
-        <li><code>TOOL_EXEC_START</code> — before <code>execute()</code></li>
-        <li><code>TOOL_EXEC_END</code> — after success</li>
-        <li><code>TOOL_EXEC_FAILED</code> — exception path</li>
-        <li><code>TOOL_RECOVERY_START</code> / <code>TOOL_RECOVERY_END</code> — retry path</li>
-        <li><code>TOOL_APPROVAL_REQUEST</code> / <code>GRANTED</code> / <code>DENIED</code> — HITL gate</li>
-      </ul>
+            <h2>도구 실행 라이프사이클 (Hook 이벤트)</h2>
+            <ul>
+              <li><code>TOOL_EXEC_START</code>. <code>execute()</code> 이전</li>
+              <li><code>TOOL_EXEC_END</code>. 성공 이후</li>
+              <li><code>TOOL_EXEC_FAILED</code>. 예외 경로</li>
+              <li><code>TOOL_RECOVERY_START</code> / <code>TOOL_RECOVERY_END</code>. 재시도 경로</li>
+              <li><code>TOOL_APPROVAL_REQUEST</code> / <code>GRANTED</code> / <code>DENIED</code>. HITL 게이트</li>
+            </ul>
 
-      <h2>4-tier safety</h2>
-      <p>
-        Tools are tagged with a safety tier in <code>definitions.json</code>:
-      </p>
-      <ol>
-        <li><strong>Read-only</strong> — Read, Grep, Glob, Search → no approval</li>
-        <li><strong>Local mutation</strong> — Edit, Write → in-CWD allow-listed</li>
-        <li><strong>Side-effect</strong> — Bash, message-send → HITL approval</li>
-        <li><strong>Destructive</strong> — rm -rf, force push → confirmation required</li>
-      </ol>
+            <h2>4-티어 안전성</h2>
+            <p>
+              도구는 <code>definitions.json</code>에서 안전 티어로 태깅됩니다.
+            </p>
+            <ol>
+              <li><strong>읽기 전용</strong>. Read, Grep, Glob, Search → 승인 없음</li>
+              <li><strong>로컬 변경</strong>. Edit, Write → CWD 내 allow-list</li>
+              <li><strong>부수 효과</strong>. Bash, 메시지 전송 → HITL 승인</li>
+              <li><strong>파괴적</strong>. rm -rf, force push → 확인 필요</li>
+            </ol>
 
-      <h2>Categories</h2>
-      <ul>
-        <li><strong>FileTools</strong> — Read, Write, Edit, Glob, Grep</li>
-        <li><strong>MemoryTools</strong> — memory_search, memory_get, memory_save</li>
-        <li><strong>DataTools</strong> — query_monolake, IP profile lookup</li>
-        <li><strong>ComputerUse</strong> — provider-agnostic desktop automation (PyAutoGUI)</li>
-        <li><strong>MCP</strong> — exposed via <code>core/mcp/</code> service (16 servers, 25K guard)</li>
-      </ul>
+            <h2>카테고리</h2>
+            <ul>
+              <li><strong>FileTools</strong>. Read, Write, Edit, Glob, Grep</li>
+              <li><strong>MemoryTools</strong>. memory_search, memory_get, memory_save</li>
+              <li><strong>DataTools</strong>. query_monolake, IP 프로파일 조회</li>
+              <li><strong>ComputerUse</strong>. 프로바이더 독립 데스크탑 자동화 (PyAutoGUI)</li>
+              <li><strong>MCP</strong>. <code>core/mcp/</code> 서비스를 통해 노출 (서버 16개, 25K 가드)</li>
+            </ul>
+          </>
+        }
+        en={
+          <>
+            <h2>The protocol</h2>
+            <p>
+              <code>core/tools/base.py:35</code> defines <code>Tool</code> as a
+              Protocol class. Every tool — native, MCP, plugin — implements:
+            </p>
+            <pre>{`class Tool(Protocol):
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    async def execute(self, **kwargs) -> Any: ...`}</pre>
+
+            <h2>Single source of truth</h2>
+            <p>
+              <code>core/tools/definitions.json</code> centralizes tool metadata
+              (name, description, schema, always-on flag). Handlers live in
+              category modules (<code>core/tools/file_tools.py</code>,{" "}
+              <code>core/tools/memory_tools.py</code>, etc.) and are wired into
+              the registry by name.
+            </p>
+
+            <h2>Deferred loading</h2>
+            <p>
+              With 56 tools, sending all definitions on every LLM call would burn
+              ~10K tokens of input per turn. GEODE splits the catalog:
+            </p>
+            <table>
+              <thead><tr><th>Tier</th><th>Count</th><th>Behaviour</th></tr></thead>
+              <tbody>
+                <tr><td>Always-loaded</td><td>6</td><td>Sent on every LLM call: <code>list_ips</code>, <code>search_ips</code>, <code>analyze_ip</code>, <code>memory_search</code>, <code>show_help</code>, <code>general_web_search</code></td></tr>
+                <tr><td>Deferred</td><td>51</td><td>Discoverable via <code>tool_search</code>, loaded on demand. Activates when total tools exceed <code>defer_threshold</code> (default 10).</td></tr>
+              </tbody>
+            </table>
+            <p>
+              Total tool count: <strong>57</strong> (verified via{" "}
+              <code>core/tools/definitions.json</code>). The frozenset of
+              always-loaded tools lives at <code>core/tools/registry.py:209-218</code>{" "}
+              as <code>ALWAYS_LOADED_TOOLS</code>.
+            </p>
+            <p>
+              The pattern is borrowed from Claude Code&apos;s tool deferred-loading
+              design.
+            </p>
+
+            <h2>Tool execution lifecycle (Hook events)</h2>
+            <ul>
+              <li><code>TOOL_EXEC_START</code> — before <code>execute()</code></li>
+              <li><code>TOOL_EXEC_END</code> — after success</li>
+              <li><code>TOOL_EXEC_FAILED</code> — exception path</li>
+              <li><code>TOOL_RECOVERY_START</code> / <code>TOOL_RECOVERY_END</code> — retry path</li>
+              <li><code>TOOL_APPROVAL_REQUEST</code> / <code>GRANTED</code> / <code>DENIED</code> — HITL gate</li>
+            </ul>
+
+            <h2>4-tier safety</h2>
+            <p>
+              Tools are tagged with a safety tier in <code>definitions.json</code>:
+            </p>
+            <ol>
+              <li><strong>Read-only</strong> — Read, Grep, Glob, Search → no approval</li>
+              <li><strong>Local mutation</strong> — Edit, Write → in-CWD allow-listed</li>
+              <li><strong>Side-effect</strong> — Bash, message-send → HITL approval</li>
+              <li><strong>Destructive</strong> — rm -rf, force push → confirmation required</li>
+            </ol>
+
+            <h2>Categories</h2>
+            <ul>
+              <li><strong>FileTools</strong> — Read, Write, Edit, Glob, Grep</li>
+              <li><strong>MemoryTools</strong> — memory_search, memory_get, memory_save</li>
+              <li><strong>DataTools</strong> — query_monolake, IP profile lookup</li>
+              <li><strong>ComputerUse</strong> — provider-agnostic desktop automation (PyAutoGUI)</li>
+              <li><strong>MCP</strong> — exposed via <code>core/mcp/</code> service (16 servers, 25K guard)</li>
+            </ul>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/verification/biasbuster/page.tsx
+++ b/site/src/app/docs/verification/biasbuster/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "BiasBuster — GEODE Docs" };
 
@@ -7,54 +7,109 @@ export default function Page() {
     <DocsShell
       slug="verification/biasbuster"
       title="BiasBuster"
+      titleKo="BiasBuster"
       summary="Six bias detectors run against the analyst panel before the synthesizer. overall_pass=true requires all six false."
+      summaryKo="synthesizer 전에 analyst 패널을 대상으로 6종 편향 검사기가 동작. overall_pass=true는 6개 모두 false일 때만 성립."
     >
-      <h2>The six biases</h2>
-      <table>
-        <thead><tr><th>Bias</th><th>Trigger</th></tr></thead>
-        <tbody>
-          <tr><td>Confirmation</td><td>All analysts trend in the same direction without sufficient signal divergence</td></tr>
-          <tr><td>Recency</td><td>Most recent signal weighted &gt; 50% of the score</td></tr>
-          <tr><td>Anchoring</td><td>CV (coefficient of variation) &lt; 0.05 across 4+ analysts</td></tr>
-          <tr><td>Position</td><td>First/last evaluator score deviates &gt; 1 std from the rest</td></tr>
-          <tr><td>Verbosity</td><td>Score correlates with evidence-paragraph length (threshold tunable per domain)</td></tr>
-          <tr><td>Self-enhancement</td><td>Evaluator scores its own previous output favourably</td></tr>
-        </tbody>
-      </table>
+      <Bi
+        ko={
+          <>
+            <h2>6종 편향</h2>
+            <table>
+              <thead><tr><th>편향</th><th>트리거</th></tr></thead>
+              <tbody>
+                <tr><td>Confirmation</td><td>모든 analyst가 충분한 신호 발산 없이 같은 방향으로 추세</td></tr>
+                <tr><td>Recency</td><td>최근 신호가 점수의 50% 초과 가중치를 차지</td></tr>
+                <tr><td>Anchoring</td><td>4명 이상 analyst에서 CV (변동계수) &lt; 0.05</td></tr>
+                <tr><td>Position</td><td>첫째 또는 마지막 evaluator 점수가 나머지로부터 표준편차 1 초과 이탈</td></tr>
+                <tr><td>Verbosity</td><td>점수가 evidence 단락 길이와 상관 (임계값은 도메인별 조정 가능)</td></tr>
+                <tr><td>Self-enhancement</td><td>evaluator가 자신의 이전 출력을 유리하게 채점</td></tr>
+              </tbody>
+            </table>
 
-      <h2>The decision rule</h2>
-      <p>
-        <code>overall_pass = all(flag is False for flag in [confirmation, recency, anchoring, position, verbosity, self_enhancement])</code>
-      </p>
-      <p>
-        Any single bias flagged sends the panel back through a re-scoring
-        round with the flagged bias surfaced as a constraint to the
-        evaluator prompt.
-      </p>
+            <h2>결정 규칙</h2>
+            <p>
+              <code>overall_pass = all(flag is False for flag in [confirmation, recency, anchoring, position, verbosity, self_enhancement])</code>
+            </p>
+            <p>
+              어느 편향이라도 하나 표시되면 패널을 재스코어링 라운드로 되돌리며, 표시된 편향이
+              evaluator 프롬프트에 제약 조건으로 노출됩니다.
+            </p>
 
-      <h2>The prompt</h2>
-      <p>
-        <code>core/llm/prompts/biasbuster.md</code> holds the system + user
-        templates. They are pinned in <code>_PINNED_HASHES</code> as{" "}
-        <code>BIASBUSTER_SYSTEM</code> and <code>BIASBUSTER_USER</code>.
-      </p>
+            <h2>프롬프트</h2>
+            <p>
+              <code>core/llm/prompts/biasbuster.md</code>가 system + user 템플릿을 보관합니다.
+              <code>_PINNED_HASHES</code>에 <code>BIASBUSTER_SYSTEM</code>과
+              <code>BIASBUSTER_USER</code>로 핀 처리됩니다.
+            </p>
 
-      <h2>Why a separate stage</h2>
-      <p>
-        The evaluators are scored individually and BiasBuster is the only
-        step that sees the <em>panel</em>. The 6 detectors are population-
-        level statistics on the analyst scores, not individual-output
-        checks. Putting them in a separate stage lets the evaluators stay
-        oblivious to each other (good for independence) while still getting
-        the cross-evaluator sanity check.
-      </p>
+            <h2>왜 별도 단계인가</h2>
+            <p>
+              evaluator는 개별적으로 채점되며, BiasBuster는 <em>패널</em>을 보는 유일한 단계입니다.
+              6개 검출기는 analyst 점수에 대한 집단 수준 통계이지 개별 출력 검사가 아닙니다.
+              이를 별도 단계에 두면 evaluator는 서로를 모르는 상태 (독립성에 좋음)를 유지하면서도
+              cross-evaluator 점검을 받을 수 있습니다.
+            </p>
 
-      <h2>Tunable thresholds</h2>
-      <p>
-        Numeric thresholds (CV &lt; 0.05, r &gt; 0.7) live in{" "}
-        <code>plugins/game_ip/config/evaluator_axes.yaml</code> for the
-        Game IP plugin. Other domains define their own.
-      </p>
+            <h2>조정 가능 임계값</h2>
+            <p>
+              수치 임계값 (CV &lt; 0.05, r &gt; 0.7)은 Game IP 플러그인의
+              <code>plugins/game_ip/config/evaluator_axes.yaml</code>에 있습니다. 다른 도메인은
+              자체적으로 정의합니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The six biases</h2>
+            <table>
+              <thead><tr><th>Bias</th><th>Trigger</th></tr></thead>
+              <tbody>
+                <tr><td>Confirmation</td><td>All analysts trend in the same direction without sufficient signal divergence</td></tr>
+                <tr><td>Recency</td><td>Most recent signal weighted &gt; 50% of the score</td></tr>
+                <tr><td>Anchoring</td><td>CV (coefficient of variation) &lt; 0.05 across 4+ analysts</td></tr>
+                <tr><td>Position</td><td>First/last evaluator score deviates &gt; 1 std from the rest</td></tr>
+                <tr><td>Verbosity</td><td>Score correlates with evidence-paragraph length (threshold tunable per domain)</td></tr>
+                <tr><td>Self-enhancement</td><td>Evaluator scores its own previous output favourably</td></tr>
+              </tbody>
+            </table>
+
+            <h2>The decision rule</h2>
+            <p>
+              <code>overall_pass = all(flag is False for flag in [confirmation, recency, anchoring, position, verbosity, self_enhancement])</code>
+            </p>
+            <p>
+              Any single bias flagged sends the panel back through a re-scoring
+              round with the flagged bias surfaced as a constraint to the
+              evaluator prompt.
+            </p>
+
+            <h2>The prompt</h2>
+            <p>
+              <code>core/llm/prompts/biasbuster.md</code> holds the system + user
+              templates. They are pinned in <code>_PINNED_HASHES</code> as{" "}
+              <code>BIASBUSTER_SYSTEM</code> and <code>BIASBUSTER_USER</code>.
+            </p>
+
+            <h2>Why a separate stage</h2>
+            <p>
+              The evaluators are scored individually and BiasBuster is the only
+              step that sees the <em>panel</em>. The 6 detectors are population-
+              level statistics on the analyst scores, not individual-output
+              checks. Putting them in a separate stage lets the evaluators stay
+              oblivious to each other (good for independence) while still getting
+              the cross-evaluator sanity check.
+            </p>
+
+            <h2>Tunable thresholds</h2>
+            <p>
+              Numeric thresholds (CV &lt; 0.05, r &gt; 0.7) live in{" "}
+              <code>plugins/game_ip/config/evaluator_axes.yaml</code> for the
+              Game IP plugin. Other domains define their own.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/app/docs/verification/guardrails/page.tsx
+++ b/site/src/app/docs/verification/guardrails/page.tsx
@@ -1,4 +1,4 @@
-import { DocsShell } from "@/components/geode-docs/docs-shell";
+import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 
 export const metadata = { title: "Guardrails G1-G4 — GEODE Docs" };
 
@@ -7,10 +7,15 @@ export default function Page() {
     <DocsShell
       slug="verification/guardrails"
       title="Guardrails G1-G4"
+      titleKo="가드레일 G1-G4"
       summary="Four progressive checks on LLM output. Schema, Range, Grounding, Coherence. Fail-fast, ladder-shaped."
+      summaryKo="LLM 출력에 대한 4단계 점진적 검사. Schema, Range, Grounding, Coherence. fail-fast, 사다리 구조."
     >
-      <h2>The ladder</h2>
-      <pre>{`G1 Schema      — does the JSON parse and match the type?
+      <Bi
+        ko={
+          <>
+            <h2>사다리</h2>
+            <pre>{`G1 Schema      — does the JSON parse and match the type?
    ↓ pass
 G2 Range       — are numeric scores in [1,5], probabilities in [0,1]?
    ↓ pass
@@ -19,58 +24,121 @@ G3 Grounding   — is each finding backed by evidence in the input?
 G4 Coherence   — do the findings imply the score?
    ↓ pass
 output accepted`}</pre>
-      <p>
-        Each gate is cheaper than the next. G1 is a Pydantic validation. G2
-        is a numeric check. G3 calls a verifier LLM that re-reads the input
-        and confirms each cited fact. G4 calls a verifier LLM that asks
-        whether the score follows from the findings. We do not pay for G4
-        if G1 already failed.
-      </p>
+            <p>
+              각 게이트는 다음 단계보다 저렴합니다. G1은 Pydantic 검증, G2는 수치 검사입니다.
+              G3는 verifier LLM이 입력을 다시 읽고 인용된 각 사실을 확인합니다. G4는 verifier
+              LLM이 점수가 findings로부터 따라 나오는지 묻습니다. G1이 이미 실패했다면 G4 비용은
+              지불하지 않습니다.
+            </p>
 
-      <h2>The verification engine</h2>
-      <p>
-        <code>core/verification/engine.py</code> orchestrates the ladder.
-        <code>core/verification/guardrails.py</code> defines the
-        <code>GuardrailType</code> enum and the per-type validators.
-      </p>
+            <h2>검증 엔진</h2>
+            <p>
+              <code>core/verification/engine.py</code>가 사다리를 오케스트레이션합니다.
+              <code>core/verification/guardrails.py</code>는 <code>GuardrailType</code> enum과
+              타입별 validator를 정의합니다.
+            </p>
 
-      <h2>What a failure does</h2>
-      <p>
-        Failure fires <code>VERIFICATION_FAIL</code> hook, which the
-        AgenticLoop&apos;s <code>ErrorRecoveryStrategy</code> can catch. The
-        default recovery prompts the model with a structured re-ask:
-      </p>
-      <ul>
-        <li>What rule was violated</li>
-        <li>The exact failing field</li>
-        <li>An expected shape (without giving the answer away)</li>
-      </ul>
-      <p>
-        Up to N retries (configurable). Beyond that, the analyst output is
-        marked <code>analyst_failed</code> and the synthesizer skips that
-        contributor.
-      </p>
+            <h2>실패 시 동작</h2>
+            <p>
+              실패는 <code>VERIFICATION_FAIL</code> 훅을 발화시키며, AgenticLoop의
+              <code>ErrorRecoveryStrategy</code>가 이를 잡을 수 있습니다. 기본 복구는 모델에
+              구조화된 re-ask를 보냅니다.
+            </p>
+            <ul>
+              <li>위반된 규칙</li>
+              <li>실패한 정확한 필드</li>
+              <li>기대 형태 (정답을 흘리지 않는 선에서)</li>
+            </ul>
+            <p>
+              최대 N회 재시도 (설정 가능). 그 이상은 analyst 출력이 <code>analyst_failed</code>로
+              표시되고 synthesizer가 해당 기여자를 건너뜁니다.
+            </p>
 
-      <h2>What guardrails do not cover</h2>
-      <p>
-        Guardrails check the <em>shape</em> and <em>defensibility</em> of an
-        output. They do not check for bias — that is{" "}
-        <a href="/geode/docs/verification/biasbuster">BiasBuster</a> — and
-        they do not check the cross-LLM consistency that{" "}
-        <code>cross_llm.md</code> templates provide via independent
-        re-scoring.
-      </p>
+            <h2>가드레일이 다루지 않는 영역</h2>
+            <p>
+              가드레일은 출력의 <em>형상</em>과 <em>방어 가능성</em>을 검사합니다. 편향 검사는
+              다루지 않습니다. 그것은 <a href="/geode/docs/verification/biasbuster">BiasBuster</a>의
+              영역입니다. <code>cross_llm.md</code> 템플릿이 독립 재스코어링으로 제공하는
+              Cross-LLM 일관성도 가드레일이 검사하지 않습니다.
+            </p>
 
-      <h2>Cause classification (synthesizer-locked)</h2>
-      <p>
-        After verification, a separate decision tree classifies the cause
-        (one of six: <code>conversion_failure</code>,{" "}
-        <code>undermarketed</code>, <code>discovery_failure</code>,{" "}
-        <code>genre_mismatch</code>, <code>technical_debt</code>,{" "}
-        <code>none</code>) and the synthesizer is forbidden from
-        re-classifying — it can only narrate. This separation prevents the
-        narrative from inventing a cause that contradicts the evidence.
-      </p>
+            <h2>원인 분류 (synthesizer 잠금)</h2>
+            <p>
+              검증 후 별도의 결정 트리가 원인을 분류합니다. 6가지 중 하나:
+              <code>conversion_failure</code>, <code>undermarketed</code>,
+              <code>discovery_failure</code>, <code>genre_mismatch</code>,
+              <code>technical_debt</code>, <code>none</code>. synthesizer는 재분류가 금지됩니다.
+              서술만 가능합니다. 이 분리는 서술이 증거에 모순되는 원인을 만들어 내는 것을 막습니다.
+            </p>
+          </>
+        }
+        en={
+          <>
+            <h2>The ladder</h2>
+            <pre>{`G1 Schema      — does the JSON parse and match the type?
+   ↓ pass
+G2 Range       — are numeric scores in [1,5], probabilities in [0,1]?
+   ↓ pass
+G3 Grounding   — is each finding backed by evidence in the input?
+   ↓ pass
+G4 Coherence   — do the findings imply the score?
+   ↓ pass
+output accepted`}</pre>
+            <p>
+              Each gate is cheaper than the next. G1 is a Pydantic validation. G2
+              is a numeric check. G3 calls a verifier LLM that re-reads the input
+              and confirms each cited fact. G4 calls a verifier LLM that asks
+              whether the score follows from the findings. We do not pay for G4
+              if G1 already failed.
+            </p>
+
+            <h2>The verification engine</h2>
+            <p>
+              <code>core/verification/engine.py</code> orchestrates the ladder.
+              <code>core/verification/guardrails.py</code> defines the
+              <code>GuardrailType</code> enum and the per-type validators.
+            </p>
+
+            <h2>What a failure does</h2>
+            <p>
+              Failure fires <code>VERIFICATION_FAIL</code> hook, which the
+              AgenticLoop&apos;s <code>ErrorRecoveryStrategy</code> can catch. The
+              default recovery prompts the model with a structured re-ask:
+            </p>
+            <ul>
+              <li>What rule was violated</li>
+              <li>The exact failing field</li>
+              <li>An expected shape (without giving the answer away)</li>
+            </ul>
+            <p>
+              Up to N retries (configurable). Beyond that, the analyst output is
+              marked <code>analyst_failed</code> and the synthesizer skips that
+              contributor.
+            </p>
+
+            <h2>What guardrails do not cover</h2>
+            <p>
+              Guardrails check the <em>shape</em> and <em>defensibility</em> of an
+              output. They do not check for bias — that is{" "}
+              <a href="/geode/docs/verification/biasbuster">BiasBuster</a> — and
+              they do not check the cross-LLM consistency that{" "}
+              <code>cross_llm.md</code> templates provide via independent
+              re-scoring.
+            </p>
+
+            <h2>Cause classification (synthesizer-locked)</h2>
+            <p>
+              After verification, a separate decision tree classifies the cause
+              (one of six: <code>conversion_failure</code>,{" "}
+              <code>undermarketed</code>, <code>discovery_failure</code>,{" "}
+              <code>genre_mismatch</code>, <code>technical_debt</code>,{" "}
+              <code>none</code>) and the synthesizer is forbidden from
+              re-classifying — it can only narrate. This separation prevents the
+              narrative from inventing a cause that contradicts the evidence.
+            </p>
+          </>
+        }
+      />
     </DocsShell>
   );
 }

--- a/site/src/components/geode-docs/docs-shell.tsx
+++ b/site/src/components/geode-docs/docs-shell.tsx
@@ -4,12 +4,30 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { type ReactNode } from "react";
 import { useLocale, useSetLocale, t } from "@/components/geode/locale-context";
-import { DOCS_SITEMAP, adjacentPages } from "@/lib/geode-docs/sitemap";
+import { DOCS_SITEMAP, adjacentPages, findPage, QUADRANT_META, type DocQuadrant } from "@/lib/geode-docs/sitemap";
+import { GEODE_SOT } from "@/data/geode/sot";
 
 const DOCS_BASE = "/docs";
 
 function pageHref(slug: string): string {
   return slug ? `${DOCS_BASE}/${slug}` : DOCS_BASE;
+}
+
+function QuadrantChip({ quadrant, size = "sm" }: { quadrant: DocQuadrant; size?: "sm" | "xs" }) {
+  const locale = useLocale();
+  const meta = QUADRANT_META[quadrant];
+  const classes =
+    size === "xs"
+      ? "inline-flex items-center px-1.5 py-0 rounded text-[9px] font-mono uppercase tracking-wider"
+      : "inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider";
+  return (
+    <span
+      className={classes}
+      style={{ color: meta.color, border: `1px solid ${meta.color}40`, backgroundColor: `${meta.color}10` }}
+    >
+      {t(locale, meta.labelKo, meta.label)}
+    </span>
+  );
 }
 
 function Sidebar() {
@@ -23,7 +41,7 @@ function Sidebar() {
       >
         {t(locale, "GEODE Docs", "GEODE Docs")}
       </Link>
-      <div className="mt-2 space-y-6">
+      <div className="mt-2 space-y-5">
         {DOCS_SITEMAP.map((section) => (
           <div key={section.id}>
             <div className="px-3 text-[10px] uppercase tracking-[0.18em] text-white/40 font-semibold mb-2">
@@ -33,18 +51,27 @@ function Sidebar() {
               {section.pages.map((page) => {
                 const href = pageHref(page.slug);
                 const active = pathname === href || pathname === `${href}/`;
+                const meta = QUADRANT_META[page.quadrant];
                 return (
                   <li key={page.slug || "_index"}>
                     <Link
                       href={href}
                       className={
-                        "block px-3 py-1.5 rounded text-[13px] transition-colors " +
+                        "flex items-center gap-2 px-3 py-1.5 rounded text-[13px] transition-colors " +
                         (active
                           ? "bg-white/[0.06] text-[#F0F0FF]"
                           : "text-white/60 hover:text-[#F0F0FF] hover:bg-white/[0.03]")
                       }
                     >
-                      {t(locale, page.titleKo, page.title)}
+                      <span
+                        className="shrink-0 inline-block w-1 h-1 rounded-full"
+                        style={{ backgroundColor: meta.color }}
+                        aria-label={meta.label}
+                      />
+                      <span className="flex-1 truncate">{t(locale, page.titleKo, page.title)}</span>
+                      {page.externalUrl && (
+                        <span className="text-[9px] text-white/30">↗</span>
+                      )}
                     </Link>
                   </li>
                 );
@@ -149,22 +176,24 @@ export function DocsShell({
   const displayTitle = titleKo ? t(locale, titleKo, title) : title;
   const displaySummary =
     summary && summaryKo ? t(locale, summaryKo, summary) : summary;
+  const found = findPage(slug);
+  const quadrant = found?.page.quadrant;
   return (
     <div className="min-h-screen bg-[#0B1628] text-[#F0F0FF]">
       <header className="sticky top-0 z-30 border-b border-white/[0.06] bg-[#0B1628]/85 backdrop-blur">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
           <div className="flex items-center gap-6">
             <Link href="/portfolio" className="text-sm text-white/60 hover:text-white">
-              ← /geode
+              ← /geode/portfolio
             </Link>
             <span className="text-sm font-display font-bold tracking-wide">
-              {t(locale, "GEODE · 문서", "GEODE · Docs")}
+              {t(locale, "GEODE . 문서", "GEODE . Docs")}
             </span>
           </div>
           <div className="flex items-center gap-4">
             <LocaleToggle />
             <a
-              href="https://github.com/mangowhoiscloud/portfolio"
+              href="https://github.com/mangowhoiscloud/geode"
               className="text-xs text-white/50 hover:text-white"
               target="_blank"
               rel="noreferrer"
@@ -182,6 +211,11 @@ export function DocsShell({
 
         <main className="flex-1 min-w-0 max-w-3xl">
           <div className="mb-10">
+            {quadrant && (
+              <div className="mb-3">
+                <QuadrantChip quadrant={quadrant} />
+              </div>
+            )}
             <h1 className="text-3xl md:text-4xl font-display font-bold tracking-tight">
               {displayTitle}
             </h1>
@@ -195,11 +229,21 @@ export function DocsShell({
       </div>
 
       <footer className="border-t border-white/[0.06] mt-20">
-        <div className="max-w-7xl mx-auto px-6 py-6 text-xs text-white/40 flex justify-between">
+        <div className="max-w-7xl mx-auto px-6 py-6 text-xs text-white/40 flex justify-between flex-wrap gap-2">
           <span>
-            {t(locale, "GEODE v0.64.0 · 문서 생성 2026-05-01", "GEODE v0.64.0 · Docs generated 2026-05-01")}
+            {t(
+              locale,
+              `GEODE v${GEODE_SOT.version} . 문서 동기화 ${GEODE_SOT.syncedAt}`,
+              `GEODE v${GEODE_SOT.version} . Docs synced ${GEODE_SOT.syncedAt}`
+            )}
           </span>
-          <span>{t(locale, "출처: github.com/mangowhoiscloud/portfolio", "Source: github.com/mangowhoiscloud/portfolio")}</span>
+          <span>
+            {t(
+              locale,
+              "출처: github.com/mangowhoiscloud/geode",
+              "Source: github.com/mangowhoiscloud/geode"
+            )}
+          </span>
         </div>
       </footer>
     </div>

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -1,11 +1,20 @@
 /**
- * GEODE Docs sitemap — single source of truth for navigation and route generation.
+ * GEODE Docs sitemap. Single source of truth for navigation and route
+ * generation.
  *
- * Each leaf entry maps to a static page at /geode/docs/<slug>.
+ * Each leaf entry maps to a static page at /docs/<slug> (basePath = /geode,
+ * so the final URL is `mangowhoiscloud.github.io/geode/docs/<slug>`).
+ *
  * Sections are rendered in the sidebar in the order declared.
+ *
+ * Quadrant follows Diátaxis (https://diataxis.fr). Every page must declare
+ * one of `tutorial`, `how-to`, `reference`, `explanation`. The sidebar
+ * shows a small color chip per page.
  *
  * Bilingual: every entry carries an English and Korean title + summary.
  */
+
+export type DocQuadrant = "tutorial" | "how-to" | "reference" | "explanation";
 
 export type DocPage = {
   slug: string;
@@ -13,6 +22,9 @@ export type DocPage = {
   titleKo: string;
   summary?: string;
   summaryKo?: string;
+  quadrant: DocQuadrant;
+  /** Optional outbound link. If set, sidebar shows it and the page may simply redirect. */
+  externalUrl?: string;
 };
 
 export type DocSection = {
@@ -24,106 +36,138 @@ export type DocSection = {
 
 export const DOCS_SITEMAP: DocSection[] = [
   {
-    id: "intro",
-    title: "Introduction",
+    id: "00-welcome",
+    title: "Welcome",
     titleKo: "시작하기",
     pages: [
-      { slug: "", title: "Overview", titleKo: "개요", summary: "What GEODE is and how the docs are organized", summaryKo: "GEODE의 정체성과 docs 구성" },
-      { slug: "quick-start", title: "Quick Start", titleKo: "빠른 시작", summary: "Install and run", summaryKo: "설치와 실행" },
+      {
+        slug: "",
+        title: "What GEODE is",
+        titleKo: "GEODE 소개",
+        summary: "A self-hosting agent harness. What it does, who it is for, where to go next.",
+        summaryKo: "스스로를 빌드하는 자율 에이전트 하네스. 무엇을 하고, 누구를 위한 것이고, 어디로 갈지.",
+        quadrant: "explanation",
+      },
+      {
+        slug: "quick-start",
+        title: "Quick Start",
+        titleKo: "빠른 시작",
+        summary: "Install GEODE and run your first analysis in five minutes.",
+        summaryKo: "5분 안에 GEODE를 설치하고 첫 분석을 실행합니다.",
+        quadrant: "tutorial",
+      },
+      {
+        slug: "architecture/overview",
+        title: "4-Layer Stack",
+        titleKo: "4-계층 스택",
+        summary: "Model. Runtime. Harness. Agent. One paragraph each.",
+        summaryKo: "Model. Runtime. Harness. Agent. 한 문단씩.",
+        quadrant: "reference",
+      },
     ],
   },
   {
-    id: "architecture",
-    title: "Architecture",
-    titleKo: "아키텍처",
+    id: "01-run",
+    title: "Run GEODE",
+    titleKo: "GEODE 실행하기",
     pages: [
-      { slug: "architecture/overview", title: "4-Layer Stack", titleKo: "4-계층 스택", summary: "Model → Runtime → Harness → Agent", summaryKo: "Model → Runtime → Harness → Agent" },
-      { slug: "architecture/agentic-loop", title: "Agentic Loop", titleKo: "Agentic 루프", summary: "while(tool_use) primitive", summaryKo: "while(tool_use) 기본 단위" },
-      { slug: "architecture/system-index", title: "System Index", titleKo: "시스템 색인", summary: "All subsystems catalog", summaryKo: "전체 서브시스템 카탈로그" },
+      { slug: "run/pick-path", title: "Pick a Path", titleKo: "경로 선택", summary: "Subscription, API key, or free path. How to choose for your situation.", summaryKo: "구독, API 키, 무료 경로 중 본인 상황에 맞춰 고르는 법.", quadrant: "how-to" },
+      { slug: "run/providers", title: "Configure Providers", titleKo: "프로바이더 설정", summary: "Anthropic, OpenAI, Codex, GLM. Where keys go, what fallback chain you get.", summaryKo: "Anthropic, OpenAI, Codex, GLM. 키를 어디에 두고 어떤 폴백 체인이 동작하는지.", quadrant: "how-to" },
+      { slug: "run/analyze", title: "Run an Analysis", titleKo: "분석 실행", summary: "Run the Game IP pipeline end to end, dry-run or live.", summaryKo: "Game IP 파이프라인을 dry-run 또는 라이브로 끝까지 돌리기.", quadrant: "how-to" },
+      { slug: "run/schedule", title: "Schedule Tasks", titleKo: "작업 예약", summary: "Natural language plus cron, with jitter. Daily reports as a single command.", summaryKo: "자연어와 cron, jitter 포함. 일일 리포트를 한 줄 명령으로.", quadrant: "how-to" },
+      { slug: "run/serve", title: "Run as Daemon", titleKo: "데몬으로 실행", summary: "Start serve, restart, stop. Thin CLI on top of an IPC-served runtime.", summaryKo: "serve 시작·재시작·종료. IPC 데몬 위에 thin CLI.", quadrant: "how-to" },
+      { slug: "run/messaging", title: "Messaging Integrations", titleKo: "메신저 연동", summary: "Hook GEODE into Slack, Discord, or Telegram via gateway adapters.", summaryKo: "게이트웨이 어댑터로 Slack, Discord, Telegram에 연결.", quadrant: "how-to" },
+      { slug: "run/troubleshooting", title: "Troubleshooting", titleKo: "문제 해결", summary: "Common failure modes and where to look. Logs, hooks, runlog.", summaryKo: "흔한 실패 모드와 살펴볼 곳. 로그, 훅, runlog.", quadrant: "how-to" },
     ],
   },
   {
-    id: "runtime-llm",
-    title: "Runtime · LLM",
-    titleKo: "런타임 · LLM",
+    id: "02-reference",
+    title: "System Reference",
+    titleKo: "시스템 레퍼런스",
     pages: [
-      { slug: "runtime/llm/prompt-system", title: "Prompt System", titleKo: "프롬프트 시스템", summary: "5-layer prompt architecture", summaryKo: "프롬프트 5계층 아키텍처" },
-      { slug: "runtime/llm/prompt-caching", title: "Prompt Caching", titleKo: "프롬프트 캐싱", summary: "STATIC/DYNAMIC boundary + ephemeral", summaryKo: "STATIC/DYNAMIC 경계 + ephemeral 캐시" },
-      { slug: "runtime/llm/prompt-hashing", title: "Prompt Hashing", titleKo: "프롬프트 해싱", summary: "Karpathy P4 ratchet, 20 pinned hashes", summaryKo: "Karpathy P4 ratchet, 20 핀" },
-      { slug: "runtime/llm/providers", title: "Providers", titleKo: "프로바이더", summary: "Anthropic / OpenAI / Codex / GLM", summaryKo: "Anthropic / OpenAI / Codex / GLM" },
-      { slug: "runtime/llm/langsmith", title: "LangSmith", titleKo: "LangSmith", summary: "Opt-in tracing", summaryKo: "Opt-in 트레이싱" },
+      { slug: "architecture/agentic-loop", title: "Agentic Loop", titleKo: "Agentic 루프", summary: "while(tool_use) primitive. 50-round limit. 5 termination paths.", summaryKo: "while(tool_use) 기본 단위. 50 라운드 상한. 5종 종료 경로.", quadrant: "reference" },
+      { slug: "architecture/system-index", title: "System Index", titleKo: "시스템 색인", summary: "Every subsystem with file paths. The flat catalog.", summaryKo: "모든 서브시스템과 파일 경로. 평면 카탈로그.", quadrant: "reference" },
+      { slug: "runtime/llm/providers", title: "Providers", titleKo: "프로바이더", summary: "Anthropic, OpenAI, Codex, GLM. Wire-level differences and fallback chains.", summaryKo: "Anthropic, OpenAI, Codex, GLM. wire-level 차이와 폴백 체인.", quadrant: "reference" },
+      { slug: "runtime/llm/prompt-system", title: "Prompt System", titleKo: "프롬프트 시스템", summary: "5-layer prompt architecture. Assembly pipeline.", summaryKo: "프롬프트 5계층 아키텍처. 어셈블리 파이프라인.", quadrant: "reference" },
+      { slug: "runtime/llm/prompt-caching", title: "Prompt Caching", titleKo: "프롬프트 캐싱", summary: "STATIC and DYNAMIC boundary. Ephemeral cache control.", summaryKo: "STATIC과 DYNAMIC 경계. ephemeral 캐시 제어.", quadrant: "reference" },
+      { slug: "runtime/llm/prompt-hashing", title: "Prompt Hashing", titleKo: "프롬프트 해싱", summary: "Karpathy P4 ratchet. 20 pinned hashes. Build break on drift.", summaryKo: "Karpathy P4 ratchet. 20개 해시 핀. drift 발생 시 빌드 break.", quadrant: "reference" },
+      { slug: "runtime/llm/langsmith", title: "LangSmith", titleKo: "LangSmith", summary: "Opt-in tracing. Hook + RunLog replacement path.", summaryKo: "Opt-in 트레이싱. 훅과 RunLog 대체 경로.", quadrant: "reference" },
+      { slug: "runtime/tools/protocol", title: "Tool Protocol", titleKo: "도구 프로토콜", summary: "Registry, deferred loading, 61 tools. Six always-loaded, the rest fetched on demand.", summaryKo: "레지스트리, 지연 로딩, 61개 도구. 6개 상시 로드, 나머지는 요청 시 가져옴.", quadrant: "reference" },
+      { slug: "runtime/tools/mcp", title: "MCP Servers", titleKo: "MCP 서버", summary: "Servers, 25K result guard, HTML to Markdown fallback.", summaryKo: "서버, 25K 결과 가드, HTML to Markdown 폴백.", quadrant: "reference" },
+      { slug: "runtime/memory/5-tier", title: "5-Tier Context", titleKo: "5계층 컨텍스트", summary: "raw → assembled → projected. Where each layer reads and writes.", summaryKo: "raw → assembled → projected. 각 계층의 read·write 경로.", quadrant: "reference" },
+      { slug: "runtime/memory/vault", title: "Vault", titleKo: "Vault", summary: "Agent artifact storage. Lifetime and access rules.", summaryKo: "에이전트 산출물 저장소. 수명과 접근 규칙.", quadrant: "reference" },
+      { slug: "harness/cli", title: "CLI and Slash", titleKo: "CLI와 슬래시 명령", summary: "Thin gateway plus IPC. /model /stop /clean /uninstall /status.", summaryKo: "Thin 게이트웨이와 IPC. /model /stop /clean /uninstall /status.", quadrant: "reference" },
+      { slug: "harness/hooks", title: "Hook System", titleKo: "훅 시스템", summary: "58 lifecycle events grouped into 14 categories. Three trigger modes.", summaryKo: "58개 라이프사이클 이벤트, 14개 카테고리. 세 가지 트리거 모드.", quadrant: "reference" },
+      { slug: "harness/lifecycle", title: "Lifecycle", titleKo: "라이프사이클", summary: "Bootstrap, serve, shutdown. ContextVar injection order.", summaryKo: "Bootstrap, serve, shutdown. ContextVar 주입 순서.", quadrant: "reference" },
+      { slug: "verification/guardrails", title: "Guardrails G1-G4", titleKo: "가드레일 G1-G4", summary: "Schema, Range, Grounding, Coherence. Fail-fast ladder.", summaryKo: "Schema, Range, Grounding, Coherence. fail-fast 사다리.", quadrant: "reference" },
+      { slug: "verification/biasbuster", title: "BiasBuster", titleKo: "BiasBuster", summary: "Six bias detectors. Confirmation, recency, anchoring, and three more.", summaryKo: "6종 편향 검사기. Confirmation, recency, anchoring 외 3종.", quadrant: "reference" },
+      { slug: "runtime/computer-use", title: "Computer Use", titleKo: "컴퓨터 사용", summary: "Provider-agnostic desktop automation. Anthropic plus OpenAI unified.", summaryKo: "프로바이더 독립 데스크탑 자동화. Anthropic + OpenAI 통합.", quadrant: "reference" },
+      { slug: "runtime/scheduler", title: "Scheduler", titleKo: "스케줄러", summary: "Natural language plus cron plus jitter. Where jobs persist.", summaryKo: "자연어 + cron + jitter. 작업 영속 위치.", quadrant: "reference" },
+      { slug: "runtime/automation", title: "Automation (L4.5)", titleKo: "자동화 (L4.5)", summary: "Feedback loop plus model promotion. Drift detection.", summaryKo: "피드백 루프 + 모델 프로모션. drift 감지.", quadrant: "reference" },
+      { slug: "runtime/orchestration", title: "Orchestration", titleKo: "오케스트레이션", summary: "LangGraph StateGraph. Node topology. Send API parallelism.", summaryKo: "LangGraph StateGraph. 노드 토폴로지. Send API 병렬화.", quadrant: "reference" },
+      { slug: "runtime/auth", title: "Auth and OAuth", titleKo: "인증과 OAuth", summary: "Profile rotator, Anthropic ToS path, Codex flow.", summaryKo: "프로파일 로테이터, Anthropic ToS 경로, Codex 플로우.", quadrant: "reference" },
+      { slug: "runtime/domains", title: "Domain Plugins", titleKo: "도메인 플러그인", summary: "DomainPort protocol. plugin loader. Add a domain in 30 lines.", summaryKo: "DomainPort 프로토콜. 플러그인 로더. 30 라인으로 도메인 추가.", quadrant: "reference" },
+      { slug: "runtime/skills", title: "Skill Registry", titleKo: "스킬 레지스트리", summary: "Runtime skills. Discovery, lifecycle, override.", summaryKo: "런타임 스킬. 발견, 라이프사이클, 오버라이드.", quadrant: "reference" },
+      { slug: "plugins/game-ip", title: "Game IP Plugin", titleKo: "Game IP 플러그인", summary: "4 Analysts plus 3 Evaluators plus Synthesizer. 14-axis PSM scoring.", summaryKo: "Analyst 4 + Evaluator 3 + Synthesizer. 14-axis PSM 점수.", quadrant: "reference" },
     ],
   },
   {
-    id: "runtime-tools",
-    title: "Runtime · Tools",
-    titleKo: "런타임 · 도구",
+    id: "03-build",
+    title: "Build on GEODE",
+    titleKo: "GEODE 위에서 만들기",
     pages: [
-      { slug: "runtime/tools/protocol", title: "Tool Protocol", titleKo: "도구 프로토콜", summary: "Tool registry, deferred loading", summaryKo: "도구 레지스트리, 지연 로딩" },
-      { slug: "runtime/tools/mcp", title: "MCP Servers", titleKo: "MCP 서버", summary: "16 servers, 25K guard", summaryKo: "16개 서버, 25K 토큰 가드" },
+      { slug: "build/add-tool", title: "Add a Tool", titleKo: "도구 추가하기", summary: "Define, register, expose via definitions.json. Make it deferred-loadable.", summaryKo: "정의하고, 등록하고, definitions.json에 노출. deferred 가능하게 만들기.", quadrant: "how-to" },
+      { slug: "build/add-domain", title: "Add a Domain Plugin", titleKo: "도메인 플러그인 추가", summary: "Implement DomainPort. Wire into core/domains/loader.py registry.", summaryKo: "DomainPort 구현. core/domains/loader.py 레지스트리에 연결.", quadrant: "how-to" },
+      { slug: "build/add-hook", title: "Add a Hook Handler", titleKo: "훅 핸들러 추가", summary: "Pick an event, register a handler, verify with the test harness.", summaryKo: "이벤트 선택, 핸들러 등록, 테스트 하네스로 검증.", quadrant: "how-to" },
+      { slug: "build/testing", title: "Test Your Changes", titleKo: "변경사항 테스트", summary: "ruff. mypy. pytest. E2E dry-run. The four quality gates.", summaryKo: "ruff. mypy. pytest. E2E dry-run. 4개 품질 게이트.", quadrant: "how-to" },
     ],
   },
   {
-    id: "runtime-memory",
-    title: "Runtime · Memory",
-    titleKo: "런타임 · 메모리",
+    id: "04-ops",
+    title: "Operations",
+    titleKo: "운영",
     pages: [
-      { slug: "runtime/memory/5-tier", title: "5-Tier Context", titleKo: "5계층 컨텍스트", summary: "raw → assembled → projected", summaryKo: "raw → assembled → projected" },
-      { slug: "runtime/memory/vault", title: "Vault", titleKo: "Vault", summary: "Agent artifact storage", summaryKo: "에이전트 산출물 저장소" },
+      { slug: "ops/long-running", title: "Long-running Safety", titleKo: "장기 실행 안전", summary: "Token guards, context overflow, sliding window. Graceful drain.", summaryKo: "토큰 가드, 컨텍스트 오버플로, 슬라이딩 윈도. graceful drain.", quadrant: "how-to" },
+      { slug: "ops/cost", title: "Cost Monitoring", titleKo: "비용 모니터링", summary: "Per-session and per-day budgets. When to switch models.", summaryKo: "세션·일별 예산. 모델 전환 시점.", quadrant: "how-to" },
+      { slug: "ops/oauth", title: "OAuth Token Rotation", titleKo: "OAuth 토큰 회전", summary: "Anthropic ToS, Codex flow, refresh policy.", summaryKo: "Anthropic ToS, Codex 플로우, 갱신 정책.", quadrant: "how-to" },
+      { slug: "ops/observability", title: "Observability", titleKo: "관측성", summary: "Hooks, RunLog, Petri audits. Three lenses, one runtime.", summaryKo: "훅, RunLog, Petri 감사. 세 가지 렌즈, 하나의 런타임.", quadrant: "how-to" },
     ],
   },
   {
-    id: "runtime-other",
-    title: "Runtime · Other",
-    titleKo: "런타임 · 기타",
+    id: "05-petri",
+    title: "Petri Audit",
+    titleKo: "Petri 감사",
     pages: [
-      { slug: "runtime/scheduler", title: "Scheduler", titleKo: "스케줄러", summary: "NL + cron + jitter", summaryKo: "자연어 + cron + jitter" },
-      { slug: "runtime/automation", title: "Automation (L4.5)", titleKo: "자동화 (L4.5)", summary: "Feedback loop + model promotion", summaryKo: "피드백 루프 + 모델 프로모션" },
-      { slug: "runtime/orchestration", title: "Orchestration", titleKo: "오케스트레이션", summary: "LangGraph StateGraph", summaryKo: "LangGraph StateGraph" },
-      { slug: "runtime/auth", title: "Auth & OAuth", titleKo: "인증 & OAuth", summary: "Profile rotator, Anthropic ToS, Codex", summaryKo: "프로파일 로테이터, Anthropic ToS, Codex" },
-      { slug: "runtime/computer-use", title: "Computer Use", titleKo: "컴퓨터 사용", summary: "Provider-agnostic desktop automation", summaryKo: "프로바이더 독립 데스크탑 자동화" },
-      { slug: "runtime/domains", title: "Domain Plugins", titleKo: "도메인 플러그인", summary: "DomainPort protocol, plugin loader", summaryKo: "DomainPort 프로토콜, 플러그인 로더" },
+      { slug: "petri/overview", title: "Petri × GEODE Integration", titleKo: "Petri × GEODE 통합", summary: "Anthropic Alignment Science's framework, wrapped over GEODE's agent. 173 seeds, 38 judge dimensions.", summaryKo: "Anthropic Alignment Science의 프레임워크를 GEODE 에이전트 위에 얹음. 173 seeds, 38 judge 차원.", quadrant: "explanation" },
+      { slug: "petri/run", title: "Run an Audit", titleKo: "감사 실행", summary: "inspect eval inspect_petri/audit. Choose model roles, seeds, and turn budget.", summaryKo: "inspect eval inspect_petri/audit. 모델 역할, seeds, turn 예산 선택.", quadrant: "how-to" },
+      { slug: "petri/judge-dimensions", title: "38 Judge Dimensions", titleKo: "38 Judge 차원", summary: "What each dimension scores. How to read the heatmap.", summaryKo: "각 차원이 무엇을 평가하는지. heatmap 읽는 법.", quadrant: "reference" },
+      { slug: "petri/bundle", title: "Audit Bundle Viewer", titleKo: "감사 Bundle 뷰어", summary: "Live inspect_ai transcript viewer for the latest GEODE audit run.", summaryKo: "최신 GEODE 감사 run의 라이브 inspect_ai 트랜스크립트 뷰어.", quadrant: "reference", externalUrl: "/petri-bundle/" },
     ],
   },
   {
-    id: "harness",
-    title: "Harness",
-    titleKo: "하네스",
+    id: "06-why",
+    title: "Explanation",
+    titleKo: "왜 이렇게",
     pages: [
-      { slug: "harness/cli", title: "CLI & Slash Commands", titleKo: "CLI & 슬래시 명령", summary: "Thin gateway + IPC", summaryKo: "Thin 게이트웨이 + IPC" },
-      { slug: "harness/hooks", title: "Hook System", titleKo: "훅 시스템", summary: "58 events lifecycle", summaryKo: "58개 라이프사이클 이벤트" },
-      { slug: "harness/lifecycle", title: "Lifecycle", titleKo: "라이프사이클", summary: "Bootstrap / serve / shutdown", summaryKo: "부트스트랩 / 서브 / 종료" },
+      { slug: "explanation/self-hosting", title: "Why a Self-Hosting Harness", titleKo: "왜 self-hosting 하네스인가", summary: "The runtime and the build line share primitives. Why that mattered.", summaryKo: "런타임과 빌드 라인이 같은 기본 단위를 공유하는 이유.", quadrant: "explanation" },
+      { slug: "explanation/ratchet", title: "Why Ratchet Discipline", titleKo: "왜 ratchet 규율인가", summary: "20 pinned prompt hashes. 5-stage CI. The ratchet shape that prevents drift.", summaryKo: "20개 프롬프트 해시 핀. 5단계 CI. drift를 막는 ratchet 형태.", quadrant: "explanation" },
+      { slug: "explanation/4-layer", title: "Why 4 Layers", titleKo: "왜 4-계층인가", summary: "Model, Runtime, Harness, Agent. Where each layer's responsibility ends.", summaryKo: "Model, Runtime, Harness, Agent. 각 계층의 책임이 끝나는 지점.", quadrant: "explanation" },
+      { slug: "explanation/solo", title: "Why a Solo Author", titleKo: "왜 단독 저자인가", summary: "What ratchet-driven release lets one person hold together. Trade-offs.", summaryKo: "ratchet-driven release가 한 명이 끌고 갈 수 있게 해주는 것. 트레이드오프.", quadrant: "explanation" },
     ],
   },
   {
-    id: "verification",
-    title: "Verification",
-    titleKo: "검증",
-    pages: [
-      { slug: "verification/guardrails", title: "Guardrails G1-G4", titleKo: "가드레일 G1-G4", summary: "Schema/Range/Grounding/Coherence", summaryKo: "Schema/Range/Grounding/Coherence" },
-      { slug: "verification/biasbuster", title: "BiasBuster", titleKo: "BiasBuster", summary: "6 bias detection", summaryKo: "6가지 편향 검사" },
-    ],
-  },
-  {
-    id: "plugins",
-    title: "Plugins",
-    titleKo: "플러그인",
-    pages: [
-      { slug: "plugins/game-ip", title: "Game IP Plugin", titleKo: "Game IP 플러그인", summary: "4 Analysts + 3 Evaluators + Synthesizer", summaryKo: "4 Analyst + 3 Evaluator + Synthesizer" },
-    ],
-  },
-  {
-    id: "reference",
+    id: "99-reference",
     title: "Reference",
     titleKo: "레퍼런스",
     pages: [
-      { slug: "reference/changelog", title: "Changelog", titleKo: "변경 이력", summary: "Version history", summaryKo: "버전 이력" },
-      { slug: "reference/frontier-comparison", title: "Frontier Comparison", titleKo: "프론티어 비교", summary: "GEODE vs Hermes/OpenClaw/Claude Code", summaryKo: "GEODE vs Hermes/OpenClaw/Claude Code" },
+      { slug: "reference/changelog", title: "Changelog", titleKo: "변경 이력", summary: "Version history mirrored from CHANGELOG.md.", summaryKo: "CHANGELOG.md를 미러한 버전 이력.", quadrant: "reference" },
+      { slug: "reference/frontier-comparison", title: "Frontier Comparison", titleKo: "프론티어 비교", summary: "GEODE versus Claude Code, Codex CLI, OpenClaw, Hermes, autoresearch.", summaryKo: "GEODE와 Claude Code, Codex CLI, OpenClaw, Hermes, autoresearch 비교.", quadrant: "reference" },
+      { slug: "reference/sot-metrics", title: "System Metrics SOT", titleKo: "시스템 메트릭 SOT", summary: "Live values for version, modules, tests, releases, since.", summaryKo: "version, 모듈, 테스트, 릴리스, since 라이브 값.", quadrant: "reference" },
     ],
   },
 ];
 
-/** Flat list of all leaf pages — used by [...slug]/generateStaticParams. */
+/** Flat list of all leaf pages. Used by [...slug]/generateStaticParams. */
 export function flattenSitemap(): DocPage[] {
   const out: DocPage[] = [];
   for (const section of DOCS_SITEMAP) {
@@ -154,3 +198,11 @@ export function adjacentPages(slug: string): { prev?: DocPage; next?: DocPage } 
     next: idx < all.length - 1 ? all[idx + 1] : undefined,
   };
 }
+
+/** Quadrant display metadata. */
+export const QUADRANT_META: Record<DocQuadrant, { label: string; labelKo: string; color: string }> = {
+  tutorial: { label: "Tutorial", labelKo: "튜토리얼", color: "#E89B57" },
+  "how-to": { label: "How-to", labelKo: "How-to", color: "#7BB97B" },
+  reference: { label: "Reference", labelKo: "레퍼런스", color: "#7895C2" },
+  explanation: { label: "Explanation", labelKo: "Explanation", color: "#A573E8" },
+};


### PR DESCRIPTION
## Summary

- site/docs 전면 재구성. **Diátaxis 4-quadrant** (Tutorial · How-to · Reference · Explanation) 기반 **8 챕터 53 페이지**
- **53/53 페이지가 `<Bi ko en />` bilingual** — 이전: 28 페이지 중 3 페이지만 bilingual
- 새 챕터 5개: **01 Run GEODE · 03 Build on GEODE · 04 Operations · 05 Petri Audit · 06 Explanation**
- `https://mangowhoiscloud.github.io/geode/petri-bundle/` 외부 viewer 링크 추가

## Why

- 기존 docs는 28 페이지 중 25 페이지가 EN-only. 사용자 요청: "KR/ENG 누락없이 완벽히 적용"
- v0.65 → v0.95 사이 30 minor 버전이 흘렀는데 docs는 v0.65 facts에 묶여 있었음. SOT import + DocsShell footer로 자동 동기화
- Petri × GEODE 통합 (v0.92.0+)이 docs에 없었음. 사용자 요청대로 신설 + bundle 링크
- Frontier 패턴 (Hermes llms.txt, OpenClaw AGENTS.md, Diátaxis, Anthropic) 비교 리서치 후 구조 결정

## Changes

| File / Area | Change |
|---|---|
| `site/src/lib/geode-docs/sitemap.ts` | 8 챕터 53 페이지 재설계. `DocQuadrant` 타입 + `quadrant` 필드 + `externalUrl?` 필드 + `QUADRANT_META` 색상 매핑 |
| `site/src/components/geode-docs/docs-shell.tsx` | quadrant chip (title 영역 + sidebar dot) · footer `GEODE_SOT` import · github 링크 `/portfolio` → `/geode` · header 백링크 `/portfolio` |
| `site/src/app/docs/run/*` (7 신규) | pick-path · providers · analyze · schedule · serve · messaging · troubleshooting |
| `site/src/app/docs/build/*` (4 신규) | add-tool · add-domain · add-hook · testing |
| `site/src/app/docs/ops/*` (4 신규) | long-running · cost · oauth · observability |
| `site/src/app/docs/petri/*` (4 신규) | overview · run · judge-dimensions · bundle (외부 링크) |
| `site/src/app/docs/explanation/*` (4 신규) | self-hosting · ratchet · 4-layer · solo |
| `site/src/app/docs/runtime/skills/page.tsx` (신규) | Skill Registry reference |
| `site/src/app/docs/reference/sot-metrics/page.tsx` (신규) | SOT 라이브 값 노출 페이지 |
| 25 기존 페이지 (architecture · harness · runtime · verification · plugins · reference) | `<Bi ko en />` 래핑 + titleKo/summaryKo prop + 한국어 본문 번역 (3 병렬 agent로 작업) |
| `CHANGELOG.md` | [Unreleased] § Infrastructure 엔트리 |
| `site/DOCS-PROGRESS.md` (신규) | 페이지별 KO/EN 상태 추적 표 (53/53 ✅) |

## GAP Audit

| Item | Status | Notes |
|---|---|---|
| 28 기존 페이지 bilingual 변환 | Implemented | 3 병렬 agent로 25 페이지 변환 |
| 새 챕터 5개 stub | Implemented | 25 신규 페이지 모두 quadrant 선언 + wiki source 참조 |
| Petri chapter + bundle link | Implemented | overview 본문 + 38 dimension 표 + bundle 페이지 외부 링크 |
| SOT footer | Implemented | DocsShell footer `GEODE_SOT.version` / `syncedAt` 직접 참조 |
| Quadrant chip | Implemented | title 영역 chip + sidebar 색 dot |
| llms.txt (Hermes 패턴) | Deferred | Sprint D 작업으로 분리 |
| AGENTS.md (OpenClaw 패턴) | Deferred | Sprint D 작업으로 분리 |
| 깊은 본문 보강 (각 신규 stub의 콘텐츠) | Deferred | wiki/concepts 33편 SOT가 준비돼 있음. 다음 sprint |

## Verification

- [x] ruff check 통과 — Python 무수정
- [x] `npm run build` 통과 — 53 routes 정적 prerender
- [x] `<Bi>` audit: 53/53 페이지 bilingual ✓
- [x] `titleKo`/`summaryKo` audit: 53/53 페이지 ✓
- [x] NO-BI 페이지 0개 ✓
- [x] sitemap.ts entry 와 page.tsx 파일 1:1 매칭

## Reference

- Diátaxis 4-quadrant: https://diataxis.fr
- Hermes Agent docs (NousResearch): https://hermes-agent.nousresearch.com/docs/
- OpenClaw docs/AGENTS.md: https://github.com/openclaw/openclaw/blob/main/AGENTS.md
- Anthropic Platform docs: https://platform.claude.com/docs/en/docs/welcome
- 본 사이트 P1 sprint (#1069 + #1068)