### PR TITLE
fix(test): root-cause CircuitBreaker xdist worker contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-CB-FLAKE — CircuitBreaker xdist worker contamination (PR #1429/#1430/#1431 cascade).**
+  Test 의 module-level `CircuitBreaker` singleton (anthropic / openai / glm /
+  codex 4 provider + `provider_dispatch._openai_cb` / `_glm_cb` 2 dispatcher
+  = 총 6개) 가 *failure-injecting* test 와 같은 xdist worker 에서 콜로케이션
+  될 때 OPEN 상태로 leak — 후속 test 의 첫 `can_execute()` 가 즉시
+  False 반환하며 `RuntimeError("Circuit breaker is open …")` cascade.
+  PR #1429 → #1431 sprint 에서 4회 발생 ([feedback_circuit_breaker_flake](#)).
+  **Root cause**: `test_failover.py::test_no_silent_fallback_to_other_models`
+  가 `MAX_RETRIES` 회 `RateLimitError` side_effect 로 `_circuit_breaker.record_failure()`
+  threshold (5) 도달 → state="open". 같은 worker 에 분배된 `test_tool_use.py`
+  의 mocked 호출이 breaker 게이트에서 차단. **Fix**: (a) `CircuitBreaker.reset()`
+  메서드 신설 — state="closed" + failures=0 + last_failure=0 force-clear.
+  (b) `tests/conftest.py` autouse fixture `_reset_circuit_breakers` 가 매
+  test pre/post 6 singleton 모두 reset. ImportError / AttributeError tolerate
+  (vendored SDK 없는 stripped env / 향후 rename 내성). **9 regression test**
+  `tests/test_circuit_breaker_isolation.py` — reset 메서드 존재 + part1/part2
+  cross-test reset 입증 (deliberately OPEN → 다음 test 에 CLOSED) +
+  parametrize 로 6 singleton 각각 test entry 에 CLOSED 검증.
+
 ### Added
 
 - **PR-M4.2 — DPO publisher adapters (TRL / OpenAI / Bedrock, ADR-012).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,11 @@ functional change.
   메서드 신설 — state="closed" + failures=0 + last_failure=0 force-clear.
   (b) `tests/conftest.py` autouse fixture `_reset_circuit_breakers` 가 매
   test pre/post 6 singleton 모두 reset. ImportError / AttributeError tolerate
-  (vendored SDK 없는 stripped env / 향후 rename 내성). **9 regression test**
-  `tests/test_circuit_breaker_isolation.py` — reset 메서드 존재 + part1/part2
-  cross-test reset 입증 (deliberately OPEN → 다음 test 에 CLOSED) +
-  parametrize 로 6 singleton 각각 test entry 에 CLOSED 검증.
+  (vendored SDK 없는 stripped env / 향후 rename 내성). **4 def / 9 runtime
+  case** `tests/test_circuit_breaker_isolation.py` — reset 메서드 존재 +
+  part1/part2 cross-test reset 입증 (deliberately OPEN → 다음 test 에
+  CLOSED) + parametrize 1 def × 6 singleton = 6 case (각 singleton 의
+  test entry CLOSED 검증).
 
 ### Added
 

--- a/core/llm/fallback.py
+++ b/core/llm/fallback.py
@@ -187,6 +187,22 @@ class CircuitBreaker:
                 return False
             return True  # half-open: allow one attempt
 
+    def reset(self) -> None:
+        """Force-clear breaker state. Test-only — drops all accumulated failure history.
+
+        Production code should rely on natural recovery via the
+        ``recovery_timeout`` half-open path. The pytest autouse fixture
+        in ``tests/conftest.py`` calls this between tests so module-level
+        breaker singletons don't leak failure counters across unrelated
+        suites when xdist's ``loadfile`` distribution puts a
+        failure-injecting test (e.g. ``test_failover``) on the same
+        worker as a downstream consumer (e.g. ``test_tool_use``).
+        """
+        with self._lock:
+            self._failures = 0
+            self._state = "closed"
+            self._last_failure = 0.0
+
 
 def retry_with_backoff_generic(
     fn: Any,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,3 +59,53 @@ def _reset_auth_singletons():
     # to remove it. Tolerate concurrent FileNotFoundError.
     with contextlib.suppress(FileNotFoundError):
         os.remove(_test_auth_toml)
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_breakers():
+    """Reset module-level CircuitBreaker singletons before & after each test.
+
+    Failure-injecting tests (e.g. ``test_failover.py::test_no_silent_fallback_to_other_models``)
+    raise ``MAX_RETRIES`` RateLimitErrors per invocation, which pushes the
+    shared anthropic / openai / glm / codex breakers to the OPEN state.
+    When pytest-xdist's ``loadfile`` distribution colocates a failure-
+    injecting test with a downstream consumer on the same worker, the
+    consumer's first ``can_execute()`` check returns False and the test
+    fails with "Circuit breaker is open" — a cascade flake that has
+    nothing to do with the consumer's PR.
+
+    Reset both pre- and post-test so accumulated state from prior runs
+    can't bleed in either direction.
+    """
+
+    def _reset_all() -> None:
+        # Import lazily and tolerate ImportError so the reset survives the
+        # case where a vendored SDK isn't installed in a stripped-down
+        # test environment. AttributeError tolerated for the same reason
+        # — a future refactor that renames a singleton shouldn't break
+        # the whole conftest.
+        with contextlib.suppress(ImportError, AttributeError):
+            from core.llm.providers import anthropic as _anth
+
+            _anth._circuit_breaker.reset()
+        with contextlib.suppress(ImportError, AttributeError):
+            from core.llm.providers import openai as _oai
+
+            _oai._openai_circuit_breaker.reset()
+        with contextlib.suppress(ImportError, AttributeError):
+            from core.llm.providers import glm as _glm
+
+            _glm._glm_circuit_breaker.reset()
+        with contextlib.suppress(ImportError, AttributeError):
+            from core.llm.providers import codex as _cdx
+
+            _cdx._codex_circuit_breaker.reset()
+        with contextlib.suppress(ImportError, AttributeError):
+            from core.llm import provider_dispatch as _disp
+
+            _disp._openai_cb.reset()
+            _disp._glm_cb.reset()
+
+    _reset_all()
+    yield
+    _reset_all()

--- a/tests/test_circuit_breaker_isolation.py
+++ b/tests/test_circuit_breaker_isolation.py
@@ -1,0 +1,75 @@
+"""Pin the autouse CircuitBreaker reset added in conftest.py.
+
+Reproduces the xdist `loadfile` cascade by forcing the anthropic
+breaker into OPEN, then asserting the autouse fixture resets it before
+the next test starts. Without the fixture, the second test would
+inherit the OPEN state and fail with "Circuit breaker is open …" —
+exactly the failure mode seen on PR #1429-#1431 CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_breaker_reset_class_method_exists() -> None:
+    """CircuitBreaker.reset() is the test-only escape hatch — must exist."""
+    from core.llm.fallback import CircuitBreaker
+
+    cb = CircuitBreaker(failure_threshold=2)
+    cb.record_failure()
+    cb.record_failure()
+    assert not cb.can_execute()  # OPEN
+    cb.reset()
+    assert cb.can_execute()  # CLOSED again
+    assert cb._failures == 0
+    assert cb._state == "closed"
+
+
+def test_anthropic_breaker_singleton_reset_between_tests_part1() -> None:
+    """Step 1: deliberately open the anthropic breaker.
+
+    The conftest autouse fixture must reset it before the next test
+    runs. test_..._part2 verifies the reset took effect.
+    """
+    from core.llm.providers import anthropic as _anth
+
+    cb = _anth._circuit_breaker
+    for _ in range(cb._threshold + 1):
+        cb.record_failure()
+    assert not cb.can_execute(), "test setup: breaker should be OPEN"
+
+
+def test_anthropic_breaker_singleton_reset_between_tests_part2() -> None:
+    """Step 2: previous test left the breaker OPEN — fixture must have reset it."""
+    from core.llm.providers import anthropic as _anth
+
+    cb = _anth._circuit_breaker
+    assert cb.can_execute(), (
+        "Circuit breaker should be CLOSED at start of test — "
+        "the autouse fixture in conftest.py did not reset between tests"
+    )
+    assert cb._failures == 0
+
+
+@pytest.mark.parametrize(
+    "module_path,attr",
+    [
+        ("core.llm.providers.anthropic", "_circuit_breaker"),
+        ("core.llm.providers.openai", "_openai_circuit_breaker"),
+        ("core.llm.providers.glm", "_glm_circuit_breaker"),
+        ("core.llm.providers.codex", "_codex_circuit_breaker"),
+        ("core.llm.provider_dispatch", "_openai_cb"),
+        ("core.llm.provider_dispatch", "_glm_cb"),
+    ],
+)
+def test_every_singleton_breaker_starts_closed(module_path: str, attr: str) -> None:
+    """All 6 module-level singletons start CLOSED at test entry — fixture covers each."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    cb = getattr(mod, attr)
+    assert cb.can_execute(), (
+        f"{module_path}.{attr} is not closed at test entry — "
+        "the conftest reset fixture is missing this singleton"
+    )


### PR DESCRIPTION
## Summary
- Module-level `CircuitBreaker` singleton 6개 (anthropic/openai/glm/codex providers + provider_dispatch._openai_cb/_glm_cb dispatchers) 가 pytest-xdist `loadfile` 분배에서 같은 worker 에 colocate 되면 OPEN 상태로 leak — 후속 test 의 첫 `can_execute()` 가 cascade fail.
- `CircuitBreaker.reset()` 메서드 + `conftest.py` autouse fixture 로 매 test pre/post 6 singleton 모두 reset.
- PR #1429–#1431 sprint 에서 4회 발생한 알려진 flake 의 영구적 root-cause fix.

## Why
`tests/test_failover.py::test_no_silent_fallback_to_other_models` 가 `MagicMock(side_effect=rate_err)` 로 매 호출 RateLimitError 를 발생시켜 `_retry_with_backoff` 가 `MAX_RETRIES` (5) 회 retry, 매번 `_circuit_breaker.record_failure()` → threshold (5) 도달 → state="open". xdist `loadfile` 가 `test_tool_use.py` 를 같은 worker 에 두면 mocked client 호출이 breaker 게이트에 차단되며 `RuntimeError("Circuit breaker is open — LLM API calls are temporarily blocked. ...")`. PR 코드와 무관한 알려진 flake 로 `feedback_circuit_breaker_flake` 에 기록.

## Changes
| File | Change |
|------|--------|
| `core/llm/fallback.py` | `CircuitBreaker.reset()` 메서드 신설 — state="closed" + failures=0 + last_failure=0 force-clear. Production code 는 자연 recovery (`recovery_timeout` half-open) 사용. test-only 용도 docstring 명시 |
| `tests/conftest.py` | autouse fixture `_reset_circuit_breakers` 추가 — 매 test pre+post 6 singleton 모두 reset. `contextlib.suppress(ImportError, AttributeError)` 로 stripped env / 향후 rename 내성 |
| `tests/test_circuit_breaker_isolation.py` | 신규 — 9 regression test 로 fix 영구 pin |
| `CHANGELOG.md` | PR-CB-FLAKE entry (Fixed section) |

## Test inventory (9)
- `test_breaker_reset_class_method_exists` — reset() 메서드 존재 + closed-state 복원 + counters=0
- `test_anthropic_breaker_singleton_reset_between_tests_part1` — anthropic breaker 를 deliberately OPEN (cross-test 시드)
- `test_anthropic_breaker_singleton_reset_between_tests_part2` — part1 에서 OPEN 상태 leak 했어야 하지만 autouse fixture 가 CLOSED 로 복원 검증
- `test_every_singleton_breaker_starts_closed[6 parametrize]` — anthropic / openai / glm / codex / dispatch.openai / dispatch.glm 6 singleton 각각 test entry 에 CLOSED

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Reset method already exists | No | `grep "def reset" core/llm/fallback.py` returned 0 hits |
| Conftest fixture already exists | No | conftest 의 기존 `_reset_auth_singletons` 패턴 follow |
| Production code change | No | reset() 는 test-only docstring 명시, fallback chain 자체는 미변경 |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter — no diff |

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check core/llm/fallback.py tests/` clean
- [x] `uv run mypy core/llm/fallback.py` clean
- [x] `uv run pytest tests/test_circuit_breaker_isolation.py tests/test_failover.py tests/test_tool_use.py tests/test_arun_llm_dispatch.py -q` 51/51 PASS
- [x] No `# type: ignore` / no `# noqa` added

## Reference
- `feedback_circuit_breaker_flake` memory — PR #1429-#1431 sprint 의 4회 발생 기록
- `CircuitBreaker` class — core/llm/fallback.py:143
- Frontier 사례: pytest 의 xdist `loadgroup` 으로 우회하는 방법도 있으나 conftest reset 이 더 명확 + 더 좁은 변경