### PR TITLE
refactor(paths): P2 sloppiness 정리 — 12 사이트 SoT 정렬

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,27 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **P2 — paths.py constant 정렬 (11+1 사이트).** PR #1098 audit 의
+  마지막 SoT 정리 단계. paths.py 가 SoT 인데 hardcoded `Path.home() /
+  ".geode" / ...` 또는 `Path(".geode/...")` literal 사용하던 12 사이트가
+  모두 paths.py constant 사용으로 변경 — `core/runtime.py:93`
+  (`DEFAULT_LOG_DIR`), `core/server/supervised/services.py:267`
+  (`build_hooks log_dir`), `core/llm/usage_store.py:21` (`DEFAULT_USAGE_DIR`),
+  `core/memory/user_profile.py:96` (`FileBasedUserProfile._global_dir`,
+  module-level import 으로 변경 + 호출 test 도 갱신), `core/config/
+  _settings.py:20` (`env_file`), `core/server/ipc_server/poller.py:38`
+  (`DEFAULT_SOCKET_PATH`), `core/runtime_state/transcript.py:37`
+  (`_get_default_transcript_dir`), `core/agent/worker.py:33` (`WORKER_DIR`),
+  `core/orchestration/tool_offload.py:59` (`ToolResultOffloadStore._base_dir`),
+  `core/utils/env_io.py:61` (config writer), `core/tools/policy.py:302`
+  (org policy loader), 그리고 parameterized root 케이스
+  `core/memory/project.py:112-113` 도 `PROJECT_GEODE_DIR` (relative Path)
+  과 `GEODE_HOME` 조합으로 정렬. **행위 변경 없음** — 순수 SoT 정렬.
+  회귀: 4749 tests pass, `test_context_hub.py::test_build_user_context_no_data`
+  의 patch site 도 `GLOBAL_USER_PROFILE_DIR` 로 갱신.
+
 ### Added
 
 - **P3 — `core.paths` 에 누락된 5 상수 추가** (`PROJECT_AGENT_MEMORY_DIR`,

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -21,8 +21,9 @@ import logging
 import sys
 import time
 from dataclasses import asdict, dataclass, field
-from pathlib import Path
 from typing import Any
+
+from core.paths import GLOBAL_WORKERS_DIR
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ log = logging.getLogger(__name__)
 # Data contracts
 # ---------------------------------------------------------------------------
 
-WORKER_DIR = Path.home() / ".geode" / "workers"
+WORKER_DIR = GLOBAL_WORKERS_DIR  # P2 — was `Path.home() / ".geode" / "workers"`
 
 
 @dataclass

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -8,16 +8,17 @@ exposed only for type hints and test fixtures.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from core.paths import GLOBAL_ENV_FILE
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="GEODE_",
-        env_file=(".env", str(Path.home() / ".geode" / ".env")),
+        # P2 (v0.95.x) — was literal `str(Path.home() / ".geode" / ".env")`
+        env_file=(".env", str(GLOBAL_ENV_FILE)),
         extra="ignore",
     )
 

--- a/core/llm/usage_store.py
+++ b/core/llm/usage_store.py
@@ -16,9 +16,11 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
+from core.paths import GLOBAL_USAGE_DIR
+
 log = logging.getLogger(__name__)
 
-DEFAULT_USAGE_DIR = Path.home() / ".geode" / "usage"
+DEFAULT_USAGE_DIR: Path = GLOBAL_USAGE_DIR  # P2 — was literal `Path.home() / ".geode" / "usage"`
 
 
 @dataclass(slots=True)

--- a/core/memory/project.py
+++ b/core/memory/project.py
@@ -108,9 +108,15 @@ class ProjectMemory:
     """
 
     def __init__(self, project_root: Path | None = None) -> None:
+        # P2 (v0.95.x) — `Path` division joins relative `PROJECT_GEODE_DIR` to
+        # the caller-supplied root, replacing the previous literal
+        # `root / ".geode"` while still respecting the test-supplied root.
+        # `GEODE_HOME` is the SoT for the user-home tier.
+        from core.paths import GEODE_HOME, PROJECT_GEODE_DIR
+
         root = project_root or Path(".")
-        self._geode_dir = root / ".geode"
-        self._global_geode_dir = Path.home() / ".geode"
+        self._geode_dir = root / PROJECT_GEODE_DIR
+        self._global_geode_dir = GEODE_HOME
         self._memory_dir = self._geode_dir / "memory"
         self._memory_file = self._memory_dir / "PROJECT.md"
         self._rules_dir = self._geode_dir / "rules"

--- a/core/memory/user_profile.py
+++ b/core/memory/user_profile.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from core.paths import GLOBAL_USER_PROFILE_DIR
 from core.skills._frontmatter import _FRONTMATTER_RE
 from core.utils.atomic_io import atomic_write_text
 
@@ -93,7 +94,10 @@ class FileBasedUserProfile:
         global_dir: Path | None = None,
         project_dir: Path | None = None,
     ) -> None:
-        self._global_dir = global_dir or (Path.home() / ".geode" / "user_profile")
+        # P2 (v0.95.x) — `GLOBAL_USER_PROFILE_DIR` imported at module level so
+        # tests can `patch("core.memory.user_profile.GLOBAL_USER_PROFILE_DIR", ...)`
+        # to redirect to tmp_path without re-importing `core.paths`.
+        self._global_dir = global_dir or GLOBAL_USER_PROFILE_DIR
         self._project_dir = project_dir  # None = no project-local override
 
     @property

--- a/core/orchestration/tool_offload.py
+++ b/core/orchestration/tool_offload.py
@@ -53,10 +53,13 @@ class ToolResultOffloadStore:
         ttl_hours: float = 4.0,
         base_dir: Path | None = None,
     ) -> None:
+        from core.paths import PROJECT_TOOL_OFFLOAD
+
         self.session_id = session_id
         self.threshold = threshold
         self._ttl_s = ttl_hours * 3600
-        self._base_dir = base_dir or Path(".geode/tool-offload")
+        # P2 (v0.95.x) — was literal `Path(".geode/tool-offload")`
+        self._base_dir = base_dir or PROJECT_TOOL_OFFLOAD
         self._session_dir = self._base_dir / session_id
         self._session_dir.mkdir(parents=True, exist_ok=True)
 

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -68,6 +68,7 @@ from core.memory.session_key import build_session_key, build_thread_config
 from core.orchestration.lane_queue import LaneQueue
 from core.orchestration.run_log import RunLog
 from core.orchestration.stuck_detection import StuckDetector
+from core.paths import GLOBAL_RUNS_DIR
 from core.tools.policy import NodeScopePolicy, PolicyChain
 from core.tools.registry import ToolRegistry
 from core.wiring.bootstrap import (  # noqa: F401  — backward compat
@@ -90,7 +91,7 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 DEFAULT_SESSION_TTL = 3600.0  # 1 hour
-DEFAULT_LOG_DIR = Path.home() / ".geode" / "runs"
+DEFAULT_LOG_DIR = GLOBAL_RUNS_DIR  # P2 (v0.95.x) — was literal `Path.home() / ".geode" / "runs"`
 DEFAULT_STUCK_TIMEOUT_S = 7200.0  # 2 hours
 
 

--- a/core/runtime_state/transcript.py
+++ b/core/runtime_state/transcript.py
@@ -30,11 +30,14 @@ def _get_default_transcript_dir() -> Path:
     Project slug is derived from CWD (same pattern as Claude Code).
     Falls back to 'default' if CWD cannot be resolved.
     """
+    from core.paths import GLOBAL_JOURNAL_DIR
+
     try:
         slug = str(Path.cwd()).replace("/", "-")
     except OSError:
         slug = "default"
-    return Path.home() / ".geode" / "journal" / "transcripts" / slug
+    # P2 (v0.95.x) — was literal `Path.home() / ".geode" / "journal" / "transcripts"`
+    return GLOBAL_JOURNAL_DIR / "transcripts" / slug
 
 
 DEFAULT_TRANSCRIPT_DIR = _get_default_transcript_dir()

--- a/core/server/ipc_server/poller.py
+++ b/core/server/ipc_server/poller.py
@@ -35,7 +35,9 @@ log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from core.server.supervised.services import SharedServices
 
-DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
+from core.paths import CLI_SOCKET_PATH  # noqa: E402 — placed after TYPE_CHECKING block
+
+DEFAULT_SOCKET_PATH = CLI_SOCKET_PATH  # P2 — was `Path.home() / ".geode" / "cli.sock"`
 
 # Thread-local terminal capability advertised by the connected thin CLI.
 # v0.84.0 — populated when the daemon receives a ``client_capability``

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -15,7 +15,6 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from enum import StrEnum
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -259,12 +258,13 @@ def build_shared_services(
 
     # Build hooks if not provided
     if hook_system is None:
+        from core.paths import GLOBAL_RUNS_DIR
         from core.wiring.bootstrap import build_hooks
 
         hook_system, _run_log, _stuck, _metrics = build_hooks(
             session_key=f"geode-{uuid.uuid4().hex[:8]}",
             run_id=uuid.uuid4().hex[:12],
-            log_dir=Path.home() / ".geode" / "runs",
+            log_dir=GLOBAL_RUNS_DIR,  # P2 — was `Path.home() / ".geode" / "runs"`
             stuck_timeout_s=getattr(_settings, "stuck_timeout_s", 600.0),
         )
 

--- a/core/tools/policy.py
+++ b/core/tools/policy.py
@@ -298,7 +298,10 @@ def load_org_policy(config_path: str | None = None) -> OrgPolicy:
     import tomllib
     from pathlib import Path
 
-    path = Path(config_path) if config_path else Path(".geode") / "config.toml"
+    from core.paths import PROJECT_CONFIG_TOML
+
+    # P2 (v0.95.x) — was literal `Path(".geode") / "config.toml"`
+    path = Path(config_path) if config_path else PROJECT_CONFIG_TOML
 
     if not path.exists():
         return OrgPolicy()

--- a/core/utils/env_io.py
+++ b/core/utils/env_io.py
@@ -58,7 +58,10 @@ def upsert_config_toml(section: str, key: str, value: str) -> None:
 
     Section headings use ``[section.subsection]`` notation per TOML.
     """
-    config_path = Path(".geode") / "config.toml"
+    from core.paths import PROJECT_CONFIG_TOML
+
+    # P2 (v0.95.x) — was literal `Path(".geode") / "config.toml"`
+    config_path = PROJECT_CONFIG_TOML
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     target_line = f'{key} = "{value}"'

--- a/tests/test_context_hub.py
+++ b/tests/test_context_hub.py
@@ -103,7 +103,13 @@ class TestUserContextSystemPrompt:
             encoding="utf-8",
         )
 
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
+        # P2 (v0.95.x) — patch the module-level constant directly. Patching
+        # `Path.home` no longer works because the constant was captured at
+        # `core.paths` import time.
+        with patch(
+            "core.memory.user_profile.GLOBAL_USER_PROFILE_DIR",
+            profile_dir,
+        ):
             result = _build_user_context()
 
         # G1 (2026-05-12) — context blocks now wrap in XML tags

--- a/tests/test_context_hub.py
+++ b/tests/test_context_hub.py
@@ -114,7 +114,14 @@ class TestUserContextSystemPrompt:
     def test_build_user_context_no_data(self, tmp_path: Path) -> None:
         from core.agent.system_prompt import _build_user_context
 
-        with patch("core.memory.user_profile.Path.home", return_value=tmp_path):
+        # P2 (v0.95.x) — `FileBasedUserProfile` now resolves its global dir
+        # from the module-level `GLOBAL_USER_PROFILE_DIR` constant imported
+        # from `core.paths`. Patch that symbol (not `Path.home`) so the
+        # profile reads from tmp_path instead of the live user-home.
+        with patch(
+            "core.memory.user_profile.GLOBAL_USER_PROFILE_DIR",
+            tmp_path / "user_profile",
+        ):
             result = _build_user_context()
         assert result == ""
 


### PR DESCRIPTION
## Summary

12 사이트의 hardcoded \`Path.home() / \".geode\" / ...\` / \`Path(\".geode/...\")\` literal 을 paths.py constant 사용으로 변경. **행위 변경 없음 — 순수 SoT refactor.** PR #1098 audit 의 P2 단계 (P1 #1102 → P3 #1104 → 이번).

## Why

paths.py 가 SoT 인데 12 모듈이 literal 박아서 우회. Hermes Agent (\`hermes_constants.py:14-68\`) 패턴의 \"every path on a single SoT module\" 과 정확히 어긋남. 향후 path 변경 시 12 군데 동시 수정 부담 + grep audit 어려움.

## Changes — 12 sites

| 파일:line | 기존 | → 변경 |
|-----------|------|--------|
| \`core/runtime.py:93\` (\`DEFAULT_LOG_DIR\`) | \`Path.home() / \".geode\" / \"runs\"\` | \`GLOBAL_RUNS_DIR\` |
| \`core/server/supervised/services.py:267\` | 동일 | \`GLOBAL_RUNS_DIR\` |
| \`core/llm/usage_store.py:21\` (\`DEFAULT_USAGE_DIR\`) | \`Path.home() / \".geode\" / \"usage\"\` | \`GLOBAL_USAGE_DIR\` |
| \`core/memory/user_profile.py:96\` | \`Path.home() / \".geode\" / \"user_profile\"\` | \`GLOBAL_USER_PROFILE_DIR\` (module-level import — test patchability) |
| \`core/config/_settings.py:20\` | \`Path.home() / \".geode\" / \".env\"\` | \`GLOBAL_ENV_FILE\` |
| \`core/server/ipc_server/poller.py:38\` (\`DEFAULT_SOCKET_PATH\`) | \`Path.home() / \".geode\" / \"cli.sock\"\` | \`CLI_SOCKET_PATH\` (TYPE_CHECKING 후 noqa E402) |
| \`core/runtime_state/transcript.py:37\` | \`Path.home() / \".geode\" / \"journal\" / \"transcripts\" / slug\` | \`GLOBAL_JOURNAL_DIR / \"transcripts\" / slug\` |
| \`core/agent/worker.py:33\` (\`WORKER_DIR\`) | \`Path.home() / \".geode\" / \"workers\"\` | \`GLOBAL_WORKERS_DIR\` |
| \`core/orchestration/tool_offload.py:59\` | \`Path(\".geode/tool-offload\")\` | \`PROJECT_TOOL_OFFLOAD\` |
| \`core/utils/env_io.py:61\` | \`Path(\".geode\") / \"config.toml\"\` | \`PROJECT_CONFIG_TOML\` |
| \`core/tools/policy.py:302\` | 동일 | \`PROJECT_CONFIG_TOML\` |
| \`core/memory/project.py:112-113\` | \`root / \".geode\"\` + \`Path.home() / \".geode\"\` | \`root / PROJECT_GEODE_DIR\` + \`GEODE_HOME\` (parameterized root 유지) |

## Test 갱신

\`tests/test_context_hub.py::test_build_user_context_no_data\` 가 \`patch(\"core.memory.user_profile.Path.home\", ...)\` 사용 — module-level constant 캡쳐 이후 무의미. 새 패턴에 맞춰 \`patch(\"core.memory.user_profile.GLOBAL_USER_PROFILE_DIR\", tmp_path / \"user_profile\")\` 으로 변경. 의미적으로 등가.

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| S1 11 사이트 | 11/11 정렬 | |
| project.py parameterized root | 정렬 | \`root / PROJECT_GEODE_DIR\` (Path 합성) |
| S4 의도적 \`_LEGACY_*\` marker | 유지 | migration detection 용 |
| 행위 변경 | 없음 | literal 과 constant 가 같은 값 |

## Verification

- [x] ruff check / format clean (E402 1건 — TYPE_CHECKING 다음 import 라 noqa, 의도적)
- [x] mypy clean (359 source files)
- [x] pytest -m \"not live\" — **4749 passed**, 24 skipped (회귀 없음)

후속 — P4 (lint guardrail, optional) 또는 vault TTL / runs bucket 같은 substantial 마이그레이션.

## Reference

- PR #1098 (storage-hierarchy doc) 의 audit S1 카테고리
- Hermes Agent \`hermes_constants.py:14-68\` (single SoT 모듈 패턴)