### PR TITLE
feat(paths): P3 sloppiness 정리 — paths.py 에 누락된 5 상수 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Added
+
+- **P3 — `core.paths` 에 누락된 5 상수 추가** (`PROJECT_AGENT_MEMORY_DIR`,
+  `PROJECT_MODEL_POLICY`, `PROJECT_ROUTING_CONFIG`, `GLOBAL_SKILLS_DIR`,
+  `GLOBAL_USER_PREFERENCES`). 후속 sloppiness 정리의 두 번째 단계 — PR
+  #1098 audit 의 S2 카테고리. 5 사용처가 hardcoded `Path(".geode/...")`
+  literal 대신 새 상수 사용 — `core/memory/agent_memory.py`,
+  `core/config/__init__.py` 의 `MODEL_POLICY_PATH` + `ROUTING_CONFIG_PATH`
+  (re-export 로 backwards-compat), `core/tools/policy.py:_load_profile_policy`,
+  `core/llm/skill_registry.py:_resolve_skill_dirs`. bundled skills 의
+  `__file__` 기반 경로는 의도적으로 literal 유지 (geode 패키지 source tree
+  의 위치라 runtime 상수 의미 없음). S1 (11 사이트, paths.py constant 있는데
+  literal 쓰는 곳) 정리는 P2 후속 PR.
+
 ### Removed
 
 - **`PROJECT_EMBEDDING_CACHE` / `PROJECT_VECTORS_DIR`** path constants

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -295,7 +295,9 @@ def _resolve_provider(model: str) -> str:
 # Model Policy — allowlist / denylist governance (.geode/model-policy.toml)
 # ---------------------------------------------------------------------------
 
-MODEL_POLICY_PATH = Path(".geode") / "model-policy.toml"
+# P3 (v0.95.x) — single source of truth in `core.paths`; kept as a module-level
+# re-export for callers that import `MODEL_POLICY_PATH` from `core.config`.
+from core.paths import PROJECT_MODEL_POLICY as MODEL_POLICY_PATH  # noqa: E402
 
 
 @dataclass
@@ -343,7 +345,8 @@ def is_model_allowed(model: str, policy: ModelPolicy | None = None) -> bool:
 # Routing Config — per-node model routing (.geode/routing.toml)
 # ---------------------------------------------------------------------------
 
-ROUTING_CONFIG_PATH = Path(".geode") / "routing.toml"
+# P3 (v0.95.x) — re-export from `core.paths` (SoT).
+from core.paths import PROJECT_ROUTING_CONFIG as ROUTING_CONFIG_PATH  # noqa: E402
 
 _routing_config_cache: RoutingConfig | None = None
 

--- a/core/llm/skill_registry.py
+++ b/core/llm/skill_registry.py
@@ -122,16 +122,24 @@ class SkillRegistry:
     # -- Internal -----------------------------------------------------------
 
     def _resolve_skill_dirs(self) -> list[Path]:
-        """Return skill directories in 5-priority order (low → high)."""
+        """Return skill directories in 5-priority order (low → high).
+
+        Bundled skills live inside the geode package source tree (resolved
+        via ``__file__``) so we keep that one as a literal join — there is
+        no meaningful runtime constant for "the geode package root". Every
+        other tier is sourced from ``core.paths`` (P3 cleanup).
+        """
+        from core.paths import GLOBAL_SKILLS_DIR, PROJECT_SKILLS_DIR
+
         root = Path(__file__).resolve().parent.parent.parent
         cwd = Path.cwd()
         dirs: list[Path] = [
-            root / ".geode" / "skills",  # 1. Bundled (GEODE package)
-            Path.home() / ".geode" / "skills",  # 2. User global
-            cwd / ".geode" / "skills",  # 3. Project local (CWD)
+            root / ".geode" / "skills",  # 1. Bundled (GEODE package source tree)
+            GLOBAL_SKILLS_DIR,  # 2. User global (~/.geode/skills)
+            cwd / PROJECT_SKILLS_DIR,  # 3. Project local ({cwd}/.geode/skills)
             cwd / "skills",  # 4. Project flat
         ]
-        dirs.extend(self._extra_dirs)  # 4. Extra
+        dirs.extend(self._extra_dirs)  # 5. Extra
         return dirs
 
     @staticmethod

--- a/core/memory/agent_memory.py
+++ b/core/memory/agent_memory.py
@@ -14,11 +14,12 @@ import logging
 import time
 from pathlib import Path
 
+from core.paths import PROJECT_AGENT_MEMORY_DIR
 from core.utils.atomic_io import atomic_write_json
 
 log = logging.getLogger(__name__)
 
-DEFAULT_BASE_DIR = Path(".geode") / "agent-memory"
+DEFAULT_BASE_DIR: Path = PROJECT_AGENT_MEMORY_DIR
 DEFAULT_TTL_HOURS = 24.0
 
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -33,6 +33,9 @@ GLOBAL_ENV_FILE = GEODE_HOME / ".env"
 # User identity & profile
 GLOBAL_IDENTITY_DIR = GEODE_HOME / "identity"
 GLOBAL_USER_PROFILE_DIR = GEODE_HOME / "user_profile"
+# P3 (v0.95.x) — user preferences TOML inside user_profile/.
+# Read by `core/tools/policy.py` to seed ProfilePolicy at boot.
+GLOBAL_USER_PREFERENCES = GLOBAL_USER_PROFILE_DIR / "preferences.toml"
 
 # Non-project-scoped data
 GLOBAL_VAULT_DIR = GEODE_HOME / "vault"
@@ -41,6 +44,11 @@ GLOBAL_RUNS_DIR = GEODE_HOME / "runs"
 GLOBAL_USAGE_DIR = GEODE_HOME / "usage"
 GLOBAL_MCP_DIR = GEODE_HOME / "mcp"
 GLOBAL_SCHEDULER_DIR = GEODE_HOME / "scheduler"
+# P3 (v0.95.x) — user-tier installed skills (priority 2 of 4-tier
+# resolution; see `core/llm/skill_registry.py`). Bundled skills live
+# inside the package source tree, not at `GEODE_HOME` — resolve via
+# `__file__` in skill_registry, do NOT add a constant for them here.
+GLOBAL_SKILLS_DIR = GEODE_HOME / "skills"
 
 # Project-scoped user data root
 GLOBAL_PROJECTS_DIR = GEODE_HOME / "projects"
@@ -92,6 +100,13 @@ PROJECT_MEMORY_INDEX = PROJECT_GEODE_DIR / "MEMORY.md"
 # archived to `.geode/_archive/` by layout migration v1 → v2 (see
 # `core/wiring/layout_migrator.py:_migrate_v1_to_v2`).
 PROJECT_TOOL_OFFLOAD = PROJECT_GEODE_DIR / "tool-offload"
+
+# P3 (v0.95.x) — project-level state files. Surfaced here so writers stop
+# hardcoding `Path(".geode/<file>")` literals (frontier parity — Hermes
+# `hermes_constants.py:14-68` keeps every path on a single SoT module).
+PROJECT_AGENT_MEMORY_DIR = PROJECT_GEODE_DIR / "agent-memory"
+PROJECT_MODEL_POLICY = PROJECT_GEODE_DIR / "model-policy.toml"
+PROJECT_ROUTING_CONFIG = PROJECT_GEODE_DIR / "routing.toml"
 
 
 # ---------------------------------------------------------------------------

--- a/core/tools/policy.py
+++ b/core/tools/policy.py
@@ -267,10 +267,9 @@ def load_profile_policy(profile_dir: str | None = None) -> ProfilePolicy:
     import tomllib
     from pathlib import Path
 
-    if profile_dir:
-        pref_path = Path(profile_dir) / "preferences.toml"
-    else:
-        pref_path = Path.home() / ".geode" / "user_profile" / "preferences.toml"
+    from core.paths import GLOBAL_USER_PREFERENCES
+
+    pref_path = Path(profile_dir) / "preferences.toml" if profile_dir else GLOBAL_USER_PREFERENCES
 
     if not pref_path.exists():
         return ProfilePolicy()


### PR DESCRIPTION
## Summary

- \`core.paths\` 에 5 신규 상수 (\`PROJECT_AGENT_MEMORY_DIR\`, \`PROJECT_MODEL_POLICY\`, \`PROJECT_ROUTING_CONFIG\`, \`GLOBAL_SKILLS_DIR\`, \`GLOBAL_USER_PREFERENCES\`).
- 5 사용처가 hardcoded \`Path(\".geode/...\")\` literal 대신 새 상수 사용.
- \`MODEL_POLICY_PATH\` / \`ROUTING_CONFIG_PATH\` 는 \`core.config\` 에서 re-export 유지 (외부 caller backwards-compat).

## Why

PR #1098 의 storage-hierarchy audit 에서 발견된 sloppiness 의 P3 단계. paths.py 가 SoT 인데 일부 모듈이 literal 박아서 SoT 우회 — Hermes Agent (\`~/workspace/hermes-agent/hermes_constants.py:14-68\`) 의 "every path on a single SoT module" 패턴과 어긋남.

P1 (vestigial 제거, PR #1102) 다음 단계. 후속 — P2 (paths.py constant 있는데 literal 쓰는 11 사이트), P4 (lint guardrail).

## Changes

| File | Change |
|------|--------|
| \`core/paths.py\` | 5 신규 상수 + 위치 분류 comment |
| \`core/memory/agent_memory.py\` | \`DEFAULT_BASE_DIR\` 가 \`PROJECT_AGENT_MEMORY_DIR\` 사용 |
| \`core/config/__init__.py\` | \`MODEL_POLICY_PATH\` / \`ROUTING_CONFIG_PATH\` 가 paths.py 의 새 상수 re-export |
| \`core/tools/policy.py\` | \`_load_profile_policy\` 가 \`GLOBAL_USER_PREFERENCES\` 사용 + 삼항 |
| \`core/llm/skill_registry.py\` | 4-tier skill resolution 의 user/project tier 가 새 상수 사용. bundled tier (\`__file__\` 기반) 는 의도적 literal 유지 + 주석 |
| \`CHANGELOG.md\` | \`Added\` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| paths.py 누락 상수 6개 | 5개 정리. 1개 (\`core/memory/project.py\` parameterized root) 는 helper 함수 필요 → P2 에서 처리 |
| MODEL_POLICY_PATH / ROUTING_CONFIG_PATH 외부 caller | re-export 로 보존 |
| bundled skills 경로 | 의도적 literal 유지 (package source tree) + 주석 |
| S1 11 사이트 | P2 후속 PR |

## Verification

- [x] ruff check / format clean
- [x] mypy clean (359 source files)
- [x] pytest -m \"not live\" — **4749 passed**, 24 skipped (회귀 없음)

## Reference

- PR #1098 (storage-hierarchy doc) 의 audit 결과
- Hermes Agent \`hermes_constants.py:14-68\` (SoT 단일 모듈 패턴)