### PR TITLE
PR-OL-A1 — self-improving loop mutator auto-trigger (cron + 4-backend grounded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,18 +81,26 @@ functional change.
   runner_factory=None, lock_path=None, timestamp_path=None, now=None)`
   가 6 terminal state 중 하나 (`fired` / `lock_busy` /
   `interval_blocked` / `runner_error` / `parse_error` / `disabled`) 의
-  `AutoTriggerStatus` dataclass 반환. 절대 raise 하지 않음 — scheduler
-  loop crash 방지. **2-layer 동시성 가드**: (1) `fcntl.flock` LOCK_EX |
-  LOCK_NB 기반 advisory lock (`~/.geode/self-improving-loop/auto_trigger.lock`)
+  `AutoTriggerStatus` dataclass 반환. 발화 중 발생 가능한 모든 예외
+  (factory raise / runner __init__ raise / `run_once()` raise)는 try/except
+  로 잡혀 `runner_error` 또는 `parse_error` state 로 환원 — scheduler loop
+  crash 방지 (Codex MCP fix-up). **2-layer 동시성 가드**: (1) `fcntl.flock`
+  LOCK_EX | LOCK_NB advisory lock (`~/.geode/self-improving-loop/auto_trigger.lock`)
   — 두 cron-fire 혹은 cron + manual `geode self-improve mutate` race 차단,
   kernel crash 시 자동 해제. (2) `min_interval_minutes` 타임스탬프 게이트
-  (`auto_trigger_last_run.txt`) — clock-skew / restart re-fire 흡수. **4-backend
-  추상화 검증**: wrapper 가 자체 source vocabulary 를 가지지 않고
+  (`auto_trigger_last_run.txt`) — clock-skew / restart re-fire 흡수. 게이트는
+  lock 획득 *전후* 모두 평가 (TOCTOU 방어 — Codex MCP fix-up). **4-backend
+  source 라우팅 검증**: wrapper 가 자체 source vocabulary 를 가지지 않고
   `SelfImprovingLoopRunner.run_once()` 에 dispatch. Runner 는 PR-PAPERCLIP
   (#1433) 의 `[self_improving_loop.mutator].source` 4-enum (`auto` /
-  `api_key` / `claude-cli` / `openai-codex`) 을 이미 honour — Claude Code
-  subscription, Codex CLI subscription, Anthropic PAYG, OpenAI PAYG 4
-  backend 모두 추가 코드 없이 작동 (어댑터 추상화 적합성 확인 완료).
+  `api_key` / `claude-cli` / `openai-codex`) 을 이미 honour. Dispatch
+  topology 는 *두 경로*: (a) `claude-cli` / `openai-codex` 는
+  `core/self_improving_loop/cli_subprocess.py` 의 subprocess 로 라우팅
+  (Claude Code Max / ChatGPT Plus subscription 청구 — `_ADAPTER_MAP` 우회),
+  (b) `auto` / `api_key` 는 `core/llm/adapters.py::_ADAPTER_MAP` 의 3-provider
+  (`anthropic` / `openai` / `glm`) + `openai-codex` 어댑터 경유. 총 4 backend
+  (Claude Code subscription / Codex CLI subscription / Anthropic PAYG / OpenAI
+  PAYG) 모두 추가 코드 없이 작동.
   **신규 config** `[self_improving_loop.scheduler]` (`SchedulerConfig` in
   `core/config/self_improving_loop.py`) — `enabled: bool = False` (opt-in
   default), `cron: str = "0 */6 * * *"` (5-field cron, every 6 hours),
@@ -103,18 +111,19 @@ functional change.
   min_interval_minutes)` 호출. Default `enabled=False` 이면 `TriggerConfig`
   등록 자체를 건너뜀 — 즉 운영자가 `config.toml` 에 `enabled = true` 명시
   안 하면 *코드 path 가 dormant*. `try/except` 로 wiring 오류가 startup
-  block 하지 않게 가드. **24 invariant test** (`tests/test_ol_a1_auto_trigger.py`)
+  block 하지 않게 가드. **26 invariant test** (`tests/test_ol_a1_auto_trigger.py`)
   — SchedulerConfig defaults x4 (off / 6-hour cron / 60-min interval +
   range validation + extra forbid + top-level config carries scheduler) +
   lock semantics x3 (acquire fd / contention rejection / parent dir
   creation) + timestamp x3 (missing → None / round-trip / unparseable →
   None) + min-interval x3 (no prior / recent blocks / old satisfies) +
-  auto_trigger_mutator terminal states x7 (disabled / interval_blocked /
+  auto_trigger_mutator terminal states x9 (disabled / interval_blocked /
   lock_busy / fired / runner_error / parse_error / lock-released-after-
-  raise) + lazy runner import x1 + register_auto_trigger wiring x3
-  (disabled skip / enabled registers SCHEDULED TriggerConfig / closure
-  forwards into `auto_trigger_mutator`). Quality gates clean (ruff +
-  mypy + 24/24 pytest + 403 adjacent scheduler/wiring/trigger/automation
+  raise / runner-factory-raises → runner_error / post-lock interval re-check
+  blocks fresh timestamp) + lazy runner import x1 + register_auto_trigger
+  wiring x3 (disabled skip / enabled registers SCHEDULED TriggerConfig /
+  closure forwards into `auto_trigger_mutator`). Quality gates clean (ruff +
+  mypy + 26/26 pytest + 403 adjacent scheduler/wiring/trigger/automation
   regression). **Telemetry deferred** (`HookEvent.SELF_IMPROVING_AUTO_TRIGGER_*`
   + outer-loop bundle viewer) — OL-A2/OL-A3 scope.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,53 @@ functional change.
 
 ### Added
 
+- **PR-OL-A1 — self-improving loop mutator auto-trigger (cron + 4-backend grounded).**
+  Pre-OL-A1 의 `SelfImprovingLoopRunner` 는 *manual* 발화만 지원 (operator
+  가 `geode self-improve mutate` 호출, 혹은 autoresearch sprint runner
+  안에서 sync invoke). OL-A1 가 GEODE daemon scheduler 위에 cron-가능한
+  auto-trigger 를 얹어 operator 부재 상태에서도 wrapper-prompt / 정책
+  진화가 계속되게 함. **신규 모듈** `core/self_improving_loop/auto_trigger.py`
+  — pure 유틸 `auto_trigger_mutator(*, enabled, min_interval_minutes,
+  runner_factory=None, lock_path=None, timestamp_path=None, now=None)`
+  가 6 terminal state 중 하나 (`fired` / `lock_busy` /
+  `interval_blocked` / `runner_error` / `parse_error` / `disabled`) 의
+  `AutoTriggerStatus` dataclass 반환. 절대 raise 하지 않음 — scheduler
+  loop crash 방지. **2-layer 동시성 가드**: (1) `fcntl.flock` LOCK_EX |
+  LOCK_NB 기반 advisory lock (`~/.geode/self-improving-loop/auto_trigger.lock`)
+  — 두 cron-fire 혹은 cron + manual `geode self-improve mutate` race 차단,
+  kernel crash 시 자동 해제. (2) `min_interval_minutes` 타임스탬프 게이트
+  (`auto_trigger_last_run.txt`) — clock-skew / restart re-fire 흡수. **4-backend
+  추상화 검증**: wrapper 가 자체 source vocabulary 를 가지지 않고
+  `SelfImprovingLoopRunner.run_once()` 에 dispatch. Runner 는 PR-PAPERCLIP
+  (#1433) 의 `[self_improving_loop.mutator].source` 4-enum (`auto` /
+  `api_key` / `claude-cli` / `openai-codex`) 을 이미 honour — Claude Code
+  subscription, Codex CLI subscription, Anthropic PAYG, OpenAI PAYG 4
+  backend 모두 추가 코드 없이 작동 (어댑터 추상화 적합성 확인 완료).
+  **신규 config** `[self_improving_loop.scheduler]` (`SchedulerConfig` in
+  `core/config/self_improving_loop.py`) — `enabled: bool = False` (opt-in
+  default), `cron: str = "0 */6 * * *"` (5-field cron, every 6 hours),
+  `min_interval_minutes: Annotated[int, Field(ge=1, le=1440)] = 60`.
+  Pydantic v2 `extra="forbid"` — 오타 운영자가 발견 가능. **Wiring** —
+  `core/wiring/automation.py::build_automation` 의 scheduler_service.start
+  직후에 `register_auto_trigger(trigger_manager, enabled, cron,
+  min_interval_minutes)` 호출. Default `enabled=False` 이면 `TriggerConfig`
+  등록 자체를 건너뜀 — 즉 운영자가 `config.toml` 에 `enabled = true` 명시
+  안 하면 *코드 path 가 dormant*. `try/except` 로 wiring 오류가 startup
+  block 하지 않게 가드. **24 invariant test** (`tests/test_ol_a1_auto_trigger.py`)
+  — SchedulerConfig defaults x4 (off / 6-hour cron / 60-min interval +
+  range validation + extra forbid + top-level config carries scheduler) +
+  lock semantics x3 (acquire fd / contention rejection / parent dir
+  creation) + timestamp x3 (missing → None / round-trip / unparseable →
+  None) + min-interval x3 (no prior / recent blocks / old satisfies) +
+  auto_trigger_mutator terminal states x7 (disabled / interval_blocked /
+  lock_busy / fired / runner_error / parse_error / lock-released-after-
+  raise) + lazy runner import x1 + register_auto_trigger wiring x3
+  (disabled skip / enabled registers SCHEDULED TriggerConfig / closure
+  forwards into `auto_trigger_mutator`). Quality gates clean (ruff +
+  mypy + 24/24 pytest + 403 adjacent scheduler/wiring/trigger/automation
+  regression). **Telemetry deferred** (`HookEvent.SELF_IMPROVING_AUTO_TRIGGER_*`
+  + outer-loop bundle viewer) — OL-A2/OL-A3 scope.
+
 - **PR-OL-C2 — few-shot pool writer + autoresearch promote 호출자.**
   M3 (#1426/#1428) 이 reader (`_load_few_shot_pool_override` +
   `apply_few_shot_pool`) 만 출시하고 writer 부재로 exemplars in-context

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -51,6 +51,7 @@ __all__ = [
     "AutoresearchConfig",
     "MutatorConfig",
     "PetriRoleConfig",
+    "SchedulerConfig",
     "SeedGenerationConfig",
     "SelfImprovingLoopBindings",
     "SelfImprovingLoopConfig",
@@ -188,6 +189,56 @@ class SeedGenerationConfig(BaseModel):
     roles: dict[str, SelfImprovingLoopBindings] = Field(default_factory=dict)
 
 
+class SchedulerConfig(BaseModel):
+    """Auto-trigger schedule for the mutator (OL-A1, 2026-05-22).
+
+    Pre-OL-A1 the self-improving loop only fired *manually* — operator
+    ran ``geode self-improve mutate`` or the autoresearch sprint runner
+    invoked ``SelfImprovingLoopRunner.run_once`` synchronously. With
+    OL-A1 the loop can fire on a cron schedule, so the GEODE daemon
+    keeps improving the wrapper-prompt / policies even when no operator
+    is at the keyboard. **Default off** — opt-in via
+    ``[self_improving_loop.scheduler] enabled = true``.
+
+    Concurrency is bounded by a filesystem lock
+    (``~/.geode/self-improving-loop/auto_trigger.lock`` via
+    :mod:`fcntl`), so even an over-eager cron and a manual invocation
+    cannot race. The min-interval gate is the *complementary* knob: it
+    prevents two cron-fires within ``min_interval_minutes`` of each
+    other from doing redundant work when the lock itself would let
+    them through. Together they implement Codex CLI's
+    ``forced_single_instance`` semantics for this loop role.
+
+    Operator override of the four backends (subscription Claude Code /
+    Codex CLI / Anthropic PAYG / OpenAI PAYG) flows through the
+    *existing* :class:`MutatorConfig.source` field — the auto-trigger
+    invokes :func:`SelfImprovingLoopRunner.run_once` which honours that
+    setting via the PAPERCLIP dispatch path (#1433). The scheduler does
+    NOT introduce a second source vocabulary.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    """When False (default), the runtime never registers the trigger.
+    Operators flip to True after they've verified the mutator role
+    binding + budget. The flag is checked at wiring time, so toggling
+    requires a process restart (matches scheduler service semantics)."""
+
+    cron: str = "0 */6 * * *"
+    """5-field cron expression (min hour day month weekday). Default
+    fires every 6 hours starting at minute 0 — gives the autoresearch
+    audit cycle enough headroom to settle between runs."""
+
+    min_interval_minutes: Annotated[int, Field(ge=1, le=1440)] = 60
+    """Floor between successive mutator firings (timestamp-based gate
+    on ``~/.geode/self-improving-loop/auto_trigger_last_run.txt``).
+    Cron firings closer together than this are silently skipped — the
+    lockfile already prevents concurrent runs, this knob prevents
+    *back-to-back* runs. Must satisfy ``min_interval_minutes <= cron
+    period`` for the schedule to actually fire."""
+
+
 class SelfImprovingLoopConfig(BaseModel):
     """Top-level [self_improving_loop.*] config root.
 
@@ -221,6 +272,11 @@ class SelfImprovingLoopConfig(BaseModel):
     """PR-1 G-A — mutator role manifest. Closes the hardcoded
     ``model="claude-opus-4-7"`` + direct ``anthropic.Anthropic()``
     call in ``core/self_improving_loop/runner.py``."""
+
+    scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
+    """PR-OL-A1 — auto-trigger schedule. Default off; operator opts in
+    via ``[self_improving_loop.scheduler] enabled = true``. The cron
+    fires the mutator runner with lockfile + min-interval guards."""
 
     @model_validator(mode="after")
     def _abort_above_warn(self) -> SelfImprovingLoopConfig:

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -66,9 +66,7 @@ AUTO_TRIGGER_LOCK_PATH: Path = GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigger.lo
 so a kernel-level crash releases it automatically — no stale-lock
 manual cleanup needed."""
 
-AUTO_TRIGGER_TIMESTAMP_PATH: Path = (
-    GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigger_last_run.txt"
-)
+AUTO_TRIGGER_TIMESTAMP_PATH: Path = GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigger_last_run.txt"
 """Plain-text Unix timestamp of the last *successful* firing. Failed
 firings (lock-blocked, interval-blocked, run_once raised) deliberately
 do NOT update this — only a successful mutation cycle counts so a
@@ -155,9 +153,7 @@ def read_last_run_timestamp(timestamp_path: Path | None = None) -> float | None:
         return None
 
 
-def write_last_run_timestamp(
-    timestamp: float, timestamp_path: Path | None = None
-) -> bool:
+def write_last_run_timestamp(timestamp: float, timestamp_path: Path | None = None) -> bool:
     """Persist the timestamp atomically. Returns True on success,
     False when the write fails (logged at WARNING — not raised, the
     firing already succeeded)."""

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -1,0 +1,325 @@
+"""Mutator auto-trigger — OL-A1 (2026-05-22).
+
+Connects the existing :class:`SelfImprovingLoopRunner` (manually invoked
+pre-OL-A1) to the scheduler service so the loop fires on a cron schedule
+without an operator at the keyboard.
+
+The wrapper does three things on top of ``SelfImprovingLoopRunner.run_once``:
+
+1. **Filesystem lock** (``~/.geode/self-improving-loop/auto_trigger.lock``
+   via :mod:`fcntl.flock` LOCK_EX | LOCK_NB) — prevents two cron-fires (or
+   one cron fire + one manual ``geode self-improve mutate``) from racing
+   on the same SoT files. If acquisition fails (another holder), the
+   firing is a no-op (logged at INFO).
+2. **Min-interval gate** (``auto_trigger_last_run.txt``) — even when the
+   lock is free, if the previous successful firing landed less than
+   ``min_interval_minutes`` ago, skip. Cron expressions can over-fire
+   on restart / clock skew; this is the cheap defensive floor.
+3. **Source-aware dispatch is inherited** — the wrapper does NOT carry
+   its own 4-backend (Claude Code / Codex CLI / Anthropic PAYG / OpenAI
+   PAYG) selection. It calls :func:`SelfImprovingLoopRunner.run_once`,
+   which already dispatches via PR-PAPERCLIP (#1433) based on
+   ``[self_improving_loop.mutator].source``. One credential vocabulary.
+
+The wrapper returns a status dict (instead of raising) so the
+scheduler's :class:`HookEvent.TRIGGER_FIRED` handler does not crash the
+scheduler loop when a single firing fails. Telemetry-wise, every
+firing emits ``HookEvent.SELF_IMPROVING_AUTO_TRIGGER_*`` (out of scope
+for OL-A1 — added in OL-A2).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "AUTO_TRIGGER_LOCK_PATH",
+    "AUTO_TRIGGER_TIMESTAMP_PATH",
+    "AUTO_TRIGGER_TRIGGER_ID",
+    "AutoTriggerStatus",
+    "acquire_auto_trigger_lock",
+    "auto_trigger_mutator",
+    "is_min_interval_satisfied",
+    "read_last_run_timestamp",
+    "register_auto_trigger",
+    "release_auto_trigger_lock",
+    "write_last_run_timestamp",
+]
+
+AUTO_TRIGGER_TRIGGER_ID = "self_improving_loop_auto_trigger"
+"""Single canonical trigger_id used by the scheduler so operators can
+identify the firing in ``/schedule list`` and the audit log."""
+
+AUTO_TRIGGER_LOCK_PATH: Path = GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigger.lock"
+"""Filesystem lockfile path. Lock is advisory (fcntl LOCK_EX | LOCK_NB)
+so a kernel-level crash releases it automatically — no stale-lock
+manual cleanup needed."""
+
+AUTO_TRIGGER_TIMESTAMP_PATH: Path = (
+    GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigger_last_run.txt"
+)
+"""Plain-text Unix timestamp of the last *successful* firing. Failed
+firings (lock-blocked, interval-blocked, run_once raised) deliberately
+do NOT update this — only a successful mutation cycle counts so a
+flapping config doesn't lock the schedule out for hours."""
+
+
+@dataclass(frozen=True, slots=True)
+class AutoTriggerStatus:
+    """Return shape from :func:`auto_trigger_mutator`.
+
+    Six terminal states:
+
+    * ``fired`` — runner.run_once completed; ``mutation`` carries the
+      Mutation summary (target_section + new_value len), timestamp
+      updated.
+    * ``lock_busy`` — another holder; no-op.
+    * ``interval_blocked`` — last_run_timestamp is too recent.
+    * ``runner_error`` — run_once raised; ``error`` carries the
+      repr; timestamp NOT updated (next cron fire retries).
+    * ``disabled`` — caller explicitly passed ``enabled=False``;
+      defensive guard in case wiring misroutes.
+    * ``parse_error`` — runner.run_once raised ``ValueError``
+      (mutation parse / validation); ``error`` carries the message.
+      Treated separately from ``runner_error`` so telemetry can
+      distinguish "LLM produced garbage" from "infra crashed".
+    """
+
+    state: str
+    detail: str = ""
+
+
+def acquire_auto_trigger_lock(
+    lock_path: Path | None = None,
+) -> int | None:
+    """Open + flock the auto-trigger lockfile.
+
+    Returns the file descriptor (caller must release via
+    :func:`release_auto_trigger_lock`) on success, ``None`` when the
+    lock is already held by another process (graceful — no exception).
+    """
+    target = lock_path if lock_path is not None else AUTO_TRIGGER_LOCK_PATH
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(target, os.O_CREAT | os.O_WRONLY, 0o600)
+    except OSError as exc:
+        log.warning("auto_trigger: cannot open lockfile %s: %s", target, exc)
+        return None
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        log.info("auto_trigger: lock %s already held; skipping firing", target)
+        return None
+    return fd
+
+
+def release_auto_trigger_lock(fd: int) -> None:
+    """Release the advisory lock + close the fd. Always-safe — best-
+    effort; close failures are swallowed (the OS reaps the fd anyway
+    on process exit)."""
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError as exc:
+        log.debug("auto_trigger: LOCK_UN failed (fd=%d): %s", fd, exc)
+    try:
+        os.close(fd)
+    except OSError as exc:
+        log.debug("auto_trigger: close failed (fd=%d): %s", fd, exc)
+
+
+def read_last_run_timestamp(timestamp_path: Path | None = None) -> float | None:
+    """Read the last-run Unix timestamp from disk. Returns ``None`` when
+    the file does not exist or is unparseable (treated as "never
+    fired" — first-time bootstrap path)."""
+    target = timestamp_path if timestamp_path is not None else AUTO_TRIGGER_TIMESTAMP_PATH
+    try:
+        raw = target.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning("auto_trigger: %s contains non-numeric content; ignoring", target)
+        return None
+
+
+def write_last_run_timestamp(
+    timestamp: float, timestamp_path: Path | None = None
+) -> bool:
+    """Persist the timestamp atomically. Returns True on success,
+    False when the write fails (logged at WARNING — not raised, the
+    firing already succeeded)."""
+    target = timestamp_path if timestamp_path is not None else AUTO_TRIGGER_TIMESTAMP_PATH
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"{timestamp}\n", encoding="utf-8")
+    except OSError as exc:
+        log.warning("auto_trigger: failed to write last-run timestamp: %s", exc)
+        return False
+    return True
+
+
+def is_min_interval_satisfied(
+    *,
+    min_interval_minutes: int,
+    now: float | None = None,
+    timestamp_path: Path | None = None,
+) -> bool:
+    """True when enough time has elapsed since the last fire (or when
+    no previous fire is recorded). Operator-side gate that complements
+    the lockfile.
+    """
+    last_run = read_last_run_timestamp(timestamp_path)
+    if last_run is None:
+        return True
+    current = now if now is not None else time.time()
+    elapsed_minutes = (current - last_run) / 60.0
+    return elapsed_minutes >= min_interval_minutes
+
+
+def auto_trigger_mutator(
+    *,
+    enabled: bool,
+    min_interval_minutes: int,
+    runner_factory: Callable[[], Any] | None = None,
+    lock_path: Path | None = None,
+    timestamp_path: Path | None = None,
+    now: float | None = None,
+) -> AutoTriggerStatus:
+    """One mutator firing — guarded by lockfile + min-interval.
+
+    Args:
+        enabled: Defensive gate. When False, return ``disabled``
+            without touching disk. The wiring layer should also avoid
+            registering the trigger in this case; this is belt+suspenders.
+        min_interval_minutes: Floor between successful firings (see
+            :class:`SchedulerConfig.min_interval_minutes`).
+        runner_factory: Zero-arg callable returning an object with
+            ``run_once() -> Mutation`` method. Defaults to
+            :class:`SelfImprovingLoopRunner` constructed with no args.
+            Tests inject mocks; production wires the real runner.
+        lock_path: Lockfile path override (tests).
+        timestamp_path: Timestamp path override (tests).
+        now: Wall-clock override (tests).
+
+    Returns:
+        :class:`AutoTriggerStatus` describing the terminal state. Never
+        raises — exceptions inside ``run_once`` are caught and packed
+        into the ``runner_error`` / ``parse_error`` states.
+    """
+    if not enabled:
+        return AutoTriggerStatus(state="disabled")
+
+    if not is_min_interval_satisfied(
+        min_interval_minutes=min_interval_minutes,
+        now=now,
+        timestamp_path=timestamp_path,
+    ):
+        return AutoTriggerStatus(
+            state="interval_blocked",
+            detail=f"min_interval_minutes={min_interval_minutes}",
+        )
+
+    fd = acquire_auto_trigger_lock(lock_path)
+    if fd is None:
+        return AutoTriggerStatus(state="lock_busy")
+
+    try:
+        runner = _resolve_runner(runner_factory)
+        try:
+            mutation = runner.run_once()
+        except ValueError as exc:
+            log.warning("auto_trigger: mutator parse/validation failure: %s", exc)
+            return AutoTriggerStatus(state="parse_error", detail=str(exc))
+        except Exception as exc:
+            log.exception("auto_trigger: runner.run_once raised")
+            return AutoTriggerStatus(state="runner_error", detail=repr(exc))
+
+        current = now if now is not None else time.time()
+        write_last_run_timestamp(current, timestamp_path)
+        target_section = getattr(mutation, "target_section", "<unknown>")
+        return AutoTriggerStatus(state="fired", detail=f"target_section={target_section}")
+    finally:
+        release_auto_trigger_lock(fd)
+
+
+def _resolve_runner(factory: Callable[[], Any] | None) -> Any:
+    """Build the runner. Lazy-imports :class:`SelfImprovingLoopRunner`
+    so module import doesn't drag the runner's deps in at startup
+    (cold-start budget — runner pulls anthropic adapter etc.)."""
+    if factory is not None:
+        return factory()
+    from core.self_improving_loop.runner import SelfImprovingLoopRunner
+
+    return SelfImprovingLoopRunner()
+
+
+def register_auto_trigger(
+    trigger_manager: Any,
+    *,
+    enabled: bool,
+    cron: str,
+    min_interval_minutes: int,
+    runner_factory: Callable[[], Any] | None = None,
+) -> bool:
+    """Register the auto-trigger with the scheduler. No-op when disabled.
+
+    Wiring contract: this is the *only* function `core/wiring/automation.py`
+    needs to call. Returns True when the trigger was registered, False
+    when ``enabled=False`` (so the wiring layer can log the skip).
+
+    The callback closes over ``min_interval_minutes`` + ``runner_factory``
+    so the scheduler's bare ``callback(data)`` invocation forwards into
+    :func:`auto_trigger_mutator` with the right config. The callback
+    swallows every exception (logs at WARNING) — `TriggerManager`'s own
+    error isolation is the second layer of defense.
+    """
+    if not enabled:
+        log.info("auto_trigger: [self_improving_loop.scheduler] enabled=False; skip register")
+        return False
+
+    from core.scheduler.triggers import TriggerConfig, TriggerType
+
+    def _scheduler_callback(_data: dict[str, Any]) -> None:
+        try:
+            status = auto_trigger_mutator(
+                enabled=True,
+                min_interval_minutes=min_interval_minutes,
+                runner_factory=runner_factory,
+            )
+            log.info(
+                "auto_trigger fired: state=%s detail=%s",
+                status.state,
+                status.detail,
+            )
+        except Exception:
+            log.exception("auto_trigger callback raised; scheduler loop continues")
+
+    trigger_manager.register(
+        TriggerConfig(
+            trigger_id=AUTO_TRIGGER_TRIGGER_ID,
+            trigger_type=TriggerType.SCHEDULED,
+            name="Self-improving loop auto-trigger (OL-A1)",
+            cron_expr=cron,
+            callback=_scheduler_callback,
+            enabled=True,
+        )
+    )
+    log.info(
+        "auto_trigger registered: cron=%r min_interval_minutes=%d",
+        cron,
+        min_interval_minutes,
+    )
+    return True

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -233,7 +233,31 @@ def auto_trigger_mutator(
         return AutoTriggerStatus(state="lock_busy")
 
     try:
-        runner = _resolve_runner(runner_factory)
+        # Codex MCP catch (PR-OL-A1 fix-up): re-check interval AFTER
+        # acquiring the lock. Otherwise a second process can pass the
+        # pre-lock interval check using a stale timestamp, then acquire
+        # the lock right after the first holder writes a fresh
+        # timestamp and releases — both fires land < min_interval apart.
+        if not is_min_interval_satisfied(
+            min_interval_minutes=min_interval_minutes,
+            now=now,
+            timestamp_path=timestamp_path,
+        ):
+            return AutoTriggerStatus(
+                state="interval_blocked",
+                detail=f"min_interval_minutes={min_interval_minutes} (post-lock re-check)",
+            )
+
+        # Codex MCP catch (PR-OL-A1 fix-up): runner construction itself
+        # can raise (lazy import failure, runner __init__ side-effects).
+        # Catch here so the "never raises" contract holds — the lock is
+        # still released by the outer finally.
+        try:
+            runner = _resolve_runner(runner_factory)
+        except Exception as exc:
+            log.exception("auto_trigger: runner factory raised")
+            return AutoTriggerStatus(state="runner_error", detail=repr(exc))
+
         try:
             mutation = runner.run_once()
         except ValueError as exc:

--- a/core/wiring/automation.py
+++ b/core/wiring/automation.py
@@ -101,6 +101,23 @@ def build_automation(
             interval_s=settings.scheduler_interval_s,
         )
 
+    # OL-A1 (2026-05-22) — self-improving-loop auto-trigger. Opt-in:
+    # only fires when [self_improving_loop.scheduler] enabled=true in
+    # ~/.geode/config.toml. Default off → register_auto_trigger no-ops.
+    try:
+        from core.config.self_improving_loop import load_self_improving_loop_config
+        from core.self_improving_loop.auto_trigger import register_auto_trigger
+
+        sil_cfg = load_self_improving_loop_config()
+        register_auto_trigger(
+            trigger_manager,
+            enabled=sil_cfg.scheduler.enabled,
+            cron=sil_cfg.scheduler.cron,
+            min_interval_minutes=sil_cfg.scheduler.min_interval_minutes,
+        )
+    except Exception:
+        log.exception("auto_trigger wiring failed; scheduler continues without it")
+
     # Feedback loop (wires all L4.5 components + hooks)
     feedback_loop = FeedbackLoop(
         model_registry=model_registry,

--- a/tests/test_ol_a1_auto_trigger.py
+++ b/tests/test_ol_a1_auto_trigger.py
@@ -375,6 +375,76 @@ def test_parse_error_distinct_from_runner_error(
     assert "missing target_section" in status.detail
 
 
+def test_runner_factory_raising_yields_runner_error(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    """Codex MCP catch (PR-OL-A1 fix-up). If the *factory itself* raises
+    (e.g., lazy import fails, runner __init__ side-effect), the function
+    must still return ``runner_error`` — not propagate. Otherwise the
+    'never raises' contract is violated and the scheduler loop crashes."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock_path, ts_path = trigger_paths
+
+    def _broken_factory() -> Any:
+        raise RuntimeError("factory exploded")
+
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=_broken_factory,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+    )
+    assert status.state == "runner_error"
+    assert "factory exploded" in status.detail
+
+
+def test_post_lock_interval_recheck_blocks_when_timestamp_freshens(
+    trigger_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex MCP catch (PR-OL-A1 fix-up). TOCTOU defence: the pre-lock
+    interval check can be passed using a stale timestamp; a second
+    process can then acquire the lock right after the first holder
+    writes a fresh timestamp and releases — both fires land
+    < ``min_interval`` apart.
+
+    The post-lock re-check closes that gap. We simulate the race by
+    patching ``acquire_auto_trigger_lock`` to write a fresh timestamp
+    as a side effect (peer landed a fire just before we acquired).
+    """
+    from core.self_improving_loop.auto_trigger import (
+        auto_trigger_mutator,
+        write_last_run_timestamp,
+    )
+
+    from core.self_improving_loop import auto_trigger as at_module
+
+    lock_path, ts_path = trigger_paths
+    now = 3000000.0
+    runner = _FakeRunner()
+    real_acquire = at_module.acquire_auto_trigger_lock
+
+    def _acquire_with_peer_side_effect(path: Any = None) -> Any:
+        # Peer landed a fresh fire 5 minutes ago BEFORE we acquired.
+        write_last_run_timestamp(now - 5 * 60, ts_path)
+        return real_acquire(path)
+
+    monkeypatch.setattr(at_module, "acquire_auto_trigger_lock", _acquire_with_peer_side_effect)
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+        now=now,
+    )
+    assert status.state == "interval_blocked"
+    assert "post-lock" in status.detail
+    assert runner.run_once_count == 0
+
+
 def test_lock_released_even_after_runner_raises(
     trigger_paths: tuple[Path, Path],
 ) -> None:

--- a/tests/test_ol_a1_auto_trigger.py
+++ b/tests/test_ol_a1_auto_trigger.py
@@ -1,0 +1,494 @@
+"""OL-A1 — mutator auto-trigger invariants.
+
+Pins:
+- Lock acquire / release semantics + contention.
+- Min-interval gate behaviour (no prior run / recent run / old run).
+- Timestamp round-trip (read after write).
+- ``auto_trigger_mutator`` end-to-end:
+    * disabled → no disk I/O
+    * interval_blocked → no lock acquired, no runner call
+    * lock_busy → runner NOT invoked
+    * runner_error → caught, timestamp NOT updated
+    * parse_error → caught, timestamp NOT updated, state distinct
+    * fired → timestamp updated, lock released
+- SchedulerConfig defaults (off / 6-hour cron / 60-min interval).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def trigger_paths(tmp_path: Path) -> Iterator[tuple[Path, Path]]:
+    lock = tmp_path / "auto_trigger.lock"
+    ts = tmp_path / "auto_trigger_last_run.txt"
+    yield lock, ts
+
+
+# ---------------------------------------------------------------------------
+# SchedulerConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_config_defaults_match_spec() -> None:
+    from core.config.self_improving_loop import SchedulerConfig
+
+    cfg = SchedulerConfig()
+    assert cfg.enabled is False
+    assert cfg.cron == "0 */6 * * *"
+    assert cfg.min_interval_minutes == 60
+
+
+def test_scheduler_config_validates_min_interval_range() -> None:
+    """``min_interval_minutes`` is Annotated[int, ge=1, le=1440]."""
+    from core.config.self_improving_loop import SchedulerConfig
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SchedulerConfig(min_interval_minutes=0)
+    with pytest.raises(ValidationError):
+        SchedulerConfig(min_interval_minutes=1441)
+    SchedulerConfig(min_interval_minutes=1)
+    SchedulerConfig(min_interval_minutes=1440)
+
+
+def test_scheduler_config_forbid_extras() -> None:
+    """extra='forbid' — unknown key raises so typos surface."""
+    from core.config.self_improving_loop import SchedulerConfig
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SchedulerConfig(does_not_exist=True)  # type: ignore[call-arg]
+
+
+def test_top_level_self_improving_loop_config_carries_scheduler() -> None:
+    from core.config.self_improving_loop import (
+        SchedulerConfig,
+        SelfImprovingLoopConfig,
+    )
+
+    cfg = SelfImprovingLoopConfig()
+    assert isinstance(cfg.scheduler, SchedulerConfig)
+    assert cfg.scheduler.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Lock acquire / release
+# ---------------------------------------------------------------------------
+
+
+def test_lock_acquire_returns_fd_when_uncontended(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        release_auto_trigger_lock,
+    )
+
+    lock_path, _ = trigger_paths
+    fd = acquire_auto_trigger_lock(lock_path)
+    assert fd is not None
+    assert isinstance(fd, int)
+    release_auto_trigger_lock(fd)
+
+
+def test_lock_blocks_second_acquire(trigger_paths: tuple[Path, Path]) -> None:
+    """Second acquire while first is held → None (no exception)."""
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        release_auto_trigger_lock,
+    )
+
+    lock_path, _ = trigger_paths
+    fd1 = acquire_auto_trigger_lock(lock_path)
+    assert fd1 is not None
+    try:
+        fd2 = acquire_auto_trigger_lock(lock_path)
+        assert fd2 is None  # NB lock should refuse
+    finally:
+        release_auto_trigger_lock(fd1)
+    # After release, third acquire should succeed
+    fd3 = acquire_auto_trigger_lock(lock_path)
+    assert fd3 is not None
+    release_auto_trigger_lock(fd3)
+
+
+def test_lock_creates_parent_dir(tmp_path: Path) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        release_auto_trigger_lock,
+    )
+
+    nested = tmp_path / "deep" / "nested" / "lock.lock"
+    assert not nested.parent.exists()
+    fd = acquire_auto_trigger_lock(nested)
+    assert fd is not None
+    assert nested.parent.is_dir()
+    release_auto_trigger_lock(fd)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp read / write
+# ---------------------------------------------------------------------------
+
+
+def test_read_timestamp_missing_returns_none(trigger_paths: tuple[Path, Path]) -> None:
+    from core.self_improving_loop.auto_trigger import read_last_run_timestamp
+
+    _, ts_path = trigger_paths
+    assert read_last_run_timestamp(ts_path) is None
+
+
+def test_write_then_read_timestamp_round_trip(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        read_last_run_timestamp,
+        write_last_run_timestamp,
+    )
+
+    _, ts_path = trigger_paths
+    write_last_run_timestamp(1234567890.5, ts_path)
+    assert read_last_run_timestamp(ts_path) == pytest.approx(1234567890.5)
+
+
+def test_read_timestamp_unparseable_returns_none(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import read_last_run_timestamp
+
+    _, ts_path = trigger_paths
+    ts_path.parent.mkdir(parents=True, exist_ok=True)
+    ts_path.write_text("not-a-number\n", encoding="utf-8")
+    assert read_last_run_timestamp(ts_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Min-interval gate
+# ---------------------------------------------------------------------------
+
+
+def test_min_interval_satisfied_when_no_prior_run(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import is_min_interval_satisfied
+
+    _, ts_path = trigger_paths
+    assert is_min_interval_satisfied(
+        min_interval_minutes=60, timestamp_path=ts_path
+    )
+
+
+def test_min_interval_blocked_when_recent(trigger_paths: tuple[Path, Path]) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        is_min_interval_satisfied,
+        write_last_run_timestamp,
+    )
+
+    _, ts_path = trigger_paths
+    now = 1000000.0
+    write_last_run_timestamp(now - 30 * 60, ts_path)  # 30 minutes ago
+    assert not is_min_interval_satisfied(
+        min_interval_minutes=60, now=now, timestamp_path=ts_path
+    )
+
+
+def test_min_interval_satisfied_when_old_enough(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        is_min_interval_satisfied,
+        write_last_run_timestamp,
+    )
+
+    _, ts_path = trigger_paths
+    now = 1000000.0
+    write_last_run_timestamp(now - 90 * 60, ts_path)  # 90 minutes ago
+    assert is_min_interval_satisfied(
+        min_interval_minutes=60, now=now, timestamp_path=ts_path
+    )
+
+
+# ---------------------------------------------------------------------------
+# auto_trigger_mutator — terminal states
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner:
+    """Stand-in for SelfImprovingLoopRunner."""
+
+    def __init__(self, *, raises: Exception | None = None, target_section: str = "sec1") -> None:
+        self._raises = raises
+        self._target_section = target_section
+        self.run_once_count = 0
+
+    def run_once(self) -> Any:
+        self.run_once_count += 1
+        if self._raises is not None:
+            raise self._raises
+
+        class _M:
+            target_section = self._target_section
+
+        # Bind target_section before instantiation
+        _M.target_section = self._target_section  # type: ignore[misc]
+        return _M()
+
+
+def test_disabled_short_circuits(trigger_paths: tuple[Path, Path]) -> None:
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock_path, ts_path = trigger_paths
+    runner = _FakeRunner()
+    status = auto_trigger_mutator(
+        enabled=False,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+    )
+    assert status.state == "disabled"
+    assert runner.run_once_count == 0
+    assert not ts_path.exists()  # no I/O on disabled path
+
+
+def test_interval_blocked_skips_runner(trigger_paths: tuple[Path, Path]) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        auto_trigger_mutator,
+        write_last_run_timestamp,
+    )
+
+    lock_path, ts_path = trigger_paths
+    now = 1000000.0
+    write_last_run_timestamp(now - 10 * 60, ts_path)  # 10 minutes ago
+    runner = _FakeRunner()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+        now=now,
+    )
+    assert status.state == "interval_blocked"
+    assert "min_interval_minutes=60" in status.detail
+    assert runner.run_once_count == 0
+
+
+def test_lock_busy_skips_runner(trigger_paths: tuple[Path, Path]) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        auto_trigger_mutator,
+        release_auto_trigger_lock,
+    )
+
+    lock_path, ts_path = trigger_paths
+    held_fd = acquire_auto_trigger_lock(lock_path)
+    assert held_fd is not None
+    try:
+        runner = _FakeRunner()
+        status = auto_trigger_mutator(
+            enabled=True,
+            min_interval_minutes=60,
+            runner_factory=lambda: runner,
+            lock_path=lock_path,
+            timestamp_path=ts_path,
+        )
+        assert status.state == "lock_busy"
+        assert runner.run_once_count == 0
+    finally:
+        release_auto_trigger_lock(held_fd)
+
+
+def test_fired_updates_timestamp_and_releases_lock(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        auto_trigger_mutator,
+        read_last_run_timestamp,
+        release_auto_trigger_lock,
+    )
+
+    lock_path, ts_path = trigger_paths
+    runner = _FakeRunner(target_section="wrapper.intro")
+    now = 1234567890.0
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+        now=now,
+    )
+    assert status.state == "fired"
+    assert "wrapper.intro" in status.detail
+    assert runner.run_once_count == 1
+    # Timestamp persisted
+    assert read_last_run_timestamp(ts_path) == pytest.approx(now)
+    # Lock released — must be re-acquirable
+    fd = acquire_auto_trigger_lock(lock_path)
+    assert fd is not None
+    release_auto_trigger_lock(fd)
+
+
+def test_runner_error_does_not_update_timestamp(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    """Generic exception → runner_error state, timestamp unchanged."""
+    from core.self_improving_loop.auto_trigger import (
+        auto_trigger_mutator,
+        read_last_run_timestamp,
+    )
+
+    lock_path, ts_path = trigger_paths
+    runner = _FakeRunner(raises=RuntimeError("boom"))
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+    )
+    assert status.state == "runner_error"
+    assert "boom" in status.detail
+    assert runner.run_once_count == 1
+    # Timestamp NOT written — next cron retries
+    assert read_last_run_timestamp(ts_path) is None
+
+
+def test_parse_error_distinct_from_runner_error(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    """ValueError → parse_error (LLM produced garbage), not runner_error."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock_path, ts_path = trigger_paths
+    runner = _FakeRunner(raises=ValueError("missing target_section"))
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+    )
+    assert status.state == "parse_error"
+    assert "missing target_section" in status.detail
+
+
+def test_lock_released_even_after_runner_raises(
+    trigger_paths: tuple[Path, Path],
+) -> None:
+    """Failure path must NOT leak the lockfile — next firing should
+    succeed on lock acquisition."""
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        auto_trigger_mutator,
+        release_auto_trigger_lock,
+    )
+
+    lock_path, ts_path = trigger_paths
+    runner = _FakeRunner(raises=RuntimeError("simulated"))
+    auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock_path,
+        timestamp_path=ts_path,
+    )
+    fd = acquire_auto_trigger_lock(lock_path)
+    assert fd is not None
+    release_auto_trigger_lock(fd)
+
+
+def test_register_auto_trigger_skips_when_disabled() -> None:
+    """enabled=False → trigger_manager.register NOT called."""
+    from unittest.mock import MagicMock
+
+    from core.self_improving_loop.auto_trigger import register_auto_trigger
+
+    mgr = MagicMock()
+    result = register_auto_trigger(
+        mgr, enabled=False, cron="0 */6 * * *", min_interval_minutes=60
+    )
+    assert result is False
+    mgr.register.assert_not_called()
+
+
+def test_register_auto_trigger_registers_when_enabled() -> None:
+    """enabled=True → trigger_manager.register receives a SCHEDULED
+    TriggerConfig with the cron + callback."""
+    from unittest.mock import MagicMock
+
+    from core.scheduler.triggers import TriggerType
+    from core.self_improving_loop.auto_trigger import (
+        AUTO_TRIGGER_TRIGGER_ID,
+        register_auto_trigger,
+    )
+
+    mgr = MagicMock()
+    result = register_auto_trigger(
+        mgr, enabled=True, cron="*/15 * * * *", min_interval_minutes=10
+    )
+    assert result is True
+    mgr.register.assert_called_once()
+    config = mgr.register.call_args[0][0]
+    assert config.trigger_id == AUTO_TRIGGER_TRIGGER_ID
+    assert config.trigger_type == TriggerType.SCHEDULED
+    assert config.cron_expr == "*/15 * * * *"
+    assert config.callback is not None
+    assert config.enabled is True
+
+
+def test_registered_callback_invokes_auto_trigger_mutator(
+    trigger_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The registered callback must forward into auto_trigger_mutator
+    when fired (closure forwarding contract). Patches the default lock/
+    timestamp paths so the test does not depend on (or mutate) the
+    operator's real ``~/.geode/self-improving-loop/`` state."""
+    from unittest.mock import MagicMock
+
+    from core.self_improving_loop import auto_trigger as at_module
+    from core.self_improving_loop.auto_trigger import register_auto_trigger
+
+    lock_path, ts_path = trigger_paths
+    monkeypatch.setattr(at_module, "AUTO_TRIGGER_LOCK_PATH", lock_path)
+    monkeypatch.setattr(at_module, "AUTO_TRIGGER_TIMESTAMP_PATH", ts_path)
+    mgr = MagicMock()
+    runner = _FakeRunner(target_section="wrapper.section")
+    register_auto_trigger(
+        mgr,
+        enabled=True,
+        cron="0 * * * *",
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+    )
+    callback = mgr.register.call_args[0][0].callback
+    # Fire — runner should be called via the closure
+    callback({"trigger_id": "self_improving_loop_auto_trigger"})
+    assert runner.run_once_count == 1
+
+
+def test_default_runner_factory_imports_runner_lazily() -> None:
+    """When factory=None, the module imports SelfImprovingLoopRunner
+    lazily — we don't pay the import cost at module load."""
+    import importlib
+    import sys
+
+    # Drop the runner if cached, so we can detect a lazy import
+    mod_name = "core.self_improving_loop.runner"
+    sys.modules.pop(mod_name, None)
+    # Importing auto_trigger should NOT trigger the runner import
+    at_mod = importlib.import_module("core.self_improving_loop.auto_trigger")
+    importlib.reload(at_mod)
+    assert mod_name not in sys.modules, (
+        "auto_trigger must lazy-import SelfImprovingLoopRunner — "
+        "found in sys.modules after auto_trigger import"
+    )

--- a/tests/test_ol_a1_auto_trigger.py
+++ b/tests/test_ol_a1_auto_trigger.py
@@ -179,9 +179,7 @@ def test_min_interval_satisfied_when_no_prior_run(
     from core.self_improving_loop.auto_trigger import is_min_interval_satisfied
 
     _, ts_path = trigger_paths
-    assert is_min_interval_satisfied(
-        min_interval_minutes=60, timestamp_path=ts_path
-    )
+    assert is_min_interval_satisfied(min_interval_minutes=60, timestamp_path=ts_path)
 
 
 def test_min_interval_blocked_when_recent(trigger_paths: tuple[Path, Path]) -> None:
@@ -193,9 +191,7 @@ def test_min_interval_blocked_when_recent(trigger_paths: tuple[Path, Path]) -> N
     _, ts_path = trigger_paths
     now = 1000000.0
     write_last_run_timestamp(now - 30 * 60, ts_path)  # 30 minutes ago
-    assert not is_min_interval_satisfied(
-        min_interval_minutes=60, now=now, timestamp_path=ts_path
-    )
+    assert not is_min_interval_satisfied(min_interval_minutes=60, now=now, timestamp_path=ts_path)
 
 
 def test_min_interval_satisfied_when_old_enough(
@@ -209,9 +205,7 @@ def test_min_interval_satisfied_when_old_enough(
     _, ts_path = trigger_paths
     now = 1000000.0
     write_last_run_timestamp(now - 90 * 60, ts_path)  # 90 minutes ago
-    assert is_min_interval_satisfied(
-        min_interval_minutes=60, now=now, timestamp_path=ts_path
-    )
+    assert is_min_interval_satisfied(min_interval_minutes=60, now=now, timestamp_path=ts_path)
 
 
 # ---------------------------------------------------------------------------
@@ -413,9 +407,7 @@ def test_register_auto_trigger_skips_when_disabled() -> None:
     from core.self_improving_loop.auto_trigger import register_auto_trigger
 
     mgr = MagicMock()
-    result = register_auto_trigger(
-        mgr, enabled=False, cron="0 */6 * * *", min_interval_minutes=60
-    )
+    result = register_auto_trigger(mgr, enabled=False, cron="0 */6 * * *", min_interval_minutes=60)
     assert result is False
     mgr.register.assert_not_called()
 
@@ -432,9 +424,7 @@ def test_register_auto_trigger_registers_when_enabled() -> None:
     )
 
     mgr = MagicMock()
-    result = register_auto_trigger(
-        mgr, enabled=True, cron="*/15 * * * *", min_interval_minutes=10
-    )
+    result = register_auto_trigger(mgr, enabled=True, cron="*/15 * * * *", min_interval_minutes=10)
     assert result is True
     mgr.register.assert_called_once()
     config = mgr.register.call_args[0][0]

--- a/tests/test_ol_a1_auto_trigger.py
+++ b/tests/test_ol_a1_auto_trigger.py
@@ -445,8 +445,9 @@ def test_registered_callback_invokes_auto_trigger_mutator(
     operator's real ``~/.geode/self-improving-loop/`` state."""
     from unittest.mock import MagicMock
 
-    from core.self_improving_loop import auto_trigger as at_module
     from core.self_improving_loop.auto_trigger import register_auto_trigger
+
+    from core.self_improving_loop import auto_trigger as at_module
 
     lock_path, ts_path = trigger_paths
     monkeypatch.setattr(at_module, "AUTO_TRIGGER_LOCK_PATH", lock_path)


### PR DESCRIPTION
## Summary

- **Cron-driven mutator firing**. Pre-OL-A1 the self-improving loop only
  fired manually (`geode self-improve mutate`) or sync-inside autoresearch
  sprint runner. OL-A1 lets the GEODE daemon scheduler fire it on a cron
  schedule when an operator is not at the keyboard.
- **2-layer concurrency guard** — `fcntl.flock` LOCK_EX | LOCK_NB
  lockfile + `min_interval_minutes` timestamp gate. Lock survives kernel
  crash (advisory); interval gate absorbs clock-skew / restart re-fires.
- **4-backend abstraction verified** (per user directive 2026-05-21). The
  auto-trigger wrapper has NO source vocabulary of its own — calls
  `SelfImprovingLoopRunner.run_once()` which already dispatches on
  `[self_improving_loop.mutator].source` via PR-PAPERCLIP (#1433). Claude
  Code subscription / Codex CLI subscription / Anthropic PAYG / OpenAI
  PAYG all work without new adapter code.
- **Default off**. `[self_improving_loop.scheduler] enabled = false` is
  the pydantic default; wiring skips `TriggerConfig` registration when
  disabled. Operator opts in via `~/.geode/config.toml`.

## Why

Sequential 3-tier roadmap (Outer Loop → Inner Loop → Cognitive Loop)
needs a closed-loop mutator that fires *without* operator intervention so
the wrapper-prompt + policies drift toward higher fitness over time. M3/M4
sprint already wired everything from mutation → audit → SoT promotion;
the missing piece was *scheduling*. Without OL-A1 the loop has both ends
(propose + apply) but no clock to drive iteration cadence.

The 4-backend grounding directive was explicit: user wanted me to verify
the existing adapter abstraction covers all four credential channels
before wiring the cron. I confirmed `core/llm/adapters.py::_ADAPTER_MAP`
covers anthropic / openai / glm / openai-codex and that
`runner._default_llm_call` already routes via PR-PAPERCLIP (#1433). The
auto-trigger wrapper therefore inherits the dispatch — single credential
vocabulary across the loop instead of a second enum at the scheduler
layer.

## Changes

| File | Change |
|------|--------|
| `core/self_improving_loop/auto_trigger.py` (new) | `auto_trigger_mutator` (6-state machine) + `acquire/release_auto_trigger_lock` + `read/write_last_run_timestamp` + `is_min_interval_satisfied` + `register_auto_trigger` (scheduler wiring helper) + `AutoTriggerStatus` dataclass + `AUTO_TRIGGER_LOCK_PATH` / `AUTO_TRIGGER_TIMESTAMP_PATH` / `AUTO_TRIGGER_TRIGGER_ID` constants |
| `core/config/self_improving_loop.py` | `SchedulerConfig` pydantic model + `scheduler` field on `SelfImprovingLoopConfig`; `__all__` updated |
| `core/wiring/automation.py` | `register_auto_trigger(trigger_manager, ...)` call after `scheduler_service.start`; guarded by try/except so wiring failure does not block daemon startup |
| `tests/test_ol_a1_auto_trigger.py` (new) | 24 invariants — defaults / lock / timestamp / interval / state machine / wiring / lazy import |
| `CHANGELOG.md` | `[Unreleased]` Added entry under PR-OL-A1 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Cron-driven firing | Implemented | `register_auto_trigger` builds `TriggerConfig` with cron_expr from config |
| Lockfile (concurrency guard) | Implemented | `fcntl.flock` LOCK_EX \| LOCK_NB |
| Min-interval gate (defensive floor) | Implemented | timestamp file at `~/.geode/self-improving-loop/auto_trigger_last_run.txt` |
| 4-backend adapter abstraction | Already exists | PR-PAPERCLIP #1433, verified via `_ADAPTER_MAP` + `_default_llm_call` source dispatch |
| Default-off opt-in | Implemented | `SchedulerConfig.enabled: bool = False` + wiring no-op when disabled |
| Wiring failure tolerance | Implemented | try/except in `build_automation` |
| Lazy runner import (cold-start) | Implemented | `_resolve_runner` imports `SelfImprovingLoopRunner` only on first fire |
| Telemetry events (`SELF_IMPROVING_AUTO_TRIGGER_*`) | Dropped → OL-A2 | Needs HookEvent enum additions + outer-loop bundle viewer pairing |
| Bundle viewer | Dropped → OL-A3 | Out of scope; depends on OL-A2 telemetry |

## Verification

- [x] ruff check clean (`uv run ruff check core/self_improving_loop/auto_trigger.py tests/test_ol_a1_auto_trigger.py core/wiring/automation.py core/config/self_improving_loop.py`)
- [x] mypy clean (`uv run mypy core/self_improving_loop/auto_trigger.py core/wiring/automation.py core/config/self_improving_loop.py`)
- [x] pytest pass — 24/24 OL-A1 (`uv run pytest tests/test_ol_a1_auto_trigger.py`)
- [x] Regression — 403/403 scheduler+wiring+trigger+automation tests green
- [ ] CI green (5/5 — pending push)
- [ ] Codex MCP LLM-as-Judge (pending)

## Reference

- 4-backend adapter abstraction (already exists): `core/llm/adapters.py::_ADAPTER_MAP`
- PAPERCLIP source dispatch: `core/self_improving_loop/runner.py:509-523` (PR #1433)
- Scheduler service: `core/scheduler/triggers.py::TriggerManager`
- Wiring entry: `core/wiring/automation.py::build_automation`
- Roadmap: `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-A1
- Follow-ups: OL-A2 (telemetry events) + OL-A3 (bundle viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)