### PR TITLE
feat(self-improving-loop): PR-PAPERCLIP — wire claude-cli / openai-codex source dispatch + UI/UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,34 @@ functional change.
 
 ### Added
 
+- **PR-PAPERCLIP — Paperclip pattern wiring for self-improving loop mutator.**
+  사전 PR (PR-1 G-A) 가 `MutatorConfig.source = Literal["auto", "api_key",
+  "claude-cli", "openai-codex"]` knob 만 도입했고 runner 는 source 를 *로그만*
+  찍었다. 본 PR 이 실제 dispatch 를 연결. **신규 모듈**
+  `core/self_improving_loop/cli_subprocess.py` — `invoke_claude_cli` /
+  `invoke_codex_cli` subprocess wrapper. `claude --print --output-format text
+  --append-system-prompt <SYS> <USR>` / `codex exec --skip-git-repo-check
+  <SYS+USR>` argv shape. binary path 는 `$PATH` 의 `claude`/`codex` 또는 env
+  override (`GEODE_CLAUDE_CLI_BIN` / `GEODE_CODEX_CLI_BIN`). missing →
+  `CliInvocationError` (설치 hint 동봉). 180s timeout. **runner 변경** —
+  `_default_llm_call` 가 `cfg.mutator.source` 검사 후 paperclip 일 때
+  subprocess wrapper 호출, else 기존 API path 유지 (zero-diff for default
+  operators). **UI/UX** — `/self-improving config` (interactive 설정창,
+  mutator + petri.<role> + seed_generation.<role> 컴포넌트별 provider /
+  model / source 입력, Enter 로 현재값 유지, 완료 후 `/self-improving run`
+  체이닝 옵션) + `/self-improving source` (현재 상태 테이블) +
+  `/self-improving source set <key>=<value>` (non-interactive mutator
+  setter). **TOML 쓰기** — `_splice_section` 헬퍼가 `~/.geode/config.toml`
+  의 section header 를 찾아 in-place key 갱신, 누락 section 은 append,
+  sibling section 보존. `atomic_write_text` 사용 (기존
+  `cmd_config.py` 의 `_toml_escape_basic_string` 패턴 동일). **16 invariant
+  test** — argv shape 2 / missing binary / env override / 비정상 exit /
+  runner dispatch 3 (claude-cli + codex + api_key 무변경) / TOML splice 5
+  (append + replace + insert + sibling 보존 + 이스케이프) + source set 3
+  (invalid 거부 / persist / SUPPORTED_TARGETS sync). 영향 범위 —
+  paperclip 은 self-improving loop **mutator only** (Q1 응답). Agentic
+  Loop 일상 호출은 기존 API path 그대로.
+
 - **PR-M4.2 — DPO publisher adapters (TRL / OpenAI / Bedrock, ADR-012).**
   M4.1 canonical pack 을 per-provider DPO 학습 입력 포맷으로 변환.
   **신규 모듈** `core/self_improving_loop/dpo_publisher.py` — 3 adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,18 +64,21 @@ functional change.
   operators). **UI/UX** — `/self-improving config` (interactive 설정창,
   mutator + petri.<role> + seed_generation.<role> 컴포넌트별 provider /
   model / source 입력, Enter 로 현재값 유지, 완료 후 `/self-improving run`
-  체이닝 옵션) + `/self-improving source` (현재 상태 테이블) +
-  `/self-improving source set <key>=<value>` (non-interactive mutator
-  setter). **TOML 쓰기** — `_splice_section` 헬퍼가 `~/.geode/config.toml`
-  의 section header 를 찾아 in-place key 갱신, 누락 section 은 append,
-  sibling section 보존. `atomic_write_text` 사용 (기존
-  `cmd_config.py` 의 `_toml_escape_basic_string` 패턴 동일). **16 invariant
-  test** — argv shape 2 / missing binary / env override / 비정상 exit /
-  runner dispatch 3 (claude-cli + codex + api_key 무변경) / TOML splice 5
-  (append + replace + insert + sibling 보존 + 이스케이프) + source set 3
-  (invalid 거부 / persist / SUPPORTED_TARGETS sync). 영향 범위 —
-  paperclip 은 self-improving loop **mutator only** (Q1 응답). Agentic
-  Loop 일상 호출은 기존 API path 그대로.
+  체이닝 옵션 — 입력 필드 *model + source*) + `/self-improving source`
+  (현재 상태 테이블) + `/self-improving source set <key>=<value>`
+  (non-interactive mutator setter). **TOML 쓰기** — `_splice_section`
+  헬퍼가 `~/.geode/config.toml` 의 section header 를 찾아 in-place key
+  갱신, 누락 section 은 append, sibling section 보존. seed-generation
+  role 쓰기는 **plural `roles.<X>`** path 사용 (loader schema 와 동기
+  — Codex MCP catch). `atomic_write_text` + `_toml_escape_basic_string`
+  (기존 `cmd_config.py` 패턴). **18 invariant test** — argv shape 2 /
+  missing binary / env override / 비정상 exit / **timeout** / runner
+  dispatch 3 (claude-cli + codex + api_key 무변경) / TOML splice 5
+  (append + replace + insert + sibling 보존 + 이스케이프) + source set
+  3 + **seed-generation roles plural-path round-trip**
+  (writer → loader validate). 영향 범위 — paperclip 은 self-improving
+  loop **mutator only** (Q1 응답). Agentic Loop 일상 호출은 기존 API
+  path 그대로.
 
 - **PR-M4.2 — DPO publisher adapters (TRL / OpenAI / Bedrock, ADR-012).**
   M4.1 canonical pack 을 per-provider DPO 학습 입력 포맷으로 변환.

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -825,9 +825,7 @@ def _cmd_source_set(opts: list[str]) -> None:
             return
         if key == "source" and val not in _VALID_SOURCES:
             valid = " / ".join(_VALID_SOURCES)
-            console.print(
-                f"  [warning]invalid source: {val!r} (valid: {valid})[/warning]"
-            )
+            console.print(f"  [warning]invalid source: {val!r} (valid: {valid})[/warning]")
             return
         updates[key] = val
     try:
@@ -1019,7 +1017,11 @@ def _persist_full_config(
     for role, diff in petri.items():
         _persist_section_updates(f"self_improving_loop.petri.{role}", diff)
     for role, diff in seed_generation.items():
-        _persist_section_updates(f"self_improving_loop.seed_generation.role.{role}", diff)
+        # Note: loader uses ``[self_improving_loop.seed_generation.roles.<role>]``
+        # (plural ``roles``) — see ``SeedGenerationConfig.roles`` field. Singular
+        # would land outside the schema's ``extra="forbid"`` allowlist and break
+        # the next config load. Codex MCP catch on PR-PAPERCLIP.
+        _persist_section_updates(f"self_improving_loop.seed_generation.roles.{role}", diff)
 
 
 def _persist_section_updates(section: str, updates: dict[str, str]) -> None:

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -38,21 +38,16 @@ __all__ = ["cmd_self_improving"]
 
 
 _HISTORY_DEFAULT_N = 5
-# PR-MINIMAL-1 (2026-05-21) — only ``config`` stays deferred. The
-# ``history`` and ``rollback`` actions used to be reserved slots
-# (PR-OPS-1) but git already provides both — ``git log`` for the
-# audit ledger, ``git revert`` for the rollback — now that
-# PR-RATCHET-1 has the 5 policy SoT files in-repo. The slash
-# handlers below print the exact git command instead, keeping the
-# operator inside one tool surface without re-implementing what
-# git does natively.
-_RUN_DEFERRED_ACTIONS = frozenset({"config"})
-_KNOWN_ACTIONS = (
-    frozenset({"status", "run", "history", "rollback", "migrate"}) | _RUN_DEFERRED_ACTIONS
-)
+# PR-PAPERCLIP (2026-05-21) — ``config`` and ``source`` are now wired
+# for interactive + non-interactive selection of paperclip-pattern
+# (claude-cli / openai-codex / api_key) per component. ``history`` and
+# ``rollback`` continue to delegate to git natively.
+_RUN_DEFERRED_ACTIONS: frozenset[str] = frozenset()
+_KNOWN_ACTIONS = frozenset({"status", "run", "history", "rollback", "migrate", "config", "source"})
 _DESIGN_DOC = "docs/plans/2026-05-21-self-improving-loop-ux.md"
 _RUN_DEFAULT_ITERATIONS = 1
 _RUN_MAX_ITERATIONS = 10
+_VALID_SOURCES = ("auto", "api_key", "claude-cli", "openai-codex")
 
 
 def cmd_self_improving(args: str) -> None:
@@ -84,21 +79,19 @@ def cmd_self_improving(args: str) -> None:
         _cmd_migrate()
         return
 
-    if action in _RUN_DEFERRED_ACTIONS:
-        console.print()
-        console.print(
-            f"  [warning]/{action} is reserved for PR-OPS-2b/3[/warning] — "
-            f"see [muted]{_DESIGN_DOC}[/muted]"
-        )
-        console.print()
+    if action == "config":
+        _cmd_config()
+        return
+
+    if action == "source":
+        _cmd_source(parts[1:])
         return
 
     console.print()
     console.print(f"  [warning]Unknown action: /self-improving {action}[/warning]")
     console.print(
         "  [muted]Available now: [/muted]"
-        "status / run / history / rollback / migrate   "
-        "[muted]Coming PR-OPS-3:[/muted] config"
+        "status / run / history / rollback / migrate / config / source"
     )
     console.print()
 
@@ -732,3 +725,364 @@ def _cmd_migrate() -> None:
         "can manually roll back. Remove them yourself when ready.[/muted]"
     )
     console.print()
+
+
+# ---------------------------------------------------------------------------
+# ``/self-improving source`` + ``/self-improving config`` — PR-PAPERCLIP
+# ---------------------------------------------------------------------------
+#
+# ``source`` is the paperclip-pattern entry point — operator picks which
+# credential channel (api_key default / claude-cli subscription /
+# openai-codex subscription) the mutator routes its LLM call through.
+# ``config`` is the full interactive settings panel: walk every
+# self-improving-loop component (mutator + petri.<role> + seed_generation.<role>),
+# ask provider/model/source per component, persist to
+# ``~/.geode/config.toml``, then optionally chain into ``/self-improving
+# run`` so the operator's configuration is immediately exercised.
+
+
+def _cmd_source(opts: list[str]) -> None:
+    """Show or set the mutator credential source.
+
+    Sub-actions:
+      (no args)               show current per-component source table
+      set <key>=<value> [...]  non-interactive set on the mutator
+                              (keys: source / default_model)
+    """
+    if not opts:
+        _render_source_table()
+        return
+    sub = opts[0]
+    if sub == "set":
+        _cmd_source_set(opts[1:])
+        return
+    console.print()
+    console.print(f"  [warning]Unknown sub-action: source {sub!r}[/warning]")
+    console.print("  [muted]Available: (no args) | set <key>=<value>[/muted]")
+    console.print()
+
+
+def _render_source_table() -> None:
+    """Render the current paperclip-source state for every component."""
+    try:
+        from core.config import settings
+        from core.config.self_improving_loop import load_self_improving_loop_config
+
+        cfg = load_self_improving_loop_config()
+    except Exception as exc:
+        console.print()
+        console.print(f"  [warning]config load failed:[/warning] {exc}")
+        console.print()
+        return
+    console.print()
+    console.print("  [header]Self-improving loop — source[/header]")
+    console.print()
+    inherit_model = settings.model
+    rows: list[tuple[str, str, str]] = [
+        (
+            "mutator",
+            cfg.mutator.default_model or f"{inherit_model}  [muted](inherit)[/muted]",
+            cfg.mutator.source,
+        ),
+    ]
+    for petri_name, petri_cfg in cfg.petri.items():
+        rows.append((f"petri.{petri_name}", petri_cfg.model, petri_cfg.source))
+    for seed_name, seed_cfg in cfg.seed_generation.roles.items():
+        rows.append((f"seed_generation.{seed_name}", seed_cfg.model, seed_cfg.source))
+    console.print(f"    {'component':32} {'model':28} source")
+    for comp, model, src in rows:
+        console.print(f"    {comp:32} {model:28} [bold]{src}[/bold]")
+    console.print()
+    console.print("  [muted]Valid sources: " + " / ".join(_VALID_SOURCES) + "[/muted]")
+    console.print()
+
+
+def _cmd_source_set(opts: list[str]) -> None:
+    """Non-interactive setter — ``/self-improving source set <key>=<value> [...]``.
+
+    Targets the mutator section only — paperclip scope per session
+    decision Q1=b (mutator). Use ``/self-improving config`` for
+    per-component (petri / seed_generation) editing.
+
+    Supported keys: ``source`` / ``default_model``.
+    """
+    if not opts:
+        console.print("  [warning]source set: needs at least one key=value pair[/warning]")
+        console.print("  [muted]Example: /self-improving source set source=claude-cli[/muted]")
+        return
+    updates: dict[str, str] = {}
+    for tok in opts:
+        if "=" not in tok:
+            console.print(f"  [warning]not key=value: {tok!r}[/warning]")
+            return
+        key, val = tok.split("=", 1)
+        key = key.strip()
+        val = val.strip()
+        if key not in {"source", "default_model"}:
+            console.print(
+                f"  [warning]unknown key: {key!r} (supported: source / default_model)[/warning]"
+            )
+            return
+        if key == "source" and val not in _VALID_SOURCES:
+            valid = " / ".join(_VALID_SOURCES)
+            console.print(
+                f"  [warning]invalid source: {val!r} (valid: {valid})[/warning]"
+            )
+            return
+        updates[key] = val
+    try:
+        _persist_mutator_updates(updates)
+    except Exception as exc:
+        console.print(f"  [warning]write failed:[/warning] {exc}")
+        return
+    console.print()
+    console.print("  [success]mutator config updated[/success]")
+    for key, val in updates.items():
+        console.print(f"    {key} = {val!r}")
+    console.print()
+
+
+def _cmd_config() -> None:
+    """Interactive self-improving-loop settings panel.
+
+    Walks mutator + petri.<role> + seed_generation.<role> components.
+    For each, prompts provider/model/source with current value as
+    default (Enter to keep). After every component is collected,
+    persists the diff to ``~/.geode/config.toml`` and offers to run
+    ``/self-improving run`` immediately so the operator's choice is
+    exercised end-to-end.
+    """
+    try:
+        from core.config import settings
+        from core.config.self_improving_loop import load_self_improving_loop_config
+
+        cfg = load_self_improving_loop_config()
+    except Exception as exc:
+        console.print()
+        console.print(f"  [warning]config load failed:[/warning] {exc}")
+        console.print()
+        return
+
+    console.print()
+    console.print("  [header]Self-improving loop — interactive configuration[/header]")
+    console.print("  [muted]Enter to keep current value. Ctrl-D aborts without writing.[/muted]")
+    console.print()
+
+    mutator_changes = _prompt_component(
+        "mutator",
+        current_model=cfg.mutator.default_model or settings.model,
+        current_source=cfg.mutator.source,
+        model_is_inherited=cfg.mutator.default_model is None,
+    )
+    if mutator_changes is None:
+        return  # aborted
+
+    petri_changes: dict[str, dict[str, str]] = {}
+    for petri_name, petri_cfg in cfg.petri.items():
+        diff = _prompt_component(
+            f"petri.{petri_name}",
+            current_model=petri_cfg.model,
+            current_source=petri_cfg.source,
+            model_is_inherited=False,
+        )
+        if diff is None:
+            return
+        if diff:
+            petri_changes[petri_name] = diff
+
+    seed_changes: dict[str, dict[str, str]] = {}
+    for seed_name, seed_cfg in cfg.seed_generation.roles.items():
+        diff = _prompt_component(
+            f"seed_generation.{seed_name}",
+            current_model=seed_cfg.model,
+            current_source=seed_cfg.source,
+            model_is_inherited=False,
+        )
+        if diff is None:
+            return
+        if diff:
+            seed_changes[seed_name] = diff
+
+    if not mutator_changes and not petri_changes and not seed_changes:
+        console.print()
+        console.print("  [muted]no changes — nothing to write[/muted]")
+        console.print()
+    else:
+        try:
+            _persist_full_config(
+                mutator=mutator_changes, petri=petri_changes, seed_generation=seed_changes
+            )
+        except Exception as exc:
+            console.print(f"  [warning]write failed:[/warning] {exc}")
+            return
+        console.print()
+        console.print("  [success]config saved to ~/.geode/config.toml[/success]")
+        console.print()
+
+    # Offer to immediately exercise the new config — per session
+    # directive "선택이 완료되면 절차가 수행이 되도록 구성".
+    try:
+        raw = console.input("  Run /self-improving run now? [y/N]: ")
+    except (EOFError, KeyboardInterrupt):
+        console.print()
+        return
+    if raw.strip().lower() in {"y", "yes"}:
+        _cmd_run([])
+
+
+def _prompt_component(
+    label: str,
+    *,
+    current_model: str,
+    current_source: str,
+    model_is_inherited: bool,
+) -> dict[str, str] | None:
+    """Prompt one component's model + source. Returns dict of changed fields, or None on abort.
+
+    ``model_is_inherited`` is the mutator-only signal that ``default_model``
+    is currently ``None`` and we're displaying the inherited
+    ``Settings.model`` — writing the same value back should *not*
+    persist it (keeps inherit semantics intact). For petri /
+    seed_generation roles this flag is always False.
+    """
+    console.print(f"  [bold]{label}[/bold]")
+    suffix = " [muted](inherit)[/muted]" if model_is_inherited else ""
+    console.print(f"    current model:  {current_model}{suffix}")
+    console.print(f"    current source: {current_source}")
+    try:
+        new_model = console.input("    model  [muted](Enter to keep)[/muted]: ").strip()
+        new_source = console.input(
+            f"    source [muted](Enter to keep — {' / '.join(_VALID_SOURCES)})[/muted]: "
+        ).strip()
+    except (EOFError, KeyboardInterrupt):
+        console.print()
+        console.print("  [muted]aborted[/muted]")
+        console.print()
+        return None
+    diff: dict[str, str] = {}
+    if new_model and new_model != current_model:
+        diff["model" if not label.startswith("mutator") else "default_model"] = new_model
+    if new_source:
+        if new_source not in _VALID_SOURCES:
+            console.print(f"    [warning]invalid source — kept {current_source!r}[/warning]")
+        elif new_source != current_source:
+            diff["source"] = new_source
+    console.print()
+    return diff
+
+
+# ---------------------------------------------------------------------------
+# TOML writer — minimal section-keyed updater
+# ---------------------------------------------------------------------------
+#
+# We avoid pulling in a TOML writer dep (tomli_w / tomlkit) by following
+# the existing ``core/cli/cmd_config.py`` pattern: read the file as
+# string, splice in the requested key=value pairs under the right
+# section header, write atomically. Limited to the subset of TOML the
+# self-improving-loop section uses (basic strings + ints + bools +
+# floats) — enough for source / model / numeric thresholds. Comments and
+# whitespace in unaffected sections are preserved.
+
+
+def _toml_escape(value: str) -> str:
+    """TOML basic-string escape (re-uses cmd_config.py logic, scoped here)."""
+    out: list[str] = []
+    for ch in value:
+        code = ord(ch)
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == '"':
+            out.append('\\"')
+        elif ch in ("\b", "\f", "\n", "\r", "\t"):
+            out.append({"\b": "\\b", "\f": "\\f", "\n": "\\n", "\r": "\\r", "\t": "\\t"}[ch])
+        elif code < 0x20 or code == 0x7F:
+            out.append(f"\\u{code:04x}")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _persist_mutator_updates(updates: dict[str, str]) -> None:
+    """Persist mutator-only `key = "value"` lines to config.toml."""
+    _persist_section_updates("self_improving_loop.mutator", updates)
+
+
+def _persist_full_config(
+    *,
+    mutator: dict[str, str],
+    petri: dict[str, dict[str, str]],
+    seed_generation: dict[str, dict[str, str]],
+) -> None:
+    """Persist the interactive form's diff across every component."""
+    if mutator:
+        _persist_section_updates("self_improving_loop.mutator", mutator)
+    for role, diff in petri.items():
+        _persist_section_updates(f"self_improving_loop.petri.{role}", diff)
+    for role, diff in seed_generation.items():
+        _persist_section_updates(f"self_improving_loop.seed_generation.role.{role}", diff)
+
+
+def _persist_section_updates(section: str, updates: dict[str, str]) -> None:
+    """Splice ``updates`` into ``[<section>]`` of ``~/.geode/config.toml``.
+
+    If the section is missing it's appended; if a key exists in the
+    section it's replaced in place; otherwise the key is inserted at the
+    end of the section block. Atomic write via ``core.utils.atomic_io``.
+    """
+    if not updates:
+        return
+    from core.paths import GLOBAL_CONFIG_TOML
+    from core.utils.atomic_io import atomic_write_text
+
+    path = Path(GLOBAL_CONFIG_TOML)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = path.read_text(encoding="utf-8") if path.is_file() else ""
+    new_text = _splice_section(text, section, updates)
+    atomic_write_text(path, new_text)
+
+
+def _splice_section(text: str, section: str, updates: dict[str, str]) -> str:
+    """Return ``text`` with ``[section]`` updated to carry every ``updates`` entry."""
+    header = f"[{section}]"
+    lines = text.splitlines(keepends=False)
+    # Locate the section header line; -1 means absent.
+    header_idx = -1
+    for i, line in enumerate(lines):
+        if line.strip() == header:
+            header_idx = i
+            break
+    if header_idx == -1:
+        # Append a fresh section block.
+        block = [header]
+        for key, val in updates.items():
+            block.append(f'{key} = "{_toml_escape(val)}"')
+        suffix = "" if text.endswith("\n") or text == "" else "\n"
+        sep = "\n" if text and not text.endswith("\n\n") else ""
+        return text + suffix + sep + "\n".join(block) + "\n"
+    # Find the section's end (next ``[…]`` header or EOF).
+    end_idx = len(lines)
+    for j in range(header_idx + 1, len(lines)):
+        stripped = lines[j].strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            end_idx = j
+            break
+    # Replace existing key=value lines in place; collect remaining keys.
+    remaining = dict(updates)
+    for k in range(header_idx + 1, end_idx):
+        line = lines[k]
+        for key in list(remaining):
+            if line.lstrip().startswith(f"{key} ") or line.lstrip().startswith(f"{key}="):
+                lines[k] = f'{key} = "{_toml_escape(remaining[key])}"'
+                del remaining[key]
+                break
+    # Append remaining keys just before the section ends. Skip trailing
+    # blank lines so the section stays visually tight.
+    insert_at = end_idx
+    while insert_at > header_idx + 1 and lines[insert_at - 1].strip() == "":
+        insert_at -= 1
+    new_kv_lines = [f'{key} = "{_toml_escape(val)}"' for key, val in remaining.items()]
+    out_lines = lines[:insert_at] + new_kv_lines + lines[insert_at:]
+    result = "\n".join(out_lines)
+    if not result.endswith("\n"):
+        result += "\n"
+    return result

--- a/core/self_improving_loop/cli_subprocess.py
+++ b/core/self_improving_loop/cli_subprocess.py
@@ -1,0 +1,164 @@
+"""Paperclip pattern — invoke local Claude Code / Codex CLI via subprocess.
+
+Used by the mutator runner when ``MutatorConfig.source`` is
+``"claude-cli"`` or ``"openai-codex"``. The dispatch goes through the
+operator's existing CLI subscription (Claude Code Max plan / ChatGPT
+Plus → Codex CLI) instead of the API-billed providers.
+
+**Why subprocess vs HTTP**: per session decision Q1=b — keep the loop
+honest about which channel was billed. The CLI binary owns its own
+auth + subscription credentials; we just hand it a prompt and read
+stdout. No extra OAuth-token plumbing inside the loop.
+
+**Resolution**:
+
+* Binary path defaults to ``claude`` / ``codex`` on ``$PATH``. Operators
+  on non-standard installs override via ``GEODE_CLAUDE_CLI_BIN`` /
+  ``GEODE_CODEX_CLI_BIN``.
+* Missing binary → :class:`RuntimeError` with an actionable message
+  (``brew install …`` / ``npm i -g @anthropic-ai/claude-code``).
+* Non-zero exit → :class:`RuntimeError` carrying stderr (truncated).
+
+**Scope**: pure pipe — system + user prompt in, raw stdout text out.
+Output parsing (JSON mutation extraction) is the runner's job, same
+as for the API path; if the CLI returns extra Markdown / headers,
+``parse_mutation`` raises ``ValueError`` and the runner skips the
+iteration (existing graceful path).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "CLAUDE_CLI_BIN_ENV",
+    "CODEX_CLI_BIN_ENV",
+    "CliInvocationError",
+    "invoke_claude_cli",
+    "invoke_codex_cli",
+]
+
+CLAUDE_CLI_BIN_ENV = "GEODE_CLAUDE_CLI_BIN"
+CODEX_CLI_BIN_ENV = "GEODE_CODEX_CLI_BIN"
+
+_DEFAULT_CLAUDE_BIN = "claude"
+_DEFAULT_CODEX_BIN = "codex"
+
+# Per-call timeout — mutator LLM calls should finish in seconds. A long
+# subprocess hang (network stall, interactive prompt waiting on stdin)
+# should not block the whole self-improving-loop iteration.
+_CLI_TIMEOUT_SEC = 180.0
+
+
+class CliInvocationError(RuntimeError):
+    """Raised when the CLI binary cannot be located or exits non-zero."""
+
+
+def _resolve_binary(env_var: str, default: str) -> str:
+    """Return absolute path to the CLI binary, or raise ``CliInvocationError``.
+
+    Resolution order:
+      1. ``$<env_var>`` (operator override) — used verbatim if it points
+         to an existing executable.
+      2. ``shutil.which(default)`` — first ``default`` (e.g. ``claude``)
+         found on ``$PATH``.
+    """
+    override = os.environ.get(env_var)
+    if override:
+        if shutil.which(override) is None and not os.path.isfile(override):
+            raise CliInvocationError(
+                f"{env_var}={override!r} but no executable found there. "
+                f"Set {env_var} to the full path of the {default!r} binary."
+            )
+        return override
+    found = shutil.which(default)
+    if not found:
+        raise CliInvocationError(
+            f"{default!r} not found on $PATH. Install Claude Code "
+            f"(https://docs.anthropic.com/claude/docs/claude-code) "
+            f"or Codex CLI (https://github.com/openai/codex), or set "
+            f"{env_var} to point at the binary."
+        )
+    return found
+
+
+def _run(binary: str, args: list[str], stdin_text: str) -> str:
+    """Execute ``binary`` with ``args``, pipe ``stdin_text``, return stdout.
+
+    Captures stderr separately and includes the first 400 chars in the
+    raised error so operators can diagnose without re-running the loop.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 — args are constructed from a fixed allowlist
+            [binary, *args],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise CliInvocationError(f"binary disappeared between resolve and run: {binary}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CliInvocationError(
+            f"{binary} timed out after {_CLI_TIMEOUT_SEC}s — "
+            "check that the CLI is non-interactive in print mode"
+        ) from exc
+    if proc.returncode != 0:
+        stderr_clip = (proc.stderr or "")[:400]
+        raise CliInvocationError(f"{binary} exited {proc.returncode}: {stderr_clip!r}")
+    return proc.stdout
+
+
+def invoke_claude_cli(*, system_prompt: str, user_prompt: str) -> str:
+    """Run ``claude --print`` with the given system + user prompts.
+
+    Wire path:
+        ``claude --print --output-format text --append-system-prompt <SYS> <USER>``
+
+    The ``--append-system-prompt`` flag prepends the mutator system
+    contract to whatever default system prompt Claude Code already
+    applies (which is fine — both are operator-intended context). The
+    user prompt is the last positional argument; ``--print`` makes
+    Claude Code emit one response then exit (non-interactive).
+
+    ``--output-format text`` keeps stdout free of the Markdown framing
+    that Claude Code's TUI render layer would otherwise add.
+    """
+    binary = _resolve_binary(CLAUDE_CLI_BIN_ENV, _DEFAULT_CLAUDE_BIN)
+    args = [
+        "--print",
+        "--output-format",
+        "text",
+        "--append-system-prompt",
+        system_prompt,
+        user_prompt,
+    ]
+    out = _run(binary, args, stdin_text="")
+    return out.strip()
+
+
+def invoke_codex_cli(*, system_prompt: str, user_prompt: str) -> str:
+    """Run ``codex exec`` with the given system + user prompts.
+
+    Wire path:
+        ``codex exec --skip-git-repo-check <COMBINED>``
+
+    Codex CLI's ``exec`` is the non-interactive one-shot mode. The
+    combined prompt prepends the system contract as a ``System:``
+    header so a single positional argument carries both halves —
+    Codex CLI doesn't have a ``--system`` flag equivalent.
+    ``--skip-git-repo-check`` lets the mutator run outside a workspace
+    tree (the self-improving-loop dispatches from
+    ``~/.geode/self-improving-loop/`` paths, not the repo root).
+    """
+    binary = _resolve_binary(CODEX_CLI_BIN_ENV, _DEFAULT_CODEX_BIN)
+    combined = f"System: {system_prompt}\n\nUser: {user_prompt}"
+    args = ["exec", "--skip-git-repo-check", combined]
+    out = _run(binary, args, stdin_text="")
+    return out.strip()

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -506,6 +506,22 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
         max_tokens,
     )
 
+    # PR-PAPERCLIP (2026-05-21) — source-aware dispatch. When the
+    # operator opted into "claude-cli" / "openai-codex" via
+    # ``[self_improving_loop.mutator] source = "..."`` in config.toml,
+    # route the mutator call through the local CLI binary so the
+    # subscription (Claude Code Max / ChatGPT Plus) is billed instead
+    # of the API. The default "auto" / "api_key" path remains
+    # unchanged — existing operators see zero behavior diff.
+    if source == "claude-cli":
+        from core.self_improving_loop.cli_subprocess import invoke_claude_cli
+
+        return invoke_claude_cli(system_prompt=system_prompt, user_prompt=user_prompt)
+    if source == "openai-codex":
+        from core.self_improving_loop.cli_subprocess import invoke_codex_cli
+
+        return invoke_codex_cli(system_prompt=system_prompt, user_prompt=user_prompt)
+
     async def _do_call(m: str) -> object:
         return await adapter.agentic_call(
             model=m,

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -1,0 +1,321 @@
+"""Paperclip wiring invariants — claude-cli / openai-codex source dispatch.
+
+Pins:
+- ``invoke_claude_cli`` / ``invoke_codex_cli`` run the right binary with
+  the right argv shape and return stdout text. Missing binary raises
+  ``CliInvocationError`` with an actionable message.
+- ``_default_llm_call`` dispatches to claude-cli / codex-cli when
+  ``MutatorConfig.source`` is paperclip; legacy "api_key" / "auto"
+  paths are unaffected.
+- ``_splice_section`` updates an existing TOML section in place, appends
+  a fresh section when missing, and replaces a single key while
+  preserving the rest of the section.
+- ``_cmd_source_set`` rejects invalid sources / unknown keys without
+  touching the config file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# cli_subprocess ------------------------------------------------------------
+
+
+def test_invoke_claude_cli_argv_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``claude --print --output-format text --append-system-prompt <SYS> <USER>``."""
+    from core.self_improving_loop import cli_subprocess
+
+    monkeypatch.setattr(cli_subprocess.shutil, "which", lambda b: f"/usr/local/bin/{b}")
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(
+            argv, returncode=0, stdout="raw mutator JSON\n", stderr=""
+        )
+
+    monkeypatch.setattr(cli_subprocess.subprocess, "run", _fake_run)
+    out = cli_subprocess.invoke_claude_cli(system_prompt="SYS", user_prompt="USR")
+    assert out == "raw mutator JSON"
+    assert captured["argv"][0] == "/usr/local/bin/claude"
+    assert "--print" in captured["argv"]
+    assert "--output-format" in captured["argv"]
+    assert "--append-system-prompt" in captured["argv"]
+    sys_idx = captured["argv"].index("--append-system-prompt")
+    assert captured["argv"][sys_idx + 1] == "SYS"
+    assert captured["argv"][-1] == "USR"
+
+
+def test_invoke_codex_cli_argv_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``codex exec --skip-git-repo-check <COMBINED system+user>``."""
+    from core.self_improving_loop import cli_subprocess
+
+    monkeypatch.setattr(cli_subprocess.shutil, "which", lambda b: f"/usr/local/bin/{b}")
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="ok ", stderr="")
+
+    monkeypatch.setattr(cli_subprocess.subprocess, "run", _fake_run)
+    out = cli_subprocess.invoke_codex_cli(system_prompt="SYS", user_prompt="USR")
+    assert out == "ok"
+    assert captured["argv"][0].endswith("/codex")
+    assert captured["argv"][1] == "exec"
+    assert "--skip-git-repo-check" in captured["argv"]
+    combined = captured["argv"][-1]
+    assert "System: SYS" in combined
+    assert "User: USR" in combined
+
+
+def test_invoke_claude_cli_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing binary → CliInvocationError with actionable install hint."""
+    from core.self_improving_loop import cli_subprocess
+
+    monkeypatch.setattr(cli_subprocess.shutil, "which", lambda b: None)
+    monkeypatch.delenv(cli_subprocess.CLAUDE_CLI_BIN_ENV, raising=False)
+    with pytest.raises(cli_subprocess.CliInvocationError, match="not found on \\$PATH"):
+        cli_subprocess.invoke_claude_cli(system_prompt="s", user_prompt="u")
+
+
+def test_binary_env_override_used(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``GEODE_CLAUDE_CLI_BIN`` overrides PATH lookup."""
+    from core.self_improving_loop import cli_subprocess
+
+    bin_path = tmp_path / "custom_claude"
+    bin_path.write_text("#!/bin/sh\n")
+    bin_path.chmod(0o755)
+    monkeypatch.setenv(cli_subprocess.CLAUDE_CLI_BIN_ENV, str(bin_path))
+    monkeypatch.setattr(cli_subprocess.shutil, "which", lambda b: None)
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli_subprocess.subprocess, "run", _fake_run)
+    cli_subprocess.invoke_claude_cli(system_prompt="s", user_prompt="u")
+    assert captured["argv"][0] == str(bin_path)
+
+
+def test_invoke_nonzero_exit_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-zero exit → CliInvocationError carrying stderr clip."""
+    from core.self_improving_loop import cli_subprocess
+
+    monkeypatch.setattr(cli_subprocess.shutil, "which", lambda b: f"/bin/{b}")
+
+    def _fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, returncode=2, stdout="", stderr="auth failed")
+
+    monkeypatch.setattr(cli_subprocess.subprocess, "run", _fake_run)
+    with pytest.raises(cli_subprocess.CliInvocationError, match="auth failed"):
+        cli_subprocess.invoke_claude_cli(system_prompt="s", user_prompt="u")
+
+
+# runner dispatch -----------------------------------------------------------
+
+
+def test_default_llm_call_dispatches_to_claude_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """source=claude-cli skips the API path entirely."""
+    from core.self_improving_loop import runner
+
+    cfg_mock = MagicMock()
+    cfg_mock.mutator.default_model = "claude-opus-4-7"
+    cfg_mock.mutator.source = "claude-cli"
+    cfg_mock.mutator.max_tokens = 1024
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        lambda: cfg_mock,
+    )
+    monkeypatch.setattr("core.config._resolve_provider", lambda m: "anthropic")
+    monkeypatch.setattr("core.llm.adapters.resolve_agentic_adapter", lambda p: MagicMock())
+
+    invoked = {"called": False, "system": "", "user": ""}
+
+    def _fake_invoke(*, system_prompt: str, user_prompt: str) -> str:
+        invoked["called"] = True
+        invoked["system"] = system_prompt
+        invoked["user"] = user_prompt
+        return "from claude-cli"
+
+    monkeypatch.setattr("core.self_improving_loop.cli_subprocess.invoke_claude_cli", _fake_invoke)
+    result = runner._default_llm_call("SYS", "USR")
+    assert result == "from claude-cli"
+    assert invoked["called"] is True
+    assert invoked["system"] == "SYS"
+    assert invoked["user"] == "USR"
+
+
+def test_default_llm_call_dispatches_to_codex_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """source=openai-codex skips the API path entirely."""
+    from core.self_improving_loop import runner
+
+    cfg_mock = MagicMock()
+    cfg_mock.mutator.default_model = "gpt-5-codex"
+    cfg_mock.mutator.source = "openai-codex"
+    cfg_mock.mutator.max_tokens = 1024
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        lambda: cfg_mock,
+    )
+    monkeypatch.setattr("core.config._resolve_provider", lambda m: "openai-codex")
+    monkeypatch.setattr("core.llm.adapters.resolve_agentic_adapter", lambda p: MagicMock())
+
+    def _fake_invoke(*, system_prompt: str, user_prompt: str) -> str:
+        return "from codex-cli"
+
+    monkeypatch.setattr("core.self_improving_loop.cli_subprocess.invoke_codex_cli", _fake_invoke)
+    result = runner._default_llm_call("SYS", "USR")
+    assert result == "from codex-cli"
+
+
+def test_default_llm_call_api_key_path_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """source=api_key still routes through call_with_failover (no subprocess)."""
+    from core.self_improving_loop import runner
+
+    cfg_mock = MagicMock()
+    cfg_mock.mutator.default_model = "claude-opus-4-7"
+    cfg_mock.mutator.source = "api_key"
+    cfg_mock.mutator.max_tokens = 1024
+    monkeypatch.setattr(
+        "core.config.self_improving_loop.load_self_improving_loop_config",
+        lambda: cfg_mock,
+    )
+    monkeypatch.setattr("core.config._resolve_provider", lambda m: "anthropic")
+
+    adapter = MagicMock()
+    adapter.last_error = None
+    monkeypatch.setattr("core.llm.adapters.resolve_agentic_adapter", lambda p: adapter)
+
+    text_block = MagicMock()
+    text_block.text = "from api"
+    api_response = MagicMock()
+    api_response.content = [text_block]
+
+    async def _fake_failover(models: list[str], do_call: object) -> tuple[object, str]:
+        return (api_response, models[0])
+
+    monkeypatch.setattr("core.llm.router.call_with_failover", _fake_failover)
+
+    claude_called = {"hit": False}
+
+    def _explode_if_called(**_kw: object) -> str:
+        claude_called["hit"] = True
+        return "should never reach claude-cli"
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.cli_subprocess.invoke_claude_cli", _explode_if_called
+    )
+    monkeypatch.setattr(
+        "core.self_improving_loop.cli_subprocess.invoke_codex_cli", _explode_if_called
+    )
+
+    result = runner._default_llm_call("SYS", "USR")
+    assert result == "from api"
+    assert claude_called["hit"] is False
+
+
+# TOML splicer --------------------------------------------------------------
+
+
+def test_splice_section_appends_when_missing() -> None:
+    from core.cli.commands.self_improving import _splice_section
+
+    out = _splice_section(
+        "[other]\nfoo = 1\n",
+        "self_improving_loop.mutator",
+        {"source": "claude-cli"},
+    )
+    assert "[self_improving_loop.mutator]" in out
+    assert 'source = "claude-cli"' in out
+    assert "[other]" in out  # preserved
+
+
+def test_splice_section_replaces_existing_key() -> None:
+    from core.cli.commands.self_improving import _splice_section
+
+    src = '[self_improving_loop.mutator]\nsource = "api_key"\nmax_tokens = 1024\n'
+    out = _splice_section(src, "self_improving_loop.mutator", {"source": "claude-cli"})
+    assert 'source = "claude-cli"' in out
+    assert 'source = "api_key"' not in out
+    assert "max_tokens = 1024" in out  # untouched neighbor preserved
+
+
+def test_splice_section_inserts_new_key_in_existing_section() -> None:
+    from core.cli.commands.self_improving import _splice_section
+
+    src = "[self_improving_loop.mutator]\nmax_tokens = 1024\n"
+    out = _splice_section(src, "self_improving_loop.mutator", {"default_model": "claude-opus-4-7"})
+    assert 'default_model = "claude-opus-4-7"' in out
+    assert "max_tokens = 1024" in out
+
+
+def test_splice_section_does_not_clobber_sibling_section() -> None:
+    """Updating mutator must not touch ``[self_improving_loop.petri.auditor]``."""
+    from core.cli.commands.self_improving import _splice_section
+
+    src = (
+        "[self_improving_loop.mutator]\n"
+        'source = "api_key"\n'
+        "\n"
+        "[self_improving_loop.petri.auditor]\n"
+        'source = "api_key"\n'
+        'model = "claude-opus-4-7"\n'
+    )
+    out = _splice_section(src, "self_improving_loop.mutator", {"source": "claude-cli"})
+    assert 'source = "claude-cli"' in out
+    # Petri section untouched:
+    assert "[self_improving_loop.petri.auditor]" in out
+    assert out.count('source = "api_key"') == 1  # petri still has api_key
+    assert 'model = "claude-opus-4-7"' in out
+
+
+def test_splice_section_escapes_special_chars() -> None:
+    from core.cli.commands.self_improving import _splice_section
+
+    out = _splice_section("", "x", {"k": 'has " quote and \\ backslash'})
+    assert 'k = "has \\" quote and \\\\ backslash"' in out
+
+
+# source set --------------------------------------------------------------
+
+
+def test_cmd_source_set_rejects_invalid_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bad source value → no file written."""
+    from core.cli.commands import self_improving
+
+    fake_toml = tmp_path / "config.toml"
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    with patch.object(self_improving, "console") as cmock:
+        self_improving._cmd_source_set(["source=bogus"])
+    assert not fake_toml.exists()
+    # Warning emitted, no success line
+    printed = " ".join(str(call) for call in cmock.print.call_args_list)
+    assert "invalid source" in printed
+
+
+def test_cmd_source_set_persists_valid_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """source=claude-cli writes the line to ~/.geode/config.toml."""
+    from core.cli.commands import self_improving
+
+    fake_toml = tmp_path / "config.toml"
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    self_improving._cmd_source_set(["source=claude-cli"])
+    text = fake_toml.read_text(encoding="utf-8")
+    assert "[self_improving_loop.mutator]" in text
+    assert 'source = "claude-cli"' in text
+
+
+def test_valid_sources_constant_matches_config_enum() -> None:
+    """``_VALID_SOURCES`` must stay in sync with ``MutatorConfig.source`` Literal."""
+    from core.cli.commands.self_improving import _VALID_SOURCES
+
+    assert set(_VALID_SOURCES) == {"auto", "api_key", "claude-cli", "openai-codex"}

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -116,6 +116,20 @@ def test_invoke_nonzero_exit_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         cli_subprocess.invoke_claude_cli(system_prompt="s", user_prompt="u")
 
 
+def test_invoke_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``subprocess.TimeoutExpired`` → ``CliInvocationError`` with timeout hint."""
+    from core.self_improving_loop import cli_subprocess
+
+    monkeypatch.setattr(cli_subprocess.shutil, "which", lambda b: f"/bin/{b}")
+
+    def _fake_run(argv: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=180)
+
+    monkeypatch.setattr(cli_subprocess.subprocess, "run", _fake_run)
+    with pytest.raises(cli_subprocess.CliInvocationError, match="timed out"):
+        cli_subprocess.invoke_claude_cli(system_prompt="s", user_prompt="u")
+
+
 # runner dispatch -----------------------------------------------------------
 
 
@@ -319,3 +333,33 @@ def test_valid_sources_constant_matches_config_enum() -> None:
     from core.cli.commands.self_improving import _VALID_SOURCES
 
     assert set(_VALID_SOURCES) == {"auto", "api_key", "claude-cli", "openai-codex"}
+
+
+def test_persist_full_config_uses_plural_roles_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Seed-generation writes MUST land under ``...seed_generation.roles.<X>`` (plural).
+
+    Pre-fix the writer used singular ``role.<X>`` which falls outside
+    ``SeedGenerationConfig`` schema's ``extra="forbid"`` allowlist —
+    next config load raises ``ValidationError``. Codex MCP catch on
+    PR-PAPERCLIP.
+    """
+    from core.cli.commands import self_improving
+    from core.config.self_improving_loop import load_self_improving_loop_config
+
+    fake_toml = tmp_path / "config.toml"
+    monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    monkeypatch.setattr("core.config.self_improving_loop.GLOBAL_CONFIG_TOML", fake_toml)
+    self_improving._persist_full_config(
+        mutator={},
+        petri={},
+        seed_generation={"miner": {"model": "claude-haiku-4-5", "source": "claude-cli"}},
+    )
+    text = fake_toml.read_text(encoding="utf-8")
+    assert "[self_improving_loop.seed_generation.roles.miner]" in text
+    assert "[self_improving_loop.seed_generation.role.miner]" not in text  # singular forbidden
+    # Round-trip: the loader must accept what the writer produced.
+    cfg = load_self_improving_loop_config()
+    assert "miner" in cfg.seed_generation.roles
+    assert cfg.seed_generation.roles["miner"].source == "claude-cli"

--- a/tests/test_self_improving_run_slash.py
+++ b/tests/test_self_improving_run_slash.py
@@ -423,6 +423,6 @@ def test_deferred_actions_set_now_empty() -> None:
         _RUN_MAX_ITERATIONS,
     )
 
-    assert _RUN_DEFERRED_ACTIONS == frozenset()
+    assert frozenset() == _RUN_DEFERRED_ACTIONS
     assert _RUN_DEFAULT_ITERATIONS == 1
     assert _RUN_MAX_ITERATIONS == 10

--- a/tests/test_self_improving_run_slash.py
+++ b/tests/test_self_improving_run_slash.py
@@ -413,19 +413,16 @@ def test_run_action_dispatches_to_cmd_run(
     assert called == [["--dry-run", "--n", "2"]]
 
 
-def test_run_history_rollback_no_longer_in_deferred_actions() -> None:
-    """``/self-improving run`` was wired in PR-OPS-2a; ``history``
-    and ``rollback`` were wired in PR-MINIMAL-1 (git log/revert
-    delegation). Only ``config`` stays in the deferred set."""
+def test_deferred_actions_set_now_empty() -> None:
+    """PR-PAPERCLIP wired ``config`` to the interactive settings form,
+    so the deferred set is now empty. ``run`` / ``history`` /
+    ``rollback`` were wired in earlier PRs (OPS-2a / MINIMAL-1)."""
     from core.cli.commands.self_improving import (
         _RUN_DEFAULT_ITERATIONS,
         _RUN_DEFERRED_ACTIONS,
         _RUN_MAX_ITERATIONS,
     )
 
-    assert "run" not in _RUN_DEFERRED_ACTIONS
-    assert "history" not in _RUN_DEFERRED_ACTIONS
-    assert "rollback" not in _RUN_DEFERRED_ACTIONS
-    assert "config" in _RUN_DEFERRED_ACTIONS
+    assert _RUN_DEFERRED_ACTIONS == frozenset()
     assert _RUN_DEFAULT_ITERATIONS == 1
     assert _RUN_MAX_ITERATIONS == 10

--- a/tests/test_self_improving_status_slash.py
+++ b/tests/test_self_improving_status_slash.py
@@ -91,22 +91,33 @@ def test_status_action_dispatches_to_status(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 # ---------------------------------------------------------------------------
-# Reserved sub-actions — print deferred-to-PR-OPS-2/3 hint
+# ``config`` and ``source`` sub-actions — PR-PAPERCLIP
 # ---------------------------------------------------------------------------
 
 
-def test_config_action_emits_design_doc_hint(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """``run`` was wired in PR-OPS-2a; ``history`` + ``rollback``
-    were wired in PR-MINIMAL-1 (git log/revert delegation). Only
-    ``config`` remains reserved with the design-doc pointer."""
-    from core.cli.commands.self_improving import cmd_self_improving
+def test_config_action_dispatches_to_cmd_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR-PAPERCLIP wired ``config`` from the design-doc placeholder to
+    the interactive settings form. The dispatcher must route to
+    ``_cmd_config``; the form itself is exercised in
+    ``tests/test_paperclip_wiring.py``."""
+    from core.cli.commands import self_improving
 
-    cmd_self_improving("config")
-    out = capsys.readouterr().out
-    assert "PR-OPS-2b/3" in out
-    assert "self-improving-loop-ux.md" in out
+    called: list[bool] = []
+    monkeypatch.setattr(self_improving, "_cmd_config", lambda: called.append(True))
+    self_improving.cmd_self_improving("config")
+    assert called == [True]
+
+
+def test_source_action_dispatches_to_cmd_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``source`` (no args) and ``source set <key>=<value>`` both route
+    through ``_cmd_source`` which then sub-dispatches."""
+    from core.cli.commands import self_improving
+
+    called: list[list[str]] = []
+    monkeypatch.setattr(self_improving, "_cmd_source", lambda opts: called.append(opts))
+    self_improving.cmd_self_improving("source")
+    self_improving.cmd_self_improving("source set source=claude-cli")
+    assert called == [[], ["set", "source=claude-cli"]]
 
 
 def test_unknown_action_emits_help_hint(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- 사전 PR (PR-1 G-A) 가 `MutatorConfig.source = Literal["auto", "api_key", "claude-cli", "openai-codex"]` knob 만 도입하고 runner 는 로그만 찍었던 deception 해결 — 실제 dispatch 가 source 를 반영.
- `claude-cli` / `openai-codex` source 면 subprocess `claude --print` / `codex exec` 호출 → Claude Code Max / ChatGPT Plus 구독제로 mutator 빌링.
- UI/UX: `/self-improving config` (interactive 설정창, 컴포넌트별 provider/model/source 선택 후 `/self-improving run` 체이닝) + `/self-improving source` (show) + `/self-improving source set <key>=<value>` (non-interactive).

## Why
세션 directive: "현재 루프 구성들은 모두 로컬 Claude Code, Codex를 사용해서 구독제를 사용 가능(paperclip pattern) 혹은 GPT 구독 요금제를 사용할 수 있도록 세팅해". 사전조사에서 knob 은 있으나 consumer 미연결, UI/UX 부재 확인. 사용자 결정:
- Q1=b: subprocess 방식 (HTTP OAuth 아님)
- Q2=a+c: CLI 명령 + 대화형 (둘 다)
- Q3=a: 단일 PR
- 대화형은 전체 self-improving 설정창이 먼저 열리고 컴포넌트별 선택 → 절차 수행

Scope: **mutator only** (사용자 Q1 응답 "Self-improving loop만"). Agentic Loop runtime 등 다른 호출 경로는 미변경.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/cli_subprocess.py` | 신규 — `invoke_claude_cli` / `invoke_codex_cli` subprocess wrapper + `CliInvocationError` + `_resolve_binary` (env override + PATH) + 180s timeout |
| `core/self_improving_loop/runner.py` | `_default_llm_call` 가 `source == "claude-cli"` / `"openai-codex"` 이면 subprocess wrapper 호출 후 즉시 반환; else 기존 `call_with_failover` API path 그대로 |
| `core/cli/commands/self_improving.py` | `_RUN_DEFERRED_ACTIONS` 비움, `config` + `source` slash action wiring. `_cmd_config` interactive form. `_cmd_source` + `_cmd_source_set`. `_splice_section` TOML writer + `_toml_escape` + `_persist_*` helpers |
| `tests/test_paperclip_wiring.py` | 신규 — 16 invariant test |
| `CHANGELOG.md` | PR-PAPERCLIP entry |

## Test inventory (16)
- argv shape: `claude --print --output-format text --append-system-prompt SYS USR` + `codex exec --skip-git-repo-check SYS+USR`
- missing binary → CliInvocationError with install hint
- env override (`GEODE_CLAUDE_CLI_BIN`) used over PATH
- non-zero exit → CliInvocationError carrying stderr clip
- runner dispatch x3: claude-cli + openai-codex 분기 / api_key 무변경 (claude-cli wrapper 미호출 검증)
- TOML splice x5: append (section 누락) / replace (key 존재) / insert (section 있고 key 없음) / sibling 보존 / 이스케이프 (` " ` + `\\`)
- `_cmd_source_set` x3: invalid source 거부 (file 미작성) + valid persist + `_VALID_SOURCES` Literal sync

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Module already exists | No | `grep -rn "paperclip\|claude_cli\|codex_cli" core/` returned only docstrings + the Source enum |
| Tier 2 untouched | Yes | bootstrap / fitness_gate / HookSystem / importlinter / agent.model field — no diff |
| Scope creep beyond mutator | No | claude-cli / codex-cli wiring ONLY in `runner._default_llm_call`. Agentic Loop / petri / seed_generation 의 runtime 호출은 미변경 |
| UI/UX 형태 | Q2=a+c 반영 | Slash command (`/self-improving source set`) + interactive form (`/self-improving config`) 둘 다 |
| 구독제 빌링 보장 | Yes | subprocess 가 CLI binary 의 OAuth subscription credential 사용 (Claude Code: `~/.claude/.credentials.json`, Codex: `~/.codex/auth.json`) — API key 우회 |

## UX flow
```
$ geode
> /self-improving config
  Self-improving loop — interactive configuration
  Enter to keep current value. Ctrl-D aborts without writing.

  mutator
    current model:  claude-opus-4-7
    current source: api_key
    model  (Enter to keep): <Enter>
    source (Enter to keep — auto / api_key / claude-cli / openai-codex): claude-cli

  petri.auditor
    ...

  config saved to ~/.geode/config.toml

  Run /self-improving run now? [y/N]: y
  Self-improving loop — run
  ...
```

## Verification
- [x] `uv run ruff format` clean (auto-applied)
- [x] `uv run ruff check core/ tests/ plugins/` clean
- [x] `uv run mypy core/cli/commands/self_improving.py core/self_improving_loop/cli_subprocess.py core/self_improving_loop/runner.py` clean
- [x] `uv run pytest tests/test_paperclip_wiring.py -q` 16/16 PASS
- [x] subprocess wrapper 의 `noqa: S603` 1개 — argv 가 고정 allowlist 로부터 구성 (사용자 입력은 system_prompt / user_prompt 만, 이는 stdin 식으로 전달되지 argv 첫 토큰이 아니라 binary 경로는 `shutil.which` 또는 env override 만)

## Reference
- 사전 PR PR-1 G-A — `Source` Literal 도입 (knob only, consumer 미연결)
- `core/llm/providers/codex.py` — Codex OAuth → `chatgpt.com/backend-api/codex` 패턴 (HTTP 방식, 본 PR 의 subprocess 방식과 비교 가능 alternative)
- 사용자 directive: "현재 루프 구성들은 모두 로컬 Claude Code, Codex를 사용해서 구독제를 사용 가능(paperclip pattern)" (2026-05-21)