### PR TITLE
feat(seed-pipeline): S6.5 — cost preview + pre-flight check (auth + budget + diversity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ functional change.
 
 ### Added
 
+- **Cost preview + pre-flight check (S6.5).** New
+  `plugins/seed_pipeline/cost_preview.py` estimates per-role +
+  aggregate USD spend for one full pipeline run using
+  `core.llm.token_tracker.MODEL_PRICING` × per-role token budgets
+  calibrated from ADR-001 §5 (e.g. generator 3000 in / 1000 out per
+  candidate, ranker 3000 in / 300 out per match-voter). Reports
+  separate `subscription_usd` vs `payg_usd` so subscription-backed
+  paths surface as "quota burn equivalent" without conflating with
+  PAYG charge. `format_cost_summary()` renders a plain-text table
+  for the S11 CLI confirm prompt. New
+  `plugins/seed_pipeline/pre_flight.py` runs three checks before
+  the first LLM call: credential probe (claude-cli / openai-codex
+  OAuth + per-family api_key env vars), budget sanity (soft > hard,
+  non-positive, MIN/MAX bounds), runtime panel diversity (piggybacks
+  `validate_runtime_diversity`). Returns a `PreFlightReport` with
+  structured `PreFlightIssue` rows (severity / code / message /
+  fix-hint) instead of raising. 36 unit tests.
 - **Ranker agent + Elo tournament + 3-judge panel (S6).** New
   `plugins/seed_pipeline/tournament.py` ships pure Elo math —
   `initial_ratings`, `expected_score`, `apply_match` (in-place rating

--- a/plugins/seed_pipeline/cost_preview.py
+++ b/plugins/seed_pipeline/cost_preview.py
@@ -33,6 +33,7 @@ import math
 from dataclasses import dataclass
 
 from core.llm.token_tracker import MODEL_PRICING
+
 from plugins.seed_pipeline.picker import PickerResult, RoleBinding
 
 log = logging.getLogger(__name__)
@@ -241,8 +242,9 @@ def format_cost_summary(estimate: CostEstimate) -> str:
             f"  {row.role:<13}  {row.model:<26}  {row.calls:>5}  ${row.est_usd:>7.4f}{marker}"
         )
     lines.append("  ─────────────────────────────────────────────────────────────")
+    total_calls = sum(r.calls for r in estimate.rows)
     lines.append(
-        f"  total                                              {sum(r.calls for r in estimate.rows):>5}  "
+        f"  total                                              {total_calls:>5}  "
         f"${estimate.total_usd:>7.4f}"
     )
     if estimate.subscription_usd > 0:

--- a/plugins/seed_pipeline/cost_preview.py
+++ b/plugins/seed_pipeline/cost_preview.py
@@ -1,0 +1,254 @@
+"""Seed-pipeline cost preview — estimate per-phase + total USD spend.
+
+Surfaced to the user as a pre-run confirm prompt (S11 CLI) so a 15-
+candidate gen2 with a 3-voter Elo tournament doesn't quietly burn
+through the user's subscription quota or PAYG budget. The estimate is
+derived from:
+
+1. The picker-resolved per-role :class:`RoleBinding` (model name).
+2. The :data:`core.llm.token_tracker.MODEL_PRICING` catalogue
+   (per-million-token input / output).
+3. The role-specific token budgets in :data:`_ROLE_TOKEN_BUDGETS` —
+   empirical typical-call sizes calibrated by ADR-001 paper §5
+   (10-15 candidates × 2 judges × 3 rounds ≈ 100 LLM calls per gen).
+
+For roles bound to a subscription source (claude-cli / openai-codex)
+the OAuth quota absorbs the cost — we still surface the *equivalent*
+USD figure so the user can compare "subscription burn rate" vs PAYG.
+
+P-checklist application:
+
+- **P4 Environment Anchor**: pricing is loaded once at import time
+  via :data:`core.llm.token_tracker.MODEL_PRICING`; the cost preview
+  never reads `~/.geode/config.toml` directly.
+- **P7 Caller-Callee Contract**: every estimate row exposes the
+  fields the S11 CLI needs (role, model, family, source, calls,
+  est_usd) so the prompt renderer doesn't have to compute deltas.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+from core.llm.token_tracker import MODEL_PRICING
+from plugins.seed_pipeline.picker import PickerResult, RoleBinding
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_CANDIDATE_COUNT",
+    "CostEstimate",
+    "CostRow",
+    "estimate_cost",
+    "format_cost_summary",
+]
+
+
+DEFAULT_CANDIDATE_COUNT: int = 15
+
+
+@dataclass(frozen=True)
+class _RoleBudget:
+    """Empirical typical-call sizes per role per candidate or per match.
+
+    ``per`` is what the ``calls`` count scales with — ``"candidate"``,
+    ``"match"``, or ``"run"`` (one-shot per pipeline run).
+    """
+
+    input_tokens: int
+    output_tokens: int
+    per: str  # "candidate" | "match" | "run"
+
+
+# Calibrated from ADR-001 paper §5 + S2/S3/S5/S6 observed dispatch
+# patterns. Conservative upper bounds (worst-case typical call).
+_ROLE_TOKEN_BUDGETS: dict[str, _RoleBudget] = {
+    "generator": _RoleBudget(input_tokens=3000, output_tokens=1000, per="candidate"),
+    "critic": _RoleBudget(input_tokens=2000, output_tokens=400, per="candidate"),
+    "proximity": _RoleBudget(input_tokens=3000, output_tokens=0, per="run"),
+    "pilot": _RoleBudget(input_tokens=5000, output_tokens=1000, per="candidate"),
+    "ranker": _RoleBudget(input_tokens=3000, output_tokens=300, per="match-voter"),
+    "evolver": _RoleBudget(input_tokens=3000, output_tokens=1000, per="candidate"),
+    "meta_reviewer": _RoleBudget(input_tokens=4000, output_tokens=1000, per="run"),
+}
+
+
+@dataclass(frozen=True)
+class CostRow:
+    """One row in the cost-preview table — per role."""
+
+    role: str
+    model: str
+    family: str
+    source: str
+    calls: int
+    est_usd: float
+    subscription_backed: bool
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Aggregate cost preview across all enabled roles."""
+
+    rows: list[CostRow]
+    total_usd: float
+    subscription_usd: float
+    payg_usd: float
+    candidate_count: int
+    match_count: int
+    voter_count: int
+
+
+def _calls_for(budget: _RoleBudget, *, candidates: int, matches: int, voters: int) -> int:
+    """Translate a role's token budget into total LLM call count."""
+    if budget.per == "candidate":
+        return candidates
+    if budget.per == "match":
+        return matches
+    if budget.per == "match-voter":
+        return matches * voters
+    return 1  # "run"
+
+
+def _per_call_cost(model: str, budget: _RoleBudget) -> float:
+    """Per-call USD using :data:`MODEL_PRICING`.
+
+    Returns ``0.0`` when the model is unknown (proximity's embedding
+    pricing is the obvious case — :data:`MODEL_PRICING` only ships
+    completion-model rates). The caller can override or supplement
+    when an embedding-specific catalogue lands.
+    """
+    price = MODEL_PRICING.get(model)
+    if price is None:
+        log.debug(
+            "seed-pipeline cost_preview: model %r missing from MODEL_PRICING — $0 estimate",
+            model,
+        )
+        return 0.0
+    return budget.input_tokens * price.input + budget.output_tokens * price.output
+
+
+def _match_count_for(candidate_count: int) -> int:
+    """Default tournament match schedule — ceil(N log₂ N).
+
+    Mirrors :func:`plugins.seed_pipeline.tournament.plan_matches`'s
+    default to keep the preview consistent with what the Ranker
+    actually dispatches.
+    """
+    if candidate_count < 2:
+        return 0
+    n_pairs = candidate_count * (candidate_count - 1) // 2
+    return min(n_pairs, math.ceil(candidate_count * math.log2(max(candidate_count, 2))))
+
+
+def estimate_cost(
+    picker_result: PickerResult,
+    *,
+    candidate_count: int = DEFAULT_CANDIDATE_COUNT,
+    match_count: int | None = None,
+) -> CostEstimate:
+    """Compute per-role + aggregate cost for one full pipeline run.
+
+    Parameters
+    ----------
+    picker_result
+        :class:`PickerResult` from
+        :func:`plugins.seed_pipeline.picker.pick_bindings`.
+    candidate_count
+        Target N for the generator phase (default 15).
+    match_count
+        Override for the Elo tournament size. Defaults to the same
+        ``ceil(N log₂ N)`` schedule the Ranker plans.
+    """
+    matches = match_count if match_count is not None else _match_count_for(candidate_count)
+    voter_count = len(picker_result.voters)
+
+    rows: list[CostRow] = []
+    subscription_usd = 0.0
+    payg_usd = 0.0
+    for role, binding in picker_result.bindings.items():
+        row = _estimate_role(
+            role,
+            binding,
+            candidates=candidate_count,
+            matches=matches,
+            voters=voter_count,
+        )
+        rows.append(row)
+        if row.subscription_backed:
+            subscription_usd += row.est_usd
+        else:
+            payg_usd += row.est_usd
+
+    return CostEstimate(
+        rows=rows,
+        total_usd=subscription_usd + payg_usd,
+        subscription_usd=subscription_usd,
+        payg_usd=payg_usd,
+        candidate_count=candidate_count,
+        match_count=matches,
+        voter_count=voter_count,
+    )
+
+
+def _estimate_role(
+    role: str,
+    binding: RoleBinding,
+    *,
+    candidates: int,
+    matches: int,
+    voters: int,
+) -> CostRow:
+    budget = _ROLE_TOKEN_BUDGETS.get(role)
+    if budget is None:
+        # Unknown role — defer to a single-run conservative call.
+        budget = _RoleBudget(input_tokens=2000, output_tokens=500, per="run")
+    calls = _calls_for(budget, candidates=candidates, matches=matches, voters=voters)
+    est_usd = calls * _per_call_cost(binding.model, budget)
+    from plugins.seed_pipeline.picker import SUBSCRIPTION_SOURCES
+
+    return CostRow(
+        role=role,
+        model=binding.model,
+        family=binding.family,
+        source=binding.source,
+        calls=calls,
+        est_usd=est_usd,
+        subscription_backed=binding.source in SUBSCRIPTION_SOURCES,
+    )
+
+
+def format_cost_summary(estimate: CostEstimate) -> str:
+    """Render the estimate as a human-readable summary table.
+
+    Output is plain text (no Rich markup) so it can be embedded in
+    a CLI confirm prompt or a serialized run-context note.
+    """
+    lines: list[str] = []
+    lines.append("seed-pipeline cost preview")
+    lines.append(
+        f"  candidates: {estimate.candidate_count}  "
+        f"matches: {estimate.match_count}  voters: {estimate.voter_count}"
+    )
+    lines.append("")
+    lines.append("  role           model                       calls    est_usd")
+    lines.append("  ─────────────  ──────────────────────────  ─────  ─────────")
+    for row in estimate.rows:
+        marker = "*" if row.subscription_backed else " "
+        lines.append(
+            f"  {row.role:<13}  {row.model:<26}  {row.calls:>5}  ${row.est_usd:>7.4f}{marker}"
+        )
+    lines.append("  ─────────────────────────────────────────────────────────────")
+    lines.append(
+        f"  total                                              {sum(r.calls for r in estimate.rows):>5}  "
+        f"${estimate.total_usd:>7.4f}"
+    )
+    if estimate.subscription_usd > 0:
+        lines.append(
+            f"    * subscription-backed (quota burn equivalent): ${estimate.subscription_usd:.4f}"
+        )
+    if estimate.payg_usd > 0:
+        lines.append(f"      PAYG (will be charged):                      ${estimate.payg_usd:.4f}")
+    return "\n".join(lines)

--- a/plugins/seed_pipeline/pre_flight.py
+++ b/plugins/seed_pipeline/pre_flight.py
@@ -34,8 +34,8 @@ from plugins.seed_pipeline.picker import PickerResult, validate_runtime_diversit
 log = logging.getLogger(__name__)
 
 __all__ = [
-    "MIN_BUDGET_USD",
     "MAX_BUDGET_USD",
+    "MIN_BUDGET_USD",
     "PreFlightIssue",
     "PreFlightReport",
     "Severity",

--- a/plugins/seed_pipeline/pre_flight.py
+++ b/plugins/seed_pipeline/pre_flight.py
@@ -1,0 +1,257 @@
+"""Seed-pipeline pre-flight check — validate auth + budget before a run.
+
+Runs BEFORE the first LLM call so a misconfigured auth path or an
+absurd budget cap surfaces as a clear error instead of mid-run cost
+overrun or quorum collapse.
+
+Three categories of check:
+
+1. **Auth probe**: for each :class:`RoleBinding` / :class:`VoterBinding`,
+   verify the resolved source's credential is reachable. ``claude-cli``
+   / ``openai-codex`` use the per-family OAuth helpers; ``api_key``
+   reads :data:`core.config.settings` env-resolved keys.
+2. **Budget sanity**: reject obviously-wrong (soft > hard, negative, or
+   absurdly high) caps so the supervisor doesn't accidentally
+   un-budget a fan-out.
+3. **Panel diversity**: piggyback on
+   :func:`plugins.seed_pipeline.picker.validate_runtime_diversity` so
+   the pre-flight gate fails fast if a user override collapsed the
+   judge panel.
+
+The pre-flight emits a structured :class:`PreFlightReport` rather than
+raising — the CLI (S11) renders the issue list with severity coloring
++ actionable fix suggestion per issue.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+
+from plugins.seed_pipeline.picker import PickerResult, validate_runtime_diversity
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "MIN_BUDGET_USD",
+    "MAX_BUDGET_USD",
+    "PreFlightIssue",
+    "PreFlightReport",
+    "Severity",
+    "check_auth",
+    "check_budget",
+    "check_diversity",
+    "run_pre_flight",
+]
+
+
+Severity = Literal["info", "warning", "error"]
+
+
+MIN_BUDGET_USD: float = 0.01
+MAX_BUDGET_USD: float = 100.00
+
+
+@dataclass(frozen=True)
+class PreFlightIssue:
+    """One actionable finding from pre-flight."""
+
+    severity: Severity
+    code: str
+    message: str
+    fix: str
+
+
+@dataclass
+class PreFlightReport:
+    """Aggregate pre-flight result.
+
+    The supervisor reads :attr:`has_errors` to decide whether to abort
+    or proceed. Warnings + info are surfaced for the user but don't
+    block.
+    """
+
+    issues: list[PreFlightIssue] = field(default_factory=list)
+
+    @property
+    def has_errors(self) -> bool:
+        return any(i.severity == "error" for i in self.issues)
+
+    def add(self, issue: PreFlightIssue) -> None:
+        self.issues.append(issue)
+
+
+def _credential_present(family: str, source: str) -> bool:
+    """Probe whether the resolved credential is reachable.
+
+    Returns False (silently) on import or probe error so the
+    pre-flight surfaces a structured issue rather than crashing.
+    """
+    try:
+        if source == "claude-cli":
+            from plugins.petri_audit.claude_code_provider import is_claude_oauth_available
+
+            return is_claude_oauth_available()
+        if source == "openai-codex":
+            from plugins.petri_audit.codex_provider import is_codex_oauth_available
+
+            return is_codex_oauth_available()
+        if source == "api_key":
+            from core.config import settings
+
+            if family == "anthropic":
+                return bool(getattr(settings, "anthropic_api_key", "") or "")
+            if family == "openai":
+                return bool(getattr(settings, "openai_api_key", "") or "")
+            if family == "zhipuai":
+                return bool(getattr(settings, "zhipuai_api_key", "") or "")
+    except Exception as exc:  # pragma: no cover - defensive
+        log.debug(
+            "seed-pipeline pre-flight: credential probe raised %s (family=%r source=%r)",
+            exc,
+            family,
+            source,
+        )
+        return False
+    return False
+
+
+def check_auth(picker_result: PickerResult) -> list[PreFlightIssue]:
+    """Verify every resolved role + voter has a reachable credential."""
+    issues: list[PreFlightIssue] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _check(family: str, source: str, label: str) -> None:
+        key = (family, source)
+        if key in seen:
+            return
+        seen.add(key)
+        if not _credential_present(family, source):
+            issues.append(
+                PreFlightIssue(
+                    severity="error",
+                    code="auth.unreachable",
+                    message=(
+                        f"{label} resolved to {family}.{source} but the "
+                        f"credential is not reachable."
+                    ),
+                    fix=_fix_for(family, source),
+                )
+            )
+
+    for role, binding in picker_result.bindings.items():
+        # Embedding kind only needs the openai api_key; the OAuth
+        # subscription doesn't expose embeddings.
+        if binding.kind == "embedding":
+            _check("openai", "api_key", f"role {role!r}")
+            continue
+        _check(binding.family, binding.source, f"role {role!r}")
+    for voter in picker_result.voters:
+        _check(voter.family, voter.source, f"voter {voter.family}.{voter.source}")
+    return issues
+
+
+def _fix_for(family: str, source: str) -> str:
+    """Human-readable remediation hint for a missing credential."""
+    if source == "claude-cli":
+        return "Run `claude login` (or set GEODE_ANTHROPIC_CREDENTIAL_SOURCE=api_key)."
+    if source == "openai-codex":
+        return "Run `codex login` (or set GEODE_OPENAI_CREDENTIAL_SOURCE=api_key)."
+    if source == "api_key":
+        env_var = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "zhipuai": "ZHIPUAI_API_KEY",
+        }.get(family, "<family>_API_KEY")
+        return f"Set {env_var} (or `geode login set-key {family} <…>`)."
+    return f"Resolve the {family}.{source} binding via ~/.geode/seed-pipeline.toml."
+
+
+def check_budget(*, soft_usd: float, hard_usd: float) -> list[PreFlightIssue]:
+    """Sanity-check soft / hard budget caps."""
+    issues: list[PreFlightIssue] = []
+    if soft_usd <= 0 or hard_usd <= 0:
+        issues.append(
+            PreFlightIssue(
+                severity="error",
+                code="budget.non_positive",
+                message=f"Budget cap must be positive (soft={soft_usd}, hard={hard_usd}).",
+                fix="Set positive USD values via SEED_PIPELINE_BUDGET_{SOFT,HARD}_USD env vars.",
+            )
+        )
+        return issues
+    if soft_usd > hard_usd:
+        issues.append(
+            PreFlightIssue(
+                severity="error",
+                code="budget.soft_above_hard",
+                message=f"soft_usd ({soft_usd}) > hard_usd ({hard_usd}).",
+                fix="Set soft below hard — soft warns, hard aborts the run.",
+            )
+        )
+    if hard_usd > MAX_BUDGET_USD:
+        issues.append(
+            PreFlightIssue(
+                severity="warning",
+                code="budget.absurd_high",
+                message=(
+                    f"hard_usd ({hard_usd}) exceeds {MAX_BUDGET_USD} — this is "
+                    "a single-run cap, intentional?"
+                ),
+                fix="Lower SEED_PIPELINE_BUDGET_HARD_USD or confirm via explicit override.",
+            )
+        )
+    if soft_usd < MIN_BUDGET_USD:
+        issues.append(
+            PreFlightIssue(
+                severity="warning",
+                code="budget.absurd_low",
+                message=(
+                    f"soft_usd ({soft_usd}) is below ${MIN_BUDGET_USD:.2f} — most runs "
+                    "will trip the soft warning immediately."
+                ),
+                fix="Raise SEED_PIPELINE_BUDGET_SOFT_USD to a realistic per-phase floor.",
+            )
+        )
+    return issues
+
+
+def check_diversity(picker_result: PickerResult) -> list[PreFlightIssue]:
+    """Re-run the runtime diversity gate at pre-flight."""
+    try:
+        validate_runtime_diversity(picker_result)
+    except ValueError as exc:
+        return [
+            PreFlightIssue(
+                severity="error",
+                code="diversity.collapsed",
+                message=str(exc),
+                fix=(
+                    "Edit ~/.geode/seed-pipeline.toml to spread the judge panel "
+                    "across ≥ 2 (family, source) pairs."
+                ),
+            )
+        ]
+    return []
+
+
+def run_pre_flight(
+    picker_result: PickerResult,
+    *,
+    soft_usd: float,
+    hard_usd: float,
+) -> PreFlightReport:
+    """Run all 3 categories and bundle into one report.
+
+    The caller (CLI / supervisor) checks ``report.has_errors`` to
+    decide whether to abort the run.
+    """
+    report = PreFlightReport()
+    for issue in check_diversity(picker_result):
+        report.add(issue)
+    for issue in check_budget(soft_usd=soft_usd, hard_usd=hard_usd):
+        report.add(issue)
+    for issue in check_auth(picker_result):
+        report.add(issue)
+    return report

--- a/tests/plugins/seed_pipeline/test_cost_preview.py
+++ b/tests/plugins/seed_pipeline/test_cost_preview.py
@@ -1,0 +1,279 @@
+"""Tests for ``plugins.seed_pipeline.cost_preview``."""
+
+from __future__ import annotations
+
+from plugins.seed_pipeline.cost_preview import (
+    DEFAULT_CANDIDATE_COUNT,
+    CostEstimate,
+    CostRow,
+    estimate_cost,
+    format_cost_summary,
+)
+from plugins.seed_pipeline.picker import PickerResult, RoleBinding, VoterBinding
+
+
+def _make_picker_result(*, voter_source: str = "api_key") -> PickerResult:
+    bindings: dict[str, RoleBinding] = {
+        "generator": RoleBinding(
+            role="generator",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "critic": RoleBinding(
+            role="critic",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "proximity": RoleBinding(
+            role="proximity",
+            model="text-embedding-3-small",
+            family="openai",
+            source="api_key",
+            kind="embedding",
+        ),
+        "pilot": RoleBinding(
+            role="pilot",
+            model="claude-haiku-4-5",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "ranker": RoleBinding(
+            role="ranker",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "evolver": RoleBinding(
+            role="evolver",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "meta_reviewer": RoleBinding(
+            role="meta_reviewer",
+            model="claude-opus-4-7",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+    }
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source=voter_source),
+        VoterBinding(model="gpt-5.5", family="openai", source="api_key"),
+        VoterBinding(model="claude-haiku-4-5", family="anthropic", source="api_key"),
+    ]
+    return PickerResult(
+        bindings=bindings,
+        voters=voters,
+        diversity_families=2,
+        subscription_paths_in_use=frozenset(),
+    )
+
+
+def test_estimate_cost_returns_per_role_row_for_each_binding() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=15)
+    assert {r.role for r in est.rows} == set(pr.bindings.keys())
+
+
+def test_estimate_cost_default_candidate_count() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr)
+    assert est.candidate_count == DEFAULT_CANDIDATE_COUNT
+
+
+def test_estimate_cost_match_count_follows_n_log_n() -> None:
+    """For 15 candidates, ceil(15 * log2(15)) ≈ 59, well below 105 = C(15,2)."""
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=15)
+    assert 0 < est.match_count <= 60
+
+
+def test_estimate_cost_voter_count_reflects_panel_size() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=10)
+    assert est.voter_count == 3
+
+
+def test_estimate_cost_ranker_calls_scale_with_voters_x_matches() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=10)
+    ranker_row = next(r for r in est.rows if r.role == "ranker")
+    assert ranker_row.calls == est.match_count * est.voter_count
+
+
+def test_estimate_cost_generator_one_call_per_candidate() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=8)
+    gen_row = next(r for r in est.rows if r.role == "generator")
+    assert gen_row.calls == 8
+
+
+def test_estimate_cost_pilot_one_call_per_candidate() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=8)
+    pilot_row = next(r for r in est.rows if r.role == "pilot")
+    assert pilot_row.calls == 8
+
+
+def test_estimate_cost_meta_reviewer_one_call_per_run() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=8)
+    mr_row = next(r for r in est.rows if r.role == "meta_reviewer")
+    assert mr_row.calls == 1
+
+
+def test_estimate_cost_total_is_sum_of_rows() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr)
+    total = sum(r.est_usd for r in est.rows)
+    assert abs(est.total_usd - total) < 1e-9
+
+
+def test_estimate_cost_subscription_vs_payg_split() -> None:
+    pr = _make_picker_result()
+    bindings = dict(pr.bindings)
+    bindings["generator"] = RoleBinding(
+        role="generator",
+        model="claude-sonnet-4-6",
+        family="anthropic",
+        source="claude-cli",
+        kind="completion",
+    )
+    pr = PickerResult(
+        bindings=bindings,
+        voters=pr.voters,
+        diversity_families=pr.diversity_families,
+        subscription_paths_in_use=frozenset({"claude-cli"}),
+    )
+    est = estimate_cost(pr, candidate_count=15)
+    assert est.subscription_usd > 0
+    assert est.payg_usd > 0
+    assert abs(est.subscription_usd + est.payg_usd - est.total_usd) < 1e-9
+
+
+def test_estimate_cost_proximity_zero_or_negligible_for_embedding() -> None:
+    """Embedding pricing not in MODEL_PRICING → 0 estimate (acceptable)."""
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=15)
+    prox_row = next(r for r in est.rows if r.role == "proximity")
+    # Embedding model not in completion pricing catalogue → 0.0
+    assert prox_row.est_usd == 0.0
+
+
+def test_estimate_cost_explicit_match_count_override() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=15, match_count=10)
+    assert est.match_count == 10
+    ranker_row = next(r for r in est.rows if r.role == "ranker")
+    assert ranker_row.calls == 10 * 3
+
+
+def test_format_cost_summary_returns_multiline_string() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=5)
+    summary = format_cost_summary(est)
+    assert "seed-pipeline cost preview" in summary
+    assert "generator" in summary
+    assert "total" in summary
+
+
+def test_format_cost_summary_marks_subscription_rows() -> None:
+    pr = _make_picker_result()
+    bindings = dict(pr.bindings)
+    bindings["generator"] = RoleBinding(
+        role="generator",
+        model="claude-sonnet-4-6",
+        family="anthropic",
+        source="claude-cli",
+        kind="completion",
+    )
+    pr = PickerResult(
+        bindings=bindings,
+        voters=pr.voters,
+        diversity_families=pr.diversity_families,
+        subscription_paths_in_use=frozenset({"claude-cli"}),
+    )
+    est = estimate_cost(pr, candidate_count=5)
+    summary = format_cost_summary(est)
+    assert "subscription-backed" in summary
+
+
+def test_estimate_cost_row_carries_binding_metadata() -> None:
+    pr = _make_picker_result()
+    est = estimate_cost(pr, candidate_count=5)
+    for row in est.rows:
+        assert row.model
+        assert row.family in {"anthropic", "openai", "zhipuai"}
+        assert row.source
+        assert row.calls >= 0
+        assert row.est_usd >= 0
+
+
+def test_estimate_cost_unknown_model_logs_and_zeros() -> None:
+    """Unknown model → 0.0 cost, not crash."""
+    bindings = {
+        "generator": RoleBinding(
+            role="generator",
+            model="mystery-x9-unknown",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+    }
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source="api_key"),
+        VoterBinding(model="gpt-5.5", family="openai", source="api_key"),
+    ]
+    pr = PickerResult(
+        bindings=bindings,
+        voters=voters,
+        diversity_families=2,
+        subscription_paths_in_use=frozenset(),
+    )
+    est = estimate_cost(pr, candidate_count=5)
+    gen_row = next(r for r in est.rows if r.role == "generator")
+    assert gen_row.est_usd == 0.0
+
+
+def test_cost_row_immutable() -> None:
+    row = CostRow(
+        role="x",
+        model="y",
+        family="z",
+        source="w",
+        calls=0,
+        est_usd=0.0,
+        subscription_backed=False,
+    )
+    try:
+        row.calls = 5  # type: ignore[misc]
+    except Exception:
+        return
+    msg = "CostRow should be frozen"
+    raise AssertionError(msg)
+
+
+def test_cost_estimate_immutable() -> None:
+    est = CostEstimate(
+        rows=[],
+        total_usd=0.0,
+        subscription_usd=0.0,
+        payg_usd=0.0,
+        candidate_count=0,
+        match_count=0,
+        voter_count=0,
+    )
+    try:
+        est.total_usd = 1.0  # type: ignore[misc]
+    except Exception:
+        return
+    msg = "CostEstimate should be frozen"
+    raise AssertionError(msg)

--- a/tests/plugins/seed_pipeline/test_cost_preview.py
+++ b/tests/plugins/seed_pipeline/test_cost_preview.py
@@ -244,6 +244,10 @@ def test_estimate_cost_unknown_model_logs_and_zeros() -> None:
 
 
 def test_cost_row_immutable() -> None:
+    import dataclasses
+
+    import pytest
+
     row = CostRow(
         role="x",
         model="y",
@@ -253,15 +257,15 @@ def test_cost_row_immutable() -> None:
         est_usd=0.0,
         subscription_backed=False,
     )
-    try:
+    with pytest.raises(dataclasses.FrozenInstanceError):
         row.calls = 5  # type: ignore[misc]
-    except Exception:
-        return
-    msg = "CostRow should be frozen"
-    raise AssertionError(msg)
 
 
 def test_cost_estimate_immutable() -> None:
+    import dataclasses
+
+    import pytest
+
     est = CostEstimate(
         rows=[],
         total_usd=0.0,
@@ -271,9 +275,5 @@ def test_cost_estimate_immutable() -> None:
         match_count=0,
         voter_count=0,
     )
-    try:
+    with pytest.raises(dataclasses.FrozenInstanceError):
         est.total_usd = 1.0  # type: ignore[misc]
-    except Exception:
-        return
-    msg = "CostEstimate should be frozen"
-    raise AssertionError(msg)

--- a/tests/plugins/seed_pipeline/test_pre_flight.py
+++ b/tests/plugins/seed_pipeline/test_pre_flight.py
@@ -1,0 +1,215 @@
+"""Tests for ``plugins.seed_pipeline.pre_flight``."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from plugins.seed_pipeline.picker import PickerResult, RoleBinding, VoterBinding
+from plugins.seed_pipeline.pre_flight import (
+    MAX_BUDGET_USD,
+    MIN_BUDGET_USD,
+    PreFlightIssue,
+    PreFlightReport,
+    check_auth,
+    check_budget,
+    check_diversity,
+    run_pre_flight,
+)
+
+
+def _good_picker() -> PickerResult:
+    bindings = {
+        "generator": RoleBinding(
+            role="generator",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "proximity": RoleBinding(
+            role="proximity",
+            model="text-embedding-3-small",
+            family="openai",
+            source="api_key",
+            kind="embedding",
+        ),
+    }
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source="api_key"),
+        VoterBinding(model="gpt-5.5", family="openai", source="api_key"),
+        VoterBinding(model="claude-haiku-4-5", family="anthropic", source="api_key"),
+    ]
+    return PickerResult(
+        bindings=bindings,
+        voters=voters,
+        diversity_families=2,
+        subscription_paths_in_use=frozenset(),
+    )
+
+
+def test_check_budget_valid_returns_empty() -> None:
+    assert check_budget(soft_usd=2.0, hard_usd=10.0) == []
+
+
+def test_check_budget_negative_soft_errors() -> None:
+    issues = check_budget(soft_usd=-1.0, hard_usd=10.0)
+    assert any(i.code == "budget.non_positive" and i.severity == "error" for i in issues)
+
+
+def test_check_budget_zero_hard_errors() -> None:
+    issues = check_budget(soft_usd=1.0, hard_usd=0.0)
+    assert any(i.code == "budget.non_positive" and i.severity == "error" for i in issues)
+
+
+def test_check_budget_soft_above_hard_errors() -> None:
+    issues = check_budget(soft_usd=10.0, hard_usd=5.0)
+    assert any(i.code == "budget.soft_above_hard" and i.severity == "error" for i in issues)
+
+
+def test_check_budget_absurd_high_warns() -> None:
+    issues = check_budget(soft_usd=1.0, hard_usd=MAX_BUDGET_USD + 1.0)
+    assert any(i.code == "budget.absurd_high" and i.severity == "warning" for i in issues)
+
+
+def test_check_budget_absurd_low_warns() -> None:
+    issues = check_budget(soft_usd=MIN_BUDGET_USD / 2, hard_usd=1.0)
+    assert any(i.code == "budget.absurd_low" and i.severity == "warning" for i in issues)
+
+
+def test_check_auth_all_present() -> None:
+    """When every credential probe returns True, no issues are reported."""
+    picker = _good_picker()
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", return_value=True):
+        issues = check_auth(picker)
+    assert issues == []
+
+
+def test_check_auth_missing_api_key_errors() -> None:
+    picker = _good_picker()
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", return_value=False):
+        issues = check_auth(picker)
+    assert any(i.code == "auth.unreachable" and i.severity == "error" for i in issues)
+
+
+def test_check_auth_provides_fix_hint() -> None:
+    picker = _good_picker()
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", return_value=False):
+        issues = check_auth(picker)
+    for issue in issues:
+        assert issue.fix
+        assert any(token in issue.fix for token in ("API_KEY", "login", "geode"))
+
+
+def test_check_auth_embedding_role_probes_openai_api_key() -> None:
+    """Embedding role short-circuits to (openai, api_key) for the probe."""
+    picker = _good_picker()
+    probed: list[tuple[str, str]] = []
+
+    def _probe(family: str, source: str) -> bool:
+        probed.append((family, source))
+        return True
+
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", side_effect=_probe):
+        check_auth(picker)
+    assert ("openai", "api_key") in probed
+
+
+def test_check_auth_dedups_repeated_pairs() -> None:
+    """Two voters with same (family, source) → only one probe."""
+    bindings = {
+        "generator": RoleBinding(
+            role="generator",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+    }
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source="api_key"),
+        VoterBinding(model="claude-haiku-4-5", family="anthropic", source="api_key"),
+        VoterBinding(model="gpt-5.5", family="openai", source="api_key"),
+    ]
+    picker = PickerResult(
+        bindings=bindings,
+        voters=voters,
+        diversity_families=2,
+        subscription_paths_in_use=frozenset(),
+    )
+    probed: list[tuple[str, str]] = []
+
+    def _probe(family: str, source: str) -> bool:
+        probed.append((family, source))
+        return True
+
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", side_effect=_probe):
+        check_auth(picker)
+    assert probed.count(("anthropic", "api_key")) == 1
+
+
+def test_check_diversity_valid_returns_empty() -> None:
+    picker = _good_picker()
+    assert check_diversity(picker) == []
+
+
+def test_check_diversity_collapsed_panel_errors() -> None:
+    """A single-family panel triggers a diversity error."""
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source="claude-cli"),
+        VoterBinding(model="claude-haiku-4-5", family="anthropic", source="api_key"),
+    ]
+    picker = PickerResult(
+        bindings={},
+        voters=voters,
+        diversity_families=1,
+        subscription_paths_in_use=frozenset(),
+    )
+    issues = check_diversity(picker)
+    assert any(i.code == "diversity.collapsed" and i.severity == "error" for i in issues)
+
+
+def test_run_pre_flight_aggregates_all_checks() -> None:
+    picker = _good_picker()
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", return_value=True):
+        report = run_pre_flight(picker, soft_usd=2.0, hard_usd=10.0)
+    assert isinstance(report, PreFlightReport)
+    assert not report.has_errors
+
+
+def test_run_pre_flight_surfaces_errors() -> None:
+    picker = _good_picker()
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", return_value=False):
+        report = run_pre_flight(picker, soft_usd=2.0, hard_usd=10.0)
+    assert report.has_errors
+
+
+def test_run_pre_flight_surfaces_budget_errors() -> None:
+    picker = _good_picker()
+    with patch("plugins.seed_pipeline.pre_flight._credential_present", return_value=True):
+        report = run_pre_flight(picker, soft_usd=10.0, hard_usd=2.0)
+    assert report.has_errors
+    assert any(i.code == "budget.soft_above_hard" for i in report.issues)
+
+
+def test_pre_flight_report_has_errors_only_for_error_severity() -> None:
+    """Warning-only reports don't trip has_errors."""
+    report = PreFlightReport()
+    report.add(
+        PreFlightIssue(
+            severity="warning",
+            code="x",
+            message="test warning",
+            fix="ignore",
+        )
+    )
+    assert not report.has_errors
+
+
+def test_pre_flight_issue_immutable() -> None:
+    issue = PreFlightIssue(severity="info", code="x", message="y", fix="z")
+    try:
+        issue.code = "different"  # type: ignore[misc]
+    except Exception:
+        return
+    msg = "PreFlightIssue should be frozen"
+    raise AssertionError(msg)

--- a/tests/plugins/seed_pipeline/test_pre_flight.py
+++ b/tests/plugins/seed_pipeline/test_pre_flight.py
@@ -206,10 +206,10 @@ def test_pre_flight_report_has_errors_only_for_error_severity() -> None:
 
 
 def test_pre_flight_issue_immutable() -> None:
+    import dataclasses
+
+    import pytest
+
     issue = PreFlightIssue(severity="info", code="x", message="y", fix="z")
-    try:
+    with pytest.raises(dataclasses.FrozenInstanceError):
         issue.code = "different"  # type: ignore[misc]
-    except Exception:
-        return
-    msg = "PreFlightIssue should be frozen"
-    raise AssertionError(msg)


### PR DESCRIPTION
## Summary
- Adds `plugins/seed_pipeline/cost_preview.py` — Per-role + aggregate USD estimate using `core.llm.token_tracker.MODEL_PRICING` × per-role token budgets calibrated from ADR-001 §5. Splits subscription-backed (quota burn equivalent) from PAYG charge.
- Adds `plugins/seed_pipeline/pre_flight.py` — Three sanity gates before the first LLM call: credential probe (OAuth + api_key per family), budget sanity ($0.01–$100 bounds, soft ≤ hard), runtime panel diversity (piggybacks `validate_runtime_diversity`).
- Returns structured `PreFlightReport` / `CostEstimate` so the S11 CLI renderer doesn't need to compute deltas. 36 unit tests.

## Why
S6.5 is the pre-run guardrail layer. Without cost preview, a 15-candidate gen2 with 3-judge Elo (~100 LLM calls) silently burns $1–$2 of PAYG or subscription quota with no user confirmation. Without pre-flight, a missing claude-cli token or a typo'd override would surface as mid-run failures (quorum collapse, cascading sub-agent errors). Both surfaces required by ADR-003 §13 "subscription expiry frequent" risk mitigation.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/cost_preview.py` | NEW — cost estimator (~220 LOC) |
| `plugins/seed_pipeline/pre_flight.py` | NEW — pre-flight checks (~220 LOC) |
| `tests/plugins/seed_pipeline/test_cost_preview.py` | NEW — 18 tests |
| `tests/plugins/seed_pipeline/test_pre_flight.py` | NEW — 18 tests |
| `CHANGELOG.md` | S6.5 entry under `[Unreleased]` |

## Codex MCP Audit Findings (resolved in followup commit)
| Severity | Finding | Resolution |
|----------|---------|------------|
| FAIL | ruff (import block / long line / unsorted __all__) | Auto-fix + extract local |
| LOW | Broad `try/except: return` in immutable tests | Replaced with `pytest.raises(FrozenInstanceError)` |
| MEDIUM | `BudgetGuard` real-time worker propagation | Deferred to S6.5-wire (task #73) |
| LOW | Fallback plan auto-suggest on subscription expiry | Deferred to S11 (CLI scope) |

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] mypy plugins/seed_pipeline/ clean
- [x] pytest tests/plugins/seed_pipeline/test_cost_preview.py + test_pre_flight.py — 36/36 pass

## Reference
- ADR-001 `docs/architecture/seed-pipeline-decision.md` §13 settled defaults (soft $2 / hard $10)
- ADR-003 `docs/architecture/seed-pipeline-ui-decision.md` 4-path auth matrix
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S6.5 row
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied