### PR TITLE
PR-CSA-1 — paperclip-pattern claude-cli inspect_ai provider (text-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,41 @@ functional change.
 
 ### Added
 
+- **PR-CSA-1 — paperclip-pattern claude-cli provider (text-only, judge role).**
+  Pattern B subscription audit 의 OAuth raw-SDK 경로가 100% 429 enforcement
+  맞는 진단 (trace-68931.log: 27/27 requests 429, retry-after 770 sec) 후
+  paperclip pattern (`~/workspace/paperclip/packages/adapters/claude-local/
+  src/server/execute.ts:679` 검증) 차용. **신규 inspect_ai 프로바이더**
+  `plugins/petri_audit/claude_cli_provider.py::ClaudeCliAPI` —
+  `@modelapi(name="claude-cli")` 로 등록. Identifier shape `claude-cli/
+  <model>`. 매 `generate()` 호출당 `claude --print - --output-format
+  stream-json --verbose --model <m> --max-turns 1` subprocess spawn,
+  stdin 으로 ChatMessage 시리얼라이즈 (role-header sentinels), stdout
+  stream-json events 파싱 → `ModelOutput` 빌드. OAuth header 는 claude
+  CLI 가 내부 처리 (`claude-code-20250219`, `oauth-2025-04-20`, session-
+  aware) — 우리는 stdin/stdout 만 다룸. **CSA-1 boundary**: tool-use 미지원
+  (`generate(tools=[...])` → `NotImplementedError("tool_use deferred to
+  CSA-2 MCP bridge")`). judge role 처리 충분 (judge 는 custom tool 안 씀).
+  CSA-2 가 MCP bridge 로 auditor 활성화. **신규 모듈 (~570 LOC)** —
+  `_resolve_claude_binary` (env `GEODE_CLAUDE_CLI_BIN` > PATH),
+  `_resolve_timeout_s` (env `GEODE_CLAUDE_CLI_TIMEOUT_S`),
+  `build_claude_cli_argv` (MCP / allowed-tools / extra-args 인자 — CSA-2
+  까지 forward-compat), `serialise_messages_to_prompt`, `parse_stream_json_
+  events`, `_extract_assistant_text` (delta 우선 + result fallback),
+  `_extract_stop_reason` (end_turn→stop / tool_use→tool_calls 매핑),
+  `_extract_usage` (input/output/cache 4 필드), `_run_claude_subprocess`
+  (asyncio + timeout). **__init__ hook** — `plugins/petri_audit/__init__.py`
+  의 try/except register 추가 (audit extra 부재시 graceful skip).
+  **37 invariant test** — binary x4 / timeout x3 / argv x5 / serialiser x4
+  / parser x4 / text x2 / stop_reason x4 / usage x2 / subprocess x4 /
+  provider+boundary+round-trip x5. Quality gates clean (ruff + ruff
+  format --check + mypy + 37/37 pytest). **Operator surface (CSA-1)**:
+  manual opt-in via `claude-cli/<model>` identifier in inspect eval argv.
+  Default config 라우팅 (manifest `[petri.adapter.anthropic.claude-cli]
+  inspect_prefix`) flip 은 CSA-3 (MCP bridge 후) 로 deferred — 안전한 점진
+  롤아웃.
+
+
 - **Supervisor phase — run-level strategy synthesis (CSP-4)** — New
   Phase 0 of the seed-generation pipeline (paper §3 Supervisor).
   `plugins/seed_generation/agents/supervisor.py` dispatches one Opus

--- a/plugins/petri_audit/__init__.py
+++ b/plugins/petri_audit/__init__.py
@@ -87,4 +87,20 @@ except ImportError:
         exc_info=True,
     )
 
+# CSA-1 (2026-05-22) — register the ``claude-cli`` ModelAPI for the
+# paperclip-pattern adapter. Routes ``claude-cli/<model>`` ids through
+# ``claude --print`` subprocess (per-call). Avoids the raw-SDK + OAuth
+# 100% 429 enforcement that breaks ``claude-code/`` path on Claude Max
+# OAuth subscription. CSA-1 ships text-only generate (judge role);
+# CSA-2 will add MCP bridge for tool-use (auditor role).
+try:
+    from plugins.petri_audit.claude_cli_provider import register as _register_claude_cli
+
+    _register_claude_cli()
+except ImportError:
+    _logging.getLogger(__name__).debug(
+        "petri_audit claude-cli ModelAPI registration deferred — [audit] extra not installed",
+        exc_info=True,
+    )
+
 __all__: list[str] = []

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -1,0 +1,555 @@
+"""Paperclip-pattern adapter — inspect_ai provider that invokes
+``claude --print`` subprocess for every ``generate()`` call.
+
+CSA-1 (2026-05-22) — scaffold + text-only generate (judge role).
+
+Why this exists
+===============
+
+The existing ``ClaudeOAuthAPI`` (``claude_code_provider.py``) routes
+inspect_ai's ``/v1/messages`` calls through the raw Anthropic Python
+SDK using the OAuth token as ``x-api-key``. Empirically this triggers
+**100% 429 enforcement** even on the very first request (verified
+2026-05-22 in ``trace-68931.log`` — 27/27 requests 429, exponential
+backoff to 770 sec). The same OAuth token works perfectly when used by
+the ``claude`` CLI binary (smoke verified: ``claude --print "Hi"``
+returns 3.9s, $0.18).
+
+The diagnosis: Anthropic gateway distinguishes "OAuth token via raw
+SDK" (rate-limited) from "OAuth token via Claude Code CLI" (full
+subscription tier). The CLI sends session-aware headers (``claude-
+code-session-id``, ``x-stainless-helper-method``, anthropic-beta
+bundle) that we cannot easily replicate from Python.
+
+Paperclip's solution (verified in
+``~/workspace/paperclip/packages/adapters/claude-local/src/server/
+execute.ts:679``): spawn ``claude --print`` per inference call and
+parse the ``stream-json`` output. No raw SDK calls.
+
+This module mirrors that pattern for inspect_ai. Each
+``generate()`` call:
+
+1. Builds argv: ``claude --print - --output-format stream-json --verbose
+   --model <m> --max-turns 1 [--mcp-config ...]``
+2. Serialises ``inspect_ai.ChatMessage[]`` into a single prompt string
+   (system / user / assistant turns concatenated with role headers).
+3. Spawns the subprocess via ``asyncio.create_subprocess_exec`` —
+   stdin gets the prompt, stdout the stream-json events.
+4. Parses event stream → ``ChatMessageAssistant.content`` + usage
+   counts + stop_reason.
+5. Returns ``ModelOutput`` to inspect_ai's harness.
+
+CSA-1 scope
+===========
+
+This PR ships the **text-only** path:
+
+* Provider scaffold + ``@modelapi("claude-cli")`` registration.
+* argv builder + stdin serialiser + stream-json parser.
+* ``ModelOutput`` construction (content / usage / stop_reason).
+* No tool support — ``generate()`` with non-empty ``tools`` raises
+  ``NotImplementedError("tool_use deferred to CSA-2 MCP bridge")``.
+
+This is sufficient for the **judge role** (the audit's scoring
+role) which does not call custom tools. Auditor role (which uses
+inspect_petri's ``send_message`` + ``recommend_termination``) is
+deferred to CSA-2 where MCP bridge wires the tool path.
+
+Operator surface
+================
+
+inspect_ai picks up the provider when the model id is prefixed with
+``claude-cli/`` (e.g. ``claude-cli/claude-opus-4-7``). The
+``to_inspect_model`` router in ``models.py`` flips
+``source="claude-cli"`` configs to this prefix automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "CLAUDE_CLI_BIN_ENV",
+    "CLAUDE_CLI_MODEL_NOT_FOUND",
+    "CLAUDE_CLI_SUBPROCESS_TIMEOUT_S",
+    "ClaudeCliInvocationError",
+    "build_claude_cli_argv",
+    "parse_stream_json_events",
+    "register",
+    "serialise_messages_to_prompt",
+]
+
+
+CLAUDE_CLI_BIN_ENV = "GEODE_CLAUDE_CLI_BIN"
+"""Operator override for the ``claude`` binary path. When unset, the
+provider uses :func:`shutil.which("claude")`."""
+
+_DEFAULT_CLAUDE_BIN = "claude"
+
+CLAUDE_CLI_SUBPROCESS_TIMEOUT_S = 600.0
+"""10-minute hard ceiling per subprocess invocation. inspect_ai's
+``--max-turns 1`` keeps the LLM emission bounded, but a stalled
+network / dead Claude Code session needs an upper bound. Operators
+who need longer (e.g. extended thinking on large prompts) bump this
+via ``GEODE_CLAUDE_CLI_TIMEOUT_S`` env."""
+
+CLAUDE_CLI_TIMEOUT_ENV = "GEODE_CLAUDE_CLI_TIMEOUT_S"
+
+CLAUDE_CLI_MODEL_NOT_FOUND = "claude-cli-model-not-found"
+"""Sentinel for the metadata field surfaced when claude CLI rejects
+the model id (operator typo / model deprecated). Sliced over to
+inspect_ai's ``ModelOutput.metadata`` so downstream telemetry can
+spot the failure mode without scraping stderr."""
+
+
+class ClaudeCliInvocationError(RuntimeError):
+    """Raised when the ``claude`` binary cannot be located, the
+    subprocess exits non-zero, or stream-json output is unparseable.
+
+    Carries enough operator context (returncode + stderr clip) to
+    diagnose without re-running the audit. inspect_ai's harness
+    wraps this into a ``ModelEvent`` with the error string visible
+    in the Inspect viewer."""
+
+
+@dataclass(frozen=True, slots=True)
+class StreamJsonEvent:
+    """One row of ``claude --print --output-format stream-json``.
+
+    Wraps the raw dict so callers (test fixtures, parser) treat the
+    event stream as a typed sequence. We accept ANY ``type`` field
+    value — claude CLI may emit new event types in future versions
+    and the parser should tolerate the addition (forward-compat).
+    """
+
+    type: str
+    payload: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Binary resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_claude_binary() -> str:
+    """Return absolute path to the ``claude`` binary or raise
+    :class:`ClaudeCliInvocationError`.
+
+    Resolution order (Codex CLI / paperclip parity):
+      1. ``$GEODE_CLAUDE_CLI_BIN`` env override (operator pins).
+      2. ``shutil.which("claude")`` (PATH lookup).
+    """
+    override = os.environ.get(CLAUDE_CLI_BIN_ENV)
+    if override:
+        if shutil.which(override) is None and not os.path.isfile(override):
+            raise ClaudeCliInvocationError(
+                f"{CLAUDE_CLI_BIN_ENV}={override!r} but no executable at that path. "
+                "Set to the full path of the `claude` binary or unset to use PATH."
+            )
+        return override
+    found = shutil.which(_DEFAULT_CLAUDE_BIN)
+    if not found:
+        raise ClaudeCliInvocationError(
+            "`claude` binary not found on PATH. Install Claude Code "
+            "(https://docs.anthropic.com/claude/docs/claude-code) or set "
+            f"{CLAUDE_CLI_BIN_ENV} to the full path."
+        )
+    return found
+
+
+def _resolve_timeout_s() -> float:
+    """Env override for subprocess timeout. Operators bump for long
+    extended-thinking calls. Defaults to module constant."""
+    raw = os.environ.get(CLAUDE_CLI_TIMEOUT_ENV)
+    if not raw:
+        return CLAUDE_CLI_SUBPROCESS_TIMEOUT_S
+    try:
+        return max(1.0, float(raw))
+    except ValueError:
+        log.warning(
+            "%s=%r not a number; using default %.0fs",
+            CLAUDE_CLI_TIMEOUT_ENV,
+            raw,
+            CLAUDE_CLI_SUBPROCESS_TIMEOUT_S,
+        )
+        return CLAUDE_CLI_SUBPROCESS_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# argv builder
+# ---------------------------------------------------------------------------
+
+
+def build_claude_cli_argv(
+    *,
+    binary: str,
+    model_name: str,
+    max_turns: int = 1,
+    mcp_config_path: str | None = None,
+    allowed_tools: list[str] | None = None,
+    extra_args: Iterable[str] | None = None,
+) -> list[str]:
+    """Construct the ``claude --print`` argv.
+
+    Args:
+        binary: Absolute path to ``claude``.
+        model_name: Anthropic model id (e.g. ``claude-opus-4-7``).
+            Passed via ``--model`` so the CLI respects per-call
+            routing instead of its default.
+        max_turns: ``--max-turns`` cap. Defaults to 1 because
+            inspect_ai expects ``generate()`` to return after one
+            turn (it owns the iteration loop).
+        mcp_config_path: ``--mcp-config`` JSON path. ``None`` skips
+            MCP server registration — CSA-2 wires this for the
+            tool-use case.
+        allowed_tools: Whitelist of tool names (``["mcp__<server>__
+            <tool>", ...]``) when MCP is used. Pairs with
+            ``mcp_config_path``.
+        extra_args: Additional flags to append (test injection,
+            operator hooks). Validated only by claude CLI itself.
+
+    The output format is pinned to ``stream-json`` + ``--verbose`` —
+    we need every event to construct ``ModelOutput`` faithfully.
+    """
+    argv: list[str] = [
+        binary,
+        "--print",
+        "-",  # read prompt from stdin
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        model_name,
+        "--max-turns",
+        str(max_turns),
+    ]
+    if mcp_config_path:
+        argv += ["--mcp-config", mcp_config_path, "--strict-mcp-config"]
+    if allowed_tools:
+        # CLI flag accepts space-or-comma-separated list.
+        argv += ["--allowed-tools", ",".join(allowed_tools)]
+    if extra_args:
+        argv += list(extra_args)
+    return argv
+
+
+# ---------------------------------------------------------------------------
+# Message serialisation
+# ---------------------------------------------------------------------------
+
+
+_ROLE_HEADERS = {
+    "system": "<<<SYSTEM>>>",
+    "user": "<<<USER>>>",
+    "assistant": "<<<ASSISTANT>>>",
+    "tool": "<<<TOOL_RESULT>>>",
+}
+
+
+def serialise_messages_to_prompt(messages: list[Any]) -> str:
+    """Flatten ``inspect_ai.ChatMessage[]`` into a single stdin prompt.
+
+    The ``claude --print`` CLI accepts one prompt over stdin and
+    handles its own system-message setup internally. We preserve
+    multi-turn context by joining role-tagged blocks with sentinels.
+
+    The role-header sentinels (``<<<USER>>>`` etc.) are intentionally
+    visible — the LLM treats them as conversational scaffolding. For
+    inspect_petri's auditor that orchestrates multi-turn dialogues,
+    this matches the existing transcript style.
+
+    Accepts duck-typed messages with ``role`` + ``content`` attrs
+    (pydantic BaseModel) so tests can pass plain SimpleNamespace
+    without importing the inspect_ai ChatMessage classes.
+    """
+    parts: list[str] = []
+    for msg in messages:
+        role = getattr(msg, "role", "user")
+        header = _ROLE_HEADERS.get(role, f"<<<{role.upper()}>>>")
+        content = getattr(msg, "content", "")
+        # Normalise content shape — inspect_ai uses str OR list[Content]
+        # where Content has ``.text`` (text blocks). Tool blocks are
+        # ignored in CSA-1 (CSA-2 handles them).
+        text_chunks: list[str] = []
+        if isinstance(content, str):
+            text_chunks.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                block_text = getattr(block, "text", None)
+                if isinstance(block_text, str):
+                    text_chunks.append(block_text)
+        parts.append(f"{header}\n{''.join(text_chunks).rstrip()}")
+    return "\n\n".join(parts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# stream-json parser
+# ---------------------------------------------------------------------------
+
+
+def parse_stream_json_events(stdout: str) -> list[StreamJsonEvent]:
+    """Parse the ``claude --print --output-format stream-json --verbose``
+    stdout into a list of :class:`StreamJsonEvent`.
+
+    Each line is a JSON object with a ``type`` field. Malformed lines
+    are silently skipped (forward-compat: claude CLI may emit non-JSON
+    debug lines under certain conditions). An empty stdout returns an
+    empty list — caller decides whether that's a failure.
+    """
+    events: list[StreamJsonEvent] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            log.debug("claude-cli: skipping non-JSON stdout line: %r", line[:200])
+            continue
+        if not isinstance(row, dict):
+            continue
+        event_type = row.get("type", "")
+        if not isinstance(event_type, str):
+            event_type = ""
+        events.append(StreamJsonEvent(type=event_type, payload=row))
+    return events
+
+
+def _extract_assistant_text(events: list[StreamJsonEvent]) -> str:
+    """Concatenate the assistant text from a stream-json event sequence.
+
+    Looks for ``content_block_delta`` events with ``delta.type ==
+    "text_delta"`` (canonical claude CLI streaming shape) AND for the
+    terminal ``result`` event's ``result`` field (a single-shot
+    fallback some CLI versions emit). The first non-empty source wins.
+    """
+    chunks: list[str] = []
+    for event in events:
+        if event.type == "content_block_delta":
+            delta = event.payload.get("delta", {})
+            if isinstance(delta, dict) and delta.get("type") == "text_delta":
+                text = delta.get("text", "")
+                if isinstance(text, str):
+                    chunks.append(text)
+    if chunks:
+        return "".join(chunks)
+    # Fallback — `result` event carries the final text directly
+    for event in events:
+        if event.type == "result":
+            text = event.payload.get("result", "")
+            if isinstance(text, str) and text:
+                return text
+    return ""
+
+
+def _extract_stop_reason(events: list[StreamJsonEvent]) -> str:
+    """Map claude CLI ``stop_reason`` → inspect_ai canonical labels.
+
+    inspect_ai uses ``"stop" | "max_tokens" | "tool_calls" | ...``
+    while claude CLI emits ``"end_turn" | "tool_use" | "max_tokens" |
+    "stop_sequence"``. We translate the common pairs.
+    """
+    raw: str | None = None
+    for event in events:
+        if event.type == "message_delta":
+            delta = event.payload.get("delta", {})
+            if isinstance(delta, dict):
+                stop = delta.get("stop_reason")
+                if isinstance(stop, str):
+                    raw = stop
+                    break
+        if event.type == "result":
+            stop = event.payload.get("stop_reason")
+            if isinstance(stop, str):
+                raw = stop
+                break
+    if raw is None:
+        return "unknown"
+    mapping = {
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "max_tokens",
+    }
+    return mapping.get(raw, "unknown")
+
+
+def _extract_usage(events: list[StreamJsonEvent]) -> dict[str, int]:
+    """Sum input/output tokens across the event stream.
+
+    claude CLI emits ``usage`` on multiple events (``message_start``,
+    ``message_delta``, ``result``) — the most authoritative copy is on
+    the terminal ``result`` event when ``--verbose`` is set.
+    """
+    for event in reversed(events):
+        if event.type == "result":
+            usage = event.payload.get("usage", {})
+            if isinstance(usage, dict):
+                return {
+                    "input_tokens": int(usage.get("input_tokens") or 0),
+                    "output_tokens": int(usage.get("output_tokens") or 0),
+                    "cache_read_input_tokens": int(usage.get("cache_read_input_tokens") or 0),
+                    "cache_creation_input_tokens": int(
+                        usage.get("cache_creation_input_tokens") or 0
+                    ),
+                }
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subprocess runner
+# ---------------------------------------------------------------------------
+
+
+async def _run_claude_subprocess(
+    argv: list[str], stdin_text: str, timeout_s: float
+) -> tuple[str, str, int]:
+    """Spawn ``claude`` subprocess, pipe stdin, capture stdout+stderr.
+
+    Returns ``(stdout, stderr, returncode)``. Raises
+    :class:`ClaudeCliInvocationError` on timeout or process spawn
+    failure (NOT on non-zero returncode — caller decides).
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        raise ClaudeCliInvocationError(f"failed to spawn `claude`: {exc!r}") from exc
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(stdin_text.encode("utf-8")),
+            timeout=timeout_s,
+        )
+    except TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise ClaudeCliInvocationError(
+            f"claude subprocess timed out after {timeout_s:.0f}s"
+        ) from exc
+    return (
+        stdout_b.decode("utf-8", errors="replace"),
+        stderr_b.decode("utf-8", errors="replace"),
+        proc.returncode or 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider registration
+# ---------------------------------------------------------------------------
+
+
+if TYPE_CHECKING:  # pragma: no cover — import-only for type hints
+    pass
+
+
+def register() -> None:
+    """Register ``@modelapi(name="claude-cli")`` with inspect_ai.
+
+    Called from ``plugins/petri_audit/__init__.py`` at plugin load
+    time so the provider is available when inspect_ai resolves a
+    ``claude-cli/<model>`` id.
+    """
+    from inspect_ai.model import GenerateConfig, ModelOutput, modelapi
+    from inspect_ai.model._chat_message import ChatMessageAssistant
+    from inspect_ai.model._model import ModelAPI
+    from inspect_ai.model._model_output import ChatCompletionChoice, ModelUsage
+
+    @modelapi(name="claude-cli")
+    class ClaudeCliAPI(ModelAPI):
+        """inspect_ai provider that delegates to ``claude --print``.
+
+        Identifier shape: ``claude-cli/<model-id>``. inspect_ai's
+        router strips the ``claude-cli/`` prefix and instantiates this
+        class with ``model_name=<model-id>``.
+        """
+
+        def __init__(
+            self,
+            model_name: str,
+            base_url: str | None = None,
+            api_key: str | None = None,
+            api_key_vars: list[str] | None = None,
+            config: Any = None,
+            **model_args: Any,
+        ) -> None:
+            super().__init__(
+                model_name=model_name,
+                base_url=base_url,
+                api_key=api_key,
+                api_key_vars=api_key_vars or [],
+                config=config or GenerateConfig(),
+            )
+            self._binary = _resolve_claude_binary()
+            self._timeout_s = _resolve_timeout_s()
+            self._model_args = model_args
+
+        async def generate(
+            self,
+            input: Any,  # list[ChatMessage]
+            tools: Any,  # list[ToolInfo]
+            tool_choice: Any,  # ToolChoice
+            config: Any,  # GenerateConfig
+        ) -> Any:  # ModelOutput
+            if tools:
+                # CSA-1 ships text-only. Tool support requires the MCP
+                # bridge layer (CSA-2). Raising NotImplementedError
+                # lets inspect_ai surface the boundary instead of
+                # silently dropping tools.
+                raise NotImplementedError(
+                    "claude-cli provider: tool_use deferred to CSA-2 "
+                    "(MCP bridge). Use claude-code/ provider for now if "
+                    "tools are required."
+                )
+            argv = build_claude_cli_argv(
+                binary=self._binary,
+                model_name=self.model_name,
+            )
+            prompt = serialise_messages_to_prompt(input)
+            stdout, stderr, returncode = await _run_claude_subprocess(argv, prompt, self._timeout_s)
+            if returncode != 0:
+                raise ClaudeCliInvocationError(f"claude exited {returncode}: {stderr[:400]!r}")
+            events = parse_stream_json_events(stdout)
+            if not events:
+                raise ClaudeCliInvocationError(
+                    f"claude stdout had no stream-json events. stderr: {stderr[:400]!r}"
+                )
+            text = _extract_assistant_text(events)
+            stop_reason = _extract_stop_reason(events)
+            usage_dict = _extract_usage(events)
+            choice = ChatCompletionChoice(
+                message=ChatMessageAssistant(content=text),
+                stop_reason=stop_reason,
+            )
+            usage = ModelUsage(
+                input_tokens=usage_dict["input_tokens"],
+                output_tokens=usage_dict["output_tokens"],
+                total_tokens=usage_dict["input_tokens"] + usage_dict["output_tokens"],
+                input_tokens_cache_read=usage_dict["cache_read_input_tokens"] or None,
+                input_tokens_cache_write=usage_dict["cache_creation_input_tokens"] or None,
+            )
+            return ModelOutput(
+                model=self.model_name,
+                choices=[choice],
+                completion=text,
+                usage=usage,
+            )
+
+    globals()["ClaudeCliAPI"] = ClaudeCliAPI

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -473,12 +473,20 @@ def register() -> None:
     from inspect_ai.model._model_output import ChatCompletionChoice, ModelUsage
 
     @modelapi(name="claude-cli")
-    class ClaudeCliAPI(ModelAPI):
+    class ClaudeCliAPI(ModelAPI):  # type: ignore[misc, unused-ignore]
         """inspect_ai provider that delegates to ``claude --print``.
 
         Identifier shape: ``claude-cli/<model-id>``. inspect_ai's
         router strips the ``claude-cli/`` prefix and instantiates this
         class with ``model_name=<model-id>``.
+
+        ``# type: ignore[misc, unused-ignore]`` mirrors the sibling
+        providers (``GeodeModelAPI`` / ``ClaudeOAuthAPI`` /
+        ``OpenAICodexAPI``): inspect_ai ships without type stubs, so
+        in the default ``uv sync`` (no ``[audit]`` extra) environment
+        ``ModelAPI`` resolves to ``Any`` and strict mypy rejects the
+        subclass; with the extra installed, the suppression is unused
+        (hence ``unused-ignore`` flag).
         """
 
         def __init__(

--- a/tests/plugins/petri_audit/test_claude_cli_provider.py
+++ b/tests/plugins/petri_audit/test_claude_cli_provider.py
@@ -1,0 +1,611 @@
+"""CSA-1 — claude-cli provider invariants (text-only).
+
+Mock-based tests covering:
+
+* Binary resolution (env override / PATH lookup / not-found).
+* Subprocess timeout env override.
+* argv builder (flag presence + order + MCP integration deferred to CSA-2).
+* Message serialiser (str / list / multi-turn).
+* Stream-json parser (well-formed / malformed / empty).
+* Text extraction (content_block_delta vs result fallback).
+* Stop reason mapping (end_turn → stop, tool_use → tool_calls, etc.).
+* Usage extraction.
+* Subprocess runner (success / non-zero exit / timeout).
+* Provider registration on inspect_ai modelapi registry.
+* CSA-1 boundary: tools=[...] raises NotImplementedError (defers to CSA-2).
+
+inspect_ai-dependent tests are gated on ``pytest.importorskip``.
+Pure-helper tests (argv / serialiser / parser) run in any env.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Binary resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_binary_via_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """``GEODE_CLAUDE_CLI_BIN`` env points at an executable."""
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_BIN_ENV,
+        _resolve_claude_binary,
+    )
+
+    fake = tmp_path / "fake-claude"
+    fake.write_text("#!/bin/sh\necho ok\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv(CLAUDE_CLI_BIN_ENV, str(fake))
+    assert _resolve_claude_binary() == str(fake)
+
+
+def test_resolve_binary_via_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no env override, falls back to ``shutil.which("claude")``."""
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_BIN_ENV,
+        _resolve_claude_binary,
+    )
+
+    monkeypatch.delenv(CLAUDE_CLI_BIN_ENV, raising=False)
+    with patch("shutil.which", return_value="/fake/path/claude"):
+        assert _resolve_claude_binary() == "/fake/path/claude"
+
+
+def test_resolve_binary_env_invalid_path_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """env points at nonexistent file → ClaudeCliInvocationError."""
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_BIN_ENV,
+        ClaudeCliInvocationError,
+        _resolve_claude_binary,
+    )
+
+    monkeypatch.setenv(CLAUDE_CLI_BIN_ENV, "/nonexistent/binary")
+    with (
+        patch("shutil.which", return_value=None),
+        pytest.raises(ClaudeCliInvocationError, match="no executable"),
+    ):
+        _resolve_claude_binary()
+
+
+def test_resolve_binary_not_on_path_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env + no PATH binary → ClaudeCliInvocationError."""
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_BIN_ENV,
+        ClaudeCliInvocationError,
+        _resolve_claude_binary,
+    )
+
+    monkeypatch.delenv(CLAUDE_CLI_BIN_ENV, raising=False)
+    with (
+        patch("shutil.which", return_value=None),
+        pytest.raises(ClaudeCliInvocationError, match="not found on PATH"),
+    ):
+        _resolve_claude_binary()
+
+
+def test_resolve_timeout_default() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_SUBPROCESS_TIMEOUT_S,
+        _resolve_timeout_s,
+    )
+
+    # Without env, returns module default
+    assert _resolve_timeout_s() == CLAUDE_CLI_SUBPROCESS_TIMEOUT_S
+
+
+def test_resolve_timeout_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_TIMEOUT_ENV,
+        _resolve_timeout_s,
+    )
+
+    monkeypatch.setenv(CLAUDE_CLI_TIMEOUT_ENV, "1200")
+    assert _resolve_timeout_s() == 1200.0
+
+
+def test_resolve_timeout_env_garbage_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        CLAUDE_CLI_SUBPROCESS_TIMEOUT_S,
+        CLAUDE_CLI_TIMEOUT_ENV,
+        _resolve_timeout_s,
+    )
+
+    monkeypatch.setenv(CLAUDE_CLI_TIMEOUT_ENV, "not-a-number")
+    assert _resolve_timeout_s() == CLAUDE_CLI_SUBPROCESS_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# argv builder
+# ---------------------------------------------------------------------------
+
+
+def test_argv_minimal_shape() -> None:
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/usr/bin/claude",
+        model_name="claude-opus-4-7",
+    )
+    assert argv[0] == "/usr/bin/claude"
+    assert "--print" in argv
+    assert argv[argv.index("--print") + 1] == "-"  # stdin marker
+    assert "--output-format" in argv
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+    assert "--verbose" in argv
+    assert "--model" in argv
+    assert argv[argv.index("--model") + 1] == "claude-opus-4-7"
+    assert "--max-turns" in argv
+    assert argv[argv.index("--max-turns") + 1] == "1"  # default — single turn
+
+
+def test_argv_custom_max_turns() -> None:
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/usr/bin/claude",
+        model_name="claude-opus-4-7",
+        max_turns=5,
+    )
+    assert argv[argv.index("--max-turns") + 1] == "5"
+
+
+def test_argv_mcp_config_adds_strict_flag() -> None:
+    """CSA-2 hook: passing mcp_config_path also sets --strict-mcp-config."""
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/usr/bin/claude",
+        model_name="claude-opus-4-7",
+        mcp_config_path="/tmp/mcp.json",  # noqa: S108
+    )
+    assert "--mcp-config" in argv
+    assert "/tmp/mcp.json" in argv  # noqa: S108
+    assert "--strict-mcp-config" in argv
+
+
+def test_argv_allowed_tools_joins_csv() -> None:
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/usr/bin/claude",
+        model_name="claude-opus-4-7",
+        allowed_tools=["mcp__bridge__send_message", "mcp__bridge__recommend_termination"],
+    )
+    assert "--allowed-tools" in argv
+    idx = argv.index("--allowed-tools")
+    # CLI accepts space-or-comma — we use comma for safety
+    assert "send_message" in argv[idx + 1]
+    assert "recommend_termination" in argv[idx + 1]
+
+
+def test_argv_extra_args_appended() -> None:
+    from plugins.petri_audit.claude_cli_provider import build_claude_cli_argv
+
+    argv = build_claude_cli_argv(
+        binary="/usr/bin/claude",
+        model_name="claude-opus-4-7",
+        extra_args=["--reasoning-effort", "high"],
+    )
+    assert argv[-2:] == ["--reasoning-effort", "high"]
+
+
+# ---------------------------------------------------------------------------
+# Message serialiser
+# ---------------------------------------------------------------------------
+
+
+def test_serialise_single_user_message() -> None:
+    from plugins.petri_audit.claude_cli_provider import serialise_messages_to_prompt
+
+    msgs = [SimpleNamespace(role="user", content="Hello")]
+    out = serialise_messages_to_prompt(msgs)
+    assert "<<<USER>>>" in out
+    assert "Hello" in out
+
+
+def test_serialise_multi_turn_order_preserved() -> None:
+    from plugins.petri_audit.claude_cli_provider import serialise_messages_to_prompt
+
+    msgs = [
+        SimpleNamespace(role="system", content="You are helpful."),
+        SimpleNamespace(role="user", content="What is 2+2?"),
+        SimpleNamespace(role="assistant", content="4"),
+        SimpleNamespace(role="user", content="And 3+3?"),
+    ]
+    out = serialise_messages_to_prompt(msgs)
+    # Order preserved
+    sys_idx = out.index("<<<SYSTEM>>>")
+    user1_idx = out.index("<<<USER>>>", sys_idx)
+    assistant_idx = out.index("<<<ASSISTANT>>>", user1_idx)
+    user2_idx = out.index("<<<USER>>>", assistant_idx)
+    assert sys_idx < user1_idx < assistant_idx < user2_idx
+    assert "What is 2+2?" in out
+    assert "And 3+3?" in out
+
+
+def test_serialise_content_blocks_extracts_text() -> None:
+    """list-of-Content (with .text attr) shape — extract text from each block."""
+    from plugins.petri_audit.claude_cli_provider import serialise_messages_to_prompt
+
+    blocks = [
+        SimpleNamespace(text="part1"),
+        SimpleNamespace(text="part2"),
+    ]
+    msgs = [SimpleNamespace(role="user", content=blocks)]
+    out = serialise_messages_to_prompt(msgs)
+    assert "part1" in out
+    assert "part2" in out
+
+
+def test_serialise_unknown_role_uses_uppercase_sentinel() -> None:
+    """Forward-compat — new role names get auto-sentinel."""
+    from plugins.petri_audit.claude_cli_provider import serialise_messages_to_prompt
+
+    msgs = [SimpleNamespace(role="auditor", content="hmm")]
+    out = serialise_messages_to_prompt(msgs)
+    assert "<<<AUDITOR>>>" in out
+
+
+# ---------------------------------------------------------------------------
+# Stream-json parser
+# ---------------------------------------------------------------------------
+
+
+def _make_stream_json(events: list[dict]) -> str:
+    """Helper — serialise to claude CLI's per-line JSON format."""
+    return "\n".join(json.dumps(e) for e in events) + "\n"
+
+
+def test_parse_well_formed_events() -> None:
+    from plugins.petri_audit.claude_cli_provider import parse_stream_json_events
+
+    stdout = _make_stream_json(
+        [
+            {"type": "message_start", "message": {}},
+            {"type": "content_block_start", "index": 0},
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hi"}},
+            {"type": "message_stop"},
+            {"type": "result", "result": "Hi"},
+        ]
+    )
+    events = parse_stream_json_events(stdout)
+    assert [e.type for e in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "message_stop",
+        "result",
+    ]
+
+
+def test_parse_skips_malformed_lines() -> None:
+    """Non-JSON lines (debug noise) silently dropped."""
+    from plugins.petri_audit.claude_cli_provider import parse_stream_json_events
+
+    stdout = '{"type": "ok", "x": 1}\nnot-json-debug\n{"type": "ok", "x": 2}\n'
+    events = parse_stream_json_events(stdout)
+    assert len(events) == 2
+    assert all(e.type == "ok" for e in events)
+
+
+def test_parse_empty_stdout_returns_empty_list() -> None:
+    from plugins.petri_audit.claude_cli_provider import parse_stream_json_events
+
+    assert parse_stream_json_events("") == []
+
+
+def test_parse_skips_non_object_lines() -> None:
+    """Top-level arrays / strings are valid JSON but not events — skip."""
+    from plugins.petri_audit.claude_cli_provider import parse_stream_json_events
+
+    stdout = '"just a string"\n[1, 2, 3]\n{"type": "ok"}\n'
+    events = parse_stream_json_events(stdout)
+    assert len(events) == 1
+    assert events[0].type == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Text + stop + usage extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_from_content_block_deltas() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_assistant_text,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hel"}},
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "lo"}},
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": " world"}},
+        ]
+    )
+    events = parse_stream_json_events(stdout)
+    assert _extract_assistant_text(events) == "Hello world"
+
+
+def test_extract_text_result_fallback() -> None:
+    """When no content_block_delta events, fall back to result.result."""
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_assistant_text,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json([{"type": "result", "result": "Just OK"}])
+    events = parse_stream_json_events(stdout)
+    assert _extract_assistant_text(events) == "Just OK"
+
+
+def test_extract_stop_reason_end_turn_maps_to_stop() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_stop_reason,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json([{"type": "message_delta", "delta": {"stop_reason": "end_turn"}}])
+    assert _extract_stop_reason(parse_stream_json_events(stdout)) == "stop"
+
+
+def test_extract_stop_reason_tool_use_maps_to_tool_calls() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_stop_reason,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json([{"type": "message_delta", "delta": {"stop_reason": "tool_use"}}])
+    assert _extract_stop_reason(parse_stream_json_events(stdout)) == "tool_calls"
+
+
+def test_extract_stop_reason_max_tokens_preserved() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_stop_reason,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json([{"type": "result", "stop_reason": "max_tokens"}])
+    assert _extract_stop_reason(parse_stream_json_events(stdout)) == "max_tokens"
+
+
+def test_extract_stop_reason_unknown_when_absent() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_stop_reason,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json([{"type": "message_start"}])
+    assert _extract_stop_reason(parse_stream_json_events(stdout)) == "unknown"
+
+
+def test_extract_usage_from_result_event() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_usage,
+        parse_stream_json_events,
+    )
+
+    stdout = _make_stream_json(
+        [
+            {
+                "type": "result",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 200,
+                    "cache_creation_input_tokens": 300,
+                },
+            }
+        ]
+    )
+    usage = _extract_usage(parse_stream_json_events(stdout))
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 50
+    assert usage["cache_read_input_tokens"] == 200
+    assert usage["cache_creation_input_tokens"] == 300
+
+
+def test_extract_usage_zero_when_absent() -> None:
+    from plugins.petri_audit.claude_cli_provider import (
+        _extract_usage,
+        parse_stream_json_events,
+    )
+
+    usage = _extract_usage(parse_stream_json_events("{}"))
+    assert usage == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subprocess runner
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_runner_success(tmp_path: Any) -> None:
+    """End-to-end: fake binary echoes a fixture stream-json to stdout."""
+    from plugins.petri_audit.claude_cli_provider import _run_claude_subprocess
+
+    # Tiny fake "claude" that emits stream-json then exits 0
+    fake = tmp_path / "fake-claude"
+    fake.write_text(
+        "#!/bin/sh\n"
+        "cat <<EOF\n"
+        '{"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hi"}}\n'
+        '{"type": "result", "result": "Hi", "stop_reason": "end_turn"}\n'
+        "EOF\n"
+    )
+    fake.chmod(0o755)
+    argv = [str(fake), "--print", "-"]
+    stdout, stderr, rc = asyncio.run(_run_claude_subprocess(argv, "prompt", 10.0))
+    assert rc == 0
+    assert '"text_delta"' in stdout
+
+
+def test_subprocess_runner_nonzero_exit(tmp_path: Any) -> None:
+    """Non-zero exit returns the code; caller decides what to do."""
+    from plugins.petri_audit.claude_cli_provider import _run_claude_subprocess
+
+    fake = tmp_path / "fake-claude"
+    fake.write_text("#!/bin/sh\necho err >&2\nexit 2\n")
+    fake.chmod(0o755)
+    stdout, stderr, rc = asyncio.run(_run_claude_subprocess([str(fake)], "", 10.0))
+    assert rc == 2
+    assert "err" in stderr
+
+
+def test_subprocess_runner_timeout(tmp_path: Any) -> None:
+    """Timeout → ClaudeCliInvocationError."""
+    from plugins.petri_audit.claude_cli_provider import (
+        ClaudeCliInvocationError,
+        _run_claude_subprocess,
+    )
+
+    fake = tmp_path / "fake-claude"
+    fake.write_text("#!/bin/sh\nsleep 10\n")
+    fake.chmod(0o755)
+    with pytest.raises(ClaudeCliInvocationError, match="timed out"):
+        asyncio.run(_run_claude_subprocess([str(fake)], "", 0.5))
+
+
+def test_subprocess_runner_binary_missing() -> None:
+    """Spawn-time FileNotFoundError → ClaudeCliInvocationError."""
+    from plugins.petri_audit.claude_cli_provider import (
+        ClaudeCliInvocationError,
+        _run_claude_subprocess,
+    )
+
+    with pytest.raises(ClaudeCliInvocationError, match="failed to spawn"):
+        asyncio.run(_run_claude_subprocess(["/nonexistent/binary"], "", 10.0))
+
+
+# ---------------------------------------------------------------------------
+# Provider registration + generate() boundary
+# ---------------------------------------------------------------------------
+
+
+pytest.importorskip("inspect_ai")
+
+
+@pytest.fixture(autouse=True)
+def _register_provider_once() -> None:
+    """Ensure register() has run (idempotent — modelapi registry tolerates
+    re-registration on the same name)."""
+    from plugins.petri_audit import claude_cli_provider as p
+
+    if not hasattr(p, "ClaudeCliAPI"):
+        p.register()
+
+
+def test_provider_registers_modelapi() -> None:
+    """register() exposes ClaudeCliAPI at module level."""
+    from plugins.petri_audit import claude_cli_provider as p
+
+    assert hasattr(p, "ClaudeCliAPI")
+
+
+def test_generate_with_tools_raises_csa1_boundary(tmp_path: Any) -> None:
+    """CSA-1 boundary — tools forces NotImplementedError (CSA-2 wires MCP)."""
+    from plugins.petri_audit import claude_cli_provider as p
+
+    fake = tmp_path / "fake-claude"
+    fake.write_text("#!/bin/sh\necho ok\n")
+    fake.chmod(0o755)
+    with patch(
+        "plugins.petri_audit.claude_cli_provider._resolve_claude_binary", return_value=str(fake)
+    ):
+        api = p.ClaudeCliAPI(model_name="claude-opus-4-7")
+        with pytest.raises(NotImplementedError, match="MCP bridge"):
+            asyncio.run(api.generate([], tools=["fake-tool"], tool_choice="auto", config=None))
+
+
+def test_generate_text_only_round_trip(tmp_path: Any) -> None:
+    """End-to-end: fake claude binary → provider → ModelOutput."""
+    from inspect_ai.model._model_output import ModelOutput
+
+    from plugins.petri_audit import claude_cli_provider as p
+
+    fake = tmp_path / "fake-claude"
+    # Emit a complete stream-json with text + usage
+    fake.write_text(
+        "#!/bin/sh\n"
+        "cat <<EOF\n"
+        '{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}\n'
+        '{"type":"content_block_delta","delta":{"type":"text_delta","text":" world"}}\n'
+        '{"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n'
+        '{"type":"result","result":"Hello world","stop_reason":"end_turn",'
+        '"usage":{"input_tokens":10,"output_tokens":2,'
+        '"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}\n'
+        "EOF\n"
+    )
+    fake.chmod(0o755)
+    with patch(
+        "plugins.petri_audit.claude_cli_provider._resolve_claude_binary", return_value=str(fake)
+    ):
+        api = p.ClaudeCliAPI(model_name="claude-opus-4-7")
+        msgs = [SimpleNamespace(role="user", content="Say hello")]
+        output = asyncio.run(api.generate(msgs, tools=[], tool_choice="auto", config=None))
+    assert isinstance(output, ModelOutput)
+    assert output.completion == "Hello world"
+    assert output.usage is not None
+    assert output.usage.input_tokens == 10
+    assert output.usage.output_tokens == 2
+    assert output.choices[0].stop_reason == "stop"
+
+
+def test_generate_nonzero_exit_raises(tmp_path: Any) -> None:
+    """Subprocess non-zero exit → ClaudeCliInvocationError surfaced."""
+    from plugins.petri_audit import claude_cli_provider as p
+
+    fake = tmp_path / "fake-claude"
+    fake.write_text("#!/bin/sh\necho 'oops' >&2\nexit 1\n")
+    fake.chmod(0o755)
+    with patch(
+        "plugins.petri_audit.claude_cli_provider._resolve_claude_binary", return_value=str(fake)
+    ):
+        api = p.ClaudeCliAPI(model_name="claude-opus-4-7")
+        with pytest.raises(p.ClaudeCliInvocationError, match="exited 1"):
+            asyncio.run(
+                api.generate(
+                    [SimpleNamespace(role="user", content="hi")],
+                    tools=[],
+                    tool_choice="auto",
+                    config=None,
+                )
+            )
+
+
+def test_generate_empty_stdout_raises(tmp_path: Any) -> None:
+    """Empty stream-json output → ClaudeCliInvocationError."""
+    from plugins.petri_audit import claude_cli_provider as p
+
+    fake = tmp_path / "fake-claude"
+    fake.write_text("#!/bin/sh\nexit 0\n")  # no stdout
+    fake.chmod(0o755)
+    with patch(
+        "plugins.petri_audit.claude_cli_provider._resolve_claude_binary", return_value=str(fake)
+    ):
+        api = p.ClaudeCliAPI(model_name="claude-opus-4-7")
+        with pytest.raises(p.ClaudeCliInvocationError, match="no stream-json"):
+            asyncio.run(
+                api.generate(
+                    [SimpleNamespace(role="user", content="hi")],
+                    tools=[],
+                    tool_choice="auto",
+                    config=None,
+                )
+            )


### PR DESCRIPTION
## Summary

- New `plugins/petri_audit/claude_cli_provider.py::ClaudeCliAPI` — `@modelapi(name="claude-cli")` registration for inspect_ai.
- Each `generate()` call spawns `claude --print` subprocess (paperclip pattern, verified in `~/workspace/paperclip/packages/adapters/claude-local/src/server/execute.ts:679`) instead of raw Anthropic SDK.
- CSA-1 scope: text-only (judge role). Tool support deferred to CSA-2 (MCP bridge for auditor).

## Why

Pattern B subscription audit (Claude Max OAuth) was hitting 100% 429 enforcement — verified by direct trace inspection (`trace-68931.log`):

```
27/27 HTTP requests → 429 (none successful)
Retry sequence: 6s → 8s → 13s → 24s → 49s → 98s → 194s → 770s
```

Diagnosis: Anthropic gateway distinguishes "OAuth token via raw SDK" (rate-limited harshly) from "OAuth token via Claude Code CLI" (full subscription tier). Smoke test confirmed: `claude --print "Hi"` succeeds in 3.9s while raw SDK 429s 100%. The CLI sends session-aware headers (`claude-code-20250219`, `oauth-2025-04-20`, `claude-code-session-id`, `x-stainless-*`) that are non-trivial to replicate from Python.

Paperclip solves this by routing ALL inference through `claude --print` subprocess. We mirror the pattern. CSA-1 builds the scaffolding for the text-only path (sufficient for judge role); CSA-2 will add MCP bridge so auditor's `inspect_petri` tools (`send_message`, `recommend_termination`) can flow through claude CLI too.

## Changes

| File | Change |
|------|--------|
| `plugins/petri_audit/claude_cli_provider.py` (new, ~570 LOC) | Full provider — binary discovery, argv builder, message serialiser, stream-json parser, text/stop/usage extractors, async subprocess runner, `@modelapi("claude-cli")` class |
| `plugins/petri_audit/__init__.py` | try/except register hook (graceful skip when [audit] extra absent) |
| `tests/plugins/petri_audit/test_claude_cli_provider.py` (new, ~600 LOC) | 37 mock-based invariants — binary x4 + timeout x3 + argv x5 + serialiser x4 + parser x4 + text x2 + stop_reason x4 + usage x2 + subprocess x4 + provider+boundary+round-trip x5 |
| `CHANGELOG.md` | `[Unreleased]` Added entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `@modelapi("claude-cli")` registration | Implemented | Identifier prefix `claude-cli/<model>` |
| Binary resolution (env + PATH + error) | Implemented | `GEODE_CLAUDE_CLI_BIN` operator override |
| subprocess timeout (with env override) | Implemented | Default 600s, `GEODE_CLAUDE_CLI_TIMEOUT_S` |
| Multi-turn message serialiser | Implemented | Role-header sentinels preserve context |
| stream-json event parser | Implemented | Forward-compat (unknown event types tolerated) |
| Tool support (auditor) | Deferred (CSA-2) | `generate(tools=[...])` → NotImplementedError |
| Manifest flip (default routing) | Deferred (CSA-3) | After MCP bridge proves auditor works |
| MCP config + allowed-tools argv hooks | Forward-compat scaffolded | `build_claude_cli_argv` accepts both kwargs |

## Verification

- [x] ruff check + ruff format --check clean
- [x] mypy clean
- [x] pytest 37/37 mock-based (no live LLM)
- [ ] CI green (5/5 — pending push)
- [ ] Codex MCP LLM-as-Judge (pending)
- [ ] Post-merge: manual smoke `inspect eval ... --model-role judge=claude-cli/claude-opus-4-7` → expect non-429 completion

## Reference

- paperclip source: `~/workspace/paperclip/packages/adapters/claude-local/src/server/execute.ts:679`
- 429 evidence: `~/Library/Application Support/inspect_ai/traces/trace-68931.log`
- inspect_ai ModelAPI base: `.venv/lib/python3.12/site-packages/inspect_ai/model/_model.py:181`
- Existing provider (raw SDK) to replace: `plugins/petri_audit/claude_code_provider.py`
- Follow-up sprint: CSA-2 (MCP bridge) → CSA-3 (manifest flip + autoresearch routing) → CSA-4 (`/petri status` + doctor extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)