### PR TITLE
release: v0.95.4 — detector path-context + bracket fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.95.4] — 2026-05-16
+
 ### Added
 
 - **autoresearch cross-axis regression gate.** `compute_fitness` 가

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,23 @@ renders as a single column with a `KR`-only or `EN`-only chip.
   The dry-run baseline still uses the placeholder, so the
   `fitness=0.535895` plumbing contract is unchanged.
 
+### Fixed
+
+- **CLI LaTeX slash-division detector + uppercase subscript display.**
+  delimiter-less 수식 detector 가 `/` 하나만 보고 path 로 오판하던 문제를
+  수정했습니다. `E_i = 1/1 + 10^(R_j - R_i)/400` 의 마지막 `R_i` 는
+  이제 `Rᵢ` inline math 로 잡히고, `foo/bar/baz.py` / `src/main.tsx`
+  같은 실제 path 는 계속 text 로 남습니다. Unicode 아래첨자에 없는
+  대문자 Latin payload 는 raw `_` 대신 bracket fallback (`τ_P` → `τ[P]`)
+  으로 표시해 터미널에서 marker 누수를 피합니다.
+- **CLI LaTeX slash-division detector + uppercase subscript display.**
+  The delimiter-less math detector no longer treats any nearby `/` as
+  path evidence. `E_i = 1/1 + 10^(R_j - R_i)/400` now captures the final
+  `R_i` as `Rᵢ`, while real paths such as `foo/bar/baz.py` and
+  `src/main.tsx` remain plain text. Unsupported uppercase Latin subscript
+  payloads now use a bracket fallback (`τ_P` → `τ[P]`) instead of leaking
+  the raw `_` marker.
+
 ## [0.95.3] — 2026-05-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.95.3
+- **Version**: 0.95.4
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.95.3 — Long-running Autonomous Execution Harness
+# GEODE v0.95.4 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.3**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.95.4**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -137,6 +137,46 @@ _SUPERSCRIPT_MAP: Final[dict[str, str]] = {
     "(": "⁽",
     ")": "⁾",
 }
+_GREEK_WORD_BASES: Final[frozenset[str]] = frozenset(
+    {
+        "Alpha",
+        "Beta",
+        "Gamma",
+        "Delta",
+        "Epsilon",
+        "Lambda",
+        "Omega",
+        "Phi",
+        "Pi",
+        "Psi",
+        "Sigma",
+        "Theta",
+        "Xi",
+        "alpha",
+        "beta",
+        "chi",
+        "delta",
+        "epsilon",
+        "eta",
+        "gamma",
+        "iota",
+        "kappa",
+        "lambda",
+        "mu",
+        "nu",
+        "omega",
+        "phi",
+        "pi",
+        "psi",
+        "rho",
+        "sigma",
+        "tau",
+        "theta",
+        "upsilon",
+        "xi",
+        "zeta",
+    }
+)
 _SCRIPT_CHAR_CLASS: Final = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-="
 _UNICODE_SCRIPT = re.compile(
     rf"(?P<marker>[_^])(?:\{{(?P<braced>[^{{}}\n]+)\}}|"
@@ -151,7 +191,7 @@ def _has_tier2_construct(src: str) -> bool:
 
 
 def _apply_unicode_scripts(text: str) -> str:
-    """Rewrite fully-supported ``_`` / ``^`` script tokens to Unicode glyphs."""
+    """Rewrite terminal-friendly ``_`` / ``^`` script tokens."""
     if not text:
         return text
     if _LATEX_LINEBREAK_SENTINEL in text:
@@ -169,10 +209,49 @@ def _apply_unicode_scripts(text: str) -> str:
         script_map = _SUBSCRIPT_MAP if marker == "_" else _SUPERSCRIPT_MAP
         mapped = [script_map.get(ch) for ch in token]
         if any(ch is None for ch in mapped):
-            return match.group(0)
+            fallback = _unsupported_script_presentation(text, match, token, mapped)
+            if fallback is None:
+                return match.group(0)
+            return fallback
         return "".join(ch for ch in mapped if ch is not None)
 
     return _UNICODE_SCRIPT.sub(replace, text)
+
+
+def _unsupported_script_presentation(
+    text: str,
+    match: re.Match[str],
+    token: str,
+    mapped: list[str | None],
+) -> str | None:
+    """Return a conservative no-raw-marker fallback for unsupported scripts."""
+    if token.isascii() and token.isalpha() and token.islower() and len(token) > 1:
+        return None
+    has_partial_mapping = any(ch is not None for ch in mapped)
+    if not has_partial_mapping and not _script_base_looks_math(text, match.start()):
+        return None
+
+    # Unicode has no uppercase Latin subscript alphabet. Bracketing preserves
+    # the script as a unit (τ[P]) without pretending the base identifier is τP.
+    payload = "".join(
+        mapped_ch if mapped_ch is not None else raw_ch
+        for raw_ch, mapped_ch in zip(token, mapped, strict=True)
+    )
+    return f"[{payload}]"
+
+
+def _script_base_looks_math(text: str, marker_start: int) -> bool:
+    """True when an unsupported script is attached to a Greek/math base."""
+    if marker_start <= 0:
+        return False
+    prev = text[marker_start - 1]
+    if prev in _UNICODE_MATH_GLYPHS:
+        return True
+
+    left = marker_start
+    while left > 0 and text[left - 1].isalpha():
+        left -= 1
+    return text[left:marker_start] in _GREEK_WORD_BASES
 
 
 def _render_tier1(src: str) -> str:
@@ -388,6 +467,9 @@ _MACRO_NAMES = (
 _UNICODE_MATH_GLYPHS: Final = (
     "√∑∫∏≤≥→←⇒⇐↔∞≈≠±×÷∈∉⊂⊆∂∇ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω"
 )
+_PATH_EXTENSION = re.compile(r"\.[A-Za-z0-9]{1,8}\b")
+_PATH_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_MATH_SCRIPT_SEGMENT = re.compile(r"[A-Za-z]_[A-Za-z0-9](?:,[A-Za-z0-9]+)?")
 _SCRIPT_CHARS = "A-Za-z0-9" + re.escape(_UNICODE_MATH_GLYPHS + ",:-")
 _SCRIPT_BODY = rf"(?:\([^()`\n]+\)|[{_SCRIPT_CHARS}]+)"
 _UNICODE_TOKEN_HEAD = (
@@ -520,7 +602,7 @@ def _delimiterless_candidate_allowed(text: str, start: int, end: int, token: str
 
 
 def _looks_like_path_context(text: str, start: int, end: int) -> bool:
-    """Reject tokens embedded in slash paths or filename extensions."""
+    """Reject tokens embedded in filename or slash-path context."""
     left = start
     while left > 0 and not text[left - 1].isspace():
         left -= 1
@@ -528,9 +610,25 @@ def _looks_like_path_context(text: str, start: int, end: int) -> bool:
     while right < len(text) and not text[right].isspace():
         right += 1
     surrounding = text[left:right]
-    if "/" in surrounding:
+    if "/" not in surrounding:
+        return bool(_PATH_EXTENSION.search(surrounding))
+    if surrounding.startswith(("/", "./", "../", "~/")):
         return True
-    return bool(re.search(r"\.[A-Za-z0-9]{1,8}\b", surrounding))
+    if _PATH_EXTENSION.search(surrounding) and _slash_segments_look_pathish(surrounding):
+        return True
+    return surrounding.count("/") >= 2 and _slash_segments_look_pathish(surrounding)
+
+
+def _slash_segments_look_pathish(surrounding: str) -> bool:
+    """True for slash runs made of path segments, false for formula fractions."""
+    segments = [segment for segment in surrounding.split("/") if segment]
+    if len(segments) < 2:
+        return False
+    if not all(_PATH_SEGMENT.fullmatch(segment) for segment in segments):
+        return False
+    if all(_MATH_SCRIPT_SEGMENT.fullmatch(segment) for segment in segments):
+        return False
+    return any(any(ch.isalpha() for ch in segment) and len(segment) > 1 for segment in segments)
 
 
 def _script_parts_look_index_like(token: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.95.3"
+version = "0.95.4"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_cli_latex_uiux.py
+++ b/tests/test_cli_latex_uiux.py
@@ -164,11 +164,38 @@ class TestStageAComponent:
         """Bare-underscore identifiers (`snake_case`, file paths, Python
         variables) must never be promoted to math segments — that would
         mangle ordinary prose and code references."""
-        text = "use `snake_case` for vars and `path/to/file_name.py` for paths"
+        text = "use `snake_case` for vars and `path/to/file_name.py` plus foo/bar/baz.py"
         output = _render_through_helper(text)
         # Markdown code spans + identifier substrings survive.
         assert "snake_case" in output
         assert "file_name" in output
+        assert "foo/bar/baz.py" in output
+
+    def test_delimiterless_division_does_not_hide_subscript_math(self) -> None:
+        text = "E_i = 1/1 + 10^(R_j - R_i)/400"
+        output = _render_through_helper(text)
+        assert "Eᵢ" in output
+        assert "Rⱼ" in output
+        assert "Rᵢ" in output
+        assert "R_i" not in output
+
+    def test_delimiterless_elo_update_renders_each_subscript(self) -> None:
+        text = "R_i' = R_i + K(S_i - E_i)"
+        output = _render_through_helper(text)
+        assert output.count("Rᵢ") == 2
+        assert "Sᵢ" in output
+        assert "Eᵢ" in output
+
+    def test_delimiterless_uppercase_subscript_uses_bracket_presentation(self) -> None:
+        output = _render_through_helper("τ_P = τ_T + τ_A")
+        assert "τ[P]" in output
+        assert "τ[T]" in output
+        assert "τ[A]" in output
+        assert "τ_P" not in output
+
+    def test_delimiterless_plain_snake_case_stays_text(self) -> None:
+        output = _render_through_helper("snake_case_var")
+        assert "snake_case_var" in output
 
     def test_delimiterless_macro_list(self) -> None:
         """Backslash macros from the allow-list render even without

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -60,6 +60,10 @@ class TestTier1Unicode:
     def test_unsupported_subscript_token_stays_raw(self) -> None:
         assert _render_tier1("h_∞") == "h_∞"
 
+    def test_unsupported_uppercase_subscript_uses_bracket_presentation(self) -> None:
+        assert _render_tier1("τ_P") == "τ[P]"
+        assert _render_tier1("tau_P") == "tau[P]"
+
     def test_empty_string(self) -> None:
         assert render_latex("").plain == ""
 
@@ -124,6 +128,18 @@ class TestMixedContent:
         assert any("hⱼ" in payload for payload in inline_payloads)
         assert not any("h_i" in payload or "h_j" in payload for payload in inline_payloads)
 
+    def test_delimiterless_division_context_keeps_late_subscript_math(self) -> None:
+        chunks = list(extract_and_render_inline("E_i = 1/1 + 10^(R_j - R_i)/400"))
+        inline_payloads = [payload for kind, payload in chunks if kind == "inline_math"]
+        text_payloads = [payload for kind, payload in chunks if kind == "text"]
+        assert inline_payloads == ["Eᵢ", "Rⱼ", "Rᵢ"]
+        assert not any("R_i" in payload for payload in text_payloads)
+
+    def test_delimiterless_elo_update_segments_all_subscripts(self) -> None:
+        chunks = list(extract_and_render_inline("R_i' = R_i + K(S_i - E_i)"))
+        inline_payloads = [payload for kind, payload in chunks if kind == "inline_math"]
+        assert inline_payloads == ["Rᵢ", "Rᵢ", "Sᵢ", "Eᵢ"]
+
     def test_block_math(self) -> None:
         chunks = list(extract_and_render_inline(r"see $$\frac{a}{b}$$ here"))
         kinds = [k for k, _ in chunks]
@@ -180,6 +196,7 @@ class TestDelimiterlessMathWidening:
         [
             "snake_case_var",
             "foo/bar/baz.py",
+            "src/main.tsx",
             "**bold**",
             "*x*",
         ],


### PR DESCRIPTION
## Summary
develop → main release ratchet. v0.95.4 PATCH bump.

- PR #1193: detector `_looks_like_path_context` 정교화 (분수 `/` false-positive 제거) + `_apply_unicode_scripts` bracket fallback (`τ_P` → `τ[P]`)
- PR #1194: 4-location version bump + `[Unreleased]` → `[0.95.4]` promotion

## Verification
- [x] PR #1193 CI 7/7 PASS, develop merged
- [x] PR #1194 CI 7/7 PASS, develop merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)