### PR TITLE
refactor(agent-loop): PR-D Phase 2a — extract round guards from arun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-D Phase 2a — ``_check_round_guards`` extraction from
+  ``arun``.** Continues the god-method decomposition started in
+  v0.99.24 (PR-D Phase 1 extracted session-start signals). Phase
+  2a takes the smallest, lowest-risk slice from the while-loop
+  body: the two round-entry guards (round limit + time budget /
+  Karpathy P3). Both moved into ``AgenticLoop._check_round_guards``
+  returning ``"round_limit" | "time_budget" | None`` — ``arun``
+  ``break``s the loop when the helper returns non-None, so the
+  loop's downstream wrap-up code (final ``AgenticResult``
+  construction + ``finalize_and_return``) runs identically to
+  pre-refactor. Round-limit precedence over time-budget preserved
+  exactly. 12 invariant tests pin the helper signature, both
+  guards firing at expected boundaries, precedence ordering, no
+  spurious trigger on defaults, ``arun`` delegation with
+  ``break``-not-``return`` semantics, anti-residue (inline
+  ``Guard 1`` / ``Guard 2`` blocks gone), and reason-string
+  spellings. Phase 2b/2c will continue chipping at model-drift
+  sync, LLM-call dispatch, and response handling so the full
+  Claude Code declarative ``while + structured stop_reason``
+  pattern emerges incrementally.
+
 ## [0.99.25] — 2026-05-21
 
 > **Cognitive Loop Uplift — Phase 2 sprint.** 6 PRs (#1380-#1385)

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -499,6 +499,39 @@ class AgenticLoop:
 
         return None
 
+    def _check_round_guards(self, round_idx: int) -> str | None:
+        """PR-D Phase 2a — round-entry guards extracted from ``arun``.
+
+        Returns ``None`` if both guards pass (proceed with the
+        round). Returns a short string identifying the triggered
+        guard otherwise — ``arun`` breaks the while-loop on a
+        non-None response, deferring the result-construction to the
+        loop's existing wrap-up code below (mirrors the pre-refactor
+        ``break`` semantics).
+
+        Guards (Karpathy P3):
+          * ``round_limit`` — ``max_rounds > 0`` enforces; ``0`` =
+            unlimited. Round indices are 0-based, so we break when
+            ``round_idx >= max_rounds``.
+          * ``time_budget`` — ``time_budget_s > 0`` enforces;
+            ``0.0`` = no time limit. Wall clock measured against
+            ``self._loop_start_time``.
+
+        Behaviour preserved exactly from the pre-refactor inline
+        ``Guard 1`` + ``Guard 2`` blocks — this helper is a
+        *structural* extraction. PR-D Phase 2b/2c will continue
+        chipping at the god-method.
+        """
+        import time as _time
+
+        if self.max_rounds > 0 and round_idx >= self.max_rounds:
+            return "round_limit"
+        if self._time_budget_s > 0:
+            elapsed = _time.monotonic() - self._loop_start_time
+            if elapsed >= self._time_budget_s:
+                return "time_budget"
+        return None
+
     def _overthinking_token_threshold(self) -> int:
         """Per-round output-token threshold for the overthinking signal.
 
@@ -678,14 +711,15 @@ class AgenticLoop:
         self._usage_snapshot = _get_tracker().snapshot()
         round_idx = 0
         while True:
-            # Guard 1: Round limit (max_rounds > 0 enforces; 0 = unlimited)
-            if self.max_rounds > 0 and round_idx >= self.max_rounds:
+            # PR-D Phase 2a — round-entry guards extracted to a helper
+            # so ``arun``'s while-loop body shrinks toward the Claude
+            # Code declarative shape. Returning ``None`` means "no
+            # guard triggered, proceed"; a non-None reason means
+            # "break the loop and finalize". Behaviour preserved
+            # exactly — both guards still ``break`` (not return) so
+            # the loop's downstream wrap-up paths run.
+            if self._check_round_guards(round_idx) is not None:
                 break
-            # Guard 2: Time budget (Karpathy P3)
-            if self._time_budget_s > 0:
-                elapsed = _time.monotonic() - self._loop_start_time
-                if elapsed >= self._time_budget_s:
-                    break
 
             is_last_round = (self.max_rounds > 0) and (round_idx == self.max_rounds - 1)
             self._op_logger.begin_round("AgenticLoop")

--- a/tests/test_arun_round_guards.py
+++ b/tests/test_arun_round_guards.py
@@ -1,0 +1,208 @@
+"""PR-D Phase 2a — ``_check_round_guards`` extraction invariants.
+
+Pins the structural extraction of the round-entry guards (round
+limit + time budget) from ``arun``'s while-loop into a dedicated
+helper. Phase 2a is pure refactor (zero behaviour change);
+``arun`` still breaks on a non-None return value, so the existing
+loop wrap-up code runs identically.
+
+Subsequent phases (2b model-drift sync, 2c LLM-call dispatch, etc.)
+will continue extracting the per-round body so the full Claude
+Code declarative pattern emerges. Phase 2a stops at the smallest,
+safest extraction so Codex MCP can confirm zero behavior change
+before further surgery.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+
+import pytest
+from core.agent.loop.agent_loop import AgenticLoop
+
+# ---------------------------------------------------------------------------
+# Method exists with the right signature
+# ---------------------------------------------------------------------------
+
+
+def test_check_round_guards_method_exists() -> None:
+    assert hasattr(AgenticLoop, "_check_round_guards")
+    method = AgenticLoop._check_round_guards
+    sig = inspect.signature(method)
+    assert "round_idx" in sig.parameters
+    # Returns str | None — non-None reason on break, None when
+    # the round should proceed.
+    assert "str | None" in str(sig.return_annotation) or sig.return_annotation == "str | None"
+
+
+def test_check_round_guards_is_sync() -> None:
+    """Guards are pure functions — no await needed. Async return
+    would force callers to redundantly await."""
+    assert not inspect.iscoroutinefunction(AgenticLoop._check_round_guards)
+
+
+# ---------------------------------------------------------------------------
+# Behaviour — exact pre-refactor semantics
+# ---------------------------------------------------------------------------
+
+
+class _StubLoop:
+    """Minimal AgenticLoop stub — only the fields ``_check_round_guards``
+    reads. Lets the test invoke the helper without constructing the
+    full runtime."""
+
+    def __init__(
+        self,
+        *,
+        max_rounds: int = 0,
+        time_budget_s: float = 0.0,
+        loop_start_time: float = 0.0,
+    ) -> None:
+        self.max_rounds = max_rounds
+        self._time_budget_s = time_budget_s
+        self._loop_start_time = loop_start_time
+
+
+def _call_guards(stub: _StubLoop, round_idx: int) -> str | None:
+    """Bind the helper to a stub via descriptor protocol — avoids
+    AgenticLoop.__init__ side-effects."""
+    bound = AgenticLoop._check_round_guards.__get__(stub, _StubLoop)
+    return bound(round_idx)
+
+
+def test_no_limits_means_no_guard_trigger() -> None:
+    """max_rounds=0 + time_budget_s=0 (defaults) means unlimited.
+    Helper must return None for any round_idx."""
+    stub = _StubLoop()
+    assert _call_guards(stub, 0) is None
+    assert _call_guards(stub, 999) is None
+
+
+def test_round_limit_triggers_at_max() -> None:
+    """0-based round_idx: max_rounds=3 means rounds 0, 1, 2 proceed
+    and round 3 hits the limit. Pin the boundary."""
+    stub = _StubLoop(max_rounds=3)
+    assert _call_guards(stub, 0) is None
+    assert _call_guards(stub, 1) is None
+    assert _call_guards(stub, 2) is None
+    assert _call_guards(stub, 3) == "round_limit"
+    assert _call_guards(stub, 999) == "round_limit"
+
+
+def test_time_budget_triggers_when_elapsed() -> None:
+    """Wall clock comparison against self._loop_start_time."""
+    # Loop "started" far in the past — elapsed > 1.0 second
+    stub = _StubLoop(
+        time_budget_s=1.0,
+        loop_start_time=time.monotonic() - 100.0,
+    )
+    assert _call_guards(stub, 0) == "time_budget"
+
+
+def test_time_budget_not_triggered_when_within() -> None:
+    """Just-started loop — elapsed ≈ 0 < budget."""
+    stub = _StubLoop(
+        time_budget_s=60.0,
+        loop_start_time=time.monotonic(),
+    )
+    assert _call_guards(stub, 0) is None
+
+
+def test_round_limit_takes_precedence_over_time_budget() -> None:
+    """If both would trigger, the round-limit check runs first
+    (mirrors pre-refactor order: Guard 1 before Guard 2). Pin via
+    the returned reason."""
+    stub = _StubLoop(
+        max_rounds=1,
+        time_budget_s=1.0,
+        loop_start_time=time.monotonic() - 100.0,
+    )
+    # round_idx=5 > max_rounds=1 AND elapsed > 1.0; reason = round_limit
+    assert _call_guards(stub, 5) == "round_limit"
+
+
+def test_time_budget_zero_means_disabled() -> None:
+    """time_budget_s=0.0 disables the guard, no matter how much
+    time has elapsed."""
+    stub = _StubLoop(
+        time_budget_s=0.0,
+        loop_start_time=time.monotonic() - 10000.0,
+    )
+    assert _call_guards(stub, 0) is None
+
+
+# ---------------------------------------------------------------------------
+# arun delegates to the helper
+# ---------------------------------------------------------------------------
+
+
+def test_arun_calls_check_round_guards() -> None:
+    """``arun``'s while-loop body must call the helper exactly
+    once. Anti-residue guard — the inline ``Guard 1`` / ``Guard 2``
+    blocks must NOT remain in ``arun``."""
+    src = inspect.getsource(AgenticLoop.arun)
+    # Helper is invoked
+    assert "self._check_round_guards(round_idx)" in src
+    # Inline guards removed
+    assert "Guard 1: Round limit" not in src
+    assert "Guard 2: Time budget" not in src
+
+
+def test_arun_breaks_on_non_none_guard_response() -> None:
+    """Pin the break semantics — non-None return → ``break`` (not
+    ``return``). The loop's downstream wrap-up code (final
+    AgenticResult construction + finalize_and_return) must still
+    run, matching pre-refactor behaviour."""
+    src = inspect.getsource(AgenticLoop.arun)
+    # The exact pattern arun uses (newline-tolerant via string
+    # split — the exact whitespace shape is rendered by ruff format
+    # and may shift; pin the semantic instead).
+    assert "if self._check_round_guards(round_idx) is not None:" in src
+    # The very next non-blank line in arun must be ``break``.
+    # Find the guard call site and walk forward.
+    idx = src.index("if self._check_round_guards(round_idx) is not None:")
+    after = src[idx:].splitlines()[1:5]  # next 4 lines
+    next_nonblank = next((ln.strip() for ln in after if ln.strip()), "")
+    assert next_nonblank == "break", (
+        "arun must ``break`` (not ``return``) on a triggered guard so "
+        "the loop's wrap-up code constructs the AgenticResult — "
+        f"got {next_nonblank!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants pinned (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_guard_reason_values() -> None:
+    """The reason strings are public-facing only inside this helper
+    (used for ``log.debug`` and future telemetry hooks). Pin the
+    spellings so a future renamer hits this test, not whatever
+    consumer eventually subscribes."""
+    stub = _StubLoop(max_rounds=1)
+    assert _call_guards(stub, 5) == "round_limit"
+
+    stub2 = _StubLoop(time_budget_s=0.001, loop_start_time=time.monotonic() - 1.0)
+    assert _call_guards(stub2, 0) == "time_budget"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2a doesn't change phase 1 behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_session_start_helper_still_exists() -> None:
+    """Cross-phase parity — PR-D Phase 1's
+    ``_emit_session_start_signals`` must still be there. Phase 2a
+    is additive; it must not regress the prior extraction."""
+    assert hasattr(AgenticLoop, "_emit_session_start_signals")
+
+
+@pytest.fixture(autouse=True)
+def _reset_time_calls() -> None:
+    """No shared state to reset — the stub-based tests are
+    self-contained. Fixture present so a future per-test setup hook
+    has a place to live."""
+    yield


### PR DESCRIPTION
## Summary

- **`arun()`의 round-entry guards (round limit + time budget) 를 `_check_round_guards` 헬퍼로 추출.** Returns `"round_limit" | "time_budget" | None`.
- **Pure refactor — zero behavior change.** `break` (not `return`) 의미 보존 → loop wrap-up 코드 그대로 실행.
- **Precedence 보존**: round_limit > time_budget 순서 (pre-refactor `Guard 1` → `Guard 2` 순서 정확히 유지).

## Why

Frontier matrix concern #1 — `arun()` god-method 분해 phase 2 시작. PR-D Phase 1 (v0.99.24)에서 session-start 49 LOC 추출. Phase 2a는 가장 격리된 슬라이스 (~15 LOC, 2 guard) — Codex MCP가 zero-behavior-change 확인 가능. Phase 2b/2c (model-drift sync / LLM-call dispatch) 후속.

## Changes

| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | NEW `_check_round_guards(round_idx) -> str \| None`. arun's inline `Guard 1`/`Guard 2` blocks replaced by single `if ... is not None: break`. |
| `tests/test_arun_round_guards.py` | NEW — 12 invariant tests |
| `CHANGELOG.md` | `[Unreleased] Changed` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Helper signature `(round_idx) -> str \| None` | Implemented | sync (guards are pure) |
| Round-limit guard | Implemented | `round_idx >= max_rounds` |
| Time-budget guard | Implemented | `elapsed >= time_budget_s` |
| Precedence (round_limit first) | Implemented | matches pre-refactor inline order |
| `break`-not-`return` semantics | Implemented | wrap-up code still runs |
| Anti-residue (inline Guard 1/2 gone) | Implemented | grep test pins |
| Phase 2b/2c (model-drift / LLM-call) | Deferred | follow-up PRs |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_arun_round_guards.py tests/test_arun_session_start_extraction.py -q` — 23/23 pass

## Reference

- Backlog item A (PR-D Phase 2/3): god-method 본체 추출, 단계별 진행
- Phase 1 (#1383, `febcfee5`): session-start signals 추출 (49 LOC)