### PR TITLE
fix(seed-pipeline): S2-wire — SubAgent → AgentDefinition dispatch (Codex MCP HIGH 1)

### DIFF
--- a/core/agent/loop/_context.py
+++ b/core/agent/loop/_context.py
@@ -68,14 +68,26 @@ def repair_messages(messages: list[dict[str, Any]]) -> None:
 
 
 def build_system_prompt(loop: AgenticLoop) -> str:
-    """Build the system prompt with skill context and agentic suffix."""
-    base = _build_system_prompt(model=loop.model)
-    # Inject skill context into placeholder
+    """Build the system prompt with skill context and agentic suffix.
+
+    S2-wire (2026-05-18): when ``loop._system_prompt_override`` is set
+    (AgentDefinition-driven spawn), the override replaces the default
+    GEODE system body. Skill context + agentic suffix + system_suffix
+    are still appended so tool-calling and observability invariants
+    hold for all spawns regardless of role.
+    """
+    override = getattr(loop, "_system_prompt_override", None)
     skill_ctx = ""
     if loop._skill_registry is not None:
         skill_ctx = loop._skill_registry.get_context_block()
-    base = base.replace("{skill_context}", skill_ctx or '<available_skills status="empty" />')
-    prompt = base + "\n" + AGENTIC_SUFFIX
+    if override:
+        base = override
+        if skill_ctx:
+            base = base + "\n\n" + skill_ctx
+    else:
+        base = _build_system_prompt(model=loop.model)
+        base = base.replace("{skill_context}", skill_ctx or '<available_skills status="empty" />')
+    prompt: str = base + "\n" + AGENTIC_SUFFIX
     if loop._system_suffix:
         prompt += "\n\n" + loop._system_suffix
     return prompt

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -85,6 +85,7 @@ class AgenticLoop:
         enable_goal_decomposition: bool = True,
         parent_session_key: str = "",
         system_suffix: str = "",
+        system_prompt_override: str | None = None,
         quiet: bool = False,
         disable_settings_drift: bool = False,
     ) -> None:
@@ -92,6 +93,15 @@ class AgenticLoop:
         self.executor = tool_executor
         self._parent_session_key = parent_session_key
         self._system_suffix = system_suffix
+        # S2-wire (2026-05-18): when set, _build_system_prompt uses this
+        # string as the entire role/instruction body, replacing the
+        # default ``_build_system_prompt(model=loop.model)`` output.
+        # Skill context + agentic suffix still appended (tool calling
+        # contract preserved). Used by AgentDefinition-driven sub-agents
+        # (``.claude/agents/seed_*.md``) so the seed_generator role's
+        # full contract — not GEODE's generic system prompt — drives
+        # the spawned worker.
+        self._system_prompt_override = system_prompt_override
         self._quiet = quiet  # suppress spinner (sub-agent, headless)
         self.max_rounds = max_rounds
         self.max_tokens = max_tokens

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -511,18 +511,40 @@ class SubAgentManager:
         difficulty = getattr(task, "difficulty", "medium")
         task_effort = _DIFFICULTY_TO_EFFORT.get(difficulty, settings.agentic_effort)
 
+        # S2-wire (2026-05-18): resolve AgentDefinition if task.agent is set
+        # so the worker can apply the agent's system_prompt + tools + model.
+        # Pre-S2-wire, _resolve_agent was only called by the legacy task-
+        # handler path; the production subprocess path defaulted to GEODE's
+        # generic prompt regardless of task.agent.
+        agent_ctx = self._resolve_agent(task)
+        agent_name = ""
+        agent_system_prompt = ""
+        agent_allowed_tools: list[str] = []
+        worker_model = settings.model
+        if agent_ctx is not None:
+            agent_name = str(agent_ctx.get("agent_name", ""))
+            agent_system_prompt = str(agent_ctx.get("system_prompt", ""))
+            tools_raw = agent_ctx.get("tools") or []
+            agent_allowed_tools = [str(t) for t in tools_raw]
+            # AgentDefinition model override wins over settings default.
+            if agent_ctx.get("model"):
+                worker_model = str(agent_ctx["model"])
+
         return WorkerRequest(
             task_id=task.task_id,
             task_type=task.task_type,
             description=task.description,
             args=task.args,
             denied_tools=denied,
-            model=settings.model,
-            provider=_resolve_provider(settings.model),
+            model=worker_model,
+            provider=_resolve_provider(worker_model),
             timeout_s=self._timeout_s,
             time_budget_s=self._time_budget_s,
             thinking_budget=settings.agentic_thinking_budget,
             effort=task_effort,
+            agent_name=agent_name,
+            agent_system_prompt=agent_system_prompt,
+            agent_allowed_tools=agent_allowed_tools,
         )
 
     def _resolve_agent(self, task: SubTask) -> dict[str, Any] | None:

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -51,6 +51,18 @@ class WorkerRequest:
     thinking_budget: int = 0  # 0 = disabled; >0 = thinking tokens per call (legacy)
     effort: str = "high"  # "low" | "medium" | "high" | "max" | "xhigh" (v0.56.0)
     isolation: str = ""  # Reserved for Phase 3: "worktree" etc.
+    # Agent context (S2-wire, 2026-05-18):
+    # When ``agent_name`` is non-empty the parent has resolved an
+    # AgentDefinition (``.claude/agents/<agent_name>.md``) and pre-
+    # populated the role/system prompt/tools/model overrides. The
+    # worker applies these to the spawned AgenticLoop so the spawn
+    # actually behaves as the named agent rather than the generic
+    # default. ``agent_allowed_tools`` is a *whitelist* that the worker
+    # translates into a denied set against the full tool list; empty
+    # means the agent inherits the parent's denied set unchanged.
+    agent_name: str = ""
+    agent_system_prompt: str = ""
+    agent_allowed_tools: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -76,6 +88,9 @@ class WorkerRequest:
             thinking_budget=data.get("thinking_budget", 0),
             effort=data.get("effort", "high"),
             isolation=data.get("isolation", ""),
+            agent_name=data.get("agent_name", ""),
+            agent_system_prompt=data.get("agent_system_prompt", ""),
+            agent_allowed_tools=data.get("agent_allowed_tools", []),
         )
 
 
@@ -132,10 +147,20 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
 
     handlers = _build_tool_handlers(verbose=False)
 
-    # 2. Filter denied tools
+    # 2. Filter tools
+    # Always deny delegate_task in worker (depth=1 enforcement).
     denied = set(request.denied_tools)
-    # Always deny delegate_task in worker (depth=1 enforcement)
     denied.add("delegate_task")
+    # S2-wire (2026-05-18): when agent_allowed_tools is set, the
+    # AgentDefinition declared a whitelist. Tools NOT on that whitelist
+    # are added to the denied set so the spawned worker only sees the
+    # tools the agent role is supposed to use. ``delegate_task`` remains
+    # denied regardless (depth=1).
+    if request.agent_allowed_tools:
+        allowed = set(request.agent_allowed_tools)
+        for tool_name in list(handlers):
+            if tool_name not in allowed:
+                denied.add(tool_name)
     if denied:
         handlers = {k: v for k, v in handlers.items() if k not in denied}
 
@@ -155,6 +180,13 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     # 5. Build AgenticLoop
     from core.agent.loop import AgenticLoop
 
+    # S2-wire (2026-05-18): propagate AgentDefinition.system_prompt into the
+    # spawned loop so AgentDefinition-driven sub-agents (seed_generator etc.)
+    # actually behave as the named agent rather than running GEODE's generic
+    # default. Worker carries the resolved prompt over the IPC boundary so
+    # the subprocess does not need its own AgentRegistry lookup.
+    system_prompt_override: str | None = request.agent_system_prompt or None
+
     loop = AgenticLoop(
         conversation,
         executor,
@@ -173,6 +205,7 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
         thinking_budget=request.thinking_budget,
         effort=request.effort,
         time_budget_s=request.time_budget_s,
+        system_prompt_override=system_prompt_override,
         quiet=True,  # Suppress spinner — parent handles UI
     )
 

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -125,6 +125,33 @@ class WorkerResult:
 # ---------------------------------------------------------------------------
 
 
+def filter_handlers(
+    *,
+    handlers: dict[str, Any],
+    denied_tools: list[str],
+    agent_allowed_tools: list[str],
+) -> dict[str, Any]:
+    """Apply denied-set + AgentDefinition whitelist to the tool handler map.
+
+    Pure function — testable without the worker's AgenticLoop bootstrap.
+
+    - ``delegate_task`` is always denied (depth=1 enforcement).
+    - When ``agent_allowed_tools`` is non-empty, tools not on the whitelist
+      are added to the denied set (whitelist takes precedence over
+      inherited tools).
+    """
+    denied = set(denied_tools)
+    denied.add("delegate_task")
+    if agent_allowed_tools:
+        allowed = set(agent_allowed_tools)
+        for tool_name in list(handlers):
+            if tool_name not in allowed:
+                denied.add(tool_name)
+    if denied:
+        return {k: v for k, v in handlers.items() if k not in denied}
+    return handlers
+
+
 def _save_result_backup(result: WorkerResult) -> None:
     """Save result JSON to ~/.geode/workers/ for crash debugging."""
     try:
@@ -148,21 +175,11 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
     handlers = _build_tool_handlers(verbose=False)
 
     # 2. Filter tools
-    # Always deny delegate_task in worker (depth=1 enforcement).
-    denied = set(request.denied_tools)
-    denied.add("delegate_task")
-    # S2-wire (2026-05-18): when agent_allowed_tools is set, the
-    # AgentDefinition declared a whitelist. Tools NOT on that whitelist
-    # are added to the denied set so the spawned worker only sees the
-    # tools the agent role is supposed to use. ``delegate_task`` remains
-    # denied regardless (depth=1).
-    if request.agent_allowed_tools:
-        allowed = set(request.agent_allowed_tools)
-        for tool_name in list(handlers):
-            if tool_name not in allowed:
-                denied.add(tool_name)
-    if denied:
-        handlers = {k: v for k, v in handlers.items() if k not in denied}
+    handlers = filter_handlers(
+        handlers=handlers,
+        denied_tools=request.denied_tools,
+        agent_allowed_tools=request.agent_allowed_tools,
+    )
 
     # 3. Build ToolExecutor (auto_approve=True for sub-agents)
     from core.agent.tool_executor import ToolExecutor

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -208,20 +208,61 @@ class SharedServices:
     # --- internal helpers -----------------------------------------------------
 
     def _build_sub_agent_manager(self) -> Any:
-        """Build SubAgentManager with shared resources."""
+        """Build SubAgentManager with shared resources.
+
+        S2-wire (2026-05-18): construct AgentRegistry from .claude/agents/
+        + _DEFAULT_AGENTS so SubAgentManager can resolve SubTask.agent
+        names (e.g. seed_generator) into the AgentDefinition's
+        system_prompt + tools + model. Without an AgentRegistry the
+        production path silently fell back to GEODE's default prompt
+        regardless of the named role.
+        """
         from core.agent.sub_agent import SubAgentManager
         from core.config import settings
         from core.orchestration.isolated_execution import IsolatedRunner
 
         global_lane = self.lane_queue.get_lane("global") if self.lane_queue else None
+        agent_registry = self._build_agent_registry()
+
         return SubAgentManager(
             IsolatedRunner(hooks=self.hook_system, lane=global_lane),
             action_handlers=self.tool_handlers,
             mcp_manager=self.mcp_manager,
             skill_registry=self.skill_registry,
+            agent_registry=agent_registry,
             hooks=self.hook_system,
             max_depth=settings.max_subagent_depth,
         )
+
+    def _build_agent_registry(self) -> Any:
+        """Build AgentRegistry with defaults + .claude/agents/*.md.
+
+        Defaults (research_assistant, data_analyst, web_researcher) load
+        first; then ``.claude/agents/`` files are loaded per-file so a
+        single bad/duplicate file doesn't drop the rest. Conflicts with
+        a default are skipped with a warning — the user's file does NOT
+        override the default in this S2-wire iteration; an explicit
+        override mechanism can land later if needed.
+        """
+        from core.skills.agents import AgentRegistry, SubagentLoader
+
+        registry = AgentRegistry()
+        registry.load_defaults()
+        loader = SubagentLoader()
+        for path in loader.discover():
+            try:
+                definition = loader.load_file(path)
+            except Exception:
+                log.warning("AgentRegistry: failed to load %s (skipped)", path, exc_info=True)
+                continue
+            try:
+                registry.register(definition)
+            except ValueError:
+                log.debug(
+                    "AgentRegistry: %r already registered (default wins)",
+                    definition.name,
+                )
+        return registry
 
     def _propagate_contextvars(self) -> None:
         """Re-inject ContextVars for daemon/scheduler threads."""

--- a/tests/core/agent/test_agent_loop_system_prompt_override.py
+++ b/tests/core/agent/test_agent_loop_system_prompt_override.py
@@ -1,0 +1,64 @@
+"""Verify S2-wire — AgenticLoop.system_prompt_override replaces default body."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from core.agent.conversation import ConversationContext
+from core.agent.loop import AgenticLoop
+from core.agent.loop._context import build_system_prompt
+from core.agent.tool_executor import ToolExecutor
+
+
+def _make_loop(*, override: str | None = None) -> AgenticLoop:
+    """Build an AgenticLoop with minimum dependencies for prompt-build test."""
+    conversation = ConversationContext(max_turns=200)
+    executor = ToolExecutor(action_handlers={}, auto_approve=True)
+    return AgenticLoop(
+        conversation,
+        executor,
+        system_prompt_override=override,
+    )
+
+
+def test_override_replaces_default_system_body() -> None:
+    """When set, override is used as the system body."""
+    loop = _make_loop(override="ROLE_BODY_FROM_AGENT_DEFINITION")
+    prompt = build_system_prompt(loop)
+    assert "ROLE_BODY_FROM_AGENT_DEFINITION" in prompt
+
+
+def test_override_does_not_include_default_prompt_template() -> None:
+    """The default ``_build_system_prompt(model=...)`` body must NOT leak in."""
+    loop = _make_loop(override="ROLE_BODY")
+    prompt = build_system_prompt(loop)
+    assert "ROLE_BODY" in prompt
+    assert "{skill_context}" not in prompt
+
+
+def test_override_none_uses_default_path() -> None:
+    """When override is None, the legacy build path runs."""
+    loop = _make_loop(override=None)
+    prompt = build_system_prompt(loop)
+    assert prompt
+    assert "ROLE_BODY_FROM_AGENT_DEFINITION" not in prompt
+
+
+def test_override_with_skill_registry_appends_skills() -> None:
+    """Skill context is still surfaced when override is set."""
+    fake_registry = MagicMock()
+    fake_registry.get_context_block.return_value = "<skill_x />"
+    loop = _make_loop(override="ROLE_BODY")
+    loop._skill_registry = fake_registry  # type: ignore[assignment]
+    prompt = build_system_prompt(loop)
+    assert "ROLE_BODY" in prompt
+    assert "<skill_x />" in prompt
+
+
+def test_agentic_suffix_present_with_override() -> None:
+    """Tool-calling contract must be preserved across override path."""
+    from core.agent.loop._context import AGENTIC_SUFFIX
+
+    loop = _make_loop(override="ROLE_BODY")
+    prompt = build_system_prompt(loop)
+    assert AGENTIC_SUFFIX in prompt

--- a/tests/core/agent/test_subagent_agent_dispatch.py
+++ b/tests/core/agent/test_subagent_agent_dispatch.py
@@ -1,0 +1,136 @@
+"""Verify S2-wire — SubAgentManager dispatches AgentDefinition to worker.
+
+Pre-S2-wire, ``SubTask.agent="seed_generator"`` was set by the seed-
+pipeline Generator but ``SubAgentManager._build_worker_request`` did not
+call ``_resolve_agent``, so the spawned worker ran with GEODE's generic
+system prompt. These tests pin the fix: WorkerRequest now carries the
+resolved AgentDefinition's system_prompt + tools + model.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.sub_agent import SubAgentManager, SubTask
+from core.agent.worker import WorkerRequest
+from core.orchestration.isolated_execution import IsolatedRunner
+from core.skills.agents import AgentDefinition, AgentRegistry
+
+
+@pytest.fixture
+def seed_generator_registry() -> AgentRegistry:
+    """An AgentRegistry pre-populated with the seed_generator role."""
+    registry = AgentRegistry()
+    registry.register(
+        AgentDefinition(
+            name="seed_generator",
+            role="Petri seed candidate generator",
+            system_prompt="You are the Generation agent of the seed-pipeline.",
+            tools=["read_document", "write_file", "grep_files"],
+            model="claude-sonnet-4-6",
+        )
+    )
+    return registry
+
+
+def _make_manager(
+    registry: AgentRegistry,
+    *,
+    action_handlers: dict[str, object] | None = None,
+) -> SubAgentManager:
+    """A SubAgentManager wired with the production subprocess path enabled.
+
+    ``action_handlers`` being non-None is the gate that routes
+    ``_build_worker_request`` (vs the legacy task-handler thread path).
+    A dummy empty dict is sufficient for the dispatch-only tests below;
+    no actual subprocess runs.
+    """
+    return SubAgentManager(
+        runner=IsolatedRunner(),
+        agent_registry=registry,
+        action_handlers=action_handlers or {},
+    )
+
+
+def test_build_worker_request_pulls_agent_system_prompt(
+    seed_generator_registry: AgentRegistry,
+) -> None:
+    manager = _make_manager(seed_generator_registry)
+    task = SubTask(
+        task_id="t-1",
+        description="generate seed",
+        task_type="seed-generation",
+        args={"target_dim": "broken_tool_use"},
+        agent="seed_generator",
+    )
+    request: WorkerRequest = manager._build_worker_request(task)
+    assert request.agent_name == "seed_generator"
+    assert "Generation agent" in request.agent_system_prompt
+    assert request.agent_allowed_tools == [
+        "read_document",
+        "write_file",
+        "grep_files",
+    ]
+
+
+def test_build_worker_request_applies_agent_model_override(
+    seed_generator_registry: AgentRegistry,
+) -> None:
+    manager = _make_manager(seed_generator_registry)
+    task = SubTask(
+        task_id="t-2",
+        description="generate seed",
+        task_type="seed-generation",
+        args={},
+        agent="seed_generator",
+    )
+    request: WorkerRequest = manager._build_worker_request(task)
+    assert request.model == "claude-sonnet-4-6"
+
+
+def test_build_worker_request_without_agent_uses_settings_model() -> None:
+    """When task.agent is None and no _TYPE_AGENT_MAP hit, no override."""
+    registry = AgentRegistry()  # empty
+    manager = _make_manager(registry)
+    task = SubTask(
+        task_id="t-3",
+        description="generic task",
+        task_type="unknown",
+        args={},
+        agent=None,
+    )
+    request: WorkerRequest = manager._build_worker_request(task)
+    assert request.agent_name == ""
+    assert request.agent_system_prompt == ""
+    assert request.agent_allowed_tools == []
+
+
+def test_build_worker_request_missing_agent_in_registry_is_skipped(
+    seed_generator_registry: AgentRegistry,
+) -> None:
+    """task.agent='nonexistent' must not crash — fall back to default."""
+    manager = _make_manager(seed_generator_registry)
+    task = SubTask(
+        task_id="t-4",
+        description="generate seed",
+        task_type="seed-generation",
+        args={},
+        agent="nonexistent_agent",
+    )
+    request: WorkerRequest = manager._build_worker_request(task)
+    assert request.agent_name == ""
+    assert request.agent_system_prompt == ""
+
+
+def test_worker_request_round_trip_preserves_agent_fields() -> None:
+    """to_dict / from_dict must round-trip the new agent fields."""
+    req = WorkerRequest(
+        task_id="t-5",
+        agent_name="seed_generator",
+        agent_system_prompt="role prompt body",
+        agent_allowed_tools=["read_document", "write_file"],
+    )
+    blob = req.to_dict()
+    restored = WorkerRequest.from_dict(blob)
+    assert restored.agent_name == "seed_generator"
+    assert restored.agent_system_prompt == "role prompt body"
+    assert restored.agent_allowed_tools == ["read_document", "write_file"]

--- a/tests/core/agent/test_subagent_agent_dispatch.py
+++ b/tests/core/agent/test_subagent_agent_dispatch.py
@@ -134,3 +134,88 @@ def test_worker_request_round_trip_preserves_agent_fields() -> None:
     assert restored.agent_name == "seed_generator"
     assert restored.agent_system_prompt == "role prompt body"
     assert restored.agent_allowed_tools == ["read_document", "write_file"]
+
+
+def test_filter_handlers_always_denies_delegate_task() -> None:
+    """``delegate_task`` is always removed (depth=1 enforcement)."""
+    from core.agent.worker import filter_handlers
+
+    handlers = {"delegate_task": object(), "read_document": object()}
+    filtered = filter_handlers(handlers=handlers, denied_tools=[], agent_allowed_tools=[])
+    assert "delegate_task" not in filtered
+    assert "read_document" in filtered
+
+
+def test_filter_handlers_applies_whitelist() -> None:
+    """``agent_allowed_tools`` whitelist removes non-allowed tools."""
+    from core.agent.worker import filter_handlers
+
+    handlers = {
+        "read_document": object(),
+        "write_file": object(),
+        "run_bash": object(),
+        "manage_login": object(),
+    }
+    filtered = filter_handlers(
+        handlers=handlers,
+        denied_tools=[],
+        agent_allowed_tools=["read_document", "write_file"],
+    )
+    assert set(filtered.keys()) == {"read_document", "write_file"}
+
+
+def test_filter_handlers_whitelist_does_not_unblock_delegate_task() -> None:
+    """Whitelist with delegate_task does NOT unlock it (depth=1 wins)."""
+    from core.agent.worker import filter_handlers
+
+    handlers = {"delegate_task": object(), "read_document": object()}
+    filtered = filter_handlers(
+        handlers=handlers,
+        denied_tools=[],
+        agent_allowed_tools=["delegate_task", "read_document"],
+    )
+    assert "delegate_task" not in filtered
+    assert "read_document" in filtered
+
+
+def test_filter_handlers_no_whitelist_keeps_all_minus_denied() -> None:
+    """Empty whitelist → only ``denied_tools`` + ``delegate_task`` removed."""
+    from core.agent.worker import filter_handlers
+
+    handlers = {
+        "read_document": object(),
+        "write_file": object(),
+        "delegate_task": object(),
+    }
+    filtered = filter_handlers(
+        handlers=handlers,
+        denied_tools=["write_file"],
+        agent_allowed_tools=[],
+    )
+    assert set(filtered.keys()) == {"read_document"}
+
+
+def test_shared_services_passes_agent_registry_to_manager() -> None:
+    """Production wiring — SharedServices._build_sub_agent_manager() now
+    populates AgentRegistry so SubAgentManager._resolve_agent works."""
+    from core.server.supervised.services import SharedServices
+
+    services = SharedServices(
+        hook_system=None,  # type: ignore[arg-type]
+        mcp_manager=None,
+        skill_registry=None,
+        tool_handlers={},
+        lane_queue=None,  # type: ignore[arg-type]
+    )
+    registry = services._build_agent_registry()
+    # Defaults always loaded
+    names = registry.list_agents()
+    assert "research_assistant" in names
+    assert "data_analyst" in names
+    assert "web_researcher" in names
+    # seed_* roles also loaded from .claude/agents/
+    if "seed_generator" in names:
+        defn = registry.get("seed_generator")
+        assert defn is not None
+        assert defn.role  # non-empty role
+        assert defn.system_prompt  # non-empty prompt


### PR DESCRIPTION
## Summary

- S2-wire fix — SubAgentManager now resolves `SubTask.agent` to an AgentDefinition and propagates the role's `system_prompt + tools + model` to the spawned worker subprocess via `WorkerRequest`.
- Worker applies override via new `AgenticLoop(system_prompt_override=…)` parameter; whitelist filter routes non-allowed tools to the denied set.
- SharedServices now constructs an AgentRegistry (defaults + .claude/agents/*.md) and passes it to SubAgentManager — without this, the production path bypassed S2-wire entirely.

## Why

- Codex MCP S2 audit HIGH 1: pre-fix, `SubTask.agent="seed_generator"` was set but ignored — sub-agent ran with GEODE's generic prompt.
- Unblocks S3-S8 concrete agents (each needs its AgentDefinition's role-specific system prompt to work).
- Round-2 fix addresses production wiring (SharedServices) + adds whitelist filter test.

## Changes

| File | Change |
|------|--------|
| `core/agent/worker.py` | `WorkerRequest` +3 fields (agent_name, agent_system_prompt, agent_allowed_tools) with IPC round-trip. `_run_agentic` reads agent_system_prompt → AgenticLoop's `system_prompt_override`. New pure helper `filter_handlers()` applies denied_tools + whitelist (delegate_task always denied). |
| `core/agent/sub_agent.py` | `_build_worker_request` calls `_resolve_agent(task)` and populates agent fields. AgentDefinition's `model` overrides settings.model. Missing AgentRegistry/agent gracefully falls back. |
| `core/agent/loop/agent_loop.py` | AgenticLoop accepts `system_prompt_override: str \| None`. |
| `core/agent/loop/_context.py` | `build_system_prompt` uses override when set; AGENTIC_SUFFIX + skill_context + system_suffix still applied. |
| `core/server/supervised/services.py` | `_build_agent_registry()` loads 3 defaults + .claude/agents/*.md per-file (graceful skip on conflict). Passed to SubAgentManager. |
| `tests/core/agent/test_subagent_agent_dispatch.py` | 10 test — agent dispatch round-trip, model override, missing-registry/missing-agent fallback, IPC round-trip, 4 filter tests, 1 SharedServices integration. |
| `tests/core/agent/test_agent_loop_system_prompt_override.py` | 5 test — override replaces default, skill registry surfaces, AGENTIC_SUFFIX preserved, None path unchanged. |

## GAP Audit (Codex MCP `gpt-5.2-codex`)

| Round | Finding | Resolution |
|---|---|---|
| 1 HIGH | SubAgentManager.delegate doesn't apply AgentDefinition.system_prompt | round 1: WorkerRequest fields + AgenticLoop override + worker apply |
| 2 HIGH | SharedServices doesn't pass AgentRegistry — production bypass | round 2: `_build_agent_registry()` + wire into `_build_sub_agent_manager` |
| 2 MEDIUM | Missing test for whitelist → denied translation | round 2: 4 filter_handlers tests |

## Verification

- [x] ruff check core/ tests/ plugins/ — clean
- [x] ruff format — clean
- [x] mypy core/ plugins/ — Success: no issues found in 333 source files
- [x] pytest core/agent + plugins/seed_pipeline + sub_agent regression — 149 pass
- [ ] CI 5/5 — 자동 dispatch

## Reference

- Codex MCP S2 audit (in PR #1274 body)
- Task #72 (S2-wire) — this PR resolves
- Task #73 (S6.5-wire) — remains pending (BudgetGuard real-time worker propagation, scope of S6.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)