### PR TITLE
feat: PR 3 — slop prevention audit (6-lens scan + skill + baseline)

### DIFF
--- a/.geode/skills/slop-audit/SKILL.md
+++ b/.geode/skills/slop-audit/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: slop-audit
+description: 6-lens slop prevention audit — unused imports, dead private fns, duplicate signatures, abandoned TODOs, lint bypass markers, stale refs. Baseline-gated growth check. Triggers — slop, dead code, unused, audit, duplicate, todo, noqa, stale.
+---
+
+# Slop Prevention Audit
+
+Recurring 6-lens scan of `core/` / `plugins/` / `autoresearch/` /
+`scripts/` to catch the patterns that accumulate during long PR
+sequences and rot codebase health when nobody is grepping for them.
+
+## When to run
+
+- **Per session, before the final PR merges.** Catches inline duplicates
+  + dead helpers introduced during a sprint.
+- **After a large refactor / removal PR.** Surfaces stale references
+  to the removed feature in unrelated files.
+- **CI advisory mode.** `python scripts/slop_audit.py --check` against
+  the committed baseline emits a non-zero exit when any lens count
+  grew; informational, not gating.
+
+## The 6 lenses
+
+| # | Lens | What it surfaces | Severity tier |
+|---|------|------------------|---------------|
+| 1 | `unused_imports` | `ruff F401` — module imports never referenced. | warning |
+| 2 | `dead_private_functions` | `def _foo(...)` with zero in-file callers. | warning if >10 |
+| 3 | `duplicate_signatures` | Same function name defined in ≥3 files (lift-to-helper signal). | info |
+| 4 | `abandoned_todos` | `TODO/FIXME/XXX` without owner `(name)` or `YYYY-MM-DD` date. | warning if >5 |
+| 5 | `lint_bypass_markers` | `# noqa` + `# type: ignore` count (ratchet against baseline). | info |
+| 6 | `stale_references` | Known-removed names that re-appear in source (`BudgetGuard`, `seeds_safe10`, etc.). | error if >0 |
+
+Severity is **diagnostic** — the script's `--check` mode only compares
+counts against the baseline, so growth of any tier-info metric is
+still surfaced as a CI failure.
+
+## Reading the output
+
+```bash
+uv run python scripts/slop_audit.py
+```
+
+Emits a markdown report with the count table + first 5 samples per
+lens. Inspect samples for patterns:
+
+- **unused_imports samples in tests/** → leftover after a refactor.
+  Auto-fix: `uv run ruff check --fix --select F401`.
+- **dead_private_functions in agent files** → a helper that was
+  extracted but never called. Either inline at the one caller or
+  remove.
+- **duplicate_signatures = "init"/"build"/etc.** → expected
+  framework method. duplicate_signatures = "parse_critique" with 4
+  copies → lift to `agents/base.py`.
+- **abandoned_todos** → add owner `(@handle)` or remove. The convention
+  is `# TODO(@user, 2026-05-18): ...`.
+- **stale_references = N** for any N > 0 → fix in the same PR as the
+  feature removal; allowing it to land merges the rot.
+
+## Workflow
+
+```bash
+# First run (after PR 0/1/2 land) — generates the canonical baseline
+uv run python scripts/slop_audit.py --baseline-out docs/audits/2026-05-18-slop-audit-baseline.md
+
+# Subsequent CI advisory checks
+uv run python scripts/slop_audit.py --check
+```
+
+The baseline file is checked into `docs/audits/`. Refresh the
+baseline (and the timestamp in the filename) whenever an
+intentional cleanup PR reduces a count — the goal is **monotone
+non-growth**, not zero (some lint_bypass markers, e.g. the bandit
+SHA1 nosec, are intentional and stay forever).
+
+## Stale-reference list
+
+`scripts/slop_audit.py` maintains `_STALE_REFS` — a tuple of names
+that should not re-appear in production code after their removal PR.
+Current list:
+
+- `BudgetGuard` (removed PR 1)
+- `SUBAGENT_BUDGET_WARNING` (removed PR 1)
+- `seeds_safe10` (renamed PR 0)
+- `FitnessBaseline` (removed S9)
+
+Add a new entry whenever you remove a public surface. The lens
+ignores `docs/` and `CHANGELOG.md` so historical prose stays
+documented.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ functional change.
 
 ### Added
 
+- **Slop prevention audit + 6-lens skill (PR 3).** New
+  `scripts/slop_audit.py` runs a 6-lens scan across `core/` +
+  `plugins/` + `autoresearch/` + `scripts/`: (1) unused imports
+  (`ruff F401`), (2) dead private functions (zero-caller heuristic),
+  (3) duplicate signatures (≥3 same-name defs), (4) abandoned TODOs
+  (no owner / date), (5) lint-bypass markers (`# noqa` /
+  `# type: ignore` counted vs baseline), (6) stale references
+  (known-removed names like `BudgetGuard` / `FitnessBaseline` /
+  `seeds_safe10` that should not re-appear in source). Lines with
+  `# slop:keep` are ignored so historical references in docstrings
+  stay documented. Adds `.geode/skills/slop-audit/SKILL.md`
+  documenting interpretation + workflow. Generated baseline at
+  `docs/audits/2026-05-18-slop-audit-baseline.md`; `--check` mode
+  exits 1 only when a count grew vs baseline (CI advisory). 7 unit
+  tests covering all 6 lenses + baseline round-trip + slop:keep
+  marker.
+
 - **4-path × 4-component auth coverage matrix (PR 2).** New
   `plugins/seed_pipeline/auth_coverage.py` defines the canonical
   16-cell matrix: 4 components (`seed_pipeline`, `petri_audit`,

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -43,7 +43,7 @@ new dim_mean drifted UP relative to the baseline:
   (formula unchanged from G3).
 - **info 3** — recorded for the report, never enters fitness.
 
-The :class:`FitnessBaseline` dataclass + ``baseline_from_summary``
+The :class:`FitnessBaseline` dataclass + ``baseline_from_summary``  # slop:keep
 wrapping is removed; ``compute_fitness`` accepts raw
 ``baseline_means`` / ``baseline_stderr`` dicts directly, matching the
 shape Petri's ``core/audit/dim_extractor`` already emits.
@@ -191,7 +191,7 @@ S9 schema (ADR-002 §3 baseline wrapping 제거)::
      "dim_stderr": {"broken_tool_use": 0.4, ...}}
 
 Matches Petri's ``core/audit/dim_extractor.extract_dim_aggregates``
-output shape — no FitnessBaseline wrapping layer. Absent file → gate
+output shape — no FitnessBaseline wrapping layer. Absent file → gate  # slop:keep
 dormant (first run / fresh branch).
 """
 
@@ -594,7 +594,7 @@ def _load_baseline() -> tuple[dict[str, float] | None, dict[str, float] | None]:
     file / unparseable JSON / empty payload — caller treats this as the
     gate-dormant case. Schema mirrors Petri's
     ``core/audit/dim_extractor.extract_dim_aggregates`` output (no
-    FitnessBaseline wrapping per ADR-002 §3).
+    FitnessBaseline wrapping per ADR-002 §3).  # slop:keep
     """
     if not BASELINE_PATH.is_file():
         return None, None

--- a/docs/audits/2026-05-18-slop-audit-baseline.md
+++ b/docs/audits/2026-05-18-slop-audit-baseline.md
@@ -1,0 +1,42 @@
+# GEODE slop audit — 2026-05-18-slop-audit-baseline.md
+
+| Lens | Count | Severity |
+|------|------:|----------|
+| unused_imports | 0 | info |
+| dead_private_functions | 139 | warning |
+| duplicate_signatures | 76 | info |
+| abandoned_todos | 0 | info |
+| lint_bypass_markers | 91 | info |
+| stale_references | 0 | info |
+
+## Samples (first 5 per lens)
+### unused_imports
+- _(none)_
+
+### dead_private_functions
+- `core/ui/event_renderer.py :: _handle_round_start`
+- `core/ui/event_renderer.py :: _handle_thinking_start`
+- `core/ui/event_renderer.py :: _handle_thinking_end`
+- `core/ui/event_renderer.py :: _handle_tool_start`
+- `core/ui/event_renderer.py :: _handle_tool_end`
+
+### duplicate_signatures
+- `main (17 copies): core/mcp_server.py`
+- `stop (9 copies): core/ui/event_renderer.py`
+- `start (6 copies): core/ui/status.py`
+- `update (4 copies): core/ui/status.py`
+- `name (32 copies): core/tools/web_tools.py`
+
+### abandoned_todos
+- _(none)_
+
+### lint_bypass_markers
+- `core/runtime.py:72`
+- `core/runtime.py:76`
+- `core/runtime.py:78`
+- `core/runtime.py:81`
+- `core/ui/context_local.py:91`
+
+### stale_references
+- _(none)_
+

--- a/plugins/seed_pipeline/__init__.py
+++ b/plugins/seed_pipeline/__init__.py
@@ -2,7 +2,7 @@
 
 co-scientist 의 7-role generate/debate/evolve loop 를 GEODE 의 sub-agent
 인프라 위에 port. Petri × autoresearch 의 frozen seed pool quality + size
-확장 (`plugins/petri_audit/seeds_safe10/` → `plugins/petri_audit/seeds_gen<N>/`).
+확장 (legacy flat pool → hierarchical tree per PR 0).  # slop:keep
 
 본 plugin 은 ``plugins.petri_audit`` 에 sibling 의존:
 - credential resolution: ``plugins.petri_audit.credential_source``

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -287,7 +287,7 @@ class Pipeline:
         Cost rollup is purely informational — the agent (or its test
         stub) sets ``result.usd_spent`` / ``prompt_tokens`` /
         ``completion_tokens`` directly and the orchestrator sums them
-        into ``state.*``. The pre-PR-1 BudgetGuard hard-cap layer was
+        into ``state.*``. The pre-PR-1 BudgetGuard hard-cap layer was  # slop:keep
         removed (2026-05-18); operators control spend via the
         pre-run cost preview + human gate at the CLI surface.
         """

--- a/scripts/slop_audit.py
+++ b/scripts/slop_audit.py
@@ -1,0 +1,432 @@
+"""Slop prevention audit — 6-lens scan of core/ + plugins/ + autoresearch/.
+
+Surfaces patterns that accumulate during long PR sequences and rot
+codebase health if uncaught:
+
+1. **Unused imports** (`ruff F401`) — module-level imports never
+   referenced.
+2. **Dead functions** (heuristic via vulture-style scan: defs without
+   external callers / unused private helpers).
+3. **Duplicate patterns** (≥3 inline copies of the same N-line
+   snippet) — usually a missed lift-to-helper opportunity.
+4. **Abandoned TODOs** (`TODO` / `FIXME` / `XXX` without an owner
+   handle or date stamp).
+5. **Lint bypass markers** (`# noqa` / `# type: ignore`) — counted
+   against a baseline so net additions surface in PR review.
+6. **Stale references** (renamed module / removed feature names that
+   still appear in comments or docstrings).
+
+Usage:
+
+    uv run python scripts/slop_audit.py
+    uv run python scripts/slop_audit.py --baseline-out docs/audits/<file>.md
+    uv run python scripts/slop_audit.py --check  # exit 1 on new slop vs baseline
+
+The first invocation produces a baseline snapshot
+(`docs/audits/2026-05-18-slop-audit-baseline.md`); subsequent CI runs
+compare against it and fail only when a metric *grows*.
+
+Pure-script; no test dependencies — runs from a fresh checkout via
+``uv run``. The skill at ``.geode/skills/slop-audit/SKILL.md`` documents
+how to interpret the output and what to do when each lens fires.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = ("core/", "plugins/", "autoresearch/", "scripts/")
+
+
+@dataclass
+class LensResult:
+    """One audit lens' findings."""
+
+    name: str
+    count: int
+    samples: list[str]
+    severity: str  # "info" | "warning" | "error"
+
+
+# ---------------------------------------------------------------------------
+# Lens 1 — Unused imports
+# ---------------------------------------------------------------------------
+
+
+def lens_unused_imports() -> LensResult:
+    """Count F401 violations across the scan roots.
+
+    F401 fires on imports that are never used. We do NOT include
+    F811 (re-imports) or F841 (unused vars) — those are noise for
+    this audit.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "ruff",
+        "check",
+        "--select",
+        "F401",
+        "--output-format",
+        "json",
+        *SCAN_ROOTS,
+    ]
+    proc = subprocess.run(  # noqa: S603  # nosec B603 — argv from module constants
+        cmd, capture_output=True, text=True, check=False
+    )
+    try:
+        findings = json.loads(proc.stdout) if proc.stdout.strip() else []
+    except json.JSONDecodeError:
+        findings = []
+    samples = [
+        f"{Path(f['filename']).relative_to(REPO_ROOT)}:{f['location']['row']} {f['code']}"
+        for f in findings[:5]
+    ]
+    return LensResult(
+        name="unused_imports",
+        count=len(findings),
+        samples=samples,
+        severity="warning" if findings else "info",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lens 2 — Dead functions (heuristic)
+# ---------------------------------------------------------------------------
+
+
+_DEF_PATTERN = re.compile(r"^\s*def\s+(_[a-zA-Z0-9_]+)\s*\(", re.MULTILINE)
+
+
+def lens_dead_private_functions() -> LensResult:
+    """Detect ``def _foo(...)`` (private) with zero external callers.
+
+    Walks every .py file, collects private def names per file, then
+    greps the same file for ``_foo`` references outside the def line.
+    Lightweight: misses cross-module callers but those are rare for
+    private helpers.
+    """
+    samples: list[str] = []
+    count = 0
+    for py in _iter_py_files():
+        text = py.read_text(encoding="utf-8", errors="ignore")
+        for match in _DEF_PATTERN.finditer(text):
+            name = match.group(1)
+            # Skip dunders (__init__, __repr__, etc.)
+            if name.startswith("__") and name.endswith("__"):
+                continue
+            # Skip _make / _build common fixtures
+            references = text.count(name)
+            # references includes the definition itself; want > 1 for usage
+            if references <= 1:
+                count += 1
+                if len(samples) < 5:
+                    samples.append(f"{py.relative_to(REPO_ROOT)} :: {name}")
+    return LensResult(
+        name="dead_private_functions",
+        count=count,
+        samples=samples,
+        severity="warning" if count > 10 else "info",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lens 3 — Duplicate patterns (3+ inline copies)
+# ---------------------------------------------------------------------------
+
+
+_SIGNATURE_PATTERN = re.compile(r"^\s*def\s+([a-zA-Z0-9_]+)\s*\(", re.MULTILINE)
+
+
+def lens_duplicate_signatures() -> LensResult:
+    """Detect ``def <same_name>`` repeated ≥3 times across files.
+
+    Repeated names are a weak signal — could be legitimate (init,
+    execute) or a missed shared-helper opportunity. We exclude
+    common Python dunders + framework method names (execute, run,
+    setUp, tearDown, __init__).
+    """
+    skip = frozenset({"execute", "run", "setUp", "tearDown", "delegate", "test_"})
+    counts: dict[str, list[str]] = {}
+    for py in _iter_py_files():
+        text = py.read_text(encoding="utf-8", errors="ignore")
+        for match in _SIGNATURE_PATTERN.finditer(text):
+            name = match.group(1)
+            if name.startswith("__") and name.endswith("__"):
+                continue
+            if name in skip or name.startswith("test_"):
+                continue
+            counts.setdefault(name, []).append(str(py.relative_to(REPO_ROOT)))
+    duplicates = {n: files for n, files in counts.items() if len(files) >= 3}
+    samples = [
+        f"{name} ({len(files)} copies): {files[0]}" for name, files in list(duplicates.items())[:5]
+    ]
+    return LensResult(
+        name="duplicate_signatures",
+        count=len(duplicates),
+        samples=samples,
+        severity="info",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lens 4 — Abandoned TODOs
+# ---------------------------------------------------------------------------
+
+
+_TODO_PATTERN = re.compile(r"#\s*(TODO|FIXME|XXX|HACK)\b(?:\(([^)]+)\))?(.*)", re.IGNORECASE)
+
+
+def lens_abandoned_todos() -> LensResult:
+    """TODO without an owner ``(name)`` or date stamp."""
+    samples: list[str] = []
+    count = 0
+    for py in _iter_py_files():
+        for lineno, line in enumerate(
+            py.read_text(encoding="utf-8", errors="ignore").splitlines(), start=1
+        ):
+            match = _TODO_PATTERN.search(line)
+            if not match:
+                continue
+            owner = match.group(2)
+            tail = match.group(3) or ""
+            has_date = bool(re.search(r"\d{4}-\d{2}-\d{2}", tail))
+            if not owner and not has_date:
+                count += 1
+                if len(samples) < 5:
+                    samples.append(f"{py.relative_to(REPO_ROOT)}:{lineno}")
+    return LensResult(
+        name="abandoned_todos",
+        count=count,
+        samples=samples,
+        severity="warning" if count > 5 else "info",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lens 5 — Lint bypass markers
+# ---------------------------------------------------------------------------
+
+
+def lens_lint_bypass() -> LensResult:
+    """Count ``# noqa`` and ``# type: ignore`` markers.
+
+    Reported as a single combined count for the baseline — net
+    additions surface in PR review. PR-time enforcement is a separate
+    ratchet (not implemented in this script; documented in the SKILL).
+    """
+    samples: list[str] = []
+    count = 0
+    for py in _iter_py_files():
+        for lineno, line in enumerate(
+            py.read_text(encoding="utf-8", errors="ignore").splitlines(), start=1
+        ):
+            if "# noqa" in line or "# type: ignore" in line:
+                count += 1
+                if len(samples) < 5:
+                    samples.append(f"{py.relative_to(REPO_ROOT)}:{lineno}")
+    return LensResult(
+        name="lint_bypass_markers",
+        count=count,
+        samples=samples,
+        severity="info",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lens 6 — Stale references
+# ---------------------------------------------------------------------------
+
+
+_STALE_REFS: tuple[str, ...] = (
+    # Pre-PR-0 / PR-1 cleanups — keep this list current as features
+    # are removed so a re-appearance in docs is flagged.
+    "BudgetGuard",
+    "SUBAGENT_BUDGET_WARNING",
+    "seeds_safe10",
+    "FitnessBaseline",
+)
+
+
+def lens_stale_references() -> LensResult:
+    """Flag any of :data:`_STALE_REFS` that show up in production code.
+
+    Comments / CHANGELOG references to *historical* changes are
+    allowed — we look at ``core/`` / ``plugins/`` / ``autoresearch/``
+    source only, NOT ``docs/`` or ``CHANGELOG.md``. The CHANGELOG is
+    the canonical home for "we removed X" prose.
+
+    The slop_audit.py script itself is excluded — it literally defines
+    ``_STALE_REFS`` so a self-match is a false positive. Historical
+    references in docstrings ("pre-PR-1 BudgetGuard layer was removed",
+    "no FitnessBaseline wrapping") are intentional change-log context;
+    they're allowed via the ``# slop:keep`` line marker on the same
+    line as the reference.
+    """
+    samples: list[str] = []
+    count = 0
+    for py in _iter_py_files():
+        # The audit script itself defines the list — never count its
+        # own occurrences.
+        if py.name == "slop_audit.py":
+            continue
+        text = py.read_text(encoding="utf-8", errors="ignore")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            # Allow explicit historical references via inline marker.
+            if "# slop:keep" in line:
+                continue
+            for ref in _STALE_REFS:
+                if ref in line:
+                    count += 1
+                    if len(samples) < 5:
+                        samples.append(f"{py.relative_to(REPO_ROOT)}:{lineno} :: {ref}")
+    return LensResult(
+        name="stale_references",
+        count=count,
+        samples=samples,
+        severity="error" if count > 0 else "info",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _iter_py_files() -> list[Path]:
+    """Walk ``SCAN_ROOTS`` for ``.py`` files (excludes ``__pycache__``)."""
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        for py in (REPO_ROOT / root).rglob("*.py"):
+            if "__pycache__" in py.parts:
+                continue
+            files.append(py)
+    return files
+
+
+def run_all_lenses() -> list[LensResult]:
+    """Invoke every lens in order. Order matches the SKILL.md doc."""
+    return [
+        lens_unused_imports(),
+        lens_dead_private_functions(),
+        lens_duplicate_signatures(),
+        lens_abandoned_todos(),
+        lens_lint_bypass(),
+        lens_stale_references(),
+    ]
+
+
+def format_report(results: list[LensResult], *, header: str = "") -> str:
+    """Render a markdown report for the audit run."""
+    lines: list[str] = []
+    if header:
+        lines.append(f"# {header}")
+        lines.append("")
+    lines.append("| Lens | Count | Severity |")
+    lines.append("|------|------:|----------|")
+    for r in results:
+        lines.append(f"| {r.name} | {r.count} | {r.severity} |")
+    lines.append("")
+    lines.append("## Samples (first 5 per lens)")
+    for r in results:
+        lines.append(f"### {r.name}")
+        if r.samples:
+            for s in r.samples:
+                lines.append(f"- `{s}`")
+        else:
+            lines.append("- _(none)_")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    """Parse a baseline file's table back into ``{lens: count}``."""
+    if not path.is_file():
+        return {}
+    counts: dict[str, int] = {}
+    table_started = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("|------"):
+            table_started = True
+            continue
+        if not table_started:
+            continue
+        if not line.startswith("|"):
+            break
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        try:
+            counts[cells[0]] = int(cells[1])
+        except (ValueError, IndexError):
+            continue
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=REPO_ROOT / "docs/audits/2026-05-18-slop-audit-baseline.md",
+        help="Baseline markdown file to compare against.",
+    )
+    parser.add_argument(
+        "--baseline-out",
+        type=Path,
+        default=None,
+        help="If given, write the current results as the new baseline.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 when any lens count grew vs baseline. CI advisory.",
+    )
+    args = parser.parse_args()
+
+    results = run_all_lenses()
+    report = format_report(
+        results,
+        header="GEODE slop audit — " + (args.baseline_out.name if args.baseline_out else "run"),
+    )
+    print(report)
+
+    if args.baseline_out is not None:
+        out = args.baseline_out
+        if not out.is_absolute():
+            out = REPO_ROOT / out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(report + "\n", encoding="utf-8")
+        try:
+            display = out.relative_to(REPO_ROOT)
+        except ValueError:
+            display = out
+        print(f"\nbaseline written → {display}", file=sys.stderr)
+        return 0
+
+    if args.check:
+        baseline = load_baseline(args.baseline)
+        grew: list[str] = []
+        for r in results:
+            base = baseline.get(r.name, 0)
+            if r.count > base:
+                grew.append(f"{r.name}: {base} → {r.count}")
+        if grew:
+            print("\nslop audit: GROWTH detected vs baseline", file=sys.stderr)
+            for g in grew:
+                print(f"  - {g}", file=sys.stderr)
+            return 1
+        print("\nslop audit: no growth vs baseline.", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_slop_audit.py
+++ b/tests/test_slop_audit.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def _load_slop_audit_module():
+def _load_slop_audit_module() -> ModuleType:
     """Load scripts/slop_audit.py without putting scripts/ on sys.path."""
     path = REPO_ROOT / "scripts" / "slop_audit.py"
     spec = importlib.util.spec_from_file_location("_slop_audit_for_tests", path)
@@ -29,11 +30,11 @@ def _load_slop_audit_module():
 
 
 @pytest.fixture(scope="module")
-def slop_audit():
+def slop_audit() -> ModuleType:
     return _load_slop_audit_module()
 
 
-def test_run_all_lenses_returns_six_results(slop_audit) -> None:  # type: ignore[no-untyped-def]
+def test_run_all_lenses_returns_six_results(slop_audit: ModuleType) -> None:
     results = slop_audit.run_all_lenses()
     names = [r.name for r in results]
     assert names == [
@@ -46,7 +47,7 @@ def test_run_all_lenses_returns_six_results(slop_audit) -> None:  # type: ignore
     ]
 
 
-def test_stale_references_zero(slop_audit) -> None:  # type: ignore[no-untyped-def]
+def test_stale_references_zero(slop_audit: ModuleType) -> None:
     """The stale-reference lens must be zero on develop after PR 3.
 
     PR 0 / PR 1 documentation refers to BudgetGuard / FitnessBaseline /
@@ -59,7 +60,7 @@ def test_stale_references_zero(slop_audit) -> None:  # type: ignore[no-untyped-d
     )
 
 
-def test_unused_imports_below_threshold(slop_audit) -> None:  # type: ignore[no-untyped-def]
+def test_unused_imports_below_threshold(slop_audit: ModuleType) -> None:
     """Unused imports must stay under a coarse threshold.
 
     Threshold is intentionally loose — the audit fires per-PR via
@@ -70,7 +71,7 @@ def test_unused_imports_below_threshold(slop_audit) -> None:  # type: ignore[no-
     assert result.count <= 50, f"unused_imports count {result.count} exceeds soft threshold 50"
 
 
-def test_format_report_renders_table(slop_audit) -> None:  # type: ignore[no-untyped-def]
+def test_format_report_renders_table(slop_audit: ModuleType) -> None:
     results = slop_audit.run_all_lenses()
     report = slop_audit.format_report(results, header="test run")
     assert "| Lens | Count | Severity |" in report
@@ -86,7 +87,7 @@ def test_format_report_renders_table(slop_audit) -> None:  # type: ignore[no-unt
         assert name in report
 
 
-def test_baseline_load_round_trip(tmp_path, slop_audit) -> None:  # type: ignore[no-untyped-def]
+def test_baseline_load_round_trip(tmp_path: Path, slop_audit: ModuleType) -> None:
     """`load_baseline` reads a generated report back into a count dict."""
     results = slop_audit.run_all_lenses()
     report = slop_audit.format_report(results, header="round trip")
@@ -104,7 +105,9 @@ def test_baseline_file_committed() -> None:
     assert path.is_file(), f"missing baseline file at {path}"
 
 
-def test_slop_keep_marker_works(slop_audit, tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_slop_keep_marker_works(
+    slop_audit: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A line with ``# slop:keep`` and a stale ref is ignored."""
     tmp_root = tmp_path / "fake_repo"
     (tmp_root / "core").mkdir(parents=True)

--- a/tests/test_slop_audit.py
+++ b/tests/test_slop_audit.py
@@ -1,0 +1,119 @@
+"""Tests for ``scripts/slop_audit.py`` — the slop-prevention audit driver.
+
+Smoke-tests every lens against the current tree so a refactor that
+breaks the audit script surfaces immediately. The baseline file at
+``docs/audits/2026-05-18-slop-audit-baseline.md`` is the authoritative
+contract for "the slop counts we accept as the current floor".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_slop_audit_module():
+    """Load scripts/slop_audit.py without putting scripts/ on sys.path."""
+    path = REPO_ROOT / "scripts" / "slop_audit.py"
+    spec = importlib.util.spec_from_file_location("_slop_audit_for_tests", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_slop_audit_for_tests"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def slop_audit():
+    return _load_slop_audit_module()
+
+
+def test_run_all_lenses_returns_six_results(slop_audit) -> None:  # type: ignore[no-untyped-def]
+    results = slop_audit.run_all_lenses()
+    names = [r.name for r in results]
+    assert names == [
+        "unused_imports",
+        "dead_private_functions",
+        "duplicate_signatures",
+        "abandoned_todos",
+        "lint_bypass_markers",
+        "stale_references",
+    ]
+
+
+def test_stale_references_zero(slop_audit) -> None:  # type: ignore[no-untyped-def]
+    """The stale-reference lens must be zero on develop after PR 3.
+
+    PR 0 / PR 1 documentation refers to BudgetGuard / FitnessBaseline /
+    seeds_safe10 in historical context — those occurrences carry a
+    ``# slop:keep`` marker so this lens stays clean.
+    """
+    result = slop_audit.lens_stale_references()
+    assert result.count == 0, (
+        f"stale_references must be 0; got {result.count}. Samples: {result.samples}"
+    )
+
+
+def test_unused_imports_below_threshold(slop_audit) -> None:  # type: ignore[no-untyped-def]
+    """Unused imports must stay under a coarse threshold.
+
+    Threshold is intentionally loose — the audit fires per-PR via
+    `--check`, not at every commit. CI fast-fail is the F401 ruff
+    rule on the changed files, not this aggregate.
+    """
+    result = slop_audit.lens_unused_imports()
+    assert result.count <= 50, f"unused_imports count {result.count} exceeds soft threshold 50"
+
+
+def test_format_report_renders_table(slop_audit) -> None:  # type: ignore[no-untyped-def]
+    results = slop_audit.run_all_lenses()
+    report = slop_audit.format_report(results, header="test run")
+    assert "| Lens | Count | Severity |" in report
+    assert "## Samples (first 5 per lens)" in report
+    for name in [
+        "unused_imports",
+        "dead_private_functions",
+        "duplicate_signatures",
+        "abandoned_todos",
+        "lint_bypass_markers",
+        "stale_references",
+    ]:
+        assert name in report
+
+
+def test_baseline_load_round_trip(tmp_path, slop_audit) -> None:  # type: ignore[no-untyped-def]
+    """`load_baseline` reads a generated report back into a count dict."""
+    results = slop_audit.run_all_lenses()
+    report = slop_audit.format_report(results, header="round trip")
+    baseline_path = tmp_path / "baseline.md"
+    baseline_path.write_text(report + "\n", encoding="utf-8")
+
+    loaded = slop_audit.load_baseline(baseline_path)
+    for r in results:
+        assert loaded[r.name] == r.count, f"round trip mismatch for {r.name}"
+
+
+def test_baseline_file_committed() -> None:
+    """The canonical baseline file must exist for `--check` mode."""
+    path = REPO_ROOT / "docs/audits/2026-05-18-slop-audit-baseline.md"
+    assert path.is_file(), f"missing baseline file at {path}"
+
+
+def test_slop_keep_marker_works(slop_audit, tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A line with ``# slop:keep`` and a stale ref is ignored."""
+    tmp_root = tmp_path / "fake_repo"
+    (tmp_root / "core").mkdir(parents=True)
+    sample = tmp_root / "core" / "fake.py"
+    sample.write_text(
+        '"""Doc that mentions BudgetGuard for historical context."""  # slop:keep\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(slop_audit, "REPO_ROOT", tmp_root)
+    monkeypatch.setattr(slop_audit, "SCAN_ROOTS", ("core/",))
+    result = slop_audit.lens_stale_references()
+    assert result.count == 0


### PR DESCRIPTION
## Summary
- Adds `scripts/slop_audit.py` — 6-lens scan driver covering unused imports, dead private fns, duplicate signatures, abandoned TODOs, lint-bypass markers, and stale references.
- Adds `.geode/skills/slop-audit/SKILL.md` — interpretation + workflow guide.
- Generated `docs/audits/2026-05-18-slop-audit-baseline.md` — committed baseline that `--check` mode compares against (CI advisory: exits 1 only on growth).
- `# slop:keep` inline marker excludes historical references in docstrings; 3 such lines (BudgetGuard / FitnessBaseline / seeds_safe10) marked.

## Why
Per the 2026-05-18 user directive: "불필요한 코드, 중복, Audit, Dead code 점검 워크플로우 넣어서 Slop 방지해". The previous 16 PRs in this sprint accumulated patterns that single-PR review doesn't catch — duplicate parser shapes (Critic/Pilot inline parsers vs S6 shared lift), stale references after removals (BudgetGuard mentions surviving the PR-1 removal), unused-import drift after refactors. This PR institutes a recurring 6-lens check so each of those patterns surfaces in PR review *and* in CI advisory mode.

## Changes
| File | Change |
|------|--------|
| `scripts/slop_audit.py` | NEW — 6-lens driver (~440 LOC) |
| `.geode/skills/slop-audit/SKILL.md` | NEW — skill guide |
| `docs/audits/2026-05-18-slop-audit-baseline.md` | NEW — committed baseline (count table + samples) |
| `tests/test_slop_audit.py` | NEW — 7 tests |
| `plugins/seed_pipeline/__init__.py` + `orchestrator.py` + `autoresearch/train.py` | `# slop:keep` markers added to 3 historical-context lines |
| `CHANGELOG.md` | PR 3 entry under `[Unreleased]` Added |

## Codex MCP Audit Findings (resolved in followup commit)
| Severity | Finding | Resolution |
|----------|---------|------------|
| MEDIUM | 6 `# type: ignore[no-untyped-def]` in test fixture/helpers | Replaced with proper `ModuleType` annotation + typed parameters |
| LOW | All other checks PASS | — |

## Verification
- [x] ruff check core/ tests/ plugins/ autoresearch/ scripts/ clean
- [x] mypy scripts/slop_audit.py + tests/test_slop_audit.py clean
- [x] pytest tests/test_slop_audit.py — 7/7 pass
- [x] `uv run python scripts/slop_audit.py --check` — exits 0 (no growth vs baseline)
- [x] Baseline counts: unused_imports=0, dead_private_functions=139, duplicate_signatures=76, abandoned_todos=0, lint_bypass_markers=91, stale_references=0

## Reference
- 2026-05-18 user directive (slop prevention workflow)
- Cycle skill `.geode/skills/seed-pipeline-cycle/SKILL.md` Phase A-F applied