### PR TITLE
PR-1 of petri-schema-v2 — dim_extractor emits sample_count + measurement_modality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,38 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-1 of petri-schema-v2 cascade — ``extract_dim_aggregates``
+  emits ``sample_count`` + ``measurement_modality`` provenance**.
+  Foundation for the baseline.json v2 schema (5-PR cascade documented
+  in ``docs/plans/2026-05-23-petri-schema-v2.md``).
+
+  ``core/audit/dim_extractor.extract_dim_aggregates`` now returns 4
+  top-level keys instead of 2:
+
+  - ``dim_means`` / ``dim_stderr`` (behaviour unchanged).
+  - **``sample_count: dict[str, int]``** — N per dim, lets autoresearch
+    ``_should_promote`` disambiguate ``stderr == 0.0`` between
+    (a) N=1 "no signal" vs (b) N>1 identical values "perfect
+    stability". Two tests pin both cases.
+  - **``measurement_modality: dict[str, str]``** — ``"judge_llm"``
+    (20 rubric dims), ``"token_count"`` (``verbose_padding``),
+    ``"tool_log"`` (``redundant_tool_invocation``). Built from
+    module-level ``_ANALYTICS_MODALITY`` + ``DEFAULT_MODALITY``.
+
+  Empty-result invariant preserved on every graceful-fail path
+  (no inspect_ai, missing file, parse error, empty samples) — all
+  four keys present with empty dicts. Downstream callers
+  (``plugins/petri_audit/cli_audit.py:125`` JSON-print,
+  ``autoresearch/train.py:840`` ``summary.get("dim_means", {})``)
+  are backwards-compatible because they ignore unknown keys.
+
+  Codex MCP reviewed at thread ``019e51d4-95bc-76a1-878c-5e2ce7b75ff2``
+  — no CRITICAL/HIGH; 2 LOWs (docstring nit + missing test for
+  N>1 identical values) addressed in the same commit. 31
+  ``tests/audit/test_dim_extractor.py`` pass.
+
 ### Fixed
 
 - **PR-MIC (Model Identity Cleanup) — drift_sync label + ack purge boost

--- a/core/audit/dim_extractor.py
+++ b/core/audit/dim_extractor.py
@@ -51,6 +51,17 @@ __all__ = [
 ]
 
 
+# PR-1 (2026-05-23) — explicit per-dim measurement modality tag for the
+# baseline.json v2 schema. The 20 judge-scored dims share ``judge_llm``;
+# the two post-judge analytics dims live here so the autoresearch caller
+# can tell them apart without re-deriving from dim name.
+_ANALYTICS_MODALITY: dict[str, str] = {
+    "verbose_padding": "token_count",
+    "redundant_tool_invocation": "tool_log",
+}
+DEFAULT_MODALITY = "judge_llm"
+
+
 def _coerce_float(value: Any) -> float | None:
     """Return ``float(value)`` when value is a real scalar, else ``None``.
 
@@ -265,14 +276,34 @@ def _aggregate(values: list[float]) -> tuple[float, float]:
     return mean, stderr
 
 
-def extract_dim_aggregates(eval_path: Path | str) -> dict[str, dict[str, float]]:
-    """Read the ``.eval`` archive and return per-dim mean + stderr.
+def extract_dim_aggregates(eval_path: Path | str) -> dict[str, Any]:
+    """Read the ``.eval`` archive and return per-dim aggregates + provenance.
 
-    Returns ``{"dim_means": {dim: float, ...}, "dim_stderr": {dim:
-    float, ...}}``. Both dicts have the same key set (every dim with at
-    least one numeric value).
+    Returns a dict with these keys (PR-1, 2026-05-23 — extends the
+    legacy ``{dim_means, dim_stderr}`` shape with two provenance
+    fields the baseline.json v2 schema consumes):
 
-    Returns empty dicts (not raises) when:
+    - ``"dim_means"``: ``{dim: float}`` — mean per dim, raw Petri scale.
+    - ``"dim_stderr"``: ``{dim: float}`` — standard error of the mean.
+      ``0.0`` arises in TWO distinct cases that ``sample_count``
+      disambiguates: (a) ``N == 1`` — variance undefined under ddof=1,
+      so "no stability signal"; (b) ``N > 1 and all values identical``
+      — variance genuinely zero, so "perfect stability". Callers
+      should treat (a) and (b) differently.
+    - ``"sample_count"``: ``{dim: int}`` — number of numeric values that
+      went into ``(mean, stderr)`` for this dim. The disambiguator
+      for the two ``stderr == 0.0`` cases above.
+    - ``"measurement_modality"``: ``{dim: str}`` — provenance of the dim's
+      score. ``"judge_llm"`` for rubric-scored dims, ``"token_count"`` for
+      ``verbose_padding``, ``"tool_log"`` for ``redundant_tool_invocation``.
+      Future analytics dims would default to ``"judge_llm"`` — guard
+      via ``_ANALYTICS_MODALITY`` when adding a new analytics source.
+
+    All four dicts have the same key set (every dim with at least one
+    numeric value).
+
+    Returns dicts with empty ``dim_means`` / ``dim_stderr`` / ``sample_count``
+    / ``measurement_modality`` (not raises) when:
 
     - ``inspect_ai`` is not installed (default ``uv sync`` env — the
       ``[audit]`` extra is opt-in).
@@ -282,22 +313,28 @@ def extract_dim_aggregates(eval_path: Path | str) -> dict[str, dict[str, float]]
     Failures during read are logged at WARNING and swallowed — the
     self-improving-loop is best-effort scaffolding, not a blocker.
     """
+    empty: dict[str, Any] = {
+        "dim_means": {},
+        "dim_stderr": {},
+        "sample_count": {},
+        "measurement_modality": {},
+    }
     try:
         from inspect_ai.log import read_eval_log
     except ImportError:
         log.debug("dim_extractor: inspect_ai not installed — no-op")
-        return {"dim_means": {}, "dim_stderr": {}}
+        return empty
 
     path = Path(eval_path).expanduser()
     if not path.is_file():
         log.warning("dim_extractor: %s does not exist", path)
-        return {"dim_means": {}, "dim_stderr": {}}
+        return empty
 
     try:
         elog = read_eval_log(str(path))
     except Exception:
         log.warning("dim_extractor: failed to read %s", path, exc_info=True)
-        return {"dim_means": {}, "dim_stderr": {}}
+        return empty
 
     samples = getattr(elog, "samples", None)
     per_dim = _walk_dim_values(samples)
@@ -312,10 +349,14 @@ def extract_dim_aggregates(eval_path: Path | str) -> dict[str, dict[str, float]]
 
     dim_means: dict[str, float] = {}
     dim_stderr: dict[str, float] = {}
+    sample_count: dict[str, int] = {}
+    measurement_modality: dict[str, str] = {}
     for dim, vals in per_dim.items():
         mean, stderr = _aggregate(vals)
         dim_means[dim] = mean
         dim_stderr[dim] = stderr
+        sample_count[dim] = len(vals)
+        measurement_modality[dim] = _ANALYTICS_MODALITY.get(dim, DEFAULT_MODALITY)
 
     log.info(
         "dim_extractor: aggregated %d dim(s) across %d sample(s) from %s",
@@ -323,7 +364,12 @@ def extract_dim_aggregates(eval_path: Path | str) -> dict[str, dict[str, float]]
         len(samples or []),
         path.name,
     )
-    return {"dim_means": dim_means, "dim_stderr": dim_stderr}
+    return {
+        "dim_means": dim_means,
+        "dim_stderr": dim_stderr,
+        "sample_count": sample_count,
+        "measurement_modality": measurement_modality,
+    }
 
 
 def _walk_evidence(samples: Any) -> dict[str, list[dict[str, Any]]]:

--- a/docs/plans/2026-05-23-petri-schema-v2.md
+++ b/docs/plans/2026-05-23-petri-schema-v2.md
@@ -1,0 +1,173 @@
+# Petri Schema v2 + autoresearch GAP fix — SOT
+
+**Date**: 2026-05-23
+**Driver**: Session 67 (post v0.99.36 release)
+**Owner**: human + claude
+**Status**: PR-1 in flight
+
+## 1. Why
+
+2026-05-23 self-improving loop audit (`session_session67_audit` 회차) 가 autoresearch
+포팅 (Karpathy `~/workspace/autoresearch` MIT 2026-03 → GEODE `autoresearch/`) 의
+**여러 invariant 손실** + **Petri 주입 파이프라인의 측정 결함** 을 surface 함. 핵심:
+
+- 21 autoresearch run 중 real-mode 4건에서 **3건이 "bootstrap"** 로 promote.
+  실제로는 baseline.json 이 존재하는데 axis_coverage 체크에서 fail 하는 의심.
+- 모든 dim 의 `stderr=0.0` — N=1 single-sample 의 결과인데 `_should_promote`
+  rule 3 의 margin 가드가 `max(stderr, 0.05)` floor 만 적용 → defense 무력.
+- `dim_extractor` 가 dim 별 `sample_count` 를 emit 하지 않아 N=1 vs N=10 의
+  stderr=0 차이를 운영자/promotion 룰이 disambiguate 불가.
+- `compute_dim_scores` 의 "missing dim = best case (1.0)" semantic 이 Goodhart
+  risk — mutation 이 측정 자체를 회피하도록 진화 가능.
+- baseline.json schema 가 raw Petri scale (1-10) 인지 normalized fitness (0-1)
+  인지 stamp 없음 — 운영자 인지 부담.
+- `verbose_padding` / `redundant_tool_invocation` 은 judge LLM 안 거치고 token
+  count / tool log 에서 derived analytics 인데 동일 weight (0.0333) 받음 —
+  measurement modality 가 다른 dim 이 균일 취급.
+
+원본 audit 결과 — Karpathy invariant 대비 손실:
+- L1 — Git as Optimizer 깨짐 (mutations.jsonl gitignored, PR-G5b #1350 사고)
+- L2 — Single-file constraint 5 surface 로 분산
+- L3 — 신호 분해능 폭발 + stderr=0
+- L4 — schema 단위 인지 부담 (raw vs normalized layer 불명시)
+- L5 — 4-axis weight 정의됐으나 ux/admire/bench wiring 불완전
+- L7 — bootstrap rule 항상 fire
+- L8 — agent 가 train.py 자체 변이 가능 (safety boundary 부재)
+
+Petri 측 추가 GAP:
+- P1 — `seed_limit=2` × `statistics.stdev` ddof=1 → stderr 폭발
+- P2 — N=1 → stderr=0 의 이중 해석 ("no signal" vs "perfect")
+- P3 — judge vs analytics dim 의 dual lifecycle 가 fitness aggregate 에서 균일 처리
+- P4 — missing dim = best-case 가 Goodhart 위험
+- P5 — `_should_promote` margin 이 N 정보 없이 stderr 만 봄
+- P6 — baseline.json 에 `.eval` archive pointer 부재 → replay 불가
+
+## 2. Decision — Schema v2 + 5-PR cascade
+
+baseline.json schema 를 4-layer 분리 + 메타데이터 보강 형태로 확장. 후방
+호환성은 `schema_version` 으로 분기. v1 baseline 은 load 시 raw 만 채우고
+나머지 namespace 는 default. 첫 v2 promote 시점부터 새 schema 로 write.
+
+### 2.1 Schema v2 (target)
+
+```json
+{
+  "schema_version": 2,
+  "session_id": "<run_id>",
+  "gen_tag": "<운영자 의미 tag>",
+  "commit": "<git sha>",
+  "ts_utc": "<ISO 8601>",
+
+  "raw": {
+    "dim_means":   {dim: float (1-10)},
+    "dim_stderr":  {dim: float},
+    "sample_count": {dim: int},           // P1+P2+P5 fix
+    "rubric_version": "v3-22dim-PR0",
+    "eval_archive": "<path>",
+    "eval_archive_sha256": "<hex>",       // P6 fix
+    "measurement_modality": {             // P3 fix
+      "<dim>": "judge_llm" | "token_count" | "tool_log"
+    }
+  },
+
+  "normalized": {
+    "dim_scores": {dim: float (0-1)},
+    "stability_score": float,
+    "missing_dims": [dim, ...],           // P4 fix
+    "stability_axis_n_eligible": int      // P2 fix
+  },
+
+  "axes": {
+    "ux_means":     {success_rate, token_cost_norm, revert_ratio_norm, latency_norm} | null,
+    "admire_means": {pairwise_win_rate, human_calibration_corr} | null,
+    "bench_means":  {<7 fields>} | null
+  },
+
+  "fitness": {
+    "value": float,
+    "formula_version": "compute_fitness_3axis_v2",
+    "weights": {dim_part, ux_part, admire_part, bench_part},
+    "components": {critical_min, auxiliary_mean, info_mean, stability_axis}
+  },
+
+  "audit": {
+    "audit_seconds": float,
+    "target_model": str, "judge_model": str, "auditor_model": str,
+    "seed_limit": int, "dim_set": str, "max_turns": int,
+    "usd_spent": float                    // G7 fix
+  },
+
+  "promotion": {
+    "from_session": "<prev_id>" | null,
+    "reason": "bootstrap" | "delta_improvement" | "manual_force",
+    "delta_fitness": float | null,
+    "margin_required": float,
+    "margin_realized": float | null
+  }
+}
+```
+
+### 2.2 PR cascade (실행 순서)
+
+| PR | 범위 | Prereq | 영향 |
+|----|------|--------|------|
+| **PR-1** | `dim_extractor.extract_dim_aggregates` 가 `sample_count` per-dim + `measurement_modality` 태그도 emit | — | API 확장만, behavior 무변화 |
+| **PR-2** | `_write_baseline` schema_version=2 + 4-layer namespace 분리 | PR-1 | baseline.json 신규 형식, `load_baseline` v1/v2 분기 |
+| **PR-3** | `_should_promote` 의 N=1 분기 (sample_count ≤ 1 dim 의 margin 강화) | PR-1+PR-2 | promote 결정 룰 강화 |
+| **PR-4** | `compute_dim_scores` 의 `missing_dims` 명시 + emit | PR-1 | results.tsv/jsonl 정합 |
+| **PR-5** | results.tsv / results.jsonl row 가 새 schema 와 정합 | PR-2+PR-4 | reporting 일관성 |
+
+PR-1 부터 순차 진행. 각 PR 의 verification 단계는 `feedback_codex_mcp_verification`
+에 따라 Codex MCP read-only review 필수.
+
+## 3. Workflow (per PR)
+
+각 PR 동일 사이클:
+
+1. Worktree + branch (필요시)
+2. Code edit (single-purpose, P10 Simplicity)
+3. Local gates:
+   - `uv run ruff check core/ tests/ plugins/`
+   - `uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/`
+   - `uv run mypy core/ plugins/`
+   - `uv run lint-imports`
+   - `uv run pytest <impacted files>` (광범위 sweep 은 PR-5 끝나고 한 번)
+4. **Codex MCP review** (read-only, CRITICAL/HIGH/MEDIUM 카테고리별)
+5. Codex 결과 반영 → 게이트 재실행
+6. CHANGELOG `[Unreleased]` 갱신
+7. Commit + push
+8. PR develop ← feature, HEREDOC body, CI watch
+9. CI 8/8 green 확인 후 사용자 GO → merge
+
+## 4. Non-goals
+
+- gen-0 baseline 실측 (Anthropic credit 차단 별도 결정)
+- LaneQueue / Hermes / Tier 3 LaTeX (out-of-scope, 별도 backlog)
+- agent 의 train.py 자체 변이 권한 가드 (L8) — 이번 sprint 의 schema scope
+  와 분리, 다음 sprint 후보
+
+## 5. Verification artifacts
+
+- 각 PR 의 Codex MCP review thread ID 를 commit message + PR body 에 기록
+- baseline.json migration smoke: 기존 v1 파일 두고 `load_baseline` 호출 시 raw
+  layer 만 populated 인지 확인하는 단위 테스트
+- `_write_baseline` 호출 시 새 schema 가 형식 invariant 만족하는지 (필수 namespace,
+  optional axes null 처리) 확인하는 단위 테스트
+
+## 6. SOT location
+
+- 이 문서: `docs/plans/2026-05-23-petri-schema-v2.md`
+- Schema v2 reference impl: `autoresearch/train.py:_write_baseline` (PR-2 적용 후)
+- 측정 source: `core/audit/dim_extractor.py` (PR-1 적용 후)
+- Rollback path: revert PR-2 first, then PR-1 (PR-3/4/5 는 PR-1+PR-2 위에 lifted)
+
+## 7. 관련 메모리 + 사고 기록
+
+- `[[research_karpathy_autoresearch_agenthub]]` — 원본 디자인 reference
+- `[[project_session60_handoff]]` — autoresearch fork + wrapper-override hook
+- CLAUDE.md DONT 테이블:
+  - 2026-05-20 PR-G5b #1350 (CHANGELOG/PR-body parity, mutations.jsonl gitignored)
+  - 2026-05-20 PR-G2 #1346 (reader-assumption drift, evidence persistence)
+  - 2026-05-20 PR-G3 #1347 (conditional read parity, baseline auto branch)
+- `[[feedback_codex_mcp_verification]]` — 각 PR 의 verify 게이트
+- `[[feedback_changelog_implementation_parity]]` — verb/adjective grep-provable

--- a/tests/audit/test_dim_extractor.py
+++ b/tests/audit/test_dim_extractor.py
@@ -129,7 +129,12 @@ class TestEdgeCases:
 
     def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
         result = extract_dim_aggregates(tmp_path / "does_not_exist.eval")
-        assert result == {"dim_means": {}, "dim_stderr": {}}
+        assert result == {
+            "dim_means": {},
+            "dim_stderr": {},
+            "sample_count": {},
+            "measurement_modality": {},
+        }
 
     def test_empty_samples_returns_empty(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -139,7 +144,12 @@ class TestEdgeCases:
         _patch_read(monkeypatch, FakeEvalLog(samples=[]))
 
         result = extract_dim_aggregates(path)
-        assert result == {"dim_means": {}, "dim_stderr": {}}
+        assert result == {
+            "dim_means": {},
+            "dim_stderr": {},
+            "sample_count": {},
+            "measurement_modality": {},
+        }
 
     def test_read_failure_swallowed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """A broken ``.eval`` must not propagate exceptions — the
@@ -153,7 +163,12 @@ class TestEdgeCases:
         monkeypatch.setattr("inspect_ai.log.read_eval_log", boom)
 
         result = extract_dim_aggregates(path)
-        assert result == {"dim_means": {}, "dim_stderr": {}}
+        assert result == {
+            "dim_means": {},
+            "dim_stderr": {},
+            "sample_count": {},
+            "measurement_modality": {},
+        }
 
     def test_non_numeric_values_skipped(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -287,6 +302,151 @@ def test_compute_redundant_tool_invocation_handles_unserializable_args() -> None
     ]
     # Falls back to repr; same repr → still detected as duplicate
     assert compute_redundant_tool_invocation(calls) >= 4.0
+
+
+# ---------------------------------------------------------------------------
+# PR-1 (2026-05-23) — sample_count + measurement_modality provenance
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    """PR-1 adds two provenance dicts so the baseline.json v2 schema can
+    distinguish single-sample N=1 stderr=0 ("no signal") from
+    multi-sample stderr=0 ("perfect stability"), and tell judge-LLM
+    dims apart from post-judge analytics dims (token_count / tool_log).
+    """
+
+    def test_sample_count_matches_value_count(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``sample_count[dim]`` must equal the number of numeric values
+        that went into the aggregation for that dim."""
+        path = tmp_path / "fake.eval"
+        path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 2.0, "dim_b": 1.0})}),
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 4.0, "dim_b": 5.0})}),
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 6.0})}),
+            ]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        result = extract_dim_aggregates(path)
+        assert result["sample_count"]["dim_a"] == 3
+        assert result["sample_count"]["dim_b"] == 2
+
+    def test_n1_sample_count_disambiguates_stderr_zero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """N=1 stderr=0 must surface as ``sample_count=1`` so the
+        autoresearch ``_should_promote`` rule can treat it as "no
+        stability signal" rather than "perfect stability"."""
+        path = tmp_path / "fake.eval"
+        path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[FakeSample(scores={"judge": FakeScore(value={"dim_a": 3.0})})]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        result = extract_dim_aggregates(path)
+        assert result["sample_count"]["dim_a"] == 1
+        assert result["dim_stderr"]["dim_a"] == 0.0  # invariant unchanged
+
+    def test_judge_dim_modality_is_judge_llm(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A rubric-scored dim must carry the ``judge_llm`` modality."""
+        path = tmp_path / "fake.eval"
+        path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[FakeSample(scores={"judge": FakeScore(value={"broken_tool_use": 4.0})})]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        result = extract_dim_aggregates(path)
+        assert result["measurement_modality"]["broken_tool_use"] == "judge_llm"
+
+    def test_analytics_dim_modalities_tagged_distinctly(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``verbose_padding`` → ``token_count``;
+        ``redundant_tool_invocation`` → ``tool_log``. Both differ from
+        the judge-LLM default so the autoresearch fitness aggregator
+        can weight them differently if needed."""
+        path = tmp_path / "fake.eval"
+        path.write_bytes(b"placeholder")
+
+        # Build a sample whose messages carry assistant-role usage +
+        # duplicate tool calls so both analytics dims fire.
+        class _Usage:
+            output_tokens = 4000  # well above typical median
+
+        class _Msg:
+            role = "assistant"
+            usage = _Usage()
+            tool_calls = [
+                {"function": {"name": "shell", "arguments": '{"cmd": "ls"}'}},
+                {"function": {"name": "shell", "arguments": '{"cmd": "ls"}'}},
+            ]
+
+        class _SampleWithUsage:
+            scores = {"judge": FakeScore(value={"input_hallucination": 2.0})}
+            messages = [_Msg()]
+
+        fake_log = FakeEvalLog(samples=[_SampleWithUsage()])
+        _patch_read(monkeypatch, fake_log)
+
+        result = extract_dim_aggregates(path)
+        modality = result["measurement_modality"]
+        assert modality.get("input_hallucination") == "judge_llm"
+        assert modality.get("verbose_padding") == "token_count"
+        assert modality.get("redundant_tool_invocation") == "tool_log"
+
+    def test_n_gt_1_identical_values_stderr_zero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``stderr == 0.0`` also arises when ``N > 1`` and all sample
+        values are identical (variance is genuinely zero, not
+        "undefined"). ``sample_count > 1`` is the disambiguator from
+        the ``N == 1`` case."""
+        path = tmp_path / "fake.eval"
+        path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 3.0})}),
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 3.0})}),
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 3.0})}),
+            ]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        result = extract_dim_aggregates(path)
+        assert result["dim_stderr"]["dim_a"] == 0.0
+        assert result["sample_count"]["dim_a"] == 3  # NOT 1 — perfect stability, not no-signal
+
+    def test_all_four_dicts_share_key_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``dim_means`` / ``dim_stderr`` / ``sample_count`` /
+        ``measurement_modality`` must all carry the same key set —
+        downstream baseline.json v2 build path zips them together
+        and a key mismatch would silently drop dims."""
+        path = tmp_path / "fake.eval"
+        path.write_bytes(b"placeholder")
+        fake_log = FakeEvalLog(
+            samples=[
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 2.0, "dim_b": 7.0})}),
+                FakeSample(scores={"judge": FakeScore(value={"dim_a": 4.0, "dim_b": 5.0})}),
+            ]
+        )
+        _patch_read(monkeypatch, fake_log)
+
+        result = extract_dim_aggregates(path)
+        means_keys = set(result["dim_means"])
+        assert set(result["dim_stderr"]) == means_keys
+        assert set(result["sample_count"]) == means_keys
+        assert set(result["measurement_modality"]) == means_keys
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Foundation PR (1 of 5) for the **baseline.json v2 schema cascade** documented in ``docs/plans/2026-05-23-petri-schema-v2.md`` (SOT).
- ``extract_dim_aggregates`` returns 4 keys instead of 2 — adds ``sample_count`` (per-dim N) and ``measurement_modality`` (judge_llm / token_count / tool_log) provenance dicts.
- Closes the Petri-side GAPs (P1/P2/P3/P5) where ``stderr == 0.0`` was ambiguous between "N=1 no signal" and "perfect stability", and where the two analytics dims (``verbose_padding``, ``redundant_tool_invocation``) were indistinguishable from judge-scored dims in the aggregate output.

## Why
2026-05-23 self-improving loop audit (Session 67) surfaced that ``autoresearch/state/baseline.json`` was carrying ``stderr=0.0`` for 22/24 dims with no way for ``autoresearch._should_promote`` to tell apart single-sample N=1 measurements from genuinely stable multi-sample measurements. Same audit found that two post-judge analytics dims (token-count derived ``verbose_padding`` and tool-log derived ``redundant_tool_invocation``) were aggregated alongside 20 judge-LLM rubric dims with identical schema, blocking the planned baseline.json v2 schema's per-modality handling.

This PR is the API foundation — no behaviour change to downstream callers, only new keys in the return dict that future PRs (PR-2 writes new baseline.json schema, PR-3 strengthens promotion margin, etc.) will consume.

## Changes
| File | Change |
|------|--------|
| ``core/audit/dim_extractor.py`` | Add ``_ANALYTICS_MODALITY`` map + ``DEFAULT_MODALITY``. ``extract_dim_aggregates`` populates ``sample_count`` per dim (= ``len(values)``) and ``measurement_modality`` per dim (lookup in map, default ``"judge_llm"``). Return type ``dict[str, dict[str, float]]`` → ``dict[str, Any]``. Empty-result invariant: all 4 keys present with empty dicts on every graceful-fail path. |
| ``tests/audit/test_dim_extractor.py`` | 3 existing empty-equality assertions updated to expect all 4 keys. New ``TestProvenance`` class with 6 tests: sample_count parity, N=1 disambiguation, N>1 identical-values disambiguation, judge_llm modality, analytics modality (token_count + tool_log) tagged distinctly, all-4-dicts-share-key-set invariant. |
| ``docs/plans/2026-05-23-petri-schema-v2.md`` | **NEW** — SOT plan doc for the 5-PR cascade. Section 1 (Why) catalogs L1-L9 Karpathy-port losses + P1-P6 Petri-pipeline gaps. Section 2 (Decision) specifies the schema v2 layout + PR cascade. Section 3 (Workflow) defines per-PR verification (including Codex MCP). |
| ``CHANGELOG.md`` | ``[Unreleased] ### Added`` — PR-1 entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ``sample_count`` per dim | Implemented | line 343 of dim_extractor.py |
| ``measurement_modality`` per dim | Implemented | line 344, default ``judge_llm`` |
| N=1 vs N>1 identical-values stderr=0 disambiguation | Pinned by 2 tests | ``test_n1_sample_count_disambiguates_stderr_zero`` + ``test_n_gt_1_identical_values_stderr_zero`` |
| Backwards-compatible downstream emit | Verified | ``plugins/petri_audit/cli_audit.py:125`` JSON-prints; ``autoresearch/train.py:840`` ``.get("dim_means", {})`` |
| 4-dict key-set invariant | Pinned by test | ``test_all_four_dicts_share_key_set`` |

## Verification
- [x] ``uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/`` — 832 files already formatted
- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run mypy core/ plugins/`` (CI sync mode, no audit extra) — Success: 412 source files
- [x] ``uv run lint-imports`` — Contracts: 4 kept, 0 broken
- [x] ``uv run pytest tests/audit/test_dim_extractor.py`` — 31 passed (was 25; +6 new)
- [x] ``uv run pytest tests/plugins/petri_audit/`` — 686 passed (no downstream regression)
- [x] Codex MCP cross-review at thread ``019e51d4-95bc-76a1-878c-5e2ce7b75ff2`` — 0 CRITICAL / 0 HIGH / 0 MEDIUM / 2 LOW addressed in this commit

## Reference
- SOT plan: ``docs/plans/2026-05-23-petri-schema-v2.md``
- Karpathy original: ``~/workspace/autoresearch`` (MIT 2026-03)
- Codex MCP thread: ``019e51d4-95bc-76a1-878c-5e2ce7b75ff2``
- Related memories: ``research_karpathy_autoresearch_agenthub``, ``project_session60_handoff``

🤖 Generated with [Claude Code](https://claude.com/claude-code)