### PR TITLE
autoresearch self-positioning rewrite — drop fork framing + name petri/autoresearch role split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,25 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **autoresearch self-positioning rewrite — drop "fork" framing, name the
+  petri/autoresearch role split.** The 5 autoresearch files (`__init__.py`,
+  `program.md`, `README.md`, `train.py` docstring, `prepare.py`) no longer
+  describe themselves as "a Petri-signal fork of Karpathy/autoresearch".
+  autoresearch is now framed as **GEODE's self-improving loop driver**:
+  petri owns the *measurement* layer (rubric + dim scoring +
+  `dim_extractor` raw `mean`/`stderr`); autoresearch owns the
+  *aggregation + selection* layer (tier classification, weights, cross-axis
+  gate, auto-promote). The 3-file shape + fixed-budget loop + git-as-optimiser
+  idiom borrowed from Karpathy autoresearch (MIT, 2026-03) stay credited
+  as attribution but are no longer the headline framing. README.md adds a
+  role-split table verifying no code duplication between petri's
+  `core/audit/dim_extractor.extract_dim_aggregates` (raw measurement only)
+  and autoresearch's `compute_fitness` (selection only). No behaviour
+  change — `prepare.py` stdout banner and `train.py` docstring header are
+  the only string outputs that move.
+
 ### Added
 
 - **PR-ε1 — `geode config migrate-petri-toml` CLI + sample

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -1,27 +1,40 @@
-# autoresearch — Petri-signal fork (GEODE)
+# autoresearch — GEODE self-improving loop driver
 
-A GEODE Petri-domain fork of Karpathy's
-[autoresearch](https://github.com/karpathy/autoresearch) (MIT, 2026-03,
-26K+ stars — a single-file ML training loop). The original
-3-file pattern (`prepare` / `train` / `program.md`), fixed-budget
-loop, and "git as optimiser" philosophy are kept verbatim; the domain
-is swapped from ML (GPT pre-train + `val_bpb`) to alignment auditing
-(Petri seed pool + AlphaEval fitness).
+`autoresearch/` is **GEODE's self-improving loop driver**. Petri's
+`geode audit` subprocess scores each transcript on the 20-dim alignment
+rubric and emits a per-dim `mean + stderr` baseline; this driver runs
+the wrapper-prompt mutation loop on top of that baseline, picking
+hypotheses that push the fitness scalar up without regressing the
+5 critical dims.
 
-## Why fork instead of port
+The 3-file shape (`prepare` / `train` / `program.md`), fixed per-run
+budget, and "git as optimiser" idiom are borrowed from Karpathy's
+[autoresearch](https://github.com/karpathy/autoresearch) (MIT,
+2026-03, 26K+ stars). The domain is GEODE's own alignment audit —
+not GPT pre-training — so `val_bpb` is replaced by the AlphaEval
+fitness scalar, `fineweb` tokenisation by the Petri seed pool +
+20-dim rubric, and the Muon-optimised training loop by a single
+audit invocation per file edit.
 
-The 3-file constraint Karpathy keeps so small is **the** design.
-The self-improving-loop agent (Claude Code / Codex) advances research by
-mutating a single file and grepping a few metrics. If GEODE's
-self-improving loop can pass through the same constraint, the cost frontier of
-self-improvement simplifies sharply. This fork places an equivalent
-single-mutation file (`train.py`) and a read-only harness
-(`prepare.py`) inside the GEODE tree to reuse exactly that loop
-pattern.
+## Role split — petri vs autoresearch
+
+| Layer | Owner | Outputs |
+|------|-------|---------|
+| dim universe (20 names + 3 info) | `plugins/petri_audit/judge_dims/geode_5axes.yaml` | rubric YAML |
+| per-dim raw measurement (`mean` + `stderr`, 1-10 concerning scale) | `geode audit` subprocess (LLM judge) → `core/audit/dim_extractor` | `dim_means` / `dim_stderr` dicts |
+| per-run baseline (latest "good" snapshot) | autoresearch (`state/baseline.json` after promote) | promoted snapshot |
+| tier classification (critical / auxiliary / info) | autoresearch (`AXIS_TIERS` in `train.py`) | constant tuples |
+| weight allocation (17 + stability sum to 1.0) | autoresearch (`DIM_WEIGHTS` + `STABILITY_WEIGHT`) | constant dict |
+| cross-axis gate + auto-promote rule | autoresearch (`compute_fitness` / `decide_promote`) | scalar + verdict |
+| wrapper-prompt mutation candidate | self-improving-loop agent (edits `WRAPPER_PROMPT_SECTIONS`) | git commit |
+
+Petri owns *what* gets measured; autoresearch owns *how it accrues into
+fitness* and *what counts as a promote*. No code overlap — the boundary
+runs through `dim_extractor` → `compute_fitness`.
 
 ## How it works
 
-Same three-file structure as the original:
+Same three-file structure borrowed from Karpathy autoresearch:
 
 - **`prepare.py`** — Petri seed pool + AlphaEval 20-dim rubric
   existence/format sanity check and audit-harness self-test. The
@@ -32,13 +45,13 @@ Same three-file structure as the original:
   wording, additions, deletions, and reordering are all fair game.
 - **`program.md`** — instructions to the agent. Humans modify this.
 
-The original's fixed 5-min wall-clock budget becomes the audit budget
+The Karpathy 5-min wall-clock budget maps onto the audit budget
 (default ~5 min, capped by ChatGPT Plus quota / Anthropic API spend).
-The original's `val_bpb` metric becomes AlphaEval fitness — a 17-dim
-weighted aggregate (5 critical + 12 auxiliary) plus a derived
-stability axis (1.0 total weight, **higher = better**), with 3 info
-dims tracked alongside but not weighted. `results.tsv` keeps the same role but
-its columns are now per-tier aggregates and `fitness`; the raw 20-dim
+The `val_bpb` metric maps onto AlphaEval fitness — a 17-dim weighted
+aggregate (5 critical + 12 auxiliary) plus a derived stability axis
+(1.0 total weight, **higher = better**), with 3 info dims tracked
+alongside but not weighted. `results.tsv` keeps a per-row layout but
+its columns are per-tier aggregates and `fitness`; the raw 20-dim
 signal lives in the companion `results.jsonl`.
 
 Mutations to `WRAPPER_PROMPT_SECTIONS` propagate into the audit
@@ -73,7 +86,7 @@ The final `---` block on stdout carries grep-friendly metrics.
 ## Running the agent
 
 Boot the self-improving-loop agent with `program.md` in context. The
-Karpathy-style prompt translates directly:
+boot prompt is intentionally minimal:
 
 ```
 Read program.md and start a new experiment. Begin with the baseline
@@ -106,7 +119,7 @@ that into `AUTORESEARCH_SEED_SELECT` so the next audit consumes the
 evolved pool instead of the static tree. Unset / whitespace falls
 back to the hierarchical `plugins/petri_audit/seeds/` default.
 
-## Design choices (preserved from the original)
+## Design choices
 
 - **Single file to modify.** The agent only edits `train.py`. The
   mutation scope's upper bound is explicit, so every diff is
@@ -121,9 +134,10 @@ back to the hierarchical `plugins/petri_audit/seeds/` default.
 
 ## Source
 
-- Karpathy autoresearch: https://github.com/karpathy/autoresearch (228791f)
-- Local reference clone: `~/workspace/autoresearch`
-- GEODE self-improving-loop spec (older 6-module stub, replaced by this fork):
+- Attribution — Karpathy autoresearch (3-file pattern + fixed-budget
+  loop source): https://github.com/karpathy/autoresearch (228791f);
+  local reference clone at `~/workspace/autoresearch`.
+- Older 6-module self-improving-loop stub (superseded by this driver):
   `docs/architecture/autoresearch.md`
 - Petri evidence (gen-0 fitness signal):
   `docs/audits/2026-05-15-petri-insights.md` +
@@ -133,5 +147,5 @@ back to the hierarchical `plugins/petri_audit/seeds/` default.
 
 ## License
 
-MIT (matches the upstream). The fork inherits the GEODE repo's
-license.
+MIT (matches the Karpathy autoresearch attribution); this driver
+otherwise inherits the GEODE repo's license terms.

--- a/autoresearch/__init__.py
+++ b/autoresearch/__init__.py
@@ -1,12 +1,12 @@
-"""autoresearch — Petri-signal fork of Karpathy/autoresearch (MIT, 2026-03).
+"""autoresearch — GEODE self-improving loop driver.
 
-A GEODE-side port of Karpathy's 3-file pattern (``prepare.py`` /
-``train.py`` / ``program.md``) into the alignment-audit domain.
-The original ML pre-train + ``val_bpb`` slot is replaced by a Petri
-seed pool + AlphaEval tiered fitness. This ``__init__`` is
-deliberately empty — the self-improving-loop agent never imports the package,
-it just invokes ``uv run python autoresearch/train.py`` in keeping
-with the upstream's single-script constraint.
+Runs the wrapper-prompt mutation loop on top of petri's per-dim
+baseline. petri owns the measurement layer (rubric + dim scoring);
+this package owns the aggregation + selection layer (tier weights +
+fitness + auto-promote). This ``__init__`` is deliberately empty —
+the self-improving-loop agent never imports the package, it just
+invokes ``uv run python autoresearch/train.py`` (the single-script
+invocation idiom borrowed from Karpathy autoresearch, MIT 2026-03).
 
 Reference: ``autoresearch/README.md`` + ``autoresearch/program.md``.
 """

--- a/autoresearch/prepare.py
+++ b/autoresearch/prepare.py
@@ -1,17 +1,20 @@
 """
-One-time sanity check for autoresearch experiments (Petri-signal fork).
+One-time sanity check for autoresearch — GEODE self-improving loop pre-flight.
 
-Karpathy 원본의 ``prepare.py`` 는 fineweb 다운로드 + BPE tokenizer 학습
-이었음. 본 fork 의 prepare 는 그 자리에 **fixed audit harness** 의 무결성
-검증을 둠 — Petri seed pool 의 file count / format, AlphaEval rubric 의 dim
-count, audit CLI 의 dry-run reachability.
+``train.py`` 가 자동 엔지니어링 루프를 돌리기 전에 ``prepare.py`` 가 한 번
+실행되어 **fixed audit harness** 의 무결성을 검증한다 — Petri seed pool 의
+file count / format, AlphaEval rubric 의 dim count, audit CLI 의 dry-run
+reachability. 측정 대상 (rubric · seed pool · subprocess 진입점) 은 모두
+petri 가 소유하는 자산이며, ``prepare.py`` 는 그 자산이 자동 엔지니어링
+루프에 사용 가능한 상태인지를 확인할 뿐 직접 수정하지 않는다.
 
 Usage:
     uv run python autoresearch/prepare.py             # full check
     uv run python autoresearch/prepare.py --skip-cli  # rubric/seed only
 
-Artefact 위치 (원본 prepare 의 ``~/.cache/autoresearch/`` 와 동일한 정신
-으로, 본 fork 는 ``~/.cache/autoresearch-petri/`` 에 sanity report 만 저장):
+Artefact 위치 — sanity report 만 ``~/.cache/autoresearch-petri/`` 에
+저장한다 (3-file pattern 의 그릇은 Karpathy autoresearch 에서 차용했지만
+저장 위치는 GEODE 의 ``~/.cache/`` 관행을 따른다):
 
     ~/.cache/autoresearch-petri/prepare-report.txt
 """
@@ -152,7 +155,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    print("autoresearch (Petri-signal fork) — prepare.py sanity check")
+    print("autoresearch — prepare.py sanity check")
     print(f"  repo: {REPO_ROOT}")
     print()
 

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -1,8 +1,19 @@
-# autoresearch (GEODE Petri-signal fork)
+# autoresearch — GEODE self-improving loop driver
 
-This `program.md` is the self-improving-loop agent's baseline instruction. The
-Karpathy original drives ML research; this fork drives GEODE
-alignment-audit research instead.
+This `program.md` is the self-improving-loop agent's baseline
+instruction. **autoresearch is GEODE's self-improving loop driver**:
+Petri's `geode audit` subprocess scores each transcript on the 20-dim
+rubric and emits a per-dim `mean + stderr` baseline; this driver runs
+the wrapper-prompt mutation loop **on top of that baseline**, picking
+hypotheses that should push the fitness scalar up without regressing
+the critical-dim floor.
+
+The 3-file shape (`prepare` / `train` / `program.md`), the
+fixed-budget per-run constraint, and the "git as optimiser" idiom are
+borrowed from Karpathy's
+[autoresearch](https://github.com/karpathy/autoresearch) (MIT,
+2026-03); the domain is GEODE's own alignment audit, not GPT
+pre-training.
 
 ## Setup
 
@@ -15,7 +26,7 @@ Before starting a new experiment run, confirm with the user:
    the current `develop`.
 3. **Read the in-scope files end-to-end**. Only the four files below
    matter:
-   - `autoresearch/README.md` — fork context.
+   - `autoresearch/README.md` — driver overview + role split with petri.
    - `autoresearch/prepare.py` — seed pool + rubric sanity check. **Do
      not modify.**
    - `autoresearch/train.py` — the single file the agent modifies.
@@ -329,7 +340,7 @@ on.
 
 **Never stop**: Once experimentation starts, do not ask the user
 "shall I continue?". The loop runs indefinitely until the user
-interrupts it. When ideas thin out, dig deeper — consult the fork's
+interrupts it. When ideas thin out, dig deeper — consult the driver's
 SOT documents (`docs/audits/2026-05-15-petri-insights.md`,
 `docs/audits/2026-05-15-autoresearch-gen0-plan.md`) for the 9
 hypothesis space, and use the cross-model driver-seed signals
@@ -345,5 +356,5 @@ in the morning.
 - This program: `autoresearch/program.md`
 - Petri gen-0 plan: `docs/audits/2026-05-15-autoresearch-gen0-plan.md`
 - Petri insights: `docs/audits/2026-05-15-petri-insights.md`
-- Outer-loop wiring sprint: `docs/plans/2026-05-19-self-improving-loop-wiring-sprint.md`
-- Karpathy reference: `~/workspace/autoresearch/program.md` (228791f)
+- Self-improving-loop wiring sprint: `docs/plans/2026-05-19-self-improving-loop-wiring-sprint.md`
+- Attribution — Karpathy autoresearch (3-file pattern source): `~/workspace/autoresearch/program.md` (228791f)

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1,10 +1,26 @@
 """
-Single-experiment runner for autoresearch (Petri-signal fork).
+Single-experiment runner for autoresearch — GEODE self-improving loop driver.
 
-Karpathy's upstream ``train.py`` is a single-GPU GPT pre-train (model +
-Muon optimiser + training loop, ~630 LOC). This fork's ``train.py``
-keeps the same role but runs **one audit per invocation** — it is the
-single file the self-improving-loop agent modifies.
+``train.py`` runs **one audit per invocation** and is the single file
+the self-improving-loop agent modifies. Role split with petri (the
+measurement layer) is strict:
+
+* **petri** owns *what gets measured* — the 20-dim rubric
+  (``plugins/petri_audit/judge_dims/geode_5axes.yaml``) defines the
+  dim universe, ``geode audit`` runs the judge subprocess, and
+  ``core/audit/dim_extractor`` emits raw ``dim_means`` /
+  ``dim_stderr`` dicts on the 1–10 concerning-behaviour scale.
+* **autoresearch (this file)** owns *how the measurement accrues into
+  a selection signal* — tier classification (``AXIS_TIERS``), weight
+  allocation (``DIM_WEIGHTS`` + ``STABILITY_WEIGHT``), the cross-axis
+  monotone gate (``compute_fitness``), and the auto-promote rule
+  (``decide_promote``). No code path here re-implements raw
+  measurement — every per-dim number is sourced verbatim from petri's
+  ``dim_extractor`` output.
+
+The 3-file shape (``prepare`` / ``train`` / ``program.md``),
+fixed-budget per-run constraint, and "git as optimiser" idiom are
+borrowed from Karpathy's autoresearch (MIT, 2026-03).
 
 Agent CAN modify:
   * ``WRAPPER_PROMPT_SECTIONS`` — the system prompt's section dict.
@@ -736,7 +752,7 @@ def print_summary(
     dry_run: bool,
     baseline_active: bool,
 ) -> None:
-    """Karpathy-style grep-friendly stdout block — per-dim scores + means + stderr.
+    """Grep-friendly stdout block — per-dim scores + means + stderr.
 
     Per ADR-002 + PR 0 the report lists all 20 dims (5 critical +
     12 auxiliary + 3 info) so the self-improving-loop agent's results.tsv can


### PR DESCRIPTION
## Summary
- autoresearch 5 파일 (`__init__.py` / `program.md` / `README.md` / `train.py` docstring / `prepare.py`) 의 "Petri-signal fork of Karpathy/autoresearch" self-positioning 을 **"GEODE self-improving loop driver"** 로 재작성. Karpathy 3-file pattern + 단일-스크립트 idiom 차용 사실은 attribution 으로 보존.
- README.md 에 **"Role split — petri vs autoresearch"** 7-row 표 추가. petri (measurement: 20-dim rubric + raw `mean`/`stderr`) vs autoresearch (selection: tier + weight + fitness + auto-promote) 책임 경계를 명문화.
- train.py docstring 에서 "No code path here re-implements raw measurement — every per-dim number is sourced verbatim from petri's `dim_extractor` output" 명시.
- 동작 변경 무 — `prepare.py` stdout banner 1줄 + `train.py` docstring + `_emit_journal` docstring 1줄만 string output 변경.

## Why
사용자 요청: \"autoresearch 프롬프트 수정하자. 굳이 fork로 표현할 필요없어. 현재 petri에서 baseline을 잡아주면 그 축을 기반으로 자동 엔지니어링을 수행하는 역할이니 train.py에서 이 역할과 겹치는 파트도 제거됐는지 재점검하고.\"

autoresearch 의 5 파일 모두 자신을 외부 코드의 fork 로 self-position 하고 있어 GEODE 안에서의 본질적 역할 (petri baseline 위에서 wrapper-prompt 자동 엔지니어링) 이 가려짐. \"fork\" framing 제거 + 본질을 명문화.

## Changes
| File | Change |
|------|--------|
| `autoresearch/__init__.py` | self-positioning 재작성 + petri/autoresearch 책임 분리 1줄 |
| `autoresearch/program.md` | 제목 + 첫 문단 재작성. agent prompt 의 self-positioning 이 driver 본질 먼저 명시 + Karpathy 패턴 attribution 으로 변경. \"fork's SOT documents\" → \"driver's SOT documents\". \"Karpathy reference\" → \"Attribution — Karpathy autoresearch\". |
| `autoresearch/README.md` | 제목 + 1-2단락 재작성. \"Why fork instead of port\" 섹션 제거. \"Role split — petri vs autoresearch\" 7-row 표 추가. License 섹션 attribution 톤. |
| `autoresearch/train.py` | docstring 재작성: \"Single-experiment runner for autoresearch — GEODE self-improving loop driver\". petri vs autoresearch 책임 분리 명문 단락. `_emit_journal` 의 \"Karpathy-style grep-friendly\" → \"Grep-friendly\". |
| `autoresearch/prepare.py` | docstring 재작성 + stdout banner \"(Petri-signal fork)\" 제거. |
| `CHANGELOG.md` | `[Unreleased]` Changed 항목 추가. |

## GAP Audit — petri/autoresearch role duplication 재점검
| 영역 | Petri (`core/audit/`, `plugins/petri_audit/`) | autoresearch (`autoresearch/`) | 중복? |
|------|---|---|---|
| dim universe (20 names + 3 info) | `judge_dims/geode_5axes.yaml` | — | No |
| per-dim raw measurement (`mean`/`stderr`) | `core/audit/dim_extractor.extract_dim_aggregates` | — | No |
| seed pool 디렉토리 분류 (critical/aux/info 폴더) | `plugins/petri_audit/seed_tree.py:54` | — | No (autoresearch `AXIS_TIERS` 와 이름만 같음 — 별도 책임: seed selection vs dim aggregation) |
| tier classification (dim → critical/auxiliary/info) | — | `AXIS_TIERS` | autoresearch 단독 |
| weight allocation (17 + stability = 1.0) | — | `DIM_WEIGHTS` + `STABILITY_WEIGHT` | autoresearch 단독 |
| cross-axis gate + auto-promote | — | `compute_fitness` + `decide_promote` | autoresearch 단독 |
| wrapper-prompt mutation candidate | — | `WRAPPER_PROMPT_SECTIONS` (agent edits) | autoresearch 단독 |

**결론**: 진짜 중복 코드 없음. 책임 분리 명확. README 표 + train.py docstring 단락이 이 경계를 영구화.

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run mypy core/ plugins/ autoresearch/` — 0 issues (356 source files)
- [x] `uv run pytest autoresearch/ tests/ -m \"not live\"` — **4913 passed**, 31 skipped (197s) — no behaviour change
- [x] Grep audit — `fork|Fork|FORK` 0 hits across 5 autoresearch files post-edit

## Reference
- 사용자 메시지 (Session 65, 2026-05-20)
- Karpathy autoresearch attribution: https://github.com/karpathy/autoresearch (228791f)
- Role split SOT: this PR's `autoresearch/README.md` (Role split table) + `autoresearch/train.py` docstring (책임 분리 단락)

🤖 Generated with [Claude Code](https://claude.com/claude-code)