### PR TITLE
fix(self-improving-loop): G5b.fix2 — runner actually loads autoresearch/program.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,26 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **G5b.fix2 — `core/self_improving_loop/runner.py` actually loads
+  `autoresearch/program.md` so "program.md-driven" is no longer fiction.**
+  Codex MCP LLM-as-Judge on PR-G5b (#1350) caught the second
+  anti-deception case: the PR title claimed "program.md-driven
+  self-improving loop runner" but `_SYSTEM_PROMPT` was a hardcoded
+  f-string and `grep -rn "program.md" core/ autoresearch/` returned
+  zero reads. Fix: replace the constant with `_build_system_prompt()`
+  which calls `_load_program_md()` (path resolved relative to the
+  runner module so worktrees work) and concatenates the file body with
+  a runner-specific `_MUTATION_CONTRACT_SUFFIX` (the single-shot JSON
+  contract). When program.md is unreadable (missing / OSError), the
+  function logs WARNING and returns `_FALLBACK_SYSTEM_PROMPT` — the
+  pre-fix inline prompt — so the loop never goes offline. 4 new tests:
+  (a) program.md body reaches the LLM, (b) fallback when load returns
+  None, (c) real in-repo program.md is reachable from the runner's
+  path resolution (refactor-canary), (d) end-to-end `run_once`
+  surfaces program.md to the captured LLM call.
+
 ### Changed
 
 - **Scaffold: CLAUDE.md gains 2 new wiring rules + 1 deception rule + a

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -173,7 +173,7 @@ def build_runner_context() -> RunnerContext:
 # ---------------------------------------------------------------------------
 
 
-_SYSTEM_PROMPT = (
+_FALLBACK_SYSTEM_PROMPT = (
     "You are the self-improving-loop mutator for GEODE, an autonomous "
     "execution agent. Your job: read the audit baseline, meta-review "
     "priors, and the current WRAPPER_PROMPT_SECTIONS dict, then propose "
@@ -197,6 +197,83 @@ _SYSTEM_PROMPT = (
     '  "target_dim": "<dim name the mutation aims at, or empty>"\n'
     "}\n"
 )
+"""Inline fallback prompt used when ``autoresearch/program.md`` is unreadable.
+
+Kept as a complete, self-contained string so a `program.md` outage (missing
+file, OSError) doesn't take the runner offline. Tests that don't need the
+program.md content monkeypatch :func:`_load_program_md` to skip the disk read.
+"""
+
+
+_MUTATION_CONTRACT_SUFFIX = (
+    "\n\n"
+    "## Mutation Contract (runner-specific, on top of program.md)\n"
+    "\n"
+    "For THIS invocation, ignore the broader autoresearch loop instructions "
+    "in program.md and act as a single-shot mutator with these constraints:\n"
+    "\n"
+    "- Change exactly ONE section of WRAPPER_PROMPT_SECTIONS. Adding a new "
+    "section key counts as a change; deleting does NOT (the runner ignores "
+    "deletions).\n"
+    "- ``new_value`` must be a non-empty single-paragraph string under 600 "
+    "characters.\n"
+    "- ``rationale`` must cite the specific regression evidence or "
+    "meta-review prior that motivates the change.\n"
+    "- Respond with a single JSON object — NO surrounding prose, NO code fences.\n"
+    "\n"
+    "Response schema:\n"
+    "{\n"
+    '  "target_section": "<section key>",\n'
+    '  "new_value": "<replacement text>",\n'
+    '  "rationale": "<= 200 chars, citing the evidence>",\n'
+    '  "target_dim": "<dim name the mutation aims at, or empty>"\n'
+    "}\n"
+)
+"""Appended to program.md so the runner can scope it to a single mutation step.
+
+program.md (Karpathy P7 — the agent instruction document) describes the
+*overall* self-improving loop: branch creation, multi-iteration ratchet,
+fitness measurement etc. This runner is a single-shot step inside that loop
+that proposes ONE mutation per invocation. The suffix narrows the broader
+contract to the JSON output the parser expects.
+"""
+
+
+def _load_program_md() -> str | None:
+    """Read ``autoresearch/program.md`` from disk; return ``None`` on failure.
+
+    Resolves the path relative to the runner module so the lookup works in
+    worktrees / installs where ``cwd`` doesn't match the repo root.
+    Returns ``None`` (not a raised exception) on missing file / OSError so
+    the runner can fall back to the inline prompt without breaking the loop.
+    Tests monkeypatch this function to inject canned content.
+    """
+    program_md_path = Path(__file__).resolve().parents[2] / "autoresearch" / "program.md"
+    try:
+        return program_md_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning(
+            "self-improving-loop runner: could not read %s (%s); using fallback prompt",
+            program_md_path,
+            exc,
+        )
+        return None
+
+
+def _build_system_prompt() -> str:
+    """Compose the system prompt: program.md body + single-mutation contract.
+
+    G5b.fix1.b (2026-05-20) — closes the second of the Codex MCP findings on
+    PR-G5b: the runner is now genuinely "program.md-driven" because the
+    document is loaded and used at every invocation. When program.md is
+    unreadable, the runner falls back to :data:`_FALLBACK_SYSTEM_PROMPT`
+    (the previous hardcoded prompt) so the loop never goes offline due to
+    a missing/corrupt instruction file.
+    """
+    program_md = _load_program_md()
+    if program_md is None:
+        return _FALLBACK_SYSTEM_PROMPT
+    return program_md.rstrip() + _MUTATION_CONTRACT_SUFFIX
 
 
 def _build_user_prompt(ctx: RunnerContext) -> str:
@@ -486,7 +563,7 @@ class SelfImprovingLoopRunner:
         """
         ctx = build_runner_context()
         user_prompt = _build_user_prompt(ctx)
-        raw_response = self.llm_call(_SYSTEM_PROMPT, user_prompt)
+        raw_response = self.llm_call(_build_system_prompt(), user_prompt)
         mutation = parse_mutation(raw_response)
         _new_sections, previous_value = apply_mutation(
             mutation, current_sections=ctx.current_sections

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -417,3 +417,104 @@ def test_runner_context_defaults() -> None:
     assert ctx.meta_review_snapshot is None
     assert ctx.current_sections == {}
     assert ctx.target_dim == ""
+
+
+# ---------------------------------------------------------------------------
+# G5b.fix2 (2026-05-20) — program.md is actually loaded as the system prompt
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_loads_program_md_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When program.md is readable, _build_system_prompt prepends its body."""
+    from core.self_improving_loop import runner
+
+    monkeypatch.setattr(
+        runner,
+        "_load_program_md",
+        lambda: "## CUSTOM PROGRAM MD BODY\n\nThis text must reach the LLM.",
+    )
+    prompt = runner._build_system_prompt()
+    assert "## CUSTOM PROGRAM MD BODY" in prompt
+    assert "This text must reach the LLM." in prompt
+    # The mutation-contract suffix is appended so the JSON contract is still
+    # present alongside the program.md body.
+    assert "Response schema:" in prompt
+    assert "target_section" in prompt
+
+
+def test_system_prompt_falls_back_when_program_md_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When _load_program_md returns None (missing/OSError), use fallback."""
+    from core.self_improving_loop import runner
+
+    monkeypatch.setattr(runner, "_load_program_md", lambda: None)
+    prompt = runner._build_system_prompt()
+    # Fallback content (the pre-G5b.fix2 inline prompt) is returned verbatim.
+    assert prompt == runner._FALLBACK_SYSTEM_PROMPT
+    assert "Response schema:" in prompt
+
+
+def test_load_program_md_reads_real_file_in_repo() -> None:
+    """The real ``autoresearch/program.md`` file is reachable from the runner.
+
+    Sanity check that the path resolution in :func:`_load_program_md`
+    actually finds the in-repo file — if a refactor moves the runner,
+    this test fails loudly instead of silently dropping into the
+    fallback prompt every run.
+    """
+    from core.self_improving_loop.runner import _load_program_md
+
+    program_md = _load_program_md()
+    assert program_md is not None, (
+        "autoresearch/program.md was not reachable from the runner. "
+        "Check the path resolution in _load_program_md if the runner "
+        "module moved."
+    )
+    assert "autoresearch" in program_md.lower()
+
+
+def test_run_once_uses_program_md_in_system_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: SelfImprovingLoopRunner.run_once passes program.md body to LLM."""
+    from autoresearch import train as auto_train
+
+    from core.self_improving_loop import runner
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    sot_path.write_text(json.dumps({"role": "old"}), encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_load_program_md",
+        lambda: "## CUSTOM PROGRAM MD\n\nThe runner must surface this.",
+    )
+    monkeypatch.setattr(runner, "GLOBAL_SELF_IMPROVING_LOOP_DIR", tmp_path / "sil_home")
+
+    captured: dict[str, str] = {}
+
+    def _capture_llm(system: str, _user: str) -> str:
+        captured["system"] = system
+        return json.dumps({"target_section": "role", "new_value": "new", "rationale": "r"})
+
+    runner.SelfImprovingLoopRunner(
+        llm_call=_capture_llm,
+        audit_log_path=tmp_path / "mutations.jsonl",
+        commit_enabled=False,
+        rerun_enabled=False,
+    ).run_once()
+    assert "CUSTOM PROGRAM MD" in captured["system"]
+    assert "The runner must surface this." in captured["system"]
+    # And the mutation contract suffix is still appended.
+    assert "Response schema:" in captured["system"]


### PR DESCRIPTION
## Summary
- `core/self_improving_loop/runner.py` 의 `_SYSTEM_PROMPT` 상수를 `_build_system_prompt()` + `_load_program_md()` 로 교체
- `autoresearch/program.md` 를 LLM system prompt 의 본문으로 직접 사용 (단일 mutation contract suffix 부착)
- 4 신규 tests
- 2026-05-20 self-improving-loop sprint fix-up 시리즈의 2번 PR

## Why
Codex MCP LLM-as-Judge 가 PR-G5b (#1350) 에서 발견한 **2번째 anti-deception 결함**:

> PR title: "program.md-driven self-improving loop runner"
> Reality: `_SYSTEM_PROMPT` is a hardcoded f-string; `grep -rn "program.md" core/ autoresearch/` shows zero reads. PR title overstates implementation.

본 fix 후:
- `_load_program_md()` 가 `autoresearch/program.md` (Karpathy P7 agent instruction document) 의 360-line 본문을 매 invocation 마다 read
- 그 본문에 `_MUTATION_CONTRACT_SUFFIX` (단일 JSON 응답 contract) 를 append → LLM system prompt
- 파일 unreadable 시 `_FALLBACK_SYSTEM_PROMPT` (pre-fix 인라인 prompt) 로 graceful degrade — 로프 절대 죽이지 않음
- `grep -rn "program.md" core/self_improving_loop/` 가 실제 read 보임 (CHANGELOG parity 입증)

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | `_SYSTEM_PROMPT` → `_FALLBACK_SYSTEM_PROMPT` 이름 변경. 새 `_MUTATION_CONTRACT_SUFFIX` 상수. 새 `_load_program_md()` (worktree-safe path resolution + OSError → None graceful). 새 `_build_system_prompt()` (program.md 본문 + suffix, 또는 fallback). `run_once()` 호출부 갱신 |
| `tests/core/self_improving_loop/test_runner.py` | 4 신규 — program.md body 가 LLM 에 도달 / fallback on None / real-file reachable (refactor canary) / end-to-end `run_once` propagation |
| `CHANGELOG.md` | `[Unreleased] Fixed` G5b.fix2 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `autoresearch/program.md` actual read | Implemented | `_load_program_md()` |
| Worktree-safe path resolution | Implemented | `Path(__file__).resolve().parents[2]` |
| Graceful fallback on missing file | Implemented | `_FALLBACK_SYSTEM_PROMPT` 보존 |
| Single-mutation contract scoping | Implemented | `_MUTATION_CONTRACT_SUFFIX` appended |
| CHANGELOG parity ("program.md-driven") | Implemented | grep-provable |
| Refactor canary test | Implemented | real file 도달 안 되면 명시 fail |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean (308 source files)
- [x] pytest 25 pass (existing 21 G5b runner + new 4)
- [x] `grep -rn "program.md" core/self_improving_loop/` shows real reads

## Reference
- 2026-05-20 Codex MCP LLM-as-Judge — PR-G5b FAIL finding #2
- karpathy-patterns P7 "program.md interface" — 이제 *실제로* 적용
- CLAUDE.md `DONT — Real Incidents` 표 row #2 (PR #1351) — 이 PR 이 그 incident 해소
- `feedback_changelog_implementation_parity` — 이 fix 가 parity 입증의 reference 사례

🤖 Generated with [Claude Code](https://claude.com/claude-code)