### PR TITLE
feat(autoresearch): flip JUDGE_MODEL sonnet → opus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **autoresearch judge model: sonnet → opus.** `autoresearch/train.py`
+  default `JUDGE_MODEL` flipped from `claude-code/sonnet` to
+  `claude-code/opus` (and `autoresearch/program.md` reference table
+  updated to match). Per 2026-05-19 directive: opus judge for the outer
+  Elo loop trades extra latency for tighter 15-dim adjudication during
+  gen-0 baseline collection. Routes via the same `claude-code/*` inspect
+  prefix → claude-cli adapter (no auth path change).
+
 ### Added
 
 - **Slop prevention audit + 6-lens skill (PR 3).** New

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -111,7 +111,7 @@ total_seconds:            315.4
 seed_count:               10
 dim_count:                15
 target_model:             geode/gpt-5.5
-judge_model:              claude-code/sonnet
+judge_model:              claude-code/opus
 budget_minutes:           5
 wrapper_override_active:  true
 section_count:            5

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -66,7 +66,7 @@ from pathlib import Path
 
 BUDGET_MINUTES = 5
 TARGET_MODEL = "geode/gpt-5.5"
-JUDGE_MODEL = "claude-code/sonnet"
+JUDGE_MODEL = "claude-code/opus"
 USE_OAUTH = True
 SEED_LIMIT = 10
 SEED_SELECT = "plugins/petri_audit/seeds"


### PR DESCRIPTION
## Summary
- `autoresearch/train.py` 의 `JUDGE_MODEL` 기본값을 `claude-code/sonnet` → `claude-code/opus` 로 변경.
- `autoresearch/program.md` 의 reference 표(line 114) 도 동일하게 갱신.
- CHANGELOG `[Unreleased] > Changed` 항목 추가 (no version bump — constant flip).

## Why
2026-05-19 사용자 지시 — outer Elo loop 의 judge 를 opus 로 격상해 gen-0 baseline collection 단계에서 15-dim adjudication 정확도를 높임. 추가 latency 는 감수. 기존 `claude-code/*` inspect prefix → claude-cli adapter 라우팅은 그대로 유지되며, auth path 변경 없음.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | line 69 `JUDGE_MODEL` 상수 `claude-code/sonnet` → `claude-code/opus` |
| `autoresearch/program.md` | line 114 reference table `judge_model` 표기 동기화 |
| `CHANGELOG.md` | `[Unreleased] > Changed` 신규 항목 |

## Verification
- [x] `uv run ruff check autoresearch/` → All checks passed
- [x] `uv run mypy autoresearch/` → Success: no issues
- [x] `uv run pytest tests/ -k "autoresearch or judge_model"` → 40 passed / 3 skipped / 4717 deselected
- [x] Codex MCP audit (5 항목 모두 PASS/LOW): diff 범위 / 잔존 sonnet ref 부재 / adapter 라우팅 / CHANGELOG 위치 / 추가 JUDGE_MODEL 상수 부재 확인
- [x] `grep -rn "claude-code/sonnet" autoresearch/ plugins/` → 0 matches (docs/audits, docs/plans 의 snapshot ref 는 의도적으로 보존)

## Reference
- 2026-05-19 directive: "sonnet 대신 opus 로 전환 부탁해"
- adapter routing: `plugins/petri_audit/petri.plugin.toml:89` `inspect_prefix = "claude-code"` → claude-cli adapter
- 모델 화이트리스트 우회 경로: `plugins/petri_audit/models.py:146` (slash-containing IDs 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)