### PR TITLE
feat(auth+ui): OpenAI plan tier 자동 재조정 + OAuth Enter→브라우저 자동 오픈

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `.resolve()` in `add_working_directory` / `remove_working_directory`.
   Regression: `tests/test_sandbox.py::TestTildeExpansion` (4 cases —
   bare `~`, `~/`, sandbox-expanded resolution, working-dir registration).
+- **OpenAI OAuth plan tier auto-reconcile.** `chatgpt_plan_type` was
+  extracted from the JWT once during `/login` and frozen into
+  `Plan.subscription_tier`. If the user upgraded their ChatGPT plan
+  (Plus → Pro/Max/etc.) between logins, the stored tier kept showing
+  the old value while the JWT itself had the new claim. `load_auth_toml`
+  now calls `reconcile_plan_tier_from_stored_jwt()` after hydration,
+  which re-decodes the access_token's claims and updates
+  `Plan.subscription_tier` + profile metadata in place when a drift is
+  found. Drift events log at INFO so the change is visible without
+  forcing a re-login (a fresh `/login` still produces a brand-new JWT
+  with the current tier — this is the in-between fix).
+- **OpenAI OAuth — JWT decode DRY.** Extracted the inline base64+JSON
+  decode block in `login_openai()` into a reusable `_decode_jwt_claims`
+  helper; `_plan_type_from_token` builds on top so the reconciliation
+  path and login path can't drift apart.
+
+### Added
+
+- **OAuth login UX — press Enter to open the verification URL.**
+  `EventRenderer._handle_oauth_login_started` now prints
+  `Press [Enter] to open the URL in your browser` and spawns a daemon
+  thread that calls `webbrowser.open(verification_uri)` on the first
+  stdin line. Skipped automatically when stdin is not a TTY (piped
+  invocations stay quiet). Pattern grounded from Claude Code's OAuth
+  start prompt (`/Users/.../claude-code-ref/src/auth/providers.ts`).
 
 ### Infrastructure
 

--- a/core/auth/auth_toml.py
+++ b/core/auth/auth_toml.py
@@ -286,6 +286,17 @@ def load_auth_toml(
     for model, plan_ids in (data.get("routing") or {}).items():
         if isinstance(plan_ids, list):
             registry.set_routing(str(model), [str(pid) for pid in plan_ids])
+
+    # v0.95.x — re-read the stored JWT for the GEODE-owned OpenAI OAuth and
+    # update Plan.subscription_tier if the user's plan tier changed since
+    # auth.toml was last written (e.g. Plus → Pro upgrade between logins).
+    # Failures are non-fatal: the load itself has already succeeded.
+    try:
+        from core.auth.oauth_login import reconcile_plan_tier_from_stored_jwt
+
+        reconcile_plan_tier_from_stored_jwt()
+    except Exception:
+        log.debug("Plan tier reconciliation skipped", exc_info=True)
     return True
 
 

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -58,6 +58,87 @@ AUTH_STORE_PATH = auth_store_path()
 _GEODE_OPENAI_PLAN_ID = "openai-codex-geode"
 
 
+def _decode_jwt_claims(token: str) -> dict[str, Any]:
+    """Decode the payload section of a (signed) JWT, no verification.
+
+    Used to read OpenAI-issued claims like ``chatgpt_plan_type`` /
+    ``chatgpt_account_id`` / ``email`` from the access_token. The token's
+    signature is the OAuth provider's concern; GEODE only needs the
+    public claims for routing + display.
+    """
+    import base64
+
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    try:
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _plan_type_from_token(token: str) -> str:
+    """Extract ``chatgpt_plan_type`` from an OpenAI OAuth access token."""
+    claims = _decode_jwt_claims(token)
+    auth_claim = claims.get("https://api.openai.com/auth", {})
+    if isinstance(auth_claim, dict):
+        plan_type = auth_claim.get("chatgpt_plan_type", "")
+        return str(plan_type) if plan_type else ""
+    return ""
+
+
+def reconcile_plan_tier_from_stored_jwt() -> tuple[str, str] | None:
+    """Re-decode the stored OpenAI OAuth JWT and sync ``subscription_tier``.
+
+    The user's ChatGPT plan can change between logins (Plus → Pro → Max,
+    etc.). The Plan's ``subscription_tier`` is set on login but stays
+    frozen if the user only refreshes their access token via
+    ``refresh_token`` flow. This re-extracts ``chatgpt_plan_type`` from
+    the live JWT and updates both the Plan and the profile metadata.
+
+    Returns ``(old, new)`` tuple if a drift was reconciled, ``None``
+    when no GEODE OAuth profile exists or the tier matches.
+    """
+    try:
+        from core.auth.plan_registry import get_plan_registry
+        from core.wiring.container import ensure_profile_store
+    except Exception:
+        return None
+
+    registry = get_plan_registry()
+    plan = registry.get(_GEODE_OPENAI_PLAN_ID)
+    store = ensure_profile_store()
+    profile = store.get(f"{_GEODE_OPENAI_PLAN_ID}:user") if plan else None
+    if plan is None or profile is None or not profile.key:
+        return None
+
+    fresh = _plan_type_from_token(profile.key)
+    if not fresh:
+        return None
+    stored = plan.subscription_tier or ""
+    if fresh == stored:
+        return None
+
+    plan.subscription_tier = fresh
+    if profile.metadata is not None:
+        profile.metadata["plan_type"] = fresh
+    try:
+        from core.auth.auth_toml import save_auth_toml
+
+        save_auth_toml()
+    except Exception:
+        log.debug("auth.toml persist after tier drift skipped", exc_info=True)
+    log.info(
+        "OpenAI plan tier reconciled from JWT: %s → %s (plan=%s)",
+        stored or "(unset)",
+        fresh,
+        plan.id,
+    )
+    return (stored, fresh)
+
+
 def _migrate_legacy_auth_json_if_present() -> dict[str, Any]:
     """One-shot migration of pre-v0.50.2 ``~/.geode/auth.json``.
 
@@ -314,25 +395,15 @@ def login_openai() -> dict[str, Any]:
     if not access_token:
         raise RuntimeError("Token exchange did not return an access_token")
 
-    # Extract account info from JWT
-    account_id = ""
-    email = ""
-    plan_type = ""
-    try:
-        import base64
-
-        parts = access_token.split(".")
-        if len(parts) >= 2:
-            padded = parts[1] + "=" * (4 - len(parts[1]) % 4)
-            payload = json.loads(base64.urlsafe_b64decode(padded))
-            auth_claim = payload.get("https://api.openai.com/auth", {})
-            profile_claim = payload.get("https://api.openai.com/profile", {})
-            account_id = auth_claim.get("chatgpt_account_id", "")
-            plan_type = auth_claim.get("chatgpt_plan_type", "")
-            email = profile_claim.get("email", "")
-            exp = payload.get("exp", 0)
-    except Exception:
-        exp = 0
+    # Extract account info from JWT (uses _decode_jwt_claims helper —
+    # any decode failure returns {} so the unpacks below resolve to "").
+    payload = _decode_jwt_claims(access_token)
+    auth_claim = payload.get("https://api.openai.com/auth", {}) or {}
+    profile_claim = payload.get("https://api.openai.com/profile", {}) or {}
+    account_id = str(auth_claim.get("chatgpt_account_id", "") or "")
+    plan_type = str(auth_claim.get("chatgpt_plan_type", "") or "")
+    email = str(profile_claim.get("email", "") or "")
+    exp = payload.get("exp", 0) or 0
 
     now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
 

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -11,12 +11,15 @@ Pipeline panels render client-side from structured events (no raw stream).
 
 from __future__ import annotations
 
+import logging
 import sys
 import threading
 import time
 from typing import Any
 
 from core.ui.tool_tracker import ToolCallTracker
+
+log = logging.getLogger(__name__)
 
 
 def _fmt_tokens(n: int) -> str:
@@ -410,7 +413,13 @@ class EventRenderer:
     # -- OAuth device-code events (v0.51.1 IPC parity) ------------------------
 
     def _handle_oauth_login_started(self, event: dict[str, Any]) -> None:
-        """Render the device-code prompt with URL + user code highlighted."""
+        """Render the device-code prompt with URL + user code highlighted.
+
+        Also spawns a daemon thread that opens the verification URI in the
+        user's default browser the first time stdin yields a line (typically
+        Enter). The daemon dies with the process — no explicit cleanup
+        needed.
+        """
         self._suppress_all_spinners()
         provider = str(event.get("provider", ""))
         uri = str(event.get("verification_uri", ""))
@@ -424,8 +433,39 @@ class EventRenderer:
         self._out.write("  2. Enter this code:\n")
         self._out.write(f"     \033[1;93m{code}\033[0m\n")
         self._out.write("\n")
+        if uri:
+            self._out.write("  \033[2mPress [Enter] to open the URL in your browser.\033[0m\n")
+            self._start_oauth_browser_watcher(uri)
         self._out.write("  \033[2mWaiting for sign-in... (Ctrl+C to cancel)\033[0m\n")
         self._out.flush()
+
+    def _start_oauth_browser_watcher(self, uri: str) -> None:
+        """Daemon thread: open `uri` in the default browser on first stdin line.
+
+        Non-blocking — `_handle_oauth_login_started` returns immediately so
+        the polling heartbeats can continue rendering. If the user finishes
+        OAuth without pressing Enter the thread stays blocked on
+        ``sys.stdin.readline()``; it's a daemon thread so it dies with the
+        process.
+
+        Skips when stdin is not a TTY (piped / non-interactive sessions).
+        """
+        if not sys.stdin.isatty():
+            return
+
+        def _watcher() -> None:
+            try:
+                sys.stdin.readline()
+            except Exception:
+                return
+            try:
+                import webbrowser
+
+                webbrowser.open(uri)
+            except Exception:  # pragma: no cover — webbrowser is best-effort
+                log.debug("webbrowser.open failed for %s", uri, exc_info=True)
+
+        threading.Thread(target=_watcher, daemon=True, name="oauth-browser-watcher").start()
 
     def _handle_oauth_login_pending(self, event: dict[str, Any]) -> None:
         """Heartbeat — overwrite a single 'Waiting…' line in place."""

--- a/tests/test_oauth_login.py
+++ b/tests/test_oauth_login.py
@@ -159,3 +159,169 @@ class TestCmdLogin:
 
         assert "/login" in COMMAND_MAP
         assert COMMAND_MAP["/login"] == "login"
+
+
+def _build_fake_jwt(claims: dict) -> str:
+    """Construct a JWT-shaped string with ``claims`` as the payload.
+
+    Signature is bogus — ``_decode_jwt_claims`` does no verification.
+    """
+    import base64
+    import json
+
+    header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=").decode()
+    body = (
+        base64.urlsafe_b64encode(json.dumps(claims, separators=(",", ":")).encode())
+        .rstrip(b"=")
+        .decode()
+    )
+    return f"{header}.{body}.signature"
+
+
+class TestJWTDecode:
+    """`_decode_jwt_claims` + `_plan_type_from_token` — regression for the
+    v0.95.x plan tier reconciliation path."""
+
+    def test_decode_valid_jwt(self):
+        from core.auth.oauth_login import _decode_jwt_claims
+
+        token = _build_fake_jwt(
+            {
+                "https://api.openai.com/auth": {"chatgpt_plan_type": "pro"},
+                "https://api.openai.com/profile": {"email": "u@example.com"},
+                "exp": 9999999999,
+            }
+        )
+        claims = _decode_jwt_claims(token)
+        assert claims["exp"] == 9999999999
+        assert claims["https://api.openai.com/auth"]["chatgpt_plan_type"] == "pro"
+
+    def test_decode_malformed_returns_empty(self):
+        from core.auth.oauth_login import _decode_jwt_claims
+
+        # Fewer than 2 dot-separated parts → early return.
+        assert _decode_jwt_claims("not-a-jwt") == {}
+        assert _decode_jwt_claims("") == {}
+        # 2+ parts but the payload section is not valid base64+JSON.
+        assert _decode_jwt_claims("garbage.payload.sig") == {}
+        assert _decode_jwt_claims("only.one") == {}
+
+    def test_plan_type_extraction(self):
+        from core.auth.oauth_login import _plan_type_from_token
+
+        token = _build_fake_jwt(
+            {"https://api.openai.com/auth": {"chatgpt_plan_type": "max"}}
+        )
+        assert _plan_type_from_token(token) == "max"
+
+    def test_plan_type_missing_claim(self):
+        from core.auth.oauth_login import _plan_type_from_token
+
+        token = _build_fake_jwt({"some_other_claim": "x"})
+        assert _plan_type_from_token(token) == ""
+
+
+class TestPlanTierReconcile:
+    """`reconcile_plan_tier_from_stored_jwt` — drift detection + update."""
+
+    def test_no_drift_returns_none(self, tmp_path: Path, monkeypatch):
+        from core.auth.oauth_login import reconcile_plan_tier_from_stored_jwt
+        from core.auth.plan_registry import get_plan_registry, reset_plan_registry
+        from core.auth.plans import Plan, PlanKind
+        from core.auth.profiles import AuthProfile, CredentialType
+        from core.wiring import container as container_mod
+
+        _isolate(tmp_path, monkeypatch)
+        reset_plan_registry()
+
+        registry = get_plan_registry()
+        registry.add(
+            Plan(
+                id="openai-codex-geode",
+                provider="openai-codex",
+                kind=PlanKind.OAUTH_BORROWED,
+                display_name="OpenAI Codex (GEODE OAuth)",
+                base_url="https://chatgpt.com/backend-api/codex",
+                subscription_tier="prolite",
+            )
+        )
+
+        from core.auth.profiles import ProfileStore
+
+        store = ProfileStore()
+        token = _build_fake_jwt(
+            {"https://api.openai.com/auth": {"chatgpt_plan_type": "prolite"}}
+        )
+        store.add(
+            AuthProfile(
+                name="openai-codex-geode:user",
+                provider="openai-codex",
+                credential_type=CredentialType.OAUTH,
+                key=token,
+                plan_id="openai-codex-geode",
+            )
+        )
+        monkeypatch.setattr(container_mod, "ensure_profile_store", lambda: store)
+
+        assert reconcile_plan_tier_from_stored_jwt() is None
+
+    def test_drift_reconciles_and_returns_pair(self, tmp_path: Path, monkeypatch):
+        from core.auth.oauth_login import reconcile_plan_tier_from_stored_jwt
+        from core.auth.plan_registry import get_plan_registry, reset_plan_registry
+        from core.auth.plans import Plan, PlanKind
+        from core.auth.profiles import AuthProfile, CredentialType, ProfileStore
+        from core.wiring import container as container_mod
+
+        _isolate(tmp_path, monkeypatch)
+        reset_plan_registry()
+
+        registry = get_plan_registry()
+        registry.add(
+            Plan(
+                id="openai-codex-geode",
+                provider="openai-codex",
+                kind=PlanKind.OAUTH_BORROWED,
+                display_name="OpenAI Codex (GEODE OAuth)",
+                base_url="https://chatgpt.com/backend-api/codex",
+                subscription_tier="plus",  # stale
+            )
+        )
+
+        store = ProfileStore()
+        token = _build_fake_jwt(
+            {"https://api.openai.com/auth": {"chatgpt_plan_type": "max"}}
+        )
+        store.add(
+            AuthProfile(
+                name="openai-codex-geode:user",
+                provider="openai-codex",
+                credential_type=CredentialType.OAUTH,
+                key=token,
+                plan_id="openai-codex-geode",
+                metadata={"plan_type": "plus"},
+            )
+        )
+        monkeypatch.setattr(container_mod, "ensure_profile_store", lambda: store)
+
+        result = reconcile_plan_tier_from_stored_jwt()
+        assert result == ("plus", "max")
+        plan = get_plan_registry().get("openai-codex-geode")
+        assert plan is not None
+        assert plan.subscription_tier == "max"
+        # Profile metadata also updated
+        profile = store.get("openai-codex-geode:user")
+        assert profile is not None
+        assert profile.metadata["plan_type"] == "max"
+
+    def test_no_profile_returns_none(self, tmp_path: Path, monkeypatch):
+        from core.auth.oauth_login import reconcile_plan_tier_from_stored_jwt
+        from core.auth.plan_registry import reset_plan_registry
+        from core.auth.profiles import ProfileStore
+        from core.wiring import container as container_mod
+
+        _isolate(tmp_path, monkeypatch)
+        reset_plan_registry()
+
+        monkeypatch.setattr(container_mod, "ensure_profile_store", lambda: ProfileStore())
+
+        assert reconcile_plan_tier_from_stored_jwt() is None

--- a/tests/test_oauth_login.py
+++ b/tests/test_oauth_login.py
@@ -209,9 +209,7 @@ class TestJWTDecode:
     def test_plan_type_extraction(self):
         from core.auth.oauth_login import _plan_type_from_token
 
-        token = _build_fake_jwt(
-            {"https://api.openai.com/auth": {"chatgpt_plan_type": "max"}}
-        )
+        token = _build_fake_jwt({"https://api.openai.com/auth": {"chatgpt_plan_type": "max"}})
         assert _plan_type_from_token(token) == "max"
 
     def test_plan_type_missing_claim(self):
@@ -249,9 +247,7 @@ class TestPlanTierReconcile:
         from core.auth.profiles import ProfileStore
 
         store = ProfileStore()
-        token = _build_fake_jwt(
-            {"https://api.openai.com/auth": {"chatgpt_plan_type": "prolite"}}
-        )
+        token = _build_fake_jwt({"https://api.openai.com/auth": {"chatgpt_plan_type": "prolite"}})
         store.add(
             AuthProfile(
                 name="openai-codex-geode:user",
@@ -288,9 +284,7 @@ class TestPlanTierReconcile:
         )
 
         store = ProfileStore()
-        token = _build_fake_jwt(
-            {"https://api.openai.com/auth": {"chatgpt_plan_type": "max"}}
-        )
+        token = _build_fake_jwt({"https://api.openai.com/auth": {"chatgpt_plan_type": "max"}})
         store.add(
             AuthProfile(
                 name="openai-codex-geode:user",


### PR DESCRIPTION
## Summary

- **plan tier 재조정** — `load_auth_toml()` 이 JWT 의 `chatgpt_plan_type` 을 다시 읽어 `Plan.subscription_tier` 가 stale 하면 갱신. 사용자가 ChatGPT 구독 등급 (Plus → Pro/Max) 을 바꿔도 재로그인 없이 in-place 정합성 회복.
- **OAuth Enter → 브라우저 자동 오픈** — `oauth_login_started` 시 `Press [Enter] to open the URL in your browser` 안내. daemon 스레드가 stdin readline 한 번 받으면 `webbrowser.open(uri)`. stdin 비TTY 시 skip.
- **JWT decode DRY** — 기존 inline base64+JSON 디코드 블록을 `_decode_jwt_claims` / `_plan_type_from_token` 헬퍼로 합침.

## Why

사용자가 ChatGPT Plus → Max 로 업그레이드 후 GEODE 에 반영되는지 확인 요청. 코드 확인 결과:

1. **로그인 시점 (`login_openai()`)** — JWT 의 `chatgpt_plan_type` 을 추출해 Plan 에 저장. 이미 동작.
2. **로그인 이후** — auth.toml 의 stored JWT 가 그대로 남고, refresh 없이 사용. JWT 가 갱신되더라도 `Plan.subscription_tier` 는 frozen.

실제 사용자 auth.toml 의 JWT payload:
\`\`\`json
{
  "chatgpt_plan_type": "prolite",
  "email": "ryoo0504@gmail.com",
  ...
}
\`\`\`
그러나 `subscription_tier = \"plus\"` 로 stored — drift.

해결: bootstrap 의 `load_auth_toml()` 직후 JWT 를 재디코드해 drift 시 갱신. 비파괴 (실패해도 load 자체는 성공). 부산물 — `chatgpt_plan_type` 의 다양한 값 (prolite, pro, max, …) 을 GEODE 가 자동으로 따라감.

OAuth 안내 — 현재 URL/code 출력만 하고 사용자가 수동으로 브라우저 열어야 함. 프론티어 (claude-code-ref `src/auth/providers.ts`) 패턴 따라 Enter 한 번에 자동 오픈.

## Changes

| File | Change |
|------|--------|
| \`core/auth/oauth_login.py\` | \`_decode_jwt_claims\` + \`_plan_type_from_token\` 헬퍼 신설. \`reconcile_plan_tier_from_stored_jwt\` 신설. \`login_openai\` 의 inline JWT decode 를 헬퍼로 교체. |
| \`core/auth/auth_toml.py\` | \`load_auth_toml\` 끝에 \`reconcile_plan_tier_from_stored_jwt()\` 호출. |
| \`core/ui/event_renderer.py\` | \`_handle_oauth_login_started\` 에 Press [Enter] 안내 + \`_start_oauth_browser_watcher(uri)\` 호출. 신규: daemon stdin reader → webbrowser.open. \`logging\` 임포트 추가. |
| \`tests/test_oauth_login.py\` | \`_build_fake_jwt\` helper. \`TestJWTDecode\` (4) + \`TestPlanTierReconcile\` (3). |
| \`CHANGELOG.md\` | Fixed + Added 항목. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| login 시점 plan_type 추출 | Already exists | line 320-344 → 헬퍼로 추출 |
| Plan.subscription_tier on login | Already exists | line 107 |
| Plan tier on token refresh / re-read | Not implemented → 이번 PR | load 시 JWT 재디코드 |
| OAuth URL/code 출력 | Already exists | event_renderer line 412-428 |
| Enter → 브라우저 자동 오픈 | Not implemented → 이번 PR | daemon stdin watcher |

## Verification

- [x] ruff check clean (\`core/ tests/ plugins/\`)
- [x] mypy clean (356 files)
- [x] pytest tests/test_oauth_login.py tests/test_auth_toml.py — 24 passed
- [x] pytest -m \"not live\" full — **4696 passed**, 24 skipped, 24 deselected
- [x] 사용자 케이스 (auth.toml 의 JWT \`prolite\` ↔ stored \`plus\`) — \`TestPlanTierReconcile.test_drift_reconciles_and_returns_pair\` 로 등가 재현

## Frontier 그라운딩

- OAuth 안내 패턴 — \`/Users/mango/workspace/claude-code-ref/src/auth/providers.ts\` (Claude.ai OAuth → 브라우저 자동 오픈)
- JWT no-verification decode — Hermes Agent / OpenClaw \`extractAccountId\` 패턴 (서명 검증은 인증 서버 책임, GEODE 는 public claims 만 읽음)

## Reference

- 사용자 보고: \`prolite\` 가 OpenAI JWT 에 들어 있지만 GEODE 는 \`plus\` 로 표시 (auth.toml 검증)
- 직전 PR #1075 (sandbox tilde fix) 와 독립적 — 다른 worktree 에서 작업