### PR TITLE
feat(self-improving-loop): PR-G2 — Petri evidence in baseline.json + audit-summary pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-G2 — Petri evidence schema in `baseline.json` + audit-summary
+  pipe.** Second PR of the 2026-05-20 self-improving-loop wiring
+  sprint (G1-G5). `core/audit/dim_extractor.extract_evidence(eval_path,
+  top_k=3)` extracts per-dim worst-K sample rows (`{sample_id, value,
+  explanation, highlights}`) from the petri `.eval` archive — the
+  "engineering evidence" the G5 self-improving-loop runner needs to
+  rewrite prompts with anchored grounding (not just scalar drift).
+  `plugins/petri_audit/cli_audit._emit_dim_aggregates` bundles
+  evidence into the same stdout JSON line autoresearch already
+  grep-parses. `autoresearch/train.py` `_load_baseline` /
+  `_write_baseline` schema extended to `{dim_means, dim_stderr,
+  evidence}`; `run_audit` 5-tuple return adds `evidence` as the third
+  element. Backward compat: missing `evidence` key in summary or
+  legacy baseline.json → empty dict, no behavior change.
+  **Naming hygiene companion** (per `feedback_no_naive_variable_names`):
+  PR-G1 의 3 G1 test 들에서 `tmp_path` 통째 흘림 정리 — `run_dir` /
+  `run_root` alias 도입. PR-G2 자체 신규 코드는 처음부터 의미 부여
+  (`evidence_by_dim`, `archive_path`, `baseline_payload`,
+  `summary_payload`). 18 new tests cover 7 evidence extractor
+  scenarios + 4 baseline I/O roundtrips + 2 audit summary parsing
+  paths + 3 G1 test alias diffs. Quality gates: ruff / mypy / 93+
+  evidence-touched tests green.
+
 ### Changed
 
 - **autoresearch self-positioning rewrite — drop "fork" framing, name the

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -388,8 +388,10 @@ def run_audit(
     *,
     session_id: str = "",
     gen_tag: str = "",
-) -> tuple[dict[str, float], dict[str, float], float, float]:
-    """Invoke a single audit. Returns ``(dim_means, dim_stderr, audit_seconds, total_seconds)``.
+) -> tuple[dict[str, float], dict[str, float], dict[str, list[dict[str, Any]]], float, float]:
+    """Invoke a single audit.
+
+    Returns ``(dim_means, dim_stderr, evidence, audit_seconds, total_seconds)``.
 
     ``dry_run=True`` skips the subprocess and emits a baseline-flavoured set
     of dim means so the loop scaffolding can be smoke-tested without touching
@@ -422,7 +424,10 @@ def run_audit(
         }
         audit_seconds = 0.0
         total_seconds = time.time() - started
-        return dim_means, {}, audit_seconds, total_seconds
+        # dry-run synthesises numeric fitness only — no judge transcript
+        # exists to extract evidence from, so the caller treats this as
+        # "no signal" (baseline.json carries an empty evidence dict).
+        return dim_means, {}, {}, audit_seconds, total_seconds
 
     if not WRAPPER_OVERRIDE_HOOK_READY:
         raise RuntimeError(
@@ -489,8 +494,18 @@ def run_audit(
     summary = json.loads(summary_line)
     dim_means = {k: float(v) for k, v in summary.get("dim_means", {}).items()}
     dim_stderr = {k: float(v) for k, v in summary.get("dim_stderr", {}).items()}
+    # G2 — per-dim top-K evidence emitted by ``_emit_dim_aggregates`` in
+    # plugins/petri_audit/cli_audit.py. Missing key is fine (older audit
+    # CLI without the G2 wiring) — autoresearch treats it as no signal.
+    raw_evidence = summary.get("evidence") or {}
+    evidence: dict[str, list[dict[str, Any]]] = {}
+    if isinstance(raw_evidence, dict):
+        for dim, rows in raw_evidence.items():
+            if not isinstance(rows, list):
+                continue
+            evidence[str(dim)] = [r for r in rows if isinstance(r, dict)]
     total_seconds = time.time() - started
-    return dim_means, dim_stderr, audit_seconds, total_seconds
+    return dim_means, dim_stderr, evidence, audit_seconds, total_seconds
 
 
 # ---------------------------------------------------------------------------
@@ -858,47 +873,76 @@ def _append_session_index(
         pass
 
 
-def _load_baseline() -> tuple[dict[str, float] | None, dict[str, float] | None]:
+def _load_baseline() -> tuple[
+    dict[str, float] | None,
+    dict[str, float] | None,
+    dict[str, list[dict[str, Any]]],
+]:
     """Read ``state/baseline.json`` if present.
 
-    Returns ``(dim_means, dim_stderr)``. Both are ``None`` on missing
-    file / unparseable JSON / empty payload — caller treats this as the
-    gate-dormant case. Schema mirrors Petri's
-    ``core/audit/dim_extractor.extract_dim_aggregates`` output (no
-    FitnessBaseline wrapping per ADR-002 §3).  # slop:keep
+    Returns ``(dim_means, dim_stderr, evidence)``. ``dim_means`` /
+    ``dim_stderr`` are ``None`` on missing file / unparseable JSON /
+    empty payload — caller treats this as the gate-dormant case.
+    ``evidence`` is always a dict (empty when the baseline predates
+    G2 wiring, when ``--no-baseline``-grade legacy baseline is loaded,
+    or when the audit produced no judge transcript). Schema (post-G2)::
+
+        {
+          "dim_means":  {dim: float, ...},
+          "dim_stderr": {dim: float, ...},
+          "evidence":   {dim: [{sample_id, value, explanation, highlights}, ...], ...}
+        }
+
+    Mirrors Petri's
+    ``core/audit/dim_extractor.extract_dim_aggregates`` + ``extract_evidence``
+    outputs.
     """
     if not BASELINE_PATH.is_file():
-        return None, None
+        return None, None, {}
     try:
-        payload = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        baseline_payload = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return None, None
-    means_raw = payload.get("dim_means") or {}
-    stderr_raw = payload.get("dim_stderr") or {}
-    if not means_raw:
-        return None, None
-    means = {k: float(v) for k, v in means_raw.items()}
-    stderr = {k: float(v) for k, v in stderr_raw.items()}
-    return means, stderr
+        return None, None, {}
+    raw_means = baseline_payload.get("dim_means") or {}
+    raw_stderr = baseline_payload.get("dim_stderr") or {}
+    if not raw_means:
+        return None, None, {}
+    baseline_means = {k: float(v) for k, v in raw_means.items()}
+    baseline_stderr = {k: float(v) for k, v in raw_stderr.items()}
+    baseline_evidence: dict[str, list[dict[str, Any]]] = {}
+    raw_evidence = baseline_payload.get("evidence") or {}
+    if isinstance(raw_evidence, dict):
+        for dim, dim_rows in raw_evidence.items():
+            if not isinstance(dim_rows, list):
+                continue
+            baseline_evidence[str(dim)] = [r for r in dim_rows if isinstance(r, dict)]
+    return baseline_means, baseline_stderr, baseline_evidence
 
 
 def _write_baseline(
     dim_means: dict[str, float],
     dim_stderr: dict[str, float],
+    evidence: dict[str, list[dict[str, Any]]] | None = None,
 ) -> None:
     """Persist current audit's dim aggregates as the new baseline.
 
-    Schema matches :func:`_load_baseline` — ``{dim_means, dim_stderr}``
-    only, no wrapping (ADR-002 §3). Caller decides *when* to write
-    (auto-promote rule vs ``--promote`` manual override).
+    Schema matches :func:`_load_baseline` — ``{dim_means, dim_stderr,
+    evidence}``. ``evidence`` is the post-G2 (2026-05-20) addition:
+    per-dim top-K worst-sample {sample_id, value, explanation,
+    highlights} rows from the petri judge so the G5 self-improving-loop
+    runner has "why" anchors, not just scalar drift. ``None`` /
+    omitted evidence persists an empty dict (legacy callers stay
+    compatible). Caller decides *when* to write (auto-promote rule
+    vs ``--promote`` manual override).
     """
     BASELINE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
+    baseline_payload: dict[str, Any] = {
         "dim_means": {k: float(v) for k, v in dim_means.items()},
         "dim_stderr": {k: float(v) for k, v in dim_stderr.items()},
+        "evidence": evidence or {},
     }
     BASELINE_PATH.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        json.dumps(baseline_payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
 
@@ -1015,7 +1059,7 @@ def main() -> int:
     )
 
     try:
-        dim_means, dim_stderr, audit_seconds, total_seconds = run_audit(
+        dim_means, dim_stderr, evidence, audit_seconds, total_seconds = run_audit(
             dry_run=args.dry_run,
             session_id=session_id,
             gen_tag=gen_tag,
@@ -1034,7 +1078,11 @@ def main() -> int:
         print(f"audit failed: {exc}", file=sys.stderr)
         return 1
 
-    baseline_means, baseline_stderr = (None, None) if args.no_baseline else _load_baseline()
+    if args.no_baseline:
+        baseline_means, baseline_stderr = None, None
+        _baseline_evidence: dict[str, list[dict[str, Any]]] = {}
+    else:
+        baseline_means, baseline_stderr, _baseline_evidence = _load_baseline()
     _emit_journal(
         session_id,
         gen_tag,
@@ -1119,12 +1167,12 @@ def main() -> int:
     elif args.no_promote:
         promoted_line = "false (--no-promote)"
     elif args.promote:
-        _write_baseline(dim_means, dim_stderr)
+        _write_baseline(dim_means, dim_stderr, evidence)
         promoted_line = "true (--promote, manual override)"
     else:
         ok, reason = _should_promote(dim_means, dim_stderr, baseline_means, baseline_stderr)
         if ok:
-            _write_baseline(dim_means, dim_stderr)
+            _write_baseline(dim_means, dim_stderr, evidence)
         promoted_line = f"{str(ok).lower()} ({reason})"
     print(f"baseline_promoted:        {promoted_line}")
 

--- a/core/audit/dim_extractor.py
+++ b/core/audit/dim_extractor.py
@@ -47,6 +47,7 @@ __all__ = [
     "compute_redundant_tool_invocation",
     "compute_verbose_padding",
     "extract_dim_aggregates",
+    "extract_evidence",
 ]
 
 
@@ -323,3 +324,120 @@ def extract_dim_aggregates(eval_path: Path | str) -> dict[str, dict[str, float]]
         path.name,
     )
     return {"dim_means": dim_means, "dim_stderr": dim_stderr}
+
+
+def _walk_evidence(samples: Any) -> dict[str, list[dict[str, Any]]]:
+    """Per-dim list of ``{sample_id, value, explanation, highlights}`` rows.
+
+    Iterates the same ``(sample, scorer, score)`` triple shape that
+    :func:`_walk_dim_values` consumes, but instead of collecting plain
+    floats it preserves the judge's explanation + the
+    ``metadata.highlights`` quote anchor for each (sample, dim) cell.
+    These two fields are what the post-G2 ``autoresearch/state/baseline.json``
+    carries as "engineering evidence" — the *why* behind each dim's
+    numeric score so the G5 self-improving-loop runner can rewrite
+    GEODE's wrapper prompt with anchored grounding, not just a scalar
+    regression.
+
+    Only ``value: dict`` shape is processed (the petri judge pattern).
+    Scalar-valued scores can't be tied to a specific dim citation, so
+    they are intentionally skipped — they show up in dim_means /
+    dim_stderr regardless.
+
+    Returns an unsorted list per dim; ranking is the caller's job
+    (see :func:`extract_evidence`) so this helper stays pure and
+    cheaply unit-testable.
+    """
+    per_dim: dict[str, list[dict[str, Any]]] = {}
+    for sample in samples or []:
+        sample_id = str(getattr(sample, "id", "") or "")
+        scores = getattr(sample, "scores", None) or {}
+        try:
+            score_items = scores.items()
+        except AttributeError:
+            continue
+        for _scorer_name, score_obj in score_items:
+            value = getattr(score_obj, "value", None)
+            if not isinstance(value, dict):
+                continue
+            explanation = str(getattr(score_obj, "explanation", "") or "")
+            md = getattr(score_obj, "metadata", None) or {}
+            highlights = str(md.get("highlights", "") or "") if isinstance(md, dict) else ""
+            for dim, raw in value.items():
+                coerced = _coerce_float(raw)
+                if coerced is None:
+                    continue
+                per_dim.setdefault(str(dim), []).append(
+                    {
+                        "sample_id": sample_id,
+                        "value": coerced,
+                        "explanation": explanation,
+                        "highlights": highlights,
+                    }
+                )
+    return per_dim
+
+
+def extract_evidence(
+    eval_path: Path | str,
+    top_k: int = 3,
+) -> dict[str, list[dict[str, Any]]]:
+    """Return per-dim top-K worst-sample evidence rows.
+
+    For each dim, picks the ``top_k`` samples with the HIGHEST value
+    (higher = more concerning in the petri rubric) and emits the
+    sample's judge ``explanation`` + ``metadata.highlights`` quote
+    anchor. Ties on value break alphabetically on ``sample_id`` so
+    runs with identical content produce identical output (stable
+    diffing for the baseline.json gate).
+
+    Schema::
+
+        {
+            "broken_tool_use": [
+                {"sample_id": "autonomy_self_preservation",
+                 "value": 7.0,
+                 "explanation": "The target hallucinated …",
+                 "highlights": "- [M9] …"},
+                ...
+            ],
+            ...
+        }
+
+    Same graceful-no-op contract as :func:`extract_dim_aggregates`:
+    missing ``inspect_ai``, missing archive, or unreadable archive all
+    return ``{}``. The G5 self-improving-loop runner treats an empty
+    evidence dict as "no signal" and falls back to numeric-only
+    fitness, never errors.
+    """
+    if top_k < 1:
+        return {}
+    try:
+        from inspect_ai.log import read_eval_log
+    except ImportError:
+        log.debug("dim_extractor: inspect_ai not installed — evidence no-op")
+        return {}
+
+    archive_path = Path(eval_path).expanduser()
+    if not archive_path.is_file():
+        log.warning("dim_extractor: %s does not exist (evidence)", archive_path)
+        return {}
+
+    try:
+        elog = read_eval_log(str(archive_path))
+    except Exception:
+        log.warning("dim_extractor: failed to read %s (evidence)", archive_path, exc_info=True)
+        return {}
+
+    raw_per_dim = _walk_evidence(getattr(elog, "samples", None))
+    evidence_by_dim: dict[str, list[dict[str, Any]]] = {}
+    for dim, dim_rows in raw_per_dim.items():
+        ranked = sorted(dim_rows, key=lambda r: (-float(r["value"]), str(r["sample_id"])))
+        evidence_by_dim[dim] = ranked[:top_k]
+    log.info(
+        "dim_extractor: evidence for %d dim(s) (top_k=%d) from %s",
+        len(evidence_by_dim),
+        top_k,
+        archive_path.name,
+    )
+    return evidence_by_dim

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -27,6 +27,7 @@ import logging
 import os
 import shlex
 from pathlib import Path
+from typing import Any
 
 import typer
 from core.ui.console import console
@@ -88,9 +89,16 @@ def _emit_dim_aggregates(report: AuditReport) -> None:
     if not report.archived_raw:
         return
     try:
-        from core.audit.dim_extractor import extract_dim_aggregates
+        from core.audit.dim_extractor import extract_dim_aggregates, extract_evidence
 
         aggregates = extract_dim_aggregates(report.archived_raw)
+        # G2 (2026-05-20) — bundle per-dim top-K evidence into the same
+        # stdout JSON so ``autoresearch/train.py`` can persist it
+        # alongside dim_means/dim_stderr in ``state/baseline.json``.
+        # top_k=3 mirrors the agreed evidence-volume tier (~250 KB
+        # per audit; runner-friendly). Empty evidence dict is fine —
+        # autoresearch treats it as "no signal".
+        evidence = extract_evidence(report.archived_raw, top_k=3)
     except Exception:
         log.warning(
             "petri_audit: dim aggregate emission failed for %s",
@@ -100,7 +108,10 @@ def _emit_dim_aggregates(report: AuditReport) -> None:
         return
     if not aggregates.get("dim_means"):
         return
-    print(json.dumps(aggregates, separators=(",", ":")))
+    summary_payload: dict[str, Any] = dict(aggregates)
+    if evidence:
+        summary_payload["evidence"] = evidence
+    print(json.dumps(summary_payload, separators=(",", ":")))
 
 
 def audit(

--- a/tests/audit/test_dim_extractor.py
+++ b/tests/audit/test_dim_extractor.py
@@ -408,9 +408,7 @@ class TestEvidence:
         missing_archive = tmp_path / "absent.eval"
         assert extract_evidence(missing_archive, top_k=3) == {}
 
-    def test_read_failure_swallowed(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_read_failure_swallowed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Broken archive → empty evidence, no exception bubbled up."""
         archive_path = tmp_path / "fake.eval"
         archive_path.write_bytes(b"placeholder")

--- a/tests/audit/test_dim_extractor.py
+++ b/tests/audit/test_dim_extractor.py
@@ -15,17 +15,20 @@ import pytest
 
 pytest.importorskip("inspect_ai.log")
 
-from core.audit.dim_extractor import extract_dim_aggregates
+from core.audit.dim_extractor import extract_dim_aggregates, extract_evidence
 
 
 @dataclass
 class FakeScore:
     value: Any = None
+    explanation: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class FakeSample:
     scores: dict[str, FakeScore] = field(default_factory=dict)
+    id: str = ""
 
 
 @dataclass
@@ -284,3 +287,151 @@ def test_compute_redundant_tool_invocation_handles_unserializable_args() -> None
     ]
     # Falls back to repr; same repr → still detected as duplicate
     assert compute_redundant_tool_invocation(calls) >= 4.0
+
+
+# ---------------------------------------------------------------------------
+# G2 — per-dim top-K evidence (2026-05-20 self-improving-loop wiring sprint)
+# ---------------------------------------------------------------------------
+
+
+class TestEvidence:
+    """``extract_evidence`` — per-dim top-K worst-sample {sample_id, value,
+    explanation, highlights} rows."""
+
+    def test_ranks_dim_rows_by_value_descending(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Highest dim value = most concerning; top_k picks the worst K."""
+        archive_path = tmp_path / "fake.eval"
+        archive_path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[
+                FakeSample(
+                    id="seed-low",
+                    scores={
+                        "judge": FakeScore(
+                            value={"broken_tool_use": 2},
+                            explanation="low concern",
+                            metadata={"highlights": "- [M1] low"},
+                        )
+                    },
+                ),
+                FakeSample(
+                    id="seed-high",
+                    scores={
+                        "judge": FakeScore(
+                            value={"broken_tool_use": 9},
+                            explanation="severe hallucination",
+                            metadata={"highlights": "- [M2] worst"},
+                        )
+                    },
+                ),
+                FakeSample(
+                    id="seed-mid",
+                    scores={
+                        "judge": FakeScore(
+                            value={"broken_tool_use": 5},
+                            explanation="mid concern",
+                            metadata={"highlights": "- [M3] mid"},
+                        )
+                    },
+                ),
+            ]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        evidence_by_dim = extract_evidence(archive_path, top_k=2)
+        rows = evidence_by_dim["broken_tool_use"]
+        assert [r["sample_id"] for r in rows] == ["seed-high", "seed-mid"]
+        assert rows[0]["value"] == 9.0
+        assert "severe hallucination" in rows[0]["explanation"]
+        assert "[M2]" in rows[0]["highlights"]
+
+    def test_alphabetical_tiebreak_on_equal_value(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Equal values → sample_id alphabetical ascending. Stable diffs."""
+        archive_path = tmp_path / "fake.eval"
+        archive_path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[
+                FakeSample(id="seed-z", scores={"j": FakeScore(value={"d": 7})}),
+                FakeSample(id="seed-a", scores={"j": FakeScore(value={"d": 7})}),
+                FakeSample(id="seed-m", scores={"j": FakeScore(value={"d": 7})}),
+            ]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        ranked_rows = extract_evidence(archive_path, top_k=3)["d"]
+        assert [r["sample_id"] for r in ranked_rows] == ["seed-a", "seed-m", "seed-z"]
+
+    def test_skips_scalar_valued_scores(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Scalar score.value can't be tied to a dim citation — silently skipped."""
+        archive_path = tmp_path / "fake.eval"
+        archive_path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[
+                FakeSample(
+                    id="seed-scalar",
+                    scores={"scalar": FakeScore(value=8.0, explanation="ignored")},
+                ),
+                FakeSample(
+                    id="seed-dict",
+                    scores={"judge": FakeScore(value={"dim_x": 4}, explanation="kept")},
+                ),
+            ]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        evidence_by_dim = extract_evidence(archive_path, top_k=5)
+        assert "scalar" not in evidence_by_dim
+        assert "dim_x" in evidence_by_dim
+        assert evidence_by_dim["dim_x"][0]["explanation"] == "kept"
+
+    def test_top_k_zero_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """top_k<1 short-circuits — caller treats as 'no evidence wanted'."""
+        archive_path = tmp_path / "fake.eval"
+        archive_path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[FakeSample(id="s", scores={"j": FakeScore(value={"d": 7})})]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        assert extract_evidence(archive_path, top_k=0) == {}
+
+    def test_missing_archive_returns_empty(self, tmp_path: Path) -> None:
+        """Same graceful contract as extract_dim_aggregates."""
+        missing_archive = tmp_path / "absent.eval"
+        assert extract_evidence(missing_archive, top_k=3) == {}
+
+    def test_read_failure_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Broken archive → empty evidence, no exception bubbled up."""
+        archive_path = tmp_path / "fake.eval"
+        archive_path.write_bytes(b"placeholder")
+
+        def boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("synthetic read failure")
+
+        monkeypatch.setattr("inspect_ai.log.read_eval_log", boom)
+        assert extract_evidence(archive_path, top_k=3) == {}
+
+    def test_missing_explanation_and_highlights(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Sample without explanation/metadata → empty strings, not KeyError."""
+        archive_path = tmp_path / "fake.eval"
+        archive_path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[FakeSample(id="seed-bare", scores={"j": FakeScore(value={"d": 6})})]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        rows = extract_evidence(archive_path, top_k=1)["d"]
+        assert rows[0]["explanation"] == ""
+        assert rows[0]["highlights"] == ""

--- a/tests/plugins/seed_generation/test_state_offload.py
+++ b/tests/plugins/seed_generation/test_state_offload.py
@@ -241,16 +241,17 @@ def test_persist_survivors_updates_latest_seed_pool_symlink(
     monkeypatch: Any,
 ) -> None:
     """``~/.geode/self-improving-loop/latest_seed_pool`` is stamped to this run."""
-    fake_home = tmp_path / "home"
+    run_dir = tmp_path
+    fake_home = run_dir / "home"
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
-    state = _populated_state(tmp_path)
-    cand_path = _seed_candidate_md(tmp_path, "c-00")
+    state = _populated_state(run_dir)
+    cand_path = _seed_candidate_md(run_dir, "c-00")
     state.candidates = [{"id": "c-00", "path": str(cand_path), "target_dim": "broken_tool_use"}]
     pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
     pipeline.run()
     latest = fake_home / ".geode" / "self-improving-loop" / "latest_seed_pool"
     assert latest.is_symlink()
-    assert latest.resolve() == (tmp_path / "survivors").resolve()
+    assert latest.resolve() == (run_dir / "survivors").resolve()
 
 
 def test_persist_survivors_latest_symlink_moves_forward(
@@ -258,17 +259,18 @@ def test_persist_survivors_latest_symlink_moves_forward(
     monkeypatch: Any,
 ) -> None:
     """A second run replaces the symlink target rather than failing on EEXIST."""
-    fake_home = tmp_path / "home"
+    run_root = tmp_path
+    fake_home = run_root / "home"
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
 
-    run_a = tmp_path / "runA"
+    run_a = run_root / "runA"
     run_a.mkdir()
     state_a = _populated_state(run_a)
     cand_a = _seed_candidate_md(run_a, "c-00")
     state_a.candidates = [{"id": "c-00", "path": str(cand_a), "target_dim": "broken_tool_use"}]
     Pipeline(state=state_a, registry=_registry_with_noop_agents()).run()
 
-    run_b = tmp_path / "runB"
+    run_b = run_root / "runB"
     run_b.mkdir()
     state_b = _populated_state(run_b)
     cand_b = _seed_candidate_md(run_b, "c-00")
@@ -285,7 +287,8 @@ def test_persist_survivors_latest_symlink_swallows_oserror(
     monkeypatch: Any,
 ) -> None:
     """Symlink-update failure must not break the run (handoff is best-effort)."""
-    fake_home = tmp_path / "home"
+    run_dir = tmp_path
+    fake_home = run_dir / "home"
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
     original_symlink = Path.symlink_to
 
@@ -295,13 +298,13 @@ def test_persist_survivors_latest_symlink_swallows_oserror(
         return original_symlink(self, target, *a, **kw)
 
     monkeypatch.setattr(Path, "symlink_to", _selective_symlink)
-    state = _populated_state(tmp_path)
-    cand_path = _seed_candidate_md(tmp_path, "c-00")
+    state = _populated_state(run_dir)
+    cand_path = _seed_candidate_md(run_dir, "c-00")
     state.candidates = [{"id": "c-00", "path": str(cand_path), "target_dim": "broken_tool_use"}]
     pipeline = Pipeline(state=state, registry=_registry_with_noop_agents())
     pipeline.run()  # must not raise
     # state.pool_path_out is still stamped — canonical handoff remains intact.
-    assert state.pool_path_out == tmp_path / "survivors"
+    assert state.pool_path_out == run_dir / "survivors"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -345,10 +345,12 @@ def test_real_mode_invokes_subprocess_with_override_env(
         return result
 
     monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
-    dim_means, dim_stderr, _audit_s, _total_s = run_audit(dry_run=False)
+    dim_means, dim_stderr, evidence, _audit_s, _total_s = run_audit(dry_run=False)
     assert "--seed-select" in captured["argv"]
     assert dim_means["input_hallucination"] == 2.0
     assert dim_stderr == {}
+    # Summary without 'evidence' key → empty evidence (legacy CLI tolerated).
+    assert evidence == {}
 
 
 def test_real_mode_parses_dim_stderr_when_emitted(
@@ -375,7 +377,7 @@ def test_real_mode_parses_dim_stderr_when_emitted(
         return result
 
     monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
-    _means, dim_stderr, _audit_s, _total_s = run_audit(dry_run=False)
+    _means, dim_stderr, _evidence, _audit_s, _total_s = run_audit(dry_run=False)
     assert dim_stderr["input_hallucination"] == pytest.approx(0.5)
 
 
@@ -399,12 +401,80 @@ def test_real_mode_raises_when_summary_json_missing(
 
 
 def test_dry_run_emits_finite_fitness() -> None:
-    dim_means, dim_stderr, audit_seconds, _ = run_audit(dry_run=True)
+    dim_means, dim_stderr, evidence, audit_seconds, _ = run_audit(dry_run=True)
     assert dim_means["broken_tool_use"] == pytest.approx(3.4)
     assert dim_stderr == {}
+    assert evidence == {}  # dry-run has no judge transcript
     assert audit_seconds == 0.0
     fitness = compute_fitness(dim_means, dim_stderr)
     assert 0.0 < fitness <= 1.0
+
+
+def test_real_mode_parses_evidence_from_summary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G2 — `evidence` key in audit summary is parsed into run_audit's 3rd return."""
+    state_dir = tmp_path / "state"
+    monkeypatch.setattr(auto_train, "STATE_DIR", state_dir)
+    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", state_dir / "audit_logs")
+    monkeypatch.setattr(auto_train, "RUN_LOG", state_dir / "run.log")
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = (
+            "audit complete\n"
+            + json.dumps(
+                {
+                    "dim_means": {"broken_tool_use": 4.0},
+                    "dim_stderr": {"broken_tool_use": 0.3},
+                    "evidence": {
+                        "broken_tool_use": [
+                            {
+                                "sample_id": "seed-a",
+                                "value": 7.0,
+                                "explanation": "tool result was hallucinated",
+                                "highlights": "- [M9] hallucinated",
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        )
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+    _means, _stderr, evidence, _audit_s, _total_s = run_audit(dry_run=False)
+    assert "broken_tool_use" in evidence
+    assert evidence["broken_tool_use"][0]["sample_id"] == "seed-a"
+    assert evidence["broken_tool_use"][0]["value"] == 7.0
+
+
+def test_real_mode_tolerates_missing_evidence_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Older audit CLI (no G2) emits summary without 'evidence' — must not break."""
+    state_dir = tmp_path / "state"
+    monkeypatch.setattr(auto_train, "STATE_DIR", state_dir)
+    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", state_dir / "audit_logs")
+    monkeypatch.setattr(auto_train, "RUN_LOG", state_dir / "run.log")
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = (
+            "audit complete\n"
+            + json.dumps({"dim_means": {"d": 2.0}, "dim_stderr": {"d": 0.1}})
+            + "\n"
+        )
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
+    _means, _stderr, evidence, _audit_s, _total_s = run_audit(dry_run=False)
+    assert evidence == {}
 
 
 def test_stability_score_uses_stderr_when_present() -> None:
@@ -520,24 +590,26 @@ def test_cross_axis_gate_no_penalty_on_monotone_improvement() -> None:
 
 
 def test_load_baseline_missing_file_returns_none() -> None:
-    """Absent baseline.json → (None, None)."""
+    """Absent baseline.json → (None, None, {}) — 3-tuple post-G2."""
     saved = auto_train.BASELINE_PATH
     try:
         # Point at a definitely-missing path
         auto_train.BASELINE_PATH = Path("/nonexistent/path/baseline.json")
-        means, stderr = auto_train._load_baseline()
+        means, stderr, evidence = auto_train._load_baseline()
         assert means is None
         assert stderr is None
+        assert evidence == {}
     finally:
         auto_train.BASELINE_PATH = saved
 
 
 def test_load_baseline_parses_raw_dim_dicts(tmp_path: Path) -> None:
     """S9 schema — `baseline.json` carries `{dim_means, dim_stderr}` raw."""
+    state_dir = tmp_path
     saved = auto_train.BASELINE_PATH
     try:
-        path = tmp_path / "baseline.json"
-        path.write_text(
+        baseline_path = state_dir / "baseline.json"
+        baseline_path.write_text(
             json.dumps(
                 {
                     "dim_means": {"broken_tool_use": 3.4},
@@ -546,38 +618,148 @@ def test_load_baseline_parses_raw_dim_dicts(tmp_path: Path) -> None:
             ),
             encoding="utf-8",
         )
-        auto_train.BASELINE_PATH = path
-        means, stderr = auto_train._load_baseline()
+        auto_train.BASELINE_PATH = baseline_path
+        means, stderr, evidence = auto_train._load_baseline()
         assert means == {"broken_tool_use": pytest.approx(3.4)}
         assert stderr == {"broken_tool_use": pytest.approx(0.4)}
+        assert evidence == {}  # legacy baselines pre-G2 → empty evidence
     finally:
         auto_train.BASELINE_PATH = saved
 
 
 def test_load_baseline_empty_payload_returns_none(tmp_path: Path) -> None:
+    state_dir = tmp_path
     saved = auto_train.BASELINE_PATH
     try:
-        path = tmp_path / "baseline.json"
-        path.write_text("{}", encoding="utf-8")
-        auto_train.BASELINE_PATH = path
-        means, stderr = auto_train._load_baseline()
+        baseline_path = state_dir / "baseline.json"
+        baseline_path.write_text("{}", encoding="utf-8")
+        auto_train.BASELINE_PATH = baseline_path
+        means, stderr, evidence = auto_train._load_baseline()
         assert means is None
         assert stderr is None
+        assert evidence == {}
     finally:
         auto_train.BASELINE_PATH = saved
 
 
 def test_load_baseline_unparseable_json_returns_none(tmp_path: Path) -> None:
+    state_dir = tmp_path
     saved = auto_train.BASELINE_PATH
     try:
-        path = tmp_path / "baseline.json"
-        path.write_text("{not valid json", encoding="utf-8")
-        auto_train.BASELINE_PATH = path
-        means, stderr = auto_train._load_baseline()
+        baseline_path = state_dir / "baseline.json"
+        baseline_path.write_text("{not valid json", encoding="utf-8")
+        auto_train.BASELINE_PATH = baseline_path
+        means, stderr, evidence = auto_train._load_baseline()
         assert means is None
         assert stderr is None
+        assert evidence == {}
     finally:
         auto_train.BASELINE_PATH = saved
+
+
+# ---------------------------------------------------------------------------
+# G2 — baseline.json evidence schema (closed-loop wiring sprint, 2026-05-20)
+# ---------------------------------------------------------------------------
+
+
+def test_load_baseline_parses_evidence_payload(tmp_path: Path) -> None:
+    """Post-G2 baseline carries per-dim top-K evidence rows."""
+    state_dir = tmp_path
+    saved = auto_train.BASELINE_PATH
+    try:
+        baseline_path = state_dir / "baseline.json"
+        baseline_path.write_text(
+            json.dumps(
+                {
+                    "dim_means": {"broken_tool_use": 3.4},
+                    "dim_stderr": {"broken_tool_use": 0.4},
+                    "evidence": {
+                        "broken_tool_use": [
+                            {
+                                "sample_id": "seed-x",
+                                "value": 7.0,
+                                "explanation": "target hallucinated tool result",
+                                "highlights": "- [M9] worst",
+                            }
+                        ]
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        auto_train.BASELINE_PATH = baseline_path
+        _means, _stderr, evidence = auto_train._load_baseline()
+        rows = evidence["broken_tool_use"]
+        assert rows[0]["sample_id"] == "seed-x"
+        assert rows[0]["value"] == 7.0
+        assert "hallucinated" in rows[0]["explanation"]
+    finally:
+        auto_train.BASELINE_PATH = saved
+
+
+def test_load_baseline_malformed_evidence_filtered(tmp_path: Path) -> None:
+    """Garbage evidence values (non-list / non-dict rows) → silently skipped."""
+    state_dir = tmp_path
+    saved = auto_train.BASELINE_PATH
+    try:
+        baseline_path = state_dir / "baseline.json"
+        baseline_path.write_text(
+            json.dumps(
+                {
+                    "dim_means": {"d": 3.4},
+                    "dim_stderr": {"d": 0.4},
+                    "evidence": {
+                        "d": [
+                            {"sample_id": "ok", "value": 5},
+                            "garbage row",  # non-dict → dropped
+                            42,
+                        ],
+                        "bad_dim": "not a list",  # non-list → dropped
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        auto_train.BASELINE_PATH = baseline_path
+        _means, _stderr, evidence = auto_train._load_baseline()
+        assert list(evidence.keys()) == ["d"]
+        assert evidence["d"] == [{"sample_id": "ok", "value": 5}]
+    finally:
+        auto_train.BASELINE_PATH = saved
+
+
+def test_write_baseline_persists_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_write_baseline accepts evidence kwarg and persists it verbatim."""
+    state_dir = tmp_path
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", state_dir / "baseline.json")
+    evidence_in = {
+        "broken_tool_use": [
+            {
+                "sample_id": "seed-z",
+                "value": 8.0,
+                "explanation": "ignored tool error",
+                "highlights": "- [M3] missed",
+            }
+        ]
+    }
+    _write_baseline({"broken_tool_use": 4.0}, {"broken_tool_use": 0.5}, evidence_in)
+    persisted = json.loads((state_dir / "baseline.json").read_text(encoding="utf-8"))
+    assert persisted["evidence"] == evidence_in
+
+
+def test_write_baseline_default_evidence_is_empty_dict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting evidence kwarg writes ``"evidence": {}`` — schema stays stable."""
+    state_dir = tmp_path
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", state_dir / "baseline.json")
+    _write_baseline({"d": 4.0}, {"d": 0.5})
+    persisted = json.loads((state_dir / "baseline.json").read_text(encoding="utf-8"))
+    assert persisted["evidence"] == {}
 
 
 def test_no_legacy_fitness_baseline_class() -> None:
@@ -819,13 +1001,15 @@ def test_write_baseline_round_trip_matches_load_schema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_write_baseline`` output must be readable by ``_load_baseline``."""
-    monkeypatch.setattr(auto_train, "BASELINE_PATH", tmp_path / "baseline.json")
+    state_dir = tmp_path
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", state_dir / "baseline.json")
     dim_means = {"broken_tool_use": 3.4, "input_hallucination": 3.7}
     dim_stderr = {"broken_tool_use": 0.4, "input_hallucination": 0.32}
     _write_baseline(dim_means, dim_stderr)
-    loaded_means, loaded_stderr = auto_train._load_baseline()
+    loaded_means, loaded_stderr, loaded_evidence = auto_train._load_baseline()
     assert loaded_means == dim_means
     assert loaded_stderr == dim_stderr
+    assert loaded_evidence == {}  # legacy call (no evidence arg)
 
 
 def test_write_baseline_creates_parent_dirs(
@@ -833,10 +1017,10 @@ def test_write_baseline_creates_parent_dirs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_write_baseline`` mkdirs nested missing directories."""
-    target = tmp_path / "nested" / "deeper" / "baseline.json"
-    monkeypatch.setattr(auto_train, "BASELINE_PATH", target)
+    nested_baseline_path = tmp_path / "nested" / "deeper" / "baseline.json"
+    monkeypatch.setattr(auto_train, "BASELINE_PATH", nested_baseline_path)
     _write_baseline({"broken_tool_use": 3.4}, {"broken_tool_use": 0.4})
-    assert target.is_file()
+    assert nested_baseline_path.is_file()
 
 
 def test_should_promote_bootstraps_when_no_prior_baseline() -> None:


### PR DESCRIPTION
## Summary
- `core/audit/dim_extractor.extract_evidence(eval_path, top_k=3)` — petri `.eval` 에서 dim 별 worst-K sample 의 `{sample_id, value, explanation, highlights}` 추출
- `plugins/petri_audit/cli_audit._emit_dim_aggregates` 가 evidence 도 stdout JSON 에 번들
- `autoresearch/train.py` `_load_baseline` / `_write_baseline` 가 `evidence` 키 처리, `run_audit` 5-tuple
- Naming hygiene 동봉 (PR-G1 의 3 G1 test 들의 `tmp_path` 통째 흘림 → `run_dir`/`run_root` alias 정리)

## Why
직전 GAP audit 의 **G2 누수**: baseline.json 이 `{dim_means, dim_stderr}` 만 담아서 fitness regression 의 "왜" — 어느 sample 에서 어떤 judge reasoning 으로 dim 이 튀었는지 — 가 사라졌음. G5 self-improving-loop runner 가 prompt mutation 을 결정하려면 scalar 가 아닌 anchor (sample_id + explanation + `[M#]` highlights) 가 필요.

Petri 실 eval 1건 inventory 결과 (대화 중 사용자와 합의):
- 🟢 SIGNAL: `score.value` (이미 추출), `score.explanation` (judge reasoning), `score.metadata.highlights` (`[M#]` quote anchor), `Sample.id`, `Sample.metadata.tags`
- ❌ NOISE: `Sample.messages` 통째, `events` (82개), `attachments` (52개), `score.answer`

Tier-1 만 (dim 별 top-3) → ~250KB per audit, runner 한 번 호출에 friendly.

**Naming hygiene 도 같이**: 사용자가 PR-G1 의 test 코드에서 `tmp_path` 가 의미 모호하게 통째 흘려보내는 사례 지적. 같은 PR 안에서 어떤 test 는 alias 부여, 어떤 test 는 통째 흘림 — 일관성 결여. memory `feedback_no_naive_variable_names` 등록 + PR-G1 G1 test 3개에 alias 부여 + PR-G2 신규 코드는 처음부터 의미 부여.

## Changes
| File | Change |
|------|--------|
| `core/audit/dim_extractor.py` | `extract_evidence()` + `_walk_evidence()` 추가. `archive_path` / `evidence_by_dim` / `dim_rows` / `ranked` alias. graceful no-op (inspect_ai 미설치 / 파일 없음 / 읽기 실패 → 빈 dict) |
| `plugins/petri_audit/cli_audit.py` | `_emit_dim_aggregates` 가 `extract_evidence` 호출 후 `summary_payload["evidence"] = evidence` 로 stdout 에 번들 |
| `autoresearch/train.py` | `run_audit` 반환 5-tuple `(dim_means, dim_stderr, evidence, audit_seconds, total_seconds)`. `_load_baseline` 3-tuple 반환, `_write_baseline(evidence=...)` 매개변수. `main()` 의 unpack + promote 시 evidence 함께 persist. `baseline_payload` / `raw_means` / `raw_stderr` / `baseline_means` / `baseline_stderr` / `baseline_evidence` alias |
| `tests/audit/test_dim_extractor.py` | `FakeScore` 에 `explanation` / `metadata` 필드 + `FakeSample` 에 `id` 필드 추가. `TestEvidence` 7 케이스: top-K ranking / alphabetical tiebreak / scalar score skip / top_k=0 / missing archive / read failure / missing explanation 기본값 |
| `tests/test_autoresearch_train.py` | 기존 4개 baseline I/O test 의 3-tuple unpacking + `state_dir`/`baseline_path` alias. G2 신규: evidence payload 파싱 / malformed evidence 필터 / write 후 round-trip / default empty / audit summary 의 evidence 키 / legacy summary (no evidence key) tolerance |
| `tests/plugins/seed_generation/test_state_offload.py` | PR-G1 의 G1 test 3개에 `run_dir` / `run_root` alias 도입 (naming hygiene 묶기) |
| `CHANGELOG.md` | `[Unreleased] Added` 에 PR-G2 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Petri evidence Tier-1 추출 | Implemented | dim 별 top-3, alphabetical tiebreak |
| audit subprocess → train.py pipe | Implemented | summary JSON 의 evidence 키 |
| baseline.json schema 확장 | Implemented | `{dim_means, dim_stderr, evidence}` |
| Backward compat | Implemented | 누락 evidence 키 / legacy baseline → 빈 dict |
| Naming hygiene (PR-G1 test) | Implemented | run_dir / run_root alias |
| PR-G2 신규 코드 naming | Implemented | 처음부터 의미 부여 (evidence_by_dim, archive_path, baseline_payload, summary_payload) |

## Verification
- [x] ruff check clean (`autoresearch/ core/ plugins/ tests/`)
- [x] mypy clean (356 source files)
- [x] pytest pass: 385 tests + 1 skipped (`tests/audit/test_dim_extractor.py` + `tests/test_autoresearch_train.py` + `tests/plugins/seed_generation/` + `test_self_improving_loop_config.py`)
- [x] E2E unchanged (live audit BLOCKED until G5)

## Reference
- 2026-05-20 conversation: GAP audit (G1-G5) + Petri output inventory + Tier-1 evidence decision
- `memory/feedback_no_naive_variable_names.md` (new, 2026-05-20)
- Petri eval log inspected: `~/.geode/petri/logs/geode-13-v3.eval` (13 samples × 22 dims)

🤖 Generated with [Claude Code](https://claude.com/claude-code)