### PR TITLE
PR-Async-Phase-C foundation — SubAgentManager.adelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,33 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-Async-Phase-C foundation — ``SubAgentManager.adelegate``**.
+  First leg of the async-only migration plan ([[async-phase-c]] —
+  Phase A+B sequence). New ``async def adelegate(tasks, *,
+  on_progress=None, announce=True)`` uses ``asyncio.gather`` over
+  the existing async ``IsolatedRunner.arun`` per task — each task
+  off-loads its blocking subprocess/thread wait via
+  ``asyncio.to_thread``, so the caller's event loop is not pinned.
+  Backpressure is now suspended-coroutine cost (~1 KB) instead of
+  thread/subprocess RSS. Contract parity with sync ``delegate`` —
+  same depth guard, dedup, sandbox-dir expansion, hooks
+  (``SUBAGENT_STARTED/COMPLETED/FAILED``), run-record bookkeeping,
+  and announce semantics; only the wait mechanic differs
+  (asyncio.gather vs polling).
+
+  The legacy sync ``delegate`` now emits ``DeprecationWarning`` and
+  carries a ``# DEPRECATED-ASYNC-PHASE-C:`` grep anchor for the
+  bulk-removal pass at the end of the migration. Six new behaviour
+  tests in ``tests/test_agentic_loop.py::TestSubAgentManagerAdelegate``
+  pin parity (empty / handler success / handler failure / parallel
+  fan-out wall-clock / depth-guard short-circuit / deprecation
+  warning emission). All 127 pre-existing sub-agent tests stay green.
+
+  Next slice in the migration: Pipeline.arun + BaseSeedAgent.aexecute
+  + 8 seed-generation agents native async + CLI wiring.
+
 ### Changed
 
 - **autoresearch outer-loop UX cleanup — auditor default + config

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -273,7 +273,22 @@ class SubAgentManager:
                 Callers that already return full results via tool_result
                 (e.g. delegate_task) should pass announce=False to avoid
                 injecting the same information into the parent context twice.
+
+        .. deprecated:: 0.99.34
+            Use :meth:`adelegate` (async) instead. The polling-based sync
+            collection is replaced by ``asyncio.gather`` for cheaper
+            backpressure (no thread suspension during LLM wait). This
+            method is retained for non-async tool handler call sites
+            and will be removed once they migrate.
+            # DEPRECATED-ASYNC-PHASE-C: removal target
         """
+        import warnings
+
+        warnings.warn(
+            "SubAgentManager.delegate is deprecated; use adelegate() (async) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not tasks:
             return []
 
@@ -461,6 +476,202 @@ class SubAgentManager:
             len(results),
         )
         return results
+
+    async def adelegate(
+        self,
+        tasks: list[SubTask],
+        *,
+        on_progress: Callable[[SubResult], None] | None = None,
+        announce: bool = True,
+    ) -> list[SubResult]:
+        """Async sibling of :meth:`delegate` — ``asyncio.gather`` based fan-out.
+
+        PR-Async-Phase-C (2026-05-22) — replaces the polling collection loop
+        with native async. Each task runs in its own
+        :class:`IsolatedRunner.arun` coroutine (which uses ``asyncio.to_thread``
+        to off-load the blocking subprocess/thread wait); ``asyncio.gather``
+        completes when all tasks finish. Backpressure is suspended-coroutine
+        cost (~1 KB) instead of thread/subprocess RSS — fits cleanly with
+        async caller paths (Pipeline.arun, async tool handlers).
+
+        Contract parity with sync :meth:`delegate`: same depth guard, dedup,
+        sandbox directory expansion, hooks, run-record bookkeeping, announce
+        semantics. Only the *waiting* mechanic differs (asyncio.gather vs
+        polling).
+        """
+        import asyncio
+
+        if not tasks:
+            return []
+
+        # Explicit depth guard (defense-in-depth alongside denied_tools)
+        if self._depth >= self._max_depth:
+            log.warning(
+                "Sub-agent depth limit reached (%d/%d), rejecting %d tasks",
+                self._depth,
+                self._max_depth,
+                len(tasks),
+            )
+            return [
+                SubResult(
+                    task_id=t.task_id,
+                    description=t.description,
+                    success=False,
+                    error=f"Depth limit exceeded ({self._depth}/{self._max_depth})",
+                )
+                for t in tasks
+            ]
+
+        tasks = self._deduplicate(tasks)
+        if not tasks:
+            log.info("All tasks coalesced — nothing to execute")
+            return []
+
+        # Expand sandbox for sub-agent working directories
+        added_dirs: list[Path] = []
+        if self._working_dirs:
+            from core.tools.sandbox import add_working_directory
+
+            for dir_str in self._working_dirs:
+                dir_path = Path(dir_str)
+                if dir_path.is_dir():
+                    add_working_directory(dir_path)
+                    added_dirs.append(dir_path)
+
+        graph = self._build_task_graph(tasks)
+
+        # Build per-task IsolationConfig + run-record + hook STARTED in
+        # the same shape sync delegate uses.
+        from core.memory.session_key import build_subagent_session_key
+
+        per_task_setup: list[tuple[SubTask, Any, IsolationConfig]] = []
+        for task in tasks:
+            graph.mark_running(task.task_id)
+            self._emit_hook(HookEvent.SUBAGENT_STARTED, task)
+
+            child_key = build_subagent_session_key(
+                task.args.get("subject_id", task.args.get("subject", "unknown")), task.task_id
+            )
+
+            import uuid as _uuid
+
+            record = SubagentRunRecord(
+                run_id=_uuid.uuid4().hex[:12],
+                task_id=task.task_id,
+                child_session_key=child_key,
+                parent_session_key=self._parent_session_key,
+                task_type=task.task_type,
+                started_at=time.time(),
+            )
+            with self._records_lock:
+                self._run_records[task.task_id] = record
+                if len(self._run_records) > 200:
+                    oldest_key = next(iter(self._run_records))
+                    self._run_records.pop(oldest_key, None)
+
+            config = IsolationConfig(
+                session_id=task.task_id,
+                timeout_s=self._timeout_s,
+                post_to_main=False,
+                prefix=f"SubAgent:{task.task_type}",
+                metadata={
+                    "description": task.description,
+                    "task_type": task.task_type,
+                    "child_session_key": child_key,
+                },
+            )
+            fn_or_request: Any
+            if self._action_handlers is not None:
+                fn_or_request = self._build_worker_request(task)
+            else:
+                # _execute_subtask is bound method; arun expects callable
+                # passed via args/kwargs. The thread-mode path is sync.
+                fn_or_request = self._execute_subtask
+            per_task_setup.append((task, fn_or_request, config))
+
+        # Launch ALL tasks concurrently via asyncio.gather over IsolatedRunner.arun.
+        # arun's signature: arun(fn_or_request, *, args=(), kwargs=None, config=None)
+        # For the legacy thread mode, args=(task,) carries the SubTask payload.
+        async def _run_one(task: SubTask, fn_or_request: Any, config: IsolationConfig) -> SubResult:
+            try:
+                if self._action_handlers is not None:
+                    # Subprocess mode — WorkerRequest carries the payload.
+                    isolation = await self._runner.arun(fn_or_request, config=config)
+                else:
+                    # Thread mode — legacy callable + SubTask arg.
+                    isolation = await self._runner.arun(fn_or_request, args=(task,), config=config)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning("adelegate: arun raised for %s — %s", task.task_id, exc)
+                isolation = None
+            sub_result = self._to_sub_result(task, isolation)
+            if sub_result.success:
+                graph.mark_completed(task.task_id, result=sub_result.output)
+                self._emit_hook(HookEvent.SUBAGENT_COMPLETED, task, sub_result=sub_result)
+            else:
+                graph.mark_failed(task.task_id, error=sub_result.error or "unknown")
+                self._emit_hook(HookEvent.SUBAGENT_FAILED, task, error=sub_result.error)
+            if on_progress is not None:
+                try:
+                    on_progress(sub_result)
+                except Exception:
+                    log.warning(
+                        "on_progress callback failed for %s",
+                        task.task_id,
+                        exc_info=True,
+                    )
+            return sub_result
+
+        results: list[SubResult] = await asyncio.gather(
+            *[
+                _run_one(task, fn_or_request, config)
+                for task, fn_or_request, config in per_task_setup
+            ]
+        )
+
+        # Update run records with outcomes (G7 observability)
+        now = time.time()
+        with self._records_lock:
+            for sub_result in results:
+                rec = self._run_records.get(sub_result.task_id)
+                if rec is not None:
+                    rec.completed_at = now
+                    rec.outcome = "ok" if sub_result.success else "error"
+
+        # Announce completed results to parent (OpenClaw Spawn+Announce)
+        if announce and self._announce_enabled and self._parent_session_key:
+            for sub_result in results:
+                summary = ""
+                if sub_result.success:
+                    summary = sub_result.output.get("summary", "") if sub_result.output else ""
+                    if not summary:
+                        summary = str(sub_result.output)[:200] if sub_result.output else "completed"
+                else:
+                    summary = sub_result.error or "failed"
+                agent_result = SubAgentResult(
+                    task_id=sub_result.task_id,
+                    task_type=sub_result.description,
+                    status="ok" if sub_result.success else "error",
+                    summary=summary,
+                    data=sub_result.output,
+                    duration_ms=sub_result.duration_ms,
+                    error_message=sub_result.error,
+                )
+                self._announce_result(self._parent_session_key, agent_result)
+
+        # Clean up expanded sandbox directories
+        if added_dirs:
+            from core.tools.sandbox import remove_working_directory
+
+            for dir_path in added_dirs:
+                remove_working_directory(dir_path)
+
+        succeeded = sum(1 for r in results if r.success)
+        log.info(
+            "SubAgent async batch complete: %d/%d succeeded",
+            succeeded,
+            len(results),
+        )
+        return list(results)
 
     @property
     def hooks(self) -> HookSystem | None:

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -1018,6 +1018,126 @@ class TestSubAgentManager:
 
 
 # ---------------------------------------------------------------------------
+# adelegate — async sibling parity (PR-Async-Phase-C, 2026-05-22)
+# ---------------------------------------------------------------------------
+
+
+class TestSubAgentManagerAdelegate:
+    """Behaviour-parity tests for async ``SubAgentManager.adelegate``.
+
+    Mirrors the sync ``delegate`` test class so a future bulk-delete of
+    the sync path (Phase C cleanup) keeps full coverage on the async
+    survivor. Each test exercises the same input shape as its sync sibling.
+    """
+
+    def test_adelegate_empty_tasks(self) -> None:
+        import asyncio
+
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        runner = IsolatedRunner()
+        manager = SubAgentManager(runner)
+        results = asyncio.run(manager.adelegate([]))
+        assert results == []
+
+    def test_adelegate_with_handler(self) -> None:
+        import asyncio
+
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        runner = IsolatedRunner()
+
+        def handler(task_type: str, args: dict[str, Any]) -> dict[str, Any]:
+            return {"processed": True, "type": task_type}
+
+        manager = SubAgentManager(runner, task_handler=handler, timeout_s=10)
+        tasks = [SubTask("t1", "Test task 1", "analyze", {"subject_id": "Test"})]
+        results = asyncio.run(manager.adelegate(tasks))
+
+        assert len(results) == 1
+        assert results[0].task_id == "t1"
+        assert results[0].success is True
+
+    def test_adelegate_handler_failure(self) -> None:
+        import asyncio
+
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        runner = IsolatedRunner()
+
+        def handler(task_type: str, args: dict[str, Any]) -> dict[str, Any]:
+            raise ValueError("task handler failed")
+
+        manager = SubAgentManager(runner, task_handler=handler, timeout_s=10)
+        tasks = [SubTask("t1", "Failing task", "analyze", {})]
+        results = asyncio.run(manager.adelegate(tasks))
+
+        assert len(results) == 1
+        assert results[0].output.get("error") is not None
+
+    def test_adelegate_fans_out_in_parallel(self) -> None:
+        """Async fan-out must launch tasks concurrently via gather.
+
+        Verifies the wall-clock duration is closer to a single task's
+        runtime than to N × runtime — i.e., tasks ran in parallel.
+        """
+        import asyncio
+        import time
+
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        runner = IsolatedRunner()
+
+        def handler(task_type: str, args: dict[str, Any]) -> dict[str, Any]:
+            time.sleep(0.1)
+            return {"ok": True}
+
+        manager = SubAgentManager(runner, task_handler=handler, timeout_s=10)
+        tasks = [SubTask(f"t{i}", f"Task {i}", "analyze", {}) for i in range(5)]
+
+        started = time.time()
+        results = asyncio.run(manager.adelegate(tasks))
+        elapsed = time.time() - started
+
+        assert len(results) == 5
+        assert all(r.success for r in results)
+        # 5 × 0.1s sequential = 0.5s; parallel should be ≤ 0.3s with
+        # generous CI buffer.
+        assert elapsed < 0.3, f"parallel fan-out too slow: {elapsed:.2f}s"
+
+    def test_adelegate_depth_guard(self) -> None:
+        """Depth limit returns synthetic failures without launching tasks."""
+        import asyncio
+
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        runner = IsolatedRunner()
+        manager = SubAgentManager(runner, depth=2, max_depth=1)
+        tasks = [SubTask("t1", "Should be rejected", "analyze", {})]
+        results = asyncio.run(manager.adelegate(tasks))
+        assert len(results) == 1
+        assert results[0].success is False
+        assert "depth limit exceeded" in (results[0].error or "").lower()
+
+    def test_sync_delegate_emits_deprecation_warning(self) -> None:
+        """The sync ``delegate`` must surface a DeprecationWarning so
+        callers see the migration cue. ``adelegate`` is the survivor."""
+        import warnings
+
+        from core.orchestration.isolated_execution import IsolatedRunner
+
+        runner = IsolatedRunner()
+        manager = SubAgentManager(runner)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            manager.delegate([])
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "adelegate" in str(w.message)
+            for w in caught
+        )
+
+
+# ---------------------------------------------------------------------------
 # SubAgentManager — Orchestration Integration tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

First leg of the async-only Phase C migration. Adds ``async def SubAgentManager.adelegate(tasks, ...)`` using ``asyncio.gather`` over the existing async ``IsolatedRunner.arun``; the legacy sync ``delegate`` now emits ``DeprecationWarning`` and carries a ``# DEPRECATED-ASYNC-PHASE-C:`` grep anchor for the final bulk-delete pass.

## Why

User-confirmed Phase C migration plan (4-step sequence):
1. **This PR** — add async siblings + grep-anchor deprecate sync APIs (most-used: delegate)
2. Migrate seed-gen pipeline + 8 agents + CLI to async-only
3. Migrate non-seed-gen callers (audit_lane, tool_executor general handler, hooks)
4. ``grep DEPRECATED-ASYNC-PHASE-C`` → bulk delete sync APIs

Backpressure improvement: parent's event loop is not pinned during sub-agent wait (``asyncio.gather`` vs ``while pending: poll get_result()``). Suspended-coroutine cost (~1 KB) replaces per-thread RSS amplification.

Typer/process boundary grounding (verified via PyPI + GitHub issue #950 + main.py raw source): Typer 0.25.1 has **no native async command support**. ``run_process_coroutine`` (core/async_runtime.py) stays as the permitted 1-line sync↔async adapter for OS process boundaries (Typer, worker main). Runtime layer migrates to async-only inside that boundary.

## Changes

| File | Change |
|------|--------|
| ``core/agent/sub_agent.py`` | New ``adelegate`` (~180 LOC). Contract parity with ``delegate``: depth guard, dedup, sandbox-dir expansion, hooks, run-record bookkeeping, announce. Sync ``delegate`` decorated with ``DeprecationWarning`` + grep anchor |
| ``tests/test_agentic_loop.py`` | New ``TestSubAgentManagerAdelegate`` class — 6 behaviour tests including parallel-fan-out wall-clock proof (5 × 100ms tasks must finish in < 300ms) |
| ``CHANGELOG.md`` | ``[Unreleased] / ### Added`` entry with full migration sequence |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| adelegate parity | Implemented | depth guard, dedup, hooks, announce, run-records all match sync delegate |
| DeprecationWarning on sync delegate | Implemented | grep anchor ``# DEPRECATED-ASYNC-PHASE-C:`` for bulk delete |
| Parallel fan-out proof | Implemented | wall-clock test — 5 × 100ms < 300ms vs 500ms sequential |
| Sync delegate caller compat | Preserved | 127 pre-existing tests pass with warnings only |
| Pipeline.arun migration | **Deferred** | Follow-up PR (next sequence step) |
| 8 agent native async transitions | Deferred | Follow-up PR |
| IsolatedRunner._aexecute_subprocess | Deferred | Follow-up PR |
| Bulk delete of sync APIs | Deferred | Final cleanup PR after all migrations |

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``ruff format --check`` clean (818 files)
- [x] ``mypy core/ plugins/`` clean (411 source files)
- [x] ``pytest tests/test_agentic_loop.py tests/test_subagent_announce.py`` — 127 passed, 0 failed
- [ ] Full pytest suite — pending CI

## Reference

- Typer issue #950 (closed 2026-05-18, no merged async PR); Typer 0.25.1 PyPI deps: ``click + shellingham + rich + annotated-doc`` (no anyio/asyncio)
- open-coscientist async pattern: ``asyncio.gather`` + ``asyncio.Semaphore`` (verified by code grounding 2026-05-22)
- core/async_runtime.py:run_process_coroutine — OS process boundary 1-line adapter, runtime-internal use blocked via ``asyncio.get_running_loop()`` check