### PR TITLE
chore(release): v0.95.1 — Unreleased stamp + 4-location version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.95.1] — 2026-05-16
+
 ### Fixed
 
 - **Docs 사이트 broken link 3 개 정정 (6 사이트).** docs 사이트 내부 링크

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.95.0
+- **Version**: 0.95.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.95.0 — Long-running Autonomous Execution Harness
+# GEODE v0.95.1 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -309,7 +309,7 @@ uv tool install -e . --force
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.1**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.95.0 — Long-running Autonomous Execution Harness
+# GEODE v0.95.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.1**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.95.0"
+version = "0.95.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- [Unreleased] 누적 stamp → `[0.95.1] — 2026-05-16`. SemVer PATCH (사용자 결정, 외부 API 변화 없음).
- 4-location version sync: `pyproject.toml` / `CLAUDE.md` / `README.md` (× 2 위치) / `README.ko.md` (× 2 위치) → 0.95.1.

## Why

`feedback_about_sync` 가 반복적으로 짚는 누락: version bump 시 4 location 동기 필수. 이번 sprint 의 [Unreleased] 가 0.95.0 (2026-05-12) 이후 큰 누적 — 닫지 않으면 release discipline 위반 ("No leaving `[Unreleased]` on main").

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `version = "0.95.1"` |
| `CLAUDE.md` | `Version: 0.95.1` |
| `README.md` | heading + frontier comparison line `GEODE v0.95.1` |
| `README.ko.md` | 위와 동일 |
| `CHANGELOG.md` | `[Unreleased]` 빈 헤더 유지 + 그 아래 `[0.95.1] — 2026-05-16` stamp |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] 4 location grep 일치
- [ ] CI 5/5 (PR 후 watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)