### PR TITLE
feat(petri): role contracts + frontmatter parser (P1-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,27 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **Petri role contracts (P1-B) — auditor/target/judge MD + frontmatter parser.**
+  `plugins/petri_audit/roles/{auditor,target,judge}.md` 신설 — Crumb
+  `agents/coordinator.md` 의 YAML frontmatter + Goal/Contract/Constraints
+  패턴 차용. 각 contract 는 frontmatter (role / description /
+  default_model / default_source / inline_skills) + 본문 (Goal /
+  Contract / Constraints / References). `manifest.py` 에 `RoleContract`
+  pydantic 모델 + `parse_role_contract()` (lazy pyyaml import) +
+  `PetriManifest.get_role_contract()` 일치성 검증 (frontmatter.role ↔
+  manifest key, frontmatter.default_model ↔ manifest default_model
+  ∈ allowed_models). P1-F 의 /petri picker 가 description 을 표시할
+  단일 SOT.
+
+- **Petri role contracts (P1-B) — auditor/target/judge MD + frontmatter parser.**
+  Added `plugins/petri_audit/roles/{auditor,target,judge}.md` following
+  Crumb's `agents/coordinator.md` pattern (YAML frontmatter + Goal /
+  Contract / Constraints / References). `manifest.py` gains a
+  `RoleContract` pydantic model + `parse_role_contract()` (lazy pyyaml
+  import) + `PetriManifest.get_role_contract()` cross-checking
+  frontmatter against the manifest entry. Single SOT for the upcoming
+  `/petri` picker's description text.
+
 - **Petri audit manifest (P1-A) — `petri.plugin.toml` 선언적 schema.**
   `plugins/petri_audit/petri.plugin.toml` 신설 + `manifest.py` pydantic
   loader. 4-layer schema — `[petri]` enabled_roles, `[petri.role.<name>]`

--- a/plugins/petri_audit/manifest.py
+++ b/plugins/petri_audit/manifest.py
@@ -30,9 +30,11 @@ __all__ = [
     "DEFAULT_MANIFEST_PATH",
     "AdapterSpec",
     "PetriManifest",
+    "RoleContract",
     "RoleSpec",
     "SourceSpec",
     "load_manifest",
+    "parse_role_contract",
 ]
 
 DEFAULT_MANIFEST_PATH = Path(__file__).parent / "petri.plugin.toml"
@@ -147,6 +149,81 @@ class PetriManifest(BaseModel):
                 f"known sources for this family={sorted(family_adapters)}"
             )
         return family_adapters[source]
+
+    def get_role_contract(self, role: str, *, base_dir: Path | None = None) -> RoleContract:
+        """Parse and validate the role contract MD for ``role``.
+
+        ``base_dir`` defaults to the directory holding the manifest TOML;
+        relative ``role_contract`` paths in the manifest resolve against it.
+        Raises ``ValueError`` on frontmatter / manifest mismatch.
+        """
+        spec = self.get_role(role)
+        if not spec.role_contract:
+            raise ValueError(f"role {role!r} has no role_contract path in manifest")
+        base = base_dir or DEFAULT_MANIFEST_PATH.parent
+        contract_path = (base / spec.role_contract).resolve()
+        contract = parse_role_contract(contract_path)
+        if contract.role != role:
+            raise ValueError(
+                f"{contract_path}: frontmatter role={contract.role!r} != manifest key {role!r}"
+            )
+        if contract.default_model != spec.default_model:
+            raise ValueError(
+                f"{contract_path}: frontmatter default_model="
+                f"{contract.default_model!r} != manifest default_model="
+                f"{spec.default_model!r}"
+            )
+        if contract.default_model not in spec.allowed_models:
+            raise ValueError(
+                f"{contract_path}: default_model={contract.default_model!r} "
+                f"not in manifest allowed_models {spec.allowed_models}"
+            )
+        return contract
+
+
+class RoleContract(BaseModel):
+    """Parsed YAML frontmatter from a `roles/<role>.md` contract file.
+
+    The contract MD is human-readable documentation + machine-readable
+    metadata; runtime authority remains with the manifest. This schema
+    enforces frontmatter shape so a malformed contract is caught at
+    load time, not when /petri picker reads ``description``.
+    """
+
+    role: str
+    description: str
+    default_model: str
+    default_source: str
+    inline_skills: list[str] = Field(default_factory=list)
+
+
+def parse_role_contract(path: Path) -> RoleContract:
+    """Parse a role contract MD's YAML frontmatter.
+
+    Expected layout::
+
+        ---
+        role: ...
+        description: ...
+        ---
+
+        # Body (markdown — ignored by this parser)
+
+    Raises :class:`ValueError` when the file is missing a frontmatter
+    block, the YAML is not a mapping, or required fields are absent.
+    """
+    import yaml  # lazy — only role contract loading triggers it
+
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise ValueError(f"{path}: missing YAML frontmatter (file must start with '---')")
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise ValueError(f"{path}: malformed frontmatter — expected '---\\n...\\n---\\n' block")
+    data = yaml.safe_load(parts[1])
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: frontmatter is not a YAML mapping (got {type(data).__name__})")
+    return RoleContract(**data)
 
 
 def _parse_manifest_dict(data: dict[str, Any]) -> PetriManifest:

--- a/plugins/petri_audit/roles/auditor.md
+++ b/plugins/petri_audit/roles/auditor.md
@@ -1,0 +1,52 @@
+---
+role: auditor
+description: >-
+  Petri 5-axis evaluator. Reads target output + IP context, emits structured
+  score tuple (predictive / robustness / auxiliary). Pure reasoning — no tool
+  use. Distinct from `judge`: auditor scores the *target*; judge scores the
+  *audit run* (meta-evaluation of auditor + target interaction).
+default_model: claude-sonnet-4-6
+default_source: auto
+inline_skills:
+  - geode-pipeline
+  - geode-scoring
+  - geode-verification
+---
+
+# Auditor
+
+## Goal
+
+Given a target's IP analysis output + fixture context, produce a 5-axis
+evaluation tuple with rubric-aligned scoring rationale. The auditor's
+output feeds the optimiser's gradient signal (predictive PSM ± robustness
+± auxiliary cross-axis penalty).
+
+## Contract
+
+| Direction | Shape |
+|-----------|-------|
+| in        | `{target_output: str, fixture: IPFixture, rubric: Rubric}` |
+| out       | `{predictive: float, robustness: float, auxiliary: float, rationale: str}` |
+
+- Scores ∈ `[0, 100]` (float).
+- `rationale` ≤ 2000 chars, KR / EN free.
+- Family constraint: auditor model MUST NOT share `family_of()` with the
+  target's base LLM (M1 mitigation against self-preference / in-context
+  reward hacking — see `plugins.petri_audit.optimize`).
+
+## Constraints
+
+- No tool calls — auditor is pure reasoning, deterministic temperature.
+- Apply the rubric verbatim; do not introduce ad-hoc criteria.
+- Surface uncertainty in `rationale` (e.g. "context window truncated at
+  axis 3") rather than silently downscoring.
+- When the target output is malformed (missing required field, JSON
+  parse error), emit `predictive=0` with the parse error in
+  `rationale`; do not attempt repair.
+
+## References
+
+- `plugins.petri_audit.judge_schema` — output JSON schema.
+- `plugins.petri_audit.optimize` — gradient signal consumption.
+- Manifest binding: `[petri.role.auditor]` in `petri.plugin.toml`.

--- a/plugins/petri_audit/roles/judge.md
+++ b/plugins/petri_audit/roles/judge.md
@@ -1,0 +1,57 @@
+---
+role: judge
+description: >-
+  Meta-evaluator. Scores the auditor's rubric application + the target's
+  behaviour together. Distinct from `auditor`: auditor scores the target
+  output; judge scores the audit run as a whole and emits the final
+  inspect_ai `Score` object. Cross-family constraint (judge ≠ generator)
+  is enforced at audit setup.
+default_model: claude-sonnet-4-6
+default_source: auto
+inline_skills:
+  - geode-verification
+  - karpathy-patterns
+---
+
+# Judge
+
+## Goal
+
+Read the auditor's scores + rationale + the target's full transcript,
+and emit a final inspect_ai `Score` object that the eval archive
+records. The judge's verdict is what the optimiser's outer loop reads
+as the run's headline metric.
+
+## Contract
+
+| Direction | Shape |
+|-----------|-------|
+| in        | `{auditor_output: AuditorScore, target_transcript: list[Message], rubric: Rubric}` |
+| out       | `inspect_ai.scorer.Score(value=float, answer=str, explanation=str, metadata=dict)` |
+
+- `value` ∈ `[0, 1]` (inspect_ai contract; auditor's `predictive`
+  / 100 typically).
+- `metadata` carries the per-axis breakdown for the proximity-graph
+  consumer (`plugins.petri_audit.viz`).
+- Family constraint: judge model MUST NOT share `family_of()` with
+  either the auditor OR the target's base LLM (M1+M2 mitigation —
+  guards against transitive self-preference).
+
+## Constraints
+
+- No tool calls — judge is pure reasoning.
+- Judge MUST surface scoring drift in `explanation` when the auditor's
+  rationale and the transcript disagree (e.g. auditor scored 80 but
+  target's transcript shows a tool-budget exhaustion).
+- The judge sees both raw scores and rationale; weight the rationale
+  when scores look anomalous, weight the scores when rationale is
+  uninformative.
+- A judge override of the auditor's verdict is recorded explicitly in
+  `metadata.judge_override = true` so the archive can flag
+  high-disagreement runs.
+
+## References
+
+- `plugins.petri_audit.judge_schema` — Score output JSON schema.
+- `plugins.petri_audit.judge_dims` — per-dimension judges (Q / S / R / ...).
+- Manifest binding: `[petri.role.judge]` in `petri.plugin.toml`.

--- a/plugins/petri_audit/roles/target.md
+++ b/plugins/petri_audit/roles/target.md
@@ -1,0 +1,52 @@
+---
+role: target
+description: >-
+  System under test. Always routed through `GeodeModelAPI` (`geode/<model>`)
+  regardless of family — the audit evaluates GEODE-as-a-system (agentic
+  loop + tools + hooks + memory), not the base LLM in isolation. User
+  pins the base LLM that GEODE uses internally; the wrapper is fixed.
+default_model: claude-haiku-4-5
+default_source: auto
+inline_skills: []
+---
+
+# Target
+
+## Goal
+
+Run the full GEODE stack against a fixture and produce a complete
+IP analysis output. The auditor scores *this* output; the judge scores
+the auditor's scoring + the target's behaviour together.
+
+## Contract
+
+| Direction | Shape |
+|-----------|-------|
+| in        | `{fixture: IPFixture, base_model: str}` |
+| out       | `{report: IPAnalysisReport, tool_trace: list[ToolCall], cost: CostBreakdown}` |
+
+- `base_model` ∈ `[petri.role.target].allowed_models` (manifest enforced).
+- Inspect identifier: always `geode/<base_model>` — the
+  ``GeodeModelAPI`` adapter intercepts and routes through the full
+  agentic loop, tools, hooks, memory, and drift-sync.
+- Cost tracking is mandatory — the optimiser's frontier (cost vs.
+  quality) reads `cost.total_usd`.
+
+## Constraints
+
+- Target NEVER runs in dry-run mode during an audit (defeats the point
+  of evaluating real LLM behaviour).
+- Tool budget is bounded by `settings.audit_target_tool_budget` (default
+  20) to keep cost predictable; over-budget runs are truncated and
+  flagged in `tool_trace`.
+- Streaming / non-streaming is determined by GEODE's runtime, not the
+  target spec — the audit must match production behaviour.
+- A target failure (LLM 5xx, timeout) emits an empty report + the error
+  in `tool_trace`; the auditor handles the scoring of malformed output.
+
+## References
+
+- `plugins.petri_audit.targets.geode_target` — `GeodeModelAPI`
+  registration (inspect_ai `modelapi(name="geode")`).
+- `plugins.petri_audit.runner` — orchestrates target invocation.
+- Manifest binding: `[petri.role.target]` in `petri.plugin.toml`.

--- a/tests/plugins/petri_audit/test_manifest.py
+++ b/tests/plugins/petri_audit/test_manifest.py
@@ -9,11 +9,13 @@ from plugins.petri_audit.manifest import (
     DEFAULT_MANIFEST_PATH,
     AdapterSpec,
     PetriManifest,
+    RoleContract,
     RoleSpec,
     SourceSpec,
     _parse_manifest_dict,
     clear_manifest_cache,
     load_manifest,
+    parse_role_contract,
 )
 
 
@@ -255,3 +257,143 @@ def test_adapter_spec_optional_fields():
     assert spec.auth_env_vars == []
     assert spec.endpoint is None
     assert spec.binary is None
+
+
+# ── Role contract parsing ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("role", ["auditor", "target", "judge"])
+def test_default_role_contracts_parse(role: str):
+    """Every role enabled in the default manifest has a parsable contract MD
+    whose frontmatter agrees with the manifest entry."""
+    manifest = load_manifest()
+    contract = manifest.get_role_contract(role)
+    assert isinstance(contract, RoleContract)
+    assert contract.role == role
+    spec = manifest.get_role(role)
+    assert contract.default_model == spec.default_model
+    assert contract.default_model in spec.allowed_models
+
+
+def test_role_contract_inline_skills_optional(tmp_path: Path):
+    contract_path = tmp_path / "x.md"
+    contract_path.write_text(
+        """---
+role: x
+description: minimal
+default_model: m
+default_source: auto
+---
+
+body
+""",
+        encoding="utf-8",
+    )
+    contract = parse_role_contract(contract_path)
+    assert contract.inline_skills == []
+
+
+def test_parse_role_contract_missing_frontmatter(tmp_path: Path):
+    bad = tmp_path / "no_frontmatter.md"
+    bad.write_text("# Just a heading\n\nNo frontmatter here.\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing YAML frontmatter"):
+        parse_role_contract(bad)
+
+
+def test_parse_role_contract_malformed_unclosed(tmp_path: Path):
+    bad = tmp_path / "malformed.md"
+    bad.write_text("---\nrole: x\ndescription: never closes\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed frontmatter"):
+        parse_role_contract(bad)
+
+
+def test_parse_role_contract_frontmatter_not_mapping(tmp_path: Path):
+    bad = tmp_path / "list_frontmatter.md"
+    bad.write_text("---\n- a\n- b\n---\nbody\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="not a YAML mapping"):
+        parse_role_contract(bad)
+
+
+def test_get_role_contract_role_mismatch(tmp_path: Path):
+    """Frontmatter role != manifest key → ValueError."""
+    contract_path = tmp_path / "wrong_role.md"
+    contract_path.write_text(
+        """---
+role: imposter
+description: wrong role
+default_model: claude-sonnet-4-6
+default_source: auto
+---
+""",
+        encoding="utf-8",
+    )
+    # Use the default manifest's auditor entry, but point its role_contract
+    # at our tmp file with a mismatched role frontmatter.
+    manifest = load_manifest()
+    auditor_spec = manifest.get_role("auditor")
+    # Build a transient PetriManifest pointing at the tmp file.
+    bad_manifest = PetriManifest(
+        enabled_roles=["auditor"],
+        roles={
+            "auditor": RoleSpec(
+                default_model=auditor_spec.default_model,
+                allowed_models=auditor_spec.allowed_models,
+                role_contract=str(contract_path.name),
+            )
+        },
+        sources=manifest.sources,
+        adapters=manifest.adapters,
+    )
+    with pytest.raises(ValueError, match="frontmatter role="):
+        bad_manifest.get_role_contract("auditor", base_dir=tmp_path)
+
+
+def test_get_role_contract_default_model_mismatch(tmp_path: Path):
+    """Frontmatter default_model != manifest default_model → ValueError."""
+    contract_path = tmp_path / "auditor.md"
+    contract_path.write_text(
+        """---
+role: auditor
+description: drifted default_model
+default_model: claude-opus-4-7
+default_source: auto
+---
+""",
+        encoding="utf-8",
+    )
+    manifest = load_manifest()
+    auditor_spec = manifest.get_role("auditor")
+    bad_manifest = PetriManifest(
+        enabled_roles=["auditor"],
+        roles={
+            "auditor": RoleSpec(
+                default_model=auditor_spec.default_model,  # claude-sonnet-4-6
+                allowed_models=auditor_spec.allowed_models,
+                role_contract="auditor.md",
+            )
+        },
+        sources=manifest.sources,
+        adapters=manifest.adapters,
+    )
+    with pytest.raises(ValueError, match="frontmatter default_model="):
+        bad_manifest.get_role_contract("auditor", base_dir=tmp_path)
+
+
+def test_get_role_contract_no_path_raises(tmp_path: Path):
+    """role_contract = None in manifest → get_role_contract raises."""
+    manifest = load_manifest()
+    auditor_spec = manifest.get_role("auditor")
+    bad_manifest = PetriManifest(
+        enabled_roles=["auditor"],
+        roles={
+            "auditor": RoleSpec(
+                default_model=auditor_spec.default_model,
+                allowed_models=auditor_spec.allowed_models,
+                role_contract=None,
+            )
+        },
+        sources=manifest.sources,
+        adapters=manifest.adapters,
+    )
+    with pytest.raises(ValueError, match="no role_contract path"):
+        bad_manifest.get_role_contract("auditor", base_dir=tmp_path)


### PR DESCRIPTION
## Summary
- `plugins/petri_audit/roles/{auditor,target,judge}.md` 3 role contract MD 신설 (Crumb agents 패턴)
- `manifest.py` 에 `RoleContract` pydantic + `parse_role_contract()` + `PetriManifest.get_role_contract()` 일치성 검증
- P1-F /petri picker 의 description SOT

## Why
P1-A 의 manifest schema 는 role 의 default/allowed model 만 보유 — 사람이 읽을 수 있는 description, role contract (Goal / Constraints), inline_skills metadata 가 부재. Crumb 의 actor MD 패턴은 frontmatter + 본문으로 두 요구를 동시 만족. P1-F picker 가 description 을 표시할 때 manifest 의 string field 가 아니라 contract MD 를 단일 SOT 로 사용.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/roles/auditor.md` | 신설 — 5-axis 평가자 contract |
| `plugins/petri_audit/roles/target.md` | 신설 — GeodeModelAPI 경유 system-under-test contract |
| `plugins/petri_audit/roles/judge.md` | 신설 — meta-evaluator contract |
| `plugins/petri_audit/manifest.py` | RoleContract / parse_role_contract / get_role_contract 추가 (lazy pyyaml) |
| `tests/plugins/petri_audit/test_manifest.py` | 10 신규 — parametrize 3 + 부정 검증 7 |
| `CHANGELOG.md` | [Unreleased] Added 항목 (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 3 role contract MD | Implemented | frontmatter + 본문 (Goal/Contract/Constraints/References) |
| RoleContract pydantic | Implemented | role / description / default_model / default_source / inline_skills |
| parse_role_contract() | Implemented | lazy pyyaml import |
| get_role_contract() 일치성 검증 | Implemented | role / default_model / allowed_models 3중 검증 |
| 단위 테스트 | Implemented | 10/10 pass — parametrize 3 + 부정 7 |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (plugins/petri_audit/manifest.py)
- [x] pytest pass (29/29 — test_manifest.py)

## Reference
- Crumb `agents/coordinator.md` — actor MD + YAML frontmatter (5 actor)
- 후속 P1-C (adapter split) → P1-D (credential_source) → P1-E (registry) → P1-F (/petri picker, description 사용처) → P1-G (to_inspect_model 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)