### PR TITLE
feat(s4): task-completion seed cohort (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@ functional change.
 
 ### Added
 
+- **PR-S4 — task-completion seed cohort (ADR-012).** seed-generation 에
+  cohort 개념 도입 — 어떤 *axis* 의 regression 을 다음 generation 이 공격할지
+  결정. `petri_17dim` (default, BC) 와 `task_completion` (S4 신설) 2 cohort
+  로 시작, 추후 `admire_routing` / `bench_capability` 확장 forward-compat.
+  **`plugins/seed_generation/baseline_reader.py`**: (a) 3 신규 constant
+  `PETRI_17DIM_COHORT` / `TASK_COMPLETION_COHORT` / `SEED_COHORTS` export,
+  (b) 신규 picker `pick_regression_target(snapshot, cohort)` — cohort 별
+  signal direction 처리: petri 는 MAX (높을수록 concerning, rubric
+  invariant), task_completion 은 MIN (ux_means 의 normalized-higher-is-better
+  contract 따라 lowest 가 worst). Tie-break alphabetical. Unknown cohort
+  → `ValueError`. **`plugins/seed_generation/orchestrator.py:PipelineState`**:
+  `cohort: str = "petri_17dim"` field 추가 (BC). **기존
+  `pick_regression_target_dim` unchanged** — pre-S4 caller 그대로.
+  **13 invariant test** — cohort enum 3 + petri picker 2 +
+  task_completion picker 3 + validation 2 + BC 2 + export 1.
+  Generator/critic/evolver 의 cohort-specific prompt + CLI `--cohort`
+  flag 은 S4b 후속 PR (이 PR 은 picker + state schema 만).
+
 - **PR-S3 — 공동 ratchet: 4축 baseline.json (ADR-012).** `baseline.json`
   schema 가 pre-S3 `{dim_means, dim_stderr}` 에서 S3 의 **5-field 4축
   schema** `{dim_means, dim_stderr, ux_means, admire_means, bench_means}`

--- a/plugins/seed_generation/baseline_reader.py
+++ b/plugins/seed_generation/baseline_reader.py
@@ -43,14 +43,37 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "PETRI_17DIM_COHORT",
+    "SEED_COHORTS",
+    "TASK_COMPLETION_COHORT",
     "BaselineSnapshot",
     "MetaReviewSnapshot",
     "format_evidence_block",
     "format_priors_block",
     "load_baseline",
     "load_latest_meta_review",
+    "pick_regression_target",
     "pick_regression_target_dim",
 ]
+
+# ADR-012 S4 (2026-05-21) — seed cohort enum. A cohort labels what
+# *kind* of regression the next generation should attack:
+#
+# - ``petri_17dim`` (default, pre-S4 behaviour) — picks the worst dim
+#   from Petri's 17-dim universe (critical / auxiliary tiers). The
+#   resulting seed teaches Petri's auditor to elicit that vulnerability
+#   on the next audit.
+# - ``task_completion`` (S4 new) — picks the worst ux_means field
+#   (success_rate is the strongest signal; token_cost / latency /
+#   revert_ratio rotate in as success_rate saturates). The seed asks
+#   the agent to complete a task the prior generation failed.
+#
+# Picking happens through :func:`pick_regression_target`. The two-cohort
+# space is forward-compatible: adding ``admire_routing`` or
+# ``bench_capability`` is a single tuple entry + branch.
+PETRI_17DIM_COHORT = "petri_17dim"
+TASK_COMPLETION_COHORT = "task_completion"
+SEED_COHORTS: tuple[str, ...] = (PETRI_17DIM_COHORT, TASK_COMPLETION_COHORT)
 
 
 @dataclass(frozen=True)
@@ -272,6 +295,44 @@ def pick_regression_target_dim(
 
     top_value = max(candidates.values())
     return min((d for d, v in candidates.items() if v == top_value), default=None)
+
+
+def pick_regression_target(
+    snapshot: BaselineSnapshot,
+    cohort: str = PETRI_17DIM_COHORT,
+    *,
+    prefer_critical: bool = True,
+) -> str | None:
+    """Return the worst-regressed signal name for ``cohort`` (ADR-012 S4).
+
+    Cohort-aware target picker:
+
+    - ``petri_17dim`` (default) — delegates to
+      :func:`pick_regression_target_dim` (worst dim from the operational
+      Petri tier). ``prefer_critical`` is honoured.
+    - ``task_completion`` — picks the worst ux_means field. The ux axis
+      stores normalized-higher-is-better signals (S1 contract), so the
+      *lowest* value is the worst. ``prefer_critical`` is ignored because
+      ux fields don't carry a tier (each is treated equally; the loop's
+      weight schedule lives in :data:`autoresearch.ux_means.UX_DIM_WEIGHTS`).
+
+    Returns ``None`` when the relevant axis on the snapshot is empty —
+    the caller then prompts for an explicit target or falls back to
+    cohort-specific defaults (e.g. ``"success_rate"`` for task_completion).
+
+    Unknown cohort raises ``ValueError`` — the cohort space is small and
+    enumerated, so a typo is more likely a bug than a forward-compat
+    expectation.
+    """
+    if cohort == PETRI_17DIM_COHORT:
+        return pick_regression_target_dim(snapshot, prefer_critical=prefer_critical)
+    if cohort == TASK_COMPLETION_COHORT:
+        candidates = snapshot.ux_means
+        if not candidates:
+            return None
+        bottom = min(candidates.values())
+        return min((k for k, v in candidates.items() if v == bottom), default=None)
+    raise ValueError(f"unknown seed-generation cohort {cohort!r}; expected one of {SEED_COHORTS}")
 
 
 LATEST_PETRI_EVAL_PATH = Path.home() / ".geode" / "petri" / "logs" / "latest.eval"

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -72,6 +72,9 @@ def _state_to_json(state: PipelineState) -> str:
     payload: dict[str, Any] = {
         "run_id": state.run_id,
         "target_dim": state.target_dim,
+        # ADR-012 S4 (2026-05-21) — persist cohort so a state.json
+        # replay re-hydrates the same picker semantics.
+        "cohort": state.cohort,
         "gen_tag": state.gen_tag,
         "candidates_requested": state.candidates_requested,
         "pool_path_in": str(state.pool_path_in) if state.pool_path_in else None,

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -145,6 +145,12 @@ class PipelineState:
     run_id: str
     target_dim: str
     gen_tag: str
+    # ADR-012 S4 (2026-05-21) — seed cohort label. Default preserves
+    # the pre-S4 contract (Petri 17-dim). Switching to ``"task_completion"``
+    # tells the picker + downstream agents to interpret ``target_dim``
+    # as a ux_means field (e.g. ``"success_rate"``).
+    # See :mod:`plugins.seed_generation.baseline_reader.SEED_COHORTS`.
+    cohort: str = "petri_17dim"
     candidates_requested: int = 15
     pool_path_in: Path | None = None
     pool_path_out: Path | None = None

--- a/tests/test_s4_task_completion_cohort.py
+++ b/tests/test_s4_task_completion_cohort.py
@@ -136,3 +136,22 @@ def test_baseline_reader_exports_cohort_constants() -> None:
     assert "PETRI_17DIM_COHORT" in br.__all__
     assert "TASK_COMPLETION_COHORT" in br.__all__
     assert "pick_regression_target" in br.__all__
+
+
+def test_state_to_json_persists_cohort_field() -> None:
+    """S4 fix-up (Codex MCP FLAG, PR #1424) — ``_state_to_json`` must
+    include ``cohort`` so a state.json replay re-hydrates the same picker
+    semantics. Without persistence the field is effectively only an
+    in-memory hint."""
+    import json as _json
+
+    from plugins.seed_generation.orchestrator import PipelineState, _state_to_json
+
+    state = PipelineState(
+        run_id="r1",
+        target_dim="success_rate",
+        gen_tag="auto-HEAD",
+        cohort="task_completion",
+    )
+    payload = _json.loads(_state_to_json(state))
+    assert payload["cohort"] == "task_completion"

--- a/tests/test_s4_task_completion_cohort.py
+++ b/tests/test_s4_task_completion_cohort.py
@@ -1,0 +1,138 @@
+"""ADR-012 S4 — task-completion seed cohort invariants.
+
+Pins:
+- ``SEED_COHORTS`` enum has both petri_17dim + task_completion.
+- ``pick_regression_target(cohort)`` picks worst-dim (petri) vs
+  worst-ux-field (task_completion) — invariant: petri picks MAX value
+  (higher = more concerning per rubric), task_completion picks MIN value
+  (lower = more concerning per normalized-higher-is-better S1 contract).
+- ``PipelineState.cohort`` defaults to ``"petri_17dim"`` (BC).
+- Unknown cohort raises ValueError.
+"""
+
+from __future__ import annotations
+
+import pytest
+from plugins.seed_generation.baseline_reader import (
+    PETRI_17DIM_COHORT,
+    SEED_COHORTS,
+    TASK_COMPLETION_COHORT,
+    BaselineSnapshot,
+    pick_regression_target,
+)
+
+# Cohort enum -----------------------------------------------------------------
+
+
+def test_seed_cohorts_lists_two_canonical_values() -> None:
+    assert SEED_COHORTS == ("petri_17dim", "task_completion")
+    assert PETRI_17DIM_COHORT == "petri_17dim"
+    assert TASK_COMPLETION_COHORT == "task_completion"
+
+
+def test_pipeline_state_default_cohort_is_petri_17dim() -> None:
+    """Pre-S4 BC — operator/runner that doesn't set cohort gets the legacy
+    Petri 17-dim picker behavior."""
+    from plugins.seed_generation.orchestrator import PipelineState
+
+    state = PipelineState(run_id="r1", target_dim="broken_tool_use", gen_tag="auto-HEAD")
+    assert state.cohort == "petri_17dim"
+
+
+# Picker — petri_17dim cohort -------------------------------------------------
+
+
+def test_pick_petri_cohort_picks_worst_dim_max_value() -> None:
+    """Petri rubric: higher value = more concerning. Picker returns MAX."""
+    snap = BaselineSnapshot(
+        dim_means={"broken_tool_use": 3.4, "input_hallucination": 5.2, "overrefusal": 1.0},
+    )
+    # prefer_critical=False so the picker doesn't promote a critical-tier
+    # value above a larger auxiliary value (test focuses on top-overall).
+    target = pick_regression_target(snap, PETRI_17DIM_COHORT, prefer_critical=False)
+    assert target == "input_hallucination"
+
+
+def test_pick_petri_cohort_returns_none_when_empty() -> None:
+    assert pick_regression_target(BaselineSnapshot(), PETRI_17DIM_COHORT) is None
+
+
+# Picker — task_completion cohort --------------------------------------------
+
+
+def test_pick_task_completion_picks_lowest_ux_value() -> None:
+    """ux_means contract: normalized higher-is-better. Picker returns MIN."""
+    snap = BaselineSnapshot(
+        dim_means={"broken_tool_use": 5.0},  # irrelevant for this cohort
+        ux_means={
+            "success_rate": 0.35,
+            "token_cost_norm": 0.92,
+            "revert_ratio_norm": 0.71,
+            "latency_norm": 0.88,
+        },
+    )
+    target = pick_regression_target(snap, TASK_COMPLETION_COHORT)
+    assert target == "success_rate"
+
+
+def test_pick_task_completion_ties_break_alphabetically() -> None:
+    snap = BaselineSnapshot(
+        ux_means={"success_rate": 0.5, "latency_norm": 0.5, "token_cost_norm": 0.99},
+    )
+    target = pick_regression_target(snap, TASK_COMPLETION_COHORT)
+    # alphabetical: latency_norm < success_rate
+    assert target == "latency_norm"
+
+
+def test_pick_task_completion_returns_none_when_ux_empty() -> None:
+    """Pre-S3 baseline / no ux signal yet → fall through to None.
+    Caller (CLI) picks a default like 'success_rate' or prompts operator."""
+    snap = BaselineSnapshot(dim_means={"broken_tool_use": 5.0})  # ux_means={}
+    assert pick_regression_target(snap, TASK_COMPLETION_COHORT) is None
+
+
+# Cohort validation -----------------------------------------------------------
+
+
+def test_unknown_cohort_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unknown seed-generation cohort"):
+        pick_regression_target(BaselineSnapshot(), "bench_capability")
+
+
+def test_unknown_cohort_message_lists_valid_values() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        pick_regression_target(BaselineSnapshot(), "badness")
+    assert "petri_17dim" in str(excinfo.value)
+    assert "task_completion" in str(excinfo.value)
+
+
+# Backwards compat ------------------------------------------------------------
+
+
+def test_pick_regression_target_dim_unchanged() -> None:
+    """The pre-S4 ``pick_regression_target_dim`` keeps the same contract —
+    operating on dim_means only, no cohort awareness."""
+    from plugins.seed_generation.baseline_reader import pick_regression_target_dim
+
+    snap = BaselineSnapshot(dim_means={"input_hallucination": 5.2})
+    assert pick_regression_target_dim(snap, prefer_critical=False) == "input_hallucination"
+
+
+def test_pick_default_cohort_argument_matches_petri() -> None:
+    """Calling ``pick_regression_target(snap)`` (no cohort arg) defaults
+    to petri_17dim — preserves the legacy behavior for existing callers."""
+    snap = BaselineSnapshot(dim_means={"broken_tool_use": 3.4})
+    assert pick_regression_target(snap) == pick_regression_target(snap, PETRI_17DIM_COHORT)
+
+
+# Schema exports --------------------------------------------------------------
+
+
+def test_baseline_reader_exports_cohort_constants() -> None:
+    """Public API surface: cohort constants and the picker must be in __all__."""
+    import plugins.seed_generation.baseline_reader as br
+
+    assert "SEED_COHORTS" in br.__all__
+    assert "PETRI_17DIM_COHORT" in br.__all__
+    assert "TASK_COMPLETION_COHORT" in br.__all__
+    assert "pick_regression_target" in br.__all__


### PR DESCRIPTION
## Summary
- seed-generation 에 **cohort** 개념 도입 — petri_17dim (default, BC) + task_completion (신설).
- cohort 별 signal direction 처리: petri = MAX (rubric), task_completion = MIN (ux normalized HiB).
- 13 invariant test — cohort enum / picker / validation / BC / export.

## Why
S1 (ux_means) + S3 (4축 baseline.json) 의 작업으로 baseline 이 4축 모두 disk 통합됨. 다음 단계는 seed-generation 이 task-completion (ux_means) 축의 regression 도 target 할 수 있게 cohort 분기. 기존 picker `pick_regression_target_dim` 은 dim_means 만 보는데 — cohort 가 task_completion 일 땐 ux_means 의 가장 낮은 field 를 picker 가 골라야 함 (정상 방향 inversion).

## Changes
| File | Change |
|------|--------|
| `plugins/seed_generation/baseline_reader.py` | 3 cohort constant + `pick_regression_target(snapshot, cohort)` 신규 picker |
| `plugins/seed_generation/orchestrator.py:PipelineState` | `cohort: str = "petri_17dim"` field (BC) |
| `tests/test_s4_task_completion_cohort.py` | 13 invariant test |
| `CHANGELOG.md` | `### Added` PR-S4 entry |

## Cohorts
| Cohort | Source signal | Direction | Picker logic |
|--------|---------------|-----------|--------------|
| `petri_17dim` (default) | `dim_means` (Petri 17-dim) | higher = worse | MAX (with optional `prefer_critical`) |
| `task_completion` (new) | `ux_means` (success_rate / token_cost_norm / revert_ratio_norm / latency_norm) | normalized higher-is-better → lower = worse | MIN |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Cohort enum 3 constants | Implemented | exported via `__all__` |
| Picker cohort dispatch | Implemented | `pick_regression_target` 분기 |
| Petri picker BC | Implemented | `pick_regression_target_dim` 그대로 |
| PipelineState cohort field | Implemented | default = "petri_17dim" |
| Generator/critic prompt customization | Deferred | S4b 후속 PR |
| CLI `--cohort` flag | Deferred | S4b 후속 PR |
| Unknown cohort guard | Implemented | `ValueError` with valid-values 메시지 |

## Verification
- [x] ruff check + format clean
- [x] mypy clean
- [x] pytest tests/test_s4_task_completion_cohort.py — 13/13 pass
- [x] regression smoke — tests/plugins/seed_generation — 363 pass (376 total)
- [x] Tier 2 untouched

## Reference
ADR-012 §Decision.3 — seed cohort dispatch (post-S1/S3 4축 baseline).
Predecessors: PR-S1 (ux_means), PR-S3 (4축 baseline.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)