### PR TITLE
release: v0.99.30 — CSP-7+8+9+10 bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.30] - 2026-05-22
+
+> Reproducibility-ratchet trilogy completion (CSP-7 in-repo state +
+> CSP-8 paper-§3 LLM-clustering Proximity + CSP-9 plugin-colocated
+> prompts) plus CSP-10 embedding plumbing drop + 2026-05-22 supported
+> model lineup realign. Net effect — a fresh clone reproduces the
+> seed-generation pipeline on any host without manual `~/.geode/`
+> bootstrap or `.claude/agents/` setup, every role goes through the
+> completion path, and `allowed_models` lists track today's Claude
+> Code + Codex CLI surface.
+
 ### Changed
 
 - **CSP-10 — supported-model lineup realigned + embedding plumbing removed**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.29
+- **Version**: 0.99.30
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
@@ -93,7 +93,7 @@ These cannot be violated at any stage. Violations must be immediately halted and
 | | No unauthorized live test (`-m live`) execution | Cost control (P3) |
 | **Docs** | No omitting CHANGELOG from code commits | Traceability |
 | | No leaving `[Unreleased]` on main | Release discipline |
-| | No version mismatch across 4 locations | Single source of truth |
+| | No version mismatch across 5 locations | Single source of truth |
 | **PR** | No PR body without HEREDOC | Format consistency |
 | | No PR without a "Why" rationale | Decision record |
 | | No PR body without Summary/Why/Changes/Verification sections | Information completeness |
@@ -255,7 +255,7 @@ See `geode-changelog` skill.
 
 | Sync Target | Verification |
 |-------------|--------------|
-| Version across 4 locations | CHANGELOG, CLAUDE.md, README.md, pyproject.toml |
+| Version across 5 locations | CHANGELOG, CLAUDE.md, README.md, README.ko.md, pyproject.toml |
 | Metrics | Tests, Modules, Commands — measured values |
 
 **Versioning**: New feature = MINOR, Bug fix = PATCH, Docs only = none.

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.29 — Long-running Autonomous Execution Harness
+# GEODE v0.99.30 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.29 — Long-running Autonomous Execution Harness
+# GEODE v0.99.30 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.29**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.30**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.29"
+version = "0.99.30"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.29"
+version = "0.99.30"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Version bump 0.99.29 → 0.99.30 across the 5 stamp locations (CHANGELOG, CLAUDE.md, README.md, README.ko.md, pyproject.toml).
- Promote `[Unreleased]` → `[0.99.30] - 2026-05-22` in CHANGELOG with a trilogy-completion + CSP-10 summary blurb.
- CLAUDE.md doc fix: "version across 4 locations" → "5 locations" (README.ko.md was the missing slot).

## Bundle contents

| PR | Title |
|----|-------|
| #1466 | PR-CSP-7 — symlink-free in-repo state (STATE_ROOT + JSON pointer) |
| #1467 | PR-CSP-8 — Proximity reverted to paper §3 LLM-clustering |
| #1469 | PR-CSP-9 — co-scientist prompts colocated with plugin package |
| #1470 | PR-CSP-10 — embedding plumbing drop + 2026-05-22 model lineup realign |

## Verification

- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/` clean (790 files)
- [x] `mypy core/ plugins/` clean (400 source files)
- [x] `geode version` smoke → `GEODE v0.99.30`
- [ ] CI 5/5 — pending