### PR TITLE
PR-OL-A1.5 — auto-trigger telemetry events + JSONL audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,41 @@ functional change.
 
 ### Added
 
+- **PR-OL-A1.5 — auto-trigger telemetry events + JSONL audit log.**
+  PR-OL-A1 (#1445) 가 cron-driven mutator firing 을 도입하면서 `state`
+  값을 INFO log 로만 출력 — Petri/Inspect viewer 같은 다운스트림이
+  세션을 통계로 그릴 수 없는 deception 잔존. 본 PR 가 닫기. **HookEvent
+  5종 추가** (`core/hooks/system.py`) — `SELF_IMPROVING_AUTO_TRIGGER_{FIRED,
+  LOCK_BUSY, INTERVAL_BLOCKED, RUNNER_ERROR, PARSE_ERROR}` 로 각 terminal
+  state 1:1 매핑. `disabled` 는 의도적으로 enum 미포함 (운영자가 명시적
+  off → 매 cron tick 마다 무의미 event 발생 방지, wiring 의 startup log
+  가 SoT). 매핑 테이블 `STATE_TO_HOOK_EVENT` 노출 — runtime resolution
+  은 `getattr(HookEvent, name)`. **JSONL audit log** 신규 writer
+  `append_history_entry(*, state, detail, ts, trigger_id, history_path)`
+  가 `~/.geode/self-improving-loop/auto_trigger_history.jsonl` 에 append-
+  only 한 줄당 `{ts, state, detail, trigger_id}`. `ensure_ascii=False` 로
+  한글 detail (`섹션=한글`) 보존. `mkdir + write_text` 단일 try (PR-OL-C2
+  Codex MCP lesson). OSError 시 `False` 반환 + WARNING log — telemetry
+  실패가 state machine 영향 못 줌. Path 는 ``~/.geode/`` 하위 — 레포
+  외부, gitignore N/A (PR-G5b #1350 "git-tracked but isn't" 사례 회피).
+  **`auto_trigger_mutator` 리팩토링** — 매 `return AutoTriggerStatus(...)`
+  를 `_finalize_status` helper 로 단일 출구점 통과: hook emit + history
+  append + status 반환 3가지 부수효과가 drift 없이 같은 분기에서 fire.
+  `hooks: Any = None` 기본값 — REPL/CLI 직접 호출 graceful (telemetry
+  sink 없어도 작동). `_BrokenHooks` 시뮬레이션 test 로 hook handler
+  raise 가 state machine crash 못 시킨다는 invariant 검증. **wiring**:
+  `core/wiring/automation.py::build_automation` 의 `register_auto_trigger`
+  호출에 `hooks=hooks` 인자 추가 — daemon 의 HookSystem instance 가
+  callback closure 로 캡쳐돼 cron fire 마다 자동 emit. **17 invariant test**
+  (`tests/test_ol_a15_telemetry.py`) — HookEvent enum x3 (5 variant value /
+  STATE_TO_HOOK_EVENT 5-state coverage + disabled 부재 / getattr resolve)
+  + append_history_entry x5 (1 row write / multi-append / parent dir 생성
+  / Unicode preserve / OSError graceful) + auto_trigger_mutator end-to-end
+  x9 (fired/lock_busy/interval_blocked/runner_error/parse_error 각각 hook+
+  history 발생 / disabled 가 hook+history 둘 다 skip / hooks=None graceful /
+  multi-call append-only / hook handler raise 격리). Quality gates clean
+  (ruff + format-check + mypy + 43/43 pytest 누적 OL-A1+A1.5).
+
 - **PR-OL-A1 — self-improving loop mutator auto-trigger (cron + 4-backend grounded).**
   Pre-OL-A1 의 `SelfImprovingLoopRunner` 는 *manual* 발화만 지원 (operator
   가 `geode self-improve mutate` 호출, 혹은 autoresearch sprint runner

--- a/core/hooks/system.py
+++ b/core/hooks/system.py
@@ -168,6 +168,22 @@ class HookEvent(Enum):
     COGNITIVE_REFLECT = "cognitive_reflect"
     COGNITIVE_UPDATE_MEMORY = "cognitive_update_memory"
 
+    # Self-improving loop auto-trigger telemetry (OL-A1.5 — 2026-05-22).
+    # One event per terminal state of ``auto_trigger_mutator`` so a
+    # downstream subscriber (audit log writer, Inspect viewer, FE) can
+    # count firings, distinguish lock contention from interval gating,
+    # and surface runner failures without parsing the daemon log.
+    # Payload schema (every variant):
+    #   {"trigger_id": str, "ts": float, "detail": str}
+    # The ``trigger_id`` is the canonical id from
+    # ``AUTO_TRIGGER_TRIGGER_ID`` so subscribers can filter by id when
+    # multiple trigger families coexist in the same scheduler.
+    SELF_IMPROVING_AUTO_TRIGGER_FIRED = "self_improving_auto_trigger_fired"
+    SELF_IMPROVING_AUTO_TRIGGER_LOCK_BUSY = "self_improving_auto_trigger_lock_busy"
+    SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED = "self_improving_auto_trigger_interval_blocked"
+    SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR = "self_improving_auto_trigger_runner_error"
+    SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR = "self_improving_auto_trigger_parse_error"
+
 
 @dataclass
 class HookResult:

--- a/core/self_improving_loop/auto_trigger.py
+++ b/core/self_improving_loop/auto_trigger.py
@@ -31,6 +31,7 @@ for OL-A1 — added in OL-A2).
 from __future__ import annotations
 
 import fcntl
+import json
 import logging
 import os
 import time
@@ -44,11 +45,14 @@ from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "AUTO_TRIGGER_HISTORY_PATH",
     "AUTO_TRIGGER_LOCK_PATH",
     "AUTO_TRIGGER_TIMESTAMP_PATH",
     "AUTO_TRIGGER_TRIGGER_ID",
+    "STATE_TO_HOOK_EVENT",
     "AutoTriggerStatus",
     "acquire_auto_trigger_lock",
+    "append_history_entry",
     "auto_trigger_mutator",
     "is_min_interval_satisfied",
     "read_last_run_timestamp",
@@ -71,6 +75,39 @@ AUTO_TRIGGER_TIMESTAMP_PATH: Path = GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigg
 firings (lock-blocked, interval-blocked, run_once raised) deliberately
 do NOT update this — only a successful mutation cycle counts so a
 flapping config doesn't lock the schedule out for hours."""
+
+AUTO_TRIGGER_HISTORY_PATH: Path = GLOBAL_SELF_IMPROVING_LOOP_DIR / "auto_trigger_history.jsonl"
+"""Append-only JSONL audit log — one row per firing (terminal state).
+
+Schema: ``{"ts": float, "state": str, "detail": str, "trigger_id": str}``.
+
+Unlike :data:`AUTO_TRIGGER_TIMESTAMP_PATH` which records only
+*successful* fires for the interval gate, the history log captures
+**every** firing including no-ops (``lock_busy`` / ``interval_blocked``
+/ ``disabled``) and errors. OL-A3 ``geode self-improve audit`` viewer
+consumes this file to render the auto-trigger timeline.
+
+Stored under ``~/.geode/self-improving-loop/`` (outside the repo) so
+the file is operator-private and not subject to the repo's
+``.gitignore`` rules — no "claims to be git-tracked but isn't" risk."""
+
+
+STATE_TO_HOOK_EVENT: dict[str, str] = {
+    "fired": "SELF_IMPROVING_AUTO_TRIGGER_FIRED",
+    "lock_busy": "SELF_IMPROVING_AUTO_TRIGGER_LOCK_BUSY",
+    "interval_blocked": "SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED",
+    "runner_error": "SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR",
+    "parse_error": "SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR",
+}
+"""Maps terminal :class:`AutoTriggerStatus.state` → HookEvent enum name.
+
+The ``disabled`` state is intentionally NOT in this map — when the
+defensive guard at the top of :func:`auto_trigger_mutator` returns
+early, the wiring layer should have already prevented registration
+(``enabled=False`` skips ``trigger_manager.register``). Emitting
+``disabled`` would generate a useless event on every cron tick from
+some misconfigured caller. The wiring's own startup log line is the
+SoT for "trigger was registered or skipped"."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -185,6 +222,94 @@ def is_min_interval_satisfied(
     return elapsed_minutes >= min_interval_minutes
 
 
+def append_history_entry(
+    *,
+    state: str,
+    detail: str,
+    ts: float,
+    trigger_id: str = AUTO_TRIGGER_TRIGGER_ID,
+    history_path: Path | None = None,
+) -> bool:
+    """Append one JSONL row to the auto-trigger history log.
+
+    Best-effort: any OSError (parent missing, disk full, permission
+    denied) is logged at WARNING and the function returns False. The
+    caller (:func:`auto_trigger_mutator`) ignores the return value
+    because telemetry failure must not affect the state machine.
+
+    Codex MCP PR-OL-C2 lesson applied — mkdir + write_text inside the
+    same try block.
+    """
+    target = history_path if history_path is not None else AUTO_TRIGGER_HISTORY_PATH
+    row = {"ts": ts, "state": state, "detail": detail, "trigger_id": trigger_id}
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        log.warning("auto_trigger: history append failed: %s", exc)
+        return False
+    return True
+
+
+def _emit_state_event(
+    hooks: Any,
+    *,
+    state: str,
+    detail: str,
+    ts: float,
+    trigger_id: str,
+) -> None:
+    """Emit the HookEvent variant for the given terminal state.
+
+    ``hooks`` is the :class:`core.hooks.HookSystem` instance (typed as
+    Any to avoid the import cost at module load — telemetry must not
+    drag the hook system into the cold path of the manual REPL caller).
+    When ``hooks`` is None, the function is a no-op so unit tests and
+    one-off CLI invocations can use the auto-trigger without wiring
+    the hook system.
+
+    Exception isolation: a misbehaving hook handler must NOT crash the
+    auto-trigger. We swallow any exception and log at WARNING — same
+    contract as :meth:`HookSystem.trigger` itself, which also isolates,
+    but defending against a buggy custom hook injection.
+    """
+    if hooks is None:
+        return
+    hook_event_name = STATE_TO_HOOK_EVENT.get(state)
+    if hook_event_name is None:
+        return  # "disabled" — intentionally not telemetry-emitted
+    try:
+        from core.hooks import HookEvent
+
+        event = getattr(HookEvent, hook_event_name)
+        hooks.trigger(event, {"trigger_id": trigger_id, "ts": ts, "detail": detail})
+    except Exception:
+        log.exception("auto_trigger: hook emit failed for state=%s", state)
+
+
+def _finalize_status(
+    state: str,
+    detail: str,
+    *,
+    hooks: Any,
+    history_path: Path | None,
+    ts: float,
+    trigger_id: str = AUTO_TRIGGER_TRIGGER_ID,
+) -> AutoTriggerStatus:
+    """Single exit point — emit HookEvent + append history + return status.
+
+    Every ``return AutoTriggerStatus(...)`` in :func:`auto_trigger_mutator`
+    goes through this helper so the three side-effects (hook, audit
+    log, return value) cannot drift apart.
+    """
+    _emit_state_event(hooks, state=state, detail=detail, ts=ts, trigger_id=trigger_id)
+    append_history_entry(
+        state=state, detail=detail, ts=ts, trigger_id=trigger_id, history_path=history_path
+    )
+    return AutoTriggerStatus(state=state, detail=detail)
+
+
 def auto_trigger_mutator(
     *,
     enabled: bool,
@@ -192,6 +317,8 @@ def auto_trigger_mutator(
     runner_factory: Callable[[], Any] | None = None,
     lock_path: Path | None = None,
     timestamp_path: Path | None = None,
+    history_path: Path | None = None,
+    hooks: Any = None,
     now: float | None = None,
 ) -> AutoTriggerStatus:
     """One mutator firing — guarded by lockfile + min-interval.
@@ -208,6 +335,11 @@ def auto_trigger_mutator(
             Tests inject mocks; production wires the real runner.
         lock_path: Lockfile path override (tests).
         timestamp_path: Timestamp path override (tests).
+        history_path: JSONL audit log path override (tests).
+        hooks: :class:`HookSystem` instance. When provided, every
+            terminal state (except ``disabled``) emits a
+            ``SELF_IMPROVING_AUTO_TRIGGER_*`` event. None → no telemetry
+            (graceful for unit tests / manual CLI use).
         now: Wall-clock override (tests).
 
     Returns:
@@ -215,7 +347,10 @@ def auto_trigger_mutator(
         raises — exceptions inside ``run_once`` are caught and packed
         into the ``runner_error`` / ``parse_error`` states.
     """
+    ts_now = now if now is not None else time.time()
     if not enabled:
+        # ``disabled`` is the only state that skips telemetry + history
+        # (see STATE_TO_HOOK_EVENT docstring for rationale).
         return AutoTriggerStatus(state="disabled")
 
     if not is_min_interval_satisfied(
@@ -223,14 +358,23 @@ def auto_trigger_mutator(
         now=now,
         timestamp_path=timestamp_path,
     ):
-        return AutoTriggerStatus(
-            state="interval_blocked",
-            detail=f"min_interval_minutes={min_interval_minutes}",
+        return _finalize_status(
+            "interval_blocked",
+            f"min_interval_minutes={min_interval_minutes}",
+            hooks=hooks,
+            history_path=history_path,
+            ts=ts_now,
         )
 
     fd = acquire_auto_trigger_lock(lock_path)
     if fd is None:
-        return AutoTriggerStatus(state="lock_busy")
+        return _finalize_status(
+            "lock_busy",
+            "",
+            hooks=hooks,
+            history_path=history_path,
+            ts=ts_now,
+        )
 
     try:
         # Codex MCP catch (PR-OL-A1 fix-up): re-check interval AFTER
@@ -243,34 +387,58 @@ def auto_trigger_mutator(
             now=now,
             timestamp_path=timestamp_path,
         ):
-            return AutoTriggerStatus(
-                state="interval_blocked",
-                detail=f"min_interval_minutes={min_interval_minutes} (post-lock re-check)",
+            return _finalize_status(
+                "interval_blocked",
+                f"min_interval_minutes={min_interval_minutes} (post-lock re-check)",
+                hooks=hooks,
+                history_path=history_path,
+                ts=ts_now,
             )
 
         # Codex MCP catch (PR-OL-A1 fix-up): runner construction itself
         # can raise (lazy import failure, runner __init__ side-effects).
-        # Catch here so the "never raises" contract holds — the lock is
-        # still released by the outer finally.
         try:
             runner = _resolve_runner(runner_factory)
         except Exception as exc:
             log.exception("auto_trigger: runner factory raised")
-            return AutoTriggerStatus(state="runner_error", detail=repr(exc))
+            return _finalize_status(
+                "runner_error",
+                repr(exc),
+                hooks=hooks,
+                history_path=history_path,
+                ts=ts_now,
+            )
 
         try:
             mutation = runner.run_once()
         except ValueError as exc:
             log.warning("auto_trigger: mutator parse/validation failure: %s", exc)
-            return AutoTriggerStatus(state="parse_error", detail=str(exc))
+            return _finalize_status(
+                "parse_error",
+                str(exc),
+                hooks=hooks,
+                history_path=history_path,
+                ts=ts_now,
+            )
         except Exception as exc:
             log.exception("auto_trigger: runner.run_once raised")
-            return AutoTriggerStatus(state="runner_error", detail=repr(exc))
+            return _finalize_status(
+                "runner_error",
+                repr(exc),
+                hooks=hooks,
+                history_path=history_path,
+                ts=ts_now,
+            )
 
-        current = now if now is not None else time.time()
-        write_last_run_timestamp(current, timestamp_path)
+        write_last_run_timestamp(ts_now, timestamp_path)
         target_section = getattr(mutation, "target_section", "<unknown>")
-        return AutoTriggerStatus(state="fired", detail=f"target_section={target_section}")
+        return _finalize_status(
+            "fired",
+            f"target_section={target_section}",
+            hooks=hooks,
+            history_path=history_path,
+            ts=ts_now,
+        )
     finally:
         release_auto_trigger_lock(fd)
 
@@ -293,6 +461,7 @@ def register_auto_trigger(
     cron: str,
     min_interval_minutes: int,
     runner_factory: Callable[[], Any] | None = None,
+    hooks: Any = None,
 ) -> bool:
     """Register the auto-trigger with the scheduler. No-op when disabled.
 
@@ -301,10 +470,11 @@ def register_auto_trigger(
     when ``enabled=False`` (so the wiring layer can log the skip).
 
     The callback closes over ``min_interval_minutes`` + ``runner_factory``
-    so the scheduler's bare ``callback(data)`` invocation forwards into
-    :func:`auto_trigger_mutator` with the right config. The callback
-    swallows every exception (logs at WARNING) — `TriggerManager`'s own
-    error isolation is the second layer of defense.
+    + ``hooks`` so the scheduler's bare ``callback(data)`` invocation
+    forwards into :func:`auto_trigger_mutator` with the right config
+    and telemetry sink. The callback swallows every exception (logs at
+    WARNING) — `TriggerManager`'s own error isolation is the second
+    layer of defense.
     """
     if not enabled:
         log.info("auto_trigger: [self_improving_loop.scheduler] enabled=False; skip register")
@@ -318,6 +488,7 @@ def register_auto_trigger(
                 enabled=True,
                 min_interval_minutes=min_interval_minutes,
                 runner_factory=runner_factory,
+                hooks=hooks,
             )
             log.info(
                 "auto_trigger fired: state=%s detail=%s",

--- a/core/wiring/automation.py
+++ b/core/wiring/automation.py
@@ -114,6 +114,7 @@ def build_automation(
             enabled=sil_cfg.scheduler.enabled,
             cron=sil_cfg.scheduler.cron,
             min_interval_minutes=sil_cfg.scheduler.min_interval_minutes,
+            hooks=hooks,
         )
     except Exception:
         log.exception("auto_trigger wiring failed; scheduler continues without it")

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -436,7 +436,7 @@ class TestRecoveryHookEvents:
 
     def test_total_hook_event_count(self) -> None:
         """Verify total hook event count after H6 orphan pruning."""
-        assert len(HookEvent) == 64  # +6 PR-2 cognitive cycle members
+        assert len(HookEvent) == 69  # +6 PR-2 cognitive + 5 PR-OL-A1.5 auto-trigger
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,7 +10,7 @@ from core.hooks import HookEvent, HookResult, HookSystem, InterceptResult
 class TestHookEvent:
     def test_all_events_exist(self):
         assert (
-            len(HookEvent) == 64
+            len(HookEvent) == 69
         )  # +6 PR-2: COGNITIVE_PERCEIVE/PLAN/ACT/OBSERVE/REFLECT/UPDATE_MEMORY
 
     def test_event_values(self):

--- a/tests/test_llm_lifecycle_hooks.py
+++ b/tests/test_llm_lifecycle_hooks.py
@@ -27,7 +27,7 @@ class TestLLMLifecycleEvents:
 
     def test_event_count_includes_llm_events(self) -> None:
         """64 events total — +6 cognitive cycle members in PR-2."""
-        assert len(HookEvent) == 64
+        assert len(HookEvent) == 69
 
 
 class TestFireHook:

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -36,7 +36,7 @@ class TestMCPHookEvents:
 
     def test_hook_event_count(self) -> None:
         """Total hook events — +6 cognitive cycle members in PR-2."""
-        assert len(HookEvent) == 64
+        assert len(HookEvent) == 69
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ol_a15_telemetry.py
+++ b/tests/test_ol_a15_telemetry.py
@@ -1,0 +1,426 @@
+"""OL-A1.5 — auto-trigger HookEvent + audit log JSONL invariants.
+
+Pins:
+- 5 new HookEvent variants exist (one per terminal state, except ``disabled``).
+- ``STATE_TO_HOOK_EVENT`` maps each state correctly + does NOT include ``disabled``.
+- ``append_history_entry`` writes one JSONL row per call, round-trips.
+- ``append_history_entry`` graceful on OSError (returns False, no raise).
+- ``auto_trigger_mutator`` emits the right HookEvent + appends one
+  history row for every terminal state EXCEPT ``disabled``.
+- ``hooks=None`` short-circuits hook emit (audit log still writes).
+- Multi-call history log is append-only (entry count grows).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def trigger_paths(tmp_path: Path) -> Iterator[tuple[Path, Path, Path]]:
+    lock = tmp_path / "auto_trigger.lock"
+    ts = tmp_path / "auto_trigger_last_run.txt"
+    hist = tmp_path / "auto_trigger_history.jsonl"
+    yield lock, ts, hist
+
+
+class _FakeRunner:
+    def __init__(self, *, raises: Exception | None = None, target_section: str = "sec") -> None:
+        self._raises = raises
+        self._target_section = target_section
+        self.run_once_count = 0
+
+    def run_once(self) -> Any:
+        self.run_once_count += 1
+        if self._raises is not None:
+            raise self._raises
+
+        class _M:
+            target_section = self._target_section
+
+        _M.target_section = self._target_section  # type: ignore[misc]
+        return _M()
+
+
+class _CapturingHooks:
+    """Records every HookEvent.trigger call for assertion."""
+
+    def __init__(self) -> None:
+        self.emitted: list[tuple[Any, dict[str, Any]]] = []
+
+    def trigger(self, event: Any, data: dict[str, Any]) -> None:
+        self.emitted.append((event, data))
+
+
+# ---------------------------------------------------------------------------
+# HookEvent enum additions
+# ---------------------------------------------------------------------------
+
+
+def test_hook_event_has_five_auto_trigger_variants() -> None:
+    from core.hooks import HookEvent
+
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_FIRED.value == "self_improving_auto_trigger_fired"
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_LOCK_BUSY.value == (
+        "self_improving_auto_trigger_lock_busy"
+    )
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED.value == (
+        "self_improving_auto_trigger_interval_blocked"
+    )
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR.value == (
+        "self_improving_auto_trigger_runner_error"
+    )
+    assert HookEvent.SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR.value == (
+        "self_improving_auto_trigger_parse_error"
+    )
+
+
+def test_state_to_hook_event_map_covers_five_states_only() -> None:
+    """`disabled` is intentionally absent — see module docstring."""
+    from core.self_improving_loop.auto_trigger import STATE_TO_HOOK_EVENT
+
+    assert set(STATE_TO_HOOK_EVENT) == {
+        "fired",
+        "lock_busy",
+        "interval_blocked",
+        "runner_error",
+        "parse_error",
+    }
+    assert "disabled" not in STATE_TO_HOOK_EVENT
+
+
+def test_state_to_hook_event_values_resolve_via_getattr() -> None:
+    """Each mapped string MUST resolve via `getattr(HookEvent, name)`."""
+    from core.hooks import HookEvent
+    from core.self_improving_loop.auto_trigger import STATE_TO_HOOK_EVENT
+
+    for hook_name in STATE_TO_HOOK_EVENT.values():
+        assert hasattr(HookEvent, hook_name), f"HookEvent missing {hook_name}"
+
+
+# ---------------------------------------------------------------------------
+# append_history_entry
+# ---------------------------------------------------------------------------
+
+
+def test_history_entry_writes_one_jsonl_row(trigger_paths: tuple[Path, Path, Path]) -> None:
+    from core.self_improving_loop.auto_trigger import append_history_entry
+
+    _, _, hist = trigger_paths
+    ok = append_history_entry(
+        state="fired",
+        detail="target_section=wrapper.intro",
+        ts=1234567890.0,
+        trigger_id="test-trigger",
+        history_path=hist,
+    )
+    assert ok is True
+    lines = hist.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row == {
+        "ts": 1234567890.0,
+        "state": "fired",
+        "detail": "target_section=wrapper.intro",
+        "trigger_id": "test-trigger",
+    }
+
+
+def test_history_entry_appends_multiple_rows(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    from core.self_improving_loop.auto_trigger import append_history_entry
+
+    _, _, hist = trigger_paths
+    for i in range(3):
+        append_history_entry(state="fired", detail=f"row{i}", ts=float(i), history_path=hist)
+    lines = hist.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 3
+    rows = [json.loads(ln) for ln in lines]
+    assert [r["detail"] for r in rows] == ["row0", "row1", "row2"]
+
+
+def test_history_entry_creates_parent_dir(tmp_path: Path) -> None:
+    from core.self_improving_loop.auto_trigger import append_history_entry
+
+    nested = tmp_path / "deep" / "nested" / "history.jsonl"
+    assert not nested.parent.exists()
+    ok = append_history_entry(state="fired", detail="d", ts=1.0, history_path=nested)
+    assert ok is True
+    assert nested.is_file()
+
+
+def test_history_entry_preserves_unicode_in_detail(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    """Korean / non-ASCII detail must not be escaped to ``\\uXXXX``."""
+    from core.self_improving_loop.auto_trigger import append_history_entry
+
+    _, _, hist = trigger_paths
+    append_history_entry(
+        state="fired",
+        detail="target_section=섹션-한글",
+        ts=1.0,
+        history_path=hist,
+    )
+    raw = hist.read_text(encoding="utf-8")
+    assert "섹션-한글" in raw
+    assert "\\u" not in raw  # ensure_ascii=False applied
+
+
+def test_history_entry_graceful_on_oserror(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Disk failure → returns False, does not raise."""
+    from core.self_improving_loop import auto_trigger as at_module
+
+    def _boom_mkdir(self: Path, *args: Any, **kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "mkdir", _boom_mkdir)
+    target = tmp_path / "blocked" / "history.jsonl"
+    ok = at_module.append_history_entry(state="fired", detail="d", ts=1.0, history_path=target)
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# auto_trigger_mutator end-to-end with telemetry + history
+# ---------------------------------------------------------------------------
+
+
+def test_fired_emits_hook_and_appends_history(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    from core.hooks import HookEvent
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+    runner = _FakeRunner(target_section="wrapper.intro")
+    hooks = _CapturingHooks()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=hooks,
+        now=2000000.0,
+    )
+    assert status.state == "fired"
+    # Hook emitted exactly once with the FIRED variant
+    assert len(hooks.emitted) == 1
+    event, payload = hooks.emitted[0]
+    assert event == HookEvent.SELF_IMPROVING_AUTO_TRIGGER_FIRED
+    assert payload["ts"] == 2000000.0
+    assert "wrapper.intro" in payload["detail"]
+    # History appended exactly once
+    lines = hist.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["state"] == "fired"
+
+
+def test_lock_busy_emits_hook_and_appends_history(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    from core.hooks import HookEvent
+    from core.self_improving_loop.auto_trigger import (
+        acquire_auto_trigger_lock,
+        auto_trigger_mutator,
+        release_auto_trigger_lock,
+    )
+
+    lock, ts, hist = trigger_paths
+    held = acquire_auto_trigger_lock(lock)
+    assert held is not None
+    try:
+        hooks = _CapturingHooks()
+        status = auto_trigger_mutator(
+            enabled=True,
+            min_interval_minutes=60,
+            runner_factory=lambda: _FakeRunner(),
+            lock_path=lock,
+            timestamp_path=ts,
+            history_path=hist,
+            hooks=hooks,
+        )
+        assert status.state == "lock_busy"
+        assert len(hooks.emitted) == 1
+        assert hooks.emitted[0][0] == HookEvent.SELF_IMPROVING_AUTO_TRIGGER_LOCK_BUSY
+        assert hist.read_text(encoding="utf-8").strip().splitlines()
+    finally:
+        release_auto_trigger_lock(held)
+
+
+def test_interval_blocked_emits_hook_and_appends_history(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    from core.hooks import HookEvent
+    from core.self_improving_loop.auto_trigger import (
+        auto_trigger_mutator,
+        write_last_run_timestamp,
+    )
+
+    lock, ts, hist = trigger_paths
+    now = 1000000.0
+    write_last_run_timestamp(now - 10 * 60, ts)  # 10 minutes ago
+    hooks = _CapturingHooks()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=hooks,
+        now=now,
+    )
+    assert status.state == "interval_blocked"
+    assert len(hooks.emitted) == 1
+    assert hooks.emitted[0][0] == HookEvent.SELF_IMPROVING_AUTO_TRIGGER_INTERVAL_BLOCKED
+
+
+def test_runner_error_emits_hook_and_appends_history(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    from core.hooks import HookEvent
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+    runner = _FakeRunner(raises=RuntimeError("boom"))
+    hooks = _CapturingHooks()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=hooks,
+    )
+    assert status.state == "runner_error"
+    assert len(hooks.emitted) == 1
+    assert hooks.emitted[0][0] == HookEvent.SELF_IMPROVING_AUTO_TRIGGER_RUNNER_ERROR
+
+
+def test_parse_error_emits_hook_and_appends_history(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    from core.hooks import HookEvent
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+    runner = _FakeRunner(raises=ValueError("malformed mutation"))
+    hooks = _CapturingHooks()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=hooks,
+    )
+    assert status.state == "parse_error"
+    assert len(hooks.emitted) == 1
+    assert hooks.emitted[0][0] == HookEvent.SELF_IMPROVING_AUTO_TRIGGER_PARSE_ERROR
+
+
+def test_disabled_skips_hook_and_history(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    """`disabled` is the only state that does NOT emit a hook OR
+    append a row — see STATE_TO_HOOK_EVENT docstring for rationale.
+    """
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+    hooks = _CapturingHooks()
+    status = auto_trigger_mutator(
+        enabled=False,
+        min_interval_minutes=60,
+        runner_factory=lambda: _FakeRunner(),
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=hooks,
+    )
+    assert status.state == "disabled"
+    assert hooks.emitted == []
+    assert not hist.exists()
+
+
+def test_hooks_none_does_not_crash(trigger_paths: tuple[Path, Path, Path]) -> None:
+    """Manual REPL / unit-test path: hooks=None must not raise."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+    runner = _FakeRunner()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=None,
+    )
+    assert status.state == "fired"
+    # History still written (telemetry sink-free is still loggable)
+    assert hist.read_text(encoding="utf-8").strip().splitlines()
+
+
+def test_multi_call_history_is_append_only(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    """Three sequential calls → three rows."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+    for i in range(3):
+        runner = _FakeRunner(target_section=f"sec{i}")
+        # Each call uses a unique ts; min_interval=0 effectively
+        status = auto_trigger_mutator(
+            enabled=True,
+            min_interval_minutes=1,
+            runner_factory=lambda r=runner: r,
+            lock_path=lock,
+            timestamp_path=ts,
+            history_path=hist,
+            now=1000.0 + i * 120.0,  # 2 minutes apart
+        )
+        assert status.state == "fired"
+    lines = hist.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 3
+
+
+def test_hook_handler_exception_does_not_break_mutator(
+    trigger_paths: tuple[Path, Path, Path],
+) -> None:
+    """A misbehaving hook subscriber must not crash the state machine."""
+    from core.self_improving_loop.auto_trigger import auto_trigger_mutator
+
+    lock, ts, hist = trigger_paths
+
+    class _BrokenHooks:
+        def trigger(self, event: Any, data: dict[str, Any]) -> None:
+            raise RuntimeError("hook handler broke")
+
+    runner = _FakeRunner()
+    status = auto_trigger_mutator(
+        enabled=True,
+        min_interval_minutes=60,
+        runner_factory=lambda: runner,
+        lock_path=lock,
+        timestamp_path=ts,
+        history_path=hist,
+        hooks=_BrokenHooks(),
+    )
+    # State machine completed despite hook subscriber crash
+    assert status.state == "fired"
+    # History still written
+    assert hist.read_text(encoding="utf-8").strip().splitlines()


### PR DESCRIPTION
## Summary

- 5 new HookEvent variants (`SELF_IMPROVING_AUTO_TRIGGER_{FIRED,LOCK_BUSY,INTERVAL_BLOCKED,RUNNER_ERROR,PARSE_ERROR}`) — 1:1 with `AutoTriggerStatus.state` (except `disabled` which is intentionally skipped).
- JSONL audit log at `~/.geode/self-improving-loop/auto_trigger_history.jsonl` — append-only, one row per firing including no-ops + errors. OL-A3 viewer's prerequisite.
- `auto_trigger_mutator` refactored through `_finalize_status` single-exit helper so hook emit + history append + status return cannot drift apart.

## Why

PR-OL-A1 (#1445) shipped cron-driven firing but only logged terminal state at INFO. No structured channel for downstream subscribers (Petri / Inspect viewer / FE) to count firings, distinguish lock contention from interval gating, or surface runner failures without parsing the daemon log. OL-A3 (`geode self-improve audit` viewer) cannot ship without this audit log — it needs structured input.

## Changes

| File | Change |
|------|--------|
| `core/hooks/system.py` | Add 5 `SELF_IMPROVING_AUTO_TRIGGER_*` variants to `HookEvent` enum |
| `core/self_improving_loop/auto_trigger.py` | Add `AUTO_TRIGGER_HISTORY_PATH` + `STATE_TO_HOOK_EVENT` + `append_history_entry` + `_emit_state_event` + `_finalize_status` helpers; refactor `auto_trigger_mutator` to route every return through `_finalize_status`; add `hooks` + `history_path` kwargs |
| `core/wiring/automation.py` | Forward `hooks=hooks` to `register_auto_trigger` |
| `tests/test_ol_a15_telemetry.py` (new) | 17 invariants — HookEvent enum / audit log / state-emit parity / hooks=None graceful / hook handler crash isolation |
| `CHANGELOG.md` | `[Unreleased]` Added entry under PR-OL-A1.5 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| HookEvent enum additions | Implemented | 5 variants matching state mapping |
| State→HookEvent mapping table | Implemented | `STATE_TO_HOOK_EVENT` dict |
| `disabled` skips telemetry | Implemented | Defensive — wiring should not register when disabled |
| JSONL audit log writer | Implemented | `append_history_entry` with ensure_ascii=False + mkdir-inside-try |
| Single exit point for state machine | Implemented | `_finalize_status` helper |
| `hooks=None` graceful | Implemented | REPL/CLI usable without HookSystem |
| Hook handler raise isolated | Implemented | `_emit_state_event` swallows exceptions |
| Backwards-compat with OL-A1 | Verified | All 26 OL-A1 tests still pass |
| Audit log path NOT in repo | Verified | `~/.geode/` outside the repo, no gitignore conflict |

## Verification

- [x] ruff check clean
- [x] ruff format --check clean
- [x] mypy clean
- [x] pytest 43/43 (17 OL-A1.5 + 26 OL-A1)
- [ ] CI green (5/5 — pending push)
- [ ] Codex MCP LLM-as-Judge (pending)

## Reference

- Predecessor: PR-OL-A1 #1445 (cron + lock + 4-backend)
- Follow-up: OL-A3 (`geode self-improve audit` viewer — consumes this log)
- Roadmap: `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-A2 telemetry slice (renamed from roadmap's OL-A2 which is a data-run-only Phase E task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)