### PR TITLE
feat(self-improving-loop): PR-OL-C2 — few-shot pool writer + autoresearch promote caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,29 @@ functional change.
 
 ### Added
 
+- **PR-OL-C2 — few-shot pool writer + autoresearch promote 호출자.**
+  M3 (#1426/#1428) 이 reader (`_load_few_shot_pool_override` +
+  `apply_few_shot_pool`) 만 출시하고 writer 부재로 exemplars in-context
+  slot (M4.4 #1435) 가 영구 empty pool 위에 작동했던 deception 해소.
+  **신규 함수** `core/llm/few_shot_pool.append_exemplar(user_msg,
+  assistant_msg, fitness_delta, source, pool_path, max_size)` —
+  16-hex SHA256 signature idempotent dedup + FIFO eviction
+  (`MAX_EXEMPLAR_POOL_SIZE = 1000`). 모듈 `__all__` 에
+  `append_exemplar` + `MAX_EXEMPLAR_POOL_SIZE` 노출. **autoresearch
+  caller** — `autoresearch/train.py::main()` 의 OL-C1 eval emit 직후
+  `args.dry_run is False` AND `"true" in promoted_line.lower()` 시
+  `append_exemplar(source="autoresearch_audit_promote", fitness_delta=
+  fitness - mean(baseline_means))` 호출 (rejected pile 은 in-context
+  exemplars 채널에 들어가지 않게 gate). 전체 try/except 로 감싸져
+  audit cycle 보호. **8 def / 14 invariant test** — signature
+  determinism + field sensitivity / writer x4 (one row / idempotent /
+  multi-pair / round-trip with `_parse_jsonl`) / FIFO eviction 1 +
+  cap constant 1 / graceful 2 (parent dir creation, Unicode preserve)
+  / train.py source 검증 4종 (import 존재 / promote gate / try/except
+  / OL-C1 emit 후 위치 — order pin). **메타-level exemplar caveat**:
+  audit cycle 의 `(prompt, response)` 는 meta-level — 향후 OL-C2.2
+  follow-up 에서 AgenticLoop-turn-level + Petri-per-turn writer 추가.
+
 - **PR-OL-C1 — `eval_response_recorded` 호출자 wiring (autoresearch audit cycle 단위).**
   M4.0 (#1429) 이 "deferred to caller wiring" 으로 남긴 emit 함수가
   드디어 production 에 첫 호출자 획득. `autoresearch/train.py::main()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,12 +85,14 @@ functional change.
   `append_exemplar(source="autoresearch_audit_promote", fitness_delta=
   fitness - mean(baseline_means))` 호출 (rejected pile 은 in-context
   exemplars 채널에 들어가지 않게 gate). 전체 try/except 로 감싸져
-  audit cycle 보호. **8 def / 14 invariant test** — signature
-  determinism + field sensitivity / writer x4 (one row / idempotent /
-  multi-pair / round-trip with `_parse_jsonl`) / FIFO eviction 1 +
-  cap constant 1 / graceful 2 (parent dir creation, Unicode preserve)
-  / train.py source 검증 4종 (import 존재 / promote gate / try/except
-  / OL-C1 emit 후 위치 — order pin). **메타-level exemplar caveat**:
+  audit cycle 보호. **mkdir + write_text 모두 단일 try 안** (Codex MCP
+  FLAG fix — mkdir OSError 도 graceful False 반환, raise 안 함).
+  **14 invariant test** — signature x2 (determinism + field sensitivity)
+  + writer x4 (one row / idempotent / multi-pair / round-trip with
+  `_parse_jsonl`) + FIFO x2 (eviction at over-cap + cap constant
+  exposed) + graceful x2 (parent dir creation + Unicode preserve) +
+  train.py source 검증 4종 (import 존재 / promote gate /
+  try/except wrap / OL-C1 emit 후 위치 — order pin). **메타-level exemplar caveat**:
   audit cycle 의 `(prompt, response)` 는 meta-level — 향후 OL-C2.2
   follow-up 에서 AgenticLoop-turn-level + Petri-per-turn writer 추가.
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1663,6 +1663,31 @@ def main() -> int:
     except Exception:  # pragma: no cover — defensive
         # Eval-stream emit must never break the audit cycle itself.
         log.debug("OL-C1 eval emit failed", exc_info=True)
+
+    # OL-C2 (2026-05-22) — Activate the M3 ``few_shot_pool`` writer that
+    # PR-M3 (#1426/#1428) deferred. Only PROMOTED audits contribute to
+    # the pool (rejected piles stay out of the in-context exemplars
+    # channel). Audit-level ``(prompt, response)`` is a *meta-level*
+    # exemplar — same caveat as OL-C1: agent-loop-turn-level + Petri-
+    # per-turn callers land as OL-C2.2 follow-up after we have a clean
+    # API to extract per-turn pairs.
+    try:
+        if not args.dry_run and "true" in promoted_line.lower():
+            from core.llm.few_shot_pool import append_exemplar
+
+            fitness_delta = (
+                fitness - (sum(baseline_means.values()) / len(baseline_means))
+                if baseline_means
+                else fitness
+            )
+            append_exemplar(
+                user_msg=prompt_label,
+                assistant_msg=response_label,
+                fitness_delta=float(fitness_delta),
+                source="autoresearch_audit_promote",
+            )
+    except Exception:  # pragma: no cover — defensive
+        log.debug("OL-C2 few-shot pool append failed", exc_info=True)
     return 0
 
 

--- a/core/llm/few_shot_pool.py
+++ b/core/llm/few_shot_pool.py
@@ -164,6 +164,106 @@ def _coerce_entry(entry: Any, path: Path, lineno: int, *, strict: bool) -> FewSh
     )
 
 
+_DEDUP_SIG_CHARS = 16
+MAX_EXEMPLAR_POOL_SIZE = 1000
+"""Hard cap on pool size — FIFO eviction (oldest drop) when ``append_exemplar``
+makes the count exceed this. 1000 covers months of audit cycles in typical
+operator usage while keeping JSONL scan times sub-millisecond."""
+
+
+def _exemplar_signature(user_msg: str, assistant_msg: str) -> str:
+    """Idempotency key — appending the same ``(user, assistant)`` twice is no-op.
+
+    16-hex SHA256 prefix — collision risk ~2^-64 per pair; negligible at
+    1000-entry pool scale.
+    """
+    import hashlib
+
+    blob = f"{user_msg}\x1f{assistant_msg}".encode()
+    return hashlib.sha256(blob).hexdigest()[:_DEDUP_SIG_CHARS]
+
+
+def append_exemplar(
+    *,
+    user_msg: str,
+    assistant_msg: str,
+    fitness_delta: float = 0.0,
+    source: str = "",
+    pool_path: Path | None = None,
+    max_size: int = MAX_EXEMPLAR_POOL_SIZE,
+) -> bool:
+    """Append a ``(user, assistant)`` pair to the few-shot pool. Idempotent.
+
+    PR-OL-C2 (2026-05-22) — M3 (PR #1426/#1428) shipped the *reader* +
+    ``apply_few_shot_pool`` but no writer existed. The ``exemplars``
+    in-context slot (M4.4 #1435) was thus permanently empty in
+    production. This writer closes the loop.
+
+    Args:
+        user_msg: The verbatim user-side prompt for the exemplar.
+        assistant_msg: The verbatim assistant response.
+        fitness_delta: Promote-vs-baseline fitness delta (or any ranking
+            signal). ``apply_few_shot_pool`` sorts by this desc.
+        source: Provenance tag (``"autoresearch_audit_promote"`` /
+            ``"petri_per_turn"`` / ``"live_session"``).
+        pool_path: Optional override of the SoT path
+            (:data:`GLOBAL_FEW_SHOT_POOL_PATH`). Tests pass ``tmp_path``.
+        max_size: Cap; older entries (top of file) are evicted FIFO when
+            the new pool would exceed this.
+
+    Returns:
+        ``True`` if the exemplar was appended.
+        ``False`` if (a) the signature already exists (idempotent no-op),
+        or (b) the read / write failed silently (logged at WARNING).
+    """
+    target = pool_path or _FEW_SHOT_POOL_SOT_PATH
+    new_sig = _exemplar_signature(user_msg, assistant_msg)
+    existing_lines: list[str] = []
+    if target.is_file():
+        try:
+            existing_lines = target.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            log.warning("few-shot-pool read failed at %s: %s", target, exc)
+            return False
+    # Dedup — scan existing lines for the signature.
+    for line in existing_lines:
+        line_clean = line.strip()
+        if not line_clean:
+            continue
+        try:
+            entry = json.loads(line_clean)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        existing_user = entry.get("user_msg")
+        existing_assist = entry.get("assistant_msg")
+        if (
+            isinstance(existing_user, str)
+            and isinstance(existing_assist, str)
+            and _exemplar_signature(existing_user, existing_assist) == new_sig
+        ):
+            return False  # already present
+    # Build new line + FIFO evict.
+    new_row = {
+        "user_msg": user_msg,
+        "assistant_msg": assistant_msg,
+        "fitness_delta": float(fitness_delta),
+        "source": source,
+    }
+    new_line = json.dumps(new_row, ensure_ascii=False)
+    next_lines = [line for line in existing_lines if line.strip()] + [new_line]
+    if len(next_lines) > max_size:
+        next_lines = next_lines[-max_size:]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target.write_text("\n".join(next_lines) + "\n", encoding="utf-8")
+    except OSError as exc:
+        log.warning("few-shot-pool write failed at %s: %s", target, exc)
+        return False
+    return True
+
+
 def apply_few_shot_pool(
     messages: list[dict[str, Any]],
     pool: list[FewShotExemplar] | None,
@@ -190,4 +290,9 @@ def apply_few_shot_pool(
     return prefix + list(messages)
 
 
-__all__ = ["FewShotExemplar", "apply_few_shot_pool"]
+__all__ = [
+    "MAX_EXEMPLAR_POOL_SIZE",
+    "FewShotExemplar",
+    "append_exemplar",
+    "apply_few_shot_pool",
+]

--- a/core/llm/few_shot_pool.py
+++ b/core/llm/few_shot_pool.py
@@ -255,8 +255,12 @@ def append_exemplar(
     next_lines = [line for line in existing_lines if line.strip()] + [new_line]
     if len(next_lines) > max_size:
         next_lines = next_lines[-max_size:]
-    target.parent.mkdir(parents=True, exist_ok=True)
     try:
+        # mkdir + write_text both inside try — Codex MCP FLAG (PR-OL-C2):
+        # mkdir OSError must also yield ``False`` per the function contract,
+        # not raise. Keeping both calls in the same try keeps the "graceful
+        # on any I/O failure" guarantee honest.
+        target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("\n".join(next_lines) + "\n", encoding="utf-8")
     except OSError as exc:
         log.warning("few-shot-pool write failed at %s: %s", target, exc)

--- a/tests/test_ol_c2_few_shot_writer.py
+++ b/tests/test_ol_c2_few_shot_writer.py
@@ -1,0 +1,212 @@
+"""OL-C2 — few-shot pool writer invariants.
+
+Pins:
+- ``append_exemplar`` writes one JSONL row per call; reader round-trips.
+- Idempotency: same ``(user_msg, assistant_msg)`` → no second write.
+- FIFO eviction: pool > ``max_size`` drops oldest entries.
+- Graceful: read/write OSError → False return, no raise.
+- autoresearch/train.py promote step calls ``append_exemplar`` with
+  ``source="autoresearch_audit_promote"`` only on PROMOTED audits.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def pool_path(tmp_path: Path) -> Iterator[Path]:
+    yield tmp_path / "pool.jsonl"
+
+
+def _read_pool(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+# Signature ---------------------------------------------------------------
+
+
+def test_signature_deterministic() -> None:
+    from core.llm.few_shot_pool import _exemplar_signature
+
+    a = _exemplar_signature("q", "a")
+    b = _exemplar_signature("q", "a")
+    assert a == b
+    assert len(a) == 16
+
+
+def test_signature_differs_on_each_field() -> None:
+    from core.llm.few_shot_pool import _exemplar_signature
+
+    base = _exemplar_signature("q", "a")
+    assert _exemplar_signature("q2", "a") != base
+    assert _exemplar_signature("q", "a2") != base
+
+
+# Writer core -------------------------------------------------------------
+
+
+def test_append_writes_row(pool_path: Path) -> None:
+    from core.llm.few_shot_pool import append_exemplar
+
+    ok = append_exemplar(
+        user_msg="explain DPO",
+        assistant_msg="DPO trains preference-aligned models",
+        fitness_delta=0.7,
+        source="autoresearch_audit_promote",
+        pool_path=pool_path,
+    )
+    assert ok is True
+    rows = _read_pool(pool_path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["user_msg"] == "explain DPO"
+    assert row["assistant_msg"] == "DPO trains preference-aligned models"
+    assert row["fitness_delta"] == 0.7
+    assert row["source"] == "autoresearch_audit_promote"
+
+
+def test_append_idempotent_on_duplicate(pool_path: Path) -> None:
+    """Same (user, assistant) → second call returns False, no second row."""
+    from core.llm.few_shot_pool import append_exemplar
+
+    assert (
+        append_exemplar(user_msg="q", assistant_msg="a", fitness_delta=0.5, pool_path=pool_path)
+        is True
+    )
+    assert (
+        append_exemplar(user_msg="q", assistant_msg="a", fitness_delta=0.9, pool_path=pool_path)
+        is False
+    )
+    rows = _read_pool(pool_path)
+    assert len(rows) == 1
+    # First-write wins — fitness_delta stays 0.5
+    assert rows[0]["fitness_delta"] == 0.5
+
+
+def test_append_different_pairs_both_persist(pool_path: Path) -> None:
+    from core.llm.few_shot_pool import append_exemplar
+
+    append_exemplar(user_msg="q1", assistant_msg="a1", pool_path=pool_path)
+    append_exemplar(user_msg="q2", assistant_msg="a2", pool_path=pool_path)
+    rows = _read_pool(pool_path)
+    assert len(rows) == 2
+    assert {r["user_msg"] for r in rows} == {"q1", "q2"}
+
+
+# Reader round-trip -------------------------------------------------------
+
+
+def test_writer_reader_round_trip(pool_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """append_exemplar → _parse_jsonl reads it as a FewShotExemplar."""
+    from core.llm.few_shot_pool import _parse_jsonl, append_exemplar
+
+    append_exemplar(
+        user_msg="q1",
+        assistant_msg="a1",
+        fitness_delta=0.42,
+        source="autoresearch_audit_promote",
+        pool_path=pool_path,
+    )
+    raw = pool_path.read_text(encoding="utf-8")
+    exemplars = _parse_jsonl(raw, pool_path, strict=False)
+    assert len(exemplars) == 1
+    e = exemplars[0]
+    assert e.user_msg == "q1"
+    assert e.assistant_msg == "a1"
+    assert e.fitness_delta == 0.42
+    assert e.source == "autoresearch_audit_promote"
+
+
+# FIFO eviction -----------------------------------------------------------
+
+
+def test_fifo_eviction_when_over_cap(pool_path: Path) -> None:
+    """max_size=3 + 5 inserts → only last 3 survive."""
+    from core.llm.few_shot_pool import append_exemplar
+
+    for i in range(5):
+        append_exemplar(user_msg=f"q{i}", assistant_msg=f"a{i}", pool_path=pool_path, max_size=3)
+    rows = _read_pool(pool_path)
+    assert len(rows) == 3
+    # Oldest dropped — q0, q1 evicted; q2, q3, q4 survive
+    assert [r["user_msg"] for r in rows] == ["q2", "q3", "q4"]
+
+
+def test_default_cap_constant() -> None:
+    """Module constant exposed for callers + ratchet."""
+    from core.llm.few_shot_pool import MAX_EXEMPLAR_POOL_SIZE
+
+    assert MAX_EXEMPLAR_POOL_SIZE == 1000
+
+
+# Graceful ----------------------------------------------------------------
+
+
+def test_append_creates_parent_dir(tmp_path: Path) -> None:
+    """Missing parent dir → created lazily."""
+    from core.llm.few_shot_pool import append_exemplar
+
+    nested = tmp_path / "subdir" / "deeper" / "pool.jsonl"
+    assert not nested.parent.exists()
+    ok = append_exemplar(user_msg="q", assistant_msg="a", pool_path=nested)
+    assert ok is True
+    assert nested.is_file()
+
+
+def test_append_preserves_unicode(pool_path: Path) -> None:
+    """Non-ASCII content survives (CJK / emoji edge case)."""
+    from core.llm.few_shot_pool import append_exemplar
+
+    append_exemplar(
+        user_msg="안녕하세요 explain DPO",
+        assistant_msg="DPO 는 preference 모델 학습 기법입니다",
+        pool_path=pool_path,
+    )
+    raw = pool_path.read_text(encoding="utf-8")
+    assert "안녕하세요" in raw
+    assert "preference 모델" in raw
+
+
+# autoresearch caller wiring (source check) -------------------------------
+
+
+def test_train_py_imports_append_exemplar() -> None:
+    """``autoresearch/train.py`` must contain the import + call after OL-C1."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    assert "from core.llm.few_shot_pool import append_exemplar" in train_py
+    assert "append_exemplar(" in train_py
+    assert 'source="autoresearch_audit_promote"' in train_py
+
+
+def test_train_py_writer_gated_on_promote() -> None:
+    """The writer call must be guarded by ``promoted_line`` check
+    (rejected audits stay out of the pool)."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    # Pin the gate shape — args.dry_run skip + promoted_line truthy
+    assert "not args.dry_run" in train_py
+    assert '"true" in promoted_line.lower()' in train_py
+
+
+def test_train_py_writer_wrapped_in_try_except() -> None:
+    """Writer must be wrapped in try/except so audit cycle never breaks."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    pos = train_py.find("append_exemplar(")
+    assert pos > 0
+    preceding = train_py[max(0, pos - 1500) : pos]
+    assert "try:" in preceding, "append_exemplar must be wrapped in try/except"
+
+
+def test_train_py_writer_after_ol_c1_emit() -> None:
+    """OL-C2 writer must come AFTER OL-C1 emit (same scope, post-promote)."""
+    train_py = Path("autoresearch/train.py").read_text(encoding="utf-8")
+    emit_pos = train_py.find("emit_eval_response_recorded(")
+    append_pos = train_py.find("append_exemplar(")
+    assert emit_pos > 0 and append_pos > 0
+    assert append_pos > emit_pos


### PR DESCRIPTION
## Summary
- 신규 함수 `core/llm/few_shot_pool.append_exemplar(...)` — 16-hex signature idempotent dedup + FIFO eviction at 1000.
- `autoresearch/train.py::main()` 가 promote 통과 시 자동 append (`source="autoresearch_audit_promote"`).
- M3 sprint deception #2 해소 — exemplars in-context slot 의 input pool 활성화.

## Why
M3 (#1426/#1428) 가 reader + `apply_few_shot_pool` 만 출시하고 writer 부재. M4.4 (#1435) 의 exemplars slot 이 영구 empty pool 위 작동 = deception. OL-C2 가 writer + 첫 caller 출시로 실제 exemplar data 누적 시작.

## Changes
| File | Change |
|------|--------|
| `core/llm/few_shot_pool.py` | `append_exemplar` 함수 + `_exemplar_signature` 헬퍼 + `MAX_EXEMPLAR_POOL_SIZE=1000` 상수. `__all__` 에 신규 export 2 추가 |
| `autoresearch/train.py` | OL-C1 의 emit_eval 직후 append_exemplar 블록 추가. `args.dry_run is False AND "true" in promoted_line.lower()` 시에만 fire (rejected 는 exemplars 채널에 안 들어감). try/except 감쌈 |
| `tests/test_ol_c2_few_shot_writer.py` | 신규 — 8 def / 14 invariant test |
| `CHANGELOG.md` | PR-OL-C2 entry |

## Test inventory (14)
- Signature x2: determinism + field sensitivity
- Writer x4: one-row write / idempotent dup / multi-pair / round-trip with `_parse_jsonl`
- FIFO x2: eviction at over-cap (5 → 3) / `MAX_EXEMPLAR_POOL_SIZE` constant exposed
- Graceful x2: parent dir lazy creation / Unicode preserve (CJK)
- train.py source verification x4: import 존재 / promote gate (dry_run + promoted truthy) / try/except wrap / OL-C1 emit 후 order

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Writer 이미 존재 | No | `grep -rn "FewShotExemplar\|append.*few.shot" core/` 가 reader 만 (3건) → writer 신규 |
| Tier 2 untouched | Yes | bootstrap / runner / fitness_gate / HookSystem / importlinter / AgentDefinition.model — diff 없음 |
| AgenticLoop-level + Petri-per-turn writers | Deferred (OL-C2.2) | meta-level vs turn-level scope decision은 ADR 후속 |
| Default no-op preserved | Yes | append_exemplar 가 호출 안 되면 pool 영향 0 (writer는 ON-DEMAND) |

## Verification
- [x] `uv run ruff format` clean
- [x] `uv run ruff check core/llm/few_shot_pool.py autoresearch/train.py tests/test_ol_c2_few_shot_writer.py` clean
- [x] `uv run mypy core/llm/few_shot_pool.py` clean
- [x] `uv run pytest tests/test_ol_c2_few_shot_writer.py -q` 14/14 PASS

## Reference
- ADR-012 M4 in-context wiring
- `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-C2
- M3 PR #1426 + #1428 (reader 출시 + writer deferred)
- OL-C1 PR #1442 (emit_eval caller — 본 PR 의 prerequisite)