### PR TITLE
refactor(config): model defaults + fallback chains → routing.toml (P2-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,27 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **Model defaults + fallback chains migrated to routing.toml (P2-B).**
+  `core/config/__init__.py` 의 10 hardcoded 상수 (`ANTHROPIC_PRIMARY` /
+  `SECONDARY` / `BUDGET` / `FALLBACK_CHAIN` / `OPENAI_PRIMARY` /
+  `OPENAI_FALLBACK_CHAIN` / `CODEX_PRIMARY` / `CODEX_FALLBACK_CHAIN` /
+  `GLM_PRIMARY` / `GLM_FALLBACK_CHAIN`) 가 이제 P2-A 의
+  `core/config/routing.toml` 에서 lazy load. 공개 surface 그대로 — 모든
+  call site (system_prompt, approval, openai_adapter 등) 영향 0. 사용자가
+  값을 바꾸려면 `~/.geode/routing.toml` override 수정. `CODEX_BASE_URL`
+  / `GLM_BASE_URL` / `GLM_PAYG_BASE_URL` 등 endpoint 상수는 manifest 에
+  스키마가 없어 그대로 유지 — 후속에서 합칠 수도.
+
+- **Model defaults + fallback chains migrated to routing.toml (P2-B).**
+  The 10 hardcoded model constants in `core/config/__init__.py`
+  (`ANTHROPIC_PRIMARY` etc.) now load from P2-A's `core/config/
+  routing.toml`. Public surface unchanged — every call site keeps
+  working. Users override by editing `~/.geode/routing.toml`. Endpoint
+  URLs (`CODEX_BASE_URL` / `GLM_BASE_URL` / `GLM_PAYG_BASE_URL`) stay
+  hardcoded for now since the manifest does not yet schema them.
+
 ### Added
 
 - **GEODE routing manifest (P2-A) — `routing.toml` schema + loader.**

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -207,32 +207,37 @@ def __getattr__(name: str) -> Any:
 # All code MUST reference these instead of hardcoding model strings.
 # ---------------------------------------------------------------------------
 
-# Anthropic models — verified 2026-04-26 against platform.claude.com.
-# v0.53.0 — chain depth reduced to 1 (primary → secondary only) per
-# fail-fast governance: deeper chains create cost surprise + unclear
-# user attribution. Quota exhaustion now surfaces a panel + stops loop.
-ANTHROPIC_PRIMARY = "claude-opus-4-7"
-ANTHROPIC_SECONDARY = "claude-sonnet-4-6"
-ANTHROPIC_BUDGET = "claude-haiku-4-5-20251001"
-ANTHROPIC_FALLBACK_CHAIN: list[str] = [ANTHROPIC_PRIMARY, ANTHROPIC_SECONDARY]
+# P2-B (2026-05-17) — model defaults + fallback chains migrated to
+# core/config/routing.toml + ~/.geode/routing.toml. The constants below
+# retain their public surface (every existing call site keeps working)
+# but their values now load from the manifest; users edit routing.toml
+# to override rather than monkeypatching this module.
+#
+# Anthropic / OpenAI / Codex / GLM defaults all come from
+# ``[model.defaults]`` and fallback chains from ``[model.fallbacks.<provider>]``.
+# Base URLs and any constants the manifest does not yet model stay hardcoded.
+from core.config.routing_manifest import (  # noqa: E402
+    load_routing_manifest as _load_routing_manifest,
+)
 
-# OpenAI models — verified 2026-04-26 against developers.openai.com.
-# v0.52.4 — gpt-5.5 promoted to primary (Codex's new default model).
-# v0.53.0 — chain depth reduced to 1 (primary → next).
-OPENAI_PRIMARY = "gpt-5.5"
-OPENAI_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.4"]
+_routing = _load_routing_manifest()
+
+ANTHROPIC_PRIMARY: str = _routing.defaults.anthropic
+ANTHROPIC_SECONDARY: str = _routing.defaults.anthropic_secondary or ""
+ANTHROPIC_BUDGET: str = _routing.defaults.anthropic_budget or ""
+ANTHROPIC_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.anthropic)
+
+OPENAI_PRIMARY: str = _routing.defaults.openai
+OPENAI_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.openai)
 
 # OpenAI Codex — Plus quota via chatgpt.com/backend-api/codex (Responses API).
-# v0.52.4 — gpt-5.5 OAuth-only (developers.openai.com/codex/models).
-# v0.53.0 — chain depth reduced to 1.
-CODEX_PRIMARY = "gpt-5.5"
-CODEX_FALLBACK_CHAIN: list[str] = ["gpt-5.5", "gpt-5.3-codex"]
+CODEX_PRIMARY: str = _routing.defaults.codex
+CODEX_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.codex)
 CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
-# ZhipuAI (GLM) models — OpenAI-compatible API, separate provider.
-# v0.53.0 — chain depth reduced to 1 (primary → secondary).
-GLM_PRIMARY = "glm-5.1"
-GLM_FALLBACK_CHAIN: list[str] = ["glm-5.1", "glm-5"]
+# ZhipuAI (GLM) — OpenAI-compatible API, separate provider.
+GLM_PRIMARY: str = _routing.defaults.glm
+GLM_FALLBACK_CHAIN: list[str] = list(_routing.fallbacks.glm)
 # Coding Plan endpoint (subscription-billed). PAYG endpoint is api/paas/v4 — a
 # Coding Plan key called against PAYG path silently bypasses the subscription
 # quota and incurs metered billing instead.


### PR DESCRIPTION
## Summary
- 10 hardcoded model constants → `core/config/routing.toml` lazy load
- 공개 surface 유지 (`from core.config import ANTHROPIC_PRIMARY` 등 그대로 작동)
- 사용자 override — `~/.geode/routing.toml` 의 `[model.defaults]` + `[model.fallbacks.<provider>]`

## Why
P2-A 의 routing.toml + routing_manifest 가 7 시간 dormant. P2-B 가 첫 consumer — 가장 noise 적은 migration (10 constants → 1 manifest section 매핑) 으로 검증. drift 가 routing_manifest validator 로 차단됨을 확인.

## Changes
| File | Change |
|------|--------|
| `core/config/__init__.py` | 10 module-level constants 를 `_load_routing_manifest()` 결과로 set |
| `CHANGELOG.md` | [Unreleased] Changed (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ANTHROPIC_PRIMARY / SECONDARY / BUDGET / FALLBACK_CHAIN | Migrated | manifest defaults / fallbacks.anthropic |
| OPENAI_PRIMARY / OPENAI_FALLBACK_CHAIN | Migrated | defaults.openai / fallbacks.openai |
| CODEX_PRIMARY / CODEX_FALLBACK_CHAIN | Migrated | defaults.codex / fallbacks.codex |
| GLM_PRIMARY / GLM_FALLBACK_CHAIN | Migrated | defaults.glm / fallbacks.glm |
| CODEX_BASE_URL / GLM_BASE_URL / GLM_PAYG_BASE_URL | Kept hardcoded | manifest 미포함 (후속에서 합칠 수도) |

## Verification
- [x] ruff check clean (1 noqa: E402 + 1 noqa: I001 의도된 module-level lazy import)
- [x] ruff format clean
- [x] mypy clean (core/config/__init__.py)
- [x] pytest selective (test_routing_config / test_routing_manifest / test_openai_adapter) pass
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) 유지

## Reference
- P2-A `core/config/routing_manifest.py` — schema + loader (drift validator)
- 후속: P2-C (credential patterns + keychain) → P2-D (_resolve_provider 통합) → P2-E (pipeline node defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)