### PR TITLE
release: v0.99.23 — deferred model-UX gaps (X1.1 + L2 + L4) + X2 deferral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,61 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.23] — 2026-05-20
+
+Model-UX governance gap closure — final slice covering the items deferred
+from v0.99.22 (M3 / L1 already done in earlier versions; L2 / L4 / X1.1
+new in this release; X2 stays deferred pending operator decision).
+
+### Added
+
+- **X1.1 — full multi-rank auth ordering on top of X1's single-active
+  pin.** Closes the deferred slice of the X1 governance gap. New
+  ``ProfileStore.set_auth_order(provider, names)`` /
+  ``get_auth_order`` / ``clear_auth_order`` carry an ordered list of
+  profile names; ``ProfileRotator.resolve`` walks them in order before
+  falling back to the legacy ``sort_key`` tail. Missing or ineligible
+  entries gracefully step aside without starving lower ranks.
+  ``set_auth_order`` writes the head element to ``_pinned_active`` so
+  X1's ``/login`` ``(active)`` badge stays in sync. CLI:
+  ``/login order set <provider> <name1> [<name2> …]`` registers the
+  list; ``/login order clear <provider>`` drops it (back to LRU);
+  ``/login order [<provider>]`` now annotates ``active`` (rank 1) /
+  ``ranked`` (rank 2+) / ``queued`` (tail) / ``<reject_reason>``
+  (ineligible) per row. 13 new tests in
+  ``tests/test_login_auth_order_multi.py`` pin the store API
+  (set/get/clear + KeyError/ValueError surfaces), the rotator's
+  multi-rank walk + step-aside contract, and the CLI command paths.
+
+- **L2 — ``/login refresh`` console output.** Closes the governance
+  gap noted in ``docs/research/model-ux-governance.md`` (L2: *success
+  silent (logged but no console)*). Pre-fix the refresh branch only
+  emitted ``log.info`` records, so a REPL operator running
+  ``/login refresh`` saw nothing on stdout and could not tell whether
+  the daemon had picked up the new plan / profile. The success branch
+  now surfaces an ``auth.toml reloaded +N plan / +M profile`` line
+  with per-entry muted bullets; the no-change path prints a muted
+  "no new plans or profiles" line; the failure path prints a warning
+  pointing at the daemon log for the traceback. Logs preserved
+  (``log.info`` still records the same counts).
+
+- **L4 — ``/key`` (no args) inline migration guide.** Closes the
+  governance gap noted in ``docs/research/model-ux-governance.md``
+  (L4: *redirect msg 만, 가이드 부재*). Pre-fix ``/key`` (no args)
+  printed a single muted line and redirected to ``/login``, leaving
+  the operator without a learning surface for the new commands. The
+  redirect now carries a small migration table — ``/key <sk-...>`` →
+  ``/login add``, ``/key openai <key>`` → ``/login set-key openai-payg
+  <key>``, ``/key glm <key>`` → ``/login set-key glm-payg <key>`` —
+  plus a pointer to ``/login providers`` for the full variant table.
+
+### Notes — X2 still deferred
+
+X2 (system prompt model identity injection, v0.52.8) remains pending an
+operator decision among (A) keep as-is, (B) weaken to align with
+reference harnesses, (C) Codex-only assertion. The v0.52.5 incident's
+fix-2 (stale ack purge) is independent of this knob and stays.
+
 ## [0.99.22] — 2026-05-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.22
+- **Version**: 0.99.23
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.21 — Long-running Autonomous Execution Harness
+# GEODE v0.99.23 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.21**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.23**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.22 — Long-running Autonomous Execution Harness
+# GEODE v0.99.23 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -342,7 +342,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.22**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.23**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/auth/profiles.py
+++ b/core/auth/profiles.py
@@ -143,6 +143,12 @@ class ProfileStore:
         # only honours the *manual* pin so the legacy LRU/type-priority sort
         # still wins when no operator has explicitly chosen a profile.
         self._pinned_active: dict[str, str] = {}  # provider → profile name
+        # X1.1 — full multi-rank ordering: when populated, the rotator
+        # tries the listed profiles in order before falling back to the
+        # legacy ``sort_key`` tail. The single-active ``_pinned_active``
+        # entry from X1 is automatically the first element of any list
+        # set here (``set_auth_order`` keeps the two surfaces in sync).
+        self._auth_order: dict[str, list[str]] = {}  # provider → ordered profile names
 
     def add(self, profile: AuthProfile) -> None:
         """Add a profile. If no active profile exists for the provider, set it."""
@@ -310,10 +316,58 @@ class ProfileStore:
             return None
         return self._profiles.get(name)
 
+    def set_auth_order(self, provider: str, names: list[str]) -> None:
+        """Pin a *multi-rank* auth order for `provider` (X1.1).
+
+        ``ProfileRotator.resolve`` tries the listed profiles in order
+        before falling back to the legacy ``sort_key`` tail; missing /
+        ineligible entries gracefully step aside. Setting ``names=[]``
+        is equivalent to ``clear_auth_order(provider)``.
+
+        Every name must already exist in the store — KeyError
+        otherwise so the operator notices the typo immediately
+        instead of seeing the rotator silently skip the bad entry.
+
+        The first element is also written to ``_pinned_active`` so
+        ``get_pinned_active`` (X1) stays in sync with the head of
+        the order list.
+        """
+        if not names:
+            self.clear_auth_order(provider)
+            return
+        for name in names:
+            profile = self._profiles.get(name)
+            if profile is None:
+                raise KeyError(f"Profile '{name}' not found")
+            if profile.provider != provider:
+                raise ValueError(
+                    f"Profile '{name}' belongs to provider {profile.provider!r}, not {provider!r}"
+                )
+        self._auth_order[provider] = list(names)
+        # Head of the list is the manual pin too — keep X1 parity.
+        self._pinned_active[provider] = names[0]
+        self._active[provider] = names[0]
+
+    def get_auth_order(self, provider: str) -> list[str]:
+        """Return the multi-rank auth order for `provider` (X1.1).
+
+        Empty list when nothing has been pinned via ``set_auth_order``.
+        The rotator treats an empty list as "no override" and falls
+        back to the legacy ``sort_key`` order.
+        """
+        return list(self._auth_order.get(provider, []))
+
+    def clear_auth_order(self, provider: str) -> None:
+        """Remove the multi-rank pin for `provider`. Also clears the
+        single-active pin (X1) so the rotator returns to pure sort_key."""
+        self._auth_order.pop(provider, None)
+        self._pinned_active.pop(provider, None)
+
     def clear(self) -> None:
         self._profiles.clear()
         self._active.clear()
         self._pinned_active.clear()
+        self._auth_order.clear()
 
     def __len__(self) -> int:
         return len(self._profiles)

--- a/core/auth/rotation.py
+++ b/core/auth/rotation.py
@@ -106,25 +106,37 @@ class ProfileRotator:
                 log.warning("No profiles registered for provider=%s", provider)
             return None
 
-        # X1 — honour user-pinned active profile first. Pre-fix the
-        # sort key alone decided the order (type priority → LRU), so
-        # operators with multiple eligible profiles for a provider could
-        # not pin a preferred one without removing the others. When
-        # ``ProfileStore.set_active(name)`` has named an eligible
-        # profile for this provider, surface it as the first
-        # candidate; remaining profiles fall back to the legacy
-        # sort_key tiebreak so an ineligible pin gracefully steps
-        # aside.
-        active = self._store.get_pinned_active(provider)
-        active_pinned: AuthProfile | None = None
-        if active is not None:
-            for p in eligible_profiles:
-                if p.name == active.name:
-                    active_pinned = p
-                    break
-        others = [p for p in eligible_profiles if p is not active_pinned]
+        # X1.1 — honour the multi-rank ``set_auth_order`` list first.
+        # When populated, the rotator tries the listed profiles in
+        # exactly the operator-supplied order before falling back to
+        # the legacy ``sort_key`` tail. Missing / ineligible entries
+        # in the list gracefully step aside (rotator does not starve
+        # the tail).
+        #
+        # X1 single-active pin is now the head of any multi-rank list
+        # (``set_auth_order`` keeps the two surfaces in sync), so the
+        # rotator only needs to consult ``get_auth_order``.
+        order = self._store.get_auth_order(provider)
+        ranked: list[AuthProfile] = []
+        ranked_set: set[str] = set()
+        eligible_by_name = {p.name: p for p in eligible_profiles}
+        for name in order:
+            profile = eligible_by_name.get(name)
+            if profile is not None and name not in ranked_set:
+                ranked.append(profile)
+                ranked_set.add(name)
+        # Back-compat: single-active pin (legacy X1 surface) is
+        # respected when ``set_auth_order`` has *not* been used.
+        if not ranked:
+            active = self._store.get_pinned_active(provider)
+            if active is not None:
+                profile = eligible_by_name.get(active.name)
+                if profile is not None:
+                    ranked.append(profile)
+                    ranked_set.add(profile.name)
+        others = [p for p in eligible_profiles if p.name not in ranked_set]
         others.sort(key=lambda p: p.sort_key())
-        ordered = ([active_pinned] if active_pinned is not None else []) + others
+        ordered = ranked + others
         selected = ordered[0]
 
         # Proactive refresh: re-read if managed + expiring within skew

--- a/core/cli/commands/key.py
+++ b/core/cli/commands/key.py
@@ -32,9 +32,31 @@ def cmd_key(args: str) -> bool:
 
     parts = args.split(None, 1) if args else []
 
-    # /key (no args) → defer to the unified /login dashboard
+    # /key (no args) → defer to the unified /login dashboard.
+    # L4 — pre-fix the redirect printed a single muted line with no
+    # migration guide; an operator who'd just typed ``/key`` had no
+    # way to learn the new command surface short of running ``/login``
+    # and inferring it. Surface the migration table inline so the
+    # legacy command becomes self-documenting.
     if not parts:
         _pkg.console.print("\n  [muted]/key now redirects to the unified /login dashboard.[/muted]")
+        _pkg.console.print("\n  [header]Migration guide[/header]")
+        _pkg.console.print(
+            "  [muted]Legacy[/muted]                      → [muted]Replacement[/muted]\n"
+            "  [label]/key <sk-...>[/label]               → [label]/login add[/label]  "
+            "[muted](interactive — picks provider by prefix)[/muted]\n"
+            "  [label]/key openai <key>[/label]           → "
+            "[label]/login set-key openai-payg <key>[/label]\n"
+            "  [label]/key glm <key>[/label]              → "
+            "[label]/login set-key glm-payg <key>[/label]\n"
+            "\n"
+            "  [muted]The legacy forms above still work — they shim into the unified\n"
+            "  Plan/Profile model, but `/login add` registers richer metadata\n"
+            "  (subscription tier, expiry, quota) that `/key` cannot express.\n"
+            "  Run `/login providers` to see every provider variant the dashboard\n"
+            "  supports; `/login` (bare) to see plans + profiles + routing.[/muted]"
+        )
+        _pkg.console.print()
         _pkg.cmd_login("")
         return False
 

--- a/core/cli/commands/login.py
+++ b/core/cli/commands/login.py
@@ -174,8 +174,47 @@ def cmd_login(args: str) -> None:
                 log.info("auth.toml reload: + plan %s", plan_id)
             for profile_name in sorted(new_profiles):
                 log.info("auth.toml reload: + profile %s", profile_name)
+            # L2 — pre-fix this branch logged via ``log.info`` only, so
+            # the operator running ``/login refresh`` from the REPL saw
+            # nothing on stdout and could not tell whether the daemon
+            # had picked up the new plan/profile. Surface the same
+            # counts to the console so the success path is visible.
+            from core.cli import commands as _pkg
+
+            if not ok:
+                _pkg.console.print(
+                    f"  [warning]auth.toml reload failed[/warning]  "
+                    f"[muted]({auth_toml_path()})[/muted]\n"
+                )
+            elif new_plans or new_profiles:
+                added = []
+                if new_plans:
+                    added.append(f"{len(new_plans)} plan{'s' if len(new_plans) != 1 else ''}")
+                if new_profiles:
+                    added.append(
+                        f"{len(new_profiles)} profile{'s' if len(new_profiles) != 1 else ''}"
+                    )
+                _pkg.console.print(
+                    f"  [success]auth.toml reloaded[/success]  [muted]+{' · +'.join(added)}[/muted]"
+                )
+                for plan_id in sorted(new_plans):
+                    _pkg.console.print(f"    [muted]+ plan {plan_id}[/muted]")
+                for profile_name in sorted(new_profiles):
+                    _pkg.console.print(f"    [muted]+ profile {profile_name}[/muted]")
+                _pkg.console.print()
+            else:
+                _pkg.console.print(
+                    f"  [muted]auth.toml reloaded — no new plans or profiles "
+                    f"(total: {len(plans_after)} plans, {len(profiles_after)} profiles)[/muted]\n"
+                )
         except Exception:
             log.warning("auth.toml reload failed", exc_info=True)
+            from core.cli import commands as _pkg
+
+            _pkg.console.print(
+                "  [warning]auth.toml reload failed[/warning]  "
+                "[muted](see daemon log for traceback)[/muted]\n"
+            )
         return
     if sub in ("help", "?"):
         _login_help()
@@ -207,6 +246,8 @@ def _login_help() -> None:
         "  [label]/login use[/label] <plan>            Pin a plan as active for its provider\n"
         "  [label]/login use-profile[/label] <name>    Pin a profile as active for its provider\n"
         "  [label]/login order[/label] [<provider>]    Show effective profile order per provider\n"
+        "  [label]/login order set[/label] <prov> <n1> <n2>…  Pin multi-rank auth order\n"
+        "  [label]/login order clear[/label] <prov>    Drop the multi-rank pin\n"
         "  [label]/login route[/label] <model> <plan>… Bind a model to plan(s) in priority order\n"
         "  [label]/login remove[/label] <plan>         Delete a plan\n"
         "  [label]/login quota[/label]                 Per-plan quota / usage\n"
@@ -945,19 +986,66 @@ def _login_use_profile(rest: str) -> None:
 
 
 def _login_order(rest: str) -> None:
-    """Show the effective profile order per provider.
+    """Show or mutate the effective profile order per provider.
 
-    X1 — answers "which profile will the next call use?" for each
-    registered provider. The first row is the pinned active profile
-    (when set) or the legacy sort_key winner; subsequent rows are the
-    siblings in the order the rotator would try them after the pin.
-    Ineligible profiles surface with their reject reason so the
-    operator sees why a pin might be ignored.
+    Subcommands::
+
+        /login order                       — show every provider's order
+        /login order <provider>            — show one provider's order
+        /login order set <provider> <n1> <n2> …   — pin multi-rank
+        /login order clear <provider>      — drop the pin (back to LRU)
+
+    X1.1 — the rotator tries the listed profiles in order before
+    falling back to ``sort_key`` (legacy LRU/type-priority). The
+    first list element is also written to the single-active pin
+    (``ProfileStore.set_active`` parity) so X1's ``/login`` ``(active)``
+    badge stays accurate.
     """
     from core.cli import commands as _pkg
     from core.wiring.container import ensure_profile_store
 
     store = ensure_profile_store()
+
+    # X1.1 mutating subcommands.
+    parts = rest.split()
+    if parts and parts[0].lower() in ("set", "clear"):
+        action = parts[0].lower()
+        if len(parts) < 2:
+            _pkg.console.print(
+                "  [warning]Usage: /login order set <provider> <name1> <name2> …[/warning]\n"
+                "  [warning]       /login order clear <provider>[/warning]\n"
+            )
+            return
+        provider = parts[1]
+        if action == "clear":
+            store.clear_auth_order(provider)
+            _pkg._persist_auth_state()
+            _pkg.console.print(
+                f"  [success]Cleared auth order[/success]  {provider}  "
+                "[muted](rotator falls back to LRU/type-priority)[/muted]\n"
+            )
+            return
+        names = parts[2:]
+        if not names:
+            _pkg.console.print(
+                "  [warning]Usage: /login order set <provider> <name1> "
+                "[<name2> …][/warning]\n"
+                "  [muted]Pass at least one profile name; use "
+                "`/login order clear <provider>` to drop a pin.[/muted]\n"
+            )
+            return
+        try:
+            store.set_auth_order(provider, names)
+        except (KeyError, ValueError) as exc:
+            _pkg.console.print(f"  [warning]{exc}[/warning]\n")
+            return
+        _pkg._persist_auth_state()
+        _pkg.console.print(
+            f"  [success]Pinned auth order[/success]  {provider}  "
+            f"[muted]({' → '.join(names)})[/muted]\n"
+        )
+        return
+
     profiles = store.list_all()
     if not profiles:
         _pkg.console.print(
@@ -978,32 +1066,45 @@ def _login_order(rest: str) -> None:
 
     _pkg.console.print("\n  [header]Profile order[/header]")
     for provider in sorted(by_provider.keys()):
-        active = store.get_pinned_active(provider)
-        active_name = active.name if active is not None else None
+        # X1.1 — full multi-rank order if set; else fall back to X1
+        # single-active pin (head of the implicit one-element list).
+        ranked_names = store.get_auth_order(provider)
+        if not ranked_names:
+            pinned_profile = store.get_pinned_active(provider)
+            if pinned_profile is not None:
+                ranked_names = [pinned_profile.name]
         verdicts = {v.profile_name: v for v in store.evaluate_eligibility(provider)}
-        # Same ordering as ProfileRotator.resolve: active pin first
-        # (when eligible), then sort_key for the rest. Ineligible
-        # profiles trail with their reason.
         eligible = [
             p
             for p in by_provider[provider]
             if (v := verdicts.get(p.name)) is not None and v.eligible
         ]
         ineligible = [p for p in by_provider[provider] if p not in eligible]
-        pinned: AuthProfile | None = None
-        for p in eligible:
-            if p.name == active_name:
-                pinned = p
-                break
-        others = [p for p in eligible if p is not pinned]
+        # Pull the ranked entries first (preserve operator order),
+        # then sort the remaining eligible by sort_key.
+        ranked_eligible: list[AuthProfile] = []
+        ranked_set: set[str] = set()
+        eligible_by_name = {p.name: p for p in eligible}
+        for name in ranked_names:
+            profile = eligible_by_name.get(name)
+            if profile is not None and name not in ranked_set:
+                ranked_eligible.append(profile)
+                ranked_set.add(name)
+        others = [p for p in eligible if p.name not in ranked_set]
         others.sort(key=lambda p: p.sort_key())
-        ordered = ([pinned] if pinned is not None else []) + others
+        ordered = ranked_eligible + others
         _pkg.console.print(f"  [bold]{provider}[/bold]")
         if not ordered and not ineligible:
             _pkg.console.print("    [muted](no profiles)[/muted]")
             continue
         for idx, p in enumerate(ordered, 1):
-            badge = "[success]active[/success]" if pinned is p else "[muted]queued[/muted]"
+            # X1.1 — every entry from ``ranked_eligible`` is part of the
+            # operator-supplied auth order ("active" / "rank 1+"); the
+            # ``others`` tail rides on the legacy LRU sort ("queued").
+            if p in ranked_eligible:
+                badge = "[success]active[/success]" if idx == 1 else "[success]ranked[/success]"
+            else:
+                badge = "[muted]queued[/muted]"
             _pkg.console.print(f"    {idx}. {badge}  {p.name}")
         for p in ineligible:
             v = verdicts.get(p.name)

--- a/docs/research/model-ux-governance.md
+++ b/docs/research/model-ux-governance.md
@@ -387,7 +387,7 @@ All three harnesses successfully decouple login (/login / auth / models auth) fr
 |---|-----|----------|--------|---------------|
 | M1 | Provider label vs ID 불일치 (`"Codex (Plus)"` vs `openai-codex`) | S2 | S | OpenClaw uses single canonical key |
 | M2 | `forced_login_method` visible in `/model` picker | Done (v0.99.19) | M | `commands._state.forced_login_method_for(provider)` + 6-tuple picker — non-default override (`apikey` / `api` / etc.) renders `(forced: <method>)` badge in interactive + non-tty list. Alias map mirrors `plan_registry._apply_forced_login_method`. |
-| M3 | `gpt-5.5` static `_resolve_provider` → `"openai"` (실제는 Codex-only) | S1 | M | Hermes 의 PROVIDER_REGISTRY 모델 매핑 |
+| M3 | `gpt-5.5` static `_resolve_provider` → `openai-codex` | Done (v0.99.x) | M | `routing.toml [routing] codex_only_models = ["gpt-5.5", "gpt-5.5-pro"]` + `routing_manifest.resolve_provider` 가 `codex_only_models` → `codex_suffixes` → prefix 순. 더 이상 `openai` 로 잘못 라우팅 안 됨. |
 | M4 | Silent credential fallback (~~breadcrumb 추가~~ → v0.99.19 elimination) | Done (v0.99.19) | — | 본 doc Addendum 의 Phase F1 + F3 (옵션 C). silent fallback 자체를 제거; breadcrumb 도 dead code. |
 | M5 | `MODEL_PROFILES` login-state 필터링 | Done (v0.99.19) | S | `commands._state.model_available()` + 5-tuple picker — un-credentialed rows dim + `(login required)` suffix; Enter cancels instead of mutating settings; `/model <name>` emits `/login` hint before applying. |
 
@@ -395,18 +395,19 @@ All three harnesses successfully decouple login (/login / auth / models auth) fr
 
 | # | Gap | Severity | Effort | Reference fix |
 |---|-----|----------|--------|---------------|
-| L1 | `/login list` shortcut 없음 (bare `/login` 만) | S3 | S | OpenClaw `models auth list` |
-| L2 | `/login refresh` success silent (logged but no console) | S3 | S | Hermes `auth login --refresh` |
+| L1 | `/login list` / `/login ls` shortcut | Done (v0.99.x) | S | `cmd_login` 의 router 에 `("status", "list", "ls")` alias 등재됨 (line 92). bare `/login` 과 동일 dashboard 출력. |
+| L2 | `/login refresh` console output | Done (v0.99.23) | S | success 시 `auth.toml reloaded +N plan / +M profile` 콘솔 출력 + 각 신규 plan/profile 별 muted bullet. no-change/failure path 별도 메시지. 기존 `log.info` 도 유지. |
 | L3 | OAuth status plan binding | Done (v0.99.19) | M | `/login` Profiles 섹션의 `plan=<id>` 가 `<id> (<kind>·<tier> · <display_name>)` 로 확장. `_format_plan_binding` helper 가 PlanRegistry.get 결과로 라벨 합성; 사라진 plan 은 `(unbound)` 로 표시. |
-| L4 | `/key` 마이그레이션 UX 부족 (redirect msg 만, 가이드 부재) | S3 | S | Hermes `auth migrate` |
+| L4 | `/key` 마이그레이션 가이드 | Done (v0.99.23) | S | `/key` (no args) 가 `/login` redirect 와 함께 legacy → 신규 surface 매핑 표 출력 (`/key <sk-...>` → `/login add` 등). 사용자가 별도 docs 없이 새 surface 학습 가능. |
 | L5 | Eligibility verdict legend + `/login health` | Done (v0.99.19) | S | `/login help` 이 reason_code 6개 모두 의미 설명 + `/login health [<profile>]` 가 단일/전체 profile 의 verdict + actionable suggestion 출력. |
 
 ### Cross-cutting (architectural)
 
 | # | Gap | Severity | Effort | Reference fix |
 |---|-----|----------|--------|---------------|
-| X1 | Per-provider user-tunable auth order (first slice) | Done (v0.99.19) | M | `ProfileStore.set_active` → `_pinned_active` 분리, `ProfileRotator.resolve` 가 manual pin 을 sort_key 보다 우선. CLI: `/login use-profile <name>` (set), `/login order [<provider>]` (show). `/login` Profiles row 에 `(active)` badge. Ineligible pin 은 graceful step-aside. Full list ordering 은 후속 PR (X1.1). |
-| X2 | system prompt model identity injection (v0.52.8) — reference 와 어긋남 | S2 | S | Decision: 유지 / 약화 / Codex-only 中 택 |
+| X1 | Per-provider user-tunable auth order (single-active pin) | Done (v0.99.19) | M | `ProfileStore.set_active` → `_pinned_active` 분리, `ProfileRotator.resolve` 가 manual pin 을 sort_key 보다 우선. CLI: `/login use-profile <name>` (set), `/login order [<provider>]` (show). |
+| X1.1 | Per-provider auth order (multi-rank list) | Done (v0.99.23) | M | `ProfileStore.set_auth_order(provider, names)` + `get_auth_order` + `clear_auth_order`. Rotator walks the list in order; head 가 `_pinned_active` 와 sync (X1 parity). CLI: `/login order set <provider> <n1> <n2>…`, `/login order clear <provider>`. Missing/ineligible 은 graceful step-aside. |
+| X2 | system prompt model identity injection (v0.52.8) — reference 와 어긋남 | Deferred — needs decision | S | 옵션 (A) 유지 / (B) 약화 / (C) Codex-only 中 사용자 결정 필요. v0.52.5 incident 의 fix-2 (stale ack purge) 는 X2 와 별개로 유지됨 — X2 결정은 *prompt-level* 강도 조정 only. |
 | X3 | Provider equivalence map view | Done (v0.99.19) | S | `/login providers` (alias `provider`) 가 PROVIDER_VARIANTS + base_url + multi-member equivalence class (openai ↔ openai-codex, glm ↔ glm-coding) 출력. de-dup 으로 같은 class 가 sibling key 마다 중복 표시되지 않음. |
 
 ### 종합 priority

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.22"
+version = "0.99.23"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_login_auth_order_multi.py
+++ b/tests/test_login_auth_order_multi.py
@@ -1,0 +1,226 @@
+"""X1.1 — full multi-rank auth ordering on top of X1 single-active pin.
+
+X1 (v0.99.22) added ``ProfileStore.set_active`` + rotator honouring
+``get_pinned_active``. This second slice adds full list ordering so
+operators can specify ``[primary, secondary, tertiary]`` per provider;
+the rotator tries them in order before falling back to the legacy
+``sort_key`` tail.
+
+Contracts pinned here:
+
+1. ``ProfileStore.set_auth_order(provider, names)`` records the list,
+   writes head to ``_pinned_active`` for X1 parity, and raises
+   ``KeyError`` / ``ValueError`` on unknown / wrong-provider names.
+2. ``get_auth_order`` returns a copy (mutation-safe).
+3. ``clear_auth_order`` drops both the list and the single-active pin
+   so the rotator falls back to pure ``sort_key``.
+4. ``ProfileRotator.resolve`` walks the multi-rank list in order;
+   missing / ineligible entries skip without starving the tail.
+5. ``/login order set / clear`` CLI subcommands wrap the store API
+   and emit visible confirmation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from core.auth.profiles import AuthProfile, CredentialType, ProfileStore
+from core.auth.rotation import ProfileRotator
+
+
+def _three_profiles() -> ProfileStore:
+    store = ProfileStore()
+    for i, last_used in enumerate([100.0, 50.0, 200.0], start=1):
+        store.add(
+            AuthProfile(
+                name=f"openai-codex:p{i}",
+                provider="openai-codex",
+                credential_type=CredentialType.OAUTH,
+                key=f"token-{i}",
+                last_used=last_used,
+            )
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 — set_auth_order writes the list and the head pin
+# ---------------------------------------------------------------------------
+
+
+def test_set_auth_order_records_list_and_head_pin() -> None:
+    store = _three_profiles()
+    store.set_auth_order("openai-codex", ["openai-codex:p2", "openai-codex:p3", "openai-codex:p1"])
+
+    assert store.get_auth_order("openai-codex") == [
+        "openai-codex:p2",
+        "openai-codex:p3",
+        "openai-codex:p1",
+    ]
+    pinned = store.get_pinned_active("openai-codex")
+    assert pinned is not None and pinned.name == "openai-codex:p2", (
+        "head of multi-rank list must keep X1's get_pinned_active in sync"
+    )
+
+
+def test_set_auth_order_unknown_name_raises() -> None:
+    store = _three_profiles()
+    with pytest.raises(KeyError):
+        store.set_auth_order("openai-codex", ["openai-codex:p1", "nope"])
+
+
+def test_set_auth_order_wrong_provider_raises() -> None:
+    store = _three_profiles()
+    store.add(
+        AuthProfile(
+            name="anthropic:work",
+            provider="anthropic",
+            credential_type=CredentialType.OAUTH,
+            key="token",
+        )
+    )
+    with pytest.raises(ValueError):
+        store.set_auth_order("openai-codex", ["openai-codex:p1", "anthropic:work"])
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — get_auth_order returns a copy
+# ---------------------------------------------------------------------------
+
+
+def test_get_auth_order_returns_copy() -> None:
+    store = _three_profiles()
+    store.set_auth_order("openai-codex", ["openai-codex:p1"])
+    snapshot = store.get_auth_order("openai-codex")
+    snapshot.append("openai-codex:p2")
+    # Mutation of the returned list must not affect the store.
+    assert store.get_auth_order("openai-codex") == ["openai-codex:p1"]
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — clear_auth_order drops both surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_clear_auth_order_drops_both_surfaces() -> None:
+    store = _three_profiles()
+    store.set_auth_order("openai-codex", ["openai-codex:p1", "openai-codex:p2"])
+    store.clear_auth_order("openai-codex")
+    assert store.get_auth_order("openai-codex") == []
+    assert store.get_pinned_active("openai-codex") is None
+
+
+def test_set_auth_order_empty_list_clears() -> None:
+    store = _three_profiles()
+    store.set_auth_order("openai-codex", ["openai-codex:p1"])
+    store.set_auth_order("openai-codex", [])
+    assert store.get_auth_order("openai-codex") == []
+    assert store.get_pinned_active("openai-codex") is None
+
+
+# ---------------------------------------------------------------------------
+# Contract 4 — rotator walks the list in order; missing entries skip
+# ---------------------------------------------------------------------------
+
+
+def test_rotator_walks_multi_rank_in_order() -> None:
+    store = _three_profiles()
+    # Multi-rank: p3 first even though p2 has the lowest last_used (LRU
+    # winner under the legacy path).
+    store.set_auth_order("openai-codex", ["openai-codex:p3", "openai-codex:p1"])
+
+    rotator = ProfileRotator(store)
+    selected = rotator.resolve("openai-codex")
+    assert selected is not None
+    assert selected.name == "openai-codex:p3"
+
+
+def test_rotator_skips_ineligible_pin_falls_to_next_rank() -> None:
+    store = _three_profiles()
+    p3 = store.get("openai-codex:p3")
+    assert p3 is not None
+    p3.disabled = True
+    store.set_auth_order("openai-codex", ["openai-codex:p3", "openai-codex:p1"])
+
+    rotator = ProfileRotator(store)
+    selected = rotator.resolve("openai-codex")
+    assert selected is not None
+    assert selected.name == "openai-codex:p1", (
+        "ineligible head entry must step aside without starving the next rank"
+    )
+
+
+def test_rotator_falls_back_to_sort_key_when_no_order() -> None:
+    """No pin + no auth order → legacy LRU/type-priority wins."""
+    store = _three_profiles()
+    rotator = ProfileRotator(store)
+    selected = rotator.resolve("openai-codex")
+    assert selected is not None
+    # last_used=50.0 (p2) is the LRU winner under the legacy path.
+    assert selected.name == "openai-codex:p2"
+
+
+# ---------------------------------------------------------------------------
+# Contract 5 — CLI: /login order set / clear
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_login_order_set_records_pin(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_order
+
+    store = _three_profiles()
+    with (
+        patch("core.wiring.container.ensure_profile_store", return_value=store),
+        patch("core.cli.commands._persist_auth_state"),
+    ):
+        _login_order("set openai-codex openai-codex:p2 openai-codex:p3")
+
+    out = capsys.readouterr().out
+    assert "Pinned auth order" in out
+    assert "openai-codex:p2" in out
+    assert store.get_auth_order("openai-codex") == [
+        "openai-codex:p2",
+        "openai-codex:p3",
+    ]
+
+
+def test_cmd_login_order_clear_drops_pin(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_order
+
+    store = _three_profiles()
+    store.set_auth_order("openai-codex", ["openai-codex:p1"])
+    with (
+        patch("core.wiring.container.ensure_profile_store", return_value=store),
+        patch("core.cli.commands._persist_auth_state"),
+    ):
+        _login_order("clear openai-codex")
+
+    out = capsys.readouterr().out
+    assert "Cleared auth order" in out
+    assert store.get_auth_order("openai-codex") == []
+
+
+def test_cmd_login_order_set_missing_args_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_order
+
+    store = _three_profiles()
+    with patch("core.wiring.container.ensure_profile_store", return_value=store):
+        _login_order("set")
+
+    out = capsys.readouterr().out
+    assert "Usage:" in out
+
+
+def test_cmd_login_order_set_unknown_name_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import _login_order
+
+    store = _three_profiles()
+    with (
+        patch("core.wiring.container.ensure_profile_store", return_value=store),
+        patch("core.cli.commands._persist_auth_state"),
+    ):
+        _login_order("set openai-codex does-not-exist")
+
+    out = capsys.readouterr().out
+    assert "not found" in out

--- a/tests/test_login_refresh_l4_l2.py
+++ b/tests/test_login_refresh_l4_l2.py
@@ -1,0 +1,114 @@
+"""L2 + L4 — /login refresh console output + /key migration guide.
+
+L2 — pre-fix ``/login refresh`` only emitted ``log.info`` records, so
+the operator running the command from the REPL saw nothing on stdout
+and could not tell whether the daemon had picked up the new plan or
+profile. The success branch now surfaces a ``+N plan / +M profile``
+summary alongside the failure / no-change paths.
+
+L4 — pre-fix ``/key`` (no args) printed a single muted line and
+redirected to ``/login``. The migration table is now inline so the
+legacy command becomes self-documenting (operator learns the new
+surface without grepping the changelog).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# L2 — /login refresh console output
+# ---------------------------------------------------------------------------
+
+
+def _patch_refresh_path(
+    *,
+    ok: bool,
+    new_plans: set[str],
+    new_profiles: set[str],
+) -> tuple[object, ...]:
+    """Build the three patches the refresh branch needs."""
+    plan_store = MagicMock()
+    plan_store.list_all.return_value = [
+        type("P", (), {"id": p})() for p in (new_plans | {"existing-plan"})
+    ]
+    profile_store = MagicMock()
+    profile_store.list_all.return_value = [
+        type("PR", (), {"name": n})() for n in (new_profiles | {"existing:env"})
+    ]
+
+    # Two `list_all` calls — before vs after `load_auth_toml`. Pre-call
+    # returns just the existing entries; post-call returns existing +
+    # new.
+    plan_calls = [
+        [type("P", (), {"id": "existing-plan"})()],
+        [type("P", (), {"id": p})() for p in ({"existing-plan"} | new_plans)],
+    ]
+    profile_calls = [
+        [type("PR", (), {"name": "existing:env"})()],
+        [type("PR", (), {"name": n})() for n in ({"existing:env"} | new_profiles)],
+    ]
+    plan_store.list_all.side_effect = plan_calls
+    profile_store.list_all.side_effect = profile_calls
+
+    return (
+        patch("core.llm.routing.plan_registry.get_plan_registry", return_value=plan_store),
+        patch("core.wiring.container.ensure_profile_store", return_value=profile_store),
+        patch("core.auth.auth_toml.load_auth_toml", return_value=ok),
+        patch("core.auth.auth_toml.auth_toml_path", return_value="/tmp/auth.toml"),  # noqa: S108
+    )
+
+
+def test_login_refresh_success_with_new_plans(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import cmd_login
+
+    patches = _patch_refresh_path(ok=True, new_plans={"glm-coding-lite"}, new_profiles=set())
+    with patches[0], patches[1], patches[2], patches[3]:
+        cmd_login("refresh")
+
+    out = capsys.readouterr().out
+    assert "auth.toml reloaded" in out
+    assert "+1 plan" in out
+    assert "glm-coding-lite" in out
+
+
+def test_login_refresh_no_changes_shows_muted(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import cmd_login
+
+    patches = _patch_refresh_path(ok=True, new_plans=set(), new_profiles=set())
+    with patches[0], patches[1], patches[2], patches[3]:
+        cmd_login("refresh")
+
+    out = capsys.readouterr().out
+    assert "no new plans or profiles" in out
+
+
+def test_login_refresh_failure_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.login import cmd_login
+
+    patches = _patch_refresh_path(ok=False, new_plans=set(), new_profiles=set())
+    with patches[0], patches[1], patches[2], patches[3]:
+        cmd_login("refresh")
+
+    out = capsys.readouterr().out
+    assert "auth.toml reload failed" in out
+
+
+# ---------------------------------------------------------------------------
+# L4 — /key (no args) carries migration guide
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_key_noargs_prints_migration_guide(capsys: pytest.CaptureFixture[str]) -> None:
+    from core.cli.commands.key import cmd_key
+
+    with patch("core.cli.commands.cmd_login") as fake_login:
+        cmd_key("")
+        fake_login.assert_called_once_with("")
+
+    out = capsys.readouterr().out
+    assert "Migration guide" in out
+    assert "/login add" in out
+    assert "/login set-key" in out

--- a/uv.lock
+++ b/uv.lock
@@ -1190,7 +1190,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.21"
+version = "0.99.23"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

v0.99.22 → **v0.99.23**. Closes the deferred items from the v0.99.22 sprint:

- **X1.1** (multi-rank auth order) — `ProfileStore.set_auth_order` / `get_auth_order` / `clear_auth_order`; rotator walks the list before legacy LRU. CLI: `/login order set <provider> <n1> <n2>…` + `/login order clear`. Head of list keeps X1 single-active pin parity.
- **L2** (`/login refresh` console output) — success / no-change / failure paths visible on stdout.
- **L4** (`/key` migration guide) — inline table maps legacy `/key` forms to the unified `/login` surface.

Governance doc closures (already complete in earlier versions, doc rows updated):
- **M3** — `gpt-5.5` routing via `codex_only_models` (routing.toml).
- **L1** — `/login list` / `/login ls` already alias bare `/login`.

X2 explicitly **Deferred** — needs operator decision (A keep / B weaken / C Codex-only).

## Verification

- [x] `ruff check core/ tests/ plugins/` — clean
- [x] `ruff format --check core/ tests/ plugins/` — clean
- [x] `mypy core/ plugins/` — 0 issues / 356 files
- [x] `pytest tests/ -m "not live"` — 5115+ passed (incl. 17 new tests across X1.1/L2/L4)
- [x] Version stamps — pyproject.toml / CLAUDE.md / README.md / README.ko.md / CHANGELOG → all v0.99.23