### PR TITLE
feat(self-improving-loop): PR-OPS-2a — /self-improving run + propose/apply split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,12 @@ functional change.
   only — show the mutation, NO write), `--n N` (1–10 iterations,
   default 1), `--target-kind X` (filter — skip iteration if the LLM
   proposes a different SoT kind than requested). (3) Per-iteration
-  confirmation prompt — `y` apply, `N`/empty/Ctrl-D reject (writes a
+  confirmation prompt — `y` apply, `N`/empty reject (writes a
   `kind=rejected` audit row for mutator-LLM learning signal), `d`
-  show diff and re-prompt, `s` show full rationale and re-prompt.
-  EOF/KeyboardInterrupt → abort breaks the iteration loop cleanly.
+  show diff and re-prompt, `s` show full rationale and re-prompt,
+  EOF/Ctrl-D/KeyboardInterrupt → abort breaks the iteration loop
+  cleanly *without* writing a rejection row (the abort is the
+  operator's intent to stop, not a verdict on the proposal).
   (4) Static text pre-flight block surfaces mutator model + source +
   target_kind filter + iterations + mode + harness label
   (no-op for now — PR-OPS-2b wires autoresearch/petri_raw harness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,46 @@ functional change.
 
 ### Added
 
+- **PR-OPS-2a — `/self-improving run` slash + propose/apply split.**
+  Second slice of the self-improving-loop UX foundation. PR-OPS-1
+  wired the read-only `/self-improving status` surface; PR-OPS-2a
+  adds the *write* surface — operators can now drive one or more
+  mutation iterations from the REPL with per-iteration confirmation,
+  WITHOUT knowing internal module paths. Changes: (1) splits the
+  monolithic `SelfImprovingLoopRunner.run_once()` into `propose()`
+  (build context + LLM call + parse, no SoT write) and
+  `apply_proposal(proposal)` (write SoT + audit log + optional
+  rerun) — `run_once()` becomes a backward-compat wrapper composing
+  the two so existing callers (autoresearch self-improving loop)
+  see no change. The new `Proposal` dataclass exports
+  `mutation` + `target_sections` + `original_sections` (rollback
+  snapshot) + `baseline_fitness` (UI convenience). (2) Wires
+  `/self-improving run` with three flags: `--dry-run` (propose
+  only — show the mutation, NO write), `--n N` (1–10 iterations,
+  default 1), `--target-kind X` (filter — skip iteration if the LLM
+  proposes a different SoT kind than requested). (3) Per-iteration
+  confirmation prompt — `y` apply, `N`/empty/Ctrl-D reject (writes a
+  `kind=rejected` audit row for mutator-LLM learning signal), `d`
+  show diff and re-prompt, `s` show full rationale and re-prompt.
+  EOF/KeyboardInterrupt → abort breaks the iteration loop cleanly.
+  (4) Static text pre-flight block surfaces mutator model + source +
+  target_kind filter + iterations + mode + harness label
+  (no-op for now — PR-OPS-2b wires autoresearch/petri_raw harness
+  selection). (5) `run` removed from the deferred-action hint;
+  remaining `history`/`rollback`/`config` still print the design-
+  doc pointer with the updated `PR-OPS-2b/3` tag. 27 invariant tests
+  pin propose/apply split (propose() does NOT write SoT or audit
+  log, apply_proposal() does both, run_once() composes them
+  observationally), Proposal in `__all__`, full flag-parser surface
+  (defaults / --dry-run / --n parsing both `--n N` and `--n=N` /
+  --n out-of-range / 5 valid --target-kind values / invalid
+  --target-kind / unknown flag), dispatcher routing (`run` →
+  `_cmd_run` with the trailing tokens), --dry-run skips
+  apply_proposal, --target-kind=tool_policy + prompt-kind LLM →
+  skip iteration with warning, y/N/abort decisions, abort during
+  multi-iteration breaks the loop, propose-failure breaks the
+  loop, and rejection writes a kind=rejected audit row.
+
 - **PR-OPS-1 — self-improving loop operator-facing surface (slash
   `status` + design doc + frontmatter parity fix).** First slice of
   the multi-PR self-improving-loop UX foundation. Pre-PR the closed

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -38,8 +38,11 @@ __all__ = ["cmd_self_improving"]
 
 
 _HISTORY_DEFAULT_N = 5
-_KNOWN_ACTIONS = frozenset({"status", "run", "history", "rollback", "config"})
+_RUN_DEFERRED_ACTIONS = frozenset({"history", "rollback", "config"})
+_KNOWN_ACTIONS = frozenset({"status", "run"}) | _RUN_DEFERRED_ACTIONS
 _DESIGN_DOC = "docs/plans/2026-05-21-self-improving-loop-ux.md"
+_RUN_DEFAULT_ITERATIONS = 1
+_RUN_MAX_ITERATIONS = 10
 
 
 def cmd_self_improving(args: str) -> None:
@@ -55,10 +58,14 @@ def cmd_self_improving(args: str) -> None:
         _cmd_status()
         return
 
-    if action in _KNOWN_ACTIONS:
+    if action == "run":
+        _cmd_run(parts[1:])
+        return
+
+    if action in _RUN_DEFERRED_ACTIONS:
         console.print()
         console.print(
-            f"  [warning]/{action} is reserved for PR-OPS-2/3[/warning] — "
+            f"  [warning]/{action} is reserved for PR-OPS-2b/3[/warning] — "
             f"see [muted]{_DESIGN_DOC}[/muted]"
         )
         console.print()
@@ -67,8 +74,8 @@ def cmd_self_improving(args: str) -> None:
     console.print()
     console.print(f"  [warning]Unknown action: /self-improving {action}[/warning]")
     console.print(
-        "  [muted]Available now: [/muted]status   "
-        "[muted]Coming PR-OPS-2/3:[/muted] run / history / rollback / config"
+        "  [muted]Available now: [/muted]status / run   "
+        "[muted]Coming PR-OPS-2b/3:[/muted] history / rollback / config"
     )
     console.print()
 
@@ -187,3 +194,294 @@ def _print_audit_row(row: dict[str, Any]) -> None:
         f"{target_kind}.{target_section}  "
         f"[muted]id={mutation_id}[/muted]"
     )
+
+
+# ---------------------------------------------------------------------------
+# ``/self-improving run`` — PR-OPS-2a
+# ---------------------------------------------------------------------------
+
+
+def _cmd_run(opts: list[str]) -> None:
+    """Drive one or more propose/confirm/apply iterations.
+
+    Flags:
+      --dry-run        propose only — show the mutation, NO write
+      --n N            run up to N iterations (default 1, max 10)
+      --target-kind X  filter — abort iteration if the LLM proposes a
+                       different kind; useful when the operator wants
+                       to constrain mutation scope to one SoT
+    """
+    flags = _parse_run_opts(opts)
+    if flags is None:
+        return
+
+    runner = _build_runner()
+    if runner is None:
+        return
+
+    console.print()
+    console.print("  [header]Self-improving loop — run[/header]")
+    _render_preflight(flags)
+    console.print()
+
+    applied = 0
+    rejected = 0
+    for i in range(1, flags["iterations"] + 1):
+        try:
+            proposal = runner.propose()
+        except Exception as exc:
+            console.print(
+                f"  [warning]iteration {i}/{flags['iterations']} — propose failed:[/warning] {exc}"
+            )
+            break
+        if flags["target_kind"] and proposal.mutation.target_kind != flags["target_kind"]:
+            console.print(
+                f"  [warning]iteration {i}/{flags['iterations']} — "
+                f"LLM proposed {proposal.mutation.target_kind!r}, "
+                f"requested {flags['target_kind']!r}; skipping[/warning]"
+            )
+            continue
+
+        _render_proposal(proposal, index=i, total=flags["iterations"])
+
+        if flags["dry_run"]:
+            console.print(
+                "  [muted]--dry-run: proposal NOT applied. "
+                "Re-run without --dry-run to confirm interactively.[/muted]"
+            )
+            console.print()
+            continue
+
+        decision = _prompt_confirmation(proposal)
+        if decision == "apply":
+            try:
+                runner.apply_proposal(proposal)
+                applied += 1
+                console.print(
+                    f"  [success]applied[/success]  id={proposal.mutation.mutation_id[:12]}"
+                )
+            except Exception as exc:
+                console.print(f"  [warning]apply failed:[/warning] {exc}")
+        elif decision == "reject":
+            _record_rejection(runner, proposal)
+            rejected += 1
+            console.print(f"  [muted]rejected[/muted]  id={proposal.mutation.mutation_id[:12]}")
+        else:  # "abort"
+            console.print("  [muted]aborted by user[/muted]")
+            break
+
+        console.print()
+
+    console.print(f"  [muted]summary:[/muted] applied={applied}  rejected={rejected}")
+    console.print()
+
+
+def _parse_run_opts(opts: list[str]) -> dict[str, Any] | None:
+    """Parse the ``--dry-run`` / ``--n`` / ``--target-kind`` flags.
+
+    Returns ``None`` (after printing an error) on invalid input so
+    the slash exits cleanly. Defaults: ``iterations=1``,
+    ``target_kind=""`` (no filter), ``dry_run=False``.
+    """
+    dry_run = False
+    iterations = _RUN_DEFAULT_ITERATIONS
+    target_kind = ""
+    i = 0
+    while i < len(opts):
+        tok = opts[i]
+        if tok == "--dry-run":
+            dry_run = True
+        elif tok == "--n":
+            if i + 1 >= len(opts):
+                console.print("  [warning]--n requires a value[/warning]")
+                return None
+            try:
+                iterations = int(opts[i + 1])
+            except ValueError:
+                console.print(f"  [warning]--n: not an int: {opts[i + 1]!r}[/warning]")
+                return None
+            i += 1
+        elif tok.startswith("--n="):
+            try:
+                iterations = int(tok.split("=", 1)[1])
+            except ValueError:
+                console.print(f"  [warning]--n: not an int: {tok!r}[/warning]")
+                return None
+        elif tok == "--target-kind":
+            if i + 1 >= len(opts):
+                console.print("  [warning]--target-kind requires a value[/warning]")
+                return None
+            target_kind = opts[i + 1]
+            i += 1
+        elif tok.startswith("--target-kind="):
+            target_kind = tok.split("=", 1)[1]
+        else:
+            console.print(f"  [warning]unknown flag: {tok!r}[/warning]")
+            return None
+        i += 1
+    if iterations < 1 or iterations > _RUN_MAX_ITERATIONS:
+        console.print(f"  [warning]--n must be 1 ~ {_RUN_MAX_ITERATIONS}[/warning]")
+        return None
+    if target_kind and target_kind not in {
+        "prompt",
+        "tool_policy",
+        "decomposition",
+        "retrieval",
+        "reflection",
+    }:
+        console.print(
+            "  [warning]--target-kind must be one of "
+            "prompt|tool_policy|decomposition|retrieval|reflection[/warning]"
+        )
+        return None
+    return {
+        "dry_run": dry_run,
+        "iterations": iterations,
+        "target_kind": target_kind,
+    }
+
+
+def _build_runner() -> Any | None:
+    """Construct ``SelfImprovingLoopRunner`` with safe defaults.
+
+    Returns ``None`` (after printing an error) on construction
+    failure so the slash exits cleanly. ``rerun_enabled=False``
+    keeps the slash cheap by default — the operator must explicitly
+    run autoresearch separately for a measurement.
+    """
+    try:
+        from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+        return SelfImprovingLoopRunner(
+            rerun_enabled=False,
+            commit_enabled=True,
+        )
+    except Exception as exc:
+        console.print(f"  [warning]runner init failed:[/warning] {exc}")
+        return None
+
+
+def _render_preflight(flags: dict[str, Any]) -> None:
+    """Render the static text pre-flight block.
+
+    PR-OPS-2a (no Rich Panel yet — interactive dashboard lands in
+    PR-OPS-2b). Surfaces the slice of knobs an operator needs to
+    sanity-check before approving a mutation.
+    """
+    target_kind = flags["target_kind"] or "any"
+    mode = "dry-run (no write)" if flags["dry_run"] else "interactive (per-iter confirm)"
+    mutator_model: str = "?"
+    mutator_source: str = "?"
+    try:
+        from core.config.self_improving_loop import load_self_improving_loop_config
+
+        cfg = load_self_improving_loop_config()
+        mutator_model = cfg.mutator.default_model
+        mutator_source = cfg.mutator.source
+    except Exception:
+        # Best-effort UI: missing config falls through to the "?" placeholders.
+        import logging
+
+        logging.getLogger(__name__).debug("mutator config read failed", exc_info=True)
+    console.print()
+    console.print("  [bold]Pre-flight[/bold]")
+    console.print(f"    mutator      [bold]{mutator_model}[/bold]  source={mutator_source}")
+    console.print(f"    target_kind  {target_kind}")
+    console.print(f"    iterations   {flags['iterations']}")
+    console.print(f"    mode         {mode}")
+    console.print("    harness      [muted]no-op (PR-OPS-2b wires autoresearch/petri_raw)[/muted]")
+
+
+def _render_proposal(proposal: Any, *, index: int, total: int) -> None:
+    """Render one Mutation as a confirmation block."""
+    mut = proposal.mutation
+    prev = proposal.target_sections.get(mut.target_section, "")
+    console.print(f"  [header][Self-improving loop — proposal {index}/{total}][/header]")
+    console.print(f"    target_kind     {mut.target_kind}")
+    console.print(f"    target_section  {mut.target_section}")
+    console.print(
+        f"    previous_value  {_clip(prev, 80) if prev else '[muted](new section)[/muted]'}"
+    )
+    console.print(f"    new_value       {_clip(mut.new_value, 80)}")
+    if mut.rationale:
+        console.print(f"    rationale       {_clip(mut.rationale, 200)}")
+    if proposal.baseline_fitness is not None:
+        console.print(f"    baseline_fitness {proposal.baseline_fitness:.4f}  [muted](SoT)[/muted]")
+    if mut.expected_dim:
+        console.print(f"    expected_dim    {dict(mut.expected_dim)}")
+    if mut.rollback_condition:
+        console.print(f"    rollback_cond   {_clip(mut.rollback_condition, 120)}")
+
+
+def _prompt_confirmation(proposal: Any) -> str:
+    """Read one y/N/d/s response. Loops on d/s (auxiliary outputs).
+
+    Returns one of ``"apply"`` / ``"reject"`` / ``"abort"``. EOF /
+    Ctrl-D returns ``"abort"`` so the slash exits cleanly.
+    """
+    while True:
+        try:
+            raw = console.input(
+                "  Apply this mutation? "
+                "[bold]y[/bold]=apply / [bold]N[/bold]=reject / "
+                "d=show-diff / s=show-rationale: "
+            )
+        except (EOFError, KeyboardInterrupt):
+            return "abort"
+        ans = raw.strip().lower()
+        if ans in {"y", "yes"}:
+            return "apply"
+        if ans in {"", "n", "no"}:
+            return "reject"
+        if ans == "d":
+            console.print("    [muted]diff (truncated):[/muted]")
+            prev_val = proposal.target_sections.get(proposal.mutation.target_section, "")
+            console.print(f"      - {_clip(prev_val, 240)}")
+            console.print(f"      + {_clip(proposal.mutation.new_value, 240)}")
+            continue
+        if ans == "s":
+            console.print("    [muted]rationale:[/muted]")
+            console.print(f"      {_clip(proposal.mutation.rationale, 600)}")
+            continue
+        console.print("  [muted]please answer y / N / d / s[/muted]")
+
+
+def _record_rejection(runner: Any, proposal: Any) -> None:
+    """Append a ``kind=rejected`` row to the audit log.
+
+    The operator chose not to apply, but the rejection itself is
+    signal — record it so the mutator LLM can learn (via the next
+    iteration's context) which proposals get rejected and why.
+    Best-effort: failure logged but not surfaced.
+    """
+    import logging
+    import time
+
+    log = logging.getLogger(__name__)
+    audit_path = Path(runner.audit_log_path)
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        "ts": time.time(),
+        "kind": "rejected",
+        "mutation_id": proposal.mutation.mutation_id,
+        "target_kind": proposal.mutation.target_kind,
+        "target_section": proposal.mutation.target_section,
+        "previous_value": proposal.target_sections.get(proposal.mutation.target_section, ""),
+        "new_value": proposal.mutation.new_value,
+        "rationale": proposal.mutation.rationale,
+        "target_dim": proposal.mutation.target_dim,
+        "expected_dim": dict(proposal.mutation.expected_dim),
+        "rollback_condition": proposal.mutation.rollback_condition,
+        "baseline_fitness": proposal.baseline_fitness,
+    }
+    try:
+        with audit_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except OSError:
+        log.warning("audit-log rejection write failed", exc_info=True)
+
+
+def _clip(s: str, n: int) -> str:
+    if len(s) <= n:
+        return s
+    return s[: n - 1] + "…"

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -453,12 +453,23 @@ def _record_rejection(runner: Any, proposal: Any) -> None:
     signal — record it so the mutator LLM can learn (via the next
     iteration's context) which proposals get rejected and why.
     Best-effort: failure logged but not surfaced.
+
+    Codex MCP catch (2026-05-21, PR #1395): the runner's
+    ``audit_log_path`` defaults to ``None`` (lazy resolution — the
+    ``append_audit_log`` helper falls back to
+    ``MUTATION_AUDIT_LOG_PATH``). Mirror that resolution here so
+    ``Path(None)`` never trips on the real slash path where the
+    operator constructs the runner via ``_build_runner`` without
+    passing an audit_log_path.
     """
     import logging
     import time
 
+    from core.self_improving_loop.runner import MUTATION_AUDIT_LOG_PATH
+
     log = logging.getLogger(__name__)
-    audit_path = Path(runner.audit_log_path)
+    raw_path = runner.audit_log_path or MUTATION_AUDIT_LOG_PATH
+    audit_path = Path(raw_path)
     audit_path.parent.mkdir(parents=True, exist_ok=True)
     row = {
         "ts": time.time(),

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -54,6 +54,7 @@ log = logging.getLogger(__name__)
 __all__ = [
     "MUTATION_AUDIT_LOG_PATH",
     "Mutation",
+    "Proposal",
     "RunnerContext",
     "SelfImprovingLoopRunner",
     "apply_mutation",
@@ -129,6 +130,39 @@ class Mutation:
             "rollback_condition": self.rollback_condition,
             "baseline_fitness": baseline_fitness,
         }
+
+
+@dataclass
+class Proposal:
+    """One propose-only result — `propose()` returns this, the caller
+    decides whether to call `apply_proposal()` afterwards.
+
+    PR-OPS-2a (2026-05-21) — splits ``run_once`` into propose/apply
+    halves so the ``/self-improving run`` slash can show the operator
+    the LLM's mutation candidate, wait for ``y/N`` confirmation, then
+    either apply or record a ``kind=rejected`` audit row. Pre-split
+    the only entry was ``run_once`` which built context, called the
+    LLM, AND wrote the SoT in one shot — no confirmation seam.
+    """
+
+    mutation: Mutation
+    """The LLM-proposed mutation."""
+
+    target_sections: dict[str, str] = field(default_factory=dict)
+    """Current SoT contents for ``mutation.target_kind`` — what
+    ``apply_mutation`` mutates. Distinct from ``original_sections``
+    only in identity; both carry the same key/value pairs at propose
+    time, and ``apply_mutation`` mutates ``target_sections`` in place."""
+
+    original_sections: dict[str, str] = field(default_factory=dict)
+    """Frozen pre-apply snapshot for the rollback path. Captured at
+    propose time so a subsequent ``apply_proposal`` failure can
+    restore exactly the pre-mutation state."""
+
+    baseline_fitness: float | None = None
+    """The current baseline.json fitness scalar (if any), surfaced as
+    a convenience for UI rendering — operator wants to see what they
+    are comparing against before approving the mutation."""
 
 
 @dataclass
@@ -754,22 +788,27 @@ class SelfImprovingLoopRunner:
     rerun_enabled: bool = False
     rerun_dry_run: bool = True
 
-    def run_once(self) -> Mutation:
-        """Execute one mutation iteration and return the applied :class:`Mutation`.
+    def propose(self) -> Proposal:
+        """Build context, call the mutator LLM, parse one Mutation.
 
-        The function is the single-iteration unit; callers wrap it in
-        a loop (or schedule it via ``geode schedule``) when they want
-        a multi-round campaign. Each call:
+        Stops BEFORE any SoT write. Returns a :class:`Proposal` the
+        caller can show the operator for confirmation; calling
+        :meth:`apply_proposal` afterwards persists the mutation.
 
-        1. Builds context (baseline + meta-review + current sections).
-        2. Calls the LLM with the system + user prompt.
-        3. Parses + validates the mutation.
-        4. Applies it to the SoT.
-        5. Appends + (optionally) commits the audit log row.
-        6. (Optionally) re-runs autoresearch.
+        Raises :class:`ValueError` on parse / validation failure.
 
-        Raises :class:`ValueError` on parse / validation failure so
-        the caller can decide whether to retry.
+        Steps:
+
+        1. Build context (baseline + meta-review + current sections).
+        2. Call the LLM with the system + user prompt.
+        3. Parse + validate the mutation.
+        4. Load the correct SoT for the parsed ``target_kind`` (kind-
+           aware so a tool_policy mutation reads tool-policy.json, not
+           wrapper-sections.json).
+
+        ``target_sections`` and ``original_sections`` carry identical
+        contents at this point; the latter is the rollback snapshot,
+        the former is what :func:`apply_mutation` mutates in place.
         """
         ctx = build_runner_context()
         user_prompt = _build_user_prompt(ctx)
@@ -790,30 +829,64 @@ class SelfImprovingLoopRunner:
         else:
             target_sections = load_policy(mutation.target_kind)
         original_sections = dict(target_sections)
-        _new_sections, previous_value = apply_mutation(mutation, current_sections=target_sections)
-        # G5b.fix3 (2026-05-20) — atomicity boundary: if the audit log
-        # write fails after the SoT mutation lands, the in-disk state is
-        # silently divergent (SoT advanced, history missing). Roll the
-        # SoT back to ``original_sections`` so the next iteration sees a
-        # consistent state. Best-effort: rollback can itself fail (rare
-        # filesystem outage); we log + re-raise the original exception
-        # so the caller knows the iteration failed.
+        baseline_fitness: float | None = None
+        snapshot = ctx.baseline_snapshot
+        if snapshot is not None:
+            raw_fitness = getattr(snapshot, "fitness", None)
+            if isinstance(raw_fitness, int | float):
+                baseline_fitness = float(raw_fitness)
+        return Proposal(
+            mutation=mutation,
+            target_sections=target_sections,
+            original_sections=original_sections,
+            baseline_fitness=baseline_fitness,
+        )
+
+    def apply_proposal(self, proposal: Proposal) -> Mutation:
+        """Apply a previously-proposed mutation — write SoT, audit
+        log, (optional) git commit, (optional) autoresearch rerun.
+
+        Steps 4-6 of the original ``run_once``. The caller (slash
+        handler / tool / scheduler) is responsible for showing the
+        operator the proposal and gating this method on consent.
+
+        ``proposal.target_sections`` is mutated in place by
+        :func:`apply_mutation`. The G5b.fix3 atomicity boundary stays
+        intact: if the audit-log write fails after the SoT mutation
+        lands, the SoT is rolled back to
+        ``proposal.original_sections`` and the original exception
+        propagates so the caller can retry.
+        """
+        _new_sections, previous_value = apply_mutation(
+            proposal.mutation, current_sections=proposal.target_sections
+        )
         try:
             log_path = append_audit_log(
-                mutation,
+                proposal.mutation,
                 previous_value=previous_value,
                 log_path=self.audit_log_path,
             )
         except OSError as exc:
-            self._rollback_sot(original_sections, mutation=mutation, exc=exc)
+            self._rollback_sot(proposal.original_sections, mutation=proposal.mutation, exc=exc)
             raise
         if self.commit_enabled:
-            _git_commit_audit_log(log_path, mutation=mutation)
+            _git_commit_audit_log(log_path, mutation=proposal.mutation)
         if self.rerun_enabled:
             repo_root = log_path.resolve().parents[1]
             self._invoke_autoresearch(repo_root)
-        self._append_self_improving_loop_index(mutation, previous_value)
-        return mutation
+        self._append_self_improving_loop_index(proposal.mutation, previous_value)
+        return proposal.mutation
+
+    def run_once(self) -> Mutation:
+        """Execute one full propose+apply iteration. Backwards-compat
+        wrapper around :meth:`propose` + :meth:`apply_proposal` so
+        existing callers (and the autoresearch self-improving loop)
+        keep working unchanged.
+
+        Raises :class:`ValueError` on parse / validation failure so
+        the caller can decide whether to retry.
+        """
+        return self.apply_proposal(self.propose())
 
     @staticmethod
     def _rollback_sot(

--- a/tests/test_self_improving_run_slash.py
+++ b/tests/test_self_improving_run_slash.py
@@ -326,6 +326,35 @@ def test_cmd_run_confirm_n_records_rejection(
     assert "rejected" in out
 
 
+def test_cmd_run_confirm_n_with_default_audit_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Codex MCP catch (2026-05-21 PR #1395): the real ``_build_runner``
+    constructs ``SelfImprovingLoopRunner`` without ``audit_log_path``,
+    so it defaults to ``None``. ``_record_rejection`` must fall back
+    to ``MUTATION_AUDIT_LOG_PATH`` rather than crash on
+    ``Path(None)``. Pin the fallback so a refactor that drops it
+    surfaces here."""
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_with_proposal()
+    runner.audit_log_path = None  # default value the real slash uses
+    fake_default = tmp_path / "fallback_mutations.jsonl"
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH",
+        fake_default,
+    )
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    monkeypatch.setattr(self_improving, "_prompt_confirmation", lambda _p: "reject")
+    self_improving._cmd_run([])
+    runner.apply_proposal.assert_not_called()
+    assert fake_default.exists(), "rejection must fall back to MUTATION_AUDIT_LOG_PATH"
+    out = capsys.readouterr().out
+    assert "rejected" in out
+
+
 def test_cmd_run_abort_breaks_loop(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_self_improving_run_slash.py
+++ b/tests/test_self_improving_run_slash.py
@@ -1,0 +1,397 @@
+"""PR-OPS-2a — invariants for ``/self-improving run`` slash + the
+``SelfImprovingLoopRunner.propose`` / ``apply_proposal`` split.
+
+Pins:
+- propose() returns a Proposal but does NOT write to the SoT
+- apply_proposal(propose()) is observationally equivalent to run_once()
+- /self-improving run wires the dispatcher (parses flags, calls
+  propose/apply_proposal, records y/N/abort, runs N iterations)
+- --dry-run skips apply
+- --target-kind filter rejects non-matching proposals
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# propose() / apply_proposal() split — runner.py
+# ---------------------------------------------------------------------------
+
+
+def _stub_llm_response(mutation_dict: dict[str, Any]) -> str:
+    """JSON-shape LLM response the parser accepts."""
+    return json.dumps(mutation_dict)
+
+
+def _build_test_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    target_section: str = "role.intro",
+    new_value: str = "You are improved.",
+    target_kind: str = "prompt",
+) -> Any:
+    """Construct a SelfImprovingLoopRunner with a canned LLM response
+    and a tmp_path-redirected audit log + SoT."""
+    from core.self_improving_loop import runner as runner_mod
+
+    audit_path = tmp_path / "state" / "mutations.jsonl"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _fake_llm(_sys: str, _user: str) -> str:
+        return _stub_llm_response(
+            {
+                "target_section": target_section,
+                "new_value": new_value,
+                "rationale": "test rationale",
+                "target_kind": target_kind,
+            }
+        )
+
+    def _fake_context() -> Any:
+        from core.self_improving_loop.runner import RunnerContext
+
+        return RunnerContext(current_sections={"role.intro": "You are baseline."})
+
+    monkeypatch.setattr(runner_mod, "build_runner_context", _fake_context)
+
+    # Redirect prompt SoT writer + reader for the test.
+    sections_path = tmp_path / "sot" / "wrapper-sections.json"
+    sections_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _fake_write(sections: dict[str, str]) -> None:
+        sections_path.write_text(json.dumps(sections), encoding="utf-8")
+
+    monkeypatch.setattr("autoresearch.train.write_wrapper_prompt_sections", _fake_write)
+
+    return runner_mod.SelfImprovingLoopRunner(
+        llm_call=_fake_llm,
+        commit_enabled=False,
+        rerun_enabled=False,
+        audit_log_path=audit_path,
+    )
+
+
+def test_propose_returns_proposal_with_unmutated_target_sections(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """propose() must build context + parse mutation + load SoT WITHOUT
+    writing. The target_sections dict and original_sections dict carry
+    the same key/value pairs at this point."""
+    runner = _build_test_runner(monkeypatch, tmp_path)
+    proposal = runner.propose()
+    assert proposal.mutation.target_section == "role.intro"
+    assert proposal.mutation.new_value == "You are improved."
+    # original_sections is the pre-write snapshot
+    assert proposal.original_sections == {"role.intro": "You are baseline."}
+    # target_sections starts equal to original
+    assert proposal.target_sections == proposal.original_sections
+    # IDs must differ — apply_mutation mutates target_sections in place
+    assert proposal.target_sections is not proposal.original_sections
+
+
+def test_propose_does_not_write_sot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """propose() must NOT touch the SoT — write path runs only in
+    apply_proposal."""
+    runner = _build_test_runner(monkeypatch, tmp_path)
+    sections_path = tmp_path / "sot" / "wrapper-sections.json"
+    assert not sections_path.exists()
+    runner.propose()
+    assert not sections_path.exists(), "propose() must not write SoT"
+
+
+def test_propose_does_not_write_audit_log(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runner = _build_test_runner(monkeypatch, tmp_path)
+    audit_path = tmp_path / "state" / "mutations.jsonl"
+    assert not audit_path.exists()
+    runner.propose()
+    assert not audit_path.exists(), "propose() must not write audit log"
+
+
+def test_apply_proposal_writes_sot_and_audit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """apply_proposal() writes the SoT, then the audit log."""
+    runner = _build_test_runner(monkeypatch, tmp_path)
+    proposal = runner.propose()
+    sections_path = tmp_path / "sot" / "wrapper-sections.json"
+    audit_path = tmp_path / "state" / "mutations.jsonl"
+    assert not sections_path.exists()
+    assert not audit_path.exists()
+    mutation = runner.apply_proposal(proposal)
+    assert sections_path.exists(), "apply_proposal must write SoT"
+    assert audit_path.exists(), "apply_proposal must write audit log"
+    assert mutation.target_section == "role.intro"
+
+
+def test_run_once_equals_propose_plus_apply(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The backward-compat wrapper composes propose + apply_proposal.
+    Both end states must match."""
+    runner = _build_test_runner(monkeypatch, tmp_path)
+    mutation = runner.run_once()
+    assert mutation.target_section == "role.intro"
+    sections_path = tmp_path / "sot" / "wrapper-sections.json"
+    audit_path = tmp_path / "state" / "mutations.jsonl"
+    assert sections_path.exists()
+    assert audit_path.exists()
+
+
+def test_proposal_in_runner_all_exports() -> None:
+    """``Proposal`` must be exported alongside ``Mutation`` /
+    ``SelfImprovingLoopRunner`` so external callers can type-annotate
+    against it."""
+    from core.self_improving_loop import runner
+
+    assert "Proposal" in runner.__all__
+
+
+# ---------------------------------------------------------------------------
+# /self-improving run — flag parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_run_opts_defaults() -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    flags = _parse_run_opts([])
+    assert flags == {"dry_run": False, "iterations": 1, "target_kind": ""}
+
+
+def test_parse_run_opts_dry_run() -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    flags = _parse_run_opts(["--dry-run"])
+    assert flags is not None
+    assert flags["dry_run"] is True
+
+
+@pytest.mark.parametrize(
+    "tok_seq, expected_n",
+    [(["--n", "5"], 5), (["--n=3"], 3), (["--n", "10"], 10)],
+)
+def test_parse_run_opts_iterations(tok_seq: list[str], expected_n: int) -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    flags = _parse_run_opts(tok_seq)
+    assert flags is not None
+    assert flags["iterations"] == expected_n
+
+
+def test_parse_run_opts_iterations_out_of_range(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    assert _parse_run_opts(["--n", "0"]) is None
+    assert _parse_run_opts(["--n", "11"]) is None
+    out = capsys.readouterr().out
+    assert "1 ~ 10" in out
+
+
+@pytest.mark.parametrize(
+    "kind", ["prompt", "tool_policy", "decomposition", "retrieval", "reflection"]
+)
+def test_parse_run_opts_target_kind_valid(kind: str) -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    flags = _parse_run_opts(["--target-kind", kind])
+    assert flags is not None
+    assert flags["target_kind"] == kind
+
+
+def test_parse_run_opts_target_kind_invalid(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    assert _parse_run_opts(["--target-kind", "nonsense"]) is None
+    out = capsys.readouterr().out
+    assert "must be one of" in out
+
+
+def test_parse_run_opts_unknown_flag_rejected(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from core.cli.commands.self_improving import _parse_run_opts
+
+    assert _parse_run_opts(["--bogus"]) is None
+    out = capsys.readouterr().out
+    assert "unknown flag" in out
+
+
+# ---------------------------------------------------------------------------
+# /self-improving run — dispatch + iteration
+# ---------------------------------------------------------------------------
+
+
+def _stub_runner_with_proposal(
+    target_kind: str = "prompt",
+) -> tuple[Any, Any]:
+    """Build a mock SelfImprovingLoopRunner that returns a canned
+    proposal and tracks apply_proposal calls."""
+    from core.self_improving_loop.runner import Mutation, Proposal
+
+    mutation = Mutation(
+        target_section="role.intro",
+        new_value="improved",
+        rationale="test",
+        target_kind=target_kind,
+    )
+    proposal = Proposal(
+        mutation=mutation,
+        target_sections={"role.intro": "baseline"},
+        original_sections={"role.intro": "baseline"},
+        baseline_fitness=0.7,
+    )
+    runner = MagicMock()
+    runner.audit_log_path = Path("/tmp/dummy.jsonl")  # noqa: S108 — test stub
+    runner.propose.return_value = proposal
+    runner.apply_proposal.return_value = mutation
+    return runner, proposal
+
+
+def test_cmd_run_dry_run_skips_apply(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_with_proposal()
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    self_improving._cmd_run(["--dry-run"])
+    runner.propose.assert_called_once()
+    runner.apply_proposal.assert_not_called()
+    out = capsys.readouterr().out
+    assert "--dry-run" in out
+    assert "improved" in out
+
+
+def test_cmd_run_target_kind_filter_skips_mismatched(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--target-kind=tool_policy with an LLM that proposes 'prompt'
+    must skip the iteration WITHOUT applying."""
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_with_proposal(target_kind="prompt")
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    self_improving._cmd_run(["--target-kind", "tool_policy"])
+    runner.propose.assert_called_once()
+    runner.apply_proposal.assert_not_called()
+    out = capsys.readouterr().out
+    assert "skipping" in out
+
+
+def test_cmd_run_confirm_y_applies(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_with_proposal()
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    monkeypatch.setattr(self_improving, "_prompt_confirmation", lambda _p: "apply")
+    self_improving._cmd_run([])
+    runner.apply_proposal.assert_called_once()
+    out = capsys.readouterr().out
+    assert "applied" in out
+
+
+def test_cmd_run_confirm_n_records_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Rejection must NOT call apply_proposal AND must append a
+    kind=rejected row to the audit log."""
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_with_proposal()
+    audit_path = tmp_path / "mutations.jsonl"
+    runner.audit_log_path = audit_path
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    monkeypatch.setattr(self_improving, "_prompt_confirmation", lambda _p: "reject")
+    self_improving._cmd_run([])
+    runner.apply_proposal.assert_not_called()
+    assert audit_path.exists()
+    rows = [json.loads(line) for line in audit_path.read_text().splitlines() if line]
+    assert any(r["kind"] == "rejected" for r in rows)
+    out = capsys.readouterr().out
+    assert "rejected" in out
+
+
+def test_cmd_run_abort_breaks_loop(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """User-initiated abort (EOF / Ctrl-D) must stop the iteration loop
+    without calling apply_proposal."""
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_with_proposal()
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    monkeypatch.setattr(self_improving, "_prompt_confirmation", lambda _p: "abort")
+    self_improving._cmd_run(["--n", "3"])
+    # Even though --n=3 was requested, abort breaks after the first
+    runner.propose.assert_called_once()
+    runner.apply_proposal.assert_not_called()
+    out = capsys.readouterr().out
+    assert "aborted" in out
+
+
+def test_cmd_run_propose_failure_breaks_loop(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from core.cli.commands import self_improving
+
+    runner = MagicMock()
+    runner.propose.side_effect = ValueError("LLM parse failure")
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    self_improving._cmd_run([])
+    out = capsys.readouterr().out
+    assert "propose failed" in out
+    assert "LLM parse failure" in out
+
+
+# ---------------------------------------------------------------------------
+# Slash dispatch — 'run' routes to _cmd_run
+# ---------------------------------------------------------------------------
+
+
+def test_run_action_dispatches_to_cmd_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.cli.commands import self_improving
+
+    called: list[list[str]] = []
+    monkeypatch.setattr(self_improving, "_cmd_run", lambda opts: called.append(opts))
+    self_improving.cmd_self_improving("run --dry-run --n 2")
+    assert called == [["--dry-run", "--n", "2"]]
+
+
+def test_run_no_longer_in_deferred_actions() -> None:
+    """``/self-improving run`` is wired now — must NOT appear in the
+    deferred-action help hint."""
+    from core.cli.commands.self_improving import (
+        _RUN_DEFAULT_ITERATIONS,
+        _RUN_DEFERRED_ACTIONS,
+        _RUN_MAX_ITERATIONS,
+    )
+
+    assert "run" not in _RUN_DEFERRED_ACTIONS
+    assert _RUN_DEFAULT_ITERATIONS == 1
+    assert _RUN_MAX_ITERATIONS == 10
+
+
+def test_history_still_deferred(capsys: pytest.CaptureFixture[str]) -> None:
+    """The other reserved actions still print the design-doc hint."""
+    from core.cli.commands.self_improving import cmd_self_improving
+
+    cmd_self_improving("history")
+    out = capsys.readouterr().out
+    assert "PR-OPS-2b/3" in out

--- a/tests/test_self_improving_status_slash.py
+++ b/tests/test_self_improving_status_slash.py
@@ -95,15 +95,17 @@ def test_status_action_dispatches_to_status(monkeypatch: pytest.MonkeyPatch) -> 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("action", ["run", "history", "rollback", "config"])
+@pytest.mark.parametrize("action", ["history", "rollback", "config"])
 def test_reserved_actions_emit_design_doc_hint(
     action: str, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """``run`` action was wired in PR-OPS-2a; the remaining three
+    (history/rollback/config) still print the design-doc pointer."""
     from core.cli.commands.self_improving import cmd_self_improving
 
     cmd_self_improving(action)
     out = capsys.readouterr().out
-    assert "PR-OPS-2/3" in out
+    assert "PR-OPS-2b/3" in out
     assert "self-improving-loop-ux.md" in out
 
 


### PR DESCRIPTION
## Summary

Second slice of the self-improving-loop UX foundation. PR-OPS-1 wired the read-only `/self-improving status`; PR-OPS-2a adds the *write* surface — `/self-improving run` with per-iteration confirmation prompt. Splits `SelfImprovingLoopRunner.run_once()` into `propose()` + `apply_proposal()` so a slash/tool can show the operator the LLM's proposal before committing it.

## Why

Pre-PR operators had no way to actually drive a mutation through GEODE without knowing `from core.self_improving_loop import SelfImprovingLoopRunner` and writing Python by hand. `run_once()` also did everything in one shot — no seam to insert confirmation. PR-OPS-2a splits the runner internally + wires the slash externally.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/runner.py` | New `Proposal` dataclass; `propose()` / `apply_proposal()` / `run_once()` (composes both) |
| `core/cli/commands/self_improving.py` | `_cmd_run` action handler with `--dry-run` / `--n N` / `--target-kind X` parsing; confirmation prompt (y/N/d/s/EOF); rejection audit row writer |
| `tests/test_self_improving_run_slash.py` | 27 new invariants |
| `tests/test_self_improving_status_slash.py` | Updated — `run` removed from deferred-action parametrize; hint label updated to `PR-OPS-2b/3` |
| `CHANGELOG.md` | `[Unreleased]` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `propose()` / `apply_proposal()` split | Implemented | Backward-compat `run_once()` composes both |
| `/self-improving run` slash | Implemented | --dry-run / --n N / --target-kind X |
| Per-iteration confirmation (y/N/d/s) | Implemented | EOF/Ctrl-D → abort breaks loop |
| Static text pre-flight block | Implemented | mutator/source/kind/iterations/mode/harness |
| Rich Panel dashboard + sub-pickers | Deferred | PR-OPS-2b |
| Tool `run_self_improving_loop` (NL) | Deferred | PR-OPS-2b |
| 3 profile presets | Deferred | PR-OPS-2b |
| `petri_raw` harness wiring | Deferred | PR-OPS-2b |
| `/self-improving history` + `rollback` + `config` | Deferred | PR-OPS-3 |

## Verification

- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/` clean
- [x] `mypy core/ plugins/` clean (363 source files)
- [x] Full suite — 5449/5449 pass (5422 prior + 27 new), exit 0 locally
- [x] Targeted: `test_self_improving_run_slash` + `test_self_improving_status_slash` + `test_command_registry` + `test_self_improving_loop_gap_fill` + `test_self_improving_loop_config` — all pass

## Reference

Design doc: `docs/plans/2026-05-21-self-improving-loop-ux.md`
Prior slice: PR #1394 (PR-OPS-1)
Karpathy idiom (Mode A): `autoresearch/program.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)