### PR TITLE
PR-OL-C3 — memory_recall MD writer (close M4.4.1 reader's write-side)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,43 @@ functional change.
 
 ### Added
 
+- **PR-OL-C3 — `memory_recall` MD writer (close M4.4.1 reader's write-side).**
+  M4.4.1 (#1436) 가 `core/self_improving_loop/memory_recall.load_memory_entries`
+  + `in_context_wiring.py:123` 로 reader 만 출시 → 운영자가 직접 `.md`
+  파일을 손으로 채우지 않는 한 `memory_recall` in-context slot 이 영구
+  empty list 위에 ranking 작동 (PR-OL-C2 의 few-shot pool 과 동일한
+  reader-without-writer deception). **신규 모듈**
+  `core/memory/recall_writer.py` — pure 유틸 `write_recall_entry(*, name,
+  description, body, type_label, recall_dir=None, overwrite=False)` 가
+  M4.4.1 frontmatter parser 가 기대하는 정확한 schema
+  (`---\nname: …\ndescription: …\nmetadata:\n  type: …\n---\n\n{body}\n`)
+  로 한 줄당 `.md` 를 작성. `_slugify_name` 으로 alnum+hyphen 파일명 보장,
+  `_escape_frontmatter_value` 로 multi-line name/description 단일 라인
+  강제 (YAML-light parser 의 line-per-key 규약). `mkdir(parents=True,
+  exist_ok=True)` + `write_text` 단일 try (Codex MCP PR-OL-C2 의 mkdir-
+  outside-try 사례 적용). Idempotent — `overwrite=False` (default) 가
+  기존 슬러그 파일 보존, `True` 시 대체. `resolve_recall_dir()` 가
+  `$GEODE_MEMORY_RECALL_DIR` 운영자 override > `~/.geode/memory/recall/`
+  default — reader 와 *같은* env var 를 honour 해서 운영자가 dir 한
+  곳만 옮기면 read+write 둘 다 따라옴. 4 canonical type 상수
+  (`RECALL_TYPE_{USER,FEEDBACK,PROJECT,REFERENCE}`) + `VALID_RECALL_TYPES`
+  frozenset 노출 — Claude Code 의 auto-memory schema 와 parity. Non-
+  canonical type 도 작성 자체는 허용 (DEBUG log) → 운영자 도메인 별
+  custom type 막지 않음. **Auto-trigger 부재 (의도)** — `SESSION_ENDED`
+  hook 에서 자동 발화 / LLM-curator 는 OL-C3.2 follow-up 으로 deferred,
+  근거: (1) ADR 부재 (every session 채택? promoted-only? curator?),
+  (2) cost ceiling 미합의, (3) disk usage cap 미합의. 현재 entry-point
+  은 운영자가 CLI/REPL slash 로 `write_recall_entry` 직접 호출. **16
+  invariant test** (`tests/test_ol_c3_recall_writer.py`) — resolve x2
+  (env override / 기본 path), slugify x3 (canonical / 공백+punct /
+  empty→untitled), writer x6 (파일 생성 / M4.4.1 reader round-trip /
+  idempotent skip / overwrite=True / multi-line frontmatter strip /
+  parent dir 생성 / non-canonical type 작성), list x2 (정렬 / 없는 dir
+  empty), batch x2 (전체 작성 / 기존 slug skip). Reader-writer schema
+  drift 방지의 핵심은 `test_write_round_trips_with_m4_4_1_reader` 가
+  *실제* reader 를 import 해서 동일 파일을 parsing — 한 쪽이 schema
+  변경하면 즉시 RED. Quality gates clean (ruff + mypy + 16/16 pytest).
+
 - **PR-OL-C2 — few-shot pool writer + autoresearch promote 호출자.**
   M3 (#1426/#1428) 이 reader (`_load_few_shot_pool_override` +
   `apply_few_shot_pool`) 만 출시하고 writer 부재로 exemplars in-context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,11 @@ functional change.
   description, body, type_label, recall_dir=None, overwrite=False)` 가
   M4.4.1 frontmatter parser 가 기대하는 정확한 schema
   (`---\nname: …\ndescription: …\nmetadata:\n  type: …\n---\n\n{body}\n`)
-  로 한 줄당 `.md` 를 작성. `_slugify_name` 으로 alnum+hyphen 파일명 보장,
-  `_escape_frontmatter_value` 로 multi-line name/description 단일 라인
-  강제 (YAML-light parser 의 line-per-key 규약). `mkdir(parents=True,
+  로 한 줄당 `.md` 를 작성. `_slugify_name` 으로 alnum+hyphen+underscore
+  파일명 보장, `_escape_frontmatter_value` 로 multi-line name/description/
+  type_label 단일 라인 강제 (YAML-light parser 의 line-per-key 규약 —
+  type_label 까지 escape 하는 건 Codex MCP fix-up 후 추가, frontmatter
+  injection 방지). `mkdir(parents=True,
   exist_ok=True)` + `write_text` 단일 try (Codex MCP PR-OL-C2 의 mkdir-
   outside-try 사례 적용). Idempotent — `overwrite=False` (default) 가
   기존 슬러그 파일 보존, `True` 시 대체. `resolve_recall_dir()` 가
@@ -97,16 +99,17 @@ functional change.
   hook 에서 자동 발화 / LLM-curator 는 OL-C3.2 follow-up 으로 deferred,
   근거: (1) ADR 부재 (every session 채택? promoted-only? curator?),
   (2) cost ceiling 미합의, (3) disk usage cap 미합의. 현재 entry-point
-  은 운영자가 CLI/REPL slash 로 `write_recall_entry` 직접 호출. **16
+  은 운영자가 CLI/REPL slash 로 `write_recall_entry` 직접 호출. **17
   invariant test** (`tests/test_ol_c3_recall_writer.py`) — resolve x2
   (env override / 기본 path), slugify x3 (canonical / 공백+punct /
-  empty→untitled), writer x6 (파일 생성 / M4.4.1 reader round-trip /
+  empty→untitled), writer x7 (파일 생성 / M4.4.1 reader round-trip /
   idempotent skip / overwrite=True / multi-line frontmatter strip /
-  parent dir 생성 / non-canonical type 작성), list x2 (정렬 / 없는 dir
-  empty), batch x2 (전체 작성 / 기존 slug skip). Reader-writer schema
-  drift 방지의 핵심은 `test_write_round_trips_with_m4_4_1_reader` 가
-  *실제* reader 를 import 해서 동일 파일을 parsing — 한 쪽이 schema
-  변경하면 즉시 RED. Quality gates clean (ruff + mypy + 16/16 pytest).
+  parent dir 생성 / non-canonical type 작성 / type_label newline-escape
+  injection 방지), list x2 (정렬 / 없는 dir empty), batch x2 (전체 작성
+  / 기존 slug skip). Reader-writer schema drift 방지의 핵심은
+  `test_write_round_trips_with_m4_4_1_reader` 가 *실제* reader 를 import
+  해서 동일 파일을 parsing — 한 쪽이 schema 변경하면 즉시 RED. Quality
+  gates clean (ruff + mypy + 17/17 pytest).
 
 - **PR-OL-C2 — few-shot pool writer + autoresearch promote 호출자.**
   M3 (#1426/#1428) 이 reader (`_load_few_shot_pool_override` +

--- a/core/memory/recall_writer.py
+++ b/core/memory/recall_writer.py
@@ -1,0 +1,213 @@
+"""Memory-recall MD writer — OL-C3 (2026-05-22) substrate.
+
+M4.4.1 (PR #1436) shipped the *reader* — `memory_recall.load_memory_entries`
+walks `~/.geode/memory/recall/*.md`, ranks by keyword overlap × recency,
+prepends a `<memory-recall>` block to the system prompt. But no writer
+existed in GEODE itself — the slot's input pool was either operator-
+hand-curated or empty.
+
+OL-C3 ships the writer that closes that loop. The writer is a *pure
+utility* — caller decides when to invoke it and what to record. We
+deliberately do NOT auto-fire on every SESSION_ENDED because:
+
+* Noise: every interactive turn is rarely worth persisting.
+* Cost: auto-LLM-curator on every session would cost real money.
+* Schema lock-in: deciding what counts as a "memory" is operator-
+  domain-specific and we don't want to bake one choice into core.
+
+Auto-trigger paths (SESSION_ENDED hook handler + LLM curator) land as
+OL-C3.2 follow-up after we have:
+1. An ADR on selection (every session? promoted only? LLM-curator?).
+2. A cost ceiling on the curator path.
+3. A cap on memory-pool disk usage.
+
+For now: operator calls `write_recall_entry(...)` via CLI / REPL slash
+when a session yields a memory worth keeping.
+
+**File shape** (matches M4.4.1 reader's frontmatter parser):
+
+.. code-block:: markdown
+
+    ---
+    name: feedback-cli-budget
+    description: User prefers Sonnet over Opus when quota is exhausted.
+    metadata:
+      type: feedback
+    ---
+
+    Body text — verbatim or curated insight. M4.4.1 ranker uses
+    description + body for keyword overlap scoring.
+
+**Path resolution**: writes to `core.memory.recall_writer.resolve_recall_dir()`
+which mirrors M4.4.1's reader resolution — `$GEODE_MEMORY_RECALL_DIR`
+env override > `~/.geode/memory/recall/` default. Parent dir is
+created lazily.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from core.paths import GLOBAL_MEMORY_DIR
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "GEODE_MEMORY_RECALL_DIR_ENV",
+    "RECALL_TYPE_FEEDBACK",
+    "RECALL_TYPE_PROJECT",
+    "RECALL_TYPE_REFERENCE",
+    "RECALL_TYPE_USER",
+    "VALID_RECALL_TYPES",
+    "resolve_recall_dir",
+    "write_recall_entry",
+]
+
+GEODE_MEMORY_RECALL_DIR_ENV = "GEODE_MEMORY_RECALL_DIR"
+"""Match M4.4.1 reader's env var (`core/self_improving_loop/memory_recall.py`)
+so writer + reader honour the same operator override."""
+
+_DEFAULT_RECALL_DIR = GLOBAL_MEMORY_DIR / "recall"
+
+# 4 canonical types — match Claude Code's auto-memory schema. Operators
+# can write any string but using the canonical set keeps the reader's
+# type-tag rendering consistent.
+RECALL_TYPE_USER = "user"
+RECALL_TYPE_FEEDBACK = "feedback"
+RECALL_TYPE_PROJECT = "project"
+RECALL_TYPE_REFERENCE = "reference"
+
+VALID_RECALL_TYPES: frozenset[str] = frozenset(
+    {RECALL_TYPE_USER, RECALL_TYPE_FEEDBACK, RECALL_TYPE_PROJECT, RECALL_TYPE_REFERENCE}
+)
+
+# Filenames must be filesystem-safe — alnum + hyphen + underscore.
+_NAME_SLUG_RE = re.compile(r"[^A-Za-z0-9_\-]+")
+
+
+def resolve_recall_dir() -> Path:
+    """Where to write — env override > default. Always returns a Path
+    (does NOT verify existence; the writer creates it lazily)."""
+    override = os.environ.get(GEODE_MEMORY_RECALL_DIR_ENV)
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_RECALL_DIR
+
+
+def _slugify_name(name: str) -> str:
+    """Turn an operator-provided name into a filesystem-safe slug.
+
+    Replaces non-alnum runs with single hyphen, lowercases, strips
+    leading/trailing hyphens. Empty result → ``"untitled"`` (so the
+    writer always produces a usable filename even on bizarre input).
+    """
+    slug = _NAME_SLUG_RE.sub("-", name).strip("-").lower()
+    return slug or "untitled"
+
+
+def _escape_frontmatter_value(value: str) -> str:
+    """Strip newlines from frontmatter scalar values — they'd break the
+    YAML-light parser in M4.4.1's reader (which is single-line-per-key)."""
+    return value.replace("\n", " ").replace("\r", " ").strip()
+
+
+def write_recall_entry(
+    *,
+    name: str,
+    description: str,
+    body: str,
+    type_label: str = RECALL_TYPE_FEEDBACK,
+    recall_dir: Path | None = None,
+    overwrite: bool = False,
+) -> Path | None:
+    """Write one frontmatter MD entry to the recall dir.
+
+    Args:
+        name: Slug for the filename + frontmatter ``name`` field. Will
+            be slugified (alnum + hyphen).
+        description: One-line summary. M4.4.1 ranker uses this for
+            keyword overlap (along with body).
+        body: Verbatim memory content (multi-line allowed).
+        type_label: Canonical type (``"user"`` / ``"feedback"`` /
+            ``"project"`` / ``"reference"``). Free-form strings allowed
+            but logged at DEBUG so operators notice typos.
+        recall_dir: Override the resolved dir (test fixture; defaults
+            to :func:`resolve_recall_dir`).
+        overwrite: When True, replace an existing file with the same
+            slug. When False (default), the function returns ``None``
+            if the file already exists (idempotent no-op).
+
+    Returns:
+        ``Path`` to the written file on success.
+        ``None`` if (a) ``overwrite=False`` and file exists, or
+        (b) write failed (OSError, logged at WARNING).
+    """
+    target_dir = recall_dir if recall_dir is not None else resolve_recall_dir()
+    slug = _slugify_name(name)
+    if type_label not in VALID_RECALL_TYPES:
+        log.debug(
+            "recall_writer: type %r not in canonical set %s; writing anyway",
+            type_label,
+            sorted(VALID_RECALL_TYPES),
+        )
+    safe_name = _escape_frontmatter_value(name)
+    safe_desc = _escape_frontmatter_value(description)
+    file_path = target_dir / f"{slug}.md"
+    if file_path.exists() and not overwrite:
+        log.debug("recall_writer: %s already exists; skip (overwrite=False)", file_path)
+        return None
+    content = (
+        f"---\nname: {safe_name}\ndescription: {safe_desc}\n"
+        f"metadata:\n  type: {type_label}\n---\n\n{body.rstrip()}\n"
+    )
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        log.warning("recall_writer: failed to write %s: %s", file_path, exc)
+        return None
+    return file_path
+
+
+def list_recall_entries(recall_dir: Path | None = None) -> list[Path]:
+    """Light-weight enumeration — returns sorted ``.md`` paths.
+
+    Tests use this to verify the writer's output without re-implementing
+    the M4.4.1 reader. Returns an empty list if the dir is missing.
+    """
+    target_dir = recall_dir if recall_dir is not None else resolve_recall_dir()
+    if not target_dir.is_dir():
+        return []
+    return sorted(target_dir.glob("*.md"))
+
+
+def write_recall_entries(
+    entries: Iterable[dict[str, str]],
+    *,
+    recall_dir: Path | None = None,
+    overwrite: bool = False,
+) -> list[Path]:
+    """Batch convenience — write multiple entries, return paths that succeeded.
+
+    Each entry must carry ``name`` + ``description`` + ``body``;
+    optional ``type_label``. Failures (already-exists / OSError) are
+    logged + skipped — return list only includes the writes that
+    actually persisted to disk.
+    """
+    out: list[Path] = []
+    for entry in entries:
+        path = write_recall_entry(
+            name=entry["name"],
+            description=entry["description"],
+            body=entry["body"],
+            type_label=entry.get("type_label", RECALL_TYPE_FEEDBACK),
+            recall_dir=recall_dir,
+            overwrite=overwrite,
+        )
+        if path is not None:
+            out.append(path)
+    return out

--- a/core/memory/recall_writer.py
+++ b/core/memory/recall_writer.py
@@ -156,13 +156,14 @@ def write_recall_entry(
         )
     safe_name = _escape_frontmatter_value(name)
     safe_desc = _escape_frontmatter_value(description)
+    safe_type = _escape_frontmatter_value(type_label)
     file_path = target_dir / f"{slug}.md"
     if file_path.exists() and not overwrite:
         log.debug("recall_writer: %s already exists; skip (overwrite=False)", file_path)
         return None
     content = (
         f"---\nname: {safe_name}\ndescription: {safe_desc}\n"
-        f"metadata:\n  type: {type_label}\n---\n\n{body.rstrip()}\n"
+        f"metadata:\n  type: {safe_type}\n---\n\n{body.rstrip()}\n"
     )
     try:
         target_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_ol_c3_recall_writer.py
+++ b/tests/test_ol_c3_recall_writer.py
@@ -1,0 +1,244 @@
+"""OL-C3 — memory_recall MD writer invariants.
+
+Pins:
+- ``write_recall_entry`` writes frontmatter MD matching M4.4.1 reader's
+  schema (name / description / metadata.type) so round-trip works.
+- Idempotency: same slug → ``None`` (no overwrite) unless explicit
+  ``overwrite=True``.
+- Filename slugification: arbitrary names become filesystem-safe slugs.
+- Resolution chain: ``$GEODE_MEMORY_RECALL_DIR`` env > default.
+- Graceful: OSError logged + returns ``None`` (no raise).
+- Round-trip with M4.4.1 reader (`load_memory_entries`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def recall_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    target = tmp_path / "recall"
+    monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(target))
+    yield target
+
+
+# resolve_recall_dir --------------------------------------------------------
+
+
+def test_resolve_uses_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from core.memory.recall_writer import resolve_recall_dir
+
+    monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(tmp_path / "custom"))
+    assert resolve_recall_dir() == tmp_path / "custom"
+
+
+def test_resolve_default_when_no_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.memory.recall_writer import resolve_recall_dir
+
+    monkeypatch.delenv("GEODE_MEMORY_RECALL_DIR", raising=False)
+    # Default ends with `memory/recall`
+    assert resolve_recall_dir().name == "recall"
+    assert resolve_recall_dir().parent.name == "memory"
+
+
+# slugify -------------------------------------------------------------------
+
+
+def test_slugify_canonical_input() -> None:
+    from core.memory.recall_writer import _slugify_name
+
+    assert _slugify_name("feedback-cli-budget") == "feedback-cli-budget"
+
+
+def test_slugify_strips_spaces_and_punctuation() -> None:
+    from core.memory.recall_writer import _slugify_name
+
+    assert _slugify_name("User Wants Terse Output!") == "user-wants-terse-output"
+
+
+def test_slugify_empty_input_yields_untitled() -> None:
+    from core.memory.recall_writer import _slugify_name
+
+    assert _slugify_name("") == "untitled"
+    assert _slugify_name("!!!") == "untitled"
+
+
+# write_recall_entry --------------------------------------------------------
+
+
+def test_write_creates_md_file(recall_dir: Path) -> None:
+    from core.memory.recall_writer import write_recall_entry
+
+    path = write_recall_entry(
+        name="feedback-test",
+        description="user prefers terse",
+        body="The user told me they want short responses.",
+        type_label="feedback",
+    )
+    assert path is not None
+    assert path.is_file()
+    content = path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "name: feedback-test" in content
+    assert "description: user prefers terse" in content
+    assert "type: feedback" in content
+    assert "The user told me they want short responses." in content
+
+
+def test_write_round_trips_with_m4_4_1_reader(recall_dir: Path) -> None:
+    """Writer output must parse cleanly via M4.4.1's reader."""
+    from core.memory.recall_writer import write_recall_entry
+    from core.self_improving_loop.memory_recall import load_memory_entries
+
+    write_recall_entry(
+        name="feedback-roundtrip",
+        description="round-trip check",
+        body="Body content for the round-trip.",
+        type_label="feedback",
+    )
+    entries = load_memory_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.name == "feedback-roundtrip"
+    assert entry.description == "round-trip check"
+    assert entry.type == "feedback"
+    assert "Body content for the round-trip." in entry.body
+
+
+def test_write_idempotent_no_overwrite_default(recall_dir: Path) -> None:
+    """Second write with same slug → None, file unchanged."""
+    from core.memory.recall_writer import write_recall_entry
+
+    p1 = write_recall_entry(name="same", description="first", body="b1", type_label="user")
+    assert p1 is not None
+    p2 = write_recall_entry(name="same", description="second", body="b2", type_label="user")
+    assert p2 is None
+    # Original content preserved
+    assert "description: first" in p1.read_text(encoding="utf-8")
+    assert "b1" in p1.read_text(encoding="utf-8")
+
+
+def test_write_overwrites_when_flag_set(recall_dir: Path) -> None:
+    from core.memory.recall_writer import write_recall_entry
+
+    p1 = write_recall_entry(name="same", description="first", body="b1", type_label="user")
+    p2 = write_recall_entry(
+        name="same",
+        description="second",
+        body="b2",
+        type_label="user",
+        overwrite=True,
+    )
+    assert p2 is not None
+    assert p2 == p1
+    content = p2.read_text(encoding="utf-8")
+    assert "description: second" in content
+    assert "b2" in content
+
+
+def test_write_strips_newlines_from_frontmatter(recall_dir: Path) -> None:
+    """Newlines in name / description would break YAML-light parser."""
+    from core.memory.recall_writer import write_recall_entry
+
+    path = write_recall_entry(
+        name="multi\nline\nname",
+        description="multi\nline\ndesc",
+        body="body keeps\nnewlines\nfine",
+        type_label="user",
+    )
+    assert path is not None
+    content = path.read_text(encoding="utf-8")
+    # frontmatter section (before second ---) must NOT contain raw \n in values
+    parts = content.split("---")
+    assert len(parts) >= 3
+    fm = parts[1]
+    # Lines within fm starting with "name:" / "description:" must be single-line
+    for line in fm.splitlines():
+        if line.startswith(("name:", "description:")):
+            assert "\n" not in line and "\r" not in line
+    # body section keeps newlines
+    body_section = parts[2]
+    assert "body keeps\nnewlines\nfine" in body_section
+
+
+def test_write_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing parent dir → created lazily."""
+    from core.memory.recall_writer import write_recall_entry
+
+    nested = tmp_path / "subdir" / "deeper" / "recall"
+    monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(nested))
+    assert not nested.exists()
+    path = write_recall_entry(
+        name="nested-test", description="d", body="b", type_label="user"
+    )
+    assert path is not None
+    assert nested.is_dir()
+
+
+def test_write_unknown_type_label_still_writes(recall_dir: Path) -> None:
+    """Non-canonical type_label is allowed (logged DEBUG, not rejected)."""
+    from core.memory.recall_writer import write_recall_entry
+
+    path = write_recall_entry(
+        name="custom-type",
+        description="d",
+        body="b",
+        type_label="custom_operator_type",
+    )
+    assert path is not None
+    assert "type: custom_operator_type" in path.read_text(encoding="utf-8")
+
+
+# list_recall_entries -------------------------------------------------------
+
+
+def test_list_returns_sorted_paths(recall_dir: Path) -> None:
+    from core.memory.recall_writer import list_recall_entries, write_recall_entry
+
+    for slug in ["zeta", "alpha", "mike"]:
+        write_recall_entry(name=slug, description="d", body="b", type_label="user")
+    paths = list_recall_entries()
+    names = [p.stem for p in paths]
+    assert names == sorted(names)
+
+
+def test_list_empty_when_dir_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from core.memory.recall_writer import list_recall_entries
+
+    monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(tmp_path / "no_such_dir"))
+    assert list_recall_entries() == []
+
+
+# write_recall_entries (batch) ----------------------------------------------
+
+
+def test_batch_writes_all_entries(recall_dir: Path) -> None:
+    from core.memory.recall_writer import (
+        list_recall_entries,
+        write_recall_entries,
+    )
+
+    paths = write_recall_entries(
+        [
+            {"name": "a", "description": "ad", "body": "ab"},
+            {"name": "b", "description": "bd", "body": "bb", "type_label": "project"},
+            {"name": "c", "description": "cd", "body": "cb"},
+        ]
+    )
+    assert len(paths) == 3
+    assert len(list_recall_entries()) == 3
+
+
+def test_batch_skips_existing_without_overwrite(recall_dir: Path) -> None:
+    from core.memory.recall_writer import write_recall_entries
+
+    # First batch
+    paths_a = write_recall_entries([{"name": "dup", "description": "d1", "body": "b1"}])
+    assert len(paths_a) == 1
+    # Second batch — same slug
+    paths_b = write_recall_entries([{"name": "dup", "description": "d2", "body": "b2"}])
+    assert len(paths_b) == 0

--- a/tests/test_ol_c3_recall_writer.py
+++ b/tests/test_ol_c3_recall_writer.py
@@ -191,6 +191,37 @@ def test_write_unknown_type_label_still_writes(recall_dir: Path) -> None:
     assert "type: custom_operator_type" in path.read_text(encoding="utf-8")
 
 
+def test_write_escapes_newlines_in_type_label(recall_dir: Path) -> None:
+    """type_label with embedded newlines must NOT inject frontmatter keys.
+
+    Codex MCP catch (PR-OL-C3 fix-up). Without escaping,
+    ``type_label="user\\nname: hijack"`` would write::
+
+        metadata:
+          type: user
+        name: hijack
+        ---
+
+    and the reader would override the original ``name`` field.
+    The escape collapses the newline so the injected key never reaches
+    the reader's parser.
+    """
+    from core.memory.recall_writer import write_recall_entry
+    from core.self_improving_loop.memory_recall import load_memory_entries
+
+    write_recall_entry(
+        name="original-name",
+        description="d",
+        body="b",
+        type_label="user\nname: hijack",
+    )
+    entries = load_memory_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.name == "original-name"
+    assert "hijack" not in entry.name
+
+
 # list_recall_entries -------------------------------------------------------
 
 

--- a/tests/test_ol_c3_recall_writer.py
+++ b/tests/test_ol_c3_recall_writer.py
@@ -172,9 +172,7 @@ def test_write_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     nested = tmp_path / "subdir" / "deeper" / "recall"
     monkeypatch.setenv("GEODE_MEMORY_RECALL_DIR", str(nested))
     assert not nested.exists()
-    path = write_recall_entry(
-        name="nested-test", description="d", body="b", type_label="user"
-    )
+    path = write_recall_entry(name="nested-test", description="d", body="b", type_label="user")
     assert path is not None
     assert nested.is_dir()
 


### PR DESCRIPTION
## Summary

- M4.4.1 (#1436) 가 `memory_recall` reader (`load_memory_entries` +
  `in_context_wiring.py:123`) 만 출시했고 GEODE 안에 writer 가 부재 →
  운영자가 손으로 `~/.geode/memory/recall/*.md` 채우지 않는 한 slot 이
  영구 empty list 위에 ranking 작동 (PR-OL-C2 #1443 의 few-shot pool 과
  같은 reader-without-writer deception).
- 신규 모듈 `core/memory/recall_writer.write_recall_entry` — M4.4.1
  frontmatter parser 가 기대하는 정확한 schema 로 `.md` 작성, idempotent
  (`overwrite=False` default), env-var aware, multi-line frontmatter
  값 strip, mkdir+write 단일 try (Codex MCP OL-C2 lesson).
- 16 invariant tests. Round-trip 테스트는 *실제* M4.4.1 reader 를 import
  해서 schema drift 발생시 즉시 RED.

## Why

M4 스프린트 retrospective 가 노출한 두 reader-without-writer deception
중 두 번째 (첫 번째는 OL-C2 의 few-shot pool, #1443 에서 해소). M4.4.1
reader 는 wired 됐지만 GEODE 내부 어디서도 `.md` 파일을 쓰지 않아 in-
context slot 이 운영자 hand-curation 의존. OL-C3 가 writer 만 제공
(auto-trigger 는 OL-C3.2 follow-up, deferred — ADR/cost ceiling/disk cap
미합의).

## Changes

| File | Change |
|------|--------|
| `core/memory/recall_writer.py` (new) | `write_recall_entry`, `list_recall_entries`, `write_recall_entries`, `resolve_recall_dir`, `_slugify_name`, `_escape_frontmatter_value`, 4 canonical type 상수 |
| `tests/test_ol_c3_recall_writer.py` (new) | 16 invariants — resolve / slugify / writer / list / batch + reader round-trip |
| `CHANGELOG.md` | `[Unreleased]` Added 에 PR-OL-C3 entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Reader-side parity (M4.4.1) | Already exists | `core/self_improving_loop/memory_recall.load_memory_entries`, wired in `in_context_wiring.py:123` |
| Writer | Implemented | `core/memory/recall_writer.write_recall_entry` |
| Reader-writer round-trip | Implemented | `test_write_round_trips_with_m4_4_1_reader` imports *actual* reader → schema drift = RED |
| Idempotent skip on existing slug | Implemented | `overwrite=False` (default) returns `None` |
| env override parity (`$GEODE_MEMORY_RECALL_DIR`) | Implemented | Same var as reader |
| mkdir-outside-try (PR-OL-C2 Codex catch) | Avoided | Both calls in single try block |
| Auto-trigger (SESSION_ENDED + LLM curator) | Dropped → OL-C3.2 | ADR + cost ceiling + disk cap 미합의 — pure utility 로 ship |

## Verification

- [x] ruff check clean (`uv run ruff check core/memory/recall_writer.py tests/test_ol_c3_recall_writer.py`)
- [x] mypy clean (`uv run mypy core/memory/recall_writer.py`)
- [x] pytest pass — 16/16 (`uv run pytest tests/test_ol_c3_recall_writer.py`)
- [ ] CI green (5/5 — pending push)
- [ ] Codex MCP LLM-as-Judge (pending)

## Reference

- M4.4.1 reader: `core/self_improving_loop/memory_recall.py` (PR #1436)
- Reader wiring: `core/self_improving_loop/in_context_wiring.py:116-137`
- Sibling reader-without-writer fix: PR-OL-C2 #1443 (few-shot pool)
- Roadmap: `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-C3
- Auto-trigger follow-up: OL-C3.2 (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)