### PR TITLE
feat(cognitive-loop): PR-4 — episodic action-outcome memory (C-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,40 @@ functional change.
 
 ### Added
 
+- **PR-4 C-3 — episodic action-outcome memory.** Pre-PR-4
+  ``core.memory`` carried four memory types (user / project /
+  feedback / reference) but had no place to record action → outcome
+  triples. New ``core/memory/episodic.py`` introduces an append-only
+  JSONL ledger at ``~/.geode/memory/episodes.jsonl`` (constants
+  ``GLOBAL_MEMORY_DIR`` + ``GLOBAL_EPISODES_LOG`` in ``core/paths.py``)
+  with one row per tool execution: ``timestamp_ns / session_id /
+  round / tool_name / tool_input_head (200 chars) / success / error
+  (200 chars) / duration_ms / cognitive_state`` snapshot. Rolling
+  cap of 1000 rows with 25%-overshoot rotation tolerance (atomic
+  temp-file rewrite so concurrent readers never see a partial file).
+  Retrieval API ``EpisodicStore.recent(*, tool_name, session_id,
+  limit)`` returns newest-first, defensively skips malformed rows
+  with a WARN. Process-global singleton via ``get_episodic_store`` /
+  ``set_episodic_store`` (test seam).
+
+- **PR-4 C-3 — ContextVar bridge for the active cognitive state.**
+  Hooks fired from inside the tool executor (TOOL_EXEC_ENDED → the
+  episodic recorder) need both ``CognitiveState`` and ``session_id``
+  but the executor knows neither. New
+  ``core/agent/cognitive_state_ctx.py`` exposes paired get/set
+  accessors (CLAUDE.md "ContextVar injection" rule — every
+  ``get_*()`` has a corresponding ``set_*()``). ``AgenticLoop.arun``
+  binds both at session start; the bootstrap hook reads them when
+  recording each episode.
+
+- **PR-4 C-3 — bootstrap TOOL_EXEC_ENDED handler.**
+  ``core/wiring/bootstrap.py`` registers the
+  ``episodic_memory_recorder`` plugin (priority 70, observer) — fires
+  after the interceptor chain but before audit loggers. Writes one
+  Episode per tool execution including the cognitive-state snapshot
+  read from the ContextVar. ``OSError`` during append is swallowed
+  with a WARN so a full disk can't crash the agentic loop.
+
 - **PR-3 C-2 — reflection node (LLM-driven belief update after the
   tool batch).** Pre-PR-3 the loop went tool result → next action with
   no explicit belief-update step; ``CognitiveState.hypotheses`` and

--- a/core/agent/cognitive_state_ctx.py
+++ b/core/agent/cognitive_state_ctx.py
@@ -1,0 +1,69 @@
+"""ContextVar-scoped accessor for the active :class:`CognitiveState`.
+
+PR-4 C-3 of the cognitive-loop-uplift sprint
+(``docs/plans/2026-05-21-cognitive-loop-uplift.md``).
+
+Hooks fired from inside the agentic loop (TOOL_EXEC_ENDED in
+particular) need to embed a ``cognitive_state`` snapshot in the
+episode they record, but the tool executor — which constructs the
+TOOL_EXEC_ENDED payload — has no reference to the surrounding
+:class:`AgenticLoop`. A ContextVar bridges the two without coupling
+the executor's API to a new positional argument.
+
+Contract:
+  - :class:`AgenticLoop` calls :func:`set_cognitive_state` once at
+    session start with its ``self.cognitive_state``.
+  - Hook handlers and any cross-cutting observer can read it via
+    :func:`get_cognitive_state`. Returns ``None`` if no loop is
+    active (test harnesses, standalone tool invocations).
+
+Read-Write parity (CLAUDE.md): every reader pairs with a writer.
+Both live in this module so the bilateral wiring stays grep-visible.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.agent.cognitive_state import CognitiveState
+
+
+_active_state: ContextVar[CognitiveState | None] = ContextVar(
+    "geode_active_cognitive_state", default=None
+)
+_active_session_id: ContextVar[str] = ContextVar("geode_active_session_id", default="")
+
+
+def get_cognitive_state() -> CognitiveState | None:
+    """Return the active :class:`CognitiveState`, or ``None`` if no
+    agentic loop is bound to this context."""
+    return _active_state.get()
+
+
+def set_cognitive_state(state: CognitiveState | None) -> None:
+    """Bind ``state`` to the current context. ``None`` clears the
+    binding (useful for test isolation)."""
+    _active_state.set(state)
+
+
+def get_session_id() -> str:
+    """Return the active agentic loop's session id, or ``""`` if no
+    loop is bound to this context. Paired with the cognitive-state
+    ContextVar so episodic memory rows can carry both without the
+    tool executor knowing about either."""
+    return _active_session_id.get()
+
+
+def set_session_id(session_id: str) -> None:
+    """Bind ``session_id`` to the current context."""
+    _active_session_id.set(session_id)
+
+
+__all__ = [
+    "get_cognitive_state",
+    "get_session_id",
+    "set_cognitive_state",
+    "set_session_id",
+]

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -543,6 +543,14 @@ class AgenticLoop:
         # hooks fired from inside the tool executor (TOOL_EXEC_ENDED
         # → episodic memory recorder) can read the live state without
         # being coupled to AgenticLoop directly.
+        #
+        # Lifetime: the binding is asyncio-task-scoped. Each top-level
+        # task gets its own ``contextvars.Context`` copy, so two
+        # concurrent AgenticLoops in different tasks each see their
+        # own bind. Within the same task multiple ``arun`` calls
+        # overwrite idempotently. No explicit reset is needed since
+        # the next ``arun`` overwrites and out-of-loop hook firings
+        # in the same task are not a documented use case.
         from core.agent.cognitive_state_ctx import set_cognitive_state, set_session_id
 
         set_cognitive_state(self.cognitive_state)

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -539,6 +539,14 @@ class AgenticLoop:
         # viewer can segment the session by cognitive cycle step.
         if not self.cognitive_state.goal:
             self.cognitive_state.goal = user_input
+        # PR-4 C-3 — bind the CognitiveState to the ContextVar so
+        # hooks fired from inside the tool executor (TOOL_EXEC_ENDED
+        # → episodic memory recorder) can read the live state without
+        # being coupled to AgenticLoop directly.
+        from core.agent.cognitive_state_ctx import set_cognitive_state, set_session_id
+
+        set_cognitive_state(self.cognitive_state)
+        set_session_id(self._session_id)
         await self._emit_cognitive(
             HookEvent.COGNITIVE_PERCEIVE,
             user_input=user_input,

--- a/core/memory/episodic.py
+++ b/core/memory/episodic.py
@@ -1,0 +1,244 @@
+"""EpisodicStore — append-only action-outcome ledger.
+
+PR-4 C-3 of the cognitive-loop-uplift sprint
+(``docs/plans/2026-05-21-cognitive-loop-uplift.md``).
+
+Pre-PR-4 ``core.memory`` carried four memory types (user / project /
+feedback / reference) but had no place to record *action → outcome*
+triples. PR-5 (causal attribution) needs that signal to compute
+"tool X succeeded in situation Y at rate Z" deltas; PR-3's
+reflection node already populates ``CognitiveState.hypotheses`` /
+``confidence`` but never persisted them anywhere cross-session.
+
+This module persists one row per tool execution to
+``~/.geode/memory/episodes.jsonl``:
+
+  - timestamp_ns       (int)
+  - session_id         (str)
+  - round              (int, 0-based)
+  - tool_name          (str)
+  - tool_input_head    (str <= 200 chars — head of the input dict)
+  - success            (bool)
+  - error              (str | None, <= 200 chars)
+  - duration_ms        (float)
+  - cognitive_state    (dict — full snapshot, see CognitiveState.to_snapshot)
+
+The file is rolling-capped at ``EPISODE_LOG_MAX_ROWS`` (default
+1000) — when an append crosses the threshold the oldest rows are
+dropped via an atomic write-and-rename so concurrent readers always
+see a consistent file.
+
+Retrieval API:
+  - :meth:`EpisodicStore.recent` — most-recent N rows, optionally
+    filtered by ``tool_name`` and/or ``session_id``.
+
+PR-5 will add cosine-embedding-based retrieval on top of this base
+layer (Voyager ``SkillLibrary`` pattern); PR-4 stops at the file +
+recency filter so the foundation is committed before the embedding
+dependency lands.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_EPISODES_LOG, GLOBAL_MEMORY_DIR
+
+log = logging.getLogger(__name__)
+
+EPISODE_LOG_MAX_ROWS = 1000
+
+
+@dataclass
+class Episode:
+    """One row in the episodic ledger."""
+
+    timestamp_ns: int
+    session_id: str
+    round: int
+    tool_name: str
+    tool_input_head: str
+    success: bool
+    error: str | None
+    duration_ms: float
+    cognitive_state: dict[str, Any] = field(default_factory=dict)
+
+    def to_jsonl(self) -> str:
+        """Serialize to a single JSONL line (no trailing newline)."""
+        return json.dumps(asdict(self), ensure_ascii=False, sort_keys=True)
+
+
+def _summarise_tool_input(tool_input: dict[str, Any] | str | None, cap: int = 200) -> str:
+    """Best-effort short string for the ``tool_input_head`` field.
+
+    Dicts are dumped to JSON; strings pass through; None becomes
+    ``""``. Output is trimmed to ``cap`` chars + ellipsis.
+    """
+    if tool_input is None:
+        return ""
+    if isinstance(tool_input, str):
+        text = tool_input
+    else:
+        try:
+            text = json.dumps(tool_input, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            text = str(tool_input)
+    text = text.replace("\n", " ").strip()
+    if len(text) > cap:
+        return text[:cap] + "…"
+    return text
+
+
+class EpisodicStore:
+    """File-backed rolling-cap episodic ledger.
+
+    The store is a thin wrapper around ``GLOBAL_EPISODES_LOG`` — every
+    append writes one JSONL row; periodically (when the row count
+    crosses ``max_rows + max_rows // 4``) the file is rewritten with
+    only the most recent ``max_rows`` rows so the on-disk size stays
+    bounded.
+
+    The 25% overshoot tolerance is intentional — rewriting on every
+    append would be wasteful. Worst case the file holds
+    ``max_rows * 1.25`` rows for a moment.
+    """
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        max_rows: int = EPISODE_LOG_MAX_ROWS,
+    ) -> None:
+        self._path = path if path is not None else GLOBAL_EPISODES_LOG
+        self._max_rows = max_rows
+        # File access is serialised with a lock — multiple AgenticLoop
+        # instances in the same process (sub-agents) can record
+        # concurrently. Cross-process locking is not done here; the
+        # final consumer is PR-5 which only reads.
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, episode: Episode) -> None:
+        """Append ``episode`` to the log; rotate on overshoot."""
+        with self._lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(episode.to_jsonl())
+                fh.write("\n")
+            self._maybe_rotate()
+
+    def _maybe_rotate(self) -> None:
+        """Rewrite the log keeping only the last ``max_rows`` rows if
+        the row count crosses the 25% overshoot threshold."""
+        threshold = self._max_rows + self._max_rows // 4
+        try:
+            with self._path.open("r", encoding="utf-8") as fh:
+                rows = fh.readlines()
+        except FileNotFoundError:
+            return
+        if len(rows) <= threshold:
+            return
+        keep = rows[-self._max_rows :]
+        # Atomic rewrite — temp file + rename so a concurrent reader
+        # never sees a partial file.
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text("".join(keep), encoding="utf-8")
+        tmp.replace(self._path)
+
+    def recent(
+        self,
+        *,
+        tool_name: str | None = None,
+        session_id: str | None = None,
+        limit: int = 10,
+    ) -> list[Episode]:
+        """Return the most-recent ``limit`` episodes matching the
+        optional ``tool_name`` and/or ``session_id`` filters.
+
+        Returned list is ordered newest-first.
+
+        Malformed rows (legacy schema, partial write) are skipped with
+        a WARN — never raise. The retrieval API is read-side defensive
+        because PR-5 will run it during every audit cycle.
+        """
+        try:
+            with self._path.open("r", encoding="utf-8") as fh:
+                rows = fh.readlines()
+        except FileNotFoundError:
+            return []
+        matches: list[Episode] = []
+        for raw in reversed(rows):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                log.warning("episodic log row not valid JSON; skipping. raw=%r", line[:120])
+                continue
+            if tool_name is not None and payload.get("tool_name") != tool_name:
+                continue
+            if session_id is not None and payload.get("session_id") != session_id:
+                continue
+            try:
+                matches.append(Episode(**payload))
+            except TypeError:
+                log.warning(
+                    "episodic log row missing fields; skipping. payload=%r",
+                    {k: type(v).__name__ for k, v in payload.items()},
+                )
+                continue
+            if len(matches) >= limit:
+                break
+        return matches
+
+
+# ---------------------------------------------------------------------------
+# Process-global singleton — bootstrap registers a TOOL_EXEC_ENDED hook
+# handler that calls ``record_episode``; PR-5 readers consult the same
+# instance via :func:`get_episodic_store`.
+# ---------------------------------------------------------------------------
+
+_singleton: EpisodicStore | None = None
+_singleton_lock = threading.Lock()
+
+
+def get_episodic_store() -> EpisodicStore:
+    """Return the process-wide episodic store singleton.
+
+    The store is lazily created on first call to keep cold-start free
+    of the memory-dir mkdir. Tests can substitute a different store
+    via :func:`set_episodic_store`.
+    """
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = EpisodicStore()
+    return _singleton
+
+
+def set_episodic_store(store: EpisodicStore | None) -> None:
+    """Replace the singleton (test seam). Pass ``None`` to reset."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = store
+
+
+__all__ = [
+    "EPISODE_LOG_MAX_ROWS",
+    "GLOBAL_EPISODES_LOG",
+    "GLOBAL_MEMORY_DIR",
+    "Episode",
+    "EpisodicStore",
+    "get_episodic_store",
+    "set_episodic_store",
+]

--- a/core/paths.py
+++ b/core/paths.py
@@ -62,6 +62,14 @@ GLOBAL_SELF_IMPROVING_LOOP_DIR = GEODE_HOME / "self-improving-loop"
 # (no env var required).
 GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "wrapper-sections.json"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
+# PR-4 C-3 (2026-05-21) — cross-session episodic action-outcome log
+# (~/.geode/memory/episodes.jsonl). Append-only JSONL: one row per
+# tool execution with (timestamp, session_id, tool_name, tool_input,
+# success/error, cognitive_state snapshot). Rolling cap of
+# ``EPISODE_LOG_MAX_ROWS`` keeps the file bounded. Read by
+# :class:`core.memory.episodic.EpisodicStore` retrieval API.
+GLOBAL_MEMORY_DIR = GEODE_HOME / "memory"
+GLOBAL_EPISODES_LOG = GLOBAL_MEMORY_DIR / "episodes.jsonl"
 # P1-F (2026-05-17) — per-user Petri audit role × model × source override.
 # Read by ``plugins.petri_audit.user_overrides`` and merged into the
 # binding resolver. Kept as a separate TOML (rather than wedged into

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -396,6 +396,15 @@ def build_hooks(
     # so PR-5 can compute "tool X succeeded in situation Y at rate Z"
     # deltas. Hook is registered at priority 70 — observer, runs after
     # the TOOL_EXEC_ENDED interceptors but before audit loggers.
+    #
+    # Threading note: the EpisodicStore.append path is synchronous file
+    # I/O. It fires inside the asyncio hook flow (the agent loop awaits
+    # ``trigger_with_result_async``) so it briefly blocks the event
+    # loop. Per-write cost is one ``write()`` + occasional rotation
+    # (capped at max_rows * 1.25 ≈ 1250 rows, with an atomic temp-file
+    # rewrite). Bounded enough that async-to-thread offload would add
+    # more overhead than it saves; revisit if hot-path profiling shows
+    # the recorder is a tail-latency contributor.
     def _reg_episodic_memory() -> None:
         import time
 

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -390,6 +390,61 @@ def build_hooks(
 
     _register_plugin("tool_approval_hook", _reg_tool_approval)
 
+    # PR-4 C-3 — episodic action-outcome ledger. TOOL_EXEC_ENDED carries
+    # (tool_name, tool_input, has_error, result, duration_ms); we record
+    # an Episode row + the COGNITIVE_UPDATE_MEMORY hook (PR-2) snapshot
+    # so PR-5 can compute "tool X succeeded in situation Y at rate Z"
+    # deltas. Hook is registered at priority 70 — observer, runs after
+    # the TOOL_EXEC_ENDED interceptors but before audit loggers.
+    def _reg_episodic_memory() -> None:
+        import time
+
+        from core.agent.cognitive_state_ctx import get_cognitive_state, get_session_id
+        from core.memory.episodic import Episode, _summarise_tool_input, get_episodic_store
+
+        store = get_episodic_store()
+
+        def _on_tool_end(_event: HookEvent, data: dict[str, Any]) -> None:
+            tool_name = str(data.get("tool_name", "?"))
+            tool_input = data.get("tool_input")
+            has_error = bool(data.get("has_error"))
+            result = data.get("result")
+            error: str | None = None
+            if has_error and isinstance(result, dict):
+                error_val = result.get("error")
+                if isinstance(error_val, str):
+                    error = error_val[:200]
+            state = get_cognitive_state()
+            snapshot = state.to_snapshot() if state is not None else {}
+            session_id = get_session_id()
+            round_raw = snapshot.get("round_count", 0)
+            round_count = round_raw if isinstance(round_raw, int) else 0
+            input_head_arg = tool_input if isinstance(tool_input, dict | str) else None
+            episode = Episode(
+                timestamp_ns=time.time_ns(),
+                session_id=session_id,
+                round=round_count,
+                tool_name=tool_name,
+                tool_input_head=_summarise_tool_input(input_head_arg),
+                success=not has_error,
+                error=error,
+                duration_ms=float(data.get("duration_ms", 0.0)),
+                cognitive_state=snapshot,
+            )
+            try:
+                store.append(episode)
+            except OSError:
+                log.warning("episodic store append failed; skipping", exc_info=True)
+
+        hooks.register(
+            HookEvent.TOOL_EXEC_ENDED,
+            _on_tool_end,
+            name="episodic_memory_recorder",
+            priority=70,
+        )
+
+    _register_plugin("episodic_memory_hook", _reg_episodic_memory)
+
     # C8: Filesystem hook plugin auto-discovery (.geode/hooks/ + core/hooks/plugins/)
     def _reg_filesystem_plugins() -> None:
         from core.hooks.discovery import HookPluginLoader

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -1,0 +1,343 @@
+"""PR-4 C-3 — Episodic action-outcome memory invariants.
+
+Pins the contract for ``core/memory/episodic.py`` (Episode dataclass,
+EpisodicStore append + rotate + recent), the ContextVar bridge
+(``core/agent/cognitive_state_ctx.py``), and the bootstrap hook
+that records one Episode per TOOL_EXEC_ENDED event.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from core.memory.episodic import (
+    EPISODE_LOG_MAX_ROWS,
+    Episode,
+    EpisodicStore,
+    _summarise_tool_input,
+)
+
+# ---------------------------------------------------------------------------
+# Episode dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_episode_to_jsonl_roundtrip() -> None:
+    ep = Episode(
+        timestamp_ns=12345,
+        session_id="s-abc",
+        round=3,
+        tool_name="bash",
+        tool_input_head="ls",
+        success=True,
+        error=None,
+        duration_ms=42.0,
+        cognitive_state={"goal": "x", "round_count": 3},
+    )
+    line = ep.to_jsonl()
+    payload = json.loads(line)
+    assert payload["tool_name"] == "bash"
+    assert payload["success"] is True
+    assert payload["round"] == 3
+    assert payload["cognitive_state"]["goal"] == "x"
+
+
+def test_episode_to_jsonl_no_trailing_newline() -> None:
+    """``append`` writes the newline; ``to_jsonl`` returns the row only.
+    Otherwise the file ends up double-newline-separated."""
+    ep = Episode(
+        timestamp_ns=1,
+        session_id="s",
+        round=0,
+        tool_name="t",
+        tool_input_head="",
+        success=True,
+        error=None,
+        duration_ms=0.0,
+    )
+    assert not ep.to_jsonl().endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# _summarise_tool_input
+# ---------------------------------------------------------------------------
+
+
+def test_summarise_tool_input_none() -> None:
+    assert _summarise_tool_input(None) == ""
+
+
+def test_summarise_tool_input_str_passthrough() -> None:
+    assert _summarise_tool_input("hello") == "hello"
+
+
+def test_summarise_tool_input_dict_to_json() -> None:
+    out = _summarise_tool_input({"path": "./foo.txt", "mode": "r"})
+    assert "path" in out and "foo.txt" in out
+
+
+def test_summarise_tool_input_caps_long() -> None:
+    out = _summarise_tool_input("x" * 500)
+    assert out.endswith("…")
+    # 200 head + ellipsis
+    assert len(out) == 201
+
+
+# ---------------------------------------------------------------------------
+# EpisodicStore — append + rotate + recent
+# ---------------------------------------------------------------------------
+
+
+def _make_episode(i: int, *, tool: str = "bash", session: str = "s-1") -> Episode:
+    return Episode(
+        timestamp_ns=i,
+        session_id=session,
+        round=i,
+        tool_name=tool,
+        tool_input_head=f"input{i}",
+        success=True,
+        error=None,
+        duration_ms=float(i),
+    )
+
+
+def test_store_append_creates_file_and_writes_row(tmp_path: Path) -> None:
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl")
+    store.append(_make_episode(1))
+    assert store.path.exists()
+    rows = store.path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 1
+    assert json.loads(rows[0])["timestamp_ns"] == 1
+
+
+def test_store_append_creates_parent_dir(tmp_path: Path) -> None:
+    """Parent dir is created on first append — the writer must not
+    assume the global ~/.geode/memory/ dir exists."""
+    nested = tmp_path / "deep" / "nested" / "memory"
+    store = EpisodicStore(path=nested / "episodes.jsonl")
+    store.append(_make_episode(1))
+    assert (nested / "episodes.jsonl").exists()
+
+
+def test_store_rotate_triggers_at_25pct_overshoot(tmp_path: Path) -> None:
+    """Rotation fires when row count exceeds ``max_rows + max_rows//4``.
+    Append exactly max_rows + 1 over the threshold to force one
+    rotation; verify the file then holds exactly ``max_rows`` rows
+    AND the newest entry survives."""
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl", max_rows=100)
+    threshold = 100 + 100 // 4  # 125
+    for i in range(1, threshold + 2):  # 126 rows → rotation triggers on the 126th
+        store.append(_make_episode(i))
+    rows = store.path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 100, f"expected 100 after rotation, got {len(rows)}"
+    last = json.loads(rows[-1])
+    first = json.loads(rows[0])
+    assert last["timestamp_ns"] == 126
+    # Oldest kept = 126 - 100 + 1 = 27
+    assert first["timestamp_ns"] == 27
+
+
+def test_store_rotate_keeps_growth_bounded(tmp_path: Path) -> None:
+    """Long-running: 130 appends with cap 100 leaves the file holding
+    at most ``max_rows * 1.25`` (125) rows — the 25% overshoot is the
+    documented worst case."""
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl", max_rows=100)
+    for i in range(1, 131):
+        store.append(_make_episode(i))
+    rows = store.path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) <= 125
+    last = json.loads(rows[-1])
+    assert last["timestamp_ns"] == 130
+
+
+def test_store_no_rotate_below_threshold(tmp_path: Path) -> None:
+    """At max + 24% (just under 25% overshoot) the rotate does NOT
+    fire — avoid thrashing on the boundary."""
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl", max_rows=100)
+    for i in range(1, 125):  # 124 rows = max + 24%
+        store.append(_make_episode(i))
+    rows = store.path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 124
+
+
+def test_store_recent_returns_newest_first(tmp_path: Path) -> None:
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl", max_rows=100)
+    for i in range(1, 11):
+        store.append(_make_episode(i))
+    recent = store.recent(limit=3)
+    assert len(recent) == 3
+    assert [e.timestamp_ns for e in recent] == [10, 9, 8]
+
+
+def test_store_recent_filters_by_tool_name(tmp_path: Path) -> None:
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl", max_rows=100)
+    for i in range(1, 6):
+        store.append(_make_episode(i, tool="bash"))
+    for i in range(6, 11):
+        store.append(_make_episode(i, tool="read"))
+    recent = store.recent(tool_name="bash", limit=10)
+    assert len(recent) == 5
+    assert all(e.tool_name == "bash" for e in recent)
+
+
+def test_store_recent_filters_by_session_id(tmp_path: Path) -> None:
+    store = EpisodicStore(path=tmp_path / "episodes.jsonl", max_rows=100)
+    store.append(_make_episode(1, session="s-A"))
+    store.append(_make_episode(2, session="s-B"))
+    store.append(_make_episode(3, session="s-A"))
+    recent = store.recent(session_id="s-A")
+    assert len(recent) == 2
+    assert all(e.session_id == "s-A" for e in recent)
+
+
+def test_store_recent_empty_log_returns_empty_list(tmp_path: Path) -> None:
+    store = EpisodicStore(path=tmp_path / "absent.jsonl")
+    assert store.recent() == []
+
+
+def test_store_recent_skips_malformed_rows(tmp_path: Path) -> None:
+    """Anti-deception — partial writes / legacy schemas must not
+    raise; they're skipped with a WARN. PR-5 retrieval runs against
+    the live log on every audit."""
+    path = tmp_path / "episodes.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                _make_episode(1).to_jsonl(),
+                "this is not json",
+                _make_episode(2).to_jsonl(),
+                "{}",  # valid JSON but missing schema fields
+                _make_episode(3).to_jsonl(),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    store = EpisodicStore(path=path)
+    recent = store.recent(limit=10)
+    assert [e.timestamp_ns for e in recent] == [3, 2, 1]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_default_max_rows_is_1000() -> None:
+    """Plan Q4 — cap 1000 episodes (rolling)."""
+    assert EPISODE_LOG_MAX_ROWS == 1000
+
+
+def test_global_paths_constants_exist() -> None:
+    from core.paths import GLOBAL_EPISODES_LOG, GLOBAL_MEMORY_DIR
+
+    assert GLOBAL_MEMORY_DIR.name == "memory"
+    assert GLOBAL_EPISODES_LOG.name == "episodes.jsonl"
+    assert GLOBAL_EPISODES_LOG.parent == GLOBAL_MEMORY_DIR
+
+
+# ---------------------------------------------------------------------------
+# ContextVar bridge — get/set parity
+# ---------------------------------------------------------------------------
+
+
+def test_cognitive_state_ctx_has_paired_get_set() -> None:
+    """CLAUDE.md "ContextVar injection" — every get_*() must pair
+    with a set_*(). Both pairs live in cognitive_state_ctx."""
+    from core.agent import cognitive_state_ctx
+
+    assert hasattr(cognitive_state_ctx, "get_cognitive_state")
+    assert hasattr(cognitive_state_ctx, "set_cognitive_state")
+    assert hasattr(cognitive_state_ctx, "get_session_id")
+    assert hasattr(cognitive_state_ctx, "set_session_id")
+
+
+def test_cognitive_state_ctx_default_is_none() -> None:
+    """Unset ContextVar reads must be safe (not raise) — hooks may
+    fire outside the agentic loop (e.g. background tool execution)."""
+    from core.agent.cognitive_state_ctx import get_cognitive_state, get_session_id
+
+    # No bind — defaults
+    assert get_cognitive_state() is None
+    assert get_session_id() == ""
+
+
+def test_cognitive_state_ctx_set_get_roundtrip() -> None:
+    from core.agent.cognitive_state import CognitiveState
+    from core.agent.cognitive_state_ctx import (
+        get_cognitive_state,
+        get_session_id,
+        set_cognitive_state,
+        set_session_id,
+    )
+
+    state = CognitiveState(goal="x")
+    set_cognitive_state(state)
+    set_session_id("s-ctx-test")
+    try:
+        assert get_cognitive_state() is state
+        assert get_session_id() == "s-ctx-test"
+    finally:
+        # clean up so other tests aren't affected
+        set_cognitive_state(None)
+        set_session_id("")
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap wiring — TOOL_EXEC_ENDED handler registered
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_registers_episodic_memory_hook() -> None:
+    """Pin the bootstrap registration. Without this, the recorder
+    would exist but never fire (Handler exists ≠ handler fires —
+    CLAUDE.md Hook registration rule)."""
+    from core.wiring import bootstrap
+
+    src = inspect.getsource(bootstrap)
+    # the plugin registration call
+    assert '"episodic_memory_hook"' in src
+    # registers on TOOL_EXEC_ENDED
+    assert "HookEvent.TOOL_EXEC_ENDED" in src
+    assert "episodic_memory_recorder" in src
+
+
+def test_agentic_loop_arun_binds_contextvars() -> None:
+    """Pin the writer side of the ContextVar parity. arun() must
+    call both set_cognitive_state and set_session_id at session
+    start so the bootstrap hook handler sees a bound state."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    src = inspect.getsource(AgenticLoop.arun)
+    assert "set_cognitive_state(self.cognitive_state)" in src
+    assert "set_session_id(self._session_id)" in src
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> None:
+    """Reset the EpisodicStore singleton between tests so each test
+    that uses the global accessor starts clean."""
+    from core.memory.episodic import set_episodic_store
+
+    set_episodic_store(None)
+    yield
+    set_episodic_store(None)
+
+
+def test_get_episodic_store_returns_singleton() -> None:
+    from core.memory.episodic import get_episodic_store
+
+    a = get_episodic_store()
+    b = get_episodic_store()
+    assert a is b
+
+
+def test_set_episodic_store_overrides_singleton(tmp_path: Path) -> None:
+    from core.memory.episodic import get_episodic_store, set_episodic_store
+
+    custom = EpisodicStore(path=tmp_path / "x.jsonl")
+    set_episodic_store(custom)
+    assert get_episodic_store() is custom


### PR DESCRIPTION
## Summary

- **C-3 Episodic memory.** New `core/memory/episodic.py` — append-only JSONL at `~/.geode/memory/episodes.jsonl`, one row per tool execution with `(timestamp, session_id, round, tool_name, tool_input_head, success, error, duration_ms, cognitive_state snapshot)`. Rolling cap of 1000 with 25%-overshoot rotation tolerance + atomic rewrite. `recent(tool_name, session_id, limit)` retrieval, newest-first, defensively skips malformed rows.
- **ContextVar bridge.** New `core/agent/cognitive_state_ctx.py` — paired `get/set_cognitive_state` + `get/set_session_id` accessors. `AgenticLoop.arun` binds both at session start; the bootstrap hook reads them when recording each episode (decouples the tool executor from the agentic loop).
- **Bootstrap wiring.** `core/wiring/bootstrap.py` registers `episodic_memory_recorder` on `TOOL_EXEC_ENDED` at priority 70. `OSError` on append swallowed with WARN — full disk can't crash the loop.

## Why

PR-5 (causal attribution) needs cross-session action → outcome triples to compute "tool X succeeded in situation Y at rate Z" deltas; PR-3 already populates `CognitiveState.hypotheses` / `confidence` but never persisted them cross-session. PR-4 is the persistence layer — file format, rotation policy, retrieval API, and wiring. Cosine-embedding-based retrieval is deferred to a follow-up (Voyager `SkillLibrary` pattern) so the foundation lands first.

## Changes

| File | Change |
|------|--------|
| `core/memory/episodic.py` | NEW — `Episode` dataclass, `EpisodicStore` (append + rotate + recent), `_summarise_tool_input`, singleton |
| `core/agent/cognitive_state_ctx.py` | NEW — paired ContextVar accessors |
| `core/agent/loop/agent_loop.py` | `arun()` binds `set_cognitive_state` + `set_session_id` |
| `core/paths.py` | `GLOBAL_MEMORY_DIR` + `GLOBAL_EPISODES_LOG` constants |
| `core/wiring/bootstrap.py` | `episodic_memory_hook` plugin — `TOOL_EXEC_ENDED` recorder |
| `tests/test_episodic_memory.py` | NEW — 25 tests (dataclass, summarise, store ops, ContextVar parity, wiring) |
| `CHANGELOG.md` | `[Unreleased] Added` — 3 entries |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Episode dataclass + JSONL ledger | Implemented | 9 fields, rolling cap 1000, 25% overshoot tolerance |
| ToolExecutor exports results | Implemented | Via TOOL_EXEC_ENDED hook listener (no executor API change) |
| Retrieval API | Implemented | `recent(tool_name, session_id, limit)`, newest-first |
| Cosine similarity retrieval | Deferred | Follow-up; foundation stays embedding-free |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (360 source files)
- [x] `uv run python -m pytest tests/test_episodic_memory.py -q` — 25/25 pass
- [x] Full suite — running in background

## Reference

- Plan: `docs/plans/2026-05-21-cognitive-loop-uplift.md` C-3 (Q1-Q5)
- 3-codebase consensus: OpenClaw `ToolExecutionLog`, Voyager `SkillLibrary`, autoresearch `seed_pool.jsonl`