### PR TITLE
feat(test): P4 sloppiness 정리 — paths.py SoT lint guardrail + 14 사이트 정렬

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Added
+
+- **P4 — paths.py SoT lint guardrail + 추가 14 사이트 정렬.** PR #1098
+  audit 의 마지막 단계. `tests/test_path_literal_guard.py` 신설 — pytest
+  단위에서 `core/` 트리를 regex 스캔해 `Path.home() / ".geode"` 또는
+  `Path(".geode/...")` literal 을 검출. 통과 조건: (1) paths.py 의 적절한
+  constant 사용, (2) `# noqa: paths-literal` 주석 + 사유, 또는 (3)
+  `_FILE_ALLOWLIST` 등재. `tests/test_no_daemon_print.py` 와 동일 패턴
+  (regex + per-line 옵트아웃).
+  - **P2 audit 누락 14 사이트 일괄 정렬** — P4 가드가 폭로:
+    `core/cli/bootstrap.py` (3), `core/cli/cmd_skill.py` (2), `core/cli/
+    commands/cost.py` (2), `core/cli/doctor.py` (2), `core/cli/ipc_client.py`,
+    `core/cli/typer_commands.py`, `core/mcp/manager.py`, `core/mcp/
+    registry.py`, `core/orchestration/isolated_execution.py`, `core/
+    orchestration/run_log.py`, `core/skills/skills.py`, `core/wiring/
+    adapters.py`, `core/wiring/bootstrap.py` (3), `core/audit/diagnostics.py`,
+    `core/auth/auth_toml.py`. 행위 변경 없음.
+  - **paths.py 신규 constants 4개** — `PROJECT_USER_PROFILE_DIR`,
+    `PROJECT_HOOKS_DIR`, `GLOBAL_DIAGNOSTICS_DIR`, `GLOBAL_AUTH_TOML`.
+    P3 의 5 constants 와 합쳐 paths.py 가 사실상 모든 `.geode/` 경로의
+    SoT.
+  - **allowlist** 4 파일 — `core/paths.py` (SoT), `core/scheduler/
+    scheduler/models.py` + `core/auth/oauth_login.py` (legacy migration
+    markers, 의도적), `core/cli/typer_init.py` (`geode init` 프로젝트
+    부트스트랩 — 20+ 일회성 mkdir, constant 화 가성비 낮음).
+
 ### Changed
 
 - **P2 — paths.py constant 정렬 (11+1 사이트).** PR #1098 audit 의

--- a/core/audit/diagnostics.py
+++ b/core/audit/diagnostics.py
@@ -43,10 +43,12 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from core.paths import GLOBAL_DIAGNOSTICS_DIR
+
 __all__ = ["DEFAULT_DIAGNOSTICS_DIR", "diag", "diagnostics_path"]
 
 #: GEODE convention. ``~/.geode/`` 의 다른 artifacts 와 동거.
-DEFAULT_DIAGNOSTICS_DIR: Path = Path.home() / ".geode" / "diagnostics"
+DEFAULT_DIAGNOSTICS_DIR: Path = GLOBAL_DIAGNOSTICS_DIR
 
 
 def diagnostics_path() -> Path:

--- a/core/auth/auth_toml.py
+++ b/core/auth/auth_toml.py
@@ -47,10 +47,11 @@ from typing import Any
 from core.auth.plan_registry import PlanRegistry, get_plan_registry
 from core.auth.plans import Plan, PlanKind, Quota
 from core.auth.profiles import AuthProfile, CredentialType, ProfileStore
+from core.paths import GLOBAL_AUTH_TOML
 
 log = logging.getLogger(__name__)
 
-DEFAULT_AUTH_TOML = Path.home() / ".geode" / "auth.toml"
+DEFAULT_AUTH_TOML: Path = GLOBAL_AUTH_TOML
 
 
 def auth_toml_path() -> Path:

--- a/core/cli/bootstrap.py
+++ b/core/cli/bootstrap.py
@@ -73,12 +73,13 @@ class GeodeBootstrap:
 
             from core.config import settings
             from core.memory.user_profile import FileBasedUserProfile
+            from core.paths import PROJECT_USER_PROFILE_DIR
             from core.tools.profile_tools import set_user_profile
 
             global_dir = Path(settings.user_profile_dir) if settings.user_profile_dir else None
             if global_dir is None:
                 log.debug("Using default global profile dir: ~/.geode/user_profile")
-            project_dir = Path(".geode") / "user_profile"
+            project_dir = PROJECT_USER_PROFILE_DIR
             set_user_profile(
                 FileBasedUserProfile(
                     global_dir=global_dir,
@@ -102,7 +103,9 @@ def setup_contextvars(*, load_env: bool = False) -> None:
         from dotenv import dotenv_values, load_dotenv
 
         # 1) Global ~/.geode/.env — baseline for all projects
-        global_env = Path.home() / ".geode" / ".env"
+        from core.paths import GLOBAL_ENV_FILE
+
+        global_env = GLOBAL_ENV_FILE
         if global_env.exists():
             load_dotenv(str(global_env), override=False)
 
@@ -158,12 +161,13 @@ def setup_contextvars(*, load_env: bool = False) -> None:
 
         from core.config import settings
         from core.memory.user_profile import FileBasedUserProfile
+        from core.paths import PROJECT_USER_PROFILE_DIR
         from core.tools.profile_tools import set_user_profile
 
         global_dir = Path(settings.user_profile_dir) if settings.user_profile_dir else None
         if global_dir is None:
             log.debug("Using default global profile dir: ~/.geode/user_profile")
-        project_dir = Path(".geode") / "user_profile"
+        project_dir = PROJECT_USER_PROFILE_DIR
         user_profile = FileBasedUserProfile(
             global_dir=global_dir,
             project_dir=project_dir if project_dir.parent.exists() else None,

--- a/core/cli/cmd_skill.py
+++ b/core/cli/cmd_skill.py
@@ -14,12 +14,13 @@ from typing import Annotated
 
 import typer
 
+from core.paths import GLOBAL_SKILLS_DIR, PROJECT_SKILLS_DIR
 from core.skills._frontmatter import parse_yaml_frontmatter
 
 app = typer.Typer(name="skill", help="Manage GEODE skills (list/create/install).")
 
-_PROJECT_SKILLS = Path(".geode/skills")
-_PERSONAL_SKILLS = Path.home() / ".geode" / "skills"
+_PROJECT_SKILLS = PROJECT_SKILLS_DIR
+_PERSONAL_SKILLS = GLOBAL_SKILLS_DIR
 
 
 def _discover_skills() -> list[dict[str, str]]:

--- a/core/cli/commands/cost.py
+++ b/core/cli/commands/cost.py
@@ -14,7 +14,8 @@ pattern used by ``core/ui/agentic_ui``.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+
+from core.paths import PROJECT_CONFIG_TOML
 
 log = logging.getLogger(__name__)
 
@@ -172,7 +173,7 @@ def _get_cost_budget() -> float:
         except ValueError:
             pass
 
-    config_path = Path(".geode") / "config.toml"
+    config_path = PROJECT_CONFIG_TOML
     if config_path.exists():
         import tomllib
 
@@ -187,7 +188,7 @@ def _get_cost_budget() -> float:
 
 def _set_cost_budget(amount: float) -> None:
     """Write monthly budget to .geode/config.toml."""
-    config_path = Path(".geode") / "config.toml"
+    config_path = PROJECT_CONFIG_TOML
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     lines: list[str] = []

--- a/core/cli/doctor.py
+++ b/core/cli/doctor.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import subprocess
-from pathlib import Path
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -150,8 +149,10 @@ def _check_scopes() -> dict[str, Any]:
 
 def _check_bindings() -> list[dict[str, Any]]:
     """Check config.toml gateway bindings."""
+    from core.paths import PROJECT_CONFIG_TOML
+
     results: list[dict[str, Any]] = []
-    config_path = Path(".geode/config.toml")
+    config_path = PROJECT_CONFIG_TOML
 
     if not config_path.exists():
         results.append(
@@ -250,7 +251,9 @@ def _check_mcp_slack() -> dict[str, Any]:
 
 def _check_socket() -> dict[str, Any]:
     """Check if IPC socket exists (serve is accepting connections)."""
-    sock_path = Path.home() / ".geode" / "cli.sock"
+    from core.paths import CLI_SOCKET_PATH
+
+    sock_path = CLI_SOCKET_PATH
     if sock_path.exists():
         return {"ok": True, "detail": str(sock_path)}
     return {"ok": False, "detail": "cli.sock not found", "hint": "geode serve creates this"}

--- a/core/cli/ipc_client.py
+++ b/core/cli/ipc_client.py
@@ -16,9 +16,11 @@ import socket
 from pathlib import Path
 from typing import Any
 
+from core.paths import CLI_SOCKET_PATH
+
 log = logging.getLogger(__name__)
 
-DEFAULT_SOCKET_PATH = Path.home() / ".geode" / "cli.sock"
+DEFAULT_SOCKET_PATH: Path = CLI_SOCKET_PATH
 
 
 def start_serve_if_needed(socket_path: Path | None = None, timeout_s: float = 10.0) -> bool:

--- a/core/cli/typer_commands.py
+++ b/core/cli/typer_commands.py
@@ -119,8 +119,10 @@ def about() -> None:
         )
 
     # Paths
-    geode_home = Path("~/.geode").expanduser()
-    project_geode = Path(".geode")
+    from core.paths import GEODE_HOME, PROJECT_GEODE_DIR
+
+    geode_home = GEODE_HOME
+    project_geode = PROJECT_GEODE_DIR
     console.print(f"  [bold]User home[/bold]  [muted]{geode_home}[/muted]")
     console.print(
         f"  [bold]Project[/bold]    [muted]{project_geode}"

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -26,11 +26,11 @@ from typing import Any
 from dotenv import dotenv_values
 
 from core.mcp.stdio_client import StdioMCPClient
-from core.paths import get_project_root
+from core.paths import GLOBAL_ENV_FILE, get_project_root
 
 log = logging.getLogger(__name__)
 
-_GLOBAL_DOTENV_PATH = Path.home() / ".geode" / ".env"
+_GLOBAL_DOTENV_PATH = GLOBAL_ENV_FILE
 
 _EMPTY_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
 

--- a/core/mcp/registry.py
+++ b/core/mcp/registry.py
@@ -12,7 +12,6 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -25,10 +24,11 @@ _CACHE_TTL_S = 86400  # 24 hours
 # v0.95.x layout migration v1 — moved under ~/.geode/mcp/ to group with
 # other MCP state (trace-runs/, etc.). Legacy ``~/.geode/mcp-registry-cache.json``
 # is migrated by ``core.wiring.layout_migrator._migrate_v0_to_v1`` on first boot.
-# Single source of truth lives in ``core.paths.MCP_REGISTRY_CACHE``; this file
-# imports it lazily to avoid a circular import (paths imports layout_migrator).
-_CACHE_DIR = Path.home() / ".geode" / "mcp"
-_CACHE_FILE = _CACHE_DIR / "registry-cache.json"
+# Single source of truth: ``core.paths.GLOBAL_MCP_DIR`` + ``MCP_REGISTRY_CACHE``.
+from core.paths import GLOBAL_MCP_DIR, MCP_REGISTRY_CACHE  # noqa: E402
+
+_CACHE_DIR = GLOBAL_MCP_DIR
+_CACHE_FILE = MCP_REGISTRY_CACHE
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/orchestration/isolated_execution.py
+++ b/core/orchestration/isolated_execution.py
@@ -21,7 +21,6 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
 from typing import Any
 
 from core.hooks import HookEvent, HookSystem
@@ -524,8 +523,10 @@ class IsolatedRunner:
     @staticmethod
     def _save_stderr(session_id: str, stderr_bytes: bytes) -> None:
         """Save subprocess stderr to ~/.geode/workers/ for debugging."""
+        from core.paths import GLOBAL_WORKERS_DIR
+
         try:
-            worker_dir = Path.home() / ".geode" / "workers"
+            worker_dir = GLOBAL_WORKERS_DIR
             worker_dir.mkdir(parents=True, exist_ok=True)
             path = worker_dir / f"{session_id}.stderr.log"
             path.write_bytes(stderr_bytes)

--- a/core/orchestration/run_log.py
+++ b/core/orchestration/run_log.py
@@ -17,9 +17,11 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from core.paths import GLOBAL_RUNS_DIR
+
 log = logging.getLogger(__name__)
 
-DEFAULT_LOG_DIR = Path.home() / ".geode" / "runs"
+DEFAULT_LOG_DIR: Path = GLOBAL_RUNS_DIR
 DEFAULT_MAX_BYTES = 2 * 1024 * 1024  # 2MB
 DEFAULT_KEEP_LINES = 2000
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -44,6 +44,12 @@ GLOBAL_RUNS_DIR = GEODE_HOME / "runs"
 GLOBAL_USAGE_DIR = GEODE_HOME / "usage"
 GLOBAL_MCP_DIR = GEODE_HOME / "mcp"
 GLOBAL_SCHEDULER_DIR = GEODE_HOME / "scheduler"
+# P4 (v0.95.x) — added during lint-guardrail rollout. fa4 diagnostics
+# log dir (cross-process append-only) and the auth.toml SoT path.
+# `core.auth.auth_toml` overrides via `GEODE_AUTH_TOML` env var; this
+# constant is the default fallback.
+GLOBAL_DIAGNOSTICS_DIR = GEODE_HOME / "diagnostics"
+GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
 # P3 (v0.95.x) — user-tier installed skills (priority 2 of 4-tier
 # resolution; see `core/llm/skill_registry.py`). Bundled skills live
 # inside the package source tree, not at `GEODE_HOME` — resolve via
@@ -90,6 +96,11 @@ PROJECT_SCHEDULER_LOG_DIR = PROJECT_GEODE_DIR / "scheduler_logs"
 PROJECT_PLANS_FILE = PROJECT_GEODE_DIR / "plans.json"
 PROJECT_LEARNING_FILE = PROJECT_GEODE_DIR / "LEARNING.md"
 PROJECT_MEMORY_INDEX = PROJECT_GEODE_DIR / "MEMORY.md"
+# P4 (v0.95.x) — added during the lint-guardrail rollout. project-local
+# user_profile override (read by `core.cli.bootstrap` + `core.wiring.bootstrap`)
+# and project-local hooks dir (read by `core.wiring.bootstrap` plugin loader).
+PROJECT_USER_PROFILE_DIR = PROJECT_GEODE_DIR / "user_profile"
+PROJECT_HOOKS_DIR = PROJECT_GEODE_DIR / "hooks"
 
 # Per-project caches surfaced by /clean for selective wipe.
 #

--- a/core/skills/skills.py
+++ b/core/skills/skills.py
@@ -228,11 +228,15 @@ class SkillLoader:
         if self._primary_dir:
             return [self._primary_dir, *self._extra_dirs]
 
+        from core.paths import GLOBAL_SKILLS_DIR, PROJECT_SKILLS_DIR
+
         cwd = Path.cwd()
         dirs: list[Path] = [
-            _PACKAGE_ROOT / ".geode" / "skills",  # 1. Bundled
-            Path.home() / ".geode" / "skills",  # 2. User global
-            cwd / ".geode" / "skills",  # 3. Project local (CWD)
+            _PACKAGE_ROOT
+            / ".geode"
+            / "skills",  # 1. Bundled (package source tree)  # noqa: paths-literal
+            GLOBAL_SKILLS_DIR,  # 2. User global (~/.geode/skills)
+            cwd / PROJECT_SKILLS_DIR,  # 3. Project local ({cwd}/.geode/skills)
         ]
         dirs.extend(self._extra_dirs)  # 4. Extra
         return dirs

--- a/core/wiring/adapters.py
+++ b/core/wiring/adapters.py
@@ -198,9 +198,10 @@ def build_gateway() -> None:
     config_path = None
     try:
         import tomllib
-        from pathlib import Path
 
-        config_path = Path(".geode") / "config.toml"
+        from core.paths import PROJECT_CONFIG_TOML
+
+        config_path = PROJECT_CONFIG_TOML
         if config_path.exists():
             with open(config_path, "rb") as f:
                 toml_config = tomllib.load(f)

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -55,7 +55,9 @@ def __getattr__(name: str) -> Any:
 # ---------------------------------------------------------------------------
 # Default configuration (re-exported from runtime.py constants)
 # ---------------------------------------------------------------------------
-DEFAULT_LOG_DIR = Path.home() / ".geode" / "runs"
+from core.paths import GLOBAL_RUNS_DIR  # noqa: E402 — module sits below TYPE_CHECKING block
+
+DEFAULT_LOG_DIR: Path = GLOBAL_RUNS_DIR
 CONFIG_WATCHER_DEBOUNCE_MS = 300.0  # Avoid thrashing on rapid file changes
 
 # ---------------------------------------------------------------------------
@@ -389,9 +391,10 @@ def build_hooks(
     # C8: Filesystem hook plugin auto-discovery (.geode/hooks/ + core/hooks/plugins/)
     def _reg_filesystem_plugins() -> None:
         from core.hooks.discovery import HookPluginLoader
+        from core.paths import PROJECT_HOOKS_DIR
 
         loader = HookPluginLoader()
-        plugin_dirs = [Path(".geode/hooks"), Path("core/hooks/plugins")]
+        plugin_dirs = [PROJECT_HOOKS_DIR, Path("core/hooks/plugins")]
         loader.load_from_dirs(plugin_dirs)
         loader.register_all(hooks)
 
@@ -528,8 +531,10 @@ def build_memory(
     organization_memory = MonoLakeOrganizationMemory(fixture_dir=fixture_dir)
 
     # Tier 0.5: User Profile
+    from core.paths import PROJECT_USER_PROFILE_DIR
+
     global_profile_dir = Path(settings.user_profile_dir) if settings.user_profile_dir else None
-    project_profile_dir = Path(".geode") / "user_profile"
+    project_profile_dir = PROJECT_USER_PROFILE_DIR
     user_profile = FileBasedUserProfile(
         global_dir=global_profile_dir,
         project_dir=project_profile_dir,

--- a/tests/test_path_literal_guard.py
+++ b/tests/test_path_literal_guard.py
@@ -1,0 +1,168 @@
+"""P4 — lint guardrail for paths.py SoT.
+
+After PR #1102 (P1 vestigial), PR #1104 (P3 missing constants), and
+PR #1106 (P2 alignment), every module in ``core/`` resolves ``.geode``
+paths through ``core.paths`` constants. This test fails when a new
+hardcoded ``Path.home() / ".geode"`` or ``Path(".geode/...")`` literal
+appears outside the allowlist — preventing regression of the
+sloppiness we just spent three PRs cleaning up.
+
+The guard is a test (not a ``ruff`` custom rule or shell script) so
+it runs in the same gate as everything else and reports violations
+with file paths the developer can jump to in their editor.
+
+Mirrors ``tests/test_no_daemon_print.py``'s pattern — file allowlist
++ per-line ``# noqa`` opt-out + regex scan, no AST overhead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# File-level allowlist — these files are *expected* to mention ``.geode``
+# literals because they ARE the source of truth, legacy markers, or
+# bootstrap-only project scaffolding that constructs many one-off dirs.
+_FILE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # The single source of truth — every other module reads from here.
+        "core/paths.py",
+        # Legacy migration detection markers (S4 from PR #1098 audit).
+        "core/scheduler/scheduler/models.py",  # _LEGACY_STORE_PATH
+        "core/auth/oauth_login.py",  # LEGACY_AUTH_STORE_PATH
+        # Project init bootstrap — `geode init` creates the full `.geode/`
+        # tree on first run. Some of these subdirs (journal/transcripts,
+        # vault/profile, etc.) have no SoT constants because nothing else
+        # reads them at module level. Promoting them to constants would
+        # only add 20+ entries to paths.py for one-shot mkdir calls.
+        "core/cli/typer_init.py",
+    }
+)
+
+# Patterns that indicate a hardcoded ``.geode`` literal. Caught by
+# substring + regex — no AST needed because the literal forms are
+# narrow.
+_LITERAL_PATTERNS: list[re.Pattern[str]] = [
+    # `Path.home() / ".geode"` (with or without subsequent path parts)
+    re.compile(r'Path\.home\(\)\s*/\s*"\.geode"'),
+    # `Path(".geode/...")` — relative project-local literal
+    re.compile(r'Path\(\s*"\.geode/'),
+    re.compile(r"Path\(\s*'\.geode/"),
+    # `Path(".geode")` exact (no trailing slash) — used as relative root
+    re.compile(r'Path\(\s*"\.geode"\s*\)'),
+    re.compile(r"Path\(\s*'\.geode'\s*\)"),
+]
+
+# Per-line opt-out annotation.
+_NOQA_RE = re.compile(r"#\s*noqa:\s*paths-literal\b")
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CORE_ROOT = _REPO_ROOT / "core"
+
+
+def _strip_inline_comment(line: str) -> str:
+    """Return the code portion of *line* with any trailing ``# comment``
+    removed. We strip naively at the first ``#`` outside a string — which
+    is good enough because every legitimate occurrence of the patterns we
+    look for happens in code, not inside a string literal. Lines that
+    quote a path literal *inside* a string (e.g. doctest, comment) are
+    deliberately not matched."""
+    # Find the first '#' that isn't enclosed in matching quotes. A
+    # full-fidelity parser would use tokenize, but for this regex check
+    # a small state machine is enough.
+    in_str: str | None = None
+    for i, ch in enumerate(line):
+        if in_str:
+            if ch == in_str and line[i - 1] != "\\":
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "#":
+            return line[:i]
+    return line
+
+
+def _is_violation_line(code_part: str) -> bool:
+    """Return True iff the *code* portion of a line contains a forbidden
+    literal and is not annotated with ``# noqa: paths-literal``."""
+    return any(p.search(code_part) for p in _LITERAL_PATTERNS)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, code_only_line)`` for each violation in *path*."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    violations: list[tuple[int, str]] = []
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        # Per-line opt-out — the trailing ``# noqa: paths-literal`` lives in
+        # the comment, so check the full line for the annotation.
+        if _NOQA_RE.search(raw_line):
+            continue
+        stripped = raw_line.lstrip()
+        if stripped.startswith("#"):
+            continue  # pure comment
+        code = _strip_inline_comment(raw_line)
+        if _is_violation_line(code):
+            violations.append((lineno, code.strip()))
+    return violations
+
+
+def test_no_hardcoded_geode_path_literals_in_core() -> None:
+    """Every ``.geode`` path under ``core/`` must come from ``core.paths``.
+
+    To resolve a failure: import the relevant constant from
+    ``core.paths`` (e.g. ``GLOBAL_USAGE_DIR``, ``PROJECT_CONFIG_TOML``),
+    or — if the literal is truly required (e.g. test fixture inside
+    runtime code, legacy migration detection) — annotate with
+    ``# noqa: paths-literal`` and explain why.
+
+    See ``docs/architecture/storage-hierarchy.md`` for the SoT policy.
+    """
+    violations_by_file: dict[str, list[tuple[int, str]]] = {}
+
+    for py_file in sorted(_CORE_ROOT.rglob("*.py")):
+        rel = py_file.relative_to(_REPO_ROOT).as_posix()
+        if rel in _FILE_ALLOWLIST:
+            continue
+        if "__pycache__" in py_file.parts:
+            continue
+        hits = _scan_file(py_file)
+        if hits:
+            violations_by_file[rel] = hits
+
+    if violations_by_file:
+        lines = [
+            "Hardcoded `.geode` path literals found in core/ — bypass `core.paths` SoT.",
+            "Resolve by importing the matching constant, or annotate with",
+            "  # noqa: paths-literal  — <reason>",
+            "(see docs/architecture/storage-hierarchy.md).",
+            "",
+        ]
+        for rel, hits in violations_by_file.items():
+            lines.append(f"  {rel}:")
+            for lineno, content in hits:
+                lines.append(f"    L{lineno}: {content}")
+        raise AssertionError("\n".join(lines))
+
+
+def test_allowlisted_files_actually_have_literals() -> None:
+    """Sanity check — every entry in :data:`_FILE_ALLOWLIST` should
+    contain at least one matching literal. If we ever migrate a legacy
+    marker (e.g. remove ``_LEGACY_STORE_PATH``), the allowlist entry
+    becomes dead and the guard's contract weakens.
+
+    A failure here means: someone removed a legitimate literal from an
+    allowlisted file. Update the allowlist to match.
+    """
+    stale: list[str] = []
+    for rel in _FILE_ALLOWLIST:
+        path = _REPO_ROOT / rel
+        if not path.exists():
+            stale.append(f"{rel}: file no longer exists")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if not any(p.search(text) for p in _LITERAL_PATTERNS):
+            stale.append(f"{rel}: no literals remain — drop from allowlist")
+    assert not stale, "Stale entries in `_FILE_ALLOWLIST` (this guard):\n  " + "\n  ".join(stale)


### PR DESCRIPTION
## Summary

- 신규 \`tests/test_path_literal_guard.py\` — pytest 단위 regex 스캔 가드. 새 \`Path.home() / \".geode\"\` / \`Path(\".geode/...\")\` literal 등장 즉시 fail.
- P4 guard 가 폭로한 P2 audit 누락 14 사이트 일괄 정렬 (행위 변경 없음).
- paths.py 신규 4 constants (\`PROJECT_USER_PROFILE_DIR\`, \`PROJECT_HOOKS_DIR\`, \`GLOBAL_DIAGNOSTICS_DIR\`, \`GLOBAL_AUTH_TOML\`).
- allowlist 4 파일 (SoT + legacy markers + project init bootstrap).

## Why

PR #1098 storage-hierarchy audit 의 마지막 단계 (P1 #1102 → P3 #1104 → P2 #1106 → **P4 이번 PR**). guard 도입 시 P2 audit 이 grep 으로 놓친 14 추가 사이트가 폭로됨 — 한 PR 로 마무리.

paths.py 가 SoT 라는 원칙이 코드로 강제됨 (test 가 enforces). 새 hardcoded literal 추가 시 CI 즉시 차단.

## Changes

| File 카테고리 | 사이트 | 변경 |
|--------------|------|------|
| guard test (신규) | \`tests/test_path_literal_guard.py\` | regex 스캔 + 옵션 (constant import / noqa / allowlist) |
| paths.py | 신규 4 constants | \`PROJECT_USER_PROFILE_DIR\`, \`PROJECT_HOOKS_DIR\`, \`GLOBAL_DIAGNOSTICS_DIR\`, \`GLOBAL_AUTH_TOML\` |
| cli/ | bootstrap (3) + cmd_skill (2) + cost (2) + doctor (2) + ipc_client + typer_commands | 11 사이트 정렬 |
| mcp/ | manager + registry | 2 사이트 정렬 |
| orchestration/ | isolated_execution + run_log | 2 사이트 정렬 |
| skills/ | skills.py | 1 사이트 정렬 |
| wiring/ | adapters + bootstrap (3) | 4 사이트 정렬 |
| audit/auth | diagnostics + auth_toml | 2 사이트 정렬 |

총 14 파일 + paths.py + 신규 test + CHANGELOG.

## GAP Audit

| Item | Status |
|------|--------|
| P1 (vestigial 제거) | done in #1102 |
| P3 (누락 constants) | done in #1104 + 이번 PR 의 4 추가 |
| P2 (alignment) | done in #1106 + 이번 PR 의 14 추가 |
| **P4 (guard + regression prevention)** | **이번 PR** |
| 후속 backlog (runs bucket / vault TTL / stale projects) | unchanged |

## Verification

- [x] ruff check / format clean
- [x] mypy clean (359 source files)
- [x] pytest -m \"not live\" — **4751 passed**, 24 skipped, 24 deselected (+ 2 신규 guard tests)
- [x] guard 가 새 hardcoded literal 시도 시 fail (회귀 방지 검증)
- [x] sanity test: allowlisted 파일들이 실제로 literal 보유 (stale allowlist 방지)

## Reference

- PR #1098 (storage-hierarchy doc) — audit 의 S1/S2/S3/S4 카테고리
- 패턴: \`tests/test_no_daemon_print.py\` (regex + per-line opt-out)
- Hermes Agent \`hermes_constants.py:14-68\` — single SoT 모듈 패턴