### PR TITLE
feat(llm): model pricing + context window TOML + loader (P3-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,29 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Added
+
+- **Model pricing + context windows TOML (P3-A) — schema + loader.**
+  `core/llm/model_pricing.toml` 신설 (17 model pricing × 20 context
+  window entries) + `core/llm/pricing_loader.py` (lru_cache 기반).
+  Schema: `[pricing.<family>.<model>]` per-token base price (anthropic
+  derives cache_write/read/thinking; openai needs explicit cached +
+  reasoning flag) + `[context_windows]` model → int. `PricingCatalogue`
+  dataclass + `ModelPrice` NamedTuple (token_tracker's와 동일 shape) +
+  parity tests vs legacy `MODEL_PRICING` / `MODEL_CONTEXT_WINDOW` 모두
+  통과. **Dormant** — P3-B 가 token_tracker 의 dict 를 loader 호출로
+  교체.
+
+- **Model pricing + context windows TOML (P3-A) — schema + loader.**
+  New `core/llm/model_pricing.toml` (17 pricing + 20 context window
+  entries) and `core/llm/pricing_loader.py`. Schema uses
+  `[pricing.<family>.<model>]` with the base per-mtok pair; the loader
+  applies the family-specific derive formulas (anthropic's
+  cache_write/read/thinking multipliers; openai's explicit cached +
+  reasoning flag). Parity tests verify the loader's output matches the
+  legacy `MODEL_PRICING` / `MODEL_CONTEXT_WINDOW` dicts. **Dormant** —
+  P3-B will swap `token_tracker.py` over to the loader.
+
 ### Changed
 
 - **Pipeline node defaults migrated to routing.toml `[nodes]` (P2-E).**

--- a/core/llm/model_pricing.toml
+++ b/core/llm/model_pricing.toml
@@ -1,0 +1,149 @@
+# GEODE model pricing + context window catalogue.
+#
+# Source of truth for per-token cost and context limits. P3-A (2026-05-17)
+# introduces this file + ``pricing_loader.py``; P3-B migrates
+# ``core.llm.token_tracker.MODEL_PRICING`` / ``MODEL_CONTEXT_WINDOW`` to
+# read from here. Until then this file is dormant.
+#
+# Quasi-static — refresh per quarter on pricing or model-list changes.
+# Schema layers:
+#   [pricing.<family>.<model>]  per-token pricing (per-million-token units)
+#   [context_windows]            model → int (tokens)
+#
+# Derive formulas applied by the loader (family-specific):
+#   anthropic: cache_write = input × 1.25, cache_read = input × 0.1,
+#              thinking = output
+#   openai:    cache_read = cached_per_mtok (explicit),
+#              thinking = output if reasoning, else 0
+
+# ── Anthropic (verified 2026-04-23) ───────────────────────────────────────
+# Source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+
+[pricing.anthropic."claude-opus-4-7"]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+
+[pricing.anthropic."claude-opus-4-6"]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+
+[pricing.anthropic."claude-opus-4-5"]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+
+[pricing.anthropic."claude-opus-4-1"]
+input_per_mtok = 15.00
+output_per_mtok = 75.00
+
+[pricing.anthropic."claude-opus-4"]
+input_per_mtok = 15.00
+output_per_mtok = 75.00
+
+[pricing.anthropic."claude-sonnet-4-6"]
+input_per_mtok = 3.00
+output_per_mtok = 15.00
+
+[pricing.anthropic."claude-sonnet-4-5-20250929"]
+input_per_mtok = 3.00
+output_per_mtok = 15.00
+
+[pricing.anthropic."claude-sonnet-4"]
+input_per_mtok = 3.00
+output_per_mtok = 15.00
+
+[pricing.anthropic."claude-haiku-4-5-20251001"]
+input_per_mtok = 1.00
+output_per_mtok = 5.00
+
+# ── OpenAI GPT-5 family (verified 2026-04-26) ─────────────────────────────
+# Source: developers.openai.com/api/docs/pricing/ + /codex/pricing.
+
+[pricing.openai."gpt-5.5"]
+input_per_mtok = 5.00
+output_per_mtok = 30.00
+cached_per_mtok = 0.50
+
+[pricing.openai."gpt-5.4"]
+input_per_mtok = 2.50
+output_per_mtok = 15.00
+cached_per_mtok = 0.25
+
+[pricing.openai."gpt-5.4-mini"]
+input_per_mtok = 0.75
+output_per_mtok = 4.50
+cached_per_mtok = 0.075
+
+[pricing.openai."gpt-5.3-codex"]
+input_per_mtok = 1.75
+output_per_mtok = 14.00
+cached_per_mtok = 0.175
+
+# ── OpenAI Reasoning (verified 2026-03-19) ────────────────────────────────
+
+[pricing.openai."o3"]
+input_per_mtok = 2.00
+output_per_mtok = 8.00
+reasoning = true
+
+[pricing.openai."o4-mini"]
+input_per_mtok = 1.10
+output_per_mtok = 4.40
+cached_per_mtok = 0.275
+reasoning = true
+
+# ── ZhipuAI GLM (verified 2026-04-26 against docs.z.ai/guides/overview/pricing)
+# v0.52.4 — refreshed pricing; pre-fix glm-5.1 / glm-5 were stale.
+# glm-4.7 retained because Coding Plan defaults still route Opus/Sonnet
+# env aliases to it (see docs.z.ai/devpack/overview).
+#
+# GLM uses the openai derive formula (cache_read = explicit cached, no
+# reasoning multiplier) by manifest convention.
+
+[pricing.openai."glm-5.1"]
+input_per_mtok = 1.40
+output_per_mtok = 4.40
+
+[pricing.openai."glm-5"]
+input_per_mtok = 1.00
+output_per_mtok = 3.20
+
+[pricing.openai."glm-5-turbo"]
+input_per_mtok = 1.20
+output_per_mtok = 4.00
+
+[pricing.openai."glm-4.7"]
+input_per_mtok = 0.60
+output_per_mtok = 2.20
+
+[pricing.openai."glm-4.7-flash"]
+input_per_mtok = 0.00
+output_per_mtok = 0.00  # free tier (limited-time)
+
+# ── Context windows (verified 2026-04-26 / GLM 2026-05-12 GAP-X1) ─────────
+# Anthropic: 1M tokens for opus-4-6/7 + sonnet-4-6; 200K for legacy.
+# OpenAI 5.x: 1.05M tokens for gpt-5.5/5.4/5.4-mini; 200K for 5.3-codex
+# + reasoning (o3/o4-mini). GLM: all share 202_752 (z.ai rounds to 200K
+# in marketing; precise value matters for the 200K guard's early-trip
+# margin).
+
+[context_windows]
+"claude-opus-4-7"            = 1000000
+"claude-opus-4-6"            = 1000000
+"claude-opus-4-5"            = 200000
+"claude-opus-4-1"            = 200000
+"claude-opus-4"              = 200000
+"claude-sonnet-4-6"          = 1000000
+"claude-sonnet-4-5-20250929" = 200000
+"claude-sonnet-4"            = 200000
+"claude-haiku-4-5-20251001"  = 200000
+"gpt-5.5"                    = 1050000
+"gpt-5.4"                    = 1050000
+"gpt-5.4-mini"               = 1050000
+"gpt-5.3-codex"              = 200000
+"o3"                         = 200000
+"o4-mini"                    = 200000
+"glm-5.1"                    = 202752
+"glm-5"                      = 202752
+"glm-5-turbo"                = 202752
+"glm-4.7"                    = 202752
+"glm-4.7-flash"              = 202752

--- a/core/llm/pricing_loader.py
+++ b/core/llm/pricing_loader.py
@@ -1,0 +1,174 @@
+"""Loader for ``core/llm/model_pricing.toml`` — pricing + context windows.
+
+P3-A (2026-05-17) introduces this loader. P3-B migrates
+:mod:`core.llm.token_tracker`'s ``MODEL_PRICING`` and
+``MODEL_CONTEXT_WINDOW`` dicts to consume it. Until then the loader is
+dormant — no production call site reads from this module.
+
+Schema (matches the TOML, family-prefixed):
+
+- ``[pricing.anthropic.<model>]`` — ``input_per_mtok`` + ``output_per_mtok``.
+  Loader applies the Anthropic derive: ``cache_write = input × 1.25``,
+  ``cache_read = input × 0.1``, ``thinking = output``.
+- ``[pricing.openai.<model>]`` — same two keys plus optional
+  ``cached_per_mtok`` and ``reasoning`` (bool). Loader applies:
+  ``cache_read = cached_per_mtok`` (explicit), ``thinking = output if
+  reasoning else 0.0``. GLM models live under ``[pricing.openai.*]``
+  by manifest convention (OpenAI-compatible API, openai derive formula).
+- ``[context_windows]`` — model id → int (tokens).
+
+Output: a single :class:`PricingCatalogue` dataclass with both maps
+already in the ``ModelPrice`` form that ``token_tracker`` consumes.
+
+Refresh cadence: quarterly per the upstream pricing pages. Tests verify
+the loader's parity with the legacy hardcoded dicts so a stale file is
+caught immediately during P3-B's migration.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, NamedTuple
+
+__all__ = [
+    "DEFAULT_PRICING_PATH",
+    "ModelPrice",
+    "PricingCatalogue",
+    "clear_pricing_cache",
+    "load_pricing_catalogue",
+]
+
+DEFAULT_PRICING_PATH = Path(__file__).parent / "model_pricing.toml"
+
+
+class ModelPrice(NamedTuple):
+    """Per-token pricing for a single model.
+
+    Mirrors :class:`core.llm.token_tracker.ModelPrice` so P3-B can
+    drop-in replace the legacy ``MODEL_PRICING`` dict without
+    changing any consumer.
+    """
+
+    input: float
+    output: float
+    cache_write: float = 0.0
+    cache_read: float = 0.0
+    thinking: float = 0.0
+
+
+def _derive_anthropic(input_mtok: float, output_mtok: float) -> ModelPrice:
+    """Anthropic derive: cache_write = input × 1.25, cache_read = input × 0.1,
+    thinking = output (Extended Thinking billed as output)."""
+    inp = input_mtok / 1_000_000
+    out = output_mtok / 1_000_000
+    return ModelPrice(
+        input=inp,
+        output=out,
+        cache_write=inp * 1.25,
+        cache_read=inp * 0.1,
+        thinking=out,
+    )
+
+
+def _derive_openai(
+    input_mtok: float,
+    output_mtok: float,
+    cached_mtok: float = 0.0,
+    reasoning: bool = False,
+) -> ModelPrice:
+    """OpenAI derive: explicit cache_read price, thinking = output for
+    reasoning models (o3 / o4-mini billed at output rate for reasoning
+    tokens)."""
+    out = output_mtok / 1_000_000
+    return ModelPrice(
+        input=input_mtok / 1_000_000,
+        output=out,
+        cache_read=cached_mtok / 1_000_000 if cached_mtok else 0.0,
+        thinking=out if reasoning else 0.0,
+    )
+
+
+@dataclass(frozen=True)
+class PricingCatalogue:
+    """Parsed view of ``model_pricing.toml`` — pricing + context windows."""
+
+    pricing: dict[str, ModelPrice]
+    context_windows: dict[str, int]
+
+
+def _parse_family(family: str, entries: dict[str, Any]) -> dict[str, ModelPrice]:
+    """Build a {model: ModelPrice} dict for a single family section."""
+    out: dict[str, ModelPrice] = {}
+    for model, fields in entries.items():
+        if not isinstance(fields, dict):
+            continue
+        try:
+            input_mtok = float(fields["input_per_mtok"])
+            output_mtok = float(fields["output_per_mtok"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"[pricing.{family}.{model!r}]: missing or non-numeric "
+                f"input_per_mtok / output_per_mtok"
+            ) from exc
+        if family == "anthropic":
+            out[model] = _derive_anthropic(input_mtok, output_mtok)
+        elif family == "openai":
+            out[model] = _derive_openai(
+                input_mtok,
+                output_mtok,
+                cached_mtok=float(fields.get("cached_per_mtok", 0.0)),
+                reasoning=bool(fields.get("reasoning", False)),
+            )
+        else:
+            raise ValueError(
+                f"[pricing.{family}.{model!r}]: unknown family — supported "
+                f"families are 'anthropic' and 'openai' (GLM models route "
+                f"through 'openai' by manifest convention)"
+            )
+    return out
+
+
+@lru_cache(maxsize=4)
+def _load_cached(path_str: str) -> PricingCatalogue:
+    path = Path(path_str)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    pricing_section = data.get("pricing", {})
+    if not isinstance(pricing_section, dict):
+        raise ValueError(f"{path}: [pricing] is not a table")
+
+    pricing: dict[str, ModelPrice] = {}
+    for family, entries in pricing_section.items():
+        if not isinstance(entries, dict):
+            continue
+        pricing.update(_parse_family(family, entries))
+
+    context_raw = data.get("context_windows", {})
+    if not isinstance(context_raw, dict):
+        raise ValueError(f"{path}: [context_windows] is not a table")
+    context_windows: dict[str, int] = {}
+    for model, value in context_raw.items():
+        try:
+            context_windows[model] = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"[context_windows] {model!r}: not an integer ({value!r})") from exc
+
+    return PricingCatalogue(pricing=pricing, context_windows=context_windows)
+
+
+def load_pricing_catalogue(path: Path | str | None = None) -> PricingCatalogue:
+    """Load and validate the model pricing catalogue.
+
+    Defaults to :data:`DEFAULT_PRICING_PATH`. Result cached per absolute
+    path so repeat calls share the parsed catalogue. Tests that fixture
+    custom TOML files call :func:`clear_pricing_cache` first.
+    """
+    target = Path(path) if path is not None else DEFAULT_PRICING_PATH
+    return _load_cached(str(target.resolve()))
+
+
+def clear_pricing_cache() -> None:
+    """Drop the lru_cache — used by tests."""
+    _load_cached.cache_clear()

--- a/tests/test_pricing_loader.py
+++ b/tests/test_pricing_loader.py
@@ -41,8 +41,9 @@ def test_load_default_catalogue():
 
 def test_parity_with_legacy_pricing():
     """Loader output must match the legacy ``MODEL_PRICING`` dict P3-B replaces."""
-    from core.llm.token_tracker import MODEL_PRICING as legacy
+    from core.llm.token_tracker import MODEL_PRICING
 
+    legacy = MODEL_PRICING
     cat = load_pricing_catalogue()
     assert set(cat.pricing) == set(legacy), (
         f"Model id sets differ — loader extras: "
@@ -62,8 +63,9 @@ def test_parity_with_legacy_pricing():
 
 
 def test_parity_with_legacy_context_windows():
-    from core.llm.token_tracker import MODEL_CONTEXT_WINDOW as legacy
+    from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
+    legacy = MODEL_CONTEXT_WINDOW
     cat = load_pricing_catalogue()
     assert set(cat.context_windows) == set(legacy), (
         f"Context window id sets differ — loader extras: "

--- a/tests/test_pricing_loader.py
+++ b/tests/test_pricing_loader.py
@@ -1,0 +1,243 @@
+"""Unit tests for core.llm.pricing_loader (P3-A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.llm.pricing_loader import (
+    DEFAULT_PRICING_PATH,
+    ModelPrice,
+    PricingCatalogue,
+    clear_pricing_cache,
+    load_pricing_catalogue,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_pricing_cache()
+    yield
+    clear_pricing_cache()
+
+
+# ── Default file presence + shape ──────────────────────────────────────────
+
+
+def test_default_file_exists():
+    assert DEFAULT_PRICING_PATH.exists()
+    assert DEFAULT_PRICING_PATH.suffix == ".toml"
+
+
+def test_load_default_catalogue():
+    cat = load_pricing_catalogue()
+    assert isinstance(cat, PricingCatalogue)
+    assert isinstance(cat.pricing, dict)
+    assert isinstance(cat.context_windows, dict)
+
+
+# ── Parity with legacy MODEL_PRICING ───────────────────────────────────────
+
+
+def test_parity_with_legacy_pricing():
+    """Loader output must match the legacy ``MODEL_PRICING`` dict P3-B replaces."""
+    from core.llm.token_tracker import MODEL_PRICING as legacy
+
+    cat = load_pricing_catalogue()
+    assert set(cat.pricing) == set(legacy), (
+        f"Model id sets differ — loader extras: "
+        f"{set(cat.pricing) - set(legacy)}, missing: "
+        f"{set(legacy) - set(cat.pricing)}"
+    )
+    for model, legacy_price in legacy.items():
+        loaded = cat.pricing[model]
+        assert loaded.input == pytest.approx(legacy_price.input), f"{model}.input"
+        assert loaded.output == pytest.approx(legacy_price.output), f"{model}.output"
+        assert loaded.cache_write == pytest.approx(legacy_price.cache_write), f"{model}.cache_write"
+        assert loaded.cache_read == pytest.approx(legacy_price.cache_read), f"{model}.cache_read"
+        assert loaded.thinking == pytest.approx(legacy_price.thinking), f"{model}.thinking"
+
+
+# ── Parity with legacy MODEL_CONTEXT_WINDOW ────────────────────────────────
+
+
+def test_parity_with_legacy_context_windows():
+    from core.llm.token_tracker import MODEL_CONTEXT_WINDOW as legacy
+
+    cat = load_pricing_catalogue()
+    assert set(cat.context_windows) == set(legacy), (
+        f"Context window id sets differ — loader extras: "
+        f"{set(cat.context_windows) - set(legacy)}, missing: "
+        f"{set(legacy) - set(cat.context_windows)}"
+    )
+    for model, legacy_ctx in legacy.items():
+        assert cat.context_windows[model] == legacy_ctx, f"{model} context window"
+
+
+# ── Anthropic derive formula ───────────────────────────────────────────────
+
+
+def test_anthropic_derive_formula(tmp_path: Path):
+    """Anthropic family: cache_write = input × 1.25, cache_read = input × 0.1,
+    thinking = output."""
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.anthropic."m"]
+input_per_mtok = 4.0
+output_per_mtok = 20.0
+
+[context_windows]
+"m" = 100
+""",
+        encoding="utf-8",
+    )
+    cat = load_pricing_catalogue(toml)
+    p = cat.pricing["m"]
+    assert p.input == pytest.approx(4.0 / 1_000_000)
+    assert p.output == pytest.approx(20.0 / 1_000_000)
+    assert p.cache_write == pytest.approx(4.0 / 1_000_000 * 1.25)
+    assert p.cache_read == pytest.approx(4.0 / 1_000_000 * 0.1)
+    assert p.thinking == pytest.approx(20.0 / 1_000_000)
+
+
+# ── OpenAI derive formula ──────────────────────────────────────────────────
+
+
+def test_openai_derive_with_cached(tmp_path: Path):
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.openai."m"]
+input_per_mtok = 5.0
+output_per_mtok = 30.0
+cached_per_mtok = 0.5
+
+[context_windows]
+"m" = 100
+""",
+        encoding="utf-8",
+    )
+    cat = load_pricing_catalogue(toml)
+    p = cat.pricing["m"]
+    assert p.cache_read == pytest.approx(0.5 / 1_000_000)
+    assert p.thinking == 0.0  # not reasoning
+
+
+def test_openai_derive_reasoning(tmp_path: Path):
+    """reasoning = true → thinking = output."""
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.openai."m"]
+input_per_mtok = 2.0
+output_per_mtok = 8.0
+reasoning = true
+
+[context_windows]
+"m" = 100
+""",
+        encoding="utf-8",
+    )
+    cat = load_pricing_catalogue(toml)
+    p = cat.pricing["m"]
+    assert p.thinking == pytest.approx(8.0 / 1_000_000)
+    assert p.cache_read == 0.0
+
+
+def test_openai_derive_no_cached(tmp_path: Path):
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.openai."m"]
+input_per_mtok = 1.4
+output_per_mtok = 4.4
+
+[context_windows]
+"m" = 100
+""",
+        encoding="utf-8",
+    )
+    cat = load_pricing_catalogue(toml)
+    p = cat.pricing["m"]
+    assert p.cache_read == 0.0
+    assert p.thinking == 0.0
+
+
+# ── Negative validation ────────────────────────────────────────────────────
+
+
+def test_unknown_family_raises(tmp_path: Path):
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.mystery."m"]
+input_per_mtok = 1.0
+output_per_mtok = 2.0
+
+[context_windows]
+"m" = 100
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unknown family"):
+        load_pricing_catalogue(toml)
+
+
+def test_missing_required_field_raises(tmp_path: Path):
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.anthropic."m"]
+output_per_mtok = 20.0
+
+[context_windows]
+"m" = 100
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing or non-numeric"):
+        load_pricing_catalogue(toml)
+
+
+def test_non_int_context_window_raises(tmp_path: Path):
+    toml = tmp_path / "p.toml"
+    toml.write_text(
+        """
+[pricing.anthropic."m"]
+input_per_mtok = 1.0
+output_per_mtok = 2.0
+
+[context_windows]
+"m" = "not-an-int"
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="not an integer"):
+        load_pricing_catalogue(toml)
+
+
+# ── Cache behaviour ────────────────────────────────────────────────────────
+
+
+def test_load_caches_by_path(tmp_path: Path):
+    a = load_pricing_catalogue()
+    b = load_pricing_catalogue()
+    assert a is b
+
+
+def test_clear_cache_forces_reload():
+    a = load_pricing_catalogue()
+    clear_pricing_cache()
+    b = load_pricing_catalogue()
+    assert a is not b
+
+
+# ── ModelPrice dataclass ───────────────────────────────────────────────────
+
+
+def test_model_price_defaults():
+    p = ModelPrice(input=1.0, output=2.0)
+    assert p.cache_write == 0.0
+    assert p.cache_read == 0.0
+    assert p.thinking == 0.0


### PR DESCRIPTION
## Summary
- `core/llm/model_pricing.toml` 신설 — 17 pricing entries + 20 context window entries
- `core/llm/pricing_loader.py` 신설 — pydantic 없이 dataclass + NamedTuple + lru_cache
- Parity tests — 새 loader 가 legacy `MODEL_PRICING` / `MODEL_CONTEXT_WINDOW` 와 100% 일치
- **Dormant** — P3-B 가 token_tracker 의 dict 를 loader 호출로 교체

## Why
`core/llm/token_tracker.py` 의 hardcoded pricing/context dict 가 분기별 갱신 필요한 quasi-static data. TOML 외부화로 코드 PR 없이 pricing 업데이트 가능. Petri/GEODE 의 manifest 패턴 (P1-A/P2-A) 정합.

## Changes
| File | Change |
|------|--------|
| `core/llm/model_pricing.toml` | 신설 — 5 family × 17 model pricing + 20 context window |
| `core/llm/pricing_loader.py` | 신설 — PricingCatalogue + ModelPrice + load_pricing_catalogue + lru_cache |
| `tests/test_pricing_loader.py` | 신설 — 14 cases (parity + derive + negative + cache) |
| `CHANGELOG.md` | [Unreleased] Added (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Pricing TOML schema | Implemented | family-prefixed, base + derive formula |
| Context window section | Implemented | 단순 dict[model, int] |
| pricing_loader 구현 | Implemented | lru_cache + family derive |
| Parity vs legacy | Implemented | test_parity_with_legacy_pricing/context_windows 통과 |
| Token_tracker rewire | Deferred — P3-B | dormant 유지 |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean (core/llm/pricing_loader.py)
- [x] pytest pass (14/14)

## Reference
- P1-A / P2-A 의 manifest 패턴 정합 (TOML + lru_cache loader)
- 후속: P3-B (token_tracker 의 MODEL_PRICING / MODEL_CONTEXT_WINDOW dict 제거, loader 호출로 교체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)