### PR TITLE
release: v0.100.0 — Routing externalisation sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+## [0.100.0] — 2026-05-17
+
+**Routing externalisation sprint** — 14 PR cycle (Petri P1 + GEODE P2 +
+Pricing P3). 모든 hardcoded routing 매핑 (model defaults, fallbacks,
+provider resolver, credential patterns, keychain, pipeline node
+defaults, pricing, context windows) 을 TOML manifest 위임. 사용자가
+`~/.geode/{petri,routing}.toml` + `core/llm/model_pricing.toml` 편집
+만으로 model / provider / credential / pricing 토글 가능.
+
 ### Changed
 
 - **`token_tracker.MODEL_PRICING` + `MODEL_CONTEXT_WINDOW` 가 manifest 로 lazy load (P3-B).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.10
+- **Version**: 0.100.0
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.10 — Long-running Autonomous Execution Harness
+# GEODE v0.100.0 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -315,7 +315,7 @@ uv tool install -e . --force
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.10**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.100.0**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode"
-version = "0.99.10"
+version = "0.100.0"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- [Unreleased] 14 entries → [0.100.0] — 2026-05-17 stamp
- 4-location version sync (CHANGELOG / pyproject / CLAUDE.md / README)
- Petri P1 (7 PR) + GEODE P2 (5 PR) + Pricing P3 (2 PR) — backward-compat architectural 변화

## Why
14 PR sprint 의 routing externalisation 작업을 v0.100.0 으로 release. semver 상 새 manifest 시스템은 MINOR bump 정합 — 공개 surface 보존되므로 MAJOR 까지는 아님. Petri/GEODE/pricing 3 area 의 hardcoded routing 전부 외부화 → 사용자가 TOML 편집만으로 routing 토글 가능.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | [Unreleased] → [0.100.0] stamp + release header |
| `pyproject.toml` | version 0.99.10 → 0.100.0 |
| `CLAUDE.md` | Version 라인 갱신 |
| `README.md` | v0.99.10 → v0.100.0 (2 곳) |

## Verification
- [x] ruff format clean (659 files)
- [x] pytest selective pass (test_routing_manifest + test_pricing_loader + tests/plugins/petri_audit/)
- [x] E2E `geode analyze "Cowboy Bebop" --dry-run` → A (68.4) 유지

## Sprint roll-up
| Sprint | PRs | Theme |
|---|---|---|
| Petri P1 | #1245–#1251 | manifest + role MD + adapter registry + credential_source + registry + picker + routing collapse |
| GEODE P2 | #1252–#1256 | routing.toml schema + defaults + credentials + provider resolver + node defaults |
| Pricing P3 | #1257–#1258 | model_pricing.toml + loader + token_tracker rewire |

🤖 Generated with [Claude Code](https://claude.com/claude-code)