### PR TITLE
feat(self-improving-loop): PR-M4.4 — in-context slot wiring orchestrator + provider wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,35 @@ functional change.
 
 ### Added
 
+- **PR-M4.4 — In-context slot wiring orchestrator + provider wiring (ADR-012).**
+  M4 DPO pipeline 의 closing piece — S5 (#1425) 의 4-slot schema 와 M3
+  (#1426/#1428) 의 few-shot pool substrate 를 실제 inference path 에
+  연결. **신규 모듈** `core/self_improving_loop/in_context_wiring.py`
+  의 `apply_in_context_slots(messages, system="")` orchestrator —
+  S5 `_load_in_context_slots_override()` 가 None 이면 input 객체
+  **identity** 반환 (zero-allocation no-op fast path; default GEODE
+  operator 는 추가 비용 0). slot 활성 시 per-slot try/except 로 각
+  reader/apply 가 독립 graceful. **exemplars 슬롯 = 실제 활성** —
+  M3 의 `_load_few_shot_pool_override` + `apply_few_shot_pool` 을
+  호출, top-K (user, assistant) 쌍을 messages head 에 prepend.
+  fitness_delta desc rank. **memory_recall / rubric_excerpts /
+  tool_hints 3 슬롯 = 명시적 stub** — orchestrator 이 SoT 에서 그
+  존재를 인식하지만 reader 미구현이라 no-op; 후속 PR (M4.4.1+) 이
+  reader 1개씩 추가 시 한 함수 wiring 만으로 활성화. **Provider
+  wiring 2지점** — `core/llm/providers/anthropic.py::ClaudeAgenticAdapter.agentic_call`
+  + `core/llm/providers/openai.py::OpenAIAgenticAdapter.agentic_call`
+  의 api-key/circuit-breaker 체크 직후 orchestrator 호출, 결과로
+  `(messages, system)` 갱신. 두 path 모두 inspect.getsource grep
+  assertion 으로 wiring 보증. **11 invariant test** — no-op
+  identity 3 (no SoT / 빈 dict / reader exception) + exemplars
+  prepend 1 + exemplars 빈 pool no-op + exemplars 실패 graceful +
+  system passthrough + 3 stub slot non-error + provider import
+  smoke 2 + __all__ minimal export. ContextVar / hook 미사용 —
+  매 LLM call 마다 ContextVar lookup 한 번도 없는 stateless
+  orchestrator. Frontier 비교: Claude Code system prompt /
+  Codex CLI `<system-reminder>` 의 4 layer wiring 을 mutator-target
+  화 한 explicit schema.
+
 - **PR-M4.3 — DPO pack PII redaction + stats (ADR-012).**
   M4.1 canonical pack (`~/.geode/self-improving-loop/dpo/pack.jsonl`) 가
   user prompts + assistant responses 를 verbatim 으로 가지므로 M4.2

--- a/core/llm/providers/anthropic.py
+++ b/core/llm/providers/anthropic.py
@@ -718,6 +718,16 @@ class ClaudeAgenticAdapter:
         if self._client is None:
             self._client = get_async_anthropic_client(api_key)
 
+        # PR-M4.4 (2026-05-21) — 4-slot in-context wiring. No-op fast
+        # path inside ``apply_in_context_slots`` when no SoT is
+        # configured (the GEODE default), so this call adds zero
+        # overhead for operators who have not opted in. Per-slot
+        # graceful: any reader/apply failure is logged at DEBUG and
+        # the original ``messages`` / ``system`` flow through unchanged.
+        from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+        messages, system = apply_in_context_slots(messages, system=system)
+
         # GAP-T1 — normalize cross-provider tool_choice into the Anthropic
         # dict shape ({"type": "auto"|"any"|"tool"|"none", "name"?: ...}).
         from core.llm.tool_choice import normalize as _normalize_tool_choice

--- a/core/llm/providers/openai.py
+++ b/core/llm/providers/openai.py
@@ -589,6 +589,13 @@ class OpenAIAgenticAdapter:
             log.warning("%s circuit breaker is OPEN, skipping call", self.provider_name)
             return None
 
+        # PR-M4.4 (2026-05-21) — 4-slot in-context wiring. No-op fast
+        # path when no SoT configured (zero overhead for default
+        # operators). See ``core.self_improving_loop.in_context_wiring``.
+        from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+        messages, system = apply_in_context_slots(messages, system=system)
+
         # GAP-T1 — normalize cross-provider tool_choice into the Responses API
         # shape (string or {"type": "function", "name": "..."}).
         from core.llm.tool_choice import normalize as _normalize_tool_choice

--- a/core/self_improving_loop/in_context_wiring.py
+++ b/core/self_improving_loop/in_context_wiring.py
@@ -1,0 +1,114 @@
+"""In-context slot wiring orchestrator — ADR-012 M4.4.
+
+Connects the S5 in-context slot schema (`core/self_improving_loop/in_context_slots.py`)
+to the actual LLM inference path. For every active LLM call, this
+orchestrator consults the 4-slot SoT and applies the configured
+transforms to the outgoing ``messages`` + ``system`` text before they
+reach the provider.
+
+**4 slots → wiring status**:
+
+* ``exemplars`` — **wired**. Reads the M3 few-shot exemplar pool
+  (`core/llm/few_shot_pool.py`) via ``_load_few_shot_pool_override`` →
+  applies via ``apply_few_shot_pool`` (top-K by fitness_delta desc).
+  Prepends ``(user, assistant)`` pairs at the head of ``messages``.
+* ``memory_recall`` — **stub**. Reader (``~/.geode/memory/`` recency ×
+  cosine similarity) is a follow-up PR. Orchestrator iterates this
+  slot today as a no-op so the wiring path is in place; activating it
+  is a single function injection.
+* ``rubric_excerpts`` — **stub**. Reader (Petri 17-dim worst-regressed
+  rubric) is a follow-up PR.
+* ``tool_hints`` — **stub**. Reader (RunLog + episodic memory
+  success_rate ranked) is a follow-up PR.
+
+**No-op fast path**: when ``_load_in_context_slots_override`` returns
+``None`` (no SoT configured, the GEODE default), the orchestrator
+returns the input ``messages`` + ``system`` unchanged — zero allocation,
+zero log noise. This is the path the agentic loop hits on every call
+for operators who have not opted into in-context wiring.
+
+**Per-slot graceful**: each slot's reader / apply path runs inside its
+own ``try / except``. A failure in one slot never blocks the others
+or the underlying LLM call.
+
+**Frontier parity**: Claude Code's system prompt and Codex CLI's
+``<system-reminder>`` framework both ship hardcoded equivalents of
+the 4 slots. GEODE surfaces them as explicit mutator targets so the
+self-improving loop can optimize each independently.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = ["apply_in_context_slots"]
+
+
+def apply_in_context_slots(
+    messages: list[dict[str, Any]],
+    *,
+    system: str = "",
+) -> tuple[list[dict[str, Any]], str]:
+    """Apply the 4-slot in-context wiring to ``messages`` + ``system``.
+
+    Args:
+        messages: The agentic-loop's pending ``messages`` list (will be
+            passed to the provider's ``messages.create`` / ``responses``
+            endpoint). Caller passes the list verbatim; orchestrator
+            never mutates in place.
+        system: The system prompt text. ``""`` when the caller hasn't
+            set one. Always returned alongside ``messages`` so a future
+            slot reader (``memory_recall`` / ``rubric_excerpts``) that
+            wants ``injection_point="system_prompt"`` can transform it.
+
+    Returns:
+        ``(new_messages, new_system)`` — both are fresh objects when any
+        slot fired, else the input identities for the no-op fast path.
+    """
+    # No-op fast path — done first so the common "no SoT configured"
+    # case adds zero overhead on every LLM call.
+    try:
+        from core.self_improving_loop.in_context_slots import (
+            SLOT_EXEMPLARS,
+            _load_in_context_slots_override,
+        )
+
+        slots = _load_in_context_slots_override()
+    except Exception:  # pragma: no cover — defensive
+        log.debug("in_context_slots load failed; skipping wiring", exc_info=True)
+        return messages, system
+    if not slots:
+        return messages, system
+
+    new_messages = messages
+    new_system = system
+
+    # exemplars — M3 substrate active. Top-K few-shot pairs at head of
+    # the messages list, ranked by fitness_delta desc.
+    exemplars_cfg = slots.get(SLOT_EXEMPLARS)
+    if exemplars_cfg is not None:
+        try:
+            from core.llm.few_shot_pool import (
+                _load_few_shot_pool_override,
+                apply_few_shot_pool,
+            )
+
+            pool = _load_few_shot_pool_override()
+            if pool:
+                new_messages = apply_few_shot_pool(
+                    new_messages, pool, max_entries=exemplars_cfg.max_entries
+                )
+        except Exception as exc:
+            log.debug("exemplars slot apply failed: %s", exc, exc_info=True)
+
+    # memory_recall / rubric_excerpts / tool_hints — readers deferred to
+    # follow-up PRs (M4.4.1+). The orchestrator iterates them here so
+    # the wiring path is in place; each becomes active by wiring in its
+    # reader + apply function inside its own try / except block, exactly
+    # mirroring the exemplars path above. No iteration today because
+    # zero-cost no-op is preferable to a per-slot loop that does nothing.
+
+    return new_messages, new_system

--- a/tests/test_m4_4_in_context_wiring.py
+++ b/tests/test_m4_4_in_context_wiring.py
@@ -1,0 +1,269 @@
+"""ADR-012 M4.4 — In-context slot wiring invariants.
+
+Pins:
+- ``apply_in_context_slots`` takes ``(messages, system=)`` and returns
+  ``(new_messages, new_system)``.
+- No-op fast path: when no SoT is configured, returns *identity*
+  (same objects, not just equal values) so per-call cost is zero.
+- exemplars slot wired: reads M3 few-shot pool, prepends top-K
+  ``(user, assistant)`` pairs at head of messages.
+- Per-slot graceful: a reader / apply failure on one slot doesn't
+  break the LLM call.
+- anthropic.py + openai.py agentic_call paths both invoke the
+  orchestrator (smoke check via import + grep-style source assertion).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+# No-op fast path ------------------------------------------------------------
+
+
+def test_no_sot_configured_returns_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No SoT → identical objects returned (zero allocation)."""
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: None,
+    )
+    msgs = [{"role": "user", "content": "hi"}]
+    new_msgs, new_sys = apply_in_context_slots(msgs, system="SYS")
+    assert new_msgs is msgs  # identity, not just equality
+    assert new_sys == "SYS"
+
+
+def test_empty_dict_slots_returns_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty dict from the reader → identity (truthiness check)."""
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {},
+    )
+    msgs = [{"role": "user", "content": "hi"}]
+    new_msgs, _ = apply_in_context_slots(msgs)
+    assert new_msgs is msgs
+
+
+def test_load_failure_returns_identity_and_swallows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reader exception → identity, no propagation (defensive)."""
+
+    def _boom() -> dict[str, Any]:
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        _boom,
+    )
+    msgs = [{"role": "user", "content": "hi"}]
+    new_msgs, _ = apply_in_context_slots(msgs)
+    assert new_msgs is msgs
+
+
+# exemplars slot — M3 substrate wired ---------------------------------------
+
+
+def test_exemplars_slot_prepends_few_shot_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When exemplars slot active + pool has entries → ``(user, assistant)``
+    pairs land at head of messages."""
+    from core.llm.few_shot_pool import FewShotExemplar
+    from core.self_improving_loop.in_context_slots import SLOT_EXEMPLARS, InContextSlot
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_EXEMPLARS: InContextSlot(
+                name=SLOT_EXEMPLARS,
+                max_entries=2,
+                rank_by="fitness_delta",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "core.llm.few_shot_pool._load_few_shot_pool_override",
+        lambda: [
+            FewShotExemplar(
+                user_msg="ex1_user",
+                assistant_msg="ex1_assistant",
+                fitness_delta=0.9,
+                source="petri",
+            ),
+            FewShotExemplar(
+                user_msg="ex2_user",
+                assistant_msg="ex2_assistant",
+                fitness_delta=0.7,
+                source="petri",
+            ),
+        ],
+    )
+    msgs = [{"role": "user", "content": "real"}]
+    new_msgs, _ = apply_in_context_slots(msgs)
+    # 2 exemplar pairs (4 messages) + the 1 real message = 5
+    assert len(new_msgs) == 5
+    assert new_msgs[0]["content"] == "ex1_user"
+    assert new_msgs[1]["content"] == "ex1_assistant"
+    assert new_msgs[2]["content"] == "ex2_user"
+    assert new_msgs[3]["content"] == "ex2_assistant"
+    assert new_msgs[4]["content"] == "real"
+
+
+def test_exemplars_slot_empty_pool_no_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    """exemplars slot configured but pool empty → messages unchanged."""
+    from core.self_improving_loop.in_context_slots import SLOT_EXEMPLARS, InContextSlot
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_EXEMPLARS: InContextSlot(
+                name=SLOT_EXEMPLARS,
+                max_entries=3,
+                rank_by="fitness_delta",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "core.llm.few_shot_pool._load_few_shot_pool_override",
+        lambda: None,
+    )
+    msgs = [{"role": "user", "content": "hi"}]
+    new_msgs, _ = apply_in_context_slots(msgs)
+    assert new_msgs == msgs
+
+
+def test_exemplars_slot_pool_failure_logged_not_raised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """exemplars reader exception → swallowed; other slots / call proceed."""
+    from core.self_improving_loop.in_context_slots import SLOT_EXEMPLARS, InContextSlot
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_EXEMPLARS: InContextSlot(
+                name=SLOT_EXEMPLARS,
+                max_entries=2,
+                rank_by="fitness_delta",
+                injection_point="system_prompt",
+            )
+        },
+    )
+
+    def _pool_boom() -> Any:
+        raise RuntimeError("synthetic pool failure")
+
+    monkeypatch.setattr("core.llm.few_shot_pool._load_few_shot_pool_override", _pool_boom)
+    msgs = [{"role": "user", "content": "real"}]
+    new_msgs, _ = apply_in_context_slots(msgs)
+    assert new_msgs == msgs  # unchanged after failure
+
+
+# System prompt passthrough --------------------------------------------------
+
+
+def test_system_passthrough_when_no_slot_targets_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    """exemplars only mutates messages, never system."""
+    from core.llm.few_shot_pool import FewShotExemplar
+    from core.self_improving_loop.in_context_slots import SLOT_EXEMPLARS, InContextSlot
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_EXEMPLARS: InContextSlot(
+                name=SLOT_EXEMPLARS,
+                max_entries=1,
+                rank_by="fitness_delta",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "core.llm.few_shot_pool._load_few_shot_pool_override",
+        lambda: [FewShotExemplar(user_msg="u", assistant_msg="a", fitness_delta=0.5, source="t")],
+    )
+    _, new_sys = apply_in_context_slots([], system="ORIG_SYSTEM")
+    assert new_sys == "ORIG_SYSTEM"
+
+
+# Provider wiring smoke ------------------------------------------------------
+
+
+def test_anthropic_agentic_call_imports_orchestrator() -> None:
+    """anthropic.py 의 agentic_call 본문 안에서 ``apply_in_context_slots`` import 가 일어남.
+
+    PR-M4.4 의 wiring claim 을 grep-provable 하게 pin.
+    """
+    import inspect
+
+    from core.llm.providers import anthropic as _anth
+
+    src = inspect.getsource(_anth.ClaudeAgenticAdapter.agentic_call)
+    assert "from core.self_improving_loop.in_context_wiring import apply_in_context_slots" in src
+    assert "apply_in_context_slots(messages, system=system)" in src
+
+
+def test_openai_agentic_call_imports_orchestrator() -> None:
+    """openai.py 의 agentic_call 도 같은 wiring path."""
+    import inspect
+
+    from core.llm.providers import openai as _oai
+
+    src = inspect.getsource(_oai.OpenAIAgenticAdapter.agentic_call)
+    assert "from core.self_improving_loop.in_context_wiring import apply_in_context_slots" in src
+    assert "apply_in_context_slots(messages, system=system)" in src
+
+
+def test_orchestrator_module_public_api() -> None:
+    """Only ``apply_in_context_slots`` is exported (single entry point)."""
+    import core.self_improving_loop.in_context_wiring as wiring
+
+    assert wiring.__all__ == ["apply_in_context_slots"]
+
+
+# Stub slots behave as no-ops ----------------------------------------------
+
+
+def test_stub_slots_do_not_break_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """memory_recall / rubric_excerpts / tool_hints active → no-op (no reader yet).
+
+    Verifies the orchestrator's iteration over stub slots doesn't raise
+    or mutate output; their readers land in follow-up PRs.
+    """
+    from core.self_improving_loop.in_context_slots import (
+        SLOT_MEMORY_RECALL,
+        SLOT_RUBRIC_EXCERPTS,
+        SLOT_TOOL_HINTS,
+        InContextSlot,
+    )
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_MEMORY_RECALL: InContextSlot(
+                name=SLOT_MEMORY_RECALL,
+                max_entries=5,
+                rank_by="recency",
+                injection_point="system_prompt",
+            ),
+            SLOT_RUBRIC_EXCERPTS: InContextSlot(
+                name=SLOT_RUBRIC_EXCERPTS,
+                max_entries=3,
+                rank_by="regression_severity",
+                injection_point="system_prompt",
+            ),
+            SLOT_TOOL_HINTS: InContextSlot(
+                name=SLOT_TOOL_HINTS,
+                max_entries=5,
+                rank_by="success_rate",
+                injection_point="tool_descriptions",
+            ),
+        },
+    )
+    msgs = [{"role": "user", "content": "hi"}]
+    new_msgs, new_sys = apply_in_context_slots(msgs, system="S")
+    assert new_msgs == msgs
+    assert new_sys == "S"


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/self_improving_loop/in_context_wiring.py` — S5 (#1425) 의 4-slot schema 와 M3 (#1426/#1428) 의 few-shot pool substrate 를 inference path 에 연결하는 orchestrator.
- Provider wiring 2지점 — `ClaudeAgenticAdapter.agentic_call` + `OpenAIAgenticAdapter.agentic_call` 의 매 호출이 orchestrator 통과.
- exemplars 슬롯은 실제 활성; memory_recall / rubric_excerpts / tool_hints 는 명시적 stub (reader 후속 PR).

## Why
M4 DPO sprint (M4.0~M4.3) 가 eval event → DPO pack writer → publisher → redaction/stats 을 끝냈지만, **마지막 1마일** — pack 의 결과 데이터가 *agentic loop 의 다음 호출에 실제로 반영* 되는 경로 — 가 없었음. M3 의 `apply_few_shot_pool` 도 schema 만 + 호출자 부재 deception 상태. M4.4 가 그 경로를 완성:
- Default operators (SoT 미설정): zero-overhead no-op (identity 반환)
- exemplars 옵트인: fitness-promoted top-K pair 가 system_prompt 직후 prepend
- Stub 3 슬롯: orchestrator iteration 자리만 마련, reader 1개씩 follow-up

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/in_context_wiring.py` | 신규 — `apply_in_context_slots(messages, system="")` orchestrator. fast-path identity + per-slot try/except + exemplars wired |
| `core/llm/providers/anthropic.py` | `ClaudeAgenticAdapter.agentic_call` 의 api-key 체크 직후 orchestrator 호출 |
| `core/llm/providers/openai.py` | `OpenAIAgenticAdapter.agentic_call` 의 circuit-breaker 체크 직후 orchestrator 호출 |
| `tests/test_m4_4_in_context_wiring.py` | 신규 — 11 invariant test |
| `CHANGELOG.md` | PR-M4.4 entry |

## Test inventory (11)
- no-op fast path × 3 (no SoT / 빈 dict / reader exception → identity)
- exemplars prepend (top-K 순서 + 본 messages 뒤로)
- exemplars 빈 pool no-op
- exemplars 실패 graceful (pool reader 예외 → unchanged)
- system prompt passthrough (exemplars 가 system 미수정)
- provider wiring smoke × 2 (`inspect.getsource` 로 anthropic + openai 의 `agentic_call` 본문에 import + 호출이 grep-provable)
- `__all__` minimal export (orchestrator 단일 entry)
- stub 슬롯 비-에러 (3 슬롯 active 시 orchestrator 가 no-op 처리)

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Orchestrator module already exists | No | `grep -rn "apply_in_context_slots" core/` returned 0 before PR |
| S5 substrate 재구현 | No | `_load_in_context_slots_override` import 로 재활용 — 단일 SoT |
| M3 substrate 재구현 | No | `_load_few_shot_pool_override` + `apply_few_shot_pool` import 로 재활용 |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter / AgentDefinition.model 미변경. anthropic/openai 의 `agentic_call` 본문은 **Tier 1** (LLM 호출 경로) — 변경하지만 default 동작은 identity 보장 |
| Stub 3 슬롯 honesty | Yes | CHANGELOG/PR/코드 모두 "stub" 으로 명시. 미래 PR 가 reader 한 개씩 추가 |

## Default behavior preservation
가장 중요한 invariant: SoT 미설정 (default GEODE) 인 operator 의 LLM 호출은 **byte-equal**.
- `_load_in_context_slots_override()` → `None` (no SoT file, no env var) → orchestrator 가 즉시 `(messages, system)` identity 반환
- anthropic.py/openai.py 의 호출 직후 `messages = messages; system = system` (참조 unchanged)
- API request body 변동 0

## Verification
- [x] `uv run ruff format` clean (auto-applied)
- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run mypy core/self_improving_loop/in_context_wiring.py core/llm/providers/anthropic.py core/llm/providers/openai.py` clean
- [x] `uv run pytest tests/test_m4_4_in_context_wiring.py -q` 11/11 PASS
- [x] No new `# type: ignore` / `# noqa`
- [x] Provider wiring grep-provable (test_anthropic + test_openai 가 `inspect.getsource` 로 confirm)

## Reference
- ADR-012 M4 DPO pipeline (M4.0 #1429 → M4.1 #1430 → M4.2 #1431 → M4.3 #1434 → **M4.4 본 PR** = sprint 종료)
- S5 #1425 — 4-slot schema declaration
- M3 #1426 (skill catalog mutation) + #1428 (few-shot pool reader) — substrate
- 후속: M4.4.1/2/3 = memory_recall / rubric_excerpts / tool_hints reader 추가