### PR TITLE
Prepare geode-agent PyPI distribution

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -8,7 +8,8 @@ name: Install Smoke Test
 #   3. UPDATE    — `geode update --dry-run` resolves the source-checkout path
 #                  and `uv tool install -e . --force` remains idempotent
 #   4. UNINSTALL — `geode uninstall --force` removes runtime files and the
-#                  installed uv tool without leaving a PATH-visible shim
+#                  installed `geode-agent` uv tool without leaving a
+#                  PATH-visible `geode` shim
 #
 # A failure here means the README setup steps no longer work on a clean
 # machine — block the merge and fix the install path before shipping.
@@ -70,8 +71,8 @@ jobs:
             echo "::error::geode binary still on PATH after uninstall: $(command -v geode)"
             exit 1
           fi
-          if uv tool list | grep -q '^geode\b'; then
-            echo "::error::uv tool list still contains geode after uninstall"
+          if uv tool list | grep -q '^geode-agent\b'; then
+            echo "::error::uv tool list still contains geode-agent after uninstall"
             uv tool list
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,11 +123,45 @@ jobs:
       - name: Package content gate — skills, prompts, tool schemas, audit assets
         run: |
           version="${{ inputs.version }}"
-          wheel="dist/geode-${version}-py3-none-any.whl"
-          sdist="dist/geode-${version}.tar.gz"
+          dist_stem=$(uv run python - <<'PY'
+          import re
+          import tomllib
+
+          name = tomllib.load(open("pyproject.toml", "rb"))["project"]["name"]
+          print(re.sub(r"[-_.]+", "_", name).lower())
+          PY
+          )
+          wheel="dist/${dist_stem}-${version}-py3-none-any.whl"
+          sdist="dist/${dist_stem}-${version}.tar.gz"
 
           uv run python -m zipfile -l "$wheel" > /tmp/geode-wheel-files.txt
           tar -tzf "$sdist" > /tmp/geode-sdist-files.txt
+          uv run python - "$wheel" "$sdist" <<'PY'
+          import stat
+          import sys
+          import tarfile
+          import zipfile
+
+          wheel, sdist = sys.argv[1:]
+          wheel_symlinks = []
+          with zipfile.ZipFile(wheel) as zf:
+              for info in zf.infolist():
+                  mode = (info.external_attr >> 16) & 0xFFFF
+                  if stat.S_IFMT(mode) == stat.S_IFLNK:
+                      wheel_symlinks.append(info.filename)
+
+          sdist_symlinks = []
+          with tarfile.open(sdist, "r:gz") as tf:
+              for member in tf.getmembers():
+                  if member.issym() or member.islnk():
+                      sdist_symlinks.append(member.name)
+
+          if wheel_symlinks or sdist_symlinks:
+              raise SystemExit(
+                  "release artifacts must not contain symlinks: "
+                  f"wheel={wheel_symlinks}, sdist={sdist_symlinks}"
+              )
+          PY
 
           grep -q "core/skills/skills.py" /tmp/geode-wheel-files.txt
           grep -q "core/skills/reports/templates/report.html" /tmp/geode-wheel-files.txt
@@ -137,18 +171,26 @@ jobs:
           grep -q "plugins/petri_audit/judge_dims/geode_5axes.yaml" /tmp/geode-wheel-files.txt
           grep -q "plugins/petri_audit/seeds/research_fabrication_under_pressure.md" /tmp/geode-wheel-files.txt
 
-          grep -q "geode-${version}/core/skills/skills.py" /tmp/geode-sdist-files.txt
-          grep -q "geode-${version}/core/skills/reports/templates/report.html" /tmp/geode-sdist-files.txt
-          grep -q "geode-${version}/core/tools/definitions.json" /tmp/geode-sdist-files.txt
+          grep -q "${dist_stem}-${version}/core/skills/skills.py" /tmp/geode-sdist-files.txt
+          grep -q "${dist_stem}-${version}/core/skills/reports/templates/report.html" /tmp/geode-sdist-files.txt
+          grep -q "${dist_stem}-${version}/core/tools/definitions.json" /tmp/geode-sdist-files.txt
           ! grep -q "plugins/game_ip" /tmp/geode-wheel-files.txt
           ! grep -q "plugins/game_ip" /tmp/geode-sdist-files.txt
 
       - name: Clean wheel install smoke
         run: |
           version="${{ inputs.version }}"
+          dist_stem=$(uv run python - <<'PY'
+          import re
+          import tomllib
+
+          name = tomllib.load(open("pyproject.toml", "rb"))["project"]["name"]
+          print(re.sub(r"[-_.]+", "_", name).lower())
+          PY
+          )
           uv run python -m venv .release-venv
           .release-venv/bin/python -m pip install --upgrade pip
-          .release-venv/bin/python -m pip install "dist/geode-${version}-py3-none-any.whl"
+          .release-venv/bin/python -m pip install "dist/${dist_stem}-${version}-py3-none-any.whl"
           .release-venv/bin/geode version | grep "GEODE v${version}"
 
       - name: Generate release notes and checksums
@@ -278,6 +320,7 @@ jobs:
           test -n "$HF_TOKEN"
           python -m pip install --upgrade "huggingface_hub>=1.0"
           python - <<'PY'
+          import json
           import os
           from pathlib import Path
 
@@ -311,23 +354,22 @@ jobs:
               commit_message=f"Upload GEODE v{version} release bundle ({source_sha[:12]})",
           )
 
+          local_manifest_path = bundle / f"releases/v{version}/manifest.json"
+          manifest = json.loads(local_manifest_path.read_text(encoding="utf-8"))
           required = {
               "README.md",
               "latest.json",
               f"releases/v{version}/manifest.json",
               f"releases/v{version}/SHA256SUMS",
               f"releases/v{version}/release-notes.md",
-              f"releases/v{version}/dist/geode-{version}.tar.gz",
-              f"releases/v{version}/dist/geode-{version}-py3-none-any.whl",
           }
+          required.update(str(artifact["path"]) for artifact in manifest["artifacts"])
           remote_files = set(api.list_repo_files(repo_id=repo_id, repo_type="dataset"))
           missing = sorted(required - remote_files)
           if missing:
               raise SystemExit(f"HF upload verification failed; missing: {missing}")
 
-          local_manifest = (bundle / f"releases/v{version}/manifest.json").read_text(
-              encoding="utf-8"
-          )
+          local_manifest = local_manifest_path.read_text(encoding="utf-8")
           remote_manifest_path = hf_hub_download(
               repo_id=repo_id,
               repo_type="dataset",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ renders as a single column with a `KR`-only or `EN`-only chip.
 
 ### Infrastructure
 
+- **PyPI distribution rename.** GEODE now publishes under the available PyPI
+  distribution name `geode-agent` while preserving the installed console
+  command `geode`. Release gates now derive wheel/sdist filenames from
+  `pyproject.toml` and reject symlink entries inside release artifacts.
+
+- **PyPI distribution 이름 변경.** GEODE 는 PyPI 에서 사용 가능한
+  distribution name `geode-agent` 로 배포하고, 설치 후 console command 는
+  계속 `geode` 로 유지합니다. release gate 는 이제 `pyproject.toml` 에서
+  wheel/sdist 파일명을 계산하고 release artifact 내부 symlink 를 거부합니다.
+
 - **GitHub Release publish job fix.** The release workflow now passes
   `--repo` to `gh release create`, so the publish job can create releases from
   downloaded artifacts without requiring a checked-out `.git` directory.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -21,7 +21,7 @@ def _resolve_version() -> str:
     from importlib.metadata import version as _pkg_version
 
     try:
-        return _pkg_version("geode")
+        return _pkg_version("geode-agent")
     except PackageNotFoundError:
         # Fallback: read from pyproject.toml directly (dev / non-installed env)
         from pathlib import Path as _Path

--- a/core/cli/cmd_lifecycle.py
+++ b/core/cli/cmd_lifecycle.py
@@ -936,7 +936,7 @@ def do_uninstall(
     if geode_bin:
         try:
             subprocess.run(
-                ["uv", "tool", "uninstall", "geode"],  # noqa: S607
+                ["uv", "tool", "uninstall", "geode-agent"],  # noqa: S607
                 capture_output=True,
                 text=True,
                 timeout=30,

--- a/core/cli/tool_handlers/system.py
+++ b/core/cli/tool_handlers/system.py
@@ -33,8 +33,7 @@ def _build_system_handlers(
         return {"status": "ok", "action": "help", "commands": commands}
 
     def handle_check_status(**_kwargs: Any) -> dict[str, Any]:
-        from importlib.metadata import version as _pkg_version
-
+        from core import __version__ as geode_version
         from core.config import settings
         from core.domains.port import get_domain_or_none
 
@@ -47,7 +46,6 @@ def _build_system_handlers(
             except Exception:
                 log.debug("Domain list_fixtures() failed", exc_info=True)
 
-        geode_version = _pkg_version("geode")
         ant_ok = bool(settings.anthropic_api_key)
         oai_ok = bool(settings.openai_api_key)
         mode = "full_llm" if (readiness and not readiness.force_dry_run) else "dry_run"

--- a/docs/plans/2026-05-17-release-packaging.md
+++ b/docs/plans/2026-05-17-release-packaging.md
@@ -21,7 +21,7 @@ actual user surfaces:
 |---|---|---|
 | Homebrew Python for Formula Authors | Python applications should be installed into a `libexec` virtualenv, with Python dependencies declared as formula resources and installed into that virtualenv. `brew update-python-resources` is the intended helper for resource stanzas. | Build `packaging/homebrew/geode.rb` around `Language::Python::Virtualenv`, a semver release sdist, and explicit resource stanzas. |
 | Homebrew Formula Cookbook | A formula is a Ruby package definition created from an upstream tarball, installed with `brew install`, debugged with `brew install --debug --verbose`, and verified with formula tests/audit. | Treat `brew audit --new --strict geode` and `brew test geode` as release gates before publishing a tap. |
-| `../hermes-agent/packaging/homebrew` | Stable Homebrew source should target the semver-named sdist release asset, not a repository auto-tarball. The wrapper exports managed-install environment variables and verifies that self-update routes users back to Homebrew. | Publish `geode-0.99.12.tar.gz` as a GitHub release asset and make the formula point there. Add `GEODE_MANAGED=homebrew` once update/install commands exist. |
+| `../hermes-agent/packaging/homebrew` | Stable Homebrew source should target the semver-named sdist release asset, not a repository auto-tarball. The wrapper exports managed-install environment variables and verifies that self-update routes users back to Homebrew. | Publish the `geode_agent-<version>.tar.gz` sdist as a GitHub release asset and make the formula point there. Add `GEODE_MANAGED=homebrew` once update/install commands exist. |
 | `huggingface/ml-intern` | CLI install is `uv sync` + `uv tool install -e .`; runtime relies on `HF_TOKEN`; sandbox tools can use HF Spaces; sessions are uploaded to a private HF dataset in Claude-Code-style JSONL for trace viewing. Its Space deploy notes keep PR review separate from pushes to the HF Space remote. | Keep local CLI install first-class. For this release, publish release artifacts to a versioned HF dataset repo only after the manual release workflow is approved; consider trace export and a Space demo after packaging is stable. |
 | `../openclaw/extensions/huggingface` | Hugging Face is modeled as a provider with `HF_TOKEN` / `HUGGINGFACE_HUB_TOKEN`, provider-specific config, and OpenAI-compatible router defaults. | If GEODE adds a Hugging Face provider, use provider-scoped auth/config instead of mixing it with packaging. Packaging remains separate from model routing. |
 | OpenClaw release validation | Release validation is split into install smoke, cross-OS package checks, package acceptance, live/E2E, and focused rerun handles. | Add GEODE release gates in phases: local build/install smoke first, then Homebrew formula test, then live/E2E and optional HF artifact upload. |
@@ -125,9 +125,12 @@ and fuller KR/EN page-pair coverage beyond README/changelog.
 Primary install target:
 
 ```bash
-uv tool install geode
+uv tool install geode-agent
 geode --version
 ```
+
+The PyPI distribution name is `geode-agent`; the installed console command
+remains `geode`.
 
 Release gates:
 
@@ -143,8 +146,8 @@ Release gates:
 
 Release assets:
 
-- `geode-0.99.12.tar.gz`
-- `geode-0.99.12-py3-none-any.whl`
+- `geode_agent-0.99.12.tar.gz`
+- `geode_agent-0.99.12-py3-none-any.whl`
 - `SHA256SUMS`
 - release notes sourced from `CHANGELOG.md` `## [0.99.12]`
 
@@ -158,7 +161,7 @@ Initial formula shape:
 
 - `class Geode < Formula`
 - `include Language::Python::Virtualenv`
-- `url` points to `geode-0.99.12.tar.gz`
+- `url` points to `geode_agent-0.99.12.tar.gz`
 - `depends_on "python@3.y"` using the current Homebrew Python accepted by the
   dependency graph
 - install via `virtualenv_install_with_resources` unless GEODE needs custom
@@ -180,7 +183,7 @@ the tap itself:
 ```bash
 uv run python scripts/render_homebrew_formula.py \
   --version 0.99.12 \
-  --sdist-url https://github.com/mangowhoiscloud/geode/releases/download/v0.99.12/geode-0.99.12.tar.gz \
+  --sdist-url https://github.com/mangowhoiscloud/geode/releases/download/v0.99.12/geode_agent-0.99.12.tar.gz \
   --sdist-sha256 <sha256-from-SHA256SUMS> \
   --output packaging/homebrew/geode.rb
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "geode"
+name = "geode-agent"
 version = "0.99.12"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"

--- a/scripts/prepare_hf_release_bundle.py
+++ b/scripts/prepare_hf_release_bundle.py
@@ -78,8 +78,9 @@ metadata. It does not contain model weights.
 - `releases/v{version}/manifest.json` - machine-readable artifact manifest.
 - `latest.json` - pointer to the latest uploaded GEODE release.
 
-Install GEODE from PyPI or the GitHub release. Use this Hub repo as a mirrored
-artifact index for agent workflows and reproducibility checks.
+Install GEODE from PyPI as `geode-agent` or from the GitHub release. Use this
+Hub repo as a mirrored artifact index for agent workflows and reproducibility
+checks.
 
 Repository: `{repo_id}`
 """

--- a/tests/test_lifecycle_commands.py
+++ b/tests/test_lifecycle_commands.py
@@ -383,6 +383,28 @@ class TestUninstall:
         ):
             do_uninstall(force=True)
 
+    def test_uninstalls_geode_agent_distribution(self, tmp_path: Path) -> None:
+        geode_bin = tmp_path / "bin" / "geode"
+        geode_bin.parent.mkdir()
+        geode_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        with (
+            patch("core.cli.cmd_lifecycle.PROJECT_GEODE_DIR", tmp_path / "nope"),
+            patch("core.cli.cmd_lifecycle.GEODE_HOME", tmp_path / "nope2"),
+            patch("core.cli.cmd_lifecycle.stop_serve"),
+            patch("core.cli.cmd_lifecycle.subprocess.run") as mock_run,
+            patch("shutil.which", return_value=str(geode_bin)),
+            patch("pathlib.Path.cwd", return_value=tmp_path),
+        ):
+            do_uninstall(force=True)
+
+        mock_run.assert_any_call(
+            ["uv", "tool", "uninstall", "geode-agent"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
 
 # ---------------------------------------------------------------------------
 # FindServePid

--- a/tests/test_prepare_hf_release_bundle.py
+++ b/tests/test_prepare_hf_release_bundle.py
@@ -11,8 +11,8 @@ from scripts.prepare_hf_release_bundle import is_distribution_artifact, prepare_
 
 
 def test_distribution_artifact_filter(tmp_path: Path) -> None:
-    wheel = tmp_path / "geode-0.99.11-py3-none-any.whl"
-    sdist = tmp_path / "geode-0.99.11.tar.gz"
+    wheel = tmp_path / "geode_agent-0.99.11-py3-none-any.whl"
+    sdist = tmp_path / "geode_agent-0.99.11.tar.gz"
     dotfile = tmp_path / ".gitignore"
     wheel.write_bytes(b"wheel")
     sdist.write_bytes(b"sdist")
@@ -26,8 +26,8 @@ def test_distribution_artifact_filter(tmp_path: Path) -> None:
 def test_prepare_bundle_creates_versioned_dataset_layout(tmp_path: Path) -> None:
     dist = tmp_path / "dist"
     dist.mkdir()
-    wheel = dist / "geode-0.99.11-py3-none-any.whl"
-    sdist = dist / "geode-0.99.11.tar.gz"
+    wheel = dist / "geode_agent-0.99.11-py3-none-any.whl"
+    sdist = dist / "geode_agent-0.99.11.tar.gz"
     wheel.write_bytes(b"wheel")
     sdist.write_bytes(b"sdist")
     (dist / ".gitignore").write_text("*\n", encoding="utf-8")
@@ -82,8 +82,8 @@ def test_prepare_bundle_creates_versioned_dataset_layout(tmp_path: Path) -> None
 def test_prepare_bundle_rejects_mismatched_checksums(tmp_path: Path) -> None:
     dist = tmp_path / "dist"
     dist.mkdir()
-    wheel = dist / "geode-0.99.11-py3-none-any.whl"
-    sdist = dist / "geode-0.99.11.tar.gz"
+    wheel = dist / "geode_agent-0.99.11-py3-none-any.whl"
+    sdist = dist / "geode_agent-0.99.11.tar.gz"
     wheel.write_bytes(b"wheel")
     sdist.write_bytes(b"sdist")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1189,7 +1189,7 @@ wheels = [
 ]
 
 [[package]]
-name = "geode"
+name = "geode-agent"
 version = "0.99.12"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

- Rename the PyPI distribution from `geode` to the available `geode-agent` name while preserving the installed `geode` console command.
- Update version resolution to read `geode-agent` package metadata after wheel install.
- Make release workflow artifact checks derive the wheel/sdist stem from `pyproject.toml` and reject symlink entries inside wheel/sdist artifacts.
- Keep HF publish deferred and make HF upload verification use manifest artifact paths instead of hard-coded filenames.

## Symlink Check

- Tracked symlinks: none (`git ls-files -s | rg '^120000'` returned no entries).
- Active tree symlinks excluding `.git`, `.venv`, `site/node_modules`, and `.claude/worktrees`: none.
- Built `geode_agent-0.99.12` wheel/sdist: no symlink entries in either artifact.

## Validation

- `uv lock`
- `uv build --out-dir /private/tmp/geode-agent-dist-check2`
- `uv run twine check /private/tmp/geode-agent-dist-check2/*`
- `uv run ruff check .`
- `uv run mypy core plugins scripts tests/test_prepare_hf_release_bundle.py`
- `uv run pytest tests/test_cli_version.py tests/test_prepare_hf_release_bundle.py -q`
- `uv run python scripts/check_repo_hygiene.py`
- Python 3.12 clean venv wheel install from `geode_agent-0.99.12-py3-none-any.whl`
- smoke venv: `geode --version` and `geode version` -> `GEODE v0.99.12`
- HF bundle dry-run with `geode_agent-*` artifacts
- `git diff --check`

## Release Order

After merge, run the manual release workflow with `publish_pypi=true`, `publish_github_release=false`, and `publish_huggingface_artifacts=false`. HF remains last.