### PR TITLE
fix(test): isolate _build_model_card lru_cache between tests (CI regression)

### DIFF
--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -57,6 +57,7 @@ def _clear_model_card_cache() -> Any:
     yield
     _build_model_card.cache_clear()
 
+
 # ---------------------------------------------------------------------------
 # Contract 1 — model card asserts identity strongly
 # ---------------------------------------------------------------------------

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -1,5 +1,15 @@
 """v0.52.8 — model identity must not leak across `/model` switches.
 
+v0.99.5 (2026-05-17) — added autouse fixture to clear
+``_build_model_card`` ``@lru_cache(maxsize=8)`` before each test. After
+the async-only refactor (main 2026-05-17 db2a2bf3), some other test in
+the same xdist `loadfile` worker can trigger ``_build_model_card`` 's
+exception path (``return ""`` at the bottom of the ``try``) when a
+``core.config`` lazy import is mocked or fails; that empty result lands
+in the lru_cache and a later run of ``test_model_card_for_anthropic_model``
+hits the cached ``""``. Clearing the cache per test isolates the unit
+behavior under test from any cross-test cache pollution.
+
 Production incident 2026-04-27: User issued ``/model gpt-5.5`` and the
 LLM (running on gpt-5.5, daemon log confirmed) responded
 "현재 사용 중인 모델은 gpt-5.4-mini" (claimed to be the previous model).
@@ -30,8 +40,23 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 import core.agent.loop as _loop_mod
 from core.agent.system_prompt import _build_model_card
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_card_cache() -> Any:
+    """Isolate ``_build_model_card`` 's ``@lru_cache`` between tests.
+
+    See module docstring for the cross-test cache pollution this guards
+    against. Clear on both setup and teardown so neighbours can't poison
+    each other regardless of test order.
+    """
+    _build_model_card.cache_clear()
+    yield
+    _build_model_card.cache_clear()
 
 # ---------------------------------------------------------------------------
 # Contract 1 — model card asserts identity strongly

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -40,9 +40,8 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 import core.agent.loop as _loop_mod
+import pytest
 from core.agent.system_prompt import _build_model_card
 
 


### PR DESCRIPTION
## Summary

PR #1227 (async-only refactor merge) 이후 CI 의 `tests/test_model_identity.py::test_model_card_for_anthropic_model` 가 consistent fail. local 통과 / CI fail = xdist 환경 의존성. root cause 분석 후 autouse fixture 로 cache 격리.

## Why

CI 로그 분석:
```
[gw1] linux -- ...
tests/test_model_identity.py:76: in test_model_card_for_anthropic_model
    assert "<model_card>" in card
E   AssertionError: assert '<model_card>' in ''
```

`_build_model_card` 코드 (`core/agent/system_prompt.py:224-314`):

```python
@lru_cache(maxsize=8)
def _build_model_card(model: str) -> str:
    try:
        from core.config import _resolve_provider
        # ... build parts ...
        return "<model_card>\n" + "\n".join(parts) + "\n</model_card>"
    except Exception:
        log.debug("Failed to build model card", exc_info=True)
        return ""
```

**Mechanism**:
1. xdist `--dist=loadfile` 정책 — 같은 file 의 test 는 같은 worker. 다른 file 의 test 는 round-robin 분산
2. 같은 worker (`gw1`) 에 들어간 다른 test 가 `_build_model_card("claude-opus-4-7")` 를 호출하는 시점에 `core.config` 의 lazy import 가 mock 으로 fail
3. `try/except` 의 `return ""` path 진입 → empty string 이 lru_cache 에 캐싱
4. 후속 `test_model_card_for_anthropic_model` 가 cache hit → `""` 반환 → fail

local 통과는 분산 패턴이 우연히 다른 worker 라 cache pollution 회피.

main 자체 CI 도 fail (run 25979485671) — async-only refactor (`db2a2bf3`) 가 `core.config` 의 lazy import 패턴 변경으로 mock-fail path 자주 hit 시킴.

## Fix

`tests/test_model_identity.py` 에 autouse fixture 추가:

```python
@pytest.fixture(autouse=True)
def _clear_model_card_cache() -> Any:
    _build_model_card.cache_clear()
    yield
    _build_model_card.cache_clear()
```

매 test setup/teardown 에서 cache clear → 다른 test 의 cache pollution 격리.

production `@lru_cache(maxsize=8)` 유지 (G8 2026-05-12 의 의도된 최적화).

## Changes

| File | Change |
|------|--------|
| `tests/test_model_identity.py` | autouse fixture 추가 + import re-order + 모듈 docstring 에 root cause 기록 |

## Verification

- [x] local `pytest tests/test_model_identity.py -n 2 --dist=loadfile` 9/9 pass
- [x] ruff clean
- [ ] CI 본 PR 의 Test 통과

## Reference

- 회귀 발견: PR #1228 (forensic dump v0.99.5) 의 Test 4회 연속 fail
- async-only refactor: `db2a2bf3 refactor: make tool loop async-only`
- lru_cache 도입: G8 2026-05-12 (`core/agent/system_prompt.py:224`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)