### PR TITLE
release: v0.99.26 — arun god-method decomposition Phase 2 trilogy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.26] — 2026-05-21
+
+> **arun god-method decomposition — Phase 2 trilogy.** 3 PRs
+> (#1387/#1388/#1389) continue PR-D Phase 1 (v0.99.25 — session-start
+> signals). Phase 2a extracted round-entry guards (round limit +
+> time budget). Phase 2b extracted model-drift sync +
+> ``system_prompt`` rebuild. Phase 2c extracted LLM-call dispatch
+> + ``BillingError`` / ``UserCancelledError`` handlers via the
+> discriminator-return pattern. All three pure structural refactors
+> with zero behavior change, Codex MCP verified end-to-end. Tests
+> 5346 → 5386 (+40 invariant tests across Phase 2a/2b/2c). Modules
+> unchanged (314 core + 48 plugins = 362). Phase 3 (response handler
+> + overthinking + convergence ~210 LOC) deferred — needs
+> sub-splitting before the next slice.
+
 ### Changed
 
 - **PR-D Phase 2c — ``_dispatch_llm_call`` extraction from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.25
+- **Version**: 0.99.26
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 314 core + 48 plugins = 362
-- **Tests**: 5346 (+5 live)
+- **Tests**: 5386 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.25 — Long-running Autonomous Execution Harness
+# GEODE v0.99.26 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.25**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.26**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.25 — Long-running Autonomous Execution Harness
+# GEODE v0.99.26 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.25**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.26**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.25"
+version = "0.99.26"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1190,7 +1190,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.24"
+version = "0.99.26"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Cuts v0.99.26 covering the arun() god-method decomposition Phase 2 trilogy:
- PR-D Phase 2a (#1387) — `_check_round_guards` extraction
- PR-D Phase 2b (#1388) — `_sync_model_and_rebuild_prompt` extraction
- PR-D Phase 2c (#1389) — `_dispatch_llm_call` extraction

## Verification

- [x] ruff check clean
- [x] uv.lock refreshed to 0.99.26
- [x] Version synced across 4 locations (pyproject / CLAUDE.md / README.md / README.ko.md)
- [x] CHANGELOG `[0.99.26]` block written with sprint preamble
- [x] Tests 5346 → 5386 (+40 invariant tests; Codex MCP verified each PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)