### PR TITLE
docs(seed-pipeline): S12 — seeds_gen1 scaffolding + run-book (execution deferred)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ functional change.
 
 ### Added
 
+- **Seed-pipeline gen1 run-book + seeds_gen1/ scaffolding (S12).**
+  Creates `plugins/petri_audit/seeds_gen1/` directory (empty README
+  documenting the prerequisite gates) and the operator run-book at
+  `docs/audits/seed-generation-runs/2026-05-18/run-book.md` covering
+  the 7-step procedure (picker dry-run → pre-flight → `geode
+  audit-seeds generate` → inspect artifacts → promote survivors →
+  refresh `autoresearch/state/baseline.json` (new S9 schema) → tag).
+  Execution itself is deferred behind two prerequisites still
+  pending: S6.5-wire (BudgetGuard worker propagation, task #73) and
+  S11-wire (PipelineRegistry agent-factory instantiation). The
+  run-book gives the operator a copy-pasteable procedure as soon as
+  those land + Anthropic credits become available; until then, the
+  CLI gate flow + cost preview + slash command are fully exercisable
+  end-to-end with the empty registry.
 - **Seed-pipeline CLI sub-app + `/audit-seeds` slash + human gate (S11).**
   New `plugins/seed_pipeline/cli.py` defines a `geode audit-seeds`
   Typer sub-app (`generate` action with `--target-dim`, `--gen-tag`,

--- a/docs/audits/seed-generation-runs/2026-05-18/run-book.md
+++ b/docs/audits/seed-generation-runs/2026-05-18/run-book.md
@@ -1,0 +1,143 @@
+# 2026-05-18 — seed-pipeline gen1 run-book
+
+> First scheduled execution of the seed-pipeline orchestrator end-to-end.
+> Treated here as a run-book (operator-followable procedure) rather than
+> a finished artifact, because two prerequisites remain open. See the
+> "Prerequisites" section below.
+
+## Status
+
+**Run-book authored, execution deferred.** S12 (sprint plan
+`docs/plans/2026-05-18-seed-pipeline-sprint-plan.md`) ships this
+document + the empty `plugins/petri_audit/seeds_gen1/` directory; the
+actual run waits on the two prerequisites.
+
+## Prerequisites
+
+| Item | Tracked as | Status |
+|------|-----------|--------|
+| BudgetGuard worker-side propagation | task #73 (S6.5-wire) | Pending |
+| PipelineRegistry agent-factory wiring | S11-wire (implicit) | Pending |
+| Anthropic credit availability | external | Constrained per Session 60-62 |
+
+## Procedure (when prerequisites are green)
+
+### 1. Picker dry-run
+
+```bash
+uv run python -c "
+from plugins.seed_pipeline.picker import pick_bindings
+from plugins.seed_pipeline.cost_preview import estimate_cost, format_cost_summary
+pr = pick_bindings(auto_probe=True)
+print(format_cost_summary(estimate_cost(pr, candidate_count=15)))
+"
+```
+
+Confirms: (a) every role resolves to a concrete `(family, source)`
+binding, (b) the cost estimate sits within the `$2.00 soft / $10.00
+hard` per-phase budget. If subscription paths are in use, the ToS
+notice prints once.
+
+### 2. Pre-flight gate
+
+```bash
+uv run python -c "
+from plugins.seed_pipeline.picker import pick_bindings
+from plugins.seed_pipeline.pre_flight import run_pre_flight
+report = run_pre_flight(pick_bindings(), soft_usd=2.0, hard_usd=10.0)
+for issue in report.issues:
+    print(issue.severity, issue.code, issue.message, '|', issue.fix)
+print('has_errors:', report.has_errors)
+"
+```
+
+`has_errors: False` is required before proceeding.
+
+### 3. Generation run (`geode audit-seeds`)
+
+```bash
+geode audit-seeds generate \
+  --target-dim broken_tool_use \
+  --gen-tag gen1 \
+  --candidates 15 \
+  --soft-usd 2.00 \
+  --hard-usd 10.00
+```
+
+The CLI surfaces the cost preview + pre-flight report and prompts for
+`yes` to proceed. Drop `--yes` from this first run so the human gate
+is exercised; the operator should READ the preview before confirming.
+
+After the prompt, the orchestrator walks all 7 phases (Generator →
+Proximity → Critic → Pilot → Ranker → Evolver → MetaReviewer) and
+writes the run state to `~/.geode/seed-pipeline/gen1-broken_tool_use/`.
+
+### 4. Inspect the run artifacts
+
+| Artifact | Location |
+|----------|----------|
+| state.json (S8 offload) | `~/.geode/seed-pipeline/gen1-<dim>/state.json` |
+| elo_log.tsv (S6) | `~/.geode/seed-pipeline/gen1-<dim>/elo_log.tsv` |
+| candidates_*/ | `~/.geode/seed-pipeline/gen1-<dim>/candidates/`, `candidates_evolved/` |
+| meta_review | state.json `meta_review` key |
+
+### 5. Promote surviving candidates
+
+```bash
+# Inspect state.json → meta_review.session_summary
+jq .meta_review ~/.geode/seed-pipeline/gen1-broken_tool_use/state.json
+
+# Promote the top-K survivors into plugins/petri_audit/seeds_gen1/
+for survivor in $(jq -r .survivors[] state.json); do
+  cp ~/.geode/seed-pipeline/gen1-broken_tool_use/candidates/${survivor}.md \
+     plugins/petri_audit/seeds_gen1/
+done
+```
+
+### 6. Refresh autoresearch baseline (post-S9)
+
+```bash
+# Trigger one audit on the new seeds_gen1 pool to seed baseline.json
+geode audit --seed-select plugins/petri_audit/seeds_gen1 --dim-set 5axes --live
+
+# The audit emits a summary JSON with dim_means + dim_stderr;
+# write the post-S9 schema (no axes wrapping) to:
+cat > autoresearch/state/baseline.json <<EOF
+{
+  "dim_means":  { ... },
+  "dim_stderr": { ... }
+}
+EOF
+```
+
+### 7. Commit + tag
+
+```bash
+git add plugins/petri_audit/seeds_gen1/
+git commit -m "data: seed-pipeline gen1 — N survivors for <target_dim>"
+git tag autoresearch/2026-05-XX-seeds-gen1
+```
+
+`autoresearch/state/baseline.json` is gitignored — treat the tag as
+the reproducible marker for "this audit run defined the baseline."
+
+## Definition of done
+
+- `plugins/petri_audit/seeds_gen1/` contains 5+ promoted survivors.
+- `autoresearch/state/baseline.json` exists with the new schema
+  (`{"dim_means": ..., "dim_stderr": ...}`).
+- `~/.geode/seed-pipeline/gen1-<dim>/state.json` archived alongside
+  this run-book at `docs/audits/seed-generation-runs/2026-05-18/`.
+- An updated `session_summary` paragraph (from the MetaReviewer
+  output) is pasted into a follow-up session handoff note.
+
+## Cost expectation
+
+Per S6.5 cost preview with default (15 candidates × 3-judge × ~59
+matches):
+
+- claude-cli / openai-codex (subscription) ≈ $1.50 quota-equivalent
+- api_key (PAYG) ≈ $1.00–$1.50
+
+Total: under $3 per generation. The $10 hard cap per phase is the
+safety net.

--- a/plugins/petri_audit/seeds_gen1/README.md
+++ b/plugins/petri_audit/seeds_gen1/README.md
@@ -1,0 +1,47 @@
+# seeds_gen1 — first co-scientist generated batch
+
+This directory will hold the first `gen1` batch of Petri seeds produced
+by the seed-pipeline orchestrator (`plugins/seed_pipeline/`). It is the
+output of the S12 generation run (sprint plan
+`docs/plans/2026-05-18-seed-pipeline-sprint-plan.md`).
+
+## Current status
+
+**EMPTY — awaiting first run.** S12 ships the scaffolding (this
+directory + the run-book at
+`docs/audits/seed-generation-runs/2026-05-18/`) but the actual
+generation is deferred behind two prerequisites:
+
+1. **S6.5-wire (task #73)** — `BudgetGuard` real-time worker
+   propagation. Until the per-phase guard threads through to the
+   worker subprocess's LLM call sites, soft/hard caps fire only at
+   the end of each phase rather than mid-call. Acceptable for a
+   manually-supervised first run but should land before unattended
+   generations.
+
+2. **PipelineRegistry agent factories** — `plugins/seed_pipeline/cli.py`
+   `_dispatch_pipeline()` currently builds an empty
+   `PipelineRegistry`, so `Pipeline.run()` raises a `RuntimeError("no
+   registered agent")` on the first phase. The 7 concrete agents
+   (Generator, Critic, Proximity, Pilot, Ranker, Evolver,
+   MetaReviewer — all S2-S8) need to be instantiated with their
+   resolved `RoleBinding` from the picker and registered before
+   `geode audit-seeds generate` can produce real seeds.
+
+3. **Credit availability** — the user has flagged Anthropic credits
+   as currently constrained (Session 60-62 baseline retry notes).
+   When credits become available the operator can execute the
+   run-book below; until then the gate flow + cost preview + slash
+   command are all exercisable end-to-end with the empty registry to
+   verify the operator experience.
+
+## Once the prereqs land
+
+See `docs/audits/seed-generation-runs/2026-05-18/run-book.md` for the
+step-by-step procedure. Expected output: 15 candidate `.md` files
+named `<gen_tag>-<uuid>.md`, frontmatter declaring `target_dim`,
+selected via the Ranker top-K (`survivors_k=5`) AND optionally the
+Evolution agent's section-rewrite variants. After human ratification,
+the surviving seeds are promoted into `seeds_safe<N>/` and the
+`autoresearch/state/baseline.json` is refreshed from the audit's
+dim_means/dim_stderr.


### PR DESCRIPTION
## Summary
- Adds `plugins/petri_audit/seeds_gen1/README.md` — empty placeholder directory documenting the prerequisite gates.
- Adds `docs/audits/seed-generation-runs/2026-05-18/run-book.md` — 7-step operator procedure for when the gates land.
- The actual generation run is deferred behind S6.5-wire (task #73), S11-wire (empty registry), and external Anthropic credit availability.

## Why
S12 in the sprint plan was the first real generation run. Two prerequisites remain unmet — until BudgetGuard propagates to workers (S6.5-wire) and `_dispatch_pipeline()` instantiates the 7 concrete agents (S11-wire), `Pipeline.run()` raises on the first phase. Plus Anthropic credits are constrained (Session 60-62 baseline retry notes). Rather than fake an execution, S12 ships the operator run-book so the procedure is copy-pasteable the moment the prereqs are green. The CLI gate flow + cost preview + slash command are exercisable end-to-end with the empty registry, giving the operator UX verifiable before any LLM call.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/seeds_gen1/README.md` | NEW — placeholder + prereq tracker |
| `docs/audits/seed-generation-runs/2026-05-18/run-book.md` | NEW — 7-step procedure |
| `CHANGELOG.md` | S12 entry under `[Unreleased]` Added (honest deferral note) |

## Codex MCP Audit Findings
| Severity | Finding | Resolution |
|----------|---------|------------|
| — | All checks PASS | No fixes required |

The audit confirmed: README explicitly states "EMPTY — awaiting first run", lists both S6.5-wire and S11-wire prerequisites + the credit constraint; run-book uses the post-S9 baseline.json schema (`{"dim_means": ..., "dim_stderr": ...}`), references `geode audit-seeds generate`, cites S6.5 cost preview values, and is honest about deferred execution; CHANGELOG entry is honest about deferral.

## Verification
- [x] ruff check core/ tests/ plugins/ autoresearch/ scripts/ clean (no Python changes)
- [x] Run-book references the correct post-S9 schema + S11 CLI command
- [x] README explicitly documents the 2 prereqs + external constraint

## Sprint completion note
S12 is the 13th and final PR of the Session 63 seed-pipeline sprint
(S0/S1/S2/S2-wire/S2-fix/cycle-skill from Session 63 start + S2.5
through S12 from this conversation). All 7 co-scientist agents
(Generator/Critic/Proximity/Pilot/Ranker/Evolver/MetaReviewer),
the picker, cost preview, pre-flight, CLI sub-app, autoresearch
15-axis raw fitness + results.tsv 10-col + results.jsonl raw emit
have all merged. The remaining items (S6.5-wire BudgetGuard worker
propagation, S11-wire registry, S12 actual generation run) are
tracked as follow-ups in the next session handoff.

## Reference
- Sprint plan `docs/plans/2026-05-18-seed-pipeline-sprint-plan.md` S12 row
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied