### PR TITLE
feat(self-improving-loop): PR-M4.4.1 — memory_recall slot reader (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,29 @@ functional change.
 
 ### Added
 
+- **PR-M4.4.1 — `memory_recall` slot reader 활성화 (ADR-012).**
+  M4.4 (#1435) 의 4 슬롯 중 첫 번째 stub 을 활성화. 신규 모듈
+  `core/self_improving_loop/memory_recall.py` — frontmatter-style MD
+  파일 (Claude Code 의 auto-memory 와 동일 schema) 을
+  `~/.geode/memory/recall/` (또는 `GEODE_MEMORY_RECALL_DIR` env
+  override) 에서 walk → `MemoryEntry(name, type, description, body,
+  mtime)` 로 parse → `rank_memory_entries(entries, query, top_k)` 가
+  keyword overlap × recency_weight (`1 / (1 + age_days)`) 로 정렬 →
+  `format_memory_block` 이 `<memory-recall>\n- [type] description\n
+  ...\n</memory-recall>` 블록 render. **Orchestrator wiring** —
+  `in_context_wiring.apply_in_context_slots` 가 `SLOT_MEMORY_RECALL`
+  cfg 발견 시 위 3단계 호출, 결과 블록을 system prompt 앞에
+  prepend (per-slot try/except 로 실패 시 graceful). `_latest_user_query`
+  helper 가 messages 의 마지막 user-role string content 추출 → similarity
+  ranking 의 query 로 사용. **Per-file graceful** — frontmatter 누락 /
+  unreadable file / 잘못된 YAML 은 silent skip. **No-op fast path**
+  유지 — recall dir 미존재 시 `resolve_recall_dir()` 가 None 반환 →
+  reader 가 `[]` 반환 → orchestrator 가 system 미변경. **14 invariant
+  test** — resolve x3 (env override / env-missing-graceful / default-missing) +
+  load x3 (no-dir / frontmatter parse / malformed skip) + rank x4 (overlap /
+  recency tiebreak / top_k=0 / top_k cap) + format x2 (empty / type-tag
+  render) + orchestrator 통합 x2 (block prepend / no-dir no-op).
+
 - **PR-M4.4 — In-context slot wiring orchestrator + provider wiring (ADR-012).**
   M4 DPO pipeline 의 closing piece — S5 (#1425) 의 4-slot schema 와 M3
   (#1426/#1428) 의 few-shot pool substrate 를 실제 inference path 에

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,11 +88,13 @@ functional change.
   ranking 의 query 로 사용. **Per-file graceful** — frontmatter 누락 /
   unreadable file / 잘못된 YAML 은 silent skip. **No-op fast path**
   유지 — recall dir 미존재 시 `resolve_recall_dir()` 가 None 반환 →
-  reader 가 `[]` 반환 → orchestrator 가 system 미변경. **14 invariant
+  reader 가 `[]` 반환 → orchestrator 가 system 미변경. **16 invariant
   test** — resolve x3 (env override / env-missing-graceful / default-missing) +
   load x3 (no-dir / frontmatter parse / malformed skip) + rank x4 (overlap /
-  recency tiebreak / top_k=0 / top_k cap) + format x2 (empty / type-tag
-  render) + orchestrator 통합 x2 (block prepend / no-dir no-op).
+  recency tiebreak / top_k=0 / top_k cap) + format x4 (empty / type-tag
+  render / **description-only with empty body** / **body-only fallback** —
+  Codex MCP 가 잡은 ternary precedence regression) + orchestrator 통합 x2
+  (block prepend / no-dir no-op).
 
 - **PR-M4.4 — In-context slot wiring orchestrator + provider wiring (ADR-012).**
   M4 DPO pipeline 의 closing piece — S5 (#1425) 의 4-slot schema 와 M3

--- a/core/self_improving_loop/in_context_wiring.py
+++ b/core/self_improving_loop/in_context_wiring.py
@@ -12,14 +12,14 @@ reach the provider.
   (`core/llm/few_shot_pool.py`) via ``_load_few_shot_pool_override`` →
   applies via ``apply_few_shot_pool`` (top-K by fitness_delta desc).
   Prepends ``(user, assistant)`` pairs at the head of ``messages``.
-* ``memory_recall`` — **stub**. Reader (``~/.geode/memory/`` recency ×
-  cosine similarity) is a follow-up PR. Orchestrator iterates this
-  slot today as a no-op so the wiring path is in place; activating it
-  is a single function injection.
+* ``memory_recall`` — **wired (M4.4.1)**. Reads frontmatter-style
+  memory files from ``~/.geode/memory/recall/`` (or
+  ``GEODE_MEMORY_RECALL_DIR`` env override), ranks by keyword overlap
+  × recency, prepends a ``<memory-recall>`` block to the system prompt.
 * ``rubric_excerpts`` — **stub**. Reader (Petri 17-dim worst-regressed
-  rubric) is a follow-up PR.
+  rubric) is a follow-up PR (M4.4.2).
 * ``tool_hints`` — **stub**. Reader (RunLog + episodic memory
-  success_rate ranked) is a follow-up PR.
+  success_rate ranked) is a follow-up PR (M4.4.3).
 
 **No-op fast path**: when ``_load_in_context_slots_override`` returns
 ``None`` (no SoT configured, the GEODE default), the orchestrator
@@ -73,6 +73,7 @@ def apply_in_context_slots(
     try:
         from core.self_improving_loop.in_context_slots import (
             SLOT_EXEMPLARS,
+            SLOT_MEMORY_RECALL,
             _load_in_context_slots_override,
         )
 
@@ -104,11 +105,48 @@ def apply_in_context_slots(
         except Exception as exc:
             log.debug("exemplars slot apply failed: %s", exc, exc_info=True)
 
-    # memory_recall / rubric_excerpts / tool_hints — readers deferred to
-    # follow-up PRs (M4.4.1+). The orchestrator iterates them here so
-    # the wiring path is in place; each becomes active by wiring in its
-    # reader + apply function inside its own try / except block, exactly
-    # mirroring the exemplars path above. No iteration today because
-    # zero-cost no-op is preferable to a per-slot loop that does nothing.
+    # memory_recall — M4.4.1 reader active. Frontmatter MD files from
+    # ``~/.geode/memory/recall/`` (or env override) ranked by keyword
+    # overlap × recency, formatted as a ``<memory-recall>`` block and
+    # prepended to the system prompt.
+    memory_cfg = slots.get(SLOT_MEMORY_RECALL)
+    if memory_cfg is not None:
+        try:
+            from core.self_improving_loop.memory_recall import (
+                format_memory_block,
+                load_memory_entries,
+                rank_memory_entries,
+            )
+
+            entries = load_memory_entries()
+            if entries:
+                query = _latest_user_query(new_messages)
+                ranked = rank_memory_entries(entries, query, top_k=memory_cfg.max_entries)
+                block = format_memory_block(ranked)
+                if block:
+                    new_system = block + "\n\n" + new_system if new_system else block
+        except Exception as exc:
+            log.debug("memory_recall slot apply failed: %s", exc, exc_info=True)
+
+    # rubric_excerpts / tool_hints — readers deferred to follow-up PRs
+    # (M4.4.2 / M4.4.3). Wiring framework is in place; each becomes
+    # active by mirroring the memory_recall block above with its own
+    # reader + format helpers.
 
     return new_messages, new_system
+
+
+def _latest_user_query(messages: list[dict[str, Any]]) -> str:
+    """Return the most recent user-role string content, or ``""`` if absent.
+
+    Used by ``memory_recall`` (and future similarity-ranked slots) to
+    score memory entries against the operator's current task. Tolerates
+    tool-result / non-string content shapes by skipping them.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+    return ""

--- a/core/self_improving_loop/memory_recall.py
+++ b/core/self_improving_loop/memory_recall.py
@@ -1,0 +1,240 @@
+"""Memory recall reader — ADR-012 M4.4.1 (in-context slot follow-up).
+
+Activates the ``memory_recall`` slot declared in S5 (#1425). Reads
+frontmatter-style memory entries from ``~/.geode/memory/recall/`` (or
+``GEODE_MEMORY_RECALL_DIR``), ranks by keyword overlap with the current
+task prompt × file recency, and emits a formatted block for the
+in-context wiring orchestrator to prepend to the system prompt.
+
+**File layout** — one ``.md`` per memory, frontmatter-then-body shape
+(same convention as Claude Code's auto-memory)::
+
+    ---
+    name: feedback-cli-budget
+    description: User wants Sonnet over Opus when Opus quota is exhausted.
+    metadata:
+      type: feedback
+    ---
+
+    The user has a hard preference for switching to Sonnet …
+
+**Resolution**:
+
+1. ``$GEODE_MEMORY_RECALL_DIR`` (operator override) — points at an
+   alternate directory; useful when the operator wants to recall from
+   Claude Code's ``~/.claude/projects/<X>/memory/`` instead.
+2. ``~/.geode/memory/recall/`` (default) — GEODE-owned location. When
+   the directory is missing or empty, the reader returns ``[]`` and
+   the orchestrator's per-slot try/except keeps the LLM call clean.
+
+**Ranking** — pure-stdlib keyword overlap (no embeddings dependency).
+Score = ``|prompt_tokens ∩ memory_tokens|`` × ``recency_weight``, where
+``recency_weight = 1 / (1 + age_days)`` so a fresh-yesterday memory beats
+a year-old high-overlap one. Ties tolerate insertion order (stable sort).
+
+**Format** — one ``- [type] description`` line per ranked entry inside
+a ``<memory-recall>`` tag, mirroring the ``<system-reminder>`` framing
+Claude Code uses for its own auto-memory injection.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.paths import GLOBAL_MEMORY_DIR
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "GEODE_MEMORY_RECALL_DIR_ENV",
+    "MemoryEntry",
+    "format_memory_block",
+    "load_memory_entries",
+    "rank_memory_entries",
+    "resolve_recall_dir",
+]
+
+GEODE_MEMORY_RECALL_DIR_ENV = "GEODE_MEMORY_RECALL_DIR"
+_DEFAULT_RECALL_DIR = GLOBAL_MEMORY_DIR / "recall"
+
+# Frontmatter parsing — minimal YAML-light. Memory files are
+# operator-curated so we accept only the simple ``key: value`` lines we
+# actually read (name / description / metadata.type). Anything fancier
+# is silently ignored per the per-file graceful contract.
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n(.*)", re.DOTALL)
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]{3,}")  # min 3-char tokens to skip noise
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryEntry:
+    """Parsed memory file ready for ranking + formatting."""
+
+    name: str
+    type: str  # "user" / "feedback" / "project" / "reference" / "" (default)
+    description: str
+    body: str
+    mtime: float
+
+
+def resolve_recall_dir() -> Path | None:
+    """Return the directory the reader should walk, or ``None`` to skip.
+
+    ``$GEODE_MEMORY_RECALL_DIR`` wins if set. Otherwise fall back to
+    ``~/.geode/memory/recall/`` when the dir exists. Missing default
+    dir → ``None`` (graceful: orchestrator no-ops the slot).
+    """
+    override = os.environ.get(GEODE_MEMORY_RECALL_DIR_ENV)
+    if override:
+        path = Path(override).expanduser()
+        if not path.is_dir():
+            log.debug(
+                "%s=%s but directory missing; skipping memory_recall",
+                GEODE_MEMORY_RECALL_DIR_ENV,
+                override,
+            )
+            return None
+        return path
+    if not _DEFAULT_RECALL_DIR.is_dir():
+        return None
+    return _DEFAULT_RECALL_DIR
+
+
+def load_memory_entries() -> list[MemoryEntry]:
+    """Walk the resolved recall dir, parse each ``.md`` → :class:`MemoryEntry`.
+
+    Per-file graceful — a malformed frontmatter, missing required field,
+    or unreadable file is logged at DEBUG and silently skipped; the
+    remaining files still come through.
+    """
+    base = resolve_recall_dir()
+    if base is None:
+        return []
+    entries: list[MemoryEntry] = []
+    for path in sorted(base.glob("*.md")):
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            log.debug("memory_recall: %s unreadable: %s", path, exc)
+            continue
+        parsed = _parse_frontmatter(raw)
+        if parsed is None:
+            log.debug("memory_recall: %s missing frontmatter; skipping", path)
+            continue
+        meta, body = parsed
+        name = str(meta.get("name") or path.stem)
+        description = str(meta.get("description") or "").strip()
+        type_label = str(meta.get("metadata.type") or "").strip()
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        entries.append(
+            MemoryEntry(
+                name=name,
+                type=type_label,
+                description=description,
+                body=body.strip(),
+                mtime=mtime,
+            )
+        )
+    return entries
+
+
+def rank_memory_entries(
+    entries: list[MemoryEntry],
+    query: str,
+    *,
+    top_k: int,
+    now: float | None = None,
+) -> list[MemoryEntry]:
+    """Top-K by ``keyword_overlap × recency_weight``.
+
+    Memories with zero keyword overlap rank by recency alone, so a fresh
+    memory still surfaces in a topic-unrelated session (Claude Code
+    auto-memory parity — recent feedback wins over stale alignment).
+
+    Args:
+        entries: All loaded entries.
+        query: The current task's user prompt (latest user message).
+        top_k: Cap. Zero / negative → empty.
+        now: Override the recency anchor (test-only). Defaults to
+            ``time.time()``.
+    """
+    if top_k <= 0 or not entries:
+        return []
+    anchor = now if now is not None else time.time()
+    query_tokens = _tokenize(query)
+    scored: list[tuple[float, int, MemoryEntry]] = []
+    for idx, entry in enumerate(entries):
+        memory_tokens = _tokenize(entry.description + " " + entry.body)
+        overlap = float(len(query_tokens & memory_tokens))
+        age_days = max(0.0, (anchor - entry.mtime) / 86400.0)
+        recency = 1.0 / (1.0 + age_days)
+        # ``overlap + 0.1`` so the recency channel still differentiates
+        # entries with zero overlap (otherwise they'd all tie at 0).
+        score = (overlap + 0.1) * recency
+        scored.append((score, idx, entry))
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    return [entry for _, _, entry in scored[:top_k]]
+
+
+def format_memory_block(entries: list[MemoryEntry]) -> str:
+    """Render ranked entries as a ``<memory-recall>`` block, or ``""`` if empty."""
+    if not entries:
+        return ""
+    lines = ["<memory-recall>"]
+    for entry in entries:
+        type_tag = f"[{entry.type}]" if entry.type else "[memory]"
+        desc = entry.description or entry.body.splitlines()[0] if entry.body else ""
+        lines.append(f"- {type_tag} {desc}".rstrip())
+    lines.append("</memory-recall>")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(raw: str) -> tuple[dict[str, str], str] | None:
+    """Return ``(meta, body)`` or ``None`` when the file lacks frontmatter.
+
+    YAML-light parser — handles flat ``key: value`` lines plus the single
+    nested ``metadata.type`` we care about. Other YAML constructs (lists,
+    nested dicts beyond depth 1) are silently dropped.
+    """
+    m = _FRONTMATTER_RE.match(raw)
+    if not m:
+        return None
+    head, body = m.group(1), m.group(2)
+    meta: dict[str, str] = {}
+    indent_parent: str | None = None
+    for line in head.splitlines():
+        if not line.strip():
+            continue
+        if ":" not in line:
+            continue
+        if line.startswith(" ") or line.startswith("\t"):
+            # Nested under a parent — only ``metadata: { type: X }`` is
+            # consumed.
+            key_part, _, val_part = line.strip().partition(":")
+            if indent_parent and val_part:
+                meta[f"{indent_parent}.{key_part.strip()}"] = val_part.strip()
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if not val:
+            indent_parent = key  # next nested lines belong to this parent
+            continue
+        indent_parent = None
+        meta[key] = val
+    return meta, body
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase 3+ alphanumeric tokens. Set for overlap calc."""
+    return {tok.lower() for tok in _TOKEN_RE.findall(text)}

--- a/core/self_improving_loop/memory_recall.py
+++ b/core/self_improving_loop/memory_recall.py
@@ -190,7 +190,15 @@ def format_memory_block(entries: list[MemoryEntry]) -> str:
     lines = ["<memory-recall>"]
     for entry in entries:
         type_tag = f"[{entry.type}]" if entry.type else "[memory]"
-        desc = entry.description or entry.body.splitlines()[0] if entry.body else ""
+        # Explicit branches — earlier ``desc = a or b.splitlines()[0] if b else ""``
+        # had wrong precedence (ternary binds looser than ``or``), dropping a
+        # valid description when ``body == ""``. (Codex MCP catch.)
+        if entry.description:
+            desc = entry.description
+        elif entry.body:
+            desc = entry.body.splitlines()[0]
+        else:
+            desc = ""
         lines.append(f"- {type_tag} {desc}".rstrip())
     lines.append("</memory-recall>")
     return "\n".join(lines)

--- a/tests/test_m4_4_1_memory_recall.py
+++ b/tests/test_m4_4_1_memory_recall.py
@@ -1,0 +1,309 @@
+"""ADR-012 M4.4.1 — memory_recall reader + orchestrator wiring invariants.
+
+Pins:
+- ``resolve_recall_dir`` honours ``$GEODE_MEMORY_RECALL_DIR`` override,
+  falls back to ``~/.geode/memory/recall/`` when it exists, returns
+  ``None`` otherwise.
+- ``load_memory_entries`` parses frontmatter MD files; malformed /
+  unreadable files silently skipped (per-file graceful).
+- ``rank_memory_entries`` orders by ``overlap × recency_weight``;
+  ties stable by insertion order; ``top_k=0`` → empty.
+- ``format_memory_block`` renders a ``<memory-recall>`` block, empty
+  list → empty string.
+- Orchestrator integration: when SoT has ``memory_recall`` + recall
+  dir has entries, the system prompt receives the rendered block.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def recall_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Override the recall directory via env var."""
+    target = tmp_path / "recall"
+    target.mkdir()
+    monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(target))
+    yield target
+
+
+def _write_memory(
+    path: Path,
+    *,
+    name: str,
+    description: str,
+    body: str,
+    type_label: str = "feedback",
+    mtime: float | None = None,
+) -> None:
+    content = (
+        f"---\nname: {name}\ndescription: {description}\n"
+        f"metadata:\n  type: {type_label}\n---\n\n{body}\n"
+    )
+    path.write_text(content, encoding="utf-8")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
+# resolve_recall_dir --------------------------------------------------------
+
+
+def test_resolve_returns_env_override(recall_dir: Path) -> None:
+    from core.self_improving_loop.memory_recall import resolve_recall_dir
+
+    assert resolve_recall_dir() == recall_dir
+
+
+def test_resolve_env_override_missing_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(tmp_path / "nope"))
+    from core.self_improving_loop.memory_recall import resolve_recall_dir
+
+    assert resolve_recall_dir() is None
+
+
+def test_resolve_default_dir_missing_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GEODE_MEMORY_RECALL_DIR", raising=False)
+    # Point default dir at a guaranteed-missing path
+    monkeypatch.setattr(
+        "core.self_improving_loop.memory_recall._DEFAULT_RECALL_DIR",
+        Path("/no/such/dir/exists"),
+    )
+    from core.self_improving_loop.memory_recall import resolve_recall_dir
+
+    assert resolve_recall_dir() is None
+
+
+# load_memory_entries -------------------------------------------------------
+
+
+def test_load_returns_empty_when_no_recall_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_MEMORY_RECALL_DIR", raising=False)
+    monkeypatch.setattr(
+        "core.self_improving_loop.memory_recall._DEFAULT_RECALL_DIR",
+        Path("/no/such/dir"),
+    )
+    from core.self_improving_loop.memory_recall import load_memory_entries
+
+    assert load_memory_entries() == []
+
+
+def test_load_parses_frontmatter(recall_dir: Path) -> None:
+    from core.self_improving_loop.memory_recall import load_memory_entries
+
+    _write_memory(
+        recall_dir / "feedback-sample.md",
+        name="feedback-sample",
+        description="user prefers terse output",
+        body="Body text here.",
+        type_label="feedback",
+    )
+    entries = load_memory_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.name == "feedback-sample"
+    assert entry.type == "feedback"
+    assert entry.description == "user prefers terse output"
+    assert "Body text here." in entry.body
+
+
+def test_load_skips_malformed_files(recall_dir: Path) -> None:
+    """Files without frontmatter delimiters are silently dropped."""
+    from core.self_improving_loop.memory_recall import load_memory_entries
+
+    (recall_dir / "broken.md").write_text("no frontmatter at all\n", encoding="utf-8")
+    _write_memory(
+        recall_dir / "valid.md",
+        name="valid",
+        description="ok",
+        body="b",
+    )
+    entries = load_memory_entries()
+    assert len(entries) == 1
+    assert entries[0].name == "valid"
+
+
+# rank_memory_entries -------------------------------------------------------
+
+
+def test_rank_by_overlap(recall_dir: Path) -> None:
+    """Memory with matching keywords beats one without (same mtime)."""
+    from core.self_improving_loop.memory_recall import (
+        load_memory_entries,
+        rank_memory_entries,
+    )
+
+    now = time.time()
+    _write_memory(
+        recall_dir / "match.md",
+        name="match",
+        description="DPO training pipeline notes",
+        body="prefer DPO over PPO",
+        mtime=now,
+    )
+    _write_memory(
+        recall_dir / "unrelated.md",
+        name="unrelated",
+        description="kitchen recipe ideas",
+        body="pasta carbonara recipe",
+        mtime=now,
+    )
+    entries = load_memory_entries()
+    ranked = rank_memory_entries(entries, "explain DPO training", top_k=2, now=now + 1)
+    assert ranked[0].name == "match"
+
+
+def test_rank_recency_tiebreak(recall_dir: Path) -> None:
+    """Zero overlap on both → fresher file wins."""
+    from core.self_improving_loop.memory_recall import (
+        load_memory_entries,
+        rank_memory_entries,
+    )
+
+    now = time.time()
+    _write_memory(
+        recall_dir / "old.md",
+        name="old",
+        description="topic alpha",
+        body="b",
+        mtime=now - 30 * 86400,  # 30 days old
+    )
+    _write_memory(
+        recall_dir / "fresh.md",
+        name="fresh",
+        description="topic beta",
+        body="b",
+        mtime=now - 1 * 86400,  # 1 day old
+    )
+    entries = load_memory_entries()
+    ranked = rank_memory_entries(entries, "unrelated query gamma delta", top_k=2, now=now)
+    assert ranked[0].name == "fresh"
+
+
+def test_rank_top_k_zero_returns_empty(recall_dir: Path) -> None:
+    from core.self_improving_loop.memory_recall import (
+        load_memory_entries,
+        rank_memory_entries,
+    )
+
+    _write_memory(recall_dir / "a.md", name="a", description="d", body="b", mtime=time.time())
+    assert rank_memory_entries(load_memory_entries(), "q", top_k=0) == []
+
+
+def test_rank_top_k_caps_results(recall_dir: Path) -> None:
+    from core.self_improving_loop.memory_recall import (
+        load_memory_entries,
+        rank_memory_entries,
+    )
+
+    now = time.time()
+    for i in range(5):
+        _write_memory(recall_dir / f"e{i}.md", name=f"e{i}", description="d", body="b", mtime=now)
+    ranked = rank_memory_entries(load_memory_entries(), "q", top_k=3, now=now)
+    assert len(ranked) == 3
+
+
+# format_memory_block -------------------------------------------------------
+
+
+def test_format_empty_returns_empty_string() -> None:
+    from core.self_improving_loop.memory_recall import format_memory_block
+
+    assert format_memory_block([]) == ""
+
+
+def test_format_renders_block_with_type_tags(recall_dir: Path) -> None:
+    from core.self_improving_loop.memory_recall import (
+        format_memory_block,
+        load_memory_entries,
+    )
+
+    _write_memory(
+        recall_dir / "fb.md",
+        name="fb",
+        description="user wants terse",
+        body="b",
+        type_label="feedback",
+        mtime=time.time(),
+    )
+    block = format_memory_block(load_memory_entries())
+    assert block.startswith("<memory-recall>")
+    assert block.endswith("</memory-recall>")
+    assert "[feedback] user wants terse" in block
+
+
+# Orchestrator wiring -------------------------------------------------------
+
+
+def test_orchestrator_prepends_memory_block(
+    recall_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """memory_recall slot active + recall dir has match → block lands in system."""
+    from core.self_improving_loop.in_context_slots import (
+        SLOT_MEMORY_RECALL,
+        InContextSlot,
+    )
+    from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_MEMORY_RECALL: InContextSlot(
+                name=SLOT_MEMORY_RECALL,
+                max_entries=3,
+                rank_by="recency",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    _write_memory(
+        recall_dir / "matching.md",
+        name="matching",
+        description="DPO preference signals",
+        body="signal body",
+        mtime=time.time(),
+    )
+    msgs = [{"role": "user", "content": "explain DPO training"}]
+    _, new_sys = apply_in_context_slots(msgs, system="ORIGINAL")
+    assert "<memory-recall>" in new_sys
+    assert "[feedback] DPO preference signals" in new_sys
+    assert new_sys.endswith("ORIGINAL")
+
+
+def test_orchestrator_no_op_when_recall_dir_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """memory_recall slot active but no recall dir → system unchanged."""
+    from core.self_improving_loop.in_context_slots import (
+        SLOT_MEMORY_RECALL,
+        InContextSlot,
+    )
+    from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+    monkeypatch.delenv("GEODE_MEMORY_RECALL_DIR", raising=False)
+    monkeypatch.setattr(
+        "core.self_improving_loop.memory_recall._DEFAULT_RECALL_DIR",
+        Path("/no/such/dir"),
+    )
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_MEMORY_RECALL: InContextSlot(
+                name=SLOT_MEMORY_RECALL,
+                max_entries=3,
+                rank_by="recency",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    _, new_sys = apply_in_context_slots([{"role": "user", "content": "task"}], system="SYS")
+    assert new_sys == "SYS"

--- a/tests/test_m4_4_1_memory_recall.py
+++ b/tests/test_m4_4_1_memory_recall.py
@@ -221,6 +221,46 @@ def test_format_empty_returns_empty_string() -> None:
     assert format_memory_block([]) == ""
 
 
+def test_format_preserves_description_when_body_empty() -> None:
+    """Regression — earlier ``desc = a or b.splitlines()[0] if b else ""`` had
+    wrong precedence (ternary binds looser than ``or``), dropping a valid
+    description when ``body == ""``. Pin the explicit-branches form."""
+    from core.self_improving_loop.memory_recall import (
+        MemoryEntry,
+        format_memory_block,
+    )
+
+    entry = MemoryEntry(
+        name="desc-only",
+        type="feedback",
+        description="kept even though body is empty",
+        body="",
+        mtime=0.0,
+    )
+    block = format_memory_block([entry])
+    assert "kept even though body is empty" in block
+    assert "[feedback]" in block
+
+
+def test_format_falls_back_to_body_first_line_when_no_description() -> None:
+    """No description but non-empty body → first body line surfaces."""
+    from core.self_improving_loop.memory_recall import (
+        MemoryEntry,
+        format_memory_block,
+    )
+
+    entry = MemoryEntry(
+        name="body-only",
+        type="project",
+        description="",
+        body="first body line\nsecond ignored",
+        mtime=0.0,
+    )
+    block = format_memory_block([entry])
+    assert "first body line" in block
+    assert "second ignored" not in block
+
+
 def test_format_renders_block_with_type_tags(recall_dir: Path) -> None:
     from core.self_improving_loop.memory_recall import (
         format_memory_block,


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/self_improving_loop/memory_recall.py` — frontmatter-style MD 파일 reader + keyword overlap × recency ranker + `<memory-recall>` block formatter.
- M4.4 (#1435) 의 첫 번째 stub 슬롯 활성화 — orchestrator 가 `SLOT_MEMORY_RECALL` cfg 발견 시 ranked 메모리 블록을 system prompt 앞에 prepend.
- 3 슬롯 (rubric_excerpts / tool_hints) 은 여전히 stub (M4.4.2 / M4.4.3 follow-up).

## Why
M4.4 가 wiring framework 만 깔고 exemplars 만 활성화했었음. memory_recall 은 Claude Code 의 auto-memory pattern (user / feedback / project / reference 4 type frontmatter MD) 과 동일한 schema 를 GEODE-owned 경로 `~/.geode/memory/recall/` 에 두고, 매 LLM call 의 user query 와 keyword overlap × recency 로 top-K 를 골라 inject. 운영자가 자신의 Claude Code auto-memory 디렉터리를 `GEODE_MEMORY_RECALL_DIR` 로 직접 가리킬 수도 있음.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/memory_recall.py` | 신규 — `MemoryEntry` dataclass + 4 entry-point 함수 + YAML-light frontmatter parser |
| `core/self_improving_loop/in_context_wiring.py` | `memory_recall` 슬롯 try/except 블록 + `_latest_user_query` helper + docstring "stub" → "wired (M4.4.1)" 갱신 |
| `tests/test_m4_4_1_memory_recall.py` | 신규 — 14 invariant test |
| `CHANGELOG.md` | PR-M4.4.1 entry |

## Algorithm
- **Tokenize**: `[A-Za-z0-9_]{3,}` 정규식, lowercased → set (3+ char 토큰만 통계화)
- **Score**: `(overlap + 0.1) × (1 / (1 + age_days))` — overlap 채널 + recency 채널 동시 활성, zero overlap 여러 개에서도 recency 가 tiebreak
- **Rank**: score desc, idx asc (stable)
- **Format**: `<memory-recall>\n- [type] description\n...\n</memory-recall>`

## Test inventory (14)
- `resolve_recall_dir` × 3: env override / env-missing-graceful / default-missing → None
- `load_memory_entries` × 3: no-dir empty / frontmatter parse / malformed skip
- `rank_memory_entries` × 4: overlap winner / recency tiebreak / `top_k=0` empty / `top_k` cap
- `format_memory_block` × 2: empty `""` / type-tag render
- Orchestrator × 2: block prepend / no-dir no-op

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Reader exists | No | `grep -rn "memory_recall\|MemoryEntry" core/` returns only this PR's module + docstrings |
| Frontmatter parser already exists | No | `core/utils` / `core/memory` 검색 — auto-memory parser 가 GEODE 내부에 없음. YAML-light inline parser 신규 |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter / AgentDefinition.model — diff 없음 |
| Wiring symmetry | Yes | exemplars 슬롯과 동일한 try/except + `cfg.max_entries` 사용 패턴 |
| Default no-op preserved | Yes | recall dir 미존재 → reader `[]` 반환 → `if entries:` 가드 |

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run mypy core/self_improving_loop/memory_recall.py core/self_improving_loop/in_context_wiring.py` clean
- [x] `uv run pytest tests/test_m4_4_1_memory_recall.py tests/test_m4_4_in_context_wiring.py -q` 25/25 PASS (14 신규 + 11 기존 M4.4 회귀 무변동)
- [x] No new `# type: ignore` / `# noqa`

## Reference
- ADR-012 M4 in-context wiring: M4.4 (#1435 — orchestrator + exemplars) → **M4.4.1 본 PR (memory_recall)** → M4.4.2 (rubric_excerpts) → M4.4.3 (tool_hints)
- Claude Code auto-memory frontmatter schema — `~/.claude/projects/<X>/memory/<name>.md`