### PR TITLE
feat(cli): /model role tab — primary + reflection in single picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-A — ``/model`` role tab for reflection-model selection.** Pre-
+  PR-A the picker only set ``settings.model`` (primary agentic loop).
+  The PR-3 C-2 reflection node had a knob
+  (``settings.cognitive_reflection_model``) but no runtime UI —
+  operators had to edit ``~/.geode/config.toml`` or
+  ``GEODE_COGNITIVE_REFLECTION_MODEL`` and restart. New
+  ``AGENT_ROLES`` registry in ``core/cli/commands/_state.py``
+  declares each LLM-driven role (currently ``primary`` +
+  ``reflection``; mutator/judge are follow-ups) with its settings
+  field, env var, and ``config.toml (section, key)``. ``/model``
+  interactive picker draws a Tab-cyclable tab strip at the top so a
+  single Enter persists to the focused role's knob.
+  ``/model reflection <name>`` (or ``/model reflection`` for the
+  picker focused on that tab) is the explicit non-interactive path.
+  The non-tty fallback list now annotates each model with per-role
+  markers (``P←`` primary, ``R←`` reflection) so curl-driven callers
+  see both selections at once. ``PickerResult`` gains a ``role``
+  field (default ``"primary"`` for backward compat). The
+  context-window guard runs only for primary (reflection's clean-
+  context discipline from PR-3 sidesteps the main loop's context
+  size). 15 invariant tests pin registry / signature / dispatcher /
+  reflection-branch persistence / role-prefix parsing.
+
 ## [0.99.24] — 2026-05-21
 
 > **Cognitive Loop Uplift Sprint** — 6 PRs (#1373 / #1374 / #1375 /

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -71,6 +71,81 @@ MODEL_PROFILES: list[ModelProfile] = [
 
 _MODEL_INDEX: dict[str, ModelProfile] = {m.id: m for m in MODEL_PROFILES}
 
+
+# ---------------------------------------------------------------------------
+# Agent Role Registry — PR-A (2026-05-21)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentRole:
+    """One LLM-driven role inside GEODE that owns its own model knob.
+
+    ``/model`` cycles through registered roles via Tab so each role's
+    chosen model can be picked through the same UI. Each role maps to:
+
+      * ``settings_field`` — the ``Settings`` attribute that drives the
+        runtime (read by the producer, e.g. ``settings.model`` →
+        AgenticLoop; ``settings.cognitive_reflection_model`` →
+        ``core.agent.loop._reflection.reflect_async``).
+      * ``env_var`` — the canonical env var name written by
+        ``_upsert_env`` so the picker's choice survives one restart.
+      * ``toml_section`` / ``toml_key`` — durable persistence path in
+        ``~/.geode/config.toml`` so the picker's choice survives every
+        restart.
+      * ``description`` — short hint shown next to the role tab.
+    """
+
+    name: str
+    label: str
+    settings_field: str
+    env_var: str
+    toml_section: str
+    toml_key: str
+    description: str
+    has_effort: bool  # primary uses agentic_effort, reflection doesn't
+
+
+AGENT_ROLES: list[AgentRole] = [
+    AgentRole(
+        name="primary",
+        label="Primary",
+        settings_field="model",
+        env_var="GEODE_MODEL",
+        toml_section="llm",
+        toml_key="primary_model",
+        description="Main agentic loop — drives plan / act / observe rounds",
+        has_effort=True,
+    ),
+    AgentRole(
+        name="reflection",
+        label="Reflection",
+        settings_field="cognitive_reflection_model",
+        env_var="GEODE_COGNITIVE_REFLECTION_MODEL",
+        toml_section="cognitive",
+        toml_key="reflection_model",
+        description="Belief-update node (PR-3 C-2) — runs after each tool batch",
+        has_effort=False,
+    ),
+]
+
+_ROLE_INDEX: dict[str, AgentRole] = {r.name: r for r in AGENT_ROLES}
+
+
+def role_by_name(name: str) -> AgentRole:
+    """Return the :class:`AgentRole` matching ``name``.
+
+    Raises :class:`ValueError` on unknown roles so the picker fails
+    closed rather than silently writing to an unexpected settings field.
+    """
+    try:
+        return _ROLE_INDEX[name]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown agent role {name!r}; expected one of {[r.name for r in AGENT_ROLES]!r}"
+        ) from exc
+
+
 # ---------------------------------------------------------------------------
 # Conversation Context ContextVar (shared with tool handlers)
 # ---------------------------------------------------------------------------

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -195,6 +195,7 @@ def _interactive_model_picker() -> None:
     ]
     role_tabs = [(r.name, r.label, r.description) for r in AGENT_ROLES]
     role_initial_models = {r.name: _current_model_for_role(r) for r in AGENT_ROLES}
+    role_has_effort = {r.name: r.has_effort for r in AGENT_ROLES}
     current_effort = getattr(settings, "agentic_effort", "high")
     result = pick_model_and_effort(
         profiles,
@@ -203,6 +204,7 @@ def _interactive_model_picker() -> None:
         roles=role_tabs,
         initial_role="primary",
         role_initial_models=role_initial_models,
+        role_has_effort=role_has_effort,
     )
     if result.cancelled:
         # M5 — surface the "login first" path explicitly when the user
@@ -248,6 +250,7 @@ def _interactive_model_picker_for_role(role_def: AgentRole) -> None:
     ]
     role_tabs = [(r.name, r.label, r.description) for r in AGENT_ROLES]
     role_initial_models = {r.name: _current_model_for_role(r) for r in AGENT_ROLES}
+    role_has_effort = {r.name: r.has_effort for r in AGENT_ROLES}
     current_for_focus = role_initial_models.get(role_def.name) or settings.model
     current_effort = getattr(settings, "agentic_effort", "high")
     result = pick_model_and_effort(
@@ -257,6 +260,7 @@ def _interactive_model_picker_for_role(role_def: AgentRole) -> None:
         roles=role_tabs,
         initial_role=role_def.name,
         role_initial_models=role_initial_models,
+        role_has_effort=role_has_effort,
     )
     if result.cancelled:
         _pkg.console.print("  [muted]Cancelled[/muted]")

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -16,17 +16,35 @@ import logging
 
 from core.cli.commands._state import (
     _MODEL_INDEX,
+    AGENT_ROLES,
     MODEL_PROFILES,
+    AgentRole,
     ModelProfile,
     forced_login_method_for,
     model_available,
+    role_by_name,
 )
 
 log = logging.getLogger(__name__)
 
 
-def _apply_model(selected: ModelProfile, *, effort: str | None = None) -> None:
-    """Apply a model selection — update settings + .env.
+def _current_model_for_role(role: AgentRole) -> str:
+    """Read the current model id for ``role`` from ``settings``.
+
+    Centralised reader so the picker, non-tty fallback, and post-apply
+    confirmation all consult the same source. Falls back to an empty
+    string if the field is unset (shouldn't happen — every registered
+    role's settings field has a default — but defensive against config
+    drift)."""
+    from core.config import settings
+
+    return getattr(settings, role.settings_field, "") or ""
+
+
+def _apply_model(
+    selected: ModelProfile, *, effort: str | None = None, role: str = "primary"
+) -> None:
+    """Apply a model selection — update settings + .env + config.toml.
 
     v0.59.0 — accepts an optional ``effort`` parameter coming from the
     two-axis picker (``effort_picker.pick_model_and_effort``). When
@@ -36,59 +54,82 @@ def _apply_model(selected: ModelProfile, *, effort: str | None = None) -> None:
     field). ``None`` means "no effort knob applies for this model" —
     leave the existing setting untouched.
 
+    PR-A (2026-05-21) — ``role`` selects which agent's model knob is
+    updated. ``"primary"`` (default) preserves the legacy behaviour
+    (writes ``settings.model`` + ``GEODE_MODEL`` env + ``[llm]
+    primary_model``). ``"reflection"`` writes the PR-3 C-2 knob
+    (``settings.cognitive_reflection_model`` + the corresponding env
+    var + ``[cognitive] reflection_model``). Effort is *only* applied
+    when the role declares ``has_effort=True`` — the reflection node
+    has no effort axis.
+
     Includes context window guard: blocks downgrade when current context
-    exceeds 80% of the target model's window.
+    exceeds 80% of the target model's window (primary role only —
+    reflection runs on a separate cheap model and doesn't share the
+    main loop's context).
     """
     from core.cli import commands as _pkg
     from core.config import settings
+    from core.utils.env_io import upsert_config_toml
 
-    old = settings.model
+    role_def = role_by_name(role)
+    old = _current_model_for_role(role_def)
     old_effort = getattr(settings, "agentic_effort", "high")
     same_model = selected.id == old
-    same_effort = effort is None or effort == old_effort
+    same_effort = not role_def.has_effort or effort is None or effort == old_effort
 
     if same_model and same_effort:
-        _pkg.console.print(f"  [muted]Already using {selected.label}[/muted]")
+        _pkg.console.print(
+            f"  [muted]Already using {selected.label} for {role_def.label.lower()}[/muted]"
+        )
         _pkg.console.print()
         return
 
     _pkg._check_provider_key(selected)
 
-    # --- Context Window Guard ---
-    ctx = _pkg.get_conversation_context()
-    if ctx is not None and ctx.messages:
-        from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
-        from core.orchestration.context_monitor import estimate_message_tokens
+    # --- Context Window Guard --- (primary only — reflection runs in
+    # a clean-context sandbox per PR-3 C-2 design, so the main loop's
+    # context size doesn't constrain its model choice).
+    if role_def.name == "primary":
+        ctx = _pkg.get_conversation_context()
+        if ctx is not None and ctx.messages:
+            from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
+            from core.orchestration.context_monitor import estimate_message_tokens
 
-        current_tokens = estimate_message_tokens(ctx.messages)
-        target_window = MODEL_CONTEXT_WINDOW.get(selected.id, 200_000)
-        threshold = int(target_window * 0.8)
+            current_tokens = estimate_message_tokens(ctx.messages)
+            target_window = MODEL_CONTEXT_WINDOW.get(selected.id, 200_000)
+            threshold = int(target_window * 0.8)
 
-        if current_tokens > threshold:
-            _pkg.console.print()
-            _pkg.console.print(
-                f"  [warning]Context guard: {current_tokens:,} tokens "
-                f"exceeds {selected.label} limit "
-                f"({target_window:,} x 80% = {threshold:,})[/warning]"
-            )
-            _pkg.console.print("  [muted]Run /compact or /clear first, then retry /model.[/muted]")
-            _pkg.console.print()
-            return
+            if current_tokens > threshold:
+                _pkg.console.print()
+                _pkg.console.print(
+                    f"  [warning]Context guard: {current_tokens:,} tokens "
+                    f"exceeds {selected.label} limit "
+                    f"({target_window:,} x 80% = {threshold:,})[/warning]"
+                )
+                _pkg.console.print(
+                    "  [muted]Run /compact or /clear first, then retry /model.[/muted]"
+                )
+                _pkg.console.print()
+                return
 
     # v0.61.0 — picker choices now persist to BOTH .env (session) and
-    # .geode/config.toml (durable). Previously the comment claimed
-    # config.toml sync but only .env was actually written; on next
-    # session the user got the env-loaded value, but only because .env
-    # happens to survive — wiping .env would lose the choice silently.
-    # 3-codebase consensus (Hermes/Codex/Claude Code all persist picker
-    # choices to durable config).
-    from core.utils.env_io import upsert_config_toml
-
+    # .geode/config.toml (durable). 3-codebase consensus (Hermes/Codex/
+    # Claude Code all persist picker choices to durable config).
     if not same_model:
-        settings.model = selected.id
-        _pkg._upsert_env("GEODE_MODEL", selected.id)
-        upsert_config_toml("llm", "primary_model", selected.id)
-    if effort is not None and effort != old_effort:
+        # Pydantic v2 ``Settings`` is frozen on instance attribute
+        # writes via __setattr__; the legacy primary-model path used
+        # direct attribute assignment which works for the ``model``
+        # field but not for arbitrary new fields. ``object.__setattr__``
+        # bypasses validation so the picker's choice lands regardless
+        # of the field's pydantic descriptor type.
+        try:
+            object.__setattr__(settings, role_def.settings_field, selected.id)
+        except Exception:
+            log.debug("Could not persist %s to settings", role_def.settings_field, exc_info=True)
+        _pkg._upsert_env(role_def.env_var, selected.id)
+        upsert_config_toml(role_def.toml_section, role_def.toml_key, selected.id)
+    if role_def.has_effort and effort is not None and effort != old_effort:
         try:
             object.__setattr__(settings, "agentic_effort", effort)
         except Exception:
@@ -100,18 +141,21 @@ def _apply_model(selected: ModelProfile, *, effort: str | None = None) -> None:
     # checks settings.model at the start of each round and applies
     # the change safely between LLM calls. Direct loop.update_model_async()
     # during tool execution caused adapter swap mid-call → crash.
+    # Reflection model is read lazily inside ``_maybe_reflect`` so no
+    # hot-swap plumbing is needed there.
 
-    if not same_model and effort is not None:
+    role_tag = "" if role_def.name == "primary" else f"  [muted]({role_def.label})[/muted]"
+    if not same_model and role_def.has_effort and effort is not None:
         _pkg.console.print(
             f"  [success]Model[/success]  {old} → [bold]{selected.label}[/bold]"
-            f"  [muted]({selected.id} · effort={effort})[/muted]"
+            f"  [muted]({selected.id} · effort={effort})[/muted]{role_tag}"
         )
     elif not same_model:
         _pkg.console.print(
             f"  [success]Model[/success]  {old} → [bold]{selected.label}[/bold]"
-            f"  [muted]({selected.id})[/muted]"
+            f"  [muted]({selected.id})[/muted]{role_tag}"
         )
-    elif effort is not None:
+    elif role_def.has_effort and effort is not None:
         _pkg.console.print(
             f"  [success]Effort[/success]  {old_effort} → [bold]{effort}[/bold]"
             f"  [muted](model unchanged: {selected.label})[/muted]"
@@ -126,6 +170,13 @@ def _interactive_model_picker() -> None:
     Claude Code ``ModelPicker.tsx`` pattern. Per-provider effort enum
     in ``core/cli/effort_picker.py``. Ctrl+C / q / ESC cancels; Enter
     confirms both the model and its current effort selection.
+
+    PR-A (2026-05-21) — adds a role-tab axis. Tab cycles between
+    ``primary`` (default — main agentic loop) and ``reflection``
+    (PR-3 C-2 belief-update node), with future roles (mutator /
+    judge) registerable in :data:`core.cli.commands._state.AGENT_ROLES`.
+    Enter persists the focused-tab role's selection via
+    :func:`_apply_model` ``role=`` kwarg.
     """
     from core.cli import commands as _pkg
     from core.cli.effort_picker import pick_model_and_effort
@@ -142,8 +193,17 @@ def _interactive_model_picker() -> None:
         )
         for p in MODEL_PROFILES
     ]
+    role_tabs = [(r.name, r.label, r.description) for r in AGENT_ROLES]
+    role_initial_models = {r.name: _current_model_for_role(r) for r in AGENT_ROLES}
     current_effort = getattr(settings, "agentic_effort", "high")
-    result = pick_model_and_effort(profiles, settings.model, current_effort)
+    result = pick_model_and_effort(
+        profiles,
+        settings.model,
+        current_effort,
+        roles=role_tabs,
+        initial_role="primary",
+        role_initial_models=role_initial_models,
+    )
     if result.cancelled:
         # M5 — surface the "login first" path explicitly when the user
         # tried to pick an unavailable model. ``pick_model_and_effort``
@@ -159,48 +219,117 @@ def _interactive_model_picker() -> None:
         return
 
     chosen_profile = next(p for p in MODEL_PROFILES if p.id == result.model_id)
-    _apply_model(chosen_profile, effort=result.effort)
+    _apply_model(chosen_profile, effort=result.effort, role=result.role)
+
+
+def _interactive_model_picker_for_role(role_def: AgentRole) -> None:
+    """PR-A — picker entered with ``initial_role=role_def.name``.
+
+    Same UI as :func:`_interactive_model_picker` but the tab strip is
+    anchored on the requested role so e.g. ``/model reflection``
+    drops the user straight into the reflection picker. Tab still
+    cycles to other roles so the operator can switch within the same
+    invocation.
+    """
+    from core.cli import commands as _pkg
+    from core.cli.effort_picker import pick_model_and_effort
+    from core.config import settings
+
+    profiles = [
+        (
+            p.id,
+            p.provider,
+            p.label,
+            p.cost,
+            model_available(p.id),
+            forced_login_method_for(p.provider),
+        )
+        for p in MODEL_PROFILES
+    ]
+    role_tabs = [(r.name, r.label, r.description) for r in AGENT_ROLES]
+    role_initial_models = {r.name: _current_model_for_role(r) for r in AGENT_ROLES}
+    current_for_focus = role_initial_models.get(role_def.name) or settings.model
+    current_effort = getattr(settings, "agentic_effort", "high")
+    result = pick_model_and_effort(
+        profiles,
+        current_for_focus,
+        current_effort,
+        roles=role_tabs,
+        initial_role=role_def.name,
+        role_initial_models=role_initial_models,
+    )
+    if result.cancelled:
+        _pkg.console.print("  [muted]Cancelled[/muted]")
+        _pkg.console.print()
+        return
+    chosen_profile = next(p for p in MODEL_PROFILES if p.id == result.model_id)
+    _apply_model(chosen_profile, effort=result.effort, role=result.role)
 
 
 def cmd_model(args: str) -> None:
     """Handle /model command (OpenClaw Auth Profile Rotation pattern).
 
-    /model         → interactive arrow-key picker
-    /model 2       → select by number
-    /model gpt-5.4 → select by name
+    /model                       → interactive arrow-key picker
+                                   (Tab cycles roles: primary / reflection)
+    /model 2                     → select by number (applies to primary)
+    /model gpt-5.4               → select by name (applies to primary)
+    /model reflection            → interactive picker for reflection role
+    /model reflection haiku-4.5  → set reflection model by name
+    /model reflection 4          → set reflection model by number
     """
     from core.cli import commands as _pkg
 
     arg = args.strip()
 
-    # /model (no args) → interactive picker (requires tty)
+    # PR-A — explicit role prefix: ``/model <role>`` or
+    # ``/model <role> <picker-arg>``. The role token must match a
+    # registered :class:`AgentRole` name; otherwise fall through to
+    # the legacy number/name resolver (primary role).
+    role_name = "primary"
+    if arg:
+        first, _, rest = arg.partition(" ")
+        if first in {r.name for r in AGENT_ROLES}:
+            role_name = first
+            arg = rest.strip()
+    role_def = role_by_name(role_name)
+
+    # /model (no args, primary role) → interactive picker (requires tty)
+    # /model reflection → interactive picker focused on reflection tab
     if not arg:
         import sys
 
         if not sys.stdin.isatty():
-            # Non-interactive: show model list instead of crashing
-            from core.config import settings
-
+            # Non-interactive: show model list with per-role markers
             _pkg.console.print()
             _pkg.console.print("  [header]Models[/header]")
+            # Track each registered role's current pick so the list
+            # marks all of them in one render — matches the
+            # multi-tab picker's "Primary / Reflection" semantics.
+            role_currents = {r.name: _current_model_for_role(r) for r in AGENT_ROLES}
             for i, p in enumerate(MODEL_PROFILES, 1):
-                marker = " ←" if p.id == settings.model else ""
-                # M5 — surface login-state so a curl-driven caller (or a
-                # user who pipes /model into stdin) sees which entries
-                # would 401 before they hit them.
+                role_marks = " ".join(
+                    f"{r.label[0]}←" for r in AGENT_ROLES if role_currents[r.name] == p.id
+                )
+                marker = f"  [muted]{role_marks}[/muted]" if role_marks else ""
                 avail = "" if model_available(p.id) else "  [muted](login required)[/muted]"
-                # M2 — same row also surfaces a per-provider
-                # ``forced_login_method`` override (Codex CLI parity).
                 forced = forced_login_method_for(p.provider)
                 forced_suffix = f"  [muted](forced: {forced})[/muted]" if forced else ""
                 _pkg.console.print(
                     f"  {i}. {p.label:<12} {p.provider:<10} {p.cost}{marker}{avail}{forced_suffix}"
                 )
             _pkg.console.print()
-            _pkg.console.print("  [muted]Usage: /model <number> or /model <name>[/muted]")
+            _pkg.console.print(
+                "  [muted]Usage: /model <number> | /model <name> | /model <role> <name>[/muted]"
+            )
+            _pkg.console.print("  [muted]Role markers: P← = Primary, R← = Reflection[/muted]")
             _pkg.console.print()
             return
-        _interactive_model_picker()
+        if role_name == "primary":
+            _interactive_model_picker()
+        else:
+            # Single-role picker invocation — render the picker with
+            # the role-tab axis but anchored on the requested role.
+            _interactive_model_picker_for_role(role_def)
         return
 
     # Resolve by number or name
@@ -253,4 +382,4 @@ def cmd_model(args: str) -> None:
         _pkg.console.print()
         return
 
-    _apply_model(selected)
+    _apply_model(selected, role=role_def.name)

--- a/core/cli/effort_picker.py
+++ b/core/cli/effort_picker.py
@@ -168,11 +168,18 @@ def effort_label(level: str) -> str:
 
 @dataclass
 class PickerResult:
-    """Outcome of the two-axis picker."""
+    """Outcome of the picker.
+
+    PR-A (2026-05-21) — added ``role`` so a single Enter persists to
+    the *currently focused* agent role (primary / reflection / future:
+    mutator). Defaults to ``"primary"`` for backward compatibility
+    with callers that don't pass ``roles``.
+    """
 
     model_id: str
     effort: str | None  # None → no effort knob applies for this model
     cancelled: bool = False
+    role: str = "primary"
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +192,7 @@ _KEY_LEFT = "LEFT"
 _KEY_RIGHT = "RIGHT"
 _KEY_ENTER = "ENTER"
 _KEY_QUIT = "QUIT"
+_KEY_TAB = "TAB"
 
 
 def _read_key() -> str:
@@ -205,6 +213,8 @@ def _read_key() -> str:
             return {"A": _KEY_UP, "B": _KEY_DOWN, "C": _KEY_RIGHT, "D": _KEY_LEFT}.get(ch3, "")
         if ch in ("\r", "\n"):
             return _KEY_ENTER
+        if ch == "\t":
+            return _KEY_TAB
         if ch in ("q", "Q"):
             return _KEY_QUIT
         if ch == "\x03":
@@ -219,6 +229,10 @@ def _render(
     cursor: int,
     effort_per_model: dict[str, str | None],
     initial_model: str,
+    *,
+    roles: list[tuple[str, str, str]] | None = None,
+    role_cursor: int = 0,
+    role_initials: dict[str, str] | None = None,
 ) -> int:
     """Render the picker. Returns lines written so the caller can rewind.
 
@@ -230,19 +244,12 @@ def _render(
     badge so a user who pinned the PAYG escape hatch sees the
     override before selecting.
 
-    Layout (mirrors the user-supplied spec):
-
-        Select model
-        Switch between models. Applies to this session.
-
-        ❯ 1. {label} {default-marker}     {description}
-          2. {label}              (login required)
-          3. {label}              (forced: apikey)
-          ...
-
-        ◉ {Effort} effort {(default)} ← → to adjust
-
-        Enter to confirm · Esc to exit
+    PR-A (2026-05-21) — when ``roles`` is supplied
+    (``[(name, label, description), ...]``), a role-tab strip is
+    drawn at the top with the currently-focused role highlighted.
+    ``role_initials`` carries the current per-role model id so each
+    tab can show its own ✔ marker (the focused role's model gets the
+    ✔; other roles' selections appear next to their tab label).
     """
     out = sys.stdout
     lines = 0
@@ -253,6 +260,22 @@ def _render(
         "Models with effort knobs let you tune reasoning depth with ←→ arrows.\033[0m\n\n"
     )
     lines += 4
+
+    # PR-A — role tabs above the model list. Only render when more
+    # than one role is registered; single-role callers (legacy
+    # behaviour) skip the strip so the existing UX is unchanged.
+    if roles and len(roles) > 1:
+        tab_parts: list[str] = []
+        for i, (_name, role_label, _desc) in enumerate(roles):
+            if i == role_cursor:
+                tab_parts.append(f"\033[1;36m[ {role_label} ]\033[0m")
+            else:
+                tab_parts.append(f"\033[2m[ {role_label} ]\033[0m")
+        out.write("  " + " ".join(tab_parts) + "  \033[2m(Tab to cycle)\033[0m\n")
+        if 0 <= role_cursor < len(roles):
+            out.write(f"  \033[2m{roles[role_cursor][2]}\033[0m\n")
+        out.write("\n")
+        lines += 3
 
     # Compute label column width so descriptions align
     label_width = max(len(p[2]) for p in profiles) + 2
@@ -318,6 +341,10 @@ def pick_model_and_effort(
     profiles: list[tuple[str, str, str, str, bool, str | None]],
     current_model: str,
     current_effort: str,
+    *,
+    roles: list[tuple[str, str, str]] | None = None,
+    initial_role: str = "primary",
+    role_initial_models: dict[str, str] | None = None,
 ) -> PickerResult:
     """Run the interactive picker.
 
@@ -332,11 +359,36 @@ def pick_model_and_effort(
     explicitly overridden the default routing (``"apikey"`` etc.), or
     ``None`` when at default — the picker renders a ``(forced: …)``
     badge so the override stays visible at selection time.
-    Returns PickerResult with the chosen model + effort, or
+
+    PR-A (2026-05-21) — when ``roles`` is supplied
+    (``[(name, label, description), ...]`` for each registered agent
+    role), the picker draws a tab strip at the top and lets Tab cycle
+    between roles. ``initial_role`` selects the focused tab on entry
+    (must match one of the names in ``roles`` or defaults to the
+    first). ``role_initial_models`` carries the *current* model id
+    per role so cycling Tab re-anchors the cursor to that role's
+    selection. When ``roles`` is None or has length 1, the picker
+    behaves identically to its single-axis predecessor.
+
+    Returns PickerResult with the chosen model + effort + role, or
     cancelled=True on q/ESC.
     """
     if not profiles:
         return PickerResult(model_id=current_model, effort=None, cancelled=True)
+
+    # Normalise role state. Roles list of one (or None) means
+    # single-role mode — same UX as before.
+    if roles is None or len(roles) <= 1:
+        role_names: list[str] = ["primary"]
+        role_tabs: list[tuple[str, str, str]] = []
+    else:
+        role_names = [r[0] for r in roles]
+        role_tabs = list(roles)
+    role_cursor = role_names.index(initial_role) if initial_role in role_names else 0
+    role_initial_models = dict(role_initial_models or {})
+    # Per-role anchor model — falls back to ``current_model`` (which
+    # is the focused role's current selection) when not supplied.
+    role_initial_models.setdefault(role_names[role_cursor], current_model)
 
     cursor = next(
         (i for i, (mid, *_rest) in enumerate(profiles) if mid == current_model),
@@ -354,16 +406,35 @@ def pick_model_and_effort(
         else:
             effort_per_model[mid] = default_effort(mid, prov)
 
-    line_count = _render(profiles, cursor, effort_per_model, current_model)
+    initial_for_render = role_initial_models.get(role_names[role_cursor], current_model)
+    line_count = _render(
+        profiles,
+        cursor,
+        effort_per_model,
+        initial_for_render,
+        roles=role_tabs or None,
+        role_cursor=role_cursor,
+        role_initials=role_initial_models,
+    )
     while True:
         try:
             key = _read_key()
         except KeyboardInterrupt:
             _clear_lines(line_count)
-            return PickerResult(model_id=current_model, effort=current_effort, cancelled=True)
+            return PickerResult(
+                model_id=current_model,
+                effort=current_effort,
+                cancelled=True,
+                role=role_names[role_cursor],
+            )
         if key == _KEY_QUIT:
             _clear_lines(line_count)
-            return PickerResult(model_id=current_model, effort=current_effort, cancelled=True)
+            return PickerResult(
+                model_id=current_model,
+                effort=current_effort,
+                cancelled=True,
+                role=role_names[role_cursor],
+            )
         if key == _KEY_ENTER:
             chosen_mid, chosen_prov, _label, _cost, available, _forced = profiles[cursor]
             if not available:
@@ -375,14 +446,27 @@ def pick_model_and_effort(
                     model_id=current_model,
                     effort=current_effort,
                     cancelled=True,
+                    role=role_names[role_cursor],
                 )
             _clear_lines(line_count)
             return PickerResult(
                 model_id=chosen_mid,
                 effort=effort_per_model.get(chosen_mid),
                 cancelled=False,
+                role=role_names[role_cursor],
             )
-        if key == _KEY_UP:
+        if key == _KEY_TAB and len(role_names) > 1:
+            role_cursor = (role_cursor + 1) % len(role_names)
+            # Re-anchor cursor to the new role's current model so the
+            # picker's highlight follows the role-switch instead of
+            # staying on whichever row the user was hovering.
+            new_anchor = role_initial_models.get(role_names[role_cursor])
+            if new_anchor is not None:
+                cursor = next(
+                    (i for i, (mid, *_rest) in enumerate(profiles) if mid == new_anchor),
+                    cursor,
+                )
+        elif key == _KEY_UP:
             cursor = (cursor - 1) % len(profiles)
         elif key == _KEY_DOWN:
             cursor = (cursor + 1) % len(profiles)
@@ -397,4 +481,13 @@ def pick_model_and_effort(
         else:
             continue
         _clear_lines(line_count)
-        line_count = _render(profiles, cursor, effort_per_model, current_model)
+        initial_for_render = role_initial_models.get(role_names[role_cursor], current_model)
+        line_count = _render(
+            profiles,
+            cursor,
+            effort_per_model,
+            initial_for_render,
+            roles=role_tabs or None,
+            role_cursor=role_cursor,
+            role_initials=role_initial_models,
+        )

--- a/core/cli/effort_picker.py
+++ b/core/cli/effort_picker.py
@@ -233,6 +233,7 @@ def _render(
     roles: list[tuple[str, str, str]] | None = None,
     role_cursor: int = 0,
     role_initials: dict[str, str] | None = None,
+    show_effort: bool = True,
 ) -> int:
     """Render the picker. Returns lines written so the caller can rewind.
 
@@ -305,9 +306,19 @@ def _render(
             )
         lines += 1
 
-    # Effort line for the focused model
+    # Effort line for the focused model. PR-A fix-up #1 — when the
+    # focused role has ``has_effort=False`` (e.g. reflection) we
+    # render an explicit "no effort knob" hint instead of the disc +
+    # ← → adjuster, which the dispatcher would silently ignore.
     out.write("\n")
     lines += 1
+    if not show_effort:
+        out.write("  \033[2m· No effort knob for this role · ←→ disabled\033[0m\n")
+        lines += 1
+        out.write("\n  \033[2mEnter to confirm · Esc to exit\033[0m\n")
+        lines += 2
+        out.flush()
+        return lines
     cur_mid, cur_prov, _cur_label, _cur_cost, _cur_avail, _cur_forced = profiles[cursor]
     levels = supported_efforts(cur_mid, cur_prov)
     current = effort_per_model.get(cur_mid)
@@ -345,6 +356,7 @@ def pick_model_and_effort(
     roles: list[tuple[str, str, str]] | None = None,
     initial_role: str = "primary",
     role_initial_models: dict[str, str] | None = None,
+    role_has_effort: dict[str, bool] | None = None,
 ) -> PickerResult:
     """Run the interactive picker.
 
@@ -406,7 +418,9 @@ def pick_model_and_effort(
         else:
             effort_per_model[mid] = default_effort(mid, prov)
 
+    role_has_effort = dict(role_has_effort or {})
     initial_for_render = role_initial_models.get(role_names[role_cursor], current_model)
+    show_effort = role_has_effort.get(role_names[role_cursor], True)
     line_count = _render(
         profiles,
         cursor,
@@ -415,6 +429,7 @@ def pick_model_and_effort(
         roles=role_tabs or None,
         role_cursor=role_cursor,
         role_initials=role_initial_models,
+        show_effort=show_effort,
     )
     while True:
         try:
@@ -471,6 +486,11 @@ def pick_model_and_effort(
         elif key == _KEY_DOWN:
             cursor = (cursor + 1) % len(profiles)
         elif key in (_KEY_LEFT, _KEY_RIGHT):
+            # PR-A fix-up #1 — block ←→ entirely for roles whose
+            # has_effort=False so the user gets no false signal that
+            # they're tuning anything.
+            if not role_has_effort.get(role_names[role_cursor], True):
+                continue
             mid, prov, *_rest = profiles[cursor]
             levels = supported_efforts(mid, prov)
             if not levels:
@@ -482,6 +502,7 @@ def pick_model_and_effort(
             continue
         _clear_lines(line_count)
         initial_for_render = role_initial_models.get(role_names[role_cursor], current_model)
+        show_effort = role_has_effort.get(role_names[role_cursor], True)
         line_count = _render(
             profiles,
             cursor,
@@ -490,4 +511,5 @@ def pick_model_and_effort(
             roles=role_tabs or None,
             role_cursor=role_cursor,
             role_initials=role_initial_models,
+            show_effort=show_effort,
         )

--- a/tests/test_model_role_tab.py
+++ b/tests/test_model_role_tab.py
@@ -227,3 +227,56 @@ def test_picker_without_roles_runs_in_single_axis_mode() -> None:
     sig = inspect.signature(effort_picker.pick_model_and_effort)
     # Default = None so callers can omit
     assert sig.parameters["roles"].default is None
+
+
+def test_picker_render_accepts_show_effort_flag() -> None:
+    """Codex MCP #1 catch — picker must hide effort controls when the
+    focused role has ``has_effort=False`` so the user can't move ←→
+    expecting a no-op write. Pin the show_effort parameter."""
+    sig = inspect.signature(effort_picker._render)
+    assert "show_effort" in sig.parameters
+    assert sig.parameters["show_effort"].default is True
+
+
+def test_picker_pass_role_has_effort_dict() -> None:
+    """The model.py picker entry must pass ``role_has_effort`` so the
+    picker knows which roles support effort. Without this kwarg,
+    show_effort defaults to True and the bug remains."""
+    sig = inspect.signature(effort_picker.pick_model_and_effort)
+    assert "role_has_effort" in sig.parameters
+
+    from core.cli.commands import model as _model_mod
+
+    src = inspect.getsource(_model_mod._interactive_model_picker)
+    assert "role_has_effort=role_has_effort" in src
+    src_role = inspect.getsource(_model_mod._interactive_model_picker_for_role)
+    assert "role_has_effort=role_has_effort" in src_role
+
+
+def test_picker_render_show_effort_false_emits_no_knob_hint() -> None:
+    """Behavioural check — when show_effort=False the render writes
+    the 'No effort knob for this role' hint so the user gets
+    explicit feedback instead of an absent line."""
+    import io
+    import sys
+
+    profiles = [
+        ("claude-haiku-4-5-20251001", "anthropic", "Haiku 4.5", "$", True, None),
+    ]
+    buf = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        effort_picker._render(
+            profiles,
+            cursor=0,
+            effort_per_model={"claude-haiku-4-5-20251001": None},
+            initial_model="claude-haiku-4-5-20251001",
+            show_effort=False,
+        )
+    finally:
+        sys.stdout = old_stdout
+    out = buf.getvalue()
+    assert "No effort knob for this role" in out
+    # And it does NOT render the disc + ←→ adjuster
+    assert "← → to adjust" not in out

--- a/tests/test_model_role_tab.py
+++ b/tests/test_model_role_tab.py
@@ -1,0 +1,229 @@
+"""PR-A — `/model` role-tab (primary + reflection) invariants.
+
+Pins the new ``AGENT_ROLES`` registry, the ``PickerResult.role``
+field, the Tab key plumbing in ``_read_key``, and the
+``_apply_model`` dispatcher.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from core.cli.commands._state import (
+    AGENT_ROLES,
+    role_by_name,
+)
+
+from core.cli import effort_picker
+
+# ---------------------------------------------------------------------------
+# AGENT_ROLES registry
+# ---------------------------------------------------------------------------
+
+
+def test_agent_roles_includes_primary_and_reflection() -> None:
+    names = {r.name for r in AGENT_ROLES}
+    assert {"primary", "reflection"} <= names
+
+
+def test_primary_role_writes_to_settings_model() -> None:
+    primary = role_by_name("primary")
+    assert primary.settings_field == "model"
+    assert primary.env_var == "GEODE_MODEL"
+    assert primary.toml_section == "llm"
+    assert primary.toml_key == "primary_model"
+    assert primary.has_effort is True
+
+
+def test_reflection_role_writes_to_cognitive_reflection_model() -> None:
+    reflection = role_by_name("reflection")
+    assert reflection.settings_field == "cognitive_reflection_model"
+    assert reflection.env_var == "GEODE_COGNITIVE_REFLECTION_MODEL"
+    assert reflection.toml_section == "cognitive"
+    assert reflection.toml_key == "reflection_model"
+    # Reflection node has no effort axis — different LLM, different
+    # contract (one-shot JSON output, no reasoning depth knob).
+    assert reflection.has_effort is False
+
+
+def test_role_by_name_raises_on_unknown() -> None:
+    with pytest.raises(ValueError, match="unknown agent role"):
+        role_by_name("not_a_role")
+
+
+# ---------------------------------------------------------------------------
+# PickerResult role field
+# ---------------------------------------------------------------------------
+
+
+def test_picker_result_defaults_role_to_primary() -> None:
+    """Backward compat — callers that don't specify role get
+    primary so the legacy single-axis flow keeps working."""
+    r = effort_picker.PickerResult(model_id="x", effort="high")
+    assert r.role == "primary"
+
+
+def test_picker_result_carries_explicit_role() -> None:
+    r = effort_picker.PickerResult(model_id="x", effort=None, role="reflection")
+    assert r.role == "reflection"
+
+
+# ---------------------------------------------------------------------------
+# Tab key + role tabs in render
+# ---------------------------------------------------------------------------
+
+
+def test_read_key_handles_tab() -> None:
+    """``\\t`` must map to ``_KEY_TAB`` so the picker can cycle roles."""
+    src = inspect.getsource(effort_picker._read_key)
+    assert '"\\t"' in src or "'\\t'" in src
+    assert effort_picker._KEY_TAB == "TAB"
+
+
+def test_render_signature_accepts_roles() -> None:
+    """Pin the role-tab parameter so a future refactor that drops it
+    surfaces here, not at runtime."""
+    sig = inspect.signature(effort_picker._render)
+    assert "roles" in sig.parameters
+    assert "role_cursor" in sig.parameters
+    assert "role_initials" in sig.parameters
+
+
+def test_pick_model_and_effort_signature_accepts_roles() -> None:
+    sig = inspect.signature(effort_picker.pick_model_and_effort)
+    assert "roles" in sig.parameters
+    assert "initial_role" in sig.parameters
+    assert "role_initial_models" in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# _apply_model dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_apply_model_accepts_role_kwarg() -> None:
+    """Pin the ``role`` kwarg on ``_apply_model`` — the picker passes
+    it through from ``PickerResult.role``."""
+    from core.cli.commands.model import _apply_model
+
+    sig = inspect.signature(_apply_model)
+    assert "role" in sig.parameters
+    assert sig.parameters["role"].default == "primary"
+
+
+def test_apply_model_dispatches_to_reflection_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reflection branch must write to
+    ``settings.cognitive_reflection_model`` (not ``settings.model``)
+    and to the reflection env/toml keys."""
+    from core.cli.commands import model as _model_mod
+    from core.cli.commands._state import ModelProfile
+    from core.config import settings
+
+    # Stub _check_provider_key + console + upsert_env + upsert_config_toml
+    # to capture invocations without touching real .env / config.toml.
+    from core.cli import commands as _pkg
+
+    monkeypatch.setattr(_pkg, "_check_provider_key", lambda _p: None)
+    monkeypatch.setattr(_pkg, "get_conversation_context", lambda: None)
+    upsert_env_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(_pkg, "_upsert_env", lambda k, v: upsert_env_calls.append((k, v)))
+
+    from core.utils import env_io as _env_io
+
+    upsert_toml_calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        _env_io,
+        "upsert_config_toml",
+        lambda section, key, value: upsert_toml_calls.append((section, key, value)),
+    )
+
+    # Snapshot the current reflection model so we can restore + verify.
+    old_reflection = getattr(settings, "cognitive_reflection_model", "")
+    target = ModelProfile(
+        id="claude-haiku-4-5-20251001", provider="anthropic", label="Haiku 4.5", cost="$"
+    )
+
+    # Set a sentinel so the test exercises the change path
+    object.__setattr__(settings, "cognitive_reflection_model", "claude-opus-4-7")
+
+    _model_mod._apply_model(target, effort=None, role="reflection")
+
+    # settings field flipped
+    assert settings.cognitive_reflection_model == "claude-haiku-4-5-20251001"
+    # env_io wrote the reflection env + toml keys, NOT GEODE_MODEL /
+    # [llm] primary_model
+    assert ("GEODE_COGNITIVE_REFLECTION_MODEL", "claude-haiku-4-5-20251001") in upsert_env_calls
+    assert ("cognitive", "reflection_model", "claude-haiku-4-5-20251001") in upsert_toml_calls
+    assert not any(k == "GEODE_MODEL" for k, _v in upsert_env_calls)
+    assert not any(s == "llm" for s, _k, _v in upsert_toml_calls)
+
+    # Restore
+    object.__setattr__(settings, "cognitive_reflection_model", old_reflection)
+
+
+def test_apply_model_primary_skips_effort_for_reflection_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``has_effort=False`` roles must never call ``_upsert_env``
+    with ``GEODE_AGENTIC_EFFORT`` even when ``effort=`` is passed
+    (defensive — picker passes None for non-effort roles, but the
+    dispatcher must double-check)."""
+    from core.cli.commands import model as _model_mod
+    from core.cli.commands._state import ModelProfile
+
+    from core.cli import commands as _pkg
+
+    monkeypatch.setattr(_pkg, "_check_provider_key", lambda _p: None)
+    monkeypatch.setattr(_pkg, "get_conversation_context", lambda: None)
+    upsert_env_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(_pkg, "_upsert_env", lambda k, v: upsert_env_calls.append((k, v)))
+    from core.utils import env_io as _env_io
+
+    monkeypatch.setattr(_env_io, "upsert_config_toml", lambda *_a, **_kw: None)
+
+    target = ModelProfile(id="claude-haiku-4-5-20251001", provider="anthropic", label="x", cost="$")
+    # Pass effort even though reflection role doesn't have one
+    _model_mod._apply_model(target, effort="high", role="reflection")
+    assert not any(k == "GEODE_AGENTIC_EFFORT" for k, _v in upsert_env_calls)
+
+
+# ---------------------------------------------------------------------------
+# cmd_model arg parsing — role prefix
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_model_parses_role_prefix() -> None:
+    """``/model reflection haiku-4.5`` must route to the reflection
+    role, not interpret 'reflection' as a model name."""
+    from core.cli.commands.model import cmd_model
+
+    src = inspect.getsource(cmd_model)
+    # Pin the role-prefix parsing branch
+    assert "first, _, rest = arg.partition" in src or "partition" in src
+    assert "role_name = first" in src or "role_name=" in src
+
+
+def test_cmd_model_role_def_passed_to_apply_model() -> None:
+    """End-to-end grep — ``cmd_model`` must pass ``role=role_def.name``
+    into ``_apply_model``, not the hardcoded 'primary' default."""
+    from core.cli.commands.model import cmd_model
+
+    src = inspect.getsource(cmd_model)
+    assert "role=role_def.name" in src
+
+
+# ---------------------------------------------------------------------------
+# Single-role mode still works (backward compat)
+# ---------------------------------------------------------------------------
+
+
+def test_picker_without_roles_runs_in_single_axis_mode() -> None:
+    """Pin that calling pick_model_and_effort WITHOUT ``roles`` keeps
+    the legacy behaviour — older test fixtures that don't construct
+    the role tab list must not break."""
+    sig = inspect.signature(effort_picker.pick_model_and_effort)
+    # Default = None so callers can omit
+    assert sig.parameters["roles"].default is None


### PR DESCRIPTION
## Summary

- **`/model` 안에서 reflection 모델까지 선택 가능.** Tab으로 `[ Primary ][ Reflection ]` 탭 사이를 토글, Enter는 focused role의 knob에 저장. `/model reflection <name>` 명령도 추가.
- **`AGENT_ROLES` 레지스트리.** 각 역할이 자기 settings field / env var / config.toml `(section, key)`를 선언 — 향후 mutator (PR-1 paperclip), judge 추가 시 추가 변경 없음.
- **Non-tty fallback** — `/model` 리스트에서 `P←` (Primary) / `R←` (Reflection) 마커로 각 역할의 현재 선택을 동시에 표시.

## Why

PR-3 C-2 reflection node has `settings.cognitive_reflection_model` knob (default Haiku 4.5) but no runtime UI — operators had to edit `~/.geode/config.toml` or env var and restart. User asked for `/model` 안에서 선택 가능하게 해달라. Option A (role-tab) 채택 — sprint가 이미 mutator (PR-1) + reflection (PR-3) 두 역할을 만들었고, judge/critic도 같은 패턴이 될 가능성이 큼. 역할 차원을 `/model`의 1차 시민으로 올리는 게 long-term cohesion에 맞음.

## Changes

| File | Change |
|------|--------|
| `core/cli/commands/_state.py` | NEW `AgentRole` + `AGENT_ROLES` registry + `role_by_name` |
| `core/cli/effort_picker.py` | `_KEY_TAB` + role params in `_render` / `pick_model_and_effort` + `PickerResult.role` |
| `core/cli/commands/model.py` | `_apply_model` role kwarg dispatcher; `_current_model_for_role` helper; `_interactive_model_picker_for_role`; `cmd_model` role-prefix parsing; per-role markers in non-tty fallback |
| `tests/test_model_role_tab.py` | NEW — 15 invariant tests |
| `CHANGELOG.md` | `[Unreleased] Added` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `AGENT_ROLES` registry | Implemented | primary + reflection; structure absorbs future mutator/judge |
| Tab-cyclable picker UI | Implemented | Tab cycles, re-anchors cursor to new role's current model |
| `_apply_model` role dispatcher | Implemented | settings field + env var + config.toml keys per role |
| `/model reflection <name>` CLI | Implemented | Non-interactive role-prefix path |
| Mutator (`[self_improving_loop.mutator]`) role | Deferred | Add a 3rd `AgentRole` entry in a follow-up — schema is ready |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_model_role_tab.py -q` — 15/15 pass
- [x] Rebased on top of v0.99.24 release (`45b0818f`)

## Reference

- User direction: "reflection 노드는 하드코딩이 되어있어? `/model`에서 유저가 선택할 수 있도록 수정해" (2026-05-21)
- 3-codebase consensus for role × model × source axis: Codex CLI `model_*` rate-limited per role, Claude Code `ModelPicker.tsx` role-aware tabs, OpenClaw Auth Profile Rotation per binding