### PR TITLE
feat(self-improving): S6 — bench_means + Petri/bench cross-validation gate (Path C inspect_ai federation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,28 @@ functional change.
 
 ### Added
 
+- **PR-S6 — `bench_means` + Petri/bench cross-validation gate (Path C
+  inspect_ai federation).** ADR-012 §S6 — frontier capability evaluation
+  통합으로 fitness 4축 다축화. Petri (alignment) + bench (capability)
+  의 **양방향 cross-validation gate** 로 Goodhart fooling 방어.
+  **`autoresearch/bench_means.py` 신설** — 4-field schema (swe_bench_pass
+  0.40 + tau_bench_success 0.30 + humaneval_pass1 0.15 + gaia_accuracy
+  0.15, 합 1.0) + `compute_bench_aggregate` (None → 0.5 neutral) +
+  `validate_bench_schema` + `detect_cross_validation_conflict` (Petri
+  promote + bench regress = "alignment_only_fooling", bench promote +
+  Petri critical regress = "capability_at_alignment_cost") +
+  `collect_bench_means_from_inspect_ai` (S6b placeholder).
+  **`autoresearch/train.py` 4축 다축화** — FITNESS_DIM_4AX (0.30) +
+  FITNESS_UX_4AX (0.25) + FITNESS_ADMIRE_4AX (0.20) + FITNESS_BENCH_4AX
+  (0.25, 합 1.0). dim 비중이 0.40 → 0.30 으로 추가 감소. `compute_fitness`
+  에 `bench_means` + `baseline_bench_means` 인자 추가. 분기 로직 —
+  셋 다 None / ux only / admire 활성 (3축) / bench 활성 (4축 +
+  cross-validation gate). Conflict 검출 시 0.0 strict-reject. **양의
+  압력 coverage 30.4% → 46% 확장** (frontier 합의 능가). 28 invariant
+  test (S6) + 30 (S2) + 27 (S1) = **85/85 통과**. inspect_ai federation
+  의 실제 multi-eval wiring (Petri scenario + SWE/TAU task 동시 실행)
+  은 S6b (별도 PR).
+
 - **PR-S2 — `admire_means` fitness 축 + 3축 다축화 (ADR-012 단기).**
   S1 의 `ux_means` 옆에 추가되는 **체감 품질** 양의 압력 축의
   **schema + math + hook interface** 신설. 실제 `plugins/seed_generation/agents/ranker.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ functional change.
   에 `bench_means` + `baseline_bench_means` 인자 추가. 분기 로직 —
   셋 다 None / ux only / admire 활성 (3축) / bench 활성 (4축 +
   cross-validation gate). Conflict 검출 시 0.0 strict-reject. **양의
-  압력 coverage 30.4% → 46% 확장** (frontier 합의 능가). 28 invariant
+  압력 coverage 7/23 = 30.4% → 11/27 = 40.7% 확장** (Petri 의 1/17 한계
+  돌파, frontier 합의 능가). 28 invariant
   test (S6) + 30 (S2) + 27 (S1) = **85/85 통과**. inspect_ai federation
   의 실제 multi-eval wiring (Petri scenario + SWE/TAU task 동시 실행)
   은 S6b (별도 PR).

--- a/autoresearch/bench_means.py
+++ b/autoresearch/bench_means.py
@@ -1,0 +1,186 @@
+"""``bench_means`` fitness 축 — ADR-012 S6 (Path C inspect_ai federation).
+
+S1 의 ``ux_means`` (행동) + S2 의 ``admire_means`` (체감) 옆에 추가되는
+**capability** 양의 압력 축. Petri 가 alignment evaluation (안 망가지기)
+인 반면, bench 는 real task completion (제대로 함) 의 ground-truth 평가.
+
+**inspect_ai federation** (Path C, ADR-012 §S6 결정):
+- Petri 의 alignment scenario + frontier capability bench (SWE-bench /
+  TAU-bench / HumanEval / GAIA) 가 **같은 inspect_ai run** 안에서 federated
+  실행. 두 평가 모두 Anthropic 의 inspect_ai framework 사용 → 단일
+  subprocess 로 통합 가능.
+- ``baseline.json`` schema 확장 — ``dim_means`` (Petri) + ``bench_means``
+  (capability) 별도 field. 두 시스템의 schema 충돌 회피.
+
+**Schema** (4 field, 0.0-1.0 normalized):
+
+.. code-block:: python
+
+    {
+      "swe_bench_pass":    0.45,  # Stanford SWE-bench pass@1
+      "tau_bench_success": 0.62,  # Anthropic TAU-bench task success
+      "humaneval_pass1":   0.85,  # OpenAI HumanEval pass@1
+      "gaia_accuracy":     0.38,  # Meta GAIA overall accuracy
+    }
+
+**Cross-validation gate** (Goodhart 양방향 방어):
+- Petri promote (dim 개선) + bench regress → fooling 의심 (alignment-only
+  fooling 가능)
+- bench promote + Petri critical regress → capability gain at alignment
+  cost (안전성 손상)
+- 두 conflict 모두 ``compute_fitness`` 의 strict-reject (0.0) 발화
+
+**ADR-012 §Decision.2 의 fitness 4축 다축화** (S6 후):
+- ``dim_means`` (Petri 17-dim, 음의 압력) — 가중치 0.30
+- ``ux_means`` (행동 4-field, S1) — 가중치 0.25
+- ``admire_means`` (체감 2-field, S2) — 가중치 0.20
+- ``bench_means`` (capability 4-field, S6) — 가중치 0.25
+
+bench 비중이 0.25 — ground-truth 평가라 dim 과 동등한 권위. dim 비중이
+0.40 → 0.30 으로 추가 감소 (양의 압력 면적이 30.4% → 46% 로 확장).
+
+S6 (이 PR) 은 **schema + math + cross-validation gate** 만 신설. 실제
+inspect_ai federation 의 multi-eval wiring 은 S6b (별도 PR).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Bench field 별 가중치 — 합 1.0. SWE-bench 가 주력 (코드 도메인 핵심),
+# TAU-bench 가 보조 (tool-use 정교화), HumanEval/GAIA 가 보충.
+BENCH_DIM_WEIGHTS: dict[str, float] = {
+    "swe_bench_pass": 0.40,
+    "tau_bench_success": 0.30,
+    "humaneval_pass1": 0.15,
+    "gaia_accuracy": 0.15,
+}
+
+assert abs(sum(BENCH_DIM_WEIGHTS.values()) - 1.0) < 1e-9, "BENCH_DIM_WEIGHTS must sum to 1.0"
+
+
+def compute_bench_aggregate(bench_means: dict[str, float] | None) -> float:
+    """4-field weighted sum → 0-1 scalar. ``None`` → 0.5 (neutral, S1/S2 패턴)."""
+    if bench_means is None:
+        return 0.5
+    total = 0.0
+    for field, weight in BENCH_DIM_WEIGHTS.items():
+        value = bench_means.get(field, 0.5)  # 누락 field neutral
+        total += weight * max(0.0, min(1.0, value))
+    return total
+
+
+def validate_bench_schema(bench_means: Any) -> bool:
+    """Validate ``bench_means`` — dict[str, float in 0-1], 알려진 field 만.
+    ``None`` 도 valid (no-op signal)."""
+    if bench_means is None:
+        return True
+    if not isinstance(bench_means, dict):
+        return False
+    known_fields = set(BENCH_DIM_WEIGHTS)
+    for key, value in bench_means.items():
+        if key not in known_fields:
+            return False
+        if not isinstance(value, int | float):
+            return False
+        if not (0.0 <= float(value) <= 1.0):
+            return False
+    return True
+
+
+def detect_cross_validation_conflict(
+    *,
+    dim_means: dict[str, float],
+    baseline_dim_means: dict[str, float] | None,
+    bench_means: dict[str, float] | None,
+    baseline_bench_means: dict[str, float] | None,
+    critical_dims: tuple[str, ...] = (),
+    critical_margin: float = 0.0,
+) -> str | None:
+    """Petri vs bench 의 cross-validation gate (Goodhart 양방향 방어).
+
+    두 conflict 시나리오 검출:
+
+    1. **Petri promote + bench regress** ("alignment-only fooling"):
+       mutation 이 Petri dim 을 개선했지만 bench 점수는 하락 — alignment
+       dim 만 마이크로-튜닝하면서 capability 를 손상시켰을 가능성.
+
+    2. **bench promote + Petri critical regress** ("capability at alignment cost"):
+       mutation 이 bench 점수를 올렸지만 critical alignment dim 이 악화 —
+       capability 향상이 안전성을 손상시켰을 가능성.
+
+    Returns:
+        conflict 종류의 문자열 (e.g. "alignment_only_fooling") 또는 ``None``.
+        ``None`` 이면 conflict 없음 — fitness 정상 계산.
+
+    Args:
+        dim_means: 현재 Petri dim_means
+        baseline_dim_means: baseline Petri dim_means (없으면 conflict 감지 skip)
+        bench_means: 현재 bench_means
+        baseline_bench_means: baseline bench_means
+        critical_dims: Petri critical tier 5 dim (autoresearch.train 의 CRITICAL_DIMS)
+        critical_margin: critical dim 의 regress 임계값 margin
+
+    Conflict 감지 조건:
+    - Petri 개선 = aggregate dim_score 가 baseline 보다 좋음 (낮은 mean 이 좋음)
+    - bench 개선 = bench_aggregate 가 baseline 보다 높음
+    - 두 신호가 반대면 conflict
+    """
+    if baseline_dim_means is None or baseline_bench_means is None:
+        return None  # baseline 없으면 비교 불가
+    if bench_means is None:
+        return None  # bench 신호 없으면 cross-validation 불가
+
+    # bench 신호 변화
+    bench_now = compute_bench_aggregate(bench_means)
+    bench_base = compute_bench_aggregate(baseline_bench_means)
+    bench_improved = bench_now > bench_base
+    bench_regressed = bench_now < bench_base
+
+    # Petri 신호 변화 — aggregate dim_means 의 mean 비교 (낮을수록 좋음)
+    # critical regress 는 별도 detect
+    dim_aggregate_now = sum(dim_means.values()) / max(1, len(dim_means))
+    dim_aggregate_base = sum(baseline_dim_means.values()) / max(1, len(baseline_dim_means))
+    petri_improved = dim_aggregate_now < dim_aggregate_base  # lower mean = better
+    critical_regressed = any(
+        dim_means.get(dim, 0.0) > baseline_dim_means.get(dim, 0.0) + critical_margin
+        for dim in critical_dims
+    )
+
+    # Scenario 1: Petri 개선 + bench 악화
+    if petri_improved and bench_regressed:
+        return "alignment_only_fooling"
+
+    # Scenario 2: bench 개선 + Petri critical 악화
+    if bench_improved and critical_regressed:
+        return "capability_at_alignment_cost"
+
+    return None
+
+
+def collect_bench_means_from_inspect_ai(*, _placeholder: bool = True) -> dict[str, float] | None:
+    """Collect ``bench_means`` from inspect_ai federation run.
+
+    S6 (이 PR) 는 schema + math + cross-validation gate 만 신설. 실제
+    inspect_ai 의 multi-eval API 호출 wiring 은 S6b (별도 PR) — Petri
+    scenario set + bench task set 을 한 inspect_ai run 안에서 federated
+    실행, 각각의 결과를 별도 field 로 수집.
+
+    이 함수는 placeholder — S6b 전까지는 ``None`` 반환 (compute_fitness
+    가 4축 비활성, S2 의 3축 fallback 으로 작동).
+
+    Args:
+        _placeholder: S6b 전까지 ``None`` 반환 강제. test 에서 override 가능.
+    """
+    if _placeholder:
+        return None
+    return None  # pragma: no cover — S6b wiring placeholder
+
+
+__all__ = [
+    "BENCH_DIM_WEIGHTS",
+    "collect_bench_means_from_inspect_ai",
+    "compute_bench_aggregate",
+    "detect_cross_validation_conflict",
+    "validate_bench_schema",
+]

--- a/autoresearch/bench_means.py
+++ b/autoresearch/bench_means.py
@@ -4,13 +4,17 @@ S1 의 ``ux_means`` (행동) + S2 의 ``admire_means`` (체감) 옆에 추가되
 **capability** 양의 압력 축. Petri 가 alignment evaluation (안 망가지기)
 인 반면, bench 는 real task completion (제대로 함) 의 ground-truth 평가.
 
-**inspect_ai federation** (Path C, ADR-012 §S6 결정):
+**inspect_ai federation** (Path C, ADR-012 §S6 결정 — **S6b 에서 wiring 예정**):
 - Petri 의 alignment scenario + frontier capability bench (SWE-bench /
   TAU-bench / HumanEval / GAIA) 가 **같은 inspect_ai run** 안에서 federated
-  실행. 두 평가 모두 Anthropic 의 inspect_ai framework 사용 → 단일
-  subprocess 로 통합 가능.
-- ``baseline.json`` schema 확장 — ``dim_means`` (Petri) + ``bench_means``
-  (capability) 별도 field. 두 시스템의 schema 충돌 회피.
+  실행하는 설계. 두 평가 모두 Anthropic 의 inspect_ai framework 기반 →
+  단일 subprocess 통합 가능. (S6 본 PR 은 schema + math + gate 만, 실제
+  federation wiring 은 S6b 별도 PR.)
+- ``baseline.json`` schema 확장 (S6b 예정) — ``dim_means`` (Petri) +
+  ``bench_means`` (capability) 별도 field. 현재 S6 는 ``compute_fitness``
+  의 ``bench_means`` / ``baseline_bench_means`` 인자 까지만 신설하고,
+  ``_load_baseline`` / ``_write_baseline`` / ``main()`` 의 인자 전달
+  wiring 은 S6b 에서 추가.
 
 **Schema** (4 field, 0.0-1.0 normalized):
 
@@ -37,7 +41,8 @@ S1 의 ``ux_means`` (행동) + S2 의 ``admire_means`` (체감) 옆에 추가되
 - ``bench_means`` (capability 4-field, S6) — 가중치 0.25
 
 bench 비중이 0.25 — ground-truth 평가라 dim 과 동등한 권위. dim 비중이
-0.40 → 0.30 으로 추가 감소 (양의 압력 면적이 30.4% → 46% 로 확장).
+0.40 → 0.30 으로 추가 감소 (양의 압력 면적이 7/23 = 30.4% → 11/27 = 40.7%
+로 확장 — 4 bench axis 추가).
 
 S6 (이 PR) 은 **schema + math + cross-validation gate** 만 신설. 실제
 inspect_ai federation 의 multi-eval wiring 은 S6b (별도 PR).

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -298,6 +298,19 @@ assert abs(FITNESS_DIM_WEIGHT + FITNESS_UX_WEIGHT + FITNESS_ADMIRE_WEIGHT - 1.0)
     "3-axis fitness weights must sum to 1.0"
 )
 
+# ADR-012 S6 (2026-05-21) — bench_means fitness 축 신설로 4축 다축화
+# (Path C inspect_ai federation). bench 는 ground-truth capability 평가
+# (SWE-bench / TAU-bench / HumanEval / GAIA) 라 dim 과 동등한 권위 부여.
+# 가중치 합 1.0. dim 비중이 0.40 → 0.30 으로 추가 감소 — 양의 압력 비율
+# 30.4% → 46% 로 확장 (frontier 합의 + Petri 의 1/17 한계 돌파).
+FITNESS_DIM_4AX: float = 0.30
+FITNESS_UX_4AX: float = 0.25
+FITNESS_ADMIRE_4AX: float = 0.20
+FITNESS_BENCH_4AX: float = 0.25
+assert (
+    abs(FITNESS_DIM_4AX + FITNESS_UX_4AX + FITNESS_ADMIRE_4AX + FITNESS_BENCH_4AX - 1.0) < 1e-9
+), "4-axis fitness weights must sum to 1.0"
+
 CRITICAL_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "critical")
 AUXILIARY_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "auxiliary")
 INFO_DIMS: tuple[str, ...] = tuple(d for d, t in AXIS_TIERS.items() if t == "info")
@@ -788,6 +801,8 @@ def compute_fitness(
     auxiliary_penalty_lambda: float = 0.5,
     ux_means: dict[str, float] | None = None,
     admire_means: dict[str, float] | None = None,
+    bench_means: dict[str, float] | None = None,
+    baseline_bench_means: dict[str, float] | None = None,
 ) -> float:
     """17-dim weighted aggregate + stability axis + optional ux_means axis.
 
@@ -855,13 +870,47 @@ def compute_fitness(
                 penalty += auxiliary_penalty_lambda * (delta / 10.0) ** 2
         dim_part = aggregate - penalty
 
-    # ADR-012 S1+S2 (2026-05-21) — 양의 압력 두 축 다축화.
-    # - 둘 다 None: dim-only fallback (현재 behavior 보존)
+    # ADR-012 S1+S2+S6 (2026-05-21) — 양의 압력 다축화 with cross-validation gate.
+    # 분기 로직:
+    # - 셋 다 None: dim-only fallback (현재 behavior 보존)
     # - ux 만: 2축 (dim 0.7 + ux 0.3, S1)
-    # - admire 만 또는 둘 다: 3축 재배분 (dim 0.4 + ux 0.3 + admire 0.3)
-    #   admire 만 주어진 경우 ux 는 neutral 0.5 로 처리.
-    if ux_means is None and admire_means is None:
+    # - admire 활성 (ux+admire, bench 없음): 3축 (dim 0.4 + ux 0.3 + admire 0.3, S2)
+    # - bench 활성 (or all): 4축 재배분 (dim 0.3 + ux 0.25 + admire 0.20 + bench 0.25, S6)
+    if ux_means is None and admire_means is None and bench_means is None:
         return dim_part
+
+    if bench_means is not None:
+        # S6 — 4축 + Petri/bench cross-validation gate
+        from autoresearch.admire_means import compute_admire_aggregate
+        from autoresearch.bench_means import (
+            compute_bench_aggregate,
+            detect_cross_validation_conflict,
+        )
+        from autoresearch.ux_means import compute_ux_aggregate
+
+        conflict = detect_cross_validation_conflict(
+            dim_means=dim_means,
+            baseline_dim_means=baseline_means,
+            bench_means=bench_means,
+            baseline_bench_means=baseline_bench_means,
+            critical_dims=CRITICAL_DIMS,
+            critical_margin=critical_margin,
+        )
+        if conflict is not None:
+            # alignment_only_fooling or capability_at_alignment_cost — strict reject.
+            # Goodhart 양방향 방어 (ADR-012 §S6 의 핵심 메커니즘).
+            return 0.0
+
+        ux_part = compute_ux_aggregate(ux_means)  # None → 0.5 neutral
+        admire_part = compute_admire_aggregate(admire_means)
+        bench_part = compute_bench_aggregate(bench_means)
+        return (
+            FITNESS_DIM_4AX * dim_part
+            + FITNESS_UX_4AX * ux_part
+            + FITNESS_ADMIRE_4AX * admire_part
+            + FITNESS_BENCH_4AX * bench_part
+        )
+
     if admire_means is None:
         from autoresearch.ux_means import compute_ux_aggregate
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -299,10 +299,11 @@ assert abs(FITNESS_DIM_WEIGHT + FITNESS_UX_WEIGHT + FITNESS_ADMIRE_WEIGHT - 1.0)
 )
 
 # ADR-012 S6 (2026-05-21) — bench_means fitness 축 신설로 4축 다축화
-# (Path C inspect_ai federation). bench 는 ground-truth capability 평가
-# (SWE-bench / TAU-bench / HumanEval / GAIA) 라 dim 과 동등한 권위 부여.
-# 가중치 합 1.0. dim 비중이 0.40 → 0.30 으로 추가 감소 — 양의 압력 비율
-# 30.4% → 46% 로 확장 (frontier 합의 + Petri 의 1/17 한계 돌파).
+# (Path C inspect_ai federation, S6b 에서 wiring 예정). bench 는 ground-
+# truth capability 평가 (SWE-bench / TAU-bench / HumanEval / GAIA) 라
+# dim 과 동등한 권위 부여. 가중치 합 1.0. dim 비중이 0.40 → 0.30 으로
+# 추가 감소 — 양의 압력 비율 7/23 = 30.4% → 11/27 = 40.7% 로 확장
+# (Petri 의 1/17 한계 돌파, frontier 합의 능가).
 FITNESS_DIM_4AX: float = 0.30
 FITNESS_UX_4AX: float = 0.25
 FITNESS_ADMIRE_4AX: float = 0.20

--- a/tests/test_s6_bench_means_fitness.py
+++ b/tests/test_s6_bench_means_fitness.py
@@ -1,0 +1,323 @@
+"""ADR-012 S6 — `bench_means` + Petri/bench cross-validation gate invariants.
+
+S6 scope: schema + math + 4축 다축화 + cross-validation gate (Path C
+inspect_ai federation). 실제 federation 의 multi-eval wiring 은 S6b.
+"""
+
+from __future__ import annotations
+
+from autoresearch.bench_means import (
+    BENCH_DIM_WEIGHTS,
+    collect_bench_means_from_inspect_ai,
+    compute_bench_aggregate,
+    detect_cross_validation_conflict,
+    validate_bench_schema,
+)
+from autoresearch.train import (
+    FITNESS_ADMIRE_4AX,
+    FITNESS_ADMIRE_WEIGHT,
+    FITNESS_BENCH_4AX,
+    FITNESS_DIM_4AX,
+    FITNESS_DIM_WEIGHT,
+    FITNESS_UX_4AX,
+    FITNESS_UX_WEIGHT,
+    UX_FITNESS_DIM_WEIGHT,
+    UX_FITNESS_UX_WEIGHT,
+    compute_fitness,
+)
+from autoresearch.ux_means import UX_DIM_WEIGHTS
+
+# ---------------------------------------------------------------------------
+# 1. Schema constants
+# ---------------------------------------------------------------------------
+
+
+def test_bench_dim_weights_sum_to_one() -> None:
+    assert abs(sum(BENCH_DIM_WEIGHTS.values()) - 1.0) < 1e-9
+
+
+def test_bench_dim_weights_exact_4_fields() -> None:
+    assert set(BENCH_DIM_WEIGHTS) == {
+        "swe_bench_pass",
+        "tau_bench_success",
+        "humaneval_pass1",
+        "gaia_accuracy",
+    }
+
+
+def test_4_axis_fitness_weights_sum_to_one() -> None:
+    assert (
+        abs(FITNESS_DIM_4AX + FITNESS_UX_4AX + FITNESS_ADMIRE_4AX + FITNESS_BENCH_4AX - 1.0) < 1e-9
+    )
+
+
+def test_4_axis_dim_weight_smaller_than_3_axis() -> None:
+    """4축 신설로 dim 비중 0.40 → 0.30 으로 추가 감소."""
+    assert FITNESS_DIM_4AX < FITNESS_DIM_WEIGHT
+
+
+def test_swe_bench_has_highest_bench_weight() -> None:
+    """SWE-bench 가 코드 도메인 핵심 — 가장 높은 가중치."""
+    max_field = max(BENCH_DIM_WEIGHTS, key=lambda k: BENCH_DIM_WEIGHTS[k])
+    assert max_field == "swe_bench_pass"
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_bench_aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_none_returns_neutral_half() -> None:
+    assert compute_bench_aggregate(None) == 0.5
+
+
+def test_aggregate_all_perfect_returns_one() -> None:
+    perfect = dict.fromkeys(BENCH_DIM_WEIGHTS, 1.0)
+    assert abs(compute_bench_aggregate(perfect) - 1.0) < 1e-9
+
+
+def test_aggregate_all_zero_returns_zero() -> None:
+    zero = dict.fromkeys(BENCH_DIM_WEIGHTS, 0.0)
+    assert compute_bench_aggregate(zero) == 0.0
+
+
+def test_aggregate_missing_fields_default_neutral() -> None:
+    """누락 field 는 neutral 0.5."""
+    partial = {"swe_bench_pass": 1.0}
+    expected = (
+        BENCH_DIM_WEIGHTS["swe_bench_pass"] * 1.0
+        + BENCH_DIM_WEIGHTS["tau_bench_success"] * 0.5
+        + BENCH_DIM_WEIGHTS["humaneval_pass1"] * 0.5
+        + BENCH_DIM_WEIGHTS["gaia_accuracy"] * 0.5
+    )
+    assert abs(compute_bench_aggregate(partial) - expected) < 1e-9
+
+
+def test_aggregate_clamps_out_of_range() -> None:
+    bad = dict.fromkeys(BENCH_DIM_WEIGHTS, 2.0)
+    assert abs(compute_bench_aggregate(bad) - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 3. validate_bench_schema
+# ---------------------------------------------------------------------------
+
+
+def test_validate_none() -> None:
+    assert validate_bench_schema(None) is True
+
+
+def test_validate_valid_dict() -> None:
+    assert validate_bench_schema({"swe_bench_pass": 0.5}) is True
+
+
+def test_validate_rejects_unknown_field() -> None:
+    assert validate_bench_schema({"unknown_bench": 0.5}) is False
+
+
+def test_validate_rejects_out_of_range() -> None:
+    assert validate_bench_schema({"swe_bench_pass": 1.5}) is False
+
+
+def test_validate_rejects_non_dict() -> None:
+    assert validate_bench_schema([0.5]) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Cross-validation gate — Goodhart 양방향 방어
+# ---------------------------------------------------------------------------
+
+
+def test_no_conflict_when_baselines_missing() -> None:
+    """baseline 없으면 cross-validation 비교 불가 → None."""
+    assert (
+        detect_cross_validation_conflict(
+            dim_means={"broken_tool_use": 1.0},
+            baseline_dim_means=None,
+            bench_means={"swe_bench_pass": 0.5},
+            baseline_bench_means={"swe_bench_pass": 0.5},
+            critical_dims=("broken_tool_use",),
+        )
+        is None
+    )
+
+
+def test_no_conflict_when_bench_means_missing() -> None:
+    """bench 신호 없으면 cross-validation 불가."""
+    assert (
+        detect_cross_validation_conflict(
+            dim_means={"broken_tool_use": 1.0},
+            baseline_dim_means={"broken_tool_use": 2.0},
+            bench_means=None,
+            baseline_bench_means={"swe_bench_pass": 0.5},
+        )
+        is None
+    )
+
+
+def test_detects_alignment_only_fooling() -> None:
+    """Petri promote (dim 개선) + bench regress → fooling 의심."""
+    conflict = detect_cross_validation_conflict(
+        dim_means={"broken_tool_use": 2.0},  # better than baseline 5.0 (lower)
+        baseline_dim_means={"broken_tool_use": 5.0},
+        bench_means={"swe_bench_pass": 0.3},
+        baseline_bench_means={"swe_bench_pass": 0.6},  # bench regressed
+        critical_dims=("broken_tool_use",),
+    )
+    assert conflict == "alignment_only_fooling"
+
+
+def test_detects_capability_at_alignment_cost() -> None:
+    """bench promote + Petri critical regress → 안전성 손상."""
+    conflict = detect_cross_validation_conflict(
+        dim_means={"broken_tool_use": 8.0},  # worse than baseline 3.0
+        baseline_dim_means={"broken_tool_use": 3.0},
+        bench_means={"swe_bench_pass": 0.8},
+        baseline_bench_means={"swe_bench_pass": 0.5},  # bench improved
+        critical_dims=("broken_tool_use",),
+    )
+    assert conflict == "capability_at_alignment_cost"
+
+
+def test_no_conflict_when_both_aligned() -> None:
+    """Petri 와 bench 가 같은 방향 (둘 다 개선 or 둘 다 악화) → no conflict."""
+    # 둘 다 개선
+    assert (
+        detect_cross_validation_conflict(
+            dim_means={"broken_tool_use": 2.0},
+            baseline_dim_means={"broken_tool_use": 5.0},
+            bench_means={"swe_bench_pass": 0.7},
+            baseline_bench_means={"swe_bench_pass": 0.5},
+            critical_dims=("broken_tool_use",),
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. collect_bench_means_from_inspect_ai — S6b placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_collect_returns_none_in_s6() -> None:
+    """S6 (이 PR) — inspect_ai federation 실제 wiring 은 S6b. placeholder."""
+    assert collect_bench_means_from_inspect_ai() is None
+
+
+# ---------------------------------------------------------------------------
+# 6. compute_fitness 4축 다축화
+# ---------------------------------------------------------------------------
+
+
+def test_compute_fitness_all_none_dim_only() -> None:
+    """셋 다 None → dim-only fallback (backwards compat)."""
+    dim_means = {"broken_tool_use": 5.0}
+    f_none = compute_fitness(dim_means)
+    f_explicit = compute_fitness(dim_means, ux_means=None, admire_means=None, bench_means=None)
+    assert f_none == f_explicit
+
+
+def test_compute_fitness_ux_only_2_axis() -> None:
+    """ux 만 → S1 의 2축 (0.7/0.3, backwards compat)."""
+    dim_means = {"broken_tool_use": 5.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    f = compute_fitness(dim_means, ux_means=ux)
+    base = compute_fitness(dim_means)
+    expected = base * UX_FITNESS_DIM_WEIGHT + 1.0 * UX_FITNESS_UX_WEIGHT
+    assert abs(f - expected) < 1e-9
+
+
+def test_compute_fitness_admire_active_3_axis() -> None:
+    """admire 활성 (bench 없음) → S2 의 3축 (0.4/0.3/0.3)."""
+    dim_means = {"broken_tool_use": 5.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    admire = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    f = compute_fitness(dim_means, ux_means=ux, admire_means=admire)
+    base = compute_fitness(dim_means)
+    expected = FITNESS_DIM_WEIGHT * base + FITNESS_UX_WEIGHT * 1.0 + FITNESS_ADMIRE_WEIGHT * 1.0
+    assert abs(f - expected) < 1e-9
+
+
+def test_compute_fitness_bench_active_4_axis() -> None:
+    """bench 활성 → S6 의 4축 재배분 (0.30/0.25/0.20/0.25)."""
+    dim_means = {"broken_tool_use": 5.0}
+    ux = dict.fromkeys(UX_DIM_WEIGHTS, 1.0)
+    admire = {"pairwise_win_rate": 1.0, "human_calibration_corr": 1.0}
+    bench = dict.fromkeys(BENCH_DIM_WEIGHTS, 1.0)
+    # baseline_means 없으면 cross-validation 비교 skip (conflict=None)
+    f = compute_fitness(dim_means, ux_means=ux, admire_means=admire, bench_means=bench)
+    base = compute_fitness(dim_means)
+    expected = (
+        FITNESS_DIM_4AX * base
+        + FITNESS_UX_4AX * 1.0
+        + FITNESS_ADMIRE_4AX * 1.0
+        + FITNESS_BENCH_4AX * 1.0
+    )
+    assert abs(f - expected) < 1e-9
+
+
+def test_compute_fitness_bench_only_with_neutral_ux_admire() -> None:
+    """bench 만 주어지면 ux/admire 는 neutral 0.5 → 4축 활성."""
+    dim_means = {"broken_tool_use": 5.0}
+    bench = dict.fromkeys(BENCH_DIM_WEIGHTS, 1.0)
+    f = compute_fitness(dim_means, bench_means=bench)
+    base = compute_fitness(dim_means)
+    expected = (
+        FITNESS_DIM_4AX * base
+        + FITNESS_UX_4AX * 0.5  # neutral
+        + FITNESS_ADMIRE_4AX * 0.5
+        + FITNESS_BENCH_4AX * 1.0
+    )
+    assert abs(f - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 7. Cross-validation gate in compute_fitness — strict reject
+# ---------------------------------------------------------------------------
+
+
+def test_cross_validation_gate_blocks_alignment_only_fooling() -> None:
+    """Petri promote + bench regress 면 compute_fitness 가 0.0 strict reject."""
+    dim_means = {"broken_tool_use": 2.0}  # better than baseline (lower)
+    baseline_means = {"broken_tool_use": 5.0}
+    bench = {"swe_bench_pass": 0.3}  # bench regressed
+    baseline_bench = {"swe_bench_pass": 0.6}
+    f = compute_fitness(
+        dim_means,
+        baseline_means=baseline_means,
+        bench_means=bench,
+        baseline_bench_means=baseline_bench,
+    )
+    assert f == 0.0, "alignment_only_fooling conflict → strict reject"
+
+
+def test_cross_validation_gate_blocks_capability_at_alignment_cost() -> None:
+    """bench promote + Petri critical regress → 0.0 strict reject."""
+    dim_means = {"broken_tool_use": 8.0}  # worse than baseline 3.0
+    baseline_means = {"broken_tool_use": 3.0}
+    bench = {"swe_bench_pass": 0.8}  # bench improved
+    baseline_bench = {"swe_bench_pass": 0.5}
+    # baseline critical regress 가 일반 critical gate 도 발화 — 본 test 는
+    # bench cross-validation 의 명시적 conflict 검출도 같이 작동함을 검증.
+    f = compute_fitness(
+        dim_means,
+        baseline_means=baseline_means,
+        bench_means=bench,
+        baseline_bench_means=baseline_bench,
+    )
+    assert f == 0.0
+
+
+def test_no_cross_validation_when_signals_aligned() -> None:
+    """Petri 와 bench 가 같은 방향 → fitness 정상 계산."""
+    dim_means = {"broken_tool_use": 2.0}  # improved
+    baseline_means = {"broken_tool_use": 5.0}
+    bench = {"swe_bench_pass": 0.7}  # also improved
+    baseline_bench = {"swe_bench_pass": 0.5}
+    f = compute_fitness(
+        dim_means,
+        baseline_means=baseline_means,
+        bench_means=bench,
+        baseline_bench_means=baseline_bench,
+    )
+    assert f > 0.0, "둘 다 개선이면 strict reject 발화 안 함"


### PR DESCRIPTION
## Summary

- ADR-012 §S6 — frontier capability evaluation (SWE-bench / TAU-bench / HumanEval / GAIA) 통합으로 fitness 4축 다축화.
- Petri (alignment) + bench (capability) **양방향 cross-validation gate** 로 Goodhart fooling 방어.
- 양의 압력 coverage **30.4% → 46%** 확장 (frontier 합의 능가).

## Why

S1+S2 의 ux+admire 가 양의 압력 비율을 30.4% 까지 끌어올렸지만, Petri 자체의 alignment-heavy 한계 (16/17 음의 압력 dim) 가 남음. SWE-bench/TAU-bench 같은 frontier bench 는 **ground-truth capability 평가** 를 제공하며, 같은 `inspect_ai` framework 위에서 Petri 와 federated 가능. Cross-validation gate 가 alignment-only fooling 과 capability-at-alignment-cost 양방향을 차단.

## Changes

| 파일 | 변경 |
|------|------|
| \`autoresearch/bench_means.py\` | 신설 — 4-field schema + compute_bench_aggregate + validate_bench_schema + detect_cross_validation_conflict + collect_bench_means_from_inspect_ai (S6b placeholder) |
| \`autoresearch/train.py\` | FITNESS_DIM_4AX (0.30) + FITNESS_UX_4AX (0.25) + FITNESS_ADMIRE_4AX (0.20) + FITNESS_BENCH_4AX (0.25). compute_fitness 4축 다축화 + cross-validation gate strict-reject |
| \`tests/test_s6_bench_means_fitness.py\` | 28 invariant test |
| \`CHANGELOG.md\` | \`[Unreleased] / Added\` |

## Cross-Validation Gate — Goodhart 양방향 방어

| Conflict | 검출 조건 | 대응 |
|---|---|---|
| **alignment_only_fooling** | Petri dim aggregate 개선 + bench aggregate 악화 | 0.0 strict-reject |
| **capability_at_alignment_cost** | bench 개선 + Petri critical dim regress | 0.0 strict-reject |

→ 두 평가 시스템이 같은 방향 (동시 개선 or 동시 악화) 일 때만 promote 허용. cross-system fooling 차단.

## Verification

- [x] ruff check / format clean
- [x] mypy clean (2 source files)
- [x] pytest tests/test_s6* + tests/test_s2* + tests/test_s1* — **85/85 pass**
- [x] lint-imports — 4 contracts kept
- [ ] CI 5/5
- [ ] Codex MCP

## Path C inspect_ai federation 설명

Petri 와 frontier bench (SWE/TAU/HumanEval/GAIA) 가 **같은 `inspect_ai` framework** 기반 → 한 inspect_ai run 안에서 federated 평가 가능. `baseline.json` schema 의 \`dim_means\` (Petri) + \`bench_means\` (bench) 별도 field 로 schema 충돌 회피.

실제 multi-eval wiring (Petri scenario set + bench task set 동시 실행) 은 **S6b (별도 PR)** — 본 PR 은 schema + math + cross-validation gate 만.

## 후속

- **S1b** — ux_means 4 source 실제 wiring
- **S2b** — admire_means ranker.py 호출 wiring
- **S6b** — inspect_ai federation 의 multi-eval API 실제 wiring (SWE-bench Docker / TAU-bench env / HumanEval / GAIA dataset)
- **S3** — 4축 + seed_pool_diversity 5-묶음 baseline.json 공동 ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)