### PR TITLE
PR-LQ-Phase1 — LaneQueue hierarchy invariant restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **LaneQueue Phase 1 — hierarchy invariant restored**. The
+  ``seed-generation`` workload lane defaulted to ``max_concurrent=16``
+  while the ``global`` lane was capped at 8 — a textbook hierarchy
+  violation. The 16-slot advertisement was a false signal: every leaf
+  sub-agent call still funnels through ``global`` and blocked at 8.
+  Dropped ``DEFAULT_SEED_PIPELINE_CONCURRENCY`` to ``4`` so workload
+  cap composes correctly under the global cap, and added an explicit
+  invariant test (``tests/test_lane_queue.py::TestAcquireAllSync::
+  test_workload_cap_does_not_exceed_global_cap_invariant``) that fails
+  if any registered workload lane defaults to a cap larger than
+  ``DEFAULT_GLOBAL_CONCURRENCY``. The seed-generation orchestrator
+  now walks the full OpenClaw hierarchy
+  (``["session", "seed-generation", "global"]``) via the new sync
+  ``LaneQueue.acquire_all`` API; the ``session`` key is
+  ``seed-generation:<run_id>`` so concurrent ``Pipeline.run()`` calls
+  for the same run serialize (kills the pre-PR race where two launches
+  of the same ``run_id`` non-atomically incremented ``state.usd_spent``
+  and friends). Re-raising the cap is gated on Phase 2 (sub-agent
+  lane isolation) per
+  [[project_lanequeue_handoff_2026_05_22]].
+
 ## [0.99.30] - 2026-05-22
 
 > Reproducibility-ratchet trilogy completion (CSP-7 in-repo state +

--- a/core/orchestration/lane_queue.py
+++ b/core/orchestration/lane_queue.py
@@ -497,6 +497,48 @@ class LaneQueue:
             for item in reversed(acquired):
                 item._raw_release(key)
 
+    @contextmanager
+    def acquire_all(
+        self,
+        key: str,
+        lane_names: list[str],
+    ) -> Generator[None, None, None]:
+        """Sync sibling of :meth:`acquire_all_async`.
+
+        Provided so sync call sites (e.g. ``Pipeline._run_phase`` —
+        the seed-generation orchestrator) can compose the OpenClaw
+        hierarchy ``["session", <workload>, "global"]`` without bouncing
+        through ``asyncio.run``. Mirrors the async version's
+        ordering + partial-failure release semantics: lanes are
+        acquired in the order given and released in reverse, so a
+        timeout mid-chain still releases everything already held.
+        """
+        acquired: list[Lane | SessionLane] = []
+        try:
+            for name in lane_names:
+                if name == "session":
+                    if self._session_lane is None:
+                        continue
+                    if not self._session_lane._raw_acquire(key):
+                        raise TimeoutError(f"SessionLane timeout for key '{key}'")
+                    acquired.append(self._session_lane)
+                else:
+                    lane = self._lanes.get(name)
+                    if lane is None:
+                        raise KeyError(f"Lane '{name}' not found")
+                    if not lane._raw_acquire(key):
+                        raise TimeoutError(
+                            f"Lane '{name}' timeout after {lane.timeout_s}s "
+                            f"(max_concurrent={lane.max_concurrent})"
+                        )
+                    acquired.append(lane)
+
+            yield
+
+        finally:
+            for item in reversed(acquired):
+                item._raw_release(key)
+
     def status(self) -> dict[str, Any]:
         """Get status of all lanes."""
         result: dict[str, Any] = {}

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -34,7 +34,17 @@ def __getattr__(name: str) -> Any:
 # ---------------------------------------------------------------------------
 DEFAULT_GLOBAL_CONCURRENCY = 8
 DEFAULT_GATEWAY_CONCURRENCY = 4
-DEFAULT_SEED_PIPELINE_CONCURRENCY = 16
+# PR-LQ-Phase1 (2026-05-22) — seed-generation lane bumped DOWN from 16 to 4
+# to restore the OpenClaw lane hierarchy invariant
+# ``max(workload_lane) <= max(global)``. Pre-PR the workload cap (16) was
+# strictly larger than the global cap (8), so 16 "seed-generation slots" was
+# a false signal — leaf sub-agent calls still funnel through the global lane
+# and blocked at 8. The lane cap is now the same load shape the global
+# semaphore can actually deliver, and an explicit invariant test in
+# ``tests/test_lane_queue.py`` guards future drift. Re-raising the cap is
+# fine once the global lane grows OR a Claude-CLI-specific sub-agent lane
+# isolates that path (see [[project_lanequeue_handoff_2026_05_22]] Phase 2).
+DEFAULT_SEED_PIPELINE_CONCURRENCY = 4
 
 # Module-level accessors set by build_auth().
 # Both runtime LLM dispatch and the CLI (`/login`) read from the
@@ -157,15 +167,25 @@ def build_default_lanes() -> LaneQueue:
 
         SessionLane (per-key serial, max=256)
             ↓
-        Workload Lanes (per-workload cap)
-        ├── "gateway"  (max=4)  — Slack/Discord/Telegram messages
-        └── (CLI/sub-agent use global only)
+        Workload Lanes (per-workload cap, MUST be <= global)
+        ├── "gateway"          (max=4)  — Slack/Discord/Telegram messages
+        ├── "seed-generation"  (max=4)  — co-scientist 8-role sub-agent pipeline
+        └── (CLI/general sub-agent paths use global only)
             ↓
         "global" (max=8) — total system capacity
 
     Gateway messages acquire ["session", "gateway", "global"].
-    CLI/sub-agents acquire ["session", "global"] (no workload lane).
-    This prevents Gateway from starving CLI when busy.
+    Seed-generation phases acquire ["session", "seed-generation", "global"]
+    so the workload cap composes with the global cap rather than bypassing
+    it. CLI/general sub-agents acquire ["session", "global"] (no workload
+    lane). This prevents Gateway from starving CLI when busy and prevents
+    seed-generation fan-out from saturating the global slot pool.
+
+    Hierarchy invariant (PR-LQ-Phase1, 2026-05-22): every workload lane's
+    ``max_concurrent`` MUST be <= the ``global`` lane's cap. A workload
+    cap larger than global is a false signal — the leaf semaphore still
+    blocks at the global cap. ``tests/test_lane_queue.py`` pins the
+    invariant.
     """
     from core.orchestration.lane_queue import SessionLane
 

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -859,21 +859,33 @@ class Pipeline:
         return result
 
     def _acquire_lane(self, role: str) -> Any:
-        """Return a context manager that acquires the ``seed-generation`` lane.
+        """Return a context manager that walks the OpenClaw lane hierarchy.
 
-        When no ``LaneQueue`` was supplied (test path) or the lane is not
-        registered, returns a no-op context manager. The actual semaphore
-        gating only takes effect when the agent fans out via
-        ``SubAgentManager.delegate(tasks=[…])`` in S2+.
+        Acquires ``["session", "seed-generation", "global"]`` in order so
+        per-role concurrency is bounded by BOTH the seed-generation
+        workload cap and the global cap (PR-LQ-Phase1, 2026-05-22). The
+        SessionLane keys on ``seed-generation:<run_id>`` so two concurrent
+        ``Pipeline.run()`` calls for the same ``run_id`` serialize
+        (prevents the pre-PR race where two launches of the same run
+        non-atomically incremented ``state.usd_spent`` etc.).
+
+        When no ``LaneQueue`` was supplied (test path) or the
+        ``seed-generation`` lane is not registered, returns a no-op
+        context manager. The actual semaphore gating only takes effect
+        when the agent fans out via ``SubAgentManager.delegate(tasks=[…])``
+        in S2+.
         """
         from contextlib import nullcontext
 
         if self._lane_queue is None:
             return nullcontext()
-        lane = self._lane_queue.get_lane("seed-generation")
-        if lane is None:
+        if self._lane_queue.get_lane("seed-generation") is None:
             return nullcontext()
-        return lane.acquire(f"seed-generation/{self.state.run_id}/{role}")
+        session_key = f"seed-generation:{self.state.run_id}"
+        return self._lane_queue.acquire_all(
+            session_key,
+            ["session", "seed-generation", "global"],
+        )
 
     def _emit_hook(self, event: HookEvent, role: str, **extra: Any) -> None:
         if self._hooks is None:

--- a/tests/core/orchestration/test_seed_generation_lane.py
+++ b/tests/core/orchestration/test_seed_generation_lane.py
@@ -8,7 +8,11 @@ wiring. The third checks the constant directly.
 from __future__ import annotations
 
 import pytest
-from core.wiring.container import DEFAULT_SEED_PIPELINE_CONCURRENCY, build_default_lanes
+from core.wiring.container import (
+    DEFAULT_GLOBAL_CONCURRENCY,
+    DEFAULT_SEED_PIPELINE_CONCURRENCY,
+    build_default_lanes,
+)
 
 
 @pytest.fixture
@@ -28,8 +32,16 @@ def real_queue(monkeypatch: pytest.MonkeyPatch) -> object:
     return build_default_lanes()
 
 
-def test_seed_generation_lane_max_concurrent_is_16() -> None:
-    assert DEFAULT_SEED_PIPELINE_CONCURRENCY == 16
+def test_seed_generation_lane_default_matches_global_safe_share() -> None:
+    """PR-LQ-Phase1 (2026-05-22) — seed-generation cap MUST be <= global.
+
+    Pre-PR the cap was 16 while global was 8, a hierarchy violation that
+    advertised 16 slots a leaf semaphore could never deliver. Lowered
+    to 4 so the workload cap composes correctly with the global cap.
+    Re-raising requires growing global or introducing a sub-agent lane
+    (see [[project_lanequeue_handoff_2026_05_22]] Phase 2)."""
+    assert DEFAULT_SEED_PIPELINE_CONCURRENCY == 4
+    assert DEFAULT_SEED_PIPELINE_CONCURRENCY <= DEFAULT_GLOBAL_CONCURRENCY
 
 
 def test_seed_generation_lane_is_registered_by_real_builder(real_queue: object) -> None:

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -166,18 +166,30 @@ def test_pipeline_accepts_lane_queue_without_lane_registered() -> None:
 
 
 def test_pipeline_acquires_lane_when_registered() -> None:
-    """When the seed-generation lane is on the queue, execute is gated through it."""
+    """When the OpenClaw lane chain (session → seed-generation → global)
+    is on the queue, execute is gated through every layer.
+
+    PR-LQ-Phase1 (2026-05-22) — ``_acquire_lane`` now walks the full
+    chain via ``LaneQueue.acquire_all``. The test registers all three
+    layers so it mirrors production wiring; reaching `run()` completion
+    proves acquire/release symmetry across all 7 phases for each layer.
+    """
+    from core.orchestration.lane_queue import SessionLane
+
     registry, _ = _make_registry_with_all_stubs()
     state = PipelineState(run_id="t-lane", target_dim="x", gen_tag="gen2")
     queue = LaneQueue()
+    queue.set_session_lane(SessionLane(max_sessions=8))
     queue.add_lane("seed-generation", max_concurrent=4, timeout_s=5.0)
+    queue.add_lane("global", max_concurrent=8, timeout_s=5.0)
     Pipeline(state, registry, lane_queue=queue).run()
-    # No assertion target beyond completion — the lane.acquire would block
-    # if the slot wasn't released, so reaching here proves acquire/release
-    # symmetry across all 7 phases.
+
     seed_lane = queue.get_lane("seed-generation")
+    global_lane = queue.get_lane("global")
     assert seed_lane is not None
+    assert global_lane is not None
     assert seed_lane.active_count == 0
+    assert global_lane.active_count == 0
 
 
 class _RecordingHookSystem:

--- a/tests/test_lane_queue.py
+++ b/tests/test_lane_queue.py
@@ -461,3 +461,84 @@ class TestSessionLane:
             assert sl.active_count == 0
 
         asyncio.run(scenario())
+
+
+class TestAcquireAllSync:
+    """PR-LQ-Phase1 (2026-05-22) — sync sibling of ``acquire_all_async``.
+
+    The seed-generation orchestrator runs each phase synchronously and
+    needs to compose the OpenClaw lane hierarchy
+    ``["session", "seed-generation", "global"]`` without bouncing through
+    ``asyncio.run``. This class pins the contract: ordering, partial-
+    failure release, missing-lane errors.
+    """
+
+    def test_acquire_all_runs_through_session_workload_and_global(self) -> None:
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=8))
+        q.add_lane("seed-generation", max_concurrent=2)
+        q.add_lane("global", max_concurrent=4)
+
+        with q.acquire_all("run-1", ["session", "seed-generation", "global"]):
+            assert q.get_lane("seed-generation").active_count == 1  # type: ignore[union-attr]
+            assert q.get_lane("global").active_count == 1  # type: ignore[union-attr]
+        assert q.get_lane("seed-generation").active_count == 0  # type: ignore[union-attr]
+        assert q.get_lane("global").active_count == 0  # type: ignore[union-attr]
+
+    def test_acquire_all_unknown_lane_releases_prior_acquisitions(self) -> None:
+        """If a later lane name is missing, the earlier acquisitions release."""
+        q = LaneQueue()
+        q.add_lane("global", max_concurrent=2)
+
+        with pytest.raises(KeyError, match="not found"):
+            with q.acquire_all("k1", ["global", "missing"]):
+                pass
+
+        # global should be back to 0 active (partial-failure release).
+        assert q.get_lane("global").active_count == 0  # type: ignore[union-attr]
+
+    def test_acquire_all_skips_session_when_none_registered(self) -> None:
+        """Same shape as acquire_all_async: ``session`` is silently skipped
+        when no SessionLane was registered."""
+        q = LaneQueue()
+        q.add_lane("global", max_concurrent=2)
+        with q.acquire_all("k1", ["session", "global"]):
+            assert q.get_lane("global").active_count == 1  # type: ignore[union-attr]
+        assert q.get_lane("global").active_count == 0  # type: ignore[union-attr]
+
+    def test_acquire_all_releases_in_reverse_order(self) -> None:
+        """LIFO release matches acquire_all_async's finally-loop semantics
+        (``for item in reversed(acquired): item._raw_release(key)``)."""
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=8))
+        q.add_lane("seed-generation", max_concurrent=2)
+        q.add_lane("global", max_concurrent=4)
+
+        with q.acquire_all("k1", ["session", "seed-generation", "global"]):
+            pass
+        # After release every lane is empty.
+        for name in ("seed-generation", "global"):
+            assert q.get_lane(name).active_count == 0  # type: ignore[union-attr]
+
+    def test_workload_cap_does_not_exceed_global_cap_invariant(self) -> None:
+        """Hierarchy invariant — ``max(workload_lane) <= max(global)``.
+
+        A workload cap larger than global is a false signal: the leaf
+        semaphore still funnels through the global lane. The seed-
+        generation lane (DEFAULT_SEED_PIPELINE_CONCURRENCY) is the
+        first concrete consumer of this invariant.
+        """
+        from core.wiring.container import (
+            DEFAULT_GATEWAY_CONCURRENCY,
+            DEFAULT_GLOBAL_CONCURRENCY,
+            DEFAULT_SEED_PIPELINE_CONCURRENCY,
+        )
+
+        for workload_name, workload_cap in (
+            ("gateway", DEFAULT_GATEWAY_CONCURRENCY),
+            ("seed-generation", DEFAULT_SEED_PIPELINE_CONCURRENCY),
+        ):
+            assert workload_cap <= DEFAULT_GLOBAL_CONCURRENCY, (
+                f"workload lane {workload_name!r} cap {workload_cap} > "
+                f"global cap {DEFAULT_GLOBAL_CONCURRENCY} — hierarchy violation"
+            )

--- a/tests/test_lane_queue.py
+++ b/tests/test_lane_queue.py
@@ -490,9 +490,11 @@ class TestAcquireAllSync:
         q = LaneQueue()
         q.add_lane("global", max_concurrent=2)
 
-        with pytest.raises(KeyError, match="not found"):
-            with q.acquire_all("k1", ["global", "missing"]):
-                pass
+        with (
+            pytest.raises(KeyError, match="not found"),
+            q.acquire_all("k1", ["global", "missing"]),
+        ):
+            pass
 
         # global should be back to 0 active (partial-failure release).
         assert q.get_lane("global").active_count == 0  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

- Drop ``DEFAULT_SEED_PIPELINE_CONCURRENCY`` from 16 to 4 so the workload cap composes correctly with the global cap (was 16 > 8, a hierarchy violation that advertised slots the leaf semaphore could never deliver).
- Add sync ``LaneQueue.acquire_all`` API mirroring the async sibling — partial-failure release semantics included — so the seed-generation orchestrator can walk ``["session", "seed-generation", "global"]`` without bouncing through ``asyncio.run``.
- ``Pipeline._acquire_lane`` keys on ``seed-generation:<run_id>`` and walks the full lane chain. Same-``run_id`` concurrent ``Pipeline.run()`` calls now serialize, closing the pre-PR race on ``state.usd_spent`` / ``prompt_tokens`` / ``completion_tokens``.
- New invariant test fails if any registered workload lane defaults to a cap larger than ``DEFAULT_GLOBAL_CONCURRENCY``.

## Why

Phase 1 of the LaneQueue 5-phase plan ([[project_lanequeue_handoff_2026_05_22]]). Pre-PR every claim of "16 seed-generation slots" lied — the leaf sub-agent path still blocks at the 8-slot global semaphore. Same code also exposed the OAuth bucket to ``gateway(4) + global(8) + seed-generation(16) = 28`` theoretical in-flight LLM calls on a single token, well past Anthropic's burst limiter (3-4 concurrent in claude-cli). And same-``run_id`` re-launches raced on ``state.usd_spent +=`` because no SessionLane key tied them together.

This PR makes the lane shape match the reality the global cap can deliver, pins the invariant in tests, and serializes per-run launches via SessionLane. Re-raising the seed-generation cap depends on Phase 2 (sub-agent lane isolation + paperclip OAuth usage polling).

## Changes

| File | Change |
|------|--------|
| ``core/wiring/container.py`` | ``DEFAULT_SEED_PIPELINE_CONCURRENCY`` 16 → 4; updated ``build_default_lanes`` docstring with the hierarchy invariant |
| ``core/orchestration/lane_queue.py`` | New sync ``LaneQueue.acquire_all`` — partial-failure release in reverse order, mirrors async sibling |
| ``plugins/seed_generation/orchestrator.py`` | ``Pipeline._acquire_lane`` walks ``["session", "seed-generation", "global"]`` with session key ``seed-generation:<run_id>`` |
| ``tests/core/orchestration/test_seed_generation_lane.py`` | Updated default-value test (16 → 4) + invariant assertion |
| ``tests/test_lane_queue.py`` | New ``TestAcquireAllSync`` class (5 tests: hierarchy walk, partial-failure release, session skip, LIFO release, **workload ≤ global invariant**) |
| ``CHANGELOG.md`` | ``[Unreleased] / ### Changed`` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Cap drop 16 → 4 | Implemented | ``DEFAULT_SEED_PIPELINE_CONCURRENCY`` |
| Workload ≤ global invariant test | Implemented | ``tests/test_lane_queue.py::TestAcquireAllSync::test_workload_cap_does_not_exceed_global_cap_invariant`` |
| Sync ``acquire_all`` API | Implemented | mirrors async sibling 1:1 |
| Orchestrator walks full hierarchy | Implemented | ``Pipeline._acquire_lane`` |
| SessionLane join for same-run race | Implemented | session key = ``seed-generation:<run_id>`` |
| Docstring drift | Updated | ``build_default_lanes`` describes the new shape |

## Verification

- [x] ``ruff check core/ tests/ plugins/`` clean
- [x] ``ruff format --check core/ tests/ plugins/`` clean (790 files)
- [x] ``mypy core/ plugins/`` clean (400 source files)
- [x] ``pytest tests/test_lane_queue.py tests/core/orchestration/test_seed_generation_lane.py tests/plugins/seed_generation/`` all green
- [ ] Full pytest suite — pending CI

## Reference

- [[project_lanequeue_handoff_2026_05_22]] — Phase 1 spec; Phase 2-5 follow-ups
- ``core/orchestration/lane_queue.py`` — OpenClaw lane pattern
- paperclip ``packages/adapters/claude-local`` — burst-limit grounding (Phase 2+ source)