### PR TITLE
feat(petri): registry — role × model × source binding (P1-E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,30 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **Petri registry — role × model × source binding (P1-E).**
+  `plugins/petri_audit/registry.py` 신설 — manifest + credential_source
+  를 결합해 `PetriBinding(role, model, source, family, adapter_module,
+  inspect_prefix, inspect_id)` 을 노출. `get_binding(role, *, model=None,
+  source=None)` 가 manifest default + caller override + credential
+  resolve 를 한 곳에 묶음. target role 은 family 와 무관하게
+  `geode/<model>` prefix 로 routing — 기존 `to_inspect_target` 동작
+  보존. `infer_family(model)` 도 함께 — 기존 `models.family_of` 의 strict
+  버전 (unknown 시 raise). P1-F /petri picker + P1-G to_inspect_model
+  routing 갱신의 최종 진입점.
+
+- **Petri registry — role × model × source binding (P1-E).**
+  Added `plugins/petri_audit/registry.py`. `get_binding(role, *,
+  model=None, source=None)` combines the manifest defaults, caller
+  overrides, and credential resolution into a single frozen
+  `PetriBinding` dataclass (role, model, source, family,
+  adapter_module, inspect_prefix, inspect_id). The target role is
+  always routed through the `geode/` prefix regardless of the
+  underlying family adapter — preserves the legacy
+  `to_inspect_target` invariant. Companion `infer_family(model)` is a
+  strict variant of `models.family_of` (raises on unknown ids).
+  Final entry point for the upcoming `/petri` picker (P1-F) and the
+  `to_inspect_model` routing collapse (P1-G).
+
 - **Petri credential_source 모듈 (P1-D) — per-family resolve / list / suppress SOT.**
   `plugins/petri_audit/credential_source.py` 신설 — Hermes
   `agent/credential_sources.py` 패턴 정합. resolve_credential_source(

--- a/plugins/petri_audit/registry.py
+++ b/plugins/petri_audit/registry.py
@@ -1,0 +1,150 @@
+"""Petri role × model × source binding resolver.
+
+Top layer of the manifest stack — combines :mod:`plugins.petri_audit.manifest`
+(role / source / adapter declarations) with :mod:`plugins.petri_audit.
+credential_source` (per-family resolve / suppress) into a single
+:class:`PetriBinding` that callers (/petri picker, to_inspect_model
+router, runner) consume.
+
+Layers below:
+
+- :class:`PetriBinding` — frozen dataclass: (role, model, source, family,
+  adapter_module, inspect_prefix, inspect_id).
+- :func:`get_binding` — manifest defaults + caller overrides + credential
+  resolution. Cheap; no caching (each call re-checks suppressions).
+- :func:`infer_family` — model prefix → family (claude- / gpt- / glm-).
+
+Target role specialisation: when ``role == "target"``, the inspect id is
+``geode/<model>`` regardless of the family adapter's prefix — the audit
+always routes the target through ``GeodeModelAPI`` so the full GEODE
+stack is what gets evaluated. See ``plugins.petri_audit.targets.
+geode_target`` for the inspect_ai registration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from plugins.petri_audit.credential_source import resolve_credential_source
+from plugins.petri_audit.manifest import load_manifest
+
+__all__ = [
+    "FamilyInferenceError",
+    "PetriBinding",
+    "get_binding",
+    "infer_family",
+]
+
+
+_TARGET_INSPECT_PREFIX = "geode"
+
+
+class FamilyInferenceError(ValueError):
+    """Raised when a model id does not match any known family prefix."""
+
+
+@dataclass(frozen=True)
+class PetriBinding:
+    """Resolved (role, model, source) → adapter binding.
+
+    Fields:
+
+    - ``role``: 'auditor' | 'target' | 'judge' (from manifest enabled_roles)
+    - ``model``: concrete model id (e.g. 'claude-sonnet-4-6')
+    - ``source``: concrete credential source (never 'auto') — e.g.
+      'api_key' / 'claude-cli' / 'openai-codex'
+    - ``family``: inferred from model prefix — 'anthropic' / 'openai' /
+      'zhipuai'
+    - ``adapter_module``: dotted import path to the adapter module
+    - ``inspect_prefix``: prefix used by inspect_ai (e.g. 'anthropic',
+      'claude-code', 'openai-codex', 'geode'). For the target role this
+      is always 'geode' regardless of family.
+    - ``inspect_id``: ``f"{inspect_prefix}/{model}"`` — ready to pass to
+      inspect_ai's ``--model`` / ``--model-role`` flags.
+    """
+
+    role: str
+    model: str
+    source: str
+    family: str
+    adapter_module: str
+    inspect_prefix: str
+    inspect_id: str
+
+
+def infer_family(model: str) -> str:
+    """Return the family for a model id.
+
+    Mirrors :func:`plugins.petri_audit.models.family_of` but raises on
+    unknown ids (the legacy helper returned 'unknown'). The strict
+    behaviour keeps :func:`get_binding` from silently producing a
+    nonsensical inspect id. P1-G consolidates these two helpers.
+    """
+    if not model:
+        raise FamilyInferenceError(f"empty model id {model!r}")
+    base = model.rsplit("/", 1)[-1]  # accept 'anthropic/claude-...' too
+    if base.startswith("claude-"):
+        return "anthropic"
+    if base.startswith("gpt-") or base in ("o3", "o4-mini"):
+        return "openai"
+    if base.startswith("glm-"):
+        return "zhipuai"
+    # Provider-prefixed fallthrough — same logic as family_of's tail.
+    if model.startswith("anthropic/"):
+        return "anthropic"
+    if model.startswith("openai/") or model.startswith("openai-api/"):
+        return "openai"
+    raise FamilyInferenceError(
+        f"cannot infer family for model {model!r}; expected "
+        f"claude-/gpt-/glm- or provider-prefixed id"
+    )
+
+
+def get_binding(
+    role: str,
+    *,
+    model: str | None = None,
+    source: str | None = None,
+) -> PetriBinding:
+    """Resolve the effective binding for a Petri role.
+
+    Resolution order:
+
+    1. ``model`` argument (caller override) — must be in the role's
+       ``allowed_models``; otherwise raises :class:`ValueError`.
+    2. Manifest ``[petri.role.<role>].default_model``.
+
+    Source resolution delegates to :func:`plugins.petri_audit.
+    credential_source.resolve_credential_source` (which itself respects
+    override → settings → manifest default → 'auto' expansion). The
+    ``source`` argument here is passed through as the override.
+    """
+    manifest = load_manifest()
+    role_spec = manifest.get_role(role)
+
+    chosen_model = model or role_spec.default_model
+    if chosen_model not in role_spec.allowed_models:
+        raise ValueError(
+            f"role={role}: model {chosen_model!r} not in allowed_models {role_spec.allowed_models}"
+        )
+
+    family = infer_family(chosen_model)
+    resolved_source = resolve_credential_source(family, override=source)
+    adapter_spec = manifest.get_adapter(family, resolved_source)
+
+    # Target role is always routed through GeodeModelAPI — the audit
+    # evaluates the full GEODE stack, not the bare LLM. Family adapter
+    # is still recorded so the picker can show the underlying source,
+    # but the inspect id uses the 'geode' prefix.
+    inspect_prefix = _TARGET_INSPECT_PREFIX if role == "target" else adapter_spec.inspect_prefix
+    inspect_id = f"{inspect_prefix}/{chosen_model}"
+
+    return PetriBinding(
+        role=role,
+        model=chosen_model,
+        source=resolved_source,
+        family=family,
+        adapter_module=adapter_spec.module,
+        inspect_prefix=inspect_prefix,
+        inspect_id=inspect_id,
+    )

--- a/tests/plugins/petri_audit/test_registry.py
+++ b/tests/plugins/petri_audit/test_registry.py
@@ -1,0 +1,200 @@
+"""Unit tests for plugins.petri_audit.registry (P1-E)."""
+
+from __future__ import annotations
+
+import pytest
+from plugins.petri_audit.manifest import clear_manifest_cache
+from plugins.petri_audit.registry import (
+    FamilyInferenceError,
+    PetriBinding,
+    get_binding,
+    infer_family,
+)
+
+from plugins.petri_audit import credential_source as cs
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    clear_manifest_cache()
+    cs.clear_suppressions()
+    yield
+    cs.clear_suppressions()
+    clear_manifest_cache()
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _stub_settings(monkeypatch):
+    monkeypatch.setattr(cs, "_settings_source", lambda family: None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_oauth(monkeypatch):
+    from plugins.petri_audit.adapters import claude_cli_backend, openai_codex_oauth
+
+    monkeypatch.setattr(claude_cli_backend, "is_available", lambda: False)
+    monkeypatch.setattr(openai_codex_oauth, "is_available", lambda: False)
+
+
+# ── infer_family ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-sonnet-4-6", "anthropic"),
+        ("claude-opus-4-7", "anthropic"),
+        ("claude-haiku-4-5", "anthropic"),
+        ("gpt-5.5", "openai"),
+        ("gpt-5.4-mini", "openai"),
+        ("o3", "openai"),
+        ("o4-mini", "openai"),
+        ("glm-4-6", "zhipuai"),
+        ("anthropic/claude-sonnet-4-6", "anthropic"),
+        ("openai/gpt-5.5", "openai"),
+        ("openai-api/gpt-5.5", "openai"),
+    ],
+)
+def test_infer_family(model: str, expected: str):
+    assert infer_family(model) == expected
+
+
+def test_infer_family_unknown_raises():
+    with pytest.raises(FamilyInferenceError, match="cannot infer family"):
+        infer_family("mystery-model-7")
+
+
+def test_infer_family_empty_raises():
+    with pytest.raises(FamilyInferenceError, match="empty model"):
+        infer_family("")
+
+
+# ── get_binding — happy path ───────────────────────────────────────────────
+
+
+def test_get_binding_auditor_default(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    binding = get_binding("auditor")
+    assert isinstance(binding, PetriBinding)
+    assert binding.role == "auditor"
+    assert binding.model == "claude-sonnet-4-6"
+    assert binding.source == "api_key"
+    assert binding.family == "anthropic"
+    assert binding.adapter_module == "plugins.petri_audit.adapters.http_anthropic"
+    assert binding.inspect_prefix == "anthropic"
+    assert binding.inspect_id == "anthropic/claude-sonnet-4-6"
+
+
+def test_get_binding_judge_default(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    binding = get_binding("judge")
+    assert binding.role == "judge"
+    assert binding.model == "claude-sonnet-4-6"
+    assert binding.inspect_id == "anthropic/claude-sonnet-4-6"
+
+
+def test_get_binding_target_uses_geode_prefix(monkeypatch):
+    """Target role always routes through GeodeModelAPI regardless of family."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    binding = get_binding("target")
+    assert binding.role == "target"
+    assert binding.model == "claude-haiku-4-5"
+    # Family adapter still recorded — shows underlying source in picker.
+    assert binding.family == "anthropic"
+    assert binding.adapter_module == "plugins.petri_audit.adapters.http_anthropic"
+    # But the inspect id uses 'geode' prefix unconditionally.
+    assert binding.inspect_prefix == "geode"
+    assert binding.inspect_id == "geode/claude-haiku-4-5"
+
+
+# ── get_binding — overrides ────────────────────────────────────────────────
+
+
+def test_get_binding_model_override(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    binding = get_binding("auditor", model="claude-opus-4-7")
+    assert binding.model == "claude-opus-4-7"
+    assert binding.inspect_id == "anthropic/claude-opus-4-7"
+
+
+def test_get_binding_source_override(monkeypatch):
+    """Explicit source override survives even when env var is set."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    from plugins.petri_audit.adapters import claude_cli_backend
+
+    monkeypatch.setattr(claude_cli_backend, "is_available", lambda: True)
+    binding = get_binding("auditor", source="claude-cli")
+    assert binding.source == "claude-cli"
+    assert binding.inspect_prefix == "claude-code"
+
+
+def test_get_binding_model_not_in_allowed_raises():
+    """auditor.allowed_models excludes GLM family — manifest enforced."""
+    with pytest.raises(ValueError, match="not in allowed_models"):
+        get_binding("auditor", model="glm-4-6")
+
+
+def test_get_binding_judge_rejects_gpt54_mini():
+    """judge.allowed_models = [opus, sonnet, gpt-5.5] — gpt-5.4-mini not in."""
+    with pytest.raises(ValueError, match="not in allowed_models"):
+        get_binding("judge", model="gpt-5.4-mini")
+
+
+def test_get_binding_unknown_role_raises():
+    with pytest.raises(KeyError, match="Unknown petri role"):
+        get_binding("imposter")
+
+
+# ── get_binding — credential resolution ───────────────────────────────────
+
+
+def test_get_binding_no_credential_raises():
+    """No env var → resolve_credential_source raises."""
+    with pytest.raises(cs.CredentialResolutionError):
+        get_binding("auditor")
+
+
+def test_get_binding_oauth_priority(monkeypatch):
+    """When both claude-cli and api_key are available, manifest order wins."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    from plugins.petri_audit.adapters import claude_cli_backend
+
+    monkeypatch.setattr(claude_cli_backend, "is_available", lambda: True)
+    binding = get_binding("auditor")
+    assert binding.source == "claude-cli"
+    assert binding.inspect_prefix == "claude-code"
+    assert binding.inspect_id == "claude-code/claude-sonnet-4-6"
+
+
+def test_get_binding_target_with_openai_model(monkeypatch):
+    """Target with a GPT model still routes through 'geode/' prefix."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test")
+    binding = get_binding("target", model="gpt-5.4-mini")
+    assert binding.family == "openai"
+    assert binding.adapter_module == "plugins.petri_audit.adapters.http_openai"
+    assert binding.inspect_prefix == "geode"
+    assert binding.inspect_id == "geode/gpt-5.4-mini"
+
+
+def test_get_binding_target_with_glm_model(monkeypatch):
+    monkeypatch.setenv("ZHIPUAI_API_KEY", "glm-test")
+    binding = get_binding("target", model="glm-4-6")
+    assert binding.family == "zhipuai"
+    assert binding.inspect_prefix == "geode"
+    assert binding.inspect_id == "geode/glm-4-6"
+
+
+# ── PetriBinding immutability ──────────────────────────────────────────────
+
+
+def test_petri_binding_is_frozen(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    binding = get_binding("auditor")
+    with pytest.raises(Exception):  # FrozenInstanceError
+        binding.model = "other"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- `plugins/petri_audit/registry.py` 신설 — manifest + credential_source 결합 진입점
- `PetriBinding` frozen dataclass + `get_binding(role, *, model, source)` + `infer_family(model)`
- target role 은 'geode/' prefix 로 고정 — 기존 `to_inspect_target` 동작 보존
- P1-F /petri picker + P1-G `to_inspect_model` 라우팅 갱신의 최종 진입점

## Why
P1-A~D 의 4 layer (manifest / role MD / adapter / credential_source) 를 callers 가 직접 합성하면 보일러플레이트 — 한 곳에 묶음. P1-F picker 가 `get_binding(role)` 한 번이면 model + source + adapter + inspect_id 전부 받음. P1-G 의 `to_inspect_model` 도 `get_binding(role).inspect_id` 만 반환하면 됨.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/registry.py` | 신설 — PetriBinding + get_binding + infer_family + FamilyInferenceError |
| `tests/plugins/petri_audit/test_registry.py` | 신설 — 26 cases |
| `CHANGELOG.md` | [Unreleased] Added (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| PetriBinding 데이터 클래스 | Implemented | frozen, 7 field |
| get_binding 합성 함수 | Implemented | manifest + credential_source 결합 |
| infer_family (strict) | Implemented | unknown 시 raise (legacy family_of 와 차별) |
| target geode/ prefix 보존 | Implemented | 기존 to_inspect_target 동작 |
| 단위 테스트 | Implemented | 26/26 pass |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean
- [x] pytest pass (26/26 + 회귀 OK)

## Reference
- 후속: P1-F (/petri 2-axis picker) → P1-G (to_inspect_model → get_binding 호출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)