### PR TITLE
chore: develop → main sync (backlog docs + pages CI guard)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -161,6 +161,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs/audits/2026-05-18-backlog-dispositions.md
+++ b/docs/audits/2026-05-18-backlog-dispositions.md
@@ -1,0 +1,130 @@
+# Backlog Disposition — 2026-05-18
+
+세 backlog 항목 (#51, #53, #55) 의 검토 결과 + 재검토 trigger 명시. 모두 현 시점 추가 작업 보류로 결론.
+
+## #55 — site/ components game_ip 잔존 정리
+
+### Finding
+
+```bash
+grep -rln "game_ip\|game-ip\|GameIP" site/src/ | grep -v "data/geode/changelog.ts"
+# → site/src/app/portfolio/versions/v{1..5}/components-snapshot/sections/*.tsx
+# → site/src/app/portfolio/versions/v{1,4,5}/CHANGELOG.md
+```
+
+### 분석
+
+- 모든 hit 가 `site/src/app/portfolio/versions/v{1..5}/components-snapshot/` 폴더 (의도적 historical snapshot).
+- `grep -rln "components-snapshot" site/src/` → 0건. 어떤 page 도 이 폴더를 import 하지 않음.
+- 각 version 의 `CHANGELOG.md` 헤더가 "Portfolio v1 — Snapshot 2026-03-28" 처럼 dated snapshot 임을 명시.
+- 실제 라이브 page 는 `versions/vN/page.tsx` 에서 `@/components/geode/sections/*` (현재 컴포넌트) 를 import — snapshot 폴더와 완전 분리.
+
+### Disposition
+
+**No action**. 의도된 archival material. live render 에 영향 없음. `site/src/data/geode/changelog.ts` 의 historical CHANGELOG bodies 보존 결정 (v0.99.13 audit) 과 같은 원칙.
+
+### 재검토 trigger
+
+- 사용자가 portfolio versions 전체를 purge 결정 (예: legal/IP 리스크 발견).
+- snapshot 폴더가 어떤 page 에서 import 되기 시작 (즉시 live render 영향).
+
+---
+
+## #51 — credential_source DI 리팩토 (P1-D follow-up)
+
+### Finding
+
+- `plugins/petri_audit/credential_source.py` (216 lines, P1-D 신설).
+- API: `list_credential_sources`, `resolve_credential_source`, `suppress_credential_source`, `is_suppressed`, `clear_suppressions`.
+- Module-level state: `_suppressed: set[tuple[str,str]]` + `_lock: threading.Lock` + `_LEGACY_OAUTH_ALIAS: dict`.
+- Direct deps: `plugins.petri_audit.adapters` (`is_adapter_available`, `get_adapter_metadata`), `plugins.petri_audit.manifest` (`load_manifest`, `AUTO_SOURCE`), `core.config.settings` (lazy import).
+- Consumers: `models.py:170`, `registry.py:28+140`, `cli.py:27+309+394`, `tests/plugins/petri_audit/test_credential_source.py`.
+
+### 분석
+
+P1-D follow-up 의도는 module-level state + 직접 import 를 클래스화 (`CredentialSource(adapters, manifest, settings)`) 해 mock 주입 가능하게 만드는 것. 하지만:
+
+| 측면 | 현재 상태 | DI 도입 효과 | 비용 |
+|------|----------|-------------|------|
+| 테스트 | `clear_suppressions()` 픽스처 + `core.config.settings` monkeypatch 로 이미 충분 | mock 주입 더 깔끔 | 기존 5개 consumer 의 호출 사이트 모두 갱신 |
+| Thread safety | 모듈 단일 `_lock` + idempotent `add` | 인스턴스마다 별도 lock (오히려 분산) | 신규 lock 관리 비용 |
+| 다중 인스턴스 필요성 | 없음 (Petri 가 단일 프로세스, 단일 manifest) | 가능해짐 (테스트 외 사용처 없음) | 추상화 부담 |
+| Hermes parity | `agent/credential_sources.py` 도 module-level state | parity 깨짐 | reference frontier 와 발산 |
+
+### Disposition
+
+**Deferred**. 현 모듈은 단순 함수형 API + thread-safe 글로벌 상태로 5개 consumer 만족. 클래스화는 호출 사이트 갱신 비용 vs 테스트성 향상 트레이드오프에서 후자가 작음. tests 는 이미 `clear_suppressions()` + settings monkeypatch 로 충분.
+
+### 재검토 trigger
+
+- 다중 Petri 인스턴스 (예: 동일 프로세스 안에서 여러 audit run 병렬 + 서로 다른 manifest) 요구사항 발생.
+- `core.config.settings` 가 mock 하기 어려운 형태로 변경 (예: lazy class proxy).
+- Hermes `credential_sources.py` 가 클래스 기반으로 리팩토링 → frontier parity 유지 필요.
+
+---
+
+## #53 — Coverage ratchet 75% 복원
+
+### Finding
+
+`pyproject.toml [tool.coverage.run].omit` 의 현재 entries:
+
+```toml
+omit = [
+    "core/ui/*",                          # CLI smoke-tested
+    "core/cli/__init__.py",
+    "core/cli/welcome.py",
+    "core/cli/search_render.py",
+    "core/cli/dispatcher.py",
+    "core/cli/prompt_session.py",
+    "core/cli/interactive_loop.py",
+    "core/cli/typer_commands.py",
+    "core/cli/typer_init.py",
+    "core/cli/typer_serve.py",
+    "core/cli/commands.py",
+    "core/mcp_server.py",
+    "core/tools/web_tools.py",
+    "core/tools/document_tools.py",
+    "core/tools/web_search.py",           # External-API + GUI tools, live-tested
+    "core/tools/computer_use.py",
+    "core/audit/dim_extractor.py",        # Inspect/Petri edge importers
+    "core/audit/eval_to_jsonl.py",
+    "core/audit/manifest.py",
+]
+fail_under = 75
+```
+
+### 분석
+
+각 omit entry 는 명시적 카테고리:
+
+1. **CLI/REPL smoke-tested** (`core/ui/*`, `core/cli/*`) — Typer 명령 + 인터랙티브 prompt_toolkit code. unit test 가 아니라 `geode version` smoke + integration test 에서 exercise. 정당.
+2. **External-API + GUI** (`core/tools/web_search.py`, `core/tools/computer_use.py`, `core/tools/web_tools.py`, `core/tools/document_tools.py`) — Playwright / search API / GUI control. `-m live` test 에서 exercise. unit cover 부적합 (mock 비용 > 가치).
+3. **Inspect/Petri 가져오기** (`core/audit/{dim_extractor,eval_to_jsonl,manifest}.py`) — Petri eval log → unified format 변환기. fixture 가 없으면 의미 있는 unit test 불가. integration test (`tests/integration/`) 에서 cover.
+
+"복원" 의 의미를 두 가지로 해석 가능:
+
+A. **omit 제거 + unit test 작성** — 위 3 카테고리 모두 mock-heavy 비실용적. 외부 의존성 (Anthropic API, Playwright, Petri eval format) mock 비용이 test 가치보다 큼.
+B. **fail_under 를 실제 coverage 로 맞춤** — 현재 75% 가 omit 적용 후 측정값. omit 제거하면 73-74% 로 떨어짐. fail_under 만 낮추는 것은 ratchet 약화 (사용자 76a13ad6 에서 명시적으로 reject).
+
+### Disposition
+
+**Deferred**. 현재 75% 가 omit 적용 후 정직한 측정값 + 각 omit 의 카테고리별 정당화 명시. 진정한 "복원" 은 (a) integration/live test 가 unit test 와 동등하게 카운트되는 coverage 도구 도입, 또는 (b) omit 된 모듈 각각에 mock-heavy unit test 신규 작성 (PR 단위 5-10건 분량). 둘 다 별도 sprint 분량 작업.
+
+### 재검토 trigger
+
+- Coverage 도구 변경 (e.g. `coverage.py` → branch+integration 통합 카운팅).
+- omit 된 모듈에 새 기능 추가되어 unit test 부담 정당화됨.
+- 사용자가 명시적으로 "single-PR coverage sprint" 지시.
+
+---
+
+## Summary
+
+| Task | Disposition | Trigger Count |
+|------|-------------|---------------|
+| #55 site/ game_ip | No action (intentional archive) | 2 |
+| #51 credential_source DI | Deferred (5-consumer cost > test benefit) | 3 |
+| #53 Coverage 75% 복원 | Deferred (real "restore" = multi-PR sprint) | 3 |
+
+세 항목 모두 명시적 trigger 가 발생할 때까지 재오픈 보류.

--- a/docs/audits/2026-05-18-i2-paperclip-review.md
+++ b/docs/audits/2026-05-18-i2-paperclip-review.md
@@ -1,0 +1,95 @@
+# I2 — Paperclip 패턴 `claude -p` subprocess adapter 검토
+
+- **Date**: 2026-05-18
+- **Status**: Deferred (PAYG path 충분, 재검토 trigger 명시)
+- **Decision**: 현 시점 production chat 에 `claude -p` subprocess adapter 도입 보류.
+
+## Background
+
+v0.99.9 까지 6회 시도된 owned-PKCE flow (`9d1c250a-…` first-party 전용 OAuth client 와 2026-04-04 Anthropic third-party block 충돌) 가 모두 실패한 후 v0.99.10 에서 `/login anthropic` 을 Anthropic Console PAYG API key path 단일화. 동시에 시도된 `claude /login` subprocess delegate 는 사용자가 spawn 된 Claude Code REPL 안에 갇히는 UX 문제로 폐기. Claude subscription path 는 Petri audit 전용 (`plugins/petri_audit/claude_code_provider.py`, in-process keychain read) 로만 잔존.
+
+I2 의 검토 대상은 **subprocess login** 이 아닌 **subprocess invocation** — paperclip / crumb 가 채택한 `claude -p "<prompt>" --output-format stream-json` non-interactive 호출 패턴을 GEODE 의 production chat / agent loop 에 도입할지 여부.
+
+## Current state (v0.99.13)
+
+| 경로 | 인증 | 위치 | 상태 |
+|------|------|------|------|
+| Production chat / agent | `sk-ant-api…` PAYG | `core/llm/providers/anthropic.py` (stock SDK) | OK |
+| Petri audit/judge | Claude subscription OAuth (keychain in-process) | `plugins/petri_audit/claude_code_provider.py` | OK (macOS only) |
+| `/login anthropic` | API key 입력만 | `core/cli/commands/login.py:_login_anthropic_api_key` | OK (v0.99.10) |
+
+## Paperclip / Crumb 패턴 분석
+
+참조 — `~/workspace/crumb/src/adapters/claude-local.ts` (163 라인):
+
+```ts
+const args = [
+  '-p', resolvePromptWithVideoRefs(req),
+  '--append-system-prompt', sandwich,
+  '--add-dir', req.sessionDir,
+  '--dangerously-skip-permissions',
+  '--output-format', 'stream-json',
+  '--verbose',
+];
+spawn('claude', args, { cwd: req.sessionDir, env, stdio: ['ignore', 'pipe', 'pipe'] });
+```
+
+핵심 특성:
+1. **Non-interactive single-turn** — `-p` 플래그로 REPL 진입 차단. login subprocess 의 UX 함정 회피.
+2. **System prompt overlay** — `--append-system-prompt @<file>` 로 호출자가 role spec injection.
+3. **Sandbox 경계** — `--add-dir <session_dir>` 로 working dir 제한.
+4. **Stream telemetry** — `--output-format stream-json` 으로 tokens_in/out + cache + cost 회수.
+5. **인증 우회 없음** — claude CLI 가 자체적으로 keychain 에서 OAuth 토큰을 읽음 (호출자는 credential 을 다루지 않음).
+
+paperclip (`github.com/paperclipai/paperclip`) 도 동일한 ACP-style delegation 패턴이라고 GEODE 의 N1 (v0.99.10) 폐기 노트에 기록 (`core/auth/oauth_login.py:524`).
+
+## 적용 시 트레이드오프
+
+### Pro
+
+- **Subscription cost-zero**. Claude Max/Pro 가입자가 PAYG 비용 없이 production chat 수행 가능. Petri 의 cost-zero path 와 동일 메커니즘.
+- **Provider-managed refresh**. Claude CLI 가 자체 OAuth refresh 책임. GEODE 가 token lifecycle 코드를 보유할 필요 없음.
+- **Cross-platform 향후 확장**. crumb 가 검증한 패턴 — macOS/Linux/Windows 모두 claude CLI 가 keyring 추상화 처리.
+
+### Con
+
+- **ToS 회색지대**. Anthropic Consumer ToS §3 (Acceptable Use) 의 "automated access" 정의가 OAuth-routed subprocess 호출에 적용되는지 모호. 문자 그대로의 위반은 없으나 정신적 위반 가능 (좁은 해석 시). 외부 배포/PR 데모/공개 호스팅에는 부적합.
+- **Latency penalty**. subprocess fork + node runtime warm-up 비용 (crumb 기준 cold start ~600-800ms 추가). PAYG SDK 직접 호출 대비 perceptible.
+- **Multi-turn 한계**. `-p` 는 single-turn. multi-turn conversation state 는 호출자가 prompt history 를 매 호출마다 직렬화해야 함 — GEODE 의 AgenticLoop 구조와 mismatch (현재 SDK 가 conversation state 보유).
+- **Tool calling 우회**. claude CLI 의 internal tool set 과 GEODE 의 tool registry 가 충돌. GEODE 의 native tool calling (`definitions.json`) 가 subprocess 안에서 미작동.
+- **Streaming surface 재구현**. SDK 의 SSE → GEODE event bus 변환 path 가 이미 hook system 에 통합되어 있는 반면, `stream-json` 라인 파싱은 별도 어댑터 작성 필요.
+- **Sandbox + permission 위협**. `--dangerously-skip-permissions` 사용은 user-facing CLI 의 안전망 우회. GEODE serve 모드에서는 정책 갈등.
+- **Petri 와 중복 path**. 이미 `claude_code_provider.py` 가 in-process 로 동일한 OAuth 토큰을 사용. subprocess path 추가 시 두 path 의 일관성 유지 부담.
+
+## 결정 — Deferred
+
+PAYG path (현재 production default) 가 cost/latency/tool-calling/multi-turn/ToS 모든 차원에서 더 단순. subscription path 의 cost-zero 매력은 cost-sensitive 사용자에게 의미 있으나, 그 use case 는 이미 Petri (audit 전용) 에서 처리. **production chat 에 subprocess adapter 도입 보류**.
+
+## 재검토 trigger 조건
+
+다음 중 하나가 발생하면 본 결정을 재검토:
+
+1. **Anthropic 이 user:inference scope 또는 동등 OAuth client 를 third-party 에 공개 발급** (PKCE flow 재가능). subprocess 불필요해짐.
+2. **Anthropic Consumer ToS 가 OAuth-routed automation 을 명시 허용**. ToS 회색지대 소거.
+3. **claude CLI 가 multi-turn conversation state 를 외부에서 inject 가능한 API/flag 추가** (e.g. `--conversation-id`). multi-turn mismatch 해소.
+4. **GEODE 사용자가 cost-zero production chat 을 강하게 요청** + 위 조건 1-2 중 하나가 충족.
+5. **paperclip / crumb 이 multi-turn / tool-calling 한계를 해결한 패턴을 공개**. 참조 구현 등장.
+
+## 작업 항목 (재검토 시)
+
+도입 결정 시:
+1. `core/llm/providers/claude_cli.py` — paperclip subprocess adapter (crumb 패턴 차용).
+2. `core/llm/routing/plans.py` — `claude-cli-sub` plan kind 추가.
+3. `core/cli/commands/login.py:_login_oauth_anthropic` 에 picker UX 복원 (paths: api-key / claude-cli) — 단 v0.99.9 의 REPL-trap 회피 필요.
+4. ToS notice — 첫 활성화 시 사용자 경고 (정신적 위반 가능성 + 외부 배포 부적합).
+5. tool calling fallback — subprocess path 에서 GEODE native tool 차단 + degrade-to-text mode.
+6. E2E test — `tests/integration/test_claude_cli_adapter.py` (가능 시 mock claude CLI 사용).
+
+## References
+
+- Crumb claude-local adapter: `~/workspace/crumb/src/adapters/claude-local.ts:1-163`
+- Paperclip: `github.com/paperclipai/paperclip`
+- v0.99.10 폐기 노트: `core/auth/oauth_login.py:515-525`
+- Petri provider (in-process keychain): `plugins/petri_audit/claude_code_provider.py:1-100`
+- Anthropic Consumer ToS §3: `https://www.anthropic.com/legal/consumer-terms`
+- Session handoff (`paperclip reference` 인용): `docs/audits/2026-05-15-session-handoff-codex-verify.md:143`


### PR DESCRIPTION
## Summary

- I2 paperclip review (#1269) + 3-backlog disposition (#1270) docs + pages.yml deploy guard.
- 코드/버전 변경 없음. docs + CI hygiene only.

## Verification

- [x] PR #1269 CI 10/11 (1 skip)
- [x] PR #1270 CI 10/11 (1 skip)
- [x] 두 PR 모두 docs/audits/ + .github/workflows/pages.yml 1줄 guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)