### PR TITLE
feat(seed-pipeline): S7 — Evolution agent (Reflection-driven section rewrite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ functional change.
 
 ### Added
 
+- **Evolution agent (S7).** New `plugins/seed_pipeline/agents/evolver.py`
+  fans out one sub-agent per Ranker survivor; each reads the Critic's
+  `rewrite_section` hint + the per-candidate `weaknesses` + Pilot
+  `dim_means` and rewrites ONLY the flagged section, preserving
+  frontmatter + target_dim + ±20% token budget per the
+  seed_evolver AgentDef contract. Emits rows to
+  `state.evolved_candidates` (schema mirrors `state.candidates` plus
+  `parent_id`, `rewrite_section`, `notes` provenance). Verdict
+  whitelist `{ok, evolution_skipped, failed}` — only `ok` rows
+  survive; skipped/failed leaves the original candidate in place.
+  Adds `evolved_candidates` to `PipelineState` + merge known set.
+  Uses the shared `parse_structured_output` helper (S6 lift); pins
+  `parent_id` from task args so a wrong LLM echo cannot route the
+  evolved seed under another parent. 16 unit tests covering reverse-
+  order pairing, mixed verdicts, default rewrite_section fallback,
+  evolved-row schema parity with candidates.
 - **Cost preview + pre-flight check (S6.5).** New
   `plugins/seed_pipeline/cost_preview.py` estimates per-role +
   aggregate USD spend for one full pipeline run using

--- a/plugins/seed_pipeline/agents/__init__.py
+++ b/plugins/seed_pipeline/agents/__init__.py
@@ -6,7 +6,7 @@
 - proximity     (S4, ✓) — 3-track dedup (embedding + lexical + role)
 - pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop 자리)
 - ranker        (S6, ✓) — Elo tournament + 3-judge panel
-- evolver       (S7)
+- evolver       (S7, ✓) — Reflection-driven section rewrite
 - meta_reviewer (S8)
 """
 
@@ -18,6 +18,7 @@ from plugins.seed_pipeline.agents.base import (
     parse_structured_output,
 )
 from plugins.seed_pipeline.agents.critic import Critic
+from plugins.seed_pipeline.agents.evolver import Evolver
 from plugins.seed_pipeline.agents.generator import Generator
 from plugins.seed_pipeline.agents.pilot import Pilot
 from plugins.seed_pipeline.agents.proximity import Proximity
@@ -26,6 +27,7 @@ from plugins.seed_pipeline.agents.ranker import Ranker
 __all__ = [
     "BaseSeedAgent",
     "Critic",
+    "Evolver",
     "Generator",
     "Pilot",
     "Proximity",

--- a/plugins/seed_pipeline/agents/evolver.py
+++ b/plugins/seed_pipeline/agents/evolver.py
@@ -1,0 +1,295 @@
+"""Evolution agent — Phase F of the seed pipeline (Reflection-driven section rewrite).
+
+For each top-K survivor (from Ranker), the Evolver fans out one
+sub-agent per survivor; the sub-agent reads the Critic's
+``rewrite_section`` hint (the section name + critique that the
+Reflection agent flagged) and rewrites ONLY that section while
+preserving frontmatter + target_dim + ±20% token budget. The evolved
+seed is written to ``<run_dir>/candidates_evolved/<uuid>.md`` and a
+manifest entry is added to ``state.evolved_candidates`` for re-piloting
+in the next generation.
+
+Per-survivor sub-agent contract (``.claude/agents/seed_evolver.md``):
+
+.. code-block:: json
+
+   {
+     "parent_id": "<original-uuid>",
+     "evolved_id": "<new-uuid>",
+     "evolved_path": "<run_dir>/candidates_evolved/<new-uuid>.md",
+     "rewrite_section": "<section name>",
+     "verdict": "ok" | "evolution_skipped" | "failed",
+     "notes": "<= 200 tokens"
+   }
+
+P-checklist application:
+
+- **P1 Stub Fidelity Audit** — tests cover reverse-order completion
+  pairing via the shared :func:`parse_structured_output` helper.
+- **P7 Caller-Callee Contract** — Evolver consumes ``state.survivors``
+  + ``state.reflections`` + ``state.pilot_scores`` (all three signals
+  the AgentDef mandates the voter see). Emits ``state.evolved_candidates``
+  list rows whose schema mirrors :class:`PipelineState.candidates`
+  (id / path / target_dim / gen_tag / task_id / duration_ms) plus the
+  evolution-specific ``parent_id`` + ``rewrite_section`` fields.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from plugins.seed_pipeline.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    parse_structured_output,
+)
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager, SubTask
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Evolver"]
+
+
+_DEFAULT_EVOLVER_MODEL = "claude-sonnet-4-6"
+_EVOLVER_AGENT_NAME = "seed_evolver"
+_TASK_TYPE = "seed-evolve"
+
+_REQUIRED_EVOLVE_FIELDS = (
+    "parent_id",
+    "evolved_id",
+    "evolved_path",
+    "rewrite_section",
+    "verdict",
+)
+_VALID_VERDICTS = frozenset({"ok", "evolution_skipped", "failed"})
+
+
+class Evolver(BaseSeedAgent):
+    """Spawn one sub-agent per survivor; collect evolved candidate rows.
+
+    Why per-survivor fan-out:
+    -------------------------
+
+    Each survivor's evolution is independent (no cross-survivor
+    information needed — the Critic feedback is per-candidate, the
+    Pilot dim_means are per-candidate). Fan-out keeps the K=5
+    evolution batch within one rollout's wall-time, gated by the
+    ``seed-pipeline`` Lane (max_concurrent=16).
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        *,
+        model: str = _DEFAULT_EVOLVER_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            role="evolver",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        self._manager = manager
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Fan out N evolution sub-agents and collect evolved candidate rows."""
+        if not state.survivors:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    "Evolver requires state.survivors to be non-empty — "
+                    "did the Ranker phase produce any survivors?"
+                ),
+            )
+
+        candidates_by_id: dict[str, dict[str, Any]] = {c["id"]: c for c in state.candidates}
+        tasks = self._build_tasks(state, candidates_by_id)
+        if not tasks:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    "Evolver could not match any survivor id to "
+                    "state.candidates — survivors list out of sync with "
+                    "candidates."
+                ),
+            )
+
+        log.info(
+            "seed-pipeline evolver dispatching %d evolution tasks to %r",
+            len(tasks),
+            _EVOLVER_AGENT_NAME,
+        )
+        results = self._manager.delegate(tasks, announce=False)
+
+        tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
+        evolved_rows: list[dict[str, Any]] = []
+        failed: list[tuple[str, str]] = []
+        for result in results:
+            task = tasks_by_id.get(result.task_id)
+            if task is None:
+                failed.append((result.task_id, f"unmatched_result: {result.error or 'no_task'}"))
+                continue
+            if not result.success:
+                failed.append((task.task_id, result.error or "unknown"))
+                continue
+            parsed = parse_structured_output(
+                result.output,
+                required_fields=_REQUIRED_EVOLVE_FIELDS,
+                pin_field="parent_id",
+                pin_value=task.args["parent_id"],
+            )
+            if parsed is None:
+                failed.append(
+                    (
+                        task.task_id,
+                        f"malformed_evolve: result.output={result.output!r}",
+                    )
+                )
+                continue
+            if parsed.get("verdict") not in _VALID_VERDICTS:
+                log.warning(
+                    "seed-pipeline evolver: parent=%s invalid verdict=%r",
+                    task.args["parent_id"],
+                    parsed.get("verdict"),
+                )
+                continue
+            if parsed["verdict"] != "ok":
+                # Evolution skipped or failed — original candidate stays.
+                continue
+            evolved_rows.append(self._build_evolved_row(parsed, task, state.gen_tag))
+
+        if failed:
+            log.warning(
+                "seed-pipeline evolver: %d/%d sub-agents failed: %s",
+                len(failed),
+                len(tasks),
+                failed[:3],
+            )
+
+        if not evolved_rows:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="evolution_failed",
+                error_message=(
+                    f"all {len(tasks)} evolution sub-agents either failed "
+                    f"or returned verdict != 'ok'; "
+                    f"first error: {failed[0][1] if failed else 'verdict_not_ok'}"
+                ),
+            )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={"evolved_candidates": evolved_rows},
+        )
+
+    def _build_tasks(
+        self,
+        state: PipelineState,
+        candidates_by_id: dict[str, dict[str, Any]],
+    ) -> list[SubTask]:
+        """One SubTask per survivor that has a corresponding candidate row."""
+        from core.agent.sub_agent import SubTask
+
+        tasks: list[SubTask] = []
+        for survivor_id in state.survivors:
+            candidate = candidates_by_id.get(survivor_id)
+            if candidate is None:
+                log.warning(
+                    "seed-pipeline evolver: survivor %r missing from state.candidates "
+                    "— skipping evolution",
+                    survivor_id,
+                )
+                continue
+            reflection = state.reflections.get(survivor_id, {})
+            rewrite_section = reflection.get("rewrite_section") or "Body"
+            pilot = state.pilot_scores.get(survivor_id, {})
+            description = self._build_description(
+                candidate=candidate,
+                rewrite_section=rewrite_section,
+                weaknesses=reflection.get("weaknesses", []),
+                dim_means=pilot.get("dim_means", {}) if isinstance(pilot, dict) else {},
+            )
+            tasks.append(
+                SubTask(
+                    task_id=f"evolve-{survivor_id}",
+                    description=description,
+                    task_type=_TASK_TYPE,
+                    args={
+                        "parent_id": survivor_id,
+                        "parent_path": candidate["path"],
+                        "target_dim": candidate.get("target_dim", state.target_dim),
+                        "rewrite_section": rewrite_section,
+                        "gen_tag": state.gen_tag,
+                    },
+                    agent=_EVOLVER_AGENT_NAME,
+                )
+            )
+        return tasks
+
+    def _build_description(
+        self,
+        *,
+        candidate: dict[str, Any],
+        rewrite_section: str,
+        weaknesses: list[Any],
+        dim_means: dict[str, Any],
+    ) -> str:
+        """Compose the per-survivor user message for the sub-agent.
+
+        The system prompt is owned by ``.claude/agents/seed_evolver.md``.
+        The description fills in the parent candidate path, the section
+        the Critic flagged, the per-candidate weaknesses list, and the
+        Pilot dim_means so the sub-agent has all 3 signals the AgentDef
+        contract mandates.
+        """
+        weakness_summary = "; ".join(str(w) for w in weaknesses) or "n/a"
+        means_summary = ", ".join(f"{k}={v}" for k, v in dim_means.items()) or "n/a"
+        return (
+            f"Evolve ONE Petri seed candidate. Parent id: {candidate['id']!r}. "
+            f"Parent path: {candidate['path']!r}. Target dim: "
+            f"{candidate.get('target_dim', 'unknown')!r}. Rewrite section: "
+            f"{rewrite_section!r}. Reflection weaknesses: {weakness_summary}. "
+            f"Pilot dim_means: {means_summary}. Per your system prompt, "
+            "rewrite ONLY that section, preserve frontmatter + target_dim, "
+            "keep total tokens within ±20% of original. Write to "
+            f"<run_dir>/candidates_evolved/<new-uuid>.md and return JSON with "
+            "`parent_id`, `evolved_id`, `evolved_path`, `rewrite_section`, "
+            "`verdict` (one of 'ok'/'evolution_skipped'/'failed'), and "
+            "`notes` (<= 200 tokens)."
+        )
+
+    def _build_evolved_row(
+        self,
+        parsed: dict[str, Any],
+        task: Any,
+        gen_tag: str,
+    ) -> dict[str, Any]:
+        """Translate a parsed sub-result into a candidates-list row.
+
+        Schema mirrors :class:`PipelineState.candidates` (id / path /
+        target_dim / gen_tag / task_id / duration_ms) plus evolution-
+        specific provenance (``parent_id``, ``rewrite_section``,
+        ``notes``).
+        """
+        return {
+            "id": str(parsed["evolved_id"]),
+            "path": str(parsed["evolved_path"]),
+            "target_dim": task.args.get("target_dim"),
+            "gen_tag": gen_tag,
+            "task_id": task.task_id,
+            "duration_ms": 0.0,
+            "parent_id": str(parsed["parent_id"]),
+            "rewrite_section": str(parsed["rewrite_section"]),
+            "notes": parsed.get("notes", ""),
+        }

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -101,6 +101,7 @@ class PipelineState:
     pilot_scores: dict[str, dict[str, Any]] = field(default_factory=dict)
     elo_ratings: dict[str, float] = field(default_factory=dict)
     survivors: list[str] = field(default_factory=list)
+    evolved_candidates: list[dict[str, Any]] = field(default_factory=list)
     meta_review: dict[str, Any] = field(default_factory=dict)
     # cost rollup
     usd_spent: float = 0.0
@@ -126,6 +127,7 @@ class PipelineState:
             "pilot_scores",
             "elo_ratings",
             "survivors",
+            "evolved_candidates",
             "meta_review",
         }
         unknown = set(output) - known

--- a/tests/plugins/seed_pipeline/test_evolver.py
+++ b/tests/plugins/seed_pipeline/test_evolver.py
@@ -1,0 +1,300 @@
+"""Tests for ``plugins.seed_pipeline.agents.evolver``.
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — `_ReverseOrderManager` returns results in
+  reverse submission order; tests verify Evolver still pairs by task_id
+  via `parse_structured_output`'s pin_field.
+- **P7 Caller-Callee Contract Pair Read** — Evolver consumes
+  ``state.survivors`` + ``state.reflections`` + ``state.pilot_scores``;
+  emits rows mirroring ``state.candidates`` schema plus provenance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.evolver import Evolver
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+
+def _good_evolve(parent_id: str = "c-1", verdict: str = "ok") -> dict[str, Any]:
+    return {
+        "parent_id": parent_id,
+        "evolved_id": f"{parent_id}-ev",
+        "evolved_path": f"fake-run/candidates_evolved/{parent_id}-ev.md",
+        "rewrite_section": "Body",
+        "verdict": verdict,
+        "notes": "test notes",
+    }
+
+
+class _StubManager:
+    def __init__(
+        self,
+        *,
+        evolve_outputs: dict[str, dict[str, Any]] | None = None,
+        force_failures: int = 0,
+        force_unparseable: bool = False,
+    ) -> None:
+        self.received_tasks: list[SubTask] = []
+        self.received_announce: bool | None = None
+        self._evolves = evolve_outputs or {}
+        self._force_failures = force_failures
+        self._force_unparseable = force_unparseable
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks = list(tasks)
+        self.received_announce = announce
+        results: list[SubResult] = []
+        for i, t in enumerate(tasks):
+            parent_id = t.args["parent_id"]
+            failed = i < self._force_failures
+            if failed:
+                results.append(
+                    SubResult(
+                        task_id=t.task_id,
+                        description=t.description,
+                        success=False,
+                        error="forced",
+                        duration_ms=10.0,
+                    )
+                )
+                continue
+            if self._force_unparseable:
+                output: Any = {"text": "not-json"}
+            else:
+                output = dict(self._evolves.get(parent_id, _good_evolve(parent_id)))
+            results.append(
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=True,
+                    output=output,
+                    duration_ms=42.0,
+                )
+            )
+        return results
+
+
+class _ReverseOrderManager(_StubManager):
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        results = super().delegate(tasks, announce=announce)
+        return list(reversed(results))
+
+
+def _state_with_survivors(n: int) -> PipelineState:
+    state = PipelineState(
+        run_id="t-evolver",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+    )
+    state.candidates = [
+        {
+            "id": f"c-{i:02d}",
+            "path": f"fake-run/candidates/c-{i:02d}.md",
+            "target_dim": "broken_tool_use",
+            "gen_tag": "gen2",
+            "task_id": f"gen-c-{i:02d}",
+            "duration_ms": 1000.0,
+        }
+        for i in range(n)
+    ]
+    state.survivors = [c["id"] for c in state.candidates]
+    state.reflections = {
+        c["id"]: {
+            "rewrite_section": "Body",
+            "weaknesses": ["partial overlap with seed_pool"],
+        }
+        for c in state.candidates
+    }
+    state.pilot_scores = {
+        c["id"]: {
+            "dim_means": {"dim_01": 0.7},
+            "dim_stderr": {"dim_01": 0.1},
+            "status": "ok",
+        }
+        for c in state.candidates
+    }
+    return state
+
+
+def test_evolver_validates_empty_survivors() -> None:
+    state = PipelineState(
+        run_id="t",
+        target_dim="x",
+        gen_tag="gen2",
+        candidates_requested=3,
+    )
+    manager = _StubManager()
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_evolver_validates_survivors_without_candidates() -> None:
+    """Survivor id not in state.candidates → skipped + validation error."""
+    state = PipelineState(
+        run_id="t",
+        target_dim="x",
+        gen_tag="gen2",
+        candidates_requested=3,
+    )
+    state.survivors = ["ghost-1"]
+    manager = _StubManager()
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_evolver_builds_one_task_per_survivor() -> None:
+    state = _state_with_survivors(3)
+    manager = _StubManager()
+    Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert len(manager.received_tasks) == 3
+    for task in manager.received_tasks:
+        assert task.agent == "seed_evolver"
+        assert task.task_type == "seed-evolve"
+        assert "parent_id" in task.args
+        assert "rewrite_section" in task.args
+
+
+def test_evolver_returns_evolved_candidates_rows() -> None:
+    state = _state_with_survivors(3)
+    manager = _StubManager()
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    rows = result.output["evolved_candidates"]
+    assert len(rows) == 3
+    for row in rows:
+        assert row["id"].endswith("-ev")
+        assert "parent_id" in row
+        assert row["rewrite_section"] == "Body"
+
+
+def test_evolver_pairs_by_task_id_under_reverse_order() -> None:
+    """P1 — reverse-order completion must still pair correctly via pin_field."""
+    state = _state_with_survivors(5)
+    manager = _ReverseOrderManager()
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    rows = result.output["evolved_candidates"]
+    for row in rows:
+        # parent_id should match a survivor id, not be the LLM echo of some other id
+        assert row["parent_id"] in state.survivors
+
+
+def test_evolver_drops_failed_sub_agents() -> None:
+    state = _state_with_survivors(5)
+    manager = _StubManager(force_failures=2)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    assert len(result.output["evolved_candidates"]) == 3
+
+
+def test_evolver_drops_unparseable_responses() -> None:
+    state = _state_with_survivors(3)
+    manager = _StubManager(force_unparseable=True)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "evolution_failed"
+
+
+def test_evolver_skips_evolution_skipped_verdict() -> None:
+    """Verdict 'evolution_skipped' → original kept, no row emitted."""
+    state = _state_with_survivors(3)
+    skipped = {cid: _good_evolve(cid, verdict="evolution_skipped") for cid in state.survivors}
+    manager = _StubManager(evolve_outputs=skipped)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success  # no rows → failure
+    assert result.error_category == "evolution_failed"
+
+
+def test_evolver_skips_failed_verdict() -> None:
+    state = _state_with_survivors(3)
+    failed_verdicts = {cid: _good_evolve(cid, verdict="failed") for cid in state.survivors}
+    manager = _StubManager(evolve_outputs=failed_verdicts)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "evolution_failed"
+
+
+def test_evolver_drops_invalid_verdict() -> None:
+    """Verdict not in whitelist → dropped."""
+    state = _state_with_survivors(1)
+    bad = {state.survivors[0]: _good_evolve(state.survivors[0], verdict="weird")}
+    manager = _StubManager(evolve_outputs=bad)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "evolution_failed"
+
+
+def test_evolver_mixed_verdicts() -> None:
+    """Some 'ok', some skipped — only 'ok' rows survive."""
+    state = _state_with_survivors(3)
+    outputs = {
+        "c-00": _good_evolve("c-00", verdict="ok"),
+        "c-01": _good_evolve("c-01", verdict="evolution_skipped"),
+        "c-02": _good_evolve("c-02", verdict="ok"),
+    }
+    manager = _StubManager(evolve_outputs=outputs)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    rows = result.output["evolved_candidates"]
+    assert len(rows) == 2
+    parent_ids = {r["parent_id"] for r in rows}
+    assert parent_ids == {"c-00", "c-02"}
+
+
+def test_evolver_pins_parent_id_from_task() -> None:
+    """LLM echoes a wrong parent_id; the task's parent_id wins."""
+    state = _state_with_survivors(1)
+    wrong = _good_evolve("WRONG-from-llm")
+    outputs = {"c-00": wrong}
+    manager = _StubManager(evolve_outputs=outputs)
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    rows = result.output["evolved_candidates"]
+    assert rows[0]["parent_id"] == "c-00"
+
+
+def test_evolver_announce_false() -> None:
+    state = _state_with_survivors(2)
+    manager = _StubManager()
+    Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert manager.received_announce is False
+
+
+def test_evolver_description_includes_pilot_means() -> None:
+    state = _state_with_survivors(1)
+    manager = _StubManager()
+    Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    desc = manager.received_tasks[0].description
+    assert "dim_01" in desc
+    assert "Body" in desc  # rewrite_section
+
+
+def test_evolver_description_default_rewrite_section_when_missing() -> None:
+    """Reflection without rewrite_section → defaults to 'Body'."""
+    state = _state_with_survivors(1)
+    state.reflections["c-00"] = {"weaknesses": ["partial overlap"]}
+    manager = _StubManager()
+    Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    task = manager.received_tasks[0]
+    assert task.args["rewrite_section"] == "Body"
+
+
+def test_evolver_evolved_row_schema_mirrors_candidates() -> None:
+    """Evolved row has the same schema as state.candidates plus provenance."""
+    state = _state_with_survivors(1)
+    manager = _StubManager()
+    result = Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
+    row = result.output["evolved_candidates"][0]
+    for key in ("id", "path", "target_dim", "gen_tag", "task_id", "duration_ms"):
+        assert key in row, f"missing {key}"
+    # Provenance-specific
+    assert "parent_id" in row
+    assert "rewrite_section" in row
+    assert "notes" in row


### PR DESCRIPTION
## Summary
- Adds `plugins/seed_pipeline/agents/evolver.py` — Per-survivor fan-out (one sub-agent per Ranker top-K survivor). Each sub-agent rewrites ONLY the section flagged by Critic's `rewrite_section` hint, weighing the Critic's `weaknesses` list and Pilot's `dim_means` signal per the seed_evolver AgentDef.
- Verdict whitelist `{ok, evolution_skipped, failed}` — only `ok` rows are merged into `state.evolved_candidates`; skipped/failed leaves the original candidate.
- Adds `evolved_candidates: list[dict]` field to `PipelineState` + the merge known set.
- Uses the shared `parse_structured_output` helper (S6 lift); pins `parent_id` from task args so a wrong LLM echo cannot route the evolved seed under a different parent. 16 unit tests.

## Why
S7 is the second-half-of-tournament feedback step — the 6th of the 7-agent topology (paper §3 Evolution). Without the section-rewrite, the seed-pipeline can only **generate** new candidates (S2) and **rank** them (S6); there's no way to incrementally improve a high-Elo seed that has one specific weakness. Section rewrite (vs full rewrite) preserves the parts the Critic + Ranker already validated and concentrates compute on the flagged weakness — mirroring co-scientist arXiv:2502.18864 §3 Evolution's gradient-of-edits pattern.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/agents/evolver.py` | NEW — Evolver(BaseSeedAgent) (~250 LOC) |
| `plugins/seed_pipeline/agents/__init__.py` | Export `Evolver`; mark S7 done |
| `plugins/seed_pipeline/orchestrator.py` | Adds `evolved_candidates` field + merge known set |
| `tests/plugins/seed_pipeline/test_evolver.py` | NEW — 16 unit tests |
| `CHANGELOG.md` | S7 entry under `[Unreleased]` |

## Codex MCP Audit Findings
| Severity | Finding | Resolution |
|----------|---------|------------|
| — | All correctness + GAP checks PASS | No fixes required |
| LOW | Critic/Pilot inline parsers still defer to retrofit | Acknowledged in CHANGELOG; not a blocker |

The S6 audit established the shared parser; Ranker (S6) and Evolver (S7) both consume it. Critic + Pilot deferred retrofit per P10 Simplicity — they already work and changing them would not have been triggered by S7 scope alone.

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] mypy plugins/seed_pipeline/ clean
- [x] pytest tests/plugins/seed_pipeline/test_evolver.py — 16/16 pass

## Reference
- co-scientist arXiv:2502.18864 §3 Evolution
- AgentDef `.claude/agents/seed_evolver.md`
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S7 row
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied