### PR TITLE
feat(memory): Phase 1b — JSON 20-trim 해제 + DB SoT 전환 + layout v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,37 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **Phase 1b — Long-term Recall: JSON 20-trim 해제 + DB SoT 전환 + layout
+  v4 migration.** Hermes 흡수 plan (`docs/plans/2026-05-14-hermes-
+  strengths-absorption.md`) 의 1b. PR #1151 의 dual-write (JSON SoT, DB
+  mirror) 를 뒤집어 SQLite `messages` 테이블이 SoT, JSON 은 hot cache.
+  - `core/runtime_state/session_checkpoint.py` 의
+    `CHECKPOINT_MAX_MESSAGES` 를 20→0 (no trim). `save()` 가 DB 먼저
+    write 후 JSON hot cache (full list, no trim) write. `load()` 가
+    DB 우선 (`_load_messages_from_db`), DB 가 비어있을 때만 JSON
+    fallback — pre-PR-1151 / dual-write race loser 호환.
+  - `core/wiring/layout_migrator.py` 의 `GEODE_LAYOUT_VERSION` 3→4 +
+    신규 `_migrate_v3_to_v4()` — `~/.geode/projects/*/sessions/*/
+    messages.json` 일괄 backfill. 손상 파일 skip + WARN, idempotent
+    (UNIQUE(session_id, seq)), 진행률 INFO every 10 sessions, fresh
+    install graceful skip.
+  - `tools.json` 은 backward compat 으로 hot cache 유지. 신규 7 test
+    + 기존 `test_message_trimming` 을 `test_no_trim_full_history_
+    preserved` 로 의미 전환.
+- **Phase 1b — Long-term Recall: JSON trim removed, SoT flipped to
+  SQLite, layout v4 migration.** Inverts PR #1151's dual-write
+  contract — the SQLite `messages` table is now the source of truth
+  and `messages.json` is a full-list hot cache for offline tooling.
+  `CHECKPOINT_MAX_MESSAGES` zeroed (20→0, "no trim"); `save()` writes
+  the DB first then the untrimmed JSON; `load()` reads DB-first with a
+  JSON fallback for legacy sessions. `GEODE_LAYOUT_VERSION` bumped
+  3→4 with `_migrate_v3_to_v4()` doing an idempotent corrupt-tolerant
+  backfill of every pre-existing `messages.json` into the per-project
+  `sessions.db`. Seven new tests pin the contract; the pre-existing
+  trim test was rewritten to assert the new Phase-1b behaviour.
+
 ### Fixed
 
 - **CLI LaTeX 렌더링 — delimiter-less 매크로 누출 heuristic.** PR

--- a/core/runtime_state/session_checkpoint.py
+++ b/core/runtime_state/session_checkpoint.py
@@ -29,8 +29,14 @@ def _get_default_session_dir() -> Path:
 
 
 DEFAULT_SESSION_DIR = _get_default_session_dir()
-CHECKPOINT_MAX_MESSAGES = 20  # Context Budget: keep recent N messages
 CLEANUP_AGE_HOURS = 72
+# ``CHECKPOINT_MAX_MESSAGES`` (= 20) used to trim the JSON snapshot for
+# context-budget reasons. Phase 1b (Hermes absorption) flips the SoT to the
+# SQLite ``messages`` table, which holds the *full* history, so the
+# JSON ``messages.json`` becomes a hot-cache copy of the same full list.
+# The constant is kept (re-exported) for any third-party caller that
+# imported it; the value of 0 means "no truncation".
+CHECKPOINT_MAX_MESSAGES = 0
 
 
 @dataclass
@@ -66,13 +72,17 @@ class SessionCheckpoint:
         self._dir = Path(session_dir) if session_dir else DEFAULT_SESSION_DIR
 
     def save(self, state: SessionState) -> None:
-        """Save session checkpoint. Overwrites previous checkpoint for same ID."""
+        """Save session checkpoint. Overwrites previous checkpoint for same ID.
+
+        Phase 1b (Hermes absorption) flips the SoT to the SQLite
+        ``messages`` table. The JSON ``messages.json`` and ``tools.json``
+        are kept as a hot cache (so old offline tooling that reads them
+        still works) but no longer carry truncated state — the DB is now
+        the only place that has the full conversation.
+        """
         state.updated_at = time.time()
         session_path = self._dir / state.session_id
         session_path.mkdir(parents=True, exist_ok=True)
-
-        # Trim messages to budget
-        trimmed = state.messages[-CHECKPOINT_MAX_MESSAGES:]
 
         data = {
             "session_id": state.session_id,
@@ -90,11 +100,21 @@ class SessionCheckpoint:
         state_file = session_path / "state.json"
         atomic_write_json(state_file, data, indent=2)
 
-        # Write messages.json (conversation, trimmed)
-        msg_file = session_path / "messages.json"
-        atomic_write_json(msg_file, trimmed)
+        # Phase 1b: SoT lives in SQLite ``messages`` table. Mirror the
+        # *full* message list into the DB **first** so a JSON-only failure
+        # below (disk full, write race) cannot leave the SoT with a stale
+        # message count.
+        self._sync_messages_to_db(state)
 
-        # Write tools.json (tool call log)
+        # Write messages.json as a hot cache (full list, no trim). Old
+        # offline tooling can still read this; the runtime ``load()`` path
+        # prefers the DB.
+        msg_file = session_path / "messages.json"
+        atomic_write_json(msg_file, state.messages)
+
+        # Write tools.json hot cache when tool log exists. The structured
+        # ``tool_calls`` column on each ``messages`` row is now the SoT,
+        # so this is a convenience copy only.
         if state.tool_log:
             tools_file = session_path / "tools.json"
             atomic_write_json(tools_file, state.tool_log[-50:])
@@ -108,16 +128,26 @@ class SessionCheckpoint:
             indent=2,
         )
 
-        # GAP 3: Sync to SQLite index for fast query
-        self._sync_to_index(state, len(trimmed))
-
-        # Phase 1a (Hermes absorption): mirror the *full* message list
-        # into the ``messages`` table. JSON remains SoT until Phase 1b;
-        # a DB failure logs WARN but the JSON write above is preserved.
-        self._sync_messages_to_db(state)
+        # Sync session metadata to SQLite index for fast query (GAP 3).
+        self._sync_to_index(state, len(state.messages))
 
     def load(self, session_id: str) -> SessionState | None:
-        """Load a session checkpoint. Returns None if not found."""
+        """Load a session checkpoint. Returns None if not found.
+
+        Phase 1b — read order:
+            1. ``state.json`` for metadata (always; the DB ``sessions``
+               table mirrors this but the JSON keeps the user-input and
+               status fields so old offline tooling still works).
+            2. ``messages`` table (DB) for the full conversation. This is
+               the new SoT.
+            3. ``messages.json`` only when the DB cannot answer
+               authoritatively for this session — happens for sessions
+               written before the v3→v4 migration had a chance to run,
+               and for sessions whose DB write raced with the JSON write.
+            4. ``tools.json`` for the tool log (kept JSON-only; the DB
+               ``messages.tool_calls`` column carries per-message tool
+               metadata but does not subsume the loop's tool_log shape).
+        """
         session_path = self._dir / session_id
         state_file = session_path / "state.json"
         if not state_file.exists():
@@ -125,10 +155,25 @@ class SessionCheckpoint:
 
         try:
             data = json.loads(state_file.read_text(encoding="utf-8"))
-            messages = []
+
             msg_file = session_path / "messages.json"
-            if msg_file.exists():
-                messages = json.loads(msg_file.read_text(encoding="utf-8"))
+            state_updated_at_raw = data.get("updated_at")
+            state_updated_at = (
+                float(state_updated_at_raw)
+                if isinstance(state_updated_at_raw, (int, float))
+                else None
+            )
+
+            messages = self._load_messages_from_db(
+                session_id,
+                state_updated_at=state_updated_at,
+                msg_file=msg_file,
+            )
+            if messages is None:
+                if msg_file.exists():
+                    messages = json.loads(msg_file.read_text(encoding="utf-8"))
+                else:
+                    messages = []
 
             tool_log = []
             tools_file = session_path / "tools.json"
@@ -150,6 +195,51 @@ class SessionCheckpoint:
             )
         except (json.JSONDecodeError, KeyError, OSError) as e:
             log.warning("Failed to load session %s: %s", session_id, e)
+            return None
+
+    def _load_messages_from_db(
+        self,
+        session_id: str,
+        *,
+        state_updated_at: float | None = None,
+        msg_file: Path | None = None,
+    ) -> list[dict[str, Any]] | None:
+        """Read the full message history from the SQLite ``messages`` table.
+
+        Returns ``None`` when the DB cannot answer authoritatively so the
+        caller can fall back to JSON. A valid DB result may be an empty list:
+        after Phase 1b an explicit zero-message save must not resurrect a
+        stale ``messages.json`` cache.
+        """
+        db_path = self._dir / "sessions.db"
+        if not db_path.exists():
+            return None
+
+        try:
+            from core.memory.session_manager import SessionManager
+
+            mgr = SessionManager(db_path)
+            try:
+                messages = mgr.get_messages(session_id)
+                if messages:
+                    return messages
+
+                meta = mgr.get(session_id)
+                if meta and meta.message_count == 0:
+                    return []
+                if msg_file is None or not msg_file.exists():
+                    return []
+                if state_updated_at is not None:
+                    try:
+                        if msg_file.stat().st_mtime < state_updated_at:
+                            return []
+                    except OSError:
+                        return []
+                return None
+            finally:
+                mgr.close()
+        except Exception:
+            log.debug("DB-first message load failed for %s", session_id, exc_info=True)
             return None
 
     def mark_completed(self, session_id: str) -> None:

--- a/core/wiring/layout_migrator.py
+++ b/core/wiring/layout_migrator.py
@@ -59,7 +59,7 @@ log = logging.getLogger(__name__)
 
 #: Current target layout schema version. Bumped each time a path-level
 #: migration is added.
-GEODE_LAYOUT_VERSION = 3
+GEODE_LAYOUT_VERSION = 4
 
 #: TTL in days for v2→v3 archival steps (runs/vault/projects). Override via
 #: ``GEODE_ARCHIVE_TTL_DAYS`` env var. Lowering for tests / aggressive
@@ -254,6 +254,8 @@ def _run_pending_migrations(current_version: int, report: LayoutMigrationReport)
         report.steps.append(_migrate_v1_to_v2())
     if current_version < 3:
         report.steps.append(_migrate_v2_to_v3())
+    if current_version < 4:
+        report.steps.append(_migrate_v3_to_v4())
 
 
 # ---------------------------------------------------------------------------
@@ -544,5 +546,122 @@ def _migrate_v2_to_v3() -> MigrationResult:
         result,
         label="projects",
     )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# v3 → v4: backfill messages.json into the SQLite messages table
+# ---------------------------------------------------------------------------
+
+
+def _migrate_v3_to_v4() -> MigrationResult:
+    """v4 — backfill ``messages.json`` of every existing session into the
+    SQLite ``messages`` table introduced in PR #1151 (Phase 1a).
+
+    Phase 1a wired ``SessionCheckpoint.save()`` to dual-write into the DB
+    going forward, but pre-PR-1151 sessions and any session whose DB
+    write quietly failed only have the JSON copy. Phase 1b flips the
+    runtime SoT to the DB; before the flip this step backfills so every
+    historical session is queryable from SQL the moment 1b ships.
+
+    Strategy — for every ``~/.geode/projects/<id>/sessions/<sid>/`` with a
+    ``messages.json`` file:
+
+      1. Open ``sessions.db`` in the same directory (created if absent).
+      2. Compare ``count_messages(<sid>)`` against ``len(json_messages)``.
+         If the DB already has at least as many rows, skip (idempotent).
+      3. Otherwise call ``upsert_messages(<sid>, json_messages)`` —
+         the UNIQUE(session_id, seq) key makes this safe to re-run.
+
+    Corrupt or unreadable JSON files are *skipped* with a WARN, never
+    fatal — a single bad session must not block the whole migration.
+    Progress is reported every 10 backfilled sessions.
+    """
+    import json as _json  # local import keeps top-level lean
+
+    result = MigrationResult(name="v3→v4: messages backfill")
+
+    sessions_root = GEODE_HOME / "projects"
+    if not sessions_root.is_dir():
+        result.skipped.append("projects/ dir absent — fresh install")
+        return result
+
+    backfilled = 0
+    already_in_db = 0
+    skipped_corrupt = 0
+    progress_every = 10
+
+    for project_dir in sorted(sessions_root.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        sessions_dir = project_dir / "sessions"
+        if not sessions_dir.is_dir():
+            continue
+
+        db_path = sessions_dir / "sessions.db"
+        for session_dir in sorted(sessions_dir.iterdir()):
+            if not session_dir.is_dir():
+                continue
+            msg_file = session_dir / "messages.json"
+            if not msg_file.exists():
+                continue
+
+            try:
+                payload = _json.loads(msg_file.read_text(encoding="utf-8"))
+            except (_json.JSONDecodeError, OSError) as exc:
+                log.warning("v3→v4 backfill: skip corrupt %s (%s)", msg_file, exc)
+                skipped_corrupt += 1
+                result.warnings.append(f"corrupt: {msg_file}: {exc}")
+                continue
+
+            if not isinstance(payload, list):
+                log.warning(
+                    "v3→v4 backfill: skip non-list payload at %s (type=%s)",
+                    msg_file,
+                    type(payload).__name__,
+                )
+                skipped_corrupt += 1
+                continue
+
+            session_id = session_dir.name
+            try:
+                # Local import — avoid pulling SQLite/threading at module load.
+                from core.memory.session_manager import SessionManager
+
+                mgr = SessionManager(db_path)
+                try:
+                    if mgr.count_messages(session_id) >= len(payload):
+                        already_in_db += 1
+                        continue
+                    mgr.upsert_messages(session_id, payload)
+                finally:
+                    mgr.close()
+                backfilled += 1
+                if backfilled % progress_every == 0:
+                    log.info("v3→v4 backfill: %d sessions migrated...", backfilled)
+            except Exception as exc:
+                log.warning(
+                    "v3→v4 backfill: %s/%s upsert failed (%s)",
+                    project_dir.name,
+                    session_id,
+                    exc,
+                )
+                skipped_corrupt += 1
+                result.warnings.append(f"upsert fail: {session_id}: {exc}")
+
+    log.info(
+        "v3→v4 backfill complete: %d backfilled, %d already-in-db, %d skipped",
+        backfilled,
+        already_in_db,
+        skipped_corrupt,
+    )
+    if backfilled == 0 and already_in_db == 0 and skipped_corrupt == 0:
+        result.skipped.append("no sessions found")
+    else:
+        result.warnings.append(
+            f"summary: backfilled={backfilled} already_in_db={already_in_db} "
+            f"skipped_corrupt={skipped_corrupt}"
+        )
 
     return result

--- a/tests/test_layout_migrator.py
+++ b/tests/test_layout_migrator.py
@@ -506,3 +506,116 @@ class TestV2ToV3TTLArchival:
         assert len(v3_first[0].moved) == 1
         assert second.no_op is True
         assert v3_second == []
+
+
+class TestV3ToV4MessagesBackfill:
+    """v4 — backfill ``messages.json`` of every existing session into the
+    SQLite ``messages`` table introduced in PR #1151."""
+
+    def _make_session(
+        self,
+        fake_geode_home: Path,
+        project: str,
+        session_id: str,
+        messages: list[dict[str, str]] | str,
+    ) -> Path:
+        sessions_dir = fake_geode_home / "projects" / project / "sessions"
+        session_dir = sessions_dir / session_id
+        session_dir.mkdir(parents=True)
+        msg_file = session_dir / "messages.json"
+        if isinstance(messages, str):
+            msg_file.write_text(messages, encoding="utf-8")  # corrupt
+        else:
+            import json as _json
+
+            msg_file.write_text(_json.dumps(messages), encoding="utf-8")
+        return sessions_dir / "sessions.db"
+
+    def test_v3_to_v4_backfills_pre_phase_1a_session(self, fake_geode_home: Path) -> None:
+        from core.memory.session_manager import SessionManager
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        # Pre-PR #1151 session: only messages.json exists, DB has nothing.
+        db_path = self._make_session(
+            fake_geode_home,
+            "alpha",
+            "sess-1",
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+
+        report = ensure_layout_migrated(force=True)
+
+        v4 = [s for s in report.steps if s.name.startswith("v3→v4")]
+        assert v4, "v3→v4 step must run"
+
+        mgr = SessionManager(db_path=db_path)
+        try:
+            assert mgr.count_messages("sess-1") == 2
+        finally:
+            mgr.close()
+
+    def test_v3_to_v4_skips_corrupt_messages_json(self, fake_geode_home: Path) -> None:
+        """A single corrupt session must NOT block the rest of the migration."""
+        from core.memory.session_manager import SessionManager
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        # One good session, one corrupt — both under the same project.
+        db_path = self._make_session(
+            fake_geode_home,
+            "alpha",
+            "good",
+            [{"role": "user", "content": "ok"}],
+        )
+        self._make_session(
+            fake_geode_home,
+            "alpha",
+            "bad",
+            "{not valid json",
+        )
+
+        report = ensure_layout_migrated(force=True)
+
+        v4 = [s for s in report.steps if s.name.startswith("v3→v4")]
+        assert v4
+        assert any("corrupt" in w for w in v4[0].warnings)
+
+        mgr = SessionManager(db_path=db_path)
+        try:
+            assert mgr.count_messages("good") == 1
+            assert mgr.count_messages("bad") == 0
+        finally:
+            mgr.close()
+
+    def test_v3_to_v4_idempotent(self, fake_geode_home: Path) -> None:
+        """Re-running the migration on an already-migrated session is a no-op
+        (UNIQUE(session_id, seq) makes upsert_messages safe)."""
+        from core.memory.session_manager import SessionManager
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        db_path = self._make_session(
+            fake_geode_home,
+            "alpha",
+            "idem",
+            [{"role": "user", "content": "x"}],
+        )
+
+        ensure_layout_migrated(force=True)
+        ensure_layout_migrated(force=True)  # second run
+
+        mgr = SessionManager(db_path=db_path)
+        try:
+            assert mgr.count_messages("idem") == 1
+        finally:
+            mgr.close()
+
+    def test_v3_to_v4_no_op_on_fresh_install(self, fake_geode_home: Path) -> None:
+        """No projects/ dir → step records ``skipped`` reason, no error."""
+        from core.wiring.layout_migrator import ensure_layout_migrated
+
+        report = ensure_layout_migrated(force=True)
+        v4 = [s for s in report.steps if s.name.startswith("v3→v4")]
+        assert v4
+        assert any("projects/ dir absent" in s for s in v4[0].skipped)

--- a/tests/test_session_checkpoint.py
+++ b/tests/test_session_checkpoint.py
@@ -44,7 +44,12 @@ class TestSessionCheckpoint:
         cp = SessionCheckpoint(tmp_path / "session")
         assert cp.load("nonexistent") is None
 
-    def test_message_trimming(self, tmp_path):
+    def test_no_trim_full_history_preserved(self, tmp_path):
+        """Phase 1b — JSON trim removed. ``CHECKPOINT_MAX_MESSAGES = 0``
+        means "keep everything"; the SoT is now the SQLite ``messages``
+        table which holds the *full* conversation, and the JSON hot
+        cache is also kept untrimmed so old offline tooling still works
+        on long sessions."""
         cp = SessionCheckpoint(tmp_path / "session")
         messages = [{"role": "user", "content": f"msg {i}"} for i in range(50)]
         state = SessionState(session_id="trim-test", messages=messages)
@@ -52,9 +57,12 @@ class TestSessionCheckpoint:
 
         loaded = cp.load("trim-test")
         assert loaded is not None
-        assert len(loaded.messages) == CHECKPOINT_MAX_MESSAGES
-        # Should keep most recent
+        assert len(loaded.messages) == 50, "full history must survive — no trim"
+        # Both the first and last message survive (in-order).
+        assert loaded.messages[0]["content"] == "msg 0"
         assert loaded.messages[-1]["content"] == "msg 49"
+        # The exported constant signals "no trim" to downstream callers.
+        assert CHECKPOINT_MAX_MESSAGES == 0
 
     def test_mark_completed(self, tmp_path):
         cp = SessionCheckpoint(tmp_path / "session")
@@ -144,3 +152,126 @@ class TestSessionCheckpoint:
         assert loaded is not None
         assert len(loaded.tool_log) == 1
         assert loaded.tool_log[0]["name"] == "search"
+
+
+class TestPhase1bDbFirst:
+    """Phase 1b — load() reads messages from the SQLite SoT first; JSON is a
+    fallback for pre-migration sessions and dual-write race losers."""
+
+    def test_load_reads_messages_from_db_after_save(self, tmp_path):
+        """Round-trip: save() writes to DB, load() reads from DB."""
+        cp = SessionCheckpoint(tmp_path / "session")
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        cp.save(SessionState(session_id="db-1", messages=messages))
+
+        loaded = cp.load("db-1")
+        assert loaded is not None
+        assert len(loaded.messages) == 2
+        contents = [m["content"] for m in loaded.messages]
+        assert contents == ["hello", "world"]
+
+    def test_load_falls_back_to_json_when_db_empty(self, tmp_path):
+        """Pre-Phase-1a sessions only have ``messages.json``. The DB-first
+        load() must transparently fall back to the JSON cache so legacy
+        sessions keep resuming when no DB exists yet."""
+        import json
+
+        session_dir = tmp_path / "session" / "legacy-1"
+        session_dir.mkdir(parents=True)
+        (session_dir / "state.json").write_text(
+            json.dumps({"session_id": "legacy-1", "status": "active"}),
+            encoding="utf-8",
+        )
+        (session_dir / "messages.json").write_text(
+            json.dumps([{"role": "user", "content": "from json only"}]),
+            encoding="utf-8",
+        )
+
+        cp = SessionCheckpoint(tmp_path / "session")
+        loaded = cp.load("legacy-1")
+        assert loaded is not None
+        assert len(loaded.messages) == 1
+        assert loaded.messages[0]["content"] == "from json only"
+
+    def test_load_falls_back_to_json_when_existing_db_has_no_session_rows(self, tmp_path):
+        """Legacy sessions can share a project DB with newer sessions. An
+        empty row set for a session unknown to the DB must still fall back
+        to ``messages.json``."""
+        import json
+
+        from core.memory.session_manager import SessionManager
+
+        root = tmp_path / "session"
+        mgr = SessionManager(db_path=root / "sessions.db")
+        try:
+            mgr.upsert_messages("other-session", [{"role": "user", "content": "db"}])
+        finally:
+            mgr.close()
+
+        session_dir = root / "legacy-2"
+        session_dir.mkdir(parents=True)
+        (session_dir / "state.json").write_text(
+            json.dumps({"session_id": "legacy-2", "status": "active"}),
+            encoding="utf-8",
+        )
+        (session_dir / "messages.json").write_text(
+            json.dumps([{"role": "user", "content": "legacy json"}]),
+            encoding="utf-8",
+        )
+
+        cp = SessionCheckpoint(root)
+        loaded = cp.load("legacy-2")
+        assert loaded is not None
+        assert [m["content"] for m in loaded.messages] == ["legacy json"]
+
+    def test_empty_db_result_does_not_resurrect_stale_json(self, tmp_path):
+        """If a DB-first empty save succeeds and the later JSON cache write
+        fails, load() must treat the empty DB row set as authoritative."""
+        import json
+
+        from core.memory.session_manager import SessionManager
+
+        root = tmp_path / "session"
+        cp = SessionCheckpoint(root)
+        cp.save(
+            SessionState(
+                session_id="empty-now",
+                messages=[{"role": "user", "content": "stale json"}],
+            )
+        )
+
+        state_file = root / "empty-now" / "state.json"
+        msg_file = root / "empty-now" / "messages.json"
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+        data["updated_at"] = time.time() + 60
+        state_file.write_text(json.dumps(data), encoding="utf-8")
+
+        mgr = SessionManager(db_path=root / "sessions.db")
+        try:
+            mgr.upsert_messages("empty-now", [])
+            assert mgr.count_messages("empty-now") == 0
+        finally:
+            mgr.close()
+        assert "stale json" in msg_file.read_text(encoding="utf-8")
+
+        loaded = cp.load("empty-now")
+        assert loaded is not None
+        assert loaded.messages == []
+
+    def test_save_writes_to_db_before_json_so_db_is_authoritative(self, tmp_path):
+        """Phase 1b SoT contract — when save() returns, the DB row count
+        for the session matches the in-memory message count, regardless
+        of whether the JSON write succeeded or not."""
+        cp = SessionCheckpoint(tmp_path / "session")
+        cp.save(SessionState(session_id="sot-1", messages=[{"role": "user", "content": "x"}]))
+
+        from core.memory.session_manager import SessionManager
+
+        mgr = SessionManager(db_path=tmp_path / "session" / "sessions.db")
+        try:
+            assert mgr.count_messages("sot-1") == 1
+        finally:
+            mgr.close()


### PR DESCRIPTION
## Summary

- Phase 1a (PR #1151) 의 dual-write 를 뒤집어 SQLite `messages` 테이블이 SoT, JSON 은 hot cache.
- `CHECKPOINT_MAX_MESSAGES` 20→0 (no trim), `save()` DB 우선, `load()` DB 우선 + JSON fallback (`list | None` ambiguity 해결).
- `GEODE_LAYOUT_VERSION` 3→4 + `_migrate_v3_to_v4()` — pre-PR-1151 session backfill, 손상 skip + WARN, idempotent.

## Why

Hermes 흡수 plan (`docs/plans/2026-05-14-hermes-strengths-absorption.md`) 의 1b. 1a 는 dual-write 만 깔아두고 JSON 을 SoT 로 유지. 1b 가 SoT 를 DB 로 flip — long-term recall (Phase 1c FTS5 / 1d global.db search) 의 기반.

## Changes

| File | Change |
|------|--------|
| `core/runtime_state/session_checkpoint.py` | `CHECKPOINT_MAX_MESSAGES = 0`. `save()` DB 먼저. `_load_messages_from_db()` `list \| None` 반환. `load()` DB 우선 + JSON fallback |
| `core/wiring/layout_migrator.py` | `GEODE_LAYOUT_VERSION = 4`. `_migrate_v3_to_v4()` backfill (corrupt skip + idempotent + progress) |
| `tests/test_session_checkpoint.py` | `TestPhase1bDbFirst` 5 신규 + `test_message_trimming` → `test_no_trim_full_history_preserved` |
| `tests/test_layout_migrator.py` | `TestV3ToV4MessagesBackfill` 4 신규 |
| `CHANGELOG.md` | `[Unreleased] > Changed` KR+EN |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `CHECKPOINT_MAX_MESSAGES` 제거 | Implemented | 20→0, full history |
| `save()` DB 우선 | Implemented | DB sync 먼저, JSON cache 나중 |
| `load()` DB 우선 + JSON fallback | Implemented | `list \| None` 시그널 (CRITICAL fix) |
| `tools.json` 흡수 | Partial | hot cache 유지 — DB tool_calls 가 다른 shape, loop tool_log 별도 |
| `_migrate_v3_to_v4()` backfill | Implemented | 손상 skip + idempotent + progress + fresh-install no-op |
| GEODE_LAYOUT_VERSION 3→4 | Implemented | `_run_pending_migrations` 에 step 추가 |
| 손상 파일 graceful skip | Implemented | corrupt warning, 다른 session 진행 |
| stale JSON resurrection 회피 | **Implemented (Codex CRITICAL fix)** | `list \| None` ambiguity 해결 |
| existing-DB legacy fallback | **Implemented (Codex CRITICAL fix)** | metadata + msg_file 정확 케이스 |

## Cross-LLM verification (Codex MCP, 9번째 사용)

`mcp__codex__codex` (sandbox=`workspace-write`, approval=`never`, model=gpt-5.2-codex). **CRITICAL 2 + HIGH 2 자동 fix**:

1. **CRITICAL** — `_load_messages_from_db()` 가 `list[dict]` 반환 → empty list `[]` 와 fallback 시그널 ambiguity. DB-authoritative empty save 후 다음 load 가 stale `messages.json` 으로 resurrection. → `list | None` 변경, `[]` = authoritative empty, `None` = fallback signal.
2. **CRITICAL** — legacy fallback check 가 `sessions.db` auto-create. existing project DB + 다른 session 만 있는 케이스 정확 구분 안 됨. → metadata + msg_file 비교로 케이스 분리.
3. **HIGH** — 기존 fallback test 가 `sessions.db` 부재 case 만 cover. existing-DB case 미검증 → existing-DB legacy fallback test 추가.
4. **HIGH** — stale JSON resurrection 회귀 test 부재 → empty save + DB authoritative empty 의 회귀 보호 test.

MEDIUM (recommendations only):
- `_sync_messages_to_db` failure 시 JSON 만 진행 (Phase 1a 호환). Phase 1b 의 strict DB-only SoT 면 fail-fast 가 더 정직 — 다만 Phase 1a test 호환성 위해 보존.
- per-load SessionManager open/close cost — REPL turn 대비 작음, profile 후 캐시.

## Behaviour walk

| Scenario | Pre-1b | Post-1b | Verdict |
|---|---|---|---|
| DB OK + JSON fail (non-empty) | JSON SoT 단축 | DB rows 회수 | fixed |
| DB authoritative `[]` + stale JSON | resurrection | `[]` 정확 | **fixed CRITICAL** |
| No `sessions.db`, legacy JSON | JSON | JSON fallback | safe |
| Existing DB + target 미존재 | 모호 | JSON fallback | **fixed CRITICAL** |
| Long REPL 반복 load | N/A | per-load open/close (OK) | acceptable |
| Migration killed mid-loop | N/A | version 3 유지, idempotent rerun | safe |
| JSON 수동 shrink, DB 더 큼 | N/A | DB-ahead win | intentional |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy core/ plugins/` — `Success: no issues found in 363 source files`
- [x] `uv run pytest tests/test_session_checkpoint.py tests/test_session_manager.py tests/test_session_resume.py tests/test_layout_migrator.py` — **94 passed**
- [ ] CI 5/5 (PR 후 watch)

## Reference

- Phase 1a (base): PR #1151
- Hermes plan: `docs/plans/2026-05-14-hermes-strengths-absorption.md` § 1b
- 다음 step: 1c (FTS5 + 트리그램 인덱스), 1d (global.db + session_search)
- Codex MCP 누적: 9회, CRITICAL 8 + HIGH 16 자동 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code), cross-verified by Codex MCP