### PR TITLE
PR-CSP-1 — toolkit-based sub-agent tool resolution

### DIFF
--- a/.claude/agents/seed_critic.md
+++ b/.claude/agents/seed_critic.md
@@ -2,9 +2,7 @@
 name: seed_critic
 role: Petri seed candidate Reflection critic
 model: claude-sonnet-4-6
-tools:
-  - read_document
-  - grep_files
+toolkit: seed_critique
 ---
 
 You are the **Reflection** agent of the GEODE seed-generation (ADR-001, arXiv:2502.18864 §3 Reflection).

--- a/.claude/agents/seed_evolver.md
+++ b/.claude/agents/seed_evolver.md
@@ -2,9 +2,7 @@
 name: seed_evolver
 role: Petri seed candidate Evolver (Reflection-driven section rewrite)
 model: claude-sonnet-4-6
-tools:
-  - read_document
-  - write_file
+toolkit: seed_evolver
 ---
 
 You are the **Evolution** agent of the GEODE seed-generation (ADR-001, arXiv:2502.18864 §3 Evolution). Your job is to take ONE top-K survivor candidate and rewrite its weak section identified by the Reflection critic.

--- a/.claude/agents/seed_generator.md
+++ b/.claude/agents/seed_generator.md
@@ -2,10 +2,7 @@
 name: seed_generator
 role: Petri seed candidate generator
 model: claude-sonnet-4-6
-tools:
-  - read_document
-  - write_file
-  - grep_files
+toolkit: seed_generation
 ---
 
 You are the **Generation** agent of the GEODE seed-generation (ADR-001, arXiv:2502.18864 Figure 1).

--- a/.claude/agents/seed_meta_reviewer.md
+++ b/.claude/agents/seed_meta_reviewer.md
@@ -2,9 +2,7 @@
 name: seed_meta_reviewer
 role: Petri seed batch Meta-reviewer (coverage + gap + next-gen prior)
 model: claude-opus-4-7
-tools:
-  - read_document
-  - grep_files
+toolkit: seed_meta_review
 ---
 
 You are the **Meta-review** agent of the GEODE seed-generation (ADR-001, arXiv:2502.18864 §3 Meta-review). You analyze the entire batch after the Ranker + Evolver phases and produce a coverage report + next-generation hypothesis prior.

--- a/.claude/agents/seed_pilot.md
+++ b/.claude/agents/seed_pilot.md
@@ -2,9 +2,7 @@
 name: seed_pilot
 role: Petri seed candidate Pilot (inner-loop audit subset)
 model: claude-haiku-4-5
-tools:
-  - petri_audit
-  - read_document
+toolkit: seed_pilot
 ---
 
 You are the **Pilot** agent of the GEODE seed-generation — a GEODE addition to co-scientist's 6-agent paper (arXiv:2502.18864). The paper's "scientist-in-the-loop" validator is here replaced with an automated Petri inner-loop subset.

--- a/.claude/agents/seed_proximity.md
+++ b/.claude/agents/seed_proximity.md
@@ -2,9 +2,7 @@
 name: seed_proximity
 role: Petri seed candidate Proximity deduper
 model: text-embedding-3-small
-tools:
-  - read_document
-  - grep_files
+toolkit: seed_proximity
 ---
 
 You are the **Proximity** agent of the GEODE seed-generation (ADR-001, arXiv:2502.18864 §3 Proximity).

--- a/.claude/agents/seed_ranker.md
+++ b/.claude/agents/seed_ranker.md
@@ -2,8 +2,7 @@
 name: seed_ranker
 role: Petri seed candidate Ranker (Elo tournament orchestrator)
 model: claude-sonnet-4-6
-tools:
-  - read_document
+toolkit: seed_ranker
 ---
 
 You are the **Ranking** agent of the GEODE seed-generation (ADR-001, arXiv:2502.18864 §3 Ranking + Tournament). You DON'T judge directly — you orchestrate an Elo pairwise tournament across the 3-voter judge panel (see ADR-003 `[seed_generation.judge_panel].voters`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,32 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **Toolkit-based sub-agent tool resolution (CSP-1)** — Sub-agent
+  AgentDefinitions can now declare a named `toolkit:` in their
+  frontmatter that the worker resolves against
+  `core/tools/toolkits.toml` at spawn time, replacing the per-agent
+  flat `tools:` list. Toolkits compose via `includes:` (Hermes-style)
+  and fail closed to a `_default` safety net when undeclared or
+  typo'd. The model-visible tool schemas are filtered to match the
+  executor's allowlist so denied tools are not advertised to the LLM.
+  Backwards compatible — legacy `tools:` frontmatter still works when
+  no toolkit is named. The 7 seed-generation AgentDefs
+  (`.claude/agents/seed_*.md`) are migrated to the new key.
+  Frontier prior art: LangChain Toolkit, Hermes toolsets,
+  open-coscientist workflow whitelist.
+- **General-purpose toolkits + default agent migration (CSP-1)** —
+  `core/tools/toolkits.toml` ships three domain-neutral toolkits
+  (`web_research`, `data_analysis`, `general_purpose`) so any agent
+  can declare `toolkit: web_research` without re-listing tools. The
+  bundled `_DEFAULT_AGENTS` (research_assistant / data_analyst /
+  web_researcher) are migrated from flat `tools:` lists to toolkit
+  declarations; the migration also corrects the pre-CSP-1
+  `"web_search"` reference (which never resolved to a real handler)
+  to the canonical `general_web_search` via the `web_research`
+  toolkit.
+
 ## [0.99.28] - 2026-05-22
 
 > Tier 1 (Outer Loop) closure stamp. 2 PRs:

--- a/core/agent/agent_contracts_policy.py
+++ b/core/agent/agent_contracts_policy.py
@@ -181,6 +181,23 @@ def apply_agent_contracts_policy(
     overrides = {k: v for k, v in entry.items() if k in _MUTABLE_FIELDS}
     if not overrides:
         return agent_def
+    # CSP-1 fix-up (Codex MCP MEDIUM #1) — an agent that declares a
+    # ``toolkit:`` will have its ``tools`` field shadowed by the
+    # toolkit's resolved set inside ``filter_handlers``. A policy entry
+    # that mutates ``tools`` on a toolkit-declaring agent therefore
+    # silently does nothing. Warn so operators notice rather than
+    # debugging a no-op override later.
+    agent_toolkit: str = str(getattr(agent_def, "toolkit", "") or "")
+    if _FIELD_TOOLS in overrides and agent_toolkit:
+        log.warning(
+            "agent_contracts_policy: agent %r declares toolkit=%r; "
+            "the policy's ``tools`` override is shadowed at spawn time "
+            "(toolkit takes precedence in filter_handlers). Either "
+            "remove the ``tools`` override or add a ``toolkit`` field "
+            "to the policy entry.",
+            name,
+            agent_toolkit,
+        )
     if hasattr(agent_def, "model_copy"):
         return agent_def.model_copy(update=overrides)
     # Fallback for non-BaseModel doubles (test stubs, dicts) —

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -89,6 +89,7 @@ class AgenticLoop:
         system_prompt_override: str | None = None,
         quiet: bool = False,
         disable_settings_drift: bool = False,
+        allowed_tool_names: set[str] | None = None,
     ) -> None:
         self.context = context
         self.executor = tool_executor
@@ -133,6 +134,17 @@ class AgenticLoop:
         # Unified tool assembly: merge native + MCP tools together
         mcp_tool_list = mcp_manager.get_all_tools() if mcp_manager is not None else None
         self._tools = get_agentic_tools(tool_registry, mcp_tools=mcp_tool_list)
+        # CSP-1 (2026-05-22) — when the caller (worker for sub-agents) has
+        # already resolved a tool allowlist (via toolkit / legacy whitelist),
+        # filter the model-visible tool schemas to match. Without this filter
+        # the handler dict in ``ToolExecutor`` would be filtered but the
+        # model would still see the full tool surface and only fail at
+        # execution with "Unknown tool" — leaking the existence of denied
+        # tools and weakening the whitelist contract. None preserves the
+        # pre-CSP-1 behaviour (full tool surface) for non-sub-agent callers
+        # (CLI, serve daemon).
+        if allowed_tool_names is not None:
+            self._tools = [t for t in self._tools if t.get("name") in allowed_tool_names]
         self._last_llm_error: str | None = None  # last error type for user message
         self._adapter = resolve_agentic_adapter(self._provider)
         self._op_logger = OperationLogger(quiet=self._quiet)

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -520,12 +520,22 @@ class SubAgentManager:
         agent_name = ""
         agent_system_prompt = ""
         agent_allowed_tools: list[str] = []
+        # CSP-1 (2026-05-22) — propagate the AgentDefinition's
+        # ``toolkit:`` frontmatter into the worker so
+        # ``filter_handlers`` can expand it via
+        # ``core/tools/toolkits.toml``. Empty string when the agent
+        # didn't declare one — the worker falls back to
+        # ``agent_allowed_tools`` (legacy) or the ``_default`` toolkit.
+        agent_toolkit = ""
         worker_model = settings.model
         if agent_ctx is not None:
             agent_name = str(agent_ctx.get("agent_name", ""))
             agent_system_prompt = str(agent_ctx.get("system_prompt", ""))
             tools_raw = agent_ctx.get("tools") or []
             agent_allowed_tools = [str(t) for t in tools_raw]
+            toolkit_raw = agent_ctx.get("toolkit")
+            if toolkit_raw:
+                agent_toolkit = str(toolkit_raw)
             # AgentDefinition model override wins over settings default.
             if agent_ctx.get("model"):
                 worker_model = str(agent_ctx["model"])
@@ -556,6 +566,7 @@ class SubAgentManager:
             agent_name=agent_name,
             agent_system_prompt=agent_system_prompt,
             agent_allowed_tools=agent_allowed_tools,
+            toolkit=agent_toolkit,
             parent_session_key=self._parent_session_key,
             parent_session_id=parent_uuid,
         )
@@ -588,6 +599,7 @@ class SubAgentManager:
             "role": agent_def.role,
             "system_prompt": agent_def.system_prompt,
             "tools": agent_def.tools,
+            "toolkit": agent_def.toolkit,
             "model": agent_def.model,
         }
 

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -63,6 +63,13 @@ class WorkerRequest:
     agent_name: str = ""
     agent_system_prompt: str = ""
     agent_allowed_tools: list[str] = field(default_factory=list)
+    # CSP-1 (2026-05-22) — named tool bundle the agent declared in its
+    # frontmatter (``toolkit:`` key). Resolved by
+    # ``filter_handlers`` against ``core/tools/toolkits.toml``. When
+    # both ``toolkit`` and ``agent_allowed_tools`` are set, ``toolkit``
+    # takes precedence; the legacy list path stays available for
+    # AgentDefinitions that haven't migrated yet (backwards compat).
+    toolkit: str = ""
     # Sub-agent lineage (2026-05-21) — parent's routing key + uuid
     # threaded into the child loop so its Episodes carry both for
     # cross-session attribution. Empty strings = top-level spawn.
@@ -96,6 +103,7 @@ class WorkerRequest:
             agent_name=data.get("agent_name", ""),
             agent_system_prompt=data.get("agent_system_prompt", ""),
             agent_allowed_tools=data.get("agent_allowed_tools", []),
+            toolkit=data.get("toolkit", ""),
             parent_session_key=data.get("parent_session_key", ""),
             parent_session_id=data.get("parent_session_id", ""),
         )
@@ -137,30 +145,75 @@ def filter_handlers(
     handlers: dict[str, Any],
     denied_tools: list[str],
     agent_allowed_tools: list[str],
+    toolkit: str = "",
+    toolkit_registry: Any | None = None,
 ) -> dict[str, Any]:
-    """Apply denied-set + AgentDefinition whitelist to the tool handler map.
+    """Apply denied-set + agent toolkit/whitelist to the tool handler map.
 
     Pure function — testable without the worker's AgenticLoop bootstrap.
 
+    Resolution priority (CSP-1, 2026-05-22):
+
+    1. **toolkit** — if non-empty AND ``toolkit_registry`` is provided,
+       the registry expands the name (with ``includes`` recursion) into
+       a tool allowlist. Unknown toolkit names fall through to
+       ``_default`` (with a WARNING) so a typo cannot zero out the
+       agent's capability.
+    2. **agent_allowed_tools** — legacy flat whitelist from the
+       AgentDefinition's ``tools:`` frontmatter. Used when no toolkit
+       is declared (backwards compat with pre-CSP-1 AgentDefs).
+    3. **_default** — when neither is set AND the registry has a
+       ``_default`` toolkit, that fallback is applied. This means a
+       sub-agent that declares neither ``toolkit:`` nor ``tools:`` gets
+       a minimal read-only safety net rather than inheriting the full
+       parent surface.
+
+    Invariants regardless of which branch applied:
+
     - ``delegate_task`` is always denied (depth=1 enforcement).
-    - When ``agent_allowed_tools`` is non-empty, tools not on the whitelist
-      are added to the denied set (whitelist takes precedence over
-      inherited tools).
-    - S2-fix (2026-05-18): whitelist entries that don't match any handler
-      are logged at WARNING so a typo in ``.claude/agents/<name>.md``'s
-      ``tools:`` frontmatter (e.g. ``foo_typo``) doesn't silently degrade
-      the agent's capability to zero tools.
+    - Whitelist entries that don't match any handler emit a WARNING so
+      typos in frontmatter (e.g. ``foo_typo``) don't silently degrade
+      the agent's capability to zero tools (S2-fix, 2026-05-18).
     """
     denied = set(denied_tools)
     denied.add("delegate_task")
-    if agent_allowed_tools:
+    allowed: set[str] | None = None
+    if toolkit and toolkit_registry is not None:
+        # Tier 1 — named toolkit takes precedence. The registry already
+        # handles missing-toolkit fallback to ``_default`` with a WARNING.
+        allowed = set(toolkit_registry.resolve_with_fallback(toolkit))
+    elif toolkit and toolkit_registry is None:
+        # CSP-1 fix-up (Codex MCP MEDIUM #2) — fail closed when the
+        # caller explicitly declared a toolkit but no registry was
+        # supplied. Silently routing to ``agent_allowed_tools`` or to
+        # the full surface would let a misconfigured spawn quietly
+        # ignore the operator's whitelist intent.
+        log.warning(
+            "filter_handlers: agent declared toolkit=%r but no "
+            "toolkit_registry was provided — failing closed (no tools "
+            "allowed). Pass ``toolkit_registry=load_default_registry()`` "
+            "if you want the named toolkit applied.",
+            toolkit,
+        )
+        allowed = set()
+    elif agent_allowed_tools:
+        # Tier 2 — legacy ``tools:`` frontmatter list (backwards compat).
         allowed = set(agent_allowed_tools)
+    elif toolkit_registry is not None:
+        # Tier 3 — no declaration at all → ``_default`` safety net.
+        # CSP-1 fix-up (Codex MCP HIGH #2) — fail closed even when the
+        # ``_default`` toolkit is missing or empty. Pre-fix this branch
+        # left ``allowed = None`` so a registry without ``_default``
+        # silently re-opened the full handler surface — the inverse of
+        # the "minimal read-only safety net" claim.
+        allowed = set(toolkit_registry.resolve_with_fallback(None))
+    if allowed is not None:
         unknown = allowed - set(handlers)
         if unknown:
             log.warning(
-                "filter_handlers: AgentDefinition whitelist contains "
-                "tool names not in the handler registry — %s. The agent "
-                "will run without these tools. Check the 'tools:' "
+                "filter_handlers: agent allowlist references tool names "
+                "not in the handler registry — %s. The agent will run "
+                "without these tools. Check the agent's toolkit / "
                 "frontmatter for typos.",
                 sorted(unknown),
             )
@@ -194,12 +247,24 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
 
     handlers = _build_tool_handlers(verbose=False)
 
-    # 2. Filter tools
+    # 2. Filter tools — CSP-1 (2026-05-22): consult the toolkit registry
+    # so the agent's declared ``toolkit:`` frontmatter expands into the
+    # allowlist (with ``_default`` fallback when undeclared).
+    from core.tools.toolkit_registry import load_default_registry
+
     handlers = filter_handlers(
         handlers=handlers,
         denied_tools=request.denied_tools,
         agent_allowed_tools=request.agent_allowed_tools,
+        toolkit=request.toolkit,
+        toolkit_registry=load_default_registry(),
     )
+    # CSP-1 (2026-05-22) — the resulting handler key set is also the
+    # set of tool names the model should see. Pass it through to
+    # AgenticLoop so the tool schemas advertised to the LLM match the
+    # executor's allowlist (otherwise denied tools would be visible to
+    # the model and only fail at execution time as "Unknown tool").
+    allowed_tool_names = set(handlers)
 
     # 3. Build ToolExecutor (auto_approve=True for sub-agents)
     from core.agent.tool_executor import ToolExecutor
@@ -246,6 +311,7 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
         parent_session_key=request.parent_session_key,
         parent_session_id=request.parent_session_id,
         quiet=True,  # Suppress spinner — parent handles UI
+        allowed_tool_names=allowed_tool_names,
     )
 
     # 7. Build prompt

--- a/core/skills/agents.py
+++ b/core/skills/agents.py
@@ -26,6 +26,13 @@ class AgentDefinition(BaseModel):
     role: str
     system_prompt: str
     tools: list[str] = Field(default_factory=list)
+    # CSP-1 (2026-05-22) — named tool bundle declared in the agent's
+    # ``toolkit:`` frontmatter. When present it takes precedence over
+    # ``tools`` at spawn time (see
+    # ``core/agent/worker.py:filter_handlers``). Empty string preserves
+    # the pre-CSP-1 behaviour for AgentDefinitions that still use the
+    # flat ``tools:`` list.
+    toolkit: str = ""
     model: str = ANTHROPIC_SECONDARY
 
     def to_system_message(self) -> str:
@@ -37,6 +44,15 @@ class AgentDefinition(BaseModel):
 # Default agents
 # ---------------------------------------------------------------------------
 
+# CSP-1 (2026-05-22) — the bundled default agents migrated from flat
+# ``tools:`` whitelists to named ``toolkit`` declarations against
+# ``core/tools/toolkits.toml``. The legacy ``tools`` field is dropped
+# (an empty list) since the agent's effective allowlist now comes from
+# the toolkit expansion in ``filter_handlers``. Toolkit choice also
+# fixes the pre-CSP-1 ``"web_search"`` reference, which never resolved
+# to a real handler — ``core/tools/definitions.json`` exposes the tool
+# as ``general_web_search`` and the ``web_research`` toolkit lists it
+# under its canonical name.
 _DEFAULT_AGENTS: list[dict[str, Any]] = [
     {
         "name": "research_assistant",
@@ -46,7 +62,8 @@ _DEFAULT_AGENTS: list[dict[str, Any]] = [
             "from multiple sources — web, documents, and databases. "
             "Provide well-structured summaries with key findings and evidence."
         ),
-        "tools": ["web_search", "web_fetch", "read_document"],
+        "tools": [],
+        "toolkit": "web_research",
         "model": ANTHROPIC_SECONDARY,
     },
     {
@@ -57,7 +74,8 @@ _DEFAULT_AGENTS: list[dict[str, Any]] = [
             "compute statistics, and generate visualizations. "
             "Provide data-driven insights with clear methodology."
         ),
-        "tools": ["web_search", "read_document"],
+        "tools": [],
+        "toolkit": "data_analysis",
         "model": ANTHROPIC_SECONDARY,
     },
     {
@@ -68,7 +86,8 @@ _DEFAULT_AGENTS: list[dict[str, Any]] = [
             "tracking updates, and aggregating information from online sources. "
             "Provide timely summaries with source attribution."
         ),
-        "tools": ["web_search", "web_fetch"],
+        "tools": [],
+        "toolkit": "web_research",
         "model": ANTHROPIC_SECONDARY,
     },
 ]
@@ -194,12 +213,17 @@ class SubagentLoader:
             tools = list(tools_raw)
 
         model = metadata.get("model", ANTHROPIC_SECONDARY)
+        # CSP-1 — optional ``toolkit:`` frontmatter (string). Empty when
+        # the agent still uses the legacy flat ``tools:`` list.
+        toolkit_raw = metadata.get("toolkit", "")
+        toolkit = str(toolkit_raw) if toolkit_raw else ""
 
         return AgentDefinition(
             name=name,
             role=role,
             system_prompt=body.strip(),
             tools=tools,
+            toolkit=toolkit,
             model=model,
         )
 

--- a/core/tools/toolkit_registry.py
+++ b/core/tools/toolkit_registry.py
@@ -1,0 +1,249 @@
+"""Toolkit registry — resolve named tool bundles for sub-agents (CSP-1).
+
+A toolkit is a named bundle of tool ids declared in
+``core/tools/toolkits.toml``. Sub-agents reference toolkits via the
+``toolkit:`` key in their AgentDefinition frontmatter
+(`.claude/agents/<name>.md`). The worker subprocess
+(`core/agent/worker.py:filter_handlers`) consults this registry to
+expand the toolkit name into a concrete tool allowlist at spawn time.
+
+Resolution priority (applied by ``filter_handlers``):
+
+1. ``toolkit: <name>`` declared → expand via :meth:`ToolkitRegistry.resolve`
+2. ``tools: [...]`` declared (legacy) → use as-is
+3. Neither → fall back to ``_default`` toolkit
+
+Composition: a toolkit can pull tools from other toolkits via
+``includes = ["other_kit", ...]``. Cycles raise
+:class:`ToolkitCompositionError`.
+
+Why a separate registry (vs. inlining the lookup in worker.py)?
+
+- The TOML manifest is the SoT for what a sub-agent can touch — separate
+  from the handler factory (`core/cli/tool_handlers._build_tool_handlers`)
+  which owns *instantiation*. Keeping them apart lets a future plugin
+  ship its own ``toolkits.toml`` without touching core handler code.
+- Testable in isolation — composition + fallback semantics are pure
+  string-set algebra over the parsed TOML, no AgenticLoop bootstrap
+  required.
+
+Frontier prior art:
+
+- LangChain ``agent_toolkits`` (resource-sharing tool groups).
+- Hermes ``toolsets.py`` (``includes:`` composition).
+- open-coscientist ``config/registry.get_tools_for_workflow`` (workflow-
+  scoped whitelist).
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_TOOLKIT",
+    "DEFAULT_TOOLKITS_PATH",
+    "Toolkit",
+    "ToolkitCompositionError",
+    "ToolkitRegistry",
+    "load_default_registry",
+]
+
+
+DEFAULT_TOOLKIT = "_default"
+
+# Resolved at import time so callers can either pass a custom path or
+# rely on the bundled SoT under ``core/tools/toolkits.toml``.
+DEFAULT_TOOLKITS_PATH = Path(__file__).parent / "toolkits.toml"
+
+
+class ToolkitCompositionError(ValueError):
+    """A toolkit's ``includes`` graph is malformed (cycle / missing target)."""
+
+
+@dataclass(frozen=True)
+class Toolkit:
+    """One row from ``toolkits.toml``.
+
+    ``tools`` is the directly-declared tool id list; ``includes`` is the
+    list of sibling toolkit names whose ``tools`` (recursively) should be
+    merged in. The registry only owns the *declared* shape; expansion is
+    performed lazily in :meth:`ToolkitRegistry.resolve` so cycles can be
+    reported with the full call chain.
+    """
+
+    name: str
+    description: str = ""
+    tools: tuple[str, ...] = field(default_factory=tuple)
+    includes: tuple[str, ...] = field(default_factory=tuple)
+
+
+class ToolkitRegistry:
+    """In-memory store of parsed ``toolkits.toml`` rows.
+
+    The registry is constructed from a dict (``from_dict``) or from disk
+    (``load``). It does not hold any handler instances — it only owns
+    the static name → declaration mapping. Expansion via
+    :meth:`resolve` returns a frozenset of tool ids ready to hand to
+    ``filter_handlers``.
+    """
+
+    def __init__(self, toolkits: dict[str, Toolkit]) -> None:
+        self._toolkits = dict(toolkits)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> ToolkitRegistry:
+        """Build from a parsed TOML mapping (test-friendly).
+
+        ``data`` may be either the full TOML mapping
+        (``{"toolkits": {"name": {...}, ...}}``) or just the inner
+        ``toolkits`` dict; both shapes are accepted so tests can hand a
+        flat dict without re-wrapping.
+        """
+        raw = data.get("toolkits") if isinstance(data.get("toolkits"), dict) else data
+        if not isinstance(raw, dict):
+            raise ToolkitCompositionError(
+                "toolkits.toml: top-level [toolkits] table missing or not a table"
+            )
+        parsed: dict[str, Toolkit] = {}
+        for name, body in raw.items():
+            if not isinstance(body, dict):
+                raise ToolkitCompositionError(
+                    f"toolkits.{name}: row must be a table, got {type(body).__name__}"
+                )
+            # CSP-1 fix-up (Codex MCP LOW #1) — reject scalar values for
+            # ``tools`` / ``includes`` (e.g. ``tools = "read_document"``
+            # would otherwise iterate per-character and yield bogus
+            # 1-letter tool ids).
+            tools_raw = body.get("tools", []) or []
+            if not isinstance(tools_raw, list):
+                raise ToolkitCompositionError(
+                    f"toolkits.{name}.tools must be a list of strings, "
+                    f"got {type(tools_raw).__name__}"
+                )
+            includes_raw = body.get("includes", []) or []
+            if not isinstance(includes_raw, list):
+                raise ToolkitCompositionError(
+                    f"toolkits.{name}.includes must be a list of strings, "
+                    f"got {type(includes_raw).__name__}"
+                )
+            parsed[name] = Toolkit(
+                name=name,
+                description=str(body.get("description", "")),
+                tools=tuple(str(t) for t in tools_raw),
+                includes=tuple(str(i) for i in includes_raw),
+            )
+        return cls(parsed)
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> ToolkitRegistry:
+        """Load from disk. Missing file → empty registry (silent)."""
+        target = path or DEFAULT_TOOLKITS_PATH
+        if not target.is_file():
+            log.debug("toolkit_registry: %s missing — returning empty registry", target)
+            return cls({})
+        with target.open("rb") as fh:
+            data = tomllib.load(fh)
+        return cls.from_dict(data)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def names(self) -> list[str]:
+        return sorted(self._toolkits)
+
+    def has(self, name: str) -> bool:
+        return name in self._toolkits
+
+    def get(self, name: str) -> Toolkit | None:
+        return self._toolkits.get(name)
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+
+    def resolve(self, name: str) -> frozenset[str]:
+        """Expand ``name`` into a frozenset of tool ids.
+
+        Recursively pulls in tools from every ``includes`` member. Unknown
+        toolkit names raise :class:`KeyError`; cycles raise
+        :class:`ToolkitCompositionError` with the offending path.
+
+        Empty toolkit (no ``tools`` AND no ``includes``) returns an empty
+        frozenset — callers (the worker) decide whether to fall through to
+        ``_default``.
+        """
+        if name not in self._toolkits:
+            raise KeyError(f"toolkit {name!r} not in registry; known: {self.names()}")
+        return self._expand(name, chain=())
+
+    def _expand(self, name: str, *, chain: tuple[str, ...]) -> frozenset[str]:
+        if name in chain:
+            cycle = " → ".join((*chain, name))
+            raise ToolkitCompositionError(f"toolkit cycle detected: {cycle}")
+        kit = self._toolkits.get(name)
+        if kit is None:
+            # An `includes:` target that doesn't exist — surface clearly
+            # rather than silently dropping its tools. Calls to
+            # ``resolve(name)`` already validate ``name`` itself; this
+            # branch only fires for missing transitive includes.
+            raise ToolkitCompositionError(
+                f"toolkit {name!r} listed in includes but not declared "
+                f"(chain: {' → '.join(chain) or '<root>'})"
+            )
+        acc: set[str] = set(kit.tools)
+        for inc in kit.includes:
+            acc |= self._expand(inc, chain=(*chain, name))
+        return frozenset(acc)
+
+    def resolve_with_fallback(self, name: str | None) -> frozenset[str]:
+        """Resolve ``name`` if present and known, else ``_default``, else empty.
+
+        Convenience for the worker: a sub-agent may declare a toolkit
+        that doesn't exist (typo / refactor lag). Rather than crashing
+        the spawn, we log a WARNING and fall through to ``_default`` so
+        the agent still has its minimal read-only safety net.
+        """
+        if name and self.has(name):
+            return self.resolve(name)
+        if name:
+            log.warning(
+                "toolkit_registry: agent requested toolkit=%r which is not "
+                "declared in toolkits.toml; falling back to %r.",
+                name,
+                DEFAULT_TOOLKIT,
+            )
+        if self.has(DEFAULT_TOOLKIT):
+            return self.resolve(DEFAULT_TOOLKIT)
+        return frozenset()
+
+
+# ----------------------------------------------------------------------
+# Module-level convenience
+# ----------------------------------------------------------------------
+
+
+_cached_registry: ToolkitRegistry | None = None
+
+
+def load_default_registry(*, force_reload: bool = False) -> ToolkitRegistry:
+    """Return a process-cached registry loaded from ``DEFAULT_TOOLKITS_PATH``.
+
+    The worker subprocess calls this once per spawn — caching avoids
+    re-parsing the TOML on every ``filter_handlers`` call. Tests can
+    pass ``force_reload=True`` to bypass the cache after writing a
+    temporary manifest.
+    """
+    global _cached_registry
+    if _cached_registry is None or force_reload:
+        _cached_registry = ToolkitRegistry.load()
+    return _cached_registry

--- a/core/tools/toolkits.toml
+++ b/core/tools/toolkits.toml
@@ -1,0 +1,101 @@
+# GEODE Toolkits — sub-agent tool grouping manifest.
+#
+# A "toolkit" is a named bundle of tool ids that a sub-agent declares it
+# wants access to (via the `toolkit:` key in `.claude/agents/<name>.md`
+# frontmatter). The worker resolves the toolkit at spawn time and passes
+# the resulting allowlist into `filter_handlers()`.
+#
+# Resolution order (see core/tools/toolkit_registry.py):
+#   1. If agent declares `toolkit: <name>`, use that toolkit's tools
+#      (after recursive `includes:` expansion).
+#   2. If agent declares `tools: [...]` (legacy frontmatter), use that
+#      list verbatim — backwards compatible with pre-CSP-1 AgentDefs.
+#   3. If neither is declared (or the named toolkit is missing), fall
+#      back to the `_default` toolkit.
+#
+# Tool names MUST match `core/tools/definitions.json` entries — typos
+# produce a WARNING at spawn time (worker.py:filter_handlers) and the
+# agent runs without the missing tool.
+
+# ---------------------------------------------------------------------------
+# Fallback — applied when an agent has no toolkit AND no tools: list.
+# Keep this minimal; agents that need more should declare a toolkit.
+# ---------------------------------------------------------------------------
+
+[toolkits._default]
+description = "Minimal read-only safety net for sub-agents without a declared toolkit."
+tools = ["read_document", "grep_files"]
+
+# ---------------------------------------------------------------------------
+# Composition leaves — reusable building blocks pulled in via `includes`.
+# Single-purpose; do not declare these as an agent's primary toolkit.
+# ---------------------------------------------------------------------------
+
+[toolkits.common_read]
+description = "Filesystem read primitives."
+tools = ["read_document", "grep_files", "glob_files"]
+
+[toolkits.common_write]
+description = "Filesystem write primitives (paired with common_read in practice)."
+tools = ["write_file", "edit_file"]
+
+# ---------------------------------------------------------------------------
+# General-purpose toolkits — domain-neutral kits any agent can declare via
+# ``toolkit:`` in `.claude/agents/<name>.md`. Each is named after the
+# *job profile* the agent is performing (web research, analysis, etc.) so
+# the meaning carries without reading the manifest.
+# ---------------------------------------------------------------------------
+
+[toolkits.web_research]
+description = "Web research — search + fetch + read primitives."
+includes = ["common_read"]
+tools = ["general_web_search", "web_fetch"]
+
+[toolkits.data_analysis]
+description = "Read-only analysis kit with web + memory context."
+includes = ["common_read"]
+tools = ["general_web_search", "memory_search"]
+
+[toolkits.general_purpose]
+description = "Broad-surface kit for orchestrator-style agents — read/write + web + notes. Distinct from ``_default`` (which is the *fallback* minimal safety net for undeclared agents); ``general_purpose`` is a *declared* full-research surface."
+includes = ["common_read", "common_write"]
+tools = ["general_web_search", "web_fetch", "memory_save", "note_save"]
+
+# ---------------------------------------------------------------------------
+# Seed-generation toolkits — one per role of the co-scientist port
+# (`plugins/seed_generation/`). The agent definitions under
+# `.claude/agents/seed_*.md` declare these via `toolkit:`.
+# ---------------------------------------------------------------------------
+
+[toolkits.seed_generation]
+description = "Petri seed candidate Generator — writes one .md candidate per spawn."
+includes = ["common_read", "common_write"]
+tools = []  # all tools come from `includes`
+
+[toolkits.seed_critique]
+description = "Reflection critic — read-only critique of a candidate seed."
+includes = ["common_read"]
+tools = []
+
+[toolkits.seed_proximity]
+description = "Proximity dedup — read-only; embedding API is invoked outside the tool handler layer (see plugins/seed_generation/agents/proximity.py)."
+includes = ["common_read"]
+tools = []
+
+[toolkits.seed_pilot]
+description = "Petri inner-loop pilot audit for one candidate."
+tools = ["petri_audit", "read_document"]
+
+[toolkits.seed_ranker]
+description = "Elo tournament voter — reads two candidates and casts a vote."
+tools = ["read_document"]
+
+[toolkits.seed_evolver]
+description = "Section-targeted rewrite of one survivor candidate."
+includes = ["common_read", "common_write"]
+tools = []
+
+[toolkits.seed_meta_review]
+description = "Aggregate meta-review across the candidate batch."
+includes = ["common_read"]
+tools = []

--- a/tests/core/agent/test_filter_handlers_toolkit.py
+++ b/tests/core/agent/test_filter_handlers_toolkit.py
@@ -1,0 +1,208 @@
+"""Tests for ``filter_handlers`` toolkit resolution (CSP-1, 2026-05-22)."""
+
+from __future__ import annotations
+
+from core.agent.worker import filter_handlers
+from core.tools.toolkit_registry import ToolkitRegistry
+
+
+def _stub_handlers() -> dict[str, object]:
+    """Mock handler map covering the names used by seed_*.md AgentDefs."""
+    names = [
+        "read_document",
+        "write_file",
+        "grep_files",
+        "glob_files",
+        "edit_file",
+        "petri_audit",
+        "general_web_search",
+        "memory_save",
+        "delegate_task",
+    ]
+    return {name: object() for name in names}
+
+
+def _registry() -> ToolkitRegistry:
+    return ToolkitRegistry.from_dict(
+        {
+            "_default": {"tools": ["read_document"]},
+            "common_read": {"tools": ["read_document", "grep_files"]},
+            "kit_generator": {
+                "includes": ["common_read"],
+                "tools": ["write_file"],
+            },
+            "kit_pilot": {"tools": ["petri_audit", "read_document"]},
+        }
+    )
+
+
+class TestFilterHandlersToolkitPriority:
+    def test_toolkit_takes_precedence(self) -> None:
+        """When ``toolkit`` is set, ``agent_allowed_tools`` is ignored."""
+        handlers = _stub_handlers()
+        # agent_allowed_tools also lists write_file but with a typo'd
+        # extra; toolkit resolution should win and ignore the legacy list.
+        filtered = filter_handlers(
+            handlers=handlers,
+            denied_tools=[],
+            agent_allowed_tools=["edit_file"],
+            toolkit="kit_generator",
+            toolkit_registry=_registry(),
+        )
+        assert set(filtered) == {"read_document", "write_file", "grep_files"}
+        assert "edit_file" not in filtered  # legacy list ignored
+        assert "delegate_task" not in filtered  # depth=1 guard
+
+    def test_legacy_tools_list_when_no_toolkit(self) -> None:
+        """When toolkit is empty, fall back to ``agent_allowed_tools``."""
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=["edit_file", "memory_save"],
+            toolkit="",
+            toolkit_registry=_registry(),
+        )
+        assert set(filtered) == {"edit_file", "memory_save"}
+
+    def test_default_fallback_when_neither(self) -> None:
+        """No toolkit + no legacy tools → ``_default`` toolkit safety net."""
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=[],
+            toolkit="",
+            toolkit_registry=_registry(),
+        )
+        assert set(filtered) == {"read_document"}
+
+    def test_no_registry_no_legacy_keeps_all_minus_denied(self) -> None:
+        """Pre-CSP-1 behaviour: no registry passed → only depth=1 + denied filter applies."""
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=["run_bash"],
+            agent_allowed_tools=[],
+            toolkit="",
+            toolkit_registry=None,
+        )
+        # delegate_task always denied; everything else stays.
+        assert "delegate_task" not in filtered
+        assert "read_document" in filtered
+        assert "write_file" in filtered
+
+    def test_unknown_toolkit_falls_back_to_default(self) -> None:
+        """A typo'd toolkit name routes through ``_default`` with WARNING."""
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=[],
+            toolkit="kit_typo",
+            toolkit_registry=_registry(),
+        )
+        assert set(filtered) == {"read_document"}
+
+    def test_pilot_toolkit_resolves_petri_audit(self) -> None:
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=[],
+            toolkit="kit_pilot",
+            toolkit_registry=_registry(),
+        )
+        assert set(filtered) == {"petri_audit", "read_document"}
+
+    def test_denied_tools_post_apply(self) -> None:
+        """``denied_tools`` is applied AFTER toolkit expansion."""
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=["write_file"],
+            agent_allowed_tools=[],
+            toolkit="kit_generator",
+            toolkit_registry=_registry(),
+        )
+        # kit_generator pulls write_file via composition; denied list
+        # subtracts it.
+        assert "write_file" not in filtered
+        assert "read_document" in filtered
+        assert "grep_files" in filtered
+
+
+class TestFilterHandlersBackwardsCompat:
+    """Pre-CSP-1 call signatures must still work without ``toolkit`` kwargs."""
+
+    def test_legacy_signature_unchanged(self) -> None:
+        """Calls without toolkit kwargs behave exactly as before."""
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=["run_bash"],
+            agent_allowed_tools=["read_document", "write_file"],
+        )
+        assert set(filtered) == {"read_document", "write_file"}
+
+
+class TestFilterHandlersFailClosed:
+    """Codex MCP HIGH #2 + MEDIUM #2 — silent re-open paths must fail closed."""
+
+    def test_empty_registry_no_default_fails_closed(self) -> None:
+        """Registry without ``_default`` + no toolkit + no legacy list →
+        all handlers denied (no silent re-open of full surface)."""
+        empty_reg = ToolkitRegistry.from_dict({"kit_only": {"tools": ["read_document"]}})
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=[],
+            toolkit="",
+            toolkit_registry=empty_reg,
+        )
+        # delegate_task is always denied; nothing else survived because
+        # ``_default`` was missing and tier-3 now fails closed.
+        assert filtered == {}
+
+    def test_empty_default_toolkit_fails_closed(self) -> None:
+        """``_default`` declared but resolving to empty set → all denied."""
+        reg = ToolkitRegistry.from_dict({"_default": {}})
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=[],
+            toolkit="",
+            toolkit_registry=reg,
+        )
+        assert filtered == {}
+
+    def test_explicit_toolkit_without_registry_fails_closed(self) -> None:
+        """toolkit declared but ``toolkit_registry=None`` → empty allowlist.
+
+        Pre-fix this silently fell through to ``agent_allowed_tools`` or
+        the full surface, masking misconfigured spawns.
+        """
+        filtered = filter_handlers(
+            handlers=_stub_handlers(),
+            denied_tools=[],
+            agent_allowed_tools=["edit_file"],
+            toolkit="kit_generator",
+            toolkit_registry=None,
+        )
+        # toolkit declared → fail closed; legacy ``agent_allowed_tools``
+        # is NOT used as a fallback here.
+        assert filtered == {}
+
+
+class TestSeedAgentDefBackwardsContract:
+    """Smoke test — the 7 seed_*.md AgentDefs all declare a real toolkit."""
+
+    def test_seed_toolkits_resolve(self) -> None:
+        from core.tools.toolkit_registry import load_default_registry
+
+        reg = load_default_registry(force_reload=True)
+        kits = [
+            "seed_generation",
+            "seed_critique",
+            "seed_pilot",
+            "seed_ranker",
+            "seed_evolver",
+            "seed_meta_review",
+            "seed_proximity",
+        ]
+        for kit in kits:
+            tools = reg.resolve(kit)
+            assert tools, f"toolkit {kit!r} resolved to empty set — review toolkits.toml"

--- a/tests/core/tools/test_toolkit_registry.py
+++ b/tests/core/tools/test_toolkit_registry.py
@@ -1,0 +1,213 @@
+"""Tests for core.tools.toolkit_registry — TOML parsing + composition + fallback."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from core.tools.toolkit_registry import (
+    DEFAULT_TOOLKIT,
+    ToolkitCompositionError,
+    ToolkitRegistry,
+    load_default_registry,
+)
+
+
+class TestFromDict:
+    def test_simple_toolkit(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {
+                "toolkits": {
+                    "kit_a": {
+                        "description": "A",
+                        "tools": ["read_document", "grep_files"],
+                    }
+                }
+            }
+        )
+        assert reg.has("kit_a")
+        assert reg.resolve("kit_a") == frozenset({"read_document", "grep_files"})
+
+    def test_flat_dict_shape_accepted(self) -> None:
+        """Tests can pass a flat dict without the ``toolkits`` wrapper."""
+        reg = ToolkitRegistry.from_dict(
+            {"kit_b": {"tools": ["read_document"]}}
+        )
+        assert reg.has("kit_b")
+        assert reg.resolve("kit_b") == frozenset({"read_document"})
+
+    def test_empty_body(self) -> None:
+        """Toolkit with no ``tools`` and no ``includes`` resolves to empty set."""
+        reg = ToolkitRegistry.from_dict({"empty_kit": {}})
+        assert reg.resolve("empty_kit") == frozenset()
+
+    def test_malformed_row(self) -> None:
+        with pytest.raises(ToolkitCompositionError):
+            ToolkitRegistry.from_dict({"toolkits": {"bad": "not_a_table"}})
+
+
+class TestComposition:
+    def test_includes_recursive(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {
+                "common_read": {"tools": ["read_document", "grep_files"]},
+                "common_write": {"tools": ["write_file"]},
+                "compound": {"includes": ["common_read", "common_write"]},
+            }
+        )
+        assert reg.resolve("compound") == frozenset(
+            {"read_document", "grep_files", "write_file"}
+        )
+
+    def test_nested_includes(self) -> None:
+        """Includes chain follows transitively."""
+        reg = ToolkitRegistry.from_dict(
+            {
+                "a": {"tools": ["t_a"]},
+                "b": {"tools": ["t_b"], "includes": ["a"]},
+                "c": {"tools": ["t_c"], "includes": ["b"]},
+            }
+        )
+        assert reg.resolve("c") == frozenset({"t_a", "t_b", "t_c"})
+
+    def test_cycle_detected(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {
+                "a": {"includes": ["b"]},
+                "b": {"includes": ["a"]},
+            }
+        )
+        with pytest.raises(ToolkitCompositionError, match="cycle"):
+            reg.resolve("a")
+
+    def test_self_cycle_detected(self) -> None:
+        reg = ToolkitRegistry.from_dict({"self_ref": {"includes": ["self_ref"]}})
+        with pytest.raises(ToolkitCompositionError, match="cycle"):
+            reg.resolve("self_ref")
+
+    def test_missing_include_target(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {"a": {"includes": ["nonexistent"]}}
+        )
+        with pytest.raises(ToolkitCompositionError, match="not declared"):
+            reg.resolve("a")
+
+    def test_duplicate_tools_merged(self) -> None:
+        """The same tool name across composed kits collapses to one entry."""
+        reg = ToolkitRegistry.from_dict(
+            {
+                "a": {"tools": ["read_document"]},
+                "b": {"tools": ["read_document", "grep_files"], "includes": ["a"]},
+            }
+        )
+        assert reg.resolve("b") == frozenset({"read_document", "grep_files"})
+
+
+class TestFallback:
+    def test_unknown_falls_back_to_default(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {
+                "_default": {"tools": ["read_document"]},
+            }
+        )
+        # ``typo_name`` is unknown; the registry logs a WARNING (not
+        # asserted here) and routes through ``_default``.
+        assert reg.resolve_with_fallback("typo_name") == frozenset({"read_document"})
+
+    def test_none_uses_default(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {"_default": {"tools": ["read_document"]}}
+        )
+        assert reg.resolve_with_fallback(None) == frozenset({"read_document"})
+
+    def test_no_default_returns_empty(self) -> None:
+        reg = ToolkitRegistry.from_dict({"kit_only": {"tools": ["read_document"]}})
+        assert reg.resolve_with_fallback(None) == frozenset()
+
+    def test_known_takes_precedence(self) -> None:
+        reg = ToolkitRegistry.from_dict(
+            {
+                "_default": {"tools": ["read_document"]},
+                "explicit": {"tools": ["write_file"]},
+            }
+        )
+        assert reg.resolve_with_fallback("explicit") == frozenset({"write_file"})
+
+
+class TestDiskLoad:
+    def test_load_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        reg = ToolkitRegistry.load(tmp_path / "missing.toml")
+        assert reg.names() == []
+
+    def test_load_real_toml(self, tmp_path: Path) -> None:
+        p = tmp_path / "toolkits.toml"
+        p.write_text(
+            textwrap.dedent(
+                """
+                [toolkits.kit_x]
+                description = "test"
+                tools = ["read_document"]
+                """
+            ).strip()
+        )
+        reg = ToolkitRegistry.load(p)
+        assert reg.has("kit_x")
+        assert reg.resolve("kit_x") == frozenset({"read_document"})
+
+
+class TestDefaultRegistry:
+    def test_bundled_toolkits_load(self) -> None:
+        """The bundled ``core/tools/toolkits.toml`` must load + parse cleanly."""
+        reg = load_default_registry(force_reload=True)
+        assert reg.has(DEFAULT_TOOLKIT), "missing _default in bundled manifest"
+        # Spot-check seed_* kits used by .claude/agents/seed_*.md
+        for name in (
+            "seed_generation",
+            "seed_critique",
+            "seed_pilot",
+            "seed_ranker",
+            "seed_evolver",
+            "seed_meta_review",
+            "seed_proximity",
+        ):
+            assert reg.has(name), f"bundled toolkit {name!r} missing"
+            # Resolution should never raise — guards against accidental
+            # cycles or typos in the manifest's ``includes``.
+            tools = reg.resolve(name)
+            assert isinstance(tools, frozenset)
+
+    def test_bundled_general_toolkits(self) -> None:
+        """CSP-1 — general-purpose toolkits available for non-seed agents."""
+        reg = load_default_registry(force_reload=True)
+        # web_research — search + fetch + common read primitives.
+        web = reg.resolve("web_research")
+        assert "general_web_search" in web
+        assert "web_fetch" in web
+        assert "read_document" in web  # via common_read
+        # data_analysis — read + search + memory, no write.
+        analysis = reg.resolve("data_analysis")
+        assert "general_web_search" in analysis
+        assert "memory_search" in analysis
+        assert "write_file" not in analysis  # read-only
+        # general_purpose — broad-surface orchestrator kit.
+        general = reg.resolve("general_purpose")
+        assert {"general_web_search", "web_fetch", "memory_save",
+                "note_save", "read_document", "write_file"} <= general
+
+    def test_default_agents_resolve_their_toolkits(self) -> None:
+        """The bundled ``_DEFAULT_AGENTS`` declare toolkits that resolve."""
+        from core.skills.agents import AgentRegistry
+
+        registry = AgentRegistry()
+        registry.load_defaults()
+        reg = load_default_registry(force_reload=True)
+        for name in ("research_assistant", "data_analyst", "web_researcher"):
+            agent = registry.get(name)
+            assert agent is not None
+            assert agent.toolkit, f"default agent {name!r} missing toolkit declaration"
+            # Toolkit must exist in the bundled manifest.
+            assert reg.has(agent.toolkit), (
+                f"default agent {name!r} declares toolkit={agent.toolkit!r} "
+                f"which is not in toolkits.toml"
+            )

--- a/tests/core/tools/test_toolkit_registry.py
+++ b/tests/core/tools/test_toolkit_registry.py
@@ -31,9 +31,7 @@ class TestFromDict:
 
     def test_flat_dict_shape_accepted(self) -> None:
         """Tests can pass a flat dict without the ``toolkits`` wrapper."""
-        reg = ToolkitRegistry.from_dict(
-            {"kit_b": {"tools": ["read_document"]}}
-        )
+        reg = ToolkitRegistry.from_dict({"kit_b": {"tools": ["read_document"]}})
         assert reg.has("kit_b")
         assert reg.resolve("kit_b") == frozenset({"read_document"})
 
@@ -56,9 +54,7 @@ class TestComposition:
                 "compound": {"includes": ["common_read", "common_write"]},
             }
         )
-        assert reg.resolve("compound") == frozenset(
-            {"read_document", "grep_files", "write_file"}
-        )
+        assert reg.resolve("compound") == frozenset({"read_document", "grep_files", "write_file"})
 
     def test_nested_includes(self) -> None:
         """Includes chain follows transitively."""
@@ -87,9 +83,7 @@ class TestComposition:
             reg.resolve("self_ref")
 
     def test_missing_include_target(self) -> None:
-        reg = ToolkitRegistry.from_dict(
-            {"a": {"includes": ["nonexistent"]}}
-        )
+        reg = ToolkitRegistry.from_dict({"a": {"includes": ["nonexistent"]}})
         with pytest.raises(ToolkitCompositionError, match="not declared"):
             reg.resolve("a")
 
@@ -116,9 +110,7 @@ class TestFallback:
         assert reg.resolve_with_fallback("typo_name") == frozenset({"read_document"})
 
     def test_none_uses_default(self) -> None:
-        reg = ToolkitRegistry.from_dict(
-            {"_default": {"tools": ["read_document"]}}
-        )
+        reg = ToolkitRegistry.from_dict({"_default": {"tools": ["read_document"]}})
         assert reg.resolve_with_fallback(None) == frozenset({"read_document"})
 
     def test_no_default_returns_empty(self) -> None:
@@ -192,8 +184,14 @@ class TestDefaultRegistry:
         assert "write_file" not in analysis  # read-only
         # general_purpose — broad-surface orchestrator kit.
         general = reg.resolve("general_purpose")
-        assert {"general_web_search", "web_fetch", "memory_save",
-                "note_save", "read_document", "write_file"} <= general
+        assert {
+            "general_web_search",
+            "web_fetch",
+            "memory_save",
+            "note_save",
+            "read_document",
+            "write_file",
+        } <= general
 
     def test_default_agents_resolve_their_toolkits(self) -> None:
         """The bundled ``_DEFAULT_AGENTS`` declare toolkits that resolve."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -73,6 +73,23 @@ class TestWorkerRequest:
         assert req.thinking_budget == 0
         assert req.time_budget_s == 0.0
 
+    def test_toolkit_roundtrip(self) -> None:
+        """CSP-1 — ``toolkit`` survives the parent→worker IPC boundary."""
+        req = WorkerRequest(
+            task_id="t-csp1",
+            description="seed generator spawn",
+            toolkit="seed_generation",
+        )
+        data = req.to_dict()
+        assert data["toolkit"] == "seed_generation"
+        restored = WorkerRequest.from_dict(data)
+        assert restored.toolkit == "seed_generation"
+
+    def test_toolkit_default_empty(self) -> None:
+        """Default ``toolkit`` is empty string — legacy callers unaffected."""
+        req = WorkerRequest.from_dict({"task_id": "t-bc"})
+        assert req.toolkit == ""
+
 
 class TestWorkerResult:
     def test_roundtrip(self) -> None:


### PR DESCRIPTION
## Summary

- Sub-agent AgentDefinitions can declare a named `toolkit:` in frontmatter; the worker resolves it against `core/tools/toolkits.toml` (Hermes-style `includes:` composition) at spawn time.
- 3-tier resolution with fail-closed semantics: `toolkit` → legacy `tools:` (BC) → `_default` safety net. Model-visible tool schemas filtered to match the executor allowlist.
- 7 seed-generation AgentDefs + 3 bundled default agents migrated. Pre-CSP-1 `"web_search"` reference (never resolved to a real handler) corrected to canonical `general_web_search` via the new `web_research` toolkit.

## Why

Adding/changing a tool surface required editing N AgentDef frontmatters because each agent shipped its own flat `tools:` list. New domains (literature tools for CSP-2, etc.) had no place to land. Co-scientist's `workflow`-scoped whitelist (`open-coscientist/src/open_coscientist/config/registry.py:274`) + LangChain's Toolkit + Hermes' `toolsets.py` all converge on the same pattern: name a bundle once, declare by name, compose by inclusion. CSP-1 brings that pattern to GEODE.

## Changes

| File | Change |
|------|--------|
| `core/tools/toolkits.toml` (new) | 13 toolkits: `_default`, `common_read`, `common_write`, `web_research`, `data_analysis`, `general_purpose`, 7 seed-generation kits |
| `core/tools/toolkit_registry.py` (new) | TOML loader, recursive `includes:` expansion, cycle detection, missing-target detection, `resolve_with_fallback` |
| `core/agent/worker.py` | `WorkerRequest.toolkit` field + `filter_handlers` 3-tier resolution + IPC roundtrip |
| `core/agent/loop/agent_loop.py` | `AgenticLoop.allowed_tool_names` kwarg — filters model-visible tool schemas (Codex HIGH #1) |
| `core/agent/sub_agent.py` | `_build_worker_request` propagates `agent_ctx["toolkit"]` to worker |
| `core/skills/agents.py` | `AgentDefinition.toolkit` Pydantic field + `SubagentLoader` frontmatter parsing |
| `core/agent/agent_contracts_policy.py` | Warns when `tools` override shadows a toolkit declaration (Codex MEDIUM #1) |
| `.claude/agents/seed_*.md` (×7) | `tools: […]` → `toolkit: seed_<role>` |
| `core/skills/agents.py` `_DEFAULT_AGENTS` | 3 default agents migrated to toolkit; `web_search` → `general_web_search` |
| `tests/core/tools/test_toolkit_registry.py` (new) | 17 cases — composition / cycle / fallback / disk load / bundled manifest / default agents resolve |
| `tests/core/agent/test_filter_handlers_toolkit.py` (new) | 11 cases — 3-tier priority / BC / fail-closed paths |
| `tests/test_worker.py` | 2 cases — toolkit IPC roundtrip + default |
| `CHANGELOG.md` | Two `[Unreleased] Added` entries |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Named toolkit registry | Implemented | `core/tools/toolkit_registry.py` |
| TOML manifest + composition | Implemented | `toolkits.toml` with `includes:` recursion |
| Worker IPC propagation | Implemented | `WorkerRequest.toolkit` + `from_dict` roundtrip |
| Model-visible schema filter | Implemented (Codex HIGH #1) | `AgenticLoop.allowed_tool_names` |
| Fail-closed semantics | Implemented (Codex HIGH #2 + MEDIUM #2) | 3-tier all close when empty |
| Schema strictness | Implemented (Codex LOW #1) | scalar `tools`/`includes` raises |
| BC for legacy `tools:` | Verified | tier-2 fallback when no toolkit declared |
| Default agents migration | Implemented | 3 bundled + 7 seed = 10 AgentDefs on toolkit |
| `web_search` bug | Fixed | corrected to `general_web_search` |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 393 files, 0 errors
- [x] `uv run pytest tests/core/tools/test_toolkit_registry.py tests/core/agent/test_filter_handlers_toolkit.py tests/test_worker.py tests/test_agents_ext.py tests/test_sub_agent_scope.py tests/core/agent/test_agent_loop_system_prompt_override.py tests/test_subagent_lineage.py` — 73+ pass
- [x] Codex MCP second-opinion review — 6 findings (2 HIGH / 2 MEDIUM / 2 LOW) addressed
- [x] Local quality gates mirror CI ratchet (ruff format, lint-imports implicit via ruff check)

## Reference

- arXiv:2502.18864 co-scientist port audit — `mango-wiki/vault/projects/geode/synthesis/coscientist-port-audit-2026-05-22.md`
- LangChain Toolkit — https://reference.langchain.com/python/langchain-community/agent_toolkits
- Hermes `toolsets.py` (`~/workspace/hermes-agent/toolsets.py`) — `includes:` composition pattern
- open-coscientist `config/registry.py:274` — `get_tools_for_workflow` workflow-scoped whitelist

🤖 Generated with [Claude Code](https://claude.com/claude-code)