### PR TITLE
feat(petri): credential_source module + manifest priority rebalance (P1-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **Petri credential_source 모듈 (P1-D) — per-family resolve / list / suppress SOT.**
+  `plugins/petri_audit/credential_source.py` 신설 — Hermes
+  `agent/credential_sources.py` 패턴 정합. resolve_credential_source(
+  family, override=None) 가 manifest priority (override → settings →
+  manifest default → 'auto' expansion) 으로 concrete source 반환,
+  list_credential_sources(family) 가 /petri picker 용 entry list 노출,
+  suppress_credential_source(family, source) 가 process-수명 suppression
+  지원. manifest 의 `[petri.source.anthropic|openai].allowed` 순서를
+  OAuth 우선 (`["claude-cli", "api_key", "auto"]`, `["openai-codex",
+  "api_key", "auto"]`) 으로 재정렬 — autoresearch outer loop 의 subscription
+  quota 우선 소비. monkeypatch 기반 테스트 격리 + 후속 DI 리팩토 backlog
+  등록.
+
+- **Petri credential_source module (P1-D) — per-family SOT for resolve /
+  list / suppress.** Added `plugins/petri_audit/credential_source.py`
+  modelled on Hermes's `agent/credential_sources.py`. The resolver
+  priority is `override → settings → manifest default → 'auto'
+  expansion`, returning a concrete source key the adapter registry can
+  immediately load. `list_credential_sources` feeds the upcoming /petri
+  picker. `suppress_credential_source` lets the resolver drop an OAuth
+  source whose first call fails mid-run without restarting the
+  process. Manifest `allowed` order rebalanced to OAuth-first so the
+  autoresearch outer loop consumes subscription quota by default.
+  Test isolation via monkeypatch fixtures; class-based DI refactor
+  tracked as a follow-up backlog item.
+
 - **Petri adapter registry (P1-C) — manifest-driven lazy dispatch.**
   `plugins/petri_audit/adapters/` 신설 — 5 adapter wrapper +
   registry (`__init__.py`). 각 adapter (`http_anthropic`, `http_openai`,

--- a/plugins/petri_audit/credential_source.py
+++ b/plugins/petri_audit/credential_source.py
@@ -1,0 +1,202 @@
+"""Per-family credential source enumeration + resolution + suppression.
+
+Centralises the "which credential should I use for *this* family right
+now" decision so the rest of the Petri plugin (`/petri` picker,
+`to_inspect_model` router, OAuth retry paths) stops re-implementing the
+``settings → keychain → API key`` fallback chain in three different
+places.
+
+Frontier reference: Hermes ``agent/credential_sources.py`` — per-source
+``suppress_credential_source(provider, source_id)`` so a token that
+turns out to be expired mid-run is dropped from the pool without
+restarting the process.
+
+Layers:
+
+- :func:`list_credential_sources` — enumerate (used by /petri picker).
+- :func:`resolve_credential_source` — pick the effective concrete source.
+- :func:`suppress_credential_source` — disable a source until process exit
+  (used when an OAuth token fails the first call mid-run).
+- :func:`is_suppressed` / :func:`clear_suppressions` — read / reset.
+
+Priority for the ``auto`` sentinel:
+
+1. ``override`` argument (callable wins over settings).
+2. ``settings.{family}_credential_source`` if it carries an explicit
+   non-auto value (e.g. ``ANTHROPIC_CREDENTIAL_SOURCE=api_key``).
+3. Manifest ``[petri.source.<family>].default`` if not auto.
+4. Manifest ``[petri.source.<family>].allowed`` order — first non-auto,
+   non-suppressed, *available* source wins. Manifest ordering is the
+   intent — keep OAuth first so the autoresearch outer loop hits
+   subscription quota by default; API-key fallback still resolves when
+   the user has only ``ANTHROPIC_API_KEY`` set.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from plugins.petri_audit.adapters import (
+    get_adapter_metadata,
+    is_adapter_available,
+)
+from plugins.petri_audit.manifest import AUTO_SOURCE, load_manifest
+
+__all__ = [
+    "CredentialResolutionError",
+    "clear_suppressions",
+    "is_suppressed",
+    "list_credential_sources",
+    "resolve_credential_source",
+    "suppress_credential_source",
+]
+
+
+_lock = threading.Lock()
+_suppressed: set[tuple[str, str]] = set()
+
+
+class CredentialResolutionError(RuntimeError):
+    """Raised when no credential source resolves for a family.
+
+    Carries ``family`` and the ``allowed`` set so callers (e.g. the
+    /petri picker) can render an actionable error instead of a bare
+    traceback.
+    """
+
+    def __init__(self, family: str, allowed: list[str]):
+        self.family = family
+        self.allowed = allowed
+        super().__init__(
+            f"family={family}: no credential source available "
+            f"(allowed={allowed}); set an env var from the picker or "
+            f"adjust settings.{family}_credential_source"
+        )
+
+
+def list_credential_sources(family: str) -> list[dict[str, Any]]:
+    """Enumerate credential sources for a family with current status.
+
+    One entry per allowed source. Shape::
+
+        {
+            family: str,
+            source: str,
+            is_default: bool,
+            is_suppressed: bool,
+            available: bool,
+            adapter: str | None,          # dotted module path; None for 'auto'
+            inspect_prefix: str | None,
+            auth_env_vars: list[str],
+            metadata: dict | None,        # OAuth-only
+        }
+
+    The /petri picker consumes this directly.
+    """
+    manifest = load_manifest()
+    spec = manifest.get_source(family)
+    out: list[dict[str, Any]] = []
+    for source in spec.allowed:
+        entry: dict[str, Any] = {
+            "family": family,
+            "source": source,
+            "is_default": source == spec.default,
+            "is_suppressed": is_suppressed(family, source),
+        }
+        if source == AUTO_SOURCE:
+            entry["available"] = True
+            entry["adapter"] = None
+            entry["inspect_prefix"] = None
+            entry["auth_env_vars"] = []
+            entry["metadata"] = None
+        else:
+            adapter = manifest.get_adapter(family, source)
+            entry["available"] = is_adapter_available(family, source) and not is_suppressed(
+                family, source
+            )
+            entry["adapter"] = adapter.module
+            entry["inspect_prefix"] = adapter.inspect_prefix
+            entry["auth_env_vars"] = list(adapter.auth_env_vars)
+            entry["metadata"] = get_adapter_metadata(family, source)
+        out.append(entry)
+    return out
+
+
+def resolve_credential_source(
+    family: str,
+    *,
+    override: str | None = None,
+) -> str:
+    """Resolve the effective concrete source for ``family``.
+
+    Never returns the ``auto`` sentinel — the caller always gets back a
+    concrete adapter key it can pass to
+    :func:`plugins.petri_audit.adapters.load_adapter_module`. Raises
+    :class:`CredentialResolutionError` when no concrete source resolves.
+
+    See module docstring for the full priority order.
+    """
+    manifest = load_manifest()
+    spec = manifest.get_source(family)
+
+    candidate = override or _settings_source(family) or spec.default
+
+    if candidate != AUTO_SOURCE:
+        if candidate not in spec.allowed:
+            raise CredentialResolutionError(family, spec.allowed)
+        if not is_suppressed(family, candidate):
+            return candidate
+        # Suppressed concrete request → fall through to auto expansion.
+
+    # 'auto' expansion — iterate allowed in manifest order, skip auto +
+    # suppressed, return the first that is available.
+    for source in spec.allowed:
+        if source == AUTO_SOURCE:
+            continue
+        if is_suppressed(family, source):
+            continue
+        if is_adapter_available(family, source):
+            return source
+    raise CredentialResolutionError(family, spec.allowed)
+
+
+def _settings_source(family: str) -> str | None:
+    """Read ``settings.{family}_credential_source`` lazily.
+
+    Returns ``None`` when the setting is absent, empty, or 'auto'.
+    Defensive against ``core.config`` import failure (e.g. test
+    environments with a stubbed settings module) so this module never
+    crashes the picker on a recoverable problem.
+    """
+    try:
+        from core.config import settings
+    except Exception:
+        return None
+    field = f"{family}_credential_source"
+    value = getattr(settings, field, None)
+    if isinstance(value, str) and value and value != AUTO_SOURCE:
+        return value
+    return None
+
+
+def suppress_credential_source(family: str, source: str) -> None:
+    """Disable a (family, source) pair for the rest of this process.
+
+    Idempotent. Used when an OAuth token's first call fails (expired,
+    revoked) so the run can fall through to the API-key path without
+    a process restart. Cleared by :func:`clear_suppressions` (tests
+    only — production never clears).
+    """
+    with _lock:
+        _suppressed.add((family, source))
+
+
+def is_suppressed(family: str, source: str) -> bool:
+    return (family, source) in _suppressed
+
+
+def clear_suppressions() -> None:
+    """Drop all suppressions — used by tests."""
+    with _lock:
+        _suppressed.clear()

--- a/plugins/petri_audit/petri.plugin.toml
+++ b/plugins/petri_audit/petri.plugin.toml
@@ -59,12 +59,16 @@ role_contract = "roles/judge.md"
 [petri.source.anthropic]
 # "auto" = consult settings.anthropic_credential_source, fall back to keychain
 # probe (see plugins.petri_audit.claude_code_provider.is_claude_oauth_available).
+# allowed[0] = priority for the auto resolver. OAuth first so the autoresearch
+# outer loop consumes the user's subscription quota when available; explicit
+# ANTHROPIC_API_KEY (api_key) still wins when set via settings or override.
 default = "auto"
-allowed = ["api_key", "claude-cli", "auto"]
+allowed = ["claude-cli", "api_key", "auto"]
 
 [petri.source.openai]
+# Same priority model as anthropic — OAuth (Codex / ChatGPT Plus quota) first.
 default = "auto"
-allowed = ["api_key", "openai-codex", "auto"]
+allowed = ["openai-codex", "api_key", "auto"]
 
 [petri.source.zhipuai]
 default = "api_key"

--- a/tests/plugins/petri_audit/test_credential_source.py
+++ b/tests/plugins/petri_audit/test_credential_source.py
@@ -1,0 +1,238 @@
+"""Unit tests for plugins.petri_audit.credential_source (P1-D)."""
+
+from __future__ import annotations
+
+import pytest
+from plugins.petri_audit.adapters import is_adapter_available
+from plugins.petri_audit.manifest import clear_manifest_cache
+
+from plugins.petri_audit import credential_source as cs
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    clear_manifest_cache()
+    cs.clear_suppressions()
+    yield
+    cs.clear_suppressions()
+    clear_manifest_cache()
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _stub_settings(monkeypatch):
+    """Pin _settings_source to None across the suite so the resolver does not
+    short-circuit on whatever GEODE's real ``settings.<family>_credential_source``
+    happens to be configured to. Tests that exercise the settings path opt in
+    by re-patching _settings_source explicitly."""
+    monkeypatch.setattr(cs, "_settings_source", lambda family: None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_oauth_adapters(monkeypatch):
+    """Force OAuth adapter is_available probes to False across the suite.
+
+    Both ``claude_cli_backend`` and ``openai_codex_oauth`` query the
+    developer machine's keychain / file-based OAuth state — running tests
+    on a host with a live ``Claude Code-credentials`` keychain entry (or
+    a valid Codex OAuth token) would otherwise leak into the resolver.
+
+    Tests that need an OAuth source to register as available opt in by
+    monkeypatching the adapter's ``is_available`` back to a True
+    callable. See ``test_resolve_auto_oauth_priority`` for the pattern.
+
+    NOTE — this fixture papers over a design gap (the resolver consults
+    three hidden sources: settings / keychain / env). The long-term fix
+    is constructor-injected DI à la ``core/auth/rotation.py::ProfileRotator``;
+    tracked as a backlog task. See P1-D PR body for the rationale.
+    """
+    from plugins.petri_audit.adapters import claude_cli_backend, openai_codex_oauth
+
+    monkeypatch.setattr(claude_cli_backend, "is_available", lambda: False)
+    monkeypatch.setattr(openai_codex_oauth, "is_available", lambda: False)
+
+
+# ── list_credential_sources ────────────────────────────────────────────────
+
+
+def test_list_credential_sources_anthropic_shape(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    out = cs.list_credential_sources("anthropic")
+    sources = [entry["source"] for entry in out]
+    # Default manifest order — OAuth first (P1-D rebalance).
+    assert sources == ["claude-cli", "api_key", "auto"]
+    api_key_entry = next(e for e in out if e["source"] == "api_key")
+    assert api_key_entry["available"] is True
+    assert api_key_entry["adapter"] == "plugins.petri_audit.adapters.http_anthropic"
+    assert api_key_entry["inspect_prefix"] == "anthropic"
+    assert api_key_entry["auth_env_vars"] == ["ANTHROPIC_API_KEY"]
+    auto_entry = next(e for e in out if e["source"] == "auto")
+    assert auto_entry["available"] is True
+    assert auto_entry["adapter"] is None
+    assert auto_entry["is_default"] is True
+
+
+def test_list_credential_sources_marks_suppressed():
+    cs.suppress_credential_source("anthropic", "api_key")
+    out = cs.list_credential_sources("anthropic")
+    api_key_entry = next(e for e in out if e["source"] == "api_key")
+    assert api_key_entry["is_suppressed"] is True
+    # Even if env var is set, suppressed → unavailable.
+    assert api_key_entry["available"] is False
+
+
+def test_list_credential_sources_zhipuai_single_source():
+    out = cs.list_credential_sources("zhipuai")
+    assert [e["source"] for e in out] == ["api_key"]
+    assert out[0]["is_default"] is True
+
+
+# ── resolve_credential_source — explicit paths ─────────────────────────────
+
+
+def test_resolve_with_explicit_override(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert cs.resolve_credential_source("anthropic", override="api_key") == "api_key"
+
+
+def test_resolve_override_invalid_raises():
+    with pytest.raises(cs.CredentialResolutionError):
+        cs.resolve_credential_source("anthropic", override="nonexistent")
+
+
+def test_resolve_override_auto_falls_through_to_expansion(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    # 'auto' override is allowed and triggers expansion — api_key is available.
+    assert cs.resolve_credential_source("anthropic", override="auto") == "api_key"
+
+
+def test_resolve_override_suppressed_falls_through(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cs.suppress_credential_source("anthropic", "claude-cli")
+    # claude-cli explicitly requested but suppressed → auto expansion picks
+    # the next available source.
+    assert cs.resolve_credential_source("anthropic", override="claude-cli") == "api_key"
+
+
+# ── resolve_credential_source — auto expansion ─────────────────────────────
+
+
+def test_resolve_auto_returns_first_available(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    # claude-cli unavailable (no keychain), api_key available → api_key.
+    assert cs.resolve_credential_source("anthropic") == "api_key"
+
+
+def test_resolve_auto_skips_suppressed(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cs.suppress_credential_source("anthropic", "api_key")
+    # api_key suppressed, claude-cli unavailable → no resolution.
+    with pytest.raises(cs.CredentialResolutionError):
+        cs.resolve_credential_source("anthropic")
+
+
+def test_resolve_auto_no_available_source_raises():
+    # No env vars, no keychain → both anthropic sources unavailable.
+    with pytest.raises(cs.CredentialResolutionError):
+        cs.resolve_credential_source("anthropic")
+
+
+def test_resolve_auto_oauth_priority(monkeypatch):
+    """When both claude-cli (OAuth) and api_key are available, manifest order
+    wins — claude-cli is listed first so it should be preferred."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    # Force claude-cli adapter to report available.
+    from plugins.petri_audit.adapters import claude_cli_backend
+
+    monkeypatch.setattr(claude_cli_backend, "is_available", lambda: True)
+    assert cs.resolve_credential_source("anthropic") == "claude-cli"
+
+
+def test_resolve_zhipuai_with_env(monkeypatch):
+    monkeypatch.setenv("ZHIPUAI_API_KEY", "glm-test")
+    assert cs.resolve_credential_source("zhipuai") == "api_key"
+
+
+def test_resolve_zhipuai_returns_default_regardless_of_env():
+    """zhipuai's manifest default = 'api_key' (not 'auto'). The resolver
+    returns it unconditionally — availability is a separate concern checked
+    at call time by the adapter, not by the resolver."""
+    assert cs.resolve_credential_source("zhipuai") == "api_key"
+    # The chosen source is unavailable (no env var) — that surfaces when
+    # inspect_ai actually attempts the call, not from resolve_credential_source.
+    assert is_adapter_available("zhipuai", "api_key") is False
+
+
+# ── settings integration ───────────────────────────────────────────────────
+
+
+def test_resolve_reads_settings_explicit(monkeypatch):
+    """settings.anthropic_credential_source = 'api_key' → returned directly."""
+    monkeypatch.setattr(
+        cs,
+        "_settings_source",
+        lambda family: "api_key" if family == "anthropic" else None,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert cs.resolve_credential_source("anthropic") == "api_key"
+
+
+def test_resolve_settings_auto_falls_to_expansion(monkeypatch):
+    """settings returns None / 'auto' → manifest default → auto expansion."""
+    monkeypatch.setattr(cs, "_settings_source", lambda family: None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert cs.resolve_credential_source("anthropic") == "api_key"
+
+
+def test_resolve_settings_invalid_raises(monkeypatch):
+    monkeypatch.setattr(cs, "_settings_source", lambda family: "imposter")
+    with pytest.raises(cs.CredentialResolutionError):
+        cs.resolve_credential_source("anthropic")
+
+
+# ── suppress / clear ───────────────────────────────────────────────────────
+
+
+def test_suppress_and_is_suppressed():
+    assert cs.is_suppressed("anthropic", "api_key") is False
+    cs.suppress_credential_source("anthropic", "api_key")
+    assert cs.is_suppressed("anthropic", "api_key") is True
+
+
+def test_clear_suppressions_resets_all():
+    cs.suppress_credential_source("anthropic", "api_key")
+    cs.suppress_credential_source("openai", "openai-codex")
+    cs.clear_suppressions()
+    assert cs.is_suppressed("anthropic", "api_key") is False
+    assert cs.is_suppressed("openai", "openai-codex") is False
+
+
+def test_suppress_is_idempotent():
+    cs.suppress_credential_source("anthropic", "api_key")
+    cs.suppress_credential_source("anthropic", "api_key")  # no raise
+    assert cs.is_suppressed("anthropic", "api_key") is True
+
+
+# ── CredentialResolutionError shape ────────────────────────────────────────
+
+
+def test_error_carries_family_and_allowed():
+    with pytest.raises(cs.CredentialResolutionError) as excinfo:
+        cs.resolve_credential_source("anthropic")
+    err = excinfo.value
+    assert err.family == "anthropic"
+    assert "claude-cli" in err.allowed
+    assert "api_key" in err.allowed
+
+
+def test_smoke_adapter_module_round_trip(monkeypatch):
+    """Resolved source must be loadable by the adapter registry."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    source = cs.resolve_credential_source("anthropic")
+    # The chosen source is a real adapter that the registry can probe.
+    assert is_adapter_available("anthropic", source) is True


### PR DESCRIPTION
## Summary
- `plugins/petri_audit/credential_source.py` 신설 — Hermes `agent/credential_sources.py` 정합. resolve / list / suppress 3-axis API
- Manifest `[petri.source.anthropic|openai].allowed` OAuth 우선 재정렬
- 후속 DI 리팩토 backlog 등록 (Task #51)

## Why
P1-A~C 의 manifest + adapter registry 위에 credential 결정 로직을 SOT 로 통합. 기존 `plugins/petri_audit/models.py::_credential_source()` + `_claude_oauth_available()` + `_codex_oauth_available()` 분산 → 단일 모듈. P1-F /petri picker 가 `list_credential_sources(family)` 만으로 entry list 생성 가능. autoresearch outer loop 의 subscription quota 우선 소비를 manifest 순서로 명시.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/credential_source.py` | 신설 — resolve / list / suppress + CredentialResolutionError |
| `plugins/petri_audit/petri.plugin.toml` | source.allowed OAuth 우선 재정렬 (anthropic / openai) |
| `tests/plugins/petri_audit/test_credential_source.py` | 신설 — 21 cases |
| `CHANGELOG.md` | [Unreleased] Added (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| resolve / list / suppress API | Implemented | Hermes 정합 |
| Manifest OAuth-first 재정렬 | Implemented | 기존 `to_inspect_model` 의 'auto' 동작 보존 |
| 단위 테스트 | Implemented | 21/21 pass, 회귀 OK |
| DI 리팩토 | Deferred — Task #51 | 정당화 3 조건 (alternate config / family 확장 / production bug) 미충족 |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (credential_source.py)
- [x] pytest pass (21/21 + tests/plugins/petri_audit/ 회귀)

## Trade-off — DI vs monkeypatch (frontier grounding)
| 시스템 | Resolver shape | 격리 |
|---|---|---|
| Hermes `credential_sources.py` | Module + Registry (419 LOC) | monkeypatch |
| GEODE `core/auth/rotation.py::ProfileRotator` | Class + DI + container singleton | container reset + fixture |
| OpenClaw `provider-auth-input.test.ts` | Function + Prompts | vi.mock + env restore |

Petri 의 stateless single-resolve → Hermes 정합 (module-level + monkeypatch). ProfileRotator 의 rotation/refresh 복잡도 없음. autoresearch alternate config 가 필요해질 때 DI 전환 — 그 시점이 Task #51 트리거.

## Reference
- Hermes `agent/credential_sources.py:15-44` — registry pattern 주석
- GEODE `core/auth/rotation.py:60-72` — ProfileRotator DI 패턴
- GEODE `tests/test_provider_switching.py:56-62` — container reset 테스트 격리
- 후속: P1-E (registry binding) → P1-F (/petri picker) → P1-G (to_inspect_model 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)