### PR TITLE
release: v0.95.2 — CLI streaming Markdown / CJK redraw / LaTeX coverage 3-PR 묶음

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,16 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Fixed
 
+- **CLI streaming Markdown cleanup.** Thin CLI raw `stream` output now tracks
+  plain daemon-console spans that look like assistant Markdown and clears that
+  transient region at turn stop, before the final `result.text` payload is
+  rendered through the existing Markdown + LaTeX renderer. ANSI/Rich stream
+  output and structured agentic events continue to render in place.
+- **CLI 스트리밍 Markdown 정리.** thin CLI 가 daemon-console 의 plain
+  `stream` 중 assistant Markdown 으로 보이는 구간을 추적하고, turn 종료 시
+  최종 `result.text` 를 기존 Markdown + LaTeX renderer 로 다시 그리기 전에
+  해당 임시 raw 구간을 지웁니다. ANSI/Rich stream 출력과 structured
+  agentic event 렌더링은 그대로 유지됩니다.
 - **CLI LaTeX 렌더링 — delimiter-less 매크로 누출 heuristic.** PR
   #1165/#1169 의 wiring 이 `\(...\)` / `$...$` / `\[...\]` 같은 명시적
   delimiter 가 있는 경우만 cover 하여 LLM 이 delimiter 없이 prose 안에

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **CLI system prompt math-formatting instruction.** GEODE 의 기본 LLM
+  prompt 가 수식 출력 규칙을 명시합니다: inline 수식은 `$...$`, display
+  수식은 독립 줄의 `$$...$$` 로 감싸도록 짧은 예시를 포함했습니다. 이
+  지시는 `PromptAssembler` 경로와 interactive CLI 의 `AgenticLoop`
+  system prompt 경로에 모두 적용됩니다.
+- **CLI system prompt math-formatting instruction.** The default LLM prompt
+  now tells the model to wrap inline math in `$...$` and display math in
+  standalone `$$...$$` blocks, with compact examples. The rule is wired into
+  both `PromptAssembler` and the interactive CLI `AgenticLoop` system prompt.
+
 - **CLI LaTeX Tier 3 (graphics inline) — capability detection scaffold.**
   CLI LaTeX 의 frontier 5-tier 조사 결과 LLM CLI 6 도구 (Claude Code /
   Codex CLI / Aider / glow / mdcat / bat) 모두 Tier 0 (raw), GEODE 만
@@ -147,6 +157,19 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Fixed
 
+- **CLI LaTeX 렌더링 — bare subscript/superscript + Unicode math 누출.**
+  delimiter 없는 fallback 이 기존에는 `P_{t-1}` 같은 braced script 와
+  allow-list macro 만 잡아 `y^ΔT_t,n`, `S^(i)_t,n`, `X_t-9:t,n,:`,
+  `√x` 같은 LLM 출력이 raw 로 남았습니다. `_DELIMITERLESS_MATH` 를
+  math-shaped line context + index-like bare script 로 확장하고, `√` /
+  Greek / comparison / arrow 등 Unicode math glyph token 을 inline math
+  segment 로 승격합니다. Markdown inline/fenced code, `snake_case`,
+  slash paths, `**bold**`, `*x*` 는 계속 text 로 유지됩니다.
+- **CLI LaTeX rendering — bare subscript/superscript + Unicode math leaks.**
+  The delimiter-less fallback now catches math-shaped bare scripts and
+  Unicode math glyph tokens such as `y^ΔT_t,n`, `S^(i)_t,n`, `X_t-9:t,n,:`,
+  and `√x`. The wider detector is guarded by code-span/path/snake-case/
+  Markdown-emphasis skips so ordinary prose and code remain untouched.
 - **CLI prompt CJK 입력 redraw lag.** prompt_toolkit thin-CLI 입력에서
   한글 같은 wide character 를 타이핑할 때 직전 글자가 다음 keystroke 전까지
   화면에 나타나지 않는 ghost 현상을 수정했습니다. `<any>` printable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,22 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Fixed
 
+- **CLI prompt CJK 입력 redraw lag.** prompt_toolkit thin-CLI 입력에서
+  한글 같은 wide character 를 타이핑할 때 직전 글자가 다음 keystroke 전까지
+  화면에 나타나지 않는 ghost 현상을 수정했습니다. `<any>` printable
+  input binding 이 `event.data` 를 정상 `insert_text()` 경로로 넣은 뒤
+  `event.app.invalidate()` 를 호출해 삽입 직후 renderer repaint 를
+  예약합니다. Enter / Escape+Enter / Backspace / Delete 같은 기존
+  binding 은 유지되며, wildcard handler 는 비어 있거나 non-printable 인
+  key data 를 삽입하지 않습니다.
+- **CLI prompt CJK insertion redraw lag.** Fixes the thin-CLI
+  prompt_toolkit prompt where newly typed wide characters such as Korean
+  Hangul could stay visually hidden until the next keystroke. A printable
+  `<any>` input binding now forwards `event.data` through the normal
+  `insert_text()` path, then calls `event.app.invalidate()` so the renderer
+  repaints immediately after insertion. Existing Enter, Escape+Enter,
+  Backspace, and Delete bindings are preserved, and the wildcard handler
+  ignores empty or non-printable key data.
 - **CLI streaming Markdown cleanup.** Thin CLI raw `stream` output now tracks
   plain daemon-console spans that look like assistant Markdown and clears that
   transient region at turn stop, before the final `result.text` payload is

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -21,6 +21,7 @@ import re
 from datetime import datetime
 from functools import lru_cache
 
+from core.llm.prompt_assembler import with_math_output_formatting
 from core.llm.prompts import ROUTER_SYSTEM
 from core.paths import get_project_root
 
@@ -132,7 +133,7 @@ def build_system_prompt(model: str = "") -> str:
     if not baseline:
         baseline = _generic_static_prefix()
 
-    static = baseline
+    static = with_math_output_formatting(baseline)
 
     # G10: Agent identity (opt-in via GEODE_PERSONA=on; default OFF so
     # GEODE behaves as a thin wrapper around the base model).

--- a/core/cli/prompt_session.py
+++ b/core/cli/prompt_session.py
@@ -39,6 +39,19 @@ def _sigint_handler(signum: int, frame: Any) -> None:
 # ---------------------------------------------------------------------------
 # prompt_toolkit REPL input (arrow keys, history)
 # ---------------------------------------------------------------------------
+def _event_data_is_printable_character(event: Any, data: str | None) -> bool:
+    """Return True only for printable character key events."""
+    if not data or not data.isprintable():
+        return False
+
+    key_sequence = getattr(event, "key_sequence", ())
+    if not key_sequence:
+        return True
+
+    key = getattr(key_sequence[-1], "key", None)
+    return key == data
+
+
 def _build_prompt_session() -> Any:
     """Create a prompt_toolkit PromptSession with history + GEODE styling.
 
@@ -46,10 +59,10 @@ def _build_prompt_session() -> Any:
     instead of each newline triggering a separate submit. Enter submits,
     Escape+Enter inserts a real newline.
 
-    Includes a custom Backspace/Delete key binding that forces a full
-    renderer redraw after deletion — fixes wide-char (Korean jamo) ghost
-    artifacts where the display doesn't update even though the buffer is
-    correctly modified.
+    Includes custom printable-insert plus Backspace/Delete key bindings
+    that force a full renderer redraw after the buffer changes — fixes
+    wide-char (Korean jamo) ghost artifacts where the display doesn't
+    update even though the buffer is correctly modified.
     """
     from prompt_toolkit import PromptSession
     from prompt_toolkit.filters import is_done
@@ -68,6 +81,15 @@ def _build_prompt_session() -> Any:
     def _newline(event: Any) -> None:
         """Escape+Enter inserts a real newline for intentional multi-line."""
         event.current_buffer.insert_text("\n")
+
+    @kb.add("<any>")
+    def _insert_printable(event: Any) -> None:
+        data = event.data
+        if not _event_data_is_printable_character(event, data):
+            return
+
+        event.current_buffer.insert_text(data)
+        event.app.invalidate()
 
     @kb.add("backspace")
     def _backspace(event: Any) -> None:

--- a/core/llm/prompt_assembler.py
+++ b/core/llm/prompt_assembler.py
@@ -15,7 +15,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from core.hooks import HookEvent, HookSystem
 from core.llm.prompts import _hash_prompt
@@ -40,6 +40,21 @@ log = logging.getLogger(__name__)
 # cannot spend quota on an accidentally ignored mutation.
 
 _WRAPPER_OVERRIDE_ENV = "GEODE_WRAPPER_OVERRIDE"
+MATH_OUTPUT_FORMATTING_INSTRUCTION: Final[str] = """<math_formatting>
+When writing formulas, do not emit raw LaTeX-like text.
+- Inline math: wrap with `$...$` (예: 수익률은 $r_t = (P_t - P_{t-1}) / P_{t-1}$ 입니다).
+- Display math: put `$$...$$` on its own lines.
+$$
+IC_t = \\frac{\\sum_i S_i y_i}{\\sqrt{\\sum_i S_i^2}\\sqrt{\\sum_i y_i^2}}
+$$
+</math_formatting>"""
+
+
+def with_math_output_formatting(system: str) -> str:
+    """Append GEODE's math-output contract once."""
+    if "<math_formatting>" in system:
+        return system
+    return system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
 
 
 def _load_wrapper_override() -> dict[str, str] | None:
@@ -167,6 +182,7 @@ class PromptAssembler:
             base_system = "\n\n".join(wrapper_override.values())
             fragments_used.append(f"wrapper-override:{len(wrapper_override)}sections")
 
+        base_system = with_math_output_formatting(base_system)
         base_hash = _hash_prompt(base_system + base_user)
 
         # --- Phase 1: Prompt Override ---
@@ -174,7 +190,7 @@ class PromptAssembler:
         system_key = f"{node}_system"
         if system_key in overrides:
             if self._allow_full_override:
-                system = overrides[system_key]
+                system = with_math_output_formatting(overrides[system_key])
                 fragments_used.append(f"override:{system_key}")
             else:
                 system = base_system + "\n\n" + overrides[system_key]

--- a/core/ui/event_renderer.py
+++ b/core/ui/event_renderer.py
@@ -12,6 +12,7 @@ Pipeline panels render client-side from structured events (no raw stream).
 from __future__ import annotations
 
 import logging
+import re
 import sys
 import threading
 import time
@@ -20,6 +21,11 @@ from typing import Any
 from core.ui.tool_tracker import ToolCallTracker
 
 log = logging.getLogger(__name__)
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_MARKDOWN_TEXT_MARKER = re.compile(
+    r"(\*\*[^*\n][\s\S]*?\*\*|__[^_\n][\s\S]*?__|`[^`\n]+`|^#{1,6}\s|\n#{1,6}\s)"
+)
 
 
 def _fmt_tokens(n: int) -> str:
@@ -81,6 +87,10 @@ class EventRenderer:
         self._turn_in_tokens: int = 0
         self._turn_out_tokens: int = 0
         self._turn_cost: float = 0.0
+        # Raw daemon console output is normally Rich/status UI. If the daemon
+        # accidentally streams plain assistant Markdown, keep enough state to
+        # erase that transient region before final Markdown rendering happens.
+        self._clearable_stream_parts: list[str] = []
 
     # -- Public API -----------------------------------------------------------
 
@@ -117,11 +127,16 @@ class EventRenderer:
 
         handler = getattr(self, f"_handle_{etype}", None)
         if handler:
+            self._reset_clearable_stream_region()
             handler(event)
 
     def on_stream(self, data: str) -> None:
         """Handle raw console stream (Rich panels, pipeline output)."""
         self._suppress_all_spinners()
+        if self._is_clearable_plain_stream(data):
+            self._clearable_stream_parts.append(data)
+        else:
+            self._reset_clearable_stream_region()
         self._out.write(data)
         self._out.flush()
 
@@ -137,6 +152,7 @@ class EventRenderer:
             self._activity_thread = None
         # Clear any leftover spinner line
         self._out.write("\r\033[2K")
+        self._clear_markdown_stream_region()
         self._out.flush()
         # Render accumulated turn status (Claude Code style)
         self._render_turn_status()
@@ -788,3 +804,27 @@ class EventRenderer:
         if self._activity and not self._activity_suppressed:
             self._out.write("\r\033[2K")
             self._out.flush()
+
+    @staticmethod
+    def _is_clearable_plain_stream(data: str) -> bool:
+        """Return True for plain text stream chunks that can be safely erased."""
+        if not data:
+            return False
+        if _ANSI_ESCAPE.search(data):
+            return False
+        return not any(ch in data for ch in "\b\f\v")
+
+    def _reset_clearable_stream_region(self) -> None:
+        self._clearable_stream_parts.clear()
+
+    def _clear_markdown_stream_region(self) -> None:
+        text = "".join(self._clearable_stream_parts)
+        self._reset_clearable_stream_region()
+        if not text or not _MARKDOWN_TEXT_MARKER.search(text):
+            return
+
+        visual_lines = len(text.splitlines()) or 1
+        self._out.write("\r\033[2K")
+        moves = visual_lines if text.endswith("\n") else max(visual_lines - 1, 0)
+        for _ in range(moves):
+            self._out.write("\033[1A\033[2K")

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -173,8 +173,8 @@ _INLINE_PAREN = re.compile(r"(?<!\\)\\\(([\s\S]+?)(?<!\\)\\\)")
 # The default delimiter scanners cannot see those tokens and the bare macros
 # leak into the Markdown render. We conservatively catch two narrow forms,
 # each requiring explicit LaTeX syntax (braces or a known macro name) so
-# ordinary ``snake_case`` identifiers, file paths, and Markdown emphasis
-# remain untouched:
+# ordinary ``snake_case`` identifiers, file paths, Markdown code, and
+# Markdown emphasis remain untouched:
 #
 #   * **Braced subscript/superscript token** — ``r_{t-1}``, ``P_{t+5}``,
 #     ``x^{2}``, ``W_{i,j}^{T}``. Requires `{…}` directly after `_` or `^`.
@@ -183,10 +183,10 @@ _INLINE_PAREN = re.compile(r"(?<!\\)\\\(([\s\S]+?)(?<!\\)\\\)")
 #     allow-list of macro names keeps the pattern from over-firing on
 #     prose like ``\n`` escape sequences.
 #
-# Bare-underscore prose (``snake_case``, ``my_var``, ``some_word_here``)
-# never matches because there is no following ``{``. Bare letters with
-# subscripts in prose (``r_t``) are also skipped — the heuristic only
-# activates when the LaTeX intent is unambiguous.
+# Bare script forms (``r_t``, ``x^2``) are accepted only when the candidate
+# sits in a math-shaped line context and the script payload looks index-like
+# (``t``, ``i,j``, ``t-9:t``), not word-like (``case``, ``name``). This
+# catches LLM formula leaks while continuing to skip ordinary identifiers.
 
 _MACRO_NAMES = (
     "Alpha",
@@ -277,6 +277,16 @@ _MACRO_NAMES = (
     "xi",
     "zeta",
 )
+_UNICODE_MATH_GLYPHS: Final = (
+    "√∑∫∏≤≥→←⇒⇐↔∞≈≠±×÷∈∉⊂⊆∂∇ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω"
+)
+_SCRIPT_CHARS = "A-Za-z0-9" + re.escape(_UNICODE_MATH_GLYPHS + ",:-")
+_SCRIPT_BODY = rf"(?:\([^()`\n]+\)|[{_SCRIPT_CHARS}]+)"
+_UNICODE_TOKEN_HEAD = (
+    rf"(?:[A-Za-z0-9]*[{re.escape(_UNICODE_MATH_GLYPHS)}][A-Za-z0-9]+"
+    rf"|[A-Za-z0-9]+[{re.escape(_UNICODE_MATH_GLYPHS)}][A-Za-z0-9]*"
+    rf"|[{re.escape(_UNICODE_MATH_GLYPHS)}](?:[_^]{_SCRIPT_BODY}))"
+)
 _DELIMITERLESS_MATH = re.compile(
     r"(?:"
     # Braced subscript/superscript token (chained): r_{t-1}, P_{t+5}^{2}, ...
@@ -290,8 +300,21 @@ _DELIMITERLESS_MATH = re.compile(
     # three so the pattern stays bounded.
     r"\\(?:" + "|".join(_MACRO_NAMES) + r")(?![A-Za-z])"
     r"(?:\{[^{}]*\}){0,3}"
+    r"|"
+    # Bare script token in math-shaped context: y^ΔT_t,n, S^(i)_t,n,
+    # close_t,n, X_t-9:t,n,:. Filtered by _delimiterless_candidate_allowed.
+    r"[A-Za-z][A-Za-z0-9]*"
+    rf"(?:[_^]{_SCRIPT_BODY})+"
+    r"|"
+    # Unicode math glyph adjacent to letters/digits/scripts: √x, α_i, ΔT,n.
+    rf"{_UNICODE_TOKEN_HEAD}"
+    rf"(?:[_^]{_SCRIPT_BODY})?"
+    r"(?:,[A-Za-z0-9]+)*"
     r")"
 )
+_SCRIPT_PART = re.compile(rf"[_^]({_SCRIPT_BODY})")
+_FENCED_CODE_BLOCK = re.compile(r"(?m)^(```|~~~)[^\n]*\n[\s\S]*?^\1\s*$")
+_INLINE_CODE_SPAN = re.compile(r"`[^`\n]*`")
 
 
 def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
@@ -332,10 +355,15 @@ def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
         if _overlaps(m.start(), m.end(), matches):
             continue
         matches.append((m.start(), m.end(), "inline_math", m.group(1)))
-    # Last-resort heuristic: catch bare LaTeX tokens (braced sub/sup or
-    # allow-listed macro) that arrived without surrounding delimiters.
+    code_spans = _markdown_code_spans(text)
+    # Last-resort heuristic: catch bare LaTeX tokens that arrived without
+    # surrounding delimiters.
     for m in _DELIMITERLESS_MATH.finditer(text):
         if _overlaps(m.start(), m.end(), matches):
+            continue
+        if _span_overlaps(m.start(), m.end(), code_spans):
+            continue
+        if not _delimiterless_candidate_allowed(text, m.start(), m.end(), m.group(0)):
             continue
         matches.append((m.start(), m.end(), "inline_math", m.group(0)))
     matches.sort(key=lambda t: t[0])
@@ -354,3 +382,89 @@ def extract_and_render_inline(text: str) -> Iterator[tuple[str, str]]:
 def _overlaps(start: int, end: int, matches: list[tuple[int, int, str, str]]) -> bool:
     """True when ``start``/``end`` intersects any accepted match span."""
     return any(start < e and s < end for s, e, _, _ in matches)
+
+
+def _span_overlaps(start: int, end: int, spans: list[tuple[int, int]]) -> bool:
+    """True when ``start``/``end`` intersects any protected span."""
+    return any(start < span_end and span_start < end for span_start, span_end in spans)
+
+
+def _markdown_code_spans(text: str) -> list[tuple[int, int]]:
+    """Return fenced-code and inline-code spans protected from fallback math."""
+    spans: list[tuple[int, int]] = [(m.start(), m.end()) for m in _FENCED_CODE_BLOCK.finditer(text)]
+    for m in _INLINE_CODE_SPAN.finditer(text):
+        if not _span_overlaps(m.start(), m.end(), spans):
+            spans.append((m.start(), m.end()))
+    return spans
+
+
+def _delimiterless_candidate_allowed(text: str, start: int, end: int, token: str) -> bool:
+    """Filter broad fallback matches down to math-shaped delimiterless tokens."""
+    if _looks_like_path_context(text, start, end):
+        return False
+    if token.startswith("\\") or "{" in token:
+        return True
+    if any(ch in _UNICODE_MATH_GLYPHS for ch in token):
+        return True
+    if "_" in token or "^" in token:
+        return _script_parts_look_index_like(token) and _has_math_context(text, start, end, token)
+    return False
+
+
+def _looks_like_path_context(text: str, start: int, end: int) -> bool:
+    """Reject tokens embedded in slash paths or filename extensions."""
+    left = start
+    while left > 0 and not text[left - 1].isspace():
+        left -= 1
+    right = end
+    while right < len(text) and not text[right].isspace():
+        right += 1
+    surrounding = text[left:right]
+    if "/" in surrounding:
+        return True
+    return bool(re.search(r"\.[A-Za-z0-9]{1,8}\b", surrounding))
+
+
+def _script_parts_look_index_like(token: str) -> bool:
+    """Reject word-like bare subscripts such as ``snake_case`` and ``file_name``."""
+    for match in _SCRIPT_PART.finditer(token):
+        raw = match.group(1).strip("()")
+        for part in re.split(r"[,:-]+", raw):
+            if not part:
+                continue
+            if part.isascii() and part.isalpha() and part.islower() and len(part) > 1:
+                return False
+    return True
+
+
+def _has_math_context(text: str, start: int, end: int, token: str) -> bool:
+    """True when a bare script token is adjacent to formula punctuation."""
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    if line_end == -1:
+        line_end = len(text)
+    line = text[line_start:line_end]
+
+    prev_char = _previous_nonspace(text, line_start, start)
+    next_char = _next_nonspace(text, end, line_end)
+    if prev_char in "=+-*/(,":
+        return True
+    if next_char in "=+-*/),":
+        return True
+    if any(op in token for op in ("-", ":", ",")) and any(op in line for op in "=+-*/"):
+        return True
+    return "^" in token and "=" in line
+
+
+def _previous_nonspace(text: str, lower: int, start: int) -> str:
+    pos = start - 1
+    while pos >= lower and text[pos].isspace():
+        pos -= 1
+    return text[pos] if pos >= lower else ""
+
+
+def _next_nonspace(text: str, start: int, upper: int) -> str:
+    pos = start
+    while pos < upper and text[pos].isspace():
+        pos += 1
+    return text[pos] if pos < upper else ""

--- a/tests/test_bootstrap_wire.py
+++ b/tests/test_bootstrap_wire.py
@@ -197,7 +197,8 @@ class TestPromptOverridesWire:
             node="analyst",
             role_type="game_mechanics",
         )
-        assert result.system == "You are an analyst."
+        assert result.system.startswith("You are an analyst.")
+        assert "<math_formatting>" in result.system
         assert result.fragment_count == 0
 
 

--- a/tests/test_event_schema_v2.py
+++ b/tests/test_event_schema_v2.py
@@ -418,6 +418,34 @@ class TestEventRendererV2:
         assert renderer._tool_tracker._line_count == 0
         assert "Berserk" in renderer._out.getvalue()
 
+    def test_stop_clears_raw_markdown_stream_region(self, renderer) -> None:
+        """Plain markdown streamed raw is transient; final result renders it."""
+        renderer.on_stream("Intro\n**bold** answer\n")
+
+        renderer.stop()
+        out = renderer._out.getvalue()
+        assert "**bold** answer" in out  # was visible progressively
+        assert "\033[1A\033[2K" in out  # then erased before final Markdown render
+
+    def test_stop_preserves_non_markdown_plain_stream(self, renderer) -> None:
+        """Plain non-markdown console output should remain visible after stop()."""
+        renderer.on_stream("  Available IPs\n  - Berserk\n")
+
+        renderer.stop()
+        out = renderer._out.getvalue()
+        assert "Berserk" in out
+        assert "\033[1A\033[2K" not in out
+
+    def test_event_resets_clearable_stream_region(self, renderer) -> None:
+        """Do not erase earlier raw text once a structured event has followed it."""
+        renderer.on_stream("**bold** answer\n")
+        renderer.on_event({"type": "round_start", "round": 1})
+
+        renderer.stop()
+        out = renderer._out.getvalue()
+        assert "**bold** answer" in out
+        assert "\033[1A\033[2K" not in out
+
 
 class TestIPCClientEventWhitelist:
     """All 28 event types are in IPCClient's event whitelist."""

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from core.llm.prompt_assembler import AssembledPrompt, PromptAssembler
+from core.llm.prompt_assembler import (
+    MATH_OUTPUT_FORMATTING_INSTRUCTION,
+    AssembledPrompt,
+    PromptAssembler,
+)
 from core.llm.prompts import _hash_prompt
 from core.llm.skill_registry import SkillDefinition, SkillRegistry
 
@@ -98,12 +102,30 @@ class TestBasicAssembly:
             role_type="game_mechanics",
         )
 
+        expected_system = base_system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
         assert isinstance(result, AssembledPrompt)
-        assert result.system == base_system
+        assert result.system == expected_system
         assert result.user == base_user
         assert result.fragment_count == 0
         assert result.fragments_used == []
-        assert result.total_chars == len(base_system) + len(base_user)
+        assert result.total_chars == len(expected_system) + len(base_user)
+
+    def test_math_formatting_instruction_included_by_default(
+        self, base_system: str, base_user: str, empty_state: dict[str, Any]
+    ) -> None:
+        assembler = PromptAssembler()
+        result = assembler.assemble(
+            base_system=base_system,
+            base_user=base_user,
+            state=empty_state,
+            node="analyst",
+            role_type="game_mechanics",
+        )
+
+        assert "<math_formatting>" in result.system
+        assert "Inline math: wrap with `$...$`" in result.system
+        assert "Display math: put `$$...$$` on its own lines" in result.system
+        assert "$r_t = (P_t - P_{t-1}) / P_{t-1}$" in result.system
 
     def test_no_assembler_fallback(self, empty_state: dict[str, Any]) -> None:
         """Verify state.get('_prompt_assembler') is None returns None (node-level fallback)."""
@@ -337,7 +359,8 @@ class TestHashing:
             role_type="game_mechanics",
         )
 
-        expected_base_hash = _hash_prompt(base_system + base_user)
+        expected_system = base_system + "\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION
+        expected_base_hash = _hash_prompt(expected_system + base_user)
         expected_assembled_hash = _hash_prompt(result.system + result.user)
 
         assert result.base_template_hash == expected_base_hash
@@ -606,8 +629,12 @@ class TestWrapperOverrideHook:
             role_type="game_mechanics",
         )
 
-        assert first_result.base_template_hash == _hash_prompt("first mutation" + base_user)
-        assert second_result.base_template_hash == _hash_prompt("second mutation" + base_user)
+        assert first_result.base_template_hash == _hash_prompt(
+            "first mutation\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION + base_user
+        )
+        assert second_result.base_template_hash == _hash_prompt(
+            "second mutation\n\n" + MATH_OUTPUT_FORMATTING_INSTRUCTION + base_user
+        )
         assert first_result.base_template_hash != second_result.base_template_hash
         assert first_result.assembled_hash != second_result.assembled_hash
 

--- a/tests/test_prompt_audit_2026_05_12.py
+++ b/tests/test_prompt_audit_2026_05_12.py
@@ -110,6 +110,20 @@ def test_g10_router_md_no_geode_name_in_baseline() -> None:
     assert "autonomous execution agent" in ROUTER_SYSTEM
 
 
+def test_math_formatting_instruction_reaches_agentic_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interactive CLI prompt path tells the model to delimit math."""
+    monkeypatch.delenv("GEODE_AUDIT_UNRESTRICTED", raising=False)
+    monkeypatch.delenv("GEODE_PERSONA", raising=False)
+
+    out = build_system_prompt(model="")
+
+    assert "<math_formatting>" in out
+    assert "Inline math: wrap with `$...$`" in out
+    assert "Display math: put `$$...$$` on its own lines" in out
+
+
 # ---------------------------------------------------------------------------
 # G1 — XML section parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_session.py
+++ b/tests/test_prompt_session.py
@@ -1,0 +1,123 @@
+"""Regression tests for prompt_toolkit prompt session key bindings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from core.cli.prompt_session import _build_prompt_session
+
+
+def _binding_keys(binding: Any) -> tuple[str, ...]:
+    return tuple(str(getattr(key, "value", key)) for key in binding.keys)
+
+
+def _handler_names(key_bindings: Any) -> set[str]:
+    return {binding.handler.__name__ for binding in key_bindings.bindings}
+
+
+def _find_binding(key_bindings: Any, *keys: str) -> Any:
+    expected = tuple(keys)
+    for binding in key_bindings.bindings:
+        binding_keys = _binding_keys(binding)
+        if binding_keys == expected or (expected == ("<any>",) and binding_keys == ("Keys.Any",)):
+            return binding
+    raise AssertionError(f"missing key binding: {expected}")
+
+
+def test_prompt_session_any_binding_inserts_cjk_and_invalidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePromptSession:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", FakePromptSession)
+    monkeypatch.setattr("prompt_toolkit.history.FileHistory", lambda path: path)
+
+    _build_prompt_session()
+
+    key_bindings = captured["key_bindings"]
+    any_binding = _find_binding(key_bindings, "<any>")
+
+    current_buffer = MagicMock()
+    app = MagicMock()
+    event = SimpleNamespace(
+        data="가",
+        key_sequence=[SimpleNamespace(key="가")],
+        current_buffer=current_buffer,
+        app=app,
+    )
+
+    any_binding.handler(event)
+
+    current_buffer.insert_text.assert_called_once_with("가")
+    app.invalidate.assert_called_once_with()
+
+
+def test_prompt_session_preserves_specific_edit_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePromptSession:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", FakePromptSession)
+    monkeypatch.setattr("prompt_toolkit.history.FileHistory", lambda path: path)
+
+    _build_prompt_session()
+
+    key_bindings = captured["key_bindings"]
+    assert {
+        "_enter",
+        "_newline",
+        "_backspace",
+        "_delete",
+        "_insert_printable",
+    } <= _handler_names(key_bindings)
+
+
+@pytest.mark.parametrize(
+    ("data", "key"),
+    [
+        ("", ""),
+        ("\x1b", "escape"),
+        ("\x1b[D", "left"),
+    ],
+)
+def test_prompt_session_any_binding_ignores_non_printable_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    data: str,
+    key: str,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePromptSession:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", FakePromptSession)
+    monkeypatch.setattr("prompt_toolkit.history.FileHistory", lambda path: path)
+
+    _build_prompt_session()
+
+    any_binding = _find_binding(captured["key_bindings"], "<any>")
+    current_buffer = MagicMock()
+    app = MagicMock()
+    event = SimpleNamespace(
+        data=data,
+        key_sequence=[SimpleNamespace(key=key)],
+        current_buffer=current_buffer,
+        app=app,
+    )
+
+    any_binding.handler(event)
+
+    current_buffer.insert_text.assert_not_called()
+    app.invalidate.assert_not_called()

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -129,6 +129,40 @@ class TestMixedContent:
         assert [k for k, _ in chunks] == expected_kinds
 
 
+class TestDelimiterlessMathWidening:
+    """Bare-script and Unicode-math fallback for LLM output that forgot delimiters."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "y^ΔT_t,n = close_t+ΔT,n - close_t,n / close_t,n",
+            "S^(i)_t,n = α_i ( X_t-L^(i)+1:t,n,: )",
+            "X_t-9:t,n,:",
+            "√x + 1",
+        ],
+    )
+    def test_user_reported_bare_script_and_unicode_math_segments(self, source: str) -> None:
+        chunks = list(extract_and_render_inline(source))
+        assert any(kind == "inline_math" for kind, _ in chunks), chunks
+        assert chunks != [("text", source)]
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "snake_case_var",
+            "foo/bar/baz.py",
+            "**bold**",
+            "*x*",
+        ],
+    )
+    def test_false_positive_guards_stay_text(self, source: str) -> None:
+        assert list(extract_and_render_inline(source)) == [("text", source)]
+
+    def test_inline_code_protects_math_shaped_text(self) -> None:
+        source = "`y^ΔT_t,n = close_t+ΔT,n`"
+        assert list(extract_and_render_inline(source)) == [("text", source)]
+
+
 class TestDelimiterExpansion:
     """PR #1165 — `\\[...\\]`, `\\(...\\)`, and `\\begin{equation}...\\end{equation}`
     are recognised in addition to the original `$`-based forms."""

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.95.0"
+version = "0.95.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
develop → main release ratchet. 3 PR 묶음:

- **#1179** — `fix(cli): 스트리밍 raw markdown 노출 정리 + final 시 clear` (Issue 1)
- **#1180** — `fix(cli): prompt_toolkit \`<any>\` 바인딩으로 CJK insert redraw 동기화` (Issue 2)
- **#1181** — `feat(cli): LaTeX detector 보강 + LLM 출력 math delimiter 지시` (Issue 3)

각 PR 모두 Codex MCP cross-LLM verify 통과, CI 7/7 PASS.

## Verification
- [x] PR #1179 CI 7/7 PASS, develop merged @ `7b5e7628`
- [x] PR #1180 CI 7/7 PASS, develop merged @ `2a5ef1f3`
- [x] PR #1181 CI 7/7 PASS, develop merged @ `d4ffdfb7`
- [x] develop HEAD = `d4ffdfb7`
- [x] ruff check / format / mypy / pytest 전 PR 호스트 재돌림 모두 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)