### PR TITLE
release: v0.99.2 — Anthropic OAuth token endpoint + Content-Type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,33 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.2] — 2026-05-17
+
+### Fixed
+
+- **`login_anthropic()` — token endpoint host + Content-Type + timeout 정정.**
+  v0.99.1 manual-paste fix 후에도 `/login anthropic` 가 `invalid_request`
+  로 거절. 사용자 콘솔 신호 + Claude Code native binary 의 prod env 객체
+  `K3q` 전체 추출 + 공식 문서 cross-check 로 3 가지 root cause 확정:
+  ① token endpoint host 가 `https://platform.claude.com/v1/oauth/token`
+  (`api.anthropic.com` 은 inference API 전용); ② Content-Type 은
+  `application/x-www-form-urlencoded` 만 허용 — `application/json` 으로
+  보내면 응답 지연/timeout 가능; ③ 응답 시간 40-60s 보고가 있어 client
+  timeout 을 15s → 60s 로 완화. `_ANTHROPIC_TOKEN_URL` 정정 + `json=` →
+  `data=` body 형식 변경 + httpx timeout 60s.
+
+- **`login_anthropic()` — corrected token endpoint host, Content-Type, and
+  timeout.** Post-v0.99.1 the manual-paste flow still failed with
+  `invalid_request`. Three root causes pinned down via the prod env object
+  `K3q` extracted from Claude Code's native binary plus cross-check with
+  official docs: ① OAuth audience lives on
+  `platform.claude.com/v1/oauth/token` (`api.anthropic.com` only serves
+  the inference API); ② endpoint accepts only
+  `application/x-www-form-urlencoded` — `application/json` causes hang/
+  timeout; ③ reported 40-60s response time under load, so client timeout
+  relaxed from 15s to 60s. Fixed `_ANTHROPIC_TOKEN_URL`, switched httpx
+  body from `json=` to `data=`, set Timeout(60).
+
 ## [0.99.1] — 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.1
+- **Version**: 0.99.2
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.1 — Long-running Autonomous Execution Harness
+# GEODE v0.99.2 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.1**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.2**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -522,10 +522,14 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 # ``docs/architecture/provider-login.md`` for the full architecture.
 #
 # Endpoints reverse-engineered from the Claude Code native binary's
-# strings on 2026-05-17:
+# ``K3q`` prod env object (strings(8) on 2026-05-17):
 #   authorize:   https://platform.claude.com/oauth/authorize
-#   token:       https://api.anthropic.com/v1/oauth/token
+#   token:       https://platform.claude.com/v1/oauth/token
+#   redirect:    https://platform.claude.com/oauth/code/callback
 #   beta header: anthropic-beta: oauth-2025-04-20
+# Note — ``api.anthropic.com/v1/oauth/token`` (initial guess in v0.99.0/0.99.1)
+# is NOT the token endpoint; that host serves the inference API only. The
+# OAuth audience lives on ``platform.claude.com``.
 #
 # Policy notice — ToS Tier 3 (impersonation): the flow reuses Claude
 # Code's public OAuth client_id (PKCE — no secret). Anthropic does not
@@ -536,7 +540,7 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 # token is consumed.
 
 _ANTHROPIC_AUTHORIZE_URL = "https://platform.claude.com/oauth/authorize"
-_ANTHROPIC_TOKEN_URL = "https://api.anthropic.com/v1/oauth/token"  # noqa: S105 — URL not password
+_ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"  # noqa: S105 — URL not password
 _ANTHROPIC_OAUTH_BETA_HEADER = "oauth-2025-04-20"
 # The OAuth client `9d1c250a-...` is registered with this server-hosted
 # redirect URI only — loopback URIs (http://localhost:*) are rejected at
@@ -678,10 +682,13 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
         raise RuntimeError("Anthropic OAuth state mismatch — possible CSRF, aborting")
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+        # 60s — Anthropic's platform.claude.com/v1/oauth/token has been reported to
+        # respond in 40-60s under load (community gist 3c9c7ff). Claude Code's
+        # hardcoded 15s timeout has been a known failure source; we relax it.
+        with httpx.Client(timeout=httpx.Timeout(60.0)) as client:
             resp = client.post(
                 _ANTHROPIC_TOKEN_URL,
-                json={
+                data={
                     "grant_type": "authorization_code",
                     "code": auth_code,
                     "redirect_uri": _ANTHROPIC_REDIRECT_URI,
@@ -690,7 +697,7 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
                     "state": state,
                 },
                 headers={
-                    "Content-Type": "application/json",
+                    "Content-Type": "application/x-www-form-urlencoded",
                     "anthropic-beta": _ANTHROPIC_OAUTH_BETA_HEADER,
                 },
             )

--- a/docs/architecture/provider-login.md
+++ b/docs/architecture/provider-login.md
@@ -62,7 +62,7 @@ flow 를 Claude Code 의 manual-paste 패턴 1:1 미러로 교체.
 | 4 | 사용자 browser 에서 Anthropic 로그인 + 동의 |
 | 5 | Anthropic 가 `/oauth/code/callback` 페이지에서 `code#state` 형식 표시 |
 | 6 | 사용자가 CLI 의 `Paste authorization code:` 프롬프트에 paste (URL, `code#state`, 또는 bare code 모두 허용 — `_parse_pasted_code`) |
-| 7 | GEODE 가 state 검증 + `POST https://api.anthropic.com/v1/oauth/token` (`anthropic-beta: oauth-2025-04-20` header) — grant_type=authorization_code, code, redirect_uri, client_id, code_verifier, state |
+| 7 | GEODE 가 state 검증 + `POST https://platform.claude.com/v1/oauth/token` (`anthropic-beta: oauth-2025-04-20` header) — grant_type=authorization_code, code, redirect_uri, client_id, code_verifier, state |
 | 8 | response: `access_token` (`sk-ant-oat01-...`), `refresh_token` (`sk-ant-ort01-...`), `expires_in`, `scopes` |
 | 9 | `~/.geode/auth.toml` 의 `[providers.anthropic]` section 에 저장 |
 | 10 | `reset_anthropic_client()` — `inspect_ai` stock `AnthropicAPI` per-request 라 cache 없음. claude-code provider 의 in-process state 만 invalidate |
@@ -74,8 +74,8 @@ flow 를 Claude Code 의 manual-paste 패턴 1:1 미러로 교체.
 | Endpoint | URL |
 |---|---|
 | Authorize | `https://platform.claude.com/oauth/authorize` |
-| Token | `https://api.anthropic.com/v1/oauth/token` |
-| Hello (validation) | `https://api.anthropic.com/v1/oauth/hello` |
+| Token | `https://platform.claude.com/v1/oauth/token` |
+| Manual redirect | `https://platform.claude.com/oauth/code/callback` |
 | Override env | `CLAUDE_CODE_CUSTOM_OAUTH_URL` |
 
 ### 3.2 client_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.1"
+version = "0.99.2"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.1"
+version = "0.99.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.2 patch — 3 root cause fix (token endpoint host / Content-Type / timeout) for `/login anthropic`. PR #1217 누적.

## Verification

- [x] PR #1217 CI 7/7 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)