### PR TITLE
release: v0.99.25 — cognitive-loop-uplift Phase 2 sprint (PR-A → PR-F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.25] — 2026-05-21
+
+> **Cognitive Loop Uplift — Phase 2 sprint.** 6 PRs (#1380-#1385)
+> close the 5 concerns the post-v0.99.24 frontier matrix (Task #36)
+> identified against Hermes / Claude Code / OpenClaw:
+> **PR-A** (#1380) — `/model` role tab so operators can pick the
+> reflection-node model alongside the primary loop model.
+> **PR-B** (#1381) — reflection node migrated from free-form JSON to
+> Anthropic `tool_use` structured output (concern #4 — eliminates the
+> 5-stage forgiving parser Codex MCP caught 3× during PR-3 review).
+> **PR-C** (#1382) — `cognitive_reflection_interval` every-N-rounds
+> gate (concern #2 — 30-round session can drop 29 LLM calls).
+> **PR-D Phase 1** (#1383) — `arun` god-method decomposition starts;
+> session-start signal block extracted into a dedicated helper
+> (concern #1; zero behavior change, ~49 LOC shrink). Phase 2/3
+> follow-ups planned.
+> **PR-E** (#1384) — causal attribution × CognitiveState confidence-
+> stability term (concern #5 — joins dim-delta + belief-trajectory
+> signals; attribution_score intentionally unchanged so PR-6
+> aggregators can weight independently).
+> **PR-F** (#1385) — sub-agent `parent_session_key` lineage
+> (concern #3 — in-process spawn path wired; subprocess WorkerRequest
+> plumbing explicitly deferred per Codex MCP review).
+> Tests 5280 → 5346 (+66). Modules unchanged (314 + 48 = 362).
+
 ### Added
 
 - **PR-F — sub-agent state propagation via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.24
+- **Version**: 0.99.25
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 314 core + 48 plugins = 362
-- **Tests**: 5280 (+5 live)
+- **Tests**: 5346 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.24 — Long-running Autonomous Execution Harness
+# GEODE v0.99.25 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.24**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.25**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.24 — Long-running Autonomous Execution Harness
+# GEODE v0.99.25 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.24**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.25**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.24"
+version = "0.99.25"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Cut `[Unreleased]` → `[0.99.25] — 2026-05-21` covering 6 PRs that closed all 5 frontier-matrix concerns.
- Version sync across 6 locations: `pyproject.toml`, `CLAUDE.md`, `README.md` (×2), `README.ko.md` (×2).
- CLAUDE.md metrics updated: tests 5280 → 5346 (+66). Modules unchanged (314 + 48 = 362).

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run geode version` — prints `GEODE v0.99.25`
- [x] All 6 feature PRs already merged to main (`775244d8` → `5c6d1d4e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)