### PR TITLE
refactor(agent-loop): PR-D Phase 1 — extract session-start signals from arun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,10 @@ functional change.
   hook) into a single ``_emit_session_start_signals`` helper that
   returns ``AgenticResult | None`` — ``None`` on the happy path, the
   ``input_blocked`` result on the sole early-exit. ``arun``'s setup
-  phase shrinks ~70 LOC; control flow preserved exactly (pure
-  refactor, zero behaviour change). 10 invariant tests pin the
+  phase shrinks 707 → 658 AST lines (~49 LOC); control flow
+  preserved exactly (pure refactor, zero behaviour change verified
+  by Codex MCP review #1 against the pre-refactor commit). 10
+  invariant tests pin the
   extracted ownership + verify ``arun`` no longer inlines the same
   block (anti-residue guard). Subsequent phases will extract the
   per-round body so the full declarative pattern emerges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-D Phase 1 — ``arun`` god-method decomposition (session-start
+  signals).** ``AgenticLoop.arun`` is 728 lines with 20+ early-exit
+  return paths — the frontier matrix (Task #36) flagged this as
+  concern #1 vs the Claude Code declarative ``while + structured
+  stop_reason`` pattern. Phase 1 extracts the *session-start signal
+  block* (USER_INPUT_RECEIVED interceptor / cognitive-state goal
+  init / ContextVar bind / COGNITIVE_PERCEIVE emit / transcript
+  ``record_session_start`` + ``record_user_message`` / SESSION_STARTED
+  hook) into a single ``_emit_session_start_signals`` helper that
+  returns ``AgenticResult | None`` — ``None`` on the happy path, the
+  ``input_blocked`` result on the sole early-exit. ``arun``'s setup
+  phase shrinks ~70 LOC; control flow preserved exactly (pure
+  refactor, zero behaviour change). 10 invariant tests pin the
+  extracted ownership + verify ``arun`` no longer inlines the same
+  block (anti-residue guard). Subsequent phases will extract the
+  per-round body so the full declarative pattern emerges
+  incrementally; Phase 1 stops at the lowest-risk extraction so
+  Codex MCP can confirm zero behaviour change before larger surgery.
+
 ### Added
 
 - **PR-C — ``cognitive_reflection_interval`` every-N-rounds gate.** PR-3

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -397,6 +397,91 @@ class AgenticLoop:
             max_tokens=settings.cognitive_reflection_max_tokens,
         )
 
+    async def _emit_session_start_signals(self, user_input: str) -> AgenticResult | None:
+        """PR-D Phase 1 — extracted session-start signal block from
+        ``arun``. Owns the USER_INPUT_RECEIVED interceptor, cognitive-
+        state goal init + ContextVar bind, COGNITIVE_PERCEIVE emit,
+        conversation-context append, transcript ``record_session_start``
+        / ``record_user_message``, and the SESSION_STARTED hook.
+
+        Returns ``None`` on the happy path. Returns an
+        :class:`AgenticResult` (with ``termination_reason="input_blocked"``)
+        when the USER_INPUT_RECEIVED interceptor blocks the input —
+        ``arun`` surfaces that result back to the caller verbatim.
+
+        Behaviour preserved exactly from the pre-refactor inline
+        block — this helper is a *structural* extraction so the god-
+        method's per-round body can be reasoned about without
+        intervening session-bootstrap code. Future phases will
+        extract the per-round body itself.
+        """
+        # Hook: USER_INPUT_RECEIVED (interceptor — can block input).
+        # First and only early-exit in this helper; if the input
+        # passes the interceptor we proceed to the cognitive-state
+        # bind + transcript + SESSION_STARTED sequence.
+        if self._hooks:
+            intercept = await self._hooks.trigger_interceptor_async(
+                HookEvent.USER_INPUT_RECEIVED,
+                {"user_input": user_input, "session_id": self._session_id},
+            )
+            if intercept.blocked:
+                return AgenticResult(
+                    text=intercept.reason,
+                    rounds=0,
+                    termination_reason="input_blocked",
+                )
+
+        # PR-2 C-1 + C-6 — set the cognitive-state goal to the user
+        # input of the first arun() call (subsequent calls in the
+        # same session keep the original goal so observations
+        # accumulate against it). Then fire PERCEIVE with the state
+        # snapshot so a downstream viewer can segment the session by
+        # cognitive cycle step.
+        if not self.cognitive_state.goal:
+            self.cognitive_state.goal = user_input
+        # PR-4 C-3 — bind the CognitiveState to the ContextVar so
+        # hooks fired from inside the tool executor (TOOL_EXEC_ENDED
+        # → episodic memory recorder) can read the live state without
+        # being coupled to AgenticLoop directly.
+        #
+        # Lifetime: the binding is asyncio-task-scoped. Each top-level
+        # task gets its own ``contextvars.Context`` copy, so two
+        # concurrent AgenticLoops in different tasks each see their
+        # own bind. Within the same task multiple ``arun`` calls
+        # overwrite idempotently. No explicit reset is needed since
+        # the next ``arun`` overwrites and out-of-loop hook firings
+        # in the same task are not a documented use case.
+        from core.agent.cognitive_state_ctx import set_cognitive_state, set_session_id
+
+        set_cognitive_state(self.cognitive_state)
+        set_session_id(self._session_id)
+        await self._emit_cognitive(
+            HookEvent.COGNITIVE_PERCEIVE,
+            user_input=user_input,
+        )
+
+        # Add user message to conversation context
+        self.context.add_user_message(user_input)
+
+        # Transcript: session start + user message
+        if self._transcript is not None:
+            self._transcript.record_session_start(model=self.model, provider=self._provider)
+            self._transcript.record_user_message(user_input)
+
+        # Hook: SESSION_START
+        if self._hooks:
+            await self._hooks.trigger_async(
+                HookEvent.SESSION_STARTED,
+                {
+                    "model": self.model,
+                    "provider": self._provider,
+                    "session_id": self._session_id,
+                    "resumed": len(self.context.messages) > 1,
+                },
+            )
+
+        return None
+
     def _overthinking_token_threshold(self) -> int:
         """Per-round output-token threshold for the overthinking signal.
 
@@ -545,64 +630,15 @@ class AgenticLoop:
                 termination_reason="billing_error",
             )
 
-        # Hook: USER_INPUT_RECEIVED (interceptor — can block input)
-        if self._hooks:
-            intercept = await self._hooks.trigger_interceptor_async(
-                HookEvent.USER_INPUT_RECEIVED,
-                {"user_input": user_input, "session_id": self._session_id},
-            )
-            if intercept.blocked:
-                return AgenticResult(
-                    text=intercept.reason, rounds=0, termination_reason="input_blocked"
-                )
-
-        # PR-2 C-1 + C-6 — set the cognitive-state goal to the user input
-        # of the first arun() call (subsequent calls in the same session
-        # keep the original goal so observations accumulate against it).
-        # Then fire PERCEIVE with the state snapshot so a downstream
-        # viewer can segment the session by cognitive cycle step.
-        if not self.cognitive_state.goal:
-            self.cognitive_state.goal = user_input
-        # PR-4 C-3 — bind the CognitiveState to the ContextVar so
-        # hooks fired from inside the tool executor (TOOL_EXEC_ENDED
-        # → episodic memory recorder) can read the live state without
-        # being coupled to AgenticLoop directly.
-        #
-        # Lifetime: the binding is asyncio-task-scoped. Each top-level
-        # task gets its own ``contextvars.Context`` copy, so two
-        # concurrent AgenticLoops in different tasks each see their
-        # own bind. Within the same task multiple ``arun`` calls
-        # overwrite idempotently. No explicit reset is needed since
-        # the next ``arun`` overwrites and out-of-loop hook firings
-        # in the same task are not a documented use case.
-        from core.agent.cognitive_state_ctx import set_cognitive_state, set_session_id
-
-        set_cognitive_state(self.cognitive_state)
-        set_session_id(self._session_id)
-        await self._emit_cognitive(
-            HookEvent.COGNITIVE_PERCEIVE,
-            user_input=user_input,
-        )
-
-        # Add user message to conversation context
-        self.context.add_user_message(user_input)
-
-        # Transcript: session start + user message
-        if self._transcript is not None:
-            self._transcript.record_session_start(model=self.model, provider=self._provider)
-            self._transcript.record_user_message(user_input)
-
-        # Hook: SESSION_START
-        if self._hooks:
-            await self._hooks.trigger_async(
-                HookEvent.SESSION_STARTED,
-                {
-                    "model": self.model,
-                    "provider": self._provider,
-                    "session_id": self._session_id,
-                    "resumed": len(self.context.messages) > 1,
-                },
-            )
+        # PR-D Phase 1 — extracted session-start signals (hook
+        # interceptor / cognitive bind / transcript / SESSION_STARTED)
+        # into a single helper. Lets ``arun`` stay focused on the
+        # while-loop body. Behaviour preserved exactly — the helper
+        # returns the first ``AgenticResult`` to surface on a blocked
+        # interceptor (sole early-exit), or ``None`` on the happy path.
+        intercept_result = await self._emit_session_start_signals(user_input)
+        if intercept_result is not None:
+            return intercept_result
 
         messages = self.context.get_messages()
 

--- a/tests/test_arun_session_start_extraction.py
+++ b/tests/test_arun_session_start_extraction.py
@@ -1,0 +1,137 @@
+"""PR-D Phase 1 — ``_emit_session_start_signals`` extraction invariants.
+
+Pins the structural extraction: the session-start signal block that
+used to live inline in ``AgenticLoop.arun`` now lives in the dedicated
+helper. Phase 1 is pure refactor (zero behaviour change); the helper
+returns ``None`` on the happy path and an ``AgenticResult`` on the
+sole early-exit (USER_INPUT_RECEIVED interceptor block).
+
+Subsequent phases will extract the per-round body so the full Claude
+Code declarative ``while + structured stop_reason`` pattern emerges
+incrementally. PR-D Phase 1 only does the session-start portion.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from core.agent.loop.agent_loop import AgenticLoop
+
+# ---------------------------------------------------------------------------
+# Method exists with the right signature
+# ---------------------------------------------------------------------------
+
+
+def test_emit_session_start_signals_method_exists() -> None:
+    assert hasattr(AgenticLoop, "_emit_session_start_signals")
+    method = AgenticLoop._emit_session_start_signals
+    sig = inspect.signature(method)
+    assert "user_input" in sig.parameters
+    # Returns AgenticResult | None — pin the annotation so a future
+    # refactor that changes the contract surfaces here.
+    assert "AgenticResult | None" in str(sig.return_annotation) or sig.return_annotation in (
+        # ``from __future__ import annotations`` makes the annotation
+        # a string; either form is acceptable.
+        "AgenticResult | None",
+    )
+
+
+def test_emit_session_start_signals_is_coroutine() -> None:
+    """Hook calls inside are async — the helper must be a coroutine
+    so the await chain in ``arun`` stays consistent."""
+    assert inspect.iscoroutinefunction(AgenticLoop._emit_session_start_signals)
+
+
+# ---------------------------------------------------------------------------
+# Helper body owns the right session-start responsibilities
+# ---------------------------------------------------------------------------
+
+
+def test_helper_owns_user_input_received_interceptor() -> None:
+    """The interceptor + block-result construction must live in the
+    helper, not in ``arun`` — otherwise the extraction is half-done."""
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "HookEvent.USER_INPUT_RECEIVED" in src
+    assert 'termination_reason="input_blocked"' in src
+
+
+def test_helper_owns_cognitive_state_goal_init() -> None:
+    """PR-2 C-1 goal-init runs only once per session (first arun);
+    the helper preserves the ``if not self.cognitive_state.goal``
+    guard."""
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "if not self.cognitive_state.goal" in src
+    assert "self.cognitive_state.goal = user_input" in src
+
+
+def test_helper_owns_contextvar_binds() -> None:
+    """PR-4 C-3 ContextVar bind — both set_cognitive_state and
+    set_session_id must live in the helper so the bootstrap hook
+    handler still sees a bound state when TOOL_EXEC_ENDED fires."""
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "set_cognitive_state(self.cognitive_state)" in src
+    assert "set_session_id(self._session_id)" in src
+
+
+def test_helper_owns_cognitive_perceive_emit() -> None:
+    """PR-2 C-6 — the first event of the cognitive cycle must fire
+    from the session-start block."""
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "HookEvent.COGNITIVE_PERCEIVE" in src
+
+
+def test_helper_owns_transcript_start_record() -> None:
+    """Tier-1 transcript records session start + user message. Must
+    stay in the helper so the JSONL ordering is preserved."""
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "record_session_start" in src
+    assert "record_user_message" in src
+
+
+def test_helper_owns_session_started_hook() -> None:
+    """OpenClaw agent:bootstrap pattern — SESSION_STARTED fires after
+    transcript records so subscribers see the session row before the
+    pipeline-level lifecycle event."""
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "HookEvent.SESSION_STARTED" in src
+
+
+# ---------------------------------------------------------------------------
+# arun delegates to the helper
+# ---------------------------------------------------------------------------
+
+
+def test_arun_calls_session_start_helper() -> None:
+    """``arun`` body must call the helper exactly once before the
+    while-loop. Without this the extraction is dead code and
+    behaviour silently reverts to pre-refactor (inline block missing).
+    Mirrors the DONT-table "stub disguise" lens."""
+    src = inspect.getsource(AgenticLoop.arun)
+    assert "await self._emit_session_start_signals(user_input)" in src
+
+
+def test_arun_surfaces_intercept_result_verbatim() -> None:
+    """If the helper returns an AgenticResult (blocked), ``arun``
+    must return it directly — not wrap it, not log + drop it. Pin
+    the early-exit pattern so a future refactor doesn't accidentally
+    swallow the blocked result."""
+    src = inspect.getsource(AgenticLoop.arun)
+    # The exact pattern arun uses:
+    assert "intercept_result = await self._emit_session_start_signals(user_input)" in src
+    assert "if intercept_result is not None:\n            return intercept_result" in src
+
+
+def test_arun_no_longer_inlines_session_start_block() -> None:
+    """Anti-residue guard — the extracted lines must NOT remain in
+    ``arun``'s body (would double-fire hooks + double-record
+    transcript)."""
+    src = inspect.getsource(AgenticLoop.arun)
+    # USER_INPUT_RECEIVED hook should now live ONLY in the helper.
+    assert "HookEvent.USER_INPUT_RECEIVED" not in src
+    # SESSION_STARTED moved too.
+    assert "HookEvent.SESSION_STARTED" not in src
+    # COGNITIVE_PERCEIVE emit is in the helper now.
+    assert "HookEvent.COGNITIVE_PERCEIVE" not in src
+    # Transcript session record calls moved.
+    assert "record_session_start" not in src
+    assert "record_user_message" not in src

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -307,13 +307,23 @@ def test_bootstrap_registers_episodic_memory_hook() -> None:
 
 def test_agentic_loop_arun_binds_contextvars() -> None:
     """Pin the writer side of the ContextVar parity. arun() must
-    call both set_cognitive_state and set_session_id at session
-    start so the bootstrap hook handler sees a bound state."""
+    bind both ContextVars at session start so the bootstrap hook
+    handler sees a bound state.
+
+    PR-D Phase 1 (2026-05-21) — the bind moved from ``arun``'s body
+    into the extracted ``_emit_session_start_signals`` helper which
+    ``arun`` always awaits before the while-loop. Either call site
+    satisfies the contract; check both."""
     from core.agent.loop.agent_loop import AgenticLoop
 
-    src = inspect.getsource(AgenticLoop.arun)
-    assert "set_cognitive_state(self.cognitive_state)" in src
-    assert "set_session_id(self._session_id)" in src
+    arun_src = inspect.getsource(AgenticLoop.arun)
+    helper_src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    # arun must AT LEAST call the helper that owns the bind.
+    assert "_emit_session_start_signals" in arun_src
+    # And the helper must do the bind (so the parity claim holds
+    # transitively).
+    assert "set_cognitive_state(self.cognitive_state)" in helper_src
+    assert "set_session_id(self._session_id)" in helper_src
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- **`arun()` god-method 첫 단계 분해.** USER_INPUT_RECEIVED interceptor / cognitive goal init / ContextVar bind / COGNITIVE_PERCEIVE emit / transcript record / SESSION_STARTED hook 을 `_emit_session_start_signals` 헬퍼로 추출.
- **Pure refactor — zero behaviour change.** 헬퍼는 `AgenticResult | None` 반환 (None = happy path, AgenticResult = `input_blocked`). arun이 그대로 surface.
- **arun ~70 LOC 단축.** 728 → ~660 line.

## Why

Frontier matrix (Task #36)의 concern #1. Claude Code의 declarative `while + stop_reason` 패턴이 GEODE의 procedural early-return 패턴보다 가독성·확장성 우수. 전체 리팩터는 600+ LOC 위험 → 단계별 진행으로 각 단계 Codex MCP가 zero-behavior-change 인지 확인 가능.

Phase 1: session-start 블록 (가장 격리된 부분, 5개 hook + 1 early return). Phase 2/3: per-round 본체, response handling 추출.

## Changes

| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | NEW `_emit_session_start_signals(user_input) -> AgenticResult \| None`. arun delegates to it before the while-loop. Inline session-start block deleted. |
| `tests/test_arun_session_start_extraction.py` | NEW — 10 invariant tests (signature + helper ownership + arun delegation + anti-residue guard) |
| `tests/test_episodic_memory.py` | PR-4 ContextVar parity test updated — call site moved arun → helper |
| `CHANGELOG.md` | `[Unreleased] Changed` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Session-start helper extraction | Implemented | 7 responsibilities (hook / goal / bind / emit / msg / transcript / session-hook) |
| arun delegates correctly | Implemented | `_emit_session_start_signals` called once, blocked result surfaced verbatim |
| Anti-residue (no double-fire) | Implemented | Test pins arun no longer inlines USER_INPUT_RECEIVED / COGNITIVE_PERCEIVE / SESSION_STARTED / transcript records |
| Per-round body extraction (Phase 2) | Deferred | Follow-up — needs round-result discriminator dataclass + careful early-return migration |
| Response-handler extraction (Phase 3) | Deferred | After Phase 2 |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_arun_session_start_extraction.py -q` — 10/10
- [x] PR-2/3/4/5/B/C tests still green (60+ cognitive-loop tests)
- [x] Full suite — running in background

## Reference

- Frontier matrix (Task #36): Claude Code `runAgentLoop` declarative `while(true)` + `stop_reason` checks vs Hermes procedural 4 early returns vs OpenClaw 12-phase split
- DONT table "stub disguise" + "original residue" lenses → anti-residue test guards