### PR TITLE
fix(cli): LaTeX detector digit-base + nested superscript group + bracket fallback bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,24 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI LaTeX digit-base superscripts + grouped scripts.** delimiter-less
+  수식 detector 가 `10^2`, `10^-3`, `10^(R_j - R_i)` 처럼 숫자 base 를
+  가진 superscript 표현을 inline math 로 승격합니다. `^(...)` /
+  `^{...}` 내부의 nested `_j` 는 바깥 superscript 방향을 따라 `ʲ` 로
+  변환되어 `10⁽ᴿʲ⁻ᴿⁱ⁾` / `10ᴿʲ⁻ᴿⁱ` 로 보이며, braced superscript 의
+  복합 payload 에 bracket fallback 이 잘못 적용되어 `10[...]` 로 깨지는
+  회귀를 막았습니다. `1_000`, `snake_case`, path false positive 는 계속
+  text 로 남습니다.
+- **CLI LaTeX digit-base superscripts + grouped scripts.** The
+  delimiter-less math detector now promotes digit-base superscripts such
+  as `10^2`, `10^-3`, and `10^(R_j - R_i)` to inline math. Nested `_j`
+  markers inside `^(...)` / `^{...}` inherit the outer superscript
+  direction, rendering as `10⁽ᴿʲ⁻ᴿⁱ⁾` / `10ᴿʲ⁻ᴿⁱ`, and complex braced
+  superscripts no longer hit the broken `10[...]` bracket fallback.
+  False positives such as `1_000`, `snake_case`, and paths stay as text.
+
 ## [0.95.4] — 2026-05-16
 
 ### Added

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -106,6 +106,25 @@ _SUPERSCRIPT_MAP: Final[dict[str, str]] = {
     "7": "⁷",
     "8": "⁸",
     "9": "⁹",
+    "A": "ᴬ",
+    "B": "ᴮ",
+    "D": "ᴰ",
+    "E": "ᴱ",
+    "G": "ᴳ",
+    "H": "ᴴ",
+    "I": "ᴵ",
+    "J": "ᴶ",
+    "K": "ᴷ",
+    "L": "ᴸ",
+    "M": "ᴹ",
+    "N": "ᴺ",
+    "O": "ᴼ",
+    "P": "ᴾ",
+    "R": "ᴿ",
+    "T": "ᵀ",
+    "U": "ᵁ",
+    "V": "ⱽ",
+    "W": "ᵂ",
     "a": "ᵃ",
     "b": "ᵇ",
     "c": "ᶜ",
@@ -180,8 +199,11 @@ _GREEK_WORD_BASES: Final[frozenset[str]] = frozenset(
 _SCRIPT_CHAR_CLASS: Final = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-="
 _UNICODE_SCRIPT = re.compile(
     rf"(?P<marker>[_^])(?:\{{(?P<braced>[^{{}}\n]+)\}}|"
-    rf"(?P<parenthesized>\([{re.escape(_SCRIPT_CHAR_CLASS)}]+\))|"
+    r"\((?P<parenthesized>[^()\n]+)\)|"
     rf"(?P<bare>[{re.escape(_SCRIPT_CHAR_CLASS)}]+))"
+)
+_DIGIT_BASE_GROUPED_SUPERSCRIPT = re.compile(
+    r"(?P<base>\d+)\^(?:\{(?P<braced>[^{}\n]+)\}|\((?P<parenthesized>[^()\n]+)\))"
 )
 
 
@@ -201,7 +223,20 @@ def _apply_unicode_scripts(text: str) -> str:
 
     def replace(match: re.Match[str]) -> str:
         marker = match.group("marker")
-        token = match.group("braced") or match.group("parenthesized") or match.group("bare")
+        braced = match.group("braced")
+        parenthesized = match.group("parenthesized")
+        bare = match.group("bare")
+        if marker == "^" and (braced is not None or parenthesized is not None):
+            converted = _convert_grouped_superscript_payload(braced or parenthesized or "")
+            if converted is None:
+                return match.group(0)
+            if parenthesized is not None:
+                return f"{_SUPERSCRIPT_MAP['(']}{converted}{_SUPERSCRIPT_MAP[')']}"
+            return converted
+
+        token = braced or bare
+        if parenthesized is not None:
+            token = f"({parenthesized})"
         if not token:
             log.debug("Unexpected empty LaTeX script token in %r", match.group(0))
             return match.group(0)
@@ -218,6 +253,86 @@ def _apply_unicode_scripts(text: str) -> str:
     return _UNICODE_SCRIPT.sub(replace, text)
 
 
+def _prepare_digit_base_grouped_superscripts(src: str) -> tuple[str, dict[str, str]]:
+    """Pre-convert digit-base grouped superscripts before pylatexenc strips braces."""
+    protected: dict[str, str] = {}
+
+    def replace(match: re.Match[str]) -> str:
+        parenthesized = match.group("parenthesized")
+        payload = match.group("braced") or parenthesized or ""
+        converted = _convert_grouped_superscript_payload(payload)
+        if converted is None:
+            sentinel = f"<<<GEODE_LATEX_SCRIPT_{len(protected)}>>>"
+            protected[sentinel] = match.group(0)
+            return sentinel
+        if parenthesized is not None:
+            converted = f"{_SUPERSCRIPT_MAP['(']}{converted}{_SUPERSCRIPT_MAP[')']}"
+        return f"{match.group('base')}{converted}"
+
+    return _DIGIT_BASE_GROUPED_SUPERSCRIPT.sub(replace, src), protected
+
+
+def _convert_grouped_superscript_payload(payload: str) -> str | None:
+    """Convert a braced/parenthesized superscript payload as one script unit.
+
+    Nested markers inside a superscript group inherit the outer superscript
+    direction: ``R_j`` in ``^(R_j)`` becomes ``ᴿʲ`` rather than ``ᴿⱼ``.
+    Whitespace inside the group is presentation-only and is dropped because
+    Unicode has no portable superscript space.
+    """
+    converted: list[str] = []
+    pos = 0
+    while pos < len(payload):
+        ch = payload[pos]
+        if ch.isspace():
+            pos += 1
+            continue
+        if ch in "_^":
+            token, next_pos = _read_script_token(payload, pos + 1)
+            if token is None:
+                return None
+            mapped_token = _map_script_chars(token, _SUPERSCRIPT_MAP)
+            if mapped_token is None:
+                return None
+            converted.append(mapped_token)
+            pos = next_pos
+            continue
+        mapped_ch = _SUPERSCRIPT_MAP.get(ch)
+        if mapped_ch is None:
+            return None
+        converted.append(mapped_ch)
+        pos += 1
+    return "".join(converted)
+
+
+def _read_script_token(payload: str, start: int) -> tuple[str | None, int]:
+    """Read a nested script token from ``payload`` starting after `_`/`^`."""
+    if start >= len(payload):
+        return None, start
+    opener = payload[start]
+    if opener in "({":
+        closer = ")" if opener == "(" else "}"
+        end = payload.find(closer, start + 1)
+        if end == -1:
+            return None, start
+        return payload[start + 1 : end], end + 1
+
+    end = start
+    while end < len(payload) and payload[end] in _SCRIPT_CHAR_CLASS:
+        end += 1
+    if end == start:
+        return None, start
+    return payload[start:end], end
+
+
+def _map_script_chars(token: str, script_map: dict[str, str]) -> str | None:
+    """Return ``token`` mapped through ``script_map`` or ``None`` atomically."""
+    mapped = [script_map.get(ch) for ch in token]
+    if any(ch is None for ch in mapped):
+        return None
+    return "".join(ch for ch in mapped if ch is not None)
+
+
 def _unsupported_script_presentation(
     text: str,
     match: re.Match[str],
@@ -225,9 +340,15 @@ def _unsupported_script_presentation(
     mapped: list[str | None],
 ) -> str | None:
     """Return a conservative no-raw-marker fallback for unsupported scripts."""
+    if match.group("marker") == "^" and (
+        match.group("braced") is not None or match.group("parenthesized") is not None
+    ):
+        return None
     if token.isascii() and token.isalpha() and token.islower() and len(token) > 1:
         return None
     has_partial_mapping = any(ch is not None for ch in mapped)
+    if has_partial_mapping and mapped.count(None) > len(mapped) // 2:
+        return None
     if not has_partial_mapping and not _script_base_looks_math(text, match.start()):
         return None
 
@@ -273,11 +394,14 @@ def _render_tier1(src: str) -> str:
         return src
     try:
         src = _DISPLAY_FRACTION_MACRO.sub(r"\\frac", src)
+        src, protected_scripts = _prepare_digit_base_grouped_superscripts(src)
         protected_src = _LATEX_LINEBREAK.sub(
             f" {_LATEX_LINEBREAK_SENTINEL} ",
             src,
         )
         raw: str = LatexNodes2Text().latex_to_text(protected_src).strip()
+        for sentinel, original in protected_scripts.items():
+            raw = raw.replace(sentinel, original)
         raw = _apply_unicode_scripts(raw)
         lines = [re.sub(r"\s+", " ", part).strip() for part in raw.split(_LATEX_LINEBREAK_SENTINEL)]
         return "\n".join(line for line in lines if line)
@@ -479,8 +603,8 @@ _UNICODE_TOKEN_HEAD = (
 )
 _DELIMITERLESS_MATH = re.compile(
     r"(?:"
-    # Braced subscript/superscript token (chained): r_{t-1}, P_{t+5}^{2}, ...
-    r"[A-Za-z][A-Za-z0-9]*"
+    # Braced subscript/superscript token (chained): r_{t-1}, 10^{2}, ...
+    r"(?:[A-Za-z][A-Za-z0-9]*|\d+)"
     r"(?:[_^]\{[^{}]+\})+"
     r"(?:[A-Za-z0-9]*[_^]\{[^{}]+\})*"
     r"|"
@@ -491,9 +615,10 @@ _DELIMITERLESS_MATH = re.compile(
     r"\\(?:" + "|".join(_MACRO_NAMES) + r")(?![A-Za-z])"
     r"(?:\{[^{}]*\}){0,3}"
     r"|"
-    # Bare script token in math-shaped context: y^ΔT_t,n, S^(i)_t,n,
-    # close_t,n, X_t-9:t,n,:. Filtered by _delimiterless_candidate_allowed.
-    r"[A-Za-z][A-Za-z0-9]*"
+    # Bare script token in math-shaped context: y^ΔT_t,n, 10^2,
+    # S^(i)_t,n, close_t,n, X_t-9:t,n,:. Filtered by
+    # _delimiterless_candidate_allowed.
+    r"(?:[A-Za-z][A-Za-z0-9]*|\d+)"
     rf"(?:[_^]{_SCRIPT_BODY})+"
     r"|"
     # Unicode math glyph adjacent to letters/digits/scripts: √x, α_i, ΔT,n.
@@ -597,6 +722,8 @@ def _delimiterless_candidate_allowed(text: str, start: int, end: int, token: str
     if any(ch in _UNICODE_MATH_GLYPHS for ch in token):
         return True
     if "_" in token or "^" in token:
+        if token[0].isdigit():
+            return "^" in token and _script_parts_look_index_like(token)
         return _script_parts_look_index_like(token) and _has_math_context(text, start, end, token)
     return False
 

--- a/tests/test_cli_latex_uiux.py
+++ b/tests/test_cli_latex_uiux.py
@@ -175,9 +175,22 @@ class TestStageAComponent:
         text = "E_i = 1/1 + 10^(R_j - R_i)/400"
         output = _render_through_helper(text)
         assert "Eᵢ" in output
-        assert "Rⱼ" in output
-        assert "Rᵢ" in output
+        assert "10⁽ᴿʲ⁻ᴿⁱ⁾" in output
         assert "R_i" not in output
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("10^2", "10²"),
+            ("10^-3", "10⁻³"),
+            ("10^(R_j - R_i)", "10⁽ᴿʲ⁻ᴿⁱ⁾"),
+            ("10^{R_j - R_i}", "10ᴿʲ⁻ᴿⁱ"),
+        ],
+    )
+    def test_delimiterless_digit_base_superscripts_render(self, text: str, expected: str) -> None:
+        output = _render_through_helper(text)
+        assert expected in output
+        assert "10[" not in output
 
     def test_delimiterless_elo_update_renders_each_subscript(self) -> None:
         text = "R_i' = R_i + K(S_i - E_i)"
@@ -194,8 +207,10 @@ class TestStageAComponent:
         assert "τ_P" not in output
 
     def test_delimiterless_plain_snake_case_stays_text(self) -> None:
-        output = _render_through_helper("snake_case_var")
+        output = _render_through_helper("snake_case_var and 1_000")
         assert "snake_case_var" in output
+        assert "1_000" in output
+        assert "1₀₀₀" not in output
 
     def test_delimiterless_macro_list(self) -> None:
         """Backslash macros from the allow-list render even without

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from core.ui.latex import (
+    _apply_unicode_scripts,
     _has_tier2_construct,
     _render_tier1,
     extract_and_render_inline,
@@ -43,6 +44,10 @@ class TestTier1Unicode:
             ("w_{12}", "w₁₂"),
             ("x^{2}", "x²"),
             ("x^123", "x¹²³"),
+            ("10^(R_j - R_i)", "10⁽ᴿʲ⁻ᴿⁱ⁾"),
+            ("10^{R_j - R_i}", "10ᴿʲ⁻ᴿⁱ"),
+            ("e^{x+1}", "eˣ⁺¹"),
+            ("e^(x+1)", "e⁽ˣ⁺¹⁾"),
         ],
     )
     def test_unicode_script_postprocess_supported_tokens(
@@ -59,6 +64,12 @@ class TestTier1Unicode:
 
     def test_unsupported_subscript_token_stays_raw(self) -> None:
         assert _render_tier1("h_∞") == "h_∞"
+
+    def test_complex_grouped_superscript_never_uses_bracket_fallback(self) -> None:
+        source = "10^{C_j - R_i}"
+        assert _apply_unicode_scripts(source) == source
+        assert _render_tier1(source) == source
+        assert list(extract_and_render_inline(source)) == [("inline_math", source)]
 
     def test_unsupported_uppercase_subscript_uses_bracket_presentation(self) -> None:
         assert _render_tier1("τ_P") == "τ[P]"
@@ -132,8 +143,24 @@ class TestMixedContent:
         chunks = list(extract_and_render_inline("E_i = 1/1 + 10^(R_j - R_i)/400"))
         inline_payloads = [payload for kind, payload in chunks if kind == "inline_math"]
         text_payloads = [payload for kind, payload in chunks if kind == "text"]
-        assert inline_payloads == ["Eᵢ", "Rⱼ", "Rᵢ"]
+        assert inline_payloads == ["Eᵢ", "10⁽ᴿʲ⁻ᴿⁱ⁾"]
         assert not any("R_i" in payload for payload in text_payloads)
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("10^2", "10²"),
+            ("10^-3", "10⁻³"),
+            ("10^(R_j - R_i)", "10⁽ᴿʲ⁻ᴿⁱ⁾"),
+            ("10^{R_j - R_i}", "10ᴿʲ⁻ᴿⁱ"),
+        ],
+    )
+    def test_delimiterless_digit_base_superscripts_render_as_single_math_segment(
+        self,
+        source: str,
+        expected: str,
+    ) -> None:
+        assert list(extract_and_render_inline(source)) == [("inline_math", expected)]
 
     def test_delimiterless_elo_update_segments_all_subscripts(self) -> None:
         chunks = list(extract_and_render_inline("R_i' = R_i + K(S_i - E_i)"))
@@ -195,6 +222,7 @@ class TestDelimiterlessMathWidening:
         "source",
         [
             "snake_case_var",
+            "1_000",
             "foo/bar/baz.py",
             "src/main.tsx",
             "**bold**",

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.95.3"
+version = "0.95.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Detector base 에 digit 허용 (`10^2`, `10^-3`, `10^(...)`)
- `_apply_unicode_scripts` 가 `^(payload)` 내부 nested `_X` 를 superscript 방향으로 재귀 변환 (Option b: `R_j` → `Rʲ`)
- bracket fallback 가드 — partial mapping 시 bracket 변환 금지, atomic raw 유지
- Codex MCP cross-LLM verify 통과

## Why
사용자 보고 (2026-05-16 fourth wave) probe 3건:
- `10^(R_j - R_i)` → `10^(` raw 노출 (detector base letter-only, group 처리 없음)
- `10^{R_j - R_i}` → `10[R_ʲ ⁻ R_ⁱ]` 깨진 출력 (bracket fallback bug)
- `10^2`, `10^-3` → tier1 변환 가능하지만 detector 가 segment 미캡처 → text 그대로

## Changes
| File | Change |
|------|--------|
| `core/ui/latex.py` | `_DELIMITERLESS_MATH` digit-base 확장 + `_apply_unicode_scripts` nested group 재귀 (Option b) + `_unsupported_script_presentation` bracket 가드 + digit-base preprocessor for grouped superscripts |
| `tests/test_ui_latex.py` | digit-base + grouped superscript + 1_000 false-positive 가드 regression |
| `tests/test_cli_latex_uiux.py` | end-to-end 7 케이스 |
| `CHANGELOG.md` | `[Unreleased]` Fixed (KR/EN) |

## Behavior Delta
| Input | Before | After |
|---|---|---|
| `10^(R_j - R_i)` | text raw `10^(...)` | `10⁽ᴿʲ⁻ᴿⁱ⁾` |
| `10^{R_j - R_i}` | broken `10[R_ʲ ⁻ R_ⁱ]` | `10ᴿʲ⁻ᴿⁱ` |
| `10^2` | text raw | `10²` |
| `10^-3` | text raw | `10⁻³` |
| `E_i = 1/1 + 10^(R_j - R_i)/400` | partial | `Eᵢ = 1/1 + 10⁽ᴿʲ⁻ᴿⁱ⁾/400` |
| `e^{x+1}` | `eˣ⁺¹` ✓ | unchanged |
| `e^(x+1)` | `e⁽ˣ⁺¹⁾` ✓ | unchanged |
| `1_000` | text ✓ | unchanged (thousands separator 보호) |
| `snake_case_var`, `foo/bar.py` | text ✓ | unchanged |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| digit-base detector | Implemented | math_context 가드로 `1_000` false-positive 차단 |
| nested superscript group (Option b) | Implemented | `R_j` inside `^(...)` → `Rʲ` (subscript form `Rⱼ` 가 아닌 superscript form) |
| bracket fallback bug 수정 | Implemented | partial mapping 시 bracket 금지, atomic raw |
| 기존 regression 없음 | Verified | 96 passed (test_ui_latex + test_cli_latex_uiux) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean (631 files)
- [x] `uv run mypy core/ plugins/` clean (365 files)
- [x] `uv run pytest tests/test_ui_latex.py tests/test_cli_latex_uiux.py` 96 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)

## Reference
- Series: #1193 (path-context + bracket) → **#1196 (digit-base + nested group + bracket bug)**
- 사용자 probe `10^(R_j - R_i)` → 진단 후 root cause 3건 동시 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)