### PR TITLE
docs(adr): paperclip/crumb within-source profile rotation + 2-axis picker UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,26 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **ADR + plan extension — paperclip/crumb-style within-source profile
+  rotation + 2-axis account picker UX.** Closes 2026-05-19 user
+  directive "paperclip, crumb 의 사례처럼 로컬에 기록된 계정 기록으로
+  롤아웃 + provider 좌우 / account 위아래 picker." Updates
+  `docs/architecture/outer-loop-resume-decision.md` with a new
+  "Within-source account rotation" section: GEODE already has
+  `core/auth/profiles.py` + `rotation.py` + `credential_breadcrumb.py`
+  (richer than paperclip/crumb's subprocess pickup); outer-loop just
+  wasn't using it. Adds an "Account picker UX (2-axis)" section with
+  ASCII mockup mirroring `core/cli/effort_picker.py`
+  (`pick_model_and_effort`) — provider←→ × profile↑↓ + action row
+  (Enter swap / n add / w wait / p PAYG opt-in / Esc keep aborted).
+  Two entry points: `/login picker` slash + agent-loop NL recogniser.
+  Rotation is **operator-driven**, never automatic. Plan ledger
+  expanded from 6 to 8 PRs under Phase ζ — PR-ζ5.5 (ProfileRotator
+  wiring into outer-loop credential path) + PR-ζ5.6 (account picker
+  UI). Total sprint LOC 2,350 → 2,900.
+
 ## [0.99.16] — 2026-05-19
 
 ### Fixed

--- a/docs/architecture/outer-loop-resume-decision.md
+++ b/docs/architecture/outer-loop-resume-decision.md
@@ -99,6 +99,49 @@ On resume:
 2. If active source changed (e.g., claude-cli → claude-cli on a different account), record it in the checkpoint with a `credential_rolled_over_at` marker so the journal carries the boundary.
 3. If the user explicitly requested `fallback_to_payg=true` on the resume invocation that was `false` on the original, the runtime emits a `credential_policy_change` event into the journal before continuing.
 
+### Within-source account rotation (paperclip / crumb pattern)
+
+A separate dimension from the cross-source PAYG ramp blocked by PR-β1: **multiple accounts inside the same `family.source`** (e.g., two Claude Code OAuth accounts the operator has both stored). The 2026-05-19 user directive — "paperclip, crumb 의 사례처럼 로컬에 기록된 계정 기록으로 롤아웃" — refers to this case. paperclip / crumb (cf. `docs/audits/2026-05-18-i2-paperclip-review.md`, external repo `~/workspace/crumb/`) achieve it via `claude -p` subprocess picking up `~/.claude/credentials` automatically + symlink swap or env var for account selection. The pattern is **non-interactive subprocess + locally-recorded credential**.
+
+GEODE already has a richer, in-process equivalent — `core/auth/profiles.py` (AuthProfile / ProfileStore / EligibilityResult), `core/auth/rotation.py` (`ProfileRotator.resolve(provider)` returning best-eligible, `mark_failure` → cooldown, managed-token auto-refresh ≤120 s pre-expiry), `core/auth/credential_breadcrumb.py` (LLM-readable hint per ProfileRejectReason — Claude Code `createModelSwitchBreadcrumbs` parity). Outer-loop currently uses none of it; `plugins/petri_audit/credential_source.py` only does process-local `suppress_credential_source(family, source)` (no profile dimension).
+
+**Decision** (Phase ζ extension):
+
+1. **Wire `ProfileRotator` into the outer-loop credential path.**
+   `resolve_credential_source(family, ..., fallback_to_payg)` returns the source key (e.g. `claude-cli`); a new layer `resolve_outer_loop_binding(family) → (source, profile)` adds the second dimension. autoresearch / seed-pipeline pass `profile.name` through every LLM call so failures route into `ProfileRotator.mark_failure(profile)` instead of the in-process suppress set.
+
+2. **Rotation is operator-driven, never automatic.** When strict-mode trips abort (PR-β1's `CredentialResolutionError(subscription_only=True)`), the FE banner (PR-γ1) checks whether ProfileRotator has another eligible profile for the same family. If yes, the abort dialog shows a 2-axis picker (next sub-section). If no, the dialog shows the existing "add a profile / wait for reset / opt-in PAYG" options.
+
+3. **Rollout boundary writes to journal.** The new active `(source, profile)` is captured in the checkpoint and a `credential_rolled_over` event is appended to `~/.geode/outer-loop/<session>/journal.jsonl` (P1c). Idempotency keys per LLM call (PR-ζ4) already include `agent_role`, so a swapped account picks up the same cache entries when applicable.
+
+### Account picker UX (2-axis, GEODE slash-command parity)
+
+Per 2026-05-19 user directive — "자연어 뿐 아니라 UI/UX 로도 선택/입력 가능 (GEODE 슬래시 명령어 구조 참고). provider 변경은 좌우, 계정 선택은 위아래" — the picker is a 2D interactive selector mirroring the existing `pick_model_and_effort` pattern in `core/cli/effort_picker.py` (Claude Code `ModelPicker.tsx` parity):
+
+```
+┌─ Subscription quota exhausted — claude-cli (anthropic:work) ─────────┐
+│                                                                       │
+│  ◀ anthropic    openai     zhipuai ▶          (←/→ change provider)  │
+│                                                                       │
+│  Profiles for anthropic:                                              │
+│    anthropic:work                              [exhausted]            │
+│  ▶ anthropic:personal     OAuth · 0% used      [eligible]    ↑↓      │
+│    anthropic:org-shared   OAuth · 12% used     [eligible]             │
+│    anthropic:api-key      api_key · PAYG       [blocked by strict]    │
+│    + Add new profile…                                                 │
+│                                                                       │
+│  [Enter] swap & resume     [n] add new     [w] wait for reset         │
+│  [p] opt-in PAYG fallback (this run only)    [Esc] keep aborted       │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+Entry points (both required per directive):
+
+1. **Slash command**: `/login` already exists for account add/remove (`core/cli/commands/login.py`). Extend with `/login picker` or trigger via `/account` alias to open the 2-axis picker directly. Auto-triggered when banner is red (aborted state).
+2. **Natural language**: agent loop recognises phrases like "swap account", "use my other Claude account", "rollout to next profile" and invokes the same picker programmatically.
+
+Implementation reuses `pick_model_and_effort`'s raw-tty 2-axis input loop. Per directive: **provider = ←→, account = ↑↓**. The action row (`[Enter] / [n] / [w] / [p] / [Esc]`) makes the policy boundary explicit — there is no automatic rotation; every swap is a user keystroke.
+
 ## Non-Decisions (explicitly rejected)
 
 | Alternative | Why rejected |
@@ -130,13 +173,15 @@ On resume:
 
 ## Implementation plan
 
-Lives as Phase ζ in `docs/plans/2026-05-19-outer-loop-config-consolidation.md`. 6 PRs (~1500 LOC + 1 backfill):
+Lives as Phase ζ in `docs/plans/2026-05-19-outer-loop-config-consolidation.md`. **8 PRs** (~2100 LOC + 1 backfill) — expanded from 6 after the 2026-05-19 paperclip/crumb directive:
 
-- **PR-ζ1**: extend `SessionCheckpoint` schema for outer-loop fields (active_sources, completed_units, next_unit, fallback_to_payg). Tests round-trip.
+- **PR-ζ1**: extend `SessionCheckpoint` schema for outer-loop fields (active_sources, completed_units, next_unit, fallback_to_payg, active_profile). Tests round-trip.
 - **PR-ζ2**: `_load_state()` companion for `plugins/seed_pipeline/orchestrator.py:PipelineState`. CLI flag `geode audit-seeds resume <run_id>`.
 - **PR-ζ3**: autoresearch `_load_pending_audit()` + `--resume <session_id>` flag in `autoresearch/train.py`.
 - **PR-ζ4**: idempotency-key embedding in LLM call metadata + local response cache lookup (`~/.geode/outer-loop/<session>/idempotency.db`).
 - **PR-ζ5**: credential-rollover detection — at resume, compare active sources to checkpoint; emit `credential_rolled_over_at` event into journal.
+- **PR-ζ5.5** (NEW): wire `ProfileRotator` into the outer-loop credential path. `resolve_outer_loop_binding(family) → (source, profile)` adds the profile dimension. `plugins/petri_audit/credential_source.py` routes failures through `ProfileRotator.mark_failure(profile)` instead of the in-process suppress set. autoresearch + seed-pipeline pass `profile.name` through LLM call metadata so cooldowns track per-account.
+- **PR-ζ5.6** (NEW): 2-axis account picker (provider ←→ × profile ↑↓), mirroring `core/cli/effort_picker.py`. Two entry points: (a) `/login picker` slash command + auto-trigger from the red banner abort dialog (PR-γ1 trigger condition), (b) agent loop natural-language phrase recogniser invokes the picker programmatically. Action row: Enter (swap+resume) / n (add new profile via `claude /login` subprocess delegate) / w (wait for reset) / p (opt-in PAYG for this run) / Esc (keep aborted).
 - **PR-ζ6**: docs + sample resume run-book (`docs/audits/2026-05-19-resume-rollout-runbook.md`) + CHANGELOG.
 
 ## Reference

--- a/docs/plans/2026-05-19-outer-loop-config-consolidation.md
+++ b/docs/plans/2026-05-19-outer-loop-config-consolidation.md
@@ -117,6 +117,8 @@ Phase ζ — checkpoint + resume on credential rollout
   PR-ζ3 — autoresearch _load_pending_audit() + --resume flag (~200 LOC)
   PR-ζ4 — idempotency-key + 로컬 response cache (~/.geode/outer-loop/<s>/idempotency.db)  (~350 LOC)
   PR-ζ5 — credential-rollover detection + journal event (~150 LOC)
+  PR-ζ5.5 — outer-loop ↔ ProfileRotator wiring                  (~300 LOC)
+  PR-ζ5.6 — 2-axis account picker (provider ←→ × profile ↑↓)    (~250 LOC)
   PR-ζ6 — docs + runbook                                       (~100 LOC)
                                   ↓
 [Phase C of wiring sprint] — gen-0 baseline smoke (~$5)
@@ -135,10 +137,12 @@ Phase ζ — checkpoint + resume on credential rollout
 | **PR-ζ3** | feat(autoresearch): `_load_pending_audit` + `--resume <session>` | ADR settled | ~200 | `autoresearch/train.py` (resume entry point + active-source check), tests | PR-ζ1 + PR-δ1 |
 | **PR-ζ4** | feat(checkpoint): idempotency-key + local response cache | ADR settled | ~350 | `core/runtime_state/idempotency.py` (NEW, SQLite-backed cache at `~/.geode/outer-loop/<s>/idempotency.db`), LLM call wrapper checks cache pre-call, writes post-call, tests | PR-ζ1 |
 | **PR-ζ5** | feat(observability): credential-rollover detection + journal event | ADR settled | ~150 | resume path comparison: checkpoint.active_sources vs current resolved sources → emit `credential_rolled_over` event to journal (P1c), tests | PR-ζ1 + PR-γ1 |
-| **PR-ζ6** | docs + runbook | wrap-up | ~100 | `docs/audits/2026-05-19-resume-rollout-runbook.md` (NEW, operator manual), CHANGELOG entries, plan doc finalisation | Phase ζ |
+| **PR-ζ5.5** | feat(petri+auth): wire ProfileRotator into outer-loop credential path | 2026-05-19 paperclip/crumb directive | ~300 | `plugins/petri_audit/credential_source.py` (route mark_failure → ProfileRotator), new `resolve_outer_loop_binding(family) → (source, profile)`, autoresearch + seed-pipeline LLM call sites pass profile.name through metadata, tests | PR-β1 + PR-δ1 + PR-δ2 |
+| **PR-ζ5.6** | feat(cli): 2-axis account picker (provider ←→ × profile ↑↓) | 2026-05-19 picker UX directive | ~250 | `core/cli/account_picker.py` (NEW, mirrors `core/cli/effort_picker.py` 2-axis pattern), `/login picker` slash, banner abort-dialog auto-trigger (PR-γ1 wire), agent loop NL phrase recogniser, tests | PR-ζ5.5 + PR-γ1 |
+| **PR-ζ6** | docs + runbook | wrap-up | ~150 | `docs/audits/2026-05-19-resume-rollout-runbook.md` (NEW, operator manual w/ picker screenshots), CHANGELOG entries, plan doc finalisation | Phase ζ |
 
-**Total estimate**: ~2,350 LOC (Phase α-ε ~1,050 + Phase ζ ~1,300) + 1 ADR + 1 schema doc + 1 runbook + 1 sample fixture.
-**Sprint estimate**: 4-5 sprint (per-PR Codex MCP audit 포함).
+**Total estimate**: ~2,900 LOC (Phase α-ε ~1,050 + Phase ζ ~1,850) + 1 ADR + 1 schema doc + 1 runbook + 1 sample fixture.
+**Sprint estimate**: 5-6 sprint (per-PR Codex MCP audit 포함).
 
 ## Phase α (PR-α1) — config schema 상세
 
@@ -300,6 +304,9 @@ PR-δ2 (seed-pipeline + petri user_overrides):
 | Phase ζ resume 시 active_source 가 변경됐으나 idempotency-key 가 매칭되어 잘못된 cached response 재사용 | idempotency-key 가 `(run_id, unit_id, agent_role)` 만으로 구성 — source 가 바뀌어도 의미상 같은 unit. 단 critical 변경 (e.g. judge=opus → judge=sonnet) 은 caller 가 새 key 발급 책임 (config.toml hash 를 key 에 prefix) |
 | Phase ζ 의 SQLite idempotency.db 가 disk full 로 write 실패 | atomic_write_io 패턴 채택, write 실패 시 in-memory only fallback + journal 에 `idempotency_disabled` event |
 | co-scientist 원본/reference impl 모두 production-ready resume 미제공 → 우리가 first-class implementer | ADR 의 reference table 에 명시. LangGraph + Inspect_ai + Stripe 의 검증된 패턴 합성, novel design 아님 |
+| ProfileRotator wiring (PR-ζ5.5) 에서 autoresearch + seed-pipeline 의 LLM call 사이트가 수십 개라 migration 누락 위험 | Codex MCP audit 으로 `grep -r "agentic_call\|llm.*call"` 후 모든 사이트가 profile.name 전달하는지 검증. 누락된 site 는 fallback 으로 기본 profile resolver 의 결과 사용 (행동 변경 없음) |
+| 2-axis picker UX (PR-ζ5.6) 가 non-tty (CI / pipe) 환경에서 깨짐 | `pick_model_and_effort` 와 동일 패턴 — `sys.stdin.isatty()` 체크 후 fallback 으로 numbered list 출력 + arg-by-name 지원 (e.g. `/login picker --provider anthropic --profile work`) |
+| paperclip/crumb subprocess delegate (`claude -p`) 흡수 여부 | 본 sprint scope 외 — `docs/audits/2026-05-18-i2-paperclip-review.md` 가 별도 "Deferred — PAYG path 충분" 결정. Future ADR 으로 분리 |
 
 ## Reference
 
@@ -314,6 +321,8 @@ PR-δ2 (seed-pipeline + petri user_overrides):
   - "설정은 SOT 로 단일화해서 묶고"
   - "outer loop 가 subscription 초과로 끊겨도 계정 롤아웃해서 이어갈 수 있게 체크포인트와 같은 replay-resume 조치"
   - "ADR 들어가기 전에 관련 레퍼런스 디깅 + 원본인 co-scientist 의 패키지 구현본 살피기"
+  - "paperclip, crumb 의 사례처럼 로컬에 기록된 계정 기록으로 롤아웃이 가능한지 살피고 현재 구조에서 어떻게 보강 구현할지도 고려"
+  - "유저가 자연어 뿐 아니라 UI/UX 로도 선택/입력할 수 있게 개선 (GEODE 슬래시 명령어 구조 참고). 롤아웃 기준은 자동이 아니라 크레딧 소진 시 연결된 프로바이더별로 연결된 계정을 리스트업 혹은 추가 입력하도록 UI/UX 를 제시 (provider 변경은 좌우, 계정 선택은 위아래)"
 - Codex CLI `forced_login_method`: https://developers.openai.com/codex/config-reference
 - prompt_toolkit `bottom_toolbar` + refresh: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/277
 - Hermes auxiliary roles: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
@@ -323,6 +332,9 @@ PR-δ2 (seed-pipeline + petri user_overrides):
 - Stripe idempotency keys: https://docs.stripe.com/api/idempotent_requests
 - co-scientist paper: https://arxiv.org/abs/2502.18864 (§4.5 + §5)
 - AI-CoScientist reference impl: https://github.com/The-Swarm-Corporation/AI-CoScientist
+- paperclip / crumb subprocess pattern: `docs/audits/2026-05-18-i2-paperclip-review.md` + 외부 `~/workspace/crumb/src/adapters/claude-local.ts`
+- GEODE 기존 multi-profile infra: `core/auth/profiles.py` (AuthProfile + ProfileStore), `core/auth/rotation.py` (ProfileRotator), `core/auth/credential_breadcrumb.py` (LLM hint)
+- GEODE 기존 2-axis picker pattern: `core/cli/effort_picker.py` (`pick_model_and_effort` — Claude Code `ModelPicker.tsx` parity)
 
 ## Post-completion exit
 


### PR DESCRIPTION
## Summary
- ADR `docs/architecture/outer-loop-resume-decision.md` 에 2 신규 section: "Within-source account rotation" + "Account picker UX (2-axis)"
- Plan ledger 의 Phase ζ 가 6 → 8 PR — PR-ζ5.5 (ProfileRotator 외부 wiring) + PR-ζ5.6 (2-axis 계정 picker) 추가
- 핵심 발견: GEODE 가 이미 `core/auth/profiles.py` + `rotation.py` + `credential_breadcrumb.py` 라는 paperclip/crumb 보다 우월한 멀티 프로필 인프라 보유. outer-loop 가 0% 사용. wiring 만 하면 됨.

## Why
사용자 directive 2026-05-19 (2 메시지):
1. "paperclip, crumb 의 사례처럼 로컬에 기록된 계정 기록으로 롤아웃이 가능한지 살피고 현재 구조에서 어떻게 보강 구현할지도 고려"
2. "유저가 자연어 뿐 아니라 UI/UX 로도 선택/입력할 수 있게 개선 (GEODE 슬래시 명령어 구조 참고). 롤아웃 기준은 자동이 아니라 크레딧 소진 시 연결된 프로바이더별로 연결된 계정을 리스트업 혹은 추가 입력. provider 변경은 좌우, 계정 선택은 위아래"

paperclip/crumb 패턴은 subprocess `claude -p` + 로컬 OAuth 자동 픽업. GEODE 의 in-process 동등은 ProfileRotator 인데 outer-loop 가 안 씀.

자동 rollout 거부 + 크레딧 소진 시에만 picker 노출 = 사용자 directive 그대로.

## Changes
| File | Change |
|------|--------|
| `docs/architecture/outer-loop-resume-decision.md` | "Within-source account rotation" + "Account picker UX (2-axis)" section 추가, Implementation plan 의 PR 수 6 → 8 |
| `docs/plans/...consolidation.md` | Phase ζ ledger 에 PR-ζ5.5 + PR-ζ5.6 추가. Risk register 에 3 신규 risk. Reference 에 GEODE infra 인용. 사용자 directive 2개 추가 인용 |
| `CHANGELOG.md` | `[Unreleased] > Changed` ADR + plan extension 항목 |

## Verification
- [x] markdown 만 — 코드 변경 없음
- [x] Reference 검증: GEODE `core/auth/profiles.py` (AuthProfile 73라인), `rotation.py` (ProfileRotator.resolve 76라인), `credential_breadcrumb.py` (Claude Code createModelSwitchBreadcrumbs parity)
- [x] 외부 reference: `~/workspace/crumb/src/adapters/claude-local.ts` (paperclip review 의 인용)
- [x] 기존 2-axis picker 패턴 검증: `core/cli/effort_picker.py` (pick_model_and_effort)

## Reference
- 직전 ADR PR: #1310
- 사용자 directive: 위 Why 인용
- paperclip review: `docs/audits/2026-05-18-i2-paperclip-review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)