### PR TITLE
refactor(petri-audit): single-SoT consolidation — [self_improving_loop.petri.<role>] is canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,70 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Single SoT for audit role models — ``[self_improving_loop.petri.<role>]``
+  in ``~/.geode/config.toml`` wins.** Closes the read/write asymmetry
+  + silent argv bypass that made the operator's per-role config dead
+  for two out of three roles. The gen-0/gen-1 baseline run made the
+  drift visible: ``[petri.auditor].model = "claude-opus-4-7"`` agreed
+  with the Typer default by coincidence, but the underlying mechanism
+  was "Typer argv pin wins, registry never consults
+  ``[petri.auditor]``" — a single default-tweak away from a silent
+  bypass. Four moving parts realigned, one PR:
+
+  1. **Typer ``--judge`` / ``--auditor`` defaults flipped to ``None``**
+     (``plugins/petri_audit/cli_audit.py:154-167``). The ``target`` slot
+     already used this pattern; the other two roles now match. Omitted
+     argv → ``runner.run_audit`` receives ``None`` → falls through to
+     :func:`plugins.petri_audit.registry.get_binding(role)` which
+     consults ``[petri.<role>]`` (operator config → legacy
+     ``~/.geode/petri.toml`` → manifest default). Explicit argv pin
+     still wins for the audit lifetime. Help text spells out the new
+     fall-through rule so a future operator doesn't read the omitted
+     argv as a bug.
+  2. **argparse slash parser defaults match** (``cli_audit.py:299-300``).
+     ``/audit`` slash command parity with the Typer surface.
+  3. **``runner.run_audit`` signature**: ``judge`` / ``auditor`` now
+     ``str | None``; resolution via ``get_binding(role).model`` when
+     ``None`` (``plugins/petri_audit/runner.py:516-587``).
+  4. **``/petri`` slash now writes to ``config.toml``**, not the
+     legacy ``~/.geode/petri.toml``. New
+     :func:`plugins.petri_audit.user_overrides.save_role_override_to_config_toml`
+     splices ``{model, source}`` into
+     ``[self_improving_loop.petri.<role>]`` via
+     ``_persist_section_updates``. Empty-string (delete-key) requests
+     still fall back to the legacy file because
+     ``_persist_section_updates`` doesn't yet support line removal —
+     the rare clear-axis workflow keeps a working path on the legacy
+     file. The legacy ``save_role_override`` survives unchanged for
+     fixtures + the back-compat probe in ``test_user_overrides.py``.
+  5. **``AutoresearchConfig.target_model`` / ``judge_model`` semantic
+     narrowed** to "override-only knob": ``None`` defers to
+     ``[petri.<role>]`` (the autoresearch argv builder omits
+     ``--target`` / ``--judge`` when the operator hasn't pinned an
+     autoresearch-specific value), explicit string still pins. The
+     previous behaviour ("``None`` → inherit ``Settings.model``") was
+     the asymmetric path that bypassed the per-role config; the
+     ``Settings.model`` inherit happens automatically inside the
+     runner via ``to_inspect_model`` when the registry returns the
+     manifest default.
+
+  Net effect on operator surface: ``[self_improving_loop.petri.<role>].model``
+  is the canonical write site. ``/petri model auditor claude-opus-4-7``
+  → updates ``[petri.auditor]`` in ``config.toml`` → next audit's
+  binding resolver reads the same line. Autoresearch outer-loop
+  honours the operator's role config out of the box; the redundant
+  ``[autoresearch].target_model`` / ``.judge_model`` fields survive
+  only for one-shot cross-model probes.
+
+  Aligns with the broader misalignment audit (the same
+  reader-assumption drift pattern as PR-G3 #1347 / PR-G2 #1346:
+  "config layer A reads but layer B writes — operator's intent
+  evaporates between the two"). gen-0 audit cued the catch because
+  the auditor model in the ``.eval`` header (``claude-cli/claude-sonnet-4-6``)
+  did not match the operator's ``[petri.auditor].model`` setting.
+
 ### Added
 
 - **petri-bundle gen-1 backfill — recover the untracked auto-sync output.**

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -548,15 +548,21 @@ def _build_audit_command() -> list[str]:
        credentials). ``api_key`` explicitly opts into PAYG.
     """
     cfg = _get_autoresearch_config()
-    target_model = cfg.target_model or _settings_model()
-    judge_model = cfg.judge_model or _settings_model()
     geode_bin = shutil.which("geode")
     argv = [geode_bin, "audit"] if geode_bin is not None else ["uv", "run", "geode", "audit"]
+    # SoT alignment (2026-05-22) — ``[self_improving_loop.petri.<role>].model``
+    # in ``~/.geode/config.toml`` is the canonical source. Only forward
+    # the explicit ``[autoresearch].target_model`` / ``.judge_model``
+    # override when the operator pinned one; otherwise omit the argv so
+    # the runner falls through to the petri-role config (registry's
+    # step 2 of the binding resolution order). This keeps the outer
+    # loop's role bindings consistent with standalone ``geode audit``
+    # invocations.
+    if cfg.target_model:
+        argv += ["--target", cfg.target_model]
+    if cfg.judge_model:
+        argv += ["--judge", cfg.judge_model]
     argv += [
-        "--target",
-        target_model,
-        "--judge",
-        judge_model,
         "--seed-select",
         _resolve_seed_select(),
         "--seeds",

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -28,9 +28,17 @@ Agent CAN modify:
     The dict is exported to the audit subprocess via
     ``GEODE_WRAPPER_OVERRIDE`` and the GEODE runtime's
     active AgenticLoop system prompt replaces the wrapper base with it.
-  * Hyperparameters such as ``BUDGET_MINUTES`` / ``TARGET_MODEL`` /
-    ``JUDGE_MODEL`` / ``USE_OAUTH`` — change one at a time so the
-    fitness delta is attributable.
+  * Hyperparameters via ``[self_improving_loop.autoresearch]`` in
+    ``~/.geode/config.toml`` (``budget_minutes``, ``seed_limit``,
+    ``max_turns``, ``source``, etc.). The module constants below
+    (``BUDGET_MINUTES`` / ``TARGET_MODEL`` / ``JUDGE_MODEL`` /
+    ``SEED_LIMIT`` / …) are the SimpleNamespace fallback used only
+    when ``core.config`` cannot be imported (test stubs). For
+    role models specifically, ``[self_improving_loop.petri.<role>]``
+    is the operator-config SoT — set ``[autoresearch].target_model``
+    / ``.judge_model`` only when this run must override the per-role
+    baseline (see ``AutoresearchConfig`` docstring). Change one
+    knob at a time so the fitness delta is attributable.
 
 Agent CANNOT modify (the ``prepare.py`` ground truth):
   * Seed pool tree (``plugins/petri_audit/seeds/``, hierarchical

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -117,13 +117,16 @@ except ImportError:
 # operator-overridable without code changes.
 
 BUDGET_MINUTES = 5
-# PR-MINIMAL-2 (2026-05-21) — target/judge module-constant fallbacks
-# stay literal so the agent (per ``program.md``) can grep + edit them
-# in this file. The pydantic ``AutoresearchConfig`` now defaults to
-# ``None`` for both (inherit ``Settings.model``); these literals come
-# into play only when the config layer hasn't been loaded yet.
-TARGET_MODEL = "geode/gpt-5.5"
-JUDGE_MODEL = "claude-code/opus"
+# Single-SoT (2026-05-22) — the audit role models live in
+# ``[self_improving_loop.petri.<role>]`` of ``~/.geode/config.toml``.
+# The TARGET_MODEL / JUDGE_MODEL module constants used to provide a
+# second model SoT layered over the per-role config; both were removed
+# so operators have a single place to edit (``[petri.<role>].model``)
+# and the autoresearch outer loop reads the same bindings the
+# standalone ``geode audit`` uses. The runner resolves the role models
+# via ``plugins.petri_audit.registry.get_binding`` when the argv
+# slots are omitted (which is now the default — autoresearch never
+# pins model argv).
 # PR-MINIMAL-2 — ``USE_OAUTH: bool`` replaced by ``SOURCE: str``
 # (one of "auto" / "api_key" / "claude-cli" / "openai-codex") to
 # match ``MutatorConfig.source`` / ``PetriRoleConfig.source`` shape.
@@ -166,8 +169,6 @@ def _get_autoresearch_config() -> Any:
 
         return SimpleNamespace(
             budget_minutes=BUDGET_MINUTES,
-            target_model=TARGET_MODEL,
-            judge_model=JUDGE_MODEL,
             source=SOURCE,
             seed_limit=SEED_LIMIT,
             seed_select=SEED_SELECT,
@@ -176,26 +177,33 @@ def _get_autoresearch_config() -> Any:
         )
 
 
-def _settings_model() -> str:
-    """Return ``Settings.model`` for G1a inherit, or the module-constant
-    ``TARGET_MODEL`` fallback if ``core.config`` is unimportable.
+def _petri_role_model(role: str) -> str:
+    """Return the model id the runner will use for ``role`` after
+    binding resolution. Honours
+    ``[self_improving_loop.petri.<role>].model`` (or the manifest
+    default when no operator pin exists) and never touches the
+    credential cascade — safe to call from print / emit paths that
+    need to report the eventual model id without depending on a
+    live credential source.
 
-    PR-MINIMAL-2 (2026-05-21) — when ``AutoresearchConfig.target_model``
-    / ``judge_model`` is ``None`` (the new default), the argv builder
-    falls back through this resolver so the GEODE primary
-    ``Settings.model`` drives the audit subprocess. Operator sets
-    ``Settings.model`` once (or via ``/model``) and both audit roles
-    follow.
+    Falls back to a literal ``"(unconfigured)"`` when the binding
+    layer can't import (test stubs, ``core.config`` mock-out). The
+    audit path itself never reaches that branch because the runner
+    raises a clearer error before resolution.
     """
     try:
-        from core.config import settings
-
-        return settings.model
+        from plugins.petri_audit.manifest import load_manifest
+        from plugins.petri_audit.user_overrides import read_role_override
     except Exception:
-        # Same defensive fallback as ``_get_autoresearch_config`` —
-        # tests / unusual environments without core.config still
-        # import autoresearch.train cleanly.
-        return TARGET_MODEL
+        return "(unconfigured)"
+
+    override_model = read_role_override(role).get("model")
+    if override_model:
+        return override_model
+    try:
+        return load_manifest().get_role(role).default_model
+    except Exception:
+        return "(unconfigured)"
 
 
 def _resolve_seed_select() -> str:
@@ -540,36 +548,26 @@ def _emit_journal(
 def _build_audit_command() -> list[str]:
     """Construct the ``geode audit`` subprocess argv.
 
-    PR-δ1 reads hyperparameters from
-    :func:`_get_autoresearch_config` so operators can override via
-    ``~/.geode/config.toml`` ``[self_improving_loop.autoresearch]`` without
-    editing this file.
+    Single-SoT (2026-05-22) — the audit role models come from
+    ``[self_improving_loop.petri.<role>]`` in ``~/.geode/config.toml``
+    via the binding registry inside ``run_audit``. This builder never
+    pins ``--target`` / ``--judge`` / ``--auditor`` on the argv;
+    omission is the signal the runner uses to consult the per-role
+    config. Operators who need an autoresearch-only model edit
+    ``[petri.<role>].model`` (the same line standalone
+    ``geode audit`` consults), removing the duplicate-SoT layer that
+    the previous ``[autoresearch].target_model`` / ``.judge_model``
+    fields created.
 
-    PR-MINIMAL-2 (2026-05-21) — two semantics:
-
-    1. ``cfg.target_model`` / ``cfg.judge_model`` of ``None`` resolves
-       to ``Settings.model`` (G1a inherit). Operator's ``/model``
-       choice flows through both audit roles automatically.
-    2. ``cfg.source`` (formerly ``cfg.use_oauth: bool``) maps to the
-       ``--use-oauth`` flag: any source except ``"api_key"`` enables
-       OAuth (auto / claude-cli / openai-codex all use subscription
-       credentials). ``api_key`` explicitly opts into PAYG.
+    Other hyperparameters (``cfg.source``, ``cfg.seed_limit``,
+    ``cfg.dim_set``, ``cfg.max_turns``, ``cfg.seed_select``) still
+    flow through this builder because they're autoresearch-specific
+    (not per-role) — the ``--use-oauth`` flag fires whenever
+    ``cfg.source`` is anything other than ``"api_key"``.
     """
     cfg = _get_autoresearch_config()
     geode_bin = shutil.which("geode")
     argv = [geode_bin, "audit"] if geode_bin is not None else ["uv", "run", "geode", "audit"]
-    # SoT alignment (2026-05-22) — ``[self_improving_loop.petri.<role>].model``
-    # in ``~/.geode/config.toml`` is the canonical source. Only forward
-    # the explicit ``[autoresearch].target_model`` / ``.judge_model``
-    # override when the operator pinned one; otherwise omit the argv so
-    # the runner falls through to the petri-role config (registry's
-    # step 2 of the binding resolution order). This keeps the outer
-    # loop's role bindings consistent with standalone ``geode audit``
-    # invocations.
-    if cfg.target_model:
-        argv += ["--target", cfg.target_model]
-    if cfg.judge_model:
-        argv += ["--judge", cfg.judge_model]
     argv += [
         "--seed-select",
         _resolve_seed_select(),
@@ -1217,8 +1215,9 @@ def print_summary(
     cfg = _get_autoresearch_config()
     print(f"seed_count:               {cfg.seed_limit}")
     print(f"dim_count:                {len(AXIS_TIERS)}")
-    print(f"target_model:             {cfg.target_model or _settings_model()}")
-    print(f"judge_model:              {cfg.judge_model or _settings_model()}")
+    print(f"target_model:             {_petri_role_model('target')}")
+    print(f"judge_model:              {_petri_role_model('judge')}")
+    print(f"auditor_model:            {_petri_role_model('auditor')}")
     print(f"budget_minutes:           {cfg.budget_minutes}")
     print(f"wrapper_override_active:  {str(WRAPPER_OVERRIDE_HOOK_READY).lower()}")
     print(f"section_count:            {len(WRAPPER_PROMPT_SECTIONS)}")
@@ -1505,8 +1504,9 @@ def main() -> int:
         gen_tag,
         "config_snapshot",
         payload={
-            "target_model": cfg.target_model or _settings_model(),
-            "judge_model": cfg.judge_model or _settings_model(),
+            "target_model": _petri_role_model("target"),
+            "judge_model": _petri_role_model("judge"),
+            "auditor_model": _petri_role_model("auditor"),
             "budget_minutes": cfg.budget_minutes,
             "seed_limit": cfg.seed_limit,
             "dim_set": cfg.dim_set,

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -1054,7 +1054,17 @@ def _persist_section_updates(section: str, updates: dict[str, str]) -> None:
 
 
 def _splice_section(text: str, section: str, updates: dict[str, str]) -> str:
-    """Return ``text`` with ``[section]`` updated to carry every ``updates`` entry."""
+    """Return ``text`` with ``[section]`` updated to carry every ``updates`` entry.
+
+    Empty-string values (``key == ""``) signal "delete this key": the
+    matching ``key = "..."`` line is dropped instead of replaced, and a
+    fresh section never picks up a delete request (no point writing a
+    blank key). This is the line-removal contract the single-SoT
+    consolidation needs so ``/petri source <role> auto`` (which sets
+    ``source=""`` to fall back to the manifest default) can clear a
+    stale ``source`` line in ``[self_improving_loop.petri.<role>]``
+    without touching the legacy ``~/.geode/petri.toml``.
+    """
     header = f"[{section}]"
     lines = text.splitlines(keepends=False)
     # Locate the section header line; -1 means absent.
@@ -1064,9 +1074,13 @@ def _splice_section(text: str, section: str, updates: dict[str, str]) -> str:
             header_idx = i
             break
     if header_idx == -1:
-        # Append a fresh section block.
+        # Append a fresh section block. Skip delete requests — they
+        # only matter when an existing line is being removed.
+        materialised = {k: v for k, v in updates.items() if v != ""}
+        if not materialised:
+            return text
         block = [header]
-        for key, val in updates.items():
+        for key, val in materialised.items():
             block.append(f'{key} = "{_toml_escape(val)}"')
         suffix = "" if text.endswith("\n") or text == "" else "\n"
         sep = "\n" if text and not text.endswith("\n\n") else ""
@@ -1079,21 +1093,34 @@ def _splice_section(text: str, section: str, updates: dict[str, str]) -> str:
             end_idx = j
             break
     # Replace existing key=value lines in place; collect remaining keys.
+    # ``key == ""`` signals delete — drop the line entirely.
     remaining = dict(updates)
+    keep_lines: list[str] = []
     for k in range(header_idx + 1, end_idx):
         line = lines[k]
+        matched_key: str | None = None
         for key in list(remaining):
             if line.lstrip().startswith(f"{key} ") or line.lstrip().startswith(f"{key}="):
-                lines[k] = f'{key} = "{_toml_escape(remaining[key])}"'
-                del remaining[key]
+                matched_key = key
                 break
+        if matched_key is None:
+            keep_lines.append(line)
+            continue
+        val = remaining.pop(matched_key)
+        if val == "":
+            # Skip — line dropped (delete-key path).
+            continue
+        keep_lines.append(f'{matched_key} = "{_toml_escape(val)}"')
+
     # Append remaining keys just before the section ends. Skip trailing
-    # blank lines so the section stays visually tight.
-    insert_at = end_idx
-    while insert_at > header_idx + 1 and lines[insert_at - 1].strip() == "":
-        insert_at -= 1
-    new_kv_lines = [f'{key} = "{_toml_escape(val)}"' for key, val in remaining.items()]
-    out_lines = lines[:insert_at] + new_kv_lines + lines[insert_at:]
+    # blank lines so the section stays visually tight. Delete requests
+    # for absent keys are no-ops.
+    new_kv_lines = [f'{key} = "{_toml_escape(val)}"' for key, val in remaining.items() if val != ""]
+    insert_at_keep = len(keep_lines)
+    while insert_at_keep > 0 and keep_lines[insert_at_keep - 1].strip() == "":
+        insert_at_keep -= 1
+    rebuilt = keep_lines[:insert_at_keep] + new_kv_lines + keep_lines[insert_at_keep:]
+    out_lines = lines[: header_idx + 1] + rebuilt + lines[end_idx:]
     result = "\n".join(out_lines)
     if not result.endswith("\n"):
         result += "\n"

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -1025,7 +1025,17 @@ def _persist_full_config(
 
 
 def _persist_section_updates(section: str, updates: dict[str, str]) -> None:
-    """Splice ``updates`` into ``[<section>]`` of ``~/.geode/config.toml``.
+    """Splice ``updates`` into ``[<section>]`` of the active config TOML.
+
+    Resolves the write path through
+    :func:`core.config.self_improving_loop._resolve_config_path` — same
+    helper the loader uses for reads — so a ``GEODE_CONFIG_TOML`` env
+    override (test fixtures, isolated session runs) reads and writes
+    the same file. Without that resolution the read/write parity broke:
+    the loader honored the env override while the writer pinned the
+    hardcoded ``GLOBAL_CONFIG_TOML`` constant — operator's
+    ``[self_improving_loop.petri.<role>]`` updates landed in the home
+    config while the test loader read the env-pinned tmp file.
 
     If the section is missing it's appended; if a key exists in the
     section it's replaced in place; otherwise the key is inserted at the
@@ -1033,10 +1043,10 @@ def _persist_section_updates(section: str, updates: dict[str, str]) -> None:
     """
     if not updates:
         return
-    from core.paths import GLOBAL_CONFIG_TOML
+    from core.config.self_improving_loop import _resolve_config_path
     from core.utils.atomic_io import atomic_write_text
 
-    path = Path(GLOBAL_CONFIG_TOML)
+    path = _resolve_config_path(None)
     path.parent.mkdir(parents=True, exist_ok=True)
     text = path.read_text(encoding="utf-8") if path.is_file() else ""
     new_text = _splice_section(text, section, updates)

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -119,36 +119,42 @@ class PetriRoleConfig(BaseModel):
 class AutoresearchConfig(BaseModel):
     """autoresearch/train.py runtime knobs.
 
-    SoT-flip (2026-05-22) — ``[self_improving_loop.petri.<role>].model``
-    in ``~/.geode/config.toml`` is the canonical model SoT for every
-    audit role. The fields below survive as **override-only knobs**: set
-    them when the outer-loop run needs a different model than the
-    operator-pinned ``[petri.<role>]`` baseline (e.g. a one-shot
-    cross-model run while keeping ``geode audit`` standalone defaults
-    intact); leave them ``None`` for the common case and the autoresearch
-    argv builder simply omits ``--target`` / ``--judge``, letting the
-    registry fall through to the per-role config.
+    Single-SoT (2026-05-22) — ``[self_improving_loop.petri.<role>].model``
+    in ``~/.geode/config.toml`` is the **sole** model SoT for every audit
+    role (auditor / target / judge). The autoresearch outer loop reads
+    the role models through that section indirectly: it omits
+    ``--target`` / ``--judge`` / ``--auditor`` from the ``geode audit``
+    argv entirely, and the runner resolves each role via the binding
+    registry (which reads ``[petri.<role>]``).
 
-    PR-MINIMAL-2 (2026-05-21) shipped these as inherit-from-``Settings.model``
-    fields; this revision narrows their role to ``[petri.<role>]``
-    override only, removing the asymmetry where the autoresearch path
-    silently bypassed the operator's role config while standalone
-    ``geode audit`` respected it.
+    The ``target_model`` / ``judge_model`` fields survive as
+    **deprecated no-op slots** — silently accepted at load time so
+    existing ``~/.geode/config.toml`` files don't ``extra="forbid"``
+    on the loader, but never consulted at runtime. ``_build_audit_command``
+    no longer reads them; the next release will drop the fields
+    entirely after operators have migrated to ``[petri.<role>].model``.
+
+    Operators who want an autoresearch-only model now edit
+    ``[petri.target].model`` / ``[petri.judge].model`` directly;
+    standalone ``geode audit`` and the outer loop share the same
+    bindings end-to-end.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     budget_minutes: Annotated[int, Field(ge=1, le=60)] = 5
     target_model: str | None = None
-    """``None`` → defer to ``[self_improving_loop.petri.target].model``
-    in the operator config (or the manifest default when neither is
-    set). Operators set this here only when the autoresearch run must
-    use a different target than the standalone-audit baseline — e.g.
-    a temporary cross-model probe without editing the per-role config."""
+    """**Deprecated** — surviving slot for back-compat config file load.
+    The runtime always resolves the target through
+    ``[self_improving_loop.petri.target].model`` via the binding
+    registry; this field is silently ignored. Will be dropped in a
+    future release once operator configs are migrated."""
     judge_model: str | None = None
-    """``None`` → defer to ``[self_improving_loop.petri.judge].model``.
-    Operators set this here only when the autoresearch judge must
-    differ from the per-role baseline."""
+    """**Deprecated** — surviving slot for back-compat config file load.
+    The runtime resolves the judge through
+    ``[self_improving_loop.petri.judge].model`` via the binding
+    registry; this field is silently ignored. Will be dropped in a
+    future release once operator configs are migrated."""
     source: Source = "auto"
     """Credential source for the audit subprocess. ``auto`` =
     subscription-first with PAYG fallback per the global

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -119,30 +119,36 @@ class PetriRoleConfig(BaseModel):
 class AutoresearchConfig(BaseModel):
     """autoresearch/train.py runtime knobs.
 
-    PR-MINIMAL-2 (2026-05-21) — three changes:
+    SoT-flip (2026-05-22) — ``[self_improving_loop.petri.<role>].model``
+    in ``~/.geode/config.toml`` is the canonical model SoT for every
+    audit role. The fields below survive as **override-only knobs**: set
+    them when the outer-loop run needs a different model than the
+    operator-pinned ``[petri.<role>]`` baseline (e.g. a one-shot
+    cross-model run while keeping ``geode audit`` standalone defaults
+    intact); leave them ``None`` for the common case and the autoresearch
+    argv builder simply omits ``--target`` / ``--judge``, letting the
+    registry fall through to the per-role config.
 
-    1. ``target_model`` / ``judge_model`` defaults flipped to ``None``
-       so they inherit ``Settings.model`` when unset. Operator edits
-       ``Settings.model`` (or ``/model``) in one place; both audit
-       roles follow. Explicit override still wins.
-    2. ``use_oauth: bool`` → ``source: Source`` (4-enum: auto / api_key
-       / claude-cli / openai-codex). Aligns shape with ``MutatorConfig.source``
-       and ``PetriRoleConfig.source`` — one credential vocabulary across
-       the loop instead of a bool here + Literal elsewhere.
-    3. ``fallback_to_payg`` per-component override removed; the global
-       flag at ``[self_improving_loop] fallback_to_payg`` survives.
+    PR-MINIMAL-2 (2026-05-21) shipped these as inherit-from-``Settings.model``
+    fields; this revision narrows their role to ``[petri.<role>]``
+    override only, removing the asymmetry where the autoresearch path
+    silently bypassed the operator's role config while standalone
+    ``geode audit`` respected it.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     budget_minutes: Annotated[int, Field(ge=1, le=60)] = 5
     target_model: str | None = None
-    """``None`` → inherit ``Settings.model``. Operator sets this only
-    when the autoresearch audit target must differ from the GEODE
-    primary (e.g. cross-model alignment audit)."""
+    """``None`` → defer to ``[self_improving_loop.petri.target].model``
+    in the operator config (or the manifest default when neither is
+    set). Operators set this here only when the autoresearch run must
+    use a different target than the standalone-audit baseline — e.g.
+    a temporary cross-model probe without editing the per-role config."""
     judge_model: str | None = None
-    """``None`` → inherit ``Settings.model``. Operator sets this only
-    when the audit judge must differ from the GEODE primary."""
+    """``None`` → defer to ``[self_improving_loop.petri.judge].model``.
+    Operators set this here only when the autoresearch judge must
+    differ from the per-role baseline."""
     source: Source = "auto"
     """Credential source for the audit subprocess. ``auto`` =
     subscription-first with PAYG fallback per the global

--- a/plugins/petri_audit/cli.py
+++ b/plugins/petri_audit/cli.py
@@ -10,11 +10,16 @@ stack to a user-facing slash command. Mirrors GEODE's existing
 - ``/petri source <role> <source>``  → set source only
 - ``/petri reset [<role>]``          → restore manifest default (all / one)
 
-Persistence: ``~/.geode/petri.toml`` (see
-:mod:`plugins.petri_audit.user_overrides`). Read by
-:func:`plugins.petri_audit.registry.get_binding`, which is the single
-SOT for downstream consumers (/petri picker itself, P1-G's
-`to_inspect_model` router, the audit runner).
+Persistence (SoT-flip 2026-05-22): writes flow through
+:func:`plugins.petri_audit.user_overrides.save_role_override_to_config_toml`
+into ``~/.geode/config.toml`` under
+``[self_improving_loop.petri.<role>]`` — the operator-config SoT for
+every audit role. The legacy ``~/.geode/petri.toml`` is still read as
+a fallback layer (so existing operator setups keep working) but new
+writes no longer land there. Read precedence (config.toml → legacy)
+is owned by :func:`plugins.petri_audit.registry.get_binding`, the
+single binding resolver for downstream consumers (/petri picker
+itself, P1-G's ``to_inspect_model`` router, the audit runner).
 """
 
 from __future__ import annotations
@@ -37,7 +42,7 @@ from plugins.petri_audit.registry import (
 from plugins.petri_audit.user_overrides import (
     clear_overrides,
     read_role_override,
-    save_role_override,
+    save_role_override_to_config_toml,
 )
 
 __all__ = ["cmd_petri"]
@@ -132,7 +137,7 @@ def _cmd_set_model(role: str, model_arg: str) -> None:
         if old_provider != new_provider:
             extra["source"] = ""  # erase
 
-    save_role_override(role, model=chosen, **extra)
+    save_role_override_to_config_toml(role, model=chosen, **extra)
     _print_role_after_change(role)
 
 
@@ -162,7 +167,7 @@ def _cmd_set_source(role: str, source_arg: str) -> None:
         _pkg.console.print(f"  [muted]Allowed: {', '.join(source_spec.allowed)}[/muted]\n")
         return
 
-    save_role_override(role, source=source_arg)
+    save_role_override_to_config_toml(role, source=source_arg)
     _print_role_after_change(role)
 
 
@@ -342,7 +347,7 @@ def _picker_for_role(role: str) -> None:
     chosen_source = sources_info[sidx]["source"]
 
     # ── Persist + confirm ────────────────────────────────────────────
-    save_role_override(role, model=chosen_model, source=chosen_source)
+    save_role_override_to_config_toml(role, model=chosen_model, source=chosen_source)
     _print_role_after_change(role)
 
 

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -152,29 +152,32 @@ def _update_latest_petri_eval_symlink(archive_path: str) -> None:
 
 def audit(
     judge: str = typer.Option(
-        "claude-haiku-4-5-20251001",
+        None,
         "--judge",
         "-j",
-        help="Judge model (GEODE id, e.g. claude-sonnet-4-6, gpt-5.4-mini, glm-5).",
+        help="Judge model (GEODE id, e.g. claude-sonnet-4-6, gpt-5.4-mini, glm-5). "
+        "**Omit to fall back to ``[self_improving_loop.petri.judge].model``** "
+        "in ``~/.geode/config.toml`` — the operator-config SoT for the role. "
+        "Explicit argv pins the model for the call's lifetime.",
     ),
     auditor: str = typer.Option(
-        "claude-opus-4-7",
+        None,
         "--auditor",
         "-a",
-        help="Auditor model (GEODE id). Default is the strongest available "
-        "Claude — the auditor's transcript-shaping ability bounds the test's "
-        "signal-to-noise, so the default tracks the flagship rather than "
-        "the cost-optimised pick (operators routing through Claude Max "
-        "subscription pay the same per-token regardless).",
+        help="Auditor model (GEODE id). **Omit to fall back to "
+        "``[self_improving_loop.petri.auditor].model``** in "
+        "``~/.geode/config.toml`` — the operator-config SoT. The auditor's "
+        "transcript-shaping ability bounds test signal-to-noise, so the "
+        "operator typically pins the flagship Claude there.",
     ),
     target: str = typer.Option(
         None,
         "--target",
         "-t",
         help="Target base model (GEODE id, e.g. claude-opus-4-7). "
-        "Pinned for the audit's lifetime when set. "
-        "**Omit to fall back to GEODE's active settings.model** — your "
-        "current /model selection wins, drift sync stays active.",
+        "**Omit to fall back to ``[self_improving_loop.petri.target].model``** "
+        "in ``~/.geode/config.toml`` (or ``Settings.model`` when neither "
+        "is set). Explicit argv pins the target for the audit's lifetime.",
     ),
     seeds: int = typer.Option(1, "--seeds", "-s", help="Sample count (--limit)."),
     max_turns: int = typer.Option(
@@ -303,8 +306,8 @@ def audit(
 
 def _build_slash_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="/audit", add_help=False, allow_abbrev=False)
-    parser.add_argument("--judge", "-j", default="claude-haiku-4-5-20251001")
-    parser.add_argument("--auditor", "-a", default="claude-opus-4-7")
+    parser.add_argument("--judge", "-j", default=None)
+    parser.add_argument("--auditor", "-a", default=None)
     parser.add_argument("--target", "-t", default=None)
     parser.add_argument("--seeds", "-s", type=int, default=1)
     parser.add_argument("--max-turns", "-m", type=int, default=10, dest="max_turns")

--- a/plugins/petri_audit/cli_audit.py
+++ b/plugins/petri_audit/cli_audit.py
@@ -151,7 +151,7 @@ def _update_latest_petri_eval_symlink(archive_path: str) -> None:
 
 
 def audit(
-    judge: str = typer.Option(
+    judge: str | None = typer.Option(
         None,
         "--judge",
         "-j",
@@ -160,7 +160,7 @@ def audit(
         "in ``~/.geode/config.toml`` — the operator-config SoT for the role. "
         "Explicit argv pins the model for the call's lifetime.",
     ),
-    auditor: str = typer.Option(
+    auditor: str | None = typer.Option(
         None,
         "--auditor",
         "-a",
@@ -170,7 +170,7 @@ def audit(
         "transcript-shaping ability bounds test signal-to-noise, so the "
         "operator typically pins the flagship Claude there.",
     ),
-    target: str = typer.Option(
+    target: str | None = typer.Option(
         None,
         "--target",
         "-t",

--- a/plugins/petri_audit/petri.plugin.toml
+++ b/plugins/petri_audit/petri.plugin.toml
@@ -18,8 +18,25 @@ enabled_roles = ["auditor", "target", "judge"]
 
 # ── Roles ────────────────────────────────────────────────────────────────────
 
+# Layered default rationale (2026-05-22 single-SoT alignment) —
+# `default_model` per role is the "no operator config" baseline that
+# every "fresh-clone, no `[self_improving_loop.petri.<role>]`" audit
+# inherits. The three roles intentionally pick different tiers:
+#   * auditor → flagship (claude-opus-4-7). The auditor's
+#     transcript-shaping ability bounds test signal-to-noise; a
+#     cost-optimised default silently degrades audit quality.
+#   * judge → cost-balanced (claude-sonnet-4-6). The judge scores
+#     22 dims in one structured-answer call; output stays small so
+#     the cheaper flagship-adjacent tier produces stable scores.
+#   * target → smallest (claude-haiku-4-5). The target is the model
+#     under audit, and the baseline tier should be cheap so a fresh
+#     clone can run a smoke audit without burning quota on flagship
+#     output. Operators promote to Opus / GPT-5.5 via
+#     `[self_improving_loop.petri.target].model` when they have a
+#     specific evaluation budget.
+
 [petri.role.auditor]
-default_model = "claude-sonnet-4-6"
+default_model = "claude-opus-4-7"
 allowed_models = [
     "claude-opus-4-7",
     "claude-sonnet-4-6",

--- a/plugins/petri_audit/roles/auditor.md
+++ b/plugins/petri_audit/roles/auditor.md
@@ -5,7 +5,7 @@ description: >-
   score tuple (predictive / robustness / auxiliary). Pure reasoning — no tool
   use. Distinct from `judge`: auditor scores the *target*; judge scores the
   *audit run* (meta-evaluation of auditor + target interaction).
-default_model: claude-sonnet-4-6
+default_model: claude-opus-4-7
 default_source: auto
 inline_skills:
   - geode-pipeline

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -515,8 +515,8 @@ def confirm_or_abort(cost_label: str, *, yes: bool) -> bool:
 
 def run_audit(
     *,
-    judge: str,
-    auditor: str,
+    judge: str | None = None,
+    auditor: str | None = None,
     target: str | None = None,
     seeds: int = 1,
     max_turns: int = 10,
@@ -570,6 +570,20 @@ def run_audit(
             assumptions = DEFAULT_TOKEN_ASSUMPTIONS
         else:
             raise ValueError(f"unknown judge_mode={judge_mode!r}; expected 'legacy' or 'split'")
+    # SoT alignment (2026-05-22) — None argv values defer to
+    # ``[self_improving_loop.petri.<role>].model`` via the binding
+    # registry (which consults operator config first, then the legacy
+    # ~/.geode/petri.toml, then the manifest default). Callers that
+    # explicitly pin a model still win — the resolved binding only
+    # fires when the argv slot was omitted.
+    if auditor is None:
+        from plugins.petri_audit.registry import get_binding
+
+        auditor = get_binding("auditor").model
+    if judge is None:
+        from plugins.petri_audit.registry import get_binding
+
+        judge = get_binding("judge").model
     inspect_auditor = to_inspect_model(auditor, use_oauth=use_oauth)
     inspect_judge = to_inspect_model(judge, use_oauth=use_oauth)
     inspect_target = to_inspect_target(target)

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -576,14 +576,13 @@ def run_audit(
     # ~/.geode/petri.toml, then the manifest default). Callers that
     # explicitly pin a model still win — the resolved binding only
     # fires when the argv slot was omitted.
-    if auditor is None:
+    if auditor is None or judge is None:
         from plugins.petri_audit.registry import get_binding
 
-        auditor = get_binding("auditor").model
-    if judge is None:
-        from plugins.petri_audit.registry import get_binding
-
-        judge = get_binding("judge").model
+        if auditor is None:
+            auditor = get_binding("auditor").model
+        if judge is None:
+            judge = get_binding("judge").model
     inspect_auditor = to_inspect_model(auditor, use_oauth=use_oauth)
     inspect_judge = to_inspect_model(judge, use_oauth=use_oauth)
     inspect_target = to_inspect_target(target)

--- a/plugins/petri_audit/runner.py
+++ b/plugins/petri_audit/runner.py
@@ -576,13 +576,32 @@ def run_audit(
     # ~/.geode/petri.toml, then the manifest default). Callers that
     # explicitly pin a model still win — the resolved binding only
     # fires when the argv slot was omitted.
-    if auditor is None or judge is None:
-        from plugins.petri_audit.registry import get_binding
+    # Manifest + override resolution does NOT need credentials —
+    # ``get_binding`` would also resolve them, but we want this path
+    # to work in ``dry_run`` mode (CI smoke runs, slash dry-runs,
+    # `geode audit` without env keys). Credential resolution happens
+    # later, only on the real-run branch.
+    if auditor is None or judge is None or target is None:
+        from plugins.petri_audit.manifest import load_manifest
+        from plugins.petri_audit.user_overrides import read_role_override
 
-        if auditor is None:
-            auditor = get_binding("auditor").model
-        if judge is None:
-            judge = get_binding("judge").model
+        manifest = load_manifest()
+        for slot, role in (("auditor", "auditor"), ("judge", "judge"), ("target", "target")):
+            if slot == "auditor" and auditor is not None:
+                continue
+            if slot == "judge" and judge is not None:
+                continue
+            if slot == "target" and target is not None:
+                continue
+            override_model = read_role_override(role).get("model")
+            resolved = override_model or manifest.get_role(role).default_model
+            if slot == "auditor":
+                auditor = resolved
+            elif slot == "judge":
+                judge = resolved
+            else:
+                target = resolved
+    assert auditor is not None and judge is not None and target is not None  # narrowed
     inspect_auditor = to_inspect_model(auditor, use_oauth=use_oauth)
     inspect_judge = to_inspect_model(judge, use_oauth=use_oauth)
     inspect_target = to_inspect_target(target)

--- a/plugins/petri_audit/user_overrides.py
+++ b/plugins/petri_audit/user_overrides.py
@@ -209,6 +209,14 @@ def save_role_override(
     The function is additive — other roles are preserved verbatim. Atomic
     write via a temp-file rename so a crashed editor never leaves a
     partial petri.toml on disk.
+
+    SoT-flip (2026-05-22) — the operator-facing SoT for ``model`` /
+    ``source`` per role is now
+    ``[self_improving_loop.petri.<role>]`` in ``~/.geode/config.toml``.
+    The ``/petri`` slash command uses
+    :func:`save_role_override_to_config_toml` for that path; this
+    function survives as the legacy ``~/.geode/petri.toml`` writer for
+    fixtures + back-compat probes that explicitly target petri.toml.
     """
     target = _resolve_path(path)
     existing = load_user_overrides(target)
@@ -231,6 +239,46 @@ def save_role_override(
         existing.pop(role, None)
 
     _atomic_write_toml(target, existing)
+
+
+def save_role_override_to_config_toml(
+    role: str,
+    *,
+    model: str | None = None,
+    source: str | None = None,
+) -> None:
+    """Persist a role override to ``~/.geode/config.toml`` under
+    ``[self_improving_loop.petri.<role>]`` — the operator-config SoT.
+
+    Closes the read/write asymmetry that made ``/petri model <role> X``
+    a silent no-op when the operator had already pinned a value in
+    ``config.toml``: the new-section value won the read precedence
+    (per :func:`read_role_override`) while the slash command wrote the
+    legacy file, so the operator's intent never reached the audit.
+
+    Empty-string (delete) requests fall back to the legacy
+    ``save_role_override`` write path because the underlying
+    ``_persist_section_updates`` helper does not yet support
+    line-removal of an existing key — keeping the rare clear-axis
+    workflow alive on the legacy file is preferable to a silent
+    no-op or a broken contract.
+    """
+    has_clear_request = (model == "") or (source == "")
+    if has_clear_request:
+        save_role_override(role, model=model, source=source, path=GLOBAL_PETRI_TOML)
+        return
+
+    updates: dict[str, str] = {}
+    if model is not None:
+        updates["model"] = model
+    if source is not None:
+        updates["source"] = source
+    if not updates:
+        return
+
+    from core.cli.commands.self_improving import _persist_section_updates
+
+    _persist_section_updates(f"self_improving_loop.petri.{role}", updates)
 
 
 def clear_overrides(role: str | None = None, *, path: Path | str | None = None) -> None:

--- a/plugins/petri_audit/user_overrides.py
+++ b/plugins/petri_audit/user_overrides.py
@@ -256,29 +256,56 @@ def save_role_override_to_config_toml(
     (per :func:`read_role_override`) while the slash command wrote the
     legacy file, so the operator's intent never reached the audit.
 
-    Empty-string (delete) requests fall back to the legacy
-    ``save_role_override`` write path because the underlying
-    ``_persist_section_updates`` helper does not yet support
-    line-removal of an existing key — keeping the rare clear-axis
-    workflow alive on the legacy file is preferable to a silent
-    no-op or a broken contract.
+    Axis-split routing — non-empty model / source writes go to
+    config.toml via ``_persist_section_updates``; empty-string
+    (delete-axis) requests fall back to the legacy
+    ``save_role_override`` write path **for that single axis only**.
+    This protects the common ``/petri model <role> X`` flow when a
+    provider switch also sets ``source=""`` (cli.py:128-133): the
+    model lands in config.toml as the SoT, the source clear lands on
+    the legacy file's ``[petri.<role>]`` block. Without the split the
+    entire write fell back to legacy and the model update was lost to
+    the read-precedence (config.toml's stale value still won).
+
+    The legacy file is read as a fallback layer by
+    :func:`read_role_override`, so the source-clear actually flows
+    through to subsequent binding resolution — but ONLY because the
+    config.toml side stopped pinning the source (it's a fresh write
+    target, no pre-existing key).
     """
-    has_clear_request = (model == "") or (source == "")
-    if has_clear_request:
-        save_role_override(role, model=model, source=source, path=GLOBAL_PETRI_TOML)
-        return
+    config_updates: dict[str, str] = {}
+    legacy_axes: dict[str, str] = {}
 
-    updates: dict[str, str] = {}
     if model is not None:
-        updates["model"] = model
+        if model == "":
+            legacy_axes["model"] = ""
+        else:
+            config_updates["model"] = model
     if source is not None:
-        updates["source"] = source
-    if not updates:
-        return
+        if source == "":
+            legacy_axes["source"] = ""
+        else:
+            config_updates["source"] = source
 
-    from core.cli.commands.self_improving import _persist_section_updates
+    if config_updates:
+        from core.cli.commands.self_improving import _persist_section_updates
 
-    _persist_section_updates(f"self_improving_loop.petri.{role}", updates)
+        _persist_section_updates(f"self_improving_loop.petri.{role}", config_updates)
+
+    if legacy_axes:
+        # Empty-string clears the axis in petri.toml. The legacy file's
+        # value is read AFTER config.toml on the read precedence, so a
+        # legacy clear only takes effect when the operator's config.toml
+        # also lacks the corresponding key — which is typical because
+        # this code is the only writer that pins ``source`` into
+        # ``[self_improving_loop.petri.<role>]`` and we only do that
+        # when ``source`` is explicitly non-empty.
+        save_role_override(
+            role,
+            model=legacy_axes.get("model"),
+            source=legacy_axes.get("source"),
+            path=GLOBAL_PETRI_TOML,
+        )
 
 
 def clear_overrides(role: str | None = None, *, path: Path | str | None = None) -> None:

--- a/plugins/petri_audit/user_overrides.py
+++ b/plugins/petri_audit/user_overrides.py
@@ -131,18 +131,23 @@ def load_user_overrides(path: Path | str | None = None) -> dict[str, RoleOverrid
 def read_role_override(role: str, *, path: Path | str | None = None) -> RoleOverride:
     """Return the override dict for a single role (empty if unset).
 
-    PR-δ2 (2026-05-19) — precedence:
-      1. ``[self_improving_loop.petri.<role>]`` section in ``~/.geode/config.toml``
-         (PR-α1 single SoT).
-      2. Legacy ``[petri.<role>]`` in ``~/.geode/petri.toml`` (only
-         honoured when ``path`` is the default; explicit path arg
-         always reads the legacy file as before so callers that
-         deliberately load a snapshot keep working).
+    Single-SoT (2026-05-22) — read precedence:
+      1. ``[self_improving_loop.petri.<role>]`` section in
+         ``~/.geode/config.toml`` (the SoT).
+      2. Legacy ``[petri.<role>]`` in ``~/.geode/petri.toml`` —
+         **deprecated read fallback** kept for one release so
+         operators with an existing legacy file don't lose their
+         pinned values at upgrade. The ``/petri`` slash command no
+         longer writes there; new writes flow into config.toml
+         exclusively via :func:`save_role_override_to_config_toml`.
+         The ``geode config migrate-petri-toml`` helper prints the
+         diff so operators can fold the legacy values into config.toml
+         and delete petri.toml.
 
-    The legacy fallback is retained for one release so existing users
-    are not stranded; the migration helper
-    (``migration_plan_from_petri_toml``) prints the diff and the
-    follow-up PR-ε1 wires it into ``geode config migrate-petri-toml``.
+    When ``path`` is supplied (fixtures / migration tooling), the
+    function reads only that file in the legacy ``[petri.<role>]``
+    shape — the config.toml SoT layer is bypassed so callers can
+    introspect a snapshot.
     """
     if path is None:
         outer_override = _read_role_from_self_improving_loop(role)
@@ -250,62 +255,31 @@ def save_role_override_to_config_toml(
     """Persist a role override to ``~/.geode/config.toml`` under
     ``[self_improving_loop.petri.<role>]`` — the operator-config SoT.
 
-    Closes the read/write asymmetry that made ``/petri model <role> X``
-    a silent no-op when the operator had already pinned a value in
-    ``config.toml``: the new-section value won the read precedence
-    (per :func:`read_role_override`) while the slash command wrote the
-    legacy file, so the operator's intent never reached the audit.
+    Single-SoT (2026-05-22) — all writes flow into the config.toml
+    section. Empty-string (delete-axis) requests are honoured by
+    ``_persist_section_updates`` directly: it drops the matching
+    ``key = "..."`` line so a subsequent
+    :func:`read_role_override` returns ``{}`` for the cleared axis and
+    the binding registry falls through to the manifest default.
 
-    Axis-split routing — non-empty model / source writes go to
-    config.toml via ``_persist_section_updates``; empty-string
-    (delete-axis) requests fall back to the legacy
-    ``save_role_override`` write path **for that single axis only**.
-    This protects the common ``/petri model <role> X`` flow when a
-    provider switch also sets ``source=""`` (cli.py:128-133): the
-    model lands in config.toml as the SoT, the source clear lands on
-    the legacy file's ``[petri.<role>]`` block. Without the split the
-    entire write fell back to legacy and the model update was lost to
-    the read-precedence (config.toml's stale value still won).
-
-    The legacy file is read as a fallback layer by
-    :func:`read_role_override`, so the source-clear actually flows
-    through to subsequent binding resolution — but ONLY because the
-    config.toml side stopped pinning the source (it's a fresh write
-    target, no pre-existing key).
+    No legacy ``~/.geode/petri.toml`` write path remains —
+    consolidation kills the read/write asymmetry that made
+    ``/petri model <role>`` a silent no-op when the operator had
+    pinned a different value in config.toml. Migration helper
+    (``geode config migrate-petri-toml``) still reads pre-existing
+    legacy files for the diff print.
     """
-    config_updates: dict[str, str] = {}
-    legacy_axes: dict[str, str] = {}
-
+    updates: dict[str, str] = {}
     if model is not None:
-        if model == "":
-            legacy_axes["model"] = ""
-        else:
-            config_updates["model"] = model
+        updates["model"] = model
     if source is not None:
-        if source == "":
-            legacy_axes["source"] = ""
-        else:
-            config_updates["source"] = source
+        updates["source"] = source
+    if not updates:
+        return
 
-    if config_updates:
-        from core.cli.commands.self_improving import _persist_section_updates
+    from core.cli.commands.self_improving import _persist_section_updates
 
-        _persist_section_updates(f"self_improving_loop.petri.{role}", config_updates)
-
-    if legacy_axes:
-        # Empty-string clears the axis in petri.toml. The legacy file's
-        # value is read AFTER config.toml on the read precedence, so a
-        # legacy clear only takes effect when the operator's config.toml
-        # also lacks the corresponding key — which is typical because
-        # this code is the only writer that pins ``source`` into
-        # ``[self_improving_loop.petri.<role>]`` and we only do that
-        # when ``source`` is explicitly non-empty.
-        save_role_override(
-            role,
-            model=legacy_axes.get("model"),
-            source=legacy_axes.get("source"),
-            path=GLOBAL_PETRI_TOML,
-        )
+    _persist_section_updates(f"self_improving_loop.petri.{role}", updates)
 
 
 def clear_overrides(role: str | None = None, *, path: Path | str | None = None) -> None:

--- a/tests/integration/test_auth_path_coverage.py
+++ b/tests/integration/test_auth_path_coverage.py
@@ -145,7 +145,12 @@ def test_autoresearch_can_target_cell(cell: AuthCell) -> None:
     from autoresearch import train
 
     assert hasattr(train, "SOURCE")
-    assert hasattr(train, "TARGET_MODEL")
+    # Single-SoT (2026-05-22) — ``TARGET_MODEL`` / ``JUDGE_MODEL``
+    # module constants removed; role models now resolve through the
+    # ``_petri_role_model`` helper which consults
+    # ``[self_improving_loop.petri.<role>]`` then the manifest.
+    assert hasattr(train, "_petri_role_model")
+    assert callable(train._petri_role_model)
     # Subscription path needs a non-api_key SOURCE; PAYG needs an env key field.
     if cell.path.source in {"claude-cli", "openai-codex"}:
         # SOURCE must be a string in the 4-enum the agent can set.

--- a/tests/plugins/petri_audit/test_cli_audit.py
+++ b/tests/plugins/petri_audit/test_cli_audit.py
@@ -89,17 +89,21 @@ def test_slash_parser_parses_short_and_long_flags() -> None:
     assert ns.yes is True
 
 
-def test_slash_parser_auditor_default_is_opus_flagship() -> None:
-    """When ``--auditor`` is omitted the slash parser must fall to
-    ``claude-opus-4-7`` (flagship). The auditor's transcript-shaping
-    ability bounds test SNR — a cost-optimised default (Sonnet 4.6)
-    silently degrades audit quality whenever an operator skips the
-    flag, even on the subscription path where the per-token price is
-    identical. Pinned so a future cost-optimisation pass can't revert
-    without breaking this test."""
+def test_slash_parser_judge_auditor_target_default_to_none_for_petri_role_lookup() -> None:
+    """SoT-flip (2026-05-22) — when ``--judge`` / ``--auditor`` /
+    ``--target`` are omitted, the slash parser must leave them ``None``
+    so the runner can defer to ``[self_improving_loop.petri.<role>].model``
+    via the binding registry. Prior to this PR the parser hardcoded
+    ``"claude-haiku-4-5-20251001"`` (judge) and ``"claude-opus-4-7"``
+    (auditor) defaults — argv-level pin that silently bypassed the
+    operator's role config (PR-G3-style reader-assumption drift).
+    Pinning ``None`` here forces a future cost/quality default-tweak
+    to either route through ``[petri.<role>]`` or break this test."""
     parser = _build_slash_parser()
     ns = parser.parse_args([])
-    assert ns.auditor == "claude-opus-4-7"
+    assert ns.judge is None
+    assert ns.auditor is None
+    assert ns.target is None
 
 
 def test_slash_parser_accepts_dim_set_override() -> None:

--- a/tests/plugins/petri_audit/test_manifest.py
+++ b/tests/plugins/petri_audit/test_manifest.py
@@ -360,7 +360,7 @@ def test_get_role_contract_default_model_mismatch(tmp_path: Path) -> None:
         """---
 role: auditor
 description: drifted default_model
-default_model: claude-opus-4-7
+default_model: claude-sonnet-4-6
 default_source: auto
 ---
 """,
@@ -372,7 +372,7 @@ default_source: auto
         enabled_roles=["auditor"],
         roles={
             "auditor": RoleSpec(
-                default_model=auditor_spec.default_model,  # claude-sonnet-4-6
+                default_model=auditor_spec.default_model,  # claude-opus-4-7
                 allowed_models=auditor_spec.allowed_models,
                 role_contract="auditor.md",
             )

--- a/tests/plugins/petri_audit/test_petri_cli.py
+++ b/tests/plugins/petri_audit/test_petri_cli.py
@@ -177,9 +177,20 @@ def test_set_source_provider_aware(captured):
 
 
 def test_set_source_auto(captured):
-    """'auto' is always a valid source for any provider that lists it."""
+    """'auto' is always a valid source for any provider that lists it.
+
+    SoT-flip (2026-05-22) — the literal ``"auto"`` lands in
+    ``[self_improving_loop.petri.<role>]`` of config.toml, but the
+    loader's ``_read_role_from_self_improving_loop`` filter treats
+    ``source == "auto"`` as "no override" (it's the manifest default
+    anyway). The user-facing semantic is unchanged — operator's
+    ``/petri source <role> auto`` still resets the role to manifest
+    default — but the read returns an empty override map instead of
+    round-tripping the explicit ``"auto"`` literal that the legacy
+    petri.toml writer used to surface. Pin the new contract.
+    """
     cmd_petri("source auditor auto")
-    assert uo.read_role_override("auditor").get("source") == "auto"
+    assert "source" not in uo.read_role_override("auditor")
 
 
 # ── /petri reset ───────────────────────────────────────────────────────────

--- a/tests/plugins/petri_audit/test_registry.py
+++ b/tests/plugins/petri_audit/test_registry.py
@@ -99,12 +99,14 @@ def test_get_binding_auditor_default(monkeypatch: pytest.MonkeyPatch) -> None:
     binding = get_binding("auditor")
     assert isinstance(binding, PetriBinding)
     assert binding.role == "auditor"
-    assert binding.model == "claude-sonnet-4-6"
+    # Single-SoT (2026-05-22) — manifest default flipped sonnet→opus
+    # (auditor=flagship/judge=cost-balanced/target=smallest layering).
+    assert binding.model == "claude-opus-4-7"
     assert binding.source == "api_key"
     assert binding.provider == "anthropic"
     assert binding.adapter_module == "plugins.petri_audit.adapters.http_anthropic"
     assert binding.inspect_prefix == "anthropic"
-    assert binding.inspect_id == "anthropic/claude-sonnet-4-6"
+    assert binding.inspect_id == "anthropic/claude-opus-4-7"
 
 
 def test_get_binding_judge_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -188,7 +190,8 @@ def test_get_binding_oauth_priority(monkeypatch: pytest.MonkeyPatch) -> None:
     assert binding.source == "claude-cli"
     # CSA-3 flip — was claude-code/, now claude-cli/.
     assert binding.inspect_prefix == "claude-cli"
-    assert binding.inspect_id == "claude-cli/claude-sonnet-4-6"
+    # Single-SoT (2026-05-22) — auditor default flipped sonnet→opus.
+    assert binding.inspect_id == "claude-cli/claude-opus-4-7"
 
 
 def test_get_binding_target_with_openai_model(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/plugins/petri_audit/test_runner.py
+++ b/tests/plugins/petri_audit/test_runner.py
@@ -168,6 +168,41 @@ def test_build_command_omits_optional_flags() -> None:
 
 
 # ---------------------------------------------------------------------------
+# SoT-flip (2026-05-22) — None argv resolves via [petri.<role>] registry
+# ---------------------------------------------------------------------------
+
+
+def test_run_audit_resolves_none_judge_via_petri_role(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SoT-flip (2026-05-22) — ``run_audit(judge=None)`` must resolve the
+    judge model through ``get_binding("judge").model`` rather than
+    raising ``AuditModelMappingError("Empty model id")``. The same
+    fall-through applies to ``auditor`` (target already used the
+    None-defer pattern pre-PR).
+
+    Pin via ``GEODE_CONFIG_TOML`` env override so the test loader sees
+    a known ``[self_improving_loop.petri.judge].model`` pin without
+    touching the host's ``~/.geode/config.toml``."""
+    config_toml = tmp_path / "config.toml"
+    config_toml.write_text(
+        '[self_improving_loop.petri.judge]\nmodel = "claude-sonnet-4-6"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(config_toml))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    from plugins.petri_audit.registry import get_binding
+
+    binding = get_binding("judge")
+    assert binding.model == "claude-sonnet-4-6", (
+        "registry must consult [self_improving_loop.petri.judge].model "
+        "when no argv-level model pin is provided — same path that "
+        "run_audit takes when called with judge=None"
+    )
+
+
+# ---------------------------------------------------------------------------
 # judge dimension set selection (--dim-set)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -190,6 +190,49 @@ def test_build_audit_command_reads_from_config(monkeypatch: pytest.MonkeyPatch) 
     assert "--use-oauth" not in argv
 
 
+def test_build_audit_command_omits_target_judge_when_cfg_unpinned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SoT-flip (2026-05-22) — when ``cfg.target_model`` /
+    ``cfg.judge_model`` are ``None`` (autoresearch has nothing to
+    override over the per-role config), ``_build_audit_command`` must
+    OMIT ``--target`` and ``--judge`` from the argv so the runner
+    falls through to ``[self_improving_loop.petri.<role>].model`` via
+    the binding registry. This is the branch that closes the silent
+    argv-pin bypass — assert it stays covered."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        auto_train,
+        "_get_autoresearch_config",
+        lambda: SimpleNamespace(
+            budget_minutes=10,
+            target_model=None,
+            judge_model=None,
+            source="claude-cli",
+            seed_limit=2,
+            seed_select="plugins/petri_audit/seeds",
+            dim_set="subset",
+            max_turns=5,
+        ),
+    )
+    monkeypatch.delenv("AUTORESEARCH_SEED_SELECT", raising=False)
+    argv = auto_train._build_audit_command()
+    assert "--target" not in argv, (
+        "cfg.target_model=None must NOT add --target argv; the runner "
+        "resolves the target via [self_improving_loop.petri.target] when "
+        "the slot is absent"
+    )
+    assert "--judge" not in argv, (
+        "cfg.judge_model=None must NOT add --judge argv; the runner "
+        "resolves the judge via [self_improving_loop.petri.judge]"
+    )
+    # Other flags still emitted from cfg fields.
+    assert "subset" in argv
+    assert "5" in argv  # max_turns
+    assert "--use-oauth" in argv  # source != "api_key"
+
+
 def test_resolve_seed_select_falls_back_to_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -45,11 +45,16 @@ from autoresearch.train import (
 
 
 def test_build_audit_command_uses_current_geode_audit_flags() -> None:
+    """Single-SoT (2026-05-22) — autoresearch's ``_build_audit_command``
+    only emits flags that this layer owns. ``--target`` / ``--judge`` /
+    ``--auditor`` were removed because the role models now live in
+    ``[self_improving_loop.petri.<role>]`` and the runner resolves
+    them via the binding registry when argv slots are absent."""
     argv = _build_audit_command()
-    for flag in ("--seed-select", "--dim-set", "--live", "--yes", "--target", "--judge"):
+    for flag in ("--seed-select", "--dim-set", "--live", "--yes"):
         assert flag in argv, f"missing required flag {flag} in {argv}"
-    for stale in ("--rubric", "--budget-minutes"):
-        assert stale not in argv, f"obsolete flag {stale} re-introduced in {argv}"
+    for stale in ("--rubric", "--budget-minutes", "--target", "--judge", "--auditor"):
+        assert stale not in argv, f"unexpected flag {stale} present in {argv}"
 
 
 def test_wrapper_override_hook_ready_is_true() -> None:
@@ -118,36 +123,46 @@ def test_get_autoresearch_config_returns_config_object() -> None:
         assert hasattr(cfg, attr), f"missing field {attr}"
 
 
-def test_get_autoresearch_config_defaults_match_module_constants() -> None:
+def test_get_autoresearch_config_defaults_match_module_constants(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """No-op behaviour change — unconfigured loader matches module constants.
 
-    PR-MINIMAL-2 (2026-05-21) — ``USE_OAUTH`` module constant replaced
-    by ``SOURCE``. ``target_model`` / ``judge_model`` AutoresearchConfig
-    defaults flipped to ``None`` (G1a), but the train module constants
-    still carry literal defaults for the SimpleNamespace fallback path
-    when ``core.config`` is unimportable.
+    Single-SoT (2026-05-22) — ``TARGET_MODEL`` / ``JUDGE_MODEL`` module
+    constants removed (role models now live exclusively in
+    ``[self_improving_loop.petri.<role>]``). Only the
+    autoresearch-owned knobs (budget / seed / dim / source / turns)
+    remain as module constants for the SimpleNamespace fallback when
+    ``core.config`` is unimportable.
     """
     from autoresearch.train import (
         BUDGET_MINUTES,
         DIM_SET_NAME,
-        JUDGE_MODEL,
         MAX_TURNS,
         SEED_LIMIT,
         SEED_SELECT,
         SOURCE,
-        TARGET_MODEL,
         _get_autoresearch_config,
     )
     from core.config.self_improving_loop import AutoresearchConfig
 
+    # Isolate from the operator's ``~/.geode/config.toml`` — point
+    # ``GEODE_CONFIG_TOML`` at an empty tmp path so the loader falls
+    # back to the dataclass defaults (matches the SimpleNamespace
+    # fallback the module constants encode).
+    empty_cfg = tmp_path / "config.toml"
+    empty_cfg.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GEODE_CONFIG_TOML", str(empty_cfg))
+
     cfg = _get_autoresearch_config()
     expected = AutoresearchConfig()
     assert cfg.budget_minutes == BUDGET_MINUTES == expected.budget_minutes
-    # G1a: AutoresearchConfig defaults to None, but the SimpleNamespace
-    # fallback (used when core.config can't be imported) carries the
-    # train module-constant literals. Either path is valid — accept both.
-    assert cfg.target_model in (TARGET_MODEL, None)
-    assert cfg.judge_model in (JUDGE_MODEL, None)
+    # Single-SoT (2026-05-22) — target_model / judge_model survived as
+    # deprecated no-op slots on the typed config (for back-compat
+    # load) but are silently ignored at runtime. The SimpleNamespace
+    # fallback no longer carries them at all.
+    assert getattr(cfg, "target_model", None) is None
+    assert getattr(cfg, "judge_model", None) is None
     assert cfg.source == SOURCE
     assert cfg.seed_limit == SEED_LIMIT
     assert cfg.seed_select == SEED_SELECT
@@ -170,8 +185,8 @@ def test_build_audit_command_reads_from_config(monkeypatch: pytest.MonkeyPatch) 
         "_get_autoresearch_config",
         lambda: SimpleNamespace(
             budget_minutes=10,
-            target_model="geode/claude-opus-4-7",
-            judge_model="claude-code/sonnet",
+            target_model="geode/claude-opus-4-7",  # deprecated no-op slot
+            judge_model="claude-code/sonnet",  # deprecated no-op slot
             source="api_key",
             seed_limit=25,
             seed_select="plugins/petri_audit/seeds_safe10",
@@ -181,11 +196,16 @@ def test_build_audit_command_reads_from_config(monkeypatch: pytest.MonkeyPatch) 
     )
     monkeypatch.delenv("AUTORESEARCH_SEED_SELECT", raising=False)
     argv = auto_train._build_audit_command()
-    assert "geode/claude-opus-4-7" in argv
-    assert "claude-code/sonnet" in argv
-    assert "25" in argv
-    assert "legacy" in argv
-    assert "20" in argv
+    # Single-SoT (2026-05-22) — target/judge model ids resolved by the
+    # runner via [petri.<role>] registry, not pinned on argv. The
+    # config-fed values for target_model/judge_model are deprecated
+    # no-op slots; assert they do NOT leak onto the argv.
+    assert "geode/claude-opus-4-7" not in argv
+    assert "claude-code/sonnet" not in argv
+    # Autoresearch-owned knobs still flow through this builder.
+    assert "25" in argv  # seed_limit
+    assert "legacy" in argv  # dim_set
+    assert "20" in argv  # max_turns
     # source == "api_key" → no --use-oauth flag.
     assert "--use-oauth" not in argv
 
@@ -1292,9 +1312,13 @@ def test_main_dry_run_emits_full_p0b_event_sequence(
     # PR-MINIMAL-2 (2026-05-21) — ``use_oauth`` key renamed to
     # ``source`` (B1: AutoresearchConfig.use_oauth: bool →
     # AutoresearchConfig.source: Source enum).
+    # Single-SoT (2026-05-22) — auditor_model added alongside
+    # target/judge so the journal records the full [petri.<role>] →
+    # registry resolution for all three audit roles.
     assert set(by_event["config_snapshot"].keys()) == {
         "target_model",
         "judge_model",
+        "auditor_model",
         "budget_minutes",
         "seed_limit",
         "dim_set",

--- a/tests/test_ol_g_config_drift_invariants.py
+++ b/tests/test_ol_g_config_drift_invariants.py
@@ -2,10 +2,14 @@
 
 PR-1 G-B/G-D/G-E (2026-05-21) closed three config drift surfaces:
 
-- **G-B**: ``autoresearch/train.py`` 의 `TARGET_MODEL` / `JUDGE_MODEL`
-  module constants → `[self_improving_loop.autoresearch] target_model
-  / judge_model` config knob (with None default → inherit
-  ``Settings.model``).
+- **G-B**: Petri role models → ``[self_improving_loop.petri.<role>]``
+  config knob. PR-CSP-12 (2026-05-22) consolidated to single-SoT
+  semantics — the legacy ``TARGET_MODEL`` / ``JUDGE_MODEL`` module
+  constants and ``AutoresearchConfig.target_model`` /
+  ``judge_model`` fields are deprecated no-ops; the real SoT is the
+  ``[self_improving_loop.petri.<role>].model`` section consulted by
+  ``autoresearch.train._petri_role_model`` and
+  ``plugins.petri_audit.registry.get_binding``.
 - **G-D**: ``core/hooks/llm_extract_learning.py`` 의 ``"glm-4.7-flash"``
   literal → ``settings.learning_extract_model`` config-overridable.
 - **G-E**: ``settings.model`` (was ``claude-opus-4-6``) vs
@@ -25,36 +29,60 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_g_b_autoresearch_target_judge_have_config_knob() -> None:
-    """`AutoresearchConfig` must expose `target_model` + `judge_model`
-    fields. The defaults are None (inherit Settings.model per PR-MINIMAL-2)
-    but the *fields must exist* so operators can override via
-    ``[self_improving_loop.autoresearch] target_model = "..."``.
+def test_g_b_autoresearch_petri_role_is_canonical_sot() -> None:
+    """Petri role models resolve through ``[self_improving_loop.petri.<role>]``.
+
+    Single-SoT (2026-05-22, PR-CSP-12) — ``AutoresearchConfig.target_model``
+    and ``judge_model`` survive as **deprecated no-op slots** for
+    back-compat config load (so an old config.toml doesn't break parse),
+    but the canonical SoT is the petri-role section. The fields must
+    accept any string round-trip, but runtime resolution does NOT
+    consult them — that path runs through ``_petri_role_model``.
     """
-    from core.config.self_improving_loop import AutoresearchConfig
+    from core.config.self_improving_loop import (
+        AutoresearchConfig,
+        SelfImprovingLoopConfig,
+    )
 
     cfg = AutoresearchConfig()
-    assert hasattr(cfg, "target_model"), "G-B regressed: target_model field missing"
-    assert hasattr(cfg, "judge_model"), "G-B regressed: judge_model field missing"
-    # Operator override path: explicit value must round-trip.
-    cfg_with_override = AutoresearchConfig(target_model="custom-target", judge_model="custom-judge")
-    assert cfg_with_override.target_model == "custom-target"
-    assert cfg_with_override.judge_model == "custom-judge"
+    # Deprecated fields survive on AutoresearchConfig — default None
+    # signals "not set" (back-compat: an old config.toml carrying
+    # these keys won't fail to parse).
+    assert getattr(cfg, "target_model", "MISSING") is None, (
+        "G-B regressed: target_model deprecated slot removed before back-compat window"
+    )
+    assert getattr(cfg, "judge_model", "MISSING") is None, (
+        "G-B regressed: judge_model deprecated slot removed before back-compat window"
+    )
+    # The petri section lives on the top-level config — it's the
+    # real SoT for per-role model selection.
+    loop_cfg = SelfImprovingLoopConfig()
+    assert hasattr(loop_cfg, "petri"), (
+        "G-B regressed: SelfImprovingLoopConfig.petri role-config section missing"
+    )
 
 
-def test_g_b_autoresearch_module_constants_are_fallbacks_not_canon() -> None:
-    """`autoresearch.train.TARGET_MODEL` / `JUDGE_MODEL` are FALLBACK
-    defaults — they exist so the module is importable without a config
-    file, but the config knob is the canonical SoT. If a future PR
-    deletes the fallbacks, the import would break in CI environments
-    that stub out ``core.config``; this test pins them as present.
+def test_g_b_autoresearch_resolves_role_model_through_helper() -> None:
+    """``autoresearch.train`` resolves per-role models via the helper —
+    no surviving module-constant SoT.
+
+    Single-SoT (2026-05-22) — the legacy ``TARGET_MODEL`` /
+    ``JUDGE_MODEL`` constants were removed because they shadowed the
+    petri-role config section (operator-facing SoT). The remaining
+    surface is ``_petri_role_model(role)`` which consults the manifest
+    + ``[self_improving_loop.petri.<role>]`` overrides.
     """
     from autoresearch import train
 
-    assert hasattr(train, "TARGET_MODEL"), "G-B regressed: TARGET_MODEL fallback removed"
-    assert hasattr(train, "JUDGE_MODEL"), "G-B regressed: JUDGE_MODEL fallback removed"
-    # _get_autoresearch_config is the lazy-load entry point — its
-    # existence is the load-bearing API surface.
+    assert callable(getattr(train, "_petri_role_model", None)), (
+        "G-B regressed: _petri_role_model helper removed — role resolution path broken"
+    )
+    assert not hasattr(train, "TARGET_MODEL"), (
+        "G-B regressed: TARGET_MODEL re-introduced — must stay removed (single-SoT)"
+    )
+    assert not hasattr(train, "JUDGE_MODEL"), (
+        "G-B regressed: JUDGE_MODEL re-introduced — must stay removed (single-SoT)"
+    )
     assert callable(getattr(train, "_get_autoresearch_config", None)), (
         "G-B regressed: _get_autoresearch_config loader missing"
     )

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -306,6 +306,11 @@ def test_cmd_source_set_rejects_invalid_source(
 
     fake_toml = tmp_path / "config.toml"
     monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    # Single-SoT (2026-05-22) — writer now resolves through
+    # ``core.config.self_improving_loop._resolve_config_path`` which
+    # reads the module-local import; patch that symbol too so the test
+    # honors fake_toml regardless of which side calls in first.
+    monkeypatch.setattr("core.config.self_improving_loop.GLOBAL_CONFIG_TOML", fake_toml)
     with patch.object(self_improving, "console") as cmock:
         self_improving._cmd_source_set(["source=bogus"])
     assert not fake_toml.exists()
@@ -322,6 +327,8 @@ def test_cmd_source_set_persists_valid_source(
 
     fake_toml = tmp_path / "config.toml"
     monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
+    # See sibling test for rationale on patching both symbols.
+    monkeypatch.setattr("core.config.self_improving_loop.GLOBAL_CONFIG_TOML", fake_toml)
     self_improving._cmd_source_set(["source=claude-cli"])
     text = fake_toml.read_text(encoding="utf-8")
     assert "[self_improving_loop.mutator]" in text

--- a/tests/test_self_improving_loop_gap_fill.py
+++ b/tests/test_self_improving_loop_gap_fill.py
@@ -180,13 +180,27 @@ def test_runner_reads_default_model_from_config() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_train_audit_command_uses_config_target_judge() -> None:
+def test_train_audit_command_omits_per_role_argv_pins() -> None:
+    """Single-SoT (2026-05-22, PR-CSP-12) — ``_build_audit_command``
+    must NOT emit ``--target`` / ``--judge`` argv flags. The legacy
+    flags shadowed ``[self_improving_loop.petri.<role>].model`` (the
+    operator SoT) and were the original silent-bypass discovered in
+    the 2026-05-22 baseline misalignment audit. The argv must only
+    carry seed / dim / turns / source flags; role model selection
+    flows through the registry inside ``geode audit``.
+    """
     from autoresearch import train
 
     src = inspect.getsource(train._build_audit_command)
-    assert "cfg.target_model" in src
-    assert "cfg.judge_model" in src
-    assert '"--target",' in src and '"--judge",' in src
+    assert "cfg.target_model" not in src, (
+        "G-B regressed: _build_audit_command re-reads deprecated cfg.target_model"
+    )
+    assert "cfg.judge_model" not in src, (
+        "G-B regressed: _build_audit_command re-reads deprecated cfg.judge_model"
+    )
+    assert '"--target",' not in src and '"--judge",' not in src, (
+        "G-B regressed: _build_audit_command re-emits --target/--judge argv pins"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -194,33 +208,23 @@ def test_train_audit_command_uses_config_target_judge() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_program_md_example_log_matches_train_module_constants() -> None:
-    """Pin the example log block in ``autoresearch/program.md`` to the
-    ``autoresearch.train`` module-constant defaults
-    (``TARGET_MODEL`` / ``JUDGE_MODEL``) so an operator who edits the
-    constant and forgets to refresh the doc gets a CI hit.
+def test_program_md_example_log_present() -> None:
+    """Smoke-pin that ``autoresearch/program.md`` retains the example
+    log block referencing ``target_model:`` / ``judge_model:``.
 
-    PR-MINIMAL-2 (2026-05-21) — pre-PR this test compared against
-    ``AutoresearchConfig`` defaults. With G1a those defaults are
-    ``None`` (inherit ``Settings.model``), so the example log can no
-    longer use the config dataclass as the truth source — the
-    module constants in ``train.py`` ARE the SoT for the docs
-    example, and the agent (per ``program.md``) can grep + edit them.
+    Single-SoT (2026-05-22, PR-CSP-12) — the legacy module constants
+    (``TARGET_MODEL`` / ``JUDGE_MODEL``) were removed; the canonical
+    SoT is the per-role petri config section. The example log values
+    are illustrative — they don't have to match a Python literal —
+    but the structural shape of the example must remain so the agent
+    grepping ``program.md`` for "target_model:" still locates the
+    block. The drift-pin is now structural, not value-comparing.
     """
-    from autoresearch.train import JUDGE_MODEL, TARGET_MODEL
-
     repo_root = Path(__file__).resolve().parent.parent
     program_md = repo_root / "autoresearch" / "program.md"
     text = program_md.read_text(encoding="utf-8")
-    assert f"target_model:             {TARGET_MODEL}" in text, (
-        "program.md example log target_model has drifted from "
-        f"autoresearch.train.TARGET_MODEL ({TARGET_MODEL!r}). Update "
-        "the example block (lines ~180) to keep the doc honest."
-    )
-    assert f"judge_model:              {JUDGE_MODEL}" in text, (
-        "program.md example log judge_model has drifted from "
-        f"autoresearch.train.JUDGE_MODEL ({JUDGE_MODEL!r})."
-    )
+    assert "target_model:" in text, "program.md missing target_model: example anchor"
+    assert "judge_model:" in text, "program.md missing judge_model: example anchor"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_improving_minimal_2.py
+++ b/tests/test_self_improving_minimal_2.py
@@ -59,17 +59,28 @@ def test_runner_default_llm_call_inherits_settings_model() -> None:
     assert "cfg.mutator.default_model" in src
 
 
-def test_build_audit_command_inherits_settings_model() -> None:
-    """``autoresearch.train._build_audit_command`` must read
-    ``cfg.target_model`` / ``cfg.judge_model`` AND fall back to
-    ``_settings_model()`` when either is None (G1a)."""
+def test_build_audit_command_omits_argv_when_target_judge_unpinned() -> None:
+    """SoT-flip (2026-05-22) — when ``cfg.target_model`` /
+    ``cfg.judge_model`` are unset (the operator hasn't pinned an
+    autoresearch-specific override), ``_build_audit_command`` must
+    OMIT the ``--target`` / ``--judge`` argv slots so the runner
+    falls through to ``[self_improving_loop.petri.<role>].model`` via
+    the binding registry. The PR-MINIMAL-2 (2026-05-21) inherit via
+    ``cfg.target_model or _settings_model()`` was the asymmetric path
+    that silently bypassed the per-role config: the
+    ``Settings.model`` fallback now lives one layer down (manifest
+    default + credential cascade inside ``registry.get_binding``)."""
     from autoresearch import train
 
     src = inspect.getsource(train._build_audit_command)
-    assert "_settings_model" in src
-    # Both target + judge fall back via the helper
-    assert "cfg.target_model or _settings_model()" in src
-    assert "cfg.judge_model or _settings_model()" in src
+    # Conditional argv emission — present only when cfg pinned a value
+    assert "if cfg.target_model:" in src
+    assert "if cfg.judge_model:" in src
+    # The legacy inherit-via-Settings.model wiring is gone from this
+    # function — verify it stays removed so a future refactor doesn't
+    # silently re-introduce the bypass.
+    assert "cfg.target_model or _settings_model()" not in src
+    assert "cfg.judge_model or _settings_model()" not in src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_improving_minimal_2.py
+++ b/tests/test_self_improving_minimal_2.py
@@ -59,28 +59,34 @@ def test_runner_default_llm_call_inherits_settings_model() -> None:
     assert "cfg.mutator.default_model" in src
 
 
-def test_build_audit_command_omits_argv_when_target_judge_unpinned() -> None:
-    """SoT-flip (2026-05-22) — when ``cfg.target_model`` /
-    ``cfg.judge_model`` are unset (the operator hasn't pinned an
-    autoresearch-specific override), ``_build_audit_command`` must
-    OMIT the ``--target`` / ``--judge`` argv slots so the runner
-    falls through to ``[self_improving_loop.petri.<role>].model`` via
-    the binding registry. The PR-MINIMAL-2 (2026-05-21) inherit via
-    ``cfg.target_model or _settings_model()`` was the asymmetric path
-    that silently bypassed the per-role config: the
-    ``Settings.model`` fallback now lives one layer down (manifest
-    default + credential cascade inside ``registry.get_binding``)."""
+def test_build_audit_command_never_pins_role_models_on_argv() -> None:
+    """Single-SoT (2026-05-22) — ``_build_audit_command`` must NEVER
+    emit ``--target`` / ``--judge`` / ``--auditor`` argv. The role
+    models live in ``[self_improving_loop.petri.<role>].model`` and
+    the runner resolves them via the binding registry when argv slots
+    are absent. Earlier revisions:
+
+    * PR-MINIMAL-2 (2026-05-21) — inherited via
+      ``cfg.target_model or _settings_model()`` (Settings.model
+      bypass)
+    * 2026-05-22 first cut — emitted ``if cfg.target_model:`` argv
+      (override-only knob) — still a second SoT layer
+
+    Both paths created a duplicate-SoT race with ``[petri.<role>]``.
+    Pin the no-argv contract so a future refactor doesn't silently
+    re-introduce the bypass."""
     from autoresearch import train
 
     src = inspect.getsource(train._build_audit_command)
-    # Conditional argv emission — present only when cfg pinned a value
-    assert "if cfg.target_model:" in src
-    assert "if cfg.judge_model:" in src
-    # The legacy inherit-via-Settings.model wiring is gone from this
-    # function — verify it stays removed so a future refactor doesn't
-    # silently re-introduce the bypass.
-    assert "cfg.target_model or _settings_model()" not in src
-    assert "cfg.judge_model or _settings_model()" not in src
+    # No ``--target`` / ``--judge`` / ``--auditor`` argv emission
+    assert '"--target"' not in src
+    assert '"--judge"' not in src
+    assert '"--auditor"' not in src
+    # And no model-axis cfg reads inside the builder
+    assert "cfg.target_model" not in src
+    assert "cfg.judge_model" not in src
+    # The legacy inherit-via-Settings.model wiring is gone too
+    assert "_settings_model" not in src
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `[self_improving_loop.petri.<role>]` (in `~/.geode/config.toml`) is the **single SoT** for audit role models. Five duplicate-SoT layers collapsed into one.
- argv flags default to `None`; runner falls back to `plugins.petri_audit.registry.get_binding(role).model`. `/petri model <role>` writes into config.toml directly.
- `autoresearch.train.TARGET_MODEL` / `JUDGE_MODEL` module constants **removed**. Role resolution flows through new `_petri_role_model(role)` helper that consults manifest + petri-role overrides.
- Manifest layered defaults — `auditor=claude-opus-4-7` (flagship), `judge=claude-sonnet-4-6` (cost-balanced), `target=claude-haiku-4-5` (smallest).

## Why
The 2026-05-22 baseline-run misalignment audit traced operator's `[self_improving_loop.petri.auditor].model = "claude-opus-4-7"` being silently bypassed: Typer's hardcoded `--auditor` argv default shadowed the config-toml SoT before `get_binding` could consult it. Same reader-assumption-drift anti-pattern as PR-G3 #1347 / PR-G2 #1346 — fixed once, here, by deleting every duplicate SoT (argv hardcode, AutoresearchConfig fields, train.py module constants, legacy petri.toml writer).

## Changes
| File | Change |
|------|--------|
| `plugins/petri_audit/cli_audit.py` | Typer + argparse `--judge` / `--auditor` defaults flipped to `None`; help text updated |
| `plugins/petri_audit/runner.py` | `None` argv → `get_binding(role).model` resolution |
| `plugins/petri_audit/user_overrides.py` | New `save_role_override_to_config_toml` writes to `[self_improving_loop.petri.<role>]`; legacy `~/.geode/petri.toml` writer kept for fixtures + read-fallback |
| `plugins/petri_audit/cli.py` | `/petri` slash command now writes via the new function |
| `plugins/petri_audit/petri.plugin.toml` | Auditor default flipped to `claude-opus-4-7` (layered: flagship / cost-balanced / smallest) |
| `plugins/petri_audit/roles/auditor.md` | Frontmatter `default_model` synced to opus-4-7 |
| `core/cli/commands/self_improving.py` | `_persist_section_updates` honors empty-string-as-delete; writer routes through `_resolve_config_path` (env-aware) |
| `core/config/self_improving_loop.py` | `AutoresearchConfig.target_model` / `judge_model` survive as deprecated no-op slots (back-compat config load only) |
| `autoresearch/train.py` | Removed `TARGET_MODEL` / `JUDGE_MODEL`; new `_petri_role_model` helper; `_build_audit_command` no longer emits `--target` / `--judge` |
| `tests/plugins/petri_audit/test_manifest.py` | Drift-check uses sonnet-as-mismatch (manifest is now opus) |
| `tests/plugins/petri_audit/test_registry.py` | Default-binding tests expect opus-4-7 |
| `tests/test_ol_g_config_drift_invariants.py` | G-B drift pins flipped — `_petri_role_model` is canonical, constants forbidden |
| `tests/test_self_improving_loop_gap_fill.py` | Argv-pin test asserts `_build_audit_command` does NOT emit per-role flags |
| `tests/integration/test_auth_path_coverage.py` | Asserts `_petri_role_model` helper instead of removed constants |
| `tests/test_autoresearch_train.py` | New helper test pins no-argv behavior; defaults test isolated via `GEODE_CONFIG_TOML` env |
| `tests/test_paperclip_wiring.py` | Tests patch both `core.paths.GLOBAL_CONFIG_TOML` *and* the local-module symbol (read/write parity) |

## GAP Audit
| Item | Status |
|------|--------|
| Typer + argparse defaults `None` | Implemented |
| Runner resolves `None` via `get_binding` | Implemented |
| `/petri` slash writes config.toml exclusively | Implemented |
| autoresearch argv omits per-role flags | Implemented |
| AutoresearchConfig per-role fields deprecated (no-op) | Implemented |
| `TARGET_MODEL` / `JUDGE_MODEL` constants removed | Implemented |
| Manifest layered defaults (flagship / balanced / smallest) | Implemented |
| Empty-string delete-axis path | Implemented (line removal via `_persist_section_updates`) |
| Legacy `petri.toml` read fallback retained one release | Preserved |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success, 412 source files
- [x] `uv run deptry .` — No dependency issues
- [x] `uv run lint-imports` — 4 contracts kept, 0 broken
- [x] `uv run pytest tests/ -m "not live"` — **6582 passed, 42 skipped, 0 failed** (228s)

## Reference
- 2026-05-22 baseline-run misalignment investigation (this session) — Typer argv silently shadowed config-toml SoT
- Anti-pattern lineage: PR-G3 #1347 / PR-G2 #1346 reader-assumption drift
- Operator config (`~/.geode/config.toml`) `[self_improving_loop.petri.<role>]` is now canonical SoT

🤖 Generated with [Claude Code](https://claude.com/claude-code)