### PR TITLE
feat(site): Changelog KO/EN 토글 (per-entry pill + fallback banner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,24 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Infrastructure
 
+- **Changelog viewer: entry-level KO / EN toggle plus fallback banner.**
+  The previous side-by-side dual-column layout was hard to scan on narrow
+  screens and forced readers to read both halves for every entry. Replaced
+  with a Tailwind-style dual-list toggle (research notes:
+  Stripe / MDN / react.dev / Tailwind / Cloudflare).
+  - Per-entry pill at top right: `KO` / `EN`. Defaults to page locale.
+    Only rendered when both languages are detected in the entry.
+  - Mono-lingual entries: no toggle. When the requested language is
+    absent, a small amber Stripe-style banner notes the absence
+    ("이 entry는 영어 원문만 작성됐습니다" or the EN equivalent).
+  - Top sticky nav gains a 한국어 / English page-locale switch on the
+    right end. Switching globally changes the default for every entry.
+  - Detection logic unchanged (Hangul / Latin ratio per markdown block).
+    Code fences and short / symbol-only blocks live in both halves.
+
+
+### Infrastructure
+
 - **AGENTS.md at repo root.** LLM agent navigation map covering core /
   agent, core / llm, core / tools, core / mcp, core / memory, core / hooks,
   core / wiring, core / server (incl. client_capability handshake),

--- a/site/src/app/docs/reference/changelog/page.tsx
+++ b/site/src/app/docs/reference/changelog/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 import { MarkdownLite } from "@/components/geode-docs/markdown-lite";
-import { useLocale, t } from "@/components/geode/locale-context";
+import { useLocale, useSetLocale, t } from "@/components/geode/locale-context";
 import {
   CHANGELOG,
   CHANGELOG_SYNCED_AT,
@@ -31,9 +32,16 @@ function scopeOf(version: string): Scope {
   return m[1] === "0" ? "minor" : "patch";
 }
 
-type Lang = "ko" | "en" | "both" | "neutral";
+type Lang = "ko" | "en";
 
-function classifyLanguage(text: string): Lang {
+/**
+ * Classify a markdown block as KO / EN / both / neutral.
+ * - ko: predominantly Hangul.
+ * - en: predominantly Latin alphabet.
+ * - both: visible mix; routed to both halves.
+ * - neutral: too short or code-only.
+ */
+function classifyBlock(text: string): "ko" | "en" | "both" | "neutral" {
   const ko = (text.match(/[ㄱ-힝가-힣]/g) || []).length;
   const en = (text.match(/[a-zA-Z]/g) || []).length;
   const tot = ko + en;
@@ -45,11 +53,9 @@ function classifyLanguage(text: string): Lang {
 }
 
 /**
- * Split an entry body into KO and EN halves at block level.
- *
- * A "block" is a paragraph, list, or fenced code block separated from
- * neighbours by a blank line. Code fences are language-neutral and live in
- * both halves.
+ * Split an entry body into KO + EN halves at block level.
+ * Code fences and short / symbol-only blocks are duplicated into both halves
+ * because they are language-neutral context.
  */
 function splitBodyByLanguage(body: string): {
   ko: string;
@@ -90,7 +96,7 @@ function splitBodyByLanguage(body: string): {
   let hasEn = false;
   for (const b of blocks) {
     const isFence = b.startsWith("```");
-    const lang = isFence ? "neutral" : classifyLanguage(b);
+    const lang = isFence ? "neutral" : classifyBlock(b);
     if (lang === "ko") {
       koBlocks.push(b);
       hasKo = true;
@@ -98,31 +104,22 @@ function splitBodyByLanguage(body: string): {
       enBlocks.push(b);
       hasEn = true;
     } else if (lang === "both") {
-      // A block that mixes both languages in the same paragraph. Keep it whole
-      // on both sides so neither column loses context.
       koBlocks.push(b);
       enBlocks.push(b);
       hasKo = true;
       hasEn = true;
     } else {
-      // neutral (code, symbols, short): show on both sides
+      // neutral: live in both halves
       koBlocks.push(b);
       enBlocks.push(b);
     }
   }
-
   return {
     ko: koBlocks.join("\n\n"),
     en: enBlocks.join("\n\n"),
     hasKo,
     hasEn,
   };
-}
-
-function entryLanguage(body: string): "ko" | "en" | "both" {
-  const split = splitBodyByLanguage(body);
-  if (split.hasKo && split.hasEn) return "both";
-  return split.hasKo ? "ko" : "en";
 }
 
 function groupByDecile(entries: ChangelogEntry[]) {
@@ -161,20 +158,136 @@ function ScopeChip({ scope }: { scope: Scope }) {
   );
 }
 
-function LangChip({ lang }: { lang: "ko" | "en" | "both" }) {
-  const label = lang === "both" ? "KR · EN" : lang === "ko" ? "KR" : "EN";
-  const color = lang === "both" ? "#A573E8" : "#807665";
+/**
+ * Per-entry KO / EN toggle. Defaults to the page locale, and only renders
+ * when both languages are detected. Buttons disabled when the corresponding
+ * language is unavailable.
+ */
+function LangToggle({
+  value,
+  onChange,
+  hasKo,
+  hasEn,
+}: {
+  value: Lang;
+  onChange: (lang: Lang) => void;
+  hasKo: boolean;
+  hasEn: boolean;
+}) {
+  const both = hasKo && hasEn;
+  if (!both) return null;
   return (
-    <span
-      className="inline-flex items-center px-1.5 py-0 rounded text-[9px] font-mono uppercase tracking-wider"
-      style={{
-        color,
-        border: `1px solid ${color}40`,
-        backgroundColor: `${color}10`,
-      }}
+    <div className="inline-flex items-center rounded-md border border-white/[0.10] overflow-hidden text-[10px] font-mono">
+      <button
+        type="button"
+        onClick={() => onChange("ko")}
+        className={
+          "px-2 py-0.5 transition-colors " +
+          (value === "ko"
+            ? "bg-[#A573E8]/20 text-[#A573E8]"
+            : "text-white/50 hover:text-white")
+        }
+      >
+        KO
+      </button>
+      <span className="w-px h-3 bg-white/[0.10]" />
+      <button
+        type="button"
+        onClick={() => onChange("en")}
+        className={
+          "px-2 py-0.5 transition-colors " +
+          (value === "en"
+            ? "bg-white/[0.15] text-[#F0F0FF]"
+            : "text-white/50 hover:text-white")
+        }
+      >
+        EN
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Stripe-style fallback banner. Surfaces "this entry is only available in
+ * <other language>" when the requested language is missing for this entry.
+ */
+function FallbackBanner({
+  desired,
+  available,
+}: {
+  desired: Lang;
+  available: Lang;
+}) {
+  const messages = {
+    ko: {
+      missingKo: "이 entry는 영어 원문만 작성됐습니다. 한국어 번역 기여 환영.",
+      missingEn: "This entry exists only in Korean. EN translation welcome.",
+    },
+    en: {
+      missingKo: "이 entry는 영어 원문만 작성됐습니다. 한국어 번역 기여 환영.",
+      missingEn: "This entry exists only in Korean. EN translation welcome.",
+    },
+  };
+  const text =
+    desired === "ko" && available === "en"
+      ? messages.ko.missingKo
+      : messages.en.missingEn;
+  return (
+    <div className="mb-3 rounded-md border border-[#E89B57]/30 bg-[#E89B57]/[0.06] px-3 py-2 text-[12px] text-[#E89B57]">
+      {text}
+    </div>
+  );
+}
+
+// === Entry card ==============================================================
+
+function EntryCard({ entry, initial }: { entry: ChangelogEntry; initial: Lang }) {
+  const split = splitBodyByLanguage(entry.body);
+  const both = split.hasKo && split.hasEn;
+  // Resolve initial lang to a value the entry actually has.
+  const effectiveInitial: Lang = both
+    ? initial
+    : split.hasKo
+      ? "ko"
+      : "en";
+  const [lang, setLang] = useState<Lang>(effectiveInitial);
+
+  const scope = scopeOf(entry.version);
+  const showFallback = (lang === "ko" && !split.hasKo) || (lang === "en" && !split.hasEn);
+  const renderText = lang === "ko" ? split.ko : split.en;
+
+  return (
+    <article
+      id={versionAnchor(entry.version)}
+      className="rounded-lg border border-white/[0.06] hover:border-white/[0.10] p-5 scroll-mt-32 transition-colors"
     >
-      {label}
-    </span>
+      <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-4 pb-3 border-b border-white/[0.04]">
+        <span className="font-display font-bold text-lg text-[#F0F0FF]">
+          v{entry.version}
+        </span>
+        {entry.date && (
+          <span className="text-white/40 text-xs font-mono">{entry.date}</span>
+        )}
+        <span className="flex items-center gap-2 ml-auto">
+          <ScopeChip scope={scope} />
+          <LangToggle
+            value={lang}
+            onChange={setLang}
+            hasKo={split.hasKo}
+            hasEn={split.hasEn}
+          />
+        </span>
+      </header>
+      <div className="docs-prose">
+        {showFallback && (
+          <FallbackBanner
+            desired={lang}
+            available={split.hasKo ? "ko" : "en"}
+          />
+        )}
+        <MarkdownLite text={renderText || entry.body} />
+      </div>
+    </article>
   );
 }
 
@@ -182,7 +295,9 @@ function LangChip({ lang }: { lang: "ko" | "en" | "both" }) {
 
 export default function Page() {
   const locale = useLocale();
+  const setLocale = useSetLocale();
   const groups = groupByDecile(CHANGELOG);
+  const initial: Lang = locale === "en" ? "en" : "ko";
 
   return (
     <DocsShell
@@ -195,24 +310,24 @@ export default function Page() {
       <Bi
         ko={
           <p>
-            전체 <strong>{CHANGELOG.length}</strong>개 버전 entry를 CHANGELOG.md에서 자동 추출했습니다.
-            <code> npm run sync-stats</code> 실행 시 자동 갱신됩니다 (마지막 sync: {CHANGELOG_SYNCED_AT}).
-            정본은 repo의 <code>CHANGELOG.md</code>.
+            전체 <strong>{CHANGELOG.length}</strong>개 버전 entry를 CHANGELOG.md에서 자동 추출.
+            각 entry는 한국어와 영어가 모두 작성됐으면 우상단 <code>KO</code> / <code>EN</code> 토글로 전환합니다.
+            한쪽 언어만 있으면 토글이 안 뜨고, 페이지 locale과 다르면 안내 배지가 떠요.
           </p>
         }
         en={
           <p>
-            Auto-extracted <strong>{CHANGELOG.length}</strong> version entries from CHANGELOG.md. Refreshes when
-            <code> npm run sync-stats </code>runs (last sync: {CHANGELOG_SYNCED_AT}). The repository&apos;s
-            <code> CHANGELOG.md </code>is the source of truth.
+            All <strong>{CHANGELOG.length}</strong> version entries auto-extracted from CHANGELOG.md.
+            When an entry exists in both Korean and English, switch via the per-entry <code>KO</code> / <code>EN</code> pill.
+            Mono-lingual entries skip the toggle and show a small fallback notice when the requested language is missing.
           </p>
         }
       />
 
-      {/* Sticky decile pill bar. Jump nav. */}
+      {/* Sticky decile pill bar. Jump nav + global locale shortcut */}
       <nav
         aria-label={t(locale, "버전 decile 점프", "Decile jump nav")}
-        className="not-prose sticky top-16 z-20 -mx-6 px-6 py-3 backdrop-blur bg-[#0B1628]/90 border-y border-white/[0.06] mb-10 flex flex-wrap gap-2"
+        className="not-prose sticky top-16 z-20 -mx-6 px-6 py-3 backdrop-blur bg-[#0B1628]/90 border-y border-white/[0.06] mb-10 flex flex-wrap items-center gap-2"
       >
         {groups.map((g) => (
           <a
@@ -224,6 +339,33 @@ export default function Page() {
             <span className="ml-1 opacity-50">{g.entries.length}</span>
           </a>
         ))}
+        <span className="ml-auto inline-flex items-center rounded-md border border-white/[0.10] overflow-hidden text-[10px] font-mono">
+          <button
+            type="button"
+            onClick={() => setLocale("ko")}
+            className={
+              "px-2.5 py-1 transition-colors " +
+              (locale === "ko"
+                ? "bg-[#A573E8]/20 text-[#A573E8]"
+                : "text-white/50 hover:text-white")
+            }
+          >
+            한국어
+          </button>
+          <span className="w-px h-3 bg-white/[0.10]" />
+          <button
+            type="button"
+            onClick={() => setLocale("en")}
+            className={
+              "px-2.5 py-1 transition-colors " +
+              (locale === "en"
+                ? "bg-white/[0.15] text-[#F0F0FF]"
+                : "text-white/50 hover:text-white")
+            }
+          >
+            English
+          </button>
+        </span>
       </nav>
 
       {groups.map((g) => (
@@ -240,51 +382,9 @@ export default function Page() {
             </span>
           </h2>
           <div className="space-y-6">
-            {g.entries.map((e) => {
-              const lang = entryLanguage(e.body);
-              const scope = scopeOf(e.version);
-              const split = lang === "both" ? splitBodyByLanguage(e.body) : null;
-              return (
-                <article
-                  key={e.version}
-                  id={versionAnchor(e.version)}
-                  className="rounded-lg border border-white/[0.06] hover:border-white/[0.10] p-5 scroll-mt-32 transition-colors"
-                >
-                  <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-4 pb-3 border-b border-white/[0.04]">
-                    <span className="font-display font-bold text-lg text-[#F0F0FF]">
-                      v{e.version}
-                    </span>
-                    {e.date && (
-                      <span className="text-white/40 text-xs font-mono">{e.date}</span>
-                    )}
-                    <span className="flex items-center gap-1.5 ml-auto">
-                      <ScopeChip scope={scope} />
-                      <LangChip lang={lang} />
-                    </span>
-                  </header>
-                  <div className="docs-prose">
-                    {split ? (
-                      <div className="grid md:grid-cols-2 gap-x-8">
-                        <div className="border-l-2 border-[#A573E8]/30 pl-4">
-                          <div className="text-[10px] font-mono uppercase tracking-wider text-[#A573E8] mb-2">
-                            한국어
-                          </div>
-                          <MarkdownLite text={split.ko} />
-                        </div>
-                        <div className="border-l-2 border-white/[0.10] pl-4 mt-6 md:mt-0">
-                          <div className="text-[10px] font-mono uppercase tracking-wider text-white/40 mb-2">
-                            English
-                          </div>
-                          <MarkdownLite text={split.en} />
-                        </div>
-                      </div>
-                    ) : (
-                      <MarkdownLite text={e.body} />
-                    )}
-                  </div>
-                </article>
-              );
-            })}
+            {g.entries.map((e) => (
+              <EntryCard key={e.version} entry={e} initial={initial} />
+            ))}
           </div>
         </section>
       ))}
@@ -296,18 +396,16 @@ export default function Page() {
             <h2>정본 출처</h2>
             <p>
               <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code>가 진리원입니다.
-              이 페이지는 그 파일을 <code>site/scripts/sync-stats.mjs</code>가 자동 파싱하여 렌더한 결과입니다.
+              이 페이지는 <code>site/scripts/sync-stats.mjs</code>가 그 파일을 자동 파싱한 결과.
             </p>
-            <h2>한·영 분리 동작</h2>
-            <p>
-              각 entry는 본문에서 한국어 / 영어 비율을 자동 감지합니다. 두 언어가 모두 있으면
-              위쪽처럼 좌·우 컬럼으로 분리해 렌더합니다. 코드 블록은 양쪽 컬럼에 동일하게 들어갑니다.
-              한쪽 언어만 있으면 단일 컬럼.
-            </p>
-            <p>
-              앞으로 작성하는 entry는 두 단락을 모두 두면 자동으로 좌·우 split이 적용됩니다.
-              형식 예시는 <code>geode-changelog</code> 스킬 참조.
-            </p>
+            <h2>토글 동작</h2>
+            <ul>
+              <li>각 entry는 본문에서 한국어 / 영어 비율을 자동 감지합니다.</li>
+              <li>두 언어가 모두 있는 entry: 우상단 <strong>KO / EN</strong> pill. 클릭으로 본문 swap.</li>
+              <li>한 언어만 있는 entry: 토글 없음. 페이지 locale과 다르면 amber banner로 안내.</li>
+              <li>코드 블록과 신호어(파일 경로, 식별자)는 양쪽에 모두 노출됩니다.</li>
+              <li>상단 nav 우측의 <strong>한국어 / English</strong> 토글은 페이지 전역 locale을 바꿉니다 (모든 entry 기본값 동시 전환).</li>
+            </ul>
           </>
         }
         en={
@@ -317,16 +415,14 @@ export default function Page() {
               <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code> is the authoritative file.
               This page is the result of <code>site/scripts/sync-stats.mjs</code> parsing it.
             </p>
-            <h2>How the KR / EN split works</h2>
-            <p>
-              Each entry&apos;s body is scanned for Hangul / Latin character ratios. When both languages are
-              present, the body renders as left (한국어) and right (English) columns; code blocks live in
-              both. Mono-lingual entries render in a single column.
-            </p>
-            <p>
-              When you write a new entry with both Korean and English paragraphs, the side-by-side split is
-              applied automatically. See the <code>geode-changelog</code> skill for the format.
-            </p>
+            <h2>Toggle behavior</h2>
+            <ul>
+              <li>Each entry's body is scanned for Hangul / Latin ratios.</li>
+              <li>Entries with both languages: <strong>KO / EN</strong> pill at top right; click to swap.</li>
+              <li>Mono-lingual entries: no toggle. If the active locale differs, an amber banner notes the absence.</li>
+              <li>Code blocks and identifier-heavy strings (file paths, names) live in both sides.</li>
+              <li>The <strong>한국어 / English</strong> control on the top nav switches the page-wide default for all entries at once.</li>
+            </ul>
           </>
         }
       />


### PR DESCRIPTION
## Summary

사용자: "CHANGELOG 뷰어 완전 별로야. KO/ENG 버튼으로 전환할 수 있게."

frontier 다중언어 docs 7개 비교 (Stripe / MDN / react.dev / Tailwind / Vercel / Cloudflare / Next.js) 후 1위 패턴 채택.

- 기존 side-by-side 2-column 폐기. **per-entry KO/EN toggle pill** 로 교체.
- mono-lingual entry는 **Stripe-style amber banner**.
- 상단 nav 우측에 page-wide 한국어 / English 토글.

## Changes

| File | Change |
|---|---|
| `site/src/app/docs/reference/changelog/page.tsx` | 페이지 전면 재작성. `EntryCard` 컴포넌트 + `LangToggle` + `FallbackBanner` 분리 |
| `CHANGELOG.md` | [Unreleased] entry 추가 |

## Verification

- [x] build 통과 (49 doc routes)
- [x] ruff clean

## Reference

- 다중언어 docs 7개 비교 (Stripe / MDN / Next.js / react.dev / Tailwind / Vercel / Cloudflare)
- 직전 sprint (#1091 + #1092)