### PR TITLE
feat(petri): adapter registry + 5 module facades (P1-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,30 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **Petri adapter registry (P1-C) — manifest-driven lazy dispatch.**
+  `plugins/petri_audit/adapters/` 신설 — 5 adapter wrapper +
+  registry (`__init__.py`). 각 adapter (`http_anthropic`, `http_openai`,
+  `http_zhipuai`, `claude_cli_backend`, `openai_codex_oauth`) 는
+  uniform 인터페이스 — `INSPECT_PREFIX`, `register()`, `is_available()`,
+  optional `metadata()` — 노출. registry helper 는 `load_adapter_module()`,
+  `register_adapter()`, `is_adapter_available()`, `get_adapter_metadata()`.
+  OAuth 어댑터 (claude_cli_backend, openai_codex_oauth) 는 기존
+  `claude_code_provider.py` / `codex_provider.py` 의 thin re-export —
+  실제 코드 흡수는 P1-G 의 routing 갱신 시점에 결정. P1-E registry
+  + P1-F /petri picker 가 hardcoded if/elif chain 대신 manifest 의
+  `[petri.adapter.<family>.<source>]` 으로 dispatch 할 수 있는 기반.
+
+- **Petri adapter registry (P1-C) — manifest-driven lazy dispatch.**
+  Added `plugins/petri_audit/adapters/` — 5 adapter facades + a
+  registry (`__init__.py`). Each adapter exposes the uniform contract
+  `INSPECT_PREFIX` / `register()` / `is_available()` / optional
+  `metadata()`. The OAuth adapters (`claude_cli_backend`,
+  `openai_codex_oauth`) are thin re-exports of the existing
+  `claude_code_provider.py` and `codex_provider.py`; the call into
+  those legacy modules will collapse when P1-G migrates the
+  `to_inspect_model` routing onto the manifest. Foundation for the
+  upcoming P1-E (registry binding) + P1-F (/petri picker).
+
 - **Petri role contracts (P1-B) — auditor/target/judge MD + frontmatter parser.**
   `plugins/petri_audit/roles/{auditor,target,judge}.md` 신설 — Crumb
   `agents/coordinator.md` 의 YAML frontmatter + Goal/Contract/Constraints

--- a/plugins/petri_audit/adapters/__init__.py
+++ b/plugins/petri_audit/adapters/__init__.py
@@ -1,0 +1,136 @@
+"""Petri audit adapter registry — manifest-driven lazy dispatch.
+
+Each ``(family, source)`` pair in :mod:`plugins.petri_audit.manifest`
+maps to a concrete adapter module. The registry imports those modules
+lazily so the default ``uv sync`` (no ``[audit]`` extra) keeps cold-start
+clean, and exposes a uniform interface:
+
+- :func:`load_adapter_module` — import the module declared by manifest.
+- :func:`register_adapter` — call the module's ``register()`` (if any),
+  which wires its inspect_ai ``ModelAPI`` into the global registry.
+- :func:`is_adapter_available` — call the module's ``is_available()``
+  (if any) to probe credentials without side effects.
+
+Adapter module contract (loose — registry checks ``hasattr`` per call):
+
+- ``register() -> None`` — idempotent inspect_ai registration. Stock
+  providers (e.g. plain ``anthropic/``, ``openai/``) need no extra
+  registration; the function may be absent or a no-op.
+- ``is_available() -> bool`` — readiness probe. Stock providers fall
+  back to env-var presence; OAuth-backed adapters check the keychain
+  / authoritative token file.
+- ``metadata() -> dict | None`` (optional) — picker-friendly metadata
+  (subscription plan, scopes, expiry). Only OAuth adapters populate.
+
+Used by the upcoming P1-E registry layer (role × source binding) and
+the /petri picker (P1-F) to keep adapter selection logic out of the
+hardcoded if/elif chain in :mod:`plugins.petri_audit.models`.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+from plugins.petri_audit.manifest import AdapterSpec, load_manifest
+
+__all__ = [
+    "get_adapter_metadata",
+    "get_adapter_spec",
+    "is_adapter_available",
+    "load_adapter_module",
+    "register_adapter",
+]
+
+
+def get_adapter_spec(family: str, source: str) -> AdapterSpec:
+    """Return the :class:`AdapterSpec` declared by the active manifest.
+
+    Thin wrapper kept here so callers don't need to import
+    :func:`plugins.petri_audit.manifest.load_manifest` directly.
+    """
+    return load_manifest().get_adapter(family, source)
+
+
+def load_adapter_module(family: str, source: str) -> ModuleType:
+    """Import the adapter module for ``(family, source)`` lazily.
+
+    Raises :class:`ImportError` when the declared module is missing
+    (e.g. the ``[audit]`` extra is not installed and the adapter
+    depends on it); raises :class:`KeyError` when the manifest has no
+    binding for the pair (see :class:`PetriManifest.get_adapter`).
+    """
+    spec = get_adapter_spec(family, source)
+    return importlib.import_module(spec.module)
+
+
+def register_adapter(family: str, source: str) -> None:
+    """Invoke the adapter module's ``register()`` if it exposes one.
+
+    Stock providers (inspect_ai's native ``anthropic`` / ``openai`` /
+    ``geode``) need no explicit registration; their modules either omit
+    ``register`` or implement a no-op. OAuth-backed adapters (claude-cli
+    keychain, codex OAuth) use ``register()`` to wire a ``ModelAPI``
+    subclass into inspect_ai's registry. Idempotent — inspect_ai's
+    registry overwrites existing entries with the same name.
+    """
+    module = load_adapter_module(family, source)
+    register_fn = getattr(module, "register", None)
+    if callable(register_fn):
+        register_fn()
+
+
+def is_adapter_available(family: str, source: str) -> bool:
+    """Probe whether the adapter has credentials to run.
+
+    Returns ``True`` when:
+
+    - the module exposes ``is_available() -> bool`` and it returns True; OR
+    - the module has no ``is_available`` AND has the env vars listed in
+      its :class:`AdapterSpec.auth_env_vars` (fallback for stock
+      providers that lean on env-var probes).
+
+    Returns ``False`` otherwise. Never raises — credential probes must
+    be side-effect-free, so import failures collapse to "unavailable".
+    """
+    try:
+        module = load_adapter_module(family, source)
+    except ImportError:
+        return False
+    probe = getattr(module, "is_available", None)
+    if callable(probe):
+        try:
+            return bool(probe())
+        except Exception:
+            return False
+    # Fallback — check env vars from the manifest.
+    import os
+
+    spec = get_adapter_spec(family, source)
+    if not spec.auth_env_vars:
+        # No env vars declared and no probe function — assume available
+        # (e.g. geode target adapter, which uses GeodeModelAPI internally).
+        return True
+    return any(os.environ.get(env_var) for env_var in spec.auth_env_vars)
+
+
+def get_adapter_metadata(family: str, source: str) -> dict[str, Any] | None:
+    """Return picker-friendly metadata from the adapter module.
+
+    Only OAuth-backed adapters populate this — stock API-key adapters
+    return ``None``. Errors collapse to ``None`` (consumer should treat
+    missing metadata as benign and fall back to defaults).
+    """
+    try:
+        module = load_adapter_module(family, source)
+    except ImportError:
+        return None
+    fn = getattr(module, "metadata", None)
+    if not callable(fn):
+        return None
+    try:
+        result = fn()
+    except Exception:
+        return None
+    return result if isinstance(result, dict) else None

--- a/plugins/petri_audit/adapters/claude_cli_backend.py
+++ b/plugins/petri_audit/adapters/claude_cli_backend.py
@@ -1,0 +1,55 @@
+"""Claude OAuth (subscription quota) adapter — manifest-bound facade.
+
+Maps the manifest binding ``[petri.adapter.anthropic.claude-cli]`` to
+the existing :mod:`plugins.petri_audit.claude_code_provider`. The
+provider already implements the inspect_ai ``claude-code`` ``ModelAPI``
+subclass (OAuth token resolved from the local ``claude`` CLI keychain
++ GEODE auth.toml fallback); this module is a thin re-export so the
+adapter registry has a stable import target and so a future P1-G
+refactor can collapse the call sites onto the manifest contract
+without re-shuffling exports.
+
+The original :mod:`plugins.petri_audit.claude_code_provider` stays the
+authoritative implementation for now — P1-G will migrate the routing
+in :mod:`plugins.petri_audit.models.to_inspect_model` onto the
+manifest, at which point we can decide whether to fold the provider
+into this file or keep the indirection. Either way the public surface
+documented here is the long-term contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from plugins.petri_audit.claude_code_provider import (
+    get_claude_oauth_metadata,
+    is_claude_oauth_available,
+)
+from plugins.petri_audit.claude_code_provider import (
+    register as _register_claude_code,
+)
+
+__all__ = ["INSPECT_PREFIX", "is_available", "metadata", "register"]
+
+INSPECT_PREFIX = "claude-code"
+
+
+def register() -> None:
+    """Register the ``claude-code`` ``ModelAPI`` with inspect_ai."""
+    _register_claude_code()
+
+
+def is_available() -> bool:
+    """True when the Claude OAuth token resolves (auth.toml or keychain)."""
+    return is_claude_oauth_available()
+
+
+def metadata() -> dict[str, Any] | None:
+    """Return picker-friendly subscription metadata.
+
+    Shape — ``{subscription_type, rate_limit_tier, scopes, expires_at,
+    source}``. ``None`` when no OAuth token is available. See
+    :func:`plugins.petri_audit.claude_code_provider.get_claude_oauth_metadata`
+    for the field-level contract.
+    """
+    return get_claude_oauth_metadata()

--- a/plugins/petri_audit/adapters/http_anthropic.py
+++ b/plugins/petri_audit/adapters/http_anthropic.py
@@ -1,0 +1,34 @@
+"""HTTP API-key adapter for Anthropic — stock inspect_ai pathway.
+
+Maps the manifest binding ``[petri.adapter.anthropic.api_key]`` to
+inspect_ai's native ``anthropic/<model>`` provider. No subclass is
+needed because inspect_ai already speaks the Anthropic Messages API
+when ``ANTHROPIC_API_KEY`` is present; this module exists so the
+adapter registry has a concrete import target + a uniform readiness
+probe.
+
+Contract surface:
+
+- :func:`register` is a no-op (stock provider auto-registers).
+- :func:`is_available` checks ``ANTHROPIC_API_KEY`` env presence.
+- :data:`INSPECT_PREFIX` mirrors the manifest entry so callers can
+  build ``f"{INSPECT_PREFIX}/{model}"`` ids without re-parsing the TOML.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["INSPECT_PREFIX", "is_available", "register"]
+
+INSPECT_PREFIX = "anthropic"
+
+
+def register() -> None:
+    """No-op — inspect_ai registers the stock ``AnthropicAPI`` itself."""
+    return None
+
+
+def is_available() -> bool:
+    """True when ``ANTHROPIC_API_KEY`` is set in the environment."""
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))

--- a/plugins/petri_audit/adapters/http_openai.py
+++ b/plugins/petri_audit/adapters/http_openai.py
@@ -1,0 +1,24 @@
+"""HTTP API-key adapter for OpenAI — stock inspect_ai pathway.
+
+Maps the manifest binding ``[petri.adapter.openai.api_key]`` to
+inspect_ai's native ``openai/<model>`` provider. Sibling of
+:mod:`plugins.petri_audit.adapters.http_anthropic`.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["INSPECT_PREFIX", "is_available", "register"]
+
+INSPECT_PREFIX = "openai"
+
+
+def register() -> None:
+    """No-op — inspect_ai registers the stock ``OpenAIAPI`` itself."""
+    return None
+
+
+def is_available() -> bool:
+    """True when ``OPENAI_API_KEY`` is set in the environment."""
+    return bool(os.environ.get("OPENAI_API_KEY"))

--- a/plugins/petri_audit/adapters/http_zhipuai.py
+++ b/plugins/petri_audit/adapters/http_zhipuai.py
@@ -1,0 +1,33 @@
+"""HTTP API-key adapter for Zhipu (GLM family) — routes via GeodeModelAPI.
+
+Maps the manifest binding ``[petri.adapter.zhipuai.api_key]`` to
+inspect_ai's ``geode/<model>`` provider (registered by
+:mod:`plugins.petri_audit.targets.geode_target`). inspect_ai has no
+native GLM provider, so GLM family ids are routed through the GEODE
+wrapper that the full agentic stack uses anyway — the same path
+production code takes.
+
+Registration is shared with the target adapter; this module just
+exposes the readiness probe + inspect_prefix metadata so the registry
+has a uniform import target.
+"""
+
+from __future__ import annotations
+
+import os
+
+from plugins.petri_audit.targets.geode_target import register as _register_geode
+
+__all__ = ["INSPECT_PREFIX", "is_available", "register"]
+
+INSPECT_PREFIX = "geode"
+
+
+def register() -> None:
+    """Register the ``geode`` ``ModelAPI`` (shared with the target adapter)."""
+    _register_geode()
+
+
+def is_available() -> bool:
+    """True when ``ZHIPUAI_API_KEY`` is set in the environment."""
+    return bool(os.environ.get("ZHIPUAI_API_KEY"))

--- a/plugins/petri_audit/adapters/openai_codex_oauth.py
+++ b/plugins/petri_audit/adapters/openai_codex_oauth.py
@@ -1,0 +1,38 @@
+"""OpenAI Codex OAuth (ChatGPT Plus quota) adapter — manifest-bound facade.
+
+Maps the manifest binding ``[petri.adapter.openai.openai-codex]`` to
+the existing :mod:`plugins.petri_audit.codex_provider`. Sibling of
+:mod:`plugins.petri_audit.adapters.claude_cli_backend` — re-export
+only so the adapter registry has a stable import target.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from plugins.petri_audit.codex_provider import (
+    get_codex_oauth_metadata,
+    is_codex_oauth_available,
+)
+from plugins.petri_audit.codex_provider import (
+    register as _register_codex,
+)
+
+__all__ = ["INSPECT_PREFIX", "is_available", "metadata", "register"]
+
+INSPECT_PREFIX = "openai-codex"
+
+
+def register() -> None:
+    """Register the ``openai-codex`` ``ModelAPI`` with inspect_ai."""
+    _register_codex()
+
+
+def is_available() -> bool:
+    """True when the Codex OAuth token resolves."""
+    return is_codex_oauth_available()
+
+
+def metadata() -> dict[str, Any] | None:
+    """Return picker-friendly subscription metadata."""
+    return get_codex_oauth_metadata()

--- a/tests/plugins/petri_audit/test_adapters.py
+++ b/tests/plugins/petri_audit/test_adapters.py
@@ -1,0 +1,174 @@
+"""Unit tests for the Petri adapter registry + per-adapter facades (P1-C)."""
+
+from __future__ import annotations
+
+import pytest
+from plugins.petri_audit.adapters import (
+    get_adapter_metadata,
+    get_adapter_spec,
+    is_adapter_available,
+    load_adapter_module,
+    register_adapter,
+)
+from plugins.petri_audit.manifest import AUTO_SOURCE, clear_manifest_cache, load_manifest
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_manifest_cache()
+    yield
+    clear_manifest_cache()
+
+
+def _concrete_bindings() -> list[tuple[str, str]]:
+    """Return every (family, source) pair from the default manifest, skipping
+    the 'auto' sentinel which is not a concrete adapter."""
+    manifest = load_manifest()
+    pairs: list[tuple[str, str]] = []
+    for family, source_spec in manifest.sources.items():
+        for source in source_spec.allowed:
+            if source != AUTO_SOURCE:
+                pairs.append((family, source))
+    return pairs
+
+
+# ── load_adapter_module ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("family,source", _concrete_bindings())
+def test_every_manifest_binding_imports(family: str, source: str):
+    """Every (family, source) declared by manifest resolves to an importable
+    Python module — guards against typos in the manifest module path."""
+    module = load_adapter_module(family, source)
+    assert module is not None
+
+
+@pytest.mark.parametrize("family,source", _concrete_bindings())
+def test_module_exposes_inspect_prefix(family: str, source: str):
+    """Adapter modules export ``INSPECT_PREFIX`` matching the manifest entry."""
+    module = load_adapter_module(family, source)
+    spec = get_adapter_spec(family, source)
+    assert getattr(module, "INSPECT_PREFIX", None) == spec.inspect_prefix
+
+
+# ── register_adapter ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("family,source", _concrete_bindings())
+def test_module_exposes_register(family: str, source: str):
+    """Every adapter module exposes a callable ``register`` (may be a no-op)."""
+    module = load_adapter_module(family, source)
+    register_fn = getattr(module, "register", None)
+    assert callable(register_fn)
+
+
+def test_register_adapter_invokes_module_register(monkeypatch):
+    """``register_adapter`` calls the adapter module's ``register()``."""
+    calls = []
+    module = load_adapter_module("anthropic", "api_key")
+
+    def _fake_register() -> None:
+        calls.append(("anthropic", "api_key"))
+
+    monkeypatch.setattr(module, "register", _fake_register)
+    register_adapter("anthropic", "api_key")
+    assert calls == [("anthropic", "api_key")]
+
+
+def test_register_adapter_no_op_when_module_has_no_register(monkeypatch):
+    """No ``register`` attribute → silently skip (no AttributeError)."""
+    module = load_adapter_module("anthropic", "api_key")
+    monkeypatch.delattr(module, "register", raising=False)
+    register_adapter("anthropic", "api_key")  # no raise
+
+
+# ── is_adapter_available ───────────────────────────────────────────────────
+
+
+def test_is_available_http_anthropic_reads_env(monkeypatch):
+    """http_anthropic.is_available reflects ``ANTHROPIC_API_KEY`` presence."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert is_adapter_available("anthropic", "api_key") is False
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert is_adapter_available("anthropic", "api_key") is True
+
+
+def test_is_available_http_openai_reads_env(monkeypatch):
+    """http_openai.is_available reflects ``OPENAI_API_KEY`` presence."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert is_adapter_available("openai", "api_key") is False
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test")
+    assert is_adapter_available("openai", "api_key") is True
+
+
+def test_is_available_http_zhipuai_reads_env(monkeypatch):
+    """http_zhipuai.is_available reflects ``ZHIPUAI_API_KEY`` presence."""
+    monkeypatch.delenv("ZHIPUAI_API_KEY", raising=False)
+    assert is_adapter_available("zhipuai", "api_key") is False
+    monkeypatch.setenv("ZHIPUAI_API_KEY", "glm-test")
+    assert is_adapter_available("zhipuai", "api_key") is True
+
+
+def test_is_available_swallows_probe_exception(monkeypatch):
+    """A probe that raises collapses to False (no propagation)."""
+    module = load_adapter_module("anthropic", "api_key")
+
+    def _boom() -> bool:
+        raise RuntimeError("probe boom")
+
+    monkeypatch.setattr(module, "is_available", _boom)
+    assert is_adapter_available("anthropic", "api_key") is False
+
+
+def test_is_available_falls_back_to_env_vars_when_no_probe(monkeypatch):
+    """No ``is_available`` attribute → check manifest auth_env_vars."""
+    module = load_adapter_module("anthropic", "api_key")
+    monkeypatch.delattr(module, "is_available", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert is_adapter_available("anthropic", "api_key") is False
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert is_adapter_available("anthropic", "api_key") is True
+
+
+# ── get_adapter_metadata ───────────────────────────────────────────────────
+
+
+def test_metadata_stock_provider_returns_none():
+    """Stock providers (no OAuth) — no metadata function → None."""
+    assert get_adapter_metadata("anthropic", "api_key") is None
+    assert get_adapter_metadata("openai", "api_key") is None
+    assert get_adapter_metadata("zhipuai", "api_key") is None
+
+
+def test_metadata_swallows_exception(monkeypatch):
+    """A metadata function that raises returns None."""
+    module = load_adapter_module("anthropic", "claude-cli")
+
+    def _boom() -> dict:
+        raise RuntimeError("metadata boom")
+
+    monkeypatch.setattr(module, "metadata", _boom)
+    assert get_adapter_metadata("anthropic", "claude-cli") is None
+
+
+def test_metadata_rejects_non_dict(monkeypatch):
+    """Non-dict return values collapse to None."""
+    module = load_adapter_module("anthropic", "claude-cli")
+    monkeypatch.setattr(module, "metadata", lambda: ["not", "a", "dict"])
+    assert get_adapter_metadata("anthropic", "claude-cli") is None
+
+
+# ── Unknown bindings ───────────────────────────────────────────────────────
+
+
+def test_load_unknown_family_raises_keyerror():
+    # ``get_adapter`` falls through to "No adapter for family=…" when the
+    # family has no entry in ``manifest.adapters`` (empty dict). The exact
+    # message is the manifest's; we just verify the failure mode.
+    with pytest.raises(KeyError, match="No adapter for family=nonexistent"):
+        load_adapter_module("nonexistent", "api_key")
+
+
+def test_load_auto_source_raises_valueerror():
+    with pytest.raises(ValueError, match="Cannot resolve adapter for 'auto'"):
+        load_adapter_module("anthropic", AUTO_SOURCE)


### PR DESCRIPTION
## Summary
- `plugins/petri_audit/adapters/` 신설 — manifest 기반 lazy dispatch registry + 5 adapter wrapper
- 각 adapter: `INSPECT_PREFIX`, `register()`, `is_available()`, optional `metadata()`
- OAuth adapter (claude_cli_backend, openai_codex_oauth) 는 기존 provider 의 thin re-export — P1-G 흡수 시점에 결정

## Why
P1-A manifest schema 의 `[petri.adapter.<family>.<source>]` 가 가리키는 모듈을 실체화. 향후 P1-E registry (role × model × source binding) 와 P1-F /petri picker 가 hardcoded if/elif chain (`plugins/petri_audit/models.py::to_inspect_model` 134-176) 대신 manifest 의 module 경로로 dispatch 할 수 있는 base. OAuth 모듈은 기존 코드 흡수 vs re-export 의 결정을 P1-G 라우팅 갱신 시점으로 미뤄서 PR 크기 컨트롤.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/adapters/__init__.py` | 신설 — load_adapter_module / register_adapter / is_adapter_available / get_adapter_metadata |
| `plugins/petri_audit/adapters/http_anthropic.py` | 신설 — stock anthropic placeholder (env probe) |
| `plugins/petri_audit/adapters/http_openai.py` | 신설 — stock openai placeholder |
| `plugins/petri_audit/adapters/http_zhipuai.py` | 신설 — geode target re-export (GLM family) |
| `plugins/petri_audit/adapters/claude_cli_backend.py` | 신설 — claude_code_provider thin re-export (OAuth) |
| `plugins/petri_audit/adapters/openai_codex_oauth.py` | 신설 — codex_provider thin re-export (OAuth) |
| `tests/plugins/petri_audit/test_adapters.py` | 신설 — 27 cases (parametrize × registry × env probe × 부정) |
| `CHANGELOG.md` | [Unreleased] Added 항목 (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| adapter registry (lazy import) | Implemented | manifest 경로 typo 검증 포함 |
| 5 adapter module (3 stock + 2 OAuth) | Implemented | uniform 인터페이스 |
| OAuth 코드 흡수 | Deferred to P1-G | thin re-export only — P1-G routing 갱신 시점에 흡수 여부 결정 |
| 단위 테스트 | Implemented | 27/27 pass, 전체 petri_audit 회귀 OK |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (6 source files)
- [x] pytest pass (27/27 — test_adapters.py)
- [x] pytest regression OK (tests/plugins/petri_audit/ 전체)

## Reference
- OpenClaw `extensions/anthropic/cli-backend.ts` — adapter 인터페이스
- Crumb `src/adapters/types.ts` — Adapter / SpawnRequest contract
- 후속: P1-D (credential_source) → P1-E (registry binding) → P1-F (/petri picker) → P1-G (to_inspect_model 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)