### PR TITLE
feat(auth): forensic dump on Anthropic OAuth token exchange failure (v0.99.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,29 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.4] — 2026-05-17
+
+### Observability
+
+- **`login_anthropic()` — token exchange 실패 시 forensic dump 추가.**
+  v0.99.3 에서도 사용자 시도 결과 `invalid_request` 지속. `script` 캡처 없이
+  사후 root cause 분석을 가능하게 하려면 영구 dump 필요.
+  `~/.geode/diagnostics/anthropic-oauth-<unix_ts>.json` 으로 (a) endpoint,
+  (b) status_code, (c) response body 전체, (d) response headers, (e) 우리가
+  보낸 request 의 client_id / redirect_uri / scope / code 접두 8자 /
+  verifier 접두 8자 / state 접두 6자 기록. `code_verifier` 같은 민감 값은
+  접두만 — 응답 body 의 `error_description` 이 root cause 진단의 핵심.
+  콘솔 `body_preview` 도 300 → 500 자로 확대.
+
+- **`login_anthropic()` — added forensic dump on token exchange failure.**
+  v0.99.3 still surfaced `invalid_request` and the user could not capture
+  the response via `script`. The flow now persists
+  `~/.geode/diagnostics/anthropic-oauth-<unix_ts>.json` containing (a)
+  endpoint, (b) status_code, (c) full response body, (d) response headers,
+  and (e) sanitized request metadata (client_id, redirect_uri, scope,
+  truncated code/verifier/state prefixes). Console preview also widens
+  from 300 → 500 chars.
+
 ## [0.99.3] — 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.3
+- **Version**: 0.99.4
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.3 — Long-running Autonomous Execution Harness
+# GEODE v0.99.4 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.3**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.4**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -710,7 +710,44 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
         raise RuntimeError(f"Anthropic token exchange failed: {exc}") from exc
 
     if resp.status_code != 200:
-        body_preview = resp.text[:300] if resp.text else "(empty)"
+        # Persist a forensic dump so root-cause analysis does not depend on
+        # the user re-running the flow under ``script``. Tokens are not
+        # part of the request, the response body on a 4xx is the OAuth
+        # error_description we need, and the only sensitive value in
+        # the request body (``code_verifier``) is masked to its prefix.
+        try:
+            import json as _json
+            from pathlib import Path as _Path
+
+            dump_dir = _Path.home() / ".geode" / "diagnostics"
+            dump_dir.mkdir(parents=True, exist_ok=True)
+            dump_path = dump_dir / f"anthropic-oauth-{int(time.time())}.json"
+            dump_path.write_text(
+                _json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "endpoint": _ANTHROPIC_TOKEN_URL,
+                        "status_code": resp.status_code,
+                        "response_body": resp.text,
+                        "response_headers": dict(resp.headers),
+                        "request": {
+                            "client_id": client_id,
+                            "redirect_uri": _ANTHROPIC_REDIRECT_URI,
+                            "scope": scope,
+                            "code_prefix": auth_code[:8] + "...",
+                            "verifier_prefix": verifier[:8] + "...",
+                            "state_prefix": state[:6] + "...",
+                        },
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            log.warning("anthropic-oauth: failure dumped → %s", dump_path)
+        except Exception:
+            log.debug("anthropic-oauth: failure dump write failed", exc_info=True)
+
+        body_preview = resp.text[:500] if resp.text else "(empty)"
         raise RuntimeError(f"Anthropic token exchange returned {resp.status_code}: {body_preview}")
 
     return dict(resp.json())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.3"
+version = "0.99.4"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.3"
+version = "0.99.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.3 의 token exchange JSON fix 후에도 사용자 시도 결과 `invalid_request` 지속. 사용자가 `script` 캡처 없이 시도 → 사후 진단 신호 0건. **forensic dump** 추가로 다음 시도 1회로 root cause 확정 가능하도록.

## Why

세션에서 사용자가 `/login anthropic` 을 시도 → 콘솔에 `RuntimeError(Anthropic token exchange returned <status>: <body>)` 떴지만 PID 가 죽으면 캡처 사후 접근 불가. `script` 명령 가이드도 거치지 않음.

`~/.geode/diagnostics/2026-05.log` 는 petri 전용이고 serve daemon log 는 thin path 라 oauth 흐름 안 찍힘. 즉 v0.99.3 코드는 이미 binary 와 1:1 일치하는데도 `invalid_request` 가 나오는 root cause 진단 불가 상태.

응답 body 의 `error_description` 만 잡으면 H1 (state in body) / H2 (paste 잘못 파싱) / H3 (scope 거절) / H4 (redirect mismatch → invalid_grant) / H5 (code 잘림) 어느 가설인지 즉시 결정.

## Changes

| File | Change |
|------|--------|
| `core/auth/oauth_login.py` | `_run_anthropic_pkce_flow` 의 `status_code != 200` 분기에 `~/.geode/diagnostics/anthropic-oauth-<unix_ts>.json` dump 추가. body_preview 300 → 500 |
| `CHANGELOG.md` | `[0.99.4]` Observability 섹션 (KR+EN) |
| `pyproject.toml`, `CLAUDE.md`, `README.md` | 0.99.3 → 0.99.4 |
| `uv.lock` | editable geode 0.99.4 정합 |

## Dump 구조

```json
{
  "ts": <unix>,
  "endpoint": "https://platform.claude.com/v1/oauth/token",
  "status_code": 400,
  "response_body": "<server 의 error_description 전체>",
  "response_headers": {...},
  "request": {
    "client_id": "9d1c250a-...",
    "redirect_uri": "https://platform.claude.com/oauth/code/callback",
    "scope": "user:inference user:profile user:sessions:claude_code user:mcp_servers",
    "code_prefix": "abc12345...",
    "verifier_prefix": "qrs45678...",
    "state_prefix": "xyz789..."
  }
}
```

`code_verifier` 같은 민감값은 8자 접두만 — 응답 body 의 `error_description` 이 진단 핵심이라 충분.

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| forensic dump | Implemented | ~/.geode/diagnostics/ |
| sensitive value 마스킹 | Implemented | code/verifier/state 접두 8자만 |
| 콘솔 body_preview 확대 | Implemented | 300 → 500 |
| body shape 변경 | Dropped | 이번 PR scope 밖. dump 결과 보고 다음 PR 에서 결정 |

## Verification

- [x] ruff/mypy clean
- [x] 4-location version sync (0.99.4)
- [ ] CI 7/7
- [ ] **사용자 live trial** — main 머지 + rebuild 후 `/login anthropic` 1회. 실패 시 `cat ~/.geode/diagnostics/anthropic-oauth-*.json | tail -1` 결과만 인용해주시면 곧장 다음 fix

## Reference

- v0.99.3 후 사용자 보고: "여전히 invalid"
- 사용자 thin CLI PID 77339 활성, ttys003, 11:14AM 시작 — 콘솔 출력 사후 접근 불가
- ~/.geode/diagnostics/ 가 forensic dump 의 GEODE convention 위치 ([memory/feedback_fa4_temp_location.md](https://github.com/mangowhoiscloud/geode))

🤖 Generated with [Claude Code](https://claude.com/claude-code)