### PR TITLE
PR-OL-A3 — `geode outer-bundle` viewer (Tier 1 closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-OL-A3 — `geode outer-bundle` viewer (Tier 1 closure).**
+  OL-A1.5 (#1446) 가 `auto_trigger_history.jsonl` 을 신규 산출하면서
+  outer-loop 가 만드는 3 streams (`auto_trigger_history.jsonl` /
+  `mutations.jsonl` / `baseline.json`) 가 모두 매겨졌는데, 운영자가 셋
+  중 어느 파일을 grep 해야 할지 모르는 surface gap 잔존 — 본 PR 가
+  closure. **신규 모듈** `core/cli/outer_bundle.py` (~280 LOC) — Typer
+  command `geode outer-bundle [--limit N] [--json]` 가 3 source 를
+  chronologically merge → Rich table (default) 또는 JSONL (--json) 출력.
+  `BundleEvent` dataclass (`ts: float`, `source: str`, `detail: str`)
+  + `load_bundle_events()` public loader + `_parse_iso_or_epoch` (float/
+  ISO-8601 dual-format) + `_tail_jsonl` (graceful partial-line skip).
+  Source discriminator 3-값: `auto_trigger` / `mutation` / `baseline`
+  (마지막은 synthetic 1-row from current promoted baseline.json). 누락
+  파일 → empty bundle (raise 없음). **CLI 등록**: `core/cli/__init__.py`
+  의 `app.command(name="outer-bundle")` 로 entry point. **15 invariant
+  test** (`tests/test_ol_a3_outer_bundle.py`) — BundleEvent round-trip
+  + parse helpers x3 (float / ISO / garbage) + _tail_jsonl x3 (last-N /
+  malformed skip / missing path) + load_bundle_events x5 (auto-trigger
+  only / mutation row / baseline synthetic / 3-source chronological
+  sort / all-missing empty) + CLI x3 (Typer registration / no-data
+  callable / --json output). Quality gates clean (ruff + ruff format
+  --check + mypy + 15/15 pytest). CLI smoke (`geode outer-bundle
+  --help`) renders.
+
 ## [0.99.27] - 2026-05-22
 
 > 51 PRs accumulated since v0.99.26. Headline arcs:

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -336,6 +336,11 @@ app.command()(audit)
 app.command(name="petri-archive")(petri_archive)
 app.add_typer(audit_seeds_app, name="audit-seeds")
 
+# OL-A3 (2026-05-22) — outer-loop bundle viewer
+from core.cli.outer_bundle import outer_bundle_command  # noqa: E402
+
+app.command(name="outer-bundle")(outer_bundle_command)
+
 
 def _version_option(value: bool) -> None:
     if value:

--- a/core/cli/outer_bundle.py
+++ b/core/cli/outer_bundle.py
@@ -1,0 +1,320 @@
+"""Outer-loop bundle viewer — `geode outer-bundle` Typer command.
+
+OL-A3 (2026-05-22) prerequisite stack now in place:
+
+- ``~/.geode/self-improving-loop/auto_trigger_history.jsonl`` (OL-A1.5)
+  — per-firing JSONL, one row per terminal state of the auto-trigger
+  state machine (fired / lock_busy / interval_blocked / runner_error /
+  parse_error).
+- ``autoresearch/state/mutations.jsonl`` — git-tracked mutation audit
+  ledger (one row per ``apply_mutation`` call: applied / rejected /
+  rolled_back).
+- ``autoresearch/state/baseline.json`` — current fitness baseline
+  (promoted only — failing audits do not update it; see PR-G2 #1346
+  retrospective).
+
+This module crosswalks the three streams into a single chronologically
+sorted timeline so an operator can answer "what did the self-improving
+loop do today?" without grepping three files. Output is Rich-rendered
+table; output for ``--json`` is one row per event so downstream tools
+can consume it.
+
+**Why a separate viewer instead of extending `/self-improving status`?**
+
+The slash command `_cmd_status` (`core/cli/commands/self_improving.py`)
+already reads baseline + mutations and ships in the REPL. But:
+
+1. **Outside-REPL access** — operators frequently want this view from
+   their shell prompt (e.g., post-incident review, daemon health check
+   from a deploy tool). A standalone Typer command satisfies that.
+2. **Triple-source crosswalk** — auto_trigger_history.jsonl is OL-A1.5
+   data; slash command does NOT read it. Bundling that signal with
+   the mutation ledger is the new value-add.
+3. **Future evolution** — OL-A3 is the foundation for richer outer-
+   loop diagnostics (e.g., per-session bundle, by-state filter,
+   regression timeline). A dedicated module keeps the surface focused.
+
+The two surfaces are intentionally redundant on baseline/mutations —
+in-REPL `_cmd_status` for quick check, standalone `outer-bundle` for
+deeper investigation + automation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
+from core.self_improving_loop.auto_trigger import AUTO_TRIGGER_HISTORY_PATH
+
+log = logging.getLogger(__name__)
+console = Console()
+
+__all__ = [
+    "BundleEvent",
+    "load_bundle_events",
+    "outer_bundle_command",
+]
+
+
+# Default tail size — matches `/self-improving status` default. Operator
+# can override with ``--limit N`` for a wider window.
+_DEFAULT_TAIL = 20
+
+
+@dataclass(frozen=True, slots=True)
+class BundleEvent:
+    """One row in the unified outer-loop timeline.
+
+    Three sources contribute (via ``source`` discriminator):
+
+    * ``"auto_trigger"`` — from ``auto_trigger_history.jsonl``;
+      ``detail`` carries the state machine variant (fired/lock_busy/etc.)
+    * ``"mutation"`` — from ``mutations.jsonl``; ``detail`` carries
+      ``kind`` (applied/rejected/rolled_back) + ``target_section``.
+    * ``"baseline"`` — from ``baseline.json``; single synthetic event
+      representing the most recent promoted fitness, with ``ts`` from
+      the file's ``timestamp`` field. Only emitted when baseline.json
+      exists.
+
+    ``ts`` is Unix epoch seconds (float). Sources that store ISO-8601
+    strings are normalised to epoch in the loader; on parse failure the
+    row is skipped + logged at DEBUG.
+    """
+
+    ts: float
+    source: str
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"ts": self.ts, "source": self.source, "detail": self.detail}
+
+
+def _parse_iso_or_epoch(value: Any) -> float | None:
+    """Accept either a float epoch or an ISO-8601 string. Return None
+    on parse failure so the row is dropped silently."""
+    if isinstance(value, int | float):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip().rstrip("Z")
+    try:
+        # ISO-8601 most-common: 2026-05-22T13:42:15.123456
+        from datetime import datetime
+
+        return datetime.fromisoformat(text).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _tail_jsonl(path: Path, *, limit: int) -> list[dict[str, Any]]:
+    """Read the last ``limit`` valid JSON rows from a JSONL file.
+
+    Missing path → empty list (graceful). Malformed lines → silently
+    skipped (the file is append-only; concurrent writer can leave a
+    half-flushed last row).
+    """
+    if not path.is_file() or limit <= 0:
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        log.debug("outer_bundle: %s unreadable: %s", path, exc)
+        return []
+    parsed: list[dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            parsed.append(row)
+    return parsed[-limit:]
+
+
+def _load_auto_trigger_events(*, limit: int) -> list[BundleEvent]:
+    """Read OL-A1.5 audit log → BundleEvent list (source='auto_trigger')."""
+    rows = _tail_jsonl(AUTO_TRIGGER_HISTORY_PATH, limit=limit)
+    events: list[BundleEvent] = []
+    for row in rows:
+        ts = _parse_iso_or_epoch(row.get("ts"))
+        if ts is None:
+            continue
+        state = str(row.get("state") or "")
+        extra = str(row.get("detail") or "")
+        detail = f"{state}" + (f" — {extra}" if extra else "")
+        events.append(BundleEvent(ts=ts, source="auto_trigger", detail=detail))
+    return events
+
+
+def _load_mutation_events(*, limit: int) -> list[BundleEvent]:
+    """Read mutations.jsonl → BundleEvent list (source='mutation').
+
+    Lazy-imports ``MUTATION_AUDIT_LOG_PATH`` from runner so the bundle
+    module doesn't drag the full runner deps at module load.
+    """
+    try:
+        from core.self_improving_loop.runner import MUTATION_AUDIT_LOG_PATH
+    except ImportError as exc:
+        log.debug("outer_bundle: mutation log path unavailable: %s", exc)
+        return []
+    rows = _tail_jsonl(Path(MUTATION_AUDIT_LOG_PATH), limit=limit)
+    events: list[BundleEvent] = []
+    for row in rows:
+        ts = _parse_iso_or_epoch(row.get("ts"))
+        if ts is None:
+            continue
+        kind = str(row.get("kind") or "")
+        target_kind = str(row.get("target_kind") or "")
+        target_section = str(row.get("target_section") or "")
+        # Format: applied[prompt:wrapper.intro] / rejected[tool_policy:...]
+        scope = f"{target_kind}:{target_section}" if target_kind or target_section else ""
+        detail = f"{kind}" + (f"[{scope}]" if scope else "")
+        events.append(BundleEvent(ts=ts, source="mutation", detail=detail))
+    return events
+
+
+def _load_baseline_event() -> BundleEvent | None:
+    """Synthetic single event for the most recent promoted baseline.
+
+    The baseline file only updates on PROMOTE — see PR-G2 #1346 — so
+    this is the "last successful audit" marker in the timeline.
+    """
+    try:
+        from core.self_improving_loop.runner import MUTATION_AUDIT_LOG_PATH
+    except ImportError:
+        return None
+    baseline_path = Path(MUTATION_AUDIT_LOG_PATH).parent / "baseline.json"
+    if not baseline_path.is_file():
+        return None
+    try:
+        data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug("outer_bundle: baseline.json unreadable: %s", exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    ts = _parse_iso_or_epoch(data.get("timestamp") or data.get("ts"))
+    if ts is None:
+        return None
+    fitness = data.get("fitness")
+    fitness_str = f"{fitness:.4f}" if isinstance(fitness, int | float) else "?"
+    reason = data.get("promote_reason") or data.get("reason") or "?"
+    detail = f"promoted fitness={fitness_str} ({reason})"
+    return BundleEvent(ts=ts, source="baseline", detail=detail)
+
+
+def load_bundle_events(
+    *,
+    limit: int = _DEFAULT_TAIL,
+    history_path: Path | None = None,
+) -> list[BundleEvent]:
+    """Public loader — three-source crosswalk + chronological sort.
+
+    Args:
+        limit: Per-source tail. The output may have up to 2×limit + 1
+            events (auto_trigger + mutation + baseline).
+        history_path: Override for the auto-trigger history path (test
+            injection). Default uses the canonical
+            :data:`AUTO_TRIGGER_HISTORY_PATH`.
+    """
+    # auto_trigger load uses module constant — for tests we monkey-patch
+    # the module attribute instead of plumbing path here.
+    if history_path is not None:
+        # Temporarily redirect the constant via globals override.
+        # Tests typically use monkeypatch.setattr; this branch is the
+        # explicit-arg path that lets non-test callers swap the source.
+        rows = _tail_jsonl(history_path, limit=limit)
+        auto_events: list[BundleEvent] = []
+        for row in rows:
+            ts = _parse_iso_or_epoch(row.get("ts"))
+            if ts is None:
+                continue
+            state = str(row.get("state") or "")
+            extra = str(row.get("detail") or "")
+            detail = f"{state}" + (f" — {extra}" if extra else "")
+            auto_events.append(BundleEvent(ts=ts, source="auto_trigger", detail=detail))
+    else:
+        auto_events = _load_auto_trigger_events(limit=limit)
+    mutation_events = _load_mutation_events(limit=limit)
+    baseline_event = _load_baseline_event()
+    combined = auto_events + mutation_events
+    if baseline_event is not None:
+        combined.append(baseline_event)
+    combined.sort(key=lambda ev: ev.ts)
+    return combined
+
+
+def _format_ts(epoch: float) -> str:
+    """Render epoch as ``YYYY-MM-DD HH:MM:SS`` local time."""
+    from datetime import datetime
+
+    return datetime.fromtimestamp(epoch).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _render_table(events: list[BundleEvent]) -> None:
+    """Print events as a Rich table."""
+    table = Table(title="Outer-loop bundle — auto_trigger × mutations × baseline")
+    table.add_column("Timestamp", style="cyan", no_wrap=True)
+    table.add_column("Source", style="magenta")
+    table.add_column("Detail", style="white")
+    for ev in events:
+        table.add_row(_format_ts(ev.ts), ev.source, ev.detail)
+    console.print(table)
+
+
+def outer_bundle_command(
+    limit: int = typer.Option(
+        _DEFAULT_TAIL,
+        "--limit",
+        "-n",
+        help="Per-source tail size. Output is up to 2×limit + 1 events.",
+        min=1,
+        max=500,
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit one JSON row per event to stdout instead of a Rich table.",
+    ),
+) -> None:
+    """View the outer self-improving loop's activity bundle.
+
+    Crosswalks three sources into one chronological timeline:
+
+    * ``auto_trigger_history.jsonl`` — cron firings (OL-A1.5)
+    * ``mutations.jsonl`` — mutation audit ledger
+    * ``baseline.json`` — current promoted fitness baseline
+
+    Output (default) is a Rich table sorted ascending by timestamp.
+    ``--json`` switches to JSONL-on-stdout for downstream tools.
+
+    Files outside ``~/.geode/`` and ``autoresearch/state/`` are
+    ignored. Missing files render as an empty bundle (no error).
+    """
+    events = load_bundle_events(limit=limit)
+    if json_output:
+        for ev in events:
+            console.print_json(data=ev.as_dict())
+        return
+    if not events:
+        console.print(
+            "[muted]No bundle events — auto_trigger_history.jsonl + "
+            "mutations.jsonl + baseline.json all empty/absent.[/muted]"
+        )
+        console.print(
+            f"[muted]Looked for: {AUTO_TRIGGER_HISTORY_PATH} + "
+            f"{GLOBAL_SELF_IMPROVING_LOOP_DIR.parent}/autoresearch/state/[/muted]"
+        )
+        return
+    _render_table(events)

--- a/core/cli/outer_bundle.py
+++ b/core/cli/outer_bundle.py
@@ -189,6 +189,16 @@ def _load_baseline_event() -> BundleEvent | None:
 
     The baseline file only updates on PROMOTE — see PR-G2 #1346 — so
     this is the "last successful audit" marker in the timeline.
+
+    Codex MCP catch (PR-OL-A3 fix-up): real `baseline.json` (written by
+    ``autoresearch/train.py:_persist_baseline``) carries only aggregate
+    payload (``dim_means`` / ``dim_stderr`` + optional ``ux_means`` /
+    ``admire_means`` / ``bench_means``) — NO ``timestamp`` or
+    ``fitness`` scalar fields. We therefore derive the event timestamp
+    from the file's mtime (the moment of promotion) and synthesise the
+    detail from the dim count + a "promoted" marker. Tests can still
+    inject an explicit ``timestamp`` field (which takes precedence) so
+    historical fixture data with the legacy schema keeps working.
     """
     try:
         from core.self_improving_loop.runner import MUTATION_AUDIT_LOG_PATH
@@ -204,13 +214,26 @@ def _load_baseline_event() -> BundleEvent | None:
         return None
     if not isinstance(data, dict):
         return None
+    # Prefer explicit timestamp / ts when present (legacy schema / test
+    # fixtures). Otherwise fall back to file mtime — the actual
+    # baseline writer does not emit a timestamp field.
     ts = _parse_iso_or_epoch(data.get("timestamp") or data.get("ts"))
     if ts is None:
-        return None
+        try:
+            ts = baseline_path.stat().st_mtime
+        except OSError:
+            return None
+    # `fitness` scalar may or may not be present; if not, summarise
+    # dim_means count instead so the event still renders informatively.
     fitness = data.get("fitness")
-    fitness_str = f"{fitness:.4f}" if isinstance(fitness, int | float) else "?"
-    reason = data.get("promote_reason") or data.get("reason") or "?"
-    detail = f"promoted fitness={fitness_str} ({reason})"
+    if isinstance(fitness, int | float):
+        body_detail = f"fitness={fitness:.4f}"
+    else:
+        dim_means = data.get("dim_means") or {}
+        dim_count = len(dim_means) if isinstance(dim_means, dict) else 0
+        body_detail = f"dim_means[{dim_count}]"
+    reason = data.get("promote_reason") or data.get("reason") or "promoted"
+    detail = f"baseline {body_detail} ({reason})"
     return BundleEvent(ts=ts, source="baseline", detail=detail)
 
 
@@ -304,8 +327,13 @@ def outer_bundle_command(
     """
     events = load_bundle_events(limit=limit)
     if json_output:
+        # Codex MCP catch (PR-OL-A3 fix-up): `console.print_json` pretty-
+        # prints with indentation across multiple lines per object, which
+        # is NOT JSONL. Downstream tools (jq, awk, line-based readers)
+        # need exactly one JSON object per line. Use json.dumps + plain
+        # print to satisfy the JSONL contract.
         for ev in events:
-            console.print_json(data=ev.as_dict())
+            print(json.dumps(ev.as_dict(), ensure_ascii=False))
         return
     if not events:
         console.print(

--- a/tests/test_ol_a3_outer_bundle.py
+++ b/tests/test_ol_a3_outer_bundle.py
@@ -251,14 +251,20 @@ def test_outer_bundle_command_callable_with_no_data(
 def test_outer_bundle_command_json_output(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """--json mode emits one JSON object per event."""
+    """--json mode emits ONE JSON object PER LINE (true JSONL).
+
+    Codex MCP catch (PR-OL-A3 fix-up): `console.print_json` pretty-prints
+    across multiple lines per object, which breaks downstream jq /
+    line-based readers. Pin the JSONL contract here.
+    """
     from core.cli import outer_bundle as ob
 
     hist = tmp_path / "auto_trigger_history.jsonl"
-    hist.write_text(
-        json.dumps({"ts": 1000.0, "state": "fired", "detail": "y"}) + "\n",
-        encoding="utf-8",
-    )
+    rows = [
+        {"ts": 1000.0, "state": "fired", "detail": "alpha"},
+        {"ts": 2000.0, "state": "lock_busy", "detail": ""},
+    ]
+    hist.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
     monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", hist)
     monkeypatch.setattr(
         "core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH",
@@ -266,7 +272,53 @@ def test_outer_bundle_command_json_output(
     )
     ob.outer_bundle_command(limit=10, json_output=True)
     out = capsys.readouterr().out
-    # Should contain the JSON encoding of the event we wrote
-    assert '"source"' in out
-    assert '"auto_trigger"' in out
-    assert '"fired' in out
+    # Exactly 2 non-empty lines → 2 events
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert len(lines) == 2, f"Expected JSONL output, got {out!r}"
+    # Each line must parse as valid JSON dict
+    parsed = [json.loads(ln) for ln in lines]
+    assert all(isinstance(p, dict) for p in parsed)
+    assert {p["detail"][:5] for p in parsed} == {"fired", "lock_"}
+
+
+def test_baseline_uses_file_mtime_when_no_timestamp_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex MCP catch (PR-OL-A3 fix-up): the real `baseline.json` writer
+    (`autoresearch/train.py:_persist_baseline`) does NOT emit ``timestamp``
+    or ``fitness`` fields — only ``dim_means`` / ``dim_stderr`` /
+    optional axis-specific means. The viewer must fall back to file
+    mtime + synthesise the detail from dim count.
+    """
+    import os
+    import time
+
+    from core.cli import outer_bundle as ob
+
+    mut = tmp_path / "state" / "mutations.jsonl"
+    mut.parent.mkdir(parents=True)
+    baseline = mut.parent / "baseline.json"
+    # Production schema — only aggregate payload, NO timestamp/fitness.
+    baseline.write_text(
+        json.dumps(
+            {
+                "dim_means": {"correctness": 0.85, "safety": 0.92, "depth": 0.78},
+                "dim_stderr": {"correctness": 0.02, "safety": 0.01, "depth": 0.03},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Stamp a known mtime so the test is deterministic.
+    fixed_mtime = time.time() - 3600  # 1 hour ago
+    os.utime(baseline, (fixed_mtime, fixed_mtime))
+    monkeypatch.setattr("core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH", mut)
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", tmp_path / "no_history.jsonl")
+    events = ob.load_bundle_events(limit=10)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.source == "baseline"
+    # mtime fallback worked
+    assert abs(ev.ts - fixed_mtime) < 1.0
+    # detail uses dim_means count (3 axes) since no fitness scalar
+    assert "dim_means[3]" in ev.detail
+    assert "promoted" in ev.detail

--- a/tests/test_ol_a3_outer_bundle.py
+++ b/tests/test_ol_a3_outer_bundle.py
@@ -1,0 +1,272 @@
+"""OL-A3 — `geode outer-bundle` viewer invariants.
+
+Pins:
+- `BundleEvent` shape (ts / source / detail) round-trips via as_dict.
+- `_parse_iso_or_epoch` accepts float, ISO-8601, returns None on garbage.
+- `_tail_jsonl` reads last N rows + skips malformed lines silently.
+- `load_bundle_events` merges 3 sources chronologically.
+- Auto-trigger row → source='auto_trigger'.
+- Mutation row → source='mutation'.
+- Baseline → source='baseline', synthetic 1-row.
+- Missing files → empty event list (no raise).
+- Output sorted ascending by ts.
+- Typer CLI command registered.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_bundle_event_round_trip() -> None:
+    from core.cli.outer_bundle import BundleEvent
+
+    ev = BundleEvent(ts=1000.5, source="auto_trigger", detail="fired — target=x")
+    d = ev.as_dict()
+    assert d == {"ts": 1000.5, "source": "auto_trigger", "detail": "fired — target=x"}
+
+
+def test_parse_iso_or_epoch_accepts_float() -> None:
+    from core.cli.outer_bundle import _parse_iso_or_epoch
+
+    assert _parse_iso_or_epoch(1234567890.5) == 1234567890.5
+    assert _parse_iso_or_epoch(1234567890) == 1234567890.0
+
+
+def test_parse_iso_or_epoch_accepts_iso8601() -> None:
+    # Round-trip via datetime to get expected epoch
+    from datetime import datetime
+
+    from core.cli.outer_bundle import _parse_iso_or_epoch
+
+    expected = datetime.fromisoformat("2026-05-22T12:34:56").timestamp()
+    assert _parse_iso_or_epoch("2026-05-22T12:34:56") == expected
+    # Trailing Z stripped
+    assert _parse_iso_or_epoch("2026-05-22T12:34:56Z") == expected
+
+
+def test_parse_iso_or_epoch_garbage_returns_none() -> None:
+    from core.cli.outer_bundle import _parse_iso_or_epoch
+
+    assert _parse_iso_or_epoch(None) is None
+    assert _parse_iso_or_epoch("") is None
+    assert _parse_iso_or_epoch("not-a-date") is None
+    assert _parse_iso_or_epoch({}) is None
+
+
+def test_tail_jsonl_reads_last_n_rows(tmp_path: Path) -> None:
+    from core.cli.outer_bundle import _tail_jsonl
+
+    p = tmp_path / "log.jsonl"
+    lines = [json.dumps({"i": i}) for i in range(10)]
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    out = _tail_jsonl(p, limit=3)
+    assert [r["i"] for r in out] == [7, 8, 9]
+
+
+def test_tail_jsonl_skips_malformed_lines(tmp_path: Path) -> None:
+    from core.cli.outer_bundle import _tail_jsonl
+
+    p = tmp_path / "log.jsonl"
+    p.write_text(
+        '{"ok": 1}\nnot-json\n{"ok": 2}\n   \n{"ok": 3}\n',
+        encoding="utf-8",
+    )
+    out = _tail_jsonl(p, limit=10)
+    assert [r["ok"] for r in out] == [1, 2, 3]
+
+
+def test_tail_jsonl_missing_file_returns_empty(tmp_path: Path) -> None:
+    from core.cli.outer_bundle import _tail_jsonl
+
+    assert _tail_jsonl(tmp_path / "no_such.jsonl", limit=5) == []
+
+
+def test_load_bundle_events_auto_trigger_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bundle reader picks up auto_trigger rows when only that source exists."""
+    from core.cli import outer_bundle as ob
+
+    hist = tmp_path / "auto_trigger_history.jsonl"
+    rows = [
+        {"ts": 1000.0, "state": "fired", "detail": "target_section=wrapper.intro"},
+        {"ts": 2000.0, "state": "lock_busy", "detail": ""},
+    ]
+    hist.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    # Redirect mutation/baseline lookups to nonexistent paths so only
+    # auto_trigger contributes.
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", hist)
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH",
+        tmp_path / "no_mutations.jsonl",
+    )
+    events = ob.load_bundle_events(limit=10)
+    assert len(events) == 2
+    assert {ev.source for ev in events} == {"auto_trigger"}
+    assert events[0].ts == 1000.0
+    assert "fired" in events[0].detail
+    assert "wrapper.intro" in events[0].detail
+    assert events[1].detail.startswith("lock_busy")
+
+
+def test_load_bundle_events_mutation_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.cli import outer_bundle as ob
+
+    mut = tmp_path / "mutations.jsonl"
+    rows = [
+        {
+            "ts": 1500.0,
+            "kind": "applied",
+            "target_kind": "prompt",
+            "target_section": "wrapper.intro",
+            "mutation_id": "m1",
+        },
+        {
+            "ts": 1600.0,
+            "kind": "rejected",
+            "target_kind": "tool_policy",
+            "target_section": "search",
+            "mutation_id": "m2",
+        },
+    ]
+    mut.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    monkeypatch.setattr("core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH", mut)
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", tmp_path / "no_history.jsonl")
+    events = ob.load_bundle_events(limit=10)
+    assert len(events) == 2
+    assert all(ev.source == "mutation" for ev in events)
+    assert "applied" in events[0].detail
+    assert "prompt:wrapper.intro" in events[0].detail
+    assert "rejected" in events[1].detail
+
+
+def test_load_bundle_events_baseline_synthetic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.cli import outer_bundle as ob
+
+    mut = tmp_path / "state" / "mutations.jsonl"
+    mut.parent.mkdir(parents=True)
+    baseline = mut.parent / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "ts": 3000.0,
+                "fitness": 0.875,
+                "promote_reason": "audit_passed",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH", mut)
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", tmp_path / "no_history.jsonl")
+    events = ob.load_bundle_events(limit=10)
+    assert len(events) == 1
+    assert events[0].source == "baseline"
+    assert "0.8750" in events[0].detail
+    assert "audit_passed" in events[0].detail
+
+
+def test_load_bundle_events_sorts_ascending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crosswalk must interleave the three sources by timestamp."""
+    from core.cli import outer_bundle as ob
+
+    hist = tmp_path / "auto_trigger_history.jsonl"
+    mut = tmp_path / "state" / "mutations.jsonl"
+    mut.parent.mkdir(parents=True)
+    baseline = mut.parent / "baseline.json"
+
+    hist.write_text(
+        json.dumps({"ts": 1500.0, "state": "fired", "detail": "x"}) + "\n",
+        encoding="utf-8",
+    )
+    mut.write_text(
+        json.dumps(
+            {
+                "ts": 1700.0,
+                "kind": "applied",
+                "target_kind": "prompt",
+                "target_section": "intro",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    baseline.write_text(
+        json.dumps({"ts": 1200.0, "fitness": 0.5, "promote_reason": "init"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", hist)
+    monkeypatch.setattr("core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH", mut)
+    events = ob.load_bundle_events(limit=10)
+    assert [ev.source for ev in events] == ["baseline", "auto_trigger", "mutation"]
+    assert events[0].ts == 1200.0 < events[1].ts == 1500.0 < events[2].ts == 1700.0
+
+
+def test_load_bundle_events_all_missing_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No files anywhere → empty list, no exception."""
+    from core.cli import outer_bundle as ob
+
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", tmp_path / "no_hist.jsonl")
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH",
+        tmp_path / "no_state" / "no_mut.jsonl",
+    )
+    assert ob.load_bundle_events(limit=10) == []
+
+
+def test_outer_bundle_command_registered_on_app() -> None:
+    """Typer should resolve `outer-bundle` as a registered command."""
+    from core.cli import app
+
+    cmd_names = {c.name for c in app.registered_commands}
+    assert "outer-bundle" in cmd_names
+
+
+def test_outer_bundle_command_callable_with_no_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Calling the command directly with no input files should
+    print the empty-state message without raising."""
+    from core.cli import outer_bundle as ob
+
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", tmp_path / "no_hist.jsonl")
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH",
+        tmp_path / "no_state" / "no_mut.jsonl",
+    )
+    # Call the function directly (bypass Typer arg parsing).
+    ob.outer_bundle_command(limit=10, json_output=False)
+
+
+def test_outer_bundle_command_json_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--json mode emits one JSON object per event."""
+    from core.cli import outer_bundle as ob
+
+    hist = tmp_path / "auto_trigger_history.jsonl"
+    hist.write_text(
+        json.dumps({"ts": 1000.0, "state": "fired", "detail": "y"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ob, "AUTO_TRIGGER_HISTORY_PATH", hist)
+    monkeypatch.setattr(
+        "core.self_improving_loop.runner.MUTATION_AUDIT_LOG_PATH",
+        tmp_path / "no_mut.jsonl",
+    )
+    ob.outer_bundle_command(limit=10, json_output=True)
+    out = capsys.readouterr().out
+    # Should contain the JSON encoding of the event we wrote
+    assert '"source"' in out
+    assert '"auto_trigger"' in out
+    assert '"fired' in out


### PR DESCRIPTION
## Summary

- New Typer command `geode outer-bundle [--limit N] [--json]` that crosswalks 3 outer-loop data streams (`auto_trigger_history.jsonl` + `mutations.jsonl` + `baseline.json`) into a chronologically sorted timeline.
- Rich-rendered table (default) or JSONL stdout (`--json` for downstream tools).
- 15 invariants covering load helpers + 3-source crosswalk + CLI registration + empty-state.

## Why

PR-OL-A1.5 (#1446) shipped `auto_trigger_history.jsonl`. Combined with the pre-existing `mutations.jsonl` (mutation audit ledger) and `baseline.json` (current promoted fitness), the outer self-improving loop now produces 3 data files — but no operator-facing aggregator existed.

Without the bundle viewer, an operator answering "what did the loop do today?" has to grep three files in different directories and manually correlate timestamps. OL-A3 closes that gap.

`/self-improving status` (slash command) already shows baseline + mutations in-REPL — kept intentionally redundant with the new Typer command:
- Slash: quick in-REPL check.
- Typer: standalone shell access + auto_trigger crosswalk + automation (--json).

## Changes

| File | Change |
|------|--------|
| `core/cli/outer_bundle.py` (new) | `BundleEvent` dataclass + `load_bundle_events` + `_parse_iso_or_epoch` + `_tail_jsonl` + `outer_bundle_command` Typer command (~280 LOC) |
| `core/cli/__init__.py` | Register `app.command(name="outer-bundle")(outer_bundle_command)` |
| `tests/test_ol_a3_outer_bundle.py` (new) | 15 invariants |
| `CHANGELOG.md` | `[Unreleased]` Added entry under PR-OL-A3 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| auto_trigger_history.jsonl reader | Implemented | OL-A1.5's append-only log consumed |
| mutations.jsonl reader | Implemented | Pre-existing audit ledger crosswalk |
| baseline.json (synthetic event) | Implemented | Single row for current promoted fitness |
| Chronological sort | Implemented | All events combined + sorted by ts ascending |
| JSON output for automation | Implemented | `--json` flag emits JSONL on stdout |
| Empty-state handling | Implemented | Missing files → empty bundle, no raise |
| Dual-format ts (float / ISO) | Implemented | `_parse_iso_or_epoch` accepts both |
| Slash `_cmd_status` (existing) | Intentionally redundant | In-REPL quick check coexists with standalone command |

## Verification

- [x] ruff check + ruff format --check clean
- [x] mypy clean (`core/cli/outer_bundle.py`)
- [x] pytest 15/15 OL-A3
- [x] CLI smoke (`geode outer-bundle --help` renders correctly)
- [ ] CI green (5/5 — pending push)
- [ ] Codex MCP LLM-as-Judge (pending)

## Reference

- Data source: PR-OL-A1.5 #1446 (`AUTO_TRIGGER_HISTORY_PATH`)
- Sibling viewer (slash command): `core/cli/commands/self_improving.py::_cmd_status`
- Roadmap: `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-A3

🤖 Generated with [Claude Code](https://claude.com/claude-code)