### PR TITLE
feat(cognitive-loop): subagent-lineage — subprocess WorkerRequest threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,30 +49,45 @@ functional change.
 
 ### Added
 
-- **PR-F — sub-agent state propagation via ``parent_session_id``
-  lineage.** Concern #3 from the post-sprint frontier matrix: PR-4
-  bound ``CognitiveState`` + ``session_id`` per-task via ContextVar,
-  but sub-agents (OpenClaw spawn pattern) inherited a *fresh*
-  cognitive context with no link back to the parent. Episode rows
-  from child loops had ``session_id=child`` but no record of the
-  spawning parent, so the PR-E confidence-trajectory aggregator
-  couldn't group sub-agent rounds under the parent for cross-
-  session attribution. PR-F closes the loop. New
-  ``get_parent_session_id`` / ``set_parent_session_id`` ContextVar
-  pair in ``core/agent/cognitive_state_ctx.py`` (matches CLAUDE.md
+- **PR-F — sub-agent state propagation via
+  ``parent_session_key`` lineage.** Concern #3 from the post-sprint
+  frontier matrix: PR-4 bound ``CognitiveState`` + ``session_id``
+  per-task via ContextVar, but sub-agents (OpenClaw spawn pattern)
+  inherited a *fresh* cognitive context with no link back to the
+  parent. Episode rows from child loops had ``session_id=child``
+  but no record of the spawning parent, so the PR-E confidence-
+  trajectory aggregator couldn't group sub-agent rounds under the
+  parent for cross-session attribution. PR-F closes the in-process
+  spawn half of the loop. New ``get_parent_session_key`` /
+  ``set_parent_session_key`` ContextVar pair in
+  ``core/agent/cognitive_state_ctx.py`` (matches CLAUDE.md
   reader/writer parity rule). ``AgenticLoop._emit_session_start_signals``
   binds ``self._parent_session_key`` (already plumbed through the
   constructor for the OpenClaw spawn pattern) into the ContextVar
   alongside the existing ``set_cognitive_state`` /
-  ``set_session_id`` calls. ``Episode`` gains a ``parent_session_id``
-  field (default ``""``, so older readers + hand-constructed
-  fixtures still work). The bootstrap ``TOOL_EXEC_ENDED`` handler
-  reads ``get_parent_session_id()`` and stamps the value onto every
+  ``set_session_id`` calls. ``Episode`` gains a
+  ``parent_session_key`` field (default ``""``, so older readers +
+  hand-constructed fixtures still work). The bootstrap
+  ``TOOL_EXEC_ENDED`` handler reads
+  ``get_parent_session_key()`` and stamps the value onto every
   Episode row. Legacy JSONL rows without the field load with the
-  default empty string. 8 invariant tests pin: ContextVar default
+  default empty string. 10 invariant tests pin: ContextVar default
   + roundtrip + ``__all__`` surface; Episode field + JSONL
   roundtrip + persistence + legacy-row tolerance; bootstrap
-  reader; AgenticLoop bind site; constructor signature preservation.
+  reader; AgenticLoop bind site; constructor signature
+  preservation.
+
+  Naming caveat (Codex MCP PR-F review #1 catch): the propagated
+  value is the OpenClaw *routing key* (e.g. ``"subject:foo:bar"``),
+  not the parent's ``_session_id`` uuid. The field is named
+  ``parent_session_key`` to match the data shape — an aggregator
+  that wants uuid-based linkage needs a separate
+  ``parent_session_id`` ContextVar populated from the parent's
+  ``_session_id``. Two scope-deferred follow-ups: (a) plumb
+  ``parent_session_id`` from the in-process spawner, (b) extend
+  ``WorkerRequest`` so subprocess sub-agents
+  (``SubAgentManager → worker.py`` path) also carry the parent
+  lineage — today their child Episodes record ``""``.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,33 @@ functional change.
 
 ### Added
 
+- **PR-F — sub-agent state propagation via ``parent_session_id``
+  lineage.** Concern #3 from the post-sprint frontier matrix: PR-4
+  bound ``CognitiveState`` + ``session_id`` per-task via ContextVar,
+  but sub-agents (OpenClaw spawn pattern) inherited a *fresh*
+  cognitive context with no link back to the parent. Episode rows
+  from child loops had ``session_id=child`` but no record of the
+  spawning parent, so the PR-E confidence-trajectory aggregator
+  couldn't group sub-agent rounds under the parent for cross-
+  session attribution. PR-F closes the loop. New
+  ``get_parent_session_id`` / ``set_parent_session_id`` ContextVar
+  pair in ``core/agent/cognitive_state_ctx.py`` (matches CLAUDE.md
+  reader/writer parity rule). ``AgenticLoop._emit_session_start_signals``
+  binds ``self._parent_session_key`` (already plumbed through the
+  constructor for the OpenClaw spawn pattern) into the ContextVar
+  alongside the existing ``set_cognitive_state`` /
+  ``set_session_id`` calls. ``Episode`` gains a ``parent_session_id``
+  field (default ``""``, so older readers + hand-constructed
+  fixtures still work). The bootstrap ``TOOL_EXEC_ENDED`` handler
+  reads ``get_parent_session_id()`` and stamps the value onto every
+  Episode row. Legacy JSONL rows without the field load with the
+  default empty string. 8 invariant tests pin: ContextVar default
+  + roundtrip + ``__all__`` surface; Episode field + JSONL
+  roundtrip + persistence + legacy-row tolerance; bootstrap
+  reader; AgenticLoop bind site; constructor signature preservation.
+
+### Added
+
 - **PR-E — causal attribution × CognitiveState confidence-stability
   term.** Concern #5 from the post-sprint frontier matrix: PR-5's
   ``compute_attribution`` only consumed baseline dim deltas + the

--- a/core/agent/cognitive_state_ctx.py
+++ b/core/agent/cognitive_state_ctx.py
@@ -34,6 +34,14 @@ _active_state: ContextVar[CognitiveState | None] = ContextVar(
     "geode_active_cognitive_state", default=None
 )
 _active_session_id: ContextVar[str] = ContextVar("geode_active_session_id", default="")
+# PR-F (2026-05-21) — sub-agent lineage. When the active loop is a
+# child spawned via the OpenClaw spawn pattern, this carries the
+# *parent* loop's ``session_id`` so the episodic recorder can stamp
+# the child's Episode rows with the parent reference for cross-
+# session attribution. Empty string = top-level loop, no parent.
+_active_parent_session_id: ContextVar[str] = ContextVar(
+    "geode_active_parent_session_id", default=""
+)
 
 
 def get_cognitive_state() -> CognitiveState | None:
@@ -61,9 +69,25 @@ def set_session_id(session_id: str) -> None:
     _active_session_id.set(session_id)
 
 
+def get_parent_session_id() -> str:
+    """PR-F (2026-05-21) — return the active loop's *parent* session
+    id, or ``""`` for a top-level loop. Read by the episodic recorder
+    so cross-session attribution can group child Episode rows under
+    the parent."""
+    return _active_parent_session_id.get()
+
+
+def set_parent_session_id(parent_session_id: str) -> None:
+    """Bind ``parent_session_id`` to the current context. Empty
+    string clears the binding (top-level loop)."""
+    _active_parent_session_id.set(parent_session_id)
+
+
 __all__ = [
     "get_cognitive_state",
+    "get_parent_session_id",
     "get_session_id",
     "set_cognitive_state",
+    "set_parent_session_id",
     "set_session_id",
 ]

--- a/core/agent/cognitive_state_ctx.py
+++ b/core/agent/cognitive_state_ctx.py
@@ -36,11 +36,15 @@ _active_state: ContextVar[CognitiveState | None] = ContextVar(
 _active_session_id: ContextVar[str] = ContextVar("geode_active_session_id", default="")
 # PR-F (2026-05-21) — sub-agent lineage. When the active loop is a
 # child spawned via the OpenClaw spawn pattern, this carries the
-# *parent* loop's ``session_id`` so the episodic recorder can stamp
-# the child's Episode rows with the parent reference for cross-
-# session attribution. Empty string = top-level loop, no parent.
-_active_parent_session_id: ContextVar[str] = ContextVar(
-    "geode_active_parent_session_id", default=""
+# parent loop's ``_parent_session_key`` (the OpenClaw routing key,
+# e.g. ``"subject:foo:bar"``, NOT the parent's ``_session_id`` uuid
+# format). Naming matches the AgenticLoop constructor kwarg so the
+# data shape is unambiguous. Empty string = top-level loop.
+# Future-PR scope: a separate ContextVar ``parent_session_id`` can
+# be added when the sub-agent spawner is plumbed to forward the
+# parent's actual ``_session_id`` through WorkerRequest.
+_active_parent_session_key: ContextVar[str] = ContextVar(
+    "geode_active_parent_session_key", default=""
 )
 
 
@@ -69,25 +73,31 @@ def set_session_id(session_id: str) -> None:
     _active_session_id.set(session_id)
 
 
-def get_parent_session_id() -> str:
-    """PR-F (2026-05-21) — return the active loop's *parent* session
-    id, or ``""`` for a top-level loop. Read by the episodic recorder
-    so cross-session attribution can group child Episode rows under
-    the parent."""
-    return _active_parent_session_id.get()
+def get_parent_session_key() -> str:
+    """PR-F (2026-05-21) — return the active loop's parent
+    ``_parent_session_key`` (OpenClaw routing-key format like
+    ``"subject:foo:bar"``), or ``""`` for a top-level loop. Read by
+    the episodic recorder so cross-session attribution can group
+    child Episode rows by spawning parent.
+
+    NOTE: this is the *routing key*, NOT the parent's ``_session_id``
+    uuid. A future PR can add a separate ``parent_session_id``
+    ContextVar when the sub-agent spawner is plumbed to forward
+    the parent's actual session id through WorkerRequest."""
+    return _active_parent_session_key.get()
 
 
-def set_parent_session_id(parent_session_id: str) -> None:
-    """Bind ``parent_session_id`` to the current context. Empty
+def set_parent_session_key(parent_session_key: str) -> None:
+    """Bind ``parent_session_key`` to the current context. Empty
     string clears the binding (top-level loop)."""
-    _active_parent_session_id.set(parent_session_id)
+    _active_parent_session_key.set(parent_session_key)
 
 
 __all__ = [
     "get_cognitive_state",
-    "get_parent_session_id",
+    "get_parent_session_key",
     "get_session_id",
     "set_cognitive_state",
-    "set_parent_session_id",
+    "set_parent_session_key",
     "set_session_id",
 ]

--- a/core/agent/cognitive_state_ctx.py
+++ b/core/agent/cognitive_state_ctx.py
@@ -40,9 +40,21 @@ _active_session_id: ContextVar[str] = ContextVar("geode_active_session_id", defa
 # e.g. ``"subject:foo:bar"``, NOT the parent's ``_session_id`` uuid
 # format). Naming matches the AgenticLoop constructor kwarg so the
 # data shape is unambiguous. Empty string = top-level loop.
-# Future-PR scope: a separate ContextVar ``parent_session_id`` can
-# be added when the sub-agent spawner is plumbed to forward the
-# parent's actual ``_session_id`` through WorkerRequest.
+#
+# TODO(PR-F-followup): A separate ContextVar ``parent_session_id``
+# (uuid format) is needed when the sub-agent spawner is plumbed to
+# forward the parent's actual ``_session_id`` through WorkerRequest.
+# Today only the in-process spawn path carries lineage; subprocess
+# children (``SubAgentManager → worker.py``) record empty.
+#
+# TODO(PR-F-followup): Same-task nested spawn (A → B → A) is NOT
+# covered by PR-4's lifetime comment below — that comment talks
+# about repeated arun() in the same task and separate asyncio
+# tasks. If a top-level loop A spawns child B *in the same task*
+# (not subprocess), B's bind would leak back into A until A's next
+# arun() re-binds. Add Token-based reset (``ContextVar.set`` returns
+# a Token; pair with ``ContextVar.reset(token)`` in a try/finally)
+# when this path becomes a documented use case.
 _active_parent_session_key: ContextVar[str] = ContextVar(
     "geode_active_parent_session_key", default=""
 )

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -451,10 +451,21 @@ class AgenticLoop:
         # overwrite idempotently. No explicit reset is needed since
         # the next ``arun`` overwrites and out-of-loop hook firings
         # in the same task are not a documented use case.
-        from core.agent.cognitive_state_ctx import set_cognitive_state, set_session_id
+        from core.agent.cognitive_state_ctx import (
+            set_cognitive_state,
+            set_parent_session_id,
+            set_session_id,
+        )
 
         set_cognitive_state(self.cognitive_state)
         set_session_id(self._session_id)
+        # PR-F (2026-05-21) — sub-agent lineage. When this loop was
+        # spawned via the OpenClaw spawn pattern, ``_parent_session_key``
+        # holds the parent's session identifier; bind it to the
+        # ContextVar so the episodic recorder can stamp
+        # ``Episode.parent_session_id`` for cross-session attribution.
+        # Empty for top-level loops.
+        set_parent_session_id(self._parent_session_key)
         await self._emit_cognitive(
             HookEvent.COGNITIVE_PERCEIVE,
             user_input=user_input,

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -466,8 +466,11 @@ class AgenticLoop:
         # ``_session_id`` uuid). Bind it to the ContextVar so the
         # episodic recorder can stamp ``Episode.parent_session_key``
         # for cross-session attribution. Empty for top-level loops.
-        # Subprocess sub-agents (SubAgentManager → WorkerRequest path)
-        # don't yet forward this value; future PR for that plumbing.
+        # TODO(PR-F-followup): subprocess sub-agents (SubAgentManager
+        # → WorkerRequest → worker.py path) don't forward this value;
+        # child Episodes record empty. WorkerRequest needs a
+        # ``parent_session_key`` field + worker.py needs to honour it
+        # before spawning the child AgenticLoop.
         set_parent_session_key(self._parent_session_key)
         await self._emit_cognitive(
             HookEvent.COGNITIVE_PERCEIVE,

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -453,19 +453,22 @@ class AgenticLoop:
         # in the same task are not a documented use case.
         from core.agent.cognitive_state_ctx import (
             set_cognitive_state,
-            set_parent_session_id,
+            set_parent_session_key,
             set_session_id,
         )
 
         set_cognitive_state(self.cognitive_state)
         set_session_id(self._session_id)
         # PR-F (2026-05-21) — sub-agent lineage. When this loop was
-        # spawned via the OpenClaw spawn pattern, ``_parent_session_key``
-        # holds the parent's session identifier; bind it to the
-        # ContextVar so the episodic recorder can stamp
-        # ``Episode.parent_session_id`` for cross-session attribution.
-        # Empty for top-level loops.
-        set_parent_session_id(self._parent_session_key)
+        # spawned via the OpenClaw in-process spawn pattern,
+        # ``_parent_session_key`` holds the parent's routing key
+        # (e.g. ``"subject:foo:bar"`` — NOT the parent's
+        # ``_session_id`` uuid). Bind it to the ContextVar so the
+        # episodic recorder can stamp ``Episode.parent_session_key``
+        # for cross-session attribution. Empty for top-level loops.
+        # Subprocess sub-agents (SubAgentManager → WorkerRequest path)
+        # don't yet forward this value; future PR for that plumbing.
+        set_parent_session_key(self._parent_session_key)
         await self._emit_cognitive(
             HookEvent.COGNITIVE_PERCEIVE,
             user_input=user_input,

--- a/core/memory/episodic.py
+++ b/core/memory/episodic.py
@@ -56,7 +56,14 @@ EPISODE_LOG_MAX_ROWS = 1000
 
 @dataclass
 class Episode:
-    """One row in the episodic ledger."""
+    """One row in the episodic ledger.
+
+    PR-F (2026-05-21) — added ``parent_session_id`` for sub-agent
+    lineage. Empty string = top-level loop; otherwise the parent
+    AgenticLoop's ``session_id`` so cross-session attribution can
+    group child rows under the parent. Defaulted (not required) so
+    older readers + tests that hand-construct Episodes still work.
+    """
 
     timestamp_ns: int
     session_id: str
@@ -67,6 +74,7 @@ class Episode:
     error: str | None
     duration_ms: float
     cognitive_state: dict[str, Any] = field(default_factory=dict)
+    parent_session_id: str = ""
 
     def to_jsonl(self) -> str:
         """Serialize to a single JSONL line (no trailing newline)."""

--- a/core/memory/episodic.py
+++ b/core/memory/episodic.py
@@ -58,11 +58,17 @@ EPISODE_LOG_MAX_ROWS = 1000
 class Episode:
     """One row in the episodic ledger.
 
-    PR-F (2026-05-21) — added ``parent_session_id`` for sub-agent
-    lineage. Empty string = top-level loop; otherwise the parent
-    AgenticLoop's ``session_id`` so cross-session attribution can
-    group child rows under the parent. Defaulted (not required) so
-    older readers + tests that hand-construct Episodes still work.
+    PR-F (2026-05-21) — added ``parent_session_key`` for sub-agent
+    lineage. Empty string = top-level loop; otherwise the parent's
+    OpenClaw routing key (the AgenticLoop ``_parent_session_key``
+    constructor kwarg — e.g. ``"subject:foo:bar"``, NOT a uuid).
+    Defaulted (not required) so older readers + tests that hand-
+    construct Episodes still work. NOTE: subprocess sub-agents
+    spawned via ``SubAgentManager → WorkerRequest`` do not yet
+    forward this value; their child Episodes record ``""``. The
+    in-process spawn path (``parent_session_key`` constructor kwarg
+    on AgenticLoop) is fully wired. See PR-F CHANGELOG for the
+    follow-up scope.
     """
 
     timestamp_ns: int
@@ -74,7 +80,7 @@ class Episode:
     error: str | None
     duration_ms: float
     cognitive_state: dict[str, Any] = field(default_factory=dict)
-    parent_session_id: str = ""
+    parent_session_key: str = ""
 
     def to_jsonl(self) -> str:
         """Serialize to a single JSONL line (no trailing newline)."""

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -408,7 +408,11 @@ def build_hooks(
     def _reg_episodic_memory() -> None:
         import time
 
-        from core.agent.cognitive_state_ctx import get_cognitive_state, get_session_id
+        from core.agent.cognitive_state_ctx import (
+            get_cognitive_state,
+            get_parent_session_id,
+            get_session_id,
+        )
         from core.memory.episodic import Episode, _summarise_tool_input, get_episodic_store
 
         store = get_episodic_store()
@@ -426,6 +430,13 @@ def build_hooks(
             state = get_cognitive_state()
             snapshot = state.to_snapshot() if state is not None else {}
             session_id = get_session_id()
+            # PR-F (2026-05-21) — sub-agent lineage. Empty string for
+            # top-level loops; non-empty when the active loop was
+            # spawned via the OpenClaw spawn pattern. Reader for the
+            # PR-E confidence-trajectory aggregator: an Episode's
+            # ``parent_session_id`` lets cross-session attribution
+            # group child rows under the parent's session_id.
+            parent_session_id = get_parent_session_id()
             round_raw = snapshot.get("round_count", 0)
             round_count = round_raw if isinstance(round_raw, int) else 0
             input_head_arg = tool_input if isinstance(tool_input, dict | str) else None
@@ -439,6 +450,7 @@ def build_hooks(
                 error=error,
                 duration_ms=float(data.get("duration_ms", 0.0)),
                 cognitive_state=snapshot,
+                parent_session_id=parent_session_id,
             )
             try:
                 store.append(episode)

--- a/core/wiring/bootstrap.py
+++ b/core/wiring/bootstrap.py
@@ -410,7 +410,7 @@ def build_hooks(
 
         from core.agent.cognitive_state_ctx import (
             get_cognitive_state,
-            get_parent_session_id,
+            get_parent_session_key,
             get_session_id,
         )
         from core.memory.episodic import Episode, _summarise_tool_input, get_episodic_store
@@ -434,9 +434,13 @@ def build_hooks(
             # top-level loops; non-empty when the active loop was
             # spawned via the OpenClaw spawn pattern. Reader for the
             # PR-E confidence-trajectory aggregator: an Episode's
-            # ``parent_session_id`` lets cross-session attribution
-            # group child rows under the parent's session_id.
-            parent_session_id = get_parent_session_id()
+            # ``parent_session_key`` lets cross-session attribution
+            # group child rows under the spawning parent. NOTE: the
+            # value is the OpenClaw *routing key* (e.g.
+            # ``"subject:foo:bar"``), not a uuid; an aggregator that
+            # wants uuid-based linkage needs a future PR plumbing
+            # parent ``_session_id`` through WorkerRequest.
+            parent_session_key = get_parent_session_key()
             round_raw = snapshot.get("round_count", 0)
             round_count = round_raw if isinstance(round_raw, int) else 0
             input_head_arg = tool_input if isinstance(tool_input, dict | str) else None
@@ -450,7 +454,7 @@ def build_hooks(
                 error=error,
                 duration_ms=float(data.get("duration_ms", 0.0)),
                 cognitive_state=snapshot,
-                parent_session_id=parent_session_id,
+                parent_session_key=parent_session_key,
             )
             try:
                 store.append(episode)

--- a/tests/test_subagent_lineage.py
+++ b/tests/test_subagent_lineage.py
@@ -1,7 +1,7 @@
 """PR-F — sub-agent state propagation invariants.
 
-Pins the new ``parent_session_id`` ContextVar pair, the
-``Episode.parent_session_id`` field, the bootstrap hook reader, and
+Pins the new ``parent_session_key`` ContextVar pair, the
+``Episode.parent_session_key`` field, the bootstrap hook reader, and
 the AgenticLoop wire-up so child Episode rows carry the parent's
 session id for cross-session attribution (PR-E aggregator dependency).
 
@@ -16,8 +16,8 @@ from pathlib import Path
 
 import pytest
 from core.agent.cognitive_state_ctx import (
-    get_parent_session_id,
-    set_parent_session_id,
+    get_parent_session_key,
+    set_parent_session_key,
 )
 from core.memory.episodic import Episode, EpisodicStore
 
@@ -26,50 +26,50 @@ from core.memory.episodic import Episode, EpisodicStore
 # ---------------------------------------------------------------------------
 
 
-def test_parent_session_id_default_is_empty() -> None:
+def test_parent_session_key_default_is_empty() -> None:
     """Unset ContextVar reads must be safe (not raise) — hooks may
     fire outside the agentic loop (e.g. background tool invocation)
     and top-level loops have no parent."""
     # The default state in a fresh asyncio Context is "", but in
     # this test process the var may have been bound by a previous
     # test. Reset to baseline before asserting.
-    set_parent_session_id("")
-    assert get_parent_session_id() == ""
+    set_parent_session_key("")
+    assert get_parent_session_key() == ""
 
 
-def test_parent_session_id_set_get_roundtrip() -> None:
-    set_parent_session_id("s-parent-001")
+def test_parent_session_key_set_get_roundtrip() -> None:
+    set_parent_session_key("s-parent-001")
     try:
-        assert get_parent_session_id() == "s-parent-001"
+        assert get_parent_session_key() == "s-parent-001"
     finally:
-        set_parent_session_id("")
+        set_parent_session_key("")
 
 
-def test_parent_session_id_paired_get_set_exist() -> None:
+def test_parent_session_key_paired_get_set_exist() -> None:
     """CLAUDE.md ContextVar-injection rule — every getter pairs with
     a setter in the same module. Pin both names so a refactor that
     drops one surfaces here."""
     from core.agent import cognitive_state_ctx
 
-    assert hasattr(cognitive_state_ctx, "get_parent_session_id")
-    assert hasattr(cognitive_state_ctx, "set_parent_session_id")
+    assert hasattr(cognitive_state_ctx, "get_parent_session_key")
+    assert hasattr(cognitive_state_ctx, "set_parent_session_key")
     # Both names are in __all__ so external callers can import them.
-    assert "get_parent_session_id" in cognitive_state_ctx.__all__
-    assert "set_parent_session_id" in cognitive_state_ctx.__all__
+    assert "get_parent_session_key" in cognitive_state_ctx.__all__
+    assert "set_parent_session_key" in cognitive_state_ctx.__all__
 
 
 # ---------------------------------------------------------------------------
-# Episode dataclass — parent_session_id field
+# Episode dataclass — parent_session_key field
 # ---------------------------------------------------------------------------
 
 
-def test_episode_has_parent_session_id_field() -> None:
+def test_episode_has_parent_session_key_field() -> None:
     """Defaults to empty string so older readers + hand-constructed
     Episodes don't break."""
     from dataclasses import fields
 
     field_names = {f.name for f in fields(Episode)}
-    assert "parent_session_id" in field_names
+    assert "parent_session_key" in field_names
     ep = Episode(
         timestamp_ns=1,
         session_id="s-child",
@@ -80,10 +80,10 @@ def test_episode_has_parent_session_id_field() -> None:
         error=None,
         duration_ms=0.0,
     )
-    assert ep.parent_session_id == ""
+    assert ep.parent_session_key == ""
 
 
-def test_episode_jsonl_roundtrip_includes_parent_session_id() -> None:
+def test_episode_jsonl_roundtrip_includes_parent_session_key() -> None:
     ep = Episode(
         timestamp_ns=12345,
         session_id="s-child",
@@ -93,13 +93,13 @@ def test_episode_jsonl_roundtrip_includes_parent_session_id() -> None:
         success=True,
         error=None,
         duration_ms=10.0,
-        parent_session_id="s-parent-xyz",
+        parent_session_key="s-parent-xyz",
     )
     payload = json.loads(ep.to_jsonl())
-    assert payload["parent_session_id"] == "s-parent-xyz"
+    assert payload["parent_session_key"] == "s-parent-xyz"
 
 
-def test_episode_store_persists_parent_session_id(tmp_path: Path) -> None:
+def test_episode_store_persists_parent_session_key(tmp_path: Path) -> None:
     """End-to-end: store.append → file → store.recent recovers the
     field. Without this, the parent linkage would be writeable but
     not readable, half-disconnecting the attribution path."""
@@ -114,20 +114,20 @@ def test_episode_store_persists_parent_session_id(tmp_path: Path) -> None:
         success=True,
         error=None,
         duration_ms=0.0,
-        parent_session_id="s-parent-abc",
+        parent_session_key="s-parent-abc",
     )
     store.append(ep)
     recovered = store.recent(limit=10)
     assert len(recovered) == 1
-    assert recovered[0].parent_session_id == "s-parent-abc"
+    assert recovered[0].parent_session_key == "s-parent-abc"
 
 
 def test_episode_legacy_rows_without_parent_id_still_parse(tmp_path: Path) -> None:
     """Older JSONL rows (written before PR-F) lack the
-    ``parent_session_id`` key. recent() must still return them with
+    ``parent_session_key`` key. recent() must still return them with
     the default empty string — not skip them."""
     path = tmp_path / "episodes.jsonl"
-    # Hand-write a row without parent_session_id (legacy schema)
+    # Hand-write a row without parent_session_key (legacy schema)
     legacy_row = {
         "timestamp_ns": 1,
         "session_id": "s-legacy",
@@ -142,27 +142,27 @@ def test_episode_legacy_rows_without_parent_id_still_parse(tmp_path: Path) -> No
     path.write_text(json.dumps(legacy_row) + "\n", encoding="utf-8")
     store = EpisodicStore(path=path)
     rows = store.recent()
-    # Legacy row parses; parent_session_id defaults to "".
+    # Legacy row parses; parent_session_key defaults to "".
     assert len(rows) == 1
     assert rows[0].session_id == "s-legacy"
-    assert rows[0].parent_session_id == ""
+    assert rows[0].parent_session_key == ""
 
 
 # ---------------------------------------------------------------------------
-# Bootstrap hook reads the parent_session_id ContextVar
+# Bootstrap hook reads the parent_session_key ContextVar
 # ---------------------------------------------------------------------------
 
 
-def test_bootstrap_handler_reads_parent_session_id() -> None:
+def test_bootstrap_handler_reads_parent_session_key() -> None:
     """Anti-disconnection — the bootstrap TOOL_EXEC_ENDED handler
-    must consult ``get_parent_session_id`` so the value plumbs into
+    must consult ``get_parent_session_key`` so the value plumbs into
     Episode. Source-pin so a refactor that drops the read surfaces
     here, not at runtime."""
     from core.wiring import bootstrap
 
     src = inspect.getsource(bootstrap)
-    assert "get_parent_session_id" in src
-    assert "parent_session_id=parent_session_id" in src
+    assert "get_parent_session_key" in src
+    assert "parent_session_key=parent_session_key" in src
 
 
 # ---------------------------------------------------------------------------
@@ -170,14 +170,14 @@ def test_bootstrap_handler_reads_parent_session_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_agentic_loop_binds_parent_session_id_from_parent_key() -> None:
+def test_agentic_loop_binds_parent_session_key_from_parent_key() -> None:
     """PR-D Phase 1 extracted session-start signals into a helper.
     The PR-F lineage bind must live in that same helper so a sub-
     agent's first round sees the parent ContextVar bound."""
     from core.agent.loop.agent_loop import AgenticLoop
 
     src = inspect.getsource(AgenticLoop._emit_session_start_signals)
-    assert "set_parent_session_id(self._parent_session_key)" in src
+    assert "set_parent_session_key(self._parent_session_key)" in src
 
 
 # ---------------------------------------------------------------------------
@@ -202,10 +202,10 @@ def test_agentic_loop_init_accepts_parent_session_key() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _reset_parent_session_id() -> None:
+def _reset_parent_session_key() -> None:
     """ContextVar state can leak across tests in the same task.
     Reset to default before each test so per-test assertions about
     the empty default are deterministic."""
-    set_parent_session_id("")
+    set_parent_session_key("")
     yield
-    set_parent_session_id("")
+    set_parent_session_key("")

--- a/tests/test_subagent_lineage.py
+++ b/tests/test_subagent_lineage.py
@@ -1,0 +1,211 @@
+"""PR-F — sub-agent state propagation invariants.
+
+Pins the new ``parent_session_id`` ContextVar pair, the
+``Episode.parent_session_id`` field, the bootstrap hook reader, and
+the AgenticLoop wire-up so child Episode rows carry the parent's
+session id for cross-session attribution (PR-E aggregator dependency).
+
+Concern #3 from the post-sprint frontier matrix.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from core.agent.cognitive_state_ctx import (
+    get_parent_session_id,
+    set_parent_session_id,
+)
+from core.memory.episodic import Episode, EpisodicStore
+
+# ---------------------------------------------------------------------------
+# ContextVar pair
+# ---------------------------------------------------------------------------
+
+
+def test_parent_session_id_default_is_empty() -> None:
+    """Unset ContextVar reads must be safe (not raise) — hooks may
+    fire outside the agentic loop (e.g. background tool invocation)
+    and top-level loops have no parent."""
+    # The default state in a fresh asyncio Context is "", but in
+    # this test process the var may have been bound by a previous
+    # test. Reset to baseline before asserting.
+    set_parent_session_id("")
+    assert get_parent_session_id() == ""
+
+
+def test_parent_session_id_set_get_roundtrip() -> None:
+    set_parent_session_id("s-parent-001")
+    try:
+        assert get_parent_session_id() == "s-parent-001"
+    finally:
+        set_parent_session_id("")
+
+
+def test_parent_session_id_paired_get_set_exist() -> None:
+    """CLAUDE.md ContextVar-injection rule — every getter pairs with
+    a setter in the same module. Pin both names so a refactor that
+    drops one surfaces here."""
+    from core.agent import cognitive_state_ctx
+
+    assert hasattr(cognitive_state_ctx, "get_parent_session_id")
+    assert hasattr(cognitive_state_ctx, "set_parent_session_id")
+    # Both names are in __all__ so external callers can import them.
+    assert "get_parent_session_id" in cognitive_state_ctx.__all__
+    assert "set_parent_session_id" in cognitive_state_ctx.__all__
+
+
+# ---------------------------------------------------------------------------
+# Episode dataclass — parent_session_id field
+# ---------------------------------------------------------------------------
+
+
+def test_episode_has_parent_session_id_field() -> None:
+    """Defaults to empty string so older readers + hand-constructed
+    Episodes don't break."""
+    from dataclasses import fields
+
+    field_names = {f.name for f in fields(Episode)}
+    assert "parent_session_id" in field_names
+    ep = Episode(
+        timestamp_ns=1,
+        session_id="s-child",
+        round=0,
+        tool_name="t",
+        tool_input_head="",
+        success=True,
+        error=None,
+        duration_ms=0.0,
+    )
+    assert ep.parent_session_id == ""
+
+
+def test_episode_jsonl_roundtrip_includes_parent_session_id() -> None:
+    ep = Episode(
+        timestamp_ns=12345,
+        session_id="s-child",
+        round=2,
+        tool_name="bash",
+        tool_input_head="ls",
+        success=True,
+        error=None,
+        duration_ms=10.0,
+        parent_session_id="s-parent-xyz",
+    )
+    payload = json.loads(ep.to_jsonl())
+    assert payload["parent_session_id"] == "s-parent-xyz"
+
+
+def test_episode_store_persists_parent_session_id(tmp_path: Path) -> None:
+    """End-to-end: store.append → file → store.recent recovers the
+    field. Without this, the parent linkage would be writeable but
+    not readable, half-disconnecting the attribution path."""
+    path = tmp_path / "episodes.jsonl"
+    store = EpisodicStore(path=path)
+    ep = Episode(
+        timestamp_ns=1,
+        session_id="s-child",
+        round=0,
+        tool_name="bash",
+        tool_input_head="",
+        success=True,
+        error=None,
+        duration_ms=0.0,
+        parent_session_id="s-parent-abc",
+    )
+    store.append(ep)
+    recovered = store.recent(limit=10)
+    assert len(recovered) == 1
+    assert recovered[0].parent_session_id == "s-parent-abc"
+
+
+def test_episode_legacy_rows_without_parent_id_still_parse(tmp_path: Path) -> None:
+    """Older JSONL rows (written before PR-F) lack the
+    ``parent_session_id`` key. recent() must still return them with
+    the default empty string — not skip them."""
+    path = tmp_path / "episodes.jsonl"
+    # Hand-write a row without parent_session_id (legacy schema)
+    legacy_row = {
+        "timestamp_ns": 1,
+        "session_id": "s-legacy",
+        "round": 0,
+        "tool_name": "t",
+        "tool_input_head": "",
+        "success": True,
+        "error": None,
+        "duration_ms": 0.0,
+        "cognitive_state": {},
+    }
+    path.write_text(json.dumps(legacy_row) + "\n", encoding="utf-8")
+    store = EpisodicStore(path=path)
+    rows = store.recent()
+    # Legacy row parses; parent_session_id defaults to "".
+    assert len(rows) == 1
+    assert rows[0].session_id == "s-legacy"
+    assert rows[0].parent_session_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap hook reads the parent_session_id ContextVar
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_handler_reads_parent_session_id() -> None:
+    """Anti-disconnection — the bootstrap TOOL_EXEC_ENDED handler
+    must consult ``get_parent_session_id`` so the value plumbs into
+    Episode. Source-pin so a refactor that drops the read surfaces
+    here, not at runtime."""
+    from core.wiring import bootstrap
+
+    src = inspect.getsource(bootstrap)
+    assert "get_parent_session_id" in src
+    assert "parent_session_id=parent_session_id" in src
+
+
+# ---------------------------------------------------------------------------
+# AgenticLoop wires the parent key into the ContextVar
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_loop_binds_parent_session_id_from_parent_key() -> None:
+    """PR-D Phase 1 extracted session-start signals into a helper.
+    The PR-F lineage bind must live in that same helper so a sub-
+    agent's first round sees the parent ContextVar bound."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    src = inspect.getsource(AgenticLoop._emit_session_start_signals)
+    assert "set_parent_session_id(self._parent_session_key)" in src
+
+
+# ---------------------------------------------------------------------------
+# AgenticLoop constructor preserves parent_session_key kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_loop_init_accepts_parent_session_key() -> None:
+    """The constructor's parent_session_key kwarg already existed;
+    pin it so a future refactor doesn't drop the entry point the
+    sub-agent spawner relies on."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    sig = inspect.signature(AgenticLoop.__init__)
+    assert "parent_session_key" in sig.parameters
+    assert sig.parameters["parent_session_key"].default == ""
+
+
+# ---------------------------------------------------------------------------
+# Fixture isolation — reset ContextVar between tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_parent_session_id() -> None:
+    """ContextVar state can leak across tests in the same task.
+    Reset to default before each test so per-test assertions about
+    the empty default are deterministic."""
+    set_parent_session_id("")
+    yield
+    set_parent_session_id("")

--- a/uv.lock
+++ b/uv.lock
@@ -1190,7 +1190,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.23"
+version = "0.99.24"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Closes the PR-F follow-up gap. Subprocess sub-agents now carry both `parent_session_key` (routing key) and a new `parent_session_id` (parent's `_session_id` uuid) end-to-end. Pre-fix, subprocess children recorded `parent_session_key=\"\"` in their Episodes and had no notion of the parent's uuid at all — only the in-process spawn path carried lineage.

## Why

Concern #3 from the cognitive-loop-uplift frontier matrix (PR-F-followup tag, recorded as `TODO(PR-F-followup)` in `cognitive_state_ctx.py:44`, `agent_loop.py:469`). The PR-E confidence-trajectory aggregator needs both:

- `parent_session_key` — group child Episodes by spawning parent's routing key
- `parent_session_id` — pinpoint a single parent invocation (uuid)

Without the uuid, an aggregator that wants to attribute a child's behavior change to one specific parent run has no key to join on.

## Changes

| File | Change |
|------|--------|
| `core/agent/cognitive_state_ctx.py` | New `get/set_parent_session_id` ContextVar pair + `__all__` |
| `core/agent/loop/agent_loop.py` | AgenticLoop `parent_session_id` kwarg + `set_parent_session_id` bind in session-start |
| `core/memory/episodic.py` | `Episode.parent_session_id` field (defaulted) |
| `core/wiring/bootstrap.py` | TOOL_EXEC_ENDED handler reads + stamps `parent_session_id` on Episodes |
| `core/agent/worker.py` | `WorkerRequest.parent_session_key` + `parent_session_id` fields (defaulted, backwards-compat from_dict); `_run_agentic` threads both into child AgenticLoop |
| `core/agent/sub_agent.py` | `_build_worker_request` reads `get_session_id()` (parent's uuid via ContextVar) + `self._parent_session_key` (construction kwarg), populates WorkerRequest |
| `tests/test_subagent_lineage_subprocess.py` | 17 new invariants |
| `CHANGELOG.md` | `[Unreleased]` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Subprocess parent_session_key threading | Implemented | WorkerRequest field + worker.py kwarg + SubAgentManager populate |
| Subprocess parent_session_id (uuid) threading | Implemented | new ContextVar + new WorkerRequest field + new AgenticLoop kwarg + Episode field |
| Same-task A→B→A Token reset | Deferred | Separate PR; TODO line preserved in `cognitive_state_ctx.py` |

## Verification

- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/` clean
- [x] `mypy core/ plugins/` clean (0 issues, 362 source files)
- [x] Full suite passes — 5403 collected (5386 pre-PR + 17 new), exit 0 locally
- [x] Targeted: `test_subagent_lineage.py` + `test_subagent_lineage_subprocess.py` + `test_episodic_memory.py` + `test_cognitive_state_and_telemetry.py` + `test_subagent_announce.py` + `test_agentic_loop.py` + `test_worker.py` — 197/197 pass

## Reference

Concern #3 follow-up from cognitive-loop-uplift sprint frontier matrix. PR-F (#1385) wired in-process; this PR completes the subprocess thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)