### PR TITLE
release: v0.95.2 — CLI rendering trilogy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.95.2] — 2026-05-16
+
 ### Added
 
 - **CLI system prompt math-formatting instruction.** GEODE 의 기본 LLM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.95.1
+- **Version**: 0.95.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.95.1 — Long-running Autonomous Execution Harness
+# GEODE v0.95.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.1**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.2**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.95.1"
+version = "0.95.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.95.1"
+version = "0.95.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 4-location version bump: pyproject.toml / CLAUDE.md / README.md / CHANGELOG.md (0.95.1 → 0.95.2)
- CHANGELOG `[Unreleased]` → `[0.95.2] — 2026-05-16` promotion
- 묶인 fix 3건: streaming Markdown clear (#1179) / CJK insert redraw (#1180) / LaTeX detector 보강 + LLM math delimiter 지시 (#1181)

## Why
3 PR 이 develop 에 들어갔고 main 까지 ratchet (#1182). main 의 CHANGELOG 가 `[Unreleased]` 그대로 → CANNOT "No leaving [Unreleased] on main" 위반. PATCH bump + section promotion 으로 release discipline 회복.

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] 4 location version 일치 확인 (`0.95.2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)