### PR TITLE
feat(cognitive-loop): PR-B — reflection node tool_use structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,21 +60,36 @@ functional change.
   ``tool_use`` contract every provider-aware GEODE caller already
   uses: declare a ``record_reflection`` tool with a JSON
   ``input_schema`` (``hypotheses[<=5]`` / ``confidence ∈ [0,1]`` /
-  ``next_action_hint``), force its invocation via
-  ``tool_choice={"type": "tool", "name": "record_reflection"}``,
+  ``next_action_hint``) + ``strict: True`` opt-in for the Anthropic
+  strict-tool-input validator, dispatch with the canonical
+  ``tool_choice="any"`` (= must use SOME declared tool; with only
+  one declared this effectively forces ``record_reflection`` while
+  staying compatible with Anthropic adaptive thinking on Opus 4.7),
   and read the parsed ``input`` dict directly off the
-  ``ToolUseBlock``. The Anthropic SDK enforces the schema server-
-  side, so the shape is guaranteed by the time the dispatcher sees
-  it. ``_apply_reflection`` keeps its schema-typed casts (incl. the
-  ``bool``-exclusion guard mirroring PR-5's mutator fix) so a
-  non-Anthropic provider in the dispatcher fork can't poison state.
-  Eliminates ~80 lines of parsing fallback + 4 parser-edge-case
-  tests; replaces them with 4 ``_extract_reflection_input``
-  resolver tests and 1 wire-up invariant test pinning that
-  ``reflect_async`` passes the tool schema + forced choice to the
-  adapter. Public surface exposes ``REFLECTION_TOOL_NAME`` so
-  transcript renderers / debug tools can grep without importing
-  the private dict.
+  ``ToolUseBlock``. ``_apply_reflection`` keeps its schema-typed
+  casts (incl. the ``bool``-exclusion guard mirroring PR-5's
+  mutator fix) so a non-Anthropic provider in the dispatcher fork
+  can't poison state. Eliminates ~80 lines of parsing fallback + 4
+  parser-edge-case tests; replaces them with 4
+  ``_extract_reflection_input`` resolver tests and 1 wire-up
+  invariant test pinning that ``reflect_async`` passes the tool
+  schema + ``tool_choice="any"`` to the adapter. Public surface
+  exposes ``REFLECTION_TOOL_NAME`` so transcript renderers / debug
+  tools can grep without importing the private dict.
+
+- **PR-B fix-up — Codex provider routes ``tool_choice`` through
+  the cross-provider normaliser.** Pre-fix
+  ``core/llm/providers/codex.py:309`` grabbed
+  ``tool_choice.get("type")`` and passed the literal value straight
+  through to the Responses API, dropping the forced-tool name
+  (``{"type": "tool", "name": "X"}`` → ``"tool"``) and rejecting
+  canonical aliases like ``"any"``. Any forced-tool caller (the
+  PR-B reflection node was the first) hit silent no-ops on the
+  ``openai-codex`` provider. Codex MCP review #1 caught the gap.
+  Fix routes through :func:`core.llm.tool_choice.normalize` (same
+  as the OpenAI/GLM adapters) so ``"any"`` becomes ``"required"``
+  and named-tool forcing translates to the OpenAI ``{"type":
+  "function", "name": "X"}`` shape.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,9 +87,22 @@ functional change.
   PR-B reflection node was the first) hit silent no-ops on the
   ``openai-codex`` provider. Codex MCP review #1 caught the gap.
   Fix routes through :func:`core.llm.tool_choice.normalize` (same
-  as the OpenAI/GLM adapters) so ``"any"`` becomes ``"required"``
-  and named-tool forcing translates to the OpenAI ``{"type":
-  "function", "name": "X"}`` shape.
+  as the OpenAI/GLM adapters) so ``"auto"`` / ``"any"`` /
+  named-tool forcing translate to the right OpenAI/Responses
+  shapes.
+
+- **PR-B fix-up — Anthropic ``_API_ALLOWED_KEYS`` adds ``strict``;
+  reflection drops to ``tool_choice="auto"``.** Codex MCP review #2
+  caught: (a) ``strict: True`` was being stripped from the tool
+  definition before the Anthropic API call because the allow-list
+  filter omitted ``"strict"``; (b) ``tool_choice="any"`` (and any
+  named-tool forcing) is *also* incompatible with Anthropic
+  extended/adaptive thinking, not just the ``{"type": "tool"}``
+  shape — only ``"auto"`` works across every model + thinking
+  regime. Reflection now passes ``tool_choice="auto"``; with one
+  tool declared and a strong system prompt the LLM still calls it
+  on the happy path, and the rare decline is handled by
+  ``_extract_reflection_input`` returning ``None`` + WARN.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,35 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-B — reflection node uses ``tool_use`` structured output.** Pre-
+  PR-B ``core/agent/loop/_reflection.py`` told the LLM "Return ONLY
+  this JSON, no prose" and ran a 5-stage forgiving parser
+  (``_parse_reflection`` + ``_extract_first_json_object`` with
+  fence strip + prose-prefix extraction + string-aware brace counting)
+  to recover from the contract drift the LLM inevitably caused.
+  Codex MCP caught parser gaps three times during the PR-3 review
+  rounds. PR-B replaces the entire fragile path with the same
+  ``tool_use`` contract every provider-aware GEODE caller already
+  uses: declare a ``record_reflection`` tool with a JSON
+  ``input_schema`` (``hypotheses[<=5]`` / ``confidence ∈ [0,1]`` /
+  ``next_action_hint``), force its invocation via
+  ``tool_choice={"type": "tool", "name": "record_reflection"}``,
+  and read the parsed ``input`` dict directly off the
+  ``ToolUseBlock``. The Anthropic SDK enforces the schema server-
+  side, so the shape is guaranteed by the time the dispatcher sees
+  it. ``_apply_reflection`` keeps its schema-typed casts (incl. the
+  ``bool``-exclusion guard mirroring PR-5's mutator fix) so a
+  non-Anthropic provider in the dispatcher fork can't poison state.
+  Eliminates ~80 lines of parsing fallback + 4 parser-edge-case
+  tests; replaces them with 4 ``_extract_reflection_input``
+  resolver tests and 1 wire-up invariant test pinning that
+  ``reflect_async`` passes the tool schema + forced choice to the
+  adapter. Public surface exposes ``REFLECTION_TOOL_NAME`` so
+  transcript renderers / debug tools can grep without importing
+  the private dict.
+
 ### Added
 
 - **PR-A — ``/model`` role tab for reflection-model selection.** Pre-

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -11,11 +11,16 @@ JSON: {...}"``, ``` ```json``` fences, trailing prose, etc.), and
 a 5-stage forgiving parser handled the drift. Codex MCP caught
 parser gaps 3 times during PR-3. The fix is to use the structured-
 output contract every other GEODE provider-aware caller already
-uses: declare a tool with a JSON schema, force its invocation, and
-read the parsed ``input`` dict directly off the ``ToolUseBlock``.
-The Anthropic SDK enforces the schema server-side, so the
-``hypotheses[]`` / ``confidence`` / ``next_action_hint`` shape is
-guaranteed by the time it reaches us.
+uses: declare a tool with a JSON ``input_schema`` + ``strict:
+True`` opt-in, prefer its invocation via ``tool_choice="auto"``,
+and read the parsed ``input`` dict directly off the
+``ToolUseBlock``. We use ``"auto"`` rather than forced
+``"any"`` / ``{"type": "tool"}`` because both forced shapes are
+incompatible with Anthropic extended/adaptive thinking — only
+``"auto"`` works across every model + thinking regime (Codex MCP
+PR-B review #2). With one tool declared and a strong system
+prompt the LLM still calls the tool on the happy path; rare
+declines fall through to a WARN + keep-previous-state path.
 
 Pre-PR-3 the agentic loop went tool result → next action with no
 explicit belief-update step. ``CognitiveState.hypotheses`` and
@@ -223,8 +228,9 @@ async def reflect_async(
     """Run the reflection LLM call and update ``state`` in place.
 
     PR-B (2026-05-21) — uses ``tool_use`` structured output (the
-    ``record_reflection`` tool with a forced ``tool_choice``). The
-    Anthropic SDK enforces the JSON schema, so we read ``input``
+    ``record_reflection`` tool with ``strict: True`` schema +
+    ``tool_choice="auto"``). The Anthropic API validates the schema
+    server-side when ``strict`` is set, so we read ``input``
     directly off the returned ``ToolUseBlock``.
 
     Errors (LLM failure, model declined the tool, schema mismatch

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -255,22 +255,24 @@ async def reflect_async(
         )
 
         async def _do_call(m: str) -> object:
-            # PR-B fix-up #1 — canonical ``"any"`` (= must use SOME
-            # declared tool). Since only one tool is declared this
-            # effectively forces ``record_reflection``. ``{"type":
-            # "tool", "name": ...}`` would be more explicit but
-            # conflicts with Anthropic adaptive thinking (Opus 4.7 /
-            # Sonnet 4.6) per the Anthropic tool-use docs — the API
-            # returns 400 when forced-tool + extended-thinking
-            # combine. ``"any"`` is compatible with both regimes and
-            # cleanly translates to ``required`` for OpenAI / Codex
-            # via :func:`core.llm.tool_choice.normalize`.
+            # PR-B fix-up #2 — ``tool_choice="auto"``. Anthropic docs
+            # mark *both* ``"any"`` and named-tool forcing as
+            # incompatible with extended/adaptive thinking, so
+            # operators who pick Opus 4.7 / Sonnet 4.6 via
+            # ``/model reflection`` would otherwise hit a 400. Only
+            # ``"auto"`` works across every model + thinking regime.
+            # With one tool declared + a strong "invoke the tool"
+            # system prompt the LLM still calls the tool on the
+            # happy path; the rare decline is handled gracefully by
+            # ``_extract_reflection_input → None → keep previous
+            # state``. Cross-provider: ``"auto"`` normalises to
+            # ``"auto"`` on OpenAI/Codex via the shared normaliser.
             return await adapter.agentic_call(
                 model=m,
                 system=_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": user_prompt}],
                 tools=[_REFLECTION_TOOL],
-                tool_choice="any",
+                tool_choice="auto",
                 max_tokens=max_tokens,
                 temperature=0.2,
             )

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -3,6 +3,20 @@
 PR-3 C-2 of the cognitive-loop-uplift sprint
 (``docs/plans/2026-05-21-cognitive-loop-uplift.md``).
 
+PR-B (2026-05-21) — migrated the reflection call from free-form
+JSON-in-text to Anthropic ``tool_use`` structured output. Pre-PR-B
+the system prompt asked the LLM to "Return ONLY this JSON, no
+prose" but models frequently disobeyed (wrapped in ``"Here is the
+JSON: {...}"``, ``` ```json``` fences, trailing prose, etc.), and
+a 5-stage forgiving parser handled the drift. Codex MCP caught
+parser gaps 3 times during PR-3. The fix is to use the structured-
+output contract every other GEODE provider-aware caller already
+uses: declare a tool with a JSON schema, force its invocation, and
+read the parsed ``input`` dict directly off the ``ToolUseBlock``.
+The Anthropic SDK enforces the schema server-side, so the
+``hypotheses[]`` / ``confidence`` / ``next_action_hint`` shape is
+guaranteed by the time it reaches us.
+
 Pre-PR-3 the agentic loop went tool result → next action with no
 explicit belief-update step. ``CognitiveState.hypotheses`` and
 ``CognitiveState.confidence`` were declared in PR-2 but never
@@ -13,7 +27,7 @@ signal to record against an outcome.
 The reflection node runs ONE LLM call after every tool-use round.
 It sees only the cognitive-state snapshot + a compact tool-result
 summary (NOT the full conversation — clean-context discipline) and
-returns a small JSON object with:
+invokes the ``record_reflection`` tool which carries:
 
   hypotheses[<=5]   — short claims about the task state
   confidence ∈ [0,1] — overall confidence the goal will be achieved
@@ -32,7 +46,6 @@ established by PR-1).
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -44,20 +57,49 @@ from core.llm.router import call_with_failover
 log = logging.getLogger(__name__)
 
 
+REFLECTION_TOOL_NAME = "record_reflection"
+
+
+_REFLECTION_TOOL: dict[str, Any] = {
+    "name": REFLECTION_TOOL_NAME,
+    "description": (
+        "Record the agent's updated beliefs after the round that just finished. "
+        "Prefer pruning stale hypotheses over piling new ones — the loop tracks "
+        "evolution not history. If the round produced no useful signal, keep "
+        "the previous hypotheses and lower confidence."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "hypotheses": {
+                "type": "array",
+                "items": {"type": "string"},
+                "maxItems": 5,
+                "description": "Short claims about the task state (each <= 120 chars).",
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": "Overall confidence the goal will be achieved.",
+            },
+            "next_action_hint": {
+                "type": "string",
+                "description": "Single-line hint for what to try next (<= 120 chars).",
+            },
+        },
+        "required": ["hypotheses", "confidence"],
+    },
+}
+
+
 _SYSTEM_PROMPT = (
     "You are the reflection node of an autonomous execution agent. "
     "Given the agent's current cognitive state and a compact summary "
-    "of the round that just finished, produce a JSON object that "
-    "updates the agent's beliefs.\n\n"
-    "Output schema (return ONLY this JSON, no prose):\n"
-    "{\n"
-    '  "hypotheses": ["short claim 1", ...],  // <= 5 entries, each <= 120 chars\n'
-    '  "confidence": 0.0,                      // float in [0,1]\n'
-    '  "next_action_hint": "..."               // <= 120 chars, what to try next\n'
-    "}\n\n"
-    "Prefer pruning stale hypotheses over piling new ones; the loop "
-    "tracks evolution not history. If the round produced no useful "
-    "signal, keep the previous hypotheses and lower confidence."
+    "of the round that just finished, invoke the "
+    f"``{REFLECTION_TOOL_NAME}`` tool to update the agent's beliefs. "
+    "Do NOT emit free-form prose; the tool call is the only required "
+    "output."
 )
 
 
@@ -103,98 +145,35 @@ def _build_user_prompt(state: CognitiveState, tool_summary: str) -> str:
         f"Previous hypotheses: {state.hypotheses!r}\n"
         f"Previous confidence: {state.confidence!r}\n\n"
         f"Tool batch results:\n{tool_summary}\n\n"
-        "Return ONLY the JSON object specified in the system prompt."
+        f"Invoke the {REFLECTION_TOOL_NAME} tool now."
     )
 
 
-def _parse_reflection(text: str) -> dict[str, Any]:
-    """Parse the reflection LLM output into a structured dict.
+def _extract_reflection_input(response: Any) -> dict[str, Any] | None:
+    """Find the ``record_reflection`` tool_use block in the response.
 
-    The LLM is instructed to return only JSON. In practice models
-    emit it wrapped in ``"Here is the JSON: {...}"`` prose, a
-    ```json``` fence (often with trailing text after the closing
-    fence), or other decoration. The parser is intentionally
-    forgiving:
-
-      1. Strip fence wrappers if present (opening fence with or
-         without language tag; trailing fence even if more prose
-         follows).
-      2. Otherwise extract the first balanced ``{...}`` block by
-         scanning for the first ``{`` and matching ``}``, with
-         string-aware brace counting so a ``}`` inside a string
-         value doesn't close the object early.
-      3. Parse the extracted block; non-object results raise
-         ``ValueError`` so the caller falls back to previous state.
+    Returns the tool's ``input`` dict (already parsed by the adapter
+    normalizer — see :class:`core.llm.agentic_response.ToolUseBlock`).
+    Returns ``None`` when the model declined to invoke the tool;
+    callers swallow this case with a WARN.
     """
-    candidate = text.strip()
-
-    if candidate.startswith("```"):
-        # drop opening fence (with or without language tag)
-        first_newline = candidate.find("\n")
-        if first_newline != -1:
-            candidate = candidate[first_newline + 1 :]
-        # drop closing fence — anywhere in the remaining text, then
-        # trim any prose after it (models sometimes append
-        # "this should help" or similar).
-        closing = candidate.find("```")
-        if closing != -1:
-            candidate = candidate[:closing]
-        candidate = candidate.strip()
-
-    # Always extract the first balanced {...} block — handles bare
-    # JSON followed by prose ("{...}\\nthanks"), prose prefix
-    # ("Here is the JSON: {...}"), and the happy path (returns the
-    # input unchanged when it's already a clean JSON object).
-    # Brace counting is string-aware so a ``}`` inside a value
-    # doesn't close the outer object early.
-    candidate = _extract_first_json_object(candidate)
-
-    parsed = json.loads(candidate)
-    if not isinstance(parsed, dict):
-        raise ValueError(f"reflection output is not a JSON object: {type(parsed).__name__}")
-    return parsed
-
-
-def _extract_first_json_object(text: str) -> str:
-    """Return the first balanced ``{...}`` block in ``text``.
-
-    Brace counting is string-aware: a ``}`` inside a JSON string
-    value does not close the outer object. Raises ``ValueError`` if
-    no balanced object is found.
-    """
-    depth = 0
-    in_string = False
-    escape_next = False
-    start = -1
-    for index, char in enumerate(text):
-        if escape_next:
-            escape_next = False
-            continue
-        if in_string:
-            if char == "\\":
-                escape_next = True
-            elif char == '"':
-                in_string = False
-            continue
-        if char == '"':
-            in_string = True
-            continue
-        if char == "{":
-            if depth == 0:
-                start = index
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0 and start != -1:
-                return text[start : index + 1]
-    raise ValueError("no balanced JSON object found in reflection output")
+    for block in getattr(response, "content", []) or []:
+        if getattr(block, "type", None) == "tool_use" and getattr(block, "name", "") == (
+            REFLECTION_TOOL_NAME
+        ):
+            payload = getattr(block, "input", None)
+            if isinstance(payload, dict):
+                return payload
+    return None
 
 
 def _apply_reflection(state: CognitiveState, parsed: dict[str, Any]) -> None:
     """Update ``state`` in-place with reflection output.
 
-    Schema-typed casts — invalid types per field silently drop that
-    field rather than poisoning the entire state. PR-3 prefers
+    Schema-typed casts — even though the Anthropic schema validator
+    enforces field types server-side, the dispatcher fork (GLM /
+    OpenAI / Codex) may not. Drop fields with the wrong type
+    silently rather than poisoning the entire state. PR-3 prefers
     *partial* belief update over complete rejection so a flaky
     reflection model still moves the needle.
     """
@@ -209,7 +188,11 @@ def _apply_reflection(state: CognitiveState, parsed: dict[str, Any]) -> None:
         state.hypotheses = cleaned
 
     confidence_raw = parsed.get("confidence")
-    if isinstance(confidence_raw, int | float):
+    # ``bool`` is an ``int`` subclass — exclude explicitly so
+    # ``True``/``False`` doesn't collapse to ``1.0``/``0.0`` and
+    # mute a real confidence signal (Codex MCP review of PR-5
+    # caught the same anti-pattern in the mutator schema).
+    if isinstance(confidence_raw, int | float) and not isinstance(confidence_raw, bool):
         state.confidence = max(0.0, min(1.0, float(confidence_raw)))
 
     hint_raw = parsed.get("next_action_hint")
@@ -232,10 +215,15 @@ async def reflect_async(
 ) -> None:
     """Run the reflection LLM call and update ``state`` in place.
 
-    Errors (LLM failure, JSON parse failure, schema mismatch) are
-    logged at WARN and swallowed — the loop must remain robust to a
-    flaky reflection model. The next round just re-runs reflection
-    with the same previous state.
+    PR-B (2026-05-21) — uses ``tool_use`` structured output (the
+    ``record_reflection`` tool with a forced ``tool_choice``). The
+    Anthropic SDK enforces the JSON schema, so we read ``input``
+    directly off the returned ``ToolUseBlock``.
+
+    Errors (LLM failure, model declined the tool, schema mismatch
+    on a non-Anthropic provider) are logged at WARN and swallowed —
+    the loop must remain robust to a flaky reflection model. The
+    next round just re-runs reflection with the same previous state.
 
     Dispatch goes through ``core.llm.router.call_with_failover`` so
     the call shares the credential rotator with the rest of GEODE
@@ -264,8 +252,8 @@ async def reflect_async(
                 model=m,
                 system=_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": user_prompt}],
-                tools=[],
-                tool_choice={"type": "auto"},
+                tools=[_REFLECTION_TOOL],
+                tool_choice={"type": "tool", "name": REFLECTION_TOOL_NAME},
                 max_tokens=max_tokens,
                 temperature=0.2,
             )
@@ -282,23 +270,15 @@ async def reflect_async(
         log.warning("reflection LLM call returned None (model=%s); keeping previous state", model)
         return
 
-    text_chunks: list[str] = []
-    for block in getattr(response, "content", []):
-        block_text = getattr(block, "text", "")
-        if block_text:
-            text_chunks.append(block_text)
-    raw = "".join(text_chunks)
-    if not raw:
-        log.warning("reflection LLM returned empty text; keeping previous state")
-        return
-
-    try:
-        parsed = _parse_reflection(raw)
-    except (ValueError, json.JSONDecodeError):
-        log.warning("reflection output not valid JSON; keeping previous state. raw=%r", raw[:200])
+    parsed = _extract_reflection_input(response)
+    if parsed is None:
+        log.warning(
+            "reflection response did not include a %s tool_use block; keeping previous state",
+            REFLECTION_TOOL_NAME,
+        )
         return
 
     _apply_reflection(state, parsed)
 
 
-__all__ = ["reflect_async"]
+__all__ = ["REFLECTION_TOOL_NAME", "reflect_async"]

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -68,6 +68,13 @@ _REFLECTION_TOOL: dict[str, Any] = {
         "evolution not history. If the round produced no useful signal, keep "
         "the previous hypotheses and lower confidence."
     ),
+    # PR-B fix-up #1 — ``strict: True`` opts into Anthropic's strict
+    # tool-input validation so a malformed payload is rejected server-
+    # side instead of needing client-side coercion. Codex MCP review
+    # called out that the previous "Anthropic enforces schema" claim
+    # was overstated without this flag. See
+    # https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
+    "strict": True,
     "input_schema": {
         "type": "object",
         "properties": {
@@ -248,12 +255,22 @@ async def reflect_async(
         )
 
         async def _do_call(m: str) -> object:
+            # PR-B fix-up #1 — canonical ``"any"`` (= must use SOME
+            # declared tool). Since only one tool is declared this
+            # effectively forces ``record_reflection``. ``{"type":
+            # "tool", "name": ...}`` would be more explicit but
+            # conflicts with Anthropic adaptive thinking (Opus 4.7 /
+            # Sonnet 4.6) per the Anthropic tool-use docs — the API
+            # returns 400 when forced-tool + extended-thinking
+            # combine. ``"any"`` is compatible with both regimes and
+            # cleanly translates to ``required`` for OpenAI / Codex
+            # via :func:`core.llm.tool_choice.normalize`.
             return await adapter.agentic_call(
                 model=m,
                 system=_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": user_prompt}],
                 tools=[_REFLECTION_TOOL],
-                tool_choice={"type": "tool", "name": REFLECTION_TOOL_NAME},
+                tool_choice="any",
                 max_tokens=max_tokens,
                 temperature=0.2,
             )

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -594,7 +594,9 @@ async def retry_with_backoff_async(
 # ClaudeAgenticAdapter — Anthropic LLM adapter for agentic loop
 # ---------------------------------------------------------------------------
 
-_API_ALLOWED_KEYS = frozenset({"name", "description", "input_schema", "cache_control", "type"})
+_API_ALLOWED_KEYS = frozenset(
+    {"name", "description", "input_schema", "cache_control", "type", "strict"}
+)
 
 # Models that support server-side context management + compaction beta.
 # Haiku 4.5 (2025-10-01) predates compact-2026-01-12 and rejects the beta

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -306,7 +306,18 @@ class CodexAgenticAdapter(OpenAIAgenticAdapter):
         # struct + Hermes ``agent/transports/codex.py`` shape. Spec doc:
         # ``docs/research/codex-oauth-request-spec.md`` (3-codebase grounded).
         oai_tools = _tools_to_openai(tools)
-        tc_val = tool_choice.get("type", "auto") if isinstance(tool_choice, dict) else tool_choice
+        # PR-B fix-up #1 — route through the cross-provider normaliser
+        # so canonical ``"any"`` → OpenAI/Responses ``"required"`` and
+        # ``{"type": "tool", "name": "X"}`` → ``{"type": "function",
+        # "name": "X"}`` translate correctly. Pre-fix the codex adapter
+        # only grabbed ``tool_choice.get("type")`` which silently passed
+        # the literal ``"any"`` or ``"tool"`` string straight through —
+        # values the Responses API rejects, so any forced-tool caller
+        # (e.g. ``core.agent.loop._reflection.reflect_async``) hit
+        # silent no-ops on the ``openai-codex`` provider.
+        from core.llm.tool_choice import normalize as _normalize_tool_choice
+
+        tc_val: Any = _normalize_tool_choice("openai", tool_choice) or "auto"
         is_reasoning = _is_codex_reasoning_model(model)
 
         async def _do_call(m: str) -> Any:

--- a/tests/test_reflection_node.py
+++ b/tests/test_reflection_node.py
@@ -82,6 +82,16 @@ def test_reflection_tool_schema_declares_required_shape() -> None:
     assert set(schema["required"]) == {"hypotheses", "confidence"}
 
 
+def test_anthropic_adapter_passes_strict_flag_through() -> None:
+    """Codex MCP review #2 catch — ``strict: True`` was being stripped
+    by ``_API_ALLOWED_KEYS`` filter on the Anthropic adapter so the
+    schema flag never reached the API. Pin that ``strict`` is in the
+    allowlist."""
+    from core.llm.providers.anthropic import _API_ALLOWED_KEYS
+
+    assert "strict" in _API_ALLOWED_KEYS
+
+
 def test_reflection_module_exports_tool_name_for_other_callers() -> None:
     """Re-exported so downstream (transcript renderer, debug tools) can
     grep for the tool name without importing the private dict."""
@@ -389,11 +399,11 @@ def test_reflect_async_passes_tool_schema_to_adapter(
     assert isinstance(tools, list) and len(tools) == 1
     assert tools[0]["name"] == REFLECTION_TOOL_NAME
     assert tools[0].get("strict") is True
-    # PR-B fix-up #1 — canonical ``"any"`` instead of the forced-named
-    # ``{"type": "tool", "name": ...}``. With only one tool declared,
-    # ``"any"`` effectively forces it AND stays compatible with
-    # Anthropic adaptive thinking.
-    assert adapter.last_kwargs.get("tool_choice") == "any"
+    # PR-B fix-up #2 — ``tool_choice="auto"``. Anthropic docs mark
+    # both ``"any"`` and named-tool forcing as incompatible with
+    # adaptive/extended thinking, so only ``"auto"`` is safe across
+    # every reflection-model setting.
+    assert adapter.last_kwargs.get("tool_choice") == "auto"
 
 
 def test_reflect_async_swallows_setup_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_reflection_node.py
+++ b/tests/test_reflection_node.py
@@ -388,10 +388,12 @@ def test_reflect_async_passes_tool_schema_to_adapter(
     tools = adapter.last_kwargs.get("tools")
     assert isinstance(tools, list) and len(tools) == 1
     assert tools[0]["name"] == REFLECTION_TOOL_NAME
-    assert adapter.last_kwargs.get("tool_choice") == {
-        "type": "tool",
-        "name": REFLECTION_TOOL_NAME,
-    }
+    assert tools[0].get("strict") is True
+    # PR-B fix-up #1 — canonical ``"any"`` instead of the forced-named
+    # ``{"type": "tool", "name": ...}``. With only one tool declared,
+    # ``"any"`` effectively forces it AND stays compatible with
+    # Anthropic adaptive thinking.
+    assert adapter.last_kwargs.get("tool_choice") == "any"
 
 
 def test_reflect_async_swallows_setup_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_reflection_node.py
+++ b/tests/test_reflection_node.py
@@ -1,20 +1,24 @@
 """PR-3 C-2 — Reflection node invariants.
 
-Pins the structure + behaviour of ``core/agent/loop/_reflection.py``:
-prompt assembly, JSON parsing, schema-typed casts, settings knobs,
-and AgenticLoop wiring. The actual LLM call is mocked — tests must
-not consume provider quota.
+PR-B (2026-05-21) — migrated to Anthropic ``tool_use`` structured
+output. The free-form-JSON fence/brace parser is gone; the LLM
+invokes the ``record_reflection`` tool and we read ``input``
+directly off the ``ToolUseBlock``. Schema-typed casts in
+``_apply_reflection`` survive so a non-Anthropic provider (which
+may not enforce the schema server-side) can't poison state.
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from core.agent.cognitive_state import CognitiveState
 from core.agent.loop import _reflection
+from core.agent.loop._reflection import REFLECTION_TOOL_NAME
 
 # ---------------------------------------------------------------------------
 # Pure-function invariants (no LLM)
@@ -54,59 +58,40 @@ def test_summarise_tool_results_caps_entries() -> None:
     assert "t8" not in out
 
 
-def test_parse_reflection_plain_json() -> None:
-    parsed = _reflection._parse_reflection('{"hypotheses": ["a"], "confidence": 0.5}')
-    assert parsed == {"hypotheses": ["a"], "confidence": 0.5}
+# ---------------------------------------------------------------------------
+# Tool schema declaration — pinned so a refactor that drops fields surfaces here
+# ---------------------------------------------------------------------------
 
 
-def test_parse_reflection_strips_fence() -> None:
-    parsed = _reflection._parse_reflection('```json\n{"hypotheses": ["a"], "confidence": 0.5}\n```')
-    assert parsed == {"hypotheses": ["a"], "confidence": 0.5}
+def test_reflection_tool_schema_declares_required_shape() -> None:
+    """Pin the tool schema. The Anthropic SDK enforces this server-
+    side, so dropping a property or required field would silently
+    change the contract."""
+    tool = _reflection._REFLECTION_TOOL
+    assert tool["name"] == REFLECTION_TOOL_NAME == "record_reflection"
+    schema = tool["input_schema"]
+    assert schema["type"] == "object"
+    props = schema["properties"]
+    assert set(props.keys()) == {"hypotheses", "confidence", "next_action_hint"}
+    assert props["hypotheses"]["type"] == "array"
+    assert props["hypotheses"]["maxItems"] == 5
+    assert props["confidence"]["type"] == "number"
+    assert props["confidence"]["minimum"] == 0.0
+    assert props["confidence"]["maximum"] == 1.0
+    # hypotheses + confidence are required; next_action_hint optional
+    assert set(schema["required"]) == {"hypotheses", "confidence"}
 
 
-def test_parse_reflection_raises_on_non_object() -> None:
-    with pytest.raises(ValueError):
-        _reflection._parse_reflection('["not", "an", "object"]')
+def test_reflection_module_exports_tool_name_for_other_callers() -> None:
+    """Re-exported so downstream (transcript renderer, debug tools) can
+    grep for the tool name without importing the private dict."""
+    assert "REFLECTION_TOOL_NAME" in _reflection.__all__
+    assert REFLECTION_TOOL_NAME == "record_reflection"
 
 
-def test_parse_reflection_strips_prose_prefix() -> None:
-    """Codex MCP review #1 catch — models often emit
-    ``"Here is the JSON: {...}"`` and the original fence-only parser
-    rejected those. The robust parser extracts the first balanced
-    ``{...}`` block."""
-    parsed = _reflection._parse_reflection(
-        'Here is the JSON: {"hypotheses": ["a"], "confidence": 0.5}'
-    )
-    assert parsed == {"hypotheses": ["a"], "confidence": 0.5}
-
-
-def test_parse_reflection_handles_text_after_closing_fence() -> None:
-    """Models sometimes emit ```json\\n{...}\\n```\\nhope this helps.
-    The original parser kept the trailing prose and failed to parse."""
-    parsed = _reflection._parse_reflection('```json\n{"hypotheses": ["a"]}\n```\nhope this helps')
-    assert parsed == {"hypotheses": ["a"]}
-
-
-def test_parse_reflection_brace_in_string_value() -> None:
-    """String-aware brace counting — a ``}`` inside a string value
-    must not close the outer object."""
-    parsed = _reflection._parse_reflection('{"hypotheses": ["a } with brace"], "confidence": 0.5}')
-    assert parsed == {"hypotheses": ["a } with brace"], "confidence": 0.5}
-
-
-def test_parse_reflection_no_object_raises() -> None:
-    with pytest.raises(ValueError):
-        _reflection._parse_reflection("definitely not json")
-
-
-def test_parse_reflection_handles_bare_json_with_trailing_prose() -> None:
-    """Codex MCP review #2 non-blocking caveat — models occasionally
-    emit ``{"hypotheses":["a"]}\\nthanks`` (no fence, prose after the
-    object). The original fix-up #1 only ran extraction when the
-    candidate did NOT start with ``{`` so this case was bypassed and
-    json.loads choked on the trailing prose."""
-    parsed = _reflection._parse_reflection('{"hypotheses": ["a"], "confidence": 0.5}\nthanks!')
-    assert parsed == {"hypotheses": ["a"], "confidence": 0.5}
+# ---------------------------------------------------------------------------
+# _apply_reflection — schema-typed casts
+# ---------------------------------------------------------------------------
 
 
 def test_apply_reflection_populates_hypotheses() -> None:
@@ -138,6 +123,16 @@ def test_apply_reflection_clamps_confidence() -> None:
     assert state.confidence == 0.0
 
 
+def test_apply_reflection_rejects_bool_confidence() -> None:
+    """``bool`` is an ``int`` subclass — must be excluded so the LLM
+    can't accidentally collapse confidence to 0/1 by returning
+    True/False. Mirrors PR-5 fix-up on the mutator schema."""
+    state = CognitiveState(confidence=0.5)
+    _reflection._apply_reflection(state, {"confidence": True})
+    # True would have flipped confidence to 1.0; the guard preserves 0.5
+    assert state.confidence == 0.5
+
+
 def test_apply_reflection_pushes_hint_into_subgoals() -> None:
     state = CognitiveState()
     _reflection._apply_reflection(state, {"next_action_hint": "try X"})
@@ -156,7 +151,9 @@ def test_apply_reflection_caps_subgoals_at_five() -> None:
 
 def test_apply_reflection_ignores_wrong_types() -> None:
     """Schema-typed casts — bad types silently drop the field, not
-    poison the whole state."""
+    poison the whole state. Even though the Anthropic SDK enforces
+    types server-side, non-Anthropic providers don't, so this guard
+    protects the dispatcher fork."""
     state = CognitiveState(goal="x", confidence=0.5, hypotheses=["keep"])
     _reflection._apply_reflection(
         state,
@@ -166,6 +163,55 @@ def test_apply_reflection_ignores_wrong_types() -> None:
     assert state.hypotheses == ["keep"]
     assert state.confidence == 0.5
     assert state.subgoals == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_reflection_input — tool_use block resolver
+# ---------------------------------------------------------------------------
+
+
+def _tool_use_block(name: str, payload: dict[str, Any]) -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", name=name, input=payload)
+
+
+def _text_block(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def test_extract_reflection_input_finds_named_tool_block() -> None:
+    response = SimpleNamespace(
+        content=[
+            _text_block("thinking..."),
+            _tool_use_block(
+                REFLECTION_TOOL_NAME,
+                {"hypotheses": ["h1"], "confidence": 0.5},
+            ),
+        ]
+    )
+    out = _reflection._extract_reflection_input(response)
+    assert out == {"hypotheses": ["h1"], "confidence": 0.5}
+
+
+def test_extract_reflection_input_ignores_other_tools() -> None:
+    response = SimpleNamespace(
+        content=[
+            _tool_use_block("some_other_tool", {"junk": True}),
+            _text_block("no reflection here"),
+        ]
+    )
+    assert _reflection._extract_reflection_input(response) is None
+
+
+def test_extract_reflection_input_handles_empty_content() -> None:
+    response = SimpleNamespace(content=[])
+    assert _reflection._extract_reflection_input(response) is None
+
+
+def test_extract_reflection_input_handles_none_content() -> None:
+    """Defensive — adapters that return a response without a content
+    attribute (or with content=None) must not crash the helper."""
+    response = SimpleNamespace(content=None)
+    assert _reflection._extract_reflection_input(response) is None
 
 
 # ---------------------------------------------------------------------------
@@ -227,26 +273,25 @@ def test_run_cognitive_act_observe_cycle_calls_maybe_reflect() -> None:
 
 
 # ---------------------------------------------------------------------------
-# reflect_async — error tolerance
+# reflect_async — error tolerance + tool_use roundtrip
 # ---------------------------------------------------------------------------
 
 
 class _StubAdapter:
-    def __init__(self, response: Any = None, raise_exc: BaseException | None = None) -> None:
+    def __init__(
+        self,
+        response: Any = None,
+        raise_exc: BaseException | None = None,
+    ) -> None:
         self._response = response
         self._raise = raise_exc
+        self.last_kwargs: dict[str, Any] = {}
 
-    async def agentic_call(self, **_kwargs: Any) -> Any:
+    async def agentic_call(self, **kwargs: Any) -> Any:
+        self.last_kwargs = dict(kwargs)
         if self._raise is not None:
             raise self._raise
         return self._response
-
-
-class _StubResponse:
-    def __init__(self, text: str) -> None:
-        from types import SimpleNamespace
-
-        self.content = [SimpleNamespace(text=text)]
 
 
 def _install_reflection_stubs(
@@ -280,24 +325,37 @@ def test_reflect_async_swallows_llm_failure(monkeypatch: pytest.MonkeyPatch) -> 
     assert state.confidence == 0.4
 
 
-def test_reflect_async_swallows_empty_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    state = CognitiveState(hypotheses=["keep"])
-    _install_reflection_stubs(monkeypatch, adapter=_StubAdapter(response=_StubResponse("")))
+def test_reflect_async_swallows_response_without_tool_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the LLM ignores the forced tool_choice and returns only
+    text (or some other tool), keep previous state."""
+    state = CognitiveState(hypotheses=["keep"], confidence=0.4)
+    response = SimpleNamespace(content=[_text_block("I have nothing to say")])
+    _install_reflection_stubs(monkeypatch, adapter=_StubAdapter(response=response))
 
     asyncio.run(_reflection.reflect_async(state, [], model="m", max_tokens=128))
     assert state.hypotheses == ["keep"]
+    assert state.confidence == 0.4
 
 
-def test_reflect_async_applies_valid_response(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_reflect_async_applies_tool_use_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path — adapter returns a ToolUseBlock with the parsed
+    input dict; reflect_async applies it to state."""
     state = CognitiveState(goal="x")
-    _install_reflection_stubs(
-        monkeypatch,
-        adapter=_StubAdapter(
-            response=_StubResponse(
-                '{"hypotheses": ["h1", "h2"], "confidence": 0.7, "next_action_hint": "do it"}'
+    response = SimpleNamespace(
+        content=[
+            _tool_use_block(
+                REFLECTION_TOOL_NAME,
+                {
+                    "hypotheses": ["h1", "h2"],
+                    "confidence": 0.7,
+                    "next_action_hint": "do it",
+                },
             )
-        ),
+        ]
     )
+    _install_reflection_stubs(monkeypatch, adapter=_StubAdapter(response=response))
 
     asyncio.run(_reflection.reflect_async(state, [], model="m", max_tokens=128))
     assert state.hypotheses == ["h1", "h2"]
@@ -305,20 +363,42 @@ def test_reflect_async_applies_valid_response(monkeypatch: pytest.MonkeyPatch) -
     assert state.subgoals == ["do it"]
 
 
-def test_reflect_async_swallows_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
-    state = CognitiveState(hypotheses=["keep"])
-    _install_reflection_stubs(
-        monkeypatch, adapter=_StubAdapter(response=_StubResponse("definitely not json"))
+def test_reflect_async_passes_tool_schema_to_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wire-up invariant — reflect_async must call the adapter with
+    the reflection tool declared and tool_choice forced. Pin via
+    captured adapter kwargs so a refactor that drops tools=[]
+    surfaces here, not at runtime."""
+    state = CognitiveState()
+    adapter = _StubAdapter(
+        response=SimpleNamespace(
+            content=[
+                _tool_use_block(
+                    REFLECTION_TOOL_NAME,
+                    {"hypotheses": [], "confidence": 0.5},
+                )
+            ]
+        )
     )
+    _install_reflection_stubs(monkeypatch, adapter=adapter)
+
     asyncio.run(_reflection.reflect_async(state, [], model="m", max_tokens=128))
-    assert state.hypotheses == ["keep"]
+
+    tools = adapter.last_kwargs.get("tools")
+    assert isinstance(tools, list) and len(tools) == 1
+    assert tools[0]["name"] == REFLECTION_TOOL_NAME
+    assert adapter.last_kwargs.get("tool_choice") == {
+        "type": "tool",
+        "name": REFLECTION_TOOL_NAME,
+    }
 
 
 def test_reflect_async_swallows_setup_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Codex MCP review #1 catch — provider / adapter resolution used
-    to escape the try block, breaking the agentic loop. Pin that even
-    setup-time errors (unknown model, missing adapter, importable
-    chain) keep the loop alive."""
+    """Codex MCP review (PR-3 #1) catch — provider / adapter
+    resolution used to escape the try block, breaking the agentic
+    loop. Pin that even setup-time errors (unknown model, missing
+    adapter, importable chain) keep the loop alive."""
     state = CognitiveState(hypotheses=["keep"], confidence=0.4)
 
     def _boom_resolve(_model: str) -> str:


### PR DESCRIPTION
## Summary

- **Reflection LLM 호출이 free-form JSON에서 `tool_use` structured output으로 전환.** `record_reflection` 툴 + `tool_choice={"type":"tool","name":"record_reflection"}` 강제 호출. Anthropic SDK가 server-side에서 `input_schema` 강제 → 결과의 `input` 딕셔너리를 직접 사용.
- **5단계 forgiving parser 폐기.** `_parse_reflection`, `_extract_first_json_object`, fence/prose/brace 추출 모두 삭제 (~80 LOC). 
- **`_apply_reflection` schema-typed cast 유지.** 비-Anthropic 프로바이더 (GLM / OpenAI / Codex) 분기에서는 schema 미강제이므로 bool 제외 / 타입 검사 살림.

## Why

PR-3 review 동안 Codex MCP가 reflection JSON parser 갭을 3번 잡았다 (fence-prose 혼합 / 닫는 fence 뒤 prose / bare JSON + trailing prose). 매번 parser를 손봤지만 LLM의 "Return ONLY JSON" 계약 자체가 fiction. Frontier 매트릭스에서 Hermes / Claude Code / OpenClaw 셋 다 internal LLM 호출에서 `tool_use` native를 사용 — GEODE만 free-form JSON. **계약을 강화하는 게 parser를 손보는 것보다 근본 해결**.

## Changes

| File | Change |
|------|--------|
| `core/agent/loop/_reflection.py` | NEW `_REFLECTION_TOOL` + `REFLECTION_TOOL_NAME` export. `reflect_async` passes `tools=[_REFLECTION_TOOL]` + forced `tool_choice`. NEW `_extract_reflection_input(response)` — finds named ToolUseBlock. DELETED `_parse_reflection`, `_extract_first_json_object`, `json` import. `_SYSTEM_PROMPT` rewritten. `_apply_reflection` bool-exclusion guard on confidence (PR-5 mirror). |
| `tests/test_reflection_node.py` | 7 parser-fallback tests dropped, 7 new tests added (tool schema pin + extract_input cases + wire-up + bool-exclude). Net: 28 tests, 28 pass. |
| `CHANGELOG.md` | `[Unreleased] Changed` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `record_reflection` tool declared with input_schema | Implemented | hypotheses[<=5] / confidence ∈ [0,1] / next_action_hint |
| Forced tool_choice | Implemented | `{"type": "tool", "name": "record_reflection"}` |
| Parser/fallback removal | Implemented | `_parse_reflection` + `_extract_first_json_object` deleted, json import removed |
| Bool-exclusion guard on confidence | Implemented | Mirrors PR-5's mutator schema-typed cast fix |
| Non-Anthropic provider schema enforcement | Partial | Anthropic enforces server-side; GLM/OpenAI/Codex rely on `_apply_reflection` guards. Documented in docstring. |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_reflection_node.py -q` — 28/28 pass

## Reference

- Frontier matrix (Task #36, 2026-05-21): Hermes / Claude Code / OpenClaw all use `tool_use` native for internal calls; GEODE's free-form JSON was outlier
- DONT table: "graceful contract violation" + "reader-assumption drift" (parser vs LLM)