### PR TITLE
feat(seed-pipeline): S8 — Meta-review agent + parent-context offload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ functional change.
 
 ### Added
 
+- **Meta-review agent + parent-context offload (S8).** New
+  `plugins/seed_pipeline/agents/meta_reviewer.py` dispatches a single
+  sub-agent (no per-candidate fan-out) carrying a compact state
+  snapshot (candidate counts, target_dim coverage, elo p50/p95,
+  evolution yield) so the LLM produces an aggregate report without
+  context blowing past 1KB. Required fields: `coverage`,
+  `underrepresented_dims`, `overrepresented_dims`, `next_gen_priors`,
+  `elo_distribution`, `evolution_yield`, `session_summary` — partial
+  payloads dropped via `parse_structured_output`. Adds
+  `_persist_state()` to `Pipeline.run()` (S8 parent-context offload)
+  that writes `<run_dir>/state.json` after meta-review fires;
+  runtime-only fields (`budget_guard`) skipped, Path fields coerced
+  to strings. Skipped silently when `state.run_dir` is None; persist
+  failures logged as WARNING (in-memory state remains primary).
+  17 unit tests (12 meta_reviewer + 5 state_offload).
 - **Evolution agent (S7).** New `plugins/seed_pipeline/agents/evolver.py`
   fans out one sub-agent per Ranker survivor; each reads the Critic's
   `rewrite_section` hint + the per-candidate `weaknesses` + Pilot

--- a/plugins/seed_pipeline/agents/__init__.py
+++ b/plugins/seed_pipeline/agents/__init__.py
@@ -7,7 +7,7 @@
 - pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop 자리)
 - ranker        (S6, ✓) — Elo tournament + 3-judge panel
 - evolver       (S7, ✓) — Reflection-driven section rewrite
-- meta_reviewer (S8)
+- meta_reviewer (S8, ✓) — coverage + next-gen prior + session summary
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from plugins.seed_pipeline.agents.base import (
 from plugins.seed_pipeline.agents.critic import Critic
 from plugins.seed_pipeline.agents.evolver import Evolver
 from plugins.seed_pipeline.agents.generator import Generator
+from plugins.seed_pipeline.agents.meta_reviewer import MetaReviewer
 from plugins.seed_pipeline.agents.pilot import Pilot
 from plugins.seed_pipeline.agents.proximity import Proximity
 from plugins.seed_pipeline.agents.ranker import Ranker
@@ -29,6 +30,7 @@ __all__ = [
     "Critic",
     "Evolver",
     "Generator",
+    "MetaReviewer",
     "Pilot",
     "Proximity",
     "Ranker",

--- a/plugins/seed_pipeline/agents/meta_reviewer.py
+++ b/plugins/seed_pipeline/agents/meta_reviewer.py
@@ -1,0 +1,237 @@
+"""Meta-review agent — Phase G of the seed pipeline.
+
+Per ADR-001 paper §3 Meta-review: after the Ranker + Evolver phases,
+analyse the entire candidate batch and emit a coverage report + next-
+generation hypothesis prior + session summary. The orchestrator merges
+the report under :attr:`PipelineState.meta_review` and persists it as
+part of the parent-context offload (S8 second deliverable, handled in
+``plugins.seed_pipeline.orchestrator``).
+
+Single-shot, single sub-agent — unlike Generator / Critic / Pilot /
+Ranker / Evolver this phase doesn't fan out per-candidate. One
+sub-agent reads the aggregated state (candidates, pilot_scores,
+elo_ratings, survivors, reflections, evolved_candidates) and produces
+one structured report.
+
+Sub-agent contract (``.claude/agents/seed_meta_reviewer.md``):
+
+.. code-block:: json
+
+   {
+     "coverage": {"<target_dim>": <count>, ...},
+     "underrepresented_dims": ["<dim>", ...],
+     "overrepresented_dims": ["<dim>", ...],
+     "next_gen_priors": [
+       {"target_dim": "<dim>", "weight": <0..1>, "rationale": "<= 80 tokens"}
+     ],
+     "elo_distribution": {"min": <float>, "p50": <float>, "p95": <float>},
+     "evolution_yield": {"attempted": <int>, "successful": <int>},
+     "session_summary": "<= 300 tokens"
+   }
+
+P-checklist application:
+
+- **P1 Stub Fidelity Audit** — tests cover failure paths (missing
+  fields, non-dict shape, JSON-as-text fallback) via
+  :func:`parse_structured_output`'s contract.
+- **P7 Caller-Callee Contract Pair Read** — Meta-reviewer reads ALL
+  6 upstream-phase state fields. Emits `state.meta_review` whose keys
+  the S10 results.tsv writer + S11 CLI summary renderer consume.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from plugins.seed_pipeline.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    parse_structured_output,
+)
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager, SubTask
+
+log = logging.getLogger(__name__)
+
+__all__ = ["MetaReviewer"]
+
+
+_DEFAULT_META_REVIEWER_MODEL = "claude-opus-4-7"
+_META_REVIEWER_AGENT_NAME = "seed_meta_reviewer"
+_TASK_TYPE = "seed-meta-review"
+
+_REQUIRED_META_FIELDS = (
+    "coverage",
+    "underrepresented_dims",
+    "overrepresented_dims",
+    "next_gen_priors",
+    "elo_distribution",
+    "evolution_yield",
+    "session_summary",
+)
+
+
+class MetaReviewer(BaseSeedAgent):
+    """Single-shot aggregate analyzer.
+
+    Dispatches ONE sub-agent (via SubAgentManager.delegate with a
+    single-item list to keep the supervisor's announce-queue / lane
+    plumbing uniform with the per-candidate phases).
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        *,
+        model: str = _DEFAULT_META_REVIEWER_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            role="meta_reviewer",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        self._manager = manager
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Dispatch one meta-review sub-agent and parse the structured report."""
+        if not state.candidates:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="validation",
+                error_message=(
+                    "MetaReviewer requires state.candidates to be non-empty — "
+                    "the run produced no candidates to review."
+                ),
+            )
+
+        task = self._build_task(state)
+        log.info(
+            "seed-pipeline meta_reviewer dispatching aggregate review to %r",
+            _META_REVIEWER_AGENT_NAME,
+        )
+        results = self._manager.delegate([task], announce=False)
+        if not results:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="meta_review_failed",
+                error_message="SubAgentManager returned no results for meta_reviewer task.",
+            )
+
+        result = results[0]
+        if not result.success:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="meta_review_failed",
+                error_message=result.error or "meta_review sub-agent failed",
+            )
+        parsed = parse_structured_output(
+            result.output,
+            required_fields=_REQUIRED_META_FIELDS,
+        )
+        if parsed is None:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="meta_review_failed",
+                error_message=(f"malformed meta_review payload: result.output={result.output!r}"),
+            )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={"meta_review": parsed},
+        )
+
+    def _build_task(self, state: PipelineState) -> SubTask:
+        """Build the single SubTask carrying the aggregate state snapshot."""
+        from core.agent.sub_agent import SubTask
+
+        snapshot = _state_snapshot(state)
+        return SubTask(
+            task_id=f"meta-{state.run_id}",
+            description=self._build_description(state, snapshot),
+            task_type=_TASK_TYPE,
+            args={
+                "run_id": state.run_id,
+                "target_dim": state.target_dim,
+                "gen_tag": state.gen_tag,
+                "snapshot": snapshot,
+            },
+            agent=_META_REVIEWER_AGENT_NAME,
+        )
+
+    def _build_description(
+        self,
+        state: PipelineState,
+        snapshot: dict[str, Any],
+    ) -> str:
+        """Compose the user message for the single sub-agent.
+
+        Includes the *counts* (not the raw rows) because the AgentDef
+        contract caps the meta-reviewer's output at one paragraph + a
+        few aggregate dicts — passing all candidate bodies would blow
+        the context budget for what is fundamentally an aggregate
+        statistics call.
+        """
+        return (
+            f"Produce ONE meta-review report for the seed-pipeline run "
+            f"{state.run_id!r}. Aggregate state snapshot: "
+            f"{snapshot['summary']}. Target dim for this gen: "
+            f"{state.target_dim!r}. Per your system prompt, return JSON "
+            "with fields `coverage`, `underrepresented_dims`, "
+            "`overrepresented_dims`, `next_gen_priors`, "
+            "`elo_distribution`, `evolution_yield`, `session_summary` "
+            "(<= 300 tokens). Reference the candidate ids "
+            f"{snapshot['candidate_ids'][:5]!r} (showing first 5 of "
+            f"{len(snapshot['candidate_ids'])}). Use `read_document` to "
+            "inspect specific candidates as needed; do NOT request the "
+            "entire pool body."
+        )
+
+
+def _state_snapshot(state: PipelineState) -> dict[str, Any]:
+    """Build a compact serializable snapshot of state for the meta_reviewer.
+
+    The snapshot is small enough to fit in a single sub-agent task
+    description (~ 1KB) so the LLM doesn't have to re-fetch upstream
+    state — it gets counts + ids and the AgentDef tells it to use
+    ``read_document`` for specific candidates.
+    """
+    candidate_ids = [c["id"] for c in state.candidates]
+    coverage: dict[str, int] = {}
+    for c in state.candidates:
+        dim = c.get("target_dim", state.target_dim)
+        coverage[dim] = coverage.get(dim, 0) + 1
+    elo_values = sorted(state.elo_ratings.values())
+    elo_distribution = {
+        "min": elo_values[0] if elo_values else 0.0,
+        "p50": elo_values[len(elo_values) // 2] if elo_values else 0.0,
+        "p95": elo_values[int(len(elo_values) * 0.95)] if elo_values else 0.0,
+    }
+    summary = (
+        f"{len(state.candidates)} candidates, "
+        f"{len(state.reflections)} reflections, "
+        f"{len(state.pilot_scores)} pilot rows, "
+        f"{len(state.survivors)} survivors, "
+        f"{len(state.evolved_candidates)} evolved, "
+        f"elo p50={elo_distribution['p50']:.1f}"
+    )
+    return {
+        "summary": summary,
+        "candidate_ids": candidate_ids,
+        "survivors": list(state.survivors),
+        "coverage": coverage,
+        "elo_distribution": elo_distribution,
+        "evolution_yield": {
+            "attempted": len(state.survivors),
+            "successful": len(state.evolved_candidates),
+        },
+    }

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -39,6 +39,7 @@ register themselves; once registered the phase calls succeed.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -65,6 +66,37 @@ __all__ = [
     "PipelineRegistry",
     "PipelineState",
 ]
+
+
+def _state_to_json(state: PipelineState) -> str:
+    """Serialize PipelineState fields safe for JSON persistence.
+
+    Skips runtime-only fields (``budget_guard``, ``run_dir`` path
+    object). Path-typed fields are coerced to strings so the JSON is
+    portable across machines (re-hydration converts back).
+    """
+    payload: dict[str, Any] = {
+        "run_id": state.run_id,
+        "target_dim": state.target_dim,
+        "gen_tag": state.gen_tag,
+        "candidates_requested": state.candidates_requested,
+        "pool_path_in": str(state.pool_path_in) if state.pool_path_in else None,
+        "pool_path_out": str(state.pool_path_out) if state.pool_path_out else None,
+        "run_dir": str(state.run_dir) if state.run_dir else None,
+        "candidates": state.candidates,
+        "reflections": state.reflections,
+        "pilot_scores": state.pilot_scores,
+        "elo_ratings": state.elo_ratings,
+        "survivors": state.survivors,
+        "evolved_candidates": state.evolved_candidates,
+        "meta_review": state.meta_review,
+        "usd_spent": state.usd_spent,
+        "prompt_tokens": state.prompt_tokens,
+        "completion_tokens": state.completion_tokens,
+        "baseline_means": state.baseline_means,
+        "baseline_stderr": state.baseline_stderr,
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False)
 
 
 _PHASE_ORDER: tuple[str, ...] = (
@@ -210,6 +242,10 @@ class Pipeline:
         )
         for phase in _PHASE_ORDER:
             self._run_phase(phase)
+        # S8 parent-context offload — persist the final state.json so a
+        # follow-up CLI invocation (S11) can resume the meta-review +
+        # survivor pool without re-reading every candidate body.
+        self._persist_state()
         log.info(
             "seed-pipeline run finished: run_id=%s survivors=%d usd=%.4f",
             self.state.run_id,
@@ -217,6 +253,39 @@ class Pipeline:
             self.state.usd_spent,
         )
         return self.state
+
+    def _persist_state(self) -> None:
+        """Write a JSON snapshot of state to ``<run_dir>/state.json``.
+
+        S8 parent-context offload — the parent loop should not have to
+        carry the entire pool in memory after the meta_review fires.
+        Persisting the state at end-of-run is the offload boundary; the
+        S11 CLI ``geode audit-seeds resume`` will re-hydrate from here.
+
+        Skipped when ``state.run_dir`` is None (test fixtures often
+        omit it); state is kept in memory for the caller to consume.
+        Persistence failures log a WARNING but do not raise — the
+        primary signal is the in-memory state, not the disk artifact.
+        """
+        if self.state.run_dir is None:
+            return
+        try:
+            self.state.run_dir.mkdir(parents=True, exist_ok=True)
+            snapshot_path = self.state.run_dir / "state.json"
+            snapshot_path.write_text(
+                _state_to_json(self.state),
+                encoding="utf-8",
+            )
+            log.info(
+                "seed-pipeline parent-context offload: state persisted to %s",
+                snapshot_path,
+            )
+        except OSError as exc:
+            log.warning(
+                "seed-pipeline parent-context offload failed at %s: %s",
+                self.state.run_dir,
+                exc,
+            )
 
     def _run_phase(self, role: str) -> SeedAgentResult:
         """Look up the role's agent, invoke it, merge the result.

--- a/tests/plugins/seed_pipeline/test_meta_reviewer.py
+++ b/tests/plugins/seed_pipeline/test_meta_reviewer.py
@@ -1,0 +1,218 @@
+"""Tests for ``plugins.seed_pipeline.agents.meta_reviewer``."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.agent.sub_agent import SubResult, SubTask
+from plugins.seed_pipeline.agents.meta_reviewer import MetaReviewer
+from plugins.seed_pipeline.orchestrator import PipelineState
+
+
+def _good_meta() -> dict[str, Any]:
+    return {
+        "coverage": {"broken_tool_use": 4, "input_hallucination": 3},
+        "underrepresented_dims": ["unfaithful_thinking"],
+        "overrepresented_dims": ["overrefusal"],
+        "next_gen_priors": [
+            {"target_dim": "unfaithful_thinking", "weight": 0.4, "rationale": "underrepresented"}
+        ],
+        "elo_distribution": {"min": 940.0, "p50": 1020.0, "p95": 1180.0},
+        "evolution_yield": {"attempted": 5, "successful": 3},
+        "session_summary": "Pool well-covered on broken_tool_use; gap on unfaithful_thinking.",
+    }
+
+
+class _StubManager:
+    def __init__(
+        self,
+        *,
+        output: Any = None,
+        success: bool = True,
+        force_unparseable: bool = False,
+    ) -> None:
+        self.received_tasks: list[SubTask] = []
+        self.received_announce: bool | None = None
+        self._output = output if output is not None else _good_meta()
+        self._success = success
+        self._force_unparseable = force_unparseable
+
+    def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
+        self.received_tasks = list(tasks)
+        self.received_announce = announce
+        if not tasks:
+            return []
+        t = tasks[0]
+        if not self._success:
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=False,
+                    error="forced",
+                    duration_ms=10.0,
+                )
+            ]
+        output = {"text": "not-valid-json"} if self._force_unparseable else self._output
+        return [
+            SubResult(
+                task_id=t.task_id,
+                description=t.description,
+                success=True,
+                output=output,
+                duration_ms=42.0,
+            )
+        ]
+
+
+def _state_with_full_pipeline_data(n: int = 5) -> PipelineState:
+    state = PipelineState(
+        run_id="t-meta",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=n,
+    )
+    state.candidates = [
+        {
+            "id": f"c-{i:02d}",
+            "path": f"fake-run/candidates/c-{i:02d}.md",
+            "target_dim": "broken_tool_use",
+            "gen_tag": "gen2",
+            "task_id": f"gen-c-{i:02d}",
+            "duration_ms": 1000.0,
+        }
+        for i in range(n)
+    ]
+    state.reflections = {
+        c["id"]: {"strengths": ["a"], "weaknesses": ["b"]} for c in state.candidates
+    }
+    state.pilot_scores = {
+        c["id"]: {"dim_means": {"dim_01": 0.7}, "dim_stderr": {"dim_01": 0.1}, "status": "ok"}
+        for c in state.candidates
+    }
+    state.elo_ratings = {c["id"]: 1000.0 + i * 30 for i, c in enumerate(state.candidates)}
+    state.survivors = [c["id"] for c in state.candidates[:3]]
+    state.evolved_candidates = [
+        {"id": f"{cid}-ev", "parent_id": cid} for cid in state.survivors[:2]
+    ]
+    return state
+
+
+def test_meta_reviewer_validates_empty_candidates() -> None:
+    state = PipelineState(
+        run_id="t",
+        target_dim="x",
+        gen_tag="gen2",
+        candidates_requested=3,
+    )
+    manager = _StubManager()
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "validation"
+
+
+def test_meta_reviewer_dispatches_single_task() -> None:
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager()
+    MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert len(manager.received_tasks) == 1
+    task = manager.received_tasks[0]
+    assert task.agent == "seed_meta_reviewer"
+    assert task.task_type == "seed-meta-review"
+
+
+def test_meta_reviewer_merges_report_into_meta_review() -> None:
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager()
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    meta = result.output["meta_review"]
+    assert "coverage" in meta
+    assert "next_gen_priors" in meta
+    assert "session_summary" in meta
+
+
+def test_meta_reviewer_drops_malformed_payload() -> None:
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager(output={"partial": "dict"})
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "meta_review_failed"
+
+
+def test_meta_reviewer_handles_sub_agent_failure() -> None:
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager(success=False)
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "meta_review_failed"
+
+
+def test_meta_reviewer_accepts_text_json_fallback() -> None:
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager(output={"text": json.dumps(_good_meta())})
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+
+
+def test_meta_reviewer_announce_false() -> None:
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager()
+    MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert manager.received_announce is False
+
+
+def test_meta_reviewer_snapshot_includes_counts() -> None:
+    """Task args should carry the state snapshot with counts."""
+    state = _state_with_full_pipeline_data(5)
+    manager = _StubManager()
+    MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    task = manager.received_tasks[0]
+    snapshot = task.args["snapshot"]
+    assert snapshot["candidate_ids"] == [c["id"] for c in state.candidates]
+    assert snapshot["evolution_yield"]["successful"] == 2  # 2 evolved
+    assert snapshot["evolution_yield"]["attempted"] == 3  # 3 survivors
+    assert "elo_distribution" in snapshot
+
+
+def test_meta_reviewer_description_mentions_run_id() -> None:
+    state = _state_with_full_pipeline_data(3)
+    manager = _StubManager()
+    MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    desc = manager.received_tasks[0].description
+    assert "t-meta" in desc
+    assert "broken_tool_use" in desc
+
+
+def test_meta_reviewer_drops_response_missing_session_summary() -> None:
+    """All 7 fields required — missing any → drop."""
+    state = _state_with_full_pipeline_data(3)
+    partial = _good_meta()
+    del partial["session_summary"]
+    manager = _StubManager(output=partial)
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert not result.success
+    assert result.error_category == "meta_review_failed"
+
+
+def test_meta_reviewer_empty_elo_ratings_safe() -> None:
+    """elo_distribution computation tolerates empty elo_ratings dict."""
+    state = _state_with_full_pipeline_data(3)
+    state.elo_ratings = {}
+    manager = _StubManager()
+    result = MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert result.success
+    snapshot = manager.received_tasks[0].args["snapshot"]
+    assert snapshot["elo_distribution"]["min"] == 0.0
+
+
+def test_meta_reviewer_coverage_aggregates_target_dims() -> None:
+    """Snapshot coverage groups candidates by target_dim."""
+    state = _state_with_full_pipeline_data(2)
+    state.candidates[1]["target_dim"] = "input_hallucination"
+    manager = _StubManager()
+    MetaReviewer(manager=manager).execute(state)  # type: ignore[arg-type]
+    snapshot = manager.received_tasks[0].args["snapshot"]
+    assert snapshot["coverage"]["broken_tool_use"] == 1
+    assert snapshot["coverage"]["input_hallucination"] == 1

--- a/tests/plugins/seed_pipeline/test_state_offload.py
+++ b/tests/plugins/seed_pipeline/test_state_offload.py
@@ -1,0 +1,113 @@
+"""Tests for the S8 parent-context offload — Pipeline._persist_state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from plugins.seed_pipeline.agents.base import BaseSeedAgent, SeedAgentResult
+from plugins.seed_pipeline.orchestrator import (
+    Pipeline,
+    PipelineRegistry,
+    PipelineState,
+)
+
+
+class _NoopAgent(BaseSeedAgent):
+    """Concrete agent that returns success without touching state.
+
+    Used by tests that only exercise the orchestrator's persistence
+    boundary, not the agent logic.
+    """
+
+    def __init__(self, role: str) -> None:
+        super().__init__(role=role, model="dummy")
+
+    def execute(self, state: Any) -> SeedAgentResult:
+        return SeedAgentResult(role=self.role)
+
+
+def _populated_state(run_dir: Path) -> PipelineState:
+    state = PipelineState(
+        run_id="t-offload",
+        target_dim="broken_tool_use",
+        gen_tag="gen2",
+        candidates_requested=3,
+        run_dir=run_dir,
+    )
+    state.candidates = [{"id": "c-00", "path": "x", "target_dim": "broken_tool_use"}]
+    state.reflections = {"c-00": {"strengths": ["a"]}}
+    state.pilot_scores = {"c-00": {"dim_means": {"d": 0.5}}}
+    state.elo_ratings = {"c-00": 1010.0}
+    state.survivors = ["c-00"]
+    state.evolved_candidates = [{"id": "c-00-ev", "parent_id": "c-00"}]
+    state.meta_review = {"coverage": {"broken_tool_use": 1}}
+    state.usd_spent = 0.42
+    return state
+
+
+def _registry_with_noop_agents() -> PipelineRegistry:
+    reg = PipelineRegistry()
+    for role in (
+        "generator",
+        "proximity",
+        "critic",
+        "pilot",
+        "ranker",
+        "evolver",
+        "meta_reviewer",
+    ):
+        reg.register(_NoopAgent(role))
+    return reg
+
+
+def test_persist_state_writes_state_json(tmp_path: Path) -> None:
+    state = _populated_state(tmp_path)
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    state_path = tmp_path / "state.json"
+    assert state_path.is_file()
+    blob = json.loads(state_path.read_text(encoding="utf-8"))
+    assert blob["run_id"] == "t-offload"
+    assert blob["survivors"] == ["c-00"]
+    assert blob["evolved_candidates"][0]["id"] == "c-00-ev"
+    assert blob["meta_review"]["coverage"]["broken_tool_use"] == 1
+
+
+def test_persist_state_includes_cost_rollup(tmp_path: Path) -> None:
+    state = _populated_state(tmp_path)
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    blob = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert blob["usd_spent"] == 0.42
+
+
+def test_persist_state_omitted_when_run_dir_unset(tmp_path: Path) -> None:
+    state = _populated_state(tmp_path)
+    state.run_dir = None
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    # No state.json written
+    assert not (tmp_path / "state.json").exists()
+
+
+def test_persist_state_path_fields_coerced_to_strings(tmp_path: Path) -> None:
+    state = _populated_state(tmp_path)
+    state.pool_path_in = tmp_path / "pool_in"
+    state.pool_path_out = tmp_path / "pool_out"
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    blob = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert isinstance(blob["pool_path_in"], str)
+    assert isinstance(blob["pool_path_out"], str)
+    assert isinstance(blob["run_dir"], str)
+
+
+def test_persist_state_skips_budget_guard(tmp_path: Path) -> None:
+    """Runtime-only fields (budget_guard) are not persisted."""
+    state = _populated_state(tmp_path)
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    blob = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert "budget_guard" not in blob


### PR DESCRIPTION
## Summary
- Adds `plugins/seed_pipeline/agents/meta_reviewer.py` — single-shot aggregate analyzer (NOT per-candidate fan-out). Dispatches one sub-agent with a compact ~1KB snapshot (counts + ids + elo distribution + evolution yield); AgentDef instructs the LLM to use `read_document` for specific candidate bodies. All 7 required fields enforced via `parse_structured_output`; partial payloads dropped.
- Adds `_persist_state()` to `Pipeline.run()` — S8 parent-context offload. Writes `<run_dir>/state.json` with all phase artifacts (Path fields coerced to strings, `budget_guard` runtime-only skipped). The S11 CLI `geode audit-seeds resume` will re-hydrate from this artifact.
- 17 unit tests (12 meta_reviewer + 5 state_offload).

## Why
S8 is the LAST agent role in the 7-role topology — completes the co-scientist paper §3 Meta-review loop. Without it, the pipeline produces survivors + evolved candidates but no aggregate report; the next-generation hypothesis prior would be re-derived from scratch by the operator instead of carrying forward as a structured signal. Parent-context offload is the second deliverable: long-running pipelines should not keep the entire pool in supervisor memory across runs — persisting to disk after meta-review is the natural offload boundary.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/agents/meta_reviewer.py` | NEW — single-shot meta_reviewer (~220 LOC) |
| `plugins/seed_pipeline/orchestrator.py` | Adds `_persist_state()` + `_state_to_json()` helper + json import |
| `plugins/seed_pipeline/agents/__init__.py` | Exports `MetaReviewer` |
| `tests/plugins/seed_pipeline/test_meta_reviewer.py` | NEW — 12 unit tests |
| `tests/plugins/seed_pipeline/test_state_offload.py` | NEW — 5 tests |
| `CHANGELOG.md` | S8 entry under `[Unreleased]` |

## Codex MCP Audit Findings
| Severity | Finding | Resolution |
|----------|---------|------------|
| — | All correctness + GAP + 누락 + 중복 checks PASS | No fixes required |

The audit confirmed `_persist_state()` is called from `Pipeline.run()`, `_state_to_json` skips `budget_guard` runtime field, Path fields coerce to strings, `parse_structured_output` is used (no inline parser), and the `_state_snapshot` vs `_state_to_json` separation has different consumers and is acceptable.

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] mypy plugins/seed_pipeline/ clean
- [x] pytest tests/plugins/seed_pipeline/test_meta_reviewer.py + test_state_offload.py — 17/17 pass

## Reference
- co-scientist arXiv:2502.18864 §3 Meta-review
- AgentDef `.claude/agents/seed_meta_reviewer.md`
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S8 row
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied