### PR TITLE
PR-LQ-Phase2 — claude-cli-subagent lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **LaneQueue Phase 2 — ``claude-cli-subagent`` lane**. New module-
+  level :class:`~core.orchestration.lane_queue.Lane` at
+  ``core/orchestration/claude_cli_lane.py`` (same pattern as
+  ``core/llm/audit_lane.py``) caps the concurrent ``claude --print``
+  subprocess fan-out from BOTH spawn sites — the self-improving-loop
+  mutator runner
+  (:func:`core.self_improving_loop.cli_subprocess.invoke_claude_cli`)
+  and the Petri inspect_ai bridge
+  (:class:`plugins.petri_audit.claude_cli_provider.ClaudeCliAPI.generate`)
+  — at ``DEFAULT_CLAUDE_CLI_LANE_MAX=2``, one slot below the public
+  3-4 burst-limiter floor (anthropics/claude-code#53922) so the
+  operator's host Claude Code session has bucket headroom. Operators
+  tune via ``GEODE_CLAUDE_CLI_LANE_MAX`` (positive int; empty /
+  non-int / non-positive falls back to the default). Sync + async
+  acquire helpers (:func:`acquire_claude_cli_lane` /
+  :func:`acquire_claude_cli_lane_async`) share the SAME semaphore so
+  the cap composes across the two spawn paths. The lane is mirrored
+  in ``build_default_lanes`` for ``LaneQueue.status()`` dashboards.
+  Phase 3 (paperclip OAuth-usage polling) will plug into the same
+  acquire site to surface 5h-bucket telemetry before each slot grab.
+
 ### Changed
 
 - **LaneQueue Phase 1 — hierarchy invariant restored**. The

--- a/core/orchestration/claude_cli_lane.py
+++ b/core/orchestration/claude_cli_lane.py
@@ -1,0 +1,230 @@
+"""Module-level Lane for ``claude --print`` sub-agent subprocess
+serialisation.
+
+PR-LQ-Phase2 (2026-05-22) — second leg of the LaneQueue 5-phase plan
+([[project_lanequeue_handoff_2026_05_22]]).
+
+Why a separate lane (not just ``global``)
+=========================================
+
+Both the self-improving-loop mutator runner
+(:func:`core.self_improving_loop.cli_subprocess.invoke_claude_cli`) and
+the Petri inspect_ai bridge
+(:class:`plugins.petri_audit.claude_cli_provider.ClaudeCliAPI`) spawn
+``claude --print`` subprocesses for their inference path. Those
+subprocesses go out through the host's Claude Code OAuth bucket — the
+SAME bucket the operator's interactive Claude Code session is using
+right now. Anthropic rate-limits per-account-bucket, not per-process,
+and the public surface confirms a burst limiter at **3-4 concurrent
+in-flight** before 429s (anthropics/claude-code#53922; paperclip
+empirical findings — see [[project_lanequeue_handoff_2026_05_22]]).
+
+The ``global`` lane (max=8) is too permissive for this path: 8
+concurrent ``claude --print`` spawns saturate the OAuth bucket and
+collide with the operator's host session. Conversely the ``global``
+lane is too restrictive for non-Claude-CLI traffic (API-billed
+Anthropic / OpenAI completions). The two flows need separate caps,
+which is why this lane sits alongside ``global`` rather than under it.
+
+Why ``max_concurrent=2``
+========================
+
+One slot below the public burst-limiter floor of 3, leaving room for
+the operator's host Claude Code session to occupy 1 slot without
+hitting the 429 threshold. Two stacked rationales:
+
+1. **Burst limiter headroom**: host session (≈1 in-flight) + 2
+   ``claude --print`` sub-agents = 3 total = burst-limit floor. A 4th
+   would race the limiter and start drawing 429 + Retry-After.
+2. **Conservative until Phase 3**: paperclip's OAuth-usage polling
+   (Phase 3) would let us raise the cap on tiers with larger 5h
+   token pools. Until then we ship the safe lower bound and let
+   operators tune via environment override
+   (:data:`CLAUDE_CLI_LANE_MAX_ENV`).
+
+**Pre-flight measurement gap**: [[project_lanequeue_handoff_2026_05_22]]
+calls for a one-time measurement of the operator's actual burst
+threshold before Phase 2. Live measurement requires network access to
+the operator's OAuth bucket which CSP-sprint sessions don't have, so
+this PR ships the conservative public-doc-grounded cap (2) and
+exposes the override for post-deploy tuning.
+
+Why module-level (not LaneQueue-registered)
+===========================================
+
+Same rationale as
+:mod:`core.llm.audit_lane`:
+
+* The self-improving-loop mutator runs from contexts where the global
+  ``LaneQueue`` singleton (built in
+  ``core/wiring/container.py::build_default_lanes``) may not exist
+  (standalone ``python -m`` invocations, pytest fixtures that skip
+  the container).
+* The inspect_ai bridge is loaded as a Petri plugin and instantiates
+  its ``ModelAPI`` subclass through inspect_ai's router, well outside
+  the path that constructs the container.
+
+A module-level :class:`~core.orchestration.lane_queue.Lane` works in
+all three contexts (daemon, CLI, plugin-mounted inspect_ai) without
+plumbing a queue reference through the call chain.
+
+The lane name (:data:`CLAUDE_CLI_LANE_NAME`) is also registered on the
+default :class:`~core.orchestration.lane_queue.LaneQueue` (see
+``core.wiring.container.build_default_lanes``) so dashboards / status
+endpoints surface it alongside ``gateway`` / ``global`` /
+``seed-generation``. The two registrations stay in lockstep via the
+constants defined in this module.
+
+Future Phase 3+ integration
+===========================
+
+Phase 3 (paperclip P1 port) will surface OAuth-usage telemetry via
+``core/llm/oauth_usage.py`` (planned). The lane's
+:meth:`~core.orchestration.lane_queue.Lane.acquire` call site is the
+natural integration point: poll utilisation immediately before
+``_raw_acquire``, and back off when ``five_hour.utilization >= 0.8``.
+That work is scoped to Phase 3 and explicitly out of this PR.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+
+from core.orchestration.lane_queue import Lane
+
+__all__ = [
+    "CLAUDE_CLI_LANE_MAX_ENV",
+    "CLAUDE_CLI_LANE_NAME",
+    "CLAUDE_CLI_LANE_TIMEOUT_S",
+    "DEFAULT_CLAUDE_CLI_LANE_MAX",
+    "acquire_claude_cli_lane",
+    "acquire_claude_cli_lane_async",
+    "get_claude_cli_lane",
+    "resolve_claude_cli_lane_max",
+]
+
+
+CLAUDE_CLI_LANE_NAME = "claude-cli-subagent"
+"""Lane name surfaced in logs + ``LaneQueue.status()`` dashboards."""
+
+CLAUDE_CLI_LANE_MAX_ENV = "GEODE_CLAUDE_CLI_LANE_MAX"
+"""Operator override for :data:`DEFAULT_CLAUDE_CLI_LANE_MAX`.
+
+Set to a positive integer to raise / lower the cap (e.g. operators on
+Max20x tier with larger 5h pools may raise to 3). Invalid values
+silently fall back to the default — the lane should never harden into
+"no slots" mid-run because of a typo.
+"""
+
+DEFAULT_CLAUDE_CLI_LANE_MAX = 2
+"""One slot below the documented 3-4 burst limiter floor so the
+operator's host Claude Code session occupies the spare slot without
+crossing the 429 threshold. See the module docstring for the full
+rationale."""
+
+CLAUDE_CLI_LANE_TIMEOUT_S = 300.0
+"""5 minutes. A legitimate ``claude --print`` for mutator-sized prompts
+finishes in seconds-to-tens-of-seconds; an inspect_ai eval call may
+take a minute or two. The lane wait should outlast a queued slow
+call but not so long that a genuinely-stuck subprocess hides the
+problem from operators."""
+
+
+_CLAUDE_CLI_LANE: Lane | None = None
+_CLAUDE_CLI_LANE_INIT_LOCK = threading.Lock()
+"""Double-checked locking around lazy init (same pattern as
+``core/llm/audit_lane.py``). Two concurrent first-callers could
+otherwise observe ``_CLAUDE_CLI_LANE is None`` and construct distinct
+:class:`Lane` instances, defeating the per-bucket cap this module
+exists to enforce."""
+
+
+def resolve_claude_cli_lane_max() -> int:
+    """Return the effective cap, honouring :data:`CLAUDE_CLI_LANE_MAX_ENV`.
+
+    Falls back to :data:`DEFAULT_CLAUDE_CLI_LANE_MAX` for empty,
+    non-integer, or non-positive overrides. Surfaced as a function
+    rather than a constant so tests can monkeypatch ``os.environ`` and
+    re-resolve without touching the module-level singleton.
+    """
+    raw = os.environ.get(CLAUDE_CLI_LANE_MAX_ENV, "").strip()
+    if not raw:
+        return DEFAULT_CLAUDE_CLI_LANE_MAX
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return DEFAULT_CLAUDE_CLI_LANE_MAX
+    if parsed <= 0:
+        return DEFAULT_CLAUDE_CLI_LANE_MAX
+    return parsed
+
+
+def get_claude_cli_lane() -> Lane:
+    """Return the singleton ``claude-cli-subagent`` lane, lazily initialised.
+
+    Thread-safe via double-checked locking (see
+    :data:`_CLAUDE_CLI_LANE_INIT_LOCK`). Exposed for tests that need
+    to inspect ``lane.stats`` / ``lane.get_active()`` after a series of
+    acquires.
+    """
+    global _CLAUDE_CLI_LANE
+    if _CLAUDE_CLI_LANE is None:
+        with _CLAUDE_CLI_LANE_INIT_LOCK:
+            if _CLAUDE_CLI_LANE is None:  # re-check inside lock
+                _CLAUDE_CLI_LANE = Lane(
+                    name=CLAUDE_CLI_LANE_NAME,
+                    max_concurrent=resolve_claude_cli_lane_max(),
+                    timeout_s=CLAUDE_CLI_LANE_TIMEOUT_S,
+                )
+    return _CLAUDE_CLI_LANE
+
+
+@contextmanager
+def acquire_claude_cli_lane(key: str) -> Iterator[None]:
+    """Block until a ``claude --print`` slot is free, then yield.
+
+    Used as a sync context manager around the mutator runner's
+    ``subprocess.run(["claude", "--print", ...])`` call::
+
+        with acquire_claude_cli_lane(key=session_id):
+            stdout = invoke_claude_cli(system_prompt=..., user_prompt=...)
+
+    Raises :class:`TimeoutError` (propagated from
+    :meth:`Lane.acquire`) when the slot doesn't free within
+    :data:`CLAUDE_CLI_LANE_TIMEOUT_S`.
+    """
+    lane = get_claude_cli_lane()
+    with lane.acquire(key):
+        yield
+
+
+@asynccontextmanager
+async def acquire_claude_cli_lane_async(key: str) -> AsyncIterator[None]:
+    """Async sibling for inspect_ai's :class:`ClaudeCliAPI.generate`.
+
+    Shares the SAME underlying semaphore as
+    :func:`acquire_claude_cli_lane`, so the cap is global across the
+    sync and async spawn paths. The blocking acquire runs in a worker
+    thread (``asyncio.to_thread``) so the event loop is not pinned
+    while waiting for a slot.
+    """
+    lane = get_claude_cli_lane()
+    async with lane.acquire_async(key):
+        yield
+
+
+def _reset_claude_cli_lane_for_tests() -> None:
+    """Drop the module-level singleton so the next ``get_claude_cli_lane``
+    call rebuilds it.
+
+    Tests that mutate :data:`CLAUDE_CLI_LANE_MAX_ENV` via
+    ``monkeypatch.setenv`` need this to re-resolve the cap; without
+    it the first call captures the cap forever (per double-checked
+    locking).
+    """
+    global _CLAUDE_CLI_LANE
+    with _CLAUDE_CLI_LANE_INIT_LOCK:
+        _CLAUDE_CLI_LANE = None

--- a/core/self_improving_loop/cli_subprocess.py
+++ b/core/self_improving_loop/cli_subprocess.py
@@ -129,7 +129,18 @@ def invoke_claude_cli(*, system_prompt: str, user_prompt: str) -> str:
 
     ``--output-format text`` keeps stdout free of the Markdown framing
     that Claude Code's TUI render layer would otherwise add.
+
+    Concurrency gate (PR-LQ-Phase2, 2026-05-22): the call is wrapped
+    in :func:`core.orchestration.claude_cli_lane.acquire_claude_cli_lane`
+    so simultaneous mutator invocations + Petri inspect_ai bridge
+    spawns share a single bucket-wide cap (default 2 — one slot below
+    the public 3-4 burst-limiter floor, leaving room for the
+    operator's host Claude Code session). See
+    [[project_lanequeue_handoff_2026_05_22]] for Phase 2 rationale +
+    Phase 3 OAuth-usage polling integration.
     """
+    from core.orchestration.claude_cli_lane import acquire_claude_cli_lane
+
     binary = _resolve_binary(CLAUDE_CLI_BIN_ENV, _DEFAULT_CLAUDE_BIN)
     args = [
         "--print",
@@ -139,7 +150,8 @@ def invoke_claude_cli(*, system_prompt: str, user_prompt: str) -> str:
         system_prompt,
         user_prompt,
     ]
-    out = _run(binary, args, stdin_text="")
+    with acquire_claude_cli_lane(key="self_improving_loop.mutator"):
+        out = _run(binary, args, stdin_text="")
     return out.strip()
 
 

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -211,6 +211,25 @@ def build_default_lanes() -> LaneQueue:
         max_concurrent=DEFAULT_SEED_PIPELINE_CONCURRENCY,
         timeout_s=300.0,
     )
+    # PR-LQ-Phase2 (2026-05-22) — surface the module-level
+    # claude-cli-subagent lane in the LaneQueue dashboard for parity
+    # with the autoresearch-audit lane pattern. The actual semaphore
+    # lives at :mod:`core.orchestration.claude_cli_lane`; this lane
+    # registration is a dashboard mirror that ``LaneQueue.status()``
+    # consumers can read alongside ``gateway`` / ``global`` /
+    # ``seed-generation``. Both registrations stay in lockstep by
+    # routing through the same constants + ``resolve_*`` resolver.
+    from core.orchestration.claude_cli_lane import (
+        CLAUDE_CLI_LANE_NAME,
+        CLAUDE_CLI_LANE_TIMEOUT_S,
+        resolve_claude_cli_lane_max,
+    )
+
+    queue.add_lane(
+        CLAUDE_CLI_LANE_NAME,
+        max_concurrent=resolve_claude_cli_lane_max(),
+        timeout_s=CLAUDE_CLI_LANE_TIMEOUT_S,
+    )
     return queue
 
 

--- a/plugins/petri_audit/claude_cli_provider.py
+++ b/plugins/petri_audit/claude_cli_provider.py
@@ -531,7 +531,19 @@ def register() -> None:
                 model_name=self.model_name,
             )
             prompt = serialise_messages_to_prompt(input)
-            stdout, stderr, returncode = await _run_claude_subprocess(argv, prompt, self._timeout_s)
+            # PR-LQ-Phase2 (2026-05-22) — share the
+            # claude-cli-subagent lane with the self-improving-loop
+            # mutator path so the host OAuth bucket sees at most
+            # ``DEFAULT_CLAUDE_CLI_LANE_MAX`` (=2) concurrent
+            # ``claude --print`` subprocesses. The lane runs the
+            # blocking semaphore wait in a worker thread so the
+            # event loop is not pinned while queued.
+            from core.orchestration.claude_cli_lane import acquire_claude_cli_lane_async
+
+            async with acquire_claude_cli_lane_async(key=f"petri.claude_cli.{self.model_name}"):
+                stdout, stderr, returncode = await _run_claude_subprocess(
+                    argv, prompt, self._timeout_s
+                )
             if returncode != 0:
                 raise ClaudeCliInvocationError(f"claude exited {returncode}: {stderr[:400]!r}")
             events = parse_stream_json_events(stdout)

--- a/tests/core/orchestration/test_claude_cli_lane.py
+++ b/tests/core/orchestration/test_claude_cli_lane.py
@@ -1,0 +1,147 @@
+"""Tests for ``core.orchestration.claude_cli_lane``.
+
+PR-LQ-Phase2 (2026-05-22) — pin the module-level singleton's contract:
+
+* Singleton identity across ``get_claude_cli_lane`` calls.
+* Operator-override env honoured (positive int) and silently rejected
+  (empty / non-int / non-positive) — the lane should never harden into
+  "no slots" mid-run because of a typo.
+* Sync + async acquire share the SAME underlying semaphore so the cap
+  composes across the two spawn paths.
+* Dashboard mirror in ``build_default_lanes`` exposes the lane with
+  the resolved cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from core.orchestration.claude_cli_lane import (
+    CLAUDE_CLI_LANE_MAX_ENV,
+    CLAUDE_CLI_LANE_NAME,
+    DEFAULT_CLAUDE_CLI_LANE_MAX,
+    _reset_claude_cli_lane_for_tests,
+    acquire_claude_cli_lane,
+    acquire_claude_cli_lane_async,
+    get_claude_cli_lane,
+    resolve_claude_cli_lane_max,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_lane(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the singleton + clear the env override before each test.
+
+    Without this the first test's cap leaks into every subsequent test
+    via double-checked locking (the module guards against multi-init
+    by design).
+    """
+    monkeypatch.delenv(CLAUDE_CLI_LANE_MAX_ENV, raising=False)
+    _reset_claude_cli_lane_for_tests()
+
+
+class TestResolveClaudeCliLaneMax:
+    def test_default_when_env_unset(self) -> None:
+        assert resolve_claude_cli_lane_max() == DEFAULT_CLAUDE_CLI_LANE_MAX
+
+    def test_env_override_positive_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(CLAUDE_CLI_LANE_MAX_ENV, "5")
+        assert resolve_claude_cli_lane_max() == 5
+
+    def test_env_override_empty_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(CLAUDE_CLI_LANE_MAX_ENV, "")
+        assert resolve_claude_cli_lane_max() == DEFAULT_CLAUDE_CLI_LANE_MAX
+
+    def test_env_override_non_integer_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(CLAUDE_CLI_LANE_MAX_ENV, "not-a-number")
+        assert resolve_claude_cli_lane_max() == DEFAULT_CLAUDE_CLI_LANE_MAX
+
+    def test_env_override_zero_or_negative_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for value in ("0", "-1"):
+            monkeypatch.setenv(CLAUDE_CLI_LANE_MAX_ENV, value)
+            assert resolve_claude_cli_lane_max() == DEFAULT_CLAUDE_CLI_LANE_MAX
+
+
+class TestSingleton:
+    def test_get_claude_cli_lane_returns_singleton(self) -> None:
+        first = get_claude_cli_lane()
+        second = get_claude_cli_lane()
+        assert first is second
+
+    def test_lane_name_and_default_cap(self) -> None:
+        lane = get_claude_cli_lane()
+        assert lane.name == CLAUDE_CLI_LANE_NAME
+        assert lane.max_concurrent == DEFAULT_CLAUDE_CLI_LANE_MAX
+
+    def test_env_override_applied_after_reset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(CLAUDE_CLI_LANE_MAX_ENV, "3")
+        _reset_claude_cli_lane_for_tests()
+        lane = get_claude_cli_lane()
+        assert lane.max_concurrent == 3
+
+
+class TestAcquireSync:
+    def test_sync_acquire_increments_and_releases_active_count(self) -> None:
+        lane = get_claude_cli_lane()
+        assert lane.active_count == 0
+        with acquire_claude_cli_lane(key="job-1"):
+            assert lane.active_count == 1
+        assert lane.active_count == 0
+
+
+class TestAcquireAsync:
+    def test_async_acquire_shares_semaphore_with_sync(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sync acquire holds the slot; concurrent async acquire must
+        WAIT — proving they share the same underlying semaphore."""
+        monkeypatch.setenv(CLAUDE_CLI_LANE_MAX_ENV, "1")
+        _reset_claude_cli_lane_for_tests()
+        lane = get_claude_cli_lane()
+        assert lane.max_concurrent == 1
+
+        async def scenario() -> None:
+            # Hold the only slot synchronously, then try an async acquire
+            # with a very short timeout to prove the cap is shared.
+            from core.orchestration.claude_cli_lane import get_claude_cli_lane as _g
+
+            held = _g()
+            # Raw-acquire instead of context-manager so we can release
+            # explicitly inside the async branch.
+            assert held._raw_acquire("sync-holder")  # type: ignore[attr-defined]
+            try:
+                # 0.05s timeout — semaphore is held by sync side, async
+                # must time out.
+                lane_inner = _g()
+                lane_inner.timeout_s = 0.05
+                with pytest.raises(TimeoutError, match="claude-cli-subagent"):
+                    async with acquire_claude_cli_lane_async(key="async-blocked"):
+                        pass
+            finally:
+                held._raw_release("sync-holder")  # type: ignore[attr-defined]
+
+        asyncio.run(scenario())
+
+
+class TestDefaultLanesDashboardMirror:
+    def test_build_default_lanes_registers_claude_cli_lane(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The container's dashboard mirror exposes the lane with the
+        same cap as the module-level singleton resolver."""
+        from core.wiring.container import build_default_lanes
+
+        from core import config as _config
+
+        class _StubSettings:
+            gateway_max_concurrent = 0
+
+        monkeypatch.setattr(_config, "settings", _StubSettings(), raising=False)
+
+        queue = build_default_lanes()
+        lane = queue.get_lane(CLAUDE_CLI_LANE_NAME)
+        assert lane is not None
+        assert lane.max_concurrent == resolve_claude_cli_lane_max()


### PR DESCRIPTION
## Summary

- New module-level ``Lane`` at ``core/orchestration/claude_cli_lane.py`` (audit_lane.py-style singleton) caps concurrent ``claude --print`` subprocess fan-out from BOTH spawn sites at a shared semaphore: the self-improving-loop mutator runner (sync) and the Petri inspect_ai bridge (async).
- Default cap ``DEFAULT_CLAUDE_CLI_LANE_MAX = 2`` sits one slot below the public 3-4 burst-limiter floor (anthropics/claude-code#53922) so the operator's host Claude Code session retains bucket headroom. Operator override via ``GEODE_CLAUDE_CLI_LANE_MAX`` (positive int; empty / non-int / non-positive → default).
- Dashboard mirror in ``build_default_lanes`` exposes the lane in ``LaneQueue.status()`` alongside gateway / global / seed-generation.

## Why

Phase 2 of the LaneQueue 5-phase plan ([[project_lanequeue_handoff_2026_05_22]]). Both ``claude --print`` spawn sites currently share the operator's host OAuth bucket with the interactive Claude Code session, and Anthropic rate-limits per-account-bucket, not per-process. Without a dedicated cap the inspect_ai bridge can fan out concurrent generate() calls that race the 3-4 burst-limit floor and start drawing 429 + Retry-After mid-eval. The audit_lane.py module-level pattern was deliberately chosen over a LaneQueue registration because the mutator runner + inspect_ai plugin both spawn from contexts where the container singleton may not exist (CLI ``python -m``, pytest, inspect_ai router instantiation).

The cap (2) is conservative until Phase 3 lands the paperclip OAuth-usage polling port — that work will let the lane raise its cap dynamically based on the resolved 5h-bucket utilisation. The handoff doc requests a one-time live burst-threshold measurement before this PR; that measurement requires operator OAuth credentials this session cannot access, so the conservative public-doc-grounded cap ships with an explicit override knob for post-deploy tuning.

## Changes

| File | Change |
|------|--------|
| ``core/orchestration/claude_cli_lane.py`` (NEW) | Module-level Lane singleton + sync/async acquire helpers + env override resolver + test reset hook |
| ``core/self_improving_loop/cli_subprocess.py`` | ``invoke_claude_cli`` wraps subprocess in ``acquire_claude_cli_lane`` |
| ``plugins/petri_audit/claude_cli_provider.py`` | ``ClaudeCliAPI.generate`` wraps subprocess in ``acquire_claude_cli_lane_async`` |
| ``core/wiring/container.py`` | ``build_default_lanes`` mirrors the lane in the queue for dashboard parity |
| ``tests/core/orchestration/test_claude_cli_lane.py`` (NEW) | 5 test classes: env resolver, singleton identity, sync acquire, sync/async share-semaphore, dashboard mirror |
| ``CHANGELOG.md`` | ``[Unreleased] / ### Added`` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Lane module singleton | Implemented | ``audit_lane.py`` pattern; double-checked locking |
| Sync acquire wraps mutator | Implemented | ``invoke_claude_cli`` |
| Async acquire wraps inspect_ai bridge | Implemented | ``ClaudeCliAPI.generate`` |
| Sync + async share semaphore | Implemented | both go through ``get_claude_cli_lane()`` |
| Env override knob | Implemented | ``GEODE_CLAUDE_CLI_LANE_MAX`` w/ silent fallback |
| Dashboard mirror | Implemented | ``build_default_lanes`` |
| Pre-flight measurement | Deferred | requires live OAuth bucket; documented in module docstring |
| ``--resume`` token-savings (paperclip P4) | Deferred | scoped to a follow-up PR |

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``ruff format --check core/ tests/ plugins/ autoresearch/`` clean (798 files)
- [x] ``mypy core/ plugins/`` clean (401 source files)
- [x] ``lint-imports`` 4/4 contracts kept
- [x] ``pytest tests/core/orchestration/test_claude_cli_lane.py tests/test_lane_queue.py tests/core/orchestration/test_seed_generation_lane.py tests/plugins/seed_generation/test_orchestrator.py`` all green
- [x] ``geode version`` → ``GEODE v0.99.30``
- [ ] Full pytest suite — pending CI

## Reference

- [[project_lanequeue_handoff_2026_05_22]] — Phase 2 spec + Pre-flight measurement gap
- anthropics/claude-code#53922 — burst limiter 3-4 floor
- ``~/workspace/paperclip/packages/adapters/claude-local`` — empirical findings
- ``core/llm/audit_lane.py`` — sibling module-level Lane pattern