### PR TITLE
release: v0.99.6 — Anthropic authorize host fix (Claude.ai consumer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,29 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.6] — 2026-05-17
+
+### Fixed
+
+- **`login_anthropic()` — authorize URL host 변경 (`platform.claude.com` → `claude.com/cai`).**
+  v0.99.5 forensic dump 가 token exchange 단계 dump 0건 — 사용자 보고 결과
+  authorize 단계에서 "Invalid Request Format" 거절. Claude Code binary 의
+  authorize URL 생성 코드 `O ? CLAUDE_AI_AUTHORIZE_URL : CONSOLE_AUTHORIZE_URL`
+  분기에서 우리가 항상 CONSOLE URL 사용한 것이 root cause. Claude Max
+  (consumer) 사용자는 `claude.com/cai/oauth/authorize` 가 정답.
+  token endpoint (`platform.claude.com/v1/oauth/token`) 는 그대로 유지.
+
+- **`login_anthropic()` — switched authorize host from `platform.claude.com`
+  to `claude.com/cai` for Claude.ai consumer accounts.** v0.99.5 forensic
+  dumps showed no `response-*` stages — server-side authorize page
+  rejected the request with "Invalid Request Format" before any callback.
+  Claude Code's binary picks one of two authorize hosts via
+  `loginMethod`; we now mirror the Claude Pro / Max consumer branch
+  by default (`claude.com/cai/oauth/authorize`). Token endpoint
+  unchanged.
+
+
+
 ## [0.99.5] — 2026-05-17
 
 ### Observability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.5
+- **Version**: 0.99.6
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.5 — Long-running Autonomous Execution Harness
+# GEODE v0.99.6 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.5**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.6**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -544,7 +544,19 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 # :mod:`plugins.petri_audit.claude_code_provider` once the resulting
 # token is consumed.
 
-_ANTHROPIC_AUTHORIZE_URL = "https://platform.claude.com/oauth/authorize"
+# Claude Code branches the authorize host on the user's account type:
+#   ``O ? CLAUDE_AI_AUTHORIZE_URL : CONSOLE_AUTHORIZE_URL``
+# where ``O`` is the ``loginMethod`` boolean. Console URL serves Anthropic
+# developer/team accounts on ``platform.claude.com``; the Claude.ai URL
+# serves Claude Pro / Max consumer subscriptions on ``claude.com``.
+#
+# v0.99.0..0.99.5 used CONSOLE only — Claude.ai Max users received the
+# server-side error "Invalid Request Format" because the public OAuth
+# client (``9d1c250a-...``) is registered against the ``claude.com``
+# origin for consumer subscriptions. v0.99.6 switches the default to
+# CLAUDE_AI; future patch may add a ``/login source console`` toggle
+# for users whose access lives on ``platform.claude.com``.
+_ANTHROPIC_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 _ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"  # noqa: S105 — URL not password
 # Mirrors Claude Code binary's ``HA()`` helper (``claude-code/${VERSION}``).
 # v0.99.5 added this header explicitly to keep our request fingerprint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.5"
+version = "0.99.6"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.5"
+version = "0.99.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.6 patch — `_ANTHROPIC_AUTHORIZE_URL` host 변경 (`platform.claude.com` → `claude.com/cai`). Claude Max consumer 가입자 routing 정합. PR #1232 누적.

## Verification

- [x] PR #1232 CI 8/8 통과
- [x] binary ground truth 분석 (CONSOLE_AUTHORIZE_URL vs CLAUDE_AI_AUTHORIZE_URL)
- [x] 4-location version sync (0.99.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)