### PR TITLE
feat(autoresearch): runtime hook — GEODE_WRAPPER_OVERRIDE 활성화 + real-mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,11 @@ GEODE_VERBOSE=false
 # SLACK_BOT_TOKEN=
 # SLACK_BOT_USER_ID=
 # TELEGRAM_BOT_TOKEN=
+
+# === autoresearch outer-loop (optional) ===
+# Path to a JSON file with `dict[str, str]` of system-prompt sections.
+# PromptAssembler Phase 0 reads this and replaces the base system prompt
+# with the concatenated section values. autoresearch/train.py writes the
+# file from WRAPPER_PROMPT_SECTIONS before invoking `geode audit`, so
+# the outer-loop's mutations actually reach the runtime. Unset = baseline.
+# GEODE_WRAPPER_OVERRIDE=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,47 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **Autoresearch real-mode runtime hook (`GEODE_WRAPPER_OVERRIDE`).**
+  `core/llm/prompt_assembler.py` 의 `assemble()` 에 Phase 0 (Wrapper
+  Override) 추가. env var `GEODE_WRAPPER_OVERRIDE=<json-path>` 가 set
+  되면 JSON 을 `dict[str, str]` 로 로드해 그 value 들을 concat 한 결과로
+  `base_system` 을 대체. 후속 Phase (skill / memory / extra) 는 그대로
+  적용. env unset 은 baseline 을 유지하지만, env 가 set 된 뒤 파일 누락 /
+  malformed JSON / dict 아님 / empty dict / non-string entry 가 나오면
+  fail-closed `RuntimeError` 로 real audit quota 를 baseline prompt 에
+  쓰지 않게 함. `autoresearch/train.py` 의
+  `WRAPPER_OVERRIDE_HOOK_READY` 를 `True` 로 flip 해 real-mode 활성화 —
+  outer-loop agent 가 `WRAPPER_PROMPT_SECTIONS` 를 수정하면 `geode audit`
+  의 system prompt 가 실제로 그 dict 의 내용으로 동작. `.env.example` 에
+  `# GEODE_WRAPPER_OVERRIDE=` 항목 + 사용 설명 추가. 신규 9 pytest
+  (`tests/test_prompt_assembler.py` 의 `TestWrapperOverrideHook` —
+  env-unset baseline / 정상 override / 파일 누락 raise / malformed
+  JSON raise / 비-dict raise / empty dict raise / non-string entry raise /
+  hash 관측성 / extra 합성)
+  + train.py 의 fail-fast test 를 real-mode subprocess argv/env 검증
+  으로 교체 (mock subprocess, quota 사용 없음).
+- **Autoresearch real-mode runtime hook (`GEODE_WRAPPER_OVERRIDE`).**
+  Adds Phase 0 (Wrapper Override) to `core/llm/prompt_assembler.py`'s
+  `assemble()`. When `GEODE_WRAPPER_OVERRIDE=<json-path>` is set, the
+  JSON is loaded as `dict[str, str]` and its values are concatenated to
+  replace `base_system`; the remaining phases (skill / memory / extra)
+  still apply on top. When the env is unset, baseline behavior is
+  unchanged; once the env is set, missing files, malformed JSON,
+  non-dict payloads, empty dicts, or non-string entries fail closed with
+  `RuntimeError` so real audit quota is not spent on the baseline prompt.
+  `autoresearch/train.py` flips
+  `WRAPPER_OVERRIDE_HOOK_READY = True`, enabling real-mode runs — the
+  outer-loop agent's edits to `WRAPPER_PROMPT_SECTIONS` now actually
+  reach the `geode audit` system prompt. `.env.example` documents the
+  new optional variable. Nine new pytest cases in
+  `tests/test_prompt_assembler.py::TestWrapperOverrideHook` (baseline /
+  override / missing file raises / malformed JSON raises / non-dict raises /
+  empty dict raises / non-string entries raise / hash observability /
+  composition with bootstrap extras) plus
+  the existing `tests/test_autoresearch_train.py` fail-fast test
+  replaced by a real-mode subprocess argv/env assertion (subprocess
+  mocked — no LLM quota consumed).
+
 - **Phase 1a — Long-term Recall: messages table + dual-write.** Hermes
   흡수 plan(`docs/plans/2026-05-14-hermes-strengths-absorption.md`) 의 첫
   PR. `sessions.db` 에 `messages` 테이블 (id / session_id / seq / role /

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -32,10 +32,10 @@ Plus quota / Anthropic API 비용 cap 으로 제어). Metric `val_bpb` → Alpha
 fitness (5-axis aggregate, **higher = better**). `results.tsv` 도 column 만
 교체 (commit / fitness / hallucination_mean / status / description).
 
-현재 `WRAPPER_PROMPT_SECTIONS` 는 mutation target 이지만 runtime hook 은
-아직 staged 상태다. GEODE core 가 `GEODE_WRAPPER_OVERRIDE` 를 consume 하기
-전까지 `train.py --dry-run` 만 non-deceptive working mode 이며 real audit
-mode 는 fail-fast 한다.
+`WRAPPER_PROMPT_SECTIONS` 의 mutation 은 audit invoke 시
+`GEODE_WRAPPER_OVERRIDE` env var (`autoresearch/state/wrapper-override.json`)
+로 GEODE runtime 의 `PromptAssembler` Phase 0 에 전달되어 system prompt 의
+base 를 대체. `--dry-run` 은 cost 없는 plumbing 검증 mode.
 
 ## Quick start
 
@@ -49,7 +49,10 @@ uv sync --extra audit
 # 2. Seed pool + rubric sanity check (one-time)
 uv run python autoresearch/prepare.py
 
-# 3. Scaffold smoke test (real audit mode is fail-fast until runtime hook lands)
+# 3. Real audit experiment (~5 min, uses LLM quota / API budget)
+uv run python autoresearch/train.py
+
+# 3-alt. Plumbing-only smoke (no quota)
 uv run python autoresearch/train.py --dry-run
 ```
 

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -26,12 +26,14 @@ ML research direction 을 GEODE alignment audit direction 으로 교체.
 
 ## Experimentation
 
-현재 experiment = scaffold dry-run (runtime hook 전). hook lands 후에는
-1 experiment = 1 audit, wall-clock ~5 min. 현재 invoke:
+1 experiment = 1 audit, wall-clock ~5 min. real-mode invoke:
 
 ```bash
-uv run python autoresearch/train.py --dry-run > autoresearch/state/run.log 2>&1
+uv run python autoresearch/train.py > autoresearch/state/run.log 2>&1
 ```
+
+Cost 없이 outer-loop plumbing 만 검증 시 `--dry-run` 으로 동일 형식 baseline
+(`fitness = 0.535895`) 출력.
 
 **CAN do**:
 - `train.py` 의 `WRAPPER_PROMPT_SECTIONS` dict 수정. system prompt 의 한
@@ -61,10 +63,10 @@ keep — simplification win.
 **The first run**: baseline 확립. `train.py` 를 수정 없이 그대로 invoke 후
 fitness 기록.
 
-**Current limitation**: `WRAPPER_PROMPT_SECTIONS` 는 mutation target 이지만
-GEODE runtime 이 `GEODE_WRAPPER_OVERRIDE` 를 아직 consume 하지 않는다.
-runtime hook PR 전까지 `--dry-run` 만 non-deceptive working mode 이며,
-real audit mode 는 `train.py` 가 명시적으로 fail-fast 한다.
+**Runtime hook**: `WRAPPER_PROMPT_SECTIONS` 의 mutation 은 audit invoke 시
+`GEODE_WRAPPER_OVERRIDE` env var 로 `PromptAssembler` Phase 0 에 전달되어
+system prompt 의 base 를 대체. 즉 dict 수정이 실제 wrapper 동작에 그대로
+반영. `--dry-run` 은 baseline emulation 으로 plumbing 검증 용도.
 
 ## Output format
 
@@ -123,8 +125,9 @@ d4e5f6g	0.000000	0.0	crash	rewrite system prompt in TOML — load fail
 2. `train.py` 의 `WRAPPER_PROMPT_SECTIONS` 를 1 hypothesis 로 수정 — 직접
    코드 hack.
 3. `git commit -am "exp: <짧은 description>"`.
-4. Audit 실행: `uv run python autoresearch/train.py --dry-run >
+4. Audit 실행: `uv run python autoresearch/train.py >
    autoresearch/state/run.log 2>&1` (redirect — stdout flood 금지).
+   Plumbing only smoke 면 `--dry-run` 추가.
 5. metric 추출: `grep "^fitness:\|^input_hallucination_mean:"
    autoresearch/state/run.log`. 빈 결과면 crash — `tail -n 50` 로 stack
    trace 확인 + 단순 fix 시도.

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -7,9 +7,9 @@ optimizer + train loop, ~630 LOC). 본 fork 의 train.py 는 같은 자리에
 
 Agent CAN modify:
   * ``WRAPPER_PROMPT_SECTIONS`` — system prompt 의 section dict. 추가 / 삭제
-    / 순서 변경 / wording 모두 fair game. 현재 GEODE runtime 은
-    ``GEODE_WRAPPER_OVERRIDE`` 를 아직 읽지 않으므로 ``--dry-run`` 만
-    non-deceptive working mode. real audit hook 은 follow-up PR 의 일.
+    / 순서 변경 / wording 모두 fair game. 본 dict 는 audit invoke 시
+    ``GEODE_WRAPPER_OVERRIDE`` env var 로 GEODE runtime 의
+    ``PromptAssembler`` Phase 0 에 전달되어 system prompt 의 base 를 대체.
   * ``BUDGET_MINUTES`` / ``TARGET_MODEL`` / ``JUDGE_MODEL`` / ``USE_OAUTH``
     같은 hyperparameter (한 번에 하나만 변경 권장).
 
@@ -20,7 +20,7 @@ Agent CANNOT modify (prepare.py 의 fixed ground-truth):
 
 Usage::
 
-    uv run python autoresearch/train.py             # staged real audit; fail-fast until hook lands
+    uv run python autoresearch/train.py             # real audit (cost!)
     uv run python autoresearch/train.py --dry-run   # skip subprocess, emit baseline
 
 Output: ``---`` separator + grep-friendly ``key: value`` lines on stdout.
@@ -49,7 +49,7 @@ SEED_LIMIT = 10
 SEED_SELECT = "plugins/petri_audit/seeds_safe10"
 DIM_SET_NAME = "5axes"
 MAX_TURNS = 10
-WRAPPER_OVERRIDE_HOOK_READY = False
+WRAPPER_OVERRIDE_HOOK_READY = True
 
 # Fitness 가중치 — Karpathy single-metric (val_bpb) 와 다르게 본 fork 는
 # 5-axis aggregate (gen 0 plan § 2). Agent 가 weight 자체는 수정 X — Q4 의

--- a/core/llm/prompt_assembler.py
+++ b/core/llm/prompt_assembler.py
@@ -10,8 +10,11 @@ Central assembly point that resolves the 5 disconnections identified in ADR-007:
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from core.hooks import HookEvent, HookSystem
@@ -19,6 +22,52 @@ from core.llm.prompts import _hash_prompt
 from core.llm.skill_registry import SkillDefinition, SkillRegistry
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-override loader (autoresearch outer-loop hook)
+# ---------------------------------------------------------------------------
+#
+# When ``GEODE_WRAPPER_OVERRIDE=<path-to-json>`` is set, the JSON file is
+# read as ``dict[str, str]`` and its values are concatenated to *replace*
+# ``base_system`` in :meth:`PromptAssembler.assemble`. autoresearch's
+# ``train.py`` writes this file before invoking ``geode audit``, so the
+# outer-loop's wrapper-section mutations actually reach the runtime.
+#
+# If the env var is absent, assembly proceeds with the unmodified
+# ``base_system``. If the env var is present but the payload cannot be loaded
+# as a non-empty ``dict[str, str]``, assembly fails closed so real-mode audits
+# cannot spend quota on an accidentally ignored mutation.
+
+_WRAPPER_OVERRIDE_ENV = "GEODE_WRAPPER_OVERRIDE"
+
+
+def _load_wrapper_override() -> dict[str, str] | None:
+    """Return the wrapper-section override dict, or ``None`` when disabled.
+
+    The env var is the opt-in signal. Once it is set, malformed payloads are
+    fatal because silently falling back to the baseline would make the
+    autoresearch mutation surface unobservable.
+    """
+    override_path = os.environ.get(_WRAPPER_OVERRIDE_ENV)
+    if not override_path:
+        return None
+    path = Path(override_path)
+    if not path.is_file():
+        raise RuntimeError(f"{_WRAPPER_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_WRAPPER_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    if not isinstance(data, dict) or not data:
+        raise RuntimeError(f"{_WRAPPER_OVERRIDE_ENV}={path} must be a non-empty dict[str, str]")
+    for key, value in data.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise RuntimeError(
+                f"{_WRAPPER_OVERRIDE_ENV}={path} has non-string key/value at {key!r}"
+            )
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -104,10 +153,21 @@ class PromptAssembler:
         Returns:
             ``AssembledPrompt`` with fully composed prompts and metadata.
         """
-        base_hash = _hash_prompt(base_system + base_user)
         fragments_used: list[str] = []
         skill_hashes: dict[str, str] = {}  # Karpathy P4: track skill content for drift
         truncation_events: list[str] = []  # Karpathy P6: record what was truncated
+
+        # --- Phase 0: Wrapper-level override (autoresearch outer-loop) ---
+        # GEODE_WRAPPER_OVERRIDE=<json-path> lets ``autoresearch/train.py``
+        # mutate the wrapper system prompt for a single audit run. The dict
+        # values replace ``base_system`` entirely; the rest of the assembly
+        # phases (skill / memory / extra) still apply on top.
+        wrapper_override = _load_wrapper_override()
+        if wrapper_override:
+            base_system = "\n\n".join(wrapper_override.values())
+            fragments_used.append(f"wrapper-override:{len(wrapper_override)}sections")
+
+        base_hash = _hash_prompt(base_system + base_user)
 
         # --- Phase 1: Prompt Override ---
         overrides = state.get("_prompt_overrides", {})

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1,15 +1,24 @@
 """Smoke tests for the Petri-signal autoresearch fork.
 
 These cover the surface that ruff/mypy/dry-run already exercise *and* the
-real-mode fail-fast that the dry-run can never reach. The point is to make
-sure the next time someone tweaks `geode audit` CLI flags or removes the
-`WRAPPER_OVERRIDE_HOOK_READY` guard, this catches the regression cheaply.
+real-mode plumbing (subprocess argv + env override path) that the dry-run
+can never reach. The point is to make sure the next time someone tweaks
+``geode audit`` CLI flags, flips ``WRAPPER_OVERRIDE_HOOK_READY`` back to
+``False``, or drops the wrapper-override env handoff, this catches the
+regression cheaply without touching real LLM quota.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
 import pytest
+from autoresearch import train as auto_train
 from autoresearch.train import (
+    WRAPPER_OVERRIDE_HOOK_READY,
     _build_audit_command,
     compute_fitness,
     run_audit,
@@ -28,16 +37,89 @@ def test_build_audit_command_uses_current_geode_audit_flags() -> None:
         assert stale not in argv, f"obsolete flag {stale} re-introduced in {argv}"
 
 
-def test_real_mode_fails_fast_until_runtime_hook_lands() -> None:
-    """Until ``core/`` reads ``GEODE_WRAPPER_OVERRIDE``, real mode must abort
-    rather than silently invoking an audit that ignores the mutation surface."""
-    with pytest.raises(RuntimeError, match="GEODE_WRAPPER_OVERRIDE"):
+def test_wrapper_override_hook_ready_is_true() -> None:
+    """Real-mode is gated by this flag. Flipping it back to ``False`` without
+    a corresponding GEODE core regression would re-deceive the outer loop."""
+    assert WRAPPER_OVERRIDE_HOOK_READY is True
+
+
+def test_real_mode_invokes_subprocess_with_override_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Real mode must (a) build argv, (b) export ``GEODE_WRAPPER_OVERRIDE``
+    pointing at a JSON dump of ``WRAPPER_PROMPT_SECTIONS``, and (c) parse
+    the audit's summary JSON. We mock the subprocess so this stays free."""
+    # Redirect state dir to a tmp path so we don't pollute the worktree.
+    monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", tmp_path / "state" / "audit_logs")
+    monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env", {})
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = (
+            "audit complete\n"
+            + json.dumps(
+                {
+                    "dim_means": {
+                        "broken_tool_use": 2.5,
+                        "input_hallucination": 2.0,
+                        "overrefusal": 1.2,
+                        "eval_awareness": 1.0,
+                        "unprompted_sycophancy": 1.0,
+                    }
+                }
+            )
+            + "\n"
+        )
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+
+    dim_means, audit_seconds, total_seconds = run_audit(dry_run=False)
+
+    # argv contains the current flag set
+    assert "--seed-select" in captured["argv"]
+    assert "--live" in captured["argv"]
+    # Env exports the override path, and the file actually contains the dict
+    override_path = captured["env"]["GEODE_WRAPPER_OVERRIDE"]
+    payload = json.loads(Path(override_path).read_text(encoding="utf-8"))
+    assert set(payload.keys()) == set(auto_train.WRAPPER_PROMPT_SECTIONS.keys())
+    # Dim means came from the mocked stdout
+    assert dim_means["input_hallucination"] == 2.0
+    assert audit_seconds >= 0.0
+    assert total_seconds >= audit_seconds
+
+
+def test_real_mode_raises_when_summary_json_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the audit subprocess does not emit the trailing summary JSON,
+    ``run_audit`` must fail loudly instead of silently zeroing fitness."""
+    monkeypatch.setattr(auto_train, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", tmp_path / "state" / "audit_logs")
+    monkeypatch.setattr(auto_train, "RUN_LOG", tmp_path / "state" / "run.log")
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "audit complete but no JSON\n"
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+
+    with pytest.raises(RuntimeError, match="summary JSON"):
         run_audit(dry_run=False)
 
 
 def test_dry_run_emits_baseline_dim_means_and_finite_fitness() -> None:
-    """The dry-run path is the *only* non-deceptive mode today; pin its
-    contract so the outer-loop scaffolding keeps working without quota."""
+    """The dry-run path stays cheap-and-deterministic for plumbing tests."""
     dim_means, audit_seconds, _ = run_audit(dry_run=True)
     assert dim_means["input_hallucination"] == pytest.approx(3.7)
     assert dim_means["broken_tool_use"] == pytest.approx(3.4)

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -30,6 +30,11 @@ def empty_state() -> dict[str, Any]:
     return {}
 
 
+@pytest.fixture(autouse=True)
+def clear_wrapper_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_WRAPPER_OVERRIDE", raising=False)
+
+
 @pytest.fixture()
 def mock_skill() -> SkillDefinition:
     return SkillDefinition(
@@ -413,3 +418,217 @@ class TestCombinedAssembly:
         assert "combo-skill:2.0" in result.fragments_used
         assert "memory-context" in result.fragments_used
         assert "bootstrap-extra:1" in result.fragments_used
+
+
+class TestWrapperOverrideHook:
+    """Phase 0 — GEODE_WRAPPER_OVERRIDE consumer (autoresearch outer-loop)."""
+
+    def _write_override(self, tmp_path: Path, payload: object) -> Path:
+        import json
+
+        path = tmp_path / "wrapper-override.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_no_env_var_keeps_base_system(
+        self,
+        tmp_path: Path,
+        base_system: str,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("GEODE_WRAPPER_OVERRIDE", raising=False)
+        assembler = PromptAssembler()
+        result = assembler.assemble(
+            base_system=base_system,
+            base_user=base_user,
+            state=empty_state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+        assert base_system in result.system
+        assert not any(f.startswith("wrapper-override:") for f in result.fragments_used)
+
+    def test_override_replaces_base_system(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        override_path = self._write_override(
+            tmp_path,
+            {
+                "role": "You are an autoresearch-mutated agent.",
+                "tool_handling": "Be extra careful with tool results.",
+            },
+        )
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(override_path))
+
+        assembler = PromptAssembler()
+        result = assembler.assemble(
+            base_system="ORIGINAL_BASELINE_DO_NOT_USE",
+            base_user=base_user,
+            state=empty_state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+        assert "ORIGINAL_BASELINE_DO_NOT_USE" not in result.system
+        assert "autoresearch-mutated agent" in result.system
+        assert "extra careful" in result.system
+        assert "wrapper-override:2sections" in result.fragments_used
+
+    def test_missing_file_raises(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(tmp_path / "nonexistent.json"))
+        assembler = PromptAssembler()
+        with pytest.raises(RuntimeError, match="file not found"):
+            assembler.assemble(
+                base_system="ORIGINAL",
+                base_user=base_user,
+                state=empty_state,
+                node="analyst",
+                role_type="game_mechanics",
+            )
+
+    def test_malformed_json_raises(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(bad))
+        assembler = PromptAssembler()
+        with pytest.raises(RuntimeError, match="load failed"):
+            assembler.assemble(
+                base_system="ORIGINAL",
+                base_user=base_user,
+                state=empty_state,
+                node="analyst",
+                role_type="game_mechanics",
+            )
+
+    def test_non_dict_payload_raises(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        override_path = self._write_override(tmp_path, ["not", "a", "dict"])
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(override_path))
+        assembler = PromptAssembler()
+        with pytest.raises(RuntimeError, match=r"non-empty dict\[str, str\]"):
+            assembler.assemble(
+                base_system="ORIGINAL",
+                base_user=base_user,
+                state=empty_state,
+                node="analyst",
+                role_type="game_mechanics",
+            )
+
+    def test_empty_dict_raises(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        override_path = self._write_override(tmp_path, {})
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(override_path))
+        assembler = PromptAssembler()
+        with pytest.raises(RuntimeError, match=r"non-empty dict\[str, str\]"):
+            assembler.assemble(
+                base_system="ORIGINAL",
+                base_user=base_user,
+                state=empty_state,
+                node="analyst",
+                role_type="game_mechanics",
+            )
+
+    def test_non_string_entries_raise(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        override_path = self._write_override(
+            tmp_path,
+            {"role": "good string", "bogus": 42, "also_bogus": ["list", "nope"]},
+        )
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(override_path))
+        assembler = PromptAssembler()
+        with pytest.raises(RuntimeError, match="non-string key/value"):
+            assembler.assemble(
+                base_system="ORIGINAL_BASE",
+                base_user=base_user,
+                state=empty_state,
+                node="analyst",
+                role_type="game_mechanics",
+            )
+
+    def test_override_hashes_change_with_payload(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        empty_state: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        first = self._write_override(tmp_path, {"role": "first mutation"})
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(first))
+        assembler = PromptAssembler()
+        first_result = assembler.assemble(
+            base_system="ORIGINAL_BASE",
+            base_user=base_user,
+            state=empty_state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+
+        second = tmp_path / "wrapper-override-2.json"
+        second.write_text('{"role": "second mutation"}', encoding="utf-8")
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(second))
+        second_result = assembler.assemble(
+            base_system="ORIGINAL_BASE",
+            base_user=base_user,
+            state=empty_state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+
+        assert first_result.base_template_hash == _hash_prompt("first mutation" + base_user)
+        assert second_result.base_template_hash == _hash_prompt("second mutation" + base_user)
+        assert first_result.base_template_hash != second_result.base_template_hash
+        assert first_result.assembled_hash != second_result.assembled_hash
+
+    def test_override_composes_with_extra_instructions(
+        self,
+        tmp_path: Path,
+        base_user: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        override_path = self._write_override(tmp_path, {"role": "mutated role"})
+        monkeypatch.setenv("GEODE_WRAPPER_OVERRIDE", str(override_path))
+        state: dict[str, Any] = {"_extra_instructions": ["never apologize"]}
+        assembler = PromptAssembler()
+        result = assembler.assemble(
+            base_system="ORIGINAL",
+            base_user=base_user,
+            state=state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+        # Wrapper override replaces base, then bootstrap extras still append.
+        assert "mutated role" in result.system
+        assert "ORIGINAL" not in result.system
+        assert "never apologize" in result.system


### PR DESCRIPTION
## Summary

- `core/llm/prompt_assembler.py` 의 `assemble()` 에 Phase 0 (Wrapper Override) — env var `GEODE_WRAPPER_OVERRIDE=<json-path>` 의 dict 를 `base_system` 으로 대체.
- `autoresearch/train.py` 의 `WRAPPER_OVERRIDE_HOOK_READY=True` flip — outer-loop agent 가 `WRAPPER_PROMPT_SECTIONS` 수정 시 실제 audit 의 system prompt 가 그 dict 로 동작.
- `.env.example` 에 새 env var 항목 + 설명. `autoresearch/{program,README}.md` 의 dry-run-only 경고 제거.

## Why

PR #1155 (autoresearch Karpathy fork) 가 `WRAPPER_PROMPT_SECTIONS` 를 mutation surface 로 도입했지만 GEODE core 가 그 env var 를 consume 하지 않아 real-mode 가 fail-fast 차단됨. 이 PR 이 그 hook 을 닫음 — autoresearch 의 outer loop 가 actual fitness Δ 신호를 받을 수 있는 첫 PR. gen 0 plan 의 9 hypothesis ablation 의 prerequisite.

## Changes

| File | Change |
|------|--------|
| `core/llm/prompt_assembler.py` | `_load_wrapper_override()` + assemble() Phase 0. env unset → baseline. env set + invalid → fail-closed `RuntimeError` (real audit quota 보호) |
| `autoresearch/train.py` | `WRAPPER_OVERRIDE_HOOK_READY = True`. docstring 정정 |
| `autoresearch/program.md` / `README.md` | dry-run-only 경고 제거, real-mode invoke 가 main path |
| `.env.example` | `# GEODE_WRAPPER_OVERRIDE=` 항목 + 설명 |
| `tests/test_prompt_assembler.py` | `TestWrapperOverrideHook` 9 신규 (env-unset baseline / 정상 override / missing file raises / malformed JSON raises / non-dict raises / empty dict raises / non-string entry raises / extra 합성 / hash 관측성) |
| `tests/test_autoresearch_train.py` | 기존 fail-fast test 를 real-mode subprocess argv/env 검증 + summary JSON missing raises 로 교체 (subprocess mock, quota 0) |
| `CHANGELOG.md` | Unreleased / Added KR+EN |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Phase 0 wired into assemble() | Implemented | `core/llm/prompt_assembler.py:178` |
| env var name = `GEODE_WRAPPER_OVERRIDE` | Implemented | `_WRAPPER_OVERRIDE_ENV` constant + `.env.example` |
| JSON `dict[str, str]` 스키마 | Implemented | `_load_wrapper_override()` 의 type 검증 |
| `base_template_hash` reflects override | Implemented | `base_hash = _hash_prompt(base_system + base_user)` 가 override 적용 후 계산 |
| `fragments_used` carries `wrapper-override:Nsections` | Implemented | PROMPT_ASSEMBLED hook 의 observability |
| Fail-closed on invalid payload | **Implemented (Codex CRITICAL fix)** | env set + missing/malformed/non-dict/empty/non-string → `RuntimeError` |
| Hash regression test | **Implemented (Codex HIGH fix)** | `test_override_hashes_change_with_payload` |
| `WRAPPER_OVERRIDE_HOOK_READY = True` | Implemented | `autoresearch/train.py:52` |
| `.env.example` 항목 | Implemented | doc + commented value |
| Docs sync (`program.md` / `README.md`) | Implemented | dry-run-only 경고 제거 |

## Cross-LLM verification (Codex MCP, third use)

Phase 1a (PR #1151) + autoresearch fork (PR #1155) 에 이어 본 PR 도 Codex MCP `mcp__codex__codex` (sandbox=`workspace-write`, approval=`never`, model=gpt-5.2-codex) 로 review. Codex 가 CRITICAL 1 + HIGH 1 자동 fix:

1. **CRITICAL** — env set + invalid 시 silently fallback 이 새 deception. autoresearch 의 의도된 mutation 인데 baseline prompt 로 audit 호출되어 quota 소비. → fail-closed `RuntimeError` 로 변경. test 들 모두 `pytest.raises` 로 update.
2. **HIGH** — outer-loop fitness Δ 의 traceability. 다른 mutation dump 가 같은 hash 면 어떤 mutation 의 효과인지 추적 불가. → `test_override_hashes_change_with_payload` 추가.

MEDIUM 권고 (recommendations only):
- subprocess returncode != 0 의 negative test 부재 (production code 는 raise — test depth 만 부족)
- env var scope 는 process-wide (현재 의도; node-scoped override 가 필요해지면 별도 fix)

## Verification

- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run mypy core/ plugins/` — `Success: no issues found in 363 source files`
- [x] `uv run pytest tests/test_prompt_assembler.py tests/test_autoresearch_train.py -q` — 29 passed
- [x] `uv run python autoresearch/train.py --dry-run` — `fitness: 0.535895` (unchanged)
- [ ] CI 5/5 (PR 후 watch)

## Reference

- 1차 fork: PR #1155 (Karpathy 3-file fork)
- Codex MCP first use: PR #1151 (Phase 1a)
- Karpathy autoresearch: https://github.com/karpathy/autoresearch (228791f)
- Local reference: `~/workspace/autoresearch`
- Gen 0 plan: `docs/audits/2026-05-15-autoresearch-gen0-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code), cross-verified by Codex MCP