### PR TITLE
docs(readme): peer comparison — 7 → 25 grounded axes across 5 tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,42 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Documentation
+
+- **README peer comparison: 7 → 25 grounded axes across 5 thematic
+  tables.** 기존 표가 (a) 사실 오류 — Claude Code 는 "Anthropic only"
+  표기였으나 실제로는 Bedrock/Vertex 라우팅 지원, Codex CLI 는
+  "OpenAI only" 표기였으나 실제로는 `model_providers` 로 Azure /
+  Bedrock / Ollama / any OpenAI-compatible 까지 — 와 (b) "everyone ✅"
+  셀 과다로 차별화 신호가 약했음. Claude Code v2.1.72 · Codex CLI
+  v0.130 · OpenClaw v2026.5.12 · GEODE v0.95 의 실제 상태를 18 축씩
+  리서치한 결과를 5 thematic 테이블 (Runtime posture / Channels & UX /
+  LLM provider & cost / Persistence, memory & verification /
+  Extensibility & observability) 25 축으로 재구성. 4-level marker
+  (`✅✅`/`✅`/`⚠️`/`❌`) 로 nuance 표현. GEODE 차별화 셀에 CHANGELOG
+  version ref — 200K token guard (v0.40), 5-layer context overflow
+  (v0.39), 58-event hook system, 5-tier memory, 5-layer verification
+  (G1-G4 + BiasBuster + Krippendorff α ≥ 0.67), Petri observability
+  (v0.90). 결론 한 줄도 3 use case (Claude/Codex · OpenClaw · GEODE)
+  매핑으로 확장.
+- **README peer comparison: 7 → 25 grounded axes across 5 thematic
+  tables.** The prior table contained (a) factual errors — Claude Code
+  listed as "Anthropic only" when Bedrock/Vertex routing has shipped,
+  Codex CLI listed as "OpenAI only" when `model_providers` supports
+  Azure / Bedrock / Ollama / any OpenAI-compatible — and (b) too many
+  "everyone ✅" cells, weakening differentiation. Researched the actual
+  state of Claude Code v2.1.72, Codex CLI v0.130, OpenClaw v2026.5.12,
+  and GEODE v0.95 across 18 axes each, then restructured into 5
+  thematic tables (Runtime posture / Channels & UX / LLM provider &
+  cost / Persistence, memory & verification / Extensibility &
+  observability) totalling 25 axes. 4-level marker (`✅✅`/`✅`/`⚠️`/`❌`)
+  captures nuance. GEODE differentiator cells gain CHANGELOG version
+  refs — 200K token guard (v0.40), 5-layer context overflow (v0.39),
+  58-event hook system, 5-tier memory, 5-layer verification (G1-G4 +
+  BiasBuster + Krippendorff α ≥ 0.67), Petri observability (v0.90).
+  Closing recommendation expanded to map 3 use-case patterns to 3
+  systems (Claude/Codex · OpenClaw · GEODE).
+
 ### Changed
 
 - **시작 배너 `harness:` 라벨을 GEODE 단독으로 축소.** 기존에는

--- a/README.md
+++ b/README.md
@@ -315,17 +315,63 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+
+### A. Runtime posture — how the agent stays alive
+
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
-| Always-on daemon | ❌ session only | ❌ session only | ✅ Gateway | ✅ `geode serve` |
-| Slack/Discord channels | ❌ | ❌ | ✅ many | ✅ Slack first-class |
-| Multi-provider failover | ⚠️ Anthropic only | ⚠️ OpenAI only | ✅ many | ✅ 3 + governance |
-| Subscription OAuth (no API key) | ✅ Pro/Max | ✅ Plus | ✅ both | ⚠️ ChatGPT only (Plus, Pro, Business, Edu, Enterprise — Anthropic ToS blocks Claude OAuth) |
-| Disk-persistent plans + memory | ⚠️ partial | ⚠️ partial | ✅ | ✅ 5-tier |
-| Swappable domain DAG | ❌ | ❌ | ❌ | ✅ `DomainPort` |
-| Scheduler (long-running) | ❌ | ❌ | ⚠️ partial | ✅ cron + triggers |
+| Always-on daemon | ❌ per-invocation | ⚠️ opt-in `codex remote-control` (v0.130+) | ✅✅ launchd / systemd control plane | ✅ `geode serve` daemon |
+| Native scheduler (cron) | ❌ (claude.ai web-only) | ❌ (Codex Cloud Automations only — [issue #8317](https://github.com/openai/codex/issues/8317)) | ✅ `cron add/edit/list` CLI | ✅ cron + event triggers |
+| Thin CLI ↔ daemon IPC | ❌ | ⚠️ remote-control server mode | ✅ Gateway / Agent split | ✅ IPC server (v0.48+) |
+| Sub-agent isolation | ✅ Agent tool + `run_in_background` | ✅ `multi_agent` feature, default `max_threads=6` | ✅✅ Lane Queue + Session bindings | ✅ Lane + depth / cost guard |
+| Session resume / fork | ✅ JSONL transcripts | ✅ `/resume` + `/fork` slash commands | ✅ Session bindings with TTL | ✅ session resume (v0.21+) |
 
-Use **Claude Code** or **Codex** for short coding sessions. Use **GEODE** when you need it to keep running, watch signals, and report back over hours or days.
+### B. Channels & UX surfaces — how it reaches users
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| Slack | ❌ (MCP plugin possible) | ⚠️ Codex Cloud only, not CLI | ✅ Socket Mode, first-class | ✅ Socket Mode, first-class |
+| Discord / Telegram / other chat | ❌ | ❌ | ✅✅ 23+ channels (Discord, Telegram, WhatsApp, Signal, iMessage, Teams, Matrix, Feishu, LINE, ...) | ✅ Discord + Telegram pollers |
+| IDE plugin | ❌ (Chrome MCP extension only) | ✅✅ VS Code · JetBrains · Cursor · Windsurf | ❌ | ❌ |
+| Web UI | ✅ claude.ai/code | ✅ Codex Cloud | ⚠️ WebChat plugin | ❌ (docs site only) |
+| MCP server catalog | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic-published registry (200+ servers, cached at `~/.geode/mcp/registry-cache.json`) |
+
+### C. LLM provider & cost governance
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| Multi-provider failover | ✅ Anthropic + AWS Bedrock + Google Vertex (env routing) | ✅✅ OpenAI + Azure + Bedrock + Ollama + any OpenAI-compatible (`model_providers` config) | ✅ `auth.order` cooldown-based auto-failover | ✅ Anthropic + OpenAI + ZhipuAI, in-provider only |
+| Subscription OAuth tier | ✅ Pro / Max | ✅✅ Plus · Pro · Business · Edu · Enterprise | ⚠️ OpenAI + Gemini onboarding | ⚠️ ChatGPT only (Plus / Pro / Business / Edu / Enterprise) — Anthropic ToS (2026-01-09) blocks third-party Claude OAuth |
+| Token / cost budget guard | ⚠️ cache token tracking only | ⚠️ retry caps (`request_max_retries`) | ⚠️ partial | ✅ **200K token guard** (v0.40), explicit budget governance |
+| Context overflow handling | ✅ autocompaction | ⚠️ skills progressive disclosure (~2% budget) + fork | ✅ compaction + transcript streaming (252 MB → 27 MB peak) | ✅✅ **5-layer context overflow** (v0.39+) |
+| Cross-vendor failover policy | ❌ | ⚠️ manual `model_providers` switch | ✅ automatic | ❌ by design (v0.53 governance — no surprise cross-vendor charges) |
+
+### D. Persistence, memory & verification
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| Memory tiers | ⚠️ 3 (user / project / local settings merge) | ✅ hierarchical AGENTS.md (global `~/.codex/` + repo + nested dirs) | ⚠️ session-scoped | ✅✅ **5-tier** (SOUL · User · Org · Project · Session) |
+| Disk-persistent plans | ✅ TodoWrite persistence | ⚠️ via resumable threads | ✅ task registry | ✅ `.geode/plans.json` |
+| Permission / sandbox layers | ✅ 3-mode (default / auto / bypass) + Confirmation UI | ✅ `sandbox_mode` 3-level (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain (40+ audit surfaces) | ✅ Policy Chain + tool gates |
+| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **5-layer verification** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
+| Hook event count | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 event types · many bundled handlers | ✅✅ **58 events** (`docs/architecture/hook-system.md`) |
+
+### E. Extensibility & observability
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| Plugin / extension surfaces | ✅ manifest + marketplace (user / project / local scopes) | ✅ `/plugins` slash command + plugin sharing (v0.130+) | ✅✅ 4 extension points (Channel · Tool · Skill · Hook) via `@openclaw/plugin-sdk` | ✅ `DomainPort` Protocol + plugin loader |
+| Skill system | ✅ Deferred tools + SKILL.md manifest | ✅ SKILL.md + progressive disclosure (`.agents/skills/`) | ✅ skill filter + archive upload | ✅ runtime `SkillRegistry` (13 runtime skills) |
+| **Swappable domain DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — not a DAG abstraction) | ✅✅ `DomainPort` Protocol — pipeline is a first-class extension point |
+| Trace / replay / Run Log | ✅ `tengu_*` telemetry + `/insights` HTML | ⚠️ `/status` + `/debug-config` only | ✅ ACP session lineage + Task Registry | ✅ Run Log + Petri eval integration (v0.90+, replaces LangSmith) |
+| Cross-LLM verification | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 inter-rater agreement gate |
+
+---
+
+Use **Claude Code** or **Codex** for short coding sessions inside an IDE or via cloud sync. Use **OpenClaw** to run a multi-channel chat agent fleet across 23+ messaging surfaces. Use **GEODE** when an agent must work over hours or days on a non-coding domain with multi-tier memory, multi-layer verification, and a swappable domain pipeline.
+
+> Sources — Claude Code v2.1.72 (build 2026-03-09, reverse-engineered reference). Codex CLI v0.130.0 release notes + [developers.openai.com/codex/config-reference](https://developers.openai.com/codex/config-reference) + [github.com/openai/codex](https://github.com/openai/codex). OpenClaw v2026.5.12-beta.1 (1.8M LoC TypeScript). GEODE — `CHANGELOG.md` (`v0.39` context overflow, `v0.40` 200K guard, `v0.85` 4-layer stack, `v0.90` Petri observability).
 
 ---
 


### PR DESCRIPTION
## Summary

- README \`How GEODE compares\` 표를 7 축 → 25 축 (5 thematic table) 으로 재구성.
- 사실 오류 셀 4 개 교정 (Claude Code Bedrock/Vertex, Codex CLI Azure/Bedrock/Ollama/any-OAI, Codex OAuth 5 tier, OpenClaw 23+ channels).
- GEODE 차별화 셀에 CHANGELOG version ref — 200K token guard (v0.40), 5-layer context overflow (v0.39), 58-event hook, 5-tier memory, 5-layer verification (Krippendorff α ≥ 0.67), Petri observability (v0.90).
- 4-level marker (\`✅✅\`/\`✅\`/\`⚠️\`/\`❌\`) 로 nuance 표현.

## Why

기존 표가 (a) Claude Code 와 Codex CLI 의 multi-provider 지원을 잘못 표기 (각각 Bedrock/Vertex, Azure/Bedrock/Ollama 등 지원함에도 \"only\" 라고 적혀 있었음) 했고, (b) \"everyone ✅\" 셀이 많아 차별화 신호가 약했음. 최근 6 개월간 GEODE 에 들어온 200K token guard, 5-layer context overflow, 58-event hook, Petri observability 등이 표에 전혀 surface 되지 않아 페이지 방문자가 GEODE 의 현재 위치를 정확히 읽을 수 없었음.

## Changes

| File | Change |
|------|--------|
| \`README.md\` | \`How GEODE compares\` 섹션을 5 thematic table × 5 axes = 25 axes 로 재구성. Source line 추가 (Claude Code v2.1.72 / Codex v0.130 / OpenClaw v2026.5.12 / GEODE v0.95) |
| \`CHANGELOG.md\` | \`[Unreleased] > Documentation\` 항목 KR/EN 추가 |

## Research grounding

| System | Source |
|--------|--------|
| Claude Code v2.1.72 (build 2026-03-09) | Local reverse-engineered reference (Explore agent survey) |
| Codex CLI v0.130.0 (2026-05-08) | [github.com/openai/codex](https://github.com/openai/codex) release notes + [developers.openai.com/codex/config-reference](https://developers.openai.com/codex/config-reference) (web research agent) |
| OpenClaw v2026.5.12-beta.1 | Local checkout (1.8M TS LoC, 14,184 files; Explore agent survey) |
| GEODE v0.95.0 | \`CHANGELOG.md\` v0.39 (context overflow), v0.40 (200K token guard), v0.85 (4-layer stack), v0.90 (Petri integration) |

## Verification

- [x] README diff renders correctly (5 markdown tables, all properly aligned)
- [x] No code changes → ruff/mypy/pytest unaffected
- [x] Source footnote uses public URLs only (no local user paths — per \`feedback_no_hardcoded_user_paths\` rule)
- [x] All competitor cells grounded against version-specific source (file path, doc URL, or release date)
- [x] GEODE differentiator cells (5-tier memory, 58-event hooks, 5-layer verification, 200K guard, 5-layer overflow, Petri) cross-referenced to CHANGELOG entries