### PR TITLE
PR-CSP-10 — embedding plumbing drop + 2026-05-22 model lineup realign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,36 @@ functional change.
 
 ### Changed
 
+- **CSP-10 — supported-model lineup realigned + embedding plumbing removed**.
+  Updated `seed_generation.plugin.toml` `allowed_models` lists so every
+  role advertises only what Claude Code CLI (`claude-opus-4-7` /
+  `claude-sonnet-4-6` / `claude-haiku-4-5`) and Codex CLI (`gpt-5.5` /
+  `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.3-codex`) actually expose as of
+  2026-05-22 (cross-checked against `core/llm/model_pricing.toml`).
+  Pilot now lists `gpt-5.3-codex` (Codex-specialized small) alongside
+  `gpt-5.4-mini`; Ranker / Evolver / Meta-Reviewer added `gpt-5.5` so
+  judge-panel / rewrite paths can opt into Codex without an explicit
+  override. Dropped the legacy `o1-` / `o3-` reasoning-model prefix
+  mappings from `picker._PROVIDER_PREFIX_MAP` — Codex CLI no longer
+  exposes those families, so the picker now raises rather than
+  silently binding them to the openai adapter.
+
+- **CSP-10 — drop the embedding ``kind`` discriminator**. CSP-8 had
+  reverted the only embedding consumer (Proximity) to the paper's
+  LLM-clustering pattern, but left a `kind: Literal["completion",
+  "embedding"]` field on `SeedRoleSpec` + `RoleBinding` plus dead
+  branches in `pre_flight.check_auth` and `cost_preview._per_call_cost`
+  for forward-compat. CSP-10 deletes the field, the picker's
+  `text-embedding-` prefix mapping, the pre-flight embedding branch,
+  and the manifest TOML's `kind = "completion"` line on the proximity
+  role. Stale docstrings in `agents/__init__.py` (proximity 3-track
+  blurb), `agents/base.py` (pre-CSP-8 bypass paragraph), and
+  `agents/generator.py` (Proximity-computes-embeddings paragraph) are
+  rewritten to match the post-CSP-8 LLM-clustering reality. Two new
+  regression pins: `SeedRoleSpec.model_fields` must NOT contain
+  `kind`, and the shipped TOML must NOT carry any bare `kind = "..."`
+  line.
+
 - **CSP-9 — seed-generation prompts colocated with the plugin package**.
   Moved the 8 seed-generation agent prompt files (`seed_critic.md`,
   `seed_evolver.md`, `seed_generator.md`, `seed_meta_reviewer.md`,

--- a/plugins/seed_generation/agents/__init__.py
+++ b/plugins/seed_generation/agents/__init__.py
@@ -3,7 +3,7 @@
 7 role (paper 6 + GEODE Pilot):
 - generator     (S2, ✓)
 - critic        (S3, ✓) — Reflection
-- proximity     (S4, ✓) — 3-track dedup (embedding + lexical + role)
+- proximity     (S4, ✓) — paper §3 LLM-clustering (CSP-8 revert)
 - pilot         (S5, ✓) — GEODE addition (scientist-in-the-loop slot)
 - ranker        (S6, ✓) — Elo tournament + 3-judge panel
 - evolver       (S7, ✓) — Reflection-driven section rewrite

--- a/plugins/seed_generation/agents/base.py
+++ b/plugins/seed_generation/agents/base.py
@@ -34,12 +34,11 @@ Lifecycle
 Sub-agent integration
 =====================
 
-Every role (including the CSP-8 LLM-clustering Proximity role)
-dispatches through ``SubAgentManager.delegate`` (S2+). Pre-CSP-8
-the Proximity role was an embedding-only path that bypassed
-``delegate`` and called the ``text_embed`` tool directly; the
-LLM-clustering revert (paper §3 Proximity) collapsed it into the
-standard sub-agent pattern.
+Every role dispatches through ``SubAgentManager.delegate`` (S2+).
+There is no per-role embedding branch — pre-CSP-8 Proximity called
+``text_embed`` directly outside the delegate path; CSP-8 reverted
+that to the paper's §3 LLM-clustering, and CSP-10 dropped the
+remaining ``kind`` plumbing from the manifest / picker / pre-flight.
 """
 
 from __future__ import annotations

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -22,9 +22,10 @@ Return shape (merged into ``PipelineState.candidates``)::
     ]
 
 The output dict is what later phases consume — Proximity (S4) reads
-the file to compute embeddings, Reflection (S3) critiques it, Pilot (S5)
-runs it through the Petri inner-loop subset. The candidate id is also
-the basename of the seed file, so disk layout matches state shape 1:1.
+the file to cluster near-duplicates by LLM call (paper §3, CSP-8),
+Reflection (S3) critiques it, Pilot (S5) runs it through the Petri
+inner-loop subset. The candidate id is also the basename of the seed
+file, so disk layout matches state shape 1:1.
 
 Cost accounting:
 ================

--- a/plugins/seed_generation/cost_preview.py
+++ b/plugins/seed_generation/cost_preview.py
@@ -116,10 +116,9 @@ def _calls_for(budget: _RoleBudget, *, candidates: int, matches: int, voters: in
 def _per_call_cost(model: str, budget: _RoleBudget) -> float:
     """Per-call USD using :data:`MODEL_PRICING`.
 
-    Returns ``0.0`` when the model is unknown (proximity's embedding
-    pricing is the obvious case — :data:`MODEL_PRICING` only ships
-    completion-model rates). The caller can override or supplement
-    when an embedding-specific catalogue lands.
+    Returns ``0.0`` when the model is unknown. :data:`MODEL_PRICING`
+    only ships completion-model rates (all GEODE seed-generation roles
+    are completion calls after CSP-8 + CSP-10).
     """
     price = MODEL_PRICING.get(model)
     if price is None:

--- a/plugins/seed_generation/manifest.py
+++ b/plugins/seed_generation/manifest.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import tomllib
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -58,23 +58,17 @@ class SeedRoleSpec(BaseModel):
     """Per-role default + allowed model set + contract path.
 
     Mirrors :class:`plugins.petri_audit.manifest.RoleSpec` in field shape
-    (default + allowed + contract). The ``kind`` discriminator was added
-    pre-CSP-8 when Proximity ran an embedding API directly; CSP-8
-    reverted Proximity to the LLM-completion path, so every shipped
-    role is now ``kind="completion"``. The field is retained for
-    forward-compat (a future plugin may want to introduce a non-
-    completion role kind).
-
-    Field values:
-    - ``completion`` (default) — LLM chat completion via Petri adapters.
-    - ``embedding`` — reserved for future vector-embedding-driven roles
-      (no current GEODE role uses this; pre-CSP-8 Proximity did).
+    (default + allowed + contract). Every shipped role is an LLM
+    completion call dispatched through :class:`SubAgentManager.delegate`
+    — there is no longer any embedding-driven role surface (CSP-10
+    removed the pre-CSP-8 ``kind`` discriminator after CSP-8 reverted
+    the only embedding consumer, Proximity, to the paper's
+    LLM-clustering path).
     """
 
     default_model: str
     allowed_models: list[str]
     role_contract: str | None = None
-    kind: Literal["completion", "embedding"] = "completion"
 
     @model_validator(mode="after")
     def _default_in_allowed(self) -> SeedRoleSpec:

--- a/plugins/seed_generation/picker.py
+++ b/plugins/seed_generation/picker.py
@@ -7,7 +7,7 @@ runtime, factoring in:
 1. The role's ``default_model`` from
    ``plugins/seed_generation/seed_generation.plugin.toml``.
 2. The model's provider, inferred from a prefix table (claude-*
-   → anthropic, gpt-* / text-embedding-* → openai, glm-* → zhipuai).
+   → anthropic, gpt-* → openai, glm-* → zhipuai).
 3. The Petri source table's ``default`` (typically ``auto``) for that
    provider.
 4. The OAuth probe (``is_claude_oauth_available`` /
@@ -52,10 +52,6 @@ P1-P7 prevention checklist application:
 - **P4 Environment Anchor**: ``GLOBAL_SEED_PIPELINE_TOML`` is the single
   filesystem anchor (``core/paths.py``), NOT a cwd-relative or
   module-relative path. Mirrors :data:`core.paths.GLOBAL_PETRI_TOML`.
-- **P7 Caller-Callee Contract**: every :class:`RoleBinding` carries the
-  ``kind`` discriminator (``completion`` / ``embedding``), so the S6
-  Ranker / S5 Pilot dispatchers don't need to guess by model-name
-  string.
 """
 
 from __future__ import annotations
@@ -66,7 +62,7 @@ import tomllib
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Literal
+from typing import IO
 
 from core.paths import GLOBAL_SEED_PIPELINE_TOML
 
@@ -98,10 +94,7 @@ SUBSCRIPTION_SOURCES = frozenset({"claude-cli", "openai-codex"})
 
 _PROVIDER_PREFIX_MAP: tuple[tuple[str, str], ...] = (
     ("claude-", "anthropic"),
-    ("text-embedding-", "openai"),
     ("gpt-", "openai"),
-    ("o1-", "openai"),
-    ("o3-", "openai"),
     ("glm-", "zhipuai"),
 )
 
@@ -128,16 +121,15 @@ class RoleBinding:
     """Resolved auth binding for one seed-generation role.
 
     All fields are concrete after :func:`pick_bindings` returns — no
-    ``auto`` sentinel, no ``None`` source. The ``kind`` discriminator
-    mirrors :attr:`SeedRoleSpec.kind` so callers don't have to re-import
-    the manifest schema.
+    ``auto`` sentinel, no ``None`` source. Every role goes through the
+    completion path; CSP-10 dropped the pre-CSP-8 ``kind`` discriminator
+    once Proximity reverted to LLM clustering.
     """
 
     role: str
     model: str
     provider: str
     source: str
-    kind: Literal["completion", "embedding"]
 
 
 @dataclass(frozen=True)
@@ -336,7 +328,6 @@ def pick_bindings(
             model=model,
             provider=provider,
             source=source,
-            kind=spec.kind,
         )
         if source in SUBSCRIPTION_SOURCES:
             subscription_paths.add(source)

--- a/plugins/seed_generation/pre_flight.py
+++ b/plugins/seed_generation/pre_flight.py
@@ -133,11 +133,6 @@ def check_auth(picker_result: PickerResult) -> list[PreFlightIssue]:
             )
 
     for role, binding in picker_result.bindings.items():
-        # Embedding kind only needs the openai api_key; the OAuth
-        # subscription doesn't expose embeddings.
-        if binding.kind == "embedding":
-            _check("openai", "api_key", f"role {role!r}")
-            continue
         _check(binding.provider, binding.source, f"role {role!r}")
     for voter in picker_result.voters:
         _check(voter.provider, voter.source, f"voter {voter.provider}.{voter.source}")

--- a/plugins/seed_generation/seed_generation.plugin.toml
+++ b/plugins/seed_generation/seed_generation.plugin.toml
@@ -19,6 +19,12 @@
 #
 # Defaults reflect ADR-003's settled-decision table (Plan §13). Override
 # via ~/.geode/seed-generation.toml is wired in S5.5 (picker).
+#
+# Supported model lineup (CSP-10, 2026-05-22) — only models currently exposed
+# by Claude Code CLI (anthropic.claude-cli) or Codex CLI (openai.openai-codex)
+# may appear in allowed_models. Anthropic surface: claude-opus-4-7 /
+# claude-sonnet-4-6 / claude-haiku-4-5. Codex surface: gpt-5.5 / gpt-5.4 /
+# gpt-5.4-mini / gpt-5.3-codex (see core/llm/model_pricing.toml).
 
 [seed_generation]
 enabled_roles = [
@@ -39,6 +45,7 @@ allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.5",
+    "gpt-5.4",
 ]
 role_contract = "plugins/seed_generation/agents/generator.md"
 
@@ -48,27 +55,31 @@ allowed_models = [
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
     "gpt-5.5",
+    "gpt-5.4-mini",
 ]
 role_contract = "plugins/seed_generation/agents/critic.md"
 
 [seed_generation.role.proximity]
 # CSP-8 (2026-05-22) — Proximity reverted to LLM-clustering pattern
-# (paper §3). Pre-CSP-8 was kind="embedding" + text-embedding-3-small;
-# now an LLM completion call like every other role.
+# (paper §3). Pre-CSP-8 was an embedding call to text-embedding-3-small;
+# now an LLM completion call like every other role. CSP-10 dropped the
+# ``kind`` field from the schema (every role is completion now).
 default_model = "claude-sonnet-4-6"
 allowed_models = [
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
     "gpt-5.5",
+    "gpt-5.4-mini",
 ]
 role_contract = "plugins/seed_generation/agents/proximity.md"
-kind = "completion"
 
 [seed_generation.role.pilot]
+# Cheap-fast slot — runs inside the Petri inner-loop on every candidate.
 default_model = "claude-haiku-4-5"
 allowed_models = [
     "claude-haiku-4-5",
     "gpt-5.4-mini",
+    "gpt-5.3-codex",
 ]
 role_contract = "plugins/seed_generation/agents/pilot.md"
 
@@ -79,6 +90,7 @@ default_model = "claude-sonnet-4-6"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
+    "gpt-5.5",
 ]
 role_contract = "plugins/seed_generation/agents/ranker.md"
 
@@ -87,6 +99,7 @@ default_model = "claude-sonnet-4-6"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
+    "gpt-5.5",
 ]
 role_contract = "plugins/seed_generation/agents/evolver.md"
 
@@ -95,6 +108,7 @@ default_model = "claude-opus-4-7"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",
+    "gpt-5.5",
 ]
 role_contract = "plugins/seed_generation/agents/meta_reviewer.md"
 

--- a/tests/plugins/seed_generation/test_cli.py
+++ b/tests/plugins/seed_generation/test_cli.py
@@ -33,14 +33,12 @@ def _good_picker() -> PickerResult:
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "proximity": RoleBinding(
             role="proximity",
-            model="text-embedding-3-small",
-            provider="openai",
+            model="claude-sonnet-4-6",
+            provider="anthropic",
             source="api_key",
-            kind="embedding",
         ),
     }
     voters = [

--- a/tests/plugins/seed_generation/test_cost_preview.py
+++ b/tests/plugins/seed_generation/test_cost_preview.py
@@ -19,49 +19,42 @@ def _make_picker_result(*, voter_source: str = "api_key") -> PickerResult:
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "critic": RoleBinding(
             role="critic",
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "proximity": RoleBinding(
             role="proximity",
-            model="text-embedding-3-small",
+            model="claude-sonnet-4-6",
             provider="openai",
             source="api_key",
-            kind="embedding",
         ),
         "pilot": RoleBinding(
             role="pilot",
             model="claude-haiku-4-5",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "ranker": RoleBinding(
             role="ranker",
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "evolver": RoleBinding(
             role="evolver",
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "meta_reviewer": RoleBinding(
             role="meta_reviewer",
             model="claude-opus-4-7",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
     }
     voters = [
@@ -145,7 +138,6 @@ def test_estimate_cost_subscription_vs_payg_split() -> None:
         model="claude-sonnet-4-6",
         provider="anthropic",
         source="claude-cli",
-        kind="completion",
     )
     pr = PickerResult(
         bindings=bindings,
@@ -159,13 +151,16 @@ def test_estimate_cost_subscription_vs_payg_split() -> None:
     assert abs(est.subscription_usd + est.payg_usd - est.total_usd) < 1e-9
 
 
-def test_estimate_cost_proximity_zero_or_negligible_for_embedding() -> None:
-    """Embedding pricing not in MODEL_PRICING → 0 estimate (acceptable)."""
+def test_estimate_cost_proximity_uses_completion_pricing() -> None:
+    """CSP-10 — Proximity now runs claude-sonnet-4-6 (LLM clustering,
+    paper §3) so its row carries a positive completion-pricing estimate,
+    NOT the pre-CSP-10 zero-estimate fallback for the dropped
+    text-embedding-3-small model.
+    """
     pr = _make_picker_result()
     est = estimate_cost(pr, candidate_count=15)
     prox_row = next(r for r in est.rows if r.role == "proximity")
-    # Embedding model not in completion pricing catalogue → 0.0
-    assert prox_row.est_usd == 0.0
+    assert prox_row.est_usd > 0.0
 
 
 def test_estimate_cost_explicit_match_count_override() -> None:
@@ -193,7 +188,6 @@ def test_format_cost_summary_marks_subscription_rows() -> None:
         model="claude-sonnet-4-6",
         provider="anthropic",
         source="claude-cli",
-        kind="completion",
     )
     pr = PickerResult(
         bindings=bindings,
@@ -225,7 +219,6 @@ def test_estimate_cost_unknown_model_logs_and_zeros() -> None:
             model="mystery-x9-unknown",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
     }
     voters = [

--- a/tests/plugins/seed_generation/test_manifest.py
+++ b/tests/plugins/seed_generation/test_manifest.py
@@ -213,38 +213,41 @@ def test_manifest_get_role_known_returns_spec() -> None:
     assert spec.default_model in spec.allowed_models
 
 
-def test_role_kind_completion_default() -> None:
-    """Roles default to kind='completion' when not specified."""
-    spec = SeedRoleSpec(
-        default_model="claude-sonnet-4-6",
-        allowed_models=["claude-sonnet-4-6"],
-    )
-    assert spec.kind == "completion"
+def test_role_spec_has_no_kind_field() -> None:
+    """CSP-10 (2026-05-22) — the ``kind`` discriminator was removed
+    from :class:`SeedRoleSpec` once the only embedding consumer
+    (Proximity) reverted to LLM clustering in CSP-8. Pin the field
+    absence so a future contributor reintroducing ``kind`` has to
+    touch this test first."""
+    assert "kind" not in SeedRoleSpec.model_fields
 
 
-def test_role_kind_embedding_explicit() -> None:
-    """An embedding role (e.g. proximity) must set kind='embedding'."""
-    spec = SeedRoleSpec(
-        default_model="text-embedding-3-small",
-        allowed_models=["text-embedding-3-small"],
-        kind="embedding",
-    )
-    assert spec.kind == "embedding"
-
-
-def test_bundled_proximity_role_is_completion() -> None:
-    """CSP-8 (2026-05-22): Proximity role flipped from ``kind="embedding"``
-    to ``kind="completion"`` when it reverted to the paper's LLM-clustering
-    pattern. The ``kind`` field stays in the schema for forward-compat —
-    a future plugin may want a non-completion role kind — but no role
-    in the bundled seed-generation manifest currently uses it."""
+def test_bundled_manifest_proximity_role_loads_without_kind() -> None:
+    """CSP-10 — the shipped TOML must not declare a ``kind`` key on
+    any role. Loading via :func:`load_manifest` returning a clean
+    :class:`SeedRoleSpec` for proximity is the smoke check; any
+    stale ``kind = "..."`` left in TOML would be silently ignored by
+    pydantic's default permissive parsing, so we also grep the file
+    body for the bare keyword."""
     clear_manifest_cache()
     manifest = load_manifest()
     proximity = manifest.get_role("proximity")
-    assert proximity.kind == "completion"
-    # Sibling check — every shipped role is now completion.
-    assert manifest.get_role("generator").kind == "completion"
-    assert manifest.get_role("critic").kind == "completion"
+    assert proximity.default_model == "claude-sonnet-4-6"
+
+    toml_body = (
+        Path(__file__).resolve().parents[3]
+        / "plugins"
+        / "seed_generation"
+        / "seed_generation.plugin.toml"
+    ).read_text(encoding="utf-8")
+    # Grep — every ``kind = "..."`` line was the embedding plumbing.
+    for line in toml_body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        assert not stripped.startswith("kind ="), (
+            f"manifest still carries an embedding-era 'kind' key: {line!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/seed_generation/test_picker.py
+++ b/tests/plugins/seed_generation/test_picker.py
@@ -8,8 +8,8 @@ P-checklist application (cycle-skill SKILL.md):
 - **P4 Environment Anchor** — overrides loaded via explicit path arg
   in tests; no env-var coupling.
 - **P7 Caller-Callee Contract** — every test asserts the resolver's
-  output shape: concrete (no ``auto``) sources, kind discriminator,
-  diversity counts, subscription set membership.
+  output shape: concrete (no ``auto``) sources, diversity counts,
+  subscription set membership.
 """
 
 from __future__ import annotations
@@ -52,9 +52,8 @@ def _make_manifest() -> SeedGenerationManifest:
             allowed_models=["claude-sonnet-4-6"],
         ),
         "proximity": SeedRoleSpec(
-            default_model="text-embedding-3-small",
-            allowed_models=["text-embedding-3-small"],
-            kind="embedding",
+            default_model="claude-sonnet-4-6",
+            allowed_models=["claude-sonnet-4-6"],
         ),
         "pilot": SeedRoleSpec(
             default_model="claude-haiku-4-5",
@@ -96,7 +95,21 @@ def test_infer_provider_claude_models() -> None:
 
 def test_infer_provider_openai_models() -> None:
     assert infer_provider("gpt-5.5") == "openai"
-    assert infer_provider("text-embedding-3-small") == "openai"
+    assert infer_provider("gpt-5.4-mini") == "openai"
+    assert infer_provider("gpt-5.3-codex") == "openai"
+
+
+def test_infer_provider_drops_legacy_o1_o3_prefixes() -> None:
+    """CSP-10 (2026-05-22) — Codex CLI's current surface is the gpt-5.x
+    family. Legacy ``o1-`` / ``o3-`` reasoning models are no longer
+    exposed by Codex CLI, so the picker rejects them rather than
+    silently routing to openai (the old behaviour bound them to the
+    OpenAI provider regardless of whether the adapter could call them).
+    """
+    with pytest.raises(ValueError, match=r"did not match any known prefix"):
+        infer_provider("o1-mini")
+    with pytest.raises(ValueError, match=r"did not match any known prefix"):
+        infer_provider("o3-mini")
 
 
 def test_infer_provider_zhipuai() -> None:
@@ -119,12 +132,10 @@ def test_pick_bindings_resolves_all_roles_with_oauth() -> None:
     for role in ("generator", "critic", "pilot", "ranker", "evolver", "meta_reviewer"):
         assert result.bindings[role].provider == "anthropic"
         assert result.bindings[role].source == "claude-cli"
-    # Proximity (embedding) — openai provider, but with OAuth probe we still
-    # land on openai-codex (semantics of "auto" probe). Note this is a
-    # known limitation; embeddings actually need api_key but the picker's
-    # job here is the binding, not the runtime check (S4 text_embed reads
-    # OPENAI_API_KEY directly so this won't break in practice).
-    assert result.bindings["proximity"].provider == "openai"
+    # Proximity now runs claude-sonnet completion (CSP-8 LLM-clustering
+    # revert, paper §3); CSP-10 dropped the embedding kind plumbing.
+    assert result.bindings["proximity"].provider == "anthropic"
+    assert result.bindings["proximity"].source == "claude-cli"
 
 
 def test_pick_bindings_resolves_payg_when_no_oauth() -> None:
@@ -159,14 +170,6 @@ def test_pick_bindings_user_override_model() -> None:
     with patch("plugins.seed_generation.picker._probe_oauth", return_value=False):
         result = pick_bindings(manifest=manifest, overrides=overrides)
     assert result.bindings["generator"].model == "claude-opus-4-7"
-
-
-def test_pick_bindings_carries_kind_discriminator() -> None:
-    manifest = _make_manifest()
-    with patch("plugins.seed_generation.picker._probe_oauth", return_value=False):
-        result = pick_bindings(manifest=manifest, overrides={})
-    assert result.bindings["proximity"].kind == "embedding"
-    assert result.bindings["generator"].kind == "completion"
 
 
 def test_pick_bindings_voter_panel_resolved() -> None:

--- a/tests/plugins/seed_generation/test_pre_flight.py
+++ b/tests/plugins/seed_generation/test_pre_flight.py
@@ -21,14 +21,12 @@ def _good_picker() -> PickerResult:
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
         "proximity": RoleBinding(
             role="proximity",
-            model="text-embedding-3-small",
-            provider="openai",
+            model="claude-sonnet-4-6",
+            provider="anthropic",
             source="api_key",
-            kind="embedding",
         ),
     }
     voters = [
@@ -68,8 +66,11 @@ def test_check_auth_provides_fix_hint() -> None:
         assert any(token in issue.fix for token in ("API_KEY", "login", "geode"))
 
 
-def test_check_auth_embedding_role_probes_openai_api_key() -> None:
-    """Embedding role short-circuits to (openai, api_key) for the probe."""
+def test_check_auth_probes_every_resolved_binding() -> None:
+    """CSP-10 — every role binding flows through the same probe path
+    (the pre-CSP-10 embedding-role short-circuit is gone). Verify the
+    probe sees each role's resolved (provider, source) at least once.
+    """
     picker = _good_picker()
     probed: list[tuple[str, str]] = []
 
@@ -79,6 +80,9 @@ def test_check_auth_embedding_role_probes_openai_api_key() -> None:
 
     with patch("plugins.seed_generation.pre_flight._credential_present", side_effect=_probe):
         check_auth(picker)
+    # _good_picker has 2 role bindings + 3 voters all on (anthropic|openai, api_key);
+    # dedup collapses the repeats, so the unique probed set is exactly those pairs.
+    assert ("anthropic", "api_key") in probed
     assert ("openai", "api_key") in probed
 
 
@@ -90,7 +94,6 @@ def test_check_auth_dedups_repeated_pairs() -> None:
             model="claude-sonnet-4-6",
             provider="anthropic",
             source="api_key",
-            kind="completion",
         ),
     }
     voters = [


### PR DESCRIPTION
## Summary

- Delete the residual embedding ``kind`` discriminator left on `SeedRoleSpec` / `RoleBinding` + the dead branches in `pre_flight.check_auth` and `cost_preview._per_call_cost`. CSP-8 reverted Proximity to LLM clustering; CSP-10 finishes the dead-code removal.
- Realign `seed_generation.plugin.toml` `allowed_models` lists with the **2026-05-22 Claude Code + Codex CLI surface** (anthropic: opus-4-7 / sonnet-4-6 / haiku-4-5; codex: gpt-5.5 / 5.4 / 5.4-mini / 5.3-codex — cross-checked against `core/llm/model_pricing.toml`).
- Drop legacy `o1-` / `o3-` prefix mappings from `picker._PROVIDER_PREFIX_MAP` — Codex CLI no longer exposes those families, so silent binding to the openai adapter would mis-route at runtime.

## Why

After CSP-8 reverted the only embedding consumer (Proximity) to the paper's §3 LLM-clustering pattern, the manifest schema still carried `kind: Literal["completion", "embedding"]` "for forward-compat", picker still mapped `text-embedding-*` → openai, pre_flight still had an `if binding.kind == "embedding":` short-circuit, and three plugin docstrings still described pre-CSP-8 behaviour. That's accumulated rot — a future contributor reading the code can't tell which branches are live.

At the same time, the per-role `allowed_models` lists were stamped pre-2026 and missed several models that Claude Code / Codex CLI now expose (gpt-5.3-codex for Pilot, gpt-5.4 as Generator cost variance, gpt-5.5 on judge / evolver / meta-reviewer for Codex parity). Pinning the lineup to the model_pricing.toml catalogue makes the manifest a single source of truth.

## Changes

| File | Change |
|------|--------|
| `plugins/seed_generation/manifest.py` | Drop `kind` field + `Literal` import; rewrite class docstring |
| `plugins/seed_generation/picker.py` | Drop `text-embedding-` mapping, `o1-` / `o3-` mappings, RoleBinding.kind field, `Literal` import |
| `plugins/seed_generation/pre_flight.py` | Drop embedding-role short-circuit in `check_auth`; every binding now flows through the same probe |
| `plugins/seed_generation/cost_preview.py` | Rewrite `_per_call_cost` docstring (no more "embedding-specific catalogue" hedge) |
| `plugins/seed_generation/seed_generation.plugin.toml` | Drop `kind = "completion"` line; realign 7-role `allowed_models` lists per 2026-05-22 Claude Code + Codex CLI lineup |
| `plugins/seed_generation/agents/{__init__,base,generator}.py` | Rewrite outdated docstrings (3-track / pre-CSP-8 bypass / "compute embeddings" paragraph) |
| `tests/plugins/seed_generation/test_manifest.py` | New pins: `SeedRoleSpec.model_fields` has no `kind`; TOML body has no `kind =` line |
| `tests/plugins/seed_generation/test_picker.py` | Add gpt-5.4-mini / gpt-5.3-codex assertions; add `o1-` / `o3-` rejection test; drop kind-discriminator test |
| `tests/plugins/seed_generation/{test_pre_flight,test_cli,test_cost_preview}.py` | Drop `kind="..."` kwargs; Proximity test fixtures retire `text-embedding-3-small` |
| `CHANGELOG.md` | Two `[Unreleased]` entries — lineup + plumbing drop |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `kind` field removed from SeedRoleSpec | Implemented | + Literal import removed |
| `kind` field removed from RoleBinding | Implemented | + Literal import removed |
| `text-embedding-` prefix dropped | Implemented | picker `_PROVIDER_PREFIX_MAP` |
| `o1-` / `o3-` prefix dropped | Implemented | Codex CLI no longer exposes those |
| Pre-flight embedding branch deleted | Implemented | every binding probes uniformly now |
| Cost-preview embedding hedge updated | Implemented | docstring only — code path was already dead |
| TOML `kind = "completion"` line removed | Implemented | proximity role |
| `allowed_models` realigned 2026-05-22 | Implemented | 4 roles updated (pilot/ranker/evolver/meta_reviewer + generator cost variance) |
| Stale agent docstrings refreshed | Implemented | 3 files |
| Regression pins added | Implemented | model_fields + TOML grep |

## Verification

- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/` clean (790 files)
- [x] `mypy core/ plugins/` clean (400 source files)
- [x] `lint-imports` 4/4 contracts kept
- [x] `pytest tests/plugins/seed_generation/` — all green (was 15 failing before fix-ups)
- [x] `pytest tests/ -m "not live"` — only known-local `test_get_autoresearch_config_defaults_match_module_constants` fails (user-machine `~/.geode/config.toml` pollution; passes in CI — pre-existing, unrelated to CSP-10)
- [x] `geode version` smoke — `GEODE v0.99.29`

## Reference

- CSP-8 (PR #1467) — Proximity LLM-clustering revert (paper §3)
- arXiv:2502.18864 §3 — co-scientist 6-role topology
- `core/llm/model_pricing.toml` — canonical model catalogue
- Claude Code CLI + Codex CLI surface (as of 2026-05-22)