### PR TITLE
feat(self-improving-loop): PR-G5b — program.md-driven LLM mutation runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,32 @@ functional change.
 
 ### Added
 
+- **PR-G5b — program.md-driven self-improving loop runner.** Final PR
+  of the 2026-05-20 self-improving-loop wiring sprint (G1-G5). New
+  `core/self_improving_loop/` package composes the G1-G5a upstream:
+  `build_runner_context()` gathers baseline (G3) + meta-review priors
+  (G4) + current wrapper sections (G5a). `SelfImprovingLoopRunner.run_once()`
+  packs the context into a system + user prompt, dispatches to an
+  injected `llm_call` (default: `claude-opus-4-7` via anthropic SDK),
+  parses the response as a typed `Mutation` (schema-validated:
+  non-empty target/value, ≤600 char value, JSON-only response with
+  optional code-fence tolerance), applies it to the SoT via
+  `write_wrapper_prompt_sections`, appends a row to the git-tracked
+  `autoresearch/state/mutations.jsonl` audit log, commits the row
+  (best-effort — non-fatal on git failure), and optionally re-runs
+  `autoresearch/train.py` (default off to keep loops cheap). The
+  audit log is the git-as-optimiser ledger — each row is one
+  committed mutation event with target_section / previous_value /
+  new_value / rationale / target_dim / baseline_fitness so the
+  lineage of wrapper-prompt evolution is replayable from `git log`.
+  Side-effect: appends a `component: self-improving-loop-mutator` row
+  to the shared `~/.geode/self-improving-loop/sessions.jsonl`
+  registry. 21 new tests (9 parse_mutation + 2 apply_mutation + 3
+  append_audit_log + 2 build_runner_context + 3 run_once end-to-end +
+  2 dataclass) — quality gates: ruff / format / mypy / 442 tests
+  green. Real autoresearch re-run still BLOCKED on Anthropic credit;
+  scaffold is ready for the next budget window.
+
 - **PR-G5a — wrapper sections file-backed SoT + env-less daily-run
   fallback.** First half of the 2026-05-20 self-improving-loop wiring
   sprint's final PR (G5). Splits the static

--- a/core/self_improving_loop/__init__.py
+++ b/core/self_improving_loop/__init__.py
@@ -1,0 +1,46 @@
+"""Self-improving loop runner — program.md-driven wrapper-prompt mutation.
+
+PR-G5b (2026-05-20) — closes the final gap in the 2026-05-20
+self-improving-loop wiring sprint. Composes the upstream PRs:
+
+* PR-G1: ``latest_seed_pool`` symlink → autoresearch picks freshest pool.
+* PR-G2: Petri evidence in ``baseline.json`` → top-K per dim.
+* PR-G3: seed-gen reads ``baseline.json`` evidence + auto target dim.
+* PR-G4: ``next_gen_priors`` persist + next-run reader.
+* PR-G5a: wrapper sections file SoT + env-less daily-run fallback.
+
+PR-G5b ties the loop closed: the runner reads the most-recent audit's
+baseline + evidence + meta-review priors, asks an LLM to propose a
+single-section ``WRAPPER_PROMPT_SECTIONS`` mutation, applies it to the
+SoT, appends the mutation to a git-tracked audit log, and (optionally)
+re-runs autoresearch so the next baseline reflects the change.
+
+Public API:
+
+* :class:`SelfImprovingLoopRunner` — top-level orchestrator.
+* :func:`build_runner_context` — gather baseline + evidence + priors.
+* :func:`apply_mutation` — write the SoT after schema validation.
+
+The LLM call is injected as a callable so tests can supply a mock
+without touching real provider quota. The default callable hits
+``claude-opus-4-7`` via the anthropic SDK; see
+:func:`_default_llm_call` for the binding.
+"""
+
+from __future__ import annotations
+
+from core.self_improving_loop.runner import (
+    Mutation,
+    RunnerContext,
+    SelfImprovingLoopRunner,
+    apply_mutation,
+    build_runner_context,
+)
+
+__all__ = [
+    "Mutation",
+    "RunnerContext",
+    "SelfImprovingLoopRunner",
+    "apply_mutation",
+    "build_runner_context",
+]

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -1,0 +1,538 @@
+"""Program.md-driven self-improving loop runner.
+
+PR-G5b (2026-05-20). The runner is intentionally thin — every
+component it composes already has its own PR + tests:
+
+* ``baseline_reader.load_baseline()`` (G3) — typed BaselineSnapshot.
+* ``baseline_reader.load_latest_meta_review()`` (G4) — MetaReviewSnapshot.
+* ``autoresearch.train.load_wrapper_prompt_sections()`` (G5a) — SoT load.
+* ``autoresearch.train.write_wrapper_prompt_sections()`` (G5a) — SoT write.
+
+What the runner adds:
+
+1. **Context bundling** — fetch the three snapshots into a single
+   :class:`RunnerContext` dataclass.
+2. **Prompt rendering** — pack the context into the program.md system
+   prompt + a structured user message asking for ONE mutation.
+3. **LLM dispatch** — call the injected ``llm_call`` callable; the
+   default binding hits ``claude-opus-4-7`` via the anthropic SDK.
+4. **Response parsing** — extract a :class:`Mutation` from the LLM's
+   JSON, validate against the SoT schema.
+5. **Apply + audit log** — call ``write_wrapper_prompt_sections`` and
+   append the mutation to the git-tracked audit jsonl
+   (``autoresearch/state/mutations.jsonl``).
+6. **Optional re-run** — when ``rerun=True`` (default ``False`` to
+   keep dry-runs cheap), spawn ``autoresearch/train.py`` so the next
+   baseline reflects the new wrapper.
+
+Test strategy:
+
+* Unit tests inject a mock ``llm_call`` returning a canned JSON dict.
+* No test touches real ``~/.geode/`` — all paths are monkeypatched.
+* The autoresearch re-run is wrapped in ``_run_autoresearch_subprocess``
+  so tests can monkeypatch the subprocess entirely.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "MUTATION_AUDIT_LOG_PATH",
+    "Mutation",
+    "RunnerContext",
+    "SelfImprovingLoopRunner",
+    "apply_mutation",
+    "build_runner_context",
+    "parse_mutation",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Mutation:
+    """One LLM-proposed wrapper-section edit.
+
+    Schema mirrors the LLM response contract (see :func:`_build_user_prompt`).
+    ``target_section`` may be new (insert) or existing (rewrite); the
+    runner enforces non-empty strings at apply time.
+    """
+
+    target_section: str
+    new_value: str
+    rationale: str
+    target_dim: str = ""
+    """The regression dim the mutation is aimed at — informational, may
+    be empty when the LLM declines to commit to one."""
+
+    def to_audit_row(
+        self,
+        *,
+        previous_value: str,
+        timestamp: float | None = None,
+        baseline_fitness: float | None = None,
+    ) -> dict[str, Any]:
+        """Render the mutation as one audit-log row."""
+        return {
+            "ts": timestamp if timestamp is not None else time.time(),
+            "target_section": self.target_section,
+            "previous_value": previous_value,
+            "new_value": self.new_value,
+            "rationale": self.rationale,
+            "target_dim": self.target_dim,
+            "baseline_fitness": baseline_fitness,
+        }
+
+
+@dataclass
+class RunnerContext:
+    """Inputs gathered from G2-G4 readers + autoresearch state.
+
+    Held as a plain dataclass (not frozen) so the runner can carry
+    additional debug fields without breaking the call site contract.
+    """
+
+    baseline_snapshot: Any = None
+    meta_review_snapshot: Any = None
+    current_sections: dict[str, str] = field(default_factory=dict)
+    target_dim: str = ""
+    """The dim the runner will focus the mutation on. Picked from
+    baseline via ``pick_regression_target_dim`` when present."""
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+MUTATION_AUDIT_LOG_PATH = (
+    Path(__file__).resolve().parents[2] / "autoresearch" / "state" / "mutations.jsonl"
+)
+"""Git-tracked audit log of every applied mutation.
+
+Lives in-repo (not in ``~/.geode``) because the audit log IS the
+git-as-optimiser ledger — each row is committed so the lineage of
+wrapper-prompt evolution is replayable from ``git log``. The SoT file
+(``~/.geode/self-improving-loop/wrapper-sections.json``) only ever
+holds the *current* state; this log holds the *history*.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Context gathering
+# ---------------------------------------------------------------------------
+
+
+def build_runner_context() -> RunnerContext:
+    """Gather baseline + meta-review + current wrapper sections.
+
+    All three lookups are best-effort — a missing baseline or
+    meta-review just means the runner has less context to work with;
+    the LLM call can still propose a mutation based on the current
+    wrapper sections alone. The auto target_dim picker fires only
+    when the baseline is present.
+    """
+    from autoresearch.train import load_wrapper_prompt_sections
+    from plugins.seed_generation.baseline_reader import (
+        load_baseline,
+        load_latest_meta_review,
+        pick_regression_target_dim,
+    )
+
+    baseline_snapshot = load_baseline()
+    meta_review_snapshot = load_latest_meta_review()
+    current_sections = load_wrapper_prompt_sections()
+    target_dim = ""
+    if baseline_snapshot is not None:
+        target_dim = pick_regression_target_dim(baseline_snapshot) or ""
+    return RunnerContext(
+        baseline_snapshot=baseline_snapshot,
+        meta_review_snapshot=meta_review_snapshot,
+        current_sections=current_sections,
+        target_dim=target_dim,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT = (
+    "You are the self-improving-loop mutator for GEODE, an autonomous "
+    "execution agent. Your job: read the audit baseline, meta-review "
+    "priors, and the current WRAPPER_PROMPT_SECTIONS dict, then propose "
+    "ONE single-section mutation that should drive the next audit's "
+    "fitness up.\n"
+    "\n"
+    "Constraints:\n"
+    "- Change exactly ONE section. Adding a new section counts; "
+    "deleting does not.\n"
+    "- New value must be a non-empty single-paragraph string under 600 "
+    "characters.\n"
+    "- Rationale must cite the specific regression evidence or prior "
+    "the mutation responds to.\n"
+    "- Respond with a single JSON object — NO prose, NO code fences.\n"
+    "\n"
+    "Response schema:\n"
+    "{\n"
+    '  "target_section": "<section key>",\n'
+    '  "new_value": "<replacement text>",\n'
+    '  "rationale": "<= 200 chars, citing the evidence>",\n'
+    '  "target_dim": "<dim name the mutation aims at, or empty>"\n'
+    "}\n"
+)
+
+
+def _build_user_prompt(ctx: RunnerContext) -> str:
+    """Render the per-iteration context as the LLM's user message."""
+    from plugins.seed_generation.baseline_reader import (
+        format_evidence_block,
+        format_priors_block,
+    )
+
+    blocks: list[str] = []
+    if ctx.baseline_snapshot is not None and ctx.target_dim:
+        evidence = format_evidence_block(ctx.baseline_snapshot, ctx.target_dim)
+        if evidence:
+            blocks.append(evidence)
+    if ctx.meta_review_snapshot is not None:
+        priors = format_priors_block(ctx.meta_review_snapshot, target_dim=ctx.target_dim)
+        if priors:
+            blocks.append(priors)
+    sections_block = "Current WRAPPER_PROMPT_SECTIONS:\n" + json.dumps(
+        ctx.current_sections, indent=2, ensure_ascii=False
+    )
+    blocks.append(sections_block)
+    if ctx.target_dim:
+        blocks.append(f"Focus your mutation on improving dim: {ctx.target_dim!r}.")
+    blocks.append("Return the JSON mutation object now.")
+    return "\n\n".join(blocks)
+
+
+# ---------------------------------------------------------------------------
+# LLM call default + response parsing
+# ---------------------------------------------------------------------------
+
+
+LLMCallable = Callable[[str, str], str]
+"""Signature: ``llm_call(system_prompt, user_prompt) -> raw response``."""
+
+
+def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
+    """Anthropic SDK call to ``claude-opus-4-7``.
+
+    Imported lazily so the runner module stays importable without the
+    anthropic SDK in test environments. Tests inject a mock callable
+    via ``SelfImprovingLoopRunner(llm_call=...)``.
+    """
+    try:
+        import anthropic
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "self-improving-loop runner requires the anthropic SDK "
+            "(install with `uv sync` or pass a mock llm_call)"
+        ) from exc
+
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model="claude-opus-4-7",
+        max_tokens=1024,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    # Concatenate text blocks defensively — the SDK can return a list
+    # of content blocks even for a single text response.
+    text_chunks: list[str] = []
+    for block in response.content:
+        text = getattr(block, "text", "")
+        if text:
+            text_chunks.append(text)
+    return "".join(text_chunks)
+
+
+def parse_mutation(raw: str) -> Mutation:
+    """Extract a :class:`Mutation` from the LLM's raw response.
+
+    The model is instructed to emit a bare JSON object, but defensive
+    parsing tolerates leading/trailing whitespace and (rarely) a
+    surrounding triple-backtick code fence — strip those before json.loads.
+
+    Raises :class:`ValueError` on missing fields or wrong types so the
+    runner can catch + log + skip a malformed iteration without
+    crashing the whole loop.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("empty LLM response")
+    text = raw.strip()
+    if text.startswith("```"):
+        # Strip fence: ```json ... ```
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"LLM response is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"LLM response must be a JSON object, got {type(payload).__name__}")
+    target_section = payload.get("target_section")
+    new_value = payload.get("new_value")
+    rationale = payload.get("rationale", "")
+    target_dim = payload.get("target_dim", "")
+    if not isinstance(target_section, str) or not target_section.strip():
+        raise ValueError("target_section must be a non-empty string")
+    if not isinstance(new_value, str) or not new_value.strip():
+        raise ValueError("new_value must be a non-empty string")
+    if not isinstance(rationale, str):
+        raise ValueError("rationale must be a string")
+    if not isinstance(target_dim, str):
+        raise ValueError("target_dim must be a string")
+    if len(new_value) > 600:
+        raise ValueError(f"new_value length {len(new_value)} exceeds 600 char cap")
+    return Mutation(
+        target_section=target_section.strip(),
+        new_value=new_value,
+        rationale=rationale.strip(),
+        target_dim=target_dim.strip(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Apply + audit log
+# ---------------------------------------------------------------------------
+
+
+def apply_mutation(
+    mutation: Mutation,
+    *,
+    current_sections: dict[str, str] | None = None,
+) -> tuple[dict[str, str], str]:
+    """Apply a single-section mutation to the SoT.
+
+    Returns ``(new_sections, previous_value)``. ``previous_value`` is
+    the string the mutation replaced (empty for insertions) — captured
+    so the audit log can record the diff.
+
+    The SoT write is strict: schema failures raise
+    :class:`ValueError` via ``write_wrapper_prompt_sections``.
+    """
+    from autoresearch.train import load_wrapper_prompt_sections, write_wrapper_prompt_sections
+
+    sections = (
+        dict(current_sections) if current_sections is not None else load_wrapper_prompt_sections()
+    )
+    previous_value = sections.get(mutation.target_section, "")
+    sections[mutation.target_section] = mutation.new_value
+    write_wrapper_prompt_sections(sections)
+    return sections, previous_value
+
+
+def append_audit_log(
+    mutation: Mutation,
+    *,
+    previous_value: str,
+    baseline_fitness: float | None = None,
+    log_path: Path | None = None,
+) -> Path:
+    """Append one mutation row to the git-tracked audit jsonl.
+
+    Returns the path of the audit log so the caller can ``git add``
+    it. Best-effort — directory is created if missing.
+    """
+    target = log_path if log_path is not None else MUTATION_AUDIT_LOG_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    row = mutation.to_audit_row(previous_value=previous_value, baseline_fitness=baseline_fitness)
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Git commit + autoresearch re-run
+# ---------------------------------------------------------------------------
+
+
+def _git_commit_audit_log(
+    log_path: Path,
+    *,
+    mutation: Mutation,
+    runner: subprocess.CompletedProcess[str] | None = None,
+) -> bool:
+    """Stage + commit the audit log row.
+
+    Returns ``True`` on success, ``False`` when git is unavailable or
+    the commit fails. The runner treats commit failure as
+    non-blocking: the SoT is already updated in-place, so the loop's
+    correctness boundary is the file write, not the git commit.
+
+    ``runner`` is exposed so tests can inject a mock that records the
+    argv without running real git.
+    """
+    try:
+        repo_root = log_path.resolve().parents[1]
+        subprocess.run(  # noqa: S603  # nosec B603 — argv = audit-log path
+            ["git", "add", str(log_path)],  # noqa: S607  # nosec B607 — git in PATH
+            cwd=str(repo_root),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        commit_message = (
+            f"self-improving-loop: mutate '{mutation.target_section}'\n\n"
+            f"target_dim: {mutation.target_dim or '(unspecified)'}\n"
+            f"rationale: {mutation.rationale}\n"
+        )
+        subprocess.run(  # noqa: S603  # nosec B603 — commit_message from validated Mutation
+            ["git", "commit", "-m", commit_message],  # noqa: S607  # nosec B607 — git in PATH
+            cwd=str(repo_root),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        log.warning("self-improving-loop git commit failed: %s", exc)
+        return False
+    return True
+
+
+def _run_autoresearch_subprocess(
+    *,
+    repo_root: Path,
+    dry_run: bool,
+) -> subprocess.CompletedProcess[str]:
+    """Spawn ``autoresearch/train.py`` for the post-mutation audit.
+
+    Default ``dry_run=True`` keeps the loop cheap during development;
+    operators flip to ``dry_run=False`` for a real budget-spending
+    audit. The subprocess is non-fatal — failures log + return so the
+    runner can record the mutation row even when the audit aborts.
+    """
+    argv = ["uv", "run", "python", "autoresearch/train.py"]
+    if dry_run:
+        argv.append("--dry-run")
+    return subprocess.run(  # noqa: S603  # nosec B603 — argv built from constants
+        argv,
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SelfImprovingLoopRunner:
+    """Top-level runner — composes context + LLM + apply + audit + re-run.
+
+    Construction parameters:
+
+    * ``llm_call`` — injected callable. Defaults to
+      :func:`_default_llm_call` (anthropic SDK); tests pass a mock.
+    * ``audit_log_path`` — override for the audit jsonl location
+      (tests).
+    * ``commit_enabled`` — when ``False``, skip the git step
+      (useful for dry-runs / detached HEAD).
+    * ``rerun_enabled`` — when ``False`` (default), skip the
+      autoresearch re-run. The next ``geode audit`` invocation picks
+      up the new SoT automatically; the re-run flag is opt-in so
+      operators control quota spend.
+    * ``rerun_dry_run`` — when re-run is enabled, default to
+      ``--dry-run`` to keep the loop cheap.
+    """
+
+    llm_call: LLMCallable = field(default=_default_llm_call)
+    audit_log_path: Path | None = None
+    commit_enabled: bool = True
+    rerun_enabled: bool = False
+    rerun_dry_run: bool = True
+
+    def run_once(self) -> Mutation:
+        """Execute one mutation iteration and return the applied :class:`Mutation`.
+
+        The function is the single-iteration unit; callers wrap it in
+        a loop (or schedule it via ``geode schedule``) when they want
+        a multi-round campaign. Each call:
+
+        1. Builds context (baseline + meta-review + current sections).
+        2. Calls the LLM with the system + user prompt.
+        3. Parses + validates the mutation.
+        4. Applies it to the SoT.
+        5. Appends + (optionally) commits the audit log row.
+        6. (Optionally) re-runs autoresearch.
+
+        Raises :class:`ValueError` on parse / validation failure so
+        the caller can decide whether to retry.
+        """
+        ctx = build_runner_context()
+        user_prompt = _build_user_prompt(ctx)
+        raw_response = self.llm_call(_SYSTEM_PROMPT, user_prompt)
+        mutation = parse_mutation(raw_response)
+        _new_sections, previous_value = apply_mutation(
+            mutation, current_sections=ctx.current_sections
+        )
+        log_path = append_audit_log(
+            mutation,
+            previous_value=previous_value,
+            log_path=self.audit_log_path,
+        )
+        if self.commit_enabled:
+            _git_commit_audit_log(log_path, mutation=mutation)
+        if self.rerun_enabled:
+            repo_root = log_path.resolve().parents[1]
+            self._invoke_autoresearch(repo_root)
+        self._append_self_improving_loop_index(mutation, previous_value)
+        return mutation
+
+    def _invoke_autoresearch(self, repo_root: Path) -> None:
+        """Wrap the autoresearch subprocess so tests can override."""
+        try:
+            _run_autoresearch_subprocess(repo_root=repo_root, dry_run=self.rerun_dry_run)
+        except Exception:  # pragma: no cover — defensive
+            log.warning("self-improving-loop autoresearch re-run failed", exc_info=True)
+
+    @staticmethod
+    def _append_self_improving_loop_index(mutation: Mutation, previous_value: str) -> None:
+        """Best-effort append to the shared session index.
+
+        Lets the existing ``~/.geode/self-improving-loop/sessions.jsonl``
+        registry (P1a) carry one row per mutator invocation so external
+        consumers can see the mutator alongside seed-generation /
+        autoresearch runs.
+        """
+        index_path = GLOBAL_SELF_IMPROVING_LOOP_DIR / "sessions.jsonl"
+        try:
+            GLOBAL_SELF_IMPROVING_LOOP_DIR.mkdir(parents=True, exist_ok=True)
+            row = {
+                "ts": time.time(),
+                "component": "self-improving-loop-mutator",
+                "target_section": mutation.target_section,
+                "target_dim": mutation.target_dim,
+                "rationale": mutation.rationale,
+                "previous_value_len": len(previous_value),
+                "new_value_len": len(mutation.new_value),
+            }
+            with index_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+        except OSError:
+            log.debug("self-improving-loop sessions.jsonl append failed", exc_info=True)

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -1,0 +1,419 @@
+"""Tests for ``core.self_improving_loop.runner`` — PR-G5b (2026-05-20)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.self_improving_loop.runner import (
+    Mutation,
+    RunnerContext,
+    SelfImprovingLoopRunner,
+    append_audit_log,
+    apply_mutation,
+    build_runner_context,
+    parse_mutation,
+)
+
+# ---------------------------------------------------------------------------
+# parse_mutation
+# ---------------------------------------------------------------------------
+
+
+class TestParseMutation:
+    def test_parses_bare_json(self) -> None:
+        raw = json.dumps(
+            {
+                "target_section": "tool_handling",
+                "new_value": "Be careful with tool calls.",
+                "rationale": "broken_tool_use regressed (value=7)",
+                "target_dim": "broken_tool_use",
+            }
+        )
+        mutation = parse_mutation(raw)
+        assert mutation.target_section == "tool_handling"
+        assert "Be careful" in mutation.new_value
+        assert mutation.target_dim == "broken_tool_use"
+
+    def test_strips_code_fence(self) -> None:
+        raw = (
+            "```json\n"
+            + json.dumps({"target_section": "x", "new_value": "y", "rationale": "z"})
+            + "\n```"
+        )
+        mutation = parse_mutation(raw)
+        assert mutation.target_section == "x"
+
+    def test_empty_response_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            parse_mutation("")
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            parse_mutation("{ not json")
+
+    def test_non_object_raises(self) -> None:
+        with pytest.raises(ValueError, match="JSON object"):
+            parse_mutation(json.dumps(["not", "a", "dict"]))
+
+    def test_missing_target_section_raises(self) -> None:
+        with pytest.raises(ValueError, match="target_section"):
+            parse_mutation(json.dumps({"new_value": "x", "rationale": "y"}))
+
+    def test_empty_target_section_raises(self) -> None:
+        with pytest.raises(ValueError, match="target_section"):
+            parse_mutation(
+                json.dumps({"target_section": "   ", "new_value": "x", "rationale": "y"})
+            )
+
+    def test_missing_new_value_raises(self) -> None:
+        with pytest.raises(ValueError, match="new_value"):
+            parse_mutation(json.dumps({"target_section": "x", "rationale": "y"}))
+
+    def test_new_value_too_long_raises(self) -> None:
+        with pytest.raises(ValueError, match="600 char cap"):
+            parse_mutation(
+                json.dumps({"target_section": "x", "new_value": "a" * 700, "rationale": "y"})
+            )
+
+
+# ---------------------------------------------------------------------------
+# apply_mutation
+# ---------------------------------------------------------------------------
+
+
+def test_apply_mutation_rewrites_existing_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoresearch import train as auto_train
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    current = {"role": "old role", "tools": "old tools"}
+    mutation = Mutation(
+        target_section="role",
+        new_value="new role text",
+        rationale="r",
+    )
+    new_sections, previous_value = apply_mutation(mutation, current_sections=current)
+    assert previous_value == "old role"
+    assert new_sections["role"] == "new role text"
+    # SoT file persists the change.
+    persisted = json.loads(sot_path.read_text(encoding="utf-8"))
+    assert persisted["role"] == "new role text"
+
+
+def test_apply_mutation_inserts_new_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoresearch import train as auto_train
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    mutation = Mutation(
+        target_section="brand_new",
+        new_value="freshly inserted",
+        rationale="r",
+    )
+    new_sections, previous_value = apply_mutation(mutation, current_sections={"role": "r"})
+    assert previous_value == ""
+    assert new_sections["brand_new"] == "freshly inserted"
+    persisted = json.loads(sot_path.read_text(encoding="utf-8"))
+    assert persisted["brand_new"] == "freshly inserted"
+    assert persisted["role"] == "r"  # untouched
+
+
+# ---------------------------------------------------------------------------
+# append_audit_log
+# ---------------------------------------------------------------------------
+
+
+def test_append_audit_log_writes_jsonl_row(tmp_path: Path) -> None:
+    log_path = tmp_path / "mutations.jsonl"
+    mutation = Mutation(
+        target_section="x",
+        new_value="y",
+        rationale="r",
+        target_dim="broken_tool_use",
+    )
+    written = append_audit_log(
+        mutation, previous_value="old y", log_path=log_path, baseline_fitness=0.85
+    )
+    assert written == log_path
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["target_section"] == "x"
+    assert row["previous_value"] == "old y"
+    assert row["new_value"] == "y"
+    assert row["baseline_fitness"] == 0.85
+    assert "ts" in row
+
+
+def test_append_audit_log_appends_to_existing(tmp_path: Path) -> None:
+    log_path = tmp_path / "mutations.jsonl"
+    for i in range(3):
+        append_audit_log(
+            Mutation(target_section=f"s{i}", new_value="v", rationale="r"),
+            previous_value="",
+            log_path=log_path,
+        )
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    sections = [json.loads(line)["target_section"] for line in lines]
+    assert sections == ["s0", "s1", "s2"]
+
+
+def test_append_audit_log_creates_parent_dir(tmp_path: Path) -> None:
+    nested = tmp_path / "deep" / "subdir" / "mutations.jsonl"
+    append_audit_log(
+        Mutation(target_section="x", new_value="y", rationale="r"),
+        previous_value="",
+        log_path=nested,
+    )
+    assert nested.is_file()
+
+
+# ---------------------------------------------------------------------------
+# build_runner_context
+# ---------------------------------------------------------------------------
+
+
+def test_build_runner_context_with_baseline_and_priors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All 3 lookups feed the RunnerContext + target_dim auto-picked."""
+    from autoresearch import train as auto_train
+    from plugins.seed_generation.baseline_reader import BaselineSnapshot, MetaReviewSnapshot
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    sot_path.write_text(json.dumps({"role": "r"}), encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+
+    fake_baseline = BaselineSnapshot(dim_means={"broken_tool_use": 8.0})
+    fake_priors = MetaReviewSnapshot(underrepresented_dims=["broken_tool_use"])
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: fake_baseline,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: fake_priors,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.pick_regression_target_dim",
+        lambda _snap, **_kw: "broken_tool_use",
+    )
+    ctx = build_runner_context()
+    assert ctx.baseline_snapshot is fake_baseline
+    assert ctx.meta_review_snapshot is fake_priors
+    assert ctx.target_dim == "broken_tool_use"
+    assert ctx.current_sections == {"role": "r"}
+
+
+def test_build_runner_context_bootstrap_no_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No baseline → target_dim empty, snapshots None, fallback sections."""
+    from autoresearch import train as auto_train
+
+    sot_path = tmp_path / "wrapper-sections.json"  # not created
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+    ctx = build_runner_context()
+    assert ctx.baseline_snapshot is None
+    assert ctx.meta_review_snapshot is None
+    assert ctx.target_dim == ""
+    # Falls back to the hardcoded default dict.
+    assert "role" in ctx.current_sections
+
+
+# ---------------------------------------------------------------------------
+# SelfImprovingLoopRunner.run_once — end-to-end with mocks
+# ---------------------------------------------------------------------------
+
+
+def test_runner_run_once_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock LLM + audit-log path + disable commit/rerun → run_once returns Mutation."""
+    from autoresearch import train as auto_train
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    sot_path.write_text(json.dumps({"role": "old", "tools": "old"}), encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _mock_llm(system: str, user: str) -> str:
+        captured["system"] = system
+        captured["user"] = user
+        return json.dumps(
+            {
+                "target_section": "role",
+                "new_value": "new role text from mock LLM",
+                "rationale": "mock test",
+                "target_dim": "broken_tool_use",
+            }
+        )
+
+    audit_log = tmp_path / "mutations.jsonl"
+    runner = SelfImprovingLoopRunner(
+        llm_call=_mock_llm,
+        audit_log_path=audit_log,
+        commit_enabled=False,
+        rerun_enabled=False,
+    )
+    # Prevent the sessions.jsonl side-effect from touching real ~/.geode.
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.GLOBAL_SELF_IMPROVING_LOOP_DIR",
+        tmp_path / "sil_home",
+    )
+    mutation = runner.run_once()
+    assert mutation.target_section == "role"
+    assert "mock LLM" in mutation.new_value
+    # SoT updated.
+    persisted = json.loads(sot_path.read_text(encoding="utf-8"))
+    assert "mock LLM" in persisted["role"]
+    # Audit log appended.
+    log_lines = audit_log.read_text(encoding="utf-8").splitlines()
+    assert len(log_lines) == 1
+    row = json.loads(log_lines[0])
+    assert row["target_section"] == "role"
+    assert row["previous_value"] == "old"
+    # sessions.jsonl side-effect landed in monkeypatched dir.
+    sessions_path = tmp_path / "sil_home" / "sessions.jsonl"
+    assert sessions_path.is_file()
+    # LLM prompt carried the system + sections context.
+    assert "WRAPPER_PROMPT_SECTIONS" in captured["user"]
+    assert "Mutator" in captured["system"] or "mutator" in captured["system"]
+
+
+def test_runner_propagates_llm_validation_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bad LLM response → parse_mutation ValueError bubbles up."""
+    from autoresearch import train as auto_train
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+
+    runner = SelfImprovingLoopRunner(
+        llm_call=lambda _s, _u: "{ not valid json",
+        audit_log_path=tmp_path / "mutations.jsonl",
+        commit_enabled=False,
+        rerun_enabled=False,
+    )
+    with pytest.raises(ValueError, match="not valid JSON"):
+        runner.run_once()
+    # SoT untouched (write only happens after successful parse).
+    assert not sot_path.exists()
+
+
+def test_runner_uses_baseline_evidence_in_user_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When baseline has evidence for target_dim, the user prompt embeds it."""
+    from autoresearch import train as auto_train
+    from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    fake_baseline = BaselineSnapshot(
+        dim_means={"broken_tool_use": 7.0},
+        dim_stderr={"broken_tool_use": 0.3},
+        evidence={
+            "broken_tool_use": [
+                {
+                    "sample_id": "seed-x",
+                    "value": 9.0,
+                    "explanation": "tool result was hallucinated under stress",
+                    "highlights": "- [M9] worst",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: fake_baseline,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+
+    captured: dict[str, str] = {}
+
+    def _capture_llm(_s: str, user: str) -> str:
+        captured["user"] = user
+        return json.dumps({"target_section": "role", "new_value": "v", "rationale": "r"})
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.GLOBAL_SELF_IMPROVING_LOOP_DIR",
+        tmp_path / "sil_home",
+    )
+    SelfImprovingLoopRunner(
+        llm_call=_capture_llm,
+        audit_log_path=tmp_path / "mutations.jsonl",
+        commit_enabled=False,
+        rerun_enabled=False,
+    ).run_once()
+    assert "broken_tool_use" in captured["user"]
+    assert "hallucinated under stress" in captured["user"]
+    assert "Focus your mutation on improving dim" in captured["user"]
+
+
+# ---------------------------------------------------------------------------
+# Mutation.to_audit_row
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_to_audit_row_includes_all_fields() -> None:
+    mutation = Mutation(
+        target_section="s",
+        new_value="n",
+        rationale="r",
+        target_dim="d",
+    )
+    row = mutation.to_audit_row(previous_value="p", timestamp=12345.0, baseline_fitness=0.5)
+    assert row == {
+        "ts": 12345.0,
+        "target_section": "s",
+        "previous_value": "p",
+        "new_value": "n",
+        "rationale": "r",
+        "target_dim": "d",
+        "baseline_fitness": 0.5,
+    }
+
+
+def test_runner_context_defaults() -> None:
+    """Bare RunnerContext is constructible (bootstrap path uses defaults)."""
+    ctx = RunnerContext()
+    assert ctx.baseline_snapshot is None
+    assert ctx.meta_review_snapshot is None
+    assert ctx.current_sections == {}
+    assert ctx.target_dim == ""


### PR DESCRIPTION
## Summary
- 새 `core/self_improving_loop/` 패키지 — G1-G5a 의 reader 들을 composing 하는 mutation runner
- `SelfImprovingLoopRunner.run_once()`: context build → LLM call → parse → apply SoT → audit log → (optional) git commit + autoresearch re-run
- 21 신규 tests (LLM mock 으로 end-to-end)
- 2026-05-20 self-improving-loop sprint G1-G5 의 마지막 PR

## Why
직전 GAP audit 의 **G5 누수**: PR-G5a 가 wrapper-sections.json file SoT + daily-run fallback 을 만들었지만, *누가 SoT 를 mutate 하는가* 는 여전히 사람 — train.py 의 `WRAPPER_PROMPT_SECTIONS` 를 직접 grep + edit. closed loop 완성을 위해서는 LLM-driven mutation runner 가 필요.

PR-G5b 가 만드는 것:
1. autoresearch 가 promote 후 → baseline.json 에 evidence stamp (G2)
2. seed-generation 이 next gen priors persist (G4)
3. **G5b runner**: 둘 다 read + LLM 호출 → wrapper-sections.json 갱신 + audit log commit
4. 다음 daily `geode` 실행 자동 픽업 (G5a fallback)
5. (옵션) 즉시 autoresearch re-run

이로써 **사용자 명시 design decision** ("LLM 제안 + commit 자동 + 다음 run 자동") 가 코드로 구현됨.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/__init__.py` (new) | Public API re-export |
| `core/self_improving_loop/runner.py` (new) | `Mutation` / `RunnerContext` dataclasses, `build_runner_context()`, `_build_user_prompt()`, `parse_mutation()` (schema validation + code-fence tolerance), `apply_mutation()`, `append_audit_log()`, `_git_commit_audit_log()`, `_run_autoresearch_subprocess()`, `SelfImprovingLoopRunner` orchestrator |
| `tests/core/self_improving_loop/__init__.py` (new) | test package marker |
| `tests/core/self_improving_loop/test_runner.py` (new) | 21 케이스 — parse / apply / append / build / run_once / dataclass |
| `CHANGELOG.md` | `[Unreleased] Added` PR-G5b entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| RunnerContext bundling (G3+G4+G5a) | Implemented | `build_runner_context()` |
| LLM call interface | Implemented | injectable `LLMCallable`, default = claude-opus-4-7 |
| Response parsing + validation | Implemented | `parse_mutation()` — 9 케이스 |
| Single-section mutation apply | Implemented | `apply_mutation()` |
| Git-tracked audit log | Implemented | `autoresearch/state/mutations.jsonl` |
| Best-effort git commit | Implemented | `_git_commit_audit_log()`, non-fatal |
| Optional autoresearch re-run | Implemented | default `rerun_enabled=False` |
| Shared sessions.jsonl registry | Implemented | component=`self-improving-loop-mutator` row |
| Real LLM call (live test) | **Blocked** | Anthropic credit per `project_autoresearch_outer_loop.md`. Scaffold ready. |
| CLI entry (`geode self-improving-loop run`) | **Deferred** | follow-up PR (PR scope creep 방지) |

## Verification
- [x] ruff check clean (`autoresearch/ core/ plugins/ tests/`)
- [x] ruff format --check clean
- [x] mypy clean (359 source files)
- [x] pytest 442 pass (`tests/core/self_improving_loop/` + `tests/plugins/seed_generation/` + `tests/test_autoresearch_train.py` + `tests/test_path_literal_guard.py`)
- [x] No real LLM call (모든 test 가 mock 사용)
- [x] No real ~/.geode 누수 (`GLOBAL_SELF_IMPROVING_LOOP_DIR` monkeypatch)

## Reference
- 2026-05-20 GAP audit (G5 leak)
- 사용자 design decision (대화 중): "LLM 제안 + commit 자동 + 다음 run 자동"
- PR-G5a (#1349) — SoT writer 측 (이 PR 가 mutator 측)
- `project_autoresearch_outer_loop.md` (gen 0 baseline BLOCKED on credit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)