### PR TITLE
docs(readme): 5 단원 collapsible + KO sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,25 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Documentation
 
+- **README peer comparison: 5 단원 collapsible + KO sync.** GitHub 에서
+  README 가 한 페이지에 너무 길어 보였던 문제 — 25 axes 5 테이블이 한꺼번에
+  렌더되어 scroll 이 길었음 — 을 해결하기 위해 A∼E 5 단원을 각자
+  `<details>` 블록으로 감쌌음 (기본 closed). 인트로 한 줄 + 결론 한 줄은
+  항상 보이게 유지. 또한 `README.ko.md` 가 이전 PR 의 영문 sync 에서
+  누락되어 옛 7-axis 표 + 사실 오류 셀 (Bedrock/Vertex 누락, Azure/Ollama
+  누락) 이 그대로 남아 있었음 — 영문판과 동일한 5 단원 25 축 구조 +
+  collapsible + 출처 footnote 까지 완전 sync.
+- **README peer comparison: collapsible 5 sections + KO sync.** Fixed
+  page-length problem on GitHub where 25 axes across 5 tables rendered
+  as one long scroll. Each of A–E now lives in its own `<details>` block
+  (closed by default). Intro line + closing recommendation remain
+  always visible. Also fixed a sync gap: `README.ko.md` retained the
+  old 7-axis table (with the factually wrong "Anthropic only" / "OpenAI
+  only" cells) because the previous PR only touched the English
+  README. The Korean README now mirrors the English structure
+  exactly — 5 collapsible thematic sections, 25 grounded axes, 4-level
+  marker, and source footnote.
+
 - **README peer comparison: 7 → 25 grounded axes across 5 thematic
   tables.** 기존 표가 (a) 사실 오류 — Claude Code 는 "Anthropic only"
   표기였으나 실제로는 Bedrock/Vertex 라우팅 지원, Codex CLI 는

--- a/README.ko.md
+++ b/README.ko.md
@@ -309,17 +309,78 @@ uv tool install -e . --force
 
 ## GEODE 비교
 
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+
+<details>
+<summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>
+
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
-| 상시 데몬 | ❌ 세션 only | ❌ 세션 only | ✅ Gateway | ✅ `geode serve` |
-| Slack/Discord 채널 | ❌ | ❌ | ✅ 다수 | ✅ Slack first-class |
-| 멀티 프로바이더 페일오버 | ⚠️ Anthropic only | ⚠️ OpenAI only | ✅ 다수 | ✅ 3 + 거버넌스 |
-| 구독 OAuth (API 키 불필요) | ✅ Pro/Max | ✅ Plus | ✅ 둘 다 | ⚠️ ChatGPT 만 (Plus, Pro, Business, Edu, Enterprise — Anthropic 약관이 Claude OAuth 차단) |
-| 디스크 영구 plan + 메모리 | ⚠️ 부분 | ⚠️ 부분 | ✅ | ✅ 5-tier |
-| 교체 가능한 도메인 DAG | ❌ | ❌ | ❌ | ✅ `DomainPort` |
-| 스케줄러 (장시간) | ❌ | ❌ | ⚠️ 부분 | ✅ cron + triggers |
+| 상시 데몬 | ❌ per-invocation | ⚠️ opt-in `codex remote-control` (v0.130+) | ✅✅ launchd / systemd 컨트롤 plane | ✅ `geode serve` 데몬 |
+| 네이티브 스케줄러 (cron) | ❌ (claude.ai 웹 전용) | ❌ (Codex Cloud Automations 전용 — [issue #8317](https://github.com/openai/codex/issues/8317)) | ✅ `cron add/edit/list` CLI | ✅ cron + 이벤트 트리거 |
+| Thin CLI ↔ 데몬 IPC | ❌ | ⚠️ remote-control 서버 모드 | ✅ Gateway / Agent 분리 | ✅ IPC 서버 (v0.48+) |
+| Sub-agent 격리 | ✅ Agent 도구 + `run_in_background` | ✅ `multi_agent` 기능, 기본 `max_threads=6` | ✅✅ Lane Queue + Session bindings | ✅ Lane + depth / cost 가드 |
+| 세션 resume / fork | ✅ JSONL 트랜스크립트 | ✅ `/resume` + `/fork` 슬래시 커맨드 | ✅ Session bindings + TTL | ✅ session resume (v0.21+) |
 
-짧은 코딩 세션엔 **Claude Code** 또는 **Codex**. 몇 시간/며칠 동안 계속 돌면서 시그널을 watch 하고 보고하는 작업엔 **GEODE**.
+</details>
+
+<details>
+<summary><strong>B. 채널 & UX 표면</strong> — 사용자에게 어떻게 닿는가</summary>
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| Slack | ❌ (MCP 플러그인 가능) | ⚠️ Codex Cloud 전용, CLI 는 미지원 | ✅ Socket Mode, first-class | ✅ Socket Mode, first-class |
+| Discord / Telegram / 기타 chat | ❌ | ❌ | ✅✅ 23+ 채널 (Discord, Telegram, WhatsApp, Signal, iMessage, Teams, Matrix, Feishu, LINE, ...) | ✅ Discord + Telegram 폴러 |
+| IDE 플러그인 | ❌ (Chrome MCP 확장만) | ✅✅ VS Code · JetBrains · Cursor · Windsurf | ❌ | ❌ |
+| Web UI | ✅ claude.ai/code | ✅ Codex Cloud | ⚠️ WebChat 플러그인 | ❌ (문서 사이트만) |
+| MCP 서버 카탈로그 | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic 배포 레지스트리 (200+ 서버, `~/.geode/mcp/registry-cache.json` 캐시) |
+
+</details>
+
+<details>
+<summary><strong>C. LLM 프로바이더 & 비용 거버넌스</strong></summary>
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| 멀티 프로바이더 페일오버 | ✅ Anthropic + AWS Bedrock + Google Vertex (환경변수 라우팅) | ✅✅ OpenAI + Azure + Bedrock + Ollama + OpenAI-호환 엔드포인트 전체 (`model_providers` 설정) | ✅ `auth.order` 쿨다운 기반 자동 페일오버 | ✅ Anthropic + OpenAI + ZhipuAI, in-provider 전용 |
+| 구독 OAuth tier | ✅ Pro / Max | ✅✅ Plus · Pro · Business · Edu · Enterprise | ⚠️ OpenAI + Gemini 온보딩 | ⚠️ ChatGPT 만 (Plus / Pro / Business / Edu / Enterprise) — Anthropic 약관 (2026-01-09) 이 3rd-party Claude OAuth 차단 |
+| 토큰 / 비용 예산 가드 | ⚠️ 캐시 토큰 추적만 | ⚠️ 재시도 cap 만 (`request_max_retries`) | ⚠️ 부분 | ✅ **200K 토큰 가드** (v0.40), 명시적 예산 거버넌스 |
+| 컨텍스트 overflow 처리 | ✅ 자동 컴팩션 | ⚠️ Skills progressive disclosure (~2% 예산) + fork | ✅ 컴팩션 + 트랜스크립트 스트리밍 (252 MB → 27 MB 피크) | ✅✅ **5-layer 컨텍스트 overflow** (v0.39+) |
+| 벤더 간 페일오버 정책 | ❌ | ⚠️ `model_providers` 수동 전환 | ✅ 자동 | ❌ 의도적 (v0.53 거버넌스 — 예기치 못한 cross-vendor 과금 방지) |
+
+</details>
+
+<details>
+<summary><strong>D. 영속성, 메모리 & 검증</strong></summary>
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| 메모리 tier | ⚠️ 3 (user / project / local 세팅 머지) | ✅ 계층적 AGENTS.md (전역 `~/.codex/` + repo + nested dirs) | ⚠️ 세션 범위 | ✅✅ **5-tier** (SOUL · User · Org · Project · Session) |
+| 디스크 영구 plan | ✅ TodoWrite 영속화 | ⚠️ resumable 스레드 경유 | ✅ task registry | ✅ `.geode/plans.json` |
+| 권한 / 샌드박스 계층 | ✅ 3-mode (default / auto / bypass) + Confirmation UI | ✅ `sandbox_mode` 3 단계 (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain (40+ 감사 표면) | ✅ Policy Chain + 도구 게이트 |
+| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅✅ **5-layer 검증** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
+| Hook 이벤트 수 | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 이벤트 타입 · 다수 번들 핸들러 | ✅✅ **58 이벤트** (`docs/architecture/hook-system.md`) |
+
+</details>
+
+<details>
+<summary><strong>E. 확장성 & 관측성</strong></summary>
+
+| | Claude Code | Codex CLI | OpenClaw | **GEODE** |
+|---|---|---|---|---|
+| 플러그인 / 확장 표면 | ✅ manifest + 마켓플레이스 (user / project / local 스코프) | ✅ `/plugins` 슬래시 커맨드 + 플러그인 공유 (v0.130+) | ✅✅ 4 확장 지점 (Channel · Tool · Skill · Hook) via `@openclaw/plugin-sdk` | ✅ `DomainPort` Protocol + 플러그인 로더 |
+| Skill 시스템 | ✅ Deferred tools + SKILL.md manifest | ✅ SKILL.md + progressive disclosure (`.agents/skills/`) | ✅ 스킬 필터 + archive 업로드 | ✅ 런타임 `SkillRegistry` (13 런타임 skills) |
+| **교체 가능한 도메인 DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — DAG 추상화 아님) | ✅✅ `DomainPort` Protocol — 파이프라인이 first-class 확장 지점 |
+| 트레이스 / 리플레이 / Run Log | ✅ `tengu_*` 텔레메트리 + `/insights` HTML | ⚠️ `/status` + `/debug-config` 만 | ✅ ACP 세션 lineage + Task Registry | ✅ Run Log + Petri eval 통합 (v0.90+, LangSmith 대체) |
+| Cross-LLM 검증 | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 평가자 간 일치도 게이트 |
+
+</details>
+
+---
+
+IDE 내부 또는 클라우드 동기화로 짧은 코딩 세션을 돌릴 땐 **Claude Code** / **Codex**. 23+ 메시징 표면에 걸친 멀티 채널 chat 에이전트 fleet 을 운영할 땐 **OpenClaw**. 코딩 외 도메인을 다중 tier 메모리 + 다중 계층 검증 + 교체 가능 도메인 파이프라인으로 몇 시간 / 며칠 돌릴 땐 **GEODE**.
+
+> 출처 — Claude Code v2.1.72 (빌드 2026-03-09, 역공학 레퍼런스). Codex CLI v0.130.0 릴리즈 노트 + [developers.openai.com/codex/config-reference](https://developers.openai.com/codex/config-reference) + [github.com/openai/codex](https://github.com/openai/codex). OpenClaw v2026.5.12-beta.1 (1.8M LoC TypeScript). GEODE — `CHANGELOG.md` (`v0.39` 컨텍스트 overflow, `v0.40` 200K 가드, `v0.85` 4-layer stack, `v0.90` Petri 관측성).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ uv tool install -e . --force
 
 Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
-### A. Runtime posture — how the agent stays alive
+<details>
+<summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>
 
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
@@ -327,7 +328,10 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Sub-agent isolation | ✅ Agent tool + `run_in_background` | ✅ `multi_agent` feature, default `max_threads=6` | ✅✅ Lane Queue + Session bindings | ✅ Lane + depth / cost guard |
 | Session resume / fork | ✅ JSONL transcripts | ✅ `/resume` + `/fork` slash commands | ✅ Session bindings with TTL | ✅ session resume (v0.21+) |
 
-### B. Channels & UX surfaces — how it reaches users
+</details>
+
+<details>
+<summary><strong>B. Channels & UX surfaces</strong> — how it reaches users</summary>
 
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
@@ -337,7 +341,10 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Web UI | ✅ claude.ai/code | ✅ Codex Cloud | ⚠️ WebChat plugin | ❌ (docs site only) |
 | MCP server catalog | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic-published registry (200+ servers, cached at `~/.geode/mcp/registry-cache.json`) |
 
-### C. LLM provider & cost governance
+</details>
+
+<details>
+<summary><strong>C. LLM provider & cost governance</strong></summary>
 
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
@@ -347,7 +354,10 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Context overflow handling | ✅ autocompaction | ⚠️ skills progressive disclosure (~2% budget) + fork | ✅ compaction + transcript streaming (252 MB → 27 MB peak) | ✅✅ **5-layer context overflow** (v0.39+) |
 | Cross-vendor failover policy | ❌ | ⚠️ manual `model_providers` switch | ✅ automatic | ❌ by design (v0.53 governance — no surprise cross-vendor charges) |
 
-### D. Persistence, memory & verification
+</details>
+
+<details>
+<summary><strong>D. Persistence, memory & verification</strong></summary>
 
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
@@ -357,7 +367,10 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **5-layer verification** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
 | Hook event count | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 event types · many bundled handlers | ✅✅ **58 events** (`docs/architecture/hook-system.md`) |
 
-### E. Extensibility & observability
+</details>
+
+<details>
+<summary><strong>E. Extensibility & observability</strong></summary>
 
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
@@ -366,6 +379,8 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | **Swappable domain DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — not a DAG abstraction) | ✅✅ `DomainPort` Protocol — pipeline is a first-class extension point |
 | Trace / replay / Run Log | ✅ `tengu_*` telemetry + `/insights` HTML | ⚠️ `/status` + `/debug-config` only | ✅ ACP session lineage + Task Registry | ✅ Run Log + Petri eval integration (v0.90+, replaces LangSmith) |
 | Cross-LLM verification | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 inter-rater agreement gate |
+
+</details>
 
 ---
 


### PR DESCRIPTION
## Summary

- README peer comparison 5 단원 (A∼E) 을 각각 \`<details>\` 블록으로 wrap (default closed). intro + 결론은 항상 보임.
- \`README.ko.md\` 를 영문판과 1:1 sync — 5 단원 25 axes + collapsible + 버전 footnote. 사실 오류 셀 4 개 (Bedrock/Vertex, Azure/Ollama, Codex OAuth 5 tier, OpenClaw 23+ channels) 정정.

## Why

1. **Scroll 부담** — 25 axes × 5 tables 가 한꺼번에 펼쳐져 README 가 너무 길었음. 사용자 요청.
2. **KO sync gap** — 이전 PR #1117 이 영문만 업데이트해서 \`README.ko.md\` 는 옛 7-axis 표 + 사실 오류 그대로. 리포 컨벤션이 README.md ↔ README.ko.md 동일 구조 유지.

## Changes

| File | Change |
|------|--------|
| \`README.md\` | A∼E 5 단원 각각 \`<details><summary>\` 로 wrap. intro/결론 unfold 상태 유지 |
| \`README.ko.md\` | 옛 7-axis 표 → 25 axes 5 단원 collapsible 구조로 완전 sync. 영문판 셀과 1:1 매핑 |
| \`CHANGELOG.md\` | \`[Unreleased] > Documentation\` 항목 KR/EN 추가 |

## Verification

- [x] README.md A∼E 5 \`<details>\` 블록 확인
- [x] README.ko.md 동일 5 \`<details>\` 블록 + 인트로/결론 한글화
- [x] 사실 오류 셀 4 개 KO 페이지에서도 정정됨
- [x] 출처 footnote KO 번역 (외부 URL 그대로)
- [x] 코드 변경 없음 → ruff / mypy / pytest unaffected