### PR TITLE
PR-OL-P2 — Petri quota actual enforcement (auto-trip + opt-in gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-OL-P2 — Petri quota actual enforcement (auto-trip + opt-in call gate).**
+  Pre-OL-P2 의 `SubscriptionQuotaBanner.abort_threshold` 가 *display-only*
+  — `tier()` 가 red 반환 → 시각만 빨개지지만 실제 abort 는 credential
+  resolver 의 strict-mode 만 발화. 자연 usage 가 threshold 를 넘어도
+  enforcement 없음. **신규 2 wiring**: (1) `set_state` 가 새 ratio 가
+  `abort_threshold` 를 cross 하면 자동으로 `aborted=True` + 정보성
+  `abort_reason` 채움. 이미 abort 된 상태면 기존 reason 보존 (credential
+  issue 가 usage issue 보다 우선 신호). `clear_abort` 후 다시 breach 하면
+  재-trip. (2) **`enforce_or_raise()` 신규 메서드** — `QuotaAbortError`
+  (RuntimeError 하위) 를 banner aborted 상태일 때 raise. 운영자가 호출
+  지점에 opt-in 으로 wrapping → fail-fast. **신규 example caller**:
+  `autoresearch/train.py::run_audit(dry_run=False)` 가 `_build_audit_command`
+  직전에 `current_banner() and current_banner().enforce_or_raise()` 호출
+  → quota 가 trip 되면 audit subprocess 자체를 spawn 안 함 (가장 비싼
+  caller 이므로 first wiring). 기존 caller 들은 unchanged (backwards-compat
+  preserved). **신규 export**: `QuotaAbortError` 추가, `__all__` 갱신.
+  **기존 test 1 개 갱신** (`test_render_red_when_at_abort_threshold` 가
+  pre-OL-P2 의 "95% used" 출력 대신 새 "aborted" 출력 검증). **12 신규
+  invariant test** (`tests/test_ol_p2_quota_enforcement.py`) — auto-trip
+  x6 + enforce_or_raise x4 + autoresearch wiring x2. Quality gates clean
+  (ruff + ruff format --check + mypy + 12/12 OL-P2 + 69 regression on
+  adjacent quota tests).
+
 ## [0.99.27] - 2026-05-22
 
 > 51 PRs accumulated since v0.99.26. Headline arcs:

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -636,6 +636,24 @@ def run_audit(
             "use --dry-run until the runtime hook lands"
         )
 
+    # OL-P2 (2026-05-22) — opt-in quota gate. When the operator-level
+    # quota banner is in aborted state (either via credential-resolver
+    # trip or via auto-trip on `abort_threshold` breach), refuse to
+    # spawn the audit subprocess at all. Cost saving > audit usefulness
+    # when quota is exhausted. Graceful: if no banner is installed
+    # (non-REPL execution, e.g., CI run), the gate is a no-op.
+    try:
+        from core.cli.quota_banner import QuotaAbortError, current_banner
+
+        banner = current_banner()
+        if banner is not None:
+            banner.enforce_or_raise()
+    except QuotaAbortError as exc:
+        raise RuntimeError(f"autoresearch audit aborted: quota gate tripped — {exc}") from exc
+    except ImportError:
+        # core.cli is not present in some packaged distros; silent skip.
+        pass
+
     argv = _build_audit_command()
     env = os.environ.copy()
     env["GEODE_WRAPPER_OVERRIDE"] = str(override_path)

--- a/core/cli/quota_banner.py
+++ b/core/cli/quota_banner.py
@@ -43,12 +43,30 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "AbortDialog",
+    "QuotaAbortError",
     "QuotaBannerRefresher",
     "QuotaState",
     "SubscriptionQuotaBanner",
     "current_banner",
     "render_abort_message",
 ]
+
+
+class QuotaAbortError(RuntimeError):
+    """Raised by :meth:`SubscriptionQuotaBanner.enforce_or_raise` when the
+    banner is in aborted state — either from a credential-resolver trip
+    or from automatic threshold breach (OL-P2).
+
+    Callers that opt into the gate (`enforce_or_raise()` before the LLM
+    call) get this exception; the existing call sites that do NOT call
+    it stay backwards-compat. Keeps OL-P2 surface tight — operators flip
+    enforcement on per-caller rather than getting a system-wide hard gate.
+    """
+
+    def __init__(self, *, provider: str, reason: str) -> None:
+        super().__init__(f"quota aborted ({provider}): {reason}")
+        self.provider = provider
+        self.reason = reason
 
 
 Tier = Literal["green", "yellow", "red"]
@@ -121,15 +139,36 @@ class SubscriptionQuotaBanner:
         used_tokens: int,
         total_tokens: int,
     ) -> None:
-        """Replace the quota counters. Does not touch the ``aborted`` flag."""
+        """Replace the quota counters. Auto-trips ``trip_abort`` when the
+        new ratio crosses ``abort_threshold`` (OL-P2 — enforcement
+        wiring). Otherwise preserves the existing ``aborted`` flag.
+        """
         with self._lock:
-            self._state = QuotaState(
+            new_state = QuotaState(
                 provider=provider,
                 used_tokens=used_tokens,
                 total_tokens=total_tokens,
                 aborted=self._state.aborted,
                 abort_reason=self._state.abort_reason,
             )
+            # OL-P2 (2026-05-22) — actual enforcement on threshold
+            # breach. Pre-OL-P2 the banner only DISPLAYED red when usage
+            # crossed abort_threshold; the abort flag itself was only
+            # set by credential-resolver. Now an actual usage breach
+            # auto-trips so downstream call gates (and the bottom_toolbar
+            # render) reflect the policy without operator intervention.
+            ratio = new_state.usage_ratio
+            if not new_state.aborted and ratio >= self._abort:
+                new_state = QuotaState(
+                    provider=provider,
+                    used_tokens=used_tokens,
+                    total_tokens=total_tokens,
+                    aborted=True,
+                    abort_reason=(
+                        f"quota usage {ratio:.1%} >= abort_threshold {self._abort:.1%} ({provider})"
+                    ),
+                )
+            self._state = new_state
 
     def trip_abort(self, *, reason: str) -> None:
         """Lock the banner to red until :meth:`clear_abort` is called.
@@ -158,6 +197,31 @@ class SubscriptionQuotaBanner:
                 total_tokens=self._state.total_tokens,
                 aborted=False,
                 abort_reason="",
+            )
+
+    def enforce_or_raise(self) -> None:
+        """OL-P2 opt-in call gate — raise :class:`QuotaAbortError` when
+        the banner is in aborted state.
+
+        Callers wrap the LLM call entry-point::
+
+            try:
+                current_banner() and current_banner().enforce_or_raise()
+            except QuotaAbortError as exc:
+                # surface the abort to the operator + skip the call
+                ...
+
+        Backwards-compat: existing call sites that do NOT call this gate
+        continue working unchanged. The banner state stays purely
+        visual for them. OL-P2 ships the gate as opt-in so per-channel
+        rollout is possible (e.g., Petri auditor first, daemon REPL
+        last, OAuth flow exempt).
+        """
+        state = self.state
+        if state.aborted:
+            raise QuotaAbortError(
+                provider=state.provider or "unknown",
+                reason=state.abort_reason or "no reason given",
             )
 
     def tier(self) -> Tier:

--- a/tests/core/cli/test_quota_banner.py
+++ b/tests/core/cli/test_quota_banner.py
@@ -114,11 +114,18 @@ def test_render_yellow_format() -> None:
 
 
 def test_render_red_when_at_abort_threshold() -> None:
+    """OL-P2 (2026-05-22) — crossing abort_threshold now auto-trips the
+    ``aborted`` flag (set_state has actual enforcement, not just display).
+    The render path therefore takes the aborted branch, not the raw-
+    percentage branch. Pre-OL-P2 this test asserted "95%" in the output;
+    now it asserts the abort message.
+    """
     banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
     banner.set_state(provider="openai", used_tokens=95, total_tokens=100)
+    assert banner.state.aborted is True  # OL-P2 auto-trip
     out = banner.render()
     assert "red" in out
-    assert "95%" in out
+    assert "aborted" in out
 
 
 def test_render_red_when_aborted_carries_resolution_hint() -> None:

--- a/tests/test_ol_p2_quota_enforcement.py
+++ b/tests/test_ol_p2_quota_enforcement.py
@@ -1,0 +1,212 @@
+"""OL-P2 — Petri quota actual enforcement invariants.
+
+Pre-OL-P2 the `SubscriptionQuotaBanner.abort_threshold` was display-only
+— ratio >= abort_threshold turned the banner red, but `aborted=True`
+was only set by the credential resolver's strict-mode trip. Crossing
+the threshold via natural usage did NOT abort anything.
+
+OL-P2 adds two pieces:
+
+1. **Auto-trip on threshold breach** — `set_state` now checks the new
+   ratio against `abort_threshold` and auto-calls `trip_abort` when
+   it breaches.
+2. **Opt-in call gate** — `enforce_or_raise()` raises
+   `QuotaAbortError` when the banner is aborted. Callers wire this
+   before LLM call to fail-fast instead of consuming more quota.
+3. **autoresearch audit wired** — `autoresearch/train.py::main`'s
+   audit subprocess invocation calls `enforce_or_raise` before
+   `subprocess.run` so an aborted quota stops the audit at the gate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Auto-trip on threshold breach
+# ---------------------------------------------------------------------------
+
+
+def test_set_state_below_warn_does_not_trip() -> None:
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.set_state(provider="anthropic", used_tokens=10, total_tokens=100)
+    assert banner.state.aborted is False
+    assert banner.tier() == "green"
+
+
+def test_set_state_between_warn_and_abort_does_not_trip() -> None:
+    """Yellow tier should NOT auto-trip — only red (>= abort_threshold) does."""
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.set_state(provider="anthropic", used_tokens=60, total_tokens=100)
+    assert banner.tier() == "yellow"
+    assert banner.state.aborted is False
+
+
+def test_set_state_above_abort_threshold_auto_trips() -> None:
+    """Crossing abort_threshold → banner.state.aborted=True automatically."""
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.set_state(provider="anthropic", used_tokens=95, total_tokens=100)
+    assert banner.tier() == "red"
+    assert banner.state.aborted is True
+    assert "abort_threshold" in banner.state.abort_reason
+    assert "anthropic" in banner.state.abort_reason
+
+
+def test_auto_trip_does_not_overwrite_existing_abort_reason() -> None:
+    """If banner is already aborted (e.g., by credential resolver),
+    `set_state` keeps the original abort_reason — credential issues
+    are higher priority signal than usage breach."""
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.trip_abort(reason="credential-resolver: subscription denied")
+    # Now natural usage update also breaches threshold
+    banner.set_state(provider="anthropic", used_tokens=95, total_tokens=100)
+    # Original reason preserved (set_state preserves aborted=True path)
+    assert banner.state.aborted is True
+    assert "credential-resolver" in banner.state.abort_reason
+
+
+def test_clear_abort_re_enables_auto_trip() -> None:
+    """After clear_abort, a subsequent threshold breach should re-trip."""
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.set_state(provider="anthropic", used_tokens=95, total_tokens=100)
+    assert banner.state.aborted is True
+    banner.clear_abort()
+    assert banner.state.aborted is False
+    # Push another threshold-breaching update — should auto-trip again
+    banner.set_state(provider="anthropic", used_tokens=96, total_tokens=100)
+    assert banner.state.aborted is True
+
+
+def test_auto_trip_uses_configured_abort_threshold() -> None:
+    """Threshold parameter is respected — 0.7 vs 0.9 produces different
+    auto-trip points."""
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    tight = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.7)
+    tight.set_state(provider="openai", used_tokens=75, total_tokens=100)
+    assert tight.state.aborted is True  # 0.75 >= 0.70
+
+    loose = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.95)
+    loose.set_state(provider="openai", used_tokens=75, total_tokens=100)
+    assert loose.state.aborted is False  # 0.75 < 0.95
+
+
+# ---------------------------------------------------------------------------
+# enforce_or_raise call gate
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_or_raise_passes_when_not_aborted() -> None:
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.set_state(provider="anthropic", used_tokens=10, total_tokens=100)
+    banner.enforce_or_raise()  # no exception
+
+
+def test_enforce_or_raise_raises_when_aborted() -> None:
+    from core.cli.quota_banner import QuotaAbortError, SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.trip_abort(reason="quota exhausted")
+    with pytest.raises(QuotaAbortError) as exc_info:
+        banner.enforce_or_raise()
+    # Exception carries provider + reason for downstream rendering
+    assert exc_info.value.reason == "quota exhausted"
+
+
+def test_enforce_or_raise_carries_provider() -> None:
+    from core.cli.quota_banner import QuotaAbortError, SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.set_state(provider="anthropic", used_tokens=95, total_tokens=100)
+    # Auto-tripped
+    with pytest.raises(QuotaAbortError) as exc_info:
+        banner.enforce_or_raise()
+    assert exc_info.value.provider == "anthropic"
+
+
+def test_quota_abort_error_is_runtime_error_subclass() -> None:
+    """`QuotaAbortError` extends RuntimeError so generic except-blocks
+    catch it (callers without specific quota handling still see the
+    exception in their fallback path)."""
+    from core.cli.quota_banner import QuotaAbortError
+
+    assert issubclass(QuotaAbortError, RuntimeError)
+    exc = QuotaAbortError(provider="x", reason="y")
+    assert "quota aborted" in str(exc)
+    assert "x" in str(exc)
+    assert "y" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# autoresearch wiring
+# ---------------------------------------------------------------------------
+
+
+def test_autoresearch_train_calls_enforce_or_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The audit subprocess invocation site must call `enforce_or_raise`
+    before `subprocess.run`. We grep the source rather than execute the
+    full audit (which would need real config + LLM credentials).
+    """
+    from pathlib import Path
+
+    from autoresearch import train
+
+    source = Path(train.__file__).read_text(encoding="utf-8")
+    # The gate call must be in the file
+    assert "enforce_or_raise" in source, (
+        "OL-P2 regressed: autoresearch/train.py does not call enforce_or_raise"
+    )
+    # And QuotaAbortError must be imported / caught
+    assert "QuotaAbortError" in source, (
+        "OL-P2 regressed: autoresearch/train.py does not handle QuotaAbortError"
+    )
+
+
+def test_autoresearch_run_audit_aborts_on_tripped_banner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When `current_banner()` returns a tripped banner, `run_audit`
+    should RuntimeError BEFORE `subprocess.run` is reached.
+
+    We patch both ``current_banner`` and ``subprocess.run`` to verify the
+    gate fires first.
+    """
+    from core.cli.quota_banner import SubscriptionQuotaBanner
+
+    banner = SubscriptionQuotaBanner(warn_threshold=0.5, abort_threshold=0.9)
+    banner.trip_abort(reason="test-tripped")
+
+    from autoresearch import train
+
+    monkeypatch.setattr("core.cli.quota_banner.current_banner", lambda: banner)
+    subprocess_calls: list[Any] = []
+
+    def _fake_run(*args: Any, **kwargs: Any) -> Any:
+        subprocess_calls.append((args, kwargs))
+        raise AssertionError("subprocess.run must not be reached when banner is tripped")
+
+    monkeypatch.setattr(train.subprocess, "run", _fake_run)
+    # `run_audit(dry_run=False)` is the audit entry point. The gate
+    # lives inside the `if not dry_run:` branch just before
+    # `_build_audit_command()`.
+    with pytest.raises(RuntimeError, match="quota gate tripped"):
+        train.run_audit(dry_run=False)
+    assert subprocess_calls == [], (
+        "OL-P2 regressed: subprocess.run was called despite tripped banner"
+    )


### PR DESCRIPTION
## Summary

- `SubscriptionQuotaBanner.set_state` now auto-trips `aborted=True` when usage crosses `abort_threshold` (was display-only pre-OL-P2).
- New `enforce_or_raise()` method + `QuotaAbortError` exception — opt-in call gate that fails-fast when banner is aborted.
- First wired caller: `autoresearch/train.py::run_audit(dry_run=False)` — checks gate before spawning audit subprocess (most expensive caller, biggest quota impact).
- 12 new invariants + 1 existing test updated for new auto-trip semantics.

## Why

Pre-OL-P2 the `[self_improving_loop] warn_threshold / abort_threshold` config existed but had no enforcement — `tier() == "red"` only tinted the banner; the `aborted` flag was only set by credential-resolver strict-mode trips. Natural usage crossing the threshold did NOT abort anything.

Operator pain: subscription quota could run out silently during an unattended autoresearch audit. The roadmap calls this out as Tier 1 OL-P2 — actual `core/llm/quota.py` gate (we landed it in `core/cli/quota_banner.py` since the banner already owns the threshold state).

Why opt-in call gate (not global)? Adding `enforce_or_raise()` at every LLM call site would be invasive and might block OAuth refresh / login flows that legitimately need to call with low quota. OL-P2 keeps the gate as a per-caller knob — the audit subprocess wires it first (highest cost), other callers can opt in incrementally.

## Changes

| File | Change |
|------|--------|
| `core/cli/quota_banner.py` | Add `QuotaAbortError` + `enforce_or_raise()` method; `set_state` auto-trips on `abort_threshold` breach; update `__all__` |
| `autoresearch/train.py` | Call `current_banner().enforce_or_raise()` before `_build_audit_command()` in `run_audit(dry_run=False)`; raise RuntimeError on QuotaAbortError |
| `tests/test_ol_p2_quota_enforcement.py` (new) | 12 invariants — auto-trip x6 + enforce_or_raise x4 + autoresearch wiring x2 |
| `tests/core/cli/test_quota_banner.py` | Update `test_render_red_when_at_abort_threshold` for new auto-trip semantics |
| `CHANGELOG.md` | `[Unreleased]` Added entry under PR-OL-P2 |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| auto-trip on threshold breach | Implemented | `set_state` checks ratio vs `abort_threshold` |
| preserves credential-resolver reason | Implemented | Already-aborted state not overwritten by usage breach |
| `clear_abort` + re-breach re-trips | Implemented | Verified by test |
| `enforce_or_raise` opt-in gate | Implemented | `QuotaAbortError` exception |
| First caller wired (audit subprocess) | Implemented | `autoresearch/train.py::run_audit` |
| Other callers (REPL / Slack gateway / scheduler) | Deferred | Opt-in per channel — separate small PRs |
| Existing test compat | Updated | `test_render_red_when_at_abort_threshold` reflects new auto-trip path |

## Verification

- [x] ruff check + ruff format --check clean
- [x] mypy clean
- [x] pytest 12/12 OL-P2 + 69 adjacent quota tests pass
- [ ] CI green (5/5 — pending push)
- [ ] Codex MCP LLM-as-Judge (pending)

## Reference

- Config schema: `core/config/self_improving_loop.py::SelfImprovingLoopConfig.warn_threshold / abort_threshold`
- Banner module: `core/cli/quota_banner.py`
- Audit invocation: `autoresearch/train.py::run_audit`
- Roadmap: `docs/plans/2026-05-22-self-improving-roadmap.md` Tier 1 OL-P2

🤖 Generated with [Claude Code](https://claude.com/claude-code)