### PR TITLE
feat(backfill-sot): 3-layer SoT chain + env-as-SoT for 4 mutation readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,10 @@ functional change.
   env 모두 `_OVERRIDE` + `_STRICT=1` 동반 set — 기존 fail-fast 보존.
   4 reader 의 docstring 에서 stale `operator-local` 주장 (S0a/b/c 의
   Codex MCP catch 와 동일 inheritance) 도 함께 정합화 — 실제 3-layer
-  chain 으로 갱신. 27 신규 invariant test (shared resolver 8 + 4 reader 별
-  graceful/priority 19) + 5 기존 strict test 갱신 (`_STRICT=1` 명시).
-  Read-write parity 보존 — `apply_*_policy` 의 deep-copy 패턴 (S0b)
-  여전히 유효.
+  chain 으로 갱신. **19 신규 invariant test** (shared resolver 9 +
+  reader 별 env-graceful/operator-local 10) + **8 기존 strict test
+  갱신** (`_STRICT=1` 명시). Read-write parity 보존 — `apply_*_policy`
+  의 deep-copy 패턴 (S0b) 여전히 유효.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,35 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-BACKFILL-SOT — Operator-local SoT layer + env-as-SoT for 4 mutation
+  surface readers (post-PR-T1 #1416 fix).** PR #1416 의 Codex MCP FAIL #5
+  (CHANGELOG/PR-body parity 위반 — `~/.geode/self-improving-loop/...`
+  operator-local fallback 을 주장했으나 reader 코드 부재) 의 근원 GAP 을
+  메움. 4 reader (tool_policy / reflection / decomposition / tool_descriptions)
+  가 **3-layer SoT chain** 으로 전환 — 운영자 가 env 만 set 해도 SoT 처럼
+  graceful 로 다룰 수 있고, audit subprocess 는 명시적 STRICT flag opt-in.
+  **신규 helper** `core/self_improving_loop/sot_resolution.py` —
+  `resolve_sot(env_var, operator_local, in_repo) → SoTSelection(path,
+  strict) | None` 단일 함수, 4 reader 가 공유. `<X>_STRICT` env name 은
+  `<X>_OVERRIDE` 에서 `removesuffix("_OVERRIDE") + "_STRICT"` 로 자동
+  파생 — per-reader 등록 불필요. **resolution order**: (1) env var
+  `GEODE_<X>_OVERRIDE` — `GEODE_<X>_STRICT=1` 동반 시 strict-fail, 그렇지
+  않으면 graceful (no fall-through, env 가 authoritative). (2)
+  operator-local `~/.geode/self-improving-loop/<file>.json` (graceful).
+  (3) in-repo `autoresearch/state/policies/<file>.json` (graceful,
+  ratchet-tracked). (4) `None` → no-op. **`core/paths.py`** 에 4
+  `OPERATOR_LOCAL_*_PATH` 상수 추가 (`GLOBAL_SELF_IMPROVING_LOOP_DIR /
+  <file>.json`). **`autoresearch/train.py`** 의 audit subprocess 가 4
+  env 모두 `_OVERRIDE` + `_STRICT=1` 동반 set — 기존 fail-fast 보존.
+  4 reader 의 docstring 에서 stale `operator-local` 주장 (S0a/b/c 의
+  Codex MCP catch 와 동일 inheritance) 도 함께 정합화 — 실제 3-layer
+  chain 으로 갱신. 27 신규 invariant test (shared resolver 8 + 4 reader 별
+  graceful/priority 19) + 5 기존 strict test 갱신 (`_STRICT=1` 명시).
+  Read-write parity 보존 — `apply_*_policy` 의 deep-copy 패턴 (S0b)
+  여전히 유효.
+
 ### Changed
 
 - **PR-S6-UPDATE — `bench_means` schema 2026 frontier 갱신 (4 outdated → 7).**

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -653,15 +653,23 @@ def run_audit(
         GLOBAL_TOOL_POLICY_PATH,
     )
 
+    # PR-BACKFILL-SOT (2026-05-21) — audit subprocess sets both _OVERRIDE
+    # (path) and _STRICT=1 (fail-fast flag). With the 3-layer SoT chain
+    # (env → operator-local → in-repo), env path defaults to graceful for
+    # operator daily use; audit explicitly opts into strict for mutation
+    # cycle fidelity.
     if GLOBAL_TOOL_POLICY_PATH.is_file():
         env["GEODE_TOOL_POLICY_OVERRIDE"] = str(GLOBAL_TOOL_POLICY_PATH)
+        env["GEODE_TOOL_POLICY_STRICT"] = "1"
     if GLOBAL_REFLECTION_POLICY_PATH.is_file():
         env["GEODE_REFLECTION_POLICY_OVERRIDE"] = str(GLOBAL_REFLECTION_POLICY_PATH)
+        env["GEODE_REFLECTION_POLICY_STRICT"] = "1"
     if GLOBAL_DECOMPOSITION_POLICY_PATH.is_file():
         env["GEODE_DECOMPOSITION_POLICY_OVERRIDE"] = str(GLOBAL_DECOMPOSITION_POLICY_PATH)
-    # ADR-013 T1 (2026-05-21) — tool descriptions override env wiring.
+        env["GEODE_DECOMPOSITION_POLICY_STRICT"] = "1"
     if GLOBAL_TOOL_DESCRIPTIONS_PATH.is_file():
         env["GEODE_TOOL_DESCRIPTIONS_OVERRIDE"] = str(GLOBAL_TOOL_DESCRIPTIONS_PATH)
+        env["GEODE_TOOL_DESCRIPTIONS_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/decomposition_policy.py
+++ b/core/agent/decomposition_policy.py
@@ -23,30 +23,43 @@ prompt 를 로드하지만 ``decomposition.json`` 과는 미연결 (PR-AUDIT-5SL
 빈 정책 / 누락 / 부적합 schema → no-op (load_prompt 결과 그대로 사용).
 ``system_prompt`` 가 있으면 다른 두 field 는 무시 (override 우선).
 
-**Resolution order** (S0a/S0b 와 동일):
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21, shared
+:mod:`core.self_improving_loop.sot_resolution`):
 
-1. ``GEODE_DECOMPOSITION_POLICY_OVERRIDE`` env var — audit subprocess, strict.
-2. ``~/.geode/self-improving-loop/decomposition.json`` — daily-run, graceful.
-3. ``None`` — no-op.
+1. ``GEODE_DECOMPOSITION_POLICY_OVERRIDE`` env var — explicit override.
+
+   - With ``GEODE_DECOMPOSITION_POLICY_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+
+2. ``~/.geode/self-improving-loop/decomposition.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/decomposition.json`` — in-repo, graceful.
+4. ``None`` — no-op.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
-from core.paths import GLOBAL_DECOMPOSITION_POLICY_PATH
+from core.paths import (
+    GLOBAL_DECOMPOSITION_POLICY_PATH,
+    OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH,
+)
+from core.self_improving_loop.sot_resolution import resolve_sot
 
 log = logging.getLogger(__name__)
 
 _DECOMPOSITION_POLICY_OVERRIDE_ENV = "GEODE_DECOMPOSITION_POLICY_OVERRIDE"
 
 _DECOMPOSITION_POLICY_SOT_PATH = GLOBAL_DECOMPOSITION_POLICY_PATH
-"""Cross-process SoT path (S0c, 2026-05-21). module-local alias 로 테스트
-가 monkeypatch 가능 (path-literal guard contract)."""
+"""Cross-process in-repo SoT path (S0c, 2026-05-21). module-local alias 로
+테스트가 monkeypatch 가능 (path-literal guard contract)."""
+
+_OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH = OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH
+"""Operator-local SoT path (PR-BACKFILL-SOT, 2026-05-21). Module-local
+alias kept for monkeypatch in tests."""
 
 
 _FIELD_SYSTEM_PROMPT = "system_prompt"
@@ -56,20 +69,20 @@ _ALL_FIELDS = frozenset({_FIELD_SYSTEM_PROMPT, _FIELD_PREFIX, _FIELD_SUFFIX})
 
 
 def _load_decomposition_policy_override() -> dict[str, str] | None:
-    """Return active decomposition policy, or ``None`` when no override applies.
+    """Return active decomposition policy, or ``None`` when no SoT applies.
 
-    Resolution order:
-
-    1. ``GEODE_DECOMPOSITION_POLICY_OVERRIDE`` env var (audit subprocess) — strict.
-    2. ``~/.geode/self-improving-loop/decomposition.json`` (daily run) — graceful.
-    3. ``None`` — no policy.
+    Resolution order — see module docstring (3-layer chain).
     """
-    override_path = os.environ.get(_DECOMPOSITION_POLICY_OVERRIDE_ENV)
-    if override_path:
-        return _strict_load(Path(override_path))
-    if _DECOMPOSITION_POLICY_SOT_PATH.is_file():
-        return _graceful_load(_DECOMPOSITION_POLICY_SOT_PATH)
-    return None
+    selection = resolve_sot(
+        env_var=_DECOMPOSITION_POLICY_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH,
+        in_repo=_DECOMPOSITION_POLICY_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
 
 
 def _strict_load(path: Path) -> dict[str, str]:

--- a/core/agent/reflection_policy.py
+++ b/core/agent/reflection_policy.py
@@ -22,11 +22,17 @@
 는 mutate 대상이 아님 — record_reflection 의 typed payload contract 는
 유지 (`hypotheses` / `confidence` / `next_action_hint`).
 
-**Resolution order** (`wrapper-sections.json` + `tool_policy.py` 와 동일):
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21, shared
+:mod:`core.self_improving_loop.sot_resolution`):
 
-1. ``GEODE_REFLECTION_POLICY_OVERRIDE`` env var — audit subprocess, strict.
-2. ``~/.geode/self-improving-loop/reflection.json`` — daily-run, graceful.
-3. ``None`` — no-op.
+1. ``GEODE_REFLECTION_POLICY_OVERRIDE`` env var — explicit override.
+
+   - With ``GEODE_REFLECTION_POLICY_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+
+2. ``~/.geode/self-improving-loop/reflection.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/reflection.json`` — in-repo, graceful.
+4. ``None`` — no-op.
 
 **Read-Write parity** (S0a Codex MCP lesson): ``write_policy()`` 가
 ``dict[str, str]`` 만 직렬화하므로 reader 는 string payload 그대로 수용.
@@ -39,19 +45,23 @@ from __future__ import annotations
 import copy
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
-from core.paths import GLOBAL_REFLECTION_POLICY_PATH
+from core.paths import GLOBAL_REFLECTION_POLICY_PATH, OPERATOR_LOCAL_REFLECTION_POLICY_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
 
 log = logging.getLogger(__name__)
 
 _REFLECTION_POLICY_OVERRIDE_ENV = "GEODE_REFLECTION_POLICY_OVERRIDE"
 
 _REFLECTION_POLICY_SOT_PATH = GLOBAL_REFLECTION_POLICY_PATH
-"""Cross-process SoT path (S0b, 2026-05-21). module-local alias 로 테스트
-가 monkeypatch 가능 (path-literal guard contract)."""
+"""Cross-process in-repo SoT path (S0b, 2026-05-21). module-local alias 로
+테스트가 monkeypatch 가능 (path-literal guard contract)."""
+
+_OPERATOR_LOCAL_REFLECTION_POLICY_PATH = OPERATOR_LOCAL_REFLECTION_POLICY_PATH
+"""Operator-local SoT path (PR-BACKFILL-SOT, 2026-05-21). Module-local
+alias kept for monkeypatch in tests."""
 
 
 _FIELD_DESCRIPTION = "description"
@@ -60,20 +70,20 @@ _ALL_FIELDS = frozenset({_FIELD_DESCRIPTION, _FIELD_SYSTEM_PROMPT})
 
 
 def _load_reflection_policy_override() -> dict[str, str] | None:
-    """Return active reflection policy, or ``None`` when no override applies.
+    """Return active reflection policy, or ``None`` when no SoT applies.
 
-    Resolution order:
-
-    1. ``GEODE_REFLECTION_POLICY_OVERRIDE`` env var (audit subprocess) — strict.
-    2. ``~/.geode/self-improving-loop/reflection.json`` (daily run) — graceful.
-    3. ``None`` — no policy.
+    Resolution order — see module docstring (3-layer chain).
     """
-    override_path = os.environ.get(_REFLECTION_POLICY_OVERRIDE_ENV)
-    if override_path:
-        return _strict_load(Path(override_path))
-    if _REFLECTION_POLICY_SOT_PATH.is_file():
-        return _graceful_load(_REFLECTION_POLICY_SOT_PATH)
-    return None
+    selection = resolve_sot(
+        env_var=_REFLECTION_POLICY_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_REFLECTION_POLICY_PATH,
+        in_repo=_REFLECTION_POLICY_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
 
 
 def _strict_load(path: Path) -> dict[str, str]:

--- a/core/agent/tool_descriptions_policy.py
+++ b/core/agent/tool_descriptions_policy.py
@@ -23,11 +23,17 @@ dim) 직접 영향.
 
 빈 entry / 누락 tool / 부적합 schema → no-op (default description 유지).
 
-**Resolution order** (``wrapper-sections.json`` 패턴 동일):
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21, shared
+:mod:`core.self_improving_loop.sot_resolution`):
 
-1. ``GEODE_TOOL_DESCRIPTIONS_OVERRIDE`` env var — audit subprocess, strict.
-2. ``autoresearch/state/policies/tool-descriptions.json`` (in-repo, ratchet-tracked).
-3. ``None`` — no-op (default description 사용).
+1. ``GEODE_TOOL_DESCRIPTIONS_OVERRIDE`` env var — explicit override.
+
+   - With ``GEODE_TOOL_DESCRIPTIONS_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+
+2. ``~/.geode/self-improving-loop/tool-descriptions.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/tool-descriptions.json`` — in-repo, graceful.
+4. ``None`` — no-op (default description 사용).
 
 **Frontier**: OpenAI function calling docs — "clearer descriptions yield
 more accurate selection" + Anthropic tool-use guide.
@@ -38,19 +44,22 @@ from __future__ import annotations
 import copy
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
-from core.paths import GLOBAL_TOOL_DESCRIPTIONS_PATH
+from core.paths import GLOBAL_TOOL_DESCRIPTIONS_PATH, OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
 
 log = logging.getLogger(__name__)
 
 _TOOL_DESCRIPTIONS_OVERRIDE_ENV = "GEODE_TOOL_DESCRIPTIONS_OVERRIDE"
 
 _TOOL_DESCRIPTIONS_SOT_PATH = GLOBAL_TOOL_DESCRIPTIONS_PATH
-"""Cross-process SoT path (T1, 2026-05-21). module-local alias 로 테스트
-가 monkeypatch 가능."""
+"""Cross-process in-repo SoT path (T1, 2026-05-21). module-local alias."""
+
+_OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH = OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH
+"""Operator-local SoT path (PR-BACKFILL-SOT, 2026-05-21). Module-local
+alias kept for monkeypatch in tests."""
 
 
 _FIELD_DESCRIPTION = "description"
@@ -58,13 +67,20 @@ _FIELD_HINTS = "hints"
 
 
 def _load_tool_descriptions_override() -> dict[str, dict[str, Any]] | None:
-    """Return active tool-descriptions override, or ``None`` if no SoT."""
-    override_path = os.environ.get(_TOOL_DESCRIPTIONS_OVERRIDE_ENV)
-    if override_path:
-        return _strict_load(Path(override_path))
-    if _TOOL_DESCRIPTIONS_SOT_PATH.is_file():
-        return _graceful_load(_TOOL_DESCRIPTIONS_SOT_PATH)
-    return None
+    """Return active tool-descriptions override, or ``None`` if no SoT.
+
+    Resolution order — see module docstring (3-layer chain).
+    """
+    selection = resolve_sot(
+        env_var=_TOOL_DESCRIPTIONS_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH,
+        in_repo=_TOOL_DESCRIPTIONS_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
 
 
 def _strict_load(path: Path) -> dict[str, dict[str, Any]]:

--- a/core/agent/tool_policy.py
+++ b/core/agent/tool_policy.py
@@ -19,35 +19,44 @@ reader 의 패턴을 그대로 차용해 ``tool-policy.json`` 의 정책을 도�
 빈 정책 / 누락 / 부적합 schema → no-op (현재 행동 유지). 정책이 ALIVE
 신호를 내려면 셋 중 하나라도 비어 있지 않아야 한다.
 
-**Resolution order** (``_load_wrapper_override`` 와 동일):
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21, shared
+:mod:`core.self_improving_loop.sot_resolution`):
 
-1. ``GEODE_TOOL_POLICY_OVERRIDE`` env var — audit subprocess hook,
-   strict load (schema 실패 시 RuntimeError 로 fail-fast).
-2. ``~/.geode/self-improving-loop/tool-policy.json`` — daily-run SoT,
-   graceful load (schema 실패 시 WARNING + ``None`` 반환).
-3. ``None`` — no-op (도구 목록 그대로).
+1. ``GEODE_TOOL_POLICY_OVERRIDE`` env var — explicit override.
+
+   - With ``GEODE_TOOL_POLICY_STRICT=1`` (audit subprocess): strict load,
+     RuntimeError on missing/unparseable (fail-fast for mutation audit).
+   - Without strict flag (operator daily): graceful load, returns ``None``
+     on issue (no fall-through to lower layers; env is authoritative).
+
+2. ``~/.geode/self-improving-loop/tool-policy.json`` — operator-local SoT,
+   graceful load (per-machine override outside the in-repo ratchet).
+3. ``autoresearch/state/policies/tool-policy.json`` — in-repo,
+   ratchet-tracked, graceful load (default policy site).
+4. ``None`` — no-op (도구 목록 그대로).
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
-from core.paths import GLOBAL_TOOL_POLICY_PATH
+from core.paths import GLOBAL_TOOL_POLICY_PATH, OPERATOR_LOCAL_TOOL_POLICY_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
 
 log = logging.getLogger(__name__)
 
 _TOOL_POLICY_OVERRIDE_ENV = "GEODE_TOOL_POLICY_OVERRIDE"
 
 _TOOL_POLICY_SOT_PATH = GLOBAL_TOOL_POLICY_PATH
-"""Cross-process SoT path shared with :mod:`autoresearch.train` (S0a, 2026-05-21).
+"""Cross-process in-repo SoT path shared with :mod:`autoresearch.train`
+(S0a, 2026-05-21). Module-local alias kept for monkeypatch in tests."""
 
-``wrapper-sections.json`` reader 와 동일하게 module-local alias 를 둬서
-테스트가 ``core.agent.tool_policy._TOOL_POLICY_SOT_PATH`` 를 monkeypatch
-할 수 있도록 한다 (path-literal guard contract)."""
+_OPERATOR_LOCAL_TOOL_POLICY_PATH = OPERATOR_LOCAL_TOOL_POLICY_PATH
+"""Operator-local SoT path (PR-BACKFILL-SOT, 2026-05-21). Module-local
+alias kept for monkeypatch in tests."""
 
 
 # Schema field 이름들 — 외부 정책 파일과 1:1 mapping.
@@ -58,20 +67,20 @@ _ALL_FIELDS = frozenset({_FIELD_ALLOWED, _FIELD_FORBIDDEN, _FIELD_PRIORITY})
 
 
 def _load_tool_policy_override() -> dict[str, list[str]] | None:
-    """Return the active tool policy dict, or ``None`` when no override applies.
+    """Return the active tool policy dict, or ``None`` when no SoT applies.
 
-    Resolution order:
-
-    1. ``GEODE_TOOL_POLICY_OVERRIDE`` env var (audit subprocess) — strict.
-    2. ``~/.geode/self-improving-loop/tool-policy.json`` (daily run) — graceful.
-    3. ``None`` — no policy active.
+    Resolution order — see module docstring (3-layer chain).
     """
-    override_path = os.environ.get(_TOOL_POLICY_OVERRIDE_ENV)
-    if override_path:
-        return _strict_load(Path(override_path))
-    if _TOOL_POLICY_SOT_PATH.is_file():
-        return _graceful_load(_TOOL_POLICY_SOT_PATH)
-    return None
+    selection = resolve_sot(
+        env_var=_TOOL_POLICY_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_TOOL_POLICY_PATH,
+        in_repo=_TOOL_POLICY_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
 
 
 def _strict_load(path: Path) -> dict[str, list[str]]:

--- a/core/paths.py
+++ b/core/paths.py
@@ -95,6 +95,15 @@ GLOBAL_RETRIEVAL_POLICY_PATH = GLOBAL_POLICIES_DIR / "retrieval.json"
 GLOBAL_REFLECTION_POLICY_PATH = GLOBAL_POLICIES_DIR / "reflection.json"
 # ADR-013 T1 (2026-05-21) — Tool descriptions mutation SoT.
 GLOBAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_POLICIES_DIR / "tool-descriptions.json"
+# PR-BACKFILL-SOT (2026-05-21) — operator-local SoT layer for the 4 active
+# mutation surface readers (tool_policy / reflection / decomposition /
+# tool_descriptions). Per-machine overrides without touching in-repo
+# ratchet-tracked files. Resolution order: env-override (strict/graceful)
+# → operator-local (graceful) → in-repo (graceful) → None.
+OPERATOR_LOCAL_TOOL_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-policy.json"
+OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "decomposition.json"
+OPERATOR_LOCAL_REFLECTION_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "reflection.json"
+OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-descriptions.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/core/self_improving_loop/sot_resolution.py
+++ b/core/self_improving_loop/sot_resolution.py
@@ -1,0 +1,87 @@
+"""Shared 3-layer SoT path resolution for the 4 active mutation-surface readers.
+
+Used by ``core.agent.tool_policy``, ``core.agent.reflection_policy``,
+``core.agent.decomposition_policy``, and ``core.agent.tool_descriptions_policy``
+to keep their resolution order coherent. Replaces the previous inline
+2-layer chain (env-strict → in-repo-graceful), which had a stale docstring
+claim about an unimplemented operator-local layer (Codex MCP catch on PR
+#1416, 2026-05-21).
+
+**Resolution order**:
+
+1. ``GEODE_<X>_OVERRIDE`` env var (file path) — explicit override:
+
+   - With ``GEODE_<X>_STRICT=1`` (audit subprocess from ``autoresearch.train``):
+     return ``strict=True`` → caller raises ``RuntimeError`` on
+     missing/unparseable. Preserves fail-fast for the mutation audit cycle.
+   - Without strict flag (operator set env directly): return
+     ``strict=False`` → caller does graceful load and returns ``None`` on
+     issue. **No fall-through** — env override is authoritative; operator
+     gets a clear no-op signal rather than silent fallback to other layers.
+
+2. **Operator-local** ``~/.geode/self-improving-loop/<file>.json`` — per-
+   machine override (graceful). Useful when an operator wants policies that
+   don't enter the in-repo ratchet (e.g. experimenting locally).
+
+3. **In-repo** ``autoresearch/state/policies/<file>.json`` — ratchet-
+   tracked baseline (graceful). Default policy site populated by the
+   mutator's ``write_policy()``.
+
+4. ``None`` — no SoT available, reader returns ``None``.
+
+The ``strict`` flag is conveyed back to the caller so each reader keeps its
+own ``_strict_load`` / ``_graceful_load`` pair (schema validation is
+reader-specific). This module only owns the **chain ordering** and the
+strict-flag derivation.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_OVERRIDE_SUFFIX = "_OVERRIDE"
+_STRICT_SUFFIX = "_STRICT"
+
+
+@dataclass(frozen=True)
+class SoTSelection:
+    """Result of :func:`resolve_sot`: which SoT to load and with what strictness."""
+
+    path: Path
+    strict: bool
+
+
+def resolve_sot(
+    *,
+    env_var: str,
+    operator_local: Path,
+    in_repo: Path,
+) -> SoTSelection | None:
+    """Resolve the active SoT path + strict flag for a mutation surface reader.
+
+    Args:
+        env_var: Env var name pointing to a SoT file path. Must end in
+            ``_OVERRIDE`` so the matching strict flag can be derived as
+            ``<prefix>_STRICT``.
+        operator_local: ``~/.geode/self-improving-loop/<file>.json`` candidate.
+        in_repo: ``autoresearch/state/policies/<file>.json`` candidate.
+
+    Returns:
+        ``SoTSelection(path, strict)`` for the highest-priority layer present,
+        or ``None`` if no layer is available.
+    """
+    override_path = os.environ.get(env_var)
+    if override_path:
+        strict_env = env_var.removesuffix(_OVERRIDE_SUFFIX) + _STRICT_SUFFIX
+        is_strict = os.environ.get(strict_env) == "1"
+        return SoTSelection(Path(override_path), strict=is_strict)
+    if operator_local.is_file():
+        return SoTSelection(operator_local, strict=False)
+    if in_repo.is_file():
+        return SoTSelection(in_repo, strict=False)
+    return None
+
+
+__all__ = ["SoTSelection", "resolve_sot"]

--- a/tests/test_s0a_tool_policy_reader.py
+++ b/tests/test_s0a_tool_policy_reader.py
@@ -26,11 +26,14 @@ from core.agent import tool_policy
 
 @pytest.fixture
 def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """Monkeypatch ``_TOOL_POLICY_SOT_PATH`` to tmp_path so tests don't read
-    or pollute the operator's real SoT at ``~/.geode/self-improving-loop/``."""
+    """Isolate all 3 SoT layers (env / operator-local / in-repo) to tmp_path
+    so tests don't read or pollute the operator's real artefacts."""
     sot = tmp_path / "tool-policy.json"
+    operator_local = tmp_path / "operator-local-tool-policy.json"
     monkeypatch.setattr(tool_policy, "_TOOL_POLICY_SOT_PATH", sot)
+    monkeypatch.setattr(tool_policy, "_OPERATOR_LOCAL_TOOL_POLICY_PATH", operator_local)
     monkeypatch.delenv("GEODE_TOOL_POLICY_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_TOOL_POLICY_STRICT", raising=False)
     yield sot
 
 
@@ -91,9 +94,10 @@ def test_load_unknown_fields_ignored(isolated_sot: Path) -> None:
 def test_strict_load_via_env_var_raises_on_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``GEODE_TOOL_POLICY_OVERRIDE`` 가 가리키는 파일이 없으면 RuntimeError."""
+    """audit subprocess (``_OVERRIDE`` + ``_STRICT=1``) — missing file → RuntimeError."""
     missing = tmp_path / "nope.json"
     monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(missing))
+    monkeypatch.setenv("GEODE_TOOL_POLICY_STRICT", "1")
     with pytest.raises(RuntimeError, match="GEODE_TOOL_POLICY_OVERRIDE"):
         _load_tool_policy_override()
 
@@ -101,13 +105,54 @@ def test_strict_load_via_env_var_raises_on_missing(
 def test_strict_load_via_env_var_raises_on_type_violation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """audit subprocess 는 type 위반 (list 도 string 도 아님) 시 RuntimeError (fail-fast).
+    """audit subprocess (``_OVERRIDE`` + ``_STRICT=1``) — type 위반 RuntimeError (fail-fast).
     Producer parity 확장 후 string 은 valid → dict/int 등 다른 type 만 violation."""
     bad = tmp_path / "bad.json"
     bad.write_text(json.dumps({"forbidden_tools": {"nested": "dict"}}), encoding="utf-8")
     monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(bad))
+    monkeypatch.setenv("GEODE_TOOL_POLICY_STRICT", "1")
     with pytest.raises(RuntimeError, match="forbidden_tools"):
         _load_tool_policy_override()
+
+
+def test_env_var_without_strict_flag_is_graceful_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-BACKFILL-SOT (2026-05-21) — env var alone (no ``_STRICT=1``)
+    treats env path graceful: missing file → ``None`` (no fall-through)."""
+    missing = tmp_path / "nope.json"
+    monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(missing))
+    monkeypatch.delenv("GEODE_TOOL_POLICY_STRICT", raising=False)
+    assert _load_tool_policy_override() is None
+
+
+def test_env_var_without_strict_flag_is_graceful_on_invalid_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Operator daily use — broken JSON in env-pointed file → ``None`` + WARNING."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json {", encoding="utf-8")
+    monkeypatch.setenv("GEODE_TOOL_POLICY_OVERRIDE", str(bad))
+    monkeypatch.delenv("GEODE_TOOL_POLICY_STRICT", raising=False)
+    assert _load_tool_policy_override() is None
+
+
+def test_operator_local_layer_read_when_in_repo_absent(isolated_sot: Path) -> None:
+    """PR-BACKFILL-SOT (2026-05-21) — ``~/.geode/self-improving-loop/tool-policy.json``
+    (operator-local) layer is read when env unset + in-repo absent."""
+    operator_local = isolated_sot.parent / "operator-local-tool-policy.json"
+    operator_local.write_text(json.dumps({"allowed_tools": ["bash"]}), encoding="utf-8")
+    assert not isolated_sot.exists()
+    assert _load_tool_policy_override() == {"allowed_tools": ["bash"]}
+
+
+def test_operator_local_layer_takes_priority_over_in_repo(isolated_sot: Path) -> None:
+    """3-layer chain — operator-local > in-repo when both present."""
+    operator_local = isolated_sot.parent / "operator-local-tool-policy.json"
+    operator_local.write_text(json.dumps({"allowed_tools": ["from-ops"]}), encoding="utf-8")
+    _write(isolated_sot, {"allowed_tools": ["from-repo"]})
+    result = _load_tool_policy_override()
+    assert result == {"allowed_tools": ["from-ops"]}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_s0b_reflection_reader.py
+++ b/tests/test_s0b_reflection_reader.py
@@ -21,10 +21,13 @@ from core.agent import reflection_policy
 
 @pytest.fixture
 def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """Monkeypatch ``_REFLECTION_POLICY_SOT_PATH`` to tmp_path."""
+    """Isolate all 3 SoT layers (env / operator-local / in-repo) to tmp_path."""
     sot = tmp_path / "reflection.json"
+    operator_local = tmp_path / "operator-local-reflection.json"
     monkeypatch.setattr(reflection_policy, "_REFLECTION_POLICY_SOT_PATH", sot)
+    monkeypatch.setattr(reflection_policy, "_OPERATOR_LOCAL_REFLECTION_POLICY_PATH", operator_local)
     monkeypatch.delenv("GEODE_REFLECTION_POLICY_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_REFLECTION_POLICY_STRICT", raising=False)
     yield sot
 
 
@@ -81,8 +84,10 @@ def test_load_empty_string_fields_dropped(isolated_sot: Path) -> None:
 def test_strict_load_via_env_var_raises_on_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """audit subprocess (``_OVERRIDE`` + ``_STRICT=1``) — missing → RuntimeError."""
     missing = tmp_path / "nope.json"
     monkeypatch.setenv("GEODE_REFLECTION_POLICY_OVERRIDE", str(missing))
+    monkeypatch.setenv("GEODE_REFLECTION_POLICY_STRICT", "1")
     with pytest.raises(RuntimeError, match="GEODE_REFLECTION_POLICY_OVERRIDE"):
         _load_reflection_policy_override()
 
@@ -93,8 +98,27 @@ def test_strict_load_via_env_var_raises_on_type_violation(
     bad = tmp_path / "bad.json"
     bad.write_text(json.dumps({"description": ["list", "not", "str"]}), encoding="utf-8")
     monkeypatch.setenv("GEODE_REFLECTION_POLICY_OVERRIDE", str(bad))
+    monkeypatch.setenv("GEODE_REFLECTION_POLICY_STRICT", "1")
     with pytest.raises(RuntimeError, match="description"):
         _load_reflection_policy_override()
+
+
+def test_env_var_without_strict_flag_is_graceful_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-BACKFILL-SOT (2026-05-21) — env var alone treats env path graceful."""
+    missing = tmp_path / "nope.json"
+    monkeypatch.setenv("GEODE_REFLECTION_POLICY_OVERRIDE", str(missing))
+    monkeypatch.delenv("GEODE_REFLECTION_POLICY_STRICT", raising=False)
+    assert _load_reflection_policy_override() is None
+
+
+def test_operator_local_layer_takes_priority_over_in_repo(isolated_sot: Path) -> None:
+    """3-layer chain — operator-local > in-repo when both present."""
+    operator_local = isolated_sot.parent / "operator-local-reflection.json"
+    operator_local.write_text(json.dumps({"system_prompt": "from-ops"}), encoding="utf-8")
+    _write(isolated_sot, {"system_prompt": "from-repo"})
+    assert _load_reflection_policy_override() == {"system_prompt": "from-ops"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_s0c_decomposition_reader.py
+++ b/tests/test_s0c_decomposition_reader.py
@@ -21,9 +21,15 @@ from core.agent import decomposition_policy
 
 @pytest.fixture
 def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolate all 3 SoT layers to tmp_path."""
     sot = tmp_path / "decomposition.json"
+    operator_local = tmp_path / "operator-local-decomposition.json"
     monkeypatch.setattr(decomposition_policy, "_DECOMPOSITION_POLICY_SOT_PATH", sot)
+    monkeypatch.setattr(
+        decomposition_policy, "_OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH", operator_local
+    )
     monkeypatch.delenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_DECOMPOSITION_POLICY_STRICT", raising=False)
     yield sot
 
 
@@ -68,7 +74,9 @@ def test_load_empty_string_dropped(isolated_sot: Path) -> None:
 
 
 def test_strict_load_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """audit subprocess (``_OVERRIDE`` + ``_STRICT=1``) — missing → RuntimeError."""
     monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_STRICT", "1")
     with pytest.raises(RuntimeError, match="GEODE_DECOMPOSITION_POLICY_OVERRIDE"):
         _load_decomposition_policy_override()
 
@@ -77,8 +85,26 @@ def test_strict_load_raises_on_type(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     bad = tmp_path / "bad.json"
     bad.write_text(json.dumps({"prefix": ["list"]}), encoding="utf-8")
     monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", str(bad))
+    monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_STRICT", "1")
     with pytest.raises(RuntimeError, match="prefix"):
         _load_decomposition_policy_override()
+
+
+def test_env_var_without_strict_flag_is_graceful_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-BACKFILL-SOT (2026-05-21) — env var alone treats env path graceful."""
+    monkeypatch.setenv("GEODE_DECOMPOSITION_POLICY_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_DECOMPOSITION_POLICY_STRICT", raising=False)
+    assert _load_decomposition_policy_override() is None
+
+
+def test_operator_local_layer_takes_priority_over_in_repo(isolated_sot: Path) -> None:
+    """3-layer chain — operator-local > in-repo when both present."""
+    operator_local = isolated_sot.parent / "operator-local-decomposition.json"
+    operator_local.write_text(json.dumps({"prefix": "from-ops"}), encoding="utf-8")
+    _write(isolated_sot, {"prefix": "from-repo"})
+    assert _load_decomposition_policy_override() == {"prefix": "from-ops"}
 
 
 # Apply -----------------------------------------------------------------------

--- a/tests/test_sot_resolution_chain.py
+++ b/tests/test_sot_resolution_chain.py
@@ -1,0 +1,157 @@
+"""PR-BACKFILL-SOT — shared 3-layer SoT resolution invariants.
+
+Pins the resolution order (env → operator-local → in-repo → None) and the
+strict-flag opt-in semantics that the 4 mutation-surface readers depend on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.sot_resolution import SoTSelection, resolve_sot
+
+_ENV = "GEODE_FAKE_POLICY_OVERRIDE"
+_STRICT_ENV = "GEODE_FAKE_POLICY_STRICT"
+
+
+def _resolve(operator_local: Path, in_repo: Path) -> SoTSelection | None:
+    return resolve_sot(env_var=_ENV, operator_local=operator_local, in_repo=in_repo)
+
+
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    monkeypatch.delenv(_STRICT_ENV, raising=False)
+
+
+# Empty chain -----------------------------------------------------------------
+
+
+def test_returns_none_when_no_layer_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear(monkeypatch)
+    assert _resolve(tmp_path / "ops.json", tmp_path / "repo.json") is None
+
+
+# In-repo layer ---------------------------------------------------------------
+
+
+def test_returns_in_repo_graceful_when_only_in_repo_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear(monkeypatch)
+    in_repo = tmp_path / "repo.json"
+    in_repo.write_text("{}", encoding="utf-8")
+    result = _resolve(tmp_path / "ops.json", in_repo)
+    assert result == SoTSelection(in_repo, strict=False)
+
+
+# Operator-local layer --------------------------------------------------------
+
+
+def test_returns_operator_local_graceful_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear(monkeypatch)
+    operator_local = tmp_path / "ops.json"
+    operator_local.write_text("{}", encoding="utf-8")
+    in_repo = tmp_path / "repo.json"
+    in_repo.write_text("{}", encoding="utf-8")
+    result = _resolve(operator_local, in_repo)
+    assert result == SoTSelection(operator_local, strict=False)
+
+
+def test_operator_local_takes_priority_over_in_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """3-layer chain order — operator-local > in-repo when both exist."""
+    _clear(monkeypatch)
+    operator_local = tmp_path / "ops.json"
+    operator_local.write_text("{}", encoding="utf-8")
+    in_repo = tmp_path / "repo.json"
+    in_repo.write_text("{}", encoding="utf-8")
+    result = _resolve(operator_local, in_repo)
+    assert result is not None
+    assert result.path == operator_local
+
+
+# Env layer -------------------------------------------------------------------
+
+
+def test_env_var_alone_returns_graceful_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Operator daily — env path is selected but graceful (no strict flag)."""
+    target = tmp_path / "env.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(_ENV, str(target))
+    monkeypatch.delenv(_STRICT_ENV, raising=False)
+    result = _resolve(tmp_path / "ops.json", tmp_path / "repo.json")
+    assert result == SoTSelection(target, strict=False)
+
+
+def test_env_var_with_strict_flag_returns_strict_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Audit subprocess — both _OVERRIDE and _STRICT=1 set → strict=True."""
+    target = tmp_path / "env.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(_ENV, str(target))
+    monkeypatch.setenv(_STRICT_ENV, "1")
+    result = _resolve(tmp_path / "ops.json", tmp_path / "repo.json")
+    assert result == SoTSelection(target, strict=True)
+
+
+def test_strict_flag_value_other_than_one_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only literal ``"1"`` activates strict. ``"true"`` / ``"0"`` / ``""`` → graceful."""
+    target = tmp_path / "env.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(_ENV, str(target))
+    for non_one in ("0", "true", "True", "yes", ""):
+        monkeypatch.setenv(_STRICT_ENV, non_one)
+        result = _resolve(tmp_path / "ops.json", tmp_path / "repo.json")
+        assert result == SoTSelection(target, strict=False), (
+            f"_STRICT={non_one!r} should be graceful, got strict=True"
+        )
+
+
+def test_env_var_overrides_lower_layers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env layer takes priority — no fall-through even when env file is missing."""
+    missing_env = tmp_path / "missing-env.json"
+    operator_local = tmp_path / "ops.json"
+    operator_local.write_text("{}", encoding="utf-8")
+    in_repo = tmp_path / "repo.json"
+    in_repo.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(_ENV, str(missing_env))
+    monkeypatch.delenv(_STRICT_ENV, raising=False)
+    result = _resolve(operator_local, in_repo)
+    assert result is not None
+    # Env path selected as the authoritative SoT, not the operator-local/in-repo.
+    assert result.path == missing_env
+    assert result.strict is False
+
+
+# Strict-suffix derivation ----------------------------------------------------
+
+
+def test_strict_env_name_is_derived_from_override_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``GEODE_X_OVERRIDE`` → ``GEODE_X_STRICT`` automatic derivation —
+    no per-reader registration required."""
+    target = tmp_path / "env.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("GEODE_CUSTOM_OVERRIDE", str(target))
+    monkeypatch.setenv("GEODE_CUSTOM_STRICT", "1")
+    monkeypatch.delenv("GEODE_FAKE_POLICY_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_FAKE_POLICY_STRICT", raising=False)
+    result = resolve_sot(
+        env_var="GEODE_CUSTOM_OVERRIDE",
+        operator_local=tmp_path / "ops.json",
+        in_repo=tmp_path / "repo.json",
+    )
+    assert result is not None
+    assert result.strict is True

--- a/tests/test_t1_tool_descriptions.py
+++ b/tests/test_t1_tool_descriptions.py
@@ -26,9 +26,15 @@ from core.agent import tool_descriptions_policy
 
 @pytest.fixture
 def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolate all 3 SoT layers to tmp_path."""
     sot = tmp_path / "tool-descriptions.json"
+    operator_local = tmp_path / "operator-local-tool-descriptions.json"
     monkeypatch.setattr(tool_descriptions_policy, "_TOOL_DESCRIPTIONS_SOT_PATH", sot)
+    monkeypatch.setattr(
+        tool_descriptions_policy, "_OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH", operator_local
+    )
     monkeypatch.delenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_TOOL_DESCRIPTIONS_STRICT", raising=False)
     yield sot
 
 
@@ -68,7 +74,9 @@ def test_load_unknown_field_in_entry_ignored(isolated_sot: Path) -> None:
 
 
 def test_strict_load_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """audit subprocess (``_OVERRIDE`` + ``_STRICT=1``) — missing → RuntimeError."""
     monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_STRICT", "1")
     with pytest.raises(RuntimeError, match="GEODE_TOOL_DESCRIPTIONS_OVERRIDE"):
         _load_tool_descriptions_override()
 
@@ -77,8 +85,26 @@ def test_strict_load_raises_on_hints_type(tmp_path: Path, monkeypatch: pytest.Mo
     bad = tmp_path / "bad.json"
     bad.write_text(json.dumps({"bash": {"hints": "not-a-list"}}), encoding="utf-8")
     monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", str(bad))
+    monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_STRICT", "1")
     with pytest.raises(RuntimeError, match="hints"):
         _load_tool_descriptions_override()
+
+
+def test_env_var_without_strict_flag_is_graceful_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-BACKFILL-SOT (2026-05-21) — env var alone treats env path graceful."""
+    monkeypatch.setenv("GEODE_TOOL_DESCRIPTIONS_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_TOOL_DESCRIPTIONS_STRICT", raising=False)
+    assert _load_tool_descriptions_override() is None
+
+
+def test_operator_local_layer_takes_priority_over_in_repo(isolated_sot: Path) -> None:
+    """3-layer chain — operator-local > in-repo when both present."""
+    operator_local = isolated_sot.parent / "operator-local-tool-descriptions.json"
+    operator_local.write_text(json.dumps({"bash": {"description": "from-ops"}}), encoding="utf-8")
+    _write(isolated_sot, {"bash": {"description": "from-repo"}})
+    assert _load_tool_descriptions_override() == {"bash": {"description": "from-ops"}}
 
 
 # Apply -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 4 mutation surface reader (tool_policy / reflection / decomposition / tool_descriptions) 가 **3-layer SoT chain** 으로 전환 — env → operator-local → in-repo.
- **env 를 first-class SoT layer 로 승격**: `GEODE_<X>_STRICT=1` opt-in 시에만 strict-fail, 그렇지 않으면 graceful (operator 가 env 만 set 해도 SoT 처럼 동작).
- 19 신규 invariant test + 8 기존 strict test 갱신 — 기존 audit subprocess fail-fast 행동 보존.

## Why
PR #1416 (PR-T1) 의 Codex MCP FAIL #5 — CHANGELOG/docstring 이 `~/.geode/self-improving-loop/<file>.json` (operator-local) fallback 을 주장했으나 reader 코드 부재. 4 reader 가 같은 stale inheritance 보유 (S0a/S0b/S0c/T1). #1416 의 fix-up commit `8392dbfd` 는 docstring 만 정합화 — 본 PR 이 **실제 GAP** (operator-local layer 코드) 을 메우면서 env 까지 SoT layer 로 다룰 수 있도록 개선.

CLAUDE.md DONT 표의 "CHANGELOG/PR-body parity" 카테고리 5번째 (2026-05-21 #1416 line) 와 짝 — claim 과 code 의 분리를 닫는 작업.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/sot_resolution.py` | **신규** — shared resolver. `resolve_sot(env_var, operator_local, in_repo) → SoTSelection(path, strict) \| None`. STRICT env name `<X>_OVERRIDE → <X>_STRICT` 자동 파생 |
| `core/paths.py` | 4 `OPERATOR_LOCAL_<X>_PATH` 상수 추가 (`GLOBAL_SELF_IMPROVING_LOOP_DIR / <file>.json`) |
| `core/agent/tool_policy.py` | inline 2-layer → shared 3-layer chain. `_OPERATOR_LOCAL_TOOL_POLICY_PATH` module alias. docstring 정합화 |
| `core/agent/reflection_policy.py` | 동일 패턴 |
| `core/agent/decomposition_policy.py` | 동일 패턴 |
| `core/agent/tool_descriptions_policy.py` | 동일 패턴 |
| `autoresearch/train.py` | audit subprocess 가 4 env 모두 `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_sot_resolution_chain.py` | **신규** — 9 shared resolver invariant test |
| `tests/test_s0a_tool_policy_reader.py` | 2 기존 strict 갱신 + 4 신규 |
| `tests/test_s0b_reflection_reader.py` | 2 기존 strict 갱신 + 2 신규 |
| `tests/test_s0c_decomposition_reader.py` | 2 기존 strict 갱신 + 2 신규 |
| `tests/test_t1_tool_descriptions.py` | 2 기존 strict 갱신 + 2 신규 |
| `CHANGELOG.md` | `### Added` PR-BACKFILL-SOT entry |

## Resolution order (post-fix)
1. `GEODE_<X>_OVERRIDE` env var:
   - With `GEODE_<X>_STRICT=1` (audit subprocess) → strict-fail
   - Without strict flag (operator daily) → graceful, no fall-through (env authoritative)
2. `~/.geode/self-improving-loop/<file>.json` — operator-local, graceful
3. `autoresearch/state/policies/<file>.json` — in-repo, ratchet-tracked, graceful
4. `None` — no-op

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| operator-local layer 4 reader 실제 구현 | Implemented | 모든 reader 가 `resolve_sot()` 통해 layer 검사 |
| env-as-SoT (graceful by default) | Implemented | `<X>_STRICT=1` opt-in 으로 strict 분리 |
| audit subprocess fail-fast 보존 | Implemented | `train.py` 가 `_OVERRIDE` + `_STRICT=1` 동반 set |
| Docstring/code 정합 | Implemented | 4 reader docstring 의 stale `~/.geode/...` 주장 → 실제 3-layer chain 으로 갱신 |
| DRY (4 reader 공통 resolution) | Implemented | `sot_resolution.py` 단일 helper |
| Test isolation | Implemented | 4 reader fixture 가 `_OPERATOR_LOCAL_*_PATH` 도 monkey-patch |

## Codex MCP review (fix-up applied)
- **#5 FAIL → fixed**: 첫 push 의 CHANGELOG 가 "27 신규 + 5 갱신" 이라 주장했으나 실제 diff 는 19+8. 정정 commit `5xxxxxxx`.
- 다른 8/9 PASS — shared resolver / 4 reader 통합 / path 상수 / audit fail-fast / Tier 2 untouched / test isolation / STRICT literal-1 / no-fall-through.

## Verification
- [x] ruff check core/ tests/ plugins/ clean
- [x] ruff format check clean (auto-formatted)
- [x] mypy core/ plugins/ clean (368 files)
- [x] lint-imports (4 architecture contracts kept)
- [x] pytest 5 reader files — 98/98 pass
- [x] regression smoke — self_improving minimal_1/2 + 5_slot_audit + loop_config + gap_fill + run_slash — 105 pass
- [x] Tier 2 untouched (bootstrap / runner / fitness gate / CI ratchet / HookSystem / mutator contract / importlinter / version stamp)
- [x] CI ALL DONE (Detect / Lint+Format / Security / Type / macOS-install / ubuntu-install / Gate / Test) — 8/8 pass

## Reference
PR #1416 Codex MCP FAIL #5 (operator-local stale claim).
CLAUDE.md DONT 표: 2026-05-20 PR-G5b "CHANGELOG/PR-body parity violation" — adjective claim → grep absent 패턴.
ADR-012 S0a-c + ADR-013 T1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)