### PR TITLE
feat(wiring): ~/.geode/ 디렉터리 layout migration 인프라

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,30 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **`~/.geode/` 디렉터리 layout migration 인프라.** Hermes Agent (NousResearch)
+  의 `SessionDB._init_schema` 패턴 + OpenClaw `autoMigrateLegacyStateDir`
+  + GEODE 기존 `_resolve_with_fallback` 셋 종합. 신규 `core/wiring/
+  layout_migrator.py` — `GEODE_LAYOUT_VERSION` (현재 1), `~/.geode/
+  .layout-version` dotfile marker (Hermes 의 `.managed` / `active_profile`
+  dotfile 전례), module-level once-flag 로 idempotent (OpenClaw
+  `autoMigrateStateDirChecked` + Hermes `_bootstrap_applied` 평행),
+  `GEODE_DISABLE_LAYOUT_MIGRATION` env escape hatch.
+  - **v0→v1 마이그레이션**: 세 path 오류 정정 — (1) `serve.log` 가
+    `~/.geode/` 루트에서 `~/.geode/logs/serve.log` 로 (paths.py 의
+    `SERVE_LOG_PATH` 가 이미 가리키던 곳), (2) `approve_history.json`
+    (paths.py 오타) → `approval_history.jsonl` (실제 writer 이름),
+    (3) `mcp-registry-cache.json` → `mcp/registry-cache.json` (다른
+    MCP state 와 함께 묶음). `shutil.move` 로 atomic, 동일 파일 destination
+    이미 존재 시 손대지 않고 warning surface (never overwrite user data).
+  - **호출 시점**: `core.paths.ensure_directories()` 끝 — bootstrap 의
+    매 호출마다 (idempotent). `uv tool install` / `uv tool update` 는 우리 코드를
+    실행하지 않으므로 사실상 install/update 직후 첫 `geode` 명령에서 트리거됨.
+  - **회귀**: `tests/test_layout_migrator.py` 12 cases — version marker
+    round-trip / corrupt marker / disable env / idempotency / v0→v1 의
+    세 path 별 + conflict-keep-both + missing-source-skip.
+
+### Added
+
 - **Wanted.co.kr 기반 한국 job 검색 도구 (`wanted_jobs_search`).** LinkedIn
   의 PerimeterX/Cloudflare bot detection 으로 `search_jobs` MCP 가 매번
   403 + empty body 로 차단되는 상황에 대한 대체 경로. Wanted 의 공개 REST

--- a/core/mcp/registry.py
+++ b/core/mcp/registry.py
@@ -22,8 +22,13 @@ _REGISTRY_API = (
     "?version=latest&visibility=commercial&limit=200"
 )
 _CACHE_TTL_S = 86400  # 24 hours
-_CACHE_DIR = Path.home() / ".geode"
-_CACHE_FILE = _CACHE_DIR / "mcp-registry-cache.json"
+# v0.95.x layout migration v1 — moved under ~/.geode/mcp/ to group with
+# other MCP state (trace-runs/, etc.). Legacy ``~/.geode/mcp-registry-cache.json``
+# is migrated by ``core.wiring.layout_migrator._migrate_v0_to_v1`` on first boot.
+# Single source of truth lives in ``core.paths.MCP_REGISTRY_CACHE``; this file
+# imports it lazily to avoid a circular import (paths imports layout_migrator).
+_CACHE_DIR = Path.home() / ".geode" / "mcp"
+_CACHE_FILE = _CACHE_DIR / "registry-cache.json"
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/paths.py
+++ b/core/paths.py
@@ -55,8 +55,15 @@ CLI_STARTUP_LOCK = GEODE_HOME / "cli.startup.lock"
 SERVE_LOG_PATH = GEODE_HOME / "logs" / "serve.log"
 GLOBAL_JOURNAL_DIR = GEODE_HOME / "journal"
 GLOBAL_WORKERS_DIR = GEODE_HOME / "workers"
-MCP_REGISTRY_CACHE = GEODE_HOME / "mcp-registry-cache.json"
-APPROVE_HISTORY = GEODE_HOME / "approve_history.json"
+# v0.95.x layout migration v1 — moved under mcp/ to group with other MCP state.
+# Legacy ``~/.geode/mcp-registry-cache.json`` migrated by
+# ``core.wiring.layout_migrator._migrate_v0_to_v1`` on first bootstrap.
+MCP_REGISTRY_CACHE = GEODE_HOME / "mcp" / "registry-cache.json"
+# v0.95.x layout migration v1 — renamed to match the actual writer
+# (``core.hooks.approval_tracker``, which has always used ``approval_history.jsonl``).
+# Legacy ``~/.geode/approve_history.json`` (paths.py-side typo) migrated by
+# ``core.wiring.layout_migrator._migrate_v0_to_v1``.
+APPROVE_HISTORY = GEODE_HOME / "approval_history.jsonl"
 
 # ---------------------------------------------------------------------------
 # Project-level — {workspace}/.geode/
@@ -281,6 +288,19 @@ def ensure_directories() -> None:
 
     if created:
         _paths_log.info("Created %d directories: %s", len(created), ", ".join(created))
+
+    # --- Layout migration (Hermes `_init_schema` pattern) ---
+    # Runs on every bootstrap, idempotent via the module-level once-flag
+    # inside :mod:`core.wiring.layout_migrator`. Reconciles legacy paths
+    # produced by older GEODE versions with the current constants above.
+    # Lazy import — keeps `core.paths` free of `core.wiring` dependency for
+    # consumers that need pure path utilities without bootstrap side-effects.
+    try:
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated()
+    except Exception:  # pragma: no cover — migration must never block boot
+        _paths_log.warning("Layout migration skipped", exc_info=True)
 
 
 def _ensure_geode_gitignore() -> None:

--- a/core/wiring/layout_migrator.py
+++ b/core/wiring/layout_migrator.py
@@ -1,0 +1,272 @@
+"""Version-aware migration for ``~/.geode/`` directory layout.
+
+Implements three frontier patterns synthesized from Hermes Agent
+(NousResearch) + OpenClaw + GEODE's own ``_resolve_with_fallback``:
+
+1. **Schema version marker** — ``~/.geode/.layout-version`` dotfile holds
+   an integer. Mirrors Hermes' ``schema_version`` table-inside-state.db
+   approach (the version travels *with* the data), adapted for a
+   directory-level schema where there is no single state.db. Hermes
+   precedent for dotfile markers: ``.managed``, ``active_profile``
+   (``hermes_constants.py:14-68``).
+
+2. **Idempotent runner** — :func:`ensure_layout_migrated` is safe to call
+   on every boot. Pattern mirrors Hermes ``SessionDB._init_schema``
+   (``hermes_state.py:550-678``): read version → run pending steps →
+   bump marker, with each step independently version-gated
+   (``if current_version < N``).
+
+3. **Module-level once-flag** — `_migration_checked` ensures one
+   migration check per process even if multiple bootstraps call in.
+   Mirrors OpenClaw ``autoMigrateStateDirChecked``
+   (``src/infra/state-migrations.ts:76-77``) and Hermes
+   ``_bootstrap_applied`` (``hermes_bootstrap.py:59-129``).
+
+Migrations recorded here are **path-level** (file renames, directory
+restructures). Data-level migrations (auth.toml schema, etc.) live in
+their respective modules (``core/auth/auth_toml.py``,
+``core/auth/oauth_login.py:_migrate_legacy_auth_json_if_present``).
+
+Adding a new migration:
+
+  1. Bump :data:`GEODE_LAYOUT_VERSION`.
+  2. Append a step in :func:`_run_pending_migrations` under the
+     ``if current_version < N`` guard.
+  3. Each step must be *idempotent* (safe to re-run partially completed).
+  4. Each step must be *lossless* — moves use :func:`shutil.move` so the
+     filesystem either has the source or the destination, never neither.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import shutil
+import threading
+from dataclasses import dataclass, field
+
+from core.paths import GEODE_HOME
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Current target layout schema version. Bumped each time a path-level
+#: migration is added.
+GEODE_LAYOUT_VERSION = 1
+
+#: Marker file recording the migrated-up-to version. Absent ⇒ version 0
+#: (pre-versioned install — every existing user starts here on first run
+#: after this PR lands).
+LAYOUT_VERSION_FILE = GEODE_HOME / ".layout-version"
+
+#: Env var escape hatch — set to skip migration entirely (for tests, CI,
+#: or operator override). Mirrors OpenClaw ``OPENCLAW_STATE_DIR`` opt-out
+#: at ``src/infra/state-migrations.ts:528``.
+DISABLE_ENV_VAR = "GEODE_DISABLE_LAYOUT_MIGRATION"
+
+# Module-level idempotency guard. Multiple bootstrap call sites
+# (`build_memory_components`, `build_default_runtime`, etc.) all call
+# `ensure_layout_migrated()` — only the first one in this process does work.
+_migration_checked = False
+_migration_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MigrationResult:
+    """Outcome of a single migration step. Lifted from OpenClaw's
+    ``StateDirMigrationResult`` shape (``state-migrations.ts:430-435``)."""
+
+    name: str
+    moved: list[tuple[str, str]] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LayoutMigrationReport:
+    """Aggregate report — what ran, what changed, what stayed put."""
+
+    from_version: int
+    to_version: int
+    steps: list[MigrationResult] = field(default_factory=list)
+    disabled: bool = False
+    no_op: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Version marker read / write
+# ---------------------------------------------------------------------------
+
+
+def read_layout_version() -> int:
+    """Return the migrated-up-to version, or ``0`` if marker is absent.
+
+    Pre-versioned installs (any directory created before this PR) return 0.
+    Corrupt marker (non-integer content) is treated as 0 and overwritten
+    on the next successful migration pass.
+    """
+    try:
+        text = LAYOUT_VERSION_FILE.read_text(encoding="utf-8").strip()
+        return int(text)
+    except FileNotFoundError:
+        return 0
+    except (ValueError, OSError):
+        log.warning("Corrupt %s — treating as version 0", LAYOUT_VERSION_FILE)
+        return 0
+
+
+def write_layout_version(version: int) -> None:
+    """Persist the layout version using an atomic write.
+
+    Hermes pattern: ``atomic_yaml_write`` (``utils.py:139-188``) — write to
+    temp file in same dir, ``fsync``, then ``os.replace``. We do the same
+    minus YAML serialization since this is a single integer.
+    """
+    LAYOUT_VERSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = LAYOUT_VERSION_FILE.with_suffix(LAYOUT_VERSION_FILE.suffix + ".tmp")
+    payload = f"{version}\n"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, LAYOUT_VERSION_FILE)
+    except OSError as exc:
+        log.warning("Failed to persist layout version marker: %s", exc)
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def ensure_layout_migrated(*, force: bool = False) -> LayoutMigrationReport:
+    """Bring ``~/.geode/`` up to the current target layout version.
+
+    Called from :func:`core.paths.ensure_directories` on every bootstrap.
+    Idempotent — second call in the same process returns immediately
+    (module-level ``_migration_checked`` guard). ``force=True`` bypasses
+    the guard, used by tests.
+
+    Returns a :class:`LayoutMigrationReport` describing what was done.
+    Never raises on partial failure — individual migration steps catch
+    and warn so the rest of bootstrap can proceed.
+    """
+    global _migration_checked
+
+    if os.environ.get(DISABLE_ENV_VAR):
+        return LayoutMigrationReport(from_version=-1, to_version=-1, disabled=True)
+
+    with _migration_lock:
+        if _migration_checked and not force:
+            return LayoutMigrationReport(
+                from_version=GEODE_LAYOUT_VERSION,
+                to_version=GEODE_LAYOUT_VERSION,
+                no_op=True,
+            )
+        _migration_checked = True
+
+    GEODE_HOME.mkdir(parents=True, exist_ok=True)
+    current = read_layout_version()
+    if current >= GEODE_LAYOUT_VERSION:
+        return LayoutMigrationReport(from_version=current, to_version=current, no_op=True)
+
+    report = LayoutMigrationReport(from_version=current, to_version=GEODE_LAYOUT_VERSION)
+    _run_pending_migrations(current, report)
+    write_layout_version(GEODE_LAYOUT_VERSION)
+    log.info(
+        "Layout migration v%d → v%d completed: %d step(s)",
+        report.from_version,
+        report.to_version,
+        len(report.steps),
+    )
+    return report
+
+
+def reset_migration_guard() -> None:
+    """Test helper — clear the once-per-process flag."""
+    global _migration_checked
+    with _migration_lock:
+        _migration_checked = False
+
+
+# ---------------------------------------------------------------------------
+# Migration step registry
+# ---------------------------------------------------------------------------
+
+
+def _run_pending_migrations(current_version: int, report: LayoutMigrationReport) -> None:
+    """Run every migration step whose version > current_version.
+
+    Hermes pattern (``hermes_state.py:594-651``): each step is gated by
+    an ``if current_version < N`` block. After this function returns
+    successfully, the caller bumps the persisted version to TARGET.
+    """
+    if current_version < 1:
+        report.steps.append(_migrate_v0_to_v1())
+
+
+# ---------------------------------------------------------------------------
+# v0 → v1: path-bug corrections (3 known mismatches in core/paths.py)
+# ---------------------------------------------------------------------------
+
+
+def _migrate_v0_to_v1() -> MigrationResult:
+    """v1 — reconcile three known path mismatches.
+
+    1. ``~/.geode/serve.log`` → ``~/.geode/logs/serve.log``
+       (``paths.py:SERVE_LOG_PATH`` already expects the new path)
+    2. ``~/.geode/approve_history.json`` → ``~/.geode/approval_history.jsonl``
+       (paths.py used the old name; actual writer in
+       ``approval_tracker.py`` uses the new name — old file is stranded)
+    3. ``~/.geode/mcp-registry-cache.json`` → ``~/.geode/mcp/registry-cache.json``
+       (group with the rest of MCP state under the ``mcp/`` subdir)
+
+    Strategy — :func:`shutil.move` (atomic on same filesystem). If the
+    destination already exists, the source is left in place with a
+    warning so the operator can resolve manually (we never silently
+    overwrite user data).
+    """
+    result = MigrationResult(name="v0→v1: path reconciliation")
+
+    moves = [
+        (GEODE_HOME / "serve.log", GEODE_HOME / "logs" / "serve.log"),
+        (
+            GEODE_HOME / "approve_history.json",
+            GEODE_HOME / "approval_history.jsonl",
+        ),
+        (
+            GEODE_HOME / "mcp-registry-cache.json",
+            GEODE_HOME / "mcp" / "registry-cache.json",
+        ),
+    ]
+
+    for src, dst in moves:
+        if not src.exists():
+            result.skipped.append(f"{src.name}: source absent")
+            continue
+        if dst.exists():
+            result.warnings.append(
+                f"{src.name}: both source and destination present — left {src} for manual review"
+            )
+            continue
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            result.moved.append((str(src), str(dst)))
+            log.info("Layout v0→v1: moved %s → %s", src, dst)
+        except OSError as exc:
+            result.warnings.append(f"{src.name}: move failed: {exc}")
+
+    return result

--- a/tests/test_layout_migrator.py
+++ b/tests/test_layout_migrator.py
@@ -1,0 +1,185 @@
+"""Tests for ``core.wiring.layout_migrator`` — version-aware ~/.geode/ migration.
+
+Mirrors the integration patterns Hermes uses for ``hermes_state._init_schema``
+(``hermes_state.py:550-678``): idempotency, version-gating, atomic marker
+write, lossless moves. We exercise the public entry point
+:func:`ensure_layout_migrated` against an isolated ``tmp_path`` instead of
+``~/.geode`` so tests are sandboxed and parallel-safe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_geode_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``GEODE_HOME`` (and all derived paths) to a tmp dir."""
+    # Both the constant and the live reference in layout_migrator/paths must
+    # point at tmp_path so reads + writes land in the sandbox.
+    monkeypatch.setattr("core.paths.GEODE_HOME", tmp_path)
+    monkeypatch.setattr("core.wiring.layout_migrator.GEODE_HOME", tmp_path)
+    monkeypatch.setattr(
+        "core.wiring.layout_migrator.LAYOUT_VERSION_FILE",
+        tmp_path / ".layout-version",
+    )
+
+    # Reset the once-per-process guard so each test starts fresh.
+    from core.wiring.layout_migrator import reset_migration_guard
+
+    reset_migration_guard()
+    yield tmp_path
+    reset_migration_guard()
+
+
+class TestVersionMarker:
+    """`.layout-version` dotfile read/write — Hermes ``schema_version``
+    table analog."""
+
+    def test_absent_marker_returns_zero(self, fake_geode_home: Path) -> None:
+        from core.wiring.layout_migrator import read_layout_version
+
+        assert read_layout_version() == 0
+
+    def test_write_then_read_round_trip(self, fake_geode_home: Path) -> None:
+        from core.wiring.layout_migrator import read_layout_version, write_layout_version
+
+        write_layout_version(7)
+        assert read_layout_version() == 7
+        # Atomic write — no leftover .tmp
+        assert not (fake_geode_home / ".layout-version.tmp").exists()
+
+    def test_corrupt_marker_treated_as_zero(self, fake_geode_home: Path) -> None:
+        """Hermes idempotency rule — never crash bootstrap on a bad marker."""
+        from core.wiring.layout_migrator import read_layout_version
+
+        (fake_geode_home / ".layout-version").write_text("not-a-number")
+        assert read_layout_version() == 0
+
+
+class TestEnsureLayoutMigrated:
+    """Public entry point — bootstrap call site."""
+
+    def test_no_op_when_already_at_target(self, fake_geode_home: Path) -> None:
+        from core.wiring.layout_migrator import (
+            GEODE_LAYOUT_VERSION,
+            ensure_layout_migrated,
+            write_layout_version,
+        )
+
+        write_layout_version(GEODE_LAYOUT_VERSION)
+        report = ensure_layout_migrated(force=True)
+        assert report.no_op is True
+        assert report.steps == []
+
+    def test_disable_env_var_skips_migration(
+        self, fake_geode_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.wiring.layout_migrator import (
+            DISABLE_ENV_VAR,
+            ensure_layout_migrated,
+        )
+
+        monkeypatch.setenv(DISABLE_ENV_VAR, "1")
+        report = ensure_layout_migrated(force=True)
+        assert report.disabled is True
+        # Marker file must NOT be created when migration is disabled.
+        assert not (fake_geode_home / ".layout-version").exists()
+
+    def test_idempotent_within_process(self, fake_geode_home: Path) -> None:
+        """Second call in the same process returns a no-op report (mirrors
+        ``autoMigrateStateDirChecked`` + Hermes ``_bootstrap_applied``)."""
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        first = ensure_layout_migrated()
+        second = ensure_layout_migrated()
+        assert first.no_op is False or first.steps  # something happened OR fresh+empty
+        assert second.no_op is True
+
+    def test_fresh_install_writes_marker_at_target(self, fake_geode_home: Path) -> None:
+        from core.wiring.layout_migrator import (
+            GEODE_LAYOUT_VERSION,
+            ensure_layout_migrated,
+            read_layout_version,
+        )
+
+        report = ensure_layout_migrated(force=True)
+        assert report.from_version == 0
+        assert report.to_version == GEODE_LAYOUT_VERSION
+        assert read_layout_version() == GEODE_LAYOUT_VERSION
+
+
+class TestV0ToV1PathReconciliation:
+    """v0→v1 — three documented path mismatches in legacy ``~/.geode/``."""
+
+    def test_serve_log_relocated(self, fake_geode_home: Path) -> None:
+        legacy = fake_geode_home / "serve.log"
+        legacy.write_text("legacy serve content")
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not legacy.exists()
+        new_path = fake_geode_home / "logs" / "serve.log"
+        assert new_path.exists()
+        assert new_path.read_text() == "legacy serve content"
+
+    def test_approve_history_renamed(self, fake_geode_home: Path) -> None:
+        """paths.py-side typo (``approve_history.json``) reconciled with
+        the actual writer's name (``approval_history.jsonl``)."""
+        legacy = fake_geode_home / "approve_history.json"
+        legacy.write_text("{}")
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not legacy.exists()
+        assert (fake_geode_home / "approval_history.jsonl").exists()
+
+    def test_mcp_registry_cache_relocated(self, fake_geode_home: Path) -> None:
+        legacy = fake_geode_home / "mcp-registry-cache.json"
+        legacy.write_text('{"servers": []}')
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not legacy.exists()
+        new_path = fake_geode_home / "mcp" / "registry-cache.json"
+        assert new_path.exists()
+        assert new_path.read_text() == '{"servers": []}'
+
+    def test_conflict_left_for_manual_review(self, fake_geode_home: Path) -> None:
+        """When both legacy and destination exist, leave both in place +
+        emit a warning. Never overwrite user data."""
+        legacy = fake_geode_home / "serve.log"
+        new = fake_geode_home / "logs" / "serve.log"
+        new.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("old")
+        new.write_text("new")
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+
+        assert legacy.exists()
+        assert new.exists()
+        assert new.read_text() == "new"  # untouched
+        # Warning surfaced in the step report
+        step = next(s for s in report.steps if s.name.startswith("v0→v1"))
+        assert any("manual review" in w for w in step.warnings)
+
+    def test_missing_legacy_files_skip_silently(self, fake_geode_home: Path) -> None:
+        """Fresh install with no legacy files — should run cleanly + record skips."""
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+        step = next(s for s in report.steps if s.name.startswith("v0→v1"))
+        # All three sources are absent → three skipped entries
+        assert len(step.skipped) == 3
+        assert step.moved == []
+        assert step.warnings == []


### PR DESCRIPTION
## Summary

- 신규 \`core/wiring/layout_migrator.py\` — version-aware \`~/.geode/\` migration runner. Hermes Agent (NousResearch) \`SessionDB._init_schema\` 패턴 + OpenClaw \`autoMigrateLegacyStateDir\` + GEODE 기존 \`_resolve_with_fallback\` 합성.
- \`~/.geode/.layout-version\` dotfile marker (Hermes \`.managed\` 전례). \`GEODE_LAYOUT_VERSION = 1\`.
- v0→v1 migration — 3 path 오류 정정 (serve.log / approval_history / mcp-registry-cache).
- bootstrap hook (\`core.paths.ensure_directories\`) 끝에 자동 트리거 — idempotent, module-level once-flag.

## Why

사용자 요청 — \`~/.geode/\` 25+ 디렉터리에 누적된 path 오류 + 향후 마이그레이션 framework. 사용자가 hermes 구조 가장 튼튼하다고 함 → NousResearch hermes-agent 재클론 후 storage / migration / startup-hook 패턴 6 카테고리 추출 → GEODE 에 backport.

발견된 path 오류 3건 (paths.py constants 와 실제 file 불일치):

| 항목 | as-is (legacy disk) | paths.py 가 가리키던/기대하던 곳 |
|------|---------------------|--------------------------------|
| serve.log | \`~/.geode/serve.log\` | \`~/.geode/logs/serve.log\` |
| approval 기록 | (writer 는 \`approval_history.jsonl\` 작성, paths.py 는 \`approve_history.json\` 가리킴) | \`approval_history.jsonl\` |
| MCP cache | \`~/.geode/mcp-registry-cache.json\` | \`~/.geode/mcp/registry-cache.json\` (mcp/ 하위로 묶음) |

## 프론티어 패턴 합성

| 출처 | 패턴 | GEODE 어디에 적용 |
|------|------|-------------------|
| Hermes \`SessionDB._init_schema\` (\`hermes_state.py:550-678\`) | version 을 데이터와 함께 보관 (DB 내부 \`schema_version\` 테이블) | \`~/.geode/.layout-version\` dotfile (디렉터리-level 등가, Hermes \`.managed\` dotfile 전례) |
| Hermes \`_bootstrap_applied\` (\`hermes_bootstrap.py:59-129\`) | module-level once-flag | \`_migration_checked\` |
| OpenClaw \`autoMigrateLegacyStateDir\` (\`state-migrations.ts:517\`) | env escape hatch + result object | \`GEODE_DISABLE_LAYOUT_MIGRATION\` + \`MigrationResult\` dataclass |
| Hermes \`atomic_yaml_write\` (\`utils.py:139-188\`) | tempfile + fsync + os.replace | \`write_layout_version\` |
| GEODE 기존 \`_resolve_with_fallback\` | check-at-read fallback | 유지 — lazy migration 보완 |

## Changes

| File | Change |
|------|--------|
| \`core/wiring/layout_migrator.py\` (신규) | \`GEODE_LAYOUT_VERSION\` / \`LAYOUT_VERSION_FILE\` / \`ensure_layout_migrated\` / \`_migrate_v0_to_v1\` / \`MigrationResult\` / \`LayoutMigrationReport\`. \`shutil.move\` atomic, conflict 시 warning + 원본 보존 |
| \`core/paths.py\` | \`APPROVE_HISTORY\` / \`MCP_REGISTRY_CACHE\` 새 경로. \`ensure_directories()\` 끝에 \`ensure_layout_migrated()\` 호출 (lazy import, fail-soft) |
| \`core/mcp/registry.py\` | \`_CACHE_FILE\` 새 위치 |
| \`tests/test_layout_migrator.py\` (신규) | 12 cases (version round-trip / corrupt marker / disable env / idempotency / v0→v1 path 3건 + conflict-keep-both + missing-skip) |
| \`CHANGELOG.md\` | Added entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| layout version marker | Not implemented → 이번 PR | dotfile, Hermes \`.managed\` 전례 |
| migration runner (idempotent + once-flag) | Not implemented → 이번 PR | Hermes + OpenClaw 패턴 합성 |
| bootstrap hook 연결 | Partially exists | \`ensure_directories\` 끝에 호출 추가 |
| \`_resolve_with_fallback\` (read-time fallback) | Already exists | 보완으로 동작 |
| 3 path 오류 정정 | Not implemented → 이번 PR | v0→v1 step |
| install/update 자동 트리거 | uv/pip 사용자 코드 미실행 | 첫 \`geode\` 실행에서 bootstrap → 트리거. Hermes 도 동일 — \`pyproject.toml\` post-install hook 없음 |

## Verification

- [x] ruff check / format clean
- [x] mypy clean (359 source files)
- [x] pytest -m \"not live\" — **4741 passed**, 24 skipped, 24 deselected (+ 12 신규)
- [x] 실제 \`~/.geode/\` 변경 없음 (test 는 tmp_path 격리, 머지 후 첫 \`geode\` 실행에서 자동 트리거)

## Reference

- NousResearch hermes-agent (방금 clone, \`~/workspace/hermes-agent/\`):
  - \`hermes_state.py:550-678\` (\`_init_schema\`, \`_reconcile_columns\`)
  - \`hermes_constants.py:14-68\` (directory layout)
  - \`hermes_constants.py:124-142\` (\`get_hermes_dir\` lazy fallback)
  - \`hermes_bootstrap.py:59-129\` (module-level once-flag)
  - \`utils.py:139-188\` (\`atomic_yaml_write\`)
- OpenClaw \`src/infra/state-migrations.ts:517\` (\`autoMigrateLegacyStateDir\`)
- GEODE 기존 path resolver: \`core/paths.py:_resolve_with_fallback\` (v0.66+ 부터 vault/models 에 사용)