### PR TITLE
chore(gitignore): 누락 패턴 4개 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,20 @@ docs/progress-report.html
 # CI trigger
 /.audit/
 
+# Playwright MCP browser captures (console logs + screenshots from
+# transient debugging sessions). Never part of the tracked tree.
+.playwright-mcp/
+
+# Ad-hoc artifact dumps from local audit/benchmark runs.
+artifacts/
+
+# Scheduler lock file written by `geode serve` cron worker.
+.claude/scheduled_tasks.lock
+
+# Layout migration v1→v2 archive — vestigial dir archival output.
+# Reversible (user can `mv` back or `rm -rf`). Never tracked.
+.geode/_archive/
+
 # Next.js site (site/) build + install artifacts. The site/ tree itself is
 # tracked; only generated contents are excluded.
 site/node_modules/


### PR DESCRIPTION
## Summary

\`.gitignore\` 에 4개 패턴 추가 — \`.playwright-mcp/\`, \`artifacts/\`, \`.claude/scheduled_tasks.lock\`, \`.geode/_archive/\`.

## Why

세션 시작 시점부터 누적된 누락 패턴 + 직전 layout migration (PR #1102 의 v1→v2) 의 부산물 (\`.geode/_archive/\`) 정리.

## Changes

| File | Change |
|------|--------|
| \`.gitignore\` | 4 패턴 추가 with inline comment |

## Verification

- [x] docs-only (`.gitignore` 변경)
- [x] CI lint/test 무관 (gitignore 자체는 tooling 영향 없음)

## Reference

- 4번째 패턴 \`.geode/_archive/\` 의 출처: PR #1102 의 \`_migrate_v1_to_v2()\` 가 vestigial 디렉터리 (\`.geode/{embedding-cache,vectors}/\`) 를 \`.geode/_archive/<name>-<UTC>/\` 로 옮김. 실제 사용자 머신에 archive 발생 확인됨.