### PR TITLE
PR-LQ-Phase5 — LaneQueue observability boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ functional change.
 
 ### Added
 
+- **LaneQueue Phase 5 — observability boost**. ``LaneQueue.status()``
+  now returns lifetime ``stats`` (``acquired`` / ``released`` /
+  ``timeouts`` per lane) and a ``stuck`` list of keys held longer
+  than the supplied ``stuck_threshold_s`` (default 300 s, matching
+  the upper end of the gateway / global timeouts). New
+  :meth:`Lane.get_stuck(threshold_s)` / :meth:`SessionLane.get_stuck`
+  helpers surface the same info standalone — operators can poll a
+  single lane without paying for the full ``status()`` walk.
+  ``SessionLane.get_stuck`` skips released-but-cached entries (those
+  belong to the idle-eviction path, a different concern), so the
+  list only flags work that's currently held but not progressing. A
+  zero or negative threshold returns an empty list rather than
+  flagging every fresh acquisition — sensible default for callers
+  that haven't yet decided on a threshold value. Three new test
+  classes pin ``get_stuck`` precedence + the enriched status shape.
+
 - **LaneQueue Phase 4 — ``claude-cli`` error parser + tiered backoff**.
   New ``core/llm/claude_cli_errors.py`` module ports paperclip's
   ``parse.ts`` regex patterns (``CLAUDE_TRANSIENT_UPSTREAM_RE`` +

--- a/core/orchestration/lane_queue.py
+++ b/core/orchestration/lane_queue.py
@@ -189,6 +189,28 @@ class Lane:
         with self._lock:
             return {k: now - v for k, v in self._active.items()}
 
+    def get_stuck(self, threshold_s: float) -> list[str]:
+        """Return active keys held longer than ``threshold_s`` seconds.
+
+        PR-LQ-Phase5 (2026-05-22) — diagnostic helper so operators can
+        spot work that's blocked behind an upstream timeout. A "stuck"
+        slot is one whose elapsed time exceeds the threshold; the
+        decision of *what* to do about it (cancel, alert, ignore) is
+        left to the caller.
+
+        Returns keys in insertion order (Python ``dict`` preserves it)
+        so dashboards render the oldest stuck job first. An empty list
+        means no slot has crossed the threshold yet — the lane is
+        healthy at the moment of the call.
+        """
+        if threshold_s <= 0:
+            # A zero/negative threshold would label every active slot
+            # "stuck" the instant it acquired, which is not the intent.
+            return []
+        now = time.time()
+        with self._lock:
+            return [k for k, started_at in self._active.items() if now - started_at >= threshold_s]
+
     # --- Internal: for LaneQueue.acquire_all_async() duck-typing ----
 
     def _raw_acquire(self, key: str) -> bool:
@@ -350,6 +372,26 @@ class SessionLane:
         now = time.time()
         with self._lock:
             return {k: now - e.last_used for k, e in self._sessions.items() if e.held}
+
+    def get_stuck(self, threshold_s: float) -> list[str]:
+        """Return held session keys older than ``threshold_s`` since last
+        use.
+
+        PR-LQ-Phase5 (2026-05-22) — same contract as
+        :meth:`Lane.get_stuck`. A "stuck" SessionLane key is one whose
+        held entry hasn't released within the threshold; the
+        ``cleanup_idle`` path treats unheld+idle entries as evictable
+        (different category) so this method only flags *held* keys.
+        """
+        if threshold_s <= 0:
+            return []
+        now = time.time()
+        with self._lock:
+            return [
+                k
+                for k, entry in self._sessions.items()
+                if entry.held and now - entry.last_used >= threshold_s
+            ]
 
     # --- Idle cleanup (OpenClaw defect fix) ---
 
@@ -539,20 +581,41 @@ class LaneQueue:
             for item in reversed(acquired):
                 item._raw_release(key)
 
-    def status(self) -> dict[str, Any]:
-        """Get status of all lanes."""
+    def status(self, *, stuck_threshold_s: float = 300.0) -> dict[str, Any]:
+        """Get status of all lanes.
+
+        PR-LQ-Phase5 (2026-05-22) — each lane entry now carries:
+
+        * ``active`` / ``max`` / ``available`` — instantaneous shape
+          (unchanged contract from earlier phases).
+        * ``stats`` — lifetime counters (``acquired`` / ``released`` /
+          ``timeouts``) sourced from the lane's :class:`_LaneStats`.
+          Surfacing them here so operators can spot timeout pressure
+          without poking at private state.
+        * ``stuck`` — list of keys held longer than ``stuck_threshold_s``
+          seconds (default 5 minutes, matching the upper end of the
+          gateway / global timeouts). Empty list means "healthy at the
+          moment of the call".
+
+        SessionLane gets the same shape minus ``max`` / ``available``
+        (which don't apply to a per-key Semaphore(1) pool).
+        """
         result: dict[str, Any] = {}
         if self._session_lane is not None:
             result["session"] = {
                 "active": self._session_lane.active_count,
                 "sessions": self._session_lane.session_count,
                 "max_sessions": self._session_lane.max_sessions,
+                "stats": self._session_lane.stats.to_dict(),
+                "stuck": self._session_lane.get_stuck(stuck_threshold_s),
             }
         for name, lane in self._lanes.items():
             result[name] = {
                 "active": lane.active_count,
                 "max": lane.max_concurrent,
                 "available": lane.available,
+                "stats": lane.stats.to_dict(),
+                "stuck": lane.get_stuck(stuck_threshold_s),
             }
         return result
 

--- a/tests/test_lane_queue.py
+++ b/tests/test_lane_queue.py
@@ -263,6 +263,126 @@ class TestLaneQueue:
 
 
 # ---------------------------------------------------------------------------
+# PR-LQ-Phase5 — observability surface
+# ---------------------------------------------------------------------------
+
+
+class TestGetStuck:
+    """Lane.get_stuck / SessionLane.get_stuck pin the stuck-key shape:
+    a positive threshold returns keys held >= threshold, negative or
+    zero returns empty.
+
+    Tests construct ``_active`` / session-entry state directly with a
+    backdated timestamp so we don't have to ``time.sleep`` for the
+    threshold to elapse — the production code reads ``time.time()``
+    so we just shift the stored value.
+    """
+
+    def test_lane_get_stuck_returns_keys_past_threshold(self) -> None:
+        lane = Lane("test", max_concurrent=4)
+        # Construct active entries with backdated timestamps directly.
+        # We don't need to acquire/release through the semaphore — the
+        # purpose is to test the threshold filter, not the semaphore.
+        old_ts = time.time() - 10.0
+        recent_ts = time.time() - 0.1
+        with lane._lock:
+            lane._active["stuck-job"] = old_ts
+            lane._active["fresh-job"] = recent_ts
+
+        stuck_5s = lane.get_stuck(threshold_s=5.0)
+        assert stuck_5s == ["stuck-job"]
+
+        stuck_1s = lane.get_stuck(threshold_s=1.0)
+        assert stuck_1s == ["stuck-job"]
+
+        stuck_15s = lane.get_stuck(threshold_s=15.0)
+        assert stuck_15s == []  # neither is older than 15s
+
+    def test_lane_get_stuck_returns_empty_for_zero_or_negative_threshold(
+        self,
+    ) -> None:
+        """A zero/negative threshold would otherwise label every active
+        slot stuck the instant it acquired — explicitly refused."""
+        lane = Lane("test", max_concurrent=2)
+        with lane._lock:
+            lane._active["job"] = time.time() - 1.0
+        assert lane.get_stuck(threshold_s=0) == []
+        assert lane.get_stuck(threshold_s=-1.0) == []
+
+    def test_session_lane_get_stuck_only_counts_held_entries(self) -> None:
+        """SessionLane keeps released entries around for the idle-evict
+        path; ``get_stuck`` must skip those."""
+        sl = SessionLane(max_sessions=4)
+        # Acquire two keys, release one of them.
+        with sl.acquire("held"):
+            sl.try_acquire("released")
+            sl.manual_release("released")
+            # Backdate both entries to land outside the stuck threshold.
+            with sl._lock:
+                sl._sessions["held"].last_used = time.time() - 30.0
+                sl._sessions["released"].last_used = time.time() - 30.0
+            # Only "held" is currently held → only it is "stuck".
+            stuck = sl.get_stuck(threshold_s=5.0)
+            assert stuck == ["held"]
+
+
+class TestStatusObservability:
+    """PR-LQ-Phase5 — ``LaneQueue.status()`` returns the full per-lane
+    observability shape: instantaneous counts + lifetime stats +
+    stuck keys."""
+
+    def test_status_includes_stats_and_stuck_for_each_lane(self) -> None:
+        q = LaneQueue()
+        q.set_session_lane(SessionLane(max_sessions=8))
+        q.add_lane("global", max_concurrent=4)
+
+        with q.acquire_all("k1", ["session", "global"]):
+            # Force a fake-old entry on the global lane so it shows up
+            # as stuck.
+            global_lane = q.get_lane("global")
+            assert global_lane is not None
+            with global_lane._lock:
+                global_lane._active["k1"] = time.time() - 600.0
+
+            snapshot = q.status(stuck_threshold_s=300.0)
+            assert "session" in snapshot
+            assert "global" in snapshot
+
+            # Lifetime stats surfaced.
+            assert snapshot["global"]["stats"]["acquired"] >= 1
+            assert "released" in snapshot["global"]["stats"]
+            assert "timeouts" in snapshot["global"]["stats"]
+            assert snapshot["session"]["stats"]["acquired"] >= 1
+
+            # Stuck list populated for the backdated key.
+            assert snapshot["global"]["stuck"] == ["k1"]
+
+    def test_status_stuck_threshold_default_is_5_minutes(self) -> None:
+        q = LaneQueue()
+        q.add_lane("global", max_concurrent=1)
+        with q.acquire_all("k1", ["global"]):
+            # Backdate to 60 s — well under the 300 s default.
+            global_lane = q.get_lane("global")
+            assert global_lane is not None
+            with global_lane._lock:
+                global_lane._active["k1"] = time.time() - 60.0
+
+            snapshot = q.status()
+            assert snapshot["global"]["stuck"] == []
+
+    def test_status_after_release_has_no_active_or_stuck(self) -> None:
+        q = LaneQueue()
+        q.add_lane("global", max_concurrent=2)
+        with q.acquire_all("k1", ["global"]):
+            pass
+        snapshot = q.status()
+        assert snapshot["global"]["active"] == 0
+        assert snapshot["global"]["stuck"] == []
+        # acquired == released by now.
+        assert snapshot["global"]["stats"]["acquired"] == snapshot["global"]["stats"]["released"]
+
+
+# ---------------------------------------------------------------------------
 # C4 Regression: acquire_all partial failure (v0.35.1 fix)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add ``Lane.get_stuck(threshold_s)`` / ``SessionLane.get_stuck`` returning the list of currently-held keys held longer than the threshold.
- ``LaneQueue.status(stuck_threshold_s=300.0)`` now returns lifetime ``stats`` + a ``stuck`` list per lane alongside the pre-existing ``active`` / ``max`` / ``available`` shape.

## Why

Phase 5 of the LaneQueue 5-phase plan ([[project_lanequeue_handoff_2026_05_22]]). Pre-PR ``LaneQueue.status()`` exposed only instantaneous counts — operators couldn't see lifetime acquire/release pressure (was the lane bottlenecked over the last hour?) or spot work that's been stuck for minutes behind an upstream timeout. ``_LaneStats`` was already tracked internally; this PR just surfaces it through the public observability surface.

The 300 s default for ``stuck_threshold_s`` matches the upper end of the gateway / global lane timeouts — anything still held longer than the lane's own timeout is almost certainly blocked behind an external dependency (LLM call hung, subprocess wedged). Operators can pass a shorter threshold for tighter alerts.

``SessionLane.get_stuck`` deliberately skips released-but-cached entries because they're a different category — the idle-evict path (``cleanup_idle``) handles them — and conflating the two would over-report stuck work whenever the cache had a few warm-but-unused session entries.

## Changes

| File | Change |
|------|--------|
| ``core/orchestration/lane_queue.py`` | ``Lane.get_stuck`` + ``SessionLane.get_stuck`` + ``LaneQueue.status(stuck_threshold_s=…)`` enrichment |
| ``tests/test_lane_queue.py`` | Two new classes — ``TestGetStuck`` (3 cases: positive threshold filter, zero/negative short-circuit, SessionLane held-only) and ``TestStatusObservability`` (3 cases: full shape, default threshold, post-release cleanup) |
| ``CHANGELOG.md`` | ``[Unreleased] / ### Added`` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| ``Lane.get_stuck`` | Implemented | preserves ``get_active`` shape |
| ``SessionLane.get_stuck`` | Implemented | held-only |
| ``LaneQueue.status`` stats + stuck enrichment | Implemented | default threshold 300 s |
| Zero/negative threshold safety | Implemented | returns ``[]`` |
| Tests pin contract | Implemented | 6 new cases |

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``ruff format --check core/ tests/ plugins/ autoresearch/`` clean (800 files)
- [x] ``mypy core/ plugins/`` clean (402 source files)
- [x] ``lint-imports`` 4/4 contracts kept
- [x] ``pytest tests/test_lane_queue.py`` — all 45 cases green
- [ ] Full pytest suite — pending CI

## Reference

- [[project_lanequeue_handoff_2026_05_22]] — Phase 5 spec
- ``core/llm/audit_lane.py`` / ``core/orchestration/claude_cli_lane.py`` — consumers of ``Lane.stats``