### PR TITLE
fix(auth): Anthropic OAuth token exchange JSON 복귀 (v0.99.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,31 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.3] — 2026-05-17
+
+### Fixed
+
+- **`login_anthropic()` — token exchange body 형식 JSON 복귀 + `anthropic-beta`
+  헤더 제거.** v0.99.2 가 `application/x-www-form-urlencoded` 로 변경하고
+  `anthropic-beta: oauth-2025-04-20` 를 추가했으나 사용자 시도 결과 여전히
+  `invalid_request`. ../openclaw + ../claude-code 그라운딩 + Claude Code
+  native binary 의 `h6.post(TOKEN_URL, z, {headers:{"Content-Type":
+  "application/json"}, timeout:30000})` 호출 자체를 추출하여 ground truth
+  확인:  Content-Type 은 JSON, beta 헤더는 token endpoint 에 보내지 않음.
+  v0.99.0/0.99.1 의 JSON 패턴 자체는 맞았으나 host (`api.anthropic.com`)
+  가 틀렸던 것 — v0.99.2 가 host fix 와 함께 Content-Type 까지 의심해서
+  잘못된 방향으로 바꾼 셈. 공식 docs / community gist 의 "form-urlencoded"
+  정보가 정확하지 않다는 결론.
+
+- **`login_anthropic()` — reverted token exchange body to JSON + dropped
+  `anthropic-beta` header.** Even after the v0.99.2 host fix the user
+  still saw `invalid_request`. Grounding against the openclaw + claude-code
+  source trees plus extracting the actual `h6.post` call site from
+  claude.exe (`{"Content-Type":"application/json"}`, no beta header)
+  confirmed the binary is the ground truth: JSON-only on the token
+  endpoint, no anthropic-beta. Public docs and community gists are
+  incorrect on this point.
+
 ### Infrastructure
 
 - **CI Phase 1 — path-filter + pytest-xdist + draft skip.** Hermes 와

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.2
+- **Version**: 0.99.3
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.2 — Long-running Autonomous Execution Harness
+# GEODE v0.99.3 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.2**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.3**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -521,15 +521,20 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 # user pastes it back into the CLI). See
 # ``docs/architecture/provider-login.md`` for the full architecture.
 #
-# Endpoints reverse-engineered from the Claude Code native binary's
-# ``K3q`` prod env object (strings(8) on 2026-05-17):
-#   authorize:   https://platform.claude.com/oauth/authorize
-#   token:       https://platform.claude.com/v1/oauth/token
-#   redirect:    https://platform.claude.com/oauth/code/callback
-#   beta header: anthropic-beta: oauth-2025-04-20
-# Note — ``api.anthropic.com/v1/oauth/token`` (initial guess in v0.99.0/0.99.1)
-# is NOT the token endpoint; that host serves the inference API only. The
-# OAuth audience lives on ``platform.claude.com``.
+# Endpoints + body shape reverse-engineered from the Claude Code native
+# binary (claude.exe strings on 2026-05-17, prod env object ``K3q`` plus
+# the ``h6.post(TOKEN_URL, ...)`` call site):
+#   authorize:    https://platform.claude.com/oauth/authorize
+#   token:        https://platform.claude.com/v1/oauth/token
+#   redirect:     https://platform.claude.com/oauth/code/callback
+#   Content-Type: application/json (body = JSON object, NOT form-urlencoded)
+#   no anthropic-beta header on the token endpoint
+# Note — ``api.anthropic.com/v1/oauth/token`` (v0.99.0/0.99.1) is NOT the
+# token endpoint; that host serves the inference API only. The OAuth
+# audience lives on ``platform.claude.com``. Public docs + community
+# gists incorrectly suggested form-urlencoded + an anthropic-beta header
+# (v0.99.2 followed that lead and still got ``invalid_request``). The
+# binary is the ground truth.
 #
 # Policy notice — ToS Tier 3 (impersonation): the flow reuses Claude
 # Code's public OAuth client_id (PKCE — no secret). Anthropic does not
@@ -541,7 +546,6 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 
 _ANTHROPIC_AUTHORIZE_URL = "https://platform.claude.com/oauth/authorize"
 _ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"  # noqa: S105 — URL not password
-_ANTHROPIC_OAUTH_BETA_HEADER = "oauth-2025-04-20"
 # The OAuth client `9d1c250a-...` is registered with this server-hosted
 # redirect URI only — loopback URIs (http://localhost:*) are rejected at
 # the authorize step. The /oauth/code/callback page renders the
@@ -682,13 +686,17 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
         raise RuntimeError("Anthropic OAuth state mismatch — possible CSRF, aborting")
 
     try:
-        # 60s — Anthropic's platform.claude.com/v1/oauth/token has been reported to
-        # respond in 40-60s under load (community gist 3c9c7ff). Claude Code's
-        # hardcoded 15s timeout has been a known failure source; we relax it.
+        # Body shape + headers reverse-engineered from Claude Code's native
+        # binary (claude.exe `h6.post(TOKEN_URL, z, {headers:{"Content-Type":
+        # "application/json"}, timeout:30000})`). Earlier guesses based on
+        # public docs / community gists pointed at form-urlencoded + an
+        # ``anthropic-beta`` header on the token endpoint; the binary
+        # disproves both — JSON only, no beta header. 30s is the upstream
+        # timeout; we keep 60s as headroom for slow-network cases.
         with httpx.Client(timeout=httpx.Timeout(60.0)) as client:
             resp = client.post(
                 _ANTHROPIC_TOKEN_URL,
-                data={
+                json={
                     "grant_type": "authorization_code",
                     "code": auth_code,
                     "redirect_uri": _ANTHROPIC_REDIRECT_URI,
@@ -696,10 +704,7 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
                     "code_verifier": verifier,
                     "state": state,
                 },
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "anthropic-beta": _ANTHROPIC_OAUTH_BETA_HEADER,
-                },
+                headers={"Content-Type": "application/json"},
             )
     except Exception as exc:
         raise RuntimeError(f"Anthropic token exchange failed: {exc}") from exc

--- a/docs/architecture/provider-login.md
+++ b/docs/architecture/provider-login.md
@@ -62,7 +62,7 @@ flow 를 Claude Code 의 manual-paste 패턴 1:1 미러로 교체.
 | 4 | 사용자 browser 에서 Anthropic 로그인 + 동의 |
 | 5 | Anthropic 가 `/oauth/code/callback` 페이지에서 `code#state` 형식 표시 |
 | 6 | 사용자가 CLI 의 `Paste authorization code:` 프롬프트에 paste (URL, `code#state`, 또는 bare code 모두 허용 — `_parse_pasted_code`) |
-| 7 | GEODE 가 state 검증 + `POST https://platform.claude.com/v1/oauth/token` (`anthropic-beta: oauth-2025-04-20` header) — grant_type=authorization_code, code, redirect_uri, client_id, code_verifier, state |
+| 7 | GEODE 가 state 검증 + `POST https://platform.claude.com/v1/oauth/token` (`Content-Type: application/json`, no `anthropic-beta` header — claude.exe binary 의 `h6.post` 호출 site 와 정합) — JSON body: grant_type=authorization_code, code, redirect_uri, client_id, code_verifier, state |
 | 8 | response: `access_token` (`sk-ant-oat01-...`), `refresh_token` (`sk-ant-ort01-...`), `expires_in`, `scopes` |
 | 9 | `~/.geode/auth.toml` 의 `[providers.anthropic]` section 에 저장 |
 | 10 | `reset_anthropic_client()` — `inspect_ai` stock `AnthropicAPI` per-request 라 cache 없음. claude-code provider 의 in-process state 만 invalidate |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.2"
+version = "0.99.3"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.2"
+version = "0.99.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.2 의 form-urlencoded + `anthropic-beta` 헤더 변경 후에도 `/login anthropic` 여전히 `invalid_request`. ../openclaw + ../claude-code 그라운딩 + Claude Code native binary 의 `h6.post` 호출 site 자체 추출로 ground truth 확인 — **Content-Type=JSON, no anthropic-beta header**.

| 차원 | v0.99.0/0.99.1 | v0.99.2 | **v0.99.3** | Claude Code binary |
|---|---|---|---|---|
| host | api.anthropic.com (틀림) | platform.claude.com ✓ | platform.claude.com ✓ | platform.claude.com |
| Content-Type | application/json | application/x-www-form-urlencoded | **application/json** | application/json |
| `anthropic-beta` 헤더 | 포함 | 포함 | **제거** | (없음) |
| body 형식 | JSON | form-data | **JSON** | JSON object (z) |
| httpx timeout | 15s | 60s | 60s | 30s (binary) |

## Why

사용자 보고: v0.99.2 시도 결과 여전히 `invalid_request`. ../openclaw 와 ../claude-code-ref 그라운딩 + Claude Code native binary 의 token exchange 호출 site 자체 추출:

```js
await h6.post(
  Iq().TOKEN_URL,                                 // platform.claude.com/v1/oauth/token
  z,                                              // body = JSON object: {grant_type, code, redirect_uri, client_id, code_verifier, state}
  { headers: { "Content-Type": "application/json" }, timeout: 30000 }
);
```

OpenClaw 의 `extensions/anthropic/stream-wrappers.ts` 의 `anthropic-beta` header (`claude-code-20250219,oauth-2025-04-20`) 는 **inference (`/v1/messages`) 호출** 에 한정. token endpoint 에는 beta header 안 보냄. 공식 docs + community gist 의 "form-urlencoded only" 정보가 정확하지 않은 것으로 확인 — **binary 가 ground truth**.

v0.99.0/0.99.1 의 JSON 자체는 맞았으나 host (`api.anthropic.com`) 가 틀렸음. v0.99.2 가 host fix 와 함께 의심 범위를 Content-Type 까지 확대해서 잘못된 방향으로 변경한 셈.

## Changes

| File | Change |
|------|--------|
| `core/auth/oauth_login.py` | `data=` → `json=` 복귀, Content-Type `application/json`, `anthropic-beta` header 제거, `_ANTHROPIC_OAUTH_BETA_HEADER` 상수 제거 (token endpoint 한정 unused), endpoint comment 정정 |
| `docs/architecture/provider-login.md` | step 7 정정 — JSON body + beta header 없음 명시 |
| `CHANGELOG.md` | `[0.99.3]` Fixed 섹션 (KR+EN) |
| `pyproject.toml`, `CLAUDE.md`, `README.md` | 0.99.2 → 0.99.3 |
| `uv.lock` | editable geode 0.99.3 정합 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Content-Type JSON 복귀 | Implemented | httpx `json=` + header |
| anthropic-beta 헤더 제거 | Implemented | token endpoint 에는 불필요 |
| Beta header 상수 제거 | Implemented | dead constant 정리 |
| Body shape | Unchanged | grant_type/code/redirect_uri/client_id/code_verifier/state — binary 와 일치 |

## Verification

- [x] ruff/mypy clean
- [x] 4-location version sync (0.99.3)
- [ ] CI 7/7
- [ ] **사용자 live trial — main 머지 + rebuild 후 `/login anthropic`**

## Reference

- Claude Code native binary `h6.post(TOKEN_URL, z, {headers:{"Content-Type":"application/json"}, timeout:30000})` (strings 추출, 2026-05-17)
- ../openclaw/src/agents/anthropic-transport-stream.ts — `anthropic-beta` 는 inference `/v1/messages` 한정
- 사용자 보고: v0.99.2 `/login anthropic` → "Invalid Request format" 지속

🤖 Generated with [Claude Code](https://claude.com/claude-code)