### PR TITLE
release: v0.99.24 — cognitive-loop-uplift sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,23 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.24] — 2026-05-21
+
+> **Cognitive Loop Uplift Sprint** — 6 PRs (#1373 / #1374 / #1375 /
+> #1376 / #1377 / #1378) close the gap between the self-improving
+> loop's *prompt-only* mutation surface and a full PERCEIVE → PLAN →
+> ACT → OBSERVE → REFLECT → UPDATE_MEMORY cognitive cycle. PR-1 fills
+> the paperclip-style abstraction gap so the mutator shares the
+> credential rotator. PR-2 introduces the `CognitiveState` container
+> and 6 cognitive `HookEvent` taxa. PR-3 wires an LLM-driven
+> reflection node that populates hypotheses + confidence. PR-4
+> persists action → outcome triples to a rolling episodic ledger.
+> PR-5 adds paired-baseline 95% CI causal attribution per applied
+> mutation. PR-6 expands the mutation target from "wrapper prompt
+> only" to five policy SoTs (prompt / tool_policy / decomposition /
+> retrieval / reflection). Modules 356 → 362 (+6), tests 5082 →
+> 5280 (+198).
+
 ### Added
 
 - **PR-6 C-5 — policy mutation expansion (5 target kinds).** Pre-PR-6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.23
+- **Version**: 0.99.24
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
-- **Modules**: 308 core + 48 plugins = 356
-- **Tests**: 5082 (+5 live)
+- **Modules**: 314 core + 48 plugins = 362
+- **Tests**: 5280 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.23 — Long-running Autonomous Execution Harness
+# GEODE v0.99.24 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.23**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.24**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.23 — Long-running Autonomous Execution Harness
+# GEODE v0.99.24 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.23**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.24**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.23"
+version = "0.99.24"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Cut `[Unreleased]` → `[0.99.24] — 2026-05-21` accumulating 6 sprint PRs (#1373-#1378).
- Version sync across the 4 locations: `pyproject.toml`, `CLAUDE.md`, `README.md` (2 mentions).
- CLAUDE.md metrics updated: modules 356 → 362 (+6), tests 5082 → 5280 (+198).

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run geode version` — prints `GEODE v0.99.24`
- [x] All 6 feature PRs already merged to main (`19d3f4e3` → `ef568591`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)