### PR TITLE
feat(site): Changelog cleanup. flat 리스트, 단일 토글, 빈 헤더 필터링

### DIFF
--- a/site/src/app/docs/reference/changelog/page.tsx
+++ b/site/src/app/docs/reference/changelog/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { DocsShell, Bi } from "@/components/geode-docs/docs-shell";
 import { MarkdownLite } from "@/components/geode-docs/markdown-lite";
 import { useLocale, useSetLocale, t } from "@/components/geode/locale-context";
@@ -16,30 +15,14 @@ function versionAnchor(version: string): string {
   return "v-" + version.toLowerCase().replace(/[^a-z0-9.]/g, "-");
 }
 
-function decileOf(version: string): string {
-  if (version === "Unreleased") return "Unreleased";
-  const m = version.match(/^0\.(\d+)\./);
-  if (!m) return "Other";
-  return `0.${Math.floor(parseInt(m[1], 10) / 10)}x`;
-}
-
-type Scope = "minor" | "patch" | "unreleased";
-
-function scopeOf(version: string): Scope {
-  if (version === "Unreleased") return "unreleased";
-  const m = version.match(/^\d+\.\d+\.(\d+)/);
-  if (!m) return "patch";
-  return m[1] === "0" ? "minor" : "patch";
-}
-
 type Lang = "ko" | "en";
 
 /**
- * Classify a markdown block as KO / EN / both / neutral.
- * - ko: predominantly Hangul.
- * - en: predominantly Latin alphabet.
- * - both: visible mix; routed to both halves.
- * - neutral: too short or code-only.
+ * Classify one markdown block.
+ *  - ko: predominantly Hangul
+ *  - en: predominantly Latin alphabet
+ *  - both: visible mix
+ *  - neutral: too short or code-only
  */
 function classifyBlock(text: string): "ko" | "en" | "both" | "neutral" {
   const ko = (text.match(/[ㄱ-힝가-힣]/g) || []).length;
@@ -53,9 +36,10 @@ function classifyBlock(text: string): "ko" | "en" | "both" | "neutral" {
 }
 
 /**
- * Split an entry body into KO + EN halves at block level.
- * Code fences and short / symbol-only blocks are duplicated into both halves
- * because they are language-neutral context.
+ * Walk the body and split it into KO / EN halves, grouping by `### Section`.
+ * A section header is only emitted on a side when at least one block under it
+ * lives on that side. Prevents empty "Infrastructure" headers from appearing
+ * when one language has no content for that section.
  */
 function splitBodyByLanguage(body: string): {
   ko: string;
@@ -63,6 +47,7 @@ function splitBodyByLanguage(body: string): {
   hasKo: boolean;
   hasEn: boolean;
 } {
+  // Step 1. Parse into block strings.
   const lines = body.split("\n");
   const blocks: string[] = [];
   let cur: string[] = [];
@@ -90,176 +75,104 @@ function splitBodyByLanguage(body: string): {
   }
   if (cur.length) blocks.push(cur.join("\n"));
 
-  const koBlocks: string[] = [];
-  const enBlocks: string[] = [];
-  let hasKo = false;
-  let hasEn = false;
+  // Step 2. Group into sections delimited by `### ` headings.
+  type Section = { header: string | null; blocks: string[] };
+  const sections: Section[] = [];
+  let curSec: Section = { header: null, blocks: [] };
   for (const b of blocks) {
-    const isFence = b.startsWith("```");
-    const lang = isFence ? "neutral" : classifyBlock(b);
-    if (lang === "ko") {
-      koBlocks.push(b);
-      hasKo = true;
-    } else if (lang === "en") {
-      enBlocks.push(b);
-      hasEn = true;
-    } else if (lang === "both") {
-      koBlocks.push(b);
-      enBlocks.push(b);
-      hasKo = true;
-      hasEn = true;
+    if (b.startsWith("### ") && !b.includes("\n")) {
+      if (curSec.header || curSec.blocks.length) sections.push(curSec);
+      curSec = { header: b, blocks: [] };
     } else {
-      // neutral: live in both halves
-      koBlocks.push(b);
-      enBlocks.push(b);
+      curSec.blocks.push(b);
     }
   }
+  if (curSec.header || curSec.blocks.length) sections.push(curSec);
+
+  // Step 3. Per side, only include a section's header if at least one of its
+  // blocks lives on that side.
+  const koOut: string[] = [];
+  const enOut: string[] = [];
+  let hasKo = false;
+  let hasEn = false;
+
+  for (const sec of sections) {
+    const koBlocks: string[] = [];
+    const enBlocks: string[] = [];
+    let secHasMeaningfulKo = false;
+    let secHasMeaningfulEn = false;
+    for (const b of sec.blocks) {
+      const isFence = b.startsWith("```");
+      const lang = isFence ? "neutral" : classifyBlock(b);
+      if (lang === "ko") {
+        koBlocks.push(b);
+        secHasMeaningfulKo = true;
+        hasKo = true;
+      } else if (lang === "en") {
+        enBlocks.push(b);
+        secHasMeaningfulEn = true;
+        hasEn = true;
+      } else if (lang === "both") {
+        koBlocks.push(b);
+        enBlocks.push(b);
+        secHasMeaningfulKo = true;
+        secHasMeaningfulEn = true;
+        hasKo = true;
+        hasEn = true;
+      } else {
+        // neutral: route to both, but does not count as meaningful for header emission
+        koBlocks.push(b);
+        enBlocks.push(b);
+      }
+    }
+    if (sec.header && secHasMeaningfulKo) {
+      koOut.push(sec.header);
+    }
+    if (secHasMeaningfulKo) {
+      koOut.push(...koBlocks);
+    }
+    if (sec.header && secHasMeaningfulEn) {
+      enOut.push(sec.header);
+    }
+    if (secHasMeaningfulEn) {
+      enOut.push(...enBlocks);
+    }
+  }
+
   return {
-    ko: koBlocks.join("\n\n"),
-    en: enBlocks.join("\n\n"),
+    ko: koOut.join("\n\n"),
+    en: enOut.join("\n\n"),
     hasKo,
     hasEn,
   };
 }
 
-function groupByDecile(entries: ChangelogEntry[]) {
-  const seenDeciles: string[] = [];
-  const byDecile: Record<string, ChangelogEntry[]> = {};
-  for (const e of entries) {
-    const d = decileOf(e.version);
-    if (!byDecile[d]) {
-      byDecile[d] = [];
-      seenDeciles.push(d);
-    }
-    byDecile[d].push(e);
-  }
-  return seenDeciles.map((d) => ({ decile: d, entries: byDecile[d] }));
-}
-
 // === UI atoms ================================================================
 
-function ScopeChip({ scope }: { scope: Scope }) {
-  const meta = {
-    minor: { label: "MINOR", color: "#7BB97B" },
-    patch: { label: "PATCH", color: "#7895C2" },
-    unreleased: { label: "PENDING", color: "#E89B57" },
-  }[scope];
+function MonolingualChip({ lang }: { lang: "ko" | "en" }) {
   return (
-    <span
-      className="inline-flex items-center px-1.5 py-0 rounded text-[9px] font-mono uppercase tracking-wider"
-      style={{
-        color: meta.color,
-        border: `1px solid ${meta.color}40`,
-        backgroundColor: `${meta.color}10`,
-      }}
-    >
-      {meta.label}
+    <span className="text-[9px] font-mono uppercase tracking-wider text-white/30 border border-white/[0.10] rounded px-1.5 py-0">
+      {lang === "ko" ? "KR only" : "EN only"}
     </span>
-  );
-}
-
-/**
- * Per-entry KO / EN toggle. Defaults to the page locale, and only renders
- * when both languages are detected. Buttons disabled when the corresponding
- * language is unavailable.
- */
-function LangToggle({
-  value,
-  onChange,
-  hasKo,
-  hasEn,
-}: {
-  value: Lang;
-  onChange: (lang: Lang) => void;
-  hasKo: boolean;
-  hasEn: boolean;
-}) {
-  const both = hasKo && hasEn;
-  if (!both) return null;
-  return (
-    <div className="inline-flex items-center rounded-md border border-white/[0.10] overflow-hidden text-[10px] font-mono">
-      <button
-        type="button"
-        onClick={() => onChange("ko")}
-        className={
-          "px-2 py-0.5 transition-colors " +
-          (value === "ko"
-            ? "bg-[#A573E8]/20 text-[#A573E8]"
-            : "text-white/50 hover:text-white")
-        }
-      >
-        KO
-      </button>
-      <span className="w-px h-3 bg-white/[0.10]" />
-      <button
-        type="button"
-        onClick={() => onChange("en")}
-        className={
-          "px-2 py-0.5 transition-colors " +
-          (value === "en"
-            ? "bg-white/[0.15] text-[#F0F0FF]"
-            : "text-white/50 hover:text-white")
-        }
-      >
-        EN
-      </button>
-    </div>
-  );
-}
-
-/**
- * Stripe-style fallback banner. Surfaces "this entry is only available in
- * <other language>" when the requested language is missing for this entry.
- */
-function FallbackBanner({
-  desired,
-  available,
-}: {
-  desired: Lang;
-  available: Lang;
-}) {
-  const messages = {
-    ko: {
-      missingKo: "이 entry는 영어 원문만 작성됐습니다. 한국어 번역 기여 환영.",
-      missingEn: "This entry exists only in Korean. EN translation welcome.",
-    },
-    en: {
-      missingKo: "이 entry는 영어 원문만 작성됐습니다. 한국어 번역 기여 환영.",
-      missingEn: "This entry exists only in Korean. EN translation welcome.",
-    },
-  };
-  const text =
-    desired === "ko" && available === "en"
-      ? messages.ko.missingKo
-      : messages.en.missingEn;
-  return (
-    <div className="mb-3 rounded-md border border-[#E89B57]/30 bg-[#E89B57]/[0.06] px-3 py-2 text-[12px] text-[#E89B57]">
-      {text}
-    </div>
   );
 }
 
 // === Entry card ==============================================================
 
-function EntryCard({ entry, initial }: { entry: ChangelogEntry; initial: Lang }) {
+function EntryCard({ entry }: { entry: ChangelogEntry }) {
+  const locale = useLocale() as Lang;
   const split = splitBodyByLanguage(entry.body);
   const both = split.hasKo && split.hasEn;
-  // Resolve initial lang to a value the entry actually has.
-  const effectiveInitial: Lang = both
-    ? initial
-    : split.hasKo
-      ? "ko"
-      : "en";
-  const [lang, setLang] = useState<Lang>(effectiveInitial);
-
-  const scope = scopeOf(entry.version);
-  const showFallback = (lang === "ko" && !split.hasKo) || (lang === "en" && !split.hasEn);
-  const renderText = lang === "ko" ? split.ko : split.en;
+  const monoLang: Lang | null = !both ? (split.hasKo ? "ko" : "en") : null;
+  const body =
+    locale === "ko"
+      ? split.ko || split.en || entry.body
+      : split.en || split.ko || entry.body;
 
   return (
     <article
       id={versionAnchor(entry.version)}
-      className="rounded-lg border border-white/[0.06] hover:border-white/[0.10] p-5 scroll-mt-32 transition-colors"
+      className="rounded-lg border border-white/[0.06] p-5 scroll-mt-24"
     >
       <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-4 pb-3 border-b border-white/[0.04]">
         <span className="font-display font-bold text-lg text-[#F0F0FF]">
@@ -268,24 +181,14 @@ function EntryCard({ entry, initial }: { entry: ChangelogEntry; initial: Lang })
         {entry.date && (
           <span className="text-white/40 text-xs font-mono">{entry.date}</span>
         )}
-        <span className="flex items-center gap-2 ml-auto">
-          <ScopeChip scope={scope} />
-          <LangToggle
-            value={lang}
-            onChange={setLang}
-            hasKo={split.hasKo}
-            hasEn={split.hasEn}
-          />
-        </span>
+        {monoLang && (
+          <span className="ml-auto">
+            <MonolingualChip lang={monoLang} />
+          </span>
+        )}
       </header>
       <div className="docs-prose">
-        {showFallback && (
-          <FallbackBanner
-            desired={lang}
-            available={split.hasKo ? "ko" : "en"}
-          />
-        )}
-        <MarkdownLite text={renderText || entry.body} />
+        <MarkdownLite text={body} />
       </div>
     </article>
   );
@@ -296,98 +199,70 @@ function EntryCard({ entry, initial }: { entry: ChangelogEntry; initial: Lang })
 export default function Page() {
   const locale = useLocale();
   const setLocale = useSetLocale();
-  const groups = groupByDecile(CHANGELOG);
-  const initial: Lang = locale === "en" ? "en" : "ko";
 
   return (
     <DocsShell
       slug="reference/changelog"
       title="Changelog"
       titleKo="변경 이력"
-      summary={`Full version history auto-synced from CHANGELOG.md (${CHANGELOG.length} entries, last synced ${CHANGELOG_SYNCED_AT}).`}
-      summaryKo={`CHANGELOG.md에서 자동 sync된 전체 버전 이력 (${CHANGELOG.length} entries, ${CHANGELOG_SYNCED_AT} 최신).`}
+      summary={`Full history auto-synced from CHANGELOG.md. ${CHANGELOG.length} entries, last synced ${CHANGELOG_SYNCED_AT}.`}
+      summaryKo={`CHANGELOG.md에서 자동 sync된 전체 이력. ${CHANGELOG.length} entries, ${CHANGELOG_SYNCED_AT} 최신.`}
     >
       <Bi
         ko={
           <p>
-            전체 <strong>{CHANGELOG.length}</strong>개 버전 entry를 CHANGELOG.md에서 자동 추출.
-            각 entry는 한국어와 영어가 모두 작성됐으면 우상단 <code>KO</code> / <code>EN</code> 토글로 전환합니다.
-            한쪽 언어만 있으면 토글이 안 뜨고, 페이지 locale과 다르면 안내 배지가 떠요.
+            전체 <strong>{CHANGELOG.length}</strong>개 entry를 CHANGELOG.md에서 자동 추출.
+            상단 토글로 한국어 / 영어 전환. 한쪽만 작성된 entry는 표시 옆에 작은
+            <code className="mx-1">KR only</code>/<code>EN only</code> 라벨이 붙고, 현재 locale에 콘텐츠가
+            없는 경우 자동으로 다른 언어 fallback. 정본은 repo의 <code>CHANGELOG.md</code>.
           </p>
         }
         en={
           <p>
-            All <strong>{CHANGELOG.length}</strong> version entries auto-extracted from CHANGELOG.md.
-            When an entry exists in both Korean and English, switch via the per-entry <code>KO</code> / <code>EN</code> pill.
-            Mono-lingual entries skip the toggle and show a small fallback notice when the requested language is missing.
+            All <strong>{CHANGELOG.length}</strong> entries auto-extracted from CHANGELOG.md.
+            Switch language with the toggle above. Entries authored in only one language carry a small
+            <code className="mx-1">KR only</code>/<code>EN only</code> chip; missing content falls back
+            automatically. The repo&apos;s <code>CHANGELOG.md</code> is the source of truth.
           </p>
         }
       />
 
-      {/* Sticky decile pill bar. Jump nav + global locale shortcut */}
-      <nav
-        aria-label={t(locale, "버전 decile 점프", "Decile jump nav")}
-        className="not-prose sticky top-16 z-20 -mx-6 px-6 py-3 backdrop-blur bg-[#0B1628]/90 border-y border-white/[0.06] mb-10 flex flex-wrap items-center gap-2"
-      >
-        {groups.map((g) => (
-          <a
-            key={g.decile}
-            href={`#decile-${g.decile.replace(/[^a-zA-Z0-9]/g, "-")}`}
-            className="text-[11px] font-mono px-2.5 py-1 rounded-full border border-white/[0.10] hover:border-[#A573E8] text-white/70 hover:text-[#F0F0FF] transition-colors"
-          >
-            {g.decile}
-            <span className="ml-1 opacity-50">{g.entries.length}</span>
-          </a>
-        ))}
-        <span className="ml-auto inline-flex items-center rounded-md border border-white/[0.10] overflow-hidden text-[10px] font-mono">
+      {/* Single prominent top toggle. Replaces the previous sticky bar. */}
+      <div className="not-prose flex justify-center my-8">
+        <div className="inline-flex items-center rounded-md border border-white/[0.12] overflow-hidden text-sm">
           <button
             type="button"
             onClick={() => setLocale("ko")}
             className={
-              "px-2.5 py-1 transition-colors " +
+              "px-4 py-1.5 transition-colors " +
               (locale === "ko"
-                ? "bg-[#A573E8]/20 text-[#A573E8]"
-                : "text-white/50 hover:text-white")
+                ? "bg-[#A573E8]/20 text-[#A573E8] font-medium"
+                : "text-white/55 hover:text-white")
             }
           >
             한국어
           </button>
-          <span className="w-px h-3 bg-white/[0.10]" />
+          <span className="w-px h-5 bg-white/[0.12]" />
           <button
             type="button"
             onClick={() => setLocale("en")}
             className={
-              "px-2.5 py-1 transition-colors " +
+              "px-4 py-1.5 transition-colors " +
               (locale === "en"
-                ? "bg-white/[0.15] text-[#F0F0FF]"
-                : "text-white/50 hover:text-white")
+                ? "bg-white/[0.15] text-[#F0F0FF] font-medium"
+                : "text-white/55 hover:text-white")
             }
           >
             English
           </button>
-        </span>
-      </nav>
+        </div>
+      </div>
 
-      {groups.map((g) => (
-        <section
-          key={g.decile}
-          id={`decile-${g.decile.replace(/[^a-zA-Z0-9]/g, "-")}`}
-          className="not-prose scroll-mt-32 mb-16"
-        >
-          <h2 className="font-display text-2xl md:text-3xl font-bold tracking-tight mb-6 flex items-baseline gap-3">
-            <span>{g.decile}</span>
-            <span className="text-white/40 text-sm font-normal font-mono">
-              {g.entries.length}{" "}
-              {t(locale, "릴리스", g.entries.length === 1 ? "release" : "releases")}
-            </span>
-          </h2>
-          <div className="space-y-6">
-            {g.entries.map((e) => (
-              <EntryCard key={e.version} entry={e} initial={initial} />
-            ))}
-          </div>
-        </section>
-      ))}
+      <div className="not-prose space-y-4">
+        {CHANGELOG.map((e) => (
+          <EntryCard key={e.version} entry={e} />
+        ))}
+      </div>
 
       <hr />
       <Bi
@@ -398,14 +273,10 @@ export default function Page() {
               <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code>가 진리원입니다.
               이 페이지는 <code>site/scripts/sync-stats.mjs</code>가 그 파일을 자동 파싱한 결과.
             </p>
-            <h2>토글 동작</h2>
-            <ul>
-              <li>각 entry는 본문에서 한국어 / 영어 비율을 자동 감지합니다.</li>
-              <li>두 언어가 모두 있는 entry: 우상단 <strong>KO / EN</strong> pill. 클릭으로 본문 swap.</li>
-              <li>한 언어만 있는 entry: 토글 없음. 페이지 locale과 다르면 amber banner로 안내.</li>
-              <li>코드 블록과 신호어(파일 경로, 식별자)는 양쪽에 모두 노출됩니다.</li>
-              <li>상단 nav 우측의 <strong>한국어 / English</strong> 토글은 페이지 전역 locale을 바꿉니다 (모든 entry 기본값 동시 전환).</li>
-            </ul>
+            <p>
+              {t(locale, "마지막 sync: ", "Last sync: ")}
+              <code>{CHANGELOG_SYNCED_AT}</code>
+            </p>
           </>
         }
         en={
@@ -415,14 +286,9 @@ export default function Page() {
               <code>github.com/mangowhoiscloud/geode/blob/main/CHANGELOG.md</code> is the authoritative file.
               This page is the result of <code>site/scripts/sync-stats.mjs</code> parsing it.
             </p>
-            <h2>Toggle behavior</h2>
-            <ul>
-              <li>Each entry's body is scanned for Hangul / Latin ratios.</li>
-              <li>Entries with both languages: <strong>KO / EN</strong> pill at top right; click to swap.</li>
-              <li>Mono-lingual entries: no toggle. If the active locale differs, an amber banner notes the absence.</li>
-              <li>Code blocks and identifier-heavy strings (file paths, names) live in both sides.</li>
-              <li>The <strong>한국어 / English</strong> control on the top nav switches the page-wide default for all entries at once.</li>
-            </ul>
+            <p>
+              Last sync: <code>{CHANGELOG_SYNCED_AT}</code>
+            </p>
           </>
         }
       />


### PR DESCRIPTION
## Summary

사용자 피드백 응답.

- **빈 section header 필터링**: \`### Infrastructure\` 같은 헤더가 다른 언어에 의미 있는 내용이 없을 때 자동 제거.
- **상단 매퍼·중복 토글 제거**: sticky decile pill bar + nav locale toggle 모두 제거.
- **맨 상단 단일 토글**: 한국어 / English button group. 페이지 모든 entry default 동시 변경.
- **per-entry pill 제거**: 단순 flat 리스트.
- **Claude Code style**: 그룹화 없는 chronological list.

## Changes

| File | Change |
|---|---|
| \`site/src/app/docs/reference/changelog/page.tsx\` | 전면 재작성. \`splitBodyByLanguage\` 가 \`### Section\` 단위 그룹핑 후 의미 있는 본문 있을 때만 header emit |
| \`CHANGELOG.md\` | [Unreleased] entry |

## Verification

- [x] build 통과
- [x] ruff clean

## Reference

- Claude Code CHANGELOG.md format
- 직전 sprint #1093 + #1095 retro