### PR TITLE
refactor(config): pipeline node defaults → routing.toml [nodes] (P2-E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,24 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Changed
 
+- **Pipeline node defaults migrated to routing.toml `[nodes]` (P2-E).**
+  `core/config/__init__.py::_PIPELINE_NODE_DEFAULTS` dict (4 entry) 제거.
+  `get_node_model(node_name)` 가 project routing.toml → manifest
+  `[nodes]` 2-단계 cascade. routing_manifest 의 `RoutingManifest.nodes`
+  field 추가 (이전엔 loader 가 nodes 섹션 무시). **P2 (GEODE routing
+  externalisation) 종결** — `core/config/__init__.py` 의 hardcoded
+  routing 전부 manifest 로 위임.
+
+- **Pipeline node defaults migrated to routing.toml `[nodes]` (P2-E).**
+  Removed `_PIPELINE_NODE_DEFAULTS` (4 entries) from
+  `core/config/__init__.py`. `get_node_model` now cascades project
+  `.geode/routing.toml` → manifest `[nodes]`. Added the `nodes` field
+  to `RoutingManifest` (the loader previously dropped the section).
+  **Closes the P2 routing-externalisation initiative** — every
+  hardcoded routing table in `core/config/__init__.py` (defaults,
+  fallbacks, provider resolver, credential patterns, keychain, node
+  defaults) now lives in the manifest.
+
 - **`_resolve_provider` + `family_of` 통합 SOT (P2-D).**
   GEODE 의 두 hardcoded routing table 을 manifest 의
   `[routing.prefixes]` + `codex_only_models` + `codex_suffixes` 로

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -359,26 +359,32 @@ def load_routing_config(path: Path | None = None) -> RoutingConfig:
         return _routing_config_cache
 
 
-# Pipeline nodes ALWAYS use these models regardless of user's REPL model.
-# When routing.toml has no per-node config, these defaults prevent
-# fallback to settings.model (the user's active REPL model like glm-5).
-_PIPELINE_NODE_DEFAULTS: dict[str, str] = {
-    "analyst": ANTHROPIC_PRIMARY,
-    "evaluator": ANTHROPIC_PRIMARY,
-    "scoring": ANTHROPIC_PRIMARY,
-    "synthesizer": ANTHROPIC_PRIMARY,
-}
-
-
 def get_node_model(node_name: str) -> str | None:
     """Return the model for a pipeline node, or None for default fallback.
 
-    Priority: routing.toml > _PIPELINE_NODE_DEFAULTS > None.
-    Pipeline nodes (analyst, evaluator, scoring, synthesizer) always return
-    a fixed model so they never inherit the user's REPL model.
+    Priority (post-P2-E):
+      1. Project routing.toml (``<project>/.geode/routing.toml`` —
+         legacy per-project override, loaded by :func:`load_routing_config`).
+      2. Global routing manifest (``core/config/routing.toml`` +
+         ``~/.geode/routing.toml`` user override, loaded by
+         :func:`core.config.routing_manifest.load_routing_manifest`).
+      3. ``None`` — caller falls back to ``settings.model``.
+
+    Pipeline nodes (analyst, evaluator, scoring, synthesizer) always
+    return a fixed model so they never inherit the user's REPL model.
+    The shipped manifest pins all four to the Anthropic primary; users
+    customise per-node by editing either routing.toml.
     """
     cfg = load_routing_config()
-    return cfg.nodes.get(node_name) or _PIPELINE_NODE_DEFAULTS.get(node_name)
+    if node_name in cfg.nodes:
+        return cfg.nodes[node_name]
+    try:
+        from core.config.routing_manifest import load_routing_manifest
+
+        manifest = load_routing_manifest()
+    except Exception:
+        return None
+    return manifest.nodes.get(node_name)
 
 
 def reset_routing_cache() -> None:

--- a/core/config/routing_manifest.py
+++ b/core/config/routing_manifest.py
@@ -7,11 +7,18 @@ Loads ``core/config/routing.toml`` (shipped default) merged with
 pattern (data → cross-layer consistency → cached load → typed
 accessors).
 
-P2-A scope: schema + loader only. Subsequent PRs (P2-B..E) migrate the
-hardcoded constants in :mod:`core.config.__init__` (``ANTHROPIC_PRIMARY``
-et al., ``_resolve_provider``, ``_PIPELINE_NODE_DEFAULTS``, onboarding
-regexes) onto this loader. Until then this module is dormant — no
-existing call site is rewired by P2-A.
+Migration history:
+
+- P2-A (2026-05-17): schema + loader (dormant).
+- P2-B: ``ANTHROPIC_PRIMARY`` / ``OPENAI_PRIMARY`` etc. constants now
+  load from ``[model.defaults]`` + ``[model.fallbacks.<provider>]``.
+- P2-C: ``onboarding._KEY_PATTERNS`` + ``claude_code_provider.
+  KEYCHAIN_SERVICE`` route through ``[credentials.*]``.
+- P2-D: ``core.config._resolve_provider`` + ``petri.models.family_of``
+  delegate to ``[routing.prefixes]`` + ``codex_only_models`` +
+  ``codex_suffixes``.
+- P2-E (this PR): ``get_node_model`` reads ``[nodes]`` after the
+  project-scoped ``.geode/routing.toml`` check.
 
 Sections (mirroring TOML structure):
 
@@ -180,6 +187,10 @@ class RoutingManifest(BaseModel):
     credential_patterns: CredentialPatterns
     credential_keychain: CredentialKeychain
     credential_env_vars: CredentialEnvVars = Field(default_factory=CredentialEnvVars)
+    # P2-E (2026-05-17) — pipeline node → model overrides. Consumed by
+    # ``core.config.get_node_model`` after the project-scoped
+    # ``.geode/routing.toml`` check, before falling back to None.
+    nodes: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _consistency(self) -> RoutingManifest:
@@ -236,7 +247,7 @@ def _parse_manifest(data: dict[str, Any]) -> RoutingManifest:
     """
     model_section = data.get("model", {})
     routing_section = data.get("routing", {})
-    nodes_section = data.get("nodes", {})  # noqa: F841 — P2-E consumes
+    nodes_section = data.get("nodes", {})
     credentials_section = data.get("credentials", {})
 
     defaults = ModelDefaults(**model_section.get("defaults", {}))
@@ -264,6 +275,7 @@ def _parse_manifest(data: dict[str, Any]) -> RoutingManifest:
         credential_patterns=patterns,
         credential_keychain=keychain,
         credential_env_vars=env_vars,
+        nodes=dict(nodes_section) if isinstance(nodes_section, dict) else {},
     )
 
 

--- a/tests/test_routing_config.py
+++ b/tests/test_routing_config.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 from core.config import (
-    _PIPELINE_NODE_DEFAULTS,
     ANTHROPIC_PRIMARY,
     RoutingConfig,
     get_node_model,
@@ -121,19 +120,25 @@ class TestGetNodeModel:
         assert get_node_model("evaluator") == ANTHROPIC_PRIMARY
 
     def test_pipeline_node_defaults_cover_all_nodes(self) -> None:
-        """Verify _PIPELINE_NODE_DEFAULTS covers analyst/evaluator/scoring/synthesizer."""
+        """P2-E: manifest [nodes] covers analyst/evaluator/scoring/synthesizer."""
+        from core.config.routing_manifest import load_routing_manifest
+
         expected_nodes = {"analyst", "evaluator", "scoring", "synthesizer"}
-        assert set(_PIPELINE_NODE_DEFAULTS.keys()) == expected_nodes
-        # All defaults must be ANTHROPIC_PRIMARY
-        for node, model in _PIPELINE_NODE_DEFAULTS.items():
-            assert model == ANTHROPIC_PRIMARY, f"{node} default should be {ANTHROPIC_PRIMARY}"
+        manifest_nodes = load_routing_manifest().nodes
+        assert expected_nodes <= set(manifest_nodes), (
+            f"manifest [nodes] missing: {expected_nodes - set(manifest_nodes)}"
+        )
+        for node in expected_nodes:
+            assert manifest_nodes[node] == ANTHROPIC_PRIMARY, (
+                f"{node} default should be {ANTHROPIC_PRIMARY}"
+            )
 
     def test_routing_toml_overrides_pipeline_defaults(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """routing.toml takes priority over _PIPELINE_NODE_DEFAULTS."""
+        """Project routing.toml takes priority over manifest [nodes]."""
         import core.config as cfg
 
         toml_file = tmp_path / "routing.toml"


### PR DESCRIPTION
## Summary
- `_PIPELINE_NODE_DEFAULTS` dict (4 entries) 제거
- `get_node_model` 이 project `.geode/routing.toml` → manifest `[nodes]` 2-단계 cascade
- `RoutingManifest.nodes` field 추가 (loader 흡수)
- **P2 (GEODE routing externalisation) 종결**

## Why
P2-A~D 누적으로 model defaults / fallbacks / provider resolver / credential patterns / keychain 이 모두 manifest 로 위임됨. P2-E 가 마지막 hardcoded routing — pipeline node defaults — 를 manifest 로 옮겨 종결. 이제 `core/config/__init__.py` 안에 hardcoded routing 매핑이 없음. 사용자는 `routing.toml` 편집으로 모든 routing 토글 가능.

## Changes
| File | Change |
|------|--------|
| `core/config/__init__.py` | `_PIPELINE_NODE_DEFAULTS` 제거, `get_node_model` 2-단계 cascade |
| `core/config/routing_manifest.py` | `RoutingManifest.nodes` field 추가, loader 갱신, 문서 정리 |
| `tests/test_routing_config.py` | `_PIPELINE_NODE_DEFAULTS` import 제거, manifest.nodes 검증으로 교체 |
| `CHANGELOG.md` | [Unreleased] Changed (KR/EN) + P2 종결 표기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `_PIPELINE_NODE_DEFAULTS` 제거 | Implemented | 외부 import 검증 — tests 만 사용했음 |
| `get_node_model` cascade | Implemented | project routing.toml > manifest [nodes] > None |
| `RoutingManifest.nodes` 노출 | Implemented | loader 가 [nodes] 섹션 흡수 |
| `test_pipeline_node_defaults_cover_all_nodes` | Migrated | manifest.nodes 검증으로 의미 보존 |
| P2 마이그레이션 history 문서 | Implemented | routing_manifest 모듈 docstring |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (core/config/)
- [x] pytest selective pass (test_routing_config + test_routing_manifest 50개)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) 유지

## Reference
P2 누적 PR:
- #1252 P2-A schema + loader (dormant)
- #1253 P2-B model defaults + fallback chains
- #1254 P2-C credential patterns + keychain
- #1255 P2-D _resolve_provider + family_of
- **(this) P2-E pipeline node defaults**

후속: P3 (model_pricing.toml 외부화) — pricing + context window quasi-static data 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)