### PR TITLE
fix(cli): Tier 1 LaTeX unicode subscript/superscript 후처리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI LaTeX bare script Unicode rendering.** Tier 1 LaTeX 렌더러가
+  `pylatexenc` 출력 이후 `_i`, `_1`, `^2` 같은 delimiter-less
+  subscript/superscript 토큰을 Unicode 아래/위첨자로 후처리합니다.
+  지원 문자가 없는 토큰은 원문 marker 를 보존해 `h_∞` 같은 표기를
+  부분 변환하지 않습니다.
+- **CLI LaTeX bare script Unicode rendering.** Tier 1 now post-processes
+  `pylatexenc` output so delimiter-less scripts such as `h_i`, `w_1`, and
+  `x^2` render as Unicode glyphs. Tokens containing unsupported script
+  characters remain raw atomically, preserving forms like `h_∞` instead of
+  producing mixed output.
+
 ## [0.95.2] — 2026-05-16
 
 ### Added

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -61,11 +61,118 @@ _TIER2_TOKENS: Final[tuple[str, ...]] = (
 _LATEX_LINEBREAK = re.compile(r"(?<!\\)\\\\(?:\s*\[[^\]]*\])?")
 _LATEX_LINEBREAK_SENTINEL: Final = "<<<GEODE_LATEX_LINEBREAK_4A7D1B>>>"
 _DISPLAY_FRACTION_MACRO = re.compile(r"\\[dt]frac(?=\{)")
+_SUBSCRIPT_MAP: Final[dict[str, str]] = {
+    "0": "₀",
+    "1": "₁",
+    "2": "₂",
+    "3": "₃",
+    "4": "₄",
+    "5": "₅",
+    "6": "₆",
+    "7": "₇",
+    "8": "₈",
+    "9": "₉",
+    "a": "ₐ",
+    "e": "ₑ",
+    "h": "ₕ",
+    "i": "ᵢ",
+    "j": "ⱼ",
+    "k": "ₖ",
+    "l": "ₗ",
+    "m": "ₘ",
+    "n": "ₙ",
+    "o": "ₒ",
+    "p": "ₚ",
+    "r": "ᵣ",
+    "s": "ₛ",
+    "t": "ₜ",
+    "u": "ᵤ",
+    "v": "ᵥ",
+    "x": "ₓ",
+    "+": "₊",
+    "-": "₋",
+    "=": "₌",
+    "(": "₍",
+    ")": "₎",
+}
+_SUPERSCRIPT_MAP: Final[dict[str, str]] = {
+    "0": "⁰",
+    "1": "¹",
+    "2": "²",
+    "3": "³",
+    "4": "⁴",
+    "5": "⁵",
+    "6": "⁶",
+    "7": "⁷",
+    "8": "⁸",
+    "9": "⁹",
+    "a": "ᵃ",
+    "b": "ᵇ",
+    "c": "ᶜ",
+    "d": "ᵈ",
+    "e": "ᵉ",
+    "f": "ᶠ",
+    "g": "ᵍ",
+    "h": "ʰ",
+    "i": "ⁱ",
+    "j": "ʲ",
+    "k": "ᵏ",
+    "l": "ˡ",
+    "m": "ᵐ",
+    "n": "ⁿ",
+    "o": "ᵒ",
+    "p": "ᵖ",
+    "r": "ʳ",
+    "s": "ˢ",
+    "t": "ᵗ",
+    "u": "ᵘ",
+    "v": "ᵛ",
+    "w": "ʷ",
+    "x": "ˣ",
+    "y": "ʸ",
+    "z": "ᶻ",
+    "+": "⁺",
+    "-": "⁻",
+    "=": "⁼",
+    "(": "⁽",
+    ")": "⁾",
+}
+_SCRIPT_CHAR_CLASS: Final = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-="
+_UNICODE_SCRIPT = re.compile(
+    rf"(?P<marker>[_^])(?:\{{(?P<braced>[^{{}}\n]+)\}}|"
+    rf"(?P<parenthesized>\([{re.escape(_SCRIPT_CHAR_CLASS)}]+\))|"
+    rf"(?P<bare>[{re.escape(_SCRIPT_CHAR_CLASS)}]+))"
+)
 
 
 def _has_tier2_construct(src: str) -> bool:
     """True when ``src`` contains a 2D math construct worth pretty-printing."""
     return any(tok in src for tok in _TIER2_TOKENS)
+
+
+def _apply_unicode_scripts(text: str) -> str:
+    """Rewrite fully-supported ``_`` / ``^`` script tokens to Unicode glyphs."""
+    if not text:
+        return text
+    if _LATEX_LINEBREAK_SENTINEL in text:
+        return _LATEX_LINEBREAK_SENTINEL.join(
+            _apply_unicode_scripts(part) for part in text.split(_LATEX_LINEBREAK_SENTINEL)
+        )
+
+    def replace(match: re.Match[str]) -> str:
+        marker = match.group("marker")
+        token = match.group("braced") or match.group("parenthesized") or match.group("bare")
+        if not token:
+            log.debug("Unexpected empty LaTeX script token in %r", match.group(0))
+            return match.group(0)
+
+        script_map = _SUBSCRIPT_MAP if marker == "_" else _SUPERSCRIPT_MAP
+        mapped = [script_map.get(ch) for ch in token]
+        if any(ch is None for ch in mapped):
+            return match.group(0)
+        return "".join(ch for ch in mapped if ch is not None)
+
+    return _UNICODE_SCRIPT.sub(replace, text)
 
 
 def _render_tier1(src: str) -> str:
@@ -92,6 +199,7 @@ def _render_tier1(src: str) -> str:
             src,
         )
         raw: str = LatexNodes2Text().latex_to_text(protected_src).strip()
+        raw = _apply_unicode_scripts(raw)
         lines = [re.sub(r"\s+", " ", part).strip() for part in raw.split(_LATEX_LINEBREAK_SENTINEL)]
         return "\n".join(line for line in lines if line)
     except Exception:

--- a/tests/test_cli_latex_uiux.py
+++ b/tests/test_cli_latex_uiux.py
@@ -157,8 +157,8 @@ class TestStageAComponent:
         assert "P_{t-1}" not in output
         assert output.count("P_t-1") == 2 or output.count("Pₜ₋₁") == 2
         # The bare-letter parts (no braces) keep their literal form.
-        assert "r_t" in output
-        assert "P_t" in output
+        assert "rₜ" in output
+        assert "Pₜ" in output
 
     def test_delimiterless_does_not_match_snake_case_or_paths(self) -> None:
         """Bare-underscore identifiers (`snake_case`, file paths, Python
@@ -248,7 +248,7 @@ class TestStageAComponent:
         # Math is rendered (key Unicode tokens reached the buffer).
         assert "∑" in output
         assert "√" in output
-        assert "IC_t" in output
+        assert "ICₜ" in output
         assert "는 trial t" in output
         # No raw LaTeX macros leaked through.
         for raw in ("\\(", "\\)", "\\frac", "\\sqrt", "\\sum", "\\bar"):
@@ -260,7 +260,9 @@ class TestStageAComponent:
             line for line in output.splitlines() if line.strip() and "는 trial t" not in line
         ]
         math_lines = [
-            line for line in body_lines if "여기서" in line or "S_t" in line or "y_t" in line
+            line
+            for line in body_lines
+            if ("여기서" in line or "S_t" in line or "Sₜ" in line or "y_t" in line or "yₜ" in line)
         ]
         assert len(math_lines) <= 6, (
             f"multi-line LaTeX source did not collapse — {len(math_lines)} math "
@@ -312,6 +314,24 @@ class TestStageAComponent:
 
         assert lines == ["a b", "c d"]
         assert "a b c d" not in rendered
+
+    def test_user_reported_bare_scripts_render_unicode_end_to_end(self) -> None:
+        """Regression guard for the 2026-05-16 second-wave CLI report."""
+        text = "\n".join(
+            [
+                "h^* = max_h ∈ℋ S(h |G, E)",
+                "S(h) = w_1 + w_2 + w_3",
+                "h_i, h_j",
+                "C(h_i, h_j) = 1",
+                "W(h_i) = 1/N-1 ∑_j C(h_i, h_j)",
+            ]
+        )
+        output = _render_through_helper(text)
+
+        for rendered in ("maxₕ", "w₁", "w₂", "w₃", "hᵢ", "hⱼ", "∑ⱼ"):
+            assert rendered in output
+        for raw in ("max_h", "w_1", "w_2", "w_3", "h_i", "h_j", "∑_j"):
+            assert raw not in output
 
     @pytest.mark.parametrize(
         "text,math_tokens",

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from core.ui.latex import (
     _has_tier2_construct,
+    _render_tier1,
     extract_and_render_inline,
     render_latex,
 )
@@ -32,11 +33,32 @@ class TestTier1Unicode:
 
     def test_subscript_superscript(self) -> None:
         out = render_latex(r"x_{i}^{2}").plain
-        # pylatexenc emits x_i^2 — Unicode digits in superscript are preferred
-        # but the exact glyphs depend on the font. We only require the chars.
-        assert "x" in out
-        assert "i" in out
-        assert "2" in out
+        assert out == "xᵢ²"
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("h_i", "hᵢ"),
+            ("w_1", "w₁"),
+            ("w_{12}", "w₁₂"),
+            ("x^{2}", "x²"),
+            ("x^123", "x¹²³"),
+        ],
+    )
+    def test_unicode_script_postprocess_supported_tokens(
+        self,
+        source: str,
+        expected: str,
+    ) -> None:
+        assert _render_tier1(source) == expected
+
+    def test_superscript_star_stays_raw(self) -> None:
+        # Unicode has no standard superscript asterisk that reads better in
+        # terminal math, so the atomic fallback preserves the raw marker.
+        assert _render_tier1("h^*") == "h^*"
+
+    def test_unsupported_subscript_token_stays_raw(self) -> None:
+        assert _render_tier1("h_∞") == "h_∞"
 
     def test_empty_string(self) -> None:
         assert render_latex("").plain == ""
@@ -94,6 +116,13 @@ class TestMixedContent:
         _, math = chunks[1]
         assert "α" in math
         assert "β" in math
+
+    def test_delimiterless_bare_subscripts_render_unicode(self) -> None:
+        chunks = list(extract_and_render_inline("h_i, h_j"))
+        inline_payloads = [payload for kind, payload in chunks if kind == "inline_math"]
+        assert any("hᵢ" in payload for payload in inline_payloads)
+        assert any("hⱼ" in payload for payload in inline_payloads)
+        assert not any("h_i" in payload or "h_j" in payload for payload in inline_payloads)
 
     def test_block_math(self) -> None:
         chunks = list(extract_and_render_inline(r"see $$\frac{a}{b}$$ here"))


### PR DESCRIPTION
## Summary
- `_render_tier1` 가 `latex_to_text()` 출력 직후 `_apply_unicode_scripts` 호출 → bare/braced `_X`, `^X` 패턴을 unicode subscript (`₀₁₂... ᵢⱼₕ...`) / superscript (`⁰¹²... ᵃᵇᶜ...`) 로 변환
- atomic 규칙: 토큰의 모든 char 가 map 에 있을 때만 변환, 빠지면 raw 유지 (mojibake 방지)
- Codex MCP cross-LLM verify 통과

## Why
사용자 보고 (2026-05-16 second wave): PR #1181 detector 는 `h_i`, `h^*`, `w_1` 정상 catch (inline_math) 하지만 Tier 1 (`pylatexenc.LatexNodes2Text`) 가 bare bracketless subscript/superscript 를 raw 통과시켜 화면에 `h_i`, `w_1` 그대로 노출.

직접 probe (`_render_tier1('h_i')`):
- before: `'h_i'`
- after: `'hᵢ'`

심지어 braces 형식 (`h_{i}`) 도 pylatexenc 가 `h_i` 로만 반환 → unicode 변환 안 됨이 근본 원인.

## Changes
| File | Change |
|------|--------|
| `core/ui/latex.py` | `_SUBSCRIPT_MAP` / `_SUPERSCRIPT_MAP` / `_apply_unicode_scripts` / `_UNICODE_SCRIPT` 추가; `_render_tier1` 에서 collapse 전 호출 |
| `tests/test_ui_latex.py` | bare + braced + atomic-fallback (`h_∞`) regression |
| `tests/test_cli_latex_uiux.py` | extract_and_render_inline 통과 후 console output 에 unicode glyph 포함 + bare 형식 잔존 안 함 |
| `CHANGELOG.md` | `[Unreleased]` Fixed (KR/EN) |

## Behavior Delta
| Input | Before | After |
|---|---|---|
| `h_i` | `h_i` | `hᵢ` |
| `h^*` | `h^*` | `h^*` (asterisk unicode 미존재, atomic raw) |
| `w_1`, `w_2`, `w_3` | `w_1` | `w₁` |
| `max_h` | `max_h` | `maxₕ` |
| `h_i, h_j` | `h_i, h_j` | `hᵢ, hⱼ` |
| `W(h_i) = 1/N-1 ∑_j` | raw | `W(hᵢ) = 1/N-1 ∑ⱼ` |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 사용자 선택 — Tier 1 후처리 직접 변환 | Implemented | `_render_tier1` 내부, sentinel 보존, atomic 규칙 |
| atomic fallback | Implemented + tested | `h_∞`, uppercase 등 unsupported char 시 raw 유지 |
| 기존 LaTeX 테스트 regression 없음 | Verified | 74 passed (test_ui_latex + test_cli_latex_uiux) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean (629 files)
- [x] `uv run mypy core/ plugins/` clean (364 files)
- [x] `uv run pytest tests/test_ui_latex.py tests/test_cli_latex_uiux.py` 74 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)
- [x] direct probe: `'h_i, h_j' -> 'hᵢ, hⱼ'` 확인

## Atomic raw 의도 (Unicode 미존재 → 그대로)
- Subscript 미존재: `b c d f g q w y z`, uppercase letters, Greek/math (`∞` 등), punctuation
- Superscript 미존재: `q`, uppercase letters, `*`, Greek/math, punctuation

## Reference
- Series: #1179 (streaming Markdown clear) → #1180 (CJK insert redraw) → #1181 (detector + LLM math delimiter) → #1183 (v0.95.2 release) → **#1185 (Tier 1 unicode 후처리)**
- 사용자 응답 분석 + probe — `/Users/mango/.claude/projects/-Users-mango-workspace-geode/53df0b8a-dbc1-4b05-85db-056897b9595c.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)