### PR TITLE
feat(cognitive-loop): PR-C — reflection cost gate (cognitive_reflection_interval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,28 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-C — ``cognitive_reflection_interval`` every-N-rounds gate.** PR-3
+  fires one extra LLM call per tool-use round (default Haiku 4.5), so
+  30-round sessions paid 30 extra calls. PR-C adds the
+  ``cognitive_reflection_interval`` settings field (default ``1`` =
+  every round, zero regression). When set to ``N > 1`` the reflection
+  node runs on rounds 1, 1+N, 1+2N, ... — the first round always
+  reflects so the loop sees an LLM-derived belief snapshot before any
+  throttling, and subsequent calls are thinned to every Nth round.
+  Operators flip via ``GEODE_COGNITIVE_REFLECTION_INTERVAL`` env var
+  or ``[cognitive] reflection_interval = N`` in ``config.toml``
+  (mapped in ``_TOML_TO_SETTINGS``). Pydantic ``ge=1`` validator
+  rejects ``0`` / negatives so the interval knob can't accidentally
+  disable reflection (operators should use the explicit
+  ``cognitive_reflection_enabled`` toggle instead).
+  ``_maybe_reflect`` clamps to 1 as defence-in-depth in case a
+  downstream bypasses the validator via ``object.__setattr__``.
+  10 invariant tests pin the field / TOML map / validator + 5
+  behavioural scenarios (interval=1/3/5/30, disabled-toggle
+  short-circuit).
+
 ### Changed
 
 - **PR-B — reflection node uses ``tool_use`` structured output.** Pre-

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -359,10 +359,34 @@ class AgenticLoop:
         the next round (no restart needed). Errors are swallowed inside
         ``reflect_async`` — the loop must stay robust to a flaky
         reflection model.
+
+        PR-C (2026-05-21) — every-N rounds gate. The 1 LLM call per
+        tool-use round was the dominant overhead for long-running
+        sessions (30 rounds ⇒ 30 extra Haiku calls). Operators can
+        set ``cognitive_reflection_interval=N`` (1 = current
+        behaviour) to thin the reflection cadence. The first round
+        always runs so the loop sees an LLM-derived belief snapshot
+        before any throttling kicks in.
         """
         from core.config import settings
 
         if not settings.cognitive_reflection_enabled:
+            return
+        interval = max(1, int(settings.cognitive_reflection_interval))
+        # ``record_round`` ran immediately before ``_maybe_reflect`` in
+        # ``_run_cognitive_act_observe_cycle`` so ``round_count`` is
+        # already the *current* round's number (1-based: 1, 2, 3...).
+        # ``(round_count - 1) % interval == 0`` runs on rounds
+        # 1, 1+N, 1+2N, ... — first round always reflects, then every
+        # Nth thereafter.
+        round_count = self.cognitive_state.round_count
+        if interval > 1 and (round_count - 1) % interval != 0:
+            log.debug(
+                "reflection skipped: round=%d interval=%d (next at round %d)",
+                round_count,
+                interval,
+                round_count + (interval - (round_count - 1) % interval),
+            )
             return
         from core.agent.loop._reflection import reflect_async
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -57,6 +57,7 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "cognitive.reflection_enabled": "cognitive_reflection_enabled",
     "cognitive.reflection_model": "cognitive_reflection_model",
     "cognitive.reflection_max_tokens": "cognitive_reflection_max_tokens",
+    "cognitive.reflection_interval": "cognitive_reflection_interval",
     "output.verbose": "verbose",
     "pipeline.confidence_threshold": "confidence_threshold",
     "pipeline.max_iterations": "max_iterations",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -95,6 +95,23 @@ class Settings(BaseSettings):
             "cost. PR-3 C-2."
         ),
     )
+    cognitive_reflection_interval: int = Field(
+        default=1,
+        ge=1,
+        validation_alias=AliasChoices(
+            "cognitive_reflection_interval",
+            "GEODE_COGNITIVE_REFLECTION_INTERVAL",
+        ),
+        description=(
+            "Reflection fires every Nth tool-use round. ``1`` (default) "
+            "= every round (current PR-3 behaviour, zero regression). "
+            "``3`` = round 1, 4, 7, 10... (skip 2 rounds between calls). "
+            "Higher values cut the extra-LLM-call overhead at the cost "
+            "of staler hypotheses + confidence. The first round always "
+            "runs so the loop sees an LLM-derived belief snapshot "
+            "before any throttling kicks in. PR-C (2026-05-21)."
+        ),
+    )
     verbose: bool = False
     checkpoint_db: str = "geode_checkpoints.db"
 

--- a/tests/test_reflection_cost_gate.py
+++ b/tests/test_reflection_cost_gate.py
@@ -1,0 +1,204 @@
+"""PR-C — reflection cost gate (``cognitive_reflection_interval``).
+
+PR-3 fires 1 LLM call per tool-use round; 30-round sessions paid
+30 extra Haiku calls. PR-C adds the ``cognitive_reflection_interval``
+setting (default 1 = current behaviour, no regression). When set
+to N > 1 the reflection node runs on rounds 1, 1+N, 1+2N, ... so
+the first round always sees an LLM-derived belief snapshot and
+subsequent calls are thinned to every Nth round.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import pytest
+from core.agent.cognitive_state import CognitiveState
+
+# ---------------------------------------------------------------------------
+# Settings field + TOML map
+# ---------------------------------------------------------------------------
+
+
+def test_settings_carries_cognitive_reflection_interval() -> None:
+    from core.config._settings import Settings
+
+    fields = Settings.model_fields
+    assert "cognitive_reflection_interval" in fields
+    assert fields["cognitive_reflection_interval"].default == 1
+
+
+def test_toml_map_carries_reflection_interval_key() -> None:
+    from core.config import _TOML_TO_SETTINGS
+
+    assert _TOML_TO_SETTINGS["cognitive.reflection_interval"] == "cognitive_reflection_interval"
+
+
+def test_settings_rejects_interval_below_one() -> None:
+    """The ``ge=1`` validator must reject ``0`` / negatives so an
+    operator can't accidentally disable reflection via the interval
+    knob (they should use ``cognitive_reflection_enabled=False``
+    explicitly)."""
+    from core.config._settings import Settings
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Settings(cognitive_reflection_interval=0)
+
+
+# ---------------------------------------------------------------------------
+# _maybe_reflect gate behaviour
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Captures whether reflect_async was invoked + which round."""
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []  # round_count at each call
+
+    async def fake_reflect_async(
+        self,
+        state: CognitiveState,
+        _tool_results: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+    ) -> None:
+        self.calls.append(state.round_count)
+
+
+@pytest.fixture
+def _stub_reflect_async(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Patch reflect_async in the lazy-imported namespace so
+    _maybe_reflect doesn't touch the real LLM path."""
+    recorder = _Recorder()
+    from core.agent.loop import _reflection
+
+    monkeypatch.setattr(_reflection, "reflect_async", recorder.fake_reflect_async)
+    return recorder
+
+
+def _maybe_reflect_runner(
+    state: CognitiveState,
+    monkeypatch: pytest.MonkeyPatch,
+    recorder: _Recorder,
+    *,
+    interval: int,
+) -> None:
+    """Synchronous helper — stamps interval, runs _maybe_reflect."""
+    from core.config import settings
+
+    object.__setattr__(settings, "cognitive_reflection_interval", interval)
+
+    # Build a minimal stub for AgenticLoop._maybe_reflect — bypass
+    # __init__ (which wires the entire runtime). Bind the bound
+    # method via descriptor.__get__ so it sees a fake `self` with
+    # only the attributes the method touches.
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    class _StubSelf:
+        cognitive_state = state
+
+    bound = AgenticLoop._maybe_reflect.__get__(_StubSelf(), _StubSelf)
+    asyncio.run(bound([]))
+
+
+def test_interval_one_runs_every_round(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """Default ``interval=1`` matches PR-3 behaviour — every round
+    triggers reflection."""
+    state = CognitiveState()
+    for r in range(1, 6):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=1)
+    assert _stub_reflect_async.calls == [1, 2, 3, 4, 5]
+
+
+def test_interval_three_runs_rounds_one_four_seven(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """``interval=3`` — first round always runs, then every 3rd."""
+    state = CognitiveState()
+    for r in range(1, 11):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=3)
+    # rounds 1, 4, 7, 10 reflect; 2, 3, 5, 6, 8, 9 skipped
+    assert _stub_reflect_async.calls == [1, 4, 7, 10]
+
+
+def test_interval_five_runs_rounds_one_six_eleven(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    state = CognitiveState()
+    for r in range(1, 12):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=5)
+    assert _stub_reflect_async.calls == [1, 6, 11]
+
+
+def test_interval_30_session_only_runs_first(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """User-supplied scenario — 30-round session with interval=30
+    should fire ONCE on round 1, saving 29 LLM calls."""
+    state = CognitiveState()
+    for r in range(1, 31):
+        state.round_count = r
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=30)
+    assert _stub_reflect_async.calls == [1]
+
+
+def test_interval_treats_zero_or_negative_as_one(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """Defensive — even if some downstream sets the field to 0
+    (bypassing the pydantic validator via ``object.__setattr__``),
+    ``_maybe_reflect`` clamps to 1 so reflection still runs (no
+    silent disable)."""
+    state = CognitiveState()
+    state.round_count = 1
+    _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=0)
+    assert _stub_reflect_async.calls == [1]
+
+
+def test_disabled_toggle_short_circuits_before_interval_check(
+    monkeypatch: pytest.MonkeyPatch, _stub_reflect_async: _Recorder
+) -> None:
+    """If ``cognitive_reflection_enabled=False`` the interval gate is
+    irrelevant. The enabled toggle must win."""
+    from core.config import settings
+
+    state = CognitiveState()
+    state.round_count = 1
+    object.__setattr__(settings, "cognitive_reflection_enabled", False)
+    try:
+        _maybe_reflect_runner(state, monkeypatch, _stub_reflect_async, interval=1)
+        assert _stub_reflect_async.calls == []
+    finally:
+        object.__setattr__(settings, "cognitive_reflection_enabled", True)
+
+
+# ---------------------------------------------------------------------------
+# _maybe_reflect source pin — the gate must be IN the method body
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_reflect_reads_interval_setting() -> None:
+    """Pin that the gate is implemented in ``_maybe_reflect`` body —
+    a refactor that drops the modulo check would surface here, not
+    in production behaviour."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    src = inspect.getsource(AgenticLoop._maybe_reflect)
+    assert "cognitive_reflection_interval" in src
+    assert "round_count" in src
+    assert "interval" in src
+    # The "first round always runs" property is implemented via
+    # ``(round_count - 1) % interval == 0`` — pin the modulo form so
+    # a future refactor doesn't accidentally flip to ``round_count %
+    # interval`` (which would skip round 1).
+    assert "(round_count - 1) % interval" in src or "(round_count-1) % interval" in src


### PR DESCRIPTION
## Summary

- **`cognitive_reflection_interval` 설정 추가.** Default `1` = 매 라운드 (PR-3 동작 유지, regression 0). `N > 1` 시 라운드 1, 1+N, 1+2N, ... 에서만 reflection LLM 호출. 30-라운드 세션 + `interval=30` = LLM 호출 1번 (29× 절약).
- **Defence-in-depth**: pydantic `ge=1` validator + `_maybe_reflect`의 `max(1, int(...))` clamp — operator가 `object.__setattr__`로 validator 우회해도 reflection 실행됨 (silent disable 방지).
- **Modulo on `(round_count - 1)`** — operator intent "초기 belief snapshot은 항상 보고, 이후 throttle"에 맞춰 round 1이 항상 reflect함.

## Why

Frontier matrix (Task #36)의 concern #2 — Hermes / Claude Code / OpenClaw 셋 다 internal reflection 호출 부재. GEODE PR-3가 매 round 1 추가 LLM 호출을 묶었는데 사용자 비용 directly 직결. 사용자 retro에서 "belief-delta gate 또는 every-N rounds 옵션 자연스러움"이라 제안. PR-C는 every-N 옵션 (deterministic, no state needed). Belief-delta는 follow-up.

## Changes

| File | Change |
|------|--------|
| `core/config/_settings.py` | NEW `cognitive_reflection_interval: int = Field(default=1, ge=1)` |
| `core/config/__init__.py` | `_TOML_TO_SETTINGS["cognitive.reflection_interval"]` |
| `core/agent/loop/agent_loop.py` | `_maybe_reflect`: interval read + modulo gate + debug log on skip |
| `tests/test_reflection_cost_gate.py` | NEW — 10 tests |
| `CHANGELOG.md` | `[Unreleased] Added` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Settings field | Implemented | Default 1, `ge=1` validator |
| Env / TOML alias | Implemented | `GEODE_COGNITIVE_REFLECTION_INTERVAL` + `[cognitive] reflection_interval` |
| Gate in `_maybe_reflect` | Implemented | `(round_count - 1) % interval == 0` |
| Defence-in-depth clamp | Implemented | `max(1, int(...))` |
| Belief-delta gate | Deferred | follow-up — needs confidence-trajectory tracking |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_reflection_cost_gate.py -q` — 10/10 pass
- [x] PR-B reflection tests still green (29/29)

## Reference

- Frontier matrix (Task #36): Hermes/Claude Code/OpenClaw 모두 internal reflection LLM 부재 → GEODE PR-3 add는 research pattern; 비용 제어 필수
- User retro (2026-05-21): "매 round 1 LLM call 비용 ... → belief-delta gate 또는 every-N rounds 옵션이 자연스러움"