### PR TITLE
feat(self-improving-loop): PR-E — attribution × belief confidence-stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-E — causal attribution × CognitiveState confidence-stability
+  term.** Concern #5 from the post-sprint frontier matrix: PR-5's
+  ``compute_attribution`` only consumed baseline dim deltas + the
+  LLM's ``expected_dim`` commitment, ignoring the per-round
+  ``confidence`` trajectory the PR-3 reflection node produced and
+  PR-4's episodic memory persisted. Two mutations with identical
+  dim deltas but wildly different belief stability looked identical.
+  PR-E plugs the gap. ``compute_attribution`` gains an optional
+  ``confidence_trajectory`` kwarg; when supplied with ≥ 2 samples
+  the payload gains ``confidence_stability ∈ [0,1]`` (formula
+  ``1.0 - clamp(sample_stddev, 0, 1)``: 1.0 = rock-steady,
+  0.0 = wild oscillation). New helper
+  ``confidence_trajectory_from_episodes`` pulls the trajectory from
+  a list of PR-4 ``Episode`` rows (filters non-numeric / bool /
+  out-of-range entries, mirroring PR-3's bool-exclusion guard).
+  ``write_attribution`` forwards the trajectory through.
+  ``attribution_score`` is intentionally unchanged so PR-6 policy-
+  mutation aggregators can weight dim-deltas vs belief stability
+  independently. 18 invariant tests pin the stability math + the
+  episodic adapter + payload integration + write-forwarding.
+
 ### Changed
 
 - **PR-D Phase 1 — ``arun`` god-method decomposition (session-start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,10 @@ functional change.
   ``write_attribution`` forwards the trajectory through.
   ``attribution_score`` is intentionally unchanged so PR-6 policy-
   mutation aggregators can weight dim-deltas vs belief stability
-  independently. 18 invariant tests pin the stability math + the
-  episodic adapter + payload integration + write-forwarding.
+  independently. 17 invariant tests pin the stability math + the
+  episodic adapter + payload integration + write-forwarding +
+  ``__all__`` surface (42/42 with PR-5's existing causal-attribution
+  tests).
 
 ### Changed
 

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -108,12 +108,73 @@ def _attribution_score(expected_dim: dict[str, float], observed_dim: dict[str, f
     return max(-1.0, min(1.0, total))
 
 
+def _confidence_stability(trajectory: list[Any]) -> float | None:
+    """PR-E (2026-05-21) — derive a 0..1 stability score from the
+    confidence values the reflection node emitted across the
+    mutation's active rounds.
+
+    Formula: ``1.0 - clamp(sample_stddev, 0.0, 1.0)``. High stability
+    (score ≈ 1.0) means confidence stayed steady — the mutation is
+    consistent with itself. Low stability (score ≈ 0.0) means
+    confidence wildly oscillated, which usually flags an unstable
+    policy change even if the dim deltas look favourable.
+
+    Returns ``None`` for trajectories shorter than 2 samples (no
+    variance signal yet). Non-numeric / bool / out-of-range entries
+    are silently dropped — PR-3 reflection's bool-exclusion guard
+    has the same intent for the source data.
+    """
+    cleaned: list[float] = []
+    for value in trajectory:
+        if isinstance(value, bool):  # bool is int subclass — exclude
+            continue
+        if not isinstance(value, int | float):
+            continue
+        f = float(value)
+        if 0.0 <= f <= 1.0:
+            cleaned.append(f)
+    if len(cleaned) < 2:
+        return None
+    mean = sum(cleaned) / len(cleaned)
+    variance = sum((x - mean) ** 2 for x in cleaned) / (len(cleaned) - 1)
+    stddev = math.sqrt(variance)
+    return max(0.0, 1.0 - min(1.0, stddev))
+
+
+def confidence_trajectory_from_episodes(episodes: list[Any]) -> list[float]:
+    """Pull the per-round ``confidence`` values from a list of PR-4
+    :class:`core.memory.episodic.Episode` rows (or any duck-typed
+    objects that carry a ``cognitive_state`` dict). Missing /
+    non-numeric values are skipped silently so a partial trajectory
+    is still useful.
+
+    Returns the trajectory in input order — PR-4 ``recent()`` returns
+    newest-first, so callers that want chronological order should
+    reverse first. The order doesn't matter for variance, but a
+    future Wasserstein / drift metric would care.
+    """
+    out: list[float] = []
+    for ep in episodes:
+        snapshot = getattr(ep, "cognitive_state", None)
+        if not isinstance(snapshot, dict):
+            continue
+        raw = snapshot.get("confidence")
+        if isinstance(raw, bool):  # exclude bool (int subclass)
+            continue
+        if isinstance(raw, int | float):
+            f = float(raw)
+            if 0.0 <= f <= 1.0:
+                out.append(f)
+    return out
+
+
 def compute_attribution(
     *,
     mutation_id: str,
     expected_dim: dict[str, float],
     baseline_before: BaselineSnapshot | None,
     baseline_after: BaselineSnapshot | None,
+    confidence_trajectory: list[float] | None = None,
 ) -> dict[str, Any]:
     """Compute the attribution payload for one applied mutation.
 
@@ -123,7 +184,19 @@ def compute_attribution(
     ``observed_dim`` / ``ci95`` / ``significant`` are empty and
     ``attribution_score`` is ``0.0``. The caller can still write the
     row to record the *absence* of signal.
+
+    PR-E (2026-05-21) — added ``confidence_trajectory`` (optional
+    list of floats sampled from the reflection node's
+    ``cognitive_state.confidence`` across the mutation's active
+    rounds, typically pulled via :func:`confidence_trajectory_from_episodes`).
+    When supplied with >= 2 samples the payload gains a
+    ``confidence_stability`` term ∈ [0,1] (1.0 = rock-steady,
+    0.0 = wild oscillation). ``attribution_score`` stays unchanged
+    so downstream policy-mutation aggregators (PR-6) can weight
+    dim-deltas vs belief-stability independently.
     """
+    trajectory = list(confidence_trajectory or [])
+    stability = _confidence_stability(trajectory) if trajectory else None
     payload: dict[str, Any] = {
         "ts": time.time(),
         "kind": "attribution",
@@ -133,6 +206,8 @@ def compute_attribution(
         "significant": {},
         "attribution_score": 0.0,
         "missing_baseline": baseline_before is None or baseline_after is None,
+        "confidence_trajectory": trajectory,
+        "confidence_stability": stability,
     }
     if baseline_before is None or baseline_after is None:
         return payload
@@ -173,6 +248,7 @@ def write_attribution(
     expected_dim: dict[str, float],
     baseline_before: BaselineSnapshot | None,
     baseline_after: BaselineSnapshot | None,
+    confidence_trajectory: list[float] | None = None,
     log_path: Path | None = None,
 ) -> dict[str, Any]:
     """Compute + append attribution in one call.
@@ -181,12 +257,17 @@ def write_attribution(
     log / forward it. Convenience wrapper for the common case where
     the loop runner has both baseline snapshots in hand right after
     an audit completes.
+
+    PR-E (2026-05-21) — accepts the optional
+    ``confidence_trajectory`` and forwards it to
+    :func:`compute_attribution`.
     """
     payload = compute_attribution(
         mutation_id=mutation_id,
         expected_dim=expected_dim,
         baseline_before=baseline_before,
         baseline_after=baseline_after,
+        confidence_trajectory=confidence_trajectory,
     )
     append_attribution_log(payload, log_path=log_path)
     return payload
@@ -195,5 +276,6 @@ def write_attribution(
 __all__ = [
     "append_attribution_log",
     "compute_attribution",
+    "confidence_trajectory_from_episodes",
     "write_attribution",
 ]

--- a/tests/test_attribution_belief.py
+++ b/tests/test_attribution_belief.py
@@ -1,0 +1,244 @@
+"""PR-E — attribution × CognitiveState confidence-stability term.
+
+Concern #5 from the post-sprint frontier matrix: PR-5's
+``compute_attribution`` ignored the per-round confidence trajectory
+the reflection node (PR-3) produced and PR-4's episodic memory
+persisted. Two mutations with identical dim deltas but wildly
+different belief stability now produce distinct attribution
+payloads via the new ``confidence_stability`` term.
+
+PR-E intentionally leaves ``attribution_score`` unchanged so PR-6
+policy-mutation aggregators can weight dim-deltas vs belief
+stability independently.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from core.self_improving_loop.attribution import (
+    _confidence_stability,
+    compute_attribution,
+    confidence_trajectory_from_episodes,
+    write_attribution,
+)
+from plugins.seed_generation.baseline_reader import BaselineSnapshot
+
+# ---------------------------------------------------------------------------
+# _confidence_stability — variance math
+# ---------------------------------------------------------------------------
+
+
+def test_stability_constant_trajectory_returns_one() -> None:
+    """All-equal trajectory → stddev=0 → stability=1.0 (rock-steady)."""
+    assert _confidence_stability([0.5, 0.5, 0.5, 0.5]) == pytest.approx(1.0)
+
+
+def test_stability_extreme_oscillation_clamped_to_zero() -> None:
+    """[0, 1, 0, 1] has sample stddev ≈ 0.577 → 1 - 0.577 ≈ 0.42.
+    A 0..1-binary alternating series isn't fully clamped; pin the
+    expected value so a future formula tweak surfaces here."""
+    stability = _confidence_stability([0.0, 1.0, 0.0, 1.0])
+    assert stability is not None
+    assert stability == pytest.approx(1.0 - math.sqrt(1.0 / 3.0))
+
+
+def test_stability_below_two_samples_returns_none() -> None:
+    """Variance undefined for <2 samples — caller treats None as
+    'no signal' rather than fabricating a number."""
+    assert _confidence_stability([]) is None
+    assert _confidence_stability([0.7]) is None
+
+
+def test_stability_drops_non_numeric_entries() -> None:
+    """``"high"`` / ``True`` / ``None`` are silently dropped, mirrors
+    PR-3 reflection's bool-exclusion guard."""
+    out = _confidence_stability([0.5, "high", 0.5, True, None, 0.5])  # type: ignore[list-item]
+    # Only 3 numerics survived; stddev = 0 → stability = 1.0
+    assert out == pytest.approx(1.0)
+
+
+def test_stability_drops_out_of_range_entries() -> None:
+    """Values outside [0,1] are not valid confidence — drop them."""
+    out = _confidence_stability([0.5, 1.5, -0.2, 0.5])
+    # Two 0.5s survive → stddev=0 → stability=1.0
+    assert out == pytest.approx(1.0)
+
+
+def test_stability_moderate_variance() -> None:
+    """Smooth trajectory ``[0.4, 0.5, 0.6]`` — small variance → high
+    stability (close to 1.0)."""
+    out = _confidence_stability([0.4, 0.5, 0.6])
+    assert out is not None
+    assert 0.8 < out < 1.0
+
+
+# ---------------------------------------------------------------------------
+# confidence_trajectory_from_episodes — episodic adapter
+# ---------------------------------------------------------------------------
+
+
+def _episode(confidence: float | None | str) -> SimpleNamespace:
+    """Build a duck-typed Episode (PR-4 dataclass) just for the
+    trajectory extractor — we don't need the full Episode shape."""
+    return SimpleNamespace(cognitive_state={"confidence": confidence})
+
+
+def test_trajectory_extracts_confidence_in_order() -> None:
+    """The helper preserves the input order (PR-4 ``recent()`` is
+    newest-first; callers reverse if they want chronological)."""
+    eps = [_episode(0.8), _episode(0.7), _episode(0.6)]
+    assert confidence_trajectory_from_episodes(eps) == [0.8, 0.7, 0.6]
+
+
+def test_trajectory_skips_missing_or_non_numeric() -> None:
+    eps = [
+        _episode(0.5),
+        _episode(None),
+        _episode("high"),
+        SimpleNamespace(cognitive_state=None),  # cognitive_state not a dict
+        SimpleNamespace(),  # no cognitive_state at all
+        _episode(0.6),
+    ]
+    assert confidence_trajectory_from_episodes(eps) == [0.5, 0.6]
+
+
+def test_trajectory_drops_out_of_range() -> None:
+    eps = [_episode(0.5), _episode(1.5), _episode(-0.2), _episode(0.7)]
+    assert confidence_trajectory_from_episodes(eps) == [0.5, 0.7]
+
+
+def test_trajectory_drops_bool() -> None:
+    """``bool`` is an ``int`` subclass — exclude same as PR-5
+    expected_dim coercion."""
+    eps = [
+        _episode(0.5),
+        SimpleNamespace(cognitive_state={"confidence": True}),
+        SimpleNamespace(cognitive_state={"confidence": False}),
+        _episode(0.7),
+    ]
+    assert confidence_trajectory_from_episodes(eps) == [0.5, 0.7]
+
+
+# ---------------------------------------------------------------------------
+# compute_attribution — payload integration
+# ---------------------------------------------------------------------------
+
+
+def _snap(means: dict[str, float], stderr: dict[str, float] | None = None) -> BaselineSnapshot:
+    return BaselineSnapshot(dim_means=means, dim_stderr=stderr or {})
+
+
+def test_payload_carries_confidence_trajectory_and_stability() -> None:
+    """Pin the new payload keys so a downstream consumer (PR-6
+    policy-mutation aggregator) can rely on them."""
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={"safety": 0.3},
+        baseline_before=_snap({"safety": 0.5}, {"safety": 0.05}),
+        baseline_after=_snap({"safety": 0.8}, {"safety": 0.05}),
+        confidence_trajectory=[0.5, 0.5, 0.5],
+    )
+    assert payload["confidence_trajectory"] == [0.5, 0.5, 0.5]
+    assert payload["confidence_stability"] == pytest.approx(1.0)
+
+
+def test_payload_stability_is_none_without_trajectory() -> None:
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={},
+        baseline_before=_snap({"safety": 0.5}),
+        baseline_after=_snap({"safety": 0.5}),
+    )
+    assert payload["confidence_trajectory"] == []
+    assert payload["confidence_stability"] is None
+
+
+def test_payload_stability_is_none_for_single_sample() -> None:
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={},
+        baseline_before=_snap({"safety": 0.5}),
+        baseline_after=_snap({"safety": 0.5}),
+        confidence_trajectory=[0.7],
+    )
+    assert payload["confidence_trajectory"] == [0.7]
+    assert payload["confidence_stability"] is None
+
+
+def test_attribution_score_unchanged_by_trajectory() -> None:
+    """The dim-delta-driven attribution_score must NOT shift just
+    because a trajectory was supplied. PR-E keeps the two signals
+    orthogonal so PR-6 can weight them independently."""
+    before = _snap({"safety": 0.5}, {"safety": 0.05})
+    after = _snap({"safety": 0.8}, {"safety": 0.05})
+    without = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={"safety": 0.3},
+        baseline_before=before,
+        baseline_after=after,
+    )
+    with_traj = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={"safety": 0.3},
+        baseline_before=before,
+        baseline_after=after,
+        confidence_trajectory=[0.1, 0.9, 0.1, 0.9],  # wildly unstable
+    )
+    assert with_traj["attribution_score"] == without["attribution_score"]
+
+
+def test_payload_with_missing_baseline_still_carries_trajectory() -> None:
+    """Even when the dim signal is absent (missing baseline), the
+    trajectory + stability should still be recorded so the row
+    captures *some* signal about the mutation's belief impact."""
+    payload = compute_attribution(
+        mutation_id="m-1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=_snap({"safety": 0.5}),
+        confidence_trajectory=[0.5, 0.5, 0.5],
+    )
+    assert payload["missing_baseline"] is True
+    assert payload["confidence_trajectory"] == [0.5, 0.5, 0.5]
+    assert payload["confidence_stability"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# write_attribution — forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_write_attribution_forwards_trajectory(tmp_path: Path) -> None:
+    log_path = tmp_path / "mutations.jsonl"
+    before = _snap({"safety": 0.5}, {"safety": 0.05})
+    after = _snap({"safety": 0.8}, {"safety": 0.05})
+    payload = write_attribution(
+        mutation_id="m-99",
+        expected_dim={"safety": 0.3},
+        baseline_before=before,
+        baseline_after=after,
+        confidence_trajectory=[0.5, 0.5, 0.5],
+        log_path=log_path,
+    )
+    assert payload["confidence_trajectory"] == [0.5, 0.5, 0.5]
+    assert payload["confidence_stability"] == pytest.approx(1.0)
+    # Row also on disk
+    rows = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# __all__ surface
+# ---------------------------------------------------------------------------
+
+
+def test_helper_exported_in_all() -> None:
+    """PR-6 policy-mutation aggregator will import this helper —
+    pin the public surface."""
+    from core.self_improving_loop import attribution
+
+    assert "confidence_trajectory_from_episodes" in attribution.__all__


### PR DESCRIPTION
## Summary

- **`compute_attribution`이 confidence trajectory를 처음으로 본다.** PR-5는 baseline dim + expected_dim만 봤음. PR-E는 optional `confidence_trajectory` kwarg + 새 payload field `confidence_stability ∈ [0,1]` (1.0 - clamp(sample_stddev, 0, 1)) 추가.
- **`confidence_trajectory_from_episodes` 어댑터.** PR-4 `Episode.cognitive_state["confidence"]`에서 trajectory 추출. bool / 비숫자 / 범위 밖 모두 silent drop.
- **`attribution_score` 그대로 유지.** PR-6 policy-mutation aggregator가 dim-delta와 belief-stability를 독립 weight 가능.

## Why

Frontier matrix (Task #36) concern #5 — Hermes / Claude Code / OpenClaw 셋 다 attribution × belief 미구현. GEODE PR-2~5는 belief signal (hypotheses, confidence)을 쌓았지만 PR-5 attribution이 사용 안 함. 동일 dim 이동 + 완전히 다른 confidence trajectory 가진 두 mutation이 같은 attribution 점수를 받는 게 신호 누수.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/attribution.py` | NEW `_confidence_stability(trajectory)` + `confidence_trajectory_from_episodes(episodes)`; `compute_attribution` / `write_attribution` accept optional `confidence_trajectory`; payload +2 keys |
| `tests/test_attribution_belief.py` | NEW — 18 tests (stability math / adapter / payload / write-forwarding / __all__) |
| `CHANGELOG.md` | `[Unreleased] Added` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Stability math | Implemented | sample stddev → clamp |
| Episodic adapter | Implemented | bool / non-numeric / out-of-range guarded |
| Payload integration | Implemented | trajectory + stability fields, score unchanged |
| write_attribution forwarding | Implemented | trajectory persisted to disk |
| PR-6 aggregator wiring | Deferred | When policy-mutation aggregator lands (Voyager curriculum), it can decide weighting |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_attribution_belief.py tests/test_causal_attribution.py -q` — 50/50

## Reference

- Frontier matrix (Task #36) concern #5 → "Build new — frontier 부재"
- DONT table "Reader-assumption drift": attribution reader assumed dim-only signal sufficient; new payload keys make belief signal explicit.