### PR TITLE
release: cli-latex-newline-collapse hotfix (#1169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,58 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI LaTeX 렌더링 — multi-line source 의 vertical 줄긋기 회귀.**
+  PR #1141/#1165 의 wiring 이후 LLM 이 `\frac` / `\sum` / `\sqrt` 같은
+  매크로를 multi-line LaTeX source 로 emit 하면 (`\frac{<newline>num
+  <newline>}{<newline>denom<newline>}`), pylatexenc 가 source line break
+  를 그대로 보존하여 터미널에서 모든 토큰이 한 줄씩 vertical 로 늘어졌음
+  (사용자 보고 2026-05-16: IC_t / = / ∑_i=1^N / ( / S_t,i - S̄_t,: / )
+  ... 16+ 줄).
+  - `core/ui/latex.py:_render_tier1` 이 explicit LaTeX row break (`\\`)
+    를 보존하면서 rendered line 내부의 whitespace run 을 single space 로
+    collapse. LaTeX source line break 는 mathematical 의미가 없으므로
+    inline + block fallback 의 vertical stack 을 막되, `cases`/`aligned`
+    스타일의 의도적 행 구분은 유지. Tier 2 (SymPy pretty) 는 무관.
+  - `core/ui/latex.py:_INLINE_PAREN` 의 `[^\n]+?` → `[\s\S]+?` —
+    multi-line 본문의 `\(...\)` 도 인식하도록. 이전엔 inline regex 가
+    매치 실패 시 본문이 raw 텍스트로 흘러 `\frac`/`\sum` 매크로가 그대로
+    노출됐음.
+  - 3 신규 회귀 test (`tests/test_cli_latex_uiux.py` 의
+    `test_multiline_latex_source_collapses_to_single_line_inline` +
+    `_block`, `test_tier1_preserves_explicit_latex_row_breaks`) — IC_t
+    Pearson 상관계수 식의 7-line LaTeX source 가 inline (`\(...\)`) /
+    block (`\[...\]`) 두 형식에서 모두 single-paragraph 로 흐름 + raw
+    매크로 leak 0 + math 토큰 (∑, √) 출현 + 출력 line 수 cap. 추가로
+    `cases` 의 explicit row break 보존을 pin. pre-fix 의 16+
+    vertical-stack regression 차단.
+- **CLI LaTeX rendering — vertical-stack regression from multi-line
+  source.** After PR #1141/#1165 wired the renderer, an LLM emitting
+  `\frac` / `\sum` / `\sqrt` with source-level line breaks
+  (`\frac{<newline>num<newline>}{<newline>denom<newline>}`) caused
+  pylatexenc to preserve every newline verbatim, which a narrow terminal
+  printed as a vertical stack of single tokens (`IC_t` / `=` / `∑_i=1^N`
+  / `(` / `S_t,i - S̄_t,:` / `)` / …, 16+ lines).
+  - `core/ui/latex.py:_render_tier1` now preserves explicit LaTeX row
+    breaks (`\\`) while collapsing whitespace runs inside each rendered
+    line to a single space. LaTeX source line breaks have no mathematical
+    meaning — flattening preserves the math while restoring inline flow,
+    without erasing intentional `cases`/`aligned` rows. Affects inline
+    and block Tier 1 fallback; Tier 2 (SymPy pretty) is untouched.
+  - `core/ui/latex.py:_INLINE_PAREN` widens `[^\n]+?` to `[\s\S]+?` so
+    multi-line `\(…\)` segments are recognised. Pre-fix, the inline
+    regex silently failed on a multi-line body and the raw `\frac` /
+    `\sum` / `\bar` macros leaked through as plain prose.
+  - 3 new regression tests (`tests/test_cli_latex_uiux.py`,
+    `test_multiline_latex_source_collapses_to_single_line_inline`,
+    `_block`, and `test_tier1_preserves_explicit_latex_row_breaks`) drive
+    a 7-line IC_t Pearson-correlation formula through both `\(…\)` and
+    `\[…\]` modes and assert: (a) math symbols (`∑`, `√`) reach the
+    output, (b) no raw `\`-macros leak, (c) the math block stays within a
+    sane line-count cap. The third test pins explicit `cases` row breaks,
+    blocking both the pre-fix 16-line regression and over-collapse.
+
 ### Infrastructure
 
 - **CLI UI/UX regression tests for LaTeX rendering — Stage A/B/C 추가.**

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -90,10 +90,7 @@ def _render_tier1(src: str) -> str:
             src,
         )
         raw: str = LatexNodes2Text().latex_to_text(protected_src).strip()
-        lines = [
-            re.sub(r"\s+", " ", part).strip()
-            for part in raw.split(_LATEX_LINEBREAK_SENTINEL)
-        ]
+        lines = [re.sub(r"\s+", " ", part).strip() for part in raw.split(_LATEX_LINEBREAK_SENTINEL)]
         return "\n".join(line for line in lines if line)
     except Exception:
         log.debug("Tier 1 LaTeX render failed for %r", src, exc_info=True)

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -58,6 +58,8 @@ _TIER2_TOKENS: Final[tuple[str, ...]] = (
     r"\sqrt{",
     r"\lim_",
 )
+_LATEX_LINEBREAK = re.compile(r"(?<!\\)\\\\(?:\s*\[[^\]]*\])?")
+_LATEX_LINEBREAK_SENTINEL: Final = "<<<GEODE_LATEX_LINEBREAK_4A7D1B>>>"
 
 
 def _has_tier2_construct(src: str) -> bool:
@@ -66,16 +68,33 @@ def _has_tier2_construct(src: str) -> bool:
 
 
 def _render_tier1(src: str) -> str:
-    """Flatten LaTeX to a single Unicode line. Never raises — pylatexenc
-    swallows unknown macros and returns whatever it can parse."""
+    """Flatten LaTeX source whitespace to Unicode text. Never raises — pylatexenc
+    swallows unknown macros and returns whatever it can parse.
+
+    Source-level line breaks in the input (an LLM emitting ``\\frac`` on
+    one line and its numerator on the next) carry **no mathematical
+    meaning** but pylatexenc preserves them verbatim. We collapse every
+    run of whitespace (newlines, tabs, multiple spaces) inside a rendered
+    line so the inline-flow guarantee holds even when the LLM hands us a
+    multi-line LaTeX block. Explicit LaTeX row breaks (``\\``) are
+    preserved for cases/aligned-style output.
+    """
     try:
         # pylatexenc ships no py.typed marker; suppress at site.
         from pylatexenc.latex2text import LatexNodes2Text  # type: ignore[import-untyped]
     except ImportError:  # pragma: no cover — declared in pyproject
         return src
     try:
-        result: str = LatexNodes2Text().latex_to_text(src).strip()
-        return result
+        protected_src = _LATEX_LINEBREAK.sub(
+            f" {_LATEX_LINEBREAK_SENTINEL} ",
+            src,
+        )
+        raw: str = LatexNodes2Text().latex_to_text(protected_src).strip()
+        lines = [
+            re.sub(r"\s+", " ", part).strip()
+            for part in raw.split(_LATEX_LINEBREAK_SENTINEL)
+        ]
+        return "\n".join(line for line in lines if line)
     except Exception:
         log.debug("Tier 1 LaTeX render failed for %r", src, exc_info=True)
         return src
@@ -145,7 +164,7 @@ _BLOCK_ENV = re.compile(
     r"(?<!\\)\\end\{\1\}"
 )
 _INLINE_DOLLAR = re.compile(r"\$(?!\s)([^\s$][^$]*[^\s$]|[^\s$])\$")
-_INLINE_PAREN = re.compile(r"(?<!\\)\\\(([^\n]+?)(?<!\\)\\\)")
+_INLINE_PAREN = re.compile(r"(?<!\\)\\\(([\s\S]+?)(?<!\\)\\\)")
 
 
 def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:

--- a/tests/test_cli_latex_uiux.py
+++ b/tests/test_cli_latex_uiux.py
@@ -183,7 +183,9 @@ class TestStageAComponent:
         body_lines = [
             line for line in output.splitlines() if line.strip() and "는 trial t" not in line
         ]
-        math_lines = [line for line in body_lines if "여기서" in line or "S_t" in line or "y_t" in line]
+        math_lines = [
+            line for line in body_lines if "여기서" in line or "S_t" in line or "y_t" in line
+        ]
         assert len(math_lines) <= 6, (
             f"multi-line LaTeX source did not collapse — {len(math_lines)} math "
             f"lines (pre-fix bug was 12+):\n{output!r}"

--- a/tests/test_cli_latex_uiux.py
+++ b/tests/test_cli_latex_uiux.py
@@ -37,6 +37,7 @@ from unittest.mock import patch
 import pytest
 from core.cli.interactive_loop import _render_ipc_response, _render_text_with_latex
 from core.ui.console import GEODE_THEME
+from core.ui.latex import render_latex
 from rich.console import Console
 
 # ---------------------------------------------------------------------------
@@ -143,6 +144,96 @@ class TestStageAComponent:
             assert delim not in output
         assert "inline" in output
         assert "more text" in output
+
+    def test_multiline_latex_source_collapses_to_single_line_inline(self) -> None:
+        """LLMs frequently emit LaTeX with source-level line breaks
+        between ``\\frac`` and its arguments. pylatexenc preserves those
+        breaks verbatim, which (before the Tier 1 whitespace collapse) shows
+        up in narrow terminals as a vertical stack of single tokens —
+        ``IC_t`` on one line, ``=`` on the next, ``(`` on the next, etc.
+
+        Regression guard: a multi-line LaTeX source inside an inline
+        ``\\(...\\)`` segment must render as flowing Unicode prose, not as
+        a vertical stack. We accept terminal width-induced wrapping but
+        forbid (a) source-level newline preservation, (b) raw backslash
+        macros leaking through, and (c) explosion to more lines than the
+        terminal width could possibly justify.
+        """
+        text = (
+            "여기서 \\( IC_t = \\frac{\n"
+            "  \\sum_{i=1}^{N}(S_{t,i} - \\bar{S}_{t,:})\n"
+            "  (y_{t,i} - \\bar{y}_{t,:})\n"
+            "}{\n"
+            "  \\sqrt{\\sum_{i=1}^{N}(S_{t,i} - \\bar{S}_{t,:})^2}\n"
+            "  \\sqrt{\\sum_{i=1}^{N}(y_{t,i} - \\bar{y}_{t,:})^2}\n"
+            "} \\) 는 trial t."
+        )
+        output = _render_through_helper(text)
+        # Math is rendered (key Unicode tokens reached the buffer).
+        assert "∑" in output
+        assert "√" in output
+        assert "IC_t" in output
+        assert "는 trial t" in output
+        # No raw LaTeX macros leaked through.
+        for raw in ("\\(", "\\)", "\\frac", "\\sqrt", "\\sum", "\\bar"):
+            assert raw not in output, f"raw {raw} leaked into output: {output!r}"
+        # Source-level structure exploded into 16+ lines pre-fix. Cap at 6
+        # so a single-line response with width=80 wrap (~2 lines) passes
+        # but a fully vertical regression fails.
+        body_lines = [
+            line for line in output.splitlines() if line.strip() and "는 trial t" not in line
+        ]
+        math_lines = [line for line in body_lines if "여기서" in line or "S_t" in line or "y_t" in line]
+        assert len(math_lines) <= 6, (
+            f"multi-line LaTeX source did not collapse — {len(math_lines)} math "
+            f"lines (pre-fix bug was 12+):\n{output!r}"
+        )
+
+    def test_multiline_latex_source_collapses_to_single_line_block(self) -> None:
+        """Same regression in block (``\\[...\\]``) mode. When Tier 2 SymPy
+        parsing fails (which it does for `\\bar{S}_{t,:}` and similar
+        LLM-emitted notation), the Tier 1 fallback path must still produce
+        a single line — not the raw multi-line pylatexenc output."""
+        text = (
+            "loss:\n\n"
+            "\\[\n"
+            "IC_t = \\frac{\n"
+            "  \\sum_{i=1}^{N}(S_{t,i} - \\bar{S}_{t,:})\n"
+            "  (y_{t,i} - \\bar{y}_{t,:})\n"
+            "}{\n"
+            "  \\sqrt{\\sum_{i=1}^{N}(S_{t,i} - \\bar{S}_{t,:})^2}\n"
+            "  \\sqrt{\\sum_{i=1}^{N}(y_{t,i} - \\bar{y}_{t,:})^2}\n"
+            "}\n"
+            "\\]\n\n"
+            "end."
+        )
+        output = _render_through_helper(text)
+        # Both Tier 2 (pretty 2D, multi-line OK) and Tier 1 fallback paths
+        # produce *bounded* line counts. The pre-fix bug yielded 16+
+        # 1-token lines in the math block. Cap the math block at 12 lines
+        # so a future regression of the same shape would trip.
+        math_lines = [
+            line.rstrip()
+            for line in output.splitlines()
+            if line.strip() and "loss:" not in line and line.strip() != "end."
+        ]
+        assert len(math_lines) <= 12, (
+            f"math block too tall ({len(math_lines)} lines) — "
+            f"likely Tier 1 newline regression:\n{output!r}"
+        )
+        for raw in ("\\[", "\\]", "\\frac"):
+            assert raw not in output
+
+    def test_tier1_preserves_explicit_latex_row_breaks(self) -> None:
+        """Whitespace collapse must not erase meaningful ``\\`` row breaks."""
+        rendered = render_latex(
+            r"\begin{cases} a & b \\ c & d \end{cases}",
+            block=True,
+        ).plain
+        lines = [line.strip() for line in rendered.splitlines() if line.strip()]
+
+        assert lines == ["a b", "c d"]
+        assert "a b c d" not in rendered
 
     @pytest.mark.parametrize(
         "text,math_tokens",


### PR DESCRIPTION
## Summary

develop → main release for PR #1169 hotfix.

- **#1169** `fix(cli): LaTeX multi-line source collapse + row break preserve` — 사용자가 보고한 IC_t Pearson 상관계수 식의 16+ 줄 vertical stack 회귀 차단. `_render_tier1` 의 sentinel-protect collapse 패턴으로 source-level newline 은 collapse, explicit `\\` row break 는 보존 (Codex CRITICAL fix). `_INLINE_PAREN` multi-line 본문 인식 widen.

## Verification

- [x] PR #1169 CI 7/7 pass
- [ ] release PR CI (이 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code), cross-verified by Codex MCP