### PR TITLE
feat(cli): CLI LaTeX 렌더링 — Tier 1/2 폴백 체인 (Option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,62 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **CLI LaTeX 렌더링 — Tier 1 (Unicode) + Tier 2 (2D pretty-print).**
+  `core/ui/latex.py` 신규. 다른 frontier LLM CLI (Claude Code, Codex CLI,
+  Aider, jupyter-console) 가 모두 LaTeX 를 raw text 로 흘리는 동안 GEODE
+  는 두 단계 폴백으로 렌더합니다.
+
+  - **Tier 1 — pylatexenc** (모든 터미널). `\alpha` → α, `x^{2}` → x²,
+    `\text{operators}` → operators. 사용자 예시 `Complexity(f) = \#\,
+    \text{operators} + \#\,\text{variables} + \text{depth}(f)` 가
+    `Complexity(f) = # operators + # variables + depth(f)` 로 흐름.
+    pure-Python, ~5 MB.
+  - **Tier 2 — latex2sympy2 + sympy.pretty** (모든 터미널, 멀티라인 출력).
+    `block=True` + 2D 토큰 (`\frac`, `\matrix`, `\sum_`, `\int_`,
+    `\prod_`, `\binom`, `\sqrt{`, `\lim_`) 감지 시에만 SymPy 파서 호출.
+    `\frac{a+b}{c+d}` 가 3 줄 Unicode 분수로 렌더 (예: `a + b ─── c +
+    d`). 파서 실패 시 Tier 1 로 silent fallback.
+  - **`extract_and_render_inline`** — 산문 안에 섞인 `$...$` (인라인) /
+    `$$...$$` (블록) 세그먼트 스캔. docs 사이트 MarkdownLite 와 동일한
+    우선순위 (block > inline > 텍스트). "비용 $3.00 발생" 같이 delimiter
+    안쪽에 공백 시작/끝 있는 경우 수식으로 오인식 안 됨.
+
+  의존성 추가 — `pylatexenc>=2.10` (~5 MB) + `latex2sympy2>=1.9` +
+  `sympy>=1.12` (~30 MB). 테스트 19 종 (`tests/test_ui_latex.py`) —
+  Tier 1/2/혼합 컨텐츠 + 가격 오인식 방지 + parse 실패 폴백 케이스.
+  외부 통합은 본 PR 범위 밖 (라이브러리 + 테스트만). 다음 단계 후보 —
+  `event_renderer` 가 LLM 응답 텍스트에 `extract_and_render_inline` 적용.
+
+- **CLI LaTeX rendering — Tier 1 (Unicode) + Tier 2 (2D pretty-print).**
+  New `core/ui/latex.py`. Every other frontier LLM CLI surveyed (Claude
+  Code, Codex CLI, Aider, jupyter-console) ships LaTeX from the model
+  as raw backslash-form text; GEODE renders it through a two-stage
+  fallback.
+
+  - **Tier 1 — pylatexenc** (every terminal). `\alpha` → α, `x^{2}` →
+    x², `\text{operators}` → operators. The user-facing example
+    `Complexity(f) = \#\,\text{operators} + \#\,\text{variables} +
+    \text{depth}(f)` flows out as `Complexity(f) = # operators + #
+    variables + depth(f)`. Pure-Python, ~5 MB.
+  - **Tier 2 — latex2sympy2 + sympy.pretty** (every terminal,
+    multi-line output). Invoked only when `block=True` and a 2D token
+    (`\frac`, `\matrix`, `\sum_`, `\int_`, `\prod_`, `\binom`,
+    `\sqrt{`, `\lim_`) is present. `\frac{a+b}{c+d}` renders as a
+    three-line Unicode fraction. Silent fall-back to Tier 1 on parser
+    failure.
+  - **`extract_and_render_inline`** — scans mixed prose for `$...$`
+    (inline) and `$$...$$` (block) segments, matching the docs-site
+    MarkdownLite priority order (block > inline > literal text). The
+    inline regex forbids whitespace adjacent to a delimiter so "$3.00"
+    in prose is not misread as math.
+
+  Deps — `pylatexenc>=2.10` (~5 MB) + `latex2sympy2>=1.9` +
+  `sympy>=1.12` (~30 MB). 19 tests in `tests/test_ui_latex.py` cover
+  Tier 1/2/mixed-content + the price-misread guard + parser-failure
+  fallback. No external integration yet (library + tests only) —
+  next step candidate is to apply `extract_and_render_inline` inside
+  `event_renderer` for LLM response text.
+
 - **Docs 사이트 LaTeX 렌더링 (KaTeX).** `site/` (Next.js docs 사이트) 의
   `MarkdownLite` 인라인 토크나이저가 `$...$` (인라인) / `$$...$$` (블록)
   구문을 인식해 KaTeX 로 수식을 렌더합니다. 또한 hand-written TSX 페이지

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -1,0 +1,170 @@
+"""CLI LaTeX rendering — Tier 1 (Unicode) + Tier 2 (2D pretty-print) fallback.
+
+Why this module
+---------------
+Other frontier LLM CLIs (Claude Code, Codex CLI, Aider, jupyter-console)
+emit LaTeX from the model as raw text and the terminal user sees the
+backslash form. GEODE renders it.
+
+Tiers
+-----
+**Tier 1 — pylatexenc.LatexNodes2Text** (every terminal).
+    Flattens inline LaTeX into a single Unicode line: ``\\alpha`` → α,
+    ``x^{2}`` → x², ``\\text{operators}`` → operators. Covers the case
+    in the user-facing example ``Complexity(f) = \\#\\,\\text{operators}
+    + \\#\\,\\text{variables} + \\text{depth}(f)`` and most prose-style
+    math the LLM emits.
+
+**Tier 2 — latex2sympy2 + sympy.pretty** (any terminal, taller output).
+    Only invoked when the expression contains a 2D construct
+    (``\\frac``, ``\\matrix``, ``\\begin{matrix}``, ``\\sum_``,
+    ``\\int_``, ``\\prod_``, ``\\binom``, ``\\sqrt`` with explicit
+    radicand). Returns a multi-line block. If the SymPy parser raises,
+    we fall back to Tier 1 silently. The Tier 1 result is still
+    legible; the 2D block is an upgrade.
+
+Public API
+----------
+- :func:`render_latex` — convert a LaTeX string to a Rich ``Text``
+  block ready for ``Console.print``.
+- :func:`extract_and_render_inline` — scan a mixed-content string for
+  ``$...$`` / ``$$...$$`` segments and yield rendered + literal chunks.
+  Mirrors the docs-site MarkdownLite tokenizer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterator
+from typing import Final
+
+from rich.text import Text
+
+log = logging.getLogger(__name__)
+
+# Heuristic: only call into Tier 2 when one of these tokens appears.
+# Cheap regex check; avoids paying the SymPy parser cost on prose math.
+_TIER2_TOKENS: Final[tuple[str, ...]] = (
+    r"\frac",
+    r"\matrix",
+    r"\begin{matrix}",
+    r"\begin{pmatrix}",
+    r"\begin{bmatrix}",
+    r"\sum_",
+    r"\int_",
+    r"\prod_",
+    r"\binom",
+    r"\sqrt{",
+    r"\lim_",
+)
+
+
+def _has_tier2_construct(src: str) -> bool:
+    """True when ``src`` contains a 2D math construct worth pretty-printing."""
+    return any(tok in src for tok in _TIER2_TOKENS)
+
+
+def _render_tier1(src: str) -> str:
+    """Flatten LaTeX to a single Unicode line. Never raises — pylatexenc
+    swallows unknown macros and returns whatever it can parse."""
+    try:
+        # pylatexenc ships no py.typed marker; suppress at site.
+        from pylatexenc.latex2text import LatexNodes2Text  # type: ignore[import-untyped]
+    except ImportError:  # pragma: no cover — declared in pyproject
+        return src
+    try:
+        result: str = LatexNodes2Text().latex_to_text(src).strip()
+        return result
+    except Exception:
+        log.debug("Tier 1 LaTeX render failed for %r", src, exc_info=True)
+        return src
+
+
+def _render_tier2(src: str) -> str | None:
+    """Render a 2D block via SymPy. Return ``None`` to let the caller
+    fall back to Tier 1; never raise."""
+    try:
+        # latex2sympy2 and sympy ship no py.typed marker; suppress at site.
+        from latex2sympy2 import latex2sympy  # type: ignore[import-untyped]
+        from sympy import pretty  # type: ignore[import-untyped]
+    except ImportError:  # pragma: no cover — declared in pyproject
+        return None
+    try:
+        expr = latex2sympy(src)
+    except Exception:
+        log.debug("Tier 2 LaTeX parse failed for %r", src, exc_info=True)
+        return None
+    try:
+        rendered: str = pretty(expr, use_unicode=True)
+        return rendered
+    except Exception:
+        log.debug("Tier 2 SymPy pretty failed for %r", src, exc_info=True)
+        return None
+
+
+def render_latex(src: str, *, block: bool = False) -> Text:
+    """Render a LaTeX expression to a Rich :class:`Text`.
+
+    ``block=True`` hints that 2D pretty-print is desired (multi-line OK).
+    Inline (``block=False``) skips Tier 2 entirely so the result stays on
+    one line and inline-flow rendering is predictable.
+    """
+    src = src.strip()
+    if not src:
+        return Text("")
+
+    if block and _has_tier2_construct(src):
+        rendered = _render_tier2(src)
+        if rendered is not None:
+            return Text(rendered, style="math")
+
+    return Text(_render_tier1(src), style="math")
+
+
+# ---------------------------------------------------------------------------
+# Mixed-content scanner — `$...$` and `$$...$$` segments embedded in prose.
+# ---------------------------------------------------------------------------
+
+_BLOCK_MATH = re.compile(r"\$\$([^$]+)\$\$")
+# Inline: forbid whitespace immediately inside the delimiters so a phrase
+# like "비용 $3.00" does not get treated as a math segment.
+_INLINE_MATH = re.compile(r"\$(?!\s)([^\s$][^$]*[^\s$]|[^\s$])\$")
+
+
+def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
+    """Yield ``(kind, payload)`` tuples for each segment of ``text``.
+
+    ``kind`` is one of:
+      * ``"text"`` — payload is the literal substring.
+      * ``"inline_math"`` — payload is the rendered Unicode string.
+      * ``"block_math"`` — payload is the rendered (possibly multi-line)
+        Unicode string.
+
+    Block math takes precedence over inline math at the same position
+    (matches the docs-site MarkdownLite priority).
+    """
+    if not text:
+        return
+
+    # Build a single match-stream: block segments first, then inline,
+    # then resolve by earliest start position.
+    matches: list[tuple[int, int, str, str]] = []  # (start, end, kind, inner)
+    for m in _BLOCK_MATH.finditer(text):
+        matches.append((m.start(), m.end(), "block_math", m.group(1)))
+    for m in _INLINE_MATH.finditer(text):
+        # Skip if this inline match overlaps any block match already accepted.
+        if any(start <= m.start() < end for start, end, _, _ in matches):
+            continue
+        matches.append((m.start(), m.end(), "inline_math", m.group(1)))
+    matches.sort(key=lambda t: t[0])
+
+    pos = 0
+    for start, end, kind, inner in matches:
+        if start > pos:
+            yield ("text", text[pos:start])
+        block = kind == "block_math"
+        yield (kind, render_latex(inner, block=block).plain)
+        pos = end
+    if pos < len(text):
+        yield ("text", text[pos:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,15 @@ dependencies = [
     "rich>=14.0.0",
     "simple-term-menu>=1.6.0",
     "typer>=0.15.0",
+    # CLI LaTeX rendering (`core/ui/latex.py`).
+    # Tier 1 — pylatexenc converts inline LaTeX (symbols, Greek letters,
+    # super/subscripts) to a flat Unicode string. pure-Python, ~5 MB.
+    # Tier 2 — latex2sympy2 parses LaTeX into a SymPy expression and
+    # sympy.pretty draws a 2D Unicode block (fractions, matrices,
+    # integrals, sums). Adds sympy + mpmath (~30 MB).
+    "pylatexenc>=2.10",
+    "latex2sympy2>=1.9",
+    "sympy>=1.12",
 ]
 
 [project.scripts]

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -1,0 +1,133 @@
+"""Tests for ``core.ui.latex`` — Tier 1/2 LaTeX rendering."""
+
+from __future__ import annotations
+
+import pytest
+from core.ui.latex import (
+    _has_tier2_construct,
+    extract_and_render_inline,
+    render_latex,
+)
+
+
+class TestTier1Unicode:
+    """Tier 1 — flat Unicode (every terminal)."""
+
+    def test_user_facing_example(self) -> None:
+        # The literal expression from the bug report.
+        src = r"Complexity(f) = \#\,\text{operators} + \#\,\text{variables} + \text{depth}(f)"
+        out = render_latex(src).plain
+        assert "operators" in out
+        assert "variables" in out
+        assert "depth" in out
+        # No leftover \text{} braces.
+        assert "\\text" not in out
+        assert "{" not in out
+
+    def test_greek_letters(self) -> None:
+        out = render_latex(r"\alpha + \beta = \gamma").plain
+        assert "α" in out
+        assert "β" in out
+        assert "γ" in out
+
+    def test_subscript_superscript(self) -> None:
+        out = render_latex(r"x_{i}^{2}").plain
+        # pylatexenc emits x_i^2 — Unicode digits in superscript are preferred
+        # but the exact glyphs depend on the font. We only require the chars.
+        assert "x" in out
+        assert "i" in out
+        assert "2" in out
+
+    def test_empty_string(self) -> None:
+        assert render_latex("").plain == ""
+
+    def test_whitespace_only(self) -> None:
+        assert render_latex("   ").plain == ""
+
+    def test_garbage_does_not_raise(self) -> None:
+        # Malformed input: render should never raise.
+        render_latex(r"\\\\frac{\{").plain  # noqa: B018 — smoke test
+
+
+class TestTier2PrettyPrint:
+    """Tier 2 — SymPy 2D pretty-print (block mode + 2D construct)."""
+
+    def test_fraction_uses_2d_when_block(self) -> None:
+        out = render_latex(r"\frac{a+b}{c+d}", block=True).plain
+        # 2D output contains the horizontal rule character.
+        assert "─" in out or "-" in out
+        assert "a" in out and "b" in out and "c" in out and "d" in out
+        # Multi-line.
+        assert "\n" in out
+
+    def test_inline_fraction_stays_flat(self) -> None:
+        # block=False must NOT use the 2D pretty-printer.
+        out = render_latex(r"\frac{a}{b}", block=False).plain
+        assert "\n" not in out
+
+    def test_2d_token_detection(self) -> None:
+        assert _has_tier2_construct(r"\frac{1}{2}")
+        assert _has_tier2_construct(r"\sum_{i=0}^{n} i")
+        assert _has_tier2_construct(r"\sqrt{x}")
+        assert not _has_tier2_construct(r"\alpha + \beta")
+        assert not _has_tier2_construct(r"x^2 + y^2")
+
+    def test_unparseable_falls_back_to_tier1(self) -> None:
+        # latex2sympy2 cannot parse a free-form `\text{...}` block, but the
+        # caller should still get a usable Tier 1 string back.
+        out = render_latex(
+            r"\frac{\text{numerator}}{\text{denominator}}", block=True
+        ).plain
+        assert "numerator" in out
+        assert "denominator" in out
+
+
+class TestMixedContent:
+    """`extract_and_render_inline` — `$...$` and `$$...$$` segments in prose."""
+
+    def test_pure_text_yields_single_chunk(self) -> None:
+        chunks = list(extract_and_render_inline("hello world"))
+        assert chunks == [("text", "hello world")]
+
+    def test_inline_math(self) -> None:
+        chunks = list(extract_and_render_inline(r"intro $\alpha+\beta$ outro"))
+        kinds = [k for k, _ in chunks]
+        assert kinds == ["text", "inline_math", "text"]
+        _, math = chunks[1]
+        assert "α" in math
+        assert "β" in math
+
+    def test_block_math(self) -> None:
+        chunks = list(extract_and_render_inline(r"see $$\frac{a}{b}$$ here"))
+        kinds = [k for k, _ in chunks]
+        assert kinds == ["text", "block_math", "text"]
+        _, math = chunks[1]
+        assert "\n" in math  # 2D pretty-print
+
+    def test_price_not_misread_as_math(self) -> None:
+        # The whitespace-after-$ guard prevents "비용 $3.00" from matching.
+        chunks = list(extract_and_render_inline("비용 $3.00 발생"))
+        # The whole thing must come back as a single text chunk.
+        assert chunks == [("text", "비용 $3.00 발생")]
+
+    def test_block_takes_precedence_over_inline(self) -> None:
+        # `$$x$$` must not be parsed as two adjacent `$x$` inline segments.
+        chunks = list(extract_and_render_inline(r"a $$x+y$$ b"))
+        kinds = [k for k, _ in chunks]
+        assert "block_math" in kinds
+        assert kinds.count("inline_math") == 0
+
+    @pytest.mark.parametrize(
+        ("source", "expected_kinds"),
+        [
+            ("plain text", ["text"]),
+            (r"$x$", ["inline_math"]),
+            (r"$$x$$", ["block_math"]),
+            (r"start $a$ mid $b$ end", ["text", "inline_math", "text", "inline_math", "text"]),
+        ],
+    )
+    def test_segmentation_table(
+        self, source: str, expected_kinds: list[str]
+    ) -> None:
+        chunks = list(extract_and_render_inline(source))
+        assert [k for k, _ in chunks] == expected_kinds

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/14/8ac135ec7cc9db3f768e2d032776718c6b23f74e63543f0974b4873500b2/antlr4-python3-runtime-4.7.2.tar.gz", hash = "sha256:168cdcec8fb9152e84a87ca6fd261b3d54c8f6358f42ab3b813b14a7193bb50b", size = 112278, upload-time = "2018-12-18T18:50:52.313Z" }
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1175,6 +1181,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "latex2sympy2" },
     { name = "markdownify" },
     { name = "numpy" },
     { name = "openai" },
@@ -1182,10 +1189,12 @@ dependencies = [
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pylatexenc" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "simple-term-menu" },
+    { name = "sympy" },
     { name = "typer" },
 ]
 
@@ -1243,6 +1252,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.1.0" },
     { name = "langgraph-checkpoint", specifier = ">=4.0.1" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0" },
+    { name = "latex2sympy2", specifier = ">=1.9" },
     { name = "markdownify", specifier = ">=0.14.1" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
@@ -1256,10 +1266,12 @@ requires-dist = [
     { name = "pyautogui", marker = "extra == 'desktop'", specifier = ">=0.9.54" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
+    { name = "pylatexenc", specifier = ">=2.10" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "simple-term-menu", specifier = ">=1.6.0" },
+    { name = "sympy", specifier = ">=1.12" },
     { name = "textgrad", marker = "extra == 'reason'", specifier = ">=0.1.6" },
     { name = "traceloop-sdk", marker = "extra == 'obs'", specifier = ">=0.34.0" },
     { name = "typer", specifier = ">=0.15.0" },
@@ -2174,6 +2186,18 @@ wheels = [
 ]
 
 [[package]]
+name = "latex2sympy2"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/9e/4520682ab29a9219f1845643fdc75f1453bebf4b602c6e4421579de1f05d/latex2sympy2-1.9.1-py3-none-any.whl", hash = "sha256:44f24d263d235164a91173167a30d449f4360e3f0a59239ce6b843c50a41c601", size = 89798, upload-time = "2023-04-23T07:44:11.064Z" },
+]
+
+[[package]]
 name = "libcst"
 version = "1.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2605,6 +2629,15 @@ dependencies = [
     { name = "rubicon-objc", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/fa/b2ba8229b9381e8f6381c1dcae6f4159a7f72349e414ed19cfbbd1817173/MouseInfo-0.1.3.tar.gz", hash = "sha256:2c62fb8885062b8e520a3cce0a297c657adcc08c60952eb05bc8256ef6f7f6e7", size = 10850, upload-time = "2020-03-27T21:20:10.136Z" }
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
 
 [[package]]
 name = "multidict"
@@ -4304,6 +4337,12 @@ crypto = [
 ]
 
 [[package]]
+name = "pylatexenc"
+version = "2.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3", size = 162597, upload-time = "2021-04-06T07:56:07.854Z" }
+
+[[package]]
 name = "pymarkdownlnt"
 version = "0.9.37"
 source = { registry = "https://pypi.org/simple" }
@@ -5028,6 +5067,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- \`core/ui/latex.py\` 신규 — \`render_latex(src, block=False)\` + \`extract_and_render_inline(text)\`
- Tier 1 (pylatexenc, Unicode flat) + Tier 2 (latex2sympy2+sympy.pretty, 2D ASCII) 폴백 체인
- 산문 속 \`\$...\$\` / \`\$\$...\$\$\` 세그먼트 스캐너 — docs-site MarkdownLite 와 동일 우선순위
- 19 신규 테스트 + 의존성 3 개 추가 (pylatexenc, latex2sympy2, sympy)

## Why

리서치 결과, frontier LLM CLI **모두** (Claude Code [#21433](https://github.com/anthropics/claude-code/issues/21433), [#36742](https://github.com/anthropics/claude-code/issues/36742), Codex CLI, Aider, jupyter-console) LaTeX raw text 로 흘림. Qt console 만 MathJax 렌더. 이 surface 가 차별화 후보로 떠올랐고, 사용자 예시 \`Complexity(f) = #\\text{operators} + ...\` 같은 LLM-generated 식이 GEODE 터미널에서 형태 갖춰 보이게 하는 것이 목표.

## Tiers

| Tier | 라이브러리 | 발동 조건 | 출력 |
|---|---|---|---|
| **1** | pylatexenc.LatexNodes2Text | 항상 (기본) | 한 줄 Unicode (\`\\alpha\` → α, \`\\text{...}\` → 평문) |
| **2** | latex2sympy2 → sympy.pretty | \`block=True\` + 2D 토큰 (\`\\frac\`, \`\\matrix\`, \`\\sum_\`, \`\\int_\`, \`\\prod_\`, \`\\binom\`, \`\\sqrt{\`, \`\\lim_\`) | 멀티라인 2D Unicode (분수/합/적분/행렬) |

Tier 2 파서 실패 시 silent fallback to Tier 1. Tier 1 자체도 \`try/except\` 로 입력 무엇이든 raise 안 함.

## 라이브 검증

\`\`\`
=== Tier 1 — user-facing example ===
Complexity(f) = # operators + # variables + depth(f)

=== Tier 1 — Greek + super/subscript ===
α_ij^2 + β = ∑γ_k

=== Tier 2 — fraction (block) ===
a + b
─────
c + d

=== Tier 2 — sum (block) ===
  n      
 ___     
 ╲       
  ╲     2
  ╱   xᵢ 
 ╱       
 ‾‾‾     
i = 0    
\`\`\`

## Changes

| File | Change |
|------|--------|
| \`core/ui/latex.py\` | NEW. \`render_latex\` + \`extract_and_render_inline\` + Tier 1/2 헬퍼 + \`_TIER2_TOKENS\` 휴리스틱 |
| \`tests/test_ui_latex.py\` | NEW. 19 cases (Tier 1/2/mixed/price-misread/parse-fail) |
| \`pyproject.toml\` | +\`pylatexenc>=2.10\`, +\`latex2sympy2>=1.9\`, +\`sympy>=1.12\` |
| \`uv.lock\` | 종속성 lock 갱신 (sympy + mpmath + antlr4 등) |
| \`CHANGELOG.md\` | \`[Unreleased] > Added\` KR/EN |

## Verification

- [x] \`uv run ruff check core/ tests/ plugins/\` — 0 errors (auto-fix 4 적용 후)
- [x] \`uv run mypy core/ plugins/\` — 0 errors (362 source files)
- [x] \`uv run pytest -m "not live"\` — **4816 passed**, 28 skipped (+19 신규)
- [x] 라이브 검증: Tier 1 사용자 예시 + Tier 2 fraction/sum + mixed-content 세그멘테이션 모두 정상

## Out of scope (의도적 — 별 PR)

- \`event_renderer\` / \`agentic_ui\` 가 LLM 응답에서 자동으로 \`extract_and_render_inline\` 호출하는 통합
- Tier 3 (kitty / iTerm2 이미지 inline) — matplotlib + textual-kitty 의존성 무게 과함, 향후 \`--extra latex-image\` optional
- Streaming 환경에서 partial \`\$...\$\` 처리 (현재는 줄 단위 완성된 텍스트 가정)