### PR TITLE
release: layout v3 migration + harness self-only display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **Layout migration v2 → v3 — TTL archival for runs/vault/projects.** PR
+  feature/layout-v3. `core/wiring/layout_migrator.py` 의 `_migrate_v2_to_v3`
+  가 `~/.geode/runs/` (현재 600+ 파일 평면), `~/.geode/vault/{general,research}/`
+  (1800+ 파일), `~/.geode/projects/<encoded-cwd>/` (제거된 worktree 대응
+  엔트리 포함) 의 자식 중 `mtime` 이 TTL 보다 오래된 것을 `_archive/<YYYY-MM>/`
+  월 버킷으로 이동. TTL 기본 30일, `GEODE_ARCHIVE_TTL_DAYS` 로 오버라이드.
+  Hermes `SessionDB._init_schema` + Claude Code 월별 버킷 + GEODE 자체
+  `shutil.move` 무손실 패턴 합성. Writer 변경 없음 — bootstrap 1회 sweep,
+  버전 마커로 게이트.
+- **Layout migration v2 → v3 — TTL archival for runs/vault/projects.** PR
+  feature/layout-v3. `_migrate_v2_to_v3` archives children whose mtime is
+  past TTL from `~/.geode/runs/` (600+ flat files), `~/.geode/vault/
+  {general,research}/` (1800+ files), and `~/.geode/projects/` (entries
+  for removed worktrees) into `_archive/<YYYY-MM>/` monthly buckets. TTL
+  defaults to 30 days, overridable via `GEODE_ARCHIVE_TTL_DAYS`.
+  Synthesizes Hermes `SessionDB._init_schema` + Claude Code monthly
+  bucketing + GEODE's own `shutil.move` lossless pattern. No writer
+  change — one-shot bootstrap sweep gated by version marker.
+- **Migration report per-step diagnostic logging.** `ensure_layout_migrated`
+  의 종료 INFO 라인이 step 마다 `moved=/skipped=/warnings=` 카운트를
+  찍음. v1→v2 트리거 갭 ("마커는 v=2 인데 아카이브가 안 일어났다") 후속
+  진단 — `~/.geode/logs/serve.log` 한 줄로 "v3 가 무엇을 옮겼나" 가 보임.
+- **Migration report per-step diagnostic logging.** Closing INFO line now
+  emits per-step moved/skipped/warnings counts, so operators can answer
+  "did v3 actually archive anything?" at a glance.
+
 - **P4 — paths.py SoT lint guardrail + 추가 14 사이트 정렬.** PR #1098
   audit 의 마지막 단계. `tests/test_path_literal_guard.py` 신설 — pytest
   단위에서 `core/` 트리를 regex 스캔해 `Path.home() / ".geode"` 또는

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,31 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **시작 배너 `harness:` 라벨을 GEODE 단독으로 축소.** 기존에는
+  `KNOWN_HARNESSES` 가 `.claude/`, `.cursor/`, `.codex/`, `.copilot/`,
+  `.openclaw/` 등 10 개 AI 도구 설정 디렉터리를 감지해 `harness: Claude
+  Code, GEODE` 처럼 함께 출력했는데, 이게 "GEODE 가 Claude Code 위에서
+  돌아간다" 는 잘못된 브랜드 신호로 읽혔습니다. GEODE 는 자체 런타임으로
+  LLM API 콜 + agentic loop + tool 실행 + tiered context memory + plugin
+  레지스트리를 직접 수행합니다. `.claude/` 등의 디렉터리는 **개발자가
+  GEODE 를 제작·정비할 때 사용하는 build-time 도구 설정**이지 GEODE 의
+  runtime dependency 가 아닙니다. `KNOWN_HARNESSES` 를 `{".geode":
+  "GEODE"}` 단일 항목으로 축소했고, 동일 데이터를 LLM context 로 주입하는
+  `core/memory/context.py:_inject_project_env` 도 같은 신호만 보게 됩니다.
+- **Startup banner `harness:` label reduced to GEODE only.**
+  `KNOWN_HARNESSES` previously detected 10 AI tool config directories
+  (`.claude/`, `.cursor/`, `.codex/`, `.copilot/`, `.openclaw/`, ...) and
+  rendered e.g. `harness: Claude Code, GEODE` at startup. That read as
+  "GEODE runs on top of Claude Code", which is wrong: GEODE drives its
+  own LLM API calls, agentic loop, tool execution, tiered context
+  memory, and plugin registry. `.claude/` etc. are **build-time** tooling
+  used by maintainers when developing GEODE, not runtime dependencies.
+  `KNOWN_HARNESSES` is now `{".geode": "GEODE"}`, and the parallel
+  injection into `core/memory/context.py:_inject_project_env` therefore
+  exposes the same self-only signal to the LLM context.
+
 ### Added
 
 - **P4 — paths.py SoT lint guardrail + 추가 14 사이트 정렬.** PR #1098

--- a/core/utils/project_detect.py
+++ b/core/utils/project_detect.py
@@ -1,14 +1,19 @@
 """Project type detection — harness-for-real init.sh pattern in Python.
 
 Auto-detects project type, package manager, build/test/lint commands,
-and AI agent harness directories by inspecting the project root.
+and the GEODE harness directory by inspecting the project root.
 
 Supported project types:
   node (npm/yarn/pnpm/bun), python-uv, python-pip, rust, go, java-maven, java-gradle
 
-Detected harness directories:
-  .claude/, .cursor/, .windsurf/, .copilot/, .openclaw/, .codeium/, .aider/,
-  .codex/, .geode/, .devin/
+Harness detection is intentionally GEODE-only. GEODE runs its own LLM
+API calls + agentic loop + tool execution + tiered context memory +
+plugin registry — it is not hosted on top of another agent harness.
+Listing co-existing AI agent config directories (`.claude/`, `.cursor/`,
+`.codex/`, ...) in the startup `harness:` banner historically read as
+"GEODE runs on top of <X>", which is wrong: those directories reflect
+**build-time** tooling used by maintainers, not GEODE's runtime
+dependencies. So only `.geode/` is recognised here.
 """
 
 from __future__ import annotations
@@ -17,18 +22,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Known AI agent harness directories (name → display label)
 KNOWN_HARNESSES: dict[str, str] = {
-    ".claude": "Claude Code",
-    ".cursor": "Cursor",
-    ".windsurf": "Windsurf",
-    ".copilot": "GitHub Copilot",
-    ".openclaw": "OpenClaw",
-    ".codeium": "Codeium",
-    ".aider": "Aider",
-    ".codex": "Codex",
     ".geode": "GEODE",
-    ".devin": "Devin",
 }
 
 

--- a/core/wiring/layout_migrator.py
+++ b/core/wiring/layout_migrator.py
@@ -40,11 +40,14 @@ Adding a new migration:
 from __future__ import annotations
 
 import contextlib
+import datetime as _dt
 import logging
 import os
 import shutil
 import threading
+import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from core.paths import GEODE_HOME
 
@@ -56,7 +59,13 @@ log = logging.getLogger(__name__)
 
 #: Current target layout schema version. Bumped each time a path-level
 #: migration is added.
-GEODE_LAYOUT_VERSION = 2
+GEODE_LAYOUT_VERSION = 3
+
+#: TTL in days for v2→v3 archival steps (runs/vault/projects). Override via
+#: ``GEODE_ARCHIVE_TTL_DAYS`` env var. Lowering for tests / aggressive
+#: cleanup; raising preserves more history at the cost of disk.
+DEFAULT_ARCHIVE_TTL_DAYS = 30.0
+ARCHIVE_TTL_ENV_VAR = "GEODE_ARCHIVE_TTL_DAYS"
 
 #: Marker file recording the migrated-up-to version. Absent ⇒ version 0
 #: (pre-versioned install — every existing user starts here on first run
@@ -185,13 +194,39 @@ def ensure_layout_migrated(*, force: bool = False) -> LayoutMigrationReport:
     report = LayoutMigrationReport(from_version=current, to_version=GEODE_LAYOUT_VERSION)
     _run_pending_migrations(current, report)
     write_layout_version(GEODE_LAYOUT_VERSION)
+    _log_migration_summary(report)
+    return report
+
+
+def _log_migration_summary(report: LayoutMigrationReport) -> None:
+    """Emit a per-step INFO summary so operators can confirm at-a-glance
+    that archival actually ran.
+
+    Diagnostic for the v1→v2 trigger gap: the previous one-line summary
+    only said "N step(s)" — operators had no way to tell whether each
+    step found work to do or no-op'd. We now log moved/skipped/warning
+    counts per step so a glance at ``~/.geode/logs/serve.log`` answers
+    "did v3 archive anything?"
+    """
+    total_moved = sum(len(s.moved) for s in report.steps)
     log.info(
-        "Layout migration v%d → v%d completed: %d step(s)",
+        "Layout migration v%d → v%d: %d step(s), %d entr%s moved",
         report.from_version,
         report.to_version,
         len(report.steps),
+        total_moved,
+        "y" if total_moved == 1 else "ies",
     )
-    return report
+    for step in report.steps:
+        log.info(
+            "  step %r: moved=%d skipped=%d warnings=%d",
+            step.name,
+            len(step.moved),
+            len(step.skipped),
+            len(step.warnings),
+        )
+        for warning in step.warnings:
+            log.info("    warning: %s", warning)
 
 
 def reset_migration_guard() -> None:
@@ -217,6 +252,8 @@ def _run_pending_migrations(current_version: int, report: LayoutMigrationReport)
         report.steps.append(_migrate_v0_to_v1())
     if current_version < 2:
         report.steps.append(_migrate_v1_to_v2())
+    if current_version < 3:
+        report.steps.append(_migrate_v2_to_v3())
 
 
 # ---------------------------------------------------------------------------
@@ -310,8 +347,6 @@ def _migrate_v1_to_v2() -> MigrationResult:
         result.skipped.append(".geode/: absent in current workspace")
         return result
 
-    import datetime as _dt
-
     stamp = _dt.datetime.now(_dt.UTC).strftime("%Y%m%dT%H%M%SZ")
     archive_root = geode_dir / "_archive"
     candidates = [
@@ -349,5 +384,165 @@ def _migrate_v1_to_v2() -> MigrationResult:
             log.info("Layout v1→v2: archived %s → %s", src, dst)
         except OSError as exc:
             result.warnings.append(f"{src.name}: archive failed: {exc}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# v2 → v3: TTL-based archival of runs/, vault/, projects/
+# ---------------------------------------------------------------------------
+
+
+def _resolve_archive_ttl_days() -> float:
+    """Return the configured TTL in days. Falls back to default on any
+    parse / sign error so a misconfigured env var never blocks bootstrap.
+    """
+    raw = os.environ.get(ARCHIVE_TTL_ENV_VAR)
+    if raw is None:
+        return DEFAULT_ARCHIVE_TTL_DAYS
+    try:
+        value = float(raw)
+    except ValueError:
+        log.warning(
+            "%s=%r is not numeric — using default %.0f days",
+            ARCHIVE_TTL_ENV_VAR,
+            raw,
+            DEFAULT_ARCHIVE_TTL_DAYS,
+        )
+        return DEFAULT_ARCHIVE_TTL_DAYS
+    if value <= 0:
+        log.warning(
+            "%s=%r is non-positive — using default %.0f days",
+            ARCHIVE_TTL_ENV_VAR,
+            raw,
+            DEFAULT_ARCHIVE_TTL_DAYS,
+        )
+        return DEFAULT_ARCHIVE_TTL_DAYS
+    return value
+
+
+def _archive_old_entries_by_mtime(
+    source_dir: Path,
+    archive_root: Path,
+    cutoff: float,
+    result: MigrationResult,
+    *,
+    label: str,
+    bucket_by_month: bool = True,
+) -> None:
+    """Move every direct child of ``source_dir`` older than ``cutoff`` into
+    ``archive_root/<YYYY-MM>/`` (or ``archive_root/`` flat if
+    ``bucket_by_month=False``).
+
+    Uses ``mtime`` for files and the directory's own ``mtime`` for
+    subdirectories — sufficient signal for "user hasn't touched this
+    bucket in N days." Records moves on ``result`` (one entry per child).
+    Skips ``archive_root`` itself if it happens to live inside
+    ``source_dir`` so the migration cannot eat its own tail.
+    """
+    if not source_dir.exists():
+        result.skipped.append(f"{label}: {source_dir} absent")
+        return
+    try:
+        entries = list(source_dir.iterdir())
+    except OSError as exc:
+        result.warnings.append(f"{label}: iterdir({source_dir}) failed: {exc}")
+        return
+
+    archive_resolved = archive_root.resolve()
+    for entry in entries:
+        try:
+            if entry.resolve() == archive_resolved:
+                continue
+        except OSError:
+            pass
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError as exc:
+            result.warnings.append(f"{label}: stat({entry.name}) failed: {exc}")
+            continue
+        if mtime >= cutoff:
+            continue
+
+        if bucket_by_month:
+            bucket = _dt.datetime.fromtimestamp(mtime, tz=_dt.UTC).strftime("%Y-%m")
+            dst_dir = archive_root / bucket
+        else:
+            dst_dir = archive_root
+        dst = dst_dir / entry.name
+        if dst.exists():
+            result.warnings.append(
+                f"{label}: {entry.name} already present in archive — left source untouched"
+            )
+            continue
+        try:
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(entry), str(dst))
+            result.moved.append((str(entry), str(dst)))
+        except OSError as exc:
+            result.warnings.append(f"{label}: archive of {entry.name} failed: {exc}")
+
+
+def _migrate_v2_to_v3() -> MigrationResult:
+    """v3 — TTL-based archival of high-volume global directories.
+
+    Three target categories under ``~/.geode/``:
+
+    1. ``runs/`` — per-execution receipts. Currently 600+ flat files,
+       indefinite retention. Archive children older than TTL to
+       ``runs/_archive/<YYYY-MM>/``.
+
+    2. ``vault/general/`` and ``vault/research/`` — long-term memory.
+       Currently 1800+ files across both, no eviction policy. Archive
+       per-file by ``mtime`` to ``vault/<scope>/_archive/<YYYY-MM>/``.
+
+    3. ``projects/<encoded-cwd>/`` — per-workspace state. Many entries
+       correspond to removed worktrees (``.claude/worktrees/*``).
+       Archive entire workspace dirs whose own ``mtime`` is past TTL to
+       ``projects/_archive/<YYYY-MM>/``.
+
+    TTL defaults to 30 days, overridable via ``GEODE_ARCHIVE_TTL_DAYS``.
+    Bucketing by month matches Claude Code's project-tracking dir
+    structure and keeps the archive browsable.
+
+    Lossless — uses :func:`shutil.move`. Reversible — operator can move
+    bucket contents back. No writer change: existing call sites keep
+    writing to the un-bucketed directories; archival is a periodic
+    sweep run at bootstrap, gated by the version marker so it only runs
+    once per install.
+    """
+    result = MigrationResult(name="v2→v3: TTL archival (runs/vault/projects)")
+
+    ttl_days = _resolve_archive_ttl_days()
+    cutoff = time.time() - ttl_days * 86400.0
+    result.warnings.append(f"TTL={ttl_days:.1f} days, cutoff={int(cutoff)}")
+
+    from core.paths import GLOBAL_PROJECTS_DIR, GLOBAL_RUNS_DIR, GLOBAL_VAULT_DIR
+
+    _archive_old_entries_by_mtime(
+        GLOBAL_RUNS_DIR,
+        GLOBAL_RUNS_DIR / "_archive",
+        cutoff,
+        result,
+        label="runs",
+    )
+
+    for scope in ("general", "research"):
+        scope_dir = GLOBAL_VAULT_DIR / scope
+        _archive_old_entries_by_mtime(
+            scope_dir,
+            scope_dir / "_archive",
+            cutoff,
+            result,
+            label=f"vault/{scope}",
+        )
+
+    _archive_old_entries_by_mtime(
+        GLOBAL_PROJECTS_DIR,
+        GLOBAL_PROJECTS_DIR / "_archive",
+        cutoff,
+        result,
+        label="projects",
+    )
 
     return result

--- a/tests/test_layout_migrator.py
+++ b/tests/test_layout_migrator.py
@@ -29,6 +29,14 @@ def fake_geode_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         tmp_path / ".layout-version",
     )
 
+    # v2→v3 archives runs/vault/projects under GEODE_HOME. The constants
+    # were captured at core.paths import time bound to the *real*
+    # ``~/.geode/``, so monkeypatching ``GEODE_HOME`` alone is not enough
+    # — we also have to redirect the derived paths to ``tmp_path``.
+    monkeypatch.setattr("core.paths.GLOBAL_RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr("core.paths.GLOBAL_VAULT_DIR", tmp_path / "vault")
+    monkeypatch.setattr("core.paths.GLOBAL_PROJECTS_DIR", tmp_path / "projects")
+
     # Project root → a workspace inside tmp_path. v1→v2 migration archives
     # things under {workspace}/.geode/_archive so we want the workspace to
     # be sandboxed too.
@@ -294,9 +302,9 @@ class TestV1ToV2VestigialArchival:
         # Single skipped entry — the .geode/ short-circuit
         assert any(".geode/" in s for s in step.skipped)
 
-    def test_full_v0_to_v2_chain_on_fresh_install(self, fake_geode_home: Path) -> None:
-        """Pre-versioned install runs both v0→v1 and v1→v2 in one pass and
-        ends at the target marker."""
+    def test_full_chain_on_fresh_install(self, fake_geode_home: Path) -> None:
+        """Pre-versioned install runs every step in one pass and ends at
+        the current target marker."""
         from core.wiring.layout_migrator import (
             GEODE_LAYOUT_VERSION,
             ensure_layout_migrated,
@@ -307,7 +315,8 @@ class TestV1ToV2VestigialArchival:
         step_names = [s.name for s in report.steps]
         assert any(n.startswith("v0→v1") for n in step_names)
         assert any(n.startswith("v1→v2") for n in step_names)
-        assert read_layout_version() == GEODE_LAYOUT_VERSION == 2
+        assert any(n.startswith("v2→v3") for n in step_names)
+        assert read_layout_version() == GEODE_LAYOUT_VERSION
 
     def test_constants_removed_from_paths(self, fake_geode_home: Path) -> None:
         """Sanity — the two vestigial constants must no longer exist on
@@ -316,3 +325,184 @@ class TestV1ToV2VestigialArchival:
 
         assert not hasattr(paths, "PROJECT_EMBEDDING_CACHE")
         assert not hasattr(paths, "PROJECT_VECTORS_DIR")
+
+
+# ---------------------------------------------------------------------------
+# v2 → v3: TTL-based archival of runs/, vault/, projects/
+# ---------------------------------------------------------------------------
+
+
+class TestV2ToV3TTLArchival:
+    """v2→v3 — children of `runs/`, `vault/{general,research}/`, and
+    `projects/` older than the TTL are moved to a monthly bucket under
+    `_archive/<YYYY-MM>/`. No writer changes; one-shot sweep gated by
+    the version marker."""
+
+    @staticmethod
+    def _age_by_days(path: Path, days: float) -> None:
+        """Set ``mtime`` (and ``atime``) on ``path`` to ``days`` ago."""
+        import os
+        import time as _time
+
+        when = _time.time() - days * 86400.0
+        os.utime(path, (when, when))
+
+    def test_runs_old_files_archived_into_monthly_bucket(self, fake_geode_home: Path) -> None:
+        runs_dir = fake_geode_home / "runs"
+        runs_dir.mkdir(parents=True)
+        old = runs_dir / "run-old.jsonl"
+        old.write_text('{"trace": "old"}')
+        self._age_by_days(old, days=90)
+        fresh = runs_dir / "run-fresh.jsonl"
+        fresh.write_text('{"trace": "fresh"}')
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not old.exists()
+        assert fresh.exists()
+        archive = runs_dir / "_archive"
+        buckets = list(archive.iterdir())
+        assert len(buckets) == 1
+        assert len(buckets[0].name) == 7 and buckets[0].name[4] == "-"  # YYYY-MM
+        assert (buckets[0] / "run-old.jsonl").exists()
+
+    def test_vault_general_and_research_both_archived(self, fake_geode_home: Path) -> None:
+        general = fake_geode_home / "vault" / "general"
+        research = fake_geode_home / "vault" / "research"
+        general.mkdir(parents=True)
+        research.mkdir(parents=True)
+        old_g = general / "g-old.md"
+        old_r = research / "r-old.md"
+        old_g.write_text("g")
+        old_r.write_text("r")
+        self._age_by_days(old_g, days=60)
+        self._age_by_days(old_r, days=60)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not old_g.exists()
+        assert not old_r.exists()
+        # Each scope keeps its own _archive bucket.
+        assert any((general / "_archive").iterdir())
+        assert any((research / "_archive").iterdir())
+
+    def test_projects_stale_workspace_dir_archived(self, fake_geode_home: Path) -> None:
+        projects = fake_geode_home / "projects"
+        stale = projects / "encoded-cwd-stale"
+        stale.mkdir(parents=True)
+        (stale / "marker").write_text("x")
+        self._age_by_days(stale, days=90)
+        active = projects / "encoded-cwd-active"
+        active.mkdir(parents=True)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not stale.exists()
+        assert active.exists()
+        archived_buckets = list((projects / "_archive").iterdir())
+        assert len(archived_buckets) == 1
+        assert (archived_buckets[0] / "encoded-cwd-stale").exists()
+
+    def test_ttl_respected_default_30_days(self, fake_geode_home: Path) -> None:
+        runs_dir = fake_geode_home / "runs"
+        runs_dir.mkdir(parents=True)
+        just_inside = runs_dir / "29-days-old"
+        just_inside.write_text("a")
+        self._age_by_days(just_inside, days=29)
+        just_outside = runs_dir / "31-days-old"
+        just_outside.write_text("b")
+        self._age_by_days(just_outside, days=31)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert just_inside.exists(), "29-day-old file must NOT be archived"
+        assert not just_outside.exists(), "31-day-old file must be archived"
+
+    def test_env_var_overrides_ttl(
+        self, fake_geode_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GEODE_ARCHIVE_TTL_DAYS", "5")
+        runs_dir = fake_geode_home / "runs"
+        runs_dir.mkdir(parents=True)
+        seven_day = runs_dir / "7-day"
+        seven_day.write_text("c")
+        self._age_by_days(seven_day, days=7)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert not seven_day.exists(), "7-day-old file must be archived when TTL=5"
+
+    def test_bad_env_var_falls_back_to_default(
+        self, fake_geode_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GEODE_ARCHIVE_TTL_DAYS", "not-a-number")
+        runs_dir = fake_geode_home / "runs"
+        runs_dir.mkdir(parents=True)
+        ten_day = runs_dir / "10-day"
+        ten_day.write_text("d")
+        self._age_by_days(ten_day, days=10)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        # Fallback to 30-day default → 10-day file stays.
+        assert ten_day.exists()
+
+    def test_absent_directories_skip_cleanly(self, fake_geode_home: Path) -> None:
+        """Fresh install with no runs/vault/projects → step records skips
+        and emits no warnings besides the TTL banner."""
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+        step = next(s for s in report.steps if s.name.startswith("v2→v3"))
+        assert step.moved == []
+        assert len(step.skipped) >= 4  # runs, vault/general, vault/research, projects
+
+    def test_archive_root_is_not_self_archived(self, fake_geode_home: Path) -> None:
+        """The migration must not eat its own ``_archive`` directory even
+        if its mtime drifts past the TTL."""
+        runs_dir = fake_geode_home / "runs"
+        runs_dir.mkdir(parents=True)
+        archive = runs_dir / "_archive"
+        archive.mkdir()
+        self._age_by_days(archive, days=365)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        ensure_layout_migrated(force=True)
+
+        assert archive.exists()
+        assert archive.is_dir()
+        # Nothing nested into itself.
+        assert not (archive / "_archive").exists()
+
+    def test_v2_to_v3_idempotent_on_rerun(self, fake_geode_home: Path) -> None:
+        """A second `force=True` run after archival completes must not
+        re-archive (marker is at v3, no work)."""
+        runs_dir = fake_geode_home / "runs"
+        runs_dir.mkdir(parents=True)
+        old = runs_dir / "x"
+        old.write_text("x")
+        self._age_by_days(old, days=90)
+
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        first = ensure_layout_migrated(force=True)
+        second = ensure_layout_migrated(force=True)
+
+        v3_first = [s for s in first.steps if s.name.startswith("v2→v3")]
+        v3_second = [s for s in second.steps if s.name.startswith("v2→v3")]
+        assert len(v3_first[0].moved) == 1
+        assert second.no_op is True
+        assert v3_second == []

--- a/tests/test_project_detect.py
+++ b/tests/test_project_detect.py
@@ -209,53 +209,59 @@ class TestGenerateSettingsJsonHooks:
 
 
 class TestHarnessDetection:
-    """Test AI agent harness directory detection."""
+    """Test GEODE harness directory detection.
+
+    GEODE runs its own runtime — it is not hosted on another agent harness.
+    Only ``.geode/`` is detected; co-existing AI tool config directories
+    (`.claude/`, `.cursor/`, ...) are intentionally ignored to avoid the
+    "GEODE runs on top of <X>" misreading in the startup banner.
+    """
 
     def test_no_harnesses(self, tmp_path: Path) -> None:
         info = detect_project_type(tmp_path)
         assert info.harnesses == []
 
-    def test_detect_claude(self, tmp_path: Path) -> None:
-        (tmp_path / ".claude").mkdir()
+    def test_detect_geode(self, tmp_path: Path) -> None:
+        (tmp_path / ".geode").mkdir()
         info = detect_project_type(tmp_path)
-        assert ".claude" in info.harnesses
+        assert ".geode" in info.harnesses
 
-    def test_detect_multiple_harnesses(self, tmp_path: Path) -> None:
+    def test_other_agent_dirs_ignored(self, tmp_path: Path) -> None:
+        """Co-existing AI tool configs do not show up as harnesses.
+
+        ``.claude/`` etc. reflect build-time tooling used by maintainers,
+        not GEODE's runtime dependencies, so the banner must not list them.
+        """
+        for d in [".claude", ".cursor", ".codex", ".copilot"]:
+            (tmp_path / d).mkdir()
+        info = detect_project_type(tmp_path)
+        assert info.harnesses == []
+
+    def test_geode_alongside_other_dirs(self, tmp_path: Path) -> None:
         for d in [".claude", ".cursor", ".geode"]:
             (tmp_path / d).mkdir()
         info = detect_project_type(tmp_path)
-        assert ".claude" in info.harnesses
-        assert ".cursor" in info.harnesses
-        assert ".geode" in info.harnesses
-        assert len(info.harnesses) == 3
-
-    def test_harnesses_sorted(self, tmp_path: Path) -> None:
-        for d in [".geode", ".claude", ".cursor"]:
-            (tmp_path / d).mkdir()
-        info = detect_project_type(tmp_path)
-        assert info.harnesses == sorted(info.harnesses)
+        assert info.harnesses == [".geode"]
 
     def test_ignores_files_not_dirs(self, tmp_path: Path) -> None:
-        (tmp_path / ".claude").write_text("not a dir")
+        (tmp_path / ".geode").write_text("not a dir")
         info = detect_project_type(tmp_path)
-        assert ".claude" not in info.harnesses
+        assert ".geode" not in info.harnesses
 
     def test_harness_with_project_type(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
-        (tmp_path / ".claude").mkdir()
-        (tmp_path / ".cursor").mkdir()
+        (tmp_path / ".geode").mkdir()
+        (tmp_path / ".claude").mkdir()  # ignored
         info = detect_project_type(tmp_path)
         assert info.project_type == "python-uv"
-        assert ".claude" in info.harnesses
-        assert ".cursor" in info.harnesses
+        assert info.harnesses == [".geode"]
 
     def test_get_harness_summary_empty(self) -> None:
         assert get_harness_summary([]) == "none"
 
     def test_get_harness_summary_labels(self) -> None:
-        result = get_harness_summary([".claude", ".cursor"])
-        assert "Claude Code" in result
-        assert "Cursor" in result
+        result = get_harness_summary([".geode"])
+        assert "GEODE" in result
 
-    def test_known_harnesses_complete(self) -> None:
-        assert len(KNOWN_HARNESSES) >= 10
+    def test_known_harnesses_self_only(self) -> None:
+        assert KNOWN_HARNESSES == {".geode": "GEODE"}


### PR DESCRIPTION
## Summary
- **#1114** layout migration v2→v3 — TTL archival of `~/.geode/runs/`, `~/.geode/vault/{general,research}/`, `~/.geode/projects/` to `_archive/<YYYY-MM>/` monthly buckets (default TTL 30d, `GEODE_ARCHIVE_TTL_DAYS` overridable). Per-step diagnostic INFO logging.
- **#1115** harness banner — drop Claude Code / build-time tools from runtime display, show GEODE only.

## Verification
- [x] feature PRs #1114 and #1115 both passed CI 7/7 before merging to develop
- [ ] develop→main CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)