### PR TITLE
feat(self-improving-loop): PR-M4.2 — DPO publisher adapters (TRL / OpenAI / Bedrock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,34 @@ functional change.
 
 ### Added
 
+- **PR-M4.2 — DPO publisher adapters (TRL / OpenAI / Bedrock, ADR-012).**
+  M4.1 canonical pack 을 per-provider DPO 학습 입력 포맷으로 변환.
+  **신규 모듈** `core/self_improving_loop/dpo_publisher.py` — 3 adapter
+  함수 (`to_trl_format` / `to_openai_format` / `to_bedrock_format`) +
+  `publish_pack(target, pack_path, out_path) -> int` dispatcher. 모든
+  변환은 **pure transform** — network call / SDK import / API key
+  read 일체 없음. 운영자는 결과 JSONL 을 provider 의 upload tool
+  (`openai files create` / `aws s3 cp` / `hf datasets push`) 에 전달.
+  **Idempotency** — `publish_pack` 가 destination 을 매번 overwrite
+  하므로 동일 (pack, target) 입력은 byte-equal output 생성.
+  **Adapter 별 row schema**: TRL = 최소 triple `{prompt, chosen,
+  rejected}` (TRL DPOTrainer 직접 소비). OpenAI = messages 스타일
+  `{input.messages, preferred_output, non_preferred_output}` (OpenAI
+  preference fine-tuning guide 의 schema). Bedrock = generic
+  passthrough `{prompt, chosen, rejected, signature, fitness_chosen,
+  fitness_rejected, fitness_delta}` (base model family 별 schema
+  편차가 커서 운영자가 후처리하도록 audit metadata 유지). **Graceful**
+  — missing pack file → 0 rows + empty out file. Malformed JSONL line
+  + 비 dict + prompt/chosen/rejected str 누락 row 는 silently drop.
+  **ValueError** — `SUPPORTED_TARGETS = ("trl", "openai", "bedrock")`
+  외 target. 본 PR 은 transform 만; CLI integration + network upload
+  + PII redaction (M4.3) 은 후속. **14 invariant test** — TRL minimal
+  triple / OpenAI messages schema / Bedrock fitness 보존 + 누락 graceful
+  / SUPPORTED_TARGETS manifest / publish_pack one-row-per-pack-row /
+  overwrite / byte-equal rerun / missing pack empty file / invalid
+  target ValueError / malformed line drop / openai+bedrock dispatch /
+  no-network import guard (forbidden SDK 8종 stdlib 외 미적재).
+
 - **PR-M4.1 — DPO canonical preference-pack JSONL writer (ADR-012).**
   Consumes M4.0 의 `eval_response_recorded` event stream → 각 unique
   `prompt` group 을 chosen pile (`rollback_flag=False`) + rejected pile

--- a/core/self_improving_loop/dpo_publisher.py
+++ b/core/self_improving_loop/dpo_publisher.py
@@ -1,0 +1,175 @@
+"""DPO publisher adapters — ADR-012 M4.2.
+
+Transforms M4.1's canonical preference pack (one row per ``(prompt,
+chosen, rejected)`` tuple) into per-provider DPO training formats.
+Three targets in scope:
+
+* ``trl`` — HuggingFace TRL ``DPOTrainer``. Row schema is the simplest
+  of the three (``{prompt, chosen, rejected}``) and is the de-facto
+  standard for open-weight DPO training across the ecosystem.
+* ``openai`` — OpenAI preference fine-tuning. Uses the messages-style
+  schema with ``input.messages`` + ``preferred_output`` +
+  ``non_preferred_output``. Field names follow the OpenAI fine-tuning
+  guide. Each ``prompt`` becomes one user message; ``chosen`` and
+  ``rejected`` become assistant-role completions.
+* ``bedrock`` — Amazon Bedrock fine-tuning. The exact schema varies by
+  base model family; we emit a passthrough that the operator can
+  post-process per model. Documented as ``raw`` so callers aren't
+  misled into thinking we know every Bedrock model's flavor.
+
+**Scope** — adapters are *pure transforms*. No network calls, no SDK
+imports, no API keys read. The publisher writes a JSONL file the
+operator hands off to the provider's upload tool (``openai files
+create``, ``aws s3 cp``, ``hf datasets push``). M4.3 will add PII
+redaction + ratchet gates; M4.4 the in-context wiring path.
+
+**Idempotency** — :func:`publish_pack` overwrites the destination
+file each invocation. The canonical pack (M4.1) is the durable
+source-of-truth; the published artefact is a *derived view* whose
+identity is the (pack content, target) pair. Re-running over the
+same pack produces a byte-equal output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Literal
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "SUPPORTED_TARGETS",
+    "Target",
+    "publish_pack",
+    "to_bedrock_format",
+    "to_openai_format",
+    "to_trl_format",
+]
+
+Target = Literal["trl", "openai", "bedrock"]
+SUPPORTED_TARGETS: tuple[Target, ...] = ("trl", "openai", "bedrock")
+
+
+def to_trl_format(row: dict[str, Any]) -> dict[str, Any]:
+    """HuggingFace TRL ``DPOTrainer`` row — minimal canonical triple."""
+    return {
+        "prompt": row["prompt"],
+        "chosen": row["chosen"],
+        "rejected": row["rejected"],
+    }
+
+
+def to_openai_format(row: dict[str, Any]) -> dict[str, Any]:
+    """OpenAI preference fine-tuning row — messages-style schema.
+
+    ``input.messages`` carries the user turn; ``preferred_output`` and
+    ``non_preferred_output`` are assistant-role completions. Schema
+    matches the OpenAI fine-tuning guide (``input`` + ``preferred_output``
+    + ``non_preferred_output``). If OpenAI's exact field names drift,
+    callers should override at the adapter boundary rather than mutate
+    canonical pack rows.
+    """
+    return {
+        "input": {
+            "messages": [{"role": "user", "content": row["prompt"]}],
+        },
+        "preferred_output": [{"role": "assistant", "content": row["chosen"]}],
+        "non_preferred_output": [{"role": "assistant", "content": row["rejected"]}],
+    }
+
+
+def to_bedrock_format(row: dict[str, Any]) -> dict[str, Any]:
+    """Amazon Bedrock fine-tuning row — generic passthrough.
+
+    Bedrock's preference-tuning schema varies by base model family
+    (Anthropic-on-Bedrock differs from Llama-on-Bedrock). Rather than
+    bake one assumption into the publisher, we emit a stable triple
+    (``prompt``/``chosen``/``rejected``) plus the per-row metadata
+    (signature, fitness scores) so an operator-side script can adapt
+    to the specific model with full audit context.
+    """
+    return {
+        "prompt": row["prompt"],
+        "chosen": row["chosen"],
+        "rejected": row["rejected"],
+        "signature": row.get("signature", ""),
+        "fitness_chosen": row.get("fitness_chosen"),
+        "fitness_rejected": row.get("fitness_rejected"),
+        "fitness_delta": row.get("fitness_delta"),
+    }
+
+
+_ADAPTERS: dict[Target, Any] = {
+    "trl": to_trl_format,
+    "openai": to_openai_format,
+    "bedrock": to_bedrock_format,
+}
+
+
+def _iter_pack_rows(pack_path: Path) -> list[dict[str, Any]]:
+    """Read the canonical pack JSONL → list of row dicts.
+
+    Malformed JSON lines silently dropped (per-line graceful — a stray
+    bad row shouldn't block the rest of the pack from publishing).
+    Rows missing the required ``prompt``/``chosen``/``rejected`` triple
+    are also skipped — the publisher can only emit what the canonical
+    pack has labelled.
+    """
+    if not pack_path.is_file():
+        return []
+    try:
+        text = pack_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning("dpo_publisher: failed to read pack %s: %s", pack_path, exc)
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        if not all(isinstance(row.get(k), str) for k in ("prompt", "chosen", "rejected")):
+            continue
+        rows.append(row)
+    return rows
+
+
+def publish_pack(
+    *,
+    target: Target,
+    pack_path: Path,
+    out_path: Path,
+) -> int:
+    """Transform every row in ``pack_path`` via the ``target`` adapter, write to ``out_path``.
+
+    Args:
+        target: One of :data:`SUPPORTED_TARGETS`. Selects the adapter.
+        pack_path: Canonical pack JSONL (M4.1 output).
+        out_path: Destination JSONL. The file is OVERWRITTEN — re-run
+            with the same pack produces a byte-equal output.
+
+    Returns:
+        Number of rows written.
+
+    Raises:
+        ValueError: ``target`` is not in :data:`SUPPORTED_TARGETS`.
+    """
+    if target not in _ADAPTERS:
+        raise ValueError(f"unsupported target {target!r}; expected one of {SUPPORTED_TARGETS}")
+    adapter = _ADAPTERS[target]
+    rows = _iter_pack_rows(pack_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with out_path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            transformed = adapter(row)
+            fh.write(json.dumps(transformed, ensure_ascii=False) + "\n")
+            written += 1
+    return written

--- a/tests/test_m4_2_dpo_publisher.py
+++ b/tests/test_m4_2_dpo_publisher.py
@@ -1,0 +1,238 @@
+"""ADR-012 M4.2 — DPO publisher adapter invariants.
+
+Pins:
+- 3 target adapters (``trl`` / ``openai`` / ``bedrock``) emit the
+  per-provider JSONL row shape claimed in :mod:`core.self_improving_loop.dpo_publisher`.
+- ``publish_pack(target, pack_path, out_path)`` overwrites ``out_path``
+  with one transformed row per valid pack row, returning the count.
+- Unsupported target → ``ValueError``.
+- Pure transforms — no network, no SDK imports, no API keys.
+- Graceful: missing pack → 0 rows, empty file; malformed lines dropped;
+  rows missing the ``prompt``/``chosen``/``rejected`` triple skipped.
+- Idempotency: second run over the same pack produces byte-equal output.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.dpo_publisher import (
+    SUPPORTED_TARGETS,
+    publish_pack,
+    to_bedrock_format,
+    to_openai_format,
+    to_trl_format,
+)
+
+
+@pytest.fixture
+def pack_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "pack.jsonl"
+
+
+@pytest.fixture
+def out_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "published" / "out.jsonl"
+
+
+def _write_pack(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+_SAMPLE_PACK_ROW = {
+    "signature": "abc123def4567890",
+    "prompt": "What is DPO?",
+    "chosen": "DPO is Direct Preference Optimization.",
+    "rejected": "I don't know.",
+    "fitness_chosen": 0.9,
+    "fitness_rejected": 0.2,
+    "fitness_delta": 0.7,
+    "ts_chosen": 100.0,
+    "ts_rejected": 200.0,
+    "session_id_chosen": "s1",
+    "session_id_rejected": "s2",
+    "source_chosen": "petri_audit",
+    "source_rejected": "live_session",
+}
+
+
+# Adapter shape -------------------------------------------------------------
+
+
+def test_trl_format_returns_minimal_triple() -> None:
+    out = to_trl_format(_SAMPLE_PACK_ROW)
+    assert out == {
+        "prompt": "What is DPO?",
+        "chosen": "DPO is Direct Preference Optimization.",
+        "rejected": "I don't know.",
+    }
+    assert set(out.keys()) == {"prompt", "chosen", "rejected"}
+
+
+def test_openai_format_uses_messages_schema() -> None:
+    out = to_openai_format(_SAMPLE_PACK_ROW)
+    assert out["input"]["messages"] == [{"role": "user", "content": "What is DPO?"}]
+    assert out["preferred_output"] == [
+        {"role": "assistant", "content": "DPO is Direct Preference Optimization."}
+    ]
+    assert out["non_preferred_output"] == [{"role": "assistant", "content": "I don't know."}]
+
+
+def test_bedrock_format_carries_fitness_metadata() -> None:
+    """Bedrock passthrough keeps the audit fields so per-model adapters can use them."""
+    out = to_bedrock_format(_SAMPLE_PACK_ROW)
+    assert out["prompt"] == "What is DPO?"
+    assert out["chosen"] == "DPO is Direct Preference Optimization."
+    assert out["rejected"] == "I don't know."
+    assert out["signature"] == "abc123def4567890"
+    assert out["fitness_chosen"] == 0.9
+    assert out["fitness_rejected"] == 0.2
+    assert out["fitness_delta"] == 0.7
+
+
+def test_bedrock_format_tolerates_missing_optionals() -> None:
+    """Adapter doesn't crash when fitness fields are absent from the row."""
+    row = {"prompt": "p", "chosen": "c", "rejected": "r"}
+    out = to_bedrock_format(row)
+    assert out["signature"] == ""
+    assert out["fitness_chosen"] is None
+    assert out["fitness_rejected"] is None
+
+
+# Supported targets manifest ------------------------------------------------
+
+
+def test_supported_targets_manifest() -> None:
+    """The Literal type alias and SUPPORTED_TARGETS must stay in sync."""
+    assert SUPPORTED_TARGETS == ("trl", "openai", "bedrock")
+
+
+# publish_pack --------------------------------------------------------------
+
+
+def test_publish_pack_writes_one_row_per_pack_row(pack_path: Path, out_path: Path) -> None:
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW, _SAMPLE_PACK_ROW])
+    n = publish_pack(target="trl", pack_path=pack_path, out_path=out_path)
+    assert n == 2
+    rows = _read_jsonl(out_path)
+    assert len(rows) == 2
+    assert all(r["prompt"] == "What is DPO?" for r in rows)
+
+
+def test_publish_pack_overwrites_existing_destination(pack_path: Path, out_path: Path) -> None:
+    """First call writes 3 rows; second call with 1-row pack leaves only 1 row."""
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW, _SAMPLE_PACK_ROW, _SAMPLE_PACK_ROW])
+    publish_pack(target="trl", pack_path=pack_path, out_path=out_path)
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW])
+    n = publish_pack(target="trl", pack_path=pack_path, out_path=out_path)
+    assert n == 1
+    assert len(_read_jsonl(out_path)) == 1
+
+
+def test_publish_pack_byte_equal_on_rerun(pack_path: Path, out_path: Path) -> None:
+    """Same pack + same target → byte-equal output (idempotent)."""
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW, _SAMPLE_PACK_ROW])
+    publish_pack(target="openai", pack_path=pack_path, out_path=out_path)
+    bytes1 = out_path.read_bytes()
+    publish_pack(target="openai", pack_path=pack_path, out_path=out_path)
+    bytes2 = out_path.read_bytes()
+    assert bytes1 == bytes2
+
+
+def test_publish_pack_missing_pack_writes_empty_file(tmp_path: Path, out_path: Path) -> None:
+    missing = tmp_path / "nope.jsonl"
+    n = publish_pack(target="trl", pack_path=missing, out_path=out_path)
+    assert n == 0
+    assert out_path.is_file()
+    assert out_path.read_text(encoding="utf-8") == ""
+
+
+def test_publish_pack_invalid_target_raises(pack_path: Path, out_path: Path) -> None:
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW])
+    with pytest.raises(ValueError, match="unsupported target"):
+        publish_pack(
+            target="anthropic",  # type: ignore[arg-type]  # intentional bad target
+            pack_path=pack_path,
+            out_path=out_path,
+        )
+
+
+def test_publish_pack_drops_malformed_lines(pack_path: Path, out_path: Path) -> None:
+    """Bad JSON + non-dict + missing triple → skipped, no crash."""
+    pack_path.parent.mkdir(parents=True, exist_ok=True)
+    pack_path.write_text(
+        "\n".join(
+            [
+                "not json",
+                json.dumps(["array not dict"]),
+                json.dumps({"prompt": "p"}),  # missing chosen/rejected
+                json.dumps({"prompt": 123, "chosen": "c", "rejected": "r"}),  # non-str prompt
+                json.dumps(_SAMPLE_PACK_ROW),
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    n = publish_pack(target="trl", pack_path=pack_path, out_path=out_path)
+    assert n == 1  # only the valid row
+
+
+# Per-target round-trip via publish_pack -------------------------------------
+
+
+def test_publish_pack_dispatches_to_openai_adapter(pack_path: Path, out_path: Path) -> None:
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW])
+    publish_pack(target="openai", pack_path=pack_path, out_path=out_path)
+    rows = _read_jsonl(out_path)
+    assert rows[0]["input"]["messages"][0]["role"] == "user"
+    assert rows[0]["preferred_output"][0]["role"] == "assistant"
+
+
+def test_publish_pack_dispatches_to_bedrock_adapter(pack_path: Path, out_path: Path) -> None:
+    _write_pack(pack_path, [_SAMPLE_PACK_ROW])
+    publish_pack(target="bedrock", pack_path=pack_path, out_path=out_path)
+    rows = _read_jsonl(out_path)
+    assert rows[0]["fitness_delta"] == 0.7
+    assert rows[0]["signature"] == "abc123def4567890"
+
+
+# No-network guard -----------------------------------------------------------
+
+
+def test_no_network_imports_in_module() -> None:
+    """Pure transform — no openai/boto3/transformers/requests at import time."""
+    import sys
+
+    forbidden = {
+        "openai",
+        "boto3",
+        "transformers",
+        "trl",
+        "requests",
+        "httpx",
+        "urllib3",
+        "anthropic",
+    }
+    loaded_via_publisher = {
+        name for name in sys.modules if any(name.startswith(f) for f in forbidden)
+    }
+    # If any of the forbidden SDKs are loaded, they must have come from
+    # elsewhere in the test harness — not from importing dpo_publisher.
+    # The module itself only imports stdlib (json/logging/pathlib/typing).
+    import core.self_improving_loop.dpo_publisher as pub  # noqa: F401
+
+    after = {name for name in sys.modules if any(name.startswith(f) for f in forbidden)}
+    assert after == loaded_via_publisher, (
+        f"dpo_publisher must not import network SDKs at import time; new: {after - loaded_via_publisher}"
+    )

--- a/tests/test_m4_2_dpo_publisher.py
+++ b/tests/test_m4_2_dpo_publisher.py
@@ -211,8 +211,19 @@ def test_publish_pack_dispatches_to_bedrock_adapter(pack_path: Path, out_path: P
 
 
 def test_no_network_imports_in_module() -> None:
-    """Pure transform — no openai/boto3/transformers/requests at import time."""
-    import sys
+    """Pure transform — no SDK imports in module source (static AST check).
+
+    A runtime ``sys.modules`` check is fragile because the test file
+    itself imports the publisher at top level, so any forbidden SDK
+    pulled in transitively would already be loaded before the test
+    captures its baseline. An AST walk of the module source is the
+    definitive check: if the import statement isn't there, the SDK
+    cannot have been loaded by this module.
+    """
+    import ast
+    import inspect
+
+    import core.self_improving_loop.dpo_publisher as pub
 
     forbidden = {
         "openai",
@@ -224,15 +235,14 @@ def test_no_network_imports_in_module() -> None:
         "urllib3",
         "anthropic",
     }
-    loaded_via_publisher = {
-        name for name in sys.modules if any(name.startswith(f) for f in forbidden)
-    }
-    # If any of the forbidden SDKs are loaded, they must have come from
-    # elsewhere in the test harness — not from importing dpo_publisher.
-    # The module itself only imports stdlib (json/logging/pathlib/typing).
-    import core.self_improving_loop.dpo_publisher as pub  # noqa: F401
-
-    after = {name for name in sys.modules if any(name.startswith(f) for f in forbidden)}
-    assert after == loaded_via_publisher, (
-        f"dpo_publisher must not import network SDKs at import time; new: {after - loaded_via_publisher}"
-    )
+    source = inspect.getsource(pub)
+    tree = ast.parse(source)
+    imported_top_level: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_top_level.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_top_level.add(node.module.split(".", 1)[0])
+    bad = imported_top_level & forbidden
+    assert not bad, f"dpo_publisher must not import network SDKs; found: {bad}"


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/self_improving_loop/dpo_publisher.py` — M4.1 canonical pack 을 TRL / OpenAI / Bedrock 학습 입력 포맷으로 변환하는 **pure transform** adapter 3종.
- `publish_pack(target, pack_path, out_path) -> int` dispatcher — 매 호출마다 destination overwrite, byte-equal rerun 보장.
- 변환만; CLI / network upload / PII redaction (M4.3) 은 후속.

## Why
M4.1 (#1430) 의 canonical preference pack 은 13-field 풍부한 row 지만 어떤 DPO trainer 도 그 schema 를 직접 소비하지 못함. M4.2 가 operator 가 "geode dpo publish --target trl --out /tmp/out.jsonl" 같이 provider 별 entry-point 로 던질 수 있는 변환층을 깐다. Rafailov 2023 DPO + TRL DPOTrainer + OpenAI preference fine-tuning + Bedrock fine-tuning 모두 비슷한 본질을 다른 schema 로 받아서, 단일 adapter dispatcher 가 최소 비용으로 cover.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/dpo_publisher.py` | 신규 — `to_trl_format` / `to_openai_format` / `to_bedrock_format` + `publish_pack` + `SUPPORTED_TARGETS` + `Target` Literal |
| `tests/test_m4_2_dpo_publisher.py` | 신규 — 14 invariant test |
| `CHANGELOG.md` | PR-M4.2 entry (M4.1 위에) |

## Adapter row schemas
- **TRL** — `{prompt, chosen, rejected}` (TRL DPOTrainer 직접 소비)
- **OpenAI** — `{input.messages, preferred_output, non_preferred_output}` (OpenAI preference fine-tuning guide schema)
- **Bedrock** — generic passthrough `{prompt, chosen, rejected, signature, fitness_chosen, fitness_rejected, fitness_delta}` (base model family 별 편차가 커서 운영자가 후처리, audit metadata 유지)

## Test inventory (14)
- Adapter shape × 3 (TRL minimal / OpenAI messages / Bedrock metadata)
- Bedrock missing-optionals graceful
- SUPPORTED_TARGETS manifest
- publish_pack one-row-per-pack-row × 1
- publish_pack overwrite (3→1 row)
- publish_pack byte-equal rerun
- publish_pack missing pack → 0 rows + empty file
- publish_pack invalid target → ValueError
- publish_pack drops malformed lines
- publish_pack dispatch openai
- publish_pack dispatch bedrock
- No-network import guard (openai / boto3 / transformers / trl / requests / httpx / urllib3 / anthropic 미적재)

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Module already exists | No | `grep` for `dpo_publisher\|to_trl\|preference.*publish` clean |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter — no diff |
| Network/SDK pulled in | No | dedicated test asserts forbidden 8 SDK 안 적재 |
| CLI wiring | Deferred | `geode dpo publish` subcommand 은 후속 PR |

## Verification
- [x] `uv run ruff format` clean (auto-applied)
- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run mypy core/self_improving_loop/dpo_publisher.py` clean
- [x] `uv run pytest tests/test_m4_2_dpo_publisher.py -q` 14/14 PASS
- [x] No new `# noqa`; one `# type: ignore[arg-type]` in test (intentional bad-target ValueError test, comment explains)

## Reference
- ADR-012 M4 DPO pipeline (M4.0 #1429 → M4.1 #1430 → M4.2 본 PR → M4.3 redaction → M4.4 in-context wiring)
- TRL DPOTrainer dataset format: `{prompt, chosen, rejected}` columns
- OpenAI preference fine-tuning guide — messages-style `input` / `preferred_output` / `non_preferred_output`