### PR TITLE
feat(m3): few-shot exemplar pool 자동 적재 (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,32 @@ functional change.
 
 ### Added
 
+- **PR-M3 — Few-shot exemplar pool 자동 적재 (ADR-012).** S5 (#1425)
+  에서 declared 만 됐던 `exemplars` slot 의 실제 *적재 메커니즘* 신설.
+  fitness gate 통과한 task-completion candidate 의 `(user_msg,
+  assistant_msg, fitness_delta, source)` triple 을 JSONL append-only
+  로 축적; runtime 에 top-K 선별해 messages 앞에 in-context exemplar
+  pair 로 삽입. **5-element 패턴**: SoT
+  `autoresearch/state/policies/few-shot-pool.jsonl` + operator-local /
+  `GLOBAL_FEW_SHOT_POOL_PATH` + `OPERATOR_LOCAL_FEW_SHOT_POOL_PATH`
+  추가 / `core/llm/few_shot_pool.py` reader (`FewShotExemplar` frozen
+  dataclass + `_load_few_shot_pool_override` + `apply_few_shot_pool`) /
+  inference entry 는 M4.4 deferred (현 PR 은 SoT + reader + apply
+  함수만, anthropic.py / openai.py 의 message 조립부 wiring 은
+  후속 PR) / `GEODE_FEW_SHOT_POOL_OVERRIDE` + `_STRICT=1` env pair.
+  **Per-line graceful** — JSONL 한 줄이 broken 이어도 나머지 줄은
+  유지 (`_parse_jsonl` 단위). bool fitness_delta 등 type trap →
+  0.0 coerce. missing/empty user_msg/assistant_msg → skip. T5 (cache
+  policy) 와 호환 — exemplar prefix 가 Anthropic cache breakpoint
+  의 stable prefix 로 자연스럽게 정렬. **23 invariant test** —
+  reader 11 (None / empty / blank / valid / per-line graceful /
+  missing field / non-dict / fitness coerce / bool trap / strict /
+  operator-local) + apply 6 (None / empty / max=0 / single insert /
+  top-K rank / cap / no-mutate) + 3-layer wiring + path const +
+  env wiring + ALIVE marker. Voyager / STaR 의 *successful trajectory
+  pool* 패턴 그대로 — 자기 성공 사례를 다음 cycle 의 in-context
+  exemplar 로 재투입.
+
 - **PR-M2 — Agent contract mutation slot (ADR-012).** AgentDefinition
   의 `role` / `system_prompt` / `tools` 를 mutator 가 evolve. `model`
   field 는 Tier 2 (안전성 invariants root) — 본 surface 에서 명시적

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -650,6 +650,7 @@ def run_audit(
         GLOBAL_AGENT_CONTRACTS_PATH,
         GLOBAL_CACHE_POLICY_PATH,
         GLOBAL_DECOMPOSITION_POLICY_PATH,
+        GLOBAL_FEW_SHOT_POOL_PATH,
         GLOBAL_HEURISTICS_PATH,
         GLOBAL_IN_CONTEXT_SLOTS_PATH,
         GLOBAL_PROVIDER_ROUTING_PATH,
@@ -698,6 +699,9 @@ def run_audit(
     if GLOBAL_AGENT_CONTRACTS_PATH.is_file():
         env["GEODE_AGENT_CONTRACTS_OVERRIDE"] = str(GLOBAL_AGENT_CONTRACTS_PATH)
         env["GEODE_AGENT_CONTRACTS_STRICT"] = "1"
+    if GLOBAL_FEW_SHOT_POOL_PATH.is_file():
+        env["GEODE_FEW_SHOT_POOL_OVERRIDE"] = str(GLOBAL_FEW_SHOT_POOL_PATH)
+        env["GEODE_FEW_SHOT_POOL_STRICT"] = "1"
     timeout_sec = _get_autoresearch_config().budget_minutes * 60 + 120
 
     _emit_journal(

--- a/core/llm/few_shot_pool.py
+++ b/core/llm/few_shot_pool.py
@@ -1,0 +1,193 @@
+"""Few-shot exemplar pool reader + applier — ADR-012 M3.
+
+S5 의 ``exemplars`` slot 의 실제 *적재 메커니즘*. fitness gate 통과한
+task-completion candidate 의 ``(user_msg, assistant_msg, fitness_delta)``
+triple 을 JSONL append-only 로 축적; runtime 에 top-K 선별해 messages
+앞에 in-context exemplar pair 로 삽입.
+
+**SoT schema** (JSONL — 한 줄 = 한 exemplar):
+
+.. code-block:: json
+
+    {"user_msg": "...",
+     "assistant_msg": "...",
+     "fitness_delta": 0.12,
+     "source": "audit_cycle_2026-05-21T0143"}
+
+Field 정의:
+- ``user_msg`` (str, required) — user role message 의 content.
+- ``assistant_msg`` (str, required) — assistant role의 successful response.
+- ``fitness_delta`` (float, optional, default 0.0) — baseline 대비 향상폭
+  (postive=개선). top-K rank 의 ordering key.
+- ``source`` (str, optional) — 추적용 메타.
+
+**Resolution order** (PR-BACKFILL-SOT 2026-05-21 shared chain):
+
+1. ``GEODE_FEW_SHOT_POOL_OVERRIDE`` env var — explicit override.
+   - With ``GEODE_FEW_SHOT_POOL_STRICT=1`` (audit subprocess): strict.
+   - Without strict flag: graceful (no fall-through).
+2. ``~/.geode/self-improving-loop/few-shot-pool.jsonl`` — operator-local.
+3. ``autoresearch/state/policies/few-shot-pool.jsonl`` — in-repo.
+4. ``None`` — no-op.
+
+**Frontier**: Anthropic prompt caching docs — 동일 prefix 의 multi-turn
+exemplar 가 cache 적중률 높음. T5 의 cache_policy 와 자연스럽게 호환
+(exemplar block 이 cache_control breakpoint 의 stable prefix 가 됨).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.paths import (
+    GLOBAL_FEW_SHOT_POOL_PATH,
+    OPERATOR_LOCAL_FEW_SHOT_POOL_PATH,
+)
+from core.self_improving_loop.sot_resolution import resolve_sot
+
+log = logging.getLogger(__name__)
+
+_FEW_SHOT_POOL_OVERRIDE_ENV = "GEODE_FEW_SHOT_POOL_OVERRIDE"
+
+_FEW_SHOT_POOL_SOT_PATH = GLOBAL_FEW_SHOT_POOL_PATH
+"""Cross-process in-repo SoT path (M3, 2026-05-21). Module-local alias."""
+
+_OPERATOR_LOCAL_FEW_SHOT_POOL_PATH = OPERATOR_LOCAL_FEW_SHOT_POOL_PATH
+"""Operator-local SoT path. Module-local alias for monkey-patch."""
+
+
+@dataclass(frozen=True)
+class FewShotExemplar:
+    """Single exemplar entry — frozen so callers can pass through safely."""
+
+    user_msg: str
+    assistant_msg: str
+    fitness_delta: float = 0.0
+    source: str = ""
+
+
+def _load_few_shot_pool_override() -> list[FewShotExemplar] | None:
+    """Return the active exemplar list (rank-by fitness_delta desc), or
+    ``None`` if no SoT applies."""
+    selection = resolve_sot(
+        env_var=_FEW_SHOT_POOL_OVERRIDE_ENV,
+        operator_local=_OPERATOR_LOCAL_FEW_SHOT_POOL_PATH,
+        in_repo=_FEW_SHOT_POOL_SOT_PATH,
+    )
+    if selection is None:
+        return None
+    if selection.strict:
+        return _strict_load(selection.path)
+    return _graceful_load(selection.path)
+
+
+def _strict_load(path: Path) -> list[FewShotExemplar]:
+    if not path.is_file():
+        raise RuntimeError(f"{_FEW_SHOT_POOL_OVERRIDE_ENV}={path} file not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"{_FEW_SHOT_POOL_OVERRIDE_ENV}={path} load failed: {exc}") from exc
+    return _parse_jsonl(raw, path, strict=True)
+
+
+def _graceful_load(path: Path) -> list[FewShotExemplar] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        log.warning("few-shot-pool at %s is unreadable; ignoring", path)
+        return None
+    return _parse_jsonl(raw, path, strict=False)
+
+
+def _parse_jsonl(raw: str, path: Path, *, strict: bool) -> list[FewShotExemplar]:
+    """Parse JSONL line-by-line — per-line graceful (one bad line doesn't
+    invalidate the rest)."""
+    exemplars: list[FewShotExemplar] = []
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            if strict:
+                raise RuntimeError(
+                    f"few-shot-pool at {path}:{lineno} JSON decode failed: {exc}"
+                ) from exc
+            log.warning(
+                "few-shot-pool at %s:%d JSON decode failed; skipping line: %s",
+                path,
+                lineno,
+                exc,
+            )
+            continue
+        coerced = _coerce_entry(entry, path, lineno, strict=strict)
+        if coerced is not None:
+            exemplars.append(coerced)
+    return exemplars
+
+
+def _coerce_entry(entry: Any, path: Path, lineno: int, *, strict: bool) -> FewShotExemplar | None:
+    if not isinstance(entry, dict):
+        msg = f"few-shot-pool at {path}:{lineno} must be a dict, got {type(entry).__name__}"
+        if strict:
+            raise RuntimeError(msg)
+        log.warning("%s; skipping", msg)
+        return None
+    user_msg = entry.get("user_msg")
+    assistant_msg = entry.get("assistant_msg")
+    if not isinstance(user_msg, str) or not user_msg:
+        if strict:
+            raise RuntimeError(f"few-shot-pool at {path}:{lineno} missing/invalid user_msg")
+        return None
+    if not isinstance(assistant_msg, str) or not assistant_msg:
+        if strict:
+            raise RuntimeError(f"few-shot-pool at {path}:{lineno} missing/invalid assistant_msg")
+        return None
+    raw_delta = entry.get("fitness_delta", 0.0)
+    try:
+        fitness_delta = float(raw_delta) if not isinstance(raw_delta, bool) else 0.0
+    except (TypeError, ValueError):
+        fitness_delta = 0.0
+    source_raw = entry.get("source", "")
+    source = source_raw if isinstance(source_raw, str) else ""
+    return FewShotExemplar(
+        user_msg=user_msg,
+        assistant_msg=assistant_msg,
+        fitness_delta=fitness_delta,
+        source=source,
+    )
+
+
+def apply_few_shot_pool(
+    messages: list[dict[str, Any]],
+    pool: list[FewShotExemplar] | None,
+    *,
+    max_entries: int = 3,
+) -> list[dict[str, Any]]:
+    """Insert top-K exemplar (user/assistant) pairs at the head of ``messages``.
+
+    Returns a new list (no in-place mutation). When ``pool is None`` or
+    empty / ``max_entries <= 0``, returns the original list unchanged.
+
+    Top-K selection ranks by ``fitness_delta`` descending. Ties tolerate
+    insertion order (stable sort).
+    """
+    if not pool or max_entries <= 0:
+        return messages
+    ranked = sorted(pool, key=lambda e: -e.fitness_delta)[:max_entries]
+    if not ranked:
+        return messages
+    prefix: list[dict[str, Any]] = []
+    for ex in ranked:
+        prefix.append({"role": "user", "content": ex.user_msg})
+        prefix.append({"role": "assistant", "content": ex.assistant_msg})
+    return prefix + list(messages)
+
+
+__all__ = ["FewShotExemplar", "apply_few_shot_pool"]

--- a/core/paths.py
+++ b/core/paths.py
@@ -149,6 +149,12 @@ OPERATOR_LOCAL_IN_CONTEXT_SLOTS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "in-cont
 # 있어 mutation surface 에서 제외.
 GLOBAL_AGENT_CONTRACTS_PATH = GLOBAL_POLICIES_DIR / "agent-contracts.json"
 OPERATOR_LOCAL_AGENT_CONTRACTS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "agent-contracts.json"
+# ADR-012 M3 (2026-05-21) — Few-shot exemplar pool (JSONL append-only).
+# fitness gate 통과한 task-completion candidate 를 누적; runtime 에
+# top-K 선별해 system prompt 직후 in-context exemplar 로 적재. S5 의
+# ``exemplars`` slot 의 실제 *적재 메커니즘*.
+GLOBAL_FEW_SHOT_POOL_PATH = GLOBAL_POLICIES_DIR / "few-shot-pool.jsonl"
+OPERATOR_LOCAL_FEW_SHOT_POOL_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "few-shot-pool.jsonl"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/tests/test_m3_few_shot_pool.py
+++ b/tests/test_m3_few_shot_pool.py
@@ -1,0 +1,281 @@
+"""ADR-012 M3 — Few-shot exemplar pool invariants.
+
+Pins JSONL append-only schema + top-K rank + apply 가 messages 앞에
+exemplar pair 삽입 + 3-layer BACKFILL-SOT chain.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from core.llm import few_shot_pool as fsp
+from core.llm.few_shot_pool import (
+    FewShotExemplar,
+    _load_few_shot_pool_override,
+    apply_few_shot_pool,
+)
+
+
+@pytest.fixture
+def isolated_sot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    sot = tmp_path / "few-shot-pool.jsonl"
+    operator_local = tmp_path / "operator-local-few-shot-pool.jsonl"
+    monkeypatch.setattr(fsp, "_FEW_SHOT_POOL_SOT_PATH", sot)
+    monkeypatch.setattr(fsp, "_OPERATOR_LOCAL_FEW_SHOT_POOL_PATH", operator_local)
+    monkeypatch.delenv("GEODE_FEW_SHOT_POOL_OVERRIDE", raising=False)
+    monkeypatch.delenv("GEODE_FEW_SHOT_POOL_STRICT", raising=False)
+    yield sot
+
+
+def _write_jsonl(sot: Path, entries: list[dict[str, Any]]) -> None:
+    sot.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+# Reader ----------------------------------------------------------------------
+
+
+def test_load_returns_none_when_sot_missing(isolated_sot: Path) -> None:
+    assert _load_few_shot_pool_override() is None
+
+
+def test_load_empty_file_returns_empty_list(isolated_sot: Path) -> None:
+    isolated_sot.write_text("", encoding="utf-8")
+    result = _load_few_shot_pool_override()
+    assert result == []
+
+
+def test_load_skips_blank_lines(isolated_sot: Path) -> None:
+    isolated_sot.write_text('\n\n{"user_msg": "q", "assistant_msg": "a"}\n\n', encoding="utf-8")
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert len(result) == 1
+
+
+def test_load_valid_payload(isolated_sot: Path) -> None:
+    _write_jsonl(
+        isolated_sot,
+        [
+            {
+                "user_msg": "user 1",
+                "assistant_msg": "assist 1",
+                "fitness_delta": 0.5,
+                "source": "cycle-1",
+            },
+            {"user_msg": "user 2", "assistant_msg": "assist 2"},
+        ],
+    )
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert len(result) == 2
+    assert result[0].user_msg == "user 1"
+    assert result[0].fitness_delta == 0.5
+    assert result[0].source == "cycle-1"
+    assert result[1].fitness_delta == 0.0  # default
+    assert result[1].source == ""
+
+
+def test_load_per_line_graceful_one_bad_line_kept_rest(isolated_sot: Path) -> None:
+    """JSONL per-line — broken line skipped, valid lines retained."""
+    isolated_sot.write_text(
+        "\n".join(
+            [
+                json.dumps({"user_msg": "ok1", "assistant_msg": "a1"}),
+                "not valid json {",
+                json.dumps({"user_msg": "ok2", "assistant_msg": "a2"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert [e.user_msg for e in result] == ["ok1", "ok2"]
+
+
+def test_load_skips_missing_user_msg(isolated_sot: Path) -> None:
+    _write_jsonl(isolated_sot, [{"assistant_msg": "no user"}])
+    result = _load_few_shot_pool_override()
+    assert result == []
+
+
+def test_load_skips_empty_assistant_msg(isolated_sot: Path) -> None:
+    _write_jsonl(isolated_sot, [{"user_msg": "q", "assistant_msg": ""}])
+    result = _load_few_shot_pool_override()
+    assert result == []
+
+
+def test_load_skips_non_dict_entry(isolated_sot: Path) -> None:
+    """Top-level scalar / list in JSONL line → skipped."""
+    isolated_sot.write_text(
+        "\n".join(["42", '["a","b"]', json.dumps({"user_msg": "q", "assistant_msg": "a"})]) + "\n",
+        encoding="utf-8",
+    )
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert len(result) == 1
+
+
+def test_load_coerces_non_numeric_fitness_delta_to_zero(isolated_sot: Path) -> None:
+    _write_jsonl(
+        isolated_sot,
+        [
+            {
+                "user_msg": "q",
+                "assistant_msg": "a",
+                "fitness_delta": "not a number",
+            }
+        ],
+    )
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert result[0].fitness_delta == 0.0
+
+
+def test_load_rejects_bool_fitness_delta(isolated_sot: Path) -> None:
+    """bool subclass int trap — should coerce to 0.0, not True/False."""
+    _write_jsonl(
+        isolated_sot,
+        [
+            {"user_msg": "q", "assistant_msg": "a", "fitness_delta": True},
+        ],
+    )
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert result[0].fitness_delta == 0.0
+
+
+def test_strict_env_var_raises_on_bad_jsonl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text("garbage {{\n", encoding="utf-8")
+    monkeypatch.setenv("GEODE_FEW_SHOT_POOL_OVERRIDE", str(bad))
+    monkeypatch.setenv("GEODE_FEW_SHOT_POOL_STRICT", "1")
+    with pytest.raises(RuntimeError, match="JSON decode failed"):
+        _load_few_shot_pool_override()
+
+
+def test_env_var_without_strict_is_graceful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEODE_FEW_SHOT_POOL_OVERRIDE", str(tmp_path / "nope.jsonl"))
+    monkeypatch.delenv("GEODE_FEW_SHOT_POOL_STRICT", raising=False)
+    assert _load_few_shot_pool_override() is None
+
+
+def test_operator_local_layer_priority(isolated_sot: Path) -> None:
+    operator_local = isolated_sot.parent / "operator-local-few-shot-pool.jsonl"
+    operator_local.write_text(
+        json.dumps({"user_msg": "from-ops", "assistant_msg": "a"}) + "\n",
+        encoding="utf-8",
+    )
+    _write_jsonl(isolated_sot, [{"user_msg": "from-repo", "assistant_msg": "a"}])
+    result = _load_few_shot_pool_override()
+    assert result is not None
+    assert result[0].user_msg == "from-ops"
+
+
+# Apply -----------------------------------------------------------------------
+
+
+def _msgs(*roles_and_contents: tuple[str, str]) -> list[dict[str, Any]]:
+    return [{"role": r, "content": c} for r, c in roles_and_contents]
+
+
+def test_apply_none_returns_original_unchanged() -> None:
+    msgs = _msgs(("user", "hello"))
+    assert apply_few_shot_pool(msgs, None) is msgs
+
+
+def test_apply_empty_pool_returns_original() -> None:
+    msgs = _msgs(("user", "hello"))
+    assert apply_few_shot_pool(msgs, []) is msgs
+
+
+def test_apply_zero_max_entries_returns_original() -> None:
+    msgs = _msgs(("user", "hello"))
+    pool = [FewShotExemplar(user_msg="q", assistant_msg="a")]
+    assert apply_few_shot_pool(msgs, pool, max_entries=0) is msgs
+
+
+def test_apply_inserts_exemplar_pair_at_head() -> None:
+    msgs = _msgs(("user", "real question"))
+    pool = [FewShotExemplar(user_msg="ex_q", assistant_msg="ex_a")]
+    out = apply_few_shot_pool(msgs, pool, max_entries=1)
+    assert out == [
+        {"role": "user", "content": "ex_q"},
+        {"role": "assistant", "content": "ex_a"},
+        {"role": "user", "content": "real question"},
+    ]
+
+
+def test_apply_ranks_by_fitness_delta_desc() -> None:
+    pool = [
+        FewShotExemplar(user_msg="q_low", assistant_msg="a_low", fitness_delta=0.1),
+        FewShotExemplar(user_msg="q_high", assistant_msg="a_high", fitness_delta=0.9),
+        FewShotExemplar(user_msg="q_mid", assistant_msg="a_mid", fitness_delta=0.5),
+    ]
+    out = apply_few_shot_pool([], pool, max_entries=2)
+    # top-2 by fitness_delta desc: q_high, q_mid
+    user_contents = [m["content"] for m in out if m["role"] == "user"]
+    assert user_contents == ["q_high", "q_mid"]
+
+
+def test_apply_does_not_mutate_input_lists() -> None:
+    msgs = _msgs(("user", "original"))
+    pool = [FewShotExemplar(user_msg="ex_q", assistant_msg="ex_a")]
+    original_len = len(msgs)
+    apply_few_shot_pool(msgs, pool)
+    assert len(msgs) == original_len  # input list intact
+
+
+def test_apply_respects_max_entries_cap() -> None:
+    pool = [
+        FewShotExemplar(user_msg=f"q{i}", assistant_msg=f"a{i}", fitness_delta=float(i))
+        for i in range(10)
+    ]
+    out = apply_few_shot_pool([], pool, max_entries=3)
+    # 3 pairs = 6 messages
+    assert len(out) == 6
+
+
+# Wiring + path constants ----------------------------------------------------
+
+
+def test_path_constants_present() -> None:
+    from core.paths import (
+        GLOBAL_FEW_SHOT_POOL_PATH,
+        OPERATOR_LOCAL_FEW_SHOT_POOL_PATH,
+    )
+
+    assert GLOBAL_FEW_SHOT_POOL_PATH.name == "few-shot-pool.jsonl"
+    assert OPERATOR_LOCAL_FEW_SHOT_POOL_PATH.name == "few-shot-pool.jsonl"
+    assert "policies" in str(GLOBAL_FEW_SHOT_POOL_PATH)
+    assert "self-improving-loop" in str(OPERATOR_LOCAL_FEW_SHOT_POOL_PATH)
+
+
+def test_train_py_sets_few_shot_pool_env_pair() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    src = (repo_root / "autoresearch/train.py").read_text(encoding="utf-8")
+    assert "GEODE_FEW_SHOT_POOL_OVERRIDE" in src
+    assert "GEODE_FEW_SHOT_POOL_STRICT" in src
+    assert "GLOBAL_FEW_SHOT_POOL_PATH" in src
+
+
+def test_few_shot_pool_jsonl_referenced_in_inference_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    hits: list[str] = []
+    for path in (repo_root / "core").rglob("*.py"):
+        if "test_" in path.name:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "few-shot-pool.jsonl" in content:
+            hits.append(str(path.relative_to(repo_root)))
+    assert any("few_shot_pool.py" in h for h in hits)


### PR DESCRIPTION
## Summary
- S5 (#1425) 의 `exemplars` slot 의 실제 *적재 메커니즘* 신설 — fitness gate 통과한 candidate 의 (user_msg, assistant_msg, fitness_delta) triple 을 JSONL append-only 로 축적.
- runtime 에 top-K 선별해 messages 앞에 exemplar pair 로 삽입 (apply_few_shot_pool 함수).
- 23 invariant test — reader 11 + apply 6 + wiring + path + env + ALIVE marker.

## Why
S5 가 `exemplars` slot 의 schema 만 정의했고 실제 *축적 → top-K 선별 → message 삽입* 메커니즘은 없었음. M3 가 그 GAP closure. Voyager/STaR 식 *successful trajectory pool* 패턴으로 자기 성공 사례를 다음 cycle 의 in-context exemplar 로 재투입. T5 cache_policy 와 호환 — exemplar prefix 가 Anthropic cache breakpoint 의 stable prefix 로 정렬.

## Changes
| File | Change |
|------|--------|
| `core/paths.py` | `GLOBAL_FEW_SHOT_POOL_PATH` + `OPERATOR_LOCAL_FEW_SHOT_POOL_PATH` 2 상수 |
| `core/llm/few_shot_pool.py` | **신규** — `FewShotExemplar` frozen dataclass + `_load_few_shot_pool_override` + `apply_few_shot_pool` |
| `autoresearch/train.py` | audit subprocess `_OVERRIDE` + `_STRICT=1` 동반 set |
| `tests/test_m3_few_shot_pool.py` | 23 invariant test |
| `CHANGELOG.md` | `### Added` PR-M3 entry |

## Schema (JSONL)
```json
{"user_msg": "...", "assistant_msg": "...", "fitness_delta": 0.12, "source": "audit_cycle_2026-05-21"}
```
- `user_msg` / `assistant_msg`: str required
- `fitness_delta`: float default 0.0 (rank ordering key)
- `source`: str optional (추적)

## Resolution order
1. `GEODE_FEW_SHOT_POOL_OVERRIDE` env var — `_STRICT=1` 시 strict.
2. `~/.geode/self-improving-loop/few-shot-pool.jsonl` — operator-local.
3. `autoresearch/state/policies/few-shot-pool.jsonl` — in-repo.
4. `None` → no-op.

## Per-line graceful
JSONL 한 줄이 broken JSON 이어도 다른 줄 retain. `bool` fitness_delta → 0.0 coerce (bool-is-int trap 방어). missing/empty user_msg/assistant_msg entry skip.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 5-element 패턴 (no wiring) | Implemented (M4.4 deferred) | inference entry 는 후속 PR |
| FewShotExemplar frozen dataclass | Implemented | aliasing risk 차단 |
| Top-K rank (fitness_delta desc) | Implemented | stable sort |
| Per-line graceful | Implemented | JSONL 단위 isolation |
| bool fitness_delta trap | Implemented | explicit `isinstance(v, bool)` reject |
| ALIVE marker | Implemented | `few-shot-pool.jsonl` grep → reader |
| Inference wiring | Deferred (M4.4) | explicit scope split |

## Verification
- [x] ruff check + format clean
- [x] mypy clean
- [x] pytest tests/test_m3_few_shot_pool.py — 23/23 pass
- [x] Tier 2 untouched

## Reference
ADR-012 §Decision.4 — exemplars slot. Predecessor: S5 (#1425) schema declaration.
Successor: M4.4 — message 조립부 wiring 4 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)