### PR TITLE
release: cli-latex-wiring (#1165) + test_failover spinner-tolerant fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,66 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI LaTeX 렌더링 — `interactive_loop` wiring + `\[...\]`/`\(...\)`/
+  `\begin{env}…\end{env}` delimiter 추가.** PR #1141 이 `core/ui/latex.py`
+  의 Tier 1 (pylatexenc) + Tier 2 (latex2sympy2 + sympy.pretty) 라이브
+  러리 + 19 test 만 추가하고 "다음 단계 후보 — event_renderer 가 LLM 응답
+  텍스트에 extract_and_render_inline 적용" 으로 wiring 을 follow-up 으로
+  남겨두었음. 결과적으로 사용자는 LLM 응답에서 `\[ \frac{1}{m} \sum_{i=1}
+  ^{m} \ell(\alpha_i) \]` 같은 raw LaTeX 를 그대로 보고 있었다. 본 PR 이
+  두 갭을 닫음:
+  - `core/cli/interactive_loop.py` 의 `_render_ipc_response` 가 LLM final
+    text 를 `rich.markdown.Markdown` 으로 직접 흘리던 부분을 신규
+    `_render_text_with_latex` 헬퍼로 교체. 헬퍼는
+    `extract_and_render_inline(text)` 로 segment 분할 후 inline math 는
+    rendered Unicode 로 주변 Markdown paragraph 에 다시 합치고,
+    `block_math` 는 multi-line block 으로 render. math 가 전혀 없으면
+    단일 Markdown 호출로 fallback (회귀 위험 0).
+  - `core/ui/latex.py` 의 delimiter 가 `$...$` / `$$...$$` 두 가지 뿐이라
+    LLM 이 자주 출력하는 `\[...\]` (display) / `\(...\)` (inline) /
+    `\begin{equation|align|gather|multline|displaymath}…\end{...}` 가
+    모두 누락. 본 PR 이 세 패턴 모두 지원하도록 regex 확장 + overlap-
+    aware 우선순위 resolution (block > inline) 추가.
+  - 신규 test 13 (`tests/test_ui_latex.py::TestDelimiterExpansion` 7 +
+    `tests/test_interactive_loop_latex.py` 6) — 모든 delimiter form,
+    mixed segments, overlap 회피, raw 백슬래시 leak 회귀, 사용자가 보고한
+    `\[ \frac{1}{m} \sum_{i=1}^{m} \ell(\alpha_i) \]` 케이스 직접 검증.
+  - 의도된 비지원: backslash 없는 `[...]` / `(...)` — markdown link
+    문법과 충돌 + 일반 bracket 어휘 noise. 사용자는 `\[...\]` 형식을 써야
+    함.
+- **CLI LaTeX rendering — `interactive_loop` wiring + `\[...\]`/`\(...\)`/
+  `\begin{env}…\end{env}` delimiter support.** PR #1141 introduced
+  `core/ui/latex.py` with the Tier 1 (pylatexenc) and Tier 2
+  (latex2sympy2 + sympy.pretty) renderers plus 19 tests, but the
+  CHANGELOG flagged the actual wiring as a follow-up — the response
+  print path stayed on `rich.markdown.Markdown(text)`. Users therefore
+  saw the raw backslash form (e.g. `\[ \frac{1}{m} \sum_{i=1}^{m}
+  \ell(\alpha_i) \]`) in their terminals. This PR closes both gaps:
+  - The LLM final-text branch of
+    `core/cli/interactive_loop._render_ipc_response` now calls a new
+    `_render_text_with_latex` helper. The helper splits the body via
+    `extract_and_render_inline(text)`, folds inline math back into the
+    surrounding Markdown paragraph as rendered Unicode, and renders
+    `block_math` as a multi-line block. When the body has no math at
+    all, it falls back to the single Markdown call (zero regression
+    risk).
+  - `core/ui/latex.py` only knew `$...$` and `$$...$$`. The new regex
+    set adds the three forms LLMs actually emit — `\[…\]` for
+    display, `\(…\)` for inline, and `\begin{equation|align|gather|
+    multline|displaymath}…\end{...}` — with overlap-aware priority
+    resolution (block > inline) so an inline match inside a
+    multi-line bracket block is not double-extracted.
+  - 13 new tests
+    (`tests/test_ui_latex.py::TestDelimiterExpansion` plus
+    `tests/test_interactive_loop_latex.py`) pin every delimiter form,
+    mixed segments, the overlap rule, the raw-backslash leak
+    regression, and the user-reported case verbatim.
+  - Deliberately not supported: bracket forms without backslashes
+    (`[...]` / `(...)`) — those collide with Markdown link syntax and
+    ordinary parenthetical prose. Users must write `\[…\]`.
+
 ## [0.95.1] — 2026-05-16
 
 ### Infrastructure

--- a/core/cli/interactive_loop.py
+++ b/core/cli/interactive_loop.py
@@ -48,6 +48,52 @@ def _drain_scheduler_queue(
     )
 
 
+def _render_text_with_latex(text: str) -> None:
+    """Render an LLM response with LaTeX segments lifted out of Markdown.
+
+    The body is scanned for math delimiters (``$``/``$$``/``\\[\\]``/``\\(\\)``/
+    ``\\begin{equation}…``) and split into text + math segments. Text
+    segments still flow through :class:`rich.markdown.Markdown`; math
+    segments render through :func:`core.ui.latex.render_latex` so the
+    user sees Unicode (Tier 1) or a 2D Sympy block (Tier 2) instead of
+    raw backslash form. Inline math is folded back into the surrounding
+    Markdown paragraph; block math splits the Markdown stream. Falls back
+    to plain Markdown when the body contains no math.
+    """
+    from rich.markdown import Markdown
+
+    from core.ui.latex import extract_and_render_inline
+
+    segments = list(extract_and_render_inline(text))
+    has_math = any(kind != "text" for kind, _ in segments)
+
+    console.print()
+    if not has_math:
+        console.print(Markdown(text))
+        console.print()
+        return
+
+    text_buffer: list[str] = []
+
+    def flush_text_buffer() -> None:
+        if text_buffer:
+            console.print(Markdown("".join(text_buffer)))
+            text_buffer.clear()
+
+    for kind, payload in segments:
+        if not payload:
+            continue
+        if kind in {"text", "inline_math"}:
+            text_buffer.append(payload)
+        else:  # block_math
+            flush_text_buffer()
+            console.print()
+            console.print(payload, style="value")
+            console.print()
+    flush_text_buffer()
+    console.print()
+
+
 def _render_ipc_response(response: dict[str, Any], *, streamed: bool = False) -> None:
     """Render an IPC response from serve.
 
@@ -71,11 +117,7 @@ def _render_ipc_response(response: dict[str, Any], *, streamed: bool = False) ->
         # Main text (always render — this is the LLM's final response)
         text = response.get("text", "")
         if text:
-            from rich.markdown import Markdown
-
-            console.print()
-            console.print(Markdown(text))
-            console.print()
+            _render_text_with_latex(text)
 
         if not streamed:
             # Fallback status line when streaming wasn't available

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -117,19 +117,35 @@ def render_latex(src: str, *, block: bool = False) -> Text:
     if block and _has_tier2_construct(src):
         rendered = _render_tier2(src)
         if rendered is not None:
-            return Text(rendered, style="math")
+            return Text(rendered, style="value")
 
-    return Text(_render_tier1(src), style="math")
+    return Text(_render_tier1(src), style="value")
 
 
 # ---------------------------------------------------------------------------
-# Mixed-content scanner — `$...$` and `$$...$$` segments embedded in prose.
+# Mixed-content scanner — math segments embedded in prose.
 # ---------------------------------------------------------------------------
+#
+# Supported delimiters (in resolution-priority order):
+#   * Block:  ``$$ ... $$``    — TeX dollar-double
+#             ``\[ ... \]``    — LaTeX display math (backslash form)
+#             ``\begin{...} ... \end{...}`` — equation / align / gather / etc.
+#   * Inline: ``$ ... $``      — TeX dollar-single
+#             ``\( ... \)``    — LaTeX inline math
+#
+# Heuristics on the inline ``$ ... $`` form forbid whitespace immediately
+# inside the delimiters so prose like "비용 $3.00" does not get mis-parsed
+# as math.
 
-_BLOCK_MATH = re.compile(r"\$\$([^$]+)\$\$")
-# Inline: forbid whitespace immediately inside the delimiters so a phrase
-# like "비용 $3.00" does not get treated as a math segment.
-_INLINE_MATH = re.compile(r"\$(?!\s)([^\s$][^$]*[^\s$]|[^\s$])\$")
+_BLOCK_DOLLAR = re.compile(r"\$\$([^$]+)\$\$")
+_BLOCK_BRACKET = re.compile(r"(?<!\\)\\\[([\s\S]+?)(?<!\\)\\\]")
+_BLOCK_ENV = re.compile(
+    r"(?<!\\)\\begin\{(equation\*?|align\*?|gather\*?|multline\*?|displaymath)\}"
+    r"([\s\S]+?)"
+    r"(?<!\\)\\end\{\1\}"
+)
+_INLINE_DOLLAR = re.compile(r"\$(?!\s)([^\s$][^$]*[^\s$]|[^\s$])\$")
+_INLINE_PAREN = re.compile(r"(?<!\\)\\\(([^\n]+?)(?<!\\)\\\)")
 
 
 def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
@@ -148,13 +164,26 @@ def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
         return
 
     # Build a single match-stream: block segments first, then inline,
-    # then resolve by earliest start position.
+    # then resolve by earliest start position. ``\begin{env}`` matches
+    # capture the env name in group 1 and the body in group 2; the other
+    # patterns capture the body in group 1.
     matches: list[tuple[int, int, str, str]] = []  # (start, end, kind, inner)
-    for m in _BLOCK_MATH.finditer(text):
+    for m in _BLOCK_DOLLAR.finditer(text):
         matches.append((m.start(), m.end(), "block_math", m.group(1)))
-    for m in _INLINE_MATH.finditer(text):
-        # Skip if this inline match overlaps any block match already accepted.
-        if any(start <= m.start() < end for start, end, _, _ in matches):
+    for m in _BLOCK_BRACKET.finditer(text):
+        if _overlaps(m.start(), m.end(), matches):
+            continue
+        matches.append((m.start(), m.end(), "block_math", m.group(1)))
+    for m in _BLOCK_ENV.finditer(text):
+        if _overlaps(m.start(), m.end(), matches):
+            continue
+        matches.append((m.start(), m.end(), "block_math", m.group(2)))
+    for m in _INLINE_DOLLAR.finditer(text):
+        if _overlaps(m.start(), m.end(), matches):
+            continue
+        matches.append((m.start(), m.end(), "inline_math", m.group(1)))
+    for m in _INLINE_PAREN.finditer(text):
+        if _overlaps(m.start(), m.end(), matches):
             continue
         matches.append((m.start(), m.end(), "inline_math", m.group(1)))
     matches.sort(key=lambda t: t[0])
@@ -168,3 +197,8 @@ def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
         pos = end
     if pos < len(text):
         yield ("text", text[pos:])
+
+
+def _overlaps(start: int, end: int, matches: list[tuple[int, int, str, str]]) -> bool:
+    """True when ``start``/``end`` intersects any accepted match span."""
+    return any(start < e and s < end for s, e, _, _ in matches)

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -35,7 +35,15 @@ class TestRetryWithBackoff:
         result = _retry_with_backoff(fn, model="test-model")
         assert result == "ok"
         assert fn.call_count == 2
-        mock_sleep.assert_called_once()
+        # Filter out background spinner sleeps (always exactly 0.08s from
+        # ``core.ui.{event_renderer,status,tool_tracker}._animate``) so we
+        # only count the genuine retry-backoff sleep emitted by
+        # ``_retry_with_backoff`` itself. ``@patch("core.llm.fallback.time.sleep")``
+        # rebinds the ``time`` module attribute, which is shared across
+        # every module that ``import time``, so daemon spinner threads
+        # started by a prior test leak into this mock's call_args_list.
+        retry_sleeps = [c for c in mock_sleep.call_args_list if c.args[0] != 0.08]
+        assert len(retry_sleeps) == 1, retry_sleeps
 
     @patch("core.llm.fallback.time.sleep")
     def test_fallback_model_on_persistent_failure(self, mock_sleep):

--- a/tests/test_interactive_loop_latex.py
+++ b/tests/test_interactive_loop_latex.py
@@ -8,7 +8,6 @@ print path. This module pins the wiring so a future refactor of
 
 from __future__ import annotations
 
-from io import StringIO
 from unittest.mock import MagicMock, patch
 
 from core.cli.interactive_loop import _render_text_with_latex
@@ -89,16 +88,13 @@ def test_mixed_segments_alternate_markdown_and_math() -> None:
     assert kinds.count("math") >= 1
 
 
-def test_math_segments_print_with_configured_rich_style() -> None:
-    """The configured style must exist on the real GEODE theme."""
-    from rich.console import Console
-
-    buf = StringIO()
-    real_console = Console(file=buf, force_terminal=False, theme=GEODE_THEME, width=80)
-    with patch("core.cli.interactive_loop.console", real_console):
-        _render_text_with_latex(r"the term \(x^2\) and \[ \frac{a}{b} \]")
-
-    output = buf.getvalue()
-    assert "\\(" not in output
-    assert "\\[" not in output
-    assert "x" in output
+def test_math_style_is_defined_in_geode_theme() -> None:
+    """Math segments are printed with ``style="value"``. If that style is
+    not registered on :data:`GEODE_THEME`, Rich raises ``MissingStyle`` at
+    render time. This guard catches a future theme rename without spinning
+    up a real ``Console`` (which can leak EventRenderer animation threads
+    into other tests' mock contexts and inflate their ``time.sleep`` counts)."""
+    assert "value" in GEODE_THEME.styles, (
+        "math segments call console.print(..., style='value'); "
+        "the 'value' style must be present in GEODE_THEME"
+    )

--- a/tests/test_interactive_loop_latex.py
+++ b/tests/test_interactive_loop_latex.py
@@ -1,0 +1,104 @@
+"""Tests for the LaTeX wiring in `core/cli/interactive_loop._render_text_with_latex`.
+
+PR #1141 shipped `core/ui/latex.py` but never wired it into the response
+print path. This module pins the wiring so a future refactor of
+`interactive_loop._render_ipc_response` cannot silently regress to plain
+`Markdown(text)` and re-expose raw backslash LaTeX to the user.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from core.cli.interactive_loop import _render_text_with_latex
+from core.ui.console import GEODE_THEME
+
+
+def _capture_console_calls(text: str) -> list[tuple[tuple, dict]]:
+    """Run ``_render_text_with_latex`` against ``text`` and return every
+    positional/keyword arg passed to ``console.print``."""
+    calls: list[tuple[tuple, dict]] = []
+    with patch("core.cli.interactive_loop.console") as mock_console:
+        mock_console.print = MagicMock(side_effect=lambda *a, **kw: calls.append((a, kw)))
+        _render_text_with_latex(text)
+    return calls
+
+
+def _markdown_payloads(calls: list[tuple[tuple, dict]]) -> list[str]:
+    return [args[0].markup for args, _ in calls if args and type(args[0]).__name__ == "Markdown"]
+
+
+def test_plain_text_falls_through_to_markdown() -> None:
+    """No math → single Markdown render, no segment loop."""
+    calls = _capture_console_calls("just prose, no math here")
+    # 3 print calls: leading blank, Markdown, trailing blank.
+    assert len(calls) == 3
+    # Middle call carries a Markdown instance.
+    middle_arg = calls[1][0][0]
+    assert type(middle_arg).__name__ == "Markdown"
+
+
+def test_dollar_inline_math_routes_through_latex_render() -> None:
+    """`$x$` should NOT be wrapped in a Markdown instance — it must go
+    through the math segment path so the user sees the rendered Unicode."""
+    calls = _capture_console_calls("the value $x$ matters")
+    markdown = "\n".join(_markdown_payloads(calls))
+    assert "$" not in markdown
+    assert "the value x matters" in markdown
+
+
+def test_bracket_block_math_routes_through_latex_render() -> None:
+    """The user's reported case — `\\[ \\frac{1}{m} \\sum_{i=1}^{m} \\ell(\\alpha_i) \\]`
+    must render as a math block, not as raw Markdown text."""
+    text = r"loss is \[ \frac{1}{m} \sum_{i=1}^{m} \ell(\alpha_i) \] for the batch."
+    calls = _capture_console_calls(text)
+    math_calls = [c for c in calls if c[1].get("style") == "value"]
+    assert math_calls, "expected at least one math-styled print"
+    # The math payload should be multi-line (Tier 2 fraction render).
+    assert any("\n" in (c[0][0] if c[0] else "") for c in math_calls)
+
+
+def test_paren_inline_math_does_not_leak_raw_backslashes() -> None:
+    """`\\(x^2\\)` must reach the user as `x²` (or similar Unicode), not
+    raw `\\(x^2\\)`."""
+    calls = _capture_console_calls(r"the term \(x^2\) appears")
+    markdown = "\n".join(_markdown_payloads(calls))
+    assert "\\(" not in markdown, f"raw backslash leaked: {markdown!r}"
+    assert "x" in markdown
+
+
+def test_mixed_segments_alternate_markdown_and_math() -> None:
+    """Mixed text + math should produce a sequence of Markdown / math /
+    Markdown calls within a single response render."""
+    calls = _capture_console_calls(r"start $a$ middle \[ \frac{b}{c} \] end")
+    # Skip the two leading/trailing blank prints — focus on style/type.
+    kinds: list[str] = []
+    for args, kw in calls:
+        if not args:
+            kinds.append("blank")
+            continue
+        first = args[0]
+        if type(first).__name__ == "Markdown":
+            kinds.append("md")
+        elif kw.get("style") == "value":
+            kinds.append("math")
+        else:
+            kinds.append("other")
+    assert kinds.count("md") >= 1
+    assert kinds.count("math") >= 1
+
+
+def test_math_segments_print_with_configured_rich_style() -> None:
+    """The configured style must exist on the real GEODE theme."""
+    from rich.console import Console
+
+    buf = StringIO()
+    real_console = Console(file=buf, force_terminal=False, theme=GEODE_THEME, width=80)
+    with patch("core.cli.interactive_loop.console", real_console):
+        _render_text_with_latex(r"the term \(x^2\) and \[ \frac{a}{b} \]")
+
+    output = buf.getvalue()
+    assert "\\(" not in output
+    assert "\\[" not in output
+    assert "x" in output

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -127,3 +127,71 @@ class TestMixedContent:
     def test_segmentation_table(self, source: str, expected_kinds: list[str]) -> None:
         chunks = list(extract_and_render_inline(source))
         assert [k for k, _ in chunks] == expected_kinds
+
+
+class TestDelimiterExpansion:
+    """PR #1165 — `\\[...\\]`, `\\(...\\)`, and `\\begin{equation}...\\end{equation}`
+    are recognised in addition to the original `$`-based forms."""
+
+    def test_bracket_block_math(self) -> None:
+        text = r"기대 손실은 \[ \frac{1}{m} \sum_{i=1}^{m} \ell(\alpha_i) \] 로 표현."
+        segments = list(extract_and_render_inline(text))
+        kinds = [k for k, _ in segments]
+        assert "block_math" in kinds, segments
+        # Bracket form contains \\frac → Tier 2 path → multi-line render.
+        block_payload = next(p for k, p in segments if k == "block_math")
+        assert "\n" in block_payload  # multi-line block
+
+    def test_paren_inline_math(self) -> None:
+        text = r"the term \(x^2\) appears once"
+        segments = list(extract_and_render_inline(text))
+        kinds = [k for k, _ in segments]
+        assert kinds == ["text", "inline_math", "text"]
+        _, payload = next(p for p in segments if p[0] == "inline_math")
+        assert "x²" in payload or "x^2" in payload
+
+    def test_equation_environment(self) -> None:
+        text = r"""다음을 보자
+\begin{equation}
+\frac{a}{b}
+\end{equation}
+끝."""
+        segments = list(extract_and_render_inline(text))
+        kinds = [k for k, _ in segments]
+        assert "block_math" in kinds
+
+    def test_align_environment(self) -> None:
+        text = r"""\begin{align}
+x &= 1
+\end{align}"""
+        segments = list(extract_and_render_inline(text))
+        assert any(k == "block_math" for k, _ in segments)
+
+    def test_mixed_dollar_and_bracket(self) -> None:
+        text = r"inline $x$ and block \[ \frac{a}{b} \] together"
+        segments = list(extract_and_render_inline(text))
+        kinds = [k for k, _ in segments]
+        assert kinds.count("inline_math") == 1
+        assert kinds.count("block_math") == 1
+
+    def test_paren_inside_bracket_block_does_not_double_match(self) -> None:
+        """Inline `\\(…\\)` inside a `\\[…\\]` block must not be re-extracted."""
+        text = r"\[ a = \frac{1}{2} \text{ where }(x) is normal \]"
+        segments = list(extract_and_render_inline(text))
+        kinds = [k for k, _ in segments]
+        # The whole bracketed span is one block_math; no spurious inline_math.
+        assert kinds.count("inline_math") == 0
+        assert kinds.count("block_math") == 1
+
+    def test_user_reported_case_logic_block(self) -> None:
+        """The exact example the user surfaced in the 2026-05-16 session."""
+        text = (
+            r"[ \mathrm{Logic} ]"  # The user pasted this as `[…]`, not `\[…\]` —
+            "\n\n"  # see the test below for that variant.
+            r"\[ \frac{1}{m} \sum_{i=1}^{m} \ell(\alpha_i) \]"
+        )
+        segments = list(extract_and_render_inline(text))
+        kinds = [k for k, _ in segments]
+        # `[ ... ]` (no backslash) is NOT a recognised LaTeX delimiter; it
+        # stays as text. The `\[ ... \]` form is recognised.
+        assert kinds.count("block_math") == 1


### PR DESCRIPTION
## Summary

develop → main release.

- **#1165** `fix(cli): LaTeX 렌더링 wiring + \\[...\\]/\\(...\\)/\\begin{env} delimiter` — PR #1141 의 미완 wiring 닫음. `_render_text_with_latex` 헬퍼 + delimiter 5 패턴 + overlap-aware. Codex MCP 4번째 verify, CRITICAL 1 (`style="math"` undefined → crash) + HIGH 4 fix.
- **#1165** 의 follow-up 2 commit: real-console test → theme-style assertion (spinner thread leak 회피), `test_retry_on_rate_limit` spinner-tolerant filter (mock_sleep call_args_list 에서 spinner 0.08 leak 제거).

## Verification

- [x] PR #1165 CI 7/7 pass (Lint / Format / Type / Test / Security / macos+ubuntu install)
- [ ] release PR CI (이 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code), cross-verified by Codex MCP