### PR TITLE
Fix GitHub release publishing job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,7 @@ jobs:
           gh release create "v${version}" \
             release-artifacts/dist/* \
             release-artifacts/SHA256SUMS \
+            --repo "${{ github.repository }}" \
             --target "${{ needs.validate-build.outputs.sha }}" \
             --title "GEODE v${version}" \
             --notes-file release-artifacts/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **GitHub Release publish job fix.** The release workflow now passes
+  `--repo` to `gh release create`, so the publish job can create releases from
+  downloaded artifacts without requiring a checked-out `.git` directory.
+
+- **GitHub Release publish job 수정.** release workflow 가 `gh release create`
+  호출에 `--repo` 를 명시해, publish job 이 `.git` checkout 없이 내려받은
+  artifact 만으로 GitHub Release 를 생성할 수 있게 했습니다.
+
 ## [0.99.12] — 2026-05-17
 
 ### Added


### PR DESCRIPTION
## Summary

- Pass `--repo` to `gh release create` so the release publish job works without a checked-out `.git` directory.
- Record the release workflow fix under `[Unreleased]`.

## Validation

- `git diff --check`
- Release validation run `25995506867` already passed through artifact generation; only GitHub release creation failed on missing `.git` before this fix.

## Release Order

HF remains deferred. PyPI remains disabled because the `geode` package name is already owned by another PyPI account.