### PR TITLE
feat(self-improving-loop): PR-M4.1 — DPO canonical preference-pack JSONL writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,32 @@ functional change.
 
 ### Added
 
+- **PR-M4.1 — DPO canonical preference-pack JSONL writer (ADR-012).**
+  Consumes M4.0 의 `eval_response_recorded` event stream → 각 unique
+  `prompt` group 을 chosen pile (`rollback_flag=False`) + rejected pile
+  (`rollback_flag=True`) 로 분할 → **top-fitness chosen × bottom-fitness
+  rejected** 1 pair 를 emit (가장 선명한 fitness margin = DPO 학습 신호
+  최대). **신규 모듈** `core/self_improving_loop/dpo_pack.py` —
+  `build_dpo_pack(journal_paths, pack_path) -> BuildResult` (appended /
+  duplicate / events_seen / unpaired count) + `pair_signature(prompt,
+  chosen, rejected)` 16-hex 식별자 + `BuildResult` frozen dataclass.
+  **Idempotency** — signature-keyed dedup 으로 재실행 시 신규 pair 만
+  append; 기존 pack rows 보존. **Graceful** — missing journal file →
+  empty 처리, malformed JSONL line 은 silently drop (per-line parse
+  guard). Pack 경로 `GLOBAL_DPO_PACK_PATH = ~/.geode/self-improving-loop/dpo/pack.jsonl`
+  (operator-local, NOT git-tracked — preference data 는 M4.3 redaction
+  까지 사용자-사적). **Pack schema** — `signature` / `prompt` /
+  `chosen` / `rejected` / `fitness_chosen` / `fitness_rejected` /
+  `fitness_delta` / `ts_chosen` / `ts_rejected` / `session_id_chosen` /
+  `session_id_rejected` / `source_chosen` / `source_rejected` (13
+  field). 본 PR 은 transform 만; M4.2 publisher (OpenAI / Bedrock /
+  HuggingFace TRL adapter) 는 후속. **12 invariant test** — signature
+  determinism + field-sensitivity / empty journal / missing-file
+  graceful / pair-selection top×bottom / chosen-only + rejected-only
+  unpaired / idempotency 재실행 zero append / 신규 prompt 만 append /
+  multi-journal cross-session merge / malformed line drop. Rafailov
+  2023 DPO formulation 의 `(x, y_w, y_l)` triple 과 직접 정합.
+
 - **PR-M4.0 — `eval_response_recorded` SessionJournal event (ADR-012).**
   DPO pipeline (M4.x) 의 첫 piece — 각 (prompt, response) turn 마다
   fitness 측정값 + 평가 metadata 를 active SessionJournal 에 emit.

--- a/core/paths.py
+++ b/core/paths.py
@@ -155,6 +155,14 @@ OPERATOR_LOCAL_AGENT_CONTRACTS_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "agent-co
 # ``exemplars`` slot 의 실제 *적재 메커니즘*.
 GLOBAL_FEW_SHOT_POOL_PATH = GLOBAL_POLICIES_DIR / "few-shot-pool.jsonl"
 OPERATOR_LOCAL_FEW_SHOT_POOL_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "few-shot-pool.jsonl"
+# ADR-012 M4.1 (2026-05-21) — DPO canonical preference-pack JSONL.
+# Consumes ``eval_response_recorded`` events (M4.0) and emits one row
+# per ``(prompt, chosen, rejected)`` tuple. Format-agnostic — M4.2
+# adapts this to per-provider publishers (OpenAI fine-tuning / Bedrock
+# DPO / HuggingFace TRL). Operator-local, NOT git-tracked: preference
+# data may include user-private prompts until an explicit redaction
+# step (M4.3) ships a sanitized copy.
+GLOBAL_DPO_PACK_PATH = GLOBAL_SELF_IMPROVING_LOOP_DIR / "dpo" / "pack.jsonl"
 # PR-MINIMAL-2 (2026-05-21) — git-tracked audit ledger of every
 # applied mutation. Lives in-repo alongside the 5 policy SoT JSONs
 # so the git-as-optimiser ledger and the current-state files are

--- a/core/self_improving_loop/dpo_pack.py
+++ b/core/self_improving_loop/dpo_pack.py
@@ -139,11 +139,15 @@ def _iter_eval_events(journal_path: Path) -> list[_EvalEvent]:
         fitness = payload.get("fitness_score")
         if not isinstance(prompt, str) or not isinstance(response, str):
             continue
+        if not isinstance(fitness, (int, float, str)):
+            continue
         try:
-            fitness_f = float(fitness)  # type: ignore[arg-type]
+            fitness_f = float(fitness)
         except (TypeError, ValueError):
             continue
         ts_raw = row.get("ts", 0.0)
+        if not isinstance(ts_raw, (int, float, str)):
+            ts_raw = 0.0
         try:
             ts_f = float(ts_raw)
         except (TypeError, ValueError):

--- a/core/self_improving_loop/dpo_pack.py
+++ b/core/self_improving_loop/dpo_pack.py
@@ -1,0 +1,281 @@
+"""DPO canonical pack JSONL writer — ADR-012 M4.1.
+
+Consumes the ``eval_response_recorded`` SessionJournal event stream
+(M4.0) and emits a canonical preference pack — one JSONL row per
+``(prompt, chosen, rejected)`` tuple — that any downstream DPO trainer
+(OpenAI fine-tuning, Bedrock DPO, HuggingFace TRL ``DPOTrainer``)
+can consume directly. M4.2 will adapt this pack to per-provider
+publisher formats; M4.1 is the format-agnostic substrate.
+
+**Pairing rule** — for each unique ``prompt`` text seen across the
+journal(s):
+
+* Group emitted ``eval_response_recorded`` events by ``prompt``.
+* Within the group, split into ``chosen`` pile (``rollback_flag = False``)
+  and ``rejected`` pile (``rollback_flag = True``).
+* If both piles are non-empty, pair the **highest-fitness chosen** with
+  the **lowest-fitness rejected**. This gives the steepest
+  ``fitness_delta`` signal per prompt — DPO learns best from clear
+  margins. Other potential pairings (cross-product, random, top-K) are
+  deferred to M4.3+.
+
+**Idempotency** — each pair is hashed by ``(prompt, chosen_response,
+rejected_response)`` → 16-hex signature. The writer skips any signature
+already present in the pack file, so re-running the builder over an
+expanded journal stream only appends new pairs.
+
+**Pack location** — ``GLOBAL_DPO_PACK_PATH`` (``~/.geode/self-improving-loop/dpo/pack.jsonl``).
+The parent directory is created lazily on first append. The pack is
+NOT git-tracked — preference data can be sensitive and is operator-local
+until an explicit publish step (M4.2) ships a redacted copy.
+
+**Schema** (one row per emitted pair)::
+
+    {
+      "signature": "...16-hex...",
+      "prompt": "...",
+      "chosen": "...",
+      "rejected": "...",
+      "fitness_chosen": 0.91,
+      "fitness_rejected": 0.32,
+      "fitness_delta": 0.59,
+      "ts_chosen": 1731957600.123,
+      "ts_rejected": 1731957800.456,
+      "session_id_chosen": "...",
+      "session_id_rejected": "...",
+      "source_chosen": "petri_audit",
+      "source_rejected": "live_session"
+    }
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.self_improving_loop.eval_journaling import EVENT_NAME
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "BuildResult",
+    "build_dpo_pack",
+    "pair_signature",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class _EvalEvent:
+    """Parsed view of one ``eval_response_recorded`` JSONL row."""
+
+    prompt: str
+    response: str
+    fitness_score: float
+    rollback_flag: bool
+    ts: float
+    session_id: str
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class BuildResult:
+    """Outcome of a single :func:`build_dpo_pack` invocation.
+
+    Counts are reported separately so M4.2/M4.3 can ratchet on
+    *pairs_appended* (genuine new signal) vs *events_seen* (volume) vs
+    *prompts_unpaired* (chosen-only or rejected-only piles that still
+    need their counterpart).
+    """
+
+    pairs_appended: int
+    pairs_skipped_duplicate: int
+    events_seen: int
+    prompts_unpaired: int
+
+
+def pair_signature(prompt: str, chosen: str, rejected: str) -> str:
+    """Deterministic 16-hex pair signature — idempotency key for the pack."""
+    blob = f"{prompt}\x1f{chosen}\x1f{rejected}".encode()
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _iter_eval_events(journal_path: Path) -> list[_EvalEvent]:
+    """Read one ``journal.jsonl`` file → list of ``eval_response_recorded`` rows.
+
+    Lines that fail to parse, lack the canonical event name, or are
+    missing required payload fields are silently skipped (the journal
+    is intentionally lossy — a stray malformed line shouldn't kill the
+    builder).
+    """
+    if not journal_path.is_file():
+        return []
+    out: list[_EvalEvent] = []
+    try:
+        text = journal_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning("dpo_pack: failed to read journal %s: %s", journal_path, exc)
+        return []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        if row.get("event") != EVENT_NAME:
+            continue
+        payload = row.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        prompt = payload.get("prompt")
+        response = payload.get("response")
+        fitness = payload.get("fitness_score")
+        if not isinstance(prompt, str) or not isinstance(response, str):
+            continue
+        try:
+            fitness_f = float(fitness)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        ts_raw = row.get("ts", 0.0)
+        try:
+            ts_f = float(ts_raw)
+        except (TypeError, ValueError):
+            ts_f = 0.0
+        out.append(
+            _EvalEvent(
+                prompt=prompt,
+                response=response,
+                fitness_score=fitness_f,
+                rollback_flag=bool(payload.get("rollback_flag", False)),
+                ts=ts_f,
+                session_id=str(row.get("session_id", "")),
+                source=str(payload.get("source", "")),
+            )
+        )
+    return out
+
+
+def _existing_signatures(pack_path: Path) -> set[str]:
+    """Collect signatures already present in the pack — idempotency guard."""
+    if not pack_path.is_file():
+        return set()
+    sigs: set[str] = set()
+    try:
+        text = pack_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning("dpo_pack: failed to read pack %s: %s", pack_path, exc)
+        return sigs
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        sig = row.get("signature") if isinstance(row, dict) else None
+        if isinstance(sig, str):
+            sigs.add(sig)
+    return sigs
+
+
+def _select_pair(events: list[_EvalEvent]) -> tuple[_EvalEvent, _EvalEvent] | None:
+    """Top-fitness chosen × bottom-fitness rejected — clearest margin."""
+    chosen = [e for e in events if not e.rollback_flag]
+    rejected = [e for e in events if e.rollback_flag]
+    if not chosen or not rejected:
+        return None
+    best_chosen = max(chosen, key=lambda e: e.fitness_score)
+    worst_rejected = min(rejected, key=lambda e: e.fitness_score)
+    return best_chosen, worst_rejected
+
+
+def build_dpo_pack(
+    *,
+    journal_paths: list[Path],
+    pack_path: Path,
+) -> BuildResult:
+    """Walk ``journal_paths`` → group by prompt → append new pairs to ``pack_path``.
+
+    Args:
+        journal_paths: ``journal.jsonl`` files to scan. Missing files are
+            treated as empty (graceful).
+        pack_path: Destination JSONL. Created lazily; existing rows are
+            preserved + their signatures are honoured for dedup.
+
+    Returns:
+        :class:`BuildResult` with append / dedup / unpaired counts.
+    """
+    events: list[_EvalEvent] = []
+    for jp in journal_paths:
+        events.extend(_iter_eval_events(jp))
+    events_seen = len(events)
+
+    grouped: dict[str, list[_EvalEvent]] = {}
+    for ev in events:
+        grouped.setdefault(ev.prompt, []).append(ev)
+
+    existing = _existing_signatures(pack_path)
+    appended = 0
+    skipped_dupe = 0
+    unpaired = 0
+    new_rows: list[dict[str, Any]] = []
+
+    for prompt, group in grouped.items():
+        pair = _select_pair(group)
+        if pair is None:
+            unpaired += 1
+            continue
+        chosen_ev, rejected_ev = pair
+        sig = pair_signature(prompt, chosen_ev.response, rejected_ev.response)
+        if sig in existing:
+            skipped_dupe += 1
+            continue
+        new_rows.append(
+            {
+                "signature": sig,
+                "prompt": prompt,
+                "chosen": chosen_ev.response,
+                "rejected": rejected_ev.response,
+                "fitness_chosen": chosen_ev.fitness_score,
+                "fitness_rejected": rejected_ev.fitness_score,
+                "fitness_delta": chosen_ev.fitness_score - rejected_ev.fitness_score,
+                "ts_chosen": chosen_ev.ts,
+                "ts_rejected": rejected_ev.ts,
+                "session_id_chosen": chosen_ev.session_id,
+                "session_id_rejected": rejected_ev.session_id,
+                "source_chosen": chosen_ev.source,
+                "source_rejected": rejected_ev.source,
+            }
+        )
+        existing.add(sig)
+        appended += 1
+
+    if new_rows:
+        try:
+            pack_path.parent.mkdir(parents=True, exist_ok=True)
+            with pack_path.open("a", encoding="utf-8") as fh:
+                for row in new_rows:
+                    fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            log.warning("dpo_pack: append to %s failed: %s", pack_path, exc)
+            return BuildResult(
+                pairs_appended=0,
+                pairs_skipped_duplicate=skipped_dupe,
+                events_seen=events_seen,
+                prompts_unpaired=unpaired,
+            )
+
+    return BuildResult(
+        pairs_appended=appended,
+        pairs_skipped_duplicate=skipped_dupe,
+        events_seen=events_seen,
+        prompts_unpaired=unpaired,
+    )

--- a/tests/test_m4_1_dpo_pack.py
+++ b/tests/test_m4_1_dpo_pack.py
@@ -1,0 +1,305 @@
+"""ADR-012 M4.1 — DPO canonical pack JSONL writer invariants.
+
+Pins:
+- ``build_dpo_pack`` reads ``eval_response_recorded`` events (M4.0
+  output) and writes one JSONL row per ``(prompt, chosen, rejected)``
+  tuple.
+- Pairing: top-fitness chosen × bottom-fitness rejected — clearest
+  margin per prompt.
+- Idempotency: re-running over the same journals + pack file appends
+  zero new rows (signature-keyed dedup).
+- Graceful: missing journals → empty pack, no exception. Malformed
+  JSONL lines silently dropped.
+- ``fitness_delta = fitness_chosen - fitness_rejected``.
+- Prompts with chosen-only or rejected-only piles counted as
+  ``prompts_unpaired`` — no row written.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.observability.session_journal import (
+    SessionJournal,
+    session_journal_scope,
+)
+from core.self_improving_loop.dpo_pack import (
+    BuildResult,
+    build_dpo_pack,
+    pair_signature,
+)
+from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "session-A" / "journal.jsonl"
+
+
+@pytest.fixture
+def pack_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "dpo" / "pack.jsonl"
+
+
+def _journal(path: Path, session_id: str = "test") -> SessionJournal:
+    return SessionJournal(
+        session_id=session_id,
+        gen_tag="auto",
+        component="test",
+        path=path,
+    )
+
+
+def _read_pack(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+# Signature ------------------------------------------------------------------
+
+
+def test_pair_signature_is_deterministic() -> None:
+    sig1 = pair_signature("p", "good", "bad")
+    sig2 = pair_signature("p", "good", "bad")
+    assert sig1 == sig2
+    assert len(sig1) == 16
+
+
+def test_pair_signature_differs_on_any_field() -> None:
+    base = pair_signature("p", "good", "bad")
+    assert pair_signature("p2", "good", "bad") != base
+    assert pair_signature("p", "good2", "bad") != base
+    assert pair_signature("p", "good", "bad2") != base
+    # Field-order can't collide with separator collapse — pin via empty fields.
+    assert pair_signature("a", "", "b") != pair_signature("", "a", "b")
+
+
+# Empty / missing inputs -----------------------------------------------------
+
+
+def test_build_with_no_journals_returns_zero(pack_path: Path) -> None:
+    result = build_dpo_pack(journal_paths=[], pack_path=pack_path)
+    assert result == BuildResult(
+        pairs_appended=0,
+        pairs_skipped_duplicate=0,
+        events_seen=0,
+        prompts_unpaired=0,
+    )
+    assert not pack_path.exists()
+
+
+def test_build_with_missing_journal_file_graceful(tmp_path: Path, pack_path: Path) -> None:
+    """Missing journal file is treated as empty — no exception, no pack file."""
+    missing = tmp_path / "nope.jsonl"
+    result = build_dpo_pack(journal_paths=[missing], pack_path=pack_path)
+    assert result.events_seen == 0
+    assert result.pairs_appended == 0
+
+
+# Pairing rule ---------------------------------------------------------------
+
+
+def test_pairs_chosen_with_rejected_for_same_prompt(journal_path: Path, pack_path: Path) -> None:
+    with session_journal_scope(_journal(journal_path)):
+        emit_eval_response_recorded(prompt="explain DPO", response="good answer", fitness_score=0.9)
+        emit_eval_response_recorded(
+            prompt="explain DPO",
+            response="bad answer",
+            fitness_score=0.2,
+            rollback_flag=True,
+        )
+    result = build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    assert result.pairs_appended == 1
+    assert result.prompts_unpaired == 0
+    rows = _read_pack(pack_path)
+    assert len(rows) == 1
+    assert rows[0]["prompt"] == "explain DPO"
+    assert rows[0]["chosen"] == "good answer"
+    assert rows[0]["rejected"] == "bad answer"
+    assert rows[0]["fitness_chosen"] == 0.9
+    assert rows[0]["fitness_rejected"] == 0.2
+    assert rows[0]["fitness_delta"] == pytest.approx(0.7)
+
+
+def test_picks_highest_chosen_and_lowest_rejected(journal_path: Path, pack_path: Path) -> None:
+    """Three chosen + three rejected → top × bottom (steepest margin)."""
+    with session_journal_scope(_journal(journal_path)):
+        for resp, fit in [("good_low", 0.5), ("good_top", 0.95), ("good_mid", 0.7)]:
+            emit_eval_response_recorded(prompt="q", response=resp, fitness_score=fit)
+        for resp, fit in [("bad_high", 0.4), ("bad_bottom", 0.05), ("bad_mid", 0.2)]:
+            emit_eval_response_recorded(
+                prompt="q", response=resp, fitness_score=fit, rollback_flag=True
+            )
+    build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    rows = _read_pack(pack_path)
+    assert len(rows) == 1
+    assert rows[0]["chosen"] == "good_top"
+    assert rows[0]["rejected"] == "bad_bottom"
+    assert rows[0]["fitness_delta"] == pytest.approx(0.95 - 0.05)
+
+
+def test_chosen_only_prompt_counted_as_unpaired(journal_path: Path, pack_path: Path) -> None:
+    """No rollback → no rejected → no pair, but events still counted."""
+    with session_journal_scope(_journal(journal_path)):
+        emit_eval_response_recorded(prompt="q", response="a", fitness_score=0.8)
+    result = build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    assert result.events_seen == 1
+    assert result.pairs_appended == 0
+    assert result.prompts_unpaired == 1
+    assert not pack_path.exists()  # no rows = no file
+
+
+def test_rejected_only_prompt_counted_as_unpaired(journal_path: Path, pack_path: Path) -> None:
+    with session_journal_scope(_journal(journal_path)):
+        emit_eval_response_recorded(prompt="q", response="a", fitness_score=0.1, rollback_flag=True)
+    result = build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    assert result.prompts_unpaired == 1
+    assert result.pairs_appended == 0
+
+
+# Idempotency ----------------------------------------------------------------
+
+
+def test_rerun_skips_duplicates(journal_path: Path, pack_path: Path) -> None:
+    """Re-running the builder over the same journal appends zero new rows."""
+    with session_journal_scope(_journal(journal_path)):
+        emit_eval_response_recorded(prompt="q", response="good", fitness_score=0.9)
+        emit_eval_response_recorded(
+            prompt="q", response="bad", fitness_score=0.1, rollback_flag=True
+        )
+    first = build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    second = build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    assert first.pairs_appended == 1
+    assert second.pairs_appended == 0
+    assert second.pairs_skipped_duplicate == 1
+    assert len(_read_pack(pack_path)) == 1
+
+
+def test_new_pair_appended_on_rerun(journal_path: Path, pack_path: Path) -> None:
+    """Fresh prompt added to journal → second invocation appends just that pair."""
+    journal = _journal(journal_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(prompt="q1", response="g", fitness_score=0.9)
+        emit_eval_response_recorded(
+            prompt="q1", response="b", fitness_score=0.1, rollback_flag=True
+        )
+    build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(prompt="q2", response="g2", fitness_score=0.8)
+        emit_eval_response_recorded(
+            prompt="q2", response="b2", fitness_score=0.2, rollback_flag=True
+        )
+    second = build_dpo_pack(journal_paths=[journal_path], pack_path=pack_path)
+    assert second.pairs_appended == 1
+    assert second.pairs_skipped_duplicate == 1
+    rows = _read_pack(pack_path)
+    prompts = sorted(r["prompt"] for r in rows)
+    assert prompts == ["q1", "q2"]
+
+
+# Multi-journal --------------------------------------------------------------
+
+
+def test_multi_journal_merge(tmp_path: Path, pack_path: Path) -> None:
+    """Two journals (different sessions) feed the same prompt → cross-session pair."""
+    j1 = tmp_path / "s1" / "journal.jsonl"
+    j2 = tmp_path / "s2" / "journal.jsonl"
+    with session_journal_scope(_journal(j1, session_id="s1")):
+        emit_eval_response_recorded(
+            prompt="shared", response="great", fitness_score=0.95, source="petri_audit"
+        )
+    with session_journal_scope(_journal(j2, session_id="s2")):
+        emit_eval_response_recorded(
+            prompt="shared",
+            response="awful",
+            fitness_score=0.05,
+            rollback_flag=True,
+            source="live_session",
+        )
+    result = build_dpo_pack(journal_paths=[j1, j2], pack_path=pack_path)
+    assert result.pairs_appended == 1
+    row = _read_pack(pack_path)[0]
+    assert row["session_id_chosen"] == "s1"
+    assert row["session_id_rejected"] == "s2"
+    assert row["source_chosen"] == "petri_audit"
+    assert row["source_rejected"] == "live_session"
+
+
+# Malformed input ------------------------------------------------------------
+
+
+def test_malformed_lines_silently_dropped(tmp_path: Path, pack_path: Path) -> None:
+    """Bad JSON / wrong event / missing payload fields → skipped, no crash."""
+    journal_p = tmp_path / "j.jsonl"
+    journal_p.parent.mkdir(parents=True, exist_ok=True)
+    valid_chosen = json.dumps(
+        {
+            "ts": 1.0,
+            "session_id": "s",
+            "gen_tag": "g",
+            "component": "c",
+            "level": "info",
+            "event": "eval_response_recorded",
+            "payload": {
+                "prompt": "q",
+                "response": "good",
+                "fitness_score": 0.9,
+                "rollback_flag": False,
+                "source": "",
+            },
+        }
+    )
+    valid_rejected = json.dumps(
+        {
+            "ts": 2.0,
+            "session_id": "s",
+            "gen_tag": "g",
+            "component": "c",
+            "level": "info",
+            "event": "eval_response_recorded",
+            "payload": {
+                "prompt": "q",
+                "response": "bad",
+                "fitness_score": 0.1,
+                "rollback_flag": True,
+                "source": "",
+            },
+        }
+    )
+    journal_p.write_text(
+        "\n".join(
+            [
+                "not json at all",
+                "{}",  # missing event
+                json.dumps({"event": "different_event", "payload": {}}),
+                json.dumps(
+                    {
+                        "event": "eval_response_recorded",
+                        "payload": {"prompt": "x"},  # missing response/fitness
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event": "eval_response_recorded",
+                        "payload": {
+                            "prompt": "y",
+                            "response": "r",
+                            "fitness_score": "not_a_number",
+                        },
+                    }
+                ),
+                valid_chosen,
+                valid_rejected,
+                "",  # empty line
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = build_dpo_pack(journal_paths=[journal_p], pack_path=pack_path)
+    assert result.events_seen == 2  # only the two valid rows
+    assert result.pairs_appended == 1


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/self_improving_loop/dpo_pack.py` — M4.0 `eval_response_recorded` event stream 을 (prompt, chosen, rejected) preference pair 로 변환.
- Pairing rule: 동일 prompt 내 chosen pile 최고 fitness × rejected pile 최저 fitness — DPO 학습 신호가 가장 선명한 margin.
- Idempotency: 16-hex `pair_signature(prompt, chosen, rejected)` 로 재실행 시 dedup, 신규 pair 만 append.

## Why
ADR-012 M4 DPO pipeline 의 두 번째 piece — M4.0 (event emit, #1429) 에 이어 stream → pack format-agnostic transform 을 완성. M4.2 publisher (OpenAI fine-tuning / Bedrock DPO / HuggingFace TRL `DPOTrainer`) 가 이 canonical JSONL 을 입력으로 사용. Rafailov 2023 DPO formulation 의 `(x, y_w, y_l)` triple 과 직접 정합.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/dpo_pack.py` | 신규 — `build_dpo_pack` / `pair_signature` / `BuildResult`. 내부 `_iter_eval_events` parser + `_EvalEvent` private dataclass + `_select_pair(events)` top×bottom 선택 |
| `core/paths.py` | `GLOBAL_DPO_PACK_PATH = ~/.geode/self-improving-loop/dpo/pack.jsonl` 추가 (operator-local, NOT git-tracked) |
| `tests/test_m4_1_dpo_pack.py` | 신규 — 12 invariant test |
| `CHANGELOG.md` | PR-M4.1 entry (M4.0 위에) |

## Pack schema (13 field)
```
{
  "signature": "...16-hex...",
  "prompt": "...",
  "chosen": "...", "rejected": "...",
  "fitness_chosen": 0.91, "fitness_rejected": 0.32, "fitness_delta": 0.59,
  "ts_chosen": ..., "ts_rejected": ...,
  "session_id_chosen": "...", "session_id_rejected": "...",
  "source_chosen": "...", "source_rejected": "..."
}
```

## Test inventory (12)
- `test_pair_signature_is_deterministic` — 동일 입력 = 동일 16-hex
- `test_pair_signature_differs_on_any_field` — 4-way sensitivity + separator collapse 차단
- `test_build_with_no_journals_returns_zero` — empty input → 0 / 0 / 0 / 0
- `test_build_with_missing_journal_file_graceful` — file 부재 → no exception
- `test_pairs_chosen_with_rejected_for_same_prompt` — 기본 chosen × rejected pair
- `test_picks_highest_chosen_and_lowest_rejected` — 3 chosen × 3 rejected → top × bottom 선택
- `test_chosen_only_prompt_counted_as_unpaired` — rollback 없는 prompt → unpaired
- `test_rejected_only_prompt_counted_as_unpaired` — rollback only → unpaired
- `test_rerun_skips_duplicates` — idempotency
- `test_new_pair_appended_on_rerun` — 신규 prompt 추가 → 1 row append + 1 skip
- `test_multi_journal_merge` — 2 session journal 의 cross-session pair
- `test_malformed_lines_silently_dropped` — bad JSON / wrong event / missing field 전부 silent drop

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Module already exists | No | `grep -rn "dpo\|canonical_pack\|preference_pack" core/` returns only M4.0 docstring refs |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter / version — no diff |
| Caller wiring | Deferred | M4.0 의 emit 자체가 후속 PR 에서 wiring 예정이므로 M4.1 도 schema-only |

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/self_improving_loop/dpo_pack.py` clean
- [x] `uv run pytest tests/test_m4_1_dpo_pack.py -q` 12/12 PASS
- [x] No `# type: ignore` / no `# noqa` added (one `type: ignore[arg-type]` on `float(fitness)` because `payload.get` returns `object` — narrow, justified)

## Reference
- ADR-012 M4 DPO pipeline plan (M4.0 #1429 → M4.1 본 PR → M4.2 publisher → M4.3 redaction → M4.4 in-context wiring)
- Rafailov et al. 2023, "Direct Preference Optimization" — `(x, y_w, y_l)` triple format
- M4.0 PR #1429 — `eval_response_recorded` event source