### PR TITLE
feat(adr-013-t2): skill catalog JSON mutation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,34 @@ functional change.
 
 ### Added
 
+- **PR-T2 — Skill catalog JSON mutation surface (ADR-013).** mutator
+  가 skill `description` (LLM 라우팅 키) + `user_invocable` (가시성) 을
+  per-skill 단위로 JSON 으로 mutate → agent 의 skill 선택 정확도 ↑
+  (Voyager 식 curriculum 진화 패턴). **5-element 패턴** (S0a 검증):
+  SoT `autoresearch/state/policies/skill-catalog.json` (in-repo,
+  ratchet-tracked) + `~/.geode/self-improving-loop/skill-catalog.json`
+  (operator-local) / `GLOBAL_SKILL_CATALOG_PATH` + `OPERATOR_LOCAL_SKILL_
+  CATALOG_PATH` `core/paths.py` 추가 / `core/skills/skill_catalog_policy.py`
+  reader (`_load_skill_catalog_override` + `apply_skill_catalog_policy`,
+  schema `{skill_name: {description: str, user_invocable: bool}}`) /
+  `core/agent/loop/_context.py` 의 `_build_system_prompt` 가 기존
+  `registry.get_context_block()` 호출 자리에 `apply_skill_catalog_policy(
+  registry, _load_skill_catalog_override())` 호출 (정책 부재 시 base
+  registry 의 `get_context_block` 으로 위임 — no behavior change) /
+  `GEODE_SKILL_CATALOG_OVERRIDE` + `GEODE_SKILL_CATALOG_STRICT=1` env
+  pair (`autoresearch/train.py` 의 audit subprocess 가 SoT 존재 시 둘
+  다 inject — strict-fail 옵트인). `apply_skill_catalog_policy` 는
+  registry 의 base XML 렌더링 로직을 재사용하면서 per-skill override
+  를 우선 적용 — base registry 가 authoritative (unknown skill name 은
+  무시). Forward-compat: entry 내 unknown field 자동 drop. **23
+  invariant test** — reader graceful/strict + apply 9 케이스 (none /
+  empty / desc / visibility true/false / unknown skill / empty registry /
+  max_chars 절단 / XML escape) + context.py wiring source-grep + path
+  상수 2 + env wiring + ALIVE marker. Frontier: Voyager (Wang et al.,
+  2023) curriculum loop — agent 가 자체 skill library + description 을
+  loop 으로 갱신. AlphaEvolve-식 코드 mutation 배제 (skill body=SKILL.md
+  는 Tier 2, 본 surface 미접근).
+
 - **PR-BACKFILL-SOT — Operator-local SoT layer + env-as-SoT for 4 mutation
   surface readers (post-PR-T1 #1416 fix).** PR #1416 의 Codex MCP FAIL #5
   (CHANGELOG/PR-body parity 위반 — `~/.geode/self-improving-loop/...`

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -649,6 +649,7 @@ def run_audit(
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
+        GLOBAL_SKILL_CATALOG_PATH,
         GLOBAL_TOOL_DESCRIPTIONS_PATH,
         GLOBAL_TOOL_POLICY_PATH,
     )
@@ -670,6 +671,9 @@ def run_audit(
     if GLOBAL_TOOL_DESCRIPTIONS_PATH.is_file():
         env["GEODE_TOOL_DESCRIPTIONS_OVERRIDE"] = str(GLOBAL_TOOL_DESCRIPTIONS_PATH)
         env["GEODE_TOOL_DESCRIPTIONS_STRICT"] = "1"
+    if GLOBAL_SKILL_CATALOG_PATH.is_file():
+        env["GEODE_SKILL_CATALOG_OVERRIDE"] = str(GLOBAL_SKILL_CATALOG_PATH)
+        env["GEODE_SKILL_CATALOG_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/loop/_context.py
+++ b/core/agent/loop/_context.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING, Any
 
 from core.agent.system_prompt import build_system_prompt as _build_system_prompt
 from core.llm.prompts import AGENTIC_SUFFIX
+from core.skills.skill_catalog_policy import (
+    _load_skill_catalog_override,
+    apply_skill_catalog_policy,
+)
 
 if TYPE_CHECKING:
     from .agent_loop import AgenticLoop
@@ -79,7 +83,13 @@ def build_system_prompt(loop: AgenticLoop) -> str:
     override = getattr(loop, "_system_prompt_override", None)
     skill_ctx = ""
     if loop._skill_registry is not None:
-        skill_ctx = loop._skill_registry.get_context_block()
+        # ADR-013 T2 (2026-05-21) — skill catalog mutation surface. policy
+        # SoT 가 부재면 apply_*_policy 는 registry.get_context_block() 에
+        # 위임 (no behavior change). 정책이 있으면 per-skill description /
+        # user_invocable override 적용.
+        skill_ctx = apply_skill_catalog_policy(
+            loop._skill_registry, _load_skill_catalog_override()
+        )
     # Skills enter the active prompt path here: the loop-level registry renders
     # one context block, then ``{skill_context}`` in the system wrapper is
     # substituted below. The legacy PromptAssembler Phase 2 injection path was

--- a/core/agent/loop/_context.py
+++ b/core/agent/loop/_context.py
@@ -87,9 +87,7 @@ def build_system_prompt(loop: AgenticLoop) -> str:
         # SoT 가 부재면 apply_*_policy 는 registry.get_context_block() 에
         # 위임 (no behavior change). 정책이 있으면 per-skill description /
         # user_invocable override 적용.
-        skill_ctx = apply_skill_catalog_policy(
-            loop._skill_registry, _load_skill_catalog_override()
-        )
+        skill_ctx = apply_skill_catalog_policy(loop._skill_registry, _load_skill_catalog_override())
     # Skills enter the active prompt path here: the loop-level registry renders
     # one context block, then ``{skill_context}`` in the system wrapper is
     # substituted below. The legacy PromptAssembler Phase 2 injection path was

--- a/core/paths.py
+++ b/core/paths.py
@@ -104,6 +104,11 @@ OPERATOR_LOCAL_TOOL_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-policy.
 OPERATOR_LOCAL_DECOMPOSITION_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "decomposition.json"
 OPERATOR_LOCAL_REFLECTION_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "reflection.json"
 OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-descriptions.json"
+# ADR-013 T2 (2026-05-21) — Skill catalog mutation SoT. Mutator overrides
+# per-skill description text + user_invocable visibility for the LLM's
+# skill-routing context block.
+GLOBAL_SKILL_CATALOG_PATH = GLOBAL_POLICIES_DIR / "skill-catalog.json"
+OPERATOR_LOCAL_SKILL_CATALOG_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "skill-catalog.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/core/skills/skill_catalog_policy.py
+++ b/core/skills/skill_catalog_policy.py
@@ -1,0 +1,220 @@
+"""Skill catalog SoT reader — ADR-013 T2, JSON mutation surface.
+
+Mutator overrides per-skill ``description`` text + ``user_invocable``
+visibility for the LLM's skill-routing context block (rendered by
+``core.skills.skills.SkillRegistry.get_context_block``).
+
+Selecting the right skill is bandwidth-limited by description quality —
+identical to ADR-013 T1 (tool descriptions) but applied to the agent's
+*skill catalog* surface (Voyager-style routing — frontier curriculum
+agents evolve their own task taxonomy via the same JSON-only loop).
+
+**SoT schema** (모든 entry optional):
+
+.. code-block:: json
+
+    {
+      "geode-gitflow": {
+        "description": "Curated workflow for branch/PR/merge operations.",
+        "user_invocable": true
+      },
+      "frontier-harness-research": {
+        "user_invocable": false
+      }
+    }
+
+빈 entry / 누락 skill / 부적합 schema → no-op (default SKILL.md metadata
+유지). Unknown skill name 은 정책에 있어도 무시 — base registry 가
+authoritative.
+
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21 shared chain):
+
+1. ``GEODE_SKILL_CATALOG_OVERRIDE`` env var — explicit override.
+
+   - With ``GEODE_SKILL_CATALOG_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+
+2. ``~/.geode/self-improving-loop/skill-catalog.json`` — operator-local,
+   graceful.
+3. ``autoresearch/state/policies/skill-catalog.json`` — in-repo, graceful.
+4. ``None`` — no-op.
+
+**Frontier**: Voyager (Wang et al., 2023) curriculum loop — agent
+maintains its own skill library + descriptions, both updated by the loop.
+GEODE separates the *description text* (mutable here) from the *skill body*
+(SKILL.md, Tier 2, untouched in this surface).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from html import escape
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from core.paths import GLOBAL_SKILL_CATALOG_PATH, OPERATOR_LOCAL_SKILL_CATALOG_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
+
+if TYPE_CHECKING:
+    from core.skills.skills import SkillRegistry
+
+log = logging.getLogger(__name__)
+
+_SKILL_CATALOG_OVERRIDE_ENV = "GEODE_SKILL_CATALOG_OVERRIDE"
+
+_SKILL_CATALOG_SOT_PATH = GLOBAL_SKILL_CATALOG_PATH
+"""Cross-process in-repo SoT path (T2, 2026-05-21). Module-local alias
+for monkey-patch in tests."""
+
+_OPERATOR_LOCAL_SKILL_CATALOG_PATH = OPERATOR_LOCAL_SKILL_CATALOG_PATH
+"""Operator-local SoT path. Module-local alias for monkey-patch."""
+
+_FIELD_DESCRIPTION = "description"
+_FIELD_USER_INVOCABLE = "user_invocable"
+_ALL_FIELDS = frozenset({_FIELD_DESCRIPTION, _FIELD_USER_INVOCABLE})
+
+
+def _load_skill_catalog_override() -> dict[str, dict[str, Any]] | None:
+    """Return active skill-catalog override, or ``None`` if no SoT.
+
+    Resolution order — see module docstring (3-layer chain).
+    """
+    selection = resolve_sot(
+        env_var=_SKILL_CATALOG_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_SKILL_CATALOG_PATH,
+        in_repo=_SKILL_CATALOG_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
+
+
+def _strict_load(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.is_file():
+        raise RuntimeError(f"{_SKILL_CATALOG_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"{_SKILL_CATALOG_OVERRIDE_ENV}={path} load failed: {exc}"
+        ) from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, dict[str, Any]] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("skill-catalog SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("skill-catalog SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """``data`` 가 ``dict[str, dict[description: str, user_invocable: bool]]`` 모양인지.
+
+    Unknown field 는 무시 (forward-compatible)."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"skill-catalog at {path} must be a dict")
+    for skill_name, entry in data.items():
+        if not isinstance(skill_name, str):
+            type_name = type(skill_name).__name__
+            raise RuntimeError(
+                f"skill-catalog at {path} key must be str, got {type_name}"
+            )
+        if not isinstance(entry, dict):
+            type_name = type(entry).__name__
+            raise RuntimeError(
+                f"skill-catalog at {path}[{skill_name!r}] must be dict, got {type_name}"
+            )
+        if _FIELD_DESCRIPTION in entry and not isinstance(entry[_FIELD_DESCRIPTION], str):
+            raise RuntimeError(
+                f"skill-catalog at {path}[{skill_name!r}].description must be str"
+            )
+        if _FIELD_USER_INVOCABLE in entry and not isinstance(entry[_FIELD_USER_INVOCABLE], bool):
+            raise RuntimeError(
+                f"skill-catalog at {path}[{skill_name!r}].user_invocable must be bool"
+            )
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """알려진 field 만 추출 — entry 별 description / user_invocable 만 보존."""
+    result: dict[str, dict[str, Any]] = {}
+    for skill_name, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        kept: dict[str, Any] = {}
+        if _FIELD_DESCRIPTION in entry:
+            kept[_FIELD_DESCRIPTION] = entry[_FIELD_DESCRIPTION]
+        if _FIELD_USER_INVOCABLE in entry:
+            kept[_FIELD_USER_INVOCABLE] = entry[_FIELD_USER_INVOCABLE]
+        if kept:
+            result[skill_name] = kept
+    return result
+
+
+def apply_skill_catalog_policy(
+    registry: SkillRegistry,
+    policy: dict[str, dict[str, Any]] | None,
+    *,
+    max_chars: int = 8000,
+) -> str:
+    """Render the skill catalog context block with per-skill overrides applied.
+
+    Replaces the registry's ``get_context_block()`` call at the inference
+    entry point. When ``policy is None``, delegates to the registry's
+    own renderer (no behavior change).
+
+    Otherwise iterates the registry and emits the same XML format
+    (``<available_skills>...<skill ...>desc</skill>...</available_skills>``)
+    but for each skill checks ``policy.get(skill.name, {})`` and prefers
+    override values for ``description`` / ``user_invocable``. Unknown
+    skill names in the policy are ignored — base registry is authoritative
+    for which skills exist.
+    """
+    if not policy:
+        return registry.get_context_block(max_chars=max_chars)
+
+    skills = sorted(registry._skills.values(), key=lambda s: s.name)
+    if not skills:
+        return ""
+
+    lines: list[str] = ["<available_skills>"]
+    total = 0
+    for skill in skills:
+        override = policy.get(skill.name, {})
+        effective_invocable = override.get(_FIELD_USER_INVOCABLE, skill.user_invocable)
+        effective_description = override.get(_FIELD_DESCRIPTION, skill.description)
+        attrs = [
+            f'name="{escape(skill.name, quote=True)}"',
+            f'user_invocable="{str(effective_invocable).lower()}"',
+        ]
+        if skill.tools:
+            attrs.append(f'tools="{escape(", ".join(skill.tools), quote=True)}"')
+        if skill.context_fork:
+            attrs.append('context="fork"')
+        desc = escape(effective_description[:200])
+        line = f"  <skill {' '.join(attrs)}>{desc}</skill>"
+        if total + len(line) > max_chars:
+            remaining = len(skills) - (len(lines) - 1)
+            lines.append(f'  <truncated remaining="{remaining}" />')
+            break
+        lines.append(line)
+        total += len(line)
+    lines.append("</available_skills>")
+
+    return "\n".join(lines)
+
+
+__all__ = ["apply_skill_catalog_policy"]

--- a/core/skills/skill_catalog_policy.py
+++ b/core/skills/skill_catalog_policy.py
@@ -99,9 +99,7 @@ def _strict_load(path: Path) -> dict[str, dict[str, Any]]:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
     except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(
-            f"{_SKILL_CATALOG_OVERRIDE_ENV}={path} load failed: {exc}"
-        ) from exc
+        raise RuntimeError(f"{_SKILL_CATALOG_OVERRIDE_ENV}={path} load failed: {exc}") from exc
     _validate_schema(data, path)
     return _coerce(data)
 
@@ -130,18 +128,14 @@ def _validate_schema(data: Any, path: Path) -> None:
     for skill_name, entry in data.items():
         if not isinstance(skill_name, str):
             type_name = type(skill_name).__name__
-            raise RuntimeError(
-                f"skill-catalog at {path} key must be str, got {type_name}"
-            )
+            raise RuntimeError(f"skill-catalog at {path} key must be str, got {type_name}")
         if not isinstance(entry, dict):
             type_name = type(entry).__name__
             raise RuntimeError(
                 f"skill-catalog at {path}[{skill_name!r}] must be dict, got {type_name}"
             )
         if _FIELD_DESCRIPTION in entry and not isinstance(entry[_FIELD_DESCRIPTION], str):
-            raise RuntimeError(
-                f"skill-catalog at {path}[{skill_name!r}].description must be str"
-            )
+            raise RuntimeError(f"skill-catalog at {path}[{skill_name!r}].description must be str")
         if _FIELD_USER_INVOCABLE in entry and not isinstance(entry[_FIELD_USER_INVOCABLE], bool):
             raise RuntimeError(
                 f"skill-catalog at {path}[{skill_name!r}].user_invocable must be bool"

--- a/tests/test_t2_skill_catalog.py
+++ b/tests/test_t2_skill_catalog.py
@@ -29,9 +29,7 @@ def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Pa
     sot = tmp_path / "skill-catalog.json"
     operator_local = tmp_path / "operator-local-skill-catalog.json"
     monkeypatch.setattr(skill_catalog_policy, "_SKILL_CATALOG_SOT_PATH", sot)
-    monkeypatch.setattr(
-        skill_catalog_policy, "_OPERATOR_LOCAL_SKILL_CATALOG_PATH", operator_local
-    )
+    monkeypatch.setattr(skill_catalog_policy, "_OPERATOR_LOCAL_SKILL_CATALOG_PATH", operator_local)
     monkeypatch.delenv("GEODE_SKILL_CATALOG_OVERRIDE", raising=False)
     monkeypatch.delenv("GEODE_SKILL_CATALOG_STRICT", raising=False)
     yield sot
@@ -44,9 +42,7 @@ def _write(sot: Path, payload: dict[str, Any]) -> None:
 def _make_registry(*skills: tuple[str, str, bool]) -> SkillRegistry:
     reg = SkillRegistry()
     for name, desc, user_invocable in skills:
-        reg.register(
-            SkillDefinition(name=name, description=desc, user_invocable=user_invocable)
-        )
+        reg.register(SkillDefinition(name=name, description=desc, user_invocable=user_invocable))
     return reg
 
 
@@ -83,9 +79,7 @@ def test_load_unknown_field_ignored(isolated_sot: Path) -> None:
     assert _load_skill_catalog_override() == {"sk": {"description": "x"}}
 
 
-def test_strict_env_var_raises_on_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_strict_env_var_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GEODE_SKILL_CATALOG_OVERRIDE", str(tmp_path / "nope.json"))
     monkeypatch.setenv("GEODE_SKILL_CATALOG_STRICT", "1")
     with pytest.raises(RuntimeError, match="GEODE_SKILL_CATALOG_OVERRIDE"):
@@ -102,9 +96,7 @@ def test_env_var_without_strict_is_graceful(
 
 def test_operator_local_layer_priority(isolated_sot: Path) -> None:
     operator_local = isolated_sot.parent / "operator-local-skill-catalog.json"
-    operator_local.write_text(
-        json.dumps({"sk": {"description": "from-ops"}}), encoding="utf-8"
-    )
+    operator_local.write_text(json.dumps({"sk": {"description": "from-ops"}}), encoding="utf-8")
     _write(isolated_sot, {"sk": {"description": "from-repo"}})
     assert _load_skill_catalog_override() == {"sk": {"description": "from-ops"}}
 
@@ -113,16 +105,23 @@ def test_operator_local_layer_priority(isolated_sot: Path) -> None:
 
 
 def test_apply_none_delegates_to_registry() -> None:
-    reg = _make_registry(("sk1", "default desc", True))
+    """No behavior change contract — exact XML equality vs registry's own renderer."""
+    reg = _make_registry(
+        ("sk1", "default desc", True),
+        ("sk2", "another desc", False),
+    )
     out = apply_skill_catalog_policy(reg, None)
-    assert "default desc" in out
-    assert "sk1" in out
+    assert out == reg.get_context_block()
 
 
 def test_apply_empty_dict_delegates_to_registry() -> None:
-    reg = _make_registry(("sk1", "default desc", True))
+    """Empty dict same as None — exact XML equality (Codex MCP catch, PR #1418)."""
+    reg = _make_registry(
+        ("sk1", "default desc", True),
+        ("sk2", "another desc", False),
+    )
     out = apply_skill_catalog_policy(reg, {})
-    assert "default desc" in out
+    assert out == reg.get_context_block()
 
 
 def test_apply_description_override() -> None:
@@ -172,9 +171,7 @@ def test_apply_respects_max_chars_truncation() -> None:
 def test_apply_xml_escapes_special_chars() -> None:
     """XML escape (S0b deep-copy 식 안전성) — `<` 등이 raw 로 새지 않음."""
     reg = _make_registry(("sk1", "default", True))
-    out = apply_skill_catalog_policy(
-        reg, {"sk1": {"description": "has <html> & quotes \""}}
-    )
+    out = apply_skill_catalog_policy(reg, {"sk1": {"description": 'has <html> & quotes "'}})
     assert "&lt;html&gt;" in out
     assert "&amp;" in out
 

--- a/tests/test_t2_skill_catalog.py
+++ b/tests/test_t2_skill_catalog.py
@@ -1,0 +1,242 @@
+"""ADR-013 T2 — Skill catalog JSON mutation surface invariants.
+
+5-element 패턴 (S0a-checked):
+- SoT: skill-catalog.json
+- Path: GLOBAL_SKILL_CATALOG_PATH + OPERATOR_LOCAL_SKILL_CATALOG_PATH
+- Reader: core/skills/skill_catalog_policy.py
+- Entry: core/agent/loop/_context.py:_build_system_prompt
+- Env: GEODE_SKILL_CATALOG_OVERRIDE (+ _STRICT=1 opt-in)
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.skills import skill_catalog_policy
+from core.skills.skill_catalog_policy import (
+    _load_skill_catalog_override,
+    apply_skill_catalog_policy,
+)
+from core.skills.skills import SkillDefinition, SkillRegistry
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "skill-catalog.json"
+    operator_local = tmp_path / "operator-local-skill-catalog.json"
+    monkeypatch.setattr(skill_catalog_policy, "_SKILL_CATALOG_SOT_PATH", sot)
+    monkeypatch.setattr(
+        skill_catalog_policy, "_OPERATOR_LOCAL_SKILL_CATALOG_PATH", operator_local
+    )
+    monkeypatch.delenv("GEODE_SKILL_CATALOG_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_SKILL_CATALOG_STRICT", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_registry(*skills: tuple[str, str, bool]) -> SkillRegistry:
+    reg = SkillRegistry()
+    for name, desc, user_invocable in skills:
+        reg.register(
+            SkillDefinition(name=name, description=desc, user_invocable=user_invocable)
+        )
+    return reg
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_skill_catalog_override() is None
+
+
+def test_load_returns_none_when_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_skill_catalog_override() is None
+
+
+def test_load_returns_none_when_description_not_str(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"sk": {"description": ["list", "not", "str"]}})
+    assert _load_skill_catalog_override() is None
+
+
+def test_load_returns_none_when_user_invocable_not_bool(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"sk": {"user_invocable": "true"}})
+    assert _load_skill_catalog_override() is None
+
+
+def test_load_valid_payload(isolated_sot: Path) -> None:
+    payload = {"sk": {"description": "x", "user_invocable": False}}
+    _write(isolated_sot, payload)
+    assert _load_skill_catalog_override() == payload
+
+
+def test_load_unknown_field_ignored(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"sk": {"description": "x", "extra": "ignored"}})
+    assert _load_skill_catalog_override() == {"sk": {"description": "x"}}
+
+
+def test_strict_env_var_raises_on_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_SKILL_CATALOG_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_SKILL_CATALOG_STRICT", "1")
+    with pytest.raises(RuntimeError, match="GEODE_SKILL_CATALOG_OVERRIDE"):
+        _load_skill_catalog_override()
+
+
+def test_env_var_without_strict_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_SKILL_CATALOG_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_SKILL_CATALOG_STRICT", raising=False)
+    assert _load_skill_catalog_override() is None
+
+
+def test_operator_local_layer_priority(isolated_sot: Path) -> None:
+    operator_local = isolated_sot.parent / "operator-local-skill-catalog.json"
+    operator_local.write_text(
+        json.dumps({"sk": {"description": "from-ops"}}), encoding="utf-8"
+    )
+    _write(isolated_sot, {"sk": {"description": "from-repo"}})
+    assert _load_skill_catalog_override() == {"sk": {"description": "from-ops"}}
+
+
+# Apply -----------------------------------------------------------------------
+
+
+def test_apply_none_delegates_to_registry() -> None:
+    reg = _make_registry(("sk1", "default desc", True))
+    out = apply_skill_catalog_policy(reg, None)
+    assert "default desc" in out
+    assert "sk1" in out
+
+
+def test_apply_empty_dict_delegates_to_registry() -> None:
+    reg = _make_registry(("sk1", "default desc", True))
+    out = apply_skill_catalog_policy(reg, {})
+    assert "default desc" in out
+
+
+def test_apply_description_override() -> None:
+    reg = _make_registry(("sk1", "default desc", True))
+    out = apply_skill_catalog_policy(reg, {"sk1": {"description": "EVOLVED desc"}})
+    assert "EVOLVED desc" in out
+    assert "default desc" not in out
+
+
+def test_apply_user_invocable_false_overrides_to_false() -> None:
+    reg = _make_registry(("sk1", "desc", True))
+    out = apply_skill_catalog_policy(reg, {"sk1": {"user_invocable": False}})
+    assert 'user_invocable="false"' in out
+
+
+def test_apply_user_invocable_true_overrides_to_true() -> None:
+    reg = _make_registry(("sk1", "desc", False))
+    out = apply_skill_catalog_policy(reg, {"sk1": {"user_invocable": True}})
+    assert 'user_invocable="true"' in out
+
+
+def test_apply_unknown_skill_in_policy_ignored() -> None:
+    """Base registry is authoritative for which skills exist."""
+    reg = _make_registry(("sk1", "default desc", True))
+    out = apply_skill_catalog_policy(reg, {"nonexistent": {"description": "X"}})
+    assert "X" not in out
+    assert "default desc" in out
+    assert "sk1" in out
+
+
+def test_apply_empty_registry_returns_empty_string() -> None:
+    """No skills + any policy → empty block (consistent with `get_context_block`)."""
+    reg = SkillRegistry()
+    assert apply_skill_catalog_policy(reg, {"sk1": {"description": "x"}}) == ""
+
+
+def test_apply_respects_max_chars_truncation() -> None:
+    reg = _make_registry(
+        ("sk1", "d1" * 100, True),
+        ("sk2", "d2" * 100, True),
+        ("sk3", "d3" * 100, True),
+    )
+    out = apply_skill_catalog_policy(reg, {"sk1": {"description": "ovr"}}, max_chars=120)
+    assert "<truncated" in out
+
+
+def test_apply_xml_escapes_special_chars() -> None:
+    """XML escape (S0b deep-copy 식 안전성) — `<` 등이 raw 로 새지 않음."""
+    reg = _make_registry(("sk1", "default", True))
+    out = apply_skill_catalog_policy(
+        reg, {"sk1": {"description": "has <html> & quotes \""}}
+    )
+    assert "&lt;html&gt;" in out
+    assert "&amp;" in out
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_context_module_imports_reader_and_apply() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/loop/_context.py").read_text(encoding="utf-8")
+    assert "_load_skill_catalog_override" in src
+    assert "apply_skill_catalog_policy" in src
+
+
+def test_context_module_calls_apply_instead_of_get_context_block_direct() -> None:
+    """T2 wires the override into the inference path — apply_*_policy must be
+    invoked where the previous direct ``get_context_block()`` lived (skill_ctx)."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/loop/_context.py").read_text(encoding="utf-8")
+    # The earlier-built skill_ctx line must now reach through apply_*_policy.
+    assert "skill_ctx = apply_skill_catalog_policy(" in src
+
+
+# Path constants --------------------------------------------------------------
+
+
+def test_path_constants_present() -> None:
+    from core.paths import GLOBAL_SKILL_CATALOG_PATH, OPERATOR_LOCAL_SKILL_CATALOG_PATH
+
+    assert GLOBAL_SKILL_CATALOG_PATH.name == "skill-catalog.json"
+    assert OPERATOR_LOCAL_SKILL_CATALOG_PATH.name == "skill-catalog.json"
+    assert "policies" in str(GLOBAL_SKILL_CATALOG_PATH)
+    assert "self-improving-loop" in str(OPERATOR_LOCAL_SKILL_CATALOG_PATH)
+
+
+# Env wiring in train.py ------------------------------------------------------
+
+
+def test_train_py_sets_skill_catalog_env() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_SKILL_CATALOG_OVERRIDE" in src
+    assert "GEODE_SKILL_CATALOG_STRICT" in src
+    assert "GLOBAL_SKILL_CATALOG_PATH" in src
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_skill_catalog_json_referenced_in_inference_path() -> None:
+    """grep `skill-catalog.json` lands in `core/skills/skill_catalog_policy.py`."""
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "skill-catalog.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("skill_catalog_policy.py" in h for h in hits), (
+        f"skill-catalog.json must appear in core/skills/skill_catalog_policy.py. hits={hits}"
+    )


### PR DESCRIPTION
## Summary
- ADR-013 의 두번째 mutation 표면 — mutator 가 skill `description` (LLM 라우팅 키) + `user_invocable` (가시성) 을 per-skill JSON 으로 mutate.
- 5-element 패턴 (S0a 검증) 적용 + PR-BACKFILL-SOT 의 3-layer chain 재사용.
- 23 invariant test — reader / apply / wiring / path / env / ALIVE marker.

## Why
ADR-013 의 6 surfaces (T1-T6) 중 두번째. T1 (tool descriptions) 이 도구 선택을 mutate 하듯 T2 (skill catalog) 는 skill 선택을 mutate. `core/agent/loop/_context.py:82` 의 `registry.get_context_block()` 가 inference 진입점 — 여기서 description text 가 LLM 의 routing decision 의 1차 정보. Voyager 식 curriculum 진화 패턴 그대로 (frontier curriculum agent 가 같은 JSON-only loop 으로 skill library 갱신).

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_SKILL_CATALOG_PATH` + `OPERATOR_LOCAL_SKILL_CATALOG_PATH` 2 상수 추가 |
| `core/skills/skill_catalog_policy.py` | **신규** — reader + apply func. schema `{skill_name: {description: str, user_invocable: bool}}` |
| `core/agent/loop/_context.py` | `skill_ctx = apply_skill_catalog_policy(registry, _load_skill_catalog_override())` 으로 교체 — 정책 부재 시 base registry 의 `get_context_block` 으로 위임 (no behavior change) |
| `autoresearch/train.py` | audit subprocess 에 `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_t2_skill_catalog.py` | 23 invariant test |
| `CHANGELOG.md` | `### Added` PR-T2 entry |

## Resolution order
1. `GEODE_SKILL_CATALOG_OVERRIDE` env var — `GEODE_SKILL_CATALOG_STRICT=1` 동반 시 strict-fail, 아니면 graceful (no fall-through).
2. `~/.geode/self-improving-loop/skill-catalog.json` — operator-local, graceful.
3. `autoresearch/state/policies/skill-catalog.json` — in-repo, ratchet-tracked, graceful.
4. `None` → base registry 의 `get_context_block()` 위임 (no-op).

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 | Implemented | SoT 2 후보 + Path 2 상수 + Reader + Entry + Env 쌍 |
| 3-layer SoT chain 재사용 | Implemented | `resolve_sot(env_var, operator_local, in_repo)` 동일 호출 |
| Base registry authoritative | Implemented | Unknown skill name in policy 는 무시 |
| No-op delegation | Implemented | policy is None or empty dict → `registry.get_context_block(max_chars)` |
| Forward-compat | Implemented | unknown field `_coerce` 에서 drop |
| ALIVE marker | Implemented | `skill-catalog.json` grep → `core/skills/skill_catalog_policy.py` |

## Verification
- [x] ruff check clean
- [x] ruff format check clean
- [x] mypy core/ clean
- [x] lint-imports (4 contracts kept)
- [x] pytest tests/test_t2_skill_catalog.py — 23/23 pass
- [x] regression smoke — skill_registry / skill_v2 / 5_slot_audit / sot_resolution_chain — 48 pass
- [x] Tier 2 untouched (bootstrap / runner / fitness gate / CI ratchet / HookSystem / mutator contract / importlinter / version stamp)

## Reference
ADR-013 — `docs/adr/ADR-013-mutation-surface-expansion-via-json-schema.md`
Frontier: Voyager (Wang et al., 2023) — curriculum agent 의 self-evolving skill library + description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)