### PR TITLE
PR-MIC — Model Identity Cleanup (drift_sync label + ack purge boost + auth dedup + weakened card)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,64 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-MIC (Model Identity Cleanup) — drift_sync label + ack purge boost
+  + auth.toml dedup**. Closes a 2026-05-23 production incident chain
+  surfaced in the REPL header (``Model: gpt-5.5 → claude-opus-4-6
+  (user_switch)`` immediately followed by Anthropic PAYG quota
+  exhaustion) and the X2 deferred decision from
+  ``project_session65_deferred_followup.md``.
+
+  **Label correctness — ``reason="drift_sync"``**
+  (``core/agent/loop/_model_switching.py``):
+  ``sync_model_from_settings_async`` was omitting the ``reason`` kwarg,
+  so ``update_model_async``'s default ``"user_switch"`` reached the
+  ``MODEL_SWITCHED`` hook and the REPL header — mis-attributing
+  Settings-drift auto-sync to the operator. Now passes
+  ``reason="drift_sync"`` so the UI surfaces the real trigger.
+
+  **Stale-ack purge — block-form aware**
+  (``core/agent/loop/_model_switching.py``): ``_purge_stale_model_switch_acks``
+  previously gated on ``isinstance(content, str)`` only, so an ack
+  stored as Anthropic-style ``[{"type": "text", "text": "Understood. I
+  am now …"}]`` block-form silently survived. Now scans text blocks
+  too — any prefix-matching text block drops the whole message.
+  Mixed-content (image + text) handled.
+
+  **Model card weakened — Option B from X2 decision**
+  (``core/agent/system_prompt.py``): the v0.52.8 strong 3-sentence
+  "non-negotiable" identity assertion + explicit stale-ack override
+  text is replaced with a single neutral ``You are {model} ({provider}).``
+  line. The root cause of the v0.52.8 production incident (history
+  pollution from prior ``Understood. I am now <prev>.`` acks) is now
+  fully covered by the block-form-aware purge — the assertion
+  carried ~80 tokens per round defending against a hypothetical
+  backend system-layer override with no public evidence (deferred
+  WebFetch verification in v0.52.8 returned 403 on 3 openai.com
+  URLs). Aligns with claw + hermes which carry no identity
+  assertion in their system prompt. If a recurrence surfaces, the
+  "Option C" Codex-only branch reintroduction is the documented
+  rollback path.
+
+  **Auth-profile dedup** (``core/wiring/container.py``): the legacy
+  ``anthropic:default`` / ``openai:default`` / ``glm:default``
+  in-memory profile add at startup used to shadow-duplicate the
+  canonical ``<provider>-payg:env`` row that ``load_auth_toml``
+  hydrates from disk — same credential, no ``plan_id`` metadata,
+  redundant rotator entry. Now skipped when ``~/.geode/auth.toml``
+  exists.
+
+  **Tests**: ``test_purge_handles_non_string_content`` flipped to
+  ``test_purge_handles_block_form_content`` (asserts purge now eats
+  block-form acks) + new ``test_purge_handles_mixed_block_types``.
+  ``test_model_card_asserts_active_identity_for_gpt_5_5`` rewritten
+  as ``test_model_card_names_active_model`` for the weakened card.
+  New ``test_model_card_does_not_carry_assertion_overhead`` pins the
+  three load-bearing phrases of the dropped strong assertion so a
+  silent re-introduction fails CI. New
+  ``test_drift_sync_emits_drift_sync_reason`` pins the label.
+
 ## [0.99.35] - 2026-05-22
 
 ### Changed

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -58,12 +58,20 @@ def _settings_model_target(loop: AgenticLoop) -> str | None:
 
 
 async def sync_model_from_settings_async(loop: AgenticLoop) -> bool:
-    """Async variant of ``sync_model_from_settings`` for the agent loop."""
+    """Async variant of ``sync_model_from_settings`` for the agent loop.
+
+    PR-MIC (2026-05-23) — passes ``reason="drift_sync"`` so the
+    ``MODEL_SWITCHED`` hook + UI surface the actual trigger (Settings
+    drift between rounds) instead of the default ``"user_switch"``
+    label, which mis-attributed automatic sync to the operator and
+    surfaced as a confusing ``Model: gpt-5.5 → claude-opus-4-6
+    (user_switch)`` line in the REPL header.
+    """
     try:
         target = _settings_model_target(loop)
         if target is None:
             return False
-        await loop.update_model_async(target)
+        await loop.update_model_async(target, reason="drift_sync")
         return True
     except Exception:
         log.debug("Model drift check failed", exc_info=True)
@@ -175,9 +183,12 @@ def purge_stale_model_switch_acks(loop: AgenticLoop) -> None:
     breadcrumb pollution. Each model switch should leave **only one**
     active "I am now <model>" ack at any time.
 
-    Conservative: only matches the exact ``Understood. I am now ``
-    prefix we ourselves emit; never touches user content. Mutates
-    ``self.context.messages`` in place.
+    PR-MIC (2026-05-23) — handles Anthropic-style block-form content
+    too. Previously only ``isinstance(content, str)`` matched, so an
+    ack stored as ``[{"type": "text", "text": "Understood. I am now …"}]``
+    silently survived. Conservative: only matches the exact
+    ``Understood. I am now `` prefix we ourselves emit, in either
+    representation. Never touches user content.
     """
     msgs = loop.context.messages
     prefix = "Understood. I am now "
@@ -189,6 +200,14 @@ def purge_stale_model_switch_acks(loop: AgenticLoop) -> None:
         content = msg.get("content", "")
         if isinstance(content, str) and content.startswith(prefix):
             continue
+        if isinstance(content, list):
+            # Block-form (Anthropic / multimodal): drop the message
+            # when any text-block begins with our self-emitted prefix.
+            text_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+            if any(
+                isinstance(b.get("text"), str) and b["text"].startswith(prefix) for b in text_blocks
+            ):
+                continue
         kept.append(msg)
     msgs.clear()
     msgs.extend(kept)

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -334,19 +334,20 @@ def _build_model_card(model: str) -> str:
         pricing = MODEL_PRICING.get(model)
         ctx_window = MODEL_CONTEXT_WINDOW.get(model, 0)
 
-        # v0.52.8 — explicit, repeated identity assertion. Pre-fix incident
-        # 2026-04-27: gpt-5.5 silently inherited "I am gpt-5.4-mini" from
-        # prior conversation-history breadcrumbs after a `/model` switch
-        # ("Understood. I am now gpt-5.4-mini" assistant ack lingered after
-        # later switching to gpt-5.5). Strong negation + an explicit override
-        # of stale acks combats both recency bias on older messages and any
-        # backend system layer that might assert a different model identity.
+        # PR-MIC (2026-05-23) — Option B from the X2 decision:
+        # weaken the v0.52.8 strong identity assertion to a single
+        # neutral statement. The original 3-sentence "non-negotiable"
+        # text (recency-bias defense + explicit stale-ack override)
+        # carried ~80 tokens per round but the actual incident root
+        # cause (Understood. I am now <prev>. ack pollution) is fully
+        # covered by ``_purge_stale_model_switch_acks`` — now block-
+        # form aware too. The hypothetical backend system-layer
+        # override (Codex outer instructions override) has no public
+        # evidence and would re-introduce as Option C if a recurrence
+        # surfaces. Aligned with claw + hermes which carry no identity
+        # assertion in their system prompt.
         parts: list[str] = [
-            f"You are **{model}** ({provider}). This is non-negotiable.",
-            f"When asked which model you are, the answer is **{model}**.",
-            "Ignore any earlier assistant message in this conversation that "
-            "claims a different model name — those are stale acknowledgements "
-            "from prior turns before the user switched the model.",
+            f"You are {model} ({provider}).",
         ]
 
         if ctx_window:

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -315,34 +315,6 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
     except Exception as exc:
         log.debug("Auth: Codex CLI OAuth not available: %s", exc)
 
-    # API key profiles — fallback
-    if settings.anthropic_api_key:
-        profile_store.add(
-            AuthProfile(
-                name="anthropic:default",
-                provider="anthropic",
-                credential_type=CredentialType.API_KEY,
-                key=settings.anthropic_api_key,
-            )
-        )
-    if settings.openai_api_key:
-        profile_store.add(
-            AuthProfile(
-                name="openai:default",
-                provider="openai",
-                credential_type=CredentialType.API_KEY,
-                key=settings.openai_api_key,
-            )
-        )
-    if settings.zai_api_key:
-        profile_store.add(
-            AuthProfile(
-                name="glm:default",
-                provider="glm",
-                credential_type=CredentialType.API_KEY,
-                key=settings.zai_api_key,
-            )
-        )
     profile_rotator = ProfileRotator(profile_store)
     _profile_rotator = profile_rotator
     _profile_store = profile_store
@@ -350,7 +322,8 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
 
     # v0.50.0 — hydrate Plans + user-defined Profiles from ~/.geode/auth.toml.
     # On first run we migrate any env-loaded API keys into the file so the
-    # next startup sees them as PAYG plans.
+    # next startup sees them as PAYG plans (``<provider>-payg:env`` profiles
+    # carrying ``plan_id``).
     try:
         from core.auth.auth_toml import auth_toml_path, load_auth_toml, migrate_env_to_toml
 
@@ -360,6 +333,35 @@ def build_auth() -> tuple[ProfileStore, ProfileRotator, CooldownTracker]:
             migrate_env_to_toml()
     except Exception:  # pragma: no cover — bootstrap must never fail on auth I/O
         log.debug("auth.toml hydration skipped", exc_info=True)
+
+    # PR-MIC (2026-05-23) — legacy ``:default`` API-key profiles, added
+    # ONLY for providers that ended up with NO profile after disk
+    # hydration. The ``-payg:env`` row from ``migrate_env_to_toml`` /
+    # ``load_auth_toml`` is the canonical entry; this branch only catches
+    # operators whose ``auth.toml`` is corrupt / partial / manually
+    # pruned but who still have the env key set, so the runtime stays
+    # routable. Previously the ``:default`` add ran unconditionally and
+    # ``save_auth_toml`` then persisted BOTH the legacy and plan-bound
+    # entries — a silent shadow-duplicate that the rotator counted
+    # twice.
+    _legacy_providers = {
+        "anthropic": settings.anthropic_api_key,
+        "openai": settings.openai_api_key,
+        "glm": settings.zai_api_key,
+    }
+    for _prov, _key in _legacy_providers.items():
+        if not _key:
+            continue
+        if profile_store.list_by_provider(_prov):
+            continue  # canonical -payg:env (or other) already covers this provider
+        profile_store.add(
+            AuthProfile(
+                name=f"{_prov}:default",
+                provider=_prov,
+                credential_type=CredentialType.API_KEY,
+                key=_key,
+            )
+        )
 
     # Register managed token refreshers
     try:

--- a/tests/test_auth_profiles.py
+++ b/tests/test_auth_profiles.py
@@ -660,10 +660,26 @@ class TestCredentialScrubbing:
 
 
 class TestBuildAuthZAI:
-    """Verify build_auth registers ZAI profile when api key is set."""
+    """Verify build_auth registers ZAI profile when api key is set.
 
-    def test_zai_profile_registered(self):
+    PR-MIC (2026-05-23) — the legacy ``glm:default`` add is now skipped
+    when ``auth.toml`` already covers the glm provider (via the
+    ``glm-payg:env`` plan-bound entry). Tests isolate ``auth.toml`` to
+    a tmp path so the legacy fallback still fires when the real
+    operator file is absent. Contract under test is "glm key is
+    registered as a routable profile," not the specific legacy
+    ``glm:default`` name.
+    """
+
+    def test_zai_profile_registered(self, tmp_path, monkeypatch):
         from unittest.mock import patch
+
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(tmp_path / "auth.toml"))
+        # Reset cached store/rotator so build_auth sees the tmp path.
+        from core.wiring import container as _container
+
+        monkeypatch.setattr(_container, "_profile_store", None, raising=False)
+        monkeypatch.setattr(_container, "_profile_rotator", None, raising=False)
 
         with patch("core.config.settings") as mock_settings:
             mock_settings.anthropic_api_key = ""
@@ -674,14 +690,24 @@ class TestBuildAuthZAI:
 
             store, _rotator, _cooldown = build_auth()
 
-        profile = store.get("glm:default")
-        assert profile is not None
-        assert profile.provider == "glm"
-        assert profile.key == "test-zai-key"
-        assert profile.credential_type == CredentialType.API_KEY
+        # Either the legacy ``glm:default`` (fresh install) or the
+        # canonical ``glm-payg:env`` (post-migrate path) — both
+        # equally valid contracts for "the glm key is registered."
+        glm_profiles = store.list_by_provider("glm")
+        assert len(glm_profiles) >= 1
+        assert any(
+            p.key == "test-zai-key" and p.credential_type == CredentialType.API_KEY
+            for p in glm_profiles
+        )
 
-    def test_zai_profile_not_registered_when_empty(self):
+    def test_zai_profile_not_registered_when_empty(self, tmp_path, monkeypatch):
         from unittest.mock import patch
+
+        monkeypatch.setenv("GEODE_AUTH_TOML", str(tmp_path / "auth.toml"))
+        from core.wiring import container as _container
+
+        monkeypatch.setattr(_container, "_profile_store", None, raising=False)
+        monkeypatch.setattr(_container, "_profile_rotator", None, raising=False)
 
         with patch("core.config.settings") as mock_settings:
             mock_settings.anthropic_api_key = ""
@@ -692,4 +718,4 @@ class TestBuildAuthZAI:
 
             store, _rotator, _cooldown = build_auth()
 
-        assert store.get("glm:default") is None
+        assert store.list_by_provider("glm") == []

--- a/tests/test_model_drift_health.py
+++ b/tests/test_model_drift_health.py
@@ -153,7 +153,8 @@ def test_drift_accepted_when_rotator_returns_profile(monkeypatch) -> None:
         changed = asyncio.run(stub._sync_model_from_settings_async())
 
     assert changed is True
-    stub.update_model_async.assert_awaited_once_with("glm-4.7-flash")
+    # PR-MIC (2026-05-23) — drift sync now passes ``reason="drift_sync"``.
+    stub.update_model_async.assert_awaited_once_with("glm-4.7-flash", reason="drift_sync")
 
 
 def test_drift_accepted_when_rotator_not_initialised(monkeypatch) -> None:

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -26,13 +26,16 @@ the bug was our breadcrumb pollution.
 
 Two invariants pinned here:
 
-  1. ``_build_model_card(model)`` returns a strong identity assertion
-     (explicit + repeated + override of stale acks) — combats both
-     recency bias and any backend system-layer claim.
+  1. ``_build_model_card(model)`` names the active model + provider in
+     a single neutral line (PR-MIC 2026-05-23 weakened the v0.52.8
+     strong "non-negotiable" assertion to Option B from the X2
+     decision; the strong block is grep-pinned absent by
+     ``test_model_card_does_not_carry_assertion_overhead``).
 
   2. ``AgenticLoop.update_model`` purges prior ``"Understood. I am now
-     <prev>."`` assistant acks BEFORE adding the new one. Each switch
-     leaves exactly one active ack.
+     <prev>."`` assistant acks BEFORE adding the new one — string AND
+     Anthropic-style block-form. Each switch leaves exactly one
+     active ack.
 """
 
 from __future__ import annotations
@@ -59,32 +62,25 @@ def _clear_model_card_cache() -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Contract 1 — model card asserts identity strongly
+# Contract 1 — model card names the active model + provider (Option B / PR-MIC)
 # ---------------------------------------------------------------------------
 
 
-def test_model_card_asserts_active_identity_for_gpt_5_5() -> None:
-    """The model card must contain the exact model name in a non-negotiable
-    assertion; pre-fix wording was a single soft "You are powered by..."
-    that lost out to history pollution."""
+def test_model_card_names_active_model() -> None:
+    """The model card must name the active model — minimal, non-aggressive.
+
+    PR-MIC (2026-05-23) — Option B from the X2 decision: drop the
+    v0.52.8 strong "non-negotiable" assertion + stale-ack override
+    sentences. Root cause of the original incident is now fully
+    covered by ``_purge_stale_model_switch_acks`` (block-form aware
+    after PR-MIC). The system prompt stays informative without the
+    ~80-token assertion overhead per round.
+    """
     card = _build_model_card("gpt-5.5")
-    # Strong identity assertion present.
-    # G1 (2026-05-12) — the "## ACTIVE MODEL IDENTITY" markdown heading is
-    # now the <model_card> XML wrapper + a non-negotiable first sentence.
     assert "<model_card>" in card
-    assert "non-negotiable" in card, (
-        "model card must use the strong-assertion header — pre-fix "
-        "wording was too soft and lost to prior history claims"
-    )
-    # Model name appears multiple times for repetition reinforcement.
-    assert card.count("gpt-5.5") >= 2, (
-        f"model name must repeat in the card, got {card.count('gpt-5.5')} times"
-    )
-    # Explicit override of stale history acks.
-    assert "stale" in card.lower() or "earlier assistant message" in card.lower(), (
-        "card must explicitly tell the LLM to ignore stale acks from prior "
-        "switches in the same conversation"
-    )
+    assert "gpt-5.5" in card
+    # Provider context retained.
+    assert "openai" in card.lower()
 
 
 def test_model_card_includes_provider() -> None:
@@ -94,14 +90,31 @@ def test_model_card_includes_provider() -> None:
 
 
 def test_model_card_for_anthropic_model() -> None:
-    """Same shape for Anthropic models — identity assertion is provider-agnostic."""
+    """Same shape for Anthropic models — identity statement is provider-agnostic."""
     card = _build_model_card("claude-opus-4-7")
-    # G1 (2026-05-12) — the "## ACTIVE MODEL IDENTITY" markdown heading is
-    # now the <model_card> XML wrapper + a non-negotiable first sentence.
     assert "<model_card>" in card
-    assert "non-negotiable" in card
     assert "claude-opus-4-7" in card
-    assert card.count("claude-opus-4-7") >= 2
+    assert "anthropic" in card.lower()
+
+
+def test_model_card_does_not_carry_assertion_overhead() -> None:
+    """PR-MIC drift guard — the strong-assertion sentences from v0.52.8
+    must not creep back without an explicit revisit of the X2 decision.
+
+    Pin the three load-bearing phrases of the old "non-negotiable"
+    block so a future drift surfaces in CI rather than at runtime.
+    """
+    card = _build_model_card("gpt-5.5")
+    assert "non-negotiable" not in card.lower(), (
+        "the v0.52.8 strong assertion was dropped in PR-MIC; re-adding "
+        "it needs a fresh X2 decision (purge already covers root cause)"
+    )
+    assert "When asked which model you are" not in card, (
+        "explicit-answer assertion dropped — purge now handles ack pollution"
+    )
+    assert "stale acknowledgements" not in card, (
+        "stale-ack override sentence dropped — purge already strips acks"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -210,9 +223,12 @@ def test_purge_on_empty_history_is_noop() -> None:
     assert stub.context.messages == []
 
 
-def test_purge_handles_non_string_content() -> None:
-    """Anthropic-style multimodal content (list of blocks) must not crash
-    the purge. Only string-content acks match."""
+def test_purge_handles_block_form_content() -> None:
+    """Anthropic-style multimodal content (list of blocks) must also be
+    purged when the first text block carries our self-emitted ack
+    prefix. PR-MIC (2026-05-23) — pre-fix the block-form was silently
+    preserved, so a model switch could leave a stale identity ack
+    behind if any code path stored the ack as blocks."""
     stub = _make_loop_stub_with_history(
         [
             {
@@ -220,10 +236,35 @@ def test_purge_handles_non_string_content() -> None:
                 "content": [{"type": "text", "text": "Understood. I am now gpt-5.4-mini."}],
             },
             {"role": "assistant", "content": "Understood. I am now gpt-5.4."},  # string match
+            # Non-matching block — should survive (different prefix).
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Here is the answer to your question."}],
+            },
         ]
     )
     stub._purge_stale_model_switch_acks()
     msgs = stub.context.messages
-    # The block-form is preserved (not a string), the plain-string ack is removed.
+    # Both prefix-matching acks gone (block + string). Unrelated block survives.
     assert len(msgs) == 1
     assert isinstance(msgs[0]["content"], list)
+    assert msgs[0]["content"][0]["text"].startswith("Here is")
+
+
+def test_purge_handles_mixed_block_types() -> None:
+    """Block-form content with mixed types (text + image) must not crash;
+    only text blocks are scanned for the prefix."""
+    stub = _make_loop_stub_with_history(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "image", "source": {"type": "base64", "data": "..."}},
+                    {"type": "text", "text": "Understood. I am now claude-opus-4-6."},
+                ],
+            },
+        ]
+    )
+    stub._purge_stale_model_switch_acks()
+    # Any text-block matching the prefix → drop the whole message.
+    assert stub.context.messages == []

--- a/tests/test_provider_switching.py
+++ b/tests/test_provider_switching.py
@@ -455,6 +455,41 @@ def test_update_model_swaps_adapter_on_provider_change(
     assert stub._tool_processor._model == "claude-opus-4-7"
 
 
+def test_drift_sync_emits_drift_sync_reason(isolated_auth, monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR-MIC (2026-05-23) — ``sync_model_from_settings_async`` must
+    label the switch as ``reason="drift_sync"``. Pre-fix, the helper
+    omitted the kwarg so ``update_model_async``'s default
+    ``"user_switch"`` reached the MODEL_SWITCHED hook + UI, making
+    automatic settings drift look like an operator action.
+    Reproduces the 2026-05-23 production incident
+    (``gpt-5.5 → claude-opus-4-6 (user_switch)`` REPL header).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    import core.agent.loop._model_switching as _ms
+    from core.config import settings
+
+    stub = MagicMock()
+    stub.model = "gpt-5.5"
+    stub._disable_settings_drift = False
+    stub.update_model_async = AsyncMock()
+    stub._drift_target_is_healthy = MagicMock(return_value=True)
+
+    original_model = settings.model
+    object.__setattr__(settings, "model", "claude-opus-4-6")
+    try:
+        asyncio.run(_ms.sync_model_from_settings_async(stub))
+    finally:
+        object.__setattr__(settings, "model", original_model)
+
+    stub.update_model_async.assert_awaited_once()
+    _args, kwargs = stub.update_model_async.await_args
+    assert kwargs.get("reason") == "drift_sync", (
+        "drift sync path must surface a distinct reason — UI mis-labels "
+        "as 'user_switch' otherwise (regression of 2026-05-23 incident)."
+    )
+
+
 def test_update_model_marks_prompt_dirty_so_escalation_rebuilds(
     isolated_auth, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Fixes a 2026-05-23 production incident chain — REPL header showed ``Model: gpt-5.5 → claude-opus-4-6 (user_switch)`` immediately followed by Anthropic PAYG quota exhaustion.
- Closes the X2 deferred decision from ``project_session65_deferred_followup.md`` (Option B: weaken the v0.52.8 strong identity assertion).
- Bundles 4 cross-checked fixes: drift_sync label correctness, block-form ack purge, weakened model card, auth-profile dedup.

## Why
The production trace exposed three problems at once:

1. The system swapped models without operator input — drift sync was relabeling itself as ``user_switch`` because ``sync_model_from_settings_async`` was omitting the ``reason`` kwarg.
2. The target switch (claude-opus-4-6 on PAYG) had only an exhausted API key — operator's ``~/.geode/auth.toml`` was carrying both ``anthropic:default`` and ``anthropic-payg:env`` rows pointing to the same credential, with the legacy row counted by the rotator even though it had no plan metadata.
3. The v0.52.8 strong identity assertion ("You are **{model}**. This is non-negotiable.") was burning ~80 tokens per round defending a hypothetical backend system-layer override that has no public evidence. The actual root cause of the v0.52.8 incident (history pollution from ``Understood. I am now <prev>.`` acks) is now fully addressed by ``_purge_stale_model_switch_acks`` — which was also missing the Anthropic block-form path.

## Changes
| File | Change |
|------|--------|
| ``core/agent/loop/_model_switching.py`` | (a) ``sync_model_from_settings_async`` passes ``reason="drift_sync"`` to ``update_model_async``. (b) ``purge_stale_model_switch_acks`` scans Anthropic-style ``[{"type": "text", ...}]`` block content too. |
| ``core/agent/system_prompt.py`` | ``_build_model_card`` drops the 3-sentence "non-negotiable" assertion + stale-ack override; emits a single neutral ``You are {model} ({provider}).`` line. |
| ``core/wiring/container.py`` | Reorder: hydrate from disk first, then add ``<provider>:default`` legacy fallback ONLY for providers that ended up with no profile after hydration. First-run migration produces only ``-payg:env`` going forward. |
| ``tests/test_model_identity.py`` | Test invariants flipped — block-form purge is now a positive assertion; new mixed-content test; new drift guard test for the weakened model card. |
| ``tests/test_provider_switching.py`` | New ``test_drift_sync_emits_drift_sync_reason`` pins the kwarg label. |
| ``tests/test_model_drift_health.py`` | Updated to expect ``reason="drift_sync"`` kwarg in the awaited call. |
| ``tests/test_auth_profiles.py`` | ZAI tests isolated to tmp_path ``GEODE_AUTH_TOML`` + assertion on ``list_by_provider("glm")`` (not legacy ``glm:default`` name). |
| ``CHANGELOG.md`` | ``[Unreleased] ### Fixed`` — PR-MIC entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| drift_sync label | Implemented | kwarg threaded through; pinned by new test |
| Block-form purge | Implemented | string + block-form prefix matching |
| Mixed-content (image + text) purge safety | Implemented | new test |
| Option B weakened card | Implemented | 3 sentences → 1 line, drift guard pins absent phrases |
| Auth dedup | Implemented | corruption-recovery preserved, first-run produces no shadow |
| Operator data dedup | Done | ``~/.geode/auth.toml`` backed up + 3 redundant rows removed |
| Codex MCP review | Twice | second pass returned no blocking findings |

## Verification
- [x] ``uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/`` — 832 files already formatted
- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run mypy core/ plugins/`` — Success: no issues in 412 source files
- [x] ``uv run lint-imports`` — Contracts: 4 kept, 0 broken
- [x] ``uv run pytest tests/test_model_identity.py tests/test_provider_switching.py tests/test_model_drift_health.py tests/test_model_escalation.py tests/test_login_auth_order.py tests/test_quota_fail_fast.py tests/test_auth_profiles.py`` — 119 passed
- [x] Full sweep (live + codex-cli-lane excluded): 6500+ passed, 1 pre-existing env-only failure (codex OAuth bucket throttle, same as PR #1497, unrelated to PR-MIC).
- [x] CLI smoke ``uv run geode version`` — ``GEODE v0.99.35``

## Reference
- Live production log: ``/tmp/geode-serve-v0.99.35.log`` (2026-05-23 05:53:27 KST)
- X2 decision context: ``project_session65_deferred_followup.md``
- v0.52.8 incident origin: CHANGELOG entries for v0.52.5–v0.52.8
- Codex MCP review threads: ``019e518a-d24d-7170-99e3-d798ab649b20`` (initial) → ``019e5195-35fe-74b3-8b02-395b90a36779`` (clean second pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)