### PR TITLE
feat(adr-013-t6): heuristic indicators JSON mutation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,33 @@ functional change.
 
 ### Added
 
+- **PR-T6 — Heuristic indicators JSON mutation surface (ADR-013).**
+  mutator 가 keyword/phrase library 를 evolve — task-triage 시 매칭되는
+  complexity / high_risk / time_pressure 표지어. Promptbreeder-식
+  진화: 3 group 의 phrase list 가 JSON 에서 mutate → agent 의 task
+  classification 정확도 → 적절한 strategy 선택 (careful/fast,
+  confirm-first/proceed) → ux_means.success_rate 영향. **T3 (style
+  guide enum)** 과 분리: T3 는 fixed style 선택, T6 는 concrete phrase
+  library. **5-element 패턴** (S0a 검증): SoT
+  `autoresearch/state/policies/heuristics.json` (in-repo) +
+  `~/.geode/self-improving-loop/heuristics.json` (operator-local) /
+  `GLOBAL_HEURISTICS_PATH` + `OPERATOR_LOCAL_HEURISTICS_PATH`
+  `core/paths.py` 추가 / `core/agent/heuristics_policy.py` reader
+  (`_load_heuristics_override` + `apply_heuristics_policy`, schema
+  `{complexity_indicators / high_risk_indicators / time_pressure_indicators:
+  list[str]}`) / `core/agent/system_prompt.py:build_system_prompt` 가
+  T3 style-guide apply 직후 `static = apply_heuristics_policy(static,
+  _load_heuristics_override())` 호출 → static (cache-eligible) 영역에
+  `<heuristic_indicators>` 블록 append (정책 부재 시 static 그대로 —
+  no behavior change) / `GEODE_HEURISTICS_OVERRIDE` +
+  `GEODE_HEURISTICS_STRICT=1` env pair. `_coerce` 가 unknown group +
+  empty string + duplicate phrase 셋 다 graceful drop (forward-compat +
+  order-preserving dedupe). XML escape 로 `<`, `&`, `"` 안전 처리.
+  **25 invariant test** — reader graceful/strict 13 + apply 7 + wiring +
+  path + env + ALIVE marker. Frontier: Promptbreeder (Fernando et al.,
+  2023) curriculum loop. **T6 머지 시 ADR-013 6 surface 시퀀스 종결**
+  (T1 #1416 + T2 #1418 + T3 #1419 + T4 #1420 + T5 #1421 + T6 #1422).
+
 - **PR-T5 — Cache breakpoint policy JSON mutation surface (ADR-013).**
   mutator 가 Anthropic API 의 `apply_messages_cache_control(messages,
   n_breakpoints=N)` 의 N 값을 JSON 으로 mutate (0..3, Anthropic cap 의

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -649,6 +649,7 @@ def run_audit(
     from core.paths import (
         GLOBAL_CACHE_POLICY_PATH,
         GLOBAL_DECOMPOSITION_POLICY_PATH,
+        GLOBAL_HEURISTICS_PATH,
         GLOBAL_PROVIDER_ROUTING_PATH,
         GLOBAL_REFLECTION_POLICY_PATH,
         GLOBAL_SKILL_CATALOG_PATH,
@@ -686,6 +687,9 @@ def run_audit(
     if GLOBAL_CACHE_POLICY_PATH.is_file():
         env["GEODE_CACHE_POLICY_OVERRIDE"] = str(GLOBAL_CACHE_POLICY_PATH)
         env["GEODE_CACHE_POLICY_STRICT"] = "1"
+    if GLOBAL_HEURISTICS_PATH.is_file():
+        env["GEODE_HEURISTICS_OVERRIDE"] = str(GLOBAL_HEURISTICS_PATH)
+        env["GEODE_HEURISTICS_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/agent/heuristics_policy.py
+++ b/core/agent/heuristics_policy.py
@@ -1,0 +1,180 @@
+"""Heuristic indicators SoT reader — ADR-013 T6, JSON mutation surface.
+
+Mutator evolves keyword/phrase lists that prime the LLM's task-triage
+heuristics — complexity / risk / time-pressure markers injected into the
+system prompt's static block. Promptbreeder-식 evolution: agent uses
+indicator phrases to classify the current request and pick a strategy
+(careful-mode vs fast-mode, confirm-first vs proceed, etc.).
+
+Different from T3 (style guide enums) — T3 picks a *fixed style*; T6
+exposes *concrete phrase libraries* the LLM consults at parse-time.
+
+**SoT schema** (모든 indicator group optional):
+
+.. code-block:: json
+
+    {
+      "complexity_indicators": ["multi-step", "if and only if", "compare and contrast"],
+      "high_risk_indicators": ["delete all", "drop table", "rm -rf", "force push"],
+      "time_pressure_indicators": ["asap", "urgent", "deadline"]
+    }
+
+빈 정책 / 누락 group → 해당 group skip (no-op). Unknown group / 부적합
+schema → graceful drop (forward-compat).
+
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21 shared chain):
+
+1. ``GEODE_HEURISTICS_OVERRIDE`` env var — explicit override.
+   - With ``GEODE_HEURISTICS_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag (operator daily): graceful (no fall-through).
+2. ``~/.geode/self-improving-loop/heuristics.json`` — operator-local, graceful.
+3. ``autoresearch/state/policies/heuristics.json`` — in-repo, graceful.
+4. ``None`` — no-op.
+
+**Frontier**: Promptbreeder (Fernando et al., 2023) — self-referential
+self-improvement of mutation operators + thinking styles, JSON-driven
+phrase evolution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from html import escape
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_HEURISTICS_PATH, OPERATOR_LOCAL_HEURISTICS_PATH
+from core.self_improving_loop.sot_resolution import resolve_sot
+
+log = logging.getLogger(__name__)
+
+_HEURISTICS_OVERRIDE_ENV = "GEODE_HEURISTICS_OVERRIDE"
+
+_HEURISTICS_SOT_PATH = GLOBAL_HEURISTICS_PATH
+"""Cross-process in-repo SoT path (T6, 2026-05-21). Module-local alias."""
+
+_OPERATOR_LOCAL_HEURISTICS_PATH = OPERATOR_LOCAL_HEURISTICS_PATH
+"""Operator-local SoT path. Module-local alias for monkey-patch."""
+
+# Known indicator groups + their human-readable labels in the rendered block.
+_GROUP_COMPLEXITY = "complexity_indicators"
+_GROUP_HIGH_RISK = "high_risk_indicators"
+_GROUP_TIME_PRESSURE = "time_pressure_indicators"
+
+_GROUP_LABELS: dict[str, str] = {
+    _GROUP_COMPLEXITY: "complexity",
+    _GROUP_HIGH_RISK: "high_risk",
+    _GROUP_TIME_PRESSURE: "time_pressure",
+}
+
+
+def _load_heuristics_override() -> dict[str, list[str]] | None:
+    """Return the active heuristics dict, or ``None`` if no SoT applies."""
+    selection = resolve_sot(
+        env_var=_HEURISTICS_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_HEURISTICS_PATH,
+        in_repo=_HEURISTICS_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
+
+
+def _strict_load(path: Path) -> dict[str, list[str]]:
+    if not path.is_file():
+        raise RuntimeError(f"{_HEURISTICS_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{_HEURISTICS_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    _validate_schema(data, path)
+    return _coerce(data)
+
+
+def _graceful_load(path: Path) -> dict[str, list[str]] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        log.warning("heuristics SoT at %s is unreadable; ignoring", path)
+        return None
+    try:
+        _validate_schema(data, path)
+    except RuntimeError as exc:
+        log.warning("heuristics SoT at %s schema invalid: %s; ignoring", path, exc)
+        return None
+    return _coerce(data)
+
+
+def _validate_schema(data: Any, path: Path) -> None:
+    """Top-level dict; each group value must be ``list[str]`` if present."""
+    if not isinstance(data, dict):
+        raise RuntimeError(f"heuristics at {path} must be a dict")
+    for group, value in data.items():
+        if not isinstance(group, str):
+            type_name = type(group).__name__
+            raise RuntimeError(f"heuristics at {path} key must be str, got {type_name}")
+        if not isinstance(value, list):
+            type_name = type(value).__name__
+            raise RuntimeError(f"heuristics at {path}[{group!r}] must be list, got {type_name}")
+        if not all(isinstance(p, str) for p in value):
+            raise RuntimeError(f"heuristics at {path}[{group!r}] must be list[str]")
+
+
+def _coerce(data: dict[str, Any]) -> dict[str, list[str]]:
+    """Extract known groups + drop empty strings / dedupe / preserve order."""
+    result: dict[str, list[str]] = {}
+    for group in _GROUP_LABELS:
+        if group not in data:
+            continue
+        phrases = data[group]
+        if not isinstance(phrases, list):
+            continue
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for p in phrases:
+            if isinstance(p, str) and p and p not in seen:
+                seen.add(p)
+                normalized.append(p)
+        if normalized:
+            result[group] = normalized
+    return result
+
+
+def apply_heuristics_policy(
+    base_prompt: str,
+    policy: dict[str, list[str]] | None,
+) -> str:
+    """Append a ``<heuristic_indicators>`` block to ``base_prompt``.
+
+    Block renders each non-empty group as ``<group label="...">phrase1,
+    phrase2, ...</group>``. Cache-friendly (lives in static section).
+
+    ``policy is None`` / 빈 dict → ``base_prompt`` unchanged (no behavior
+    change).
+    """
+    if not policy:
+        return base_prompt
+    lines: list[str] = ["<heuristic_indicators>"]
+    rendered_any = False
+    for group, label in _GROUP_LABELS.items():
+        phrases = policy.get(group)
+        if not phrases:
+            continue
+        safe_phrases = ", ".join(escape(p, quote=False) for p in phrases)
+        lines.append(f'  <group label="{escape(label, quote=True)}">{safe_phrases}</group>')
+        rendered_any = True
+    lines.append("</heuristic_indicators>")
+    if not rendered_any:
+        return base_prompt
+    block = "\n".join(lines)
+    if base_prompt:
+        return f"{base_prompt}\n\n{block}"
+    return block
+
+
+__all__ = ["apply_heuristics_policy"]

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -23,6 +23,10 @@ from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 
+from core.agent.heuristics_policy import (
+    _load_heuristics_override,
+    apply_heuristics_policy,
+)
 from core.agent.style_guide_policy import (
     _load_style_guide_override,
     apply_style_guide_policy,
@@ -218,6 +222,10 @@ def build_system_prompt(model: str = "") -> str:
     # <response_style> 블록 append — static 영역 이므로 cache-eligible
     # (정책 변경 시에만 cache miss).
     static = apply_style_guide_policy(static, _load_style_guide_override())
+
+    # ADR-013 T6 (2026-05-21) — heuristic indicators append to static.
+    # Promptbreeder-식 phrase library — agent 가 task-triage 시 매칭.
+    static = apply_heuristics_policy(static, _load_heuristics_override())
 
     # G10: Agent identity (opt-in via GEODE_PERSONA=on; default OFF so
     # GEODE behaves as a thin wrapper around the base model).

--- a/core/paths.py
+++ b/core/paths.py
@@ -128,6 +128,14 @@ OPERATOR_LOCAL_PROVIDER_ROUTING_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "provide
 # $0.10/MTok 오버헤드). ↓ → cache hit ↓ but per-call cost ↓.
 GLOBAL_CACHE_POLICY_PATH = GLOBAL_POLICIES_DIR / "cache-policy.json"
 OPERATOR_LOCAL_CACHE_POLICY_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "cache-policy.json"
+# ADR-013 T6 (2026-05-21) — Heuristic indicators mutation SoT. Mutator
+# evolves the keyword/phrase list that primes the LLM's task-triage
+# heuristics — complexity / risk / time-pressure markers injected into
+# the system prompt static block. Promptbreeder-식 evolution: agent
+# uses indicators to classify task → better triage → ux_means success
+# rate ↑.
+GLOBAL_HEURISTICS_PATH = GLOBAL_POLICIES_DIR / "heuristics.json"
+OPERATOR_LOCAL_HEURISTICS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "heuristics.json"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/tests/test_t6_heuristic_indicators.py
+++ b/tests/test_t6_heuristic_indicators.py
@@ -1,0 +1,248 @@
+"""ADR-013 T6 — Heuristic indicators JSON mutation surface invariants.
+
+5-element 패턴:
+- SoT: heuristics.json
+- Path: GLOBAL_HEURISTICS_PATH + OPERATOR_LOCAL_HEURISTICS_PATH
+- Reader: core/agent/heuristics_policy.py
+- Entry: core/agent/system_prompt.py:build_system_prompt
+- Env: GEODE_HEURISTICS_OVERRIDE + GEODE_HEURISTICS_STRICT
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.agent.heuristics_policy import (
+    _load_heuristics_override,
+    apply_heuristics_policy,
+)
+
+from core.agent import heuristics_policy
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "heuristics.json"
+    operator_local = tmp_path / "operator-local-heuristics.json"
+    monkeypatch.setattr(heuristics_policy, "_HEURISTICS_SOT_PATH", sot)
+    monkeypatch.setattr(heuristics_policy, "_OPERATOR_LOCAL_HEURISTICS_PATH", operator_local)
+    monkeypatch.delenv("GEODE_HEURISTICS_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_HEURISTICS_STRICT", raising=False)
+    yield sot
+
+
+def _write(sot: Path, payload: dict[str, Any]) -> None:
+    sot.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_heuristics_override() is None
+
+
+def test_load_returns_none_when_unreadable(isolated_sot: Path) -> None:
+    isolated_sot.write_text("bad json {", encoding="utf-8")
+    assert _load_heuristics_override() is None
+
+
+def test_load_returns_none_when_value_not_list(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"complexity_indicators": "single string"})
+    assert _load_heuristics_override() is None
+
+
+def test_load_returns_none_when_value_contains_non_str(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"complexity_indicators": ["x", 42]})
+    assert _load_heuristics_override() is None
+
+
+def test_load_valid_payload_all_groups(isolated_sot: Path) -> None:
+    payload = {
+        "complexity_indicators": ["multi-step", "if and only if"],
+        "high_risk_indicators": ["delete all", "drop table"],
+        "time_pressure_indicators": ["asap", "urgent"],
+    }
+    _write(isolated_sot, payload)
+    assert _load_heuristics_override() == payload
+
+
+def test_load_partial_groups(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"complexity_indicators": ["x"]})
+    assert _load_heuristics_override() == {"complexity_indicators": ["x"]}
+
+
+def test_load_dedupes_phrases_preserving_order(isolated_sot: Path) -> None:
+    _write(
+        isolated_sot,
+        {"complexity_indicators": ["a", "b", "a", "c", "b"]},
+    )
+    assert _load_heuristics_override() == {"complexity_indicators": ["a", "b", "c"]}
+
+
+def test_load_drops_empty_strings(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"complexity_indicators": ["a", "", "b"]})
+    assert _load_heuristics_override() == {"complexity_indicators": ["a", "b"]}
+
+
+def test_load_drops_empty_group(isolated_sot: Path) -> None:
+    _write(isolated_sot, {"complexity_indicators": [], "high_risk_indicators": ["x"]})
+    assert _load_heuristics_override() == {"high_risk_indicators": ["x"]}
+
+
+def test_load_unknown_group_dropped(isolated_sot: Path) -> None:
+    """Forward-compat — unknown group 자동 drop."""
+    _write(
+        isolated_sot,
+        {"complexity_indicators": ["x"], "unknown_indicators": ["y"]},
+    )
+    assert _load_heuristics_override() == {"complexity_indicators": ["x"]}
+
+
+def test_strict_env_var_raises_on_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEODE_HEURISTICS_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("GEODE_HEURISTICS_STRICT", "1")
+    with pytest.raises(RuntimeError, match="GEODE_HEURISTICS_OVERRIDE"):
+        _load_heuristics_override()
+
+
+def test_env_var_without_strict_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_HEURISTICS_OVERRIDE", str(tmp_path / "nope.json"))
+    monkeypatch.delenv("GEODE_HEURISTICS_STRICT", raising=False)
+    assert _load_heuristics_override() is None
+
+
+def test_operator_local_layer_priority(isolated_sot: Path) -> None:
+    operator_local = isolated_sot.parent / "operator-local-heuristics.json"
+    operator_local.write_text(json.dumps({"complexity_indicators": ["from-ops"]}), encoding="utf-8")
+    _write(isolated_sot, {"complexity_indicators": ["from-repo"]})
+    assert _load_heuristics_override() == {"complexity_indicators": ["from-ops"]}
+
+
+# Apply -----------------------------------------------------------------------
+
+
+_BASE = "BASE PROMPT TEXT"
+
+
+def test_apply_none_is_noop() -> None:
+    assert apply_heuristics_policy(_BASE, None) == _BASE
+
+
+def test_apply_empty_dict_is_noop() -> None:
+    assert apply_heuristics_policy(_BASE, {}) == _BASE
+
+
+def test_apply_all_empty_groups_is_noop() -> None:
+    """policy 가 있어도 모든 group 이 비어있으면 base 그대로."""
+    assert apply_heuristics_policy(_BASE, {"complexity_indicators": []}) == _BASE
+
+
+def test_apply_single_group_renders_block() -> None:
+    out = apply_heuristics_policy(_BASE, {"complexity_indicators": ["multi-step"]})
+    assert out.startswith(_BASE)
+    assert "<heuristic_indicators>" in out
+    assert 'label="complexity"' in out
+    assert "multi-step" in out
+    assert "</heuristic_indicators>" in out
+
+
+def test_apply_all_groups_renders_each() -> None:
+    out = apply_heuristics_policy(
+        _BASE,
+        {
+            "complexity_indicators": ["multi-step"],
+            "high_risk_indicators": ["delete all"],
+            "time_pressure_indicators": ["asap"],
+        },
+    )
+    assert 'label="complexity"' in out
+    assert 'label="high_risk"' in out
+    assert 'label="time_pressure"' in out
+    assert "multi-step" in out
+    assert "delete all" in out
+    assert "asap" in out
+
+
+def test_apply_xml_escapes_special_chars() -> None:
+    out = apply_heuristics_policy(_BASE, {"complexity_indicators": ["foo & bar", "<html>"]})
+    assert "foo &amp; bar" in out
+    assert "&lt;html&gt;" in out
+    assert "<html>" not in out.replace("&lt;html&gt;", "")
+
+
+def test_apply_with_empty_base_prompt() -> None:
+    out = apply_heuristics_policy("", {"complexity_indicators": ["x"]})
+    assert out.startswith("<heuristic_indicators>")
+
+
+# Wiring ----------------------------------------------------------------------
+
+
+def test_system_prompt_imports_reader_and_apply() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/system_prompt.py").read_text(encoding="utf-8")
+    assert "_load_heuristics_override" in src
+    assert "apply_heuristics_policy" in src
+
+
+def test_system_prompt_wires_apply_into_static() -> None:
+    """`static = apply_heuristics_policy(static, _load_heuristics_override())`
+    must appear AFTER the T3 style-guide apply, both in the static path."""
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "core/agent/system_prompt.py").read_text(encoding="utf-8")
+    style_idx = src.find("apply_style_guide_policy(static,")
+    heur_idx = src.find("apply_heuristics_policy(static,")
+    assert style_idx > 0
+    assert heur_idx > 0
+    # Heuristics applied AFTER style-guide (so its block renders below).
+    assert style_idx < heur_idx
+
+
+# Path constants --------------------------------------------------------------
+
+
+def test_path_constants_present() -> None:
+    from core.paths import GLOBAL_HEURISTICS_PATH, OPERATOR_LOCAL_HEURISTICS_PATH
+
+    assert GLOBAL_HEURISTICS_PATH.name == "heuristics.json"
+    assert OPERATOR_LOCAL_HEURISTICS_PATH.name == "heuristics.json"
+    assert "policies" in str(GLOBAL_HEURISTICS_PATH)
+    assert "self-improving-loop" in str(OPERATOR_LOCAL_HEURISTICS_PATH)
+
+
+# Env wiring in train.py ------------------------------------------------------
+
+
+def test_train_py_sets_heuristics_env_pair() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_HEURISTICS_OVERRIDE" in src
+    assert "GEODE_HEURISTICS_STRICT" in src
+    assert "GLOBAL_HEURISTICS_PATH" in src
+
+
+# ALIVE marker ----------------------------------------------------------------
+
+
+def test_heuristics_json_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "heuristics.json" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("heuristics_policy.py" in h for h in hits), (
+        f"heuristics.json must appear in core/agent/heuristics_policy.py. hits={hits}"
+    )


### PR DESCRIPTION
## Summary
- ADR-013 의 마지막 (여섯번째) mutation 표면 — mutator 가 task-triage phrase library 를 evolve (complexity / high_risk / time_pressure 3 group).
- T3 (style guide enum) 과 분리: T3 는 fixed style 선택, T6 는 concrete phrase library — Promptbreeder-식 진화.
- 25 invariant test — reader 13 + apply 7 + wiring + path + env + ALIVE marker.

## Why
응답 스타일 (T3) 은 fixed → mutator 의 search space 가 작은 enum 격자. 그러나 *어떤 신호로 task 를 분류하느냐* 는 별도 lever — 운영자/agent 가 "multi-step / drop table / asap" 같은 phrase 를 보면 strategy switch. 이 phrase 셋 자체가 mutate 대상. Promptbreeder (Fernando et al., 2023) 가 phrase-list mutation 으로 자기-개선하는 패턴 그대로 적용.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_HEURISTICS_PATH` + `OPERATOR_LOCAL_HEURISTICS_PATH` 2 상수 |
| `core/agent/heuristics_policy.py` | **신규** — reader + apply. 3-group schema |
| `core/agent/system_prompt.py:build_system_prompt` | T3 style-guide apply 직후 `static = apply_heuristics_policy(static, _load_heuristics_override())` |
| `autoresearch/train.py` | audit subprocess `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_t6_heuristic_indicators.py` | 25 invariant test |
| `CHANGELOG.md` | `### Added` PR-T6 entry |

## Schema
```json
{
  "complexity_indicators": ["multi-step", "if and only if", "compare and contrast"],
  "high_risk_indicators": ["delete all", "drop table", "rm -rf", "force push"],
  "time_pressure_indicators": ["asap", "urgent", "deadline"]
}
```

## Resolution order
1. `GEODE_HEURISTICS_OVERRIDE` env var — `_STRICT=1` 동반 시 strict.
2. `~/.geode/self-improving-loop/heuristics.json` — operator-local.
3. `autoresearch/state/policies/heuristics.json` — in-repo.
4. `None` → no-op.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 | Implemented | SoT 2 + Path 2 + Reader + Entry + Env 쌍 |
| 3-layer SoT chain 재사용 | Implemented | `resolve_sot()` |
| Per-group graceful (unknown group) | Implemented | `_coerce` 가 알려진 3 group 만 추출 |
| Duplicate phrase 제거 | Implemented | `_coerce` 의 order-preserving dedupe |
| Empty string drop | Implemented | `_coerce` 의 `isinstance(p, str) and p` filter |
| XML escape | Implemented | `<`, `&`, `"` 안전 처리 |
| T3 와 비충돌 | Implemented | system_prompt.py 의 T3 apply 직후 위치 |
| ALIVE marker | Implemented | `heuristics.json` grep → reader |

## Codex MCP review (fix-up applied)
- **#6 FAIL → fixed**: 첫 push 의 PR body / CHANGELOG 가 "ADR-013 6 surfaces 완성 — T1~T6 전체 머지" 주장했으나 실제로 T5 #1421 still open + T6 본 PR before merge. "T6 머지 시 ADR-013 6 surface 시퀀스 종결 (T5 #1421 머지 직후 T6 머지 권고 순서)" 로 정정.
- 다른 7/8 PASS — 5-element, apply correctness, schema validation, XML safety, no regression, Tier 2 untouched, ALIVE marker.

## Verification
- [x] ruff check + format clean
- [x] mypy clean
- [x] pytest tests/test_t6_heuristic_indicators.py — 25/25 pass
- [x] Tier 2 untouched
- [x] CI 8/8 (Detect / Lint+Format / Security / Type / macOS-install / ubuntu-install / Gate / Test) — 첫 push 8/8 PASS

## Reference
ADR-013 — `docs/adr/ADR-013-mutation-surface-expansion-via-json-schema.md`
Frontier: Promptbreeder (Fernando et al., 2023) — self-referential JSON-driven phrase evolution.

ADR-013 6-surface 시퀀스 (T5 #1421 머지 후 T6 머지 시 종결):
- T1 (#1416 merged) tool descriptions
- T2 (#1418 merged) skill catalog
- T3 (#1419 merged) style guide
- T4 (#1420 merged) provider routing
- T5 (#1421 open) cache policy
- T6 (#1422 this) heuristic indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)