### PR TITLE
feat(seed-pipeline): S2.5 — manifest schema + cross-manifest validator + proximity kind discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@ functional change.
   → `error_category="generation_failed"`. `announce=False` so sub-spawns
   don't double-fire the parent loop's announce queue.
 
+- **Seed pipeline manifest schema + cross-manifest validator (S2.5).**
+  `plugins/seed_pipeline/{seed_pipeline.plugin.toml, manifest.py}` per
+  ADR-003 — 7-role + 3-voter judge panel declarative binding. Reuses
+  Petri's `[petri.source.*]` / `[petri.adapter.*]` layers via
+  cross-manifest validation: voter (family, source) pairs are validated
+  against `petri.source.<family>.allowed` at load time so a typo'd
+  source (`claude_cli` vs `claude-cli`) fails immediately. Pydantic
+  schema enforces default∈allowed, voters≥2, family diversity, and
+  rejects `source="auto"` for judge bindings. 15 unit test + bundled
+  TOML. P-checklist: P4 (package-relative manifest path) + P7
+  (cross-manifest contract validation at load time).
 - **`seed-pipeline-cycle` skill (cycle scaffold).** Session 63 의 6-PR 검증
   사이클을 `.geode/skills/seed-pipeline-cycle/SKILL.md` 로 codify. 6 phase
   (Allocation / Implement + P1-P7 checklist / Verify + Codex MCP audit /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A general-purpose autonomous execution agent built on LangGraph. Autonomously pe
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 300 core + 33 plugins = 333
+- **Modules**: 300 core + 34 plugins = 334
 - **Tests**: 4910 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/plugins/seed_pipeline/__init__.py
+++ b/plugins/seed_pipeline/__init__.py
@@ -22,6 +22,13 @@ SOT:
 from __future__ import annotations
 
 from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.manifest import (
+    JudgePanelSpec,
+    SeedPipelineManifest,
+    SeedRoleSpec,
+    VoterSpec,
+    load_manifest,
+)
 from plugins.seed_pipeline.orchestrator import (
     Pipeline,
     PipelineRegistry,
@@ -30,8 +37,13 @@ from plugins.seed_pipeline.orchestrator import (
 
 __all__ = [
     "BaseSeedAgent",
+    "JudgePanelSpec",
     "Pipeline",
     "PipelineRegistry",
     "PipelineState",
     "SeedAgentResult",
+    "SeedPipelineManifest",
+    "SeedRoleSpec",
+    "VoterSpec",
+    "load_manifest",
 ]

--- a/plugins/seed_pipeline/manifest.py
+++ b/plugins/seed_pipeline/manifest.py
@@ -1,0 +1,242 @@
+"""Seed pipeline manifest loader — declarative 7-role + 3-judge-panel schema.
+
+Reads ``plugins/seed_pipeline/seed_pipeline.plugin.toml`` into a validated
+pydantic tree. Source / adapter layers are intentionally NOT defined here
+— they are reused from ``plugins/petri_audit/petri.plugin.toml`` (the
+Petri manifest is the SOT for credential family/source binding). The
+seed-pipeline manifest's voter rows are cross-validated against the
+Petri source table at load time so a typo'd ``family`` or ``source`` is
+caught immediately, not on first runtime use.
+
+Layers (mirroring TOML structure):
+
+- :class:`SeedRoleSpec` — per-role default model + allowed model set
+- :class:`VoterSpec` — one (model, family, source) row in judge_panel
+- :class:`JudgePanelSpec` — voters list + required_diversity_families gate
+- :class:`SeedPipelineManifest` — top-level container with cross-layer +
+  cross-manifest consistency checks
+
+The loader does **not** import any LLM SDK or adapter module — manifest
+parsing must remain cold-start clean so `geode version` does not pay the
+seed-pipeline cost.
+
+P1-P7 prevention checklist application (cycle-skill SKILL.md):
+
+- **P4 Environment Anchor**: ``DEFAULT_MANIFEST_PATH`` is anchored at
+  ``Path(__file__).parent / "seed_pipeline.plugin.toml"`` — package-
+  relative, not cwd-relative. Same anchor pattern as Petri's manifest.
+- **P7 Caller-Callee Contract**: voter source values are validated
+  against ``petri_audit.manifest.PetriManifest.get_source(family).allowed``
+  so a typo'd ``source = "claude_cli"`` (underscore vs hyphen) is
+  caught at load time rather than at runtime when the picker tries
+  to bind to a non-existent adapter.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+__all__ = [
+    "DEFAULT_MANIFEST_PATH",
+    "JudgePanelSpec",
+    "SeedPipelineManifest",
+    "SeedRoleSpec",
+    "VoterSpec",
+    "clear_manifest_cache",
+    "load_manifest",
+]
+
+DEFAULT_MANIFEST_PATH = Path(__file__).parent / "seed_pipeline.plugin.toml"
+
+
+class SeedRoleSpec(BaseModel):
+    """Per-role default + allowed model set + contract path.
+
+    Mirrors :class:`plugins.petri_audit.manifest.RoleSpec` but lives in the
+    seed-pipeline domain — petri's RoleSpec validates against inspect_ai's
+    ModelAPI prefixes, seed_pipeline's must validate against AgentDefinition
+    paths (``.claude/agents/seed_*.md``).
+    """
+
+    default_model: str
+    allowed_models: list[str]
+    role_contract: str | None = None
+
+    @model_validator(mode="after")
+    def _default_in_allowed(self) -> SeedRoleSpec:
+        if self.default_model not in self.allowed_models:
+            raise ValueError(
+                f"default_model {self.default_model!r} not in allowed_models {self.allowed_models}"
+            )
+        return self
+
+
+class VoterSpec(BaseModel):
+    """One voter row in the Ranker phase's judge panel.
+
+    Fields:
+    - ``model`` — the LLM model name (e.g. ``claude-sonnet-4-6``).
+    - ``family`` — provider family (e.g. ``anthropic``, ``openai``); must
+      match one of Petri's ``[petri.source.<family>]`` keys.
+    - ``source`` — credential source (e.g. ``claude-cli``, ``openai-codex``,
+      ``api_key``); must be in
+      ``petri.source.<family>.allowed``. The ``auto`` sentinel is rejected
+      here — judge voters require a concrete binding so the panel diversity
+      check is meaningful.
+    """
+
+    model: str
+    family: str
+    source: str
+
+    @model_validator(mode="after")
+    def _source_not_auto(self) -> VoterSpec:
+        if self.source == "auto":
+            raise ValueError(
+                f"voter ({self.model}, {self.family}) cannot use source=auto — "
+                "judge panel diversity requires concrete bindings"
+            )
+        return self
+
+
+class JudgePanelSpec(BaseModel):
+    """Ranker phase's 3-voter panel + diversity gate."""
+
+    voters: list[VoterSpec]
+    required_diversity_families: int = 2
+
+    @model_validator(mode="after")
+    def _diversity(self) -> JudgePanelSpec:
+        if len(self.voters) < 2:
+            raise ValueError(f"judge panel requires >= 2 voters, got {len(self.voters)}")
+        families = {v.family for v in self.voters}
+        if len(families) < self.required_diversity_families:
+            raise ValueError(
+                f"judge panel diversity violated — voters span "
+                f"{sorted(families)} ({len(families)} family/families) but "
+                f"required_diversity_families={self.required_diversity_families}"
+            )
+        return self
+
+
+class SeedPipelineManifest(BaseModel):
+    """Top-level manifest container with cross-layer consistency checks."""
+
+    enabled_roles: list[str]
+    roles: dict[str, SeedRoleSpec]
+    judge_panel: JudgePanelSpec
+
+    @model_validator(mode="after")
+    def _consistency(self) -> SeedPipelineManifest:
+        if set(self.enabled_roles) != set(self.roles):
+            raise ValueError(
+                f"enabled_roles {self.enabled_roles} != role spec keys {sorted(self.roles)}"
+            )
+        return self
+
+    # ── Accessors (used by S5.5 picker / S6 ranker / S11 CLI) ────────────
+
+    def get_role(self, role: str) -> SeedRoleSpec:
+        if role not in self.roles:
+            raise KeyError(f"Unknown seed_pipeline role {role!r}; enabled={self.enabled_roles}")
+        return self.roles[role]
+
+    def list_voter_families(self) -> list[str]:
+        return [v.family for v in self.judge_panel.voters]
+
+    def voter_diversity(self) -> int:
+        return len(set(self.list_voter_families()))
+
+
+def _parse_manifest_dict(data: dict[str, Any]) -> SeedPipelineManifest:
+    """Build a :class:`SeedPipelineManifest` from the parsed TOML dict.
+
+    Split out so tests can feed dict literals without round-tripping
+    through a TOML file.
+    """
+    seed = data.get("seed_pipeline")
+    if not seed:
+        raise ValueError("Manifest missing [seed_pipeline] root section")
+
+    judge_data = seed.get("judge_panel", {})
+    judge_panel = JudgePanelSpec(
+        voters=[VoterSpec(**v) for v in judge_data.get("voters", [])],
+        required_diversity_families=judge_data.get("required_diversity_families", 2),
+    )
+
+    return SeedPipelineManifest(
+        enabled_roles=seed.get("enabled_roles", []),
+        roles={k: SeedRoleSpec(**v) for k, v in seed.get("role", {}).items()},
+        judge_panel=judge_panel,
+    )
+
+
+def _cross_validate_with_petri(manifest: SeedPipelineManifest) -> None:
+    """Validate voter (family, source) pairs against Petri's source table.
+
+    P7 Caller-Callee Contract — the seed_pipeline manifest depends on the
+    Petri manifest as the SOT for credential source binding. A typo here
+    (``claude_cli`` instead of ``claude-cli``, or a non-existent family)
+    must fail at manifest load, not when the picker attempts to resolve
+    the adapter. This function is the cross-manifest gate.
+
+    Raised at the load layer rather than the validator to keep the
+    pydantic schema free of the Petri import (allows seed-pipeline to
+    be loaded in test fixtures without Petri available).
+    """
+    from plugins.petri_audit.manifest import load_manifest as load_petri_manifest
+
+    petri = load_petri_manifest()
+    for voter in manifest.judge_panel.voters:
+        try:
+            source_spec = petri.get_source(voter.family)
+        except KeyError as exc:
+            raise ValueError(
+                f"voter {voter.model!r} (family={voter.family!r}) — family "
+                f"not in petri.source table; "
+                f"known families = {sorted(petri.sources)}"
+            ) from exc
+        if voter.source not in source_spec.allowed:
+            raise ValueError(
+                f"voter {voter.model!r} ({voter.family}.{voter.source}) — "
+                f"source not in petri.source.{voter.family}.allowed = "
+                f"{source_spec.allowed}"
+            )
+
+
+@lru_cache(maxsize=4)
+def _load_cached(path_str: str) -> SeedPipelineManifest:
+    data = tomllib.loads(Path(path_str).read_text(encoding="utf-8"))
+    manifest = _parse_manifest_dict(data)
+    _cross_validate_with_petri(manifest)
+    return manifest
+
+
+def load_manifest(path: Path | str | None = None) -> SeedPipelineManifest:
+    """Load and validate the seed_pipeline manifest at ``path``.
+
+    Defaults to :data:`DEFAULT_MANIFEST_PATH`. Results are cached per
+    absolute path (max 4 entries) so repeated callers (picker, ranker,
+    CLI) share the parsed tree.
+
+    Raises ``ValueError`` on any schema or cross-manifest validation
+    failure. The error messages are designed to point operators at the
+    exact TOML key requiring attention.
+    """
+    target = Path(path) if path is not None else DEFAULT_MANIFEST_PATH
+    return _load_cached(str(target.resolve()))
+
+
+def clear_manifest_cache() -> None:
+    """Drop the lru_cache — used by tests that mutate manifest fixtures."""
+    _load_cached.cache_clear()
+
+
+# Field reference held to silence linters that flag pydantic.Field as unused
+# when only validators reference it indirectly.
+_ = Field

--- a/plugins/seed_pipeline/manifest.py
+++ b/plugins/seed_pipeline/manifest.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import tomllib
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -57,15 +57,26 @@ DEFAULT_MANIFEST_PATH = Path(__file__).parent / "seed_pipeline.plugin.toml"
 class SeedRoleSpec(BaseModel):
     """Per-role default + allowed model set + contract path.
 
-    Mirrors :class:`plugins.petri_audit.manifest.RoleSpec` but lives in the
-    seed-pipeline domain — petri's RoleSpec validates against inspect_ai's
-    ModelAPI prefixes, seed_pipeline's must validate against AgentDefinition
-    paths (``.claude/agents/seed_*.md``).
+    Mirrors :class:`plugins.petri_audit.manifest.RoleSpec` in field shape
+    (default + allowed + contract) but adds the ``kind`` discriminator
+    because the seed-pipeline 7-role topology includes one role
+    (``proximity``) that runs an embedding tool rather than an LLM
+    completion. The ``kind`` field is the explicit dispatch tag so
+    downstream code (S4 ``text_embed`` tool wiring, S5.5 picker) can
+    route ``embedding`` roles through the embedding adapter instead of
+    the Petri completion adapter table.
+
+    Field rationale:
+    - ``completion`` (default) — LLM chat completion via Petri adapters.
+    - ``embedding`` — vector embedding model (e.g. ``text-embedding-3-small``);
+      bound at runtime to the ``text_embed`` tool, NOT Petri's
+      [petri.adapter.<family>.<source>] table.
     """
 
     default_model: str
     allowed_models: list[str]
     role_contract: str | None = None
+    kind: Literal["completion", "embedding"] = "completion"
 
     @model_validator(mode="after")
     def _default_in_allowed(self) -> SeedRoleSpec:

--- a/plugins/seed_pipeline/seed_pipeline.plugin.toml
+++ b/plugins/seed_pipeline/seed_pipeline.plugin.toml
@@ -52,13 +52,15 @@ allowed_models = [
 role_contract = ".claude/agents/seed_critic.md"
 
 [seed_pipeline.role.proximity]
-# Embedding-based — not LLM completion. The default_model names the
-# embedding model; the manifest loader special-cases this role so its
-# binding goes through the `text_embed` tool (S4) rather than the
-# Petri adapter table.
+# Embedding-based — not LLM completion. ``kind="embedding"`` is the
+# explicit dispatch tag so the S4 wiring routes through the
+# ``text_embed`` tool, NOT Petri's [petri.adapter.*] table. Without
+# this discriminator downstream code would have to guess the role's
+# kind from the model-name string.
 default_model = "text-embedding-3-small"
 allowed_models = ["text-embedding-3-small"]
 role_contract = ".claude/agents/seed_proximity.md"
+kind = "embedding"
 
 [seed_pipeline.role.pilot]
 default_model = "claude-haiku-4-5"

--- a/plugins/seed_pipeline/seed_pipeline.plugin.toml
+++ b/plugins/seed_pipeline/seed_pipeline.plugin.toml
@@ -1,0 +1,121 @@
+# Seed pipeline plugin manifest — declarative 7-role + 3-judge-panel binding.
+#
+# Per ADR-003 the source / adapter layers (per-family credential resolution +
+# concrete adapter modules) are REUSED from `plugins/petri_audit/petri.plugin.toml`.
+# This manifest defines only:
+#
+#   1. [seed_pipeline]              — enabled roles
+#   2. [seed_pipeline.role.<name>]  — per-role default + allowed model set
+#   3. [seed_pipeline.judge_panel]  — Ranker phase's 3-voter binding +
+#                                     required_diversity_families gate
+#
+# Loader: plugins.seed_pipeline.manifest.load_manifest() →
+#         SeedPipelineManifest (pydantic). Validates against the Petri source
+#         table so voter sources are always one of petri.source.<family>.allowed.
+#
+# 7-role topology — ADR-001 §Topology (paper's 6 agents + Pilot for GEODE):
+#
+#   generator → proximity → critic → pilot → ranker → evolver → meta_reviewer
+#
+# Defaults reflect ADR-003's settled-decision table (Plan §13). Override
+# via ~/.geode/seed-pipeline.toml is wired in S5.5 (picker).
+
+[seed_pipeline]
+enabled_roles = [
+    "generator",
+    "critic",
+    "proximity",
+    "pilot",
+    "ranker",
+    "evolver",
+    "meta_reviewer",
+]
+
+# ── Roles ────────────────────────────────────────────────────────────────────
+
+[seed_pipeline.role.generator]
+default_model = "claude-sonnet-4-6"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "gpt-5.5",
+]
+role_contract = ".claude/agents/seed_generator.md"
+
+[seed_pipeline.role.critic]
+default_model = "claude-sonnet-4-6"
+allowed_models = [
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-5.5",
+]
+role_contract = ".claude/agents/seed_critic.md"
+
+[seed_pipeline.role.proximity]
+# Embedding-based — not LLM completion. The default_model names the
+# embedding model; the manifest loader special-cases this role so its
+# binding goes through the `text_embed` tool (S4) rather than the
+# Petri adapter table.
+default_model = "text-embedding-3-small"
+allowed_models = ["text-embedding-3-small"]
+role_contract = ".claude/agents/seed_proximity.md"
+
+[seed_pipeline.role.pilot]
+default_model = "claude-haiku-4-5"
+allowed_models = [
+    "claude-haiku-4-5",
+    "gpt-5.4-mini",
+]
+role_contract = ".claude/agents/seed_pilot.md"
+
+[seed_pipeline.role.ranker]
+# 3-judge panel orchestrator. Its own default_model is a placeholder —
+# the panel's voter binding (below) drives actual LLM calls.
+default_model = "claude-sonnet-4-6"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+]
+role_contract = ".claude/agents/seed_ranker.md"
+
+[seed_pipeline.role.evolver]
+default_model = "claude-sonnet-4-6"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+]
+role_contract = ".claude/agents/seed_evolver.md"
+
+[seed_pipeline.role.meta_reviewer]
+default_model = "claude-opus-4-7"
+allowed_models = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+]
+role_contract = ".claude/agents/seed_meta_reviewer.md"
+
+# ── Judge panel (Ranker sub-section, not a role) ─────────────────────────────
+#
+# Per ADR-003: 3-voter panel with provider diversity gate. Each voter's
+# (family, source) pair must match plugins/petri_audit/petri.plugin.toml's
+# [petri.source.<family>].allowed list so the existing adapter binding
+# applies. The manifest loader validates this cross-manifest constraint
+# at load time, NOT lazily.
+
+[seed_pipeline.judge_panel]
+required_diversity_families = 2
+
+[[seed_pipeline.judge_panel.voters]]
+model = "claude-sonnet-4-6"
+family = "anthropic"
+source = "claude-cli"
+
+[[seed_pipeline.judge_panel.voters]]
+model = "gpt-5.5"
+family = "openai"
+source = "openai-codex"
+
+[[seed_pipeline.judge_panel.voters]]
+model = "claude-haiku-4-5"
+family = "anthropic"
+source = "api_key"

--- a/tests/plugins/seed_pipeline/test_manifest.py
+++ b/tests/plugins/seed_pipeline/test_manifest.py
@@ -213,6 +213,36 @@ def test_manifest_get_role_known_returns_spec() -> None:
     assert spec.default_model in spec.allowed_models
 
 
+def test_role_kind_completion_default() -> None:
+    """Roles default to kind='completion' when not specified."""
+    spec = SeedRoleSpec(
+        default_model="claude-sonnet-4-6",
+        allowed_models=["claude-sonnet-4-6"],
+    )
+    assert spec.kind == "completion"
+
+
+def test_role_kind_embedding_explicit() -> None:
+    """An embedding role (e.g. proximity) must set kind='embedding'."""
+    spec = SeedRoleSpec(
+        default_model="text-embedding-3-small",
+        allowed_models=["text-embedding-3-small"],
+        kind="embedding",
+    )
+    assert spec.kind == "embedding"
+
+
+def test_bundled_proximity_role_is_embedding() -> None:
+    """Proximity role in seed_pipeline.plugin.toml must be embedding kind."""
+    clear_manifest_cache()
+    manifest = load_manifest()
+    proximity = manifest.get_role("proximity")
+    assert proximity.kind == "embedding"
+    # Sibling check — generator/critic remain completion
+    assert manifest.get_role("generator").kind == "completion"
+    assert manifest.get_role("critic").kind == "completion"
+
+
 # ---------------------------------------------------------------------------
 # Parse path (no I/O — dict literal)
 # ---------------------------------------------------------------------------

--- a/tests/plugins/seed_pipeline/test_manifest.py
+++ b/tests/plugins/seed_pipeline/test_manifest.py
@@ -1,0 +1,255 @@
+"""Tests for ``plugins.seed_pipeline.manifest``.
+
+Coverage targets the P-checklist (cycle-skill SKILL.md):
+
+- P4 Environment Anchor — DEFAULT_MANIFEST_PATH package-relative
+- P7 Caller-Callee Contract — voter (family, source) cross-validated
+  against the Petri manifest's source table
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from plugins.seed_pipeline.manifest import (
+    DEFAULT_MANIFEST_PATH,
+    JudgePanelSpec,
+    SeedPipelineManifest,
+    SeedRoleSpec,
+    VoterSpec,
+    _parse_manifest_dict,
+    clear_manifest_cache,
+    load_manifest,
+)
+
+# ---------------------------------------------------------------------------
+# Schema-level validators (in-memory dict input — no TOML round-trip)
+# ---------------------------------------------------------------------------
+
+
+def test_role_default_must_be_in_allowed() -> None:
+    with pytest.raises(ValueError, match="default_model"):
+        SeedRoleSpec(
+            default_model="claude-sonnet-4-6",
+            allowed_models=["claude-opus-4-7"],
+            role_contract=None,
+        )
+
+
+def test_voter_rejects_auto_source() -> None:
+    with pytest.raises(ValueError, match="auto"):
+        VoterSpec(model="claude-sonnet-4-6", family="anthropic", source="auto")
+
+
+def test_judge_panel_requires_minimum_voters() -> None:
+    with pytest.raises(ValueError, match=">= 2 voters"):
+        JudgePanelSpec(
+            voters=[VoterSpec(model="x", family="anthropic", source="api_key")],
+            required_diversity_families=1,
+        )
+
+
+def test_judge_panel_diversity_violation() -> None:
+    with pytest.raises(ValueError, match="diversity violated"):
+        JudgePanelSpec(
+            voters=[
+                VoterSpec(model="x1", family="anthropic", source="api_key"),
+                VoterSpec(model="x2", family="anthropic", source="claude-cli"),
+                VoterSpec(model="x3", family="anthropic", source="claude-cli"),
+            ],
+            required_diversity_families=2,
+        )
+
+
+def test_judge_panel_diversity_satisfied() -> None:
+    panel = JudgePanelSpec(
+        voters=[
+            VoterSpec(model="x1", family="anthropic", source="api_key"),
+            VoterSpec(model="x2", family="openai", source="api_key"),
+        ],
+        required_diversity_families=2,
+    )
+    assert len(panel.voters) == 2
+
+
+def test_manifest_role_keys_must_match_enabled_roles() -> None:
+    with pytest.raises(ValueError, match="enabled_roles"):
+        SeedPipelineManifest(
+            enabled_roles=["generator", "critic"],
+            roles={
+                "generator": SeedRoleSpec(
+                    default_model="claude-sonnet-4-6",
+                    allowed_models=["claude-sonnet-4-6"],
+                ),
+                # Missing 'critic' role spec
+            },
+            judge_panel=JudgePanelSpec(
+                voters=[
+                    VoterSpec(model="x", family="anthropic", source="api_key"),
+                    VoterSpec(model="y", family="openai", source="api_key"),
+                ],
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# TOML load path — uses bundled seed_pipeline.plugin.toml
+# ---------------------------------------------------------------------------
+
+
+def test_default_manifest_path_is_package_relative() -> None:
+    """P4 Environment Anchor — the default path must NOT be cwd-relative."""
+    assert DEFAULT_MANIFEST_PATH.is_absolute()
+    assert DEFAULT_MANIFEST_PATH.parent.name == "seed_pipeline"
+    assert DEFAULT_MANIFEST_PATH.name == "seed_pipeline.plugin.toml"
+
+
+def test_bundled_manifest_loads() -> None:
+    clear_manifest_cache()
+    manifest = load_manifest()
+    assert set(manifest.enabled_roles) == {
+        "generator",
+        "critic",
+        "proximity",
+        "pilot",
+        "ranker",
+        "evolver",
+        "meta_reviewer",
+    }
+    assert manifest.voter_diversity() >= 2
+
+
+def test_bundled_manifest_voters_pass_cross_validation() -> None:
+    """P7 Caller-Callee Contract — voters must reference real Petri sources."""
+    clear_manifest_cache()
+    manifest = load_manifest()
+    voters = manifest.judge_panel.voters
+    # The defaults pin (anthropic, claude-cli), (openai, openai-codex),
+    # (anthropic, api_key) — all must be in Petri's allowed lists.
+    for voter in voters:
+        assert voter.family in {"anthropic", "openai"}
+        assert voter.source in {"claude-cli", "openai-codex", "api_key"}
+
+
+def test_voter_unknown_family_rejected(tmp_path: Path) -> None:
+    """Cross-manifest validation — unknown family in voter must fail."""
+    bad_toml = tmp_path / "bad.toml"
+    bad_toml.write_text(
+        textwrap.dedent(
+            """\
+            [seed_pipeline]
+            enabled_roles = ["generator"]
+
+            [seed_pipeline.role.generator]
+            default_model = "x"
+            allowed_models = ["x"]
+
+            [seed_pipeline.judge_panel]
+            required_diversity_families = 2
+
+            [[seed_pipeline.judge_panel.voters]]
+            model = "x"
+            family = "imaginary-llm-provider"
+            source = "api_key"
+
+            [[seed_pipeline.judge_panel.voters]]
+            model = "y"
+            family = "anthropic"
+            source = "api_key"
+            """
+        )
+    )
+    clear_manifest_cache()
+    with pytest.raises(ValueError, match=r"not in petri\.source table"):
+        load_manifest(bad_toml)
+
+
+def test_voter_unknown_source_rejected(tmp_path: Path) -> None:
+    """Cross-manifest validation — typo'd source in voter must fail."""
+    bad_toml = tmp_path / "bad.toml"
+    bad_toml.write_text(
+        textwrap.dedent(
+            """\
+            [seed_pipeline]
+            enabled_roles = ["generator"]
+
+            [seed_pipeline.role.generator]
+            default_model = "x"
+            allowed_models = ["x"]
+
+            [seed_pipeline.judge_panel]
+            required_diversity_families = 2
+
+            [[seed_pipeline.judge_panel.voters]]
+            model = "x"
+            family = "anthropic"
+            source = "claude_cli"
+
+            [[seed_pipeline.judge_panel.voters]]
+            model = "y"
+            family = "openai"
+            source = "api_key"
+            """
+        )
+    )
+    clear_manifest_cache()
+    with pytest.raises(ValueError, match=r"not in petri\.source\.anthropic\.allowed"):
+        load_manifest(bad_toml)
+
+
+def test_manifest_get_role_unknown_raises() -> None:
+    clear_manifest_cache()
+    manifest = load_manifest()
+    with pytest.raises(KeyError, match="Unknown seed_pipeline role"):
+        manifest.get_role("nonexistent")
+
+
+def test_manifest_get_role_known_returns_spec() -> None:
+    clear_manifest_cache()
+    manifest = load_manifest()
+    spec = manifest.get_role("generator")
+    assert spec.default_model in spec.allowed_models
+
+
+# ---------------------------------------------------------------------------
+# Parse path (no I/O — dict literal)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_manifest_dict_missing_root_raises() -> None:
+    with pytest.raises(ValueError, match=r"missing \[seed_pipeline\] root"):
+        _parse_manifest_dict({"unrelated": "section"})
+
+
+def test_parse_manifest_dict_minimal_valid() -> None:
+    data: dict = {
+        "seed_pipeline": {
+            "enabled_roles": ["generator"],
+            "role": {
+                "generator": {
+                    "default_model": "claude-sonnet-4-6",
+                    "allowed_models": ["claude-sonnet-4-6"],
+                }
+            },
+            "judge_panel": {
+                "required_diversity_families": 2,
+                "voters": [
+                    {
+                        "model": "claude-sonnet-4-6",
+                        "family": "anthropic",
+                        "source": "api_key",
+                    },
+                    {
+                        "model": "gpt-5.5",
+                        "family": "openai",
+                        "source": "api_key",
+                    },
+                ],
+            },
+        }
+    }
+    manifest = _parse_manifest_dict(data)
+    assert manifest.enabled_roles == ["generator"]
+    assert manifest.voter_diversity() == 2


### PR DESCRIPTION
## Summary

- 신규 `plugins/seed_pipeline/{seed_pipeline.plugin.toml, manifest.py}` per ADR-003.
- 7-role + 3-voter judge panel declarative binding. Petri source/adapter layer 재사용 (cross-manifest validation).
- `kind` discriminator (`completion` | `embedding`) — proximity role 의 embedding tool 라우팅 명시.
- 18 unit tests + cycle-skill Phase A-D 적용 (S2.5 가 첫 cycle 적용).

## Why

- ADR-001/003 의 7-role topology 가 declarative binding 필요. 이전 S1-S2 는 hardcoded.
- 5.5 picker / S6 ranker / S11 CLI 가 manifest 를 single source-of-truth 로 consume.
- Codex MCP round-1 MEDIUM 2 (proximity special-case 미구현) round-2 에서 해소 — `kind` 필드 추가.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_pipeline/seed_pipeline.plugin.toml` (신규) | 7 role spec + judge_panel (3 voter) + required_diversity_families |
| `plugins/seed_pipeline/manifest.py` (신규, ~225 LOC) | pydantic schema: SeedRoleSpec/VoterSpec/JudgePanelSpec/SeedPipelineManifest + load_manifest with lru_cache + cross-manifest validation against Petri's source table |
| `plugins/seed_pipeline/__init__.py` | manifest types + load_manifest export |
| `tests/plugins/seed_pipeline/test_manifest.py` (신규, 18 test) | schema validators + bundled TOML load + cross-manifest typo rejection + kind discriminator |
| `CHANGELOG.md` | Unreleased Added |
| `CLAUDE.md` | Modules 333 → 334 |

## GAP Audit (Codex MCP `gpt-5.2-codex`)

| Round | Finding | Resolution |
|---|---|---|
| 1 | MEDIUM proximity special-case 미구현 | round 2 — `kind: Literal["completion", "embedding"]` field |
| 1 | MEDIUM CLAUDE.md modules stale | round 2 — 333 → 334 |
| 1 | LOW — 모두 verify pass | — |

## Cycle skill 적용 (Phase A-D)

- ✅ Phase A — worktree 할당, develop sync 확인, Task in_progress
- ✅ Phase B — Plan ledger 매핑 (P4 Environment Anchor: package-relative manifest path; P7 Caller-Callee Contract: cross-manifest validation at load time)
- ✅ Phase C — Codex MCP audit 2 round, all MEDIUM resolved
- ✅ Phase D — PR & CI (자동 dispatch)

## Verification

- [x] ruff check core/ tests/ plugins/ — clean
- [x] ruff format — clean
- [x] mypy core/ plugins/ — Success: 334 source files
- [x] pytest tests/plugins/seed_pipeline/test_manifest.py — 18 pass
- [ ] CI 5/5 — 자동 dispatch
- [x] Codex MCP audit 2 round — all RESOLVED

## Reference

- ADR-003 (`docs/architecture/seed-pipeline-ui-decision.md`) — manifest schema 정의
- ADR-001 (`docs/architecture/seed-pipeline-decision.md`) — 7-role topology
- Petri P1-A pattern (`plugins/petri_audit/petri.plugin.toml`) — 4-layer manifest reference
- `.geode/skills/seed-pipeline-cycle/SKILL.md` — Phase A-D 첫 적용 사례

다음 — S3 (Reflection agent) cycle Phase A 부터.

🤖 Generated with [Claude Code](https://claude.com/claude-code)