### PR TITLE
feat(self-improving-loop): PR-G4 — /run summary source telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-G4 — `/self-improving run` summary now carries source
+  telemetry.** Wave 1 / 3 PRs. Adds ``model=...`` and ``source=...``
+  to the per-run summary line so the operator can verify which
+  channel was billed at the end of a confirmation cycle. New
+  ``_resolve_run_summary_telemetry`` helper mirrors the runner's
+  ``_default_llm_call`` resolution (G1a inherit: ``None`` default
+  → ``Settings.model``). Defensive — config-import failure returns
+  ``("?", "?")`` placeholders rather than crashing the slash.
+  4 invariant tests pin the summary-line shape, the inherit path,
+  explicit-default override, and the placeholder fallback.
+
 ### Changed
 
 - **PR-MINIMAL-2 — 13-item alignment / pruning bundle for the

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -330,9 +330,7 @@ def _resolve_run_summary_telemetry() -> tuple[str, str]:
     except Exception:
         import logging
 
-        logging.getLogger(__name__).debug(
-            "run-summary telemetry resolve failed", exc_info=True
-        )
+        logging.getLogger(__name__).debug("run-summary telemetry resolve failed", exc_info=True)
         return ("?", "?")
 
 

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -295,8 +295,45 @@ def _cmd_run(opts: list[str]) -> None:
 
         console.print()
 
-    console.print(f"  [muted]summary:[/muted] applied={applied}  rejected={rejected}")
+    # PR-G4 (2026-05-21) — surface the mutator's resolved (model, source)
+    # so the operator knows which channel was billed for this run.
+    # Both are read from the same toml SoT (``[self_improving_loop.mutator]``)
+    # the runner consults at dispatch time; with PR-MINIMAL-2 G1a a
+    # ``None`` default_model means the mutator inherited
+    # ``Settings.model``, which we resolve here for the display line.
+    resolved_model, resolved_source = _resolve_run_summary_telemetry()
+    console.print(
+        f"  [muted]summary:[/muted] applied={applied}  rejected={rejected}  "
+        f"model={resolved_model}  source={resolved_source}"
+    )
     console.print()
+
+
+def _resolve_run_summary_telemetry() -> tuple[str, str]:
+    """Resolve the (model, source) the mutator just dispatched against.
+
+    Mirrors the runner's ``_default_llm_call`` resolution: read
+    ``MutatorConfig.default_model`` from ``~/.geode/config.toml``, fall
+    back to ``Settings.model`` when unset (PR-MINIMAL-2 G1a). Read
+    ``MutatorConfig.source`` directly. Best-effort — returns ``"?"``
+    placeholders when the config layer cannot be imported (e.g. test
+    contexts that stub ``core.config``).
+    """
+    try:
+        from core.config import settings
+        from core.config.self_improving_loop import load_self_improving_loop_config
+
+        cfg = load_self_improving_loop_config()
+        model = cfg.mutator.default_model or settings.model
+        source = cfg.mutator.source
+        return (model, source)
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).debug(
+            "run-summary telemetry resolve failed", exc_info=True
+        )
+        return ("?", "?")
 
 
 def _parse_run_opts(opts: list[str]) -> dict[str, Any] | None:

--- a/tests/test_run_summary_source_telemetry.py
+++ b/tests/test_run_summary_source_telemetry.py
@@ -1,0 +1,131 @@
+"""PR-G4 — ``/self-improving run`` summary now carries source telemetry.
+
+Pins:
+- The final summary line includes ``model=...`` and ``source=...``.
+- ``_resolve_run_summary_telemetry`` resolves model with G1a inherit
+  (None default_model → Settings.model).
+- The resolver returns ``("?", "?")`` on config-import failure rather
+  than crashing the slash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _stub_runner_proposal() -> tuple[MagicMock, MagicMock]:
+    from core.self_improving_loop.runner import Mutation, Proposal
+
+    mutation = Mutation(
+        target_section="role.intro",
+        new_value="improved",
+        rationale="test",
+        target_kind="prompt",
+    )
+    proposal = Proposal(
+        mutation=mutation,
+        target_sections={"role.intro": "baseline"},
+        original_sections={"role.intro": "baseline"},
+        baseline_fitness=0.7,
+    )
+    runner = MagicMock()
+    runner.audit_log_path = Path("/tmp/dummy.jsonl")  # noqa: S108 — test stub
+    runner.propose.return_value = proposal
+    runner.apply_proposal.return_value = mutation
+    return runner, proposal
+
+
+def test_summary_line_includes_model_and_source(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """After ``y`` confirmation, the summary line must surface
+    ``model=...`` and ``source=...`` so the operator knows which
+    channel was billed."""
+    from core.cli.commands import self_improving
+
+    runner, _ = _stub_runner_proposal()
+    monkeypatch.setattr(self_improving, "_build_runner", lambda: runner)
+    monkeypatch.setattr(self_improving, "_prompt_confirmation", lambda _p: "apply")
+    monkeypatch.setattr(
+        self_improving,
+        "_resolve_run_summary_telemetry",
+        lambda: ("claude-sonnet-4-6", "claude-cli"),
+    )
+    self_improving._cmd_run([])
+    out = capsys.readouterr().out
+    assert "summary:" in out
+    assert "applied=1" in out
+    assert "model=claude-sonnet-4-6" in out
+    assert "source=claude-cli" in out
+
+
+def test_resolve_telemetry_inherits_settings_model_when_default_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G1a inherit — when ``MutatorConfig.default_model is None``, the
+    telemetry resolver must fall back to ``Settings.model`` so the
+    summary line shows what the runner actually invoked."""
+    from core.cli.commands import self_improving
+
+    class _StubMutator:
+        default_model = None
+        source = "auto"
+
+    class _StubCfg:
+        mutator = _StubMutator()
+
+    class _StubSettings:
+        model = "claude-opus-4-7"
+
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        lambda: _StubCfg(),
+    )
+    monkeypatch.setattr("core.config.settings", _StubSettings())
+    model, source = self_improving._resolve_run_summary_telemetry()
+    assert model == "claude-opus-4-7"  # inherited from Settings.model
+    assert source == "auto"
+
+
+def test_resolve_telemetry_uses_explicit_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator-set ``default_model`` wins over the inherit fallback."""
+    from core.cli.commands import self_improving
+
+    class _StubMutator:
+        default_model = "claude-haiku-4-5-20251001"
+        source = "api_key"
+
+    class _StubCfg:
+        mutator = _StubMutator()
+
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        lambda: _StubCfg(),
+    )
+    model, source = self_improving._resolve_run_summary_telemetry()
+    assert model == "claude-haiku-4-5-20251001"
+    assert source == "api_key"
+
+
+def test_resolve_telemetry_returns_placeholders_on_config_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive — config-import failure (e.g. test stub) returns
+    ``("?", "?")`` so the slash never crashes on the summary line."""
+    from core.cli.commands import self_improving
+
+    def _broken_loader() -> None:
+        raise ImportError("simulated config layer missing")
+
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        _broken_loader,
+    )
+    model, source = self_improving._resolve_run_summary_telemetry()
+    assert model == "?"
+    assert source == "?"


### PR DESCRIPTION
## Summary

Wave 1 / 3 parallel PRs. Adds `model=...` + `source=...` to the `/self-improving run` final summary line so the operator can verify which channel was billed at the end of a confirmation cycle.

## Why

PR-MINIMAL-2 G1a made `MutatorConfig.default_model` inherit `Settings.model` when `None`. The runner picks the actual model at dispatch time; the operator can't easily see what just ran without grep'ing logs. PR-G4 surfaces the resolved (model, source) directly in the run summary.

## Changes

| File | Change |
|------|--------|
| `core/cli/commands/self_improving.py` | Summary line extended; new `_resolve_run_summary_telemetry` helper |
| `tests/test_run_summary_source_telemetry.py` | 4 new invariants |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Verification

- [x] ruff check clean
- [x] mypy clean (315 source files)
- [x] 48/48 pass on cluster (test_run_summary_source_telemetry + test_self_improving_run_slash + test_self_improving_status_slash)
- Full suite verification in CI

## Reference

Sprint plan: Wave 1 (parallel with G2 + MINIMAL-4)
Inherit path source: PR-MINIMAL-2 G1a

🤖 Generated with [Claude Code](https://claude.com/claude-code)