### PR TITLE
feat(cli): LaTeX detector 보강 + LLM 출력 math delimiter 지시

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **CLI system prompt math-formatting instruction.** GEODE 의 기본 LLM
+  prompt 가 수식 출력 규칙을 명시합니다: inline 수식은 `$...$`, display
+  수식은 독립 줄의 `$$...$$` 로 감싸도록 짧은 예시를 포함했습니다. 이
+  지시는 `PromptAssembler` 경로와 interactive CLI 의 `AgenticLoop`
+  system prompt 경로에 모두 적용됩니다.
+- **CLI system prompt math-formatting instruction.** The default LLM prompt
+  now tells the model to wrap inline math in `$...$` and display math in
+  standalone `$$...$$` blocks, with compact examples. The rule is wired into
+  both `PromptAssembler` and the interactive CLI `AgenticLoop` system prompt.
+
 - **CLI LaTeX Tier 3 (graphics inline) — capability detection scaffold.**
   CLI LaTeX 의 frontier 5-tier 조사 결과 LLM CLI 6 도구 (Claude Code /
   Codex CLI / Aider / glow / mdcat / bat) 모두 Tier 0 (raw), GEODE 만
@@ -146,6 +156,20 @@ renders as a single column with a `KR`-only or `EN`-only chip.
   supporting the auditor role.
 
 ### Fixed
+
+- **CLI LaTeX 렌더링 — bare subscript/superscript + Unicode math 누출.**
+  delimiter 없는 fallback 이 기존에는 `P_{t-1}` 같은 braced script 와
+  allow-list macro 만 잡아 `y^ΔT_t,n`, `S^(i)_t,n`, `X_t-9:t,n,:`,
+  `√x` 같은 LLM 출력이 raw 로 남았습니다. `_DELIMITERLESS_MATH` 를
+  math-shaped line context + index-like bare script 로 확장하고, `√` /
+  Greek / comparison / arrow 등 Unicode math glyph token 을 inline math
+  segment 로 승격합니다. Markdown inline/fenced code, `snake_case`,
+  slash paths, `**bold**`, `*x*` 는 계속 text 로 유지됩니다.
+- **CLI LaTeX rendering — bare subscript/superscript + Unicode math leaks.**
+  The delimiter-less fallback now catches math-shaped bare scripts and
+  Unicode math glyph tokens such as `y^ΔT_t,n`, `S^(i)_t,n`, `X_t-9:t,n,:`,
+  and `√x`. The wider detector is guarded by code-span/path/snake-case/
+  Markdown-emphasis skips so ordinary prose and code remain untouched.
 
 - **CLI streaming Markdown cleanup.** Thin CLI raw `stream` output now tracks
   plain daemon-console spans that look like assistant Markdown and clears that

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -21,6 +21,7 @@ import re
 from datetime import datetime
 from functools import lru_cache
 
+from core.llm.prompt_assembler import with_math_output_formatting
 from core.llm.prompts import ROUTER_SYSTEM
 from core.paths import get_project_root
 
@@ -132,7 +133,7 @@ def build_system_prompt(model: str = "") -> str:
     if not baseline:
         baseline = _generic_static_prefix()
 
-    static = baseline
+    static = with_math_output_formatting(baseline)
 
     # G10: Agent identity (opt-in via GEODE_PERSONA=on; default OFF so
     # GEODE behaves as a thin wrapper around the base model).

--- a/core/llm/prompt_assembler.py
+++ b/core/llm/prompt_assembler.py
@@ -15,7 +15,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from core.hooks import HookEvent, HookSystem
 from core.llm.prompts import _hash_prompt
@@ -40,6 +40,21 @@ log = logging.getLogger(__name__)
 # cannot spend quota on an accidentally ignored mutation.
 
 _WRAPPER_OVERRIDE_ENV = "GEODE_WRAPPER_OVERRIDE"
+MATH_OUTPUT_FORMATTING_INSTRUCTION: Final[str] = """<math_formatting>
+When writing formulas, do not emit raw LaTeX-like text.
+- Inline math: wrap with `$...$` (예: 수익률은 $r_t = (P_t - P_{t-1}) / P_{t-1}$ 입니다).
+- Display math: put `$$...$$` on its own lines.
+$$
+IC_t = \\frac{\\sum_i S_i y_i}{\\sqrt{\\sum_i S_i^2}\\sqrt{\\sum_i y_i^2}}
+$$
+</math_formatting>"""
+
+
+def with_math_output_formatting(system: str) -> str:
+    """Append GEODE's math-output contract once."""
+    if "<math_formatting>" in system:
+        return system
+    return system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
 
 
 def _load_wrapper_override() -> dict[str, str] | None:
@@ -167,6 +182,7 @@ class PromptAssembler:
             base_system = "\n\n".join(wrapper_override.values())
             fragments_used.append(f"wrapper-override:{len(wrapper_override)}sections")
 
+        base_system = with_math_output_formatting(base_system)
         base_hash = _hash_prompt(base_system + base_user)
 
         # --- Phase 1: Prompt Override ---
@@ -174,7 +190,7 @@ class PromptAssembler:
         system_key = f"{node}_system"
         if system_key in overrides:
             if self._allow_full_override:
-                system = overrides[system_key]
+                system = with_math_output_formatting(overrides[system_key])
                 fragments_used.append(f"override:{system_key}")
             else:
                 system = base_system + "\n\n" + overrides[system_key]

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -173,8 +173,8 @@ _INLINE_PAREN = re.compile(r"(?<!\\)\\\(([\s\S]+?)(?<!\\)\\\)")
 # The default delimiter scanners cannot see those tokens and the bare macros
 # leak into the Markdown render. We conservatively catch two narrow forms,
 # each requiring explicit LaTeX syntax (braces or a known macro name) so
-# ordinary ``snake_case`` identifiers, file paths, and Markdown emphasis
-# remain untouched:
+# ordinary ``snake_case`` identifiers, file paths, Markdown code, and
+# Markdown emphasis remain untouched:
 #
 #   * **Braced subscript/superscript token** — ``r_{t-1}``, ``P_{t+5}``,
 #     ``x^{2}``, ``W_{i,j}^{T}``. Requires `{…}` directly after `_` or `^`.
@@ -183,10 +183,10 @@ _INLINE_PAREN = re.compile(r"(?<!\\)\\\(([\s\S]+?)(?<!\\)\\\)")
 #     allow-list of macro names keeps the pattern from over-firing on
 #     prose like ``\n`` escape sequences.
 #
-# Bare-underscore prose (``snake_case``, ``my_var``, ``some_word_here``)
-# never matches because there is no following ``{``. Bare letters with
-# subscripts in prose (``r_t``) are also skipped — the heuristic only
-# activates when the LaTeX intent is unambiguous.
+# Bare script forms (``r_t``, ``x^2``) are accepted only when the candidate
+# sits in a math-shaped line context and the script payload looks index-like
+# (``t``, ``i,j``, ``t-9:t``), not word-like (``case``, ``name``). This
+# catches LLM formula leaks while continuing to skip ordinary identifiers.
 
 _MACRO_NAMES = (
     "Alpha",
@@ -277,6 +277,16 @@ _MACRO_NAMES = (
     "xi",
     "zeta",
 )
+_UNICODE_MATH_GLYPHS: Final = (
+    "√∑∫∏≤≥→←⇒⇐↔∞≈≠±×÷∈∉⊂⊆∂∇ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω"
+)
+_SCRIPT_CHARS = "A-Za-z0-9" + re.escape(_UNICODE_MATH_GLYPHS + ",:-")
+_SCRIPT_BODY = rf"(?:\([^()`\n]+\)|[{_SCRIPT_CHARS}]+)"
+_UNICODE_TOKEN_HEAD = (
+    rf"(?:[A-Za-z0-9]*[{re.escape(_UNICODE_MATH_GLYPHS)}][A-Za-z0-9]+"
+    rf"|[A-Za-z0-9]+[{re.escape(_UNICODE_MATH_GLYPHS)}][A-Za-z0-9]*"
+    rf"|[{re.escape(_UNICODE_MATH_GLYPHS)}](?:[_^]{_SCRIPT_BODY}))"
+)
 _DELIMITERLESS_MATH = re.compile(
     r"(?:"
     # Braced subscript/superscript token (chained): r_{t-1}, P_{t+5}^{2}, ...
@@ -290,8 +300,21 @@ _DELIMITERLESS_MATH = re.compile(
     # three so the pattern stays bounded.
     r"\\(?:" + "|".join(_MACRO_NAMES) + r")(?![A-Za-z])"
     r"(?:\{[^{}]*\}){0,3}"
+    r"|"
+    # Bare script token in math-shaped context: y^ΔT_t,n, S^(i)_t,n,
+    # close_t,n, X_t-9:t,n,:. Filtered by _delimiterless_candidate_allowed.
+    r"[A-Za-z][A-Za-z0-9]*"
+    rf"(?:[_^]{_SCRIPT_BODY})+"
+    r"|"
+    # Unicode math glyph adjacent to letters/digits/scripts: √x, α_i, ΔT,n.
+    rf"{_UNICODE_TOKEN_HEAD}"
+    rf"(?:[_^]{_SCRIPT_BODY})?"
+    r"(?:,[A-Za-z0-9]+)*"
     r")"
 )
+_SCRIPT_PART = re.compile(rf"[_^]({_SCRIPT_BODY})")
+_FENCED_CODE_BLOCK = re.compile(r"(?m)^(```|~~~)[^\n]*\n[\s\S]*?^\1\s*$")
+_INLINE_CODE_SPAN = re.compile(r"`[^`\n]*`")
 
 
 def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
@@ -332,10 +355,15 @@ def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
         if _overlaps(m.start(), m.end(), matches):
             continue
         matches.append((m.start(), m.end(), "inline_math", m.group(1)))
-    # Last-resort heuristic: catch bare LaTeX tokens (braced sub/sup or
-    # allow-listed macro) that arrived without surrounding delimiters.
+    code_spans = _markdown_code_spans(text)
+    # Last-resort heuristic: catch bare LaTeX tokens that arrived without
+    # surrounding delimiters.
     for m in _DELIMITERLESS_MATH.finditer(text):
         if _overlaps(m.start(), m.end(), matches):
+            continue
+        if _span_overlaps(m.start(), m.end(), code_spans):
+            continue
+        if not _delimiterless_candidate_allowed(text, m.start(), m.end(), m.group(0)):
             continue
         matches.append((m.start(), m.end(), "inline_math", m.group(0)))
     matches.sort(key=lambda t: t[0])
@@ -354,3 +382,89 @@ def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
 def _overlaps(start: int, end: int, matches: list[tuple[int, int, str, str]]) -> bool:
     """True when ``start``/``end`` intersects any accepted match span."""
     return any(start < e and s < end for s, e, _, _ in matches)
+
+
+def _span_overlaps(start: int, end: int, spans: list[tuple[int, int]]) -> bool:
+    """True when ``start``/``end`` intersects any protected span."""
+    return any(start < span_end and span_start < end for span_start, span_end in spans)
+
+
+def _markdown_code_spans(text: str) -> list[tuple[int, int]]:
+    """Return fenced-code and inline-code spans protected from fallback math."""
+    spans: list[tuple[int, int]] = [(m.start(), m.end()) for m in _FENCED_CODE_BLOCK.finditer(text)]
+    for m in _INLINE_CODE_SPAN.finditer(text):
+        if not _span_overlaps(m.start(), m.end(), spans):
+            spans.append((m.start(), m.end()))
+    return spans
+
+
+def _delimiterless_candidate_allowed(text: str, start: int, end: int, token: str) -> bool:
+    """Filter broad fallback matches down to math-shaped delimiterless tokens."""
+    if _looks_like_path_context(text, start, end):
+        return False
+    if token.startswith("\\") or "{" in token:
+        return True
+    if any(ch in _UNICODE_MATH_GLYPHS for ch in token):
+        return True
+    if "_" in token or "^" in token:
+        return _script_parts_look_index_like(token) and _has_math_context(text, start, end, token)
+    return False
+
+
+def _looks_like_path_context(text: str, start: int, end: int) -> bool:
+    """Reject tokens embedded in slash paths or filename extensions."""
+    left = start
+    while left > 0 and not text[left - 1].isspace():
+        left -= 1
+    right = end
+    while right < len(text) and not text[right].isspace():
+        right += 1
+    surrounding = text[left:right]
+    if "/" in surrounding:
+        return True
+    return bool(re.search(r"\.[A-Za-z0-9]{1,8}\b", surrounding))
+
+
+def _script_parts_look_index_like(token: str) -> bool:
+    """Reject word-like bare subscripts such as ``snake_case`` and ``file_name``."""
+    for match in _SCRIPT_PART.finditer(token):
+        raw = match.group(1).strip("()")
+        for part in re.split(r"[,:-]+", raw):
+            if not part:
+                continue
+            if part.isascii() and part.isalpha() and part.islower() and len(part) > 1:
+                return False
+    return True
+
+
+def _has_math_context(text: str, start: int, end: int, token: str) -> bool:
+    """True when a bare script token is adjacent to formula punctuation."""
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    if line_end == -1:
+        line_end = len(text)
+    line = text[line_start:line_end]
+
+    prev_char = _previous_nonspace(text, line_start, start)
+    next_char = _next_nonspace(text, end, line_end)
+    if prev_char in "=+-*/(,":
+        return True
+    if next_char in "=+-*/),":
+        return True
+    if any(op in token for op in ("-", ":", ",")) and any(op in line for op in "=+-*/"):
+        return True
+    return "^" in token and "=" in line
+
+
+def _previous_nonspace(text: str, lower: int, start: int) -> str:
+    pos = start - 1
+    while pos >= lower and text[pos].isspace():
+        pos -= 1
+    return text[pos] if pos >= lower else ""
+
+
+def _next_nonspace(text: str, start: int, upper: int) -> str:
+    pos = start
+    while pos < upper and text[pos].isspace():
+        pos += 1
+    return text[pos] if pos < upper else ""

--- a/tests/test_bootstrap_wire.py
+++ b/tests/test_bootstrap_wire.py
@@ -197,7 +197,8 @@ class TestPromptOverridesWire:
             node="analyst",
             role_type="game_mechanics",
         )
-        assert result.system == "You are an analyst."
+        assert result.system.startswith("You are an analyst.")
+        assert "<math_formatting>" in result.system
         assert result.fragment_count == 0
 
 

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from core.llm.prompt_assembler import AssembledPrompt, PromptAssembler
+from core.llm.prompt_assembler import (
+    MATH_OUTPUT_FORMATTING_INSTRUCTION,
+    AssembledPrompt,
+    PromptAssembler,
+)
 from core.llm.prompts import _hash_prompt
 from core.llm.skill_registry import SkillDefinition, SkillRegistry
 
@@ -98,12 +102,30 @@ class TestBasicAssembly:
             role_type="game_mechanics",
         )
 
+        expected_system = base_system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
         assert isinstance(result, AssembledPrompt)
-        assert result.system == base_system
+        assert result.system == expected_system
         assert result.user == base_user
         assert result.fragment_count == 0
         assert result.fragments_used == []
-        assert result.total_chars == len(base_system) + len(base_user)
+        assert result.total_chars == len(expected_system) + len(base_user)
+
+    def test_math_formatting_instruction_included_by_default(
+        self, base_system: str, base_user: str, empty_state: dict[str, Any]
+    ) -> None:
+        assembler = PromptAssembler()
+        result = assembler.assemble(
+            base_system=base_system,
+            base_user=base_user,
+            state=empty_state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+
+        assert "<math_formatting>" in result.system
+        assert "Inline math: wrap with `$...$`" in result.system
+        assert "Display math: put `$$...$$` on its own lines" in result.system
+        assert "$r_t = (P_t - P_{t-1}) / P_{t-1}$" in result.system
 
     def test_no_assembler_fallback(self, empty_state: dict[str, Any]) -> None:
         """Verify state.get('_prompt_assembler') is None returns None (node-level fallback)."""
@@ -337,7 +359,8 @@ class TestHashing:
             role_type="game_mechanics",
         )
 
-        expected_base_hash = _hash_prompt(base_system + base_user)
+        expected_system = base_system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
+        expected_base_hash = _hash_prompt(expected_system + base_user)
         expected_assembled_hash = _hash_prompt(result.system + result.user)
 
         assert result.base_template_hash == expected_base_hash
@@ -606,8 +629,12 @@ class TestWrapperOverrideHook:
             role_type="game_mechanics",
         )
 
-        assert first_result.base_template_hash == _hash_prompt("first mutation" + base_user)
-        assert second_result.base_template_hash == _hash_prompt("second mutation" + base_user)
+        assert first_result.base_template_hash == _hash_prompt(
+            "first mutation\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION + base_user
+        )
+        assert second_result.base_template_hash == _hash_prompt(
+            "second mutation\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION + base_user
+        )
         assert first_result.base_template_hash != second_result.base_template_hash
         assert first_result.assembled_hash != second_result.assembled_hash
 

--- a/tests/test_prompt_audit_2026_05_12.py
+++ b/tests/test_prompt_audit_2026_05_12.py
@@ -110,6 +110,20 @@ def test_g10_router_md_no_geode_name_in_baseline() -> None:
     assert "autonomous execution agent" in ROUTER_SYSTEM
 
 
+def test_math_formatting_instruction_reaches_agentic_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interactive CLI prompt path tells the model to delimit math."""
+    monkeypatch.delenv("GEODE_AUDIT_UNRESTRICTED", raising=False)
+    monkeypatch.delenv("GEODE_PERSONA", raising=False)
+
+    out = build_system_prompt(model="")
+
+    assert "<math_formatting>" in out
+    assert "Inline math: wrap with `$...$`" in out
+    assert "Display math: put `$$...$$` on its own lines" in out
+
+
 # ---------------------------------------------------------------------------
 # G1 — XML section parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -129,6 +129,40 @@ class TestMixedContent:
         assert [k for k, _ in chunks] == expected_kinds
 
 
+class TestDelimiterlessMathWidening:
+    """Bare-script and Unicode-math fallback for LLM output that forgot delimiters."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "y^ΔT_t,n = close_t+ΔT,n - close_t,n / close_t,n",
+            "S^(i)_t,n = α_i ( X_t-L^(i)+1:t,n,: )",
+            "X_t-9:t,n,:",
+            "√x + 1",
+        ],
+    )
+    def test_user_reported_bare_script_and_unicode_math_segments(self, source: str) -> None:
+        chunks = list(extract_and_render_inline(source))
+        assert any(kind == "inline_math" for kind, _ in chunks), chunks
+        assert chunks != [("text", source)]
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "snake_case_var",
+            "foo/bar/baz.py",
+            "**bold**",
+            "*x*",
+        ],
+    )
+    def test_false_positive_guards_stay_text(self, source: str) -> None:
+        assert list(extract_and_render_inline(source)) == [("text", source)]
+
+    def test_inline_code_protects_math_shaped_text(self) -> None:
+        source = "`y^ΔT_t,n = close_t+ΔT,n`"
+        assert list(extract_and_render_inline(source)) == [("text", source)]
+
+
 class TestDelimiterExpansion:
     """PR #1165 — `\\[...\\]`, `\\(...\\)`, and `\\begin{equation}...\\end{equation}`
     are recognised in addition to the original `$`-based forms."""


### PR DESCRIPTION
## Summary
- Producer (1차 방어): system prompt 에 `<math_formatting>` 지시 추가 — inline `$..$`, display `$$..$$`, 한국어 친화 prose + 예시 2개. `core/llm/prompt_assembler.py` + `core/agent/system_prompt.py` 둘 다 wire
- Detector (2차 방어, `core/ui/latex.py`): `_DELIMITERLESS_MATH` 확장 — bare subscript/superscript (`r_t`, `X_t-9`, `S^(i)_t,n`) + Unicode math glyph (`√`, `α`, `β`, `≤`, `→`, `Δ`) catch. Markdown code span / path literal / snake_case / emphasis 는 skip
- Codex MCP cross-LLM verify 통과 (sandbox=workspace-write)

## Why
사용자 보고 (2026-05-16): LLM 응답에서 `√` (sqrt), `_` subscript, `^` superscript 등 bare LaTeX 마커가 raw 노출. 사용자 제시 예시:
- `y^ΔT_t,n = close_t+ΔT,n - close_t,n / close_t,n`
- `S^(i)_t,n = α_i ( X_t-L^(i)+1:t,n,: )`
- `X_t-9:t,n,:`

기존 `_DELIMITERLESS_MATH` 는 **braced** subscript 만 (`r_{t-1}`) catch, bare 는 snake_case false-positive 우려로 skip. 사용자 제안 — explicit delimiter (XML/달러) 부여하도록 LLM 측 prompt 보강 + 누락 catch 위해 detector heuristic 확장.

## Changes
| File | Change |
|------|--------|
| `core/llm/prompt_assembler.py` | `<math_formatting>` 지시 (`$..$`/`$$..$$` + 한국어 prose + 예시) 추가 |
| `core/agent/system_prompt.py` | AgenticLoop 측 동일 지시 wire (LLM CLI path 일관) |
| `core/ui/latex.py` | `_DELIMITERLESS_MATH` 확장 — bare subscript/superscript + Unicode math glyph catch; code span / path / snake_case / emphasis skip layer 추가 |
| `tests/test_ui_latex.py` | 사용자 3 예시 + `√x + 1` regression + false-positive negative test |
| `tests/test_prompt_assembler.py` | `<math_formatting>` instruction assembled prompt 포함 검증 |
| `tests/test_prompt_audit_2026_05_12.py`, `tests/test_bootstrap_wire.py` | 신규 instruction 반영 업데이트 |
| `CHANGELOG.md` | `[Unreleased]` Added/Fixed (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Producer-side `<math_formatting>` 지시 | Implemented | 2 path (PromptAssembler + AgenticLoop) 동시 wire — 1차 방어선 |
| Detector-side bare subscript catch | Implemented | `r_t`, `X_t-9`, `S^(i)_t,n` 정상 매칭 |
| Detector-side Unicode glyph catch | Implemented | `√`, `α`, `Δ` 등 math context 내 catch |
| False-positive 차단 (snake_case, path, code span, emphasis) | Implemented + tested | 4 negative case 모두 plain text 유지 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean (628 files)
- [x] `uv run mypy core/ plugins/` clean (364 files)
- [x] `uv run pytest tests/test_ui_latex.py tests/test_prompt_assembler.py tests/test_prompt_audit_2026_05_12.py tests/test_bootstrap_wire.py` 100 passed
- [x] regression: `uv run pytest tests/test_cli_latex_uiux.py tests/test_event_schema_v2.py` 71 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)

## Reference
- 사용자 보고 + 이미지 분석 — `/Users/mango/.claude/projects/-Users-mango-workspace-geode/53df0b8a-dbc1-4b05-85db-056897b9595c.jsonl`
- 기존 detector — `core/ui/latex.py:280-294` (`_DELIMITERLESS_MATH`)
- 기존 macro allow-list — `core/ui/latex.py:191-279` (`_MACRO_NAMES`)
- 시리즈 — PR #1179 (streaming Markdown clear), PR #1180 (CJK insert redraw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)