### PR TITLE
refactor(hooks): emit 사이트 string-literal → direct HookEvent (Stage A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,45 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **Hook emit 사이트 string-literal → direct enum (Stage A).** Stage C
+  audit 후 발견된 50+ 호출 사이트에서 `_fire_hook("event_name", data)`
+  / `_fire_interceptor("event_name", data)` / `_fire_with_result(
+  "event_name", data)` 형태로 string 을 넘기던 패턴을 모두
+  `HookEvent.EVENT_NAME` 직접 참조로 변환. 8 wrapper 함수 (`memory_tools.
+  _fire_hook`, `provider_dispatch._fire_hook`, `router/_hooks._fire_hook`,
+  `mcp/manager._fire_mcp_hook`, `agent/approval.ApprovalWorkflow.
+  _fire_hook`, `tool_executor/executor.ToolExecutor._fire_hook`,
+  `tool_executor/processor.{._fire_hook,_fire_interceptor,_fire_with_result}`)
+  의 signature 도 `event_name: str` → `event: HookEvent` 로 강타입화.
+  부수 발견: `core/llm/router/calls/_failover.py:118` 가 `"retry_wait"`
+  를 emit 하던 사이트 — 이 string 은 `HookEvent` enum 멤버가 아니라
+  `fire_hook(_hooks_ctx, "retry_wait", data)` 가 `HookEvent("retry_wait")`
+  ValueError 로 silent fail 하던 dead emit 이었음. payload 의미 (model
+  / attempt / max_retries / delay_s / elapsed_s / error_type) 가
+  `LLM_CALL_RETRY` 와 일치하므로 그 enum 으로 라우팅. 행위 변경 — 이전엔
+  silent drop, 이제 RunLog wildcard + LLM_CALL_RETRY listener 가 fire.
+- **Hook emit sites: string-literal → direct enum (Stage A).** All 50+
+  call sites that previously passed a raw string to `_fire_hook(...)`,
+  `_fire_interceptor(...)`, or `_fire_with_result(...)` now pass a
+  typed `HookEvent` member directly. Tightened the signatures of 8
+  wrapper methods (`memory_tools._fire_hook`,
+  `provider_dispatch._fire_hook`, `router/_hooks._fire_hook`,
+  `mcp/manager._fire_mcp_hook`, `agent/approval.ApprovalWorkflow.
+  _fire_hook`, `tool_executor/executor.ToolExecutor._fire_hook`,
+  `tool_executor/processor.{_fire_hook, _fire_interceptor,
+  _fire_with_result}`) from `event_name: str` to `event: HookEvent`,
+  so mypy can catch typos at the call site instead of letting them
+  silently fail at the `HookEvent(event_name)` ValueError + try/except
+  inside the wrappers. Side finding: `core/llm/router/calls/
+  _failover.py:118` was emitting `"retry_wait"`, which is not a member
+  of `HookEvent` — the call silently swallowed for every retry. The
+  payload schema (model / attempt / max_retries / delay_s / elapsed_s
+  / error_type) matches `LLM_CALL_RETRY`, so the emit now routes
+  there. Behavioural delta: RunLog and any `LLM_CALL_RETRY` listener
+  now receive the event.
+
 ### Fixed
 
 - **GitHub Pages 의 `/geode/petri-bundle/` 404 복구.** `pages.yml` 의

--- a/core/agent/approval.py
+++ b/core/agent/approval.py
@@ -20,6 +20,7 @@ from core.agent.safety import (
     WRITE_TOOLS,
     is_bash_command_read_only,
 )
+from core.hooks.system import HookEvent
 from core.ui.console import console
 
 if TYPE_CHECKING:
@@ -84,16 +85,13 @@ class ApprovalWorkflow:
         self._tool_approval_counts: dict[str, int] = {}
         self._tool_denial_counts: dict[str, int] = {}
 
-    def _fire_hook(self, event_name: str, data: dict[str, Any]) -> None:
+    def _fire_hook(self, event: HookEvent, data: dict[str, Any]) -> None:
         if self._hooks is None:
             return
-        from core.hooks import HookEvent
-
         try:
-            event = HookEvent(event_name)
             self._hooks.trigger(event, data)
         except Exception:
-            log.debug("Hook fire failed for %s", event_name, exc_info=True)
+            log.debug("Hook fire failed for %s", event, exc_info=True)
 
     # -----------------------------------------------------------------
     # Pattern learning
@@ -184,12 +182,12 @@ class ApprovalWorkflow:
                     approved = True
                 else:
                     self._fire_hook(
-                        "tool_approval_requested",
+                        HookEvent.TOOL_APPROVAL_REQUESTED,
                         {"tool_name": tool_name, "safety_level": "write"},
                     )
                     if not self.confirm_write(tool_name, tool_input):
                         self._fire_hook(
-                            "tool_approval_denied",
+                            HookEvent.TOOL_APPROVAL_DENIED,
                             {
                                 "tool_name": tool_name,
                                 "safety_level": "write",
@@ -200,7 +198,7 @@ class ApprovalWorkflow:
                         )
                         return _write_denial_with_fallback(tool_name), False
                     self._fire_hook(
-                        "tool_approval_granted",
+                        HookEvent.TOOL_APPROVAL_GRANTED,
                         {
                             "tool_name": tool_name,
                             "safety_level": "write",
@@ -221,12 +219,12 @@ class ApprovalWorkflow:
                 else:
                     cost = EXPENSIVE_TOOLS[tool_name]
                     self._fire_hook(
-                        "tool_approval_requested",
+                        HookEvent.TOOL_APPROVAL_REQUESTED,
                         {"tool_name": tool_name, "safety_level": "cost"},
                     )
                     if not self.confirm_cost(tool_name, cost):
                         self._fire_hook(
-                            "tool_approval_denied",
+                            HookEvent.TOOL_APPROVAL_DENIED,
                             {
                                 "tool_name": tool_name,
                                 "safety_level": "cost",
@@ -240,7 +238,7 @@ class ApprovalWorkflow:
                             "denied": True,
                         }, False
                     self._fire_hook(
-                        "tool_approval_granted",
+                        HookEvent.TOOL_APPROVAL_GRANTED,
                         {
                             "tool_name": tool_name,
                             "safety_level": "cost",
@@ -268,7 +266,7 @@ class ApprovalWorkflow:
             console.print()
 
         self._fire_hook(
-            "tool_approval_requested",
+            HookEvent.TOOL_APPROVAL_REQUESTED,
             {
                 "tool_name": tool_name,
                 "safety_level": "MCP",
@@ -285,7 +283,7 @@ class ApprovalWorkflow:
             if response == "a":
                 self._always_approved_categories.add(f"mcp:{server}")
             self._fire_hook(
-                "tool_approval_granted",
+                HookEvent.TOOL_APPROVAL_GRANTED,
                 {
                     "tool_name": tool_name,
                     "permission_level": "MCP",
@@ -295,7 +293,7 @@ class ApprovalWorkflow:
             )
             return True
         self._fire_hook(
-            "tool_approval_denied",
+            HookEvent.TOOL_APPROVAL_DENIED,
             {
                 "tool_name": tool_name,
                 "permission_level": "MCP",
@@ -341,7 +339,7 @@ class ApprovalWorkflow:
 
         if self.check_auto_deny(tool_name):
             self._fire_hook(
-                "tool_approval_denied",
+                HookEvent.TOOL_APPROVAL_DENIED,
                 {
                     "tool_name": tool_name,
                     "permission_level": "WRITE",
@@ -352,7 +350,7 @@ class ApprovalWorkflow:
             return False
 
         self._fire_hook(
-            "tool_approval_requested",
+            HookEvent.TOOL_APPROVAL_REQUESTED,
             {
                 "tool_name": tool_name,
                 "safety_level": "WRITE",
@@ -370,7 +368,7 @@ class ApprovalWorkflow:
             if response == "a":
                 self._always_approved_categories.add("write")
             self._fire_hook(
-                "tool_approval_granted",
+                HookEvent.TOOL_APPROVAL_GRANTED,
                 {
                     "tool_name": tool_name,
                     "permission_level": "WRITE",
@@ -381,7 +379,7 @@ class ApprovalWorkflow:
             )
             return True
         self._fire_hook(
-            "tool_approval_denied",
+            HookEvent.TOOL_APPROVAL_DENIED,
             {
                 "tool_name": tool_name,
                 "permission_level": "WRITE",
@@ -409,7 +407,7 @@ class ApprovalWorkflow:
             console.print()
 
         self._fire_hook(
-            "tool_approval_requested",
+            HookEvent.TOOL_APPROVAL_REQUESTED,
             {
                 "tool_name": tool_name,
                 "safety_level": "EXPENSIVE",
@@ -419,7 +417,7 @@ class ApprovalWorkflow:
 
         if self.check_auto_deny(tool_name):
             self._fire_hook(
-                "tool_approval_denied",
+                HookEvent.TOOL_APPROVAL_DENIED,
                 {
                     "tool_name": tool_name,
                     "permission_level": "EXPENSIVE",
@@ -439,7 +437,7 @@ class ApprovalWorkflow:
             if response == "a":
                 self._always_approved_categories.add("cost")
             self._fire_hook(
-                "tool_approval_granted",
+                HookEvent.TOOL_APPROVAL_GRANTED,
                 {
                     "tool_name": tool_name,
                     "permission_level": "EXPENSIVE",
@@ -450,7 +448,7 @@ class ApprovalWorkflow:
             )
             return True
         self._fire_hook(
-            "tool_approval_denied",
+            HookEvent.TOOL_APPROVAL_DENIED,
             {
                 "tool_name": tool_name,
                 "permission_level": "EXPENSIVE",
@@ -474,7 +472,7 @@ class ApprovalWorkflow:
             console.print()
 
         self._fire_hook(
-            "tool_approval_requested",
+            HookEvent.TOOL_APPROVAL_REQUESTED,
             {
                 "tool_name": "run_bash",
                 "safety_level": "DANGEROUS",
@@ -484,7 +482,7 @@ class ApprovalWorkflow:
 
         if self.check_auto_deny("run_bash"):
             self._fire_hook(
-                "tool_approval_denied",
+                HookEvent.TOOL_APPROVAL_DENIED,
                 {
                     "tool_name": "run_bash",
                     "permission_level": "DANGEROUS",
@@ -504,7 +502,7 @@ class ApprovalWorkflow:
             if response == "a":
                 self._always_approved_categories.add("bash")
             self._fire_hook(
-                "tool_approval_granted",
+                HookEvent.TOOL_APPROVAL_GRANTED,
                 {
                     "tool_name": "run_bash",
                     "permission_level": "DANGEROUS",
@@ -515,7 +513,7 @@ class ApprovalWorkflow:
             )
             return True
         self._fire_hook(
-            "tool_approval_denied",
+            HookEvent.TOOL_APPROVAL_DENIED,
             {
                 "tool_name": "run_bash",
                 "permission_level": "DANGEROUS",

--- a/core/agent/tool_executor/executor.py
+++ b/core/agent/tool_executor/executor.py
@@ -18,6 +18,7 @@ from core.agent.safety import (
     EXPENSIVE_TOOLS,
     WRITE_TOOLS,
 )
+from core.hooks.system import HookEvent
 
 log = logging.getLogger(__name__)
 
@@ -76,17 +77,14 @@ class ToolExecutor:
             approval_callback=approval_callback,
         )
 
-    def _fire_hook(self, event_name: str, data: dict[str, Any]) -> None:
+    def _fire_hook(self, event: HookEvent, data: dict[str, Any]) -> None:
         """Fire a hook event if HookSystem is available. No-op otherwise."""
         if self._hooks is None:
             return
-        from core.hooks import HookEvent
-
         try:
-            event = HookEvent(event_name)
             self._hooks.trigger(event, data)
         except Exception:
-            log.debug("Hook fire failed for %s", event_name, exc_info=True)
+            log.debug("Hook fire failed for %s", event, exc_info=True)
 
     def _track_decision(self, tool_name: str, decision: str) -> None:
         """Delegates to ApprovalWorkflow."""
@@ -139,12 +137,12 @@ class ToolExecutor:
                 approved = True
             else:
                 self._fire_hook(
-                    "tool_approval_requested",
+                    HookEvent.TOOL_APPROVAL_REQUESTED,
                     {"tool_name": tool_name, "safety_level": "write"},
                 )
                 if not self._confirm_write(tool_name, tool_input):
                     self._fire_hook(
-                        "tool_approval_denied",
+                        HookEvent.TOOL_APPROVAL_DENIED,
                         {
                             "tool_name": tool_name,
                             "safety_level": "write",
@@ -155,7 +153,7 @@ class ToolExecutor:
                     )
                     return _write_denial_with_fallback(tool_name), False
                 self._fire_hook(
-                    "tool_approval_granted",
+                    HookEvent.TOOL_APPROVAL_GRANTED,
                     {
                         "tool_name": tool_name,
                         "safety_level": "write",
@@ -175,12 +173,12 @@ class ToolExecutor:
             else:
                 cost = EXPENSIVE_TOOLS[tool_name]
                 self._fire_hook(
-                    "tool_approval_requested",
+                    HookEvent.TOOL_APPROVAL_REQUESTED,
                     {"tool_name": tool_name, "safety_level": "cost"},
                 )
                 if not self._confirm_cost(tool_name, cost):
                     self._fire_hook(
-                        "tool_approval_denied",
+                        HookEvent.TOOL_APPROVAL_DENIED,
                         {
                             "tool_name": tool_name,
                             "safety_level": "cost",
@@ -191,7 +189,7 @@ class ToolExecutor:
                     )
                     return {"error": "User denied expensive operation", "denied": True}, False
                 self._fire_hook(
-                    "tool_approval_granted",
+                    HookEvent.TOOL_APPROVAL_GRANTED,
                     {
                         "tool_name": tool_name,
                         "safety_level": "cost",

--- a/core/agent/tool_executor/processor.py
+++ b/core/agent/tool_executor/processor.py
@@ -20,6 +20,7 @@ from core.agent.safety import (
     SAFE_TOOLS,
     WRITE_TOOLS,
 )
+from core.hooks.system import HookEvent
 
 from ._helpers import _compute_model_tool_limit, _guard_tool_result
 from .executor import ToolExecutor
@@ -216,7 +217,7 @@ class ToolCallProcessor:
 
             # Hook: TOOL_EXEC_START (interceptor — can block or modify input)
             intercept = self._fire_interceptor(
-                "tool_exec_start", {"tool_name": tool_name, "tool_input": tool_input}
+                HookEvent.TOOL_EXEC_START, {"tool_name": tool_name, "tool_input": tool_input}
             )
             if intercept is not None and intercept.blocked:
                 log.info("Tool %s blocked by TOOL_EXEC_START hook: %s", tool_name, intercept.reason)
@@ -245,7 +246,7 @@ class ToolCallProcessor:
                 "has_error": _has_error,
                 "result": result,
             }
-            post_results = self._fire_with_result("tool_exec_end", _post_data)
+            post_results = self._fire_with_result(HookEvent.TOOL_EXEC_END, _post_data)
             # Apply result modifications from PostToolUse-style handlers
             for hr in post_results:
                 if hr.success and isinstance(hr.data, dict):
@@ -260,7 +261,7 @@ class ToolCallProcessor:
             # Hook: TOOL_EXEC_FAILED (observer — fires only on error)
             if _has_error:
                 self._fire_hook(
-                    "tool_exec_failed",
+                    HookEvent.TOOL_EXEC_FAILED,
                     {
                         "tool_name": tool_name,
                         "tool_input": tool_input,
@@ -277,7 +278,7 @@ class ToolCallProcessor:
 
             # Hook: TOOL_RESULT_TRANSFORM (feedback — result rewriting, post-observation)
             transform_results = self._fire_with_result(
-                "tool_result_transform",
+                HookEvent.TOOL_RESULT_TRANSFORM,
                 {
                     "tool_name": tool_name,
                     "tool_input": tool_input,
@@ -447,7 +448,7 @@ class ToolCallProcessor:
         and emits hook events for observability.
         """
         self._fire_hook(
-            "tool_recovery_attempted",
+            HookEvent.TOOL_RECOVERY_ATTEMPTED,
             {
                 "tool_name": tool_name,
                 "fail_count": fail_count,
@@ -465,7 +466,7 @@ class ToolCallProcessor:
         if recovery_result.recovered:
             self._consecutive_failures[tool_name] = 0
             self._fire_hook(
-                "tool_recovery_succeeded",
+                HookEvent.TOOL_RECOVERY_SUCCEEDED,
                 {
                     "tool_name": tool_name,
                     "strategy": recovery_result.strategy_used.value
@@ -481,7 +482,7 @@ class ToolCallProcessor:
             return result
 
         self._fire_hook(
-            "tool_recovery_failed",
+            HookEvent.TOOL_RECOVERY_FAILED,
             {
                 "tool_name": tool_name,
                 "attempts": len(recovery_result.attempts),
@@ -495,19 +496,16 @@ class ToolCallProcessor:
         result["skipped"] = True
         return result
 
-    def _fire_hook(self, event_name: str, data: dict[str, Any]) -> None:
+    def _fire_hook(self, event: HookEvent, data: dict[str, Any]) -> None:
         """Emit a hook event if HookSystem is configured."""
         if self._hooks is None:
             return
         try:
-            from core.hooks import HookEvent as _HookEvent
-
-            event = _HookEvent(event_name)
             self._hooks.trigger(event, data)
         except Exception:
-            log.debug("Hook trigger failed for %s", event_name, exc_info=True)
+            log.debug("Hook trigger failed for %s", event, exc_info=True)
 
-    def _fire_interceptor(self, event_name: str, data: dict[str, Any]) -> InterceptResult | None:
+    def _fire_interceptor(self, event: HookEvent, data: dict[str, Any]) -> InterceptResult | None:
         """Emit a hook event as interceptor (block/modify semantics).
 
         Returns InterceptResult if hooks are configured, None otherwise.
@@ -515,15 +513,12 @@ class ToolCallProcessor:
         if self._hooks is None:
             return None
         try:
-            from core.hooks import HookEvent as _HookEvent
-
-            event = _HookEvent(event_name)
             return self._hooks.trigger_interceptor(event, data)
         except Exception:
-            log.debug("Interceptor trigger failed for %s", event_name, exc_info=True)
+            log.debug("Interceptor trigger failed for %s", event, exc_info=True)
             return None
 
-    def _fire_with_result(self, event_name: str, data: dict[str, Any]) -> list[HookResult]:
+    def _fire_with_result(self, event: HookEvent, data: dict[str, Any]) -> list[HookResult]:
         """Emit a hook event capturing handler return values.
 
         Returns list of HookResult with handler-returned data.
@@ -531,12 +526,9 @@ class ToolCallProcessor:
         if self._hooks is None:
             return []
         try:
-            from core.hooks import HookEvent as _HookEvent
-
-            event = _HookEvent(event_name)
             return self._hooks.trigger_with_result(event, data)
         except Exception:
-            log.debug("Hook trigger_with_result failed for %s", event_name, exc_info=True)
+            log.debug("Hook trigger_with_result failed for %s", event, exc_info=True)
             return []
 
     @staticmethod

--- a/core/llm/provider_dispatch.py
+++ b/core/llm/provider_dispatch.py
@@ -18,6 +18,7 @@ from core.config import (
     OPENAI_FALLBACK_CHAIN,
     is_model_allowed,
 )
+from core.hooks.system import HookEvent
 from core.hooks.utils import fire_hook
 from core.llm.fallback import CircuitBreaker, retry_with_backoff_generic
 
@@ -53,9 +54,9 @@ def set_dispatch_hooks(hooks: Any) -> None:
     _hooks_ctx = hooks
 
 
-def _fire_hook(event_name: str, data: dict[str, Any]) -> None:
+def _fire_hook(event: HookEvent, data: dict[str, Any]) -> None:
     """Fire a hook event if HookSystem is wired (or no-op)."""
-    fire_hook(_hooks_ctx, event_name, data)
+    fire_hook(_hooks_ctx, event, data)
 
 
 # ---------------------------------------------------------------------------
@@ -262,7 +263,7 @@ def _cross_provider_dispatch(  # noqa: UP047 — PEP695 syntax requires Python 3
                     elapsed_ms,
                 )
                 _fire_hook(
-                    "fallback_cross_provider",
+                    HookEvent.FALLBACK_CROSS_PROVIDER,
                     {
                         "from_provider": provider,
                         "to_provider": next_p,

--- a/core/llm/router/_hooks.py
+++ b/core/llm/router/_hooks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from core.hooks.system import HookEvent
 from core.hooks.utils import fire_hook
 
 log = logging.getLogger(__name__)
@@ -27,6 +28,6 @@ def set_router_hooks(hooks: Any) -> None:
     _hooks_ctx = hooks
 
 
-def _fire_hook(event_name: str, data: dict[str, Any]) -> None:
+def _fire_hook(event: HookEvent, data: dict[str, Any]) -> None:
     """Fire a hook event if HookSystem is wired (or no-op)."""
-    fire_hook(_hooks_ctx, event_name, data)
+    fire_hook(_hooks_ctx, event, data)

--- a/core/llm/router/calls/_failover.py
+++ b/core/llm/router/calls/_failover.py
@@ -13,6 +13,7 @@ import time
 from typing import Any
 
 from core.config import is_model_allowed
+from core.hooks.system import HookEvent
 from core.llm.router._hooks import _fire_hook
 
 # v0.88.0 — RETRYABLE_ERRORS / NON_RETRYABLE_ERRORS are lazy-resolved
@@ -113,9 +114,14 @@ async def call_with_failover(
                     type(exc).__name__,
                     wait,
                 )
-                # Emit retry_wait event for UX (elapsed timer + interrupt hint)
+                # Emit LLM_CALL_RETRY for UX (elapsed timer + interrupt hint).
+                # The legacy string "retry_wait" was silently swallowed by
+                # ``fire_hook`` since no enum member named "RETRY_WAIT" exists —
+                # routing to LLM_CALL_RETRY matches the payload semantics
+                # (model + attempt + max_retries + delay_s + elapsed_s + error_type)
+                # and unblocks any handler that listens to LLM_CALL_RETRY.
                 _fire_hook(
-                    "retry_wait",
+                    HookEvent.LLM_CALL_RETRY,
                     {
                         "model": current_model,
                         "attempt": attempt + 1,

--- a/core/llm/router/calls/parsed.py
+++ b/core/llm/router/calls/parsed.py
@@ -6,6 +6,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, TypeVar, cast
 
+from core.hooks.system import HookEvent
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
     _get_provider_client,
@@ -54,7 +55,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
 
     def _dispatch(p: str, m: str) -> T:
         _fire_hook(
-            "llm_call_start",
+            HookEvent.LLM_CALL_START,
             {"model": m, "provider": p, "function": "call_llm_parsed"},
         )
         t0 = time.monotonic()
@@ -113,7 +114,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                "llm_call_end",
+                HookEvent.LLM_CALL_END,
                 {
                     "model": m,
                     "provider": p,
@@ -126,7 +127,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         _fire_hook(
-            "llm_call_end",
+            HookEvent.LLM_CALL_END,
             {
                 "model": m,
                 "provider": p,

--- a/core/llm/router/calls/streaming.py
+++ b/core/llm/router/calls/streaming.py
@@ -6,6 +6,10 @@ import logging
 import time
 from collections.abc import Iterator
 
+# v0.88.0 — RETRYABLE_ERRORS resolves through providers/anthropic
+# ``__getattr__`` (lazy SDK load).  Defer to function scope so the
+# cold-start path does not pull anthropic at module import.
+from core.hooks.system import HookEvent
 from core.llm.providers.anthropic import (
     FALLBACK_MODELS,
     get_anthropic_client,
@@ -13,10 +17,6 @@ from core.llm.providers.anthropic import (
 from core.llm.providers.anthropic import (
     system_with_cache as _system_with_cache,
 )
-
-# v0.88.0 — RETRYABLE_ERRORS resolves through providers/anthropic
-# ``__getattr__`` (lazy SDK load).  Defer to function scope so the
-# cold-start path does not pull anthropic at module import.
 from core.llm.router._hooks import _fire_hook
 from core.llm.router._usage import _record_response_usage
 
@@ -48,7 +48,7 @@ def call_llm_streaming(
 
     # Hook: LLM_CALL_START
     _fire_hook(
-        "llm_call_start",
+        HookEvent.LLM_CALL_START,
         {"model": target_model, "provider": provider, "function": "call_llm_streaming"},
     )
     t0 = time.monotonic()
@@ -79,7 +79,7 @@ def call_llm_streaming(
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                "llm_call_end",
+                HookEvent.LLM_CALL_END,
                 {
                     "model": target_model,
                     "provider": provider,
@@ -92,7 +92,7 @@ def call_llm_streaming(
         else:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                "llm_call_end",
+                HookEvent.LLM_CALL_END,
                 {
                     "model": target_model,
                     "provider": provider,

--- a/core/llm/router/calls/text.py
+++ b/core/llm/router/calls/text.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 
+from core.hooks.system import HookEvent
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
     _get_provider_client,
@@ -49,7 +50,7 @@ def call_llm(
 
     def _dispatch(p: str, m: str) -> str:
         _fire_hook(
-            "llm_call_start",
+            HookEvent.LLM_CALL_START,
             {"model": m, "provider": p, "function": "call_llm"},
         )
         t0 = time.monotonic()
@@ -96,7 +97,7 @@ def call_llm(
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                "llm_call_end",
+                HookEvent.LLM_CALL_END,
                 {
                     "model": m,
                     "provider": p,
@@ -109,7 +110,7 @@ def call_llm(
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         _fire_hook(
-            "llm_call_end",
+            HookEvent.LLM_CALL_END,
             {
                 "model": m,
                 "provider": p,

--- a/core/llm/router/calls/tools.py
+++ b/core/llm/router/calls/tools.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Any
 
+from core.hooks.system import HookEvent
 from core.llm.provider_dispatch import (
     _cross_provider_dispatch,
     _get_provider_client,
@@ -50,7 +51,7 @@ def call_llm_with_tools(
 
     def _dispatch(p: str, m: str) -> ToolUseResult:
         _fire_hook(
-            "llm_call_start",
+            HookEvent.LLM_CALL_START,
             {"model": m, "provider": p, "function": "call_llm_with_tools"},
         )
         t0_tools = time.monotonic()
@@ -197,7 +198,7 @@ def call_llm_with_tools(
         except Exception as exc:
             elapsed_ms_total = (time.monotonic() - t0_tools) * 1000
             _fire_hook(
-                "llm_call_end",
+                HookEvent.LLM_CALL_END,
                 {
                     "model": m,
                     "provider": p,
@@ -210,7 +211,7 @@ def call_llm_with_tools(
 
         elapsed_ms_total = (time.monotonic() - t0_tools) * 1000
         _fire_hook(
-            "llm_call_end",
+            HookEvent.LLM_CALL_END,
             {
                 "model": m,
                 "provider": p,

--- a/core/mcp/manager.py
+++ b/core/mcp/manager.py
@@ -44,16 +44,19 @@ def set_mcp_hooks(hooks: Any) -> None:
     _mcp_hooks = hooks
 
 
-def _fire_mcp_hook(event_name: str, data: dict[str, Any]) -> None:
-    """Fire a hook event if HookSystem is available."""
+def _fire_mcp_hook(event: Any, data: dict[str, Any]) -> None:
+    """Fire a hook event if HookSystem is available.
+
+    ``event`` is a ``HookEvent`` member (typed via ``Any`` only so the
+    annotation does not require importing HookEvent at module top level,
+    which would create a circular dependency in some bootstrap paths).
+    """
     if _mcp_hooks is None:
         return
     try:
-        from core.hooks import HookEvent
-
-        _mcp_hooks.trigger(HookEvent(event_name), data)
+        _mcp_hooks.trigger(event, data)
     except Exception:
-        log.debug("MCP hook fire failed for %s", event_name, exc_info=True)
+        log.debug("MCP hook fire failed for %s", event, exc_info=True)
 
 
 # Singleton instance — prevents duplicate MCP server processes
@@ -414,14 +417,16 @@ class MCPServerManager:
             )
             return None
 
+        from core.hooks import HookEvent
+
         client = StdioMCPClient(command=command, args=args, env=env)
         if client.connect():
             self._clients[server_name] = client
-            _fire_mcp_hook("mcp_server_connected", {"server_name": server_name})
+            _fire_mcp_hook(HookEvent.MCP_SERVER_CONNECTED, {"server_name": server_name})
             return client
 
         _fire_mcp_hook(
-            "mcp_server_failed",
+            HookEvent.MCP_SERVER_FAILED,
             {"server_name": server_name, "error": "Connection failed"},
         )
         log.debug("MCP server not available (skipped): %s", server_name)

--- a/core/tools/memory_tools.py
+++ b/core/tools/memory_tools.py
@@ -16,6 +16,7 @@ import logging
 from contextvars import ContextVar
 from typing import Any
 
+from core.hooks.system import HookEvent
 from core.hooks.utils import fire_hook
 from core.memory.organization import MonoLakeOrganizationMemory
 from core.memory.port import SessionStorePort
@@ -61,9 +62,9 @@ def set_memory_hooks(hooks: Any) -> None:
     _hooks_ctx.set(hooks)
 
 
-def _fire_hook(event_name: str, data: dict[str, Any]) -> None:
+def _fire_hook(event: HookEvent, data: dict[str, Any]) -> None:
     """Fire a hook event using the ContextVar-bound HookSystem (or no-op)."""
-    fire_hook(_hooks_ctx.get(), event_name, data)
+    fire_hook(_hooks_ctx.get(), event, data)
 
 
 def _get_session_store(store: SessionStorePort | None = None) -> SessionStorePort:
@@ -335,7 +336,7 @@ class MemorySaveTool:
                     insight = str(data.get("content", data))
                     proj.add_insight(insight)
 
-        _fire_hook("memory_saved", {"key": session_id, "persistent": persistent})
+        _fire_hook(HookEvent.MEMORY_SAVED, {"key": session_id, "persistent": persistent})
 
         return {
             "result": {
@@ -400,7 +401,7 @@ class RuleCreateTool:
 
         success = proj.create_rule(rule_name, paths, content)
         if success:
-            _fire_hook("rule_created", {"name": rule_name, "paths": paths})
+            _fire_hook(HookEvent.RULE_CREATED, {"name": rule_name, "paths": paths})
         return {
             "result": {
                 "created": success,
@@ -451,7 +452,7 @@ class RuleUpdateTool:
 
         success = proj.update_rule(rule_name, content)
         if success:
-            _fire_hook("rule_updated", {"name": rule_name})
+            _fire_hook(HookEvent.RULE_UPDATED, {"name": rule_name})
         return {
             "result": {
                 "updated": success,
@@ -493,7 +494,7 @@ class RuleDeleteTool:
 
         success = proj.delete_rule(rule_name)
         if success:
-            _fire_hook("rule_deleted", {"name": rule_name})
+            _fire_hook(HookEvent.RULE_DELETED, {"name": rule_name})
         return {
             "result": {
                 "deleted": success,


### PR DESCRIPTION
## Summary

- 50+ \`_fire_hook("event_name", data)\` 형태 호출을 \`HookEvent.EVENT_NAME\` 직접 참조로 변환
- 8 wrapper 함수 signature 강타입화 (\`event_name: str\` → \`event: HookEvent\`)
- 부수 수정: \`_failover.py\` 의 silent-drop emit (\`"retry_wait"\` 라는 비-enum string) 을 \`LLM_CALL_RETRY\` 로 라우팅

## Why

Stage C audit 에서 발견: 동일 hook 시스템 안에서 emit 방식이 두 가지로 갈려 있었음 — 50 사이트는 \`HookEvent.X\` 직접, 8 (실제로 12 — TOOL_EXEC 4 포함) 사이트는 \`_fire_hook("x", data)\` 의 string-literal. 후자는 wrapper 내부 \`HookEvent(event_name)\` lookup + try/except 으로 typo 가 silent failure 가 됨. enum 이름 바꾸면 string 안 따라가서 disconnect 가능. 일관성 + type safety 회복 목적.

## Changes

| File | 변경 |
|------|--------|
| \`core/tools/memory_tools.py\` | MEMORY_SAVED + RULE_*×3 (4 사이트) |
| \`core/llm/provider_dispatch.py\` | FALLBACK_CROSS_PROVIDER (1 사이트) |
| \`core/llm/router/calls/{text,tools,parsed,streaming}.py\` | LLM_CALL_START/END (12 사이트) |
| \`core/llm/router/calls/_failover.py\` | retry_wait silent-drop → LLM_CALL_RETRY 라우팅 |
| \`core/llm/router/_hooks.py\` | wrapper signature 강타입화 |
| \`core/mcp/manager.py\` | MCP_SERVER_CONNECTED/FAILED (2 사이트) |
| \`core/agent/approval.py\` | TOOL_APPROVAL_*×3 (21 사이트) |
| \`core/agent/tool_executor/executor.py\` | TOOL_APPROVAL_*×3 (6 사이트) |
| \`core/agent/tool_executor/processor.py\` | TOOL_EXEC_*×4 + TOOL_RECOVERY_*×3 (7 사이트), wrapper 3 signature |
| \`CHANGELOG.md\` | \`[Unreleased] > Changed\` KR/EN |

## 부수 발견 / 수정 — \`retry_wait\` silent-drop

\`core/llm/router/calls/_failover.py:118\` 가 다음 패턴으로 emit:

\`\`\`python
_fire_hook("retry_wait", {model, attempt, max_retries, delay_s, elapsed_s, error_type})
\`\`\`

\`"retry_wait"\` 는 HookEvent enum 의 어떤 member 와도 매칭 안 됨 → \`HookEvent("retry_wait")\` ValueError → \`fire_hook\` 의 try/except 가 silent swallow. 즉 retry loop 매 iteration 마다 hook 이 silent drop 됐음.

payload schema 가 \`LLM_CALL_RETRY\` 와 정확히 일치 (enum 값 \`"llm_call_retry"\`, 동일 의미) 하므로 그 enum 으로 라우팅. **행위 변경**: 이전엔 drop, 이제 RunLog wildcard + 미래의 LLM_CALL_RETRY listener 가 받음.

## Verification

- [x] \`uv run ruff check core/ tests/ plugins/\` — 0 errors (5 import-order 자동 수정 후)
- [x] \`uv run mypy core/ plugins/\` — 0 errors (359 source files)
- [x] \`uv run pytest tests/ -m "not live"\` — **4760 passed, 24 skipped**
- [x] \`uv run pytest -k "hook or approval or tool_executor or memory_tool or llm_router or mcp_manager"\` — 272 passed
- [x] \`grep -rE '_fire_hook\(\s*"[a-z_]+"' core/\` — 0 hits (잔존 사이트 없음)

## Follow-up

- **Stage B** — lifecycle event 명명 정규화 (\`_START\` ↔ \`_STARTED\`, \`_COMPLETE\` ↔ \`_COMPLETED\`, \`_END\` 통일). string value 는 보존하여 RunLog JSONL 호환성 유지.