### PR TITLE
feat(cli): L5 — /login help carries verdict legend + /login health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,27 @@ functional change.
 
 ### Added
 
+- **L5 — ``/login help`` carries the eligibility-verdict legend; new
+  ``/login health [<profile>]`` walks the verdict per profile with an
+  actionable suggestion.** Closes the governance gap noted in
+  ``docs/research/model-ux-governance.md`` (L5: *Help text 에
+  eligibility verdict 부재*). Pre-fix the ``/login`` status dashboard
+  already rendered each profile with an inline reject badge (cooldown
+  / expired / disabled / missing_key / provider_mismatch / ok), but
+  the reason codes were opaque to first-time readers and there was no
+  per-profile health view. ``_login_help`` now documents every
+  ``ProfileRejectReason`` code; ``cmd_login`` routes the new
+  ``health`` subcommand to ``_login_health``, which walks
+  ``ProfileStore.evaluate_eligibility`` and prints, per profile, the
+  badge (``ok`` / reason_code), the detail string, and an actionable
+  ``→ suggestion`` row pulled from the ``_HEALTH_SUGGESTIONS`` table
+  ("re-run ``claude``", "wait <cooldown>", …). ``/login health
+  <unknown>`` warns + points back at bare ``/login``; the empty-store
+  path prints the "no profiles" hint without crashing. 7 new tests in
+  ``tests/test_login_health.py`` pin the legend, the router, the
+  no-arg / narrowed / unknown / empty-store cases, and the suggestion
+  surfacing.
+
 - **PR-Π3 — Proximity embedding conditions on the research goal
   (`state.target_dim`).** Closes the third P0 gap from the
   Co-Scientist ↔ GEODE proximity-agent comparison; completes the

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -65,6 +65,7 @@ def cmd_login(args: str) -> None:
         /login remove <plan>
         /login route <model> <plan> [<plan>...]
         /login quota          — per-plan usage breakdown
+        /login health [<profile>] — eligibility verdict + actionable suggestion
         /login status         — legacy alias of bare /login
     """
     from core.cli import commands as _pkg
@@ -107,6 +108,9 @@ def cmd_login(args: str) -> None:
         return
     if sub == "quota":
         _login_quota()
+        return
+    if sub == "health":
+        _login_health(rest)
         return
     if sub == "source":
         _login_source(rest)
@@ -194,6 +198,17 @@ def _login_help() -> None:
         "  [label]/login route[/label] <model> <plan>… Bind a model to plan(s) in priority order\n"
         "  [label]/login remove[/label] <plan>         Delete a plan\n"
         "  [label]/login quota[/label]                 Per-plan quota / usage\n"
+        "  [label]/login health[/label] [<profile>]    Eligibility verdict per profile\n"
+        "\n"
+        "  [muted]Eligibility verdicts (shown next to each profile in /login):[/muted]\n"
+        "  [muted]  ok               — profile passes every check, ready to dispatch[/muted]\n"
+        "  [muted]  missing_key      — key/token field is empty; rerun add or set-key[/muted]\n"
+        "  [muted]  expired          — OAuth token past expires_at; refresh via the[/muted]\n"
+        "  [muted]                     owning CLI (`claude` / `codex`) and rerun /login[/muted]\n"
+        "  [muted]  cooling_down     — consecutive failures tripped backoff; wait for[/muted]\n"
+        "  [muted]                     cooldown or run /login health <profile> for ETA[/muted]\n"
+        "  [muted]  disabled         — manually disabled (`/login remove` to delete)[/muted]\n"
+        "  [muted]  provider_mismatch — not for the queried provider (info only)[/muted]\n"
     )
 
 
@@ -911,4 +926,83 @@ def _login_quota() -> None:
                 else ""
             )
         )
+    _pkg.console.print()
+
+
+# ---------------------------------------------------------------------------
+# /login health — per-profile eligibility verdict + actionable suggestion
+# ---------------------------------------------------------------------------
+
+
+_HEALTH_SUGGESTIONS: dict[str, str] = {
+    "ok": "Ready to dispatch.",
+    "missing_key": "Key/token is empty. Run `/login add` (interactive) or "
+    "`/login set-key <plan> <key>` to populate.",
+    "expired": "OAuth token past expires_at. Re-run the owning CLI's login "
+    "(e.g. `claude` or `codex`) and then `/login refresh` so GEODE "
+    "picks the new token up.",
+    "cooling_down": "Backoff after consecutive failures. The verdict line "
+    "shows the cooldown deadline — wait it out or "
+    "`/login use <other-plan>` to switch providers in the meantime.",
+    "disabled": "Manually disabled (`/login remove <plan>` to delete, or "
+    "edit `~/.geode/auth.toml` to flip `disabled=false`).",
+    "provider_mismatch": "Profile belongs to a different provider — info only, no action needed.",
+}
+
+
+def _login_health(rest: str) -> None:
+    """Render eligibility verdicts for one profile or every profile.
+
+    L5 — the `/login` status dashboard already shows an inline reject
+    badge (cooldown / expired / etc), but the reason codes are opaque
+    until the user knows what each one means. ``/login help`` now
+    documents the codes; this subcommand turns the same data into a
+    per-profile report with an actionable suggestion ("re-run
+    `claude`", "wait Xm", …) so the user can resolve a verdict without
+    guessing.
+    """
+    from core.auth.profiles import EligibilityResult
+    from core.cli import commands as _pkg
+    from core.wiring.container import ensure_profile_store
+
+    store = ensure_profile_store()
+    profiles = store.list_all()
+    if not profiles:
+        _pkg.console.print(
+            "  [muted]No profiles registered. Run `/login add` to create one.[/muted]\n"
+        )
+        return
+
+    target = rest.strip()
+
+    # When the operator names a profile, narrow down — same matching the
+    # rest of the login subcommands use (exact name).
+    verdicts: list[EligibilityResult] = []
+    seen_providers: set[str] = set()
+    for profile in profiles:
+        if profile.provider in seen_providers:
+            continue
+        seen_providers.add(profile.provider)
+        verdicts.extend(store.evaluate_eligibility(profile.provider))
+
+    if target:
+        narrowed = [v for v in verdicts if v.profile_name == target]
+        if not narrowed:
+            _pkg.console.print(
+                f"\n  [warning]No profile named[/warning] {target}\n"
+                "  [muted]Run `/login` to list all profiles.[/muted]\n"
+            )
+            return
+        verdicts = narrowed
+
+    _pkg.console.print("\n  [header]Eligibility[/header]")
+    for v in verdicts:
+        code = v.reason_code
+        badge = "[success]ok[/success]" if v.eligible else f"[warning]{code}[/warning]"
+        _pkg.console.print(f"  {badge:<24} [bold]{v.profile_name}[/bold]")
+        if v.detail:
+            _pkg.console.print(f"    [muted]{v.detail}[/muted]")
+        suggestion = _HEALTH_SUGGESTIONS.get(code, "")
+        if suggestion:
+            _pkg.console.print(f"    → {suggestion}")
     _pkg.console.print()

--- a/docs/research/model-ux-governance.md
+++ b/docs/research/model-ux-governance.md
@@ -399,7 +399,7 @@ All three harnesses successfully decouple login (/login / auth / models auth) fr
 | L2 | `/login refresh` success silent (logged but no console) | S3 | S | Hermes `auth login --refresh` |
 | L3 | OAuth status 가 plan 바인딩 안 보여줌 | S2 | M | OpenClaw `auth show <profile>` shows plan link |
 | L4 | `/key` 마이그레이션 UX 부족 (redirect msg 만, 가이드 부재) | S3 | S | Hermes `auth migrate` |
-| L5 | Help text 에 eligibility verdict 부재 | S2 | S | OpenClaw `auth health <profile>` |
+| L5 | Eligibility verdict legend + `/login health` | Done (v0.99.19) | S | `/login help` 이 reason_code 6개 모두 의미 설명 + `/login health [<profile>]` 가 단일/전체 profile 의 verdict + actionable suggestion 출력. |
 
 ### Cross-cutting (architectural)
 

--- a/tests/test_login_health.py
+++ b/tests/test_login_health.py
@@ -1,0 +1,220 @@
+"""L5 — /login help carries eligibility-verdict legend + /login health subcommand.
+
+Pre-fix the `/login` status dashboard rendered each profile with an
+inline reject badge (cooldown / expired / disabled / etc.), but the
+reason codes were opaque to a user reading them for the first time and
+there was no per-profile health view. ``/login help`` now documents
+every verdict code and ``/login health [<profile>]`` walks the
+``ProfileStore.evaluate_eligibility`` output with an actionable
+suggestion per profile.
+
+Contracts pinned here:
+
+1. ``_login_help`` mentions every ``ProfileRejectReason`` value
+   (``missing_key``, ``expired``, ``cooling_down``, ``disabled``,
+   ``provider_mismatch``) plus the ``ok`` baseline.
+2. ``/login health`` dispatches to ``_login_health`` from ``cmd_login``.
+3. ``/login health`` with no profile lists every profile's verdict.
+4. ``/login health <profile>`` narrows to that profile.
+5. ``/login health <unknown>`` prints a warning + how-to-list hint.
+6. Empty store path prints the "no profiles" hint, never crashes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.auth.profiles import (
+    AuthProfile,
+    CredentialType,
+    EligibilityResult,
+    ProfileRejectReason,
+    ProfileStore,
+)
+
+# ---------------------------------------------------------------------------
+# Contract 1 — help text documents every verdict code
+# ---------------------------------------------------------------------------
+
+
+def test_login_help_documents_eligibility_codes(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_help
+
+    _login_help()
+    out = capsys.readouterr().out
+
+    for code in (
+        "ok",
+        "missing_key",
+        "expired",
+        "cooling_down",
+        "disabled",
+        "provider_mismatch",
+    ):
+        assert code in out, f"verdict code {code!r} missing from /login help"
+
+    # Health subcommand must be discoverable from /login help too.
+    assert "/login health" in out
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — cmd_login routes "health" to _login_health
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_login_health_dispatches() -> None:
+    from core.cli.commands.login import cmd_login
+
+    with patch("core.cli.commands.login._login_health") as fake:
+        cmd_login("health")
+        fake.assert_called_once_with("")
+
+        fake.reset_mock()
+        cmd_login("health anthropic:work")
+        fake.assert_called_once_with("anthropic:work")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a populated ProfileStore + matching eligibility verdicts
+# ---------------------------------------------------------------------------
+
+
+def _build_store() -> ProfileStore:
+    store = ProfileStore()
+    store.add(
+        AuthProfile(
+            name="anthropic:work",
+            provider="anthropic",
+            credential_type=CredentialType.OAUTH,
+            key="dummy-token",
+        )
+    )
+    store.add(
+        AuthProfile(
+            name="openai:payg",
+            provider="openai",
+            credential_type=CredentialType.TOKEN,
+            key="",  # missing key → reason_code == "missing_key"
+        )
+    )
+    return store
+
+
+def _patch_health(store: ProfileStore) -> object:
+    return patch(
+        "core.wiring.container.ensure_profile_store",
+        return_value=store,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — /login health (no arg) lists every profile
+# ---------------------------------------------------------------------------
+
+
+def test_login_health_lists_all_profiles(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_health
+
+    store = _build_store()
+    with _patch_health(store):
+        _login_health("")
+
+    out = capsys.readouterr().out
+    assert "anthropic:work" in out
+    assert "openai:payg" in out
+    # Section header surfaces so the operator knows what the block means.
+    assert "Eligibility" in out
+
+
+# ---------------------------------------------------------------------------
+# Contract 4 — /login health <profile> narrows
+# ---------------------------------------------------------------------------
+
+
+def test_login_health_narrows_to_single_profile(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_health
+
+    store = _build_store()
+    with _patch_health(store):
+        _login_health("anthropic:work")
+
+    out = capsys.readouterr().out
+    assert "anthropic:work" in out
+    assert "openai:payg" not in out
+
+
+# ---------------------------------------------------------------------------
+# Contract 5 — /login health <unknown> warns instead of crashing
+# ---------------------------------------------------------------------------
+
+
+def test_login_health_unknown_profile_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_health
+
+    store = _build_store()
+    with _patch_health(store):
+        _login_health("does-not-exist")
+
+    out = capsys.readouterr().out
+    assert "No profile named" in out
+    assert "does-not-exist" in out
+
+
+# ---------------------------------------------------------------------------
+# Contract 6 — empty store path
+# ---------------------------------------------------------------------------
+
+
+def test_login_health_empty_store(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_health
+
+    store = ProfileStore()  # empty
+    with _patch_health(store):
+        _login_health("")
+
+    out = capsys.readouterr().out
+    assert "No profiles registered" in out
+
+
+# ---------------------------------------------------------------------------
+# Contract 7 — verdict suggestion text surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_login_health_renders_actionable_suggestion(capsys: pytest.CaptureFixture[str]) -> None:
+    """Each verdict line must carry the `→ suggestion` row so the user
+    sees *what to do next*, not just the bare reason code."""
+    from core.cli.commands.login import _login_health
+
+    store = _build_store()
+    # Force a cooldown verdict so we exercise a non-trivial suggestion path.
+    fake_verdict = EligibilityResult(
+        profile_name="openai:payg",
+        provider="openai",
+        credential_type=CredentialType.TOKEN,
+        eligible=False,
+        reason=ProfileRejectReason.COOLING_DOWN,
+        detail="cooldown until +120s after 3 errors",
+        cooldown_until=9_999_999_999.0,
+    )
+
+    def fake_eval(provider: str, **_kwargs: object) -> list[EligibilityResult]:
+        return [fake_verdict] if provider == "openai" else []
+
+    store_mock = MagicMock(spec=ProfileStore)
+    store_mock.list_all.return_value = list(store.list_all())
+    store_mock.evaluate_eligibility.side_effect = fake_eval
+
+    with patch(
+        "core.wiring.container.ensure_profile_store",
+        return_value=store_mock,
+    ):
+        _login_health("openai:payg")
+
+    out = capsys.readouterr().out
+    assert "cooling_down" in out
+    assert "Backoff" in out, (
+        "actionable suggestion missing — `_HEALTH_SUGGESTIONS[cooling_down]` "
+        "must surface so the user sees how to recover"
+    )


### PR DESCRIPTION
## Summary

- `/login help` now documents every `ProfileRejectReason` code (``ok`` / ``missing_key`` / ``expired`` / ``cooling_down`` / ``disabled`` / ``provider_mismatch``).
- New `/login health [<profile>]` walks `ProfileStore.evaluate_eligibility` and prints the badge + detail + an actionable ``→ suggestion`` per profile (e.g. "re-run ``claude``", "wait <cooldown>", "run `/login set-key …`").
- Empty store / unknown profile paths emit hints rather than crashing.

## Why

Governance gap **L5** in `docs/research/model-ux-governance.md` (*Help text 에 eligibility verdict 부재*). Pre-fix the `/login` status dashboard already rendered an inline reject badge per profile, but the codes were opaque to a first-time reader and there was no per-profile health view — users saw ``cooling_down`` and had to guess what to do.

## Changes

| File | Change |
|------|--------|
| `core/cli/commands/login.py` | `_login_help` documents every verdict code; `cmd_login` routes ``health`` → `_login_health`; new `_login_health(rest)` walks `evaluate_eligibility` + prints badge + detail + suggestion from `_HEALTH_SUGGESTIONS`. |
| `tests/test_login_health.py` | 7 new tests — legend coverage, router dispatch, no-arg / narrowed / unknown / empty-store cases, suggestion surfacing. |
| `docs/research/model-ux-governance.md` | L5 row → Done (v0.99.19). |
| `CHANGELOG.md` | `[Unreleased] Added` entry. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Help legend | Implemented | every reason_code documented + tested |
| `health` subcommand | Implemented | router + handler + tests |
| Per-profile narrowing | Implemented | exact profile name match |
| Actionable suggestion | Implemented | `_HEALTH_SUGGESTIONS` per code |
| Empty store guard | Implemented | "no profiles registered" hint |

## Verification

- [x] `ruff check core/ tests/ plugins/` — All checks passed
- [x] `ruff format --check core/ tests/ plugins/` — formatted
- [x] `uv run mypy core/ plugins/` — 0 issues / 356 files
- [x] `uv run pytest tests/ -m \"not live\" --ignore=tests/test_petri_artifact_capture.py` — **5058 passed**, 34 skipped, 5 deselected

## Reference

- `docs/research/model-ux-governance.md` L5 row — OpenClaw `auth health <profile>` pattern.