### PR TITLE
feat(self-improving-loop): PR-RATCHET-1 — 5 SoT files in-repo (git-tracked)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,4 +148,11 @@ autoresearch/state/*
 # every applied wrapper-prompt mutation is committed via _git_commit_audit_log.
 # The trailing negation lets `git add autoresearch/state/mutations.jsonl` succeed.
 !autoresearch/state/mutations.jsonl
+# PR-RATCHET-1 (2026-05-21) — 5 mutation SoT JSONs (wrapper-sections /
+# tool-policy / decomposition / retrieval / reflection) moved in-repo
+# from ~/.geode/self-improving-loop/ so `git diff` shows the current
+# mutation state and `git revert` discards a hypothesis. The trailing
+# negation re-includes the whole sot/ subtree under git tracking.
+!autoresearch/state/sot/
+!autoresearch/state/sot/**
 .claude/scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -148,11 +148,13 @@ autoresearch/state/*
 # every applied wrapper-prompt mutation is committed via _git_commit_audit_log.
 # The trailing negation lets `git add autoresearch/state/mutations.jsonl` succeed.
 !autoresearch/state/mutations.jsonl
-# PR-RATCHET-1 (2026-05-21) — 5 mutation SoT JSONs (wrapper-sections /
+# PR-RATCHET-1 (2026-05-21) — 5 mutation-target JSONs (wrapper-sections /
 # tool-policy / decomposition / retrieval / reflection) moved in-repo
 # from ~/.geode/self-improving-loop/ so `git diff` shows the current
-# mutation state and `git revert` discards a hypothesis. The trailing
-# negation re-includes the whole sot/ subtree under git tracking.
-!autoresearch/state/sot/
-!autoresearch/state/sot/**
+# mutation state and `git revert` discards a hypothesis. The directory
+# name matches the existing module/function/constant naming
+# (policies.py / load_policy / GLOBAL_*_POLICY_SOT). The trailing
+# negation re-includes the whole policies/ subtree under git tracking.
+!autoresearch/state/policies/
+!autoresearch/state/policies/**
 .claude/scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,53 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-RATCHET-1 — 5 mutation SoT files moved in-repo (git-tracked).**
+  First slice of the CI-ratchet realignment sprint. Pre-PR the
+  self-improving loop's 5 SoT files (``wrapper-sections.json`` /
+  ``tool-policy.json`` / ``decomposition.json`` / ``retrieval.json`` /
+  ``reflection.json``) lived under ``~/.geode/self-improving-loop/``
+  (operator home, untracked) — so a ``git diff`` of a self-improving
+  loop run showed nothing about which mutation actually applied. This
+  diverged from upstream Karpathy autoresearch's "branch tip = best
+  wrapper" principle: 9/10 of GEODE's experiment-lineage state lived
+  outside git. PR-RATCHET-1 converges back: (1) the 5 SoT files now
+  live at ``autoresearch/state/sot/<file>.json`` (in-repo); (2)
+  ``.gitignore`` re-includes the new dir via ``!autoresearch/state/sot/``
+  + ``!autoresearch/state/sot/**`` negations (kept narrow — only the
+  ``sot/`` subtree, not the broader ``state/`` dir whose
+  ``baseline.json`` / ``results.tsv`` remain gitignored pending
+  PR-RATCHET-2); (3) ``LEGACY_SOT_DIR`` constant exposed alongside
+  ``GLOBAL_SOT_DIR`` so a freshly-upgraded operator install
+  preserves continuity — ``policies._maybe_migrate_legacy_sot``
+  copies the pre-PR ``~/.geode/self-improving-loop/<file>.json``
+  payload to the new in-repo location on first ``load_policy`` /
+  ``write_policy`` call, idempotent, leaves the legacy source in
+  place so an operator can roll back manually if needed. The
+  ``GLOBAL_*_SOT`` constant names are preserved for backwards
+  compatibility (only the value moves); all 5 known callers
+  (``policies.py`` / ``agent/system_prompt.py`` / ``autoresearch/train.py``
+  / etc.) consume the constant and automatically pick up the new
+  path. 13 invariant tests pin (a) the 5 SoT paths under
+  ``autoresearch/state/sot/``, (b) ``LEGACY_SOT_DIR`` still maps to
+  the operator-home pre-PR path, (c) the 5 SoT files + ``.gitkeep``
+  are NOT git-ignored (subprocess ``git check-ignore`` runs against
+  the worktree's actual ``.gitignore``), (d) migration copies legacy
+  → new when missing, (e) migration is idempotent (no clobber when
+  new exists with different content), (f) migration no-ops on
+  missing legacy or unknown kind, (g) ``_LEGACY_FILE_NAMES`` map
+  covers every ``TARGET_KINDS`` entry, (h) ``load_policy`` and
+  ``write_policy`` both trigger the migration before I/O.
+
+  Prior ``test_global_policy_paths_under_self_improving_loop_dir``
+  test invariant updated — the assertion now checks
+  ``GLOBAL_SOT_DIR`` (not ``GLOBAL_SELF_IMPROVING_LOOP_DIR``) since
+  the SoT files are no longer co-located with the operator-home
+  ``sessions.jsonl`` / ``journal.jsonl`` index files; those remain
+  in ``~/.geode/`` until PR-RATCHET-2 collapses them into a single
+  git-tracked journal.
+
 ### Added
 
 - **PR-OPS-2a — `/self-improving run` slash + propose/apply split.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,13 +59,13 @@ functional change.
   diverged from upstream Karpathy autoresearch's "branch tip = best
   wrapper" principle: 9/10 of GEODE's experiment-lineage state lived
   outside git. PR-RATCHET-1 converges back: (1) the 5 SoT files now
-  live at ``autoresearch/state/sot/<file>.json`` (in-repo); (2)
-  ``.gitignore`` re-includes the new dir via ``!autoresearch/state/sot/``
-  + ``!autoresearch/state/sot/**`` negations (kept narrow — only the
-  ``sot/`` subtree, not the broader ``state/`` dir whose
+  live at ``autoresearch/state/policies/<file>.json`` (in-repo); (2)
+  ``.gitignore`` re-includes the new dir via ``!autoresearch/state/policies/``
+  + ``!autoresearch/state/policies/**`` negations (kept narrow — only the
+  ``policies/`` subtree, not the broader ``state/`` dir whose
   ``baseline.json`` / ``results.tsv`` remain gitignored pending
   PR-RATCHET-2); (3) ``LEGACY_SOT_DIR`` constant exposed alongside
-  ``GLOBAL_SOT_DIR`` so a freshly-upgraded operator install
+  ``GLOBAL_POLICIES_DIR`` so a freshly-upgraded operator install
   preserves continuity — ``policies._maybe_migrate_legacy_sot``
   copies the pre-PR ``~/.geode/self-improving-loop/<file>.json``
   payload to the new in-repo location on first ``load_policy`` /
@@ -76,7 +76,7 @@ functional change.
   (``policies.py`` / ``agent/system_prompt.py`` / ``autoresearch/train.py``
   / etc.) consume the constant and automatically pick up the new
   path. 13 invariant tests pin (a) the 5 SoT paths under
-  ``autoresearch/state/sot/``, (b) ``LEGACY_SOT_DIR`` still maps to
+  ``autoresearch/state/policies/``, (b) ``LEGACY_SOT_DIR`` still maps to
   the operator-home pre-PR path, (c) the 5 SoT files + ``.gitkeep``
   are NOT git-ignored (subprocess ``git check-ignore`` runs against
   the worktree's actual ``.gitignore``), (d) migration copies legacy
@@ -88,7 +88,7 @@ functional change.
 
   Prior ``test_global_policy_paths_under_self_improving_loop_dir``
   test invariant updated — the assertion now checks
-  ``GLOBAL_SOT_DIR`` (not ``GLOBAL_SELF_IMPROVING_LOOP_DIR``) since
+  ``GLOBAL_POLICIES_DIR`` (not ``GLOBAL_SELF_IMPROVING_LOOP_DIR``) since
   the SoT files are no longer co-located with the operator-home
   ``sessions.jsonl`` / ``journal.jsonl`` index files; those remain
   in ``~/.geode/`` until PR-RATCHET-2 collapses them into a single

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -380,10 +380,19 @@ try:
     from core.paths import GLOBAL_WRAPPER_SECTIONS_SOT as _CORE_WRAPPER_SECTIONS_SOT
 except ImportError:
     # ``autoresearch.train`` is importable from environments where ``core``
-    # isn't installed (legacy fixture path) — fall back to the literal so the
+    # isn't installed (legacy fixture path) — fall back to a literal so the
     # module still loads. Tests pin parity via ``test_sot_path_parity_with_autoresearch``.
+    # PR-RATCHET-1 (2026-05-21) — fallback path follows the in-repo
+    # ``autoresearch/state/policies/`` location, not the pre-PR
+    # ``~/.geode/self-improving-loop/``, so a degraded import does not
+    # silently re-introduce the legacy out-of-repo location and bypass
+    # the git-as-optimiser invariant.
     _CORE_WRAPPER_SECTIONS_SOT = (
-        Path.home() / ".geode" / "self-improving-loop" / "wrapper-sections.json"
+        Path(__file__).resolve().parents[1]
+        / "autoresearch"
+        / "state"
+        / "policies"
+        / "wrapper-sections.json"
     )
 WRAPPER_SECTIONS_SOT_PATH = _CORE_WRAPPER_SECTIONS_SOT
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -55,23 +55,40 @@ GLOBAL_DIAGNOSTICS_DIR = GEODE_HOME / "diagnostics"
 # (P1c, event stream within a single run). See
 # ``docs/plans/2026-05-19-self-improving-loop-wiring-sprint.md``.
 GLOBAL_SELF_IMPROVING_LOOP_DIR = GEODE_HOME / "self-improving-loop"
+# PR-RATCHET-1 (2026-05-21) — the 5 mutation SoT files now live in
+# the in-repo ``autoresearch/state/sot/`` directory rather than the
+# operator's ``~/.geode/self-improving-loop/``. The rename converges
+# on upstream Karpathy's "branch tip = current best" principle: the
+# SoT is git-tracked, so ``git diff`` shows the current mutation
+# state and ``git revert`` discards a hypothesis. The constants below
+# keep their ``GLOBAL_*_SOT`` names for backwards compatibility with
+# existing callers; only the value moves. Lazy migration of any
+# legacy ``~/.geode/self-improving-loop/<file>.json`` payload is
+# handled by :mod:`core.self_improving_loop.policies`.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AUTORESEARCH_STATE_DIR = _REPO_ROOT / "autoresearch" / "state"
+GLOBAL_SOT_DIR = _AUTORESEARCH_STATE_DIR / "sot"
+LEGACY_SOT_DIR = GLOBAL_SELF_IMPROVING_LOOP_DIR
+"""Pre-RATCHET-1 SoT dir under ``~/.geode/self-improving-loop/``.
+Kept for the lazy migration path so an upgrade of an existing
+operator install copies their last-known wrapper/policy state into
+the new in-repo location on first read/write."""
 # G5a (2026-05-20) — cross-process SoT for the AgenticLoop wrapper prompt
 # sections. Written by ``autoresearch.train.write_wrapper_prompt_sections``
 # after a self-improving-loop promotion; read by
-# ``core.agent.system_prompt._load_wrapper_override`` for daily GEODE runs
-# (no env var required).
-GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "wrapper-sections.json"
+# ``core.agent.system_prompt._load_wrapper_override`` for daily GEODE runs.
+GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_SOT_DIR / "wrapper-sections.json"
 # PR-6 C-5 (2026-05-21) — policy mutation SoT files. Each
 # ``target_kind`` (tool_policy / decomposition / retrieval /
 # reflection) gets its own ``dict[str, str]`` JSON file alongside
 # ``wrapper-sections.json``. ``prompt`` keeps the legacy wrapper-
-# sections path so older mutation rows replay correctly; the others
+# sections name so older mutation rows replay correctly; the others
 # land in fresh files because they evolve independently. Read /
 # written by :mod:`core.self_improving_loop.policies`.
-GLOBAL_TOOL_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-policy.json"
-GLOBAL_DECOMPOSITION_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "decomposition.json"
-GLOBAL_RETRIEVAL_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "retrieval.json"
-GLOBAL_REFLECTION_POLICY_SOT = GLOBAL_SELF_IMPROVING_LOOP_DIR / "reflection.json"
+GLOBAL_TOOL_POLICY_SOT = GLOBAL_SOT_DIR / "tool-policy.json"
+GLOBAL_DECOMPOSITION_POLICY_SOT = GLOBAL_SOT_DIR / "decomposition.json"
+GLOBAL_RETRIEVAL_POLICY_SOT = GLOBAL_SOT_DIR / "retrieval.json"
+GLOBAL_REFLECTION_POLICY_SOT = GLOBAL_SOT_DIR / "reflection.json"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
 # PR-4 C-3 (2026-05-21) — cross-session episodic action-outcome log
 # (~/.geode/memory/episodes.jsonl). Append-only JSONL: one row per

--- a/core/paths.py
+++ b/core/paths.py
@@ -55,21 +55,23 @@ GLOBAL_DIAGNOSTICS_DIR = GEODE_HOME / "diagnostics"
 # (P1c, event stream within a single run). See
 # ``docs/plans/2026-05-19-self-improving-loop-wiring-sprint.md``.
 GLOBAL_SELF_IMPROVING_LOOP_DIR = GEODE_HOME / "self-improving-loop"
-# PR-RATCHET-1 (2026-05-21) — the 5 mutation SoT files now live in
-# the in-repo ``autoresearch/state/sot/`` directory rather than the
-# operator's ``~/.geode/self-improving-loop/``. The rename converges
-# on upstream Karpathy's "branch tip = current best" principle: the
-# SoT is git-tracked, so ``git diff`` shows the current mutation
-# state and ``git revert`` discards a hypothesis. The constants below
-# keep their ``GLOBAL_*_SOT`` names for backwards compatibility with
-# existing callers; only the value moves. Lazy migration of any
-# legacy ``~/.geode/self-improving-loop/<file>.json`` payload is
-# handled by :mod:`core.self_improving_loop.policies`.
+# PR-RATCHET-1 (2026-05-21) — the 5 mutation-target files now live in
+# the in-repo ``autoresearch/state/policies/`` directory rather than
+# the operator's ``~/.geode/self-improving-loop/``. The rename converges
+# on upstream Karpathy's "branch tip = current best" principle: each
+# policy is git-tracked, so ``git diff`` shows the current mutation
+# state and ``git revert`` discards a hypothesis. The directory name
+# matches the existing module/function/constant naming
+# (``policies.py`` / ``load_policy`` / ``GLOBAL_*_POLICY_SOT``); the
+# constants below keep their ``GLOBAL_*_SOT`` names for backwards
+# compatibility with existing callers; only the value moves. Lazy
+# migration of any legacy ``~/.geode/self-improving-loop/<file>.json``
+# payload is handled by :mod:`core.self_improving_loop.policies`.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _AUTORESEARCH_STATE_DIR = _REPO_ROOT / "autoresearch" / "state"
-GLOBAL_SOT_DIR = _AUTORESEARCH_STATE_DIR / "sot"
+GLOBAL_POLICIES_DIR = _AUTORESEARCH_STATE_DIR / "policies"
 LEGACY_SOT_DIR = GLOBAL_SELF_IMPROVING_LOOP_DIR
-"""Pre-RATCHET-1 SoT dir under ``~/.geode/self-improving-loop/``.
+"""Pre-RATCHET-1 policy dir under ``~/.geode/self-improving-loop/``.
 Kept for the lazy migration path so an upgrade of an existing
 operator install copies their last-known wrapper/policy state into
 the new in-repo location on first read/write."""
@@ -77,7 +79,7 @@ the new in-repo location on first read/write."""
 # sections. Written by ``autoresearch.train.write_wrapper_prompt_sections``
 # after a self-improving-loop promotion; read by
 # ``core.agent.system_prompt._load_wrapper_override`` for daily GEODE runs.
-GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_SOT_DIR / "wrapper-sections.json"
+GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_POLICIES_DIR / "wrapper-sections.json"
 # PR-6 C-5 (2026-05-21) — policy mutation SoT files. Each
 # ``target_kind`` (tool_policy / decomposition / retrieval /
 # reflection) gets its own ``dict[str, str]`` JSON file alongside
@@ -85,10 +87,10 @@ GLOBAL_WRAPPER_SECTIONS_SOT = GLOBAL_SOT_DIR / "wrapper-sections.json"
 # sections name so older mutation rows replay correctly; the others
 # land in fresh files because they evolve independently. Read /
 # written by :mod:`core.self_improving_loop.policies`.
-GLOBAL_TOOL_POLICY_SOT = GLOBAL_SOT_DIR / "tool-policy.json"
-GLOBAL_DECOMPOSITION_POLICY_SOT = GLOBAL_SOT_DIR / "decomposition.json"
-GLOBAL_RETRIEVAL_POLICY_SOT = GLOBAL_SOT_DIR / "retrieval.json"
-GLOBAL_REFLECTION_POLICY_SOT = GLOBAL_SOT_DIR / "reflection.json"
+GLOBAL_TOOL_POLICY_SOT = GLOBAL_POLICIES_DIR / "tool-policy.json"
+GLOBAL_DECOMPOSITION_POLICY_SOT = GLOBAL_POLICIES_DIR / "decomposition.json"
+GLOBAL_RETRIEVAL_POLICY_SOT = GLOBAL_POLICIES_DIR / "retrieval.json"
+GLOBAL_REFLECTION_POLICY_SOT = GLOBAL_POLICIES_DIR / "reflection.json"
 GLOBAL_AUTH_TOML = GEODE_HOME / "auth.toml"
 # PR-4 C-3 (2026-05-21) — cross-session episodic action-outcome log
 # (~/.geode/memory/episodes.jsonl). Append-only JSONL: one row per

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -73,14 +73,20 @@ _LEGACY_FILE_NAMES: dict[str, str] = {
 
 
 def _maybe_migrate_legacy_sot(kind: str, new_path: Path) -> None:
-    """Copy the pre-RATCHET-1 SoT file to ``new_path`` if it exists
-    and the new in-repo path doesn't yet. Idempotent — once the
-    in-repo file is present the legacy copy is ignored on subsequent
-    calls.
+    """Copy the pre-RATCHET-1 policy file to ``new_path`` if it
+    exists and the new in-repo path doesn't yet. Idempotent — once
+    the in-repo file is present the legacy copy is ignored on
+    subsequent calls.
 
     Failures are logged but never raise — the caller's
     ``FileNotFoundError`` fallback (returning ``{}``) still produces
-    a usable state.
+    a usable state. The catch is intentionally broad (``Exception``)
+    because the migration is best-effort observability glue: a
+    decode failure (e.g. non-UTF-8 legacy JSON, ``UnicodeDecodeError``)
+    or any other unexpected condition should leave the caller free
+    to fall through to the empty-policy state rather than crash the
+    self-improving loop. Codex MCP review of PR-RATCHET-1 caught
+    the original ``except OSError`` scope being too narrow.
     """
     if new_path.exists():
         return
@@ -98,7 +104,7 @@ def _maybe_migrate_legacy_sot(kind: str, new_path: Path) -> None:
             legacy_path,
             new_path,
         )
-    except OSError:
+    except Exception:
         log.warning(
             "PR-RATCHET-1 migration: failed to copy %s → %s",
             legacy_path,
@@ -156,7 +162,7 @@ def load_policy(kind: str) -> dict[str, str]:
 
     PR-RATCHET-1 (2026-05-21) — lazy migration from the pre-PR
     ``~/.geode/self-improving-loop/`` location to the in-repo
-    ``autoresearch/state/sot/`` location runs before the read.
+    ``autoresearch/state/policies/`` location runs before the read.
     """
     path = policy_path(kind)
     _maybe_migrate_legacy_sot(kind, path)

--- a/core/self_improving_loop/policies.py
+++ b/core/self_improving_loop/policies.py
@@ -51,9 +51,60 @@ from core.paths import (
     GLOBAL_RETRIEVAL_POLICY_SOT,
     GLOBAL_TOOL_POLICY_SOT,
     GLOBAL_WRAPPER_SECTIONS_SOT,
+    LEGACY_SOT_DIR,
 )
 
 log = logging.getLogger(__name__)
+
+# PR-RATCHET-1 (2026-05-21) — when the in-repo SoT path doesn't
+# exist yet, fall back to the pre-RATCHET-1 ``~/.geode/self-improving-loop/``
+# location. Operators upgrading an existing install have their last
+# mutation state there; copying it forward on first read keeps the
+# loop continuous across the migration without a manual step. The
+# legacy file is preserved (not deleted) so an operator can roll back
+# manually if needed.
+_LEGACY_FILE_NAMES: dict[str, str] = {
+    "prompt": "wrapper-sections.json",
+    "tool_policy": "tool-policy.json",
+    "decomposition": "decomposition.json",
+    "retrieval": "retrieval.json",
+    "reflection": "reflection.json",
+}
+
+
+def _maybe_migrate_legacy_sot(kind: str, new_path: Path) -> None:
+    """Copy the pre-RATCHET-1 SoT file to ``new_path`` if it exists
+    and the new in-repo path doesn't yet. Idempotent — once the
+    in-repo file is present the legacy copy is ignored on subsequent
+    calls.
+
+    Failures are logged but never raise — the caller's
+    ``FileNotFoundError`` fallback (returning ``{}``) still produces
+    a usable state.
+    """
+    if new_path.exists():
+        return
+    legacy_name = _LEGACY_FILE_NAMES.get(kind)
+    if legacy_name is None:
+        return
+    legacy_path = LEGACY_SOT_DIR / legacy_name
+    if not legacy_path.is_file():
+        return
+    try:
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        new_path.write_text(legacy_path.read_text(encoding="utf-8"), encoding="utf-8")
+        log.info(
+            "PR-RATCHET-1 migration: copied %s → %s (legacy preserved)",
+            legacy_path,
+            new_path,
+        )
+    except OSError:
+        log.warning(
+            "PR-RATCHET-1 migration: failed to copy %s → %s",
+            legacy_path,
+            new_path,
+            exc_info=True,
+        )
 
 
 # Canonical list of target kinds. Order matters for the type-hint enum
@@ -102,8 +153,13 @@ def load_policy(kind: str) -> dict[str, str]:
     over time. Malformed JSON also returns ``{}`` with a WARN, never
     raises; the readers downstream (PR-5 attribution) must remain
     robust to incomplete state.
+
+    PR-RATCHET-1 (2026-05-21) — lazy migration from the pre-PR
+    ``~/.geode/self-improving-loop/`` location to the in-repo
+    ``autoresearch/state/sot/`` location runs before the read.
     """
     path = policy_path(kind)
+    _maybe_migrate_legacy_sot(kind, path)
     try:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -133,8 +189,16 @@ def write_policy(kind: str, sections: dict[str, str]) -> Path:
     """Write the policy for ``kind`` to its SoT file, returning the
     written path. The dir is created if missing; the file is rewritten
     atomically (temp + rename) so concurrent readers never see a
-    partial file."""
+    partial file.
+
+    PR-RATCHET-1 (2026-05-21) — runs the lazy legacy-SoT migration
+    before the write so a pre-PR-RATCHET-1 operator state at
+    ``~/.geode/self-improving-loop/`` is captured in the in-repo
+    location as the *previous* value of this kind, rather than being
+    overwritten on the first mutation after upgrade.
+    """
     path = policy_path(kind)
+    _maybe_migrate_legacy_sot(kind, path)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(
         {k: v for k, v in sections.items() if isinstance(k, str)},

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -467,16 +467,16 @@ def test_rollback_sot_prompt_kind_still_uses_legacy_writer(
     assert written == [{"role": "original"}]
 
 
-def test_global_policy_paths_under_sot_dir() -> None:
+def test_global_policy_paths_under_policies_dir() -> None:
     """All 5 SoT paths live under the same in-repo dir
-    (``autoresearch/state/sot/``) — operators expect them co-located,
-    and the in-repo location is git-tracked so ``git diff`` shows
-    the current mutation state (PR-RATCHET-1, 2026-05-21)."""
+    (``autoresearch/state/policies/``) — operators expect them
+    co-located, and the in-repo location is git-tracked so ``git diff``
+    shows the current mutation state (PR-RATCHET-1, 2026-05-21)."""
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_SOT,
+        GLOBAL_POLICIES_DIR,
         GLOBAL_REFLECTION_POLICY_SOT,
         GLOBAL_RETRIEVAL_POLICY_SOT,
-        GLOBAL_SOT_DIR,
         GLOBAL_TOOL_POLICY_SOT,
         GLOBAL_WRAPPER_SECTIONS_SOT,
     )
@@ -488,4 +488,4 @@ def test_global_policy_paths_under_sot_dir() -> None:
         GLOBAL_RETRIEVAL_POLICY_SOT,
         GLOBAL_REFLECTION_POLICY_SOT,
     ):
-        assert path.parent == GLOBAL_SOT_DIR
+        assert path.parent == GLOBAL_POLICIES_DIR

--- a/tests/test_policy_mutation.py
+++ b/tests/test_policy_mutation.py
@@ -467,14 +467,16 @@ def test_rollback_sot_prompt_kind_still_uses_legacy_writer(
     assert written == [{"role": "original"}]
 
 
-def test_global_policy_paths_under_self_improving_loop_dir() -> None:
-    """All 5 SoT paths live under the same dir as wrapper-sections —
-    operators expect them co-located."""
+def test_global_policy_paths_under_sot_dir() -> None:
+    """All 5 SoT paths live under the same in-repo dir
+    (``autoresearch/state/sot/``) — operators expect them co-located,
+    and the in-repo location is git-tracked so ``git diff`` shows
+    the current mutation state (PR-RATCHET-1, 2026-05-21)."""
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_SOT,
         GLOBAL_REFLECTION_POLICY_SOT,
         GLOBAL_RETRIEVAL_POLICY_SOT,
-        GLOBAL_SELF_IMPROVING_LOOP_DIR,
+        GLOBAL_SOT_DIR,
         GLOBAL_TOOL_POLICY_SOT,
         GLOBAL_WRAPPER_SECTIONS_SOT,
     )
@@ -486,4 +488,4 @@ def test_global_policy_paths_under_self_improving_loop_dir() -> None:
         GLOBAL_RETRIEVAL_POLICY_SOT,
         GLOBAL_REFLECTION_POLICY_SOT,
     ):
-        assert path.parent == GLOBAL_SELF_IMPROVING_LOOP_DIR
+        assert path.parent == GLOBAL_SOT_DIR

--- a/tests/test_ratchet_policies_in_repo.py
+++ b/tests/test_ratchet_policies_in_repo.py
@@ -1,14 +1,16 @@
-"""PR-RATCHET-1 invariants — 5 mutation SoT files moved in-repo.
+"""PR-RATCHET-1 invariants — 5 mutation-target policy files moved in-repo.
 
 Pins:
-- 5 SoT constants now point under ``autoresearch/state/sot/``.
-- ``.gitignore`` allows the new path (negation re-includes ``sot/**``).
+- 5 policy SoT constants now point under ``autoresearch/state/policies/``.
+- ``.gitignore`` allows the new path (negation re-includes ``policies/**``).
 - ``LEGACY_SOT_DIR`` still references ``~/.geode/self-improving-loop/``
   for the lazy migration path.
 - ``_maybe_migrate_legacy_sot`` copies the legacy file to the new
   location on first read/write, is idempotent, preserves the legacy
-  source (operator can roll back manually), and silently no-ops when
-  the new path already exists or the legacy file is missing.
+  source (operator can roll back manually), silently no-ops when the
+  new path already exists or the legacy file is missing, and treats
+  ANY copy-time exception (incl. ``UnicodeDecodeError``) as
+  best-effort observability (Codex MCP catch on PR-RATCHET-1).
 """
 
 from __future__ import annotations
@@ -25,22 +27,22 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def test_sot_constants_under_in_repo_sot_dir() -> None:
-    """Each of the 5 SoT constants must resolve under
-    ``<repo>/autoresearch/state/sot/`` — NOT ``~/.geode/...``. The
-    in-repo location is the CI-ratchet alignment fix."""
+def test_policy_constants_under_in_repo_policies_dir() -> None:
+    """Each of the 5 policy SoT constants must resolve under
+    ``<repo>/autoresearch/state/policies/`` — NOT ``~/.geode/...``.
+    The in-repo location is the CI-ratchet alignment fix."""
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_SOT,
+        GLOBAL_POLICIES_DIR,
         GLOBAL_REFLECTION_POLICY_SOT,
         GLOBAL_RETRIEVAL_POLICY_SOT,
-        GLOBAL_SOT_DIR,
         GLOBAL_TOOL_POLICY_SOT,
         GLOBAL_WRAPPER_SECTIONS_SOT,
     )
 
-    sot_dir_parts = GLOBAL_SOT_DIR.parts
-    # The in-repo SoT dir's last three components are fixed:
-    assert sot_dir_parts[-3:] == ("autoresearch", "state", "sot")
+    policies_dir_parts = GLOBAL_POLICIES_DIR.parts
+    # The in-repo policies dir's last three components are fixed:
+    assert policies_dir_parts[-3:] == ("autoresearch", "state", "policies")
 
     paths_by_kind = {
         "wrapper-sections.json": GLOBAL_WRAPPER_SECTIONS_SOT,
@@ -51,7 +53,7 @@ def test_sot_constants_under_in_repo_sot_dir() -> None:
     }
     for filename, path in paths_by_kind.items():
         assert path.name == filename
-        assert path.parent == GLOBAL_SOT_DIR
+        assert path.parent == GLOBAL_POLICIES_DIR
 
 
 def test_legacy_sot_dir_still_exported() -> None:
@@ -79,17 +81,17 @@ def test_legacy_sot_dir_still_exported() -> None:
         ".gitkeep",
     ],
 )
-def test_sot_files_not_gitignored(filename: str) -> None:
+def test_policy_files_not_gitignored(filename: str) -> None:
     """``git check-ignore <path>`` must exit 1 (not ignored) for the
-    new in-repo SoT files. Pre-PR-RATCHET-1, ``autoresearch/state/*``
+    new in-repo policy files. Pre-PR-RATCHET-1, ``autoresearch/state/*``
     swept everything under the rug; the negation
-    ``!autoresearch/state/sot/**`` re-includes them."""
-    from core.paths import GLOBAL_SOT_DIR
+    ``!autoresearch/state/policies/**`` re-includes them."""
+    from core.paths import GLOBAL_POLICIES_DIR
 
     git_bin = shutil.which("git")
     if git_bin is None:
         pytest.skip("git executable not in PATH")
-    target = GLOBAL_SOT_DIR / filename
+    target = GLOBAL_POLICIES_DIR / filename
     # Run from the worktree root so .gitignore is the right one.
     repo_root = Path(__file__).resolve().parents[1]
     result = subprocess.run(  # noqa: S603
@@ -181,6 +183,30 @@ def test_migration_handles_unknown_kind(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert not new_path.exists()
 
 
+def test_migration_swallows_unicode_decode_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Codex MCP catch (PR-RATCHET-1): legacy file with non-UTF-8
+    content used to raise ``UnicodeDecodeError`` past the ``OSError``
+    catch. The widened ``except Exception`` must swallow it so the
+    caller falls through to the empty-state branch."""
+    from core.self_improving_loop import policies as policies_mod
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    new_path = tmp_path / "new" / "tool-policy.json"
+    # Latin-1 byte 0xff is not a valid UTF-8 lead byte.
+    legacy_file = legacy_dir / "tool-policy.json"
+    legacy_file.write_bytes(b"\xff\xfe garbled-bytes")
+
+    monkeypatch.setattr(policies_mod, "LEGACY_SOT_DIR", legacy_dir)
+    # Must NOT raise.
+    policies_mod._maybe_migrate_legacy_sot("tool_policy", new_path)
+    # New path stays absent — the caller's FileNotFoundError fallback
+    # path will produce an empty policy state.
+    assert not new_path.exists()
+
+
 @pytest.mark.parametrize(
     "kind, expected_filename",
     [
@@ -224,6 +250,24 @@ def test_load_policy_triggers_migration(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert result == {"delegate_task.priority": "8"}
     # Migration also created the in-repo file as a side effect
     assert new_path.is_file()
+
+
+def test_train_module_fallback_path_points_in_repo() -> None:
+    """Codex MCP catch (PR-RATCHET-1): ``autoresearch/train.py`` has a
+    fallback path used when ``core.paths`` cannot be imported. Pre-fix
+    the fallback hardcoded ``~/.geode/self-improving-loop/...`` —
+    silently re-introducing the out-of-repo location. Pin that the
+    fallback now resolves under the in-repo policies dir so a
+    degraded import does not bypass the git-as-optimiser invariant."""
+    import inspect
+
+    import autoresearch.train as auto_train
+
+    src = inspect.getsource(auto_train)
+    # The fallback must NOT contain the legacy operator-home literal.
+    assert "self-improving-loop" not in src or "policies" in src
+    # The in-repo target name must be present in the fallback.
+    assert '"policies"' in src or "/policies/" in src
 
 
 def test_write_policy_triggers_migration_before_write(

--- a/tests/test_ratchet_sot_in_repo.py
+++ b/tests/test_ratchet_sot_in_repo.py
@@ -1,0 +1,250 @@
+"""PR-RATCHET-1 invariants — 5 mutation SoT files moved in-repo.
+
+Pins:
+- 5 SoT constants now point under ``autoresearch/state/sot/``.
+- ``.gitignore`` allows the new path (negation re-includes ``sot/**``).
+- ``LEGACY_SOT_DIR`` still references ``~/.geode/self-improving-loop/``
+  for the lazy migration path.
+- ``_maybe_migrate_legacy_sot`` copies the legacy file to the new
+  location on first read/write, is idempotent, preserves the legacy
+  source (operator can roll back manually), and silently no-ops when
+  the new path already exists or the legacy file is missing.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path constants — pinned at the in-repo location
+# ---------------------------------------------------------------------------
+
+
+def test_sot_constants_under_in_repo_sot_dir() -> None:
+    """Each of the 5 SoT constants must resolve under
+    ``<repo>/autoresearch/state/sot/`` — NOT ``~/.geode/...``. The
+    in-repo location is the CI-ratchet alignment fix."""
+    from core.paths import (
+        GLOBAL_DECOMPOSITION_POLICY_SOT,
+        GLOBAL_REFLECTION_POLICY_SOT,
+        GLOBAL_RETRIEVAL_POLICY_SOT,
+        GLOBAL_SOT_DIR,
+        GLOBAL_TOOL_POLICY_SOT,
+        GLOBAL_WRAPPER_SECTIONS_SOT,
+    )
+
+    sot_dir_parts = GLOBAL_SOT_DIR.parts
+    # The in-repo SoT dir's last three components are fixed:
+    assert sot_dir_parts[-3:] == ("autoresearch", "state", "sot")
+
+    paths_by_kind = {
+        "wrapper-sections.json": GLOBAL_WRAPPER_SECTIONS_SOT,
+        "tool-policy.json": GLOBAL_TOOL_POLICY_SOT,
+        "decomposition.json": GLOBAL_DECOMPOSITION_POLICY_SOT,
+        "retrieval.json": GLOBAL_RETRIEVAL_POLICY_SOT,
+        "reflection.json": GLOBAL_REFLECTION_POLICY_SOT,
+    }
+    for filename, path in paths_by_kind.items():
+        assert path.name == filename
+        assert path.parent == GLOBAL_SOT_DIR
+
+
+def test_legacy_sot_dir_still_exported() -> None:
+    """``LEGACY_SOT_DIR`` must remain importable so the migration
+    helper can find old payloads. The constant points at the pre-
+    PR-RATCHET-1 location (``~/.geode/self-improving-loop/``)."""
+    from core.paths import GEODE_HOME, LEGACY_SOT_DIR
+
+    assert LEGACY_SOT_DIR == GEODE_HOME / "self-improving-loop"
+
+
+# ---------------------------------------------------------------------------
+# .gitignore — the in-repo SoT path must NOT be ignored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "wrapper-sections.json",
+        "tool-policy.json",
+        "decomposition.json",
+        "retrieval.json",
+        "reflection.json",
+        ".gitkeep",
+    ],
+)
+def test_sot_files_not_gitignored(filename: str) -> None:
+    """``git check-ignore <path>`` must exit 1 (not ignored) for the
+    new in-repo SoT files. Pre-PR-RATCHET-1, ``autoresearch/state/*``
+    swept everything under the rug; the negation
+    ``!autoresearch/state/sot/**`` re-includes them."""
+    from core.paths import GLOBAL_SOT_DIR
+
+    git_bin = shutil.which("git")
+    if git_bin is None:
+        pytest.skip("git executable not in PATH")
+    target = GLOBAL_SOT_DIR / filename
+    # Run from the worktree root so .gitignore is the right one.
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(  # noqa: S603
+        [git_bin, "check-ignore", str(target)],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    # exit 1 = not ignored; exit 0 = ignored
+    assert result.returncode == 1, (
+        f"{target} is git-ignored: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy migration helper — _maybe_migrate_legacy_sot
+# ---------------------------------------------------------------------------
+
+
+def test_migration_copies_legacy_when_new_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the in-repo path is missing AND the legacy file exists,
+    the migration copies legacy → new."""
+    from core.self_improving_loop import policies as policies_mod
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    new_path = tmp_path / "new" / "tool-policy.json"
+    legacy_file = legacy_dir / "tool-policy.json"
+    legacy_file.write_text(json.dumps({"delegate_task.priority": "5"}))
+
+    monkeypatch.setattr(policies_mod, "LEGACY_SOT_DIR", legacy_dir)
+    policies_mod._maybe_migrate_legacy_sot("tool_policy", new_path)
+
+    assert new_path.is_file()
+    assert json.loads(new_path.read_text()) == {"delegate_task.priority": "5"}
+    # Legacy preserved (not deleted)
+    assert legacy_file.is_file()
+
+
+def test_migration_no_op_when_new_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Idempotency — once the in-repo path is populated, subsequent
+    migration calls leave it untouched (even if legacy has different
+    content)."""
+    from core.self_improving_loop import policies as policies_mod
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    new_path = tmp_path / "new" / "tool-policy.json"
+    new_path.parent.mkdir(parents=True)
+
+    legacy_file = legacy_dir / "tool-policy.json"
+    legacy_file.write_text(json.dumps({"from_legacy": "old"}))
+    new_path.write_text(json.dumps({"from_new": "fresh"}))
+
+    monkeypatch.setattr(policies_mod, "LEGACY_SOT_DIR", legacy_dir)
+    policies_mod._maybe_migrate_legacy_sot("tool_policy", new_path)
+
+    # The new path's content must NOT be clobbered by the legacy copy.
+    assert json.loads(new_path.read_text()) == {"from_new": "fresh"}
+
+
+def test_migration_no_op_when_legacy_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fresh-install path — no legacy file means no migration; the
+    caller falls through to the empty-state branch."""
+    from core.self_improving_loop import policies as policies_mod
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    new_path = tmp_path / "new" / "tool-policy.json"
+
+    monkeypatch.setattr(policies_mod, "LEGACY_SOT_DIR", legacy_dir)
+    policies_mod._maybe_migrate_legacy_sot("tool_policy", new_path)
+
+    assert not new_path.exists()
+
+
+def test_migration_handles_unknown_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Unknown kinds (not in ``_LEGACY_FILE_NAMES``) must no-op
+    silently rather than raise — defensive for future kinds added
+    after RATCHET-1."""
+    from core.self_improving_loop import policies as policies_mod
+
+    new_path = tmp_path / "future_kind.json"
+    policies_mod._maybe_migrate_legacy_sot("unknown_kind", new_path)
+    assert not new_path.exists()
+
+
+@pytest.mark.parametrize(
+    "kind, expected_filename",
+    [
+        ("prompt", "wrapper-sections.json"),
+        ("tool_policy", "tool-policy.json"),
+        ("decomposition", "decomposition.json"),
+        ("retrieval", "retrieval.json"),
+        ("reflection", "reflection.json"),
+    ],
+)
+def test_legacy_filename_map_matches_target_kinds(kind: str, expected_filename: str) -> None:
+    """The migration's ``_LEGACY_FILE_NAMES`` map must include every
+    public target_kind so no migration path goes silently dark."""
+    from core.self_improving_loop import policies as policies_mod
+
+    assert kind in policies_mod._LEGACY_FILE_NAMES
+    assert policies_mod._LEGACY_FILE_NAMES[kind] == expected_filename
+
+
+# ---------------------------------------------------------------------------
+# load_policy / write_policy — migration fires before the I/O
+# ---------------------------------------------------------------------------
+
+
+def test_load_policy_triggers_migration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``load_policy`` must invoke ``_maybe_migrate_legacy_sot``
+    BEFORE attempting to read, so a freshly-upgraded operator gets
+    their last mutation state visible on the first call."""
+    from core.self_improving_loop import policies as policies_mod
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    legacy_file = legacy_dir / "tool-policy.json"
+    legacy_file.write_text(json.dumps({"delegate_task.priority": "8"}))
+
+    new_path = tmp_path / "new" / "tool-policy.json"
+    monkeypatch.setattr(policies_mod, "LEGACY_SOT_DIR", legacy_dir)
+    monkeypatch.setattr(policies_mod, "_KIND_TO_PATH", {"tool_policy": new_path})
+
+    result = policies_mod.load_policy("tool_policy")
+    assert result == {"delegate_task.priority": "8"}
+    # Migration also created the in-repo file as a side effect
+    assert new_path.is_file()
+
+
+def test_write_policy_triggers_migration_before_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Write path must run migration too — otherwise a write that
+    happens BEFORE the first read would clobber the legacy state."""
+    from core.self_improving_loop import policies as policies_mod
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    legacy_file = legacy_dir / "tool-policy.json"
+    legacy_file.write_text(json.dumps({"legacy_section": "v1"}))
+
+    new_path = tmp_path / "new" / "tool-policy.json"
+    monkeypatch.setattr(policies_mod, "LEGACY_SOT_DIR", legacy_dir)
+    monkeypatch.setattr(policies_mod, "_KIND_TO_PATH", {"tool_policy": new_path})
+
+    # write happens AFTER the migration so the legacy state is
+    # preserved as "previous value" rather than dropped on the floor.
+    policies_mod.write_policy("tool_policy", {"legacy_section": "v2"})
+    assert json.loads(new_path.read_text()) == {"legacy_section": "v2"}
+    # Legacy still preserved
+    assert legacy_file.is_file()


### PR DESCRIPTION
## Summary

First slice of the CI-ratchet realignment sprint. Moves the 5 mutation SoT files from `~/.geode/self-improving-loop/` (operator home, untracked) to `autoresearch/state/sot/` (in-repo, git-tracked). Restores upstream Karpathy autoresearch's "branch tip = current best wrapper" principle — `git diff` now shows the current mutation state, `git revert` discards a hypothesis.

## Why

Pre-PR, 9/10 of GEODE's experiment-lineage state lived outside git:

| File | Pre-PR location | Tracked? |
|------|---------------|---------|
| `wrapper-sections.json` + 4 policy SoTs | `~/.geode/self-improving-loop/` | ❌ |
| `baseline.json` / `results.tsv` / `results.jsonl` | `autoresearch/state/` (gitignored sweep) | ❌ |
| `sessions.jsonl` | `~/.geode/self-improving-loop/` | ❌ |
| `mutations.jsonl` | `autoresearch/state/` (negation exception) | ✓ |

PR-RATCHET-1 fixes the 5 SoT JSONs (largest slice). Remaining 4 files land in PR-RATCHET-2 (journal collapse) and PR-RATCHET-3 (results consolidation).

## Changes

| File | Change |
|------|--------|
| `core/paths.py` | New `GLOBAL_SOT_DIR` + `LEGACY_SOT_DIR`; 5 SoT constants point in-repo (names preserved) |
| `.gitignore` | `!autoresearch/state/sot/` + `!autoresearch/state/sot/**` negations |
| `autoresearch/state/sot/.gitkeep` | New — keeps dir alive in fresh clones |
| `core/self_improving_loop/policies.py` | `_maybe_migrate_legacy_sot` helper + invocation from `load_policy`/`write_policy` |
| `tests/test_ratchet_sot_in_repo.py` | 13 new invariants |
| `tests/test_policy_mutation.py` | 1 prior assertion updated to `GLOBAL_SOT_DIR` |
| `CHANGELOG.md` | `[Unreleased]` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| 5 SoT in-repo | Implemented | Constants + .gitignore + .gitkeep |
| Lazy migration from legacy | Implemented | Idempotent, preserves legacy source |
| Backwards-compat constant names | Implemented | `GLOBAL_*_SOT` names unchanged |
| `baseline.json` / `results.tsv` / `results.jsonl` git tracking | Deferred | PR-RATCHET-2/3 |
| `sessions.jsonl` git tracking + journal collapse | Deferred | PR-RATCHET-2 |

## Verification

- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/` clean
- [x] `mypy core/ plugins/` clean (363 source files)
- [x] `git check-ignore` returns exit 1 for all 5 SoT files (verified by test parametrize)
- [x] Full suite — 5469/5469 pass (5449 prior + 20 new), exit 0 locally

## Reference

Design doc: `docs/plans/2026-05-21-self-improving-loop-ux.md`
CI-ratchet sprint plan: this PR + PR-RATCHET-2/3 (journal collapse / results consolidation)
Upstream pattern: `autoresearch/README.md` "Git as optimiser" section
Anti-deception lens: CLAUDE.md DONT incident 2026-05-20 PR-G5b #1350 (`git check-ignore` is now part of the invariants suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)