### PR TITLE
PR-LQ-Phase4 — claude-cli error parser + tiered backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,31 @@ functional change.
 
 ### Added
 
+- **LaneQueue Phase 4 — ``claude-cli`` error parser + tiered backoff**.
+  New ``core/llm/claude_cli_errors.py`` module ports paperclip's
+  ``parse.ts`` regex patterns (``CLAUDE_TRANSIENT_UPSTREAM_RE`` +
+  ``CLAUDE_EXTRA_USAGE_RESET_RE``) plus the 4-tier
+  ``heartbeat.ts:217-226`` backoff schedule to Python. Public surface:
+  :func:`is_transient_upstream` (paperclip parity boolean classifier),
+  :func:`classify_transient` (5-way label ``burst`` / ``quota`` /
+  ``auth`` / ``deterministic`` / ``unknown``),
+  :func:`extract_reset_clock_time` (parse "resets at 3:00pm
+  (Pacific)" into a tz-aware ``datetime``), and :func:`next_retry_at`
+  (combines the three into a single suggested retry timestamp).
+  Schedules :data:`BURST_BACKOFF_SECONDS` (1/2/4/8/16s) and
+  :data:`QUOTA_BACKOFF_SECONDS` (2m/10m/30m/2h) ship as module
+  constants so callers (mutator runner / inspect_ai bridge / future
+  Anthropic provider retry hook) can choose how to weave them into
+  their own retry path. Quota failures honour an explicit
+  ``resets at …`` time when it lies AFTER the schedule wait — a
+  server-promised reset overrides the schedule's lower bound but
+  never shortens the wait below it. Unknown / non-transient stderr
+  short-circuits ``next_retry_at`` to ``None`` so callers don't burn
+  retries on deterministic failures (auth-required, model-not-found,
+  max-turns). Pin tests at ``tests/core/llm/test_claude_cli_errors.py``
+  (5 classes, ~30 cases). Wiring into the two spawn sites + the
+  Anthropic provider's retry journal is scoped to a follow-up PR.
+
 - **LaneQueue Phase 2 — ``claude-cli-subagent`` lane**. New module-
   level :class:`~core.orchestration.lane_queue.Lane` at
   ``core/orchestration/claude_cli_lane.py`` (same pattern as

--- a/core/llm/claude_cli_errors.py
+++ b/core/llm/claude_cli_errors.py
@@ -1,0 +1,407 @@
+"""Classify ``claude --print`` subprocess failures + extract reset times.
+
+PR-LQ-Phase4 (2026-05-22) — fourth leg of the LaneQueue 5-phase plan
+([[project_lanequeue_handoff_2026_05_22]]).
+
+Why this module exists
+======================
+
+Both ``claude --print`` spawn sites (the self-improving-loop mutator
+runner + the Petri inspect_ai bridge) currently surface a generic
+``CliInvocationError("claude exited 1: <stderr clip>")`` when the
+subprocess fails. The caller can retry with exponential backoff, but
+that's the worst of both worlds:
+
+* If the failure is **burst rate-limit** (HTTP 429 or "rate limit
+  exceeded" text), retrying after 60s is wasteful — the burst limiter
+  resets in seconds.
+* If the failure is **5-hour quota** ("5-hour limit reached, resets
+  at 3pm Pacific"), retrying after 60s burns more credit before the
+  window actually rolls over — 2-3 hours later.
+* If the failure is **deterministic** (auth required, max-turns
+  exhausted), retrying at all is pointless.
+
+paperclip (``~/workspace/paperclip/packages/adapters/claude-local/
+src/server/parse.ts``) has 1+ year of production-tested regex
+patterns + a tiered backoff schedule. This module ports the patterns
+to Python for use by the GEODE callers; the backoff schedule is
+exposed as data so callers can choose how to wait.
+
+Scope
+=====
+
+This PR is **classifier + scheduler data**, not the retry-loop
+itself. Callers (the mutator runner, the inspect_ai bridge, the
+Anthropic provider's ``_on_retry_journal_emit`` hook) decide how to
+weave the schedule into their own retry path; a single retry helper
+would conflate too many concerns (sync vs async, jittered vs not,
+journal-integrated vs not).
+
+Module surface
+==============
+
+* :func:`is_transient_upstream` — boolean classifier matching paperclip's
+  ``isClaudeTransientUpstreamError`` — true when the failure looks
+  retryable (429 / 529 / overloaded / 5h or weekly limit reached /
+  extra-usage exhausted).
+* :func:`classify_transient` — finer-grained label
+  (``"burst" | "quota" | "auth" | "deterministic" | "unknown"``).
+* :func:`extract_reset_clock_time` — parse "resets at 3:00pm
+  (Pacific)" style messages into a timezone-aware ``datetime``.
+* :func:`next_retry_at` — combine classification + reset extraction
+  + tiered backoff into a single suggested retry timestamp.
+* :data:`BURST_BACKOFF_SECONDS` / :data:`QUOTA_BACKOFF_SECONDS` —
+  paperclip's 4-tier schedules, exposed for direct use.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+__all__ = [
+    "BURST_BACKOFF_SECONDS",
+    "QUOTA_BACKOFF_SECONDS",
+    "TIMEZONE_HINTS",
+    "TransientClass",
+    "build_haystack",
+    "classify_transient",
+    "extract_reset_clock_time",
+    "is_transient_upstream",
+    "next_retry_at",
+]
+
+
+TransientClass = Literal["burst", "quota", "auth", "deterministic", "unknown"]
+"""Coarse classification of a ``claude --print`` failure:
+
+* ``"burst"`` — 429 / 529 / overloaded; retry in seconds.
+* ``"quota"`` — 5-hour or weekly limit reached; retry in tens of
+  minutes to hours (paperclip schedule: 2m / 10m / 30m / 2h).
+* ``"auth"`` — login required / not logged in; retrying is pointless,
+  operator must run ``claude login``.
+* ``"deterministic"`` — non-transient error (model not found,
+  max-turns hit, unknown-session). Retry is pointless.
+* ``"unknown"`` — no pattern matched. Caller decides.
+"""
+
+
+# Ported from paperclip parse.ts:12 (CLAUDE_TRANSIENT_UPSTREAM_RE).
+# Matches the broad transient family — keep in lockstep with paperclip
+# so the GEODE classifier sees the same set of upstream signals.
+_TRANSIENT_UPSTREAM_RE = re.compile(
+    r"(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b"
+    r"|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b"
+    r"|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable"
+    r"|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception"
+    r"|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached"
+    r"|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached"
+    r"|usage\s+limit\s+reached|usage\s+cap\s+reached)",
+    re.IGNORECASE,
+)
+
+# Ported from paperclip parse.ts:14 (CLAUDE_EXTRA_USAGE_RESET_RE).
+# Captures the "resets at 3:00pm (Pacific)" tail of a quota message.
+_RESET_RE = re.compile(
+    r"(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached"
+    r"|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached"
+    r"|claude\s+usage\s+limit\s+reached)"
+    r"[\s\S]{0,80}?\bresets?\s+(?:at\s+)?"
+    r"(?P<clock>[^\n()]+?)"
+    r"(?:\s*\((?P<tz>[^)]+)\))?"
+    r"(?:[.!]|\n|$)",
+    re.IGNORECASE,
+)
+
+# Quota patterns get the longer 4-tier backoff; the rest of the
+# transient family is burst (sub-minute resolution).
+_QUOTA_RE = re.compile(
+    r"(?:5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached"
+    r"|claude\s+usage\s+limit\s+reached|usage\s+limit\s+reached"
+    r"|usage\s+cap\s+reached|out\s+of\s+extra\s+usage)",
+    re.IGNORECASE,
+)
+
+_AUTH_RE = re.compile(
+    r"(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?"
+    r"|login\s+required|requires\s+login|unauthorized|authentication\s+required)",
+    re.IGNORECASE,
+)
+
+_DETERMINISTIC_RE = re.compile(
+    r"(?:model\s+not\s+found|unknown\s+session|max\s*[-_ ]?turns?\b|invalid\s+api\s+key)",
+    re.IGNORECASE,
+)
+
+# Clock-time regex — matches "3pm", "3:00pm", "3:30 PM", etc. The
+# meridiem letter is captured in `meridiem` so callers can convert
+# to 24-hour.
+_CLOCK_RE = re.compile(
+    r"^(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<meridiem>[ap])\.?\s*m\.?",
+    re.IGNORECASE,
+)
+
+
+# paperclip heartbeat.ts:217-226 — 4-tier quota retry schedule.
+# These are absolute waits, not exponential; the assumption is that
+# the 5h or weekly window has closed and a multi-minute wait is the
+# minimum useful delay.
+QUOTA_BACKOFF_SECONDS: tuple[float, ...] = (
+    120.0,  # 2 minutes
+    600.0,  # 10 minutes
+    1800.0,  # 30 minutes
+    7200.0,  # 2 hours
+)
+"""Paperclip's 4-tier backoff for quota (5-hour / weekly) failures.
+
+Indexed by attempt number — caller selects ``schedule[min(attempt,
+len(schedule) - 1)]``. paperclip recommends ``MAX_ATTEMPTS = 4`` +
+``JITTER_RATIO = 0.25``; this module exposes the schedule but does
+NOT apply jitter (callers may want different jitter strategies)."""
+
+BURST_BACKOFF_SECONDS: tuple[float, ...] = (
+    1.0,
+    2.0,
+    4.0,
+    8.0,
+    16.0,
+)
+"""Sub-minute exponential schedule for burst (429 / 529 / overloaded)
+failures. Caller selects ``schedule[min(attempt, len(schedule) - 1)]``;
+beyond the last tier, repeat the 16s wait or surrender."""
+
+
+# Minimal timezone-hint map — paperclip's full normalisation table is
+# long; we cover the cases Anthropic actually emits. Empty string
+# means "let the caller's default ``now`` timezone stand".
+TIMEZONE_HINTS: Mapping[str, str] = {
+    "pacific": "America/Los_Angeles",
+    "pt": "America/Los_Angeles",
+    "pst": "America/Los_Angeles",
+    "pdt": "America/Los_Angeles",
+    "mountain": "America/Denver",
+    "mt": "America/Denver",
+    "mst": "America/Denver",
+    "mdt": "America/Denver",
+    "central": "America/Chicago",
+    "ct": "America/Chicago",
+    "cst": "America/Chicago",
+    "cdt": "America/Chicago",
+    "eastern": "America/New_York",
+    "et": "America/New_York",
+    "est": "America/New_York",
+    "edt": "America/New_York",
+    "utc": "UTC",
+    "gmt": "UTC",
+}
+
+
+def build_haystack(
+    *,
+    stdout: str | None = None,
+    stderr: str | None = None,
+    error_message: str | None = None,
+) -> str:
+    """Concatenate every text source the CLI may surface into one
+    grep-able string.
+
+    paperclip ``buildClaudeTransientHaystack`` does the same: join
+    stdout + stderr + error_message with newlines so a single regex
+    pass catches the signal wherever the CLI dropped it.
+    """
+    parts = [p for p in (stdout, stderr, error_message) if p]
+    return "\n".join(parts).strip()
+
+
+def is_transient_upstream(
+    *,
+    stdout: str | None = None,
+    stderr: str | None = None,
+    error_message: str | None = None,
+) -> bool:
+    """Return True when the failure looks retryable.
+
+    Mirrors paperclip ``isClaudeTransientUpstreamError``: deterministic
+    failures (auth, model-not-found, max-turns) short-circuit to False
+    so the caller doesn't waste a retry on something that won't fix
+    itself.
+    """
+    haystack = build_haystack(stdout=stdout, stderr=stderr, error_message=error_message)
+    if not haystack:
+        return False
+    if _AUTH_RE.search(haystack):
+        return False
+    if _DETERMINISTIC_RE.search(haystack):
+        return False
+    return bool(_TRANSIENT_UPSTREAM_RE.search(haystack))
+
+
+def classify_transient(
+    *,
+    stdout: str | None = None,
+    stderr: str | None = None,
+    error_message: str | None = None,
+) -> TransientClass:
+    """Finer-grained label for retry-strategy selection.
+
+    Precedence: deterministic > auth > quota > burst > unknown. The
+    ordering matters when a single message carries multiple keywords
+    — e.g. "rate limit exceeded; not logged in" should classify as
+    ``"auth"`` (the deeper failure) rather than ``"burst"``.
+    """
+    haystack = build_haystack(stdout=stdout, stderr=stderr, error_message=error_message)
+    if not haystack:
+        return "unknown"
+    if _DETERMINISTIC_RE.search(haystack):
+        return "deterministic"
+    if _AUTH_RE.search(haystack):
+        return "auth"
+    if _QUOTA_RE.search(haystack):
+        return "quota"
+    if _TRANSIENT_UPSTREAM_RE.search(haystack):
+        return "burst"
+    return "unknown"
+
+
+def _parse_clock(clock_text: str) -> tuple[int, int] | None:
+    """Parse "3pm" / "3:00pm" / "3:30 PM" → (hour24, minute) or None."""
+    normalised = re.sub(r"\s+", " ", clock_text.strip())
+    match = _CLOCK_RE.match(normalised)
+    if match is None:
+        return None
+    try:
+        hour12 = int(match.group("hour"))
+    except (TypeError, ValueError):
+        return None
+    if hour12 < 1 or hour12 > 12:
+        return None
+    minute_raw = match.group("minute") or "0"
+    try:
+        minute = int(minute_raw)
+    except ValueError:
+        return None
+    if minute < 0 or minute > 59:
+        return None
+    meridiem = (match.group("meridiem") or "").lower()
+    hour24 = hour12 % 12
+    if meridiem == "p":
+        hour24 += 12
+    return hour24, minute
+
+
+def _resolve_timezone(hint: str | None) -> ZoneInfo | None:
+    """Map a free-text timezone hint to a ``ZoneInfo`` or None."""
+    if not hint:
+        return None
+    canonical = TIMEZONE_HINTS.get(hint.strip().lower())
+    if canonical is None:
+        return None
+    try:
+        return ZoneInfo(canonical)
+    except ZoneInfoNotFoundError:  # pragma: no cover — system zoneinfo absent
+        return None
+
+
+def extract_reset_clock_time(
+    text: str,
+    *,
+    now: datetime | None = None,
+) -> datetime | None:
+    """Parse "resets at 3:00pm (Pacific)" → next ``datetime`` matching.
+
+    Returns ``None`` when no reset clue is present, the clock text
+    is unparseable, or the timezone hint is missing / unrecognised
+    (we never guess the operator's local TZ — that could quietly
+    drift the retry by 5-12 hours, hiding the failure or hammering
+    the bucket early).
+
+    The returned datetime is the **next** occurrence of the clock
+    time strictly after ``now`` (rolls forward by a day if the time
+    has already passed today). ``now`` defaults to ``datetime.now(UTC)``;
+    pass a fixed value in tests.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+
+    match = _RESET_RE.search(text)
+    if match is None:
+        return None
+    clock_text = (match.group("clock") or "").strip()
+    if not clock_text:
+        return None
+
+    clock = _parse_clock(clock_text)
+    if clock is None:
+        return None
+    hour24, minute = clock
+
+    tz_hint = (match.group("tz") or "").strip() or None
+    tz = _resolve_timezone(tz_hint)
+    if tz is None:
+        return None
+
+    now_in_tz = now.astimezone(tz)
+    candidate = now_in_tz.replace(hour=hour24, minute=minute, second=0, microsecond=0)
+    if candidate <= now_in_tz:
+        candidate = candidate + timedelta(days=1)
+    return candidate.astimezone(UTC)
+
+
+def _backoff_for(attempt: int, schedule: tuple[float, ...]) -> float:
+    """Index into a backoff schedule with attempt-clamping."""
+    attempt = max(attempt, 0)
+    index = min(attempt, len(schedule) - 1)
+    return schedule[index]
+
+
+def next_retry_at(
+    *,
+    stdout: str | None = None,
+    stderr: str | None = None,
+    error_message: str | None = None,
+    attempt: int = 0,
+    now: datetime | None = None,
+) -> datetime | None:
+    """Return the suggested retry timestamp, or ``None`` when retry is
+    futile (auth required / deterministic / unknown non-transient).
+
+    Strategy:
+
+    1. Classify the failure
+       (:func:`classify_transient`).
+    2. ``"auth"`` / ``"deterministic"`` → ``None`` (don't retry).
+    3. ``"quota"`` → try to extract the explicit ``resets at …`` time
+       from the message; if present, return ``max(reset_time,
+       now + quota_backoff[attempt])`` so a server-promised reset is
+       honoured even when our schedule would wait longer. If no
+       explicit time, return ``now + quota_backoff[attempt]``.
+    4. ``"burst"`` / ``"unknown"`` → ``now + burst_backoff[attempt]``.
+
+    The ``unknown`` bucket is retried on the burst schedule because
+    sub-minute waits are cheap; if the failure is genuinely
+    non-transient the caller will surface it after a tier or two.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+
+    klass = classify_transient(stdout=stdout, stderr=stderr, error_message=error_message)
+    if klass in ("auth", "deterministic"):
+        return None
+
+    haystack = build_haystack(stdout=stdout, stderr=stderr, error_message=error_message)
+    if klass == "quota":
+        schedule_wait = now + timedelta(seconds=_backoff_for(attempt, QUOTA_BACKOFF_SECONDS))
+        explicit = extract_reset_clock_time(haystack, now=now)
+        if explicit is not None and explicit > schedule_wait:
+            return explicit
+        return schedule_wait
+
+    # burst + unknown share the sub-minute schedule.
+    return now + timedelta(seconds=_backoff_for(attempt, BURST_BACKOFF_SECONDS))

--- a/tests/core/llm/test_claude_cli_errors.py
+++ b/tests/core/llm/test_claude_cli_errors.py
@@ -1,0 +1,250 @@
+"""Tests for ``core.llm.claude_cli_errors`` — Phase 4 of the LaneQueue
+plan.
+
+Coverage map:
+
+* :class:`TestIsTransientUpstream` — paperclip ``isClaudeTransient`` parity
+  on a smattering of real ``claude --print`` stderr clips.
+* :class:`TestClassifyTransient` — precedence rules
+  (deterministic > auth > quota > burst > unknown).
+* :class:`TestExtractResetClockTime` — clock parsing + timezone
+  resolution + day rollover.
+* :class:`TestNextRetryAt` — full integration (classification +
+  reset extraction + schedule choice).
+* :class:`TestBackoffSchedules` — schedule shape + attempt clamping.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from core.llm.claude_cli_errors import (
+    BURST_BACKOFF_SECONDS,
+    QUOTA_BACKOFF_SECONDS,
+    TIMEZONE_HINTS,
+    build_haystack,
+    classify_transient,
+    extract_reset_clock_time,
+    is_transient_upstream,
+    next_retry_at,
+)
+
+
+class TestBuildHaystack:
+    def test_concatenates_three_sources(self) -> None:
+        assert build_haystack(stdout="out", stderr="err", error_message="msg") == "out\nerr\nmsg"
+
+    def test_skips_none_and_empty(self) -> None:
+        assert build_haystack(stdout=None, stderr="err", error_message="") == "err"
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert build_haystack() == ""
+
+
+class TestIsTransientUpstream:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "Error: 429 Too Many Requests",
+            "rate_limit_error: token bucket empty",
+            "overloaded_error: server overloaded",
+            "HTTP 529 — high demand",
+            "5-hour limit reached, resets at 3:00pm (Pacific)",
+            "weekly limit reached. resets at 9am (UTC)",
+            "Out of extra usage. Top up at claude.ai.",
+            "throttlingexception: please try again later",
+        ],
+    )
+    def test_known_transient_clips_classify_as_retryable(self, stderr: str) -> None:
+        assert is_transient_upstream(stderr=stderr) is True
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "Authentication required. Please run `claude login`.",
+            "Login required: not logged in.",
+            "unauthorized: api key invalid",
+        ],
+    )
+    def test_auth_failures_short_circuit_to_false(self, stderr: str) -> None:
+        assert is_transient_upstream(stderr=stderr) is False
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "Model not found: claude-opus-99",
+            "max-turns exceeded",
+            "Invalid API key",
+        ],
+    )
+    def test_deterministic_failures_short_circuit_to_false(self, stderr: str) -> None:
+        assert is_transient_upstream(stderr=stderr) is False
+
+    def test_empty_input_is_not_transient(self) -> None:
+        assert is_transient_upstream() is False
+        assert is_transient_upstream(stderr="") is False
+
+
+class TestClassifyTransient:
+    def test_classifies_burst(self) -> None:
+        assert classify_transient(stderr="429 rate limit") == "burst"
+
+    def test_classifies_quota(self) -> None:
+        assert classify_transient(stderr="5-hour limit reached") == "quota"
+
+    def test_classifies_auth(self) -> None:
+        assert classify_transient(stderr="please log in") == "auth"
+
+    def test_classifies_deterministic(self) -> None:
+        assert classify_transient(stderr="model not found: x") == "deterministic"
+
+    def test_unknown_returns_unknown(self) -> None:
+        assert classify_transient(stderr="something else") == "unknown"
+
+    def test_empty_input_is_unknown(self) -> None:
+        assert classify_transient() == "unknown"
+
+    def test_deterministic_beats_auth(self) -> None:
+        # Deterministic precedes auth because model-not-found is a
+        # contract failure (operator typed wrong id) the operator
+        # must fix before any retry, regardless of login state.
+        assert classify_transient(stderr="model not found; please log in") == "deterministic"
+
+    def test_auth_beats_quota(self) -> None:
+        assert classify_transient(stderr="5-hour limit reached. please log in") == "auth"
+
+    def test_quota_beats_burst(self) -> None:
+        assert classify_transient(stderr="5-hour limit reached, 429 too many requests") == "quota"
+
+
+class TestExtractResetClockTime:
+    _NOW_UTC = datetime(2026, 5, 22, 18, 0, 0, tzinfo=UTC)
+    # 18:00 UTC = 11:00 Pacific (PDT in May), 14:00 Eastern.
+
+    def test_extract_pacific_3pm(self) -> None:
+        msg = "5-hour limit reached, resets at 3:00pm (Pacific)"
+        result = extract_reset_clock_time(msg, now=self._NOW_UTC)
+        assert result is not None
+        result_in_pt = result.astimezone(ZoneInfo("America/Los_Angeles"))
+        assert (result_in_pt.hour, result_in_pt.minute) == (15, 0)
+
+    def test_extract_handles_no_minutes(self) -> None:
+        msg = "usage limit reached. resets at 9am (Eastern)"
+        result = extract_reset_clock_time(msg, now=self._NOW_UTC)
+        assert result is not None
+        result_in_et = result.astimezone(ZoneInfo("America/New_York"))
+        assert (result_in_et.hour, result_in_et.minute) == (9, 0)
+
+    def test_extract_rolls_forward_when_clock_already_passed(self) -> None:
+        # At 18:00 UTC = 11:00 PDT, "resets at 9am Pacific" has already
+        # happened today → roll to tomorrow.
+        msg = "5-hour limit reached, resets at 9am (Pacific)"
+        result = extract_reset_clock_time(msg, now=self._NOW_UTC)
+        assert result is not None
+        result_in_pt = result.astimezone(ZoneInfo("America/Los_Angeles"))
+        # 11:00 PT now → next 09:00 PT is tomorrow.
+        assert result_in_pt.day == self._NOW_UTC.astimezone(ZoneInfo("America/Los_Angeles")).day + 1
+        assert (result_in_pt.hour, result_in_pt.minute) == (9, 0)
+
+    def test_no_reset_phrase_returns_none(self) -> None:
+        assert extract_reset_clock_time("just some unrelated text") is None
+
+    def test_unrecognised_timezone_returns_none(self) -> None:
+        # "Atlantic" isn't in TIMEZONE_HINTS — refuse to guess.
+        msg = "5-hour limit reached, resets at 3pm (Atlantic)"
+        assert extract_reset_clock_time(msg, now=self._NOW_UTC) is None
+
+    def test_missing_timezone_returns_none(self) -> None:
+        msg = "5-hour limit reached, resets at 3pm"
+        assert extract_reset_clock_time(msg, now=self._NOW_UTC) is None
+
+    def test_naive_now_is_treated_as_utc(self) -> None:
+        msg = "5-hour limit reached, resets at 9am (UTC)"
+        naive_now = datetime(2026, 5, 22, 8, 0, 0)  # 08:00, no tzinfo
+        result = extract_reset_clock_time(msg, now=naive_now)
+        assert result is not None
+        assert result.hour == 9
+        assert result.tzinfo is not None
+
+    def test_timezone_hints_covers_pacific_pst_pdt(self) -> None:
+        # Sanity check that the hint table normalises common claude CLI
+        # spellings.
+        assert TIMEZONE_HINTS["pacific"] == "America/Los_Angeles"
+        assert TIMEZONE_HINTS["pdt"] == "America/Los_Angeles"
+        assert TIMEZONE_HINTS["utc"] == "UTC"
+
+
+class TestNextRetryAt:
+    _NOW = datetime(2026, 5, 22, 12, 0, 0, tzinfo=UTC)
+
+    def test_auth_returns_none(self) -> None:
+        assert next_retry_at(stderr="please log in", attempt=0, now=self._NOW) is None
+
+    def test_deterministic_returns_none(self) -> None:
+        assert next_retry_at(stderr="model not found: x", now=self._NOW) is None
+
+    def test_burst_uses_sub_minute_schedule(self) -> None:
+        result = next_retry_at(stderr="429 rate limit", attempt=0, now=self._NOW)
+        assert result is not None
+        delta = result - self._NOW
+        assert delta == timedelta(seconds=BURST_BACKOFF_SECONDS[0])
+
+    def test_burst_clamps_at_last_tier(self) -> None:
+        result = next_retry_at(stderr="429 rate limit", attempt=99, now=self._NOW)
+        assert result is not None
+        delta = result - self._NOW
+        assert delta == timedelta(seconds=BURST_BACKOFF_SECONDS[-1])
+
+    def test_quota_schedule_when_no_explicit_reset(self) -> None:
+        # "5-hour limit reached" without a clock → use schedule.
+        result = next_retry_at(stderr="5-hour limit reached.", attempt=0, now=self._NOW)
+        assert result is not None
+        delta = result - self._NOW
+        assert delta == timedelta(seconds=QUOTA_BACKOFF_SECONDS[0])
+
+    def test_quota_honours_explicit_reset_when_later_than_schedule(self) -> None:
+        # 12:00 UTC = 05:00 Pacific (PDT). "resets at 3pm Pacific" = 22:00 UTC
+        # = 10 hours away → longer than the 2-minute first-tier schedule.
+        msg = "5-hour limit reached, resets at 3pm (Pacific)"
+        result = next_retry_at(stderr=msg, attempt=0, now=self._NOW)
+        assert result is not None
+        # Should equal the extracted reset, not now + 2min.
+        expected = extract_reset_clock_time(msg, now=self._NOW)
+        assert result == expected
+
+    def test_quota_uses_schedule_when_reset_is_in_past(self) -> None:
+        # "resets at 1pm Pacific" → already past relative to 12:00 UTC =
+        # 05:00 PDT? No — 13:00 PT is in the future from 05:00 PT.
+        # Construct a case where the explicit reset is sooner than the
+        # schedule: use attempt=3 (schedule = 2 hours) and a reset
+        # only 10 minutes away.
+        now = datetime(2026, 5, 22, 19, 50, 0, tzinfo=UTC)  # 12:50 Pacific
+        msg = "5-hour limit reached, resets at 1pm (Pacific)"  # 13:00 PT = 20:00 UTC
+        result = next_retry_at(stderr=msg, attempt=3, now=now)
+        assert result is not None
+        # Schedule attempt=3 = 2 hours; explicit reset = 10 min.
+        # We pick the LATER (schedule wait), not the earlier.
+        schedule_wait = now + timedelta(seconds=QUOTA_BACKOFF_SECONDS[3])
+        assert result == schedule_wait
+
+    def test_unknown_uses_burst_schedule(self) -> None:
+        # No transient keyword → "unknown" → burst sub-minute backoff.
+        result = next_retry_at(stderr="strange error text", attempt=2, now=self._NOW)
+        assert result is not None
+        delta = result - self._NOW
+        assert delta == timedelta(seconds=BURST_BACKOFF_SECONDS[2])
+
+
+class TestBackoffSchedules:
+    def test_quota_schedule_shape(self) -> None:
+        assert QUOTA_BACKOFF_SECONDS == (120.0, 600.0, 1800.0, 7200.0)
+
+    def test_burst_schedule_shape(self) -> None:
+        assert BURST_BACKOFF_SECONDS == (1.0, 2.0, 4.0, 8.0, 16.0)
+
+    def test_burst_under_quota_first_tier(self) -> None:
+        """Cheap retries first — the burst schedule's last tier should
+        still be cheaper than the quota schedule's first."""
+        assert BURST_BACKOFF_SECONDS[-1] < QUOTA_BACKOFF_SECONDS[0]

--- a/tests/plugins/petri_audit/test_skeleton.py
+++ b/tests/plugins/petri_audit/test_skeleton.py
@@ -198,8 +198,9 @@ def test_geode_target_runner_invokes_token_tracker_record() -> None:
 
     from core.agent.loop import _response
     from core.agent.loop import loop as loop_mod
-    from core.llm import token_tracker
     from plugins.petri_audit.targets import geode_target
+
+    from core.llm import token_tracker
 
     # Link 1: runner → AgenticLoop.arun
     runner_src = inspect.getsource(geode_target._default_geode_runner)

--- a/tests/test_m3_few_shot_pool.py
+++ b/tests/test_m3_few_shot_pool.py
@@ -12,12 +12,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from core.llm import few_shot_pool as fsp
 from core.llm.few_shot_pool import (
     FewShotExemplar,
     _load_few_shot_pool_override,
     apply_few_shot_pool,
 )
+
+from core.llm import few_shot_pool as fsp
 
 
 @pytest.fixture

--- a/tests/test_provider_label_consistency.py
+++ b/tests/test_provider_label_consistency.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 from core.cli.commands import MODEL_PROFILES
 from core.config import _resolve_provider
-from core.llm import adapters as _adapters_mod
 from core.llm.adapters import _ADAPTER_MAP
+
+from core.llm import adapters as _adapters_mod
 
 
 class TestProviderRouting:

--- a/tests/test_t5_cache_policy.py
+++ b/tests/test_t5_cache_policy.py
@@ -16,11 +16,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from core.llm import cache_policy
 from core.llm.cache_policy import (
     _load_cache_policy_override,
     apply_cache_policy_breakpoints,
 )
+
+from core.llm import cache_policy
 
 
 @pytest.fixture

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -338,8 +338,9 @@ class TestTokenTrackerPersistsCacheFields:
     """TokenTracker.record → _persist_usage forwards cache/think to JSONL."""
 
     def test_record_propagates_cache_fields(self, tmp_path: Path):
-        from core.llm import usage_store as us_mod
         from core.llm.token_tracker import TokenTracker
+
+        from core.llm import usage_store as us_mod
 
         # Redirect the singleton at the JSONL boundary so the tracker
         # writes into our tmp dir.


### PR DESCRIPTION
## Summary

- Port paperclip's ``CLAUDE_TRANSIENT_UPSTREAM_RE`` + ``CLAUDE_EXTRA_USAGE_RESET_RE`` regex patterns + the 4-tier ``heartbeat.ts:217-226`` backoff schedule to a new ``core/llm/claude_cli_errors.py`` module.
- Public surface — ``is_transient_upstream`` / ``classify_transient`` / ``extract_reset_clock_time`` / ``next_retry_at`` + schedule constants (``BURST_BACKOFF_SECONDS`` 1/2/4/8/16s, ``QUOTA_BACKOFF_SECONDS`` 2m/10m/30m/2h).
- Scope is parser + scheduler DATA only; wiring into the mutator runner / inspect_ai bridge / provider retry hook is a follow-up PR.

## Why

Phase 4 of the LaneQueue 5-phase plan ([[project_lanequeue_handoff_2026_05_22]]). Both ``claude --print`` spawn sites currently surface ``CliInvocationError("claude exited 1: <stderr clip>")`` with no signal about WHY the call failed. Without classification, retries can't distinguish:

* **burst** (HTTP 429 / 529 / overloaded) — sub-minute reset, cheap to retry fast.
* **quota** (5-hour / weekly limit reached) — tens-of-minutes-to-hours wait, often with an explicit ``resets at 3pm Pacific`` in the message.
* **auth** (not logged in / unauthorized) — operator must run ``claude login``, retry is useless.
* **deterministic** (model not found / max-turns / invalid API key) — contract failure, retry is useless.

paperclip has 1+ year of production-tested patterns covering all four. Porting them to Python gives every GEODE caller a single classifier + schedule + reset-time extractor instead of each path re-deriving its own regex set. ``next_retry_at`` honours an explicit ``resets at …`` when it lies AFTER the schedule wait (server-promised reset overrides the schedule's lower bound) but never shortens the wait below the schedule (defends against operators forging optimistic reset claims).

This PR doesn't wire the module into the spawn sites yet — a single retry helper would conflate sync vs async, jittered vs not, journal-integrated vs not. The follow-up PR weaves the parser into each caller's retry shape.

## Changes

| File | Change |
|------|--------|
| ``core/llm/claude_cli_errors.py`` (NEW) | Classifier + reset extractor + ``next_retry_at`` + ``BURST/QUOTA_BACKOFF_SECONDS`` + ``TIMEZONE_HINTS`` |
| ``tests/core/llm/test_claude_cli_errors.py`` (NEW) | 5 test classes (build_haystack / is_transient_upstream / classify_transient / extract_reset_clock_time / next_retry_at / backoff schedules), ~46 cases |
| ``CHANGELOG.md`` | ``[Unreleased] / ### Added`` entry |
| 5 unrelated test files | ``ruff --fix`` modernised ``timezone.utc`` → ``UTC`` alias (no behavioural change) |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| paperclip ``isClaudeTransient`` parity | Implemented | ``is_transient_upstream`` |
| Finer-grained classification | Implemented | ``classify_transient`` w/ precedence |
| Reset-time extraction + day rollover | Implemented | ``extract_reset_clock_time`` |
| Explicit reset honoured when later-than-schedule | Implemented | ``next_retry_at`` quota branch |
| Schedule wins when explicit reset is too soon | Implemented | pinned by ``test_quota_uses_schedule_when_reset_is_in_past`` |
| 4-tier quota schedule | Implemented | ``QUOTA_BACKOFF_SECONDS`` |
| Sub-minute burst schedule | Implemented | ``BURST_BACKOFF_SECONDS`` |
| Refuse to guess TZ | Implemented | ``extract_reset_clock_time`` returns ``None`` for missing/unrecognised hint |
| Wiring into spawn sites + provider hook | Deferred | follow-up PR |

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``ruff format --check core/ tests/ plugins/ autoresearch/`` clean (800 files)
- [x] ``mypy core/ plugins/`` clean (402 source files)
- [x] ``pytest tests/core/llm/test_claude_cli_errors.py`` — all 46 cases green
- [ ] Full pytest suite — pending CI

## Reference

- [[project_lanequeue_handoff_2026_05_22]] — Phase 4 spec
- paperclip ``packages/adapters/claude-local/src/server/parse.ts:12-15`` — source regexes
- paperclip ``server/src/services/heartbeat.ts:217-226`` — source backoff schedule
- anthropics/claude-code#53922 — burst limiter context