### PR TITLE
fix(auth): Anthropic OAuth flow — loopback → manual-paste (v0.99.0 fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,35 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`login_anthropic()` — loopback redirect_uri → manual-paste 패턴 교체.**
+  v0.99.0 에서 도입된 loopback HTTP server (`http://localhost:54123/callback`)
+  는 OAuth client `9d1c250a-…` 에 등록된 redirect URI 가 아니라 authorize
+  단계에서 거절됐다 (사용자 보고 — 두 번 시도 모두 ~50초 만에 실패, auth.toml
+  미변경). Claude Code native binary 의 strings 분석으로 정답 redirect URI
+  가 `https://platform.claude.com/oauth/code/callback` 임을 확인 — 서버 측
+  callback 페이지가 사용자에게 `code#state` 형식을 표시하면 사용자가 CLI
+  로 paste 하는 manual-paste 패턴. `_run_anthropic_pkce_flow` 를 1:1
+  미러로 재작성: HTTPServer / `_pick_free_port` / 콜백 핸들러 제거, paste
+  파서 (`_parse_pasted_code` — URL/fragment/bare code 3 형식 수용) 도입,
+  scope 에 `user:sessions:claude_code` 추가 (binary hint 정합). Tier 3
+  impersonation 정책은 그대로.
+
+- **`login_anthropic()` — switched loopback redirect to manual-paste.**
+  v0.99.0's loopback HTTP server (`http://localhost:54123/callback`) was
+  rejected at the authorize step because the OAuth client `9d1c250a-…`
+  is registered with only one redirect URI:
+  `https://platform.claude.com/oauth/code/callback` (server-hosted).
+  Confirmed by `strings(8)` analysis of Claude Code's native binary +
+  user reports of two consecutive ~50s failures with no auth.toml write.
+  `_run_anthropic_pkce_flow` rewritten as a 1:1 mirror of Claude Code's
+  manual-paste flow: the loopback HTTP server, port picker, and request
+  handler are removed; a paste parser (`_parse_pasted_code`) accepts the
+  full callback URL, the `code#state` fragment, or the bare code; scope
+  set extended with `user:sessions:claude_code` per the binary's hint
+  string. Tier 3 impersonation posture unchanged.
+
 ## [0.99.0] — 2026-05-17
 
 ### Added

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -661,7 +661,10 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
     _pkg.console.print()
 
     try:
-        raw = input("  Paste authorization code: ").strip()
+        # /login is a THIN-handler command (see core.cli.routing — RunLocation.THIN),
+        # so this input() runs in the thin-client process where stdin is the user's
+        # terminal. Daemon never reaches this code path.
+        raw = input("  Paste authorization code: ").strip()  # allow-direct-io: thin-only OAuth manual-paste
     except (EOFError, KeyboardInterrupt) as exc:
         raise RuntimeError("Anthropic OAuth cancelled — no code provided") from exc
 

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -517,7 +517,8 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 # Mirrors :func:`login_openai` for the Anthropic side. The two providers
 # share the post-flow path (auth.toml SOT + ProfileStore.add) but use
 # different grant types — Codex's device-code endpoint vs Anthropic's
-# PKCE redirect (loopback callback). See
+# manual-paste PKCE (browser → /oauth/code/callback page renders code →
+# user pastes it back into the CLI). See
 # ``docs/architecture/provider-login.md`` for the full architecture.
 #
 # Endpoints reverse-engineered from the Claude Code native binary's
@@ -537,14 +538,20 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 _ANTHROPIC_AUTHORIZE_URL = "https://platform.claude.com/oauth/authorize"
 _ANTHROPIC_TOKEN_URL = "https://api.anthropic.com/v1/oauth/token"  # noqa: S105 — URL not password
 _ANTHROPIC_OAUTH_BETA_HEADER = "oauth-2025-04-20"
-_ANTHROPIC_REDIRECT_PORT_RANGE = (54123, 54199)  # avoid clash with /geode serve
-_ANTHROPIC_LOGIN_TIMEOUT_S = 5 * 60  # 5 min — user has to complete browser flow
+# The OAuth client `9d1c250a-...` is registered with this server-hosted
+# redirect URI only — loopback URIs (http://localhost:*) are rejected at
+# the authorize step. The /oauth/code/callback page renders the
+# authorization code so the user can copy & paste it back into the CLI.
+_ANTHROPIC_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
 
-# Scopes derived from the Claude Max OAuth token (`scopes` field).
-# All three are needed for inference + profile metadata + MCP servers.
+# Scope set mirrors Claude Code's hint string in the native binary:
+#   "user:profile user:inference user:sessions:claude_code user:mcp_servers"
+# Anthropic rejects authorize requests asking for scopes outside the
+# set registered for the client, so we send the full superset.
 _ANTHROPIC_DEFAULT_SCOPES = (
     "user:inference",
     "user:profile",
+    "user:sessions:claude_code",
     "user:mcp_servers",
 )
 
@@ -556,46 +563,6 @@ _ANTHROPIC_CLIENT_ID_CANDIDATES = (
     # Most likely: matches the well-known Claude Code OAuth client id.
     "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
 )
-
-
-class _AnthropicCallbackHandler:
-    """Loopback HTTP handler that captures the PKCE redirect callback.
-
-    Defined as a closure factory so the request handler can share the
-    ``captured`` dict with the outer :func:`_run_anthropic_pkce_flow`
-    without a module-level singleton.
-    """
-
-
-def _build_anthropic_callback_handler(captured: dict[str, str]) -> type:
-    """Return a request handler class that stores the ``code`` / ``state``
-    query parameters into the supplied ``captured`` dict."""
-    import urllib.parse
-    from http.server import BaseHTTPRequestHandler
-
-    class _Handler(BaseHTTPRequestHandler):
-        def log_message(self, fmt: str, *args: Any) -> None:
-            log.debug("anthropic-oauth callback: " + fmt, *args)
-
-        def do_GET(self) -> None:
-            parsed = urllib.parse.urlparse(self.path)
-            params = urllib.parse.parse_qs(parsed.query)
-            captured["code"] = params.get("code", [""])[0]
-            captured["state"] = params.get("state", [""])[0]
-            captured["error"] = params.get("error", [""])[0]
-            body = (
-                b"<!DOCTYPE html><html><body style='font-family:system-ui;padding:40px'>"
-                b"<h2>GEODE Anthropic OAuth</h2>"
-                b"<p>Login received. You can close this window and return to GEODE.</p>"
-                b"</body></html>"
-            )
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-    return _Handler
 
 
 def _generate_pkce_pair() -> tuple[str, str]:
@@ -618,99 +585,106 @@ def _generate_pkce_pair() -> tuple[str, str]:
     return verifier, challenge
 
 
-def _pick_free_port(port_range: tuple[int, int]) -> int:
-    """Find a free TCP port in ``[lo, hi]`` for the loopback callback."""
-    import socket
+def _parse_pasted_code(raw: str) -> tuple[str, str]:
+    """Extract ``(code, state)`` from a pasted authorization response.
 
-    lo, hi = port_range
-    for port in range(lo, hi + 1):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.bind(("127.0.0.1", port))
-                return port
-            except OSError:
-                continue
-    raise RuntimeError(f"Could not find a free port for the Anthropic OAuth callback in {lo}..{hi}")
+    The /oauth/code/callback page shows the value in ``code#state`` fragment
+    form (Claude Code's native binary uses the same split). Users may also
+    paste the full callback URL or the bare code on its own — we accept
+    all three. An empty returned state lets the caller skip CSRF check;
+    that is acceptable for a public PKCE flow where the verifier already
+    binds the request.
+    """
+    import urllib.parse
+
+    if raw.startswith(("http://", "https://")):
+        parsed = urllib.parse.urlparse(raw)
+        params = urllib.parse.parse_qs(parsed.query)
+        return params.get("code", [""])[0], params.get("state", [""])[0]
+    if "#" in raw:
+        code, _, state = raw.partition("#")
+        return code, state
+    return raw, ""
 
 
 def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
-    """Drive a single PKCE OAuth round with ``client_id``.
+    """Drive a single manual-paste PKCE OAuth round with ``client_id``.
 
-    Raises ``RuntimeError`` on token-exchange failure (so the caller can
-    fall through to the next candidate). Returns the parsed credentials
-    dict on success.
+    Mirrors Claude Code's native flow: open the authorize URL, wait for
+    the user to paste back the ``code#state`` value rendered on
+    ``/oauth/code/callback``. Raises ``RuntimeError`` on token-exchange
+    failure (so the caller can fall through to the next candidate).
     """
     import secrets
-    import threading
     import urllib.parse
     import webbrowser
-    from http.server import HTTPServer
 
     import httpx
 
+    from core.ui import agentic_ui as _pkg
+
     verifier, challenge = _generate_pkce_pair()
     state = secrets.token_urlsafe(16)
-    port = _pick_free_port(_ANTHROPIC_REDIRECT_PORT_RANGE)
-    redirect_uri = f"http://localhost:{port}/callback"
+    scope = " ".join(_ANTHROPIC_DEFAULT_SCOPES)
+    auth_url = (
+        _ANTHROPIC_AUTHORIZE_URL
+        + "?"
+        + urllib.parse.urlencode(
+            {
+                "code": "true",
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": _ANTHROPIC_REDIRECT_URI,
+                "scope": scope,
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }
+        )
+    )
 
-    captured: dict[str, str] = {}
-    handler_cls = _build_anthropic_callback_handler(captured)
-    server = HTTPServer(("127.0.0.1", port), handler_cls)
+    log.info("anthropic-oauth: opening browser (manual-paste flow)")
+    webbrowser.open(auth_url)
 
-    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-    server_thread.start()
+    _pkg.console.print()
+    _pkg.console.print(
+        "  [bold]A browser window has been opened to authorize with Anthropic.[/bold]"
+    )
+    _pkg.console.print(f"  [muted]If it didn't open, visit:[/muted] {auth_url}")
+    _pkg.console.print()
+    _pkg.console.print(
+        "  After approving, copy the code shown on the callback page and paste it below."
+    )
+    _pkg.console.print(
+        "  [muted]Accepted formats: 'code#state', the full callback URL, or just the code.[/muted]"
+    )
+    _pkg.console.print()
 
     try:
-        scope = " ".join(_ANTHROPIC_DEFAULT_SCOPES)
-        auth_url = (
-            _ANTHROPIC_AUTHORIZE_URL
-            + "?"
-            + urllib.parse.urlencode(
-                {
-                    "response_type": "code",
-                    "client_id": client_id,
-                    "redirect_uri": redirect_uri,
-                    "scope": scope,
-                    "state": state,
-                    "code_challenge": challenge,
-                    "code_challenge_method": "S256",
-                }
-            )
-        )
+        raw = input("  Paste authorization code: ").strip()
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise RuntimeError("Anthropic OAuth cancelled — no code provided") from exc
 
-        log.info("anthropic-oauth: opening browser to %s", _ANTHROPIC_AUTHORIZE_URL)
-        webbrowser.open(auth_url)
+    if not raw:
+        raise RuntimeError("Anthropic OAuth: empty code")
 
-        # Wait for the callback to populate ``captured`` (server runs on
-        # a background thread). We poll the captured dict because
-        # HTTPServer's serve_forever has no built-in "until first request"
-        # mode without subclassing.
-        deadline = time.monotonic() + _ANTHROPIC_LOGIN_TIMEOUT_S
-        while time.monotonic() < deadline:
-            if captured.get("code") or captured.get("error"):
-                break
-            time.sleep(0.25)
-    finally:
-        server.shutdown()
-        server.server_close()
-
-    if not captured.get("code"):
-        err = captured.get("error") or "timed out before user completed login"
-        raise RuntimeError(f"Anthropic OAuth callback returned no code: {err}")
-    if captured.get("state") != state:
+    auth_code, returned_state = _parse_pasted_code(raw)
+    if not auth_code:
+        raise RuntimeError("Anthropic OAuth: could not parse code from pasted value")
+    if returned_state and returned_state != state:
         raise RuntimeError("Anthropic OAuth state mismatch — possible CSRF, aborting")
 
-    # Token exchange (PKCE — public client, no client_secret).
     try:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             resp = client.post(
                 _ANTHROPIC_TOKEN_URL,
                 json={
                     "grant_type": "authorization_code",
-                    "code": captured["code"],
-                    "redirect_uri": redirect_uri,
+                    "code": auth_code,
+                    "redirect_uri": _ANTHROPIC_REDIRECT_URI,
                     "client_id": client_id,
                     "code_verifier": verifier,
+                    "state": state,
                 },
                 headers={
                     "Content-Type": "application/json",
@@ -721,8 +695,6 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
         raise RuntimeError(f"Anthropic token exchange failed: {exc}") from exc
 
     if resp.status_code != 200:
-        # Surface body so the caller can log the actual error class
-        # (``invalid_client`` / ``invalid_grant`` / ``unauthorized_client``).
         body_preview = resp.text[:300] if resp.text else "(empty)"
         raise RuntimeError(f"Anthropic token exchange returned {resp.status_code}: {body_preview}")
 

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -664,7 +664,7 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
         # /login is a THIN-handler command (see core.cli.routing — RunLocation.THIN),
         # so this input() runs in the thin-client process where stdin is the user's
         # terminal. Daemon never reaches this code path.
-        raw = input("  Paste authorization code: ").strip()  # allow-direct-io: thin-only OAuth manual-paste
+        raw = input("  Paste authorization code: ").strip()  # allow-direct-io: thin handler
     except (EOFError, KeyboardInterrupt) as exc:
         raise RuntimeError("Anthropic OAuth cancelled — no code provided") from exc
 

--- a/docs/architecture/provider-login.md
+++ b/docs/architecture/provider-login.md
@@ -17,7 +17,7 @@
 openai 분기          anthropic 분기        그 외 → warn
   ↓                     ↓
 login_openai()      login_anthropic()
-(device-code)       (PKCE redirect)
+(device-code)       (PKCE + manual-paste)
   ↓                     ↓
   POST /v1/oauth/token (모두)
             ↓
@@ -29,7 +29,7 @@ login_openai()      login_anthropic()
 ```
 
 두 provider 의 차이점은 **OAuth grant type** 만 — OpenAI = device-code,
-Anthropic = PKCE redirect. 그 외 (storage, refresh, client reset) 는
+Anthropic = PKCE + manual-paste. 그 외 (storage, refresh, client reset) 는
 모두 정합.
 
 ## 2. OpenAI flow (device-code grant) — 기존
@@ -46,21 +46,26 @@ Anthropic = PKCE redirect. 그 외 (storage, refresh, client reset) 는
 
 구현: `core/auth/oauth_login.py::login_openai`
 
-## 3. Anthropic flow (PKCE redirect grant) — 신규 (PR C3)
+## 3. Anthropic flow (PKCE + manual-paste) — PR C3 + v0.99.1 fix
+
+PR C3 의 초기 구현은 loopback callback (`http://localhost:54123/callback`)
+을 시도했으나, OAuth client `9d1c250a-…` 에 사전 등록된 redirect URI 는
+서버 측 `https://platform.claude.com/oauth/code/callback` 단 하나 — loopback
+은 authorize 단계에서 거절됨이 v0.99.1 에서 확인됐다. 우회는 불가하므로
+flow 를 Claude Code 의 manual-paste 패턴 1:1 미러로 교체.
 
 | 단계 | 동작 |
 |---|---|
 | 1 | `code_verifier = base64url(secrets.token_bytes(96))` |
 | 2 | `code_challenge = base64url(SHA256(code_verifier))` |
-| 3 | GEODE 가 loopback HTTP server `:3000` 시작 (callback 받기 위해) |
-| 4 | `webbrowser.open("https://platform.claude.com/oauth/authorize?response_type=code&client_id=<CLAUDE_OAUTH_CLIENT_ID>&redirect_uri=http://localhost:3000/callback&code_challenge=<challenge>&code_challenge_method=S256&scope=<space-separated>&state=<random>")` |
-| 5 | 사용자 browser 에서 Anthropic 로그인 + 동의 |
-| 6 | Anthropic 가 `GET http://localhost:3000/callback?code=...&state=...` |
-| 7 | GEODE callback server 가 `code` 수신, browser 에 "로그인 완료" HTML |
-| 8 | `POST https://api.anthropic.com/v1/oauth/token` (`anthropic-beta: oauth-2025-04-20` header) — grant_type=authorization_code, code, redirect_uri, client_id, code_verifier |
-| 9 | response: `access_token` (`sk-ant-oat01-...`), `refresh_token` (`sk-ant-ort01-...`), `expires_in`, `scopes` |
-| 10 | `~/.geode/auth.toml` 의 `[oauth.anthropic-claude-code]` section 에 저장 |
-| 11 | `reset_anthropic_client()` — `inspect_ai` stock `AnthropicAPI` per-request 라 cache 없음. claude-code provider 의 in-process state 만 invalidate |
+| 3 | `webbrowser.open("https://platform.claude.com/oauth/authorize?code=true&response_type=code&client_id=<CLAUDE_OAUTH_CLIENT_ID>&redirect_uri=https://platform.claude.com/oauth/code/callback&code_challenge=<challenge>&code_challenge_method=S256&scope=user:inference+user:profile+user:sessions:claude_code+user:mcp_servers&state=<random>")` |
+| 4 | 사용자 browser 에서 Anthropic 로그인 + 동의 |
+| 5 | Anthropic 가 `/oauth/code/callback` 페이지에서 `code#state` 형식 표시 |
+| 6 | 사용자가 CLI 의 `Paste authorization code:` 프롬프트에 paste (URL, `code#state`, 또는 bare code 모두 허용 — `_parse_pasted_code`) |
+| 7 | GEODE 가 state 검증 + `POST https://api.anthropic.com/v1/oauth/token` (`anthropic-beta: oauth-2025-04-20` header) — grant_type=authorization_code, code, redirect_uri, client_id, code_verifier, state |
+| 8 | response: `access_token` (`sk-ant-oat01-...`), `refresh_token` (`sk-ant-ort01-...`), `expires_in`, `scopes` |
+| 9 | `~/.geode/auth.toml` 의 `[providers.anthropic]` section 에 저장 |
+| 10 | `reset_anthropic_client()` — `inspect_ai` stock `AnthropicAPI` per-request 라 cache 없음. claude-code provider 의 in-process state 만 invalidate |
 
 ### 3.1 OAuth endpoints (Anthropic)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.98.0"
+version = "0.99.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Anthropic OAuth flow 를 loopback callback 에서 manual-paste 패턴으로 교체
- redirect_uri → `https://platform.claude.com/oauth/code/callback` (서버-호스트, OAuth client 에 등록됨)
- scope 에 `user:sessions:claude_code` 추가, token exchange 에 state 파라미터 포함

## Why

v0.99.0 의 `/login anthropic` 이 사용자 환경에서 실패. 사후 신호 4건 수집:

| 신호 | 값 | 의미 |
|---|---|---|
| CLI client connect → reload trigger 간격 | 1차 44s / 2차 54s | 5분 timeout 아님 — 빠른 실패 |
| `~/.geode/auth.toml` mtime | 5/13 (불변) | `_persist_oauth_to_authtoml` 도달 못 함 |
| port 54123-54199 listener | 없음 | flow 종료 (finally close OK) |
| serve log oauth 라인 | 0건 | thin CLI path 정상 |

**Root cause** — OAuth client `9d1c250a-…` 에 등록된 redirect URI 는 **`https://platform.claude.com/oauth/code/callback` 단 하나**. loopback `http://localhost:54123/callback` 은 authorize 단계에서 거절. Claude Code native binary `strings(8)` 분석 + 우리 OpenAI device-code flow 와의 비교 (3-way diff) 로 확정.

OpenAI 가 작동하는 이유는 device-code flow (RFC 8628) 자체가 서버-호스트 redirect 만 사용하기 때문 — redirect 등록 문제 자체가 발생할 여지 없음. Anthropic 도 동일하게 서버-호스트 redirect 를 쓰되, code 를 페이지에 렌더링해서 사용자가 paste 하는 manual-paste 패턴.

## Changes

| File | Change |
|------|--------|
| `core/auth/oauth_login.py` | `_run_anthropic_pkce_flow` 재작성 — HTTPServer / `_pick_free_port` / `_build_anthropic_callback_handler` / `_AnthropicCallbackHandler` 제거, `_parse_pasted_code` 추가 (URL/fragment/bare 3 형식), `_ANTHROPIC_REDIRECT_URI` 상수 도입, scope 에 `user:sessions:claude_code` 추가, token exchange 에 `state` 파라미터 추가 |
| `docs/architecture/provider-login.md` | 섹션 3 (Anthropic flow) 을 manual-paste 11-step 으로 갱신, v0.99.0 → v0.99.1 fix 컨텍스트 추가 |
| `CHANGELOG.md` | `[Unreleased]` → Fixed 섹션 (KR+EN 양언어) |
| `uv.lock` | geode `0.98.0 → 0.99.0` 정합화 (base develop 의 stale lockfile) |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| loopback HTTP server 제거 | Implemented | `_AnthropicCallbackHandler`, `_build_anthropic_callback_handler`, `_pick_free_port`, `_ANTHROPIC_REDIRECT_PORT_RANGE`, `_ANTHROPIC_LOGIN_TIMEOUT_S` 전부 삭제 |
| `_run_anthropic_pkce_flow` 재작성 | Implemented | manual-paste 으로 1:1 |
| `_parse_pasted_code` 신규 | Implemented | URL/fragment/bare 3 형식 robust parsing |
| scope 확장 | Implemented | `user:sessions:claude_code` 추가 |
| token exchange state 파라미터 | Implemented | Claude Code 패턴 정합 |
| Content-Type form-urlencoded 전환 | **Dropped** | secondary 의심 — root cause (redirect_uri) 해결 후 측정 우선. 만약 v0.99.1 시도에서 token exchange 4xx 나오면 v0.99.2 에서 토글 |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 364 source files
- [x] `uv run pytest tests/ -m "not live" -k "oauth or login or auth_toml"` — 145 passed, 2 pre-existing fails (env-dependent `to_inspect_model` cases on PR #1213 main, scope 밖)
- [ ] E2E `geode analyze "Cowboy Bebop" --dry-run` — OAuth path 와 무관 (analyze 는 ANTHROPIC_API_KEY)

## Reference

- 사용자 보고: v0.99.0 / `/login anthropic` 두 번 시도 실패 ~50초
- Claude Code native binary: `/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe` (206 MB Mach-O, v1.x)
- 발견 endpoint: `/oauth/code/callback`, `/oauth/code/success?app=claude-code` (binary strings)
- 비교 baseline: `core/auth/oauth_login.py::login_openai` (device-code RFC 8628, working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)