### PR TITLE
docs(verification): 5-Layer 표기 정정 — Confidence Gate → Calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,56 @@ renders as a single column with a `KR`-only or `EN`-only chip.
   bundled/global/project scopes. (3) `~/.geode/mcp/registry-cache.
   json` `servers` array length is exactly 200 — the prior "200+"
   was inaccurate. Pure documentation change, no behavioral impact.
+- **Verification 5-Layer 표기 정정 — `Confidence Gate` 가 아니라 `Calibration`.**
+  `core/verification/` 구성요소 audit 결과 README 의 "5-Layer Verification
+  (G1-G4 + BiasBuster + Cross-LLM + Confidence Gate + Rights Risk)" 표기가
+  실제 코드와 불일치. 실제 5번째 layer 는 `core/verification/calibration.py`
+  (Swiss Cheese Layer 5, docstring 직접 인용 — "orthogonal to G1-G4
+  (structural), BiasBuster (cognitive), Cross-LLM (inter-model). Calibration
+  validates against external expert consensus"). "Confidence Gate" 는
+  실제로는 `plugins/game_ip/nodes/scoring.py:301` 의 confidence multiplier
+  ((1 - CV) × 100) — 별도 layer 가 아니라 scoring 단계의 sub-routine.
+  코드 사이트 grounding:
+  - **Layer 1 (structural)** — `core/verification/guardrails.py` 의 `_g1_schema`
+    (L13), `_g2_range` (L47), `_g3_grounding` (L90), `_g4_consistency` (L148)
+  - **Layer 2 (cognitive)** — `core/verification/biasbuster.py:43`
+    `run_biasbuster(state) -> BiasBusterResult`, 4-step RECOGNIZE → EXPLAIN
+    → ALTER → EVALUATE
+  - **Layer 3 (inter-model)** — `core/verification/cross_llm.py:81`
+    `run_cross_llm_check(...)`, `core/verification/stats.py` Krippendorff α
+  - **Layer 4 (legal)** — `core/verification/rights_risk.py:79`
+    `check_rights_risk(...) -> RightsRiskResult`
+  - **Layer 5 (Ground Truth)** — `core/verification/calibration.py:328`
+    `run_calibration(...)`, expert-annotated Golden Set 대비 axis/tier/
+    cause 일치 검증
+  README/README.ko peer comparison `Multi-layer guardrails` 셀 + `What's
+  inside` 표 의 layer 명 모두 정정 (`Confidence Gate` → `Calibration`).
+  각 layer 에 "(structural)", "(cognitive)", "(inter-model)", "(legal)",
+  "(Ground Truth, Swiss Cheese Layer 5)" 의미 라벨 추가.
+
+- **Verification 5-Layer label fix — `Confidence Gate` → `Calibration`.**
+  Audit of `core/verification/` revealed that the README's "5-Layer
+  Verification" cell (`G1-G4 + BiasBuster + Cross-LLM + Confidence Gate +
+  Rights Risk`) was inaccurate. The true layer 5 is
+  `core/verification/calibration.py` (its docstring spells out "Swiss Cheese
+  Layer 5: orthogonal to G1-G4 (structural), BiasBuster (cognitive),
+  Cross-LLM (inter-model). Calibration validates against external expert
+  consensus"). What the README called "Confidence Gate" is actually the
+  confidence multiplier `(1 - CV) × 100` inside `plugins/game_ip/nodes/
+  scoring.py:301` — a scoring sub-routine, not a verification layer.
+  Grounded layer map:
+  - **Layer 1 (structural)** — `guardrails.py` `_g1_schema` (L13),
+    `_g2_range` (L47), `_g3_grounding` (L90), `_g4_consistency` (L148)
+  - **Layer 2 (cognitive)** — `biasbuster.py:43` `run_biasbuster`,
+    4-step RECOGNIZE → EXPLAIN → ALTER → EVALUATE
+  - **Layer 3 (inter-model)** — `cross_llm.py:81` `run_cross_llm_check`
+    + `stats.py` Krippendorff α
+  - **Layer 4 (legal)** — `rights_risk.py:79` `check_rights_risk`
+  - **Layer 5 (Ground Truth)** — `calibration.py:328` `run_calibration`,
+    expert-annotated Golden Set comparison
+  README and README.ko peer comparison `Multi-layer guardrails` cell and
+  `What's inside` table both fixed (`Confidence Gate` → `Calibration`).
+  Each layer now carries the semantic label parenthetical.
 
 ### Infrastructure
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -302,7 +302,7 @@ uv tool install -e . --force
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` 로 다단계 작업 관리. 디스크 영구화 (`.geode/plans.json`), 재시작 후에도 유지 |
 | **장시간 데몬** | `geode serve` 가 백그라운드로 상주. Slack / Discord / Telegram 폴러 + 스케줄러 tick + thin CLI 용 IPC |
 | **서브에이전트** | 부모 권한 완전 상속, depth/cost 가드, Lane 격리 |
-| **5-layer 검증** | Guardrails G1-G4 + BiasBuster + Cross-LLM (Krippendorff α ≥ 0.67) + Confidence Gate + Rights Risk |
+| **5-layer 검증** | Guardrails G1-G4 (structural) + BiasBuster (cognitive) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal) + Calibration (Ground Truth, Swiss Cheese Layer 5) |
 | **도메인-specific DAG (교체 가능)** | 파이프라인 (리서치, 다축 평가, 합성) 은 `DomainPort` Protocol 로 plug-in. 레퍼런스 DAG 1개 동봉 — 어떤 탐색적 리서치 / 시그널 예측 도메인에도 교체해 사용 |
 
 ---
@@ -358,7 +358,7 @@ uv tool install -e . --force
 | 메모리 tier | ⚠️ 3 (user / project / local 세팅 머지) | ✅ 계층적 AGENTS.md (전역 `~/.codex/` + repo + nested dirs) | ⚠️ 세션 범위 | ✅✅ **5-tier** (SOUL · User · Org · Project · Session) |
 | 디스크 영구 plan | ✅ TodoWrite 영속화 | ⚠️ resumable 스레드 경유 | ✅ task registry | ✅ `.geode/plans.json` |
 | 권한 / 샌드박스 계층 | ✅ 3-mode (default / auto / bypass) + Confirmation UI | ✅ `sandbox_mode` 3 단계 (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain (40+ 감사 표면) | ✅ Policy Chain + 도구 게이트 |
-| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅✅ **5-layer 검증** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
+| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅✅ **5-layer 검증** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk + Calibration) |
 | Hook 이벤트 수 | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 이벤트 타입 · 다수 번들 핸들러 | ✅✅ **58 이벤트** (`docs/architecture/hook-system.md`) |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ uv tool install -e . --force
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` for multi-step work. Disk-persistent (`.geode/plans.json`), survives restarts |
 | **Long-running daemon** | `geode serve` runs as background daemon. Slack / Discord / Telegram pollers + scheduler tick + IPC for the thin CLI |
 | **Sub-agents** | Full inheritance of parent capability, depth/cost guards, isolation by Lane |
-| **5-layer verification** | Guardrails G1-G4 + BiasBuster + Cross-LLM (Krippendorff α ≥ 0.67) + Confidence Gate + Rights Risk |
+| **5-layer verification** | Guardrails G1-G4 (structural) + BiasBuster (cognitive) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal) + Calibration (Ground Truth, Swiss Cheese Layer 5) |
 | **Domain-specific DAG (swappable)** | Pipelines (research, multi-axis evaluation, synthesis) plug in via the `DomainPort` Protocol. Ships with one reference DAG out-of-the-box; replace it for any exploratory-research / signal-prediction problem |
 
 ---
@@ -364,7 +364,7 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Memory tiers | ⚠️ 3 (user / project / local settings merge) | ✅ hierarchical AGENTS.md (global `~/.codex/` + repo + nested dirs) | ⚠️ session-scoped | ✅✅ **5-tier** (SOUL · User · Org · Project · Session) |
 | Disk-persistent plans | ✅ TodoWrite persistence | ⚠️ via resumable threads | ✅ task registry | ✅ `.geode/plans.json` |
 | Permission / sandbox layers | ✅ 3-mode (default / auto / bypass) + Confirmation UI | ✅ `sandbox_mode` 3-level (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain (40+ audit surfaces) | ✅ Policy Chain + tool gates |
-| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **5-layer verification** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
+| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **5-layer verification** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk + Calibration) |
 | Hook event count | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 event types · many bundled handlers | ✅✅ **58 events** (`docs/architecture/hook-system.md`) |
 
 </details>


### PR DESCRIPTION
## Summary

- README 의 "5-Layer Verification" 셀이 잘못된 layer (\`Confidence Gate\`) 를 표기
- 실제 5th layer 는 \`core/verification/calibration.py\` (Swiss Cheese Layer 5 — docstring 명시)
- "Confidence Gate" 는 검증 layer 가 아니라 \`scoring.py\` 의 confidence multiplier sub-routine
- 5 layer 각각에 의미 라벨 (structural/cognitive/inter-model/legal/Ground Truth) 추가

## Why

직전 unified-daemon 다이어그램 self-audit 의 후속 (P2). \`core/verification/\` audit 결과 README 가 doc deception 상태. 실제 5번째 layer 는 \`calibration.py\` 인데 README 는 "Confidence Gate" 라고 적어 코드와 안 맞는 상태였음. 신뢰성 회복.

## Code grounding

| Layer | 의미 | Code site |
|---|---|---|
| **L1** | structural | \`core/verification/guardrails.py\` — \`_g1_schema\` (L13), \`_g2_range\` (L47), \`_g3_grounding\` (L90), \`_g4_consistency\` (L148), orchestrator \`run_all_guardrails\` (L173+) |
| **L2** | cognitive | \`core/verification/biasbuster.py:43\` \`run_biasbuster(state)\` — 4-step RECOGNIZE → EXPLAIN → ALTER → EVALUATE |
| **L3** | inter-model | \`core/verification/cross_llm.py:81\` \`run_cross_llm_check(...)\` + \`stats.py\` Krippendorff α |
| **L4** | legal | \`core/verification/rights_risk.py:79\` \`check_rights_risk(...)\` |
| **L5** | Ground Truth | \`core/verification/calibration.py:328\` \`run_calibration(...)\` — Golden Set 비교, docstring 직접 인용: "Swiss Cheese Layer 5: orthogonal to G1-G4 (structural), BiasBuster (cognitive), Cross-LLM (inter-model). Calibration validates against external expert consensus" |
| ❌ "Confidence Gate" | (잘못된 표기) | \`plugins/game_ip/nodes/scoring.py:301\` — \`Confidence = (1 - CV) * 100\`, **검증 layer 가 아닌 scoring sub-routine** |

## Changes

| File | Change |
|------|--------|
| \`README.md\` | "5-layer verification" 셀 2 군데 (What's inside + peer comparison) — Confidence Gate → Calibration + 의미 라벨 추가 |
| \`README.ko.md\` | 동일 패턴 KO 적용 |
| \`CHANGELOG.md\` | \`[Unreleased] > Documentation\` KR/EN |

## Verification

- [x] \`core/verification/__init__.py\` 빈 파일 확인 (orchestrator 없음, 각 module 독립 호출)
- [x] \`calibration.py\` docstring "Swiss Cheese Layer 5" 자체 인용 확인
- [x] "Confidence Gate" 가 game_ip scoring sub-routine 임을 코드 trace 로 확인 (\`scoring.py:301\`)
- [x] 코드 변경 0 — 순수 doc

## Reference

- Stage C audit (PR #1121) 패턴과 동일: doc claim ↔ 실제 코드 1:1 매핑