### PR TITLE
release: docs alignment with single-SoT consolidation (no version bump)

### DIFF
--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -93,9 +93,14 @@ To verify self-improving-loop plumbing without spending budget, use `--dry-run`
   (`SelfImprovingLoopRunner`) dispatches by `Mutation.target_kind`
   to the matching file; Mode A agents can edit any of the 5 directly
   via `git`-tracked JSON.
-- Tune hyperparameters on `train.py`: `BUDGET_MINUTES`, `JUDGE_MODEL`,
-  `TARGET_MODEL`, etc. Change **one at a time** so the fitness delta
-  is attributable.
+- Tune hyperparameters on `train.py`: `BUDGET_MINUTES`, `SEED_LIMIT`,
+  `MAX_TURNS`, `DIM_SET_NAME`, `SOURCE`. Change **one at a time** so the
+  fitness delta is attributable. The `auditor` / `target` / `judge` role
+  models are **not** tuned here — they live in
+  `~/.geode/config.toml` under `[self_improving_loop.petri.<role>]`
+  (PR-CSP-12, 2026-05-22) and the autoresearch outer loop reads them
+  via the binding registry. Edit those sections directly (or use the
+  `/petri model <role> <model>` slash) to flip role models.
 
 **The agent CANNOT**:
 - Modify `prepare.py`. It is the fixed ground truth for the seed pool,

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -30,15 +30,20 @@ Agent CAN modify:
     active AgenticLoop system prompt replaces the wrapper base with it.
   * Hyperparameters via ``[self_improving_loop.autoresearch]`` in
     ``~/.geode/config.toml`` (``budget_minutes``, ``seed_limit``,
-    ``max_turns``, ``source``, etc.). The module constants below
-    (``BUDGET_MINUTES`` / ``TARGET_MODEL`` / ``JUDGE_MODEL`` /
-    ``SEED_LIMIT`` / …) are the SimpleNamespace fallback used only
-    when ``core.config`` cannot be imported (test stubs). For
-    role models specifically, ``[self_improving_loop.petri.<role>]``
-    is the operator-config SoT — set ``[autoresearch].target_model``
-    / ``.judge_model`` only when this run must override the per-role
-    baseline (see ``AutoresearchConfig`` docstring). Change one
-    knob at a time so the fitness delta is attributable.
+    ``max_turns``, ``source``, ``dim_set``). The module constants below
+    (``BUDGET_MINUTES`` / ``SEED_LIMIT`` / ``MAX_TURNS`` /
+    ``DIM_SET_NAME`` / ``SOURCE``) are the SimpleNamespace fallback
+    used only when ``core.config`` cannot be imported (test stubs).
+    Role models live in a separate SoT —
+    ``[self_improving_loop.petri.<role>]`` is the canonical operator
+    section; ``_petri_role_model(role)`` resolves it for status / argv
+    print. PR-CSP-12 (2026-05-22) removed the legacy
+    ``TARGET_MODEL`` / ``JUDGE_MODEL`` module constants and the
+    ``[autoresearch].target_model`` / ``.judge_model`` argv-emit path;
+    operators who want a per-run role override now edit the petri
+    section directly or pass ``--target`` / ``--judge`` argv on the
+    ``geode audit`` invocation. Change one knob at a time so the
+    fitness delta is attributable.
 
 Agent CANNOT modify (the ``prepare.py`` ground truth):
   * Seed pool tree (``plugins/petri_audit/seeds/``, hierarchical

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -23,14 +23,22 @@ never overwrite each other.
 Precedence (Codex / OpenAI Agents pattern)
 ==========================================
 
-1. Per-component env var override (e.g. ``AUTORESEARCH_TARGET_MODEL``)
-   — handled at the caller, not here.
-2. ``~/.geode/config.toml`` ``[self_improving_loop.*]`` section — this loader.
-3. Module-level constants in ``autoresearch/train.py`` / picker
-   defaults — fallback when the section is missing.
-4. Pydantic model default — last resort.
+1. ``~/.geode/config.toml`` ``[self_improving_loop.*]`` section — this
+   loader. Per-role petri model selection lives under
+   ``[self_improving_loop.petri.<role>]`` (PR-CSP-12, 2026-05-22 — the
+   single SoT for ``auditor`` / ``target`` / ``judge`` after the
+   duplicate-SoT consolidation removed argv defaults, the
+   ``TARGET_MODEL`` / ``JUDGE_MODEL`` module constants, and the legacy
+   ``~/.geode/petri.toml`` writer).
+2. Picker defaults in ``autoresearch/train.py`` (``BUDGET_MINUTES``,
+   ``SEED_LIMIT``, etc.) — fallback when the section is missing. Role
+   models fall back to the manifest ``default_model`` in
+   ``plugins/petri_audit/petri.plugin.toml`` via
+   ``autoresearch.train._petri_role_model``.
+3. Pydantic model default — last resort.
 
-Source: 2026-05-19 config consolidation plan (settled decision #1).
+Source: 2026-05-19 config consolidation plan (settled decision #1),
+finalized by the 2026-05-22 PR-CSP-12 single-SoT consolidation.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Develop is 2 commits ahead of main with the PR #1500 docs alignment (program.md + module docstrings) on top of v0.99.35. No code behavior changes, no version bump (CLAUDE.md: docs-only = no version bump).
- Carries the develop→main backmerge merge commit (already on main via PR #1499, gitflow asymmetry) + PR #1500 (residue cleanup).

## Verification
- [x] PR #1500 already passed full CI on develop (lint/format/type/test/install all green)
- [x] No code paths touched — only `autoresearch/program.md` + 2 module docstrings
- [x] Smoke verified pre-merge: `geode audit --dry-run` resolves all 3 roles from operator config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)