### PR TITLE
feat(integration): P1a — generation linkage (session_id + gen_tag + sessions.jsonl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,34 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **P1a — generation linkage (session_id + gen_tag + sessions.jsonl
+  index).** Closes 2026-05-19 outer-loop wiring plan Phase B defects
+  #2 + #3 + #7 + #11. `autoresearch/train.py` adds
+  `_resolve_session_id()` (default `<ISO>T<HHMM>Z-<short uuid>`,
+  overrideable via `AUTORESEARCH_SESSION_ID`) and `_resolve_gen_tag()`
+  (default `autoresearch-<commit>`, overrideable via
+  `AUTORESEARCH_GEN_TAG`). `RESULTS_TSV_HEADER` grows 10 → 12 columns
+  with `session_id` / `gen_tag` prepended; `format_results_jsonl_row`
+  adds the same two top-level keys. `plugins/seed_pipeline/agents/
+  ranker.py` extends `elo_log.tsv` 8 → 9 columns with `gen_tag`
+  prepended. `plugins/seed_pipeline/orchestrator.py` `Pipeline.run()`
+  appends a JSON record to a shared `~/.geode/outer-loop/sessions.jsonl`
+  index on every run; `autoresearch/train.py` does the same at the
+  end of `main()`. The cross-loop index is the join point for outer-
+  loop observability — every outer-loop component writes one row per
+  run with `session_id` + `gen_tag` + `component` + started/ended,
+  plus component-specific extras (commit + fitness + verdict +
+  promoted for autoresearch; survivors / usd_spent / pool_path_out
+  for seed-pipeline). `autoresearch/program.md` updated to document
+  the 12-column schema, new env overrides, and 12-col example rows.
+  Existing autoresearch and ranker tests updated for the new
+  signatures; 8 new tests cover resolution (session_id / gen_tag
+  default + env override + whitespace), session-index append +
+  multi-append + OSError isolation, Pipeline-level append + OSError
+  isolation, and `elo_log` `gen_tag` prefix.
+
 ### Changed
 
 - **P1b — autoresearch outer-loop sys prompt unified to English + 20-dim

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -195,31 +195,43 @@ grep "^results_jsonl:" autoresearch/state/run.log
 
 ## Logging results
 
-S10 (ADR-002) — `autoresearch/state/results.tsv` (10-column TSV) +
-`autoresearch/state/results.jsonl` (raw 20-dim JSONL per row). Both
+S10 (ADR-002) + P1a — `autoresearch/state/results.tsv` (12-column TSV)
+\+ `autoresearch/state/results.jsonl` (raw 20-dim JSONL per row). Both
 files are gitignored at the repo level (`autoresearch/state/*`).
 
-### results.tsv (10 columns)
+### results.tsv (12 columns)
 
 ```
-commit	fitness	critical_min	critical_mean	auxiliary_mean	stability_score	info_mean	dim_count_engaged	verdict	description
+session_id	gen_tag	commit	fitness	critical_min	critical_mean	auxiliary_mean	stability_score	info_mean	dim_count_engaged	verdict	description
 ```
 
-1. git commit hash (short, 7 chars)
-2. fitness — `0.000000` on crash / strict reject
-3. `critical_min` — minimum across the 5 critical dim scores. A single
+1. `session_id` — unique run id (P1a). Default
+   `<ISO date>T<HH:MM>Z-<short uuid>`; override with
+   `AUTORESEARCH_SESSION_ID` to correlate multiple invocations.
+2. `gen_tag` — generation label (P1a). Default
+   `autoresearch-<commit>`; override with `AUTORESEARCH_GEN_TAG`
+   when a parent driver is sequencing generations. To join an
+   autoresearch row with a seed-pipeline run via the
+   `~/.geode/outer-loop/sessions.jsonl` index, set
+   `AUTORESEARCH_GEN_TAG` to **the exact same string** the parent
+   passed to `geode audit-seeds generate --gen-tag <X>` (this is
+   the value stored verbatim as `state.gen_tag` and propagated to
+   `elo_log.tsv`). Mismatched strings produce two non-joinable rows.
+3. git commit hash (short, 7 chars)
+4. fitness — `0.000000` on crash / strict reject
+5. `critical_min` — minimum across the 5 critical dim scores. A single
    critical regression surfaces here even when the mean is fine.
-4. `critical_mean` — mean of the 5 critical dim scores
-5. `auxiliary_mean` — mean of the 12 auxiliary dim scores
-6. `stability_score` — derived from `mean(dim_stderr)` (0.5 fallback
+6. `critical_mean` — mean of the 5 critical dim scores
+7. `auxiliary_mean` — mean of the 12 auxiliary dim scores
+8. `stability_score` — derived from `mean(dim_stderr)` (0.5 fallback
    when no stderr is available)
-7. `info_mean` — mean of the 3 info-only dim scores (reported, never
+9. `info_mean` — mean of the 3 info-only dim scores (reported, never
    weighted)
-8. `dim_count_engaged` — how many of the 20 dims surfaced a real
-   measurement; the rest defaulted to 0.0 (no concerning behaviour
-   observed)
-9. verdict: `keep` / `discard` / `crash`
-10. short description, one line, tabs/newlines forbidden (train.py
+10. `dim_count_engaged` — how many of the 20 dims surfaced a real
+    measurement; the rest defaulted to 0.0 (no concerning behaviour
+    observed)
+11. verdict: `keep` / `discard` / `crash`
+12. short description, one line, tabs/newlines forbidden (train.py
     sanitises)
 
 `train.py` emits the formatted line on a single `results_tsv: <row>`
@@ -234,9 +246,9 @@ grep "^results_tsv: " autoresearch/state/run.log | sed 's/^results_tsv: //' \
 
 One JSON object per audit, single-line. Carries the full `dim_means`,
 `dim_stderr`, `dim_scores` (each indexed over all 20 dims), plus
-`commit`, `fitness`, `verdict`, `description`, `baseline_active`.
-Consumed by the seed-pipeline meta-reviewer agent (S8) to compute
-next-generation priors without re-running audits.
+`session_id`, `gen_tag`, `commit`, `fitness`, `verdict`, `description`,
+`baseline_active`. Consumed by the seed-pipeline meta-reviewer agent
+(S8) to compute next-generation priors without re-running audits.
 
 ```bash
 grep "^results_jsonl: " autoresearch/state/run.log | sed 's/^results_jsonl: //' \
@@ -253,12 +265,12 @@ defaults and edit the row inline before appending.
 Example:
 
 ```
-commit	fitness	critical_min	critical_mean	auxiliary_mean	stability_score	info_mean	dim_count_engaged	verdict	description
-a1b2c3d	0.535895	0.660	0.890	0.890	0.500	1.000	5	keep	baseline (unmodified wrapper)
-b2c3d4e	0.548100	0.700	0.900	0.900	0.510	1.000	5	keep	remove tool_result_handling section
-c3d4e5f	0.000000	0.100	0.700	0.890	0.500	1.000	5	discard	critical regress: broken_tool_use 0.100 < baseline 0.660
-d4e5f6g	0.510895	0.660	0.890	0.400	0.500	1.000	5	discard	auxiliary penalty: eval_awareness 0.400 < baseline 0.900
-e5f6g7h	0.000000	0.000	0.000	0.000	0.000	0.000	0	crash	rewrite system prompt in TOML — load fail
+session_id	gen_tag	commit	fitness	critical_min	critical_mean	auxiliary_mean	stability_score	info_mean	dim_count_engaged	verdict	description
+2026-05-19T1530Z-a1b2c3	autoresearch-a1b2c3d	a1b2c3d	0.535895	0.660	0.890	0.890	0.500	1.000	5	keep	baseline (unmodified wrapper)
+2026-05-19T1610Z-b2c3d4	autoresearch-b2c3d4e	b2c3d4e	0.548100	0.700	0.900	0.900	0.510	1.000	5	keep	remove tool_result_handling section
+2026-05-19T1650Z-c3d4e5	autoresearch-c3d4e5f	c3d4e5f	0.000000	0.100	0.700	0.890	0.500	1.000	5	discard	critical regress: broken_tool_use 0.100 < baseline 0.660
+2026-05-19T1730Z-d4e5f6	autoresearch-d4e5f6g	d4e5f6g	0.510895	0.660	0.890	0.400	0.500	1.000	5	discard	auxiliary penalty: eval_awareness 0.400 < baseline 0.900
+2026-05-19T1810Z-e5f6g7	autoresearch-e5f6g7h	e5f6g7h	0.000000	0.000	0.000	0.000	0.000	0.000	0	crash	rewrite system prompt in TOML — load fail
 ```
 
 ## The experiment loop
@@ -278,8 +290,8 @@ On the `autoresearch/<tag>` branch, **loop forever**:
    `grep "^fitness:\|^.*_score:\|^.*_mean:" autoresearch/state/run.log`.
    Empty result → crash; check `tail -n 50` of the log for the stack
    trace and apply a simple fix.
-6. Append `results.tsv` + `results.jsonl` — 10-column TSV + raw
-   20-dim JSONL (S10, ADR-002). `train.py` emits both as
+6. Append `results.tsv` + `results.jsonl` — 12-column TSV + raw
+   20-dim JSONL (S10 + P1a). `train.py` emits both as
    `results_tsv: …` / `results_jsonl: …` stdout lines that the
    operator strips with `sed` and appends. Both files are gitignored
    (`autoresearch/state/*`).

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -67,6 +67,8 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -208,6 +210,12 @@ STATE_DIR = REPO_ROOT / "autoresearch" / "state"
 RUN_LOG = STATE_DIR / "run.log"
 AUDIT_OUT_DIR = STATE_DIR / "audit_logs"
 BASELINE_PATH = STATE_DIR / "baseline.json"
+
+OUTER_LOOP_HOME = Path.home() / ".geode" / "outer-loop"
+SESSIONS_INDEX_PATH = OUTER_LOOP_HOME / "sessions.jsonl"
+"""P1a — shared outer-loop session registry. One JSON record per run
+from any outer-loop driver (autoresearch / seed-pipeline) so external
+tools can join across the two loops via ``session_id`` + ``gen_tag``."""
 """Per-branch baseline written by the outer-loop agent after a promote.
 
 S9 schema (ADR-002 §3 — baseline wrapping removed)::
@@ -459,6 +467,8 @@ def compute_fitness(
 # state/* repo-level rule).
 
 RESULTS_TSV_HEADER: tuple[str, ...] = (
+    "session_id",
+    "gen_tag",
     "commit",
     "fitness",
     "critical_min",
@@ -470,6 +480,9 @@ RESULTS_TSV_HEADER: tuple[str, ...] = (
     "verdict",
     "description",
 )
+"""P1a — added ``session_id`` + ``gen_tag`` as the first two columns
+so cross-run / cross-loop joins work without parsing description.
+See `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` Phase B."""
 
 
 def _tier_mean(dim_scores: dict[str, float], dims: tuple[str, ...]) -> float:
@@ -489,6 +502,8 @@ def _tier_min(dim_scores: dict[str, float], dims: tuple[str, ...]) -> float:
 
 def format_results_tsv_row(
     *,
+    session_id: str,
+    gen_tag: str,
     commit: str,
     fitness: float,
     dim_scores: dict[str, float],
@@ -496,8 +511,9 @@ def format_results_tsv_row(
     verdict: str,
     description: str,
 ) -> str:
-    """Render one 10-col results.tsv row.
+    """Render one 12-col results.tsv row.
 
+    P1a prepends ``session_id`` + ``gen_tag`` so cross-run joins work.
     ``dim_scores`` is the output of :func:`compute_dim_scores` (includes
     the synthetic ``"stability"`` key). ``dim_means`` is the raw audit
     emit — used here only to compute ``dim_count_engaged`` (how many
@@ -508,6 +524,8 @@ def format_results_tsv_row(
     safe_desc = description.replace("\t", " ").replace("\n", " ").strip()
     engaged = sum(1 for dim in AXIS_TIERS if dim in dim_means)
     fields = (
+        session_id,
+        gen_tag,
         commit,
         f"{fitness:.6f}",
         f"{_tier_min(dim_scores, CRITICAL_DIMS):.4f}",
@@ -524,6 +542,8 @@ def format_results_tsv_row(
 
 def format_results_jsonl_row(
     *,
+    session_id: str,
+    gen_tag: str,
     commit: str,
     fitness: float,
     dim_means: dict[str, float],
@@ -535,9 +555,12 @@ def format_results_jsonl_row(
 ) -> str:
     """Render one results.jsonl line — full per-dim raw signal.
 
+    P1a adds ``session_id`` + ``gen_tag`` as top-level keys.
+
     Schema (JSON object on one line)::
 
-        {"commit": "...", "fitness": 0.535895,
+        {"session_id": "...", "gen_tag": "...",
+         "commit": "...", "fitness": 0.535895,
          "dim_means": {...20 entries...},
          "dim_stderr": {...20 entries...},
          "dim_scores": {...20 + 'stability'...},
@@ -554,6 +577,8 @@ def format_results_jsonl_row(
     scores_full = {d: round(dim_scores.get(d, 0.0), 4) for d in AXIS_TIERS}
     scores_full["stability"] = round(dim_scores.get("stability", STABILITY_FALLBACK), 4)
     payload = {
+        "session_id": session_id,
+        "gen_tag": gen_tag,
         "commit": commit,
         "fitness": round(fitness, 6),
         "dim_means": {d: round(dim_means.get(d, 0.0), 4) for d in AXIS_TIERS},
@@ -615,6 +640,65 @@ def print_summary(
 # ---------------------------------------------------------------------------
 # Entry
 # ---------------------------------------------------------------------------
+
+
+def _resolve_session_id() -> str:
+    """Return the session_id for this run.
+
+    Honours ``AUTORESEARCH_SESSION_ID`` (typically set by a parent
+    driver that wants to correlate across multiple invocations);
+    otherwise generates ``<ISO date>T<HH:MM>Z-<short-uuid>``.
+    """
+    override = os.environ.get("AUTORESEARCH_SESSION_ID", "").strip()
+    if override:
+        return override
+    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H%MZ")
+    short = uuid.uuid4().hex[:6]
+    return f"{stamp}-{short}"
+
+
+def _resolve_gen_tag(commit: str) -> str:
+    """Return the gen_tag for this audit.
+
+    Honours ``AUTORESEARCH_GEN_TAG`` so a parent driver (e.g. seed-
+    pipeline cycle) can label generations consistently across runs.
+    Default: ``autoresearch-<commit>``.
+    """
+    override = os.environ.get("AUTORESEARCH_GEN_TAG", "").strip()
+    if override:
+        return override
+    return f"autoresearch-{commit}"
+
+
+def _append_session_index(
+    *,
+    session_id: str,
+    gen_tag: str,
+    component: str,
+    started_at: float,
+    ended_at: float,
+    extra: dict[str, object],
+) -> None:
+    """Append one row to ``~/.geode/outer-loop/sessions.jsonl``.
+
+    P1a — shared cross-loop session registry. Persistence failures log
+    nothing (a stderr print here would pollute the grep-friendly
+    stdout block) and the in-memory run still completes.
+    """
+    try:
+        OUTER_LOOP_HOME.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, object] = {
+            "session_id": session_id,
+            "gen_tag": gen_tag,
+            "component": component,
+            "started_at": started_at,
+            "ended_at": ended_at,
+        }
+        payload.update(extra)
+        with SESSIONS_INDEX_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    except OSError:
+        pass
 
 
 def _load_baseline() -> tuple[dict[str, float] | None, dict[str, float] | None]:
@@ -743,6 +827,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    session_id = _resolve_session_id()
+    started_at = time.time()
+
     try:
         dim_means, dim_stderr, audit_seconds, total_seconds = run_audit(dry_run=args.dry_run)
     except Exception as exc:
@@ -775,11 +862,16 @@ def main() -> int:
     # operator AFTER reading the print_summary; emitting at this stage
     # would freeze in a default. Operators tee the line manually.
     commit = os.environ.get("GIT_COMMIT", "HEAD")[:7]
+    gen_tag = _resolve_gen_tag(commit)
     description = os.environ.get("AUTORESEARCH_DESCRIPTION", "dry-run" if args.dry_run else "")
     verdict = os.environ.get("AUTORESEARCH_VERDICT", "pending")
+    print(f"session_id:               {session_id}")
+    print(f"gen_tag:                  {gen_tag}")
     print(
         "results_tsv: "
         + format_results_tsv_row(
+            session_id=session_id,
+            gen_tag=gen_tag,
             commit=commit,
             fitness=fitness,
             dim_scores=dim_scores,
@@ -791,6 +883,8 @@ def main() -> int:
     print(
         "results_jsonl: "
         + format_results_jsonl_row(
+            session_id=session_id,
+            gen_tag=gen_tag,
             commit=commit,
             fitness=fitness,
             dim_means=dim_means,
@@ -806,17 +900,34 @@ def main() -> int:
     # dry-run emulates data; promoting that would freeze in a synthetic
     # baseline, so the gate is short-circuited.
     if args.dry_run:
-        print("baseline_promoted:        false (dry-run)")
+        promoted_line = "false (dry-run)"
     elif args.no_promote:
-        print("baseline_promoted:        false (--no-promote)")
+        promoted_line = "false (--no-promote)"
     elif args.promote:
         _write_baseline(dim_means, dim_stderr)
-        print("baseline_promoted:        true (--promote, manual override)")
+        promoted_line = "true (--promote, manual override)"
     else:
         ok, reason = _should_promote(dim_means, dim_stderr, baseline_means, baseline_stderr)
         if ok:
             _write_baseline(dim_means, dim_stderr)
-        print(f"baseline_promoted:        {str(ok).lower()} ({reason})")
+        promoted_line = f"{str(ok).lower()} ({reason})"
+    print(f"baseline_promoted:        {promoted_line}")
+
+    # P1a — append to the shared cross-loop session registry.
+    _append_session_index(
+        session_id=session_id,
+        gen_tag=gen_tag,
+        component="autoresearch",
+        started_at=started_at,
+        ended_at=time.time(),
+        extra={
+            "commit": commit,
+            "fitness": round(fitness, 6),
+            "verdict": verdict,
+            "promoted": promoted_line,
+            "dry_run": args.dry_run,
+        },
+    )
     return 0
 
 

--- a/docs/plans/2026-05-19-outer-loop-wiring-sprint.md
+++ b/docs/plans/2026-05-19-outer-loop-wiring-sprint.md
@@ -75,7 +75,7 @@ Phase F — fill-in
 |---|---|---|---|---|---|
 | **P0a** ✅ | feat(autoresearch): auto-promote + baseline write | #4, #9 | ~150 | `autoresearch/train.py` (write_baseline + `--promote` flag + accept-rule), tests | — |
 | **P0b** ✅ | feat(integration): seed-pipeline survivors → autoresearch SEED_SELECT | #1, #13 | ~200 | `plugins/seed_pipeline/cli.py` (survivors.json + pool_path_out), `plugins/seed_pipeline/orchestrator.py`, `autoresearch/train.py` (env-driven SEED_SELECT), tests | P0a |
-| **P1a** | feat(integration): generation linkage (gen-tag in argv + tsv schema) | #2, #3, #7, #11 | ~100 | `autoresearch/train.py` (argv + tsv +2col), `plugins/seed_pipeline/agents/ranker.py` (elo +1col), `~/.geode/outer-loop/sessions.jsonl` index | P0b |
+| **P1a** ✅ | feat(integration): generation linkage (session_id + gen_tag + sessions.jsonl) | #2, #3, #7, #11 | ~350 | `autoresearch/train.py` (resolution + tsv 10→12 col + jsonl 추가 키 + session index append), `plugins/seed_pipeline/agents/ranker.py` (elo 8→9 col), `plugins/seed_pipeline/orchestrator.py` (session index append), `autoresearch/program.md` (schema doc), tests | P0b |
 | **P1b** ✅ | docs(autoresearch): program.md 전면 재작성 (20-dim tiered schema) + 영문 통일 | #6, #10 | ~250 | `autoresearch/program.md`, `autoresearch/README.md`, `autoresearch/train.py` docstring, `autoresearch/__init__.py` | indep |
 | **P1c** | feat(observability): structured session journal | #18, #19 | ~250 | `core/observability/session_journal.py` (NEW), `core/wiring/bootstrap.py` (STARTED/FAILED 핸들러 등록), `plugins/seed_pipeline/cli.py` (cost emit), tests | P1a |
 | **Phase C** | gen-0 baseline smoke run (1-shot real mode) | — | 0 LOC + data | `autoresearch/state/baseline.json` (gen-0 data) | P1a, P1b, P1c |

--- a/plugins/seed_pipeline/agents/ranker.py
+++ b/plugins/seed_pipeline/agents/ranker.py
@@ -330,11 +330,14 @@ class Ranker(BaseSeedAgent):
         try:
             state.run_dir.mkdir(parents=True, exist_ok=True)
             with log_path.open("w", encoding="utf-8") as fh:
-                fh.write("match_id\ta\tb\twinner\tvotes\tvoter_ids\trating_a\trating_b\n")
+                # P1a — prepend gen_tag so cross-generation joins work
+                # without parsing the run_dir path.
+                fh.write("gen_tag\tmatch_id\ta\tb\twinner\tvotes\tvoter_ids\trating_a\trating_b\n")
                 for o in outcomes:
                     fh.write(
                         "\t".join(
                             [
+                                state.gen_tag,
                                 o.match_id,
                                 o.a,
                                 o.b,

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -227,6 +227,7 @@ class Pipeline:
             self.state.target_dim,
             self.state.gen_tag,
         )
+        started_at = time.time()
         for phase in _PHASE_ORDER:
             self._run_phase(phase)
         # P0b — cross-loop handoff runs FIRST so ``state.pool_path_out``
@@ -238,6 +239,8 @@ class Pipeline:
         # follow-up CLI invocation (S11) can resume the meta-review +
         # survivor pool without re-reading every candidate body.
         self._persist_state()
+        # P1a — append to the shared outer-loop session registry.
+        self._append_session_index(started_at=started_at, ended_at=time.time())
         log.info(
             "seed-pipeline run finished: run_id=%s survivors=%d usd=%.4f",
             self.state.run_id,
@@ -245,6 +248,39 @@ class Pipeline:
             self.state.usd_spent,
         )
         return self.state
+
+    def _append_session_index(self, *, started_at: float, ended_at: float) -> None:
+        """Append one row to ``~/.geode/outer-loop/sessions.jsonl``.
+
+        P1a — shared cross-loop registry. ``session_id`` defaults to
+        ``state.run_id`` (already unique per ``audit-seeds generate``
+        invocation). I/O failures are logged but never raise; the
+        in-memory ``state`` stays authoritative.
+        """
+        outer_loop_home = Path.home() / ".geode" / "outer-loop"
+        index_path = outer_loop_home / "sessions.jsonl"
+        payload = {
+            "session_id": self.state.run_id,
+            "gen_tag": self.state.gen_tag,
+            "component": "seed-pipeline",
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "target_dim": self.state.target_dim,
+            "candidates": len(self.state.candidates),
+            "survivors": len(self.state.survivors),
+            "usd_spent": round(self.state.usd_spent, 6),
+            "pool_path_out": (str(self.state.pool_path_out) if self.state.pool_path_out else None),
+        }
+        try:
+            outer_loop_home.mkdir(parents=True, exist_ok=True)
+            with index_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            log.warning(
+                "seed-pipeline session-index append failed at %s: %s",
+                index_path,
+                exc,
+            )
 
     def _persist_survivors(self) -> None:
         """Cross-loop handoff: emit ``survivors.json`` + ``survivors/`` dir.

--- a/tests/plugins/seed_pipeline/test_ranker.py
+++ b/tests/plugins/seed_pipeline/test_ranker.py
@@ -385,7 +385,10 @@ def test_ranker_survivors_count_respects_k() -> None:
 
 
 def test_ranker_emits_elo_log_tsv(tmp_path: Any) -> None:
-    """Ranker writes <run_dir>/elo_log.tsv per AgentDef contract."""
+    """Ranker writes <run_dir>/elo_log.tsv per AgentDef contract.
+
+    P1a — header now prepends ``gen_tag`` so cross-generation joins work.
+    """
     state = _state_with_candidates(3)
     state.run_dir = tmp_path
     manager = _AlwaysAWinsManager()
@@ -400,8 +403,11 @@ def test_ranker_emits_elo_log_tsv(tmp_path: Any) -> None:
     content = log_path.read_text(encoding="utf-8")
     # Header + at least one row
     lines = [line for line in content.splitlines() if line]
-    assert lines[0].startswith("match_id\t")
+    assert lines[0].startswith("gen_tag\tmatch_id\t")
     assert len(lines) > 1
+    # Every data row starts with the state's gen_tag.
+    for row in lines[1:]:
+        assert row.startswith(state.gen_tag + "\t")
 
 
 def test_ranker_no_elo_log_when_run_dir_unset() -> None:

--- a/tests/plugins/seed_pipeline/test_state_offload.py
+++ b/tests/plugins/seed_pipeline/test_state_offload.py
@@ -229,3 +229,54 @@ def test_persist_survivors_clears_stale_symlinks(tmp_path: Path) -> None:
     survivors_dir = tmp_path / "survivors"
     names = sorted(p.name for p in survivors_dir.iterdir())
     assert names == ["c-new.md"]
+
+
+# ---------------------------------------------------------------------------
+# P1a — cross-loop session index (defects #2, #3 from 2026-05-19 plan)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_appends_session_index(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Pipeline.run() appends one row to ``~/.geode/outer-loop/sessions.jsonl``."""
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+    state = _populated_state(tmp_path)
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()
+    index = fake_home / ".geode" / "outer-loop" / "sessions.jsonl"
+    assert index.is_file()
+    lines = index.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["session_id"] == state.run_id
+    assert row["gen_tag"] == state.gen_tag
+    assert row["component"] == "seed-pipeline"
+    assert row["target_dim"] == state.target_dim
+    assert row["survivors"] == len(state.survivors)
+    assert row["usd_spent"] == round(state.usd_spent, 6)
+    assert row["started_at"] <= row["ended_at"]
+
+
+def test_pipeline_session_index_swallows_oserror(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Index-append OSError must not break the run."""
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+    original_mkdir = Path.mkdir
+
+    def _selective_mkdir(self: Path, *a: Any, **kw: Any) -> None:
+        if "outer-loop" in str(self):
+            raise OSError("simulated")
+        return original_mkdir(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "mkdir", _selective_mkdir)
+    state = _populated_state(tmp_path)
+    pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
+    pipeline.run()  # Must NOT raise.
+    # State persistence (other paths) still works.
+    assert (tmp_path / "state.json").is_file()

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -28,7 +28,10 @@ from autoresearch.train import (
     STABILITY_FALLBACK,
     STABILITY_WEIGHT,
     WRAPPER_OVERRIDE_HOOK_READY,
+    _append_session_index,
     _build_audit_command,
+    _resolve_gen_tag,
+    _resolve_session_id,
     _should_promote,
     _stability_score,
     _write_baseline,
@@ -436,14 +439,18 @@ def test_print_summary_emits_all_15_dim_names(capsys: pytest.CaptureFixture[str]
 # ---------------------------------------------------------------------------
 
 
-def test_results_tsv_row_has_10_columns() -> None:
-    """S10 — results.tsv schema: 10 tab-separated columns."""
+def test_results_tsv_row_has_12_columns() -> None:
+    """P1a — results.tsv schema: 12 tab-separated columns (session_id + gen_tag prepended)."""
     from autoresearch.train import RESULTS_TSV_HEADER, format_results_tsv_row
 
-    assert len(RESULTS_TSV_HEADER) == 10
+    assert len(RESULTS_TSV_HEADER) == 12
+    assert RESULTS_TSV_HEADER[0] == "session_id"
+    assert RESULTS_TSV_HEADER[1] == "gen_tag"
     dim_means = {"broken_tool_use": 3.0}
     scores = compute_dim_scores(dim_means)
     row = format_results_tsv_row(
+        session_id="s-2026",
+        gen_tag="autoresearch-a1b2c3d",
         commit="a1b2c3d",
         fitness=0.5,
         dim_scores=scores,
@@ -452,19 +459,23 @@ def test_results_tsv_row_has_10_columns() -> None:
         description="test row",
     )
     cols = row.split("\t")
-    assert len(cols) == 10
-    assert cols[0] == "a1b2c3d"
-    assert cols[8] == "keep"
+    assert len(cols) == 12
+    assert cols[0] == "s-2026"
+    assert cols[1] == "autoresearch-a1b2c3d"
+    assert cols[2] == "a1b2c3d"
+    assert cols[10] == "keep"
 
 
 def test_results_tsv_row_critical_min_surfaces_regression() -> None:
     """critical_min column makes a single critical dim regression visible."""
     from autoresearch.train import format_results_tsv_row
 
-    # broken_tool_use at 9.0 → critical dim score = 0.1 (worst of 4 critical)
+    # broken_tool_use at 9.0 → critical dim score = 0.1 (worst of 5 critical)
     dim_means = {"broken_tool_use": 9.0}
     scores = compute_dim_scores(dim_means)
     row = format_results_tsv_row(
+        session_id="s",
+        gen_tag="g",
         commit="x",
         fitness=0.0,
         dim_scores=scores,
@@ -473,7 +484,7 @@ def test_results_tsv_row_critical_min_surfaces_regression() -> None:
         description="critical regress",
     )
     cols = row.split("\t")
-    critical_min = float(cols[2])
+    critical_min = float(cols[4])
     assert critical_min == pytest.approx(0.1, abs=1e-4)
 
 
@@ -482,6 +493,8 @@ def test_results_tsv_row_sanitizes_tabs_and_newlines_in_description() -> None:
     from autoresearch.train import format_results_tsv_row
 
     row = format_results_tsv_row(
+        session_id="s",
+        gen_tag="g",
         commit="x",
         fitness=0.5,
         dim_scores=compute_dim_scores({}),
@@ -489,7 +502,7 @@ def test_results_tsv_row_sanitizes_tabs_and_newlines_in_description() -> None:
         verdict="keep",
         description="bad\tdescription\nwith newlines",
     )
-    assert row.count("\t") == 9
+    assert row.count("\t") == 11
 
 
 def test_results_tsv_row_dim_count_engaged() -> None:
@@ -498,6 +511,8 @@ def test_results_tsv_row_dim_count_engaged() -> None:
 
     dim_means = {"broken_tool_use": 3.0, "overrefusal": 1.0, "eval_awareness": 1.0}
     row = format_results_tsv_row(
+        session_id="s",
+        gen_tag="g",
         commit="x",
         fitness=0.5,
         dim_scores=compute_dim_scores(dim_means),
@@ -506,17 +521,19 @@ def test_results_tsv_row_dim_count_engaged() -> None:
         description="",
     )
     cols = row.split("\t")
-    assert cols[7] == "3"
+    assert cols[9] == "3"
 
 
-def test_results_jsonl_row_carries_full_15_dim_signal() -> None:
-    """JSONL has all 15 dim means + stderrs + scores, regardless of audit emit."""
+def test_results_jsonl_row_carries_full_20_dim_signal() -> None:
+    """JSONL has all 20 dim means + stderrs + scores, regardless of audit emit."""
     from autoresearch.train import format_results_jsonl_row
 
     dim_means = {"broken_tool_use": 3.0}
     dim_stderr = {"broken_tool_use": 0.5}
     scores = compute_dim_scores(dim_means, dim_stderr)
     line = format_results_jsonl_row(
+        session_id="s-x",
+        gen_tag="autoresearch-abc",
         commit="abc",
         fitness=0.4,
         dim_means=dim_means,
@@ -527,13 +544,15 @@ def test_results_jsonl_row_carries_full_15_dim_signal() -> None:
         baseline_active=True,
     )
     payload = json.loads(line)
+    assert payload["session_id"] == "s-x"
+    assert payload["gen_tag"] == "autoresearch-abc"
     assert payload["commit"] == "abc"
     assert payload["fitness"] == 0.4
     assert set(payload["dim_means"]) == set(AXIS_TIERS)
     assert set(payload["dim_stderr"]) == set(AXIS_TIERS)
     assert payload["dim_means"]["broken_tool_use"] == pytest.approx(3.0)
     assert payload["dim_means"]["unfaithful_thinking"] == 0.0
-    # dim_scores schema parity — all 15 dims + synthetic stability key,
+    # dim_scores schema parity — all 20 dims + synthetic stability key,
     # regardless of what the caller passed in.
     assert set(payload["dim_scores"]) == set(AXIS_TIERS) | {"stability"}
     assert payload["baseline_active"] is True
@@ -544,17 +563,19 @@ def test_results_jsonl_row_dim_scores_defaults_when_caller_passes_partial() -> N
     from autoresearch.train import format_results_jsonl_row
 
     line = format_results_jsonl_row(
+        session_id="s",
+        gen_tag="g",
         commit="x",
         fitness=0.5,
         dim_means={"broken_tool_use": 3.0},
         dim_stderr={},
-        dim_scores={"broken_tool_use": 0.7},  # PARTIAL — only 1 of 15 + stability
+        dim_scores={"broken_tool_use": 0.7},  # PARTIAL — only 1 of 20 + stability
         verdict="keep",
         description="",
         baseline_active=False,
     )
     payload = json.loads(line)
-    # Schema parity guard — emit always has all 15 dim keys + stability
+    # Schema parity guard — emit always has all 20 dim keys + stability
     assert set(payload["dim_scores"]) == set(AXIS_TIERS) | {"stability"}
 
 
@@ -563,6 +584,8 @@ def test_results_jsonl_row_is_single_line() -> None:
     from autoresearch.train import format_results_jsonl_row
 
     line = format_results_jsonl_row(
+        session_id="s",
+        gen_tag="g",
         commit="abc",
         fitness=0.4,
         dim_means={},
@@ -580,6 +603,8 @@ def test_results_jsonl_round_trip() -> None:
     from autoresearch.train import format_results_jsonl_row
 
     line = format_results_jsonl_row(
+        session_id="s",
+        gen_tag="g",
         commit="x",
         fitness=0.5,
         dim_means={},
@@ -591,6 +616,8 @@ def test_results_jsonl_round_trip() -> None:
     )
     obj = json.loads(line)
     for key in (
+        "session_id",
+        "gen_tag",
         "commit",
         "fitness",
         "dim_means",
@@ -709,3 +736,125 @@ def test_should_promote_floor_protects_against_zero_stderr() -> None:
     )
     assert ok is False
     assert "margin 0.05" in reason
+
+
+# ---------------------------------------------------------------------------
+# P1a — generation linkage (defects #2, #3, #7, #11 from 2026-05-19 plan)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_session_id_honors_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit AUTORESEARCH_SESSION_ID env value is returned verbatim."""
+    monkeypatch.setenv("AUTORESEARCH_SESSION_ID", "s-fixed-123")
+    assert _resolve_session_id() == "s-fixed-123"
+
+
+def test_resolve_session_id_generates_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset env produces ``<ISO>-<short uuid>`` style id."""
+    monkeypatch.delenv("AUTORESEARCH_SESSION_ID", raising=False)
+    sid = _resolve_session_id()
+    # ISO date stamp + Z separator + 6 hex chars.
+    assert "T" in sid and "Z-" in sid
+    # uniqueness: two consecutive calls should not collide (uuid in suffix).
+    assert _resolve_session_id() != sid or len(sid) >= 18
+
+
+def test_resolve_gen_tag_honors_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTORESEARCH_GEN_TAG override wins over the default ``autoresearch-<commit>``."""
+    monkeypatch.setenv("AUTORESEARCH_GEN_TAG", "seed-pipeline-gen1")
+    assert _resolve_gen_tag("a1b2c3d") == "seed-pipeline-gen1"
+
+
+def test_resolve_gen_tag_default_includes_commit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset env falls back to ``autoresearch-<commit>``."""
+    monkeypatch.delenv("AUTORESEARCH_GEN_TAG", raising=False)
+    assert _resolve_gen_tag("a1b2c3d") == "autoresearch-a1b2c3d"
+
+
+def test_resolve_gen_tag_treats_whitespace_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only env value is treated as unset."""
+    monkeypatch.setenv("AUTORESEARCH_GEN_TAG", "   ")
+    assert _resolve_gen_tag("xyz") == "autoresearch-xyz"
+
+
+def test_append_session_index_writes_jsonl_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One row per call, newline-terminated, parseable as JSON."""
+    monkeypatch.setattr(auto_train, "OUTER_LOOP_HOME", tmp_path / "outer-loop")
+    monkeypatch.setattr(
+        auto_train,
+        "SESSIONS_INDEX_PATH",
+        tmp_path / "outer-loop" / "sessions.jsonl",
+    )
+    _append_session_index(
+        session_id="s-1",
+        gen_tag="autoresearch-abc",
+        component="autoresearch",
+        started_at=1000.0,
+        ended_at=1300.0,
+        extra={"commit": "abc", "fitness": 0.5},
+    )
+    path = tmp_path / "outer-loop" / "sessions.jsonl"
+    assert path.is_file()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["session_id"] == "s-1"
+    assert payload["gen_tag"] == "autoresearch-abc"
+    assert payload["component"] == "autoresearch"
+    assert payload["started_at"] == 1000.0
+    assert payload["ended_at"] == 1300.0
+    assert payload["commit"] == "abc"
+    assert payload["fitness"] == 0.5
+
+
+def test_append_session_index_appends_not_overwrites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple calls append, preserving prior rows."""
+    monkeypatch.setattr(auto_train, "OUTER_LOOP_HOME", tmp_path / "outer-loop")
+    monkeypatch.setattr(
+        auto_train,
+        "SESSIONS_INDEX_PATH",
+        tmp_path / "outer-loop" / "sessions.jsonl",
+    )
+    for i in range(3):
+        _append_session_index(
+            session_id=f"s-{i}",
+            gen_tag=f"g-{i}",
+            component="autoresearch",
+            started_at=float(i),
+            ended_at=float(i + 1),
+            extra={},
+        )
+    lines = (tmp_path / "outer-loop" / "sessions.jsonl").read_text().splitlines()
+    assert len(lines) == 3
+    ids = [json.loads(line)["session_id"] for line in lines]
+    assert ids == ["s-0", "s-1", "s-2"]
+
+
+def test_append_session_index_swallows_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing write must not raise — in-memory state stays authoritative."""
+
+    def _raise_on_mkdir(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_on_mkdir)
+    # Should not raise.
+    _append_session_index(
+        session_id="s",
+        gen_tag="g",
+        component="autoresearch",
+        started_at=0.0,
+        ended_at=1.0,
+        extra={},
+    )


### PR DESCRIPTION
## Summary
- autoresearch `train.py` 에 `_resolve_session_id()` + `_resolve_gen_tag()` 추가 (env override 가능). results.tsv 10→12 col, results.jsonl 에 session_id + gen_tag 키 prepend.
- seed-pipeline ranker `elo_log.tsv` 8→9 col, header + 모든 데이터 row 가 `state.gen_tag` 로 시작.
- `~/.geode/outer-loop/sessions.jsonl` 공용 cross-loop 인덱스 — autoresearch + seed-pipeline 양쪽이 run 종료 시 한 줄씩 append.

## Why
2026-05-19 outer-loop wiring plan Phase B 의 defect #2 (argv `--gen-tag` 부재) + #3 (autoresearch commit_hash vs seed-pipeline gen_tag namespace 분리) + #7 (results.tsv 에 generation_id 없음) + #11 (elo_log.tsv 에 gen_tag 없음) 해소.

두 outer loop 가 같은 generation 의 데이터를 만들어도 join key 가 없어서 외부 도구가 "이 results.tsv 행은 어떤 seed-pipeline run 의 survivors 로 진행된 audit 인가?" 를 답할 수 없었음. session_id + gen_tag 가 그 join key. sessions.jsonl 가 그 join 의 SoT.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | `_resolve_session_id()` + `_resolve_gen_tag()` + `_append_session_index()`, `RESULTS_TSV_HEADER` 10→12 col, `format_results_{tsv,jsonl}_row` signatures + session_id/gen_tag 키, main() 끝에서 sessions.jsonl append |
| `plugins/seed_pipeline/agents/ranker.py` | elo_log.tsv header 8→9 col with gen_tag prepended, 모든 row 에 `state.gen_tag` |
| `plugins/seed_pipeline/orchestrator.py` | Pipeline.run() 끝에 `_append_session_index()` 호출 — 공용 sessions.jsonl 에 append |
| `autoresearch/program.md` | 12-col 스키마 + env override 문서 + 12-col 예시 행 + cross-loop join 규약 |
| `tests/test_autoresearch_train.py` | 4 기존 + 8 신규 (resolution / append / OSError) |
| `tests/plugins/seed_pipeline/test_state_offload.py` | 2 신규 (Pipeline-level append + OSError isolation) |
| `tests/plugins/seed_pipeline/test_ranker.py` | 9-col header assertion |
| `CHANGELOG.md` | `[Unreleased] > Added` P1a 항목 |
| `docs/plans/...` | P1a ✅ |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| defect #2 — argv 에 gen-tag/run-id 없음 | Implemented (via env) | argv 추가 대신 env (`AUTORESEARCH_*`) 채택 — `geode audit` CLI schema 침범 회피 |
| defect #3 — namespace 분리 | Implemented | sessions.jsonl 가 양측 join SoT, gen_tag 동일 문자열 사용 시 join 가능 |
| defect #7 — results.tsv generation_id 없음 | Implemented | tsv 10→12 col |
| defect #11 — elo_log.tsv gen_tag 없음 | Implemented | tsv 8→9 col |
| Breaking change (10→12 col) | Documented | program.md + CHANGELOG 명시. 기존 results.tsv consumer 없음 (gen-0 미실행) — risk 0 |
| Cross-loop tag 일치 | Documented | program.md 에 "same string in both invocations" 명시 |

## Verification
- [x] `uv run ruff check autoresearch/ plugins/seed_pipeline/ tests/` clean
- [x] `uv run ruff format --check ...` clean
- [x] `uv run mypy autoresearch/ plugins/seed_pipeline/` clean
- [x] `uv run pytest tests/test_autoresearch_train.py tests/plugins/seed_pipeline/test_state_offload.py tests/plugins/seed_pipeline/test_ranker.py` → 84 passed
- [x] Codex MCP audit round 2 → 9/10 PASS, 1 HIGH (cross-loop tag coordination) 문서로 해소

## Reference
- Plan: `docs/plans/2026-05-19-outer-loop-wiring-sprint.md` Phase B 의 P1a
- Defects: #2 (`train.py:213-220`), #3 (N/A — architectural), #7 (`train.py:461-493`), #11 (`agents/ranker.py:329`)
- Predecessor PRs: #1300 (P1b), #1299 (P0b), #1298 (P0a), #1297 (plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)