### PR TITLE
PR-LQ-Codex-WHAM — paperclip fetchCodexQuota port (Path B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,37 @@ functional change.
 
 ### Added
 
+- **LQ-Codex-WHAM — Codex OAuth usage polling (paperclip ``fetchCodexQuota`` port)**.
+  Replaces the placeholder ``fetch_codex_usage`` from Phase 3 with a
+  Python 1:1 port of paperclip's
+  ``packages/adapters/codex-local/src/server/quota.ts:226-279``.
+  Path B (HTTP) of the 2-path quota scheme: stdlib ``urllib`` GET
+  against ``https://chatgpt.com/backend-api/wham/usage`` with
+  ``Authorization: Bearer <tokens.access_token>`` and optional
+  ``ChatGPT-Account-Id: <tokens.account_id>``. Path A (Codex
+  ``app-server`` JSON-RPC) is explicitly out of scope — left for a
+  future PR if the stateful subprocess proves worth the cost.
+
+  Schema: ``rate_limit.primary_window`` maps to ``CodexUsage.five_hour``
+  (admission gate), ``secondary_window`` maps to ``weekly`` (dashboard
+  only), ``credits`` + ``plan_type`` carried raw. ``reset_at`` is
+  normalised to ISO-8601 regardless of WHAM's number-vs-string
+  shape. ``used_percent`` accepts both 0-100 (current API) and 0-1
+  (legacy) per paperclip's ``normalizeCodexUsedPercent``.
+
+  New :class:`CodexAuthCredentials` dataclass threads the
+  ``(token, account_id)`` pair through the poller →
+  ``fetch_codex_usage`` chain. Both modern (``tokens.access_token``)
+  and legacy (top-level ``accessToken``) auth.json layouts are
+  accepted by :func:`read_codex_oauth_credentials`. The compat shim
+  :func:`read_codex_oauth_token` stays for callers that don't need
+  the account id.
+
+  Same fail-open default as the Anthropic side — a single WHAM
+  hiccup never hardens the lane. ``GEODE_CODEX_OAUTH_POLL_REQUIRED``
+  flips to fail-closed for strict operators;
+  ``GEODE_CODEX_OAUTH_POLL_DISABLED`` bypasses polling entirely.
+
 - **PR-CSA-2 — MCP bridge for paperclip-pattern `claude-cli` provider
   (auditor tool_use enabled).** Lifts the CSA-1 boundary
   (`NotImplementedError("tool_use deferred to CSA-2 MCP bridge")`) so

--- a/core/llm/codex_oauth_usage.py
+++ b/core/llm/codex_oauth_usage.py
@@ -1,47 +1,58 @@
-"""Codex CLI OAuth usage polling — Phase 3 Codex parity.
+"""Codex CLI OAuth usage polling — paperclip ``fetchCodexQuota`` port
+(WHAM HTTP path, Option A of the 2-path scheme).
 
-Sibling of :mod:`core.llm.oauth_usage` for ``codex exec`` subprocess
-spawn paths. Same shape (token reader, fetch, TTL poller, decision
-helper) so callers can swap providers via the lane wiring without
-re-deriving the polling pattern.
+Phase 3 sibling of :mod:`core.llm.oauth_usage` for ``codex exec``
+subprocess spawn paths. Mirrors the Anthropic poller shape (token
+reader, fetch, TTL poller, decision helper) but with the
+**ChatGPT WHAM** endpoint underneath:
 
-Endpoint status
-===============
+* Endpoint — ``GET https://chatgpt.com/backend-api/wham/usage``
+* Auth — ``Authorization: Bearer <tokens.access_token>`` plus optional
+  ``ChatGPT-Account-Id: <tokens.account_id>`` (multi-account
+  subscribers).
+* Schema —
+  ``{plan_type, rate_limit:{primary_window, secondary_window},
+  credits:{balance, unlimited}}`` with ``used_percent`` either in
+  ``0-100`` (current) or ``0-1`` (legacy) shape.
 
-paperclip's port covers Anthropic (``GET /api/oauth/usage``); the
-ChatGPT-Plus / Codex-CLI OAuth bucket does **not** currently
-advertise an equivalent public endpoint. The token surface
-(``$CODEX_HOME/auth.json``'s ``tokens.access_token``, mirroring
-codex CLI's keychain output) is real and stable, but the quota
-metadata URL is not — operators who want quota-aware admission must
-inject a verified fetch function via
-:class:`CodexUsagePoller(fetch_fn=…)`.
+paperclip operates two paths: ``fetchCodexRpcQuota`` (preferred,
+spawns ``codex … app-server`` JSON-RPC) and ``fetchCodexQuota`` (HTTP
+fallback). Option A ports ONLY the HTTP fallback so GEODE stays
+stdlib-only and matches the Anthropic-side stateless pattern; the
+RPC path is left for a later PR if its richer plan / refresh-aware
+data turns out to be worth the subprocess + protocol cost.
 
-Until that endpoint lands or an operator wires their own, the
-default :func:`fetch_codex_usage` returns ``None`` so the lane falls
-open (same fail-open contract as the Anthropic poller — see
-:data:`CODEX_OAUTH_POLL_REQUIRED_ENV` for strict mode). The
-acquire-site wiring is in place, which means a future PR that
-discovers / verifies the endpoint only needs to flip the constants +
-the fetch body, not re-thread the call graph.
+Token surface
+=============
 
-Module surface
-==============
+paperclip's ``readCodexAuthInfo`` recognises two on-disk schemas:
 
-Mirrors :mod:`core.llm.oauth_usage` field-for-field:
+* **Modern** — ``$CODEX_HOME/auth.json``::
 
-* :class:`CodexUsageWindow` / :class:`CodexUsage` (with
-  :meth:`is_throttled`).
-* :func:`read_codex_oauth_token` — locate
-  ``$CODEX_HOME/auth.json``'s ``tokens.access_token`` (Codex CLI's
-  standard location, mirrors paperclip's ``readClaudeToken`` pattern).
-* :func:`fetch_codex_usage` — placeholder returning ``None`` until
-  the endpoint is verified; signature pinned so swap-in is local.
-* :class:`CodexUsagePoller` — TTL-cached wrapper, dependency-injected
-  fetch + token resolvers so a future verified endpoint plugs in
-  without touching the lane.
-* :func:`should_block_codex_lane_acquisition` — decision helper for
-  the Codex lane's acquire site.
+      {"tokens": {"access_token": "...",
+                  "account_id": "...",
+                  "id_token": "...",
+                  "refresh_token": "..."}}
+
+* **Legacy** — top-level ``{"accessToken": "...", "accountId": "..."}``.
+
+Both are accepted by :func:`read_codex_oauth_credentials`; the
+returned :class:`CodexAuthCredentials` carries the ``account_id``
+alongside the token so the WHAM call can attach the
+``ChatGPT-Account-Id`` header when present.
+
+JWT decoding (paperclip uses it to surface plan / email in the
+dashboard) is out of scope here — admission control only needs
+``rate_limit.primary_window.used_percent``.
+
+Graceful degradation
+====================
+
+Every failure path returns ``None`` (or ``False`` from the decision
+helper). The lane MUST stay usable when the WHAM endpoint hiccups,
+mirror of the Anthropic-side policy. Operators flip the policy with
+``GEODE_CODEX_OAUTH_POLL_REQUIRED=1``; the bypass knob is
+``GEODE_CODEX_OAUTH_POLL_DISABLED=1``.
 """
 
 from __future__ import annotations
@@ -51,27 +62,41 @@ import logging
 import os
 import threading
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final
 
-from core.llm.oauth_usage import _truthy
+from core.llm.oauth_usage import _normalise_utilization, _truthy
 
 log = logging.getLogger(__name__)
 
 __all__ = [
     "CODEX_OAUTH_POLL_DISABLED_ENV",
     "CODEX_OAUTH_POLL_REQUIRED_ENV",
+    "CODEX_WHAM_USAGE_URL",
     "DEFAULT_CODEX_BLOCK_THRESHOLD",
     "DEFAULT_CODEX_TTL_S",
+    "CodexAuthCredentials",
     "CodexUsage",
     "CodexUsagePoller",
     "CodexUsageWindow",
     "fetch_codex_usage",
+    "read_codex_oauth_credentials",
     "read_codex_oauth_token",
     "should_block_codex_lane_acquisition",
 ]
 
+
+CODEX_WHAM_USAGE_URL: Final[str] = "https://chatgpt.com/backend-api/wham/usage"
+"""ChatGPT WHAM usage endpoint — paperclip
+``packages/adapters/codex-local/src/server/quota.ts:235``.
+
+Plain HTTP + Bearer (Path B in the LaneQueue handoff terminology).
+Independent of the inference SDK path — does not count toward Codex
+CLI's burst limiter per paperclip's empirical observation."""
 
 DEFAULT_CODEX_TTL_S: Final[float] = 30.0
 """TTL parity with the Anthropic poller — 30 s cache window per
@@ -79,18 +104,35 @@ acquire so concurrent fan-out doesn't multiply the metadata-endpoint
 load."""
 
 DEFAULT_CODEX_BLOCK_THRESHOLD: Final[float] = 0.8
-"""5-hour bucket threshold mirror — same value as Anthropic; revisit
-once Codex side measurements land."""
+"""5-hour bucket threshold mirror — same value as the Anthropic side.
+Operators can lower the threshold in long sessions where the bucket
+trends quickly; the default is conservative against the burst-limit
+floor."""
 
 CODEX_OAUTH_POLL_DISABLED_ENV: Final[str] = "GEODE_CODEX_OAUTH_POLL_DISABLED"
-"""Operator escape hatch — set to truthy to skip Codex polling. Until
-the endpoint is verified this knob is effectively dormant (the
-default fetch returns ``None`` regardless), but it exists so future
-wiring is one-line."""
+"""Operator escape hatch — truthy value skips polling entirely. The
+lane keeps its raw capacity cap; only the quota-aware backoff layer
+is bypassed. Mirrors :data:`core.llm.oauth_usage.OAUTH_POLL_DISABLED_ENV`."""
 
 CODEX_OAUTH_POLL_REQUIRED_ENV: Final[str] = "GEODE_CODEX_OAUTH_POLL_REQUIRED"
-"""Strict-mode flip — fail closed on polling errors. Symmetric with
-:data:`core.llm.oauth_usage.OAUTH_POLL_REQUIRED_ENV`."""
+"""Strict-mode flip — fail closed on polling errors so silent endpoint
+outages surface as a hard block instead of a free-pass. Symmetric
+with :data:`core.llm.oauth_usage.OAUTH_POLL_REQUIRED_ENV`."""
+
+
+@dataclass(frozen=True, slots=True)
+class CodexAuthCredentials:
+    """The two fields the WHAM call needs.
+
+    paperclip threads ``token + account_id`` together
+    (``readCodexToken`` returns ``{token, accountId}``); the
+    ``account_id`` is optional — single-account subscribers don't
+    have it on disk and the WHAM endpoint accepts the call without
+    the ``ChatGPT-Account-Id`` header.
+    """
+
+    token: str
+    account_id: str | None = None
 
 
 def _codex_home_dir() -> Path:
@@ -105,18 +147,53 @@ def _codex_home_dir() -> Path:
     return Path.home() / ".codex"
 
 
-def read_codex_oauth_token() -> str | None:
-    """Locate the operator's Codex CLI OAuth access token on disk.
+def _extract_credentials(parsed: object) -> CodexAuthCredentials | None:
+    """Pull token + account_id from a parsed auth.json dict.
 
-    Codex CLI writes ``$CODEX_HOME/auth.json`` with structure
-    ``{"tokens": {"access_token": "..."}}`` (verified against
-    operator install 2026-05-22). Returns the token string when the
-    file parses and the field is non-empty; ``None`` otherwise.
+    Handles both schemas paperclip recognises:
+
+    * Modern — ``{"tokens": {"access_token": ..., "account_id": ...}}``
+    * Legacy — ``{"accessToken": ..., "accountId": ...}`` (top-level)
+
+    Returns ``None`` when neither layout yields a non-empty token.
+    The ``account_id`` field is allowed to be missing — the WHAM call
+    just omits the ``ChatGPT-Account-Id`` header in that case.
+    """
+    if not isinstance(parsed, dict):
+        return None
+
+    # Modern layout first — codex CLI ≥ "tokens" block.
+    tokens = parsed.get("tokens")
+    if isinstance(tokens, dict):
+        token = tokens.get("access_token")
+        if isinstance(token, str) and token:
+            raw_account = tokens.get("account_id")
+            account_id = raw_account if isinstance(raw_account, str) and raw_account else None
+            return CodexAuthCredentials(token=token, account_id=account_id)
+
+    # Legacy top-level layout.
+    token = parsed.get("accessToken")
+    if isinstance(token, str) and token:
+        raw_account = parsed.get("accountId")
+        account_id = raw_account if isinstance(raw_account, str) and raw_account else None
+        return CodexAuthCredentials(token=token, account_id=account_id)
+
+    return None
+
+
+def read_codex_oauth_credentials() -> CodexAuthCredentials | None:
+    """Locate the operator's Codex CLI OAuth access token + account id.
+
+    Walks ``$CODEX_HOME/auth.json`` and accepts both the modern
+    (``tokens.access_token``) and legacy (top-level ``accessToken``)
+    layouts paperclip's ``readCodexAuthInfo`` handles. Returns
+    ``None`` for missing file, unreadable JSON, or empty token; the
+    caller (poller / decision helper) interprets that as
+    "polling unavailable, fall open".
 
     We deliberately walk ONLY the on-disk path (no shell-out to
     ``codex auth status`` or platform-specific keychain helpers) so
-    the module stays usable on every CI runner + Linux operator,
-    same as the Anthropic-side helper.
+    the module stays usable on every CI runner + Linux operator.
     """
     path = _codex_home_dir() / "auth.json"
     try:
@@ -128,15 +205,18 @@ def read_codex_oauth_token() -> str | None:
     except json.JSONDecodeError:
         log.debug("codex_oauth_usage: %s exists but is not valid JSON", path)
         return None
-    if not isinstance(parsed, dict):
-        return None
-    tokens = parsed.get("tokens")
-    if not isinstance(tokens, dict):
-        return None
-    token = tokens.get("access_token")
-    if isinstance(token, str) and token:
-        return token
-    return None
+    return _extract_credentials(parsed)
+
+
+def read_codex_oauth_token() -> str | None:
+    """Compatibility shim — returns only the access token string.
+
+    Kept for callers that don't need the ``account_id``; new code
+    should prefer :func:`read_codex_oauth_credentials` so the WHAM
+    header can be attached.
+    """
+    creds = read_codex_oauth_credentials()
+    return creds.token if creds is not None else None
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,72 +232,168 @@ class CodexUsageWindow:
 
 @dataclass(frozen=True, slots=True)
 class CodexUsage:
-    """Top-level Codex usage wrapper.
+    """Top-level Codex usage wrapper — paperclip ``WhamUsageResponse``
+    in Python form.
 
-    ``five_hour`` is the only window the lane consults for admission;
-    ``extra`` carries the rest of the payload as raw dict so future
-    dashboard work can inspect tier-specific fields without a schema
-    bump here.
+    Window naming choice — paperclip's WHAM payload uses
+    ``primary_window`` / ``secondary_window`` while the Anthropic
+    schema names them ``five_hour`` / ``seven_day``. We keep the
+    semantic names (``five_hour``, ``weekly``) because:
+
+    1. ``five_hour`` reads identically to the Anthropic-side field —
+       cross-provider admission code stays uniform.
+    2. Operator-facing logs / dashboards prefer the meaning
+       ("5 hours") over the API codename ("primary").
+    3. Phase 4's classifier already looks for ``5-hour`` in the
+       throttle TimeoutError text; using the same field name makes
+       that hand-off naturally readable.
+
+    ``credits`` and ``plan_type`` ship as raw fields so dashboard
+    work can surface them without a schema bump here.
     """
 
     five_hour: CodexUsageWindow | None = None
-    extra: dict[str, object] = field(default_factory=dict)
+    weekly: CodexUsageWindow | None = None
+    credits: dict[str, object] = field(default_factory=dict)
+    plan_type: str | None = None
 
     def is_throttled(self, threshold: float = DEFAULT_CODEX_BLOCK_THRESHOLD) -> bool:
         """Throttled when ``five_hour.utilization >= threshold``.
 
-        Mirrors :meth:`OAuthUsage.is_throttled` so the two providers
-        agree on the precedence rule (only 5-hour bucket gates
-        admission; weekly windows are too long to wait out in-band).
+        Only ``five_hour`` is consulted — the weekly window's reset
+        cadence (days) is too long to wait out in-band. paperclip
+        applies the same precedence on its UI side; admission control
+        gives the same answer in code.
         """
         if self.five_hour is None or self.five_hour.utilization is None:
             return False
         return self.five_hour.utilization >= threshold
 
 
-def fetch_codex_usage(token: str, *, timeout_s: float = 8.0) -> CodexUsage | None:
-    """Codex usage probe — current default returns ``None``.
+def _normalise_reset_at(raw: object) -> str | None:
+    """Normalise WHAM's ``reset_at`` to an ISO-8601 string.
 
-    The ChatGPT-Plus / Codex-CLI OAuth bucket does not expose an
-    equivalent of Anthropic's ``GET /api/oauth/usage`` at the time
-    of writing (2026-05-22). Rather than guess at the URL or scrape
-    a TUI like paperclip's ``captureClaudeCliUsageText``, this module
-    ships the no-op default + a clearly-documented injection seam:
-
-    * :class:`CodexUsagePoller(fetch_fn=...)` — operators / a future
-      PR can pin a real implementation without touching the lane
-      wiring.
-    * :data:`CODEX_OAUTH_POLL_DISABLED_ENV` /
-      :data:`CODEX_OAUTH_POLL_REQUIRED_ENV` — environment knobs are
-      already wired so flipping the default is a one-line change
-      once the endpoint contract is known.
-
-    Until the endpoint lands, ``should_block_codex_lane_acquisition``
-    will always fall open (i.e. proceed with the acquire) unless
-    strict mode is on, in which case it always blocks — matching the
-    Anthropic-side contract exactly.
-
-    The ``token`` and ``timeout_s`` parameters are accepted (and
-    ignored) so the signature is locked in — a future implementation
-    can drop into place without breaking call sites that already
-    pass a token through the lane.
+    paperclip ``fetchCodexQuota`` (``quota.ts:247-249``) handles
+    ``number`` (unix seconds) OR ``string`` (already-ISO). Convert
+    numbers to UTC ISO so downstream code (CLI dashboard, Phase 4
+    quota-class router) can parse a single shape. Anything else
+    returns ``None``.
     """
-    _ = token, timeout_s  # placeholder — see docstring
-    log.debug(
-        "codex_oauth_usage: fetch_codex_usage is a placeholder — "
-        "no public Codex /api/oauth/usage endpoint verified yet"
-    )
+    if isinstance(raw, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(raw), tz=UTC).isoformat()
+        except (OverflowError, ValueError, OSError):  # pragma: no cover — exotic timestamps
+            return None
+    if isinstance(raw, str) and raw:
+        return raw
     return None
+
+
+def _parse_window(label: str, body: object) -> CodexUsageWindow | None:
+    """Map a WHAM rate-limit window dict to :class:`CodexUsageWindow`."""
+    if not isinstance(body, dict):
+        return None
+    util = _normalise_utilization(body.get("used_percent"))
+    resets = _normalise_reset_at(body.get("reset_at"))
+    return CodexUsageWindow(label=label, utilization=util, resets_at=resets)
+
+
+def _parse_wham_payload(payload: object) -> CodexUsage:
+    """Build a :class:`CodexUsage` from a parsed WHAM JSON dict.
+
+    Tolerates missing / malformed fields — each window resolves to
+    ``None`` rather than raising, matching paperclip's null-tolerant
+    contract (``quota.ts:241-273``).
+    """
+    if not isinstance(payload, dict):
+        return CodexUsage()
+
+    plan_type_raw = payload.get("plan_type")
+    plan_type = plan_type_raw if isinstance(plan_type_raw, str) and plan_type_raw else None
+
+    rate_limit = payload.get("rate_limit")
+    primary: CodexUsageWindow | None = None
+    secondary: CodexUsageWindow | None = None
+    if isinstance(rate_limit, dict):
+        primary = _parse_window("5h limit", rate_limit.get("primary_window"))
+        secondary = _parse_window("Weekly limit", rate_limit.get("secondary_window"))
+
+    credits_raw = payload.get("credits")
+    credits: dict[str, object] = credits_raw if isinstance(credits_raw, dict) else {}
+
+    return CodexUsage(
+        five_hour=primary,
+        weekly=secondary,
+        credits=credits,
+        plan_type=plan_type,
+    )
+
+
+def fetch_codex_usage(
+    credentials: CodexAuthCredentials,
+    *,
+    timeout_s: float = 8.0,
+) -> CodexUsage | None:
+    """Make one ``GET /backend-api/wham/usage`` call.
+
+    Mirrors paperclip ``fetchCodexQuota`` (``quota.ts:226-279``):
+
+    * ``Authorization: Bearer <token>``
+    * ``ChatGPT-Account-Id: <account_id>`` — attached only when the
+      auth.json carries an account id (single-account subscribers
+      omit this and the endpoint still answers).
+    * Non-200, network error, malformed JSON → return ``None``
+      (caller decides on fail-open vs strict per env knob).
+
+    Uses :mod:`urllib` (stdlib) so the cold-start path stays free of
+    ``httpx`` / ``requests``.
+    """
+    headers = {
+        "Authorization": f"Bearer {credentials.token}",
+        "Accept": "application/json",
+    }
+    if credentials.account_id:
+        headers["ChatGPT-Account-Id"] = credentials.account_id
+
+    req = urllib.request.Request(  # noqa: S310
+        CODEX_WHAM_USAGE_URL,
+        headers=headers,
+        method="GET",
+    )
+    # CODEX_WHAM_USAGE_URL is a hardcoded https module constant — not
+    # an operator-supplied input. ruff S310 + bandit B310 both fire
+    # because the rule can't statically prove the scheme; the
+    # suppressions mark the constraint as enforced at module load.
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310  # nosec B310
+            if resp.status != 200:
+                log.debug("codex_oauth_usage: WHAM usage api returned status=%s", resp.status)
+                return None
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        log.debug("codex_oauth_usage: HTTP error %s on WHAM usage api", exc.code)
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        log.debug("codex_oauth_usage: network error on WHAM usage api — %s", exc)
+        return None
+
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        log.debug("codex_oauth_usage: malformed JSON from WHAM usage api — %s", exc)
+        return None
+
+    return _parse_wham_payload(payload)
 
 
 class CodexUsagePoller:
     """TTL-cached Codex usage poller — sibling of
     :class:`core.llm.oauth_usage.OAuthUsagePoller`.
 
-    Behaviour matches the Anthropic poller exactly so a generic
-    "block on either provider" helper can be written later without
-    branching on provider type. Operators inject ``fetch_fn`` to
-    plug in a verified Codex endpoint.
+    Behaviour matches the Anthropic poller: refresh past TTL, fall
+    back to stale-on-fail so a transient WHAM hiccup doesn't erase
+    the last good reading. Operators inject ``fetch_fn`` / ``token_fn``
+    for tests.
     """
 
     def __init__(
@@ -227,9 +403,13 @@ class CodexUsagePoller:
         fetch_fn: object | None = None,
         token_fn: object | None = None,
     ) -> None:
+        # ``fetch_fn`` signature — ``(creds, *, timeout_s) -> CodexUsage|None``.
+        # ``token_fn`` signature — ``() -> CodexAuthCredentials|None``.
+        # Kept as ``object`` so test fixtures don't need to import
+        # ``Callable``.
         self._ttl_s = ttl_s
         self._fetch_fn = fetch_fn or fetch_codex_usage
-        self._token_fn = token_fn or read_codex_oauth_token
+        self._token_fn = token_fn or read_codex_oauth_credentials
         self._lock = threading.Lock()
         self._cached: CodexUsage | None = None
         self._cached_at: float = 0.0
@@ -242,10 +422,10 @@ class CodexUsagePoller:
             if not force and self._cached is not None and now - self._cached_at < self._ttl_s:
                 return self._cached
 
-        token = self._token_fn()  # type: ignore[operator]
-        if not token:
+        creds = self._token_fn()  # type: ignore[operator]
+        if not creds:
             return self._cached
-        fresh = self._fetch_fn(token)  # type: ignore[operator]
+        fresh = self._fetch_fn(creds)  # type: ignore[operator]
         if fresh is None:
             return self._cached
 
@@ -299,12 +479,6 @@ def should_block_codex_lane_acquisition(
       poller returned fresh data.
     * Strict mode (:data:`CODEX_OAUTH_POLL_REQUIRED_ENV` truthy)
       flips "poll failed" to True so silent endpoint outages surface.
-
-    Since :func:`fetch_codex_usage` is currently a placeholder that
-    always returns ``None``, this helper currently always returns
-    ``False`` (fail-open default) unless strict mode is on. The
-    wiring stays in place so the future verified-endpoint PR is a
-    single-file change.
     """
     if _truthy(os.environ.get(CODEX_OAUTH_POLL_DISABLED_ENV)):
         return False

--- a/tests/core/llm/test_codex_oauth_usage.py
+++ b/tests/core/llm/test_codex_oauth_usage.py
@@ -1,34 +1,50 @@
-"""Tests for ``core.llm.codex_oauth_usage`` — Codex parity for Phase 3.
+"""Tests for ``core.llm.codex_oauth_usage`` — Codex WHAM HTTP path.
 
-The endpoint contract for Codex / ChatGPT-Plus OAuth quota is NOT
-publicly verified, so :func:`fetch_codex_usage` is a placeholder
-returning ``None``. These tests pin the SCAFFOLD:
+paperclip ``fetchCodexQuota`` 1:1 Python port. All HTTP calls are
+mocked through ``unittest.mock`` so the suite stays cheap and
+deterministic — no live network in CI.
 
-* token reading from ``$CODEX_HOME/auth.json``
-* poller behaviour (TTL, force, stale-on-fail) via injected stub
-* decision helper (default fail-open, strict mode flip)
-* shape parity with the Anthropic module so a future verified
-  endpoint plugs into the lane without churn.
+Coverage map:
+
+* :class:`TestReadCodexCredentials` — modern + legacy auth.json,
+  partial fields, malformed JSON.
+* :class:`TestFetchCodexUsage` — WHAM endpoint success / error /
+  timeout / malformed JSON, header attachment, reset_at number/string
+  normalisation.
+* :class:`TestParseWhamPayload` — null-tolerant field parsing.
+* :class:`TestCodexUsageIsThrottled` — threshold precedence + null
+  handling.
+* :class:`TestCodexUsagePoller` — TTL cache + force-refresh +
+  stale-on-fail + credentials hand-off.
+* :class:`TestShouldBlockCodexLaneAcquisition` — env-knob branches.
 """
 
 from __future__ import annotations
 
+import io
 import json
+import urllib.error
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from core.llm.codex_oauth_usage import (
     CODEX_OAUTH_POLL_DISABLED_ENV,
     CODEX_OAUTH_POLL_REQUIRED_ENV,
     DEFAULT_CODEX_BLOCK_THRESHOLD,
+    CodexAuthCredentials,
     CodexUsage,
     CodexUsagePoller,
     CodexUsageWindow,
+    _parse_wham_payload,
     _reset_default_codex_poller_for_tests,
     fetch_codex_usage,
+    read_codex_oauth_credentials,
     read_codex_oauth_token,
     should_block_codex_lane_acquisition,
 )
+
+from core.llm import codex_oauth_usage
 
 
 @pytest.fixture(autouse=True)
@@ -38,77 +54,320 @@ def _reset_codex_poller(monkeypatch: pytest.MonkeyPatch) -> None:
     _reset_default_codex_poller_for_tests()
 
 
-class TestReadCodexOAuthToken:
-    def test_reads_codex_home_auth_json(
+class TestReadCodexCredentials:
+    def test_reads_modern_tokens_block_with_account_id(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
-        (tmp_path / "auth.json").write_text(json.dumps({"tokens": {"access_token": "codex-token"}}))
-        assert read_codex_oauth_token() == "codex-token"
+        (tmp_path / "auth.json").write_text(
+            json.dumps(
+                {
+                    "tokens": {
+                        "access_token": "tok-modern",
+                        "account_id": "acc-1",
+                        "id_token": "jwt.xyz.sig",
+                    }
+                }
+            )
+        )
+        creds = read_codex_oauth_credentials()
+        assert creds is not None
+        assert creds.token == "tok-modern"
+        assert creds.account_id == "acc-1"
+
+    def test_modern_block_without_account_id(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "auth.json").write_text(json.dumps({"tokens": {"access_token": "tok-only"}}))
+        creds = read_codex_oauth_credentials()
+        assert creds is not None
+        assert creds.token == "tok-only"
+        assert creds.account_id is None
+
+    def test_reads_legacy_top_level_schema(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"accessToken": "tok-legacy", "accountId": "acc-2"})
+        )
+        creds = read_codex_oauth_credentials()
+        assert creds is not None
+        assert creds.token == "tok-legacy"
+        assert creds.account_id == "acc-2"
+
+    def test_modern_layout_wins_over_legacy(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If both schemas are present (transitional auth.json), modern
+        ``tokens.access_token`` must win."""
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "auth.json").write_text(
+            json.dumps(
+                {
+                    "tokens": {"access_token": "tok-modern"},
+                    "accessToken": "tok-legacy",
+                }
+            )
+        )
+        creds = read_codex_oauth_credentials()
+        assert creds is not None
+        assert creds.token == "tok-modern"
 
     def test_returns_none_when_no_file(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        assert read_codex_oauth_credentials() is None
         assert read_codex_oauth_token() is None
 
     def test_tolerates_malformed_json(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
         (tmp_path / "auth.json").write_text("{nope")
-        assert read_codex_oauth_token() is None
+        assert read_codex_oauth_credentials() is None
 
     def test_empty_token_treated_as_missing(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
         (tmp_path / "auth.json").write_text(json.dumps({"tokens": {"access_token": ""}}))
-        assert read_codex_oauth_token() is None
+        assert read_codex_oauth_credentials() is None
+
+    def test_compat_shim_returns_just_token(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"tokens": {"access_token": "tok", "account_id": "acc"}})
+        )
+        assert read_codex_oauth_token() == "tok"
 
 
-class TestFetchCodexUsagePlaceholder:
-    def test_returns_none_until_endpoint_verified(self) -> None:
-        """Default fetch is a no-op — pinned so a contributor who
-        flips it without updating tests notices immediately."""
-        assert fetch_codex_usage("any-token") is None
+class _StubResponse:
+    """Mimic the bits of ``http.client.HTTPResponse`` we touch in code."""
+
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _StubResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class TestFetchCodexUsage:
+    _PAYLOAD = {
+        "plan_type": "plus",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 42.5,
+                "limit_window_seconds": 18000,
+                "reset_at": "2026-05-22T22:00:00Z",
+            },
+            "secondary_window": {
+                "used_percent": 12,
+                "limit_window_seconds": 604800,
+                "reset_at": 1716998400,  # unix seconds — must normalise
+            },
+        },
+        "credits": {"balance": 1234, "unlimited": False},
+    }
+
+    def test_attaches_authorization_and_account_id_headers(self) -> None:
+        captured: dict[str, str] = {}
+
+        def _capture(req: Any, timeout: float = 0) -> _StubResponse:
+            captured.update(dict(req.header_items()))
+            return _StubResponse(200, json.dumps(self._PAYLOAD).encode("utf-8"))
+
+        creds = CodexAuthCredentials(token="tok-x", account_id="acc-y")
+        with patch.object(codex_oauth_usage.urllib.request, "urlopen", _capture):
+            usage = fetch_codex_usage(creds)
+
+        assert usage is not None
+        headers = {k.lower(): v for k, v in captured.items()}
+        assert headers["authorization"] == "Bearer tok-x"
+        assert headers["chatgpt-account-id"] == "acc-y"
+
+    def test_omits_account_id_header_when_credentials_have_none(self) -> None:
+        captured: dict[str, str] = {}
+
+        def _capture(req: Any, timeout: float = 0) -> _StubResponse:
+            captured.update(dict(req.header_items()))
+            return _StubResponse(200, b"{}")
+
+        creds = CodexAuthCredentials(token="tok-only", account_id=None)
+        with patch.object(codex_oauth_usage.urllib.request, "urlopen", _capture):
+            fetch_codex_usage(creds)
+
+        headers = {k.lower(): v for k, v in captured.items()}
+        assert "chatgpt-account-id" not in headers
+        assert headers["authorization"] == "Bearer tok-only"
+
+    def test_parses_complete_payload(self) -> None:
+        body = json.dumps(self._PAYLOAD).encode("utf-8")
+        with patch.object(
+            codex_oauth_usage.urllib.request,
+            "urlopen",
+            return_value=_StubResponse(200, body),
+        ):
+            usage = fetch_codex_usage(CodexAuthCredentials(token="t"))
+
+        assert usage is not None
+        assert usage.plan_type == "plus"
+
+        assert usage.five_hour is not None
+        assert usage.five_hour.utilization == pytest.approx(0.425)
+        assert usage.five_hour.resets_at == "2026-05-22T22:00:00Z"
+
+        # secondary_window's reset_at was unix seconds — must be ISO now.
+        assert usage.weekly is not None
+        assert usage.weekly.utilization == pytest.approx(0.12)
+        assert usage.weekly.resets_at is not None
+        assert "T" in usage.weekly.resets_at  # ISO-shaped
+
+        assert usage.credits["balance"] == 1234
+        assert usage.credits["unlimited"] is False
+
+    def test_returns_none_on_non_200(self) -> None:
+        with patch.object(
+            codex_oauth_usage.urllib.request,
+            "urlopen",
+            return_value=_StubResponse(503, b'{"err":"x"}'),
+        ):
+            assert fetch_codex_usage(CodexAuthCredentials(token="t")) is None
+
+    def test_returns_none_on_http_error(self) -> None:
+        exc = urllib.error.HTTPError(
+            url=codex_oauth_usage.CODEX_WHAM_USAGE_URL,
+            code=429,
+            msg="Too Many Requests",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b""),
+        )
+        with patch.object(codex_oauth_usage.urllib.request, "urlopen", side_effect=exc):
+            assert fetch_codex_usage(CodexAuthCredentials(token="t")) is None
+
+    def test_returns_none_on_url_error(self) -> None:
+        with patch.object(
+            codex_oauth_usage.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.URLError("network down"),
+        ):
+            assert fetch_codex_usage(CodexAuthCredentials(token="t")) is None
+
+    def test_returns_none_on_timeout(self) -> None:
+        with patch.object(
+            codex_oauth_usage.urllib.request,
+            "urlopen",
+            side_effect=TimeoutError("slow"),
+        ):
+            assert fetch_codex_usage(CodexAuthCredentials(token="t")) is None
+
+    def test_returns_none_on_malformed_json(self) -> None:
+        with patch.object(
+            codex_oauth_usage.urllib.request,
+            "urlopen",
+            return_value=_StubResponse(200, b"not json"),
+        ):
+            assert fetch_codex_usage(CodexAuthCredentials(token="t")) is None
+
+    def test_tolerates_empty_payload(self) -> None:
+        with patch.object(
+            codex_oauth_usage.urllib.request,
+            "urlopen",
+            return_value=_StubResponse(200, b"{}"),
+        ):
+            usage = fetch_codex_usage(CodexAuthCredentials(token="t"))
+        assert usage is not None
+        assert usage.five_hour is None
+        assert usage.weekly is None
+        assert usage.credits == {}
+        assert usage.plan_type is None
+
+
+class TestParseWhamPayload:
+    def test_drops_non_dict_payload(self) -> None:
+        assert _parse_wham_payload(None) == CodexUsage()
+        assert _parse_wham_payload("not a dict") == CodexUsage()
+
+    def test_handles_missing_rate_limit_block(self) -> None:
+        usage = _parse_wham_payload({"plan_type": "free", "credits": {"balance": 0}})
+        assert usage.plan_type == "free"
+        assert usage.five_hour is None
+        assert usage.weekly is None
+        assert usage.credits == {"balance": 0}
+
+    def test_partial_window_only_primary(self) -> None:
+        usage = _parse_wham_payload({"rate_limit": {"primary_window": {"used_percent": 60}}})
+        assert usage.five_hour is not None
+        assert usage.five_hour.utilization == pytest.approx(0.6)
+        assert usage.weekly is None
 
 
 class TestCodexUsageIsThrottled:
     def test_throttled_at_threshold(self) -> None:
-        usage = CodexUsage(five_hour=CodexUsageWindow("Current session", 0.8))
+        usage = CodexUsage(five_hour=CodexUsageWindow("5h limit", 0.8))
         assert usage.is_throttled(threshold=0.8) is True
 
     def test_below_threshold_not_throttled(self) -> None:
-        usage = CodexUsage(five_hour=CodexUsageWindow("Current session", 0.6))
+        usage = CodexUsage(five_hour=CodexUsageWindow("5h limit", 0.6))
         assert usage.is_throttled(threshold=0.8) is False
 
     def test_null_window_not_throttled(self) -> None:
         assert CodexUsage(five_hour=None).is_throttled() is False
 
+    def test_null_utilization_not_throttled(self) -> None:
+        usage = CodexUsage(five_hour=CodexUsageWindow("5h limit", None))
+        assert usage.is_throttled() is False
+
+    def test_weekly_window_does_not_gate_admission(self) -> None:
+        """Only five_hour gates admission — weekly is dashboard-only."""
+        usage = CodexUsage(
+            five_hour=CodexUsageWindow("5h limit", 0.1),
+            weekly=CodexUsageWindow("Weekly limit", 0.95),
+        )
+        assert usage.is_throttled(threshold=0.8) is False
+
 
 class TestCodexUsagePoller:
     def _usage(self, util: float) -> CodexUsage:
-        return CodexUsage(five_hour=CodexUsageWindow("Current session", util))
+        return CodexUsage(five_hour=CodexUsageWindow("5h limit", util))
 
     def test_caches_within_ttl(self) -> None:
-        calls: list[str] = []
+        calls: list[CodexAuthCredentials] = []
 
-        def _fetch(token: str) -> CodexUsage:
-            calls.append(token)
+        def _fetch(creds: CodexAuthCredentials) -> CodexUsage:
+            calls.append(creds)
             return self._usage(0.4)
 
-        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=_fetch, token_fn=lambda: "t")
+        poller = CodexUsagePoller(
+            ttl_s=60.0,
+            fetch_fn=_fetch,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         poller.current()
         poller.current()
         assert len(calls) == 1
 
     def test_force_refreshes(self) -> None:
-        calls: list[str] = []
+        calls: list[CodexAuthCredentials] = []
 
-        def _fetch(token: str) -> CodexUsage:
-            calls.append(token)
+        def _fetch(creds: CodexAuthCredentials) -> CodexUsage:
+            calls.append(creds)
             return self._usage(0.5)
 
-        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=_fetch, token_fn=lambda: "t")
+        poller = CodexUsagePoller(
+            ttl_s=60.0,
+            fetch_fn=_fetch,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         poller.current()
         poller.current(force=True)
         assert len(calls) == 2
@@ -116,13 +375,36 @@ class TestCodexUsagePoller:
     def test_returns_stale_on_failure(self) -> None:
         fetched: list[CodexUsage | None] = [self._usage(0.3), None]
 
-        def _fetch(token: str) -> CodexUsage | None:
+        def _fetch(creds: CodexAuthCredentials) -> CodexUsage | None:
             return fetched.pop(0)
 
-        poller = CodexUsagePoller(ttl_s=0.0, fetch_fn=_fetch, token_fn=lambda: "t")
+        poller = CodexUsagePoller(
+            ttl_s=0.0,
+            fetch_fn=_fetch,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         first = poller.current()
         second = poller.current()
         assert first is second
+
+    def test_returns_none_when_no_credentials(self) -> None:
+        def _fetch(creds: CodexAuthCredentials) -> CodexUsage:
+            raise AssertionError("must not be called without credentials")
+
+        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=_fetch, token_fn=lambda: None)
+        assert poller.current() is None
+
+    def test_passes_credentials_through_to_fetch(self) -> None:
+        seen: list[CodexAuthCredentials] = []
+
+        def _fetch(creds: CodexAuthCredentials) -> CodexUsage:
+            seen.append(creds)
+            return self._usage(0.1)
+
+        creds = CodexAuthCredentials(token="tk", account_id="acc")
+        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=_fetch, token_fn=lambda: creds)
+        poller.current()
+        assert seen == [creds]
 
 
 class TestShouldBlockCodexLaneAcquisition:
@@ -130,31 +412,44 @@ class TestShouldBlockCodexLaneAcquisition:
         monkeypatch.setenv(CODEX_OAUTH_POLL_DISABLED_ENV, "1")
         poller = CodexUsagePoller(
             ttl_s=60.0,
-            fetch_fn=lambda _t: pytest.fail("poller ran despite disabled env"),
-            token_fn=lambda: "t",
+            fetch_fn=lambda _c: pytest.fail("poller ran despite disabled env"),
+            token_fn=lambda: CodexAuthCredentials(token="t"),
         )
         assert should_block_codex_lane_acquisition(poller=poller) is False
 
     def test_blocks_above_threshold(self) -> None:
-        usage = CodexUsage(five_hour=CodexUsageWindow("Current session", 0.9))
-        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=lambda _t: usage, token_fn=lambda: "t")
+        usage = CodexUsage(five_hour=CodexUsageWindow("5h limit", 0.9))
+        poller = CodexUsagePoller(
+            ttl_s=60.0,
+            fetch_fn=lambda _c: usage,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         assert should_block_codex_lane_acquisition(poller=poller, threshold=0.8) is True
 
     def test_does_not_block_below_threshold(self) -> None:
-        usage = CodexUsage(five_hour=CodexUsageWindow("Current session", 0.5))
-        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=lambda _t: usage, token_fn=lambda: "t")
+        usage = CodexUsage(five_hour=CodexUsageWindow("5h limit", 0.5))
+        poller = CodexUsagePoller(
+            ttl_s=60.0,
+            fetch_fn=lambda _c: usage,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         assert should_block_codex_lane_acquisition(poller=poller, threshold=0.8) is False
 
-    def test_fails_open_by_default(self) -> None:
-        """With the default (placeholder) fetch returning None, the
-        helper must fall open — operators upgrading from the Claude-
-        only Phase 3 must not see Codex spawns suddenly blocked."""
-        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=lambda _t: None, token_fn=lambda: "t")
+    def test_fails_open_when_poll_returns_none(self) -> None:
+        poller = CodexUsagePoller(
+            ttl_s=60.0,
+            fetch_fn=lambda _c: None,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         assert should_block_codex_lane_acquisition(poller=poller) is False
 
     def test_fails_closed_in_strict_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(CODEX_OAUTH_POLL_REQUIRED_ENV, "1")
-        poller = CodexUsagePoller(ttl_s=60.0, fetch_fn=lambda _t: None, token_fn=lambda: "t")
+        poller = CodexUsagePoller(
+            ttl_s=60.0,
+            fetch_fn=lambda _c: None,
+            token_fn=lambda: CodexAuthCredentials(token="t"),
+        )
         assert should_block_codex_lane_acquisition(poller=poller) is True
 
     def test_default_threshold(self) -> None:


### PR DESCRIPTION
## Summary

- Replace Phase 3's placeholder ``fetch_codex_usage`` with a 1:1 Python port of paperclip's HTTP fallback (``packages/adapters/codex-local/src/server/quota.ts:226-279``).
- Endpoint: ``GET https://chatgpt.com/backend-api/wham/usage`` with ``Authorization: Bearer <token>`` + optional ``ChatGPT-Account-Id``.
- New ``CodexAuthCredentials`` dataclass threads ``(token, account_id)`` through the poller → fetch chain; modern + legacy ``auth.json`` layouts both accepted.

## Why

User-confirmed Option A — paperclip Path B only, no RPC. The Phase 3 PR shipped Codex parity scaffold + lane wiring with a documented `None`-returning placeholder because the WHAM endpoint contract was unverified at the time. Studying paperclip's `codex-local/quota.ts` confirms the exact URL + header set + response schema (1+ year production traffic), so the placeholder gets replaced with a real implementation.

Path A (Codex app-server JSON-RPC) is intentionally out of scope — its stateful subprocess + protocol cost is 2-3x and GEODE's 30 s TTL polling pattern fits the stateless HTTP shape better. paperclip itself uses RPC as preferred + HTTP as fallback; we ship the fallback first.

## Changes

| File | Change |
|------|--------|
| ``core/llm/codex_oauth_usage.py`` | Module rewrite — ``CODEX_WHAM_USAGE_URL`` constant, ``CodexAuthCredentials`` dataclass, ``_extract_credentials`` for modern+legacy auth.json, ``read_codex_oauth_credentials`` (new) + ``read_codex_oauth_token`` (compat shim), ``CodexUsage.five_hour`` / ``weekly`` / ``credits`` / ``plan_type``, ``_normalise_reset_at`` (number↔string), real ``fetch_codex_usage`` against WHAM, ``CodexUsagePoller`` updated to thread credentials through. ruff S310 + bandit B310 noqa on urlopen (hardcoded https constant). |
| ``tests/core/llm/test_codex_oauth_usage.py`` | Rewrite — placeholder pin replaced with WHAM HTTP path coverage. 6 classes / ~30 cases. All HTTP mocked via ``patch.object(urllib.request, "urlopen")``; no live network in CI. |
| ``CHANGELOG.md`` | ``[Unreleased] / ### Added`` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Placeholder removed | Implemented | ``fetch_codex_usage`` now hits WHAM |
| Modern + legacy auth.json | Implemented | ``_extract_credentials`` |
| account_id thread-through | Implemented | ``CodexAuthCredentials`` + header attachment |
| reset_at number↔string normalisation | Implemented | ``_normalise_reset_at`` |
| Fail-open default | Preserved | env knobs unchanged |
| paperclip Path A (RPC) | Deferred | scope-rationale documented in module docstring |
| Lane wiring | Unchanged | ``codex_cli_lane.py`` already imports the helper |
| Tests | Replaced | placeholder pin removed; real WHAM path tests added |

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``ruff format --check core/ tests/ plugins/ autoresearch/`` clean (816 files)
- [x] ``mypy core/ plugins/`` clean (410 source files)
- [x] ``bandit -r core/`` clean (0 medium/high)
- [x] ``pytest tests/core/llm/test_codex_oauth_usage.py tests/core/llm/test_oauth_usage.py tests/core/orchestration/test_codex_cli_lane.py tests/core/orchestration/test_claude_cli_lane.py`` — 97 cases green
- [ ] Full pytest suite — pending CI

## Reference

- paperclip ``packages/adapters/codex-local/src/server/quota.ts:226-279`` — source patterns
- WHAM schema discussion (this session, "WHAM 정체 정리")
- [[project_lanequeue_handoff_2026_05_22]] — Path A vs Path B framing