### PR TITLE
feat(cli): PR-G2 — /model mutator role-tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,30 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-G2 — `/model` mutator role-tab.** Wave 1 / 3 PRs.
+  Extends the ``AGENT_ROLES`` registry (PR-A pattern: primary +
+  reflection) with a third entry: ``mutator``. Pre-PR operators
+  had to edit ``~/.geode/config.toml [self_improving_loop.mutator]
+  default_model`` manually; PR-G2 wires the same role-tab UI that
+  primary + reflection already use. The mutator role differs in
+  one respect — its model knob lives in ``MutatorConfig.default_model``
+  (toml-only, post-PR-MINIMAL-2 G1a defaults to ``None`` for
+  Settings.model inherit), not on ``Settings``. The
+  ``AgentRole.settings_field=""`` sentinel signals "no Settings
+  attribute to write"; ``_current_model_for_role`` reads the toml
+  value directly via the new ``_read_toml_value`` helper (tomllib +
+  defensive empty-on-malformed-or-missing), and ``_apply_model``
+  guards the ``object.__setattr__(settings, ...)`` call behind an
+  ``if role_def.settings_field:`` check so the picker's choice
+  persists via env var + ``upsert_config_toml`` only — exactly the
+  SoT path the runner's lazy ``load_self_improving_loop_config()``
+  reads at dispatch time. 7 invariant tests pin role registration,
+  empty-settings-field sentinel, toml read paths (set / unset /
+  malformed / missing file), and the apply-time settings write
+  guard.
+
 ### Changed
 
 - **PR-MINIMAL-2 — 13-item alignment / pruning bundle for the

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -127,6 +127,29 @@ AGENT_ROLES: list[AgentRole] = [
         description="Belief-update node (PR-3 C-2) — runs after each tool batch",
         has_effort=False,
     ),
+    # PR-G2 (2026-05-21) — self-improving loop mutator role. Unlike
+    # primary / reflection (which live on ``Settings``), the mutator's
+    # model knob lives in ``MutatorConfig.default_model``
+    # (``[self_improving_loop.mutator] default_model`` in config.toml).
+    # When ``default_model`` is ``None`` (the new G1a default from
+    # PR-MINIMAL-2) the runner inherits ``Settings.model``. The
+    # ``settings_field=""`` sentinel signals "no Settings attribute to
+    # write" — the picker persists via ``upsert_config_toml`` only,
+    # which is exactly the SoT path ``_default_llm_call`` reads at
+    # dispatch time.
+    AgentRole(
+        name="mutator",
+        label="Mutator",
+        settings_field="",
+        env_var="GEODE_SELF_IMPROVING_LOOP_MUTATOR_MODEL",
+        toml_section="self_improving_loop.mutator",
+        toml_key="default_model",
+        description=(
+            "Self-improving loop mutator — proposes wrapper/policy mutations "
+            "(set to '' to inherit Settings.model)"
+        ),
+        has_effort=False,
+    ),
 ]
 
 _ROLE_INDEX: dict[str, AgentRole] = {r.name: r for r in AGENT_ROLES}

--- a/core/cli/commands/model.py
+++ b/core/cli/commands/model.py
@@ -29,16 +29,57 @@ log = logging.getLogger(__name__)
 
 
 def _current_model_for_role(role: AgentRole) -> str:
-    """Read the current model id for ``role`` from ``settings``.
+    """Read the current model id for ``role`` from ``settings`` (or the
+    role-specific toml section when the role has no Settings attr).
 
     Centralised reader so the picker, non-tty fallback, and post-apply
     confirmation all consult the same source. Falls back to an empty
-    string if the field is unset (shouldn't happen — every registered
-    role's settings field has a default — but defensive against config
-    drift)."""
+    string if the field is unset.
+
+    PR-G2 (2026-05-21) — roles with ``settings_field=""`` (e.g.
+    mutator) don't live on Settings; their durable SoT is the toml
+    section + key. Read it lazily so the picker shows what the
+    runner will actually invoke at dispatch time. Returns ``""`` when
+    the toml key is absent — caller renders this as "(inherits
+    Settings.model)".
+    """
     from core.config import settings
 
+    if not role.settings_field:
+        return _read_toml_value(role.toml_section, role.toml_key)
     return getattr(settings, role.settings_field, "") or ""
+
+
+def _read_toml_value(section: str, key: str) -> str:
+    """Read ``[<section>] <key>`` from ``~/.geode/config.toml``.
+
+    Returns ``""`` when the file is missing, the section is missing,
+    the key is missing, or any parse error occurs — the picker
+    renders empty as "(inherits Settings.model)" so a silent miss
+    falls back to the global model rather than crashing the slash.
+    Used by the PR-G2 mutator role (and any future role with
+    ``settings_field=""``)."""
+    import tomllib
+
+    from core.paths import GLOBAL_CONFIG_TOML
+
+    if not GLOBAL_CONFIG_TOML.is_file():
+        return ""
+    try:
+        data = tomllib.loads(GLOBAL_CONFIG_TOML.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return ""
+    cursor: object = data
+    for part in section.split("."):
+        if not isinstance(cursor, dict):
+            return ""
+        cursor = cursor.get(part)
+        if cursor is None:
+            return ""
+    if not isinstance(cursor, dict):
+        return ""
+    value = cursor.get(key)
+    return str(value) if value else ""
 
 
 def _apply_model(
@@ -123,10 +164,21 @@ def _apply_model(
         # field but not for arbitrary new fields. ``object.__setattr__``
         # bypasses validation so the picker's choice lands regardless
         # of the field's pydantic descriptor type.
-        try:
-            object.__setattr__(settings, role_def.settings_field, selected.id)
-        except Exception:
-            log.debug("Could not persist %s to settings", role_def.settings_field, exc_info=True)
+        #
+        # PR-G2 (2026-05-21) — roles with ``settings_field=""`` (e.g.
+        # mutator) don't live on Settings; skip the attribute write
+        # and persist via env + toml only. The runner's lazy
+        # ``load_self_improving_loop_config()`` will pick up the new
+        # toml value on the next dispatch.
+        if role_def.settings_field:
+            try:
+                object.__setattr__(settings, role_def.settings_field, selected.id)
+            except Exception:
+                log.debug(
+                    "Could not persist %s to settings",
+                    role_def.settings_field,
+                    exc_info=True,
+                )
         _pkg._upsert_env(role_def.env_var, selected.id)
         upsert_config_toml(role_def.toml_section, role_def.toml_key, selected.id)
     if role_def.has_effort and effort is not None and effort != old_effort:

--- a/tests/test_mutator_role_tab.py
+++ b/tests/test_mutator_role_tab.py
@@ -1,0 +1,120 @@
+"""PR-G2 — mutator role-tab in ``/model`` picker.
+
+Pins:
+- ``mutator`` role registered in ``AGENT_ROLES``.
+- The role has ``settings_field=""`` (sentinel — mutator lives in
+  ``MutatorConfig.default_model``, not Settings).
+- ``toml_section="self_improving_loop.mutator"`` / ``toml_key="default_model"``
+  matches the runner's lazy ``load_self_improving_loop_config()`` reader.
+- ``_current_model_for_role(mutator)`` reads the toml value (or empty
+  when unset, signalling inherit-Settings.model).
+- ``_apply_model(..., role="mutator")`` writes to env + toml only,
+  NOT to Settings (which has no such attribute).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_mutator_role_registered() -> None:
+    """``mutator`` joins ``primary`` + ``reflection`` in AGENT_ROLES."""
+    from core.cli.commands._state import AGENT_ROLES, role_by_name
+
+    names = [r.name for r in AGENT_ROLES]
+    assert "mutator" in names
+    role = role_by_name("mutator")
+    assert role.label == "Mutator"
+
+
+def test_mutator_role_has_empty_settings_field() -> None:
+    """The mutator model lives in MutatorConfig (toml), not Settings,
+    so ``settings_field`` is the empty-string sentinel."""
+    from core.cli.commands._state import role_by_name
+
+    role = role_by_name("mutator")
+    assert role.settings_field == ""
+    # toml routing points at the self-improving-loop section
+    assert role.toml_section == "self_improving_loop.mutator"
+    assert role.toml_key == "default_model"
+    # No effort axis on the mutator role
+    assert role.has_effort is False
+
+
+def test_current_model_for_mutator_reads_toml_when_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When ``settings_field=""`` the reader must consult the toml,
+    not raise ``AttributeError`` on Settings."""
+    from core.cli.commands import model as model_mod
+    from core.cli.commands._state import role_by_name
+
+    fake_toml = tmp_path / "config.toml"
+    fake_toml.write_text(
+        '[self_improving_loop.mutator]\ndefault_model = "claude-haiku-4-5-20251001"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    role = role_by_name("mutator")
+    assert model_mod._current_model_for_role(role) == "claude-haiku-4-5-20251001"
+
+
+def test_current_model_for_mutator_returns_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing toml key → empty string (signals inherit-Settings.model
+    per PR-MINIMAL-2 G1a)."""
+    from core.cli.commands import model as model_mod
+    from core.cli.commands._state import role_by_name
+
+    fake_toml = tmp_path / "config.toml"
+    fake_toml.write_text("[other_section]\nkey = 'value'\n", encoding="utf-8")
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    role = role_by_name("mutator")
+    assert model_mod._current_model_for_role(role) == ""
+
+
+def test_current_model_for_mutator_returns_empty_when_toml_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing config.toml → empty (fresh-install fallback)."""
+    from core.cli.commands import model as model_mod
+    from core.cli.commands._state import role_by_name
+
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", tmp_path / "absent.toml")
+    role = role_by_name("mutator")
+    assert model_mod._current_model_for_role(role) == ""
+
+
+def test_read_toml_value_handles_malformed_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Truncated / malformed config.toml → empty rather than raise."""
+    from core.cli.commands import model as model_mod
+
+    fake_toml = tmp_path / "config.toml"
+    fake_toml.write_text("[broken section\nkey = value\n", encoding="utf-8")
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    assert model_mod._read_toml_value("self_improving_loop.mutator", "default_model") == ""
+
+
+def test_apply_model_for_mutator_skips_settings_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Roles with ``settings_field=""`` must NOT trigger
+    ``object.__setattr__(settings, ...)`` — Settings has no mutator
+    field, the call would silently create a stray attr. Persistence
+    runs through env + toml only."""
+    import inspect
+
+    from core.cli.commands import model as model_mod
+
+    src = inspect.getsource(model_mod._apply_model)
+    # The guard must check role_def.settings_field truthy before the
+    # __setattr__ call. Anti-deception pin.
+    assert "if role_def.settings_field:" in src
+    # And the env + toml writes happen unconditionally afterwards.
+    assert "_upsert_env(role_def.env_var" in src
+    assert "upsert_config_toml(role_def.toml_section, role_def.toml_key" in src


### PR DESCRIPTION
## Summary

Wave 1 / 3 parallel PRs. Adds the **mutator** role to the ``/model`` picker so operators can switch the self-improving loop mutator model via the same role-tab UI that already covers primary + reflection.

## Why

Pre-PR an operator who wanted to switch the mutator (the LLM that proposes wrapper/policy mutations) had to edit `~/.geode/config.toml [self_improving_loop.mutator] default_model` manually — no interactive surface. PR-G2 closes that gap.

The mutator role differs from primary/reflection in one respect: its model lives in `MutatorConfig.default_model` (toml-only; PR-MINIMAL-2 G1a defaults to `None` for Settings.model inherit), not on `Settings`. The `AgentRole.settings_field=""` sentinel handles that — picker persists via env + toml only, skipping the Settings attribute write.

## Changes

| File | Change |
|------|--------|
| `core/cli/commands/_state.py` | New `mutator` AgentRole entry |
| `core/cli/commands/model.py` | `_current_model_for_role` reads toml when `settings_field=""`; `_apply_model` guards Settings write; new `_read_toml_value` helper |
| `tests/test_mutator_role_tab.py` | 7 new invariants |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Verification

- [x] ruff check clean
- [x] mypy clean (363 source files)
- [x] 25/25 pass on test_mutator_role_tab + test_model_role_tab
- Full suite verification in CI

## Reference

Sprint plan: Wave 1 (parallel with G4 + MINIMAL-4)
Design doc: `docs/plans/2026-05-21-self-improving-loop-ux.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)