### PR TITLE
feat(self-improving-loop): PR-MINIMAL-4 — subprocess_failed SessionJournal event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-MINIMAL-4 — `subprocess_failed` SessionJournal event.**
+  Wave 1 / 3 PRs. Closes one of the two PR-MINIMAL-2 A3-deferred
+  observability gaps. ``autoresearch.train.run_audit`` pre-PR
+  only emitted ``subprocess_finished`` on every subprocess return;
+  the top-level ``audit_failed`` event caught the ``RuntimeError``
+  for non-zero exits but downstream consumers grouping by event
+  name lost subprocess-specific context. PR-MINIMAL-4 adds a
+  dedicated ``subprocess_failed`` (error level) event BEFORE the
+  ``raise RuntimeError`` so the typed event lands in the journal
+  even when the exception unwinds the stack. Payload carries
+  ``exit_code`` / ``run_log`` / ``stderr_tail`` (last 5 lines) for
+  at-a-glance triage. 4 invariant tests pin the new event, payload
+  shape, emit-before-raise ordering, and the preserved siblings.
+  D1 full 9→3 event collapse remains deferred — pure naming churn
+  with downstream consumer risk.
+
 ### Changed
 
 - **PR-MINIMAL-2 — 13-item alignment / pruning bundle for the

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -651,6 +651,24 @@ def run_audit(
     RUN_LOG.write_text(log_text, encoding="utf-8")
 
     if proc.returncode != 0:
+        # PR-MINIMAL-4 (2026-05-21) — non-zero subprocess exit emits an
+        # explicit ``subprocess_failed`` event before raising. The
+        # earlier ``subprocess_finished`` event carries ``exit_code``
+        # but downstream consumers grouping by event name need a
+        # *failure-specific* event to alert on; the top-level
+        # ``audit_failed`` catches the ``RuntimeError`` but loses the
+        # subprocess-specific context (exit_code, run_log path).
+        _emit_journal(
+            session_id,
+            gen_tag,
+            "subprocess_failed",
+            level="error",
+            payload={
+                "exit_code": proc.returncode,
+                "run_log": str(RUN_LOG),
+                "stderr_tail": proc.stderr.splitlines()[-5:] if proc.stderr else [],
+            },
+        )
         raise RuntimeError(f"audit subprocess exit={proc.returncode}; see {RUN_LOG}")
 
     summary_line = next(

--- a/tests/test_subprocess_failed_event.py
+++ b/tests/test_subprocess_failed_event.py
@@ -1,0 +1,75 @@
+"""PR-MINIMAL-4 — subprocess_failed journal event on non-zero exit.
+
+Pre-PR ``autoresearch/train.py:run_audit`` only emitted
+``subprocess_finished`` (with ``exit_code`` in the payload). The
+top-level ``audit_failed`` event at ``main()`` caught the resulting
+``RuntimeError`` but lost subprocess-specific context (exit_code,
+run_log path). PR-MINIMAL-4 inserts a dedicated
+``subprocess_failed`` event before the ``raise RuntimeError`` so
+downstream consumers grouping by event name can alert on it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_subprocess_failed_event_emitted_before_runtime_error() -> None:
+    """Source-grep the run_audit body — the non-zero-exit branch must
+    emit ``subprocess_failed`` BEFORE the ``raise RuntimeError`` so a
+    downstream consumer sees the typed event, not just the generic
+    top-level ``audit_failed`` catch."""
+    from autoresearch import train
+
+    src = inspect.getsource(train.run_audit)
+    # The event name appears in the source.
+    assert '"subprocess_failed"' in src, (
+        "run_audit must emit subprocess_failed when proc.returncode != 0 "
+        "so downstream consumers grouping by event name can alert on it."
+    )
+    # The event is emitted at error level.
+    # Pin the level so a refactor that drops it (and downgrades the
+    # event to default INFO) surfaces here.
+    assert 'level="error"' in src
+    # The event must come before the raise — same branch.
+    sub_idx = src.index('"subprocess_failed"')
+    raise_idx = src.index('raise RuntimeError(f"audit subprocess exit=')
+    assert sub_idx < raise_idx, (
+        "subprocess_failed event must be emitted BEFORE the RuntimeError "
+        "so the journal row lands even if the exception unwinds the stack."
+    )
+
+
+def test_subprocess_failed_payload_includes_exit_code_and_run_log() -> None:
+    """The payload must carry enough diagnostic context (exit_code,
+    run_log path, stderr tail) for the operator to triage without
+    having to grep the raw run.log."""
+    from autoresearch import train
+
+    src = inspect.getsource(train.run_audit)
+    # exit_code must be present in the payload
+    assert '"exit_code": proc.returncode' in src
+    # run_log path must be present in the payload
+    assert '"run_log": str(RUN_LOG)' in src
+    # stderr tail (best-effort, last 5 lines) for at-a-glance triage
+    assert '"stderr_tail"' in src
+
+
+def test_subprocess_finished_event_still_emitted() -> None:
+    """Pin that the existing ``subprocess_finished`` event still fires
+    on normal exit — PR-MINIMAL-4 ADDS a sibling event, doesn't
+    replace any existing one."""
+    from autoresearch import train
+
+    src = inspect.getsource(train.run_audit)
+    assert '"subprocess_finished"' in src
+
+
+def test_subprocess_timeout_event_still_emitted() -> None:
+    """The existing ``subprocess_timeout`` event (TimeoutExpired
+    branch) must still fire. PR-MINIMAL-4 leaves timeout-branch
+    behavior unchanged."""
+    from autoresearch import train
+
+    src = inspect.getsource(train.run_audit)
+    assert '"subprocess_timeout"' in src


### PR DESCRIPTION
## Summary

Wave 1 / 3 parallel PRs. Closes one of the PR-MINIMAL-2 A3-deferred observability gaps: `autoresearch.train.run_audit` now emits a dedicated `subprocess_failed` (error level) journal event before raising `RuntimeError` on non-zero subprocess exit.

## Why

Pre-PR consumers grouping journal events by name lost subprocess-specific context (exit_code, run_log path, stderr tail) when the subprocess failed — only the top-level `audit_failed` event caught it after the exception bubbled to `main()`. PR-MINIMAL-4 surfaces the failure at its source.

## Changes

| File | Change |
|------|--------|
| `autoresearch/train.py` | New `subprocess_failed` emit before `raise RuntimeError` in non-zero-exit branch |
| `tests/test_subprocess_failed_event.py` | 4 new invariants |
| `CHANGELOG.md` | `[Unreleased]` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `subprocess_failed` event | Implemented | level=error + payload {exit_code, run_log, stderr_tail} |
| `baseline_decision` actual emit | Verified existing | Already fires in main() at line 1235 |
| D1 full 9→3 event collapse | Deferred | Pure naming churn with downstream consumer risk |

## Verification

- [x] ruff check clean
- [x] mypy clean (363 source files)
- [x] 83/83 pass on cluster (test_subprocess_failed_event + test_autoresearch_train)
- Full suite verification in CI

## Reference

Sprint plan: Wave 1 (parallel with G2 + G4)
Deferred source: PR-MINIMAL-2 A3 audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)