### PR TITLE
feat(ui): rich.Padding for OAuth console output (wrap-safe + indent)

### DIFF
--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -654,17 +654,35 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
     log.info("anthropic-oauth: opening browser (manual-paste flow)")
     webbrowser.open(auth_url)
 
+    # rich.Padding preserves the left indent when the terminal wraps a long
+    # line (e.g. the auth_url at ~250 chars). Hard-coded ``"  "`` prefixes
+    # only apply to the first wrapped line and produce a column-0 jag on
+    # the rest. ``(top, right, bottom, left) = (0, 0, 0, 2)`` mirrors the
+    # 2-space indent the rest of the OAuth UX uses.
+    from rich.padding import Padding as _Padding
+
+    _indent = (0, 0, 0, 2)
     _pkg.console.print()
     _pkg.console.print(
-        "  [bold]A browser window has been opened to authorize with Anthropic.[/bold]"
+        _Padding(
+            "[bold]A browser window has been opened to authorize with Anthropic.[/bold]",
+            _indent,
+        )
     )
-    _pkg.console.print(f"  [muted]If it didn't open, visit:[/muted] {auth_url}")
+    _pkg.console.print(_Padding(f"[muted]If it didn't open, visit:[/muted] {auth_url}", _indent))
     _pkg.console.print()
     _pkg.console.print(
-        "  After approving, copy the code shown on the callback page and paste it below."
+        _Padding(
+            "After approving, copy the code shown on the callback page and paste it below.",
+            _indent,
+        )
     )
     _pkg.console.print(
-        "  [muted]Accepted formats: 'code#state', the full callback URL, or just the code.[/muted]"
+        _Padding(
+            "[muted]Accepted formats: 'code#state', the full callback URL, "
+            "or just the code.[/muted]",
+            _indent,
+        )
     )
     _pkg.console.print()
 

--- a/core/ui/agentic_ui/events.py
+++ b/core/ui/agentic_ui/events.py
@@ -298,21 +298,31 @@ def emit_oauth_login_started(provider: str, verification_uri: str, user_code: st
             user_code=user_code,
         )
         return
+    # rich.Padding preserves the left indent when the terminal wraps a long
+    # line. Hard-coded ``"  "`` / ``"     "`` prefixes only paint the first
+    # wrapped line; wrap continuations jag back to column 0.
+    from rich.padding import Padding as _Padding
+
+    _l1 = (0, 0, 0, 2)  # primary indent (numbered step, status line)
+    _l2 = (0, 0, 0, 5)  # nested indent (URL/code under a step)
+
     _pkg.console.print()
-    _pkg.console.print(f"  [header]{provider} OAuth Login[/header]")
+    _pkg.console.print(_Padding(f"[header]{provider} OAuth Login[/header]", _l1))
     _pkg.console.print()
-    _pkg.console.print("  1. Open this URL in your browser:")
-    _pkg.console.print(f"     [link]{verification_uri}[/link]")
+    _pkg.console.print(_Padding("1. Open this URL in your browser:", _l1))
+    _pkg.console.print(_Padding(f"[link]{verification_uri}[/link]", _l2))
     _pkg.console.print()
-    _pkg.console.print("  2. Enter this code:")
-    _pkg.console.print(f"     [bold yellow]{user_code}[/bold yellow]")
+    _pkg.console.print(_Padding("2. Enter this code:", _l1))
+    _pkg.console.print(_Padding(f"[bold yellow]{user_code}[/bold yellow]", _l2))
     _pkg.console.print()
     if verification_uri:
-        _pkg.console.print("  [muted]Press \\[Enter] to open the URL in your browser.[/muted]")
+        _pkg.console.print(
+            _Padding("[muted]Press \\[Enter] to open the URL in your browser.[/muted]", _l1)
+        )
         from core.ui.oauth_browser import start_oauth_browser_watcher
 
         start_oauth_browser_watcher(verification_uri)
-    _pkg.console.print("  [muted]Waiting for sign-in... (Ctrl+C to cancel)[/muted]")
+    _pkg.console.print(_Padding("[muted]Waiting for sign-in... (Ctrl+C to cancel)[/muted]", _l1))
     _pkg.console.print()
 
 
@@ -349,14 +359,18 @@ def emit_oauth_login_success(
             stored_at=stored_at,
         )
         return
+    from rich.padding import Padding as _Padding
+
+    _l1 = (0, 0, 0, 2)
+    _l2 = (0, 0, 0, 4)
     _pkg.console.print()
-    _pkg.console.print(f"  [success]✓ {provider} login successful[/success]")
+    _pkg.console.print(_Padding(f"[success]✓ {provider} login successful[/success]", _l1))
     if email or account_id:
-        _pkg.console.print(f"  [muted]  Account:[/muted] {email or account_id}")
+        _pkg.console.print(_Padding(f"[muted]Account:[/muted] {email or account_id}", _l2))
     if plan_type:
-        _pkg.console.print(f"  [muted]  Plan:[/muted] {plan_type}")
+        _pkg.console.print(_Padding(f"[muted]Plan:[/muted] {plan_type}", _l2))
     if stored_at:
-        _pkg.console.print(f"  [muted]  Stored:[/muted] {stored_at}")
+        _pkg.console.print(_Padding(f"[muted]Stored:[/muted] {stored_at}", _l2))
     _pkg.console.print()
 
 
@@ -372,8 +386,12 @@ def emit_oauth_login_failed(provider: str, reason: str) -> None:
             reason=reason,
         )
         return
+    from rich.padding import Padding as _Padding
+
     _pkg.console.print()
-    _pkg.console.print(f"  [error]✗ {provider} login failed:[/error] {reason}")
+    _pkg.console.print(
+        _Padding(f"[error]✗ {provider} login failed:[/error] {reason}", (0, 0, 0, 2))
+    )
     _pkg.console.print()
 
 


### PR DESCRIPTION
## Summary

`/login anthropic` 의 manual-paste flow + `emit_oauth_login_*` 출력의 들여쓰기가 터미널 창이 좁을 때 wrap 시 무너지는 문제 fix. `rich.Padding` 으로 교체해 wrap 시 left padding 유지.

## Why

사용자 보고: "터미널 창 크기 변화에도 유연하게 렌더링하도록 수정 부탁해. 들여쓰기되는 라인들도 많아서 그쪽도 형식이 무너지지 않게 다듬으면 좋아."

기존 코드:
```python
_pkg.console.print("  [bold]A browser window has been opened...[/bold]")
_pkg.console.print(f"  [muted]If it didn't open, visit:[/muted] {auth_url}")
```

문제: `"  "` hard-coded prefix 가 첫 라인에만 그려지고, rich 가 wrap 한 후속 라인은 column 0 부터 시작. `auth_url` 같이 ~250 chars 의 긴 line 에서 jag 두드러짐.

`rich.Padding(text, (0, 0, 0, indent))` 은 wrap 시에도 left padding 유지 — wrap 후속 라인도 indent column 부터 시작.

## Changes

| File | Function | Indent levels |
|------|----------|---|
| `core/auth/oauth_login.py` | `_run_anthropic_pkce_flow` manual-paste prompts | `_indent = (0, 0, 0, 2)` |
| `core/ui/agentic_ui/events.py` | `emit_oauth_login_started` | `_l1 = 2` (step), `_l2 = 5` (URL/code) |
| `core/ui/agentic_ui/events.py` | `emit_oauth_login_success` | `_l1 = 2` (header), `_l2 = 4` (account/plan/stored) |
| `core/ui/agentic_ui/events.py` | `emit_oauth_login_failed` | `2` |

다른 `emit_*` (budget/retry/cost/...) 은 같은 패턴 — 별도 PR (scope 정합성).

## GAP Audit

| Item | Status |
|------|--------|
| manual-paste flow Padding | Implemented (5 prints) |
| emit_oauth_login_started Padding | Implemented (nested 2/5) |
| emit_oauth_login_success Padding | Implemented (nested 2/4) |
| emit_oauth_login_failed Padding | Implemented |
| 다른 emit_* 함수 wrap-safe | Dropped (별도 PR) |

## Verification

- [x] ruff/mypy clean
- [ ] CI 통과
- [ ] **사용자 시각적 확인** — `/login anthropic` 실행 시 터미널 너비 변경해도 indent 깨짐 없음

## Reference

- 사용자 보고: 본 세션
- rich Padding docs: https://rich.readthedocs.io/en/stable/padding.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)