### PR TITLE
fix(hooks): cooldown timestamp init float('-inf') (flaky test_auto_learn root cause)

### DIFF
--- a/core/hooks/auto_learn.py
+++ b/core/hooks/auto_learn.py
@@ -179,9 +179,18 @@ def make_auto_learn_handler(
 
     Returns (handler_name, handler_fn) for hook registration.
     """
-    # Per-session state (resets on process restart)
+    # Per-session state (resets on process restart).
+    #
+    # ``last_learn_ts = float("-inf")`` so the first call always passes the
+    # cooldown gate, regardless of how recently the process started. The
+    # previous init ``0.0`` assumed ``time.monotonic()`` was already past
+    # ``_COOLDOWN_S`` — true for long-lived servers, false for short-lived
+    # pytest-xdist worker processes that the ``load`` distribution strategy
+    # spins up fresh. That mismatch produced flaky failures in
+    # ``tests/test_auto_learn.py::TestAutoLearnHandler`` on PR #1220
+    # (2026-05-17, same commit, two CI runs — one PASS, one FAIL).
     session_count = 0
-    last_learn_ts = 0.0
+    last_learn_ts: float = float("-inf")
     tool_counter: Counter[str] = Counter()
 
     def _get_profile() -> Any:

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -174,7 +174,10 @@ def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
     """
     turn_count = 0
     session_extractions = 0
-    last_extract_ts = 0.0
+    # ``float("-inf")`` so the first call always passes the cooldown gate.
+    # Mirrors the auto_learn fix — fresh xdist worker processes have small
+    # ``time.monotonic()`` values that would otherwise trip the cooldown.
+    last_extract_ts: float = float("-inf")
     _seen_inputs: set[int] = set()  # hash of already-extracted user inputs
 
     def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

PR #1220 의 flaky 의 root cause fix. `--dist=loadfile` (PR #1221) 은 workaround — 본 PR 이 실제 원인 해결. 둘 다 유지 (다층 방어).

## Why

PR #1220 의 Test job 이 같은 commit 에서 두 번 다른 결과 (FAILURE / SUCCESS). 분석:

```python
# core/hooks/auto_learn.py
last_learn_ts = 0.0  # init
...
now = time.monotonic()
if now - last_learn_ts < _COOLDOWN_S:  # 60s
    return  # ← first call 도 suppress
```

`time.monotonic()` 의 epoch 는 process 별:
- 장기 daemon: process start 후 60s+ 흐른 뒤 호출 → cooldown 통과
- **xdist `--dist=load` worker**: fresh process → `time.monotonic()` 이 0+ε 작은 값 → `now - 0.0 < 60` → cooldown trip → `add_learned_pattern` 0번 call → AssertionError

`--dist=load` (default) 는 round-robin 으로 test class 단위 분산 — `TestAutoLearnHandler` 가 fresh worker 에 가면 fail. `--dist=loadfile` 은 같은 file 의 tests 를 같은 worker 에 묶음 → 다른 tests 가 먼저 도는 사이 `time.monotonic()` 이 충분히 흐름 → 우연히 통과.

## Fix

`last_learn_ts: float = float("-inf")` — 첫 호출 시 `now - (-inf) = inf > _COOLDOWN_S` 무조건 true → cooldown 통과, process boot 시점과 무관. `llm_extract_learning.py` 의 `last_extract_ts` 도 같은 패턴이라 같이 fix.

## Changes

| File | Change |
|------|--------|
| `core/hooks/auto_learn.py` | `last_learn_ts = 0.0` → `float("-inf")` + 주석 (PR #1220 사례 기록) |
| `core/hooks/llm_extract_learning.py` | 동일 패턴 `last_extract_ts` 도 같이 fix |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Root cause fix | Implemented | `float("-inf")` init |
| Defense-in-depth (PR #1221 loadfile) | Preserved | 다층 방어 — 향후 동일 패턴이 다른 file 에 생겨도 same-worker 보장 |
| llm_extract_learning 동일 패턴 | Fixed | 회귀 가능성 차단 |

## Verification

- [x] sanity: `pytest tests/test_auto_learn.py -n 2 -q` 27 passed (default `--dist=load`, fix 적용 후)
- [x] ruff clean, mypy clean
- [ ] CI 본 PR 의 Test job 통과 (xdist 환경 검증)

## Reference

- PR #1220 25977110601 (FAIL) / 25977112329 (SUCCESS) — same commit, different worker process age
- PR #1221 (loadfile workaround, merged) — defense-in-depth 측면 그대로 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)