### PR TITLE
release: v0.99.19 — model UX gaps (M2/M5/L3/L5/X1/X3) + silent fallback knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.19] — 2026-05-20
+
 ### Added
 
 - **X1 (first slice) — per-provider auth-order: pinned profile wins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.18
+- **Version**: 0.99.19
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.18 — Long-running Autonomous Execution Harness
+# GEODE v0.99.19 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -342,7 +342,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.18**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.19**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.18"
+version = "0.99.19"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version bump v0.99.18 → **v0.99.19** + CHANGELOG `[Unreleased]` → `[0.99.19] — 2026-05-20`.

Sprint contents (7 merged PRs on develop):

- **#1359** — silent same-provider model fallback off by default (opt-in knob via `~/.geode/routing.toml`); `CROSS_PROVIDER_FALLBACK` empty-dict shim removed.
- **#1363** — M5: `/model` picker dims un-credentialed rows + `(login required)` suffix; Enter cancels.
- **#1364** — L5: `/login help` carries eligibility-verdict legend + new `/login health [<profile>]` with actionable suggestions.
- **#1365** — X3: new `/login providers` (alias `provider`) surfaces variant table + de-duped equivalence map.
- **#1366** — M2: `/model` picker `(forced: <method>)` badge tracks `settings.forced_login_method`.
- **#1367** — L3: Profiles row reads `plan=<id> (<kind>·<tier> · <display_name>)` with `(unbound)` fallback.
- **#1369** — X1 (first slice): `ProfileRotator.resolve` honours `ProfileStore.get_pinned_active`; new `/login use-profile <name>` + `/login order [<provider>]`.

## Why

CLAUDE.md release discipline: `[Unreleased]` must not land on main; version stamps must stay in sync across 4 locations (CHANGELOG, CLAUDE.md, README.md, pyproject.toml). All 7 features merged to develop; this PR carries them through to main as v0.99.19.

## Verification

- [x] `ruff check core/ tests/ plugins/` — clean (verified post-X1 merge)
- [x] `ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 0 issues / 356 source files
- [x] `uv run pytest tests/ -m "not live" --ignore=tests/test_petri_artifact_capture.py` — 5061+ passed across the merged PRs
- [x] Version stamps synced — pyproject.toml / CLAUDE.md / README.md (×2) / CHANGELOG.md