### PR TITLE
feat(cognitive-loop): PR-5 — causal attribution (C-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,42 @@ functional change.
 
 ### Added
 
+- **PR-5 C-4 — causal attribution for applied mutations.** Pre-PR-5
+  ``mutations.jsonl`` recorded *what* changed (target section, new
+  value, rationale) but not *what happened next* — only the binary
+  ``audit_failed → rollback`` signal. The ``Mutation`` dataclass now
+  carries three new fields: ``mutation_id`` (uuid hex, auto-generated
+  when the LLM doesn't supply one), ``expected_dim`` (per-dim
+  expected delta the LLM commits to, e.g. ``{"safety": +0.3,
+  "helpfulness": -0.05}``), and ``rollback_condition`` (free-text
+  predicate for revert eligibility). ``parse_mutation`` extracts the
+  new fields with schema-typed casts (non-numeric ``expected_dim``
+  entries silently dropped, missing fields fall through to defaults
+  so older LLM responses still parse). The mutation-contract suffix
+  in the system prompt documents the new fields so the LLM knows to
+  emit them. ``Mutation.to_audit_row`` now tags each applied row
+  with ``kind="applied"`` so attribution rows can sit alongside in
+  the same JSONL.
+
+- **PR-5 C-4 — attribution module.** New
+  ``core/self_improving_loop/attribution.py`` computes per-dim
+  ``observed_dim`` (signed delta = ``after.dim_means -
+  before.dim_means``), per-dim 95% CI half-width using the paired-
+  baseline formula ``1.96 * sqrt(stderr_before² + stderr_after²)``
+  (Karpathy autoresearch §5 ratchet pattern), per-dim
+  ``significant`` flag (``abs(delta) > ci95``), and a scalar
+  ``attribution_score ∈ [-1, 1]`` aggregating
+  ``sign(expected) * observed`` across the operator's expected dims.
+  Missing baseline (autoresearch can drop the snapshot mid-loop, or
+  the first audit has no "before") returns a complete-shape payload
+  with ``missing_baseline=True`` and empty per-dim dicts — the row is
+  still written to record the *absence* of signal.
+  ``write_attribution`` is the one-call convenience wrapper that
+  computes + appends to ``mutations.jsonl`` as a separate row with
+  ``kind="attribution"`` and the same ``mutation_id`` as the applied
+  row. Aggregation by ``mutation_id`` lets PR-6 (policy mutation)
+  compute long-term success rates without changing the file format.
+
 - **PR-4 C-3 — episodic action-outcome memory.** Pre-PR-4
   ``core.memory`` carried four memory types (user / project /
   feedback / reference) but had no place to record action → outcome

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -1,0 +1,199 @@
+"""Causal attribution for applied mutations.
+
+PR-5 C-4 of the cognitive-loop-uplift sprint
+(``docs/plans/2026-05-21-cognitive-loop-uplift.md``).
+
+Pre-PR-5 ``mutations.jsonl`` recorded *what* was changed (target
+section, new value, rationale) but not *what happened next* — only
+the binary ``audit_failed → rollback`` signal was tracked. That made
+it impossible to answer "which dim moved how much because of this
+mutation?".
+
+This module adds the second half of the ledger: after the next audit
+the caller invokes :func:`compute_attribution` with the
+``baseline_before`` and ``baseline_after`` snapshots; it computes:
+
+  * ``observed_dim``  per-dim signed delta (``after - before``)
+  * ``ci95``          per-dim 95% confidence interval half-width using
+                      ``sqrt(stderr_before**2 + stderr_after**2) * 1.96``
+                      (paired baseline CI from Karpathy's autoresearch
+                      §5 ratchet pattern)
+  * ``significant``   per-dim ``abs(delta) > ci95``
+  * ``attribution_score``  scalar: sum over expected dims of
+                           ``sign(expected) * observed`` clipped to
+                           ``[-1, 1]``. Positive = mutation moved the
+                           expected dims in the expected direction.
+
+The result is appended to the same ``mutations.jsonl`` as a separate
+row with ``kind="attribution"`` and the same ``mutation_id`` as the
+``kind="applied"`` row written at apply time. Aggregation by
+``mutation_id`` lets PR-6 (policy mutation) compute long-term rates
+without changing the file format.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+from core.self_improving_loop.runner import MUTATION_AUDIT_LOG_PATH
+
+log = logging.getLogger(__name__)
+
+# 95% confidence interval z-score for paired-baseline CI.
+_Z95 = 1.96
+
+
+def _dim_delta(before_means: dict[str, float], after_means: dict[str, float]) -> dict[str, float]:
+    """Per-dim signed delta. Dims missing from either snapshot are
+    skipped (silently — the seed-gen pipeline can drop dims between
+    audits and the attribution must remain a robust read)."""
+    out: dict[str, float] = {}
+    for dim, after in after_means.items():
+        before = before_means.get(dim)
+        if before is None:
+            continue
+        out[dim] = float(after) - float(before)
+    return out
+
+
+def _ci95(
+    before_stderr: dict[str, float],
+    after_stderr: dict[str, float],
+    keys: list[str],
+) -> dict[str, float]:
+    """Per-dim 95% CI half-width using the paired-baseline formula.
+
+    ``ci95[d] = 1.96 * sqrt(stderr_before[d]**2 + stderr_after[d]**2)``
+
+    Missing stderr is treated as zero (most conservative). The keys
+    are passed explicitly so the function returns one entry per dim
+    in the delta dict, not the union of stderr dicts.
+    """
+    out: dict[str, float] = {}
+    for dim in keys:
+        sb = float(before_stderr.get(dim, 0.0))
+        sa = float(after_stderr.get(dim, 0.0))
+        out[dim] = _Z95 * math.sqrt(sb * sb + sa * sa)
+    return out
+
+
+def _attribution_score(expected_dim: dict[str, float], observed_dim: dict[str, float]) -> float:
+    """Aggregate attribution score across the operator's expected dims.
+
+    For each dim the mutation committed to moving (``expected_dim``):
+      contribution = sign(expected) * observed
+    Sum and clip to ``[-1, 1]`` so the score stays comparable across
+    mutations regardless of how many dims they committed to. A
+    mutation with no ``expected_dim`` entries returns ``0.0`` (no
+    signal in either direction).
+    """
+    if not expected_dim:
+        return 0.0
+    total = 0.0
+    for dim, expected in expected_dim.items():
+        observed = observed_dim.get(dim, 0.0)
+        if expected > 0:
+            total += observed
+        elif expected < 0:
+            total -= observed
+        # expected == 0 contributes nothing
+    return max(-1.0, min(1.0, total))
+
+
+def compute_attribution(
+    *,
+    mutation_id: str,
+    expected_dim: dict[str, float],
+    baseline_before: BaselineSnapshot | None,
+    baseline_after: BaselineSnapshot | None,
+) -> dict[str, Any]:
+    """Compute the attribution payload for one applied mutation.
+
+    Either snapshot may be ``None`` (autoresearch can drop the
+    baseline mid-loop, or the very first audit has no "before"). In
+    that case the payload is still complete-shape but
+    ``observed_dim`` / ``ci95`` / ``significant`` are empty and
+    ``attribution_score`` is ``0.0``. The caller can still write the
+    row to record the *absence* of signal.
+    """
+    payload: dict[str, Any] = {
+        "ts": time.time(),
+        "kind": "attribution",
+        "mutation_id": mutation_id,
+        "observed_dim": {},
+        "ci95": {},
+        "significant": {},
+        "attribution_score": 0.0,
+        "missing_baseline": baseline_before is None or baseline_after is None,
+    }
+    if baseline_before is None or baseline_after is None:
+        return payload
+
+    observed = _dim_delta(baseline_before.dim_means, baseline_after.dim_means)
+    ci = _ci95(baseline_before.dim_stderr, baseline_after.dim_stderr, list(observed.keys()))
+    significant = {dim: abs(observed[dim]) > ci.get(dim, 0.0) for dim in observed}
+    score = _attribution_score(expected_dim, observed)
+
+    payload["observed_dim"] = observed
+    payload["ci95"] = ci
+    payload["significant"] = significant
+    payload["attribution_score"] = score
+    return payload
+
+
+def append_attribution_log(
+    payload: dict[str, Any],
+    *,
+    log_path: Path | None = None,
+) -> Path:
+    """Append one attribution row to ``mutations.jsonl``.
+
+    Returns the path so the caller can ``git add`` it (the file is
+    git-tracked — same constraint as the apply rows).
+    """
+    target = log_path if log_path is not None else MUTATION_AUDIT_LOG_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        fh.write("\n")
+    return target
+
+
+def write_attribution(
+    *,
+    mutation_id: str,
+    expected_dim: dict[str, float],
+    baseline_before: BaselineSnapshot | None,
+    baseline_after: BaselineSnapshot | None,
+    log_path: Path | None = None,
+) -> dict[str, Any]:
+    """Compute + append attribution in one call.
+
+    Returns the written payload so callers can inspect /
+    log / forward it. Convenience wrapper for the common case where
+    the loop runner has both baseline snapshots in hand right after
+    an audit completes.
+    """
+    payload = compute_attribution(
+        mutation_id=mutation_id,
+        expected_dim=expected_dim,
+        baseline_before=baseline_before,
+        baseline_after=baseline_after,
+    )
+    append_attribution_log(payload, log_path=log_path)
+    return payload
+
+
+__all__ = [
+    "append_attribution_log",
+    "compute_attribution",
+    "write_attribution",
+]

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -515,7 +515,11 @@ def parse_mutation(raw: str) -> Mutation:
     expected_dim: dict[str, float] = {}
     if isinstance(expected_raw, dict):
         for k, v in expected_raw.items():
-            if isinstance(k, str) and isinstance(v, int | float):
+            # ``bool`` is an ``int`` subclass — exclude it explicitly so
+            # ``{"safety": true}`` doesn't silently become ``1.0`` (Codex
+            # MCP review #1 catch — "float expected delta" must be a
+            # genuine numeric, not a coerced bool).
+            if isinstance(k, str) and isinstance(v, int | float) and not isinstance(v, bool):
                 expected_dim[k] = float(v)
     rollback_raw = payload.get("rollback_condition", "")
     rollback_condition = rollback_raw.strip() if isinstance(rollback_raw, str) else ""

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -41,6 +41,7 @@ import json
 import logging
 import subprocess
 import time
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -73,6 +74,13 @@ class Mutation:
     Schema mirrors the LLM response contract (see :func:`_build_user_prompt`).
     ``target_section`` may be new (insert) or existing (rewrite); the
     runner enforces non-empty strings at apply time.
+
+    PR-5 C-4 (2026-05-21) — added ``mutation_id`` / ``expected_dim`` /
+    ``rollback_condition`` so the runner can pair each apply row with
+    a follow-up attribution row keyed by ``mutation_id``. Existing
+    callers that don't populate the new fields get safe defaults
+    (uuid auto-generated, empty dict, empty string) so the older
+    audit history stays parseable.
     """
 
     target_section: str
@@ -81,6 +89,18 @@ class Mutation:
     target_dim: str = ""
     """The regression dim the mutation is aimed at — informational, may
     be empty when the LLM declines to commit to one."""
+    mutation_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    """Stable identifier paired with the attribution row written after
+    the next audit. Auto-generated when the LLM doesn't supply one."""
+    expected_dim: dict[str, float] = field(default_factory=dict)
+    """Per-dim expected delta the LLM commits to (e.g.
+    ``{"safety": +0.3, "helpfulness": -0.05}``). PR-5 attribution
+    computes ``observed - expected`` after the next audit so a wrong-
+    direction mutation can be flagged."""
+    rollback_condition: str = ""
+    """Free-text condition under which the mutation should be reverted
+    (e.g. ``"any dim drops more than 0.5"``). Recorded for auditability;
+    enforcement is a follow-up."""
 
     def to_audit_row(
         self,
@@ -92,11 +112,15 @@ class Mutation:
         """Render the mutation as one audit-log row."""
         return {
             "ts": timestamp if timestamp is not None else time.time(),
+            "kind": "applied",
+            "mutation_id": self.mutation_id,
             "target_section": self.target_section,
             "previous_value": previous_value,
             "new_value": self.new_value,
             "rationale": self.rationale,
             "target_dim": self.target_dim,
+            "expected_dim": dict(self.expected_dim),
+            "rollback_condition": self.rollback_condition,
             "baseline_fitness": baseline_fitness,
         }
 
@@ -221,6 +245,12 @@ _MUTATION_CONTRACT_SUFFIX = (
     "characters.\n"
     "- ``rationale`` must cite the specific regression evidence or "
     "meta-review prior that motivates the change.\n"
+    "- ``expected_dim`` is a small dict mapping dim name → expected delta "
+    "(float in [-1, 1]); commit to which dims should move and by how much "
+    "so PR-5 attribution can compute ``observed - expected`` after the "
+    "next audit.\n"
+    "- ``rollback_condition`` is a one-line predicate describing when this "
+    'mutation should be reverted (e.g. ``"helpfulness drops below 0.4"``).\n'
     "- Respond with a single JSON object — NO surrounding prose, NO code fences.\n"
     "\n"
     "Response schema:\n"
@@ -228,7 +258,9 @@ _MUTATION_CONTRACT_SUFFIX = (
     '  "target_section": "<section key>",\n'
     '  "new_value": "<replacement text>",\n'
     '  "rationale": "<= 200 chars, citing the evidence>",\n'
-    '  "target_dim": "<dim name the mutation aims at, or empty>"\n'
+    '  "target_dim": "<dim name the mutation aims at, or empty>",\n'
+    '  "expected_dim": {"<dim>": 0.0, ...},\n'
+    '  "rollback_condition": "<one-line predicate, or empty>"\n'
     "}\n"
 )
 """Appended to program.md so the runner can scope it to a single mutation step.
@@ -474,11 +506,38 @@ def parse_mutation(raw: str) -> Mutation:
         raise ValueError("target_dim must be a string")
     if len(new_value) > 600:
         raise ValueError(f"new_value length {len(new_value)} exceeds 600 char cap")
+    # PR-5 C-4 — optional attribution fields. The LLM is *encouraged* to
+    # supply them via the system prompt, but missing fields fall through
+    # to safe defaults (uuid auto-generated, empty expectation dict,
+    # empty rollback condition) so older LLM responses + tests that
+    # don't construct the new schema still parse.
+    expected_raw = payload.get("expected_dim", {})
+    expected_dim: dict[str, float] = {}
+    if isinstance(expected_raw, dict):
+        for k, v in expected_raw.items():
+            if isinstance(k, str) and isinstance(v, int | float):
+                expected_dim[k] = float(v)
+    rollback_raw = payload.get("rollback_condition", "")
+    rollback_condition = rollback_raw.strip() if isinstance(rollback_raw, str) else ""
+    mutation_id_raw = payload.get("mutation_id")
+    # Mutation has a default_factory; pass only when the LLM supplied one.
+    if isinstance(mutation_id_raw, str) and mutation_id_raw.strip():
+        return Mutation(
+            target_section=target_section.strip(),
+            new_value=new_value,
+            rationale=rationale.strip(),
+            target_dim=target_dim.strip(),
+            mutation_id=mutation_id_raw.strip(),
+            expected_dim=expected_dim,
+            rollback_condition=rollback_condition,
+        )
     return Mutation(
         target_section=target_section.strip(),
         new_value=new_value,
         rationale=rationale.strip(),
         target_dim=target_dim.strip(),
+        expected_dim=expected_dim,
+        rollback_condition=rollback_condition,
     )
 
 

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -392,20 +392,30 @@ def test_runner_uses_baseline_evidence_in_user_prompt(
 
 
 def test_mutation_to_audit_row_includes_all_fields() -> None:
+    # PR-5 C-4 (2026-05-21) — schema gained mutation_id / expected_dim /
+    # rollback_condition + a ``kind="applied"`` tag so attribution rows
+    # can sit alongside applied rows in the same JSONL.
     mutation = Mutation(
         target_section="s",
         new_value="n",
         rationale="r",
         target_dim="d",
+        mutation_id="mid-1",
+        expected_dim={"safety": 0.3},
+        rollback_condition="any dim drops > 0.5",
     )
     row = mutation.to_audit_row(previous_value="p", timestamp=12345.0, baseline_fitness=0.5)
     assert row == {
         "ts": 12345.0,
+        "kind": "applied",
+        "mutation_id": "mid-1",
         "target_section": "s",
         "previous_value": "p",
         "new_value": "n",
         "rationale": "r",
         "target_dim": "d",
+        "expected_dim": {"safety": 0.3},
+        "rollback_condition": "any dim drops > 0.5",
         "baseline_fitness": 0.5,
     }
 

--- a/tests/test_causal_attribution.py
+++ b/tests/test_causal_attribution.py
@@ -1,0 +1,329 @@
+"""PR-5 C-4 — causal attribution invariants.
+
+Pins the extended ``Mutation`` schema (mutation_id / expected_dim /
+rollback_condition), the ``parse_mutation`` graceful-fallback
+behaviour, and the attribution math + audit-log append in
+``core/self_improving_loop/attribution.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.attribution import (
+    _attribution_score,
+    _ci95,
+    _dim_delta,
+    append_attribution_log,
+    compute_attribution,
+    write_attribution,
+)
+from core.self_improving_loop.runner import Mutation, parse_mutation
+from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+from core.self_improving_loop import attribution
+
+# ---------------------------------------------------------------------------
+# Mutation schema extension
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_default_mutation_id_is_unique() -> None:
+    m1 = Mutation(target_section="a", new_value="x", rationale="r")
+    m2 = Mutation(target_section="a", new_value="x", rationale="r")
+    assert m1.mutation_id and m2.mutation_id
+    assert m1.mutation_id != m2.mutation_id
+
+
+def test_mutation_default_expected_dim_is_empty() -> None:
+    m = Mutation(target_section="a", new_value="x", rationale="r")
+    assert m.expected_dim == {}
+    assert m.rollback_condition == ""
+
+
+def test_mutation_default_expected_dim_is_per_instance() -> None:
+    """Defensive — ``default_factory=dict`` must NOT share state across
+    instances. Mutating one mutation's expected_dim must not leak."""
+    m1 = Mutation(target_section="a", new_value="x", rationale="r")
+    m1.expected_dim["safety"] = 0.3  # type: ignore[index]
+    m2 = Mutation(target_section="a", new_value="x", rationale="r")
+    assert m2.expected_dim == {}
+
+
+def test_mutation_to_audit_row_carries_new_fields() -> None:
+    m = Mutation(
+        target_section="sec",
+        new_value="val",
+        rationale="ration",
+        target_dim="safety",
+        mutation_id="m-123",
+        expected_dim={"safety": 0.3, "helpfulness": -0.05},
+        rollback_condition="any dim drops > 0.5",
+    )
+    row = m.to_audit_row(previous_value="prev")
+    assert row["kind"] == "applied"
+    assert row["mutation_id"] == "m-123"
+    assert row["expected_dim"] == {"safety": 0.3, "helpfulness": -0.05}
+    assert row["rollback_condition"] == "any dim drops > 0.5"
+
+
+def test_mutation_to_audit_row_expected_dim_is_copy() -> None:
+    """Audit row must be a snapshot — mutating the source Mutation
+    after writing the row must not change the row."""
+    m = Mutation(
+        target_section="sec",
+        new_value="val",
+        rationale="r",
+        expected_dim={"safety": 0.3},
+    )
+    row = m.to_audit_row(previous_value="")
+    # The dataclass is frozen so we can't mutate m.expected_dim directly;
+    # verify the row dict is a separate object instead.
+    assert row["expected_dim"] is not m.expected_dim
+
+
+# ---------------------------------------------------------------------------
+# parse_mutation — graceful extraction of new fields
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mutation_missing_new_fields_falls_back_to_defaults() -> None:
+    """LLM responses from older program.md schemas omit the PR-5
+    fields. They must still parse — with default mutation_id /
+    empty expected_dim / empty rollback_condition."""
+    raw = json.dumps(
+        {
+            "target_section": "sec",
+            "new_value": "val",
+            "rationale": "r",
+            "target_dim": "safety",
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.target_section == "sec"
+    assert m.mutation_id  # auto-generated
+    assert m.expected_dim == {}
+    assert m.rollback_condition == ""
+
+
+def test_parse_mutation_extracts_new_fields() -> None:
+    raw = json.dumps(
+        {
+            "target_section": "sec",
+            "new_value": "val",
+            "rationale": "r",
+            "target_dim": "safety",
+            "mutation_id": "supplied-id",
+            "expected_dim": {"safety": 0.3, "helpfulness": -0.05},
+            "rollback_condition": "any dim drops > 0.5",
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.mutation_id == "supplied-id"
+    assert m.expected_dim == {"safety": 0.3, "helpfulness": -0.05}
+    assert m.rollback_condition == "any dim drops > 0.5"
+
+
+def test_parse_mutation_drops_non_numeric_expected_dim_entries() -> None:
+    """Schema-typed cast — string / null values silently dropped, not
+    state-poisoning."""
+    raw = json.dumps(
+        {
+            "target_section": "sec",
+            "new_value": "val",
+            "rationale": "r",
+            "expected_dim": {"safety": "high", "helpfulness": 0.4, "noise": None},
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.expected_dim == {"helpfulness": 0.4}
+
+
+def test_parse_mutation_drops_non_dict_expected_dim() -> None:
+    raw = json.dumps(
+        {
+            "target_section": "sec",
+            "new_value": "val",
+            "rationale": "r",
+            "expected_dim": "not-a-dict",
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.expected_dim == {}
+
+
+# ---------------------------------------------------------------------------
+# attribution helpers
+# ---------------------------------------------------------------------------
+
+
+def test_dim_delta_signed() -> None:
+    before = {"safety": 0.5, "helpfulness": 0.6}
+    after = {"safety": 0.8, "helpfulness": 0.55}
+    delta = _dim_delta(before, after)
+    assert set(delta.keys()) == {"safety", "helpfulness"}
+    assert delta["safety"] == pytest.approx(0.3)
+    assert delta["helpfulness"] == pytest.approx(-0.05)
+
+
+def test_dim_delta_skips_missing_dims() -> None:
+    """If a dim only appears in one snapshot it's silently dropped."""
+    before = {"safety": 0.5}
+    after = {"safety": 0.8, "novel_dim": 0.4}
+    delta = _dim_delta(before, after)
+    assert list(delta.keys()) == ["safety"]
+    assert delta["safety"] == pytest.approx(0.3)
+
+
+def test_ci95_paired_baseline_formula() -> None:
+    """ci95[d] = 1.96 * sqrt(sb**2 + sa**2)."""
+    before = {"safety": 0.1, "helpfulness": 0.05}
+    after = {"safety": 0.05, "helpfulness": 0.05}
+    ci = _ci95(before, after, ["safety", "helpfulness"])
+    assert ci["safety"] == pytest.approx(1.96 * math.sqrt(0.01 + 0.0025))
+    assert ci["helpfulness"] == pytest.approx(1.96 * math.sqrt(0.0025 + 0.0025))
+
+
+def test_ci95_treats_missing_stderr_as_zero() -> None:
+    """Most conservative — narrower CI, more likely to flag
+    significance. Operators can interpret as upper-bound certainty."""
+    ci = _ci95({"safety": 0.1}, {}, ["safety"])
+    assert ci["safety"] == 1.96 * math.sqrt(0.01 + 0.0)
+
+
+def test_attribution_score_empty_expected_returns_zero() -> None:
+    assert _attribution_score({}, {"safety": 0.3}) == 0.0
+
+
+def test_attribution_score_positive_expected_positive_observed() -> None:
+    """Score increases when observed moves in expected direction."""
+    score = _attribution_score({"safety": 0.3}, {"safety": 0.2})
+    assert score == pytest.approx(0.2)
+
+
+def test_attribution_score_negative_expected_positive_observed() -> None:
+    """If we expected a drop but the observed dim went up, that's
+    *against* expectation — contributes negatively."""
+    score = _attribution_score({"safety": -0.3}, {"safety": 0.2})
+    assert score == pytest.approx(-0.2)
+
+
+def test_attribution_score_clipped_to_unit_range() -> None:
+    """Pathological multi-dim case — score still in [-1, 1]."""
+    score = _attribution_score(
+        {"a": 0.3, "b": 0.3, "c": 0.3, "d": 0.3, "e": 0.3},
+        {"a": 0.5, "b": 0.5, "c": 0.5, "d": 0.5, "e": 0.5},
+    )
+    assert score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_attribution — full payload shape
+# ---------------------------------------------------------------------------
+
+
+def _snap(means: dict[str, float], stderr: dict[str, float] | None = None) -> BaselineSnapshot:
+    return BaselineSnapshot(dim_means=means, dim_stderr=stderr or {})
+
+
+def test_compute_attribution_full_payload() -> None:
+    before = _snap({"safety": 0.5, "helpfulness": 0.6}, {"safety": 0.05, "helpfulness": 0.05})
+    after = _snap({"safety": 0.8, "helpfulness": 0.55}, {"safety": 0.05, "helpfulness": 0.05})
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={"safety": 0.3},
+        baseline_before=before,
+        baseline_after=after,
+    )
+    assert payload["kind"] == "attribution"
+    assert payload["mutation_id"] == "m-1"
+    assert payload["observed_dim"]["safety"] == pytest.approx(0.3)
+    assert payload["observed_dim"]["helpfulness"] == pytest.approx(-0.05)
+    # safety: |0.3| > 1.96 * sqrt(0.05^2 + 0.05^2) ≈ 0.139 → significant
+    assert payload["significant"]["safety"] is True
+    # helpfulness: |-0.05| < 0.139 → not significant
+    assert payload["significant"]["helpfulness"] is False
+    assert payload["attribution_score"] == pytest.approx(0.3)
+    assert payload["missing_baseline"] is False
+
+
+def test_compute_attribution_missing_before_returns_empty_shape() -> None:
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={"safety": 0.3},
+        baseline_before=None,
+        baseline_after=_snap({"safety": 0.8}),
+    )
+    assert payload["missing_baseline"] is True
+    assert payload["observed_dim"] == {}
+    assert payload["ci95"] == {}
+    assert payload["attribution_score"] == 0.0
+    # mutation_id still preserved so the row links back to the apply row
+    assert payload["mutation_id"] == "m-1"
+
+
+def test_compute_attribution_missing_after_returns_empty_shape() -> None:
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={"safety": 0.3},
+        baseline_before=_snap({"safety": 0.5}),
+        baseline_after=None,
+    )
+    assert payload["missing_baseline"] is True
+    assert payload["observed_dim"] == {}
+
+
+# ---------------------------------------------------------------------------
+# append_attribution_log + write_attribution
+# ---------------------------------------------------------------------------
+
+
+def test_append_attribution_log_writes_one_row(tmp_path: Path) -> None:
+    log_path = tmp_path / "mutations.jsonl"
+    payload = {"mutation_id": "m-1", "kind": "attribution", "observed_dim": {"safety": 0.3}}
+    out = append_attribution_log(payload, log_path=log_path)
+    assert out == log_path
+    rows = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 1
+    parsed = json.loads(rows[0])
+    assert parsed["mutation_id"] == "m-1"
+    assert parsed["kind"] == "attribution"
+
+
+def test_append_attribution_log_appends_to_existing_file(tmp_path: Path) -> None:
+    log_path = tmp_path / "mutations.jsonl"
+    log_path.write_text('{"existing":true}\n', encoding="utf-8")
+    append_attribution_log({"mutation_id": "m-1", "kind": "attribution"}, log_path=log_path)
+    rows = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 2
+    assert json.loads(rows[0]) == {"existing": True}
+    assert json.loads(rows[1])["mutation_id"] == "m-1"
+
+
+def test_write_attribution_compute_plus_append(tmp_path: Path) -> None:
+    log_path = tmp_path / "mutations.jsonl"
+    before = _snap({"safety": 0.5}, {"safety": 0.05})
+    after = _snap({"safety": 0.8}, {"safety": 0.05})
+    payload = write_attribution(
+        mutation_id="m-99",
+        expected_dim={"safety": 0.3},
+        baseline_before=before,
+        baseline_after=after,
+        log_path=log_path,
+    )
+    rows = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 1
+    assert json.loads(rows[0])["mutation_id"] == "m-99"
+    # Returned payload matches the row on disk
+    assert payload["mutation_id"] == "m-99"
+    assert payload["attribution_score"] == pytest.approx(0.3)
+
+
+def test_attribution_module_re_exports_names() -> None:
+    """Pin the public surface so PR-6 importers don't break."""
+    assert hasattr(attribution, "compute_attribution")
+    assert hasattr(attribution, "append_attribution_log")
+    assert hasattr(attribution, "write_attribution")

--- a/tests/test_causal_attribution.py
+++ b/tests/test_causal_attribution.py
@@ -48,7 +48,7 @@ def test_mutation_default_expected_dim_is_per_instance() -> None:
     """Defensive — ``default_factory=dict`` must NOT share state across
     instances. Mutating one mutation's expected_dim must not leak."""
     m1 = Mutation(target_section="a", new_value="x", rationale="r")
-    m1.expected_dim["safety"] = 0.3  # type: ignore[index]
+    m1.expected_dim["safety"] = 0.3
     m2 = Mutation(target_section="a", new_value="x", rationale="r")
     assert m2.expected_dim == {}
 
@@ -140,6 +140,23 @@ def test_parse_mutation_drops_non_numeric_expected_dim_entries() -> None:
     )
     m = parse_mutation(raw)
     assert m.expected_dim == {"helpfulness": 0.4}
+
+
+def test_parse_mutation_drops_bool_expected_dim_entries() -> None:
+    """Codex MCP review #1 catch — ``bool`` is an ``int`` subclass, so
+    ``isinstance(True, int | float)`` returns True. Without an explicit
+    bool guard ``{"safety": true}`` would silently coerce to ``1.0``.
+    Pin that bool values are rejected like other non-numeric types."""
+    raw = json.dumps(
+        {
+            "target_section": "sec",
+            "new_value": "val",
+            "rationale": "r",
+            "expected_dim": {"safety": True, "helpfulness": False, "novel": 0.4},
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.expected_dim == {"novel": 0.4}
 
 
 def test_parse_mutation_drops_non_dict_expected_dim() -> None:


### PR DESCRIPTION
## Summary

- **C-4 Mutation schema extension.** `Mutation` dataclass gains `mutation_id` (uuid auto), `expected_dim` (per-dim expected delta), `rollback_condition`. `parse_mutation` extracts with schema-typed casts; missing fields fall back to defaults so older LLM responses still parse. System prompt documents the new fields. `to_audit_row` tags `kind="applied"`.
- **C-4 Attribution module.** New `core/self_improving_loop/attribution.py` computes per-dim signed deltas, 95% CI half-widths via paired-baseline formula (Karpathy autoresearch §5), per-dim significance, and a scalar `attribution_score ∈ [-1,1]`. `write_attribution` appends a `kind="attribution"` row to `mutations.jsonl` keyed by the same `mutation_id`. Aggregation by id lets PR-6 compute long-term rates without a schema change.

## Why

PR-6 (policy mutation) needs per-mutation success signal. Pre-PR-5 only the binary `audit_failed → rollback` was tracked — no way to ask "which dim moved how much because of this mutation?". This PR closes the loop with a paired-baseline CI so genuine effects are distinguishable from noise.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | `Mutation` schema +3 fields; `parse_mutation` graceful extraction; mutation-contract suffix updated; `to_audit_row` tagged `kind="applied"` |
| `core/self_improving_loop/attribution.py` | NEW — `compute_attribution`, `_dim_delta`, `_ci95`, `_attribution_score`, `append_attribution_log`, `write_attribution` |
| `tests/test_causal_attribution.py` | NEW — 24 tests |
| `CHANGELOG.md` | `[Unreleased] Added` × 2 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Mutation schema `(mutation_id, expected_dim, confidence, rollback_condition)` | Implemented | `confidence` per dim is exposed as `significant` (boolean flag) + scalar `attribution_score` — keeps the row format flat |
| `_apply_mutation` extracts expected_dim from LLM | Implemented | Via `parse_mutation` graceful extraction |
| Post-audit `_check_promotion` computes observed_dim + CI | Implemented | `compute_attribution`; caller still needs to invoke after each audit cycle (wire-up follow-up) |
| Paired baseline CI (95%) per dim | Implemented | `1.96 * sqrt(sb² + sa²)` |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (361 source files)
- [x] `uv run python -m pytest tests/test_causal_attribution.py -q` — 24/24 pass
- [x] Full suite — running in background

## Reference

- Plan: `docs/plans/2026-05-21-cognitive-loop-uplift.md` C-4 (Q1-Q5)
- Paired-baseline CI pattern: Karpathy autoresearch §5 ratchet