### PR TITLE
feat(petri): manifest schema + loader (P1-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,30 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Added
+
+- **Petri audit manifest (P1-A) — `petri.plugin.toml` 선언적 schema.**
+  `plugins/petri_audit/petri.plugin.toml` 신설 + `manifest.py` pydantic
+  loader. 4-layer schema — `[petri]` enabled_roles, `[petri.role.<name>]`
+  default_model + allowed_models, `[petri.source.<family>]` default +
+  allowed credential sources, `[petri.adapter.<family>.<source>]`
+  module + inspect_prefix + auth_env_vars. cross-layer consistency
+  검증 (default ∈ allowed, adapter coverage). lru_cache 로 reload 안전.
+  OpenClaw plugin.json 패턴 차용 — Petri 의 role × source × model 결합
+  규칙을 코드 외부로 빼서 후속 PR (P1-B/C/D/E/F/G) 에서 hardcoded
+  if/elif chain 을 manifest 조회로 치환할 기반.
+
+- **Petri audit manifest (P1-A) — `petri.plugin.toml` declarative schema.**
+  New `plugins/petri_audit/petri.plugin.toml` + `manifest.py` pydantic
+  loader. 4-layer schema (`[petri]` enabled_roles, `[petri.role.<name>]`,
+  `[petri.source.<family>]`, `[petri.adapter.<family>.<source>]`) with
+  cross-layer consistency checks (default ∈ allowed, every non-auto
+  source has an adapter binding). `lru_cache`-backed reload-safe loader.
+  Adopts the OpenClaw `plugin.json` pattern so subsequent PRs
+  (P1-B..G) can replace hardcoded if/elif routing with manifest
+  lookups — first step of the Petri side of the routing externalisation
+  plan (Petri P1 → GEODE P2 routing.toml → P3 pricing externalisation).
+
 ## [0.99.10] — 2026-05-17
 
 ### Changed

--- a/plugins/petri_audit/manifest.py
+++ b/plugins/petri_audit/manifest.py
@@ -1,0 +1,196 @@
+"""Petri audit manifest loader — declarative role × source × adapter schema.
+
+Reads ``plugins/petri_audit/petri.plugin.toml`` into a validated pydantic
+tree so the rest of the plugin (registry, /petri picker, to_inspect_model
+router) operates on a single source-of-truth instead of hardcoded
+if/elif chains.
+
+Layers (mirroring TOML structure):
+
+- :class:`RoleSpec` — per-role default model + allowed model set
+- :class:`SourceSpec` — per-family default credential source + allowed sources
+- :class:`AdapterSpec` — concrete (module, inspect_prefix, env vars) binding
+- :class:`PetriManifest` — top-level container with cross-layer consistency
+
+The loader does **not** import adapter modules — that stays lazy in
+``plugins.petri_audit.adapters.__init__`` so the default ``uv sync``
+(no ``[audit]`` extra) keeps cold-start clean.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+__all__ = [
+    "DEFAULT_MANIFEST_PATH",
+    "AdapterSpec",
+    "PetriManifest",
+    "RoleSpec",
+    "SourceSpec",
+    "load_manifest",
+]
+
+DEFAULT_MANIFEST_PATH = Path(__file__).parent / "petri.plugin.toml"
+
+# "auto" is a sentinel — resolved at binding time via
+# ``settings.{family}_credential_source`` + keychain probe — so it
+# never appears as a concrete adapter key.
+AUTO_SOURCE = "auto"
+
+
+class RoleSpec(BaseModel):
+    """Per-role default + allowed model set + contract path."""
+
+    default_model: str
+    allowed_models: list[str]
+    role_contract: str | None = None
+
+    @model_validator(mode="after")
+    def _default_in_allowed(self) -> RoleSpec:
+        if self.default_model not in self.allowed_models:
+            raise ValueError(
+                f"default_model {self.default_model!r} not in allowed_models {self.allowed_models}"
+            )
+        return self
+
+
+class SourceSpec(BaseModel):
+    """Per-family default credential source + allowed source set."""
+
+    default: str
+    allowed: list[str]
+
+    @model_validator(mode="after")
+    def _default_in_allowed(self) -> SourceSpec:
+        if self.default not in self.allowed:
+            raise ValueError(
+                f"source default {self.default!r} not in allowed {self.allowed}"
+            )
+        return self
+
+
+class AdapterSpec(BaseModel):
+    """Concrete adapter binding for a (family, source) pair.
+
+    ``module`` — dotted import path; loaded lazily by the adapter registry.
+    ``inspect_prefix`` — prefix that ``to_inspect_model`` emits (e.g.
+    ``anthropic/<model>``, ``claude-code/<model>``, ``openai-codex/<model>``,
+    ``geode/<model>``).
+    ``auth_env_vars`` — env vars consulted for credentials; used by the
+    /petri picker to flag missing credentials.
+    ``endpoint`` / ``binary`` — adapter-specific extras (HTTP base URL,
+    CLI executable name).
+    """
+
+    module: str
+    inspect_prefix: str
+    auth_env_vars: list[str] = Field(default_factory=list)
+    endpoint: str | None = None
+    binary: str | None = None
+
+
+class PetriManifest(BaseModel):
+    """Top-level manifest container with cross-layer consistency checks."""
+
+    enabled_roles: list[str]
+    roles: dict[str, RoleSpec]
+    sources: dict[str, SourceSpec]
+    adapters: dict[str, dict[str, AdapterSpec]]
+
+    @model_validator(mode="after")
+    def _consistency(self) -> PetriManifest:
+        # 1. role list <-> role spec coverage
+        if set(self.enabled_roles) != set(self.roles):
+            raise ValueError(
+                f"enabled_roles {self.enabled_roles} != role spec keys "
+                f"{sorted(self.roles)}"
+            )
+        # 2. every (family, source) in source.allowed has an adapter
+        #    (excluding the "auto" sentinel — resolved at binding time)
+        for family, source_spec in self.sources.items():
+            family_adapters = self.adapters.get(family, {})
+            for source in source_spec.allowed:
+                if source == AUTO_SOURCE:
+                    continue
+                if source not in family_adapters:
+                    raise ValueError(
+                        f"family={family} source={source} listed in "
+                        f"[petri.source.{family}].allowed but no adapter at "
+                        f"[petri.adapter.{family}.{source}]"
+                    )
+        return self
+
+    # ── Accessors (used by registry / picker / router) ────────────────────
+
+    def get_role(self, role: str) -> RoleSpec:
+        if role not in self.roles:
+            raise KeyError(f"Unknown petri role {role!r}; enabled={self.enabled_roles}")
+        return self.roles[role]
+
+    def get_source(self, family: str) -> SourceSpec:
+        if family not in self.sources:
+            raise KeyError(
+                f"Unknown petri family {family!r}; known={sorted(self.sources)}"
+            )
+        return self.sources[family]
+
+    def get_adapter(self, family: str, source: str) -> AdapterSpec:
+        if source == AUTO_SOURCE:
+            raise ValueError(
+                "Cannot resolve adapter for 'auto' — caller must resolve to a "
+                "concrete source first (e.g. via credential_source.resolve)"
+            )
+        family_adapters = self.adapters.get(family, {})
+        if source not in family_adapters:
+            raise KeyError(
+                f"No adapter for family={family} source={source}; "
+                f"known sources for this family={sorted(family_adapters)}"
+            )
+        return family_adapters[source]
+
+
+def _parse_manifest_dict(data: dict[str, Any]) -> PetriManifest:
+    """Build a :class:`PetriManifest` from the parsed TOML dict.
+
+    Split out so tests can feed dict literals without round-tripping through
+    a TOML file.
+    """
+    petri = data.get("petri")
+    if not petri:
+        raise ValueError("Manifest missing [petri] root section")
+    return PetriManifest(
+        enabled_roles=petri.get("enabled_roles", []),
+        roles={k: RoleSpec(**v) for k, v in petri.get("role", {}).items()},
+        sources={k: SourceSpec(**v) for k, v in petri.get("source", {}).items()},
+        adapters={
+            family: {src: AdapterSpec(**v) for src, v in srcs.items()}
+            for family, srcs in petri.get("adapter", {}).items()
+        },
+    )
+
+
+@lru_cache(maxsize=4)
+def _load_cached(path_str: str) -> PetriManifest:
+    data = tomllib.loads(Path(path_str).read_text(encoding="utf-8"))
+    return _parse_manifest_dict(data)
+
+
+def load_manifest(path: Path | str | None = None) -> PetriManifest:
+    """Load and validate the Petri manifest at ``path``.
+
+    Defaults to :data:`DEFAULT_MANIFEST_PATH`. Results are cached per absolute
+    path (max 4 entries) so repeated callers (registry, picker, router) share
+    the parsed tree.
+    """
+    target = Path(path) if path is not None else DEFAULT_MANIFEST_PATH
+    return _load_cached(str(target.resolve()))
+
+
+def clear_manifest_cache() -> None:
+    """Drop the lru_cache — used by tests that mutate manifest fixtures."""
+    _load_cached.cache_clear()

--- a/plugins/petri_audit/manifest.py
+++ b/plugins/petri_audit/manifest.py
@@ -68,9 +68,7 @@ class SourceSpec(BaseModel):
     @model_validator(mode="after")
     def _default_in_allowed(self) -> SourceSpec:
         if self.default not in self.allowed:
-            raise ValueError(
-                f"source default {self.default!r} not in allowed {self.allowed}"
-            )
+            raise ValueError(f"source default {self.default!r} not in allowed {self.allowed}")
         return self
 
 
@@ -107,8 +105,7 @@ class PetriManifest(BaseModel):
         # 1. role list <-> role spec coverage
         if set(self.enabled_roles) != set(self.roles):
             raise ValueError(
-                f"enabled_roles {self.enabled_roles} != role spec keys "
-                f"{sorted(self.roles)}"
+                f"enabled_roles {self.enabled_roles} != role spec keys {sorted(self.roles)}"
             )
         # 2. every (family, source) in source.allowed has an adapter
         #    (excluding the "auto" sentinel — resolved at binding time)
@@ -134,9 +131,7 @@ class PetriManifest(BaseModel):
 
     def get_source(self, family: str) -> SourceSpec:
         if family not in self.sources:
-            raise KeyError(
-                f"Unknown petri family {family!r}; known={sorted(self.sources)}"
-            )
+            raise KeyError(f"Unknown petri family {family!r}; known={sorted(self.sources)}")
         return self.sources[family]
 
     def get_adapter(self, family: str, source: str) -> AdapterSpec:

--- a/plugins/petri_audit/petri.plugin.toml
+++ b/plugins/petri_audit/petri.plugin.toml
@@ -1,0 +1,108 @@
+# Petri audit plugin manifest — declarative role × source × adapter binding.
+#
+# Schema layers:
+#   1. [petri] — enabled roles (auditor / target / judge)
+#   2. [petri.role.<name>] — per-role default model + allowed model set + contract
+#   3. [petri.source.<family>] — per-family default credential source + allowed sources
+#   4. [petri.adapter.<family>.<source>] — concrete adapter binding (module, env vars,
+#      inspect_ai prefix, endpoint / binary)
+#
+# Loader: plugins.petri_audit.manifest.load_manifest() → PetriManifest (pydantic).
+#
+# Future expansion — config.toml [petri.<role>] overrides take precedence, e.g.
+# `[petri.auditor] model = "claude-opus-4-7" source = "claude-cli"` flips runtime
+# binding without touching this manifest (P1-E registry handles the merge).
+
+[petri]
+enabled_roles = ["auditor", "target", "judge"]
+
+# ── Roles ────────────────────────────────────────────────────────────────────
+
+[petri.role.auditor]
+default_model = "claude-sonnet-4-6"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-5.5",
+    "gpt-5.4",
+]
+role_contract = "roles/auditor.md"
+
+[petri.role.target]
+# Target always routes through GeodeModelAPI (`geode/<model>`) regardless of
+# family — the audit evaluates GEODE-as-a-system. The user only pins the base
+# LLM GEODE uses internally.
+default_model = "claude-haiku-4-5"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "glm-4-6",
+]
+role_contract = "roles/target.md"
+
+[petri.role.judge]
+default_model = "claude-sonnet-4-6"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "gpt-5.5",
+]
+role_contract = "roles/judge.md"
+
+# ── Sources (per family) ─────────────────────────────────────────────────────
+
+[petri.source.anthropic]
+# "auto" = consult settings.anthropic_credential_source, fall back to keychain
+# probe (see plugins.petri_audit.claude_code_provider.is_claude_oauth_available).
+default = "auto"
+allowed = ["api_key", "claude-cli", "auto"]
+
+[petri.source.openai]
+default = "auto"
+allowed = ["api_key", "openai-codex", "auto"]
+
+[petri.source.zhipuai]
+default = "api_key"
+allowed = ["api_key"]
+
+# ── Adapters (per family × source) ───────────────────────────────────────────
+
+[petri.adapter.anthropic.api_key]
+module = "plugins.petri_audit.adapters.http_anthropic"
+inspect_prefix = "anthropic"
+auth_env_vars = ["ANTHROPIC_API_KEY"]
+endpoint = "https://api.anthropic.com"
+
+[petri.adapter.anthropic.claude-cli]
+# OAuth via Claude CLI keychain entry — ClaudeMaxAPI subclass of stock
+# AnthropicAPI; calls land on api.anthropic.com with subscription quota.
+module = "plugins.petri_audit.adapters.claude_cli_backend"
+inspect_prefix = "claude-code"
+auth_env_vars = ["ANTHROPIC_OAUTH_TOKEN"]
+binary = "claude"
+
+[petri.adapter.openai.api_key]
+module = "plugins.petri_audit.adapters.http_openai"
+inspect_prefix = "openai"
+auth_env_vars = ["OPENAI_API_KEY"]
+endpoint = "https://api.openai.com"
+
+[petri.adapter.openai.openai-codex]
+# OAuth via Codex CLI — re-routes through OpenAICodexAPI (registered ModelAPI
+# `openai-codex`) so calls consume ChatGPT Plus quota instead of PAYG.
+module = "plugins.petri_audit.adapters.openai_codex_oauth"
+inspect_prefix = "openai-codex"
+auth_env_vars = ["OPENAI_OAUTH_TOKEN"]
+
+[petri.adapter.zhipuai.api_key]
+# GLM family routes through GeodeModelAPI (`geode/<model>`) because inspect_ai
+# has no native GLM provider.
+module = "plugins.petri_audit.adapters.http_zhipuai"
+inspect_prefix = "geode"
+auth_env_vars = ["ZHIPUAI_API_KEY"]
+endpoint = "https://open.bigmodel.cn"

--- a/tests/plugins/petri_audit/test_manifest.py
+++ b/tests/plugins/petri_audit/test_manifest.py
@@ -1,0 +1,257 @@
+"""Unit tests for the Petri audit manifest schema + loader (P1-A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from plugins.petri_audit.manifest import (
+    DEFAULT_MANIFEST_PATH,
+    AdapterSpec,
+    PetriManifest,
+    RoleSpec,
+    SourceSpec,
+    _parse_manifest_dict,
+    clear_manifest_cache,
+    load_manifest,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_manifest_cache()
+    yield
+    clear_manifest_cache()
+
+
+def _valid_dict() -> dict:
+    """Minimal valid manifest dict — fixture for negative tests."""
+    return {
+        "petri": {
+            "enabled_roles": ["auditor", "judge"],
+            "role": {
+                "auditor": {
+                    "default_model": "claude-sonnet-4-6",
+                    "allowed_models": ["claude-sonnet-4-6", "claude-opus-4-7"],
+                    "role_contract": "roles/auditor.md",
+                },
+                "judge": {
+                    "default_model": "claude-sonnet-4-6",
+                    "allowed_models": ["claude-sonnet-4-6"],
+                },
+            },
+            "source": {
+                "anthropic": {
+                    "default": "auto",
+                    "allowed": ["api_key", "claude-cli", "auto"],
+                }
+            },
+            "adapter": {
+                "anthropic": {
+                    "api_key": {
+                        "module": "plugins.petri_audit.adapters.http_anthropic",
+                        "inspect_prefix": "anthropic",
+                        "auth_env_vars": ["ANTHROPIC_API_KEY"],
+                        "endpoint": "https://api.anthropic.com",
+                    },
+                    "claude-cli": {
+                        "module": "plugins.petri_audit.adapters.claude_cli_backend",
+                        "inspect_prefix": "claude-code",
+                        "auth_env_vars": ["ANTHROPIC_OAUTH_TOKEN"],
+                        "binary": "claude",
+                    },
+                }
+            },
+        }
+    }
+
+
+# ── Default manifest happy path ────────────────────────────────────────────
+
+
+def test_default_manifest_loads():
+    manifest = load_manifest()
+    assert isinstance(manifest, PetriManifest)
+    assert set(manifest.enabled_roles) == {"auditor", "target", "judge"}
+    assert "anthropic" in manifest.sources
+    assert "openai" in manifest.sources
+    assert "zhipuai" in manifest.sources
+
+
+def test_default_manifest_role_defaults_in_allowed():
+    manifest = load_manifest()
+    for role_name in manifest.enabled_roles:
+        spec = manifest.get_role(role_name)
+        assert spec.default_model in spec.allowed_models
+
+
+def test_default_manifest_adapter_coverage():
+    """Every non-auto source in source.allowed has an adapter."""
+    manifest = load_manifest()
+    for family, source_spec in manifest.sources.items():
+        for source in source_spec.allowed:
+            if source == "auto":
+                continue
+            # raises if missing
+            manifest.get_adapter(family, source)
+
+
+def test_default_manifest_default_path_constant():
+    assert DEFAULT_MANIFEST_PATH.name == "petri.plugin.toml"
+    assert DEFAULT_MANIFEST_PATH.exists()
+
+
+def test_default_manifest_inspect_prefixes():
+    """Inspect prefixes match the existing to_inspect_model contract."""
+    manifest = load_manifest()
+    assert manifest.get_adapter("anthropic", "api_key").inspect_prefix == "anthropic"
+    assert manifest.get_adapter("anthropic", "claude-cli").inspect_prefix == "claude-code"
+    assert manifest.get_adapter("openai", "api_key").inspect_prefix == "openai"
+    assert manifest.get_adapter("openai", "openai-codex").inspect_prefix == "openai-codex"
+    assert manifest.get_adapter("zhipuai", "api_key").inspect_prefix == "geode"
+
+
+# ── Negative validation paths ──────────────────────────────────────────────
+
+
+def test_role_default_not_in_allowed_raises():
+    bad = _valid_dict()
+    bad["petri"]["role"]["auditor"]["default_model"] = "claude-haiku-4-5"
+    with pytest.raises(ValueError, match="default_model"):
+        _parse_manifest_dict(bad)
+
+
+def test_source_default_not_in_allowed_raises():
+    bad = _valid_dict()
+    bad["petri"]["source"]["anthropic"]["default"] = "openai-codex"
+    with pytest.raises(ValueError, match="source default"):
+        _parse_manifest_dict(bad)
+
+
+def test_missing_adapter_for_allowed_source_raises():
+    bad = _valid_dict()
+    bad["petri"]["source"]["anthropic"]["allowed"] = [
+        "api_key",
+        "claude-cli",
+        "openai-codex",
+        "auto",
+    ]
+    with pytest.raises(ValueError, match="no adapter"):
+        _parse_manifest_dict(bad)
+
+
+def test_enabled_role_without_spec_raises():
+    bad = _valid_dict()
+    bad["petri"]["enabled_roles"] = ["auditor", "judge", "target"]
+    with pytest.raises(ValueError, match="role spec keys"):
+        _parse_manifest_dict(bad)
+
+
+def test_missing_petri_root_raises():
+    with pytest.raises(ValueError, match="\\[petri\\] root"):
+        _parse_manifest_dict({})
+
+
+# ── Accessor behaviour ─────────────────────────────────────────────────────
+
+
+def test_get_role_unknown_raises_keyerror():
+    manifest = load_manifest()
+    with pytest.raises(KeyError, match="Unknown petri role"):
+        manifest.get_role("nonexistent")
+
+
+def test_get_source_unknown_raises_keyerror():
+    manifest = load_manifest()
+    with pytest.raises(KeyError, match="Unknown petri family"):
+        manifest.get_source("nonexistent")
+
+
+def test_get_adapter_auto_raises_valueerror():
+    manifest = load_manifest()
+    with pytest.raises(ValueError, match="Cannot resolve adapter for 'auto'"):
+        manifest.get_adapter("anthropic", "auto")
+
+
+def test_get_adapter_unknown_source_raises():
+    manifest = load_manifest()
+    with pytest.raises(KeyError, match="No adapter for"):
+        manifest.get_adapter("anthropic", "nonexistent")
+
+
+# ── Cache behaviour ────────────────────────────────────────────────────────
+
+
+def test_load_manifest_caches_by_path(tmp_path: Path):
+    target = tmp_path / "petri.plugin.toml"
+    target.write_text(
+        """
+[petri]
+enabled_roles = ["judge"]
+[petri.role.judge]
+default_model = "claude-sonnet-4-6"
+allowed_models = ["claude-sonnet-4-6"]
+[petri.source.anthropic]
+default = "api_key"
+allowed = ["api_key"]
+[petri.adapter.anthropic.api_key]
+module = "plugins.petri_audit.adapters.http_anthropic"
+inspect_prefix = "anthropic"
+auth_env_vars = ["ANTHROPIC_API_KEY"]
+""",
+        encoding="utf-8",
+    )
+    m1 = load_manifest(target)
+    m2 = load_manifest(target)
+    assert m1 is m2
+
+
+def test_clear_manifest_cache_forces_reload(tmp_path: Path):
+    target = tmp_path / "petri.plugin.toml"
+    body = """
+[petri]
+enabled_roles = ["judge"]
+[petri.role.judge]
+default_model = "claude-sonnet-4-6"
+allowed_models = ["claude-sonnet-4-6"]
+[petri.source.anthropic]
+default = "api_key"
+allowed = ["api_key"]
+[petri.adapter.anthropic.api_key]
+module = "plugins.petri_audit.adapters.http_anthropic"
+inspect_prefix = "anthropic"
+auth_env_vars = ["ANTHROPIC_API_KEY"]
+"""
+    target.write_text(body, encoding="utf-8")
+    m1 = load_manifest(target)
+    clear_manifest_cache()
+    m2 = load_manifest(target)
+    assert m1 is not m2
+
+
+# ── Schema dataclass roundtrip ─────────────────────────────────────────────
+
+
+def test_role_spec_round_trip():
+    spec = RoleSpec(
+        default_model="x",
+        allowed_models=["x", "y"],
+        role_contract="roles/x.md",
+    )
+    assert spec.default_model == "x"
+    assert spec.role_contract == "roles/x.md"
+
+
+def test_source_spec_round_trip():
+    spec = SourceSpec(default="api_key", allowed=["api_key", "auto"])
+    assert spec.default == "api_key"
+
+
+def test_adapter_spec_optional_fields():
+    spec = AdapterSpec(
+        module="plugins.petri_audit.adapters.http_anthropic",
+        inspect_prefix="anthropic",
+    )
+    assert spec.auth_env_vars == []
+    assert spec.endpoint is None
+    assert spec.binary is None


### PR DESCRIPTION
## Summary
- `plugins/petri_audit/petri.plugin.toml` 선언적 manifest + `manifest.py` pydantic loader 신설
- 4-layer schema (role × source × adapter) + cross-layer 검증 + lru_cache 기반 reload
- P1 (Petri routing externalisation) 의 첫 PR — 후속 P1-B..G 에서 hardcoded if/elif chain 을 manifest 조회로 치환할 기반

## Why
사용자 요청 — GEODE/Petri 의 하드코딩 라우팅을 config.toml + .env 체계로 관리할 수 있도록 정렬. 14 개 카테고리 grounding 결과 중 Petri 측 if/elif chain (`plugins/petri_audit/models.py::to_inspect_model` 134-176, `family_of` 70-81) 이 가장 먼저 manifest 화 가능한 영역. OpenClaw `plugin.json` + Crumb actor MD + Hermes credential_sources 의 3-source 융합 패턴.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/petri.plugin.toml` | 신설 — manifest declarative schema (4-layer) |
| `plugins/petri_audit/manifest.py` | 신설 — pydantic RoleSpec / SourceSpec / AdapterSpec / PetriManifest + load_manifest() |
| `tests/plugins/petri_audit/test_manifest.py` | 신설 — 19 cases (happy × negative × accessor × cache) |
| `CHANGELOG.md` | [Unreleased] Added 항목 (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `petri.plugin.toml` 신설 | Implemented | role × source × adapter 4-layer |
| `manifest.py` loader | Implemented | pydantic + lru_cache |
| Cross-layer 검증 | Implemented | default ∈ allowed, adapter coverage, role consistency |
| 단위 테스트 | Implemented | 19/19 pass |

## Verification
- [x] ruff check clean (plugins/petri_audit/ + tests/plugins/petri_audit/test_manifest.py)
- [x] mypy clean (plugins/petri_audit/manifest.py)
- [x] pytest pass (19/19 — test_manifest.py)
- [x] manifest loads at runtime (default path + tmp_path fixture)

## Reference
- OpenClaw `extensions/anthropic/openclaw.plugin.json` — declarative plugin manifest schema
- Crumb `agents/coordinator.md` — actor MD + YAML frontmatter contract
- Hermes `agent/credential_sources.py` — per-source credential enumeration
- 계획: P1-A → P1-B (role MD) → P1-C (adapter split) → P1-D (credential_source) → P1-E (registry) → P1-F (/petri picker) → P1-G (to_inspect_model 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)