### PR TITLE
fix(hooks): flaky test_auto_learn root cause + ci phase 1.1 loadfile

### DIFF
--- a/core/hooks/auto_learn.py
+++ b/core/hooks/auto_learn.py
@@ -179,9 +179,18 @@ def make_auto_learn_handler(
 
     Returns (handler_name, handler_fn) for hook registration.
     """
-    # Per-session state (resets on process restart)
+    # Per-session state (resets on process restart).
+    #
+    # ``last_learn_ts = float("-inf")`` so the first call always passes the
+    # cooldown gate, regardless of how recently the process started. The
+    # previous init ``0.0`` assumed ``time.monotonic()`` was already past
+    # ``_COOLDOWN_S`` — true for long-lived servers, false for short-lived
+    # pytest-xdist worker processes that the ``load`` distribution strategy
+    # spins up fresh. That mismatch produced flaky failures in
+    # ``tests/test_auto_learn.py::TestAutoLearnHandler`` on PR #1220
+    # (2026-05-17, same commit, two CI runs — one PASS, one FAIL).
     session_count = 0
-    last_learn_ts = 0.0
+    last_learn_ts: float = float("-inf")
     tool_counter: Counter[str] = Counter()
 
     def _get_profile() -> Any:

--- a/core/hooks/llm_extract_learning.py
+++ b/core/hooks/llm_extract_learning.py
@@ -174,7 +174,10 @@ def make_llm_extract_handler() -> tuple[str, Callable[..., None]]:
     """
     turn_count = 0
     session_extractions = 0
-    last_extract_ts = 0.0
+    # ``float("-inf")`` so the first call always passes the cooldown gate.
+    # Mirrors the auto_learn fix — fresh xdist worker processes have small
+    # ``time.monotonic()`` values that would otherwise trip the cooldown.
+    last_extract_ts: float = float("-inf")
     _seen_inputs: set[int] = set()  # hash of already-extracted user inputs
 
     def _on_turn_complete(event: HookEvent, data: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

CI Phase 1 후 발견된 flaky test 의 root cause fix. PR #1221 (loadfile workaround) + PR #1222 (root cause `float("-inf")`) 누적.

| PR | 종류 |
|---|---|
| #1221 | xdist `--dist=loadfile` workaround (다층 방어 그대로 유지) |
| #1222 | root cause — `last_learn_ts`/`last_extract_ts` 초기값 `0.0` → `float("-inf")`. fresh xdist worker 의 작은 `time.monotonic()` 과 충돌 회피 |

## Verification

- [x] PR #1222 CI 8/8 통과
- [x] sanity: `pytest tests/test_auto_learn.py -n 2 -q` 27 passed (default `--dist=load`)
- [x] ruff/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)