### PR TITLE
docs(skills): docs-link-audit skill 등록

### DIFF
--- a/.claude/skills/docs-link-audit/SKILL.md
+++ b/.claude/skills/docs-link-audit/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: docs-link-audit
+description: Docs 사이트 (`site/` Next.js) 의 본문/JSX/markdown 링크 audit. broken 내부 링크 탐지, build-time copy 인지, 옵트인 HTTP probe. 신규 페이지 추가 / slug 이전 / chapter 삭제 후 회귀 방지. Triggered by "broken link", "404", "docs link", "hyperlink", "링크 점검", "링크 깨짐", "audit links", "link checker" 키워드.
+user-invocable: false
+---
+
+# Docs Link Audit
+
+`site/` Next.js docs 사이트의 모든 본문 링크를 정적 + 옵션 HTTP 로 검사한다.
+`scripts/check_docs_links.py` 가 본 워크플로의 1차 도구.
+
+## 언제 가동되는가
+
+신규 페이지 추가 / chapter 삭제 / slug 이전 / cross-link 개정 후. 또한
+사용자가 "404 뜨는 부분 잡자" / "링크 깨진 것 확인해줘" 같은 요청을 했을 때.
+
+## 1차 도구 — `scripts/check_docs_links.py`
+
+```
+$ python3 scripts/check_docs_links.py              # 정적 audit (1초)
+$ python3 scripts/check_docs_links.py --http       # + 외부 reachability (~10초)
+$ python3 scripts/check_docs_links.py --quiet      # broken 만 출력 (CI 적합)
+```
+
+### 분류 4 종
+
+| Category | 매칭 패턴 | 검증 방법 |
+|---|---|---|
+| **internal /docs/...** | `href="/docs/runtime/foo"` | `site/src/app/docs/**/page.tsx` slug set 과 차집합 |
+| **internal /<other>...** | `/portfolio`, `/petri-bundle/`, `/llms.txt` | app route + `site/public/` asset + build-time copy 와 대조 |
+| **anchor #section** | `href="#tier-3"` | 같은 page.tsx 의 `id="..."` 와 대조 |
+| **external https://** | `<a href="https://github.com/...">` | `--http` 옵트인 시 HEAD/GET, concurrency 8, 8s timeout, 200/3xx OK |
+
+### Link 패턴 추출 — 2 개 정규식
+
+| Pattern | 매칭 예시 |
+|---|---|
+| `\b(?:href\|src\|to)\s*=\s*\{?\s*['"`​]([^'"`​{}\s]+)['"`​]` | `href="..."`, `href={"..."}`, `href={`...`}`, `src="/img.svg"`, `to="/portfolio"` |
+| `\]\(([^)\s]+)\)` | markdown `[text](url)` — `MarkdownLite` 가 렌더하는 CHANGELOG entry 등 |
+
+### 특이 처리
+
+- **`/geode/` deploy basepath 정규화** — `/geode/docs/foo` 도 source-side `/docs/foo` 와 매칭
+- **Build-time copy 인지** — `.github/workflows/pages.yml` 의 `docs/petri-bundle/` → `site/out/petri-bundle/` copy step 알기 때문에 `/petri-bundle/` 가 source 에 없어도 OK
+- **`${...}` 보간 + relative URL** → `unresolved` 로 분리 (broken 아님)
+- **스킴 스킵** — `mailto:`, `tel:`, `javascript:`, `data:`, `blob:`
+- **`requests` 미설치 시** `--http` 옵션 자동 비활성
+
+### Exit codes — CI guard 가능
+
+| Code | 의미 |
+|---|---|
+| 0 | broken 없음 |
+| 1 | 1+ broken 발견 |
+| 2 | argparse / IO 에러 |
+
+## Workflow — 새 페이지 또는 cross-link 수정 후
+
+```
+1. 변경 → 본 변경이 새 페이지 추가 / slug 이전 / chapter 삭제 / cross-link 갱신 중 하나
+        ↓
+2. python3 scripts/check_docs_links.py
+        ↓
+3. broken 0 → 통과; PR 으로 진행
+   broken N → 메시지의 file:line 으로 이동 + slug 정정
+        ↓
+4. (선택) --http 도 돌려서 외부 URL reachability 확인
+        ↓
+5. PR cascade — fix(docs): broken link N 종 정정 (M 사이트)
+```
+
+## 잘못된 link 의 4 흔한 원인
+
+| 패턴 | 발생 시점 | 해결책 |
+|---|---|---|
+| **Chapter 삭제 후 cross-link leftover** | 옛 `build/` 챕터 삭제했는데 다른 페이지가 `/docs/build/add-domain` 참조 | 이전 destination 확인 후 새 slug 로 교체 — sitemap.ts 의 새 entry 가 1차 단서 |
+| **Section 이전** | `/docs/ops/observability` → `/docs/verification/observability` 로 옮겼는데 cross-link 갱신 누락 | 동일 |
+| **Slug 오타** | 페이지 처음 작성 시 디렉터리 명 오타 | typo 수정 |
+| **External URL 만료** | 외부 doc 의 link 가 404 (e.g. dev portal 페이지 이전) | `--http` 가 잡음. 새 URL 또는 archive.org 로 교체 |
+
+## CI wiring (선택, 별 PR)
+
+A. **Pages build pre-step** — `pages.yml` 의 build job 최상단에 추가:
+
+```yaml
+- name: Verify docs links
+  run: python3 scripts/check_docs_links.py
+```
+
+→ broken 들어오면 deploy 차단.
+
+B. **Lint job** — `ci.yml` 에 별 job, dispatch 시 `--http` 포함:
+
+```yaml
+docs-links:
+  if: github.event_name == 'workflow_dispatch'
+  steps:
+    - run: pip install requests
+    - run: python3 scripts/check_docs_links.py --http
+```
+
+→ 매일/주간 schedule cron 으로 외부 link rot 감지.
+
+## 실제 case study
+
+| 날짜 | broken 수 | 정정 방식 |
+|---|---|---|
+| 2026-05-16 PR #1157 | 3 broken × 6 ref site | 모든 destination 이 sitemap 에 다른 slug 로 존재. 단순 경로 교체 |
+| 2026-05-16 PR #1161 | 0 (script 도입) | check_docs_links.py 추가 + 위 case study 결과 0 broken 측정 |
+
+PR #1157 의 3 broken:
+
+- `/docs/build/add-domain` → `/docs/runtime/domains` (`build/` chapter D 스프린트에서 삭제됨)
+- `/docs/build/add-tool` → `/docs/runtime/tools/protocol`
+- `/docs/ops/observability` → `/docs/verification/observability` (section 이전)
+
+ad-hoc grep 으로 잡았지만 본 스크립트가 다음번부터는 1 명령으로 검출.
+
+## 한계 + 알려진 false positive
+
+| 항목 | 한계 |
+|---|---|
+| **Dynamic `href={url}`** | 변수 보간된 link 는 정적 분석 불가 → `unresolved` (broken 아님) |
+| **External URL rate-limit / login wall** | `--http` 가 401/403 받으면 broken 으로 분류 — 일부 사이트 (Anthropic dev portal 등) 가 anti-bot 으로 403 가능 |
+| **Anchor 검사 단위** | 같은 page.tsx 내 anchor 만 검증. 크로스 페이지 anchor `/docs/foo#bar` 는 `/docs/foo` 만 OK 면 통과 (anchor 자체는 검증 안 됨) |
+| **MarkdownLite regex 패턴 문자열** | `markdown-lite.tsx:14,133` 의 regex 안의 `url` 문자열이 markdown link `]( )` 패턴 매칭 — 2 unresolved 항상 발생 (false positive, 무시) |
+
+## 관련 skill
+
+- `geode-changelog` — CHANGELOG entry 작성 (모든 doc fix PR 에 필수)
+- `geode-gitflow` — feature → develop → main cascade (broken link fix 도 동일)
+- `frontier-harness-research` — peer comparison 표가 외부 URL 다수 → `--http` audit 가치 큼

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Infrastructure
 
+- **`docs-link-audit` skill 등록.** `scripts/check_docs_links.py` (PR #1161)
+  를 1차 도구로 하는 workflow skill 을 `.claude/skills/docs-link-audit/
+  SKILL.md` 에 추가. 분류 4 종 (internal /docs / internal /other / anchor
+  / external) 매핑 표, link 패턴 추출 정규식 2 개, 특이 처리 (`/geode/`
+  basepath / build-time copy 인지 / `${...}` unresolved / 스킴 스킵), exit
+  code 기반 CI guard, 잘못된 link 의 4 흔한 원인 (chapter 삭제 leftover /
+  section 이전 / slug typo / external rot), CI wiring 옵션 2 종 (pages.yml
+  pre-build / ci.yml dispatch) 모두 정리. CLAUDE.md 의 Custom Skills 표
+  에도 트리거 키워드 ("broken link", "404", "docs link", "hyperlink",
+  "링크 점검", "링크 깨짐", "audit links", "link checker") 등록. PR
+  #1157 (3 broken 정정) + PR #1161 (script 도입) 의 케이스 스터디 포함.
+- **`docs-link-audit` skill registered.** Added
+  `.claude/skills/docs-link-audit/SKILL.md` as a workflow skill around
+  `scripts/check_docs_links.py` (PR #1161). Covers the 4-category map
+  (internal /docs / internal /other / anchor / external), the 2
+  regexes that drive link extraction, special handling (`/geode/`
+  basepath, build-time copy awareness, `${...}` as unresolved, scheme
+  skip list), exit-code-based CI guard semantics, four common
+  root causes of broken links (chapter deletion leftover, section
+  move, slug typo, external rot), and two CI wiring options (pages.yml
+  pre-build vs ci.yml dispatch). CLAUDE.md Custom Skills table now
+  carries the trigger keywords ("broken link", "404", "docs link",
+  "hyperlink", "링크 점검", "링크 깨짐", "audit links", "link
+  checker"). Case studies from PR #1157 (3 broken corrected) + PR
+  #1161 (script introduction) included.
+
 - **`scripts/check_docs_links.py` — docs 사이트 링크 정적 + HTTP 점검
   스크립트.** site/src 의 모든 `.tsx`/`.ts` 에서 본문/JSX 링크 패턴 (
   `href="..."`, ``href={`...`}``, `src="..."`, `to="..."`, 그리고 markdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,3 +341,4 @@ Skills used by Scaffold during GEODE development (`.claude/skills/`). Separate f
 | `codebase-audit` | audit, dead code, refactor, god object, duplication | Code audit + refactoring workflow (v0.24.0 proven) |
 | `geode-serve` | serve, gateway, slack, binding, poller, config.toml | Slack Gateway operations + debugging guide |
 | `long-task-watcher` | monitor, tail -F, progress, background, live audit, stdbuf, buffering | Long-running task watching patterns. Petri × GEODE 의 N7' Monitor 타임아웃 사례 + 안정 패턴 (cat-and-grep / stdbuf streaming / polling) |
+| `docs-link-audit` | broken link, 404, docs link, hyperlink, 링크 점검, 링크 깨짐, audit links, link checker | Docs 사이트 (`site/` Next.js) 본문/JSX/markdown 링크 audit. `scripts/check_docs_links.py` 가 4 카테고리 (internal /docs / internal /other / anchor / external) 검증, build-time copy 인지, exit code 기반 CI guard 가능. PR #1157/#1161 케이스 스터디 포함 |


### PR DESCRIPTION
## Summary

- \`.claude/skills/docs-link-audit/SKILL.md\` 신규 — PR #1161 의 \`scripts/check_docs_links.py\` 를 1차 도구로 하는 audit 워크플로
- CLAUDE.md 의 Custom Skills 표에도 트리거 키워드 등록
- 행위 변경 0, 순수 문서

## Why

사용자 요청: "관련 사안 skill로 등록해둬". PR #1157/#1161 에서 검증한 broken-link audit 패턴이 향후 새 페이지 추가 / chapter 이전 / slug rename 때 재발할 surface. ad-hoc grep 으로 재발견하지 않고 \`/docs-link-audit\` 키워드로 즉시 workflow 진입 가능하도록 등록.

## SKILL.md 내용

| 섹션 | 내용 |
|---|---|
| 1차 도구 | \`scripts/check_docs_links.py\` 호출 방식 3 (정적 / \`--http\` / \`--quiet\`) |
| 분류 4 종 | internal /docs / internal /other / anchor / external 각각 매핑 |
| Link 패턴 | JSX \`href/src/to\` + markdown \`](url)\` 정규식 2 |
| 특이 처리 | \`/geode/\` basepath / build-time copy / \`\${...}\` unresolved / 스킴 스킵 |
| Exit codes | 0/1/2 — CI guard 가능 |
| Workflow | 변경 → script 실행 → broken 발견 시 file:line 추적 → 정정 → PR cascade |
| 4 원인 | chapter 삭제 leftover / section 이전 / slug typo / external rot |
| CI wiring | pages.yml pre-build + ci.yml dispatch 2 옵션 |
| Case study | PR #1157 (3 broken × 6 site) + #1161 (script 도입) |
| 한계 | dynamic href / external rate-limit / cross-page anchor / regex 패턴 false positive |

## Changes

| File | Change |
|------|--------|
| \`.claude/skills/docs-link-audit/SKILL.md\` | NEW (159 lines) — yaml frontmatter + 워크플로 본문 |
| \`CLAUDE.md\` | Custom Skills 표 마지막 행에 \`docs-link-audit\` 추가 |
| \`CHANGELOG.md\` | \`[Unreleased] > Infrastructure\` KR/EN |

## Verification

- [x] git add -f 로 .claude/skills/ gitignore 우회 (기존 26 skill 과 동일 방식)
- [x] frontmatter 형식 (name / description / user-invocable) 이 기존 skill 과 일치
- [x] trigger keyword 가 한/영 모두 포함 (broken link, 404, 링크 점검 등)
- [x] 행위 변경 0 — 문서만