### PR TITLE
feat(adr-013-t1): tool descriptions JSON mutation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,8 @@ functional change.
   첫 신규 표면 — mutator 가 도구 description + hint 만 JSON 으로 mutate →
   도구 후보 선택 정확도 ↑ → Petri 17-dim 의 `broken_tool_use` (유일한 양의
   압력 dim) 직접 영향. **5-element 패턴** (S0a 검증): SoT
-  `autoresearch/state/policies/tool-descriptions.json` (in-repo) +
-  `~/.geode/self-improving-loop/tool-descriptions.json` (operator-local) /
-  `GLOBAL_TOOL_DESCRIPTIONS_PATH` `core/paths.py` 추가 /
+  `autoresearch/state/policies/tool-descriptions.json` (in-repo,
+  ratchet-tracked) / `GLOBAL_TOOL_DESCRIPTIONS_PATH` `core/paths.py` 추가 /
   `core/agent/tool_descriptions_policy.py` reader (`_load_tool_descriptions_override`
   + `apply_tool_descriptions_policy`, schema `{tool_name: {description: str,
   hints: [str]}}`) / `core/agent/loop/_helpers.py:get_agentic_tools` 진입점

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,31 @@ functional change.
 
 ### Added
 
+- **PR-T1 — Tool descriptions JSON mutation surface (ADR-013).** ADR-013 의
+  첫 신규 표면 — mutator 가 도구 description + hint 만 JSON 으로 mutate →
+  도구 후보 선택 정확도 ↑ → Petri 17-dim 의 `broken_tool_use` (유일한 양의
+  압력 dim) 직접 영향. **5-element 패턴** (S0a 검증): SoT
+  `autoresearch/state/policies/tool-descriptions.json` (in-repo) +
+  `~/.geode/self-improving-loop/tool-descriptions.json` (operator-local) /
+  `GLOBAL_TOOL_DESCRIPTIONS_PATH` `core/paths.py` 추가 /
+  `core/agent/tool_descriptions_policy.py` reader (`_load_tool_descriptions_override`
+  + `apply_tool_descriptions_policy`, schema `{tool_name: {description: str,
+  hints: [str]}}`) / `core/agent/loop/_helpers.py:get_agentic_tools` 진입점
+  (base+registry+MCP merge 직후, `apply_tool_policy` 의 forbidden/priority
+  filter **직전** — description override 가 먼저 적용돼야 policy 가 갱신된
+  description 기반으로 판단) / `GEODE_TOOL_DESCRIPTIONS_OVERRIDE` env var
+  (`autoresearch/train.py` 의 audit subprocess 가 SoT 존재 시 inject —
+  strict-fail). `apply_tool_descriptions_policy` 는 `copy.deepcopy` 후
+  mutate (caller 의 module-level `_BASE_TOOLS` 오염 방지, S0b 패턴).
+  hints 가 있으면 description 끝에 `Hints:\n- …\n- …` 줄바꿈 append.
+  Forward-compat: entry 내 unknown field 무시. 19 invariant test —
+  reader graceful/strict + apply none/empty/override/hints/deepcopy +
+  helpers wiring (descriptions before tool_policy 순서 검증) + path
+  constant + train.py env wiring + ALIVE marker (`tool-descriptions.json`
+  이 `core/agent/tool_descriptions_policy.py` 에서 grep 양성). Frontier:
+  OpenAI function calling docs + Anthropic tool-use guide ("clearer
+  descriptions yield more accurate selection").
+
 - **ADR-013 — Mutation Surface Expansion via JSON Schema Pattern (Proposed).**
   ADR-012 의 S0a 검증된 패턴 (JSON SoT + reader + dispatcher) 을 6 신규
   표면 (T1-T6) 으로 확장. **AlphaEvolve 식 코드 자체 mutation 은 명시적

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -649,6 +649,7 @@ def run_audit(
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
+        GLOBAL_TOOL_DESCRIPTIONS_PATH,
         GLOBAL_TOOL_POLICY_PATH,
     )
 
@@ -658,6 +659,9 @@ def run_audit(
         env["GEODE_REFLECTION_POLICY_OVERRIDE"] = str(GLOBAL_REFLECTION_POLICY_PATH)
     if GLOBAL_DECOMPOSITION_POLICY_PATH.is_file():
         env["GEODE_DECOMPOSITION_POLICY_OVERRIDE"] = str(GLOBAL_DECOMPOSITION_POLICY_PATH)
+    # ADR-013 T1 (2026-05-21) — tool descriptions override env wiring.
+    if GLOBAL_TOOL_DESCRIPTIONS_PATH.is_file():
+        env["GEODE_TOOL_DESCRIPTIONS_OVERRIDE"] = str(GLOBAL_TOOL_DESCRIPTIONS_PATH)
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/loop/_helpers.py
+++ b/core/agent/loop/_helpers.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from core.agent.tool_descriptions_policy import (
+    _load_tool_descriptions_override,
+    apply_tool_descriptions_policy,
+)
 from core.agent.tool_policy import _load_tool_policy_override, apply_tool_policy
 from core.tools.base import load_all_tool_definitions
 
@@ -51,6 +55,12 @@ def get_agentic_tools(
             if name and name not in existing_names:
                 existing_names.add(name)
                 tools.append(mcp_tool)
+    # ADR-013 T1 (2026-05-21) — tool descriptions override 적용.
+    # base + registry + MCP merge 직후 + tool_policy filter/order 직전.
+    # description override 가 먼저 적용돼야 tool_policy 가 갱신된 description
+    # 기반의 forbidden/priority 판단 가능.
+    tools = apply_tool_descriptions_policy(tools, _load_tool_descriptions_override())
+
     # ADR-012 S0a — 5축의 ``tool_policy`` SoT 가 인퍼런스 경로에서
     # 실제로 적용되는 단일 지점. 정책이 부재하면 ``apply_tool_policy``
     # 는 no-op (현재 행동 보존).

--- a/core/agent/tool_descriptions_policy.py
+++ b/core/agent/tool_descriptions_policy.py
@@ -1,0 +1,180 @@
+"""Tool descriptions SoT reader — ADR-013 T1, JSON mutation surface.
+
+ADR-012 의 S0a 검증된 패턴 (JSON SoT + reader + dispatcher) 을 그대로
+적용한 첫 ADR-013 표면. mutator 가 ``tool-descriptions.json`` 의
+``{tool_name: {description: str, hints: [str]}}`` 를 mutate → 도구 후보
+선택 정확도 ↑ → Petri 17-dim 의 ``broken_tool_use`` (유일한 양의 압력
+dim) 직접 영향.
+
+**SoT schema** (모든 entry optional):
+
+.. code-block:: json
+
+    {
+      "bash": {
+        "description": "Execute bash commands with timeout + sandbox.",
+        "hints": ["Quote file paths with spaces", "Avoid -i flag"]
+      },
+      "read": {
+        "description": "Read file from local filesystem.",
+        "hints": ["Use offset+limit for large files"]
+      }
+    }
+
+빈 entry / 누락 tool / 부적합 schema → no-op (default description 유지).
+
+**Resolution order** (``wrapper-sections.json`` 패턴 동일):
+
+1. ``GEODE_TOOL_DESCRIPTIONS_OVERRIDE`` env var — audit subprocess, strict.
+2. ``autoresearch/state/policies/tool-descriptions.json`` (in-repo).
+3. ``~/.geode/self-improving-loop/tool-descriptions.json`` (operator-local).
+4. ``None`` — no-op (default description 사용).
+
+**Frontier**: OpenAI function calling docs — "clearer descriptions yield
+more accurate selection" + Anthropic tool-use guide.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_TOOL_DESCRIPTIONS_PATH
+
+log = logging.getLogger(__name__)
+
+_TOOL_DESCRIPTIONS_OVERRIDE_ENV = "GEODE_TOOL_DESCRIPTIONS_OVERRIDE"
+
+_TOOL_DESCRIPTIONS_SOT_PATH = GLOBAL_TOOL_DESCRIPTIONS_PATH
+"""Cross-process SoT path (T1, 2026-05-21). module-local alias 로 테스트
+가 monkeypatch 가능."""
+
+
+_FIELD_DESCRIPTION = "description"
+_FIELD_HINTS = "hints"
+
+
+def _load_tool_descriptions_override() -> dict[str, dict[str, Any]] | None:
+    """Return active tool-descriptions override, or ``None`` if no SoT."""
+    override_path = os.environ.get(_TOOL_DESCRIPTIONS_OVERRIDE_ENV)
+    if override_path:
+        return _strict_load(Path(override_path))
+    if _TOOL_DESCRIPTIONS_SOT_PATH.is_file():
+        return _graceful_load(_TOOL_DESCRIPTIONS_SOT_PATH)
+    return None
+
+
+def _strict_load(path: Path) -> dict[str, dict[str, Any]]:
+    """Audit-subprocess path: schema 실패 시 ``RuntimeError`` (fail-fast)."""
+    if not path.is_file():
+        raise RuntimeError(f"{_TOOL_DESCRIPTIONS_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_TOOL_DESCRIPTIONS_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, dict[str, Any]] | None:
+    """Daily-run path: schema 실패 시 WARNING + ``None``."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("tool-descriptions SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("tool-descriptions SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """``data`` 가 ``dict[str, dict[str, str|list[str]]]`` 모양인지.
+
+    Per-tool entry 는 ``description`` (str) 또는 ``hints`` (list[str]) 만
+    포함. Unknown field 무시 (forward-compatible).
+    """
+    if not isinstance(data, dict):
+        raise RuntimeError(f"tool-descriptions at {path} must be a dict")
+    for tool_name, entry in data.items():
+        if not isinstance(tool_name, str):
+            type_name = type(tool_name).__name__
+            raise RuntimeError(f"tool-descriptions at {path} key must be str, got {type_name}")
+        if not isinstance(entry, dict):
+            type_name = type(entry).__name__
+            raise RuntimeError(
+                f"tool-descriptions at {path}[{tool_name!r}] must be dict, got {type_name}"
+            )
+        if _FIELD_DESCRIPTION in entry and not isinstance(entry[_FIELD_DESCRIPTION], str):
+            raise RuntimeError(
+                f"tool-descriptions at {path}[{tool_name!r}].description must be str"
+            )
+        if _FIELD_HINTS in entry:
+            hints = entry[_FIELD_HINTS]
+            if not isinstance(hints, list) or not all(isinstance(h, str) for h in hints):
+                raise RuntimeError(
+                    f"tool-descriptions at {path}[{tool_name!r}].hints must be list[str]"
+                )
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """알려진 field 만 추출 — entry 별 description / hints 만 보존."""
+    result: dict[str, dict[str, Any]] = {}
+    for tool_name, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        kept: dict[str, Any] = {}
+        if _FIELD_DESCRIPTION in entry:
+            kept[_FIELD_DESCRIPTION] = entry[_FIELD_DESCRIPTION]
+        if _FIELD_HINTS in entry:
+            kept[_FIELD_HINTS] = list(entry[_FIELD_HINTS])
+        if kept:
+            result[tool_name] = kept
+    return result
+
+
+def apply_tool_descriptions_policy(
+    tools: list[dict[str, Any]],
+    policy: dict[str, dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Apply ``policy`` to ``tools`` — override description text + append hints.
+
+    ``policy is None`` → ``tools`` 그대로. 각 tool 의 ``description`` 이
+    policy 에 있으면 교체. ``hints`` 가 있으면 description 끝에 줄바꿈
+    뒤에 append (``Hints:\\n- hint1\\n- hint2``).
+
+    Tools dict 은 deep-copy 후 mutate — caller 의 module-level constant
+    오염 방지 (S0b 패턴).
+    """
+    if policy is None:
+        return tools
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        name = tool.get("name")
+        if not isinstance(name, str) or name not in policy:
+            out.append(tool)
+            continue
+        new_tool = copy.deepcopy(tool)
+        entry = policy[name]
+        if _FIELD_DESCRIPTION in entry:
+            new_tool["description"] = entry[_FIELD_DESCRIPTION]
+        if _FIELD_HINTS in entry:
+            hints = entry[_FIELD_HINTS]
+            if hints:
+                hint_block = "\n\nHints:\n" + "\n".join(f"- {h}" for h in hints)
+                base = new_tool.get("description", "")
+                new_tool["description"] = f"{base}{hint_block}" if base else hint_block.lstrip()
+        out.append(new_tool)
+    return out
+
+
+__all__ = ["apply_tool_descriptions_policy"]

--- a/core/agent/tool_descriptions_policy.py
+++ b/core/agent/tool_descriptions_policy.py
@@ -26,9 +26,8 @@ dim) 직접 영향.
 **Resolution order** (``wrapper-sections.json`` 패턴 동일):
 
 1. ``GEODE_TOOL_DESCRIPTIONS_OVERRIDE`` env var — audit subprocess, strict.
-2. ``autoresearch/state/policies/tool-descriptions.json`` (in-repo).
-3. ``~/.geode/self-improving-loop/tool-descriptions.json`` (operator-local).
-4. ``None`` — no-op (default description 사용).
+2. ``autoresearch/state/policies/tool-descriptions.json`` (in-repo, ratchet-tracked).
+3. ``None`` — no-op (default description 사용).
 
 **Frontier**: OpenAI function calling docs — "clearer descriptions yield
 more accurate selection" + Anthropic tool-use guide.

--- a/core/paths.py
+++ b/core/paths.py
@@ -93,6 +93,8 @@ GLOBAL_TOOL_POLICY_PATH = GLOBAL_POLICIES_DIR / "tool-policy.json"
 GLOBAL_DECOMPOSITION_POLICY_PATH = GLOBAL_POLICIES_DIR / "decomposition.json"
 GLOBAL_RETRIEVAL_POLICY_PATH = GLOBAL_POLICIES_DIR / "retrieval.json"
 GLOBAL_REFLECTION_POLICY_PATH = GLOBAL_POLICIES_DIR / "reflection.json"
+# ADR-013 T1 (2026-05-21) — Tool descriptions mutation SoT.
+GLOBAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_POLICIES_DIR / "tool-descriptions.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/tests/test_t1_tool_descriptions.py
+++ b/tests/test_t1_tool_descriptions.py
@@ -1,0 +1,201 @@
+"""ADR-013 T1 — `tool_descriptions` JSON mutation surface invariants.
+
+S0a 검증된 5-element 패턴 (SoT + path + reader + entry + env) 의 T1 적용:
+- SoT: tool-descriptions.json
+- Path: GLOBAL_TOOL_DESCRIPTIONS_PATH
+- Reader: core/agent/tool_descriptions_policy.py
+- Entry: core/agent/loop/_helpers.py:get_agentic_tools
+- Env: GEODE_TOOL_DESCRIPTIONS_OVERRIDE
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.agent.tool_descriptions_policy import (
+    _load_tool_descriptions_override,
+    apply_tool_descriptions_policy,
+)
+
+from core.agent import tool_descriptions_policy
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "tool-descriptions.json"
+    monkeypatch.setattr(tool_descriptions_policy, "_TOOL_DESCRIPTIONS_SOT_PATH", sot)
+    monkeypatch.delenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_tool_descriptions_override() is None
+
+
+def test_load_returns_none_when_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_tool_descriptions_override() is None
+
+
+def test_load_returns_none_when_type_violation(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"bash": {"description": ["not", "str"]}})
+    assert _load_tool_descriptions_override() is None
+
+
+def test_load_valid_payload(isolated_sot: Path) -> None:
+    payload = {"bash": {"description": "overridden", "hints": ["hint1", "hint2"]}}
+    _write(isolated_sot, payload)
+    result = _load_tool_descriptions_override()
+    assert result == payload
+
+
+def test_load_unknown_field_in_entry_ignored(isolated_sot: Path) -> None:
+    """Forward-compat — entry 내 알려지지 않은 field 는 무시."""
+    _write(isolated_sot, {"bash": {"description": "x", "unknown_field": "ignored"}})
+    result = _load_tool_descriptions_override()
+    assert result == {"bash": {"description": "x"}}
+
+
+def test_strict_load_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", str(tmp_path / "nope.json"))
+    with pytest.raises(RuntimeError, match="GEODE_TOOL_DESCRIPTIONS_OVERRIDE"):
+        _load_tool_descriptions_override()
+
+
+def test_strict_load_raises_on_hints_type(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"bash": {"hints": "not-a-list"}}), encoding="utf-8")
+    monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", str(bad))
+    with pytest.raises(RuntimeError, match="hints"):
+        _load_tool_descriptions_override()
+
+
+# Apply -----------------------------------------------------------------------
+
+
+def _tools(*specs: tuple[str, str]) -> list[dict[str, Any]]:
+    return [{"name": n, "description": d} for n, d in specs]
+
+
+def test_apply_none_is_noop() -> None:
+    tools = _tools(("bash", "default bash"))
+    assert apply_tool_descriptions_policy(tools, None) == tools
+
+
+def test_apply_empty_dict_is_noop() -> None:
+    tools = _tools(("bash", "default bash"))
+    assert apply_tool_descriptions_policy(tools, {}) == tools
+
+
+def test_apply_description_override() -> None:
+    tools = _tools(("bash", "default"), ("read", "default read"))
+    out = apply_tool_descriptions_policy(tools, {"bash": {"description": "EVOLVED"}})
+    by_name = {t["name"]: t["description"] for t in out}
+    assert by_name["bash"] == "EVOLVED"
+    assert by_name["read"] == "default read"  # 무관 tool 영향 없음
+
+
+def test_apply_hints_append_to_default_description() -> None:
+    tools = _tools(("bash", "default bash"))
+    out = apply_tool_descriptions_policy(tools, {"bash": {"hints": ["Quote paths", "Avoid -i"]}})
+    desc = out[0]["description"]
+    assert "default bash" in desc
+    assert "Hints:" in desc
+    assert "- Quote paths" in desc
+    assert "- Avoid -i" in desc
+
+
+def test_apply_description_and_hints_combined() -> None:
+    tools = _tools(("bash", "default"))
+    out = apply_tool_descriptions_policy(
+        tools, {"bash": {"description": "NEW DESC", "hints": ["h1"]}}
+    )
+    desc = out[0]["description"]
+    assert desc.startswith("NEW DESC")
+    assert "- h1" in desc
+
+
+def test_apply_unknown_tool_in_policy_ignored() -> None:
+    """policy 에 등록된 tool 이 input list 에 없으면 영향 없음."""
+    tools = _tools(("bash", "default"))
+    out = apply_tool_descriptions_policy(tools, {"unknown_tool": {"description": "X"}})
+    assert out == tools
+
+
+def test_apply_deepcopies_so_input_not_mutated() -> None:
+    """원본 tool dict 오염 방지 (S0b deep-copy 패턴)."""
+    tools = _tools(("bash", "default"))
+    original_desc = tools[0]["description"]
+    apply_tool_descriptions_policy(tools, {"bash": {"description": "EVOLVED"}})
+    assert tools[0]["description"] == original_desc
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_helpers_imports_tool_descriptions_reader() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/loop/_helpers.py").read_text(encoding="utf-8")
+    assert "_load_tool_descriptions_override" in src
+    assert "apply_tool_descriptions_policy" in src
+
+
+def test_helpers_applies_descriptions_before_tool_policy() -> None:
+    """tool_descriptions 가 tool_policy 보다 먼저 적용돼야 함 — policy 의
+    forbidden/priority 가 갱신된 description 기반으로 판단 가능."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/loop/_helpers.py").read_text(encoding="utf-8")
+    desc_pos = src.find("apply_tool_descriptions_policy(tools,")
+    policy_pos = src.find("apply_tool_policy(tools,")
+    assert desc_pos > 0 and policy_pos > 0
+    assert desc_pos < policy_pos
+
+
+# Path constant ---------------------------------------------------------------
+
+
+def test_path_constant_in_core_paths() -> None:
+    from core.paths import GLOBAL_TOOL_DESCRIPTIONS_PATH
+
+    assert GLOBAL_TOOL_DESCRIPTIONS_PATH.name == "tool-descriptions.json"
+
+
+# Env wiring in train.py ------------------------------------------------------
+
+
+def test_train_py_sets_descriptions_override_env() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_TOOL_DESCRIPTIONS_OVERRIDE" in src
+    assert "GLOBAL_TOOL_DESCRIPTIONS_PATH" in src
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_tool_descriptions_json_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core" / "agent").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "tool-descriptions.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("tool_descriptions_policy.py" in h for h in hits), (
+        f"tool-descriptions.json 이 core/agent/tool_descriptions_policy.py 에서 발견되어야 함. hits={hits}"
+    )


### PR DESCRIPTION
## Summary
- ADR-013 의 첫 신규 mutation 표면 — mutator 가 도구 description + hint 만 JSON 으로 mutate.
- 5-element 패턴 (S0a 검증) 적용: SoT 파일 + Path constant + Reader + Inference entry + Env var.
- 19 invariant test — reader / apply / wiring 순서 / path / env / ALIVE marker.

## Why
ADR-012 S0a 가 검증한 JSON mutation 패턴을 6 표면 (T1-T6) 으로 확장한 ADR-013 의 첫 PR. T1 (tool descriptions) 은 Petri 17-dim 의 `broken_tool_use` (유일한 양의 압력 dim) 에 직접 영향 — 도구 선택 정확도 가 양의 압력 coverage 의 핵심 지렛대. AlphaEvolve 식 코드 mutation 은 명시적 배제 (자기수정 재귀 / silent breakage / Goodhart on benchmark / dependency chain 4 risk) — 모든 6 표면이 JSON-only.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_POLICIES_DIR / "tool-descriptions.json"` (in-repo, ratchet-tracked) |
| `core/agent/tool_descriptions_policy.py` | 신규 reader — `_load_tool_descriptions_override` + `apply_tool_descriptions_policy`, schema `{tool_name: {description: str, hints: [str]}}` |
| `core/agent/loop/_helpers.py:get_agentic_tools` | 진입점 — base+registry+MCP merge 직후 + `apply_tool_policy` filter **직전** (description override 가 먼저 적용돼야 policy 의 forbidden/priority 가 갱신된 description 으로 판단) |
| `autoresearch/train.py` | env wiring — SoT 파일 존재 시 `GEODE_TOOL_DESCRIPTIONS_OVERRIDE` inject (audit subprocess 가 strict-fail 로 로드) |
| `tests/test_t1_tool_descriptions.py` | 19 invariant test |
| `CHANGELOG.md` | `### Added` PR-T1 entry |

## Resolution order
1. `GEODE_TOOL_DESCRIPTIONS_OVERRIDE` env var — audit subprocess, strict-fail.
2. `autoresearch/state/policies/tool-descriptions.json` (in-repo, ratchet-tracked).
3. `None` — no-op (default description 유지).

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 5/5 | Implemented | SoT + Path + Reader + Entry + Env 모두 코드 양성 |
| `apply` deep-copy | Implemented | caller 의 `_BASE_TOOLS` module-level constant 오염 방지 |
| Descriptions before tool_policy | Implemented | `_helpers.py` 순서 invariant test 로 pin |
| Forward-compat | Implemented | entry 내 unknown field `_coerce` 에서 자동 제거 |
| Graceful vs strict | Implemented | daily-run = WARNING+None, audit subprocess (env) = RuntimeError |
| ALIVE marker | Implemented | `tool-descriptions.json` grep 이 `core/agent/tool_descriptions_policy.py` 에서 양성 |

## Codex MCP review (fix-up applied)
- **#5 FAIL → fixed**: CHANGELOG + docstring 가 `~/.geode/self-improving-loop/tool-descriptions.json` (operator-local) fallback 을 주장했으나 reader 는 env + `_TOOL_POLICY_SOT_PATH`(=`autoresearch/state/policies/tool-descriptions.json`) 만 확인. operator-local 구현 X → CHANGELOG/docstring 정합화. (S0a/S0b/S0c docstring 의 동일 inheritance 는 별도 backfill PR.)
- 다른 7/8 PASS — 5-element, order, deep-copy, graceful/strict asymmetry, Tier 2 untouched, mutator scope (TARGET_KINDS 미확장), 19 test coverage.

## Verification
- [x] ruff check clean (core/agent + autoresearch + tests)
- [x] ruff format clean
- [x] mypy core/ clean (319 files)
- [x] pytest tests/test_t1_tool_descriptions.py — 19/19 pass
- [x] regression smoke — S0a / S0b / S0c / S1 / S2 / S6 / 5-slot audit / minimal-1/2 — 128 pass
- [x] Tier 2 untouched (bootstrap / runner / fitness gate / CI ratchet / HookSystem / mutator contract / importlinter / version stamp)

## Reference
ADR-013 — `docs/adr/ADR-013-mutation-surface-expansion-via-json-schema.md`
Frontier: OpenAI function calling docs + Anthropic tool-use guide ("clearer descriptions yield more accurate selection").
Codex MCP review: 2026-05-21, 7/8 PASS, FAIL #5 corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)