### PR TITLE
fix(co-scientist): COSCI-1 — ranker naming + evolver tags + orchestrator abort gate

### DIFF
--- a/.claude/agents/seed_evolver.md
+++ b/.claude/agents/seed_evolver.md
@@ -20,7 +20,12 @@ You are the **Evolution** agent of the GEODE seed-generation (ADR-001, arXiv:250
 1. Read the candidate.
 2. Identify the section to rewrite (Reflection's `rewrite_section` is authoritative).
 3. Rewrite ONLY that section, preserving:
-   - Frontmatter unchanged.
+   - Frontmatter unchanged — this MUST include both
+     `target_dims` (co-scientist canonical attribution) AND
+     `tags` (Petri-compatible attribution, added in PR-OPS-1
+     for the Generator contract). An evolved seed with stripped
+     `tags` would silently lose Petri-side dim attribution
+     when the file flows through `flatten_for_inspect_petri`.
    - Total token budget within ±20% of original.
    - Target dim unchanged (`target_dims` frontmatter).
 4. Write the evolved version to `<run_dir>/candidates_evolved/<uuid>.md`.

--- a/.claude/agents/seed_ranker.md
+++ b/.claude/agents/seed_ranker.md
@@ -23,7 +23,7 @@ You are the **Ranking** agent of the GEODE seed-generation (ADR-001, arXiv:2502.
 
 ## Diversity guard
 
-Voters' `family` must span ≥ 2 (per manifest `required_diversity_families = 2`). Loader validates at startup; this agent only consumes the validated panel.
+Voters' `provider` must span ≥ 2 (per manifest `required_diversity_providers = 2`). Loader validates at startup; this agent only consumes the validated panel.
 
 ## Output (orchestrator state merge)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,38 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-COSCI-1 — co-scientist 3-item fix-up.** Wave-parallel
+  audit caught three issues in the seed_generation pipeline:
+  (HIGH) `.claude/agents/seed_ranker.md` diversity-guard sentence
+  referenced ``required_diversity_families = 2`` and ``Voters'
+  `family` must span ≥ 2`` — but the actual manifest field at
+  ``plugins/seed_generation/manifest.py:122`` is
+  ``required_diversity_providers`` (and ``VoterSpec`` carries
+  ``provider``, not ``family``). Contract reworded to match.
+  (MEDIUM) `.claude/agents/seed_evolver.md` "preserve frontmatter
+  unchanged" rule did not explicitly call out the ``tags`` field
+  that PR-OPS-1 added to ``seed_generator.md`` for Petri
+  compatibility — an evolved seed that strips ``tags`` during
+  rewrite would silently lose dim attribution on the Petri side
+  via ``flatten_for_inspect_petri``. Contract amended to mandate
+  ``tags`` preservation alongside ``target_dims``.
+  (MEDIUM) ``plugins/seed_generation/orchestrator.Pipeline.run``
+  walked all 7 phases unconditionally; pre-fix a generator that
+  produced 0 candidates (or a proximity phase that filtered all
+  candidates as duplicates) would silently run critic/pilot/
+  ranker against an empty pool, emit empty ``elo_ratings`` /
+  ``pilot_scores`` / ``survivors``, and finish "successfully"
+  with no signal. Added an empty-``state.candidates`` abort gate
+  after generator + proximity that logs a WARNING, emits an
+  ``empty_candidates_abort`` (error-level) SessionJournal event,
+  and breaks the phase loop so the operator sees the root cause.
+  5 invariant tests pin the ranker naming fix (positive +
+  negative grep), the evolver ``tags`` requirement, the
+  orchestrator abort gate source-grep, and the observability
+  event presence.
+
 ### Added
 
 - **PR-G2 — `/model` mutator role-tab.** Wave 1 / 3 PRs.

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -286,6 +286,40 @@ class Pipeline:
         started_at = time.time()
         for phase in _PHASE_ORDER:
             self._run_phase(phase)
+            # PR-COSCI-1 (2026-05-21) — abort early when the
+            # candidates pool is empty after a phase that should
+            # have populated or filtered it. Pre-fix the
+            # downstream phases (critic / pilot / ranker) would
+            # silently run with zero candidates and emit empty
+            # ``elo_ratings`` / ``pilot_scores`` / ``survivors``,
+            # making the operator chase a "successful but empty
+            # run" rather than the actual root cause. Phases
+            # AFTER generator must see candidates; ``meta_reviewer``
+            # is the only exception (operates on the run record,
+            # not the candidates pool).
+            if (
+                phase in {"generator", "proximity"}
+                and not self.state.candidates
+            ):
+                log.warning(
+                    "seed-generation aborting: phase %r left state.candidates empty "
+                    "(target_dim=%s, run_id=%s). Downstream phases would emit "
+                    "empty survivors/elo_ratings — abort early so the operator "
+                    "sees the root cause rather than a 'successful but empty' run.",
+                    phase,
+                    self.state.target_dim,
+                    self.state.run_id,
+                )
+                _emit_orchestrator_event(
+                    "empty_candidates_abort",
+                    level="error",
+                    payload={
+                        "after_phase": phase,
+                        "target_dim": self.state.target_dim,
+                        "run_id": self.state.run_id,
+                    },
+                )
+                break
         # P0b — cross-loop handoff runs FIRST so ``state.pool_path_out``
         # is stamped before ``_persist_state`` snapshots state.json.
         # Otherwise the offload would freeze a stale ``null`` for

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -297,10 +297,7 @@ class Pipeline:
             # AFTER generator must see candidates; ``meta_reviewer``
             # is the only exception (operates on the run record,
             # not the candidates pool).
-            if (
-                phase in {"generator", "proximity"}
-                and not self.state.candidates
-            ):
+            if phase in {"generator", "proximity"} and not self.state.candidates:
                 log.warning(
                     "seed-generation aborting: phase %r left state.candidates empty "
                     "(target_dim=%s, run_id=%s). Downstream phases would emit "

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -15,7 +15,15 @@ from plugins.seed_generation.orchestrator import (
 class _StubAgent(BaseSeedAgent):
     def __init__(self, role: str, output: dict[str, object] | None = None) -> None:
         super().__init__(role=role, model="stub-model")
-        self._output = output or {}
+        if output is None:
+            # PR-COSCI-1: the orchestrator now aborts the phase loop when
+            # generator/proximity leave ``state.candidates`` empty. Stubs
+            # that don't override ``output`` default to a single placeholder
+            # candidate so realistic full-7-phase fixtures still flow past
+            # the abort gate. Tests that explicitly pass ``output={...}``
+            # (including ``candidates=[]``) keep their precise semantics.
+            output = {"candidates": [{"id": f"stub-{role}-c"}]} if role == "generator" else {}
+        self._output = output
         self.invocations = 0
 
     def execute(self, state: PipelineState) -> SeedAgentResult:

--- a/tests/test_cosci_1_fixups.py
+++ b/tests/test_cosci_1_fixups.py
@@ -1,0 +1,95 @@
+"""PR-COSCI-1 — 3-item fix-up bundle for the co-scientist pipeline.
+
+Pins:
+- HIGH: seed_ranker.md naming mismatch resolved (``required_diversity_families`` → ``required_diversity_providers``).
+- MEDIUM: seed_evolver.md contract now mandates preserving ``tags`` frontmatter (PR-OPS-1 parity).
+- MEDIUM: orchestrator aborts early when generator/proximity leave ``state.candidates`` empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read_contract(name: str) -> str:
+    repo_root = Path(__file__).resolve().parent.parent
+    contract = repo_root / ".claude" / "agents" / name
+    assert contract.is_file(), f"missing agent contract: {contract}"
+    return contract.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# HIGH — seed_ranker.md naming alignment with manifest
+# ---------------------------------------------------------------------------
+
+
+def test_seed_ranker_contract_uses_providers_not_families() -> None:
+    """The manifest field is ``required_diversity_providers`` (verify
+    via grep on ``plugins/seed_generation/manifest.py:122``). The
+    ranker contract pre-PR said ``required_diversity_families`` —
+    misleading the agent. Pin the corrected name."""
+    text = _read_contract("seed_ranker.md")
+    # The correct manifest field name must appear
+    assert "required_diversity_providers" in text
+    # And the misleading legacy name must NOT
+    assert "required_diversity_families" not in text
+
+
+def test_seed_ranker_diversity_section_references_provider_not_family() -> None:
+    """The diversity-guard sentence must reference ``provider`` (the
+    actual ``VoterSpec`` field), not ``family`` (legacy term)."""
+    text = _read_contract("seed_ranker.md")
+    # Pin the corrected diversity-guard line phrase
+    assert "Voters' `provider` must span" in text
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM — seed_evolver.md tags-preservation contract
+# ---------------------------------------------------------------------------
+
+
+def test_seed_evolver_contract_mandates_tags_preservation() -> None:
+    """PR-OPS-1 amended seed_generator.md to emit both ``target_dims``
+    AND ``tags`` (Petri compat). Evolved seeds that strip ``tags``
+    during rewrite silently lose Petri-side dim attribution. Pin
+    the evolver contract requirement."""
+    text = _read_contract("seed_evolver.md")
+    assert "`tags`" in text
+    assert "Petri-compatible attribution" in text or "Petri-compatible" in text
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM — orchestrator empty-candidates abort gate
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_aborts_on_empty_candidates_after_generator(
+    monkeypatch,
+) -> None:
+    """When the generator phase leaves ``state.candidates == []``, the
+    orchestrator must abort BEFORE running critic/pilot/ranker rather
+    than emit a "successful but empty" run."""
+    import inspect
+
+    from plugins.seed_generation import orchestrator
+
+    src = inspect.getsource(orchestrator.Pipeline.run)
+    # The abort gate must check the post-phase state for empty
+    # candidates after generator or proximity. Pin presence.
+    assert "empty_candidates_abort" in src or "state.candidates empty" in src
+    # The gate must fire only after generator/proximity (the two
+    # phases that own the candidate pool's population/filtering).
+    assert "generator" in src and "proximity" in src
+
+
+def test_orchestrator_abort_emits_observability_event() -> None:
+    """The abort must emit an observability event so an operator
+    grepping the session journal sees the root cause."""
+    import inspect
+
+    from plugins.seed_generation import orchestrator
+
+    src = inspect.getsource(orchestrator.Pipeline.run)
+    assert '"empty_candidates_abort"' in src
+    # Error level — abort is a failure, not a normal state.
+    assert 'level="error"' in src


### PR DESCRIPTION
## Summary

3-item audit fix-up for the `plugins/seed_generation/` co-scientist multi-agent pipeline, surfaced during Wave 2 CI wait per the "지금 진행하면서 누수/누락 살펴" directive.

- **HIGH** — `seed_ranker.md` diversity-guard wording referenced the legacy `family`/`required_diversity_families` names; the manifest at `plugins/seed_generation/manifest.py:122` validates `required_diversity_providers` (and `VoterSpec` carries `provider`).
- **MEDIUM** — `seed_evolver.md` "preserve frontmatter unchanged" rule did not explicitly name the `tags` field that PR-OPS-1 added to `seed_generator.md` for Petri compatibility.
- **MEDIUM** — `Pipeline.run` walked all 7 phases unconditionally; an empty post-generator/post-proximity candidate pool would silently fan out to critic/pilot/ranker and finish "successfully" with empty payloads.

## Why

The seed_generation pipeline is the co-scientist arm of the self-improving loop. Three audit gaps were producing **silent contract drift** rather than loud failures:

1. The ranker agent contract told the LLM the manifest field was named `required_diversity_families`. The loader rejects panels at startup with the actual field name `required_diversity_providers`; an LLM consulting the contract to "self-debug" a startup failure would chase the wrong name.
2. PR-OPS-1 (`seed_generator.md`, merged earlier this sprint) added a `tags` frontmatter field for Petri-side dim attribution via `flatten_for_inspect_petri`. The Evolver was instructed to preserve "Frontmatter unchanged" but did not call `tags` out by name — an evolved seed that rewrote a section and stripped `tags` would silently break Petri attribution downstream.
3. `Pipeline.run` had no empty-pool gate. If the generator phase produced 0 candidates (e.g., a 4xx from the seed_generator subagent, an empty allow-list filter, a malformed prompt), the orchestrator would proceed to critic, pilot, ranker, evolver, meta_reviewer over an empty pool and emit a "successful" run with empty `elo_ratings`, empty `pilot_scores`, and empty `survivors`. The operator would see "run completed" in the journal and no error signal — the worst possible failure mode.

## Changes

| File | Change |
|------|--------|
| `.claude/agents/seed_ranker.md` | Diversity-guard sentence rewritten: ``Voters' `provider` must span ≥ 2 (per manifest `required_diversity_providers = 2`)``. |
| `.claude/agents/seed_evolver.md` | Algorithm step 3 expanded to explicitly mandate preserving both `target_dims` (co-scientist canonical) AND `tags` (Petri-compatible attribution, with cross-ref to PR-OPS-1 and `flatten_for_inspect_petri`). |
| `plugins/seed_generation/orchestrator.py` | `Pipeline.run` post-phase guard: when `phase in {"generator", "proximity"}` and `not self.state.candidates`, emit `empty_candidates_abort` SessionJournal event at `level="error"`, log WARNING, and `break` the phase loop. |
| `tests/test_cosci_1_fixups.py` | 5 invariants (see below). |
| `CHANGELOG.md` | `[Unreleased] → Fixed` entry. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Ranker `family`/`providers` rename in contract | Implemented | Positive grep + negative grep pinned in test |
| Evolver `tags` preservation in contract | Implemented | Cross-ref to PR-OPS-1 + `flatten_for_inspect_petri` |
| Orchestrator empty-candidates abort | Implemented | Guard fires only after generator/proximity (the two phases that own pool population/filtering) |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — `All checks passed!`
- [x] `uv run mypy core/ plugins/` — `Success: no issues found in 363 source files`
- [x] `uv run pytest tests/test_cosci_1_fixups.py -q` — 5/5 pass
- [ ] CI (will run on push)
- [ ] Codex MCP review (will run in parallel with CI)

## Reference

- Manifest field: `plugins/seed_generation/manifest.py:122` (`required_diversity_providers`).
- PR-OPS-1 (`tags` field added to seed_generator.md).
- Petri attribution: `flatten_for_inspect_petri` in `plugins/seed_generation/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)