### PR TITLE
fix(sandbox): tilde 확장 누락 fix — validate_path + add/remove_working_directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sandbox tilde expansion (`~` / `~/`) — silent-fail bug.**
+  `core/tools/sandbox.py:validate_path()` advertised that bare `~` and `~/`
+  were "expanded by Python, not shell" (`check_shell_expansion` allowed
+  them through), but the actual `os.path.expanduser()` call was missing.
+  Result: paths like `~/workspace/resume/common` were joined against the
+  project root verbatim, producing `/<project>/~/workspace/...` and a
+  misleading `Not a directory` error instead of the proper
+  `expanded-path-outside-sandbox` permission error. Surfaced by `geode
+  serve` when an agent attempted `glob_files(path="~/workspace/...")`.
+  Fix: call `os.path.expanduser(path_str)` immediately before `Path()`
+  construction in `validate_path()`, and `path.expanduser()` before
+  `.resolve()` in `add_working_directory` / `remove_working_directory`.
+  Regression: `tests/test_sandbox.py::TestTildeExpansion` (4 cases —
+  bare `~`, `~/`, sandbox-expanded resolution, working-dir registration).
+
 ### Infrastructure
 
 - **Docs restructure (v0.95.0+) — 12 chapters, 49 pages, References chapter

--- a/core/tools/sandbox.py
+++ b/core/tools/sandbox.py
@@ -15,6 +15,7 @@ All file tools (Glob, Grep, Edit, Write, ReadDocument) delegate to
 from __future__ import annotations
 
 import logging
+import os
 import re
 import threading
 from pathlib import Path
@@ -77,7 +78,7 @@ _additional_dirs_lock = threading.Lock()
 def add_working_directory(path: Path) -> None:
     """Add a session-scoped working directory to the sandbox allowlist."""
     try:
-        resolved = path.resolve()
+        resolved = path.expanduser().resolve()
     except OSError:
         log.warning("Sandbox: cannot resolve %s, skipping", path)
         return
@@ -90,7 +91,7 @@ def add_working_directory(path: Path) -> None:
 def remove_working_directory(path: Path) -> None:
     """Remove a session-scoped working directory from the sandbox allowlist."""
     try:
-        resolved = path.resolve()
+        resolved = path.expanduser().resolve()
     except OSError:
         log.warning("Sandbox: cannot resolve %s, skipping", path)
         return
@@ -334,7 +335,10 @@ def validate_path(
         if err:
             return err
 
-    # 3. Construct path — resolve relative to project root
+    # 3. Construct path — expand leading ~/~ (Python-side, not shell) then resolve
+    #    relative paths against project root. `check_shell_expansion` already
+    #    rejected `~user`/`~+`/`~-`, so only bare `~` and `~/...` reach here.
+    path_str = os.path.expanduser(path_str)
     path = Path(path_str)
     if not path.is_absolute():
         path = get_project_root() / path

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -278,6 +278,73 @@ class TestValidatePath:
 
 
 # ---------------------------------------------------------------------------
+# Tilde expansion (G4 — bare ~ / ~/ expansion regression coverage)
+# ---------------------------------------------------------------------------
+
+
+class TestTildeExpansion:
+    """`~` and `~/` must be expanded by Python before path construction.
+
+    Regression for sandbox hardening: `check_shell_expansion` allows bare
+    `~` and `~/` through, but `validate_path` previously joined the literal
+    string against project root (`/<root>/~/foo`) instead of expanding it.
+    The result was a misleading "Not a directory" error for `~/...` paths.
+    """
+
+    def test_bare_tilde_expands_to_home(self, tmp_path: Path):
+        """`~` alone should expand to $HOME (then sandbox-reject if outside)."""
+        result = sandbox.validate_path("~", write=False)
+        # $HOME is outside tmp_path sandbox → permission error,
+        # but the error must NOT be "Not a directory" (= literal `~` join).
+        assert isinstance(result, dict)
+        assert "~" not in result.get("error", "")
+
+    def test_tilde_slash_expands_to_home(self, tmp_path: Path):
+        """`~/foo` should expand to $HOME/foo, not `/<root>/~/foo`."""
+        result = sandbox.validate_path("~/some_path", write=False)
+        # Same sandbox-rejection reasoning as above.
+        assert isinstance(result, dict)
+        assert "~" not in result.get("error", "")
+
+    def test_tilde_path_resolvable_when_added_to_sandbox(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`~/<dir>` should validate when its expanded path is added as a working dir."""
+        # Use tmp_path as a fake HOME so the expanded path stays sandboxed.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        target_dir = fake_home / "resume"
+        target_dir.mkdir()
+        target_file = target_dir / "common.md"
+        target_file.write_text("content")
+
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        # Without expansion, "~/resume/common.md" used to become
+        # /<sandbox>/~/resume/common.md → "Not a directory".
+        # With expansion, it becomes $HOME/resume/common.md → still outside
+        # tmp_path sandbox (the sandbox-root fixture remaps project root to
+        # tmp_path, but fake_home is tmp_path/home so it IS inside).
+        result = sandbox.validate_path("~/resume/common.md", write=False)
+        assert isinstance(result, Path), f"expected Path, got dict: {result}"
+        assert result == target_file.resolve()
+
+    def test_add_working_directory_expands_tilde(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """add_working_directory should expand `~` before resolving."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        extra = fake_home / "extra"
+        extra.mkdir()
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        sandbox.add_working_directory(Path("~/extra"))
+
+        assert extra.resolve() in sandbox._additional_dirs
+
+
+# ---------------------------------------------------------------------------
 # OSError defense (sandbox hardening v0.47.2)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `core/tools/sandbox.py:validate_path()` 에서 약속된 `os.path.expanduser()` 호출이 누락 → `~/foo` 같은 path 가 cwd 와 그대로 join 되어 `/<project>/~/foo` 가 되는 silent-fail 버그 fix.
- `add_working_directory` / `remove_working_directory` 도 동일 패턴 보완.
- `tests/test_sandbox.py::TestTildeExpansion` 4 regression 추가.

## Why

`check_shell_expansion` 의 docstring(line 129) — "Only bare ~ and ~/ are allowed (expanded by Python, not shell)" — 은 `~`/`~/` 가 통과 후 Python `expanduser` 로 확장되는 것을 전제. 하지만 `validate_path` (line 338-340) 의 path construction 단계가 이 호출을 건너뛰고 raw string 그대로 Path() 에 넘김. 결과적으로:

```
input:  "~/workspace/resume/common"
buggy:  Path("~/workspace/resume/common")  # not absolute
        → get_project_root() / Path
        → "/Users/.../geode/~/workspace/resume/common"
error:  "Not a directory" (misleading — 실제로는 sandbox 외부 의도였음)
```

증상 발견 경로: `geode serve` 의 agent 가 `glob_files(path="~/workspace/resume/common")` 호출 → 위 join 결과로 실패 → harness 의 repeat-loop detector 가 무한 retry 차단.

원인 commit: `54275962` (sandbox 신설, 2026-04-08). longstanding bug.

## Changes

| File | Change |
|------|--------|
| `core/tools/sandbox.py` | `import os` 추가. `validate_path()` 의 Path() 직전 `path_str = os.path.expanduser(path_str)` 추가. `add_working_directory` / `remove_working_directory` 의 `path.resolve()` 를 `path.expanduser().resolve()` 로 변경. |
| `tests/test_sandbox.py` | `TestTildeExpansion` 클래스 4 신규: bare `~`, `~/`, fake-HOME 의 sandbox 내부 resolution, `add_working_directory(Path("~/extra"))` registration. |
| `CHANGELOG.md` | `[Unreleased] / Fixed` entry. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `validate_path` callers (`file_tools.py` 4건, `document_tools.py` 1건) | Already exists | 모두 정상, bypass 없음 |
| 다른 `expanduser` site (cli/, audit/, plugins/petri_audit/) | Already exists | 명시 호출 — 정상 |
| 다른 entry-point 의 동일 패턴 | Not present | 단일-site 버그 확인 |

## Verification

- [x] ruff check clean (`core/ tests/ plugins/`)
- [x] mypy clean (356 source files, no issues)
- [x] pytest pass — **4689 passed**, 24 skipped, 24 deselected, 0 failed (`-m "not live"`)
- [x] sandbox 단위 51 tests (47 기존 + 4 신규) all pass

## Frontier 그라운딩

- **Pattern**: Tool boundary canonicalization — Claude Code `Read/Edit/Write` 의 path normalizer (`expanduser` → `abspath` → `realpath`).
- 직전 대화에서 검토한 4 패턴 중 ①(canonicalization) 의 minimal slice. ②(schema-level pattern) / ③(workspace-rooted only) / ④(approval visibility) 은 후속 PR 후보.

## Reference

- Bug 발견: `glob_files — Not a directory: /Users/mango/workspace/geode/~/workspace...` (geode serve 세션)
- 원인 commit: `54275962 feat: sandbox validation module — Claude Code parity`
- Trace: `~/.geode/diagnostics/2026-05.log` (petri runner — 동일 시점 정상 동작, 별개 path)