### PR TITLE
feat(m4.0): eval_response_recorded SessionJournal event (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@ functional change.
 
 ### Added
 
+- **PR-M4.0 — `eval_response_recorded` SessionJournal event (ADR-012).**
+  DPO pipeline (M4.x) 의 첫 piece — 각 (prompt, response) turn 마다
+  fitness 측정값 + 평가 metadata 를 active SessionJournal 에 emit.
+  M4.1 의 DPO canonical pack JSONL writer 가 이 stream 을 따라가며
+  chosen/rejected pile 라벨링. **신규 모듈**
+  `core/self_improving_loop/eval_journaling.py` — `EVENT_NAME` constant +
+  `emit_eval_response_recorded(prompt, response, fitness_score,
+  axis_scores, source, rollback_flag)` helper. Active scope 외에서
+  graceful no-op (False 반환) — 호출자 try/except 불필요. `rollback_flag`
+  가 True 면 user revert 신호 (M4.1 rejected 라벨). `axis_scores` 가
+  None / 빈 dict 면 payload key omit (forward-compat). int / bool 값은
+  float coerce. 본 PR 은 emit 함수 + payload schema 만; emit 호출 site
+  (Petri audit / live session / replay test 등) 는 후속 PR 에서 wiring.
+  **11 invariant test** — event name + no-scope no-op + minimal payload +
+  full payload + rollback flag (true/default) + axis_scores omit (None /
+  empty) + float coerce 2 + multi-event append. Voyager / STaR 의
+  successful-trajectory journaling 패턴 그대로.
+
 - **PR-M3 — Few-shot exemplar pool 자동 적재 (ADR-012).** S5 (#1425)
   에서 declared 만 됐던 `exemplars` slot 의 실제 *적재 메커니즘* 신설.
   fitness gate 통과한 task-completion candidate 의 `(user_msg,

--- a/core/self_improving_loop/eval_journaling.py
+++ b/core/self_improving_loop/eval_journaling.py
@@ -5,7 +5,9 @@ M4.1 의 DPO canonical pack JSONL writer 의 *source* 가 되는 단일 event.
 SessionJournal 에 emit — M4.1 이 journal stream 을 따라가며 pack
 candidate 를 누적.
 
-**Event schema** (record.payload):
+**Event schema** — ``record.payload`` only (``session_id`` / ``gen_tag`` /
+``ts`` / ``component`` / ``event`` / ``level`` are top-level SessionJournal
+record fields, not payload fields):
 
 .. code-block:: json
 
@@ -20,9 +22,7 @@ candidate 를 누적.
         "bench_means_aggregate": 0.75
       },
       "source": "petri_audit" | "live_session" | "...",
-      "rollback_flag": false,
-      "session_id": "...",
-      "gen_tag": "auto-HEAD"
+      "rollback_flag": false
     }
 
 ``rollback_flag`` 는 사용자가 그 응답을 revert 했는지 — M4.1 의

--- a/core/self_improving_loop/eval_journaling.py
+++ b/core/self_improving_loop/eval_journaling.py
@@ -1,0 +1,98 @@
+"""``eval_response_recorded`` SessionJournal event — ADR-012 M4.0.
+
+M4.1 의 DPO canonical pack JSONL writer 의 *source* 가 되는 단일 event.
+각 (prompt, response) turn 마다 fitness 측정값 + 평가 metadata 를 active
+SessionJournal 에 emit — M4.1 이 journal stream 을 따라가며 pack
+candidate 를 누적.
+
+**Event schema** (record.payload):
+
+.. code-block:: json
+
+    {
+      "prompt": "...user message verbatim...",
+      "response": "...agent assistant message verbatim...",
+      "fitness_score": 0.82,
+      "axis_scores": {
+        "dim_means_aggregate": 0.78,
+        "ux_means_aggregate": 0.84,
+        "admire_means_aggregate": 0.90,
+        "bench_means_aggregate": 0.75
+      },
+      "source": "petri_audit" | "live_session" | "...",
+      "rollback_flag": false,
+      "session_id": "...",
+      "gen_tag": "auto-HEAD"
+    }
+
+``rollback_flag`` 는 사용자가 그 응답을 revert 했는지 — M4.1 의
+chosen/rejected 라벨링 핵심 신호 (revert=True → rejected).
+
+**No journal scope = no-op**. ``current_session_journal()`` 이 ``None``
+이면 emit 자체가 안 일어남 (BACKFILL-SOT 의 contextvar 패턴 동일).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+EVENT_NAME = "eval_response_recorded"
+"""SessionJournal event name — M4.1 reader 가 이 이름으로 filter."""
+
+
+def emit_eval_response_recorded(
+    *,
+    prompt: str,
+    response: str,
+    fitness_score: float,
+    axis_scores: dict[str, float] | None = None,
+    source: str = "",
+    rollback_flag: bool = False,
+) -> bool:
+    """Emit one ``eval_response_recorded`` event to the active SessionJournal.
+
+    Returns ``True`` if the event was appended, ``False`` if no journal
+    is bound in the current ContextVar scope (graceful no-op — caller can
+    safely invoke even outside an explicit ``session_journal_scope``).
+
+    Args:
+        prompt: User-side message verbatim (M4.1 will use as DPO ``prompt``).
+        response: Assistant-side message verbatim (will land in
+            ``chosen`` or ``rejected`` pile depending on ``rollback_flag``).
+        fitness_score: 4-axis weighted aggregate (S3 의 baseline.json 의
+            compute_fitness output). 0.0~1.0+. Higher = better.
+        axis_scores: Per-axis breakdown (dim/ux/admire/bench aggregates).
+            Optional — when None, the event still carries the scalar
+            fitness_score; M4.1 의 ratchet 은 scalar 면 충분히 작동.
+        source: Free-form provenance tag (``"petri_audit"`` /
+            ``"live_session"`` / ``"replay_test"`` etc.). For audit trail.
+        rollback_flag: ``True`` iff the user reverted / dismissed this
+            response. Signals "rejected" for DPO pack labeling.
+    """
+    # Lazy import — keep this module cheap when no journal is bound.
+    from core.observability.session_journal import current_session_journal
+
+    journal = current_session_journal()
+    if journal is None:
+        return False
+    payload: dict[str, Any] = {
+        "prompt": prompt,
+        "response": response,
+        "fitness_score": float(fitness_score),
+        "source": source,
+        "rollback_flag": bool(rollback_flag),
+    }
+    if axis_scores:
+        payload["axis_scores"] = {k: float(v) for k, v in axis_scores.items()}
+    try:
+        journal.append(EVENT_NAME, payload=payload)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("eval_response_recorded emit failed: %s", exc)
+        return False
+    return True
+
+
+__all__ = ["EVENT_NAME", "emit_eval_response_recorded"]

--- a/tests/test_m4_0_eval_event.py
+++ b/tests/test_m4_0_eval_event.py
@@ -1,0 +1,209 @@
+"""ADR-012 M4.0 — eval_response_recorded SessionJournal event invariants.
+
+Pins:
+- ``emit_eval_response_recorded`` writes a single JSONL row to the active
+  SessionJournal with the canonical event name + payload schema.
+- Outside ``session_journal_scope`` → no-op returning ``False``.
+- ``rollback_flag`` defaults to ``False`` (chosen pile); explicit ``True``
+  signals rejected (for M4.1 DPO pack labeling).
+- ``axis_scores`` optional — scalar ``fitness_score`` alone is valid.
+- bool fitness_score / fitness_score=int → float coerced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.observability.session_journal import (
+    SessionJournal,
+    session_journal_scope,
+)
+from core.self_improving_loop.eval_journaling import (
+    EVENT_NAME,
+    emit_eval_response_recorded,
+)
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "journal.jsonl"
+
+
+def _read_events(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+# Event name constant --------------------------------------------------------
+
+
+def test_event_name_is_canonical() -> None:
+    """M4.1 reader 가 이 이름으로 filter — 변경하면 downstream 전부 깨짐."""
+    assert EVENT_NAME == "eval_response_recorded"
+
+
+# Emit — no journal scope → no-op --------------------------------------------
+
+
+def test_emit_outside_scope_returns_false() -> None:
+    """ContextVar 부재 시 graceful no-op — 호출자가 try/except 안 필요."""
+    result = emit_eval_response_recorded(
+        prompt="q",
+        response="a",
+        fitness_score=0.5,
+    )
+    assert result is False
+
+
+# Emit — minimal payload -----------------------------------------------------
+
+
+def test_emit_writes_minimal_payload(journal_path: Path) -> None:
+    journal = SessionJournal(
+        session_id="test-session",
+        gen_tag="auto-HEAD",
+        component="test",
+        path=journal_path,
+    )
+    with session_journal_scope(journal):
+        result = emit_eval_response_recorded(
+            prompt="user msg",
+            response="agent reply",
+            fitness_score=0.82,
+        )
+    assert result is True
+    events = _read_events(journal_path)
+    assert len(events) == 1
+    rec = events[0]
+    assert rec["event"] == "eval_response_recorded"
+    assert rec["component"] == "test"
+    assert rec["session_id"] == "test-session"
+    assert rec["gen_tag"] == "auto-HEAD"
+    assert rec["payload"]["prompt"] == "user msg"
+    assert rec["payload"]["response"] == "agent reply"
+    assert rec["payload"]["fitness_score"] == 0.82
+    assert rec["payload"]["rollback_flag"] is False
+    assert rec["payload"]["source"] == ""
+
+
+# Emit — full payload --------------------------------------------------------
+
+
+def test_emit_writes_full_payload(journal_path: Path) -> None:
+    journal = SessionJournal(session_id="s1", gen_tag="auto", component="petri", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(
+            prompt="prompt text",
+            response="response text",
+            fitness_score=0.91,
+            axis_scores={
+                "dim_means_aggregate": 0.85,
+                "ux_means_aggregate": 0.95,
+                "admire_means_aggregate": 0.92,
+                "bench_means_aggregate": 0.88,
+            },
+            source="petri_audit",
+            rollback_flag=False,
+        )
+    events = _read_events(journal_path)
+    assert len(events) == 1
+    payload = events[0]["payload"]
+    assert payload["source"] == "petri_audit"
+    assert payload["axis_scores"] == {
+        "dim_means_aggregate": 0.85,
+        "ux_means_aggregate": 0.95,
+        "admire_means_aggregate": 0.92,
+        "bench_means_aggregate": 0.88,
+    }
+
+
+# Rollback flag signals rejected ---------------------------------------------
+
+
+def test_rollback_flag_true_persisted(journal_path: Path) -> None:
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(
+            prompt="q",
+            response="a",
+            fitness_score=0.3,
+            rollback_flag=True,
+        )
+    events = _read_events(journal_path)
+    assert events[0]["payload"]["rollback_flag"] is True
+
+
+def test_rollback_flag_default_is_false(journal_path: Path) -> None:
+    """Default = False (chosen pile)."""
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(prompt="q", response="a", fitness_score=0.5)
+    events = _read_events(journal_path)
+    assert events[0]["payload"]["rollback_flag"] is False
+
+
+# axis_scores optional -------------------------------------------------------
+
+
+def test_axis_scores_omitted_when_none(journal_path: Path) -> None:
+    """``axis_scores=None`` → payload key 자체가 안 나타남 (forward-compat)."""
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(prompt="q", response="a", fitness_score=0.5)
+    payload = _read_events(journal_path)[0]["payload"]
+    assert "axis_scores" not in payload
+
+
+def test_axis_scores_empty_dict_omitted(journal_path: Path) -> None:
+    """``axis_scores={}`` 도 omit (truthiness check)."""
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(prompt="q", response="a", fitness_score=0.5, axis_scores={})
+    payload = _read_events(journal_path)[0]["payload"]
+    assert "axis_scores" not in payload
+
+
+# Type coercion --------------------------------------------------------------
+
+
+def test_fitness_score_int_coerced_to_float(journal_path: Path) -> None:
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(
+            prompt="q",
+            response="a",
+            fitness_score=1,  # int → float
+        )
+    payload = _read_events(journal_path)[0]["payload"]
+    assert payload["fitness_score"] == 1.0
+    assert isinstance(payload["fitness_score"], float)
+
+
+def test_axis_scores_values_coerced_to_float(journal_path: Path) -> None:
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(
+            prompt="q",
+            response="a",
+            fitness_score=0.5,
+            axis_scores={"a": 1, "b": 0},  # ints
+        )
+    payload = _read_events(journal_path)[0]["payload"]
+    assert payload["axis_scores"] == {"a": 1.0, "b": 0.0}
+
+
+# Multi-event append ---------------------------------------------------------
+
+
+def test_multiple_emits_append_separate_lines(journal_path: Path) -> None:
+    journal = SessionJournal(session_id="s", gen_tag="g", component="c", path=journal_path)
+    with session_journal_scope(journal):
+        for i in range(3):
+            emit_eval_response_recorded(prompt=f"q{i}", response=f"a{i}", fitness_score=0.5)
+    events = _read_events(journal_path)
+    assert len(events) == 3
+    assert [e["payload"]["prompt"] for e in events] == ["q0", "q1", "q2"]


### PR DESCRIPTION
## Summary
- DPO pipeline (M4.x) 의 첫 piece — 각 (prompt, response) turn 마다 fitness 측정값을 active SessionJournal 에 emit.
- M4.1 의 pack writer 가 이 stream 을 따라 chosen/rejected 라벨링.
- 11 invariant test — event name + payload schema + no-scope no-op + rollback flag + axis_scores optional + float coerce + multi-event.

## Why
M4 sprint (DPO pipeline 5단계) 의 source 가 필요함. 각 turn 의 fitness 측정값을 어디에 기록할 것인가 — *journal event* 가 가장 자연스러운 자리. M4.1 의 pack writer 가 별도 backfill 로 history 를 뒤지지 않고 *stream-as-it-happens* 로 누적할 수 있도록 본 PR 이 emit helper + payload schema 정의.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/eval_journaling.py` | **신규** — `EVENT_NAME` constant + `emit_eval_response_recorded` helper |
| `tests/test_m4_0_eval_event.py` | 11 invariant test |
| `CHANGELOG.md` | `### Added` PR-M4.0 entry |

## Event payload schema
```json
{
  "prompt": "...",
  "response": "...",
  "fitness_score": 0.82,
  "axis_scores": {
    "dim_means_aggregate": 0.78,
    "ux_means_aggregate": 0.84,
    "admire_means_aggregate": 0.90,
    "bench_means_aggregate": 0.75
  },
  "source": "petri_audit",
  "rollback_flag": false
}
```

`rollback_flag=True` → M4.1 의 rejected pile.

## Design decisions
- **No-scope graceful no-op** — `current_session_journal()` 이 None 이면 emit 안 일어남 + False 반환. 호출자 try/except 불필요.
- **Payload omit (axis_scores)** — None / 빈 dict 면 payload key 자체가 안 나타남 (forward-compat, M4.1 reader 는 axis_scores 부재해도 scalar fitness_score 로 충분히 동작).
- **Float coerce** — int / bool 입력값을 float 으로 통일 (JSONL 직렬화 일관성).
- **No caller wiring (yet)** — emit 호출 site (Petri audit / live session / replay test) 는 별도 후속 PR. 본 PR 은 schema + helper 만.

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Event name canonical | Implemented | M4.1 reader 의 filter key |
| Payload schema | Implemented | 6 field (prompt/response/fitness_score/axis_scores/source/rollback_flag) |
| No-scope graceful no-op | Implemented | False 반환 |
| rollback_flag = user revert 신호 | Implemented | M4.1 의 chosen/rejected 라벨링 핵심 |
| axis_scores 선택성 | Implemented | None / 빈 dict → omit |
| Float coerce | Implemented | int/bool → float |
| Caller wiring | Deferred | 별도 PR (Petri audit / live session etc.) |
| ALIVE marker | Implemented | `eval_response_recorded` grep → eval_journaling.py |

## Verification
- [x] ruff check + format clean
- [x] mypy clean (1 file)
- [x] pytest tests/test_m4_0_eval_event.py — 11/11 pass
- [x] Tier 2 untouched (bootstrap / runner / fitness gate / HookSystem / importlinter / version stamp)

## Reference
ADR-012 §Decision.4 — M4 (DPO pipeline) 의 첫 piece.
Successor: M4.1 (pack writer) — 본 PR 의 event stream consume.
Frontier: Voyager / STaR 의 successful-trajectory journaling 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)