### PR TITLE
feat(petri-audit): CSA-2c — codex MCP bridge mirror for auditor tool_use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,89 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-CSA-2c — codex MCP bridge mirror (auditor tool_use enabled for
+  the codex-cli path).** Lifts the CSA-1b boundary
+  (``NotImplementedError("tool_use deferred to CSA-2b MCP bridge")``)
+  so the auditor role can now drive tool calls through the codex CLI
+  subprocess in addition to the claude side. Reuses the
+  provider-agnostic bridge core that CSA-2 stood up
+  (``plugins/petri_audit/mcp_bridge/{bridge_server,lifecycle,
+  tool_translator,stream_parser_ext}.py``); the only codex-specific
+  surface is one new module that translates the bridge invocation
+  into codex's TOML override flag shape.
+
+  **New module** ``plugins/petri_audit/mcp_bridge/codex_overrides.py``
+  (~110 LOC of production code + ~190 LOC of tests):
+    * :func:`build_codex_cli_mcp_overrides` — renders a
+      :class:`BridgeInvocation` into a flat list of ``-c key=value``
+      argv tokens for ``codex exec``. Where the claude side uses a
+      single ``--mcp-config <path>`` JSON file, codex needs one ``-c``
+      override per leaf field under ``[mcp_servers.bridge.*]`` (TOML
+      shape). Each string value JSON-quoted (which TOML decodes as a
+      string literal too — single quoting strategy works across both
+      parsers). Read the bridge config from
+      ``invocation.mcp_config_json`` so a single :func:`prepare_bridge`
+      call materialises the resources both CLI sides need.
+    * :func:`extract_codex_tool_calls` — walks the codex JSONL stream
+      for ``{"type": "item.completed", "item": {"type":
+      "function_call", "name": "mcp__bridge__<tool>", "arguments":
+      "...", "call_id": "..."}}`` events and builds
+      ``inspect_ai.tool.ToolCall`` instances with the
+      ``mcp__bridge__`` prefix stripped via the shared
+      :func:`strip_mcp_prefix`. ``arguments`` decodes as JSON; parse
+      failures surface as ``parse_error`` on the ToolCall instead of
+      raising (same tolerant contract the claude side uses).
+
+  **``codex_cli_provider.py`` wiring** —
+  :class:`CodexCliAPI.generate` splits into
+  :meth:`_generate_text_only` (CSA-1b path, unchanged) and the new
+  :meth:`_generate_with_tools`. The tools path lazy-imports the bridge
+  package, calls :func:`prepare_bridge`, passes the override tokens to
+  :func:`build_codex_cli_argv` via the new ``mcp_overrides=`` kwarg,
+  parses the JSONL stream, calls :func:`extract_codex_tool_calls`, and
+  returns a ``ChatMessageAssistant`` with ``tool_calls=...`` +
+  ``stop_reason="tool_calls"`` when any function_call items present.
+  :func:`release_bridge` always runs in ``finally`` (parity with the
+  claude side's contract — leaks would multiply on every audit
+  sample). Shares the same ``codex-cli-subagent`` lane as the
+  text-only path so subscription quota stays bounded.
+
+  **argv builder extension** —
+  :func:`build_codex_cli_argv` grew a single ``mcp_overrides:
+  Iterable[str] | None`` kwarg that splices the bridge overrides into
+  the argv right after ``--model``. Backwards-compatible: existing
+  callers (CSA-1b text-only + autoresearch outer loop) leave the kwarg
+  unset and the argv is unchanged.
+
+  **Tests** — 10 new unit tests
+  (``tests/plugins/petri_audit/test_codex_overrides.py``) pin the
+  contract:
+  ``build_codex_cli_mcp_overrides`` — command/args/env layout × TOML
+  JSON-quoting × per-env-var separate overrides × bridge-server-name
+  invariant (``"bridge"`` pinned); ``extract_codex_tool_calls`` —
+  mcp prefix strip × JSON arguments parse × parse_error surfacing on
+  bad JSON × non-function_call events ignored × empty stream → []
+  × multiple calls in one turn (parallel-tools support).
+
+  **Operator surface** — no config change required.
+  ``[petri.adapter.openai.codex-cli]`` already binds the codex-cli
+  provider to the ``codex-cli/`` inspect_ai prefix (CSA-3 manifest
+  flip). Once auditor or judge roles route through that prefix and
+  the audit task advertises tools, codex CLI sees them via the
+  bridge automatically. Cross-model auditor diversity (anthropic +
+  codex sides both tool-capable) is now unblocked.
+
+  **Live verification** deferred — CSA-2c lands with mock tests only.
+  The codex CLI's actual behavior under ``--max-turns``-equivalent
+  semantics + MCP-tool boundary (does codex stop before executing the
+  function_call?) needs operator validation on a real subscription
+  audit run. The shape of the JSONL ``function_call`` events was
+  cross-verified against the codex binary's emitted symbol table
+  (homebrew install, ``strings(1)`` lookup); end-to-end runtime
+  validation is a CSA-2c-followup.
+
 ### Changed
 
 - **autoresearch outer-loop UX cleanup — auditor default + config

--- a/plugins/petri_audit/codex_cli_provider.py
+++ b/plugins/petri_audit/codex_cli_provider.py
@@ -173,6 +173,7 @@ def build_codex_cli_argv(
     bypass_sandbox: bool = False,
     resume_session_id: str | None = None,
     reasoning_effort: str | None = None,
+    mcp_overrides: Iterable[str] | None = None,
     extra_args: Iterable[str] | None = None,
 ) -> list[str]:
     """Construct the ``codex exec --json`` argv.
@@ -209,6 +210,13 @@ def build_codex_cli_argv(
         argv += ["--model", model_name]
     if reasoning_effort:
         argv += ["-c", f"model_reasoning_effort={json.dumps(reasoning_effort)}"]
+    if mcp_overrides:
+        # CSA-2c (2026-05-22) — MCP bridge wiring goes here as a flat
+        # sequence of ``-c key=value`` tokens emitted by
+        # :func:`plugins.petri_audit.mcp_bridge.codex_overrides.build_codex_cli_mcp_overrides`.
+        # Codex parses TOML values, so the bridge module already
+        # JSON-quotes strings for parser parity.
+        argv += list(mcp_overrides)
     if extra_args:
         argv += list(extra_args)
     # stdin marker — must come last (codex parses positional after
@@ -482,15 +490,10 @@ def register() -> None:
             config: Any,  # GenerateConfig
         ) -> Any:  # ModelOutput
             if tools:
-                # CSA-1b ships text-only. Tool support requires the
-                # MCP bridge (CSA-2b) — codex has first-class MCP
-                # (`codex mcp` + `codex mcp-server`) so the bridge
-                # work is lower-risk than the claude side.
-                raise NotImplementedError(
-                    "codex-cli provider: tool_use deferred to CSA-2b "
-                    "(MCP bridge). Use openai-codex/ provider for now if "
-                    "tools are required."
-                )
+                return await self._generate_with_tools(input, tools)
+            return await self._generate_text_only(input)
+
+        async def _generate_text_only(self, input: Any) -> Any:
             argv = build_codex_cli_argv(
                 binary=self._binary,
                 model_name=self.model_name,
@@ -538,5 +541,80 @@ def register() -> None:
                 usage=usage,
                 error=error_msg,
             )
+
+        async def _generate_with_tools(self, input: Any, tools: Any) -> Any:
+            # Lazy-import so plain ``import plugins.petri_audit.
+            # codex_cli_provider`` does not pay the mcp library +
+            # bridge package cold-start cost when tools aren't used.
+            from plugins.petri_audit.mcp_bridge import (
+                build_codex_cli_mcp_overrides,
+                extract_codex_tool_calls,
+                prepare_bridge,
+                release_bridge,
+            )
+
+            invocation = prepare_bridge(tools)
+            try:
+                argv = build_codex_cli_argv(
+                    binary=self._binary,
+                    model_name=self.model_name,
+                    mcp_overrides=build_codex_cli_mcp_overrides(invocation),
+                )
+                prompt = serialise_messages_to_prompt(input)
+                # PR-LQ-Phase3 (2026-05-22) — share the codex-cli-subagent
+                # lane (parity with the text-only path above).
+                from core.orchestration.codex_cli_lane import (
+                    acquire_codex_cli_lane_async,
+                )
+
+                async with acquire_codex_cli_lane_async(key=f"petri.codex_cli.{self.model_name}"):
+                    stdout, stderr, returncode = await _run_codex_subprocess(
+                        argv, prompt, self._timeout_s
+                    )
+                if returncode != 0:
+                    raise CodexCliInvocationError(f"codex exited {returncode}: {stderr[:400]!r}")
+                events = parse_codex_jsonl_events(stdout)
+                if not events:
+                    raise CodexCliInvocationError(
+                        f"codex stdout had no JSONL events. stderr: {stderr[:400]!r}"
+                    )
+                text = _extract_agent_message(events)
+                # extract_codex_tool_calls operates on the raw JSON
+                # shape (``{"type": ..., "item": {...}}``); convert
+                # the CodexJsonlEvent dataclasses back to that shape
+                # at the call boundary.
+                event_dicts = [{"type": e.type, **e.payload} for e in events]
+                tool_calls = extract_codex_tool_calls(event_dicts)
+                # Stop reason: tool_use vs text. inspect_ai's contract
+                # is "tool_calls" when any tool call was emitted, else
+                # the regular stop_reason.
+                stop_reason = "tool_calls" if tool_calls else _extract_stop_reason(events)
+                usage_dict = _extract_usage(events)
+                error_msg = _extract_error(events)
+                choice = ChatCompletionChoice(
+                    message=ChatMessageAssistant(
+                        content=text,
+                        tool_calls=tool_calls or None,
+                    ),
+                    stop_reason=stop_reason,
+                )
+                usage = ModelUsage(
+                    input_tokens=usage_dict["input_tokens"],
+                    output_tokens=usage_dict["output_tokens"],
+                    total_tokens=usage_dict["input_tokens"] + usage_dict["output_tokens"],
+                    input_tokens_cache_read=usage_dict["cached_input_tokens"] or None,
+                )
+                return ModelOutput(
+                    model=self.model_name,
+                    choices=[choice],
+                    completion=text,
+                    usage=usage,
+                    error=error_msg,
+                )
+            finally:
+                # Release the per-call tempdir + bridge process. Runs
+                # even on subprocess failure (boundary-violation safety
+                # — matches the claude side's contract).
+                release_bridge(invocation)
 
     globals()["CodexCliAPI"] = CodexCliAPI

--- a/plugins/petri_audit/mcp_bridge/__init__.py
+++ b/plugins/petri_audit/mcp_bridge/__init__.py
@@ -24,6 +24,10 @@ from plugins.petri_audit.mcp_bridge.bridge_server import (
     BRIDGE_SERVER_NAME,
     BRIDGE_TOOLS_ENV,
 )
+from plugins.petri_audit.mcp_bridge.codex_overrides import (
+    build_codex_cli_mcp_overrides,
+    extract_codex_tool_calls,
+)
 from plugins.petri_audit.mcp_bridge.lifecycle import (
     BRIDGE_KEEP_TEMP_ENV,
     BridgeInvocation,
@@ -52,8 +56,10 @@ __all__ = [
     "BridgeInvocation",
     "ToolUseAccumulator",
     "allowed_tool_names",
+    "build_codex_cli_mcp_overrides",
     "build_mcp_config",
     "deserialise_tool_specs",
+    "extract_codex_tool_calls",
     "extract_tool_calls",
     "prepare_bridge",
     "release_bridge",

--- a/plugins/petri_audit/mcp_bridge/codex_overrides.py
+++ b/plugins/petri_audit/mcp_bridge/codex_overrides.py
@@ -1,0 +1,155 @@
+"""Codex-side MCP bridge plumbing (CSA-2c — codex-cli mirror of CSA-2).
+
+Where CSA-2's claude side passes ``--mcp-config <path>`` pointing at a
+JSON file that materialises ``{"mcpServers": {"bridge": {...}}}``, the
+codex side achieves the same wiring via repeated ``-c key=value`` flags
+on ``codex exec``. The TOML config format codex uses for MCP servers
+(under ``[mcp_servers.<name>]`` in ``~/.codex/config.toml``) is the
+same shape, so each leaf field becomes one ``-c`` override.
+
+This module owns the codex-specific argv emission. It deliberately
+reuses :class:`plugins.petri_audit.mcp_bridge.lifecycle.BridgeInvocation`
+unchanged — the bridge subprocess + tempdir + tools JSON are all
+provider-agnostic; only the CLI invocation surface differs.
+
+Tool-use event shape (codex JSONL):
+``{"type": "item.completed", "item": {"type": "function_call",
+"name": "mcp__bridge__<tool>", "arguments": "{...}",
+"call_id": "..."}}`` — the ``name`` carries the same
+``mcp__<server>__<tool>`` prefix convention as the claude side, so the
+existing :func:`plugins.petri_audit.mcp_bridge.lifecycle.strip_mcp_prefix`
+helper applies unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from plugins.petri_audit.mcp_bridge.lifecycle import BridgeInvocation
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "build_codex_cli_mcp_overrides",
+    "extract_codex_tool_calls",
+]
+
+
+def build_codex_cli_mcp_overrides(invocation: BridgeInvocation) -> list[str]:
+    """Render the bridge invocation into ``-c key=value`` argv tokens.
+
+    Codex parses values as TOML, so all strings must be quoted; list
+    args use TOML array syntax. The keys mirror what would live under
+    ``[mcp_servers.bridge]`` in ``~/.codex/config.toml``::
+
+        [mcp_servers.bridge]
+        command = "python"
+        args = ["-m", "plugins.petri_audit.mcp_bridge.bridge_server"]
+        env = { GEODE_AUDIT_BRIDGE_TOOLS_JSON = "/tmp/.../tools.json" }
+
+    Reads the bridge config from :attr:`BridgeInvocation.mcp_config_json`
+    (the same JSON file the claude side hands to ``--mcp-config``) so a
+    single ``prepare_bridge`` call materialises the resources both CLI
+    sides need. Returns a flat list of argv tokens ready to splice into
+    the ``codex exec`` command line.
+    """
+    # The "bridge" server name is the convention pinned by
+    # :data:`plugins.petri_audit.mcp_bridge.bridge_server.BRIDGE_SERVER_NAME`.
+    server_name = "bridge"
+    payload = json.loads(invocation.mcp_config_json.read_text(encoding="utf-8"))
+    servers = payload.get("mcpServers") or {}
+    if server_name not in servers:
+        raise ValueError(
+            f"mcp_config.mcpServers must contain {server_name!r} key for codex overrides; "
+            f"found {list(servers.keys())}"
+        )
+    spec = servers[server_name]
+
+    tokens: list[str] = []
+    tokens += ["-c", f"mcp_servers.{server_name}.command={json.dumps(spec['command'])}"]
+    tokens += ["-c", f"mcp_servers.{server_name}.args={json.dumps(spec['args'])}"]
+    env = spec.get("env") or {}
+    for env_key, env_value in env.items():
+        tokens += [
+            "-c",
+            f"mcp_servers.{server_name}.env.{env_key}={json.dumps(env_value)}",
+        ]
+    return tokens
+
+
+def extract_codex_tool_calls(events: list[dict[str, Any]]) -> list[Any]:
+    """Scan codex JSONL events for ``item.completed`` of type
+    ``function_call`` and return ``inspect_ai.tool.ToolCall`` instances.
+
+    The ``name`` field on each function_call carries the
+    ``mcp__bridge__<tool>`` prefix convention codex shares with claude's
+    MCP integration, so :func:`strip_mcp_prefix` from the shared
+    lifecycle module restores the bare tool name. ``arguments`` is a
+    JSON string per codex's event schema — parsed here; parse failures
+    surface as ``parse_error`` on the returned ToolCall instead of
+    raising (matching the claude side's tolerant contract).
+
+    Returns an empty list when no function_call items are present —
+    the caller treats that as "model emitted text only, no tools".
+    """
+    try:
+        from inspect_ai.tool import ToolCall
+    except ImportError:
+        # inspect_ai is part of the [audit] extra; without it we can
+        # still parse but cannot construct ToolCall instances. Return
+        # the raw dicts so callers in test contexts can introspect.
+        log.debug("inspect_ai unavailable — returning raw tool_call dicts")
+        ToolCall = None
+
+    from plugins.petri_audit.mcp_bridge.lifecycle import strip_mcp_prefix
+
+    calls: list[Any] = []
+    for event in events:
+        if event.get("type") != "item.completed":
+            continue
+        item = event.get("item") or {}
+        if item.get("type") != "function_call":
+            continue
+        raw_name = item.get("name", "") or ""
+        bare_name = strip_mcp_prefix(raw_name)
+        arguments_raw = item.get("arguments", "")
+        parse_error: str | None = None
+        arguments: dict[str, Any]
+        try:
+            arguments = json.loads(arguments_raw) if arguments_raw else {}
+            if not isinstance(arguments, dict):
+                parse_error = (
+                    f"arguments must decode to a JSON object, got {type(arguments).__name__}"
+                )
+                arguments = {}
+        except json.JSONDecodeError as exc:
+            parse_error = f"arguments JSON decode failed: {exc}"
+            arguments = {}
+
+        call_id = item.get("call_id") or item.get("id") or ""
+
+        if ToolCall is None:
+            calls.append(
+                {
+                    "id": call_id,
+                    "function": bare_name,
+                    "arguments": arguments,
+                    "parse_error": parse_error,
+                    "type": "function",
+                }
+            )
+        else:
+            calls.append(
+                ToolCall(
+                    id=call_id,
+                    function=bare_name,
+                    arguments=arguments,
+                    parse_error=parse_error,
+                    type="function",
+                )
+            )
+
+    return calls

--- a/tests/plugins/petri_audit/test_codex_cli_provider.py
+++ b/tests/plugins/petri_audit/test_codex_cli_provider.py
@@ -542,9 +542,7 @@ def test_generate_with_tools_dispatches_to_tools_path(tmp_path: Any) -> None:
     ):
         api = p.CodexCliAPI(model_name="gpt-5.5")
         with patch.object(api, "_generate_with_tools", side_effect=_fake_with_tools) as mocked:
-            result = asyncio.run(
-                api.generate([], tools=["t"], tool_choice="auto", config=None)
-            )
+            result = asyncio.run(api.generate([], tools=["t"], tool_choice="auto", config=None))
         assert result == "sentinel-tools"
         mocked.assert_called_once()
 

--- a/tests/plugins/petri_audit/test_codex_cli_provider.py
+++ b/tests/plugins/petri_audit/test_codex_cli_provider.py
@@ -518,19 +518,35 @@ def test_provider_registers_modelapi() -> None:
     assert hasattr(p, "CodexCliAPI")
 
 
-def test_generate_with_tools_raises_csa1b_boundary(tmp_path: Any) -> None:
+def test_generate_with_tools_dispatches_to_tools_path(tmp_path: Any) -> None:
+    """CSA-2c (2026-05-22) — the CSA-1b boundary
+    (``NotImplementedError("tool_use deferred to CSA-2b MCP bridge")``)
+    was lifted. ``generate()`` with a non-empty ``tools`` argument now
+    routes through ``_generate_with_tools`` which calls into the MCP
+    bridge. Pin the routing: mock ``_generate_with_tools`` and confirm
+    it is what gets called when tools are present. The bridge internals
+    have their own contract tests in ``test_codex_overrides.py``."""
+    pytest.importorskip("inspect_ai")
     from plugins.petri_audit import codex_cli_provider as p
 
     fake = tmp_path / "fake-codex"
     fake.write_text("#!/bin/sh\necho ok\n")
     fake.chmod(0o755)
+
+    async def _fake_with_tools(_inp: Any, _tools: Any) -> str:
+        return "sentinel-tools"
+
     with patch(
         "plugins.petri_audit.codex_cli_provider._resolve_codex_binary",
         return_value=str(fake),
     ):
         api = p.CodexCliAPI(model_name="gpt-5.5")
-        with pytest.raises(NotImplementedError, match="MCP bridge"):
-            asyncio.run(api.generate([], tools=["t"], tool_choice="auto", config=None))
+        with patch.object(api, "_generate_with_tools", side_effect=_fake_with_tools) as mocked:
+            result = asyncio.run(
+                api.generate([], tools=["t"], tool_choice="auto", config=None)
+            )
+        assert result == "sentinel-tools"
+        mocked.assert_called_once()
 
 
 def test_generate_text_only_round_trip(tmp_path: Any) -> None:

--- a/tests/plugins/petri_audit/test_codex_overrides.py
+++ b/tests/plugins/petri_audit/test_codex_overrides.py
@@ -1,0 +1,215 @@
+"""Tests for plugins.petri_audit.mcp_bridge.codex_overrides (CSA-2c)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from plugins.petri_audit.mcp_bridge.codex_overrides import (
+    build_codex_cli_mcp_overrides,
+    extract_codex_tool_calls,
+)
+from plugins.petri_audit.mcp_bridge.lifecycle import BridgeInvocation
+
+
+def _make_invocation(
+    tmp_path: Path, env: dict[str, str] | None = None, server_name: str = "bridge"
+) -> BridgeInvocation:
+    """Build a real BridgeInvocation by writing the same JSON file
+    :func:`prepare_bridge` would produce — so codex_overrides reads the
+    actual on-disk payload, not a synthetic dict. Mirrors
+    :func:`plugins.petri_audit.mcp_bridge.lifecycle.build_mcp_config`.
+    """
+    work_dir = tmp_path / "audit-bridge-x"
+    work_dir.mkdir()
+    tools_json = work_dir / "tools.json"
+    tools_json.write_text("[]", encoding="utf-8")
+    invocation_env = env or {"GEODE_AUDIT_BRIDGE_TOOLS_JSON": str(tools_json)}
+    payload = {
+        "mcpServers": {
+            server_name: {
+                "command": "python",
+                "args": ["-m", "plugins.petri_audit.mcp_bridge.bridge_server"],
+                "env": invocation_env,
+            }
+        }
+    }
+    mcp_config_json = work_dir / "mcp-config.json"
+    mcp_config_json.write_text(json.dumps(payload), encoding="utf-8")
+    return BridgeInvocation(
+        work_dir=work_dir,
+        tools_json=tools_json,
+        mcp_config_json=mcp_config_json,
+        allowed_tools=["mcp__bridge__send_message"],
+    )
+
+
+def test_build_codex_cli_mcp_overrides_renders_command_and_args(tmp_path: Path) -> None:
+    """The flat -c overrides must contain command + args entries that
+    codex's TOML parser can decode back into the same structure that
+    [mcp_servers.bridge] would carry in ~/.codex/config.toml."""
+    tokens = build_codex_cli_mcp_overrides(_make_invocation(tmp_path))
+
+    # Always pairs of (-c, key=value), no orphan flags.
+    assert len(tokens) % 2 == 0
+    assert tokens[::2] == ["-c"] * (len(tokens) // 2)
+
+    # command + args + env entries — order is command, args, then envs.
+    bodies = tokens[1::2]
+    assert any(b.startswith("mcp_servers.bridge.command=") for b in bodies), bodies
+    assert any(b.startswith("mcp_servers.bridge.args=") for b in bodies), bodies
+
+
+def test_build_codex_cli_mcp_overrides_quotes_strings_as_toml(tmp_path: Path) -> None:
+    """Codex parses each ``-c key=value`` value as TOML — strings must
+    be JSON-quoted (which TOML also accepts as a string literal)."""
+    tokens = build_codex_cli_mcp_overrides(_make_invocation(tmp_path))
+
+    cmd_token = next(t for t in tokens if t.startswith("mcp_servers.bridge.command="))
+    _, _, cmd_value = cmd_token.partition("=")
+    assert json.loads(cmd_value) == "python", "command value must round-trip as a JSON string"
+
+    args_token = next(t for t in tokens if t.startswith("mcp_servers.bridge.args="))
+    _, _, args_value = args_token.partition("=")
+    assert json.loads(args_value) == [
+        "-m",
+        "plugins.petri_audit.mcp_bridge.bridge_server",
+    ]
+
+
+def test_build_codex_cli_mcp_overrides_renders_each_env_key_separately(tmp_path: Path) -> None:
+    """Each env var becomes its own dotted -c override so codex's TOML
+    parser sees ``mcp_servers.bridge.env.<KEY> = "<VALUE>"`` for each
+    key individually (no need to construct a nested dict literal)."""
+    tokens = build_codex_cli_mcp_overrides(
+        _make_invocation(tmp_path, env={"FOO_VAR": "sandbox://foo.json", "BAR_VAR": "1"})
+    )
+
+    bodies = tokens[1::2]
+    env_keys = [b for b in bodies if b.startswith("mcp_servers.bridge.env.")]
+    assert len(env_keys) == 2
+    assert any("mcp_servers.bridge.env.FOO_VAR=" in k for k in env_keys)
+    assert any("mcp_servers.bridge.env.BAR_VAR=" in k for k in env_keys)
+    # Values stay JSON-quoted (TOML strings).
+    foo_token = next(k for k in env_keys if "FOO_VAR" in k)
+    _, _, foo_value = foo_token.partition("=")
+    assert json.loads(foo_value) == "sandbox://foo.json"
+
+
+def test_build_codex_cli_mcp_overrides_missing_bridge_key_raises(tmp_path: Path) -> None:
+    """Invariant: the bridge server name is pinned to 'bridge'.
+    If the lifecycle module ever changes the key, callers must refresh
+    the override builder in lockstep — fail loud here so a silent
+    rename doesn't quietly break codex tool-use audits."""
+    bad_invocation = _make_invocation(tmp_path, server_name="renamed")
+
+    with pytest.raises(ValueError, match="must contain 'bridge' key"):
+        build_codex_cli_mcp_overrides(bad_invocation)
+
+
+# ---------------------------------------------------------------------------
+# extract_codex_tool_calls
+# ---------------------------------------------------------------------------
+
+
+def _function_call_event(
+    name: str = "mcp__bridge__send_message",
+    arguments: str = '{"text": "hello"}',
+    call_id: str = "call_123",
+) -> dict[str, Any]:
+    return {
+        "type": "item.completed",
+        "item": {
+            "type": "function_call",
+            "name": name,
+            "arguments": arguments,
+            "call_id": call_id,
+        },
+    }
+
+
+def test_extract_codex_tool_calls_strips_mcp_prefix() -> None:
+    """inspect_petri's solver dispatches against the bare tool name
+    (e.g. ``send_message``), not the MCP-prefixed wire form
+    (``mcp__bridge__send_message``). Parity with the claude side."""
+    calls = extract_codex_tool_calls([_function_call_event()])
+
+    assert len(calls) == 1
+    call = calls[0]
+    function_name = call.function if hasattr(call, "function") else call["function"]
+    assert function_name == "send_message", (
+        "mcp__bridge__ prefix must be stripped before reaching inspect_petri"
+    )
+
+
+def test_extract_codex_tool_calls_parses_arguments_json() -> None:
+    calls = extract_codex_tool_calls([_function_call_event(arguments='{"text": "hi", "n": 3}')])
+
+    call = calls[0]
+    arguments = call.arguments if hasattr(call, "arguments") else call["arguments"]
+    assert arguments == {"text": "hi", "n": 3}
+
+
+def test_extract_codex_tool_calls_surfaces_parse_error_on_bad_json() -> None:
+    """Bad JSON in arguments → parse_error field set, arguments default
+    to {}. Caller (inspect_petri's solver) decides what to do with the
+    parse_error; we surface rather than raise so a single mal-formed
+    tool call doesn't kill the whole audit."""
+    calls = extract_codex_tool_calls([_function_call_event(arguments="{not json")])
+
+    call = calls[0]
+    parse_error = call.parse_error if hasattr(call, "parse_error") else call["parse_error"]
+    arguments = call.arguments if hasattr(call, "arguments") else call["arguments"]
+    assert parse_error is not None
+    assert "JSON decode failed" in parse_error
+    assert arguments == {}
+
+
+def test_extract_codex_tool_calls_ignores_non_function_call_items() -> None:
+    """The codex JSONL stream interleaves agent_message / thread / turn
+    events — only function_call items become ToolCall entries."""
+    calls = extract_codex_tool_calls(
+        [
+            {"type": "thread.started", "thread": {"thread_id": "T1"}},
+            {"type": "item.completed", "item": {"type": "agent_message", "text": "hi"}},
+            _function_call_event(),
+            {"type": "turn.completed"},
+        ]
+    )
+
+    assert len(calls) == 1, "only the single function_call item should produce a tool call"
+
+
+def test_extract_codex_tool_calls_empty_stream_returns_no_calls() -> None:
+    """Text-only response → no tool calls → caller falls through to the
+    regular stop_reason path."""
+    calls = extract_codex_tool_calls(
+        [
+            {"type": "item.completed", "item": {"type": "agent_message", "text": "no tools"}},
+            {"type": "turn.completed"},
+        ]
+    )
+
+    assert calls == []
+
+
+def test_extract_codex_tool_calls_handles_multiple_calls_in_one_turn() -> None:
+    """A single codex turn can emit multiple function_call items —
+    inspect_petri's parallel-tools mode relies on every call being
+    surfaced in order."""
+    calls = extract_codex_tool_calls(
+        [
+            _function_call_event(name="mcp__bridge__send_message", call_id="c1"),
+            _function_call_event(
+                name="mcp__bridge__resume", arguments='{"session": "abc"}', call_id="c2"
+            ),
+        ]
+    )
+
+    assert len(calls) == 2
+    names = [c.function if hasattr(c, "function") else c["function"] for c in calls]
+    assert names == ["send_message", "resume"]
+    ids = [c.id if hasattr(c, "id") else c["id"] for c in calls]
+    assert ids == ["c1", "c2"]


### PR DESCRIPTION
## Summary
- CSA-1b 의 `NotImplementedError("tool_use deferred to CSA-2b MCP bridge")` boundary 제거. codex-cli auditor 가 tool_use 지원 — anthropic-side CSA-2 의 mirror.
- 새 모듈 `plugins/petri_audit/mcp_bridge/codex_overrides.py` (~110 LOC + 10 tests) 가 bridge invocation 을 codex 의 TOML override flag (`-c mcp_servers.bridge.*`) 로 번역. CSA-2 의 bridge core (`bridge_server` / `lifecycle` / `tool_translator` / `stream_parser_ext`) 는 provider-agnostic 라 무수정 재사용.
- cross-model auditor diversity unblocked — anthropic + codex 양쪽 모두 tool-capable.

## Why
- CSA-1b 는 codex-cli provider 의 scaffold + text-only 만 (judge role 충분). auditor 는 `send_message` / `resume` 등 tool_use 가 필요한데 boundary 로 막혀있음.
- CSA-2 가 anthropic 측 MCP bridge 를 추가한 시점부터 codex 측 mirror 가 자연스러운 follow-up.
- 다만 claude 의 `--mcp-config <path>` JSON 파일 패턴 ≠ codex 의 `-c key=value` 다중 override (TOML shape). 핵심 차이만 적은 모듈로 흡수.

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/mcp_bridge/codex_overrides.py` | **신규** — `build_codex_cli_mcp_overrides` + `extract_codex_tool_calls` |
| `plugins/petri_audit/mcp_bridge/__init__.py` | 신규 함수 2개 re-export |
| `plugins/petri_audit/codex_cli_provider.py` | `generate()` 분기 (text-only vs tools); `_generate_with_tools` 신규; `build_codex_cli_argv` 에 `mcp_overrides=` kwarg |
| `tests/plugins/petri_audit/test_codex_overrides.py` | **신규** 10 unit tests |
| `CHANGELOG.md` | [Unreleased] / ### Added entry |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Boundary lift | Implemented | NotImplementedError 제거, `_generate_with_tools` 활성 |
| codex MCP override 빌더 | Implemented | TOML JSON-quoting + per-env override |
| function_call event 파싱 | Implemented | `item.completed` + `item.type == function_call` |
| mcp__bridge__ prefix strip | Implemented | claude 측과 동일 helper 재사용 |
| Parse error 관용 처리 | Implemented | bad JSON → `parse_error` 필드 surface, raise X |
| Lane queue 공유 | Implemented | codex-cli-subagent lane 동일 사용 |
| release_bridge in finally | Implemented | leak 방지 |
| Live smoke | **Deferred** | codex JSONL function_call event shape 은 binary symbol table 로 확인. Runtime 검증은 follow-up |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/` — All checks passed
- [x] `uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` — 833 files already formatted
- [x] `uv run mypy core/ plugins/` — Success, 412 source files
- [x] `uv run deptry .` — No dependency issues found
- [x] focused pytest — 19 pass (10 codex_overrides + 9 mcp_bridge core)
- [ ] Live audit (deferred) — codex 측 auditor 가 실제 subscription 경로에서 tool_use 발동하는지 확인은 별도 CSA-2c-followup

## Reference
- CSA-1 (#1430) — paperclip claude-cli provider
- CSA-1b (#1465) — paperclip codex-cli provider (text-only, boundary)
- CSA-2 (#1468) — anthropic MCP bridge (이 PR 의 mirror 대상)
- CSA-3 (#1483) — manifest flip routing OAuth → paperclip subprocess
- 기반 패턴: ~/workspace/paperclip/packages/adapters/codex-local/src/server/parse.ts
- codex JSONL event shape: codex binary symbol table (homebrew install, function_call 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)