### PR TITLE
feat(integration): P0b — seed-pipeline ↔ autoresearch cross-loop handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,27 @@ functional change.
 
 ### Added
 
+- **P0b — seed-pipeline ↔ autoresearch cross-loop handoff.** Closes
+  2026-05-19 outer-loop wiring plan Phase A defects #1 + #13.
+  `plugins/seed_pipeline/orchestrator.py` gains `_persist_survivors()`
+  which emits two artifacts under `<run_dir>`: (1) `survivors.json`
+  metadata view (`{gen_tag, target_dim, run_id, survivors:
+  [{id, path, elo_rating, pilot}]}`) and (2) `survivors/` directory of
+  symlinks to each survivor's candidate `.md` body file.
+  `state.pool_path_out` is stamped to the **directory** (not the JSON)
+  because that is what inspect-petri's `--seed-select` consumer expects
+  (flat-glob of `*.md`). `_persist_survivors()` runs BEFORE
+  `_persist_state()` so the resulting `state.json` carries the new
+  `pool_path_out`. Symlink dir is cleared between runs to avoid
+  accumulation. `autoresearch/train.py` introduces `_resolve_seed_select()`
+  which returns the `AUTORESEARCH_SEED_SELECT` env override or falls
+  back to the hierarchical default; `_build_audit_command` calls it
+  at argv-build time so a parent driver can pipe seed-pipeline's
+  winners directly into the next audit. 10 unit tests (6 orchestrator
+  for survivors.json schema / symlink dir / pool_path_out stamp into
+  state.json / run_dir-unset / missing-elo-pilot / stale-symlink-cleanup,
+  4 autoresearch for default / override / whitespace / argv-resolution).
+
 - **P0a — autoresearch auto-promote + baseline write.** Closes 2026-05-19
   outer-loop wiring plan Phase A defects #4 + #9. New `_write_baseline()`
   helper persists the current audit's dim aggregates to

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -70,9 +70,25 @@ JUDGE_MODEL = "claude-code/opus"
 USE_OAUTH = True
 SEED_LIMIT = 10
 SEED_SELECT = "plugins/petri_audit/seeds"
+"""Default seed pool — hierarchical tree (post-PR-0). P0b adds the
+``AUTORESEARCH_SEED_SELECT`` env override consumed by
+:func:`_resolve_seed_select` so the seed-pipeline cross-loop handoff
+(``survivors.json``) can swap in its winners. The constant stays the
+literal default so existing tests and outer-loop agents can grep it."""
 DIM_SET_NAME = "5axes"
 MAX_TURNS = 10
 WRAPPER_OVERRIDE_HOOK_READY = True
+
+
+def _resolve_seed_select() -> str:
+    """Return the seed-select argv value, honoring ``AUTORESEARCH_SEED_SELECT``.
+
+    Empty / unset env falls back to the hierarchical
+    :data:`SEED_SELECT` default. Resolved at call-time (not import-time)
+    so tests can monkeypatch the env var.
+    """
+    override = os.environ.get("AUTORESEARCH_SEED_SELECT", "").strip()
+    return override or SEED_SELECT
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +227,7 @@ def _build_audit_command() -> list[str]:
         "--judge",
         JUDGE_MODEL,
         "--seed-select",
-        SEED_SELECT,
+        _resolve_seed_select(),
         "--seeds",
         str(SEED_LIMIT),
         "--dim-set",

--- a/docs/plans/2026-05-19-outer-loop-wiring-sprint.md
+++ b/docs/plans/2026-05-19-outer-loop-wiring-sprint.md
@@ -74,7 +74,7 @@ Phase F — fill-in
 | PR | Title | Defects | LOC | Files (예상) | Blocking |
 |---|---|---|---|---|---|
 | **P0a** ✅ | feat(autoresearch): auto-promote + baseline write | #4, #9 | ~150 | `autoresearch/train.py` (write_baseline + `--promote` flag + accept-rule), tests | — |
-| **P0b** | feat(integration): seed-pipeline survivors → autoresearch SEED_SELECT | #1, #13 | ~200 | `plugins/seed_pipeline/cli.py` (survivors.json + pool_path_out), `plugins/seed_pipeline/orchestrator.py`, `autoresearch/train.py` (env-driven SEED_SELECT), tests | P0a |
+| **P0b** ✅ | feat(integration): seed-pipeline survivors → autoresearch SEED_SELECT | #1, #13 | ~200 | `plugins/seed_pipeline/cli.py` (survivors.json + pool_path_out), `plugins/seed_pipeline/orchestrator.py`, `autoresearch/train.py` (env-driven SEED_SELECT), tests | P0a |
 | **P1a** | feat(integration): generation linkage (gen-tag in argv + tsv schema) | #2, #3, #7, #11 | ~100 | `autoresearch/train.py` (argv + tsv +2col), `plugins/seed_pipeline/agents/ranker.py` (elo +1col), `~/.geode/outer-loop/sessions.jsonl` index | P0b |
 | **P1b** | docs(autoresearch): program.md 전면 재작성 (15-dim tiered schema) | #6, #10 | ~150 | `autoresearch/program.md`, `autoresearch/README.md` (cross-ref) | indep |
 | **P1c** | feat(observability): structured session journal | #18, #19 | ~250 | `core/observability/session_journal.py` (NEW), `core/wiring/bootstrap.py` (STARTED/FAILED 핸들러 등록), `plugins/seed_pipeline/cli.py` (cost emit), tests | P1a |

--- a/plugins/seed_pipeline/cli.py
+++ b/plugins/seed_pipeline/cli.py
@@ -221,10 +221,15 @@ def _dispatch_pipeline(
     out.write(f"seed-pipeline: run_dir={run_dir}\n")
     out.flush()
     pipeline.run()
+    survivors_line = (
+        f"seed-pipeline: survivors.json at {state.pool_path_out}\n"
+        if state.pool_path_out is not None
+        else "seed-pipeline: survivors.json not written (run_dir unset)\n"
+    )
     out.write(
         f"seed-pipeline: run {run_id!r} finished; "
         f"survivors={len(state.survivors)} usd={state.usd_spent:.4f}\n"
-        f"seed-pipeline: state.json at {run_dir / 'state.json'}\n"
+        f"seed-pipeline: state.json at {run_dir / 'state.json'}\n" + survivors_line
     )
 
 

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -229,6 +229,11 @@ class Pipeline:
         )
         for phase in _PHASE_ORDER:
             self._run_phase(phase)
+        # P0b — cross-loop handoff runs FIRST so ``state.pool_path_out``
+        # is stamped before ``_persist_state`` snapshots state.json.
+        # Otherwise the offload would freeze a stale ``null`` for
+        # the pool_path_out field.
+        self._persist_survivors()
         # S8 parent-context offload — persist the final state.json so a
         # follow-up CLI invocation (S11) can resume the meta-review +
         # survivor pool without re-reading every candidate body.
@@ -240,6 +245,95 @@ class Pipeline:
             self.state.usd_spent,
         )
         return self.state
+
+    def _persist_survivors(self) -> None:
+        """Cross-loop handoff: emit ``survivors.json`` + ``survivors/`` dir.
+
+        P0b — defect #13 from 2026-05-19 outer-loop wiring plan. Writes
+        two artifacts under ``<run_dir>``:
+
+        1. ``survivors.json`` — metadata view for downstream queries
+           (Elo rating, pilot score per survivor)::
+
+               {
+                 "gen_tag": "...",
+                 "target_dim": "...",
+                 "run_id": "...",
+                 "survivors": [
+                   {"id": "...", "path": "<candidate.md path>",
+                    "elo_rating": 1612.4, "pilot": {...} | null}
+                 ]
+               }
+
+        2. ``survivors/`` — directory of symlinks to each survivor's
+           candidate body file. This is what
+           ``inspect-petri`` 's flat-glob ``--seed-select`` consumer
+           expects (``flatten_for_inspect_petri`` passes a directory of
+           ``*.md`` through unchanged). ``state.pool_path_out`` is
+           stamped to this directory so a parent driver can set
+           ``AUTORESEARCH_SEED_SELECT=<pool_path_out>`` and the next
+           audit will pick up the winners.
+
+        Skipped when ``state.run_dir`` is unset (test fixtures often
+        omit it). I/O failures log a WARNING but do not raise — the
+        in-memory ``state.survivors`` stays authoritative.
+        """
+        if self.state.run_dir is None:
+            return
+        candidates_by_id = {c["id"]: c for c in self.state.candidates}
+        rows: list[dict[str, Any]] = []
+        for cid in self.state.survivors:
+            cand = candidates_by_id.get(cid, {})
+            rows.append(
+                {
+                    "id": cid,
+                    "path": cand.get("path"),
+                    "elo_rating": self.state.elo_ratings.get(cid),
+                    "pilot": self.state.pilot_scores.get(cid),
+                }
+            )
+        payload = {
+            "gen_tag": self.state.gen_tag,
+            "target_dim": self.state.target_dim,
+            "run_id": self.state.run_id,
+            "survivors": rows,
+        }
+        try:
+            self.state.run_dir.mkdir(parents=True, exist_ok=True)
+            survivors_json = self.state.run_dir / "survivors.json"
+            survivors_json.write_text(
+                json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            survivors_dir = self.state.run_dir / "survivors"
+            survivors_dir.mkdir(parents=True, exist_ok=True)
+            # Clear stale entries from a previous run so the symlink set
+            # is exactly the current survivors.
+            for entry in survivors_dir.iterdir():
+                if entry.is_symlink() or entry.is_file():
+                    entry.unlink()
+            for row in rows:
+                src_str = row.get("path")
+                if not src_str:
+                    continue
+                src = Path(src_str)
+                if not src.is_file():
+                    continue
+                dst = survivors_dir / src.name
+                dst.symlink_to(src.resolve())
+            self.state.pool_path_out = survivors_dir
+            log.info(
+                "seed-pipeline cross-loop handoff: %d survivors → %s (metadata at %s)",
+                len(rows),
+                survivors_dir,
+                survivors_json,
+            )
+        except OSError as exc:
+            log.warning(
+                "seed-pipeline survivors export failed at %s: %s",
+                self.state.run_dir,
+                exc,
+            )
 
     def _persist_state(self) -> None:
         """Write a JSON snapshot of state to ``<run_dir>/state.json``.

--- a/tests/plugins/seed_pipeline/test_state_offload.py
+++ b/tests/plugins/seed_pipeline/test_state_offload.py
@@ -116,3 +116,116 @@ def test_persist_state_excludes_runtime_only_fields(tmp_path: Path) -> None:
     pipeline.run()
     blob = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
     assert "budget_guard" not in blob
+
+
+# ---------------------------------------------------------------------------
+# P0b — cross-loop handoff (defect #13 from 2026-05-19 outer-loop plan)
+# ---------------------------------------------------------------------------
+
+
+def _seed_candidate_md(run_dir: Path, cid: str) -> Path:
+    """Create a fake candidate body file under <run_dir>/candidates/."""
+    cand_dir = run_dir / "candidates"
+    cand_dir.mkdir(parents=True, exist_ok=True)
+    path = cand_dir / f"{cid}.md"
+    path.write_text(f"# {cid}\n\nbody for {cid}\n", encoding="utf-8")
+    return path
+
+
+def test_persist_survivors_writes_survivors_json(tmp_path: Path) -> None:
+    """Pipeline.run() emits ``<run_dir>/survivors.json`` with metadata."""
+    state = _populated_state(tmp_path)
+    cand_path = _seed_candidate_md(tmp_path, "c-00")
+    state.candidates = [{"id": "c-00", "path": str(cand_path), "target_dim": "broken_tool_use"}]
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    survivors_path = tmp_path / "survivors.json"
+    assert survivors_path.is_file()
+    blob = json.loads(survivors_path.read_text(encoding="utf-8"))
+    assert blob["gen_tag"] == "gen2"
+    assert blob["target_dim"] == "broken_tool_use"
+    assert blob["run_id"] == "t-offload"
+    rows = blob["survivors"]
+    assert isinstance(rows, list)
+    assert len(rows) == 1
+    assert rows[0]["id"] == "c-00"
+    assert rows[0]["path"] == str(cand_path)
+    assert rows[0]["elo_rating"] == 1010.0
+    assert rows[0]["pilot"] == {"dim_means": {"d": 0.5}}
+
+
+def test_persist_survivors_creates_symlink_dir(tmp_path: Path) -> None:
+    """``survivors/`` dir holds symlinks to each survivor candidate .md."""
+    state = _populated_state(tmp_path)
+    cand_path = _seed_candidate_md(tmp_path, "c-00")
+    state.candidates = [{"id": "c-00", "path": str(cand_path), "target_dim": "broken_tool_use"}]
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    survivors_dir = tmp_path / "survivors"
+    assert survivors_dir.is_dir()
+    link = survivors_dir / "c-00.md"
+    assert link.is_symlink()
+    assert link.resolve() == cand_path.resolve()
+
+
+def test_persist_survivors_pool_path_out_targets_directory(tmp_path: Path) -> None:
+    """state.pool_path_out points at the symlink dir (inspect-petri consumer)."""
+    state = _populated_state(tmp_path)
+    cand_path = _seed_candidate_md(tmp_path, "c-00")
+    state.candidates = [{"id": "c-00", "path": str(cand_path), "target_dim": "broken_tool_use"}]
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    assert state.pool_path_out == tmp_path / "survivors"
+    # Stamp happens before _persist_state, so state.json carries the path.
+    blob = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert blob["pool_path_out"] == str(tmp_path / "survivors")
+
+
+def test_persist_survivors_omitted_when_run_dir_unset(tmp_path: Path) -> None:
+    """Survivors export is skipped when run_dir is None (parity with state.json)."""
+    state = _populated_state(tmp_path)
+    state.run_dir = None
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    assert not (tmp_path / "survivors.json").exists()
+    assert not (tmp_path / "survivors").exists()
+    assert state.pool_path_out is None
+
+
+def test_persist_survivors_handles_missing_elo_and_pilot(tmp_path: Path) -> None:
+    """A survivor without elo_rating/pilot_score yields null entries, not KeyError."""
+    state = _populated_state(tmp_path)
+    cand_path = _seed_candidate_md(tmp_path, "c-00")
+    state.candidates = [{"id": "c-00", "path": str(cand_path), "target_dim": "broken_tool_use"}]
+    state.survivors = ["c-00", "c-missing"]
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    blob = json.loads((tmp_path / "survivors.json").read_text(encoding="utf-8"))
+    rows = {row["id"]: row for row in blob["survivors"]}
+    assert rows["c-missing"]["elo_rating"] is None
+    assert rows["c-missing"]["pilot"] is None
+    assert rows["c-missing"]["path"] is None
+    # Only c-00 has a real candidate body, so only one symlink exists.
+    symlinks = list((tmp_path / "survivors").iterdir())
+    assert len(symlinks) == 1
+    assert symlinks[0].name == "c-00.md"
+
+
+def test_persist_survivors_clears_stale_symlinks(tmp_path: Path) -> None:
+    """A second run with different survivors replaces, not accumulates, symlinks."""
+    state = _populated_state(tmp_path)
+    cand_a = _seed_candidate_md(tmp_path, "c-old")
+    cand_b = _seed_candidate_md(tmp_path, "c-new")
+    state.candidates = [
+        {"id": "c-old", "path": str(cand_a), "target_dim": "broken_tool_use"},
+        {"id": "c-new", "path": str(cand_b), "target_dim": "broken_tool_use"},
+    ]
+    state.survivors = ["c-old"]
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    # Second run with a different survivor set.
+    state.survivors = ["c-new"]
+    pipeline.run()
+    survivors_dir = tmp_path / "survivors"
+    names = sorted(p.name for p in survivors_dir.iterdir())
+    assert names == ["c-new.md"]

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -89,6 +89,49 @@ def test_seed_select_points_at_hierarchical_tree() -> None:
     assert SEED_SELECT == "plugins/petri_audit/seeds"
 
 
+# ---------------------------------------------------------------------------
+# P0b — env-driven seed-select override (defect #1 from 2026-05-19 plan)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_seed_select_returns_default_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset AUTORESEARCH_SEED_SELECT falls back to the hierarchical default."""
+    monkeypatch.delenv("AUTORESEARCH_SEED_SELECT", raising=False)
+    assert auto_train._resolve_seed_select() == "plugins/petri_audit/seeds"
+
+
+def test_resolve_seed_select_honors_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A populated env var redirects seed-select to the seed-pipeline survivors."""
+    override = str(tmp_path / "survivors.json")
+    monkeypatch.setenv("AUTORESEARCH_SEED_SELECT", override)
+    assert auto_train._resolve_seed_select() == override
+
+
+def test_resolve_seed_select_treats_whitespace_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only env value is treated as unset to avoid breaking argv."""
+    monkeypatch.setenv("AUTORESEARCH_SEED_SELECT", "   ")
+    assert auto_train._resolve_seed_select() == "plugins/petri_audit/seeds"
+
+
+def test_build_audit_command_uses_resolved_seed_select(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """_build_audit_command picks up the env override at call-time."""
+    override = str(tmp_path / "survivors.json")
+    monkeypatch.setenv("AUTORESEARCH_SEED_SELECT", override)
+    argv = auto_train._build_audit_command()
+    idx = argv.index("--seed-select")
+    assert argv[idx + 1] == override
+
+
 def test_real_mode_invokes_subprocess_with_override_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- seed-pipeline `Pipeline._persist_survivors()` 추가 — `<run_dir>/survivors.json` (metadata) + `<run_dir>/survivors/` (inspect-petri 가 직접 소비 가능한 .md 심볼릭 dir) 동시 emit
- `state.pool_path_out` 를 디렉토리 (not JSON) 로 stamp — `_persist_state()` 보다 먼저 실행해서 state.json 에도 반영
- autoresearch `_resolve_seed_select()` 추가 — `AUTORESEARCH_SEED_SELECT` env override, fallback 은 기존 하드코드된 hierarchical default

## Why
2026-05-19 outer-loop wiring plan Phase A 의 defect #1 (autoresearch SEED_SELECT 하드코드, seed-pipeline 산출물 핸드오프 경로 없음) + #13 (survivors stdout-only, pool_path_out 자동 set 안 됨) 해소. 이 둘이 막혀있어서 "seed-pipeline 으로 진화시킨 seeds 가 autoresearch 의 다음 generation 으로 자동 흘러가지 못하는" 문제 — outer-loop 가 진짜 self-improving 으로 굴러가지 못하는 핵심 결손이었음.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/orchestrator.py` | `_persist_survivors()` 추가 (json + symlink dir), `Pipeline.run()` 호출 순서 swap (survivors → state) |
| `plugins/seed_pipeline/cli.py` | 완료 메시지에 survivors.json 경로 추가 |
| `autoresearch/train.py` | `_resolve_seed_select()` + env override; `_build_audit_command` call-time 해소 |
| `tests/plugins/seed_pipeline/test_state_offload.py` | 6 new tests (schema / symlink dir / pool_path_out stamp / run_dir unset / missing elo·pilot / stale-symlink cleanup) |
| `tests/test_autoresearch_train.py` | 4 new tests (default / env override / whitespace / argv resolution) |
| `CHANGELOG.md` | `[Unreleased] > Added` P0b 항목 |
| `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` | P0b ✅ |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| defect #1 — SEED_SELECT 하드코드 | Implemented | env-driven via `_resolve_seed_select()`, call-time 해소 |
| defect #13 — survivors export | Implemented | survivors.json + survivors/ symlink dir + pool_path_out stamp |
| Read-write parity | Verified | symlink dir 가 inspect-petri 의 flat-glob `*.md` 소비 시그니처 매칭 (runner.py:240+256 + seed_tree.py:127-156) |
| state.json 의 pool_path_out 반영 | Verified | `_persist_survivors` → `_persist_state` 순서, test 로 assert |
| Backward compat | Verified | SEED_SELECT 상수 그대로 유지, default fallback 으로 사용 |

## Verification
- [x] `uv run ruff check autoresearch/ plugins/seed_pipeline/ tests/` clean
- [x] `uv run ruff format --check ...` clean (post format)
- [x] `uv run mypy autoresearch/ plugins/seed_pipeline/` clean
- [x] `uv run pytest tests/test_autoresearch_train.py tests/plugins/seed_pipeline/test_state_offload.py tests/plugins/seed_pipeline/test_orchestrator.py` → 68 passed
- [x] Codex MCP audit round 1 → 2 findings (HIGH parity + MEDIUM ordering), round 2 → 0 finding PASS

## Reference
- Plan: `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` Phase A row P0b
- Defects: #1 `autoresearch/train.py:72`, #13 `plugins/seed_pipeline/cli.py:226`
- Consumer side: `plugins/petri_audit/runner.py:240+256` + `plugins/petri_audit/seed_tree.py:127-156`
- Predecessor: PR #1298 (P0a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)