### PR TITLE
release: Stage B — HookEvent 명명 past-tense 정규화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,54 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Changed
 
+- **HookEvent 명명 정규화 (Stage B) — lifecycle 이벤트 past-tense 통일.**
+  Stage C audit 에서 식별된 시제 비일관 (`PIPELINE_START` vs
+  `SUBAGENT_STARTED`, `TURN_COMPLETE` vs `SUBAGENT_COMPLETED`,
+  `LLM_CALL_END` vs `*_COMPLETED`) 정리. 15 개 enum identifier 를 past
+  tense 로 통일: `_START` → `_STARTED`, `_END` → `_ENDED`, `_COMPLETE` →
+  `_COMPLETED`, `_ENTER`/`_EXIT` → `_ENTERED`/`_EXITED`, `_RETRY` →
+  `_RETRIED`. 컨벤션:
+  - Lifecycle pair (success+error 모두 fire): `*_STARTED`/`*_ENDED` →
+    `PIPELINE_*`, `LLM_CALL_*`, `TOOL_EXEC_*`, `SESSION_*`
+  - Direction: `*_ENTERED`/`*_EXITED` → `NODE_*`
+  - Success milestone: `*_COMPLETED` → `TURN_*`, `ANALYST_*`,
+    `EVALUATOR_*`, `SCORING_*`
+  - Action past: `*_RETRIED` → `LLM_CALL_*`
+
+  **String value 보존**: 모든 enum 의 string 값은 그대로 유지 (`"pipeline_start"`,
+  `"turn_complete"`, ...). RunLog JSONL 의 `event:` 필드 + 외부 plugin
+  / log consumer 호환성 무영향. Python identifier (enum member 이름) 만
+  바뀐다. 233 caller 사이트 일괄 sed 변환 (28 파일), `_E.X` alias 사용
+  4 사이트 추가 수정. SUBAGENT_*, TOOL_APPROVAL_*, TOOL_RECOVERY_*,
+  MEMORY/RULE_*, DRIFT_DETECTED, MODEL_PROMOTED, SNAPSHOT_CAPTURED,
+  TRIGGER_FIRED, SHUTDOWN_STARTED 등 이미 past-tense 이거나 도메인
+  특화 의미 (request-decision, attempt-outcome) 는 그대로.
+- **HookEvent naming normalization (Stage B) — past-tense uniformity
+  for lifecycle events.** Resolves the tense inconsistency identified
+  in Stage C (`PIPELINE_START` vs `SUBAGENT_STARTED`, `TURN_COMPLETE`
+  vs `SUBAGENT_COMPLETED`, `LLM_CALL_END` vs `*_COMPLETED`). Renamed
+  15 enum identifiers to past tense: `_START` → `_STARTED`, `_END` →
+  `_ENDED`, `_COMPLETE` → `_COMPLETED`, `_ENTER`/`_EXIT` →
+  `_ENTERED`/`_EXITED`, `_RETRY` → `_RETRIED`. Convention:
+  - Lifecycle pair (fires on success + error): `*_STARTED`/`*_ENDED`
+    — `PIPELINE_*`, `LLM_CALL_*`, `TOOL_EXEC_*`, `SESSION_*`
+  - Direction: `*_ENTERED`/`*_EXITED` — `NODE_*`
+  - Success milestone: `*_COMPLETED` — `TURN_*`, `ANALYST_*`,
+    `EVALUATOR_*`, `SCORING_*`
+  - Action past: `*_RETRIED` — `LLM_CALL_*`
+
+  **String values preserved**: all enum string values are unchanged
+  (`"pipeline_start"`, `"turn_complete"`, ...). Zero impact on RunLog
+  JSONL `event:` field, external plugin compatibility, or downstream
+  log consumers — only the Python identifier (enum member name)
+  changes. 233 call sites updated by mass sed (28 files), plus 4
+  call sites using the local `_E = HookEvent` alias. Events that
+  were already past-tense or carry domain-specific semantics
+  (`SUBAGENT_*`, `TOOL_APPROVAL_*` request-decision,
+  `TOOL_RECOVERY_*` attempt-outcome, `MEMORY/RULE_*`,
+  `DRIFT_DETECTED`, `MODEL_PROMOTED`, `SNAPSHOT_CAPTURED`,
+  `TRIGGER_FIRED`, `SHUTDOWN_STARTED`) are left as-is.
+
 - **Hook emit 사이트 string-literal → direct enum (Stage A).** Stage C
   audit 후 발견된 50+ 호출 사이트에서 `_fire_hook("event_name", data)`
   / `_fire_interceptor("event_name", data)` / `_fire_with_result(

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -138,7 +138,7 @@ def finalize_and_return(
     loop._save_checkpoint(user_input, round_idx=round_idx)
     if loop._hooks:
         loop._hooks.trigger(
-            HookEvent.SESSION_END,
+            HookEvent.SESSION_ENDED,
             {
                 "model": loop.model,
                 "provider": loop._provider,
@@ -150,7 +150,7 @@ def finalize_and_return(
             },
         )
         loop._hooks.trigger(
-            HookEvent.TURN_COMPLETE,
+            HookEvent.TURN_COMPLETED,
             {
                 "user_input": user_input,
                 "text": result.text[:500] if result.text else "",

--- a/core/agent/loop/loop.py
+++ b/core/agent/loop/loop.py
@@ -406,7 +406,7 @@ class AgenticLoop:
         # Hook: SESSION_START
         if self._hooks:
             self._hooks.trigger(
-                HookEvent.SESSION_START,
+                HookEvent.SESSION_STARTED,
                 {
                     "model": self.model,
                     "provider": self._provider,
@@ -734,7 +734,7 @@ class AgenticLoop:
                         )
                     if self._hooks:
                         self._hooks.trigger(
-                            HookEvent.LLM_CALL_RETRY,
+                            HookEvent.LLM_CALL_RETRIED,
                             {
                                 "model": self.model,
                                 "provider": self._provider,

--- a/core/agent/tool_executor/processor.py
+++ b/core/agent/tool_executor/processor.py
@@ -217,7 +217,7 @@ class ToolCallProcessor:
 
             # Hook: TOOL_EXEC_START (interceptor — can block or modify input)
             intercept = self._fire_interceptor(
-                HookEvent.TOOL_EXEC_START, {"tool_name": tool_name, "tool_input": tool_input}
+                HookEvent.TOOL_EXEC_STARTED, {"tool_name": tool_name, "tool_input": tool_input}
             )
             if intercept is not None and intercept.blocked:
                 log.info("Tool %s blocked by TOOL_EXEC_START hook: %s", tool_name, intercept.reason)
@@ -246,7 +246,7 @@ class ToolCallProcessor:
                 "has_error": _has_error,
                 "result": result,
             }
-            post_results = self._fire_with_result(HookEvent.TOOL_EXEC_END, _post_data)
+            post_results = self._fire_with_result(HookEvent.TOOL_EXEC_ENDED, _post_data)
             # Apply result modifications from PostToolUse-style handlers
             for hr in post_results:
                 if hr.success and isinstance(hr.data, dict):

--- a/core/graph.py
+++ b/core/graph.py
@@ -82,9 +82,9 @@ _DEGRADABLE_NODES = frozenset({"analyst", "evaluator", "scoring"})
 
 # Node → specific hook event mapping
 _NODE_COMPLETION_EVENTS: dict[str, HookEvent] = {
-    "analyst": HookEvent.ANALYST_COMPLETE,
-    "evaluator": HookEvent.EVALUATOR_COMPLETE,
-    "scoring": HookEvent.SCORING_COMPLETE,
+    "analyst": HookEvent.ANALYST_COMPLETED,
+    "evaluator": HookEvent.EVALUATOR_COMPLETED,
+    "scoring": HookEvent.SCORING_COMPLETED,
 }
 
 
@@ -212,11 +212,11 @@ def _make_hooked_node(
                 effective_state = es_dict  # type: ignore[assignment]
 
         # NODE_ENTER
-        hooks.trigger(HookEvent.NODE_ENTER, hook_data)
+        hooks.trigger(HookEvent.NODE_ENTERED, hook_data)
 
         # PIPELINE_START (router is the first real node)
         if node_name == "router":
-            hooks.trigger(HookEvent.PIPELINE_START, hook_data)
+            hooks.trigger(HookEvent.PIPELINE_STARTED, hook_data)
 
         start_time = time.time()
 
@@ -262,7 +262,7 @@ def _make_hooked_node(
                         hook_data["final_score"] = score
 
                 # NODE_EXIT
-                hooks.trigger(HookEvent.NODE_EXIT, hook_data)
+                hooks.trigger(HookEvent.NODE_EXITED, hook_data)
 
                 # Node-specific completion events
                 if node_name in _NODE_COMPLETION_EVENTS:
@@ -297,7 +297,7 @@ def _make_hooked_node(
                     hook_data["final_score"] = effective_state.get("final_score", 0.0)
                     hook_data["tier"] = effective_state.get("tier", "")
                     hook_data["dry_run"] = effective_state.get("dry_run", False)
-                    hooks.trigger(HookEvent.PIPELINE_END, hook_data)
+                    hooks.trigger(HookEvent.PIPELINE_ENDED, hook_data)
 
                 return result
 
@@ -653,7 +653,7 @@ def _register_drift_scan_hook(hooks: HookSystem) -> None:
             )
 
     hooks.register(
-        HookEvent.SCORING_COMPLETE,
+        HookEvent.SCORING_COMPLETED,
         _on_scoring_complete,
         name="drift_scan_on_scoring",
         priority=50,

--- a/core/hooks/plugins/notification_hook/hook.py
+++ b/core/hooks/plugins/notification_hook/hook.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 # Event → severity mapping
 _SEVERITY_MAP: dict[HookEvent, str] = {
-    HookEvent.PIPELINE_END: "info",
+    HookEvent.PIPELINE_ENDED: "info",
     HookEvent.PIPELINE_ERROR: "critical",
     HookEvent.DRIFT_DETECTED: "warning",
     HookEvent.SUBAGENT_FAILED: "warning",
@@ -32,7 +32,7 @@ def _format_message(event: HookEvent, data: dict[str, Any]) -> str:
     """Format a notification message from hook event data."""
     ip_name = data.get("ip_name", "unknown")
 
-    if event == HookEvent.PIPELINE_END:
+    if event == HookEvent.PIPELINE_ENDED:
         tier = data.get("tier", "?")
         score = data.get("final_score", data.get("score", 0))
         return f"Pipeline completed: {ip_name} — {tier} ({score:.1f})"

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -28,21 +28,22 @@ log = logging.getLogger(__name__)
 class HookEvent(Enum):
     """Pipeline lifecycle events."""
 
-    # Pipeline level
-    PIPELINE_START = "pipeline_start"
-    PIPELINE_END = "pipeline_end"
+    # Pipeline level (lifecycle fires on success + error; ERROR is a distinct
+    # variant rather than a sub-state of ENDED, matching SUBAGENT_FAILED)
+    PIPELINE_STARTED = "pipeline_start"
+    PIPELINE_ENDED = "pipeline_end"
     PIPELINE_ERROR = "pipeline_error"
 
     # Node level
     NODE_BOOTSTRAP = "node_bootstrap"
-    NODE_ENTER = "node_enter"
-    NODE_EXIT = "node_exit"
+    NODE_ENTERED = "node_enter"
+    NODE_EXITED = "node_exit"
     NODE_ERROR = "node_error"
 
-    # Analysis level
-    ANALYST_COMPLETE = "analyst_complete"
-    EVALUATOR_COMPLETE = "evaluator_complete"
-    SCORING_COMPLETE = "scoring_complete"
+    # Analysis level (milestone — fires only on successful stage completion)
+    ANALYST_COMPLETED = "analyst_complete"
+    EVALUATOR_COMPLETED = "evaluator_complete"
+    SCORING_COMPLETED = "scoring_complete"
 
     # Verification level
     VERIFICATION_PASS = "verification_pass"  # noqa: S105 — hook event name, not a password
@@ -75,25 +76,29 @@ class HookEvent(Enum):
     TOOL_RECOVERY_SUCCEEDED = "tool_recovery_succeeded"
     TOOL_RECOVERY_FAILED = "tool_recovery_failed"
 
-    # Agentic turn lifecycle (OpenClaw command:new pattern)
-    TURN_COMPLETE = "turn_complete"
+    # Agentic turn lifecycle (OpenClaw command:new pattern; milestone-style —
+    # fires once per turn on completion)
+    TURN_COMPLETED = "turn_complete"
 
     # Context overflow detection (Karpathy P6 Context Budget)
     CONTEXT_CRITICAL = "context_critical"
     CONTEXT_OVERFLOW_ACTION = "context_overflow_action"
 
-    # Session lifecycle (OpenClaw agent:bootstrap pattern)
-    SESSION_START = "session_start"
-    SESSION_END = "session_end"
+    # Session lifecycle (OpenClaw agent:bootstrap pattern; lifecycle pair)
+    SESSION_STARTED = "session_start"
+    SESSION_ENDED = "session_end"
 
     # Model switching (L1 Observe)
     MODEL_SWITCHED = "model_switched"
 
-    # LLM call lifecycle (model-level latency/cost observability)
-    LLM_CALL_START = "llm_call_start"
-    LLM_CALL_END = "llm_call_end"
+    # LLM call lifecycle (model-level latency/cost observability; START/ENDED
+    # are the lifecycle pair, ENDED fires on success+error with ``error`` key,
+    # FAILED is a legacy alias retained for plugin compatibility, RETRIED is
+    # the action-past form for retry attempts)
+    LLM_CALL_STARTED = "llm_call_start"
+    LLM_CALL_ENDED = "llm_call_end"
     LLM_CALL_FAILED = "llm_call_failed"
-    LLM_CALL_RETRY = "llm_call_retry"
+    LLM_CALL_RETRIED = "llm_call_retry"
 
     # Tool approval HITL lifecycle
     TOOL_APPROVAL_REQUESTED = "tool_approval_requested"
@@ -119,10 +124,13 @@ class HookEvent(Enum):
     MCP_SERVER_CONNECTED = "mcp_server_connected"
     MCP_SERVER_FAILED = "mcp_server_failed"
 
-    # Production hooks (P0) — interceptor + cost enforcement + audit
+    # Production hooks (P0) — interceptor + cost enforcement + audit.
+    # TOOL_EXEC_STARTED / TOOL_EXEC_ENDED form the lifecycle pair; FAILED is the
+    # error variant. TOOL_RESULT_TRANSFORM is a separate feedback hook (post
+    # observation, result rewriting).
     USER_INPUT_RECEIVED = "user_input_received"
-    TOOL_EXEC_START = "tool_exec_start"
-    TOOL_EXEC_END = "tool_exec_end"
+    TOOL_EXEC_STARTED = "tool_exec_start"
+    TOOL_EXEC_ENDED = "tool_exec_end"
     TOOL_EXEC_FAILED = "tool_exec_failed"
     TOOL_RESULT_TRANSFORM = "tool_result_transform"
     COST_WARNING = "cost_warning"
@@ -190,8 +198,8 @@ class HookSystem:
         def on_start(event, data):
             print(f"Pipeline started for {data.get('ip_name')}")
 
-        hooks.register(HookEvent.PIPELINE_START, on_start, priority=10)
-        results = hooks.trigger(HookEvent.PIPELINE_START, {"ip_name": "Berserk"})
+        hooks.register(HookEvent.PIPELINE_STARTED, on_start, priority=10)
+        results = hooks.trigger(HookEvent.PIPELINE_STARTED, {"ip_name": "Berserk"})
     """
 
     # Events that support matcher-based tool_name filtering.
@@ -433,8 +441,8 @@ class HookSystem:
 # Populate _TOOL_EVENTS after HookEvent members are available.
 HookSystem._TOOL_EVENTS = frozenset(
     {
-        HookEvent.TOOL_EXEC_START,
-        HookEvent.TOOL_EXEC_END,
+        HookEvent.TOOL_EXEC_STARTED,
+        HookEvent.TOOL_EXEC_ENDED,
         HookEvent.TOOL_EXEC_FAILED,
         HookEvent.TOOL_RESULT_TRANSFORM,
     }

--- a/core/llm/router/calls/_failover.py
+++ b/core/llm/router/calls/_failover.py
@@ -121,7 +121,7 @@ async def call_with_failover(
                 # (model + attempt + max_retries + delay_s + elapsed_s + error_type)
                 # and unblocks any handler that listens to LLM_CALL_RETRY.
                 _fire_hook(
-                    HookEvent.LLM_CALL_RETRY,
+                    HookEvent.LLM_CALL_RETRIED,
                     {
                         "model": current_model,
                         "attempt": attempt + 1,

--- a/core/llm/router/calls/parsed.py
+++ b/core/llm/router/calls/parsed.py
@@ -55,7 +55,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
 
     def _dispatch(p: str, m: str) -> T:
         _fire_hook(
-            HookEvent.LLM_CALL_START,
+            HookEvent.LLM_CALL_STARTED,
             {"model": m, "provider": p, "function": "call_llm_parsed"},
         )
         t0 = time.monotonic()
@@ -114,7 +114,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                HookEvent.LLM_CALL_END,
+                HookEvent.LLM_CALL_ENDED,
                 {
                     "model": m,
                     "provider": p,
@@ -127,7 +127,7 @@ def call_llm_parsed(  # noqa: UP047 — PEP695 syntax requires Python 3.12+
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         _fire_hook(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {
                 "model": m,
                 "provider": p,

--- a/core/llm/router/calls/streaming.py
+++ b/core/llm/router/calls/streaming.py
@@ -48,7 +48,7 @@ def call_llm_streaming(
 
     # Hook: LLM_CALL_START
     _fire_hook(
-        HookEvent.LLM_CALL_START,
+        HookEvent.LLM_CALL_STARTED,
         {"model": target_model, "provider": provider, "function": "call_llm_streaming"},
     )
     t0 = time.monotonic()
@@ -79,7 +79,7 @@ def call_llm_streaming(
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                HookEvent.LLM_CALL_END,
+                HookEvent.LLM_CALL_ENDED,
                 {
                     "model": target_model,
                     "provider": provider,
@@ -92,7 +92,7 @@ def call_llm_streaming(
         else:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                HookEvent.LLM_CALL_END,
+                HookEvent.LLM_CALL_ENDED,
                 {
                     "model": target_model,
                     "provider": provider,

--- a/core/llm/router/calls/text.py
+++ b/core/llm/router/calls/text.py
@@ -50,7 +50,7 @@ def call_llm(
 
     def _dispatch(p: str, m: str) -> str:
         _fire_hook(
-            HookEvent.LLM_CALL_START,
+            HookEvent.LLM_CALL_STARTED,
             {"model": m, "provider": p, "function": "call_llm"},
         )
         t0 = time.monotonic()
@@ -97,7 +97,7 @@ def call_llm(
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
             _fire_hook(
-                HookEvent.LLM_CALL_END,
+                HookEvent.LLM_CALL_ENDED,
                 {
                     "model": m,
                     "provider": p,
@@ -110,7 +110,7 @@ def call_llm(
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         _fire_hook(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {
                 "model": m,
                 "provider": p,

--- a/core/llm/router/calls/tools.py
+++ b/core/llm/router/calls/tools.py
@@ -51,7 +51,7 @@ def call_llm_with_tools(
 
     def _dispatch(p: str, m: str) -> ToolUseResult:
         _fire_hook(
-            HookEvent.LLM_CALL_START,
+            HookEvent.LLM_CALL_STARTED,
             {"model": m, "provider": p, "function": "call_llm_with_tools"},
         )
         t0_tools = time.monotonic()
@@ -198,7 +198,7 @@ def call_llm_with_tools(
         except Exception as exc:
             elapsed_ms_total = (time.monotonic() - t0_tools) * 1000
             _fire_hook(
-                HookEvent.LLM_CALL_END,
+                HookEvent.LLM_CALL_ENDED,
                 {
                     "model": m,
                     "provider": p,
@@ -211,7 +211,7 @@ def call_llm_with_tools(
 
         elapsed_ms_total = (time.monotonic() - t0_tools) * 1000
         _fire_hook(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {
                 "model": m,
                 "provider": p,

--- a/core/memory/journal_hooks.py
+++ b/core/memory/journal_hooks.py
@@ -27,7 +27,7 @@ def make_journal_handlers(
     """
 
     def _on_pipeline_end(event: HookEvent, data: dict[str, Any]) -> None:
-        if event != HookEvent.PIPELINE_END:
+        if event != HookEvent.PIPELINE_ENDED:
             return
         ip_name = data.get("ip_name", "")
         tier = data.get("tier", "")

--- a/core/orchestration/stuck_detection.py
+++ b/core/orchestration/stuck_detection.py
@@ -195,8 +195,8 @@ class StuckDetector:
 
         self._on_stuck = _on_stuck_fire_hook
 
-        hooks.register(HookEvent.NODE_ENTER, _on_enter, name="stuck_detector_enter", priority=90)
-        hooks.register(HookEvent.NODE_EXIT, _on_exit, name="stuck_detector_exit", priority=90)
+        hooks.register(HookEvent.NODE_ENTERED, _on_enter, name="stuck_detector_enter", priority=90)
+        hooks.register(HookEvent.NODE_EXITED, _on_exit, name="stuck_detector_exit", priority=90)
         hooks.register(HookEvent.NODE_ERROR, _on_error, name="stuck_detector_error", priority=90)
         log.debug("StuckDetector registered on HookSystem")
 

--- a/core/orchestration/task_bridge.py
+++ b/core/orchestration/task_bridge.py
@@ -74,13 +74,13 @@ class TaskGraphHookBridge:
         """Register NODE_ENTER/EXIT/ERROR handlers on the HookSystem."""
         self._hooks = hooks
         hooks.register(
-            HookEvent.NODE_ENTER,
+            HookEvent.NODE_ENTERED,
             self._on_node_enter,
             name="task_bridge_enter",
             priority=30,
         )
         hooks.register(
-            HookEvent.NODE_EXIT,
+            HookEvent.NODE_EXITED,
             self._on_node_exit,
             name="task_bridge_exit",
             priority=30,
@@ -97,8 +97,8 @@ class TaskGraphHookBridge:
         if self._hooks is None:
             return
         for event, name in [
-            (HookEvent.NODE_ENTER, "task_bridge_enter"),
-            (HookEvent.NODE_EXIT, "task_bridge_exit"),
+            (HookEvent.NODE_ENTERED, "task_bridge_enter"),
+            (HookEvent.NODE_EXITED, "task_bridge_exit"),
             (HookEvent.NODE_ERROR, "task_bridge_error"),
         ]:
             self._hooks.unregister(event, name)

--- a/core/wiring/automation.py
+++ b/core/wiring/automation.py
@@ -237,7 +237,7 @@ def wire_automation_hooks(
             )
 
     hooks.register(
-        HookEvent.PIPELINE_END,
+        HookEvent.PIPELINE_ENDED,
         _on_pipeline_end_snapshot,
         name="pipeline_end_snapshot",
         priority=80,
@@ -272,7 +272,7 @@ def wire_automation_hooks(
                 log.debug("Drift scan on SCORING_COMPLETE failed", exc_info=True)
 
         hooks.register(
-            HookEvent.SCORING_COMPLETE,
+            HookEvent.SCORING_COMPLETED,
             _on_scoring_drift,
             name="scoring_drift_scan",
             priority=60,
@@ -299,7 +299,7 @@ def wire_automation_hooks(
                 log.debug("Outcome scheduling on PIPELINE_END failed", exc_info=True)
 
         hooks.register(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             _on_pipeline_end_outcomes,
             name="pipeline_end_outcomes",
             priority=70,

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -100,9 +100,9 @@ def _make_stuck_hook_handler(
 
     def _track_lifecycle(event: HookEvent, data: dict[str, Any]) -> None:
         session_key = data.get("ip_name", "")
-        if event == HookEvent.PIPELINE_START:
+        if event == HookEvent.PIPELINE_STARTED:
             detector.mark_running(session_key, metadata=data)
-        elif event in (HookEvent.PIPELINE_END, HookEvent.PIPELINE_ERROR):
+        elif event in (HookEvent.PIPELINE_ENDED, HookEvent.PIPELINE_ERROR):
             detector.mark_completed(session_key)
 
     return "stuck_tracker", _track_lifecycle
@@ -172,7 +172,7 @@ def build_hooks(
     # Stuck detector + hook handler
     stuck_detector = StuckDetector(timeout_s=stuck_timeout_s)
     stuck_name, stuck_fn = _make_stuck_hook_handler(stuck_detector)
-    for event in (HookEvent.PIPELINE_START, HookEvent.PIPELINE_END, HookEvent.PIPELINE_ERROR):
+    for event in (HookEvent.PIPELINE_STARTED, HookEvent.PIPELINE_ENDED, HookEvent.PIPELINE_ERROR):
         hooks.register(event, stuck_fn, name=stuck_name, priority=40)
 
     # Context overflow action handler (CONTEXT_OVERFLOW_ACTION -> strategy recommendation)
@@ -212,7 +212,7 @@ def build_hooks(
         journal = get_project_journal()
         for handler_name, handler_fn in make_journal_handlers(journal):
             target_events = {
-                "journal_pipeline_end": [HookEvent.PIPELINE_END],
+                "journal_pipeline_end": [HookEvent.PIPELINE_ENDED],
                 "journal_pipeline_error": [HookEvent.PIPELINE_ERROR],
                 "journal_subagent": [HookEvent.SUBAGENT_COMPLETED],
             }
@@ -240,7 +240,7 @@ def build_hooks(
             pm.add_insight(insight)
 
         hooks.register(
-            HookEvent.TURN_COMPLETE,
+            HookEvent.TURN_COMPLETED,
             _on_turn_complete,
             name="turn_auto_memory",
             priority=85,
@@ -255,7 +255,7 @@ def build_hooks(
 
         name, handler = make_auto_learn_handler(profile_provider=get_user_profile)
         hooks.register(
-            HookEvent.TURN_COMPLETE,
+            HookEvent.TURN_COMPLETED,
             handler,
             name=name,
             priority=84,
@@ -269,7 +269,7 @@ def build_hooks(
 
         name, handler = make_llm_extract_handler()
         hooks.register(
-            HookEvent.TURN_COMPLETE,
+            HookEvent.TURN_COMPLETED,
             handler,
             name=name,
             priority=82,  # lower priority than auto_learn (84)
@@ -290,13 +290,13 @@ def build_hooks(
             log.info("Session ended: model=%s", data.get("model"))
 
         hooks.register(
-            HookEvent.SESSION_START,
+            HookEvent.SESSION_STARTED,
             _on_session_start,
             name="session_start_logger",
             priority=90,
         )
         hooks.register(
-            HookEvent.SESSION_END,
+            HookEvent.SESSION_ENDED,
             _on_session_end,
             name="session_end_logger",
             priority=90,
@@ -356,7 +356,7 @@ def build_hooks(
                 )
 
         hooks.register(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             _on_llm_end,
             name="llm_slow_logger",
             priority=55,
@@ -411,7 +411,7 @@ def build_hooks(
             ["usage_pct", "model"],
         ),
         (_E.SUBAGENT_STARTED, "sa_started", "SubAgent started: %s (%s)", ["task_id", "task_type"]),
-        (_E.LLM_CALL_START, "llm_start", "LLM call: %s (%s)", ["model", "function"]),
+        (_E.LLM_CALL_STARTED, "llm_start", "LLM call: %s (%s)", ["model", "function"]),
         (_E.VERIFICATION_FAIL, "verif_fail", "Verification failed: %s — %s", ["node", "ip_name"]),
         (_E.TOOL_RECOVERY_ATTEMPTED, "recovery_try", "Tool recovery attempted: %s", ["tool_name"]),
         (
@@ -433,8 +433,8 @@ def build_hooks(
         (_E.MCP_SERVER_FAILED, "mcp_fail", "MCP server failed: %s — %s", ["server_name", "error"]),
         # P0 production hooks
         (_E.USER_INPUT_RECEIVED, "user_input", "User input received: session=%s", ["session_id"]),
-        (_E.TOOL_EXEC_START, "tool_start", "Tool exec start: %s", ["tool_name"]),
-        (_E.TOOL_EXEC_END, "tool_end", "Tool exec end: %s (%.0fms)", ["tool_name", "duration_ms"]),
+        (_E.TOOL_EXEC_STARTED, "tool_start", "Tool exec start: %s", ["tool_name"]),
+        (_E.TOOL_EXEC_ENDED, "tool_end", "Tool exec end: %s (%.0fms)", ["tool_name", "duration_ms"]),
         (
             _E.TOOL_EXEC_FAILED,
             "tool_failed",
@@ -462,7 +462,7 @@ def build_hooks(
         (_E.EXECUTION_CANCELLED, "exec_cancel", "Execution cancelled: %s", ["session_id"]),
         # Asymmetry fixes — events that had triggers but no audit logger
         (_E.LLM_CALL_FAILED, "llm_failed", "LLM call FAILED: %s — %s", ["model", "error_type"]),
-        (_E.LLM_CALL_RETRY, "llm_retry", "LLM call retry: %s (attempt %s)", ["model", "attempt"]),
+        (_E.LLM_CALL_RETRIED, "llm_retry", "LLM call retry: %s (attempt %s)", ["model", "attempt"]),
         (
             _E.TOOL_RECOVERY_SUCCEEDED,
             "recovery_ok",
@@ -794,7 +794,7 @@ def build_tool_offload(
             store.cleanup_session()
 
         hooks.register(
-            HookEvent.SESSION_END,
+            HookEvent.SESSION_ENDED,
             _cleanup_offload,
             name="tool_offload_cleanup",
             priority=95,

--- a/tests/test_auto_learn.py
+++ b/tests/test_auto_learn.py
@@ -157,7 +157,7 @@ class TestAutoLearnHandler:
 
         with patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile):
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I am a game designer at Nexon", "tool_calls": []},
             )
 
@@ -172,7 +172,7 @@ class TestAutoLearnHandler:
         with patch("core.tools.profile_tools.get_user_profile", return_value=None):
             # Should not raise
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I am a game designer at Nexon", "tool_calls": []},
             )
 
@@ -182,12 +182,12 @@ class TestAutoLearnHandler:
 
         with patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile):
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I am a game designer at Nexon", "tool_calls": []},
             )
             # Second call within cooldown — should be suppressed
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I prefer concise answers always", "tool_calls": []},
             )
 
@@ -203,7 +203,7 @@ class TestAutoLearnHandler:
         ):
             for i in range(_MAX_PER_SESSION + 5):
                 handler(
-                    HookEvent.TURN_COMPLETE,
+                    HookEvent.TURN_COMPLETED,
                     {"user_input": f"I am developer number {i} at company", "tool_calls": []},
                 )
 
@@ -220,11 +220,11 @@ class TestAutoLearnHandler:
             patch("core.hooks.auto_learn._COOLDOWN_S", 0),
         ):
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I am a game designer at Nexon", "tool_calls": []},
             )
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I prefer dark fantasy game IPs", "tool_calls": []},
             )
 
@@ -239,7 +239,7 @@ class TestAutoLearnHandler:
         with patch("core.tools.profile_tools.get_user_profile", return_value=mock_profile):
             # Should not raise
             handler(
-                HookEvent.TURN_COMPLETE,
+                HookEvent.TURN_COMPLETED,
                 {"user_input": "I am a game designer at Nexon", "tool_calls": []},
             )
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -68,11 +68,11 @@ class TestBootstrapManager:
             event_order.append("enter")
 
         hooks.register(HookEvent.NODE_BOOTSTRAP, on_bootstrap)
-        hooks.register(HookEvent.NODE_ENTER, on_enter)
+        hooks.register(HookEvent.NODE_ENTERED, on_enter)
 
         # Simulate the sequence: bootstrap fires first, then enter
         mgr.prepare_node("router", "Berserk", {})
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "router"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router"})
 
         assert event_order == ["bootstrap", "enter"]
 
@@ -364,8 +364,8 @@ class TestMakeHookedNodeWithBootstrap:
         def track_events(event: HookEvent, data: dict[str, Any]) -> None:
             events_fired.append(event)
 
-        hooks.register(HookEvent.NODE_ENTER, track_events)
-        hooks.register(HookEvent.NODE_EXIT, track_events)
+        hooks.register(HookEvent.NODE_ENTERED, track_events)
+        hooks.register(HookEvent.NODE_EXITED, track_events)
 
         def fake_node(state: dict[str, Any]) -> dict[str, Any]:
             return {"value": 42}
@@ -375,8 +375,8 @@ class TestMakeHookedNodeWithBootstrap:
         result = wrapped({"ip_name": "Berserk"})  # type: ignore[arg-type]
 
         assert result == {"value": 42}
-        assert HookEvent.NODE_ENTER in events_fired
-        assert HookEvent.NODE_EXIT in events_fired
+        assert HookEvent.NODE_ENTERED in events_fired
+        assert HookEvent.NODE_EXITED in events_fired
         # NODE_BOOTSTRAP should NOT fire
         assert HookEvent.NODE_BOOTSTRAP not in events_fired
 
@@ -398,8 +398,8 @@ class TestMakeHookedNodeWithBootstrap:
             event_order.append("exit")
 
         hooks.register(HookEvent.NODE_BOOTSTRAP, on_bootstrap)
-        hooks.register(HookEvent.NODE_ENTER, on_enter)
-        hooks.register(HookEvent.NODE_EXIT, on_exit)
+        hooks.register(HookEvent.NODE_ENTERED, on_enter)
+        hooks.register(HookEvent.NODE_EXITED, on_exit)
 
         def fake_node(state: dict[str, Any]) -> dict[str, Any]:
             return {"done": True}

--- a/tests/test_e2e_orchestration_live.py
+++ b/tests/test_e2e_orchestration_live.py
@@ -101,8 +101,8 @@ class TestPipelineHookEventFlow:
         def on_exit(event: HookEvent, data: dict[str, Any]) -> None:
             exits.append(data.get("node", "unknown"))
 
-        hooks.register(HookEvent.NODE_ENTER, on_enter, name="enter_tracker")
-        hooks.register(HookEvent.NODE_EXIT, on_exit, name="exit_tracker")
+        hooks.register(HookEvent.NODE_ENTERED, on_enter, name="enter_tracker")
+        hooks.register(HookEvent.NODE_EXITED, on_exit, name="exit_tracker")
 
         graph = compile_graph(hooks=hooks)
         state: GeodeState = {
@@ -325,7 +325,7 @@ class TestEndToEndExecutionFlow:
         def track_node(event: HookEvent, data: dict[str, Any]) -> None:
             node_sequence.append(data.get("node", "?"))
 
-        hooks.register(HookEvent.NODE_ENTER, track_node, name="seq_tracker")
+        hooks.register(HookEvent.NODE_ENTERED, track_node, name="seq_tracker")
 
         graph = compile_graph(hooks=hooks)
         state: GeodeState = {
@@ -369,7 +369,7 @@ class TestEndToEndExecutionFlow:
             atype = data.get("_analyst_type", data.get("node", "unknown"))
             analyst_nodes.append(atype)
 
-        hooks.register(HookEvent.ANALYST_COMPLETE, track_analyst, name="analyst_track")
+        hooks.register(HookEvent.ANALYST_COMPLETED, track_analyst, name="analyst_track")
 
         graph = compile_graph(hooks=hooks)
         state: GeodeState = {

--- a/tests/test_hook_discovery.py
+++ b/tests/test_hook_discovery.py
@@ -77,7 +77,7 @@ def _make_class_plugin(
     plugin_dir.mkdir(parents=True, exist_ok=True)
 
     if events is None:
-        events = ["HookEvent.NODE_ENTER"]
+        events = ["HookEvent.NODE_ENTERED"]
     events_list = ", ".join(events)
 
     if class_body is None:
@@ -123,7 +123,7 @@ class TestYAMLDiscovery:
         assert len(found) == 1
         meta = found[0]
         assert meta.name == "my-yaml-hook"
-        assert HookEvent.NODE_EXIT in meta.events
+        assert HookEvent.NODE_EXITED in meta.events
         assert HookEvent.NODE_ERROR in meta.events
         assert meta.priority == 50
 
@@ -137,7 +137,7 @@ class TestYAMLDiscovery:
         hooks = HookSystem()
         loader.register_all(hooks)
 
-        results = hooks.trigger(HookEvent.PIPELINE_START, {"ip": "test"})
+        results = hooks.trigger(HookEvent.PIPELINE_STARTED, {"ip": "test"})
         assert len(results) == 1
         assert results[0].success is True
         assert results[0].handler_name == "fire-test"
@@ -150,16 +150,16 @@ class TestYAMLDiscovery:
 
 class TestClassDiscovery:
     def test_discover_class_plugin(self, hooks_dir: Path) -> None:
-        _make_class_plugin(hooks_dir, "my-class-hook", events=["HookEvent.NODE_ENTER"])
+        _make_class_plugin(hooks_dir, "my-class-hook", events=["HookEvent.NODE_ENTERED"])
 
         found = discover_hooks([hooks_dir])
         assert len(found) == 1
         meta = found[0]
         assert meta.name == "my-class-hook"
-        assert HookEvent.NODE_ENTER in meta.events
+        assert HookEvent.NODE_ENTERED in meta.events
 
     def test_class_plugin_fires(self, hooks_dir: Path) -> None:
-        _make_class_plugin(hooks_dir, "class-fire", events=["HookEvent.NODE_EXIT"])
+        _make_class_plugin(hooks_dir, "class-fire", events=["HookEvent.NODE_EXITED"])
 
         loader = HookPluginLoader()
         plugins = loader.load_from_dirs([hooks_dir])
@@ -168,7 +168,7 @@ class TestClassDiscovery:
         hooks = HookSystem()
         loader.register_all(hooks)
 
-        results = hooks.trigger(HookEvent.NODE_EXIT, {"node": "analyst"})
+        results = hooks.trigger(HookEvent.NODE_EXITED, {"node": "analyst"})
         assert len(results) == 1
         assert results[0].success is True
         assert results[0].handler_name == "class-fire"
@@ -233,7 +233,7 @@ class TestRegistration:
         hooks = HookSystem()
         loader.register_all(hooks)
 
-        results = hooks.trigger(HookEvent.NODE_EXIT, {"order": order})
+        results = hooks.trigger(HookEvent.NODE_EXITED, {"order": order})
         assert len(results) == 2
         assert all(r.success for r in results)
         assert order == ["high", "low"]
@@ -285,7 +285,7 @@ class TestEdgeCases:
         _make_class_plugin(
             hooks_dir,
             "disabled-class",
-            events=["HookEvent.NODE_ENTER"],
+            events=["HookEvent.NODE_ENTERED"],
             enabled=False,
         )
 

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -15,8 +15,8 @@ class TestMakeHookedNode:
             triggered_events.append(event)
 
         hooks = HookSystem()
-        hooks.register(HookEvent.NODE_ENTER, recorder)
-        hooks.register(HookEvent.NODE_EXIT, recorder)
+        hooks.register(HookEvent.NODE_ENTERED, recorder)
+        hooks.register(HookEvent.NODE_EXITED, recorder)
 
         def dummy_node(state: GeodeState) -> dict:
             return {"pipeline_mode": "test"}
@@ -25,8 +25,8 @@ class TestMakeHookedNode:
         result = hooked({"ip_name": "test"})
 
         assert result == {"pipeline_mode": "test"}
-        assert HookEvent.NODE_ENTER in triggered_events
-        assert HookEvent.NODE_EXIT in triggered_events
+        assert HookEvent.NODE_ENTERED in triggered_events
+        assert HookEvent.NODE_EXITED in triggered_events
 
     def test_triggers_error_on_exception(self):
         triggered_events = []
@@ -57,7 +57,7 @@ class TestMakeHookedNode:
             triggered_events.append(event)
 
         hooks = HookSystem()
-        hooks.register(HookEvent.PIPELINE_START, recorder)
+        hooks.register(HookEvent.PIPELINE_STARTED, recorder)
 
         def router_fn(state: GeodeState) -> dict:
             return {"pipeline_mode": "full_pipeline"}
@@ -65,7 +65,7 @@ class TestMakeHookedNode:
         hooked = _make_hooked_node(router_fn, "router", hooks)
         hooked({"ip_name": "test"})
 
-        assert HookEvent.PIPELINE_START in triggered_events
+        assert HookEvent.PIPELINE_STARTED in triggered_events
 
     def test_synthesizer_triggers_pipeline_end(self):
         triggered_events = []
@@ -74,7 +74,7 @@ class TestMakeHookedNode:
             triggered_events.append(event)
 
         hooks = HookSystem()
-        hooks.register(HookEvent.PIPELINE_END, recorder)
+        hooks.register(HookEvent.PIPELINE_ENDED, recorder)
 
         def synth_fn(state: GeodeState) -> dict:
             return {"synthesis": {}}
@@ -82,17 +82,17 @@ class TestMakeHookedNode:
         hooked = _make_hooked_node(synth_fn, "synthesizer", hooks)
         hooked({"ip_name": "test"})
 
-        assert HookEvent.PIPELINE_END in triggered_events
+        assert HookEvent.PIPELINE_ENDED in triggered_events
 
     def test_hook_data_contains_duration(self):
         captured_data = {}
 
         def recorder(event, data):
-            if event == HookEvent.NODE_EXIT:
+            if event == HookEvent.NODE_EXITED:
                 captured_data.update(data)
 
         hooks = HookSystem()
-        hooks.register(HookEvent.NODE_EXIT, recorder)
+        hooks.register(HookEvent.NODE_EXITED, recorder)
 
         def slow_node(state: GeodeState) -> dict:
             return {"result": "done"}
@@ -112,7 +112,7 @@ class TestMakeHookedNode:
             triggered_events.append(event)
 
         hooks = HookSystem()
-        hooks.register(HookEvent.SCORING_COMPLETE, recorder)
+        hooks.register(HookEvent.SCORING_COMPLETED, recorder)
 
         def scoring_fn(state: GeodeState) -> dict:
             return {"final_score": 82.0}
@@ -120,7 +120,7 @@ class TestMakeHookedNode:
         hooked = _make_hooked_node(scoring_fn, "scoring", hooks)
         hooked({"ip_name": "test"})
 
-        assert HookEvent.SCORING_COMPLETE in triggered_events
+        assert HookEvent.SCORING_COMPLETED in triggered_events
 
 
 class TestBuildGraphWithHooks:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -11,15 +11,15 @@ class TestHookEvent:
         assert len(HookEvent) == 58  # +2: TOOL_EXEC_FAILED, TOOL_RESULT_TRANSFORM
 
     def test_event_values(self):
-        assert HookEvent.PIPELINE_START.value == "pipeline_start"
-        assert HookEvent.PIPELINE_END.value == "pipeline_end"
+        assert HookEvent.PIPELINE_STARTED.value == "pipeline_start"
+        assert HookEvent.PIPELINE_ENDED.value == "pipeline_end"
         assert HookEvent.PIPELINE_ERROR.value == "pipeline_error"
-        assert HookEvent.NODE_ENTER.value == "node_enter"
-        assert HookEvent.NODE_EXIT.value == "node_exit"
+        assert HookEvent.NODE_ENTERED.value == "node_enter"
+        assert HookEvent.NODE_EXITED.value == "node_exit"
         assert HookEvent.NODE_ERROR.value == "node_error"
-        assert HookEvent.ANALYST_COMPLETE.value == "analyst_complete"
-        assert HookEvent.EVALUATOR_COMPLETE.value == "evaluator_complete"
-        assert HookEvent.SCORING_COMPLETE.value == "scoring_complete"
+        assert HookEvent.ANALYST_COMPLETED.value == "analyst_complete"
+        assert HookEvent.EVALUATOR_COMPLETED.value == "evaluator_complete"
+        assert HookEvent.SCORING_COMPLETED.value == "scoring_complete"
         assert HookEvent.VERIFICATION_PASS.value == "verification_pass"
         assert HookEvent.VERIFICATION_FAIL.value == "verification_fail"
 
@@ -33,8 +33,8 @@ class TestHookEvent:
     def test_production_p0_events(self):
         """P0 production hooks: interceptor + cost enforcement + audit."""
         assert HookEvent.USER_INPUT_RECEIVED.value == "user_input_received"
-        assert HookEvent.TOOL_EXEC_START.value == "tool_exec_start"
-        assert HookEvent.TOOL_EXEC_END.value == "tool_exec_end"
+        assert HookEvent.TOOL_EXEC_STARTED.value == "tool_exec_start"
+        assert HookEvent.TOOL_EXEC_ENDED.value == "tool_exec_end"
         assert HookEvent.TOOL_EXEC_FAILED.value == "tool_exec_failed"
         assert HookEvent.TOOL_RESULT_TRANSFORM.value == "tool_result_transform"
         assert HookEvent.COST_WARNING.value == "cost_warning"
@@ -125,7 +125,7 @@ class TestMemoryToolHooks:
 
 class TestHookResult:
     def test_success_result(self):
-        r = HookResult(success=True, event=HookEvent.PIPELINE_START, handler_name="my_hook")
+        r = HookResult(success=True, event=HookEvent.PIPELINE_STARTED, handler_name="my_hook")
         assert r.success is True
         assert r.error is None
 
@@ -161,8 +161,8 @@ class TestHookSystem:
         def on_start(event, data):
             calls.append({"event": event, "data": data})
 
-        hooks.register(HookEvent.PIPELINE_START, on_start)
-        results = hooks.trigger(HookEvent.PIPELINE_START, {"ip": "Berserk"})
+        hooks.register(HookEvent.PIPELINE_STARTED, on_start)
+        results = hooks.trigger(HookEvent.PIPELINE_STARTED, {"ip": "Berserk"})
 
         assert len(results) == 1
         assert results[0].success is True
@@ -179,20 +179,20 @@ class TestHookSystem:
         def high_priority(event, data):
             order.append("high")
 
-        hooks.register(HookEvent.NODE_ENTER, low_priority, priority=200)
-        hooks.register(HookEvent.NODE_ENTER, high_priority, priority=10)
+        hooks.register(HookEvent.NODE_ENTERED, low_priority, priority=200)
+        hooks.register(HookEvent.NODE_ENTERED, high_priority, priority=10)
 
-        hooks.trigger(HookEvent.NODE_ENTER)
+        hooks.trigger(HookEvent.NODE_ENTERED)
         assert order == ["high", "low"]
 
     def test_multiple_handlers_same_event(self):
         hooks = HookSystem()
         calls: list[str] = []
 
-        hooks.register(HookEvent.PIPELINE_END, lambda e, d: calls.append("a"), name="a")
-        hooks.register(HookEvent.PIPELINE_END, lambda e, d: calls.append("b"), name="b")
+        hooks.register(HookEvent.PIPELINE_ENDED, lambda e, d: calls.append("a"), name="a")
+        hooks.register(HookEvent.PIPELINE_ENDED, lambda e, d: calls.append("b"), name="b")
 
-        results = hooks.trigger(HookEvent.PIPELINE_END)
+        results = hooks.trigger(HookEvent.PIPELINE_ENDED)
         assert len(results) == 2
         assert len(calls) == 2
 
@@ -206,10 +206,10 @@ class TestHookSystem:
         def good_hook(event, data):
             calls.append("ok")
 
-        hooks.register(HookEvent.NODE_EXIT, bad_hook, name="bad", priority=1)
-        hooks.register(HookEvent.NODE_EXIT, good_hook, name="good", priority=2)
+        hooks.register(HookEvent.NODE_EXITED, bad_hook, name="bad", priority=1)
+        hooks.register(HookEvent.NODE_EXITED, good_hook, name="good", priority=2)
 
-        results = hooks.trigger(HookEvent.NODE_EXIT)
+        results = hooks.trigger(HookEvent.NODE_EXITED)
         assert len(results) == 2
         assert results[0].success is False
         assert results[0].error == "boom"
@@ -218,45 +218,45 @@ class TestHookSystem:
 
     def test_trigger_no_handlers(self):
         hooks = HookSystem()
-        results = hooks.trigger(HookEvent.SCORING_COMPLETE)
+        results = hooks.trigger(HookEvent.SCORING_COMPLETED)
         assert results == []
 
     def test_unregister(self):
         hooks = HookSystem()
-        hooks.register(HookEvent.PIPELINE_START, lambda e, d: None, name="tmp")
-        assert hooks.unregister(HookEvent.PIPELINE_START, "tmp") is True
-        assert hooks.trigger(HookEvent.PIPELINE_START) == []
+        hooks.register(HookEvent.PIPELINE_STARTED, lambda e, d: None, name="tmp")
+        assert hooks.unregister(HookEvent.PIPELINE_STARTED, "tmp") is True
+        assert hooks.trigger(HookEvent.PIPELINE_STARTED) == []
 
     def test_unregister_nonexistent(self):
         hooks = HookSystem()
-        assert hooks.unregister(HookEvent.PIPELINE_START, "nope") is False
+        assert hooks.unregister(HookEvent.PIPELINE_STARTED, "nope") is False
 
     def test_list_hooks(self):
         hooks = HookSystem()
-        hooks.register(HookEvent.NODE_ENTER, lambda e, d: None, name="h1")
-        hooks.register(HookEvent.NODE_EXIT, lambda e, d: None, name="h2")
+        hooks.register(HookEvent.NODE_ENTERED, lambda e, d: None, name="h1")
+        hooks.register(HookEvent.NODE_EXITED, lambda e, d: None, name="h2")
 
         all_hooks = hooks.list_hooks()
         assert "node_enter" in all_hooks
         assert "h1" in all_hooks["node_enter"]
 
-        filtered = hooks.list_hooks(HookEvent.NODE_EXIT)
+        filtered = hooks.list_hooks(HookEvent.NODE_EXITED)
         assert "node_exit" in filtered
         assert "h2" in filtered["node_exit"]
 
     def test_clear_specific_event(self):
         hooks = HookSystem()
-        hooks.register(HookEvent.NODE_ENTER, lambda e, d: None, name="a")
-        hooks.register(HookEvent.NODE_EXIT, lambda e, d: None, name="b")
+        hooks.register(HookEvent.NODE_ENTERED, lambda e, d: None, name="a")
+        hooks.register(HookEvent.NODE_EXITED, lambda e, d: None, name="b")
 
-        hooks.clear(HookEvent.NODE_ENTER)
-        assert hooks.list_hooks(HookEvent.NODE_ENTER) == {"node_enter": []}
-        assert "b" in hooks.list_hooks(HookEvent.NODE_EXIT)["node_exit"]
+        hooks.clear(HookEvent.NODE_ENTERED)
+        assert hooks.list_hooks(HookEvent.NODE_ENTERED) == {"node_enter": []}
+        assert "b" in hooks.list_hooks(HookEvent.NODE_EXITED)["node_exit"]
 
     def test_clear_all(self):
         hooks = HookSystem()
-        hooks.register(HookEvent.NODE_ENTER, lambda e, d: None, name="a")
-        hooks.register(HookEvent.NODE_EXIT, lambda e, d: None, name="b")
+        hooks.register(HookEvent.NODE_ENTERED, lambda e, d: None, name="a")
+        hooks.register(HookEvent.NODE_EXITED, lambda e, d: None, name="b")
 
         hooks.clear()
         assert hooks.list_hooks() == {}
@@ -267,7 +267,7 @@ class TestHookSystem:
         def my_handler(event, data):
             pass
 
-        hooks.register(HookEvent.PIPELINE_START, my_handler)
+        hooks.register(HookEvent.PIPELINE_STARTED, my_handler)
         all_hooks = hooks.list_hooks()
         assert "my_handler" in all_hooks["pipeline_start"]
 
@@ -278,8 +278,8 @@ class TestHookSystem:
         def handler(event, data):
             received.append(data)
 
-        hooks.register(HookEvent.PIPELINE_START, handler)
-        hooks.trigger(HookEvent.PIPELINE_START)  # No data arg
+        hooks.register(HookEvent.PIPELINE_STARTED, handler)
+        hooks.trigger(HookEvent.PIPELINE_STARTED)  # No data arg
         assert received == [{}]
 
 
@@ -412,10 +412,10 @@ class TestToolExecInterceptor:
                 return {"block": True, "reason": "tool blocked by policy"}
             return None
 
-        hooks.register(HookEvent.TOOL_EXEC_START, blocker, name="policy_gate")
+        hooks.register(HookEvent.TOOL_EXEC_STARTED, blocker, name="policy_gate")
 
         result = hooks.trigger_interceptor(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             {"tool_name": "dangerous_tool", "tool_input": {"cmd": "rm -rf /"}},
         )
         assert result.blocked is True
@@ -428,10 +428,10 @@ class TestToolExecInterceptor:
         def sanitizer(_event, data):
             return {"modify": {"tool_input": {"sanitized": True}}}
 
-        hooks.register(HookEvent.TOOL_EXEC_START, sanitizer, name="input_sanitizer")
+        hooks.register(HookEvent.TOOL_EXEC_STARTED, sanitizer, name="input_sanitizer")
 
         result = hooks.trigger_interceptor(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             {"tool_name": "search", "tool_input": {"query": "raw"}},
         )
         assert result.blocked is False
@@ -440,10 +440,10 @@ class TestToolExecInterceptor:
     def test_tool_exec_start_passthrough(self):
         """TOOL_EXEC_START with no-op handler passes through."""
         hooks = HookSystem()
-        hooks.register(HookEvent.TOOL_EXEC_START, lambda e, d: None, name="observer")
+        hooks.register(HookEvent.TOOL_EXEC_STARTED, lambda e, d: None, name="observer")
 
         result = hooks.trigger_interceptor(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             {"tool_name": "safe_tool", "tool_input": {}},
         )
         assert result.blocked is False
@@ -458,10 +458,10 @@ class TestToolExecInterceptor:
                 return {"updated_result": {"data": "transformed"}}
             return None
 
-        hooks.register(HookEvent.TOOL_EXEC_END, result_modifier, name="transformer")
+        hooks.register(HookEvent.TOOL_EXEC_ENDED, result_modifier, name="transformer")
 
         results = hooks.trigger_with_result(
-            HookEvent.TOOL_EXEC_END,
+            HookEvent.TOOL_EXEC_ENDED,
             {
                 "tool_name": "fetch",
                 "tool_input": {},
@@ -481,10 +481,10 @@ class TestToolExecInterceptor:
         def ctx_injector(_event, _data):
             return {"additional_context": "Extra info from hook"}
 
-        hooks.register(HookEvent.TOOL_EXEC_END, ctx_injector, name="ctx_inject")
+        hooks.register(HookEvent.TOOL_EXEC_ENDED, ctx_injector, name="ctx_inject")
 
         results = hooks.trigger_with_result(
-            HookEvent.TOOL_EXEC_END,
+            HookEvent.TOOL_EXEC_ENDED,
             {"tool_name": "search", "tool_input": {}, "duration_ms": 50, "has_error": False},
         )
         assert results[0].data["additional_context"] == "Extra info from hook"
@@ -492,10 +492,10 @@ class TestToolExecInterceptor:
     def test_tool_exec_end_no_modification(self):
         """TOOL_EXEC_END observe-only handler returns empty data."""
         hooks = HookSystem()
-        hooks.register(HookEvent.TOOL_EXEC_END, lambda e, d: None, name="observer")
+        hooks.register(HookEvent.TOOL_EXEC_ENDED, lambda e, d: None, name="observer")
 
         results = hooks.trigger_with_result(
-            HookEvent.TOOL_EXEC_END,
+            HookEvent.TOOL_EXEC_ENDED,
             {"tool_name": "t", "tool_input": {}, "duration_ms": 1, "has_error": False},
         )
         assert len(results) == 1
@@ -608,16 +608,16 @@ class TestMatcher:
         calls: list[str] = []
 
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             lambda e, d: calls.append("bash"),
             name="bash_only",
             matcher="run_bash",
         )
 
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "run_bash"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "run_bash"})
         assert calls == ["bash"]
 
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "web_search"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "web_search"})
         assert calls == ["bash"]  # not fired again
 
     def test_matcher_regex_pattern(self):
@@ -626,15 +626,15 @@ class TestMatcher:
         calls: list[str] = []
 
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             lambda e, d: calls.append(d["tool_name"]),
             name="dangerous",
             matcher="run_bash|terminal|computer_use",
         )
 
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "run_bash"})
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "terminal"})
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "web_search"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "run_bash"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "terminal"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "web_search"})
         assert calls == ["run_bash", "terminal"]
 
     def test_empty_matcher_matches_all(self):
@@ -643,13 +643,13 @@ class TestMatcher:
         calls: list[str] = []
 
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             lambda e, d: calls.append(d["tool_name"]),
             name="all_tools",
         )
 
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "any_tool"})
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "other_tool"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "any_tool"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "other_tool"})
         assert calls == ["any_tool", "other_tool"]
 
     def test_matcher_ignored_for_non_tool_events(self):
@@ -658,13 +658,13 @@ class TestMatcher:
         calls: list[str] = []
 
         hooks.register(
-            HookEvent.PIPELINE_START,
+            HookEvent.PIPELINE_STARTED,
             lambda e, d: calls.append("fired"),
             name="with_matcher",
             matcher="run_bash",
         )
 
-        hooks.trigger(HookEvent.PIPELINE_START, {"tool_name": "something_else"})
+        hooks.trigger(HookEvent.PIPELINE_STARTED, {"tool_name": "something_else"})
         assert calls == ["fired"]  # matcher not applied
 
     def test_matcher_on_interceptor(self):
@@ -675,19 +675,19 @@ class TestMatcher:
             return {"block": True, "reason": "bash blocked"}
 
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             bash_blocker,
             name="bash_gate",
             matcher="run_bash",
         )
 
         result_bash = hooks.trigger_interceptor(
-            HookEvent.TOOL_EXEC_START, {"tool_name": "run_bash"}
+            HookEvent.TOOL_EXEC_STARTED, {"tool_name": "run_bash"}
         )
         assert result_bash.blocked is True
 
         result_safe = hooks.trigger_interceptor(
-            HookEvent.TOOL_EXEC_START, {"tool_name": "web_search"}
+            HookEvent.TOOL_EXEC_STARTED, {"tool_name": "web_search"}
         )
         assert result_safe.blocked is False
 
@@ -696,20 +696,20 @@ class TestMatcher:
         hooks = HookSystem()
 
         hooks.register(
-            HookEvent.TOOL_EXEC_END,
+            HookEvent.TOOL_EXEC_ENDED,
             lambda e, d: {"updated_result": {"enriched": True}},
             name="enrich_search",
             matcher="web_search",
         )
 
         results_match = hooks.trigger_with_result(
-            HookEvent.TOOL_EXEC_END, {"tool_name": "web_search", "result": {}}
+            HookEvent.TOOL_EXEC_ENDED, {"tool_name": "web_search", "result": {}}
         )
         assert len(results_match) == 1
         assert results_match[0].data["updated_result"] == {"enriched": True}
 
         results_no_match = hooks.trigger_with_result(
-            HookEvent.TOOL_EXEC_END, {"tool_name": "read_file", "result": {}}
+            HookEvent.TOOL_EXEC_ENDED, {"tool_name": "read_file", "result": {}}
         )
         assert len(results_no_match) == 0
 
@@ -751,13 +751,13 @@ class TestMatcher:
         calls: list[str] = []
 
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             lambda e, d: calls.append("fired"),
             name="bad_regex",
             matcher="[invalid",
         )
 
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "any_tool"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "any_tool"})
         assert calls == ["fired"]
 
     def test_mixed_matcher_and_no_matcher(self):
@@ -766,24 +766,24 @@ class TestMatcher:
         calls: list[str] = []
 
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             lambda e, d: calls.append("all"),
             name="global",
             priority=10,
         )
         hooks.register(
-            HookEvent.TOOL_EXEC_START,
+            HookEvent.TOOL_EXEC_STARTED,
             lambda e, d: calls.append("bash"),
             name="bash_only",
             priority=20,
             matcher="run_bash",
         )
 
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "run_bash"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "run_bash"})
         assert calls == ["all", "bash"]
 
         calls.clear()
-        hooks.trigger(HookEvent.TOOL_EXEC_START, {"tool_name": "web_search"})
+        hooks.trigger(HookEvent.TOOL_EXEC_STARTED, {"tool_name": "web_search"})
         assert calls == ["all"]
 
 

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -20,10 +20,10 @@ class TestLLMLifecycleEvents:
     """HookEvent enum contains LLM_CALL_START and LLM_CALL_END."""
 
     def test_llm_call_start_exists(self) -> None:
-        assert HookEvent.LLM_CALL_START.value == "llm_call_start"
+        assert HookEvent.LLM_CALL_STARTED.value == "llm_call_start"
 
     def test_llm_call_end_exists(self) -> None:
-        assert HookEvent.LLM_CALL_END.value == "llm_call_end"
+        assert HookEvent.LLM_CALL_ENDED.value == "llm_call_end"
 
     def test_event_count_includes_llm_events(self) -> None:
         """40 events total after H6 orphan pruning."""
@@ -40,14 +40,14 @@ class TestFireHook:
         def recorder(event: HookEvent, data: dict[str, Any]) -> None:
             captured.append((event, data))
 
-        hooks.register(HookEvent.LLM_CALL_START, recorder, name="test_recorder")
+        hooks.register(HookEvent.LLM_CALL_STARTED, recorder, name="test_recorder")
         set_router_hooks(hooks)
         try:
             _fire_hook("llm_call_start", {"model": "test-model", "provider": "anthropic"})
 
             assert len(captured) == 1
             event, data = captured[0]
-            assert event == HookEvent.LLM_CALL_START
+            assert event == HookEvent.LLM_CALL_STARTED
             assert data["model"] == "test-model"
             assert data["provider"] == "anthropic"
         finally:
@@ -66,7 +66,7 @@ class TestFireHook:
         def recorder(event: HookEvent, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.LLM_CALL_END, recorder, name="test_end")
+        hooks.register(HookEvent.LLM_CALL_ENDED, recorder, name="test_end")
         set_router_hooks(hooks)
         try:
             _fire_hook(
@@ -93,7 +93,7 @@ class TestFireHook:
         def recorder(event: HookEvent, data: dict[str, Any]) -> None:
             captured.append(data)
 
-        hooks.register(HookEvent.LLM_CALL_END, recorder, name="test_end_ok")
+        hooks.register(HookEvent.LLM_CALL_ENDED, recorder, name="test_end_ok")
         set_router_hooks(hooks)
         try:
             _fire_hook(
@@ -120,7 +120,7 @@ class TestFireHook:
         def bad_handler(event: HookEvent, data: dict[str, Any]) -> None:
             raise RuntimeError("handler boom")
 
-        hooks.register(HookEvent.LLM_CALL_END, bad_handler, name="bad")
+        hooks.register(HookEvent.LLM_CALL_ENDED, bad_handler, name="bad")
         set_router_hooks(hooks)
         try:
             # Should not raise despite handler error
@@ -142,10 +142,10 @@ class TestBootstrapLLMLifecycleHook:
             if error:
                 warned.append(data)
 
-        hooks.register(HookEvent.LLM_CALL_END, _on_llm_end, name="test_logger")
+        hooks.register(HookEvent.LLM_CALL_ENDED, _on_llm_end, name="test_logger")
 
         hooks.trigger(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {
                 "model": "claude-opus-4-6",
                 "latency_ms": 500,
@@ -165,10 +165,10 @@ class TestBootstrapLLMLifecycleHook:
             if not data.get("error") and latency > 10_000:
                 slow_calls.append(data)
 
-        hooks.register(HookEvent.LLM_CALL_END, _on_llm_end, name="test_slow")
+        hooks.register(HookEvent.LLM_CALL_ENDED, _on_llm_end, name="test_slow")
 
         hooks.trigger(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {"model": "claude-opus-4-6", "latency_ms": 15_000, "error": None},
         )
         assert len(slow_calls) == 1
@@ -184,10 +184,10 @@ class TestBootstrapLLMLifecycleHook:
             if error or latency > 10_000:
                 logged.append(data)
 
-        hooks.register(HookEvent.LLM_CALL_END, _on_llm_end, name="test_normal")
+        hooks.register(HookEvent.LLM_CALL_ENDED, _on_llm_end, name="test_normal")
 
         hooks.trigger(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {"model": "claude-opus-4-6", "latency_ms": 2000, "error": None},
         )
         assert len(logged) == 0
@@ -214,19 +214,19 @@ class TestBootstrapLLMLifecycleHook:
             model_stats["total_latency_ms"] += latency
 
         hooks = HookSystem()
-        hooks.register(HookEvent.LLM_CALL_END, _on_llm_end, name="stats")
+        hooks.register(HookEvent.LLM_CALL_ENDED, _on_llm_end, name="stats")
 
         # Simulate 3 calls
         hooks.trigger(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {"model": "claude-opus-4-6", "latency_ms": 1000.0, "error": None},
         )
         hooks.trigger(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {"model": "gpt-5.4", "latency_ms": 2000.0, "error": None},
         )
         hooks.trigger(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             {"model": "claude-opus-4-6", "latency_ms": 500.0, "error": "timeout"},
         )
 
@@ -245,7 +245,7 @@ class TestHookPayloadSchema:
         captured: list[dict[str, Any]] = []
 
         hooks.register(
-            HookEvent.LLM_CALL_START,
+            HookEvent.LLM_CALL_STARTED,
             lambda e, d: captured.append(d),
             name="schema_check",
         )
@@ -255,7 +255,7 @@ class TestHookPayloadSchema:
             "provider": "anthropic",
             "function": "call_llm",
         }
-        hooks.trigger(HookEvent.LLM_CALL_START, payload)
+        hooks.trigger(HookEvent.LLM_CALL_STARTED, payload)
 
         assert len(captured) == 1
         data = captured[0]
@@ -268,7 +268,7 @@ class TestHookPayloadSchema:
         captured: list[dict[str, Any]] = []
 
         hooks.register(
-            HookEvent.LLM_CALL_END,
+            HookEvent.LLM_CALL_ENDED,
             lambda e, d: captured.append(d),
             name="schema_check",
         )
@@ -280,7 +280,7 @@ class TestHookPayloadSchema:
             "latency_ms": 1234.5,
             "error": None,
         }
-        hooks.trigger(HookEvent.LLM_CALL_END, payload)
+        hooks.trigger(HookEvent.LLM_CALL_ENDED, payload)
 
         assert len(captured) == 1
         data = captured[0]

--- a/tests/test_memory_writeback.py
+++ b/tests/test_memory_writeback.py
@@ -39,7 +39,7 @@ class TestPipelineEndMemoryWrite:
 
         # Should not raise
         hooks.trigger(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {
                 "node": "synthesizer",
                 "ip_name": "Berserk",
@@ -61,7 +61,7 @@ class TestEnrichedHookData:
         def _capture(event: HookEvent, data: dict[str, Any]) -> None:
             captured.append(dict(data))
 
-        hooks.register(HookEvent.PIPELINE_END, _capture, name="test_capture", priority=50)
+        hooks.register(HookEvent.PIPELINE_ENDED, _capture, name="test_capture", priority=50)
 
         # Create a fake synthesizer node that returns synthesis-like result
         class FakeSynthesis:

--- a/tests/test_notification_hook.py
+++ b/tests/test_notification_hook.py
@@ -22,7 +22,7 @@ from core.mcp.notification_port import NotificationResult, set_notification
 class TestFormatMessage:
     def test_pipeline_end(self):
         msg = _format_message(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {"ip_name": "Berserk", "tier": "S", "final_score": 81.3},
         )
         assert "Pipeline completed" in msg
@@ -92,7 +92,7 @@ class TestNotificationHookRegistration:
 
         # Trigger PIPELINE_END
         hooks.trigger(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {"ip_name": "Berserk", "tier": "S", "final_score": 81.3},
         )
 
@@ -113,7 +113,7 @@ class TestNotificationHookRegistration:
 
         # Should not raise
         results = hooks.trigger(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {"ip_name": "Test", "tier": "A", "final_score": 65.0},
         )
         assert all(r.success for r in results)

--- a/tests/test_project_journal.py
+++ b/tests/test_project_journal.py
@@ -128,7 +128,7 @@ class TestJournalHooks:
         # Simulate PIPELINE_END
         end_handler = next(fn for name, fn in handlers if name == "journal_pipeline_end")
         end_handler(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {
                 "ip_name": "Berserk",
                 "tier": "S",
@@ -177,7 +177,7 @@ class TestJournalHooks:
 
         end_handler = next(fn for name, fn in handlers if name == "journal_pipeline_end")
         # Send wrong event type
-        end_handler(HookEvent.NODE_ENTER, {"ip_name": "X"})
+        end_handler(HookEvent.NODE_ENTERED, {"ip_name": "X"})
         assert journal.get_recent_runs(5) == []
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -56,11 +56,11 @@ class TestRuntimeHooksRunLog:
 
         # Trigger a pipeline event
         runtime.hooks.trigger(
-            HookEvent.NODE_ENTER,
+            HookEvent.NODE_ENTERED,
             {"node": "router", "ip_name": "Berserk"},
         )
         runtime.hooks.trigger(
-            HookEvent.NODE_EXIT,
+            HookEvent.NODE_EXITED,
             {"node": "router", "ip_name": "Berserk", "duration_ms": 42.0},
         )
 
@@ -216,7 +216,7 @@ class TestDefaultBuilders:
         name, handler = _make_run_log_handler(run_log, "test_session", "run-001")
         assert name == "run_log_writer"
 
-        handler(HookEvent.PIPELINE_START, {"node": "router"})
+        handler(HookEvent.PIPELINE_STARTED, {"node": "router"})
         entries = run_log.read(limit=1)
         assert len(entries) == 1
         assert entries[0].event == "pipeline_start"
@@ -258,14 +258,14 @@ class TestRuntimeNewComponents:
 
         # Trigger PIPELINE_START → should mark running
         runtime.hooks.trigger(
-            HookEvent.PIPELINE_START,
+            HookEvent.PIPELINE_STARTED,
             {"node": "router", "ip_name": "Berserk"},
         )
         assert runtime.stuck_detector.running_count == 1
 
         # Trigger PIPELINE_END → should mark completed
         runtime.hooks.trigger(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {"node": "synthesizer", "ip_name": "Berserk"},
         )
         assert runtime.stuck_detector.running_count == 0
@@ -328,7 +328,7 @@ class TestReactiveChains:
         initial_snaps = runtime.snapshot_manager.list_snapshots()
 
         runtime.hooks.trigger(
-            HookEvent.PIPELINE_END,
+            HookEvent.PIPELINE_ENDED,
             {"node": "synthesizer", "ip_name": "Berserk"},
         )
 
@@ -376,7 +376,7 @@ class TestRuntimeTaskGraph:
         runtime = GeodeRuntime.create("Berserk", log_dir=tmp_path)
         old_graph = runtime.task_graph
         # Simulate some progress
-        runtime.hooks.trigger(HookEvent.NODE_ENTER, {"node": "router", "ip_name": "berserk"})
+        runtime.hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router", "ip_name": "berserk"})
         assert runtime.task_graph.get_task("berserk_router").status.value == "running"
 
         # Reset — old handlers should be unregistered
@@ -386,13 +386,13 @@ class TestRuntimeTaskGraph:
         assert runtime.task_graph.task_count == 13
 
         # Verify no duplicate handlers: trigger event → only new graph updates
-        runtime.hooks.trigger(HookEvent.NODE_ENTER, {"node": "router", "ip_name": "berserk"})
+        runtime.hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router", "ip_name": "berserk"})
         assert runtime.task_graph.get_task("berserk_router").status.value == "running"
         # Old graph should NOT have been updated again (it was already running)
         assert old_graph.get_task("berserk_router").status.value == "running"
 
     def test_hook_events_update_task_graph(self, tmp_path: Path):
         runtime = GeodeRuntime.create("Berserk", log_dir=tmp_path)
-        runtime.hooks.trigger(HookEvent.NODE_ENTER, {"node": "router", "ip_name": "berserk"})
-        runtime.hooks.trigger(HookEvent.NODE_EXIT, {"node": "router", "ip_name": "berserk"})
+        runtime.hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router", "ip_name": "berserk"})
+        runtime.hooks.trigger(HookEvent.NODE_EXITED, {"node": "router", "ip_name": "berserk"})
         assert runtime.task_graph.get_task("berserk_router").status.value == "completed"

--- a/tests/test_scheduler_async_drain.py
+++ b/tests/test_scheduler_async_drain.py
@@ -152,7 +152,7 @@ class TestAsyncScheduledDrain:
             # Allow other hook calls but not PIPELINE_END
             from core.hooks import HookEvent
 
-            if len(call.args) >= 1 and call.args[0] == HookEvent.PIPELINE_END:
+            if len(call.args) >= 1 and call.args[0] == HookEvent.PIPELINE_ENDED:
                 pytest.fail("post_to_main=False should suppress PIPELINE_END hook")
 
     def test_queue_drain_nonblocking_pattern(self) -> None:

--- a/tests/test_task_bridge.py
+++ b/tests/test_task_bridge.py
@@ -22,15 +22,15 @@ def _make_bridge(ip: str = "berserk") -> tuple[TaskGraphHookBridge, HookSystem]:
 class TestSimpleNodeMapping:
     def test_router_enter_marks_running(self):
         bridge, hooks = _make_bridge()
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "router", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router", "ip_name": "berserk"})
         task = bridge.task_graph.get_task("berserk_router")
         assert task is not None
         assert task.status == TaskStatus.RUNNING
 
     def test_router_exit_marks_completed(self):
         bridge, hooks = _make_bridge()
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "router", "ip_name": "berserk"})
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "router", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "router", "ip_name": "berserk"})
         task = bridge.task_graph.get_task("berserk_router")
         assert task is not None
         assert task.status == TaskStatus.COMPLETED
@@ -42,10 +42,10 @@ class TestSimpleNodeMapping:
         bridge.task_graph.mark_running("berserk_router")
         bridge.task_graph.mark_completed("berserk_router")
 
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "signals", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "signals", "ip_name": "berserk"})
         assert bridge.task_graph.get_task("berserk_signals").status == TaskStatus.RUNNING
 
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "signals", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "signals", "ip_name": "berserk"})
         assert bridge.task_graph.get_task("berserk_signals").status == TaskStatus.COMPLETED
 
 
@@ -62,13 +62,13 @@ class TestAnalystTypeMapping:
         g.mark_completed("berserk_signals")
 
         hooks.trigger(
-            HookEvent.NODE_ENTER,
+            HookEvent.NODE_ENTERED,
             {"node": "analyst", "ip_name": "berserk", "_analyst_type": "game_mechanics"},
         )
         assert g.get_task("berserk_analyst_game_mechanics").status == TaskStatus.RUNNING
 
         hooks.trigger(
-            HookEvent.NODE_EXIT,
+            HookEvent.NODE_EXITED,
             {"node": "analyst", "ip_name": "berserk", "_analyst_type": "game_mechanics"},
         )
         assert g.get_task("berserk_analyst_game_mechanics").status == TaskStatus.COMPLETED
@@ -85,11 +85,11 @@ class TestAnalystTypeMapping:
 
         for atype in ["game_mechanics", "player_experience", "growth_potential", "discovery"]:
             hooks.trigger(
-                HookEvent.NODE_ENTER,
+                HookEvent.NODE_ENTERED,
                 {"node": "analyst", "ip_name": "berserk", "_analyst_type": atype},
             )
             hooks.trigger(
-                HookEvent.NODE_EXIT,
+                HookEvent.NODE_EXITED,
                 {"node": "analyst", "ip_name": "berserk", "_analyst_type": atype},
             )
             assert g.get_task(f"berserk_analyst_{atype}").status == TaskStatus.COMPLETED
@@ -118,22 +118,22 @@ class TestEvaluatorCounting:
 
         # Mark evaluators running via NODE_ENTER
         hooks.trigger(
-            HookEvent.NODE_ENTER,
+            HookEvent.NODE_ENTERED,
             {"node": "evaluator", "ip_name": "berserk", "_evaluator_type": "quality_judge"},
         )
         assert g.get_task("berserk_evaluators").status == TaskStatus.RUNNING
 
         # First 2 exits — still running
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "evaluator", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "evaluator", "ip_name": "berserk"})
         assert bridge.evaluator_done_count == 1
         assert g.get_task("berserk_evaluators").status == TaskStatus.RUNNING
 
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "evaluator", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "evaluator", "ip_name": "berserk"})
         assert bridge.evaluator_done_count == 2
         assert g.get_task("berserk_evaluators").status == TaskStatus.RUNNING
 
         # Third exit — completes
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "evaluator", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "evaluator", "ip_name": "berserk"})
         assert bridge.evaluator_done_count == 3
         assert g.get_task("berserk_evaluators").status == TaskStatus.COMPLETED
 
@@ -144,7 +144,7 @@ class TestEvaluatorCounting:
 
         # Mark running
         hooks.trigger(
-            HookEvent.NODE_ENTER,
+            HookEvent.NODE_ENTERED,
             {"node": "evaluator", "ip_name": "berserk", "_evaluator_type": "quality_judge"},
         )
 
@@ -159,8 +159,8 @@ class TestEvaluatorCounting:
         assert g.get_task("berserk_scoring").status == TaskStatus.SKIPPED
 
         # Evaluators 2 & 3 exit — done_count tracks, task stays FAILED
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "evaluator", "ip_name": "berserk"})
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "evaluator", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "evaluator", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "evaluator", "ip_name": "berserk"})
         assert bridge.evaluator_done_count == 3
         assert g.get_task("berserk_evaluators").status == TaskStatus.FAILED
 
@@ -182,11 +182,11 @@ class TestMultiTaskMapping:
         g.mark_running("berserk_evaluators")
         g.mark_completed("berserk_evaluators")
 
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "scoring", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "scoring", "ip_name": "berserk"})
         assert g.get_task("berserk_scoring").status == TaskStatus.RUNNING
         assert g.get_task("berserk_psm").status == TaskStatus.RUNNING
 
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "scoring", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "scoring", "ip_name": "berserk"})
         assert g.get_task("berserk_scoring").status == TaskStatus.COMPLETED
         assert g.get_task("berserk_psm").status == TaskStatus.COMPLETED
 
@@ -207,11 +207,11 @@ class TestMultiTaskMapping:
             g.mark_running(tid)
             g.mark_completed(tid)
 
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "verification", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "verification", "ip_name": "berserk"})
         assert g.get_task("berserk_verification").status == TaskStatus.RUNNING
         assert g.get_task("berserk_cross_llm").status == TaskStatus.COMPLETED  # already done
 
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "verification", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "verification", "ip_name": "berserk"})
         assert g.get_task("berserk_verification").status == TaskStatus.COMPLETED
 
     def test_synthesizer_maps_to_synthesis_and_report(self):
@@ -237,11 +237,11 @@ class TestMultiTaskMapping:
             g.mark_running(tid)
             g.mark_completed(tid)
 
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "synthesizer", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "synthesizer", "ip_name": "berserk"})
         assert g.get_task("berserk_synthesis").status == TaskStatus.RUNNING
         assert g.get_task("berserk_report").status == TaskStatus.RUNNING
 
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "synthesizer", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "synthesizer", "ip_name": "berserk"})
         assert g.get_task("berserk_synthesis").status == TaskStatus.COMPLETED
         assert g.get_task("berserk_report").status == TaskStatus.COMPLETED
 
@@ -250,7 +250,7 @@ class TestErrorPropagation:
     def test_node_error_marks_failed_and_propagates(self):
         bridge, hooks = _make_bridge()
         hooks.trigger(
-            HookEvent.NODE_ENTER,
+            HookEvent.NODE_ENTERED,
             {"node": "router", "ip_name": "berserk"},
         )
         hooks.trigger(
@@ -268,8 +268,8 @@ class TestErrorPropagation:
 class TestIgnoredNodes:
     def test_gather_ignored(self):
         bridge, hooks = _make_bridge()
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "gather", "ip_name": "berserk"})
-        hooks.trigger(HookEvent.NODE_EXIT, {"node": "gather", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "gather", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_EXITED, {"node": "gather", "ip_name": "berserk"})
         assert bridge.task_graph.get_task("berserk_router").status == TaskStatus.PENDING
 
 
@@ -285,7 +285,7 @@ class TestBridgeLifecycle:
     def test_unregister_removes_handlers(self):
         bridge, hooks = _make_bridge()
         # Verify handlers are active
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "router", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "router", "ip_name": "berserk"})
         assert bridge.task_graph.get_task("berserk_router").status == TaskStatus.RUNNING
 
         # Unregister
@@ -296,7 +296,7 @@ class TestBridgeLifecycle:
         bridge2 = TaskGraphHookBridge(graph2, ip_prefix="berserk")
         bridge2.register(hooks)
 
-        hooks.trigger(HookEvent.NODE_ENTER, {"node": "signals", "ip_name": "berserk"})
+        hooks.trigger(HookEvent.NODE_ENTERED, {"node": "signals", "ip_name": "berserk"})
         # Key: only 1 set of handlers, no duplicate firing
         assert bridge2.task_graph.get_task("berserk_router").status == TaskStatus.PENDING
 


### PR DESCRIPTION
## Summary

- 15 enum identifier 를 past tense 로 통일 (lifecycle 시제 일관성 회복)
- String value 보존 — RunLog JSONL / 외부 plugin 호환성 무영향
- 233 caller + 4 \`_E.X\` alias 사이트 일괄 변환 (28 파일)
- 행위 변경 0, Python identifier 만 변경

## Verification

- [x] feature PR #1127 CI 7/7 passed
- [x] pytest 4760 passed / mypy 359 files clean / ruff clean
- [x] E2E Cowboy Bebop A (68.4) unchanged
- [x] **Hook audit trilogy 완성** — Stage C (doc) + A (enum 화) + B (명명) 모두 정렬