### PR TITLE
feat(self-improving): S0a — tool_policy reader 신설 (ADR-012 dead slot #1 살리기)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,33 @@ functional change.
 
 ### Added
 
+- **PR-S0a — `tool_policy` reader 신설 (ADR-012 dead slot 살리기 #1).**
+  PR-AUDIT-5SLOT (#1405) 의 진단 — 5축 mutation 중 4축이 dead policy
+  (인퍼런스 reader 부재) — 의 첫 처치. `tool-policy.json` 정책이
+  실제 도구 후보 필터링에 적용되는 단일 진입점 신설. `wrapper-sections.json`
+  reader 패턴 (`system_prompt.py:_load_wrapper_override` +
+  `_strict_load`/`_graceful_load`) 그대로 차용. **schema** (3 field
+  모두 optional, forward-compatible): `allowed_tools` (whitelist) /
+  `forbidden_tools` (blacklist) / `priority_order` (호출 순서).
+  정책 부재 → no-op (현재 행동 보존). **Resolution order**:
+  ① `GEODE_TOOL_POLICY_OVERRIDE` env var (audit subprocess, strict —
+  schema 실패 시 RuntimeError) ② `~/.geode/self-improving-loop/tool-policy.json`
+  (daily-run SoT, graceful — schema 실패 시 WARNING + no-op) ③ `None`.
+  단일 적용 지점: `core/agent/loop/_helpers.py:get_agentic_tools` 의
+  마지막 단계 — base tools + ToolRegistry extras + MCP tools 가
+  모두 합쳐진 직후 정책 필터/재정렬 적용. ADR-012 의 G2 (5축 mutation
+  의 fitness delta 가 음의 압력 dim 에 편향 측정) 가 비로소 의미를
+  가지려면 이 reader 가 필수 — `broken_tool_use` dim 이 Petri 17-dim
+  중 유일한 양의 압력 dim 이라 `tool_policy` 진화 압력이 가장 직접
+  닿는 자리. **회귀 marker 의 의도된 발화**: PR-AUDIT-5SLOT 의 invariant
+  test `test_dead_slot_has_no_inference_reader` 의 parametrize 에서
+  `tool-policy.json` 제거 + 새 `test_tool_policy_slot_is_now_alive_post_s0a`
+  추가. audit doc 의 상태표에 Post-S0a (2026-05-21 오후) update
+  섹션 추가하여 2/5 ALIVE, 3/5 DEAD 명시. ADR-012 본문의 Tier 1 표
+  와 invariant test 의 ALIVE/DEAD exact count (`== 1` / `== 4` →
+  `== 2` / `== 3`) 동기화. 19개 new invariant test + 기존 PR-AUDIT-5SLOT
+  + ADR-012 test 함께 통과 (총 51 test 그린).
+
 - **ADR-012 — Self-Improvement Surface Tiers (Proposed).** GEODE 의
   self-improving loop 가 직면한 두 가지 직교 누수를 명시적으로
   진단하고, 단기 → 중기 → 장기 성장 곡선 + 의사결정 게이트

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -606,6 +606,13 @@ def run_audit(
     argv = _build_audit_command()
     env = os.environ.copy()
     env["GEODE_WRAPPER_OVERRIDE"] = str(override_path)
+    # ADR-012 S0a (2026-05-21) — audit subprocess 가 mutation 적용된
+    # tool_policy SoT 를 strict mode 로 읽도록 env 강제. 파일 부재 시
+    # subprocess 가 fail-fast (quota 절약).
+    from core.paths import GLOBAL_TOOL_POLICY_PATH
+
+    if GLOBAL_TOOL_POLICY_PATH.is_file():
+        env["GEODE_TOOL_POLICY_OVERRIDE"] = str(GLOBAL_TOOL_POLICY_PATH)
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/loop/_helpers.py
+++ b/core/agent/loop/_helpers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from core.agent.tool_policy import _load_tool_policy_override, apply_tool_policy
 from core.tools.base import load_all_tool_definitions
 
 if TYPE_CHECKING:
@@ -50,7 +51,10 @@ def get_agentic_tools(
             if name and name not in existing_names:
                 existing_names.add(name)
                 tools.append(mcp_tool)
-    return tools
+    # ADR-012 S0a — 5축의 ``tool_policy`` SoT 가 인퍼런스 경로에서
+    # 실제로 적용되는 단일 지점. 정책이 부재하면 ``apply_tool_policy``
+    # 는 no-op (현재 행동 보존).
+    return apply_tool_policy(tools, _load_tool_policy_override())
 
 
 # ---------------------------------------------------------------------------

--- a/core/agent/tool_policy.py
+++ b/core/agent/tool_policy.py
@@ -108,25 +108,50 @@ def _graceful_load(path: Path) -> dict[str, list[str]] | None:
 
 
 def _validate_schema(data: Any, path: Path, *, strict: bool) -> None:
-    """``data`` 가 ``dict[str, list[str]]`` 모양인지 확인.
+    """``data`` 가 ``dict`` 모양인지 + 알려진 field 가 ``list[str]`` 또는
+    ``str`` (comma/newline-separated) 인지 확인.
 
-    Unknown field 는 무시 (forward-compatible). 알려진 field 는 모두
-    list[str] 이어야 함."""
+    Read-write parity (Codex MCP catch, 2026-05-21) — ``write_policy()``
+    (`core/self_improving_loop/policies.py:194`) 는 SoT 파일을
+    ``dict[str, str]`` 로만 직렬화한다 (mutation 의 ``new_value`` 가
+    string). 따라서 reader 는 ``list[str]`` 뿐 아니라 **mutation 으로
+    쓰인 string payload 도 수용** 해야 한다 — comma 또는 newline 으로
+    split 해서 list 로 정규화. Unknown field 는 무시 (forward-compatible)."""
     if not isinstance(data, dict):
         raise RuntimeError(f"tool policy at {path} must be a dict")
     for key in _ALL_FIELDS:
-        if key in data and not _is_list_of_str(data[key]):
-            got = type(data[key]).__name__
-            raise RuntimeError(f"tool policy at {path} field {key!r} must be list[str]; got {got}")
-
-
-def _is_list_of_str(value: Any) -> bool:
-    return isinstance(value, list) and all(isinstance(x, str) for x in value)
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, list):
+            if not all(isinstance(x, str) for x in value):
+                raise RuntimeError(
+                    f"tool policy at {path} field {key!r} list must contain only str"
+                )
+        elif not isinstance(value, str):
+            got = type(value).__name__
+            raise RuntimeError(
+                f"tool policy at {path} field {key!r} must be list[str] or str; got {got}"
+            )
 
 
 def _coerce(data: dict[str, Any]) -> dict[str, list[str]]:
-    """알려진 3 field 만 추출해 normalized dict 반환."""
-    return {key: list(data[key]) for key in _ALL_FIELDS if key in data}
+    """알려진 3 field 만 추출 + string payload 는 comma/newline split.
+
+    Returns ``dict[str, list[str]]`` 정규화된 형태 — ``apply_tool_policy``
+    의 입력 contract 일치."""
+    result: dict[str, list[str]] = {}
+    for key in _ALL_FIELDS:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, list):
+            result[key] = list(value)
+        elif isinstance(value, str):
+            # comma 또는 newline separator. mutation 의 string payload 정규화.
+            items = [s.strip() for s in value.replace("\n", ",").split(",") if s.strip()]
+            result[key] = items
+    return result
 
 
 def apply_tool_policy(
@@ -164,6 +189,18 @@ def apply_tool_policy(
         if allowed is not None and name not in allowed:
             continue
         filtered.append(tool)
+
+    # Self-lock guard (Codex MCP catch, 2026-05-21) — 정책이 모든 도구를
+    # 제거하면 에이전트가 응답을 만들 수 있는 수단이 없음. 의도된 동작
+    # (정책으로 완전 차단) 일 수도 있으나 운영자가 실수로 빈 list 를
+    # 입력하면 silent failure. WARNING 으로 알림.
+    if tools and not filtered:
+        log.warning(
+            "tool policy filtered out all %d tools — agent has zero tools available. "
+            "이는 의도된 동작 (정책으로 완전 차단) 일 수 있으나, 실수로 "
+            "빈 allowed_tools 를 설정한 경우라면 정책을 확인하세요.",
+            len(tools),
+        )
 
     if not priority:
         return filtered

--- a/core/agent/tool_policy.py
+++ b/core/agent/tool_policy.py
@@ -1,0 +1,183 @@
+"""Tool policy SoT reader — ADR-012 S0a, dead slot 살리기.
+
+5축 mutation 의 ``tool_policy`` slot 은 PR-6 시점부터 SoT 파일
+(`autoresearch/tool-policy.json`) 만 정의되고 인퍼런스 reader 가 부재였다
+(PR-AUDIT-5SLOT 2026-05-21 진단). 이 모듈은 ``wrapper-sections.json``
+reader 의 패턴을 그대로 차용해 ``tool-policy.json`` 의 정책을 도구 후보
+필터링 단계에서 적용한다.
+
+**SoT schema** (모든 필드 optional):
+
+.. code-block:: json
+
+    {
+      "allowed_tools": ["bash", "read"],    # whitelist (선언되면 다른 도구 제외)
+      "forbidden_tools": ["write"],          # blacklist (선언되면 그 도구 제외)
+      "priority_order": ["bash", "read"]    # 호출 우선순위 (앞쪽이 먼저, 없는 것은 뒤)
+    }
+
+빈 정책 / 누락 / 부적합 schema → no-op (현재 행동 유지). 정책이 ALIVE
+신호를 내려면 셋 중 하나라도 비어 있지 않아야 한다.
+
+**Resolution order** (``_load_wrapper_override`` 와 동일):
+
+1. ``GEODE_TOOL_POLICY_OVERRIDE`` env var — audit subprocess hook,
+   strict load (schema 실패 시 RuntimeError 로 fail-fast).
+2. ``~/.geode/self-improving-loop/tool-policy.json`` — daily-run SoT,
+   graceful load (schema 실패 시 WARNING + ``None`` 반환).
+3. ``None`` — no-op (도구 목록 그대로).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_TOOL_POLICY_PATH
+
+log = logging.getLogger(__name__)
+
+_TOOL_POLICY_OVERRIDE_ENV = "GEODE_TOOL_POLICY_OVERRIDE"
+
+_TOOL_POLICY_SOT_PATH = GLOBAL_TOOL_POLICY_PATH
+"""Cross-process SoT path shared with :mod:`autoresearch.train` (S0a, 2026-05-21).
+
+``wrapper-sections.json`` reader 와 동일하게 module-local alias 를 둬서
+테스트가 ``core.agent.tool_policy._TOOL_POLICY_SOT_PATH`` 를 monkeypatch
+할 수 있도록 한다 (path-literal guard contract)."""
+
+
+# Schema field 이름들 — 외부 정책 파일과 1:1 mapping.
+_FIELD_ALLOWED = "allowed_tools"
+_FIELD_FORBIDDEN = "forbidden_tools"
+_FIELD_PRIORITY = "priority_order"
+_ALL_FIELDS = frozenset({_FIELD_ALLOWED, _FIELD_FORBIDDEN, _FIELD_PRIORITY})
+
+
+def _load_tool_policy_override() -> dict[str, list[str]] | None:
+    """Return the active tool policy dict, or ``None`` when no override applies.
+
+    Resolution order:
+
+    1. ``GEODE_TOOL_POLICY_OVERRIDE`` env var (audit subprocess) — strict.
+    2. ``~/.geode/self-improving-loop/tool-policy.json`` (daily run) — graceful.
+    3. ``None`` — no policy active.
+    """
+    override_path = os.environ.get(_TOOL_POLICY_OVERRIDE_ENV)
+    if override_path:
+        return _strict_load(Path(override_path))
+    if _TOOL_POLICY_SOT_PATH.is_file():
+        return _graceful_load(_TOOL_POLICY_SOT_PATH)
+    return None
+
+
+def _strict_load(path: Path) -> dict[str, list[str]]:
+    """Audit-subprocess path: schema 실패 시 ``RuntimeError`` (fail-fast)."""
+    if not path.is_file():
+        raise RuntimeError(f"{_TOOL_POLICY_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_TOOL_POLICY_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path, strict=True)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, list[str]] | None:
+    """Daily-run path: schema 실패 시 WARNING + ``None`` (graceful degrade).
+
+    Asymmetric handling vs ``_strict_load`` is intentional — 동일 사유
+    (``wrapper-sections.json`` reader 의 docstring 참조): 일상 ``geode``
+    호출이 손상된 self-improving-loop artifact 때문에 hard-fail 하면 안 됨."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("tool policy SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path, strict=False)
+    except RuntimeError as exc:
+        log.warning("tool policy SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path, *, strict: bool) -> None:
+    """``data`` 가 ``dict[str, list[str]]`` 모양인지 확인.
+
+    Unknown field 는 무시 (forward-compatible). 알려진 field 는 모두
+    list[str] 이어야 함."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"tool policy at {path} must be a dict")
+    for key in _ALL_FIELDS:
+        if key in data and not _is_list_of_str(data[key]):
+            got = type(data[key]).__name__
+            raise RuntimeError(f"tool policy at {path} field {key!r} must be list[str]; got {got}")
+
+
+def _is_list_of_str(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(x, str) for x in value)
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, list[str]]:
+    """알려진 3 field 만 추출해 normalized dict 반환."""
+    return {key: list(data[key]) for key in _ALL_FIELDS if key in data}
+
+
+def apply_tool_policy(
+    tools: list[dict[str, Any]],
+    policy: dict[str, list[str]] | None,
+) -> list[dict[str, Any]]:
+    """Apply ``policy`` to ``tools``. ``policy is None`` → ``tools`` 그대로.
+
+    Order of application:
+
+    1. **forbidden_tools** — 정책에 등장하는 이름의 도구 제외.
+    2. **allowed_tools** — 선언됐다면, 그 안에 등장하는 이름만 유지
+       (whitelist). 빈 list 면 모든 도구 제외 (의도된 동작 — 정책으로
+       완전 차단 가능).
+    3. **priority_order** — 정책에 등장하는 순서대로 재정렬. 정책에
+       없는 도구는 그 뒤에 원래 상대 순서 유지.
+
+    각 도구 dict 은 ``"name"`` 키를 갖는다는 contract (Anthropic Tool
+    Use schema). 이름이 없는 도구는 정책 영향을 받지 않고 그대로 통과.
+    """
+    if policy is None:
+        return tools
+    forbidden = set(policy.get(_FIELD_FORBIDDEN, []))
+    allowed: list[str] | None = policy.get(_FIELD_ALLOWED) if _FIELD_ALLOWED in policy else None
+    priority = policy.get(_FIELD_PRIORITY, [])
+
+    filtered: list[dict[str, Any]] = []
+    for tool in tools:
+        name = tool.get("name")
+        if not isinstance(name, str):
+            filtered.append(tool)
+            continue
+        if name in forbidden:
+            continue
+        if allowed is not None and name not in allowed:
+            continue
+        filtered.append(tool)
+
+    if not priority:
+        return filtered
+
+    priority_index = {name: i for i, name in enumerate(priority)}
+    last = len(priority_index)
+
+    def _sort_key(tool: dict[str, Any]) -> int:
+        name = tool.get("name")
+        if not isinstance(name, str):
+            return last
+        return priority_index.get(name, last)
+
+    return sorted(filtered, key=_sort_key)
+
+
+__all__ = ["apply_tool_policy"]

--- a/docs/adr/ADR-012-self-improvement-surface-tiers.md
+++ b/docs/adr/ADR-012-self-improvement-surface-tiers.md
@@ -14,11 +14,13 @@ GEODE 는 weight-invariant evolutionary agent 군 (AlphaEvolve / Voyager / Refle
 
 Petri 17-dim 중 **양의 압력 (성능 향상) 으로 작동하는 dim 은 사실상 `broken_tool_use` 1개** 뿐이고 나머지는 alignment / safety evaluation 축으로 음의 압력 ("안 망가지기") 이다. 17-dim 의 가중치가 동일 차원에 압축돼 fitness 의 정의역이 "에이전트가 망가지지 않는지" 에 쏠려 있다. seed pool 의 정교화 + skill 진화의 노력 대부분이 alignment dim 의 마이크로-튜닝으로 흡수되는 구조적 누수.
 
-### 발견 2 — Mutation 표면의 wiring 누수 (1/5)
+### 발견 2 — Mutation 표면의 wiring 누수 (audit 시점 1/5, S0a 이후 2/5)
 
-PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md`) 가 진단한 결과 — mutator 가 mutate 할 수 있다고 명세된 5 slot 중 인퍼런스 reader 가 살아있는 slot 은 `prompt` 하나뿐. 나머지 4 (`tool_policy` / `decomposition` / `retrieval` / `reflection`) 는 SoT 파일 + mutation dispatcher 는 있지만 **인퍼런스 경로에서 정책을 읽어 행동에 반영하는 reader 가 부재** — `core/self_improving_loop/policies.py:29-37` 의 docstring 이 직접 자백한다 (PR-6 의 의도적 follow-up 미완 + 잊혀짐).
+PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md`) 가 진단한 audit 시점 결과 — mutator 가 mutate 할 수 있다고 명세된 5 slot 중 인퍼런스 reader 가 살아있는 slot 은 `prompt` 하나뿐. 나머지 4 (`tool_policy` / `decomposition` / `retrieval` / `reflection`) 는 SoT 파일 + mutation dispatcher 는 있지만 **인퍼런스 경로에서 정책을 읽어 행동에 반영하는 reader 가 부재** — `core/self_improving_loop/policies.py:29-37` 의 docstring 이 직접 자백한다 (PR-6 의 의도적 follow-up 미완 + 잊혀짐).
 
-→ 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이다. 누수 대비 1/40 ~ 1/85 의 진화 효율.
+**S0a (2026-05-21 머지) 이후 상태**: `tool_policy` 가 ALIVE 로 전환 — `core/agent/tool_policy.py` 의 reader 가 `core/agent/loop/_helpers.py:get_agentic_tools` 에서 호출된다. 따라서 audit 시점 1/5 → 현재 2/5 ALIVE. 남은 dead slot 은 `decomposition` (S0c) / `retrieval` (S0d 처치 결정) / `reflection` (S0b).
+
+→ 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 audit 시점 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이었다 (1/40~1/85 누수). S0a 이후 2축 × 1-2dim = 2-4 면적으로 회복 중이고 S0b/c 완료 시 4축까지 회복 예정.
 
 ### 발견 3 — Fine-tune 표면의 채널 제약
 

--- a/docs/adr/ADR-012-self-improvement-surface-tiers.md
+++ b/docs/adr/ADR-012-self-improvement-surface-tiers.md
@@ -42,7 +42,7 @@ PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.
 | 표면 | 위치 | 현재 상태 | reader 상태 |
 |---|---|---|---|
 | 5축 SoT `prompt` | `wrapper-sections.json` | **가동 중** | **ALIVE** — `system_prompt.py:57` chain |
-| 5축 SoT `tool_policy` | `tool-policy.json` | mutation target 정의만 | **DEAD** — S0a reader 신설 필요 |
+| 5축 SoT `tool_policy` | `tool-policy.json` | **가동 중** (S0a, 2026-05-21) | **ALIVE** — `core/agent/tool_policy.py` (`_load_tool_policy_override` + `apply_tool_policy`) → `core/agent/loop/_helpers.py:get_agentic_tools` |
 | 5축 SoT `decomposition` | `decomposition.json` | mutation target 정의만 | **DEAD** — `core/orchestration/goal_decomposer.py` 가 `load_prompt("decomposer", "system")` 로 별도 SoT 사용 중. `decomposition.json` 미연결. S0c reader 신설 필요 |
 | 5축 SoT `retrieval` | `retrieval.json` | mutation target 정의만 | **DEAD** — RAG 인프라 부재. S0d 에서 deprecate 또는 보류 |
 | 5축 SoT `reflection` | `reflection.json` | mutation target 정의만 | **DEAD** — `core/agent/loop/_reflection.py:65-160` 의 `_REFLECTION_TOOL` 이 module-level constant. S0b reader 신설 필요 |

--- a/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
+++ b/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
@@ -36,7 +36,7 @@ infrastructure is committed before the policies that consume them.
 | Slot | SoT 파일 | Mutation target? | **인퍼런스 reader 위치** | 상태 |
 |---|---|---|---|---|
 | `prompt` | `wrapper-sections.json` | ✓ | `core/agent/system_prompt.py:57` (`_load_wrapper_override`) → `:79-80` (SoT fallback read) → `:194` (`build_system_prompt` 호출) → `:198/:210` (audit/normal mode inject) → `core/agent/loop/_context.py:103` → `core/agent/loop/agent_loop.py` (LLM 호출 경로) | **ALIVE** |
-| `tool_policy` | `tool-policy.json` | ✓ | **없음** — `paths.py:92`, `policies.py:130` 정의만 | **DEAD** |
+| `tool_policy` | `tool-policy.json` | ✓ | **audit 시점 없음** — `paths.py:92`, `policies.py:130` 정의만. **S0a 이후** `core/agent/tool_policy.py` (`_load_tool_policy_override` + `apply_tool_policy`) → `core/agent/loop/_helpers.py:get_agentic_tools` | **DEAD → ALIVE (S0a, 2026-05-21 머지)** |
 | `decomposition` | `decomposition.json` | ✓ | **없음** — `_decomposition.py:31` 의 `GoalDecomposer` 는 prompt 를 `core.llm.prompts.load_prompt("decomposer", "system")` 로 별도 SoT 에서 로드. 즉 hardcoded 가 아니지만 어느 경로도 `decomposition.json` 을 읽지 않음 — 그게 dead 사유 | **DEAD** |
 | `retrieval` | `retrieval.json` | ✓ | **없음** — `paths.py:94`, `policies.py:132` 정의만 | **DEAD** |
 | `reflection` | `reflection.json` | ✓ | **없음** — `core/agent/loop/_reflection.py:65-160` 의 `_REFLECTION_TOOL` schema + reflection prompt 가 module-level constant. `reflection.json` 미연결 | **DEAD** |
@@ -88,13 +88,13 @@ mutator LLM
 
 ## 6. DEAD slot 별 권고
 
-### 6a. `tool_policy`
+### 6a. `tool_policy` (S0a 머지 완료, 2026-05-21)
 
 | 항목 | 내용 |
 |---|---|
 | 의도 | 도구 선택/허용/우선순위 정책의 진화 (Voyager 의 tool selection 학습) |
-| 현재 | `tool-policy.json` 파일은 mutate 가능하지만 어떤 도구 호출 경로도 이걸 읽지 않음 |
-| 권고 A (살리기) | `core/agent/loop/AgenticLoop._select_tools()` 같은 진입 지점에서 `tool-policy.json` 의 정책 (e.g. allowed_tools / forbidden_tools / priority_order) 을 읽어 도구 후보를 필터. ~30 line 의 reader 추가로 가능 |
+| audit 시점 | `tool-policy.json` 파일은 mutate 가능하지만 어떤 도구 호출 경로도 이걸 읽지 않음 |
+| S0a 머지 후 | `core/agent/tool_policy.py` 신설 (`_load_tool_policy_override` + `apply_tool_policy`), `core/agent/loop/_helpers.py:get_agentic_tools` 의 단일 적용 지점에서 호출. schema: `allowed_tools` / `forbidden_tools` / `priority_order` (list[str] 또는 mutation 의 string payload 정규화) |
 | 권고 B (deprecate) | `TARGET_KINDS` 에서 제거. 5축 → 4축으로 축소 명시 |
 | ROI 추정 | **권고 A** — `broken_tool_use` dim 직접 영향. 5축 중 가장 양의 압력 우호적인 dim 이라 ROI 높음 |
 

--- a/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
+++ b/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
@@ -41,7 +41,17 @@ infrastructure is committed before the policies that consume them.
 | `retrieval` | `retrieval.json` | ✓ | **없음** — `paths.py:94`, `policies.py:132` 정의만 | **DEAD** |
 | `reflection` | `reflection.json` | ✓ | **없음** — `core/agent/loop/_reflection.py:65-160` 의 `_REFLECTION_TOOL` schema + reflection prompt 가 module-level constant. `reflection.json` 미연결 | **DEAD** |
 
-**총평**: 1/5 ALIVE, 4/5 DEAD.
+**총평** (audit 시점, 2026-05-21 오전): 1/5 ALIVE, 4/5 DEAD.
+
+### Post-S0a (2026-05-21 오후) update
+
+ADR-012 S0a (`tool_policy` reader 신설) 머지 후 상태:
+
+| Slot | 변동 | 새 reader 위치 |
+|---|---|---|
+| `tool_policy` | **DEAD → ALIVE** | `core/agent/tool_policy.py` 의 `_load_tool_policy_override` + `apply_tool_policy` → `core/agent/loop/_helpers.py:get_agentic_tools` (도구 후보 단일 진입점) |
+
+**현재 상태**: 2/5 ALIVE, 3/5 DEAD. 남은 dead slot: `decomposition` (S0b 예정) / `retrieval` (S0d 처치 결정 예정) / `reflection` (S0c 예정).
 
 ## 4. 인과 체인의 끊김
 

--- a/tests/test_adr_012_surface_tiers.py
+++ b/tests/test_adr_012_surface_tiers.py
@@ -56,14 +56,16 @@ def test_tier_1_lists_all_5_slots_with_alive_dead_status() -> None:
     text = _read_adr()
     for slot in ("prompt", "tool_policy", "decomposition", "retrieval", "reflection"):
         assert f"`{slot}`" in text, f"slot missing in Tier 1: {slot}"
-    # ALIVE = exactly 1 (prompt 만), DEAD = exactly 4 — Codex MCP 검증 결과 반영,
-    # 단순 ≥ 4 가 아니라 정확한 count 로 강화.
-    assert text.count("**ALIVE**") == 1, (
-        f"PR-AUDIT-5SLOT 결과 ALIVE slot 은 1 개여야 함. count={text.count('**ALIVE**')}"
+    # ALIVE/DEAD count — S0a 머지 (2026-05-21) 후 `tool_policy` ALIVE 로 전환.
+    # 현재 상태: 2 ALIVE (prompt + tool_policy) / 3 DEAD (decomposition/retrieval/reflection).
+    # S0b/c/d 머지 시마다 이 count 와 ADR Tier 1 표를 함께 갱신.
+    assert text.count("**ALIVE**") == 2, (
+        f"S0a 후 ALIVE slot 은 정확히 2 개 (prompt + tool_policy) 여야 함. "
+        f"count={text.count('**ALIVE**')}"
     )
-    assert text.count("**DEAD**") == 4, (
-        f"PR-AUDIT-5SLOT 결과 DEAD slot 은 정확히 4 개여야 함. "
-        f"count={text.count('**DEAD**')} (S0a-c 의 reader 신설 후 ADR 갱신 시 함께 수정)"
+    assert text.count("**DEAD**") == 3, (
+        f"S0a 후 DEAD slot 은 정확히 3 개 (decomposition + retrieval + reflection) 여야 함. "
+        f"count={text.count('**DEAD**')} (S0b/c/d 의 reader 신설 후 함께 수정)"
     )
 
 

--- a/tests/test_s0a_tool_policy_reader.py
+++ b/tests/test_s0a_tool_policy_reader.py
@@ -55,9 +55,17 @@ def test_load_returns_none_when_sot_unreadable_json(isolated_sot: Path) -> None:
     assert _load_tool_policy_override() is None
 
 
-def test_load_returns_none_when_sot_schema_violation(isolated_sot: Path) -> None:
-    """``allowed_tools`` 가 list[str] 가 아니면 ``None`` (graceful)."""
-    _write(isolated_sot, {"allowed_tools": "not-a-list"})
+def test_load_string_payload_normalizes_to_list(isolated_sot: Path) -> None:
+    """Producer parity (Codex MCP) — string payload 는 schema violation 이
+    아니라 정규화 대상. ``"bash, read"`` → ``["bash", "read"]``."""
+    _write(isolated_sot, {"allowed_tools": "bash, read"})
+    result = _load_tool_policy_override()
+    assert result == {"allowed_tools": ["bash", "read"]}
+
+
+def test_load_returns_none_when_sot_type_violation(isolated_sot: Path) -> None:
+    """list 도 string 도 아닌 type (e.g. dict, int) → graceful ``None``."""
+    _write(isolated_sot, {"allowed_tools": {"nested": "dict"}})
     assert _load_tool_policy_override() is None
 
 
@@ -90,12 +98,13 @@ def test_strict_load_via_env_var_raises_on_missing(
         _load_tool_policy_override()
 
 
-def test_strict_load_via_env_var_raises_on_schema_violation(
+def test_strict_load_via_env_var_raises_on_type_violation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """audit subprocess 는 schema 위반 시 RuntimeError (fail-fast)."""
+    """audit subprocess 는 type 위반 (list 도 string 도 아님) 시 RuntimeError (fail-fast).
+    Producer parity 확장 후 string 은 valid → dict/int 등 다른 type 만 violation."""
     bad = tmp_path / "bad.json"
-    bad.write_text(json.dumps({"forbidden_tools": "not-a-list"}), encoding="utf-8")
+    bad.write_text(json.dumps({"forbidden_tools": {"nested": "dict"}}), encoding="utf-8")
     monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(bad))
     with pytest.raises(RuntimeError, match="forbidden_tools"):
         _load_tool_policy_override()
@@ -169,6 +178,18 @@ def test_apply_full_policy_filter_and_reorder() -> None:
     assert [t["name"] for t in result] == ["d", "a"]
 
 
+def test_apply_zero_tool_self_lock_emits_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Self-lock guard (Codex MCP catch) — 정책이 모든 도구 제거 시 WARNING.
+    의도된 동작 (정책으로 완전 차단) 일 수 있으나 silent 가 아니어야 함."""
+    tools = _tools("a", "b")
+    with caplog.at_level("WARNING"):
+        result = apply_tool_policy(tools, {"allowed_tools": []})
+    assert result == []
+    assert any("zero tools available" in r.message for r in caplog.records), (
+        "self-lock 발생 시 WARNING log 필수 — 운영자 실수 catch 용."
+    )
+
+
 def test_apply_unnamed_tool_passes_through() -> None:
     """``name`` 이 없는 도구는 정책 영향 없이 통과."""
     tools: list[dict[str, Any]] = [{"name": "a"}, {"description": "unnamed"}]
@@ -223,7 +244,74 @@ def test_get_agentic_tools_forbidden_filter_round_trip(
 
 
 # ---------------------------------------------------------------------------
-# 4. ALIVE slot 신호 — `tool-policy.json` 이 인퍼런스 경로에서 참조됨
+# 4. Producer → Reader round trip (Codex MCP catch, 2026-05-21)
+#    write_policy() 가 dict[str, str] 만 직렬화하므로 mutation 의 string
+#    payload 가 reader 의 list[str] schema 와 호환되는지 검증.
+# ---------------------------------------------------------------------------
+
+
+def test_producer_string_payload_normalized_by_reader(
+    isolated_sot: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``write_policy("tool_policy", {...string...})`` → reader 가 정규화.
+
+    Producer ``core/self_improving_loop/policies.py:write_policy`` 는
+    ``dict[str, str]`` 만 직렬화한다 (mutation 의 ``new_value`` 가 string).
+    Reader 가 그 string payload (comma/newline-separated) 를 list 로
+    정규화해야 read-write parity 가 성립."""
+    from core.self_improving_loop import policies as policies_mod
+
+    monkeypatch.setattr(policies_mod, "policy_path", lambda kind: isolated_sot)
+    # Producer 처럼 dict[str, str] 로 직렬화 — mutation 시뮬레이션
+    policies_mod.write_policy("tool_policy", {"forbidden_tools": "bash, write"})
+
+    result = _load_tool_policy_override()
+    assert result is not None, "string payload 가 reader 에서 graceful 무시되면 parity 깨짐"
+    assert result.get("forbidden_tools") == ["bash", "write"], (
+        f"comma-separated string 이 list 로 정규화돼야 함. got={result}"
+    )
+
+
+def test_producer_newline_separated_payload(
+    isolated_sot: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Newline-separated string payload 도 list 로 정규화."""
+    from core.self_improving_loop import policies as policies_mod
+
+    monkeypatch.setattr(policies_mod, "policy_path", lambda kind: isolated_sot)
+    policies_mod.write_policy("tool_policy", {"allowed_tools": "bash\nread\ngrep"})
+
+    result = _load_tool_policy_override()
+    assert result is not None
+    assert result.get("allowed_tools") == ["bash", "read", "grep"]
+
+
+def test_producer_reader_e2e_filters_get_agentic_tools(
+    isolated_sot: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end — producer (string payload) → reader → get_agentic_tools.
+
+    이게 통과해야 mutation 이 실제 fitness 압력을 만들 수 있음."""
+    from core.self_improving_loop import policies as policies_mod
+
+    monkeypatch.setattr(policies_mod, "policy_path", lambda kind: isolated_sot)
+    base = get_agentic_tools()
+    assert base, "base tools must exist for this E2E test"
+
+    target = base[0]["name"]
+    # producer 가 string 으로 mutation 출력 (실제 시나리오)
+    policies_mod.write_policy("tool_policy", {"forbidden_tools": target})
+
+    after = get_agentic_tools()
+    names = [t["name"] for t in after]
+    assert target not in names, (
+        f"E2E parity 깨짐 — producer 의 string payload 가 reader 를 통과해 "
+        f"get_agentic_tools 에서 {target} 가 필터되어야 함. names={names[:5]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. ALIVE slot 신호 — `tool-policy.json` 이 인퍼런스 경로에서 참조됨
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_s0a_tool_policy_reader.py
+++ b/tests/test_s0a_tool_policy_reader.py
@@ -1,0 +1,250 @@
+"""ADR-012 S0a — `tool_policy` reader invariants.
+
+`tool-policy.json` 의 정책이 인퍼런스 경로에서 실제로 도구 후보를
+필터/재정렬하는지 검증한다. 이 test 가 통과한 시점부터 5축의
+`tool_policy` slot 은 ALIVE 이며, PR-AUDIT-5SLOT 의 dead anchor
+회귀 marker 가 함께 갱신되어야 한다 (의도된 회귀).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.agent.loop._helpers import get_agentic_tools
+from core.agent.tool_policy import _load_tool_policy_override, apply_tool_policy
+
+from core.agent import tool_policy
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Monkeypatch ``_TOOL_POLICY_SOT_PATH`` to tmp_path so tests don't read
+    or pollute the operator's real SoT at ``~/.geode/self-improving-loop/``."""
+    sot = tmp_path / "tool-policy.json"
+    monkeypatch.setattr(tool_policy, "_TOOL_POLICY_SOT_PATH", sot)
+    monkeypatch.delenv("GEODE_TOOL_POLICY_OVERRIDE", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Reader — SoT 파일 존재/부재/손상 시 동작
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    """SoT 파일 부재 → ``None`` (no-op)."""
+    assert not isolated_sot.exists()
+    assert _load_tool_policy_override() is None
+
+
+def test_load_returns_none_when_sot_unreadable_json(isolated_sot: Path) -> None:
+    """Malformed JSON → WARNING + ``None`` (graceful)."""
+    isolated_sot.write_text("not json {", encoding="utf-8")
+    assert _load_tool_policy_override() is None
+
+
+def test_load_returns_none_when_sot_schema_violation(isolated_sot: Path) -> None:
+    """``allowed_tools`` 가 list[str] 가 아니면 ``None`` (graceful)."""
+    _write(isolated_sot, {"allowed_tools": "not-a-list"})
+    assert _load_tool_policy_override() is None
+
+
+def test_load_returns_dict_when_sot_valid(isolated_sot: Path) -> None:
+    """유효한 SoT → 정책 dict 반환."""
+    payload = {
+        "allowed_tools": ["bash", "read"],
+        "forbidden_tools": ["write"],
+        "priority_order": ["read", "bash"],
+    }
+    _write(isolated_sot, payload)
+    result = _load_tool_policy_override()
+    assert result == payload
+
+
+def test_load_unknown_fields_ignored(isolated_sot: Path) -> None:
+    """Forward-compat — 알려지지 않은 field 는 무시."""
+    _write(isolated_sot, {"allowed_tools": ["bash"], "unknown_field": "ignored"})
+    result = _load_tool_policy_override()
+    assert result == {"allowed_tools": ["bash"]}
+
+
+def test_strict_load_via_env_var_raises_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``GEODE_TOOL_POLICY_OVERRIDE`` 가 가리키는 파일이 없으면 RuntimeError."""
+    missing = tmp_path / "nope.json"
+    monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(missing))
+    with pytest.raises(RuntimeError, match="GEODE_TOOL_POLICY_OVERRIDE"):
+        _load_tool_policy_override()
+
+
+def test_strict_load_via_env_var_raises_on_schema_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """audit subprocess 는 schema 위반 시 RuntimeError (fail-fast)."""
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"forbidden_tools": "not-a-list"}), encoding="utf-8")
+    monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(bad))
+    with pytest.raises(RuntimeError, match="forbidden_tools"):
+        _load_tool_policy_override()
+
+
+# ---------------------------------------------------------------------------
+# 2. apply_tool_policy — 정책의 실제 효과
+# ---------------------------------------------------------------------------
+
+
+def _tools(*names: str) -> list[dict[str, Any]]:
+    return [{"name": n} for n in names]
+
+
+def test_apply_none_policy_is_noop() -> None:
+    """``policy is None`` → 입력 그대로 반환."""
+    tools = _tools("a", "b", "c")
+    assert apply_tool_policy(tools, None) == tools
+
+
+def test_apply_empty_policy_dict_is_noop() -> None:
+    """빈 dict 정책 → 입력 그대로."""
+    tools = _tools("a", "b", "c")
+    assert apply_tool_policy(tools, {}) == tools
+
+
+def test_apply_forbidden_tools_excludes_named() -> None:
+    """forbidden 에 등장한 도구는 결과에서 제외."""
+    tools = _tools("a", "b", "c")
+    result = apply_tool_policy(tools, {"forbidden_tools": ["b"]})
+    assert [t["name"] for t in result] == ["a", "c"]
+
+
+def test_apply_allowed_tools_whitelist() -> None:
+    """allowed 가 선언되면 그 안에 있는 도구만 유지."""
+    tools = _tools("a", "b", "c")
+    result = apply_tool_policy(tools, {"allowed_tools": ["a", "c"]})
+    assert [t["name"] for t in result] == ["a", "c"]
+
+
+def test_apply_priority_order_reorders() -> None:
+    """priority 가 선언되면 그 순서대로 재정렬, 정책에 없는 도구는 뒤로."""
+    tools = _tools("a", "b", "c", "d")
+    result = apply_tool_policy(tools, {"priority_order": ["c", "a"]})
+    # c, a 가 앞으로 + b, d 는 원래 상대 순서 유지
+    assert [t["name"] for t in result] == ["c", "a", "b", "d"]
+
+
+def test_apply_forbidden_and_allowed_combined() -> None:
+    """forbidden 먼저, allowed 다음."""
+    tools = _tools("a", "b", "c", "d")
+    result = apply_tool_policy(
+        tools,
+        {"allowed_tools": ["a", "b", "c"], "forbidden_tools": ["b"]},
+    )
+    assert [t["name"] for t in result] == ["a", "c"]
+
+
+def test_apply_full_policy_filter_and_reorder() -> None:
+    """3 field 모두 적용."""
+    tools = _tools("a", "b", "c", "d")
+    result = apply_tool_policy(
+        tools,
+        {
+            "allowed_tools": ["a", "b", "d"],
+            "forbidden_tools": ["b"],
+            "priority_order": ["d", "a"],
+        },
+    )
+    # b 제외, a/d 만 살아남고 d 가 앞
+    assert [t["name"] for t in result] == ["d", "a"]
+
+
+def test_apply_unnamed_tool_passes_through() -> None:
+    """``name`` 이 없는 도구는 정책 영향 없이 통과."""
+    tools: list[dict[str, Any]] = [{"name": "a"}, {"description": "unnamed"}]
+    result = apply_tool_policy(tools, {"forbidden_tools": ["a"]})
+    # a 제외, unnamed 는 통과
+    assert len(result) == 1
+    assert "name" not in result[0]
+
+
+# ---------------------------------------------------------------------------
+# 3. get_agentic_tools — 도구 호출 경로의 단일 진입점 통합
+# ---------------------------------------------------------------------------
+
+
+def test_get_agentic_tools_applies_policy(
+    isolated_sot: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``get_agentic_tools`` 가 ``tool-policy.json`` 정책을 실제로 적용해야 함.
+    `tool_policy` slot 이 ALIVE 임을 증명하는 핵심 test."""
+    # 정책: 모든 도구 제거 (whitelist = []).
+    _write(isolated_sot, {"allowed_tools": []})
+    result = get_agentic_tools()
+    assert result == [], (
+        "tool-policy.json 의 allowed_tools=[] 정책이 적용되어야 하는데 도구가 살아있음 — "
+        f"reader wiring 깨졌을 가능성. count={len(result)}"
+    )
+
+
+def test_get_agentic_tools_noop_without_policy(
+    isolated_sot: Path,
+) -> None:
+    """정책 부재 시 기존 동작 유지 — base + registry + mcp tools 그대로."""
+    assert not isolated_sot.exists()
+    result = get_agentic_tools()
+    # 정책 없을 때는 base tools 최소 1개 이상 (load_all_tool_definitions 가 비어있지 않음).
+    assert len(result) > 0
+
+
+def test_get_agentic_tools_forbidden_filter_round_trip(
+    isolated_sot: Path,
+) -> None:
+    """base tools 중 하나를 forbidden 으로 지정하면 결과에서 제외."""
+    base_result = get_agentic_tools()
+    assert base_result, "base tools should be non-empty for this test"
+    target = base_result[0]["name"]
+    _write(isolated_sot, {"forbidden_tools": [target]})
+    filtered = get_agentic_tools()
+    names = [t["name"] for t in filtered]
+    assert target not in names, (
+        f"forbidden_tools=[{target}] 정책이 적용되어야 하는데 {target} 가 살아있음."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. ALIVE slot 신호 — `tool-policy.json` 이 인퍼런스 경로에서 참조됨
+# ---------------------------------------------------------------------------
+
+
+def test_tool_policy_json_is_now_referenced_in_inference_path() -> None:
+    """ADR-012 S0a 의 핵심 결과 — `tool-policy.json` 이 `core/agent/` 경로
+    어딘가에서 grep 가능. PR-AUDIT-5SLOT 의 dead anchor 회귀 marker 의
+    의도된 발화 (DEAD → ALIVE)."""
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core" / "agent").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "tool-policy.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    # 적어도 tool_policy.py 의 path constant alias 위치에서 발견되어야 함
+    assert any("tool_policy.py" in h for h in hits), (
+        f"tool-policy.json 이 core/agent/tool_policy.py 에서 발견되어야 함. hits={hits}"
+    )

--- a/tests/test_self_improving_5_slot_reader_audit.py
+++ b/tests/test_self_improving_5_slot_reader_audit.py
@@ -95,7 +95,12 @@ def test_audit_doc_exists() -> None:
 def test_audit_doc_pins_1_alive_4_dead() -> None:
     """결론 한 줄 anchor."""
     text = _read(AUDIT_DOC)
-    assert "1/5 ALIVE, 4/5 DEAD" in text
+    # ADR-012 S0a (2026-05-21) 머지 이후 `tool_policy` 가 ALIVE 로 전환.
+    # audit 시점 (2026-05-21 아침) 의 사실은 1/5 — 그 줄을 유지하면서
+    # post-S0a update 섹션이 함께 등장하는지 확인.
+    assert "1/5 ALIVE, 4/5 DEAD" in text  # 원본 audit 시점 사실
+    assert "Post-S0a" in text  # S0a 후속 갱신 섹션
+    assert "2/5 ALIVE, 3/5 DEAD" in text  # 현재 상태
 
 
 def test_audit_doc_names_all_5_slots() -> None:
@@ -140,7 +145,9 @@ def test_prompt_reader_is_called_in_agentic_loop() -> None:
 @pytest.mark.parametrize(
     "sot_filename",
     [
-        "tool-policy.json",
+        # ADR-012 S0a (2026-05-21) 머지 이후 ``tool-policy.json`` 은 ALIVE —
+        # ``core/agent/tool_policy.py`` 의 reader 가 ``core/agent/loop/_helpers.py``
+        # 의 ``get_agentic_tools`` 에서 호출된다. 이 parametrize 에서 제거됨.
         "decomposition.json",
         "retrieval.json",
         "reflection.json",
@@ -150,14 +157,25 @@ def test_dead_slot_has_no_inference_reader(sot_filename: str) -> None:
     """DEAD slot 의 SoT 파일명이 인퍼런스 경로 (core/agent + core/orchestration +
     core/skills + core/llm + plugins + autoresearch — self_improving_loop
     의 mutation 정의/디스패처는 제외) 어디에서도 참조되지 않음을 pin.
-    S0a/b/c PR 에서 reader 가 신설되면 이 test 가 실패해서 함께
-    갱신해야 한다 (의도된 anchor 회귀)."""
+    S0b/c PR 에서 reader 가 신설되면 이 test 가 실패해서 함께 갱신해야
+    한다 (의도된 anchor 회귀)."""
     hits = _grep_inference_dirs(sot_filename)
     # 0 hits 가 정상 (DEAD)
     assert hits == [], (
         f"DEAD slot {sot_filename!r} 의 reader 가 발견됨. "
-        f"S0a/b/c 권고의 reader 신설이라면 이 test 와 audit doc 의 상태표를 "
+        f"S0b/c 권고의 reader 신설이라면 이 test 와 audit doc 의 상태표를 "
         f"ALIVE 로 갱신해야 함. hits={hits}"
+    )
+
+
+def test_tool_policy_slot_is_now_alive_post_s0a() -> None:
+    """ADR-012 S0a 머지 이후 ``tool-policy.json`` 은 ALIVE — reader 가
+    ``core/agent/tool_policy.py`` 에 존재. PR-AUDIT-5SLOT 의 의도된
+    회귀 marker 의 발화 결과."""
+    hits = _grep_inference_dirs("tool-policy.json")
+    # tool_policy.py 의 path constant alias 위치 + _helpers.py 의 호출 위치
+    assert any("tool_policy.py" in h for h in hits), (
+        f"tool-policy.json 이 core/agent/tool_policy.py 에서 발견되어야 함. hits={hits}"
     )
 
 

--- a/tests/test_self_improving_5_slot_reader_audit.py
+++ b/tests/test_self_improving_5_slot_reader_audit.py
@@ -170,12 +170,22 @@ def test_dead_slot_has_no_inference_reader(sot_filename: str) -> None:
 
 def test_tool_policy_slot_is_now_alive_post_s0a() -> None:
     """ADR-012 S0a 머지 이후 ``tool-policy.json`` 은 ALIVE — reader 가
-    ``core/agent/tool_policy.py`` 에 존재. PR-AUDIT-5SLOT 의 의도된
-    회귀 marker 의 발화 결과."""
+    ``core/agent/tool_policy.py`` 에 존재 + ``_helpers.py`` 의 도구 통합
+    경로에서 실제로 호출됨. PR-AUDIT-5SLOT 의 의도된 회귀 marker 의
+    발화 결과 (Codex MCP catch — cosmetic 검증 → call chain 검증)."""
     hits = _grep_inference_dirs("tool-policy.json")
     # tool_policy.py 의 path constant alias 위치 + _helpers.py 의 호출 위치
     assert any("tool_policy.py" in h for h in hits), (
         f"tool-policy.json 이 core/agent/tool_policy.py 에서 발견되어야 함. hits={hits}"
+    )
+    # Call chain 검증 — _helpers.get_agentic_tools 가 _load_tool_policy_override 를 호출.
+    helpers_src = (REPO_ROOT / "core/agent/loop/_helpers.py").read_text(encoding="utf-8")
+    assert "_load_tool_policy_override" in helpers_src, (
+        "_helpers.py 가 _load_tool_policy_override 를 import/호출해야 함 — "
+        "reader 가 inference 경로에 실제로 wired 됐는지 검증."
+    )
+    assert "apply_tool_policy" in helpers_src, (
+        "_helpers.py 가 apply_tool_policy 를 호출해야 함 — 정책이 도구 목록에 적용되는지."
     )
 
 


### PR DESCRIPTION
## Summary

- ADR-012 (#1406) 의 단기 시퀀스 첫 번째. PR-AUDIT-5SLOT (#1405) 가 진단한 4 dead slot 중 \`tool_policy\` 를 살림.
- 단일 진입점 (\`core/agent/loop/_helpers.py:get_agentic_tools\`) 에서 \`tool-policy.json\` 의 정책 (allowed/forbidden/priority) 을 도구 후보에 적용.
- 회귀 marker 의 의도된 발화 — PR-AUDIT-5SLOT 의 DEAD anchor 가 갱신되어 audit doc 의 상태표가 1/5 → 2/5 ALIVE 로.

## Why

5축 mutation 중 4축이 dead policy (PR-AUDIT-5SLOT 진단). \`tool_policy\` 가 살아나면:
- Petri 17-dim 중 유일한 양의 압력 dim \`broken_tool_use\` 에 진화 압력 직접 닿음
- ADR-012 의 G2 게이트 (음의 압력 90%+ 편향 측정) 가 비로소 의미를 가짐
- S0b/c (reflection/decomposition) 와 같은 패턴으로 후속 PR 들이 따라옴

\`wrapper-sections.json\` reader (\`system_prompt.py:_load_wrapper_override\`) 의 검증된 패턴 그대로 차용 — frontier 3+ 시스템 (Voyager / Claude Code settings / AlphaEvolve) 의 공통 정책-슬롯 디자인.

## Changes

| 파일 | 변경 |
|------|------|
| \`core/agent/tool_policy.py\` | 신설 — \`_load_tool_policy_override\` + \`apply_tool_policy\` + \`_strict_load\`/\`_graceful_load\` |
| \`core/agent/loop/_helpers.py\` | \`get_agentic_tools\` 마지막에 \`apply_tool_policy(..., _load_tool_policy_override())\` 호출 추가 |
| \`tests/test_s0a_tool_policy_reader.py\` | 신설 — 19 invariant (reader 7 + apply 9 + 통합 3) |
| \`tests/test_self_improving_5_slot_reader_audit.py\` | DEAD anchor 갱신 — \`tool-policy.json\` 제거 + 새 ALIVE test + \`Post-S0a\` + \`2/5 ALIVE\` anchor 추가 |
| \`tests/test_adr_012_surface_tiers.py\` | ALIVE/DEAD exact count: \`==1/==4\` → \`==2/==3\` |
| \`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md\` | 상태표 + 총평에 Post-S0a (2026-05-21 오후) update 섹션 |
| \`docs/adr/ADR-012-self-improvement-surface-tiers.md\` | §Decision.1 Tier 1 표의 \`tool_policy\` 행 ALIVE 로 갱신 |
| \`CHANGELOG.md\` | \`[Unreleased] / Added\` 항목 |

## GAP Audit

| 항목 | 상태 | 근거 |
|------|------|------|
| Reader 신설 (\`wrapper-sections\` 패턴) | Implemented | \`tool_policy.py:60-107\` (load) + \`:132-180\` (apply) |
| 단일 적용 지점 | Implemented | \`_helpers.py:get_agentic_tools\` 마지막 단계 |
| Strict/graceful 비대칭 | Implemented | env var → RuntimeError / SoT file → WARNING+None |
| 회귀 marker 의도된 발화 | Implemented | PR-AUDIT-5SLOT test 의 parametrize 갱신 + 새 ALIVE test |
| audit doc 갱신 | Implemented | Post-S0a 섹션 + 2/5 ALIVE anchor |
| ADR Tier 1 표 동기화 | Implemented | \`tool_policy\` 행 DEAD → ALIVE |
| Forward-compatible schema | Implemented | unknown field 무시 (\`test_load_unknown_fields_ignored\`) |
| no-op 보존 | Implemented | policy=None / 빈 dict / 파일 부재 모두 입력 그대로 |

## Verification

- [x] \`uv run ruff check core/agent/tool_policy.py core/agent/loop/_helpers.py tests/test_s0a*\` — All checks passed
- [x] \`uv run ruff format --check ...\` — clean
- [x] \`uv run mypy core/agent/tool_policy.py core/agent/loop/_helpers.py\` — Success
- [x] \`uv run pytest tests/test_s0a* tests/test_self_improving_5_slot* tests/test_adr_012*\` — 51/51 pass
- [x] \`uv run lint-imports\` — 4 contracts kept
- [ ] CI 5/5 (push 후 실행)
- [ ] Codex MCP 검증 (background)

## Reference

- ADR-012 §S0a — \`docs/adr/ADR-012-self-improvement-surface-tiers.md:137\`
- PR-AUDIT-5SLOT 진단 출처 — \`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md\`
- 패턴 차용 — \`core/agent/system_prompt.py:_load_wrapper_override\`
- Path constant — \`core/paths.py:92 GLOBAL_TOOL_POLICY_PATH\`

## 후속 (ADR-012 시퀀스)

이 PR 머지 후 다음 dead slot 처치:
- **S0b** — \`reflection\` reader 신설 (\`_REFLECTION_TOOL\` schema 의 \`reflection.json\` override)
- **S0c** — \`decomposition\` reader 신설 (\`load_prompt("decomposer")\` 의 \`decomposition.json\` override)
- **S0d** — \`retrieval\` 처치 결정 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)