### PR TITLE
docs(petri-audit): align self-improving-loop docs with single-SoT consolidation

### DIFF
--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -93,9 +93,14 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
   (`SelfImprovingLoopRunner`) dispatches by `Mutation.target_kind`
   to the matching file; Mode A agents can edit any of the 5 directly
   via `git`-tracked JSON.
-- Tune hyperparameters on `train.py`: `BUDGET_MINUTES`, `JUDGE_MODEL`,
-  `TARGET_MODEL`, etc. Change **one at a time** so the fitness delta
-  is attributable.
+- Tune hyperparameters on `train.py`: `BUDGET_MINUTES`, `SEED_LIMIT`,
+  `MAX_TURNS`, `DIM_SET_NAME`, `SOURCE`. Change **one at a time** so the
+  fitness delta is attributable. The `auditor` / `target` / `judge` role
+  models are **not** tuned here — they live in
+  `~/.geode/config.toml` under `[self_improving_loop.petri.<role>]`
+  (PR-CSP-12, 2026-05-22) and the autoresearch outer loop reads them
+  via the binding registry. Edit those sections directly (or use the
+  `/petri model <role> <model>` slash) to flip role models.
 
 **The agent CANNOT**:
 - Modify `prepare.py`. It is the fixed ground truth for the seed pool,

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -30,15 +30,20 @@ Agent CAN modify:
     active AgenticLoop system prompt replaces the wrapper base with it.
   * Hyperparameters via ``[self_improving_loop.autoresearch]`` in
     ``~/.geode/config.toml`` (``budget_minutes``, ``seed_limit``,
-    ``max_turns``, ``source``, etc.). The module constants below
-    (``BUDGET_MINUTES`` / ``TARGET_MODEL`` / ``JUDGE_MODEL`` /
-    ``SEED_LIMIT`` / …) are the SimpleNamespace fallback used only
-    when ``core.config`` cannot be imported (test stubs). For
-    role models specifically, ``[self_improving_loop.petri.<role>]``
-    is the operator-config SoT — set ``[autoresearch].target_model``
-    / ``.judge_model`` only when this run must override the per-role
-    baseline (see ``AutoresearchConfig`` docstring). Change one
-    knob at a time so the fitness delta is attributable.
+    ``max_turns``, ``source``, ``dim_set``). The module constants below
+    (``BUDGET_MINUTES`` / ``SEED_LIMIT`` / ``MAX_TURNS`` /
+    ``DIM_SET_NAME`` / ``SOURCE``) are the SimpleNamespace fallback
+    used only when ``core.config`` cannot be imported (test stubs).
+    Role models live in a separate SoT —
+    ``[self_improving_loop.petri.<role>]`` is the canonical operator
+    section; ``_petri_role_model(role)`` resolves it for status / argv
+    print. PR-CSP-12 (2026-05-22) removed the legacy
+    ``TARGET_MODEL`` / ``JUDGE_MODEL`` module constants and the
+    ``[autoresearch].target_model`` / ``.judge_model`` argv-emit path;
+    operators who want a per-run role override now edit the petri
+    section directly or pass ``--target`` / ``--judge`` argv on the
+    ``geode audit`` invocation. Change one knob at a time so the
+    fitness delta is attributable.
 
 Agent CANNOT modify (the ``prepare.py`` ground truth):
   * Seed pool tree (``plugins/petri_audit/seeds/``, hierarchical

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -23,14 +23,22 @@ never overwrite each other.
 Precedence (Codex / OpenAI Agents pattern)
 ==========================================
 
-1. Per-component env var override (e.g. ``AUTORESEARCH_TARGET_MODEL``)
-   — handled at the caller, not here.
-2. ``~/.geode/config.toml`` ``[self_improving_loop.*]`` section — this loader.
-3. Module-level constants in ``autoresearch/train.py`` / picker
-   defaults — fallback when the section is missing.
-4. Pydantic model default — last resort.
+1. ``~/.geode/config.toml`` ``[self_improving_loop.*]`` section — this
+   loader. Per-role petri model selection lives under
+   ``[self_improving_loop.petri.<role>]`` (PR-CSP-12, 2026-05-22 — the
+   single SoT for ``auditor`` / ``target`` / ``judge`` after the
+   duplicate-SoT consolidation removed argv defaults, the
+   ``TARGET_MODEL`` / ``JUDGE_MODEL`` module constants, and the legacy
+   ``~/.geode/petri.toml`` writer).
+2. Picker defaults in ``autoresearch/train.py`` (``BUDGET_MINUTES``,
+   ``SEED_LIMIT``, etc.) — fallback when the section is missing. Role
+   models fall back to the manifest ``default_model`` in
+   ``plugins/petri_audit/petri.plugin.toml`` via
+   ``autoresearch.train._petri_role_model``.
+3. Pydantic model default — last resort.
 
-Source: 2026-05-19 config consolidation plan (settled decision #1).
+Source: 2026-05-19 config consolidation plan (settled decision #1),
+finalized by the 2026-05-22 PR-CSP-12 single-SoT consolidation.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- GAP-audit follow-up on PR #1496 surfaced three docs that still pointed at the removed `TARGET_MODEL` / `JUDGE_MODEL` module constants and a never-implemented `AUTORESEARCH_TARGET_MODEL` env var path.
- Fixes the highest-impact one — `autoresearch/program.md` mutator instructions — so the self-improving-loop mutator agent (which reads program.md via `_load_program_md`) doesn't emit a mutation against non-existent identifiers.
- Aligns two adjacent module docstrings (`autoresearch/train.py`, `core/config/self_improving_loop.py`) so the precedence story and SimpleNamespace fallback set match the merged code.

## Why
Same anti-pattern as PR-G5b (CLAUDE.md DONT table): "X-driven" claims must be grep-provable in code. PR #1496 deleted `TARGET_MODEL` / `JUDGE_MODEL` but left three docs claiming they still existed:

| File | Stale claim | Fix |
|------|-------------|-----|
| `autoresearch/program.md:96-97` | Mutator instructed to "Tune JUDGE_MODEL, TARGET_MODEL" | Replaced with `[petri.<role>]` section + `/petri model` slash references |
| `core/config/self_improving_loop.py:26` | Precedence list led with `AUTORESEARCH_TARGET_MODEL` env var (zero handlers) | Rewrote precedence: petri.<role> → manifest default → pydantic default |
| `autoresearch/train.py:34` | SimpleNamespace fallback list included `TARGET_MODEL` / `JUDGE_MODEL` | Replaced with surviving constants + `_petri_role_model` flow |

The first one is the highest-impact: if the mutator agent emits a mutation targeting `JUDGE_MODEL`, the loop fails silently (no such identifier) or worse, succeeds with a no-op (silent CHANGELOG-implementation parity violation).

## Changes
| File | Change |
|------|--------|
| `autoresearch/program.md` | Mutator tunable-hyperparameter bullet replaced with surviving constants + petri-section pointer |
| `core/config/self_improving_loop.py` | Module docstring precedence rewritten |
| `autoresearch/train.py` | Module docstring SimpleNamespace-fallback bullet rewritten |

## GAP Audit
| Item | Status |
|------|--------|
| `program.md` mutator instructions match removed constants | Fixed |
| Module docstring precedence matches single-SoT | Fixed |
| SimpleNamespace fallback list matches surviving constants | Fixed |
| Other historical docs (`docs/plans/2026-05-19-…`, `docs/plans/2026-05-21-cognitive-loop-uplift.md`) | Intentionally left — frozen design records per CLAUDE.md "append don't rotate" convention |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success, 412 source files
- [x] focused pytest (test_self_improving_minimal_2 + test_self_improving_loop_config + test_autoresearch_train + test_ol_g_config_drift_invariants + test_self_improving_loop_gap_fill) — 144 passed

## Reference
- PR #1496 (petri-role SoT consolidation) left these docs untouched
- CLAUDE.md DONT table — PR-G5b CHANGELOG/PR-body parity row

🤖 Generated with [Claude Code](https://claude.com/claude-code)