### PR TITLE
fix(cli): streaming raw markdown 노출 정리 + final 시 clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,16 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Fixed
 
+- **CLI streaming Markdown cleanup.** Thin CLI raw `stream` output now tracks
+  plain daemon-console spans that look like assistant Markdown and clears that
+  transient region at turn stop, before the final `result.text` payload is
+  rendered through the existing Markdown + LaTeX renderer. ANSI/Rich stream
+  output and structured agentic events continue to render in place.
+- **CLI 스트리밍 Markdown 정리.** thin CLI 가 daemon-console 의 plain
+  `stream` 중 assistant Markdown 으로 보이는 구간을 추적하고, turn 종료 시
+  최종 `result.text` 를 기존 Markdown + LaTeX renderer 로 다시 그리기 전에
+  해당 임시 raw 구간을 지웁니다. ANSI/Rich stream 출력과 structured
+  agentic event 렌더링은 그대로 유지됩니다.
 - **CLI LaTeX 렌더링 — delimiter-less 매크로 누출 heuristic.** PR
   #1165/#1169 의 wiring 이 `\(...\)` / `$...$` / `\[...\]` 같은 명시적
   delimiter 가 있는 경우만 cover 하여 LLM 이 delimiter 없이 prose 안에

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -12,6 +12,7 @@ Pipeline panels render client-side from structured events (no raw stream).
 from __future__ import annotations
 
 import logging
+import re
 import sys
 import threading
 import time
@@ -20,6 +21,11 @@ from typing import Any
 from core.ui.tool_tracker import ToolCallTracker
 
 log = logging.getLogger(__name__)
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_MARKDOWN_TEXT_MARKER = re.compile(
+    r"(\*\*[^*\n][\s\S]*?\*\*|__[^_\n][\s\S]*?__|`[^`\n]+`|^#{1,6}\s|\n#{1,6}\s)"
+)
 
 
 def _fmt_tokens(n: int) -> str:
@@ -81,6 +87,10 @@ class EventRenderer:
         self._turn_in_tokens: int = 0
         self._turn_out_tokens: int = 0
         self._turn_cost: float = 0.0
+        # Raw daemon console output is normally Rich/status UI. If the daemon
+        # accidentally streams plain assistant Markdown, keep enough state to
+        # erase that transient region before final Markdown rendering happens.
+        self._clearable_stream_parts: list[str] = []
 
     # -- Public API -----------------------------------------------------------
 
@@ -117,11 +127,16 @@ class EventRenderer:
 
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
+            self._reset_clearable_stream_region()
             handler(event)
 
     def on_stream(self, data: str) -> None:
         """Handle raw console stream (Rich panels, pipeline output)."""
         self._suppress_all_spinners()
+        if self._is_clearable_plain_stream(data):
+            self._clearable_stream_parts.append(data)
+        else:
+            self._reset_clearable_stream_region()
         self._out.write(data)
         self._out.flush()
 
@@ -137,6 +152,7 @@ class EventRenderer:
             self._activity_thread = None
         # Clear any leftover spinner line
         self._out.write("\r\033[2K")
+        self._clear_markdown_stream_region()
         self._out.flush()
         # Render accumulated turn status (Claude Code style)
         self._render_turn_status()
@@ -788,3 +804,27 @@ class EventRenderer:
         if self._activity and not self._activity_suppressed:
             self._out.write("\r\033[2K")
             self._out.flush()
+
+    @staticmethod
+    def _is_clearable_plain_stream(data: str) -> bool:
+        """Return True for plain text stream chunks that can be safely erased."""
+        if not data:
+            return False
+        if _ANSI_ESCAPE.search(data):
+            return False
+        return not any(ch in data for ch in "\b\f\v")
+
+    def _reset_clearable_stream_region(self) -> None:
+        self._clearable_stream_parts.clear()
+
+    def _clear_markdown_stream_region(self) -> None:
+        text = "".join(self._clearable_stream_parts)
+        self._reset_clearable_stream_region()
+        if not text or not _MARKDOWN_TEXT_MARKER.search(text):
+            return
+
+        visual_lines = len(text.splitlines()) or 1
+        self._out.write("\r\033[2K")
+        moves = visual_lines if text.endswith("\n") else max(visual_lines - 1, 0)
+        for _ in range(moves):
+            self._out.write("\033[1A\033[2K")

--- a/tests/test_event_schema_v2.py
+++ b/tests/test_event_schema_v2.py
@@ -418,6 +418,34 @@ class TestEventRendererV2:
         assert renderer._tool_tracker._line_count == 0
         assert "Berserk" in renderer._out.getvalue()
 
+    def test_stop_clears_raw_markdown_stream_region(self, renderer) -> None:
+        """Plain markdown streamed raw is transient; final result renders it."""
+        renderer.on_stream("Intro\n**bold** answer\n")
+
+        renderer.stop()
+        out = renderer._out.getvalue()
+        assert "**bold** answer" in out  # was visible progressively
+        assert "\033[1A\033[2K" in out  # then erased before final Markdown render
+
+    def test_stop_preserves_non_markdown_plain_stream(self, renderer) -> None:
+        """Plain non-markdown console output should remain visible after stop()."""
+        renderer.on_stream("  Available IPs\n  - Berserk\n")
+
+        renderer.stop()
+        out = renderer._out.getvalue()
+        assert "Berserk" in out
+        assert "\033[1A\033[2K" not in out
+
+    def test_event_resets_clearable_stream_region(self, renderer) -> None:
+        """Do not erase earlier raw text once a structured event has followed it."""
+        renderer.on_stream("**bold** answer\n")
+        renderer.on_event({"type": "round_start", "round": 1})
+
+        renderer.stop()
+        out = renderer._out.getvalue()
+        assert "**bold** answer" in out
+        assert "\033[1A\033[2K" not in out
+
 
 class TestIPCClientEventWhitelist:
     """All 28 event types are in IPCClient's event whitelist."""

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.95.0"
+version = "0.95.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `EventRenderer.on_stream` 의 plain text chunk buffer 누적 + `stop()` 시 markdown marker 발견 시 ANSI clear → final `result.text` 가 기존 `_render_text_with_latex` (Markdown + LaTeX) 로 한 번 더 그려짐
- ANSI/Rich stream (Rich panel, tool 헤더) + structured agentic event (`on_event`) 는 untouched
- Codex MCP cross-LLM verify 통과

## Why
사용자 보고 (2026-05-16): CLI 응답 화면에서 raw `**bold**` 마크다운 마커가 그대로 노출. Daemon 측 `_StreamingWriter` (`core/server/ipc_server/poller.py:63`) 가 thread-local Rich console 의 모든 `console.print(...)` 를 raw `stream` IPC payload 로 송신, thin client 가 그것을 그대로 stdout 에 흘리던 구조 (`core/ui/event_renderer.py:122`) 가 원인. 동일 텍스트가 final `result.text` 경로에서 Markdown 으로 한 번 더 렌더되어 결과적으로 raw + rendered 중복.

## Changes
| File | Change |
|------|--------|
| `core/ui/event_renderer.py` | `_clearable_stream_parts` buffer 추가; `on_stream` 에서 plain (non-ANSI) chunk 만 누적; `on_event` 도착 시 buffer reset; `stop()` 에서 markdown marker 검사 후 cursor up + erase |
| `tests/test_event_schema_v2.py` | regression 테스트 (raw `**bold**` clear + non-Markdown 보존) |
| `CHANGELOG.md` | `[Unreleased]` Fixed (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 사용자 선택 Option A (streaming 누적 + final clear + Markdown 재출력) | Implemented | Codex MCP 가 (b) thin-side buffer 로 표기 — 본질적으로 동일 |
| ANSI/Rich panel 보존 | Implemented | `_ANSI_ESCAPE` 검사로 ANSI chunk 는 buffer 안 함 |
| structured event 흐름 보존 | Implemented | `on_event` 에서 buffer reset, 동작 unchanged |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean (628 files)
- [x] `uv run mypy core/ plugins/` clean (364 files)
- [x] `uv run pytest tests/test_event_schema_v2.py` 41 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)

## Reference
- 사용자 보고 + 분석 — `/Users/mango/.claude/projects/-Users-mango-workspace-geode/53df0b8a-dbc1-4b05-85db-056897b9595c.jsonl`
- root-cause walk: Codex MCP report (HIGH = `_StreamingWriter` raw stream → `on_stream` 직출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)