### PR TITLE
refactor(agent-loop): PR-D Phase 2b — extract model-drift sync from arun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,30 @@ functional change.
 
 ### Changed
 
+- **PR-D Phase 2b — ``_sync_model_and_rebuild_prompt`` extraction
+  from ``arun``.** Continues the god-method decomposition. Phase 1
+  (v0.99.24) extracted session-start signals; Phase 2a (v0.99.25)
+  extracted round-entry guards. Phase 2b takes the model-drift
+  sync + ``system_prompt`` rebuild block from the top of each
+  round (pre-refactor lines ~727-739):
+  ``_sync_model_from_settings_async()`` OR-chained with
+  ``_prompt_dirty`` → ``_build_system_prompt()`` rebuild +
+  ``decomposition_hint`` append + ``_prompt_dirty = False`` reset.
+  All of it now lives in
+  ``AgenticLoop._sync_model_and_rebuild_prompt(system_prompt,
+  decomposition_hint) -> str``. ``arun`` rebinds the local from the
+  helper's return value, preserving the exact pre-refactor
+  semantics (drift sync + dirty-flag OR-chain, rebuild path, hint
+  append with ``\n\n`` separator, dirty flag clear). 13 invariant
+  tests pin the helper signature, all 4 trigger combinations
+  (drift / dirty / both / neither), rebuild side-effect, hint
+  append/skip/ignore-when-not-rebuilding, ``arun`` delegation +
+  anti-residue, and cross-phase regression (Phase 1 + 2a helpers
+  still intact). Phase 2c (LLM-call dispatch + retry budget) will
+  continue.
+
+### Changed
+
 - **PR-D Phase 2a — ``_check_round_guards`` extraction from
   ``arun``.** Continues the god-method decomposition started in
   v0.99.24 (PR-D Phase 1 extracted session-start signals). Phase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,10 @@ functional change.
   decomposition_hint) -> str``. ``arun`` rebinds the local from the
   helper's return value, preserving the exact pre-refactor
   semantics (drift sync + dirty-flag OR-chain, rebuild path, hint
-  append with ``\n\n`` separator, dirty flag clear). 13 invariant
+  append with ``\n\n`` separator, dirty flag clear). 14 invariant
   tests pin the helper signature, all 4 trigger combinations
-  (drift / dirty / both / neither), rebuild side-effect, hint
+  (drift / dirty / both / neither — both-case verifies OR
+  short-circuit + single rebuild), rebuild side-effect, hint
   append/skip/ignore-when-not-rebuilding, ``arun`` delegation +
   anti-residue, and cross-phase regression (Phase 1 + 2a helpers
   still intact). Phase 2c (LLM-call dispatch + retry budget) will

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -499,6 +499,37 @@ class AgenticLoop:
 
         return None
 
+    async def _sync_model_and_rebuild_prompt(
+        self, system_prompt: str, decomposition_hint: str | None
+    ) -> str:
+        """PR-D Phase 2b — model-drift sync + system_prompt rebuild
+        extracted from ``arun``'s while-loop body.
+
+        Between rounds the ``settings.model`` field may have changed
+        (via the ``switch_model`` tool, the ``/model`` slash command,
+        or a config hot-reload). The drift sync detects the change
+        and rebuilds the system prompt so the next LLM call sees the
+        updated model card.
+
+        ``v0.52.5`` — ``_prompt_dirty`` catches any direct
+        ``update_model_async`` call that bypasses the drift sync;
+        without it the system_prompt model card would stay pinned to
+        the previous model after a switch.
+        ``v0.90.0`` — auto-escalation paths removed; the only such
+        callers now are user-initiated ``/model`` switches.
+
+        Returns the (possibly-rebuilt) ``system_prompt`` so ``arun``
+        can rebind its local. Side-effect: clears ``_prompt_dirty``
+        after a rebuild. Behaviour preserved exactly from the
+        pre-refactor inline block.
+        """
+        if await self._sync_model_from_settings_async() or self._prompt_dirty:
+            system_prompt = self._build_system_prompt()
+            if decomposition_hint:
+                system_prompt += "\n\n" + decomposition_hint
+            self._prompt_dirty = False
+        return system_prompt
+
     def _check_round_guards(self, round_idx: int) -> str | None:
         """PR-D Phase 2a — round-entry guards extracted from ``arun``.
 
@@ -724,19 +755,14 @@ class AgenticLoop:
             is_last_round = (self.max_rounds > 0) and (round_idx == self.max_rounds - 1)
             self._op_logger.begin_round("AgenticLoop")
 
-            # Model drift check: settings may have changed via switch_model tool
-            # or /model command between rounds. Apply safely before next LLM call.
-            #
-            # v0.52.5 — _prompt_dirty catches any direct ``update_model`` call
-            # that bypasses the drift sync; without it the system_prompt model
-            # card would stay pinned to the previous model after a switch.
-            # v0.90.0 — auto-escalation paths were removed; the only such
-            # callers now are user-initiated /model switches.
-            if await self._sync_model_from_settings_async() or self._prompt_dirty:
-                system_prompt = self._build_system_prompt()
-                if decomposition_hint:
-                    system_prompt += "\n\n" + decomposition_hint
-                self._prompt_dirty = False
+            # PR-D Phase 2b — model-drift sync extracted to a helper.
+            # The helper returns the possibly-rebuilt system_prompt;
+            # ``arun`` rebinds the local so the next LLM call sees the
+            # updated model card. Behaviour preserved exactly — the
+            # _prompt_dirty side-effect reset still happens inside.
+            system_prompt = await self._sync_model_and_rebuild_prompt(
+                system_prompt, decomposition_hint
+            )
 
             # Poll for sub-agent announced results (OpenClaw Spawn+Announce)
             self._check_announced_results(messages)

--- a/tests/test_arun_model_drift_sync.py
+++ b/tests/test_arun_model_drift_sync.py
@@ -1,0 +1,192 @@
+"""PR-D Phase 2b — ``_sync_model_and_rebuild_prompt`` extraction invariants.
+
+Pins the structural extraction of the model-drift sync + system_prompt
+rebuild block from ``arun``'s while-loop body into a dedicated helper.
+Phase 2b is pure refactor (zero behaviour change); ``arun`` rebinds
+``system_prompt`` from the helper's return value, preserving the
+exact pre-refactor semantics:
+
+  * ``_sync_model_from_settings_async()`` checks settings drift.
+  * OR-chained with ``_prompt_dirty`` so direct
+    ``update_model_async`` callers (v0.52.5) still trigger rebuild.
+  * On rebuild: ``_build_system_prompt()`` produces a new prompt;
+    ``decomposition_hint`` (if present) appended.
+  * Side effect: ``_prompt_dirty`` cleared post-rebuild.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+from core.agent.loop.agent_loop import AgenticLoop
+
+# ---------------------------------------------------------------------------
+# Method exists with the right signature
+# ---------------------------------------------------------------------------
+
+
+def test_helper_method_exists() -> None:
+    assert hasattr(AgenticLoop, "_sync_model_and_rebuild_prompt")
+    method = AgenticLoop._sync_model_and_rebuild_prompt
+    sig = inspect.signature(method)
+    assert "system_prompt" in sig.parameters
+    assert "decomposition_hint" in sig.parameters
+    # Returns str — caller rebinds the local.
+    assert "str" in str(sig.return_annotation)
+
+
+def test_helper_is_coroutine() -> None:
+    """``_sync_model_from_settings_async`` is async — the helper must
+    be too so the await chain in ``arun`` stays consistent."""
+    assert inspect.iscoroutinefunction(AgenticLoop._sync_model_and_rebuild_prompt)
+
+
+# ---------------------------------------------------------------------------
+# Behaviour — exact pre-refactor semantics
+# ---------------------------------------------------------------------------
+
+
+class _StubLoop:
+    """Minimal AgenticLoop stub — only the fields + methods
+    ``_sync_model_and_rebuild_prompt`` reads. Lets tests invoke the
+    helper without constructing the full runtime."""
+
+    def __init__(
+        self,
+        *,
+        sync_returns_drifted: bool = False,
+        prompt_dirty: bool = False,
+        rebuilt_prompt: str = "REBUILT_PROMPT",
+    ) -> None:
+        self._sync_returns_drifted = sync_returns_drifted
+        self._prompt_dirty = prompt_dirty
+        self._rebuilt_prompt = rebuilt_prompt
+        self.build_calls = 0
+        self.sync_calls = 0
+
+    async def _sync_model_from_settings_async(self) -> bool:
+        self.sync_calls += 1
+        return self._sync_returns_drifted
+
+    def _build_system_prompt(self) -> str:
+        self.build_calls += 1
+        return self._rebuilt_prompt
+
+
+def _call_helper(stub: _StubLoop, system_prompt: str, hint: str | None) -> str:
+    bound = AgenticLoop._sync_model_and_rebuild_prompt.__get__(stub, _StubLoop)
+    return asyncio.run(bound(system_prompt, hint))
+
+
+def test_no_drift_no_dirty_returns_input_unchanged() -> None:
+    """Common case: neither the settings drift nor _prompt_dirty
+    triggers. Helper returns the input system_prompt unchanged and
+    does NOT call _build_system_prompt."""
+    stub = _StubLoop(sync_returns_drifted=False, prompt_dirty=False)
+    result = _call_helper(stub, "ORIGINAL", None)
+    assert result == "ORIGINAL"
+    assert stub.build_calls == 0
+    assert stub.sync_calls == 1
+
+
+def test_drift_triggers_rebuild() -> None:
+    """Settings.model changed → drift sync returns True → rebuild."""
+    stub = _StubLoop(sync_returns_drifted=True, prompt_dirty=False)
+    result = _call_helper(stub, "ORIGINAL", None)
+    assert result == "REBUILT_PROMPT"
+    assert stub.build_calls == 1
+
+
+def test_prompt_dirty_triggers_rebuild_even_without_drift() -> None:
+    """v0.52.5 — direct update_model_async callers bypass the drift
+    sync, but set _prompt_dirty. OR-chain catches them."""
+    stub = _StubLoop(sync_returns_drifted=False, prompt_dirty=True)
+    result = _call_helper(stub, "ORIGINAL", None)
+    assert result == "REBUILT_PROMPT"
+    assert stub.build_calls == 1
+
+
+def test_rebuild_clears_prompt_dirty_flag() -> None:
+    """After rebuild ``_prompt_dirty`` must be False so subsequent
+    rounds don't loop-rebuild."""
+    stub = _StubLoop(sync_returns_drifted=False, prompt_dirty=True)
+    _call_helper(stub, "ORIGINAL", None)
+    assert stub._prompt_dirty is False
+
+
+def test_no_rebuild_leaves_prompt_dirty_flag_untouched() -> None:
+    """If no rebuild happens, ``_prompt_dirty`` keeps its value
+    (which is already False in the no-rebuild path — this just
+    pins that the helper doesn't accidentally set it to True)."""
+    stub = _StubLoop(sync_returns_drifted=False, prompt_dirty=False)
+    _call_helper(stub, "ORIGINAL", None)
+    assert stub._prompt_dirty is False
+
+
+def test_decomposition_hint_appended_when_rebuilding() -> None:
+    """If a decomposition hint exists, it's appended to the rebuilt
+    prompt with two newline separator (matches pre-refactor)."""
+    stub = _StubLoop(sync_returns_drifted=True)
+    result = _call_helper(stub, "ORIGINAL", "HINT_TEXT")
+    assert result == "REBUILT_PROMPT\n\nHINT_TEXT"
+
+
+def test_decomposition_hint_none_not_appended() -> None:
+    """No hint = no append (no ``None`` string concatenation
+    accident)."""
+    stub = _StubLoop(sync_returns_drifted=True)
+    result = _call_helper(stub, "ORIGINAL", None)
+    assert result == "REBUILT_PROMPT"
+    assert "None" not in result
+
+
+def test_decomposition_hint_ignored_when_not_rebuilding() -> None:
+    """If no rebuild happens, the hint doesn't matter — original
+    prompt returned unchanged."""
+    stub = _StubLoop(sync_returns_drifted=False, prompt_dirty=False)
+    result = _call_helper(stub, "ORIGINAL", "HINT_THAT_IS_IGNORED")
+    assert result == "ORIGINAL"
+
+
+# ---------------------------------------------------------------------------
+# arun delegates to the helper
+# ---------------------------------------------------------------------------
+
+
+def test_arun_calls_sync_and_rebuild_helper() -> None:
+    """``arun``'s while-loop must call the helper and rebind
+    ``system_prompt`` from its return value."""
+    src = inspect.getsource(AgenticLoop.arun)
+    assert "system_prompt = await self._sync_model_and_rebuild_prompt(" in src
+
+
+def test_arun_no_longer_inlines_drift_sync() -> None:
+    """Anti-residue guard — the pre-refactor inline block must NOT
+    remain in ``arun`` (would double-call sync + double-build prompt)."""
+    src = inspect.getsource(AgenticLoop.arun)
+    # The exact pre-refactor lines that should be gone:
+    assert "if await self._sync_model_from_settings_async() or self._prompt_dirty:" not in src
+    # The inline "self._prompt_dirty = False" line is now ONLY inside
+    # the helper. arun should have zero direct writes to _prompt_dirty.
+    assert "self._prompt_dirty = False" not in src
+
+
+# ---------------------------------------------------------------------------
+# Cross-phase regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_and_phase2a_helpers_still_exist() -> None:
+    """Phase 1 (_emit_session_start_signals) and Phase 2a
+    (_check_round_guards) must remain intact. Phase 2b is additive."""
+    assert hasattr(AgenticLoop, "_emit_session_start_signals")
+    assert hasattr(AgenticLoop, "_check_round_guards")
+
+
+@pytest.fixture(autouse=True)
+def _no_shared_state() -> None:
+    """Stub-based tests are self-contained; fixture present so a
+    future per-test setup hook has a place to live."""
+    yield

--- a/tests/test_arun_model_drift_sync.py
+++ b/tests/test_arun_model_drift_sync.py
@@ -108,6 +108,23 @@ def test_prompt_dirty_triggers_rebuild_even_without_drift() -> None:
     assert stub.build_calls == 1
 
 
+def test_both_drift_and_dirty_still_rebuild_exactly_once() -> None:
+    """Both flags set: OR-chain short-circuits on the first True.
+    Rebuild path still runs exactly once (not twice). Pin against a
+    future refactor that accidentally double-rebuilds."""
+    stub = _StubLoop(sync_returns_drifted=True, prompt_dirty=True)
+    result = _call_helper(stub, "ORIGINAL", None)
+    assert result == "REBUILT_PROMPT"
+    assert stub.build_calls == 1
+    # drift sync runs unconditionally (left operand of OR); dirty
+    # flag is consulted only if drift returns False (short-circuit).
+    # Here drift=True so the OR short-circuits — dirty is not
+    # *evaluated for branching*, but the post-rebuild reset still
+    # clears it.
+    assert stub.sync_calls == 1
+    assert stub._prompt_dirty is False
+
+
 def test_rebuild_clears_prompt_dirty_flag() -> None:
     """After rebuild ``_prompt_dirty`` must be False so subsequent
     rounds don't loop-rebuild."""


### PR DESCRIPTION
## Summary

- **`arun()`의 model-drift sync + system_prompt 재구성 블록 추출.** `_sync_model_and_rebuild_prompt(system_prompt, decomposition_hint) -> str`.
- **Pure refactor — zero behavior change.** OR-chain (`_sync_model_from_settings_async()` ∨ `_prompt_dirty`) → rebuild + hint append + dirty 플래그 reset 모두 헬퍼로. `arun`은 helper 반환값으로 local 재바인딩.
- **~13 LOC 단축.** Phase 2 누적: 1 (49 LOC) + 2a (15 LOC) + 2b (13 LOC).

## Why

Frontier matrix concern #1 — `arun()` god-method 분해 단계별 진행. Phase 2b는 round 본체의 두 번째 슬라이스 (model hot-swap 경로). v0.52.5의 `_prompt_dirty` 플래그가 OR-chain으로 묶여 있어 의미 보존이 까다로움 — 단독 헬퍼로 캡슐화하여 추후 변경 안전성 확보.

## Changes

| File | Change |
|------|--------|
| `core/agent/loop/agent_loop.py` | NEW `_sync_model_and_rebuild_prompt(...)`. arun's inline 13-line block → single rebind call. |
| `tests/test_arun_model_drift_sync.py` | NEW — 13 invariant tests |
| `CHANGELOG.md` | `[Unreleased] Changed` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Helper signature `(system_prompt, hint) -> str` | Implemented | coroutine (await chain preserved) |
| Drift sync OR `_prompt_dirty` trigger | Implemented | mirrors pre-refactor OR-chain |
| `_build_system_prompt` rebuild | Implemented | only on trigger |
| `decomposition_hint` append (`\n\n` separator) | Implemented | conditional on rebuild + non-None hint |
| `_prompt_dirty = False` reset | Implemented | post-rebuild side effect |
| Anti-residue (inline block gone) | Implemented | grep tests pin |
| Phase 2c (LLM-call dispatch) | Deferred | follow-up PR |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — clean (362 source files)
- [x] `uv run python -m pytest tests/test_arun_model_drift_sync.py tests/test_arun_round_guards.py tests/test_arun_session_start_extraction.py -q` — 35/35 pass

## Reference

- Backlog item A (PR-D Phase 2/3): god-method 본체 추출, 단계별 진행
- Phase 1 (#1383, `febcfee5`), Phase 2a (#1387, `b512a78b`)
- v0.52.5 `_prompt_dirty` flag — direct `update_model_async` callers (now only `/model` slash command)