### PR TITLE
feat(adr-013-t5): cache breakpoint policy JSON mutation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,31 @@ functional change.
 
 ### Added
 
+- **PR-T5 — Cache breakpoint policy JSON mutation surface (ADR-013).**
+  mutator 가 Anthropic API 의 `apply_messages_cache_control(messages,
+  n_breakpoints=N)` 의 N 값을 JSON 으로 mutate (0..3, Anthropic cap 의
+  messages-block 점유분). **trade-off**: ↑ → cache hit rate ↑ but
+  per-call overhead ↑ (각 breakpoint 가 $0.10/MTok overhead); ↓ → cache
+  hit ↓ but per-call cost ↓. ux_means.token_cost_norm + latency_norm
+  둘 다 영향. **5-element 패턴** (S0a 검증): SoT
+  `autoresearch/state/policies/cache-policy.json` (in-repo) +
+  `~/.geode/self-improving-loop/cache-policy.json` (operator-local) /
+  `GLOBAL_CACHE_POLICY_PATH` + `OPERATOR_LOCAL_CACHE_POLICY_PATH`
+  `core/paths.py` 추가 / `core/llm/cache_policy.py` reader
+  (`_load_cache_policy_override` + `apply_cache_policy_breakpoints`,
+  schema `{messages_breakpoints: int 0..3}`) / `core/llm/providers/
+  anthropic.py` 의 Anthropic streaming/non-streaming 분기 둘 다에서
+  `n_breakpoints = apply_cache_policy_breakpoints(MAX_MESSAGE_CACHE_BREAKPOINTS,
+  _load_cache_policy_override())` 호출 → `apply_messages_cache_control(
+  messages, n_breakpoints=n_breakpoints)` 로 wire (정책 부재 시 default
+  3 — no behavior change) / `GEODE_CACHE_POLICY_OVERRIDE` +
+  `GEODE_CACHE_POLICY_STRICT=1` env pair. `_validate_schema` 가 Python
+  `bool` 을 명시적으로 int 에서 제외 (Python 의 bool-is-int subclass
+  함정 방어). out-of-range 값 (4, -1, ...) 은 `_coerce` 에서 per-axis
+  graceful drop. **20 invariant test** — reader graceful/strict 10 +
+  apply 5 + wiring + path + env + ALIVE marker. Frontier: Anthropic
+  prompt caching docs — `cache_control` count 가 canonical knob.
+
 - **PR-T4 — Provider routing JSON mutation surface (ADR-013).** mutator
   가 per-model preferred plan-chain 을 JSON 으로 mutate. `resolve_routing(
   model)` 의 explicit-chain branch 가 registry's `set_routing` 결과 대신

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ functional change.
   `core/paths.py` 추가 / `core/llm/cache_policy.py` reader
   (`_load_cache_policy_override` + `apply_cache_policy_breakpoints`,
   schema `{messages_breakpoints: int 0..3}`) / `core/llm/providers/
-  anthropic.py` 의 Anthropic streaming/non-streaming 분기 둘 다에서
+  anthropic.py` 의 streaming 경로 (현재 활성 single consumer) 에서
   `n_breakpoints = apply_cache_policy_breakpoints(MAX_MESSAGE_CACHE_BREAKPOINTS,
   _load_cache_policy_override())` 호출 → `apply_messages_cache_control(
   messages, n_breakpoints=n_breakpoints)` 로 wire (정책 부재 시 default

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -647,6 +647,7 @@ def run_audit(
     # 은 "SoT 가 디스크에 있는데도 subprocess 가 못 읽는 경우" 만 발화 —
     # mutation 이 진행 중인 audit 의 quota 절약 목적.
     from core.paths import (
+        GLOBAL_CACHE_POLICY_PATH,
         GLOBAL_DECOMPOSITION_POLICY_PATH,
         GLOBAL_PROVIDER_ROUTING_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
@@ -682,6 +683,9 @@ def run_audit(
     if GLOBAL_PROVIDER_ROUTING_PATH.is_file():
         env["GEODE_PROVIDER_ROUTING_OVERRIDE"] = str(GLOBAL_PROVIDER_ROUTING_PATH)
         env["GEODE_PROVIDER_ROUTING_STRICT"] = "1"
+    if GLOBAL_CACHE_POLICY_PATH.is_file():
+        env["GEODE_CACHE_POLICY_OVERRIDE"] = str(GLOBAL_CACHE_POLICY_PATH)
+        env["GEODE_CACHE_POLICY_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/llm/cache_policy.py
+++ b/core/llm/cache_policy.py
@@ -1,0 +1,165 @@
+"""Cache breakpoint policy SoT reader — ADR-013 T5, JSON mutation surface.
+
+Mutator picks how many trailing-message ``cache_control`` breakpoints to
+apply on Anthropic API calls (the ``n_breakpoints`` argument to
+:func:`core.llm.providers.anthropic.apply_messages_cache_control`).
+
+**Trade-off**:
+
+- Higher ``n_breakpoints`` (up to 3) — more turns of the rolling history
+  window are cached → higher cache-hit rate on long multi-turn loops.
+  But each breakpoint carries a ``$0.10/MTok`` overhead on the cached
+  block whether the call hits or misses the cache.
+- Lower (0-1) — fewer breakpoints, lower per-call overhead, lower cache
+  hit rate. Right choice for short tasks where the history doesn't
+  amortize the overhead.
+
+Targets ``ux_means.token_cost_norm`` + ``latency_norm`` (cache hits
+reduce latency too).
+
+**SoT schema** (모든 field optional):
+
+.. code-block:: json
+
+    {
+      "messages_breakpoints": 3        // 0 <= int <= 3 (Anthropic cap)
+    }
+
+빈 정책 / 누락 / out-of-range 값 → no-op (default 3 유지).
+
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21 shared chain):
+
+1. ``GEODE_CACHE_POLICY_OVERRIDE`` env var — explicit override.
+   - With ``GEODE_CACHE_POLICY_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+2. ``~/.geode/self-improving-loop/cache-policy.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/cache-policy.json`` — in-repo, graceful.
+4. ``None`` — no-op.
+
+**Frontier**: Anthropic prompt caching docs — ``cache_control`` count is
+the canonical knob the user tunes; Anthropic recommends putting it on
+*stable prefix* + *recent turns* and letting the workload guide which
+turns deserve the breakpoint budget.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_CACHE_POLICY_PATH, OPERATOR_LOCAL_CACHE_POLICY_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
+
+log = logging.getLogger(__name__)
+
+_CACHE_POLICY_OVERRIDE_ENV = "GEODE_CACHE_POLICY_OVERRIDE"
+
+_CACHE_POLICY_SOT_PATH = GLOBAL_CACHE_POLICY_PATH
+"""Cross-process in-repo SoT path (T5, 2026-05-21). Module-local alias."""
+
+_OPERATOR_LOCAL_CACHE_POLICY_PATH = OPERATOR_LOCAL_CACHE_POLICY_PATH
+"""Operator-local SoT path. Module-local alias for monkey-patch."""
+
+_FIELD_MESSAGES_BREAKPOINTS = "messages_breakpoints"
+
+# Anthropic의 4-breakpoint hard cap minus 1 for the system block — agentic
+# adapter spends 1-2 on the static system prefix (STATIC + DYNAMIC split).
+_MAX_BREAKPOINTS = 3
+_MIN_BREAKPOINTS = 0
+
+
+def _load_cache_policy_override() -> dict[str, int] | None:
+    """Return the active cache-policy dict, or ``None`` if no SoT applies."""
+    selection = resolve_sot(
+        env_var=_CACHE_POLICY_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_CACHE_POLICY_PATH,
+        in_repo=_CACHE_POLICY_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
+
+
+def _strict_load(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        raise RuntimeError(f"{_CACHE_POLICY_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_CACHE_POLICY_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, int] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("cache-policy SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("cache-policy SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """Top-level shape: ``dict``. ``messages_breakpoints`` must be int.
+
+    Range validation 은 `_coerce` 에서 per-axis graceful drop — 다른
+    field 가 추가되더라도 forward-compat."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"cache-policy at {path} must be a dict")
+    if _FIELD_MESSAGES_BREAKPOINTS in data:
+        value = data[_FIELD_MESSAGES_BREAKPOINTS]
+        if not isinstance(value, int) or isinstance(value, bool):
+            type_name = type(value).__name__
+            raise RuntimeError(
+                f"cache-policy at {path}[{_FIELD_MESSAGES_BREAKPOINTS!r}] "
+                f"must be int (not {type_name})"
+            )
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, int]:
+    """Extract known fields + range-check. Out-of-range 값 은 graceful drop."""
+    result: dict[str, int] = {}
+    if _FIELD_MESSAGES_BREAKPOINTS in data:
+        value = data[_FIELD_MESSAGES_BREAKPOINTS]
+        if isinstance(value, int) and not isinstance(value, bool):
+            if _MIN_BREAKPOINTS <= value <= _MAX_BREAKPOINTS:
+                result[_FIELD_MESSAGES_BREAKPOINTS] = value
+            else:
+                log.warning(
+                    "cache-policy field %r out of range (%d <= n <= %d), got %d; dropping",
+                    _FIELD_MESSAGES_BREAKPOINTS,
+                    _MIN_BREAKPOINTS,
+                    _MAX_BREAKPOINTS,
+                    value,
+                )
+    return result
+
+
+def apply_cache_policy_breakpoints(
+    default_n: int,
+    policy: dict[str, int] | None,
+) -> int:
+    """Return effective ``n_breakpoints`` from ``policy``, else ``default_n``.
+
+    Policy field absence → ``default_n`` (no behavior change). The reader's
+    range validation guarantees the returned value is in
+    ``[_MIN_BREAKPOINTS, _MAX_BREAKPOINTS]`` whenever it comes from policy.
+    """
+    if policy is None:
+        return default_n
+    return policy.get(_FIELD_MESSAGES_BREAKPOINTS, default_n)
+
+
+__all__ = ["apply_cache_policy_breakpoints"]

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -862,7 +862,18 @@ class ClaudeAgenticAdapter:
             # Combined with the system block above, this fills up to 4 of
             # Anthropic's cache_control slots and caches the long history
             # window in multi-turn agentic loops.
-            cached_messages = apply_messages_cache_control(messages)
+            # ADR-013 T5 (2026-05-21) — cache-policy.json mutation SoT.
+            # Default 3 (Anthropic cap minus 1 for system). Policy 가 부재면
+            # default 그대로 (no behavior change).
+            from core.llm.cache_policy import (
+                _load_cache_policy_override,
+                apply_cache_policy_breakpoints,
+            )
+
+            n_breakpoints = apply_cache_policy_breakpoints(
+                MAX_MESSAGE_CACHE_BREAKPOINTS, _load_cache_policy_override()
+            )
+            cached_messages = apply_messages_cache_control(messages, n_breakpoints=n_breakpoints)
 
             create_kwargs: dict[str, Any] = {
                 "model": m,

--- a/core/paths.py
+++ b/core/paths.py
@@ -121,6 +121,13 @@ OPERATOR_LOCAL_STYLE_GUIDE_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "style-guide.
 # explicit routing — fitness 4축의 ux_means.token_cost_norm 직접 영향.
 GLOBAL_PROVIDER_ROUTING_PATH = GLOBAL_POLICIES_DIR / "provider-routing.json"
 OPERATOR_LOCAL_PROVIDER_ROUTING_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "provider-routing.json"
+# ADR-013 T5 (2026-05-21) — Cache breakpoint policy mutation SoT. Mutator
+# picks how many trailing-message cache_control breakpoints to apply
+# (Anthropic의 4-breakpoint cap 중 messages 가 가져갈 수). 0-3 사이.
+# trade-off: ↑ → cache hit ↑ but per-call overhead ↑ (각 breakpoint 가
+# $0.10/MTok 오버헤드). ↓ → cache hit ↓ but per-call cost ↓.
+GLOBAL_CACHE_POLICY_PATH = GLOBAL_POLICIES_DIR / "cache-policy.json"
+OPERATOR_LOCAL_CACHE_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "cache-policy.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/tests/test_t5_cache_policy.py
+++ b/tests/test_t5_cache_policy.py
@@ -149,9 +149,7 @@ def test_anthropic_provider_uses_apply_before_cache_control() -> None:
     call_idx = src.find("n_breakpoints=n_breakpoints")
     assert apply_idx > 0, "apply_cache_policy_breakpoints must be invoked"
     assert call_idx > 0, "apply_messages_cache_control must use n_breakpoints kwarg"
-    assert apply_idx < call_idx, (
-        "apply_cache_policy_breakpoints must precede its consumer"
-    )
+    assert apply_idx < call_idx, "apply_cache_policy_breakpoints must precede its consumer"
 
 
 # Path constants --------------------------------------------------------------

--- a/tests/test_t5_cache_policy.py
+++ b/tests/test_t5_cache_policy.py
@@ -1,0 +1,197 @@
+"""ADR-013 T5 — Cache breakpoint policy JSON mutation surface invariants.
+
+5-element 패턴:
+- SoT: cache-policy.json
+- Path: GLOBAL_CACHE_POLICY_PATH + OPERATOR_LOCAL_CACHE_POLICY_PATH
+- Reader: core/llm/cache_policy.py
+- Entry: core/llm/providers/anthropic.py (apply_messages_cache_control 호출 직전)
+- Env: GEODE_CACHE_POLICY_OVERRIDE + GEODE_CACHE_POLICY_STRICT
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.llm import cache_policy
+from core.llm.cache_policy import (
+    _load_cache_policy_override,
+    apply_cache_policy_breakpoints,
+)
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "cache-policy.json"
+    operator_local = tmp_path / "operator-local-cache-policy.json"
+    monkeypatch.setattr(cache_policy, "_CACHE_POLICY_SOT_PATH", sot)
+    monkeypatch.setattr(cache_policy, "_OPERATOR_LOCAL_CACHE_POLICY_PATH", operator_local)
+    monkeypatch.delenv("GEODE_CACHE_POLICY_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_CACHE_POLICY_STRICT", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_cache_policy_override() is None
+
+
+def test_load_returns_none_when_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_cache_policy_override() is None
+
+
+def test_load_returns_none_when_value_not_int(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"messages_breakpoints": "three"})
+    assert _load_cache_policy_override() is None
+
+
+def test_load_rejects_bool_as_int(isolated_sot: Path) -> None:
+    """Python bool is int subclass — _validate_schema rejects bool explicitly."""
+    _write(isolated_sot, {"messages_breakpoints": True})
+    assert _load_cache_policy_override() is None
+
+
+def test_load_valid_payload_each_value(isolated_sot: Path) -> None:
+    for n in (0, 1, 2, 3):
+        _write(isolated_sot, {"messages_breakpoints": n})
+        assert _load_cache_policy_override() == {"messages_breakpoints": n}
+
+
+def test_load_out_of_range_value_dropped(isolated_sot: Path) -> None:
+    """Out-of-range (4, -1) → per-axis graceful drop (returns empty dict)."""
+    _write(isolated_sot, {"messages_breakpoints": 4})
+    assert _load_cache_policy_override() == {}
+    _write(isolated_sot, {"messages_breakpoints": -1})
+    assert _load_cache_policy_override() == {}
+
+
+def test_load_unknown_field_dropped(isolated_sot: Path) -> None:
+    """Forward-compat — unknown field 자동 drop."""
+    _write(isolated_sot, {"messages_breakpoints": 2, "future_field": "x"})
+    assert _load_cache_policy_override() == {"messages_breakpoints": 2}
+
+
+def test_strict_env_var_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_CACHE_POLICY_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_CACHE_POLICY_STRICT", "1")
+    with pytest.raises(RuntimeError, match="GEODE_CACHE_POLICY_OVERRIDE"):
+        _load_cache_policy_override()
+
+
+def test_env_var_without_strict_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_CACHE_POLICY_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_CACHE_POLICY_STRICT", raising=False)
+    assert _load_cache_policy_override() is None
+
+
+def test_operator_local_layer_priority(isolated_sot: Path) -> None:
+    operator_local = isolated_sot.parent / "operator-local-cache-policy.json"
+    operator_local.write_text(json.dumps({"messages_breakpoints": 1}), encoding="utf-8")
+    _write(isolated_sot, {"messages_breakpoints": 3})
+    assert _load_cache_policy_override() == {"messages_breakpoints": 1}
+
+
+# Apply -----------------------------------------------------------------------
+
+
+def test_apply_none_returns_default() -> None:
+    assert apply_cache_policy_breakpoints(3, None) == 3
+
+
+def test_apply_empty_dict_returns_default() -> None:
+    assert apply_cache_policy_breakpoints(3, {}) == 3
+
+
+def test_apply_override_returns_policy_value() -> None:
+    assert apply_cache_policy_breakpoints(3, {"messages_breakpoints": 1}) == 1
+
+
+def test_apply_override_zero_returns_zero() -> None:
+    """0 is a valid override (disables messages caching entirely)."""
+    assert apply_cache_policy_breakpoints(3, {"messages_breakpoints": 0}) == 0
+
+
+def test_apply_with_different_defaults() -> None:
+    assert apply_cache_policy_breakpoints(0, None) == 0
+    assert apply_cache_policy_breakpoints(2, None) == 2
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_anthropic_provider_imports_reader_and_apply() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/llm/providers/anthropic.py").read_text(encoding="utf-8")
+    assert "_load_cache_policy_override" in src
+    assert "apply_cache_policy_breakpoints" in src
+
+
+def test_anthropic_provider_uses_apply_before_cache_control() -> None:
+    """`n_breakpoints = apply_cache_policy_breakpoints(...)` must precede
+    the actual `apply_messages_cache_control(...)` call where the override
+    flows into ``n_breakpoints=`` kwarg."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/llm/providers/anthropic.py").read_text(encoding="utf-8")
+    apply_idx = src.find("apply_cache_policy_breakpoints(")
+    # Find apply_messages_cache_control that uses our n_breakpoints variable.
+    call_idx = src.find("n_breakpoints=n_breakpoints")
+    assert apply_idx > 0, "apply_cache_policy_breakpoints must be invoked"
+    assert call_idx > 0, "apply_messages_cache_control must use n_breakpoints kwarg"
+    assert apply_idx < call_idx, (
+        "apply_cache_policy_breakpoints must precede its consumer"
+    )
+
+
+# Path constants --------------------------------------------------------------
+
+
+def test_path_constants_present() -> None:
+    from core.paths import GLOBAL_CACHE_POLICY_PATH, OPERATOR_LOCAL_CACHE_POLICY_PATH
+
+    assert GLOBAL_CACHE_POLICY_PATH.name == "cache-policy.json"
+    assert OPERATOR_LOCAL_CACHE_POLICY_PATH.name == "cache-policy.json"
+    assert "policies" in str(GLOBAL_CACHE_POLICY_PATH)
+    assert "self-improving-loop" in str(OPERATOR_LOCAL_CACHE_POLICY_PATH)
+
+
+# Env wiring in train.py ------------------------------------------------------
+
+
+def test_train_py_sets_cache_policy_env_pair() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_CACHE_POLICY_OVERRIDE" in src
+    assert "GEODE_CACHE_POLICY_STRICT" in src
+    assert "GLOBAL_CACHE_POLICY_PATH" in src
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_cache_policy_json_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "cache-policy.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("cache_policy.py" in h for h in hits), (
+        f"cache-policy.json must appear in core/llm/cache_policy.py. hits={hits}"
+    )


### PR DESCRIPTION
## Summary
- ADR-013 의 다섯번째 mutation 표면 — mutator 가 Anthropic API 의 `cache_control` breakpoint 수 (0..3) 를 JSON 으로 mutate.
- `apply_messages_cache_control` 의 `n_breakpoints` kwarg 에 policy 값을 흘려보냄 (정책 부재 시 default 3 — no behavior change).
- 20 invariant test — reader 10 + apply 5 + wiring + path + env + ALIVE marker.

## Why
Anthropic 의 messages-block cache_control breakpoint 는 trade-off 가 명확: 각 breakpoint 가 \$0.10/MTok 의 cached-prefix 오버헤드를 더하지만, 캐시 적중 시 nearby turn 의 input-token 비용을 0.1× 로 줄임. 짧은 task 에서는 overhead 가 hit rate 를 초과해 손해, 긴 multi-turn loop 에서는 hit rate 가 압도해 이득. 단일 하드코딩(3)은 둘 다 최적이 아님 — mutator 가 workload 마다 학습.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_CACHE_POLICY_PATH` + `OPERATOR_LOCAL_CACHE_POLICY_PATH` 2 상수 |
| `core/llm/cache_policy.py` | **신규** — reader + apply. schema `{messages_breakpoints: int 0..3}` |
| `core/llm/providers/anthropic.py` | `apply_messages_cache_control(messages)` → `n_breakpoints = apply_cache_policy_breakpoints(MAX_MESSAGE_CACHE_BREAKPOINTS, _load_cache_policy_override()); apply_messages_cache_control(messages, n_breakpoints=n_breakpoints)` |
| `autoresearch/train.py` | audit subprocess `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_t5_cache_policy.py` | 20 invariant test |
| `CHANGELOG.md` | `### Added` PR-T5 entry |

## Schema
```json
{
  "messages_breakpoints": 3
}
```
Range: `0 <= int <= 3` (Anthropic의 4-breakpoint cap 중 system block 이 1-2 소모, messages 가 나머지 3 점유).

## Resolution order
1. `GEODE_CACHE_POLICY_OVERRIDE` env var — `_STRICT=1` 동반 시 strict.
2. `~/.geode/self-improving-loop/cache-policy.json` — operator-local.
3. `autoresearch/state/policies/cache-policy.json` — in-repo.
4. `None` → default `MAX_MESSAGE_CACHE_BREAKPOINTS=3`.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 | Implemented | SoT 2 + Path 2 + Reader + Entry + Env 쌍 |
| 3-layer SoT chain 재사용 | Implemented | `resolve_sot()` |
| Bool-is-int 함정 방어 | Implemented | `_validate_schema` 가 `isinstance(value, bool)` 명시 reject |
| Out-of-range graceful drop | Implemented | `_coerce` 가 0-3 외 값 drop + WARNING |
| No behavior change when SoT 부재 | Implemented | `apply(default, None) == default` |
| Forward-compat | Implemented | unknown field 자동 drop |
| ALIVE marker | Implemented | `cache-policy.json` grep → reader |

## Verification
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy core/ clean (324 files)
- [x] lint-imports (4 contracts kept)
- [x] pytest tests/test_t5_cache_policy.py — 20/20 pass
- [x] Tier 2 untouched

## Reference
ADR-013 — `docs/adr/ADR-013-mutation-surface-expansion-via-json-schema.md`
Frontier: Anthropic prompt caching docs — `cache_control` count canonical knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)