### PR TITLE
ci(petri): isolate bundle integrity from site build + deepen validator

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -126,6 +126,24 @@ jobs:
           cache: npm
           cache-dependency-path: site/package-lock.json
 
+      # Run the petri ratchet BEFORE npm install/build. A corrupt bundle
+      # must fail fast and independently of the Next.js build — that way a
+      # site build failure (unrelated to petri) doesn't mask a regression
+      # in the published archives, and a bundle regression doesn't waste a
+      # full site build. See .github/workflows/petri-publish.yml for the
+      # PR-gate counterpart.
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Sync dev group (zipfile-zstd for validator)
+        working-directory: ${{ github.workspace }}
+        run: uv sync
+
+      - name: Validate docs/petri-bundle (deep — pre-build gate)
+        working-directory: ${{ github.workspace }}
+        run: uv run python scripts/validate_petri_bundle.py
+
       - name: Sync GEODE stats into site SOT
         run: npm run sync-stats
         env:
@@ -136,10 +154,6 @@ jobs:
 
       - name: Build static export
         run: npm run build
-
-      - name: Validate docs/petri-bundle before publish
-        working-directory: ${{ github.workspace }}
-        run: python3 scripts/validate_petri_bundle.py
 
       - name: Copy docs/petri-bundle into site/out
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/petri-publish.yml
+++ b/.github/workflows/petri-publish.yml
@@ -1,0 +1,81 @@
+name: Petri bundle integrity
+
+# Isolation layer for the Petri × GEODE benchmark bundle published at
+# https://mangowhoiscloud.github.io/geode/petri-bundle/.
+#
+# Why this exists separately from pages.yml:
+#   pages.yml bundles site/ + docs/petri-bundle/ into one Pages artifact.
+#   When a non-petri PR touches site/, pages.yml's *build* job exercises
+#   the petri ratchet, but only if the path-filter in ci.yml or pages.yml
+#   matches. This workflow makes the petri ratchet unconditional — it runs
+#   on every PR that touches the bundle, the validator, the hygiene
+#   ratchet, or this workflow file itself, plus a daily cron + manual
+#   dispatch. Site-build failures cannot mask a corrupt bundle.
+#
+# It does NOT deploy. The actual Pages publish stays in pages.yml so we
+# keep a single artifact source. This workflow is a hard *guardrail*: if
+# it fails on a PR, the bundle change must be fixed before merging,
+# regardless of the site build outcome.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "docs/petri-bundle/**"
+      - "scripts/validate_petri_bundle.py"
+      - "scripts/check_repo_hygiene.py"
+      - ".github/workflows/petri-publish.yml"
+  pull_request:
+    paths:
+      - "docs/petri-bundle/**"
+      - "scripts/validate_petri_bundle.py"
+      - "scripts/check_repo_hygiene.py"
+      - ".github/workflows/petri-publish.yml"
+  schedule:
+    # 09:00 KST = 00:00 UTC. Daily integrity check independent of pages.yml.
+    - cron: "30 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: petri-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Sync dev group
+        # `zipfile-zstd` lives in the dev group so the validator can open
+        # zstd-compressed .eval archives without pulling the heavy [audit]
+        # extra.
+        run: uv sync
+
+      - name: Hygiene ratchet (petri delete-protection)
+        run: uv run python scripts/check_repo_hygiene.py
+
+      - name: Validator (deep — listing + zip + scores + assets)
+        run: uv run python scripts/validate_petri_bundle.py
+
+      - name: Diff vs main (regression sentinel)
+        # On PRs: warn if any .eval file vanished compared to main. The
+        # hygiene ratchet already enforces the count floor; this surfaces
+        # the specific name(s) for the PR reviewer.
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          base="origin/${{ github.base_ref }}"
+          missing=$(git diff --name-only --diff-filter=D "${base}"...HEAD \
+            -- 'docs/petri-bundle/logs/*.eval' 'docs/petri-bundle/assets/**' || true)
+          if [ -n "${missing}" ]; then
+            echo "::warning::Petri bundle files removed vs ${base}:"
+            echo "${missing}" | sed 's/^/::warning:: - /'
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,36 @@ functional change.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **Petri bundle isolation.** Split the petri-bundle integrity gate out of
+  `pages.yml` into a dedicated `.github/workflows/petri-publish.yml`
+  workflow so a non-petri site-build failure can no longer mask a corrupt
+  bundle and vice versa. The new workflow runs on every PR that touches
+  `docs/petri-bundle/**`, `scripts/validate_petri_bundle.py`,
+  `scripts/check_repo_hygiene.py`, or the workflow file itself, plus a
+  daily 00:30 UTC cron and `workflow_dispatch`. The deploy still goes
+  through `pages.yml` (single Pages artifact source), but the validator
+  now runs **before** `npm install/build` in that workflow too — a bundle
+  regression aborts the deploy at the cheapest possible step. PR-gate
+  also emits a regression warning when any `.eval` or `assets/**` file
+  was deleted vs the base branch.
+- **Deeper bundle validator.** `scripts/validate_petri_bundle.py` now
+  opens each `.eval` zip and rejects: `header.results=None`, empty
+  `results.scores[]`, any score with empty `metrics`, missing
+  `header.json`, bad zip data, and missing top-level viewer assets
+  (`index.html` + `assets/index.js` + `assets/index.css`). These are the
+  exact triggers behind the click-time `formatPrettyDecimal(g.metrics[i]
+  .value)` TypeError in inspect_ai #1747. Backed by 13 unit tests in
+  `tests/test_validate_petri_bundle.py`. New `zipfile-zstd` dev-group
+  dependency (Python 3.14+ no-op shim) keeps the validator pure-stdlib
+  on the lint path — no `[audit]` extra required.
+- **Petri bundle delete-protection ratchet.** `check_repo_hygiene.py`
+  enforces a `PETRI_EVAL_FLOOR = 9` lower bound on
+  `docs/petri-bundle/logs/*.eval` count. Any PR that drops bundle
+  archives must lower the floor in the same change (Karpathy P4 explicit-
+  action ratchet), preventing silent deletions during unrelated refactors.
+
 ### Fixed
 
 - **Agentic tool executor wiring.** Restored `generate_report` and `export_json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,10 @@ dev = [
     "ruff>=0.15.2",
     "twine>=6.0.0",
     "types-pyyaml>=6.0.12.20250915",
+    # Adds zstd support to stdlib zipfile so scripts/validate_petri_bundle.py
+    # can open Petri .eval archives without the heavy [audit] extra.
+    # Python 3.14+ has native zstd in zipfile and this becomes a no-op shim.
+    "zipfile-zstd>=0.0.4",
 ]
 
 

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""CI ratchet: reject repo-shape regressions (dangling/absolute symlinks, orphan worktrees).
+"""CI ratchet: reject repo-shape regressions.
+
+Checks
+------
+- Dangling symlinks (target does not exist).
+- Absolute symlinks (path leaks to a specific machine).
+- Orphan worktrees (.claude/worktrees/<name>/ missing .owner).
+- Petri bundle file-count ratchet — guards docs/petri-bundle/logs/*.eval
+  against accidental deletion during non-petri refactors. The PR that
+  drops bundle archives must also lower the floor here, making the
+  removal explicit (Karpathy P4 Ratchet).
 
 Usage:
     python scripts/check_repo_hygiene.py
@@ -12,6 +22,12 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+
+# Lower bound for archive files under docs/petri-bundle/logs/. Pinned to
+# the count present on main (9 .eval archives, see audits PR #1130). Raise
+# this number when adding archives; lowering it requires explicit review.
+PETRI_EVAL_FLOOR = 9
+PETRI_LOGS_DIR = Path("docs/petri-bundle/logs")
 
 EXCLUDED_DIRS: frozenset[tuple[str, ...]] = frozenset(
     {
@@ -69,6 +85,22 @@ def find_absolute_symlinks(root: Path) -> list[tuple[Path, str]]:
     return result
 
 
+def check_petri_eval_floor(root: Path) -> tuple[int, int] | None:
+    """Return (found, floor) when below the petri archive floor, else None.
+
+    Returns None if the bundle directory is absent (fresh clones for unrelated
+    work shouldn't fail). The validator script enforces correctness when the
+    bundle is present; this ratchet only catches deletions.
+    """
+    logs_dir = root / PETRI_LOGS_DIR
+    if not logs_dir.is_dir():
+        return None
+    count = sum(1 for entry in logs_dir.iterdir() if entry.is_file() and entry.suffix == ".eval")
+    if count < PETRI_EVAL_FLOOR:
+        return (count, PETRI_EVAL_FLOOR)
+    return None
+
+
 def find_orphan_worktrees(root: Path) -> list[Path]:
     """Return each .claude/worktrees/<name>/ directory missing an `.owner` file."""
     worktrees_dir = root / ".claude" / "worktrees"
@@ -88,8 +120,9 @@ def format_report(
     dangling: list[tuple[Path, str]],
     absolute: list[tuple[Path, str]],
     orphans: list[Path],
+    petri_shortfall: tuple[int, int] | None,
 ) -> str:
-    total = len(dangling) + len(absolute) + len(orphans)
+    total = len(dangling) + len(absolute) + len(orphans) + (1 if petri_shortfall else 0)
     if total == 0:
         return ""
     lines = [f"Repo hygiene check: {total} issues", ""]
@@ -110,6 +143,17 @@ def format_report(
             lines.append(f"  {path.relative_to(root)}/")
             lines.append("    hint: missing .owner file; remove worktree or add .owner")
         lines.append("")
+    if petri_shortfall:
+        found, floor = petri_shortfall
+        lines.append("[petri bundle deletion]")
+        lines.append(
+            f"  {PETRI_LOGS_DIR}/ has {found} .eval archive(s); floor is {floor}.",
+        )
+        lines.append(
+            "    hint: dropping archives must lower PETRI_EVAL_FLOOR in this script "
+            "in the same PR (explicit-action ratchet).",
+        )
+        lines.append("")
     return "\n".join(lines)
 
 
@@ -118,7 +162,8 @@ def main() -> int:
     dangling = find_dangling_symlinks(root)
     absolute = find_absolute_symlinks(root)
     orphans = find_orphan_worktrees(root)
-    report = format_report(root, dangling, absolute, orphans)
+    petri_shortfall = check_petri_eval_floor(root)
+    report = format_report(root, dangling, absolute, orphans, petri_shortfall)
     if report:
         print(report, file=sys.stderr)
         return 1

--- a/scripts/validate_petri_bundle.py
+++ b/scripts/validate_petri_bundle.py
@@ -3,22 +3,32 @@
 
 Used as a **CI ratchet** — invoked from both ``.github/workflows/ci.yml``
 (PR gate, blocks merge) and ``.github/workflows/pages.yml`` (post-merge
-defense-in-depth). Either layer alone is insufficient: CI catches PRs
-before merge, pages.yml catches drift from cron-triggered rebuilds.
+defense-in-depth) and the dedicated ``.github/workflows/petri-publish.yml``
+guardrail. Each layer alone is insufficient: CI catches PRs before merge,
+pages.yml catches drift from cron-triggered rebuilds, and petri-publish.yml
+is the isolation layer that runs even when the site build is skipped.
 
 Enforces:
-1. Every listing.json entry has status='success'.
-2. Every referenced .eval file exists on disk.
-3. No partial run (status='started') or error (status='error') leaks into
-   the published bundle — both can trigger viewer TypeError on
-   ``formatPrettyDecimal(g.metrics[i].value)`` when results=None
-   (inspect_ai #1747 pattern).
+1. listing.json present + parses.
+2. Every listing entry has status='success'.
+3. Every referenced .eval file exists on disk.
+4. Inside each .eval zip:
+   - header.json present + parses.
+   - header.status == 'success'.
+   - header.results is a non-empty dict with a non-empty scores[] list.
+   - Every score has a non-empty metrics field (dict or list).
+   These three checks together prevent the click-time TypeError seen in
+   inspect_ai #1747 — ``formatPrettyDecimal(g.metrics[i].value)`` blows up
+   when ``results`` is None or ``scores[].metrics`` is empty.
+5. Required asset files present (index.html + the JS bundle the viewer
+   loads on cold start). Missing assets = silent blank-page failure for
+   end users.
 
 Run from repo root:
     uv run python scripts/validate_petri_bundle.py
 
 Exit codes:
-    0  All listing entries are status=success and files exist.
+    0  Bundle is publishable.
     1  Validation failed; prints all offending entries.
 """
 
@@ -26,10 +36,101 @@ from __future__ import annotations
 
 import json
 import sys
+import zipfile
 from pathlib import Path
+
+# Petri .eval archives use zstd-compressed entries. Python 3.14 added native
+# zstd support to zipfile; on 3.12/3.13 we rely on the `zipfile-zstd`
+# monkey-patch shipped as a dev-group dependency. If neither is available,
+# fall back to a listing-only check (catches the most common regression —
+# deleted/renamed .eval files — but cannot validate archive internals).
+_ZSTD_AVAILABLE: bool
+try:
+    import zipfile_zstd  # type: ignore[import-untyped]  # noqa: F401 — patches zipfile
+
+    _ZSTD_AVAILABLE = True
+except ImportError:
+    _ZSTD_AVAILABLE = sys.version_info >= (3, 14)
 
 BUNDLE_DIR = Path("docs/petri-bundle")
 LISTING = BUNDLE_DIR / "logs" / "listing.json"
+ASSETS_DIR = BUNDLE_DIR / "assets"
+
+# index.html + the entry JS bundle Inspect ships. Hash-suffixed chunks
+# (chunk-*.js, lib-*.js, …) intentionally not pinned — they rotate every
+# viewer rebuild. The launcher pair below is enough to detect a wholesale
+# bundle wipe.
+REQUIRED_ASSET_NAMES: tuple[str, ...] = ("index.html",)
+REQUIRED_ASSET_GLOBS: tuple[tuple[str, str], ...] = (
+    ("assets", "index.js"),
+    ("assets", "index.css"),
+)
+
+
+def _check_eval_archive(path: Path) -> list[str]:
+    """Return a list of failure messages for a single .eval archive (empty if OK)."""
+    failures: list[str] = []
+    try:
+        with zipfile.ZipFile(path) as zf:
+            try:
+                with zf.open("header.json") as fh:
+                    header = json.load(fh)
+            except KeyError:
+                return [f"{path.name}: header.json missing inside archive"]
+            except json.JSONDecodeError as exc:
+                return [f"{path.name}: header.json is not valid JSON ({exc})"]
+
+            if not isinstance(header, dict):
+                return [f"{path.name}: header.json is not a JSON object"]
+
+            status = header.get("status")
+            if status != "success":
+                failures.append(f"{path.name}: header.status={status!r} (expected 'success')")
+
+            results = header.get("results")
+            if not isinstance(results, dict) or not results:
+                failures.append(
+                    f"{path.name}: header.results missing/empty — "
+                    "would trigger TypeError on row click",
+                )
+                return failures  # downstream checks meaningless without results
+
+            scores = results.get("scores")
+            if not isinstance(scores, list) or not scores:
+                failures.append(f"{path.name}: header.results.scores is missing or empty")
+                return failures
+
+            for idx, score in enumerate(scores):
+                if not isinstance(score, dict):
+                    failures.append(f"{path.name}: scores[{idx}] is not an object")
+                    continue
+                metrics = score.get("metrics")
+                if metrics is None or (hasattr(metrics, "__len__") and len(metrics) == 0):
+                    name = score.get("name") or score.get("scorer") or f"#{idx}"
+                    failures.append(
+                        f"{path.name}: scores[{idx}] ({name}) has empty metrics "
+                        "— viewer renders 0 columns",
+                    )
+    except zipfile.BadZipFile:
+        return [f"{path.name}: file is not a valid zip archive"]
+    except OSError as exc:
+        return [f"{path.name}: could not read archive ({exc})"]
+    return failures
+
+
+def _check_assets() -> list[str]:
+    """Return a list of failure messages for missing viewer assets."""
+    failures: list[str] = []
+    for name in REQUIRED_ASSET_NAMES:
+        if not (BUNDLE_DIR / name).is_file():
+            failures.append(f"asset missing: {BUNDLE_DIR / name}")
+    for parts in REQUIRED_ASSET_GLOBS:
+        path = BUNDLE_DIR
+        for p in parts:
+            path = path / p
+        if not path.is_file():
+            failures.append(f"asset missing: {path}")
+    return failures
 
 
 def main() -> int:
@@ -37,29 +138,54 @@ def main() -> int:
         print(f"FAIL: {LISTING} missing", file=sys.stderr)
         return 1
 
-    data: dict[str, dict[str, object]] = json.loads(LISTING.read_text())
-    failures: list[str] = []
+    try:
+        data: dict[str, dict[str, object]] = json.loads(LISTING.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: {LISTING} is not valid JSON: {exc}", file=sys.stderr)
+        return 1
 
+    failures: list[str] = _check_assets()
+
+    skipped_deep = False
     for name, entry in data.items():
         status = entry.get("status")
         if status != "success":
-            failures.append(f"{name}  status={status} (only 'success' is publishable)")
+            failures.append(f"{name}: listing.status={status!r} (only 'success' is publishable)")
             continue
         file_path = BUNDLE_DIR / "logs" / name
         if not file_path.exists():
-            failures.append(f"{name}  status=success but file missing on disk: {file_path}")
+            failures.append(
+                f"{name}: listing.status=success but file missing on disk ({file_path})"
+            )
+            continue
+        if _ZSTD_AVAILABLE:
+            failures.extend(_check_eval_archive(file_path))
+        else:
+            skipped_deep = True
+
+    if skipped_deep:
+        print(
+            "NOTICE: zstd backend unavailable — skipped archive-internal checks. "
+            "Install `zipfile-zstd` (dev group) or run on Python 3.14+ for full validation.",
+            file=sys.stderr,
+        )
 
     if failures:
-        print(f"FAIL: petri-bundle validation — {len(failures)} offending entry/entries:")
+        print(f"FAIL: petri-bundle validation — {len(failures)} issue(s):")
         for f in failures:
             print(f"  - {f}")
         print()
-        print("Remove offending entries from listing.json and the .eval files from")
-        print("docs/petri-bundle/logs/ before deploying. Partial/error archives can")
-        print("trigger viewer TypeError on null metric values (inspect_ai #1747 pattern).")
+        print("Fix paths:")
+        print("  - Remove offending entries from docs/petri-bundle/logs/listing.json")
+        print("    and the .eval files from docs/petri-bundle/logs/.")
+        print("  - Rebuild the viewer bundle via `inspect view bundle` if assets are missing.")
+        print("  - Partial/error/empty-results archives trigger click-time TypeError")
+        print("    (inspect_ai #1747 pattern).")
         return 1
 
-    print(f"OK: {len(data)} entries — all status=success, all files present.")
+    print(
+        f"OK: {len(data)} archive(s) — listing + zip header + scores + assets all valid.",
+    )
     return 0
 
 

--- a/tests/test_check_repo_hygiene.py
+++ b/tests/test_check_repo_hygiene.py
@@ -80,3 +80,33 @@ def test_release_venv_symlinks_ignored(tmp_path: Path) -> None:
 
     result = run_check(tmp_path)
     assert result.returncode == 0, result.stderr
+
+
+def test_petri_bundle_absent_passes(tmp_path: Path) -> None:
+    # No docs/petri-bundle/ directory at all → ratchet must not trip.
+    result = run_check(tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_petri_bundle_at_floor_passes(tmp_path: Path) -> None:
+    from scripts.check_repo_hygiene import PETRI_EVAL_FLOOR
+
+    logs = tmp_path / "docs" / "petri-bundle" / "logs"
+    logs.mkdir(parents=True)
+    for i in range(PETRI_EVAL_FLOOR):
+        (logs / f"archive-{i}.eval").write_bytes(b"placeholder")
+    result = run_check(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_petri_bundle_below_floor_fails(tmp_path: Path) -> None:
+    from scripts.check_repo_hygiene import PETRI_EVAL_FLOOR
+
+    logs = tmp_path / "docs" / "petri-bundle" / "logs"
+    logs.mkdir(parents=True)
+    for i in range(PETRI_EVAL_FLOOR - 1):
+        (logs / f"archive-{i}.eval").write_bytes(b"placeholder")
+    result = run_check(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "petri bundle deletion" in result.stderr
+    assert f"floor is {PETRI_EVAL_FLOOR}" in result.stderr

--- a/tests/test_validate_petri_bundle.py
+++ b/tests/test_validate_petri_bundle.py
@@ -1,0 +1,208 @@
+"""Unit tests for scripts/validate_petri_bundle.py ratchet.
+
+Validator gates the GitHub Pages deploy of docs/petri-bundle/. Failure modes
+exercised here mirror the regressions that previously broke the live viewer
+(PR #1129 partial archive, PR #1130 error archive, results=None TypeError).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "validate_petri_bundle.py"
+
+
+_VALID_HEADER: dict[str, object] = {
+    "version": 2,
+    "status": "success",
+    "eval": {"eval_id": "abc", "task": "inspect_petri/audit"},
+    "results": {
+        "total_samples": 1,
+        "completed_samples": 1,
+        "scores": [
+            {
+                "name": "demo",
+                "scorer": "audit_judge",
+                "metrics": {
+                    "mean": {"name": "mean", "value": 1.0, "params": {}},
+                    "stderr": {"name": "stderr", "value": 0.0, "params": {}},
+                },
+            }
+        ],
+    },
+}
+
+
+def _write_eval(path: Path, header: dict[str, object]) -> None:
+    """Create a minimal .eval (STORED-compression zip with header.json)."""
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("header.json", json.dumps(header))
+
+
+def _scaffold_bundle(root: Path, listing: dict[str, dict[str, object]]) -> Path:
+    """Build a minimal docs/petri-bundle/ scaffold under root."""
+    bundle = root / "docs" / "petri-bundle"
+    (bundle / "logs").mkdir(parents=True)
+    (bundle / "assets").mkdir(parents=True)
+    (bundle / "index.html").write_text("<html></html>")
+    (bundle / "assets" / "index.js").write_text("// noop")
+    (bundle / "assets" / "index.css").write_text("/* noop */")
+    (bundle / "logs" / "listing.json").write_text(json.dumps(listing))
+    return bundle
+
+
+def run_validator(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(SCRIPT)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_missing_listing_fails(tmp_path: Path) -> None:
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "missing" in result.stderr.lower()
+
+
+def test_listing_invalid_json_fails(tmp_path: Path) -> None:
+    bundle = tmp_path / "docs" / "petri-bundle" / "logs"
+    bundle.mkdir(parents=True)
+    (bundle / "listing.json").write_text("{not json")
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "not valid JSON" in result.stderr
+
+
+def test_status_started_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"partial.eval": {"status": "started"}},
+    )
+    (bundle / "logs" / "partial.eval").write_text("placeholder")
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "started" in result.stdout
+
+
+def test_status_error_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"broken.eval": {"status": "error"}},
+    )
+    (bundle / "logs" / "broken.eval").write_text("placeholder")
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "error" in result.stdout
+
+
+def test_missing_eval_file_fails(tmp_path: Path) -> None:
+    _scaffold_bundle(
+        tmp_path,
+        {"phantom.eval": {"status": "success"}},
+    )
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "missing on disk" in result.stdout
+
+
+def test_missing_asset_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(tmp_path, {})
+    (bundle / "index.html").unlink()
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "asset missing" in result.stdout
+
+
+def test_valid_bundle_passes(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"good.eval": {"status": "success"}},
+    )
+    _write_eval(bundle / "logs" / "good.eval", _VALID_HEADER)
+    result = run_validator(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK:" in result.stdout
+
+
+def test_archive_results_none_fails(tmp_path: Path) -> None:
+    """Empty results = the inspect_ai #1747 TypeError trigger."""
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"empty.eval": {"status": "success"}},
+    )
+    bad_header = {**_VALID_HEADER, "results": None}
+    _write_eval(bundle / "logs" / "empty.eval", bad_header)
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "results missing" in result.stdout or "results.scores" in result.stdout
+
+
+def test_archive_empty_scores_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"noscores.eval": {"status": "success"}},
+    )
+    bad_header = {**_VALID_HEADER, "results": {"scores": []}}
+    _write_eval(bundle / "logs" / "noscores.eval", bad_header)
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "scores" in result.stdout
+
+
+def test_archive_empty_metrics_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"nometrics.eval": {"status": "success"}},
+    )
+    bad_header = {
+        **_VALID_HEADER,
+        "results": {
+            "scores": [{"name": "demo", "scorer": "audit_judge", "metrics": {}}],
+        },
+    }
+    _write_eval(bundle / "logs" / "nometrics.eval", bad_header)
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "metrics" in result.stdout
+
+
+def test_archive_bad_zip_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"corrupt.eval": {"status": "success"}},
+    )
+    (bundle / "logs" / "corrupt.eval").write_bytes(b"\x00\x01not-a-zip")
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "zip" in result.stdout.lower()
+
+
+def test_archive_header_missing_inside_fails(tmp_path: Path) -> None:
+    bundle = _scaffold_bundle(
+        tmp_path,
+        {"noheader.eval": {"status": "success"}},
+    )
+    # zip with no header.json entry
+    with zipfile.ZipFile(bundle / "logs" / "noheader.eval", "w") as zf:
+        zf.writestr("summaries.json", "[]")
+    result = run_validator(tmp_path)
+    assert result.returncode == 1
+    assert "header.json missing" in result.stdout
+
+
+def test_real_bundle_passes() -> None:
+    """Smoke test against the committed bundle. Guards against silent drift."""
+    repo_root = Path(__file__).resolve().parent.parent
+    if not (repo_root / "docs" / "petri-bundle" / "logs" / "listing.json").exists():
+        pytest.skip("petri-bundle not present in this checkout")
+    result = run_validator(repo_root)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1258,6 +1258,7 @@ dev = [
     { name = "twine" },
     { name = "types-pyyaml" },
     { name = "yamllint" },
+    { name = "zipfile-zstd" },
 ]
 
 [package.metadata]
@@ -1314,6 +1315,7 @@ dev = [
     { name = "twine", specifier = ">=6.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "yamllint", specifier = ">=1.38.0" },
+    { name = "zipfile-zstd", specifier = ">=0.0.4" },
 ]
 
 [[package]]
@@ -5966,7 +5968,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Split petri-bundle integrity gate out of `pages.yml` into a dedicated `petri-publish.yml` workflow so the site build cannot mask bundle regressions and vice versa.
- Validator now opens each `.eval` zip and rejects every known trigger of the click-time `formatPrettyDecimal(g.metrics[i].value)` TypeError (inspect_ai #1747), backed by 13 unit tests.
- Hygiene ratchet enforces a minimum count of bundle `.eval` archives — accidental deletes by unrelated PRs now hard-fail the gate.

## Why
사용자 보고: `https://mangowhoiscloud.github.io/geode/petri-bundle/` 에서 세부 행 클릭 시 TypeError 노출 우려 + GEODE 개발/병합 과정에서 petri 배포가 같이 깨질 가능성. 헤드리스 Chrome 으로는 현재 trigger 재현 불가했으나(번들 무결성 OK 확인), 향후 회귀를 막기 위해 격리/예방 가드를 강화한다.

- `pages.yml` 은 site Next.js 빌드와 bundle 배포 가 하나의 워크플로우에 묶여, site 빌드 실패가 petri 배포까지 끌어내리거나, site 변경이 petri 검증을 우회할 위험 존재.
- 기존 `validate_petri_bundle.py` 는 listing.json 의 status/파일 존재 만 검사 — zip 내부 `results=None` / empty `scores[]` / empty `metrics` (실제 viewer 의 TypeError trigger) 는 통과시킴.
- petri archive 가 다른 PR 의 광범위 삭제/리팩토링 에 휘말려 사라져도 차단 ratchet 부재.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/petri-publish.yml` | **NEW** — 격리된 ratchet 워크플로우. `docs/petri-bundle/**`, validator, hygiene, 자기 자신 변경 시 + 매일 00:30 UTC cron. PR 에서 base branch 와 diff 해 `.eval`/asset 삭제 경고. |
| `.github/workflows/pages.yml` | validator 를 `npm install/build` 직전 → 직후 가 아니라 **직전**으로 이동, `uv sync` 단계 추가. site 빌드 실패 시 bundle 검증이 안 도는 시나리오 차단. |
| `scripts/validate_petri_bundle.py` | zip 내부 `header.json.results=None`, 빈 `scores[]`, 빈 `metrics`, bad zip, 누락 `header.json`, 누락된 viewer asset 차단. Python 3.14+ 의 stdlib zstd / 3.12–3.13 의 `zipfile-zstd` shim 양쪽 지원. |
| `scripts/check_repo_hygiene.py` | `PETRI_EVAL_FLOOR = 9` 삭제 보호 ratchet 추가. |
| `pyproject.toml` | dev group 에 `zipfile-zstd>=0.0.4` (validator 의 zstd 백엔드, 3.14+ 에서는 no-op). |
| `tests/test_validate_petri_bundle.py` | **NEW** — 13 tests: missing/invalid listing, status=started/error, missing file/asset, results=None, empty scores, empty metrics, bad zip, missing inner header.json, real-bundle smoke. |
| `tests/test_check_repo_hygiene.py` | floor=0/9/8 회귀 테스트 3건 추가. |
| `CHANGELOG.md` | Unreleased — Infrastructure 섹션 3건. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 별도 `petri-publish.yml` workflow | Implemented | site build 와 분리, PR/push/cron/dispatch 4 트리거. |
| validator 검증 항목 확장 | Implemented | zip 내부 results/scores/metrics + asset 존재 + header status. |
| 번들 삭제 보호 ratchet | Implemented | `PETRI_EVAL_FLOOR = 9` 하한, 줄이려면 동일 PR 에서 floor 변경 필수. |

## Verification
- [x] `uv run ruff check scripts/ tests/` clean
- [x] `uv run ruff format --check scripts/ tests/` clean
- [x] `uv run mypy scripts/` clean (1 noqa 추가, 외부 lib 의 stub 부재)
- [x] `uv run python scripts/validate_petri_bundle.py` OK (9/9 archives)
- [x] `uv run python scripts/check_repo_hygiene.py` clean
- [x] `uv run yamllint -c .yamllint.yaml .github/workflows/petri-publish.yml .github/workflows/pages.yml` clean
- [x] `uv run pytest tests/ -m "not live" -n auto --dist=loadfile` → **4790 passed, 31 skipped**
- [x] Headless Chrome 으로 라이브 사이트 검증: row click → 상세/Samples/Scoring/모달/score cell 모두 정상 (runtime exception 0, ResizeObserver warning 만).

## Reference
- `docs/petri-bundle/README.md` — 외부 사용자 step-by-step
- 직전 회귀 PR: #1129 (partial archive 삭제), #1130 (error archive 삭제 + validator 신설)
- inspect_ai #1747 — `formatPrettyDecimal` TypeError 패턴
- 사용자 요청 (2026-05-19): "TypeError 복구 + petri CI/CD GEODE 개발 파이프라인 격리"

🤖 Generated with [Claude Code](https://claude.com/claude-code)