### PR TITLE
feat(ui): /login anthropic picker uses TerminalMenu (arrow keys, /model parity)

### DIFF
--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -686,33 +686,28 @@ def _login_oauth_anthropic() -> None:
     """
     from core.cli import commands as _pkg
 
-    _pkg.console.print()
-    _pkg.console.print("  [bold]Anthropic provider — select credential source:[/bold]")
-    _pkg.console.print()
-    _pkg.console.print("    [bold cyan]1)[/bold cyan] API key      (Anthropic Console PAYG)")
-    _pkg.console.print(
-        "    [bold cyan]2)[/bold cyan] claude CLI   (subprocess — uses Claude subscription)"
+    sources: list[tuple[str, str]] = [
+        ("api_key", "API key      (Anthropic Console PAYG)"),
+        ("claude_cli", "claude CLI   (subprocess — uses Claude subscription)"),
+    ]
+    menu = TerminalMenu(
+        [label for _, label in sources],
+        title=(
+            "\n  Anthropic provider — credential source?  (↑↓ select, Enter confirm, q cancel)\n"
+        ),
+        menu_cursor="  > ",
+        menu_cursor_style=("fg_cyan", "bold"),
     )
-    _pkg.console.print("    [muted]q)[/muted]  skip")
-    _pkg.console.print()
-
-    try:
-        # allow-direct-io: thin handler
-        choice = input("  Choice [1-2/q]: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        _pkg.console.print("  [muted]Cancelled.[/muted]\n")
+    idx = menu.show()
+    if idx is None:
+        _pkg.console.print("  [muted]Cancelled[/muted]\n")
         return
 
-    if choice in ("", "q", "quit", "exit", "skip"):
-        _pkg.console.print("  [muted]Skipped.[/muted]\n")
-        return
-
-    if choice in ("1", "api", "api-key", "key"):
+    source_id = sources[idx][0]
+    if source_id == "api_key":
         _login_anthropic_api_key()
-    elif choice in ("2", "claude", "claude-cli", "cli"):
+    elif source_id == "claude_cli":
         _login_anthropic_via_claude_cli()
-    else:
-        _pkg.console.print(f"  [warning]Unknown choice: {choice!r}[/warning]\n")
 
 
 def _login_anthropic_api_key() -> None:


### PR DESCRIPTION
## Summary

v0.99.9 의 picker 가 숫자 입력 (`Choice [1-2/q]:`) 이었던 것을 `/model` 의 `simple_term_menu.TerminalMenu` 패턴으로 교체. ↑↓ navigate + Enter confirm + q cancel.

## Why

기존 GEODE 의 `/login add` (`_login_add_interactive`) 와 `/model` 이 모두 `TerminalMenu` 사용 — 일관성. 사용자 요청 직접 반영.

## Changes

| File | Change |
|------|--------|
| `core/cli/commands/login.py` | `_login_oauth_anthropic` 의 `input()` choice 입력 제거 → `TerminalMenu(...)` picker. 기존 `_login_add_interactive` 의 menu_cursor 스타일 (`"  > "`, `fg_cyan,bold`) 그대로 |

## UX

```
  Anthropic provider — credential source?  (↑↓ select, Enter confirm, q cancel)

  > API key      (Anthropic Console PAYG)
    claude CLI   (subprocess — uses Claude subscription)
```

## Verification

- [x] ruff/mypy clean
- [ ] CI 8/8
- [ ] 사용자 시각적 확인 — `/login anthropic` 시 화살표 키로 선택

🤖 Generated with [Claude Code](https://claude.com/claude-code)