### PR TITLE
release: Tier 3 graphics scaffold (#1177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,44 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Added
+
+- **CLI LaTeX Tier 3 (graphics inline) — capability detection scaffold.**
+  CLI LaTeX 의 frontier 5-tier 조사 결과 LLM CLI 6 도구 (Claude Code /
+  Codex CLI / Aider / glow / mdcat / bat) 모두 Tier 0 (raw), GEODE 만
+  Tier 1+2 cascade. Tier 3 (image inline via Kitty / SIXEL graphics
+  protocols) 추가 시 **유일한 4-tier 통합 CLI agent**. 본 PR 은 scaffold:
+  - `core/ui/latex_graphics.py` — `detect_graphics_capability()` 가
+    `TERM=xterm-kitty` / `TERM=wezterm-*` / `TERM=xterm-ghostty` /
+    `KITTY_WINDOW_ID` / `WEZTERM_PANE` / `WEZTERM_EXECUTABLE` /
+    `GHOSTTY_RESOURCES_DIR` / `KONSOLE_VERSION` (Kitty graphics protocol
+    family) + `mlterm` / `foot` (SIXEL) conservative allow-list + non-TTY
+    회피 + `GEODE_LATEX_GRAPHICS_FORCE` / `_DISABLE` operator override.
+    `render_latex_image()` 는 public API 시그너처 pin, 현재
+    `NotImplementedError` (다음 PR 에서 matplotlib 또는 sympy.preview
+    + dvipng → PNG → Kitty/SIXEL escape wire).
+  - `graphics_opt_in_active()` — env `GEODE_LATEX_GRAPHICS` truthy
+    체크. capability detect 와 분리되어 matplotlib import 비용을
+    opt-out 사용자가 안 짊어지게.
+  - 18 신규 test (`tests/test_latex_graphics.py`): unknown / Kitty
+    family 5 / SIXEL 2 / force-disable / force-protocol / invalid
+    force / non-TTY / opt-in truthy/falsy / scaffold NotImplementedError
+    + 의도된 메시지.
+  - Frontier reference: GuyAzene/latex-terminal, MaxwellsEquation/LaTerM
+    (2025), nilqed/latex2sixel, Pan-Maciek/LaTeRm, Kitty graphics
+    protocol spec.
+- **CLI LaTeX Tier 3 (graphics inline) — capability detection
+  scaffold.** Adds `core/ui/latex_graphics.py` with conservative
+  allow-list capability detection (Kitty family + SIXEL + non-TTY
+  guard + operator overrides) and a signature-pinned `render_latex_
+  image()` that raises a clearly-described `NotImplementedError`. The
+  follow-up PR will wire matplotlib (or sympy.preview + dvipng) → PNG
+  → Kitty / SIXEL escape sequences. The matplotlib dependency stays
+  opt-in via `GEODE_LATEX_GRAPHICS=1` so users on non-graphics
+  terminals pay zero install cost. 18 new tests cover eight terminal
+  allow-list paths, three env-override behaviours, the non-TTY redirect
+  guard, the opt-in helper, and the scaffold's loud failure mode.
+
 ### Documentation
 
 - **Autoresearch gen 0 baseline 시도 — Anthropic credit 차단으로 BLOCKED.**

--- a/core/ui/latex_graphics.py
+++ b/core/ui/latex_graphics.py
@@ -1,0 +1,180 @@
+"""Tier 3 LaTeX rendering — image inline via terminal graphics protocols.
+
+Why this module
+---------------
+The 5-tier survey of CLI LaTeX rendering (`docs/audits/2026-05-16-cli-
+latex-frontier.md`, when written) places GEODE in **Tier 1 + Tier 2**
+(pylatexenc Unicode + SymPy ASCII pretty), with no LLM CLI in **Tier 3**
+(image inline via Kitty / SIXEL graphics protocols). Adding Tier 3
+puts GEODE alone in the 4-tier intersection.
+
+This module is the **scaffold**:
+
+  * :func:`detect_graphics_capability` — runtime detection of the host
+    terminal's graphics support. Returns one of ``"kitty"``, ``"sixel"``,
+    or ``None``. Pure environment / TERM probe — never spawns a
+    subprocess, never opens a TTY.
+  * :func:`render_latex_image` — the *intended* entry point that will
+    convert a LaTeX expression into a base64-encoded PNG and emit the
+    appropriate terminal escape sequence. Currently raises
+    ``NotImplementedError`` so the next PR can wire in matplotlib
+    (or a lighter dvipng / mathjax_node alternative) without breaking
+    the public API contract.
+
+The Tier 1 / Tier 2 path in :mod:`core.ui.latex` is the runtime default;
+Tier 3 only activates when *both* the capability probe returns a known
+protocol *and* a future opt-in flag (``GEODE_LATEX_GRAPHICS=1``) is set.
+This keeps the next PR's matplotlib import strictly opt-in.
+
+Frontier reference
+------------------
+- Kitty graphics protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/
+- WezTerm / Ghostty / Konsole adopt the same protocol family.
+- SIXEL: xterm, mlterm, foot.
+- Tools: `GuyAzene/latex-terminal`, `MaxwellsEquation/LaTerM`,
+  `nilqed/latex2sixel`, `Pan-Maciek/LaTeRm`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Final, Literal
+
+log = logging.getLogger(__name__)
+
+
+GraphicsProtocol = Literal["kitty", "sixel"]
+
+
+# ---------------------------------------------------------------------------
+# Capability detection
+# ---------------------------------------------------------------------------
+#
+# Detection is deliberately conservative — we prefer to *miss* a capability
+# (and fall back to Tier 1/2 ASCII art) rather than emit a graphics escape
+# sequence into a terminal that prints it as garbled bytes.
+#
+# Kitty: identified by exact / prefixed ``TERM`` values *or* env vars
+# used by terminals that implement the Kitty graphics protocol.
+#
+# SIXEL: there is no clean env-var probe, so we restrict to a small
+# allow-list of terminals known to support it (xterm with ``-ti vt340``,
+# mlterm, foot). The ``COLORTERM`` value is *not* a reliable signal.
+
+_KITTY_TERM_VALUES: Final[tuple[str, ...]] = (
+    "xterm-kitty",
+    "wezterm",
+    "ghostty",
+    "xterm-ghostty",
+)
+_KITTY_TERM_PREFIXES: Final[tuple[str, ...]] = (
+    "wezterm-",
+    "ghostty-",
+    "xterm-ghostty-",
+)
+_KITTY_ENV_VARS: Final[tuple[str, ...]] = (
+    "KITTY_WINDOW_ID",
+    "WEZTERM_PANE",
+    "WEZTERM_EXECUTABLE",
+    "GHOSTTY_RESOURCES_DIR",
+    "KONSOLE_VERSION",
+)
+_SIXEL_TERM_VALUES: Final[tuple[str, ...]] = (
+    "mlterm",
+    "foot",
+)
+_FORCE_DISABLE_ENV: Final = "GEODE_LATEX_GRAPHICS_DISABLE"
+_FORCE_PROTOCOL_ENV: Final = "GEODE_LATEX_GRAPHICS_FORCE"
+
+
+def detect_graphics_capability() -> GraphicsProtocol | None:
+    """Return the host terminal's graphics protocol, or ``None`` if
+    no supported protocol is detectable.
+
+    Resolution order:
+      1. ``GEODE_LATEX_GRAPHICS_DISABLE`` env — return ``None`` regardless.
+      2. ``GEODE_LATEX_GRAPHICS_FORCE`` env (``"kitty"`` / ``"sixel"``)
+         — operator override, useful for tests and users on terminals
+         the allow-lists below miss.
+      3. ``stdout.isatty()`` must be true — never emit graphics into
+         a redirected pipe.
+      4. Kitty allow-list (TERM value or env var).
+      5. SIXEL allow-list.
+      6. ``None``.
+    """
+    if os.environ.get(_FORCE_DISABLE_ENV):
+        return None
+
+    forced = os.environ.get(_FORCE_PROTOCOL_ENV, "").strip().lower()
+    if forced == "kitty":
+        return "kitty"
+    if forced == "sixel":
+        return "sixel"
+
+    try:
+        if not sys.stdout.isatty():
+            return None
+    except (AttributeError, ValueError):
+        return None
+
+    term = os.environ.get("TERM", "").lower()
+    if (
+        term in _KITTY_TERM_VALUES
+        or term.startswith(_KITTY_TERM_PREFIXES)
+        or any(os.environ.get(v) for v in _KITTY_ENV_VARS)
+    ):
+        return "kitty"
+    if term in _SIXEL_TERM_VALUES:
+        return "sixel"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Image-inline entry point (scaffold)
+# ---------------------------------------------------------------------------
+
+
+def render_latex_image(src: str, *, protocol: GraphicsProtocol) -> str:
+    """Convert a LaTeX expression to an inline-graphics escape sequence.
+
+    Currently raises :class:`NotImplementedError`. The follow-up PR will
+    wire one of:
+
+      * `matplotlib.mathtext` → PNG → base64 → Kitty ``\\x1b_G…\\x1b\\\\``
+        (lightest path; the user already has matplotlib in many envs).
+      * `sympy.preview` (uses `dvipng`) → PNG → SIXEL ``\\x1bP…\\x1b\\\\``.
+
+    Until then, the public API contract (signature + return type) is
+    pinned so the rest of :mod:`core.ui.latex` can call into Tier 3 by
+    name without any future refactor.
+    """
+    log.debug(
+        "Tier 3 image render requested for protocol=%s, src=%r — scaffold only",
+        protocol,
+        src[:120],
+    )
+    raise NotImplementedError(
+        "Tier 3 image rendering is staged behind a follow-up PR; "
+        "callers must check `detect_graphics_capability()` *and* the runtime "
+        "opt-in before calling `render_latex_image()`."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Opt-in helper
+# ---------------------------------------------------------------------------
+
+_GRAPHICS_OPT_IN_ENV: Final = "GEODE_LATEX_GRAPHICS"
+
+
+def graphics_opt_in_active() -> bool:
+    """True when the user has opted in to Tier 3 image rendering.
+
+    The opt-in is intentionally separate from the capability probe so the
+    next PR can ship the matplotlib import behind it — users who don't
+    set the env var pay zero install / import cost even on a Kitty
+    terminal.
+    """
+    return os.environ.get(_GRAPHICS_OPT_IN_ENV, "").strip().lower() in {"1", "true", "yes"}

--- a/tests/test_latex_graphics.py
+++ b/tests/test_latex_graphics.py
@@ -1,0 +1,154 @@
+"""Tests for the Tier 3 (graphics inline) scaffold in
+``core.ui.latex_graphics``.
+
+PR scope is *capability detection + public-API pin* only — the actual
+PNG generation lands in the follow-up. These tests therefore focus on:
+
+  * The detect probe correctly classifies Kitty / WezTerm / Ghostty /
+    Konsole / SIXEL / unknown / non-TTY environments.
+  * `GEODE_LATEX_GRAPHICS_FORCE` and `..._DISABLE` env overrides win
+    over the auto-detect.
+  * The opt-in helper reads `GEODE_LATEX_GRAPHICS` cleanly.
+  * `render_latex_image` raises a *clearly-described* `NotImplementedError`
+    so a caller that bypasses the opt-in fails loud, not silent.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from core.ui.latex_graphics import (
+    detect_graphics_capability,
+    graphics_opt_in_active,
+    render_latex_image,
+)
+
+
+@pytest.fixture()
+def isolated_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """Wipe every env var the detector consults so tests start blank."""
+    for var in (
+        "TERM",
+        "KITTY_WINDOW_ID",
+        "WEZTERM_PANE",
+        "WEZTERM_EXECUTABLE",
+        "GHOSTTY_RESOURCES_DIR",
+        "KONSOLE_VERSION",
+        "GEODE_LATEX_GRAPHICS_DISABLE",
+        "GEODE_LATEX_GRAPHICS_FORCE",
+        "GEODE_LATEX_GRAPHICS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Default to a TTY so the isatty() guard does not short-circuit
+    # the unrelated detection paths.
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True, raising=False)
+    return monkeypatch
+
+
+class TestDetectGraphicsCapability:
+    def test_unknown_terminal_returns_none(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        assert detect_graphics_capability() is None
+
+    def test_kitty_term_value(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-kitty")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_kitty_window_id_env(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        isolated_env.setenv("KITTY_WINDOW_ID", "42")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_wezterm_term_variant(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "wezterm-256color")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_wezterm_env_vars(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        isolated_env.setenv("WEZTERM_EXECUTABLE", "/Applications/WezTerm.app/wezterm")
+        assert detect_graphics_capability() == "kitty"
+        isolated_env.delenv("WEZTERM_EXECUTABLE")
+        isolated_env.setenv("WEZTERM_PANE", "1")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_ghostty_term_variant(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-ghostty")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_ghostty_resources_dir(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        isolated_env.setenv("GHOSTTY_RESOURCES_DIR", "/Applications/Ghostty.app/Contents/Resources")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_konsole_version_env(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        isolated_env.setenv("KONSOLE_VERSION", "230400")
+        assert detect_graphics_capability() == "kitty"
+
+    def test_sixel_terminals(self, isolated_env: pytest.MonkeyPatch) -> None:
+        for value in ("mlterm", "foot"):
+            isolated_env.setenv("TERM", value)
+            assert detect_graphics_capability() == "sixel", value
+
+    def test_force_disable_overrides_capability(self, isolated_env: pytest.MonkeyPatch) -> None:
+        isolated_env.setenv("TERM", "xterm-kitty")
+        isolated_env.setenv("GEODE_LATEX_GRAPHICS_DISABLE", "1")
+        assert detect_graphics_capability() is None
+
+    def test_force_protocol_overrides_unknown_terminal(
+        self, isolated_env: pytest.MonkeyPatch
+    ) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        isolated_env.setenv("GEODE_LATEX_GRAPHICS_FORCE", "kitty")
+        assert detect_graphics_capability() == "kitty"
+        isolated_env.setenv("GEODE_LATEX_GRAPHICS_FORCE", "sixel")
+        assert detect_graphics_capability() == "sixel"
+
+    def test_force_protocol_invalid_value_falls_through(
+        self, isolated_env: pytest.MonkeyPatch
+    ) -> None:
+        isolated_env.setenv("TERM", "xterm-256color")
+        isolated_env.setenv("GEODE_LATEX_GRAPHICS_FORCE", "carrot")
+        assert detect_graphics_capability() is None
+
+    def test_non_tty_returns_none_even_for_kitty(self, isolated_env: pytest.MonkeyPatch) -> None:
+        """Never emit graphics into a redirected pipe — that produces
+        garbled bytes when the operator pipes ``geode "..." | tee log``."""
+        isolated_env.setenv("TERM", "xterm-kitty")
+        # Use a real-looking non-TTY object — Rich-style StringIO.
+        isolated_env.setattr("sys.stdout", io.StringIO(), raising=False)
+        assert detect_graphics_capability() is None
+
+
+class TestGraphicsOptIn:
+    def test_default_opt_in_off(self, isolated_env: pytest.MonkeyPatch) -> None:
+        assert graphics_opt_in_active() is False
+
+    def test_opt_in_truthy_values(self, isolated_env: pytest.MonkeyPatch) -> None:
+        for value in ("1", "true", "yes", "TRUE", "Yes"):
+            isolated_env.setenv("GEODE_LATEX_GRAPHICS", value)
+            assert graphics_opt_in_active() is True, value
+
+    def test_opt_in_falsy_values(self, isolated_env: pytest.MonkeyPatch) -> None:
+        for value in ("0", "false", "no", "off", ""):
+            isolated_env.setenv("GEODE_LATEX_GRAPHICS", value)
+            assert graphics_opt_in_active() is False, value
+
+
+class TestRenderLatexImage:
+    def test_scaffold_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError, match="follow-up PR"):
+            render_latex_image(r"\frac{a}{b}", protocol="kitty")
+
+    def test_scaffold_message_mentions_opt_in(self) -> None:
+        """The error must point the caller at the opt-in path so a future
+        regression of the wiring (e.g. someone wires it up without
+        respecting the opt-in) is loud."""
+        try:
+            render_latex_image(r"x", protocol="sixel")
+        except NotImplementedError as exc:
+            msg = str(exc)
+            assert "opt-in" in msg.lower() or "capability" in msg.lower()
+        else:
+            raise AssertionError("expected NotImplementedError")


### PR DESCRIPTION
## Summary

develop → main release for PR #1177.

- **#1177** `feat(ui): CLI LaTeX Tier 3 (graphics inline) — capability detection scaffold`. `core/ui/latex_graphics.py` 신설, capability detect (Kitty family + SIXEL allow-list, non-TTY guard, operator override) + `render_latex_image()` 시그너처 pin + opt-in helper. 18 신규 test. Codex MCP 10번째 verify, HIGH 2 fix (WezTerm/Ghostty TERM variant + env var).

## Verification

- [x] PR #1177 CI 7/7 pass
- [ ] release PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code), cross-verified by Codex MCP