### PR TITLE
fix(banner): harness 표기를 GEODE 단독으로 축소

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,31 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **시작 배너 `harness:` 라벨을 GEODE 단독으로 축소.** 기존에는
+  `KNOWN_HARNESSES` 가 `.claude/`, `.cursor/`, `.codex/`, `.copilot/`,
+  `.openclaw/` 등 10 개 AI 도구 설정 디렉터리를 감지해 `harness: Claude
+  Code, GEODE` 처럼 함께 출력했는데, 이게 "GEODE 가 Claude Code 위에서
+  돌아간다" 는 잘못된 브랜드 신호로 읽혔습니다. GEODE 는 자체 런타임으로
+  LLM API 콜 + agentic loop + tool 실행 + tiered context memory + plugin
+  레지스트리를 직접 수행합니다. `.claude/` 등의 디렉터리는 **개발자가
+  GEODE 를 제작·정비할 때 사용하는 build-time 도구 설정**이지 GEODE 의
+  runtime dependency 가 아닙니다. `KNOWN_HARNESSES` 를 `{".geode":
+  "GEODE"}` 단일 항목으로 축소했고, 동일 데이터를 LLM context 로 주입하는
+  `core/memory/context.py:_inject_project_env` 도 같은 신호만 보게 됩니다.
+- **Startup banner `harness:` label reduced to GEODE only.**
+  `KNOWN_HARNESSES` previously detected 10 AI tool config directories
+  (`.claude/`, `.cursor/`, `.codex/`, `.copilot/`, `.openclaw/`, ...) and
+  rendered e.g. `harness: Claude Code, GEODE` at startup. That read as
+  "GEODE runs on top of Claude Code", which is wrong: GEODE drives its
+  own LLM API calls, agentic loop, tool execution, tiered context
+  memory, and plugin registry. `.claude/` etc. are **build-time** tooling
+  used by maintainers when developing GEODE, not runtime dependencies.
+  `KNOWN_HARNESSES` is now `{".geode": "GEODE"}`, and the parallel
+  injection into `core/memory/context.py:_inject_project_env` therefore
+  exposes the same self-only signal to the LLM context.
+
 ### Added
 
 - **P4 — paths.py SoT lint guardrail + 추가 14 사이트 정렬.** PR #1098

--- a/core/utils/project_detect.py
+++ b/core/utils/project_detect.py
@@ -1,14 +1,19 @@
 """Project type detection — harness-for-real init.sh pattern in Python.
 
 Auto-detects project type, package manager, build/test/lint commands,
-and AI agent harness directories by inspecting the project root.
+and the GEODE harness directory by inspecting the project root.
 
 Supported project types:
   node (npm/yarn/pnpm/bun), python-uv, python-pip, rust, go, java-maven, java-gradle
 
-Detected harness directories:
-  .claude/, .cursor/, .windsurf/, .copilot/, .openclaw/, .codeium/, .aider/,
-  .codex/, .geode/, .devin/
+Harness detection is intentionally GEODE-only. GEODE runs its own LLM
+API calls + agentic loop + tool execution + tiered context memory +
+plugin registry — it is not hosted on top of another agent harness.
+Listing co-existing AI agent config directories (`.claude/`, `.cursor/`,
+`.codex/`, ...) in the startup `harness:` banner historically read as
+"GEODE runs on top of <X>", which is wrong: those directories reflect
+**build-time** tooling used by maintainers, not GEODE's runtime
+dependencies. So only `.geode/` is recognised here.
 """
 
 from __future__ import annotations
@@ -17,18 +22,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Known AI agent harness directories (name → display label)
 KNOWN_HARNESSES: dict[str, str] = {
-    ".claude": "Claude Code",
-    ".cursor": "Cursor",
-    ".windsurf": "Windsurf",
-    ".copilot": "GitHub Copilot",
-    ".openclaw": "OpenClaw",
-    ".codeium": "Codeium",
-    ".aider": "Aider",
-    ".codex": "Codex",
     ".geode": "GEODE",
-    ".devin": "Devin",
 }
 
 

--- a/tests/test_project_detect.py
+++ b/tests/test_project_detect.py
@@ -209,53 +209,59 @@ class TestGenerateSettingsJsonHooks:
 
 
 class TestHarnessDetection:
-    """Test AI agent harness directory detection."""
+    """Test GEODE harness directory detection.
+
+    GEODE runs its own runtime — it is not hosted on another agent harness.
+    Only ``.geode/`` is detected; co-existing AI tool config directories
+    (`.claude/`, `.cursor/`, ...) are intentionally ignored to avoid the
+    "GEODE runs on top of <X>" misreading in the startup banner.
+    """
 
     def test_no_harnesses(self, tmp_path: Path) -> None:
         info = detect_project_type(tmp_path)
         assert info.harnesses == []
 
-    def test_detect_claude(self, tmp_path: Path) -> None:
-        (tmp_path / ".claude").mkdir()
+    def test_detect_geode(self, tmp_path: Path) -> None:
+        (tmp_path / ".geode").mkdir()
         info = detect_project_type(tmp_path)
-        assert ".claude" in info.harnesses
+        assert ".geode" in info.harnesses
 
-    def test_detect_multiple_harnesses(self, tmp_path: Path) -> None:
+    def test_other_agent_dirs_ignored(self, tmp_path: Path) -> None:
+        """Co-existing AI tool configs do not show up as harnesses.
+
+        ``.claude/`` etc. reflect build-time tooling used by maintainers,
+        not GEODE's runtime dependencies, so the banner must not list them.
+        """
+        for d in [".claude", ".cursor", ".codex", ".copilot"]:
+            (tmp_path / d).mkdir()
+        info = detect_project_type(tmp_path)
+        assert info.harnesses == []
+
+    def test_geode_alongside_other_dirs(self, tmp_path: Path) -> None:
         for d in [".claude", ".cursor", ".geode"]:
             (tmp_path / d).mkdir()
         info = detect_project_type(tmp_path)
-        assert ".claude" in info.harnesses
-        assert ".cursor" in info.harnesses
-        assert ".geode" in info.harnesses
-        assert len(info.harnesses) == 3
-
-    def test_harnesses_sorted(self, tmp_path: Path) -> None:
-        for d in [".geode", ".claude", ".cursor"]:
-            (tmp_path / d).mkdir()
-        info = detect_project_type(tmp_path)
-        assert info.harnesses == sorted(info.harnesses)
+        assert info.harnesses == [".geode"]
 
     def test_ignores_files_not_dirs(self, tmp_path: Path) -> None:
-        (tmp_path / ".claude").write_text("not a dir")
+        (tmp_path / ".geode").write_text("not a dir")
         info = detect_project_type(tmp_path)
-        assert ".claude" not in info.harnesses
+        assert ".geode" not in info.harnesses
 
     def test_harness_with_project_type(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
-        (tmp_path / ".claude").mkdir()
-        (tmp_path / ".cursor").mkdir()
+        (tmp_path / ".geode").mkdir()
+        (tmp_path / ".claude").mkdir()  # ignored
         info = detect_project_type(tmp_path)
         assert info.project_type == "python-uv"
-        assert ".claude" in info.harnesses
-        assert ".cursor" in info.harnesses
+        assert info.harnesses == [".geode"]
 
     def test_get_harness_summary_empty(self) -> None:
         assert get_harness_summary([]) == "none"
 
     def test_get_harness_summary_labels(self) -> None:
-        result = get_harness_summary([".claude", ".cursor"])
-        assert "Claude Code" in result
-        assert "Cursor" in result
+        result = get_harness_summary([".geode"])
+        assert "GEODE" in result
 
-    def test_known_harnesses_complete(self) -> None:
-        assert len(KNOWN_HARNESSES) >= 10
+    def test_known_harnesses_self_only(self) -> None:
+        assert KNOWN_HARNESSES == {".geode": "GEODE"}


### PR DESCRIPTION
## Summary

- 시작 배너 `harness:` 라벨에서 Claude Code 등 타 AI 도구 디렉터리 제거. GEODE 단독 표시.
- `KNOWN_HARNESSES` 를 10 → 1 (`{".geode": "GEODE"}`) 로 축소. LLM context 주입 경로 (`core/memory/context.py:_inject_project_env`) 도 동일한 dict 를 통과하므로 자동 적용.
- 테스트 9 종 갱신 + self-only 보장용 positive test (`test_other_agent_dirs_ignored`) 신설.

## Why

GEODE repo 에서 `geode` 실행 시 `harness: Claude Code, GEODE` 가 출력되어 "GEODE 가 Claude Code 위에서 돈다" 는 잘못된 브랜드 신호가 됨. 실제로 GEODE 는 자체 runtime 으로:

- LLM API 호출 (Anthropic / OpenAI / GLM 등 직접)
- agentic loop (`core/agent/loop/`)
- tool 실행 (`core/tools/`)
- tiered context memory (`core/memory/`)
- plugin 레지스트리 (`core/domains/loader.py`)

를 모두 수행합니다. `.claude/`/`.cursor/`/`.codex/` 등은 **GEODE 를 제작·정비하는 개발자가 사용하는 build-time 도구 설정**일 뿐 GEODE runtime 의 의존성이 아니라서 표기에서 빼는 것이 정확합니다.

## Changes

| File | Change |
|------|--------|
| `core/utils/project_detect.py` | `KNOWN_HARNESSES` 10 → 1 entry. docstring 에 self-only 의도 명시 |
| `tests/test_project_detect.py` | `test_detect_claude` → `test_detect_geode`. `test_other_agent_dirs_ignored` 신설. `test_known_harnesses_complete` → `test_known_harnesses_self_only`. 클래스 docstring 갱신 |
| `CHANGELOG.md` | `[Unreleased]` → `### Changed` 항목 KR/EN 추가 |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — 0 errors
- [x] `uv run mypy core/utils/project_detect.py` — 0 errors
- [x] `uv run pytest tests/test_project_detect.py` — 35/35 passed
- [x] `uv run pytest -k "harness or welcome or context"` — 262 passed, 2 skipped
- [x] sanity: tmp dir 에 `.claude/.cursor/.codex/.geode` 동시 생성 → `detect_project_type()` 가 `harnesses=['.geode']`, `get_harness_summary` 가 `'GEODE'` 반환 확인

## Reference

사용자 보고: `harness: Claude Code, GEODE` 가 GEODE 의 자체 런타임 정체성을 가려서 "Claude Code plugin" 처럼 보이게 만든다는 피드백.