### PR TITLE
fix(auth): authorize claude.ai + redirect console.anthropic.com (Hermes parity) (v0.99.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.7] — 2026-05-17
+
+### Fixed
+
+- **`login_anthropic()` — authorize host `claude.ai` + `login_method=claudeai` query.**
+  v0.99.6 의 `claude.com/cai/oauth/authorize` 가 server-side 로
+  `claude.ai/oauth/authorize` redirect 되었고 (사용자 browser URL 인용)
+  거기서도 "Invalid request format". claude.exe binary 의
+  `searchParams.append("login_method", $)` 분기에서 `$` 가
+  `"claudeai"` / `"console"` 중 하나로 값을 갖는데 우리가 빠뜨려
+  server 가 분기를 알지 못한 것이 root cause. v0.99.7: host 를 redirect
+  의 final destination `claude.ai` 로 직접, `login_method=claudeai`
+  query 추가, dump 의 `authorize_url_full` 도 같이 기록.
+
+- **`login_anthropic()` — switched authorize host to `claude.ai` and
+  added `login_method=claudeai` query.** v0.99.6's
+  `claude.com/cai/oauth/authorize` was server-side redirected to
+  `claude.ai/oauth/authorize` (confirmed from user's browser URL) and
+  still returned "Invalid request format". Claude Code's binary
+  appends a `login_method` query (`claudeai` for consumer flow,
+  `console` for developer); we now mirror it. The forensic dump also
+  records the full `authorize_url` so future investigation does not
+  depend on the user reading the URL out of the browser bar.
+
+
+
 ## [0.99.6] — 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.6
+- **Version**: 0.99.7
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.6 — Long-running Autonomous Execution Harness
+# GEODE v0.99.7 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.6**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.7**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -556,7 +556,11 @@ def read_geode_openai_credentials() -> dict[str, Any] | None:
 # origin for consumer subscriptions. v0.99.6 switches the default to
 # CLAUDE_AI; future patch may add a ``/login source console`` toggle
 # for users whose access lives on ``platform.claude.com``.
-_ANTHROPIC_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
+# v0.99.7 — server redirects ``claude.com/cai/oauth/authorize`` →
+# ``claude.ai/oauth/authorize`` (cai path deprecated; user confirmed
+# from the actual browser URL). Short-circuit one HTTP hop by pointing
+# at the final URL directly.
+_ANTHROPIC_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
 _ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"  # noqa: S105 — URL not password
 # Mirrors Claude Code binary's ``HA()`` helper (``claude-code/${VERSION}``).
 # v0.99.5 added this header explicitly to keep our request fingerprint
@@ -651,6 +655,11 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
     verifier, challenge = _generate_pkce_pair()
     state = secrets.token_urlsafe(16)
     scope = " ".join(_ANTHROPIC_DEFAULT_SCOPES)
+    # v0.99.7 — added ``login_method=claudeai`` from claude.exe binary's
+    # ``if($) append("login_method", $)`` site. The binary's ``$`` defaults
+    # to ``"claudeai"`` on the Claude.ai consumer path (vs ``"console"``
+    # for the Anthropic developer portal). Without this param the
+    # claude.ai server appears to return "Invalid request format".
     auth_url = (
         _ANTHROPIC_AUTHORIZE_URL
         + "?"
@@ -664,11 +673,12 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
                 "state": state,
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
+                "login_method": "claudeai",
             }
         )
     )
 
-    log.info("anthropic-oauth: opening browser (manual-paste flow)")
+    log.info("anthropic-oauth: opening browser (manual-paste flow): %s", auth_url)
     webbrowser.open(auth_url)
 
     # rich.Padding preserves the left indent when the terminal wraps a long
@@ -724,6 +734,8 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
                 "ts": ts,
                 "stage": stage,
                 "endpoint": _ANTHROPIC_TOKEN_URL,
+                "authorize_endpoint": _ANTHROPIC_AUTHORIZE_URL,
+                "authorize_url_full": auth_url,
                 "request": {
                     "client_id": client_id,
                     "redirect_uri": _ANTHROPIC_REDIRECT_URI,

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -567,11 +567,17 @@ _ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"  # noqa: S10
 # aligned with the first-party CLI (Anthropic's 2026-04-04 third-party
 # OAuth block routes unknown UA traffic to ``extra_usage`` billing).
 _ANTHROPIC_USER_AGENT = "claude-cli/2.1.140"
-# The OAuth client `9d1c250a-...` is registered with this server-hosted
-# redirect URI only — loopback URIs (http://localhost:*) are rejected at
-# the authorize step. The /oauth/code/callback page renders the
-# authorization code so the user can copy & paste it back into the CLI.
-_ANTHROPIC_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+# v0.99.7 update — Hermes Agent grounds the redirect URI at
+# ``console.anthropic.com/oauth/code/callback`` (see
+# ``hermes-agent/agent/anthropic_adapter.py:1043``, ``_OAUTH_REDIRECT_URI``).
+# That host differs from the Claude Code binary's ``K3q.MANUAL_REDIRECT_URL``
+# (``platform.claude.com/oauth/code/callback``). User's v0.99.5/0.99.6
+# attempts with the ``platform.claude.com`` redirect both returned
+# "Invalid request format" — Hermes's working pattern suggests the
+# OAuth client `9d1c250a-...` is registered against the console host,
+# and binary's K3q may be stale. The ``/oauth/code/callback`` page
+# still renders the code in ``<code>#<state>`` for manual paste.
+_ANTHROPIC_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 
 # Scope set mirrors Claude Code's hint string in the native binary:
 #   "user:profile user:inference user:sessions:claude_code user:mcp_servers"
@@ -655,25 +661,25 @@ def _run_anthropic_pkce_flow(client_id: str) -> dict[str, Any]:
     verifier, challenge = _generate_pkce_pair()
     state = secrets.token_urlsafe(16)
     scope = " ".join(_ANTHROPIC_DEFAULT_SCOPES)
-    # v0.99.7 — added ``login_method=claudeai`` from claude.exe binary's
-    # ``if($) append("login_method", $)`` site. The binary's ``$`` defaults
-    # to ``"claudeai"`` on the Claude.ai consumer path (vs ``"console"``
-    # for the Anthropic developer portal). Without this param the
-    # claude.ai server appears to return "Invalid request format".
+    # v0.99.7 — query parameters match Hermes Agent
+    # (``hermes-agent/hermes_cli/web_server.py:1755-1764``) 1:1. Note
+    # that ``login_method`` is **not** sent — the binary appends it
+    # conditionally (``if($) append("login_method", $)``) and Hermes,
+    # which works in production, omits it. Param order also mirrors
+    # Hermes's dict literal.
     auth_url = (
         _ANTHROPIC_AUTHORIZE_URL
         + "?"
         + urllib.parse.urlencode(
             {
                 "code": "true",
-                "response_type": "code",
                 "client_id": client_id,
+                "response_type": "code",
                 "redirect_uri": _ANTHROPIC_REDIRECT_URI,
                 "scope": scope,
-                "state": state,
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
-                "login_method": "claudeai",
+                "state": state,
             }
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.6"
+version = "0.99.7"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.6"
+version = "0.99.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.6 의 `claude.com/cai` 가 server-side 로 `claude.ai` redirect 후 또 "Invalid request format" → 추가 root cause 추적. ../hermes-agent 의 production-tested anthropic OAuth flow 그라운딩 결과 우리 코드의 **redirect_uri host 가 잘못** 확인.

## Why

3 source 그라운딩 매트릭스:

| 차원 | v0.99.5/0.99.6 (broken) | binary `K3q` | **Hermes** (production) | **v0.99.7** |
|---|---|---|---|---|
| authorize | platform.claude.com → cai | claude.com/cai/oauth/authorize | **claude.ai/oauth/authorize** | claude.ai/oauth/authorize ✓ |
| token | platform.claude.com/v1/oauth/token | 동일 | 동일 | 동일 ✓ |
| **redirect_uri** | **platform.claude.com/oauth/code/callback** | platform.claude.com (K3q) | **console.anthropic.com/oauth/code/callback** | **console.anthropic.com/oauth/code/callback** ✓ |
| login_method | (없음) | optional `if($)` append | **(없음)** | **(없음)** |
| state | secrets.token_urlsafe | — | verifier round-trip | secrets.token_urlsafe (별개 - future PR) |
| client_id | 9d1c250a-... | 동일 | 동일 | 동일 ✓ |

→ **redirect_uri host mismatch** 가 강력한 root cause 의심. binary K3q (`MANUAL_REDIRECT_URL`) 가 outdated/local-env-only 일 가능성. Hermes 는 production 에서 동작 확인된 패턴.

## Changes

| File | Change |
|------|--------|
| `core/auth/oauth_login.py` | `_ANTHROPIC_AUTHORIZE_URL` → `claude.ai/oauth/authorize` (cai/ alias). `_ANTHROPIC_REDIRECT_URI` → `console.anthropic.com/oauth/code/callback` (Hermes parity). `login_method=claudeai` 제거. param 순서 Hermes dict literal 정합. dump 의 `authorize_url_full` 도 같이 기록 (진단 강화) |
| `CHANGELOG.md` | `[0.99.7]` Fixed 섹션 |
| `pyproject.toml`, `CLAUDE.md`, `README.md` | 0.99.6 → 0.99.7 |
| `uv.lock` | editable 0.99.7 |

## GAP Audit

| Item | Status |
|------|--------|
| authorize host `claude.ai` | Implemented |
| redirect_uri `console.anthropic.com` | Implemented (Hermes parity) |
| login_method 제거 | Implemented (Hermes 도 안 보냄) |
| Param 순서 정합 | Implemented |
| state = verifier round-trip | Dropped (future PR; binary 와 Hermes 가 다른 패턴 — verifier-as-state 는 secret leak risk) |
| authorize_url_full dump | Implemented (다음 시도시 dump 에 우리 URL 영구 기록) |

## Verification

- [x] ruff/mypy clean
- [x] 4-location version sync (0.99.7)
- [ ] CI 통과
- [ ] **사용자 live trial** — `/login anthropic` → claude.ai → console.anthropic.com redirect → manual paste. authorize_url_full 가 dump 에 기록되어 다음 진단 가능

## Reference

- ../hermes-agent/hermes_cli/web_server.py:1670 `_ANTHROPIC_OAUTH_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"`
- ../hermes-agent/agent/anthropic_adapter.py:1043 `_OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"`
- ../hermes-agent/agent/anthropic_adapter.py:795 `client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"`
- claude.exe binary `K3q` (outdated 의심): `MANUAL_REDIRECT_URL: "https://platform.claude.com/oauth/code/callback"`
- 사용자 보고: v0.99.5/0.99.6 모두 "Invalid request format"

🤖 Generated with [Claude Code](https://claude.com/claude-code)