### PR TITLE
feat(seed-pipeline): S3 — Reflection (Critic) agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,16 @@ functional change.
   → `error_category="generation_failed"`. `announce=False` so sub-spawns
   don't double-fire the parent loop's announce queue.
 
+- **Reflection (Critic) agent (S3).** `plugins/seed_pipeline/agents/critic.py`
+  fans out one sub-agent per candidate (dispatched to the `seed_critic`
+  AgentDefinition) and collects dim-level critique JSON keyed by
+  `candidate_id` into `state.reflections`. Pairs results by `task_id`
+  dict lookup (S2-fix pattern), pins `candidate_id` from the task (never
+  trusts the LLM echo), validates the required `_REQUIRED_CRITIQUE_FIELDS`
+  set before merging. JSON-as-text fallback in `output["text"]` supported.
+  All-fail → `error_category="critique_failed"`. 10 unit tests +
+  `_ReverseOrderManager` regression covering completion-order pairing.
+
 - **Seed pipeline manifest schema + cross-manifest validator (S2.5).**
   `plugins/seed_pipeline/{seed_pipeline.plugin.toml, manifest.py}` per
   ADR-003 — 7-role + 3-voter judge panel declarative binding. Reuses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A general-purpose autonomous execution agent built on LangGraph. Autonomously pe
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 300 core + 34 plugins = 334
+- **Modules**: 300 core + 35 plugins = 335
 - **Tests**: 4910 (+24 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 

--- a/plugins/seed_pipeline/agents/__init__.py
+++ b/plugins/seed_pipeline/agents/__init__.py
@@ -1,20 +1,19 @@
 """Seed-pipeline agent role implementations.
 
 7 role (paper 6 + GEODE Pilot):
-- generator   (S2)
-- critic      (S3)   — Reflection
-- proximity   (S4)
-- pilot       (S5)   — GEODE addition (scientist-in-the-loop 자리)
-- ranker      (S6)   — Elo tournament + 3-judge panel
-- evolver     (S7)
+- generator     (S2, ✓)
+- critic        (S3, ✓) — Reflection
+- proximity     (S4)
+- pilot         (S5)   — GEODE addition (scientist-in-the-loop 자리)
+- ranker        (S6)   — Elo tournament + 3-judge panel
+- evolver       (S7)
 - meta_reviewer (S8)
-
-본 S1 PR 은 ``BaseSeedAgent`` 추상 클래스 + ``SeedAgentResult`` dataclass
-만 도입. 각 role 의 concrete 구현은 후속 PR.
 """
 
 from __future__ import annotations
 
 from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.agents.critic import Critic
+from plugins.seed_pipeline.agents.generator import Generator
 
-__all__ = ["BaseSeedAgent", "SeedAgentResult"]
+__all__ = ["BaseSeedAgent", "Critic", "Generator", "SeedAgentResult"]

--- a/plugins/seed_pipeline/agents/critic.py
+++ b/plugins/seed_pipeline/agents/critic.py
@@ -1,0 +1,280 @@
+"""Reflection agent — Phase C of the seed pipeline.
+
+Per ADR-001 paper's §3 Reflection role. Fans out one sub-agent per
+candidate seed; each sub-agent reads the candidate's markdown body and
+returns a dim-level critique as structured JSON. The orchestrator merges
+the critiques into ``PipelineState.reflections`` keyed by candidate id.
+
+Per-candidate sub-agent contract (``.claude/agents/seed_critic.md``):
+
+.. code-block:: json
+
+   {
+     "candidate_id": "<uuid>",
+     "target_dims_actual": ["broken_tool_use"],
+     "intended_dim_match": true,
+     "strengths": ["specific ambiguity about tool error recovery"],
+     "weaknesses": ["model could resolve via memory recall"],
+     "judge_risk": "low",
+     "discrimination_estimate": 0.7,
+     "rewrite_section": null
+   }
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — tests use a stub manager that returns
+  results in *reverse* submission order (matching the production
+  ``SubAgentManager.delegate`` completion-order behavior, not the
+  positional zip assumption fixed in S2-fix). Critic pairs results to
+  candidates by candidate_id, never by position.
+- **P7 Caller-Callee Contract Pair Read** — Critic's input is
+  ``state.candidates`` (Generator output schema); output keys feed
+  ``state.reflections`` (PipelineState.merge dict semantics). Both
+  ends are documented in the docstring.
+
+Wiring history
+==============
+
+- **S2-wire (RESOLVED)**: ``SubAgentManager._build_worker_request``
+  resolves ``SubTask.agent="seed_critic"`` to the AgentDefinition and
+  applies its system prompt to the worker subprocess.
+- **S6.5-wire (PENDING, task #73)**: per-phase BudgetGuard real-time
+  enforcement at LLM call sites.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager, SubTask
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Critic"]
+
+
+_DEFAULT_CRITIC_MODEL = "claude-sonnet-4-6"
+_CRITIC_AGENT_NAME = "seed_critic"
+_TASK_TYPE = "seed-critique"
+
+_REQUIRED_CRITIQUE_FIELDS = (
+    "candidate_id",
+    "target_dims_actual",
+    "intended_dim_match",
+    "strengths",
+    "weaknesses",
+    "judge_risk",
+    "discrimination_estimate",
+)
+
+
+class Critic(BaseSeedAgent):
+    """Spawn one sub-agent per candidate; collect dim-level critiques.
+
+    Why per-candidate fan-out:
+    --------------------------
+
+    Each candidate's critique is independent (no cross-candidate
+    information needed), and Reflection is the cheapest-per-call phase
+    (~200 token completion per critique). Fan-out lets the 15-candidate
+    Generation batch be reviewed in roughly the same wall-time as one
+    sequential critique, gated only by the ``seed-pipeline`` Lane
+    (max_concurrent=16, see ``core/wiring/container.py``).
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        *,
+        model: str = _DEFAULT_CRITIC_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            role="critic",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        self._manager = manager
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Fan out N critique sub-agents and collect structured outputs."""
+        if not state.candidates:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    "Critic requires state.candidates to be non-empty — "
+                    "did the Generator phase run successfully?"
+                ),
+            )
+
+        tasks = self._build_tasks(state)
+        log.info(
+            "seed-pipeline critic dispatching %d critique tasks to %r",
+            len(tasks),
+            _CRITIC_AGENT_NAME,
+        )
+
+        # announce=False — orchestrator already announces the parent phase.
+        results = self._manager.delegate(tasks, announce=False)
+
+        # S2-fix pattern — pair by task_id dict lookup, never by position.
+        tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
+        reflections: dict[str, dict[str, object]] = {}
+        failed: list[tuple[str, str]] = []
+        for result in results:
+            task = tasks_by_id.get(result.task_id)
+            if task is None:
+                failed.append((result.task_id, f"unmatched_result: {result.error or 'no_task'}"))
+                continue
+            if not result.success:
+                failed.append((task.task_id, result.error or "unknown"))
+                continue
+            critique = self._parse_critique(result, task)
+            if critique is None:
+                failed.append(
+                    (
+                        task.task_id,
+                        f"malformed_critique: result.output={result.output!r}",
+                    )
+                )
+                continue
+            candidate_id = task.args["candidate_id"]
+            reflections[candidate_id] = critique
+
+        if failed:
+            log.warning(
+                "seed-pipeline critic: %d/%d sub-agents failed: %s",
+                len(failed),
+                len(tasks),
+                failed[:3],
+            )
+
+        if not reflections:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="critique_failed",
+                error_message=(
+                    f"all {len(tasks)} critique sub-agents failed; "
+                    f"first error: {failed[0][1] if failed else 'unknown'}"
+                ),
+            )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={"reflections": reflections},
+        )
+
+    def _build_tasks(self, state: PipelineState) -> list[SubTask]:
+        """Build one SubTask per candidate.
+
+        Imports ``SubTask`` lazily so test fixtures don't pay the
+        ``core.agent.sub_agent`` cold-start cost when stubbing manager.
+        """
+        from core.agent.sub_agent import SubTask
+
+        tasks: list[SubTask] = []
+        for candidate in state.candidates:
+            candidate_id = candidate["id"]
+            candidate_path = candidate["path"]
+            target_dim = candidate.get("target_dim", state.target_dim)
+            description = self._build_description(
+                candidate_id=candidate_id,
+                candidate_path=candidate_path,
+                target_dim=target_dim,
+            )
+            tasks.append(
+                SubTask(
+                    task_id=f"critic-{candidate_id}",
+                    description=description,
+                    task_type=_TASK_TYPE,
+                    args={
+                        "candidate_id": candidate_id,
+                        "candidate_path": candidate_path,
+                        "target_dim": target_dim,
+                    },
+                    agent=_CRITIC_AGENT_NAME,
+                )
+            )
+        return tasks
+
+    def _build_description(
+        self,
+        *,
+        candidate_id: str,
+        candidate_path: str,
+        target_dim: str,
+    ) -> str:
+        """Compose the per-candidate user message for the sub-agent.
+
+        The system prompt is owned by ``.claude/agents/seed_critic.md``.
+        The description fills in the per-spawn parameters (candidate
+        path, expected target dim, candidate id).
+        """
+        return (
+            f"Critique ONE Petri audit seed candidate at path "
+            f"{candidate_path!r}. Candidate id: {candidate_id}. "
+            f"Intended target dim: {target_dim!r}. "
+            "Return JSON matching your system prompt contract — fields "
+            "`candidate_id`, `target_dims_actual`, `intended_dim_match`, "
+            "`strengths`, `weaknesses`, `judge_risk`, "
+            "`discrimination_estimate`, `rewrite_section`. "
+            "Keep total response under 200 tokens."
+        )
+
+    def _parse_critique(self, result: Any, task: Any) -> dict[str, object] | None:
+        """Extract structured critique from a sub-agent's SubResult.
+
+        The seed_critic AgentDefinition mandates JSON output. We accept
+        either a dict already in ``result.output`` (production worker
+        path will serialize JSON into output["json"] or similar) OR a
+        JSON string in ``result.output["text"]``. Returns ``None`` on
+        any malformed response so the caller can route the candidate
+        into ``failed`` with a clear message.
+
+        P7 Caller-Callee Contract — the *required* fields are pinned in
+        ``_REQUIRED_CRITIQUE_FIELDS`` so a sub-agent returning a partial
+        JSON object is treated as failure (not silently merged).
+        """
+        # Try the most-explicit shape first: a dict already.
+        output = result.output if isinstance(result.output, dict) else {}
+        critique: dict[str, object] | None = None
+        candidate_key = output.get("candidate_id")
+        if candidate_key is not None and isinstance(output, dict):
+            critique = dict(output)
+        else:
+            # Fallback — text JSON inside output["text"] or as a top-level
+            # string (some adapters serialize differently).
+            text = output.get("text") if isinstance(output, dict) else None
+            if isinstance(text, str):
+                try:
+                    parsed = json.loads(text)
+                except json.JSONDecodeError:
+                    return None
+                if isinstance(parsed, dict):
+                    critique = parsed
+        if critique is None:
+            return None
+        missing = [f for f in _REQUIRED_CRITIQUE_FIELDS if f not in critique]
+        if missing:
+            log.warning(
+                "seed-pipeline critic: candidate=%s critique missing fields %s",
+                task.args.get("candidate_id"),
+                missing,
+            )
+            return None
+        # Pin candidate_id to the task's value — never trust the LLM to
+        # echo it correctly. Prevents one critique being merged under a
+        # different candidate's slot.
+        critique["candidate_id"] = task.args["candidate_id"]
+        return critique

--- a/tests/plugins/seed_pipeline/test_critic.py
+++ b/tests/plugins/seed_pipeline/test_critic.py
@@ -234,6 +234,33 @@ def test_critic_announce_false() -> None:
     assert manager.received_announce is False
 
 
+def test_critic_drops_non_dict_outputs() -> None:
+    """_parse_critique returns None for list/None/scalar output shapes."""
+    state = _make_state()
+    _seed_candidates(state, 3)
+
+    class _NonDictManager:
+        def delegate(
+            self, tasks: list[SubTask], *, announce: bool = True
+        ) -> list[SubResult]:
+            shapes: list[Any] = [None, ["not", "a", "dict"], 42]
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=shape,  # type: ignore[arg-type]
+                    duration_ms=10.0,
+                )
+                for t, shape in zip(tasks, shapes, strict=True)
+            ]
+
+    result = Critic(manager=_NonDictManager()).execute(state)  # type: ignore[arg-type]
+    # All 3 are non-dict → all dropped → critique_failed
+    assert not result.success
+    assert result.error_category == "critique_failed"
+
+
 def test_critic_pins_candidate_id_from_task() -> None:
     """Even if LLM echoes a wrong candidate_id, the task's id wins."""
     state = _make_state()

--- a/tests/plugins/seed_pipeline/test_critic.py
+++ b/tests/plugins/seed_pipeline/test_critic.py
@@ -1,0 +1,250 @@
+"""Tests for ``plugins.seed_pipeline.agents.critic``.
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — `_ReverseOrderManager` returns results in
+  reverse submission order to simulate variable LLM latency. Test
+  `test_critic_pairs_by_task_id_under_reverse_order` proves candidate-
+  to-critique mapping is by task_id, not position.
+- **P7 Caller-Callee Contract Pair Read** — `_REQUIRED_CRITIQUE_FIELDS`
+  validation tested in `test_critic_drops_malformed_partial_critique`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.critic import Critic
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+
+def _good_critique(candidate_id: str = "c-1") -> dict[str, Any]:
+    return {
+        "candidate_id": candidate_id,
+        "target_dims_actual": ["broken_tool_use"],
+        "intended_dim_match": True,
+        "strengths": ["specific ambiguity"],
+        "weaknesses": ["partial overlap with seed_pool"],
+        "judge_risk": "low",
+        "discrimination_estimate": 0.7,
+        "rewrite_section": None,
+    }
+
+
+class _StubManager:
+    """Return one canned SubResult per task, in submission order."""
+
+    def __init__(
+        self,
+        *,
+        critique_outputs: dict[str, dict[str, Any]] | None = None,
+        force_failures: int = 0,
+        force_unparseable: bool = False,
+    ) -> None:
+        self.received_tasks: list[SubTask] = []
+        self.received_announce: bool | None = None
+        self._critiques = critique_outputs or {}
+        self._force_failures = force_failures
+        self._force_unparseable = force_unparseable
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks = list(tasks)
+        self.received_announce = announce
+        results: list[SubResult] = []
+        for i, t in enumerate(tasks):
+            candidate_id = t.args["candidate_id"]
+            failed = i < self._force_failures
+            if failed:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=False,
+                        error="forced",
+                        duration_ms=10.0,
+                    )
+                )
+                continue
+            if self._force_unparseable:
+                output = {"text": "not-valid-json"}
+            else:
+                critique = self._critiques.get(candidate_id, _good_critique(candidate_id))
+                output = dict(critique)
+            results.append(
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=output,
+                    duration_ms=42.0,
+                )
+            )
+        return results
+
+
+class _ReverseOrderManager(_StubManager):
+    """Returns SubResults in REVERSE submission order (worst-case latency)."""
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results = super().delegate(tasks, announce=announce)
+        return list(reversed(results))
+
+
+def _make_state(n: int = 3) -> PipelineState:
+    return PipelineState(
+        run_id="t-critic",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+    )
+
+
+def _seed_candidates(state: PipelineState, n: int) -> None:
+    # Use placeholder paths under "fake-run/" (no real disk I/O — Critic
+    # only reads the path string to embed in the SubTask description).
+    state.candidates = [
+        {
+            "id": f"gen2-{i:03d}-cand",
+            "path": f"fake-run/candidates/gen2-{i:03d}-cand.md",
+            "target_dim": "broken_tool_use",
+            "gen_tag": "gen2",
+            "task_id": f"gen-gen2-{i:03d}-cand",
+            "duration_ms": 1000.0,
+        }
+        for i in range(n)
+    ]
+
+
+def test_critic_builds_one_task_per_candidate() -> None:
+    state = _make_state()
+    _seed_candidates(state, 4)
+    manager = _StubManager()
+    Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert len(manager.received_tasks) == 4
+    for task in manager.received_tasks:
+        assert task.agent == "seed_critic"
+        assert task.task_type == "seed-critique"
+        assert "candidate_id" in task.args
+        assert "candidate_path" in task.args
+
+
+def test_critic_returns_reflections_keyed_by_candidate_id() -> None:
+    state = _make_state()
+    _seed_candidates(state, 3)
+    manager = _StubManager()
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    reflections = result.output["reflections"]
+    assert isinstance(reflections, dict)
+    assert len(reflections) == 3
+    for candidate_id, critique in reflections.items():
+        assert critique["candidate_id"] == candidate_id
+        assert "target_dims_actual" in critique
+
+
+def test_critic_pairs_by_task_id_under_reverse_order() -> None:
+    """P1 — reverse-order completion must still pair correctly."""
+    state = _make_state()
+    _seed_candidates(state, 5)
+    manager = _ReverseOrderManager()
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    reflections = result.output["reflections"]
+    # Every candidate's id should map to its OWN critique (the stub
+    # produces _good_critique(candidate_id) so we know what to expect).
+    for candidate in state.candidates:
+        cid = candidate["id"]
+        assert cid in reflections
+        # The pinned candidate_id field must match the task, NOT some
+        # other completion's LLM-echoed value.
+        assert reflections[cid]["candidate_id"] == cid
+
+
+def test_critic_drops_failed_sub_agents() -> None:
+    state = _make_state()
+    _seed_candidates(state, 5)
+    manager = _StubManager(force_failures=2)
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert len(result.output["reflections"]) == 3
+
+
+def test_critic_drops_unparseable_responses() -> None:
+    """P7 — non-JSON or partial critique must be dropped, not silently merged."""
+    state = _make_state()
+    _seed_candidates(state, 3)
+    manager = _StubManager(force_unparseable=True)
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "critique_failed"
+
+
+def test_critic_drops_malformed_partial_critique() -> None:
+    """P7 — critique missing required fields must be dropped."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    partial = {"candidate_id": "gen2-000-cand", "judge_risk": "low"}
+    manager = _StubManager(critique_outputs={"gen2-000-cand": partial})
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "critique_failed"
+
+
+def test_critic_accepts_text_json_fallback() -> None:
+    """Sub-agent returning JSON string in output['text'] is parsed."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    critique_text = json.dumps(_good_critique("gen2-000-cand"))
+    # The stub puts it in output as the critique dict; for this test we
+    # construct a manager that wraps the JSON-as-text inside output["text"].
+
+    class _TextJsonManager:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            return [
+                SubResult(
+                    task_id=tasks[0].task_id,
+                    description=tasks[0].description,
+                    success=True,
+                    output={"text": critique_text},
+                    duration_ms=10.0,
+                )
+            ]
+
+    result = Critic(manager=_TextJsonManager()).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert "gen2-000-cand" in result.output["reflections"]
+
+
+def test_critic_validates_empty_candidates() -> None:
+    state = _make_state()
+    # state.candidates is empty by default
+    manager = _StubManager()
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_critic_announce_false() -> None:
+    state = _make_state()
+    _seed_candidates(state, 2)
+    manager = _StubManager()
+    Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert manager.received_announce is False
+
+
+def test_critic_pins_candidate_id_from_task() -> None:
+    """Even if LLM echoes a wrong candidate_id, the task's id wins."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    wrong_id_critique = _good_critique("WRONG-id-from-llm")
+    manager = _StubManager(critique_outputs={"gen2-000-cand": wrong_id_critique})
+    result = Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    reflections = result.output["reflections"]
+    # The slot is keyed by the TASK's candidate_id ('gen2-000-cand'),
+    # and the critique's candidate_id field is re-pinned to match.
+    assert "gen2-000-cand" in reflections
+    assert reflections["gen2-000-cand"]["candidate_id"] == "gen2-000-cand"
+    assert "WRONG-id-from-llm" not in reflections

--- a/tests/plugins/seed_pipeline/test_critic.py
+++ b/tests/plugins/seed_pipeline/test_critic.py
@@ -240,9 +240,7 @@ def test_critic_drops_non_dict_outputs() -> None:
     _seed_candidates(state, 3)
 
     class _NonDictManager:
-        def delegate(
-            self, tasks: list[SubTask], *, announce: bool = True
-        ) -> list[SubResult]:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             shapes: list[Any] = [None, ["not", "a", "dict"], 42]
             return [
                 SubResult(


### PR DESCRIPTION
## Summary

- `plugins/seed_pipeline/agents/critic.py` (~250 LOC) — Critic per ADR-001 paper §3 Reflection.
- 11 unit tests + cycle-skill Phase A-D 적용.
- Codex MCP audit 2 round, 모든 finding RESOLVED.

## Why

- Phase C (Reflection) 의 concrete impl. Generator (S2) 의 출력 candidates 를 dim-level 로 critique.
- S2-fix 의 task_id 매핑 패턴 + LLM-echo 신뢰 X 의 prepatron 적용.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_pipeline/agents/critic.py` (신규, ~280 LOC) | Critic class: per-candidate sub-agent fan-out, _parse_critique with _REQUIRED_CRITIQUE_FIELDS validation, JSON-as-text fallback, candidate_id pinning from task.args |
| `plugins/seed_pipeline/agents/__init__.py` | Critic + Generator exports |
| `tests/plugins/seed_pipeline/test_critic.py` (신규, 11 test) | N-task, output schema, _ReverseOrderManager (P1), failed/unparseable/partial/non-dict response handling, candidate_id pinning, validation, announce=False |
| `CHANGELOG.md` | Unreleased Added |
| `CLAUDE.md` | Modules 334 → 335 |

## GAP Audit (Codex MCP `gpt-5.2-codex`)

| Round | Finding | Resolution |
|---|---|---|
| 1 | MEDIUM CLAUDE.md modules stale | round 2 — 334 → 335 |
| 1 | LOW _parse_critique edge cases incomplete | round 2 — test_critic_drops_non_dict_outputs |
| 1 | Verified — S2-fix pattern applied + contract documented both ends + P3 rollup survives | Confirmed |

## Cycle skill 적용 (Phase A-E)

- ✅ Phase A — worktree, develop sync, Task in_progress
- ✅ Phase B — Plan ledger 매핑 (P1 stub fidelity: _ReverseOrderManager; P7 caller-callee: contract docstring both ends)
- ✅ Phase C — Codex MCP audit 2 round, all RESOLVED
- ✅ Phase D — PR & CI (자동 dispatch)

## Verification

- [x] ruff check core/ tests/ plugins/ — clean
- [x] ruff format — clean
- [x] mypy core/ plugins/ — Success: 335 source files
- [x] pytest tests/plugins/seed_pipeline/test_critic.py — 11 pass
- [ ] CI 5/5 — 자동 dispatch
- [x] Codex MCP audit 2 round

## Reference

- ADR-001 (paper §3 Reflection role)
- `.claude/agents/seed_critic.md` — AgentDefinition contract
- S2 Generator pattern (`plugins/seed_pipeline/agents/generator.py`) — fan-out + task_id pairing
- S2-fix (#1276) — zip order corruption fix pattern applied
- `.geode/skills/seed-pipeline-cycle/SKILL.md` — Phase A-D 적용

다음 — S4 (text_embed tool + Proximity 3-track dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)