### PR TITLE
fix(pages): publish docs/petri-bundle/ on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,7 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - "docs/petri-bundle/**"
       - "CHANGELOG.md"
       - "pyproject.toml"
       - "CLAUDE.md"
@@ -64,6 +65,18 @@ jobs:
 
       - name: Build static export
         run: npm run build
+
+      - name: Copy docs/petri-bundle into site/out
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -d docs/petri-bundle ]; then
+            mkdir -p site/out/petri-bundle
+            cp -R docs/petri-bundle/. site/out/petri-bundle/
+            echo "petri-bundle copied:"
+            ls -la site/out/petri-bundle/ | head -20
+          else
+            echo "docs/petri-bundle missing — skipping copy"
+          fi
 
       - uses: actions/configure-pages@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitHub Pages 의 `/geode/petri-bundle/` 404 복구.** `pages.yml` 의
+  Next.js build artifact (`site/out`) 가 `docs/petri-bundle/` 를 포함하지
+  않아 외부에서 `https://mangowhoiscloud.github.io/geode/petri-bundle/`
+  접근 시 404 반환되던 이슈 수정. build job 에 `docs/petri-bundle` →
+  `site/out/petri-bundle` 복사 step 추가 + workflow trigger paths 에
+  `docs/petri-bundle/**` 추가하여 향후 bundle 갱신 시 자동 재배포. 본
+  bundle 은 이력서의 Petri × GEODE Alignment Audit 검증 자료로 외부
+  공유 중이라 무결성 회복이 시급.
+- **GitHub Pages `/geode/petri-bundle/` 404 recovery.** The
+  `pages.yml` workflow uploaded the Next.js artifact at `site/out`
+  only, leaving `docs/petri-bundle/` outside the published tree and
+  returning 404 at `https://mangowhoiscloud.github.io/geode/petri-bundle/`.
+  Added a copy step that mirrors `docs/petri-bundle/` into
+  `site/out/petri-bundle/` and extended trigger paths to include
+  `docs/petri-bundle/**` so future bundle updates auto-publish. The
+  bundle is the external evidence for the Petri × GEODE Alignment
+  Audit cited in the resume; integrity recovery was urgent.
+
 ### Documentation
 
 - **Hook system doc ↔ 코드 정합성 audit (Stage C).** `docs/architecture/


### PR DESCRIPTION
## Summary
- `.github/workflows/pages.yml` build job 에 `docs/petri-bundle` → `site/out/petri-bundle` 복사 step 추가
- trigger paths 에 `docs/petri-bundle/**` 추가 — 향후 bundle 갱신 시 자동 재배포

## Why
`https://mangowhoiscloud.github.io/geode/petri-bundle/` 가 **404** 반환. 원인 추적:

- Pages workflow 가 `site/out` Next.js artifact 만 upload
- `docs/petri-bundle/` 는 main 에 commit 되어 있으나 build artifact 미포함
- trigger paths 도 `site/**` 한정이라 `docs/` 변경은 rebuild 안 trigger

본 bundle 은 **이력서의 Petri × GEODE Alignment Audit 검증 자료**로 외부 공유 중. 다수 회사에 동일 URL 제출된 상태라 무결성 회복 시급.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/pages.yml` | build job 에 `docs/petri-bundle` → `site/out/petri-bundle` 복사 step 추가 + trigger paths 에 `docs/petri-bundle/**` 추가 |
| `CHANGELOG.md` | `[Unreleased] Fixed` 항목 추가 (KR/EN) |

## Verification
- [x] yaml lint clean (PyYAML safe_load 통과)
- [x] ruff check core/ clean
- [x] mypy / pytest — 코드 변경 X (yaml + markdown 만), 영향 없음
- [ ] (post-merge) `https://mangowhoiscloud.github.io/geode/petri-bundle/` 200 + index.html 정상 렌더
- [ ] (post-merge) `/geode/petri-bundle/logs/listing.json` 200 + JSON 정상

## Reference
- 원본 진단: `pages.yml` 의 `upload-pages-artifact path: site/out` (line 71-72)
- 외부 공유 자료: 이력서 GEODE subtitle 의 `Petri Audit` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)