### PR TITLE
docs(seed-pipeline): align CHANGELOG + Plan budget defaults to S2-fix values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,10 @@ functional change.
   arrive in S2-S8.
 - **Sub-agent budget guard.** `core/agent/sub_agent_budget.py` adds
   per-invocation token + USD cap (`BudgetGuard` + `SubAgentBudget`).
-  Soft warning at $0.50 / sub-agent, hard kill at $2.00, env-overridable
-  via `SEED_PIPELINE_BUDGET_SOFT_USD` / `_HARD_USD`. Cost derived from
-  `core.llm.token_tracker.calculate_cost`.
+  Soft warning at $2.00 / sub-agent, hard kill at $10.00 (relaxed in
+  S2-fix from initial $0.50 / $2.00 after user feedback on subscription-
+  path headroom), env-overridable via `SEED_PIPELINE_BUDGET_SOFT_USD` /
+  `_HARD_USD`. Cost derived from `core.llm.token_tracker.calculate_cost`.
 - **Seed-pipeline Lane.** `core/wiring/container.py` registers a new
   `seed-pipeline` Lane with `max_concurrent=16` (sibling to `global=8`,
   `gateway=4`) so 15-20 candidate parallel spawns + tournament matches

--- a/docs/plans/2026-05-18-seed-pipeline-sprint-plan.md
+++ b/docs/plans/2026-05-18-seed-pipeline-sprint-plan.md
@@ -78,7 +78,7 @@ S12 — First seeds_gen1 generation run + 첫 baseline autoresearch
 | 6 | Sprint cadence | 16 PR 연속 (mid-checkpoint 없음, per-PR Codex MCP audit 만) |
 | 7 | seed pool naming | `seeds_gen<N>` (gen suffix, monotonic). `seeds_safe10` 보존 |
 | 8 | `text_embed` provider | OpenAI text-embedding-3-small ($0.02/1M tok) |
-| 9 | Token budget guard | soft warning at $0.50/sub-agent, hard kill at $2.00 (config 가능) |
+| 9 | Token budget guard | soft warning at $2.00/sub-agent, hard kill at $10.00 (S2-fix relaxed from $0.50/$2.00 — subscription-path long-form generation 의 false-positive 회피. PAYG 사용자는 env 로 낮춤) |
 | 10 | Scope dial | Option α (user 결정) |
 | 11 | PAYG cost cap (pipeline 1회) | soft $0.30, hard $1.00 |
 | 12 | Slash | 별도 `/audit-seeds` (not `/petri seed-gen`) |


### PR DESCRIPTION
## Summary

- Codex MCP Phase F audit LOW finding — budget default doc inconsistency between CHANGELOG Added entry ($0.50/$2.00), Plan row #9 ($0.50/$2.00), and actual code ($2.00/$10.00 post-S2-fix).
- Aligns both docs to S2-fix's relaxed values + brief history note.

## Why

- SoT divergence: CHANGELOG `### Added` from S1 + Plan ledger row 9 still listed initial conservative caps, but S2-fix (per user feedback on subscription-path headroom) raised them.
- Phase F audit (cross-PR cohesion checkpoint) caught the drift.

## Changes

| File | Change |
|------|--------|
| `CHANGELOG.md` | Added entry — $2.00/$10.00 + S2-fix history note |
| `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` | Row #9 — current values + rationale |

## Verification

- [x] docs-only (no code touch)
- [ ] CI 5/5 — 자동 dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)