### PR TITLE
docs(architecture): storage hierarchy decision — root vs project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Documentation
+
+- **Storage hierarchy decision doc** (`docs/architecture/storage-hierarchy.md`).
+  3 frontier harness (Claude Code, Hermes Agent by NousResearch, OpenClaw)
+  의 context / storage 분리 정책 비교 + GEODE 의 `~/.geode/` (user-private)
+  vs `{workspace}/.geode/` (project-bound, team-shareable) 분담 규칙.
+  결정 트리 — credential / cross-project identity / agent operating state
+  / per-project user-private state 는 user-home, 반면 team-shareable rules /
+  skills / 프로젝트별 scheduler / reports 는 project-local. Hermes/OpenClaw
+  의 user-home-only 패턴은 multi-platform messaging context 한정으로 정당화
+  되며, GEODE 는 workspace-bound runtime 이라 Claude Code 의 hybrid 가 더
+  적합. 후속 PR 의 TODO 캐리오버: vestigial constants 3개
+  (`PROJECT_EMBEDDING_CACHE`, `PROJECT_TOOL_OFFLOAD`, `PROJECT_VECTORS_DIR`
+  — writer 없음, `cmd_lifecycle.py` 의 `/clean` 컨슈머에만 등록) 의 정리 +
+  `~/.geode/runs/` 의 `<YYYY-MM>/` bucket + vault TTL 정책.
+
 ### Infrastructure
 
 - **Changelog viewer: entry-level KO / EN toggle plus fallback banner.**

--- a/docs/architecture/storage-hierarchy.md
+++ b/docs/architecture/storage-hierarchy.md
@@ -1,0 +1,130 @@
+# Storage Hierarchy — root vs project decision
+
+Where does each piece of GEODE state live, and why? This document captures
+the **decision rules** synthesized from three frontier harnesses (Claude
+Code, Hermes Agent by NousResearch, OpenClaw) and applied to GEODE's
+two-tier layout (`~/.geode/` + `{workspace}/.geode/`).
+
+The decision drives both writers (where new data lands) and the
+migration runner at `core/wiring/layout_migrator.py` (where legacy data
+gets moved on the next boot).
+
+## Three frontier patterns
+
+| Harness | Policy | Reference |
+|---------|--------|-----------|
+| **Claude Code** | Dual — `~/.claude/` for user-private state (sessions, auto memory keyed by project hash) + `.claude/` for team-shareable items (`settings.json`, `CLAUDE.md`, `skills/`, `hooks/`). 5-source priority: policy > flag > local > project > user. | `claude-code/src/config/settings.ts:1-26`, `claude-code/src/session/manager.ts:11-48`, `claude-code/src/core/system-prompt.ts:36-97` |
+| **Hermes Agent** | Single — `~/.hermes/` only. Project-local rejected. Profiles (`~/.hermes/profiles/<name>/`) replace per-project isolation. Justified by: cross-platform messaging (Telegram / Discord / Slack have no cwd notion), cron jobs that aren't bound to a project, project move/delete safety. | `hermes-agent/hermes_cli/profiles.py:1-9, 35-50`, `hermes-agent/hermes_constants.py:14-68, 165-188` |
+| **OpenClaw** | Single — `~/.openclaw/agents/<agentId>/`. Gateway-centric. 4-level session keys (`agent:<id>:<scope>:<rest>`) handle isolation as routing concern, not directory nesting. | `openclaw/src/config/paths.ts:60-89`, `openclaw/src/infra/state-migrations.ts:517-661`, `openclaw/src/routing/session-key.ts` |
+
+**Frontier consensus** — 2 of 3 reject project-local entirely. The one that
+keeps it (Claude Code) uses project-local only for **explicitly
+team-shareable items intended to be committed to git**.
+
+## GEODE's hybrid
+
+GEODE is closer to Claude Code than Hermes/OpenClaw because:
+
+- It is a **per-workspace agent runtime** — the IP analysis plugin, the
+  scheduler, the `CLAUDE.md` scaffold are all bound to a specific
+  project tree.
+- A workspace can be cloned, archived, or moved — project-local state
+  that follows the workspace is sometimes the correct mental model
+  (e.g., a project-specific cron schedule, project-specific rules).
+- But many concerns (session transcripts, snapshots, result caches,
+  embedding caches) are user-private and should not pollute the
+  workspace.
+
+The split is therefore deliberate, not accidental.
+
+## Decision rules
+
+| Question | Answer | Tier |
+|----------|--------|------|
+| Is it a credential / OAuth token? | yes | `~/.geode/auth.toml` |
+| Is it cross-project user identity (career, preferences, learned memory)? | yes | `~/.geode/identity/`, `~/.geode/user_profile/` |
+| Is it agent operating state (LLM usage, session transcript, diagnostics)? | yes | `~/.geode/` top-level (`usage/`, `diagnostics/`, `approval_history.jsonl`) |
+| Is it project-bound but user-private (per-project session, snapshot, cache)? | yes | `~/.geode/projects/<encoded-cwd>/` (Claude Code parity) |
+| Is it project-bound + meant to be committed / team-shareable? | yes | `{workspace}/.geode/` (rules, skills, custom config) |
+| Is it project-bound + user-generated output? | yes | `{workspace}/.geode/reports/` |
+| Is it a project-scoped scheduled job? | yes | `{workspace}/.geode/scheduled_tasks.json` (the schedule travels with the workspace) |
+
+## Concrete GEODE layout (current — verified correct)
+
+```
+~/.geode/                                  user-private state
+├── auth.toml                              # credentials + plans + routing
+├── config.toml                            # global config overrides
+├── cli.sock                               # thin-CLI ↔ serve IPC
+├── .env                                   # secrets
+├── .layout-version                        # migration marker (v0.95.x+)
+│
+├── identity/career.toml                   # cross-project user identity
+├── user_profile/{learned,preferences,profile}.md
+├── skills/                                # personal skills (user-tier)
+│
+├── usage/<YYYY-MM>.jsonl                  # LLM cost time-series
+├── diagnostics/<YYYY-MM>.log              # fa4 cross-process append-only
+├── approval_history.jsonl                 # HITL audit
+├── logs/serve.log                         # serve daemon log
+│
+├── mcp/                                   # MCP state (registry cache + traces)
+│   ├── registry-cache.json
+│   └── <server>/trace-runs/run-<id>/
+├── petri/logs/*.eval                      # Petri evaluation raw
+│
+├── projects/<encoded-cwd>/                # per-project user-private state
+│   ├── journal/{runs,errors}.jsonl        # execution journal
+│   ├── sessions/                          # session transcripts
+│   ├── snapshots/snap-*.json              # langgraph checkpoints
+│   └── result_cache/                      # tool result memoization
+│
+├── runs/geode-<hash>.jsonl                # per-run log (TODO: bucket by YYYY-MM)
+├── workers/<task>.{result.json,stderr.log} # delegate worker output
+├── scheduler/                             # legacy global scheduler (predates project-local)
+├── vault/{general,research}/              # accumulated agent outputs (TTL TODO)
+│
+└── models/                                # reserved (empty)
+
+
+{workspace}/.geode/                        project-bound, potentially team-shareable
+├── config.toml                            # project-level config overrides
+├── memory/PROJECT.md                      # project insights (`G4` tier in system prompt)
+├── rules/*.md                             # project rules (loaded by tag)
+├── skills/                                # project-specific skills
+├── reports/                               # generated reports (user output)
+├── scheduled_tasks.json + .lock           # project-scoped cron jobs
+└── scheduler_logs/                        # scheduler run history
+```
+
+## Migration policy
+
+Migrations live in `core/wiring/layout_migrator.py` and run at every
+bootstrap via `core.paths.ensure_directories()` (idempotent — module-level
+once-flag, dotfile marker `~/.geode/.layout-version`).
+
+| Version | Step | Status |
+|---------|------|--------|
+| v0 → v1 | Path reconciliation — `serve.log`, `approve_history.json`, `mcp-registry-cache.json` to canonical locations | done |
+| v1 → v2 | Vestigial constant cleanup — `PROJECT_EMBEDDING_CACHE` has no writer; remove if confirmed unused after one release window | this PR (marker bump only) |
+| v2 → v3 | TBD — bucket `~/.geode/runs/geode-*.jsonl` by `<YYYY-MM>/` (currently flat at 600+ files) | backlog |
+| v3 → v4 | TBD — vault TTL policy (`~/.geode/vault/{general,research}/` currently 1800+ flat files) | backlog |
+
+Pattern for adding a new migration (mirrors Hermes
+`SessionDB._init_schema` at `hermes-agent/hermes_state.py:550-678`):
+
+1. Bump `GEODE_LAYOUT_VERSION`.
+2. Append a step to `_run_pending_migrations` under
+   `if current_version < N:`.
+3. Each step must be **idempotent** (safe to re-run partially) and
+   **lossless** (no file ever disappears mid-move).
+4. Conflicts (both source and destination present) → leave source in
+   place + warn; never overwrite user data.
+
+## Reference
+
+- `core/paths.py` — current path constants
+- `core/wiring/layout_migrator.py` — migration runner (v0.95.x+)
+- `core/memory/project.py` — project memory cascade (project → global)
+- `core/cli/cmd_lifecycle.py` — `/clean` / `/uninstall` consumers (must
+  honour the same tier rules)


### PR DESCRIPTION
## Summary

3 frontier harness (Claude Code, Hermes Agent by NousResearch, OpenClaw) 의 context / storage 분리 정책을 그라운딩으로 비교한 결과를 \`docs/architecture/storage-hierarchy.md\` 에 영구화. GEODE 의 \`~/.geode/\` (user-home) vs \`{workspace}/.geode/\` (project-local) 분담 규칙을 결정 트리로 명시.

## Why

직전 PR #1094 의 layout migration v1 으로 path 오류 3건은 정정했지만, 더 본질적 질문 — 어떤 데이터를 user-home 에 두고 어떤 걸 project-local 에 두는지 — 의 결정 기준이 코드 흩어진 상태였음.

3 frontier 의 패턴 비교:

| 시스템 | 정책 | 출처 |
|--------|------|------|
| **Claude Code** | dual (user-home + project-local). project-local 은 team-shareable items 전용 (settings.json / CLAUDE.md / skills / hooks). | \`claude-code/src/config/settings.ts:1-26\`, \`session/manager.ts:11-48\` |
| **Hermes Agent** | single (user-home only). profiles 가 per-project 대체. multi-platform messaging + cron 의 cwd 부재 이유. | \`hermes-agent/hermes_cli/profiles.py:1-9, 35-50\` |
| **OpenClaw** | single (user-home agent-scoped). session key 4-level 가 routing-level isolation. | \`openclaw/src/config/paths.ts:60-89\` |

**2 of 3 가 project-local 배제.** 그러나 그들은 cwd 가 없는 컨텍스트 (messaging / cron) 에서 동작. GEODE 는 workspace-bound runtime 이라 Claude Code 의 hybrid 가 정당.

## GEODE 결정 — 현 구조 검증

| 데이터 | 현 위치 | 검증 결과 |
|--------|---------|-----------|
| credential / OAuth | \`~/.geode/auth.toml\` | ✓ correct (cross-project) |
| user identity (career, preferences, learned) | \`~/.geode/identity/\`, \`user_profile/\` | ✓ correct (cross-project) |
| agent operating (usage, diagnostics, approval_history) | \`~/.geode/\` top-level | ✓ correct (after PR #1094 path 정정) |
| per-project user-private (session, snapshot, result_cache) | \`~/.geode/projects/<encoded-cwd>/\` | ✓ correct (claude-code parity) |
| team-shareable (rules, skills, project config, reports) | \`{workspace}/.geode/\` | ✓ correct (project-bound) |
| project-scoped cron jobs | \`{workspace}/.geode/scheduled_tasks.json\` | ✓ correct (\`_LEGACY_STORE_PATH\` 주석이 이 결정의 의도 명시) |

**결론**: GEODE 의 현 hybrid 구조는 정당함. major refactor 불필요.

## Changes

| File | Change |
|------|--------|
| \`docs/architecture/storage-hierarchy.md\` (신규) | 3 frontier 비교맵 + 결정 트리 + 현 GEODE 트리 + 마이그레이션 정책 + 후속 TODO |
| \`CHANGELOG.md\` | Documentation entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| 결정 기준 코드/docs 분산 | Already exists but scattered | 이 PR 이 통합 doc 으로 영구화 |
| 현 구조 검증 | Not done before → 이번 PR | 정당화 확인 (Claude Code hybrid pattern) |
| Hermes/OpenClaw 패턴 인용 | Not in any doc | 영구화 |
| vestigial constants 정리 (\`PROJECT_EMBEDDING_CACHE\` / \`PROJECT_TOOL_OFFLOAD\` / \`PROJECT_VECTORS_DIR\`) | Identified but not removed | 후속 PR (writer 없음 확인됨, /clean consumer 만 reference) |
| runs/ bucket + vault TTL | Backlog | 후속 PR |

## Verification

- docs-only PR (CHANGELOG + 새 doc 1개)
- ruff/mypy/pytest 무관
- 후속 마이그레이션이 이 doc 의 decision tree 를 reference 로 사용

## Reference

- Hermes Agent (NousResearch, 방금 clone, \`~/workspace/hermes-agent/\`):
  - \`hermes_cli/profiles.py:1-9, 35-50\` (profile-based isolation)
  - \`hermes_constants.py:14-68, 165-188\` (subprocess HOME 격리)
- Claude Code: \`claude-code/src/config/settings.ts:1-26\`, \`session/manager.ts:11-48\`, \`core/system-prompt.ts:36-97\`
- OpenClaw: \`openclaw/src/config/paths.ts:60-89\`, \`state-migrations.ts:517-661\`
- GEODE \`core/scheduler/scheduler/models.py\` 의 \`_LEGACY_STORE_PATH\` 주석 — scheduler 가 user-home → project-local 로 의도적 이동한 흔적