### PR TITLE
feat(self-improving): S0c — decomposition reader 신설 (ADR-012 dead slot #3 살리기)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,28 @@ functional change.
 
 ### Added
 
+- **PR-S0c — `decomposition` reader 신설 (ADR-012 dead slot 살리기 #3).**
+  PR-S0a/S0b 의 패턴 그대로 차용. **schema** (3 field 모두 optional,
+  string): `system_prompt` (전체 override — prefix/suffix 무시) /
+  `prefix` (default 앞에 추가) / `suffix` (default 뒤에 추가). 3-mode
+  정책으로 `load_prompt` 결과를 변형. **Resolution order**: ①
+  `GEODE_DECOMPOSITION_POLICY_OVERRIDE` (audit, strict) ②
+  `~/.geode/self-improving-loop/decomposition.json` (daily, graceful)
+  ③ `None`. 단일 적용 지점: `core/orchestration/goal_decomposer.py:_llm_decompose`
+  의 `load_prompt("decomposer", "system")` 호출 직후 —
+  `apply_decomposition_policy` 로 system prompt 정규화 후 `call_llm_parsed`
+  에 전달. **회귀 marker**: PR-AUDIT-5SLOT
+  `test_dead_slot_has_no_inference_reader` parametrize 에서
+  `decomposition.json` 제거 + 새 `test_decomposition_slot_is_now_alive_post_s0c`.
+  audit doc Post-S0c update 섹션 + 4/5 ALIVE anchor. ADR-012 Tier 1
+  표 + invariant test ALIVE/DEAD count (`==3/==2` → `==4/==1`) 동기화.
+  `autoresearch/train.py` env wiring 에 `GEODE_DECOMPOSITION_POLICY_OVERRIDE`
+  추가. ROI: `task_success_rate` (S1 의 `ux_means` 한 축) 영향 — 작업
+  분해 품질이 task 완수율로 직결. 18 new invariant + 기존 test 함께
+  통과 (총 91 test 그린). **ADR-012 단기 시퀀스의 S0a/S0b/S0c 완료**
+  → 5축 진화 면적 1축 → 4축 회복. 남은 dead slot 은 `retrieval` (S0d
+  처치 결정 예정 — deprecate or RAG 신설).
+
 - **PR-S0b — `reflection` reader 신설 (ADR-012 dead slot 살리기 #2).**
   PR-S0a (#1407) 의 패턴을 그대로 차용해 두 번째 dead slot
   (`reflection`) 을 살림. **schema** (두 field 모두 optional, string):

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -613,12 +613,18 @@ def run_audit(
     # graceful no-op 경로 (현재 default behaviour 보존). 즉 strict-fail
     # 은 "SoT 가 디스크에 있는데도 subprocess 가 못 읽는 경우" 만 발화 —
     # mutation 이 진행 중인 audit 의 quota 절약 목적.
-    from core.paths import GLOBAL_REFLECTION_POLICY_PATH, GLOBAL_TOOL_POLICY_PATH
+    from core.paths import (
+        GLOBAL_DECOMPOSITION_POLICY_PATH,
+        GLOBAL_REFLECTION_POLICY_PATH,
+        GLOBAL_TOOL_POLICY_PATH,
+    )
 
     if GLOBAL_TOOL_POLICY_PATH.is_file():
         env["GEODE_TOOL_POLICY_OVERRIDE"] = str(GLOBAL_TOOL_POLICY_PATH)
     if GLOBAL_REFLECTION_POLICY_PATH.is_file():
         env["GEODE_REFLECTION_POLICY_OVERRIDE"] = str(GLOBAL_REFLECTION_POLICY_PATH)
+    if GLOBAL_DECOMPOSITION_POLICY_PATH.is_file():
+        env["GEODE_DECOMPOSITION_POLICY_OVERRIDE"] = str(GLOBAL_DECOMPOSITION_POLICY_PATH)
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/decomposition_policy.py
+++ b/core/agent/decomposition_policy.py
@@ -1,0 +1,152 @@
+"""Decomposition policy SoT reader — ADR-012 S0c, dead slot 살리기.
+
+5축 mutation 의 ``decomposition`` slot 은 PR-6 시점부터 SoT 파일
+(`autoresearch/decomposition.json`) 만 정의되고 인퍼런스 reader 가 부재였다.
+``core/orchestration/goal_decomposer.py:_llm_decompose:241`` 의
+``load_prompt("decomposer", "system")`` 는 별도 prompt SoT 에서 system
+prompt 를 로드하지만 ``decomposition.json`` 과는 미연결 (PR-AUDIT-5SLOT
+2026-05-21 진단).
+
+이 모듈은 S0a/S0b 의 패턴을 그대로 차용해 ``decomposition.json`` 의
+정책을 GoalDecomposer 의 LLM 호출 직전에 적용한다.
+
+**SoT schema** (모든 field optional, string):
+
+.. code-block:: json
+
+    {
+      "system_prompt": "...",      # load_prompt("decomposer","system") override
+      "prefix": "...",             # default system_prompt 앞에 prefix 추가
+      "suffix": "..."              # default system_prompt 뒤에 suffix 추가
+    }
+
+빈 정책 / 누락 / 부적합 schema → no-op (load_prompt 결과 그대로 사용).
+``system_prompt`` 가 있으면 다른 두 field 는 무시 (override 우선).
+
+**Resolution order** (S0a/S0b 와 동일):
+
+1. ``GEODE_DECOMPOSITION_POLICY_OVERRIDE`` env var — audit subprocess, strict.
+2. ``~/.geode/self-improving-loop/decomposition.json`` — daily-run, graceful.
+3. ``None`` — no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_DECOMPOSITION_POLICY_PATH
+
+log = logging.getLogger(__name__)
+
+_DECOMPOSITION_POLICY_OVERRIDE_ENV = "GEODE_DECOMPOSITION_POLICY_OVERRIDE"
+
+_DECOMPOSITION_POLICY_SOT_PATH = GLOBAL_DECOMPOSITION_POLICY_PATH
+"""Cross-process SoT path (S0c, 2026-05-21). module-local alias 로 테스트
+가 monkeypatch 가능 (path-literal guard contract)."""
+
+
+_FIELD_SYSTEM_PROMPT = "system_prompt"
+_FIELD_PREFIX = "prefix"
+_FIELD_SUFFIX = "suffix"
+_ALL_FIELDS = frozenset({_FIELD_SYSTEM_PROMPT, _FIELD_PREFIX, _FIELD_SUFFIX})
+
+
+def _load_decomposition_policy_override() -> dict[str, str] | None:
+    """Return active decomposition policy, or ``None`` when no override applies.
+
+    Resolution order:
+
+    1. ``GEODE_DECOMPOSITION_POLICY_OVERRIDE`` env var (audit subprocess) — strict.
+    2. ``~/.geode/self-improving-loop/decomposition.json`` (daily run) — graceful.
+    3. ``None`` — no policy.
+    """
+    override_path = os.environ.get(_DECOMPOSITION_POLICY_OVERRIDE_ENV)
+    if override_path:
+        return _strict_load(Path(override_path))
+    if _DECOMPOSITION_POLICY_SOT_PATH.is_file():
+        return _graceful_load(_DECOMPOSITION_POLICY_SOT_PATH)
+    return None
+
+
+def _strict_load(path: Path) -> dict[str, str]:
+    """Audit-subprocess path: schema 실패 시 ``RuntimeError`` (fail-fast)."""
+    if not path.is_file():
+        raise RuntimeError(f"{_DECOMPOSITION_POLICY_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"{_DECOMPOSITION_POLICY_OVERRIDE_ENV}={path} load failed: {exc}"
+        ) from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, str] | None:
+    """Daily-run path: schema 실패 시 WARNING + ``None``."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("decomposition policy SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("decomposition policy SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """``data`` 가 ``dict`` + 알려진 field 는 모두 ``str``.
+
+    Unknown field 는 무시 (forward-compatible)."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"decomposition policy at {path} must be a dict")
+    for key in _ALL_FIELDS:
+        if key in data and not isinstance(data[key], str):
+            got = type(data[key]).__name__
+            raise RuntimeError(
+                f"decomposition policy at {path} field {key!r} must be str; got {got}"
+            )
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, str]:
+    """알려진 3 field 만 추출. 빈 string 은 drop."""
+    return {key: data[key] for key in _ALL_FIELDS if data.get(key)}
+
+
+def apply_decomposition_policy(
+    system_prompt: str,
+    policy: dict[str, str] | None,
+) -> str:
+    """Apply ``policy`` to the decomposer's system prompt.
+
+    ``policy is None`` → 입력 그대로.
+
+    - ``system_prompt`` field 가 정책에 있으면 그것으로 전체 override
+      (prefix/suffix 무시 — override 우선).
+    - 그렇지 않고 ``prefix`` 가 있으면 default 의 앞에 추가.
+    - 그렇지 않고 ``suffix`` 가 있으면 default 의 뒤에 추가.
+    - 둘 다 있으면 ``{prefix}\\n\\n{default}\\n\\n{suffix}``.
+    """
+    if policy is None:
+        return system_prompt
+    override = policy.get(_FIELD_SYSTEM_PROMPT)
+    if override:
+        return override
+    prefix = policy.get(_FIELD_PREFIX, "")
+    suffix = policy.get(_FIELD_SUFFIX, "")
+    if not prefix and not suffix:
+        return system_prompt
+    parts = [p for p in (prefix, system_prompt, suffix) if p]
+    return "\n\n".join(parts)
+
+
+__all__ = ["apply_decomposition_policy"]

--- a/core/orchestration/goal_decomposer.py
+++ b/core/orchestration/goal_decomposer.py
@@ -235,10 +235,18 @@ class GoalDecomposer:
     ) -> DecompositionResult | None:
         """Call LLM to decompose the request into sub-goals."""
         try:
+            from core.agent.decomposition_policy import (
+                _load_decomposition_policy_override,
+                apply_decomposition_policy,
+            )
             from core.llm.prompts import load_prompt
             from core.llm.router import call_llm_parsed
 
             system = load_prompt("decomposer", "system")
+            # ADR-012 S0c — 5축의 ``decomposition`` SoT 가 인퍼런스 경로에서
+            # 실제로 적용되는 단일 지점. 정책이 부재하면 ``apply_decomposition_policy``
+            # 는 system 그대로 반환 (현재 행동 보존).
+            system = apply_decomposition_policy(system, _load_decomposition_policy_override())
 
             # Build tool summary for the prompt
             tool_summary = self._build_tool_summary(tools)

--- a/docs/adr/ADR-012-self-improvement-surface-tiers.md
+++ b/docs/adr/ADR-012-self-improvement-surface-tiers.md
@@ -14,13 +14,13 @@ GEODE 는 weight-invariant evolutionary agent 군 (AlphaEvolve / Voyager / Refle
 
 Petri 17-dim 중 **양의 압력 (성능 향상) 으로 작동하는 dim 은 사실상 `broken_tool_use` 1개** 뿐이고 나머지는 alignment / safety evaluation 축으로 음의 압력 ("안 망가지기") 이다. 17-dim 의 가중치가 동일 차원에 압축돼 fitness 의 정의역이 "에이전트가 망가지지 않는지" 에 쏠려 있다. seed pool 의 정교화 + skill 진화의 노력 대부분이 alignment dim 의 마이크로-튜닝으로 흡수되는 구조적 누수.
 
-### 발견 2 — Mutation 표면의 wiring 누수 (audit 시점 1/5, S0a+S0b 이후 3/5)
+### 발견 2 — Mutation 표면의 wiring 누수 (audit 시점 1/5, S0a/S0b/S0c 이후 4/5)
 
 PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md`) 가 진단한 audit 시점 결과 — mutator 가 mutate 할 수 있다고 명세된 5 slot 중 인퍼런스 reader 가 살아있는 slot 은 `prompt` 하나뿐. 나머지 4 (`tool_policy` / `decomposition` / `retrieval` / `reflection`) 는 SoT 파일 + mutation dispatcher 는 있지만 **인퍼런스 경로에서 정책을 읽어 행동에 반영하는 reader 가 부재** — `core/self_improving_loop/policies.py:29-37` 의 docstring 이 직접 자백한다 (PR-6 의 의도적 follow-up 미완 + 잊혀짐).
 
-**S0a + S0b (2026-05-21 머지) 이후 상태**: `tool_policy` + `reflection` 이 ALIVE 로 전환. `tool_policy` reader 는 `core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools` 에서 호출. `reflection` reader 는 `core/agent/reflection_policy.py` → `_reflection.py` 의 reflection LLM 호출 직전 적용. 따라서 audit 시점 1/5 → 현재 3/5 ALIVE. 남은 dead slot 은 `decomposition` (S0c) / `retrieval` (S0d 처치 결정).
+**S0a + S0b + S0c (2026-05-21 머지) 이후 상태**: `tool_policy` + `reflection` + `decomposition` 이 ALIVE 로 전환. reader 위치 — `tool_policy`: `core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools`. `reflection`: `core/agent/reflection_policy.py` → `_reflection.py` LLM 호출 직전. `decomposition`: `core/agent/decomposition_policy.py` → `core/orchestration/goal_decomposer.py:_llm_decompose` 의 `load_prompt("decomposer", "system")` 호출 직후. 따라서 audit 시점 1/5 → 현재 4/5 ALIVE. 남은 dead slot 은 `retrieval` (S0d 처치 결정 — deprecate 또는 RAG 인프라 신설).
 
-→ 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 audit 시점 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이었다 (1/40~1/85 누수). S0a + S0b 이후 3축 × 1-2dim = 3-6 면적으로 회복 중이고 S0c 완료 시 4축까지 회복 예정.
+→ 두 누수가 곱해지면 GEODE 의 self-improving loop 는 **명세상 5축 × 17-dim = 85 면적이지만 audit 시점 실제 진화 압력은 1축 × 1-2dim = 1-2 면적**으로 운영 중이었다 (1/40~1/85 누수). S0a + S0b + S0c 이후 4축 × 1-2dim = 4-8 면적으로 회복. S0d 의 retrieval 처치 결정 후 최대 5축 또는 deprecate 시 4축으로 안정화.
 
 ### 발견 3 — Fine-tune 표면의 채널 제약
 
@@ -45,7 +45,7 @@ PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.
 |---|---|---|---|
 | 5축 SoT `prompt` | `wrapper-sections.json` | **가동 중** | **ALIVE** — `system_prompt.py:57` chain |
 | 5축 SoT `tool_policy` | `tool-policy.json` | **가동 중** (S0a, 2026-05-21) | **ALIVE** — `core/agent/tool_policy.py` (`_load_tool_policy_override` + `apply_tool_policy`) → `core/agent/loop/_helpers.py:get_agentic_tools` |
-| 5축 SoT `decomposition` | `decomposition.json` | mutation target 정의만 | **DEAD** — `core/orchestration/goal_decomposer.py` 가 `load_prompt("decomposer", "system")` 로 별도 SoT 사용 중. `decomposition.json` 미연결. S0c reader 신설 필요 |
+| 5축 SoT `decomposition` | `decomposition.json` | **가동 중** (S0c, 2026-05-21) | **ALIVE** — `core/agent/decomposition_policy.py` (`_load_decomposition_policy_override` + `apply_decomposition_policy`) → `core/orchestration/goal_decomposer.py:_llm_decompose` 의 `load_prompt("decomposer", "system")` 호출 직후 적용 (override / prefix / suffix 3-mode) |
 | 5축 SoT `retrieval` | `retrieval.json` | mutation target 정의만 | **DEAD** — RAG 인프라 부재. S0d 에서 deprecate 또는 보류 |
 | 5축 SoT `reflection` | `reflection.json` | **가동 중** (S0b, 2026-05-21) | **ALIVE** — `core/agent/reflection_policy.py` (`_load_reflection_policy_override` + `apply_reflection_policy`) → `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용 |
 | Skill 정의 | `.claude/skills/<name>/` (20+개) | 수동 (mutation 채널 밖) | n/a (M1 에서 6번째 target_kind 로 개통) |

--- a/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
+++ b/docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.md
@@ -37,7 +37,7 @@ infrastructure is committed before the policies that consume them.
 |---|---|---|---|---|
 | `prompt` | `wrapper-sections.json` | ✓ | `core/agent/system_prompt.py:57` (`_load_wrapper_override`) → `:79-80` (SoT fallback read) → `:194` (`build_system_prompt` 호출) → `:198/:210` (audit/normal mode inject) → `core/agent/loop/_context.py:103` → `core/agent/loop/agent_loop.py` (LLM 호출 경로) | **ALIVE** |
 | `tool_policy` | `tool-policy.json` | ✓ | **audit 시점 없음** — `paths.py:92`, `policies.py:130` 정의만. **S0a 이후** `core/agent/tool_policy.py` (`_load_tool_policy_override` + `apply_tool_policy`) → `core/agent/loop/_helpers.py:get_agentic_tools` | **DEAD → ALIVE (S0a, 2026-05-21 머지)** |
-| `decomposition` | `decomposition.json` | ✓ | **없음** — `_decomposition.py:31` 의 `GoalDecomposer` 는 prompt 를 `core.llm.prompts.load_prompt("decomposer", "system")` 로 별도 SoT 에서 로드. 즉 hardcoded 가 아니지만 어느 경로도 `decomposition.json` 을 읽지 않음 — 그게 dead 사유 | **DEAD** |
+| `decomposition` | `decomposition.json` | ✓ | **audit 시점 없음** — `GoalDecomposer` 는 prompt 를 `load_prompt("decomposer", "system")` 로 별도 SoT 에서 로드, `decomposition.json` 미연결. **S0c 이후** `core/agent/decomposition_policy.py` (`_load_decomposition_policy_override` + `apply_decomposition_policy`) → `core/orchestration/goal_decomposer.py:_llm_decompose` 의 `load_prompt` 호출 직후 적용 | **DEAD → ALIVE (S0c, 2026-05-21 머지)** |
 | `retrieval` | `retrieval.json` | ✓ | **없음** — `paths.py:94`, `policies.py:132` 정의만 | **DEAD** |
 | `reflection` | `reflection.json` | ✓ | **audit 시점 없음** — `_REFLECTION_TOOL` + `_SYSTEM_PROMPT` 가 module-level constant. **S0b 이후** `core/agent/reflection_policy.py` (`_load_reflection_policy_override` + `apply_reflection_policy`) → `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용 | **DEAD → ALIVE (S0b, 2026-05-21 머지)** |
 
@@ -61,9 +61,19 @@ ADR-012 S0b (`reflection` reader 신설) 머지 후 상태:
 |---|---|---|
 | `reflection` | **DEAD → ALIVE** | `core/agent/reflection_policy.py` 의 `_load_reflection_policy_override` + `apply_reflection_policy` → `core/agent/loop/_reflection.py` 의 reflection LLM 호출 직전 적용 |
 
-**현재 상태**: 3/5 ALIVE, 2/5 DEAD. 남은 dead slot: `decomposition` (S0c 예정) / `retrieval` (S0d 처치 결정 예정).
+**S0b 직후 상태**: 3/5 ALIVE, 2/5 DEAD.
 
-## 4. 인과 체인의 끊김 (audit 시점 사실, Post-S0a/S0b 갱신은 §3 참고)
+### Post-S0c (2026-05-21 오후 3차) update
+
+ADR-012 S0c (`decomposition` reader 신설) 머지 후 상태:
+
+| Slot | 변동 | 새 reader 위치 |
+|---|---|---|
+| `decomposition` | **DEAD → ALIVE** | `core/agent/decomposition_policy.py` 의 `_load_decomposition_policy_override` + `apply_decomposition_policy` (override / prefix / suffix 3-mode) → `core/orchestration/goal_decomposer.py:_llm_decompose` 의 `load_prompt("decomposer", "system")` 호출 직후 적용 |
+
+**현재 상태**: 4/5 ALIVE, 1/5 DEAD. 남은 dead slot: `retrieval` (S0d 처치 결정 예정 — deprecate or RAG 신설).
+
+## 4. 인과 체인의 끊김 (audit 시점 사실, Post-S0a/S0b/S0c 갱신은 §3 참고)
 
 ```
 mutator LLM
@@ -83,7 +93,7 @@ mutator LLM
 
 ## 5. ALIVE slot 의 상세 — `prompt` (audit 시점)
 
-audit 시점 (2026-05-21 오전) 에 `prompt` 가 진화 압력에 닿는 유일한 slot. **Post-S0a/S0b 머지 (오후) 이후 `tool_policy` + `reflection` 추가 ALIVE** — §3 의 Post-S0* update 섹션 참고. 인퍼런스 경로 도식은 audit 시점 사실로 보존:
+audit 시점 (2026-05-21 오전) 에 `prompt` 가 진화 압력에 닿는 유일한 slot. **Post-S0a/S0b/S0c 머지 (오후) 이후 `tool_policy` + `reflection` + `decomposition` 추가 ALIVE** — §3 의 Post-S0* update 섹션 참고. 인퍼런스 경로 도식은 audit 시점 사실로 보존:
 
 | 단계 | 코드 위치 | 동작 |
 |---|---|---|
@@ -94,7 +104,7 @@ audit 시점 (2026-05-21 오전) 에 `prompt` 가 진화 압력에 닿는 유일
 | 5 | `core/agent/loop/agent_loop.py` | 구성된 system prompt 가 LLM 호출 경로로 흘러들어감 |
 | 6 | Petri eval | 변경된 system prompt 로 응답 → dim_means 변동 → fitness gate 작동 |
 
-이게 audit 시점 (2026-05-21 오전) 의 사실 — 5축 중 유일하게 닫힌 루프, 나머지 4축은 (1)→(2) 사이에서 끊김. **Post-S0a/S0b 머지 후**: `tool_policy` (`core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools`) 와 `reflection` (`core/agent/reflection_policy.py` → `_reflection.py` LLM 호출 직전) 도 동일하게 닫힌 루프로 회복.
+이게 audit 시점 (2026-05-21 오전) 의 사실 — 5축 중 유일하게 닫힌 루프, 나머지 4축은 (1)→(2) 사이에서 끊김. **Post-S0a/S0b/S0c 머지 후**: `tool_policy` (`core/agent/tool_policy.py` → `_helpers.py:get_agentic_tools`), `reflection` (`core/agent/reflection_policy.py` → `_reflection.py`), `decomposition` (`core/agent/decomposition_policy.py` → `goal_decomposer.py:_llm_decompose`) 모두 동일하게 닫힌 루프로 회복.
 
 ## 6. DEAD slot 별 권고
 
@@ -108,13 +118,13 @@ audit 시점 (2026-05-21 오전) 에 `prompt` 가 진화 압력에 닿는 유일
 | 권고 B (deprecate) | `TARGET_KINDS` 에서 제거. 5축 → 4축으로 축소 명시 |
 | ROI 추정 | **권고 A** — `broken_tool_use` dim 직접 영향. 5축 중 가장 양의 압력 우호적인 dim 이라 ROI 높음 |
 
-### 6b. `decomposition`
+### 6b. `decomposition` (S0c 머지 완료, 2026-05-21)
 
 | 항목 | 내용 |
 |---|---|
 | 의도 | 작업 분해 (multi-step plan) 의 진화 |
-| 현재 | `GoalDecomposer` (`core/orchestration/goal_decomposer.py`) 의 분해 prompt 가 hardcoded — `decomposition.json` 무관 |
-| 권고 A (살리기) | `GoalDecomposer` 의 prompt 가 현재 `core.llm.prompts.load_prompt("decomposer", "system")` 로 별도 SoT 에서 로드되므로, `decomposition.json` 과 그 SoT 의 연결 (load_prompt 가 `decomposition.json` 의 sections override 를 우선 적용) 또는 `_load_decomposition_policy()` 신설로 `wrapper-sections` 패턴 재사용 |
+| audit 시점 | `GoalDecomposer` 의 prompt 가 `load_prompt("decomposer", "system")` 로 별도 SoT 에서 로드, `decomposition.json` 미연결 |
+| S0c 머지 후 | `core/agent/decomposition_policy.py` 신설 (`_load_decomposition_policy_override` + `apply_decomposition_policy`), `core/orchestration/goal_decomposer.py:_llm_decompose` 의 `load_prompt` 호출 직후 적용. schema: `system_prompt` (전체 override) / `prefix` (앞에 추가) / `suffix` (뒤에 추가) 3-mode |
 | 권고 B (deprecate) | 같음 |
 | ROI 추정 | **권고 A** — 작업 분해 품질이 `task_success_rate` (단기 S1 의 `ux_means` 의 한 축) 직접 영향 |
 
@@ -165,10 +175,10 @@ grep -n "_REFLECTION_TOOL" core/agent/loop/_reflection.py
 grep -n "PR-6 stops at the" core/self_improving_loop/policies.py
 # Reader 부재 — 현재 DEAD slot 의 SoT 파일명이 인퍼런스 디렉토리 어디에서도
 # 참조되지 않는지 확인 (self_improving_loop 의 mutation 정의/디스패처는 제외).
-# Post-S0a/S0b 머지 후: 4 DEAD → 2 DEAD (decomposition + retrieval).
-# tool-policy.json (S0a 머지) / reflection.json (S0b 머지) 는 audit-only
-# 시점 historical 검색에서만 사용:
-for slot in decomposition.json retrieval.json; do
+# Post-S0a/S0b/S0c 머지 후: 4 DEAD → 1 DEAD (retrieval).
+# tool-policy.json (S0a) / reflection.json (S0b) / decomposition.json (S0c)
+# 는 audit-only 시점 historical 검색에서만 사용:
+for slot in retrieval.json; do
   grep -rn "$slot" core/agent core/orchestration core/skills core/llm plugins autoresearch \
     | grep -v "self_improving_loop/policies.py" \
     | grep -v "self_improving_loop/runner.py" \

--- a/tests/test_adr_012_surface_tiers.py
+++ b/tests/test_adr_012_surface_tiers.py
@@ -56,15 +56,14 @@ def test_tier_1_lists_all_5_slots_with_alive_dead_status() -> None:
     text = _read_adr()
     for slot in ("prompt", "tool_policy", "decomposition", "retrieval", "reflection"):
         assert f"`{slot}`" in text, f"slot missing in Tier 1: {slot}"
-    # ALIVE/DEAD count — S0a + S0b 머지 (2026-05-21) 후 `tool_policy` +
-    # `reflection` ALIVE 로 전환. 현재 상태: 3 ALIVE (prompt + tool_policy +
-    # reflection) / 2 DEAD (decomposition + retrieval). S0c/d 머지 시마다
-    # 이 count 와 ADR Tier 1 표를 함께 갱신.
-    assert text.count("**ALIVE**") == 3, (
-        f"S0a+S0b 후 ALIVE slot 은 정확히 3 개여야 함. count={text.count('**ALIVE**')}"
+    # ALIVE/DEAD count — S0a/S0b/S0c 머지 (2026-05-21) 후 `tool_policy` +
+    # `reflection` + `decomposition` ALIVE 로 전환. 현재 상태: 4 ALIVE /
+    # 1 DEAD (retrieval). S0d 머지 (deprecate or RAG 신설) 후 다시 갱신.
+    assert text.count("**ALIVE**") == 4, (
+        f"S0a/S0b/S0c 후 ALIVE slot 은 정확히 4 개여야 함. count={text.count('**ALIVE**')}"
     )
-    assert text.count("**DEAD**") == 2, (
-        f"S0a+S0b 후 DEAD slot 은 정확히 2 개 (decomposition + retrieval) 여야 함. "
+    assert text.count("**DEAD**") == 1, (
+        f"S0a/S0b/S0c 후 DEAD slot 은 정확히 1 개 (retrieval) 여야 함. "
         f"count={text.count('**DEAD**')}"
     )
 

--- a/tests/test_s0c_decomposition_reader.py
+++ b/tests/test_s0c_decomposition_reader.py
@@ -1,0 +1,186 @@
+"""ADR-012 S0c — `decomposition` reader invariants.
+
+`decomposition.json` 의 정책이 GoalDecomposer 의 LLM 호출 직전에
+system prompt 를 override / prefix / suffix 하는지 검증.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.agent.decomposition_policy import (
+    _load_decomposition_policy_override,
+    apply_decomposition_policy,
+)
+
+from core.agent import decomposition_policy
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "decomposition.json"
+    monkeypatch.setattr(decomposition_policy, "_DECOMPOSITION_POLICY_SOT_PATH", sot)
+    monkeypatch.delenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, str]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_decomposition_policy_override() is None
+
+
+def test_load_returns_none_when_sot_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_decomposition_policy_override() is None
+
+
+def test_load_returns_none_when_sot_type_violation(isolated_sot: Path) -> None:
+    isolated_sot.write_text(json.dumps({"system_prompt": ["not", "str"]}), encoding="utf-8")
+    assert _load_decomposition_policy_override() is None
+
+
+def test_load_valid_payload(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"system_prompt": "new", "prefix": "p", "suffix": "s"})
+    assert _load_decomposition_policy_override() == {
+        "system_prompt": "new",
+        "prefix": "p",
+        "suffix": "s",
+    }
+
+
+def test_load_unknown_fields_ignored(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"prefix": "p", "unknown": "x"})
+    assert _load_decomposition_policy_override() == {"prefix": "p"}
+
+
+def test_load_empty_string_dropped(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"system_prompt": "", "prefix": "p"})
+    assert _load_decomposition_policy_override() == {"prefix": "p"}
+
+
+def test_strict_load_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", str(tmp_path / "nope.json"))
+    with pytest.raises(RuntimeError, match="GEODE_DECOMPOSITION_POLICY_OVERRIDE"):
+        _load_decomposition_policy_override()
+
+
+def test_strict_load_raises_on_type(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"prefix": ["list"]}), encoding="utf-8")
+    monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", str(bad))
+    with pytest.raises(RuntimeError, match="prefix"):
+        _load_decomposition_policy_override()
+
+
+# Apply -----------------------------------------------------------------------
+
+
+_BASE = "base decomposer system prompt"
+
+
+def test_apply_none_is_noop() -> None:
+    assert apply_decomposition_policy(_BASE, None) == _BASE
+
+
+def test_apply_empty_is_noop() -> None:
+    assert apply_decomposition_policy(_BASE, {}) == _BASE
+
+
+def test_apply_system_prompt_full_override() -> None:
+    """system_prompt 가 있으면 전체 override (prefix/suffix 무시)."""
+    out = apply_decomposition_policy(
+        _BASE,
+        {"system_prompt": "override", "prefix": "ignored", "suffix": "ignored"},
+    )
+    assert out == "override"
+
+
+def test_apply_prefix_only() -> None:
+    out = apply_decomposition_policy(_BASE, {"prefix": "P"})
+    assert out == f"P\n\n{_BASE}"
+
+
+def test_apply_suffix_only() -> None:
+    out = apply_decomposition_policy(_BASE, {"suffix": "S"})
+    assert out == f"{_BASE}\n\nS"
+
+
+def test_apply_prefix_and_suffix() -> None:
+    out = apply_decomposition_policy(_BASE, {"prefix": "P", "suffix": "S"})
+    assert out == f"P\n\n{_BASE}\n\nS"
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_goal_decomposer_imports_reader() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/orchestration/goal_decomposer.py").read_text(encoding="utf-8")
+    assert "_load_decomposition_policy_override" in src
+    assert "apply_decomposition_policy" in src
+
+
+def test_goal_decomposer_applies_policy_after_load_prompt() -> None:
+    """``load_prompt("decomposer", "system")`` 호출 직후에 정책이 적용되는지
+    source-order 검증."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/orchestration/goal_decomposer.py").read_text(encoding="utf-8")
+    load_pos = src.find('load_prompt("decomposer", "system")')
+    # apply_decomposition_policy 의 첫 호출 위치 — 들여쓰기 무관
+    apply_pos = src.find("apply_decomposition_policy(")
+    # 호출 (괄호 있는 패턴) 만 검색 — import 의 식별자 위치보다 뒤에 있어야 함
+    while apply_pos != -1 and src.count("import", 0, apply_pos) > src.count("def ", 0, apply_pos):
+        # import 라인은 스킵 — 다음 호출 위치 검색
+        next_pos = src.find("apply_decomposition_policy(", apply_pos + 1)
+        if next_pos == -1:
+            break
+        apply_pos = next_pos
+    assert load_pos > 0
+    assert apply_pos > load_pos, (
+        f"apply_decomposition_policy 호출이 load_prompt 호출 후에 와야 함. "
+        f"load_pos={load_pos} apply_pos={apply_pos}"
+    )
+
+
+# Producer → Reader -----------------------------------------------------------
+
+
+def test_producer_reader_round_trip(isolated_sot: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.self_improving_loop import policies as policies_mod
+
+    monkeypatch.setattr(policies_mod, "policy_path", lambda kind: isolated_sot)
+    policies_mod.write_policy(
+        "decomposition",
+        {"system_prompt": "evolved", "suffix": "extra rules"},
+    )
+    result = _load_decomposition_policy_override()
+    assert result == {"system_prompt": "evolved", "suffix": "extra rules"}
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_decomposition_json_is_now_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name or "self_improving_loop" in str(path):
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "decomposition.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("decomposition_policy.py" in h for h in hits), (
+        f"decomposition.json 이 core/agent/decomposition_policy.py 에서 발견되어야 함. hits={hits}"
+    )

--- a/tests/test_self_improving_5_slot_reader_audit.py
+++ b/tests/test_self_improving_5_slot_reader_audit.py
@@ -95,13 +95,14 @@ def test_audit_doc_exists() -> None:
 def test_audit_doc_pins_1_alive_4_dead() -> None:
     """결론 한 줄 anchor."""
     text = _read(AUDIT_DOC)
-    # ADR-012 S0a/S0b (2026-05-21) 머지 이후 `tool_policy`/`reflection` 이 ALIVE.
-    # audit 시점 의 사실은 1/5 — 그 줄을 유지하면서 post-S0* update 섹션
-    # 들이 함께 등장하는지 확인.
+    # ADR-012 S0a/S0b/S0c (2026-05-21) 머지 이후 `tool_policy`/`reflection`/
+    # `decomposition` 이 ALIVE. audit 시점 의 사실은 1/5 — 그 줄을 유지하면서
+    # post-S0* update 섹션들이 함께 등장하는지 확인.
     assert "1/5 ALIVE, 4/5 DEAD" in text  # 원본 audit 시점 사실
-    assert "Post-S0a" in text  # S0a 후속 갱신 섹션
-    assert "Post-S0b" in text  # S0b 후속 갱신 섹션
-    assert "3/5 ALIVE, 2/5 DEAD" in text  # 현재 상태 (S0b 후)
+    assert "Post-S0a" in text
+    assert "Post-S0b" in text
+    assert "Post-S0c" in text
+    assert "4/5 ALIVE, 1/5 DEAD" in text  # 현재 상태 (S0c 후)
 
 
 def test_audit_doc_names_all_5_slots() -> None:
@@ -146,11 +147,10 @@ def test_prompt_reader_is_called_in_agentic_loop() -> None:
 @pytest.mark.parametrize(
     "sot_filename",
     [
-        # ADR-012 S0a/S0b (2026-05-21) 머지 이후 ``tool-policy.json`` 과
-        # ``reflection.json`` 이 ALIVE — 각각의 reader 가
-        # ``core/agent/{tool_policy,reflection_policy}.py`` 에 존재. 이
-        # parametrize 에서 제거됨.
-        "decomposition.json",
+        # ADR-012 S0a/S0b/S0c (2026-05-21) 머지 이후 ``tool-policy.json``,
+        # ``reflection.json``, ``decomposition.json`` 이 ALIVE — 각각의
+        # reader 가 ``core/agent/{tool_policy,reflection_policy,decomposition_policy}.py``
+        # 에 존재. 이 parametrize 에서 제거됨.
         "retrieval.json",
     ],
 )
@@ -190,18 +190,22 @@ def test_tool_policy_slot_is_now_alive_post_s0a() -> None:
     )
 
 
-def test_decomposition_slot_not_wired_to_decomposition_json() -> None:
-    """decomposition slot 의 dead 사유 — ``_decomposition.py`` 는
-    ``GoalDecomposer`` 를 호출하고 ``GoalDecomposer`` 의 prompt 는
-    ``core.llm.prompts.load_prompt("decomposer", "system")`` 으로
-    별도 prompt SoT 에서 로드 (즉 hardcoded 가 아님). 다만 어느 경로도
-    ``decomposition.json`` 을 읽지 않음 — 그게 decomposition slot 의
-    dead 사유. (Codex MCP 검증 결과 반영 — `hardcoded` 표현은 부정확,
-    `decomposition.json 미연결` 이 정확.)"""
-    src = _read("core/agent/loop/_decomposition.py")
-    assert "GoalDecomposer" in src
-    # decomposition.json 을 읽는 reader 없음 (loop 진입 지점)
-    assert "decomposition.json" not in src
+def test_decomposition_slot_is_now_alive_post_s0c() -> None:
+    """ADR-012 S0c 머지 이후 ``decomposition.json`` 은 ALIVE — reader 가
+    ``core/agent/decomposition_policy.py`` 에 존재 + ``goal_decomposer.py``
+    의 ``_llm_decompose`` 에서 실제로 호출됨."""
+    hits = _grep_inference_dirs("decomposition.json")
+    assert any("decomposition_policy.py" in h for h in hits), (
+        f"decomposition.json 이 core/agent/decomposition_policy.py 에서 발견되어야 함. hits={hits}"
+    )
+    # Call chain 검증 — goal_decomposer.py 가 reader 를 호출.
+    src = _read("core/orchestration/goal_decomposer.py")
+    assert "_load_decomposition_policy_override" in src, (
+        "goal_decomposer.py 가 _load_decomposition_policy_override 를 호출해야 함."
+    )
+    assert "apply_decomposition_policy" in src, (
+        "goal_decomposer.py 가 apply_decomposition_policy 를 호출해야 함."
+    )
 
 
 def test_reflection_slot_is_now_alive_post_s0b() -> None:


### PR DESCRIPTION
## Summary

- ADR-012 의 단기 시퀀스 세 번째. S0a (#1407) / S0b (#1408) 의 패턴 그대로 차용해 \`decomposition\` slot 을 dead → ALIVE.
- 단일 적용 지점 (\`core/orchestration/goal_decomposer.py:_llm_decompose\`) 에서 \`load_prompt("decomposer", "system")\` 결과를 \`apply_decomposition_policy\` 로 변형.
- 5축 진화 면적: 3/5 → **4/5 ALIVE**. 남은 dead slot: \`retrieval\` (S0d 처치 결정).

## Why

PR-AUDIT-5SLOT 진단 4 dead slot 중 세 번째 처치. \`decomposition\` 살아나면:
- 작업 분해 (multi-step plan) 품질의 진화 압력이 닿음
- \`task_success_rate\` (S1 의 \`ux_means\` 한 축) 영향 — 작업 분해 품질 ↑ → task 완수율 ↑
- 3-mode schema (override / prefix / suffix) 로 mutator 가 default prompt 보존하면서 점진적 진화 가능

## Changes

| 파일 | 변경 |
|------|------|
| \`core/agent/decomposition_policy.py\` | 신설 — \`_load_decomposition_policy_override\` + \`apply_decomposition_policy\` (3-mode) |
| \`core/orchestration/goal_decomposer.py\` | \`_llm_decompose\` 에서 \`load_prompt\` 호출 직후 정책 적용 |
| \`autoresearch/train.py\` | audit subprocess env 에 \`GEODE_DECOMPOSITION_POLICY_OVERRIDE\` 추가 |
| \`tests/test_s0c_decomposition_reader.py\` | 18 invariant (reader 8 + apply 7 + wiring 2 + round trip) |
| \`tests/test_self_improving_5_slot_reader_audit.py\` | DEAD parametrize 에서 \`decomposition.json\` 제거 + 새 ALIVE test + Post-S0c + 4/5 anchor |
| \`tests/test_adr_012_surface_tiers.py\` | ALIVE/DEAD exact count: \`==3/==2\` → \`==4/==1\` |
| \`docs/audits/...reader-audit.md\` | 상태표 \`decomposition\` 행 갱신 + Post-S0c update 섹션 + §6b 권고 갱신 |
| \`docs/adr/ADR-012-...md\` | §Context 발견 2 + §Decision.1 Tier 1 표의 \`decomposition\` 행 ALIVE 로 갱신 |
| \`CHANGELOG.md\` | \`[Unreleased] / Added\` 항목 |

## Verification

- [x] \`uv run ruff check\` clean
- [x] \`uv run ruff format --check\` clean
- [x] \`uv run mypy\` — Success: no issues found in 3 source files
- [x] \`uv run pytest tests/test_s0c* tests/test_s0a* tests/test_s0b* tests/test_self_improving_5_slot* tests/test_adr_012*\` — 91/91 pass
- [x] \`uv run lint-imports\` — 4 contracts kept
- [ ] CI 5/5
- [ ] Codex MCP

## Reference

- ADR-012 §S0c
- 패턴 차용 — S0a (\`core/agent/tool_policy.py\`) + S0b (\`core/agent/reflection_policy.py\`) + \`system_prompt.py:_load_wrapper_override\`
- Path constant — \`core/paths.py:93 GLOBAL_DECOMPOSITION_POLICY_PATH\`

## 후속 — S0d

다음 PR: \`retrieval\` 처치 결정. 옵션 (a) deprecate (5축 → 4축 명시 축소) (b) RAG 인프라 신설 + reader 신설. ADR-012 의 §S0d 가 두 옵션 명시. 사용자 결정 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)