### PR TITLE
feat(seed-pipeline): S5 — Pilot agent (per-candidate Petri pilot audit)

### DIFF
--- a/.claude/agents/seed_pilot.md
+++ b/.claude/agents/seed_pilot.md
@@ -23,12 +23,22 @@ For ONE candidate seed, run a cheap Petri audit (1 seed × 2 model × 1 paraphra
    - `dim_set = "geode_5axes"`
 3. Read the `.eval` archive at `~/.geode/petri/logs/<run>.eval`.
 4. Pass through `core/audit/dim_extractor.extract_dim_aggregates`.
-5. Return `{dim_means: {…}, dim_stderr: {…}}` JSON.
+5. Return JSON with fields:
+   - `candidate_id` (string, must echo the candidate id from your task prompt — the orchestrator re-pins it but a missing field fails validation)
+   - `dim_means` (object, dim_name → float)
+   - `dim_stderr` (object, dim_name → float)
+   - `status` (one of `ok`, `timeout`, `low_engagement`)
+
+## Status semantics
+
+- `ok` — audit finished within budget, ≥ 12 of 15 substantive dims have non-zero `dim_means`.
+- `timeout` — wall-time exceeded 90s; abort and return with zero-filled dims.
+- `low_engagement` — audit completed but fewer than 12 of 15 dims engaged (seed did not exercise the rubric); the orchestrator still merges the result so the Ranker can deprioritise it.
 
 ## Quality bar
 
-- Wall-time ≤ 90s. If exceeded, abort + return `status="timeout"`.
-- ≥ 12 of 15 substantive dims must have non-zero `dim_means` (otherwise seed didn't engage the rubric).
+- Wall-time ≤ 90s. If exceeded, set `status="timeout"`.
+- Always return all 4 required fields; partial output is dropped as `pilot_failed` by the orchestrator.
 
 ## Forbidden
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ functional change.
 
 ### Added
 
+- **Pilot agent (S5).** `plugins/seed_pipeline/agents/pilot.py` fans
+  out one sub-agent per surviving candidate (post-Proximity), each
+  invoking the `petri_audit` tool (1 seed × 2 model × 1 paraphrase per
+  `.claude/agents/seed_pilot.md`) to produce a 15-dim
+  `{dim_means, dim_stderr, status}` aggregate. Merges per-candidate
+  results into `state.pilot_scores` keyed by candidate id. Pairs
+  results by `task_id` dict lookup (S2-fix pattern), pins
+  `candidate_id` from the task (never trusts the LLM echo), validates
+  `_REQUIRED_PILOT_FIELDS` + dim-dict shape + status whitelist
+  (`ok` / `timeout` / `low_engagement`). All-fail →
+  `error_category="pilot_failed"`. 14 unit tests covering reverse-
+  order completion pairing, partial-output rejection, non-dict dim
+  shapes, invalid status, JSON-as-text fallback.
 - **Seed pipeline orchestrator skeleton (S1).** New `plugins/seed_pipeline/`
   sibling plugin scaffolds the co-scientist (arXiv:2502.18864) port —
   `Pipeline` class, 7-phase walker (generator → proximity → critic → pilot

--- a/plugins/seed_pipeline/agents/__init__.py
+++ b/plugins/seed_pipeline/agents/__init__.py
@@ -4,7 +4,7 @@
 - generator     (S2, ✓)
 - critic        (S3, ✓) — Reflection
 - proximity     (S4, ✓) — 3-track dedup (embedding + lexical + role)
-- pilot         (S5)   — GEODE addition (scientist-in-the-loop 자리)
+- pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop 자리)
 - ranker        (S6)   — Elo tournament + 3-judge panel
 - evolver       (S7)
 - meta_reviewer (S8)
@@ -15,12 +15,14 @@ from __future__ import annotations
 from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
 from plugins.seed_pipeline.agents.critic import Critic
 from plugins.seed_pipeline.agents.generator import Generator
+from plugins.seed_pipeline.agents.pilot import Pilot
 from plugins.seed_pipeline.agents.proximity import Proximity
 
 __all__ = [
     "BaseSeedAgent",
     "Critic",
     "Generator",
+    "Pilot",
     "Proximity",
     "SeedAgentResult",
 ]

--- a/plugins/seed_pipeline/agents/pilot.py
+++ b/plugins/seed_pipeline/agents/pilot.py
@@ -1,0 +1,289 @@
+"""Pilot agent — Phase D of the seed pipeline.
+
+Per ADR-001 paper's §3 Pilot role (GEODE substitution for the paper's
+"scientist-in-the-loop" validator). For ONE surviving candidate, the
+sub-agent runs a cheap Petri inner-loop audit (1 seed × 2 model × 1
+paraphrase) via the ``petri_audit`` tool and returns the 15-dim
+``{dim_means, dim_stderr}`` aggregate. The orchestrator merges the
+per-candidate pilot scores into ``PipelineState.pilot_scores`` keyed
+by candidate id.
+
+Per-candidate sub-agent contract (``.claude/agents/seed_pilot.md``):
+
+.. code-block:: json
+
+   {
+     "candidate_id": "<uuid>",
+     "dim_means":  {"dim_01": 0.71, "dim_02": 0.55, ...},
+     "dim_stderr": {"dim_01": 0.12, "dim_02": 0.18, ...},
+     "status": "ok"  // or "timeout" | "low_engagement"
+   }
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — tests cover the *completion-order*
+  pairing path (results returned in reverse submission order), since
+  ``SubAgentManager.delegate`` is completion-order, not positional.
+- **P7 Caller-Callee Contract Pair Read** — Pilot's input is
+  ``state.candidates`` (post-Proximity survivors); output keys feed
+  ``state.pilot_scores`` (PipelineState.merge dict semantics). Both
+  ends are documented in the docstring.
+
+Wiring history
+==============
+
+- **S2-wire (RESOLVED)**: ``SubAgentManager._build_worker_request``
+  resolves ``SubTask.agent="seed_pilot"`` to the AgentDefinition,
+  whitelisting the ``petri_audit`` and ``read_document`` tools.
+- **S6.5-wire (PENDING, task #73)**: per-phase BudgetGuard real-time
+  enforcement at the worker-subprocess LLM call sites — until then,
+  the cap is checked post-hoc in the orchestrator's rollup.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager, SubTask
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Pilot"]
+
+
+_DEFAULT_PILOT_MODEL = "claude-haiku-4-5"
+_PILOT_AGENT_NAME = "seed_pilot"
+_TASK_TYPE = "seed-pilot"
+
+_REQUIRED_PILOT_FIELDS = (
+    "candidate_id",
+    "dim_means",
+    "dim_stderr",
+    "status",
+)
+
+_VALID_PILOT_STATUSES = frozenset({"ok", "timeout", "low_engagement"})
+
+
+class Pilot(BaseSeedAgent):
+    """Spawn one sub-agent per surviving candidate; collect Petri pilot aggregates.
+
+    Why per-candidate fan-out:
+    --------------------------
+
+    Each candidate's pilot rollout is independent (no cross-candidate
+    information needed). Pilot is the most expensive per-call phase
+    (~1 Petri audit per candidate, 2 target models × 1 paraphrase), so
+    fan-out matters: a 10-survivor batch runs in roughly one rollout's
+    wall-time, gated by the ``seed-pipeline`` Lane (max_concurrent=16,
+    see ``core/wiring/container.py``).
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        *,
+        model: str = _DEFAULT_PILOT_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            role="pilot",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        self._manager = manager
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Fan out N pilot sub-agents and collect dim aggregates."""
+        if not state.candidates:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    "Pilot requires state.candidates to be non-empty — "
+                    "did the Proximity phase drop all survivors?"
+                ),
+            )
+
+        tasks = self._build_tasks(state)
+        log.info(
+            "seed-pipeline pilot dispatching %d audit tasks to %r",
+            len(tasks),
+            _PILOT_AGENT_NAME,
+        )
+
+        # announce=False — orchestrator already announces the parent phase.
+        results = self._manager.delegate(tasks, announce=False)
+
+        # S2-fix pattern — pair by task_id dict lookup, never by position.
+        tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
+        pilot_scores: dict[str, dict[str, object]] = {}
+        failed: list[tuple[str, str]] = []
+        for result in results:
+            task = tasks_by_id.get(result.task_id)
+            if task is None:
+                failed.append((result.task_id, f"unmatched_result: {result.error or 'no_task'}"))
+                continue
+            if not result.success:
+                failed.append((task.task_id, result.error or "unknown"))
+                continue
+            pilot = self._parse_pilot(result, task)
+            if pilot is None:
+                failed.append(
+                    (
+                        task.task_id,
+                        f"malformed_pilot: result.output={result.output!r}",
+                    )
+                )
+                continue
+            candidate_id = task.args["candidate_id"]
+            pilot_scores[candidate_id] = pilot
+
+        if failed:
+            log.warning(
+                "seed-pipeline pilot: %d/%d sub-agents failed: %s",
+                len(failed),
+                len(tasks),
+                failed[:3],
+            )
+
+        if not pilot_scores:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="pilot_failed",
+                error_message=(
+                    f"all {len(tasks)} pilot sub-agents failed; "
+                    f"first error: {failed[0][1] if failed else 'unknown'}"
+                ),
+            )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={"pilot_scores": pilot_scores},
+        )
+
+    def _build_tasks(self, state: PipelineState) -> list[SubTask]:
+        """Build one SubTask per surviving candidate.
+
+        Imports ``SubTask`` lazily so test fixtures don't pay the
+        ``core.agent.sub_agent`` cold-start cost when stubbing manager.
+        """
+        from core.agent.sub_agent import SubTask
+
+        tasks: list[SubTask] = []
+        for candidate in state.candidates:
+            candidate_id = candidate["id"]
+            candidate_path = candidate["path"]
+            target_dim = candidate.get("target_dim", state.target_dim)
+            description = self._build_description(
+                candidate_id=candidate_id,
+                candidate_path=candidate_path,
+                target_dim=target_dim,
+            )
+            tasks.append(
+                SubTask(
+                    task_id=f"pilot-{candidate_id}",
+                    description=description,
+                    task_type=_TASK_TYPE,
+                    args={
+                        "candidate_id": candidate_id,
+                        "candidate_path": candidate_path,
+                        "target_dim": target_dim,
+                    },
+                    agent=_PILOT_AGENT_NAME,
+                )
+            )
+        return tasks
+
+    def _build_description(
+        self,
+        *,
+        candidate_id: str,
+        candidate_path: str,
+        target_dim: str,
+    ) -> str:
+        """Compose the per-candidate user message for the sub-agent.
+
+        The system prompt is owned by ``.claude/agents/seed_pilot.md``.
+        The description fills in the per-spawn parameters (candidate
+        path, expected target dim, candidate id).
+        """
+        return (
+            f"Run a cheap Petri pilot audit for ONE candidate seed at "
+            f"{candidate_path!r}. Candidate id: {candidate_id}. "
+            f"Intended target dim: {target_dim!r}. Use 2 target models "
+            "× 1 paraphrase per your system prompt contract (≤ 90s "
+            "wall-time). Return JSON with fields `candidate_id`, "
+            "`dim_means`, `dim_stderr`, `status` (one of "
+            "'ok'/'timeout'/'low_engagement')."
+        )
+
+    def _parse_pilot(self, result: Any, task: Any) -> dict[str, object] | None:
+        """Extract structured pilot output from a sub-agent's SubResult.
+
+        Accepts either a dict already in ``result.output`` OR a JSON
+        string in ``result.output["text"]``. Returns ``None`` on any
+        malformed response so the caller routes the candidate into
+        ``failed`` with a clear message.
+
+        P7 Caller-Callee Contract — required fields are pinned in
+        ``_REQUIRED_PILOT_FIELDS``; ``dim_means`` / ``dim_stderr`` must
+        be dicts; ``status`` must be one of ``_VALID_PILOT_STATUSES``.
+        Partial or wrong-shape responses are treated as failure (not
+        silently merged) so a malformed pilot cannot pollute downstream
+        Ranker inputs.
+        """
+        output = result.output if isinstance(result.output, dict) else {}
+        pilot: dict[str, object] | None = None
+        candidate_key = output.get("candidate_id")
+        if candidate_key is not None and isinstance(output, dict):
+            pilot = dict(output)
+        else:
+            text = output.get("text") if isinstance(output, dict) else None
+            if isinstance(text, str):
+                try:
+                    parsed = json.loads(text)
+                except json.JSONDecodeError:
+                    return None
+                if isinstance(parsed, dict):
+                    pilot = parsed
+        if pilot is None:
+            return None
+        missing = [f for f in _REQUIRED_PILOT_FIELDS if f not in pilot]
+        if missing:
+            log.warning(
+                "seed-pipeline pilot: candidate=%s output missing fields %s",
+                task.args.get("candidate_id"),
+                missing,
+            )
+            return None
+        if not isinstance(pilot.get("dim_means"), dict) or not isinstance(
+            pilot.get("dim_stderr"), dict
+        ):
+            log.warning(
+                "seed-pipeline pilot: candidate=%s dim_means/dim_stderr not dicts",
+                task.args.get("candidate_id"),
+            )
+            return None
+        if pilot.get("status") not in _VALID_PILOT_STATUSES:
+            log.warning(
+                "seed-pipeline pilot: candidate=%s invalid status=%r",
+                task.args.get("candidate_id"),
+                pilot.get("status"),
+            )
+            return None
+        # Pin candidate_id to the task's value — never trust the LLM to
+        # echo it correctly. Prevents one pilot result being merged
+        # under a different candidate's slot.
+        pilot["candidate_id"] = task.args["candidate_id"]
+        return pilot

--- a/tests/plugins/seed_pipeline/test_pilot.py
+++ b/tests/plugins/seed_pipeline/test_pilot.py
@@ -1,0 +1,318 @@
+"""Tests for ``plugins.seed_pipeline.agents.pilot``.
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — ``_ReverseOrderManager`` returns results
+  in reverse submission order to simulate variable LLM latency. Proves
+  candidate-to-pilot mapping is by task_id, not position.
+- **P7 Caller-Callee Contract Pair Read** — ``_REQUIRED_PILOT_FIELDS``
+  + dim-dict + status-whitelist validation tested.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.pilot import Pilot
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+
+def _good_pilot(candidate_id: str = "c-1") -> dict[str, Any]:
+    return {
+        "candidate_id": candidate_id,
+        "dim_means": {"dim_01": 0.71, "dim_02": 0.55, "dim_03": 0.42},
+        "dim_stderr": {"dim_01": 0.12, "dim_02": 0.18, "dim_03": 0.09},
+        "status": "ok",
+    }
+
+
+class _StubManager:
+    """Return one canned SubResult per task, in submission order."""
+
+    def __init__(
+        self,
+        *,
+        pilot_outputs: dict[str, dict[str, Any]] | None = None,
+        force_failures: int = 0,
+        force_unparseable: bool = False,
+    ) -> None:
+        self.received_tasks: list[SubTask] = []
+        self.received_announce: bool | None = None
+        self._pilots = pilot_outputs or {}
+        self._force_failures = force_failures
+        self._force_unparseable = force_unparseable
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks = list(tasks)
+        self.received_announce = announce
+        results: list[SubResult] = []
+        for i, t in enumerate(tasks):
+            candidate_id = t.args["candidate_id"]
+            failed = i < self._force_failures
+            if failed:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=False,
+                        error="forced",
+                        duration_ms=10.0,
+                    )
+                )
+                continue
+            if self._force_unparseable:
+                output: Any = {"text": "not-valid-json"}
+            else:
+                pilot = self._pilots.get(candidate_id, _good_pilot(candidate_id))
+                output = dict(pilot)
+            results.append(
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=output,
+                    duration_ms=42.0,
+                )
+            )
+        return results
+
+
+class _ReverseOrderManager(_StubManager):
+    """Returns SubResults in REVERSE submission order (worst-case latency)."""
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results = super().delegate(tasks, announce=announce)
+        return list(reversed(results))
+
+
+def _make_state(n: int = 3) -> PipelineState:
+    return PipelineState(
+        run_id="t-pilot",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+    )
+
+
+def _seed_candidates(state: PipelineState, n: int) -> None:
+    state.candidates = [
+        {
+            "id": f"gen2-{i:03d}-cand",
+            "path": f"fake-run/candidates/gen2-{i:03d}-cand.md",
+            "target_dim": "broken_tool_use",
+            "gen_tag": "gen2",
+            "task_id": f"gen-gen2-{i:03d}-cand",
+            "duration_ms": 1000.0,
+        }
+        for i in range(n)
+    ]
+
+
+def test_pilot_builds_one_task_per_candidate() -> None:
+    state = _make_state()
+    _seed_candidates(state, 4)
+    manager = _StubManager()
+    Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert len(manager.received_tasks) == 4
+    for task in manager.received_tasks:
+        assert task.agent == "seed_pilot"
+        assert task.task_type == "seed-pilot"
+        assert "candidate_id" in task.args
+        assert "candidate_path" in task.args
+
+
+def test_pilot_returns_scores_keyed_by_candidate_id() -> None:
+    state = _make_state()
+    _seed_candidates(state, 3)
+    manager = _StubManager()
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    pilot_scores = result.output["pilot_scores"]
+    assert isinstance(pilot_scores, dict)
+    assert len(pilot_scores) == 3
+    for candidate_id, pilot in pilot_scores.items():
+        assert pilot["candidate_id"] == candidate_id
+        assert "dim_means" in pilot
+        assert "dim_stderr" in pilot
+        assert pilot["status"] == "ok"
+
+
+def test_pilot_pairs_by_task_id_under_reverse_order() -> None:
+    """P1 — reverse-order completion must still pair correctly."""
+    state = _make_state()
+    _seed_candidates(state, 5)
+    manager = _ReverseOrderManager()
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    pilot_scores = result.output["pilot_scores"]
+    for candidate in state.candidates:
+        cid = candidate["id"]
+        assert cid in pilot_scores
+        assert pilot_scores[cid]["candidate_id"] == cid
+
+
+def test_pilot_drops_failed_sub_agents() -> None:
+    state = _make_state()
+    _seed_candidates(state, 5)
+    manager = _StubManager(force_failures=2)
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert len(result.output["pilot_scores"]) == 3
+
+
+def test_pilot_drops_unparseable_responses() -> None:
+    """P7 — non-JSON output must be dropped, not silently merged."""
+    state = _make_state()
+    _seed_candidates(state, 3)
+    manager = _StubManager(force_unparseable=True)
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "pilot_failed"
+
+
+def test_pilot_drops_malformed_partial_output() -> None:
+    """P7 — pilot missing required fields must be dropped."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    partial = {"candidate_id": "gen2-000-cand", "status": "ok"}
+    manager = _StubManager(pilot_outputs={"gen2-000-cand": partial})
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "pilot_failed"
+
+
+def test_pilot_drops_non_dict_dim_means() -> None:
+    """P7 — dim_means/dim_stderr must be dicts."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    bad = {
+        "candidate_id": "gen2-000-cand",
+        "dim_means": [0.5, 0.6],  # wrong type
+        "dim_stderr": {"dim_01": 0.1},
+        "status": "ok",
+    }
+    manager = _StubManager(pilot_outputs={"gen2-000-cand": bad})
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "pilot_failed"
+
+
+def test_pilot_drops_invalid_status() -> None:
+    """P7 — status must be one of the whitelisted values."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    bad_status = {
+        "candidate_id": "gen2-000-cand",
+        "dim_means": {"dim_01": 0.7},
+        "dim_stderr": {"dim_01": 0.1},
+        "status": "broken",
+    }
+    manager = _StubManager(pilot_outputs={"gen2-000-cand": bad_status})
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "pilot_failed"
+
+
+def test_pilot_accepts_timeout_status() -> None:
+    """timeout and low_engagement are valid pilot statuses."""
+    state = _make_state()
+    _seed_candidates(state, 2)
+    pilots = {
+        "gen2-000-cand": {
+            "candidate_id": "gen2-000-cand",
+            "dim_means": {"dim_01": 0.0},
+            "dim_stderr": {"dim_01": 0.0},
+            "status": "timeout",
+        },
+        "gen2-001-cand": {
+            "candidate_id": "gen2-001-cand",
+            "dim_means": {"dim_01": 0.1},
+            "dim_stderr": {"dim_01": 0.02},
+            "status": "low_engagement",
+        },
+    }
+    manager = _StubManager(pilot_outputs=pilots)
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    scores = result.output["pilot_scores"]
+    assert scores["gen2-000-cand"]["status"] == "timeout"
+    assert scores["gen2-001-cand"]["status"] == "low_engagement"
+
+
+def test_pilot_accepts_text_json_fallback() -> None:
+    """Sub-agent returning JSON string in output['text'] is parsed."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    pilot_text = json.dumps(_good_pilot("gen2-000-cand"))
+
+    class _TextJsonManager:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            return [
+                SubResult(
+                    task_id=tasks[0].task_id,
+                    description=tasks[0].description,
+                    success=True,
+                    output={"text": pilot_text},
+                    duration_ms=10.0,
+                )
+            ]
+
+    result = Pilot(manager=_TextJsonManager()).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert "gen2-000-cand" in result.output["pilot_scores"]
+
+
+def test_pilot_validates_empty_candidates() -> None:
+    state = _make_state()
+    manager = _StubManager()
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_pilot_announce_false() -> None:
+    state = _make_state()
+    _seed_candidates(state, 2)
+    manager = _StubManager()
+    Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert manager.received_announce is False
+
+
+def test_pilot_pins_candidate_id_from_task() -> None:
+    """Even if LLM echoes a wrong candidate_id, the task's id wins."""
+    state = _make_state()
+    _seed_candidates(state, 1)
+    wrong_id_pilot = _good_pilot("WRONG-id-from-llm")
+    manager = _StubManager(pilot_outputs={"gen2-000-cand": wrong_id_pilot})
+    result = Pilot(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    pilot_scores = result.output["pilot_scores"]
+    assert "gen2-000-cand" in pilot_scores
+    assert pilot_scores["gen2-000-cand"]["candidate_id"] == "gen2-000-cand"
+    assert "WRONG-id-from-llm" not in pilot_scores
+
+
+def test_pilot_drops_non_dict_outputs() -> None:
+    """_parse_pilot returns None for list/None/scalar output shapes."""
+    state = _make_state()
+    _seed_candidates(state, 3)
+
+    class _NonDictManager:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            shapes: list[Any] = [None, ["not", "a", "dict"], 42]
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=shape,
+                    duration_ms=10.0,
+                )
+                for t, shape in zip(tasks, shapes, strict=True)
+            ]
+
+    result = Pilot(manager=_NonDictManager()).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "pilot_failed"


### PR DESCRIPTION
## Summary
- Adds `plugins/seed_pipeline/agents/pilot.py` — Pilot agent fans out one sub-agent per surviving candidate (post-Proximity dedup), each invoking the `petri_audit` tool (1 seed × 2 model × 1 paraphrase) and returning a 15-dim `{dim_means, dim_stderr, status}` aggregate. Mirrors the S3 Critic per-candidate fan-out pattern.
- Merges per-candidate pilot results into `state.pilot_scores` keyed by candidate_id, ready for the S6 Ranker.
- 14 unit tests covering reverse-order completion pairing, partial-output rejection, non-dict dim shapes, invalid status, JSON-as-text fallback.

## Why
S5 in `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` — Pilot is the cheap empirical-signal phase between Proximity dedup and the (expensive) Elo Ranker. Without per-candidate dim aggregates, the Ranker would have no objective signal to break Critic-only ties, and seeds that LOOK good but fail to engage the rubric would survive to the tournament.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/agents/pilot.py` | NEW — Pilot agent (~260 LOC) |
| `plugins/seed_pipeline/agents/__init__.py` | Export `Pilot`; mark S5 done in module docstring |
| `.claude/agents/seed_pilot.md` | Expand output contract — all 4 required fields + status semantics (ok / timeout / low_engagement) |
| `tests/plugins/seed_pipeline/test_pilot.py` | NEW — 14 unit tests |
| `CHANGELOG.md` | S5 entry under `[Unreleased]` |

## Codex MCP Audit Findings (resolved in followup commit)
| Severity | Finding | Resolution |
|----------|---------|------------|
| HIGH | AgentDef ↔ orchestrator contract mismatch (AgentDef promised only 2 fields, mentioned only `status=timeout`) | Updated AgentDef to spell out `candidate_id`, `dim_means`, `dim_stderr`, `status` + 3 status semantics |
| LOW | `__init__.py` did not export `Pilot` | Added to `__all__` |
| LOW | `_parse_critique` and `_parse_pilot` duplicate JSON-as-text fallback + required-field validation | Deferred — will lift to `agents/base.py` once S6/S7 also need it (avoid premature abstraction) |

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] mypy plugins/seed_pipeline/agents/pilot.py clean
- [x] pytest tests/plugins/seed_pipeline/test_pilot.py — 14/14 pass

## Reference
- co-scientist arXiv:2502.18864 §3 Pilot role (GEODE substitution: paper's "scientist-in-the-loop" → automated Petri inner-loop subset)
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S5 row
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied