### PR TITLE
fix(self-improving-loop): G5b.fix1 — unignore mutations.jsonl audit ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,8 @@ site/tsconfig.tsbuildinfo
 # autoresearch outer-loop runtime artifact (results.tsv, audit_logs/, failure_log)
 autoresearch/state/*
 !autoresearch/state/.gitkeep
+# G5b.fix1 (2026-05-20) — mutation audit ledger is the git-as-optimiser SoT;
+# every applied wrapper-prompt mutation is committed via _git_commit_audit_log.
+# The trailing negation lets `git add autoresearch/state/mutations.jsonl` succeed.
+!autoresearch/state/mutations.jsonl
 .claude/scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,23 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **G5b.fix1 — unignore `autoresearch/state/mutations.jsonl` so the
+  self-improving-loop audit ledger really enters git.** Codex MCP
+  LLM-as-Judge on PR-G5b (#1350) caught the contradiction: the
+  CHANGELOG promised a "git-tracked audit log" but `.gitignore`'s
+  `autoresearch/state/*` glob silently ignored the file —
+  `_git_commit_audit_log`'s `git add` would no-op and the
+  git-as-optimiser ledger would never persist. Add a negation entry
+  (`!autoresearch/state/mutations.jsonl`) immediately after the base
+  glob, leaving the rest of `state/` (run.log, baseline.json,
+  audit_logs/) still ignored. 4 new tests pin the fix:
+  (a) `.gitignore` carries the negation line,
+  (b) base ignore still present,
+  (c) `git check-ignore` exits 1 for mutations.jsonl,
+  (d) sanity — baseline.json still exit 0.
+
 ### Added
 
 - **PR-G5b — program.md-driven self-improving loop runner.** Final PR

--- a/tests/core/self_improving_loop/test_audit_log_gitignored.py
+++ b/tests/core/self_improving_loop/test_audit_log_gitignored.py
@@ -1,0 +1,101 @@
+"""G5b.fix1 (2026-05-20) — mutations.jsonl must NOT be git-ignored.
+
+The G5b self-improving-loop runner appends every applied wrapper-prompt
+mutation to ``autoresearch/state/mutations.jsonl`` and calls
+``_git_commit_audit_log`` to stage + commit the row. The Codex MCP
+LLM-as-Judge audit on 2026-05-20 found that ``.gitignore`` matched
+``autoresearch/state/*`` and silently ignored the ledger; the runner's
+``git add`` then no-op'd, and the CHANGELOG's "git-tracked audit log"
+claim was false.
+
+These tests pin the negation in ``.gitignore`` so the ledger really
+enters git history.
+
+Test strategy: two independent checks.
+
+1. **File-content guard** — read the repo ``.gitignore`` and assert
+   the negation line is present. Cheap, runs in <1ms.
+2. **Behavioural guard** — shell out to ``git check-ignore`` (when
+   git is available in the test env) and assert the exit code is 1
+   (= not ignored). Costlier but catches subtler regressions like a
+   later ``*.jsonl`` glob that re-ignores the ledger.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read_gitignore() -> str:
+    return (_REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_gitignore_has_mutations_negation() -> None:
+    """``.gitignore`` carries the explicit negation for the mutation ledger."""
+    text = _read_gitignore()
+    assert "!autoresearch/state/mutations.jsonl" in text, (
+        "G5b.fix1 regression: the mutation audit log negation is missing from "
+        ".gitignore — `git add autoresearch/state/mutations.jsonl` would fail "
+        "silently and the runner's git-as-optimiser ledger would never enter "
+        "history. Add `!autoresearch/state/mutations.jsonl` AFTER the "
+        "`autoresearch/state/*` line."
+    )
+
+
+def test_gitignore_state_glob_still_present() -> None:
+    """The base ignore of ``autoresearch/state/*`` is preserved.
+
+    The negation should be additive, not a wholesale removal of the
+    ignore (which would leak run logs, baseline.json snapshots, etc.).
+    """
+    text = _read_gitignore()
+    assert "autoresearch/state/*" in text, (
+        "The base ignore rule for `autoresearch/state/*` is missing. The "
+        "G5b.fix1 negation must coexist with the base ignore; otherwise "
+        "stale run.log / audit_logs/ / baseline.json files leak into commits."
+    )
+
+
+def test_git_check_ignore_says_mutations_not_ignored() -> None:
+    """Behavioural check via ``git check-ignore`` — exit 1 = not ignored."""
+    try:
+        result = subprocess.run(  # nosec B603 — argv hard-coded
+            ["git", "check-ignore", "autoresearch/state/mutations.jsonl"],  # noqa: S607  # nosec B607
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("git binary not available in test environment")
+    assert result.returncode == 1, (
+        "git check-ignore considers autoresearch/state/mutations.jsonl "
+        f"ignored (exit={result.returncode}, stdout={result.stdout!r}). "
+        "The G5b.fix1 negation in .gitignore is not effective — perhaps a "
+        "later glob (`*.jsonl`?) re-ignores it."
+    )
+
+
+def test_git_check_ignore_still_ignores_baseline() -> None:
+    """Sanity: baseline.json (and other state/ artifacts) still ignored."""
+    try:
+        result = subprocess.run(  # nosec B603 — argv hard-coded
+            ["git", "check-ignore", "autoresearch/state/baseline.json"],  # noqa: S607  # nosec B607
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("git binary not available in test environment")
+    assert result.returncode == 0, (
+        "Sanity check failed: autoresearch/state/baseline.json should still "
+        "be ignored (exit 0 from `git check-ignore`), but got "
+        f"exit={result.returncode}. The G5b.fix1 negation may have leaked "
+        "into a too-broad rule."
+    )


### PR DESCRIPTION
## Summary
- `.gitignore` 의 `autoresearch/state/*` 뒤에 `!autoresearch/state/mutations.jsonl` negation 추가
- 4 신규 tests (content guard + behavioural guard + sanity)
- CHANGELOG `[Unreleased] Fixed` 에 G5b.fix1 entry
- 2026-05-20 self-improving-loop sprint fix-up 시리즈의 1번 PR

## Why
Codex MCP LLM-as-Judge 가 PR-G5b (#1350) 에서 발견한 **anti-deception 결함**:

> CHANGELOG claims "git-tracked audit log of every applied mutation"
> Reality: `MUTATION_AUDIT_LOG_PATH = autoresearch/state/mutations.jsonl`, but `.gitignore` matches `autoresearch/state/*`. `git add` fails silently; `_git_commit_audit_log` returns False; ledger never enters git.

`git check-ignore autoresearch/state/mutations.jsonl` → exit 0 (ignored). 결과: 모든 `git add` 가 no-op, `_git_commit_audit_log` 가 silently false 반환. CHANGELOG 의 "git-as-optimiser ledger" 약속이 실제로는 작동 안 함.

본 fix 후:
- `git check-ignore autoresearch/state/mutations.jsonl` → exit 1 (not ignored)
- `git check-ignore autoresearch/state/baseline.json` → exit 0 (sanity: 다른 state/ 파일은 여전히 ignored)
- `_git_commit_audit_log` 의 `git add` 가 실제 작동

## Changes
| File | Change |
|------|--------|
| `.gitignore` | line 147 에 `!autoresearch/state/mutations.jsonl` negation 추가 (line 146 의 `.gitkeep` 패턴과 동일) |
| `tests/core/self_improving_loop/test_audit_log_gitignored.py` (new) | 4 케이스 — gitignore content guard / base glob present / `git check-ignore` mutations 미ignored / `git check-ignore` baseline 여전히 ignored |
| `CHANGELOG.md` | `[Unreleased] Fixed` 에 G5b.fix1 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 부정 (negation) 추가 | Implemented | line 147 |
| content guard test | Implemented | line 38 |
| base preserved test | Implemented | line 50 |
| behavioural exit-1 test | Implemented | line 64 |
| sanity exit-0 test | Implemented | line 84 |
| CHANGELOG parity claim 실제 입증 | Implemented | `git check-ignore` 결과로 입증 |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean (359 source files)
- [x] `git check-ignore autoresearch/state/mutations.jsonl` → exit 1 (verified locally)
- [x] `git check-ignore autoresearch/state/baseline.json` → exit 0 (sanity)
- [x] pytest 25 pass (new 4 + existing 21 G5b runner tests)

## Reference
- 2026-05-20 Codex MCP LLM-as-Judge — PR-G5b FAIL finding #1
- `feedback_changelog_implementation_parity` (new memory)
- CLAUDE.md `DONT — Real Incidents` table row #1 (parallel PR #1351)

🤖 Generated with [Claude Code](https://claude.com/claude-code)