### PR TITLE
feat(petri): /petri slash command + 2-axis picker (P1-F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,32 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Added
 
+- **`/petri` 슬래시 명령 + 2-axis picker (P1-F).**
+  새 사용자-facing 명령 추가 — `/petri` (status table) / `/petri <role>`
+  (multi-step picker — model → source) / `/petri model <role> <name>`
+  / `/petri source <role> <src>` / `/petri reset [<role>]`. user override
+  는 `~/.geode/petri.toml` 에 영구화 (별도 파일 — config.toml 와 분리).
+  registry.get_binding 이 manifest default 와 caller override 사이
+  layer 로 user override 를 자동 적용. family 변경 시 (`/petri model
+  auditor gpt-5.5`) source 는 'auto' 로 리셋 (incompat 방지). non-TTY
+  fallback (`/petri <role>` in pipe) → status + usage hint. 신설 모듈:
+  `plugins/petri_audit/cli.py`, `plugins/petri_audit/user_overrides.py`,
+  `core/cli/commands/petri.py` (shim). `core/paths.py` 에
+  `GLOBAL_PETRI_TOML` 상수. show_help / COMMAND_MAP / dispatcher 등록.
+
+- **`/petri` slash command + 2-axis picker (P1-F).**
+  New user-facing command: `/petri` (status), `/petri <role>` (multi-step
+  picker), `/petri model <role> <name>`, `/petri source <role> <src>`,
+  `/petri reset [<role>]`. User overrides persist to `~/.geode/petri.
+  toml` (kept separate from main `config.toml`). The registry's
+  `get_binding` now reads this override layer between manifest defaults
+  and explicit caller arguments. Switching family via `/petri model
+  <role> ...` automatically clears an incompatible source. Non-TTY
+  fallback prints the status + usage hint instead of attempting the
+  picker. Added `plugins/petri_audit/{cli,user_overrides}.py`,
+  `core/cli/commands/petri.py`, `core/paths.py::GLOBAL_PETRI_TOML`, +
+  COMMAND_MAP / dispatcher / help wiring.
+
 - **Petri registry — role × model × source binding (P1-E).**
   `plugins/petri_audit/registry.py` 신설 — manifest + credential_source
   를 결합해 `PetriBinding(role, model, source, family, adapter_module,

--- a/core/cli/commands/__init__.py
+++ b/core/cli/commands/__init__.py
@@ -78,6 +78,7 @@ from .login import (
 )
 from .mcp import _mcp_add, cmd_mcp
 from .model import _apply_model, _interactive_model_picker, cmd_model
+from .petri import cmd_petri
 from .session import cmd_apply, cmd_clear, cmd_compact, cmd_context, cmd_resume
 from .skills import _skills_add, cmd_skill_invoke, cmd_skills
 from .tasks import cmd_tasks
@@ -121,6 +122,7 @@ __all__ = [
     "cmd_login",
     "cmd_mcp",
     "cmd_model",
+    "cmd_petri",
     "cmd_resume",
     "cmd_schedule",
     "cmd_skill_invoke",

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -122,6 +122,7 @@ COMMAND_MAP: dict[str, str] = {
     "/task": "tasks",
     "/t": "tasks",
     "/audit": "audit",
+    "/petri": "petri",
 }
 
 
@@ -152,6 +153,7 @@ def show_help() -> None:
     console.print("  [label]/login add[/label]          — Interactive plan/key wizard")
     console.print("  [label]/key[/label] <value>        — Quick PAYG API key (legacy alias)")
     console.print("  [label]/model[/label]              — Show & switch LLM model")
+    console.print("  [label]/petri[/label]              — Show & switch Petri role × model × source")
     console.print("  [label]/login source[/label] <p> <t> — Pick credential source per provider")
     console.print("  [label]/schedule[/label]           — Manage scheduled automations")
     console.print("  [label]/trigger[/label]            — Manage event/cron triggers")

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -153,7 +153,9 @@ def show_help() -> None:
     console.print("  [label]/login add[/label]          — Interactive plan/key wizard")
     console.print("  [label]/key[/label] <value>        — Quick PAYG API key (legacy alias)")
     console.print("  [label]/model[/label]              — Show & switch LLM model")
-    console.print("  [label]/petri[/label]              — Show & switch Petri role × model × source")
+    console.print(
+        "  [label]/petri[/label]              — Show & switch Petri role × model × source"
+    )
     console.print("  [label]/login source[/label] <p> <t> — Pick credential source per provider")
     console.print("  [label]/schedule[/label]           — Manage scheduled automations")
     console.print("  [label]/trigger[/label]            — Manage event/cron triggers")

--- a/core/cli/commands/petri.py
+++ b/core/cli/commands/petri.py
@@ -1,0 +1,20 @@
+"""Thin re-export — keeps ``core.cli.commands.petri`` importable for the
+slash dispatcher while the actual implementation lives in the plugin
+package (:mod:`plugins.petri_audit.cli`).
+
+Following the pattern of other plugin-backed commands so the audit
+extra (``[audit]``) stays the boundary — the slash dispatcher only
+imports this shim, and the heavy dependencies (TerminalMenu, manifest
+loader) are deferred until the first invocation.
+"""
+
+from __future__ import annotations
+
+__all__ = ["cmd_petri"]
+
+
+def cmd_petri(args: str) -> None:
+    """Defer to :func:`plugins.petri_audit.cli.cmd_petri`."""
+    from plugins.petri_audit.cli import cmd_petri as _impl
+
+    _impl(args)

--- a/core/cli/dispatcher.py
+++ b/core/cli/dispatcher.py
@@ -16,6 +16,7 @@ from core.cli.commands import (
     cmd_login,
     cmd_mcp,
     cmd_model,
+    cmd_petri,
     cmd_schedule,
     cmd_skills,
     cmd_trigger,
@@ -104,6 +105,8 @@ def _handle_command(
         cmd_model(args)
     elif action == "login":
         cmd_login(args)
+    elif action == "petri":
+        cmd_petri(args)
     elif action == "generate":
         from plugins.game_ip.cli.commands import cmd_generate
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -50,6 +50,12 @@ GLOBAL_SCHEDULER_DIR = GEODE_HOME / "scheduler"
 # constant is the default fallback.
 GLOBAL_DIAGNOSTICS_DIR = GEODE_HOME / "diagnostics"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
+# P1-F (2026-05-17) — per-user Petri audit role × model × source override.
+# Read by ``plugins.petri_audit.user_overrides`` and merged into the
+# binding resolver. Kept as a separate TOML (rather than wedged into
+# ``config.toml``) so main GEODE config stays decoupled from Petri-only
+# concerns; the /petri command writes here.
+GLOBAL_PETRI_TOML = GEODE_HOME / "petri.toml"
 # P3 (v0.95.x) — user-tier installed skills (priority 2 of 4-tier
 # resolution; see `core/llm/skill_registry.py`). Bundled skills live
 # inside the package source tree, not at `GEODE_HOME` — resolve via

--- a/plugins/petri_audit/cli.py
+++ b/plugins/petri_audit/cli.py
@@ -1,0 +1,405 @@
+"""Slash-command handler for ``/petri`` — role × model × source picker.
+
+Wires the manifest → adapter registry → credential_source → user_overrides
+stack to a user-facing slash command. Mirrors GEODE's existing
+``/model`` + ``/login`` patterns:
+
+- ``/petri``                         → status table (3 roles × current binding)
+- ``/petri <role>``                  → multi-step picker (model → source)
+- ``/petri model <role> <name>``     → set model only
+- ``/petri source <role> <source>``  → set source only
+- ``/petri reset [<role>]``          → restore manifest default (all / one)
+
+Persistence: ``~/.geode/petri.toml`` (see
+:mod:`plugins.petri_audit.user_overrides`). Read by
+:func:`plugins.petri_audit.registry.get_binding`, which is the single
+SOT for downstream consumers (/petri picker itself, P1-G's
+`to_inspect_model` router, the audit runner).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from plugins.petri_audit.credential_source import (
+    CredentialResolutionError,
+    list_credential_sources,
+    resolve_credential_source,
+)
+from plugins.petri_audit.manifest import AUTO_SOURCE, load_manifest
+from plugins.petri_audit.registry import (
+    FamilyInferenceError,
+    PetriBinding,
+    get_binding,
+    infer_family,
+)
+from plugins.petri_audit.user_overrides import (
+    clear_overrides,
+    read_role_override,
+    save_role_override,
+)
+
+__all__ = ["cmd_petri"]
+
+
+# ── Entry point ─────────────────────────────────────────────────────────────
+
+
+def cmd_petri(args: str) -> None:
+    """Handle the ``/petri`` slash command — dispatches on sub-command."""
+    from core.cli import commands as _pkg
+
+    raw = args.strip()
+    if not raw:
+        _print_status()
+        return
+
+    tokens = raw.split()
+    head = tokens[0].lower()
+
+    if head == "reset":
+        role_arg = tokens[1] if len(tokens) > 1 else None
+        _cmd_reset(role_arg)
+        return
+
+    if head == "model":
+        if len(tokens) < 3:
+            _pkg.console.print("  [warning]Usage: /petri model <role> <name>[/warning]\n")
+            return
+        _cmd_set_model(role=tokens[1], model_arg=" ".join(tokens[2:]))
+        return
+
+    if head == "source":
+        if len(tokens) < 3:
+            _pkg.console.print(
+                "  [warning]Usage: /petri source <role> "
+                "<auto|api_key|claude-cli|openai-codex>[/warning]\n"
+            )
+            return
+        _cmd_set_source(role=tokens[1], source_arg=tokens[2])
+        return
+
+    # /petri <role> — interactive picker for that role
+    role = head
+    if role not in _enabled_roles():
+        _pkg.console.print(
+            f"  [warning]Unknown petri role: {role}[/warning]   "
+            f"[muted](roles: {', '.join(_enabled_roles())})[/muted]\n"
+        )
+        return
+
+    if not sys.stdin.isatty():
+        # Non-TTY: status + usage hint (matches /model behaviour).
+        _print_status()
+        _pkg.console.print(
+            f"  [muted]Usage: /petri model {role} <name>  |  "
+            f"/petri source {role} <source>[/muted]\n"
+        )
+        return
+
+    _picker_for_role(role)
+
+
+# ── Sub-commands ────────────────────────────────────────────────────────────
+
+
+def _cmd_set_model(role: str, model_arg: str) -> None:
+    from core.cli import commands as _pkg
+
+    if role not in _enabled_roles():
+        _pkg.console.print(f"  [warning]Unknown petri role: {role}[/warning]\n")
+        return
+
+    manifest = load_manifest()
+    role_spec = manifest.get_role(role)
+    allowed = role_spec.allowed_models
+
+    chosen = _resolve_model_name(model_arg, allowed)
+    if chosen is None:
+        _pkg.console.print(f"  [warning]Model {model_arg!r} not in allowed for {role}[/warning]")
+        _pkg.console.print(f"  [muted]Allowed: {', '.join(allowed)}[/muted]\n")
+        return
+
+    # Family change resets source to 'auto' (manifest default) — old
+    # source may be incompatible with new family (e.g. claude-cli on
+    # gpt-* makes no sense).
+    existing = read_role_override(role)
+    extra: dict[str, str | None] = {}
+    if "source" in existing:
+        old_family = _safe_family(existing.get("model") or role_spec.default_model)
+        new_family = _safe_family(chosen)
+        if old_family != new_family:
+            extra["source"] = ""  # erase
+
+    save_role_override(role, model=chosen, **extra)
+    _print_role_after_change(role)
+
+
+def _cmd_set_source(role: str, source_arg: str) -> None:
+    from core.cli import commands as _pkg
+
+    if role not in _enabled_roles():
+        _pkg.console.print(f"  [warning]Unknown petri role: {role}[/warning]\n")
+        return
+
+    manifest = load_manifest()
+    role_spec = manifest.get_role(role)
+    # Family from the role's currently-chosen model (user override or default).
+    current_model = read_role_override(role).get("model") or role_spec.default_model
+    family = _safe_family(current_model)
+    if family is None:
+        _pkg.console.print(
+            f"  [warning]Cannot infer family for current model {current_model!r}[/warning]\n"
+        )
+        return
+
+    source_spec = manifest.get_source(family)
+    if source_arg not in source_spec.allowed:
+        _pkg.console.print(
+            f"  [warning]Source {source_arg!r} not allowed for family {family}[/warning]"
+        )
+        _pkg.console.print(f"  [muted]Allowed: {', '.join(source_spec.allowed)}[/muted]\n")
+        return
+
+    save_role_override(role, source=source_arg)
+    _print_role_after_change(role)
+
+
+def _cmd_reset(role_arg: str | None) -> None:
+    from core.cli import commands as _pkg
+
+    if role_arg is None:
+        try:
+            confirm = (
+                _pkg.console.input(
+                    "  [warning]Reset all role overrides to manifest defaults? [y/N][/warning] "
+                )
+                .strip()
+                .lower()
+            )
+        except (KeyboardInterrupt, EOFError):
+            _pkg.console.print("\n  [muted]Cancelled[/muted]\n")
+            return
+        if confirm not in ("y", "yes"):
+            _pkg.console.print("  [muted]Cancelled[/muted]\n")
+            return
+        clear_overrides()
+        _pkg.console.print("  [success]All petri overrides cleared.[/success]\n")
+        _print_status()
+        return
+
+    role = role_arg.lower()
+    if role not in _enabled_roles():
+        _pkg.console.print(f"  [warning]Unknown petri role: {role}[/warning]\n")
+        return
+    clear_overrides(role)
+    _pkg.console.print(f"  [success]Reset {role} to manifest defaults.[/success]\n")
+    _print_role_after_change(role)
+
+
+# ── Status table ────────────────────────────────────────────────────────────
+
+
+def _print_status() -> None:
+    """Render the 3-row status table + missing-env warning + edit hint."""
+    from core.cli import commands as _pkg
+
+    rows = []
+    missing_envs: set[str] = set()
+    for role in _enabled_roles():
+        try:
+            binding = get_binding(role)
+            source_label = _format_source_label(binding)
+            rows.append((role, binding.model, source_label, binding.inspect_id))
+        except CredentialResolutionError as e:
+            # No credential for this family — show the row with a marker.
+            user_model = (
+                read_role_override(role).get("model")
+                or load_manifest().get_role(role).default_model
+            )
+            rows.append((role, user_model, f"[warning]unresolved[/warning] ({e.family})", "—"))
+            missing_envs.update(_env_vars_for_family(e.family))
+        except Exception as e:
+            rows.append((role, "?", f"[warning]error: {type(e).__name__}[/warning]", "—"))
+
+    _pkg.console.print()
+    _pkg.console.print("  [header]Petri bindings[/header]")
+    _pkg.console.print()
+    _pkg.console.print(f"  [muted]{'Role':<9} {'Model':<20} {'Source':<22} Inspect ID[/muted]")
+    _pkg.console.print("  " + "─" * 80)
+    for role, model, source, inspect_id in rows:
+        _pkg.console.print(f"  {role:<9} {model:<20} {source:<22} {inspect_id}")
+    _pkg.console.print()
+    _pkg.console.print("  [muted]Edit: /petri <role>     Reset: /petri reset[/muted]")
+    if missing_envs:
+        _pkg.console.print(f"  [warning]Missing env: {', '.join(sorted(missing_envs))}[/warning]")
+    _pkg.console.print()
+
+
+def _print_role_after_change(role: str) -> None:
+    from core.cli import commands as _pkg
+
+    try:
+        binding = get_binding(role)
+    except CredentialResolutionError as e:
+        _pkg.console.print(
+            f"  [warning]{role}: saved, but no credential resolves[/warning] [muted]({e})[/muted]\n"
+        )
+        return
+    except Exception as e:
+        _pkg.console.print(f"  [warning]{role}: {type(e).__name__}: {e}[/warning]\n")
+        return
+
+    _pkg.console.print(
+        f"  [success]{role}[/success]: "
+        f"{binding.model} / {_format_source_label(binding)} "
+        f"[muted]→ {binding.inspect_id}[/muted]\n"
+    )
+
+
+# ── Picker (multi-step) ─────────────────────────────────────────────────────
+
+
+def _picker_for_role(role: str) -> None:
+    """Interactive 2-step picker — Step 1 model, Step 2 source."""
+    from core.cli import commands as _pkg
+
+    try:
+        from simple_term_menu import TerminalMenu
+    except ImportError:
+        _pkg.console.print(
+            "  [warning]simple_term_menu not installed — install it or use "
+            "/petri model / /petri source directly[/warning]\n"
+        )
+        return
+
+    manifest = load_manifest()
+    role_spec = manifest.get_role(role)
+    current = read_role_override(role)
+    current_model = current.get("model") or role_spec.default_model
+
+    # ── Step 1: model picker ─────────────────────────────────────
+    entries: list[str] = []
+    for model in role_spec.allowed_models:
+        marker = "  ← current" if model == current_model else ""
+        entries.append(f"{model}{marker}")
+    default_idx = role_spec.allowed_models.index(current_model)
+
+    model_menu = TerminalMenu(
+        entries,
+        title=f"\n  /petri {role}  ·  Step 1/2 — model  (↑↓ select, Enter confirm, q cancel)\n",
+        menu_cursor="  > ",
+        menu_cursor_style=("fg_cyan", "bold"),
+        cursor_index=default_idx,
+    )
+    midx = model_menu.show()
+    if midx is None:
+        _pkg.console.print("  [muted]Cancelled[/muted]\n")
+        return
+    chosen_model = role_spec.allowed_models[midx]
+
+    # ── Step 2: source picker (filtered by family of chosen model) ────────
+    try:
+        family = infer_family(chosen_model)
+    except FamilyInferenceError as e:
+        _pkg.console.print(f"  [warning]{e}[/warning]\n")
+        return
+
+    sources_info = list_credential_sources(family)
+    if not sources_info:
+        _pkg.console.print(f"  [warning]No sources declared for family={family}[/warning]\n")
+        return
+
+    current_source = current.get("source") or AUTO_SOURCE
+    src_entries: list[str] = []
+    for info in sources_info:
+        avail_marker = "✓" if info["available"] else "✗"
+        current_marker = "  ← current" if info["source"] == current_source else ""
+        suppressed_marker = " [suppressed]" if info["is_suppressed"] else ""
+        env_label = f"  ({', '.join(info['auth_env_vars'])})" if info["auth_env_vars"] else ""
+        src_entries.append(
+            f"[{avail_marker}] {info['source']:<14}{env_label}{suppressed_marker}{current_marker}"
+        )
+
+    default_src_idx = next(
+        (i for i, info in enumerate(sources_info) if info["source"] == current_source),
+        0,
+    )
+
+    source_menu = TerminalMenu(
+        src_entries,
+        title=f"\n  /petri {role}  ·  Step 2/2 — source for "
+        f"family={family}, model={chosen_model}\n",
+        menu_cursor="  > ",
+        menu_cursor_style=("fg_cyan", "bold"),
+        cursor_index=default_src_idx,
+    )
+    sidx = source_menu.show()
+    if sidx is None:
+        _pkg.console.print("  [muted]Cancelled[/muted]\n")
+        return
+    chosen_source = sources_info[sidx]["source"]
+
+    # ── Persist + confirm ────────────────────────────────────────────
+    save_role_override(role, model=chosen_model, source=chosen_source)
+    _print_role_after_change(role)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _enabled_roles() -> list[str]:
+    return load_manifest().enabled_roles
+
+
+def _resolve_model_name(arg: str, allowed: list[str]) -> str | None:
+    """Match arg against allowed model ids by exact or normalised compare."""
+    if arg in allowed:
+        return arg
+    norm = arg.lower().replace("-", "").replace("_", "").replace(" ", "")
+    for model in allowed:
+        if model.lower().replace("-", "").replace("_", "").replace(" ", "") == norm:
+            return model
+    return None
+
+
+def _safe_family(model: str) -> str | None:
+    try:
+        return infer_family(model)
+    except FamilyInferenceError:
+        return None
+
+
+def _format_source_label(binding: PetriBinding) -> str:
+    """Format the source column — 'auto → <resolved>' when override is auto."""
+    override = read_role_override(binding.role)
+    declared = override.get("source") or AUTO_SOURCE
+    if declared == AUTO_SOURCE and binding.source != AUTO_SOURCE:
+        return f"auto → {binding.source}"
+    return binding.source
+
+
+def _env_vars_for_family(family: str) -> list[str]:
+    """Return all auth env vars declared by adapters for a family."""
+    manifest = load_manifest()
+    out: list[str] = []
+    for source, adapter in manifest.adapters.get(family, {}).items():
+        del source
+        out.extend(adapter.auth_env_vars)
+    return out
+
+
+# Quiet noqa for symbols only used by the slash dispatcher wiring.
+_ = (resolve_credential_source,)  # type: ignore[unused-ignore]
+
+
+def _smoke() -> dict[str, Any]:  # pragma: no cover — manual REPL aid
+    """Manual smoke helper — emits the picker's status payload as a dict."""
+    out: dict[str, Any] = {}
+    for role in _enabled_roles():
+        try:
+            out[role] = get_binding(role)
+        except Exception as e:
+            out[role] = {"error": f"{type(e).__name__}: {e}"}
+    return out

--- a/plugins/petri_audit/registry.py
+++ b/plugins/petri_audit/registry.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 
 from plugins.petri_audit.credential_source import resolve_credential_source
 from plugins.petri_audit.manifest import load_manifest
+from plugins.petri_audit.user_overrides import read_role_override
 
 __all__ = [
     "FamilyInferenceError",
@@ -108,28 +109,35 @@ def get_binding(
 ) -> PetriBinding:
     """Resolve the effective binding for a Petri role.
 
-    Resolution order:
+    Resolution order (per axis):
 
-    1. ``model`` argument (caller override) — must be in the role's
-       ``allowed_models``; otherwise raises :class:`ValueError`.
-    2. Manifest ``[petri.role.<role>].default_model``.
+    1. ``model`` / ``source`` argument (caller override) — wins outright.
+    2. ``~/.geode/petri.toml`` ``[petri.<role>]`` (per-user override
+       written by the ``/petri`` slash command).
+    3. Manifest default for the model axis; the credential_source
+       cascade (settings → manifest default → 'auto' expansion) for the
+       source axis.
 
-    Source resolution delegates to :func:`plugins.petri_audit.
-    credential_source.resolve_credential_source` (which itself respects
-    override → settings → manifest default → 'auto' expansion). The
-    ``source`` argument here is passed through as the override.
+    Model overrides validate against the role's ``allowed_models`` —
+    :class:`ValueError` if not allowed. Source overrides flow through
+    :func:`plugins.petri_audit.credential_source.resolve_credential_source`
+    so suppressions still apply even when petri.toml pins a source.
     """
     manifest = load_manifest()
     role_spec = manifest.get_role(role)
 
-    chosen_model = model or role_spec.default_model
+    user_override = read_role_override(role)
+    chosen_model = model or user_override.get("model") or role_spec.default_model
     if chosen_model not in role_spec.allowed_models:
         raise ValueError(
             f"role={role}: model {chosen_model!r} not in allowed_models {role_spec.allowed_models}"
         )
 
     family = infer_family(chosen_model)
-    resolved_source = resolve_credential_source(family, override=source)
+    # Source priority — caller arg → petri.toml → resolve_credential_source
+    # cascade ('auto' expansion happens inside).
+    source_override = source or user_override.get("source")
+    resolved_source = resolve_credential_source(family, override=source_override)
     adapter_spec = manifest.get_adapter(family, resolved_source)
 
     # Target role is always routed through GeodeModelAPI — the audit

--- a/plugins/petri_audit/user_overrides.py
+++ b/plugins/petri_audit/user_overrides.py
@@ -1,0 +1,211 @@
+"""Per-user Petri override store — read/write ``~/.geode/petri.toml``.
+
+Lets the user pin a model / source per role without touching the
+manifest (which ships with the codebase). The ``/petri`` command
+writes here; :func:`plugins.petri_audit.registry.get_binding` reads
+through this layer before falling back to the manifest defaults.
+
+Schema (TOML)::
+
+    [petri.auditor]
+    model = "claude-opus-4-7"
+    source = "claude-cli"
+
+    [petri.target]
+    model = "gpt-5.4-mini"
+    # source absent → auto
+
+    [petri.judge]
+    model = "claude-sonnet-4-6"
+    source = "api_key"
+
+Both keys are optional per role. A missing role → no overrides
+(manifest default wins). A missing field → that axis stays default.
+
+The store is intentionally **side-effect-light** — read/write are
+synchronous, no schema migration, no caching beyond the OS page cache.
+This is fine for a CLI-only path that fires on user keystroke.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_PETRI_TOML
+
+__all__ = [
+    "RoleOverride",
+    "clear_overrides",
+    "load_user_overrides",
+    "read_role_override",
+    "save_role_override",
+]
+
+
+# Lightweight typed-dict-style alias; keep as plain dict[str, str] for
+# write-side simplicity. The two keys are 'model' and 'source'; either
+# may be absent.
+RoleOverride = dict[str, str]
+
+
+def _resolve_path(path: Path | str | None) -> Path:
+    """Resolve the petri.toml path, honouring ``GEODE_PETRI_TOML`` env override.
+
+    Order: explicit ``path`` argument → ``GEODE_PETRI_TOML`` env → default
+    :data:`core.paths.GLOBAL_PETRI_TOML`. Matches the pattern used by
+    :mod:`core.auth.auth_toml`.
+    """
+    if path is not None:
+        return Path(path)
+    env = os.environ.get("GEODE_PETRI_TOML")
+    if env:
+        return Path(env)
+    return GLOBAL_PETRI_TOML
+
+
+def load_user_overrides(path: Path | str | None = None) -> dict[str, RoleOverride]:
+    """Return ``{role: {model?: str, source?: str}}`` from petri.toml.
+
+    Missing file → empty dict. Malformed TOML / non-table sections →
+    skipped silently (CLI keystroke path must be robust; manifest path
+    is the authoritative SOT). Unknown roles and unknown axis keys are
+    preserved so future schema additions don't drop user data.
+    """
+    target = _resolve_path(path)
+    if not target.exists():
+        return {}
+    try:
+        data = tomllib.loads(target.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    petri = data.get("petri")
+    if not isinstance(petri, dict):
+        return {}
+    out: dict[str, RoleOverride] = {}
+    for role_name, role_data in petri.items():
+        if not isinstance(role_data, dict):
+            continue
+        cleaned: RoleOverride = {}
+        for key in ("model", "source"):
+            value = role_data.get(key)
+            if isinstance(value, str) and value:
+                cleaned[key] = value
+        if cleaned:
+            out[role_name] = cleaned
+    return out
+
+
+def read_role_override(role: str, *, path: Path | str | None = None) -> RoleOverride:
+    """Return the override dict for a single role (empty if unset)."""
+    return load_user_overrides(path).get(role, {})
+
+
+def save_role_override(
+    role: str,
+    *,
+    model: str | None = None,
+    source: str | None = None,
+    path: Path | str | None = None,
+) -> None:
+    """Persist a role override to petri.toml.
+
+    ``model`` / ``source`` semantics:
+
+    - ``None`` (default) → keep the existing value for that axis.
+    - ``""`` (empty string) → delete that axis from the role (so the
+      manifest default takes over).
+    - non-empty string → write the value.
+
+    The function is additive — other roles are preserved verbatim. Atomic
+    write via a temp-file rename so a crashed editor never leaves a
+    partial petri.toml on disk.
+    """
+    target = _resolve_path(path)
+    existing = load_user_overrides(target)
+    role_dict = dict(existing.get(role, {}))
+
+    if model is not None:
+        if model == "":
+            role_dict.pop("model", None)
+        else:
+            role_dict["model"] = model
+    if source is not None:
+        if source == "":
+            role_dict.pop("source", None)
+        else:
+            role_dict["source"] = source
+
+    if role_dict:
+        existing[role] = role_dict
+    else:
+        existing.pop(role, None)
+
+    _atomic_write_toml(target, existing)
+
+
+def clear_overrides(role: str | None = None, *, path: Path | str | None = None) -> None:
+    """Drop overrides — for a single role or for every role.
+
+    ``role=None`` (default) wipes the whole ``[petri.*]`` tree but leaves
+    other top-level sections in the file untouched (forward-compat —
+    petri.toml is currently single-section but the writer treats it as
+    additive).
+    """
+    target = _resolve_path(path)
+    existing = load_user_overrides(target)
+    if role is None:
+        existing.clear()
+    else:
+        existing.pop(role, None)
+    _atomic_write_toml(target, existing)
+
+
+def _atomic_write_toml(target: Path, overrides: dict[str, RoleOverride]) -> None:
+    """Write the overrides dict to ``target`` atomically.
+
+    Format — one ``[petri.<role>]`` block per role with stable key
+    order (model first, source second). No tomli-w dependency; we hand-
+    serialise because the surface is tiny + we want exact diffability.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not overrides:
+        # Empty state — keep the file as a tombstone so future writes
+        # don't surprise the user, but the body is just a header comment.
+        body = (
+            "# Petri per-user role × model × source overrides.\n"
+            "# Edited by `/petri` slash command — read by\n"
+            "# plugins.petri_audit.user_overrides.load_user_overrides.\n"
+        )
+    else:
+        lines: list[str] = [
+            "# Petri per-user role × model × source overrides.\n"
+            "# Edited by `/petri` slash command — read by\n"
+            "# plugins.petri_audit.user_overrides.load_user_overrides.\n",
+        ]
+        for role_name in sorted(overrides):
+            role_data = overrides[role_name]
+            lines.append(f"\n[petri.{role_name}]\n")
+            for key in ("model", "source"):
+                if key in role_data:
+                    value = role_data[key].replace('"', '\\"')
+                    lines.append(f'{key} = "{value}"\n')
+        body = "".join(lines)
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(body, encoding="utf-8")
+    tmp.replace(target)
+
+
+def _coerce(role_data: Any) -> RoleOverride:
+    """Defensive coercion used by tests + external callers."""
+    if not isinstance(role_data, dict):
+        return {}
+    out: RoleOverride = {}
+    for key in ("model", "source"):
+        value = role_data.get(key)
+        if isinstance(value, str) and value:
+            out[key] = value
+    return out

--- a/tests/plugins/petri_audit/test_petri_cli.py
+++ b/tests/plugins/petri_audit/test_petri_cli.py
@@ -1,0 +1,252 @@
+"""Unit tests for the /petri slash command (P1-F).
+
+The interactive TerminalMenu picker (``_picker_for_role``) requires a TTY
+and is exercised only via smoke + non-TTY fallback here. The sub-command
+sub-commands (status / model / source / reset) cover the bulk of the
+behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from plugins.petri_audit.cli import cmd_petri
+from plugins.petri_audit.manifest import clear_manifest_cache
+
+from plugins.petri_audit import credential_source as cs
+from plugins.petri_audit import user_overrides as uo
+
+
+@pytest.fixture(autouse=True)
+def _petri_toml(tmp_path: Path, monkeypatch):
+    """Redirect petri.toml + clear all stateful caches."""
+    target = tmp_path / "petri.toml"
+    monkeypatch.setenv("GEODE_PETRI_TOML", str(target))
+    clear_manifest_cache()
+    cs.clear_suppressions()
+    yield target
+    cs.clear_suppressions()
+    clear_manifest_cache()
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _stub_settings(monkeypatch):
+    monkeypatch.setattr(cs, "_settings_source", lambda family: None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_oauth(monkeypatch):
+    from plugins.petri_audit.adapters import claude_cli_backend, openai_codex_oauth
+
+    monkeypatch.setattr(claude_cli_backend, "is_available", lambda: False)
+    monkeypatch.setattr(openai_codex_oauth, "is_available", lambda: False)
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture every console.print call for assertion."""
+    from core.cli import commands as _pkg
+
+    lines: list[str] = []
+
+    class _StubConsole:
+        def print(self, *args, **kwargs):
+            lines.append(" ".join(str(a) for a in args))
+
+        def input(self, prompt: str = "") -> str:
+            lines.append(f"<input>{prompt}")
+            return "y"
+
+    monkeypatch.setattr(_pkg, "console", _StubConsole())
+    return lines
+
+
+# ── Status (/petri with no args) ────────────────────────────────────────────
+
+
+def test_status_lists_three_roles(captured, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cmd_petri("")
+    joined = "\n".join(captured)
+    assert "auditor" in joined
+    assert "target" in joined
+    assert "judge" in joined
+    assert "Petri bindings" in joined
+
+
+def test_status_marks_missing_env(captured):
+    # No env vars set → resolver raises → status shows 'unresolved' + missing env.
+    cmd_petri("")
+    joined = "\n".join(captured)
+    assert "unresolved" in joined
+    assert "Missing env" in joined
+    assert "ANTHROPIC_API_KEY" in joined
+
+
+def test_status_target_geode_prefix(captured, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cmd_petri("")
+    joined = "\n".join(captured)
+    assert "geode/" in joined  # target row uses geode prefix
+
+
+# ── /petri model ───────────────────────────────────────────────────────────
+
+
+def test_set_model_updates_override(captured, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cmd_petri("model auditor claude-opus-4-7")
+    assert uo.read_role_override("auditor") == {"model": "claude-opus-4-7"}
+    joined = "\n".join(captured)
+    assert "claude-opus-4-7" in joined
+
+
+def test_set_model_rejects_disallowed(captured):
+    cmd_petri("model auditor glm-4-6")  # auditor doesn't allow GLM
+    joined = "\n".join(captured)
+    assert "not in allowed" in joined
+    assert uo.read_role_override("auditor") == {}
+
+
+def test_set_model_normalised_match(captured, monkeypatch):
+    """Hyphens / case-insensitive match works (mirrors /model behaviour)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cmd_petri("model auditor CLAUDEOPUS47")  # normalised → claude-opus-4-7
+    assert uo.read_role_override("auditor").get("model") == "claude-opus-4-7"
+
+
+def test_set_model_family_change_resets_source(captured, monkeypatch):
+    """Switching family (claude- → gpt-) erases the now-incompatible source."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    # Initial — claude family + claude-cli source.
+    uo.save_role_override("auditor", model="claude-opus-4-7", source="claude-cli")
+    cmd_petri("model auditor gpt-5.5")
+    out = uo.read_role_override("auditor")
+    assert out.get("model") == "gpt-5.5"
+    assert "source" not in out  # erased
+
+
+def test_set_model_unknown_role(captured):
+    cmd_petri("model imposter claude-opus-4-7")
+    joined = "\n".join(captured)
+    assert "Unknown petri role" in joined
+
+
+def test_set_model_missing_args(captured):
+    cmd_petri("model auditor")  # missing model name
+    joined = "\n".join(captured)
+    assert "Usage" in joined
+
+
+# ── /petri source ──────────────────────────────────────────────────────────
+
+
+def test_set_source_updates_override(captured, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cmd_petri("source auditor api_key")
+    assert uo.read_role_override("auditor") == {"source": "api_key"}
+
+
+def test_set_source_rejects_invalid(captured):
+    cmd_petri("source auditor imposter")
+    joined = "\n".join(captured)
+    assert "not allowed for family" in joined
+    assert uo.read_role_override("auditor") == {}
+
+
+def test_set_source_family_aware(captured):
+    """A source belonging to a different family is rejected.
+    auditor's default model is claude-* (family=anthropic) → openai-codex
+    is not allowed for that family."""
+    cmd_petri("source auditor openai-codex")
+    joined = "\n".join(captured)
+    assert "not allowed for family" in joined
+
+
+def test_set_source_auto(captured):
+    """'auto' is always a valid source for any family that lists it."""
+    cmd_petri("source auditor auto")
+    assert uo.read_role_override("auditor").get("source") == "auto"
+
+
+# ── /petri reset ───────────────────────────────────────────────────────────
+
+
+def test_reset_single_role(captured, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    cmd_petri("reset auditor")
+    assert uo.read_role_override("auditor") == {}
+
+
+def test_reset_all_with_confirmation(captured):
+    """'/petri reset' wipes after y confirmation (stub_console returns 'y')."""
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    uo.save_role_override("judge", source="api_key")
+    cmd_petri("reset")
+    assert uo.load_user_overrides() == {}
+
+
+def test_reset_all_cancelled(captured, monkeypatch):
+    """A 'no' answer at the confirmation prompt leaves overrides intact."""
+    from core.cli import commands as _pkg
+
+    class _DenyConsole:
+        def print(self, *args, **kwargs):
+            captured.append(" ".join(str(a) for a in args))
+
+        def input(self, prompt: str = "") -> str:
+            return "n"
+
+    monkeypatch.setattr(_pkg, "console", _DenyConsole())
+
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    cmd_petri("reset")
+    assert uo.read_role_override("auditor").get("model") == "claude-opus-4-7"
+
+
+def test_reset_unknown_role(captured):
+    cmd_petri("reset imposter")
+    joined = "\n".join(captured)
+    assert "Unknown petri role" in joined
+
+
+# ── Interactive picker non-TTY fallback ────────────────────────────────────
+
+
+def test_picker_non_tty_falls_back_to_status(captured, monkeypatch):
+    """/petri auditor in a non-tty pipe shows status + usage hint instead
+    of raising on TerminalMenu init."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    cmd_petri("auditor")
+    joined = "\n".join(captured)
+    assert "Petri bindings" in joined
+    assert "Usage" in joined
+
+
+def test_picker_unknown_role(captured):
+    cmd_petri("imposter")
+    joined = "\n".join(captured)
+    assert "Unknown petri role" in joined
+
+
+# ── Command map registration ───────────────────────────────────────────────
+
+
+def test_command_map_contains_petri():
+    from core.cli.commands._state import COMMAND_MAP
+
+    assert COMMAND_MAP["/petri"] == "petri"
+
+
+def test_resolve_action_petri():
+    from core.cli.commands import resolve_action
+
+    assert resolve_action("/petri") == "petri"

--- a/tests/plugins/petri_audit/test_user_overrides.py
+++ b/tests/plugins/petri_audit/test_user_overrides.py
@@ -1,0 +1,192 @@
+"""Unit tests for plugins.petri_audit.user_overrides (P1-F)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugins.petri_audit import user_overrides as uo
+
+
+@pytest.fixture
+def petri_toml(tmp_path: Path, monkeypatch) -> Path:
+    """Redirect petri.toml to a tmp path via the env override hook."""
+    target = tmp_path / "petri.toml"
+    monkeypatch.setenv("GEODE_PETRI_TOML", str(target))
+    return target
+
+
+# ── load_user_overrides ────────────────────────────────────────────────────
+
+
+def test_load_missing_file_returns_empty(petri_toml: Path):
+    assert uo.load_user_overrides() == {}
+
+
+def test_load_valid_file(petri_toml: Path):
+    petri_toml.write_text(
+        """
+[petri.auditor]
+model = "claude-opus-4-7"
+source = "claude-cli"
+
+[petri.target]
+model = "gpt-5.4-mini"
+""",
+        encoding="utf-8",
+    )
+    out = uo.load_user_overrides()
+    assert out == {
+        "auditor": {"model": "claude-opus-4-7", "source": "claude-cli"},
+        "target": {"model": "gpt-5.4-mini"},
+    }
+
+
+def test_load_malformed_toml_returns_empty(petri_toml: Path):
+    petri_toml.write_text("this is not toml [[[", encoding="utf-8")
+    assert uo.load_user_overrides() == {}
+
+
+def test_load_missing_petri_section_returns_empty(petri_toml: Path):
+    petri_toml.write_text('[other]\nkey = "value"\n', encoding="utf-8")
+    assert uo.load_user_overrides() == {}
+
+
+def test_load_drops_non_string_fields(petri_toml: Path):
+    petri_toml.write_text(
+        """
+[petri.auditor]
+model = 42
+source = "claude-cli"
+""",
+        encoding="utf-8",
+    )
+    assert uo.load_user_overrides() == {"auditor": {"source": "claude-cli"}}
+
+
+def test_load_drops_non_table_role(petri_toml: Path):
+    """A non-table value under [petri] (e.g. petri.something = "x") is skipped."""
+    petri_toml.write_text(
+        """
+[petri]
+auditor = "not a table"
+
+[petri.target]
+model = "claude-sonnet-4-6"
+""",
+        encoding="utf-8",
+    )
+    out = uo.load_user_overrides()
+    assert "auditor" not in out
+    assert out["target"]["model"] == "claude-sonnet-4-6"
+
+
+# ── read_role_override ─────────────────────────────────────────────────────
+
+
+def test_read_role_unknown_returns_empty(petri_toml: Path):
+    assert uo.read_role_override("auditor") == {}
+
+
+def test_read_role_existing(petri_toml: Path):
+    petri_toml.write_text('[petri.judge]\nmodel = "claude-opus-4-7"\n', encoding="utf-8")
+    assert uo.read_role_override("judge") == {"model": "claude-opus-4-7"}
+
+
+# ── save_role_override ─────────────────────────────────────────────────────
+
+
+def test_save_creates_file(petri_toml: Path):
+    assert not petri_toml.exists()
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    assert petri_toml.exists()
+    assert uo.read_role_override("auditor") == {"model": "claude-opus-4-7"}
+
+
+def test_save_preserves_other_roles(petri_toml: Path):
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    uo.save_role_override("judge", source="claude-cli")
+    assert uo.read_role_override("auditor")["model"] == "claude-opus-4-7"
+    assert uo.read_role_override("judge")["source"] == "claude-cli"
+
+
+def test_save_empty_string_deletes_axis(petri_toml: Path):
+    """Passing source='' removes the source entry but keeps model."""
+    uo.save_role_override("auditor", model="claude-opus-4-7", source="claude-cli")
+    uo.save_role_override("auditor", source="")
+    assert uo.read_role_override("auditor") == {"model": "claude-opus-4-7"}
+
+
+def test_save_none_keeps_existing(petri_toml: Path):
+    """source=None leaves the existing source untouched."""
+    uo.save_role_override("auditor", model="claude-opus-4-7", source="claude-cli")
+    uo.save_role_override("auditor", model="claude-sonnet-4-6")  # source=None
+    out = uo.read_role_override("auditor")
+    assert out == {"model": "claude-sonnet-4-6", "source": "claude-cli"}
+
+
+def test_save_empties_role_when_all_axes_removed(petri_toml: Path):
+    uo.save_role_override("auditor", model="claude-opus-4-7", source="claude-cli")
+    uo.save_role_override("auditor", model="", source="")
+    assert uo.read_role_override("auditor") == {}
+
+
+def test_save_atomic_write_no_partial(petri_toml: Path, monkeypatch):
+    """A crashed write leaves the original file intact (atomic rename)."""
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    original = petri_toml.read_text(encoding="utf-8")
+
+    # Force a failure mid-write by patching replace().
+    real_replace = Path.replace
+
+    def _boom(self: Path, target: Path) -> Path:
+        raise OSError("simulated crash")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    with pytest.raises(OSError, match="simulated crash"):
+        uo.save_role_override("auditor", source="claude-cli")
+    monkeypatch.setattr(Path, "replace", real_replace)
+
+    # Original content untouched.
+    assert petri_toml.read_text(encoding="utf-8") == original
+
+
+# ── clear_overrides ────────────────────────────────────────────────────────
+
+
+def test_clear_single_role(petri_toml: Path):
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    uo.save_role_override("judge", source="claude-cli")
+    uo.clear_overrides("auditor")
+    assert uo.read_role_override("auditor") == {}
+    assert uo.read_role_override("judge")["source"] == "claude-cli"
+
+
+def test_clear_all(petri_toml: Path):
+    uo.save_role_override("auditor", model="claude-opus-4-7")
+    uo.save_role_override("judge", source="claude-cli")
+    uo.clear_overrides()
+    assert uo.load_user_overrides() == {}
+
+
+def test_clear_idempotent(petri_toml: Path):
+    uo.clear_overrides()  # no file, no raise
+    uo.clear_overrides("auditor")  # no role, no raise
+    assert uo.load_user_overrides() == {}
+
+
+# ── Explicit path argument ─────────────────────────────────────────────────
+
+
+def test_save_with_explicit_path_arg(tmp_path: Path):
+    target = tmp_path / "other.toml"
+    uo.save_role_override("auditor", model="claude-opus-4-7", path=target)
+    assert target.exists()
+    assert uo.read_role_override("auditor", path=target)["model"] == "claude-opus-4-7"
+
+
+def test_load_quoting_robust(petri_toml: Path):
+    """Values with embedded double quotes round-trip safely."""
+    uo.save_role_override("auditor", model='gpt-5.5 "tactical"')
+    assert uo.read_role_override("auditor")["model"] == 'gpt-5.5 "tactical"'


### PR DESCRIPTION
## Summary
- 새 슬래시 명령 `/petri` 추가 — status / picker / model / source / reset 5 sub-command
- user override 영구화 — `~/.geode/petri.toml` (별도 파일, Q1 결정 정합)
- registry.get_binding 이 manifest default 와 caller arg 사이 layer 로 user override 자동 적용

## Why
P1-A~E 의 manifest + adapter + credential_source + registry stack 위에 사용자 진입점. /model 의 1-axis 패턴을 3 role × 2-axis (model + source) 로 확장. petri.toml 별도 파일 — config.toml 메인 설정과 petri 전용 토글 분리.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/cli.py` | 신설 — cmd_petri + 4 sub-command + status + picker |
| `plugins/petri_audit/user_overrides.py` | 신설 — load / save / clear (atomic write) |
| `plugins/petri_audit/registry.py` | get_binding 가 user_override 적용 |
| `core/cli/commands/petri.py` | 신설 — slash dispatcher shim |
| `core/cli/commands/{_state,__init__}.py` | COMMAND_MAP + cmd_petri 등록 + help 라인 |
| `core/cli/dispatcher.py` | action == "petri" 분기 추가 |
| `core/paths.py` | GLOBAL_PETRI_TOML 상수 |
| `tests/plugins/petri_audit/test_{petri_cli,user_overrides}.py` | 40 신규 |
| `CHANGELOG.md` | [Unreleased] Added (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `/petri` status table | Implemented | Role × Model × Source × Inspect ID + missing env 표시 |
| 2-step picker (model → source) | Implemented | TerminalMenu, family-aware source filter |
| `/petri model <role> <name>` | Implemented | normalised match, family 변경 시 source reset |
| `/petri source <role> <src>` | Implemented | family-aware allowed 검증 |
| `/petri reset [<role>]` | Implemented | 전체 reset 은 y/N confirmation |
| Persist 위치 — petri.toml 별도 | Implemented | Q1 결정 정합 |
| Non-TTY fallback | Implemented | status + usage hint |
| 단위 테스트 | Implemented | 40/40 |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (cli.py, user_overrides.py, petri.py shim)
- [x] pytest pass (40 신규 + tests/plugins/petri_audit/ 회귀)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) 유지

## Reference
- /model `_interactive_model_picker` — single-axis picker 패턴 차용
- /login picker (TerminalMenu) — multi-step + cancel 처리 패턴
- Hermes credential_sources — suppress 동작 정합
- 후속: P1-G — to_inspect_model 의 if/elif chain 을 `registry.get_binding(role).inspect_id` 로 collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)