### PR TITLE
feat(adr-013-t4): provider routing JSON mutation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,31 @@ functional change.
 
 ### Added
 
+- **PR-T4 — Provider routing JSON mutation surface (ADR-013).** mutator
+  가 per-model preferred plan-chain 을 JSON 으로 mutate. `resolve_routing(
+  model)` 의 explicit-chain branch 가 registry's `set_routing` 결과 대신
+  policy override 의 chain 을 iterate → ux_means.token_cost_norm 직접
+  영향 (같은 model 을 PAYG 대신 SUBSCRIPTION 으로 route 하면 per-call
+  cost 감소). **5-element 패턴** (S0a 검증): SoT
+  `autoresearch/state/policies/provider-routing.json` (in-repo) +
+  `~/.geode/self-improving-loop/provider-routing.json` (operator-local) /
+  `GLOBAL_PROVIDER_ROUTING_PATH` + `OPERATOR_LOCAL_PROVIDER_ROUTING_PATH`
+  `core/paths.py` 추가 / `core/llm/routing/provider_routing_policy.py`
+  reader (`_load_provider_routing_override` +
+  `apply_provider_routing_policy`, schema `{model_name: [plan_id_chain]}`) /
+  `core/llm/routing/plan_registry.py:resolve_routing` explicit-chain branch
+  가 `apply_provider_routing_policy(model, registry.get_routing(model),
+  _load_provider_routing_override())` 결과 iterate (정책 부재 시 default
+  chain — no behavior change) / `GEODE_PROVIDER_ROUTING_OVERRIDE` +
+  `GEODE_PROVIDER_ROUTING_STRICT=1` env pair. `_coerce` 가 empty chain +
+  empty string entry 제거. 등록되지 않은 plan_id 는 `resolve_routing` 이
+  자동으로 건너뜀 (registry.get 결과 None 일 때 skip). **21 invariant
+  test** — reader graceful/strict 10 + apply 6 케이스 (none / empty /
+  model-not-in-policy / override / empty-chain-fallthrough / return-copy)
+  + wiring + path + env + ALIVE marker. Frontier: OpenRouter의 explicit
+  per-model plan ordering + Anthropic/OpenAI multi-tier credential
+  (subscription/PAYG/batch) 의 cost lever.
+
 - **PR-T3 — Response style guide JSON mutation surface (ADR-013).** mutator
   가 4 typed enum field (`tone` ∈ concise/balanced/verbose, `verbosity_level`
   ∈ low/medium/high, `response_format` ∈ markdown/plain/structured,

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -648,6 +648,7 @@ def run_audit(
     # mutation 이 진행 중인 audit 의 quota 절약 목적.
     from core.paths import (
         GLOBAL_DECOMPOSITION_POLICY_PATH,
+        GLOBAL_PROVIDER_ROUTING_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
         GLOBAL_SKILL_CATALOG_PATH,
         GLOBAL_STYLE_GUIDE_PATH,
@@ -678,6 +679,9 @@ def run_audit(
     if GLOBAL_STYLE_GUIDE_PATH.is_file():
         env["GEODE_STYLE_GUIDE_OVERRIDE"] = str(GLOBAL_STYLE_GUIDE_PATH)
         env["GEODE_STYLE_GUIDE_STRICT"] = "1"
+    if GLOBAL_PROVIDER_ROUTING_PATH.is_file():
+        env["GEODE_PROVIDER_ROUTING_OVERRIDE"] = str(GLOBAL_PROVIDER_ROUTING_PATH)
+        env["GEODE_PROVIDER_ROUTING_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/llm/routing/plan_registry.py
+++ b/core/llm/routing/plan_registry.py
@@ -154,8 +154,18 @@ def resolve_routing(model: str) -> RoutingTarget | None:
         return None
 
     # 1) explicit per-model routing
+    # ADR-013 T4 (2026-05-21) — JSON SoT 가 model 별 plan-chain override.
+    # 정책 부재 시 registry.get_routing(model) 그대로 (no behavior change).
+    from core.llm.routing.provider_routing_policy import (
+        _load_provider_routing_override,
+        apply_provider_routing_policy,
+    )
+
+    routed_plan_ids = apply_provider_routing_policy(
+        model, registry.get_routing(model), _load_provider_routing_override()
+    )
     explicit_chain: list[Plan] = []
-    for plan_id in registry.get_routing(model):
+    for plan_id in routed_plan_ids:
         plan = registry.get(plan_id)
         if plan is not None:
             explicit_chain.append(plan)

--- a/core/llm/routing/provider_routing_policy.py
+++ b/core/llm/routing/provider_routing_policy.py
@@ -1,0 +1,151 @@
+"""Provider routing SoT reader — ADR-013 T4, JSON mutation surface.
+
+Mutator picks the **preferred plan-chain** for each model (plan_id ordered
+list). `resolve_routing(model)` consults this override before falling back
+to the user-set `PlanRegistry.set_routing(model, ...)` chain. Targets
+``ux_means.token_cost_norm`` — choosing a cheaper plan (PAYG vs
+SUBSCRIPTION) for the same model reduces per-call cost without changing
+behavior.
+
+**SoT schema** (모든 entry optional):
+
+.. code-block:: json
+
+    {
+      "claude-opus-4-7": ["plan-anthropic-paid", "plan-anthropic-free"],
+      "gpt-5": ["plan-openai-tier4"]
+    }
+
+빈 entry / 누락 model / 부적합 schema → no-op (registry's set_routing
+chain 그대로 사용). Unknown plan_id 는 정책에 있어도 `resolve_routing`
+이 등록된 plan 만 시도하므로 silently ignored.
+
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21 shared chain):
+
+1. ``GEODE_PROVIDER_ROUTING_OVERRIDE`` env var — explicit override.
+   - With ``GEODE_PROVIDER_ROUTING_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+2. ``~/.geode/self-improving-loop/provider-routing.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/provider-routing.json`` — in-repo, graceful.
+4. ``None`` — no-op.
+
+**Frontier**: OpenRouter's explicit per-model plan ordering — same model,
+different providers, different prices. Anthropic / OpenAI both surface
+multiple credential tiers (subscription / PAYG / batch); routing across
+them is a measurable cost lever.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_PROVIDER_ROUTING_PATH, OPERATOR_LOCAL_PROVIDER_ROUTING_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
+
+log = logging.getLogger(__name__)
+
+_PROVIDER_ROUTING_OVERRIDE_ENV = "GEODE_PROVIDER_ROUTING_OVERRIDE"
+
+_PROVIDER_ROUTING_SOT_PATH = GLOBAL_PROVIDER_ROUTING_PATH
+"""Cross-process in-repo SoT path (T4, 2026-05-21). Module-local alias."""
+
+_OPERATOR_LOCAL_PROVIDER_ROUTING_PATH = OPERATOR_LOCAL_PROVIDER_ROUTING_PATH
+"""Operator-local SoT path. Module-local alias for monkey-patch."""
+
+
+def _load_provider_routing_override() -> dict[str, list[str]] | None:
+    """Return the active provider-routing dict, or ``None`` if no SoT applies."""
+    selection = resolve_sot(
+        env_var=_PROVIDER_ROUTING_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_PROVIDER_ROUTING_PATH,
+        in_repo=_PROVIDER_ROUTING_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
+
+
+def _strict_load(path: Path) -> dict[str, list[str]]:
+    if not path.is_file():
+        raise RuntimeError(f"{_PROVIDER_ROUTING_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_PROVIDER_ROUTING_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, list[str]] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("provider-routing SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("provider-routing SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """``data`` 는 ``dict[str, list[str]]`` 모양 — model_name → plan_id chain."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"provider-routing at {path} must be a dict")
+    for model, chain in data.items():
+        if not isinstance(model, str):
+            type_name = type(model).__name__
+            raise RuntimeError(f"provider-routing at {path} key must be str, got {type_name}")
+        if not isinstance(chain, list):
+            type_name = type(chain).__name__
+            raise RuntimeError(
+                f"provider-routing at {path}[{model!r}] must be list, got {type_name}"
+            )
+        if not all(isinstance(p, str) for p in chain):
+            raise RuntimeError(f"provider-routing at {path}[{model!r}] must be list[str]")
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, list[str]]:
+    """Normalize — drop empty chains (no policy effect)."""
+    result: dict[str, list[str]] = {}
+    for model, chain in data.items():
+        if not isinstance(chain, list):
+            continue
+        normalized = [p for p in chain if isinstance(p, str) and p]
+        if normalized:
+            result[model] = normalized
+    return result
+
+
+def apply_provider_routing_policy(
+    model: str,
+    default_chain: list[str],
+    policy: dict[str, list[str]] | None,
+) -> list[str]:
+    """Return the effective plan-chain for ``model``.
+
+    Resolution: ``policy[model]`` if present and non-empty → that chain
+    (authoritative — overrides registry's set_routing). Otherwise
+    ``default_chain`` (i.e. what ``registry.get_routing(model)`` returned).
+
+    ``policy is None`` or model absent → ``default_chain`` unchanged
+    (no behavior change).
+    """
+    if policy is None:
+        return default_chain
+    override_chain = policy.get(model)
+    if not override_chain:
+        return default_chain
+    return list(override_chain)
+
+
+__all__ = ["apply_provider_routing_policy"]

--- a/core/paths.py
+++ b/core/paths.py
@@ -116,6 +116,11 @@ OPERATOR_LOCAL_SKILL_CATALOG_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "skill-cata
 # 텍스트 mutation 과 분리: T3 는 constrained typed 선택지.
 GLOBAL_STYLE_GUIDE_PATH = GLOBAL_POLICIES_DIR / "style-guide.json"
 OPERATOR_LOCAL_STYLE_GUIDE_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "style-guide.json"
+# ADR-013 T4 (2026-05-21) — Provider routing mutation SoT. Mutator picks
+# per-model preferred plan chain (plan_id ordered list). OpenRouter-style
+# explicit routing — fitness 4축의 ux_means.token_cost_norm 직접 영향.
+GLOBAL_PROVIDER_ROUTING_PATH = GLOBAL_POLICIES_DIR / "provider-routing.json"
+OPERATOR_LOCAL_PROVIDER_ROUTING_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "provider-routing.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/tests/test_t4_provider_routing.py
+++ b/tests/test_t4_provider_routing.py
@@ -114,6 +114,14 @@ def test_apply_none_returns_default_chain_unchanged() -> None:
     assert apply_provider_routing_policy("gpt-5", default, None) == default
 
 
+def test_apply_none_with_empty_default_returns_empty(
+    # Codex MCP FLAG #3 fix-up (PR #1420) — explicit empty-default identity.
+) -> None:
+    """`apply(..., [], None)` must return ``[]`` — no spurious chain on
+    missing SoT + empty registry routing (the most-common production case)."""
+    assert apply_provider_routing_policy("gpt-5", [], None) == []
+
+
 def test_apply_empty_policy_returns_default() -> None:
     default = ["plan-a"]
     assert apply_provider_routing_policy("gpt-5", default, {}) == default

--- a/tests/test_t4_provider_routing.py
+++ b/tests/test_t4_provider_routing.py
@@ -1,0 +1,214 @@
+"""ADR-013 T4 — Provider routing JSON mutation surface invariants.
+
+5-element 패턴:
+- SoT: provider-routing.json (in-repo + operator-local)
+- Path: GLOBAL_PROVIDER_ROUTING_PATH + OPERATOR_LOCAL_PROVIDER_ROUTING_PATH
+- Reader: core/llm/routing/provider_routing_policy.py
+- Entry: core/llm/routing/plan_registry.py:resolve_routing (explicit-chain branch)
+- Env: GEODE_PROVIDER_ROUTING_OVERRIDE + GEODE_PROVIDER_ROUTING_STRICT
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.llm.routing import provider_routing_policy
+from core.llm.routing.provider_routing_policy import (
+    _load_provider_routing_override,
+    apply_provider_routing_policy,
+)
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "provider-routing.json"
+    operator_local = tmp_path / "operator-local-provider-routing.json"
+    monkeypatch.setattr(provider_routing_policy, "_PROVIDER_ROUTING_SOT_PATH", sot)
+    monkeypatch.setattr(
+        provider_routing_policy,
+        "_OPERATOR_LOCAL_PROVIDER_ROUTING_PATH",
+        operator_local,
+    )
+    monkeypatch.delenv("GEODE_PROVIDER_ROUTING_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_PROVIDER_ROUTING_STRICT", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_provider_routing_override() is None
+
+
+def test_load_returns_none_when_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_provider_routing_override() is None
+
+
+def test_load_returns_none_when_chain_not_list(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"gpt-5": "plan-x"})
+    assert _load_provider_routing_override() is None
+
+
+def test_load_returns_none_when_chain_contains_non_str(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"gpt-5": ["plan-x", 42]})
+    assert _load_provider_routing_override() is None
+
+
+def test_load_valid_payload(isolated_sot: Path) -> None:
+    payload = {
+        "claude-opus-4-7": ["plan-anthropic-paid", "plan-anthropic-free"],
+        "gpt-5": ["plan-openai-tier4"],
+    }
+    _write(isolated_sot, payload)
+    assert _load_provider_routing_override() == payload
+
+
+def test_load_drops_empty_chain(isolated_sot: Path) -> None:
+    """Empty chain → drop the model entry (no policy effect)."""
+    _write(isolated_sot, {"gpt-5": [], "claude": ["plan-a"]})
+    assert _load_provider_routing_override() == {"claude": ["plan-a"]}
+
+
+def test_load_drops_empty_string_entries(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"gpt-5": ["plan-a", "", "plan-b"]})
+    assert _load_provider_routing_override() == {"gpt-5": ["plan-a", "plan-b"]}
+
+
+def test_strict_env_var_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_PROVIDER_ROUTING_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_PROVIDER_ROUTING_STRICT", "1")
+    with pytest.raises(RuntimeError, match="GEODE_PROVIDER_ROUTING_OVERRIDE"):
+        _load_provider_routing_override()
+
+
+def test_env_var_without_strict_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_PROVIDER_ROUTING_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_PROVIDER_ROUTING_STRICT", raising=False)
+    assert _load_provider_routing_override() is None
+
+
+def test_operator_local_layer_priority(isolated_sot: Path) -> None:
+    operator_local = isolated_sot.parent / "operator-local-provider-routing.json"
+    operator_local.write_text(json.dumps({"gpt-5": ["from-ops"]}), encoding="utf-8")
+    _write(isolated_sot, {"gpt-5": ["from-repo"]})
+    assert _load_provider_routing_override() == {"gpt-5": ["from-ops"]}
+
+
+# Apply -----------------------------------------------------------------------
+
+
+def test_apply_none_returns_default_chain_unchanged() -> None:
+    default = ["plan-a", "plan-b"]
+    assert apply_provider_routing_policy("gpt-5", default, None) == default
+
+
+def test_apply_empty_policy_returns_default() -> None:
+    default = ["plan-a"]
+    assert apply_provider_routing_policy("gpt-5", default, {}) == default
+
+
+def test_apply_model_not_in_policy_returns_default() -> None:
+    default = ["plan-a"]
+    policy = {"claude-opus": ["plan-x"]}
+    assert apply_provider_routing_policy("gpt-5", default, policy) == default
+
+
+def test_apply_model_in_policy_overrides_default() -> None:
+    default = ["plan-a"]
+    policy = {"gpt-5": ["plan-override-1", "plan-override-2"]}
+    assert apply_provider_routing_policy("gpt-5", default, policy) == [
+        "plan-override-1",
+        "plan-override-2",
+    ]
+
+
+def test_apply_empty_chain_in_policy_falls_through_to_default() -> None:
+    """Empty list in policy → no override (registry chain authoritative)."""
+    default = ["plan-default"]
+    policy = {"gpt-5": []}
+    assert apply_provider_routing_policy("gpt-5", default, policy) == default
+
+
+def test_apply_returns_new_list_not_alias() -> None:
+    """Returned list is a fresh copy — caller mutation must not affect policy."""
+    policy = {"gpt-5": ["plan-x"]}
+    out = apply_provider_routing_policy("gpt-5", [], policy)
+    out.append("plan-injected")
+    assert policy["gpt-5"] == ["plan-x"]
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_plan_registry_module_imports_reader_and_apply() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/llm/routing/plan_registry.py").read_text(encoding="utf-8")
+    assert "_load_provider_routing_override" in src
+    assert "apply_provider_routing_policy" in src
+
+
+def test_plan_registry_uses_apply_before_iterating_chain() -> None:
+    """resolve_routing 의 explicit-chain branch 가 registry.get_routing 대신
+    apply_provider_routing_policy() 의 결과를 iterate 해야 함."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/llm/routing/plan_registry.py").read_text(encoding="utf-8")
+    assert "apply_provider_routing_policy(" in src
+    # The output of apply is what gets iterated for plan lookup.
+    apply_idx = src.find("apply_provider_routing_policy(")
+    iter_idx = src.find("for plan_id in routed_plan_ids:")
+    assert 0 < apply_idx < iter_idx
+
+
+# Path constants --------------------------------------------------------------
+
+
+def test_path_constants_present() -> None:
+    from core.paths import GLOBAL_PROVIDER_ROUTING_PATH, OPERATOR_LOCAL_PROVIDER_ROUTING_PATH
+
+    assert GLOBAL_PROVIDER_ROUTING_PATH.name == "provider-routing.json"
+    assert OPERATOR_LOCAL_PROVIDER_ROUTING_PATH.name == "provider-routing.json"
+    assert "policies" in str(GLOBAL_PROVIDER_ROUTING_PATH)
+    assert "self-improving-loop" in str(OPERATOR_LOCAL_PROVIDER_ROUTING_PATH)
+
+
+# Env wiring in train.py ------------------------------------------------------
+
+
+def test_train_py_sets_provider_routing_env_pair() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_PROVIDER_ROUTING_OVERRIDE" in src
+    assert "GEODE_PROVIDER_ROUTING_STRICT" in src
+    assert "GLOBAL_PROVIDER_ROUTING_PATH" in src
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_provider_routing_json_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "provider-routing.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("provider_routing_policy.py" in h for h in hits), (
+        f"provider-routing.json must appear in core/llm/routing/provider_routing_policy.py. hits={hits}"
+    )


### PR DESCRIPTION
## Summary
- ADR-013 의 네번째 mutation 표면 — mutator 가 per-model preferred plan-chain (plan_id ordered list) 을 JSON 으로 mutate.
- `resolve_routing(model)` 의 explicit-chain branch 가 policy override 의 chain 을 iterate → ux_means.token_cost_norm 직접 영향.
- 21 invariant test — reader / apply / wiring / path / env / ALIVE marker.

## Why
같은 model 을 PAYG 대신 SUBSCRIPTION 또는 cheaper tier 로 route 하면 per-call cost 감소 — fitness 4축 의 `ux_means.token_cost_norm` 의 직접 lever. 기존 `PlanRegistry.set_routing(model, plan_ids)` 는 user 의 명시적 CLI 호출로만 변경; T4 는 mutator 가 self-improving loop 으로 같은 lever 를 자동 조정.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_PROVIDER_ROUTING_PATH` + `OPERATOR_LOCAL_PROVIDER_ROUTING_PATH` 2 상수 |
| `core/llm/routing/provider_routing_policy.py` | **신규** — reader + apply. schema `{model_name: [plan_id_chain]}` |
| `core/llm/routing/plan_registry.py:resolve_routing` | explicit-chain branch 의 `registry.get_routing(model)` 결과를 `apply_provider_routing_policy(...)` 에 통과시켜 override 적용 (정책 부재 시 default chain — no behavior change) |
| `autoresearch/train.py` | audit subprocess `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_t4_provider_routing.py` | 21 invariant test |
| `CHANGELOG.md` | `### Added` PR-T4 entry |

## Schema
```json
{
  "claude-opus-4-7": ["plan-anthropic-paid", "plan-anthropic-free"],
  "gpt-5": ["plan-openai-tier4"]
}
```

## Resolution order
1. `GEODE_PROVIDER_ROUTING_OVERRIDE` env var — `GEODE_PROVIDER_ROUTING_STRICT=1` 동반 시 strict-fail, 아니면 graceful.
2. `~/.geode/self-improving-loop/provider-routing.json` — operator-local.
3. `autoresearch/state/policies/provider-routing.json` — in-repo.
4. `None` → registry.get_routing 의 default chain 그대로.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 | Implemented | SoT 2 + Path 2 + Reader + Entry + Env 쌍 |
| 3-layer SoT chain 재사용 | Implemented | `resolve_sot()` |
| Default chain authority | Implemented | empty chain in policy → fall through to default |
| Unknown plan_id 안전 | Implemented | `resolve_routing` 의 `registry.get(plan_id)` is None check 가 자동 skip |
| Return list-copy | Implemented | `apply_*` 가 `list(override_chain)` 으로 별도 객체 반환 |
| ALIVE marker | Implemented | `provider-routing.json` grep → reader |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy core/ clean
- [x] pytest tests/test_t4_provider_routing.py — 21/21 pass
- [x] regression smoke — login_plan_binding + plans + routing_policy + T4 — 51 pass
- [x] Tier 2 untouched

## Reference
ADR-013 — `docs/adr/ADR-013-mutation-surface-expansion-via-json-schema.md`
Frontier: OpenRouter per-model plan ordering + Anthropic/OpenAI multi-tier credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)