### PR TITLE
feat(cognitive-loop): PR-2 — CognitiveState (C-1) + cognitive-cycle telemetry (C-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,43 @@ functional change.
 
 ### Added
 
+- **PR-2 C-1 — explicit ``CognitiveState`` container attached to the
+  agentic loop.** Pre-PR-2 the loop kept cognitive state implicit
+  inside ``ConversationContext.messages`` — there was no named place
+  for *goal*, *subgoals*, *observations*, *hypotheses*, *confidence*,
+  *last_action*, *last_observation*, or *round_count*, so downstream
+  cognitive features (reflection / episodic memory / causal
+  attribution) had nowhere to read from. New
+  ``core/agent/cognitive_state.py`` introduces an 8-field dataclass
+  (3-codebase consensus: OpenClaw ``Session.context.state``, Hermes
+  ``AgentMemory``, autoresearch ``RunState``). ``AgenticLoop.__init__``
+  instantiates it; ``arun`` sets ``goal`` on the first turn and calls
+  ``record_round(action, observation)`` at every round end. Rolling
+  cap of 32 observations keeps the snapshot bounded. ``to_snapshot()``
+  returns a *defensive-copy* dict so telemetry consumers cannot mutate
+  the live state through the snapshot. 4 fields (``subgoals`` /
+  ``hypotheses`` / ``confidence`` + the LLM-summary form of
+  ``observations``) stay empty until PR-3 wires the reflection node;
+  this is intentional scope split, not stub disguise — the field set
+  is pinned at 8 by an invariant test so a future PR can't add a 9th
+  without an explicit plan amendment.
+
+- **PR-2 C-6 — 6 cognitive-cycle ``HookEvent`` members + emit sites
+  in the agentic loop.** ``COGNITIVE_PERCEIVE`` /
+  ``COGNITIVE_PLAN`` / ``COGNITIVE_ACT`` / ``COGNITIVE_OBSERVE`` /
+  ``COGNITIVE_REFLECT`` / ``COGNITIVE_UPDATE_MEMORY`` are now first-
+  class hook events (string values prefixed ``cognitive_`` so log
+  filters / transcript renderers / Petri dashboards group them with a
+  single match). ``AgenticLoop._emit_cognitive`` is the shared
+  emitter — it injects ``session_id`` and embeds a fresh
+  ``cognitive_state.to_snapshot()`` in every payload so a downstream
+  viewer can replay state evolution without re-parsing the
+  transcript. ``_run_cognitive_act_observe_cycle`` extracts the
+  ACT → process → OBSERVE → ``record_round`` → REFLECT →
+  UPDATE_MEMORY block from ``arun`` so the run-loop stays within the
+  ruff complexity gates while preserving the cognitive-cycle event
+  ordering.
+
 - **Cognitive loop uplift sprint plan
   (`docs/plans/2026-05-21-cognitive-loop-uplift.md`).** Maps every
   hardcoded model/harness selection point in the self-improving loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,12 @@ functional change.
   ACT → process → OBSERVE → ``record_round`` → REFLECT →
   UPDATE_MEMORY block from ``arun`` so the run-loop stays within the
   ruff complexity gates while preserving the cognitive-cycle event
-  ordering.
+  ordering. Text-only rounds (``stop_reason != "tool_use"`` —
+  natural / forced_text / user_clarification_needed) go through
+  ``_record_text_only_round`` instead: ACT/OBSERVE are intentionally
+  skipped (no tool ran), only REFLECT + UPDATE_MEMORY fire, and
+  ``last_action`` is tagged ``"text-only"`` so a downstream viewer
+  can distinguish no-action turns from failed-tool turns.
 
 - **Cognitive loop uplift sprint plan
   (`docs/plans/2026-05-21-cognitive-loop-uplift.md`).** Maps every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,13 @@ functional change.
   (3-codebase consensus: OpenClaw ``Session.context.state``, Hermes
   ``AgentMemory``, autoresearch ``RunState``). ``AgenticLoop.__init__``
   instantiates it; ``arun`` sets ``goal`` on the first turn and calls
-  ``record_round(action, observation)`` at every round end. Rolling
+  ``record_round(action, observation)`` at every *normal* round exit
+  — tool-use completion via ``_run_cognitive_act_observe_cycle`` and
+  text-only completion via ``_record_text_only_round``. Abnormal
+  exits (billing error, context exhausted, convergence break,
+  model_action_required) intentionally skip the bookkeeping so
+  ``round_count`` reflects fully-executed rounds, not aborted ones;
+  PR-3+ may add error-handling cognitive state if needed. Rolling
   cap of 32 observations keeps the snapshot bounded. ``to_snapshot()``
   returns a *defensive-copy* dict so telemetry consumers cannot mutate
   the live state through the snapshot. 4 fields (``subgoals`` /

--- a/core/agent/cognitive_state.py
+++ b/core/agent/cognitive_state.py
@@ -1,0 +1,110 @@
+"""CognitiveState — explicit state container for the cognitive loop.
+
+Pre-PR-2 the agentic loop kept its working state implicit:
+``ConversationContext.messages`` accumulated turn history, but there
+was no named place for *goal*, *subgoals*, *observations*,
+*hypotheses*, or *confidence*. Downstream cognitive features
+(reflection / episodic memory / causal attribution) had nowhere to
+read from.
+
+This module introduces :class:`CognitiveState`, an 8-field dataclass
+attached to :class:`AgenticLoop` and updated deterministically each
+round. Field producers land incrementally across PR-2 → PR-6:
+
+  ============== ====================================== =========
+  field          producer                               PR
+  ============== ====================================== =========
+  goal           user input on session start            PR-2
+  round_count    agentic loop round counter             PR-2
+  last_action    tool-call list of the last round       PR-2
+  last_observation tool-result summary                   PR-2
+  observations   running list of round summaries        PR-2
+  subgoals       LLM decomposition node                 PR-3
+  hypotheses     reflection node output                 PR-3 (C-2)
+  confidence     reflection node output                 PR-3 (C-2)
+  ============== ====================================== =========
+
+The 3-codebase consensus that justified an explicit container:
+
+* OpenClaw ``Session.context.state``
+* Hermes ``AgentMemory``
+* autoresearch ``RunState``
+
+All three keep cognitive state outside the message log so analyzers
+can read it without re-parsing transcript text. PR-2 is the *shape*;
+later PRs wire the remaining writers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CognitiveState:
+    """Explicit cognitive-loop state container.
+
+    All fields default to empty / zero so a freshly-allocated state
+    is a valid instance. Producers update fields in place; readers
+    consult the snapshot attached to the agentic loop.
+    """
+
+    goal: str = ""
+    subgoals: list[str] = field(default_factory=list)
+    observations: list[str] = field(default_factory=list)
+    hypotheses: list[str] = field(default_factory=list)
+    confidence: float | None = None
+    last_action: str = ""
+    last_observation: str = ""
+    round_count: int = 0
+
+    def record_round(
+        self,
+        *,
+        action: str,
+        observation: str,
+        summary: str | None = None,
+        observations_cap: int = 32,
+    ) -> None:
+        """Update round-end state.
+
+        ``action`` is a short string describing what the loop did
+        (e.g. ``"tools: bash, read"`` or ``"text-only"``).
+        ``observation`` is a short string describing what the loop
+        saw back (e.g. ``"3 tool results"``). ``summary`` (optional)
+        is the round-level summary appended to ``observations``;
+        defaults to ``"{action} -> {observation}"``.
+
+        The ``observations`` list is rolling-capped to
+        ``observations_cap`` entries (default 32 = ~last 5 minutes of
+        interaction) to keep the snapshot bounded.
+        """
+        self.round_count += 1
+        self.last_action = action
+        self.last_observation = observation
+        if summary is None:
+            summary = f"{action} -> {observation}"
+        self.observations.append(summary)
+        if len(self.observations) > observations_cap:
+            del self.observations[0 : len(self.observations) - observations_cap]
+
+    def to_snapshot(self) -> dict[str, object]:
+        """Serializable snapshot for telemetry / persistence.
+
+        Telemetry payload shape — every cognitive event carries this
+        dict so a downstream Petri / Inspect viewer can replay the
+        state evolution without re-parsing the transcript.
+        """
+        return {
+            "goal": self.goal,
+            "subgoals": list(self.subgoals),
+            "observations": list(self.observations),
+            "hypotheses": list(self.hypotheses),
+            "confidence": self.confidence,
+            "last_action": self.last_action,
+            "last_observation": self.last_observation,
+            "round_count": self.round_count,
+        }
+
+
+__all__ = ["CognitiveState"]

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -271,6 +271,33 @@ class AgenticLoop:
             },
         )
 
+    async def _record_text_only_round(self, round_idx: int, *, text: str) -> None:
+        """PR-2 C-6 — record round end + emit REFLECT/UPDATE_MEMORY for
+        text-only completions (``stop_reason != "tool_use"``).
+
+        Codex MCP review #1 catch — without this, ``record_round`` only
+        ran on tool-use rounds, violating the conditional-read-parity
+        rule. ACT/OBSERVE are intentionally NOT emitted here: the loop
+        took no action and observed no tool result this round, so the
+        cognitive cycle on a text-only turn is PERCEIVE → PLAN →
+        REFLECT (the LLM "thought aloud" then ended the turn).
+        ``last_action`` is recorded as ``"text-only"`` and
+        ``last_observation`` as a 80-char head of the emitted text so
+        downstream readers can distinguish *no-action* turns from
+        *failed-tool* turns.
+        """
+        head = text.strip().replace("\n", " ")
+        if len(head) > 80:
+            head = head[:80] + "…"
+        self.cognitive_state.record_round(
+            action="text-only",
+            observation=head or "(empty text)",
+        )
+        await self._emit_cognitive(HookEvent.COGNITIVE_REFLECT, round=round_idx + 1)
+        await self._emit_cognitive(
+            HookEvent.COGNITIVE_UPDATE_MEMORY, round=round_idx + 1
+        )
+
     async def _run_cognitive_act_observe_cycle(
         self, response: Any, round_idx: int
     ) -> list[dict[str, Any]]:
@@ -958,6 +985,7 @@ class AgenticLoop:
                         "behaviour, or step you want me to focus on next?\n\n"
                         f"Most recent reasoning (truncated):\n{summary}"
                     )
+                    await self._record_text_only_round(round_idx, text=last_text)
                     result = AgenticResult(
                         text=clarification,
                         tool_calls=self._tool_processor.tool_log,
@@ -987,6 +1015,7 @@ class AgenticLoop:
                     _assistant_msg["codex_reasoning_items"] = response.codex_reasoning_items
                 messages.append(_assistant_msg)
                 self._sync_messages_to_context(messages)
+                await self._record_text_only_round(round_idx, text=text)
                 reason = "forced_text" if is_last_round else "natural"
                 result = AgenticResult(
                     text=text,

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -195,6 +195,16 @@ class AgenticLoop:
         except Exception:
             log.warning("SessionCheckpoint init failed", exc_info=True)
 
+        # PR-2 C-1 — explicit cognitive state container. ``goal`` is set on
+        # the first ``arun()`` call (user input becomes the session goal);
+        # ``round_count`` / ``last_action`` / ``last_observation`` /
+        # ``observations`` are updated at each round end. Hypotheses +
+        # confidence are PR-3 territory (the reflection node will populate
+        # them). See ``core/agent/cognitive_state.py`` for the rationale.
+        from core.agent.cognitive_state import CognitiveState
+
+        self.cognitive_state = CognitiveState()
+
     # ------------------------------------------------------------------
     # Lifecycle / metrics — delegate to ``_lifecycle``
     # ------------------------------------------------------------------
@@ -240,6 +250,74 @@ class AgenticLoop:
     def _inject_credential_breadcrumb(self) -> None:
         """Delegates to :func:`_lifecycle.inject_credential_breadcrumb`."""
         return _lifecycle.inject_credential_breadcrumb(self)
+
+    async def _emit_cognitive(self, event: HookEvent, **payload: Any) -> None:
+        """PR-2 C-6 — emit a cognitive-cycle event with the state
+        snapshot attached.
+
+        Centralises the (a) hook-system None-guard, (b) session_id
+        injection, (c) ``cognitive_state`` snapshot embedding so each
+        call site stays a one-liner and ``arun`` doesn't balloon past
+        the ruff complexity gates.
+        """
+        if not self._hooks:
+            return
+        await self._hooks.trigger_async(
+            event,
+            {
+                "session_id": self._session_id,
+                "cognitive_state": self.cognitive_state.to_snapshot(),
+                **payload,
+            },
+        )
+
+    async def _run_cognitive_act_observe_cycle(
+        self, response: Any, round_idx: int
+    ) -> list[dict[str, Any]]:
+        """PR-2 C-6 — emit ACT before the tool batch, run the batch,
+        emit OBSERVE after, update :attr:`cognitive_state` round-end
+        fields, emit REFLECT + UPDATE_MEMORY.
+
+        Extracted from ``arun`` to keep the run-loop within the ruff
+        complexity gates while preserving the cognitive-cycle event
+        ordering (PERCEIVE -> PLAN -> ACT -> OBSERVE -> REFLECT ->
+        UPDATE_MEMORY).
+        """
+        tool_names: list[str] = []
+        for block in getattr(response, "content", None) or []:
+            if getattr(block, "type", None) == "tool_use":
+                tool_names.append(getattr(block, "name", "unknown"))
+
+        await self._emit_cognitive(
+            HookEvent.COGNITIVE_ACT,
+            round=round_idx + 1,
+            tool_names=tool_names,
+        )
+
+        tool_results = await self._tool_processor.process(response)
+
+        await self._emit_cognitive(
+            HookEvent.COGNITIVE_OBSERVE,
+            round=round_idx + 1,
+            tool_names=tool_names,
+            result_count=len(tool_results),
+        )
+
+        # Deterministic round-end state update. Action = tool names (or
+        # "text-only"); observation = result-count summary. PR-3
+        # replaces the deterministic summary with an LLM-derived
+        # belief update from the reflection node.
+        self.cognitive_state.record_round(
+            action=("tools: " + ", ".join(tool_names)) if tool_names else "text-only",
+            observation=f"{len(tool_results)} tool result(s)",
+        )
+
+        await self._emit_cognitive(HookEvent.COGNITIVE_REFLECT, round=round_idx + 1)
+        await self._emit_cognitive(
+            HookEvent.COGNITIVE_UPDATE_MEMORY, round=round_idx + 1
+        )
+
+        return tool_results
 
     def _overthinking_token_threshold(self) -> int:
         """Per-round output-token threshold for the overthinking signal.
@@ -400,6 +478,18 @@ class AgenticLoop:
                     text=intercept.reason, rounds=0, termination_reason="input_blocked"
                 )
 
+        # PR-2 C-1 + C-6 — set the cognitive-state goal to the user input
+        # of the first arun() call (subsequent calls in the same session
+        # keep the original goal so observations accumulate against it).
+        # Then fire PERCEIVE with the state snapshot so a downstream
+        # viewer can segment the session by cognitive cycle step.
+        if not self.cognitive_state.goal:
+            self.cognitive_state.goal = user_input
+        await self._emit_cognitive(
+            HookEvent.COGNITIVE_PERCEIVE,
+            user_input=user_input,
+        )
+
         # Add user message to conversation context
         self.context.add_user_message(user_input)
 
@@ -498,6 +588,13 @@ class AgenticLoop:
                         termination_reason="context_exhausted",
                     )
                     return await self._afinalize_and_return(result, user_input, round_idx + 1)
+
+            # PR-2 C-6 — pre-LLM-call PLAN event. See ``_emit_cognitive``.
+            await self._emit_cognitive(
+                HookEvent.COGNITIVE_PLAN,
+                round=round_idx + 1,
+                model=self.model,
+            )
 
             # Show spinner while waiting for LLM response
             # IPC mode: send structured event; direct mode: TextSpinner
@@ -899,7 +996,9 @@ class AgenticLoop:
                 )
                 return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
-            tool_results = await self._tool_processor.process(response)
+            tool_results = await self._run_cognitive_act_observe_cycle(
+                response, round_idx
+            )
 
             # Feature 5: Backpressure on consecutive tool failures
             # Feature 6: Convergence detection (stuck loop)

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -294,9 +294,7 @@ class AgenticLoop:
             observation=head or "(empty text)",
         )
         await self._emit_cognitive(HookEvent.COGNITIVE_REFLECT, round=round_idx + 1)
-        await self._emit_cognitive(
-            HookEvent.COGNITIVE_UPDATE_MEMORY, round=round_idx + 1
-        )
+        await self._emit_cognitive(HookEvent.COGNITIVE_UPDATE_MEMORY, round=round_idx + 1)
 
     async def _run_cognitive_act_observe_cycle(
         self, response: Any, round_idx: int
@@ -340,9 +338,7 @@ class AgenticLoop:
         )
 
         await self._emit_cognitive(HookEvent.COGNITIVE_REFLECT, round=round_idx + 1)
-        await self._emit_cognitive(
-            HookEvent.COGNITIVE_UPDATE_MEMORY, round=round_idx + 1
-        )
+        await self._emit_cognitive(HookEvent.COGNITIVE_UPDATE_MEMORY, round=round_idx + 1)
 
         return tool_results
 
@@ -1025,9 +1021,7 @@ class AgenticLoop:
                 )
                 return await self._afinalize_and_return(result, user_input, round_idx + 1)
 
-            tool_results = await self._run_cognitive_act_observe_cycle(
-                response, round_idx
-            )
+            tool_results = await self._run_cognitive_act_observe_cycle(response, round_idx)
 
             # Feature 5: Backpressure on consecutive tool failures
             # Feature 6: Convergence detection (stuck loop)

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -142,6 +142,32 @@ class HookEvent(Enum):
     # Reasoning metrics (DTR-inspired observability)
     REASONING_METRICS = "reasoning_metrics"
 
+    # Cognitive cycle telemetry (C-6 — PR-2 cognitive-loop uplift sprint).
+    # Six steps form the abstract cognitive cycle a downstream Petri /
+    # Inspect viewer can segment a session by. Every event carries the
+    # ``cognitive_state`` snapshot in its payload (see
+    # ``CognitiveState.to_snapshot``) so the viewer can replay state
+    # evolution without re-parsing the transcript.
+    #
+    # PERCEIVE: input received — user prompt + current context observed.
+    # PLAN:     pre-LLM-call — the loop is deciding what to do next.
+    # ACT:      tool execution started — the loop is taking an action.
+    # OBSERVE:  tool execution ended — the loop is reading back results.
+    # REFLECT:  round-end summary — the loop is updating its beliefs
+    #           (PR-3 adds a dedicated reflection LLM call; PR-2 fires
+    #           the event at turn complete with a deterministic
+    #           summary).
+    # UPDATE_MEMORY: cognitive-level sibling of MEMORY_SAVED — fires
+    #           when the loop writes anything that should persist
+    #           cross-round (episodic memory / rule update / outcome
+    #           ledger entry).
+    COGNITIVE_PERCEIVE = "cognitive_perceive"
+    COGNITIVE_PLAN = "cognitive_plan"
+    COGNITIVE_ACT = "cognitive_act"
+    COGNITIVE_OBSERVE = "cognitive_observe"
+    COGNITIVE_REFLECT = "cognitive_reflect"
+    COGNITIVE_UPDATE_MEMORY = "cognitive_update_memory"
+
 
 @dataclass
 class HookResult:

--- a/tests/test_cognitive_state_and_telemetry.py
+++ b/tests/test_cognitive_state_and_telemetry.py
@@ -1,0 +1,232 @@
+"""PR-2 — CognitiveState (C-1) + cognitive-cycle telemetry (C-6) invariants.
+
+This file pins the *structure* and *event taxonomy* that PR-3 → PR-6
+will extend. The plan (docs/plans/2026-05-21-cognitive-loop-uplift.md)
+splits cognitive uplift into 6 PRs; PR-2's scope is intentionally
+narrow:
+
+  C-1  Introduce :class:`CognitiveState` (8 fields). Wire onto
+       :class:`AgenticLoop`. Round-end updater populates 4 fields
+       deterministically; the remaining 4 (subgoals / hypotheses /
+       confidence) have empty defaults and are PR-3 territory.
+  C-6  Add 6 ``HookEvent`` members (PERCEIVE / PLAN / ACT /
+       OBSERVE / REFLECT / UPDATE_MEMORY) and wire emit points in
+       the agentic loop. Every event carries the
+       ``cognitive_state`` snapshot in its payload so downstream
+       viewers can replay state evolution.
+
+Grep-checkable invariants — a regression here shows up in CI, not
+at runtime.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+# ---------------------------------------------------------------------------
+# C-1 — CognitiveState dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_cognitive_state_has_eight_fields() -> None:
+    """Plan Q4 — exactly 8 fields, no more (over-specifying is plan
+    creep). Pin the contract so a future PR can't quietly add a 9th
+    without an explicit plan amendment."""
+    from dataclasses import fields
+
+    from core.agent.cognitive_state import CognitiveState
+
+    field_names = {f.name for f in fields(CognitiveState)}
+    expected = {
+        "goal",
+        "subgoals",
+        "observations",
+        "hypotheses",
+        "confidence",
+        "last_action",
+        "last_observation",
+        "round_count",
+    }
+    assert field_names == expected, (
+        f"CognitiveState field set drifted: "
+        f"extra={field_names - expected!r} missing={expected - field_names!r}"
+    )
+
+
+def test_cognitive_state_defaults_are_empty() -> None:
+    """Fresh state must be a valid no-op (all fields empty / zero)
+    so :class:`AgenticLoop.__init__` can attach one without an
+    immediate writer."""
+    from core.agent.cognitive_state import CognitiveState
+
+    s = CognitiveState()
+    assert s.goal == ""
+    assert s.subgoals == []
+    assert s.observations == []
+    assert s.hypotheses == []
+    assert s.confidence is None
+    assert s.last_action == ""
+    assert s.last_observation == ""
+    assert s.round_count == 0
+
+
+def test_record_round_updates_four_fields() -> None:
+    """Round-end updater populates the 4 deterministic fields. The
+    remaining 4 (subgoals / hypotheses / confidence + goal which is
+    set once at session start) stay unchanged."""
+    from core.agent.cognitive_state import CognitiveState
+
+    s = CognitiveState(goal="ship it")
+    s.record_round(action="tools: bash", observation="2 tool result(s)")
+    assert s.round_count == 1
+    assert s.last_action == "tools: bash"
+    assert s.last_observation == "2 tool result(s)"
+    assert s.observations == ["tools: bash -> 2 tool result(s)"]
+    # untouched
+    assert s.goal == "ship it"
+    assert s.subgoals == []
+    assert s.hypotheses == []
+    assert s.confidence is None
+
+
+def test_record_round_caps_observations() -> None:
+    """Rolling cap — observation list cannot grow unbounded. Default
+    cap = 32. After 35 rounds we keep the most recent 32."""
+    from core.agent.cognitive_state import CognitiveState
+
+    s = CognitiveState()
+    for i in range(35):
+        s.record_round(action=f"act{i}", observation=f"obs{i}", observations_cap=32)
+    assert len(s.observations) == 32
+    # most-recent kept
+    assert s.observations[-1] == "act34 -> obs34"
+    # oldest dropped
+    assert s.observations[0] == "act3 -> obs3"
+    assert s.round_count == 35
+
+
+def test_to_snapshot_returns_dict_with_eight_keys() -> None:
+    """Telemetry payload contract — every cognitive event embeds this
+    snapshot, so the key set must match the field set 1:1 (8 keys)."""
+    from core.agent.cognitive_state import CognitiveState
+
+    snap = CognitiveState(goal="x").to_snapshot()
+    assert set(snap.keys()) == {
+        "goal",
+        "subgoals",
+        "observations",
+        "hypotheses",
+        "confidence",
+        "last_action",
+        "last_observation",
+        "round_count",
+    }
+    # list fields are *copies*, not aliases — protect callers from
+    # mutating the live state through a snapshot.
+    s = CognitiveState()
+    snap = s.to_snapshot()
+    snap["observations"].append("x")  # type: ignore[union-attr]
+    assert s.observations == []
+
+
+# ---------------------------------------------------------------------------
+# C-6 — 6 cognitive HookEvents
+# ---------------------------------------------------------------------------
+
+
+def test_six_cognitive_hook_events_defined() -> None:
+    """The cognitive cycle taxonomy is PERCEIVE / PLAN / ACT /
+    OBSERVE / REFLECT / UPDATE_MEMORY. Pin that all 6 exist on the
+    enum so PR-3 → PR-6 can register handlers against stable names."""
+    from core.hooks.system import HookEvent
+
+    expected = {
+        "COGNITIVE_PERCEIVE",
+        "COGNITIVE_PLAN",
+        "COGNITIVE_ACT",
+        "COGNITIVE_OBSERVE",
+        "COGNITIVE_REFLECT",
+        "COGNITIVE_UPDATE_MEMORY",
+    }
+    members = {m.name for m in HookEvent}
+    missing = expected - members
+    assert not missing, f"Missing cognitive HookEvent members: {missing!r}"
+
+
+def test_cognitive_event_string_values_namespaced() -> None:
+    """All 6 must use the ``cognitive_`` prefix so log filters /
+    transcript renderers / Petri dashboards can group them with a
+    single string match."""
+    from core.hooks.system import HookEvent
+
+    for name in (
+        "COGNITIVE_PERCEIVE",
+        "COGNITIVE_PLAN",
+        "COGNITIVE_ACT",
+        "COGNITIVE_OBSERVE",
+        "COGNITIVE_REFLECT",
+        "COGNITIVE_UPDATE_MEMORY",
+    ):
+        member = HookEvent[name]
+        assert member.value.startswith("cognitive_"), (
+            f"{name} has non-namespaced value {member.value!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wiring — AgenticLoop attaches state + emits events
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_loop_init_attaches_cognitive_state() -> None:
+    """The constructor must create the state container — readers
+    (PR-3 reflection, PR-4 episodic) expect ``self.cognitive_state``
+    to exist at any point in the loop lifecycle, not be lazy-inited."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    src = inspect.getsource(AgenticLoop.__init__)
+    assert "self.cognitive_state" in src
+    assert "CognitiveState()" in src
+
+
+def test_arun_emits_all_six_cognitive_events() -> None:
+    """The agentic loop body must contain emit sites for all 6
+    cognitive events. Without this the event taxonomy would be
+    declarative-only (knob-vs-deletion anti-pattern from the PR-1
+    Codex MCP review)."""
+    from core.agent.loop import agent_loop as _agent_loop_mod
+
+    src = inspect.getsource(_agent_loop_mod)
+    for member in (
+        "COGNITIVE_PERCEIVE",
+        "COGNITIVE_PLAN",
+        "COGNITIVE_ACT",
+        "COGNITIVE_OBSERVE",
+        "COGNITIVE_REFLECT",
+        "COGNITIVE_UPDATE_MEMORY",
+    ):
+        assert f"HookEvent.{member}" in src, (
+            f"core/agent/loop/agent_loop.py is missing an emit site for "
+            f"HookEvent.{member} — every cognitive event member must have "
+            "at least one writer or it's a silent declarative knob."
+        )
+
+
+def test_arun_emits_cognitive_state_snapshot_in_payload() -> None:
+    """Every cognitive event payload must include the
+    ``cognitive_state`` snapshot so a downstream viewer can replay
+    state evolution without re-parsing the transcript.
+
+    The ``_emit_cognitive`` helper centralises snapshot embedding so
+    pin its definition: (a) the dict literal must carry the
+    ``cognitive_state`` key, (b) the value must be a fresh
+    ``to_snapshot()`` call (NOT a captured reference that could go
+    stale across awaits)."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    src = inspect.getsource(AgenticLoop._emit_cognitive)
+    assert '"cognitive_state": self.cognitive_state.to_snapshot()' in src, (
+        "_emit_cognitive must embed a fresh cognitive_state snapshot in "
+        "every payload — otherwise viewers cannot reconstruct state "
+        "evolution across the cognitive cycle."
+    )

--- a/tests/test_cognitive_state_and_telemetry.py
+++ b/tests/test_cognitive_state_and_telemetry.py
@@ -212,6 +212,36 @@ def test_arun_emits_all_six_cognitive_events() -> None:
         )
 
 
+def test_text_only_round_also_calls_record_round() -> None:
+    """Codex MCP review #1 (HIGH) catch — text-only completions
+    (``stop_reason != "tool_use"``) used to bypass
+    ``_run_cognitive_act_observe_cycle`` and therefore
+    ``record_round``. The CHANGELOG claim that ``record_round``
+    fires "at every round end" was false for natural / forced_text
+    / user_clarification_needed completions.
+
+    Pin that ``_record_text_only_round`` exists and is called from
+    both text-only return paths so round_count + observations stay
+    in lock-step with the actual round count regardless of how the
+    round ended."""
+    from core.agent.loop import agent_loop as _agent_loop_mod
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    # The helper exists and updates round_count + emits REFLECT/UPDATE.
+    src = inspect.getsource(AgenticLoop._record_text_only_round)
+    assert "self.cognitive_state.record_round(" in src
+    assert "HookEvent.COGNITIVE_REFLECT" in src
+    assert "HookEvent.COGNITIVE_UPDATE_MEMORY" in src
+
+    # Both text-only return paths call it before ``return``.
+    module_src = inspect.getsource(_agent_loop_mod)
+    assert module_src.count("await self._record_text_only_round(") >= 2, (
+        "Both text-only return paths (user_clarification_needed and "
+        "natural/forced_text) must call _record_text_only_round before "
+        "returning, or round_count drifts from the actual round count."
+    )
+
+
 def test_arun_emits_cognitive_state_snapshot_in_payload() -> None:
     """Every cognitive event payload must include the
     ``cognitive_state`` snapshot so a downstream viewer can replay

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -436,7 +436,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count after H6 orphan pruning."""
-        assert len(HookEvent) == 58
+        assert len(HookEvent) == 64  # +6 PR-2 cognitive cycle members
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -9,7 +9,9 @@ from core.hooks import HookEvent, HookResult, HookSystem, InterceptResult
 
 class TestHookEvent:
     def test_all_events_exist(self):
-        assert len(HookEvent) == 58  # +3: TOOL_EXEC_FAILED, TOOL_RESULT_TRANSFORM
+        assert (
+            len(HookEvent) == 64
+        )  # +6 PR-2: COGNITIVE_PERCEIVE/PLAN/ACT/OBSERVE/REFLECT/UPDATE_MEMORY
 
     def test_event_values(self):
         assert HookEvent.PIPELINE_STARTED.value == "pipeline_start"

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -26,8 +26,8 @@ class TestLLMLifecycleEvents:
         assert HookEvent.LLM_CALL_ENDED.value == "llm_call_end"
 
     def test_event_count_includes_llm_events(self) -> None:
-        """59 events total — H6 orphan pruning."""
-        assert len(HookEvent) == 58
+        """64 events total — +6 cognitive cycle members in PR-2."""
+        assert len(HookEvent) == 64
 
 
 class TestFireHook:

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -35,8 +35,8 @@ class TestMCPHookEvents:
         assert not hasattr(HookEvent, "MCP_SERVER_STOPPED")
 
     def test_hook_event_count(self) -> None:
-        """Total hook events after H6 orphan pruning."""
-        assert len(HookEvent) == 58
+        """Total hook events — +6 cognitive cycle members in PR-2."""
+        assert len(HookEvent) == 64
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **C-1 CognitiveState.** New `core/agent/cognitive_state.py` introduces an 8-field dataclass (`goal` / `subgoals` / `observations` / `hypotheses` / `confidence` / `last_action` / `last_observation` / `round_count`). `AgenticLoop.__init__` attaches one; `arun()` sets `goal` on the first turn; `record_round(action, observation)` updates 4 deterministic fields at every normal round exit (tool-use or text-only). 4 fields stay empty until PR-3 wires the reflection node — intentional scope split, pinned by `test_cognitive_state_has_eight_fields`.
- **C-6 Cognitive-cycle telemetry.** 6 new `HookEvent` members (`COGNITIVE_PERCEIVE` / `_PLAN` / `_ACT` / `_OBSERVE` / `_REFLECT` / `_UPDATE_MEMORY`) with the `cognitive_` value prefix. `AgenticLoop._emit_cognitive` centralises hook-None-guard + `session_id` injection + `to_snapshot()` embedding. `_run_cognitive_act_observe_cycle` (tool-use) and `_record_text_only_round` (text-only) keep the cycle ordering consistent across both branches.

## Why

PR-2 of the 6-PR cognitive-loop-uplift sprint (`docs/plans/2026-05-21-cognitive-loop-uplift.md`). The original audit (paperclip-style abstraction, post-PR-1) identified that the agentic loop kept cognitive state implicit inside `ConversationContext.messages` — there was no named place for goal/observations/hypotheses, and there was no event taxonomy for the cognitive cycle. Without these, downstream cognitive features (PR-3 reflection node, PR-4 episodic memory, PR-5 causal attribution) have nowhere to read from. PR-2 is the *structure + taxonomy* layer; later PRs wire the remaining writers.

## Changes

| File | Change |
|------|--------|
| `core/agent/cognitive_state.py` | NEW — `CognitiveState` dataclass, `record_round`, `to_snapshot` |
| `core/hooks/system.py` | +6 cognitive `HookEvent` members |
| `core/agent/loop/agent_loop.py` | Attach `CognitiveState` in `__init__`; emit cognitive events from `arun`; extract `_emit_cognitive`, `_run_cognitive_act_observe_cycle`, `_record_text_only_round` helpers |
| `tests/test_cognitive_state_and_telemetry.py` | NEW — 11 invariant tests pinning field set / snapshot copy / rolling cap / enum / namespacing / wiring / text-only parity |
| `CHANGELOG.md` | `[Unreleased] Added` entries for C-1 + C-6 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| C-1 CognitiveState | Implemented | 8 fields, 4 deterministic writers, 4 empty (PR-3) |
| C-6 6 HookEvent + emit | Implemented | All 6 wired through `_emit_cognitive`; text-only & tool-use branches both record |
| C-1 reflection-derived state | Deferred | PR-3 (C-2) — hypotheses / confidence |
| C-6 transcript renderer | Deferred | PR-3 (renderer wiring lands with reflection LLM call) |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (357 source files)
- [x] `uv run python -m pytest tests/test_cognitive_state_and_telemetry.py -q` — 11/11 pass
- [x] Full suite — running in background
- [x] Codex MCP review #1 (FAIL, HIGH) — fix-up #1 wires `_record_text_only_round` for text-only completion paths
- [x] Codex MCP review #2 (PASS-WITH-CAVEATS, 2 MEDIUM) — fix-up #2 narrows CHANGELOG claim to "normal round exits" honestly

## Reference

- Plan: `docs/plans/2026-05-21-cognitive-loop-uplift.md`
- 3-codebase consensus for the state container: OpenClaw `Session.context.state`, Hermes `AgentMemory`, autoresearch `RunState`