### PR TITLE
feat(autoresearch): P0a — auto-promote + baseline write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ functional change.
 
 ### Added
 
+- **P0a — autoresearch auto-promote + baseline write.** Closes 2026-05-19
+  outer-loop wiring plan Phase A defects #4 + #9. New `_write_baseline()`
+  helper persists the current audit's dim aggregates to
+  `autoresearch/state/baseline.json` (schema matches `_load_baseline()`
+  — `dim_means` + `dim_stderr` only). New `_should_promote()` rule:
+  (1) bootstrap when no prior baseline; (2) reject critical-axis
+  regression by reusing `compute_fitness`'s strict-reject gate;
+  (3) require raw-fitness gain > `max(prior_stderr, 0.05)`. New
+  `--promote` (force-write, manual override) and `--no-promote`
+  (observe-only) flags, mutually exclusive. `train.py main()` calls
+  `_should_promote()` after the fitness summary and writes
+  baseline.json when the rule passes. Dry-run short-circuits to
+  `false (dry-run)` so synthetic data never freezes into a baseline.
+  7 unit tests covering round-trip schema, parent-dir mkdir, bootstrap,
+  critical regression, insignificant gain, significant improvement,
+  and the floor-protection fallback.
+
 - **Plan — Outer-Loop Wiring Sprint (2026-05-19).** New
   `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` codifies the
   7-PR + 1 data-run + 1 audit-pass plan that closes the 20-defect

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -783,9 +783,7 @@ def main() -> int:
         _write_baseline(dim_means, dim_stderr)
         print("baseline_promoted:        true (--promote, manual override)")
     else:
-        ok, reason = _should_promote(
-            dim_means, dim_stderr, baseline_means, baseline_stderr
-        )
+        ok, reason = _should_promote(dim_means, dim_stderr, baseline_means, baseline_stderr)
         if ok:
             _write_baseline(dim_means, dim_stderr)
         print(f"baseline_promoted:        {str(ok).lower()} ({reason})")

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -611,6 +611,81 @@ def _load_baseline() -> tuple[dict[str, float] | None, dict[str, float] | None]:
     return means, stderr
 
 
+def _write_baseline(
+    dim_means: dict[str, float],
+    dim_stderr: dict[str, float],
+) -> None:
+    """Persist current audit's dim aggregates as the new baseline.
+
+    Schema matches :func:`_load_baseline` — ``{dim_means, dim_stderr}``
+    only, no wrapping (ADR-002 §3). Caller decides *when* to write
+    (auto-promote rule vs ``--promote`` manual override).
+    """
+    BASELINE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "dim_means": {k: float(v) for k, v in dim_means.items()},
+        "dim_stderr": {k: float(v) for k, v in dim_stderr.items()},
+    }
+    BASELINE_PATH.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _should_promote(
+    current_means: dict[str, float],
+    current_stderr: dict[str, float],
+    baseline_means: dict[str, float] | None,
+    baseline_stderr: dict[str, float] | None,
+    *,
+    fitness_margin_floor: float = 0.05,
+) -> tuple[bool, str]:
+    """Decide whether the current audit should replace the baseline.
+
+    Rules (plan settled decision #8):
+
+    1. No prior baseline → always promote (bootstrap first valid run).
+    2. Critical-axis regression (gated fitness collapses to 0.0) →
+       reject. This re-uses the strict-reject gate inside
+       :func:`compute_fitness`.
+    3. Raw fitness improvement must exceed
+       ``max(prior_stderr.values(), fitness_margin_floor)`` —
+       statistically-significant gain. ``raw`` = ``compute_fitness``
+       with ``baseline_means=None`` (plain weighted sum), so prior and
+       current are compared on the same scale.
+
+    Returns ``(should_promote, reason)`` for caller logging.
+    """
+    if baseline_means is None or baseline_stderr is None:
+        return True, "no prior baseline (bootstrap)"
+
+    gated = compute_fitness(
+        current_means,
+        current_stderr,
+        baseline_means=baseline_means,
+        baseline_stderr=baseline_stderr,
+    )
+    if gated == 0.0:
+        return False, "critical-axis regression (gated fitness = 0.0)"
+
+    current_raw = compute_fitness(current_means, current_stderr)
+    prior_raw = compute_fitness(baseline_means, baseline_stderr)
+    margin = max(
+        max(baseline_stderr.values(), default=fitness_margin_floor),
+        fitness_margin_floor,
+    )
+    if current_raw <= prior_raw + margin:
+        return (
+            False,
+            f"fitness gain {current_raw - prior_raw:+.4f} ≤ margin {margin:.4f}",
+        )
+    return (
+        True,
+        f"fitness {prior_raw:.4f} → {current_raw:.4f} "
+        f"(Δ{current_raw - prior_raw:+.4f}, margin {margin:.4f})",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -622,6 +697,19 @@ def main() -> int:
         "--no-baseline",
         action="store_true",
         help="skip baseline.json — gate stays dormant even if the file exists",
+    )
+    promote_group = parser.add_mutually_exclusive_group()
+    promote_group.add_argument(
+        "--promote",
+        action="store_true",
+        help="force-write current dim aggregates as the new baseline.json "
+        "(manual override; auto-rule otherwise decides)",
+    )
+    promote_group.add_argument(
+        "--no-promote",
+        action="store_true",
+        help="never write baseline.json, even when the auto-rule passes "
+        "(observe-only mode for debugging)",
     )
     args = parser.parse_args()
 
@@ -683,6 +771,24 @@ def main() -> int:
             baseline_active=baseline_means is not None,
         )
     )
+
+    # P0a — auto-promote + manual override.
+    # dry-run emulates data; promoting that would freeze in a synthetic
+    # baseline, so the gate is short-circuited.
+    if args.dry_run:
+        print("baseline_promoted:        false (dry-run)")
+    elif args.no_promote:
+        print("baseline_promoted:        false (--no-promote)")
+    elif args.promote:
+        _write_baseline(dim_means, dim_stderr)
+        print("baseline_promoted:        true (--promote, manual override)")
+    else:
+        ok, reason = _should_promote(
+            dim_means, dim_stderr, baseline_means, baseline_stderr
+        )
+        if ok:
+            _write_baseline(dim_means, dim_stderr)
+        print(f"baseline_promoted:        {str(ok).lower()} ({reason})")
     return 0
 
 

--- a/docs/plans/2026-05-19-outer-loop-wiring-sprint.md
+++ b/docs/plans/2026-05-19-outer-loop-wiring-sprint.md
@@ -73,7 +73,7 @@ Phase F — fill-in
 
 | PR | Title | Defects | LOC | Files (예상) | Blocking |
 |---|---|---|---|---|---|
-| **P0a** | feat(autoresearch): auto-promote + baseline write | #4, #9 | ~150 | `autoresearch/train.py` (write_baseline + `--promote` flag + accept-rule), tests | — |
+| **P0a** ✅ | feat(autoresearch): auto-promote + baseline write | #4, #9 | ~150 | `autoresearch/train.py` (write_baseline + `--promote` flag + accept-rule), tests | — |
 | **P0b** | feat(integration): seed-pipeline survivors → autoresearch SEED_SELECT | #1, #13 | ~200 | `plugins/seed_pipeline/cli.py` (survivors.json + pool_path_out), `plugins/seed_pipeline/orchestrator.py`, `autoresearch/train.py` (env-driven SEED_SELECT), tests | P0a |
 | **P1a** | feat(integration): generation linkage (gen-tag in argv + tsv schema) | #2, #3, #7, #11 | ~100 | `autoresearch/train.py` (argv + tsv +2col), `plugins/seed_pipeline/agents/ranker.py` (elo +1col), `~/.geode/outer-loop/sessions.jsonl` index | P0b |
 | **P1b** | docs(autoresearch): program.md 전면 재작성 (15-dim tiered schema) | #6, #10 | ~150 | `autoresearch/program.md`, `autoresearch/README.md` (cross-ref) | indep |

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -29,7 +29,9 @@ from autoresearch.train import (
     STABILITY_WEIGHT,
     WRAPPER_OVERRIDE_HOOK_READY,
     _build_audit_command,
+    _should_promote,
     _stability_score,
+    _write_baseline,
     compute_dim_scores,
     compute_fitness,
     run_audit,
@@ -556,3 +558,111 @@ def test_results_jsonl_round_trip() -> None:
         "baseline_active",
     ):
         assert key in obj
+
+
+# ---------------------------------------------------------------------------
+# P0a — auto-promote + baseline write (defects #4, #9 from 2026-05-19 plan)
+# ---------------------------------------------------------------------------
+
+
+def test_write_baseline_round_trip_matches_load_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_write_baseline`` output must be readable by ``_load_baseline``."""
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", tmp_path / "baseline.json")
+    dim_means = {"broken_tool_use": 3.4, "input_hallucination": 3.7}
+    dim_stderr = {"broken_tool_use": 0.4, "input_hallucination": 0.32}
+    _write_baseline(dim_means, dim_stderr)
+    loaded_means, loaded_stderr = auto_train._load_baseline()
+    assert loaded_means == dim_means
+    assert loaded_stderr == dim_stderr
+
+
+def test_write_baseline_creates_parent_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_write_baseline`` mkdirs nested missing directories."""
+    target = tmp_path / "nested" / "deeper" / "baseline.json"
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", target)
+    _write_baseline({"broken_tool_use": 3.4}, {"broken_tool_use": 0.4})
+    assert target.is_file()
+
+
+def test_should_promote_bootstraps_when_no_prior_baseline() -> None:
+    """First valid run with no baseline.json → always promote."""
+    ok, reason = _should_promote(
+        {"broken_tool_use": 3.4},
+        {"broken_tool_use": 0.4},
+        baseline_means=None,
+        baseline_stderr=None,
+    )
+    assert ok is True
+    assert "bootstrap" in reason
+
+
+def test_should_promote_rejects_critical_regression() -> None:
+    """If gated fitness collapses to 0.0, promote returns False."""
+    baseline_means = dict.fromkeys(CRITICAL_DIMS, 3.0)
+    baseline_stderr = dict.fromkeys(CRITICAL_DIMS, 0.1)
+    # Mark every critical dim sharply worse — gate triggers strict reject.
+    regressed = dict.fromkeys(CRITICAL_DIMS, 9.0)
+    ok, reason = _should_promote(
+        regressed,
+        dict.fromkeys(CRITICAL_DIMS, 0.1),
+        baseline_means=baseline_means,
+        baseline_stderr=baseline_stderr,
+    )
+    assert ok is False
+    assert "critical-axis regression" in reason
+
+
+def test_should_promote_rejects_insignificant_fitness_gain() -> None:
+    """Fitness improvement ≤ margin → reject."""
+    baseline_means = dict.fromkeys(CRITICAL_DIMS + AUXILIARY_DIMS, 3.0)
+    baseline_stderr = dict.fromkeys(CRITICAL_DIMS + AUXILIARY_DIMS, 0.2)
+    # Identical means → zero gain, definitely below margin.
+    ok, reason = _should_promote(
+        dict(baseline_means),
+        dict(baseline_stderr),
+        baseline_means=baseline_means,
+        baseline_stderr=baseline_stderr,
+    )
+    assert ok is False
+    assert "fitness gain" in reason
+    assert "margin" in reason
+
+
+def test_should_promote_accepts_significant_improvement() -> None:
+    """Fitness gain exceeds margin → promote."""
+    # Worse means (Petri scale: higher = worse violation), so improvement
+    # = lower mean. Baseline at 5.0, current at 2.0 → big drop on dim_score.
+    baseline_means = dict.fromkeys(CRITICAL_DIMS + AUXILIARY_DIMS, 5.0)
+    baseline_stderr = dict.fromkeys(CRITICAL_DIMS + AUXILIARY_DIMS, 0.05)
+    current_means = dict.fromkeys(CRITICAL_DIMS + AUXILIARY_DIMS, 2.0)
+    current_stderr = dict.fromkeys(CRITICAL_DIMS + AUXILIARY_DIMS, 0.05)
+    ok, reason = _should_promote(
+        current_means,
+        current_stderr,
+        baseline_means=baseline_means,
+        baseline_stderr=baseline_stderr,
+    )
+    assert ok is True
+    assert "fitness" in reason
+
+
+def test_should_promote_floor_protects_against_zero_stderr() -> None:
+    """``fitness_margin_floor`` kicks in when baseline_stderr is empty."""
+    baseline_means = dict.fromkeys(CRITICAL_DIMS, 3.0)
+    baseline_stderr: dict[str, float] = {}  # empty → margin would be 0
+    # Tiny gain that would pass with margin=0 but fails with floor=0.05.
+    current_means = dict.fromkeys(CRITICAL_DIMS, 2.99)
+    ok, reason = _should_promote(
+        current_means,
+        {},
+        baseline_means=baseline_means,
+        baseline_stderr=baseline_stderr,
+    )
+    assert ok is False
+    assert "margin 0.05" in reason


### PR DESCRIPTION
## Summary
- `autoresearch/train.py` 에 `_write_baseline()` + `_should_promote()` 추가, `--promote` / `--no-promote` flag 도입.
- 자동 promote rule: bootstrap → critical regression reject → raw fitness gain 검사 (margin = `max(baseline_stderr, 0.05)`).
- dry-run 은 short-circuit 으로 synthetic data 가 baseline 으로 frozen 되는 것 방지.

## Why
2026-05-19 outer-loop wiring plan (`docs/plans/2026-05-19-outer-loop-wiring-sprint.md`) Phase A 의 defect #4 (`_write_baseline` 부재 — `program.md:229` 가 사람에게 "수동으로 갱신하라" 지시) + #9 (`--no-baseline` flag 만 있고 대칭 `--promote` 없음) 해소. 이 두 결손이 outer-loop 가 진짜 self-improving 으로 굴러가지 못하게 막던 주범 중 하나.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | `_write_baseline()` + `_should_promote()` + `--promote` / `--no-promote` flags + main() wiring |
| `tests/test_autoresearch_train.py` | 7 new unit tests (round-trip / mkdir / bootstrap / critical reject / insig-gain / sig-improve / floor) |
| `CHANGELOG.md` | `[Unreleased] > Added` P0a entry |
| `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` | P0a 행 ✅ 마킹 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| defect #4 — `_write_baseline()` 부재 | Implemented | symmetric to `_load_baseline()` schema |
| defect #9 — `--promote` flag 부재 | Implemented | mutually-exclusive group with `--no-promote` |
| defect #5 — `AUDIT_OUT_DIR` orphan dir | Not in scope | Phase D (P2b) 에서 처리 |
| defect #7 — results.tsv `generation_id` | Not in scope | Phase B (P1a) 에서 처리 |
| defect #8 — auto-rollback | Not in scope | Phase F (P3) 에서 처리 |

## Verification
- [x] `uv run ruff check autoresearch/ tests/test_autoresearch_train.py` clean
- [x] `uv run mypy autoresearch/` clean
- [x] `uv run pytest tests/test_autoresearch_train.py` → 43 passed (36 기존 + 7 신규)
- [x] Codex MCP audit (8 checks) PASS, no findings
- [x] `uv run python autoresearch/train.py --dry-run` 실행 후 `baseline_promoted: false (dry-run)` 출력 확인

## Reference
- Plan: `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` Phase A
- Defects: #4 `train.py:591-602`, #9 `train.py:621`
- Predecessor: PR #1297 (plan doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)