### PR TITLE
refactor(llm): token_tracker dicts → pricing_loader (P3-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,27 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Changed
+
+- **`token_tracker.MODEL_PRICING` + `MODEL_CONTEXT_WINDOW` 가 manifest 로 lazy load (P3-B).**
+  `core/llm/token_tracker.py` 의 두 dict literal (17 model pricing + 20
+  context window) + `_ant`/`_oai` helper 제거. P3-A 의
+  `core/llm/pricing_loader.py` 가 `core/llm/model_pricing.toml` 로부터
+  생성한 `PricingCatalogue` 를 import 시점에 binding. `ModelPrice`
+  dataclass 정의를 pricing_loader 로 통합 — token_tracker 는 re-export
+  만 (모든 caller — runner, tests, monkeypatch 사이트 — 영향 0). **P3
+  (model pricing externalisation) 종결**.
+
+- **`token_tracker` pricing dicts now lazy-load from the manifest (P3-B).**
+  Removed the two inlined dict literals (`MODEL_PRICING`,
+  `MODEL_CONTEXT_WINDOW`) and the `_ant` / `_oai` derive helpers from
+  `core/llm/token_tracker.py`. They're now bound at import time from
+  the `PricingCatalogue` produced by P3-A's
+  `core/llm/pricing_loader.py` reading `model_pricing.toml`. The
+  `ModelPrice` dataclass moved to `pricing_loader`; `token_tracker`
+  re-exports it so every existing consumer keeps working unchanged.
+  **Closes the P3 pricing-externalisation initiative**.
+
 ### Added
 
 - **Model pricing + context windows TOML (P3-A) — schema + loader.**

--- a/core/llm/pricing_loader.py
+++ b/core/llm/pricing_loader.py
@@ -31,7 +31,7 @@ import tomllib
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any
 
 __all__ = [
     "DEFAULT_PRICING_PATH",
@@ -44,12 +44,14 @@ __all__ = [
 DEFAULT_PRICING_PATH = Path(__file__).parent / "model_pricing.toml"
 
 
-class ModelPrice(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class ModelPrice:
     """Per-token pricing for a single model.
 
-    Mirrors :class:`core.llm.token_tracker.ModelPrice` so P3-B can
-    drop-in replace the legacy ``MODEL_PRICING`` dict without
-    changing any consumer.
+    P3-B (2026-05-17): canonical definition lives here.
+    ``core.llm.token_tracker`` re-exports the class so every existing
+    consumer (`token_tracker.ModelPrice`, `plugins.petri_audit.runner`,
+    tests that monkeypatch the pricing dict) keeps working unchanged.
     """
 
     input: float

--- a/core/llm/token_tracker.py
+++ b/core/llm/token_tracker.py
@@ -125,140 +125,26 @@ class LLMUsageAccumulator:
 # ───────────────────────────────────────────────────────────────────────────
 
 
-@dataclass(frozen=True, slots=True)
-class ModelPrice:
-    """Per-token pricing for a single model.
+# P3-B (2026-05-17) — ``ModelPrice`` + pricing dict + context windows
+# now live in ``core/llm/model_pricing.toml`` + ``core.llm.pricing_loader``.
+# The legacy ``_ant`` / ``_oai`` helpers and inlined dict literals were
+# replaced by a single ``load_pricing_catalogue()`` call at import time.
+# Public surface unchanged — every consumer (``token_tracker.ModelPrice``,
+# ``MODEL_PRICING``, ``MODEL_CONTEXT_WINDOW``, monkeypatched test sites)
+# keeps working without modification because we re-export from here.
+from core.llm.pricing_loader import (  # noqa: E402
+    ModelPrice,
+    load_pricing_catalogue,
+)
 
-    Anthropic: cache_write = input × 1.25, cache_read = input × 0.1
-               thinking = output price (Extended Thinking billed as output)
-    OpenAI:    cache_read = provider-specific fixed price (no write cost)
-               thinking = output price (reasoning tokens billed as output)
-    """
-
-    input: float
-    output: float
-    cache_write: float = 0.0
-    cache_read: float = 0.0
-    thinking: float = 0.0
-
-
-def _ant(input_mtok: float, output_mtok: float) -> ModelPrice:
-    """Anthropic pricing with standard 5-min cache multipliers (1.25× / 0.1×).
-
-    Extended Thinking tokens are billed at the same rate as output tokens.
-    """
-    inp = input_mtok / 1_000_000
-    out = output_mtok / 1_000_000
-    return ModelPrice(
-        input=inp,
-        output=out,
-        cache_write=inp * 1.25,
-        cache_read=inp * 0.1,
-        thinking=out,
-    )
-
-
-def _oai(
-    input_mtok: float,
-    output_mtok: float,
-    cached_mtok: float = 0.0,
-    reasoning: bool = False,
-) -> ModelPrice:
-    """OpenAI pricing with optional cached-input price.
-
-    Reasoning models (o3, o4-mini): reasoning tokens billed as output tokens.
-    """
-    out = output_mtok / 1_000_000
-    return ModelPrice(
-        input=input_mtok / 1_000_000,
-        output=out,
-        cache_read=cached_mtok / 1_000_000 if cached_mtok else 0.0,
-        thinking=out if reasoning else 0.0,
-    )
-
-
-# fmt: off
-MODEL_PRICING: dict[str, ModelPrice] = {
-    # ── Anthropic (verified 2026-04-23) ────────────────────────────────
-    # Source: https://platform.claude.com/docs/en/docs/about-claude/pricing
-    "claude-opus-4-7":            _ant(5.00,  25.00),
-    "claude-opus-4-6":            _ant(5.00,  25.00),
-    "claude-opus-4-5":            _ant(5.00,  25.00),
-    "claude-opus-4-1":            _ant(15.00, 75.00),
-    "claude-opus-4":              _ant(15.00, 75.00),
-    "claude-sonnet-4-6":          _ant(3.00,  15.00),
-    "claude-sonnet-4-5-20250929": _ant(3.00,  15.00),
-    "claude-sonnet-4":            _ant(3.00,  15.00),
-    "claude-haiku-4-5-20251001":  _ant(1.00,   5.00),
-
-    # ── OpenAI GPT-5 family (verified 2026-04-26) ─────────────────────
-    # Source: developers.openai.com/api/docs/pricing/ + /codex/pricing
-    # v0.52.4 — gpt-5.5 added (Codex new default, OAuth-only per docs).
-    # Pre-5.3 IDs (gpt-5.1, gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.2 family
-    # except 5.2 itself) dropped per CLAUDE.md model-currency policy.
-    "gpt-5.5":      _oai(5.00, 30.00, cached_mtok=0.50),
-    "gpt-5.4":      _oai(2.50, 15.00, cached_mtok=0.25),
-    "gpt-5.4-mini": _oai(0.75,  4.50, cached_mtok=0.075),
-    "gpt-5.3-codex": _oai(1.75, 14.00, cached_mtok=0.175),
-
-    # ── OpenAI Reasoning (verified 2026-03-19) ─────────────────────────
-    "o3":       _oai(2.00,  8.00, reasoning=True),
-    "o4-mini":  _oai(1.10,  4.40, cached_mtok=0.275, reasoning=True),
-
-    # ── ZhipuAI GLM (verified 2026-04-26 against docs.z.ai/guides/overview/pricing)
-    # v0.52.4 — refreshed pricing; pre-fix glm-5.1/glm-5 were stale.
-    # glm-4.7 retained because Coding Plan defaults still route Opus/Sonnet
-    # env aliases to it (see docs.z.ai/devpack/overview).
-    "glm-5.1":         _oai(1.40,  4.40),
-    "glm-5":           _oai(1.00,  3.20),
-    "glm-5-turbo":     _oai(1.20,  4.00),
-    "glm-4.7":         _oai(0.60,  2.20),
-    "glm-4.7-flash":   _oai(0.00,  0.00),  # free tier (limited-time)
-}
-# fmt: on
+_catalogue = load_pricing_catalogue()
+MODEL_PRICING: dict[str, ModelPrice] = dict(_catalogue.pricing)
+MODEL_CONTEXT_WINDOW: dict[str, int] = dict(_catalogue.context_windows)
 
 
 # ───────────────────────────────────────────────────────────────────────────
 # TokenTracker — single record() replaces 3 scattered calls
 # ───────────────────────────────────────────────────────────────────────────
-
-
-# fmt: off
-MODEL_CONTEXT_WINDOW: dict[str, int] = {
-    # Anthropic — verified 2026-04-26.
-    # v0.53.2 — claude-opus-4 / claude-opus-4-1 added to match
-    # MODEL_PRICING entries (D3: pre-fix lookup fell through to 200K
-    # default silently if the user picked one of these legacy models).
-    "claude-opus-4-7":            1_000_000,
-    "claude-opus-4-6":            1_000_000,
-    "claude-opus-4-5":              200_000,
-    "claude-opus-4-1":              200_000,
-    "claude-opus-4":                200_000,
-    "claude-sonnet-4-6":          1_000_000,
-    "claude-sonnet-4-5-20250929":   200_000,
-    "claude-sonnet-4":              200_000,
-    "claude-haiku-4-5-20251001":    200_000,
-    # OpenAI 5.3-5.5 generation — verified 2026-04-26
-    "gpt-5.5":                    1_050_000,
-    "gpt-5.4":                    1_050_000,
-    "gpt-5.4-mini":               1_050_000,
-    "gpt-5.3-codex":                200_000,
-    # OpenAI reasoning (kept — separate generation)
-    "o3":                           200_000,
-    "o4-mini":                      200_000,
-    # GLM — re-verified 2026-05-12 against z.ai docs + openrouter (GAP-X1).
-    # All five models share 202_752 tokens of context (z.ai marketing rounds
-    # to "200K"; the precise value matters for the 200K guard's early-trip
-    # margin).  Cloudflare / LM Studio mirrors expose smaller windows
-    # (131_072 / 128k) for their hosted variants — GEODE calls z.ai directly
-    # so the upstream limit applies.
-    "glm-5.1":                      202_752,
-    "glm-5":                        202_752,
-    "glm-5-turbo":                  202_752,
-    "glm-4.7":                      202_752,
-    "glm-4.7-flash":                202_752,
-}
-# fmt: on
 
 
 class UsageSnapshot(NamedTuple):


### PR DESCRIPTION
## Summary
- `MODEL_PRICING` (17 entry) + `MODEL_CONTEXT_WINDOW` (20 entry) + `_ant` / `_oai` helper 모두 제거
- 두 dict 가 P3-A 의 `load_pricing_catalogue()` 결과로 import 시점에 binding
- `ModelPrice` 정의를 `pricing_loader.py` 로 통합, `token_tracker` 는 re-export 만
- **P3 (model pricing externalisation) 종결**

## Why
P3-A 의 `core/llm/model_pricing.toml` + loader 가 dormant. P3-B 가 token_tracker 의 hardcoded dict 를 loader 호출로 교체 — pricing/context 데이터가 코드 PR 없이 TOML 편집으로 갱신 가능. 분기별 pricing refresh 워크플로우 단축. 14 PR 총 sprint 의 마지막.

## Changes
| File | Change |
|------|--------|
| `core/llm/token_tracker.py` | 두 dict literal + _ant/_oai helper 제거, load_pricing_catalogue() 호출로 binding |
| `core/llm/pricing_loader.py` | ModelPrice 를 frozen dataclass(slots=True) 로 변경 (token_tracker SOT 통합) |
| `CHANGELOG.md` | [Unreleased] Changed (KR/EN) + P3 종결 표기 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| MODEL_PRICING dict 제거 | Implemented | pricing_loader 의 catalogue.pricing 으로 대체 |
| MODEL_CONTEXT_WINDOW dict 제거 | Implemented | catalogue.context_windows 로 대체 |
| _ant / _oai helper 제거 | Implemented | pricing_loader._derive_anthropic/_openai 가 흡수 |
| ModelPrice SOT 통합 | Implemented | pricing_loader 정의, token_tracker re-export |
| Public surface 보존 | Implemented | 모든 caller (runner, tests, monkeypatch) 영향 0 |

## Verification
- [x] ruff check clean (E402 noqa — 의도된 module-level lazy import)
- [x] ruff format clean
- [x] mypy clean
- [x] pytest selective pass (test_pricing_loader + test_llm_resilience 50개)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) 유지

## P3 누적 PR
- #1257 P3-A model_pricing.toml + pricing_loader (dormant)
- **(this) P3-B token_tracker rewire**

## 전체 sprint 누적 (14 PR)
| Sprint | PR | Title |
|---|---|---|
| **Petri P1** | #1245 | manifest schema + loader |
| | #1246 | role contracts + frontmatter parser |
| | #1247 | adapter registry + 5 facades |
| | #1248 | credential_source module |
| | #1249 | registry binding |
| | #1250 | /petri command + 2-axis picker |
| | #1251 | to_inspect_model collapse |
| **GEODE P2** | #1252 | routing.toml schema + loader |
| | #1253 | model defaults + fallback chains |
| | #1254 | credential patterns + keychain |
| | #1255 | _resolve_provider + family_of |
| | #1256 | pipeline node defaults |
| **Pricing P3** | #1257 | model_pricing.toml + loader |
| | **(this)** | token_tracker rewire |

🤖 Generated with [Claude Code](https://claude.com/claude-code)