### PR TITLE
refactor(config): credential patterns + keychain → routing.toml (P2-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,26 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Changed
 
+- **Credential patterns + keychain service migrated to routing.toml (P2-C).**
+  `core/cli/onboarding.py` 의 `_KEY_PATTERNS` 상수 (3-tuple regex/provider/
+  env_var) 가 manifest 의 `[credentials.patterns]` + `[credentials.
+  env_vars]` 에서 lazy load. `plugins/petri_audit/claude_code_provider.py`
+  의 `KEYCHAIN_SERVICE` 상수도 `[credentials.keychain]` + env override
+  (`GEODE_ANTHROPIC_KEYCHAIN_SERVICE`) 기반으로 전환. routing_manifest
+  에 `CredentialEnvVars` pydantic 모델 추가 (provider → env var).
+  Fallback (manifest 미가용 시 legacy hardcode) 유지 — 사용자가 stale
+  .geode 디렉토리여도 onboarding 깨지지 않음.
+
+- **Credential patterns + keychain service migrated to routing.toml (P2-C).**
+  Moved the `_KEY_PATTERNS` table (regex / provider / env var triples)
+  from `core/cli/onboarding.py` into the routing manifest's
+  `[credentials.patterns]` + new `[credentials.env_vars]` sections.
+  Similarly relocated `KEYCHAIN_SERVICE` in
+  `plugins/petri_audit/claude_code_provider.py` to consult an env
+  override (`GEODE_ANTHROPIC_KEYCHAIN_SERVICE`) then the manifest's
+  `[credentials.keychain]`. Added `CredentialEnvVars` pydantic model.
+  Defensive fallbacks keep onboarding usable on a stale install.
+
 - **Model defaults + fallback chains migrated to routing.toml (P2-B).**
   `core/config/__init__.py` 의 10 hardcoded 상수 (`ANTHROPIC_PRIMARY` /
   `SECONDARY` / `BUDGET` / `FALLBACK_CHAIN` / `OPENAI_PRIMARY` /

--- a/core/cli/onboarding.py
+++ b/core/cli/onboarding.py
@@ -161,12 +161,39 @@ def _wizard_api_key_path() -> bool:
 # API Key Detection (natural language input guard)
 # ---------------------------------------------------------------------------
 
-# Patterns: sk-ant-* → anthropic, sk-proj-*/sk-* → openai, hex.hex → glm
-_KEY_PATTERNS: list[tuple[str, str, str]] = [
-    (r"^sk-ant-[A-Za-z0-9_-]{10,}$", "anthropic", "ANTHROPIC_API_KEY"),
-    (r"^sk-proj-[A-Za-z0-9_-]{10,}$", "openai", "OPENAI_API_KEY"),
-    (r"^sk-[A-Za-z0-9_-]{10,}$", "openai", "OPENAI_API_KEY"),
-]
+# P2-C (2026-05-17) — credential pattern + env var binding migrated to
+# core/config/routing.toml. The wizard now reads both axes from the
+# manifest so adding a new provider is a TOML edit, not a code change.
+
+
+def _key_patterns() -> list[tuple[str, str, str]]:
+    """Return ``[(regex, provider, env_var), ...]`` from the routing manifest.
+
+    Lazy — called from :func:`detect_api_key` so the heavy manifest load
+    only fires on the natural-language input path (not at module import).
+    Falls back to a built-in default if the manifest is unreachable so
+    onboarding never crashes on a stale install.
+    """
+    try:
+        from core.config.routing_manifest import load_routing_manifest
+
+        manifest = load_routing_manifest()
+    except Exception:
+        return [
+            (r"^sk-ant-[A-Za-z0-9_-]{10,}$", "anthropic", "ANTHROPIC_API_KEY"),
+            (r"^sk-proj-[A-Za-z0-9_-]{10,}$", "openai", "OPENAI_API_KEY"),
+            (r"^sk-[A-Za-z0-9_-]{10,}$", "openai", "OPENAI_API_KEY"),
+        ]
+    env_vars = manifest.credential_env_vars.env_vars
+    out: list[tuple[str, str, str]] = []
+    for regex, provider in manifest.credential_patterns.patterns.items():
+        env_var = env_vars.get(provider)
+        if not env_var:
+            # Unknown provider — skip (manifest authors should add the env var
+            # mapping when introducing a new pattern).
+            continue
+        out.append((regex, provider, env_var))
+    return out
 
 
 def detect_api_key(text: str) -> tuple[str, str, str] | None:
@@ -181,13 +208,19 @@ def detect_api_key(text: str) -> tuple[str, str, str] | None:
     if " " in stripped or "\n" in stripped:
         return None
 
-    for pattern, provider, env_var in _KEY_PATTERNS:
+    for pattern, provider, env_var in _key_patterns():
         if re.match(pattern, stripped):
             return provider, env_var, stripped
 
-    # GLM key: {id}.{secret} pattern — uses shared helper
+    # GLM key: {id}.{secret} pattern — uses shared helper.
     if is_glm_key(stripped):
-        return "glm", "ZAI_API_KEY", stripped
+        try:
+            from core.config.routing_manifest import load_routing_manifest
+
+            glm_env = load_routing_manifest().credential_env_vars.env_vars.get("glm", "ZAI_API_KEY")
+        except Exception:
+            glm_env = "ZAI_API_KEY"
+        return "glm", glm_env, stripped
 
     return None
 

--- a/core/config/routing.toml
+++ b/core/config/routing.toml
@@ -76,11 +76,23 @@ synthesizer = "claude-opus-4-7"
 #
 # Onboarding key wizard matches user input against these regexes to
 # auto-detect the provider. Pattern → provider map; first match wins.
+# Quantified patterns reject obvious typos (length ≥ 10) before they hit
+# the key store.
 
 [credentials.patterns]
-"^sk-ant-" = "anthropic"
-"^sk-proj-" = "openai"
-"^glm-" = "glm"
+"^sk-ant-[A-Za-z0-9_-]{10,}$" = "anthropic"
+"^sk-proj-[A-Za-z0-9_-]{10,}$" = "openai"
+"^sk-[A-Za-z0-9_-]{10,}$" = "openai"
+
+# Provider → env var the API key is stored under. Onboarding upserts into
+# the env when a pattern matches. GLM keys are sniffed by a dedicated
+# helper (``core.utils.env_io.is_glm_key``) — the GLM mapping here is
+# the destination env var for that hit.
+
+[credentials.env_vars]
+anthropic = "ANTHROPIC_API_KEY"
+openai = "OPENAI_API_KEY"
+glm = "ZAI_API_KEY"
 
 # ── Keychain service names (per provider, per platform) ────────────────────
 #

--- a/core/config/routing_manifest.py
+++ b/core/config/routing_manifest.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel, Field, model_validator
 __all__ = [
     "DEFAULT_MANIFEST_PATH",
     "USER_OVERRIDE_PATH",
+    "CredentialEnvVars",
     "CredentialKeychain",
     "CredentialPatterns",
     "ModelDefaults",
@@ -156,6 +157,17 @@ class CredentialKeychain(BaseModel):
     services: dict[str, str] = Field(default_factory=dict)
 
 
+class CredentialEnvVars(BaseModel):
+    """``[credentials.env_vars]`` — provider → env var name.
+
+    Onboarding upserts the matched key into this env var. Separate
+    section (rather than a 3-tuple per pattern) so the same env var
+    can serve multiple patterns for one provider without duplication.
+    """
+
+    env_vars: dict[str, str] = Field(default_factory=dict)
+
+
 # ── Top-level manifest ─────────────────────────────────────────────────────
 
 
@@ -167,6 +179,7 @@ class RoutingManifest(BaseModel):
     routing: RoutingRules
     credential_patterns: CredentialPatterns
     credential_keychain: CredentialKeychain
+    credential_env_vars: CredentialEnvVars = Field(default_factory=CredentialEnvVars)
 
     @model_validator(mode="after")
     def _consistency(self) -> RoutingManifest:
@@ -242,6 +255,7 @@ def _parse_manifest(data: dict[str, Any]) -> RoutingManifest:
 
     patterns = CredentialPatterns(patterns=credentials_section.get("patterns", {}))
     keychain = CredentialKeychain(services=credentials_section.get("keychain", {}))
+    env_vars = CredentialEnvVars(env_vars=credentials_section.get("env_vars", {}))
 
     return RoutingManifest(
         defaults=defaults,
@@ -249,6 +263,7 @@ def _parse_manifest(data: dict[str, Any]) -> RoutingManifest:
         routing=rules,
         credential_patterns=patterns,
         credential_keychain=keychain,
+        credential_env_vars=env_vars,
     )
 
 

--- a/plugins/petri_audit/claude_code_provider.py
+++ b/plugins/petri_audit/claude_code_provider.py
@@ -74,14 +74,43 @@ __all__ = [
     "resolve_claude_oauth_token",
 ]
 
-KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+def _resolve_keychain_service() -> str:
+    """Resolve the macOS keychain entry name for Anthropic OAuth.
+
+    Priority — env var ``GEODE_ANTHROPIC_KEYCHAIN_SERVICE`` (per-process
+    override) → ``[credentials.keychain] anthropic`` in
+    ``core/config/routing.toml`` → legacy default ``"Claude Code-credentials"``.
+
+    P2-C (2026-05-17): migrated from a hardcoded module-level constant
+    so users can rebind the entry name (e.g. when running multiple
+    Claude accounts side-by-side) by editing ``~/.geode/routing.toml``.
+    """
+    import os
+
+    env = os.environ.get("GEODE_ANTHROPIC_KEYCHAIN_SERVICE")
+    if env:
+        return env
+    try:
+        from core.config.routing_manifest import load_routing_manifest
+
+        manifest = load_routing_manifest()
+    except Exception:
+        return "Claude Code-credentials"
+    return manifest.credential_keychain.services.get("anthropic", "Claude Code-credentials")
+
+
+KEYCHAIN_SERVICE = _resolve_keychain_service()
 """macOS keychain entry written by ``claude /login``. Contains the
 JSON ``{"claudeAiOauth": {"accessToken": ..., "refreshToken": ...,
 "expiresAt": ..., "scopes": [...], "subscriptionType": ..., ...}}``
 blob — the same row the CLI itself reads on startup. The
 ``subscriptionType`` field carries whichever plan the user is logged
 into (e.g. ``pro``, ``max``); the picker UI surfaces that verbatim so
-this module does not need to know the enumeration ahead of time."""
+this module does not need to know the enumeration ahead of time.
+
+P2-C: now resolved at import time via :func:`_resolve_keychain_service`
+so the env override / manifest entry / legacy default cascade applies."""
 
 _token_lock = threading.Lock()
 _warned_once = False

--- a/tests/test_routing_manifest.py
+++ b/tests/test_routing_manifest.py
@@ -94,7 +94,18 @@ def test_default_manifest_credentials_keychain():
 
 def test_default_manifest_credentials_patterns():
     manifest = load_routing_manifest()
-    assert manifest.credential_patterns.patterns.get("^sk-ant-") == "anthropic"
+    # P2-C: regexes carry length quantifiers — verify by prefix match.
+    keys = list(manifest.credential_patterns.patterns)
+    anthropic_key = next(k for k in keys if k.startswith("^sk-ant-"))
+    assert manifest.credential_patterns.patterns[anthropic_key] == "anthropic"
+
+
+def test_default_manifest_credentials_env_vars():
+    """P2-C — provider → env var mapping is loaded from the manifest."""
+    manifest = load_routing_manifest()
+    assert manifest.credential_env_vars.env_vars.get("anthropic") == "ANTHROPIC_API_KEY"
+    assert manifest.credential_env_vars.env_vars.get("openai") == "OPENAI_API_KEY"
+    assert manifest.credential_env_vars.env_vars.get("glm") == "ZAI_API_KEY"
 
 
 # ── resolve_provider — legacy parity ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- `_KEY_PATTERNS` (`core/cli/onboarding.py`) → routing.toml `[credentials.patterns]` + `[credentials.env_vars]`
- `KEYCHAIN_SERVICE` (`plugins/petri_audit/claude_code_provider.py`) → env override + routing.toml `[credentials.keychain]`
- `CredentialEnvVars` pydantic 모델 신설 (provider → env var)

## Why
P2-A 의 routing.toml `[credentials.*]` 섹션이 dormant 상태로 schema만 존재. P2-C 가 첫 consumer — onboarding wizard + Petri keychain probe 가 같은 manifest 를 읽도록 통합. provider 추가 시 코드 수정 없이 TOML 편집만으로 끝.

## Changes
| File | Change |
|------|--------|
| `core/config/routing.toml` | `[credentials.patterns]` regex 갱신 (length quantifier) + `[credentials.env_vars]` 신설 |
| `core/config/routing_manifest.py` | `CredentialEnvVars` 모델 추가 + RoutingManifest.credential_env_vars 필드 |
| `core/cli/onboarding.py` | `_KEY_PATTERNS` → `_key_patterns()` lazy function (manifest 호출) |
| `plugins/petri_audit/claude_code_provider.py` | `KEYCHAIN_SERVICE` → `_resolve_keychain_service()` (env override + manifest) |
| `tests/test_routing_manifest.py` | regex 형태 변경 반영 + CredentialEnvVars 테스트 신규 |
| `CHANGELOG.md` | [Unreleased] Changed (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `_KEY_PATTERNS` migration | Implemented | 3-tuple → manifest 2 section 매핑 |
| `KEYCHAIN_SERVICE` migration | Implemented | env > manifest > legacy default cascade |
| `CredentialEnvVars` schema | Implemented | provider → env var, 별도 pydantic 모델 |
| Fallback / defensive | Implemented | manifest 미가용 시 legacy 동작 보존 |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (routing_manifest, onboarding, claude_code_provider)
- [x] pytest selective pass (test_routing_manifest 42 + test_claude_code_provider)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) 유지

## Reference
- P2-A `core/config/routing.toml` — `[credentials.*]` schema 정의 위치
- 후속: P2-D (`_resolve_provider` + `family_of` 통합 SOT) → P2-E (pipeline node defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)