### PR TITLE
release: v0.99.33 — Codex WHAM OAuth polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.33] - 2026-05-22
+
+> Codex Phase 3 OAuth polling lands. paperclip ``fetchCodexQuota``
+> 1:1 Python port replaces the Phase 3 placeholder — Codex side now
+> has real WHAM (``chatgpt.com/backend-api/wham/usage``) admission
+> control, parity with the Anthropic poller. Path A (Codex
+> ``app-server`` JSON-RPC) deferred to a later PR.
+
 ### Added
 
 - **LQ-Codex-WHAM — Codex OAuth usage polling (paperclip ``fetchCodexQuota`` port)**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.32
+- **Version**: 0.99.33
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.32 — Long-running Autonomous Execution Harness
+# GEODE v0.99.33 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.32 — Long-running Autonomous Execution Harness
+# GEODE v0.99.33 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.32**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.33**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.32"
+version = "0.99.33"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.32"
+version = "0.99.33"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Version bump 0.99.32 → 0.99.33. Promotes ``[Unreleased]`` → ``[0.99.33] - 2026-05-22``. Bundle: PR #1484 (paperclip ``fetchCodexQuota`` 1:1 Python port for Codex Phase 3).

## Verification

- [x] ``ruff check`` clean, ``mypy`` clean (410 source files)
- [x] ``geode version`` → ``GEODE v0.99.33``