### PR TITLE
fix(seed-pipeline): S2-fix — 7 PR review findings + budget defaults relaxed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,43 @@ functional change.
   → `error_category="generation_failed"`. `announce=False` so sub-spawns
   don't double-fire the parent loop's announce queue.
 
+### Fixed
+
+- **Seed pipeline S2-fix.** Multi-PR review found 7 issues in the merged
+  S0-S2-wire stack; all resolved here:
+  - `Generator` now pairs `SubResult` to `SubTask` by `task_id` dict
+    lookup (previously `zip(tasks, results, strict=False)` silently
+    mismatched candidate metadata with whichever sub-agent finished
+    first, because `SubAgentManager.delegate` returns in completion
+    order, not submission order). Regression test covers reverse-order
+    + unmatched-result case.
+  - `BudgetGuard.record_usage` hard-cap check moved inside the lock so
+    concurrent recorders cannot both observe `usd_after < cap`, exit
+    the critical section, and bypass the kill.
+  - `Pipeline._run_phase` cost rollup moved into `finally` so the
+    `BudgetGuard`'s accumulated `usd_spent` / `prompt_tokens` /
+    `completion_tokens` flow into `state` on every path including
+    re-raised exceptions and `BudgetExceededError`. Regression test
+    pins the invariant.
+  - `SharedServices._build_agent_registry` now anchors `SubagentLoader`
+    at `get_project_root() / ".claude" / "agents"` rather than the
+    cwd-relative default; logs INFO when no agents are discovered.
+  - `build_system_prompt` honors the `{skill_context}` placeholder in
+    both the override and default branches; substitutes in place when
+    present, appends when absent.
+  - `filter_handlers` warns when the `AgentDefinition.tools` whitelist
+    references a tool name that doesn't exist in the handler registry
+    (silent typo previously degraded the agent to zero tools).
+  - `Generator` module docstring updated — "Known wiring gaps" section
+    replaced with a "Wiring history" section noting S2-wire RESOLVED.
+  - `SeedAgentResult` docstring adds explicit "why not reuse
+    `SubAgentResult`" rationale.
+- **Budget defaults relaxed.** `SEED_PIPELINE_BUDGET_SOFT_USD` default
+  raised $0.50 → $2.00 and `_HARD_USD` $2.00 → $10.00 so seed-pipeline
+  on subscription paths (claude-cli / codex-cli, ToS-aware) doesn't
+  trip false-positive soft warnings on long-form generation. PAYG users
+  drop them via the env vars.
+
 ## [0.99.13] — 2026-05-18
 
 **Post-release sync** — main 의 v0.99.12 packaging refactor + game_ip

--- a/core/agent/loop/_context.py
+++ b/core/agent/loop/_context.py
@@ -80,13 +80,24 @@ def build_system_prompt(loop: AgenticLoop) -> str:
     skill_ctx = ""
     if loop._skill_registry is not None:
         skill_ctx = loop._skill_registry.get_context_block()
+    # S2-fix (2026-05-18) — both branches honor the ``{skill_context}``
+    # placeholder so AgentDefinition authors can opt into explicit skill
+    # injection (matching ``_DEFAULT_AGENTS`` semantics). If the override
+    # has no placeholder, the skill block is appended; if it does, the
+    # placeholder is substituted in place. Empty-state marker preserved
+    # for both paths so prompts never ship a literal ``{skill_context}``
+    # token to the LLM.
+    skill_replacement = skill_ctx or '<available_skills status="empty" />'
     if override:
-        base = override
-        if skill_ctx:
-            base = base + "\n\n" + skill_ctx
+        if "{skill_context}" in override:
+            base = override.replace("{skill_context}", skill_replacement)
+        else:
+            base = override
+            if skill_ctx:
+                base = base + "\n\n" + skill_ctx
     else:
         base = _build_system_prompt(model=loop.model)
-        base = base.replace("{skill_context}", skill_ctx or '<available_skills status="empty" />')
+        base = base.replace("{skill_context}", skill_replacement)
     prompt: str = base + "\n" + AGENTIC_SUFFIX
     if loop._system_suffix:
         prompt += "\n\n" + loop._system_suffix

--- a/core/agent/sub_agent_budget.py
+++ b/core/agent/sub_agent_budget.py
@@ -60,8 +60,16 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
-DEFAULT_SOFT_USD = _env_float("SEED_PIPELINE_BUDGET_SOFT_USD", 0.50)
-DEFAULT_HARD_USD = _env_float("SEED_PIPELINE_BUDGET_HARD_USD", 2.00)
+# S2-fix (2026-05-18) — defaults relaxed per user feedback. Previous
+# 0.50 / 2.00 were too conservative for seed-pipeline use cases where
+# subscription paths (claude-cli, codex-cli) cost $0 against quota
+# rather than PAYG, but the orchestrator still tripped soft warnings
+# on the per-phase cost rollup of long-form generation. New defaults
+# 2.00 / 10.00 give the typical 15-candidate Generation phase + a
+# 3-judge tournament headroom without false positives. PAYG users
+# can drop them back via the env vars below.
+DEFAULT_SOFT_USD = _env_float("SEED_PIPELINE_BUDGET_SOFT_USD", 2.00)
+DEFAULT_HARD_USD = _env_float("SEED_PIPELINE_BUDGET_HARD_USD", 10.00)
 
 
 class BudgetExceededError(RuntimeError):
@@ -172,6 +180,12 @@ class BudgetGuard:
             input_tokens=prompt_tokens,
             output_tokens=completion_tokens,
         )
+        # S2-fix (2026-05-18) — hard-cap check must happen *inside* the lock
+        # so concurrent recorders can't both observe usd_after < cap, exit
+        # the critical section, and bypass the kill. Pre-fix the lock was
+        # released before the cap test (line 193), admitting an over-spend
+        # race of up to N-1 calls when N sub-agents share one guard.
+        hard_exceeded = False
         with self._lock:
             self._budget.prompt_tokens += prompt_tokens
             self._budget.completion_tokens += completion_tokens
@@ -180,6 +194,10 @@ class BudgetGuard:
             soft_crossed_now = not self._budget.soft_warned and usd_after >= self._budget.soft_usd
             if soft_crossed_now:
                 self._budget.soft_warned = True
+            hard_exceeded = usd_after > self._budget.hard_usd
+        # Callbacks + raise happen OUTSIDE the lock so the holder doesn't
+        # block other recorders while a slow callback runs, but the decision
+        # of whether to fire was made under the lock above.
         if soft_crossed_now and self._on_soft_warn is not None:
             try:
                 self._on_soft_warn(self._budget)
@@ -190,7 +208,7 @@ class BudgetGuard:
                     usd_after,
                     exc_info=True,
                 )
-        if usd_after > self._budget.hard_usd:
+        if hard_exceeded:
             raise BudgetExceededError(
                 usd_spent=usd_after,
                 hard_usd=self._budget.hard_usd,

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -139,11 +139,24 @@ def filter_handlers(
     - When ``agent_allowed_tools`` is non-empty, tools not on the whitelist
       are added to the denied set (whitelist takes precedence over
       inherited tools).
+    - S2-fix (2026-05-18): whitelist entries that don't match any handler
+      are logged at WARNING so a typo in ``.claude/agents/<name>.md``'s
+      ``tools:`` frontmatter (e.g. ``foo_typo``) doesn't silently degrade
+      the agent's capability to zero tools.
     """
     denied = set(denied_tools)
     denied.add("delegate_task")
     if agent_allowed_tools:
         allowed = set(agent_allowed_tools)
+        unknown = allowed - set(handlers)
+        if unknown:
+            log.warning(
+                "filter_handlers: AgentDefinition whitelist contains "
+                "tool names not in the handler registry — %s. The agent "
+                "will run without these tools. Check the 'tools:' "
+                "frontmatter for typos.",
+                sorted(unknown),
+            )
         for tool_name in list(handlers):
             if tool_name not in allowed:
                 denied.add(tool_name)

--- a/core/server/supervised/services.py
+++ b/core/server/supervised/services.py
@@ -240,16 +240,34 @@ class SharedServices:
         Defaults (research_assistant, data_analyst, web_researcher) load
         first; then ``.claude/agents/`` files are loaded per-file so a
         single bad/duplicate file doesn't drop the rest. Conflicts with
-        a default are skipped with a warning — the user's file does NOT
-        override the default in this S2-wire iteration; an explicit
-        override mechanism can land later if needed.
+        a default are skipped — user override is intentionally NOT
+        supported in this iteration; an explicit override mechanism can
+        land later if needed (logged at WARNING so users discover their
+        file isn't taking effect).
+
+        S2-fix (2026-05-18) — anchor the loader at ``get_project_root()``
+        rather than ``Path(".claude/agents")`` (cwd-relative). The
+        previous default silently returned zero files when ``geode serve``
+        was launched from a directory without ``.claude/agents/`` (e.g.
+        ``$HOME``), which made the entire S2-wire dispatch a no-op in
+        common operator deployments.
         """
+        from core.paths import get_project_root
         from core.skills.agents import AgentRegistry, SubagentLoader
 
         registry = AgentRegistry()
         registry.load_defaults()
-        loader = SubagentLoader()
-        for path in loader.discover():
+        agents_dir = get_project_root() / ".claude" / "agents"
+        loader = SubagentLoader(agents_dir=agents_dir)
+        discovered = loader.discover()
+        if not discovered:
+            log.info(
+                "AgentRegistry: no .claude/agents/*.md found at %s; "
+                "only the 3 built-in defaults are registered",
+                agents_dir,
+            )
+        loaded = 0
+        for path in discovered:
             try:
                 definition = loader.load_file(path)
             except Exception:
@@ -257,11 +275,20 @@ class SharedServices:
                 continue
             try:
                 registry.register(definition)
+                loaded += 1
             except ValueError:
-                log.debug(
-                    "AgentRegistry: %r already registered (default wins)",
+                log.warning(
+                    "AgentRegistry: %r conflicts with a built-in default and "
+                    "was NOT loaded — rename the file or unregister the "
+                    "default to apply your override (path=%s)",
                     definition.name,
+                    path,
                 )
+        log.info(
+            "AgentRegistry: loaded %d agents (3 defaults + %d from .claude/agents/)",
+            len(registry),
+            loaded,
+        )
         return registry
 
     def _propagate_contextvars(self) -> None:

--- a/plugins/seed_pipeline/agents/base.py
+++ b/plugins/seed_pipeline/agents/base.py
@@ -57,10 +57,25 @@ __all__ = ["BaseSeedAgent", "SeedAgentResult"]
 class SeedAgentResult:
     """Standardized result of one phase-agent invocation.
 
-    Maps onto ``core.agent.sub_agent.SubAgentResult`` for roles that
-    spawn sub-agents, but lives in the seed-pipeline domain so the
-    orchestrator can also use it for non-sub-agent roles
-    (Proximity, in particular).
+    Why not reuse ``core.agent.sub_agent.SubAgentResult``? S2-fix
+    (2026-05-18) explicit rationale — both dataclasses share ~80% of
+    fields (status / duration / token counts / error category), but
+    their *aggregation semantics* differ:
+
+    - ``SubAgentResult`` is per-TASK (one spawn → one result), with
+      ``task_id`` + ``announced`` flag for the parent loop's announce
+      queue. It is N-many per phase when Generator/Ranker fan out.
+    - ``SeedAgentResult`` is per-ROLE (one phase → one result),
+      consumed by the orchestrator's state merge. Carries ``output``
+      dict whose keys (``candidates``, ``reflections``, ``elo_ratings``,
+      …) map directly onto ``PipelineState`` fields.
+
+    Wrapping SubAgentResult would force every role to construct a
+    fake ``task_id`` and force the orchestrator to know about
+    sub-task-vs-phase polymorphism. Keeping them sibling types lets
+    each evolve in its own domain. Roles that spawn sub-agents
+    (Generator, Ranker, Pilot) translate ``list[SubResult]`` →
+    ``SeedAgentResult.output`` inside ``execute()``.
     """
 
     role: str

--- a/plugins/seed_pipeline/agents/generator.py
+++ b/plugins/seed_pipeline/agents/generator.py
@@ -34,29 +34,21 @@ orchestrator. Generator's own ``execute`` is short (build tasks, call
 ``delegate``, parse results) so the dominant cost is per-sub-agent
 LLM work, not Generator orchestration.
 
-Known wiring gaps (tracked outside S2):
-----------------------------------------
+Wiring history
+==============
 
-1. **AgentDefinition dispatch** (task #S2-wire). ``SubAgentManager.delegate``
-   sets ``SubTask.agent="seed_generator"``, but the production code path
-   ``_build_worker_request`` does not yet call ``_resolve_agent`` to
-   apply the AgentDefinition's ``system_prompt`` / ``tools`` /
-   ``model``. Without that wiring the sub-agent runs with GEODE's
-   default system prompt rather than the ``.claude/agents/seed_generator.md``
-   contract. The seed-pipeline plugin is correct at the orchestration
-   layer; the worker-layer fix is a separate PR.
-
-2. **BudgetGuard real-time enforcement** (task #S6.5-wire). The
-   orchestrator's per-phase BudgetGuard is attached to
-   ``state.budget_guard`` but not propagated into the subprocess
-   worker. Sub-agent LLM call sites do not yet call
-   ``guard.record_usage`` mid-flight, so a runaway sub-agent can
-   exceed the soft cap within one phase. Per-phase rollup (after
-   ``delegate`` returns) still works for accounting, but hard
-   enforcement requires worker-layer wiring (S6.5).
-
-Both gaps are intentional — wire-ups land in dedicated PRs to keep
-S2's surface focused on the Generation phase contract.
+- **S2-wire (RESOLVED, 2026-05-18)**: ``SubAgentManager._build_worker_request``
+  now resolves ``SubTask.agent="seed_generator"`` to the AgentDefinition,
+  propagates ``system_prompt`` / ``tools`` / ``model`` to the worker via
+  ``WorkerRequest`` new fields, and the worker applies them as
+  ``AgenticLoop(system_prompt_override=…)``. The whitelist filter
+  (``filter_handlers``) removes non-allowed tools.
+- **S6.5-wire (PENDING, task #73)**: BudgetGuard real-time enforcement
+  inside the worker subprocess. Per-phase rollup is already wired (the
+  orchestrator credits ``guard.record_usage`` totals into ``state.usd_spent``
+  on every path including exceptions, as of S2-fix), but mid-flight cap
+  enforcement at LLM call sites requires worker-layer wiring scheduled
+  for S6.5.
 """
 
 from __future__ import annotations
@@ -146,22 +138,35 @@ class Generator(BaseSeedAgent):
         # events.
         results = self._manager.delegate(tasks, announce=False)
 
+        # S2-fix (2026-05-18) — pair results by task_id, NOT by positional zip.
+        # ``SubAgentManager.delegate`` returns SubResult in *completion* order
+        # (poll loop in ``core/agent/sub_agent.py``), not submission order, so
+        # zip(tasks, results) was silently mismatching candidate metadata with
+        # whichever sub-agent finished first. Build a task lookup keyed by
+        # ``task_id`` and iterate results.
+        tasks_by_id: dict[str, object] = {task.task_id: task for task in tasks}
         candidates: list[dict[str, object]] = []
         failed: list[tuple[str, str]] = []
-        for task, result in zip(tasks, results, strict=False):
+        for result in results:
+            task = tasks_by_id.get(result.task_id)
+            if task is None:
+                # Manager returned a result for a task we didn't submit —
+                # surface as an unmatched failure so the run is auditable.
+                failed.append((result.task_id, f"unmatched_result: {result.error or 'no_task'}"))
+                continue
             if result.success:
                 candidates.append(
                     {
-                        "id": task.args["candidate_id"],
-                        "path": task.args["output_path"],
-                        "target_dim": task.args["target_dim"],
-                        "gen_tag": task.args["gen_tag"],
-                        "task_id": task.task_id,
+                        "id": task.args["candidate_id"],  # type: ignore[attr-defined]
+                        "path": task.args["output_path"],  # type: ignore[attr-defined]
+                        "target_dim": task.args["target_dim"],  # type: ignore[attr-defined]
+                        "gen_tag": task.args["gen_tag"],  # type: ignore[attr-defined]
+                        "task_id": task.task_id,  # type: ignore[attr-defined]
                         "duration_ms": result.duration_ms,
                     }
                 )
             else:
-                failed.append((task.task_id, result.error or "unknown"))
+                failed.append((task.task_id, result.error or "unknown"))  # type: ignore[attr-defined]
 
         if failed:
             log.warning(

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -259,6 +259,7 @@ class Pipeline:
         previous_guard = self.state.budget_guard
         self.state.budget_guard = guard
 
+        result: SeedAgentResult | None = None
         try:
             with self._acquire_lane(role):
                 try:
@@ -294,23 +295,41 @@ class Pipeline:
                         result.duration_ms = duration
         finally:
             self.state.budget_guard = previous_guard
+            # S2-fix (2026-05-18) — guard authoritative rollup, runs on EVERY
+            # path (success / BudgetExceeded result / re-raised exception).
+            # Pre-fix the rollup ran only on the success / BudgetExceeded
+            # paths because it was AFTER the try/finally, and a generic
+            # Exception re-raise skipped past it. Any guard.record_usage()
+            # calls made before a crash were silently dropped from
+            # state.usd_spent / .prompt_tokens / .completion_tokens.
+            #
+            # The guard is the single source of truth for cost when LLM
+            # call sites use it. For test-stub agents that bypass the guard
+            # entirely (set result.* directly), the post-finally block
+            # below credits result.* instead. Never both — exactly one of
+            # (guard, result) accounts for state.
+            guard_used = guard.budget.usd_spent > 0 or guard.budget.prompt_tokens > 0
+            if guard_used:
+                self.state.usd_spent += guard.budget.usd_spent
+                self.state.prompt_tokens += guard.budget.prompt_tokens
+                self.state.completion_tokens += guard.budget.completion_tokens
 
-        # If the agent did not propagate cost on its SeedAgentResult,
-        # pull from the guard (authoritative — guard intercepts the
-        # actual LLM calls). Concrete S2-S8 agents wire their LLM call
-        # sites to guard.record_usage and copy the guard's totals onto
-        # their result before returning.
-        if result.usd_spent == 0.0 and guard.budget.usd_spent > 0:
+        # Mirror guard usage onto result for observability (does NOT add
+        # to state again — the finally block already credited).
+        if guard.budget.usd_spent > 0 and result.usd_spent == 0.0:
             result.usd_spent = guard.budget.usd_spent
             result.prompt_tokens = guard.budget.prompt_tokens
             result.completion_tokens = guard.budget.completion_tokens
 
-        # Roll up the result's reported cost into state. Result.* is the
-        # single source for state aggregation so tests can stub agents
-        # without going through the guard.
-        self.state.usd_spent += result.usd_spent
-        self.state.prompt_tokens += result.prompt_tokens
-        self.state.completion_tokens += result.completion_tokens
+        # Stub-agent path — result.* was set directly without going through
+        # the guard. Credit state from result here (guard rollup above was
+        # a no-op since guard.usd_spent == 0).
+        if not guard_used and (
+            result.usd_spent > 0 or result.prompt_tokens > 0 or result.completion_tokens > 0
+        ):
+            self.state.usd_spent += result.usd_spent
+            self.state.prompt_tokens += result.prompt_tokens
+            self.state.completion_tokens += result.completion_tokens
 
         if result.success:
             self.state.merge(role, result.output)

--- a/tests/core/agent/test_budget_race.py
+++ b/tests/core/agent/test_budget_race.py
@@ -1,0 +1,98 @@
+"""Regression — Pipeline._run_phase must roll up BudgetGuard cost on every path.
+
+Pre-S2-fix the generic Exception handler re-raised without crediting the
+guard's accumulated cost into ``state.usd_spent`` (the rollup block at
+``plugins/seed_pipeline/orchestrator.py:311-313`` was AFTER the
+try/finally, unreachable on re-raise). Any ``guard.record_usage()`` calls
+made before the crash were silently lost from accounting.
+"""
+
+from __future__ import annotations
+
+import pytest
+from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.orchestrator import (
+    Pipeline,
+    PipelineRegistry,
+    PipelineState,
+)
+
+
+class _RecordingThenRaiseAgent(BaseSeedAgent):
+    """Records partial cost via state.budget_guard, then raises Exception."""
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        if state.budget_guard is not None:
+            state.budget_guard.record_usage(
+                model="claude-sonnet-4-6", prompt_tokens=100, completion_tokens=50
+            )
+        raise RuntimeError("simulated crash after partial cost")
+
+
+def _stub_cost(monkeypatch: pytest.MonkeyPatch, rate: float) -> None:
+    def _calc(model: str, *, input_tokens: int, output_tokens: int) -> float:
+        return (input_tokens + output_tokens) * rate
+
+    monkeypatch.setattr("core.llm.token_tracker.calculate_cost", _calc)
+
+
+def test_state_usd_spent_credits_guard_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a phase raises mid-flight, the BudgetGuard's recorded cost
+    must still flow into state.usd_spent / .prompt_tokens / .completion_tokens.
+    """
+    _stub_cost(monkeypatch, rate=0.001)
+
+    registry = PipelineRegistry()
+    registry.register(_RecordingThenRaiseAgent(role="generator", model="x"))
+    # Other roles never run (generator raises first), so registering only
+    # generator suffices.
+    state = PipelineState(run_id="t-rollup", target_dim="x", gen_tag="gen2")
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        Pipeline(state, registry).run()
+
+    # The pre-fix invariant violation: state.* were all zero. Post-fix:
+    # cost recorded before the raise survives.
+    assert state.prompt_tokens == 100
+    assert state.completion_tokens == 50
+    assert state.usd_spent == pytest.approx(0.150, abs=1e-6)
+
+
+def test_state_usd_spent_credits_guard_on_budget_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BudgetExceededError path also propagates guard cost into state."""
+    _stub_cost(monkeypatch, rate=0.01)
+
+    class _BurnsThroughCapAgent(BaseSeedAgent):
+        def execute(self, state: PipelineState) -> SeedAgentResult:
+            if state.budget_guard is not None:
+                # Burn through enough to trip the hard cap (default 10.0).
+                # 100 tokens × 0.01 × 1000 = 1000 usd → forces hard exit.
+                state.budget_guard.record_usage(
+                    model="m", prompt_tokens=50000, completion_tokens=50000
+                )
+            return SeedAgentResult(role=self.role)
+
+    registry = PipelineRegistry()
+    registry.register(_BurnsThroughCapAgent(role="generator", model="x"))
+    for r in ("proximity", "critic", "pilot", "ranker", "evolver", "meta_reviewer"):
+        registry.register(_RecordingThenRaiseAgent(role=r, model="x"))
+    # phase 1 should hit BudgetExceededError, set error_category="budget",
+    # phases 2+ won't run because phase 1's recording already crossed cap
+    # and subsequent phases are skipped after the error.
+
+    state = PipelineState(run_id="t-budget-cap", target_dim="x", gen_tag="gen2")
+    # The budget hard cap of 10.0 in defaults means 1 recording at 1000
+    # crosses → BudgetExceededError → translated to SeedAgentResult, not raised.
+    # Subsequent phases still run but raise themselves; first crash propagates.
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        Pipeline(state, registry, budget_hard_usd=10.0, budget_soft_usd=5.0).run()
+
+    # phase 1 (BurnsThroughCap) credited 100000 tokens before exceeding;
+    # phase 2 (RecordingThenRaise) credited 100 + 50 before raising.
+    assert state.prompt_tokens >= 50000  # generator credited
+    assert state.completion_tokens >= 50000
+    # Cost must include both phases' contributions (no silent drop on
+    # budget error path).
+    assert state.usd_spent > 0

--- a/tests/plugins/seed_pipeline/test_generator_order_corruption.py
+++ b/tests/plugins/seed_pipeline/test_generator_order_corruption.py
@@ -1,0 +1,107 @@
+"""Regression — Generator must pair results to tasks by task_id, not position.
+
+Pre-S2-fix `zip(tasks, results, strict=False)` (`plugins/seed_pipeline/agents/
+generator.py:151`) silently mismatched candidate metadata with whichever
+sub-agent completed first, because `SubAgentManager.delegate` returns
+SubResult in *completion order*, not submission order.
+
+This test stub returns results in REVERSE order to simulate variable
+LLM latency; the post-fix generator must produce candidates whose
+`id` matches the corresponding task's `args["candidate_id"]`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.generator import Generator
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+
+class _ReverseOrderManager:
+    """Returns SubResults in reverse submission order (worst-case latency mix)."""
+
+    def __init__(self) -> None:
+        self.received_tasks: list[SubTask] = []
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks = list(tasks)
+        results = [
+            SubResult(
+                task_id=t.task_id,
+                description=t.description,
+                success=True,
+                output={"path": t.args["output_path"]},
+                duration_ms=42.0,
+            )
+            for t in tasks
+        ]
+        return list(reversed(results))
+
+
+def _make_state(tmp_path: Path, n: int) -> PipelineState:
+    return PipelineState(
+        run_id="t-reorder",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+        pool_path_in=Path("plugins/petri_audit/seeds_safe10"),
+        run_dir=tmp_path,
+    )
+
+
+def test_generator_pairs_by_task_id_under_reverse_order(tmp_path: Path) -> None:
+    """A reversed delegate() return must still produce correctly-paired candidates."""
+    state = _make_state(tmp_path, n=5)
+    manager = _ReverseOrderManager()
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    candidates = result.output["candidates"]
+    assert len(candidates) == 5
+
+    # For each returned candidate, look up the original task by candidate_id.
+    # The path in candidate dict must match the path baked into that task's
+    # args["output_path"]. If zip-by-position were still in effect, candidate
+    # 0 would carry task 4's output_path and so on.
+    tasks_by_candidate_id = {t.args["candidate_id"]: t for t in manager.received_tasks}
+    for cand in candidates:
+        original_task = tasks_by_candidate_id[cand["id"]]
+        assert cand["path"] == original_task.args["output_path"], (
+            f"candidate {cand['id']} carried path {cand['path']} but its "
+            f"task's output_path is {original_task.args['output_path']}"
+        )
+        assert cand["task_id"] == original_task.task_id
+
+
+class _UnmatchedResultManager:
+    """Returns a result whose task_id doesn't match any submitted task."""
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results = [
+            SubResult(task_id=t.task_id, description=t.description, success=True, duration_ms=10)
+            for t in tasks
+        ]
+        # Inject an unmatched result that should NOT contaminate candidates
+        results.append(
+            SubResult(
+                task_id="unmatched-orphan",
+                description="orphan",
+                success=False,
+                error="rogue",
+                duration_ms=0,
+            )
+        )
+        return results
+
+
+def test_generator_handles_unmatched_result(tmp_path: Path) -> None:
+    """A SubResult with no corresponding task must be logged as failed, not silently merged."""
+    state = _make_state(tmp_path, n=2)
+    manager = _UnmatchedResultManager()
+    result = Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    # Real candidates: 2 (matched). Orphan should not appear.
+    assert result.success
+    assert len(result.output["candidates"]) == 2
+    candidate_ids = {c["task_id"] for c in result.output["candidates"]}
+    assert "unmatched-orphan" not in candidate_ids


### PR DESCRIPTION
## Summary

- Consolidates 4-PR retrospective review (#1272 S0 / #1273 S1 / #1274 S2 / #1275 S2-wire) findings.
- 3 correctness bugs + 3 production fragility + 2 docs/duplication cleanup + user feedback (budget defaults).
- 60 tests pass including 2 new regression suites (zip-order + budget-race).

## Why

- Multi-agent PR review surfaced issues the per-task Codex MCP audits missed (cross-file invariants).
- Critical: `zip(tasks, results, strict=False)` in Generator was data corruption — `SubAgentManager.delegate` returns completion-order, not submission-order.
- User feedback: BudgetGuard defaults too conservative for subscription paths (claude-cli, codex-cli ToS-aware) — tripping false-positive warnings on long-form generation.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_pipeline/agents/generator.py` | `task_id` dict lookup replaces positional zip; unmatched-result logged. Docstring "Wiring history" replaces stale "Known wiring gaps". |
| `core/agent/sub_agent_budget.py` | Hard-cap check moved inside lock (race fix). Defaults $0.50/$2.00 → $2.00/$10.00 (user feedback). |
| `plugins/seed_pipeline/orchestrator.py` | Cost rollup moved into `finally` so guard accounting survives every exception path. |
| `core/server/supervised/services.py` | `_build_agent_registry` anchors at `get_project_root() / ".claude/agents"`. INFO/WARNING logs on zero-discover and conflict. |
| `core/agent/loop/_context.py` | Override branch substitutes `{skill_context}` placeholder. |
| `core/agent/worker.py` | `filter_handlers` warns on whitelist→handler typo. |
| `plugins/seed_pipeline/agents/base.py` | `SeedAgentResult` docstring adds "why not reuse SubAgentResult" rationale. |
| `tests/plugins/seed_pipeline/test_generator_order_corruption.py` | 2 test — reverse-order pairing + unmatched result. |
| `tests/core/agent/test_budget_race.py` | 2 test — guard cost rolls into state on exception + BudgetExceeded paths. |
| `CHANGELOG.md` | Unreleased Fixed entries. |

## GAP Audit (PR Review + meta-reflection sub-agent)

| Finding | Source | Severity | Resolution |
|---|---|---|---|
| zip order corruption | PR #1274 review | HIGH | task_id dict + 2 regression tests |
| BudgetGuard hard-cap race | PR #1273 review | HIGH | hard_exceeded flag inside lock |
| Cost rollup loss on exception | PR #1273 review | MEDIUM (real bug) | rollup moved to `finally` + regression test |
| cwd-relative `.claude/agents` | PR #1275 review | HIGH (production) | `get_project_root()` anchor + INFO/WARNING |
| `{skill_context}` placeholder bypass | PR #1275 review | MEDIUM | both branches substitute |
| whitelist typo silent | PR #1275 review | MEDIUM | warn on unknown tools |
| stale "Known wiring gaps" docstring | alignment audit | LOW | rewrite as "Wiring history" with RESOLVED markers |
| SeedAgentResult duplication justification | alignment audit | LOW | explicit "why not reuse" docstring |
| Budget too conservative | user feedback | — | defaults relaxed (subscription path friendly) |

## Verification

- [x] ruff check / format — clean
- [x] mypy core/ plugins/ — Success: no issues found in 333 source files
- [x] pytest scope (S2-fix + S1/S2/S2-wire regression) — 60 pass
- [ ] CI 5/5 — 자동 dispatch
- [x] PR review (4 parallel agents, ~PR/agent)
- [x] Alignment audit vs petri_audit
- [x] Meta-reflection sub-agent — 7 prevention checklist items extracted

## Reference

- 4 PR reviews (in conversation)
- Alignment audit vs `plugins/petri_audit/`
- Meta-reflection: 7 root-cause patterns + 7 prevention checklist items
- Task #74 (this PR resolves)
- User feedback: budget conservatism + subscription path priority

다음 — Wiring Verification 룰 확장 검토 (prevention checklist 통합) + S3 (Reflection) 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)