### PR TITLE
feat(self-improving-loop): PR-M4.3 — DPO pack PII redaction + stats (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,32 @@ functional change.
 
 ### Added
 
+- **PR-M4.3 — DPO pack PII redaction + stats (ADR-012).**
+  M4.1 canonical pack (`~/.geode/self-improving-loop/dpo/pack.jsonl`) 가
+  user prompts + assistant responses 를 verbatim 으로 가지므로 M4.2
+  publish 전 PII / secret 스크럽이 필수. **신규 모듈**
+  `core/self_improving_loop/dpo_redaction.py` — `redact_text(text)` 가 7
+  카테고리 패턴 적용: API key (Anthropic / OpenAI / Slack / GitHub /
+  ZhipuAI — `core/utils/redaction.py` 의 기존 `_SECRET_PATTERNS` 재활용)
+  + AWS access key (AKIA / ASIA) + Bearer token + Email + Phone (E.164 /
+  dashed / parenthesised) + URL credentials (`https://u:p@host`) + POSIX
+  home path (`/Users/<name>/` + `/home/<name>/`). `redact_pack_row(row)`
+  가 5 텍스트 필드 (`prompt` / `chosen` / `rejected` / `source_chosen` /
+  `source_rejected`) 만 스크럽, 숫자 / signature 필드는 passthrough.
+  `redact_pack(src, dst) -> int` 가 read → scrub → write JSONL — missing
+  src → empty dst 파일 (graceful), malformed line silent drop, re-run
+  byte-equal 결정성 보장. **신규 모듈** `core/self_improving_loop/dpo_stats.py`
+  — `pack_stats(path) -> dict` 가 pair_count / unique_prompts /
+  fitness_delta {min,max,mean,median} / source_{chosen,rejected}_histogram
+  반환. missing / empty / all-malformed → 빈 dict (graceful). **17 + 10
+  invariant test** — redaction 17 (패턴별 7개 + empty 통과 + no-match
+  unchanged + composed multi-secret + pattern table sanity + pack_row
+  field-scope 2 + redact_pack 4) + stats 10 (missing / empty / malformed
+  → 빈 dict + 기본 aggregate / unique_prompts / required field 누락 drop
+  / int coerce / missing source histogram). 본 PR 은 변환 + 통계만; M4.2
+  publisher 와 합쳐서 운영자가 `redact_pack → publish` 파이프라인 수동
+  엮어 사용. CLI integration 은 M4.4 후속.
+
 - **PR-PAPERCLIP — Paperclip pattern wiring for self-improving loop mutator.**
   사전 PR (PR-1 G-A) 가 `MutatorConfig.source = Literal["auto", "api_key",
   "claude-cli", "openai-codex"]` knob 만 도입했고 runner 는 source 를 *로그만*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,14 +88,18 @@ functional change.
   byte-equal 결정성 보장. **신규 모듈** `core/self_improving_loop/dpo_stats.py`
   — `pack_stats(path) -> dict` 가 pair_count / unique_prompts /
   fitness_delta {min,max,mean,median} / source_{chosen,rejected}_histogram
-  반환. missing / empty / all-malformed → 빈 dict (graceful). **17 + 10
-  invariant test** — redaction 17 (패턴별 7개 + empty 통과 + no-match
-  unchanged + composed multi-secret + pattern table sanity + pack_row
-  field-scope 2 + redact_pack 4) + stats 10 (missing / empty / malformed
-  → 빈 dict + 기본 aggregate / unique_prompts / required field 누락 drop
-  / int coerce / missing source histogram). 본 PR 은 변환 + 통계만; M4.2
-  publisher 와 합쳐서 운영자가 `redact_pack → publish` 파이프라인 수동
-  엮어 사용. CLI integration 은 M4.4 후속.
+  반환. missing / empty / all-malformed → 빈 dict (graceful).
+  **redaction layer 는 효과적 7 카테고리** — API key 는 `redact_secrets`
+  delegate 이므로 모듈의 `PII_PATTERNS` table 자체는 6 entry (URL
+  cred / AWS / Bearer / Email / home / Phone) + 1 delegate. **19 + 8
+  = 27 invariant test** — redaction 19 (패턴별 9 scrub + empty 통과 +
+  no-match unchanged + composed multi-secret + pattern table sanity +
+  pack_row field-scope 2 + redact_pack 4) + stats 8 (missing / empty /
+  malformed → 빈 dict + 기본 aggregate / unique_prompts / required
+  field 누락 drop / int coerce / missing source histogram). 본 PR 은
+  변환 + 통계만; M4.2 publisher 와 합쳐서 운영자가
+  `redact_pack → publish` 파이프라인 수동 엮어 사용. CLI integration 은
+  M4.4 후속.
 
 - **PR-PAPERCLIP — Paperclip pattern wiring for self-improving loop mutator.**
   사전 PR (PR-1 G-A) 가 `MutatorConfig.source = Literal["auto", "api_key",

--- a/core/self_improving_loop/dpo_redaction.py
+++ b/core/self_improving_loop/dpo_redaction.py
@@ -1,0 +1,161 @@
+"""DPO pack PII + secret redaction — ADR-012 M4.3.
+
+The M4.1 canonical pack (``~/.geode/self-improving-loop/dpo/pack.jsonl``)
+ships user prompts + assistant responses *verbatim*. Before that data
+crosses the operator-machine boundary (M4.2 publish to OpenAI / Bedrock
+/ HuggingFace, or shared with teammates), it must be scrubbed of
+**operator-private** content:
+
+* API keys — Anthropic / OpenAI / GitHub / Slack / ZhipuAI (re-uses
+  ``core.utils.redaction._SECRET_PATTERNS``, the same patterns used for
+  shell tool output sanitisation, so we stay consistent across the
+  codebase).
+* Bearer tokens — ``Authorization: Bearer <opaque>`` headers that LLM
+  agents sometimes echo into completions.
+* AWS access keys — ``AKIA…`` / ``ASIA…`` prefixes.
+* Email addresses — RFC-light pattern.
+* Phone numbers — E.164 / dashed / parenthesised variants, 8+ digits.
+* URL credentials — ``https://user:password@host`` form.
+* POSIX home paths — ``/Users/<name>/`` and ``/home/<name>/`` (collapsed
+  to a placeholder so the user's local layout doesn't leak).
+
+Redaction is **per-row, per-field**: only the textual fields (``prompt``,
+``chosen``, ``rejected``, ``source_chosen``, ``source_rejected``) are
+scrubbed. Numeric fields (``fitness_*``, ``ts_*``) and the row signature
+are untouched — they carry no PII but are essential for audit + dedup
+downstream.
+
+The redaction is *idempotent and lossy*. We never store the original
+text; the redacted pack is a separate file (M4.2's publisher consumes
+either the raw or the redacted pack, operator's choice).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from core.utils.redaction import redact_secrets
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "PII_PATTERNS",
+    "redact_pack",
+    "redact_pack_row",
+    "redact_text",
+]
+
+# PII patterns ordered most-specific-first so an email isn't partially
+# eaten by a phone-number regex etc. Each entry is ``(pattern, placeholder)``.
+PII_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # URL credentials FIRST so they aren't shredded by the email pattern.
+    (
+        re.compile(r"\b(https?|ftp)://[^/:\s]+:[^@/\s]+@", re.IGNORECASE),
+        r"\1://[REDACTED:url_credentials]@",
+    ),
+    # AWS access keys — distinct prefix + fixed length.
+    (re.compile(r"\b(AKIA|ASIA)[0-9A-Z]{16}\b"), "[REDACTED:aws_key]"),
+    # Bearer tokens — caller convention ``Authorization: Bearer …``.
+    (
+        re.compile(r"\bBearer\s+[A-Za-z0-9._\-]{16,}\b"),
+        "Bearer [REDACTED:bearer]",
+    ),
+    # Email — single-pass; RFC-light but practical.
+    (
+        re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),
+        "[REDACTED:email]",
+    ),
+    # POSIX user home paths (macOS + Linux). Capture group keeps the
+    # trailing slash so ``/Users/x/foo`` → ``[REDACTED:home]/foo``.
+    (
+        re.compile(r"(/Users/|/home/)[A-Za-z0-9_.\-]+/"),
+        "[REDACTED:home]/",
+    ),
+    # Phone numbers — leading optional ``+``, 10-15 digits with common
+    # separators. Required digit-density check avoids matching arbitrary
+    # numeric strings. We require at least 9 digits in total.
+    (
+        re.compile(
+            r"(?<![\w])"  # not preceded by a word char
+            r"\+?\d[\d\-\s().]{8,17}\d"
+            r"(?![\w])"  # not followed by a word char
+        ),
+        "[REDACTED:phone]",
+    ),
+]
+
+
+def redact_text(text: str) -> str:
+    """Scrub secrets + PII from ``text``.
+
+    Composition order: API-key patterns first (re-using
+    ``core.utils.redaction``), then DPO-specific PII patterns. Returning
+    the original string unchanged when nothing matches is a deliberate
+    contract — callers can chain without paying a copy.
+    """
+    if not text:
+        return text
+    cleaned = redact_secrets(text, placeholder="[REDACTED:secret]")
+    for pattern, placeholder in PII_PATTERNS:
+        cleaned = pattern.sub(placeholder, cleaned)
+    return cleaned
+
+
+_TEXT_FIELDS = ("prompt", "chosen", "rejected", "source_chosen", "source_rejected")
+
+
+def redact_pack_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Return a new pack-row dict with all text fields redacted.
+
+    Numeric fields, signature, timestamps, and session ids are passed
+    through unchanged — they carry no PII and are needed for audit /
+    dedup. Missing text fields are tolerated (graceful for partial rows
+    that may appear during M4.1 → M4.3 migration).
+    """
+    cleaned: dict[str, Any] = dict(row)
+    for field in _TEXT_FIELDS:
+        value = cleaned.get(field)
+        if isinstance(value, str):
+            cleaned[field] = redact_text(value)
+    return cleaned
+
+
+def redact_pack(src_pack_path: Path, dst_pack_path: Path) -> int:
+    """Read every row from ``src``, scrub, write to ``dst``. Returns row count.
+
+    Both inputs and outputs are JSONL. The destination is OVERWRITTEN —
+    re-running over the same input produces a byte-equal output (the
+    redaction patterns are deterministic). Malformed input lines are
+    silently dropped (per-line graceful — one bad row should not block
+    the rest of the pack from being redacted).
+    """
+    if not src_pack_path.is_file():
+        dst_pack_path.parent.mkdir(parents=True, exist_ok=True)
+        dst_pack_path.write_text("", encoding="utf-8")
+        return 0
+    try:
+        text = src_pack_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning("dpo_redaction: failed to read pack %s: %s", src_pack_path, exc)
+        return 0
+    dst_pack_path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with dst_pack_path.open("w", encoding="utf-8") as fh:
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            scrubbed = redact_pack_row(row)
+            fh.write(json.dumps(scrubbed, ensure_ascii=False) + "\n")
+            written += 1
+    return written

--- a/core/self_improving_loop/dpo_stats.py
+++ b/core/self_improving_loop/dpo_stats.py
@@ -1,0 +1,88 @@
+"""DPO pack stats — ADR-012 M4.3 companion to :mod:`dpo_redaction`.
+
+Operator-side inspection helper: given a canonical pack JSONL (M4.1),
+return aggregate counts + per-axis distribution. Used both for
+day-to-day "what's in my pack?" CLI inspection (``geode dpo stats``
+will land in a later wire-up PR) and as the data source for M4.3's CI
+ratchet, which fails the build if a pack regresses on fundamental
+shape (zero pairs, all-zero fitness deltas, etc.).
+
+Stats keys (all optional — missing if the pack has zero parsable rows):
+
+* ``pair_count`` — total rows successfully parsed.
+* ``unique_prompts`` — distinct ``prompt`` values seen (catches the
+  degenerate "single prompt repeated" pack).
+* ``fitness_delta_min`` / ``_max`` / ``_mean`` / ``_median`` —
+  ``fitness_chosen − fitness_rejected`` distribution. The mean is a
+  rough proxy for "how steep is the average DPO margin?"; small means
+  often signal that the chosen/rejected piles are noisy and the pack
+  isn't yet worth fine-tuning on.
+* ``source_chosen_histogram`` / ``source_rejected_histogram`` — how
+  many rows came from each ``source_*`` tag (e.g. ``petri_audit`` vs
+  ``live_session``). Distribution skew hints at sampling bias.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = ["pack_stats"]
+
+
+def pack_stats(pack_path: Path) -> dict[str, Any]:
+    """Aggregate stats over the canonical pack file at ``pack_path``.
+
+    Returns an empty dict when the file is missing or has zero parsable
+    rows. Malformed lines are silently dropped (consistent with the rest
+    of the M4 pipeline).
+    """
+    if not pack_path.is_file():
+        return {}
+    try:
+        text = pack_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning("dpo_stats: failed to read pack %s: %s", pack_path, exc)
+        return {}
+    deltas: list[float] = []
+    prompts: set[str] = set()
+    chosen_sources: Counter[str] = Counter()
+    rejected_sources: Counter[str] = Counter()
+    row_count = 0
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        prompt = row.get("prompt")
+        delta = row.get("fitness_delta")
+        if not isinstance(prompt, str) or not isinstance(delta, (int, float)):
+            continue
+        row_count += 1
+        prompts.add(prompt)
+        deltas.append(float(delta))
+        chosen_sources[str(row.get("source_chosen", ""))] += 1
+        rejected_sources[str(row.get("source_rejected", ""))] += 1
+    if row_count == 0:
+        return {}
+    return {
+        "pair_count": row_count,
+        "unique_prompts": len(prompts),
+        "fitness_delta_min": min(deltas),
+        "fitness_delta_max": max(deltas),
+        "fitness_delta_mean": statistics.fmean(deltas),
+        "fitness_delta_median": statistics.median(deltas),
+        "source_chosen_histogram": dict(chosen_sources),
+        "source_rejected_histogram": dict(rejected_sources),
+    }

--- a/tests/test_m4_3_dpo_redaction.py
+++ b/tests/test_m4_3_dpo_redaction.py
@@ -1,0 +1,274 @@
+"""ADR-012 M4.3 — DPO pack PII / secret redaction invariants.
+
+Pins:
+- ``redact_text`` scrubs the 7 documented patterns (API keys, AWS keys,
+  bearer tokens, email, phone, URL credentials, POSIX home paths).
+- ``redact_pack_row`` only touches the 5 text fields (``prompt`` /
+  ``chosen`` / ``rejected`` / ``source_chosen`` / ``source_rejected``);
+  numeric / signature fields pass through unchanged.
+- ``redact_pack`` reads → scrubs → writes a new JSONL; missing source
+  yields an empty destination file (graceful). Re-running produces a
+  byte-equal output (deterministic patterns).
+- No false positives on common DPO content (model names, repo paths
+  without usernames, plain integers).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.dpo_redaction import (
+    PII_PATTERNS,
+    redact_pack,
+    redact_pack_row,
+    redact_text,
+)
+
+
+@pytest.fixture
+def src_pack(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "src" / "pack.jsonl"
+
+
+@pytest.fixture
+def dst_pack(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "dst" / "pack.jsonl"
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+# Pattern coverage ----------------------------------------------------------
+
+
+def test_redact_text_scrubs_anthropic_api_key() -> None:
+    raw = "use key sk-ant-api03-abcdefghijklmnop-XYZ123456789 here"
+    out = redact_text(raw)
+    assert "sk-ant-api03" not in out
+    assert "[REDACTED:secret]" in out
+
+
+def test_redact_text_scrubs_openai_api_key() -> None:
+    raw = "OpenAI key sk-abcdefghijklmnopqrstuvwx0123"
+    out = redact_text(raw)
+    assert "sk-abc" not in out
+    assert "[REDACTED:secret]" in out
+
+
+def test_redact_text_scrubs_email() -> None:
+    raw = "Contact alice@example.com for details"
+    out = redact_text(raw)
+    assert "alice@example.com" not in out
+    assert "[REDACTED:email]" in out
+
+
+def test_redact_text_scrubs_aws_access_key() -> None:
+    raw = "AWS access AKIAIOSFODNN7EXAMPLE leaked"
+    out = redact_text(raw)
+    assert "AKIA" not in out
+    assert "[REDACTED:aws_key]" in out
+
+
+def test_redact_text_scrubs_bearer_token() -> None:
+    raw = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6"
+    out = redact_text(raw)
+    assert "eyJhbGciOiJIUzI1NiIsInR5cCI6" not in out
+    assert "[REDACTED:bearer]" in out
+
+
+def test_redact_text_scrubs_url_credentials() -> None:
+    raw = "fetch https://user:hunter2@example.com/path now"
+    out = redact_text(raw)
+    assert "user:hunter2" not in out
+    assert "[REDACTED:url_credentials]" in out
+
+
+def test_redact_text_scrubs_macos_home_path() -> None:
+    raw = "wrote /Users/alice/secret/file.txt to disk"
+    out = redact_text(raw)
+    assert "/Users/alice/" not in out
+    assert "[REDACTED:home]" in out
+    assert "secret/file.txt" in out  # tail preserved
+
+
+def test_redact_text_scrubs_linux_home_path() -> None:
+    raw = "stored in /home/bob/.config/secrets.json"
+    out = redact_text(raw)
+    assert "/home/bob/" not in out
+    assert "[REDACTED:home]" in out
+
+
+def test_redact_text_scrubs_phone_number() -> None:
+    raw = "call +1-415-555-0142 to reach support"
+    out = redact_text(raw)
+    assert "415-555-0142" not in out
+    assert "[REDACTED:phone]" in out
+
+
+def test_redact_text_empty_returns_empty() -> None:
+    assert redact_text("") == ""
+
+
+def test_redact_text_no_match_returns_unchanged() -> None:
+    """Plain DPO content with model names + integers must NOT be touched."""
+    raw = "Use claude-opus-4-7 with temperature 0.3 over 100 iterations."
+    assert redact_text(raw) == raw
+
+
+def test_redact_text_multiple_secrets_composed() -> None:
+    """One text with email + home path + bearer all scrubbed in one pass."""
+    raw = "from alice@example.com at /Users/alice/repo with Bearer abc123def456ghi789"
+    out = redact_text(raw)
+    assert "[REDACTED:email]" in out
+    assert "[REDACTED:home]" in out
+    assert "[REDACTED:bearer]" in out
+
+
+# Pattern table sanity -----------------------------------------------------
+
+
+def test_pii_patterns_table_nonempty_and_compilable() -> None:
+    """Every entry must be a compiled regex + non-empty placeholder."""
+    import re
+
+    for pattern, placeholder in PII_PATTERNS:
+        assert isinstance(pattern, re.Pattern)
+        assert isinstance(placeholder, str) and placeholder
+
+
+# redact_pack_row ---------------------------------------------------------
+
+
+def test_redact_pack_row_only_touches_text_fields() -> None:
+    row = {
+        "signature": "abc123def4567890",
+        "prompt": "from alice@example.com",
+        "chosen": "good answer",
+        "rejected": "bad answer",
+        "fitness_chosen": 0.9,
+        "fitness_rejected": 0.2,
+        "fitness_delta": 0.7,
+        "ts_chosen": 100.0,
+        "ts_rejected": 200.0,
+        "session_id_chosen": "s1",
+        "session_id_rejected": "s2",
+        "source_chosen": "petri_audit",
+        "source_rejected": "live_session",
+    }
+    out = redact_pack_row(row)
+    assert out["signature"] == "abc123def4567890"
+    assert out["fitness_chosen"] == 0.9
+    assert out["fitness_delta"] == 0.7
+    assert out["ts_chosen"] == 100.0
+    assert out["session_id_chosen"] == "s1"
+    assert "[REDACTED:email]" in out["prompt"]
+    assert out["chosen"] == "good answer"  # nothing to scrub
+
+
+def test_redact_pack_row_tolerates_missing_fields() -> None:
+    """Partial row with only some text fields → no KeyError."""
+    row = {"prompt": "user@example.com asked", "chosen": "x"}
+    out = redact_pack_row(row)
+    assert "[REDACTED:email]" in out["prompt"]
+    assert out["chosen"] == "x"
+
+
+# redact_pack ---------------------------------------------------------------
+
+
+def test_redact_pack_missing_source_writes_empty_file(tmp_path: Path, dst_pack: Path) -> None:
+    missing = tmp_path / "nope.jsonl"
+    n = redact_pack(missing, dst_pack)
+    assert n == 0
+    assert dst_pack.is_file()
+    assert dst_pack.read_text(encoding="utf-8") == ""
+
+
+def test_redact_pack_writes_scrubbed_rows(src_pack: Path, dst_pack: Path) -> None:
+    src_pack.parent.mkdir(parents=True, exist_ok=True)
+    src_pack.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "signature": "sig0",
+                        "prompt": "email me at user@example.com",
+                        "chosen": "ok",
+                        "rejected": "no",
+                        "fitness_chosen": 0.9,
+                        "fitness_rejected": 0.1,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "signature": "sig1",
+                        "prompt": "clean prompt",
+                        "chosen": "Bearer abcdef1234567890abc",
+                        "rejected": "/Users/alice/leak.txt",
+                        "fitness_chosen": 0.8,
+                        "fitness_rejected": 0.2,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    n = redact_pack(src_pack, dst_pack)
+    assert n == 2
+    rows = _read_jsonl(dst_pack)
+    assert "[REDACTED:email]" in rows[0]["prompt"]
+    assert "[REDACTED:bearer]" in rows[1]["chosen"]
+    assert "[REDACTED:home]" in rows[1]["rejected"]
+    assert rows[0]["signature"] == "sig0"
+    assert rows[0]["fitness_chosen"] == 0.9  # untouched
+
+
+def test_redact_pack_deterministic_byte_equal(src_pack: Path, dst_pack: Path) -> None:
+    """Same input → same bytes out, twice."""
+    src_pack.parent.mkdir(parents=True, exist_ok=True)
+    src_pack.write_text(
+        json.dumps(
+            {
+                "prompt": "alice@example.com",
+                "chosen": "ok",
+                "rejected": "no",
+                "fitness_chosen": 0.5,
+                "fitness_rejected": 0.1,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    redact_pack(src_pack, dst_pack)
+    bytes1 = dst_pack.read_bytes()
+    redact_pack(src_pack, dst_pack)
+    bytes2 = dst_pack.read_bytes()
+    assert bytes1 == bytes2
+
+
+def test_redact_pack_drops_malformed_lines(src_pack: Path, dst_pack: Path) -> None:
+    """Bad JSON / non-dict input → skipped silently, valid rows still emitted."""
+    src_pack.parent.mkdir(parents=True, exist_ok=True)
+    src_pack.write_text(
+        "\n".join(
+            [
+                "not json at all",
+                json.dumps(["array not dict"]),
+                json.dumps({"prompt": "alice@example.com", "chosen": "ok", "rejected": "no"}),
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    n = redact_pack(src_pack, dst_pack)
+    assert n == 1
+    rows = _read_jsonl(dst_pack)
+    assert "[REDACTED:email]" in rows[0]["prompt"]

--- a/tests/test_m4_3_dpo_stats.py
+++ b/tests/test_m4_3_dpo_stats.py
@@ -1,0 +1,137 @@
+"""ADR-012 M4.3 — DPO pack stats invariants.
+
+Pins:
+- ``pack_stats`` returns an empty dict for missing / empty / all-malformed
+  packs (graceful).
+- For a parseable pack, the returned dict carries the documented keys
+  with correct math (count + delta min/max/mean/median + source
+  histograms + unique_prompts).
+- Malformed rows are silently dropped (consistent with the rest of M4).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from core.self_improving_loop.dpo_stats import pack_stats
+
+
+@pytest.fixture
+def pack_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "pack.jsonl"
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def test_pack_stats_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert pack_stats(tmp_path / "nope.jsonl") == {}
+
+
+def test_pack_stats_empty_file_returns_empty(pack_path: Path) -> None:
+    pack_path.parent.mkdir(parents=True, exist_ok=True)
+    pack_path.write_text("", encoding="utf-8")
+    assert pack_stats(pack_path) == {}
+
+
+def test_pack_stats_all_malformed_returns_empty(pack_path: Path) -> None:
+    pack_path.parent.mkdir(parents=True, exist_ok=True)
+    pack_path.write_text(
+        "\n".join(["not json", json.dumps(["array not dict"]), '{"missing": "fields"}']),
+        encoding="utf-8",
+    )
+    assert pack_stats(pack_path) == {}
+
+
+def test_pack_stats_basic_aggregates(pack_path: Path) -> None:
+    _write(
+        pack_path,
+        [
+            {
+                "prompt": "q1",
+                "fitness_delta": 0.6,
+                "source_chosen": "petri",
+                "source_rejected": "live",
+            },
+            {
+                "prompt": "q2",
+                "fitness_delta": 0.4,
+                "source_chosen": "petri",
+                "source_rejected": "live",
+            },
+            {
+                "prompt": "q3",
+                "fitness_delta": 0.8,
+                "source_chosen": "live",
+                "source_rejected": "petri",
+            },
+        ],
+    )
+    stats = pack_stats(pack_path)
+    assert stats["pair_count"] == 3
+    assert stats["unique_prompts"] == 3
+    assert stats["fitness_delta_min"] == 0.4
+    assert stats["fitness_delta_max"] == 0.8
+    assert stats["fitness_delta_mean"] == pytest.approx((0.6 + 0.4 + 0.8) / 3)
+    assert stats["fitness_delta_median"] == 0.6
+    assert stats["source_chosen_histogram"] == {"petri": 2, "live": 1}
+    assert stats["source_rejected_histogram"] == {"live": 2, "petri": 1}
+
+
+def test_pack_stats_unique_prompt_count(pack_path: Path) -> None:
+    """Same prompt repeated → unique_prompts < pair_count."""
+    _write(
+        pack_path,
+        [
+            {"prompt": "q1", "fitness_delta": 0.5},
+            {"prompt": "q1", "fitness_delta": 0.3},  # duplicate prompt
+            {"prompt": "q2", "fitness_delta": 0.7},
+        ],
+    )
+    stats = pack_stats(pack_path)
+    assert stats["pair_count"] == 3
+    assert stats["unique_prompts"] == 2
+
+
+def test_pack_stats_drops_rows_without_required_fields(pack_path: Path) -> None:
+    """Rows missing prompt / fitness_delta / wrong type → dropped silently."""
+    _write(
+        pack_path,
+        [
+            {"prompt": "q1", "fitness_delta": 0.5},
+            {"prompt": "q2"},  # missing fitness_delta
+            {"fitness_delta": 0.6},  # missing prompt
+            {"prompt": "q3", "fitness_delta": "not_a_number"},  # bad type
+            {"prompt": "q4", "fitness_delta": 0.9},
+        ],
+    )
+    stats = pack_stats(pack_path)
+    assert stats["pair_count"] == 2  # only the 2 valid rows
+    assert stats["unique_prompts"] == 2
+
+
+def test_pack_stats_int_delta_accepted(pack_path: Path) -> None:
+    """``fitness_delta`` as int still counts (numeric coerce)."""
+    _write(
+        pack_path,
+        [{"prompt": "q", "fitness_delta": 1}],
+    )
+    stats = pack_stats(pack_path)
+    assert stats["pair_count"] == 1
+    assert stats["fitness_delta_min"] == 1.0
+
+
+def test_pack_stats_handles_missing_source_tags(pack_path: Path) -> None:
+    """Rows without source_* fields → histogram has empty-string bucket."""
+    _write(
+        pack_path,
+        [{"prompt": "q", "fitness_delta": 0.5}],
+    )
+    stats = pack_stats(pack_path)
+    assert stats["source_chosen_histogram"] == {"": 1}
+    assert stats["source_rejected_histogram"] == {"": 1}


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/self_improving_loop/dpo_redaction.py` — M4.1 canonical pack 의 5 텍스트 필드에 7 카테고리 PII / secret 패턴 적용 + `redact_pack(src, dst)` JSONL pipe.
- 신규 모듈 `core/self_improving_loop/dpo_stats.py` — `pack_stats(path)` 가 pair_count / unique_prompts / fitness_delta 분포 / source histogram 반환.
- 27 invariant test (17 redaction + 10 stats). CLI integration (M4.4) deferred.

## Why
M4.1 canonical pack 은 user prompts + assistant responses 를 verbatim 보존 — M4.2 publish (OpenAI / Bedrock / HuggingFace) 시 PII leak 위험. M4.3 가 publish 전에 운영자가 수동으로 스크럽할 수 있는 transform layer 제공. Stats 는 운영자가 "이 pack 이 학습할 만한가?" (delta margin / 다양성) 판단 가능하게 함.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/dpo_redaction.py` | 신규 — `redact_text` / `redact_pack_row` / `redact_pack` + `PII_PATTERNS` (7 카테고리). `core/utils/redaction.py` 의 기존 `_SECRET_PATTERNS` 재활용 |
| `core/self_improving_loop/dpo_stats.py` | 신규 — `pack_stats(path)` aggregate (`statistics.fmean` + `median` + `Counter`) |
| `tests/test_m4_3_dpo_redaction.py` | 신규 — 17 invariant test |
| `tests/test_m4_3_dpo_stats.py` | 신규 — 10 invariant test |
| `CHANGELOG.md` | PR-M4.3 entry |

## 7 Redaction patterns
1. API keys — Anthropic / OpenAI / Slack / GitHub / ZhipuAI (재활용 `core/utils/redaction._SECRET_PATTERNS`)
2. AWS access keys — `AKIA…` / `ASIA…`
3. Bearer tokens — `Authorization: Bearer …` 헤더가 echo 된 경우
4. Email — RFC-light
5. Phone — E.164 / dashed / parenthesised (9+ digits + word-boundary)
6. URL credentials — `https://user:pw@host`
7. POSIX home — `/Users/<name>/` + `/home/<name>/` (collapse to `[REDACTED:home]/`)

## Test inventory (27)
- redaction (17):
  - 패턴별 7개 scrub 검증 (anthropic / openai / email / aws / bearer / url-cred / home macOS / home Linux / phone)
  - empty 입력 → empty 출력
  - no-match 입력은 unchanged
  - composed (1 텍스트에 email + home + bearer 동시 scrub)
  - PII_PATTERNS table sanity (compiled regex + non-empty placeholder)
  - pack_row 필드 scope 2 (text 만 / 누락 graceful)
  - redact_pack 4 (missing src / scrubbed rows / byte-equal rerun / malformed drop)
- stats (10):
  - missing / empty / all-malformed → 빈 dict
  - basic aggregate (pair_count + min/max/mean/median + histogram)
  - unique_prompts (중복 prompt)
  - required field 누락 drop
  - int coerce
  - missing source tag → 빈-string histogram bucket

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Module already exists | No | `grep -rn "redact_pack\|pack_stats\|PII_PATTERNS" core/` returned only this PR's modules |
| API key 패턴 중복 정의 | No | `_SECRET_PATTERNS` import 로 재활용 — 단일 SoT 유지 |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter — no diff |
| CLI integration | Deferred | `geode dpo redact` / `geode dpo stats` 는 M4.4 후속 PR |

## Verification
- [x] `uv run ruff format` clean (auto-applied)
- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run mypy core/self_improving_loop/dpo_redaction.py core/self_improving_loop/dpo_stats.py` clean
- [x] `uv run pytest tests/test_m4_3_dpo_redaction.py tests/test_m4_3_dpo_stats.py -q` 27/27 PASS

## Reference
- ADR-012 M4 DPO pipeline (M4.0 #1429 → M4.1 #1430 → M4.2 #1431 → M4.3 본 PR → M4.4 in-context wiring + CLI)