### PR TITLE
feat(adr-013-t3): response style guide JSON mutation surface (typed enum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,32 @@ functional change.
 
 ### Added
 
+- **PR-T3 — Response style guide JSON mutation surface (ADR-013).** mutator
+  가 4 typed enum field (`tone` ∈ concise/balanced/verbose, `verbosity_level`
+  ∈ low/medium/high, `response_format` ∈ markdown/plain/structured,
+  `code_style` ∈ show-first/explain-first) 을 JSON 으로 mutate. wrapper-
+  sections.json (G5a/G5b) 의 free-form 텍스트 mutation 과 분리 — T3 는
+  **constrained typed 선택지** 라 작은 expressive style space 를 효율적으로
+  탐색 가능. fitness 4축의 `ux_means` (success_rate + revert_ratio) 직접
+  영향. **5-element 패턴** (S0a 검증): SoT
+  `autoresearch/state/policies/style-guide.json` (in-repo, ratchet-tracked) +
+  `~/.geode/self-improving-loop/style-guide.json` (operator-local) /
+  `GLOBAL_STYLE_GUIDE_PATH` + `OPERATOR_LOCAL_STYLE_GUIDE_PATH`
+  `core/paths.py` 추가 / `core/agent/style_guide_policy.py` reader
+  (`_load_style_guide_override` + `apply_style_guide_policy`, schema
+  `{tone, verbosity_level, response_format, code_style}` enum-typed) /
+  `core/agent/system_prompt.py:build_system_prompt` 가 `static =
+  apply_style_guide_policy(static, _load_style_guide_override())` 로
+  static 영역 (cache-eligible) 에 `<response_style>` 블록 append (정책
+  부재 시 static 그대로 — no behavior change) / `GEODE_STYLE_GUIDE_OVERRIDE`
+  + `GEODE_STYLE_GUIDE_STRICT=1` env pair (`autoresearch/train.py` audit
+  subprocess). `_coerce` 가 unknown field + unknown enum value 둘 다
+  graceful drop — forward-compat + per-axis isolation (한 axis 가 깨져도
+  다른 axes 는 유효). **22 invariant test** — reader graceful/strict 10 +
+  apply 7 케이스 (none / empty / single / all / unknown-enum / empty-base /
+  field order) + wiring + path + env + ALIVE marker. Frontier: OpenAI /
+  Anthropic system prompt guides converge on enum-based response constraints.
+
 - **PR-T2 — Skill catalog JSON mutation surface (ADR-013).** mutator
   가 skill `description` (LLM 라우팅 키) + `user_invocable` (가시성) 을
   per-skill 단위로 JSON 으로 mutate → agent 의 skill 선택 정확도 ↑

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -650,6 +650,7 @@ def run_audit(
         GLOBAL_DECOMPOSITION_POLICY_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
         GLOBAL_SKILL_CATALOG_PATH,
+        GLOBAL_STYLE_GUIDE_PATH,
         GLOBAL_TOOL_DESCRIPTIONS_PATH,
         GLOBAL_TOOL_POLICY_PATH,
     )
@@ -674,6 +675,9 @@ def run_audit(
     if GLOBAL_SKILL_CATALOG_PATH.is_file():
         env["GEODE_SKILL_CATALOG_OVERRIDE"] = str(GLOBAL_SKILL_CATALOG_PATH)
         env["GEODE_SKILL_CATALOG_STRICT"] = "1"
+    if GLOBAL_STYLE_GUIDE_PATH.is_file():
+        env["GEODE_STYLE_GUIDE_OVERRIDE"] = str(GLOBAL_STYLE_GUIDE_PATH)
+        env["GEODE_STYLE_GUIDE_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/style_guide_policy.py
+++ b/core/agent/style_guide_policy.py
@@ -1,0 +1,202 @@
+"""Response style guide SoT reader — ADR-013 T3, JSON mutation surface.
+
+Mutator picks from a constrained typed enum (vs. wrapper-sections.json's
+free-form text mutation) so the loop can explore the small, expressive
+style space efficiently. Targets ``ux_means`` of the fitness 4-axis —
+``success_rate`` (does the agent finish the task) + ``revert_ratio``
+(does the user roll back).
+
+**SoT schema** (모든 entry optional, 각 value 는 enum):
+
+.. code-block:: json
+
+    {
+      "tone": "concise",                  // concise | balanced | verbose
+      "verbosity_level": "low",           // low | medium | high
+      "response_format": "markdown",      // markdown | plain | structured
+      "code_style": "show-first"          // show-first | explain-first
+    }
+
+빈 정책 / 누락 field → 해당 axis 는 default 동작. Unknown enum value →
+WARNING + 해당 axis drop (forward-compat 위해 다른 axes 는 유지).
+
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21 shared chain):
+
+1. ``GEODE_STYLE_GUIDE_OVERRIDE`` env var — explicit override.
+
+   - With ``GEODE_STYLE_GUIDE_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+
+2. ``~/.geode/self-improving-loop/style-guide.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/style-guide.json`` — in-repo, graceful.
+4. ``None`` — no-op.
+
+**Frontier**: OpenAI / Anthropic system prompt guides converge on
+**enum-based response constraints** (style, format, length) over
+free-form prose — easier to A/B-test and roll back.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_STYLE_GUIDE_PATH, OPERATOR_LOCAL_STYLE_GUIDE_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
+
+log = logging.getLogger(__name__)
+
+_STYLE_GUIDE_OVERRIDE_ENV = "GEODE_STYLE_GUIDE_OVERRIDE"
+
+_STYLE_GUIDE_SOT_PATH = GLOBAL_STYLE_GUIDE_PATH
+"""Cross-process in-repo SoT path (T3, 2026-05-21). Module-local alias."""
+
+_OPERATOR_LOCAL_STYLE_GUIDE_PATH = OPERATOR_LOCAL_STYLE_GUIDE_PATH
+"""Operator-local SoT path. Module-local alias for monkey-patch."""
+
+
+# Enum field → allowed values + human-readable directive on selection.
+_TONE = "tone"
+_VERBOSITY = "verbosity_level"
+_FORMAT = "response_format"
+_CODE_STYLE = "code_style"
+
+_FIELD_ENUMS: dict[str, frozenset[str]] = {
+    _TONE: frozenset({"concise", "balanced", "verbose"}),
+    _VERBOSITY: frozenset({"low", "medium", "high"}),
+    _FORMAT: frozenset({"markdown", "plain", "structured"}),
+    _CODE_STYLE: frozenset({"show-first", "explain-first"}),
+}
+
+_DIRECTIVES: dict[str, dict[str, str]] = {
+    _TONE: {
+        "concise": "Keep responses brief; 2-3 sentences for routine answers.",
+        "balanced": "Match response length to question complexity.",
+        "verbose": "Expand with context and reasoning; longer explanations welcome.",
+    },
+    _VERBOSITY: {
+        "low": "Default to minimum detail; expand only when explicitly asked.",
+        "medium": "Include relevant context but skip obvious background.",
+        "high": "Provide thorough background and edge cases by default.",
+    },
+    _FORMAT: {
+        "markdown": "Use Markdown — headers, lists, fenced code blocks.",
+        "plain": "Use plain prose; avoid Markdown formatting.",
+        "structured": "Use explicit sections and bullet lists for every response.",
+    },
+    _CODE_STYLE: {
+        "show-first": "Show working code first, then explain after.",
+        "explain-first": "Explain the approach first, then show the code.",
+    },
+}
+
+
+def _load_style_guide_override() -> dict[str, str] | None:
+    """Return the active style guide dict, or ``None`` if no SoT applies."""
+    selection = resolve_sot(
+        env_var=_STYLE_GUIDE_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_STYLE_GUIDE_PATH,
+        in_repo=_STYLE_GUIDE_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
+
+
+def _strict_load(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        raise RuntimeError(f"{_STYLE_GUIDE_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_STYLE_GUIDE_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, str] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("style-guide SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("style-guide SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """Top-level shape — ``dict[str, str]``. Enum value 검증은 `_coerce` 단계.
+
+    Forward-compat: unknown field 는 `_coerce` 에서 drop (raise X)."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"style-guide at {path} must be a dict")
+    for key, value in data.items():
+        if not isinstance(key, str):
+            type_name = type(key).__name__
+            raise RuntimeError(f"style-guide at {path} key must be str, got {type_name}")
+        if not isinstance(value, str):
+            type_name = type(value).__name__
+            raise RuntimeError(f"style-guide at {path}[{key!r}] must be str, got {type_name}")
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, str]:
+    """Drop unknown fields + unknown enum values (graceful per-axis)."""
+    result: dict[str, str] = {}
+    for field, allowed in _FIELD_ENUMS.items():
+        if field not in data:
+            continue
+        value = data[field]
+        if value in allowed:
+            result[field] = value
+        else:
+            log.warning(
+                "style-guide field %r has unknown enum value %r (allowed: %s); dropping",
+                field,
+                value,
+                sorted(allowed),
+            )
+    return result
+
+
+def apply_style_guide_policy(
+    base_prompt: str,
+    policy: dict[str, str] | None,
+) -> str:
+    """Append a ``<response_style>`` block to ``base_prompt`` per ``policy``.
+
+    Returns ``base_prompt`` unchanged when ``policy`` is empty / None.
+    The appended block lives in the **static** (cache-eligible) portion of
+    the system prompt — it changes only when the policy SoT changes, which
+    is rare enough to amortize the cache miss across many turns.
+    """
+    if not policy:
+        return base_prompt
+    lines: list[str] = ["<response_style>"]
+    for field in (_TONE, _VERBOSITY, _FORMAT, _CODE_STYLE):
+        value = policy.get(field)
+        if value is None:
+            continue
+        directive = _DIRECTIVES[field].get(value)
+        if directive is None:
+            continue
+        lines.append(f"  {field}: {value} — {directive}")
+    lines.append("</response_style>")
+    if len(lines) == 2:  # no fields rendered
+        return base_prompt
+    block = "\n".join(lines)
+    if base_prompt:
+        return f"{base_prompt}\n\n{block}"
+    return block
+
+
+__all__ = ["apply_style_guide_policy"]

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -23,6 +23,10 @@ from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 
+from core.agent.style_guide_policy import (
+    _load_style_guide_override,
+    apply_style_guide_policy,
+)
 from core.llm.prompt_assembler import with_math_output_formatting
 from core.llm.prompts import ROUTER_SYSTEM
 from core.paths import GLOBAL_WRAPPER_SECTIONS_PATH, get_project_root
@@ -208,6 +212,12 @@ def build_system_prompt(model: str = "") -> str:
         return dynamic
 
     static = with_math_output_formatting(wrapper_override or _generic_static_prefix())
+
+    # ADR-013 T3 (2026-05-21) — response style guide append to static prompt.
+    # policy 가 부재면 static 그대로 (no behavior change). 정책이 있으면
+    # <response_style> 블록 append — static 영역 이므로 cache-eligible
+    # (정책 변경 시에만 cache miss).
+    static = apply_style_guide_policy(static, _load_style_guide_override())
 
     # G10: Agent identity (opt-in via GEODE_PERSONA=on; default OFF so
     # GEODE behaves as a thin wrapper around the base model).

--- a/core/paths.py
+++ b/core/paths.py
@@ -109,6 +109,13 @@ OPERATOR_LOCAL_TOOL_DESCRIPTIONS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "tool-d
 # skill-routing context block.
 GLOBAL_SKILL_CATALOG_PATH = GLOBAL_POLICIES_DIR / "skill-catalog.json"
 OPERATOR_LOCAL_SKILL_CATALOG_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "skill-catalog.json"
+# ADR-013 T3 (2026-05-21) — Response style guide mutation SoT. Typed enum
+# schema (tone / verbosity_level / response_format / code_style) — mutator
+# picks from constrained alternatives → ux_means 의 success_rate +
+# revert_ratio 직접 영향. wrapper-sections.json (G5a/G5b) 의 free-form
+# 텍스트 mutation 과 분리: T3 는 constrained typed 선택지.
+GLOBAL_STYLE_GUIDE_PATH = GLOBAL_POLICIES_DIR / "style-guide.json"
+OPERATOR_LOCAL_STYLE_GUIDE_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "style-guide.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/tests/test_t3_style_guide.py
+++ b/tests/test_t3_style_guide.py
@@ -1,0 +1,242 @@
+"""ADR-013 T3 — Response style guide JSON mutation surface invariants.
+
+5-element 패턴:
+- SoT: style-guide.json (in-repo + operator-local)
+- Path: GLOBAL_STYLE_GUIDE_PATH + OPERATOR_LOCAL_STYLE_GUIDE_PATH
+- Reader: core/agent/style_guide_policy.py
+- Entry: core/agent/system_prompt.py:build_system_prompt
+- Env: GEODE_STYLE_GUIDE_OVERRIDE + GEODE_STYLE_GUIDE_STRICT
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.agent.style_guide_policy import (
+    _load_style_guide_override,
+    apply_style_guide_policy,
+)
+
+from core.agent import style_guide_policy
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "style-guide.json"
+    operator_local = tmp_path / "operator-local-style-guide.json"
+    monkeypatch.setattr(style_guide_policy, "_STYLE_GUIDE_SOT_PATH", sot)
+    monkeypatch.setattr(style_guide_policy, "_OPERATOR_LOCAL_STYLE_GUIDE_PATH", operator_local)
+    monkeypatch.delenv("GEODE_STYLE_GUIDE_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_STYLE_GUIDE_STRICT", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_style_guide_override() is None
+
+
+def test_load_returns_none_when_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_style_guide_override() is None
+
+
+def test_load_returns_none_when_value_not_str(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"tone": 42})
+    assert _load_style_guide_override() is None
+
+
+def test_load_valid_payload_all_fields(isolated_sot: Path) -> None:
+    payload = {
+        "tone": "concise",
+        "verbosity_level": "low",
+        "response_format": "markdown",
+        "code_style": "show-first",
+    }
+    _write(isolated_sot, payload)
+    assert _load_style_guide_override() == payload
+
+
+def test_load_partial_payload(isolated_sot: Path) -> None:
+    """Field 일부만 set → 그 field 만 반환."""
+    _write(isolated_sot, {"tone": "concise"})
+    assert _load_style_guide_override() == {"tone": "concise"}
+
+
+def test_load_unknown_enum_value_dropped_with_warning(
+    isolated_sot: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unknown enum value → axis drop (graceful), 다른 valid axis 는 유지."""
+    _write(isolated_sot, {"tone": "savage", "verbosity_level": "low"})
+    result = _load_style_guide_override()
+    assert result == {"verbosity_level": "low"}
+
+
+def test_load_unknown_field_dropped(isolated_sot: Path) -> None:
+    """Forward-compat — `_coerce` 가 알려진 enum field 만 유지."""
+    _write(isolated_sot, {"tone": "concise", "future_field": "x"})
+    assert _load_style_guide_override() == {"tone": "concise"}
+
+
+def test_strict_env_var_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_STYLE_GUIDE_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_STYLE_GUIDE_STRICT", "1")
+    with pytest.raises(RuntimeError, match="GEODE_STYLE_GUIDE_OVERRIDE"):
+        _load_style_guide_override()
+
+
+def test_env_var_without_strict_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_STYLE_GUIDE_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_STYLE_GUIDE_STRICT", raising=False)
+    assert _load_style_guide_override() is None
+
+
+def test_operator_local_layer_priority(isolated_sot: Path) -> None:
+    operator_local = isolated_sot.parent / "operator-local-style-guide.json"
+    operator_local.write_text(json.dumps({"tone": "verbose"}), encoding="utf-8")
+    _write(isolated_sot, {"tone": "concise"})
+    assert _load_style_guide_override() == {"tone": "verbose"}
+
+
+# Apply -----------------------------------------------------------------------
+
+
+_BASE = "BASE PROMPT TEXT"
+
+
+def test_apply_none_is_noop() -> None:
+    assert apply_style_guide_policy(_BASE, None) == _BASE
+
+
+def test_apply_empty_dict_is_noop() -> None:
+    assert apply_style_guide_policy(_BASE, {}) == _BASE
+
+
+def test_apply_single_field_appends_block() -> None:
+    out = apply_style_guide_policy(_BASE, {"tone": "concise"})
+    assert out.startswith(_BASE)
+    assert "<response_style>" in out
+    assert "tone: concise" in out
+    assert "Keep responses brief" in out
+    assert "</response_style>" in out
+
+
+def test_apply_all_fields_renders_all_lines() -> None:
+    out = apply_style_guide_policy(
+        _BASE,
+        {
+            "tone": "verbose",
+            "verbosity_level": "high",
+            "response_format": "structured",
+            "code_style": "explain-first",
+        },
+    )
+    assert "tone: verbose" in out
+    assert "verbosity_level: high" in out
+    assert "response_format: structured" in out
+    assert "code_style: explain-first" in out
+
+
+def test_apply_unknown_enum_value_in_policy_is_skipped() -> None:
+    """`_coerce` 가 unknown 값을 drop 했어야 하지만 직접 apply 호출 시도
+    fallback — directive 가 None 이면 줄을 건너뜀."""
+    out = apply_style_guide_policy(_BASE, {"tone": "savage"})
+    # No valid directive → block empty → return base unchanged.
+    assert out == _BASE
+
+
+def test_apply_with_empty_base_prompt() -> None:
+    out = apply_style_guide_policy("", {"tone": "concise"})
+    assert out.startswith("<response_style>")
+
+
+def test_apply_preserves_field_order() -> None:
+    """Render order: tone → verbosity → format → code_style (declarative)."""
+    out = apply_style_guide_policy(
+        _BASE,
+        {
+            "code_style": "show-first",
+            "tone": "concise",
+            "verbosity_level": "low",
+            "response_format": "plain",
+        },
+    )
+    body = out.split("<response_style>")[1]
+    idx_tone = body.find("tone:")
+    idx_verb = body.find("verbosity_level:")
+    idx_fmt = body.find("response_format:")
+    idx_code = body.find("code_style:")
+    assert 0 < idx_tone < idx_verb < idx_fmt < idx_code
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_system_prompt_imports_reader_and_apply() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/system_prompt.py").read_text(encoding="utf-8")
+    assert "_load_style_guide_override" in src
+    assert "apply_style_guide_policy" in src
+
+
+def test_system_prompt_wires_apply_into_static() -> None:
+    """`static = apply_style_guide_policy(static, _load_style_guide_override())`
+    must appear in `core/agent/system_prompt.py`."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/system_prompt.py").read_text(encoding="utf-8")
+    assert "static = apply_style_guide_policy(" in src
+
+
+# Path constants --------------------------------------------------------------
+
+
+def test_path_constants_present() -> None:
+    from core.paths import GLOBAL_STYLE_GUIDE_PATH, OPERATOR_LOCAL_STYLE_GUIDE_PATH
+
+    assert GLOBAL_STYLE_GUIDE_PATH.name == "style-guide.json"
+    assert OPERATOR_LOCAL_STYLE_GUIDE_PATH.name == "style-guide.json"
+    assert "policies" in str(GLOBAL_STYLE_GUIDE_PATH)
+    assert "self-improving-loop" in str(OPERATOR_LOCAL_STYLE_GUIDE_PATH)
+
+
+# Env wiring in train.py ------------------------------------------------------
+
+
+def test_train_py_sets_style_guide_env_pair() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_STYLE_GUIDE_OVERRIDE" in src
+    assert "GEODE_STYLE_GUIDE_STRICT" in src
+    assert "GLOBAL_STYLE_GUIDE_PATH" in src
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_style_guide_json_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "style-guide.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("style_guide_policy.py" in h for h in hits), (
+        f"style-guide.json must appear in core/agent/style_guide_policy.py. hits={hits}"
+    )


### PR DESCRIPTION
## Summary
- ADR-013 의 세번째 mutation 표면 — mutator 가 4 typed enum field (`tone` / `verbosity_level` / `response_format` / `code_style`) 로 응답 스타일 mutate.
- wrapper-sections.json (G5a/G5b) 의 free-form 텍스트 mutation 과 분리 — constrained typed 선택지로 작은 expressive 공간 효율 탐색.
- 22 invariant test — reader 10 + apply 7 + wiring + path + env + ALIVE marker.

## Why
응답 스타일 (tone / verbosity / format / code_style) 은 ux_means 의 success_rate + revert_ratio 의 직접 lever. wrapper-sections.json 은 free-form 이라 mutator 가 무한 공간에서 길을 잃을 수 있음 — typed enum 으로 좁힌 4×3×3×2 = 72-cell 공간을 탐색하면 A/B-rollback 도 쉬움. Frontier (OpenAI / Anthropic system prompt guides) 도 enum-based constraint 으로 수렴.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_STYLE_GUIDE_PATH` + `OPERATOR_LOCAL_STYLE_GUIDE_PATH` 2 상수 |
| `core/agent/style_guide_policy.py` | **신규** — reader + apply. enum-typed 4 field. `_coerce` 가 unknown field + unknown enum value 둘 다 per-axis graceful drop |
| `core/agent/system_prompt.py` | `static = apply_style_guide_policy(static, _load_style_guide_override())` — static 영역 (cache-eligible) 에 `<response_style>` 블록 append |
| `autoresearch/train.py` | audit subprocess `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_t3_style_guide.py` | 22 invariant test |
| `CHANGELOG.md` | `### Added` PR-T3 entry |

## Schema (enum-typed)
```json
{
  "tone": "concise" | "balanced" | "verbose",
  "verbosity_level": "low" | "medium" | "high",
  "response_format": "markdown" | "plain" | "structured",
  "code_style": "show-first" | "explain-first"
}
```

## Resolution order
1. `GEODE_STYLE_GUIDE_OVERRIDE` env var — `GEODE_STYLE_GUIDE_STRICT=1` 동반 시 strict-fail, 아니면 graceful.
2. `~/.geode/self-improving-loop/style-guide.json` — operator-local, graceful.
3. `autoresearch/state/policies/style-guide.json` — in-repo, ratchet-tracked, graceful.
4. `None` → no-op.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 | Implemented | SoT 2 후보 + Path 2 상수 + Reader + Entry + Env 쌍 |
| 3-layer SoT chain 재사용 | Implemented | `resolve_sot()` 호출 동일 |
| Typed enum vs free-form 구분 | Implemented | wrapper-sections.json (free-form) 과 별도 SoT |
| Per-axis graceful (unknown enum value) | Implemented | `_coerce` 가 axis drop, 다른 axes 유지 |
| Cache-friendly placement | Implemented | static 영역 (PROMPT_CACHE_BOUNDARY 이전) append |
| No-op delegation | Implemented | policy None / 빈 dict → static 그대로 |
| ALIVE marker | Implemented | `style-guide.json` grep → `core/agent/style_guide_policy.py` |

## Verification
- [x] ruff check clean (core/ tests/ plugins/ autoresearch/)
- [x] ruff format clean
- [x] mypy core/ clean (322 files)
- [x] lint-imports (4 contracts kept)
- [x] pytest tests/test_t3_style_guide.py — 22/22 pass
- [x] regression smoke — system_prompt_wrapper_override + prompt_assembler + 5_slot_audit — 49 pass
- [x] Tier 2 untouched

## Reference
ADR-013 — `docs/adr/ADR-013-mutation-surface-expansion-via-json-schema.md`
Frontier: OpenAI / Anthropic system prompt guides — enum-based response constraint convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)