### PR TITLE
feat(seed-pipeline): S11 — CLI sub-app + /audit-seeds slash + human gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ functional change.
 
 ### Added
 
+- **Seed-pipeline CLI sub-app + `/audit-seeds` slash + human gate (S11).**
+  New `plugins/seed_pipeline/cli.py` defines a `geode audit-seeds`
+  Typer sub-app (`generate` action with `--target-dim`, `--gen-tag`,
+  `--candidates`, `--soft-usd`, `--hard-usd`, `--yes`, `--quiet`
+  options) AND a `/audit-seeds` slash command. The flow composes the
+  S5.5 picker → S6.5 cost preview → S6.5 pre-flight → human gate (last
+  off-ramp before LLM calls) → S1 Pipeline.run(). Pre-flight error or
+  user-says-no aborts with exit 1; dispatch exception → exit 2;
+  pipeline success → exit 0. `core/cli/routing.py` registers
+  `/audit-seeds` slash; `core/cli/__init__.py` mounts the Typer
+  sub-app under `geode audit-seeds`. 16 unit tests covering yes/no
+  gate, pre-flight abort, dispatch exception, cost summary emission,
+  ToS quiet suppression, slash arg parsing edges (quote error,
+  unknown flag, short flags, count parse).
 - **autoresearch results.tsv 10-col + results.jsonl raw emit (S10).**
   `autoresearch/train.py` adds `format_results_tsv_row()` (10-col
   schema: `commit, fitness, critical_min, critical_mean,

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import typer
 from plugins.petri_audit.cli_audit import audit, petri_archive
+from plugins.seed_pipeline.cli import audit_seeds_app
 
 from core import __version__
 
@@ -331,6 +332,7 @@ app.command()(history)
 app.command()(serve)
 app.command()(audit)
 app.command(name="petri-archive")(petri_archive)
+app.add_typer(audit_seeds_app, name="audit-seeds")
 
 
 def _version_option(value: bool) -> None:

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -119,6 +119,7 @@ COMMAND_MAP: dict[str, str] = {
     "/task": "tasks",
     "/t": "tasks",
     "/audit": "audit",
+    "/audit-seeds": "audit-seeds",
     "/petri": "petri",
 }
 

--- a/core/cli/routing.py
+++ b/core/cli/routing.py
@@ -96,6 +96,12 @@ COMMAND_REGISTRY: dict[str, CommandSpec] = {
         description="Petri × GEODE alignment audit — choose judge/auditor/target",
         handler_path="plugins.petri_audit.cli_audit:cmd_audit_slash",
     ),
+    "/audit-seeds": CommandSpec(
+        name="/audit-seeds",
+        location=RunLocation.THIN,
+        description="Seed-pipeline candidate generation (co-scientist 7-role)",
+        handler_path="plugins.seed_pipeline.cli:cmd_audit_seeds_slash",
+    ),
     # ────────── DAEMON_RPC — short read-only daemon queries ──────────
     # Phase 4에서 core/server/handlers/ 로 이동 후 handler_path 갱신.
     # 현재는 cli/__init__.py:_handle_command 가 IPC RPC로 위임 (호환).

--- a/plugins/seed_pipeline/cli.py
+++ b/plugins/seed_pipeline/cli.py
@@ -31,7 +31,6 @@ P-checklist application:
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import shlex
 import sys
@@ -242,11 +241,13 @@ def _dispatch_pipeline(
         budget_hard_usd=hard_usd,
     )
     out.write(f"seed-pipeline: starting run {run_id!r}\n")
+    out.write(f"seed-pipeline: run_dir={run_dir}\n")
     out.flush()
     pipeline.run()
     out.write(
         f"seed-pipeline: run {run_id!r} finished; "
         f"survivors={len(state.survivors)} usd={state.usd_spent:.4f}\n"
+        f"seed-pipeline: state.json at {run_dir / 'state.json'}\n"
     )
 
 
@@ -284,50 +285,30 @@ def cmd_audit_seeds_slash(args: str) -> int:
     except ValueError as exc:
         sys.stderr.write(f"/audit-seeds: argument parse error — {exc}\n")
         return 2
-    target_dim, gen_tag, candidates, yes, quiet = _parse_slash_args(argv)
-    if target_dim is None:
-        sys.stderr.write("/audit-seeds: --target-dim is required\n")
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="/audit-seeds",
+        add_help=False,
+        allow_abbrev=False,
+    )
+    parser.add_argument("--target-dim", "-d", required=True)
+    parser.add_argument("--gen-tag", "-g", default="gen1")
+    parser.add_argument("--candidates", "-n", type=int, default=15)
+    parser.add_argument("--yes", "-y", action="store_true")
+    parser.add_argument("--quiet", "-q", action="store_true")
+    try:
+        ns = parser.parse_args(argv)
+    except SystemExit:
+        # argparse calls sys.exit on error; turn that into a clean exit 2.
+        return 2
+    except argparse.ArgumentError as exc:
+        sys.stderr.write(f"/audit-seeds: {exc}\n")
         return 2
     return run_audit_seeds(
-        target_dim=target_dim,
-        gen_tag=gen_tag,
-        candidates=candidates,
-        yes=yes,
-        quiet=quiet,
+        target_dim=ns.target_dim,
+        gen_tag=ns.gen_tag,
+        candidates=ns.candidates,
+        yes=ns.yes,
+        quiet=ns.quiet,
     )
-
-
-def _parse_slash_args(
-    argv: list[str],
-) -> tuple[str | None, str, int, bool, bool]:
-    """Minimal slash arg parser — picks out --target-dim / --gen-tag /
-    --candidates / --yes / --quiet. Unknown flags are ignored (forward-
-    compat with future options).
-    """
-    target_dim: str | None = None
-    gen_tag = "gen1"
-    candidates = 15
-    yes = False
-    quiet = False
-    i = 0
-    while i < len(argv):
-        token = argv[i]
-        if token in {"--target-dim", "-d"} and i + 1 < len(argv):
-            target_dim = argv[i + 1]
-            i += 2
-        elif token in {"--gen-tag", "-g"} and i + 1 < len(argv):
-            gen_tag = argv[i + 1]
-            i += 2
-        elif token in {"--candidates", "-n"} and i + 1 < len(argv):
-            with contextlib.suppress(ValueError):
-                candidates = int(argv[i + 1])
-            i += 2
-        elif token in {"--yes", "-y"}:
-            yes = True
-            i += 1
-        elif token in {"--quiet", "-q"}:
-            quiet = True
-            i += 1
-        else:
-            i += 1
-    return target_dim, gen_tag, candidates, yes, quiet

--- a/plugins/seed_pipeline/cli.py
+++ b/plugins/seed_pipeline/cli.py
@@ -1,0 +1,333 @@
+"""Seed-pipeline CLI sub-app — `geode audit-seeds` + `/audit-seeds`.
+
+S11 wires the seed-pipeline orchestrator into both the top-level
+``geode audit-seeds`` Typer command and the in-REPL ``/audit-seeds``
+slash command. The CLI composes the existing modules:
+
+1. :func:`plugins.seed_pipeline.picker.pick_bindings` — resolve per-role
+   ``(model, family, source)`` bindings (S5.5 picker).
+2. :func:`plugins.seed_pipeline.cost_preview.estimate_cost` — render
+   per-role + aggregate USD estimate (S6.5 cost preview).
+3. :func:`plugins.seed_pipeline.pre_flight.run_pre_flight` — credential
+   + budget + diversity gate (S6.5 pre-flight).
+4. **Human gate** — print cost summary + ToS notice + pre-flight
+   issues; abort unless the user confirms (``y`` / ``--yes``). This is
+   the last off-ramp before LLM calls.
+5. :class:`plugins.seed_pipeline.orchestrator.Pipeline` — actual run
+   (S1-S8).
+
+The CLI is intentionally thin — every layer above is already covered
+by per-module unit tests; the CLI just composes them.
+
+P-checklist application:
+
+- **P4 Environment Anchor**: paths read from
+  :mod:`plugins.seed_pipeline.picker` / cost_preview / pre_flight; the
+  CLI never reads ``~/.geode/`` directly.
+- **P7 Caller-Callee Contract**: every arg-parsing branch exits with
+  a non-zero status when the gate or pre-flight fails, so a CI wrapper
+  can distinguish abort-by-user (exit 1) from upstream errors.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import shlex
+import sys
+from collections.abc import Callable
+from typing import IO
+
+import typer
+
+from plugins.seed_pipeline.cost_preview import estimate_cost, format_cost_summary
+from plugins.seed_pipeline.picker import (
+    PickerResult,
+    pick_bindings,
+    print_tos_notice,
+)
+from plugins.seed_pipeline.pre_flight import PreFlightReport, run_pre_flight
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "audit_seeds_app",
+    "cmd_audit_seeds_slash",
+    "render_pre_flight_report",
+    "run_audit_seeds",
+]
+
+
+audit_seeds_app = typer.Typer(
+    name="audit-seeds",
+    help="Run the seed-pipeline (generate-debate-evolve) for one target dim.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@audit_seeds_app.command("generate")
+def audit_seeds_generate(
+    target_dim: str = typer.Option(
+        ...,
+        "--target-dim",
+        "-d",
+        help="Target Petri dim for this generation (e.g. broken_tool_use).",
+    ),
+    gen_tag: str = typer.Option(
+        "gen1",
+        "--gen-tag",
+        "-g",
+        help="Generation tag — used in candidate ids and run_dir.",
+    ),
+    candidates: int = typer.Option(
+        15,
+        "--candidates",
+        "-n",
+        help="Target N for the generator phase (default 15).",
+    ),
+    soft_usd: float = typer.Option(
+        2.00,
+        "--soft-usd",
+        help="Soft budget cap per phase (warning at threshold).",
+    ),
+    hard_usd: float = typer.Option(
+        10.00,
+        "--hard-usd",
+        help="Hard budget cap per phase (abort at threshold).",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the interactive human gate (assume confirm).",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress the ToS notice for subscription paths.",
+    ),
+) -> None:
+    """Generate a new candidate batch — runs picker → cost preview →
+    pre-flight → confirm → Pipeline.run().
+    """
+    exit_code = run_audit_seeds(
+        target_dim=target_dim,
+        gen_tag=gen_tag,
+        candidates=candidates,
+        soft_usd=soft_usd,
+        hard_usd=hard_usd,
+        yes=yes,
+        quiet=quiet,
+    )
+    raise typer.Exit(code=exit_code)
+
+
+def run_audit_seeds(
+    *,
+    target_dim: str,
+    gen_tag: str = "gen1",
+    candidates: int = 15,
+    soft_usd: float = 2.00,
+    hard_usd: float = 10.00,
+    yes: bool = False,
+    quiet: bool = False,
+    stdout: IO[str] | None = None,
+    stderr: IO[str] | None = None,
+    confirm_fn: Callable[[IO[str], IO[str]], bool] | None = None,
+) -> int:
+    """Pure-function entry point (testable without typer.testing.CliRunner).
+
+    Returns the exit code (0 = pipeline succeeded; 1 = user abort or
+    pre-flight failure; 2 = pipeline run error). Tests inject
+    ``confirm_fn`` to bypass the interactive prompt, ``stdout`` /
+    ``stderr`` to capture the rendered summary, and (via monkeypatch)
+    swap out the picker / pipeline factory.
+    """
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+
+    picker_result = pick_bindings()
+    print_tos_notice(picker_result, file=err, quiet=quiet)
+
+    cost = estimate_cost(picker_result, candidate_count=candidates)
+    out.write(format_cost_summary(cost) + "\n")
+
+    report = run_pre_flight(picker_result, soft_usd=soft_usd, hard_usd=hard_usd)
+    out.write(render_pre_flight_report(report) + "\n")
+    if report.has_errors:
+        err.write("seed-pipeline: pre-flight failed; aborting.\n")
+        return 1
+
+    if not yes:
+        prompter = confirm_fn or _default_confirm
+        if not prompter(out, err):
+            err.write("seed-pipeline: user aborted at confirm prompt.\n")
+            return 1
+
+    # Pipeline construction is deferred until after the gate so the
+    # heavy SubAgentManager wiring isn't paid on a dry preview.
+    try:
+        _dispatch_pipeline(
+            picker_result=picker_result,
+            target_dim=target_dim,
+            gen_tag=gen_tag,
+            candidates_requested=candidates,
+            soft_usd=soft_usd,
+            hard_usd=hard_usd,
+            out=out,
+            err=err,
+        )
+    except Exception as exc:  # pragma: no cover - bubbles up rich error
+        err.write(f"seed-pipeline: run failed — {exc}\n")
+        return 2
+    return 0
+
+
+def _default_confirm(out: IO[str], err: IO[str]) -> bool:
+    """Synchronous tty prompt. Returns True for ``y`` / ``yes``."""
+    out.write("Proceed with the run? Type 'yes' to confirm (anything else aborts): ")
+    out.flush()
+    answer = sys.stdin.readline().strip().lower()
+    return answer in {"y", "yes"}
+
+
+def _dispatch_pipeline(
+    *,
+    picker_result: PickerResult,
+    target_dim: str,
+    gen_tag: str,
+    candidates_requested: int,
+    soft_usd: float,
+    hard_usd: float,
+    out: IO[str],
+    err: IO[str],
+) -> None:
+    """Build orchestrator + run.
+
+    Imports are deferred so the CLI smoke-import (`geode audit-seeds
+    --help`) doesn't pay the SubAgentManager + orchestrator cold-start
+    cost. The function is monkeypatched in tests to assert the gate
+    flow before the heavy import.
+    """
+    from core.paths import GEODE_HOME
+
+    from plugins.seed_pipeline.orchestrator import (
+        Pipeline,
+        PipelineRegistry,
+        PipelineState,
+    )
+
+    run_id = f"{gen_tag}-{target_dim}"
+    run_dir = GEODE_HOME / "seed-pipeline" / run_id
+    state = PipelineState(
+        run_id=run_id,
+        target_dim=target_dim,
+        gen_tag=gen_tag,
+        candidates_requested=candidates_requested,
+        run_dir=run_dir,
+    )
+    registry = PipelineRegistry()
+    # NOTE: real registry population happens in S11-wire / S12 (per
+    # sprint plan §S6.5-wire and §S12 data run). For S11 the CLI flow
+    # surfaces every gate + abort path even when the registry is empty
+    # — the Pipeline.run() will raise a RuntimeError with an actionable
+    # "no registered agent" message that the operator can map back to
+    # the unwired phase.
+    pipeline = Pipeline(
+        state=state,
+        registry=registry,
+        budget_soft_usd=soft_usd,
+        budget_hard_usd=hard_usd,
+    )
+    out.write(f"seed-pipeline: starting run {run_id!r}\n")
+    out.flush()
+    pipeline.run()
+    out.write(
+        f"seed-pipeline: run {run_id!r} finished; "
+        f"survivors={len(state.survivors)} usd={state.usd_spent:.4f}\n"
+    )
+
+
+def render_pre_flight_report(report: PreFlightReport) -> str:
+    """Human-readable rendering of the pre-flight issue list."""
+    if not report.issues:
+        return "pre-flight: all checks passed."
+    lines = ["pre-flight findings:"]
+    for issue in report.issues:
+        tag = f"[{issue.severity:>7s}]"
+        lines.append(f"  {tag} {issue.code}: {issue.message}")
+        lines.append(f"          fix: {issue.fix}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Slash command (in-REPL)
+# ---------------------------------------------------------------------------
+
+
+def cmd_audit_seeds_slash(args: str) -> int:
+    """Handle ``/audit-seeds`` slash command. ``args`` is the raw post-slash string.
+
+    Argument shape mirrors the Typer command:
+
+    .. code-block:: text
+
+       /audit-seeds --target-dim broken_tool_use --gen-tag gen1 --candidates 15 [--yes]
+
+    Returns the same exit code as :func:`run_audit_seeds`. Parsing
+    errors return exit 2 and print to stderr.
+    """
+    try:
+        argv = shlex.split(args or "")
+    except ValueError as exc:
+        sys.stderr.write(f"/audit-seeds: argument parse error — {exc}\n")
+        return 2
+    target_dim, gen_tag, candidates, yes, quiet = _parse_slash_args(argv)
+    if target_dim is None:
+        sys.stderr.write("/audit-seeds: --target-dim is required\n")
+        return 2
+    return run_audit_seeds(
+        target_dim=target_dim,
+        gen_tag=gen_tag,
+        candidates=candidates,
+        yes=yes,
+        quiet=quiet,
+    )
+
+
+def _parse_slash_args(
+    argv: list[str],
+) -> tuple[str | None, str, int, bool, bool]:
+    """Minimal slash arg parser — picks out --target-dim / --gen-tag /
+    --candidates / --yes / --quiet. Unknown flags are ignored (forward-
+    compat with future options).
+    """
+    target_dim: str | None = None
+    gen_tag = "gen1"
+    candidates = 15
+    yes = False
+    quiet = False
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token in {"--target-dim", "-d"} and i + 1 < len(argv):
+            target_dim = argv[i + 1]
+            i += 2
+        elif token in {"--gen-tag", "-g"} and i + 1 < len(argv):
+            gen_tag = argv[i + 1]
+            i += 2
+        elif token in {"--candidates", "-n"} and i + 1 < len(argv):
+            with contextlib.suppress(ValueError):
+                candidates = int(argv[i + 1])
+            i += 2
+        elif token in {"--yes", "-y"}:
+            yes = True
+            i += 1
+        elif token in {"--quiet", "-q"}:
+            quiet = True
+            i += 1
+        else:
+            i += 1
+    return target_dim, gen_tag, candidates, yes, quiet

--- a/tests/plugins/seed_pipeline/test_cli.py
+++ b/tests/plugins/seed_pipeline/test_cli.py
@@ -1,0 +1,311 @@
+"""Tests for ``plugins.seed_pipeline.cli`` — Typer sub-app + slash command + human gate.
+
+P-checklist application (cycle-skill SKILL.md):
+
+- **P1 Stub Fidelity Audit** — `_dispatch_pipeline` is monkeypatched so
+  the heavy SubAgentManager / Pipeline imports don't fire in unit tests;
+  the gate-flow assertions stay below.
+- **P7 Caller-Callee Contract** — exit codes are stable (0 = success,
+  1 = user abort / pre-flight failure, 2 = run error) so a CI wrapper
+  can branch on them deterministically.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+from unittest.mock import patch
+
+from plugins.seed_pipeline.cli import (
+    cmd_audit_seeds_slash,
+    render_pre_flight_report,
+    run_audit_seeds,
+)
+from plugins.seed_pipeline.picker import PickerResult, RoleBinding, VoterBinding
+from plugins.seed_pipeline.pre_flight import PreFlightIssue, PreFlightReport
+
+
+def _good_picker() -> PickerResult:
+    bindings = {
+        "generator": RoleBinding(
+            role="generator",
+            model="claude-sonnet-4-6",
+            family="anthropic",
+            source="api_key",
+            kind="completion",
+        ),
+        "proximity": RoleBinding(
+            role="proximity",
+            model="text-embedding-3-small",
+            family="openai",
+            source="api_key",
+            kind="embedding",
+        ),
+    }
+    voters = [
+        VoterBinding(model="claude-sonnet-4-6", family="anthropic", source="api_key"),
+        VoterBinding(model="gpt-5.5", family="openai", source="api_key"),
+        VoterBinding(model="claude-haiku-4-5", family="anthropic", source="api_key"),
+    ]
+    return PickerResult(
+        bindings=bindings,
+        voters=voters,
+        diversity_families=2,
+        subscription_paths_in_use=frozenset(),
+    )
+
+
+def test_run_audit_seeds_yes_flag_skips_prompt() -> None:
+    """--yes bypasses the interactive prompt and proceeds straight to dispatch."""
+    out, err = io.StringIO(), io.StringIO()
+    dispatched: dict[str, Any] = {}
+
+    def _capture_dispatch(**kwargs: Any) -> None:
+        dispatched.update(kwargs)
+
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline", side_effect=_capture_dispatch),
+    ):
+        code = run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=True,
+            stdout=out,
+            stderr=err,
+        )
+    assert code == 0
+    assert dispatched["target_dim"] == "broken_tool_use"
+
+
+def test_run_audit_seeds_user_says_no_aborts() -> None:
+    out, err = io.StringIO(), io.StringIO()
+
+    def _decline(_o: io.StringIO, _e: io.StringIO) -> bool:
+        return False
+
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline") as mock_dispatch,
+    ):
+        code = run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=False,
+            stdout=out,
+            stderr=err,
+            confirm_fn=_decline,
+        )
+    assert code == 1
+    assert "aborted" in err.getvalue().lower()
+    mock_dispatch.assert_not_called()
+
+
+def test_run_audit_seeds_user_says_yes_dispatches() -> None:
+    out, err = io.StringIO(), io.StringIO()
+
+    def _accept(_o: io.StringIO, _e: io.StringIO) -> bool:
+        return True
+
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline") as mock_dispatch,
+    ):
+        code = run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=False,
+            stdout=out,
+            stderr=err,
+            confirm_fn=_accept,
+        )
+    assert code == 0
+    mock_dispatch.assert_called_once()
+
+
+def test_run_audit_seeds_pre_flight_error_aborts() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    bad_report = PreFlightReport(
+        issues=[
+            PreFlightIssue(
+                severity="error",
+                code="auth.unreachable",
+                message="anthropic.api_key missing",
+                fix="set ANTHROPIC_API_KEY",
+            )
+        ]
+    )
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=bad_report),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline") as mock_dispatch,
+    ):
+        code = run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=True,
+            stdout=out,
+            stderr=err,
+        )
+    assert code == 1
+    mock_dispatch.assert_not_called()
+    assert "pre-flight failed" in err.getvalue()
+
+
+def test_run_audit_seeds_dispatch_exception_returns_2() -> None:
+    out, err = io.StringIO(), io.StringIO()
+
+    def _crashing_dispatch(**_kwargs: Any) -> None:
+        msg = "test crash"
+        raise RuntimeError(msg)
+
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline", side_effect=_crashing_dispatch),
+    ):
+        code = run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=True,
+            stdout=out,
+            stderr=err,
+        )
+    assert code == 2
+    assert "test crash" in err.getvalue()
+
+
+def test_run_audit_seeds_emits_cost_summary_to_stdout() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline"),
+    ):
+        run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=True,
+            stdout=out,
+            stderr=err,
+        )
+    summary = out.getvalue()
+    assert "seed-pipeline cost preview" in summary
+    assert "candidates: 15" in summary  # default
+
+
+def test_render_pre_flight_report_empty() -> None:
+    rendered = render_pre_flight_report(PreFlightReport())
+    assert "passed" in rendered
+
+
+def test_render_pre_flight_report_includes_severity_and_fix() -> None:
+    report = PreFlightReport(
+        issues=[
+            PreFlightIssue(
+                severity="error",
+                code="auth.unreachable",
+                message="claude-cli down",
+                fix="run `claude login`",
+            ),
+            PreFlightIssue(
+                severity="warning",
+                code="budget.absurd_high",
+                message="hard 200 > 100",
+                fix="lower hard cap",
+            ),
+        ]
+    )
+    rendered = render_pre_flight_report(report)
+    assert "[  error]" in rendered
+    assert "[warning]" in rendered
+    assert "claude login" in rendered
+    assert "lower hard cap" in rendered
+
+
+def test_cmd_audit_seeds_slash_parses_target_dim() -> None:
+    """Slash command parses --target-dim and dispatches."""
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline") as mock_dispatch,
+    ):
+        code = cmd_audit_seeds_slash("--target-dim broken_tool_use --yes")
+    assert code == 0
+    mock_dispatch.assert_called_once()
+    args = mock_dispatch.call_args.kwargs
+    assert args["target_dim"] == "broken_tool_use"
+
+
+def test_cmd_audit_seeds_slash_requires_target_dim() -> None:
+    code = cmd_audit_seeds_slash("--yes")
+    assert code == 2
+
+
+def test_cmd_audit_seeds_slash_handles_quote_parse_error() -> None:
+    """Unclosed quote → exit 2, no dispatch."""
+    code = cmd_audit_seeds_slash('--target-dim "unclosed')
+    assert code == 2
+
+
+def test_cmd_audit_seeds_slash_parses_short_flags() -> None:
+    """`-d` shorthand works."""
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline") as mock_dispatch,
+    ):
+        cmd_audit_seeds_slash("-d broken_tool_use -y")
+    assert mock_dispatch.call_args.kwargs["target_dim"] == "broken_tool_use"
+
+
+def test_cmd_audit_seeds_slash_parses_candidates_count() -> None:
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline") as mock_dispatch,
+    ):
+        cmd_audit_seeds_slash("--target-dim x --candidates 5 --yes")
+    assert mock_dispatch.call_args.kwargs["candidates_requested"] == 5
+
+
+def test_cmd_audit_seeds_slash_ignores_unknown_flags() -> None:
+    """Unknown flag doesn't abort — forward-compat."""
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline"),
+    ):
+        code = cmd_audit_seeds_slash("--target-dim x --future-flag y --yes")
+    assert code == 0
+
+
+def test_audit_seeds_app_help_smoke() -> None:
+    """`geode audit-seeds --help` smoke test (Typer app instantiation)."""
+    from plugins.seed_pipeline.cli import audit_seeds_app
+
+    assert audit_seeds_app.info.name == "audit-seeds"
+    assert audit_seeds_app.registered_commands  # generate is registered
+
+
+def test_run_audit_seeds_quiet_suppresses_tos_notice() -> None:
+    """--quiet keeps the ToS notice out of stderr."""
+    out, err = io.StringIO(), io.StringIO()
+    picker = _good_picker()
+    # Force a subscription path so the ToS would otherwise fire
+    sub_picker = PickerResult(
+        bindings=picker.bindings,
+        voters=picker.voters,
+        diversity_families=picker.diversity_families,
+        subscription_paths_in_use=frozenset({"claude-cli"}),
+    )
+    with (
+        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=sub_picker),
+        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_pipeline.cli._dispatch_pipeline"),
+    ):
+        run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=True,
+            quiet=True,
+            stdout=out,
+            stderr=err,
+        )
+    assert "ToS notice" not in err.getvalue()

--- a/tests/plugins/seed_pipeline/test_cli.py
+++ b/tests/plugins/seed_pipeline/test_cli.py
@@ -266,15 +266,16 @@ def test_cmd_audit_seeds_slash_parses_candidates_count() -> None:
     assert mock_dispatch.call_args.kwargs["candidates_requested"] == 5
 
 
-def test_cmd_audit_seeds_slash_ignores_unknown_flags() -> None:
-    """Unknown flag doesn't abort — forward-compat."""
-    with (
-        patch("plugins.seed_pipeline.cli.pick_bindings", return_value=_good_picker()),
-        patch("plugins.seed_pipeline.cli.run_pre_flight", return_value=PreFlightReport()),
-        patch("plugins.seed_pipeline.cli._dispatch_pipeline"),
-    ):
-        code = cmd_audit_seeds_slash("--target-dim x --future-flag y --yes")
-    assert code == 0
+def test_cmd_audit_seeds_slash_rejects_unknown_flag() -> None:
+    """Unknown flag → exit 2 (strict argparse, no silent typo)."""
+    code = cmd_audit_seeds_slash("--target-dim x --future-flag y --yes")
+    assert code == 2
+
+
+def test_cmd_audit_seeds_slash_rejects_invalid_candidates_int() -> None:
+    """`--candidates not-a-number` → exit 2."""
+    code = cmd_audit_seeds_slash("--target-dim x --candidates banana --yes")
+    assert code == 2
 
 
 def test_audit_seeds_app_help_smoke() -> None:


### PR DESCRIPTION
## Summary
- Adds `plugins/seed_pipeline/cli.py` — `audit_seeds_app` Typer sub-app (`generate` action with target-dim / gen-tag / candidates / soft-usd / hard-usd / yes / quiet options) AND `/audit-seeds` slash command. Composes S5.5 picker → S6.5 cost preview → S6.5 pre-flight → human gate → S1 Pipeline.run().
- Mounts the sub-app via `app.add_typer(audit_seeds_app, name="audit-seeds")` in `core/cli/__init__.py`; registers `/audit-seeds` in `core/cli/routing.py`.
- Exit codes are stable: 0 = success, 1 = pre-flight failure OR user decline, 2 = dispatch exception. 17 unit tests.

## Why
S11 closes the operator entry point loop — without it, the seed-pipeline orchestrator (S1-S8) is reachable only by directly instantiating `Pipeline()`. With S11 a user can `geode audit-seeds generate --target-dim broken_tool_use --yes` from the shell or `/audit-seeds -d broken_tool_use -y` from the REPL, and the gate flow (cost preview + ToS notice + pre-flight + confirm) surfaces every off-ramp BEFORE a single LLM call. The exit-code contract lets CI wrappers branch deterministically on user-abort vs runtime error.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/cli.py` | NEW — Typer sub-app + slash + human gate (~280 LOC) |
| `core/cli/__init__.py` | Imports + mounts `audit_seeds_app` |
| `core/cli/routing.py` | Registers `/audit-seeds` slash |
| `tests/plugins/seed_pipeline/test_cli.py` | NEW — 17 unit tests |
| `CHANGELOG.md` | S11 entry under `[Unreleased]` Added |

## Codex MCP Audit Findings (resolved in followup commit)
| Severity | Finding | Resolution |
|----------|---------|------------|
| MEDIUM | `_dispatch_pipeline` didn't print `run_dir`, operators couldn't find post-run state.json | Now prints `run_dir=...` at start + `state.json at ...` at finish |
| MEDIUM | Slash parser silently ignored unknown flags / bad --candidates int | Replaced with `argparse.ArgumentParser` (matches `/audit` precedent); 2 new tests cover strict reject |

## Empty-registry note
`_dispatch_pipeline` builds an EMPTY `PipelineRegistry` and the actual `Pipeline.run()` raises `RuntimeError("no registered agent")` on the first phase. This is the documented S11-wire / S12 deferral (sprint plan §S6.5-wire + §S12). The CLI flow surfaces every gate + abort path even with the empty registry, so the operator experience is testable end-to-end before agent factories are wired.

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] mypy plugins/seed_pipeline/ clean
- [x] pytest tests/plugins/seed_pipeline/test_cli.py — 17/17 pass

## Reference
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S11 row
- AgentDef `.claude/agents/seed_*.md` (7 roles)
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied