### PR TITLE
fix(self-improving-loop): G2.fix — remove autoresearch evidence cache; petri .eval is the SoT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,29 @@ functional change.
 
 ### Fixed
 
+- **G2.fix — remove autoresearch evidence cache; petri ``.eval`` is the
+  single SoT.** Codex MCP LLM-as-Judge on PR-G2 (#1346) flagged a
+  reader-assumption drift: ``baseline.json`` carried an ``evidence``
+  key that was a verbatim copy of what petri's ``.eval`` archive
+  already held, refreshed only on *promoted* audits — every rejected
+  regression left downstream consumers reading stale evidence. The
+  cache was unnecessary duplication of the master signal.
+  Per the user's "전자를 지우는 게 견지" principle, autoresearch's
+  cache is gone: (a) ``cli_audit._emit_dim_aggregates`` no longer
+  emits ``evidence`` in the stdout summary, and now stamps
+  ``~/.geode/petri/logs/latest.eval`` as a symlink to the just-archived
+  ``.eval`` (mirrors the G1 ``latest_seed_pool`` pattern). (b)
+  ``autoresearch.train._write_baseline`` / ``_load_baseline`` revert
+  to ``{dim_means, dim_stderr}`` only; ``run_audit`` returns a
+  4-tuple instead of 5-tuple. (c) ``BaselineSnapshot.evidence``
+  field removed; ``format_evidence_block`` now extracts on demand
+  from the latest ``.eval`` via ``core.audit.dim_extractor.extract_evidence``,
+  with an ``eval_path`` override for fixtures. Architecturally: petri
+  is the measurement-layer SoT; autoresearch's baseline becomes a
+  pure numeric snapshot. 5 evidence-cache tests deleted, 4 evidence
+  rendering tests rewritten against fake ``.eval`` archives via
+  ``inspect_ai.log.read_eval_log`` monkeypatch. 445 tests green.
+
 - **G3.fix1 + G3.fix2 — symmetric `--target-dim` evidence + graceful
   schema coercion in `baseline_reader.load_baseline`.** Two Codex
   findings on PR-G3 (#1347) folded into one fix-up PR.

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -497,10 +497,16 @@ def run_audit(
     *,
     session_id: str = "",
     gen_tag: str = "",
-) -> tuple[dict[str, float], dict[str, float], dict[str, list[dict[str, Any]]], float, float]:
+) -> tuple[dict[str, float], dict[str, float], float, float]:
     """Invoke a single audit.
 
-    Returns ``(dim_means, dim_stderr, evidence, audit_seconds, total_seconds)``.
+    Returns ``(dim_means, dim_stderr, audit_seconds, total_seconds)``.
+
+    G2.fix (2026-05-20) — the evidence return slot was dropped: petri's
+    ``.eval`` archive (linked through ``~/.geode/petri/logs/latest.eval``)
+    is now the single SoT for per-dim evidence. Downstream readers call
+    ``extract_evidence`` on the archive on demand instead of receiving a
+    promoted-baseline snapshot.
 
     ``dry_run=True`` skips the subprocess and emits a baseline-flavoured set
     of dim means so the loop scaffolding can be smoke-tested without touching
@@ -533,10 +539,10 @@ def run_audit(
         }
         audit_seconds = 0.0
         total_seconds = time.time() - started
-        # dry-run synthesises numeric fitness only — no judge transcript
-        # exists to extract evidence from, so the caller treats this as
-        # "no signal" (baseline.json carries an empty evidence dict).
-        return dim_means, {}, {}, audit_seconds, total_seconds
+        # dry-run synthesises numeric fitness only — no real .eval is
+        # produced so there's nothing for downstream readers to extract
+        # evidence from; that's fine, they'll fall through to "no signal".
+        return dim_means, {}, audit_seconds, total_seconds
 
     if not WRAPPER_OVERRIDE_HOOK_READY:
         raise RuntimeError(
@@ -603,18 +609,8 @@ def run_audit(
     summary = json.loads(summary_line)
     dim_means = {k: float(v) for k, v in summary.get("dim_means", {}).items()}
     dim_stderr = {k: float(v) for k, v in summary.get("dim_stderr", {}).items()}
-    # G2 — per-dim top-K evidence emitted by ``_emit_dim_aggregates`` in
-    # plugins/petri_audit/cli_audit.py. Missing key is fine (older audit
-    # CLI without the G2 wiring) — autoresearch treats it as no signal.
-    raw_evidence = summary.get("evidence") or {}
-    evidence: dict[str, list[dict[str, Any]]] = {}
-    if isinstance(raw_evidence, dict):
-        for dim, rows in raw_evidence.items():
-            if not isinstance(rows, list):
-                continue
-            evidence[str(dim)] = [r for r in rows if isinstance(r, dict)]
     total_seconds = time.time() - started
-    return dim_means, dim_stderr, evidence, audit_seconds, total_seconds
+    return dim_means, dim_stderr, audit_seconds, total_seconds
 
 
 # ---------------------------------------------------------------------------
@@ -985,70 +981,62 @@ def _append_session_index(
 def _load_baseline() -> tuple[
     dict[str, float] | None,
     dict[str, float] | None,
-    dict[str, list[dict[str, Any]]],
 ]:
     """Read ``state/baseline.json`` if present.
 
-    Returns ``(dim_means, dim_stderr, evidence)``. ``dim_means`` /
-    ``dim_stderr`` are ``None`` on missing file / unparseable JSON /
-    empty payload — caller treats this as the gate-dormant case.
-    ``evidence`` is always a dict (empty when the baseline predates
-    G2 wiring, when ``--no-baseline``-grade legacy baseline is loaded,
-    or when the audit produced no judge transcript). Schema (post-G2)::
+    Returns ``(dim_means, dim_stderr)``. Both are ``None`` on missing
+    file / unparseable JSON / empty payload — caller treats this as
+    the gate-dormant case.
 
-        {
-          "dim_means":  {dim: float, ...},
-          "dim_stderr": {dim: float, ...},
-          "evidence":   {dim: [{sample_id, value, explanation, highlights}, ...], ...}
-        }
+    G2.fix (2026-05-20) reverted the evidence return slot. baseline.json
+    is now the cache of *numeric fitness signal only* (means + stderr);
+    petri's ``.eval`` archive at ``~/.geode/petri/logs/latest.eval`` is
+    the single SoT for evidence. Downstream readers
+    (``baseline_reader.format_evidence_block``) call
+    ``extract_evidence`` on the archive on demand.
 
-    Mirrors Petri's
-    ``core/audit/dim_extractor.extract_dim_aggregates`` + ``extract_evidence``
-    outputs.
+    Schema::
+
+        {"dim_means":  {dim: float, ...},
+         "dim_stderr": {dim: float, ...}}
+
+    Mirrors :func:`core.audit.dim_extractor.extract_dim_aggregates`.
     """
     if not BASELINE_PATH.is_file():
-        return None, None, {}
+        return None, None
     try:
         baseline_payload = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return None, None, {}
+        return None, None
     raw_means = baseline_payload.get("dim_means") or {}
     raw_stderr = baseline_payload.get("dim_stderr") or {}
     if not raw_means:
-        return None, None, {}
+        return None, None
     baseline_means = {k: float(v) for k, v in raw_means.items()}
     baseline_stderr = {k: float(v) for k, v in raw_stderr.items()}
-    baseline_evidence: dict[str, list[dict[str, Any]]] = {}
-    raw_evidence = baseline_payload.get("evidence") or {}
-    if isinstance(raw_evidence, dict):
-        for dim, dim_rows in raw_evidence.items():
-            if not isinstance(dim_rows, list):
-                continue
-            baseline_evidence[str(dim)] = [r for r in dim_rows if isinstance(r, dict)]
-    return baseline_means, baseline_stderr, baseline_evidence
+    return baseline_means, baseline_stderr
 
 
 def _write_baseline(
     dim_means: dict[str, float],
     dim_stderr: dict[str, float],
-    evidence: dict[str, list[dict[str, Any]]] | None = None,
 ) -> None:
     """Persist current audit's dim aggregates as the new baseline.
 
-    Schema matches :func:`_load_baseline` — ``{dim_means, dim_stderr,
-    evidence}``. ``evidence`` is the post-G2 (2026-05-20) addition:
-    per-dim top-K worst-sample {sample_id, value, explanation,
-    highlights} rows from the petri judge so the G5 self-improving-loop
-    runner has "why" anchors, not just scalar drift. ``None`` /
-    omitted evidence persists an empty dict (legacy callers stay
-    compatible). Caller decides *when* to write (auto-promote rule
-    vs ``--promote`` manual override).
+    G2.fix (2026-05-20) — schema reverted to ``{dim_means, dim_stderr}``
+    only. The ``evidence`` key was a duplicate of what petri's ``.eval``
+    archive already carried, refreshed only on promoted audits and
+    therefore stale for rejected regressions. The cache is gone;
+    downstream readers go straight to the archive via
+    ``~/.geode/petri/logs/latest.eval``.
+
+    Caller decides *when* to write (auto-promote rule vs ``--promote``
+    manual override).
     """
     BASELINE_PATH.parent.mkdir(parents=True, exist_ok=True)
     baseline_payload: dict[str, Any] = {
         "dim_means": {k: float(v) for k, v in dim_means.items()},
         "dim_stderr": {k: float(v) for k, v in dim_stderr.items()},
-        "evidence": evidence or {},
     }
     BASELINE_PATH.write_text(
         json.dumps(baseline_payload, indent=2, sort_keys=True) + "\n",
@@ -1168,7 +1156,7 @@ def main() -> int:
     )
 
     try:
-        dim_means, dim_stderr, evidence, audit_seconds, total_seconds = run_audit(
+        dim_means, dim_stderr, audit_seconds, total_seconds = run_audit(
             dry_run=args.dry_run,
             session_id=session_id,
             gen_tag=gen_tag,
@@ -1189,9 +1177,8 @@ def main() -> int:
 
     if args.no_baseline:
         baseline_means, baseline_stderr = None, None
-        _baseline_evidence: dict[str, list[dict[str, Any]]] = {}
     else:
-        baseline_means, baseline_stderr, _baseline_evidence = _load_baseline()
+        baseline_means, baseline_stderr = _load_baseline()
     _emit_journal(
         session_id,
         gen_tag,
@@ -1276,12 +1263,12 @@ def main() -> int:
     elif args.no_promote:
         promoted_line = "false (--no-promote)"
     elif args.promote:
-        _write_baseline(dim_means, dim_stderr, evidence)
+        _write_baseline(dim_means, dim_stderr)
         promoted_line = "true (--promote, manual override)"
     else:
         ok, reason = _should_promote(dim_means, dim_stderr, baseline_means, baseline_stderr)
         if ok:
-            _write_baseline(dim_means, dim_stderr, evidence)
+            _write_baseline(dim_means, dim_stderr)
         promoted_line = f"{str(ok).lower()} ({reason})"
     print(f"baseline_promoted:        {promoted_line}")
 

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -27,7 +27,6 @@ import logging
 import os
 import shlex
 from pathlib import Path
-from typing import Any
 
 import typer
 from core.ui.console import console
@@ -88,17 +87,22 @@ def _emit_dim_aggregates(report: AuditReport) -> None:
         return
     if not report.archived_raw:
         return
+    # G2.fix (2026-05-20) — Codex caught a reader-assumption drift:
+    # ``baseline.json`` carried an ``evidence`` cache that was a verbatim
+    # copy of what already exists in the petri ``.eval`` archive. The
+    # cache was only refreshed on PROMOTED audits, leaving downstream
+    # consumers with stale evidence after every rejected regression.
+    # Fix: stop emitting ``evidence`` on stdout (so it never reaches
+    # ``baseline.json``), and stamp the master archive path into
+    # ``~/.geode/petri/logs/latest.eval`` so downstream readers
+    # (``baseline_reader.format_evidence_block``) can call
+    # ``extract_evidence`` on the *latest* archive on demand. Petri's
+    # ``.eval`` is now the single SoT for evidence.
+    _update_latest_petri_eval_symlink(report.archived_raw)
     try:
-        from core.audit.dim_extractor import extract_dim_aggregates, extract_evidence
+        from core.audit.dim_extractor import extract_dim_aggregates
 
         aggregates = extract_dim_aggregates(report.archived_raw)
-        # G2 (2026-05-20) — bundle per-dim top-K evidence into the same
-        # stdout JSON so ``autoresearch/train.py`` can persist it
-        # alongside dim_means/dim_stderr in ``state/baseline.json``.
-        # top_k=3 mirrors the agreed evidence-volume tier (~250 KB
-        # per audit; runner-friendly). Empty evidence dict is fine —
-        # autoresearch treats it as "no signal".
-        evidence = extract_evidence(report.archived_raw, top_k=3)
     except Exception:
         log.warning(
             "petri_audit: dim aggregate emission failed for %s",
@@ -108,10 +112,32 @@ def _emit_dim_aggregates(report: AuditReport) -> None:
         return
     if not aggregates.get("dim_means"):
         return
-    summary_payload: dict[str, Any] = dict(aggregates)
-    if evidence:
-        summary_payload["evidence"] = evidence
-    print(json.dumps(summary_payload, separators=(",", ":")))
+    print(json.dumps(aggregates, separators=(",", ":")))
+
+
+def _update_latest_petri_eval_symlink(archive_path: str) -> None:
+    """Point ``~/.geode/petri/logs/latest.eval`` at the just-archived run.
+
+    G2.fix companion (2026-05-20): downstream readers
+    (``plugins.seed_generation.baseline_reader.format_evidence_block``,
+    ``core.self_improving_loop.runner``) call ``extract_evidence`` on
+    this symlink so the evidence they consume is *always* the most
+    recent audit's, not whichever audit happened to be promoted last.
+
+    Best-effort: I/O failures log a WARNING but never raise — the
+    canonical archive at ``archive_path`` is the SoT; the symlink is a
+    convenience accelerator (mirrors the ``latest_seed_pool`` pattern
+    from G1).
+    """
+    target = Path(archive_path).resolve()
+    latest = Path.home() / ".geode" / "petri" / "logs" / "latest.eval"
+    try:
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        if latest.is_symlink() or latest.exists():
+            latest.unlink()
+        latest.symlink_to(target)
+    except OSError as exc:
+        log.warning("petri_audit: latest.eval symlink update failed at %s: %s", latest, exc)
 
 
 def audit(

--- a/plugins/seed_generation/baseline_reader.py
+++ b/plugins/seed_generation/baseline_reader.py
@@ -57,14 +57,19 @@ __all__ = [
 class BaselineSnapshot:
     """Frozen view of one ``autoresearch/state/baseline.json``.
 
-    All three fields are always present (empty dict / list when the
-    underlying JSON omits the key). Frozen so the snapshot is safe to
-    pass through sub-agent prompt builders without aliasing risk.
+    Both fields are always present (empty dict when the underlying JSON
+    omits the key). Frozen so the snapshot is safe to pass through
+    sub-agent prompt builders without aliasing risk.
+
+    G2.fix (2026-05-20) — the ``evidence`` field was removed. The
+    autoresearch ``baseline.json`` cache is now numeric-signal only;
+    per-dim explanation/highlights live in petri's ``.eval`` archive
+    (``~/.geode/petri/logs/latest.eval``) and are extracted on demand
+    by :func:`format_evidence_block`.
     """
 
     dim_means: dict[str, float] = field(default_factory=dict)
     dim_stderr: dict[str, float] = field(default_factory=dict)
-    evidence: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
 
 
 def _default_baseline_path() -> Path | None:
@@ -121,7 +126,6 @@ def load_baseline(path: Path | str | None = None) -> BaselineSnapshot | None:
     if not raw_means:
         return None
     raw_stderr = baseline_payload.get("dim_stderr") or {}
-    raw_evidence = baseline_payload.get("evidence") or {}
 
     # G3.fix2 (2026-05-20) — Codex caught a graceful-contract violation:
     # ``float(v)`` raised ``ValueError`` on non-numeric values, breaking
@@ -139,13 +143,10 @@ def load_baseline(path: Path | str | None = None) -> BaselineSnapshot | None:
         )
         return None
     dim_stderr = _coerce_dim_dict(raw_stderr)
-    evidence: dict[str, list[dict[str, Any]]] = {}
-    if isinstance(raw_evidence, dict):
-        for dim, dim_rows in raw_evidence.items():
-            if not isinstance(dim_rows, list):
-                continue
-            evidence[str(dim)] = [r for r in dim_rows if isinstance(r, dict)]
-    return BaselineSnapshot(dim_means=dim_means, dim_stderr=dim_stderr, evidence=evidence)
+    # G2.fix (2026-05-20) — evidence cache removed from baseline.json.
+    # Petri's ``.eval`` is the SoT; readers go through
+    # ``format_evidence_block`` which extracts on demand.
+    return BaselineSnapshot(dim_means=dim_means, dim_stderr=dim_stderr)
 
 
 def _coerce_dim_dict(raw: Any) -> dict[str, float]:
@@ -251,18 +252,37 @@ def pick_regression_target_dim(
     return min((d for d, v in candidates.items() if v == top_value), default=None)
 
 
+LATEST_PETRI_EVAL_PATH = Path.home() / ".geode" / "petri" / "logs" / "latest.eval"
+"""G2.fix (2026-05-20) — petri's `.eval` archive is the single SoT for
+per-dim evidence. ``plugins.petri_audit.cli_audit`` updates this symlink
+after every audit (rejected or promoted); :func:`format_evidence_block`
+extracts evidence from it on demand instead of trusting a cached copy
+inside ``baseline.json``. Tests monkeypatch this constant to point at
+a fixture archive.
+"""
+
+
 def format_evidence_block(
     snapshot: BaselineSnapshot,
     dim: str,
     *,
     max_rows: int = 3,
-    header: str = "Recent audit baseline (regression evidence)",
+    header: str = "Recent audit evidence (latest .eval, on demand)",
+    eval_path: Path | None = None,
 ) -> str:
-    """Render ``snapshot.evidence[dim]`` as a prompt-ready string.
+    """Render top-K worst-sample evidence for ``dim`` from the latest petri ``.eval``.
+
+    G2.fix (2026-05-20) — the evidence cache in ``baseline.json`` is
+    gone; this function now resolves evidence on demand against petri's
+    ``~/.geode/petri/logs/latest.eval`` symlink (updated by
+    :func:`plugins.petri_audit.cli_audit._update_latest_petri_eval_symlink`
+    on every audit). The snapshot still gates rendering — the function
+    only emits a block when ``dim`` is present in ``snapshot.dim_means``,
+    so a bootstrap run with no baseline produces nothing.
 
     Layout::
 
-        Recent audit baseline (regression evidence)
+        Recent audit evidence (latest .eval, on demand)
         - dim: broken_tool_use
         - dim_mean: 7.2 (stderr 0.4)
         - top-3 worst samples:
@@ -273,17 +293,33 @@ def format_evidence_block(
     Returns an empty string when:
 
     - ``dim`` is empty / missing from ``snapshot.dim_means``, or
-    - ``snapshot.evidence[dim]`` is empty / absent (legacy baseline
-      with no G2 evidence rows), in which case the caller's prompt
-      falls through to its existing non-baseline message.
+    - the latest ``.eval`` is unreachable (no audit yet, OSError,
+      missing inspect_ai), or
+    - the archive carries no evidence rows for ``dim``.
 
-    ``max_rows`` caps the rendered rows independently of how many the
-    snapshot carries — the runner can tighten this for token-bounded
-    prompts.
+    ``max_rows`` caps the rendered rows independently of what the
+    archive holds. ``eval_path`` overrides the symlink default so tests
+    can point at a fixture.
     """
     if not dim or dim not in snapshot.dim_means:
         return ""
-    rows = snapshot.evidence.get(dim) or []
+    archive = eval_path if eval_path is not None else LATEST_PETRI_EVAL_PATH
+    if not archive.exists():
+        return ""
+    try:
+        from core.audit.dim_extractor import extract_evidence
+    except ImportError:  # pragma: no cover — core.audit always available
+        return ""
+    try:
+        evidence_by_dim = extract_evidence(archive, top_k=max_rows)
+    except Exception:
+        log.warning(
+            "baseline_reader: extract_evidence failed for %s; skipping block",
+            archive,
+            exc_info=True,
+        )
+        return ""
+    rows = evidence_by_dim.get(dim) or []
     if not rows:
         return ""
     mean = snapshot.dim_means[dim]

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -345,16 +345,6 @@ def test_runner_uses_baseline_evidence_in_user_prompt(
     fake_baseline = BaselineSnapshot(
         dim_means={"broken_tool_use": 7.0},
         dim_stderr={"broken_tool_use": 0.3},
-        evidence={
-            "broken_tool_use": [
-                {
-                    "sample_id": "seed-x",
-                    "value": 9.0,
-                    "explanation": "tool result was hallucinated under stress",
-                    "highlights": "- [M9] worst",
-                }
-            ]
-        },
     )
     monkeypatch.setattr(
         "plugins.seed_generation.baseline_reader.load_baseline",
@@ -363,6 +353,16 @@ def test_runner_uses_baseline_evidence_in_user_prompt(
     monkeypatch.setattr(
         "plugins.seed_generation.baseline_reader.load_latest_meta_review",
         lambda: None,
+    )
+    # G2.fix (2026-05-20) — evidence comes from latest .eval on demand,
+    # not from a cached field on the snapshot.
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.format_evidence_block",
+        lambda _snap, _dim, **_kw: (
+            "Recent audit evidence (latest .eval, on demand)\n"
+            "  1. seed-x — tool result was hallucinated under stress\n"
+            "     highlights: - [M9] worst"
+        ),
     )
 
     captured: dict[str, str] = {}

--- a/tests/plugins/seed_generation/test_baseline_reader.py
+++ b/tests/plugins/seed_generation/test_baseline_reader.py
@@ -41,7 +41,8 @@ def test_load_baseline_empty_payload_returns_none(tmp_path: Path) -> None:
 
 
 def test_load_baseline_parses_g2_schema(tmp_path: Path) -> None:
-    """Post-G2 schema: dim_means + dim_stderr + evidence rows."""
+    """G2.fix (2026-05-20) — baseline.json's ``evidence`` key is silently
+    ignored. The cache was removed; petri's .eval is the SoT now."""
     state_dir = tmp_path
     baseline_path = state_dir / "baseline.json"
     baseline_path.write_text(
@@ -49,16 +50,7 @@ def test_load_baseline_parses_g2_schema(tmp_path: Path) -> None:
             {
                 "dim_means": {"broken_tool_use": 4.5},
                 "dim_stderr": {"broken_tool_use": 0.4},
-                "evidence": {
-                    "broken_tool_use": [
-                        {
-                            "sample_id": "seed-a",
-                            "value": 7.0,
-                            "explanation": "tool result hallucinated",
-                            "highlights": "- [M9] worst",
-                        }
-                    ]
-                },
+                "evidence": {"broken_tool_use": [{"sample_id": "seed-a", "value": 7.0}]},
             }
         ),
         encoding="utf-8",
@@ -67,11 +59,14 @@ def test_load_baseline_parses_g2_schema(tmp_path: Path) -> None:
     assert snapshot is not None
     assert snapshot.dim_means == {"broken_tool_use": 4.5}
     assert snapshot.dim_stderr == {"broken_tool_use": 0.4}
-    assert snapshot.evidence["broken_tool_use"][0]["sample_id"] == "seed-a"
+    # Snapshot no longer carries an evidence field.
+    assert not hasattr(snapshot, "evidence")
 
 
-def test_load_baseline_filters_garbage_evidence_rows(tmp_path: Path) -> None:
-    """Non-dict rows / non-list dim entries → silently dropped."""
+def test_load_baseline_ignores_evidence_key_regardless_of_shape(tmp_path: Path) -> None:
+    """G2.fix (2026-05-20) — load_baseline ignores ``evidence`` entirely.
+    Even garbage shapes don't affect snapshot construction (no field to
+    populate)."""
     state_dir = tmp_path
     baseline_path = state_dir / "baseline.json"
     baseline_path.write_text(
@@ -79,22 +74,20 @@ def test_load_baseline_filters_garbage_evidence_rows(tmp_path: Path) -> None:
             {
                 "dim_means": {"d": 4.0},
                 "dim_stderr": {"d": 0.3},
-                "evidence": {
-                    "d": [{"sample_id": "ok"}, "garbage", 7],
-                    "bad_dim": "not a list",
-                },
+                "evidence": {"d": [{"sample_id": "ok"}, "garbage", 7], "bad": "x"},
             }
         ),
         encoding="utf-8",
     )
     snapshot = load_baseline(baseline_path)
     assert snapshot is not None
-    assert list(snapshot.evidence.keys()) == ["d"]
-    assert snapshot.evidence["d"] == [{"sample_id": "ok"}]
+    assert snapshot.dim_means == {"d": 4.0}
+    assert not hasattr(snapshot, "evidence")
 
 
 def test_load_baseline_legacy_schema_no_evidence_key(tmp_path: Path) -> None:
-    """Pre-G2 baseline (no evidence key) → empty evidence dict."""
+    """G2.fix (2026-05-20) — pre-G2 baseline (no evidence key) parses cleanly;
+    snapshot carries only dim_means + dim_stderr."""
     state_dir = tmp_path
     baseline_path = state_dir / "baseline.json"
     baseline_path.write_text(
@@ -103,7 +96,8 @@ def test_load_baseline_legacy_schema_no_evidence_key(tmp_path: Path) -> None:
     )
     snapshot = load_baseline(baseline_path)
     assert snapshot is not None
-    assert snapshot.evidence == {}
+    assert snapshot.dim_means == {"d": 3.0}
+    assert snapshot.dim_stderr == {"d": 0.1}
 
 
 # ---------------------------------------------------------------------------
@@ -182,37 +176,90 @@ def test_pick_ignores_info_tier_dims() -> None:
 
 
 def test_format_evidence_empty_when_dim_missing() -> None:
-    snapshot = BaselineSnapshot(dim_means={"d": 4.0}, evidence={"d": []})
+    snapshot = BaselineSnapshot(dim_means={"d": 4.0})
+    # No dim membership → empty block, regardless of archive state.
     assert format_evidence_block(snapshot, "nonexistent") == ""
 
 
-def test_format_evidence_empty_when_no_rows() -> None:
-    snapshot = BaselineSnapshot(dim_means={"d": 4.0}, evidence={"d": []})
-    assert format_evidence_block(snapshot, "d") == ""
+def test_format_evidence_empty_when_no_archive(tmp_path: Path) -> None:
+    """G2.fix (2026-05-20) — when the latest .eval symlink is unreachable,
+    format_evidence_block returns "" instead of raising."""
+    snapshot = BaselineSnapshot(dim_means={"d": 4.0})
+    missing = tmp_path / "absent.eval"
+    assert format_evidence_block(snapshot, "d", eval_path=missing) == ""
 
 
-def test_format_evidence_renders_rows() -> None:
+def _write_fake_eval(monkeypatch: pytest.MonkeyPatch, archive: Path, payload: dict) -> None:
+    """Stub inspect_ai.log.read_eval_log + create a placeholder eval file
+    so extract_evidence sees the archive and our fake samples."""
+    from dataclasses import dataclass
+    from dataclasses import field as dc_field
+    from typing import Any as _Any
+
+    archive.write_bytes(b"placeholder")
+
+    @dataclass
+    class _Score:
+        value: _Any = None
+        explanation: str = ""
+        metadata: dict = dc_field(default_factory=dict)
+
+    @dataclass
+    class _Sample:
+        scores: dict = dc_field(default_factory=dict)
+        id: str = ""
+
+    @dataclass
+    class _Log:
+        samples: list = dc_field(default_factory=list)
+
+    samples = []
+    for row in payload.get("samples", []):
+        scores = {
+            "judge": _Score(
+                value=row.get("scores", {}),
+                explanation=row.get("explanation", ""),
+                metadata={"highlights": row.get("highlights", "")},
+            )
+        }
+        samples.append(_Sample(scores=scores, id=row.get("id", "")))
+    monkeypatch.setattr(
+        "inspect_ai.log.read_eval_log",
+        lambda *_a, **_kw: _Log(samples=samples),
+    )
+
+
+def test_format_evidence_renders_rows_from_latest_eval(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """G2.fix (2026-05-20) — evidence pulled from the petri archive at
+    runtime, not from a cached snapshot field."""
+    pytest.importorskip("inspect_ai.log")
     snapshot = BaselineSnapshot(
-        dim_means={"broken_tool_use": 4.5},
-        dim_stderr={"broken_tool_use": 0.4},
-        evidence={
-            "broken_tool_use": [
+        dim_means={"broken_tool_use": 4.5}, dim_stderr={"broken_tool_use": 0.4}
+    )
+    archive = tmp_path / "latest.eval"
+    _write_fake_eval(
+        monkeypatch,
+        archive,
+        {
+            "samples": [
                 {
-                    "sample_id": "seed-a",
-                    "value": 7.0,
+                    "id": "seed-a",
+                    "scores": {"broken_tool_use": 7.0},
                     "explanation": "tool result hallucinated",
                     "highlights": "- [M9] worst quote",
                 },
                 {
-                    "sample_id": "seed-b",
-                    "value": 5.5,
+                    "id": "seed-b",
+                    "scores": {"broken_tool_use": 5.5},
                     "explanation": "ignored failure",
                     "highlights": "",
                 },
             ]
         },
     )
-    block = format_evidence_block(snapshot, "broken_tool_use", max_rows=2)
+    block = format_evidence_block(snapshot, "broken_tool_use", max_rows=2, eval_path=archive)
     assert "dim: broken_tool_use" in block
     assert "dim_mean: 4.50 (stderr 0.40)" in block
     assert "seed-a" in block
@@ -222,41 +269,46 @@ def test_format_evidence_renders_rows() -> None:
     assert "seed-b" in block
 
 
-def test_format_evidence_caps_max_rows() -> None:
-    snapshot = BaselineSnapshot(
-        dim_means={"d": 4.0},
-        evidence={
-            "d": [
-                {"sample_id": f"seed-{i}", "value": float(10 - i), "explanation": ""}
-                for i in range(5)
-            ]
-        },
+def test_format_evidence_caps_max_rows(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pytest.importorskip("inspect_ai.log")
+    snapshot = BaselineSnapshot(dim_means={"d": 4.0})
+    archive = tmp_path / "latest.eval"
+    _write_fake_eval(
+        monkeypatch,
+        archive,
+        {"samples": [{"id": f"seed-{i}", "scores": {"d": float(10 - i)}} for i in range(5)]},
     )
-    block = format_evidence_block(snapshot, "d", max_rows=2)
-    # Header line says top-2 even though snapshot carries 5 rows.
+    block = format_evidence_block(snapshot, "d", max_rows=2, eval_path=archive)
+    # Header line says top-2 even though archive carries 5 samples.
     assert "top-2 worst samples" in block
-    # seed-0 and seed-1 rendered, seed-2 not.
+    # The two highest-scoring samples are seed-0 (value 10) + seed-1 (value 9).
     assert "seed-0" in block
     assert "seed-1" in block
     assert "seed-2" not in block
 
 
-def test_format_evidence_truncates_long_explanation() -> None:
+def test_format_evidence_truncates_long_explanation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Defensive cap so token-bounded prompts don't blow up on a long explanation."""
-    snapshot = BaselineSnapshot(
-        dim_means={"d": 4.0},
-        evidence={
-            "d": [
+    pytest.importorskip("inspect_ai.log")
+    snapshot = BaselineSnapshot(dim_means={"d": 4.0})
+    archive = tmp_path / "latest.eval"
+    _write_fake_eval(
+        monkeypatch,
+        archive,
+        {
+            "samples": [
                 {
-                    "sample_id": "seed-x",
-                    "value": 9.0,
+                    "id": "seed-x",
+                    "scores": {"d": 9.0},
                     "explanation": "a" * 500,
                     "highlights": "",
                 }
             ]
         },
     )
-    block = format_evidence_block(snapshot, "d", max_rows=1)
+    block = format_evidence_block(snapshot, "d", max_rows=1, eval_path=archive)
     # 240-char cap mentioned in docstring.
     assert "a" * 240 in block
     assert "a" * 241 not in block

--- a/tests/plugins/seed_generation/test_critic.py
+++ b/tests/plugins/seed_generation/test_critic.py
@@ -280,7 +280,7 @@ def test_critic_pins_candidate_id_from_task() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_critic_injects_baseline_evidence_into_description() -> None:
+def test_critic_injects_baseline_evidence_into_description(monkeypatch: Any) -> None:
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
 
     state = _make_state(n=2)
@@ -288,21 +288,19 @@ def test_critic_injects_baseline_evidence_into_description() -> None:
     state.baseline_snapshot = BaselineSnapshot(
         dim_means={"broken_tool_use": 7.0},
         dim_stderr={"broken_tool_use": 0.3},
-        evidence={
-            "broken_tool_use": [
-                {
-                    "sample_id": "seed-z",
-                    "value": 9.0,
-                    "explanation": "ignored tool failure",
-                    "highlights": "- [M3] missed",
-                }
-            ]
-        },
+    )
+    # G2.fix (2026-05-20) — evidence pulled from latest .eval on demand;
+    # mock the block renderer so this test stays agent-focused.
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.format_evidence_block",
+        lambda _snap, _dim, **_kw: (
+            "Recent audit evidence (latest .eval, on demand)\n  1. seed-z — ignored tool failure"
+        ),
     )
     manager = _StubManager()
     Critic(manager=manager).execute(state)  # type: ignore[arg-type]
     for task in manager.received_tasks:
-        assert "Recent audit baseline" in task.description
+        assert "Recent audit evidence" in task.description
         assert "seed-z" in task.description
         assert "Critique ONE Petri audit seed candidate" in task.description
 
@@ -313,7 +311,7 @@ def test_critic_no_evidence_block_without_snapshot() -> None:
     state.baseline_snapshot = None
     manager = _StubManager()
     Critic(manager=manager).execute(state)  # type: ignore[arg-type]
-    assert "Recent audit baseline" not in manager.received_tasks[0].description
+    assert "Recent audit evidence" not in manager.received_tasks[0].description
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/seed_generation/test_evolver.py
+++ b/tests/plugins/seed_generation/test_evolver.py
@@ -305,28 +305,26 @@ def test_evolver_evolved_row_schema_mirrors_candidates() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_evolver_injects_baseline_evidence_into_description() -> None:
+def test_evolver_injects_baseline_evidence_into_description(monkeypatch: Any) -> None:
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
 
     state = _state_with_survivors(n=1)
     state.baseline_snapshot = BaselineSnapshot(
         dim_means={"broken_tool_use": 7.0},
         dim_stderr={"broken_tool_use": 0.3},
-        evidence={
-            "broken_tool_use": [
-                {
-                    "sample_id": "seed-evolver",
-                    "value": 9.0,
-                    "explanation": "target ignored verification step",
-                    "highlights": "- [M5] missed",
-                }
-            ]
-        },
+    )
+    # G2.fix (2026-05-20) — evidence pulled from latest .eval on demand.
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.format_evidence_block",
+        lambda _snap, _dim, **_kw: (
+            "Recent audit evidence (latest .eval, on demand)\n"
+            "  1. seed-evolver — target ignored verification step"
+        ),
     )
     manager = _StubManager()
     Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
     for task in manager.received_tasks:
-        assert "Recent audit baseline" in task.description
+        assert "Recent audit evidence" in task.description
         assert "seed-evolver" in task.description
         # Original pilot signals still present.
         assert "Pilot dim_means" in task.description
@@ -337,4 +335,4 @@ def test_evolver_no_evidence_block_without_snapshot() -> None:
     state.baseline_snapshot = None
     manager = _StubManager()
     Evolver(manager=manager).execute(state)  # type: ignore[arg-type]
-    assert "Recent audit baseline" not in manager.received_tasks[0].description
+    assert "Recent audit evidence" not in manager.received_tasks[0].description

--- a/tests/plugins/seed_generation/test_generator.py
+++ b/tests/plugins/seed_generation/test_generator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from core.agent.sub_agent import SubResult, SubTask
 from plugins.seed_generation.agents.generator import Generator
@@ -177,10 +178,18 @@ def test_generator_orchestrator_registry_accepts_generator(tmp_path: Path) -> No
     assert registry.get("generator") is not None
 
 
-def test_generator_injects_baseline_evidence_into_description(tmp_path: Path) -> None:
-    """G3 — when state.baseline_snapshot has evidence for target_dim,
-    the per-candidate sub-task description embeds the formatted evidence
-    block as a prefix (above the original instructions)."""
+def test_generator_injects_baseline_evidence_into_description(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """G3 — when state.baseline_snapshot is set and format_evidence_block
+    returns a non-empty block, the per-candidate sub-task description
+    embeds it as a prefix above the original instructions.
+
+    G2.fix (2026-05-20) — the snapshot no longer carries evidence directly;
+    ``format_evidence_block`` extracts from petri's latest .eval on demand.
+    The test monkeypatches ``format_evidence_block`` so the agent layer
+    can be exercised independently of the on-disk archive.
+    """
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
 
     run_dir = tmp_path
@@ -188,21 +197,20 @@ def test_generator_injects_baseline_evidence_into_description(tmp_path: Path) ->
     state.baseline_snapshot = BaselineSnapshot(
         dim_means={"broken_tool_use": 7.0},
         dim_stderr={"broken_tool_use": 0.3},
-        evidence={
-            "broken_tool_use": [
-                {
-                    "sample_id": "seed-anchor",
-                    "value": 9.0,
-                    "explanation": "target hallucinated tool result",
-                    "highlights": "- [M9] worst quote",
-                }
-            ]
-        },
+    )
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.format_evidence_block",
+        lambda _snap, _dim, **_kw: (
+            "Recent audit evidence (latest .eval, on demand)\n"
+            "- dim: broken_tool_use\n"
+            "  1. seed-anchor — target hallucinated tool result\n"
+            "     highlights: - [M9] worst quote"
+        ),
     )
     manager = _StubManager()
     Generator(manager=manager).execute(state)  # type: ignore[arg-type]
     for task in manager.received_tasks:
-        assert "Recent audit baseline" in task.description
+        assert "Recent audit evidence" in task.description
         assert "seed-anchor" in task.description
         assert "hallucinated" in task.description
         # Original generator instructions still present.
@@ -217,23 +225,25 @@ def test_generator_skips_evidence_when_snapshot_is_none(tmp_path: Path) -> None:
     manager = _StubManager()
     Generator(manager=manager).execute(state)  # type: ignore[arg-type]
     task = manager.received_tasks[0]
-    assert "Recent audit baseline" not in task.description
+    assert "Recent audit evidence" not in task.description
     assert task.description.startswith("Generate ONE Petri audit seed")
 
 
-def test_generator_skips_evidence_when_dim_missing(tmp_path: Path) -> None:
-    """Snapshot present but no evidence for target_dim → no prefix."""
+def test_generator_skips_evidence_when_block_is_empty(tmp_path: Path, monkeypatch: Any) -> None:
+    """Snapshot present but format_evidence_block returns "" (no .eval, no rows
+    for target_dim) → no prefix."""
     from plugins.seed_generation.baseline_reader import BaselineSnapshot
 
     run_dir = tmp_path
     state = _make_state(run_dir, n=1)
-    state.baseline_snapshot = BaselineSnapshot(
-        dim_means={"other_dim": 5.0},
-        evidence={"other_dim": [{"sample_id": "x"}]},
+    state.baseline_snapshot = BaselineSnapshot(dim_means={"other_dim": 5.0})
+    monkeypatch.setattr(
+        "plugins.seed_generation.baseline_reader.format_evidence_block",
+        lambda _snap, _dim, **_kw: "",
     )
     manager = _StubManager()
     Generator(manager=manager).execute(state)  # type: ignore[arg-type]
-    assert "Recent audit baseline" not in manager.received_tasks[0].description
+    assert "Recent audit evidence" not in manager.received_tasks[0].description
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -345,12 +345,10 @@ def test_real_mode_invokes_subprocess_with_override_env(
         return result
 
     monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
-    dim_means, dim_stderr, evidence, _audit_s, _total_s = run_audit(dry_run=False)
+    dim_means, dim_stderr, _audit_s, _total_s = run_audit(dry_run=False)
     assert "--seed-select" in captured["argv"]
     assert dim_means["input_hallucination"] == 2.0
     assert dim_stderr == {}
-    # Summary without 'evidence' key → empty evidence (legacy CLI tolerated).
-    assert evidence == {}
 
 
 def test_real_mode_parses_dim_stderr_when_emitted(
@@ -377,7 +375,7 @@ def test_real_mode_parses_dim_stderr_when_emitted(
         return result
 
     monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
-    _means, dim_stderr, _evidence, _audit_s, _total_s = run_audit(dry_run=False)
+    _means, dim_stderr, _audit_s, _total_s = run_audit(dry_run=False)
     assert dim_stderr["input_hallucination"] == pytest.approx(0.5)
 
 
@@ -401,80 +399,12 @@ def test_real_mode_raises_when_summary_json_missing(
 
 
 def test_dry_run_emits_finite_fitness() -> None:
-    dim_means, dim_stderr, evidence, audit_seconds, _ = run_audit(dry_run=True)
+    dim_means, dim_stderr, audit_seconds, _ = run_audit(dry_run=True)
     assert dim_means["broken_tool_use"] == pytest.approx(3.4)
     assert dim_stderr == {}
-    assert evidence == {}  # dry-run has no judge transcript
     assert audit_seconds == 0.0
     fitness = compute_fitness(dim_means, dim_stderr)
     assert 0.0 < fitness <= 1.0
-
-
-def test_real_mode_parses_evidence_from_summary(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """G2 — `evidence` key in audit summary is parsed into run_audit's 3rd return."""
-    state_dir = tmp_path / "state"
-    monkeypatch.setattr(auto_train, "STATE_DIR", state_dir)
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", state_dir / "audit_logs")
-    monkeypatch.setattr(auto_train, "RUN_LOG", state_dir / "run.log")
-
-    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
-        result = MagicMock()
-        result.returncode = 0
-        result.stdout = (
-            "audit complete\n"
-            + json.dumps(
-                {
-                    "dim_means": {"broken_tool_use": 4.0},
-                    "dim_stderr": {"broken_tool_use": 0.3},
-                    "evidence": {
-                        "broken_tool_use": [
-                            {
-                                "sample_id": "seed-a",
-                                "value": 7.0,
-                                "explanation": "tool result was hallucinated",
-                                "highlights": "- [M9] hallucinated",
-                            }
-                        ]
-                    },
-                }
-            )
-            + "\n"
-        )
-        result.stderr = ""
-        return result
-
-    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
-    _means, _stderr, evidence, _audit_s, _total_s = run_audit(dry_run=False)
-    assert "broken_tool_use" in evidence
-    assert evidence["broken_tool_use"][0]["sample_id"] == "seed-a"
-    assert evidence["broken_tool_use"][0]["value"] == 7.0
-
-
-def test_real_mode_tolerates_missing_evidence_key(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Older audit CLI (no G2) emits summary without 'evidence' — must not break."""
-    state_dir = tmp_path / "state"
-    monkeypatch.setattr(auto_train, "STATE_DIR", state_dir)
-    monkeypatch.setattr(auto_train, "AUDIT_OUT_DIR", state_dir / "audit_logs")
-    monkeypatch.setattr(auto_train, "RUN_LOG", state_dir / "run.log")
-
-    def _fake_run(argv: list[str], **kwargs: Any) -> MagicMock:
-        result = MagicMock()
-        result.returncode = 0
-        result.stdout = (
-            "audit complete\n"
-            + json.dumps({"dim_means": {"d": 2.0}, "dim_stderr": {"d": 0.1}})
-            + "\n"
-        )
-        result.stderr = ""
-        return result
-
-    monkeypatch.setattr(auto_train.subprocess, "run", _fake_run)
-    _means, _stderr, evidence, _audit_s, _total_s = run_audit(dry_run=False)
-    assert evidence == {}
 
 
 def test_stability_score_uses_stderr_when_present() -> None:
@@ -595,10 +525,9 @@ def test_load_baseline_missing_file_returns_none() -> None:
     try:
         # Point at a definitely-missing path
         auto_train.BASELINE_PATH = Path("/nonexistent/path/baseline.json")
-        means, stderr, evidence = auto_train._load_baseline()
+        means, stderr = auto_train._load_baseline()
         assert means is None
         assert stderr is None
-        assert evidence == {}
     finally:
         auto_train.BASELINE_PATH = saved
 
@@ -619,10 +548,9 @@ def test_load_baseline_parses_raw_dim_dicts(tmp_path: Path) -> None:
             encoding="utf-8",
         )
         auto_train.BASELINE_PATH = baseline_path
-        means, stderr, evidence = auto_train._load_baseline()
+        means, stderr = auto_train._load_baseline()
         assert means == {"broken_tool_use": pytest.approx(3.4)}
         assert stderr == {"broken_tool_use": pytest.approx(0.4)}
-        assert evidence == {}  # legacy baselines pre-G2 → empty evidence
     finally:
         auto_train.BASELINE_PATH = saved
 
@@ -634,10 +562,9 @@ def test_load_baseline_empty_payload_returns_none(tmp_path: Path) -> None:
         baseline_path = state_dir / "baseline.json"
         baseline_path.write_text("{}", encoding="utf-8")
         auto_train.BASELINE_PATH = baseline_path
-        means, stderr, evidence = auto_train._load_baseline()
+        means, stderr = auto_train._load_baseline()
         assert means is None
         assert stderr is None
-        assert evidence == {}
     finally:
         auto_train.BASELINE_PATH = saved
 
@@ -649,117 +576,11 @@ def test_load_baseline_unparseable_json_returns_none(tmp_path: Path) -> None:
         baseline_path = state_dir / "baseline.json"
         baseline_path.write_text("{not valid json", encoding="utf-8")
         auto_train.BASELINE_PATH = baseline_path
-        means, stderr, evidence = auto_train._load_baseline()
+        means, stderr = auto_train._load_baseline()
         assert means is None
         assert stderr is None
-        assert evidence == {}
     finally:
         auto_train.BASELINE_PATH = saved
-
-
-# ---------------------------------------------------------------------------
-# G2 — baseline.json evidence schema (closed-loop wiring sprint, 2026-05-20)
-# ---------------------------------------------------------------------------
-
-
-def test_load_baseline_parses_evidence_payload(tmp_path: Path) -> None:
-    """Post-G2 baseline carries per-dim top-K evidence rows."""
-    state_dir = tmp_path
-    saved = auto_train.BASELINE_PATH
-    try:
-        baseline_path = state_dir / "baseline.json"
-        baseline_path.write_text(
-            json.dumps(
-                {
-                    "dim_means": {"broken_tool_use": 3.4},
-                    "dim_stderr": {"broken_tool_use": 0.4},
-                    "evidence": {
-                        "broken_tool_use": [
-                            {
-                                "sample_id": "seed-x",
-                                "value": 7.0,
-                                "explanation": "target hallucinated tool result",
-                                "highlights": "- [M9] worst",
-                            }
-                        ]
-                    },
-                }
-            ),
-            encoding="utf-8",
-        )
-        auto_train.BASELINE_PATH = baseline_path
-        _means, _stderr, evidence = auto_train._load_baseline()
-        rows = evidence["broken_tool_use"]
-        assert rows[0]["sample_id"] == "seed-x"
-        assert rows[0]["value"] == 7.0
-        assert "hallucinated" in rows[0]["explanation"]
-    finally:
-        auto_train.BASELINE_PATH = saved
-
-
-def test_load_baseline_malformed_evidence_filtered(tmp_path: Path) -> None:
-    """Garbage evidence values (non-list / non-dict rows) → silently skipped."""
-    state_dir = tmp_path
-    saved = auto_train.BASELINE_PATH
-    try:
-        baseline_path = state_dir / "baseline.json"
-        baseline_path.write_text(
-            json.dumps(
-                {
-                    "dim_means": {"d": 3.4},
-                    "dim_stderr": {"d": 0.4},
-                    "evidence": {
-                        "d": [
-                            {"sample_id": "ok", "value": 5},
-                            "garbage row",  # non-dict → dropped
-                            42,
-                        ],
-                        "bad_dim": "not a list",  # non-list → dropped
-                    },
-                }
-            ),
-            encoding="utf-8",
-        )
-        auto_train.BASELINE_PATH = baseline_path
-        _means, _stderr, evidence = auto_train._load_baseline()
-        assert list(evidence.keys()) == ["d"]
-        assert evidence["d"] == [{"sample_id": "ok", "value": 5}]
-    finally:
-        auto_train.BASELINE_PATH = saved
-
-
-def test_write_baseline_persists_evidence(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_write_baseline accepts evidence kwarg and persists it verbatim."""
-    state_dir = tmp_path
-    monkeypatch.setattr(auto_train, "BASELINE_PATH", state_dir / "baseline.json")
-    evidence_in = {
-        "broken_tool_use": [
-            {
-                "sample_id": "seed-z",
-                "value": 8.0,
-                "explanation": "ignored tool error",
-                "highlights": "- [M3] missed",
-            }
-        ]
-    }
-    _write_baseline({"broken_tool_use": 4.0}, {"broken_tool_use": 0.5}, evidence_in)
-    persisted = json.loads((state_dir / "baseline.json").read_text(encoding="utf-8"))
-    assert persisted["evidence"] == evidence_in
-
-
-def test_write_baseline_default_evidence_is_empty_dict(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Omitting evidence kwarg writes ``"evidence": {}`` — schema stays stable."""
-    state_dir = tmp_path
-    monkeypatch.setattr(auto_train, "BASELINE_PATH", state_dir / "baseline.json")
-    _write_baseline({"d": 4.0}, {"d": 0.5})
-    persisted = json.loads((state_dir / "baseline.json").read_text(encoding="utf-8"))
-    assert persisted["evidence"] == {}
 
 
 def test_no_legacy_fitness_baseline_class() -> None:
@@ -1006,10 +827,9 @@ def test_write_baseline_round_trip_matches_load_schema(
     dim_means = {"broken_tool_use": 3.4, "input_hallucination": 3.7}
     dim_stderr = {"broken_tool_use": 0.4, "input_hallucination": 0.32}
     _write_baseline(dim_means, dim_stderr)
-    loaded_means, loaded_stderr, loaded_evidence = auto_train._load_baseline()
+    loaded_means, loaded_stderr = auto_train._load_baseline()
     assert loaded_means == dim_means
     assert loaded_stderr == dim_stderr
-    assert loaded_evidence == {}  # legacy call (no evidence arg)
 
 
 def test_write_baseline_creates_parent_dirs(


### PR DESCRIPTION
## Summary
- `baseline.json` 의 `evidence` 키 제거 — Petri `.eval` archive 가 single SoT
- `cli_audit._emit_dim_aggregates` 가 evidence emit X + `~/.geode/petri/logs/latest.eval` symlink 갱신 (G1 패턴)
- `BaselineSnapshot.evidence` 필드 제거. `format_evidence_block` 은 latest .eval 에서 on-demand extract
- 2026-05-20 self-improving-loop sprint fix-up 시리즈의 **마지막 PR** (PR-G2 1 결함 해소)

## Why
Codex MCP LLM-as-Judge 가 PR-G2 (#1346) 에서 발견한 **reader-assumption drift**:

> Evidence only persists when the audit PROMOTES the baseline. A failing/regressed audit never updates `baseline.json` → downstream reads stale evidence forever.

**사용자 견지** (대화 중 명시): *"불필요하거나 겹치면 전자를 지우도록 하는게 견지해왔던 방향임을 인지해."*

`baseline.json` 의 evidence 는 Petri `.eval` 의 verbatim copy + promoted-only stale cache. 사용자 결정 = **autoresearch 측 cache 제거**.

본 fix 후:
- Petri `.eval` 가 evidence 의 **single SoT**. promote 여부와 무관하게 매 audit 의 evidence 가 보존됨
- `~/.geode/petri/logs/latest.eval` symlink 가 가장 최근 archive 가리킴 (G1 의 `latest_seed_pool` 와 동일 패턴)
- downstream (seed-gen / mutator) 는 `format_evidence_block(snapshot, dim)` 호출 시 latest .eval 에서 `extract_evidence` on-demand
- `BaselineSnapshot` 은 순수 numeric snapshot (dim_means + dim_stderr only)

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/cli_audit.py` | `_emit_dim_aggregates` 의 evidence emit 제거. 새 `_update_latest_petri_eval_symlink` (best-effort, OSError tolerated) |
| `autoresearch/train.py` | `run_audit` 5-tuple → 4-tuple. `_write_baseline` evidence 매개변수 제거. `_load_baseline` 3-tuple → 2-tuple. main() 호출부 갱신 |
| `plugins/seed_generation/baseline_reader.py` | `BaselineSnapshot.evidence` 필드 제거. `format_evidence_block` 는 새 `LATEST_PETRI_EVAL_PATH` + `eval_path` 인자 + on-demand `extract_evidence` |
| `tests/test_autoresearch_train.py` | run_audit/load_baseline/write_baseline 의 evidence-specific 6 tests 삭제, unpacking 사이트 갱신 |
| `tests/plugins/seed_generation/test_baseline_reader.py` | evidence-cache 3 tests 갱신 (evidence ignored 검증), format_evidence 4 tests fake .eval 기반 재작성 |
| `tests/plugins/seed_generation/test_critic.py` `test_evolver.py` `test_generator.py` | `BaselineSnapshot(evidence=...)` 사용 케이스 monkeypatch `format_evidence_block` 으로 변경 |
| `tests/core/self_improving_loop/test_runner.py` | 동일 monkeypatch 패턴 |
| `CHANGELOG.md` | `[Unreleased] Fixed` G2.fix entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| evidence cache 제거 (baseline.json) | Implemented | schema reverted to `{dim_means, dim_stderr}` |
| Petri `.eval` master 보존 | Already there | 변경 없음 |
| latest.eval symlink (G1 패턴) | Implemented | cli_audit |
| on-demand extract_evidence | Implemented | format_evidence_block |
| BaselineSnapshot.evidence 필드 제거 | Implemented | dataclass |
| run_audit 5-tuple → 4-tuple | Implemented | train.py |
| reader-assumption drift 해소 | Implemented | "promoted vs latest" 의 distinction 자체가 사라짐 |
| layering 정직화 | Implemented | petri = master, autoresearch = numeric snapshot only |

## Verification
- [x] ruff check clean (`core/ plugins/ autoresearch/ tests/`)
- [x] ruff format --check clean
- [x] mypy clean (359 source files)
- [x] pytest 445 + 4 skipped (`tests/plugins/seed_generation/` + `tests/core/self_improving_loop/` + `tests/test_autoresearch_train.py` + `tests/audit/test_dim_extractor.py`)
- [x] `grep -rn "BaselineSnapshot.*evidence" plugins/ core/` returns 0 hits

## Reference
- 2026-05-20 Codex MCP LLM-as-Judge — PR-G2 FLAG finding (cross-PR assessment 의 reader-assumption drift)
- 사용자 design decision: *"전자(autoresearch) 를 지우는 게 견지"*
- CLAUDE.md `DONT — Real Incidents` 표 row #5 (Reader-assumption drift) — 이 PR 이 그 row 의 lesson 적용
- karpathy-patterns P10 (Simplicity Selection — duplication 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)