### PR TITLE
ci(phase 1.1): xdist --dist=loadfile (flaky test_auto_learn fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,14 @@ jobs:
       # covered — pushing total coverage below the 75% ratchet).
       - if: needs.changes.outputs.code == 'true'
         run: uv sync --extra audit
-      - name: Run tests with coverage (xdist parallel)
+      - name: Run tests with coverage (xdist parallel, loadfile)
         if: needs.changes.outputs.code == 'true'
-        run: uv run pytest -n auto --cov=core --cov-report=term-missing
+        # --dist=loadfile pins same-file tests to the same worker. Without
+        # it, xdist can split TestAutoLearnHandler.{test_saves_pattern_on_match,
+        # test_cooldown_prevents_rapid_fire} across workers — those two share
+        # module-level state (cooldown timestamp), producing a flaky
+        # FAILURE on develop→main PR #1220 (2026-05-17).
+        run: uv run pytest -n auto --dist=loadfile --cov=core --cov-report=term-missing
       - name: Ratchet — minimum test count
         if: needs.changes.outputs.code == 'true'
         run: |


### PR DESCRIPTION
## Summary

PR #1219 의 xdist 도입 후 `tests/test_auto_learn.py::TestAutoLearnHandler` 가 flaky — `--dist=loadfile` 추가로 same-file tests 를 same-worker 고정.

## Why

PR #1220 (develop→main, v0.99.x ci phase 1) 의 Test job 이 **같은 commit 에서 두 번 다른 결과**:

| Run | 결과 | 시간 |
|---|---|---|
| 25977110601 | FAILURE | ~100s |
| 25977112329 | SUCCESS | ~100s |

FAIL 한 테스트 2건:
- `test_saves_pattern_on_match` — `Expected 'add_learned_pattern' to have been called once. Called 0 times.`
- `test_cooldown_prevents_rapid_fire` — `assert 0 == 1`

**원인**: `TestAutoLearnHandler` 안의 두 테스트가 cooldown 관련 module-level state 를 공유. pytest-xdist 의 default `--dist=load` 가 두 테스트를 다른 worker 에 분산 → state isolation 깨짐 → flaky.

`--dist=loadfile` 은 xdist 표준 옵션: 같은 file 의 테스트를 같은 worker 에 고정. 추가 의존성 없음.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Test step: `pytest -n auto` → `pytest -n auto --dist=loadfile` + 주석 |

## Verification

- [x] local sanity: `pytest tests/test_auto_learn.py -n 2 --dist=loadfile -q` 27 passed
- [ ] CI: 본 PR 의 Test job 에서 flaky 사라짐 확인

## Reference

- PR #1220 25977110601 (FAIL) / 25977112329 (SUCCESS) — same commit
- [pytest-xdist `--dist=loadfile` docs](https://pytest-xdist.readthedocs.io/en/stable/distribution.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)