### PR TITLE
PR-Π3 — Proximity embedding conditions on research goal (Co-Scientist parity P0-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,27 @@ functional change.
 
 ### Added
 
+- **PR-Π3 — Proximity embedding conditions on the research goal
+  (`state.target_dim`).** Closes the third P0 gap from the
+  Co-Scientist ↔ GEODE proximity-agent comparison; completes the
+  3-PR proximity sprint (Π1 graph + Π2 partial-survive + Π3
+  goal-conditioning). `_embedding_track` now accepts a
+  `target_dim` kwarg; when non-empty, every candidate / pool text
+  is prefixed with `[goal: <dim>]\n` before the embedding call so
+  the same candidate body against two different research goals
+  produces different vectors. `Proximity.execute` forwards
+  `state.target_dim`. Backwards-compatible — empty `target_dim`
+  (legacy bootstrap path) returns the raw text unchanged; every
+  pre-Π3 call site behaves byte-identically. The lexical and role
+  tracks stay goal-agnostic (role already encodes the dim;
+  5-gram surface similarity isn't goal-sensitive). Matches
+  Co-Scientist §3.3.4: "similarity ... taking into account the
+  specific research goal". 6 new tests cover the helper
+  `_goal_condition` (empty / non-empty), the `_embedding_track`
+  forwarding (prefix attached / no prefix when empty), and the
+  end-to-end `execute` path (`state.target_dim` reaches the
+  embedding inputs / `state.target_dim = ""` legacy parity).
+
 - **PR-Π2 — Proximity `all_duplicates` partial-survive fallback (was: hard
   abort).** Closes the second P0 gap from the Co-Scientist ↔ GEODE
   proximity-agent comparison. Pre-Π2 the `Proximity.execute` returned

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -127,7 +127,16 @@ class Proximity(BaseSeedAgent):
         pool_texts = self._load_pool_texts(state)
 
         # 3. Compute per-track duplicate votes + pair-wise similarity scores.
-        embed_dupes, embed_scores = self._embedding_track(candidate_texts, pool_texts)
+        # PR-Π3 — the embedding track conditions on ``state.target_dim`` so
+        # the same candidate text against two different research goals
+        # produces different vectors. Co-Scientist §3.3.4 calls this
+        # "calculates similarity ... taking into account the specific
+        # research goal". Lexical / role tracks stay goal-agnostic — role
+        # already encodes the dim, and lexical 5-gram similarity is
+        # surface-form only.
+        embed_dupes, embed_scores = self._embedding_track(
+            candidate_texts, pool_texts, target_dim=state.target_dim
+        )
         lexical_dupes, lexical_scores = self._lexical_track(candidate_texts, pool_texts)
         role_dupes = self._role_track(state)
 
@@ -288,6 +297,8 @@ class Proximity(BaseSeedAgent):
         self,
         candidate_texts: dict[str, str],
         pool_texts: list[str],
+        *,
+        target_dim: str = "",
     ) -> tuple[set[str], dict[tuple[str, str], float]]:
         """Mark candidates whose embedding cosine vs sibling/pool ≥ 0.85.
 
@@ -299,13 +310,25 @@ class Proximity(BaseSeedAgent):
         are not in the graph since the Ranker only ever schedules
         candidate-vs-candidate matches.
 
+        PR-Π3 — ``target_dim`` is prepended as ``[goal: <dim>] \\n`` to
+        every embedding input when non-empty. Co-Scientist §3.3.4
+        specifies similarity should "take into account the specific
+        research goal"; the prefix conditions the embedding output so
+        the same candidate text against two different research goals
+        produces different vectors. When ``target_dim`` is empty (legacy
+        call sites or tests that don't populate ``state.target_dim``)
+        the prefix is dropped and behavior is byte-identical to the
+        pre-Π3 path.
+
         On embedding-tool failure: both return values are empty (caller
         falls back to the 2-track lexical + role dedup vote).
         """
         from core.tools.text_embed import cosine_similarity, embed_texts
 
         cids = list(candidate_texts)
-        all_texts = [candidate_texts[c] for c in cids] + pool_texts
+        cand_inputs = [_goal_condition(candidate_texts[c], target_dim) for c in cids]
+        pool_inputs = [_goal_condition(t, target_dim) for t in pool_texts]
+        all_texts = cand_inputs + pool_inputs
         try:
             vectors = embed_texts(all_texts, client=self._embed_client)
         except Exception:
@@ -447,6 +470,22 @@ class Proximity(BaseSeedAgent):
 # ────────────────────────────────────────────────────────────────────────
 # Shared helpers — module-level so tests can import directly
 # ────────────────────────────────────────────────────────────────────────
+
+
+def _goal_condition(text: str, target_dim: str) -> str:
+    """Prepend a research-goal prefix when ``target_dim`` is non-empty.
+
+    PR-Π3 — Co-Scientist §3.3.4 requires similarity to be "taking into
+    account the specific research goal". For GEODE the goal is the
+    Petri target dim that the audit is being engineered against
+    (``state.target_dim``); the prefix shifts the embedding output so
+    the same candidate body against two different dims doesn't collapse
+    into the same vector. Empty ``target_dim`` returns the text
+    unchanged — every pre-Π3 call site keeps byte-identical behavior.
+    """
+    if not target_dim:
+        return text
+    return f"[goal: {target_dim}]\n{text}"
 
 
 def _pair_key(a: str, b: str) -> tuple[str, str]:

--- a/tests/plugins/seed_generation/test_proximity.py
+++ b/tests/plugins/seed_generation/test_proximity.py
@@ -20,6 +20,7 @@ from plugins.seed_generation.agents.proximity import (
     LEXICAL_JACCARD_THRESHOLD,
     PARTIAL_SURVIVE_FLOOR,
     Proximity,
+    _goal_condition,
     _jaccard,
     _pair_key,
     _shingles,
@@ -425,6 +426,108 @@ def test_proximity_partial_survive_silent_when_no_journal_scope(
         result = Proximity().execute(state)
     assert result.success
     assert len(state.candidates) == PARTIAL_SURVIVE_FLOOR
+
+
+# ── PR-Π3 — research-goal context inject ──
+
+
+def test_goal_condition_returns_text_unchanged_when_empty_dim() -> None:
+    """Empty ``target_dim`` → no prefix; pre-Π3 byte-identical path."""
+    assert _goal_condition("alpha beta", target_dim="") == "alpha beta"
+    assert _goal_condition("", target_dim="") == ""
+
+
+def test_goal_condition_prepends_goal_prefix_when_dim_provided() -> None:
+    """Non-empty ``target_dim`` → ``[goal: <dim>]\\n<text>`` prefix."""
+    out = _goal_condition("alpha beta", target_dim="broken_tool_use")
+    assert out == "[goal: broken_tool_use]\nalpha beta"
+
+
+def test_embedding_track_passes_goal_prefix_to_embed_texts(tmp_path: Path) -> None:
+    """``_embedding_track`` forwards ``target_dim`` to the embedding call —
+    every input string carries the ``[goal: <dim>]\\n`` prefix."""
+    state = _make_state(tmp_path)
+    state.candidates = [
+        _make_candidate("c1", tmp_path / "c1.md", body="alpha beta"),
+        _make_candidate("c2", tmp_path / "c2.md", body="gamma delta"),
+    ]
+    proximity = Proximity()
+    candidate_texts = proximity._load_candidate_texts(state)
+    captured: dict[str, list[str]] = {}
+
+    def _capture(texts: list[str], *, client: object | None = None) -> list[list[float]]:
+        captured["texts"] = list(texts)
+        return [[1.0, 0.0, 0.0]] * len(texts)
+
+    with patch("core.tools.text_embed.embed_texts", side_effect=_capture):
+        proximity._embedding_track(candidate_texts, [], target_dim="broken_tool_use")
+
+    assert "texts" in captured
+    assert all(t.startswith("[goal: broken_tool_use]\n") for t in captured["texts"])
+
+
+def test_embedding_track_no_prefix_when_target_dim_empty(tmp_path: Path) -> None:
+    """Default (no ``target_dim``) → embed inputs equal raw candidate text."""
+    state = _make_state(tmp_path)
+    state.candidates = [
+        _make_candidate("c1", tmp_path / "c1.md", body="alpha beta"),
+    ]
+    proximity = Proximity()
+    candidate_texts = proximity._load_candidate_texts(state)
+    captured: dict[str, list[str]] = {}
+
+    def _capture(texts: list[str], *, client: object | None = None) -> list[list[float]]:
+        captured["texts"] = list(texts)
+        return [[1.0, 0.0, 0.0]] * len(texts)
+
+    with patch("core.tools.text_embed.embed_texts", side_effect=_capture):
+        proximity._embedding_track(candidate_texts, [], target_dim="")
+
+    assert captured["texts"] == ["alpha beta"]
+
+
+def test_execute_forwards_state_target_dim_to_embedding_track(tmp_path: Path) -> None:
+    """End-to-end — ``state.target_dim`` (set by orchestrator) reaches the
+    embedding inputs as a prefix. Pre-Π3 the dim was a state-only field
+    with no effect on the proximity track."""
+    state = _make_state(tmp_path)
+    # _make_state defaults state.target_dim = "broken_tool_use".
+    state.candidates = [
+        _make_candidate("c1", tmp_path / "c1.md", body="alpha"),
+        _make_candidate("c2", tmp_path / "c2.md", body="alpha"),
+    ]
+    captured: dict[str, list[str]] = {}
+
+    def _capture(texts: list[str], *, client: object | None = None) -> list[list[float]]:
+        captured["texts"] = list(texts)
+        return [[1.0, 0.0, 0.0, 0.0]] * len(texts)
+
+    with patch("core.tools.text_embed.embed_texts", side_effect=_capture):
+        Proximity().execute(state)
+
+    assert "texts" in captured
+    assert all(t.startswith("[goal: broken_tool_use]\n") for t in captured["texts"])
+
+
+def test_execute_no_prefix_when_target_dim_empty(tmp_path: Path) -> None:
+    """``state.target_dim = ""`` (legacy bootstrap path) → embed inputs
+    unchanged. Backwards-compatible — every pre-Π3 call site behaves
+    byte-identically."""
+    state = _make_state(tmp_path)
+    state.target_dim = ""
+    state.candidates = [
+        _make_candidate("c1", tmp_path / "c1.md", body="alpha"),
+    ]
+    captured: dict[str, list[str]] = {}
+
+    def _capture(texts: list[str], *, client: object | None = None) -> list[list[float]]:
+        captured["texts"] = list(texts)
+        return [[1.0, 0.0, 0.0, 0.0]] * len(texts)
+
+    with patch("core.tools.text_embed.embed_texts", side_effect=_capture):
+        Proximity().execute(state)
+
+    assert captured["texts"] == ["alpha"]
 
 
 def test_proximity_pool_dedup_lexical(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `_embedding_track` 가 `target_dim` kwarg 받음. 비어있지 않으면 candidate / pool text 마다 `[goal: <dim>]\n` prefix 붙여 embedding API 호출 → 같은 candidate body 도 research goal 별로 다른 vector 산출.
- `Proximity.execute` 가 `state.target_dim` 을 forward.
- Lexical / role 트랙은 goal-agnostic 유지 (role 은 이미 dim encode, lexical 5-gram 은 surface-form only).
- Backwards-compatible — `target_dim=""` → prefix 없음 → byte-identical legacy path.

## Why
Pre-Π3 의 `_embedding_track` 는 raw candidate text 만 embed → 같은 body 가 다른 research goal 일 때도 동일 vector. Co-Scientist §3.3.4 의 "similarity ... taking into account the specific research goal" 요건 미충족. 3-PR proximity 스프린트 (Π1 graph + Π2 partial-survive + Π3 goal-condition) 의 마지막 P0.

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/agents/proximity.py` | `_embedding_track` 에 `target_dim` kwarg 추가; `_goal_condition` helper 추가 (`[goal: <dim>]\n` prefix); `execute` 가 `state.target_dim` 을 forward. |
| `tests/plugins/seed_generation/test_proximity.py` | 6 새 tests — `_goal_condition` unit (empty / non-empty) + `_embedding_track` forwarding (prefix / no-prefix) + `execute` end-to-end (target_dim 있음 / 없음). |
| `CHANGELOG.md` | `[Unreleased] Added` 에 PR-Π3 entry. |

## GAP Audit (P0-3 closure)
| 항목 | Pre-Π3 | Post-Π3 |
|------|--------|---------|
| Embedding goal-conditioning | absent | `[goal: <dim>]\n` prefix 적용 |
| 같은 body, 다른 dim → 동일 vector | yes (false positive dedup 위험) | no (vector 분리) |
| Lexical / role 트랙 영향 | n/a | goal-agnostic 유지 |
| Backwards compat | n/a | empty dim → byte-identical |
| Co-Scientist §3.3.4 parity | gap | closure (P0 3건 모두 마감) |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] `uv run mypy core/ plugins/ autoresearch/` — 0 issues (359 source files)
- [x] `uv run lint-imports` — 4 contracts kept
- [x] `uv run pytest tests/ -m \"not live\"` — **5051 passed**, 34 skipped (+6 new)
- [x] Backwards compatible — `target_dim=\"\"` (default) → 사전 Π3 동작과 byte-identical

## Reference
- Co-Scientist paper §3.3.4: https://arxiv.org/abs/2502.18864
- 2026-05-20 세션 Co-Scientist ↔ GEODE Proximity GAP 분석 P0-3 (마지막).
- 후속 P1 (별도 PR): percentile-based 임계 / soft weighted dedup vote / cluster-aware diversity floor / scientist UX / async refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)