### PR TITLE
feat(self-improving): S0b — reflection reader 신설 (ADR-012 dead slot #2 살리기)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,36 @@ functional change.
 
 ### Added
 
+- **PR-S0b — `reflection` reader 신설 (ADR-012 dead slot 살리기 #2).**
+  PR-S0a (#1407) 의 패턴을 그대로 차용해 두 번째 dead slot
+  (`reflection`) 을 살림. **schema** (두 field 모두 optional, string):
+  `description` (`_REFLECTION_TOOL["description"]` override) /
+  `system_prompt` (`_SYSTEM_PROMPT` override). `input_schema` 와 `name`
+  은 mutate 대상 아님 — `record_reflection` 의 typed payload contract
+  (`hypotheses` / `confidence` / `next_action_hint`) 보존. **Resolution
+  order**: ① `GEODE_REFLECTION_POLICY_OVERRIDE` env var (audit
+  subprocess, strict — schema 실패 시 RuntimeError) ②
+  `~/.geode/self-improving-loop/reflection.json` (daily-run, graceful)
+  ③ `None`. 단일 적용 지점: `core/agent/loop/_reflection.py` 의
+  reflection LLM `agentic_call` 직전 — `apply_reflection_policy` 가
+  `(tool, system_prompt)` 튜플 정규화 후 `tools=[active_tool]` +
+  `system=active_system` 으로 전달. Tool dict 은 deep-copy 후 mutate 해서
+  module-level constant `_REFLECTION_TOOL` 의 오염 방지. **Read-Write
+  parity**: `write_policy()` 가 `dict[str, str]` 만 직렬화하므로 reader
+  도 string payload 그대로 수용 (S0a 의 list/string 두 형태 정규화는
+  reflection 에서는 본질 string 이라 split 불필요). **회귀 marker
+  의 의도된 발화**: PR-AUDIT-5SLOT 의 `test_dead_slot_has_no_inference_reader`
+  parametrize 에서 `reflection.json` 제거 + 새
+  `test_reflection_slot_is_now_alive_post_s0b` 추가. audit doc 의
+  상태표에 `reflection` 행 ALIVE 갱신 + Post-S0b update 섹션 + 3/5 ALIVE
+  anchor. ADR-012 본문의 Tier 1 표 + invariant test 의 ALIVE/DEAD count
+  (`== 2/== 3` → `== 3/== 2`) 동기화. `autoresearch/train.py` 의 audit
+  subprocess env wiring 에 `GEODE_REFLECTION_POLICY_OVERRIDE` 추가 (S0a
+  의 wrapper + tool_policy 옆에). ROI: `admire_means` (S2 신설 예정) +
+  `ux_means` (S1 신설 예정) 양쪽에 영향 — reflection 품질이 응답 품질로
+  직결되는 fitness 경로. 18 new invariant test + 기존 PR-AUDIT-5SLOT +
+  ADR-012 test 함께 통과 (총 73 test 그린).
+
 - **PR-S0a — `tool_policy` reader 신설 (ADR-012 dead slot 살리기 #1).**
   PR-AUDIT-5SLOT (#1405) 의 진단 — 5축 mutation 중 4축이 dead policy
   (인퍼런스 reader 부재) — 의 첫 처치. `tool-policy.json` 정책이

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -607,8 +607,12 @@ def run_audit(
     env = os.environ.copy()
     env["GEODE_WRAPPER_OVERRIDE"] = str(override_path)
     # ADR-012 S0a/S0b (2026-05-21) — audit subprocess 가 mutation 적용된
-    # 5축 SoT 를 strict mode 로 읽도록 env 강제. 파일 부재 시
-    # subprocess 가 fail-fast (quota 절약).
+    # 5축 SoT 를 strict mode 로 읽도록 env 강제. SoT 파일이 존재할 때만
+    # env 를 set 해서 subprocess 가 strict mode 로 동작 (파일 부재 시
+    # RuntimeError); SoT 파일이 없으면 env 미설정으로 subprocess 가
+    # graceful no-op 경로 (현재 default behaviour 보존). 즉 strict-fail
+    # 은 "SoT 가 디스크에 있는데도 subprocess 가 못 읽는 경우" 만 발화 —
+    # mutation 이 진행 중인 audit 의 quota 절약 목적.
     from core.paths import GLOBAL_REFLECTION_POLICY_PATH, GLOBAL_TOOL_POLICY_PATH
 
     if GLOBAL_TOOL_POLICY_PATH.is_file():

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -606,13 +606,15 @@ def run_audit(
     argv = _build_audit_command()
     env = os.environ.copy()
     env["GEODE_WRAPPER_OVERRIDE"] = str(override_path)
-    # ADR-012 S0a (2026-05-21) — audit subprocess 가 mutation 적용된
-    # tool_policy SoT 를 strict mode 로 읽도록 env 강제. 파일 부재 시
+    # ADR-012 S0a/S0b (2026-05-21) — audit subprocess 가 mutation 적용된
+    # 5축 SoT 를 strict mode 로 읽도록 env 강제. 파일 부재 시
     # subprocess 가 fail-fast (quota 절약).
-    from core.paths import GLOBAL_TOOL_POLICY_PATH
+    from core.paths import GLOBAL_REFLECTION_POLICY_PATH, GLOBAL_TOOL_POLICY_PATH
 
     if GLOBAL_TOOL_POLICY_PATH.is_file():
         env["GEODE_TOOL_POLICY_OVERRIDE"] = str(GLOBAL_TOOL_POLICY_PATH)
+    if GLOBAL_REFLECTION_POLICY_PATH.is_file():
+        env["GEODE_REFLECTION_POLICY_OVERRIDE"] = str(GLOBAL_REFLECTION_POLICY_PATH)
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -260,6 +260,18 @@ async def reflect_async(
             max_tokens,
         )
 
+        # ADR-012 S0b — 5축의 ``reflection`` SoT 가 인퍼런스 경로에서
+        # 실제로 적용되는 단일 지점. 정책이 부재하면 ``apply_reflection_policy``
+        # 는 입력 그대로 반환 (현재 행동 보존).
+        from core.agent.reflection_policy import (
+            _load_reflection_policy_override,
+            apply_reflection_policy,
+        )
+
+        active_tool, active_system = apply_reflection_policy(
+            _REFLECTION_TOOL, _SYSTEM_PROMPT, _load_reflection_policy_override()
+        )
+
         async def _do_call(m: str) -> object:
             # PR-B fix-up #2 — ``tool_choice="auto"``. Anthropic docs
             # mark *both* ``"any"`` and named-tool forcing as
@@ -275,9 +287,9 @@ async def reflect_async(
             # ``"auto"`` on OpenAI/Codex via the shared normaliser.
             return await adapter.agentic_call(
                 model=m,
-                system=_SYSTEM_PROMPT,
+                system=active_system,
                 messages=[{"role": "user", "content": user_prompt}],
-                tools=[_REFLECTION_TOOL],
+                tools=[active_tool],
                 tool_choice="auto",
                 max_tokens=max_tokens,
                 temperature=0.2,

--- a/core/agent/reflection_policy.py
+++ b/core/agent/reflection_policy.py
@@ -1,0 +1,156 @@
+"""Reflection policy SoT reader — ADR-012 S0b, dead slot 살리기.
+
+5축 mutation 의 ``reflection`` slot 은 PR-6 시점부터 SoT 파일
+(`autoresearch/reflection.json`) 만 정의되고 인퍼런스 reader 가 부재였다.
+``core/agent/loop/_reflection.py`` 의 ``_REFLECTION_TOOL`` schema 와
+``_SYSTEM_PROMPT`` 가 module-level constant 로 hardcoded — `reflection.json`
+미연결 (PR-AUDIT-5SLOT 2026-05-21 진단).
+
+이 모듈은 S0a (`tool_policy.py`) 의 패턴을 그대로 차용해 ``reflection.json``
+의 정책을 reflection LLM 호출 직전에 적용한다.
+
+**SoT schema** (두 field 모두 optional):
+
+.. code-block:: json
+
+    {
+      "description": "...",      # _REFLECTION_TOOL["description"] override
+      "system_prompt": "..."     # _SYSTEM_PROMPT override
+    }
+
+빈 정책 / 누락 / 부적합 schema → no-op (현재 행동 유지). ``input_schema``
+는 mutate 대상이 아님 — record_reflection 의 typed payload contract 는
+유지 (`hypotheses` / `confidence` / `next_action_hint`).
+
+**Resolution order** (`wrapper-sections.json` + `tool_policy.py` 와 동일):
+
+1. ``GEODE_REFLECTION_POLICY_OVERRIDE`` env var — audit subprocess, strict.
+2. ``~/.geode/self-improving-loop/reflection.json`` — daily-run, graceful.
+3. ``None`` — no-op.
+
+**Read-Write parity** (S0a Codex MCP lesson): ``write_policy()`` 가
+``dict[str, str]`` 만 직렬화하므로 reader 는 string payload 그대로 수용.
+S0a 와 달리 reflection 의 두 field 는 본질적으로 string 이라 split
+정규화는 불필요.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_REFLECTION_POLICY_PATH
+
+log = logging.getLogger(__name__)
+
+_REFLECTION_POLICY_OVERRIDE_ENV = "GEODE_REFLECTION_POLICY_OVERRIDE"
+
+_REFLECTION_POLICY_SOT_PATH = GLOBAL_REFLECTION_POLICY_PATH
+"""Cross-process SoT path (S0b, 2026-05-21). module-local alias 로 테스트
+가 monkeypatch 가능 (path-literal guard contract)."""
+
+
+_FIELD_DESCRIPTION = "description"
+_FIELD_SYSTEM_PROMPT = "system_prompt"
+_ALL_FIELDS = frozenset({_FIELD_DESCRIPTION, _FIELD_SYSTEM_PROMPT})
+
+
+def _load_reflection_policy_override() -> dict[str, str] | None:
+    """Return active reflection policy, or ``None`` when no override applies.
+
+    Resolution order:
+
+    1. ``GEODE_REFLECTION_POLICY_OVERRIDE`` env var (audit subprocess) — strict.
+    2. ``~/.geode/self-improving-loop/reflection.json`` (daily run) — graceful.
+    3. ``None`` — no policy.
+    """
+    override_path = os.environ.get(_REFLECTION_POLICY_OVERRIDE_ENV)
+    if override_path:
+        return _strict_load(Path(override_path))
+    if _REFLECTION_POLICY_SOT_PATH.is_file():
+        return _graceful_load(_REFLECTION_POLICY_SOT_PATH)
+    return None
+
+
+def _strict_load(path: Path) -> dict[str, str]:
+    """Audit-subprocess path: schema 실패 시 ``RuntimeError`` (fail-fast)."""
+    if not path.is_file():
+        raise RuntimeError(f"{_REFLECTION_POLICY_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_REFLECTION_POLICY_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, str] | None:
+    """Daily-run path: schema 실패 시 WARNING + ``None``."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("reflection policy SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("reflection policy SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """``data`` 가 ``dict`` 모양 + 알려진 field 는 모두 ``str`` 이어야 함.
+
+    Unknown field 는 무시 (forward-compatible)."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"reflection policy at {path} must be a dict")
+    for key in _ALL_FIELDS:
+        if key in data and not isinstance(data[key], str):
+            got = type(data[key]).__name__
+            raise RuntimeError(f"reflection policy at {path} field {key!r} must be str; got {got}")
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, str]:
+    """알려진 2 field 만 추출. 빈 string 은 ``None`` 처럼 취급되도록 제외."""
+    return {key: data[key] for key in _ALL_FIELDS if data.get(key)}
+
+
+def apply_reflection_policy(
+    tool: dict[str, Any],
+    system_prompt: str,
+    policy: dict[str, str] | None,
+) -> tuple[dict[str, Any], str]:
+    """Apply ``policy`` to the reflection tool definition and system prompt.
+
+    Returns the (possibly overridden) ``(tool, system_prompt)`` tuple.
+    ``policy is None`` → 입력 그대로.
+
+    - ``description`` field 가 정책에 있으면 tool["description"] override.
+    - ``system_prompt`` field 가 정책에 있으면 system_prompt override.
+    - ``input_schema`` 와 ``name`` 은 mutate 대상이 아님 — record_reflection
+      의 typed payload contract 보존.
+
+    Tool dict 은 deep-copy 후 mutate 해서 caller 의 module-level constant
+    가 오염되지 않도록 함.
+    """
+    if policy is None:
+        return tool, system_prompt
+    new_description = policy.get(_FIELD_DESCRIPTION)
+    new_system_prompt = policy.get(_FIELD_SYSTEM_PROMPT)
+    if not new_description and not new_system_prompt:
+        return tool, system_prompt
+    new_tool = copy.deepcopy(tool)
+    if new_description:
+        new_tool["description"] = new_description
+    final_system = new_system_prompt if new_system_prompt else system_prompt
+    return new_tool, final_system
+
+
+__all__ = ["apply_reflection_policy"]

--- a/docs/adr/ADR-012-self-improvement-surface-tiers.md
+++ b/docs/adr/ADR-012-self-improvement-surface-tiers.md
@@ -18,7 +18,7 @@ Petri 17-dim 중 **양의 압력 (성능 향상) 으로 작동하는 dim 은 사
 
 PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md`) 가 진단한 audit 시점 결과 — mutator 가 mutate 할 수 있다고 명세된 5 slot 중 인퍼런스 reader 가 살아있는 slot 은 `prompt` 하나뿐. 나머지 4 (`tool_policy` / `decomposition` / `retrieval` / `reflection`) 는 SoT 파일 + mutation dispatcher 는 있지만 **인퍼런스 경로에서 정책을 읽어 행동에 반영하는 reader 가 부재** — `core/self_improving_loop/policies.py:29-37` 의 docstring 이 직접 자백한다 (PR-6 의 의도적 follow-up 미완 + 잊혀짐).
 
-**S0a (2026-05-21 머지) 이후 상태**: `tool_policy` 가 ALIVE 로 전환 — `core/agent/tool_policy.py` 의 reader 가 `core/agent/loop/_helpers.py:get_agentic_tools` 에서 호출된다. 따라서 audit 시점 1/5 → 현재 2/5 ALIVE. 남은 dead slot 은 `decomposition` (S0c) / `retrieval` (S0d 처치 결정) / `reflection` (S0b).
+**S0a + S0b (2026-05-21 머지) 이후 상태**: `tool_policy` + `reflection` 이 ALIVE 로 전환. `tool_policy` reader 는 `core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools` 에서 호출. `reflection` reader 는 `core/agent/reflection_policy.py` → `_reflection.py` 의 reflection LLM 호출 직전 적용. 따라서 audit 시점 1/5 → 현재 3/5 ALIVE. 남은 dead slot 은 `decomposition` (S0c) / `retrieval` (S0d 처치 결정).
 
 → 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 audit 시점 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이었다 (1/40~1/85 누수). S0a 이후 2축 × 1-2dim = 2-4 면적으로 회복 중이고 S0b/c 완료 시 4축까지 회복 예정.
 
@@ -47,7 +47,7 @@ PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.
 | 5축 SoT `tool_policy` | `tool-policy.json` | **가동 중** (S0a, 2026-05-21) | **ALIVE** — `core/agent/tool_policy.py` (`_load_tool_policy_override` + `apply_tool_policy`) → `core/agent/loop/_helpers.py:get_agentic_tools` |
 | 5축 SoT `decomposition` | `decomposition.json` | mutation target 정의만 | **DEAD** — `core/orchestration/goal_decomposer.py` 가 `load_prompt("decomposer", "system")` 로 별도 SoT 사용 중. `decomposition.json` 미연결. S0c reader 신설 필요 |
 | 5축 SoT `retrieval` | `retrieval.json` | mutation target 정의만 | **DEAD** — RAG 인프라 부재. S0d 에서 deprecate 또는 보류 |
-| 5축 SoT `reflection` | `reflection.json` | mutation target 정의만 | **DEAD** — `core/agent/loop/_reflection.py:65-160` 의 `_REFLECTION_TOOL` 이 module-level constant. S0b reader 신설 필요 |
+| 5축 SoT `reflection` | `reflection.json` | **가동 중** (S0b, 2026-05-21) | **ALIVE** — `core/agent/reflection_policy.py` (`_load_reflection_policy_override` + `apply_reflection_policy`) → `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용 |
 | Skill 정의 | `.claude/skills/<name>/` (20+개) | 수동 (mutation 채널 밖) | n/a (M1 에서 6번째 target_kind 로 개통) |
 | Agent contract | `.claude/agents/seed_*.md` (7-role) | 수동 (mutation 채널 밖) | n/a (M2 에서 7번째 target_kind, 좁게 — mutator 자신 제외) |
 | Plugin 분석 코드 | `plugins/petri_audit/`, `plugins/seed_generation/` | 수동 | n/a (M5 에서 격리된 진입 슬롯) |

--- a/docs/adr/ADR-012-self-improvement-surface-tiers.md
+++ b/docs/adr/ADR-012-self-improvement-surface-tiers.md
@@ -14,13 +14,13 @@ GEODE 는 weight-invariant evolutionary agent 군 (AlphaEvolve / Voyager / Refle
 
 Petri 17-dim 중 **양의 압력 (성능 향상) 으로 작동하는 dim 은 사실상 `broken_tool_use` 1개** 뿐이고 나머지는 alignment / safety evaluation 축으로 음의 압력 ("안 망가지기") 이다. 17-dim 의 가중치가 동일 차원에 압축돼 fitness 의 정의역이 "에이전트가 망가지지 않는지" 에 쏠려 있다. seed pool 의 정교화 + skill 진화의 노력 대부분이 alignment dim 의 마이크로-튜닝으로 흡수되는 구조적 누수.
 
-### 발견 2 — Mutation 표면의 wiring 누수 (audit 시점 1/5, S0a 이후 2/5)
+### 발견 2 — Mutation 표면의 wiring 누수 (audit 시점 1/5, S0a+S0b 이후 3/5)
 
 PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md`) 가 진단한 audit 시점 결과 — mutator 가 mutate 할 수 있다고 명세된 5 slot 중 인퍼런스 reader 가 살아있는 slot 은 `prompt` 하나뿐. 나머지 4 (`tool_policy` / `decomposition` / `retrieval` / `reflection`) 는 SoT 파일 + mutation dispatcher 는 있지만 **인퍼런스 경로에서 정책을 읽어 행동에 반영하는 reader 가 부재** — `core/self_improving_loop/policies.py:29-37` 의 docstring 이 직접 자백한다 (PR-6 의 의도적 follow-up 미완 + 잊혀짐).
 
 **S0a + S0b (2026-05-21 머지) 이후 상태**: `tool_policy` + `reflection` 이 ALIVE 로 전환. `tool_policy` reader 는 `core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools` 에서 호출. `reflection` reader 는 `core/agent/reflection_policy.py` → `_reflection.py` 의 reflection LLM 호출 직전 적용. 따라서 audit 시점 1/5 → 현재 3/5 ALIVE. 남은 dead slot 은 `decomposition` (S0c) / `retrieval` (S0d 처치 결정).
 
-→ 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 audit 시점 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이었다 (1/40~1/85 누수). S0a 이후 2축 × 1-2dim = 2-4 면적으로 회복 중이고 S0b/c 완료 시 4축까지 회복 예정.
+→ 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 audit 시점 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이었다 (1/40~1/85 누수). S0a + S0b 이후 3축 × 1-2dim = 3-6 면적으로 회복 중이고 S0c 완료 시 4축까지 회복 예정.
 
 ### 발견 3 — Fine-tune 표면의 채널 제약
 
@@ -137,7 +137,7 @@ PR-AUDIT-5SLOT 으로 진단 완료. dead slot 별 reader 신설:
 | Sub-PR | 작업 | ROI |
 |---|---|---|
 | S0a | `tool_policy` reader 신설 — `core/agent/loop/AgenticLoop._select_tools()` 또는 동등 진입점에서 `tool-policy.json` 의 allowed/forbidden/priority 정책 읽어 도구 후보 필터 (~30 line) | **단기 1순위** — `broken_tool_use` dim 직접 영향 (17-dim 중 유일한 양의 압력 dim) |
-| S0b | `reflection` reader 신설 — `_REFLECTION_TOOL` 의 description/instructions/criteria 를 `reflection.json` sections 로 override (`wrapper-sections` 패턴 재사용) | **단기 2순위** — `admire_means` + `ux_means` 동시 영향 |
+| S0b | `reflection` reader 신설 (머지 완료, #1408) — `_REFLECTION_TOOL["description"]` + `_SYSTEM_PROMPT` 를 `reflection.json` 의 `description` / `system_prompt` field 로 override. `input_schema` 는 mutate 대상 아님 (typed payload contract 보존). | **단기 2순위** — `admire_means` + `ux_means` 동시 영향 |
 | S0c | `decomposition` reader 신설 — `load_prompt("decomposer", "system")` 과 `decomposition.json` 의 sections 연결 (또는 `_load_decomposition_policy()` 신설) | 단기 3순위 — `task_success_rate` 영향 |
 | S0d | `retrieval` 처치 결정 — RAG 인프라 신설 여부 결정 후 (a) reader 신설 (b) `TARGET_KINDS` 에서 제거 5축 → 4축 축소 (c) 보류 | 단기 4순위 또는 deprecate |
 

--- a/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
+++ b/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
@@ -63,7 +63,7 @@ ADR-012 S0b (`reflection` reader 신설) 머지 후 상태:
 
 **현재 상태**: 3/5 ALIVE, 2/5 DEAD. 남은 dead slot: `decomposition` (S0c 예정) / `retrieval` (S0d 처치 결정 예정).
 
-## 4. 인과 체인의 끊김
+## 4. 인과 체인의 끊김 (audit 시점 사실, Post-S0a/S0b 갱신은 §3 참고)
 
 ```
 mutator LLM
@@ -81,9 +81,9 @@ mutator LLM
 
 → 4 slot 의 mutation 은 fitness gate 에서 항상 "no signal" 로 처리된다. mutator 는 이걸 "이 slot 은 fitness 개선이 어려운 영역" 으로 잘못 학습할 수 있다.
 
-## 5. ALIVE slot 의 상세 — `prompt`
+## 5. ALIVE slot 의 상세 — `prompt` (audit 시점)
 
-`prompt` 만이 진화 압력에 닿는 유일한 slot. 인퍼런스 경로:
+audit 시점 (2026-05-21 오전) 에 `prompt` 가 진화 압력에 닿는 유일한 slot. **Post-S0a/S0b 머지 (오후) 이후 `tool_policy` + `reflection` 추가 ALIVE** — §3 의 Post-S0* update 섹션 참고. 인퍼런스 경로 도식은 audit 시점 사실로 보존:
 
 | 단계 | 코드 위치 | 동작 |
 |---|---|---|
@@ -94,7 +94,7 @@ mutator LLM
 | 5 | `core/agent/loop/agent_loop.py` | 구성된 system prompt 가 LLM 호출 경로로 흘러들어감 |
 | 6 | Petri eval | 변경된 system prompt 로 응답 → dim_means 변동 → fitness gate 작동 |
 
-이게 5축 중 유일하게 닫힌 루프. 나머지 4축은 (1)→(2) 사이에서 끊김.
+이게 audit 시점 (2026-05-21 오전) 의 사실 — 5축 중 유일하게 닫힌 루프, 나머지 4축은 (1)→(2) 사이에서 끊김. **Post-S0a/S0b 머지 후**: `tool_policy` (`core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools`) 와 `reflection` (`core/agent/reflection_policy.py` → `_reflection.py` LLM 호출 직전) 도 동일하게 닫힌 루프로 회복.
 
 ## 6. DEAD slot 별 권고
 
@@ -163,9 +163,12 @@ grep -n "GoalDecomposer" core/agent/loop/_decomposition.py
 grep -n 'load_prompt("decomposer"' core/orchestration/goal_decomposer.py
 grep -n "_REFLECTION_TOOL" core/agent/loop/_reflection.py
 grep -n "PR-6 stops at the" core/self_improving_loop/policies.py
-# Reader 부재 — 4 DEAD slot 의 SoT 파일명이 인퍼런스 디렉토리 어디에서도
-# 참조되지 않는지 확인 (self_improving_loop 의 mutation 정의/디스패처는 제외):
-for slot in tool-policy.json decomposition.json retrieval.json reflection.json; do
+# Reader 부재 — 현재 DEAD slot 의 SoT 파일명이 인퍼런스 디렉토리 어디에서도
+# 참조되지 않는지 확인 (self_improving_loop 의 mutation 정의/디스패처는 제외).
+# Post-S0a/S0b 머지 후: 4 DEAD → 2 DEAD (decomposition + retrieval).
+# tool-policy.json (S0a 머지) / reflection.json (S0b 머지) 는 audit-only
+# 시점 historical 검색에서만 사용:
+for slot in decomposition.json retrieval.json; do
   grep -rn "$slot" core/agent core/orchestration core/skills core/llm plugins autoresearch \
     | grep -v "self_improving_loop/policies.py" \
     | grep -v "self_improving_loop/runner.py" \

--- a/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
+++ b/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
@@ -39,7 +39,7 @@ infrastructure is committed before the policies that consume them.
 | `tool_policy` | `tool-policy.json` | ✓ | **audit 시점 없음** — `paths.py:92`, `policies.py:130` 정의만. **S0a 이후** `core/agent/tool_policy.py` (`_load_tool_policy_override` + `apply_tool_policy`) → `core/agent/loop/_helpers.py:get_agentic_tools` | **DEAD → ALIVE (S0a, 2026-05-21 머지)** |
 | `decomposition` | `decomposition.json` | ✓ | **없음** — `_decomposition.py:31` 의 `GoalDecomposer` 는 prompt 를 `core.llm.prompts.load_prompt("decomposer", "system")` 로 별도 SoT 에서 로드. 즉 hardcoded 가 아니지만 어느 경로도 `decomposition.json` 을 읽지 않음 — 그게 dead 사유 | **DEAD** |
 | `retrieval` | `retrieval.json` | ✓ | **없음** — `paths.py:94`, `policies.py:132` 정의만 | **DEAD** |
-| `reflection` | `reflection.json` | ✓ | **없음** — `core/agent/loop/_reflection.py:65-160` 의 `_REFLECTION_TOOL` schema + reflection prompt 가 module-level constant. `reflection.json` 미연결 | **DEAD** |
+| `reflection` | `reflection.json` | ✓ | **audit 시점 없음** — `_REFLECTION_TOOL` + `_SYSTEM_PROMPT` 가 module-level constant. **S0b 이후** `core/agent/reflection_policy.py` (`_load_reflection_policy_override` + `apply_reflection_policy`) → `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용 | **DEAD → ALIVE (S0b, 2026-05-21 머지)** |
 
 **총평** (audit 시점, 2026-05-21 오전): 1/5 ALIVE, 4/5 DEAD.
 
@@ -51,7 +51,17 @@ ADR-012 S0a (`tool_policy` reader 신설) 머지 후 상태:
 |---|---|---|
 | `tool_policy` | **DEAD → ALIVE** | `core/agent/tool_policy.py` 의 `_load_tool_policy_override` + `apply_tool_policy` → `core/agent/loop/_helpers.py:get_agentic_tools` (도구 후보 단일 진입점) |
 
-**현재 상태**: 2/5 ALIVE, 3/5 DEAD. 남은 dead slot: `decomposition` (S0b 예정) / `retrieval` (S0d 처치 결정 예정) / `reflection` (S0c 예정).
+**S0a 직후 상태**: 2/5 ALIVE, 3/5 DEAD.
+
+### Post-S0b (2026-05-21 오후 2차) update
+
+ADR-012 S0b (`reflection` reader 신설) 머지 후 상태:
+
+| Slot | 변동 | 새 reader 위치 |
+|---|---|---|
+| `reflection` | **DEAD → ALIVE** | `core/agent/reflection_policy.py` 의 `_load_reflection_policy_override` + `apply_reflection_policy` → `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용 |
+
+**현재 상태**: 3/5 ALIVE, 2/5 DEAD. 남은 dead slot: `decomposition` (S0c 예정) / `retrieval` (S0d 처치 결정 예정).
 
 ## 4. 인과 체인의 끊김
 
@@ -118,13 +128,13 @@ mutator LLM
 | 권고 B (deprecate) | 현재 단계에서는 deprecate 가 정직함. RAG 인프라가 신설되는 시점에 다시 도입 |
 | ROI 추정 | **권고 B 단기 / 권고 A 중-장기 conditional** |
 
-### 6d. `reflection`
+### 6d. `reflection` (S0b 머지 완료, 2026-05-21)
 
 | 항목 | 내용 |
 |---|---|
 | 의도 | 응답 생성 후 self-critique 정책 |
-| 현재 | `core/agent/loop/_reflection.py:65-160` 의 `_REFLECTION_TOOL` schema + reflection prompt 가 module-level constant 로 hardcoded — `reflection.json` 무관 |
-| 권고 A (살리기) | `_REFLECTION_TOOL` 의 description / instructions / criteria 를 `reflection.json` 의 sections 로 override (마찬가지로 `wrapper-sections` 패턴 재사용) |
+| audit 시점 | `_REFLECTION_TOOL` schema + `_SYSTEM_PROMPT` 가 module-level constant 로 hardcoded — `reflection.json` 무관 |
+| S0b 머지 후 | `core/agent/reflection_policy.py` 신설 (`_load_reflection_policy_override` + `apply_reflection_policy`), `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용. schema: `description` / `system_prompt` (둘 다 string). `input_schema` 는 contract 보존 차원에서 mutate 대상 아님 |
 | 권고 B (deprecate) | 같음 |
 | ROI 추정 | **권고 A** — reflection 품질 ↑ → 응답 품질 ↑ → `admire_means` (단기 S2) 와 `ux_means` 동시 영향 |
 

--- a/tests/test_adr_012_surface_tiers.py
+++ b/tests/test_adr_012_surface_tiers.py
@@ -56,16 +56,16 @@ def test_tier_1_lists_all_5_slots_with_alive_dead_status() -> None:
     text = _read_adr()
     for slot in ("prompt", "tool_policy", "decomposition", "retrieval", "reflection"):
         assert f"`{slot}`" in text, f"slot missing in Tier 1: {slot}"
-    # ALIVE/DEAD count — S0a 머지 (2026-05-21) 후 `tool_policy` ALIVE 로 전환.
-    # 현재 상태: 2 ALIVE (prompt + tool_policy) / 3 DEAD (decomposition/retrieval/reflection).
-    # S0b/c/d 머지 시마다 이 count 와 ADR Tier 1 표를 함께 갱신.
-    assert text.count("**ALIVE**") == 2, (
-        f"S0a 후 ALIVE slot 은 정확히 2 개 (prompt + tool_policy) 여야 함. "
-        f"count={text.count('**ALIVE**')}"
+    # ALIVE/DEAD count — S0a + S0b 머지 (2026-05-21) 후 `tool_policy` +
+    # `reflection` ALIVE 로 전환. 현재 상태: 3 ALIVE (prompt + tool_policy +
+    # reflection) / 2 DEAD (decomposition + retrieval). S0c/d 머지 시마다
+    # 이 count 와 ADR Tier 1 표를 함께 갱신.
+    assert text.count("**ALIVE**") == 3, (
+        f"S0a+S0b 후 ALIVE slot 은 정확히 3 개여야 함. count={text.count('**ALIVE**')}"
     )
-    assert text.count("**DEAD**") == 3, (
-        f"S0a 후 DEAD slot 은 정확히 3 개 (decomposition + retrieval + reflection) 여야 함. "
-        f"count={text.count('**DEAD**')} (S0b/c/d 의 reader 신설 후 함께 수정)"
+    assert text.count("**DEAD**") == 2, (
+        f"S0a+S0b 후 DEAD slot 은 정확히 2 개 (decomposition + retrieval) 여야 함. "
+        f"count={text.count('**DEAD**')}"
     )
 
 

--- a/tests/test_s0b_reflection_reader.py
+++ b/tests/test_s0b_reflection_reader.py
@@ -1,0 +1,221 @@
+"""ADR-012 S0b — `reflection` reader invariants.
+
+`reflection.json` 의 정책이 reflection LLM 호출 직전에 description +
+system_prompt 를 override 하는지 검증. S0a 의 패턴 그대로.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.agent.reflection_policy import (
+    _load_reflection_policy_override,
+    apply_reflection_policy,
+)
+
+from core.agent import reflection_policy
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Monkeypatch ``_REFLECTION_POLICY_SOT_PATH`` to tmp_path."""
+    sot = tmp_path / "reflection.json"
+    monkeypatch.setattr(reflection_policy, "_REFLECTION_POLICY_SOT_PATH", sot)
+    monkeypatch.delenv("GEODE_REFLECTION_POLICY_OVERRIDE", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, str]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+_BASE_TOOL: dict[str, object] = {
+    "name": "record_reflection",
+    "description": "base description",
+    "input_schema": {"type": "object", "properties": {}, "required": []},
+}
+_BASE_SYSTEM = "base system prompt"
+
+
+# ---------------------------------------------------------------------------
+# 1. Reader — SoT 파일 존재/부재/손상
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert not isolated_sot.exists()
+    assert _load_reflection_policy_override() is None
+
+
+def test_load_returns_none_when_sot_unreadable_json(isolated_sot: Path) -> None:
+    isolated_sot.write_text("not json {", encoding="utf-8")
+    assert _load_reflection_policy_override() is None
+
+
+def test_load_returns_none_when_sot_type_violation(isolated_sot: Path) -> None:
+    """dict/int 등 string 이 아닌 field → graceful ``None``."""
+    isolated_sot.write_text(json.dumps({"description": ["not", "a", "string"]}), encoding="utf-8")
+    assert _load_reflection_policy_override() is None
+
+
+def test_load_returns_dict_when_sot_valid(isolated_sot: Path) -> None:
+    payload = {"description": "new desc", "system_prompt": "new sys"}
+    _write(isolated_sot, payload)
+    assert _load_reflection_policy_override() == payload
+
+
+def test_load_unknown_fields_ignored(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"description": "x", "unknown_field": "ignored"})
+    assert _load_reflection_policy_override() == {"description": "x"}
+
+
+def test_load_empty_string_fields_dropped(isolated_sot: Path) -> None:
+    """빈 string 은 None 처럼 취급 — _coerce 가 truthy filter."""
+    _write(isolated_sot, {"description": "", "system_prompt": "real"})
+    assert _load_reflection_policy_override() == {"system_prompt": "real"}
+
+
+def test_strict_load_via_env_var_raises_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing = tmp_path / "nope.json"
+    monkeypatch.setenv("GEODE_REFLECTION_POLICY_OVERRIDE", str(missing))
+    with pytest.raises(RuntimeError, match="GEODE_REFLECTION_POLICY_OVERRIDE"):
+        _load_reflection_policy_override()
+
+
+def test_strict_load_via_env_var_raises_on_type_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"description": ["list", "not", "str"]}), encoding="utf-8")
+    monkeypatch.setenv("GEODE_REFLECTION_POLICY_OVERRIDE", str(bad))
+    with pytest.raises(RuntimeError, match="description"):
+        _load_reflection_policy_override()
+
+
+# ---------------------------------------------------------------------------
+# 2. apply_reflection_policy — 정책의 실제 효과
+# ---------------------------------------------------------------------------
+
+
+def test_apply_none_policy_is_noop() -> None:
+    tool, sys_p = apply_reflection_policy(_BASE_TOOL, _BASE_SYSTEM, None)
+    assert tool == _BASE_TOOL
+    assert sys_p == _BASE_SYSTEM
+
+
+def test_apply_empty_policy_dict_is_noop() -> None:
+    tool, sys_p = apply_reflection_policy(_BASE_TOOL, _BASE_SYSTEM, {})
+    assert tool == _BASE_TOOL
+    assert sys_p == _BASE_SYSTEM
+
+
+def test_apply_description_override() -> None:
+    tool, sys_p = apply_reflection_policy(
+        _BASE_TOOL, _BASE_SYSTEM, {"description": "overridden desc"}
+    )
+    assert tool["description"] == "overridden desc"
+    assert sys_p == _BASE_SYSTEM
+    # base tool 은 mutate 되지 않음 (deepcopy)
+    assert _BASE_TOOL["description"] == "base description"
+
+
+def test_apply_system_prompt_override() -> None:
+    tool, sys_p = apply_reflection_policy(
+        _BASE_TOOL, _BASE_SYSTEM, {"system_prompt": "overridden sys"}
+    )
+    assert tool == _BASE_TOOL  # description 안 바뀜
+    assert sys_p == "overridden sys"
+
+
+def test_apply_both_fields() -> None:
+    tool, sys_p = apply_reflection_policy(
+        _BASE_TOOL,
+        _BASE_SYSTEM,
+        {"description": "new desc", "system_prompt": "new sys"},
+    )
+    assert tool["description"] == "new desc"
+    assert sys_p == "new sys"
+
+
+def test_apply_preserves_input_schema() -> None:
+    """``input_schema`` 는 mutate 대상이 아님 — typed payload contract 보존."""
+    tool, _ = apply_reflection_policy(
+        _BASE_TOOL,
+        _BASE_SYSTEM,
+        {"description": "x", "system_prompt": "y"},
+    )
+    assert tool["input_schema"] == _BASE_TOOL["input_schema"]
+    assert tool["name"] == _BASE_TOOL["name"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Wiring — _reflection.py 가 reader 를 호출하는지
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_module_imports_reader() -> None:
+    """`_reflection.py` 가 ``_load_reflection_policy_override`` 와
+    ``apply_reflection_policy`` 둘 다 호출하는지 source-grep."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/loop/_reflection.py").read_text(encoding="utf-8")
+    assert "_load_reflection_policy_override" in src
+    assert "apply_reflection_policy" in src
+
+
+def test_reflection_module_uses_overridden_values() -> None:
+    """`_reflection.py` 가 `active_tool` / `active_system` (override 적용된
+    값) 을 사용하는지 — 단순 import 가 아니라 실제 사용 여부 검증."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/loop/_reflection.py").read_text(encoding="utf-8")
+    assert "active_tool" in src
+    assert "active_system" in src
+    assert "system=active_system" in src
+    assert "tools=[active_tool]" in src
+
+
+# ---------------------------------------------------------------------------
+# 4. Producer → Reader round trip — write_policy 의 dict[str, str] payload
+# ---------------------------------------------------------------------------
+
+
+def test_producer_reader_round_trip(isolated_sot: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``write_policy("reflection", {"description": "..."})`` → reader 가
+    그대로 정규화. reflection 의 두 field 가 본질 string 이라 split 불필요."""
+    from core.self_improving_loop import policies as policies_mod
+
+    monkeypatch.setattr(policies_mod, "policy_path", lambda kind: isolated_sot)
+    policies_mod.write_policy(
+        "reflection",
+        {"description": "evolved desc", "system_prompt": "evolved sys"},
+    )
+
+    result = _load_reflection_policy_override()
+    assert result == {"description": "evolved desc", "system_prompt": "evolved sys"}
+
+
+# ---------------------------------------------------------------------------
+# 5. ALIVE slot 신호
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_json_is_now_referenced_in_inference_path() -> None:
+    """`reflection.json` 이 `core/agent/` 경로 어딘가에서 grep 가능."""
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core" / "agent").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "reflection.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("reflection_policy.py" in h for h in hits), (
+        f"reflection.json 이 core/agent/reflection_policy.py 에서 발견되어야 함. hits={hits}"
+    )

--- a/tests/test_self_improving_5_slot_reader_audit.py
+++ b/tests/test_self_improving_5_slot_reader_audit.py
@@ -95,12 +95,13 @@ def test_audit_doc_exists() -> None:
 def test_audit_doc_pins_1_alive_4_dead() -> None:
     """결론 한 줄 anchor."""
     text = _read(AUDIT_DOC)
-    # ADR-012 S0a (2026-05-21) 머지 이후 `tool_policy` 가 ALIVE 로 전환.
-    # audit 시점 (2026-05-21 아침) 의 사실은 1/5 — 그 줄을 유지하면서
-    # post-S0a update 섹션이 함께 등장하는지 확인.
+    # ADR-012 S0a/S0b (2026-05-21) 머지 이후 `tool_policy`/`reflection` 이 ALIVE.
+    # audit 시점 의 사실은 1/5 — 그 줄을 유지하면서 post-S0* update 섹션
+    # 들이 함께 등장하는지 확인.
     assert "1/5 ALIVE, 4/5 DEAD" in text  # 원본 audit 시점 사실
     assert "Post-S0a" in text  # S0a 후속 갱신 섹션
-    assert "2/5 ALIVE, 3/5 DEAD" in text  # 현재 상태
+    assert "Post-S0b" in text  # S0b 후속 갱신 섹션
+    assert "3/5 ALIVE, 2/5 DEAD" in text  # 현재 상태 (S0b 후)
 
 
 def test_audit_doc_names_all_5_slots() -> None:
@@ -145,19 +146,19 @@ def test_prompt_reader_is_called_in_agentic_loop() -> None:
 @pytest.mark.parametrize(
     "sot_filename",
     [
-        # ADR-012 S0a (2026-05-21) 머지 이후 ``tool-policy.json`` 은 ALIVE —
-        # ``core/agent/tool_policy.py`` 의 reader 가 ``core/agent/loop/_helpers.py``
-        # 의 ``get_agentic_tools`` 에서 호출된다. 이 parametrize 에서 제거됨.
+        # ADR-012 S0a/S0b (2026-05-21) 머지 이후 ``tool-policy.json`` 과
+        # ``reflection.json`` 이 ALIVE — 각각의 reader 가
+        # ``core/agent/{tool_policy,reflection_policy}.py`` 에 존재. 이
+        # parametrize 에서 제거됨.
         "decomposition.json",
         "retrieval.json",
-        "reflection.json",
     ],
 )
 def test_dead_slot_has_no_inference_reader(sot_filename: str) -> None:
     """DEAD slot 의 SoT 파일명이 인퍼런스 경로 (core/agent + core/orchestration +
     core/skills + core/llm + plugins + autoresearch — self_improving_loop
     의 mutation 정의/디스패처는 제외) 어디에서도 참조되지 않음을 pin.
-    S0b/c PR 에서 reader 가 신설되면 이 test 가 실패해서 함께 갱신해야
+    S0c/d PR 에서 reader 가 신설되면 이 test 가 실패해서 함께 갱신해야
     한다 (의도된 anchor 회귀)."""
     hits = _grep_inference_dirs(sot_filename)
     # 0 hits 가 정상 (DEAD)
@@ -203,12 +204,23 @@ def test_decomposition_slot_not_wired_to_decomposition_json() -> None:
     assert "decomposition.json" not in src
 
 
-def test_reflection_slot_dead_via_hardcoded_tool_schema() -> None:
-    """reflection slot 의 dead 사유 — _REFLECTION_TOOL 가 module-level constant."""
-    src = _read("core/agent/loop/_reflection.py")
-    assert "_REFLECTION_TOOL" in src
-    # reflection.json 을 읽는 reader 없음
-    assert "reflection.json" not in src
+def test_reflection_slot_is_now_alive_post_s0b() -> None:
+    """ADR-012 S0b 머지 이후 ``reflection.json`` 은 ALIVE — reader 가
+    ``core/agent/reflection_policy.py`` 에 존재 + ``_reflection.py`` 의
+    reflection LLM 호출 직전에 실제로 호출됨. PR-AUDIT-5SLOT 의 의도된
+    회귀 marker 의 발화 결과."""
+    hits = _grep_inference_dirs("reflection.json")
+    assert any("reflection_policy.py" in h for h in hits), (
+        f"reflection.json 이 core/agent/reflection_policy.py 에서 발견되어야 함. hits={hits}"
+    )
+    # Call chain 검증 — _reflection.py 가 reflection_policy 의 reader 를 호출.
+    reflection_src = _read("core/agent/loop/_reflection.py")
+    assert "_load_reflection_policy_override" in reflection_src, (
+        "_reflection.py 가 _load_reflection_policy_override 를 호출해야 함."
+    )
+    assert "apply_reflection_policy" in reflection_src, (
+        "_reflection.py 가 apply_reflection_policy 를 호출해야 함 — 정책이 reflection LLM 호출에 적용되는지."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- ADR-012 의 단기 시퀀스 두 번째. S0a (#1407) 의 패턴 그대로 차용해 \`reflection\` slot 을 dead → ALIVE 로 전환.
- 단일 적용 지점 (\`core/agent/loop/_reflection.py\` 의 reflection LLM \`agentic_call\` 직전) 에서 \`reflection.json\` 의 \`description\` + \`system_prompt\` override.
- 5축 진화 면적: 2/5 → **3/5 ALIVE**. 남은 dead slot: \`decomposition\` (S0c) + \`retrieval\` (S0d).

## Why

PR-AUDIT-5SLOT (#1405) 가 진단한 4 dead slot 중 두 번째 처치. \`reflection\` 이 살아나면:
- 응답 후 self-critique 정책이 진화 가능 — \`admire_means\` (S2 신설 예정) + \`ux_means\` (S1 신설 예정) 양쪽에 동시 영향
- reflection 품질 ↑ → 응답 품질 ↑ 의 직접 fitness 경로
- S0a 와 같은 패턴으로 frontier (Reflexion / Voyager) self-critique 진화 슬롯 확보

## Changes

| 파일 | 변경 |
|------|------|
| \`core/agent/reflection_policy.py\` | 신설 — \`_load_reflection_policy_override\` + \`apply_reflection_policy\` + \`_strict_load\`/\`_graceful_load\` (S0a 패턴) |
| \`core/agent/loop/_reflection.py\` | reflection LLM 호출 직전 정책 적용 — \`active_tool\` + \`active_system\` 사용 |
| \`autoresearch/train.py\` | audit subprocess env 에 \`GEODE_REFLECTION_POLICY_OVERRIDE\` 추가 (S0a wrapper + tool_policy 옆) |
| \`tests/test_s0b_reflection_reader.py\` | 18 invariant (reader 8 + apply 6 + wiring 2 + producer-reader round trip + ALIVE marker) |
| \`tests/test_self_improving_5_slot_reader_audit.py\` | DEAD parametrize 에서 \`reflection.json\` 제거 + 새 \`test_reflection_slot_is_now_alive_post_s0b\` + \`Post-S0b\` + \`3/5 ALIVE\` anchor |
| \`tests/test_adr_012_surface_tiers.py\` | ALIVE/DEAD exact count: \`==2/==3\` → \`==3/==2\` |
| \`docs/audits/...reader-audit.md\` | 상태표의 \`reflection\` 행 갱신 + Post-S0b update 섹션 + §6d 권고 갱신 |
| \`docs/adr/ADR-012-...md\` | §Context 발견 2 + §Decision.1 Tier 1 표의 \`reflection\` 행 ALIVE 로 갱신 |
| \`CHANGELOG.md\` | \`[Unreleased] / Added\` 항목 |

## GAP Audit

| 항목 | 상태 | 근거 |
|------|------|------|
| Reader 신설 (S0a 패턴) | Implemented | \`reflection_policy.py:62-122\` (load) + \`:125-153\` (apply) |
| 단일 적용 지점 | Implemented | \`_reflection.py\` reflection LLM 호출 직전 |
| Tool dict deep-copy | Implemented | \`apply_reflection_policy:149\` (module-level constant 오염 방지) |
| input_schema 보존 | Implemented | typed payload contract — test \`test_apply_preserves_input_schema\` |
| audit subprocess env wiring | Implemented | \`train.py:614-617\` 의 \`GEODE_REFLECTION_POLICY_OVERRIDE\` |
| 회귀 marker 발화 | Implemented | parametrize 갱신 + 새 ALIVE test + audit doc Post-S0b |
| ADR Tier 1 표 동기화 | Implemented | \`reflection\` 행 DEAD → ALIVE + ALIVE/DEAD count 갱신 |
| Read-write parity | Implemented | producer→reader round trip test 통과 |

## Verification

- [x] \`uv run ruff check core/agent/reflection_policy.py core/agent/loop/_reflection.py autoresearch/train.py tests/test_s0b*\` — All checks passed
- [x] \`uv run ruff format --check ...\` — clean
- [x] \`uv run mypy core/agent/reflection_policy.py core/agent/loop/_reflection.py autoresearch/train.py\` — Success
- [x] \`uv run pytest tests/test_s0b* tests/test_s0a* tests/test_self_improving_5_slot* tests/test_adr_012*\` — 73/73 pass
- [x] \`uv run lint-imports\` — 4 contracts kept
- [ ] CI 5/5 (push 후 실행)
- [ ] Codex MCP 검증 (background)

## Reference

- ADR-012 §S0b — \`docs/adr/ADR-012-self-improvement-surface-tiers.md:147\`
- 패턴 차용 — \`core/agent/tool_policy.py\` (S0a 의 reader 패턴) + \`core/agent/system_prompt.py:_load_wrapper_override\`
- Path constant — \`core/paths.py:95 GLOBAL_REFLECTION_POLICY_PATH\`

## 후속

이 PR 머지 후:
- **S0c** — \`decomposition\` reader 신설 (\`load_prompt("decomposer")\` 의 \`decomposition.json\` 연결)
- **S0d** — \`retrieval\` 처치 결정 PR (deprecate or RAG 인프라 신설)

🤖 Generated with [Claude Code](https://claude.com/claude-code)