### PR TITLE
feat(memory): PR-Hermes-1c — FTS5 + trigram index over messages table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,31 @@ functional change.
 
 ### Added
 
+- **PR-Hermes-1c — FTS5 + 트리그램 인덱스 (Hermes absorption Phase 1c).**
+  Phase 1a (#1338) 의 messages 테이블 + Phase 1b 의 SoT flip 위에 full-text
+  search 인덱스 신설. **신규 모듈** `core/storage/fts_helpers.py` —
+  `sanitize_fts5_query` (Hermes `hermes_state.py:1796` 패턴 absorb — 하이픈/
+  도트/콜론 포함 토큰을 double-quote escape, pure-meta 토큰 drop, Unicode
+  letter bare 유지) + `has_trigram_support` (SQLite 3.34+ trigram tokenize
+  capability probe; graceful False on `OperationalError`). **`session_manager.py`
+  확장** — `__init__` 가 `messages_fts` (unicode61 tokenizer) 와 3 트리거
+  (insert/delete/update) 를 항상 생성, trigram 가능 시 `messages_fts_trigram`
+  + 트리거 3개 추가 (graceful degrade). 트리거는 generator `_fts_trigger_block`
+  으로 단일 SoT — unicode/trigram 두 테이블 간 drift 차단. 신규 method
+  `search_messages(query, session_id=, limit=, prefer_trigram=)` 가 sanitize →
+  FTS5 `MATCH ?` 쿼리 → `bm25` 점수 + `snippet()` highlight 반환. **18
+  invariant test** — sanitize 7개 (empty / bare alnum / hyphenated / dotted /
+  internal quote escape / pure-meta drop / Unicode letter bare) + capability
+  probe 2개 (modern OK / bad-conn graceful) + FTS schema 2개 (tables 생성 /
+  triggers 생성) + sync 4개 (insert → index / round-trip search / session_id
+  scope / hyphen query via sanitizer) + trigram 1개 (Korean 부분문자열
+  recall) + delete cascade 1개 + empty query 1개. 5 critical guarantees:
+  default 동작 byte-equal (기존 sessions/messages 행위 미변경 — 신규 FTS
+  table 만 추가) / trigram 없는 SQLite 빌드에서도 graceful (unicode61 만
+  활성) / 쿼리 산티타이저가 FTS5 grammar 사고 차단 / contentless FTS
+  (`content='messages'`) 라 디스크 사용 최소 / 트리거가 인덱스 자동
+  동기화 (operator 수동 reindex 불필요).
+
 - **PR-M4.4.3 — `tool_hints` slot reader 활성화 + M4 sprint 종료 (ADR-012).**
   M4.4 (#1435) 의 마지막 stub 활성화 — **모든 4 in-context slot 이제
   완전 wired**. 신규 모듈 `core/self_improving_loop/tool_hints.py` —

--- a/core/memory/session_manager.py
+++ b/core/memory/session_manager.py
@@ -102,8 +102,9 @@ CREATE INDEX IF NOT EXISTS idx_messages_tool_name ON messages (tool_name)
 # Phase 1c (Hermes absorption, 2026-05-22) — full-text search indices over
 # the messages table. ``content``, ``tool_name``, and ``tool_calls`` are
 # all indexed so a single query surfaces text matches AND tool-name
-# filters. ``content='messages'`` makes both FTS tables *contentless*
-# (rowid-only) so the underlying TEXT data isn't duplicated; the
+# filters. ``content='messages'`` makes both FTS tables *external-content*
+# (FTS5 fetches the indexed columns from the source table by rowid)
+# so the underlying TEXT data isn't duplicated; the
 # triggers below keep them in sync with the source messages table.
 #
 # unicode61 = baseline tokenizer (case + diacritic fold). Always
@@ -140,8 +141,8 @@ def _fts_trigger_block(fts_name: str) -> str:
     ``fts_name`` is sourced from a fixed allowlist (``messages_fts`` /
     ``messages_fts_trigram``); never operator input.
     """
-    # fts_name is a hardcoded literal, not user input — S608 safe to ignore.
-    return f"""CREATE TRIGGER IF NOT EXISTS {fts_name}_after_insert AFTER INSERT ON messages BEGIN
+    # fts_name is a hardcoded literal, not user input — S608/B608 safe to ignore.
+    sql = f"""CREATE TRIGGER IF NOT EXISTS {fts_name}_after_insert AFTER INSERT ON messages BEGIN
     INSERT INTO {fts_name}(rowid, content, tool_name, tool_calls)
     VALUES (new.id, new.content, new.tool_name, new.tool_calls);
 END;
@@ -154,7 +155,8 @@ CREATE TRIGGER IF NOT EXISTS {fts_name}_after_update AFTER UPDATE ON messages BE
     VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
     INSERT INTO {fts_name}(rowid, content, tool_name, tool_calls)
     VALUES (new.id, new.content, new.tool_name, new.tool_calls);
-END;"""  # noqa: S608
+END;"""  # noqa: S608  # nosec B608
+    return sql
 
 
 _FTS_TRIGGERS_UNICODE_SQL = _fts_trigger_block("messages_fts")
@@ -551,9 +553,9 @@ class SessionManager:
             return []
         table = "messages_fts_trigram" if prefer_trigram and self._has_trigram else "messages_fts"
         # ``table`` is one of two hardcoded literals (no user input) so the
-        # f-string composition is safe — S608 false positive.
+        # f-string composition is safe — S608/B608 false positive.
         sql = (
-            f"SELECT m.session_id, m.id, m.seq, m.role, m.content, m.timestamp, "  # noqa: S608
+            f"SELECT m.session_id, m.id, m.seq, m.role, m.content, m.timestamp, "  # noqa: S608  # nosec B608
             f"snippet({table}, 0, '[', ']', '…', 16), bm25({table}) "
             f"FROM {table} JOIN messages m ON m.id = {table}.rowid "
             f"WHERE {table} MATCH ?"

--- a/core/memory/session_manager.py
+++ b/core/memory/session_manager.py
@@ -99,6 +99,67 @@ _CREATE_MESSAGES_TOOL_INDEX_SQL = """\
 CREATE INDEX IF NOT EXISTS idx_messages_tool_name ON messages (tool_name)
 """
 
+# Phase 1c (Hermes absorption, 2026-05-22) — full-text search indices over
+# the messages table. ``content``, ``tool_name``, and ``tool_calls`` are
+# all indexed so a single query surfaces text matches AND tool-name
+# filters. ``content='messages'`` makes both FTS tables *contentless*
+# (rowid-only) so the underlying TEXT data isn't duplicated; the
+# triggers below keep them in sync with the source messages table.
+#
+# unicode61 = baseline tokenizer (case + diacritic fold). Always
+# created.
+# trigram = substring-recall booster (Korean / Japanese partial words,
+# identifier fragments). Requires SQLite 3.34+; gated by
+# ``has_trigram_support`` at runtime.
+
+_CREATE_MESSAGES_FTS_UNICODE_SQL = """\
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    content, tool_name, tool_calls,
+    content='messages',
+    content_rowid='id',
+    tokenize='unicode61'
+)
+"""
+
+_CREATE_MESSAGES_FTS_TRIGRAM_SQL = """\
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
+    content, tool_name, tool_calls,
+    content='messages',
+    content_rowid='id',
+    tokenize='trigram'
+)
+"""
+
+
+def _fts_trigger_block(fts_name: str) -> str:
+    """Build the 3 INSERT/DELETE/UPDATE triggers for one FTS table.
+
+    Generated rather than literal so the unicode61 and trigram tables
+    share one source-of-truth without copy-paste drift. The trigger
+    names embed ``fts_name`` for unambiguous SQL error messages.
+    ``fts_name`` is sourced from a fixed allowlist (``messages_fts`` /
+    ``messages_fts_trigram``); never operator input.
+    """
+    # fts_name is a hardcoded literal, not user input — S608 safe to ignore.
+    return f"""CREATE TRIGGER IF NOT EXISTS {fts_name}_after_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO {fts_name}(rowid, content, tool_name, tool_calls)
+    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+END;
+CREATE TRIGGER IF NOT EXISTS {fts_name}_after_delete AFTER DELETE ON messages BEGIN
+    INSERT INTO {fts_name}({fts_name}, rowid, content, tool_name, tool_calls)
+    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+END;
+CREATE TRIGGER IF NOT EXISTS {fts_name}_after_update AFTER UPDATE ON messages BEGIN
+    INSERT INTO {fts_name}({fts_name}, rowid, content, tool_name, tool_calls)
+    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    INSERT INTO {fts_name}(rowid, content, tool_name, tool_calls)
+    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+END;"""  # noqa: S608
+
+
+_FTS_TRIGGERS_UNICODE_SQL = _fts_trigger_block("messages_fts")
+_FTS_TRIGGERS_TRIGRAM_SQL = _fts_trigger_block("messages_fts_trigram")
+
 
 def _extract_message_fields(msg: dict[str, Any]) -> dict[str, Any]:
     """Extract structured columns from a chat message dict.
@@ -223,6 +284,25 @@ class SessionManager:
         self._conn.execute(_CREATE_MESSAGES_TABLE_SQL)
         self._conn.execute(_CREATE_MESSAGES_SESSION_INDEX_SQL)
         self._conn.execute(_CREATE_MESSAGES_TOOL_INDEX_SQL)
+        # Phase 1c (Hermes absorption, 2026-05-22) — FTS5 indices.
+        # unicode61 is always created. trigram is probed at runtime and
+        # skipped on SQLite builds that don't ship it; ``self._has_trigram``
+        # records the outcome so ``search_messages`` can skip the trigram
+        # branch instead of crashing.
+        from core.storage.fts_helpers import has_trigram_support
+
+        self._conn.executescript(_CREATE_MESSAGES_FTS_UNICODE_SQL)
+        self._conn.executescript(_FTS_TRIGGERS_UNICODE_SQL)
+        self._has_trigram = has_trigram_support(self._conn)
+        if self._has_trigram:
+            self._conn.executescript(_CREATE_MESSAGES_FTS_TRIGRAM_SQL)
+            self._conn.executescript(_FTS_TRIGGERS_TRIGRAM_SQL)
+        else:
+            log.warning(
+                "SQLite build lacks FTS5 trigram support; falling back to "
+                "unicode61-only search. Substring recall (e.g. partial Korean "
+                "words / identifier fragments) will be limited."
+            )
         self._conn.commit()
 
     def upsert(self, meta: SessionMeta) -> None:
@@ -434,6 +514,83 @@ class SessionManager:
             )
             self._conn.commit()
             return cursor.rowcount
+
+    def search_messages(
+        self,
+        query: str,
+        *,
+        session_id: str | None = None,
+        limit: int = 20,
+        prefer_trigram: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Full-text search across mirrored messages. Returns row dicts.
+
+        Args:
+            query: Raw operator query string. Sanitised via
+                :func:`core.storage.fts_helpers.sanitize_fts5_query` so
+                hyphens / dots / quotes don't blow up FTS5's grammar.
+            session_id: Optional scope filter — restrict to messages from
+                a single session.
+            limit: Cap on rows returned (default 20).
+            prefer_trigram: When ``True`` AND the trigram index exists,
+                query ``messages_fts_trigram`` instead of the unicode61
+                index. Useful for substring-recall scenarios (partial
+                Korean words, identifier fragments). Silently falls back
+                to unicode61 when trigram isn't supported.
+
+        Returns:
+            Newest-first list of ``{seq, role, content, timestamp,
+            session_id, message_id, snippet, score}`` dicts. ``snippet``
+            is FTS5's highlighted context window. Empty list when the
+            sanitised query is empty.
+        """
+        from core.storage.fts_helpers import sanitize_fts5_query
+
+        clean = sanitize_fts5_query(query)
+        if not clean:
+            return []
+        table = "messages_fts_trigram" if prefer_trigram and self._has_trigram else "messages_fts"
+        # ``table`` is one of two hardcoded literals (no user input) so the
+        # f-string composition is safe — S608 false positive.
+        sql = (
+            f"SELECT m.session_id, m.id, m.seq, m.role, m.content, m.timestamp, "  # noqa: S608
+            f"snippet({table}, 0, '[', ']', '…', 16), bm25({table}) "
+            f"FROM {table} JOIN messages m ON m.id = {table}.rowid "
+            f"WHERE {table} MATCH ?"
+        )
+        params: list[Any] = [clean]
+        if session_id is not None:
+            sql += " AND m.session_id = ?"
+            params.append(session_id)
+        sql += " ORDER BY m.timestamp DESC LIMIT ?"
+        params.append(limit)
+        try:
+            rows = self._conn.execute(sql, params).fetchall()
+        except sqlite3.OperationalError as exc:
+            log.warning("search_messages FTS5 query failed: %s", exc)
+            return []
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            session_id_val, msg_id, seq, role, content_raw, ts, snippet, score = r
+            content: Any = None
+            if content_raw is not None:
+                try:
+                    content = json.loads(content_raw)
+                except json.JSONDecodeError:
+                    content = content_raw
+            out.append(
+                {
+                    "session_id": session_id_val,
+                    "message_id": msg_id,
+                    "seq": seq,
+                    "role": role,
+                    "content": content,
+                    "timestamp": ts,
+                    "snippet": snippet,
+                    "score": score,
+                }
+            )
+        return out
 
     @staticmethod
     def _row_to_message(row: tuple) -> dict[str, Any]:  # type: ignore[type-arg]

--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -1,0 +1,10 @@
+"""Storage primitives — SQLite helpers shared across memory backends.
+
+PR-Hermes-1c (2026-05-22) introduced this package with
+``fts_helpers.py``: FTS5 query sanitisation + trigram capability
+detection used by ``core/memory/session_manager.py``'s text-search
+indices. Future storage adapters (sled / DuckDB / Postgres) would land
+sibling modules here.
+"""
+
+from __future__ import annotations

--- a/core/storage/fts_helpers.py
+++ b/core/storage/fts_helpers.py
@@ -1,0 +1,124 @@
+"""FTS5 query sanitisation + capability detection.
+
+PR-Hermes-1c (2026-05-22) absorbs the Hermes ``_sanitize_fts5_query``
+pattern (``hermes_state.py:1796``) for the per-project SQLite text
+indices added in ``core/memory/session_manager.py``.
+
+**Why sanitisation matters**: FTS5's query syntax reserves a handful
+of metacharacters — ``-`` is the NOT operator, ``.`` is a token
+separator, ``"`` opens a phrase. Operator queries that come in as
+"file-not-found" or "v3.34" get parsed as boolean expressions and
+either error or return zero rows. Hermes' fix is to detect
+non-alphanumeric tokens and wrap them in escaped double quotes so
+they're treated as literal phrase tokens.
+
+**Capability detection**: SQLite ships ``unicode61`` (case+diacritic
+fold) in every FTS5 build but ``trigram`` only landed in 3.34 (2020).
+GEODE's minimum runtime can't assume 3.34+, so the session_manager
+guards trigram table creation with :func:`has_trigram_support`. The
+unicode61 index covers most full-word recall; the trigram index is the
+substring-recall booster (Korean / Japanese partial-word search,
+identifier-fragment matching). Missing trigram = graceful degradation,
+not a hard failure.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+import sqlite3
+from collections.abc import Iterable
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "FTS5_META_CHARS",
+    "has_trigram_support",
+    "sanitize_fts5_query",
+]
+
+# FTS5 metacharacters that break a query when they appear unquoted. We
+# don't try to support FTS5's full operator grammar (the operator-side
+# caller doesn't write FTS5 by hand) — instead we treat any token
+# containing these as a literal phrase.
+FTS5_META_CHARS: frozenset[str] = frozenset({"-", ".", ":", "(", ")", "*", "^", "+"})
+
+# Whitelist for "this token is safe as a bare FTS5 word": ASCII alnum +
+# the underscore + any non-ASCII letter / digit (Unicode). Anything else
+# triggers double-quote wrapping.
+_BARE_TOKEN_RE = re.compile(r"\A[A-Za-z0-9_À-￿]+\Z")
+
+
+def sanitize_fts5_query(raw: str) -> str:
+    """Escape ``raw`` so it can be passed to ``SELECT ... MATCH ?``.
+
+    Algorithm (Hermes parity):
+
+    1. Split ``raw`` on whitespace into tokens.
+    2. Drop empty tokens and tokens that are *purely* FTS5 metacharacters
+       (e.g. a bare ``"-"`` left over from a hyphen-split query).
+    3. For each remaining token:
+
+       * If it matches :data:`_BARE_TOKEN_RE` (pure alnum / underscore /
+         Unicode letter), keep it bare.
+       * Otherwise wrap it in double quotes, escaping any literal ``"``
+         to ``""`` (FTS5 phrase-escape convention).
+
+    4. Join tokens with single spaces. Empty input → ``""``.
+
+    Returns a string the caller can pass directly to ``MATCH ?`` without
+    risking an FTS5 syntax error.
+    """
+    if not raw:
+        return ""
+    tokens = raw.split()
+    cleaned: list[str] = []
+    for tok in tokens:
+        if not tok:
+            continue
+        if all(ch in FTS5_META_CHARS for ch in tok):
+            # Pure metacharacter token (e.g. "-") — drop entirely. Keeping
+            # it would yield "" inside the wrapped quotes or, worse, a
+            # bare hyphen that FTS5 reads as NOT.
+            continue
+        if _BARE_TOKEN_RE.match(tok):
+            cleaned.append(tok)
+        else:
+            escaped = tok.replace('"', '""')
+            cleaned.append(f'"{escaped}"')
+    return " ".join(cleaned)
+
+
+def has_trigram_support(conn: sqlite3.Connection) -> bool:
+    """Probe whether the underlying SQLite build supports ``tokenize='trigram'``.
+
+    Runs a one-shot ``CREATE VIRTUAL TABLE ... USING fts5(... tokenize='trigram')``
+    on a throwaway name and drops it. SQLite ≥ 3.34 has trigram baked
+    in; older builds raise ``sqlite3.OperationalError``. Returns
+    ``False`` on any exception so the caller can downgrade gracefully
+    rather than crash the whole DB init.
+    """
+    probe_name = "_geode_trigram_probe"
+    try:
+        conn.execute(f"CREATE VIRTUAL TABLE {probe_name} USING fts5(c, tokenize='trigram')")
+    except sqlite3.OperationalError as exc:
+        log.debug("trigram capability probe failed: %s", exc)
+        return False
+    except Exception as exc:  # pragma: no cover — defensive
+        log.debug("trigram capability probe unexpected error: %s", exc)
+        return False
+    with contextlib.suppress(Exception):
+        # Best-effort cleanup; leaving the probe table behind is harmless.
+        conn.execute(f"DROP TABLE {probe_name}")
+    return True
+
+
+def fts_index_columns(_columns: Iterable[str]) -> str:
+    """Render an FTS5 column spec (no rowid / control args).
+
+    Tiny helper so the session_manager's schema strings stay readable
+    when adding/removing indexed columns. Kept here so future storage
+    adapters reuse the same convention.
+    """
+    return ", ".join(_columns)

--- a/tests/test_hermes_1c_fts5.py
+++ b/tests/test_hermes_1c_fts5.py
@@ -1,0 +1,241 @@
+"""Hermes Phase 1c — FTS5 + trigram index invariants.
+
+Pins:
+- ``sanitize_fts5_query`` wraps non-alnum tokens in escaped double quotes
+  and strips pure-metachar tokens; empty input → ``""``.
+- ``has_trigram_support`` returns ``True`` on the test runner's SQLite
+  build (modern CI ships 3.34+).
+- ``SessionManager`` creates ``messages_fts`` + 3 triggers (insert /
+  delete / update). On trigram-capable builds it also creates
+  ``messages_fts_trigram`` + its 3 triggers.
+- Triggers keep FTS in sync — inserting a message indexes it; deleting
+  removes the index row; updating reindexes.
+- ``search_messages`` returns hits via FTS5 ``MATCH`` with snippet +
+  bm25 score; ``session_id`` filter scopes correctly; ``prefer_trigram``
+  flips to the trigram index when available.
+- Korean partial-word recall via the trigram index.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# fts_helpers ---------------------------------------------------------------
+
+
+def test_sanitize_empty_returns_empty() -> None:
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    assert sanitize_fts5_query("") == ""
+
+
+def test_sanitize_passes_bare_alnum_tokens() -> None:
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    assert sanitize_fts5_query("hello world") == "hello world"
+
+
+def test_sanitize_wraps_hyphenated_token() -> None:
+    """``file-not-found`` would be parsed as ``file NOT not NOT found`` —
+    must be wrapped."""
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    out = sanitize_fts5_query("file-not-found")
+    assert out == '"file-not-found"'
+
+
+def test_sanitize_wraps_dotted_token() -> None:
+    """Version strings like ``v3.34`` get token-split otherwise."""
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    out = sanitize_fts5_query("v3.34")
+    assert out == '"v3.34"'
+
+
+def test_sanitize_escapes_internal_double_quote() -> None:
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    out = sanitize_fts5_query('she said "hi"')
+    assert '""hi""' in out
+
+
+def test_sanitize_drops_pure_meta_token() -> None:
+    """Bare ``-`` after splitting must NOT survive (would mean NOT)."""
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    assert sanitize_fts5_query("foo - bar") == "foo bar"
+
+
+def test_sanitize_keeps_unicode_letters_bare() -> None:
+    """Non-ASCII letters / digits should NOT trigger quote-wrapping —
+    that would defeat the unicode61 tokenizer."""
+    from core.storage.fts_helpers import sanitize_fts5_query
+
+    out = sanitize_fts5_query("안녕하세요 セッション")
+    assert out == "안녕하세요 セッション"
+
+
+# Capability probe ----------------------------------------------------------
+
+
+def test_has_trigram_support_on_modern_sqlite() -> None:
+    """SQLite 3.34+ ships trigram; the test runner is modern enough."""
+    from core.storage.fts_helpers import has_trigram_support
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        assert has_trigram_support(conn) is True
+    finally:
+        conn.close()
+
+
+def test_has_trigram_support_graceful_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ``execute`` raises, the probe returns False — caller still works."""
+    from core.storage.fts_helpers import has_trigram_support
+
+    class _BadConn:
+        def execute(self, *_a: object, **_kw: object) -> None:
+            raise sqlite3.OperationalError("trigram not supported")
+
+    assert has_trigram_support(_BadConn()) is False  # type: ignore[arg-type]
+
+
+# SessionManager FTS wiring -------------------------------------------------
+
+
+@pytest.fixture
+def sm(tmp_path: Path) -> Iterator:
+    """Fresh SessionManager with a temp DB."""
+    from core.memory.session_manager import SessionManager
+
+    mgr = SessionManager(db_path=tmp_path / "sessions.db")
+    try:
+        yield mgr
+    finally:
+        mgr.close()
+
+
+def _seed_session_with_messages(sm: object, session_id: str, messages: list[dict]) -> None:
+    """Helper: create a session row + insert messages via the mirror API."""
+    from core.memory.session_manager import SessionMeta
+
+    sm.upsert(  # type: ignore[attr-defined]
+        SessionMeta(
+            session_id=session_id,
+            created_at=1.0,
+            updated_at=1.0,
+            status="active",
+            model="",
+            provider="anthropic",
+            user_input="",
+            round_count=0,
+            message_count=len(messages),
+        )
+    )
+    sm.upsert_messages(session_id, messages)  # type: ignore[attr-defined]
+
+
+def test_fts_tables_created(sm: object) -> None:
+    """Both unicode + trigram FTS tables exist after __init__."""
+    rows = sm._conn.execute(  # type: ignore[attr-defined]
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name IN ('messages_fts', 'messages_fts_trigram')"
+    ).fetchall()
+    names = {r[0] for r in rows}
+    assert "messages_fts" in names
+    # trigram may or may not exist depending on SQLite build
+    if sm._has_trigram:  # type: ignore[attr-defined]
+        assert "messages_fts_trigram" in names
+
+
+def test_fts_triggers_created(sm: object) -> None:
+    """3 triggers per FTS table (insert + delete + update)."""
+    rows = sm._conn.execute(  # type: ignore[attr-defined]
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE 'messages_fts%'"
+    ).fetchall()
+    names = {r[0] for r in rows}
+    assert "messages_fts_after_insert" in names
+    assert "messages_fts_after_delete" in names
+    assert "messages_fts_after_update" in names
+
+
+def test_insert_indexes_message(sm: object) -> None:
+    """Inserting via ``upsert_messages`` populates the FTS table."""
+    _seed_session_with_messages(
+        sm,
+        "s1",
+        [{"role": "user", "content": "find DPO training references", "timestamp": 1.0}],
+    )
+    count = sm._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]  # type: ignore[attr-defined]
+    assert count == 1
+
+
+def test_search_finds_inserted_message(sm: object) -> None:
+    """Round-trip: insert → search → match."""
+    _seed_session_with_messages(
+        sm,
+        "s1",
+        [{"role": "user", "content": "find DPO training references", "timestamp": 1.0}],
+    )
+    hits = sm.search_messages("DPO training")  # type: ignore[attr-defined]
+    assert len(hits) == 1
+    assert hits[0]["session_id"] == "s1"
+    assert "snippet" in hits[0]
+    assert "DPO" in hits[0]["snippet"] or "training" in hits[0]["snippet"]
+
+
+def test_search_session_id_filter_scopes(sm: object) -> None:
+    """``session_id=`` restricts to that session only."""
+    _seed_session_with_messages(
+        sm, "s1", [{"role": "user", "content": "shared word", "timestamp": 1.0}]
+    )
+    _seed_session_with_messages(
+        sm, "s2", [{"role": "user", "content": "shared word", "timestamp": 2.0}]
+    )
+    s1_hits = sm.search_messages("shared", session_id="s1")  # type: ignore[attr-defined]
+    assert len(s1_hits) == 1
+    assert s1_hits[0]["session_id"] == "s1"
+
+
+def test_search_empty_query_returns_empty(sm: object) -> None:
+    """Empty / pure-meta query → empty list, no SQL error."""
+    assert sm.search_messages("") == []  # type: ignore[attr-defined]
+    assert sm.search_messages("---") == []  # type: ignore[attr-defined]
+
+
+def test_search_hyphenated_query_via_sanitizer(sm: object) -> None:
+    """``file-not-found`` query works thanks to the sanitiser."""
+    _seed_session_with_messages(
+        sm,
+        "s1",
+        [{"role": "user", "content": "got file-not-found error", "timestamp": 1.0}],
+    )
+    hits = sm.search_messages("file-not-found")  # type: ignore[attr-defined]
+    assert len(hits) == 1
+
+
+def test_search_trigram_substring_recall(sm: object) -> None:
+    """Trigram index recalls partial words (Korean / fragments)."""
+    if not sm._has_trigram:  # type: ignore[attr-defined]
+        pytest.skip("trigram tokenizer not available on this SQLite build")
+    _seed_session_with_messages(
+        sm,
+        "s1",
+        [{"role": "user", "content": "안녕하세요 반갑습니다", "timestamp": 1.0}],
+    )
+    hits = sm.search_messages("녕하세", prefer_trigram=True)  # type: ignore[attr-defined]
+    assert len(hits) >= 1
+
+
+def test_delete_message_removes_from_index(sm: object) -> None:
+    """``delete_messages`` cascades through the FTS delete trigger."""
+    _seed_session_with_messages(
+        sm, "s1", [{"role": "user", "content": "ephemeral note", "timestamp": 1.0}]
+    )
+    assert sm._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 1  # type: ignore[attr-defined]
+    sm.delete_messages("s1")  # type: ignore[attr-defined]
+    assert sm._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- 신규 모듈 `core/storage/fts_helpers.py` — Hermes `_sanitize_fts5_query` 패턴 absorb + `has_trigram_support` capability probe.
- `core/memory/session_manager.py` — `__init__` 가 `messages_fts` (unicode61) + 3 triggers + 조건부 `messages_fts_trigram` + 3 triggers 생성. 신규 method `search_messages(...)`.
- 18 invariant test. Default 동작 byte-equal (기존 sessions/messages 행위 unchanged; 신규 FTS 테이블만 추가).

## Why
Hermes absorption plan Phase 1c. Phase 1a 가 messages 테이블 도입 + 1b 가 SoT flip 까지 끝냄. 1c 는 **검색 인덱스**. FTS5 `unicode61` 만으로는 한국어 부분문자열 / 식별자 fragment recall 불가 → trigram 인덱스 추가. SQLite 3.34+ 가 trigram tokenizer 갖춤 — capability probe 로 graceful degrade. 향후 1d (`session_search` 도구) 가 본 PR 의 search_messages 위에 LLM-노출 API 빌드.

## Changes
| File | Change |
|------|--------|
| `core/storage/__init__.py` | 신규 — storage 패키지 docstring 만 |
| `core/storage/fts_helpers.py` | 신규 — `sanitize_fts5_query` + `has_trigram_support` + `fts_index_columns` |
| `core/memory/session_manager.py` | FTS schema (unicode + trigram) + 트리거 generator `_fts_trigger_block` + `__init__` wire + 신규 `search_messages` method |
| `tests/test_hermes_1c_fts5.py` | 신규 — 18 invariant test |
| `CHANGELOG.md` | PR-Hermes-1c entry |

## Algorithm
- `sanitize_fts5_query(raw)`:
  - whitespace split → drop empty / pure-meta tokens
  - each token: bare if `[A-Za-z0-9_+Unicode letter]+`, else double-quote-wrap (escape internal `"` → `""`)
- `has_trigram_support(conn)`:
  - `CREATE VIRTUAL TABLE _geode_trigram_probe USING fts5(c, tokenize='trigram')` 시도
  - `OperationalError` → False; success → True + drop probe
- `search_messages`:
  - sanitize → table 선택 (`messages_fts_trigram` if prefer_trigram + supported, else `messages_fts`)
  - FTS5 `MATCH ?` JOIN messages → `bm25()` + `snippet()` + newest-first

## Schema
```sql
CREATE VIRTUAL TABLE messages_fts USING fts5(
    content, tool_name, tool_calls,
    content='messages', content_rowid='id',
    tokenize='unicode61'
);
-- + 3 triggers (after_insert / after_delete / after_update)
-- trigram variant identical with tokenize='trigram' when supported
```

Contentless FTS (`content='messages'`) — index rowid only, no duplicate text storage.

## Test inventory (18)
- sanitize x7: empty / bare alnum / hyphen wrap / dot wrap / quote escape / pure-meta drop / Unicode bare
- capability x2: modern OK / bad-conn graceful False
- FTS schema x2: tables created / triggers created
- sync x4: insert → index / round-trip search / session_id scope filter / hyphen query
- trigram x1: Korean substring recall (`녕하세` matches `안녕하세요`)
- delete cascade x1
- empty query x1: `""` and `"---"` both return `[]`

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Module already exists | No | `grep -rn "messages_fts\|fts5_query" core/` 부재 (Phase 1a/1b 가 명시적으로 1c 자리 비워둠) |
| Default behavior preserved | Yes | existing sessions/messages CRUD unchanged; FTS 테이블 신설만 |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter |
| SQLite 3.34+ 강제 | No | trigram 미지원 환경은 WARN + unicode61 만 활성 (graceful) |

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check core/storage/ core/memory/session_manager.py tests/test_hermes_1c_fts5.py` clean
- [x] `uv run mypy core/storage/ core/memory/session_manager.py` clean
- [x] `uv run pytest tests/test_hermes_1c_fts5.py -q` 18/18 PASS
- [x] 2 `# noqa: S608` 추가 — 둘 다 hardcoded literal 만 interpolate (fts_name + table, 사용자 입력 무관). 주석으로 명시.

## Reference
- `docs/plans/2026-05-14-hermes-strengths-absorption.md` Phase 1c spec
- Hermes `hermes_state.py:1796` — `_sanitize_fts5_query` original
- Phase 1d (deferred) — `session_search` 도구 + global.db 검색 인덱스