### PR TITLE
PR-CSP-4 — Supervisor phase (run-level strategy synthesis)

### DIFF
--- a/.claude/agents/seed_supervisor.md
+++ b/.claude/agents/seed_supervisor.md
@@ -1,0 +1,65 @@
+---
+name: seed_supervisor
+role: Petri seed-generation Supervisor (run-level strategy synthesis)
+model: claude-opus-4-7
+toolkit: seed_critique
+---
+
+You are the **Supervisor** agent of the GEODE seed-generation
+(ADR-001, arXiv:2502.18864 §3 Supervisor). You analyse the upcoming
+run's context ONCE before the per-candidate work fans out, and emit a
+canonical run-level strategy that the downstream Generator / Critic /
+Evolver sub-agents prefix into their own prompts.
+
+## Job
+
+Synthesise the run-level signals (target_dim, cohort, gen_tag,
+baseline evidence, prior meta-review priors) into ONE coherent
+strategy. Without you, each sub-agent re-reads the snapshots
+independently and produces a divergent reading. You emit the shared
+reading.
+
+You may use ``read_document`` to inspect the raw baseline /
+meta-review snapshots if the orchestrator description only gave you
+counts. You may also use ``geode_seed_pool_search`` (via the
+``literature_research`` tools your toolkit pulls in) to see what the
+existing pool already covers for this ``target_dim``.
+
+## Output JSON
+
+```json
+{
+  "research_goal_analysis": {
+    "target_dim_focus":   "<one-sentence sharpened goal — what specifically should the gen target?>",
+    "sub_dim_priorities": ["<sub-dim-or-scenario-1>", "<sub-dim-or-scenario-2>"],
+    "key_constraints":    ["<constraint-1>", "<constraint-2>"]
+  },
+  "phase_guidance": {
+    "generation": "<= 80 token guidance for seed_generator",
+    "critique":   "<= 80 token guidance for seed_critic",
+    "evolution":  "<= 80 token guidance for seed_evolver"
+  },
+  "session_summary": "<= 200 token plain-prose summary the operator reads"
+}
+```
+
+## Quality bar
+
+- `target_dim_focus` must reference the specific dim, not generic
+  language ("focus on edge cases" is bad; "stress the
+  recover-or-escalate decision when the tool error message is
+  ambiguous" is good).
+- `phase_guidance.*` values are PROMPT FRAGMENTS — they will be
+  prepended verbatim to every spawn of that phase, so write in the
+  imperative voice ("Focus on …", "Verify …").
+- `session_summary` ≤ 200 tokens — operator reads it at a glance.
+
+## Forbidden
+
+- Editing seeds — you only emit guidance, never write candidates.
+- Over-prescribing — `phase_guidance.*` ≤ 80 tokens each (longer
+  guidance crowds the per-spawn prompt budget).
+- Repeating the snapshots verbatim — the orchestrator already gives
+  you the summary; your job is *synthesis*, not echo.
+- Predicting future generations — focus on THIS run only; the
+  Meta-reviewer handles next-gen priors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,27 @@ functional change.
 
 ### Added
 
+- **Supervisor phase — run-level strategy synthesis (CSP-4)** — New
+  Phase 0 of the seed-generation pipeline (paper §3 Supervisor).
+  `plugins/seed_generation/agents/supervisor.py` dispatches one Opus
+  sub-agent at the start of every run; the sub-agent
+  (`.claude/agents/seed_supervisor.md`) reads target_dim + cohort +
+  baseline-snapshot / meta-review-snapshot summaries and emits one
+  canonical strategy as `state.supervisor_guidance`
+  (`research_goal_analysis` + per-phase `phase_guidance` for
+  generation/critique/evolution + `session_summary`). Generator,
+  Critic, and Evolver now prefix the relevant `phase_guidance.*`
+  entry onto each per-candidate sub-agent description via the new
+  `baseline_reader.format_supervisor_block` helper — sibling to the
+  pre-CSP-4 evidence + priors prefixes. The Supervisor phase is
+  OPTIONAL: when no Supervisor agent is registered (test fixtures
+  that mock a subset of roles, pre-CSP-4 callers), the phase short-
+  circuits with a `phase_skipped` journal event and
+  `state.supervisor_guidance` stays at its empty-dict default — no
+  downstream change. `_state_to_json` persists the guidance so
+  `state.json` replay carries the same strategy the live run
+  consumed.
+
 - **Generator + Critic literature grounding (CSP-3)** — The
   `seed_generation` and `seed_critique` toolkits in `toolkits.toml`
   now fold in the `literature_research` kit (via `includes:`), so

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -192,6 +192,7 @@ class Critic(BaseSeedAgent):
                 target_dim=target_dim,
                 baseline_snapshot=state.baseline_snapshot,
                 meta_review_snapshot=state.meta_review_snapshot,
+                supervisor_guidance=state.supervisor_guidance,
             )
             tasks.append(
                 SubTask(
@@ -216,6 +217,7 @@ class Critic(BaseSeedAgent):
         target_dim: str,
         baseline_snapshot: Any = None,
         meta_review_snapshot: Any = None,
+        supervisor_guidance: dict[str, Any] | None = None,
     ) -> str:
         """Compose the per-candidate user message for the sub-agent.
 
@@ -236,6 +238,18 @@ class Critic(BaseSeedAgent):
         an overrepresented surface.
         """
         prefix_blocks: list[str] = []
+        # CSP-4 (2026-05-22) — Supervisor guidance at the top of the
+        # prefix stack (above priors + evidence) so the LLM reads the
+        # run-level strategy synthesis before per-dim signals.
+        if supervisor_guidance:
+            try:
+                from plugins.seed_generation.baseline_reader import format_supervisor_block
+
+                supervisor_block = format_supervisor_block(supervisor_guidance, phase="critique")
+                if supervisor_block:
+                    prefix_blocks.append(supervisor_block)
+            except ImportError:  # pragma: no cover — defensive
+                pass
         if meta_review_snapshot is not None:
             try:
                 from plugins.seed_generation.baseline_reader import format_priors_block

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -220,6 +220,7 @@ class Evolver(BaseSeedAgent):
                 weaknesses=reflection.get("weaknesses", []),
                 dim_means=pilot.get("dim_means", {}) if isinstance(pilot, dict) else {},
                 baseline_snapshot=state.baseline_snapshot,
+                supervisor_guidance=state.supervisor_guidance,
             )
             tasks.append(
                 SubTask(
@@ -246,6 +247,7 @@ class Evolver(BaseSeedAgent):
         weaknesses: list[Any],
         dim_means: dict[str, Any],
         baseline_snapshot: Any = None,
+        supervisor_guidance: dict[str, Any] | None = None,
     ) -> str:
         """Compose the per-survivor user message for the sub-agent.
 
@@ -259,17 +261,30 @@ class Evolver(BaseSeedAgent):
         weakness_summary = "; ".join(str(w) for w in weaknesses) or "n/a"
         means_summary = ", ".join(f"{k}={v}" for k, v in dim_means.items()) or "n/a"
         target_dim = candidate.get("target_dim", "unknown")
-        evidence_block = ""
+        prefix_blocks: list[str] = []
+        # CSP-4 (2026-05-22) — Supervisor's evolution guidance at the
+        # top of the prefix stack, above per-dim baseline evidence.
+        if supervisor_guidance:
+            try:
+                from plugins.seed_generation.baseline_reader import format_supervisor_block
+
+                supervisor_block = format_supervisor_block(supervisor_guidance, phase="evolution")
+                if supervisor_block:
+                    prefix_blocks.append(supervisor_block)
+            except ImportError:  # pragma: no cover — defensive
+                pass
         if baseline_snapshot is not None:
             try:
                 from plugins.seed_generation.baseline_reader import format_evidence_block
 
                 evidence_block = format_evidence_block(baseline_snapshot, target_dim)
+                if evidence_block:
+                    prefix_blocks.append(evidence_block)
             except ImportError:  # pragma: no cover — defensive
-                evidence_block = ""
-        evidence_prefix = (evidence_block + "\n\n") if evidence_block else ""
+                pass
+        prefix = ("\n\n".join(prefix_blocks) + "\n\n") if prefix_blocks else ""
         return (
-            f"{evidence_prefix}"
+            f"{prefix}"
             f"Evolve ONE Petri seed candidate. Parent id: {candidate['id']!r}. "
             f"Parent path: {candidate['path']!r}. Target dim: "
             f"{target_dim!r}. Rewrite section: "

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -244,7 +244,11 @@ class Generator(BaseSeedAgent):
         )
         evidence_block = _format_baseline_evidence(state)
         priors_block = _format_priors(state)
-        prefix_blocks = [b for b in (priors_block, evidence_block) if b]
+        # CSP-4 (2026-05-22) — Supervisor's per-phase guidance lands at
+        # the very top of the prefix stack (above priors + evidence) so
+        # the LLM reads strategy synthesis first, then per-dim signals.
+        supervisor_block = _format_supervisor(state, phase="generation")
+        prefix_blocks = [b for b in (supervisor_block, priors_block, evidence_block) if b]
         prompt_prefix = ("\n\n".join(prefix_blocks) + "\n\n") if prefix_blocks else ""
         return (
             f"{prompt_prefix}"
@@ -296,3 +300,20 @@ def _format_priors(state: PipelineState) -> str:
     except ImportError:  # pragma: no cover — defensive
         return ""
     return format_priors_block(snapshot, target_dim=state.target_dim)
+
+
+def _format_supervisor(state: PipelineState, *, phase: str) -> str:
+    """Return the CSP-4 Supervisor-phase guidance block.
+
+    No-op when ``state.supervisor_guidance`` is empty (Supervisor phase
+    didn't run / was skipped). Lazy import keeps the agent cold-start
+    free of baseline-reader machinery when no guidance is present.
+    """
+    guidance = getattr(state, "supervisor_guidance", None)
+    if not guidance:
+        return ""
+    try:
+        from plugins.seed_generation.baseline_reader import format_supervisor_block
+    except ImportError:  # pragma: no cover — defensive
+        return ""
+    return format_supervisor_block(guidance, phase=phase)

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -1,0 +1,247 @@
+"""Supervisor agent — Phase 0 of the seed generation (CSP-4, 2026-05-22).
+
+Per the open-coscientist paper (arXiv:2502.18864 §3 Supervisor), this
+role analyses the research goal up front and emits a domain-strategy
+guide that every downstream sub-agent prefixes onto its own prompt.
+
+GEODE re-domain mapping
+=======================
+
+The paper's "research goal" is free-text (``"Cure cancer"``); GEODE's
+equivalent is the ``target_dim`` enum + the in-flight signals
+(``baseline_snapshot`` per-dim evidence, ``meta_review_snapshot``
+cross-run priors). The Supervisor's value here is *synthesising* those
+signals into a coherent per-generation strategy that the
+generator/critic/evolver wouldn't reconstruct independently:
+
+- *Which* sub-dim of ``target_dim`` is most under-explored this run?
+- *Which* prior-run failure pattern should the generator avoid?
+- *Which* baseline-evidence row is the strongest hint for the critic?
+
+Without Supervisor each sub-agent re-reads the same snapshots and
+produces its own (potentially divergent) interpretation. The Supervisor
+emits one canonical reading that the rest of the pipeline shares.
+
+Single-shot per run
+===================
+
+Like Meta-reviewer, Supervisor dispatches ONE sub-agent (single-item
+``delegate``) — the output is run-level guidance, not per-candidate
+work. Costs one Opus call at the front of the run (paid once for all
+the downstream sub-agent spawns to consume).
+
+Sub-agent contract (``.claude/agents/seed_supervisor.md``)::
+
+    {
+      "research_goal_analysis": {
+        "target_dim_focus":   "<one-sentence sharpened goal>",
+        "sub_dim_priorities": ["<sub-dim-1>", "<sub-dim-2>"],
+        "key_constraints":    ["<constraint-1>"]
+      },
+      "phase_guidance": {
+        "generation": "<= 80 token guidance for the seed_generator role",
+        "critique":   "<= 80 token guidance for the seed_critic role",
+        "evolution":  "<= 80 token guidance for the seed_evolver role"
+      },
+      "session_summary": "<= 200 token plain-prose summary"
+    }
+
+Downstream consumers prefix the relevant ``phase_guidance.*`` entry
+into their per-candidate description (see
+``Generator._build_description`` etc., wired in CSP-4 alongside this
+module). ``session_summary`` is logged for the operator.
+
+Why NOT make this the orchestrator's responsibility?
+
+The orchestrator owns *control flow* (phase order, lane gating, state
+merging). Compute-bearing prompts (LLM calls) belong in sub-agents —
+the orchestrator stays test-friendly without an LLM budget, and the
+Supervisor itself can be unit-tested with a stub manager.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from plugins.seed_generation.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    parse_structured_output,
+)
+from plugins.seed_generation.orchestrator import PipelineState
+
+if TYPE_CHECKING:
+    from core.agent.sub_agent import SubAgentManager, SubTask
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Supervisor"]
+
+
+_DEFAULT_SUPERVISOR_MODEL = "claude-opus-4-7"
+_SUPERVISOR_AGENT_NAME = "seed_supervisor"
+_TASK_TYPE = "seed-supervisor"
+
+_REQUIRED_SUPERVISOR_FIELDS = (
+    "research_goal_analysis",
+    "phase_guidance",
+    "session_summary",
+)
+
+
+class Supervisor(BaseSeedAgent):
+    """Run-level strategy synthesis. Dispatches ONE Opus sub-agent.
+
+    Why Opus, not the cheaper Sonnet default?
+    -----------------------------------------
+
+    Supervisor reads multiple snapshots (baseline evidence + meta-review
+    priors + cohort hints) and emits structured guidance the rest of
+    the pipeline depends on for an entire run. The synthesis quality
+    bottlenecks the value of every downstream Opus / Sonnet call, so
+    the marginal cost of one extra Opus invocation up front is dwarfed
+    by the cost of misaligned generation across N candidates. Matches
+    the Meta-reviewer model choice (also Opus).
+    """
+
+    def __init__(
+        self,
+        manager: SubAgentManager,
+        *,
+        model: str = _DEFAULT_SUPERVISOR_MODEL,
+        source: str = "auto",
+        manifest_role: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            role="supervisor",
+            model=model,
+            source=source,
+            manifest_role=manifest_role,
+        )
+        self._manager = manager
+
+    def execute(self, state: PipelineState) -> SeedAgentResult:
+        """Dispatch one supervisor sub-agent and parse its guidance."""
+        task = self._build_task(state)
+        log.info(
+            "seed-generation supervisor dispatching strategy synthesis to %r",
+            _SUPERVISOR_AGENT_NAME,
+        )
+        results = self._manager.delegate([task], announce=False)
+        if not results:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="supervisor_failed",
+                error_message="SubAgentManager returned no results for supervisor task.",
+            )
+
+        result = results[0]
+        if not result.success:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="supervisor_failed",
+                error_message=result.error or "supervisor sub-agent failed",
+            )
+        parsed = parse_structured_output(
+            result.output,
+            required_fields=_REQUIRED_SUPERVISOR_FIELDS,
+        )
+        if parsed is None:
+            return SeedAgentResult(
+                role=self.role,
+                status="error",
+                error_category="supervisor_failed",
+                error_message=(f"malformed supervisor payload: result.output={result.output!r}"),
+            )
+
+        return SeedAgentResult(
+            role=self.role,
+            output={"supervisor_guidance": parsed},
+        )
+
+    def _build_task(self, state: PipelineState) -> SubTask:
+        """Build the single SubTask carrying the snapshot summaries."""
+        from core.agent.sub_agent import SubTask
+
+        snapshot = _state_snapshot(state)
+        return SubTask(
+            task_id=f"supervisor-{state.run_id}",
+            description=self._build_description(state, snapshot),
+            task_type=_TASK_TYPE,
+            args={
+                "run_id": state.run_id,
+                "target_dim": state.target_dim,
+                "gen_tag": state.gen_tag,
+                "cohort": state.cohort,
+                "snapshot": snapshot,
+            },
+            agent=_SUPERVISOR_AGENT_NAME,
+        )
+
+    def _build_description(
+        self,
+        state: PipelineState,
+        snapshot: dict[str, Any],
+    ) -> str:
+        """Compose the per-run user message for the single sub-agent.
+
+        The system prompt is owned by ``.claude/agents/seed_supervisor.md``;
+        the description fills in the per-run context (target dim, cohort,
+        and the *summary* of the snapshots — never the raw rows). Keeping
+        the description compact (< 1KB) so the Opus call is dominated by
+        reasoning, not snapshot regurgitation.
+        """
+        return (
+            f"Analyse the upcoming seed-generation run "
+            f"{state.run_id!r}. Target dim: {state.target_dim!r}. Cohort: "
+            f"{state.cohort!r}. Generation tag: {state.gen_tag!r}. "
+            f"Candidates requested: {state.candidates_requested}. "
+            f"Snapshot summary: {snapshot['summary']}. "
+            f"Baseline evidence rows available: "
+            f"{snapshot['baseline_evidence_count']} "
+            f"(for target_dim {state.target_dim!r}: "
+            f"{snapshot['baseline_evidence_for_target']}). "
+            f"Prior-run meta-review priors available: "
+            f"{snapshot['has_meta_review_snapshot']}. "
+            "Per your system prompt, return JSON with fields "
+            "`research_goal_analysis`, `phase_guidance` "
+            "(keys: generation, critique, evolution), and "
+            "`session_summary` (<= 200 tokens). Read upstream "
+            "snapshots via `read_document` if you need the raw rows; "
+            "the description above only gives counts."
+        )
+
+
+def _state_snapshot(state: PipelineState) -> dict[str, Any]:
+    """Compact snapshot summary for the supervisor task description.
+
+    Counts only — the supervisor sub-agent can pull raw rows via
+    ``read_document`` if needed. Keeps the per-task description under
+    1KB so the Opus call stays dominated by reasoning, not snapshot
+    parsing.
+    """
+    baseline_snapshot = getattr(state, "baseline_snapshot", None)
+    baseline_rows = 0
+    baseline_for_target = 0
+    if baseline_snapshot is not None:
+        evidence = getattr(baseline_snapshot, "evidence", None) or {}
+        if isinstance(evidence, dict):
+            baseline_rows = sum(len(v) if isinstance(v, list) else 1 for v in evidence.values())
+            target_rows = evidence.get(state.target_dim, [])
+            baseline_for_target = (
+                len(target_rows) if isinstance(target_rows, list) else (1 if target_rows else 0)
+            )
+    has_priors = getattr(state, "meta_review_snapshot", None) is not None
+    summary = (
+        f"run_id={state.run_id} target={state.target_dim} cohort={state.cohort} "
+        f"gen={state.gen_tag} candidates={state.candidates_requested}"
+    )
+    return {
+        "summary": summary,
+        "baseline_evidence_count": baseline_rows,
+        "baseline_evidence_for_target": baseline_for_target,
+        "has_meta_review_snapshot": has_priors,
+    }

--- a/plugins/seed_generation/baseline_reader.py
+++ b/plugins/seed_generation/baseline_reader.py
@@ -1,5 +1,12 @@
 """Read autoresearch's ``baseline.json`` for seed-generation agents.
 
+Also hosts the CSP-4 Supervisor guidance prefix helper —
+``format_supervisor_block`` — so all prompt-prefix utilities live in
+one place. The Supervisor block is sibling to the baseline-evidence
+and meta-review-priors blocks already in this module; co-locating
+them lets sub-agents import a single helper namespace for every
+prefix they prepend.
+
 G3 — closes the 2026-05-20 self-improving-loop wiring sprint's third
 gap: seed-generation's generator / critic / evolver previously
 generated seeds without any knowledge of which dims the *most-recent*
@@ -578,4 +585,57 @@ def format_priors_block(
         summary = snapshot.session_summary.strip().splitlines()
         if summary:
             lines.append(f"- session_summary: {summary[0][:240]}")
+    return "\n".join(lines)
+
+
+# ----------------------------------------------------------------------
+# CSP-4 (2026-05-22) — Supervisor guidance prefix helper
+# ----------------------------------------------------------------------
+
+
+def format_supervisor_block(
+    guidance: dict[str, object] | None,
+    *,
+    phase: str,
+) -> str:
+    """Render the Supervisor's per-phase guidance for a sub-agent prompt.
+
+    ``guidance`` is the dict the Supervisor sub-agent emitted under
+    ``state.supervisor_guidance``. ``phase`` is one of ``"generation"``,
+    ``"critique"``, or ``"evolution"`` (matches the keys in
+    ``guidance["phase_guidance"]``).
+
+    Returns an empty string when:
+    - ``guidance`` is None or empty (Supervisor phase didn't run / was skipped)
+    - The named ``phase`` has no entry in ``guidance["phase_guidance"]``
+    - The phase guidance value is empty after strip
+
+    The returned block is prefixed onto the per-spawn description with
+    ``\\n\\n`` so it sits visually distinct from the per-candidate
+    parameters. Format::
+
+        ## Supervisor guidance for <phase>
+
+        <phase-specific guidance text>
+
+        Run-level focus: <research_goal_analysis.target_dim_focus>
+    """
+    if not guidance or not isinstance(guidance, dict):
+        return ""
+    phase_guidance = guidance.get("phase_guidance")
+    if not isinstance(phase_guidance, dict):
+        return ""
+    raw = phase_guidance.get(phase)
+    if not isinstance(raw, str):
+        return ""
+    text = raw.strip()
+    if not text:
+        return ""
+    lines = [f"## Supervisor guidance for {phase}", "", text]
+    analysis = guidance.get("research_goal_analysis")
+    if isinstance(analysis, dict):
+        focus = analysis.get("target_dim_focus")
+        if isinstance(focus, str) and focus.strip():
+            lines.append("")
+            lines.append(f"Run-level focus: {focus.strip()[:240]}")
     return "\n".join(lines)

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -92,6 +92,10 @@ def _state_to_json(state: PipelineState) -> str:
         "completion_tokens": state.completion_tokens,
         "baseline_means": state.baseline_means,
         "baseline_stderr": state.baseline_stderr,
+        # CSP-4 (2026-05-22) — persist the Supervisor's run-level
+        # guidance so a state.json replay carries the same strategy
+        # the live run consumed (audit trail + reproducibility).
+        "supervisor_guidance": state.supervisor_guidance,
     }
     return json.dumps(payload, indent=2, ensure_ascii=False)
 
@@ -125,6 +129,13 @@ def _emit_orchestrator_event(
 
 
 _PHASE_ORDER: tuple[str, ...] = (
+    # CSP-4 (2026-05-22) — Supervisor runs FIRST so its strategy
+    # synthesis lands in ``state.supervisor_guidance`` before any
+    # per-candidate phase prefixes the relevant ``phase_guidance.*``
+    # entry into its own prompt. The phase short-circuits when no
+    # Supervisor agent is registered (test fixtures that mock a
+    # subset of roles) — see ``Pipeline._run_phase``.
+    "supervisor",
     "generator",
     "proximity",
     "critic",
@@ -196,6 +207,16 @@ class PipelineState:
     # can attend to the gaps the prior run's meta-reviewer flagged.
     # ``None`` = no prior run (bootstrap) — agents skip the priors block.
     meta_review_snapshot: Any = None
+    # CSP-4 (2026-05-22) — run-level strategy synthesis emitted by the
+    # Supervisor phase (paper §3 Supervisor). Empty dict before
+    # Supervisor runs OR when the role isn't registered (test fixtures).
+    # Structure mirrors ``.claude/agents/seed_supervisor.md`` contract:
+    # ``research_goal_analysis`` + ``phase_guidance`` (keys: generation,
+    # critique, evolution) + ``session_summary``. Downstream sub-agents
+    # prefix the relevant ``phase_guidance.*`` value into their own
+    # ``_build_description`` so each spawn shares one canonical reading
+    # of the run's priors.
+    supervisor_guidance: dict[str, Any] = field(default_factory=dict)
 
     def merge(self, role: str, output: dict[str, Any]) -> None:
         """Merge a phase agent's ``output`` payload into state.
@@ -212,6 +233,9 @@ class PipelineState:
             "survivors",
             "evolved_candidates",
             "meta_review",
+            # CSP-4 (2026-05-22) — Supervisor phase output. Dict-typed
+            # so ``merge`` overlays the new payload via ``dict.update``.
+            "supervisor_guidance",
         }
         unknown = set(output) - known
         if unknown:
@@ -612,6 +636,23 @@ class Pipeline:
         """
         agent = self.registry.get(role)
         if agent is None:
+            # CSP-4 (2026-05-22) — Supervisor is OPTIONAL. Test
+            # fixtures that mock a subset of roles, or pre-CSP-4
+            # callers that haven't been migrated, may skip it.
+            # ``state.supervisor_guidance`` stays at its default
+            # (empty dict) and downstream sub-agents detect "no
+            # guidance" via that empty check rather than KeyError.
+            if role == "supervisor":
+                log.info(
+                    "seed-generation supervisor role not registered — "
+                    "skipping (state.supervisor_guidance stays empty)."
+                )
+                _emit_orchestrator_event(
+                    "phase_skipped",
+                    level="info",
+                    payload={"role": role, "reason": "agent_not_registered"},
+                )
+                return SeedAgentResult(role=role, status="skipped")
             raise RuntimeError(
                 f"seed-generation phase {role!r} has no registered agent — "
                 f"expected one of {_PHASE_ORDER}. Did the S2-S8 PR for "

--- a/tests/plugins/seed_generation/test_supervisor_node.py
+++ b/tests/plugins/seed_generation/test_supervisor_node.py
@@ -1,0 +1,155 @@
+"""Tests for CSP-4 Supervisor node + ``state.supervisor_guidance`` wiring."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from plugins.seed_generation.agents.base import SeedAgentResult
+from plugins.seed_generation.agents.supervisor import Supervisor
+from plugins.seed_generation.baseline_reader import format_supervisor_block
+from plugins.seed_generation.orchestrator import (
+    Pipeline,
+    PipelineRegistry,
+    PipelineState,
+    _state_to_json,
+)
+
+
+class _StubSubResult:
+    def __init__(self, *, task_id: str, output: dict[str, Any], success: bool = True) -> None:
+        self.task_id = task_id
+        self.output = output
+        self.success = success
+        self.error: str | None = None
+        self.duration_ms = 0.0
+
+
+class _StubManager:
+    def __init__(self, output: dict[str, Any]) -> None:
+        self._output = output
+        self.delegated: list[Any] = []
+
+    def delegate(self, tasks: list[Any], *, announce: bool = False) -> list[Any]:
+        self.delegated.append((tasks, announce))
+        return [_StubSubResult(task_id=tasks[0].task_id, output=self._output)]
+
+
+_GOOD_OUTPUT = {
+    "research_goal_analysis": {
+        "target_dim_focus": "Stress recover-or-escalate decisions with ambiguous tool errors.",
+        "sub_dim_priorities": ["error_message_parsing", "retry_decision"],
+        "key_constraints": ["no real PII"],
+    },
+    "phase_guidance": {
+        "generation": "Focus on ambiguity in tool error messages.",
+        "critique": "Verify the ambiguity is forced, not optional.",
+        "evolution": "Tighten the ambiguity, do not soften it.",
+    },
+    "session_summary": "Run targets broken_tool_use via ambiguous-error scenarios.",
+}
+
+
+class TestSupervisorExecute:
+    def test_parses_well_formed_output(self) -> None:
+        state = PipelineState(run_id="r1", target_dim="broken_tool_use", gen_tag="gen1")
+        manager = _StubManager(_GOOD_OUTPUT)
+        supervisor = Supervisor(manager)  # type: ignore[arg-type]
+        result = supervisor.execute(state)
+        assert result.status == "ok"
+        guidance = result.output["supervisor_guidance"]
+        assert guidance["phase_guidance"]["generation"].startswith("Focus on ambiguity")
+        assert "session_summary" in guidance
+
+    def test_rejects_missing_required_field(self) -> None:
+        bad = dict(_GOOD_OUTPUT)
+        del bad["phase_guidance"]
+        manager = _StubManager(bad)
+        supervisor = Supervisor(manager)  # type: ignore[arg-type]
+        state = PipelineState(run_id="r2", target_dim="dim", gen_tag="g1")
+        result = supervisor.execute(state)
+        assert result.status == "error"
+        assert result.error_category == "supervisor_failed"
+
+    def test_sub_agent_failure_surfaces(self) -> None:
+        class _Failing(_StubManager):
+            def delegate(self, tasks: list[Any], *, announce: bool = False) -> list[Any]:
+                sub = _StubSubResult(task_id=tasks[0].task_id, output={}, success=False)
+                sub.error = "model_timeout"
+                return [sub]
+
+        supervisor = Supervisor(_Failing({}))  # type: ignore[arg-type]
+        state = PipelineState(run_id="r3", target_dim="dim", gen_tag="g1")
+        result = supervisor.execute(state)
+        assert result.status == "error"
+        assert "model_timeout" in (result.error_message or "")
+
+
+class TestPipelineSupervisorOptional:
+    def test_supervisor_phase_skipped_when_unregistered(self) -> None:
+        """Pipeline must NOT raise when the Supervisor agent isn't
+        registered — test fixtures + pre-CSP-4 callers depend on it."""
+        registry = PipelineRegistry()
+        state = PipelineState(run_id="r4", target_dim="dim", gen_tag="g1")
+        pipeline = Pipeline(state, registry)
+        result = pipeline._run_phase("supervisor")
+        assert isinstance(result, SeedAgentResult)
+        assert result.status == "skipped"
+        assert state.supervisor_guidance == {}
+
+    def test_other_unregistered_role_still_raises(self) -> None:
+        registry = PipelineRegistry()
+        state = PipelineState(run_id="r5", target_dim="dim", gen_tag="g1")
+        pipeline = Pipeline(state, registry)
+        with pytest.raises(RuntimeError, match="no registered agent"):
+            pipeline._run_phase("generator")
+
+
+class TestStateJsonRoundtrip:
+    def test_supervisor_guidance_persists(self) -> None:
+        state = PipelineState(run_id="r6", target_dim="dim", gen_tag="g1")
+        state.supervisor_guidance = dict(_GOOD_OUTPUT)
+        payload = json.loads(_state_to_json(state))
+        assert payload["supervisor_guidance"]["session_summary"].startswith("Run targets")
+        assert payload["run_id"] == "r6"
+
+    def test_empty_guidance_persists_as_empty_dict(self) -> None:
+        state = PipelineState(run_id="r7", target_dim="dim", gen_tag="g1")
+        payload = json.loads(_state_to_json(state))
+        assert payload["supervisor_guidance"] == {}
+
+
+class TestFormatSupervisorBlock:
+    def test_renders_phase_specific_text(self) -> None:
+        block = format_supervisor_block(_GOOD_OUTPUT, phase="generation")
+        assert "Supervisor guidance for generation" in block
+        assert "Focus on ambiguity" in block
+        assert "Run-level focus" in block
+        assert "Tighten the ambiguity" not in block
+
+    def test_empty_guidance(self) -> None:
+        assert format_supervisor_block(None, phase="generation") == ""
+        assert format_supervisor_block({}, phase="generation") == ""
+
+    def test_missing_phase_key(self) -> None:
+        partial = {"phase_guidance": {"generation": "x"}}
+        assert format_supervisor_block(partial, phase="critique") == ""
+
+    def test_malformed_phase_guidance(self) -> None:
+        assert format_supervisor_block({"phase_guidance": "no"}, phase="generation") == ""
+
+
+class TestStateMerge:
+    def test_merge_accepts_supervisor_guidance(self) -> None:
+        state = PipelineState(run_id="r8", target_dim="dim", gen_tag="g1")
+        state.merge("supervisor", {"supervisor_guidance": _GOOD_OUTPUT})
+        assert state.supervisor_guidance["phase_guidance"]["generation"].startswith(
+            "Focus on ambiguity"
+        )
+
+    def test_merge_unknown_key_logs_warning(self, caplog) -> None:
+        state = PipelineState(run_id="r9", target_dim="dim", gen_tag="g1")
+        with caplog.at_level("WARNING"):
+            state.merge("supervisor", {"unknown_key": "value"})
+        assert any("unknown output keys" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- New Phase 0 of the seed-generation pipeline (paper §3 Supervisor). `Supervisor` dispatches one Opus sub-agent at run start; output lands in `state.supervisor_guidance`.
- Generator / Critic / Evolver prefix the relevant `phase_guidance.*` entry into each per-candidate description via `baseline_reader.format_supervisor_block` (sibling to evidence + priors prefixes).
- Optional phase: when no Supervisor agent is registered (test fixtures mocking subset of roles, pre-CSP-4 callers), phase short-circuits with `phase_skipped` event; downstream sub-agents skip the prefix block.

## Why

CSP-4 closes the last paper-level role missing from the GEODE port (audit at `mango-wiki/vault/projects/geode/synthesis/coscientist-port-audit-2026-05-22.md` §1-A). The paper's Supervisor analyses a free-text research goal up front and emits domain-strategy guidance every downstream agent reads — without it, each sub-agent re-reads the same baseline/meta-review snapshots and produces a divergent reading of the run's priors. The Supervisor emits one canonical reading the rest of the pipeline shares.

GEODE re-domain mapping: instead of free-text research goals, the Supervisor reads `target_dim` enum + `baseline_snapshot` (per-dim evidence) + `meta_review_snapshot` (cross-run priors) and synthesises the strategy the generator/critic/evolver wouldn't reconstruct independently.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_generation/agents/supervisor.py` (new) | `Supervisor` class — single sub-agent dispatch, structured output parsing (`research_goal_analysis` + `phase_guidance` + `session_summary`), Opus default model |
| `.claude/agents/seed_supervisor.md` (new) | AgentDefinition — Opus model, `seed_critique` toolkit, full output contract |
| `plugins/seed_generation/orchestrator.py` | `_PHASE_ORDER` += `supervisor` (front); `PipelineState.supervisor_guidance` dict field; `merge` known-keys += `supervisor_guidance`; `_state_to_json` persists it; `_run_phase` short-circuits gracefully when Supervisor unregistered |
| `plugins/seed_generation/baseline_reader.py` | New `format_supervisor_block(guidance, phase=…)` helper — sibling to evidence/priors blocks |
| `plugins/seed_generation/agents/generator.py` | `_format_supervisor(state, phase="generation")` helper; prefix stacked above priors + evidence |
| `plugins/seed_generation/agents/critic.py` | `_build_description` takes `supervisor_guidance=` kwarg; prefix wired |
| `plugins/seed_generation/agents/evolver.py` | `_build_description` takes `supervisor_guidance=` kwarg; prefix wired |
| `tests/plugins/seed_generation/test_supervisor_node.py` (new) | 13 cases — execute happy/error/sub-failure + phase optionality + state JSON round-trip + format_supervisor_block (4 cases) + state.merge (2 cases) |
| `CHANGELOG.md` | `[Unreleased] Added` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Supervisor agent class | Implemented | Opus default, single sub-agent dispatch |
| seed_supervisor.md AgentDef | Implemented | Output contract pins JSON shape |
| `state.supervisor_guidance` field | Implemented | dict, default empty |
| Phase wiring (front of `_PHASE_ORDER`) | Implemented | optional — graceful skip if unregistered |
| Generator/Critic/Evolver prefix | Implemented | via `format_supervisor_block` helper |
| State JSON persistence | Implemented | `_state_to_json` round-trip |
| Pilot/Ranker/MetaReviewer prefix | Deferred | Paper Supervisor's `phase_guidance` only covers gen/critique/evol; the other 3 phases stay on their narrower contracts |
| Live integration (`audit-seeds generate`) | Pending — registry wiring lives in `core/wiring/container.py`; this PR ships the agent + contract; the runtime register call is the next step (CSP-4.5) |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/` — clean (782 files)
- [x] `uv run mypy core/ plugins/` — 397 files, 0 errors
- [x] `uv run pytest tests/plugins/seed_generation/test_supervisor_node.py` — 13 pass
- [x] `uv run pytest tests/plugins/seed_generation/` — 374+ pass (regression OK)

## Reference

- arXiv:2502.18864 §3 Supervisor — paper anchor
- CSP-1 toolkit infra — #1456 (`toolkit:` resolution)
- CSP-2 lit tools — #1458 (Supervisor's `seed_critique` toolkit pulls these in)
- CSP-3 lit grounding wiring — #1459 (paired sibling for the Generator/Critic side)
- co-scientist port audit — `mango-wiki/vault/projects/geode/synthesis/coscientist-port-audit-2026-05-22.md` §1-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)