### PR TITLE
fix(ui): OAuth Press-[Enter] 안내 — 두 render path 모두 적용 + helper 추출

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **OAuth Press-[Enter] prompt — direct-render wiring parity.** PR #1077
+  added the Press-[Enter] watcher only to the IPC render path
+  (`EventRenderer._handle_oauth_login_started`). The thin-CLI direct path
+  in `core/ui/agentic_ui/events.py:emit_oauth_login_started` (used by
+  `RunLocation.THIN` `/login oauth openai`) still rendered the legacy
+  layout without the prompt, so users on the THIN path didn't see
+  "Press [Enter]" and the browser-watcher never spawned. Extracted the
+  watcher to `core/ui/oauth_browser.start_oauth_browser_watcher`; both
+  the IPC handler and the direct fallback now call it. Regression:
+  `tests/test_oauth_browser.py::TestEmitOauthLoginStartedFallback` (2
+  cases — fallback prints prompt + spawns watcher; IPC path skips
+  fallback) + `TestStartOauthBrowserWatcher` (2 cases — TTY gating).
+
+
+
 - **Sandbox tilde expansion (`~` / `~/`) — silent-fail bug.**
   `core/tools/sandbox.py:validate_path()` advertised that bare `~` and `~/`
   were "expanded by Python, not shell" (`check_shell_expansion` allowed

--- a/core/ui/agentic_ui/events.py
+++ b/core/ui/agentic_ui/events.py
@@ -277,8 +277,15 @@ def emit_checkpoint_saved(session_id: str, round_idx: int) -> None:
 def emit_oauth_login_started(provider: str, verification_uri: str, user_code: str) -> None:
     """Surface the device-code prompt to the user.
 
-    The thin client renders this as the highlighted "Open URL → Enter
-    code" pair. In direct mode (no IPC writer), falls back to console.
+    Two render paths share the same Press [Enter] prompt + browser watcher:
+
+      * IPC path — when an IPC writer is bound (event_renderer renders).
+      * Direct path — when the OAuth flow runs in the thin CLI itself
+        (e.g. ``/login oauth openai`` is a ``RunLocation.THIN`` command),
+        no writer is set so we render via console.print here.
+
+    Both paths call :func:`core.ui.oauth_browser.start_oauth_browser_watcher`
+    so the user gets identical Enter-to-open-browser UX in either mode.
     """
     from core.ui import agentic_ui as _pkg
 
@@ -300,6 +307,11 @@ def emit_oauth_login_started(provider: str, verification_uri: str, user_code: st
     _pkg.console.print("  2. Enter this code:")
     _pkg.console.print(f"     [bold yellow]{user_code}[/bold yellow]")
     _pkg.console.print()
+    if verification_uri:
+        _pkg.console.print("  [muted]Press \\[Enter] to open the URL in your browser.[/muted]")
+        from core.ui.oauth_browser import start_oauth_browser_watcher
+
+        start_oauth_browser_watcher(verification_uri)
     _pkg.console.print("  [muted]Waiting for sign-in... (Ctrl+C to cancel)[/muted]")
     _pkg.console.print()
 

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -435,37 +435,11 @@ class EventRenderer:
         self._out.write("\n")
         if uri:
             self._out.write("  \033[2mPress [Enter] to open the URL in your browser.\033[0m\n")
-            self._start_oauth_browser_watcher(uri)
+            from core.ui.oauth_browser import start_oauth_browser_watcher
+
+            start_oauth_browser_watcher(uri)
         self._out.write("  \033[2mWaiting for sign-in... (Ctrl+C to cancel)\033[0m\n")
         self._out.flush()
-
-    def _start_oauth_browser_watcher(self, uri: str) -> None:
-        """Daemon thread: open `uri` in the default browser on first stdin line.
-
-        Non-blocking — `_handle_oauth_login_started` returns immediately so
-        the polling heartbeats can continue rendering. If the user finishes
-        OAuth without pressing Enter the thread stays blocked on
-        ``sys.stdin.readline()``; it's a daemon thread so it dies with the
-        process.
-
-        Skips when stdin is not a TTY (piped / non-interactive sessions).
-        """
-        if not sys.stdin.isatty():
-            return
-
-        def _watcher() -> None:
-            try:
-                sys.stdin.readline()
-            except Exception:
-                return
-            try:
-                import webbrowser
-
-                webbrowser.open(uri)
-            except Exception:  # pragma: no cover — webbrowser is best-effort
-                log.debug("webbrowser.open failed for %s", uri, exc_info=True)
-
-        threading.Thread(target=_watcher, daemon=True, name="oauth-browser-watcher").start()
 
     def _handle_oauth_login_pending(self, event: dict[str, Any]) -> None:
         """Heartbeat — overwrite a single 'Waiting…' line in place."""

--- a/core/ui/oauth_browser.py
+++ b/core/ui/oauth_browser.py
@@ -1,0 +1,52 @@
+"""OAuth device-code helper — open the verification URL on first stdin line.
+
+Used by both render paths of the OAuth device-code prompt:
+
+  * IPC path — ``core.ui.event_renderer.EventRenderer._handle_oauth_login_started``
+    (when the OAuth flow runs in serve and surfaces via IPC events).
+  * Direct path — ``core.ui.agentic_ui.events.emit_oauth_login_started`` fallback
+    (when the flow runs in the thin CLI process itself — e.g.
+    ``/login oauth openai`` slash command with no IPC writer set).
+
+Both paths render the same Press [Enter] prompt and spawn the same daemon
+watcher so the user gets identical UX regardless of which process owns
+the OAuth polling loop. Keeping the helper in a tiny standalone module
+avoids cyclic imports between ``event_renderer`` and ``agentic_ui.events``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+
+log = logging.getLogger(__name__)
+
+
+def start_oauth_browser_watcher(uri: str) -> None:
+    """Daemon thread: open ``uri`` in the default browser on first stdin line.
+
+    Non-blocking — returns immediately so the polling heartbeats can keep
+    rendering. If the user finishes OAuth without pressing Enter, the thread
+    stays blocked on ``sys.stdin.readline()`` until the process exits; it's
+    a daemon so it dies with the process.
+
+    Skipped when stdin is not a TTY (piped / non-interactive sessions like
+    CI runs or scripted invocations).
+    """
+    if not sys.stdin.isatty():
+        return
+
+    def _watcher() -> None:
+        try:
+            sys.stdin.readline()
+        except Exception:
+            return
+        try:
+            import webbrowser
+
+            webbrowser.open(uri)
+        except Exception:  # pragma: no cover — webbrowser is best-effort
+            log.debug("webbrowser.open failed for %s", uri, exc_info=True)
+
+    threading.Thread(target=_watcher, daemon=True, name="oauth-browser-watcher").start()

--- a/tests/test_oauth_browser.py
+++ b/tests/test_oauth_browser.py
@@ -1,0 +1,121 @@
+"""Tests for ``core.ui.oauth_browser`` + Press-Enter wiring on both
+``emit_oauth_login_started`` render paths (IPC + direct fallback)."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+
+class TestStartOauthBrowserWatcher:
+    """Module-level helper that spawns the daemon stdin watcher."""
+
+    def test_skips_when_stdin_not_a_tty(self) -> None:
+        """Non-interactive stdin (piped / CI) → no thread spawned."""
+        from core.ui.oauth_browser import start_oauth_browser_watcher
+
+        with (
+            patch("core.ui.oauth_browser.sys.stdin") as fake_stdin,
+            patch("core.ui.oauth_browser.threading.Thread") as fake_thread,
+        ):
+            fake_stdin.isatty.return_value = False
+            start_oauth_browser_watcher("https://example.test/device")
+            fake_thread.assert_not_called()
+
+    def test_spawns_daemon_thread_when_tty(self) -> None:
+        """Interactive stdin → daemon thread targeting the inner watcher."""
+        from core.ui.oauth_browser import start_oauth_browser_watcher
+
+        with (
+            patch("core.ui.oauth_browser.sys.stdin") as fake_stdin,
+            patch("core.ui.oauth_browser.threading.Thread") as fake_thread,
+        ):
+            fake_stdin.isatty.return_value = True
+            start_oauth_browser_watcher("https://example.test/device")
+            assert fake_thread.called
+            _, kwargs = fake_thread.call_args
+            assert kwargs["daemon"] is True
+            assert kwargs["name"] == "oauth-browser-watcher"
+            fake_thread.return_value.start.assert_called_once()
+
+
+class TestEmitOauthLoginStartedFallback:
+    """Direct (no-IPC-writer) path must include the Press-[Enter] prompt and
+    spawn the browser watcher — wiring regression for the thin-CLI flow."""
+
+    def test_fallback_prints_press_enter_prompt(self, monkeypatch, capsys) -> None:
+        """`/login oauth openai` runs THIN; emit must render the Enter
+        prompt and invoke the watcher even without an IPC writer."""
+        from core.ui import agentic_ui
+        from core.ui.agentic_ui import events
+        from core.ui.agentic_ui._state import _ipc_writer_local
+
+        # Ensure no IPC writer is bound — force the fallback branch.
+        if hasattr(_ipc_writer_local, "writer"):
+            monkeypatch.delattr(_ipc_writer_local, "writer", raising=False)
+
+        # Route console output to a buffer we can assert on.
+        from rich.console import Console
+
+        buf = io.StringIO()
+        monkeypatch.setattr(agentic_ui, "console", Console(file=buf, force_terminal=False))
+
+        watcher_calls: list[str] = []
+
+        def _fake_watcher(uri: str) -> None:
+            watcher_calls.append(uri)
+
+        monkeypatch.setattr("core.ui.oauth_browser.start_oauth_browser_watcher", _fake_watcher)
+
+        events.emit_oauth_login_started(
+            provider="OpenAI Codex",
+            verification_uri="https://example.test/device",
+            user_code="ABCD-1234",
+        )
+
+        rendered = buf.getvalue()
+        assert "OpenAI Codex OAuth Login" in rendered
+        assert "https://example.test/device" in rendered
+        assert "ABCD-1234" in rendered
+        assert "Press [Enter]" in rendered
+        assert "Waiting for sign-in" in rendered
+        assert watcher_calls == ["https://example.test/device"]
+
+    def test_ipc_path_skips_fallback(self, monkeypatch) -> None:
+        """When the IPC writer is bound, fallback console output must NOT
+        fire — event must be sent through the writer instead."""
+        from core.ui.agentic_ui import events
+        from core.ui.agentic_ui._state import _ipc_writer_local
+
+        sent_events: list[tuple[str, dict[str, object]]] = []
+
+        class _FakeWriter:
+            def send_event(self, name: str, **kwargs: object) -> None:
+                sent_events.append((name, dict(kwargs)))
+
+        watcher_calls: list[str] = []
+
+        def _fake_watcher(uri: str) -> None:
+            watcher_calls.append(uri)
+
+        monkeypatch.setattr("core.ui.oauth_browser.start_oauth_browser_watcher", _fake_watcher)
+
+        # `threading.local()` doesn't pre-create `.writer`; assign directly +
+        # try/finally to clear so the attribute doesn't leak to other tests.
+        _ipc_writer_local.writer = _FakeWriter()
+        try:
+            events.emit_oauth_login_started(
+                provider="OpenAI Codex",
+                verification_uri="https://example.test/device",
+                user_code="ABCD-1234",
+            )
+        finally:
+            if hasattr(_ipc_writer_local, "writer"):
+                del _ipc_writer_local.writer
+
+        assert len(sent_events) == 1
+        assert sent_events[0][0] == "oauth_login_started"
+        assert sent_events[0][1]["verification_uri"] == "https://example.test/device"
+        # Fallback watcher must NOT be invoked here — the EventRenderer side
+        # spawns it on receipt.
+        assert watcher_calls == []


### PR DESCRIPTION
## Summary

- `core/ui/oauth_browser.py` 신설 — `start_oauth_browser_watcher(uri)` module-level helper (daemon stdin watcher + webbrowser.open). 양 render path 가 cyclic import 없이 공통 사용.
- `core/ui/agentic_ui/events.py:emit_oauth_login_started` 의 fallback (no IPC writer) 분기에 Press [Enter] 라인 + watcher 호출 추가.
- `core/ui/event_renderer.py` 의 기존 method 제거 + helper import 로 교체.
- 4 신규 regression test.

## Why

PR #1077 직후 사용자가 `/login oauth openai` 실행 — Press [Enter] 안내가 화면에 보이지 않음. 디버깅 결과:

- `emit_oauth_login_started` (events.py:277-304) 에 **두 경로**:
  1. IPC writer bound — `writer.send_event` → CLI 가 받아 `EventRenderer._handle_oauth_login_started` 로 렌더 (PR #1077 에서 패치 ✓)
  2. **No writer fallback** — 같은 함수 안에서 `_pkg.console.print` 직접 (PR #1077 누락 ✗)
- `/login` 은 `RunLocation.THIN` (`core/cli/routing.py:81`) → thin CLI 프로세스 안에서 `login_openai()` 직접 호출 → IPC writer 가 set 안 됨 → fallback 경로 → Press [Enter] 없음
- 즉 PR #1077 의 feature 가 thin CLI 사용자에게는 사실상 disabled

`CLAUDE.md Wiring Verification` 의 Read-Write parity 위반 — emit 측의 두 분기 중 하나만 패치되면 일관성 깨짐. 본 PR 이 그 gap 봉합.

## Changes

| File | Change |
|------|--------|
| `core/ui/oauth_browser.py` (신규) | `start_oauth_browser_watcher(uri)` module-level helper. TTY skip / daemon thread / stdin readline → webbrowser.open(uri). |
| `core/ui/event_renderer.py` | `_start_oauth_browser_watcher` method 제거. handler 가 helper import 후 호출. |
| `core/ui/agentic_ui/events.py` | fallback 분기에 \`  Press [Enter] to open the URL in your browser.\` 출력 + helper 호출. docstring 갱신. |
| `tests/test_oauth_browser.py` (신규) | 4 regression — TTY skip / TTY spawn / fallback prompt + watcher invoked / IPC path skips fallback. |
| `CHANGELOG.md` | Fixed entry. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| EventRenderer (IPC path) Press [Enter] | Already exists (PR #1077) | 동작 보존, helper 로 위임 |
| events.py fallback Press [Enter] | Not implemented → 이번 PR | wiring gap 봉합 |
| watcher TTY 가드 | Already exists (PR #1077) | helper 로 이전 |
| 두 경로 일관성 테스트 | Not implemented → 이번 PR | 4 case |

## Verification

- [x] ruff check clean (\`core/ tests/ plugins/\`)
- [x] ruff format clean (\`--check\`)
- [x] mypy clean (357 source files)
- [x] pytest -m \"not live\" — **4700 passed**, 24 skipped, 24 deselected (+ 4 신규)
- [x] 사용자 케이스 재현 가능 (\`TestEmitOauthLoginStartedFallback.test_fallback_prints_press_enter_prompt\`)

## Reference

- 사용자 보고: 재빌드 후 \`/login oauth openai\` 화면에 Press [Enter] 안 보임
- 원인 commit: PR #1077 의 partial wiring (IPC path 만 패치)
- 직접 영향 경로: \`core/cli/routing.py:81\` (\`/login\` = THIN) → \`core/cli/commands/login.py:_login_oauth\` → \`core/auth/oauth_login.py:login_openai\` → \`core/ui/agentic_ui/events.py:emit_oauth_login_started\` fallback