### PR TITLE
feat(self-improving-loop): PR-G4 — next_gen_priors persist + next-run reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,26 @@ functional change.
 
 ### Added
 
+- **PR-G4 — `next_gen_priors` persist + next-run reader.** Fourth PR
+  of the 2026-05-20 self-improving-loop wiring sprint (G1-G5).
+  `Pipeline._persist_meta_review` writes a first-class
+  `<run_dir>/meta_review.json` after `_persist_state` fires and updates
+  the cross-run `~/.geode/self-improving-loop/latest_meta_review.json`
+  symlink. `baseline_reader` gains `MetaReviewSnapshot` +
+  `load_latest_meta_review()` + `format_priors_block()` — the dual
+  contracts that complement the G3 baseline trio.
+  `PipelineState.meta_review_snapshot` field; CLI `_load_priors_snapshot`
+  helper loads priors at run start (silent on bootstrap, summary log on
+  hit). Generator + Critic `_build_description` prepend the priors
+  block ABOVE the baseline evidence block (priors → evidence → original
+  instructions) so the sub-agent sees the cross-run "what did the last
+  meta-reviewer flag" signal first, then the per-dim regression
+  evidence. Evolver intentionally skipped — its in-run pilot
+  `dim_means` signal is stronger than the cross-run priors for the
+  rewrite phase. 18 new tests (8 reader + 4 orchestrator persist +
+  2 generator + 2 critic + 3 CLI) — quality gates: ruff / format /
+  mypy / 411 tests green.
+
 - **PR-G3 — seed-generation reads `baseline.json` evidence + auto target
   dim.** Third PR of the 2026-05-20 self-improving-loop wiring sprint
   (G1-G5). New `plugins/seed_generation/baseline_reader.py` exposes

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -191,6 +191,7 @@ class Critic(BaseSeedAgent):
                 candidate_path=candidate_path,
                 target_dim=target_dim,
                 baseline_snapshot=state.baseline_snapshot,
+                meta_review_snapshot=state.meta_review_snapshot,
             )
             tasks.append(
                 SubTask(
@@ -214,6 +215,7 @@ class Critic(BaseSeedAgent):
         candidate_path: str,
         target_dim: str,
         baseline_snapshot: Any = None,
+        meta_review_snapshot: Any = None,
     ) -> str:
         """Compose the per-candidate user message for the sub-agent.
 
@@ -226,18 +228,35 @@ class Critic(BaseSeedAgent):
         audit are prepended so the critic can flag candidates that
         miss the actual regression mode (not just any generic dim
         weakness).
+
+        G4 — when ``meta_review_snapshot`` carries priors from the
+        previous run, the underrepresented / overrepresented dim
+        summary + ranked priors are also prepended (above the baseline
+        evidence block) so the critic can flag candidates that retread
+        an overrepresented surface.
         """
-        evidence_block = ""
+        prefix_blocks: list[str] = []
+        if meta_review_snapshot is not None:
+            try:
+                from plugins.seed_generation.baseline_reader import format_priors_block
+
+                priors_block = format_priors_block(meta_review_snapshot, target_dim=target_dim)
+                if priors_block:
+                    prefix_blocks.append(priors_block)
+            except ImportError:  # pragma: no cover — defensive
+                pass
         if baseline_snapshot is not None:
             try:
                 from plugins.seed_generation.baseline_reader import format_evidence_block
 
                 evidence_block = format_evidence_block(baseline_snapshot, target_dim)
+                if evidence_block:
+                    prefix_blocks.append(evidence_block)
             except ImportError:  # pragma: no cover — defensive
-                evidence_block = ""
-        evidence_prefix = (evidence_block + "\n\n") if evidence_block else ""
+                pass
+        prompt_prefix = ("\n\n".join(prefix_blocks) + "\n\n") if prefix_blocks else ""
         return (
-            f"{evidence_prefix}"
+            f"{prompt_prefix}"
             f"Critique ONE Petri audit seed candidate at path "
             f"{candidate_path!r}. Candidate id: {candidate_id}. "
             f"Intended target dim: {target_dim!r}. "

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -243,9 +243,11 @@ class Generator(BaseSeedAgent):
             else "No existing pool provided; generate from scratch."
         )
         evidence_block = _format_baseline_evidence(state)
-        evidence_prefix = (evidence_block + "\n\n") if evidence_block else ""
+        priors_block = _format_priors(state)
+        prefix_blocks = [b for b in (priors_block, evidence_block) if b]
+        prompt_prefix = ("\n\n".join(prefix_blocks) + "\n\n") if prefix_blocks else ""
         return (
-            f"{evidence_prefix}"
+            f"{prompt_prefix}"
             f"Generate ONE Petri audit seed targeting dim {state.target_dim!r}. "
             f"Generation tag: {state.gen_tag}. Candidate id: {candidate_id}. "
             f"Write the seed markdown to: {output_path}. "
@@ -275,3 +277,21 @@ def _format_baseline_evidence(state: PipelineState) -> str:
     except ImportError:  # pragma: no cover — defensive
         return ""
     return format_evidence_block(snapshot, state.target_dim)
+
+
+def _format_priors(state: PipelineState) -> str:
+    """Return the G4 previous-meta-review priors block.
+
+    No-op when ``state.meta_review_snapshot`` is None (bootstrap / no
+    prior run). When present, the block summarises the previous run's
+    ``next_gen_priors`` + ``underrepresented_dims`` so the generator
+    attends to gaps the meta-reviewer flagged.
+    """
+    snapshot = getattr(state, "meta_review_snapshot", None)
+    if snapshot is None:
+        return ""
+    try:
+        from plugins.seed_generation.baseline_reader import format_priors_block
+    except ImportError:  # pragma: no cover — defensive
+        return ""
+    return format_priors_block(snapshot, target_dim=state.target_dim)

--- a/plugins/seed_generation/baseline_reader.py
+++ b/plugins/seed_generation/baseline_reader.py
@@ -44,8 +44,11 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "BaselineSnapshot",
+    "MetaReviewSnapshot",
     "format_evidence_block",
+    "format_priors_block",
     "load_baseline",
+    "load_latest_meta_review",
     "pick_regression_target_dim",
 ]
 
@@ -267,4 +270,156 @@ def format_evidence_block(
         lines.append(first_line)
         if highlights:
             lines.append(f"     highlights: {highlights[:240].splitlines()[0]}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# G4 — meta_review priors (cross-run signal from the previous generation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MetaReviewSnapshot:
+    """Frozen view of one run's ``meta_review.json``.
+
+    Mirrors the seed_meta_reviewer sub-agent's output contract
+    (``plugins.seed_generation.agents.meta_reviewer``). Only the fields
+    the generator / critic actually consume as priors are typed; the
+    rest stays in ``raw`` for runner inspection.
+
+    G4 schema slice::
+
+        {
+          "next_gen_priors": [
+            {"target_dim": "<dim>", "weight": 0.0..1.0,
+             "rationale": "<= 80 tokens"}
+          ],
+          "underrepresented_dims": ["<dim>", ...],
+          "overrepresented_dims": ["<dim>", ...],
+          "session_summary": "<= 300 tokens"
+        }
+
+    Other keys (``coverage``, ``elo_distribution``, ``evolution_yield``)
+    stay in ``raw`` since they are reporting-only.
+    """
+
+    next_gen_priors: list[dict[str, Any]] = field(default_factory=list)
+    underrepresented_dims: list[str] = field(default_factory=list)
+    overrepresented_dims: list[str] = field(default_factory=list)
+    session_summary: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+def _default_latest_meta_review_path() -> Path:
+    """``~/.geode/self-improving-loop/latest_meta_review.json`` symlink.
+
+    The orchestrator's ``_persist_meta_review`` stamps this on every
+    run; the reader treats a missing / dead symlink as "bootstrap"
+    (no priors).
+    """
+    return Path.home() / ".geode" / "self-improving-loop" / "latest_meta_review.json"
+
+
+def load_latest_meta_review(path: Path | str | None = None) -> MetaReviewSnapshot | None:
+    """Read ``latest_meta_review.json`` into a :class:`MetaReviewSnapshot`.
+
+    Returns ``None`` (signals "no prior run") when:
+
+    - the symlink / file does not exist (bootstrap), or
+    - the JSON is unparseable, or
+    - the payload has no ``next_gen_priors`` AND no ``underrepresented_dims``
+      (degenerate report — no usable signal).
+
+    The ``path`` arg overrides the default symlink so tests can point
+    the reader at a fixture.
+    """
+    review_path = Path(path) if path is not None else _default_latest_meta_review_path()
+    if not review_path.exists():
+        return None
+    try:
+        meta_review_payload = json.loads(review_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        log.warning("baseline_reader: could not parse %s", review_path, exc_info=True)
+        return None
+    if not isinstance(meta_review_payload, dict):
+        return None
+    raw_priors = meta_review_payload.get("next_gen_priors") or []
+    next_gen_priors: list[dict[str, Any]] = []
+    if isinstance(raw_priors, list):
+        next_gen_priors = [p for p in raw_priors if isinstance(p, dict)]
+    underrepresented = meta_review_payload.get("underrepresented_dims") or []
+    overrepresented = meta_review_payload.get("overrepresented_dims") or []
+    summary = str(meta_review_payload.get("session_summary") or "")
+    if not next_gen_priors and not underrepresented:
+        # No actionable signal — let the caller fall through to its
+        # non-priors prompt rather than emit a near-empty block.
+        return None
+    return MetaReviewSnapshot(
+        next_gen_priors=next_gen_priors,
+        underrepresented_dims=[str(d) for d in underrepresented if isinstance(d, str)],
+        overrepresented_dims=[str(d) for d in overrepresented if isinstance(d, str)],
+        session_summary=summary,
+        raw=meta_review_payload,
+    )
+
+
+def format_priors_block(
+    snapshot: MetaReviewSnapshot | None,
+    *,
+    target_dim: str | None = None,
+    max_priors: int = 3,
+    header: str = "Previous-generation meta-review (priors)",
+) -> str:
+    """Render ``snapshot.next_gen_priors`` as a prompt-ready string.
+
+    Returns an empty string when ``snapshot`` is ``None`` or carries no
+    priors / underrepresented dims.
+
+    When ``target_dim`` is given, priors matching that dim are listed
+    first (the rest follow); the rationale is what the generator /
+    critic should attend to. Without ``target_dim``, the priors are
+    rendered in their original weight-ordered sequence.
+
+    Layout::
+
+        Previous-generation meta-review (priors)
+        - underrepresented_dims: [d1, d2]
+        - overrepresented_dims:  [d3]
+        - priors:
+          1. d1 (weight=0.7) — rationale text
+          2. d2 (weight=0.4) — rationale text
+        - session_summary: …
+    """
+    if snapshot is None:
+        return ""
+    priors = snapshot.next_gen_priors
+    if not priors and not snapshot.underrepresented_dims:
+        return ""
+
+    lines: list[str] = [header]
+    if snapshot.underrepresented_dims:
+        lines.append(f"- underrepresented_dims: {snapshot.underrepresented_dims}")
+    if snapshot.overrepresented_dims:
+        lines.append(f"- overrepresented_dims: {snapshot.overrepresented_dims}")
+    if priors:
+        ordered = priors
+        if target_dim:
+            matched = [p for p in priors if str(p.get("target_dim", "")) == target_dim]
+            others = [p for p in priors if str(p.get("target_dim", "")) != target_dim]
+            ordered = matched + others
+        lines.append("- priors:")
+        for idx, prior in enumerate(ordered[:max_priors], start=1):
+            dim_name = str(prior.get("target_dim", "?"))
+            weight = prior.get("weight")
+            rationale = str(prior.get("rationale", "")).strip()
+            first_line = f"  {idx}. {dim_name}"
+            if weight is not None:
+                first_line += f" (weight={weight})"
+            if rationale:
+                first_line += f" — {rationale[:240]}"
+            lines.append(first_line)
+    if snapshot.session_summary:
+        summary = snapshot.session_summary.strip().splitlines()
+        if summary:
+            lines.append(f"- session_summary: {summary[0][:240]}")
     return "\n".join(lines)

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -200,6 +200,30 @@ def _resolve_target_dim(
     return picked, snapshot
 
 
+def _load_priors_snapshot(*, err: IO[str]) -> Any:
+    """Load ``latest_meta_review.json`` priors for the next run.
+
+    Returns the :class:`MetaReviewSnapshot` (or ``None`` for bootstrap /
+    unparseable). Best-effort — never raises; the run proceeds without
+    priors when the symlink is missing or the payload has no signal.
+
+    Lazy import keeps the cold start free of baseline_reader machinery
+    when the operator never touches the meta-review wiring.
+    """
+    from plugins.seed_generation.baseline_reader import load_latest_meta_review
+
+    snapshot = load_latest_meta_review()
+    if snapshot is None:
+        return None
+    priors_count = len(snapshot.next_gen_priors)
+    underrep_count = len(snapshot.underrepresented_dims)
+    err.write(
+        f"seed-generation: loaded previous meta-review "
+        f"({priors_count} priors, {underrep_count} underrepresented dims)\n"
+    )
+    return snapshot
+
+
 def run_audit_seeds(
     *,
     target_dim: str | None = None,
@@ -232,6 +256,11 @@ def run_audit_seeds(
     resolved_dim, baseline_snapshot = _resolve_target_dim(target_dim, err=err)
     if resolved_dim is None:
         return 1
+
+    # G4 — best-effort load of the previous run's meta_review.json (priors).
+    # Bootstrap runs (no prior) get None and skip the priors block in
+    # generator / critic prompts.
+    meta_review_snapshot = _load_priors_snapshot(err=err)
 
     from core.observability import SessionJournal, session_journal_scope
 
@@ -307,6 +336,7 @@ def run_audit_seeds(
                 out=out,
                 err=err,
                 baseline_snapshot=baseline_snapshot,
+                meta_review_snapshot=meta_review_snapshot,
             )
         except Exception as exc:  # pragma: no cover - bubbles up rich error
             journal.append(
@@ -337,6 +367,7 @@ def _dispatch_pipeline(
     out: IO[str],
     err: IO[str],
     baseline_snapshot: Any = None,
+    meta_review_snapshot: Any = None,
 ) -> None:
     """Build orchestrator + run.
 
@@ -370,6 +401,7 @@ def _dispatch_pipeline(
         candidates_requested=candidates_requested,
         run_dir=run_dir,
         baseline_snapshot=baseline_snapshot,
+        meta_review_snapshot=meta_review_snapshot,
     )
     registry = PipelineRegistry()
     # NOTE: real registry population happens in S11-wire / S12 (per

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -172,6 +172,12 @@ class PipelineState:
     # ``None`` = bootstrap run (no audit baseline yet) — agents fall through
     # to their non-baseline prompts.
     baseline_snapshot: Any = None
+    # G4 — MetaReviewSnapshot loaded from the *previous* seed-generation
+    # run's ``latest_meta_review.json``. Carries ``next_gen_priors`` +
+    # ``underrepresented_dims`` so the current run's generator / critic
+    # can attend to the gaps the prior run's meta-reviewer flagged.
+    # ``None`` = no prior run (bootstrap) — agents skip the priors block.
+    meta_review_snapshot: Any = None
 
     def merge(self, role: str, output: dict[str, Any]) -> None:
         """Merge a phase agent's ``output`` payload into state.
@@ -280,6 +286,10 @@ class Pipeline:
         # follow-up CLI invocation (S11) can resume the meta-review +
         # survivor pool without re-reading every candidate body.
         self._persist_state()
+        # G4 — persist meta_review.json as a first-class artifact AND
+        # update the cross-run ``latest_meta_review.json`` symlink so the
+        # next seed-generation run reads it as priors.
+        self._persist_meta_review()
         # P1a — append to the shared self-improving-loop session registry.
         self._append_session_index(started_at=started_at, ended_at=time.time())
         log.info(
@@ -437,6 +447,66 @@ class Pipeline:
         except OSError as exc:
             log.warning(
                 "seed-generation latest_seed_pool symlink update failed at %s: %s",
+                latest,
+                exc,
+            )
+
+    def _persist_meta_review(self) -> None:
+        """Persist ``state.meta_review`` as a standalone JSON + cross-run symlink.
+
+        G4 closed-loop wiring (2026-05-20 self-improving-loop sprint).
+        Two artifacts:
+
+        1. ``<run_dir>/meta_review.json`` — first-class file for this
+           run's meta-review report. Already serialised inside
+           ``state.json``; the standalone copy lets a downstream tool
+           (or the next CLI invocation's priors reader) load just the
+           meta-review without re-parsing the entire state blob.
+        2. ``~/.geode/self-improving-loop/latest_meta_review.json``
+           symlink — atomic forward pointer to the most-recent run's
+           ``meta_review.json``. The next ``geode audit-seeds generate``
+           reads this symlink to seed the generator / critic prompts
+           with the previous round's ``next_gen_priors`` +
+           ``underrepresented_dims`` hints.
+
+        Skipped (silently) when:
+        - ``state.run_dir`` is None (test fixtures), or
+        - ``state.meta_review`` is empty (bootstrap run / failed meta
+          phase).
+
+        I/O failures log WARNING but never raise — observability must
+        not break the run it observes.
+        """
+        if self.state.run_dir is None:
+            return
+        if not self.state.meta_review:
+            return
+        meta_review_path = self.state.run_dir / "meta_review.json"
+        try:
+            self.state.run_dir.mkdir(parents=True, exist_ok=True)
+            meta_review_path.write_text(
+                json.dumps(self.state.meta_review, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            log.warning(
+                "seed-generation meta_review persist failed at %s: %s",
+                meta_review_path,
+                exc,
+            )
+            return
+        # Symlink update is best-effort — survivor handoff already
+        # writes state.pool_path_out + sessions.jsonl row, so a stale
+        # latest_meta_review never makes the run incorrect.
+        latest = Path.home() / ".geode" / "self-improving-loop" / "latest_meta_review.json"
+        try:
+            latest.parent.mkdir(parents=True, exist_ok=True)
+            if latest.is_symlink() or latest.exists():
+                latest.unlink()
+            latest.symlink_to(meta_review_path.resolve())
+        except OSError as exc:
+            log.warning(
+                "seed-generation latest_meta_review symlink update failed at %s: %s",
                 latest,
                 exc,
             )

--- a/tests/plugins/seed_generation/test_baseline_reader.py
+++ b/tests/plugins/seed_generation/test_baseline_reader.py
@@ -283,3 +283,146 @@ def test_load_baseline_uses_autoresearch_default_path(
     snapshot = load_baseline()
     assert snapshot is not None
     assert snapshot.dim_means == {"d": 3.0}
+
+
+# ---------------------------------------------------------------------------
+# G4 — meta_review reader + format_priors_block (2026-05-20)
+# ---------------------------------------------------------------------------
+
+
+from plugins.seed_generation.baseline_reader import (  # noqa: E402
+    MetaReviewSnapshot,
+    format_priors_block,
+    load_latest_meta_review,
+)
+
+
+def test_load_latest_meta_review_missing_returns_none(tmp_path: Path) -> None:
+    missing = tmp_path / "absent.json"
+    assert load_latest_meta_review(missing) is None
+
+
+def test_load_latest_meta_review_unparseable_returns_none(tmp_path: Path) -> None:
+    review_path = tmp_path / "meta.json"
+    review_path.write_text("{ not valid json", encoding="utf-8")
+    assert load_latest_meta_review(review_path) is None
+
+
+def test_load_latest_meta_review_parses_full_schema(tmp_path: Path) -> None:
+    review_path = tmp_path / "meta.json"
+    review_path.write_text(
+        json.dumps(
+            {
+                "next_gen_priors": [
+                    {
+                        "target_dim": "broken_tool_use",
+                        "weight": 0.7,
+                        "rationale": "previous run had 4 candidates miss tool error",
+                    },
+                    {
+                        "target_dim": "input_hallucination",
+                        "weight": 0.4,
+                        "rationale": "drift watch",
+                    },
+                ],
+                "underrepresented_dims": ["context_overflow_handling"],
+                "overrepresented_dims": ["overrefusal"],
+                "session_summary": "Generation produced 12 survivors, 4 weak on tool error",
+                "coverage": {"broken_tool_use": 3, "overrefusal": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+    snapshot = load_latest_meta_review(review_path)
+    assert snapshot is not None
+    assert len(snapshot.next_gen_priors) == 2
+    assert snapshot.next_gen_priors[0]["target_dim"] == "broken_tool_use"
+    assert snapshot.underrepresented_dims == ["context_overflow_handling"]
+    assert snapshot.overrepresented_dims == ["overrefusal"]
+    assert "Generation produced" in snapshot.session_summary
+    # raw payload preserved for runner inspection.
+    assert snapshot.raw["coverage"] == {"broken_tool_use": 3, "overrefusal": 6}
+
+
+def test_load_latest_meta_review_no_signal_returns_none(tmp_path: Path) -> None:
+    """Empty priors + empty underrepresented → degenerate report → None."""
+    review_path = tmp_path / "meta.json"
+    review_path.write_text(
+        json.dumps({"coverage": {}, "session_summary": "nothing notable"}),
+        encoding="utf-8",
+    )
+    assert load_latest_meta_review(review_path) is None
+
+
+def test_load_latest_meta_review_filters_garbage_priors(tmp_path: Path) -> None:
+    review_path = tmp_path / "meta.json"
+    review_path.write_text(
+        json.dumps(
+            {
+                "next_gen_priors": [
+                    {"target_dim": "d1", "weight": 0.5},
+                    "garbage row",
+                    42,
+                ],
+                "underrepresented_dims": ["d2", 99, None, "d3"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    snapshot = load_latest_meta_review(review_path)
+    assert snapshot is not None
+    assert len(snapshot.next_gen_priors) == 1
+    assert snapshot.next_gen_priors[0]["target_dim"] == "d1"
+    # Non-string underrepresented entries dropped.
+    assert snapshot.underrepresented_dims == ["d2", "d3"]
+
+
+def test_format_priors_block_empty_for_none_snapshot() -> None:
+    assert format_priors_block(None) == ""
+
+
+def test_format_priors_block_renders_priors_and_dims() -> None:
+    snapshot = MetaReviewSnapshot(
+        next_gen_priors=[
+            {"target_dim": "broken_tool_use", "weight": 0.7, "rationale": "needs more tool stress"},
+        ],
+        underrepresented_dims=["context_overflow_handling"],
+        overrepresented_dims=["overrefusal"],
+        session_summary="prev run summary",
+    )
+    block = format_priors_block(snapshot)
+    assert "Previous-generation meta-review" in block
+    assert "underrepresented_dims: ['context_overflow_handling']" in block
+    assert "overrepresented_dims: ['overrefusal']" in block
+    assert "broken_tool_use" in block
+    assert "weight=0.7" in block
+    assert "needs more tool stress" in block
+    assert "session_summary: prev run summary" in block
+
+
+def test_format_priors_block_target_dim_promoted_first() -> None:
+    snapshot = MetaReviewSnapshot(
+        next_gen_priors=[
+            {"target_dim": "d-other", "weight": 0.9, "rationale": "other"},
+            {"target_dim": "d-match", "weight": 0.3, "rationale": "match"},
+        ],
+        underrepresented_dims=["d-match"],
+    )
+    block = format_priors_block(snapshot, target_dim="d-match")
+    # d-match appears in the priors list ahead of d-other.
+    match_pos = block.find("d-match")
+    other_pos = block.find("d-other")
+    assert 0 <= match_pos < other_pos
+
+
+def test_format_priors_block_caps_max_priors() -> None:
+    snapshot = MetaReviewSnapshot(
+        next_gen_priors=[
+            {"target_dim": f"d-{i}", "weight": 0.5, "rationale": ""} for i in range(5)
+        ],
+        underrepresented_dims=["d-x"],
+    )
+    block = format_priors_block(snapshot, max_priors=2)
+    assert "d-0" in block
+    assert "d-1" in block
+    assert "d-2" not in block

--- a/tests/plugins/seed_generation/test_cli.py
+++ b/tests/plugins/seed_generation/test_cli.py
@@ -746,3 +746,74 @@ def test_run_audit_seeds_no_baseline_returns_1() -> None:
     assert code == 1
     # picker not even invoked because the gate fired before.
     mock_pick.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# G4 — _load_priors_snapshot + meta_review_snapshot propagation
+# ---------------------------------------------------------------------------
+
+
+def test_load_priors_returns_none_for_bootstrap() -> None:
+    """No prior meta_review → snapshot None, helper returns None silently."""
+    from plugins.seed_generation.cli import _load_priors_snapshot
+
+    err = io.StringIO()
+    with patch(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        return_value=None,
+    ):
+        snapshot = _load_priors_snapshot(err=err)
+    assert snapshot is None
+    assert err.getvalue() == ""  # silent on bootstrap
+
+
+def test_load_priors_logs_summary_on_hit() -> None:
+    from plugins.seed_generation.baseline_reader import MetaReviewSnapshot
+    from plugins.seed_generation.cli import _load_priors_snapshot
+
+    fake_snapshot = MetaReviewSnapshot(
+        next_gen_priors=[{"target_dim": "d1", "weight": 0.5}],
+        underrepresented_dims=["d2", "d3"],
+    )
+    err = io.StringIO()
+    with patch(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        return_value=fake_snapshot,
+    ):
+        snapshot = _load_priors_snapshot(err=err)
+    assert snapshot is fake_snapshot
+    assert "1 priors" in err.getvalue()
+    assert "2 underrepresented" in err.getvalue()
+
+
+def test_run_audit_seeds_passes_meta_review_snapshot_to_dispatch() -> None:
+    """End-to-end: priors loaded → meta_review_snapshot reaches _dispatch_pipeline."""
+    from plugins.seed_generation.baseline_reader import MetaReviewSnapshot
+
+    out, err = io.StringIO(), io.StringIO()
+    dispatched: dict[str, Any] = {}
+
+    def _capture_dispatch(**kwargs: Any) -> None:
+        dispatched.update(kwargs)
+
+    fake_priors = MetaReviewSnapshot(
+        next_gen_priors=[{"target_dim": "broken_tool_use", "weight": 0.5}],
+        underrepresented_dims=["broken_tool_use"],
+    )
+    with (
+        patch(
+            "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+            return_value=fake_priors,
+        ),
+        patch("plugins.seed_generation.cli.pick_bindings", return_value=_good_picker()),
+        patch("plugins.seed_generation.cli.run_pre_flight", return_value=PreFlightReport()),
+        patch("plugins.seed_generation.cli._dispatch_pipeline", side_effect=_capture_dispatch),
+    ):
+        code = run_audit_seeds(
+            target_dim="broken_tool_use",
+            yes=True,
+            stdout=out,
+            stderr=err,
+        )
+    assert code == 0
+    assert dispatched["meta_review_snapshot"] is fake_priors

--- a/tests/plugins/seed_generation/test_critic.py
+++ b/tests/plugins/seed_generation/test_critic.py
@@ -314,3 +314,39 @@ def test_critic_no_evidence_block_without_snapshot() -> None:
     manager = _StubManager()
     Critic(manager=manager).execute(state)  # type: ignore[arg-type]
     assert "Recent audit baseline" not in manager.received_tasks[0].description
+
+
+# ---------------------------------------------------------------------------
+# G4 — meta_review priors injection (2026-05-20 self-improving-loop wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_critic_injects_priors_block_when_snapshot_present() -> None:
+    from plugins.seed_generation.baseline_reader import MetaReviewSnapshot
+
+    state = _make_state(n=1)
+    _seed_candidates(state, 1)
+    state.meta_review_snapshot = MetaReviewSnapshot(
+        next_gen_priors=[
+            {
+                "target_dim": "broken_tool_use",
+                "weight": 0.5,
+                "rationale": "underrepresented in prior generation",
+            }
+        ],
+        underrepresented_dims=["broken_tool_use"],
+    )
+    manager = _StubManager()
+    Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    task = manager.received_tasks[0]
+    assert "Previous-generation meta-review" in task.description
+    assert "underrepresented in prior generation" in task.description
+
+
+def test_critic_priors_block_skipped_without_snapshot() -> None:
+    state = _make_state(n=1)
+    _seed_candidates(state, 1)
+    state.meta_review_snapshot = None
+    manager = _StubManager()
+    Critic(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert "Previous-generation meta-review" not in manager.received_tasks[0].description

--- a/tests/plugins/seed_generation/test_generator.py
+++ b/tests/plugins/seed_generation/test_generator.py
@@ -234,3 +234,43 @@ def test_generator_skips_evidence_when_dim_missing(tmp_path: Path) -> None:
     manager = _StubManager()
     Generator(manager=manager).execute(state)  # type: ignore[arg-type]
     assert "Recent audit baseline" not in manager.received_tasks[0].description
+
+
+# ---------------------------------------------------------------------------
+# G4 — meta_review priors injection (2026-05-20 self-improving-loop wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_generator_injects_priors_block_when_snapshot_present(tmp_path: Path) -> None:
+    """meta_review_snapshot → priors block prepended ABOVE baseline evidence."""
+    from plugins.seed_generation.baseline_reader import MetaReviewSnapshot
+
+    run_dir = tmp_path
+    state = _make_state(run_dir, n=1)
+    state.meta_review_snapshot = MetaReviewSnapshot(
+        next_gen_priors=[
+            {
+                "target_dim": "broken_tool_use",
+                "weight": 0.7,
+                "rationale": "previous run missed tool error mode",
+            }
+        ],
+        underrepresented_dims=["broken_tool_use"],
+    )
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    task = manager.received_tasks[0]
+    assert "Previous-generation meta-review" in task.description
+    assert "broken_tool_use" in task.description
+    assert "missed tool error mode" in task.description
+    # Original generator instructions still after the block.
+    assert "Generate ONE Petri audit seed" in task.description
+
+
+def test_generator_priors_block_skipped_without_snapshot(tmp_path: Path) -> None:
+    run_dir = tmp_path
+    state = _make_state(run_dir, n=1)
+    state.meta_review_snapshot = None
+    manager = _StubManager()
+    Generator(manager=manager).execute(state)  # type: ignore[arg-type]
+    assert "Previous-generation meta-review" not in manager.received_tasks[0].description

--- a/tests/plugins/seed_generation/test_state_offload.py
+++ b/tests/plugins/seed_generation/test_state_offload.py
@@ -356,3 +356,78 @@ def test_pipeline_session_index_swallows_oserror(
     pipeline.run()  # Must NOT raise.
     # State persistence (other paths) still works.
     assert (tmp_path / "state.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# G4 — meta_review persist + latest_meta_review.json symlink (2026-05-20)
+# ---------------------------------------------------------------------------
+
+
+def test_persist_meta_review_writes_standalone_json(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Pipeline.run() emits ``<run_dir>/meta_review.json`` when state.meta_review is set."""
+    run_dir = tmp_path
+    fake_home = run_dir / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+    state = _populated_state(run_dir)
+    Pipeline(state=state, registry=_registry_with_noop_agents()).run()
+    meta_review_path = run_dir / "meta_review.json"
+    assert meta_review_path.is_file()
+    blob = json.loads(meta_review_path.read_text(encoding="utf-8"))
+    assert blob == state.meta_review
+
+
+def test_persist_meta_review_skipped_when_empty(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """No meta_review → no standalone file (bootstrap / failed meta phase)."""
+    run_dir = tmp_path
+    fake_home = run_dir / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+    state = _populated_state(run_dir)
+    state.meta_review = {}
+    Pipeline(state=state, registry=_registry_with_noop_agents()).run()
+    assert not (run_dir / "meta_review.json").exists()
+
+
+def test_persist_meta_review_updates_latest_symlink(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """latest_meta_review.json symlink points at this run's meta_review.json."""
+    run_dir = tmp_path
+    fake_home = run_dir / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+    state = _populated_state(run_dir)
+    Pipeline(state=state, registry=_registry_with_noop_agents()).run()
+    latest = fake_home / ".geode" / "self-improving-loop" / "latest_meta_review.json"
+    assert latest.is_symlink()
+    assert latest.resolve() == (run_dir / "meta_review.json").resolve()
+
+
+def test_persist_meta_review_symlink_moves_forward(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """A second run replaces the latest_meta_review symlink target."""
+    run_root = tmp_path
+    fake_home = run_root / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    run_a = run_root / "runA"
+    run_a.mkdir()
+    state_a = _populated_state(run_a)
+    Pipeline(state=state_a, registry=_registry_with_noop_agents()).run()
+
+    run_b = run_root / "runB"
+    run_b.mkdir()
+    state_b = _populated_state(run_b)
+    state_b.meta_review = {"coverage": {"d2": 1}, "next_gen_priors": []}
+    Pipeline(state=state_b, registry=_registry_with_noop_agents()).run()
+
+    latest = fake_home / ".geode" / "self-improving-loop" / "latest_meta_review.json"
+    assert latest.is_symlink()
+    assert latest.resolve() == (run_b / "meta_review.json").resolve()


### PR DESCRIPTION
## Summary
- `Pipeline._persist_meta_review` — `<run_dir>/meta_review.json` + `~/.geode/self-improving-loop/latest_meta_review.json` symlink
- `baseline_reader` 에 `MetaReviewSnapshot` + `load_latest_meta_review()` + `format_priors_block()` 추가
- `PipelineState.meta_review_snapshot` + CLI `_load_priors_snapshot` + generator/critic prompt 에 priors block prepend
- 18 신규 tests, quality gates green

## Why
직전 GAP audit 의 **G4 누수**: `MetaReviewer` agent 가 `next_gen_priors` 를 *출력* 까지는 했지만 (`state.meta_review`) 어디로 persist 도 안 되고 다음 run 도 못 읽음 → 메타 리뷰 결과 휘발.

G4 wire 후 흐름:
1. Pipeline.run() 종료 시 `_persist_meta_review` 가 `<run_dir>/meta_review.json` 작성 + latest symlink 갱신
2. 다음 `geode audit-seeds generate` 시작 시 `_load_priors_snapshot()` 가 symlink 로부터 MetaReviewSnapshot 로드
3. PipelineState.meta_review_snapshot 전달
4. generator/critic sub-task description 에 priors block prepend (baseline evidence 위)
5. Sub-agent 가 "어느 dim 이 underrepresented 였는지" + "ranked priors 의 rationale" 을 보고 candidate 생성/비평

Evolver 는 의도적 skip — in-run pilot dim_means 가 cross-run priors 보다 evolve 단계에서 더 강한 신호.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/orchestrator.py` | `_persist_meta_review` 메서드 + Pipeline.run() 끝에 호출. `PipelineState.meta_review_snapshot` 필드 |
| `plugins/seed_generation/baseline_reader.py` | `MetaReviewSnapshot` 데이터클래스 + `load_latest_meta_review()` (graceful no-op) + `format_priors_block(target_dim=...)` (target dim priors 앞으로) |
| `plugins/seed_generation/cli.py` | `_load_priors_snapshot(err=)` helper. `_dispatch_pipeline` 매개변수 + PipelineState 전달 |
| `plugins/seed_generation/agents/generator.py` | `_format_priors(state)` helper + `_build_description` 가 priors+evidence 두 블록 prepend |
| `plugins/seed_generation/agents/critic.py` | `_build_description(meta_review_snapshot=)` 매개변수 + priors → evidence → instructions 순서로 prepend |
| `tests/plugins/seed_generation/test_baseline_reader.py` | 8 신규 케이스 — load 5 + format 3 |
| `tests/plugins/seed_generation/test_state_offload.py` | 4 신규 케이스 — persist + skip empty + symlink + forward-move |
| `tests/plugins/seed_generation/test_generator.py` | 2 신규 케이스 — priors inject + no snapshot |
| `tests/plugins/seed_generation/test_critic.py` | 2 신규 케이스 — 동일 |
| `tests/plugins/seed_generation/test_cli.py` | 3 신규 케이스 — bootstrap silent + summary log + dispatch propagation |
| `CHANGELOG.md` | `[Unreleased] Added` 에 PR-G4 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| meta_review.json persist | Implemented | `_persist_meta_review` |
| latest_meta_review symlink | Implemented | G1 의 latest_seed_pool 와 동일 패턴 |
| MetaReviewSnapshot reader | Implemented | priors / underrep / overrep / summary |
| Cross-run priors injection | Implemented | generator + critic (evolver 의도 skip) |
| Bootstrap compat | Implemented | snapshot=None → 기존 prompt 유지 |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean (357 source files)
- [x] pytest 411 pass + 1 skipped
- [x] E2E unchanged (live audit BLOCKED until G5)

## Reference
- 2026-05-20 GAP audit (G4 leak: next_gen_priors 출력만 됨, persist + reader 0)
- PR-G3 (#1347) — `baseline_reader` reader pattern (이 PR 가 동일 패턴으로 priors 측 확장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)