### PR TITLE
release: v0.99.0 — owned-Anthropic OAuth PKCE + /login provider unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.0] — 2026-05-17
+
 ### Added
 
 - **`login_anthropic()` — owned-Anthropic OAuth PKCE flow (claude CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.98.0
+- **Version**: 0.99.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.98.0 — Long-running Autonomous Execution Harness
+# GEODE v0.99.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.98.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.98.0"
+version = "0.99.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- `[Unreleased]` → `[0.99.0]` stamp + 4-location version sync.
- 본 release 가 묶는 본 세션 PR — #1209 (auth removal) + #1210 (docs/spec) + #1211 (owned-Anthropic PKCE).

## Verification
- [x] CHANGELOG `[Unreleased]` 비움 + `[0.99.0]` 헤더 추가.
- [x] pyproject.toml `version = "0.99.0"`.
- [x] CLAUDE.md `**Version**: 0.99.0`.
- [x] README.md heading + 비교 표 2 곳 `v0.99.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)