### PR TITLE
fix(self-improving-loop): G5b.fix3 — SoT rolls back when audit-log write fails (atomicity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ functional change.
 
 ### Fixed
 
+- **G5b.fix3 — SoT rolls back when audit-log write fails (atomicity
+  fix for the mutation runner).** Codex MCP LLM-as-Judge on PR-G5b
+  (#1350) caught the third finding: `apply_mutation` writes the
+  wrapper-sections SoT to disk *before* `append_audit_log` records
+  the mutation. If the audit log write raised `OSError`, the SoT had
+  already advanced and the ledger had no record — the next iteration
+  would build on a mutation with no history. Fix: wrap
+  `append_audit_log` in `try/except OSError` inside `run_once`; on
+  failure, `_rollback_sot` restores the SoT to the pre-mutation
+  `original_sections` and the original `OSError` is re-raised so the
+  caller knows the iteration failed. Rollback failure itself logs but
+  doesn't shadow the original error. 2 new tests: rollback restores
+  SoT on audit-log failure / success path unchanged when audit-log
+  works.
+
 - **G5b.fix1 — unignore `autoresearch/state/mutations.jsonl` so the
   self-improving-loop audit ledger really enters git.** Codex MCP
   LLM-as-Judge on PR-G5b (#1350) caught the contradiction: the

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -485,17 +485,29 @@ class SelfImprovingLoopRunner:
         the caller can decide whether to retry.
         """
         ctx = build_runner_context()
+        original_sections = dict(ctx.current_sections)
         user_prompt = _build_user_prompt(ctx)
         raw_response = self.llm_call(_SYSTEM_PROMPT, user_prompt)
         mutation = parse_mutation(raw_response)
         _new_sections, previous_value = apply_mutation(
             mutation, current_sections=ctx.current_sections
         )
-        log_path = append_audit_log(
-            mutation,
-            previous_value=previous_value,
-            log_path=self.audit_log_path,
-        )
+        # G5b.fix3 (2026-05-20) — atomicity boundary: if the audit log
+        # write fails after the SoT mutation lands, the in-disk state is
+        # silently divergent (SoT advanced, history missing). Roll the
+        # SoT back to ``original_sections`` so the next iteration sees a
+        # consistent state. Best-effort: rollback can itself fail (rare
+        # filesystem outage); we log + re-raise the original exception
+        # so the caller knows the iteration failed.
+        try:
+            log_path = append_audit_log(
+                mutation,
+                previous_value=previous_value,
+                log_path=self.audit_log_path,
+            )
+        except OSError as exc:
+            self._rollback_sot(original_sections, mutation=mutation, exc=exc)
+            raise
         if self.commit_enabled:
             _git_commit_audit_log(log_path, mutation=mutation)
         if self.rerun_enabled:
@@ -503,6 +515,46 @@ class SelfImprovingLoopRunner:
             self._invoke_autoresearch(repo_root)
         self._append_self_improving_loop_index(mutation, previous_value)
         return mutation
+
+    @staticmethod
+    def _rollback_sot(
+        original_sections: dict[str, str],
+        *,
+        mutation: Mutation,
+        exc: OSError,
+    ) -> None:
+        """Restore the SoT to ``original_sections`` after a post-apply failure.
+
+        G5b.fix3 — invoked from ``run_once`` when
+        :func:`append_audit_log` raises ``OSError`` *after*
+        :func:`apply_mutation` has already written the new sections to
+        disk. The SoT must be rolled back to the pre-mutation state so
+        the loop never persists a mutation that has no audit-log row;
+        otherwise the git-as-optimiser ledger and the live state would
+        diverge silently.
+
+        Rollback failure is itself logged but never raised in place of
+        the original ``exc`` — the caller already has the more useful
+        signal (audit-log write failed).
+        """
+        try:
+            from autoresearch.train import write_wrapper_prompt_sections
+
+            write_wrapper_prompt_sections(original_sections)
+            log.error(
+                "self-improving-loop runner: audit-log write failed (%s); "
+                "SoT rolled back to pre-mutation state for section %r",
+                exc,
+                mutation.target_section,
+            )
+        except Exception:  # pragma: no cover — defensive
+            log.exception(
+                "self-improving-loop runner: audit-log write failed (%s) AND "
+                "rollback failed — SoT may be in a divergent state for "
+                "section %r",
+                exc,
+                mutation.target_section,
+            )
 
     def _invoke_autoresearch(self, repo_root: Path) -> None:
         """Wrap the autoresearch subprocess so tests can override."""

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -417,3 +417,90 @@ def test_runner_context_defaults() -> None:
     assert ctx.meta_review_snapshot is None
     assert ctx.current_sections == {}
     assert ctx.target_dim == ""
+
+
+# ---------------------------------------------------------------------------
+# G5b.fix3 (2026-05-20) — atomicity: SoT rolls back on audit-log OSError
+# ---------------------------------------------------------------------------
+
+
+def test_runner_rolls_back_sot_when_audit_log_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If append_audit_log raises OSError after SoT mutation, the SoT must
+    revert to the pre-mutation state so the next iteration sees consistency."""
+    from autoresearch import train as auto_train
+
+    from core.self_improving_loop import runner
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    original = {"role": "ORIGINAL_ROLE", "tools": "ORIGINAL_TOOLS"}
+    sot_path.write_text(json.dumps(original), encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+
+    def _explode_audit_log(*_a: Any, **_kw: Any) -> None:
+        raise OSError("simulated audit log write failure")
+
+    monkeypatch.setattr(runner, "append_audit_log", _explode_audit_log)
+    monkeypatch.setattr(runner, "GLOBAL_SELF_IMPROVING_LOOP_DIR", tmp_path / "sil_home")
+
+    instance = runner.SelfImprovingLoopRunner(
+        llm_call=lambda _s, _u: json.dumps(
+            {"target_section": "role", "new_value": "MUTATED", "rationale": "r"}
+        ),
+        audit_log_path=tmp_path / "mutations.jsonl",
+        commit_enabled=False,
+        rerun_enabled=False,
+    )
+    with pytest.raises(OSError, match="simulated audit log write failure"):
+        instance.run_once()
+
+    # The SoT must have rolled back to the original.
+    persisted = json.loads(sot_path.read_text(encoding="utf-8"))
+    assert persisted == original, (
+        "G5b.fix3 regression: audit-log OSError did not roll back the SoT. "
+        f"Expected {original}, got {persisted}."
+    )
+
+
+def test_runner_success_path_unchanged_by_rollback_logic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When audit-log write succeeds, SoT carries the mutation forward."""
+    from autoresearch import train as auto_train
+
+    from core.self_improving_loop import runner
+
+    sot_path = tmp_path / "wrapper-sections.json"
+    sot_path.write_text(json.dumps({"role": "old"}), encoding="utf-8")
+    monkeypatch.setattr(auto_train, "WRAPPER_SECTIONS_SOT_PATH", sot_path)
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_baseline",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.load_latest_meta_review",
+        lambda: None,
+    )
+    monkeypatch.setattr(runner, "GLOBAL_SELF_IMPROVING_LOOP_DIR", tmp_path / "sil_home")
+
+    instance = runner.SelfImprovingLoopRunner(
+        llm_call=lambda _s, _u: json.dumps(
+            {"target_section": "role", "new_value": "NEW", "rationale": "r"}
+        ),
+        audit_log_path=tmp_path / "mutations.jsonl",
+        commit_enabled=False,
+        rerun_enabled=False,
+    )
+    instance.run_once()
+    # SoT carries the mutation; rollback path not taken.
+    persisted = json.loads(sot_path.read_text(encoding="utf-8"))
+    assert persisted["role"] == "NEW"


### PR DESCRIPTION
## Summary
- `SelfImprovingLoopRunner.run_once` 가 `append_audit_log` 의 OSError 시 SoT 롤백
- 새 `_rollback_sot()` static method
- 2 신규 tests (rollback success path + happy path)
- 2026-05-20 self-improving-loop sprint fix-up 시리즈의 3번 PR (PR-G5b 3 결함 중 마지막)

## Why
Codex MCP LLM-as-Judge 가 PR-G5b (#1350) 에서 발견한 **3번째 결함 (atomicity)**:

> `apply_mutation` writes the wrapper-sections SoT to disk BEFORE `append_audit_log` records the mutation. If the audit log write raised OSError, the SoT had already advanced and the ledger had no record — the next iteration would build on a mutation with no history.

즉 두 disk 작업 사이에 *atomicity boundary 부재* — partial state divergence 가능. self-improving loop 는 git-as-optimiser 패턴이라 ledger 와 SoT 가 monotonic 하게 함께 advance 해야 함.

본 fix 후:
- `run_once()` 가 audit-log OSError 시 `_rollback_sot()` 호출
- `_rollback_sot` 가 `write_wrapper_prompt_sections(original_sections)` 으로 SoT 를 pre-mutation state 로 복구
- 원래 OSError 가 caller 에 raise (caller 가 retry 여부 판단)
- rollback 자체 실패 시 log + 원래 exception 그대로 raise (rollback 실패 메시지가 원 문제를 가리지 않음)

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | `run_once()` 에 `original_sections = dict(ctx.current_sections)` 저장. `append_audit_log` 호출 try/except OSError. 새 static method `_rollback_sot(original_sections, *, mutation, exc)` |
| `tests/core/self_improving_loop/test_runner.py` | 2 신규 — rollback restores SoT on failure / happy path unchanged |
| `CHANGELOG.md` | `[Unreleased] Fixed` G5b.fix3 entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `append_audit_log` failure → SoT rollback | Implemented | `try/except OSError` in `run_once` |
| Rollback writes `original_sections` | Implemented | `_rollback_sot` |
| Original OSError preserved for caller | Implemented | `raise` after rollback |
| Rollback failure doesn't shadow root cause | Implemented | inner `except Exception` only logs |
| Happy path unchanged | Implemented | `run_once` success path identical |

## Verification
- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean (308 source files)
- [x] pytest 27 pass (existing 25 + new 2)
- [x] G5b 3 결함 모두 해소: G5b.fix1 (ledger ignored) + G5b.fix2 (program.md hardcoded) + G5b.fix3 (atomicity)

## Reference
- 2026-05-20 Codex MCP LLM-as-Judge — PR-G5b FAIL finding #3
- 자매 PR: PR-1352 (G5b.fix1) merged, PR-1353 (G5b.fix2) green, PR-1351 (CLAUDE.md DONT 표) merged
- karpathy-patterns P5 "Git as State Machine" — ledger 와 SoT monotonic invariant 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)