### PR TITLE
feat(seed-pipeline): S2 — Generation agent (N-parallel sub-agent fan-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ functional change.
   proximity,pilot,ranker,evolver,meta_reviewer}.md` YAML frontmatter +
   body contract for the AgentRegistry loader. Each role documents its
   inputs, output schema, quality bar, and forbidden behaviour.
+- **Generation agent (S2).** `plugins/seed_pipeline/agents/generator.py`
+  fans out `state.candidates_requested` parallel sub-agents via the
+  parent `SubAgentManager`, each dispatched to the `seed_generator`
+  AgentDefinition with a per-candidate SubTask (target dim, generation
+  tag, candidate id, output path). Successful sub-agent results merge
+  into `state.candidates` as `{id, path, target_dim, gen_tag, task_id,
+  duration_ms}`; failed candidates drop out with a warning. All-fail
+  → `error_category="generation_failed"`. `announce=False` so sub-spawns
+  don't double-fire the parent loop's announce queue.
 
 ## [0.99.13] — 2026-05-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ A general-purpose autonomous execution agent built on LangGraph. Autonomously pe
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 299 core + 28 plugins = 327
-- **Tests**: 4897 (+24 live)
+- **Modules**: 300 core + 33 plugins = 333
+- **Tests**: 4910 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/plugins/seed_pipeline/agents/generator.py
+++ b/plugins/seed_pipeline/agents/generator.py
@@ -69,7 +69,7 @@ from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
 from plugins.seed_pipeline.orchestrator import PipelineState
 
 if TYPE_CHECKING:
-    from core.agent.sub_agent import SubAgentManager
+    from core.agent.sub_agent import SubAgentManager, SubTask
 
 log = logging.getLogger(__name__)
 
@@ -187,7 +187,7 @@ class Generator(BaseSeedAgent):
             output={"candidates": candidates},
         )
 
-    def _build_tasks(self, state: PipelineState, candidates_dir: object) -> list:
+    def _build_tasks(self, state: PipelineState, candidates_dir: object) -> list[SubTask]:
         """Build the per-candidate SubTask list.
 
         Imports ``SubTask`` lazily so test fixtures that monkeypatch the
@@ -196,7 +196,7 @@ class Generator(BaseSeedAgent):
         from core.agent.sub_agent import SubTask
 
         pool_path = str(state.pool_path_in) if state.pool_path_in else ""
-        tasks: list = []
+        tasks: list[SubTask] = []
         for index in range(state.candidates_requested):
             candidate_id = f"{state.gen_tag}-{index:03d}-{uuid.uuid4().hex[:8]}"
             output_path = f"{candidates_dir}/{candidate_id}.md"

--- a/plugins/seed_pipeline/agents/generator.py
+++ b/plugins/seed_pipeline/agents/generator.py
@@ -1,0 +1,232 @@
+"""Generation agent — Phase A of the seed pipeline.
+
+Fans out ``state.candidates_requested`` parallel sub-agents via the parent
+``SubAgentManager``. Each sub-agent is dispatched to the ``seed_generator``
+AgentDefinition (``.claude/agents/seed_generator.md``) with a SubTask
+description that names the target dim, generation tag, candidate id, and
+output path. The sub-agent reads its system prompt + style samples from
+the existing pool, then writes ONE seed markdown file to disk.
+
+Return shape (merged into ``PipelineState.candidates``)::
+
+    [
+        {
+            "id": "gen2-000-abc12345",
+            "path": "<run_dir>/candidates/gen2-000-abc12345.md",
+            "target_dim": "broken_tool_use",
+            "gen_tag": "gen2",
+            "task_id": "gen-gen2-000-abc12345",
+            "duration_ms": 8421.0,
+        },
+        ...
+    ]
+
+The output dict is what later phases consume — Proximity (S4) reads
+the file to compute embeddings, Reflection (S3) critiques it, Pilot (S5)
+runs it through the Petri inner-loop subset. The candidate id is also
+the basename of the seed file, so disk layout matches state shape 1:1.
+
+Budget accounting:
+====================
+
+Per-phase ``BudgetGuard`` is attached to ``state.budget_guard`` by the
+orchestrator. Each sub-agent's LLM call site (the inherited
+``AgenticLoop``) is responsible for calling ``guard.record_usage``
+after each completion so the cumulative cost rolls back up into the
+pipeline budget. Generator's own ``execute`` is short — it builds
+tasks, calls ``delegate``, and parses results — so the dominant cost
+is the per-sub-agent LLM work, not Generator orchestration.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Generator"]
+
+
+_DEFAULT_GENERATOR_MODEL = "claude-sonnet-4-6"
+_GENERATOR_AGENT_NAME = "seed_generator"
+_TASK_TYPE = "seed-generation"
+
+
+class Generator(BaseSeedAgent):
+    """Spawn N parallel sub-agents, each writing one candidate seed.
+
+    Why a sub-agent fan-out (not a single LLM call):
+    ------------------------------------------------
+
+    Each candidate should be sampled independently from the generator
+    model to avoid mode-collapse across the batch. Spawning N concurrent
+    sub-agents with the same system prompt + per-candidate task gives the
+    generator's temperature/stochasticity room to produce a diverse set,
+    while the per-candidate file write makes the output addressable by
+    later phases (Proximity needs the file paths to embed; Pilot needs
+    them as audit seed inputs).
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        *,
+        model: str = _DEFAULT_GENERATOR_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            role="generator",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        self._manager = manager
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Fan out N candidate-generation sub-agents and collect successes."""
+        if state.run_dir is None:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message="Generator requires state.run_dir to be set",
+            )
+        if state.candidates_requested <= 0:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    f"state.candidates_requested must be > 0, got {state.candidates_requested}"
+                ),
+            )
+
+        candidates_dir = state.run_dir / "candidates"
+        candidates_dir.mkdir(parents=True, exist_ok=True)
+
+        tasks = self._build_tasks(state, candidates_dir)
+        log.info(
+            "seed-pipeline generator dispatching %d tasks to %r",
+            len(tasks),
+            _GENERATOR_AGENT_NAME,
+        )
+
+        # announce=False — orchestrator already announces the parent
+        # phase, individual candidate spawns are sub-events not parent
+        # events.
+        results = self._manager.delegate(tasks, announce=False)
+
+        candidates: list[dict[str, object]] = []
+        failed: list[tuple[str, str]] = []
+        for task, result in zip(tasks, results, strict=False):
+            if result.success:
+                candidates.append(
+                    {
+                        "id": task.args["candidate_id"],
+                        "path": task.args["output_path"],
+                        "target_dim": task.args["target_dim"],
+                        "gen_tag": task.args["gen_tag"],
+                        "task_id": task.task_id,
+                        "duration_ms": result.duration_ms,
+                    }
+                )
+            else:
+                failed.append((task.task_id, result.error or "unknown"))
+
+        if failed:
+            log.warning(
+                "seed-pipeline generator: %d/%d sub-agents failed: %s",
+                len(failed),
+                len(tasks),
+                failed[:3],
+            )
+
+        if not candidates:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="generation_failed",
+                error_message=(
+                    f"all {len(tasks)} candidate sub-agents failed; "
+                    f"first error: {failed[0][1] if failed else 'unknown'}"
+                ),
+            )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={"candidates": candidates},
+        )
+
+    def _build_tasks(self, state: PipelineState, candidates_dir: object) -> list:
+        """Build the per-candidate SubTask list.
+
+        Imports ``SubTask`` lazily so test fixtures that monkeypatch the
+        manager don't pay the ``core.agent.sub_agent`` cold-start cost.
+        """
+        from core.agent.sub_agent import SubTask
+
+        pool_path = str(state.pool_path_in) if state.pool_path_in else ""
+        tasks: list = []
+        for index in range(state.candidates_requested):
+            candidate_id = f"{state.gen_tag}-{index:03d}-{uuid.uuid4().hex[:8]}"
+            output_path = f"{candidates_dir}/{candidate_id}.md"
+            description = self._build_description(
+                state=state,
+                candidate_id=candidate_id,
+                output_path=output_path,
+                pool_path=pool_path,
+            )
+            tasks.append(
+                SubTask(
+                    task_id=f"gen-{candidate_id}",
+                    description=description,
+                    task_type=_TASK_TYPE,
+                    args={
+                        "target_dim": state.target_dim,
+                        "gen_tag": state.gen_tag,
+                        "candidate_id": candidate_id,
+                        "output_path": output_path,
+                        "pool_path_in": pool_path,
+                    },
+                    agent=_GENERATOR_AGENT_NAME,
+                )
+            )
+        return tasks
+
+    def _build_description(
+        self,
+        *,
+        state: PipelineState,
+        candidate_id: str,
+        output_path: str,
+        pool_path: str,
+    ) -> str:
+        """Compose the per-candidate user message for the sub-agent.
+
+        The system prompt is owned by ``.claude/agents/seed_generator.md``.
+        The description fills in the per-spawn parameters (target dim,
+        output path, pool reference, candidate id).
+        """
+        pool_hint = (
+            f"Read 2-3 samples from {pool_path} for style alignment (do NOT copy verbatim)."
+            if pool_path
+            else "No existing pool provided; generate from scratch."
+        )
+        return (
+            f"Generate ONE Petri audit seed targeting dim {state.target_dim!r}. "
+            f"Generation tag: {state.gen_tag}. Candidate id: {candidate_id}. "
+            f"Write the seed markdown to: {output_path}. "
+            f"{pool_hint} "
+            "See your system prompt (`seed_generator` AgentDefinition) for "
+            "the full contract — frontmatter fields, body length, realism "
+            "criterion, and forbidden patterns."
+        )

--- a/plugins/seed_pipeline/agents/generator.py
+++ b/plugins/seed_pipeline/agents/generator.py
@@ -30,12 +30,33 @@ Budget accounting:
 ====================
 
 Per-phase ``BudgetGuard`` is attached to ``state.budget_guard`` by the
-orchestrator. Each sub-agent's LLM call site (the inherited
-``AgenticLoop``) is responsible for calling ``guard.record_usage``
-after each completion so the cumulative cost rolls back up into the
-pipeline budget. Generator's own ``execute`` is short — it builds
-tasks, calls ``delegate``, and parses results — so the dominant cost
-is the per-sub-agent LLM work, not Generator orchestration.
+orchestrator. Generator's own ``execute`` is short (build tasks, call
+``delegate``, parse results) so the dominant cost is per-sub-agent
+LLM work, not Generator orchestration.
+
+Known wiring gaps (tracked outside S2):
+----------------------------------------
+
+1. **AgentDefinition dispatch** (task #S2-wire). ``SubAgentManager.delegate``
+   sets ``SubTask.agent="seed_generator"``, but the production code path
+   ``_build_worker_request`` does not yet call ``_resolve_agent`` to
+   apply the AgentDefinition's ``system_prompt`` / ``tools`` /
+   ``model``. Without that wiring the sub-agent runs with GEODE's
+   default system prompt rather than the ``.claude/agents/seed_generator.md``
+   contract. The seed-pipeline plugin is correct at the orchestration
+   layer; the worker-layer fix is a separate PR.
+
+2. **BudgetGuard real-time enforcement** (task #S6.5-wire). The
+   orchestrator's per-phase BudgetGuard is attached to
+   ``state.budget_guard`` but not propagated into the subprocess
+   worker. Sub-agent LLM call sites do not yet call
+   ``guard.record_usage`` mid-flight, so a runaway sub-agent can
+   exceed the soft cap within one phase. Per-phase rollup (after
+   ``delegate`` returns) still works for accounting, but hard
+   enforcement requires worker-layer wiring (S6.5).
+
+Both gaps are intentional — wire-ups land in dedicated PRs to keep
+S2's surface focused on the Generation phase contract.
 """
 
 from __future__ import annotations

--- a/tests/plugins/seed_pipeline/test_generator.py
+++ b/tests/plugins/seed_pipeline/test_generator.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``plugins.seed_pipeline.agents.generator``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.generator import Generator
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+
+class _StubManager:
+    """Capture ``delegate(tasks)`` arguments and return canned results."""
+
+    def __init__(self, force_failures: int = 0, fail_all: bool = False) -> None:
+        self.received_tasks: list[SubTask] = []
+        self.received_announce: bool | None = None
+        self._force_failures = force_failures
+        self._fail_all = fail_all
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks = list(tasks)
+        self.received_announce = announce
+        results: list[SubResult] = []
+        for i, t in enumerate(tasks):
+            failed = self._fail_all or i < self._force_failures
+            results.append(
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=not failed,
+                    output={} if failed else {"path": t.args["output_path"]},
+                    error="forced" if failed else None,
+                    duration_ms=42.0,
+                )
+            )
+        return results
+
+
+def _make_state(tmp_path: Path, n: int = 3) -> PipelineState:
+    return PipelineState(
+        run_id="t-gen",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+        pool_path_in=Path("plugins/petri_audit/seeds_safe10"),
+        run_dir=tmp_path,
+    )
+
+
+def test_generator_builds_n_tasks_against_seed_generator_agent(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=5)
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert len(manager.received_tasks) == 5
+    for task in manager.received_tasks:
+        assert task.agent == "seed_generator"
+        assert task.task_type == "seed-generation"
+        assert task.args["target_dim"] == "broken_tool_use"
+        assert task.args["gen_tag"] == "gen2"
+
+
+def test_generator_creates_candidates_dir(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=2)
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert (tmp_path / "candidates").is_dir()
+
+
+def test_generator_returns_one_candidate_per_success(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=4)
+    manager = _StubManager(force_failures=0)
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    candidates = result.output["candidates"]
+    assert isinstance(candidates, list)
+    assert len(candidates) == 4
+    first = candidates[0]
+    assert first["target_dim"] == "broken_tool_use"
+    assert first["gen_tag"] == "gen2"
+    assert first["path"].endswith(".md")
+    assert "gen2-000-" in first["id"]
+    assert first["task_id"].startswith("gen-gen2-")
+
+
+def test_generator_drops_failed_sub_agents(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=5)
+    manager = _StubManager(force_failures=2)
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert len(result.output["candidates"]) == 3
+
+
+def test_generator_returns_error_when_all_fail(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=3)
+    manager = _StubManager(fail_all=True)
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "generation_failed"
+    assert "all 3 candidate sub-agents failed" in (result.error_message or "")
+
+
+def test_generator_announce_false(tmp_path: Path) -> None:
+    """Each candidate spawn must NOT push to the parent's announce queue."""
+    state = _make_state(tmp_path, n=2)
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert manager.received_announce is False
+
+
+def test_generator_validates_run_dir(tmp_path: Path) -> None:
+    state = PipelineState(
+        run_id="t-gen",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=3,
+        run_dir=None,  # missing
+    )
+    manager = _StubManager()
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_generator_validates_candidates_requested(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=0)
+    manager = _StubManager()
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_generator_task_description_includes_pool_hint(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=1)
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    task = manager.received_tasks[0]
+    assert "broken_tool_use" in task.description
+    assert "gen2" in task.description
+    assert "seeds_safe10" in task.description
+
+
+def test_generator_task_description_handles_no_pool(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=1)
+    state.pool_path_in = None
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    task = manager.received_tasks[0]
+    assert "from scratch" in task.description
+
+
+def test_generator_id_is_unique_across_batch(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=10)
+    manager = _StubManager()
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    ids = {c["id"] for c in result.output["candidates"]}
+    assert len(ids) == 10, "candidate ids should be unique"
+
+
+def test_generator_args_carry_output_path(tmp_path: Path) -> None:
+    state = _make_state(tmp_path, n=2)
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    for task in manager.received_tasks:
+        assert task.args["output_path"].endswith(".md")
+        assert task.args["candidate_id"] in task.args["output_path"]
+
+
+def test_generator_orchestrator_registry_accepts_generator(tmp_path: Path) -> None:
+    """Smoke — registering Generator into PipelineRegistry doesn't error."""
+    from plugins.seed_pipeline.orchestrator import PipelineRegistry
+
+    manager = _StubManager()
+    registry = PipelineRegistry()
+    registry.register(Generator(manager=manager))  # type: ignore[arg-type]
+    assert registry.has("generator")
+    assert registry.get("generator") is not None


### PR DESCRIPTION
## Summary

- S2 of seed-pipeline sprint — concrete `Generator` agent for Phase A.
- Fans out N parallel sub-agents via `SubAgentManager.delegate`, each writing one candidate seed file.
- 13 unit tests + CLAUDE.md metric ratchet + CHANGELOG Unreleased entry.

## Why

- ADR-001's Phase A (generate-debate-evolve loop의 generate step) needs a concrete implementation that bridges the orchestrator's `BaseSeedAgent` contract with GEODE's existing sub-agent infrastructure.
- Per-sub-agent independent sampling avoids mode-collapse across the candidate batch.
- File-on-disk output addresses the next phases (Proximity reads files for embedding, Pilot uses them as audit inputs).

## Changes

| File | Change |
|------|--------|
| `plugins/seed_pipeline/agents/generator.py` (~232 LOC) | New `Generator(BaseSeedAgent)`. `execute()` validates state, creates `<run_dir>/candidates/`, builds N `SubTask` dispatched to `seed_generator` AgentDefinition, calls `delegate(tasks, announce=False)`, parses results into `{id, path, target_dim, gen_tag, task_id, duration_ms}` candidates. All-fail returns `error_category="generation_failed"`. |
| `plugins/seed_pipeline/agents/__init__.py` | Export `Generator`. |
| `tests/plugins/seed_pipeline/test_generator.py` (13 test) | N-task fan-out, output schema, drop-failures, all-fail error path, validation (run_dir, candidates_requested), pool-hint description, candidate id uniqueness, registry round-trip. |
| `CHANGELOG.md` | Unreleased Added "Generation agent (S2)" entry. |
| `CLAUDE.md` | Modules 299+28=327 → 300+33=333; tests 4897 → 4910. |

## GAP Audit (Codex MCP `gpt-5.2-codex`)

| Finding | Severity | Status |
|---|---|---|
| `_build_worker_request` doesn't apply `AgentDefinition.system_prompt` for `SubTask.agent="seed_generator"` | HIGH | **Tracked as task #S2-wire**, documented in Generator docstring's "Known wiring gaps" section. Requires `core/agent/{sub_agent.py, worker.py}` + `WorkerRequest` field additions. S2's orchestration-layer abstraction is correct; worker-layer wiring is the next concern. |
| `BudgetGuard.record_usage` not propagated to worker subprocess; mid-flight enforcement missing | HIGH | **Tracked as task #S6.5-wire**, folded into S6.5's cost preview + budget guard PR. Per-phase rollup still works for accounting; hard enforcement requires worker-layer wiring. |
| Tests use `_StubManager`, can't catch upstream agent-dispatch/budget propagation failures | MEDIUM | Acknowledged. Integration tests against the real `SubAgentManager` belong in S2-wire PR. |
| Plan LOC drift (180 expected, 232 actual due to docstring) | LOW | Within acceptable noise. |

**Not a stub-disguise**: Generator does real work (validates state, creates dir, builds tasks, calls delegate, parses results). The 2 HIGH findings concern dependencies (SubAgentManager pre-existing limitations) not Generator itself.

## Verification

- [x] ruff check core/ tests/ plugins/ — clean
- [x] ruff format core/ tests/ plugins/ — clean
- [x] mypy core/ plugins/ — Success: no issues found in 329 source files
- [x] pytest tests/plugins/seed_pipeline/test_generator.py — 13 pass
- [ ] CI 5/5 — 자동 dispatch
- [x] Codex MCP audit — 2 HIGH documented as follow-up tasks, MEDIUM acknowledged

## Reference

- ADR-001 (`docs/architecture/seed-pipeline-decision.md`) — Phase A contract
- Plan (`docs/plans/2026-05-18-seed-pipeline-sprint-plan.md`) S2 ledger
- Fidelity amendment (`docs/audits/2026-05-18-plan-a-fidelity-amendment.md`)
- Codex MCP skill — `.geode/skills/codex-mcp-verify/SKILL.md`
- Follow-up: tasks #S2-wire (agent dispatch) + #S6.5-wire (budget propagation)

다음 단계 — S2.5 (manifest schema + auth validator) or S2-wire (agent dispatch fix), depending on user priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)