### PR TITLE
release: v0.99.31 — LaneQueue Phases 1+2+4+5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.31] - 2026-05-22
+
+> LaneQueue 5-phase plan landing 4 of 5 phases (Phase 1 hierarchy fix,
+> Phase 2 ``claude-cli-subagent`` lane, Phase 4 claude-cli error parser
+> + tiered backoff, Phase 5 observability boost). Phase 3 (paperclip
+> OAuth-usage polling) requires live operator OAuth credentials and is
+> deferred to a follow-up sprint — see
+> [[project_lanequeue_handoff_2026_05_22]].
+
 ### Added
 
 - **LaneQueue Phase 5 — observability boost**. ``LaneQueue.status()``

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.30
+- **Version**: 0.99.31
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.30 — Long-running Autonomous Execution Harness
+# GEODE v0.99.31 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.30 — Long-running Autonomous Execution Harness
+# GEODE v0.99.31 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.30**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.31**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.30"
+version = "0.99.31"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.30"
+version = "0.99.31"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Version bump 0.99.30 → 0.99.31 across the 5 stamp locations (CHANGELOG, CLAUDE.md, README.md, README.ko.md, pyproject.toml).
- Promote ``[Unreleased]`` → ``[0.99.31] - 2026-05-22`` with the LaneQueue 4-phase landing blurb.

## Bundle contents

| PR | Title |
|----|-------|
| #1473 | PR-LQ-Phase1 — LaneQueue hierarchy invariant restored |
| #1474 | PR-LQ-Phase2 — claude-cli-subagent lane |
| #1475 | PR-LQ-Phase4 — claude-cli error parser + tiered backoff |
| #1476 | PR-LQ-Phase5 — LaneQueue observability boost |

Phase 3 (paperclip OAuth-usage polling port) is deferred — requires live operator OAuth credentials to validate against the real ``/api/oauth/usage`` endpoint. See [[project_lanequeue_handoff_2026_05_22]].

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``mypy core/ plugins/`` clean (402 source files)
- [x] ``geode version`` → ``GEODE v0.99.31``