### PR TITLE
chore(docs): CHANGELOG 한국어 표기 + 자동 sync trigger 보강

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,14 @@ name: Deploy site to GitHub Pages
 # Builds the Next.js static export under `site/` and deploys it to GitHub
 # Pages. Site URL after deploy: https://mangowhoiscloud.github.io/geode/
 #
-# Triggers on changes to `site/**` or this workflow only — Python source
-# changes do not redeploy the site.
+# Triggers on changes to `site/**`, this workflow, or any of the SOT files
+# that `sync-stats` reads (CHANGELOG.md, pyproject.toml, CLAUDE.md). A docs
+# page like `/docs/reference/changelog` therefore stays in sync with
+# CHANGELOG.md without a separate commit to `site/`.
+#
+# Daily 09:00 KST cron also runs as a safety net so the docs page can never
+# fall more than 24 hours behind even if Pages settings get changed by an
+# accidental admin action.
 #
 # Prerequisite: enable Pages once via repo Settings → Pages → Source =
 # "GitHub Actions". The deploy action handles the rest.
@@ -14,7 +20,13 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - "CHANGELOG.md"
+      - "pyproject.toml"
+      - "CLAUDE.md"
       - ".github/workflows/pages.yml"
+  schedule:
+    # 09:00 KST = 00:00 UTC. Daily safety-net rebuild.
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:

--- a/site/src/app/docs/reference/changelog/page.tsx
+++ b/site/src/app/docs/reference/changelog/page.tsx
@@ -203,8 +203,8 @@ export default function Page() {
   return (
     <DocsShell
       slug="reference/changelog"
-      title="Changelog"
-      titleKo="변경 이력"
+      title="CHANGELOG"
+      titleKo="CHANGELOG"
       summary={`Full history auto-synced from CHANGELOG.md. ${CHANGELOG.length} entries, last synced ${CHANGELOG_SYNCED_AT}.`}
       summaryKo={`CHANGELOG.md에서 자동 sync된 전체 이력. ${CHANGELOG.length} entries, ${CHANGELOG_SYNCED_AT} 최신.`}
     >

--- a/site/src/lib/geode-docs/sitemap.ts
+++ b/site/src/lib/geode-docs/sitemap.ts
@@ -157,7 +157,7 @@ export const DOCS_SITEMAP: DocSection[] = [
     pages: [
       { slug: "reference/external-references", title: "External References", titleKo: "외부 참고", summary: "Frontier agent systems, design standards, and prior work cited by GEODE.", summaryKo: "GEODE가 인용하는 frontier 에이전트 시스템, 디자인 표준, 선행 작업.", quadrant: "reference" },
       { slug: "reference/frontier-comparison", title: "Frontier Comparison", titleKo: "프론티어 비교", summary: "GEODE versus Claude Code, Codex CLI, OpenClaw, Hermes, autoresearch.", summaryKo: "GEODE와 Claude Code, Codex CLI, OpenClaw, Hermes, autoresearch 비교.", quadrant: "reference" },
-      { slug: "reference/changelog", title: "Changelog", titleKo: "변경 이력", summary: "Selected version highlights. The authoritative source is the repo's CHANGELOG.md.", summaryKo: "선별된 버전 하이라이트. 정본은 repo의 CHANGELOG.md.", quadrant: "reference" },
+      { slug: "reference/changelog", title: "CHANGELOG", titleKo: "CHANGELOG", summary: "Full version history auto-synced from CHANGELOG.md on every main push.", summaryKo: "main push 마다 CHANGELOG.md에서 자동 sync된 전체 버전 이력.", quadrant: "reference" },
       { slug: "reference/sot-metrics", title: "System Metrics SOT", titleKo: "시스템 메트릭 SOT", summary: "Live values for version, modules, tests, releases, since.", summaryKo: "version, 모듈, 테스트, 릴리스, since 라이브 값.", quadrant: "reference" },
     ],
   },


### PR DESCRIPTION
## Summary

사용자 요청 2건.

1. **한글에서도 CHANGELOG 표기**: \`titleKo: \"변경 이력\"\` → \`titleKo: \"CHANGELOG\"\`. 사이드바·페이지 제목 모두 동일.
2. **CHANGELOG.md ↔ 페이지 자동 sync 메커니즘 보강**: Pages workflow path-filter에 \`CHANGELOG.md\` / \`pyproject.toml\` / \`CLAUDE.md\` 추가 + 일일 cron 안전망.

## 자동 sync 동작 (전체 그림)

**기존**:
- \`site/scripts/sync-stats.mjs\`가 매 빌드마다 실행 (workflow step에 포함).
- \`CHANGELOG.md\` → 파싱 → \`site/src/data/geode/changelog.ts\` 자동 생성 → 페이지가 import해서 렌더.
- → \`/docs/reference/changelog\` 페이지는 빌드 시점의 \`CHANGELOG.md\` 내용을 그대로 반영.

**문제** (이번 PR이 해결):
- Pages workflow \`paths\` filter가 \`site/**\` + \`.github/workflows/pages.yml\` 만 잡고 있었음. \`CHANGELOG.md\` 단독 commit은 workflow 트리거 안 됨 → 페이지가 stale.
- 다른 site 변경과 함께 commit되는 한 자동 반영됐지만, CHANGELOG-only commit은 누락.

**이번 PR 변경**:
- Path-filter에 \`CHANGELOG.md\`, \`pyproject.toml\`, \`CLAUDE.md\` 추가. sync-stats가 읽는 모든 SOT 파일.
- \`schedule: cron \"0 0 * * *\"\` (09:00 KST 일일 안전망). Pages 설정 사고 같은 경우에도 24시간 안 자동 복구.

## Changes

| File | Change |
|---|---|
| \`site/src/lib/geode-docs/sitemap.ts\` | \`titleKo: \"변경 이력\"\` → \`\"CHANGELOG\"\`. summary도 동기화 메커니즘 명시. |
| \`site/src/app/docs/reference/changelog/page.tsx\` | DocsShell \`titleKo\` 동일 변경. |
| \`.github/workflows/pages.yml\` | path-filter에 SOT 파일 3개 추가 + 일일 cron 안전망 |

## Verification

- [x] local build 통과
- [x] sitemap entry titleKo == \"CHANGELOG\"
- [x] cron 표현식 \"0 0 * * *\" = 매일 UTC 00:00 = 매일 KST 09:00