### PR TITLE
PR-OL-OAUTH-COUNT-TOKENS — Claude OAuth count_tokens 401 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-OL-OAUTH-COUNT-TOKENS — Claude OAuth count_tokens 401 fallback.**
+  Pattern-B subscription-routed Petri audit (Claude Max OAuth, OL-A2-data
+  + OL-P1 unblock path) was aborting before any sample ran with
+  `AuthenticationError 401 invalid x-api-key` on
+  `/v1/messages/count_tokens`. Root cause: Claude OAuth tokens carry
+  scope `user:inference` — Anthropic gateway accepts for `/v1/messages`
+  but rejects for `/v1/messages/count_tokens`. inspect_ai's class-method
+  `count_tokens` (`AnthropicAPI` line 532+) propagates the 401 with no
+  try/except → `Task interrupted (no samples completed)`. **Fix**:
+  override `count_tokens` in `plugins/petri_audit/claude_code_provider.py
+  ::ClaudeOAuthAPI` to skip the API call and return inspect_ai's own
+  documented fallback heuristic (`max(1, len(text) // 4)`). Heuristic
+  extracted to module-level pure function `estimate_tokens_for_oauth(input)`
+  so it is testable without instantiating the inspect_ai-wrapped class.
+  Accuracy degrades from "exact" to "Anthropic-standard heuristic" —
+  operators needing exact pre-flight cost numbers should use PAYG path
+  (`api_key` source). **9 invariant test** (`tests/test_ol_oauth_count_tokens_fallback.py`)
+  — string/empty/None input + list-of-msg with str-content + list-of-msg
+  with block-content (tool_use shape) + mixed shapes + skip-non-text-blocks
+  + source-level pin on override+delegation + inspect_ai-gated class
+  presence check. Quality gates clean (ruff + ruff format --check + mypy
+  + 9/9 pytest).
+
 ## [0.99.28] - 2026-05-22
 
 > Tier 1 (Outer Loop) closure stamp. 2 PRs:

--- a/plugins/petri_audit/claude_code_provider.py
+++ b/plugins/petri_audit/claude_code_provider.py
@@ -422,6 +422,72 @@ def register() -> None:
             kwargs["api_key"] = token
             super().__init__(*args, **kwargs)
 
+        async def count_tokens(
+            self,
+            input: _Any,
+            config: _Any = None,
+        ) -> int:
+            """Override that skips the ``/v1/messages/count_tokens``
+            endpoint — see :func:`estimate_tokens_for_oauth` for the
+            full rationale. The override is a thin shim so the
+            heuristic logic is testable as a pure function without
+            instantiating the inspect_ai-wrapped class.
+            """
+            return estimate_tokens_for_oauth(input)
+
     # Expose the class at module level for callers that need an
     # ``isinstance`` check or want to introspect the subclass.
     globals()["ClaudeOAuthAPI"] = ClaudeOAuthAPI
+
+
+def estimate_tokens_for_oauth(input: Any) -> int:
+    """Heuristic char-based token estimate for OAuth-routed callers.
+
+    OL-OAUTH-COUNT-TOKENS (2026-05-22) — Claude OAuth tokens carry
+    scope ``user:inference`` which Anthropic's gateway accepts for
+    ``/v1/messages`` but rejects with ``401 invalid x-api-key`` on
+    ``/v1/messages/count_tokens``.
+
+    inspect_ai's class-method ``count_tokens`` (in its stock
+    ``AnthropicAPI`` at lines 532+) propagates the 401 with no
+    try/except — a single pre-audit token-counting call kills the
+    entire audit task with ``Task interrupted (no samples completed)``.
+    Subscription-routed Petri audits (OL-A2-data / OL-P1 unblock path)
+    never reach any real sample.
+
+    Fix: ``ClaudeOAuthAPI.count_tokens`` delegates here, skipping the
+    API call entirely. Returns ``max(1, len(text) // 4)`` — the same
+    heuristic inspect_ai's module-level fallback uses on exception.
+    We just take the fallback up-front.
+
+    Accepted input shapes
+    ---------------------
+    * ``str`` — counted as-is.
+    * Iterable of message-like objects with ``content`` attribute,
+      where ``content`` is either a string or a list of block-like
+      objects with ``.text`` attribute (tool_use / thinking shapes).
+    * ``None`` — treated as empty (returns 1).
+
+    Risk surface
+    ------------
+    The heuristic is less accurate for tool_use / thinking-heavy
+    messages (where the real endpoint would account for the structured
+    block overhead). Operators who need exact pre-flight cost numbers
+    should use the PAYG path (``api_key`` source) where the stock
+    client + real API key handle ``count_tokens`` correctly.
+    """
+    text_parts: list[str] = []
+    if isinstance(input, str):
+        text_parts.append(input)
+    elif input is not None:
+        for msg in input:
+            content = getattr(msg, "content", "")
+            if isinstance(content, str):
+                text_parts.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    block_text = getattr(block, "text", "")
+                    if isinstance(block_text, str):
+                        text_parts.append(block_text)
+    text = " ".join(text_parts)
+    return max(1, len(text) // 4)

--- a/tests/test_ol_oauth_count_tokens_fallback.py
+++ b/tests/test_ol_oauth_count_tokens_fallback.py
@@ -1,0 +1,175 @@
+"""OL-OAUTH-COUNT-TOKENS — Claude OAuth count_tokens fallback invariants.
+
+Background
+==========
+
+Claude OAuth tokens carry scope ``user:inference`` which Anthropic's
+gateway accepts for ``/v1/messages`` but rejects with ``401 invalid
+x-api-key`` on ``/v1/messages/count_tokens``. inspect_ai's class-method
+``count_tokens`` (in its stock ``AnthropicAPI`` at lines 532+)
+propagates the 401 with no try/except — a single pre-audit token-
+counting call kills the entire audit task with ``Task interrupted (no
+samples completed)``.
+
+Pre-fix the run.log of a Pattern-B subscription audit (Claude Max OAuth)
+showed::
+
+    AuthenticationError: Error code: 401 - 'invalid x-api-key'
+    Task interrupted (no samples completed before interruption)
+
+The fix exposes a pure function :func:`estimate_tokens_for_oauth` that
+returns the same ``chars / 4`` Anthropic-documented heuristic
+inspect_ai's module-level helper uses on exception (lines 2944-2954).
+``ClaudeOAuthAPI.count_tokens`` is a 1-line shim delegating here, so
+the heuristic is testable without instantiating inspect_ai's wrapped
+class.
+
+Pins
+====
+
+1. ``estimate_tokens_for_oauth`` is callable on str / list / None input.
+2. ``str`` input → ``max(1, len(s) // 4)``.
+3. List of msg-like objects with ``content: str`` → concatenated estimate.
+4. List of msg-like objects with ``content: list[block]`` → blocks'
+   ``.text`` concatenated.
+5. None input → 1 (minimum token count contract).
+6. Source file declares ``count_tokens`` override on ``ClaudeOAuthAPI``
+   AND delegates to ``estimate_tokens_for_oauth`` (prevents future
+   refactor from dropping the delegation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# Provider module imports `inspect_ai` lazily inside ``register()``,
+# so the module-level import of ``estimate_tokens_for_oauth`` is safe
+# even without the audit extra. Heuristic tests run in any env.
+
+
+def test_estimate_string_input() -> None:
+    """``len(s) // 4`` for a plain string."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    assert estimate_tokens_for_oauth("a" * 400) == 100  # 400 // 4
+    assert estimate_tokens_for_oauth("hello world") == 11 // 4  # 11 chars / 4 = 2
+
+
+def test_estimate_empty_string_returns_one() -> None:
+    """Token counter min contract: never returns 0."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    assert estimate_tokens_for_oauth("") == 1
+
+
+def test_estimate_none_input_returns_one() -> None:
+    """None gracefully handled — same as empty."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    assert estimate_tokens_for_oauth(None) == 1
+
+
+def test_estimate_list_of_messages_with_str_content() -> None:
+    """Message-like objects with ``content: str`` — texts joined by space."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    messages = [
+        SimpleNamespace(content="x" * 100),
+        SimpleNamespace(content="y" * 100),
+    ]
+    # "x"*100 + " " + "y"*100 = 201 chars, // 4 = 50
+    assert estimate_tokens_for_oauth(messages) == 50
+
+
+def test_estimate_list_of_messages_with_block_content() -> None:
+    """Block-list content (tool_use / thinking shape) — extract ``.text``."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    block1 = SimpleNamespace(text="hello world", type="text")
+    block2 = SimpleNamespace(text="more text here", type="text")
+    msg = SimpleNamespace(content=[block1, block2])
+    # "hello world" + " " + "more text here" = 26 chars, // 4 = 6
+    assert estimate_tokens_for_oauth([msg]) == 6
+
+
+def test_estimate_mixed_message_shapes() -> None:
+    """A list containing both str-content and block-content messages
+    accumulates them all correctly."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    str_msg = SimpleNamespace(content="aaaa")  # 4 chars
+    block_msg = SimpleNamespace(content=[SimpleNamespace(text="bbbb")])  # 4 chars
+    # "aaaa" + " " + "bbbb" = 9 chars, // 4 = 2
+    assert estimate_tokens_for_oauth([str_msg, block_msg]) == 2
+
+
+def test_estimate_skips_non_text_blocks() -> None:
+    """Blocks without ``.text`` attribute (or with non-string ``.text``)
+    are silently skipped — heuristic stays conservative."""
+    from plugins.petri_audit.claude_code_provider import estimate_tokens_for_oauth
+
+    block_with_text = SimpleNamespace(text="abc")
+    block_without = SimpleNamespace(no_text="present")
+    block_non_string_text = SimpleNamespace(text=42)
+    msg = SimpleNamespace(content=[block_with_text, block_without, block_non_string_text])
+    # Only "abc" (3 chars) → 1 (min)
+    assert estimate_tokens_for_oauth([msg]) == 1
+
+
+def test_source_has_oauth_count_tokens_override() -> None:
+    """Source-level pin: ``ClaudeOAuthAPI`` declares ``count_tokens``
+    override AND delegates to ``estimate_tokens_for_oauth``. A future
+    refactor that drops the override (reverting to inherited stock
+    behaviour) re-introduces the 401 bug and breaks subscription-
+    routed audits.
+    """
+    from plugins.petri_audit import claude_code_provider
+
+    source = Path(claude_code_provider.__file__).read_text(encoding="utf-8")
+    assert "async def count_tokens" in source, (
+        "OL-OAUTH-COUNT-TOKENS regressed: ClaudeOAuthAPI no longer "
+        "overrides count_tokens — subscription-routed audits will hit "
+        "401 on /v1/messages/count_tokens and abort the task."
+    )
+    assert "estimate_tokens_for_oauth" in source, (
+        "OL-OAUTH-COUNT-TOKENS regressed: count_tokens override no "
+        "longer delegates to estimate_tokens_for_oauth — heuristic "
+        "drift between caller + helper risks."
+    )
+
+
+def _has_inspect_ai() -> bool:
+    """Return True when inspect_ai is importable — gates the live
+    class-instance test below."""
+    try:
+        import inspect_ai  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def test_class_override_delegates_when_inspect_ai_available() -> None:
+    """When inspect_ai is installed, ``ClaudeOAuthAPI.count_tokens`` must
+    be the override (not the inherited stock implementation). Skip in
+    minimal envs without the audit extra.
+    """
+    if not _has_inspect_ai():
+        pytest.skip("inspect_ai extra not installed")
+
+    from plugins.petri_audit import claude_code_provider as p
+
+    if not hasattr(p, "ClaudeOAuthAPI"):
+        p.register()
+
+    # The modelapi decorator wraps the class in a factory function, so
+    # we can't access the class directly. Verify via attribute on the
+    # registered object's __qualname__ (closure path includes class).
+    wrap: Any = p.ClaudeOAuthAPI
+    # Heuristic: if the wrapper exists, register() ran without error,
+    # meaning the class body (including count_tokens) compiled OK.
+    # The source-level pin above is the durable contract.
+    assert callable(wrap)


### PR DESCRIPTION
## Summary

- Override `count_tokens` in `plugins/petri_audit/claude_code_provider.py::ClaudeOAuthAPI` to skip the `/v1/messages/count_tokens` endpoint and use the `chars / 4` heuristic.
- Extract heuristic to free function `estimate_tokens_for_oauth(input)` for testability.
- 9 invariants pinning the heuristic + source-level override presence.

## Why

While unblocking OL-A2-data / OL-P1 via Pattern B subscription routing (Claude Max OAuth), the first real audit failed with:

```
AuthenticationError: Error code: 401 - 'invalid x-api-key'
Task interrupted (no samples completed before interruption)
```

**Root cause**: Claude OAuth tokens carry scope `user:inference` which Anthropic gateway accepts for `/v1/messages` (inference) but rejects for `/v1/messages/count_tokens` (pre-flight token counting). inspect_ai's class-method `count_tokens` (in stock `AnthropicAPI` at line 532+) propagates the 401 with no try/except — a single pre-audit token count call kills the entire audit task. Subscription-routed Petri audits never reach any real sample.

**Fix scope**: minimal — 1 method override + 1 free function (heuristic extraction). inspect_ai's own module-level helper at lines 2944-2954 already uses `chars / 4` as fallback on exception; we just take it up-front.

**Risk**: heuristic less accurate for tool_use / thinking-heavy messages. Operators needing exact pre-flight cost should use PAYG (`api_key` source).

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/claude_code_provider.py` | Add `count_tokens` override on `ClaudeOAuthAPI` + free function `estimate_tokens_for_oauth(input)` |
| `tests/test_ol_oauth_count_tokens_fallback.py` (new) | 9 invariants — string/empty/None/list-of-msg-str/list-of-msg-blocks/mixed/non-text-block-skip/source-level pin/inspect_ai-gated class presence |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry under PR-OL-OAUTH-COUNT-TOKENS |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| 401 root cause identified | Done | OAuth scope `user:inference` does not include count_tokens |
| Class-level override | Implemented | 1-line shim delegating to heuristic helper |
| Heuristic testable in isolation | Implemented | `estimate_tokens_for_oauth` free function |
| Source-level regression pin | Implemented | `test_source_has_oauth_count_tokens_override` greps file |
| inspect_ai-gated tests | Implemented | `_has_inspect_ai()` skip; heuristic tests run any env |
| Operator surface for accuracy | Documented | Docstring + risk surface mentions PAYG path for exact numbers |

## Verification

- [x] ruff check + ruff format --check clean
- [x] mypy clean
- [x] pytest 9/9 OL-OAUTH-COUNT-TOKENS
- [x] Pre-fix evidence: `autoresearch/state/run.log` shows 401 + task interrupt
- [ ] CI green (5/5 — pending push)
- [ ] Post-merge: re-run autoresearch audit via Pattern B subscription → expect samples completed > 0
- [ ] Codex MCP LLM-as-Judge (pending)

## Reference

- inspect_ai class-method failure path: `.venv/lib/python3.12/site-packages/inspect_ai/model/_providers/anthropic.py:532`
- inspect_ai's own fallback: same file line 2944-2954
- ClaudeOAuthAPI source: `plugins/petri_audit/claude_code_provider.py:371`
- Pattern B config: `~/.geode/config.toml` `[self_improving_loop.petri.*]`
- Blocked items: OL-A2-data + OL-P1 in `docs/plans/2026-05-22-self-improving-roadmap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)