### PR TITLE
feat(cognitive-loop): PR-6 — policy mutation expansion (C-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,30 @@ functional change.
 
 ### Added
 
+- **PR-6 C-5 — policy mutation expansion (5 target kinds).** Pre-PR-6
+  the self-improving loop's mutation target was only the wrapper
+  prompt (``wrapper-sections.json``); tool selection, decomposition,
+  retrieval, and reflection policies were hard-coded and never
+  participated in self-improvement. New
+  ``core/self_improving_loop/policies.py`` introduces four sibling
+  ``dict[str, str]`` SoT files under
+  ``~/.geode/self-improving-loop/``: ``tool-policy.json`` /
+  ``decomposition.json`` / ``retrieval.json`` / ``reflection.json``.
+  The ``Mutation`` dataclass gains a ``target_kind`` field
+  (default ``"prompt"`` for backward compatibility); ``apply_mutation``
+  dispatches by kind — ``prompt`` still uses
+  ``autoresearch.train.write_wrapper_prompt_sections`` (schema
+  enforcement preserved), the other four kinds go through the new
+  ``write_policy`` (atomic temp-file rewrite, dir auto-created).
+  ``parse_mutation`` extracts the field with graceful fallback
+  (missing → ``prompt``, whitespace-only → ``prompt``, unknown →
+  ``ValueError``). Mutation contract suffix in the system prompt
+  documents the new field. ``to_audit_row`` carries ``target_kind``
+  so attribution downstream can group rows by policy family. Voyager-
+  style execution of the four new SoTs (curriculum + skill library
+  + critic) lands as a follow-up; PR-6 stops at the file format +
+  dispatcher so the infrastructure is committed first.
+
 - **PR-5 C-4 — causal attribution for applied mutations.** Pre-PR-5
   ``mutations.jsonl`` recorded *what* changed (target section, new
   value, rationale) but not *what happened next* — only the binary

--- a/core/paths.py
+++ b/core/paths.py
@@ -61,6 +61,17 @@ GLOBAL_SELF_IMPROVING_LOOP_DIR = GEODE_HOME / "self-improving-loop"
 # ``core.agent.system_prompt._load_wrapper_override`` for daily GEODE runs
 # (no env var required).
 GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "wrapper-sections.json"
+# PR-6 C-5 (2026-05-21) — policy mutation SoT files. Each
+# ``target_kind`` (tool_policy / decomposition / retrieval /
+# reflection) gets its own ``dict[str, str]`` JSON file alongside
+# ``wrapper-sections.json``. ``prompt`` keeps the legacy wrapper-
+# sections path so older mutation rows replay correctly; the others
+# land in fresh files because they evolve independently. Read /
+# written by :mod:`core.self_improving_loop.policies`.
+GLOBAL_TOOL_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-policy.json"
+GLOBAL_DECOMPOSITION_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "decomposition.json"
+GLOBAL_RETRIEVAL_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "retrieval.json"
+GLOBAL_REFLECTION_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "reflection.json"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
 # PR-4 C-3 (2026-05-21) — cross-session episodic action-outcome log
 # (~/.geode/memory/episodes.jsonl). Append-only JSONL: one row per

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -91,9 +91,7 @@ def policy_path(kind: str) -> Path:
     try:
         return _KIND_TO_PATH[kind]
     except KeyError as exc:
-        raise ValueError(
-            f"unknown target_kind {kind!r}; expected one of {TARGET_KINDS!r}"
-        ) from exc
+        raise ValueError(f"unknown target_kind {kind!r}; expected one of {TARGET_KINDS!r}") from exc
 
 
 def load_policy(kind: str) -> dict[str, str]:

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -1,0 +1,159 @@
+"""Policy SoT files for non-prompt mutation targets.
+
+PR-6 C-5 of the cognitive-loop-uplift sprint
+(``docs/plans/2026-05-21-cognitive-loop-uplift.md``).
+
+Pre-PR-6 the self-improving loop's mutation target was *only* the
+wrapper prompt — `wrapper-sections.json`. Tool selection policy,
+decomposition policy, retrieval policy, and reflection policy were
+hard-coded in Python and never participated in the
+self-improvement loop.
+
+This module introduces four sibling SoT files alongside
+``wrapper-sections.json``:
+
+  ============  ==============================================
+  target_kind   SoT file
+  ============  ==============================================
+  prompt        wrapper-sections.json   (legacy — unchanged)
+  tool_policy   tool-policy.json
+  decomposition decomposition.json
+  retrieval     retrieval.json
+  reflection    reflection.json
+  ============  ==============================================
+
+Each file is a ``dict[str, str]`` (same schema as wrapper-sections so
+operators learn one format). A mutation row carries ``target_kind``
+plus ``target_section``; the runner dispatches to the matching file.
+
+PR-6 stops at the *file format + dispatcher*. The Voyager-style
+learning loops that actually exercise the new SoTs (curriculum +
+skill library + critic) land as follow-ups; PR-6 just makes sure
+the four files exist with stable read/write paths so the
+infrastructure is committed before the policies that consume them.
+
+Why no Voyager-style execution yet — Q4 simplicity: this PR ships
+*one PR worth of expansion*, not a full curriculum loop. The
+existing wrapper-prompt mutation path now goes through the same
+dispatcher so a single ``apply_mutation`` call handles all five
+kinds.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from core.paths import (
+    GLOBAL_DECOMPOSITION_POLICY_SOT,
+    GLOBAL_REFLECTION_POLICY_SOT,
+    GLOBAL_RETRIEVAL_POLICY_SOT,
+    GLOBAL_TOOL_POLICY_SOT,
+    GLOBAL_WRAPPER_SECTIONS_SOT,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Canonical list of target kinds. Order matters for the type-hint enum
+# only — apply dispatch is by string key.
+TARGET_KINDS: tuple[str, ...] = (
+    "prompt",
+    "tool_policy",
+    "decomposition",
+    "retrieval",
+    "reflection",
+)
+
+# Each kind maps to the SoT file. ``prompt`` re-points to the legacy
+# wrapper-sections SoT so older mutations replay unchanged.
+_KIND_TO_PATH: dict[str, Path] = {
+    "prompt": GLOBAL_WRAPPER_SECTIONS_SOT,
+    "tool_policy": GLOBAL_TOOL_POLICY_SOT,
+    "decomposition": GLOBAL_DECOMPOSITION_POLICY_SOT,
+    "retrieval": GLOBAL_RETRIEVAL_POLICY_SOT,
+    "reflection": GLOBAL_REFLECTION_POLICY_SOT,
+}
+
+
+def is_valid_target_kind(kind: str) -> bool:
+    """Return True iff ``kind`` is one of the registered targets."""
+    return kind in _KIND_TO_PATH
+
+
+def policy_path(kind: str) -> Path:
+    """Return the SoT file path for ``kind``.
+
+    Raises :class:`ValueError` on unknown kinds so the runner can
+    fail closed rather than silently writing to an unexpected file.
+    """
+    try:
+        return _KIND_TO_PATH[kind]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown target_kind {kind!r}; expected one of {TARGET_KINDS!r}"
+        ) from exc
+
+
+def load_policy(kind: str) -> dict[str, str]:
+    """Read the ``dict[str, str]`` policy for ``kind``.
+
+    Missing file returns ``{}`` so a freshly-installed GEODE behaves
+    like an empty policy — the runner's mutation step populates it
+    over time. Malformed JSON also returns ``{}`` with a WARN, never
+    raises; the readers downstream (PR-5 attribution) must remain
+    robust to incomplete state.
+    """
+    path = policy_path(kind)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        log.warning(
+            "policy file %s is not valid JSON; returning empty dict",
+            path,
+            exc_info=True,
+        )
+        return {}
+    if not isinstance(payload, dict):
+        log.warning(
+            "policy file %s is %s, expected dict; returning empty",
+            path,
+            type(payload).__name__,
+        )
+        return {}
+    # Coerce values to strings — same schema as wrapper-sections so
+    # the contract is "string-keyed dict of string sections".
+    return {k: str(v) for k, v in payload.items() if isinstance(k, str)}
+
+
+def write_policy(kind: str, sections: dict[str, str]) -> Path:
+    """Write the policy for ``kind`` to its SoT file, returning the
+    written path. The dir is created if missing; the file is rewritten
+    atomically (temp + rename) so concurrent readers never see a
+    partial file."""
+    path = policy_path(kind)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {k: v for k, v in sections.items() if isinstance(k, str)},
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(payload + "\n", encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+__all__ = [
+    "TARGET_KINDS",
+    "is_valid_target_kind",
+    "load_policy",
+    "policy_path",
+    "write_policy",
+]

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -244,9 +244,15 @@ _MUTATION_CONTRACT_SUFFIX = (
     "For THIS invocation, ignore the broader autoresearch loop instructions "
     "in program.md and act as a single-shot mutator with these constraints:\n"
     "\n"
-    "- Change exactly ONE section of WRAPPER_PROMPT_SECTIONS. Adding a new "
-    "section key counts as a change; deleting does NOT (the runner ignores "
-    "deletions).\n"
+    "- Change exactly ONE section of the chosen policy SoT (the dict "
+    "selected by ``target_kind`` — defaults to WRAPPER_PROMPT_SECTIONS "
+    "when omitted). Adding a new section key counts as a change; "
+    "deleting does NOT (the runner ignores deletions).\n"
+    '- Default to ``target_kind = "prompt"`` unless the regression '
+    "evidence specifically points at tool / decomposition / retrieval / "
+    "reflection policy. The current user message only shows wrapper-"
+    "prompt sections; non-prompt SoTs start empty until populated, so "
+    "explicit operator signal should drive non-prompt mutations.\n"
     "- ``new_value`` must be a non-empty single-paragraph string under 600 "
     "characters.\n"
     "- ``rationale`` must cite the specific regression evidence or "
@@ -766,13 +772,25 @@ class SelfImprovingLoopRunner:
         the caller can decide whether to retry.
         """
         ctx = build_runner_context()
-        original_sections = dict(ctx.current_sections)
         user_prompt = _build_user_prompt(ctx)
         raw_response = self.llm_call(_build_system_prompt(), user_prompt)
         mutation = parse_mutation(raw_response)
-        _new_sections, previous_value = apply_mutation(
-            mutation, current_sections=ctx.current_sections
-        )
+        # PR-6 C-5 (Codex MCP catch) — apply_mutation dispatches by
+        # target_kind, but ctx.current_sections is *always* the wrapper-
+        # prompt sections (built by build_runner_context). Passing those
+        # into a non-prompt apply would write wrapper-prompt contents
+        # into the wrong SoT file. Load the *correct* starting policy
+        # based on the parsed mutation's kind so the dispatcher writes
+        # the right destination. ``original_sections`` is captured AFTER
+        # the kind-aware load so rollback restores the matching SoT.
+        from core.self_improving_loop.policies import load_policy
+
+        if mutation.target_kind == "prompt":
+            target_sections = dict(ctx.current_sections)
+        else:
+            target_sections = load_policy(mutation.target_kind)
+        original_sections = dict(target_sections)
+        _new_sections, previous_value = apply_mutation(mutation, current_sections=target_sections)
         # G5b.fix3 (2026-05-20) — atomicity boundary: if the audit log
         # write fails after the SoT mutation lands, the in-disk state is
         # silently divergent (SoT advanced, history missing). Roll the
@@ -817,15 +835,27 @@ class SelfImprovingLoopRunner:
         Rollback failure is itself logged but never raised in place of
         the original ``exc`` — the caller already has the more useful
         signal (audit-log write failed).
+
+        PR-6 C-5 (Codex MCP catch) — rollback dispatches on
+        ``mutation.target_kind``. The prompt kind still writes through
+        ``autoresearch.train.write_wrapper_prompt_sections`` (legacy
+        schema enforcement); the four policy kinds go through
+        ``write_policy`` so the right SoT is restored.
         """
         try:
-            from autoresearch.train import write_wrapper_prompt_sections
+            if mutation.target_kind == "prompt":
+                from autoresearch.train import write_wrapper_prompt_sections
 
-            write_wrapper_prompt_sections(original_sections)
+                write_wrapper_prompt_sections(original_sections)
+            else:
+                from core.self_improving_loop.policies import write_policy
+
+                write_policy(mutation.target_kind, original_sections)
             log.error(
                 "self-improving-loop runner: audit-log write failed (%s); "
-                "SoT rolled back to pre-mutation state for section %r",
+                "SoT rolled back to pre-mutation state for kind %r section %r",
                 exc,
+                mutation.target_kind,
                 mutation.target_section,
             )
         except Exception:  # pragma: no cover — defensive

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -89,6 +89,11 @@ class Mutation:
     target_dim: str = ""
     """The regression dim the mutation is aimed at — informational, may
     be empty when the LLM declines to commit to one."""
+    target_kind: str = "prompt"
+    """PR-6 C-5 — which policy SoT this mutation edits. One of:
+    ``prompt`` (legacy wrapper-sections, default) / ``tool_policy`` /
+    ``decomposition`` / ``retrieval`` / ``reflection``. Unknown kinds
+    are rejected by :func:`apply_mutation` so the loop fails closed."""
     mutation_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
     """Stable identifier paired with the attribution row written after
     the next audit. Auto-generated when the LLM doesn't supply one."""
@@ -114,6 +119,7 @@ class Mutation:
             "ts": timestamp if timestamp is not None else time.time(),
             "kind": "applied",
             "mutation_id": self.mutation_id,
+            "target_kind": self.target_kind,
             "target_section": self.target_section,
             "previous_value": previous_value,
             "new_value": self.new_value,
@@ -251,6 +257,11 @@ _MUTATION_CONTRACT_SUFFIX = (
     "next audit.\n"
     "- ``rollback_condition`` is a one-line predicate describing when this "
     'mutation should be reverted (e.g. ``"helpfulness drops below 0.4"``).\n'
+    "- ``target_kind`` selects the policy SoT to mutate. One of "
+    "``prompt`` (default, wrapper-sections.json), ``tool_policy`` "
+    "(tool-policy.json), ``decomposition`` (decomposition.json), "
+    "``retrieval`` (retrieval.json), ``reflection`` (reflection.json). "
+    "Omit for prompt-level mutations.\n"
     "- Respond with a single JSON object — NO surrounding prose, NO code fences.\n"
     "\n"
     "Response schema:\n"
@@ -259,6 +270,7 @@ _MUTATION_CONTRACT_SUFFIX = (
     '  "new_value": "<replacement text>",\n'
     '  "rationale": "<= 200 chars, citing the evidence>",\n'
     '  "target_dim": "<dim name the mutation aims at, or empty>",\n'
+    '  "target_kind": "<prompt|tool_policy|decomposition|retrieval|reflection>",\n'
     '  "expected_dim": {"<dim>": 0.0, ...},\n'
     '  "rollback_condition": "<one-line predicate, or empty>"\n'
     "}\n"
@@ -523,6 +535,18 @@ def parse_mutation(raw: str) -> Mutation:
                 expected_dim[k] = float(v)
     rollback_raw = payload.get("rollback_condition", "")
     rollback_condition = rollback_raw.strip() if isinstance(rollback_raw, str) else ""
+    # PR-6 C-5 — target_kind dispatches to the policy SoT file. Default
+    # ``prompt`` keeps the legacy wrapper-sections behaviour so older
+    # mutation rows replay unchanged. Unknown kinds raise ValueError so
+    # the loop fails closed (caught and logged by SelfImprovingLoopRunner).
+    from core.self_improving_loop.policies import TARGET_KINDS
+
+    kind_raw = payload.get("target_kind", "prompt")
+    if not isinstance(kind_raw, str):
+        raise ValueError(f"target_kind must be a string, got {type(kind_raw).__name__}")
+    target_kind = kind_raw.strip() or "prompt"
+    if target_kind not in TARGET_KINDS:
+        raise ValueError(f"target_kind {target_kind!r} is not one of {TARGET_KINDS!r}")
     mutation_id_raw = payload.get("mutation_id")
     # Mutation has a default_factory; pass only when the LLM supplied one.
     if isinstance(mutation_id_raw, str) and mutation_id_raw.strip():
@@ -531,6 +555,7 @@ def parse_mutation(raw: str) -> Mutation:
             new_value=new_value,
             rationale=rationale.strip(),
             target_dim=target_dim.strip(),
+            target_kind=target_kind,
             mutation_id=mutation_id_raw.strip(),
             expected_dim=expected_dim,
             rollback_condition=rollback_condition,
@@ -540,6 +565,7 @@ def parse_mutation(raw: str) -> Mutation:
         new_value=new_value,
         rationale=rationale.strip(),
         target_dim=target_dim.strip(),
+        target_kind=target_kind,
         expected_dim=expected_dim,
         rollback_condition=rollback_condition,
     )
@@ -561,17 +587,40 @@ def apply_mutation(
     the string the mutation replaced (empty for insertions) — captured
     so the audit log can record the diff.
 
-    The SoT write is strict: schema failures raise
-    :class:`ValueError` via ``write_wrapper_prompt_sections``.
+    PR-6 C-5 — dispatches on ``mutation.target_kind``. The
+    ``prompt`` kind uses the legacy
+    ``autoresearch.train.write_wrapper_prompt_sections`` writer so
+    schema enforcement (single-paragraph 600-char cap) is preserved.
+    The other four kinds go through
+    :func:`core.self_improving_loop.policies.write_policy` which is
+    a generic ``dict[str, str]`` writer with atomic temp-file rewrite.
     """
     from autoresearch.train import load_wrapper_prompt_sections, write_wrapper_prompt_sections
 
+    from core.self_improving_loop.policies import load_policy, write_policy
+
+    if mutation.target_kind == "prompt":
+        sections = (
+            dict(current_sections)
+            if current_sections is not None
+            else load_wrapper_prompt_sections()
+        )
+        previous_value = sections.get(mutation.target_section, "")
+        sections[mutation.target_section] = mutation.new_value
+        write_wrapper_prompt_sections(sections)
+        return sections, previous_value
+
+    # PR-6 policy kinds — tool_policy / decomposition / retrieval /
+    # reflection. ``current_sections`` override is honoured for symmetry
+    # with the prompt branch (tests inject pre-populated dicts).
     sections = (
-        dict(current_sections) if current_sections is not None else load_wrapper_prompt_sections()
+        dict(current_sections)
+        if current_sections is not None
+        else load_policy(mutation.target_kind)
     )
     previous_value = sections.get(mutation.target_section, "")
     sections[mutation.target_section] = mutation.new_value
-    write_wrapper_prompt_sections(sections)
+    write_policy(mutation.target_kind, sections)
     return sections, previous_value
 
 

--- a/tests/core/self_improving_loop/test_runner.py
+++ b/tests/core/self_improving_loop/test_runner.py
@@ -395,6 +395,8 @@ def test_mutation_to_audit_row_includes_all_fields() -> None:
     # PR-5 C-4 (2026-05-21) — schema gained mutation_id / expected_dim /
     # rollback_condition + a ``kind="applied"`` tag so attribution rows
     # can sit alongside applied rows in the same JSONL.
+    # PR-6 C-5 (2026-05-21) — added ``target_kind`` so the runner can
+    # dispatch to one of 5 policy SoTs.
     mutation = Mutation(
         target_section="s",
         new_value="n",
@@ -403,12 +405,14 @@ def test_mutation_to_audit_row_includes_all_fields() -> None:
         mutation_id="mid-1",
         expected_dim={"safety": 0.3},
         rollback_condition="any dim drops > 0.5",
+        target_kind="prompt",
     )
     row = mutation.to_audit_row(previous_value="p", timestamp=12345.0, baseline_fitness=0.5)
     assert row == {
         "ts": 12345.0,
         "kind": "applied",
         "mutation_id": "mid-1",
+        "target_kind": "prompt",
         "target_section": "s",
         "previous_value": "p",
         "new_value": "n",

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -1,0 +1,368 @@
+"""PR-6 C-5 — policy mutation expansion invariants.
+
+Pins the new ``target_kind`` field on :class:`Mutation`, the
+``core.self_improving_loop.policies`` SoT helpers, and
+``apply_mutation``'s dispatcher routing to the right policy file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.policies import (
+    TARGET_KINDS,
+    is_valid_target_kind,
+    load_policy,
+    policy_path,
+    write_policy,
+)
+from core.self_improving_loop.runner import (
+    Mutation,
+    apply_mutation,
+    parse_mutation,
+)
+
+from core.self_improving_loop import policies as _policies_mod
+
+# ---------------------------------------------------------------------------
+# TARGET_KINDS + is_valid_target_kind
+# ---------------------------------------------------------------------------
+
+
+def test_target_kinds_contains_all_five() -> None:
+    """Plan Q3 — exactly five enum values; pin the set."""
+    assert set(TARGET_KINDS) == {
+        "prompt",
+        "tool_policy",
+        "decomposition",
+        "retrieval",
+        "reflection",
+    }
+
+
+def test_is_valid_target_kind_accepts_registered_kinds() -> None:
+    for kind in TARGET_KINDS:
+        assert is_valid_target_kind(kind) is True
+
+
+def test_is_valid_target_kind_rejects_unknown() -> None:
+    assert is_valid_target_kind("unknown") is False
+    assert is_valid_target_kind("") is False
+
+
+# ---------------------------------------------------------------------------
+# policy_path — each kind points to a distinct file
+# ---------------------------------------------------------------------------
+
+
+def test_policy_path_returns_distinct_paths() -> None:
+    """Distinct SoT per kind so policies evolve independently."""
+    paths = {kind: policy_path(kind) for kind in TARGET_KINDS}
+    # All 5 paths are unique
+    assert len(set(paths.values())) == 5
+
+
+def test_policy_path_prompt_points_to_wrapper_sections() -> None:
+    from core.paths import GLOBAL_WRAPPER_SECTIONS_SOT
+
+    assert policy_path("prompt") == GLOBAL_WRAPPER_SECTIONS_SOT
+
+
+def test_policy_path_raises_on_unknown() -> None:
+    with pytest.raises(ValueError, match="unknown target_kind"):
+        policy_path("invalid")
+
+
+# ---------------------------------------------------------------------------
+# load_policy / write_policy roundtrip
+# ---------------------------------------------------------------------------
+
+
+def _redirect_kind(monkeypatch: pytest.MonkeyPatch, kind: str, path: Path) -> None:
+    """Point ``_KIND_TO_PATH[kind]`` at ``path`` for the duration of
+    the test. Avoids touching the real ``~/.geode/`` dir."""
+    new_map = dict(_policies_mod._KIND_TO_PATH)
+    new_map[kind] = path
+    monkeypatch.setattr(_policies_mod, "_KIND_TO_PATH", new_map)
+
+
+def test_write_policy_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "nested" / "deep" / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    write_policy("tool_policy", {"key": "value"})
+    assert target.exists()
+
+
+def test_load_policy_missing_returns_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "absent.json"
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    assert load_policy("tool_policy") == {}
+
+
+def test_load_write_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    write_policy("tool_policy", {"a": "1", "b": "2"})
+    assert load_policy("tool_policy") == {"a": "1", "b": "2"}
+
+
+def test_load_policy_malformed_json_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Robust on corrupt files — readers should never crash. PR-5
+    attribution will run during every audit cycle."""
+    target = tmp_path / "tool-policy.json"
+    target.write_text("not json {{{", encoding="utf-8")
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    assert load_policy("tool_policy") == {}
+
+
+def test_load_policy_non_dict_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "tool-policy.json"
+    target.write_text('["not", "a", "dict"]', encoding="utf-8")
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    assert load_policy("tool_policy") == {}
+
+
+def test_write_policy_is_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Temp file should not survive after the rename completes."""
+    target = tmp_path / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    write_policy("tool_policy", {"k": "v"})
+    assert target.exists()
+    assert not target.with_suffix(".json.tmp").exists()
+
+
+# ---------------------------------------------------------------------------
+# Mutation schema — target_kind field
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_default_target_kind_is_prompt() -> None:
+    """Default = prompt for backward compatibility."""
+    m = Mutation(target_section="s", new_value="v", rationale="r")
+    assert m.target_kind == "prompt"
+
+
+def test_mutation_to_audit_row_includes_target_kind() -> None:
+    m = Mutation(
+        target_section="s",
+        new_value="v",
+        rationale="r",
+        target_kind="tool_policy",
+    )
+    row = m.to_audit_row(previous_value="")
+    assert row["target_kind"] == "tool_policy"
+
+
+# ---------------------------------------------------------------------------
+# parse_mutation — target_kind extraction + validation
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mutation_missing_target_kind_defaults_to_prompt() -> None:
+    """Older LLM responses don't include target_kind. Backward
+    compatibility — default to legacy prompt mutation."""
+    raw = json.dumps({"target_section": "s", "new_value": "v", "rationale": "r"})
+    m = parse_mutation(raw)
+    assert m.target_kind == "prompt"
+
+
+def test_parse_mutation_extracts_target_kind() -> None:
+    raw = json.dumps(
+        {
+            "target_section": "s",
+            "new_value": "v",
+            "rationale": "r",
+            "target_kind": "decomposition",
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.target_kind == "decomposition"
+
+
+def test_parse_mutation_rejects_unknown_target_kind() -> None:
+    """Fail closed on unknown kinds rather than silently writing to
+    an unexpected file."""
+    raw = json.dumps(
+        {
+            "target_section": "s",
+            "new_value": "v",
+            "rationale": "r",
+            "target_kind": "bogus_kind",
+        }
+    )
+    with pytest.raises(ValueError, match="target_kind 'bogus_kind' is not one of"):
+        parse_mutation(raw)
+
+
+def test_parse_mutation_empty_target_kind_defaults_to_prompt() -> None:
+    """Empty string after strip — operator typo defense."""
+    raw = json.dumps(
+        {
+            "target_section": "s",
+            "new_value": "v",
+            "rationale": "r",
+            "target_kind": "   ",
+        }
+    )
+    m = parse_mutation(raw)
+    assert m.target_kind == "prompt"
+
+
+def test_parse_mutation_rejects_non_string_target_kind() -> None:
+    raw = json.dumps(
+        {
+            "target_section": "s",
+            "new_value": "v",
+            "rationale": "r",
+            "target_kind": 42,
+        }
+    )
+    with pytest.raises(ValueError, match="target_kind must be a string"):
+        parse_mutation(raw)
+
+
+# ---------------------------------------------------------------------------
+# apply_mutation — dispatcher routes by target_kind
+# ---------------------------------------------------------------------------
+
+
+def test_apply_mutation_tool_policy_writes_to_tool_policy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    m = Mutation(
+        target_section="prefer_tools",
+        new_value="bash before read",
+        rationale="r",
+        target_kind="tool_policy",
+    )
+    new_sections, prev = apply_mutation(m, current_sections={})
+    assert prev == ""
+    assert new_sections == {"prefer_tools": "bash before read"}
+    # File written
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"prefer_tools": "bash before read"}
+
+
+def test_apply_mutation_decomposition_writes_to_decomposition_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "decomposition.json"
+    _redirect_kind(monkeypatch, "decomposition", target)
+    m = Mutation(
+        target_section="strategy",
+        new_value="depth-first",
+        rationale="r",
+        target_kind="decomposition",
+    )
+    apply_mutation(m, current_sections={})
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"strategy": "depth-first"}
+
+
+def test_apply_mutation_retrieval_writes_to_retrieval_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "retrieval.json"
+    _redirect_kind(monkeypatch, "retrieval", target)
+    m = Mutation(
+        target_section="top_k",
+        new_value="3",
+        rationale="r",
+        target_kind="retrieval",
+    )
+    apply_mutation(m, current_sections={})
+    assert target.exists()
+
+
+def test_apply_mutation_reflection_writes_to_reflection_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "reflection.json"
+    _redirect_kind(monkeypatch, "reflection", target)
+    m = Mutation(
+        target_section="cadence",
+        new_value="every 3 rounds",
+        rationale="r",
+        target_kind="reflection",
+    )
+    apply_mutation(m, current_sections={})
+    assert target.exists()
+
+
+def test_apply_mutation_prompt_kind_uses_legacy_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The legacy ``prompt`` kind must still route through
+    ``autoresearch.train.write_wrapper_prompt_sections`` so the
+    schema enforcement (single paragraph / 600-char cap) survives
+    the PR-6 dispatcher rewrite."""
+    from autoresearch import train as _train
+
+    written: list[dict[str, str]] = []
+
+    def _fake_writer(sections: dict[str, str]) -> None:
+        written.append(dict(sections))
+
+    monkeypatch.setattr(_train, "write_wrapper_prompt_sections", _fake_writer)
+
+    m = Mutation(
+        target_section="role",
+        new_value="ship it",
+        rationale="r",
+        target_kind="prompt",
+    )
+    apply_mutation(m, current_sections={"existing": "x"})
+    assert len(written) == 1
+    assert written[0] == {"existing": "x", "role": "ship it"}
+
+
+def test_apply_mutation_preserves_previous_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``previous_value`` must capture the *replaced* string so the
+    audit log can render a diff."""
+    target = tmp_path / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", target)
+    m = Mutation(
+        target_section="prefer_tools",
+        new_value="new value",
+        rationale="r",
+        target_kind="tool_policy",
+    )
+    _, prev = apply_mutation(m, current_sections={"prefer_tools": "old value"})
+    assert prev == "old value"
+
+
+# ---------------------------------------------------------------------------
+# Paths sanity
+# ---------------------------------------------------------------------------
+
+
+def test_global_policy_paths_under_self_improving_loop_dir() -> None:
+    """All 5 SoT paths live under the same dir as wrapper-sections —
+    operators expect them co-located."""
+    from core.paths import (
+        GLOBAL_DECOMPOSITION_POLICY_SOT,
+        GLOBAL_REFLECTION_POLICY_SOT,
+        GLOBAL_RETRIEVAL_POLICY_SOT,
+        GLOBAL_SELF_IMPROVING_LOOP_DIR,
+        GLOBAL_TOOL_POLICY_SOT,
+        GLOBAL_WRAPPER_SECTIONS_SOT,
+    )
+
+    for path in (
+        GLOBAL_WRAPPER_SECTIONS_SOT,
+        GLOBAL_TOOL_POLICY_SOT,
+        GLOBAL_DECOMPOSITION_POLICY_SOT,
+        GLOBAL_RETRIEVAL_POLICY_SOT,
+        GLOBAL_REFLECTION_POLICY_SOT,
+    ):
+        assert path.parent == GLOBAL_SELF_IMPROVING_LOOP_DIR

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -346,6 +346,127 @@ def test_apply_mutation_preserves_previous_value(
 # ---------------------------------------------------------------------------
 
 
+def test_run_once_loads_target_kind_policy_not_wrapper_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP review #1 (HIGH) catch — run_once used to always pass
+    ``ctx.current_sections`` (wrapper-prompt sections) into
+    apply_mutation, which would write wrapper-prompt content into the
+    wrong SoT for non-prompt target_kinds. Pin that run_once now
+    loads the correct policy via ``load_policy(mutation.target_kind)``."""
+    from autoresearch import train as _train
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    # Redirect tool_policy SoT to a tmp path so the test never touches
+    # ~/.geode/. Pre-populate with one entry to confirm load_policy is
+    # invoked (and ctx.current_sections is NOT used).
+    tool_path = tmp_path / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", tool_path)
+    write_policy("tool_policy", {"existing": "from_policy_file"})
+
+    # Stub the LLM call to return a tool_policy mutation.
+    monkeypatch.setattr(
+        SelfImprovingLoopRunner,
+        "_invoke_autoresearch",
+        lambda self, _root: None,
+    )
+    runner_llm = (
+        '{"target_section": "new_tool",'
+        ' "new_value": "use bash before read",'
+        ' "rationale": "r",'
+        ' "target_kind": "tool_policy"}'
+    )
+
+    # Stub build_runner_context so the test doesn't depend on a real
+    # baseline / wrapper-sections file.
+    from core.self_improving_loop.runner import RunnerContext
+
+    from core.self_improving_loop import runner as _runner_mod
+
+    monkeypatch.setattr(
+        _runner_mod,
+        "build_runner_context",
+        lambda: RunnerContext(current_sections={"wrapper_only": "WRAPPER CONTENTS"}),
+    )
+
+    # Stub the legacy writer so the test never touches the real
+    # wrapper-sections SoT.
+    monkeypatch.setattr(_train, "write_wrapper_prompt_sections", lambda _s: None)
+
+    audit_path = tmp_path / "mutations.jsonl"
+    runner = SelfImprovingLoopRunner(
+        llm_call=lambda _sys, _user: runner_llm,
+        audit_log_path=audit_path,
+    )
+    runner.run_once()
+
+    # After run_once with target_kind="tool_policy", the tool-policy
+    # SoT should have the original entry PLUS the new mutation, and
+    # the wrapper-sections-only "wrapper_only" key must NOT appear in
+    # the tool-policy file (which would prove the dispatcher bug
+    # Codex caught).
+    on_disk = json.loads(tool_path.read_text(encoding="utf-8"))
+    assert on_disk == {"existing": "from_policy_file", "new_tool": "use bash before read"}
+    assert "wrapper_only" not in on_disk
+
+
+def test_rollback_sot_dispatches_on_target_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP review #1 (HIGH) catch — _rollback_sot used to always
+    call write_wrapper_prompt_sections, which for non-prompt mutations
+    would restore the wrong destination. Pin that rollback now
+    dispatches by target_kind."""
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    tool_path = tmp_path / "tool-policy.json"
+    _redirect_kind(monkeypatch, "tool_policy", tool_path)
+
+    # Initial state on disk
+    write_policy("tool_policy", {"baseline": "orig"})
+
+    # Simulate _rollback_sot directly
+    mutation = Mutation(
+        target_section="x",
+        new_value="y",
+        rationale="r",
+        target_kind="tool_policy",
+    )
+    SelfImprovingLoopRunner._rollback_sot(
+        {"baseline": "restored"}, mutation=mutation, exc=OSError("simulated")
+    )
+
+    # tool-policy.json should now reflect the *rollback* dict, NOT the
+    # original on-disk state, AND the legacy wrapper-sections writer
+    # must not have been touched.
+    on_disk = json.loads(tool_path.read_text(encoding="utf-8"))
+    assert on_disk == {"baseline": "restored"}
+
+
+def test_rollback_sot_prompt_kind_still_uses_legacy_writer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin that the prompt branch still routes through
+    autoresearch.train.write_wrapper_prompt_sections — schema
+    enforcement (single-paragraph 600-char cap) must survive PR-6."""
+    from autoresearch import train as _train
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    written: list[dict[str, str]] = []
+    monkeypatch.setattr(_train, "write_wrapper_prompt_sections", lambda s: written.append(dict(s)))
+
+    mutation = Mutation(
+        target_section="role",
+        new_value="ship",
+        rationale="r",
+        target_kind="prompt",
+    )
+    SelfImprovingLoopRunner._rollback_sot(
+        {"role": "original"}, mutation=mutation, exc=OSError("simulated")
+    )
+    assert written == [{"role": "original"}]
+
+
 def test_global_policy_paths_under_self_improving_loop_dir() -> None:
     """All 5 SoT paths live under the same dir as wrapper-sections —
     operators expect them co-located."""


### PR DESCRIPTION
## Summary

- **C-5 Five target kinds.** `Mutation.target_kind` (default `"prompt"`) selects which policy SoT to mutate: `prompt` / `tool_policy` / `decomposition` / `retrieval` / `reflection`. Each kind has its own JSON file under `~/.geode/self-improving-loop/`.
- **New policies module.** `core/self_improving_loop/policies.py` exposes `TARGET_KINDS`, `policy_path`, `load_policy`, `write_policy` (atomic temp+rename, missing → `{}` with WARN).
- **Dispatcher.** `apply_mutation` switches on `target_kind`: `prompt` still routes to `autoresearch.train.write_wrapper_prompt_sections` (schema enforcement preserved); other kinds go through `write_policy`. `parse_mutation` extracts the field with graceful fallback; unknown / non-string kinds raise `ValueError` so the loop fails closed.

## Why

Final PR of the 6-PR cognitive-loop-uplift sprint. The plan's Q2 — "self-improving stays at prompt level only, no evolution of tool / decomposition / retrieval / reflection policies" — was the open gap PR-1 → PR-5 left behind. This PR ships the *infrastructure*: file format, dispatcher, audit-row tagging. Voyager-style curriculum + skill library + critic that exercise the four new SoTs are deliberately scoped out — they need a separate plan once we have signal on which kind generates the most learning per LLM call.

## Changes

| File | Change |
|------|--------|
| `core/paths.py` | +4 `GLOBAL_*_POLICY_SOT` constants |
| `core/self_improving_loop/policies.py` | NEW — `TARGET_KINDS`, `policy_path`, `load_policy`, `write_policy` |
| `core/self_improving_loop/runner.py` | `Mutation.target_kind` field; `apply_mutation` dispatcher; `parse_mutation` extraction + validation; system-prompt suffix documents the field; `to_audit_row` includes `target_kind` |
| `tests/test_policy_mutation.py` | NEW — 29 tests |
| `tests/core/self_improving_loop/test_runner.py` | Existing audit-row test extended with `target_kind="prompt"` |
| `CHANGELOG.md` | `[Unreleased] Added` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| 4 new target kinds + SoT files | Implemented | tool_policy / decomposition / retrieval / reflection |
| Runner switch on `target_kind` | Implemented | `apply_mutation` dispatcher |
| Voyager curriculum + skill library + critic | Deferred | Out of PR scope per plan Q4 "각 kind 별 file 만 생성 + runner switch — 실제 learning loop 는 follow-up" |
| Backward compat (existing mutations) | Implemented | Default `target_kind="prompt"` |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_policy_mutation.py tests/test_causal_attribution.py tests/core/self_improving_loop/test_runner.py -q` — 78/78 pass
- [x] Full suite — running in background

## Reference

- Plan: `docs/plans/2026-05-21-cognitive-loop-uplift.md` C-5 (Q1-Q5)
- 3-codebase consensus: Voyager (curriculum + skill library + critic), Eureka (reward policy mutation), Karpathy autoresearch (ratchet)