### PR TITLE
docs(changelog): 절대 경로 인용 제거 — repo-relative 만 사용

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   thread that calls `webbrowser.open(verification_uri)` on the first
   stdin line. Skipped automatically when stdin is not a TTY (piped
   invocations stay quiet). Pattern grounded from Claude Code's OAuth
-  start prompt (`/Users/.../claude-code-ref/src/auth/providers.ts`).
+  start prompt (`claude-code/src/auth/providers.ts`).
 
 ### Infrastructure
 
@@ -2927,8 +2927,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Reference
 - Codex Rust client (`openai/codex` repo, `codex-rs/`): `ResponseCompleted` struct (`sse/responses.rs:120-128`), accumulator pattern (`core/src/client.rs:1641-1678`), `ResponseItem` enum + serde tagging (`protocol/src/models.rs:751-902`).
-- Hermes Agent (`/Users/mango/workspace/hermes-agent`): `_chat_messages_to_responses_input` (`agent/codex_responses_adapter.py:204-325`), output_item.done accumulator (`run_agent.py:4709-4785`).
-- OpenClaw (`/Users/mango/workspace/openclaw`): `processResponsesStream` (`src/agents/openai-transport-stream.ts:353-542`).
+- Hermes Agent (`hermes-agent`): `_chat_messages_to_responses_input` (`agent/codex_responses_adapter.py:204-325`), output_item.done accumulator (`run_agent.py:4709-4785`).
+- OpenClaw (`openclaw/openclaw`): `processResponsesStream` (`src/agents/openai-transport-stream.ts:353-542`).
 - OpenAI Responses API spec (`openai-python` TypedDicts): `ResponseFunctionToolCallParam`, `FunctionCallOutput`, `ResponseOutputMessageParam`, `ResponseReasoningItemParam`. Confirmed `function_call` has NO `content` field; `function_call_output` uses `output` not `content`.
 - Production daemon log 2026-04-27 19:07:06 — `HTTP 400 Invalid type for 'input[4].content'` after a `create_plan → tool_use → continuation` cycle.
 


### PR DESCRIPTION
## Summary

CHANGELOG 의 외부 코드 인용 3 라인에서 \`/Users/.../...\` 절대 경로를 \`<repo>/<relative-path>\` 형식으로 정정. 사용자 지적 — 다른 contributor / CI / fork 머신에서 무의미한 경로.

## Why

frontier convention (코드 주석의 \`Grounded from: Hermes Agent (hermes_cli/auth.py:3054-3196)\` 같은 형식) 과 달리 CHANGELOG 에 \`/Users/mango/workspace/\` 절대 경로가 박혀 있었음. fork / CI / 다른 collaborator 에게 의미 없는 path. 사용자: "다른 사람 머신에서도 동작해야돼. 꼭 저런 패스를 하드코딩해서 푸는 행위는 하지마. 프론티어 패턴 참고해."

## Changes

| Line | Before | After |
|------|--------|-------|
| v0.95.x Added (OAuth Press-Enter) | \`/Users/.../claude-code-ref/src/auth/providers.ts\` | \`claude-code/src/auth/providers.ts\` |
| v0.81.x Reference (Hermes Agent) | \`/Users/mango/workspace/hermes-agent\` | \`hermes-agent\` |
| v0.81.x Reference (OpenClaw) | \`/Users/mango/workspace/openclaw\` | \`openclaw/openclaw\` |

규칙은 personal memory (\`feedback_no_hardcoded_user_paths.md\`) 로 보존. 앞으로 PR 전 \`grep -rn \"/Users/\\|/home/\" CHANGELOG.md docs/\" 가드 적용.

## Verification

- [x] \`grep -n \"/Users/\" CHANGELOG.md\` — 0 매치
- [x] CHANGELOG 의미 변경 없음 (참조 경로만 변경)
- [x] docs-only — code 영향 없음