### PR TITLE
release: README/CLAUDE.md grounding + Verification 5-Layer 정정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,56 @@ renders as a single column with a `KR`-only or `EN`-only chip.
   bundled/global/project scopes. (3) `~/.geode/mcp/registry-cache.
   json` `servers` array length is exactly 200 — the prior "200+"
   was inaccurate. Pure documentation change, no behavioral impact.
+- **Verification 5-Layer 표기 정정 — `Confidence Gate` 가 아니라 `Calibration`.**
+  `core/verification/` 구성요소 audit 결과 README 의 "5-Layer Verification
+  (G1-G4 + BiasBuster + Cross-LLM + Confidence Gate + Rights Risk)" 표기가
+  실제 코드와 불일치. 실제 5번째 layer 는 `core/verification/calibration.py`
+  (Swiss Cheese Layer 5, docstring 직접 인용 — "orthogonal to G1-G4
+  (structural), BiasBuster (cognitive), Cross-LLM (inter-model). Calibration
+  validates against external expert consensus"). "Confidence Gate" 는
+  실제로는 `plugins/game_ip/nodes/scoring.py:301` 의 confidence multiplier
+  ((1 - CV) × 100) — 별도 layer 가 아니라 scoring 단계의 sub-routine.
+  코드 사이트 grounding:
+  - **Layer 1 (structural)** — `core/verification/guardrails.py` 의 `_g1_schema`
+    (L13), `_g2_range` (L47), `_g3_grounding` (L90), `_g4_consistency` (L148)
+  - **Layer 2 (cognitive)** — `core/verification/biasbuster.py:43`
+    `run_biasbuster(state) -> BiasBusterResult`, 4-step RECOGNIZE → EXPLAIN
+    → ALTER → EVALUATE
+  - **Layer 3 (inter-model)** — `core/verification/cross_llm.py:81`
+    `run_cross_llm_check(...)`, `core/verification/stats.py` Krippendorff α
+  - **Layer 4 (legal)** — `core/verification/rights_risk.py:79`
+    `check_rights_risk(...) -> RightsRiskResult`
+  - **Layer 5 (Ground Truth)** — `core/verification/calibration.py:328`
+    `run_calibration(...)`, expert-annotated Golden Set 대비 axis/tier/
+    cause 일치 검증
+  README/README.ko peer comparison `Multi-layer guardrails` 셀 + `What's
+  inside` 표 의 layer 명 모두 정정 (`Confidence Gate` → `Calibration`).
+  각 layer 에 "(structural)", "(cognitive)", "(inter-model)", "(legal)",
+  "(Ground Truth, Swiss Cheese Layer 5)" 의미 라벨 추가.
+
+- **Verification 5-Layer label fix — `Confidence Gate` → `Calibration`.**
+  Audit of `core/verification/` revealed that the README's "5-Layer
+  Verification" cell (`G1-G4 + BiasBuster + Cross-LLM + Confidence Gate +
+  Rights Risk`) was inaccurate. The true layer 5 is
+  `core/verification/calibration.py` (its docstring spells out "Swiss Cheese
+  Layer 5: orthogonal to G1-G4 (structural), BiasBuster (cognitive),
+  Cross-LLM (inter-model). Calibration validates against external expert
+  consensus"). What the README called "Confidence Gate" is actually the
+  confidence multiplier `(1 - CV) × 100` inside `plugins/game_ip/nodes/
+  scoring.py:301` — a scoring sub-routine, not a verification layer.
+  Grounded layer map:
+  - **Layer 1 (structural)** — `guardrails.py` `_g1_schema` (L13),
+    `_g2_range` (L47), `_g3_grounding` (L90), `_g4_consistency` (L148)
+  - **Layer 2 (cognitive)** — `biasbuster.py:43` `run_biasbuster`,
+    4-step RECOGNIZE → EXPLAIN → ALTER → EVALUATE
+  - **Layer 3 (inter-model)** — `cross_llm.py:81` `run_cross_llm_check`
+    + `stats.py` Krippendorff α
+  - **Layer 4 (legal)** — `rights_risk.py:79` `check_rights_risk`
+  - **Layer 5 (Ground Truth)** — `calibration.py:328` `run_calibration`,
+    expert-annotated Golden Set comparison
+  README and README.ko peer comparison `Multi-layer guardrails` cell and
+  `What's inside` table both fixed (`Confidence Gate` → `Calibration`).
+  Each layer now carries the semantic label parenthetical.
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,36 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Documentation
+
+- **README + CLAUDE.md count grounding — tool 25→61, skill 13→14, MCP
+  200+→200, module 353→363, test 4608→4897.** 직전 unified-daemon
+  다이어그램 self-audit 에서 발견된 outdated 수치 정정. README/README.ko
+  의 (a) shields.io 배지, (b) `What's inside` 표, (c) peer comparison 표
+  의 MCP 셀, (d) Architecture overview 의 `Runtime Tools(N)` /
+  `ToolRegistry(N)` / `Skills(N)` 라벨, (e) `GEODE Runtime` 단락의 도구
+  / Skill 카운트 모두 실측값으로 갱신. CLAUDE.md 의 `Modules` (`find
+  core/ -name "*.py" \| wc -l` = 318, `plugins/` = 45) + `Tests` (`pytest
+  --collect-only -m "not live"` = 4897) 카운트도 동기화. 측정 방식: (1)
+  `core/tools/definitions.json` JSON 길이 = 61. (2) `SkillLoader(lazy=
+  True).load_all()` 길이 = 14 (bundled+global+project 스코프 합산).
+  (3) `~/.geode/mcp/registry-cache.json` 의 `servers` array 길이 =
+  정확히 200 (예전 "200+" 는 부정확). 행위 변경 0 — doc 수치 only.
+- **README + CLAUDE.md count grounding — tool 25→61, skill 13→14,
+  MCP 200+→200, module 353→363, test 4608→4897.** Outdated counts
+  discovered while self-auditing the unified-daemon diagram were
+  resynced against measured values. Updated in README and README.ko:
+  (a) shields.io badges, (b) `What's inside` table, (c) peer
+  comparison MCP cell, (d) `Tools(N)` / `ToolRegistry(N)` /
+  `Skills(N)` labels in the Architecture overview, (e) `GEODE
+  Runtime` paragraph tool / skill counts. CLAUDE.md `Modules` and
+  `Tests` lines also resynced. Measurement: (1) length of
+  `core/tools/definitions.json` JSON array = 61. (2)
+  `SkillLoader(lazy=True).load_all()` returns 14 across
+  bundled/global/project scopes. (3) `~/.geode/mcp/registry-cache.
+  json` `servers` array length is exactly 200 — the prior "200+"
+  was inaccurate. Pure documentation change, no behavioral impact.
+
 ### Infrastructure
 
 - **Petri raw-archive analyzer + safe10 seed pool.** `scripts/petri_analyze.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ A general-purpose autonomous execution agent built on LangGraph. Autonomously pe
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 311 core + 42 plugins = 353
-- **Tests**: 4608 (+24 live)
+- **Modules**: 318 core + 45 plugins = 363
+- **Tests**: 4897 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -302,7 +302,7 @@ uv tool install -e . --force
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` 로 다단계 작업 관리. 디스크 영구화 (`.geode/plans.json`), 재시작 후에도 유지 |
 | **장시간 데몬** | `geode serve` 가 백그라운드로 상주. Slack / Discord / Telegram 폴러 + 스케줄러 tick + thin CLI 용 IPC |
 | **서브에이전트** | 부모 권한 완전 상속, depth/cost 가드, Lane 격리 |
-| **5-layer 검증** | Guardrails G1-G4 + BiasBuster + Cross-LLM (Krippendorff α ≥ 0.67) + Confidence Gate + Rights Risk |
+| **5-layer 검증** | Guardrails G1-G4 (structural) + BiasBuster (cognitive) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal) + Calibration (Ground Truth, Swiss Cheese Layer 5) |
 | **도메인-specific DAG (교체 가능)** | 파이프라인 (리서치, 다축 평가, 합성) 은 `DomainPort` Protocol 로 plug-in. 레퍼런스 DAG 1개 동봉 — 어떤 탐색적 리서치 / 시그널 예측 도메인에도 교체해 사용 |
 
 ---
@@ -358,7 +358,7 @@ uv tool install -e . --force
 | 메모리 tier | ⚠️ 3 (user / project / local 세팅 머지) | ✅ 계층적 AGENTS.md (전역 `~/.codex/` + repo + nested dirs) | ⚠️ 세션 범위 | ✅✅ **5-tier** (SOUL · User · Org · Project · Session) |
 | 디스크 영구 plan | ✅ TodoWrite 영속화 | ⚠️ resumable 스레드 경유 | ✅ task registry | ✅ `.geode/plans.json` |
 | 권한 / 샌드박스 계층 | ✅ 3-mode (default / auto / bypass) + Confirmation UI | ✅ `sandbox_mode` 3 단계 (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain (40+ 감사 표면) | ✅ Policy Chain + 도구 게이트 |
-| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅✅ **5-layer 검증** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
+| 다중 계층 가드레일 | ⚠️ 권한 + hooks | ⚠️ hooks + 샌드박스 | ✅ `audit.runtime` 엔진 | ✅✅ **5-layer 검증** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk + Calibration) |
 | Hook 이벤트 수 | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 이벤트 타입 · 다수 번들 핸들러 | ✅✅ **58 이벤트** (`docs/architecture/hook-system.md`) |
 
 </details>

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/while(tool__use)-agentic%20loop-1e293b?style=flat-square" alt="while(tool_use)">
-  <img src="https://img.shields.io/badge/25%20tools-MCP%20native-1e293b?style=flat-square" alt="25 Tools">
+  <img src="https://img.shields.io/badge/61%20tools-MCP%20native-1e293b?style=flat-square" alt="61 Tools">
   <img src="https://img.shields.io/badge/LangGraph-StateGraph-1e293b?style=flat-square" alt="LangGraph">
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
@@ -296,7 +296,7 @@ uv tool install -e . --force
 | 기능 | 설명 |
 |------|------|
 | **`while(tool_use)` 루프** | 모든 자율 행동의 단일 원시 동작. 서브에이전트, 플랜, 배치 — 전부 같은 루프의 인스턴스 |
-| **25 도구 + MCP 카탈로그** | 웹 검색, 파일 작업, 스케줄링, 메모리, 캘린더, Slack/Discord, 한국 채용공고 검색, 그리고 Anthropic 발행 MCP 레지스트리 (200+ 서버, `~/.geode/mcp/registry-cache.json` 에 캐시). 첫 사용 시 자동 설치 |
+| **61 도구 + MCP 카탈로그** | 웹 검색, 파일 작업, 스케줄링, 메모리, 캘린더, Slack/Discord, 한국 채용공고 검색, 그리고 Anthropic 발행 MCP 레지스트리 (200 서버, `~/.geode/mcp/registry-cache.json` 에 캐시). 첫 사용 시 자동 설치 |
 | **3-프로바이더 페일오버** | Anthropic + OpenAI + ZhipuAI. 구독 OAuth (Codex, Claude CLI) 자동 감지; 사용량 과금 API 키도 사용 가능; 페일오버는 동일 프로바이더 내에서만 (예상치 못한 vendor 횡단 과금 없음, v0.53.0 거버넌스) |
 | **5-tier 메모리** | SOUL (0) → User Profile (0.5) → Organization (1) → Project (2) → Session (3). 영속화, 데몬 재시작 후에도 유지 |
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` 로 다단계 작업 관리. 디스크 영구화 (`.geode/plans.json`), 재시작 후에도 유지 |
@@ -333,7 +333,7 @@ uv tool install -e . --force
 | Discord / Telegram / 기타 chat | ❌ | ❌ | ✅✅ 23+ 채널 (Discord, Telegram, WhatsApp, Signal, iMessage, Teams, Matrix, Feishu, LINE, ...) | ✅ Discord + Telegram 폴러 |
 | IDE 플러그인 | ❌ (Chrome MCP 확장만) | ✅✅ VS Code · JetBrains · Cursor · Windsurf | ❌ | ❌ |
 | Web UI | ✅ claude.ai/code | ✅ Codex Cloud | ⚠️ WebChat 플러그인 | ❌ (문서 사이트만) |
-| MCP 서버 카탈로그 | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic 배포 레지스트리 (200+ 서버, `~/.geode/mcp/registry-cache.json` 캐시) |
+| MCP 서버 카탈로그 | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic 배포 레지스트리 (200 서버, `~/.geode/mcp/registry-cache.json` 캐시) |
 
 </details>
 
@@ -369,7 +369,7 @@ uv tool install -e . --force
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
 | 플러그인 / 확장 표면 | ✅ manifest + 마켓플레이스 (user / project / local 스코프) | ✅ `/plugins` 슬래시 커맨드 + 플러그인 공유 (v0.130+) | ✅✅ 4 확장 지점 (Channel · Tool · Skill · Hook) via `@openclaw/plugin-sdk` | ✅ `DomainPort` Protocol + 플러그인 로더 |
-| Skill 시스템 | ✅ Deferred tools + SKILL.md manifest | ✅ SKILL.md + progressive disclosure (`.agents/skills/`) | ✅ 스킬 필터 + archive 업로드 | ✅ 런타임 `SkillRegistry` (13 런타임 skills) |
+| Skill 시스템 | ✅ Deferred tools + SKILL.md manifest | ✅ SKILL.md + progressive disclosure (`.agents/skills/`) | ✅ 스킬 필터 + archive 업로드 | ✅ 런타임 `SkillRegistry` (14 skills · bundled/global/project 스코프) |
 | **교체 가능한 도메인 DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — DAG 추상화 아님) | ✅✅ `DomainPort` Protocol — 파이프라인이 first-class 확장 지점 |
 | 트레이스 / 리플레이 / Run Log | ✅ `tengu_*` 텔레메트리 + `/insights` HTML | ⚠️ `/status` + `/debug-config` 만 | ✅ ACP 세션 lineage + Task Registry | ✅ Run Log + Petri eval 통합 (v0.90+, LangSmith 대체) |
 | Cross-LLM 검증 | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 평가자 간 일치도 게이트 |
@@ -390,14 +390,14 @@ IDE 내부 또는 클라우드 동기화로 짧은 코딩 세션을 돌릴 땐 *
 GEODE 는 두 개의 컨트롤 레이어가 있습니다:
 
 - **Scaffold (생산)** — Claude Code + `CLAUDE.md` + 개발 Skills + CI Hooks. GEODE 의 코드를 만들고 품질을 보장하는 외부 하네스.
-- **GEODE Runtime (에이전트)** — `while(tool_use)` 루프 + 25 도구 + 13 런타임 Skills + 58 런타임 Hooks + 5-Layer Verification. 자율 실행 에이전트의 내부 시스템.
+- **GEODE Runtime (에이전트)** — `while(tool_use)` 루프 + 61 도구 + 14 런타임 Skills + 58 런타임 Hooks + 5-Layer Verification. 자율 실행 에이전트의 내부 시스템.
 
 4-Layer Stack (Model → Runtime → Harness → Agent) + 서브에이전트 시스템 + 5-Tier 메모리.
 
 ```mermaid
 graph LR
     AG["Agent<br/>AgenticLoop, SubAgent<br/>CLIPoller, Gateway"] --> HA["Harness<br/>SessionLane, PolicyChain<br/>TaskGraph, HookSystem"]
-    HA --> RT["Runtime<br/>Tools(25), MCP catalog<br/>Memory, Skills"]
+    HA --> RT["Runtime<br/>Tools(61), MCP catalog<br/>Memory, Skills"]
     RT --> MD["Model<br/>Claude, OpenAI, GLM"]
 
     AG -.-> DP["⊥ Domain<br/>DomainPort Protocol<br/>(swappable DAG)"]
@@ -415,7 +415,7 @@ graph LR
 |-------|------|--------------|
 | **Agent** | AgenticLoop, SubAgentManager, CLIPoller, Gateway | `core/cli/`, `core/gateway/` |
 | **Harness** | SessionLane, LaneQueue(global:8), PolicyChain, TaskGraph, HookSystem(58) | `core/orchestration/`, `core/hooks/` |
-| **Runtime** | ToolRegistry(25), MCP Catalog (200+ via Anthropic registry, 5 locally configured by default), Skills(13), Memory(5-Tier), PlanStore | `core/tools/`, `core/memory/`, `core/orchestration/plan_store.py` |
+| **Runtime** | ToolRegistry(61), MCP Catalog (200 via Anthropic registry, 5 locally configured by default), Skills(14), Memory(5-Tier), PlanStore | `core/tools/`, `core/memory/`, `core/orchestration/plan_store.py` |
 | **Model** | ClaudeAdapter, OpenAIAdapter, CodexAdapter, GLMAdapter | `core/llm/` |
 | **⊥ Domain** | `DomainPort` Protocol — 도메인-specific DAG 가 Port 통해 plug-in (cross-cutting). 레퍼런스 DAG 1개 동봉. 어떤 탐색적 리서치 / 시그널 예측 도메인이든 교체해 사용 | `core/domains/` |
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/while(tool__use)-agentic%20loop-1e293b?style=flat-square" alt="while(tool_use)">
-  <img src="https://img.shields.io/badge/25%20tools-MCP%20native-1e293b?style=flat-square" alt="25 Tools">
+  <img src="https://img.shields.io/badge/61%20tools-MCP%20native-1e293b?style=flat-square" alt="61 Tools">
   <img src="https://img.shields.io/badge/LangGraph-StateGraph-1e293b?style=flat-square" alt="LangGraph">
   <a href="https://github.com/mangowhoiscloud/geode/actions"><img src="https://img.shields.io/github/actions/workflow/status/mangowhoiscloud/geode/ci.yml?style=flat-square&label=ci&logo=github&logoColor=white" alt="CI"></a>
 </p>
@@ -302,7 +302,7 @@ uv tool install -e . --force
 | Feature | What it does |
 |---------|-------------|
 | **`while(tool_use)` loop** | The single primitive every behavior is built on. Sub-agents, plans, batches — all instances of the same loop |
-| **25 tools + MCP catalog** | Web search, file ops, scheduling, memory, calendar, Slack/Discord, Korean job-board search, plus the Anthropic-published MCP registry (200+ servers, cached at `~/.geode/mcp/registry-cache.json`). Auto-installed on first use |
+| **61 tools + MCP catalog** | Web search, file ops, scheduling, memory, calendar, Slack/Discord, Korean job-board search, plus the Anthropic-published MCP registry (200 servers, cached at `~/.geode/mcp/registry-cache.json`). Auto-installed on first use |
 | **3-provider failover** | Anthropic + OpenAI + ZhipuAI. Subscription OAuth (Codex) auto-detected; pay-as-you-go API keys also work; failover is in-provider only (no surprise cross-vendor charges, v0.53.0 governance) |
 | **5-tier memory** | SOUL (0) → User Profile (0.5) → Organization (1) → Project (2) → Session (3). Persistent, survives daemon restarts |
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` for multi-step work. Disk-persistent (`.geode/plans.json`), survives restarts |
@@ -339,7 +339,7 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Discord / Telegram / other chat | ❌ | ❌ | ✅✅ 23+ channels (Discord, Telegram, WhatsApp, Signal, iMessage, Teams, Matrix, Feishu, LINE, ...) | ✅ Discord + Telegram pollers |
 | IDE plugin | ❌ (Chrome MCP extension only) | ✅✅ VS Code · JetBrains · Cursor · Windsurf | ❌ | ❌ |
 | Web UI | ✅ claude.ai/code | ✅ Codex Cloud | ⚠️ WebChat plugin | ❌ (docs site only) |
-| MCP server catalog | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic-published registry (200+ servers, cached at `~/.geode/mcp/registry-cache.json`) |
+| MCP server catalog | ✅ first-class | ✅ first-class | ✅ first-class | ✅ Anthropic-published registry (200 servers, cached at `~/.geode/mcp/registry-cache.json`) |
 
 </details>
 
@@ -375,7 +375,7 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | | Claude Code | Codex CLI | OpenClaw | **GEODE** |
 |---|---|---|---|---|
 | Plugin / extension surfaces | ✅ manifest + marketplace (user / project / local scopes) | ✅ `/plugins` slash command + plugin sharing (v0.130+) | ✅✅ 4 extension points (Channel · Tool · Skill · Hook) via `@openclaw/plugin-sdk` | ✅ `DomainPort` Protocol + plugin loader |
-| Skill system | ✅ Deferred tools + SKILL.md manifest | ✅ SKILL.md + progressive disclosure (`.agents/skills/`) | ✅ skill filter + archive upload | ✅ runtime `SkillRegistry` (13 runtime skills) |
+| Skill system | ✅ Deferred tools + SKILL.md manifest | ✅ SKILL.md + progressive disclosure (`.agents/skills/`) | ✅ skill filter + archive upload | ✅ runtime `SkillRegistry` (14 skills across bundled/global/project scopes) |
 | **Swappable domain DAG** | ❌ | ❌ | ⚠️ flows (channel-setup / doctor / provider — not a DAG abstraction) | ✅✅ `DomainPort` Protocol — pipeline is a first-class extension point |
 | Trace / replay / Run Log | ✅ `tengu_*` telemetry + `/insights` HTML | ⚠️ `/status` + `/debug-config` only | ✅ ACP session lineage + Task Registry | ✅ Run Log + Petri eval integration (v0.90+, replaces LangSmith) |
 | Cross-LLM verification | ❌ | ❌ | ❌ | ✅✅ Krippendorff α ≥ 0.67 inter-rater agreement gate |
@@ -396,14 +396,14 @@ Use **Claude Code** or **Codex** for short coding sessions inside an IDE or via 
 GEODE has two control layers:
 
 - **Scaffold (production)** — Claude Code + `CLAUDE.md` + development Skills + CI Hooks. The external harness that produces GEODE's code and guarantees quality.
-- **GEODE Runtime (agent)** — `while(tool_use)` loop + 25 tools + 13 runtime Skills + 58 runtime Hooks + 5-Layer Verification. The internal system of the autonomously executing agent.
+- **GEODE Runtime (agent)** — `while(tool_use)` loop + 61 tools + 14 runtime Skills + 58 runtime Hooks + 5-Layer Verification. The internal system of the autonomously executing agent.
 
 4-Layer Stack (Model → Runtime → Harness → Agent) + Sub-Agent System + 5-Tier Memory.
 
 ```mermaid
 graph LR
     AG["Agent<br/>AgenticLoop, SubAgent<br/>CLIPoller, Gateway"] --> HA["Harness<br/>SessionLane, PolicyChain<br/>TaskGraph, HookSystem"]
-    HA --> RT["Runtime<br/>Tools(25), MCP catalog<br/>Memory, Skills"]
+    HA --> RT["Runtime<br/>Tools(61), MCP catalog<br/>Memory, Skills"]
     RT --> MD["Model<br/>Claude, OpenAI, GLM"]
 
     AG -.-> DP["⊥ Domain<br/>DomainPort Protocol<br/>(swappable DAG)"]
@@ -421,7 +421,7 @@ graph LR
 |-------|------|--------------|
 | **Agent** | AgenticLoop, SubAgentManager, CLIPoller, Gateway | `core/cli/`, `core/gateway/` |
 | **Harness** | SessionLane, LaneQueue(global:8), PolicyChain, TaskGraph, HookSystem(58) | `core/orchestration/`, `core/hooks/` |
-| **Runtime** | ToolRegistry(25), MCP Catalog (200+ via Anthropic registry, 5 locally configured by default), Skills(13), Memory(5-Tier), PlanStore | `core/tools/`, `core/memory/`, `core/orchestration/plan_store.py` |
+| **Runtime** | ToolRegistry(61), MCP Catalog (200 via Anthropic registry, 5 locally configured by default), Skills(14), Memory(5-Tier), PlanStore | `core/tools/`, `core/memory/`, `core/orchestration/plan_store.py` |
 | **Model** | ClaudeAdapter, OpenAIAdapter, CodexAdapter, GLMAdapter | `core/llm/` |
 | **⊥ Domain** | `DomainPort` Protocol — domain-specific DAG plugged in via Port (cross-cutting). One reference DAG ships in the repo; replace for any exploratory-research / signal-prediction domain | `core/domains/` |
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ uv tool install -e . --force
 | **Plan-mode + audit trail** | `create_plan` + `approve_plan` + `list_plans` for multi-step work. Disk-persistent (`.geode/plans.json`), survives restarts |
 | **Long-running daemon** | `geode serve` runs as background daemon. Slack / Discord / Telegram pollers + scheduler tick + IPC for the thin CLI |
 | **Sub-agents** | Full inheritance of parent capability, depth/cost guards, isolation by Lane |
-| **5-layer verification** | Guardrails G1-G4 + BiasBuster + Cross-LLM (Krippendorff α ≥ 0.67) + Confidence Gate + Rights Risk |
+| **5-layer verification** | Guardrails G1-G4 (structural) + BiasBuster (cognitive) + Cross-LLM (inter-model, Krippendorff α ≥ 0.67) + Rights Risk (legal) + Calibration (Ground Truth, Swiss Cheese Layer 5) |
 | **Domain-specific DAG (swappable)** | Pipelines (research, multi-axis evaluation, synthesis) plug in via the `DomainPort` Protocol. Ships with one reference DAG out-of-the-box; replace it for any exploratory-research / signal-prediction problem |
 
 ---
@@ -364,7 +364,7 @@ Grounded against the actual state of each frontier harness as of May 2026: **Cla
 | Memory tiers | ⚠️ 3 (user / project / local settings merge) | ✅ hierarchical AGENTS.md (global `~/.codex/` + repo + nested dirs) | ⚠️ session-scoped | ✅✅ **5-tier** (SOUL · User · Org · Project · Session) |
 | Disk-persistent plans | ✅ TodoWrite persistence | ⚠️ via resumable threads | ✅ task registry | ✅ `.geode/plans.json` |
 | Permission / sandbox layers | ✅ 3-mode (default / auto / bypass) + Confirmation UI | ✅ `sandbox_mode` 3-level (read-only / workspace-write / danger-full-access) | ✅✅ Policy Chain (40+ audit surfaces) | ✅ Policy Chain + tool gates |
-| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **5-layer verification** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Confidence Gate + Rights Risk) |
+| Multi-layer guardrails | ⚠️ permission + hooks | ⚠️ hooks + sandbox | ✅ `audit.runtime` engine | ✅✅ **5-layer verification** (G1-G4 + BiasBuster + Cross-LLM Krippendorff α ≥ 0.67 + Rights Risk + Calibration) |
 | Hook event count | ⚠️ 5 (PreToolUse / PostToolUse / SessionStart / Notification / ConfigChange) | ⚠️ 6 (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PermissionRequest / Stop) | ✅ 5 event types · many bundled handlers | ✅✅ **58 events** (`docs/architecture/hook-system.md`) |
 
 </details>


### PR DESCRIPTION
## Summary

- README/README.ko/CLAUDE.md 의 outdated 수치 5종 정정 (tool 25→61, skill 13→14, MCP 200+→200, module 353→363, test 4608→4897)
- Verification "5-Layer" 표기 정정 — Confidence Gate (scoring sub-routine) → **Calibration** (core/verification/calibration.py, Swiss Cheese Layer 5)
- 두 변경 모두 코드 변경 0, 순수 doc grounding

## Verification

- [x] feature PR #1152 (runtime stats) + #1153 (verification) 모두 CI 7/7 pass → merged
- [x] 코드 변경 없음 — pytest/mypy/ruff 무영향