### PR TITLE
feat(ui): /login anthropic picker 3-option + Crumb-style stdio pipe (v0.99.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,36 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.99.10] — 2026-05-17
+
+### Changed
+
+- **`/login anthropic` — 3-옵션 picker + Crumb-style stdio pipe.**
+  v0.99.9 의 두 옵션 (API key / claude /login subprocess) 에서 후자가
+  claude REPL 을 spawn 해 사용자가 Claude Code 의 full session 에 갇히는
+  문제 (사용자 보고). 3 옵션으로 확장 + delegate path 의 명령을
+  `claude /login` → `claude auth login` 으로 교체 (non-REPL).
+  stdio = `[ignore, pipe, pipe]` 로 Crumb 의 `src/adapters/claude-local.ts`
+  패턴 정합 — claude 의 TUI 아티팩트는 GEODE 가 필터링하고 진행 신호
+  (browser URL, success/fail 마커) 만 흘림. picker:
+
+    1. **API key** (Anthropic Console PAYG) — 변경 없음
+    2. **claude CLI auth login** (subprocess, first-time) — non-REPL, stdio pipe
+    3. **claude keychain** (read existing) — subprocess 없이 keychain 만 read
+
+  공통 helper `_mirror_claude_keychain_to_authtoml` 추출.
+
+- **`/login anthropic` — 3-option picker + Crumb-style stdio pipe.**
+  v0.99.9's claude-CLI option spawned the REPL (the user ended up
+  inside a full Claude Code session). v0.99.10 swaps the command to
+  the non-REPL `claude auth login`, pipes stdio per Crumb's
+  `src/adapters/claude-local.ts` adapter (`stdio: ['ignore','pipe','pipe']`),
+  and filters claude's output so only OAuth-progress lines surface in
+  the GEODE REPL. A third picker option lets users who already ran
+  `claude auth login` skip the spawn and just import the keychain.
+
+
+
 ## [0.99.9] — 2026-05-17
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.9
+- **Version**: 0.99.10
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.9 — Long-running Autonomous Execution Harness
+# GEODE v0.99.10 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.9**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.10**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -687,8 +687,15 @@ def _login_oauth_anthropic() -> None:
     from core.cli import commands as _pkg
 
     sources: list[tuple[str, str]] = [
-        ("api_key", "API key      (Anthropic Console PAYG)"),
-        ("claude_cli", "claude CLI   (subprocess — uses Claude subscription)"),
+        ("api_key", "API key         (Anthropic Console PAYG)"),
+        (
+            "claude_subprocess",
+            "claude CLI      (auth login subprocess — first-time setup)",
+        ),
+        (
+            "claude_keychain",
+            "claude keychain (read existing — if already signed in via claude)",
+        ),
     ]
     menu = TerminalMenu(
         [label for _, label in sources],
@@ -706,8 +713,10 @@ def _login_oauth_anthropic() -> None:
     source_id = sources[idx][0]
     if source_id == "api_key":
         _login_anthropic_api_key()
-    elif source_id == "claude_cli":
-        _login_anthropic_via_claude_cli()
+    elif source_id == "claude_subprocess":
+        _login_anthropic_via_claude_subprocess()
+    elif source_id == "claude_keychain":
+        _login_anthropic_via_claude_keychain()
 
 
 def _login_anthropic_api_key() -> None:
@@ -780,17 +789,14 @@ def _login_anthropic_api_key() -> None:
     _pkg.console.print("  [muted]Stored: ~/.geode/auth.toml[/muted]\n")
 
 
-def _login_anthropic_via_claude_cli() -> None:
-    """Branch 2 — claude CLI subprocess (paperclip ACP-style delegation).
+def _mirror_claude_keychain_to_authtoml(*, after_subprocess: bool) -> bool:
+    """Read claude CLI's OAuth keychain and persist to ``auth.toml``.
 
-    Spawns ``claude /login`` in the user's TTY; the first-party CLI drives
-    its own OAuth flow (browser → claude.ai consent → keychain persist).
-    On exit we re-read the keychain via :mod:`plugins.petri_audit.claude_code_provider`
-    and mirror the token into ``~/.geode/auth.toml`` so GEODE picks it up
-    without going through claude CLI on every call.
+    Shared between the subprocess branch (after ``claude auth login``
+    completes) and the keychain-only branch (when the user has already
+    signed in via claude separately). Returns True on success, False if
+    no token is available.
     """
-    import shutil
-    import subprocess
     from datetime import UTC, datetime
 
     from core.auth.plan_registry import get_plan_registry
@@ -798,34 +804,6 @@ def _login_anthropic_via_claude_cli() -> None:
     from core.auth.profiles import AuthProfile, CredentialType
     from core.cli import commands as _pkg
     from core.wiring.container import ensure_profile_store
-
-    claude_bin = shutil.which("claude")
-    if not claude_bin:
-        _pkg.console.print()
-        _pkg.console.print("  [warning]`claude` CLI not found in PATH.[/warning]")
-        _pkg.console.print("  [muted]Install: npm install -g @anthropic-ai/claude-code[/muted]\n")
-        return
-
-    _pkg.console.print()
-    _pkg.console.print(f"  [muted]Found claude CLI: {claude_bin}[/muted]")
-    _pkg.console.print("  [bold]Spawning `claude /login`[/bold] — browser will open via the CLI.")
-    _pkg.console.print("  [muted]Finish OAuth in your browser, then return here.[/muted]\n")
-
-    try:
-        proc = subprocess.run(  # noqa: S603 — explicit binary from shutil.which
-            [claude_bin, "/login"],
-            check=False,
-            timeout=600,
-        )
-    except (KeyboardInterrupt, subprocess.TimeoutExpired):
-        _pkg.console.print("  [muted]Cancelled.[/muted]\n")
-        return
-
-    if proc.returncode != 0:
-        _pkg.console.print(
-            f"  [warning]claude /login exited with code {proc.returncode}.[/warning]\n"
-        )
-        return
 
     try:
         from plugins.petri_audit.claude_code_provider import (
@@ -836,12 +814,22 @@ def _login_anthropic_via_claude_cli() -> None:
         _pkg.console.print(
             "  [warning]Cannot read claude keychain — `plugins.petri_audit` missing.[/warning]\n"
         )
-        return
+        return False
 
     token = resolve_claude_oauth_token()
     if not token:
-        _pkg.console.print("  [warning]claude /login completed but keychain is empty.[/warning]\n")
-        return
+        if after_subprocess:
+            _pkg.console.print(
+                "  [warning]claude auth login completed but keychain is empty.[/warning]\n"
+            )
+        else:
+            _pkg.console.print()
+            _pkg.console.print("  [warning]claude keychain is empty.[/warning]")
+            _pkg.console.print(
+                "  [muted]Run `claude auth login` first, or pick "
+                "'claude CLI (auth login subprocess)' to delegate.[/muted]\n"
+            )
+        return False
 
     meta = get_claude_oauth_metadata() or {}
     expires_at = float(meta.get("expires_at", 0) or 0)
@@ -852,7 +840,7 @@ def _login_anthropic_via_claude_cli() -> None:
         id=plan_id,
         provider="anthropic",
         kind=PlanKind.OAUTH_BORROWED,
-        display_name="Anthropic (Claude CLI subprocess)",
+        display_name="Anthropic (Claude CLI keychain)",
         base_url="https://api.anthropic.com",
         auth_type="oauth_external",
     )
@@ -879,6 +867,115 @@ def _login_anthropic_via_claude_cli() -> None:
     _pkg.console.print()
     _pkg.console.print("  [success]✓ Imported from claude CLI keychain.[/success]")
     _pkg.console.print("  [muted]Stored: ~/.geode/auth.toml[/muted]\n")
+    return True
+
+
+def _login_anthropic_via_claude_subprocess() -> None:
+    """Branch 2 — ``claude auth login`` subprocess (Crumb adapter pattern).
+
+    Spawns the first-party CLI's non-REPL login command with
+    ``stdio=[ignore, pipe, pipe]`` (mirrors Crumb's ``claude-local``
+    adapter: ``src/adapters/claude-local.ts:72``). GEODE filters the
+    piped output so claude's TUI artifacts do not leak into the GEODE
+    REPL — only progress-relevant lines (browser URL, success/failure
+    markers) bubble up. On exit, the keychain is mirrored into
+    ``auth.toml`` via :func:`_mirror_claude_keychain_to_authtoml`.
+
+    v0.99.10 — replaced ``claude /login`` (which entered the REPL) with
+    ``claude auth login`` (non-REPL) after user reported the previous
+    flow drops them into a full Claude Code session.
+    """
+    import re
+    import shutil
+    import subprocess
+    import threading
+
+    from core.cli import commands as _pkg
+
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        _pkg.console.print()
+        _pkg.console.print("  [warning]`claude` CLI not found in PATH.[/warning]")
+        _pkg.console.print("  [muted]Install: npm install -g @anthropic-ai/claude-code[/muted]\n")
+        return
+
+    _pkg.console.print()
+    _pkg.console.print(f"  [muted]Delegating to {claude_bin} auth login…[/muted]")
+    _pkg.console.print("  [bold]Browser will open;[/bold] finish OAuth there, GEODE waits below.\n")
+
+    proc = subprocess.Popen(  # noqa: S603 — explicit binary from shutil.which
+        [claude_bin, "auth", "login"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    # Filter claude's piped output. Keep only lines that signal progress —
+    # drop ANSI box-drawing, version banners, REPL prompts, mode-banner
+    # text. Pattern derived from observing v0.99.9 user report.
+    _ansi_re = re.compile(r"\x1b\[[0-9;]*[mGKHJABCDsuf]")
+    _keywords = (
+        "browser",
+        "open",
+        "url",
+        "http",
+        "code",
+        "token",
+        "success",
+        "fail",
+        "error",
+        "expir",
+        "logging in",
+        "signed in",
+    )
+
+    def _filter() -> None:
+        if proc.stdout is None:
+            return
+        for raw in proc.stdout:
+            stripped = _ansi_re.sub("", raw).strip()
+            if not stripped:
+                continue
+            low = stripped.lower()
+            if any(k in low for k in _keywords):
+                _pkg.console.print(f"  [muted]→ {stripped}[/muted]")
+
+    reader = threading.Thread(target=_filter, daemon=True)
+    reader.start()
+
+    try:
+        rc = proc.wait(timeout=600)
+    except KeyboardInterrupt:
+        proc.terminate()
+        _pkg.console.print("\n  [muted]Cancelled.[/muted]\n")
+        return
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        _pkg.console.print("  [warning]Timed out after 10 min.[/warning]\n")
+        return
+
+    if rc != 0:
+        _pkg.console.print(f"  [warning]claude auth login exited with code {rc}.[/warning]\n")
+        return
+
+    _mirror_claude_keychain_to_authtoml(after_subprocess=True)
+
+
+def _login_anthropic_via_claude_keychain() -> None:
+    """Branch 3 — read existing claude CLI keychain (Crumb pattern).
+
+    No subprocess spawn. Assumes the user has already authenticated via
+    ``claude auth login`` in a separate session and just wants GEODE to
+    import the existing token. Pure keychain read (PR #1202 pattern).
+    """
+    from core.cli import commands as _pkg
+
+    _pkg.console.print()
+    _pkg.console.print("  [muted]Reading claude CLI keychain…[/muted]")
+    _mirror_claude_keychain_to_authtoml(after_subprocess=False)
+    _pkg.console.print()
 
 
 def _login_set_key(rest: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.9"
+version = "0.99.10"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "geode"
-version = "0.99.9"
+version = "0.99.10"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.9 의 claude /login 옵션이 **Claude Code REPL 전체를 spawn** 하는 문제 (사용자 보고). 3-option picker + non-REPL 명령 + Crumb adapter 패턴 stdio pipe 으로 재설계.

## Why

사용자 v0.99.9 시도 결과:
```
> /login anthropic
[picker → claude CLI 선택]
[claude CLI 의 full REPL UI 가 GEODE 위에 출력, OAuth 완료 후에도 session 안에 갇힘]
```

Root cause: `subprocess.run([claude, "/login"])` 가 사실 claude binary 를 **REPL** 로 띄우면서 `/login` 슬래시 커맨드 실행. binary 가 별도 sub-command 를 제공:
- ❌ `claude /login` — REPL 진입
- ✅ `claude auth login` — non-REPL, login flow 만 (`claude auth --help` 확인)

## Changes

| File | Change |
|------|--------|
| `core/cli/commands/login.py` | picker 2 → 3 options. `_login_anthropic_via_claude_cli` 폐기, 새로 `_login_anthropic_via_claude_subprocess` + `_login_anthropic_via_claude_keychain` + 공통 helper `_mirror_claude_keychain_to_authtoml` |
| `CHANGELOG.md` | `[0.99.10]` Changed 섹션 |
| 4-location | 0.99.9 → 0.99.10 |

## UX 3 options

```
  Anthropic provider — credential source?  (↑↓ select, Enter confirm, q cancel)

  > API key         (Anthropic Console PAYG)
    claude CLI      (auth login subprocess — first-time setup)
    claude keychain (read existing — if already signed in via claude)
```

- **API key** — `sk-ant-…` getpass + auth.toml 저장 (변경 없음)
- **claude CLI auth login** — Crumb 패턴 (`stdio=[ignore, pipe, pipe]`) + non-REPL `claude auth login` + 필터링된 진행 메시지만 GEODE console + 완료 시 keychain import
- **claude keychain** — subprocess 없이 PR #1202 패턴으로 기존 keychain 만 read

## GAP Audit

| Item | Status |
|------|--------|
| `claude /login` → `claude auth login` | Implemented |
| `stdio=DEVNULL/PIPE/PIPE` (Crumb 정합) | Implemented |
| ANSI/box-drawing 필터 | Implemented (`_ansi_re` + keyword whitelist) |
| 3rd option (keychain-only) | Implemented |
| 공통 helper 추출 | Implemented |

## Verification

- [x] ruff/mypy clean
- [ ] CI 8/8
- [ ] **사용자 live trial** — picker 의 3 옵션 모두 동작

## Reference

- 사용자 보고: v0.99.9 시 claude REPL 가 GEODE 위에 노출
- `claude auth login` (non-REPL): `claude auth --help` 확인
- Crumb adapter: `~/workspace/crumb/src/adapters/claude-local.ts:72-75`
  ```ts
  const child = spawn('claude', args, {
    env: buildAdapterEnv(req),
    stdio: ['ignore', 'pipe', 'pipe'],
  })
  ```
- PR #1202 keychain read 패턴 (helper 재사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)