### PR TITLE
feat(self-improving-loop): PR-M4.4.3 — tool_hints slot + M4 sprint closure (ADR-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,31 @@ functional change.
 
 ### Added
 
+- **PR-M4.4.3 — `tool_hints` slot reader 활성화 + M4 sprint 종료 (ADR-012).**
+  M4.4 (#1435) 의 마지막 stub 활성화 — **모든 4 in-context slot 이제
+  완전 wired**. 신규 모듈 `core/self_improving_loop/tool_hints.py` —
+  `~/.geode/memory/episodes.jsonl` (episodic ledger, `core.memory.episodic.EpisodicStore`
+  populates) 를 `RECENT_WINDOW=200` 범위로 읽어 per-tool 집계 →
+  `MIN_INVOCATIONS=3` + `FAIL_RATE_THRESHOLD=0.34` 동시 통과 tool 만
+  surface → `fail_rate desc, total desc` 정렬 → top-K → `<tool-hints>`
+  block 으로 system prompt 앞에 prepend. 각 tool 의 *가장 최근*
+  non-empty error 캡쳐 (episodes 가 newest-first 이라 dict 첫 진입이
+  recent), 80자 + ellipsis trim. **Frontier signal**: `stuck_in_loops`
+  / `redundant_tool_invocation` 라벨이 punish 하는 패턴을 *그 자체로
+  in-context prevention* — agent 가 "Bash 가 최근 3번 실패했네" 보고
+  다른 전략 선택 가능. **Graceful** — `EpisodicStore` import 실패 /
+  ledger 없음 / read error / non-str tool_name 모두 silent skip.
+  **18 invariant test** — `load_recent_episodes` x2 (store 실패 /
+  성공) + `find_failing_tools` x8 (top_k=0 / min_invocations cap /
+  fail_rate threshold / surface / most-recent-error 캡쳐 / desc sort
+  + tiebreak / top_k cap / non-str tool_name skip / 80-char trim) +
+  `format_tool_hints_block` x3 (empty / with-error / without-error) +
+  orchestrator x2 (block prepend / no-failing no-op). **M4 sprint
+  종료** — M4.0 (#1429 event) → M4.1 (#1430 pack) → M4.2 (#1431
+  publisher) → M4.3 (#1434 redaction/stats) → M4.4 (#1435 orchestrator) →
+  M4.4.1 (#1436 memory_recall) → M4.4.2 (#1437 rubric_excerpts) →
+  **M4.4.3 본 PR (tool_hints + closure)**.
+
 - **PR-M4.4.2 — `rubric_excerpts` slot reader 활성화 (ADR-012).**
   M4.4 (#1435) 의 두 번째 stub 슬롯 활성화. 신규 모듈
   `core/self_improving_loop/rubric_excerpts.py` —

--- a/core/self_improving_loop/in_context_wiring.py
+++ b/core/self_improving_loop/in_context_wiring.py
@@ -21,8 +21,11 @@ reach the provider.
   dim_means > 0``), formats a ``<rubric-warning>`` block with the
   built-in 17-dim ``DIM_RUBRIC`` directive for each, and prepends to
   the system prompt.
-* ``tool_hints`` — **stub**. Reader (RunLog + episodic memory
-  success_rate ranked) is a follow-up PR (M4.4.3).
+* ``tool_hints`` — **wired (M4.4.3)**. Reads the episodic ledger
+  (``~/.geode/memory/episodes.jsonl``), aggregates per-tool fail
+  rate over a rolling window, and prepends a ``<tool-hints>`` block
+  for tools whose recent calls have been failing above the threshold.
+  Closes the M4 sprint — all 4 in-context slots now active.
 
 **No-op fast path**: when ``_load_in_context_slots_override`` returns
 ``None`` (no SoT configured, the GEODE default), the orchestrator
@@ -78,6 +81,7 @@ def apply_in_context_slots(
             SLOT_EXEMPLARS,
             SLOT_MEMORY_RECALL,
             SLOT_RUBRIC_EXCERPTS,
+            SLOT_TOOL_HINTS,
             _load_in_context_slots_override,
         )
 
@@ -153,9 +157,27 @@ def apply_in_context_slots(
         except Exception as exc:
             log.debug("rubric_excerpts slot apply failed: %s", exc, exc_info=True)
 
-    # tool_hints — reader deferred to follow-up PR (M4.4.3). Wiring
-    # framework is in place; activation mirrors the rubric_excerpts
-    # block above.
+    # tool_hints — M4.4.3 reader active. Reads episodic ledger,
+    # aggregates per-tool fail_rate, prepends a ``<tool-hints>`` block
+    # for tools failing above the threshold. Closes the M4 sprint —
+    # all 4 in-context slots now wired.
+    tool_hints_cfg = slots.get(SLOT_TOOL_HINTS)
+    if tool_hints_cfg is not None:
+        try:
+            from core.self_improving_loop.tool_hints import (
+                find_failing_tools,
+                format_tool_hints_block,
+                load_recent_episodes,
+            )
+
+            episodes = load_recent_episodes()
+            if episodes:
+                hints = find_failing_tools(episodes, top_k=tool_hints_cfg.max_entries)
+                block = format_tool_hints_block(hints)
+                if block:
+                    new_system = block + "\n\n" + new_system if new_system else block
+        except Exception as exc:
+            log.debug("tool_hints slot apply failed: %s", exc, exc_info=True)
 
     return new_messages, new_system
 

--- a/core/self_improving_loop/tool_hints.py
+++ b/core/self_improving_loop/tool_hints.py
@@ -1,0 +1,176 @@
+"""Tool hints reader — ADR-012 M4.4.3 (in-context slot final follow-up).
+
+Activates the ``tool_hints`` slot declared in S5 (#1425). Reads the
+episodic action-outcome ledger at
+``~/.geode/memory/episodes.jsonl`` (populated by every tool execution
+via :class:`core.memory.episodic.EpisodicStore`), aggregates per-tool
+success rates over a rolling window, and emits a ``<tool-hints>``
+block warning the agent about tools whose recent calls have been
+failing.
+
+**Signal**: an agent that keeps re-invoking a tool that's been
+returning ``success=False`` is "stuck in a loop" — exactly the
+``stuck_in_loops`` and ``redundant_tool_invocation`` failure modes the
+audit rubric punishes. Surfacing the recent failure rate as in-context
+context lets the next turn pick a different strategy.
+
+**Data path**:
+
+1. Read up to ``RECENT_WINDOW`` (default 200) most-recent episodes.
+2. Group by ``tool_name``. For each tool, compute ``fails / total``
+   and capture the most-recent non-empty ``error`` string.
+3. Filter to tools meeting BOTH ``total >= MIN_INVOCATIONS`` (default
+   3 — single failure is noise) AND ``fail_rate >= FAIL_RATE_THRESHOLD``
+   (default 0.34 — at least 1-in-3 calls failing).
+4. Sort by ``fail_rate`` desc, tiebreak by ``total`` desc (more data
+   = stronger signal).
+5. Cap at ``InContextSlot.max_entries``.
+6. Render one ``- [tool_name] N/M failed; recent error: <head>`` line
+   per tool inside a ``<tool-hints>`` tag.
+
+**Graceful**: missing ``episodes.jsonl`` → empty result. Malformed
+rows are silently dropped (per-row try/except inside ``EpisodicStore.recent``).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "FAIL_RATE_THRESHOLD",
+    "MIN_INVOCATIONS",
+    "RECENT_WINDOW",
+    "ToolHint",
+    "find_failing_tools",
+    "format_tool_hints_block",
+    "load_recent_episodes",
+]
+
+RECENT_WINDOW = 200
+"""How many of the most-recent episodes the reader inspects per LLM call."""
+
+MIN_INVOCATIONS = 3
+"""Minimum calls a tool needs in the window before its fail_rate counts."""
+
+FAIL_RATE_THRESHOLD = 0.34
+"""``fails / total`` must be >= this for a tool to surface as a hint."""
+
+_ERROR_HEAD_CHARS = 80
+"""Truncation cap for the rendered ``error`` snippet."""
+
+
+@dataclass(frozen=True, slots=True)
+class ToolHint:
+    """One tool's recent failure signal ready for rendering."""
+
+    tool_name: str
+    fail_count: int
+    total: int
+    fail_rate: float
+    recent_error: str  # most-recent non-empty error message, truncated
+
+
+def load_recent_episodes(limit: int = RECENT_WINDOW) -> list[object]:
+    """Return up to ``limit`` most-recent episodes, newest first.
+
+    Returns an empty list on missing ``episodes.jsonl`` or any read
+    failure. Episodes are :class:`core.memory.episodic.Episode`
+    instances; we annotate the return type as ``list[object]`` to keep
+    this module decoupled from the memory layer's exact class —
+    ``find_failing_tools`` only reads ``.tool_name`` / ``.success`` /
+    ``.error`` via getattr.
+    """
+    try:
+        from core.memory.episodic import EpisodicStore
+    except Exception as exc:  # pragma: no cover — defensive
+        log.debug("tool_hints: episodic store import failed: %s", exc)
+        return []
+    try:
+        store = EpisodicStore()
+        return list(store.recent(limit=limit))
+    except Exception as exc:
+        log.debug("tool_hints: episodic store read failed: %s", exc)
+        return []
+
+
+def find_failing_tools(
+    episodes: list[object],
+    *,
+    top_k: int,
+    min_invocations: int = MIN_INVOCATIONS,
+    fail_rate_threshold: float = FAIL_RATE_THRESHOLD,
+) -> list[ToolHint]:
+    """Aggregate ``episodes`` → per-tool fail_rate; return top failing tools.
+
+    Args:
+        episodes: Iterable of objects exposing ``tool_name`` (str),
+            ``success`` (bool), and ``error`` (str | None).
+        top_k: Cap on returned hints. <=0 → empty.
+        min_invocations: Minimum calls before fail_rate is considered.
+        fail_rate_threshold: Inclusive lower bound on ``fails / total``.
+
+    Returns:
+        Sorted by fail_rate desc, then total desc (more data = stronger
+        signal). Tools below either threshold are excluded.
+    """
+    if top_k <= 0:
+        return []
+    # Accumulate per tool. Episodes are newest-first, so the FIRST
+    # non-empty error we encounter per tool is the most-recent one.
+    totals: dict[str, int] = {}
+    fails: dict[str, int] = {}
+    recent_errors: dict[str, str] = {}
+    for ep in episodes:
+        tool = getattr(ep, "tool_name", None)
+        if not isinstance(tool, str) or not tool:
+            continue
+        success = getattr(ep, "success", None)
+        if not isinstance(success, bool):
+            continue
+        totals[tool] = totals.get(tool, 0) + 1
+        if not success:
+            fails[tool] = fails.get(tool, 0) + 1
+            error = getattr(ep, "error", None)
+            if isinstance(error, str) and error.strip() and tool not in recent_errors:
+                recent_errors[tool] = error.strip()
+    hints: list[ToolHint] = []
+    for tool, total in totals.items():
+        fail_count = fails.get(tool, 0)
+        if total < min_invocations:
+            continue
+        fail_rate = fail_count / total
+        if fail_rate < fail_rate_threshold:
+            continue
+        recent_error = recent_errors.get(tool, "")
+        if len(recent_error) > _ERROR_HEAD_CHARS:
+            recent_error = recent_error[: _ERROR_HEAD_CHARS - 1] + "…"
+        hints.append(
+            ToolHint(
+                tool_name=tool,
+                fail_count=fail_count,
+                total=total,
+                fail_rate=fail_rate,
+                recent_error=recent_error,
+            )
+        )
+    hints.sort(key=lambda h: (-h.fail_rate, -h.total))
+    return hints[:top_k]
+
+
+def format_tool_hints_block(hints: list[ToolHint]) -> str:
+    """Render the failing-tool hints as a ``<tool-hints>`` block, or ``""`` if empty."""
+    if not hints:
+        return ""
+    lines = ["<tool-hints>"]
+    for h in hints:
+        if h.recent_error:
+            lines.append(
+                f"- [{h.tool_name}] {h.fail_count}/{h.total} failed; recent error: {h.recent_error}"
+            )
+        else:
+            lines.append(f"- [{h.tool_name}] {h.fail_count}/{h.total} failed")
+    lines.append("</tool-hints>")
+    return "\n".join(lines)

--- a/tests/test_m4_4_3_tool_hints.py
+++ b/tests/test_m4_4_3_tool_hints.py
@@ -1,0 +1,288 @@
+"""ADR-012 M4.4.3 — tool_hints reader + orchestrator wiring invariants.
+
+Pins:
+- ``load_recent_episodes`` returns ``[]`` on missing ledger / read
+  failure / import failure (graceful).
+- ``find_failing_tools`` aggregates by tool, applies min_invocations +
+  fail_rate threshold, sorts by fail_rate desc with total desc
+  tiebreak, caps at top_k.
+- Per-tool ``recent_error`` captures the *most-recent* non-empty error
+  string (episodes pass in newest-first order).
+- ``format_tool_hints_block`` renders a ``<tool-hints>`` block; empty
+  list → empty string. Tools without recent_error get a shorter line.
+- Orchestrator: ``tool_hints`` slot active + episodes have failing tools
+  → ``<tool-hints>`` block prepended to system prompt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass
+class _StubEpisode:
+    """Minimal duck-typed Episode for testing (avoid importing the real one)."""
+
+    tool_name: str
+    success: bool
+    error: str | None = None
+
+
+# load_recent_episodes ------------------------------------------------------
+
+
+def test_load_recent_returns_empty_on_store_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``EpisodicStore`` raise → graceful ``[]``."""
+    from core.self_improving_loop import tool_hints as th
+
+    class _BoomStore:
+        def __init__(self) -> None:
+            raise RuntimeError("synthetic")
+
+    monkeypatch.setattr("core.memory.episodic.EpisodicStore", _BoomStore)
+    assert th.load_recent_episodes() == []
+
+
+def test_load_recent_returns_list_from_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.self_improving_loop import tool_hints as th
+
+    class _StubStore:
+        def __init__(self) -> None:
+            pass
+
+        def recent(self, *, limit: int) -> list[_StubEpisode]:
+            return [_StubEpisode("X", True), _StubEpisode("Y", False, "err")]
+
+    monkeypatch.setattr("core.memory.episodic.EpisodicStore", _StubStore)
+    eps = th.load_recent_episodes(limit=5)
+    assert len(eps) == 2
+
+
+# find_failing_tools --------------------------------------------------------
+
+
+def test_find_returns_empty_for_top_k_zero() -> None:
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    assert find_failing_tools([_StubEpisode("X", False, "e")] * 5, top_k=0) == []
+
+
+def test_find_filters_below_min_invocations() -> None:
+    """Tool with only 1-2 calls is below default ``MIN_INVOCATIONS=3``."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    episodes = [_StubEpisode("X", False, "err")] * 2  # only 2 calls
+    assert find_failing_tools(episodes, top_k=5) == []
+
+
+def test_find_filters_below_fail_rate_threshold() -> None:
+    """5 success + 1 fail = 1/6 = 0.166 < 0.34 threshold."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    episodes = [
+        _StubEpisode("X", True),
+        _StubEpisode("X", True),
+        _StubEpisode("X", True),
+        _StubEpisode("X", True),
+        _StubEpisode("X", True),
+        _StubEpisode("X", False, "rare error"),
+    ]
+    assert find_failing_tools(episodes, top_k=5) == []
+
+
+def test_find_surfaces_failing_tools() -> None:
+    """3 calls, 2 failures = 2/3 = 0.667 ≥ threshold → emit."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    episodes = [
+        _StubEpisode("Bash", False, "command not found"),
+        _StubEpisode("Bash", False, "permission denied"),
+        _StubEpisode("Bash", True),
+    ]
+    hints = find_failing_tools(episodes, top_k=5)
+    assert len(hints) == 1
+    assert hints[0].tool_name == "Bash"
+    assert hints[0].fail_count == 2
+    assert hints[0].total == 3
+
+
+def test_find_uses_most_recent_error_per_tool() -> None:
+    """Episodes are newest-first; the first non-empty error wins."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    # Newest first: failing with "RECENT", then earlier failure with "OLD"
+    episodes = [
+        _StubEpisode("Tool", False, "RECENT error"),
+        _StubEpisode("Tool", False, "OLD error"),
+        _StubEpisode("Tool", False, "OLDER error"),
+    ]
+    hints = find_failing_tools(episodes, top_k=5)
+    assert hints[0].recent_error == "RECENT error"
+
+
+def test_find_sorts_by_fail_rate_desc_then_total() -> None:
+    """Higher fail_rate ranks first; tie on rate → higher total wins."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    episodes = [
+        # Tool A: 4/4 = 1.0 fail rate, 4 calls
+        _StubEpisode("A", False, "ea"),
+        _StubEpisode("A", False, "ea"),
+        _StubEpisode("A", False, "ea"),
+        _StubEpisode("A", False, "ea"),
+        # Tool B: 3/3 = 1.0 fail rate, 3 calls
+        _StubEpisode("B", False, "eb"),
+        _StubEpisode("B", False, "eb"),
+        _StubEpisode("B", False, "eb"),
+        # Tool C: 2/4 = 0.5 fail rate, 4 calls (just above threshold)
+        _StubEpisode("C", False, "ec"),
+        _StubEpisode("C", False, "ec"),
+        _StubEpisode("C", True),
+        _StubEpisode("C", True),
+    ]
+    hints = find_failing_tools(episodes, top_k=5)
+    # Order: A (1.0 rate, 4 total), B (1.0 rate, 3 total — same rate, lower total),
+    # then C (0.5 rate)
+    assert [h.tool_name for h in hints] == ["A", "B", "C"]
+
+
+def test_find_top_k_caps_results() -> None:
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    episodes = []
+    for tool in "ABCDE":
+        episodes.extend([_StubEpisode(tool, False, "e")] * 3)
+    hints = find_failing_tools(episodes, top_k=2)
+    assert len(hints) == 2
+
+
+def test_find_skips_non_string_tool_names() -> None:
+    """Defensive: malformed episode with non-str tool_name → skipped."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    @dataclass
+    class _BadEpisode:
+        tool_name: object = None  # not a str
+        success: bool = False
+        error: str | None = "e"
+
+    good = [_StubEpisode("Good", False, "e")] * 3
+    bad = [_BadEpisode()] * 3
+    hints = find_failing_tools(good + bad, top_k=5)
+    assert [h.tool_name for h in hints] == ["Good"]
+
+
+def test_find_truncates_long_error_strings() -> None:
+    """Recent error trimmed to 80 chars + ellipsis."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    long_err = "x" * 500
+    episodes = [_StubEpisode("X", False, long_err)] * 3
+    hints = find_failing_tools(episodes, top_k=5)
+    assert hints[0].recent_error.endswith("…")
+    assert len(hints[0].recent_error) <= 80
+
+
+# format_tool_hints_block ---------------------------------------------------
+
+
+def test_format_empty_returns_empty_string() -> None:
+    from core.self_improving_loop.tool_hints import format_tool_hints_block
+
+    assert format_tool_hints_block([]) == ""
+
+
+def test_format_renders_block_with_error() -> None:
+    from core.self_improving_loop.tool_hints import ToolHint, format_tool_hints_block
+
+    hints = [
+        ToolHint(
+            tool_name="Bash",
+            fail_count=3,
+            total=5,
+            fail_rate=0.6,
+            recent_error="permission denied",
+        )
+    ]
+    block = format_tool_hints_block(hints)
+    assert block.startswith("<tool-hints>")
+    assert block.endswith("</tool-hints>")
+    assert "[Bash] 3/5 failed" in block
+    assert "permission denied" in block
+
+
+def test_format_renders_block_without_error() -> None:
+    """Tool with empty recent_error → shorter line (no 'recent error:' part)."""
+    from core.self_improving_loop.tool_hints import ToolHint, format_tool_hints_block
+
+    hints = [
+        ToolHint(
+            tool_name="X",
+            fail_count=2,
+            total=3,
+            fail_rate=0.667,
+            recent_error="",
+        )
+    ]
+    block = format_tool_hints_block(hints)
+    assert "[X] 2/3 failed" in block
+    assert "recent error" not in block
+
+
+# Orchestrator wiring -------------------------------------------------------
+
+
+def test_orchestrator_prepends_tool_hints_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """tool_hints slot active + failing tool in episodic ledger → block in system."""
+    from core.self_improving_loop.in_context_slots import SLOT_TOOL_HINTS, InContextSlot
+    from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_TOOL_HINTS: InContextSlot(
+                name=SLOT_TOOL_HINTS,
+                max_entries=3,
+                rank_by="success_rate",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "core.self_improving_loop.tool_hints.load_recent_episodes",
+        lambda limit=200: [
+            _StubEpisode("Bash", False, "cmd not found"),
+            _StubEpisode("Bash", False, "cmd not found"),
+            _StubEpisode("Bash", True),
+        ],
+    )
+    _, new_sys = apply_in_context_slots([{"role": "user", "content": "go"}], system="ORIGINAL")
+    assert "<tool-hints>" in new_sys
+    assert "[Bash] 2/3 failed" in new_sys
+    assert new_sys.endswith("ORIGINAL")
+
+
+def test_orchestrator_no_op_when_no_failing_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """tool_hints slot active but no tool meets threshold → system unchanged."""
+    from core.self_improving_loop.in_context_slots import SLOT_TOOL_HINTS, InContextSlot
+    from core.self_improving_loop.in_context_wiring import apply_in_context_slots
+
+    monkeypatch.setattr(
+        "core.self_improving_loop.in_context_slots._load_in_context_slots_override",
+        lambda: {
+            SLOT_TOOL_HINTS: InContextSlot(
+                name=SLOT_TOOL_HINTS,
+                max_entries=3,
+                rank_by="success_rate",
+                injection_point="system_prompt",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "core.self_improving_loop.tool_hints.load_recent_episodes",
+        lambda limit=200: [_StubEpisode("X", True)] * 5,  # all success
+    )
+    _, new_sys = apply_in_context_slots([{"role": "user", "content": "go"}], system="SYS")
+    assert new_sys == "SYS"

--- a/tests/test_m4_4_3_tool_hints.py
+++ b/tests/test_m4_4_3_tool_hints.py
@@ -185,6 +185,34 @@ def test_find_truncates_long_error_strings() -> None:
     assert len(hints[0].recent_error) <= 80
 
 
+def test_find_error_trim_preserves_first_79_chars() -> None:
+    """Trim shape is exactly first 79 chars + ellipsis (Codex FLAG #3 pin)."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    error = "abc" * 50  # 150 chars
+    episodes = [_StubEpisode("X", False, error)] * 3
+    hints = find_failing_tools(episodes, top_k=5)
+    assert hints[0].recent_error == error[:79] + "…"
+    assert len(hints[0].recent_error) == 80
+
+
+def test_find_skips_non_bool_success() -> None:
+    """Defensive: episode with non-bool ``success`` field → skipped
+    (Codex FLAG #4 pin). Mirrors the non-str tool_name guard."""
+    from core.self_improving_loop.tool_hints import find_failing_tools
+
+    @dataclass
+    class _BadEpisode:
+        tool_name: str = "WeirdTool"
+        success: object = None  # not a bool
+        error: str | None = "e"
+
+    good = [_StubEpisode("Good", False, "e")] * 3
+    bad = [_BadEpisode()] * 3
+    hints = find_failing_tools(good + bad, top_k=5)
+    assert [h.tool_name for h in hints] == ["Good"]
+
+
 # format_tool_hints_block ---------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/self_improving_loop/tool_hints.py` — episodic ledger 기반 per-tool fail_rate 집계 + 임계값 필터 + `<tool-hints>` block render.
- M4.4 의 마지막 stub 활성화 — **4 in-context slot 전부 wired**.
- M4 DPO sprint 종료 (M4.0 → M4.4.3, 총 8 PR).

## Why
mutator 가 prompt evolve 후 agent 가 같은 tool 을 반복 실패하면 `stuck_in_loops` / `redundant_tool_invocation` dim regression 직격. 그런데 agent 는 자기 episodic ledger 를 *직접 안 봄*. `tool_hints` 는 그 ledger 의 최근 N(=200) episode 를 집계해 *"Bash 최근 3번 실패; recent error: ..."* 을 in-context 주입 → agent 다음 turn 에 다른 전략 선택 가능.

## Changes
| File | Change |
|------|--------|
| `core/self_improving_loop/tool_hints.py` | 신규 — `ToolHint` + 3 entry-point 함수 + 3 constants |
| `core/self_improving_loop/in_context_wiring.py` | `tool_hints` 슬롯 try/except 블록 + docstring "stub" → "wired (M4.4.3)" + M4 sprint closure note |
| `tests/test_m4_4_3_tool_hints.py` | 신규 — 18 invariant test |
| `CHANGELOG.md` | PR-M4.4.3 entry + M4 sprint summary |

## Algorithm
1. `load_recent_episodes(200)` → `EpisodicStore().recent(limit=200)` (newest-first)
2. `find_failing_tools(eps, top_k=K)`:
   - per tool: `total += 1`, `fail += not success`, capture FIRST non-empty error
   - filter: `total >= 3` AND `fail/total >= 0.34`
   - sort by `(-fail_rate, -total)`, cap at K
   - 80-char error trim with ellipsis
3. `format_tool_hints_block(hints)` → `<tool-hints>\n- [tool] N/M failed; recent error: ...\n...\n</tool-hints>`

## Defaults
- `RECENT_WINDOW = 200` — window size (configurable via arg)
- `MIN_INVOCATIONS = 3` — single failure is noise
- `FAIL_RATE_THRESHOLD = 0.34` — at least 1-in-3 failing

## Test inventory (18)
- `load_recent_episodes` x2: store 실패 graceful / 정상 list 반환
- `find_failing_tools` x8: top_k=0 empty / min_invocations cap / fail_rate threshold / surface / most-recent-error 캡쳐 / desc sort + tiebreak / top_k cap / non-str tool_name skip / 80-char trim
- `format_tool_hints_block` x3: empty `""` / with-error / without-error
- Orchestrator x2: block prepend / no-failing-tool no-op

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Reader exists | No | `grep -rn "tool_hints\|ToolHint" core/` 부재 |
| EpisodicStore 재구현 | No | `core.memory.episodic.EpisodicStore` 재활용 — duck-typed read |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter / AgentDefinition.model |
| Default no-op preserved | Yes | episodes.jsonl 없으면 `EpisodicStore.recent` 가 `[]` 반환 → reader `[]` → orchestrator system 미변경 |

## M4 Sprint Closure
| PR | 내용 | Status |
|----|------|--------|
| M4.0 #1429 | `eval_response_recorded` event | merged |
| M4.1 #1430 | DPO canonical pack writer | merged |
| M4.2 #1431 | publisher 3-target | merged |
| M4.3 #1434 | PII redaction + stats | merged |
| M4.4 #1435 | orchestrator + exemplars | merged |
| M4.4.1 #1436 | memory_recall | merged |
| M4.4.2 #1437 | rubric_excerpts | merged |
| **M4.4.3 본 PR** | **tool_hints + closure** | **CI 대기** |

Loop closes: agent → eval event → DPO pack → in-context inject → agent (with 4-channel context: exemplars / memory / rubric / tool-hints).

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run mypy core/self_improving_loop/tool_hints.py core/self_improving_loop/in_context_wiring.py` clean
- [x] `uv run pytest tests/test_m4_4_3_tool_hints.py tests/test_m4_4_2_rubric_excerpts.py tests/test_m4_4_1_memory_recall.py tests/test_m4_4_in_context_wiring.py -q` 60/60 PASS (18 신규 + 42 regression)

## Reference
- ADR-012 M4 sprint plan
- `core/memory/episodic.py` — EpisodicStore (PR-4 C-3 / cognitive-loop-uplift sprint)