### PR TITLE
fix(cli): LaTeX bracket fallback — single-letter uppercase base 완화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ functional change.
 
 ### Fixed
 
+- **CLI LaTeX single-letter uppercase subscript fallback.** `P_T`,
+  `A_B`, `R_T` 처럼 base 가 단일 대문자 Latin 변수이고 payload 도 대문자
+  Latin 인 delimiter-less script 는 Unicode subscript codepoint 가 없을 때
+  bracket fallback 으로 `P[T]` / `A[B]` / `R[T]` 로 표시합니다.
+  `IBM_T` 같은 acronym base, `snake_case`, `alpha_beta`, Markdown code/path
+  guard, 그리고 `P_t` / `x^T` 의 기존 Unicode script 경로는 유지됩니다.
+- **CLI LaTeX single-letter uppercase subscript fallback.** Delimiter-less
+  scripts whose base is one uppercase Latin variable and whose payload is
+  uppercase Latin now use the existing bracket fallback when Unicode lacks the
+  script codepoint, so `P_T`, `A_B`, and `R_T` render as `P[T]`, `A[B]`, and
+  `R[T]`. Acronym bases such as `IBM_T`, plain identifiers such as
+  `snake_case` and `alpha_beta`, Markdown code/path guards, and existing
+  Unicode script paths such as `P_t` and `x^T` remain unchanged.
+
 - **Agentic tool executor wiring.** Restored `generate_report` and `export_json`
   in the AgenticLoop `ToolExecutor` handler map, added the missing generic
   `generate_data` implementation, and added a regression check that every

--- a/core/ui/latex.py
+++ b/core/ui/latex.py
@@ -349,7 +349,10 @@ def _unsupported_script_presentation(
     has_partial_mapping = any(ch is not None for ch in mapped)
     if has_partial_mapping and mapped.count(None) > len(mapped) // 2:
         return None
-    if not has_partial_mapping and not _script_base_looks_math(text, match.start()):
+    if not has_partial_mapping and not (
+        _script_base_looks_math(text, match.start())
+        or _has_single_uppercase_latin_base_script(text, match.start(), token)
+    ):
         return None
 
     # Unicode has no uppercase Latin subscript alphabet. Bracketing preserves
@@ -373,6 +376,20 @@ def _script_base_looks_math(text: str, marker_start: int) -> bool:
     while left > 0 and text[left - 1].isalpha():
         left -= 1
     return text[left:marker_start] in _GREEK_WORD_BASES
+
+
+def _has_single_uppercase_latin_base_script(text: str, marker_start: int, token: str) -> bool:
+    """True for unsupported uppercase scripts on a one-letter Latin variable."""
+    if marker_start <= 0:
+        return False
+    prev = text[marker_start - 1]
+    if not ("A" <= prev <= "Z"):
+        return False
+    if not token or not all("A" <= ch <= "Z" for ch in token):
+        return False
+    # Relax only for single-letter variables like P_T; multi-letter acronym
+    # bases such as IBM_T remain raw prose/identifier text.
+    return marker_start == 1 or not text[marker_start - 2].isalnum()
 
 
 def _render_tier1(src: str) -> str:

--- a/tests/test_cli_latex_uiux.py
+++ b/tests/test_cli_latex_uiux.py
@@ -200,11 +200,15 @@ class TestStageAComponent:
         assert "Eᵢ" in output
 
     def test_delimiterless_uppercase_subscript_uses_bracket_presentation(self) -> None:
-        output = _render_through_helper("τ_P = τ_T + τ_A")
+        output = _render_through_helper("τ_P = τ_T + τ_A + P_T + A_B + R_T")
         assert "τ[P]" in output
         assert "τ[T]" in output
         assert "τ[A]" in output
+        assert "P[T]" in output
+        assert "A[B]" in output
+        assert "R[T]" in output
         assert "τ_P" not in output
+        assert "P_T" not in output
 
     def test_delimiterless_plain_snake_case_stays_text(self) -> None:
         output = _render_through_helper("snake_case_var and 1_000")

--- a/tests/test_ui_latex.py
+++ b/tests/test_ui_latex.py
@@ -74,6 +74,26 @@ class TestTier1Unicode:
     def test_unsupported_uppercase_subscript_uses_bracket_presentation(self) -> None:
         assert _render_tier1("τ_P") == "τ[P]"
         assert _render_tier1("tau_P") == "tau[P]"
+        assert _render_tier1("P_T") == "P[T]"
+        assert _render_tier1("A_B") == "A[B]"
+        assert _render_tier1("R_T") == "R[T]"
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("P_t", "Pₜ"),
+            ("tau_P", "tau[P]"),
+            ("IBM_T", "IBM_T"),
+            ("alpha_beta", "alpha_beta"),
+            ("snake_case", "snake_case"),
+            ("X^*", "X^*"),
+            ("x^T", "xᵀ"),
+            ("lambda_max", "lambdaₘₐₓ"),
+            ("lambda_min", "lambdaₘᵢₙ"),
+        ],
+    )
+    def test_script_regressions_stay_on_existing_paths(self, source: str, expected: str) -> None:
+        assert _render_tier1(source) == expected
 
     def test_empty_string(self) -> None:
         assert render_latex("").plain == ""


### PR DESCRIPTION
## Summary
- `P_T`, `A_B`, `R_T` 같은 single uppercase Latin base + uppercase subscript 케이스에 bracket fallback (`P[T]`) 적용
- `IBM_T` (multi-letter acronym), `tau_P` (Greek word base), `snake_case` 는 그대로 보호
- LaTeX nested code-block edge case (PR #1193 LOW concern) → probe 결과 false alarm, 코드 변경 없음
- Codex MCP cross-LLM verify 통과

## Why
probe (Session 2026-05-19): `P_T` → `P_T` raw 노출. Codex (PR #1193) 가 snake_case false-positive 우려로 bracket fallback gate 를 `_script_base_looks_math` 로 좁힘 (Greek/math 만 통과). single-letter uppercase Latin base 는 변수 표기가 명백 → 안전하게 완화 가능.

## Changes
| File | Change |
|------|--------|
| `core/ui/latex.py` | `_has_single_uppercase_latin_base_script()` helper + bracket fallback gate 확장 |
| `tests/test_ui_latex.py` | `P_T`/`A_B`/`R_T` 변환 + `IBM_T` acronym regression |
| `tests/test_cli_latex_uiux.py` | end-to-end coverage |
| `CHANGELOG.md` | `[Unreleased]` Fixed (KR/EN) |

## Behavior Delta
| Input | Before | After |
|---|---|---|
| `P_T` | `P_T` raw | `P[T]` |
| `A_B` | `A_B` raw | `A[B]` |
| `R_T` | `R_T` raw | `R[T]` |
| `P_t` | `Pₜ` | unchanged |
| `tau_P` | `tau[P]` | unchanged |
| `IBM_T` | text | unchanged (acronym 보호) |
| `alpha_beta`, `snake_case` | text | unchanged |
| `X^*` | atomic raw | unchanged (asterisk 미존재) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| single-letter uppercase Latin base bracket | Implemented | gate predicate: `[A-Z]` base + `[A-Z]` payload + non-alnum left |
| Multi-letter acronym 보호 | Verified | `IBM_T` 그대로 |
| 기존 Greek word base, snake_case false-positive 없음 | Verified | 105 passed |
| LaTeX nested code-block | Dropped | probe 결과 false alarm, 별도 fix 불필요 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean (638 files)
- [x] `uv run mypy core/ plugins/` clean (351 files)
- [x] `uv run pytest tests/test_ui_latex.py tests/test_cli_latex_uiux.py` 105 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)

## Reference
- Series: 8th fix in CLI rendering session. 이전 7: #1179/#1180/#1181/#1185/#1193/#1196/#1199 + audit #1304
- probe + 진단 — Session 2026-05-19 transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)