### PR TITLE
PR-Async-Phase-C step 4a — scheduler_drain async-native + serve loop on asyncio.run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,42 @@ functional change.
 
 ### Changed
 
+- **PR-Async-Phase-C step 4a — scheduler_drain async-native + serve loop on
+  asyncio.run**. Migration prerequisite for step 4b's bulk delete of the
+  ``# DEPRECATED-ASYNC-PHASE-C:`` anchors. The last remaining non-deprecated
+  ``IsolatedRunner.run_async`` caller — the scheduler queue drain — flips
+  to ``asyncio.create_task`` fire-and-forget on the calling loop.
+
+  **``core/cli/scheduler_drain.py``**:
+
+  - ``drain_scheduler_queue`` flips to ``async def``. The ``runner``
+    parameter is removed (no longer needed — fire-and-forget runs on
+    the caller's event loop).
+  - Isolated dispatch path: builds an ``async def _arun_isolated``
+    closure with ``asyncio.wait_for(_loop.arun(_p), timeout=300.0)``
+    (was ``run_process_coroutine(_loop.arun(_p))`` inside a thread).
+    ``asyncio.create_task`` schedules it; the task is stored in a
+    module-level ``_INFLIGHT_SCHEDULED_TASKS: set[asyncio.Task]`` so
+    the GC cannot reap it mid-flight (``create_task`` only holds a
+    weak reference).
+  - Non-isolated REPL path: ``run_process_coroutine(main_loop.arun(prompt))``
+    → ``await main_loop.arun(prompt)``.
+
+  **``core/cli/interactive_loop.py``** — ``_drain_scheduler_queue``
+  delegator becomes ``async def`` to match.
+
+  **``core/cli/typer_serve.py``** — the sync poll loop
+  (``while not stop: _drain(...); _time.sleep(1.0)``) is hoisted into
+  an ``async def _serve_loop`` driven by ``asyncio.run(_serve_loop())``.
+  Signal handlers stay sync (they only flip the ``stop`` flag the loop
+  polls). The ``_sched_runner = IsolatedRunner()`` line is gone.
+
+  **Tests (``tests/test_scheduler_serve.py`` 9 calls +
+  ``tests/test_cli_extracted.py`` 1 call)**: each ``_drain_scheduler_queue(...)``
+  call wrapped in ``asyncio.run(...)``. The ``mock_runner`` fixture and
+  every ``mock_runner.run_async.assert_*`` assertion deleted. Dispatch
+  verification migrated to ``on_dispatch`` callbacks. 20/20 tests pass.
+
 - **PR-Async-Phase-C step 3 — IsolatedRunner subprocess + ToolExecutor
   delegate native async**. Third leg of the async-only migration.
   Two remaining non-seed-generation sync entries on the hot path —

--- a/core/cli/interactive_loop.py
+++ b/core/cli/interactive_loop.py
@@ -16,11 +16,10 @@ from typing import Any
 from core.ui.console import console
 
 
-def _drain_scheduler_queue(
+async def _drain_scheduler_queue(
     *,
     action_queue: Any,
     services: Any,
-    runner: Any,
     session_lane: Any,
     global_lane: Any,
     force_isolated: bool = False,
@@ -30,13 +29,17 @@ def _drain_scheduler_queue(
     on_skip: Any | None = None,
     on_main_run: Any | None = None,
 ) -> int:
-    """Drain pending scheduled jobs. Delegates to scheduler_drain module."""
+    """Drain pending scheduled jobs. Delegates to scheduler_drain module.
+
+    PR-Async-Phase-C step 4a (2026-05-22) — async-native; the previous
+    ``IsolatedRunner`` parameter is gone now that fire-and-forget runs on
+    the caller's event loop via ``asyncio.create_task``.
+    """
     from core.cli.scheduler_drain import drain_scheduler_queue
 
-    return drain_scheduler_queue(
+    return await drain_scheduler_queue(
         action_queue=action_queue,
         services=services,
-        runner=runner,
         session_lane=session_lane,
         global_lane=global_lane,
         force_isolated=force_isolated,

--- a/core/cli/scheduler_drain.py
+++ b/core/cli/scheduler_drain.py
@@ -1,24 +1,37 @@
 """Scheduler queue drain — extracted from cli/__init__.py for SRP.
 
 Drains pending scheduled jobs from the action queue, shared by REPL and serve modes.
+
+PR-Async-Phase-C step 4a (2026-05-22) — fully async-native drain. The old
+sync helper that dispatched isolated jobs through ``IsolatedRunner.run_async``
+is replaced by ``asyncio.create_task`` fire-and-forget on the calling loop.
+Active tasks are tracked in a module-level set so the GC cannot reap them
+mid-flight (see ``asyncio.create_task`` docs — "Save a reference to the result
+of this function").
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 from core.agent.conversation import ConversationContext
-from core.async_runtime import run_process_coroutine
 
 log = logging.getLogger(__name__)
 
 
-def drain_scheduler_queue(
+# Module-level strong refs for fire-and-forget tasks. Required because
+# ``asyncio.create_task`` only holds a weak reference; without this the
+# task could be GC'd before completion and the event loop would log
+# "Task was destroyed but it is pending!".
+_INFLIGHT_SCHEDULED_TASKS: set[asyncio.Task[None]] = set()
+
+
+async def drain_scheduler_queue(
     *,
     action_queue: Any,
     services: Any,
-    runner: Any,
     session_lane: Any,
     global_lane: Any,
     force_isolated: bool = False,
@@ -30,17 +43,17 @@ def drain_scheduler_queue(
 ) -> int:
     """Drain pending scheduled jobs from the action queue.
 
-    Shared by both REPL and serve modes.  In serve mode ``force_isolated``
+    Shared by both REPL and serve modes. In serve mode ``force_isolated``
     is True because there is no interactive main session to inject into.
 
     Uses SessionLane (per-key serial) + Global Lane (capacity) for
     concurrency control through the unified LaneQueue.
 
-    Returns the number of jobs drained.
+    Returns the number of jobs drained. Isolated dispatch is fire-and-
+    forget: the function returns once tasks are scheduled, not once
+    they complete.
     """
     import queue as _q
-
-    from core.orchestration.isolated_execution import IsolationConfig
 
     count = 0
     try:
@@ -84,42 +97,33 @@ def drain_scheduler_queue(
                         conversation=_iso_conv,
                         propagate_context=True,
                     )
-                    _cap_loop = _iso_loop
-                    _cap_prompt = prompt
-                    _cap_jid = job_id
-                    _cap_sess = session_lane
-                    _cap_glob = global_lane
-                    _cap_key = lane_key
-                    _cap_cb = on_complete
 
-                    def _run_isolated(
+                    async def _arun_isolated(
                         *,
-                        _loop: Any = _cap_loop,
-                        _p: str = _cap_prompt,
-                        _jid: str = _cap_jid,
-                        _sess: Any = _cap_sess,
-                        _glob: Any = _cap_glob,
-                        _key: str = _cap_key,
-                        _cb: Any = _cap_cb,
-                    ) -> str:
+                        _loop: Any = _iso_loop,
+                        _p: str = prompt,
+                        _jid: str = job_id,
+                        _sess: Any = session_lane,
+                        _glob: Any = global_lane,
+                        _key: str = lane_key,
+                        _cb: Any = on_complete,
+                    ) -> None:
                         try:
-                            r = run_process_coroutine(_loop.arun(_p))
+                            r = await asyncio.wait_for(_loop.arun(_p), timeout=300.0)
                             if _cb:
                                 _cb(r, job_id=_jid)
-                            return r.text if r and r.text else ""
+                        except TimeoutError:
+                            log.warning("Scheduler job %s timed out after 300s", _jid)
+                        except Exception:
+                            log.warning("Scheduler job %s execution failed", _jid, exc_info=True)
                         finally:
                             _glob.manual_release(_key)
                             _sess.manual_release(_key)
 
-                    runner.run_async(
-                        _run_isolated,
-                        config=IsolationConfig(
-                            prefix=f"scheduled:{job_id}",
-                            post_to_main=False,
-                            timeout_s=300.0,
-                        ),
-                    )
-                    _lanes_acquired = False  # ownership transferred to _run_isolated
+                    task = asyncio.create_task(_arun_isolated(), name=f"scheduled:{job_id}")
+                    _INFLIGHT_SCHEDULED_TASKS.add(task)
+                    task.add_done_callback(_INFLIGHT_SCHEDULED_TASKS.discard)
+                    _lanes_acquired = False  # ownership transferred to the task
                     if on_dispatch:
                         on_dispatch(job_id)
                 except Exception:
@@ -132,7 +136,7 @@ def drain_scheduler_queue(
                 if on_main_run:
                     on_main_run(job_id)
                 try:
-                    run_process_coroutine(main_loop.arun(prompt))
+                    await main_loop.arun(prompt)
                 except Exception:
                     log.warning("Scheduler job %s main-loop failed", job_id, exc_info=True)
     except _q.Empty:

--- a/core/cli/typer_serve.py
+++ b/core/cli/typer_serve.py
@@ -28,6 +28,7 @@ def serve(
     ),
 ) -> None:
     """Run GEODE Gateway in headless mode (no REPL, Slack/Discord/Telegram only)."""
+    import asyncio
     import logging as _logging
     import signal
     import time as _time
@@ -107,8 +108,6 @@ def serve(
     # --- Scheduler daemon (same SchedulerService as REPL, drain in main loop) ---
     import queue as _queue_mod
 
-    from core.orchestration.isolated_execution import IsolatedRunner
-
     _sched_queue: _queue_mod.Queue[tuple[str, str, bool, str]] = _queue_mod.Queue()
     _sched_svc = None
     try:
@@ -131,7 +130,6 @@ def serve(
         log.warning("SchedulerService init failed in serve", exc_info=True)
         console.print("  [warning]Scheduler init failed — running without scheduler[/warning]")
 
-    _sched_runner = IsolatedRunner()
     _serve_session_lane = _gw_services.lane_queue.session_lane
     _serve_global_lane = _gw_services.lane_queue.get_lane("global")
 
@@ -236,15 +234,22 @@ def serve(
     signal.signal(signal.SIGINT, _on_signal)
     signal.signal(signal.SIGTERM, _on_signal)
 
-    try:
-        while not stop:
-            # Drain scheduled jobs (all forced-isolated — no main session in serve)
-            from core.cli.interactive_loop import _drain_scheduler_queue
+    async def _serve_loop() -> None:
+        """Async serve loop driving scheduler drain + idle cleanup.
 
-            _drain_scheduler_queue(
+        PR-Async-Phase-C step 4a (2026-05-22) — was a sync ``while not
+        stop: _drain(...); _time.sleep(1.0)``. The drain is now async-
+        native (fire-and-forget jobs are scheduled via
+        ``asyncio.create_task`` on this loop), so the entire tick body
+        has to run inside ``asyncio.run`` for the dispatched tasks to
+        survive past the drain call.
+        """
+        from core.cli.interactive_loop import _drain_scheduler_queue
+
+        while not stop:
+            await _drain_scheduler_queue(
                 action_queue=_sched_queue,
                 services=_gw_services,
-                runner=_sched_runner,
                 session_lane=_serve_session_lane,
                 global_lane=_serve_global_lane,
                 force_isolated=True,
@@ -252,10 +257,12 @@ def serve(
                 on_dispatch=lambda jid: log.info("scheduled:%s dispatched", jid),
                 on_skip=lambda jid: log.warning("scheduled:%s skipped (slots full)", jid),
             )
-            # Periodic idle session cleanup
             if _serve_session_lane:
                 _serve_session_lane.cleanup_idle()
-            _time.sleep(1.0)
+            await asyncio.sleep(1.0)
+
+    try:
+        asyncio.run(_serve_loop())
     finally:
         # --- Phase 0: notify shutdown hook ---
         try:

--- a/tests/test_cli_extracted.py
+++ b/tests/test_cli_extracted.py
@@ -58,16 +58,18 @@ class TestSchedulerDrain:
     """Test scheduler drain function."""
 
     def test_empty_queue(self) -> None:
+        import asyncio
         import queue
 
         from core.cli.scheduler_drain import drain_scheduler_queue
 
         q: queue.Queue = queue.Queue()
-        result = drain_scheduler_queue(
-            action_queue=q,
-            services=MagicMock(),
-            runner=MagicMock(),
-            session_lane=MagicMock(),
-            global_lane=MagicMock(),
+        result = asyncio.run(
+            drain_scheduler_queue(
+                action_queue=q,
+                services=MagicMock(),
+                session_lane=MagicMock(),
+                global_lane=MagicMock(),
+            )
         )
         assert result == 0

--- a/tests/test_scheduler_serve.py
+++ b/tests/test_scheduler_serve.py
@@ -3,10 +3,15 @@
 Verifies that the _drain_scheduler_queue() helper works correctly for both
 serve mode (force_isolated=True) and REPL mode (force_isolated=False), and
 that the SchedulerService lifecycle (init/load/save/stop) is correct.
+
+PR-Async-Phase-C step 4a (2026-05-22) — drain is async-native; tests wrap
+each call in ``asyncio.run`` and verify dispatch via the ``on_dispatch``
+callback instead of the removed ``IsolatedRunner.run_async`` indirection.
 """
 
 from __future__ import annotations
 
+import asyncio
 import queue
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -36,13 +41,6 @@ def mock_services() -> MagicMock:
 
 
 @pytest.fixture()
-def mock_runner() -> MagicMock:
-    runner = MagicMock()
-    runner.run_async.return_value = "session-123"
-    return runner
-
-
-@pytest.fixture()
 def session_lane() -> SessionLane:
     return SessionLane(max_sessions=10)
 
@@ -64,77 +62,76 @@ class TestDrainSchedulerQueue:
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
         """Empty queue should drain nothing and return 0."""
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=True,
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=True,
+            )
         )
         assert count == 0
-        mock_runner.run_async.assert_not_called()
 
     def test_isolated_job_dispatched(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
-        """Isolated job should be dispatched via runner.run_async()."""
+        """Isolated job should be dispatched via asyncio.create_task (fire-and-forget)."""
         action_queue.put(("job-1", "do something", True))
         dispatched: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=False,
-            on_dispatch=lambda jid: dispatched.append(jid),
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=False,
+                on_dispatch=lambda jid: dispatched.append(jid),
+            )
         )
 
         assert count == 1
-        mock_runner.run_async.assert_called_once()
         assert dispatched == ["job-1"]
 
     def test_force_isolated_overrides_flag(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
         """In serve mode (force_isolated=True), non-isolated jobs run isolated."""
         action_queue.put(("job-2", "run report", False))  # isolated=False
+        dispatched: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=True,  # serve mode
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=True,  # serve mode
+                on_dispatch=lambda jid: dispatched.append(jid),
+            )
         )
 
         assert count == 1
-        # Should still dispatch via runner (not main_loop)
-        mock_runner.run_async.assert_called_once()
+        # Should still dispatch via the isolated path (not main_loop)
+        assert dispatched == ["job-2"]
 
     def test_non_isolated_uses_main_loop_arun(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
@@ -144,19 +141,19 @@ class TestDrainSchedulerQueue:
         main_loop.arun = AsyncMock(return_value=MagicMock(text="result"))
         main_runs: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=False,
-            main_loop=main_loop,
-            on_main_run=lambda jid: main_runs.append(jid),
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=False,
+                main_loop=main_loop,
+                on_main_run=lambda jid: main_runs.append(jid),
+            )
         )
 
         assert count == 1
-        mock_runner.run_async.assert_not_called()
         main_loop.arun.assert_awaited_once()
         assert "[scheduled-job:job-3]" in main_loop.arun.call_args[0][0]
         assert main_runs == ["job-3"]
@@ -165,56 +162,59 @@ class TestDrainSchedulerQueue:
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
     ) -> None:
         """Jobs should be skipped when global lane is full."""
         full_global = Lane("global", max_concurrent=0)  # zero capacity
         action_queue.put(("job-4", "important task", True))
         skipped: list[str] = []
+        dispatched: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=full_global,
-            force_isolated=True,
-            on_skip=lambda jid: skipped.append(jid),
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=full_global,
+                force_isolated=True,
+                on_skip=lambda jid: skipped.append(jid),
+                on_dispatch=lambda jid: dispatched.append(jid),
+            )
         )
 
         assert count == 1
-        mock_runner.run_async.assert_not_called()
+        assert dispatched == []
         assert skipped == ["job-4"]
 
     def test_empty_action_skipped(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
         """Jobs with empty fired_action should be silently skipped."""
         action_queue.put(("job-5", "", True))
+        dispatched: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=True,
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=True,
+                on_dispatch=lambda jid: dispatched.append(jid),
+            )
         )
 
         assert count == 0  # empty action does not count
-        mock_runner.run_async.assert_not_called()
+        assert dispatched == []
 
     def test_multiple_jobs_drained(
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
     ) -> None:
         """Multiple queued jobs should all be drained in one call."""
@@ -222,18 +222,21 @@ class TestDrainSchedulerQueue:
         action_queue.put(("j2", "task two", True))
         action_queue.put(("j3", "task three", True))
         big_global = Lane("global", max_concurrent=8, timeout_s=30.0)
+        dispatched: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=big_global,
-            force_isolated=True,
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=big_global,
+                force_isolated=True,
+                on_dispatch=lambda jid: dispatched.append(jid),
+            )
         )
 
         assert count == 3
-        assert mock_runner.run_async.call_count == 3
+        assert dispatched == ["j1", "j2", "j3"]
         assert action_queue.empty()
 
 
@@ -248,7 +251,6 @@ class TestDrainErrorPaths:
     def test_create_session_failure_releases_lanes(
         self,
         action_queue: queue.Queue,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
@@ -256,18 +258,21 @@ class TestDrainErrorPaths:
         failing_services = MagicMock()
         failing_services.create_session.side_effect = RuntimeError("MCP down")
         action_queue.put(("job-err", "fail task", True))
+        dispatched: list[str] = []
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=failing_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=True,
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=failing_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=True,
+                on_dispatch=lambda jid: dispatched.append(jid),
+            )
         )
 
         assert count == 1
-        mock_runner.run_async.assert_not_called()
+        assert dispatched == []
         # Lanes should NOT be leaked
         assert session_lane.active_count == 0
         assert global_lane.active_count == 0
@@ -276,7 +281,6 @@ class TestDrainErrorPaths:
         self,
         action_queue: queue.Queue,
         mock_services: MagicMock,
-        mock_runner: MagicMock,
         session_lane: SessionLane,
         global_lane: Lane,
     ) -> None:
@@ -286,14 +290,15 @@ class TestDrainErrorPaths:
         action_queue.put(("j1", "first", False))
         action_queue.put(("j2", "second", False))
 
-        count = _drain_scheduler_queue(
-            action_queue=action_queue,
-            services=mock_services,
-            runner=mock_runner,
-            session_lane=session_lane,
-            global_lane=global_lane,
-            force_isolated=False,
-            main_loop=failing_loop,
+        count = asyncio.run(
+            _drain_scheduler_queue(
+                action_queue=action_queue,
+                services=mock_services,
+                session_lane=session_lane,
+                global_lane=global_lane,
+                force_isolated=False,
+                main_loop=failing_loop,
+            )
         )
 
         assert count == 2


### PR DESCRIPTION
## Summary
- Migration prerequisite for step 4b's bulk delete of the ``# DEPRECATED-ASYNC-PHASE-C:`` anchors.
- ``drain_scheduler_queue`` flips to ``async def``; isolated dispatch uses ``asyncio.create_task`` fire-and-forget on the caller's event loop (tracked in a module-level ``_INFLIGHT_SCHEDULED_TASKS`` set so the GC can't reap mid-flight).
- ``typer_serve`` sync poll loop hoisted into ``async def _serve_loop`` driven by ``asyncio.run(_serve_loop())``; the ``_sched_runner = IsolatedRunner()`` indirection is gone.

## Why
After steps 1-3, the only remaining non-deprecated caller of ``IsolatedRunner.run_async`` was ``scheduler_drain.py:114``. The scheduler used ``run_async`` as a sync thread-spawn façade for fire-and-forget cron dispatch. Bulk-deleting ``run_async`` in step 4b first requires this caller to migrate. Option A (drain itself becomes async + ``asyncio.create_task`` for fire-and-forget) keeps the lane-acquire/release contract intact and survives ``asyncio.run`` cleanup because the active tasks share the long-lived serve loop's event loop.

## Changes
| File | Change |
|------|--------|
| ``core/cli/scheduler_drain.py`` | ``drain_scheduler_queue`` → ``async def``; ``runner`` param removed; isolated dispatch uses ``asyncio.create_task(_arun_isolated(), name=…)`` with ``_INFLIGHT_SCHEDULED_TASKS: set[asyncio.Task]`` strong-ref. ``run_process_coroutine`` import removed. |
| ``core/cli/interactive_loop.py`` | ``_drain_scheduler_queue`` delegator → ``async def`` |
| ``core/cli/typer_serve.py`` | Sync ``while not stop: _drain(...); _time.sleep(1.0)`` poll loop hoisted into ``async def _serve_loop`` driven by ``asyncio.run(_serve_loop())``. ``_sched_runner = IsolatedRunner()`` + ``IsolatedRunner`` import removed. ``asyncio`` import added. |
| ``tests/test_scheduler_serve.py`` | 9 ``_drain_scheduler_queue(...)`` calls wrapped in ``asyncio.run(...)``. ``mock_runner`` fixture + every ``mock_runner.run_async.assert_*`` deleted. Dispatch verification migrated to ``on_dispatch`` callbacks. |
| ``tests/test_cli_extracted.py`` | 1 ``drain_scheduler_queue(...)`` call wrapped in ``asyncio.run(...)`` + ``runner`` arg removed. |
| ``CHANGELOG.md`` | ``[Unreleased] ### Changed`` — step 4a entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| drain becomes async | Implemented | ``async def drain_scheduler_queue`` |
| Fire-and-forget via create_task | Implemented | ``asyncio.create_task(_arun_isolated(), name=…)`` |
| GC-safety for in-flight tasks | Implemented | module-level ``_INFLIGHT_SCHEDULED_TASKS`` set + ``add_done_callback(discard)`` |
| serve loop on asyncio.run | Implemented | ``async def _serve_loop`` + ``asyncio.run(_serve_loop())`` |
| Signal handlers preserved | Implemented | stay sync; flip ``stop`` flag the async loop polls |
| Tests adapted | Implemented | 20/20 ``test_scheduler_serve.py`` + ``test_cli_extracted.py`` pass |
| Sync drain residue removed | Implemented | ``runner`` param + ``run_process_coroutine`` import gone |

## Verification
- [x] ``uv run ruff format --check core/ tests/ plugins/`` — 814 files already formatted
- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run mypy core/ plugins/`` — Success: no issues found in 412 source files
- [x] ``uv run lint-imports`` — Contracts: 4 kept, 0 broken
- [x] ``uv run pytest tests/test_scheduler_serve.py tests/test_cli_extracted.py`` — 20 passed
- [x] ``uv run pytest tests/test_isolated_subprocess.py tests/test_isolated_execution.py tests/test_subagent_announce.py tests/plugins/seed_generation/ tests/test_hitl_level.py tests/test_tool_use.py tests/test_signal_reload.py`` — 494 passed, 3 skipped
- [x] ``uv run pytest tests/test_doctor_bootstrap.py tests/test_serve_e2e.py tests/test_agentic_loop.py`` — 122 passed, 1 skipped

## Reference
- Step 1 PR #1490, step 2 PR #1491, step 3 PR #1494.
- Next: step 4b — bulk-grep ``# DEPRECATED-ASYNC-PHASE-C:`` and delete the deprecated sync APIs (``SubAgentManager.delegate`` + ``_wait_for_result`` / ``IsolatedRunner.run_async`` + ``get_result`` + ``_execute_subprocess`` + ``_dispatch`` / ``ToolExecutor._execute_delegate`` / ``Pipeline.run`` + ``_run_phase`` + ``_acquire_lane`` / ``BaseSeedAgent.execute`` sync shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)