### PR TITLE
ci(phase 1): paths-filter + pytest-xdist + draft skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,14 @@ jobs:
       # covered — pushing total coverage below the 75% ratchet).
       - if: needs.changes.outputs.code == 'true'
         run: uv sync --extra audit
-      - name: Run tests with coverage (xdist parallel)
+      - name: Run tests with coverage (xdist parallel, loadfile)
         if: needs.changes.outputs.code == 'true'
-        run: uv run pytest -n auto --cov=core --cov-report=term-missing
+        # --dist=loadfile pins same-file tests to the same worker. Without
+        # it, xdist can split TestAutoLearnHandler.{test_saves_pattern_on_match,
+        # test_cooldown_prevents_rapid_fire} across workers — those two share
+        # module-level state (cooldown timestamp), producing a flaky
+        # FAILURE on develop→main PR #1220 (2026-05-17).
+        run: uv run pytest -n auto --dist=loadfile --cov=core --cov-report=term-missing
       - name: Ratchet — minimum test count
         if: needs.changes.outputs.code == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,57 +5,116 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Phase 1 (v0.99.x) — path-filter dispatch so docs-only / blog-only PRs
+  # skip the heavy lint/type/test steps below. Required-status-check names
+  # stay stable (Lint & Format / Type Check / Test / Security Scan / Gate)
+  # so branch protection keeps passing; only the inner steps short-circuit
+  # when ``changes.code != 'true'``. Pattern mirrored from OpenClaw +
+  # Hermes (frontier survey 2026-05-17).
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'core/**'
+              - 'plugins/**'
+              - 'tests/**'
+              - 'autoresearch/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/**'
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
+    needs: changes
     steps:
+      - name: Skip — no code change
+        if: needs.changes.outputs.code != 'true'
+        run: echo "::notice::Docs-only PR — skipping lint."
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.code == 'true'
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync
-      - run: uv run ruff check core/ tests/ plugins/ autoresearch/
-      - run: uv run ruff format --check core/ tests/ plugins/ autoresearch/
+        if: needs.changes.outputs.code == 'true'
+      - if: needs.changes.outputs.code == 'true'
+        run: uv sync
+      - if: needs.changes.outputs.code == 'true'
+        run: uv run ruff check core/ tests/ plugins/ autoresearch/
+      - if: needs.changes.outputs.code == 'true'
+        run: uv run ruff format --check core/ tests/ plugins/ autoresearch/
       - name: Dependency drift (deptry)
+        if: needs.changes.outputs.code == 'true'
         run: uv run deptry .
       - name: Legacy import ratchet
+        if: needs.changes.outputs.code == 'true'
         run: uv run python scripts/check_legacy_imports.py --base-ref origin/develop
       - name: Repo hygiene ratchet
+        if: needs.changes.outputs.code == 'true'
         run: uv run python scripts/check_repo_hygiene.py
       - name: Petri bundle ratchet
+        if: needs.changes.outputs.code == 'true'
         run: uv run python scripts/validate_petri_bundle.py
 
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    needs: changes
     steps:
+      - name: Skip — no code change
+        if: needs.changes.outputs.code != 'true'
+        run: echo "::notice::Docs-only PR — skipping typecheck."
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.code == 'true'
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync
-      - run: uv run mypy core/ plugins/ autoresearch/
+        if: needs.changes.outputs.code == 'true'
+      - if: needs.changes.outputs.code == 'true'
+        run: uv sync
+      - if: needs.changes.outputs.code == 'true'
+        run: uv run mypy core/ plugins/ autoresearch/
       - name: Prompt integrity check
+        if: needs.changes.outputs.code == 'true'
         run: uv run python -c "from core.llm.prompts import verify_prompt_integrity; verify_prompt_integrity(raise_on_drift=True)"
 
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: changes
     steps:
+      - name: Skip — no code change
+        if: needs.changes.outputs.code != 'true'
+        run: echo "::notice::Docs-only PR — skipping tests."
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.code == 'true'
       - uses: astral-sh/setup-uv@v5
+        if: needs.changes.outputs.code == 'true'
       # [audit] extra installs inspect_ai so tests/audit/ runs (otherwise
       # ``pytest.importorskip("inspect_ai.log")`` skips those modules
       # and the petri-bookkeeping code in core/audit/ shows up as 0%
       # covered — pushing total coverage below the 75% ratchet).
-      - run: uv sync --extra audit
-      - name: Run tests with coverage
-        run: uv run pytest --cov=core --cov-report=term-missing
+      - if: needs.changes.outputs.code == 'true'
+        run: uv sync --extra audit
+      - name: Run tests with coverage (xdist parallel)
+        if: needs.changes.outputs.code == 'true'
+        run: uv run pytest -n auto --cov=core --cov-report=term-missing
       - name: Ratchet — minimum test count
+        if: needs.changes.outputs.code == 'true'
         run: |
           count=$(uv run pytest --co -q 2>/dev/null | tail -1 | grep -oE '[0-9]+' | head -1)
           echo "Test count: $count"
@@ -67,11 +126,19 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    needs: changes
     steps:
+      - name: Skip — no code change
+        if: needs.changes.outputs.code != 'true'
+        run: echo "::notice::Docs-only PR — skipping security scan."
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.code == 'true'
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync
-      - run: uv run bandit -r core/ -c pyproject.toml
+        if: needs.changes.outputs.code == 'true'
+      - if: needs.changes.outputs.code == 'true'
+        run: uv sync
+      - if: needs.changes.outputs.code == 'true'
+        run: uv run bandit -r core/ -c pyproject.toml
 
   gate:
     name: Gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,27 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **CI Phase 1 — path-filter + pytest-xdist + draft skip.** Hermes 와
+  OpenClaw frontier 패턴 차용 (frontier survey 2026-05-17). `dorny/paths-filter@v3`
+  로 변경된 경로를 검출하여 docs-only/blog-only PR 은 lint/type/test/security
+  step 을 즉시 short-circuit (job 자체는 success 마킹되도록 step-level `if:`
+  사용 — branch protection required-status-check 호환). 코드 변경 PR 은
+  `pytest -n auto` 로 xdist 병렬 실행 (~3분 → ~1분 예상). `types:
+  [opened, reopened, synchronize, ready_for_review]` 로 draft PR 은 trigger
+  자체 차단. `pytest-xdist>=3.6.0` 을 `[dependency-groups.dev]` 에 추가.
+
+- **CI Phase 1 — path-filter + pytest-xdist + draft skip.** Adopted
+  patterns from Hermes and OpenClaw frontier survey (2026-05-17).
+  `dorny/paths-filter@v3` detects changed paths; docs-only / blog-only
+  PRs short-circuit the lint/type/test/security steps via step-level
+  `if:` (jobs still report success so branch-protection required-status
+  checks pass). Code-touching PRs run `pytest -n auto` (xdist) — expect
+  ~3min → ~1min. Draft PRs no longer trigger CI thanks to the new
+  `types: [..., ready_for_review]` filter. `pytest-xdist>=3.6.0` added
+  to the dev dependency group.
+
 ## [0.99.2] — 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ dev = [
     "yamllint>=1.38.0",
     "pytest>=9.0.2",
     "pytest-cov>=6.0.0",
+    "pytest-xdist>=3.6.0",
     "ruff>=0.15.2",
     "types-pyyaml>=6.0.12.20250915",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -946,6 +946,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1235,6 +1244,7 @@ dev = [
     { name = "pymarkdownlnt" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "yamllint" },
@@ -1289,6 +1299,7 @@ dev = [
     { name = "pymarkdownlnt", specifier = ">=0.9.37" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "yamllint", specifier = ">=1.38.0" },
@@ -4480,6 +4491,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

CI Phase 1 (paths-filter + xdist + draft skip) develop → main. PR #1219 누적.

3 frontier 패턴 차용 (Hermes + OpenClaw):
- `dorny/paths-filter@v3` — docs-only PR 은 lint/type/test/security short-circuit
- `pytest -n auto` — xdist 병렬
- `types: [..., ready_for_review]` — draft PR 은 CI trigger 안 함

## Verification

- [x] PR #1219 CI 8/8 통과 (자기 dogfooding 으로 새 ci.yml 검증)
- [x] `Detect changes` job 정상 등장 + 코드 변경 분류로 full course 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)