### PR TITLE
release: docs link basePath fix (#1330)

### DIFF
--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -344,6 +344,32 @@ def main() -> int:
         print("✅ no broken internal links")
     print()
 
+    # Raw `<a href="/docs/...">` in TSX bypasses Next.js basePath rewriting
+    # (only `<Link>` auto-prefixes). The resulting static HTML keeps the
+    # literal `/docs/...` which resolves at the domain root, returning 404
+    # on the deployed site at `mangowhoiscloud.github.io/docs/...` instead
+    # of `mangowhoiscloud.github.io/geode/docs/...`. Guard against the
+    # regression that PR #1330 fixed by failing on any raw `/docs/` href.
+    base_path_violations: list[str] = []
+    for link in links:
+        if link.target.startswith("/docs/"):
+            base_path_violations.append(
+                f"  {link.file.relative_to(args.base.parent)}:{link.line}  href={link.target!r} "
+                "(needs /geode prefix; raw <a> does not auto-prefix basePath)",
+            )
+    if base_path_violations:
+        print(
+            f"❌ {len(base_path_violations)} raw href missing /geode basePath:",
+        )
+        for line in base_path_violations:
+            print(line)
+        print()
+        print(
+            'Fix: replace `href="/docs/..."` with `href="/geode/docs/..."` '
+            "(or migrate to next/link `<Link>` which auto-prefixes).",
+        )
+        print()
+
     if unresolved and not args.quiet:
         print(f"ℹ️  {len(unresolved)} unresolved (interpolated or relative):")
         for line in unresolved[:20]:
@@ -364,7 +390,7 @@ def main() -> int:
         else:
             print("✅ all external URLs reachable")
 
-    return 1 if broken or ext_broken else 0
+    return 1 if broken or ext_broken or base_path_violations else 0
 
 
 if __name__ == "__main__":

--- a/site/src/app/docs/architecture/agentic-loop/page.tsx
+++ b/site/src/app/docs/architecture/agentic-loop/page.tsx
@@ -65,7 +65,7 @@ return response.text`}</pre>
               <code>build_system_prompt()</code>가 STATIC/DYNAMIC 경계
               마커(<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>)와 함께 시스템
               프롬프트를 조립합니다. Anthropic 어댑터는 이 마커를 기준으로 프롬프트
-              캐싱을 위해 분할합니다. <a href="/docs/runtime/llm/prompt-caching">프롬프트 캐싱</a>을
+              캐싱을 위해 분할합니다. <a href="/geode/docs/runtime/llm/prompt-caching">프롬프트 캐싱</a>을
               참고하세요.
             </p>
 
@@ -145,7 +145,7 @@ return response.text`}</pre>
               <code>core/agent/system_prompt.py</code> assembles the system prompt
               with a STATIC/DYNAMIC boundary marker (<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>).
               The Anthropic adapter splits at this marker for prompt caching. See{" "}
-              <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
+              <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
             </p>
 
             <h2>Hook integration</h2>

--- a/site/src/app/docs/ops/cost/page.tsx
+++ b/site/src/app/docs/ops/cost/page.tsx
@@ -21,7 +21,7 @@ export default function Page() {
               <li>실시간: <code>LLM_CALL_END</code> hook (per-call 토큰·달러).</li>
               <li>누적 (런타임): <code>geode /status</code> (현재 세션 + 일일).</li>
               <li>append-only ledger: <code>~/.geode/usage/&lt;date&gt;.jsonl</code> (v0.66+ 도입).</li>
-              <li>per-call assertion: <code>core.audit.diagnostics.CallDiagnostic</code> (v0.92+, <a href="/docs/verification/observability">Observability</a> 참조).</li>
+              <li>per-call assertion: <code>core.audit.diagnostics.CallDiagnostic</code> (v0.92+, <a href="/geode/docs/verification/observability">Observability</a> 참조).</li>
             </ul>
 
             <h2>Usage ledger 스키마</h2>
@@ -84,7 +84,7 @@ jq -s 'group_by(.model) | map({model: .[0].model, total: (map(.input_tokens + .o
 # 캐시 hit 호출만
 jq -c 'select(.cache_read_tokens > 0)' ~/.geode/usage/$(date +%F).jsonl`}</pre>
 
-            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/docs/verification/observability">Observability</a>, <a href="/docs/runtime/context">Context System (200K guard)</a>, wiki/concepts/geode-context-guard.md.</p>
+            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/geode/docs/verification/observability">Observability</a>, <a href="/geode/docs/runtime/context">Context System (200K guard)</a>, wiki/concepts/geode-context-guard.md.</p>
           </>
         }
         en={
@@ -96,7 +96,7 @@ jq -c 'select(.cache_read_tokens > 0)' ~/.geode/usage/$(date +%F).jsonl`}</pre>
               <li>Real-time: <code>LLM_CALL_END</code> hook (per-call tokens and dollars).</li>
               <li>Cumulative (runtime): <code>geode /status</code> (current session + day).</li>
               <li>Append-only ledger: <code>~/.geode/usage/&lt;date&gt;.jsonl</code> (introduced in v0.66).</li>
-              <li>Per-call assertion: <code>core.audit.diagnostics.CallDiagnostic</code> (v0.92+, see <a href="/docs/verification/observability">Observability</a>).</li>
+              <li>Per-call assertion: <code>core.audit.diagnostics.CallDiagnostic</code> (v0.92+, see <a href="/geode/docs/verification/observability">Observability</a>).</li>
             </ul>
 
             <h2>Usage ledger schema</h2>
@@ -161,7 +161,7 @@ jq -s 'group_by(.model) | map({model: .[0].model, total: (map(.input_tokens + .o
 # Cache-hit calls only
 jq -c 'select(.cache_read_tokens > 0)' ~/.geode/usage/$(date +%F).jsonl`}</pre>
 
-            <p className="text-white/40 text-sm"><em>See:</em> <a href="/docs/verification/observability">Observability</a>, <a href="/docs/runtime/context">Context System (200K guard)</a>, wiki/concepts/geode-context-guard.md.</p>
+            <p className="text-white/40 text-sm"><em>See:</em> <a href="/geode/docs/verification/observability">Observability</a>, <a href="/geode/docs/runtime/context">Context System (200K guard)</a>, wiki/concepts/geode-context-guard.md.</p>
           </>
         }
       />

--- a/site/src/app/docs/ops/long-running/page.tsx
+++ b/site/src/app/docs/ops/long-running/page.tsx
@@ -34,7 +34,7 @@ max_turns = 200`}</pre>
 
             <h2>관측</h2>
             <ul>
-              <li><a href="/docs/harness/hooks"><code>CONTEXT_OVERFLOW</code> hook</a> 으로 발생 감지</li>
+              <li><a href="/geode/docs/harness/hooks"><code>CONTEXT_OVERFLOW</code> hook</a> 으로 발생 감지</li>
               <li>Runlog에 사용량 시계열 기록</li>
             </ul>
 
@@ -63,7 +63,7 @@ max_turns = 200`}</pre>
 
             <h2>Observability</h2>
             <ul>
-              <li><a href="/docs/harness/hooks"><code>CONTEXT_OVERFLOW</code> hook</a> fires on hit.</li>
+              <li><a href="/geode/docs/harness/hooks"><code>CONTEXT_OVERFLOW</code> hook</a> fires on hit.</li>
               <li>Usage time series lands in runlog.</li>
             </ul>
 

--- a/site/src/app/docs/ops/oauth/page.tsx
+++ b/site/src/app/docs/ops/oauth/page.tsx
@@ -37,7 +37,7 @@ codex login
 geode /clean # 캐시 비우기
 geode serve & # 재기동`}</pre>
 
-            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-oauth-policy.md, <a href="/docs/runtime/auth">Auth and OAuth reference</a></p>
+            <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-oauth-policy.md, <a href="/geode/docs/runtime/auth">Auth and OAuth reference</a></p>
           </>
         }
         en={
@@ -65,7 +65,7 @@ codex login
 geode /clean # clear caches
 geode serve & # restart`}</pre>
 
-            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-oauth-policy.md, <a href="/docs/runtime/auth">Auth and OAuth reference</a>.</p>
+            <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-oauth-policy.md, <a href="/geode/docs/runtime/auth">Auth and OAuth reference</a>.</p>
           </>
         }
       />

--- a/site/src/app/docs/petri/bundle/page.tsx
+++ b/site/src/app/docs/petri/bundle/page.tsx
@@ -42,14 +42,14 @@ export default function Page() {
 
             <h2>Bundle을 새로 만들려면</h2>
             <p>
-              <a href="/docs/petri/run">감사 실행</a> 가이드에 따라 audit를 돌린 뒤 결과 디렉토리를
+              <a href="/geode/docs/petri/run">감사 실행</a> 가이드에 따라 audit를 돌린 뒤 결과 디렉토리를
               <code>site/public/petri-bundle/</code>에 publish 합니다. Pages workflow가 path-filter <code>site/**</code>를
               잡고 자동 deploy합니다.
             </p>
 
             <h2>점수 해석</h2>
             <p>
-              차원별 의미와 0-3 점수 스케일은 <a href="/docs/petri/judge-dimensions">38 Judge 차원</a> 페이지를 참조하세요.
+              차원별 의미와 0-3 점수 스케일은 <a href="/geode/docs/petri/judge-dimensions">38 Judge 차원</a> 페이지를 참조하세요.
             </p>
 
             <p className="text-white/40 text-sm">
@@ -86,14 +86,14 @@ export default function Page() {
 
             <h2>Publishing a new bundle</h2>
             <p>
-              Follow the <a href="/docs/petri/run">Run an Audit</a> guide, then drop the result directory at
+              Follow the <a href="/geode/docs/petri/run">Run an Audit</a> guide, then drop the result directory at
               <code>site/public/petri-bundle/</code>. The Pages workflow path-filter <code>site/**</code>
               will deploy automatically.
             </p>
 
             <h2>Score interpretation</h2>
             <p>
-              For dimension meanings and the 0-3 score scale, see <a href="/docs/petri/judge-dimensions">38 Judge Dimensions</a>.
+              For dimension meanings and the 0-3 score scale, see <a href="/geode/docs/petri/judge-dimensions">38 Judge Dimensions</a>.
             </p>
 
             <p className="text-white/40 text-sm">

--- a/site/src/app/docs/petri/run/page.tsx
+++ b/site/src/app/docs/petri/run/page.tsx
@@ -73,9 +73,9 @@ export default function Page() {
 
             <h2>다음 단계</h2>
             <ul>
-              <li>점수 의미: <a href="/docs/petri/judge-dimensions">17/38 Judge 차원</a></li>
-              <li>관측 분석: <a href="/docs/verification/observability">관측성</a></li>
-              <li>비용: <a href="/docs/ops/cost">비용 모니터링</a></li>
+              <li>점수 의미: <a href="/geode/docs/petri/judge-dimensions">17/38 Judge 차원</a></li>
+              <li>관측 분석: <a href="/geode/docs/verification/observability">관측성</a></li>
+              <li>비용: <a href="/geode/docs/ops/cost">비용 모니터링</a></li>
             </ul>
           </>
         }
@@ -142,9 +142,9 @@ export default function Page() {
 
             <h2>Next</h2>
             <ul>
-              <li>What the scores mean: <a href="/docs/petri/judge-dimensions">17/38 Judge Dimensions</a></li>
-              <li>Bigger picture: <a href="/docs/verification/observability">Observability</a></li>
-              <li>Cost: <a href="/docs/ops/cost">Cost Monitoring</a></li>
+              <li>What the scores mean: <a href="/geode/docs/petri/judge-dimensions">17/38 Judge Dimensions</a></li>
+              <li>Bigger picture: <a href="/geode/docs/verification/observability">Observability</a></li>
+              <li>Cost: <a href="/geode/docs/ops/cost">Cost Monitoring</a></li>
             </ul>
           </>
         }

--- a/site/src/app/docs/petri/scenarios/page.tsx
+++ b/site/src/app/docs/petri/scenarios/page.tsx
@@ -85,8 +85,8 @@ export default function Page() {
             <h2>참고</h2>
             <ul>
               <li>현 GEODE seeds 첫 등장: v0.91.0 (scenarios v1) → v0.92.0 (v2) → v0.93.0 (v3). audit reports는 <code>docs/audits/</code>.</li>
-              <li>실행: <a href="/docs/petri/run">감사 실행</a></li>
-              <li>차원: <a href="/docs/petri/judge-dimensions">38 Judge 차원</a></li>
+              <li>실행: <a href="/geode/docs/petri/run">감사 실행</a></li>
+              <li>차원: <a href="/geode/docs/petri/judge-dimensions">38 Judge 차원</a></li>
               <li>publish된 결과: <a href="/petri-bundle/">/geode/petri-bundle/</a></li>
             </ul>
           </>
@@ -148,8 +148,8 @@ export default function Page() {
             <h2>See also</h2>
             <ul>
               <li>GEODE seeds first landed in v0.91.0 (scenarios v1), v0.92.0 (v2), v0.93.0 (v3). Audit reports under <code>docs/audits/</code>.</li>
-              <li>Run: <a href="/docs/petri/run">Run an Audit</a></li>
-              <li>Dimensions: <a href="/docs/petri/judge-dimensions">38 Judge Dimensions</a></li>
+              <li>Run: <a href="/geode/docs/petri/run">Run an Audit</a></li>
+              <li>Dimensions: <a href="/geode/docs/petri/judge-dimensions">38 Judge Dimensions</a></li>
               <li>Published results: <a href="/petri-bundle/">/geode/petri-bundle/</a></li>
             </ul>
           </>

--- a/site/src/app/docs/reference/external-references/page.tsx
+++ b/site/src/app/docs/reference/external-references/page.tsx
@@ -62,7 +62,7 @@ export default function Page() {
             <h2>Petri / inspect_ai</h2>
             <ul>
               <li>
-                <strong>Anthropic Alignment Science Petri</strong> — alignment audit framework (Auditor·Target·Judge 3-role, 173 seeds, 38 dims). 본 docs <a href="/docs/petri/overview">Petri × GEODE</a> 챕터 전체.
+                <strong>Anthropic Alignment Science Petri</strong> — alignment audit framework (Auditor·Target·Judge 3-role, 173 seeds, 38 dims). 본 docs <a href="/geode/docs/petri/overview">Petri × GEODE</a> 챕터 전체.
               </li>
               <li>
                 <strong>inspect_ai (UK AISI)</strong>{" "}
@@ -100,7 +100,7 @@ export default function Page() {
             <h2>Karpathy autoresearch (2026-03) 의 5 reusable pattern</h2>
             <p>
               GEODE의 핵심 안전 메커니즘은 Karpathy의 autoresearch 패턴을 long-running agent context로 일반화한 것입니다.
-              <a href="/docs/explanation/ratchet">왜 ratchet 규율인가</a> 페이지에서 직접 인용합니다.
+              <a href="/geode/docs/explanation/ratchet">왜 ratchet 규율인가</a> 페이지에서 직접 인용합니다.
             </p>
             <ol>
               <li><strong>Fixed wall-budget</strong>으로 비교가능성 보존. 모든 실험이 5분 wall-clock. → GEODE의 StuckDetector 7200s + 30s wrap-up headroom.</li>
@@ -167,7 +167,7 @@ export default function Page() {
             <ul>
               <li>
                 <strong>Anthropic Alignment Science Petri</strong> — alignment audit framework (Auditor, Target, Judge,
-                173 seeds, 38 dims). Covered in the <a href="/docs/petri/overview">Petri × GEODE</a> chapter.
+                173 seeds, 38 dims). Covered in the <a href="/geode/docs/petri/overview">Petri × GEODE</a> chapter.
               </li>
               <li>
                 <strong>inspect_ai (UK AISI)</strong>{" "}
@@ -213,7 +213,7 @@ export default function Page() {
             <h2>Karpathy autoresearch (2026-03): five reusable patterns</h2>
             <p>
               GEODE's core safety mechanism generalizes Karpathy's autoresearch patterns to a long-running agent
-              context. <a href="/docs/explanation/ratchet">Why Ratchet Discipline</a> cites these directly.
+              context. <a href="/geode/docs/explanation/ratchet">Why Ratchet Discipline</a> cites these directly.
             </p>
             <ol>
               <li><strong>Fixed wall-budget</strong> preserves comparability. Every experiment is five minutes of wall-clock. GEODE's StuckDetector at 7200s plus 30s wrap-up headroom is the generalized form.</li>

--- a/site/src/app/docs/run/messaging/page.tsx
+++ b/site/src/app/docs/run/messaging/page.tsx
@@ -32,7 +32,7 @@ channels = ["#geode"]`}</pre>
             <p>설정 후 <code>geode serve</code> 재시작하면 자동 binding 됩니다.</p>
 
             <h2>커스텀 어댑터</h2>
-            <p>새 메신저를 붙이려면 <code>core/gateway/</code>의 base adapter를 구현하세요. 자세한 절차는 <a href="/docs/runtime/tools/protocol">도구 추가하기</a>를 참조.</p>
+            <p>새 메신저를 붙이려면 <code>core/gateway/</code>의 base adapter를 구현하세요. 자세한 절차는 <a href="/geode/docs/runtime/tools/protocol">도구 추가하기</a>를 참조.</p>
 
             <p className="text-white/40 text-sm"><em>참조:</em> wiki/concepts/geode-gateway.md, geode-serve skill</p>
           </>
@@ -57,7 +57,7 @@ channels = ["#geode"]`}</pre>
             <p>After saving, restart <code>geode serve</code> to bind.</p>
 
             <h2>Custom adapter</h2>
-            <p>To support a new messenger, implement the base adapter under <code>core/gateway/</code>. See <a href="/docs/runtime/tools/protocol">Add a Tool</a> for the general pattern.</p>
+            <p>To support a new messenger, implement the base adapter under <code>core/gateway/</code>. See <a href="/geode/docs/runtime/tools/protocol">Add a Tool</a> for the general pattern.</p>
 
             <p className="text-white/40 text-sm"><em>See:</em> wiki/concepts/geode-gateway.md, geode-serve skill.</p>
           </>

--- a/site/src/app/docs/run/pick-path/page.tsx
+++ b/site/src/app/docs/run/pick-path/page.tsx
@@ -28,8 +28,8 @@ export default function Page() {
 
             <h2>다음</h2>
             <ul>
-              <li><a href="/docs/run/providers">프로바이더 설정</a>으로 키를 등록합니다.</li>
-              <li>비용 가드는 <a href="/docs/ops/cost">비용 모니터링</a>에서.</li>
+              <li><a href="/geode/docs/run/providers">프로바이더 설정</a>으로 키를 등록합니다.</li>
+              <li>비용 가드는 <a href="/geode/docs/ops/cost">비용 모니터링</a>에서.</li>
             </ul>
 
             <p className="text-white/40 text-sm"><em>출처:</em> 본 repo README §Path A/B + wiki/concepts/geode-llm-models.md</p>
@@ -51,8 +51,8 @@ export default function Page() {
 
             <h2>Next</h2>
             <ul>
-              <li>Register your keys: <a href="/docs/run/providers">Configure Providers</a>.</li>
-              <li>Cost guards live in <a href="/docs/ops/cost">Cost Monitoring</a>.</li>
+              <li>Register your keys: <a href="/geode/docs/run/providers">Configure Providers</a>.</li>
+              <li>Cost guards live in <a href="/geode/docs/ops/cost">Cost Monitoring</a>.</li>
             </ul>
 
             <p className="text-white/40 text-sm"><em>Source:</em> repo README §Path A/B and wiki/concepts/geode-llm-models.md.</p>

--- a/site/src/app/docs/run/schedule/page.tsx
+++ b/site/src/app/docs/run/schedule/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
               <li>일시정지: <code>geode schedule pause &lt;id&gt;</code></li>
             </ul>
 
-            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/docs/runtime/scheduler">Scheduler reference</a>, wiki/concepts/geode-lifecycle-commands.md</p>
+            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/geode/docs/runtime/scheduler">Scheduler reference</a>, wiki/concepts/geode-lifecycle-commands.md</p>
           </>
         }
         en={
@@ -57,7 +57,7 @@ export default function Page() {
               <li>Pause: <code>geode schedule pause &lt;id&gt;</code></li>
             </ul>
 
-            <p className="text-white/40 text-sm"><em>See:</em> <a href="/docs/runtime/scheduler">Scheduler reference</a>, wiki/concepts/geode-lifecycle-commands.md.</p>
+            <p className="text-white/40 text-sm"><em>See:</em> <a href="/geode/docs/runtime/scheduler">Scheduler reference</a>, wiki/concepts/geode-lifecycle-commands.md.</p>
           </>
         }
       />

--- a/site/src/app/docs/run/serve/page.tsx
+++ b/site/src/app/docs/run/serve/page.tsx
@@ -44,7 +44,7 @@ geode serve &`}</pre>
 geode /model      # 현재 활성 모델
 geode /clean      # 캐시 비우기`}</pre>
 
-            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/docs/harness/lifecycle">Lifecycle reference</a>, wiki/concepts/geode-lifecycle-commands.md</p>
+            <p className="text-white/40 text-sm"><em>참조:</em> <a href="/geode/docs/harness/lifecycle">Lifecycle reference</a>, wiki/concepts/geode-lifecycle-commands.md</p>
           </>
         }
         en={
@@ -79,7 +79,7 @@ geode serve &`}</pre>
 geode /model      # current active model
 geode /clean      # clear caches`}</pre>
 
-            <p className="text-white/40 text-sm"><em>See:</em> <a href="/docs/harness/lifecycle">Lifecycle reference</a>, wiki/concepts/geode-lifecycle-commands.md.</p>
+            <p className="text-white/40 text-sm"><em>See:</em> <a href="/geode/docs/harness/lifecycle">Lifecycle reference</a>, wiki/concepts/geode-lifecycle-commands.md.</p>
           </>
         }
       />

--- a/site/src/app/docs/run/troubleshooting/page.tsx
+++ b/site/src/app/docs/run/troubleshooting/page.tsx
@@ -21,17 +21,17 @@ export default function Page() {
               <thead><tr><th>증상</th><th>1차 확인</th></tr></thead>
               <tbody>
                 <tr><td>"키가 없어요" 에러</td><td><code>echo $ANTHROPIC_API_KEY</code>와 <code>~/.geode/config.toml</code></td></tr>
-                <tr><td>"context overflow" 종료</td><td><a href="/docs/ops/long-running">장기 실행 안전</a> 가이드</td></tr>
+                <tr><td>"context overflow" 종료</td><td><a href="/geode/docs/ops/long-running">장기 실행 안전</a> 가이드</td></tr>
                 <tr><td>"MCP server timeout"</td><td><code>geode /status</code>로 MCP 헬스 확인</td></tr>
-                <tr><td>토큰 비용 초과</td><td><a href="/docs/ops/cost">비용 모니터링</a> + <code>geode /model</code>로 다운그레이드</td></tr>
-                <tr><td>OAuth 토큰 만료</td><td><a href="/docs/ops/oauth">OAuth 토큰 회전</a></td></tr>
+                <tr><td>토큰 비용 초과</td><td><a href="/geode/docs/ops/cost">비용 모니터링</a> + <code>geode /model</code>로 다운그레이드</td></tr>
+                <tr><td>OAuth 토큰 만료</td><td><a href="/geode/docs/ops/oauth">OAuth 토큰 회전</a></td></tr>
               </tbody>
             </table>
 
             <h2>로그 위치</h2>
             <ul>
               <li>Runlog: <code>~/.geode/runlog/</code> (run 단위 trace)</li>
-              <li>Hooks: <a href="/docs/harness/hooks">Hook System</a> events</li>
+              <li>Hooks: <a href="/geode/docs/harness/hooks">Hook System</a> events</li>
               <li>Serve: <code>~/.geode/serve.log</code></li>
             </ul>
 
@@ -48,17 +48,17 @@ export default function Page() {
               <thead><tr><th>Symptom</th><th>First look</th></tr></thead>
               <tbody>
                 <tr><td>"missing key" error</td><td><code>echo $ANTHROPIC_API_KEY</code> and <code>~/.geode/config.toml</code></td></tr>
-                <tr><td>"context overflow" termination</td><td><a href="/docs/ops/long-running">Long-running Safety</a></td></tr>
+                <tr><td>"context overflow" termination</td><td><a href="/geode/docs/ops/long-running">Long-running Safety</a></td></tr>
                 <tr><td>"MCP server timeout"</td><td><code>geode /status</code> for MCP health</td></tr>
-                <tr><td>Token cost overrun</td><td><a href="/docs/ops/cost">Cost Monitoring</a> + <code>geode /model</code> to downgrade</td></tr>
-                <tr><td>OAuth token expired</td><td><a href="/docs/ops/oauth">OAuth Token Rotation</a></td></tr>
+                <tr><td>Token cost overrun</td><td><a href="/geode/docs/ops/cost">Cost Monitoring</a> + <code>geode /model</code> to downgrade</td></tr>
+                <tr><td>OAuth token expired</td><td><a href="/geode/docs/ops/oauth">OAuth Token Rotation</a></td></tr>
               </tbody>
             </table>
 
             <h2>Where logs live</h2>
             <ul>
               <li>Runlog: <code>~/.geode/runlog/</code> (per-run traces)</li>
-              <li>Hooks: <a href="/docs/harness/hooks">Hook System</a> events</li>
+              <li>Hooks: <a href="/geode/docs/harness/hooks">Hook System</a> events</li>
               <li>Serve: <code>~/.geode/serve.log</code></li>
             </ul>
 

--- a/site/src/app/docs/runtime/context/page.tsx
+++ b/site/src/app/docs/runtime/context/page.tsx
@@ -101,7 +101,7 @@ class AssembledPrompt:
               <li><strong>GLM, Codex</strong>. 프로바이더 관리.</li>
             </ul>
             <p>
-              자세히: <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
+              자세히: <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
             </p>
 
             <h2>다른 시스템 비교</h2>
@@ -117,10 +117,10 @@ class AssembledPrompt:
 
             <h2>관련 문서</h2>
             <ul>
-              <li>cache 메커니즘: <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a></li>
-              <li>해시 ratchet: <a href="/docs/runtime/llm/prompt-hashing">Prompt Hashing</a></li>
-              <li>system prompt 변형: <a href="/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a></li>
-              <li>장기 실행 가드: <a href="/docs/ops/long-running">Long-running Safety</a></li>
+              <li>cache 메커니즘: <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a></li>
+              <li>해시 ratchet: <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a></li>
+              <li>system prompt 변형: <a href="/geode/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a></li>
+              <li>장기 실행 가드: <a href="/geode/docs/ops/long-running">Long-running Safety</a></li>
               <li>외부 사료: <code>mango-wiki/.../concepts/geode-memory-system.md</code>, <code>geode-prompt-assembly.md</code>, <code>geode-context-guard.md</code>, <code>geode-context-overflow-prevention.md</code></li>
             </ul>
           </>
@@ -222,7 +222,7 @@ class AssembledPrompt:
               <li><strong>GLM, Codex</strong>: provider-managed.</li>
             </ul>
             <p>
-              Details: <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
+              Details: <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.
             </p>
 
             <h2>Comparison with other systems</h2>
@@ -238,10 +238,10 @@ class AssembledPrompt:
 
             <h2>Related</h2>
             <ul>
-              <li>Cache mechanism: <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a></li>
-              <li>Hash ratchet: <a href="/docs/runtime/llm/prompt-hashing">Prompt Hashing</a></li>
-              <li>System prompt variants: <a href="/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a></li>
-              <li>Long-running guards: <a href="/docs/ops/long-running">Long-running Safety</a></li>
+              <li>Cache mechanism: <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a></li>
+              <li>Hash ratchet: <a href="/geode/docs/runtime/llm/prompt-hashing">Prompt Hashing</a></li>
+              <li>System prompt variants: <a href="/geode/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a></li>
+              <li>Long-running guards: <a href="/geode/docs/ops/long-running">Long-running Safety</a></li>
               <li>External sources: <code>mango-wiki/.../concepts/geode-memory-system.md</code>, <code>geode-prompt-assembly.md</code>, <code>geode-context-guard.md</code>, <code>geode-context-overflow-prevention.md</code></li>
             </ul>
           </>

--- a/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
+++ b/site/src/app/docs/runtime/llm/prompt-caching/page.tsx
@@ -29,7 +29,7 @@ __GEODE_PROMPT_CACHE_BOUNDARY__
 </dynamic_context>`}</pre>
             <p>
               <code>build_system_prompt()</code>이 이 marker를 두 섹션 사이에 삽입합니다.
-              audit-mode는 dynamic 블록을 strip합니다 (<a href="/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a> 참조).
+              audit-mode는 dynamic 블록을 strip합니다 (<a href="/geode/docs/runtime/llm/system-prompt-modes">System Prompt Modes</a> 참조).
             </p>
             <ul>
               <li>

--- a/site/src/app/docs/runtime/llm/providers/page.tsx
+++ b/site/src/app/docs/runtime/llm/providers/page.tsx
@@ -58,7 +58,7 @@ GLM_FALLBACK_CHAIN       = ["glm-5.1", "glm-5", "glm-5-turbo",
 
             <h2>캐싱</h2>
             <ul>
-              <li><strong>Anthropic</strong>. system 블록에 `cache_control: ephemeral` (<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>를 통한 STATIC/DYNAMIC 분할) 과 최근 3개 non-system 메시지에 대한 <code>apply_messages_cache_control()</code> (PR #864). <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a> 참조.</li>
+              <li><strong>Anthropic</strong>. system 블록에 `cache_control: ephemeral` (<code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>를 통한 STATIC/DYNAMIC 분할) 과 최근 3개 non-system 메시지에 대한 <code>apply_messages_cache_control()</code> (PR #864). <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a> 참조.</li>
               <li><strong>OpenAI</strong>. 서버 측 자동 prompt 캐싱 (GEODE wiring 불필요).</li>
               <li><strong>GLM / Codex</strong>. 프로바이더 관리.</li>
             </ul>
@@ -136,7 +136,7 @@ GLM_FALLBACK_CHAIN       = ["glm-5.1", "glm-5", "glm-5-turbo",
 
             <h2>Caching</h2>
             <ul>
-              <li><strong>Anthropic</strong> — `cache_control: ephemeral` on system block (STATIC/DYNAMIC split via <code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>) plus <code>apply_messages_cache_control()</code> on the last 3 non-system messages (PR #864). See <a href="/docs/runtime/llm/prompt-caching">Prompt Caching</a>.</li>
+              <li><strong>Anthropic</strong> — `cache_control: ephemeral` on system block (STATIC/DYNAMIC split via <code>__GEODE_PROMPT_CACHE_BOUNDARY__</code>) plus <code>apply_messages_cache_control()</code> on the last 3 non-system messages (PR #864). See <a href="/geode/docs/runtime/llm/prompt-caching">Prompt Caching</a>.</li>
               <li><strong>OpenAI</strong> — server-side automatic prompt caching (no GEODE wiring required).</li>
               <li><strong>GLM / Codex</strong> — provider-managed.</li>
             </ul>

--- a/site/src/app/docs/runtime/llm/system-prompt-modes/page.tsx
+++ b/site/src/app/docs/runtime/llm/system-prompt-modes/page.tsx
@@ -43,7 +43,7 @@ export GEODE_PERSONA=on
               평가자(Auditor·Judge)는 vanilla LLM과 비교 가능한 transcript를 받습니다.
             </p>
             <ul>
-              <li><a href="/docs/petri/run">Petri audit 실행</a> 가이드 참조.</li>
+              <li><a href="/geode/docs/petri/run">Petri audit 실행</a> 가이드 참조.</li>
               <li>strip 대상: GEODE_PERSONA 블록 + <code>&lt;dynamic_context&gt;</code> 일부.</li>
               <li>유지 대상: 도구 정의, MCP 설명, 기본 안전 가드.</li>
             </ul>
@@ -55,7 +55,7 @@ export GEODE_PERSONA=on
             </ul>
 
             <p className="text-white/40 text-sm">
-              <em>참조:</em> <a href="/docs/runtime/llm/prompt-system">Prompt System</a>, <a href="/docs/petri/overview">Petri × GEODE</a>, CHANGELOG v0.92~0.93.
+              <em>참조:</em> <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a>, <a href="/geode/docs/petri/overview">Petri × GEODE</a>, CHANGELOG v0.92~0.93.
             </p>
           </>
         }
@@ -91,7 +91,7 @@ export GEODE_PERSONA=on
               not buried under GEODE identity. The auditor and judge receive a transcript comparable to a vanilla LLM.
             </p>
             <ul>
-              <li>See <a href="/docs/petri/run">Run an Audit</a>.</li>
+              <li>See <a href="/geode/docs/petri/run">Run an Audit</a>.</li>
               <li>Stripped: the GEODE_PERSONA block plus part of <code>&lt;dynamic_context&gt;</code>.</li>
               <li>Kept: tool definitions, MCP descriptions, baseline safety guards.</li>
             </ul>
@@ -103,7 +103,7 @@ export GEODE_PERSONA=on
             </ul>
 
             <p className="text-white/40 text-sm">
-              <em>See:</em> <a href="/docs/runtime/llm/prompt-system">Prompt System</a>, <a href="/docs/petri/overview">Petri × GEODE</a>, CHANGELOG v0.92-0.93.
+              <em>See:</em> <a href="/geode/docs/runtime/llm/prompt-system">Prompt System</a>, <a href="/geode/docs/petri/overview">Petri × GEODE</a>, CHANGELOG v0.92-0.93.
             </p>
           </>
         }

--- a/site/src/app/docs/runtime/skills/page.tsx
+++ b/site/src/app/docs/runtime/skills/page.tsx
@@ -78,7 +78,7 @@ priority: 100
             <p>등록 시점: 다음 bootstrap 또는 session 재시작 시 자동 인식.</p>
 
             <p className="text-white/40 text-sm">
-              <em>참조:</em> <a href="/docs/runtime/context">Context System</a> (5-layer prompt assembly에서 skill이 L3로 주입),
+              <em>참조:</em> <a href="/geode/docs/runtime/context">Context System</a> (5-layer prompt assembly에서 skill이 L3로 주입),
               wiki/concepts/geode-prompt-assembly.md, portfolio §3 Recursion (scaffold 측 skill discovery와 mirror).
             </p>
           </>
@@ -149,7 +149,7 @@ priority: 100
             <p>The skill is picked up at the next bootstrap or session restart.</p>
 
             <p className="text-white/40 text-sm">
-              <em>See:</em> <a href="/docs/runtime/context">Context System</a> (the skill is injected at L3 of the
+              <em>See:</em> <a href="/geode/docs/runtime/context">Context System</a> (the skill is injected at L3 of the
               5-layer prompt assembly), wiki/concepts/geode-prompt-assembly.md, portfolio §3 Recursion (mirror of
               scaffold-side skill discovery).
             </p>

--- a/site/src/app/docs/verification/observability/page.tsx
+++ b/site/src/app/docs/verification/observability/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
                 <tr><td><strong>Hooks</strong></td><td>이벤트 (58개)</td><td>micro (μs to ms)</td><td><code>core/hooks/system.py</code></td><td>core</td></tr>
                 <tr><td><strong>RunLog</strong></td><td>run (LLM 호출 1회)</td><td>medium (s)</td><td><code>~/.geode/runlog/</code> JSONL</td><td>core</td></tr>
                 <tr><td><strong>Audit diagnostics</strong></td><td>call (input/output/cost)</td><td>per-call (assertion-grade)</td><td><code>core.audit.diagnostics</code></td><td>v0.92.0</td></tr>
-                <tr><td><strong>Petri Audit</strong></td><td>scenario (N seeds × M turns)</td><td>session (min to hour)</td><td><a href="/docs/petri/overview">Petri × GEODE</a></td><td>v0.92.0+</td></tr>
+                <tr><td><strong>Petri Audit</strong></td><td>scenario (N seeds × M turns)</td><td>session (min to hour)</td><td><a href="/geode/docs/petri/overview">Petri × GEODE</a></td><td>v0.92.0+</td></tr>
               </tbody>
             </table>
 
@@ -55,7 +55,7 @@ export default function Page() {
               </tbody>
             </table>
             <p>
-              자세히: <a href="/docs/harness/hooks">Hook System</a>.
+              자세히: <a href="/geode/docs/harness/hooks">Hook System</a>.
             </p>
 
             <h2>렌즈 2. RunLog</h2>
@@ -108,10 +108,10 @@ class CallDiagnostic:
               세션 단위 grain. N seeds × M turns의 격자로 misalignment risk를 측정. Auditor(적대) · Target(GEODE) · Judge 3-role 구성.
             </p>
             <ul>
-              <li>전체 통합: <a href="/docs/petri/overview">Petri × GEODE Integration</a></li>
-              <li>시나리오: <a href="/docs/petri/scenarios">Petri Scenarios</a> (173 default + 13 GEODE-specific)</li>
-              <li>실행: <a href="/docs/petri/run">Petri Run</a></li>
-              <li>차원: <a href="/docs/petri/judge-dimensions">17/38 Judge 차원</a></li>
+              <li>전체 통합: <a href="/geode/docs/petri/overview">Petri × GEODE Integration</a></li>
+              <li>시나리오: <a href="/geode/docs/petri/scenarios">Petri Scenarios</a> (173 default + 13 GEODE-specific)</li>
+              <li>실행: <a href="/geode/docs/petri/run">Petri Run</a></li>
+              <li>차원: <a href="/geode/docs/petri/judge-dimensions">17/38 Judge 차원</a></li>
             </ul>
 
             <h2>Usage Ledger (v0.66+)</h2>
@@ -171,7 +171,7 @@ $ jq -c 'select(.cache_read_tokens > 0)' ~/.geode/usage/2026-05-12.jsonl  # 캐�
                 <tr><td><strong>Hooks</strong></td><td>events (58)</td><td>micro (μs to ms)</td><td><code>core/hooks/system.py</code></td><td>core</td></tr>
                 <tr><td><strong>RunLog</strong></td><td>run (one LLM call)</td><td>medium (seconds)</td><td><code>~/.geode/runlog/</code> JSONL</td><td>core</td></tr>
                 <tr><td><strong>Audit diagnostics</strong></td><td>call (input/output/cost)</td><td>per-call assertion-grade</td><td><code>core.audit.diagnostics</code></td><td>v0.92.0</td></tr>
-                <tr><td><strong>Petri Audit</strong></td><td>scenario (N seeds × M turns)</td><td>session (minutes to hours)</td><td><a href="/docs/petri/overview">Petri × GEODE</a></td><td>v0.92.0+</td></tr>
+                <tr><td><strong>Petri Audit</strong></td><td>scenario (N seeds × M turns)</td><td>session (minutes to hours)</td><td><a href="/geode/docs/petri/overview">Petri × GEODE</a></td><td>v0.92.0+</td></tr>
               </tbody>
             </table>
 
@@ -201,7 +201,7 @@ $ jq -c 'select(.cache_read_tokens > 0)' ~/.geode/usage/2026-05-12.jsonl  # 캐�
               </tbody>
             </table>
             <p>
-              Details: <a href="/docs/harness/hooks">Hook System</a>.
+              Details: <a href="/geode/docs/harness/hooks">Hook System</a>.
             </p>
 
             <h2>Lens 2. RunLog</h2>
@@ -258,10 +258,10 @@ class CallDiagnostic:
               (adversarial), Target (GEODE), Judge.
             </p>
             <ul>
-              <li>Integration: <a href="/docs/petri/overview">Petri × GEODE Integration</a></li>
-              <li>Scenarios: <a href="/docs/petri/scenarios">Petri Scenarios</a> (173 default plus 13 GEODE-specific)</li>
-              <li>Run: <a href="/docs/petri/run">Petri Run</a></li>
-              <li>Dimensions: <a href="/docs/petri/judge-dimensions">17 / 38 Judge Dimensions</a></li>
+              <li>Integration: <a href="/geode/docs/petri/overview">Petri × GEODE Integration</a></li>
+              <li>Scenarios: <a href="/geode/docs/petri/scenarios">Petri Scenarios</a> (173 default plus 13 GEODE-specific)</li>
+              <li>Run: <a href="/geode/docs/petri/run">Petri Run</a></li>
+              <li>Dimensions: <a href="/geode/docs/petri/judge-dimensions">17 / 38 Judge Dimensions</a></li>
             </ul>
 
             <h2>Usage Ledger (since v0.66)</h2>


### PR DESCRIPTION
## Summary
- PR #1330 promotion: 77 raw hrefs basePath prefix 정정 + check_docs_links ratchet.
- 라이브 docs 의 42 broken internal link 해소.

## Verification
- [x] PR #1330 CI 11/11 green, develop 머지 완료.
- [ ] (post-merge) pages.yml deploy success + 라이브 재크롤 broken=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)