### PR TITLE
fix(auth): scope set Hermes parity (3 scopes) (v0.99.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,30 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.8] — 2026-05-17
+
+### Fixed
+
+- **`login_anthropic()` — scope set 을 Hermes 와 1:1 일치 (`org:create_api_key user:profile user:inference`).**
+  v0.99.7 의 `claude.ai/oauth/authorize` + `console.anthropic.com`
+  redirect_uri 조합이 production-tested Hermes 패턴과 정합인데도
+  사용자 시도 결과 또 "Invalid request format". dump 의
+  `authorize_url_full` 비교 결과 single 차이 = scope. 우리가 binary
+  의 hint string (`user:sessions:claude_code`, `user:mcp_servers`)
+  포함시켜 unregistered scope 거절. Hermes 의 narrower set 으로 좁힘
+  (`hermes-agent/agent/anthropic_adapter.py:1044`).
+
+- **`login_anthropic()` — narrowed scope set to Hermes parity.**
+  v0.99.7's authorize + redirect URI parity with Hermes still produced
+  "Invalid request format". Diffing dump's `authorize_url_full`
+  against Hermes's URL revealed the single remaining mismatch: scope.
+  Claude Code's binary advertises `user:sessions:claude_code` and
+  `user:mcp_servers` in a hint string, but the OAuth client only
+  accepts the smaller set Hermes ships. Now sending
+  `org:create_api_key user:profile user:inference` exactly.
+
+
+
 ## [0.99.7] — 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.7
+- **Version**: 0.99.8
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.7 — Long-running Autonomous Execution Harness
+# GEODE v0.99.8 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.7**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.8**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/oauth_login.py
+++ b/core/auth/oauth_login.py
@@ -579,15 +579,19 @@ _ANTHROPIC_USER_AGENT = "claude-cli/2.1.140"
 # still renders the code in ``<code>#<state>`` for manual paste.
 _ANTHROPIC_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 
-# Scope set mirrors Claude Code's hint string in the native binary:
-#   "user:profile user:inference user:sessions:claude_code user:mcp_servers"
-# Anthropic rejects authorize requests asking for scopes outside the
-# set registered for the client, so we send the full superset.
+# v0.99.8 — scope set matched 1:1 with Hermes Agent's working
+# ``_OAUTH_SCOPES = "org:create_api_key user:profile user:inference"``
+# (``hermes-agent/agent/anthropic_adapter.py:1044``). Claude Code's
+# binary hint string also lists ``user:sessions:claude_code`` and
+# ``user:mcp_servers``; those appear to be hint-only (advertised in
+# helper text, not actually registered on the public OAuth client),
+# because requesting them produced "Invalid request format" on the
+# Claude.ai authorize step (user reports for v0.99.5–v0.99.7). Hermes
+# 's narrower set is the one production OAuth client accepts.
 _ANTHROPIC_DEFAULT_SCOPES = (
-    "user:inference",
+    "org:create_api_key",
     "user:profile",
-    "user:sessions:claude_code",
-    "user:mcp_servers",
+    "user:inference",
 )
 
 # Claude Code's public OAuth client_id candidates, reverse-engineered from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.7"
+version = "0.99.8"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.7"
+version = "0.99.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.7 의 Hermes-parity authorize + redirect_uri 후에도 또 "Invalid request format". dump 의 `authorize_url_full` 와 Hermes 의 URL diff 결과 single 차이 = **scope**. v0.99.8 — scope 좁혀서 Hermes 와 1:1 일치.

## Why

```diff
- v0.99.7 scope: "user:inference user:profile user:sessions:claude_code user:mcp_servers" (4)
+ v0.99.8 scope: "org:create_api_key user:profile user:inference"                          (3, Hermes parity)
```

Hermes `hermes-agent/agent/anthropic_adapter.py:1044`:
```python
_OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
```

binary 의 hint string (`user:sessions:claude_code`, `user:mcp_servers`) 는 hint-only — server 측 registered set 이 좁음.

## Changes

| File | Change |
|------|--------|
| `core/auth/oauth_login.py` | `_ANTHROPIC_DEFAULT_SCOPES`: 4→3 scope, Hermes 와 정확 일치 |
| `CHANGELOG.md` | `[0.99.8]` Fixed |
| 4-location version | 0.99.7 → 0.99.8 |

## Verification

- [x] ruff/mypy clean
- [ ] CI 통과
- [ ] 사용자 live trial — `claude.ai` authorize 페이지 정상 consent 화면 여부

## Reference

- v0.99.7 dump `authorize_url_full` ([15:29 paste-cancelled](https://github.com/mangowhoiscloud/geode))
- Hermes `_OAUTH_SCOPES` 정의: `hermes-agent/agent/anthropic_adapter.py:1044`

🤖 Generated with [Claude Code](https://claude.com/claude-code)