### PR TITLE
feat(self-improving-loop): PR-OL-C1 — emit_eval caller wiring (autoresearch audit cycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,14 +83,17 @@ functional change.
   verdict.lower() in {"reject", "regression"}`** (chosen pile = 양호한
   mutation, rejected pile = critical regression 또는 명시 reject).
   Emit 전체가 try/except 로 감싸져 audit cycle 자체는 절대 break 안 됨.
-  **DPO 파이프라인 deception 해소** — M4.1 build_dpo_pack 의 journal
-  walker 가 드디어 *non-empty* stream 을 읽음 → M4.2 publisher 가
-  실제 TRL / OpenAI / Bedrock 학습 데이터 생성 가능. 같은 commit 두 번
-  audit 시 chosen/rejected pair 자동 형성. **14 invariant test** —
-  chosen pile + rejected pile + no-scope no-op + train.py source 검증 4종
-  (import 존재 / main 내부 / rollback heuristic 정확 / try/except wrap) +
-  rollback heuristic matrix 7 case. **OL-C1.2 (Petri per-turn emit) 는
-  후속** — `.eval` log walker API 가 stable 한 후 진입.
+  Response payload 는 `verdict=<v> fitness=<f> promoted=<p>
+  dim_means_count=<N> bench_means_count=<M>` 5 필드. **DPO 파이프라인
+  deception 해소** — M4.1 build_dpo_pack 의 journal walker 가 드디어
+  *non-empty* stream 을 읽음 → M4.2 publisher 가 실제 TRL / OpenAI /
+  Bedrock 학습 데이터 생성 가능. 같은 commit 두 번 audit 시
+  chosen/rejected pair 자동 형성. **8 def / 14 runtime case invariant
+  test** — chosen pile + rejected pile + no-scope no-op + train.py
+  source 검증 4종 (import 존재 / main 내부 / rollback heuristic 정확 /
+  try/except wrap) + rollback heuristic matrix 1 def × 7 parametrize.
+  **OL-C1.2 (Petri per-turn emit) 는 후속** — `.eval` log walker API
+  가 stable 한 후 진입.
 
 - **PR-Hermes-1d — `session_search` LLM tool (Hermes absorption Phase 1d, minimal).**
   Phase 1c (#1439) 의 FTS5 인덱스 위에 LLM-노출 도구 추가. 신규 모듈

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,27 @@ functional change.
 
 ### Added
 
+- **PR-OL-C1 — `eval_response_recorded` 호출자 wiring (autoresearch audit cycle 단위).**
+  M4.0 (#1429) 이 "deferred to caller wiring" 으로 남긴 emit 함수가
+  드디어 production 에 첫 호출자 획득. `autoresearch/train.py::main()`
+  의 audit_finished journal emit 직후 `emit_eval_response_recorded(...)`
+  호출 추가. 매 audit cycle 마다 1 event 생성 — prompt = "audit cycle
+  on commit X (seed_select=Y, description=Z)", response = "verdict=W
+  fitness=F promoted=P dim_means_count=N", fitness_score = aggregate
+  fitness, axis_scores = `{dim_means_aggregate, bench_means_aggregate}`,
+  source = `"autoresearch_audit"`, **rollback_flag = `fitness == 0.0 OR
+  verdict.lower() in {"reject", "regression"}`** (chosen pile = 양호한
+  mutation, rejected pile = critical regression 또는 명시 reject).
+  Emit 전체가 try/except 로 감싸져 audit cycle 자체는 절대 break 안 됨.
+  **DPO 파이프라인 deception 해소** — M4.1 build_dpo_pack 의 journal
+  walker 가 드디어 *non-empty* stream 을 읽음 → M4.2 publisher 가
+  실제 TRL / OpenAI / Bedrock 학습 데이터 생성 가능. 같은 commit 두 번
+  audit 시 chosen/rejected pair 자동 형성. **14 invariant test** —
+  chosen pile + rejected pile + no-scope no-op + train.py source 검증 4종
+  (import 존재 / main 내부 / rollback heuristic 정확 / try/except wrap) +
+  rollback heuristic matrix 7 case. **OL-C1.2 (Petri per-turn emit) 는
+  후속** — `.eval` log walker API 가 stable 한 후 진입.
+
 - **PR-Hermes-1d — `session_search` LLM tool (Hermes absorption Phase 1d, minimal).**
   Phase 1c (#1439) 의 FTS5 인덱스 위에 LLM-노출 도구 추가. 신규 모듈
   `core/tools/session_search.py` — `SessionSearchTool` 이

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1611,6 +1611,58 @@ def main() -> int:
         level="info" if fitness > 0.0 else "warn",
         payload={"dry_run": args.dry_run},
     )
+
+    # OL-C1 (2026-05-22) — Activate the M4.0 ``eval_response_recorded``
+    # stream that PR-M4.0 deferred to caller wiring. autoresearch's
+    # audit cycle is the closest meaningful (prompt, response) tuple at
+    # this layer: prompt = "audit cycle on <commit> for <seed_select>",
+    # response = "verdict=<v> fitness=<f> dim_means=<...>". The pair
+    # feeds M4.1's DPO pack writer (build_dpo_pack groups by prompt;
+    # different commits produce different prompts → mostly unpaired
+    # initially, but once mutator iterates on the same baseline twice
+    # the chosen vs rejected pairing surfaces).
+    #
+    # rollback_flag heuristic: fitness == 0.0 (critical regression /
+    # strict-reject gate) OR verdict in {"reject", "regression"} → True.
+    # Otherwise False (the audit "passed"). M4.1 's chosen pile = audits
+    # whose mutation deserves keeping; rejected pile = audits that
+    # should be rolled back.
+    #
+    # Per-Petri-turn emit (finer granularity) lands in OL-C1.2 follow-up
+    # once we have a stable API to walk the .eval log per scenario.
+    try:
+        from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
+
+        prompt_label = (
+            f"autoresearch audit cycle on commit {commit} "
+            f"(seed_select={os.environ.get('SEED_SELECT', '<default>')!r}, "
+            f"description={description!r})"
+        )
+        response_label = (
+            f"verdict={verdict} fitness={fitness:.4f} "
+            f"promoted={promoted_line} "
+            f"dim_means_count={len(dim_means)} "
+            f"bench_means_count={len(baseline_bench_means) if baseline_bench_means else 0}"
+        )
+        rollback = fitness == 0.0 or verdict.lower() in {"reject", "regression"}
+        axis_scores: dict[str, float] = {}
+        if dim_means:
+            axis_scores["dim_means_aggregate"] = sum(dim_means.values()) / len(dim_means)
+        if baseline_bench_means:
+            axis_scores["bench_means_aggregate"] = sum(baseline_bench_means.values()) / len(
+                baseline_bench_means
+            )
+        emit_eval_response_recorded(
+            prompt=prompt_label,
+            response=response_label,
+            fitness_score=float(fitness),
+            axis_scores=axis_scores or None,
+            source="autoresearch_audit",
+            rollback_flag=rollback,
+        )
+    except Exception:  # pragma: no cover — defensive
+        # Eval-stream emit must never break the audit cycle itself.
+        log.debug("OL-C1 eval emit failed", exc_info=True)
     return 0
 
 

--- a/tests/test_ol_c1_emit_eval_caller.py
+++ b/tests/test_ol_c1_emit_eval_caller.py
@@ -1,0 +1,178 @@
+"""OL-C1 — autoresearch audit cycle emits eval_response_recorded.
+
+Pins:
+- ``autoresearch/train.py`` main() emits one ``eval_response_recorded``
+  event per audit cycle inside the active SessionJournal scope.
+- Payload schema matches PR-M4.0 contract: ``prompt`` / ``response``
+  / ``fitness_score`` / ``axis_scores`` / ``source`` / ``rollback_flag``.
+- ``source`` field == ``"autoresearch_audit"``.
+- ``rollback_flag`` is True when fitness == 0.0 OR verdict in
+  ``{"reject", "regression"}``; False otherwise.
+- Emit is graceful — a synthetic emit failure does not crash the audit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from core.observability.session_journal import (
+    SessionJournal,
+    session_journal_scope,
+)
+
+
+def _journal_with_path(tmp_path: Path) -> SessionJournal:
+    return SessionJournal(
+        session_id="ol-c1-test",
+        gen_tag="auto-test",
+        component="autoresearch",
+        path=tmp_path / "journal.jsonl",
+    )
+
+
+def _read_events(path: Path, name: str = "eval_response_recorded") -> list[dict]:
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line and json.loads(line).get("event") == name
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Direct emit unit tests (validate the call site contract without running
+# the entire train.py main — the actual main has many dependencies that
+# would require full E2E; the assertions here pin the *contract* the
+# call site must follow).
+# ---------------------------------------------------------------------------
+
+
+def test_autoresearch_emit_pattern_chosen_pile(tmp_path: Path) -> None:
+    """fitness > 0 + verdict != reject → rollback_flag=False (chosen pile)."""
+    from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
+
+    journal = _journal_with_path(tmp_path)
+    with session_journal_scope(journal):
+        ok = emit_eval_response_recorded(
+            prompt="autoresearch audit cycle on commit abc123 "
+            "(seed_select='default', description='gen-1')",
+            response="verdict=accept fitness=0.7321 promoted=true dim_means_count=17 "
+            "bench_means_count=7",
+            fitness_score=0.7321,
+            axis_scores={"dim_means_aggregate": 0.78, "bench_means_aggregate": 0.65},
+            source="autoresearch_audit",
+            rollback_flag=False,
+        )
+    assert ok is True
+    events = _read_events(journal.path)
+    assert len(events) == 1
+    payload = events[0]["payload"]
+    assert payload["source"] == "autoresearch_audit"
+    assert payload["fitness_score"] == 0.7321
+    assert payload["rollback_flag"] is False
+    assert payload["axis_scores"]["dim_means_aggregate"] == 0.78
+
+
+def test_autoresearch_emit_pattern_rejected_pile(tmp_path: Path) -> None:
+    """fitness == 0.0 (critical regression) → rollback_flag=True (rejected pile)."""
+    from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
+
+    journal = _journal_with_path(tmp_path)
+    with session_journal_scope(journal):
+        emit_eval_response_recorded(
+            prompt="autoresearch audit cycle on commit def456 "
+            "(seed_select='default', description='gen-2-bad')",
+            response="verdict=reject fitness=0.0000 promoted=false dim_means_count=17 "
+            "bench_means_count=7",
+            fitness_score=0.0,
+            axis_scores={"dim_means_aggregate": 0.42, "bench_means_aggregate": 0.30},
+            source="autoresearch_audit",
+            rollback_flag=True,
+        )
+    events = _read_events(journal.path)
+    assert len(events) == 1
+    assert events[0]["payload"]["rollback_flag"] is True
+    assert events[0]["payload"]["fitness_score"] == 0.0
+
+
+def test_autoresearch_emit_pattern_no_journal_scope_is_noop() -> None:
+    """No session_journal_scope → emit returns False, no file written, no raise."""
+    from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
+
+    ok = emit_eval_response_recorded(
+        prompt="audit prompt",
+        response="audit response",
+        fitness_score=0.5,
+        source="autoresearch_audit",
+    )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Source check — ensure the train.py call site actually exists with the
+# right shape (Codex MCP catch prevention: "X-driven" claims must be
+# grep-provable in the source).
+# ---------------------------------------------------------------------------
+
+
+def test_train_py_imports_emit_eval_response_recorded() -> None:
+    """``autoresearch/train.py`` must contain the import + call."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    assert (
+        "from core.self_improving_loop.eval_journaling import emit_eval_response_recorded"
+        in train_py
+    )
+    assert "emit_eval_response_recorded(" in train_py
+    assert 'source="autoresearch_audit"' in train_py
+
+
+def test_train_py_emit_is_inside_main() -> None:
+    """The emit call site must be inside main() (not module-level)."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    main_idx = train_py.find("def main() -> int:")
+    emit_idx = train_py.find("emit_eval_response_recorded(")
+    assert main_idx > 0
+    assert emit_idx > main_idx, "emit must be inside main(), not module-level"
+
+
+def test_train_py_emit_uses_rollback_heuristic() -> None:
+    """The call site computes rollback_flag from fitness + verdict."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    # Pin the heuristic shape so refactors are surfaced
+    assert (
+        "fitness == 0.0" in train_py and 'verdict.lower() in {"reject", "regression"}' in train_py
+    )
+
+
+def test_train_py_emit_wrapped_in_try_except() -> None:
+    """Eval-stream emit must never crash the audit — try/except guard."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    # The block should sit inside a `try:` ... `except` ... block
+    emit_marker = "emit_eval_response_recorded("
+    pos = train_py.find(emit_marker)
+    assert pos > 0
+    # Search a wide window before for `try:` (the call site has multi-line
+    # f-strings between the try: line and the emit call).
+    preceding = train_py[max(0, pos - 2000) : pos]
+    assert "try:" in preceding, "emit must be wrapped in try/except per OL-C1 spec"
+
+
+@pytest.mark.parametrize(
+    "fitness, verdict, expected_rollback",
+    [
+        (0.7, "accept", False),
+        (0.0, "pending", True),  # fitness==0 wins
+        (0.5, "reject", True),
+        (0.5, "REJECT", True),  # case-insensitive
+        (0.5, "regression", True),
+        (0.5, "pending", False),
+        (0.0001, "accept", False),  # > 0
+    ],
+)
+def test_rollback_heuristic_matrix(fitness: float, verdict: str, expected_rollback: bool) -> None:
+    """The rollback heuristic exactly: fitness == 0.0 OR verdict in {reject, regression}."""
+    rollback = fitness == 0.0 or verdict.lower() in {"reject", "regression"}
+    assert rollback is expected_rollback


### PR DESCRIPTION
## Summary
- M4.0 (#1429) 의 deferred caller wiring 해소 — `autoresearch/train.py::main()` 의 audit cycle 단위로 `emit_eval_response_recorded` 첫 production 호출자 추가.
- rollback_flag heuristic: `fitness == 0.0 OR verdict ∈ {reject, regression}`.
- 14 invariant test (chosen/rejected/no-scope + source verification + heuristic matrix).

## Why
2026-05-22 retrospective 가 M4 sprint deception #1 로 진단한 항목: `emit_eval_response_recorded` 가 `core/self_improving_loop/eval_journaling.py` 에 정의만 있고 production 호출자 ZERO. DPO 파이프라인 (M4.1 pack writer / M4.2 publisher / M4.3 redaction+stats) 모두 빈 journal stream 위에서 작동 → 실제 학습 데이터 0건. OL-C1 가 autoresearch audit cycle 의 자연스러운 (prompt, response) tuple 을 첫 emit 채널로 활성화.

## Changes
| File | Change |
|------|--------|
| `autoresearch/train.py` | main() 의 audit_finished journal emit 직후 emit_eval_response_recorded 호출 블록 추가 (try/except 로 감싸 audit cycle 보호). prompt = audit cycle 식별자, response = verdict+fitness+promoted+dim count, axis_scores = `{dim_means_aggregate, bench_means_aggregate}`, rollback_flag heuristic 적용 |
| `tests/test_ol_c1_emit_eval_caller.py` | 신규 — 14 invariant test |
| `CHANGELOG.md` | PR-OL-C1 entry |

## Emit shape (per audit cycle)
```python
emit_eval_response_recorded(
    prompt=f"autoresearch audit cycle on commit {commit} (seed_select={SEED_SELECT!r}, description={description!r})",
    response=f"verdict={verdict} fitness={fitness:.4f} promoted={promoted_line} dim_means_count={N} bench_means_count={M}",
    fitness_score=float(fitness),
    axis_scores={"dim_means_aggregate": ..., "bench_means_aggregate": ...},
    source="autoresearch_audit",
    rollback_flag=(fitness == 0.0 or verdict.lower() in {"reject", "regression"}),
)
```

## Rollback heuristic 의 정당화
M4.1 build_dpo_pack 는 같은 prompt 의 chosen pile (rollback_flag=False) 과 rejected pile (rollback_flag=True) 을 pair 로 만듦.
- fitness == 0.0 (critical-axis regression — `compute_fitness` 의 strict reject gate) → rejected
- verdict ∈ {reject, regression} (operator 가 `AUTORESEARCH_VERDICT` 명시) → rejected
- 그 외 (fitness > 0 AND verdict ∈ {accept, pending, ...}) → chosen
같은 commit 으로 두 번 audit (예: gen-1 baseline 위 gen-2 mutation iterations) 가 같은 prompt → chosen vs rejected pair 자동 형성.

## Test inventory (14)
- 직접 emit x3: chosen pile / rejected pile (fitness==0) / no-scope no-op
- train.py source 검증 x4: import 존재 / main 내부 / rollback heuristic 정확 표현 / try/except wrap
- rollback heuristic matrix x7: (0.7, accept, False) / (0.0, pending, True) / (0.5, reject, True) / (0.5, REJECT, True) / (0.5, regression, True) / (0.5, pending, False) / (0.0001, accept, False)

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| 호출자 이미 존재 | No | `grep -rn "emit_eval_response_recorded" core/ autoresearch/ plugins/` 가 M4.0 사전 정의 + __all__ 만 (2건) → 본 PR 가 첫 production caller 추가 |
| Petri per-turn emit | Deferred | OL-C1.2 후속 — `.eval` log walker API stable 후 진입 |
| AgenticLoop turn-end emit | Deferred | SessionJournal scope 가 AgenticLoop 에 bound 안 됨 — OL-C1.3 후속 (scope binding 작업 후) |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter / AgentDefinition.model — diff 없음 |
| Emit graceful | Yes | try/except 가 모든 실패 흡수, audit cycle 절대 break 안 됨 |

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check autoresearch/train.py tests/test_ol_c1_emit_eval_caller.py` clean
- [x] `uv run mypy autoresearch/train.py` clean
- [x] `uv run pytest tests/test_ol_c1_emit_eval_caller.py -q` 14/14 PASS

## Reference
- ADR-012 M4 DPO pipeline
- `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-C1
- M4.0 PR #1429 (emit 함수 정의 + deferred caller wiring 명시)
- M4.1 PR #1430 (build_dpo_pack 의 journal walker — 이제 데이터 흐름)