### PR TITLE
docs(self-improving-loop): PR-C6 — Mode A operator manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ functional change.
 
 ### Added
 
+- **PR-C6 — `docs/operator-mode-a.md` Mode A operator manual.**
+  Wave 2 / pure docs. Documents the Karpathy-idiom path for
+  running the self-improving loop via an external Claude Code or
+  Codex CLI session (vs the GEODE CLI's `/self-improving run`
+  Mode B path). Covers boot recipes for both clients, the agent
+  contract pointer at ``autoresearch/program.md``, the shared
+  SoT inventory (5 policy files + audit ledger + baseline +
+  results), a Mode A vs Mode B comparison matrix with 8
+  dimensions (boot effort / iterations / confirmation / mutator
+  LLM / audit log / rollback / quota / cost gate), and decision
+  guidance for when each mode is the right choice. 7 invariant
+  tests pin the doc's presence, the all-5-SoT references, both
+  boot recipes, the design-doc cross-reference, the slash command
+  reference, the ledger reference, and the Karpathy minimal boot
+  prompt anchor.
+
 - **PR-G2 — `/model` mutator role-tab.** Wave 1 / 3 PRs.
   Extends the ``AGENT_ROLES`` registry (PR-A pattern: primary +
   reflection) with a third entry: ``mutator``. Pre-PR operators

--- a/docs/operator-mode-a.md
+++ b/docs/operator-mode-a.md
@@ -1,0 +1,166 @@
+# Mode A — operator manual (external agent runs the self-improving loop)
+
+> **Status**: doc-only (PR-C6, 2026-05-21). The GEODE CLI does NOT
+> trigger this mode — Mode A is a *manual long-horizon agent*
+> workflow. See `docs/plans/2026-05-21-self-improving-loop-ux.md`
+> for the Mode A vs Mode B comparison matrix.
+
+## TL;DR
+
+| Mode | Trigger | LLM that proposes mutations |
+|------|---------|----------------------------|
+| **A (this doc)** | An external Claude Code / Codex CLI session, manually started by you | Whatever model the external session runs |
+| **B** (`/self-improving run`) | The GEODE CLI slash command | `[self_improving_loop.mutator] default_model` (defaults to `Settings.model` via PR-MINIMAL-2 G1a) |
+
+Both modes write to the same 5 policy SoTs at
+`autoresearch/state/policies/*.json` (git-tracked since
+PR-RATCHET-1) and append the same `autoresearch/state/mutations.jsonl`
+ledger — so a campaign can mix Mode A and Mode B turns freely.
+Choose Mode A when you want a long-horizon agent reasoning over
+multiple mutations across a single session; choose Mode B when you
+want one tightly-scoped iteration with explicit confirmation.
+
+## Boot recipe (Claude Code)
+
+The original Karpathy-autoresearch idiom: the agent reads
+`autoresearch/program.md` as its baseline contract, then runs the
+loop autonomously.
+
+1. Open the repo at the branch you want to evolve:
+   ```bash
+   cd ~/workspace/geode
+   git checkout -b autoresearch/<run-tag> origin/develop
+   ```
+   The branch name convention is `autoresearch/<tag>` (per
+   `autoresearch/program.md` § Setup). The agent will commit each
+   experiment to this branch; the branch tip is "current best".
+
+2. Start a fresh Claude Code session in this repo root.
+
+3. Send the boot prompt (literally — Karpathy minimal idiom):
+   ```
+   Read program.md and start a new experiment. Begin with the
+   baseline for this PR.
+   ```
+   Claude Code resolves `program.md` to `autoresearch/program.md`
+   from its filesystem context (the repo root is the working
+   directory). The agent picks up the full 5-row mutation-kind
+   table introduced in PR-MINIMAL-2 C5 and the agent CAN/CANNOT
+   rules from § 63–78 of program.md.
+
+4. The agent will:
+   - Confirm the in-scope files with you (`prepare.py`,
+     `train.py`, `program.md`, `README.md`).
+   - Verify the seed pool tree at
+     `plugins/petri_audit/seeds/<tier>/<dim>/<NN>_<variant>.md`.
+   - Initialise `autoresearch/state/results.tsv` header.
+   - Wait for your "go" before the first audit.
+
+5. Each experiment iteration:
+   - Agent reads the current baseline + meta-review + 5 policy SoTs
+     from `autoresearch/state/policies/`.
+   - Agent edits ONE mutation target (per the program.md CAN list).
+   - Agent runs `uv run python autoresearch/train.py` and waits
+     for the `---` separator output.
+   - Agent decides promote/reject per the 3-rule gate in
+     `_should_promote`.
+   - Agent commits the change (the wrapper diff + the
+     `mutations.jsonl` append + the new `baseline.json` if
+     promoted). Branch tip advances.
+
+6. End the run: `git push origin autoresearch/<run-tag>` for
+   archival, or `git reset --hard origin/develop` to discard the
+   branch.
+
+## Boot recipe (Codex CLI)
+
+Mirror of the Claude Code recipe. Codex CLI also reads
+`autoresearch/program.md` from the working directory.
+
+```bash
+cd ~/workspace/geode
+git checkout -b autoresearch/<run-tag> origin/develop
+codex
+# Then send: "Read program.md and start a new experiment.
+# Begin with the baseline for this PR."
+```
+
+Codex CLI's OAuth flow handles model selection; the agent picks
+target/judge per the `[self_improving_loop.autoresearch]` toml
+section (PR-MINIMAL-2 G1a defaults to `Settings.model` for both).
+
+## Comparison with Mode B (`/self-improving run`)
+
+| Dimension | Mode A | Mode B |
+|-----------|--------|--------|
+| Boot effort | New agent session, manual prompt | One slash command |
+| Iterations | Many per session (operator-controlled exit) | 1 per `/run` (or `--n N`, max 10) |
+| Confirmation | Agent self-reviews per its program.md contract | Per-iteration `y/N/d/s` interactive prompt |
+| Mutator LLM | Whatever the external agent runs (typically Claude) | `MutatorConfig.default_model` (toml-only) |
+| Audit log | `git log` over branch | `/self-improving status` + `/self-improving history` (= same `git log`) |
+| Rollback | `git revert` / `git reset --hard <ref>` | `/self-improving rollback <id>` (= `git revert <commit>`) |
+| Subscription quota | External session's quota | `MutatorConfig.source` (auto / api_key / claude-cli / openai-codex) |
+| Cost gate | Manual — agent watches its quota | `~/.geode/config.toml` `warn_threshold` / `abort_threshold` + `fallback_to_payg` |
+
+## SoTs shared by both modes
+
+- `autoresearch/state/policies/wrapper-sections.json` —
+  WRAPPER_PROMPT_SECTIONS dict (legacy "prompt" target_kind)
+- `autoresearch/state/policies/tool-policy.json` — tool selection
+  policy
+- `autoresearch/state/policies/decomposition.json` —
+  decomposition heuristics
+- `autoresearch/state/policies/retrieval.json` — retrieval /
+  memory policies
+- `autoresearch/state/policies/reflection.json` — self-reflection
+  gate parameters
+- `autoresearch/state/mutations.jsonl` — git-tracked audit ledger
+  (one row per applied / rejected / rolled_back mutation)
+- `autoresearch/state/baseline.json` — fitness baseline snapshot
+  (writer: `autoresearch/train.py:_should_promote`)
+- `autoresearch/state/results.tsv` — operator-facing 12-col
+  results journal (writer: `autoresearch/train.py:main`)
+- `autoresearch/state/results.jsonl` — full 20-dim per-row
+  archive
+
+All paths are in-repo + git-trackable (PR-RATCHET-1 / B7 RATCHET).
+A campaign mixing Mode A and Mode B sees the same files — there
+is no "Mode A history" vs "Mode B history".
+
+## When Mode A is the right choice
+
+- **Long-horizon reasoning across mutations**. The external agent
+  can reflect on N consecutive mutation results, spot a pattern,
+  and decide to revert + retry differently — Mode B's single-iter
+  confirmation doesn't see N rounds of context.
+- **Cross-kind multi-step mutations**. The agent can decide that
+  `tool_policy` change A enables `prompt` change B; Mode B's
+  per-iteration scope doesn't carry that dependency.
+- **Cost-conscious campaigns**. Subscription OAuth on the agent
+  side keeps cost flat across many iterations.
+- **Exploratory hyperparameter sweeps** on `BUDGET_MINUTES` /
+  `MAX_TURNS` / `SEED_LIMIT` in `train.py` — Mode B doesn't expose
+  these knobs, the agent edits them directly per program.md.
+
+## When Mode B is the right choice
+
+- **Operator wants explicit consent per mutation**. The
+  confirmation prompt prevents surprise.
+- **Scheduled jobs**. Mode B is invokable from a `geode schedule`
+  task without booting a new agent session.
+- **Reproducibility**. The mutator LLM (model + source) is pinned
+  in `~/.geode/config.toml` — easier to audit "what model
+  proposed this mutation".
+
+## References
+
+- Karpathy autoresearch upstream:
+  https://github.com/karpathy/autoresearch (228791f, MIT 2026-03)
+- `autoresearch/README.md` — driver overview + role split with Petri
+- `autoresearch/program.md` — agent baseline instruction
+  (5-kind table in § 63–78)
+- `docs/plans/2026-05-21-self-improving-loop-ux.md` — Mode A vs B
+  matrix + UX design
+- PR-MINIMAL-2 #1398 — G1a Settings.model inherit (mutator) +
+  C5 program.md 5-kind table
+- PR-RATCHET-1 #1396 — 5 SoT files moved in-repo

--- a/tests/test_mode_a_operator_docs.py
+++ b/tests/test_mode_a_operator_docs.py
@@ -1,0 +1,83 @@
+"""PR-C6 — Mode A operator docs presence + cross-reference invariants.
+
+Pins:
+- ``docs/operator-mode-a.md`` exists on disk (git-tracked under docs/).
+- Doc references all 5 in-repo SoT policy files.
+- Doc references both boot recipes (Claude Code + Codex CLI).
+- Doc cross-references the design doc (2026-05-21-self-improving-loop-ux.md).
+- Doc compares Mode A vs Mode B with the matching slash command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read_mode_a_doc() -> str:
+    repo_root = Path(__file__).resolve().parent.parent
+    doc = repo_root / "docs" / "operator-mode-a.md"
+    assert doc.is_file(), (
+        "docs/operator-mode-a.md must exist on disk so Mode A operators "
+        "have a written boot recipe (PR-C6 closes the documentation gap)."
+    )
+    return doc.read_text(encoding="utf-8")
+
+
+def test_mode_a_doc_exists() -> None:
+    text = _read_mode_a_doc()
+    assert "Mode A" in text
+    assert "Karpathy" in text
+
+
+def test_mode_a_doc_references_all_5_policy_sots() -> None:
+    """The 5-kind policy table (PR-MINIMAL-2 C5) lists wrapper-sections /
+    tool-policy / decomposition / retrieval / reflection. Mode A
+    operators need to know which files they can edit; pin that the
+    doc surfaces all five so a refactor that adds / drops a kind
+    forces a docs update."""
+    text = _read_mode_a_doc()
+    for filename in (
+        "wrapper-sections.json",
+        "tool-policy.json",
+        "decomposition.json",
+        "retrieval.json",
+        "reflection.json",
+    ):
+        assert filename in text, f"docs/operator-mode-a.md must list {filename}"
+
+
+def test_mode_a_doc_references_both_boot_recipes() -> None:
+    """Doc covers Claude Code AND Codex CLI boot. Both clients are
+    valid Mode A entry points."""
+    text = _read_mode_a_doc()
+    assert "Claude Code" in text
+    assert "Codex CLI" in text
+
+
+def test_mode_a_doc_cross_references_design_doc() -> None:
+    """The design doc carries the canonical Mode A vs Mode B matrix.
+    Pin the cross-reference so an operator who lands on operator-mode-a.md
+    can find the full design."""
+    text = _read_mode_a_doc()
+    assert "docs/plans/2026-05-21-self-improving-loop-ux.md" in text
+
+
+def test_mode_a_doc_compares_to_slash_run() -> None:
+    """Pin the Mode B slash entry point reference so the doc explains
+    the choice point between Mode A and Mode B."""
+    text = _read_mode_a_doc()
+    assert "/self-improving run" in text
+
+
+def test_mode_a_doc_references_mutations_jsonl_ledger() -> None:
+    """Pin that the doc mentions the shared audit ledger — Mode A and
+    Mode B both write to the same git-tracked mutations.jsonl."""
+    text = _read_mode_a_doc()
+    assert "mutations.jsonl" in text
+
+
+def test_mode_a_doc_lists_program_md_recipe() -> None:
+    """Pin the canonical boot prompt (Karpathy minimal idiom)."""
+    text = _read_mode_a_doc()
+    assert "program.md" in text
+    assert "Begin with the baseline" in text


### PR DESCRIPTION
## Summary

Wave 2 / pure docs. Adds `docs/operator-mode-a.md` — the Karpathy-idiom external-agent path for running the self-improving loop (distinct from Mode B's `/self-improving run` slash).

## Why

The design doc (`docs/plans/2026-05-21-self-improving-loop-ux.md`) compares Mode A vs Mode B at the planning level. PR-C6 ships the operator-facing how-to: boot recipes for both Claude Code and Codex CLI, the shared-SoT inventory, the per-iteration agent contract pointer to `autoresearch/program.md`, and decision guidance for choosing between modes.

## Changes

| File | Change |
|------|--------|
| `docs/operator-mode-a.md` | New — 8-dimension Mode A vs Mode B matrix, boot recipes, shared-SoT inventory |
| `tests/test_mode_a_operator_docs.py` | 7 invariants — doc presence + all 5 SoT refs + both boot recipes + design-doc x-ref + slash x-ref + ledger ref + Karpathy prompt anchor |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Verification

- [x] ruff check clean
- [x] 7/7 pass on test_mode_a_operator_docs
- Full suite verification in CI

## Reference

Sprint plan: Wave 2 (parallel with RATCHET-2)
Design doc: `docs/plans/2026-05-21-self-improving-loop-ux.md`
program.md C5 anchor: PR-MINIMAL-2 #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)