### PR TITLE
feat(config): PR-α1 — outer_loop config schema + loader (pydantic v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,26 @@ functional change.
 
 ### Added
 
+- **PR-α1 — outer-loop config schema + loader (pydantic v2).** Closes
+  2026-05-19 config consolidation plan Phase α. New
+  `core/config/outer_loop.py` exposes `OuterLoopConfig` (root) +
+  `AutoresearchConfig` / `PetriRoleConfig` / `SeedPipelineConfig` /
+  `OuterLoopBindings` sub-models, all `extra='forbid'` for typo guard.
+  `load_outer_loop_config(path?)` reads the `[outer_loop.*]` section of
+  `~/.geode/config.toml` (or `GEODE_CONFIG_TOML` env override, or
+  explicit path arg) and returns a fully-defaulted model when the
+  file/section is missing. Strict-mode defaults: `fallback_to_payg=False`
+  (PAYG fallback denied), `warn_threshold=0.5`, `abort_threshold=0.9`
+  (validator enforces abort > warn). Autoresearch defaults mirror the
+  current `autoresearch/train.py` module constants so callers can be
+  migrated without behaviour change. Lives in a separate module from
+  `core.config._settings.Settings` so cold-start callers that only need
+  e.g. `ANTHROPIC_PRIMARY` constants don't pay the outer-loop
+  validation cost. 16 unit tests covering defaults, sub-config defaults,
+  missing-file fallback, empty-section fallback, env override, explicit
+  path arg, typo rejection (top-level + sub-section), threshold
+  validation, range clamping, and binding round-trip.
+
 - **Plan — Outer-Loop Config Consolidation + Subscription Guard + FE
   Warning UX (2026-05-19).** New
   `docs/plans/2026-05-19-outer-loop-config-consolidation.md` codifies

--- a/core/config/outer_loop.py
+++ b/core/config/outer_loop.py
@@ -1,0 +1,205 @@
+"""Outer-loop config — single SoT loader.
+
+Reads ``~/.geode/config.toml`` ``[outer_loop.*]`` sections into a typed
+pydantic v2 model. The loader is the SoT consumed by autoresearch /
+seed-pipeline / petri_audit / geode_main wherever outer-loop runtime
+decisions are made.
+
+Why a separate module from :mod:`core.config`
+=============================================
+
+:class:`core.config._settings.Settings` carries the user-facing GEODE
+runtime config (anthropic credential source, default model, etc.) and
+is consumed by hundreds of call sites. Adding outer-loop fields there
+would inflate every cold-start invocation that just wants a single
+constant.
+
+Outer-loop config is opt-in — only autoresearch / seed-pipeline /
+petri callers load it, and the cost is paid lazily inside their
+``run`` entrypoints. The two configs share the same file
+(``~/.geode/config.toml``) but live in disjoint sections so they
+never overwrite each other.
+
+Precedence (Codex / OpenAI Agents pattern)
+==========================================
+
+1. Per-component env var override (e.g. ``AUTORESEARCH_TARGET_MODEL``)
+   — handled at the caller, not here.
+2. ``~/.geode/config.toml`` ``[outer_loop.*]`` section — this loader.
+3. Module-level constants in ``autoresearch/train.py`` / picker
+   defaults — fallback when the section is missing.
+4. Pydantic model default — last resort.
+
+Source: 2026-05-19 config consolidation plan (settled decision #1).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tomllib
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from core.paths import GLOBAL_CONFIG_TOML
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "AutoresearchConfig",
+    "OuterLoopBindings",
+    "OuterLoopConfig",
+    "PetriRoleConfig",
+    "SeedPipelineConfig",
+    "Source",
+    "load_outer_loop_config",
+]
+
+
+Source = Literal["claude-cli", "openai-codex", "api_key", "auto"]
+"""Credential source label — matches ``plugins.petri_audit.petri.plugin.toml``."""
+
+
+class OuterLoopBindings(BaseModel):
+    """Generic per-role binding (model + source + optional fallback override)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str
+    source: Source
+    fallback_to_payg: bool | None = None
+    """``None`` → inherit ``[outer_loop] fallback_to_payg``."""
+
+
+class PetriRoleConfig(BaseModel):
+    """Petri role binding (auditor / target / judge)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str
+    source: Source = "auto"
+    fallback_to_payg: bool | None = None
+
+
+class AutoresearchConfig(BaseModel):
+    """autoresearch/train.py runtime knobs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    budget_minutes: Annotated[int, Field(ge=1, le=60)] = 5
+    target_model: str = "geode/gpt-5.5"
+    judge_model: str = "claude-code/opus"
+    use_oauth: bool = True
+    seed_limit: Annotated[int, Field(ge=1, le=1000)] = 10
+    seed_select: str = "plugins/petri_audit/seeds"
+    dim_set: str = "5axes"
+    max_turns: Annotated[int, Field(ge=1, le=200)] = 10
+    fallback_to_payg: bool | None = None
+
+
+class SeedPipelineConfig(BaseModel):
+    """seed-pipeline runtime knobs.
+
+    Per-role bindings live under ``[outer_loop.seed_pipeline.role.<X>]``
+    and are loaded into :attr:`roles`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    candidates_default: Annotated[int, Field(ge=1, le=100)] = 15
+    default_gen_tag: str = "gen1"
+    roles: dict[str, OuterLoopBindings] = Field(default_factory=dict)
+    fallback_to_payg: bool | None = None
+
+
+class OuterLoopConfig(BaseModel):
+    """Top-level [outer_loop.*] config root.
+
+    Validation entry point — every field has a documented default so an
+    empty / missing config file still produces a usable instance.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Global flags
+    fallback_to_payg: bool = False
+    """Subscription-soft default — true forces all source resolvers to
+    fall through to ``api_key`` on subscription exhaustion. False (the
+    default) aborts with an actionable error. Codex CLI's
+    ``forced_login_method`` pattern."""
+
+    warn_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    """Quota usage ratio above which the FE banner turns yellow."""
+
+    abort_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.9
+    """Quota usage ratio above which the FE banner turns red and the
+    run aborts."""
+
+    # Per-component sub-configs
+    autoresearch: AutoresearchConfig = Field(default_factory=AutoresearchConfig)
+    petri: dict[str, PetriRoleConfig] = Field(default_factory=dict)
+    """Map of role name → PetriRoleConfig. Expected keys: auditor /
+    target / judge."""
+    seed_pipeline: SeedPipelineConfig = Field(default_factory=SeedPipelineConfig)
+
+    @model_validator(mode="after")
+    def _abort_above_warn(self) -> OuterLoopConfig:
+        # ``model_validator(mode='after')`` runs after every field is
+        # populated (including defaults), so the inversion is caught
+        # even when the user only sets one of the two thresholds.
+        if self.abort_threshold <= self.warn_threshold:
+            raise ValueError(
+                f"abort_threshold ({self.abort_threshold}) must be greater than "
+                f"warn_threshold ({self.warn_threshold})"
+            )
+        return self
+
+
+def _resolve_config_path(path: Path | str | None) -> Path:
+    """Resolve which TOML to load.
+
+    Order: explicit ``path`` argument → ``GEODE_CONFIG_TOML`` env →
+    :data:`core.paths.GLOBAL_CONFIG_TOML`. Mirrors the pattern used by
+    :mod:`core.auth.auth_toml`.
+    """
+    if path is not None:
+        return Path(path).expanduser()
+    env = os.environ.get("GEODE_CONFIG_TOML", "").strip()
+    if env:
+        return Path(env).expanduser()
+    return GLOBAL_CONFIG_TOML
+
+
+def load_outer_loop_config(path: Path | str | None = None) -> OuterLoopConfig:
+    """Load + validate the ``[outer_loop.*]`` section of ``config.toml``.
+
+    Returns a fully-defaulted :class:`OuterLoopConfig` when:
+    - the file does not exist, or
+    - the file has no ``[outer_loop]`` section.
+
+    Raises:
+        ValueError: when the ``[outer_loop.*]`` section exists but
+            contains unknown fields or fails pydantic validation.
+            The error is bubbled verbatim so the operator sees the
+            offending key / value.
+    """
+    resolved = _resolve_config_path(path)
+    if not resolved.is_file():
+        log.debug("outer-loop config: %s does not exist; using defaults", resolved)
+        return OuterLoopConfig()
+    try:
+        with resolved.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except OSError as exc:
+        log.warning(
+            "outer-loop config: could not read %s (%s); using defaults",
+            resolved,
+            exc,
+        )
+        return OuterLoopConfig()
+    section = raw.get("outer_loop")
+    if not isinstance(section, dict):
+        return OuterLoopConfig()
+    return OuterLoopConfig.model_validate(section)

--- a/docs/plans/2026-05-19-outer-loop-config-consolidation.md
+++ b/docs/plans/2026-05-19-outer-loop-config-consolidation.md
@@ -76,7 +76,7 @@ source = "claude-cli"
 candidates_default = 15
 default_gen_tag    = "gen1"
 # 7 role × source binding 도 명시 가능
-# [outer_loop.seed_pipeline.role.generator]
+# [outer_loop.seed_pipeline.roles.generator]
 # model = "gpt-5.5"
 # source = "openai-codex"
 ```
@@ -115,7 +115,7 @@ Phase ε — backfill (필요 시)
 
 | PR | Title | Defects / scope | LOC | Files (예상) | Blocking |
 |---|---|---|---|---|---|
-| **PR-α1** | feat(config): outer_loop schema + loader (pydantic) | 신규 | ~250 | `core/config/outer_loop.py` (NEW), `core/paths.py` (확장), `tests/core/config/test_outer_loop.py` | — |
+| **PR-α1** ✅ | feat(config): outer_loop schema + loader (pydantic) | 신규 | ~360 | `core/config/outer_loop.py` (NEW), `tests/test_outer_loop_config.py` (NEW, 16 tests) | — |
 | **PR-β1** | feat(petri): subscription-only guard + abort path | 사용자 directive | ~150 | `plugins/petri_audit/petri.plugin.toml` (allowed 단일화), `plugins/petri_audit/credential_source.py` (fallback flag 점검), abort msg formatter, tests | PR-α1 |
 | **PR-γ1** | feat(cli): 3-tier quota banner + abort dialog | UX | ~200 | `core/cli/quota_banner.py` (NEW), `core/cli/repl.py` integration, abort dialog template, tests | PR-β1 |
 | **PR-δ1** | refactor(autoresearch): consume outer_loop config | migration | ~150 | `autoresearch/train.py` (module 상수 → config lazy load with default fallback), tests, program.md doc sync | PR-α1 |

--- a/tests/test_outer_loop_config.py
+++ b/tests/test_outer_loop_config.py
@@ -1,0 +1,298 @@
+"""Tests for ``core/config/outer_loop.py`` — single SoT loader for the
+``~/.geode/config.toml`` ``[outer_loop.*]`` section.
+
+Covers schema defaults, sub-config defaults, missing-file fallback,
+empty-section fallback, env override (``GEODE_CONFIG_TOML``), explicit
+path argument, ``extra='forbid'`` typo guard, threshold validation
+(abort > warn), and per-role binding deserialisation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.config.outer_loop import (
+    AutoresearchConfig,
+    OuterLoopBindings,
+    OuterLoopConfig,
+    PetriRoleConfig,
+    SeedPipelineConfig,
+    load_outer_loop_config,
+)
+
+
+def _write_toml(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_default_config_has_safe_defaults() -> None:
+    """OuterLoopConfig() with no input yields strict-mode safe defaults."""
+    cfg = OuterLoopConfig()
+    assert cfg.fallback_to_payg is False  # strict default
+    assert cfg.warn_threshold == pytest.approx(0.5)
+    assert cfg.abort_threshold == pytest.approx(0.9)
+    assert isinstance(cfg.autoresearch, AutoresearchConfig)
+    assert isinstance(cfg.seed_pipeline, SeedPipelineConfig)
+    assert cfg.petri == {}
+
+
+def test_autoresearch_defaults_match_train_module() -> None:
+    """Defaults mirror the existing autoresearch/train.py module constants."""
+    a = AutoresearchConfig()
+    assert a.budget_minutes == 5
+    assert a.target_model == "geode/gpt-5.5"
+    assert a.judge_model == "claude-code/opus"
+    assert a.use_oauth is True
+    assert a.seed_limit == 10
+    assert a.seed_select == "plugins/petri_audit/seeds"
+    assert a.dim_set == "5axes"
+    assert a.max_turns == 10
+    assert a.fallback_to_payg is None
+
+
+def test_load_returns_defaults_when_file_missing(tmp_path: Path) -> None:
+    """Missing file → fully-defaulted OuterLoopConfig, no error."""
+    cfg = load_outer_loop_config(tmp_path / "nonexistent.toml")
+    assert cfg == OuterLoopConfig()
+
+
+def test_load_returns_defaults_when_section_missing(tmp_path: Path) -> None:
+    """Existing file without [outer_loop] section → defaults."""
+    path = tmp_path / "config.toml"
+    _write_toml(path, "[settings]\nfoo = 'bar'\n")
+    cfg = load_outer_loop_config(path)
+    assert cfg == OuterLoopConfig()
+
+
+def test_load_reads_outer_loop_section(tmp_path: Path) -> None:
+    """[outer_loop] section keys override defaults."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop]
+fallback_to_payg = true
+warn_threshold = 0.6
+abort_threshold = 0.95
+""",
+    )
+    cfg = load_outer_loop_config(path)
+    assert cfg.fallback_to_payg is True
+    assert cfg.warn_threshold == pytest.approx(0.6)
+    assert cfg.abort_threshold == pytest.approx(0.95)
+
+
+def test_load_reads_autoresearch_subsection(tmp_path: Path) -> None:
+    """[outer_loop.autoresearch] section deserialises into AutoresearchConfig."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop.autoresearch]
+target_model = "geode/claude-opus-4-7"
+judge_model = "claude-code/sonnet"
+budget_minutes = 10
+seed_limit = 25
+""",
+    )
+    cfg = load_outer_loop_config(path)
+    assert cfg.autoresearch.target_model == "geode/claude-opus-4-7"
+    assert cfg.autoresearch.judge_model == "claude-code/sonnet"
+    assert cfg.autoresearch.budget_minutes == 10
+    assert cfg.autoresearch.seed_limit == 25
+    # Untouched fields keep defaults.
+    assert cfg.autoresearch.use_oauth is True
+
+
+def test_load_reads_petri_role_bindings(tmp_path: Path) -> None:
+    """[outer_loop.petri.<role>] keys become PetriRoleConfig entries."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop.petri.auditor]
+model = "claude-sonnet-4-6"
+source = "claude-cli"
+
+[outer_loop.petri.target]
+model = "geode/gpt-5.5"
+source = "openai-codex"
+
+[outer_loop.petri.judge]
+model = "claude-opus-4-7"
+source = "claude-cli"
+""",
+    )
+    cfg = load_outer_loop_config(path)
+    assert set(cfg.petri) == {"auditor", "target", "judge"}
+    assert cfg.petri["auditor"].model == "claude-sonnet-4-6"
+    assert cfg.petri["auditor"].source == "claude-cli"
+    assert cfg.petri["target"].source == "openai-codex"
+    assert cfg.petri["judge"].model == "claude-opus-4-7"
+
+
+def test_load_reads_seed_pipeline_subsection(tmp_path: Path) -> None:
+    """[outer_loop.seed_pipeline] + nested role bindings deserialise."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop.seed_pipeline]
+candidates_default = 20
+default_gen_tag = "gen3"
+
+[outer_loop.seed_pipeline.roles.generator]
+model = "gpt-5.5"
+source = "openai-codex"
+""",
+    )
+    cfg = load_outer_loop_config(path)
+    assert cfg.seed_pipeline.candidates_default == 20
+    assert cfg.seed_pipeline.default_gen_tag == "gen3"
+    assert cfg.seed_pipeline.roles["generator"].model == "gpt-5.5"
+
+
+def test_extra_forbid_rejects_typo(tmp_path: Path) -> None:
+    """Unknown field at top level → pydantic ValidationError."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop]
+falback_to_payg = true
+""",
+    )
+    with pytest.raises(Exception) as exc_info:
+        load_outer_loop_config(path)
+    assert "falback_to_payg" in str(exc_info.value)
+
+
+def test_extra_forbid_rejects_typo_in_autoresearch(tmp_path: Path) -> None:
+    """Unknown field in [outer_loop.autoresearch] → ValidationError."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop.autoresearch]
+budget_minute = 5
+""",
+    )
+    with pytest.raises(Exception) as exc_info:
+        load_outer_loop_config(path)
+    assert "budget_minute" in str(exc_info.value)
+
+
+def test_abort_threshold_must_exceed_warn(tmp_path: Path) -> None:
+    """abort_threshold ≤ warn_threshold → ValidationError."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop]
+warn_threshold = 0.8
+abort_threshold = 0.7
+""",
+    )
+    with pytest.raises(Exception) as exc_info:
+        load_outer_loop_config(path)
+    assert "abort_threshold" in str(exc_info.value)
+
+
+def test_threshold_range_clamps(tmp_path: Path) -> None:
+    """warn / abort thresholds outside [0, 1] are rejected."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop]
+warn_threshold = 1.5
+""",
+    )
+    with pytest.raises(Exception):
+        load_outer_loop_config(path)
+
+
+def test_env_override_resolves_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GEODE_CONFIG_TOML env var redirects the loader."""
+    path = tmp_path / "alt.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop]
+warn_threshold = 0.42
+""",
+    )
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(path))
+    cfg = load_outer_loop_config()
+    assert cfg.warn_threshold == pytest.approx(0.42)
+
+
+def test_explicit_path_arg_wins_over_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit path argument trumps GEODE_CONFIG_TOML env var."""
+    env_path = tmp_path / "env.toml"
+    arg_path = tmp_path / "arg.toml"
+    _write_toml(env_path, "[outer_loop]\nwarn_threshold = 0.1\n")
+    _write_toml(arg_path, "[outer_loop]\nwarn_threshold = 0.9\n")
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(env_path))
+    # abort_threshold must remain > warn so reduce abort and bump warn:
+    # write a valid file at arg_path.
+    _write_toml(arg_path, "[outer_loop]\nwarn_threshold = 0.5\nabort_threshold = 0.9\n")
+    cfg = load_outer_loop_config(arg_path)
+    assert cfg.warn_threshold == pytest.approx(0.5)
+
+
+def test_bindings_dataclass_round_trip() -> None:
+    """OuterLoopBindings serialises both ways without loss."""
+    b = OuterLoopBindings(model="x", source="claude-cli", fallback_to_payg=True)
+    assert b.model == "x"
+    assert b.source == "claude-cli"
+    assert b.fallback_to_payg is True
+
+
+def test_petri_role_default_source_is_auto() -> None:
+    """PetriRoleConfig without explicit source picks 'auto' default."""
+    p = PetriRoleConfig(model="claude-sonnet-4-6")
+    assert p.source == "auto"
+
+
+def test_load_handles_empty_outer_loop_section(tmp_path: Path) -> None:
+    """File with `[outer_loop]` but no body → defaults (model_validator must
+    not reject the default-vs-default threshold pair)."""
+    path = tmp_path / "config.toml"
+    _write_toml(path, "[outer_loop]\n")
+    cfg = load_outer_loop_config(path)
+    assert cfg == OuterLoopConfig()
+
+
+def test_threshold_inversion_caught_when_only_warn_set(tmp_path: Path) -> None:
+    """If user raises warn_threshold past the default abort_threshold without
+    moving abort, model_validator must catch the inversion. ``field_validator``
+    misses this case because it only fires when abort is explicitly set."""
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[outer_loop]
+warn_threshold = 0.95
+""",
+    )
+    with pytest.raises(Exception) as exc_info:
+        load_outer_loop_config(path)
+    assert "abort_threshold" in str(exc_info.value)
+
+
+def test_default_path_resolves_to_global_config_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without explicit path or env override, the loader resolves to
+    ``core.paths.GLOBAL_CONFIG_TOML``."""
+    import core.config.outer_loop as mod
+
+    monkeypatch.delenv("GEODE_CONFIG_TOML", raising=False)
+    fake = tmp_path / "global.toml"
+    _write_toml(fake, "[outer_loop]\nwarn_threshold = 0.33\n")
+    monkeypatch.setattr(mod, "GLOBAL_CONFIG_TOML", fake)
+    cfg = load_outer_loop_config()
+    assert cfg.warn_threshold == pytest.approx(0.33)


### PR DESCRIPTION
## Summary
- `core/config/outer_loop.py` (NEW) — pydantic v2 `OuterLoopConfig` root + 4 sub-models, `extra='forbid'` typo guard, `model_validator` 가 `abort > warn` 강제 (default-vs-user 조합도 cover)
- `load_outer_loop_config(path?)` — `~/.geode/config.toml [outer_loop.*]` section 읽기. precedence: 명시적 arg → `GEODE_CONFIG_TOML` env → `GLOBAL_CONFIG_TOML`. missing/empty → 기본값
- AutoresearchConfig 기본값이 `autoresearch/train.py` module 상수와 일치 → PR-δ1 의 caller migration 은 no-op behaviour change

## Why
2026-05-19 outer-loop config consolidation plan Phase α — 모든 후속 PR (β/γ/δ) 가 의존하는 foundation. 사용자 directive "설정은 SOT 로 단일화" 의 첫 step.

이전 8 surface 분산을 단일 `[outer_loop.*]` section 으로 모으려면 typed loader 가 먼저 있어야 함. pydantic v2 + `extra='forbid'` 로 사용자 typo 즉시 reject (e.g. `falback_to_payg` 오타).

## Changes
| File | Change |
|------|--------|
| `core/config/outer_loop.py` (NEW) | OuterLoopConfig + AutoresearchConfig + PetriRoleConfig + SeedPipelineConfig + OuterLoopBindings + load_outer_loop_config |
| `tests/test_outer_loop_config.py` (NEW) | 19 unit tests |
| `CHANGELOG.md` | `[Unreleased] > Added` PR-α1 항목 |
| `docs/plans/...` | PR-α1 ✅, `roles` 키 plural 통일 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Schema 정의 (plan 의 settled decisions table) | Implemented | fallback_to_payg=False default + warn 0.5 + abort 0.9 |
| autoresearch defaults mirror | Verified | train.py module 상수와 일치 (PR-δ1 의 no-op migration 위해 핵심) |
| extra='forbid' typo guard | Implemented | top-level + sub-section 모두 적용 |
| Threshold validator (default-vs-user 케이스) | Codex round 1 catch → fixed | `field_validator` → `model_validator(mode='after')` 전환 |
| Precedence (explicit/env/global) | Implemented | 3 단계 fallback |
| Missing/empty file/section fallback | Implemented | 모두 OuterLoopConfig() 반환 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` clean
- [x] `uv run ruff format --check ...` clean
- [x] `uv run mypy core/ plugins/ autoresearch/` clean (352 source files)
- [x] `uv run pytest tests/test_outer_loop_config.py` → 19 passed
- [x] Codex MCP audit round 1: HIGH default-vs-user threshold inversion + MEDIUM plan plural/singular + LOW 누락 test 모두 round 2 PASS

## Reference
- Plan: `docs/plans/2026-05-19-outer-loop-config-consolidation.md` Phase α 의 PR-α1
- Predecessor: PR #1307 (plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)