### PR TITLE
docs(seed-pipeline): unify remaining module docstrings to English (P1b follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **seed-pipeline module docstrings — English unification (P1b follow-up).**
+  `plugins/seed_pipeline/__init__.py` (5 Korean lines), `agents/__init__.py`
+  (1 line), `orchestrator.py` first docstring (1 line) → all English.
+  Tier-1 system prompts (`.claude/agents/seed_*.md` × 7,
+  `autoresearch/program.md`, `autoresearch/train.py`'s
+  `WRAPPER_PROMPT_SECTIONS`) were already monolingual per P1b/earlier
+  work; this PR closes the remaining Tier-2 module-docstring gap so
+  any outer-loop agent that imports the package and reads docstrings
+  sees consistent English throughout. Tier-3 backend implementation
+  comments in `plugins/petri_audit/{runner,codex_provider,
+  optimize,bias}.py` remain unchanged — they describe backend
+  constraints (OAuth policy, cache pricing math) rather than agent
+  instructions.
+
 ### Added
 
 - **P1c — structured session journal + SUBAGENT_STARTED/FAILED hook

--- a/plugins/seed_pipeline/__init__.py
+++ b/plugins/seed_pipeline/__init__.py
@@ -1,15 +1,16 @@
 """Seed-pipeline plugin — co-scientist (arXiv:2502.18864) port.
 
-co-scientist 의 7-role generate/debate/evolve loop 를 GEODE 의 sub-agent
-인프라 위에 port. Petri × autoresearch 의 frozen seed pool quality + size
-확장 (legacy flat pool → hierarchical tree per PR 0).  # slop:keep
+Ports the co-scientist 7-role generate/debate/evolve loop onto GEODE's
+sub-agent infrastructure. Goal: expand the Petri × autoresearch seed
+pool in both quality and size (legacy flat pool → hierarchical tree,
+post-PR-0).  # slop:keep
 
-본 plugin 은 ``plugins.petri_audit`` 에 sibling 의존:
+This plugin has sibling-level dependencies on ``plugins.petri_audit``:
 - credential resolution: ``plugins.petri_audit.credential_source``
 - adapter binding: ``plugins.petri_audit.adapters``
 - inner-loop pilot: ``plugins.petri_audit.runner``
 
-진입점:
+Entry points:
 - Typer CLI: ``geode audit-seeds <sub>`` (S11)
 - Slash: ``/audit-seeds <sub>`` (S11)
 

--- a/plugins/seed_pipeline/agents/__init__.py
+++ b/plugins/seed_pipeline/agents/__init__.py
@@ -4,7 +4,7 @@
 - generator     (S2, ✓)
 - critic        (S3, ✓) — Reflection
 - proximity     (S4, ✓) — 3-track dedup (embedding + lexical + role)
-- pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop 자리)
+- pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop slot)
 - ranker        (S6, ✓) — Elo tournament + 3-judge panel
 - evolver       (S7, ✓) — Reflection-driven section rewrite
 - meta_reviewer (S8, ✓) — coverage + next-gen prior + session summary

--- a/plugins/seed_pipeline/orchestrator.py
+++ b/plugins/seed_pipeline/orchestrator.py
@@ -1,6 +1,6 @@
 """Pipeline orchestrator — 7-phase generate-debate-evolve loop.
 
-Maps ADR-001 의 7-phase topology (Generation → Proximity → Reflection
+Maps the ADR-001 7-phase topology (Generation → Proximity → Reflection
 → Pilot → Ranking → Evolution → Meta-review) onto a sequential phase
 dispatcher backed by :class:`PipelineRegistry`. Each phase is a method
 that reads :class:`PipelineState`, looks up the role's agent from the


### PR DESCRIPTION
## Summary
- seed-pipeline 의 3 module docstring (Tier-2) 영문 통일 — `plugins/seed_pipeline/__init__.py`, `agents/__init__.py`, `orchestrator.py`
- Tier-1 sys prompts (`.claude/agents/seed_*.md` × 7, `program.md`, `WRAPPER_PROMPT_SECTIONS`) 는 이미 영문 (P1b 에서 처리됨)
- Tier-3 backend 주석 (petri_audit) 은 sys prompt 아니므로 out of scope

## Why
2026-05-19 사용자 directive "outer loop 의 sys prompt 는 영문으로 통일해" 의 follow-up. P1b 가 Tier-1 (agent 가 직접 sys prompt 으로 받는 surface) 을 처리했고, 이 PR 은 outer-loop agent 가 모듈 import 시 docstring 으로 읽을 수 있는 sys-prompt-adjacent surface (Tier-2) 의 한국어 잔존 7줄을 영문화.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_pipeline/__init__.py` | module docstring 5 Korean lines → English (의미/구조 그대로) |
| `plugins/seed_pipeline/agents/__init__.py` | pilot role 설명 1줄 "자리" → "slot" |
| `plugins/seed_pipeline/orchestrator.py` | 첫 docstring 1줄 "ADR-001 의" → "the ADR-001" |
| `CHANGELOG.md` | `[Unreleased] > Changed` 항목 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Tier-1 sys prompts 7+4 | Already done | P1b (#1300) |
| Tier-2 module docstrings | Implemented | 본 PR |
| Tier-3 backend comments | Out of scope | runner.py/codex_provider.py/optimize.py/bias.py 의 OAuth/cache 주석 — agent instruction 아님 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` clean
- [x] `uv run ruff format --check ...` clean
- [x] `uv run mypy core/ plugins/seed_pipeline/ autoresearch/` clean (322 files)
- [x] `uv run pytest tests/plugins/seed_pipeline/test_orchestrator.py tests/plugins/seed_pipeline/test_state_offload.py` → 23 passed
- [x] `grep -c '[가-힣]'` on 3 changed files → 0 each
- [x] Behavior unchanged — pure docstring rewording

## Reference
- 2026-05-19 directive: "현재 outer loop 의 sys prompt 는 영문으로 통일해" → P1b 처리 + 본 PR follow-up
- Predecessor: #1300 (P1b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)