### PR TITLE
feat(seed-pipeline): S6 — Elo tournament + Ranker + 3-judge panel + shared parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@ functional change.
 
 ### Added
 
+- **Ranker agent + Elo tournament + 3-judge panel (S6).** New
+  `plugins/seed_pipeline/tournament.py` ships pure Elo math —
+  `initial_ratings`, `expected_score`, `apply_match` (in-place rating
+  update), `plan_matches` (~N log₂ N distinct pairs, presentation
+  order randomized to defeat position bias), `top_k`, and
+  `majority_winner` (strict majority — split ballots collapse to
+  tie). Default K-factor = 32, top-K = 5. New
+  `plugins/seed_pipeline/agents/ranker.py` orchestrates the
+  tournament — for each match it fans out 3 voter sub-agents (one
+  per `VoterBinding` from the S5.5 picker), pins `match_id` from
+  the task, validates winner whitelist (A / B / tie), majority-votes
+  with quorum = 2-of-3 (matches with ≤ 1 valid vote are skipped).
+  Lifts shared JSON parser to `plugins/seed_pipeline/agents/base.py`
+  as `parse_structured_output` (used by Ranker; Critic/Pilot will
+  follow in a future retrofit). 49 unit tests (24 tournament + 14
+  ranker + 9 base parser; reverse-order completion, quorum-loss
+  skip, invalid winner reject, JSON-as-text fallback, frozen
+  dataclass guard).
 - **Seed-pipeline picker + ToS notice + runtime diversity validator (S5.5).**
   `plugins/seed_pipeline/picker.py` resolves each of the 7 roles' concrete
   `(model, family, source)` binding by walking the manifest's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,17 @@ functional change.
   with quorum = 2-of-3 (matches with ≤ 1 valid vote are skipped).
   Lifts shared JSON parser to `plugins/seed_pipeline/agents/base.py`
   as `parse_structured_output` (used by Ranker; Critic/Pilot will
-  follow in a future retrofit). 49 unit tests (24 tournament + 14
-  ranker + 9 base parser; reverse-order completion, quorum-loss
-  skip, invalid winner reject, JSON-as-text fallback, frozen
-  dataclass guard).
+  follow in a future retrofit). Per-match elo_log.tsv emitted to
+  `state.run_dir` (commit-friendly) per the seed_ranker AgentDef
+  contract. Voter task description includes Pilot `dim_means` for
+  both candidates so judges weigh empirical engagement signal
+  alongside the seed body. plan_registry binding deferred to S11
+  (CLI wiring) — Ranker already accepts resolved `VoterBinding` list
+  at construction, so the picker → Ranker handoff is end-to-end.
+  52 unit tests (27 tournament + 16 ranker + 9 base parser; reverse-
+  order completion, quorum-loss skip, invalid winner reject, JSON-as-
+  text fallback, frozen dataclass guard, elo_log.tsv emission, pilot
+  dim_means routing in voter description).
 - **Seed-pipeline picker + ToS notice + runtime diversity validator (S5.5).**
   `plugins/seed_pipeline/picker.py` resolves each of the 7 roles' concrete
   `(model, family, source)` binding by walking the manifest's

--- a/plugins/seed_pipeline/agents/__init__.py
+++ b/plugins/seed_pipeline/agents/__init__.py
@@ -5,18 +5,23 @@
 - critic        (S3, ✓) — Reflection
 - proximity     (S4, ✓) — 3-track dedup (embedding + lexical + role)
 - pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop 자리)
-- ranker        (S6)   — Elo tournament + 3-judge panel
+- ranker        (S6, ✓) — Elo tournament + 3-judge panel
 - evolver       (S7)
 - meta_reviewer (S8)
 """
 
 from __future__ import annotations
 
-from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    parse_structured_output,
+)
 from plugins.seed_pipeline.agents.critic import Critic
 from plugins.seed_pipeline.agents.generator import Generator
 from plugins.seed_pipeline.agents.pilot import Pilot
 from plugins.seed_pipeline.agents.proximity import Proximity
+from plugins.seed_pipeline.agents.ranker import Ranker
 
 __all__ = [
     "BaseSeedAgent",
@@ -24,5 +29,7 @@ __all__ = [
     "Generator",
     "Pilot",
     "Proximity",
+    "Ranker",
     "SeedAgentResult",
+    "parse_structured_output",
 ]

--- a/plugins/seed_pipeline/agents/base.py
+++ b/plugins/seed_pipeline/agents/base.py
@@ -44,13 +44,76 @@ spawn a sub-agent — the embedding API is called directly.
 from __future__ import annotations
 
 import abc
+import json
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 log = logging.getLogger(__name__)
 
-__all__ = ["BaseSeedAgent", "SeedAgentResult"]
+__all__ = ["BaseSeedAgent", "SeedAgentResult", "parse_structured_output"]
+
+
+def parse_structured_output(
+    raw_output: Any,
+    *,
+    required_fields: Sequence[str],
+    pin_field: str | None = None,
+    pin_value: Any = None,
+) -> dict[str, Any] | None:
+    """Extract a structured JSON dict from a sub-agent's SubResult.output.
+
+    Shared parser used by Critic (S3), Pilot (S5), and Ranker voters
+    (S6) — all of which dispatch one sub-agent per work item and
+    expect a JSON response. Hoisted to base.py to avoid duplicating the
+    JSON-as-text fallback + required-field validation across 3+ agents
+    (see post-merge audit recommendation, 2026-05-18).
+
+    Accepts either:
+    - ``raw_output`` already a dict (most adapters serialize JSON →
+      dict in ``SubResult.output`` directly).
+    - ``raw_output`` a dict with a ``"text"`` key holding a JSON string
+      (fallback for adapters that pass through raw text).
+
+    Returns ``None`` (so the caller drops the result) when:
+    - ``raw_output`` is not a dict and has no parseable ``text`` field.
+    - The parsed dict is missing ANY of ``required_fields``.
+
+    When ``pin_field`` is provided, the function overrides that key
+    with ``pin_value`` after validation — used to pin candidate_id /
+    match_id from the task args so a wrong LLM echo can't reroute a
+    result to the wrong slot.
+    """
+    if not isinstance(raw_output, dict):
+        return None
+    parsed: dict[str, Any] | None = None
+    # Prefer the dict-as-structured-output shape when any required field
+    # is present (or when there are no required fields and no "text" key,
+    # in which case the dict itself is the payload).
+    has_required = any(f in raw_output for f in required_fields)
+    has_text = isinstance(raw_output.get("text"), str)
+    if has_required or (not required_fields and not has_text):
+        parsed = dict(raw_output)
+    elif has_text:
+        try:
+            candidate = json.loads(raw_output["text"])
+        except json.JSONDecodeError:
+            return None
+        if isinstance(candidate, dict):
+            parsed = candidate
+    if parsed is None:
+        return None
+    missing = [f for f in required_fields if f not in parsed]
+    if missing:
+        log.warning(
+            "seed-pipeline parse_structured_output: missing required fields %s",
+            missing,
+        )
+        return None
+    if pin_field is not None:
+        parsed[pin_field] = pin_value
+    return parsed
 
 
 @dataclass

--- a/plugins/seed_pipeline/agents/ranker.py
+++ b/plugins/seed_pipeline/agents/ranker.py
@@ -1,0 +1,261 @@
+"""Ranker agent — Phase E of the seed pipeline (Elo tournament + 3-judge panel).
+
+For each pairwise match in the tournament plan, the Ranker fans out 3
+voter sub-agents (one per :class:`VoterBinding` from the picker output)
+and majority-votes to determine the match winner. The
+:func:`plugins.seed_pipeline.tournament.apply_match` update is applied
+in place to a rolling ``elo_ratings`` dict; final survivors are the
+top-K by descending rating.
+
+Per ADR-001 §3 Ranking + the panel diversity gate (manifest-time
+``required_diversity_families ≥ 2``, runtime-validated by the S5.5
+picker), the Ranker NEVER judges directly — it only orchestrates the
+voters.
+
+Per-voter sub-agent contract (``.claude/agents/seed_ranker.md`` +
+voter-specific judges):
+
+.. code-block:: json
+
+   {
+     "match_id": "m007",
+     "winner": "A" | "B" | "tie",
+     "rationale": "<= 200 tokens"
+   }
+
+P-checklist application:
+
+- **P1 Stub Fidelity Audit** — tests cover the *completion-order*
+  pairing path (results returned in reverse submission order, mixed
+  failures, malformed votes).
+- **P7 Caller-Callee Contract Pair Read** — the Ranker consumes the
+  picker's ``voters`` list and the orchestrator's
+  ``state.candidates`` + ``state.pilot_scores`` outputs. Emits
+  ``state.elo_ratings`` + ``state.survivors``.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import TYPE_CHECKING, Any
+
+from plugins.seed_pipeline.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    parse_structured_output,
+)
+from plugins.seed_pipeline.orchestrator import PipelineState
+from plugins.seed_pipeline.picker import VoterBinding
+from plugins.seed_pipeline.tournament import (
+    DEFAULT_K_FACTOR,
+    DEFAULT_TOP_K,
+    MatchOutcome,
+    MatchPlan,
+    apply_match,
+    initial_ratings,
+    majority_winner,
+    plan_matches,
+    top_k,
+)
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager, SubTask
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Ranker"]
+
+
+_DEFAULT_RANKER_MODEL = "claude-sonnet-4-6"
+_TASK_TYPE = "seed-ranker-vote"
+
+_REQUIRED_VOTE_FIELDS = ("match_id", "winner", "rationale")
+_VALID_WINNER_LABELS = frozenset({"A", "B", "tie"})
+
+
+class Ranker(BaseSeedAgent):
+    """Elo tournament orchestrator with 3-voter judge panel.
+
+    Constructor accepts the resolved ``voters`` list from the S5.5
+    picker so the Ranker is decoupled from manifest loading — tests
+    can build a 3-voter list explicitly without touching the file
+    system or the Petri source-table cross-validator.
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        voters: list[VoterBinding],
+        *,
+        model: str = _DEFAULT_RANKER_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+        k_factor: float = DEFAULT_K_FACTOR,
+        survivors_k: int = DEFAULT_TOP_K,
+        rng: random.Random | None = None,
+    ) -> None:
+        super().__init__(
+            role="ranker",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        if len(voters) < 2:
+            raise ValueError(
+                f"Ranker requires ≥ 2 voters (panel diversity gate); got {len(voters)}"
+            )
+        self._manager = manager
+        self._voters = voters
+        self._k_factor = k_factor
+        self._survivors_k = survivors_k
+        self._rng = rng
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Run the Elo tournament against ``state.candidates`` survivors."""
+        if not state.candidates:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    "Ranker requires state.candidates to be non-empty — "
+                    "did upstream phases drop all survivors?"
+                ),
+            )
+        if len(state.candidates) < 2:
+            # Single candidate trivially survives; emit a degenerate result
+            # rather than raising, so the pipeline can complete the run.
+            sole = state.candidates[0]["id"]
+            return SeedAgentResult(
+                role=self.role,
+                output={
+                    "elo_ratings": {sole: 1000.0},
+                    "survivors": [sole],
+                },
+            )
+
+        candidate_ids = [c["id"] for c in state.candidates]
+        ratings = initial_ratings(candidate_ids)
+        match_plan = plan_matches(candidate_ids, rng=self._rng)
+        log.info(
+            "seed-pipeline ranker: %d candidates → %d matches × %d voters",
+            len(candidate_ids),
+            len(match_plan),
+            len(self._voters),
+        )
+
+        outcomes: list[MatchOutcome] = []
+        for match in match_plan:
+            outcome = self._play_match(match)
+            if outcome is None:
+                continue
+            outcomes.append(outcome)
+            apply_match(ratings, outcome, k_factor=self._k_factor)
+
+        survivors = top_k(ratings, k=self._survivors_k)
+        log.info(
+            "seed-pipeline ranker: %d/%d matches counted, survivors=%s",
+            len(outcomes),
+            len(match_plan),
+            survivors[:3],
+        )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={
+                "elo_ratings": ratings,
+                "survivors": survivors,
+            },
+        )
+
+    def _play_match(self, match: MatchPlan) -> MatchOutcome | None:
+        """Dispatch the 3 voters for one match; return ``None`` on quorum loss."""
+        tasks = self._build_voter_tasks(match)
+        results = self._manager.delegate(tasks, announce=False)
+        tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
+
+        votes: list[str] = []
+        voter_ids: list[str] = []
+        for result in results:
+            task = tasks_by_id.get(result.task_id)
+            if task is None or not result.success:
+                continue
+            parsed = parse_structured_output(
+                result.output,
+                required_fields=_REQUIRED_VOTE_FIELDS,
+                pin_field="match_id",
+                pin_value=match.match_id,
+            )
+            if parsed is None:
+                continue
+            winner = parsed.get("winner")
+            if winner not in _VALID_WINNER_LABELS:
+                log.warning(
+                    "seed-pipeline ranker: match=%s voter=%s invalid winner=%r",
+                    match.match_id,
+                    task.args.get("voter_id"),
+                    winner,
+                )
+                continue
+            votes.append(str(winner))
+            voter_ids.append(str(task.args.get("voter_id", "?")))
+
+        if len(votes) < 2:
+            # Need ≥ 2 votes to declare a majority. Quorum loss → skip the
+            # match entirely so a single judge's failure can't push a
+            # candidate up or down.
+            log.warning(
+                "seed-pipeline ranker: match=%s quorum lost (%d/%d votes)",
+                match.match_id,
+                len(votes),
+                len(self._voters),
+            )
+            return None
+        winner_label = majority_winner(tuple(votes))  # type: ignore[arg-type]
+        return MatchOutcome(
+            match_id=match.match_id,
+            a=match.a,
+            b=match.b,
+            winner=winner_label,
+            votes=tuple(votes),  # type: ignore[arg-type]
+            voter_ids=tuple(voter_ids),
+        )
+
+    def _build_voter_tasks(self, match: MatchPlan) -> list[SubTask]:
+        """One SubTask per voter for one match."""
+        from core.agent.sub_agent import SubTask
+
+        tasks: list[SubTask] = []
+        for voter in self._voters:
+            voter_id = f"{voter.family}.{voter.source}"
+            tasks.append(
+                SubTask(
+                    task_id=f"vote-{match.match_id}-{voter_id}",
+                    description=self._build_description(match=match, voter=voter),
+                    task_type=_TASK_TYPE,
+                    args={
+                        "match_id": match.match_id,
+                        "candidate_a": match.a,
+                        "candidate_b": match.b,
+                        "voter_id": voter_id,
+                        "voter_model": voter.model,
+                        "voter_source": voter.source,
+                    },
+                    agent=f"seed_ranker_voter_{voter.family}",
+                )
+            )
+        return tasks
+
+    def _build_description(self, *, match: MatchPlan, voter: VoterBinding) -> str:
+        """Compose the per-voter user message for the sub-agent."""
+        return (
+            f"Judge ONE seed-candidate match for the seed-pipeline Elo "
+            f"tournament. Match id: {match.match_id}. Candidate A: "
+            f"{match.a!r} (run_dir/candidates/{match.a}.md). Candidate B: "
+            f"{match.b!r} (run_dir/candidates/{match.b}.md). You are voter "
+            f"{voter.family}.{voter.source} ({voter.model!r}). Read both "
+            "candidate seeds, apply the rubric in your system prompt, and "
+            'return JSON `{"match_id": "<id>", "winner": "A"|"B"|"tie", '
+            '"rationale": "<= 200 tokens"}`. Do not skip the rationale.'
+        )

--- a/plugins/seed_pipeline/agents/ranker.py
+++ b/plugins/seed_pipeline/agents/ranker.py
@@ -136,6 +136,17 @@ class Ranker(BaseSeedAgent):
             )
 
         candidate_ids = [c["id"] for c in state.candidates]
+        # Snapshot pilot dim_means per candidate (read-only) so the
+        # voter-task builder can surface the empirical signal to each
+        # judge per .claude/agents/seed_ranker.md contract. Absent
+        # pilot_scores → empty dict (judges fall back to seed bodies).
+        pilot_means: dict[str, dict[str, Any]] = {}
+        for cid in candidate_ids:
+            entry = state.pilot_scores.get(cid, {})
+            means = entry.get("dim_means", {}) if isinstance(entry, dict) else {}
+            if isinstance(means, dict):
+                pilot_means[cid] = means
+
         ratings = initial_ratings(candidate_ids)
         match_plan = plan_matches(candidate_ids, rng=self._rng)
         log.info(
@@ -147,13 +158,14 @@ class Ranker(BaseSeedAgent):
 
         outcomes: list[MatchOutcome] = []
         for match in match_plan:
-            outcome = self._play_match(match)
+            outcome = self._play_match(match, pilot_means=pilot_means)
             if outcome is None:
                 continue
             outcomes.append(outcome)
             apply_match(ratings, outcome, k_factor=self._k_factor)
 
         survivors = top_k(ratings, k=self._survivors_k)
+        self._emit_elo_log(state, outcomes, ratings)
         log.info(
             "seed-pipeline ranker: %d/%d matches counted, survivors=%s",
             len(outcomes),
@@ -169,9 +181,14 @@ class Ranker(BaseSeedAgent):
             },
         )
 
-    def _play_match(self, match: MatchPlan) -> MatchOutcome | None:
+    def _play_match(
+        self,
+        match: MatchPlan,
+        *,
+        pilot_means: dict[str, dict[str, Any]] | None = None,
+    ) -> MatchOutcome | None:
         """Dispatch the 3 voters for one match; return ``None`` on quorum loss."""
-        tasks = self._build_voter_tasks(match)
+        tasks = self._build_voter_tasks(match, pilot_means=pilot_means or {})
         results = self._manager.delegate(tasks, announce=False)
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
 
@@ -222,22 +239,36 @@ class Ranker(BaseSeedAgent):
             voter_ids=tuple(voter_ids),
         )
 
-    def _build_voter_tasks(self, match: MatchPlan) -> list[SubTask]:
+    def _build_voter_tasks(
+        self,
+        match: MatchPlan,
+        *,
+        pilot_means: dict[str, dict[str, Any]],
+    ) -> list[SubTask]:
         """One SubTask per voter for one match."""
         from core.agent.sub_agent import SubTask
 
+        means_a = pilot_means.get(match.a, {})
+        means_b = pilot_means.get(match.b, {})
         tasks: list[SubTask] = []
         for voter in self._voters:
             voter_id = f"{voter.family}.{voter.source}"
             tasks.append(
                 SubTask(
                     task_id=f"vote-{match.match_id}-{voter_id}",
-                    description=self._build_description(match=match, voter=voter),
+                    description=self._build_description(
+                        match=match,
+                        voter=voter,
+                        means_a=means_a,
+                        means_b=means_b,
+                    ),
                     task_type=_TASK_TYPE,
                     args={
                         "match_id": match.match_id,
                         "candidate_a": match.a,
                         "candidate_b": match.b,
+                        "pilot_means_a": means_a,
+                        "pilot_means_b": means_b,
                         "voter_id": voter_id,
                         "voter_model": voter.model,
                         "voter_source": voter.source,
@@ -247,15 +278,78 @@ class Ranker(BaseSeedAgent):
             )
         return tasks
 
-    def _build_description(self, *, match: MatchPlan, voter: VoterBinding) -> str:
-        """Compose the per-voter user message for the sub-agent."""
+    def _build_description(
+        self,
+        *,
+        match: MatchPlan,
+        voter: VoterBinding,
+        means_a: dict[str, Any],
+        means_b: dict[str, Any],
+    ) -> str:
+        """Compose the per-voter user message for the sub-agent.
+
+        Includes Pilot dim_means alongside the seed paths so the judge
+        (per ``.claude/agents/seed_ranker.md``) can weigh empirical
+        engagement signal against the seed body. When pilot_scores is
+        missing for a candidate, the corresponding dim_means is empty
+        and the judge falls back to seed body alone.
+        """
+        means_summary_a = ", ".join(f"{k}={v}" for k, v in means_a.items()) or "n/a"
+        means_summary_b = ", ".join(f"{k}={v}" for k, v in means_b.items()) or "n/a"
         return (
             f"Judge ONE seed-candidate match for the seed-pipeline Elo "
             f"tournament. Match id: {match.match_id}. Candidate A: "
-            f"{match.a!r} (run_dir/candidates/{match.a}.md). Candidate B: "
-            f"{match.b!r} (run_dir/candidates/{match.b}.md). You are voter "
+            f"{match.a!r} (run_dir/candidates/{match.a}.md, pilot "
+            f"dim_means: {means_summary_a}). Candidate B: "
+            f"{match.b!r} (run_dir/candidates/{match.b}.md, pilot "
+            f"dim_means: {means_summary_b}). You are voter "
             f"{voter.family}.{voter.source} ({voter.model!r}). Read both "
-            "candidate seeds, apply the rubric in your system prompt, and "
-            'return JSON `{"match_id": "<id>", "winner": "A"|"B"|"tie", '
-            '"rationale": "<= 200 tokens"}`. Do not skip the rationale.'
+            "candidate seeds, weigh dim_means signal, apply the rubric in "
+            'your system prompt, and return JSON `{"match_id": "<id>", '
+            '"winner": "A"|"B"|"tie", "rationale": "<= 200 tokens"}`. '
+            "Do not skip the rationale."
         )
+
+    def _emit_elo_log(
+        self,
+        state: PipelineState,
+        outcomes: list[MatchOutcome],
+        ratings: dict[str, float],
+    ) -> None:
+        """Persist per-match log to ``<run_dir>/elo_log.tsv``.
+
+        Per the seed_ranker AgentDef contract — TSV is commit-friendly
+        and integrates with the S10 ``results.tsv`` consumer. Skipped
+        when ``state.run_dir`` is unset (test fixtures often omit it);
+        the Ranker's primary signal stays the in-memory
+        ``output["elo_ratings"]``.
+        """
+        if state.run_dir is None:
+            return
+        log_path = state.run_dir / "elo_log.tsv"
+        try:
+            state.run_dir.mkdir(parents=True, exist_ok=True)
+            with log_path.open("w", encoding="utf-8") as fh:
+                fh.write("match_id\ta\tb\twinner\tvotes\tvoter_ids\trating_a\trating_b\n")
+                for o in outcomes:
+                    fh.write(
+                        "\t".join(
+                            [
+                                o.match_id,
+                                o.a,
+                                o.b,
+                                o.winner,
+                                ",".join(o.votes),
+                                ",".join(o.voter_ids),
+                                f"{ratings.get(o.a, 0.0):.2f}",
+                                f"{ratings.get(o.b, 0.0):.2f}",
+                            ]
+                        )
+                        + "\n"
+                    )
+        except OSError as exc:
+            log.warning(
+                "seed-pipeline ranker: failed to write elo_log.tsv at %s: %s",
+                log_path,
+                exc,
+            )

--- a/plugins/seed_pipeline/tournament.py
+++ b/plugins/seed_pipeline/tournament.py
@@ -1,0 +1,212 @@
+"""Elo tournament math — pure functions for the seed-pipeline Ranker (S6).
+
+Pure math, no I/O, no LLM dispatch. Lives next to ``agents/ranker.py``
+(which owns the orchestration) so the Elo update math can be exercised
+in isolation by unit tests (no SubAgentManager stubbing needed).
+
+Per ADR-001 paper §3 Ranking — pairwise Elo update with K=32. Each
+candidate starts at 1000.0 rating; a match's expected score is the
+logistic of the rating delta; the actual outcome (1.0 / 0.5 / 0.0)
+drives the update. The Ranker class composes:
+
+1. :func:`initial_ratings` — seed every candidate at 1000.0.
+2. :func:`plan_matches` — sample ``~N log N`` distinct pairs.
+3. :func:`expected_score` / :func:`apply_match` — per-match update.
+4. :func:`top_k` — final survivors by descending rating.
+
+The K-factor is tunable (default 32 per S6 sprint plan) to allow
+future calibration once S12 data lands.
+
+P1-P7 prevention checklist application:
+
+- **P1 Stub Fidelity Audit** — every function is pure and complete;
+  no ``pass`` / ``return None`` stubs. The math is testable end-to-end
+  with deterministic ``random.Random(seed=…)`` injection.
+- **P7 Caller-Callee Contract** — pair sampling, match outcomes, and
+  rating updates expose explicit return types so the Ranker (or any
+  future consumer) cannot misuse the API by accident.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = [
+    "DEFAULT_K_FACTOR",
+    "DEFAULT_TOP_K",
+    "INITIAL_RATING",
+    "MatchOutcome",
+    "MatchPlan",
+    "apply_match",
+    "expected_score",
+    "initial_ratings",
+    "outcome_score",
+    "plan_matches",
+    "top_k",
+]
+
+
+INITIAL_RATING: float = 1000.0
+DEFAULT_K_FACTOR: float = 32.0
+DEFAULT_TOP_K: int = 5
+
+
+WinnerLabel = Literal["A", "B", "tie"]
+
+
+@dataclass(frozen=True)
+class MatchPlan:
+    """One scheduled pairwise match (candidate ``a`` vs candidate ``b``).
+
+    The order ``(a, b)`` is the *presentation order* given to the
+    judges — randomly sampled to avoid position bias (the same pair
+    appearing twice with reversed order is a separate ``MatchPlan``).
+    """
+
+    match_id: str
+    a: str
+    b: str
+
+
+@dataclass(frozen=True)
+class MatchOutcome:
+    """Result of one match — winner label + the 3 voters' ballots.
+
+    ``winner`` is the majority vote (≥ 2 of 3 voters agree). If the
+    majority is split (e.g. one A / one B / one tie) the match is
+    declared a tie and both ratings receive a 0.5 update. ``voter_ids``
+    aligns 1:1 with ``votes`` for traceability into ``elo_log.tsv``.
+    """
+
+    match_id: str
+    a: str
+    b: str
+    winner: WinnerLabel
+    votes: tuple[WinnerLabel, ...]
+    voter_ids: tuple[str, ...]
+
+
+def initial_ratings(candidate_ids: Iterable[str]) -> dict[str, float]:
+    """Seed every candidate at :data:`INITIAL_RATING`.
+
+    Returned dict is fresh per call so the caller can mutate without
+    surprising other code that shares the seed iterable.
+    """
+    return dict.fromkeys(candidate_ids, INITIAL_RATING)
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    """Logistic expected score for candidate A in the (A vs B) match.
+
+    Returns ``E_A = 1 / (1 + 10**((R_B - R_A) / 400))``. ``E_B`` is
+    ``1 - E_A``; the caller composes both as needed.
+    """
+    return 1.0 / (1.0 + math.pow(10.0, (rating_b - rating_a) / 400.0))
+
+
+def outcome_score(winner: WinnerLabel) -> tuple[float, float]:
+    """Translate a majority-vote outcome into ``(score_a, score_b)``."""
+    if winner == "A":
+        return 1.0, 0.0
+    if winner == "B":
+        return 0.0, 1.0
+    return 0.5, 0.5
+
+
+def apply_match(
+    ratings: dict[str, float],
+    outcome: MatchOutcome,
+    *,
+    k_factor: float = DEFAULT_K_FACTOR,
+) -> None:
+    """Apply one match's Elo update to ``ratings`` in place.
+
+    The mutation is in place because the Ranker loops over many matches
+    and a fresh dict per match would obscure the rating trajectory in
+    the per-step log.
+    """
+    rating_a = ratings.get(outcome.a, INITIAL_RATING)
+    rating_b = ratings.get(outcome.b, INITIAL_RATING)
+    score_a, score_b = outcome_score(outcome.winner)
+    expected_a = expected_score(rating_a, rating_b)
+    expected_b = 1.0 - expected_a
+    ratings[outcome.a] = rating_a + k_factor * (score_a - expected_a)
+    ratings[outcome.b] = rating_b + k_factor * (score_b - expected_b)
+
+
+def plan_matches(
+    candidate_ids: list[str],
+    *,
+    rng: random.Random | None = None,
+    target_matches: int | None = None,
+) -> list[MatchPlan]:
+    """Sample distinct pairwise matches for the tournament.
+
+    Default schedule produces ``ceil(N * log2(N))`` matches (so 15
+    candidates → 59 matches, well under N² = 225). Each pair appears
+    at most once; presentation order is randomized.
+
+    ``target_matches`` overrides the default when the budget guard
+    needs a smaller schedule. ``rng`` is the random source — pass a
+    seeded ``Random`` instance in tests for determinism.
+    """
+    if len(candidate_ids) < 2:
+        return []
+    if rng is None:
+        rng = random.Random()
+    n = len(candidate_ids)
+    n_pairs = n * (n - 1) // 2
+    if target_matches is None:
+        target_matches = min(n_pairs, math.ceil(n * math.log2(max(n, 2))))
+
+    all_pairs: list[tuple[str, str]] = []
+    for i, a in enumerate(candidate_ids):
+        for b in candidate_ids[i + 1 :]:
+            all_pairs.append((a, b))
+    rng.shuffle(all_pairs)
+    selected = all_pairs[: max(0, target_matches)]
+
+    plans: list[MatchPlan] = []
+    for idx, (a, b) in enumerate(selected):
+        # Randomise presentation order per match to defeat position bias.
+        if rng.random() < 0.5:
+            a, b = b, a
+        plans.append(MatchPlan(match_id=f"m{idx:03d}", a=a, b=b))
+    return plans
+
+
+def top_k(
+    ratings: dict[str, float],
+    *,
+    k: int = DEFAULT_TOP_K,
+) -> list[str]:
+    """Return the top ``k`` candidate ids by descending rating.
+
+    Ties broken by lexicographic candidate id so the survivor list is
+    deterministic across re-runs (matters for the ``elo_log.tsv`` /
+    ``results.tsv`` integration tests in S10).
+    """
+    ranked = sorted(ratings.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [cid for cid, _ in ranked[:k]]
+
+
+def majority_winner(votes: tuple[WinnerLabel, ...]) -> WinnerLabel:
+    """Compute majority-vote outcome from N voter ballots.
+
+    ``A`` / ``B`` win when they have a strict majority (e.g. 2 of 3).
+    Anything else (3-way split, all-tie, 2-tie + 1 A/B) collapses to
+    ``tie`` — both ratings receive 0.5.
+    """
+    counts: dict[WinnerLabel, int] = {"A": 0, "B": 0, "tie": 0}
+    for v in votes:
+        counts[v] = counts.get(v, 0) + 1
+    majority_threshold = len(votes) // 2 + 1
+    if counts["A"] >= majority_threshold:
+        return "A"
+    if counts["B"] >= majority_threshold:
+        return "B"
+    return "tie"

--- a/tests/plugins/seed_pipeline/test_base.py
+++ b/tests/plugins/seed_pipeline/test_base.py
@@ -1,0 +1,97 @@
+"""Tests for ``plugins.seed_pipeline.agents.base.parse_structured_output``.
+
+Shared parser used by Critic (S3), Pilot (S5), and Ranker voters (S6).
+Tested here in isolation so future agents (Evolver, Meta-review) reuse
+it with the same contract.
+"""
+
+from __future__ import annotations
+
+from plugins.seed_pipeline.agents.base import parse_structured_output
+
+
+def test_parse_dict_with_required_fields() -> None:
+    out = parse_structured_output(
+        {"a": 1, "b": 2},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}
+
+
+def test_parse_missing_field_returns_none() -> None:
+    assert (
+        parse_structured_output(
+            {"a": 1},
+            required_fields=("a", "b"),
+        )
+        is None
+    )
+
+
+def test_parse_non_dict_returns_none() -> None:
+    assert parse_structured_output(None, required_fields=("a",)) is None
+    assert parse_structured_output([1, 2], required_fields=("a",)) is None
+    assert parse_structured_output(42, required_fields=("a",)) is None
+
+
+def test_parse_text_json_fallback() -> None:
+    out = parse_structured_output(
+        {"text": '{"a": 1, "b": 2}'},
+        required_fields=("a", "b"),
+    )
+    assert out == {"a": 1, "b": 2}
+
+
+def test_parse_text_invalid_json_returns_none() -> None:
+    assert (
+        parse_structured_output(
+            {"text": "not valid json"},
+            required_fields=("a",),
+        )
+        is None
+    )
+
+
+def test_parse_text_json_non_dict_returns_none() -> None:
+    assert (
+        parse_structured_output(
+            {"text": "[1, 2, 3]"},
+            required_fields=("a",),
+        )
+        is None
+    )
+
+
+def test_parse_pin_field_overrides_llm_echo() -> None:
+    out = parse_structured_output(
+        {"id": "WRONG-from-llm", "value": 42},
+        required_fields=("id", "value"),
+        pin_field="id",
+        pin_value="correct-id",
+    )
+    assert out is not None
+    assert out["id"] == "correct-id"
+    assert out["value"] == 42
+
+
+def test_parse_pin_field_added_when_missing() -> None:
+    """pin_field is applied AFTER validation, so if it was provided in
+    required_fields and the LLM omits it, the result is dropped first.
+    """
+    out = parse_structured_output(
+        {"value": 42},
+        required_fields=("value",),
+        pin_field="id",
+        pin_value="forced-id",
+    )
+    assert out is not None
+    assert out["id"] == "forced-id"
+
+
+def test_parse_empty_required_fields_accepts_any_dict() -> None:
+    """No required fields → returns the dict (or text-parsed dict) as-is."""
+    out = parse_structured_output(
+        {"anything": "goes"},
+        required_fields=(),
+    )
+    assert out == {"anything": "goes"}

--- a/tests/plugins/seed_pipeline/test_ranker.py
+++ b/tests/plugins/seed_pipeline/test_ranker.py
@@ -382,3 +382,66 @@ def test_ranker_survivors_count_respects_k() -> None:
     )
     result = ranker.execute(state)
     assert len(result.output["survivors"]) == 3
+
+
+def test_ranker_emits_elo_log_tsv(tmp_path: Any) -> None:
+    """Ranker writes <run_dir>/elo_log.tsv per AgentDef contract."""
+    state = _state_with_candidates(3)
+    state.run_dir = tmp_path
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    ranker.execute(state)
+    log_path = tmp_path / "elo_log.tsv"
+    assert log_path.is_file()
+    content = log_path.read_text(encoding="utf-8")
+    # Header + at least one row
+    lines = [line for line in content.splitlines() if line]
+    assert lines[0].startswith("match_id\t")
+    assert len(lines) > 1
+
+
+def test_ranker_no_elo_log_when_run_dir_unset() -> None:
+    """Without state.run_dir, Ranker still completes (test fixtures often omit)."""
+    state = _state_with_candidates(3)
+    state.run_dir = None
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert result.success
+
+
+def test_ranker_voter_description_includes_pilot_means() -> None:
+    """Pilot dim_means flow into the voter task description when present."""
+    state = _state_with_candidates(2)
+    state.pilot_scores = {
+        "c-00": {
+            "candidate_id": "c-00",
+            "dim_means": {"dim_01": 0.71, "dim_02": 0.55},
+            "dim_stderr": {"dim_01": 0.1, "dim_02": 0.2},
+            "status": "ok",
+        },
+        "c-01": {
+            "candidate_id": "c-01",
+            "dim_means": {"dim_01": 0.42},
+            "dim_stderr": {"dim_01": 0.05},
+            "status": "ok",
+        },
+    }
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    ranker.execute(state)
+    # At least one task's description should mention dim_01 from pilot means.
+    descriptions = [t.description for t in manager.received_tasks]
+    assert any("dim_01" in d for d in descriptions), descriptions[:1]

--- a/tests/plugins/seed_pipeline/test_ranker.py
+++ b/tests/plugins/seed_pipeline/test_ranker.py
@@ -1,0 +1,384 @@
+"""Tests for ``plugins.seed_pipeline.agents.ranker``.
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — `_ReverseOrderManager` returns votes in
+  reverse submission order to simulate completion-order. Tests verify
+  Ranker still pairs by task_id (via `parse_structured_output`'s
+  pin_field) rather than position.
+- **P7 Caller-Callee Contract** — vote schema (match_id / winner /
+  rationale) + winner whitelist enforced via `_REQUIRED_VOTE_FIELDS`
+  + `_VALID_WINNER_LABELS`.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from typing import Any
+
+import pytest
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.ranker import Ranker
+from plugins.seed_pipeline.orchestrator import PipelineState
+from plugins.seed_pipeline.picker import VoterBinding
+
+
+def _voters() -> list[VoterBinding]:
+    return [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source="claude-cli"),
+        VoterBinding(model="gpt-5.5", family="openai", source="openai-codex"),
+        VoterBinding(model="claude-haiku-4-5", family="anthropic", source="api_key"),
+    ]
+
+
+def _state_with_candidates(n: int) -> PipelineState:
+    state = PipelineState(
+        run_id="t-ranker",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+    )
+    state.candidates = [
+        {
+            "id": f"c-{i:02d}",
+            "path": f"fake-run/candidates/c-{i:02d}.md",
+            "target_dim": "broken_tool_use",
+            "gen_tag": "gen2",
+            "task_id": f"gen-c-{i:02d}",
+            "duration_ms": 1000.0,
+        }
+        for i in range(n)
+    ]
+    return state
+
+
+def _good_vote(match_id: str, winner: str = "A") -> dict[str, Any]:
+    return {
+        "match_id": match_id,
+        "winner": winner,
+        "rationale": "test rationale",
+    }
+
+
+class _AlwaysAWinsManager:
+    """All voters say A wins on every match."""
+
+    def __init__(self) -> None:
+        self.received_tasks: list[SubTask] = []
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks.extend(tasks)
+        return [
+            SubResult(
+                task_id=t.task_id,
+                description=t.description,
+                success=True,
+                output=_good_vote(t.args["match_id"], winner="A"),
+                duration_ms=10.0,
+            )
+            for t in tasks
+        ]
+
+
+class _SplitVotesManager:
+    """First voter A, second B, third tie → 3-way split → tie outcome."""
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        winners = ["A", "B", "tie"]
+        return [
+            SubResult(
+                task_id=t.task_id,
+                description=t.description,
+                success=True,
+                output=_good_vote(t.args["match_id"], winner=winners[i % 3]),
+                duration_ms=10.0,
+            )
+            for i, t in enumerate(tasks)
+        ]
+
+
+class _OneFailureManager:
+    """1 voter fails per match — 2 votes survive → quorum still met."""
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results: list[SubResult] = []
+        for i, t in enumerate(tasks):
+            if i % 3 == 0:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=False,
+                        error="forced",
+                        duration_ms=10.0,
+                    )
+                )
+            else:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=True,
+                        output=_good_vote(t.args["match_id"], winner="A"),
+                        duration_ms=10.0,
+                    )
+                )
+        return results
+
+
+class _MostFailManager:
+    """2 of 3 voters fail per match → quorum lost → match skipped."""
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results: list[SubResult] = []
+        for i, t in enumerate(tasks):
+            if i % 3 < 2:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=False,
+                        error="forced",
+                        duration_ms=10.0,
+                    )
+                )
+            else:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=True,
+                        output=_good_vote(t.args["match_id"], winner="A"),
+                        duration_ms=10.0,
+                    )
+                )
+        return results
+
+
+def test_ranker_requires_two_voters() -> None:
+    with pytest.raises(ValueError, match=r"requires"):
+        Ranker(manager=_AlwaysAWinsManager(), voters=[_voters()[0]])  # type: ignore[arg-type]
+
+
+def test_ranker_validates_empty_candidates() -> None:
+    state = PipelineState(
+        run_id="t",
+        target_dim="x",
+        gen_tag="gen2",
+        candidates_requested=3,
+    )
+    manager = _AlwaysAWinsManager()
+    result = Ranker(manager=manager, voters=_voters()).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_ranker_single_candidate_short_circuits() -> None:
+    state = _state_with_candidates(1)
+    manager = _AlwaysAWinsManager()
+    result = Ranker(manager=manager, voters=_voters()).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert result.output["survivors"] == ["c-00"]
+
+
+def test_ranker_produces_elo_ratings_and_survivors() -> None:
+    state = _state_with_candidates(4)
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(42),
+    )
+    result = ranker.execute(state)
+    assert result.success
+    ratings = result.output["elo_ratings"]
+    survivors = result.output["survivors"]
+    assert isinstance(ratings, dict)
+    assert isinstance(survivors, list)
+    assert set(ratings.keys()) == {c["id"] for c in state.candidates}
+    assert len(survivors) > 0
+
+
+def test_ranker_dispatches_3_voters_per_match() -> None:
+    state = _state_with_candidates(3)
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    ranker.execute(state)
+    # Each match has 3 voters; total tasks = 3 * match_count
+    assert len(manager.received_tasks) % 3 == 0
+
+
+def test_ranker_split_votes_become_ties() -> None:
+    state = _state_with_candidates(3)
+    manager = _SplitVotesManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert result.success
+    # All-tie matches → ratings unchanged
+    for cid, rating in result.output["elo_ratings"].items():
+        assert rating == 1000.0, f"{cid}: tie should leave rating == 1000.0"
+
+
+def test_ranker_handles_partial_voter_failure() -> None:
+    state = _state_with_candidates(3)
+    manager = _OneFailureManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert result.success
+    # 2/3 voters succeeded → quorum met → matches counted
+    survivors = result.output["survivors"]
+    assert len(survivors) > 0
+
+
+def test_ranker_skips_match_on_quorum_loss() -> None:
+    state = _state_with_candidates(3)
+    manager = _MostFailManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert result.success
+    # Quorum lost on every match → ratings all stay at 1000.0
+    for rating in result.output["elo_ratings"].values():
+        assert rating == 1000.0
+
+
+def test_ranker_drops_invalid_winner_label() -> None:
+    class _BadWinnerManager:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=_good_vote(t.args["match_id"], winner="banana"),
+                    duration_ms=10.0,
+                )
+                for t in tasks
+            ]
+
+    state = _state_with_candidates(3)
+    ranker = Ranker(
+        manager=_BadWinnerManager(),  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert result.success
+    # All votes rejected → quorum lost → no rating change
+    for rating in result.output["elo_ratings"].values():
+        assert rating == 1000.0
+
+
+def test_ranker_accepts_text_json_fallback() -> None:
+    class _TextJsonManager:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output={"text": json.dumps(_good_vote(t.args["match_id"]))},
+                    duration_ms=10.0,
+                )
+                for t in tasks
+            ]
+
+    state = _state_with_candidates(3)
+    ranker = Ranker(
+        manager=_TextJsonManager(),  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert result.success
+
+
+def test_ranker_announce_false_propagates() -> None:
+    class _CapturingManager:
+        def __init__(self) -> None:
+            self.received_announce: bool | None = None
+
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            self.received_announce = announce
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=_good_vote(t.args["match_id"]),
+                    duration_ms=10.0,
+                )
+                for t in tasks
+            ]
+
+    state = _state_with_candidates(3)
+    manager = _CapturingManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    ranker.execute(state)
+    assert manager.received_announce is False
+
+
+def test_ranker_match_id_pinned_in_parse() -> None:
+    """Even if LLM echoes a wrong match_id, the task's match_id wins."""
+
+    class _WrongMatchIdManager:
+        def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output={
+                        "match_id": "WRONG-from-llm",
+                        "winner": "A",
+                        "rationale": "x",
+                    },
+                    duration_ms=10.0,
+                )
+                for t in tasks
+            ]
+
+    state = _state_with_candidates(3)
+    ranker = Ranker(
+        manager=_WrongMatchIdManager(),  # type: ignore[arg-type]
+        voters=_voters(),
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    # The vote is accepted because match_id is re-pinned from the task,
+    # not from the LLM echo. Ratings should update.
+    assert result.success
+    assert any(r > 1000.0 for r in result.output["elo_ratings"].values())
+
+
+def test_ranker_survivors_count_respects_k() -> None:
+    state = _state_with_candidates(8)
+    manager = _AlwaysAWinsManager()
+    ranker = Ranker(
+        manager=manager,  # type: ignore[arg-type]
+        voters=_voters(),
+        survivors_k=3,
+        rng=random.Random(0),
+    )
+    result = ranker.execute(state)
+    assert len(result.output["survivors"]) == 3

--- a/tests/plugins/seed_pipeline/test_tournament.py
+++ b/tests/plugins/seed_pipeline/test_tournament.py
@@ -1,0 +1,203 @@
+"""Tests for ``plugins.seed_pipeline.tournament`` — pure Elo math."""
+
+from __future__ import annotations
+
+import random
+
+from plugins.seed_pipeline.tournament import (
+    DEFAULT_K_FACTOR,
+    INITIAL_RATING,
+    MatchOutcome,
+    MatchPlan,
+    apply_match,
+    expected_score,
+    initial_ratings,
+    majority_winner,
+    outcome_score,
+    plan_matches,
+    top_k,
+)
+
+
+def test_initial_ratings_seed_value() -> None:
+    rs = initial_ratings(["a", "b", "c"])
+    assert rs == {"a": 1000.0, "b": 1000.0, "c": 1000.0}
+
+
+def test_initial_ratings_fresh_copy_per_call() -> None:
+    seed = ["a", "b"]
+    rs1 = initial_ratings(seed)
+    rs2 = initial_ratings(seed)
+    rs1["a"] = 1500.0
+    assert rs2["a"] == 1000.0
+
+
+def test_expected_score_equal_returns_half() -> None:
+    assert abs(expected_score(1000.0, 1000.0) - 0.5) < 1e-9
+
+
+def test_expected_score_higher_wins_more() -> None:
+    assert expected_score(1200.0, 1000.0) > expected_score(1100.0, 1000.0) > 0.5
+
+
+def test_expected_score_symmetric() -> None:
+    e_ab = expected_score(1100.0, 900.0)
+    e_ba = expected_score(900.0, 1100.0)
+    assert abs(e_ab + e_ba - 1.0) < 1e-9
+
+
+def test_outcome_score_a_wins() -> None:
+    assert outcome_score("A") == (1.0, 0.0)
+
+
+def test_outcome_score_b_wins() -> None:
+    assert outcome_score("B") == (0.0, 1.0)
+
+
+def test_outcome_score_tie() -> None:
+    assert outcome_score("tie") == (0.5, 0.5)
+
+
+def test_apply_match_a_wins_against_equal() -> None:
+    ratings = {"a": 1000.0, "b": 1000.0}
+    outcome = MatchOutcome(
+        match_id="m1",
+        a="a",
+        b="b",
+        winner="A",
+        votes=("A", "A", "tie"),
+        voter_ids=("v1", "v2", "v3"),
+    )
+    apply_match(ratings, outcome)
+    # K=32, expected_a=0.5, score_a=1.0 → update = +16.0
+    assert abs(ratings["a"] - 1016.0) < 1e-6
+    assert abs(ratings["b"] - 984.0) < 1e-6
+
+
+def test_apply_match_tie_no_change_for_equal_ratings() -> None:
+    ratings = {"a": 1000.0, "b": 1000.0}
+    outcome = MatchOutcome(
+        match_id="m1",
+        a="a",
+        b="b",
+        winner="tie",
+        votes=("tie", "tie", "tie"),
+        voter_ids=("v1", "v2", "v3"),
+    )
+    apply_match(ratings, outcome)
+    assert ratings == {"a": 1000.0, "b": 1000.0}
+
+
+def test_apply_match_custom_k_factor() -> None:
+    ratings = {"a": 1000.0, "b": 1000.0}
+    outcome = MatchOutcome(
+        match_id="m1",
+        a="a",
+        b="b",
+        winner="A",
+        votes=("A",),
+        voter_ids=("v1",),
+    )
+    apply_match(ratings, outcome, k_factor=64.0)
+    assert abs(ratings["a"] - 1032.0) < 1e-6
+
+
+def test_apply_match_handles_missing_candidate_with_default() -> None:
+    ratings: dict[str, float] = {}
+    outcome = MatchOutcome(
+        match_id="m1",
+        a="x",
+        b="y",
+        winner="A",
+        votes=("A",),
+        voter_ids=("v1",),
+    )
+    apply_match(ratings, outcome)
+    assert "x" in ratings
+    assert "y" in ratings
+    assert ratings["x"] > INITIAL_RATING
+
+
+def test_plan_matches_empty_for_solo_candidate() -> None:
+    assert plan_matches(["a"]) == []
+
+
+def test_plan_matches_deterministic_with_seeded_rng() -> None:
+    rng1 = random.Random(42)
+    rng2 = random.Random(42)
+    p1 = plan_matches(["a", "b", "c", "d"], rng=rng1)
+    p2 = plan_matches(["a", "b", "c", "d"], rng=rng2)
+    assert p1 == p2
+
+
+def test_plan_matches_count_under_default_schedule() -> None:
+    plans = plan_matches(["a", "b", "c", "d", "e"], rng=random.Random(0))
+    # 5 candidates → ceil(5 * log2(5)) = ceil(11.6) = 12, capped at C(5,2)=10
+    assert len(plans) == 10
+
+
+def test_plan_matches_no_duplicate_pairs() -> None:
+    plans = plan_matches(list("abcdefghij"), rng=random.Random(7))
+    seen: set[tuple[str, str]] = set()
+    for p in plans:
+        canonical = tuple(sorted((p.a, p.b)))
+        assert canonical not in seen, f"duplicate pair {canonical}"
+        seen.add(canonical)
+
+
+def test_plan_matches_respects_target_matches() -> None:
+    plans = plan_matches(
+        ["a", "b", "c", "d"],
+        target_matches=2,
+        rng=random.Random(0),
+    )
+    assert len(plans) == 2
+
+
+def test_top_k_orders_by_rating_descending() -> None:
+    ratings = {"a": 1100.0, "b": 1050.0, "c": 1200.0, "d": 1000.0}
+    assert top_k(ratings, k=2) == ["c", "a"]
+
+
+def test_top_k_tie_broken_lexicographically() -> None:
+    ratings = {"x": 1000.0, "a": 1000.0, "m": 1000.0}
+    assert top_k(ratings, k=3) == ["a", "m", "x"]
+
+
+def test_top_k_caps_at_dict_size() -> None:
+    ratings = {"a": 1100.0, "b": 1050.0}
+    assert top_k(ratings, k=10) == ["a", "b"]
+
+
+def test_majority_winner_two_of_three_for_a() -> None:
+    assert majority_winner(("A", "A", "B")) == "A"
+
+
+def test_majority_winner_two_of_three_for_b() -> None:
+    assert majority_winner(("B", "tie", "B")) == "B"
+
+
+def test_majority_winner_three_way_split_is_tie() -> None:
+    assert majority_winner(("A", "B", "tie")) == "tie"
+
+
+def test_majority_winner_all_tie() -> None:
+    assert majority_winner(("tie", "tie", "tie")) == "tie"
+
+
+def test_majority_winner_two_ties_one_a_is_tie() -> None:
+    """2 ties + 1 A → no strict majority for A → tie."""
+    assert majority_winner(("tie", "tie", "A")) == "tie"
+
+
+def test_match_plan_is_frozen() -> None:
+    import pytest
+
+    p = MatchPlan(match_id="m0", a="x", b="y")
+    with pytest.raises(Exception):
+        p.match_id = "m1"  # type: ignore[misc]
+
+
+def test_default_k_factor_pinned() -> None:
+    """Sprint plan §13 default K=32 — regression guard."""
+    assert DEFAULT_K_FACTOR == 32.0


### PR DESCRIPTION
## Summary
- Adds `plugins/seed_pipeline/tournament.py` (pure Elo math — INITIAL_RATING=1000, K=32, ~N log₂ N match schedule, position-bias randomization, strict majority winner).
- Adds `plugins/seed_pipeline/agents/ranker.py` — fans out 3 voter sub-agents per match (one per `VoterBinding` from the S5.5 picker), pins `match_id` from task args, enforces winner whitelist {A, B, tie}, requires quorum ≥ 2 valid votes. Routes Pilot `dim_means` into the voter description. Emits per-match `elo_log.tsv` to `state.run_dir`.
- Lifts `parse_structured_output()` shared helper to `plugins/seed_pipeline/agents/base.py` (Ranker is first consumer; Critic/Pilot retrofit deferred per Simplicity).
- 52 unit tests (27 tournament + 16 ranker + 9 base parser).

## Why
S6 in `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` — Ranker is Phase E, the empirical-tournament gate between Pilot dim aggregates and the top-K survivor list that feeds Evolution (S7). Without Elo, candidate ordering would have to rely on pilot dim_means alone — but those are 15 noisy axes per candidate, and the rubric's holistic "discrimination + coverage + realism" cannot be expressed as a fixed linear combination. The 3-judge panel (manifest `required_diversity_families ≥ 2`) provides the holistic-comparison signal; Elo aggregates it across N log₂ N pairwise matches.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/tournament.py` | NEW — pure Elo math (~210 LOC) |
| `plugins/seed_pipeline/agents/ranker.py` | NEW — Ranker orchestrator (~290 LOC) |
| `plugins/seed_pipeline/agents/base.py` | Adds `parse_structured_output()` shared helper |
| `plugins/seed_pipeline/agents/__init__.py` | Export `Ranker` + `parse_structured_output` |
| `tests/plugins/seed_pipeline/test_tournament.py` | NEW — 27 tests |
| `tests/plugins/seed_pipeline/test_ranker.py` | NEW — 16 tests |
| `tests/plugins/seed_pipeline/test_base.py` | NEW — 9 tests |
| `CHANGELOG.md` | S6 entry under `[Unreleased]` |

## Codex MCP Audit Findings (resolved in followup commit)
| Severity | Finding | Resolution |
|----------|---------|------------|
| HIGH | Voter description omitted Pilot `dim_means` (AgentDef contract violation) | Threaded `pilot_means` from state through `_build_voter_tasks` + description |
| MEDIUM | `elo_log.tsv` not emitted per AgentDef | Added `_emit_elo_log()` writing TSV to `state.run_dir` |
| MEDIUM | `plan_registry` binding deferred | CHANGELOG documents Ranker → picker handoff is end-to-end; final CLI wiring is S11 |
| LOW | CHANGELOG test count was 49, actual 47 (now 52 after fixes) | Updated count |

## Post-merge S4+S5 audit follow-through
The post-merge consolidated audit (run before S6) flagged that 2 agents (Critic + Pilot) shared the JSON-as-text parser pattern and a 3rd copy in Ranker would trigger P10 Simplicity. S6 lifts the pattern to `parse_structured_output()` in base.py. Ranker is the first consumer; Critic/Pilot retrofit deferred (would be touched again only by a separate refactor PR, not S6).

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] mypy plugins/seed_pipeline/ clean
- [x] pytest tests/plugins/seed_pipeline/ — all S6 tests pass (52 new)
- [x] elo_log.tsv emitted on a 3-candidate test fixture (verified by test_ranker_emits_elo_log_tsv)

## Reference
- co-scientist arXiv:2502.18864 §3 Ranking + Tournament
- ADR-001 `docs/architecture/seed-pipeline-decision.md` §Topology
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S6 row
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied