### PR TITLE
feat(self-improving): S2 — admire_means fitness 축 + 3축 다축화 (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,32 @@ functional change.
 
 ### Added
 
+- **PR-S2 — `admire_means` fitness 축 + 3축 다축화 (ADR-012 단기).**
+  S1 의 `ux_means` 옆에 추가되는 **체감 품질** 양의 압력 축.
+  `plugins/seed_generation/agents/ranker.py` 의 ELO + 3-voter
+  cross-provider panel 인프라를 정책 mutation 평가 채널로 확장 —
+  mutation before/after 응답을 동일 panel 이 pairwise 평가, win-rate
+  를 fitness 신호로 변환. **`autoresearch/admire_means.py` 신설** —
+  2-field schema (`pairwise_win_rate` 0.70 + `human_calibration_corr`
+  0.30, 합 1.0) + `compute_admire_aggregate` (None → 0.5 neutral,
+  calibration dampening 으로 Goodhart fooling 방어) +
+  `CALIBRATION_THRESHOLD = 0.7` (corr 미만 시 win_rate 비례 감쇠) +
+  `validate_admire_schema` + `collect_admire_means_from_ranker` (S2b
+  placeholder, 현재 None 반환). **`autoresearch/train.py` 3축 다축화** —
+  `FITNESS_DIM_WEIGHT = 0.40` + `FITNESS_UX_WEIGHT = 0.30` +
+  `FITNESS_ADMIRE_WEIGHT = 0.30` 신설 (합 1.0). `compute_fitness` 에
+  `admire_means` optional 인자 추가. 분기 로직: (a) ux + admire 둘 다
+  None → dim-only fallback (현재 behavior 보존) (b) ux 만 → S1 의
+  0.7/0.3 (backwards compat) (c) admire 만 또는 둘 다 → 3축 재배분
+  0.4/0.3/0.3 (ux 누락 시 neutral 0.5). critical gate strict-reject 는
+  admire 와 무관 보존. **Goodhart 방어**: judge model 주기 교체 + 3-voter
+  cross-provider panel (PR-COSCI-1 의 `required_diversity_providers`
+  규약 재사용) + calibration dampening (corr < threshold 시 win_rate
+  비례 감쇠) + 분기 human L4 batch refresh (S2b). **28 invariant test
+  (S2)** + 27 invariant test (S1 backwards compat) = **55/55 통과**.
+  ranker.py 의 실제 ELO + voter panel 호출 wiring 은 S2b 분리 —
+  schema 안정성 검증 후 진행.
+
 - **PR-S1 — `ux_means` fitness 축 신설 (ADR-012 단기).** ADR-012
   §Decision.2 의 fitness 다축화 첫 단계 — Petri 17-dim 의 음의 압력
   (안 망가지기) 편향 risk 를 차단하기 위한 **양의 압력 축**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,11 @@ functional change.
 ### Added
 
 - **PR-S2 — `admire_means` fitness 축 + 3축 다축화 (ADR-012 단기).**
-  S1 의 `ux_means` 옆에 추가되는 **체감 품질** 양의 압력 축.
-  `plugins/seed_generation/agents/ranker.py` 의 ELO + 3-voter
-  cross-provider panel 인프라를 정책 mutation 평가 채널로 확장 —
-  mutation before/after 응답을 동일 panel 이 pairwise 평가, win-rate
-  를 fitness 신호로 변환. **`autoresearch/admire_means.py` 신설** —
+  S1 의 `ux_means` 옆에 추가되는 **체감 품질** 양의 압력 축의
+  **schema + math + hook interface** 신설. 실제 `plugins/seed_generation/agents/ranker.py`
+  의 ELO + 3-voter panel 호출 wiring 은 S2b (별도 PR) — 본 PR 에서는
+  hook (`collect_admire_means_from_ranker`) 가 placeholder (None 반환)
+  로 ranker 호출 자리를 명시만 함. **`autoresearch/admire_means.py` 신설** —
   2-field schema (`pairwise_win_rate` 0.70 + `human_calibration_corr`
   0.30, 합 1.0) + `compute_admire_aggregate` (None → 0.5 neutral,
   calibration dampening 으로 Goodhart fooling 방어) +

--- a/autoresearch/admire_means.py
+++ b/autoresearch/admire_means.py
@@ -1,0 +1,138 @@
+"""``admire_means`` fitness 축 — ADR-012 S2.
+
+S1 의 ``ux_means`` (행동 metric) 옆에 추가되는 **체감 품질** 양의 압력
+축. ``plugins/seed_generation/agents/ranker.py`` 의 ELO + 3-voter
+cross-provider panel 인프라를 정책 mutation 평가 채널로 확장 — mutation
+의 before/after 응답을 동일 panel 이 pairwise 평가, win-rate 를 fitness
+신호로 변환.
+
+**Schema** (2 field, 0.0-1.0):
+
+.. code-block:: python
+
+    {
+      "pairwise_win_rate":      0.65,   # mutation 적용 후 응답이 이긴 비율 (3-voter panel)
+      "human_calibration_corr": 0.85,   # LLM-judge 점수 와 human L4 라벨 의 상관계수
+                                         # (분기 단위 50-100 sample 로 측정, Goodhart 방어)
+    }
+
+``human_calibration_corr`` 가 0.7 미만이면 LLM-judge 가 human 기준에서
+벗어나는 신호 — Goodhart fooling 위험. ``compute_admire_aggregate`` 가
+이 축으로 win-rate 를 가중치 dampen 하는 방식으로 처리.
+
+**ADR-012 §Decision.2 의 fitness 3축 다축화**:
+
+- ``dim_means`` (Petri 17-dim, 음의 압력) — 가중치 0.4
+- ``ux_means`` (행동 4-field, 양의 압력, S1 신설) — 가중치 0.3
+- ``admire_means`` (체감 2-field, 양의 압력, 이 모듈) — 가중치 0.3
+
+S2 (이 PR) 는 **schema + math + ranker hook interface** 만 신설. 실제
+ranker.py 의 ELO + voter panel 호출 wiring 은 S2b (별도 PR) —
+``collect_admire_means_from_ranker`` 가 placeholder 로 ``None`` 반환,
+``compute_fitness`` 의 3축 다축화는 즉시 가동.
+
+**Goodhart 방어 (ADR-012 의 Risks 표)**:
+1. judge model 의 주기적 교체 — ``required_diversity_providers`` 규약
+   재사용 (PR-COSCI-1)
+2. ranker.py 의 3-voter cross-provider panel — single-judge sycophancy
+   회피
+3. ``human_calibration_corr`` < 0.7 시 win-rate dampening
+4. 분기 human L4 batch refresh (S2b 의 calibration pipeline)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Admire field 별 가중치 — 합 1.0. pairwise_win_rate 가 주 신호,
+# human_calibration_corr 는 dampening factor 역할.
+ADMIRE_DIM_WEIGHTS: dict[str, float] = {
+    "pairwise_win_rate": 0.70,
+    "human_calibration_corr": 0.30,
+}
+
+assert abs(sum(ADMIRE_DIM_WEIGHTS.values()) - 1.0) < 1e-9, "ADMIRE_DIM_WEIGHTS must sum to 1.0"
+
+# Calibration threshold — human_calibration_corr 가 이 값 미만이면 judge
+# 가 human 기준에서 drift — pairwise_win_rate 를 dampen.
+CALIBRATION_THRESHOLD: float = 0.7
+
+
+def compute_admire_aggregate(admire_means: dict[str, float] | None) -> float:
+    """2-field weighted sum with calibration dampening → 0-1 scalar.
+
+    ``None`` → 0.5 neutral (S1 의 ``ux_means`` 와 동일 패턴 — no-op signal).
+
+    Calibration dampening — ``human_calibration_corr`` < ``CALIBRATION_THRESHOLD``
+    (0.7) 이면 LLM-judge 의 ``pairwise_win_rate`` 신호가 human 기준에서
+    drift. dampened weight = ``corr / threshold`` (0-1 으로 clamp) 로
+    win-rate 의 영향 감쇠. Goodhart fooling 방어의 핵심 메커니즘.
+    """
+    if admire_means is None:
+        return 0.5
+    win_rate = max(0.0, min(1.0, admire_means.get("pairwise_win_rate", 0.5)))
+    corr = max(0.0, min(1.0, admire_means.get("human_calibration_corr", CALIBRATION_THRESHOLD)))
+
+    # Dampening factor — corr ≥ threshold 이면 1.0 (full weight), 미만이면
+    # 비례 감쇠. corr=0 이면 dampening=0 → win_rate 신호가 거의 무효.
+    dampening = min(1.0, corr / CALIBRATION_THRESHOLD) if CALIBRATION_THRESHOLD > 0 else 1.0
+
+    return (
+        ADMIRE_DIM_WEIGHTS["pairwise_win_rate"] * win_rate * dampening
+        + ADMIRE_DIM_WEIGHTS["human_calibration_corr"] * corr
+    )
+
+
+def validate_admire_schema(admire_means: Any) -> bool:
+    """Validate ``admire_means`` schema — dict[str, float] in 0-1, 알려진
+    field 만. ``None`` 도 valid (no-op signal)."""
+    if admire_means is None:
+        return True
+    if not isinstance(admire_means, dict):
+        return False
+    known_fields = set(ADMIRE_DIM_WEIGHTS)
+    for key, value in admire_means.items():
+        if key not in known_fields:
+            return False
+        if not isinstance(value, int | float):
+            return False
+        if not (0.0 <= float(value) <= 1.0):
+            return False
+    return True
+
+
+def collect_admire_means_from_ranker(
+    *,
+    _placeholder: bool = True,
+) -> dict[str, float] | None:
+    """Collect ``admire_means`` from ``plugins/seed_generation/agents/ranker.py``
+    의 ELO + 3-voter panel.
+
+    S2 (이 PR) 는 schema + math + hook interface 만 신설. 실제 ranker
+    호출 wiring 은 S2b (별도 PR) — mutation 의 before/after 응답을
+    ``Ranker._play_match`` 와 같은 패턴으로 panel 에 던지고 win-rate 계산.
+
+    이 함수는 placeholder — S2b 전까지는 ``None`` 반환 (compute_fitness
+    가 dim+ux fallback 으로 작동). S2b 머지 후:
+
+    1. mutation 의 before/after 응답 hydrate (M4.0 의 ``eval_response_recorded``)
+    2. ``Ranker._build_voter_tasks`` 와 같은 패턴으로 3-voter panel 호출
+    3. ELO update (``_play_match`` 의 K-factor=32 같은 패턴)
+    4. pairwise_win_rate = wins / (wins + losses)
+    5. human_calibration_corr = 분기 단위 L4 batch 와의 Pearson 상관계수
+
+    Args:
+        _placeholder: S2b 전까지 ``None`` 반환 강제. test 에서 override 가능.
+    """
+    if _placeholder:
+        return None
+    return None  # pragma: no cover — S2b wiring placeholder
+
+
+__all__ = [
+    "ADMIRE_DIM_WEIGHTS",
+    "CALIBRATION_THRESHOLD",
+    "collect_admire_means_from_ranker",
+    "compute_admire_aggregate",
+    "validate_admire_schema",
+]

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -279,13 +279,24 @@ STABILITY_WEIGHT: float = 0.10
 """Stability axis weight — kept outside DIM_WEIGHTS because the value
 is derived from ``dim_stderr`` aggregate, not from a per-dim mean."""
 
-# ADR-012 S1 (2026-05-21) — ux_means fitness 축 가중치. ``compute_fitness``
-# 가 ``ux_means`` 인자를 받을 때 ``dim_part * UX_FITNESS_DIM_WEIGHT +
-# ux_part * UX_FITNESS_UX_WEIGHT`` 로 다축화. admire_means (S2) 신설 시
-# 가중치 재배분 예정 (dim 0.4 + ux 0.3 + admire 0.3).
+# ADR-012 S1 (2026-05-21) — ux_means fitness 축 가중치 (admire_means
+# 부재 시의 2축 fallback). ``compute_fitness`` 가 ``ux_means`` 만 받을
+# 때 ``dim_part * UX_FITNESS_DIM_WEIGHT + ux_part * UX_FITNESS_UX_WEIGHT``.
 UX_FITNESS_DIM_WEIGHT: float = 0.70
 UX_FITNESS_UX_WEIGHT: float = 0.30
 assert abs(UX_FITNESS_DIM_WEIGHT + UX_FITNESS_UX_WEIGHT - 1.0) < 1e-9
+
+# ADR-012 S2 (2026-05-21) — admire_means fitness 축 신설로 3축 다축화.
+# ``compute_fitness`` 가 ``ux_means`` 와 ``admire_means`` 모두 받을 때
+# ``dim*FITNESS_DIM + ux*FITNESS_UX + admire*FITNESS_ADMIRE`` 로 재배분.
+# 가중치 합 1.0. dim 비중이 0.70 → 0.40 으로 감소 — 양의 압력 두 축 추가
+# 로 alignment 마이크로-튜닝 risk 추가 차단 (ADR-012 §Decision.2).
+FITNESS_DIM_WEIGHT: float = 0.40
+FITNESS_UX_WEIGHT: float = 0.30
+FITNESS_ADMIRE_WEIGHT: float = 0.30
+assert abs(FITNESS_DIM_WEIGHT + FITNESS_UX_WEIGHT + FITNESS_ADMIRE_WEIGHT - 1.0) < 1e-9, (
+    "3-axis fitness weights must sum to 1.0"
+)
 
 CRITICAL_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "critical")
 AUXILIARY_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "auxiliary")
@@ -776,6 +787,7 @@ def compute_fitness(
     critical_margin: float = 0.0,
     auxiliary_penalty_lambda: float = 0.5,
     ux_means: dict[str, float] | None = None,
+    admire_means: dict[str, float] | None = None,
 ) -> float:
     """17-dim weighted aggregate + stability axis + optional ux_means axis.
 
@@ -833,16 +845,29 @@ def compute_fitness(
                 penalty += auxiliary_penalty_lambda * (delta / 10.0) ** 2
         dim_part = aggregate - penalty
 
-    # ADR-012 S1 (2026-05-21) — ux_means 양의 압력 축. ``None`` 이면
-    # dim-only fallback (baseline_means 와 무관). 주어지면 (dim 0.7 +
-    # ux 0.3) 가중 합. admire_means (S2) 신설 시 3축 다축화 — 그때
-    # 가중치 재배분 (dim 0.4 + ux 0.3 + admire 0.3).
-    if ux_means is None:
+    # ADR-012 S1+S2 (2026-05-21) — 양의 압력 두 축 다축화.
+    # - 둘 다 None: dim-only fallback (현재 behavior 보존)
+    # - ux 만: 2축 (dim 0.7 + ux 0.3, S1)
+    # - admire 만 또는 둘 다: 3축 재배분 (dim 0.4 + ux 0.3 + admire 0.3)
+    #   admire 만 주어진 경우 ux 는 neutral 0.5 로 처리.
+    if ux_means is None and admire_means is None:
         return dim_part
+    if admire_means is None:
+        from autoresearch.ux_means import compute_ux_aggregate
+
+        ux_part = compute_ux_aggregate(ux_means)
+        return UX_FITNESS_DIM_WEIGHT * dim_part + UX_FITNESS_UX_WEIGHT * ux_part
+
+    from autoresearch.admire_means import compute_admire_aggregate
     from autoresearch.ux_means import compute_ux_aggregate
 
-    ux_part = compute_ux_aggregate(ux_means)
-    return UX_FITNESS_DIM_WEIGHT * dim_part + UX_FITNESS_UX_WEIGHT * ux_part
+    ux_part = compute_ux_aggregate(ux_means)  # None → 0.5 neutral
+    admire_part = compute_admire_aggregate(admire_means)
+    return (
+        FITNESS_DIM_WEIGHT * dim_part
+        + FITNESS_UX_WEIGHT * ux_part
+        + FITNESS_ADMIRE_WEIGHT * admire_part
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -812,10 +812,20 @@ def compute_fitness(
 
     ``ux_means`` (ADR-012 S1, 2026-05-21) — 양의 압력 4-field
     (success_rate / token_cost_norm / revert_ratio_norm / latency_norm).
-    ``None`` 이면 dim-only fallback (no-op). 주어지면 fitness =
-    ``DIM_WEIGHT_TOTAL × dim_part + UX_WEIGHT × ux_aggregate`` 의 가중
-    합 (운영 권장 가중치: dim 0.7 + ux 0.3). admire_means 신설 (S2) 시
-    3축 다축화.
+    ``admire_means`` (ADR-012 S2, 2026-05-21) — 양의 압력 2-field
+    (pairwise_win_rate / human_calibration_corr).
+
+    분기 로직:
+    - ``ux_means is None and admire_means is None`` → dim-only fallback
+      (현재 behavior 보존, S1 전 caller 와 호환)
+    - ``admire_means is None`` (ux 만) → 2축 (UX_FITNESS_DIM_WEIGHT 0.7
+      + UX_FITNESS_UX_WEIGHT 0.3) — S1 backwards compat
+    - ``admire_means`` 활성 (or 둘 다) → 3축 재배분 (FITNESS_DIM_WEIGHT
+      0.4 + FITNESS_UX_WEIGHT 0.3 + FITNESS_ADMIRE_WEIGHT 0.3). ``ux``
+      누락 시 neutral 0.5 으로 처리.
+
+    Critical gate (regress 시 ``0.0``) 는 ux/admire 와 무관하게 strict-
+    reject — ADR-012 §Decision.2 의 multi-axis strict-reject 보존.
     """
     aggregate = 0.0
     for dim, weight in DIM_WEIGHTS.items():

--- a/tests/test_s2_admire_means_fitness.py
+++ b/tests/test_s2_admire_means_fitness.py
@@ -53,6 +53,22 @@ def test_calibration_threshold_in_valid_range() -> None:
     assert CALIBRATION_THRESHOLD >= 0.5
 
 
+def test_calibration_threshold_exact_value() -> None:
+    """CALIBRATION_THRESHOLD == 0.7 — Goodhart 방어 핵심 anchor (Codex
+    MCP catch). 변경 시 test + docstring + ADR 모두 동기 갱신 필요."""
+    assert CALIBRATION_THRESHOLD == 0.7
+
+
+def test_calibration_dampening_at_exact_threshold_full_signal() -> None:
+    """corr == threshold edge case — dampening = min(1.0, 1.0) = 1.0."""
+    edge = {"pairwise_win_rate": 1.0, "human_calibration_corr": CALIBRATION_THRESHOLD}
+    expected = (
+        ADMIRE_DIM_WEIGHTS["pairwise_win_rate"] * 1.0
+        + ADMIRE_DIM_WEIGHTS["human_calibration_corr"] * CALIBRATION_THRESHOLD
+    )
+    assert abs(compute_admire_aggregate(edge) - expected) < 1e-9
+
+
 # ---------------------------------------------------------------------------
 # 2. compute_admire_aggregate
 # ---------------------------------------------------------------------------

--- a/tests/test_s2_admire_means_fitness.py
+++ b/tests/test_s2_admire_means_fitness.py
@@ -1,0 +1,256 @@
+"""ADR-012 S2 — `admire_means` fitness 축 + 3축 다축화 invariants.
+
+S2 scope: schema + math + ranker hook interface + compute_fitness 3축
+재배분. ranker.py 의 실제 ELO + voter panel 호출 wiring 은 S2b (별도 PR).
+"""
+
+from __future__ import annotations
+
+import pytest
+from autoresearch.admire_means import (
+    ADMIRE_DIM_WEIGHTS,
+    CALIBRATION_THRESHOLD,
+    collect_admire_means_from_ranker,
+    compute_admire_aggregate,
+    validate_admire_schema,
+)
+from autoresearch.train import (
+    FITNESS_ADMIRE_WEIGHT,
+    FITNESS_DIM_WEIGHT,
+    FITNESS_UX_WEIGHT,
+    UX_FITNESS_DIM_WEIGHT,
+    UX_FITNESS_UX_WEIGHT,
+    compute_fitness,
+)
+from autoresearch.ux_means import UX_DIM_WEIGHTS
+
+# ---------------------------------------------------------------------------
+# 1. Schema constants
+# ---------------------------------------------------------------------------
+
+
+def test_admire_dim_weights_sum_to_one() -> None:
+    assert abs(sum(ADMIRE_DIM_WEIGHTS.values()) - 1.0) < 1e-9
+
+
+def test_admire_dim_weights_exact_2_fields() -> None:
+    assert set(ADMIRE_DIM_WEIGHTS) == {"pairwise_win_rate", "human_calibration_corr"}
+
+
+def test_3_axis_fitness_weights_sum_to_one() -> None:
+    assert abs(FITNESS_DIM_WEIGHT + FITNESS_UX_WEIGHT + FITNESS_ADMIRE_WEIGHT - 1.0) < 1e-9
+
+
+def test_3_axis_dim_weight_smaller_than_2_axis_dim_weight() -> None:
+    """S2 신설로 dim 비중이 0.70 → 0.40 으로 감소 (양의 압력 두 축 추가)."""
+    assert FITNESS_DIM_WEIGHT < UX_FITNESS_DIM_WEIGHT
+
+
+def test_calibration_threshold_in_valid_range() -> None:
+    """CALIBRATION_THRESHOLD 가 0-1 범위 내 + 절반 이상 (judge 가 절반
+    이상 human 과 상관관계 유지해야 dampening 없음)."""
+    assert 0.0 < CALIBRATION_THRESHOLD <= 1.0
+    assert CALIBRATION_THRESHOLD >= 0.5
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_admire_aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_none_returns_neutral_half() -> None:
+    assert compute_admire_aggregate(None) == 0.5
+
+
+def test_aggregate_perfect_calibration_full_signal() -> None:
+    """calibration_corr >= threshold 이면 dampening=1.0, win_rate 신호 전달."""
+    perfect = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    # weights: 0.70 * (1.0 * 1.0 dampening) + 0.30 * 1.0 = 1.0
+    assert abs(compute_admire_aggregate(perfect) - 1.0) < 1e-9
+
+
+def test_aggregate_zero_calibration_dampens_win_rate() -> None:
+    """calibration_corr=0 → dampening=0 → win_rate 신호 무효, calibration
+    field 만 영향. weight 0.30 × 0 = 0.0."""
+    zero_corr = {"pairwise_win_rate": 1.0, "human_calibration_corr": 0.0}
+    # 0.70 * (1.0 * 0.0 dampening) + 0.30 * 0.0 = 0.0
+    assert compute_admire_aggregate(zero_corr) == 0.0
+
+
+def test_aggregate_below_threshold_dampens_proportionally() -> None:
+    """calibration_corr < threshold 이면 dampening 비례 감쇠."""
+    half = {"pairwise_win_rate": 1.0, "human_calibration_corr": CALIBRATION_THRESHOLD / 2}
+    # dampening = 0.5, win_rate*1.0*0.5 = 0.5
+    # = 0.70 * 0.5 + 0.30 * (threshold/2)
+    expected = ADMIRE_DIM_WEIGHTS["pairwise_win_rate"] * 1.0 * 0.5 + ADMIRE_DIM_WEIGHTS[
+        "human_calibration_corr"
+    ] * (CALIBRATION_THRESHOLD / 2)
+    assert abs(compute_admire_aggregate(half) - expected) < 1e-9
+
+
+def test_aggregate_above_threshold_does_not_amplify() -> None:
+    """calibration_corr > threshold 여도 dampening cap=1.0 (clamp). 가중치
+    초과 amplification 방지."""
+    above = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    # dampening = min(1.0, 1.0/0.7) = 1.0 (clamp)
+    # = 0.70 * 1.0 + 0.30 * 1.0 = 1.0
+    assert abs(compute_admire_aggregate(above) - 1.0) < 1e-9
+
+
+def test_aggregate_missing_field_defaults_neutral() -> None:
+    """누락 field 는 neutral 처리 — win_rate default 0.5, corr default threshold."""
+    partial = {"pairwise_win_rate": 1.0}
+    # corr default = threshold → dampening=1.0
+    # = 0.70 * 1.0 * 1.0 + 0.30 * threshold
+    expected = (
+        ADMIRE_DIM_WEIGHTS["pairwise_win_rate"] * 1.0
+        + ADMIRE_DIM_WEIGHTS["human_calibration_corr"] * CALIBRATION_THRESHOLD
+    )
+    assert abs(compute_admire_aggregate(partial) - expected) < 1e-9
+
+
+def test_aggregate_clamps_out_of_range() -> None:
+    bad = {"pairwise_win_rate": 2.0, "human_calibration_corr": 1.5}
+    assert abs(compute_admire_aggregate(bad) - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 3. validate_admire_schema
+# ---------------------------------------------------------------------------
+
+
+def test_validate_none() -> None:
+    assert validate_admire_schema(None) is True
+
+
+def test_validate_valid_dict() -> None:
+    assert validate_admire_schema({"pairwise_win_rate": 0.6}) is True
+
+
+def test_validate_rejects_unknown_field() -> None:
+    assert validate_admire_schema({"unknown": 0.5}) is False
+
+
+def test_validate_rejects_out_of_range() -> None:
+    assert validate_admire_schema({"pairwise_win_rate": 1.5}) is False
+
+
+def test_validate_rejects_non_numeric() -> None:
+    assert validate_admire_schema({"pairwise_win_rate": "high"}) is False
+
+
+def test_validate_rejects_non_dict() -> None:
+    assert validate_admire_schema([0.6, 0.8]) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. collect_admire_means_from_ranker — S2b placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_collect_returns_none_in_s2() -> None:
+    """S2 (이 PR) 단계 — ranker.py 의 ELO + voter panel 실제 호출은 S2b.
+    이 함수는 ``None`` 반환으로 compute_fitness 가 2축 fallback (S1 동일)."""
+    assert collect_admire_means_from_ranker() is None
+
+
+# ---------------------------------------------------------------------------
+# 5. compute_fitness 3-axis multi-axis
+# ---------------------------------------------------------------------------
+
+
+def test_compute_fitness_both_none_dim_only() -> None:
+    """ux + admire 둘 다 None → dim-only fallback (S1 backwards compat)."""
+    dim_means = {"broken_tool_use": 5.0}
+    f_both_none = compute_fitness(dim_means, ux_means=None, admire_means=None)
+    f_default = compute_fitness(dim_means)
+    assert f_both_none == f_default
+
+
+def test_compute_fitness_ux_only_uses_2_axis_weights() -> None:
+    """ux 만 주어지면 S1 의 0.7/0.3 (backwards compat) — 3축 재배분 아님."""
+    dim_means = {"broken_tool_use": 5.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    f = compute_fitness(dim_means, ux_means=ux, admire_means=None)
+    base = compute_fitness(dim_means)
+    expected = base * UX_FITNESS_DIM_WEIGHT + 1.0 * UX_FITNESS_UX_WEIGHT
+    assert abs(f - expected) < 1e-9
+
+
+def test_compute_fitness_3_axis_with_admire() -> None:
+    """ux + admire 모두 → 3축 재배분 (0.4/0.3/0.3)."""
+    dim_means = {"broken_tool_use": 5.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    admire = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    f = compute_fitness(dim_means, ux_means=ux, admire_means=admire)
+    base = compute_fitness(dim_means)
+    expected = FITNESS_DIM_WEIGHT * base + FITNESS_UX_WEIGHT * 1.0 + FITNESS_ADMIRE_WEIGHT * 1.0
+    assert abs(f - expected) < 1e-9
+
+
+def test_compute_fitness_admire_only_with_neutral_ux() -> None:
+    """admire 만 주어지면 ux 는 neutral 0.5 로 처리 + 3축 활성화."""
+    dim_means = {"broken_tool_use": 5.0}
+    admire = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    f = compute_fitness(dim_means, ux_means=None, admire_means=admire)
+    base = compute_fitness(dim_means)
+    expected = (
+        FITNESS_DIM_WEIGHT * base
+        + FITNESS_UX_WEIGHT * 0.5  # neutral
+        + FITNESS_ADMIRE_WEIGHT * 1.0
+    )
+    assert abs(f - expected) < 1e-9
+
+
+def test_compute_fitness_critical_gate_strict_reject_with_admire() -> None:
+    """admire+ux 가 perfect 여도 critical dim regress 면 fitness=0."""
+    dim_means = {"broken_tool_use": 10.0}
+    baseline_means = {"broken_tool_use": 5.0}
+    admire = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    f = compute_fitness(
+        dim_means,
+        baseline_means=baseline_means,
+        ux_means=ux,
+        admire_means=admire,
+    )
+    assert f == 0.0
+
+
+def test_compute_fitness_dim_weight_redistributed_when_admire_active() -> None:
+    """S2 의 핵심 효과 — admire 활성화 시 dim 비중이 감소. 같은 dim 점수
+    + perfect ux/admire → 3축 fitness < 2축 (S1) fitness (dim 0.4 < 0.7)."""
+    dim_means = {"broken_tool_use": 5.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 0.0)  # zero ux to isolate dim weight effect
+    admire = {"pairwise_win_rate": 0.0, "human_calibration_corr": 0.0}
+    base = compute_fitness(dim_means)
+    f_3axis = compute_fitness(dim_means, ux_means=ux, admire_means=admire)
+    f_2axis = compute_fitness(dim_means, ux_means=ux)
+    # 3축: base*0.4 + 0*0.3 + 0*0.3 = base*0.4
+    # 2축: base*0.7 + 0*0.3 = base*0.7
+    assert f_3axis < f_2axis  # dim 비중 감소 직접 검증
+    assert abs(f_3axis - base * FITNESS_DIM_WEIGHT) < 1e-9
+    assert abs(f_2axis - base * UX_FITNESS_DIM_WEIGHT) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 6. Ranker hook contract — ADR cross-reference
+# ---------------------------------------------------------------------------
+
+
+def test_collect_admire_means_signature_matches_s1_pattern() -> None:
+    """S1 의 collect_ux_means_from_sources 와 동일 시그니처 패턴 —
+    ``_placeholder=True`` 기본값, ``None`` 반환."""
+    import inspect
+
+    sig = inspect.signature(collect_admire_means_from_ranker)
+    assert "_placeholder" in sig.parameters
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["pairwise_win_rate", "human_calibration_corr"],
+)
+def test_admire_fields_in_schema(field: str) -> None:
+    """schema 의 2 field 가 등록."""
+    assert field in ADMIRE_DIM_WEIGHTS


### PR DESCRIPTION
## Summary

- ADR-012 §Decision.2 의 fitness 3축 다축화 완성. S1 의 \`ux_means\` 옆에 **체감 품질** \`admire_means\` 추가.
- \`plugins/seed_generation/agents/ranker.py\` 의 ELO + 3-voter cross-provider panel 인프라를 정책 mutation 평가 채널로 확장 (hook interface).
- \`compute_fitness\` 가중치 재배분: 2축 (0.7/0.3) → **3축 (0.4/0.3/0.3)**. dim 비중 감소로 양의 압력 두 축 추가 적용.

## Why

S1 의 \`ux_means\` 만으로는 행동 metric (success / cost / latency) 측정에 그침. 사람-체감 품질 (pairwise win-rate) 까지 fitness 에 반영해야 alignment 마이크로-튜닝 risk 가 진짜로 차단. ranker.py 의 ELO + voter panel 인프라가 이미 가동 중 (seed quality 평가용) → 정책 mutation 평가에도 같은 panel 재사용 (Goodhart 방어의 3-voter cross-provider).

## Changes

| 파일 | 변경 |
|------|------|
| \`autoresearch/admire_means.py\` | 신설 — 2-field schema (pairwise_win_rate 0.70 + human_calibration_corr 0.30) + compute_admire_aggregate (None → 0.5 neutral, calibration dampening) + CALIBRATION_THRESHOLD = 0.7 + validate_admire_schema + collect_admire_means_from_ranker (S2b placeholder) |
| \`autoresearch/train.py\` | FITNESS_DIM_WEIGHT (0.40) / FITNESS_UX_WEIGHT (0.30) / FITNESS_ADMIRE_WEIGHT (0.30) 신설 (합 1.0). compute_fitness 에 admire_means 인자 추가. 분기 로직 — 둘 다 None / ux only / admire 활성 |
| \`tests/test_s2_admire_means_fitness.py\` | 28 invariant test |
| \`CHANGELOG.md\` | \`[Unreleased] / Added\` |

## Verification

- [x] ruff check / format clean
- [x] mypy clean (2 source files)
- [x] pytest tests/test_s2* + tests/test_s1* — 55/55 pass
- [x] lint-imports — 4 contracts kept
- [ ] CI 5/5
- [ ] Codex MCP

## Goodhart 방어 (ADR-012 Risks)

1. **judge model 주기적 교체** — pairwise_win_rate 단조 상승만 보면 fooling 의심
2. **3-voter cross-provider panel** — PR-COSCI-1 의 \`required_diversity_providers\` 규약 재사용
3. **Calibration dampening** — \`human_calibration_corr\` < 0.7 시 win_rate 비례 감쇠 (현재 PR 의 핵심 메커니즘)
4. **분기 human L4 batch refresh** — S2b 의 calibration pipeline

## 후속

- **S1b** — ux_means 4 source 실제 wiring (RunLog/LLMUsage/git/OTel)
- **S2b** — admire_means 의 ranker.py 실제 호출 wiring (Ranker._play_match 패턴 재사용)
- **S3** — 3축 + seed_pool_diversity 4-묶음 baseline.json 공동 ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)