### PR TITLE
PR-Async-Phase-C step 2 — Pipeline + 8 agents native async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,65 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-Async-Phase-C step 2 — seed-generation Pipeline + 8 agents native async**.
+  Second leg of the async-only migration. The Pipeline orchestrator
+  + 8 seed-generation agents (Critic / Evolver / Generator /
+  MetaReviewer / Pilot / Proximity / Ranker / Supervisor) flip to
+  native async; sync siblings remain as ``DeprecationWarning`` +
+  ``# DEPRECATED-ASYNC-PHASE-C:`` grep-anchored shims for the
+  bulk-removal pass at the end of the migration.
+
+  **Pipeline orchestrator (``plugins/seed_generation/orchestrator.py``)**:
+
+  - ``async def arun`` (new) — walks the 8-phase ``_PHASE_ORDER``
+    (+ optional ``_ITERATION_PHASE_ORDER`` cycles) via
+    ``await self._arun_phase(phase)``.
+  - ``async def _arun_phase`` (new) — acquires the OpenClaw lane
+    chain via ``self._aacquire_lane(role)`` (async ctx) and awaits
+    the agent's ``aexecute``.
+  - ``_aacquire_lane(role)`` (new) — async context manager wrapping
+    ``LaneQueue.acquire_all_async`` with the ``["session",
+    "seed-generation", "global"]`` chain.
+  - Sync ``run`` / ``_run_phase`` / ``_acquire_lane`` retain
+    behaviour via ``run_process_coroutine(self.arun())`` shims;
+    each emits ``DeprecationWarning``.
+
+  **BaseSeedAgent (``plugins/seed_generation/agents/base.py``)**:
+
+  - Abstract method flipped to ``async def aexecute(state) ->
+    SeedAgentResult``.
+  - Sync ``execute`` becomes a deprecation shim that bridges
+    legacy callers via ``run_process_coroutine``.
+
+  **8 concrete agents**: each ``def execute`` body became
+  ``async def aexecute``, with ``self._manager.delegate(...)`` →
+  ``await self._manager.adelegate(...)``. The Ranker's
+  ``_play_match`` helper also flipped to ``async`` so the bracket
+  loop can await each match's voter fan-out.
+
+  **CLI wiring (``plugins/seed_generation/cli.py:452``)**:
+  ``pipeline.run()`` → ``run_process_coroutine(pipeline.arun())``
+  with a comment grounding the Typer 0.25.1 async-support gap
+  (issue #950 closed unmerged 2026-05-18). Group A entry points
+  (Typer CLI / worker subprocess main) MUST stay sync because Typer
+  doesn't natively support ``async def`` commands; the runtime
+  layer inside the process boundary is async-only.
+
+  **Test parity**:
+
+  - ``tests/plugins/seed_generation/`` — 14 stub manager classes
+    across 10 test files gained ``async def adelegate(tasks, ...)``
+    siblings calling ``self.delegate(...)``. Stub agents in
+    ``test_state_offload.py`` / ``test_iteration_loop.py`` /
+    ``test_base_agent.py`` / ``test_orchestrator.py`` flipped
+    ``def execute`` → ``async def aexecute``.
+  - ``tests/test_cosci_1_fixups.py`` — two ``inspect.getsource``
+    pins on ``Pipeline.run`` moved to ``Pipeline.arun`` (abort gate
+    now lives in async path).
+  - 362 seed-generation tests pass, 0 fail.
+
 ### Added
 
 - **PR-Async-Phase-C foundation — ``SubAgentManager.adelegate``**.

--- a/plugins/seed_generation/agents/base.py
+++ b/plugins/seed_generation/agents/base.py
@@ -159,9 +159,13 @@ class SeedAgentResult:
 class BaseSeedAgent(abc.ABC):
     """Abstract contract for a single seed-generation phase role.
 
-    Subclasses MUST override :meth:`execute`. Phase orchestration,
-    budget tracking, and registry lookup are owned by the Pipeline
-    class.
+    PR-Async-Phase-C step 2 (2026-05-22) — :meth:`aexecute` is now the
+    abstract method subclasses MUST override. The sync :meth:`execute`
+    is a deprecation shim that calls :meth:`aexecute` via
+    :func:`core.async_runtime.run_process_coroutine` so legacy sync
+    callers (Pipeline.run) still work while migration is in progress.
+    The shim emits ``DeprecationWarning`` and carries a grep anchor
+    (``# DEPRECATED-ASYNC-PHASE-C:``) for the bulk-removal pass.
 
     Per the fidelity amendment, the role concrete implementations
     (S2-S8) must perform substantive work — no ``pass`` /
@@ -182,14 +186,39 @@ class BaseSeedAgent(abc.ABC):
         self.manifest_role = manifest_role or {}
 
     @abc.abstractmethod
-    def execute(self, state: Any) -> SeedAgentResult:
-        """Run one phase of the pipeline against ``state``.
+    async def aexecute(self, state: Any) -> SeedAgentResult:
+        """Run one phase of the pipeline against ``state`` (async).
 
         ``state`` is the ``PipelineState`` instance (forward type to
         avoid circular import). The agent reads input fields, performs
-        its work, and returns a ``SeedAgentResult`` whose ``output``
-        the orchestrator merges back into the state.
+        its work (typically via ``await self._manager.adelegate(...)``),
+        and returns a ``SeedAgentResult`` whose ``output`` the
+        orchestrator merges back into the state.
         """
+
+    def execute(self, state: Any) -> SeedAgentResult:
+        """[DEPRECATED] Sync sibling of :meth:`aexecute`.
+
+        Bridges async ``aexecute`` to legacy sync ``Pipeline.run``
+        call sites until those migrate to ``Pipeline.arun``. The
+        bridge uses :func:`run_process_coroutine` which requires no
+        running event loop — RuntimeError if the caller already has
+        one (in which case they should ``await aexecute(...)``
+        directly).
+
+        # DEPRECATED-ASYNC-PHASE-C: removal target after Pipeline /
+        # CLI / tool_handler migrate to aexecute / arun fully.
+        """
+        import warnings
+
+        warnings.warn(
+            f"{type(self).__name__}.execute is deprecated; use aexecute (async) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from core.async_runtime import run_process_coroutine
+
+        return run_process_coroutine(self.aexecute(state))
 
     def __repr__(self) -> str:
         return (

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -102,7 +102,7 @@ class Critic(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Fan out N critique sub-agents and collect structured outputs."""
         if not state.candidates:
             return SeedAgentResult(
@@ -123,7 +123,7 @@ class Critic(BaseSeedAgent):
         )
 
         # announce=False — orchestrator already announces the parent phase.
-        results = self._manager.delegate(tasks, announce=False)
+        results = await self._manager.adelegate(tasks, announce=False)
 
         # S2-fix pattern — pair by task_id dict lookup, never by position.
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -109,7 +109,7 @@ class Evolver(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Fan out N evolution sub-agents and collect evolved candidate rows."""
         if not state.survivors:
             return SeedAgentResult(
@@ -141,7 +141,7 @@ class Evolver(BaseSeedAgent):
             len(tasks),
             _EVOLVER_AGENT_NAME,
         )
-        results = self._manager.delegate(tasks, announce=False)
+        results = await self._manager.adelegate(tasks, announce=False)
 
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
         evolved_rows: list[dict[str, Any]] = []

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -100,7 +100,7 @@ class Generator(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Fan out N candidate-generation sub-agents and collect successes."""
         if state.run_dir is None:
             return SeedAgentResult(
@@ -132,7 +132,7 @@ class Generator(BaseSeedAgent):
         # announce=False — orchestrator already announces the parent
         # phase, individual candidate spawns are sub-events not parent
         # events.
-        results = self._manager.delegate(tasks, announce=False)
+        results = await self._manager.adelegate(tasks, announce=False)
 
         # S2-fix (2026-05-18) — pair results by task_id, NOT by positional zip.
         # ``SubAgentManager.delegate`` returns SubResult in *completion* order

--- a/plugins/seed_generation/agents/meta_reviewer.py
+++ b/plugins/seed_generation/agents/meta_reviewer.py
@@ -98,7 +98,7 @@ class MetaReviewer(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Dispatch one meta-review sub-agent and parse the structured report."""
         if not state.candidates:
             return SeedAgentResult(
@@ -116,7 +116,7 @@ class MetaReviewer(BaseSeedAgent):
             "seed-generation meta_reviewer dispatching aggregate review to %r",
             _META_REVIEWER_AGENT_NAME,
         )
-        results = self._manager.delegate([task], announce=False)
+        results = await self._manager.adelegate([task], announce=False)
         if not results:
             return SeedAgentResult(
                 role=self.role,

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -98,7 +98,7 @@ class Pilot(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Fan out N pilot sub-agents and collect dim aggregates."""
         if not state.candidates:
             return SeedAgentResult(
@@ -119,7 +119,7 @@ class Pilot(BaseSeedAgent):
         )
 
         # announce=False — orchestrator already announces the parent phase.
-        results = self._manager.delegate(tasks, announce=False)
+        results = await self._manager.adelegate(tasks, announce=False)
 
         # S2-fix pattern — pair by task_id dict lookup, never by position.
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -104,7 +104,7 @@ class Proximity(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         if not state.candidates:
             return SeedAgentResult(
                 role=self.role,
@@ -125,7 +125,7 @@ class Proximity(BaseSeedAgent):
             len(state.candidates),
             _PROXIMITY_AGENT_NAME,
         )
-        results = self._manager.delegate([task], announce=False)
+        results = await self._manager.adelegate([task], announce=False)
         if not results:
             return SeedAgentResult(
                 role=self.role,

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -111,7 +111,7 @@ class Ranker(BaseSeedAgent):
         self._survivors_k = survivors_k
         self._rng = rng
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Run the Elo tournament against ``state.candidates`` survivors."""
         if not state.candidates:
             return SeedAgentResult(
@@ -164,7 +164,7 @@ class Ranker(BaseSeedAgent):
 
         outcomes: list[MatchOutcome] = []
         for match in match_plan:
-            outcome = self._play_match(match, pilot_means=pilot_means)
+            outcome = await self._play_match(match, pilot_means=pilot_means)
             if outcome is None:
                 continue
             outcomes.append(outcome)
@@ -187,7 +187,7 @@ class Ranker(BaseSeedAgent):
             },
         )
 
-    def _play_match(
+    async def _play_match(
         self,
         match: MatchPlan,
         *,
@@ -195,7 +195,7 @@ class Ranker(BaseSeedAgent):
     ) -> MatchOutcome | None:
         """Dispatch the 3 voters for one match; return ``None`` on quorum loss."""
         tasks = self._build_voter_tasks(match, pilot_means=pilot_means or {})
-        results = self._manager.delegate(tasks, announce=False)
+        results = await self._manager.adelegate(tasks, announce=False)
         tasks_by_id: dict[str, Any] = {t.task_id: t for t in tasks}
 
         votes: list[str] = []

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -121,14 +121,14 @@ class Supervisor(BaseSeedAgent):
         )
         self._manager = manager
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         """Dispatch one supervisor sub-agent and parse its guidance."""
         task = self._build_task(state)
         log.info(
             "seed-generation supervisor dispatching strategy synthesis to %r",
             _SUPERVISOR_AGENT_NAME,
         )
-        results = self._manager.delegate([task], announce=False)
+        results = await self._manager.adelegate([task], announce=False)
         if not results:
             return SeedAgentResult(
                 role=self.role,

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -449,7 +449,13 @@ def _dispatch_pipeline(
     if journal is not None:
         journal.append("pipeline_started", payload={"target_dim": target_dim})
 
-    pipeline.run()
+    # PR-Async-Phase-C step 2 (2026-05-22) — Typer command must remain
+    # sync (Typer 0.25.1 doesn't natively support ``async def`` commands;
+    # issue #950 closed without merged implementation). Bridge the
+    # async pipeline via the OS-process-boundary adapter.
+    from core.async_runtime import run_process_coroutine
+
+    run_process_coroutine(pipeline.arun())
 
     # P0a dedup — canonical run metrics (survivors, usd_spent, pool_path_out)
     # live in sessions.jsonl via Pipeline._append_session_index. The

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -350,7 +350,42 @@ class Pipeline:
         self._on_phase_error = on_phase_error
 
     def run(self) -> PipelineState:
-        """Walk the 7 phases (then optional iteration cycles). Returns the final state."""
+        """[DEPRECATED] Sync sibling — calls :meth:`arun` via run_process_coroutine.
+
+        Bridges legacy sync callers (pre-Phase-C ``cli.py:452``,
+        test fixtures still on ``pipeline.run()``) to the async-only
+        runtime. The bridge uses
+        :func:`core.async_runtime.run_process_coroutine`, which
+        requires no running event loop — RuntimeError if the caller
+        already has one (in which case they should
+        ``await pipeline.arun()`` directly).
+
+        # DEPRECATED-ASYNC-PHASE-C: removal target after cli.py +
+        # tests/* migrate to ``run_process_coroutine(pipeline.arun())``.
+        """
+        import warnings
+
+        warnings.warn(
+            "Pipeline.run is deprecated; use arun() (async) — wrap with "
+            "core.async_runtime.run_process_coroutine for sync entry points",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from core.async_runtime import run_process_coroutine
+
+        return run_process_coroutine(self.arun())
+
+    async def arun(self) -> PipelineState:
+        """Walk the 7 phases (then optional iteration cycles). Returns the final state.
+
+        PR-Async-Phase-C step 2 (2026-05-22) — async-native pipeline
+        walker. Replaces sync ``run`` which is now a deprecation
+        shim. Each phase calls :meth:`_arun_phase` (await), which
+        acquires the OpenClaw lane chain via the LaneQueue's
+        async ``acquire_all_async`` and awaits the agent's
+        :meth:`BaseSeedAgent.aexecute` — fan-out via
+        :meth:`SubAgentManager.adelegate` inside the agent.
+        """
         log.info(
             "seed-generation run started: run_id=%s target=%s gen=%s max_iters=%d",
             self.state.run_id,
@@ -397,7 +432,7 @@ class Pipeline:
                 )
             order = _PHASE_ORDER if iteration == 0 else _ITERATION_PHASE_ORDER
             for phase in order:
-                self._run_phase(phase)
+                await self._arun_phase(phase)
                 # PR-COSCI-1 (2026-05-21) — abort early when the
                 # candidates pool is empty after a phase that should
                 # have populated or filtered it. The check is scoped
@@ -758,14 +793,37 @@ class Pipeline:
             )
 
     def _run_phase(self, role: str) -> SeedAgentResult:
-        """Look up the role's agent, invoke it, merge the result.
+        """[DEPRECATED] Sync sibling of :meth:`_arun_phase`.
 
-        Wraps the execute call in an optional ``seed-generation`` lane
-        acquisition (when a ``LaneQueue`` was passed). For sequential
-        phases the lane is effectively a no-op; for phases that fan
-        out via ``delegate(tasks=[…])`` in S2+ the lane gates
-        concurrency at 16 (see ``DEFAULT_SEED_PIPELINE_CONCURRENCY``
-        in ``core/wiring/container.py``).
+        Bridges legacy sync callers to async pipeline. The actual
+        phase logic lives in :meth:`_arun_phase`; this shim uses
+        :func:`run_process_coroutine` to satisfy sync test fixtures
+        that haven't migrated to ``arun`` yet.
+
+        # DEPRECATED-ASYNC-PHASE-C: removal target after all sync
+        # ``Pipeline.run`` callers migrate to ``arun``.
+        """
+        import warnings
+
+        warnings.warn(
+            "Pipeline._run_phase is deprecated; use _arun_phase (async) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from core.async_runtime import run_process_coroutine
+
+        return run_process_coroutine(self._arun_phase(role))
+
+    async def _arun_phase(self, role: str) -> SeedAgentResult:
+        """Look up the role's agent, invoke it (async), merge the result.
+
+        PR-Async-Phase-C step 2 (2026-05-22) — async-native phase
+        runner. Wraps the agent's ``aexecute`` in the OpenClaw lane
+        chain via :meth:`_aacquire_lane` (which uses LaneQueue's
+        ``acquire_all_async``). For phases that fan out via
+        :meth:`SubAgentManager.adelegate` the lane gates concurrency
+        at the seed-generation cap (default 4 per Phase 1
+        ``DEFAULT_SEED_PIPELINE_CONCURRENCY``).
 
         Cost rollup is purely informational — the agent (or its test
         stub) sets ``result.usd_spent`` / ``prompt_tokens`` /
@@ -804,9 +862,9 @@ class Pipeline:
         started = time.time()
 
         result: SeedAgentResult | None = None
-        with self._acquire_lane(role):
+        async with self._aacquire_lane(role):
             try:
-                result = agent.execute(self.state)
+                result = await agent.aexecute(self.state)
             except Exception as exc:
                 duration = (time.time() - started) * 1000
                 log.exception("seed-generation phase %s raised", role)
@@ -859,21 +917,13 @@ class Pipeline:
         return result
 
     def _acquire_lane(self, role: str) -> Any:
-        """Return a context manager that walks the OpenClaw lane hierarchy.
+        """[DEPRECATED] Sync sibling — see :meth:`_aacquire_lane`.
 
-        Acquires ``["session", "seed-generation", "global"]`` in order so
-        per-role concurrency is bounded by BOTH the seed-generation
-        workload cap and the global cap (PR-LQ-Phase1, 2026-05-22). The
-        SessionLane keys on ``seed-generation:<run_id>`` so two concurrent
-        ``Pipeline.run()`` calls for the same ``run_id`` serialize
-        (prevents the pre-PR race where two launches of the same run
-        non-atomically incremented ``state.usd_spent`` etc.).
+        Retained because some pre-Phase-C test fixtures invoke
+        ``_run_phase`` (sync) directly. Once those fixtures migrate
+        to ``_arun_phase``, this can be removed.
 
-        When no ``LaneQueue`` was supplied (test path) or the
-        ``seed-generation`` lane is not registered, returns a no-op
-        context manager. The actual semaphore gating only takes effect
-        when the agent fans out via ``SubAgentManager.delegate(tasks=[…])``
-        in S2+.
+        # DEPRECATED-ASYNC-PHASE-C: removal target.
         """
         from contextlib import nullcontext
 
@@ -883,6 +933,38 @@ class Pipeline:
             return nullcontext()
         session_key = f"seed-generation:{self.state.run_id}"
         return self._lane_queue.acquire_all(
+            session_key,
+            ["session", "seed-generation", "global"],
+        )
+
+    def _aacquire_lane(self, role: str) -> Any:
+        """Return an async context manager walking the OpenClaw lane chain.
+
+        PR-Async-Phase-C step 2 (2026-05-22) — async sibling of
+        :meth:`_acquire_lane`. Acquires
+        ``["session", "seed-generation", "global"]`` in order via
+        :meth:`LaneQueue.acquire_all_async` so per-role concurrency
+        is bounded by BOTH the seed-generation workload cap and the
+        global cap (PR-LQ-Phase1). The SessionLane keys on
+        ``seed-generation:<run_id>`` so two concurrent
+        ``Pipeline.arun()`` calls for the same ``run_id`` serialize.
+
+        When no ``LaneQueue`` was supplied (test path) or the
+        ``seed-generation`` lane is not registered, returns an async
+        nullcontext.
+        """
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _noop() -> Any:
+            yield
+
+        if self._lane_queue is None:
+            return _noop()
+        if self._lane_queue.get_lane("seed-generation") is None:
+            return _noop()
+        session_key = f"seed-generation:{self.state.run_id}"
+        return self._lane_queue.acquire_all_async(
             session_key,
             ["session", "seed-generation", "global"],
         )

--- a/tests/plugins/seed_generation/test_base_agent.py
+++ b/tests/plugins/seed_generation/test_base_agent.py
@@ -26,7 +26,7 @@ def test_base_seed_agent_requires_execute_override() -> None:
 
 
 class _DummyAgent(BaseSeedAgent):
-    def execute(self, state: object) -> SeedAgentResult:
+    async def aexecute(self, state: object) -> SeedAgentResult:
         return SeedAgentResult(role=self.role, output={"candidates": [{"id": "x"}]})
 
 

--- a/tests/plugins/seed_generation/test_critic.py
+++ b/tests/plugins/seed_generation/test_critic.py
@@ -49,6 +49,10 @@ class _StubManager:
         self._force_failures = force_failures
         self._force_unparseable = force_unparseable
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks = list(tasks)
         self.received_announce = announce
@@ -86,6 +90,10 @@ class _StubManager:
 
 class _ReverseOrderManager(_StubManager):
     """Returns SubResults in REVERSE submission order (worst-case latency)."""
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
 
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         results = super().delegate(tasks, announce=announce)
@@ -201,6 +209,10 @@ def test_critic_accepts_text_json_fallback() -> None:
     # construct a manager that wraps the JSON-as-text inside output["text"].
 
     class _TextJsonManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             return [
                 SubResult(
@@ -240,6 +252,10 @@ def test_critic_drops_non_dict_outputs() -> None:
     _seed_candidates(state, 3)
 
     class _NonDictManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             shapes: list[Any] = [None, ["not", "a", "dict"], 42]
             return [

--- a/tests/plugins/seed_generation/test_evolver.py
+++ b/tests/plugins/seed_generation/test_evolver.py
@@ -44,6 +44,10 @@ class _StubManager:
         self._force_failures = force_failures
         self._force_unparseable = force_unparseable
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks = list(tasks)
         self.received_announce = announce
@@ -79,6 +83,10 @@ class _StubManager:
 
 
 class _ReverseOrderManager(_StubManager):
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         results = super().delegate(tasks, announce=announce)
         return list(reversed(results))

--- a/tests/plugins/seed_generation/test_evolver_anti_convergence.py
+++ b/tests/plugins/seed_generation/test_evolver_anti_convergence.py
@@ -116,6 +116,10 @@ class TestEvolverExecuteAdmissionFlow:
         }
 
         class _StubManager:
+            async def adelegate(self, tasks, *, announce: bool = True) -> list:
+                """Async sibling for Phase-C tests."""
+                return self.delegate(tasks, announce=announce)
+
             def delegate(self, tasks: list[Any], *, announce: bool = False) -> list[Any]:
                 return [_StubResult(t.task_id, outputs[t.task_id]) for t in tasks]
 

--- a/tests/plugins/seed_generation/test_generator.py
+++ b/tests/plugins/seed_generation/test_generator.py
@@ -19,6 +19,10 @@ class _StubManager:
         self._force_failures = force_failures
         self._fail_all = fail_all
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks = list(tasks)
         self.received_announce = announce

--- a/tests/plugins/seed_generation/test_generator_order_corruption.py
+++ b/tests/plugins/seed_generation/test_generator_order_corruption.py
@@ -25,6 +25,10 @@ class _ReverseOrderManager:
     def __init__(self) -> None:
         self.received_tasks: list[SubTask] = []
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks = list(tasks)
         results = [
@@ -76,6 +80,10 @@ def test_generator_pairs_by_task_id_under_reverse_order(tmp_path: Path) -> None:
 
 class _UnmatchedResultManager:
     """Returns a result whose task_id doesn't match any submitted task."""
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
 
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         results = [

--- a/tests/plugins/seed_generation/test_iteration_loop.py
+++ b/tests/plugins/seed_generation/test_iteration_loop.py
@@ -25,7 +25,7 @@ class _RecordingAgent(BaseSeedAgent):
         self._output = output or {}
         self.calls: list[int] = []
 
-    def execute(self, state: Any) -> SeedAgentResult:
+    async def aexecute(self, state: Any) -> SeedAgentResult:
         self.calls.append(state.current_iteration)
         return SeedAgentResult(role=self.role, output=dict(self._output))
 

--- a/tests/plugins/seed_generation/test_meta_reviewer.py
+++ b/tests/plugins/seed_generation/test_meta_reviewer.py
@@ -38,6 +38,10 @@ class _StubManager:
         self._success = success
         self._force_unparseable = force_unparseable
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks = list(tasks)
         self.received_announce = announce

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -26,7 +26,7 @@ class _StubAgent(BaseSeedAgent):
         self._output = output
         self.invocations = 0
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         self.invocations += 1
         return SeedAgentResult(
             role=self.role, output=self._output, prompt_tokens=10, completion_tokens=5
@@ -132,7 +132,7 @@ class _CostReportingAgent(BaseSeedAgent):
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         return SeedAgentResult(
             role=self.role,
             output={},
@@ -212,7 +212,7 @@ class _FailingAgent(BaseSeedAgent):
     def __init__(self, role: str) -> None:
         super().__init__(role=role, model="stub-model")
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         return SeedAgentResult(
             role=self.role,
             output={},
@@ -227,7 +227,7 @@ class _RaisingAgent(BaseSeedAgent):
     def __init__(self, role: str) -> None:
         super().__init__(role=role, model="stub-model")
 
-    def execute(self, state: PipelineState) -> SeedAgentResult:
+    async def aexecute(self, state: PipelineState) -> SeedAgentResult:
         raise RuntimeError("stub-induced hard failure")
 
 

--- a/tests/plugins/seed_generation/test_pilot.py
+++ b/tests/plugins/seed_generation/test_pilot.py
@@ -44,6 +44,10 @@ class _StubManager:
         self._force_failures = force_failures
         self._force_unparseable = force_unparseable
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks = list(tasks)
         self.received_announce = announce
@@ -81,6 +85,10 @@ class _StubManager:
 
 class _ReverseOrderManager(_StubManager):
     """Returns SubResults in REVERSE submission order (worst-case latency)."""
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
 
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         results = super().delegate(tasks, announce=announce)
@@ -248,6 +256,10 @@ def test_pilot_accepts_text_json_fallback() -> None:
     pilot_text = json.dumps(_good_pilot("gen2-000-cand"))
 
     class _TextJsonManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             return [
                 SubResult(
@@ -300,6 +312,10 @@ def test_pilot_drops_non_dict_outputs() -> None:
     _seed_candidates(state, 3)
 
     class _NonDictManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             shapes: list[Any] = [None, ["not", "a", "dict"], 42]
             return [

--- a/tests/plugins/seed_generation/test_proximity.py
+++ b/tests/plugins/seed_generation/test_proximity.py
@@ -36,6 +36,10 @@ class _StubManager:
         self._success = success
         self.delegated: list[Any] = []
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[Any], *, announce: bool = False) -> list[Any]:
         self.delegated.append((tasks, announce))
         return [

--- a/tests/plugins/seed_generation/test_ranker.py
+++ b/tests/plugins/seed_generation/test_ranker.py
@@ -67,6 +67,10 @@ class _AlwaysAWinsManager:
     def __init__(self) -> None:
         self.received_tasks: list[SubTask] = []
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         self.received_tasks.extend(tasks)
         return [
@@ -84,6 +88,10 @@ class _AlwaysAWinsManager:
 class _SplitVotesManager:
     """First voter A, second B, third tie → 3-way split → tie outcome."""
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         winners = ["A", "B", "tie"]
         return [
@@ -100,6 +108,10 @@ class _SplitVotesManager:
 
 class _OneFailureManager:
     """1 voter fails per match — 2 votes survive → quorum still met."""
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
 
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         results: list[SubResult] = []
@@ -129,6 +141,10 @@ class _OneFailureManager:
 
 class _MostFailManager:
     """2 of 3 voters fail per match → quorum lost → match skipped."""
+
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
 
     def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
         results: list[SubResult] = []
@@ -260,6 +276,10 @@ def test_ranker_skips_match_on_quorum_loss() -> None:
 
 def test_ranker_drops_invalid_winner_label() -> None:
     class _BadWinnerManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             return [
                 SubResult(
@@ -287,6 +307,10 @@ def test_ranker_drops_invalid_winner_label() -> None:
 
 def test_ranker_accepts_text_json_fallback() -> None:
     class _TextJsonManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             return [
                 SubResult(
@@ -313,6 +337,10 @@ def test_ranker_announce_false_propagates() -> None:
     class _CapturingManager:
         def __init__(self) -> None:
             self.received_announce: bool | None = None
+
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
 
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             self.received_announce = announce
@@ -342,6 +370,10 @@ def test_ranker_match_id_pinned_in_parse() -> None:
     """Even if LLM echoes a wrong match_id, the task's match_id wins."""
 
     class _WrongMatchIdManager:
+        async def adelegate(self, tasks, *, announce: bool = True) -> list:
+            """Async sibling for Phase-C tests."""
+            return self.delegate(tasks, announce=announce)
+
         def delegate(self, tasks: list[SubTask], *, announce: bool = True) -> list[SubResult]:
             return [
                 SubResult(

--- a/tests/plugins/seed_generation/test_state_offload.py
+++ b/tests/plugins/seed_generation/test_state_offload.py
@@ -24,7 +24,7 @@ class _NoopAgent(BaseSeedAgent):
     def __init__(self, role: str) -> None:
         super().__init__(role=role, model="dummy")
 
-    def execute(self, state: Any) -> SeedAgentResult:
+    async def aexecute(self, state: Any) -> SeedAgentResult:
         return SeedAgentResult(role=self.role)
 
 

--- a/tests/plugins/seed_generation/test_supervisor_node.py
+++ b/tests/plugins/seed_generation/test_supervisor_node.py
@@ -31,6 +31,10 @@ class _StubManager:
         self._output = output
         self.delegated: list[Any] = []
 
+    async def adelegate(self, tasks, *, announce: bool = True) -> list:
+        """Async sibling for Phase-C tests."""
+        return self.delegate(tasks, announce=announce)
+
     def delegate(self, tasks: list[Any], *, announce: bool = False) -> list[Any]:
         self.delegated.append((tasks, announce))
         return [_StubSubResult(task_id=tasks[0].task_id, output=self._output)]
@@ -74,6 +78,10 @@ class TestSupervisorExecute:
 
     def test_sub_agent_failure_surfaces(self) -> None:
         class _Failing(_StubManager):
+            async def adelegate(self, tasks, *, announce: bool = True) -> list:
+                """Async sibling for Phase-C tests."""
+                return self.delegate(tasks, announce=announce)
+
             def delegate(self, tasks: list[Any], *, announce: bool = False) -> list[Any]:
                 sub = _StubSubResult(task_id=tasks[0].task_id, output={}, success=False)
                 sub.error = "model_timeout"

--- a/tests/test_cosci_1_fixups.py
+++ b/tests/test_cosci_1_fixups.py
@@ -76,12 +76,17 @@ def test_orchestrator_aborts_on_empty_candidates_after_generator(
 ) -> None:
     """When the generator phase leaves ``state.candidates == []``, the
     orchestrator must abort BEFORE running critic/pilot/ranker rather
-    than emit a "successful but empty" run."""
+    than emit a "successful but empty" run.
+
+    PR-Async-Phase-C step 2 (2026-05-22) — abort logic now lives in
+    ``Pipeline.arun`` (async); sync ``run`` is a deprecation shim. Pin
+    the source on ``arun`` instead.
+    """
     import inspect
 
     from plugins.seed_generation import orchestrator
 
-    src = inspect.getsource(orchestrator.Pipeline.run)
+    src = inspect.getsource(orchestrator.Pipeline.arun)
     # The abort gate must check the post-phase state for empty
     # candidates after generator or proximity. Pin presence.
     assert "empty_candidates_abort" in src or "state.candidates empty" in src
@@ -97,7 +102,7 @@ def test_orchestrator_abort_emits_observability_event() -> None:
 
     from plugins.seed_generation import orchestrator
 
-    src = inspect.getsource(orchestrator.Pipeline.run)
+    src = inspect.getsource(orchestrator.Pipeline.arun)
     assert '"empty_candidates_abort"' in src
     # Error level — abort is a failure, not a normal state.
     assert 'level="error"' in src


### PR DESCRIPTION
## Summary

Second leg of the async-only Phase C migration. Pipeline orchestrator + 8 seed-generation agents flip to async-native execution; sync siblings remain as DeprecationWarning + ``# DEPRECATED-ASYNC-PHASE-C:`` grep-anchored shims for the final bulk-removal pass.

## Why

Step 2 of the 4-step Phase C plan:
1. ✅ #1490 — `SubAgentManager.adelegate` foundation
2. **This PR** — Pipeline.arun + 8 agents native async + CLI wiring
3. Follow-up — IsolatedRunner._aexecute_subprocess, tool_executor general handler, audit_lane, HookSystem
4. Follow-up — bulk-grep `# DEPRECATED-ASYNC-PHASE-C:` and delete sync APIs

Each step is independently CI-verifiable per the user-directive "검증 강도 높여서 진행".

## Changes

| File | Change |
|------|--------|
| `plugins/seed_generation/orchestrator.py` | `arun` + `_arun_phase` + `_aacquire_lane` (new async); sync `run`/`_run_phase`/`_acquire_lane` become DeprecationWarning shims via `run_process_coroutine` |
| `plugins/seed_generation/agents/base.py` | Abstract flipped to `async def aexecute`; sync `execute` deprecation shim |
| `plugins/seed_generation/agents/{8 files}.py` | `def execute` → `async def aexecute`; `delegate` → `await adelegate`. Ranker `_play_match` also async |
| `plugins/seed_generation/cli.py:452` | `pipeline.run()` → `run_process_coroutine(pipeline.arun())` with Typer-async-gap grounding comment |
| `tests/plugins/seed_generation/*.py` | 14 stub managers gained async `adelegate` siblings; 4 stub agents flipped `execute` → `aexecute` |
| `tests/test_cosci_1_fixups.py` | `inspect.getsource(Pipeline.run)` → `inspect.getsource(Pipeline.arun)` (abort gate moved) |
| `CHANGELOG.md` | `[Unreleased] / ### Changed` entry |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Pipeline.arun + _arun_phase + _aacquire_lane | Implemented | uses acquire_all_async |
| BaseSeedAgent.aexecute abstract | Implemented | sync execute = deprecation shim |
| 8 agents native async | Implemented | bulk script + Ranker._play_match manual |
| CLI Typer command async-bridge | Implemented | run_process_coroutine wrapper |
| Test stubs adelegate/aexecute | Implemented | 14 + 4 conversions |
| inspect.getsource source pins | Updated | cosci_1_fixups → arun |
| Deprecated grep anchor | Present | `# DEPRECATED-ASYNC-PHASE-C:` on 5 sync siblings |

## Verification

- [x] ``ruff check core/ tests/ plugins/ autoresearch/ scripts/`` clean
- [x] ``ruff format --check`` clean (818 files)
- [x] ``mypy core/ plugins/`` clean (411 source files)
- [x] ``pytest tests/plugins/seed_generation/`` 362 passed, 0 failed
- [x] ``geode version`` smoke → ``GEODE v0.99.33``
- 3 known-local-env failures (codex OAuth bucket throttle, autoresearch config pollution) are pre-existing, not regressions — confirmed via ``GEODE_CODEX_OAUTH_POLL_DISABLED=1 pytest …`` re-run all green
- [ ] Full pytest suite on CI — pending

## Reference

- Typer 0.25.1 native async support gap: issue #950 (closed 2026-05-18 unmerged), PR #444 (closed unmerged), main.py has 0 async references — Group A entry points MUST stay sync
- core/async_runtime.py:run_process_coroutine — process-boundary adapter, runtime-internal use blocked
- open-coscientist pure asyncio pattern (single-process LangGraph ainvoke); GEODE 's async-only target aligns at the runtime layer while preserving process-boundary subprocess isolation