### PR TITLE
fix(paths): P1 sloppiness 정리 — vestigial 상수 제거 + v1→v2 archive migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,30 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Removed
+
+- **`PROJECT_EMBEDDING_CACHE` / `PROJECT_VECTORS_DIR`** path constants
+  in `core.paths` — vestigial. No writer ever used either; the on-disk
+  directories (`{workspace}/.geode/embedding-cache/` and
+  `{workspace}/.geode/vectors/`) stopped receiving writes on
+  2026-04-05. Cascading removals: `core/cli/cmd_lifecycle.py` 의
+  `/clean` lookup + scan list, `tests/test_lifecycle_commands.py` 의
+  `PROJECT_EMBEDDING_CACHE` patch 가 모두 정리됨. 잔여 디스크 디렉터리
+  는 layout migration v1→v2 가 `_archive/` 로 옮김 (아래 항목).
+
+### Fixed
+
+- **Layout migration v1→v2 — vestigial 디렉터리 archival.**
+  `core/wiring/layout_migrator.py:_migrate_v1_to_v2()` 가 현재 workspace
+  의 `.geode/{embedding-cache,vectors}/` 를 `.geode/_archive/<name>-<UTC>/`
+  로 안전하게 옮김 (`shutil.move`, never `rmtree`). 비어있는 경우 `rmdir`
+  만 수행, archive target 이 이미 있으면 원본 보존 + warning. v0→v1 의
+  same-FS atomic move 패턴 + lossless safety 계승. `GEODE_LAYOUT_VERSION`
+  1 → 2. 회귀: `tests/test_layout_migrator.py::TestV1ToV2VestigialArchival`
+  8 cases (populated cache / populated vectors / both / empty rmdir /
+  absent skip / no .geode/ short-circuit / full v0→v2 chain / constants
+  removed sanity).
+
 ### Documentation
 
 - **Storage hierarchy decision doc** (`docs/architecture/storage-hierarchy.md`).

--- a/core/cli/cmd_lifecycle.py
+++ b/core/cli/cmd_lifecycle.py
@@ -28,12 +28,10 @@ from core.paths import (
     GLOBAL_USAGE_DIR,
     GLOBAL_WORKERS_DIR,
     MCP_REGISTRY_CACHE,
-    PROJECT_EMBEDDING_CACHE,
     PROJECT_GEODE_DIR,
     PROJECT_RESULT_CACHE_DIR,
     PROJECT_SCHEDULER_LOG_DIR,
     PROJECT_TOOL_OFFLOAD,
-    PROJECT_VECTORS_DIR,
     SERVE_LOG_PATH,
 )
 from core.ui.console import console
@@ -324,10 +322,8 @@ def show_status(*, json_output: bool = False) -> None:
 
     # Project disk usage
     project_dirs = {
-        "embedding-cache": PROJECT_EMBEDDING_CACHE,
         "tool-offload": PROJECT_TOOL_OFFLOAD,
         "result_cache": PROJECT_RESULT_CACHE_DIR,
-        "vectors": PROJECT_VECTORS_DIR,
         "scheduler_logs": PROJECT_SCHEDULER_LOG_DIR,
     }
     for name, path in project_dirs.items():
@@ -462,10 +458,8 @@ def do_clean(
     # Tier 1 — Safe (always included for matching scope)
     if include_project:
         for path, label in [
-            (PROJECT_EMBEDDING_CACHE, "embedding-cache"),
             (PROJECT_TOOL_OFFLOAD, "tool-offload"),
             (PROJECT_RESULT_CACHE_DIR, "result_cache"),
-            (PROJECT_VECTORS_DIR, "vectors"),
         ]:
             if path.exists():
                 usage = _scan_directory(path)

--- a/core/paths.py
+++ b/core/paths.py
@@ -84,9 +84,14 @@ PROJECT_LEARNING_FILE = PROJECT_GEODE_DIR / "LEARNING.md"
 PROJECT_MEMORY_INDEX = PROJECT_GEODE_DIR / "MEMORY.md"
 
 # Per-project caches surfaced by /clean for selective wipe.
-PROJECT_EMBEDDING_CACHE = PROJECT_GEODE_DIR / "embedding-cache"
+#
+# v0.95.x — `PROJECT_EMBEDDING_CACHE` and `PROJECT_VECTORS_DIR` were
+# removed (vestigial). No writer ever used either constant; the
+# corresponding on-disk directories (`.geode/embedding-cache/`,
+# `.geode/vectors/`) stopped receiving writes on 2026-04-05 and are
+# archived to `.geode/_archive/` by layout migration v1 → v2 (see
+# `core/wiring/layout_migrator.py:_migrate_v1_to_v2`).
 PROJECT_TOOL_OFFLOAD = PROJECT_GEODE_DIR / "tool-offload"
-PROJECT_VECTORS_DIR = PROJECT_GEODE_DIR / "vectors"
 
 
 # ---------------------------------------------------------------------------

--- a/core/wiring/layout_migrator.py
+++ b/core/wiring/layout_migrator.py
@@ -56,7 +56,7 @@ log = logging.getLogger(__name__)
 
 #: Current target layout schema version. Bumped each time a path-level
 #: migration is added.
-GEODE_LAYOUT_VERSION = 1
+GEODE_LAYOUT_VERSION = 2
 
 #: Marker file recording the migrated-up-to version. Absent ⇒ version 0
 #: (pre-versioned install — every existing user starts here on first run
@@ -215,6 +215,8 @@ def _run_pending_migrations(current_version: int, report: LayoutMigrationReport)
     """
     if current_version < 1:
         report.steps.append(_migrate_v0_to_v1())
+    if current_version < 2:
+        report.steps.append(_migrate_v1_to_v2())
 
 
 # ---------------------------------------------------------------------------
@@ -268,5 +270,84 @@ def _migrate_v0_to_v1() -> MigrationResult:
             log.info("Layout v0→v1: moved %s → %s", src, dst)
         except OSError as exc:
             result.warnings.append(f"{src.name}: move failed: {exc}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# v1 → v2: vestigial directory archival (embedding-cache, vectors)
+# ---------------------------------------------------------------------------
+
+
+def _migrate_v1_to_v2() -> MigrationResult:
+    """v2 — archive `.geode/embedding-cache/` and `.geode/vectors/`.
+
+    The on-disk directories exist for legacy reasons but have no writer
+    since 2026-04-05. The corresponding ``paths.py`` constants
+    (``PROJECT_EMBEDDING_CACHE`` / ``PROJECT_VECTORS_DIR``) were removed
+    in the same PR.
+
+    Strategy — **archive, not delete**. Move to
+    ``{workspace}/.geode/_archive/<name>-<UTC>/`` so the operator can
+    inspect or restore. Reversible by design — mirrors the user-data
+    safety pattern from v0→v1 (`shutil.move`, never `rmtree`).
+
+    Scope — current workspace only. Other workspaces archive themselves
+    on their next bootstrap. The migration step is keyed off
+    ``core.paths.get_project_root()`` which respects the
+    `core/paths.get_project_root` resolution rules.
+
+    Skip cases — directory absent (fresh install), or directory present
+    but empty (nothing to archive; just `rmdir`).
+    """
+    from core.paths import get_project_root
+
+    result = MigrationResult(name="v1→v2: vestigial dir archival")
+
+    project_root = get_project_root()
+    geode_dir = project_root / ".geode"
+    if not geode_dir.exists():
+        result.skipped.append(".geode/: absent in current workspace")
+        return result
+
+    import datetime as _dt
+
+    stamp = _dt.datetime.now(_dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    archive_root = geode_dir / "_archive"
+    candidates = [
+        geode_dir / "embedding-cache",
+        geode_dir / "vectors",
+    ]
+
+    for src in candidates:
+        if not src.exists():
+            result.skipped.append(f"{src.name}: absent")
+            continue
+        try:
+            entries = list(src.iterdir())
+        except OSError as exc:
+            result.warnings.append(f"{src.name}: iterdir failed: {exc}")
+            continue
+        if not entries:
+            try:
+                src.rmdir()
+                result.moved.append((str(src), "(empty — removed)"))
+                log.info("Layout v1→v2: removed empty %s", src)
+            except OSError as exc:
+                result.warnings.append(f"{src.name}: empty rmdir failed: {exc}")
+            continue
+        dst = archive_root / f"{src.name}-{stamp}"
+        if dst.exists():
+            result.warnings.append(
+                f"{src.name}: archive target {dst} already exists — left source untouched"
+            )
+            continue
+        try:
+            archive_root.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            result.moved.append((str(src), str(dst)))
+            log.info("Layout v1→v2: archived %s → %s", src, dst)
+        except OSError as exc:
+            result.warnings.append(f"{src.name}: archive failed: {exc}")
 
     return result

--- a/tests/test_layout_migrator.py
+++ b/tests/test_layout_migrator.py
@@ -16,15 +16,25 @@ import pytest
 
 @pytest.fixture
 def fake_geode_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect ``GEODE_HOME`` (and all derived paths) to a tmp dir."""
-    # Both the constant and the live reference in layout_migrator/paths must
-    # point at tmp_path so reads + writes land in the sandbox.
+    """Redirect ``GEODE_HOME`` (and all derived paths) to a tmp dir.
+
+    For v1→v2 migration, also redirect ``get_project_root`` so the
+    migration step's "current workspace" lands inside the same tmp_path
+    instead of the actual repo (which would archive real files).
+    """
     monkeypatch.setattr("core.paths.GEODE_HOME", tmp_path)
     monkeypatch.setattr("core.wiring.layout_migrator.GEODE_HOME", tmp_path)
     monkeypatch.setattr(
         "core.wiring.layout_migrator.LAYOUT_VERSION_FILE",
         tmp_path / ".layout-version",
     )
+
+    # Project root → a workspace inside tmp_path. v1→v2 migration archives
+    # things under {workspace}/.geode/_archive so we want the workspace to
+    # be sandboxed too.
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("core.paths.get_project_root", lambda: workspace)
 
     # Reset the once-per-process guard so each test starts fresh.
     from core.wiring.layout_migrator import reset_migration_guard
@@ -183,3 +193,126 @@ class TestV0ToV1PathReconciliation:
         assert len(step.skipped) == 3
         assert step.moved == []
         assert step.warnings == []
+
+
+class TestV1ToV2VestigialArchival:
+    """v1→v2 — archive `.geode/embedding-cache/` and `.geode/vectors/`
+    (no writer since 2026-04-05) under `.geode/_archive/` for safe review."""
+
+    def _workspace(self, fake_geode_home: Path) -> Path:
+        """Return the sandbox workspace that the fixture patched
+        `get_project_root` to return."""
+        return fake_geode_home / "workspace"
+
+    def test_archives_populated_embedding_cache(self, fake_geode_home: Path) -> None:
+        workspace = self._workspace(fake_geode_home)
+        src = workspace / ".geode" / "embedding-cache"
+        src.mkdir(parents=True)
+        (src / "old-cache.bin").write_bytes(b"junk")
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        # Source moved
+        assert not src.exists()
+        # Archive contains exactly one timestamped dir whose name starts with
+        # the original directory name (`embedding-cache-<UTC>`).
+        archive = workspace / ".geode" / "_archive"
+        moved = list(archive.iterdir())
+        assert len(moved) == 1
+        assert moved[0].name.startswith("embedding-cache-")
+        assert (moved[0] / "old-cache.bin").exists()
+
+    def test_archives_populated_vectors(self, fake_geode_home: Path) -> None:
+        workspace = self._workspace(fake_geode_home)
+        src = workspace / ".geode" / "vectors"
+        src.mkdir(parents=True)
+        (src / "index.faiss").write_bytes(b"stub")
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not src.exists()
+        archive = workspace / ".geode" / "_archive"
+        moved = list(archive.iterdir())
+        assert any(d.name.startswith("vectors-") for d in moved)
+
+    def test_archives_both_when_both_present(self, fake_geode_home: Path) -> None:
+        workspace = self._workspace(fake_geode_home)
+        (workspace / ".geode" / "embedding-cache").mkdir(parents=True)
+        (workspace / ".geode" / "embedding-cache" / "a").write_text("x")
+        (workspace / ".geode" / "vectors").mkdir(parents=True)
+        (workspace / ".geode" / "vectors" / "b").write_text("y")
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        archive = workspace / ".geode" / "_archive"
+        names = sorted(d.name.split("-")[0] for d in archive.iterdir())
+        assert names == ["embedding", "vectors"]
+
+    def test_empty_dir_is_rmdir_not_archived(self, fake_geode_home: Path) -> None:
+        """Empty vestigial dir gets `rmdir`'d — no archive entry."""
+        workspace = self._workspace(fake_geode_home)
+        src = workspace / ".geode" / "embedding-cache"
+        src.mkdir(parents=True)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+
+        assert not src.exists()
+        assert not (workspace / ".geode" / "_archive").exists()
+        step = next(s for s in report.steps if s.name.startswith("v1→v2"))
+        moved_destinations = [dst for _, dst in step.moved]
+        assert any("empty" in d for d in moved_destinations)
+
+    def test_absent_dirs_skip_silently(self, fake_geode_home: Path) -> None:
+        """Fresh install with no vestigial dirs — both candidates skipped."""
+        workspace = self._workspace(fake_geode_home)
+        (workspace / ".geode").mkdir(parents=True)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+        step = next(s for s in report.steps if s.name.startswith("v1→v2"))
+        assert step.moved == []
+        assert step.warnings == []
+        assert len(step.skipped) == 2
+
+    def test_no_geode_dir_short_circuits(self, fake_geode_home: Path) -> None:
+        """If the workspace has no .geode/ at all, the step skips entirely."""
+        # Workspace exists but no .geode/ in it
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+        step = next(s for s in report.steps if s.name.startswith("v1→v2"))
+        assert step.moved == []
+        # Single skipped entry — the .geode/ short-circuit
+        assert any(".geode/" in s for s in step.skipped)
+
+    def test_full_v0_to_v2_chain_on_fresh_install(self, fake_geode_home: Path) -> None:
+        """Pre-versioned install runs both v0→v1 and v1→v2 in one pass and
+        ends at the target marker."""
+        from core.wiring.layout_migrator import (
+            GEODE_LAYOUT_VERSION,
+            ensure_layout_migrated,
+            read_layout_version,
+        )
+
+        report = ensure_layout_migrated(force=True)
+        step_names = [s.name for s in report.steps]
+        assert any(n.startswith("v0→v1") for n in step_names)
+        assert any(n.startswith("v1→v2") for n in step_names)
+        assert read_layout_version() == GEODE_LAYOUT_VERSION == 2
+
+    def test_constants_removed_from_paths(self, fake_geode_home: Path) -> None:
+        """Sanity — the two vestigial constants must no longer exist on
+        ``core.paths`` (P1 sloppiness cleanup)."""
+        from core import paths
+
+        assert not hasattr(paths, "PROJECT_EMBEDDING_CACHE")
+        assert not hasattr(paths, "PROJECT_VECTORS_DIR")

--- a/tests/test_lifecycle_commands.py
+++ b/tests/test_lifecycle_commands.py
@@ -186,46 +186,44 @@ class TestStatus:
 
 class TestClean:
     def test_dry_run_deletes_nothing(self, tmp_path: Path) -> None:
-        cache = tmp_path / "embedding-cache"
-        cache.mkdir()
-        (cache / "data.npy").write_bytes(b"x" * 100)
+        # v0.95.x — `PROJECT_EMBEDDING_CACHE` was removed (vestigial). Use
+        # `PROJECT_TOOL_OFFLOAD` (still live) for the dry-run guard test.
+        offload = tmp_path / "tool-offload"
+        offload.mkdir()
+        (offload / "result.json").write_text("payload")
 
-        with patch("core.cli.cmd_lifecycle.PROJECT_EMBEDDING_CACHE", cache):
+        with patch("core.cli.cmd_lifecycle.PROJECT_TOOL_OFFLOAD", offload):
             do_clean(scope="project", dry_run=True, force=True)
 
-        assert cache.exists()
-        assert (cache / "data.npy").exists()
+        assert offload.exists()
+        assert (offload / "result.json").exists()
 
     def test_default_cleans_caches(self, tmp_path: Path) -> None:
-        cache = tmp_path / "embedding-cache"
-        cache.mkdir()
-        (cache / "data.npy").write_bytes(b"x" * 50)
-
         offload = tmp_path / "tool-offload"
         offload.mkdir()
         (offload / "result.json").write_text("{}")
 
+        result_cache = tmp_path / "result_cache"
+        result_cache.mkdir()
+        (result_cache / "cached.json").write_text("{}")
+
         with (
-            patch("core.cli.cmd_lifecycle.PROJECT_EMBEDDING_CACHE", cache),
             patch("core.cli.cmd_lifecycle.PROJECT_TOOL_OFFLOAD", offload),
-            patch("core.cli.cmd_lifecycle.PROJECT_RESULT_CACHE_DIR", tmp_path / "no"),
-            patch("core.cli.cmd_lifecycle.PROJECT_VECTORS_DIR", tmp_path / "no2"),
+            patch("core.cli.cmd_lifecycle.PROJECT_RESULT_CACHE_DIR", result_cache),
             patch("core.cli.cmd_lifecycle.MCP_REGISTRY_CACHE", tmp_path / "no3"),
             patch("core.cli.cmd_lifecycle.CLI_SOCKET_PATH", tmp_path / "no4"),
             patch("core.cli.cmd_lifecycle.CLI_STARTUP_LOCK", tmp_path / "no5"),
         ):
             do_clean(scope="project", force=True)
 
-        assert not cache.exists()
         assert not offload.exists()
+        assert not result_cache.exists()
 
     def test_nothing_to_clean(self, tmp_path: Path) -> None:
         """No error when nothing exists."""
         with (
-            patch("core.cli.cmd_lifecycle.PROJECT_EMBEDDING_CACHE", tmp_path / "no1"),
             patch("core.cli.cmd_lifecycle.PROJECT_TOOL_OFFLOAD", tmp_path / "no2"),
             patch("core.cli.cmd_lifecycle.PROJECT_RESULT_CACHE_DIR", tmp_path / "no3"),
-            patch("core.cli.cmd_lifecycle.PROJECT_VECTORS_DIR", tmp_path / "no4"),
             patch("core.cli.cmd_lifecycle.MCP_REGISTRY_CACHE", tmp_path / "no5"),
             patch("core.cli.cmd_lifecycle.CLI_SOCKET_PATH", tmp_path / "no6"),
             patch("core.cli.cmd_lifecycle.CLI_STARTUP_LOCK", tmp_path / "no7"),


### PR DESCRIPTION
## Summary

- \`core/paths.py\` 에서 vestigial 상수 \`PROJECT_EMBEDDING_CACHE\` / \`PROJECT_VECTORS_DIR\` 제거 (writer 없음, 2026-04-05 이후 디스크 정지).
- \`core/wiring/layout_migrator.py\` 의 \`_migrate_v1_to_v2()\` 신설 — 현재 workspace 의 \`.geode/{embedding-cache,vectors}/\` 를 \`.geode/_archive/<name>-<UTC>/\` 로 lossless archive.
- \`GEODE_LAYOUT_VERSION = 1 → 2\`.
- \`/clean\` consumer 및 lifecycle 테스트 cascade 정리.

## Why

PR #1098 의 storage-hierarchy doc audit 에서 4-카테고리 sloppiness 발견. **P1** (이 PR) = 진짜 vestigial cleanup. 후속 — P3 (paths.py 에 누락 상수 6개 추가), P2 (11 sites hardcoded literal → constant), P4 (lint guardrail).

vestigial 판정 근거:
- \`PROJECT_EMBEDDING_CACHE\` constant — \`grep -rn\` 결과 writer 없음. \`/clean\` consumer 만 reference.
- \`PROJECT_VECTORS_DIR\` constant — 동일.
- 디스크의 \`{workspace}/.geode/embedding-cache/\` 15 entries, \`{workspace}/.geode/vectors/\` 3 entries — 모두 mtime 2026-04-05, 그 이후 정지.

\`PROJECT_TOOL_OFFLOAD\` 는 분리 — writer (\`core/orchestration/tool_offload.py:59\`) 가 active 하지만 hardcoded \`Path(\".geode/tool-offload\")\` 사용. P2 에서 constant 로 정렬.

## Changes

| File | Change |
|------|--------|
| \`core/paths.py\` | 두 vestigial 상수 제거. comment 로 v1→v2 archive 안내 |
| \`core/cli/cmd_lifecycle.py\` | import + \`/clean\` lookup dict + scan list 양쪽 정리 |
| \`core/wiring/layout_migrator.py\` | \`GEODE_LAYOUT_VERSION = 2\`, \`_migrate_v1_to_v2()\` 신설, \`_run_pending_migrations\` 에 step 추가 |
| \`tests/test_layout_migrator.py\` | \`TestV1ToV2VestigialArchival\` 8 신규. fixture 가 \`get_project_root\` 도 sandbox workspace 로 redirect |
| \`tests/test_lifecycle_commands.py\` | \`TestClean\` 3 케이스의 patch 정리 — 살아있는 \`PROJECT_TOOL_OFFLOAD\` / \`PROJECT_RESULT_CACHE_DIR\` 로 등가 검증 |
| \`CHANGELOG.md\` | \`Removed\` + \`Fixed\` 항목 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| writer 부재 검증 | Done | grep + mtime — 2 commits 동안 안 쓰임 |
| /clean consumer 정리 | Done | 2 site (lookup + scan) |
| 디스크 cleanup migration | Done | \`_migrate_v1_to_v2()\` lossless archive |
| Test patch site | Done | 3 cases in \`test_lifecycle_commands.py\` 갱신 |
| PROJECT_TOOL_OFFLOAD (P2 backlog) | Deferred | writer hardcoded literal 사용 중, P2 에서 정렬 |

## Verification

- [x] ruff check / format clean (\`core/ tests/ plugins/\`)
- [x] mypy clean (359 source files)
- [x] pytest -m \"not live\" — **4749 passed**, 24 skipped, 24 deselected (+ 8 신규 v1→v2, 3 lifecycle cases 갱신)

## Migration safety

- \`shutil.move\` — same-FS atomic, lossless (never \`rmtree\`)
- archive target 이 이미 있으면 원본 보존 + warning (overwrite 안 함)
- 빈 dir 은 \`rmdir\` (archive 불필요)
- idempotent — once-flag + version marker (v0→v1 와 동일 패턴)
- \`GEODE_DISABLE_LAYOUT_MIGRATION\` env 로 opt-out 가능

## Reference

- 후속 PR series 의 설계: PR #1098 의 audit 결과 + 직전 사용자 대화의 phase 분할
- Hermes Agent (NousResearch, \`~/workspace/hermes-agent/\`) 의 \`hermes_state.py:550-678\` \`_init_schema\` 패턴 (version-gated idempotent migration) 계속 적용
- OpenClaw \`state-migrations.ts:517-661\` 의 lossless-move 정신 계승