### PR TITLE
fix(cli): prompt_toolkit `<any>` 바인딩으로 CJK insert redraw 동기화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,23 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Fixed
 
+- **CLI prompt CJK 입력 redraw lag.** prompt_toolkit thin-CLI 입력에서
+  한글 같은 wide character 를 타이핑할 때 직전 글자가 다음 keystroke 전까지
+  화면에 나타나지 않는 ghost 현상을 수정했습니다. `<any>` printable
+  input binding 이 `event.data` 를 정상 `insert_text()` 경로로 넣은 뒤
+  `event.app.invalidate()` 를 호출해 삽입 직후 renderer repaint 를
+  예약합니다. Enter / Escape+Enter / Backspace / Delete 같은 기존
+  binding 은 유지되며, wildcard handler 는 비어 있거나 non-printable 인
+  key data 를 삽입하지 않습니다.
+- **CLI prompt CJK insertion redraw lag.** Fixes the thin-CLI
+  prompt_toolkit prompt where newly typed wide characters such as Korean
+  Hangul could stay visually hidden until the next keystroke. A printable
+  `<any>` input binding now forwards `event.data` through the normal
+  `insert_text()` path, then calls `event.app.invalidate()` so the renderer
+  repaints immediately after insertion. Existing Enter, Escape+Enter,
+  Backspace, and Delete bindings are preserved, and the wildcard handler
+  ignores empty or non-printable key data.
+
 - **CLI LaTeX 렌더링 — delimiter-less 매크로 누출 heuristic.** PR
   #1165/#1169 의 wiring 이 `\(...\)` / `$...$` / `\[...\]` 같은 명시적
   delimiter 가 있는 경우만 cover 하여 LLM 이 delimiter 없이 prose 안에

--- a/core/cli/prompt_session.py
+++ b/core/cli/prompt_session.py
@@ -39,6 +39,19 @@ def _sigint_handler(signum: int, frame: Any) -> None:
 # ---------------------------------------------------------------------------
 # prompt_toolkit REPL input (arrow keys, history)
 # ---------------------------------------------------------------------------
+def _event_data_is_printable_character(event: Any, data: str | None) -> bool:
+    """Return True only for printable character key events."""
+    if not data or not data.isprintable():
+        return False
+
+    key_sequence = getattr(event, "key_sequence", ())
+    if not key_sequence:
+        return True
+
+    key = getattr(key_sequence[-1], "key", None)
+    return key == data
+
+
 def _build_prompt_session() -> Any:
     """Create a prompt_toolkit PromptSession with history + GEODE styling.
 
@@ -46,10 +59,10 @@ def _build_prompt_session() -> Any:
     instead of each newline triggering a separate submit. Enter submits,
     Escape+Enter inserts a real newline.
 
-    Includes a custom Backspace/Delete key binding that forces a full
-    renderer redraw after deletion — fixes wide-char (Korean jamo) ghost
-    artifacts where the display doesn't update even though the buffer is
-    correctly modified.
+    Includes custom printable-insert plus Backspace/Delete key bindings
+    that force a full renderer redraw after the buffer changes — fixes
+    wide-char (Korean jamo) ghost artifacts where the display doesn't
+    update even though the buffer is correctly modified.
     """
     from prompt_toolkit import PromptSession
     from prompt_toolkit.filters import is_done
@@ -68,6 +81,15 @@ def _build_prompt_session() -> Any:
     def _newline(event: Any) -> None:
         """Escape+Enter inserts a real newline for intentional multi-line."""
         event.current_buffer.insert_text("\n")
+
+    @kb.add("<any>")
+    def _insert_printable(event: Any) -> None:
+        data = event.data
+        if not _event_data_is_printable_character(event, data):
+            return
+
+        event.current_buffer.insert_text(data)
+        event.app.invalidate()
 
     @kb.add("backspace")
     def _backspace(event: Any) -> None:

--- a/tests/test_prompt_session.py
+++ b/tests/test_prompt_session.py
@@ -1,0 +1,123 @@
+"""Regression tests for prompt_toolkit prompt session key bindings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from core.cli.prompt_session import _build_prompt_session
+
+
+def _binding_keys(binding: Any) -> tuple[str, ...]:
+    return tuple(str(getattr(key, "value", key)) for key in binding.keys)
+
+
+def _handler_names(key_bindings: Any) -> set[str]:
+    return {binding.handler.__name__ for binding in key_bindings.bindings}
+
+
+def _find_binding(key_bindings: Any, *keys: str) -> Any:
+    expected = tuple(keys)
+    for binding in key_bindings.bindings:
+        binding_keys = _binding_keys(binding)
+        if binding_keys == expected or (expected == ("<any>",) and binding_keys == ("Keys.Any",)):
+            return binding
+    raise AssertionError(f"missing key binding: {expected}")
+
+
+def test_prompt_session_any_binding_inserts_cjk_and_invalidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePromptSession:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", FakePromptSession)
+    monkeypatch.setattr("prompt_toolkit.history.FileHistory", lambda path: path)
+
+    _build_prompt_session()
+
+    key_bindings = captured["key_bindings"]
+    any_binding = _find_binding(key_bindings, "<any>")
+
+    current_buffer = MagicMock()
+    app = MagicMock()
+    event = SimpleNamespace(
+        data="가",
+        key_sequence=[SimpleNamespace(key="가")],
+        current_buffer=current_buffer,
+        app=app,
+    )
+
+    any_binding.handler(event)
+
+    current_buffer.insert_text.assert_called_once_with("가")
+    app.invalidate.assert_called_once_with()
+
+
+def test_prompt_session_preserves_specific_edit_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePromptSession:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", FakePromptSession)
+    monkeypatch.setattr("prompt_toolkit.history.FileHistory", lambda path: path)
+
+    _build_prompt_session()
+
+    key_bindings = captured["key_bindings"]
+    assert {
+        "_enter",
+        "_newline",
+        "_backspace",
+        "_delete",
+        "_insert_printable",
+    } <= _handler_names(key_bindings)
+
+
+@pytest.mark.parametrize(
+    ("data", "key"),
+    [
+        ("", ""),
+        ("\x1b", "escape"),
+        ("\x1b[D", "left"),
+    ],
+)
+def test_prompt_session_any_binding_ignores_non_printable_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    data: str,
+    key: str,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePromptSession:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", FakePromptSession)
+    monkeypatch.setattr("prompt_toolkit.history.FileHistory", lambda path: path)
+
+    _build_prompt_session()
+
+    any_binding = _find_binding(captured["key_bindings"], "<any>")
+    current_buffer = MagicMock()
+    app = MagicMock()
+    event = SimpleNamespace(
+        data=data,
+        key_sequence=[SimpleNamespace(key=key)],
+        current_buffer=current_buffer,
+        app=app,
+    )
+
+    any_binding.handler(event)
+
+    current_buffer.insert_text.assert_not_called()
+    app.invalidate.assert_not_called()


### PR DESCRIPTION
## Summary
- `_event_data_is_printable_character` helper + `<any>` wildcard binding 추가 → printable character 입력 시 `insert_text` 후 `event.app.invalidate()` 호출
- 기존 enter / esc-enter / backspace / delete 바인딩은 그대로 보존
- Codex MCP cross-LLM verify 통과 (sandbox=workspace-write)

## Why
사용자 보고 (2026-05-16): GEODE thin CLI 입력창에서 한글 같은 wide character 를 타이핑할 때 직전 글자가 다음 keystroke 가 들어와야 화면에 반영. buffer 자체는 정상이지만 prompt_toolkit renderer 가 wide-char insert 직후 invalidate 되지 않아 repaint 가 한 박자 지연되는 ghost 현상. 기존 backspace/delete 는 이미 explicit invalidate workaround 가 있었으나 character insertion 경로에는 누락 (`core/cli/prompt_session.py:42-93`).

## Changes
| File | Change |
|------|--------|
| `core/cli/prompt_session.py` | `_event_data_is_printable_character` helper + `<any>` printable insert binding 추가 (`insert_text(data)` → `event.app.invalidate()`). docstring 갱신 |
| `tests/test_prompt_session.py` | regression suite 신규 — CJK insert / 5 binding 등록 / non-printable 무시 |
| `CHANGELOG.md` | `[Unreleased]` Fixed (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 사용자 선택 — `<any>` wildcard binding + invalidate | Implemented | `_event_data_is_printable_character` 가 escape sequence / function key / 빈 입력을 차단하여 wildcard 안전성 확보 |
| 기존 enter/esc-enter/backspace/delete 보존 | Verified | `_handler_names` 테스트가 5 binding 모두 등록 확인 |
| non-printable key 무시 | Verified | parametrized 테스트 (빈 문자열, 0x1B escape, arrow `\x1b[D`) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean
- [x] `uv run mypy core/ plugins/` clean
- [x] `uv run pytest tests/test_prompt_session.py -q` 5 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)

## Reference
- 사용자 보고 + 분석 — `/Users/mango/.claude/projects/-Users-mango-workspace-geode/53df0b8a-dbc1-4b05-85db-056897b9595c.jsonl`
- 기존 backspace/delete fix pattern — `core/cli/prompt_session.py:72-84`
- 관련 PR — #1179 (CLI streaming raw markdown clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)