### PR TITLE
fix(llm): 3-provider parity — Codex cache + OpenAI PAYG/GLM streaming + GLM caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Provider parity cache + streaming fixes.** Codex/OpenAI Responses usage now
+  surfaces `input_tokens_details.cached_tokens` as cache-read telemetry, OpenAI
+  PAYG `agentic_call` uses Responses streaming instead of blocking create, and
+  GLM `agentic_call` streams Chat Completions with `prompt_cache_key` routing plus
+  a session-scoped unsupported-param fallback.
+- **Provider parity cache + streaming fixes.** Codex/OpenAI Responses usage 의
+  `input_tokens_details.cached_tokens` 를 cache-read telemetry 로 반영하고,
+  OpenAI PAYG `agentic_call` 은 blocking create 대신 Responses streaming 을
+  사용합니다. GLM `agentic_call` 은 Chat Completions streaming 과
+  `prompt_cache_key` 라우팅을 사용하며, 파라미터 미지원 시 세션 동안 fallback
+  상태를 캐시합니다.
+
 ## [0.99.15] — 2026-05-19
 
 ### Added

--- a/core/llm/agentic_response.py
+++ b/core/llm/agentic_response.py
@@ -15,6 +15,18 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
+def _cached_tokens_from_usage(usage: Any, *detail_attrs: str) -> int:
+    """Return cached token count from the first supported usage detail path."""
+    for attr in detail_attrs:
+        details = getattr(usage, attr, None)
+        if details is None:
+            continue
+        cached = getattr(details, "cached_tokens", None)
+        if isinstance(cached, int):
+            return cached
+    return 0
+
+
 @dataclass(slots=True)
 class ToolUseBlock:
     """A single tool-use request from the LLM."""
@@ -245,10 +257,7 @@ def normalize_openai(response: Any) -> AgenticResponse:
         # portion is *included* in ``prompt_tokens`` so we surface it
         # separately for the tracker (which prices it at the cache_read
         # rate). No cache_write equivalent on Chat Completions.
-        cache_read = 0
-        prompt_details = getattr(response.usage, "prompt_tokens_details", None)
-        if prompt_details is not None:
-            cache_read = getattr(prompt_details, "cached_tokens", 0) or 0
+        cache_read = _cached_tokens_from_usage(response.usage, "prompt_tokens_details")
         usage = ResponseUsage(
             input_tokens=response.usage.prompt_tokens or 0,
             output_tokens=response.usage.completion_tokens or 0,
@@ -361,10 +370,20 @@ def normalize_openai_responses(response: Any) -> AgenticResponse:
         details = getattr(response.usage, "output_tokens_details", None)
         if details is not None:
             thinking_tok = getattr(details, "reasoning_tokens", 0) or 0
+        # Responses API reports prompt-cache hits under
+        # ``input_tokens_details.cached_tokens``. Keep the
+        # ``prompt_tokens_details`` fallback so older Chat-Completions-shaped
+        # mocks or compatibility layers still surface cache reads.
+        cache_read = _cached_tokens_from_usage(
+            response.usage,
+            "input_tokens_details",
+            "prompt_tokens_details",
+        )
         usage = ResponseUsage(
             input_tokens=getattr(response.usage, "input_tokens", 0) or 0,
             output_tokens=getattr(response.usage, "output_tokens", 0) or 0,
             thinking_tokens=thinking_tok,
+            cache_read_tokens=cache_read,
         )
 
     if not blocks and (usage.output_tokens or 0) > (usage.thinking_tokens or 0):

--- a/core/llm/providers/glm.py
+++ b/core/llm/providers/glm.py
@@ -8,8 +8,10 @@ and failover chain.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import threading
+from types import SimpleNamespace
 from typing import Any
 
 from core.config import GLM_BASE_URL, GLM_FALLBACK_CHAIN, GLM_PRIMARY
@@ -106,11 +108,10 @@ def get_circuit_breaker() -> CircuitBreaker:
 # GlmAgenticAdapter — ZhipuAI GLM adapter for agentic loop
 # ---------------------------------------------------------------------------
 
-import inspect  # noqa: E402
-
 from core.llm.errors import UserCancelledError  # noqa: E402
 from core.llm.providers.openai import (  # noqa: E402
     OpenAIAgenticAdapter,
+    _build_prompt_cache_key,
     _convert_messages_to_openai,
     _tools_to_chat_completions,
 )
@@ -165,11 +166,112 @@ def _glm_thinking_supported(model: str) -> bool:
     return model in _GLM_THINKING_MODELS
 
 
+def _glm_prompt_cache_key_rejected(exc: Exception) -> bool:
+    """Return True when GLM rejects the optional prompt-cache routing key."""
+    detail = str(exc).lower()
+    if "prompt_cache_key" not in detail and "prompt cache key" not in detail:
+        return False
+    return any(
+        marker in detail
+        for marker in (
+            "unsupported parameter",
+            "unknown parameter",
+            "invalid parameter",
+            "unexpected keyword",
+            "not permitted",
+        )
+    )
+
+
+async def _consume_glm_chat_stream(stream_obj: Any) -> Any:
+    """Convert Chat Completions delta chunks into a normalizable response."""
+    if inspect.isawaitable(stream_obj):
+        stream_obj = await stream_obj
+
+    if not hasattr(stream_obj, "__aiter__") and not hasattr(stream_obj, "__iter__"):
+        return stream_obj
+
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls_by_index: dict[int, dict[str, str]] = {}
+    finish_reason = "stop"
+    usage: Any = None
+
+    async def _handle_chunk(chunk: Any) -> None:
+        nonlocal finish_reason, usage
+        chunk_usage = getattr(chunk, "usage", None)
+        if chunk_usage is not None:
+            usage = chunk_usage
+        for choice in getattr(chunk, "choices", None) or []:
+            choice_finish = getattr(choice, "finish_reason", None)
+            if choice_finish:
+                finish_reason = choice_finish
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                continue
+            content = getattr(delta, "content", None)
+            if isinstance(content, str) and content:
+                content_parts.append(content)
+            reasoning = getattr(delta, "reasoning_content", None)
+            if isinstance(reasoning, str) and reasoning:
+                reasoning_parts.append(reasoning)
+            for call in getattr(delta, "tool_calls", None) or []:
+                index = getattr(call, "index", None)
+                if not isinstance(index, int):
+                    index = len(tool_calls_by_index)
+                acc = tool_calls_by_index.setdefault(
+                    index,
+                    {"id": "", "name": "", "arguments": ""},
+                )
+                call_id = getattr(call, "id", None)
+                if isinstance(call_id, str) and call_id:
+                    acc["id"] = call_id
+                function = getattr(call, "function", None)
+                if function is not None:
+                    name = getattr(function, "name", None)
+                    if isinstance(name, str) and name:
+                        acc["name"] += name
+                    arguments = getattr(function, "arguments", None)
+                    if isinstance(arguments, str) and arguments:
+                        acc["arguments"] += arguments
+
+    if hasattr(stream_obj, "__aiter__"):
+        async for chunk in stream_obj:
+            await _handle_chunk(chunk)
+    else:
+        for chunk in stream_obj:
+            await _handle_chunk(chunk)
+
+    tool_calls = [
+        SimpleNamespace(
+            id=call["id"],
+            function=SimpleNamespace(
+                name=call["name"],
+                arguments=call["arguments"] or "{}",
+            ),
+        )
+        for _, call in sorted(tool_calls_by_index.items())
+    ]
+    message = SimpleNamespace(
+        content="".join(content_parts),
+        reasoning_content="".join(reasoning_parts),
+        tool_calls=tool_calls,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=usage,
+    )
+
+
 class GlmAgenticAdapter(OpenAIAgenticAdapter):
     """ZhipuAI GLM adapter (glm-5.1, glm-5, glm-5-turbo, glm-5v-turbo, glm-4.7-flash).
 
     Injects GLM native web_search tool alongside function tools.
     """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._prompt_cache_key_supported = True
 
     @property
     def provider_name(self) -> str:
@@ -242,19 +344,31 @@ class GlmAgenticAdapter(OpenAIAgenticAdapter):
                     "type": _thinking_type,
                     "clear_thinking": False,
                 }
-            response = client.chat.completions.create(
-                model=m,
-                messages=oai_messages,
-                tools=oai_tools if oai_tools else None,
-                tool_choice=tc_val if oai_tools else None,
-                max_completion_tokens=max_tokens,
-                temperature=temperature,
-                extra_body=local_extra or None,
-                timeout=120.0,
-            )
-            if inspect.isawaitable(response):
-                return await response
-            return response
+            create_kwargs: dict[str, Any] = {
+                "model": m,
+                "messages": oai_messages,
+                "tools": oai_tools if oai_tools else None,
+                "tool_choice": tc_val if oai_tools else None,
+                "max_completion_tokens": max_tokens,
+                "temperature": temperature,
+                # Passed to the SDK call as extra_body= via **create_kwargs.
+                "extra_body": local_extra or None,
+                "timeout": 120.0,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
+            if self._prompt_cache_key_supported:
+                create_kwargs["prompt_cache_key"] = _build_prompt_cache_key(system, oai_tools)
+            try:
+                response = client.chat.completions.create(**create_kwargs)
+                return await _consume_glm_chat_stream(response)
+            except Exception as exc:
+                if "prompt_cache_key" in create_kwargs and _glm_prompt_cache_key_rejected(exc):
+                    self._prompt_cache_key_supported = False
+                    create_kwargs.pop("prompt_cache_key", None)
+                    response = client.chat.completions.create(**create_kwargs)
+                    return await _consume_glm_chat_stream(response)
+                raise
 
         try:
             response, used_model = await call_with_failover(failover_models, _do_call)

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -482,6 +482,21 @@ def _is_payg_reasoning_model(model: str) -> bool:
     return model in _PAYG_REASONING_O_SERIES or model.startswith("gpt-5")
 
 
+async def _stream_openai_response(client: Any, create_kwargs: dict[str, Any]) -> Any:
+    """Run a Responses API stream and return a final response with output items."""
+    async with client.responses.stream(**create_kwargs) as stream:
+        accumulated_items: list[Any] = []
+        async for event in stream:
+            if getattr(event, "type", "") == "response.output_item.done":
+                item = getattr(event, "item", None)
+                if item is not None:
+                    accumulated_items.append(item)
+        final = await stream.get_final_response()
+        if accumulated_items:
+            final.output = accumulated_items
+        return final
+
+
 class OpenAIAgenticAdapter:
     """OpenAI agentic adapter via Responses API (P1 Gateway pattern).
 
@@ -638,10 +653,7 @@ class OpenAIAgenticAdapter:
                 oai_effort = _EFFORT_MAP.get(effort, "medium")
                 create_kwargs["reasoning"] = {"effort": oai_effort, "summary": "auto"}
                 create_kwargs["include"] = ["reasoning.encrypted_content"]
-            response = client.responses.create(**create_kwargs)
-            if inspect.isawaitable(response):
-                return await response
-            return response
+            return await _stream_openai_response(client, create_kwargs)
 
         try:
             response, used_model = await call_with_failover(failover_models, _do_call)

--- a/tests/test_glm_streaming_cache.py
+++ b/tests/test_glm_streaming_cache.py
@@ -1,0 +1,130 @@
+"""GLM agentic_call streams Chat Completions and sends prompt_cache_key."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from core.llm.agentic_response import AgenticResponse
+from core.llm.providers.glm import GlmAgenticAdapter
+from core.llm.providers.openai import _build_prompt_cache_key, _tools_to_chat_completions
+
+
+def _chunk(
+    *,
+    content: str = "",
+    reasoning: str = "",
+    finish_reason: str | None = None,
+    usage: Any = None,
+) -> Any:
+    delta = SimpleNamespace(content=content, reasoning_content=reasoning, tool_calls=[])
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _stream(usage: Any | None = None) -> list[Any]:
+    return [
+        _chunk(content="hel", reasoning="think "),
+        _chunk(content="lo", reasoning="done", finish_reason="stop", usage=usage),
+    ]
+
+
+class _Completions:
+    def __init__(self, sink: list[dict[str, Any]], responses: list[Any]) -> None:
+        self._sink = sink
+        self._responses = responses
+
+    def create(self, **kwargs: Any) -> Any:
+        self._sink.append(dict(kwargs))
+        next_response = self._responses.pop(0)
+        if isinstance(next_response, Exception):
+            raise next_response
+        return next_response
+
+
+class _Client:
+    def __init__(self, sink: list[dict[str, Any]], responses: list[Any]) -> None:
+        self.chat = SimpleNamespace(completions=_Completions(sink, responses))
+
+
+def test_glm_agentic_call_streams_and_sends_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[dict[str, Any]] = []
+    usage = SimpleNamespace(
+        prompt_tokens=20,
+        completion_tokens=5,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=11),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=2),
+    )
+    client = _Client(captured, [_stream(usage)])
+    adapter = GlmAgenticAdapter()
+    monkeypatch.setattr(adapter, "_ensure_client", lambda model: client)
+
+    tools = [{"type": "function", "name": "lookup", "description": "lookup", "parameters": {}}]
+    result = asyncio.run(
+        adapter.agentic_call(
+            model="glm-5.1",
+            system="system",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            tool_choice="auto",
+            max_tokens=64,
+            temperature=0.1,
+            effort="high",
+        )
+    )
+
+    assert isinstance(result, AgenticResponse)
+    assert captured[0]["stream"] is True
+    assert captured[0]["stream_options"] == {"include_usage": True}
+    assert captured[0]["prompt_cache_key"] == _build_prompt_cache_key(
+        "system",
+        [
+            *_tools_to_chat_completions(tools),
+            {"type": "web_search", "web_search": {"enable": True}},
+        ],
+    )
+    assert result.content[0].text == "hello"
+    assert result.reasoning_summaries == ["think done"]
+    assert result.usage.input_tokens == 20
+    assert result.usage.cache_read_tokens == 11
+
+
+def test_glm_prompt_cache_key_rejection_retries_once_then_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[dict[str, Any]] = []
+    usage = SimpleNamespace(prompt_tokens=3, completion_tokens=1)
+    client = _Client(
+        captured,
+        [
+            RuntimeError("Unsupported parameter: prompt_cache_key"),
+            _stream(usage),
+            _stream(usage),
+        ],
+    )
+    adapter = GlmAgenticAdapter()
+    monkeypatch.setattr(adapter, "_ensure_client", lambda model: client)
+
+    kwargs = {
+        "model": "glm-5.1",
+        "system": "system",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [],
+        "tool_choice": "auto",
+        "max_tokens": 64,
+        "temperature": 0.1,
+        "effort": "high",
+    }
+
+    first = asyncio.run(adapter.agentic_call(**kwargs))
+    second = asyncio.run(adapter.agentic_call(**kwargs))
+
+    assert isinstance(first, AgenticResponse)
+    assert isinstance(second, AgenticResponse)
+    assert "prompt_cache_key" in captured[0]
+    assert "prompt_cache_key" not in captured[1]
+    assert "prompt_cache_key" not in captured[2]

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -300,9 +300,7 @@ class TestOpenAIResponsesApiMigration:
         # PR #1316 — PAYG switched from blocking responses.create to streaming
         # responses.stream (via _stream_openai_response helper) for TTFB parity
         # with Anthropic/Codex.
-        uses_responses = (
-            "responses.create" in module_source or "responses.stream" in module_source
-        )
+        uses_responses = "responses.create" in module_source or "responses.stream" in module_source
         assert uses_responses
         assert "chat.completions.create" not in call_source
 

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -292,13 +292,19 @@ class TestOpenAIResponsesApiMigration:
         """OpenAI adapter must use Responses API (create or stream), not chat.completions."""
         import inspect
 
+        from core.llm.providers import openai as openai_module
         from core.llm.providers.openai import OpenAIAgenticAdapter
 
-        source = inspect.getsource(OpenAIAgenticAdapter.agentic_call)
+        call_source = inspect.getsource(OpenAIAgenticAdapter.agentic_call)
+        module_source = inspect.getsource(openai_module)
         # PR #1316 — PAYG switched from blocking responses.create to streaming
-        # responses.stream for TTFB parity with Anthropic/Codex.
-        assert "responses.create" in source or "responses.stream" in source
-        assert "chat.completions.create" not in source
+        # responses.stream (via _stream_openai_response helper) for TTFB parity
+        # with Anthropic/Codex.
+        uses_responses = (
+            "responses.create" in module_source or "responses.stream" in module_source
+        )
+        assert uses_responses
+        assert "chat.completions.create" not in call_source
 
     def test_openai_native_web_search_constant(self) -> None:
         """_OPENAI_NATIVE_TOOLS must include web_search."""

--- a/tests/test_native_tools.py
+++ b/tests/test_native_tools.py
@@ -289,13 +289,15 @@ class TestOpenAIResponsesApiMigration:
         assert "Responses API" in docstring
 
     def test_openai_uses_responses_api(self) -> None:
-        """OpenAI adapter must use responses.create (not chat.completions)."""
+        """OpenAI adapter must use Responses API (create or stream), not chat.completions."""
         import inspect
 
         from core.llm.providers.openai import OpenAIAgenticAdapter
 
         source = inspect.getsource(OpenAIAgenticAdapter.agentic_call)
-        assert "responses.create" in source
+        # PR #1316 — PAYG switched from blocking responses.create to streaming
+        # responses.stream for TTFB parity with Anthropic/Codex.
+        assert "responses.create" in source or "responses.stream" in source
         assert "chat.completions.create" not in source
 
     def test_openai_native_web_search_constant(self) -> None:

--- a/tests/test_normalize_openai_responses_cache_tokens.py
+++ b/tests/test_normalize_openai_responses_cache_tokens.py
@@ -1,0 +1,62 @@
+"""Responses API prompt-cache token extraction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.llm.agentic_response import normalize_openai, normalize_openai_responses
+
+
+def test_responses_api_input_tokens_details_cached_tokens() -> None:
+    """Codex/OpenAI Responses usage reports cache hits on input token details."""
+    response = SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(
+            input_tokens=128,
+            output_tokens=8,
+            input_tokens_details=SimpleNamespace(cached_tokens=96),
+            output_tokens_details=SimpleNamespace(reasoning_tokens=3),
+        ),
+    )
+
+    result = normalize_openai_responses(response)
+
+    assert result.usage.input_tokens == 128
+    assert result.usage.output_tokens == 8
+    assert result.usage.thinking_tokens == 3
+    assert result.usage.cache_read_tokens == 96
+
+
+def test_responses_api_prompt_tokens_details_cached_tokens_fallback() -> None:
+    """Compatibility fallback for Responses-shaped mocks with old usage details."""
+    response = SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(
+            input_tokens=50,
+            output_tokens=2,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=21),
+        ),
+    )
+
+    result = normalize_openai_responses(response)
+
+    assert result.usage.cache_read_tokens == 21
+
+
+def test_chat_completions_cache_token_path_still_works() -> None:
+    """Chat Completions keeps using prompt_tokens_details.cached_tokens."""
+    message = SimpleNamespace(content="hello", tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    response = SimpleNamespace(
+        choices=[choice],
+        usage=SimpleNamespace(
+            prompt_tokens=80,
+            completion_tokens=5,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+        ),
+    )
+
+    result = normalize_openai(response)
+
+    assert result.usage.input_tokens == 80
+    assert result.usage.cache_read_tokens == 40

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -1,0 +1,114 @@
+"""OpenAI PAYG agentic_call uses Responses streaming."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from core.llm.agentic_response import AgenticResponse
+from core.llm.providers.openai import OpenAIAgenticAdapter
+
+
+class _FakeResponsesStream:
+    def __init__(self, events: list[Any], final_response: Any) -> None:
+        self._events = events
+        self._final_response = final_response
+        self._index = 0
+
+    async def __aenter__(self) -> _FakeResponsesStream:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+    def __aiter__(self) -> _FakeResponsesStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._index >= len(self._events):
+            raise StopAsyncIteration
+        event = self._events[self._index]
+        self._index += 1
+        return event
+
+    async def get_final_response(self) -> Any:
+        return self._final_response
+
+
+def _message_item(text: str) -> Any:
+    return SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+def _function_item() -> Any:
+    return SimpleNamespace(
+        type="function_call",
+        call_id="call_1",
+        name="lookup",
+        arguments='{"q":"geode"}',
+    )
+
+
+def test_openai_agentic_call_streaming_matches_blocking_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    streamed_items = [_message_item("hello"), _function_item()]
+    final_response = SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(input_tokens=34, output_tokens=12),
+    )
+    events = [
+        SimpleNamespace(type="response.output_item.done", item=item) for item in streamed_items
+    ]
+
+    class _Responses:
+        def stream(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _FakeResponsesStream(events, final_response)
+
+    class _Client:
+        responses = _Responses()
+
+    adapter = OpenAIAgenticAdapter()
+    monkeypatch.setattr(adapter, "_ensure_client", lambda model: _Client())
+    monkeypatch.setattr("core.llm.providers.openai._OPENAI_NATIVE_TOOLS", [])
+    monkeypatch.setattr(
+        "core.llm.providers.anthropic.is_computer_use_enabled",
+        lambda: False,
+    )
+
+    result = asyncio.run(
+        adapter.agentic_call(
+            model="gpt-5.5",
+            system="system",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "name": "lookup",
+                    "description": "lookup",
+                    "parameters": {},
+                }
+            ],
+            tool_choice="auto",
+            max_tokens=128,
+            temperature=0.2,
+            effort="high",
+        )
+    )
+
+    assert isinstance(result, AgenticResponse)
+    assert captured["model"] == "gpt-5.5"
+    assert captured["store"] is False
+    assert "prompt_cache_key" in captured
+    assert result.stop_reason == "tool_use"
+    assert result.content[0].text == "hello"
+    assert result.content[1].id == "call_1"
+    assert result.content[1].input == {"q": "geode"}
+    assert result.usage.input_tokens == 34
+    assert result.usage.output_tokens == 12

--- a/tests/test_openai_prompt_cache.py
+++ b/tests/test_openai_prompt_cache.py
@@ -74,13 +74,13 @@ def test_key_length_is_32_hex_chars() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Adapter wiring — prompt_cache_key reaches responses.create
+# Adapter wiring — prompt_cache_key reaches responses.stream
 # ---------------------------------------------------------------------------
 
 
 def test_agentic_call_injects_prompt_cache_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """The adapter must include ``prompt_cache_key`` in the kwargs sent to
-    ``client.responses.create``.  Capture the kwargs via a stub client.
+    ``client.responses.stream``.  Capture the kwargs via a stub client.
 
     The codebase does not depend on pytest-asyncio, so we drive the async
     method via ``asyncio.run`` directly — matching the pattern used by
@@ -95,10 +95,26 @@ def test_agentic_call_injects_prompt_cache_key(monkeypatch: pytest.MonkeyPatch) 
         output: list[Any] = []
         output_text = ""
 
-    class _StubResponses:
-        def create(self, **kwargs: Any) -> Any:
-            captured.update(kwargs)
+    class _StubStream:
+        async def __aenter__(self) -> _StubStream:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+            return False
+
+        def __aiter__(self) -> _StubStream:
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+        async def get_final_response(self) -> Any:
             return _StubResponse()
+
+    class _StubResponses:
+        def stream(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _StubStream()
 
     class _StubClient:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
Explore audit (2026-05-19) 결과 적용. 4 provider 사이 HIGH-severity GAP 3건 정리:

1. **Codex cache token silent undercount** — `normalize_openai_responses` 가 Responses API `input_tokens_details.cached_tokens` 추출 안 함 → 캐싱 hit 시 cost 0 → 분석 부정확
2. **OpenAI PAYG `agentic_call` blocking** — Anthropic/Codex 는 streaming, PAYG 만 blocking → TTFB 지연
3. **GLM blocking + 무캐싱** — Chat Completions blocking + `prompt_cache_key` 미전송 → TTFB + 반복 세션 비용 손실

Codex MCP cross-LLM verify 통과.

## Why
GEODE 가 4 LLM provider (Anthropic, OpenAI PAYG, Codex Plus, GLM) 지원하지만 GAP 으로 인해 provider 선택에 따라 사용자 체감 품질 + cost 정확성이 일정하지 않음. Anthropic 은 reference 수준, 나머지 3개에 격차.

## Changes
| File | Change |
|------|--------|
| `core/llm/agentic_response.py` | shared cache-token extraction helper + Responses API path (`input_tokens_details.cached_tokens`) → `cache_read_tokens` 매핑 |
| `core/llm/providers/openai.py` | PAYG `agentic_call` → `client.responses.stream(...)` context manager + `output_item.done` accumulate (Codex 와 동일 구조) |
| `core/llm/providers/glm.py` | Chat Completions streaming + `prompt_cache_key` 전송, reject 시 try/except 1회 retry + session-level no-cache 캐싱 |
| `tests/test_normalize_openai_responses_cache_tokens.py` (신규) | cached_tokens 추출 검증 |
| `tests/test_openai_adapter_streaming.py` (신규) | PAYG mock stream + AgenticResponse 동등성 |
| `tests/test_glm_streaming_cache.py` (신규) | GLM streaming + prompt_cache_key reject fallback |
| `CHANGELOG.md` | `[Unreleased]` Fixed (KR/EN) |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Codex cache token 추출 | Implemented | SDK type `response_usage.py` 검증: `input_tokens_details.cached_tokens` |
| OpenAI PAYG streaming | Implemented | Codex 패턴 reuse, error handling 보존 |
| GLM streaming + caching | Implemented | graceful fallback for `prompt_cache_key` reject |
| Anthropic regression 없음 | Verified | 변경 없음 |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run ruff format --check core/ tests/ plugins/` clean (641 files)
- [x] `uv run mypy core/ plugins/` clean (351 files)
- [x] `uv run pytest tests/test_normalize_openai_responses_cache_tokens.py tests/test_openai_adapter_streaming.py tests/test_glm_streaming_cache.py` 6 passed
- [x] Codex MCP cross-LLM verify (sandbox=workspace-write, gpt-5.2)

## Remaining Concerns (LOW, deferred)
- Codex `max_output_tokens` 거부 spec gap
- OpenAI reasoning 모델 temperature 검증 부재
- 모든 OpenAI 계열 `BillingError` swallow-then-rereraised 불필요 layer
- GLM `prompt_cache_key` 지원이 endpoint/model 별 가변 — runtime fallback 으로 가드

## Reference
- Explore audit report (Session 2026-05-19): 4-provider GAP matrix + 10 findings
- OpenAI SDK type 검증: `.venv/.../openai/types/responses/response_usage.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)