### PR TITLE
release: v0.99.16 — 3-provider parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.16] — 2026-05-19
+
 ### Fixed
 
 - **Provider parity cache + streaming fixes.** Codex/OpenAI Responses usage now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.15
+- **Version**: 0.99.16
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.15 — Long-running Autonomous Execution Harness
+# GEODE v0.99.16 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -326,7 +326,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.15**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.16**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.15 — Long-running Autonomous Execution Harness
+# GEODE v0.99.16 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -333,7 +333,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.15**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.16**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.15"
+version = "0.99.16"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ special test-time setup; the hook system is wired only when an
 HookSystem instance is present.
 """
 
+import contextlib
 import os
 import tempfile
 
@@ -46,11 +47,15 @@ def _reset_auth_singletons():
     _infra._profile_rotator = None
     _pr._plan_registry = None
     # Make sure no leftover auth.toml from a prior test run influences this one
-    if os.path.exists(_test_auth_toml):
+    # xdist-parallel race: two workers may both see the file exist then both try
+    # to remove it. Tolerate concurrent FileNotFoundError.
+    with contextlib.suppress(FileNotFoundError):
         os.remove(_test_auth_toml)
     yield
     _infra._profile_store = None
     _infra._profile_rotator = None
     _pr._plan_registry = None
-    if os.path.exists(_test_auth_toml):
+    # xdist-parallel race: two workers may both see the file exist then both try
+    # to remove it. Tolerate concurrent FileNotFoundError.
+    with contextlib.suppress(FileNotFoundError):
         os.remove(_test_auth_toml)

--- a/uv.lock
+++ b/uv.lock
@@ -1190,7 +1190,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.15"
+version = "0.99.16"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- 5-location version bump (0.99.15 → 0.99.16)
- `[Unreleased]` → `[0.99.16] — 2026-05-19` promotion
- 포함 변경: #1316 Codex cache token 추출 + OpenAI PAYG streaming + GLM streaming/caching

## Verification
- [x] 5 location version 일치 (`0.99.16`)
- [x] `uv run ruff check core/ tests/ plugins/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)