### PR TITLE
feat(self-improving): S1 — ux_means fitness 축 신설 (ADR-012 다축화 첫 단계)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,30 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-S1 — `ux_means` fitness 축 신설 (ADR-012 단기).** ADR-012
+  §Decision.2 의 fitness 다축화 첫 단계 — Petri 17-dim 의 음의 압력
+  (안 망가지기) 편향 risk 를 차단하기 위한 **양의 압력 축**.
+  **`autoresearch/ux_means.py` 신설** — 4-field schema (`success_rate`
+  / `token_cost_norm` / `revert_ratio_norm` / `latency_norm`) + 가중치
+  (0.40 / 0.30 / 0.20 / 0.10, 합 1.0) + `normalize_ux_field`
+  (lower-is-better metric 의 invert 처리) + `compute_ux_aggregate`
+  (`None` → 0.5 neutral) + `validate_ux_schema` + `collect_ux_means_from_sources`
+  (S1b placeholder, 현재 `None` 반환). **`autoresearch/train.py:compute_fitness`
+  다축화** — `ux_means` optional 인자 추가. `None` 이면 dim-only
+  fallback (no-op, 현재 행동 보존). 주어지면 `dim_part * 0.7 + ux_part
+  * 0.3` 가중 합 (admire_means 신설 S2 후 0.4/0.3/0.3 재배분 예정).
+  Critical gate (regress 시 `0.0`) 는 ux_means 와 무관하게 보존 —
+  strict-reject 정책. **27 invariant test** — schema 가중치 합 / 4-field
+  exact set / normalize invert 의 lower-is-better / aggregate
+  weighted-sum / validate 5 reject 케이스 / compute_fitness multi-axis
+  4 케이스 (ux=None dim-only / perfect ux 증가 / zero ux 감소 / critical
+  gate strict-reject). 4 source 의 실제 wiring (RunLog / LLMUsageAccumulator
+  / git history / OTel trace) 은 S1b (별도 PR) — schema 안정성 검증 후
+  분리 진행. ADR-012 단기 시퀀스의 G2 게이트 (음의 압력 90%+ 편향
+  4주 측정) 가 비로소 측정 가능해짐.
+
 ### Changed
 
 - **PR-S0d — `retrieval` slot deprecate (ADR-012 단기 시퀀스 종료).**

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -279,6 +279,14 @@ STABILITY_WEIGHT: float = 0.10
 """Stability axis weight — kept outside DIM_WEIGHTS because the value
 is derived from ``dim_stderr`` aggregate, not from a per-dim mean."""
 
+# ADR-012 S1 (2026-05-21) — ux_means fitness 축 가중치. ``compute_fitness``
+# 가 ``ux_means`` 인자를 받을 때 ``dim_part * UX_FITNESS_DIM_WEIGHT +
+# ux_part * UX_FITNESS_UX_WEIGHT`` 로 다축화. admire_means (S2) 신설 시
+# 가중치 재배분 예정 (dim 0.4 + ux 0.3 + admire 0.3).
+UX_FITNESS_DIM_WEIGHT: float = 0.70
+UX_FITNESS_UX_WEIGHT: float = 0.30
+assert abs(UX_FITNESS_DIM_WEIGHT + UX_FITNESS_UX_WEIGHT - 1.0) < 1e-9
+
 CRITICAL_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "critical")
 AUXILIARY_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "auxiliary")
 INFO_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "info")
@@ -767,8 +775,9 @@ def compute_fitness(
     baseline_stderr: dict[str, float] | None = None,
     critical_margin: float = 0.0,
     auxiliary_penalty_lambda: float = 0.5,
+    ux_means: dict[str, float] | None = None,
 ) -> float:
-    """17-dim weighted aggregate + stability axis with optional gate.
+    """17-dim weighted aggregate + stability axis + optional ux_means axis.
 
     20-dim universe (5 critical + 12 auxiliary + 3 info). Fitness is
     the weighted sum of 17 dims (5 critical + 12 auxiliary) plus the
@@ -788,6 +797,13 @@ def compute_fitness(
 
     When ``baseline_means`` is ``None`` the function returns the plain
     weighted sum.
+
+    ``ux_means`` (ADR-012 S1, 2026-05-21) — 양의 압력 4-field
+    (success_rate / token_cost_norm / revert_ratio_norm / latency_norm).
+    ``None`` 이면 dim-only fallback (no-op). 주어지면 fitness =
+    ``DIM_WEIGHT_TOTAL × dim_part + UX_WEIGHT × ux_aggregate`` 의 가중
+    합 (운영 권장 가중치: dim 0.7 + ux 0.3). admire_means 신설 (S2) 시
+    3축 다축화.
     """
     aggregate = 0.0
     for dim, weight in DIM_WEIGHTS.items():
@@ -795,26 +811,38 @@ def compute_fitness(
     aggregate += STABILITY_WEIGHT * _stability_score(dim_stderr)
 
     if baseline_means is None:
-        return aggregate
+        dim_part = aggregate
+    else:
+        stderr = baseline_stderr or {}
+        for dim in CRITICAL_DIMS:
+            base = baseline_means.get(dim)
+            if base is None:
+                continue
+            threshold = base + stderr.get(dim, 0.0) + critical_margin
+            if dim_means.get(dim, 0.0) > threshold:
+                # critical gate — ux_means 가 perfect 여도 strict-reject.
+                return 0.0
 
-    stderr = baseline_stderr or {}
-    for dim in CRITICAL_DIMS:
-        base = baseline_means.get(dim)
-        if base is None:
-            continue
-        threshold = base + stderr.get(dim, 0.0) + critical_margin
-        if dim_means.get(dim, 0.0) > threshold:
-            return 0.0
+        penalty = 0.0
+        for dim in AUXILIARY_DIMS:
+            base = baseline_means.get(dim)
+            if base is None:
+                continue
+            delta = dim_means.get(dim, 0.0) - base
+            if delta > 0.0:
+                penalty += auxiliary_penalty_lambda * (delta / 10.0) ** 2
+        dim_part = aggregate - penalty
 
-    penalty = 0.0
-    for dim in AUXILIARY_DIMS:
-        base = baseline_means.get(dim)
-        if base is None:
-            continue
-        delta = dim_means.get(dim, 0.0) - base
-        if delta > 0.0:
-            penalty += auxiliary_penalty_lambda * (delta / 10.0) ** 2
-    return aggregate - penalty
+    # ADR-012 S1 (2026-05-21) — ux_means 양의 압력 축. ``None`` 이면
+    # dim-only fallback (baseline_means 와 무관). 주어지면 (dim 0.7 +
+    # ux 0.3) 가중 합. admire_means (S2) 신설 시 3축 다축화 — 그때
+    # 가중치 재배분 (dim 0.4 + ux 0.3 + admire 0.3).
+    if ux_means is None:
+        return dim_part
+    from autoresearch.ux_means import compute_ux_aggregate
+
+    ux_part = compute_ux_aggregate(ux_means)
+    return UX_FITNESS_DIM_WEIGHT * dim_part + UX_FITNESS_UX_WEIGHT * ux_part
 
 
 # ---------------------------------------------------------------------------

--- a/autoresearch/ux_means.py
+++ b/autoresearch/ux_means.py
@@ -1,0 +1,127 @@
+"""``ux_means`` fitness 축 — ADR-012 S1.
+
+GEODE 의 self-improving loop 가 Petri 17-dim 의 음의 압력 (안 망가지기)
+편향에 빠지는 risk 를 차단하기 위한 **양의 압력** fitness 축. RunLog +
+LLMUsageAccumulator + git history + OTel trace 4 source 의 행동 metric 을
+0-1 정규화 후 가중 합산.
+
+**Schema** (4 field, 모두 0.0-1.0 normalized):
+
+.. code-block:: python
+
+    {
+      "success_rate": 0.95,        # RunLog.success 누적률 (높을수록 좋음)
+      "token_cost_norm": 0.30,     # 1 - clamp(token_cost/budget, 0, 1) (낮을수록 좋음 → invert)
+      "revert_ratio_norm": 0.90,   # 1 - revert_ratio (낮을수록 좋음 → invert)
+      "latency_norm": 0.80,        # 1 - clamp(latency/budget, 0, 1) (낮을수록 좋음 → invert)
+    }
+
+모든 필드는 정규화 후 **"높을수록 좋음"** 의미로 통일 (token_cost /
+revert_ratio / latency 는 lower-is-better 이므로 invert). 가중치는
+``UX_DIM_WEIGHTS`` 로 분배.
+
+**ADR-012 §Decision.2 의 fitness 다축화**:
+
+- ``dim_means`` (Petri 17-dim, 음의 압력) — 가중치 0.4
+- ``ux_means`` (행동 4-field, 양의 압력) — 가중치 0.3 (이 모듈)
+- ``admire_means`` (LLM-judge 체감, 양의 압력) — 가중치 0.3 (S2 신설 예정)
+
+S1 은 schema + math + ``compute_fitness`` 호환만 신설. 실제 4 source
+데이터 수집 wiring 은 S1b (별도 PR) — ``ux_means is None`` 일 때
+``compute_fitness`` 는 기존 dim-only fitness 반환 (no-op).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# UX field 별 가중치 — 합 1.0. 운영하면서 TOML 으로 조정 가능.
+# success_rate 가 가장 강한 신호 (task 완수 여부), token_cost 가 그 다음
+# (구독 quota 압력), revert_ratio + latency 는 secondary.
+UX_DIM_WEIGHTS: dict[str, float] = {
+    "success_rate": 0.40,
+    "token_cost_norm": 0.30,
+    "revert_ratio_norm": 0.20,
+    "latency_norm": 0.10,
+}
+
+assert abs(sum(UX_DIM_WEIGHTS.values()) - 1.0) < 1e-9, "UX_DIM_WEIGHTS must sum to 1.0"
+
+
+def normalize_ux_field(value: float, *, budget: float, invert: bool) -> float:
+    """Normalize ``value`` to 0-1 with optional invert.
+
+    - ``invert=False`` (e.g. success_rate already 0-1): clamp(value, 0, 1)
+    - ``invert=True`` (e.g. token_cost in USD, latency in seconds —
+      lower-is-better): return ``1 - clamp(value/budget, 0, 1)``
+
+    ``budget=0`` 가 invert=True 와 함께 들어오면 ``value=0`` 만 양호 신호
+    (1.0), 그 외 0.0 (degenerate).
+    """
+    if not invert:
+        return max(0.0, min(1.0, value))
+    if budget <= 0:
+        return 1.0 if value <= 0 else 0.0
+    ratio = max(0.0, min(1.0, value / budget))
+    return 1.0 - ratio
+
+
+def compute_ux_aggregate(ux_means: dict[str, float] | None) -> float:
+    """4-field weighted sum → 0-1 scalar. ``None`` → 0.5 (neutral)."""
+    if ux_means is None:
+        return 0.5  # neutral — fitness 가중치 0.3 × 0.5 = 0.15 기본 기여
+    total = 0.0
+    for field, weight in UX_DIM_WEIGHTS.items():
+        value = ux_means.get(field, 0.5)  # 누락 필드 도 neutral
+        total += weight * max(0.0, min(1.0, value))
+    return total
+
+
+def collect_ux_means_from_sources(*, _placeholder: bool = True) -> dict[str, float] | None:
+    """Collect ``ux_means`` from RunLog + LLMUsageAccumulator + git + OTel.
+
+    S1 (이 PR) 은 schema + math 만 신설. 4 source 의 실제 wiring 은 S1b
+    (별도 PR) 로 분리 — 각 source 의 reader 구현이 독립적으로 ROI 명확.
+
+    이 함수는 placeholder — S1b 전까지는 ``None`` 반환 (compute_fitness
+    가 dim-only fallback 으로 작동). S1b 머지 후 4 source 로부터 데이터
+    수집 후 normalize 해서 반환.
+
+    Args:
+        _placeholder: S1b 전까지 ``None`` 반환 강제. test 에서 override 가능.
+    """
+    if _placeholder:
+        return None
+    # S1b 에서 wiring:
+    # - RunLog.success_rate (core/orchestration/run_log.py)
+    # - LLMUsageAccumulator.token_cost (core/llm/token_tracker.py)
+    # - git revert_ratio (subprocess + git log)
+    # - OTel trace latency (있다면)
+    return None  # pragma: no cover — S1b wiring placeholder
+
+
+def validate_ux_schema(ux_means: Any) -> bool:
+    """Validate ``ux_means`` schema — dict[str, float], 알려진 field 만,
+    모두 0.0-1.0 범위. ``None`` 도 valid (no-op signal)."""
+    if ux_means is None:
+        return True
+    if not isinstance(ux_means, dict):
+        return False
+    known_fields = set(UX_DIM_WEIGHTS)
+    for key, value in ux_means.items():
+        if key not in known_fields:
+            return False
+        if not isinstance(value, int | float):
+            return False
+        if not (0.0 <= float(value) <= 1.0):
+            return False
+    return True
+
+
+__all__ = [
+    "UX_DIM_WEIGHTS",
+    "collect_ux_means_from_sources",
+    "compute_ux_aggregate",
+    "normalize_ux_field",
+    "validate_ux_schema",
+]

--- a/tests/test_s1_ux_means_fitness.py
+++ b/tests/test_s1_ux_means_fitness.py
@@ -1,0 +1,233 @@
+"""ADR-012 S1 — `ux_means` fitness 축 invariants.
+
+S1 의 minimal scope: schema + normalize + compute_fitness 다축화.
+실제 4 source (RunLog/LLMUsage/git/OTel) 의 wiring 은 S1b (별도 PR).
+"""
+
+from __future__ import annotations
+
+import pytest
+from autoresearch.train import (
+    UX_FITNESS_DIM_WEIGHT,
+    UX_FITNESS_UX_WEIGHT,
+    compute_fitness,
+)
+from autoresearch.ux_means import (
+    UX_DIM_WEIGHTS,
+    collect_ux_means_from_sources,
+    compute_ux_aggregate,
+    normalize_ux_field,
+    validate_ux_schema,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Schema constants
+# ---------------------------------------------------------------------------
+
+
+def test_ux_dim_weights_sum_to_one() -> None:
+    """4-field 가중치 합 == 1.0 (assert in module-level)."""
+    assert abs(sum(UX_DIM_WEIGHTS.values()) - 1.0) < 1e-9
+
+
+def test_ux_dim_weights_exact_4_fields() -> None:
+    """schema 의 4 field 정확히."""
+    assert set(UX_DIM_WEIGHTS) == {
+        "success_rate",
+        "token_cost_norm",
+        "revert_ratio_norm",
+        "latency_norm",
+    }
+
+
+def test_fitness_axis_weights_sum_to_one() -> None:
+    """``compute_fitness`` 의 dim/ux 가중치 합 == 1.0."""
+    assert abs(UX_FITNESS_DIM_WEIGHT + UX_FITNESS_UX_WEIGHT - 1.0) < 1e-9
+
+
+def test_fitness_dim_weight_dominates_for_s1() -> None:
+    """S1 단계 (admire_means 신설 전) 에서 dim 이 우세 — ux 의 양의 압력이
+    적용되지만 17-dim 의 음의 압력이 여전히 주축. S2 신설 시 재배분."""
+    assert UX_FITNESS_DIM_WEIGHT > UX_FITNESS_UX_WEIGHT
+
+
+# ---------------------------------------------------------------------------
+# 2. normalize_ux_field
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_no_invert_clamps_to_unit() -> None:
+    assert normalize_ux_field(0.5, budget=1.0, invert=False) == 0.5
+    assert normalize_ux_field(-1.0, budget=1.0, invert=False) == 0.0
+    assert normalize_ux_field(2.0, budget=1.0, invert=False) == 1.0
+
+
+def test_normalize_invert_lower_is_better() -> None:
+    """token_cost / latency 처럼 lower-is-better 인 metric → invert."""
+    # value=0 → 1.0 (best)
+    assert normalize_ux_field(0.0, budget=10.0, invert=True) == 1.0
+    # value=budget → 0.0 (worst)
+    assert normalize_ux_field(10.0, budget=10.0, invert=True) == 0.0
+    # value=half → 0.5
+    assert normalize_ux_field(5.0, budget=10.0, invert=True) == 0.5
+
+
+def test_normalize_invert_with_zero_budget() -> None:
+    """budget=0 + invert=True → degenerate. value=0 만 양호 (1.0), 외 0.0."""
+    assert normalize_ux_field(0.0, budget=0.0, invert=True) == 1.0
+    assert normalize_ux_field(1.0, budget=0.0, invert=True) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. compute_ux_aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_none_returns_neutral_half() -> None:
+    """``None`` ux_means → 0.5 neutral (no-op signal)."""
+    assert compute_ux_aggregate(None) == 0.5
+
+
+def test_aggregate_all_perfect_returns_one() -> None:
+    perfect = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    assert abs(compute_ux_aggregate(perfect) - 1.0) < 1e-9
+
+
+def test_aggregate_all_zero_returns_zero() -> None:
+    zero = dict.fromkeys(UX_DIM_WEIGHTS, 0.0)
+    assert compute_ux_aggregate(zero) == 0.0
+
+
+def test_aggregate_weighted_sum() -> None:
+    """success_rate=1.0 (weight 0.4) + 나머지 0.0 → 0.4."""
+    partial = {"success_rate": 1.0}
+    # 나머지는 누락 → neutral 0.5
+    expected = (
+        UX_DIM_WEIGHTS["success_rate"] * 1.0
+        + UX_DIM_WEIGHTS["token_cost_norm"] * 0.5
+        + UX_DIM_WEIGHTS["revert_ratio_norm"] * 0.5
+        + UX_DIM_WEIGHTS["latency_norm"] * 0.5
+    )
+    assert abs(compute_ux_aggregate(partial) - expected) < 1e-9
+
+
+def test_aggregate_clamps_out_of_range() -> None:
+    """범위 밖 값은 0-1 로 clamp."""
+    bad = dict.fromkeys(UX_DIM_WEIGHTS, 2.0)
+    assert abs(compute_ux_aggregate(bad) - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 4. validate_ux_schema
+# ---------------------------------------------------------------------------
+
+
+def test_validate_none() -> None:
+    assert validate_ux_schema(None) is True
+
+
+def test_validate_valid_dict() -> None:
+    assert validate_ux_schema({"success_rate": 0.5}) is True
+
+
+def test_validate_rejects_non_dict() -> None:
+    assert validate_ux_schema([1.0, 2.0]) is False
+    assert validate_ux_schema("not a dict") is False
+
+
+def test_validate_rejects_unknown_field() -> None:
+    assert validate_ux_schema({"unknown_field": 0.5}) is False
+
+
+def test_validate_rejects_out_of_range() -> None:
+    assert validate_ux_schema({"success_rate": 1.5}) is False
+    assert validate_ux_schema({"success_rate": -0.1}) is False
+
+
+def test_validate_rejects_non_numeric() -> None:
+    assert validate_ux_schema({"success_rate": "high"}) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. compute_fitness multi-axis
+# ---------------------------------------------------------------------------
+
+
+def test_compute_fitness_dim_only_when_ux_none() -> None:
+    """``ux_means is None`` → dim-only fallback (현재 behavior 보존)."""
+    dim_means = {"broken_tool_use": 5.0, "overrefusal": 2.0}
+    f_none = compute_fitness(dim_means, ux_means=None)
+    f_default = compute_fitness(dim_means)
+    assert f_none == f_default
+
+
+def test_compute_fitness_with_perfect_ux_increases() -> None:
+    """ux_means 가 모두 1.0 → fitness 증가."""
+    dim_means = {"broken_tool_use": 5.0}
+    base = compute_fitness(dim_means)
+    with_ux = compute_fitness(
+        dim_means,
+        ux_means=dict.fromkeys(UX_DIM_WEIGHTS, 1.0),
+    )
+    # dim*0.7 + ux*0.3 = base*0.7 + 1.0*0.3
+    assert with_ux > base * 0.65  # base*0.7 - epsilon < with_ux
+    expected = base * UX_FITNESS_DIM_WEIGHT + 1.0 * UX_FITNESS_UX_WEIGHT
+    assert abs(with_ux - expected) < 1e-9
+
+
+def test_compute_fitness_with_zero_ux_decreases() -> None:
+    """ux_means 가 모두 0 → fitness 감소 (dim*0.7 + 0*0.3 < dim)."""
+    dim_means = {"broken_tool_use": 5.0}
+    base = compute_fitness(dim_means)
+    with_zero_ux = compute_fitness(
+        dim_means,
+        ux_means=dict.fromkeys(UX_DIM_WEIGHTS, 0.0),
+    )
+    expected = base * UX_FITNESS_DIM_WEIGHT
+    assert abs(with_zero_ux - expected) < 1e-9
+
+
+def test_compute_fitness_ux_does_not_bypass_critical_gate() -> None:
+    """ux_means 가 perfect 여도 critical dim regress 면 fitness=0
+    (strict-reject 보존)."""
+    dim_means = {"broken_tool_use": 10.0}  # high = bad
+    baseline_means = {"broken_tool_use": 5.0}  # current is much worse
+    f = compute_fitness(
+        dim_means,
+        baseline_means=baseline_means,
+        ux_means=dict.fromkeys(UX_DIM_WEIGHTS, 1.0),
+    )
+    assert f == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 6. collect_ux_means_from_sources — S1b placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_collect_returns_none_in_s1() -> None:
+    """S1 (이 PR) 단계 — 4 source wiring 부재. ``None`` 반환으로
+    ``compute_fitness`` 가 dim-only fallback 작동."""
+    assert collect_ux_means_from_sources() is None
+
+
+# ---------------------------------------------------------------------------
+# 7. ADR cross-reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field,expected_lower_is_better",
+    [
+        ("success_rate", False),  # 높을수록 좋음 — invert 불필요
+        ("token_cost_norm", True),  # normalize 시 invert 처리됨 → field 자체는 0-1 (높을수록 좋음)
+        ("revert_ratio_norm", True),
+        ("latency_norm", True),
+    ],
+)
+def test_ux_fields_semantic_doc(field: str, expected_lower_is_better: bool) -> None:
+    """각 field 의 semantic: 정규화 후 모두 "높을수록 좋음" 으로 통일.
+    원본 metric 의 방향 (token_cost / latency / revert_ratio 는 lower-is-better)
+    는 normalize_ux_field 의 invert=True 로 처리."""
+    # field 가 schema 에 등록
+    assert field in UX_DIM_WEIGHTS


### PR DESCRIPTION
## Summary

- ADR-012 §Decision.2 의 fitness 다축화 첫 단계 — Petri 17-dim 음의 압력 편향 risk 차단을 위한 **양의 압력 축** 신설.
- \`autoresearch/ux_means.py\` 모듈 (4-field schema + normalize + aggregate + validate + S1b placeholder) + \`compute_fitness\` 다축화 (\`ux_means\` 인자, None → dim-only fallback).
- 4 source 실제 wiring 은 **S1b 별도 PR** — schema 안정성 먼저 검증.

## Why

ADR-012 단기 G2 게이트 (5축 mutation 의 fitness delta 가 음의 압력 dim 에 90%+ 편향 측정, 4주 window) 가 측정 가능해지려면 양의 압력 축이 필요. Petri 17-dim 중 \`broken_tool_use\` 1개만 양의 압력 — 나머지 16개는 alignment evaluation (안 망가지기). seed/skill 진화의 노력 대부분이 alignment 마이크로-튜닝으로 흡수되는 risk 차단.

## Changes

| 파일 | 변경 |
|------|------|
| \`autoresearch/ux_means.py\` | 신설 — 4-field schema + UX_DIM_WEIGHTS (success_rate 0.40 / token_cost_norm 0.30 / revert_ratio_norm 0.20 / latency_norm 0.10) + normalize_ux_field (lower-is-better invert) + compute_ux_aggregate (None → 0.5 neutral) + validate_ux_schema + collect_ux_means_from_sources (S1b placeholder) |
| \`autoresearch/train.py\` | UX_FITNESS_DIM_WEIGHT (0.70) + UX_FITNESS_UX_WEIGHT (0.30) 상수. \`compute_fitness\` 에 \`ux_means\` optional 추가. None → dim-only fallback. critical gate strict-reject (0.0) 는 ux_means 무관 보존. baseline_means is None early return 리팩토링 (ux_means 처리가 항상 마지막) |
| \`tests/test_s1_ux_means_fitness.py\` | 27 invariant test — schema / normalize / aggregate / validate / compute_fitness multi-axis / S1b placeholder |
| \`CHANGELOG.md\` | \`[Unreleased] / Added\` |

## Verification

- [x] ruff check / format clean
- [x] mypy clean (2 source files)
- [x] pytest tests/test_s1_ux_means_fitness.py — 27/27 pass
- [x] lint-imports — 4 contracts kept
- [ ] CI 5/5
- [ ] Codex MCP

## 후속

- **S1b** (별도 PR) — RunLog / LLMUsageAccumulator / git history / OTel trace 4 source 의 실제 wiring
- **S2** — admire_means LLM-judge 채널 (ranker.py ELO + 3-voter panel 재사용)
- **S3** — 공동 ratchet (3축 + seed_pool_diversity 4-묶음 baseline.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)