### PR TITLE
release: v0.95.1 stamp + check_docs_links script

### DIFF
--- a/.claude/skills/docs-link-audit/SKILL.md
+++ b/.claude/skills/docs-link-audit/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: docs-link-audit
+description: Docs 사이트 (`site/` Next.js) 의 본문/JSX/markdown 링크 audit. broken 내부 링크 탐지, build-time copy 인지, 옵트인 HTTP probe. 신규 페이지 추가 / slug 이전 / chapter 삭제 후 회귀 방지. Triggered by "broken link", "404", "docs link", "hyperlink", "링크 점검", "링크 깨짐", "audit links", "link checker" 키워드.
+user-invocable: false
+---
+
+# Docs Link Audit
+
+`site/` Next.js docs 사이트의 모든 본문 링크를 정적 + 옵션 HTTP 로 검사한다.
+`scripts/check_docs_links.py` 가 본 워크플로의 1차 도구.
+
+## 언제 가동되는가
+
+신규 페이지 추가 / chapter 삭제 / slug 이전 / cross-link 개정 후. 또한
+사용자가 "404 뜨는 부분 잡자" / "링크 깨진 것 확인해줘" 같은 요청을 했을 때.
+
+## 1차 도구 — `scripts/check_docs_links.py`
+
+```
+$ python3 scripts/check_docs_links.py              # 정적 audit (1초)
+$ python3 scripts/check_docs_links.py --http       # + 외부 reachability (~10초)
+$ python3 scripts/check_docs_links.py --quiet      # broken 만 출력 (CI 적합)
+```
+
+### 분류 4 종
+
+| Category | 매칭 패턴 | 검증 방법 |
+|---|---|---|
+| **internal /docs/...** | `href="/docs/runtime/foo"` | `site/src/app/docs/**/page.tsx` slug set 과 차집합 |
+| **internal /<other>...** | `/portfolio`, `/petri-bundle/`, `/llms.txt` | app route + `site/public/` asset + build-time copy 와 대조 |
+| **anchor #section** | `href="#tier-3"` | 같은 page.tsx 의 `id="..."` 와 대조 |
+| **external https://** | `<a href="https://github.com/...">` | `--http` 옵트인 시 HEAD/GET, concurrency 8, 8s timeout, 200/3xx OK |
+
+### Link 패턴 추출 — 2 개 정규식
+
+| Pattern | 매칭 예시 |
+|---|---|
+| `\b(?:href\|src\|to)\s*=\s*\{?\s*['"`​]([^'"`​{}\s]+)['"`​]` | `href="..."`, `href={"..."}`, `href={`...`}`, `src="/img.svg"`, `to="/portfolio"` |
+| `\]\(([^)\s]+)\)` | markdown `[text](url)` — `MarkdownLite` 가 렌더하는 CHANGELOG entry 등 |
+
+### 특이 처리
+
+- **`/geode/` deploy basepath 정규화** — `/geode/docs/foo` 도 source-side `/docs/foo` 와 매칭
+- **Build-time copy 인지** — `.github/workflows/pages.yml` 의 `docs/petri-bundle/` → `site/out/petri-bundle/` copy step 알기 때문에 `/petri-bundle/` 가 source 에 없어도 OK
+- **`${...}` 보간 + relative URL** → `unresolved` 로 분리 (broken 아님)
+- **스킴 스킵** — `mailto:`, `tel:`, `javascript:`, `data:`, `blob:`
+- **`requests` 미설치 시** `--http` 옵션 자동 비활성
+
+### Exit codes — CI guard 가능
+
+| Code | 의미 |
+|---|---|
+| 0 | broken 없음 |
+| 1 | 1+ broken 발견 |
+| 2 | argparse / IO 에러 |
+
+## Workflow — 새 페이지 또는 cross-link 수정 후
+
+```
+1. 변경 → 본 변경이 새 페이지 추가 / slug 이전 / chapter 삭제 / cross-link 갱신 중 하나
+        ↓
+2. python3 scripts/check_docs_links.py
+        ↓
+3. broken 0 → 통과; PR 으로 진행
+   broken N → 메시지의 file:line 으로 이동 + slug 정정
+        ↓
+4. (선택) --http 도 돌려서 외부 URL reachability 확인
+        ↓
+5. PR cascade — fix(docs): broken link N 종 정정 (M 사이트)
+```
+
+## 잘못된 link 의 4 흔한 원인
+
+| 패턴 | 발생 시점 | 해결책 |
+|---|---|---|
+| **Chapter 삭제 후 cross-link leftover** | 옛 `build/` 챕터 삭제했는데 다른 페이지가 `/docs/build/add-domain` 참조 | 이전 destination 확인 후 새 slug 로 교체 — sitemap.ts 의 새 entry 가 1차 단서 |
+| **Section 이전** | `/docs/ops/observability` → `/docs/verification/observability` 로 옮겼는데 cross-link 갱신 누락 | 동일 |
+| **Slug 오타** | 페이지 처음 작성 시 디렉터리 명 오타 | typo 수정 |
+| **External URL 만료** | 외부 doc 의 link 가 404 (e.g. dev portal 페이지 이전) | `--http` 가 잡음. 새 URL 또는 archive.org 로 교체 |
+
+## CI wiring (선택, 별 PR)
+
+A. **Pages build pre-step** — `pages.yml` 의 build job 최상단에 추가:
+
+```yaml
+- name: Verify docs links
+  run: python3 scripts/check_docs_links.py
+```
+
+→ broken 들어오면 deploy 차단.
+
+B. **Lint job** — `ci.yml` 에 별 job, dispatch 시 `--http` 포함:
+
+```yaml
+docs-links:
+  if: github.event_name == 'workflow_dispatch'
+  steps:
+    - run: pip install requests
+    - run: python3 scripts/check_docs_links.py --http
+```
+
+→ 매일/주간 schedule cron 으로 외부 link rot 감지.
+
+## 실제 case study
+
+| 날짜 | broken 수 | 정정 방식 |
+|---|---|---|
+| 2026-05-16 PR #1157 | 3 broken × 6 ref site | 모든 destination 이 sitemap 에 다른 slug 로 존재. 단순 경로 교체 |
+| 2026-05-16 PR #1161 | 0 (script 도입) | check_docs_links.py 추가 + 위 case study 결과 0 broken 측정 |
+
+PR #1157 의 3 broken:
+
+- `/docs/build/add-domain` → `/docs/runtime/domains` (`build/` chapter D 스프린트에서 삭제됨)
+- `/docs/build/add-tool` → `/docs/runtime/tools/protocol`
+- `/docs/ops/observability` → `/docs/verification/observability` (section 이전)
+
+ad-hoc grep 으로 잡았지만 본 스크립트가 다음번부터는 1 명령으로 검출.
+
+## 한계 + 알려진 false positive
+
+| 항목 | 한계 |
+|---|---|
+| **Dynamic `href={url}`** | 변수 보간된 link 는 정적 분석 불가 → `unresolved` (broken 아님) |
+| **External URL rate-limit / login wall** | `--http` 가 401/403 받으면 broken 으로 분류 — 일부 사이트 (Anthropic dev portal 등) 가 anti-bot 으로 403 가능 |
+| **Anchor 검사 단위** | 같은 page.tsx 내 anchor 만 검증. 크로스 페이지 anchor `/docs/foo#bar` 는 `/docs/foo` 만 OK 면 통과 (anchor 자체는 검증 안 됨) |
+| **MarkdownLite regex 패턴 문자열** | `markdown-lite.tsx:14,133` 의 regex 안의 `url` 문자열이 markdown link `]( )` 패턴 매칭 — 2 unresolved 항상 발생 (false positive, 무시) |
+
+## 관련 skill
+
+- `geode-changelog` — CHANGELOG entry 작성 (모든 doc fix PR 에 필수)
+- `geode-gitflow` — feature → develop → main cascade (broken link fix 도 동일)
+- `frontier-harness-research` — peer comparison 표가 외부 URL 다수 → `--http` audit 가치 큼

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,50 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **`scripts/check_docs_links.py` — docs 사이트 링크 정적 + HTTP 점검
+  스크립트.** site/src 의 모든 `.tsx`/`.ts` 에서 본문/JSX 링크 패턴 (
+  `href="..."`, ``href={`...`}``, `src="..."`, `to="..."`, 그리고 markdown
+  스타일 `[text](url)`) 을 모두 추출. 4 분류:
+  - **internal /docs/...** — `site/src/app/docs/` 하위 `page.tsx` slug
+    와 차집합 → 누락 시 broken
+  - **internal /<other>...** — `/portfolio`, `/works`, `/petri-bundle/`
+    등 → app route + public asset + build-time copy (pages.yml 의
+    `docs/petri-bundle/` → `site/out/petri-bundle/` step 인지) 와 대조
+  - **anchor #section** — 같은 page.tsx 의 `id="..."` 와 대조
+  - **external http(s)://** — `--http` 옵트인 시 HEAD/GET 으로 reachability
+    검사 (concurrent 8, 8s timeout, 200/3xx OK)
+  CI 통합 옵션: `python3 scripts/check_docs_links.py` 만으로 정적 검사
+  통과 시 exit 0, broken 발견 시 exit 1. 향후 pages.yml build job 의
+  pre-build step 또는 별 ci.yml lint 으로 wiring 가능.
+
+  현재 측정 (이 PR 적용 후): 193 link 스캔, 0 broken, 17 external 모두
+  reachable, 2 unresolved (markdown-lite.tsx 의 regex 패턴 문자열, false
+  positive 무시).
+- **`scripts/check_docs_links.py` — static + HTTP audit script for docs
+  site links.** Extracts every link-shaped string from `site/src/**.tsx`
+  / `.ts` (JSX `href="..."`, ``href={`...`}``, `src="..."`, `to="..."`,
+  and markdown-style `[text](url)` inside string literals). Classifies
+  into four buckets:
+  - **internal /docs/...** — diffed against the `page.tsx` slug set
+    under `site/src/app/docs/`; misses flagged.
+  - **internal /\<other\>...** — `/portfolio`, `/works`,
+    `/petri-bundle/` etc., diffed against app routes + public assets +
+    build-time copies (the script recognises the
+    `docs/petri-bundle/` → `site/out/petri-bundle/` copy step in
+    `.github/workflows/pages.yml`).
+  - **anchor #section** — checked against `id="..."` occurrences in
+    the emitting `page.tsx`.
+  - **external http(s)://** — opt-in `--http` HEAD/GET probe
+    (concurrency 8, 8 s timeout, 200/3xx considered OK).
+  Returns exit 0 on a clean run and exit 1 if anything is broken, so
+  the script can later be wired into the Pages build (pre-build step)
+  or into the `ci.yml` lint job. Current measurement after this PR:
+  193 link occurrences scanned, 0 broken, all 17 external URLs
+  reachable, 2 false-positive "unresolved" entries from regex pattern
+  strings in `markdown-lite.tsx` (informational, not failure).
+
 ### Fixed
 
 - **Docs 사이트 broken link 3 개 정정 (6 사이트).** docs 사이트 내부 링크

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Infrastructure
 
+- **`docs-link-audit` skill 등록.** `scripts/check_docs_links.py` (PR #1161)
+  를 1차 도구로 하는 workflow skill 을 `.claude/skills/docs-link-audit/
+  SKILL.md` 에 추가. 분류 4 종 (internal /docs / internal /other / anchor
+  / external) 매핑 표, link 패턴 추출 정규식 2 개, 특이 처리 (`/geode/`
+  basepath / build-time copy 인지 / `${...}` unresolved / 스킴 스킵), exit
+  code 기반 CI guard, 잘못된 link 의 4 흔한 원인 (chapter 삭제 leftover /
+  section 이전 / slug typo / external rot), CI wiring 옵션 2 종 (pages.yml
+  pre-build / ci.yml dispatch) 모두 정리. CLAUDE.md 의 Custom Skills 표
+  에도 트리거 키워드 ("broken link", "404", "docs link", "hyperlink",
+  "링크 점검", "링크 깨짐", "audit links", "link checker") 등록. PR
+  #1157 (3 broken 정정) + PR #1161 (script 도입) 의 케이스 스터디 포함.
+- **`docs-link-audit` skill registered.** Added
+  `.claude/skills/docs-link-audit/SKILL.md` as a workflow skill around
+  `scripts/check_docs_links.py` (PR #1161). Covers the 4-category map
+  (internal /docs / internal /other / anchor / external), the 2
+  regexes that drive link extraction, special handling (`/geode/`
+  basepath, build-time copy awareness, `${...}` as unresolved, scheme
+  skip list), exit-code-based CI guard semantics, four common
+  root causes of broken links (chapter deletion leftover, section
+  move, slug typo, external rot), and two CI wiring options (pages.yml
+  pre-build vs ci.yml dispatch). CLAUDE.md Custom Skills table now
+  carries the trigger keywords ("broken link", "404", "docs link",
+  "hyperlink", "링크 점검", "링크 깨짐", "audit links", "link
+  checker"). Case studies from PR #1157 (3 broken corrected) + PR
+  #1161 (script introduction) included.
+
 - **`scripts/check_docs_links.py` — docs 사이트 링크 정적 + HTTP 점검
   스크립트.** site/src 의 모든 `.tsx`/`.ts` 에서 본문/JSX 링크 패턴 (
   `href="..."`, ``href={`...`}``, `src="..."`, `to="..."`, 그리고 markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.95.1] — 2026-05-16
+
 ### Fixed
 
 - **Docs 사이트 broken link 3 개 정정 (6 사이트).** docs 사이트 내부 링크

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,3 +341,4 @@ Skills used by Scaffold during GEODE development (`.claude/skills/`). Separate f
 | `codebase-audit` | audit, dead code, refactor, god object, duplication | Code audit + refactoring workflow (v0.24.0 proven) |
 | `geode-serve` | serve, gateway, slack, binding, poller, config.toml | Slack Gateway operations + debugging guide |
 | `long-task-watcher` | monitor, tail -F, progress, background, live audit, stdbuf, buffering | Long-running task watching patterns. Petri × GEODE 의 N7' Monitor 타임아웃 사례 + 안정 패턴 (cat-and-grep / stdbuf streaming / polling) |
+| `docs-link-audit` | broken link, 404, docs link, hyperlink, 링크 점검, 링크 깨짐, audit links, link checker | Docs 사이트 (`site/` Next.js) 본문/JSX/markdown 링크 audit. `scripts/check_docs_links.py` 가 4 카테고리 (internal /docs / internal /other / anchor / external) 검증, build-time copy 인지, exit code 기반 CI guard 가능. PR #1157/#1161 케이스 스터디 포함 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.95.0
+- **Version**: 0.95.1
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.95.0 — Long-running Autonomous Execution Harness
+# GEODE v0.95.1 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -309,7 +309,7 @@ uv tool install -e . --force
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.1**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.95.0 — Long-running Autonomous Execution Harness
+# GEODE v0.95.1 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.1**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.95.0"
+version = "0.95.1"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+
+r"""check_docs_links — static + optional HTTP audit of every link in the docs site.
+
+Walks ``site/src/`` for every link-shaped string and classifies it:
+
+* **internal /docs/...** → must map to a page slug under ``site/src/app/docs/``.
+* **internal /\<other\>...** → must map to a ``page.tsx`` under ``site/src/app/``.
+* **anchor #...** → must match an ``id="..."`` somewhere on the page that emits it.
+* **external http(s)://...** → reachable (HTTP 200/301/302/304 considered OK).
+  Network check is opt-in via ``--http`` because it is slow + flaky on CI.
+
+Build-time copy steps (e.g. ``docs/petri-bundle/`` → ``site/out/petri-bundle/``
+done by ``.github/workflows/pages.yml``) are recognised so paths that are
+served on the deployed site but absent from ``site/public/`` do not yield
+false positives.
+
+Scans these link patterns:
+
+* JSX/TSX attribute       : ``href="..."``                          ``to="..."``
+* JSX/TSX expr container  : ``href={"..."}`` ``href={`...`}``       ``src="..."``
+* Markdown inside strings : ``[text](url)`` (CHANGELOG entries etc.)
+
+Skips:
+
+* ``mailto:`` / ``tel:`` / ``javascript:``
+* template strings whose interpolation cannot be resolved statically
+  (these are reported as ``UNRESOLVED`` instead of failed; treat as
+  informational so a CI run does not block on dynamic links).
+
+Exit codes:
+
+* 0 — no broken links
+* 1 — at least one broken link
+* 2 — argparse / IO error
+
+Usage::
+
+    python scripts/check_docs_links.py                # static only
+    python scripts/check_docs_links.py --http         # + reachability
+    python scripts/check_docs_links.py --base site    # alt site root
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Patterns
+
+# Captures the link string regardless of quote style — single, double, backtick.
+# Allows `href={"..."}` and `href={`...`}` JSX expr forms by stripping `{` `}`.
+_LINK_PATTERNS = [
+    # JSX attribute href / src / to (incl. `{` wrapper for expr)
+    re.compile(r"""\b(?:href|src|to)\s*=\s*\{?\s*['"`]([^'"`{}\s]+)['"`]"""),
+    # Markdown link inside JS/TS strings — [text](url)
+    re.compile(r"""\]\(([^)\s]+)\)"""),
+]
+
+_SKIP_SCHEMES = ("mailto:", "tel:", "javascript:", "data:", "blob:")
+_NETWORK_OK = {200, 201, 301, 302, 303, 304, 307, 308}
+
+
+class Link(NamedTuple):
+    """One link occurrence in a source file."""
+
+    target: str
+    file: Path
+    line: int
+
+
+def discover_links(root: Path) -> list[Link]:
+    """Walk *.tsx / *.ts under ``root`` and emit every link-shaped string."""
+    out: list[Link] = []
+    for path in sorted(root.rglob("*")):
+        if path.suffix not in {".tsx", ".ts"}:
+            continue
+        if "node_modules" in path.parts or ".next" in path.parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for pattern in _LINK_PATTERNS:
+                for match in pattern.finditer(line):
+                    target = match.group(1).strip()
+                    if not target or target.startswith(_SKIP_SCHEMES):
+                        continue
+                    if "${" in target:
+                        # interpolated — record as unresolved (reported but
+                        # not counted as broken)
+                        out.append(Link(target=f"UNRESOLVED:{target}", file=path, line=lineno))
+                        continue
+                    out.append(Link(target=target, file=path, line=lineno))
+    return out
+
+
+def discover_app_pages(root: Path) -> set[str]:
+    """Return the set of route paths reachable under ``site/src/app/``.
+
+    A route is the directory of every `page.tsx` relative to ``app/`` with
+    a leading slash. Example: ``site/src/app/docs/runtime/domains/page.tsx``
+    → ``/docs/runtime/domains``.
+    """
+    app = root / "app"
+    routes: set[str] = {"/"}  # root layout always serves /
+    if not app.exists():
+        return routes
+    for page in app.rglob("page.tsx"):
+        rel = page.parent.relative_to(app)
+        slug = "/" + str(rel) if str(rel) != "." else "/"
+        routes.add(slug.replace("\\", "/"))
+    return routes
+
+
+def discover_public_assets(public: Path) -> set[str]:
+    """Top-level files / dirs inside ``site/public/`` are served at the
+    site root. ``site/public/llms.txt`` → ``/llms.txt``."""
+    out: set[str] = set()
+    if not public.exists():
+        return out
+    for child in public.iterdir():
+        out.add("/" + child.name)
+        if child.is_dir():
+            out.add("/" + child.name + "/")
+    return out
+
+
+def discover_build_time_copies(repo_root: Path) -> set[str]:
+    """Paths that the Pages workflow injects into ``site/out/`` at build time
+    so they appear at deploy URL even though they live outside ``site/``.
+
+    Currently the only build-time copy is ``docs/petri-bundle/`` →
+    ``site/out/petri-bundle/`` (`.github/workflows/pages.yml` Copy step).
+    If more are added later, register them here.
+    """
+    out: set[str] = set()
+    if (repo_root / "docs" / "petri-bundle" / "index.html").exists():
+        out.add("/petri-bundle/")
+        out.add("/petri-bundle")
+    return out
+
+
+def discover_ids(root: Path) -> dict[str, set[str]]:
+    """Return ``{route: set(id_attr_values)}`` so anchor #foo can be
+    validated against the page it points to.
+
+    We index every ``id="foo"`` occurrence inside the same `page.tsx` so a
+    same-page anchor (#section) resolves against its own page.
+    """
+    by_route: dict[str, set[str]] = defaultdict(set)
+    app = root / "app"
+    if not app.exists():
+        return by_route
+    id_re = re.compile(r"""\bid\s*=\s*['"`]([A-Za-z_][\w-]*)['"`]""")
+    for page in app.rglob("page.tsx"):
+        rel = page.parent.relative_to(app)
+        route = "/" + str(rel) if str(rel) != "." else "/"
+        route = route.replace("\\", "/")
+        text = page.read_text(encoding="utf-8")
+        for match in id_re.finditer(text):
+            by_route[route].add(match.group(1))
+    return by_route
+
+
+# ---------------------------------------------------------------------------
+# Classification + verdict
+
+# Site is published under this base path on GitHub Pages.
+_DEPLOY_BASE = "/geode"
+
+
+def _strip_basepath(target: str) -> str:
+    """Normalise ``/geode/docs/foo`` to ``/docs/foo`` so internal links that
+    happen to include the deploy basepath still match the source-side routes.
+    """
+    if target.startswith(_DEPLOY_BASE + "/"):
+        return target[len(_DEPLOY_BASE) :]
+    if target == _DEPLOY_BASE:
+        return "/"
+    return target
+
+
+def classify_and_check(
+    links: list[Link],
+    routes: set[str],
+    assets: set[str],
+    page_ids: dict[str, set[str]],
+) -> tuple[list[str], list[str], list[str]]:
+    """Return ``(broken_lines, unresolved_lines, external_lines)``."""
+    broken: list[str] = []
+    unresolved: list[str] = []
+    external: list[str] = []
+
+    for link in links:
+        target = link.target
+
+        if target.startswith("UNRESOLVED:"):
+            unresolved.append(f"  {link.file}:{link.line}  {target}")
+            continue
+
+        # External
+        if target.startswith(("http://", "https://")):
+            external.append(target)
+            continue
+
+        # Anchor only — link relative to the file that emits it
+        if target.startswith("#"):
+            # Compute route from file path
+            # site/src/app/<route...>/page.tsx → /<route...>
+            parts = link.file.parts
+            try:
+                app_idx = parts.index("app")
+            except ValueError:
+                continue
+            route_segs = parts[app_idx + 1 : -1]
+            route = "/" + "/".join(route_segs) if route_segs else "/"
+            anchor = target[1:]
+            if anchor and anchor not in page_ids.get(route, set()):
+                broken.append(
+                    f"  {link.file}:{link.line}  anchor #{anchor} not found on {route}"
+                )
+            continue
+
+        # Internal absolute paths (incl. /geode/... basepath form)
+        if target.startswith("/"):
+            norm = _strip_basepath(target.split("#", 1)[0].split("?", 1)[0])
+            if not norm:
+                continue
+            if norm in routes:
+                continue
+            if norm.endswith("/") and norm[:-1] in routes:
+                continue
+            if not norm.endswith("/") and (norm + "/") in routes:
+                continue
+            if norm in assets:
+                continue
+            if any(norm.startswith(a) for a in assets if a.endswith("/")):
+                continue
+            broken.append(f"  {link.file}:{link.line}  {target}")
+            continue
+
+        # Relative / scheme-less — best-effort, leave alone for now
+        unresolved.append(f"  {link.file}:{link.line}  relative {target}")
+
+    return broken, unresolved, external
+
+
+# ---------------------------------------------------------------------------
+# Optional HTTP probe for external links
+
+
+def http_probe(urls: list[str], timeout: float = 8.0) -> list[str]:
+    """Return list of broken external URLs.
+
+    HEAD with GET fallback. Concurrency 8. Skipped if ``requests`` not
+    installed; we then return an empty list and print a notice.
+    """
+    try:
+        import requests
+    except ImportError:
+        print("  (skipping external probe — `pip install requests` to enable)", file=sys.stderr)
+        return []
+
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    broken: list[str] = []
+
+    def check(url: str) -> tuple[str, int | None]:
+        try:
+            r = requests.head(url, allow_redirects=True, timeout=timeout)
+            if r.status_code in _NETWORK_OK:
+                return url, r.status_code
+            r = requests.get(url, allow_redirects=True, timeout=timeout)
+            return url, r.status_code
+        except Exception:
+            return url, None
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {pool.submit(check, url): url for url in sorted(set(urls))}
+        for fut in as_completed(futures):
+            url, code = fut.result()
+            if code not in _NETWORK_OK:
+                broken.append(f"  {url}  →  HTTP {code}")
+
+    return broken
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=Path("site"),
+        help="site root (default: site)",
+    )
+    parser.add_argument(
+        "--http",
+        action="store_true",
+        help="also probe external https:// URLs (slow + network-dependent)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress unresolved list (keep broken summary only)",
+    )
+    args = parser.parse_args()
+
+    src = args.base / "src"
+    if not src.exists():
+        print(f"error: {src} not found", file=sys.stderr)
+        return 2
+
+    links = discover_links(src)
+    routes = discover_app_pages(src)
+    assets = discover_public_assets(args.base / "public")
+    assets |= discover_build_time_copies(args.base.parent)
+    page_ids = discover_ids(src)
+
+    print(f"Scanned {len(links)} link occurrences in {args.base}/src/")
+    print(f"  app routes:    {len(routes)}")
+    print(f"  public assets: {len(assets)}")
+    print()
+
+    broken, unresolved, external = classify_and_check(links, routes, assets, page_ids)
+
+    if broken:
+        print(f"❌ {len(broken)} broken internal link(s):")
+        for line in broken:
+            print(line)
+    else:
+        print("✅ no broken internal links")
+    print()
+
+    if unresolved and not args.quiet:
+        print(f"ℹ️  {len(unresolved)} unresolved (interpolated or relative):")
+        for line in unresolved[:20]:
+            print(line)
+        if len(unresolved) > 20:
+            print(f"  ... and {len(unresolved) - 20} more")
+        print()
+
+    ext_broken: list[str] = []
+    print(f"  external URLs: {len(set(external))}")
+    if args.http and external:
+        print("Probing external URLs (HEAD with GET fallback)...")
+        ext_broken = http_probe(external)
+        if ext_broken:
+            print(f"❌ {len(ext_broken)} broken external URL(s):")
+            for line in ext_broken:
+                print(line)
+        else:
+            print("✅ all external URLs reachable")
+
+    return 1 if broken or ext_broken else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

develop → main release for v0.95.1.

- **#1162** `chore(release): v0.95.1 — Unreleased stamp + 4-location version sync`. SemVer PATCH. 4-location (pyproject / CLAUDE / README / README.ko) → 0.95.1, CHANGELOG `[Unreleased]` → `[0.95.1] — 2026-05-16`.
- **#1161** `feat(scripts): check_docs_links.py` — docs 사이트 link static + HTTP audit (다른 세션).
- **#1163** `docs(skills): docs-link-audit skill 등록` — `.claude/skills/docs-link-audit/SKILL.md` 신설 + CLAUDE.md Custom Skills 표 등록. PR #1161 의 `check_docs_links.py` 를 1차 도구로 하는 broken-link audit workflow (다른 세션).

## Verification

- [x] PR #1162 CI 7/7 pass
- [x] PR #1161 (이미 develop 머지)
- [x] PR #1163 (이미 develop 머지)
- [ ] release PR CI (이 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)