### PR TITLE
PR-4 + PR-5 of petri-schema-v2 — compute_missing_dims + results.jsonl provenance (cascade close)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,59 @@ functional change.
 
 ### Added
 
+- **PR-5 of petri-schema-v2 cascade — ``results.jsonl`` PR-1/PR-4
+  provenance + Goodhart surface threading**. Final step of the 5-PR
+  cascade. Surfaces the per-dim provenance (sample_count,
+  measurement_modality), the Goodhart-risk surface (missing_dims),
+  and the eval_archive symlink target into ``results.jsonl`` so
+  cross-run analysis can disambiguate real measurements from
+  default-filled fallbacks without joining against baseline.json or
+  the journal.
+
+  **What changed in ``autoresearch/train.py``**:
+  - ``format_results_jsonl_row`` gains 4 new optional kwargs:
+    ``sample_count`` / ``measurement_modality`` / ``missing_dims`` /
+    ``eval_archive``. When supplied they emit into the JSONL row.
+    When omitted, defaults populate the schema slots (zeros / empty
+    strings / ``[]`` / ``null``) so downstream parsers see a stable
+    column set.
+  - The two provenance dicts (sample_count, measurement_modality)
+    are written over the full ``AXIS_TIERS`` universe so they zip
+    1-to-1 with ``dim_means`` / ``dim_stderr``.
+  - ``main()`` threads the kwargs from PR-1's ``run_audit`` return
+    (sample_count + measurement_modality), PR-4's
+    ``compute_missing_dims(dim_means)``, and
+    ``_resolve_eval_archive_path()``.
+
+  **Scope narrowing — ``results.tsv`` intentionally unchanged**:
+  the SOT plan PR-5 row mentioned both TSV and JSONL, but Codex MCP
+  review of PR-2 already discouraged TSV column expansion (downstream
+  parsers depend on the 12-column shape). JSONL alone is sufficient
+  for the cross-run analysis goal; TSV stays as the row-grep summary.
+
+  **``baseline.json normalized`` namespace** — the SOT plan also
+  hinted at extending the v2 baseline with a ``normalized.missing_dims``
+  sink. That's deferred — the baseline-side surface is observability
+  only (the auto-promote gate already runs off ``raw.sample_count``
+  via PR-3), and the journal + JSONL already carry the missing list.
+
+  **Tests added** (``tests/test_autoresearch_train.py``):
+  - ``test_results_jsonl_row_emits_pr5_provenance_when_supplied`` —
+    all 4 new fields present + dim universe parity
+  - ``test_results_jsonl_row_pr5_defaults_when_provenance_absent`` —
+    omitted kwargs → stable default values
+  - ``test_results_jsonl_row_pr5_handles_partial_provenance`` —
+    partial sample_count / modality → defaults for absent dims
+  - ``test_results_jsonl_round_trip`` updated to assert the new
+    schema keys so a future regression breaks at write time.
+
+  Codex MCP reviewed at thread ``019e521d-5d1c-70d3-9d83-bb35aa896bb2``
+  — 0 CRITICAL / 0 HIGH / 1 MEDIUM (missing CHANGELOG entry, fixed
+  here) / 2 LOW (round-trip test schema pin + missing_dims sort
+  contract docstring) addressed in this commit.
+
+  539 ``test_autoresearch_train.py`` + impacted surface pass.
+
 - **PR-4 of petri-schema-v2 cascade — ``compute_missing_dims``
   Goodhart-risk surface**. Fourth step of the 5-PR cascade. Surfaces
   the silent ``compute_dim_scores`` "missing dim = best case (1.0)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,48 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **PR-4 of petri-schema-v2 cascade — ``compute_missing_dims``
+  Goodhart-risk surface**. Fourth step of the 5-PR cascade. Surfaces
+  the silent ``compute_dim_scores`` "missing dim = best case (1.0)"
+  fallback that would let a mutation suppressing dim measurement
+  inflate fitness without a real improvement.
+
+  **What changed**:
+  - New ``autoresearch/train.py::compute_missing_dims(dim_means) ->
+    list[str]`` — sorted lexicographic list of ``AXIS_TIERS`` dims
+    absent from ``dim_means``. Empty when all dims present.
+  - ``main()`` calls it after ``compute_dim_scores`` and emits the
+    result in the journal ``per_dim_scores`` event payload alongside
+    ``dim_scores`` (new ``missing_dims`` key).
+  - ``compute_dim_scores`` docstring updated to reference the surface
+    (behaviour unchanged — observability only).
+
+  **Goodhart vector**: a mutation that drops a dim from the audit's
+  emit would silently score 1.0 on that dim (fitness ↑) without
+  improving anything. The journal now shows which dims fell back so
+  the operator can spot the pattern across runs.
+
+  **Tests added** (``tests/test_autoresearch_train.py``):
+  - ``test_compute_missing_dims_empty_when_all_present``
+  - ``test_compute_missing_dims_lists_absent_dims_sorted``
+  - ``test_compute_missing_dims_handles_empty_input``
+  - ``test_compute_missing_dims_ignores_extra_dims_outside_axis_tiers``
+  - ``test_main_dry_run_emits_full_p0b_event_sequence`` extended to
+    pin the actual emitted list against
+    ``compute_missing_dims(dim_means)`` so a future literal /
+    hardcoded payload would fail.
+
+  99 ``test_autoresearch_train.py`` + 536 across impacted surface
+  pass. Codex MCP reviewed at thread
+  ``019e520f-7556-71e1-91ed-bd49ebf8ee76`` — 0 CRITICAL / 0 HIGH /
+  0 MEDIUM / 2 LOW (docstring overclaim + thin integration assertion)
+  addressed in this commit.
+
+  PR-5 will extend ``missing_dims`` persistence into ``baseline.json``'s
+  ``normalized`` namespace + ``results.jsonl`` for cross-run analysis.
+
 ### Changed
 
 - **Release flow rotation — eliminates backmerge friction**. Pre-PR the

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -1222,10 +1222,20 @@ def format_results_jsonl_row(
     verdict: str,
     description: str,
     baseline_active: bool,
+    sample_count: dict[str, int] | None = None,
+    measurement_modality: dict[str, str] | None = None,
+    missing_dims: list[str] | None = None,
+    eval_archive: str | None = None,
 ) -> str:
     """Render one results.jsonl line — full per-dim raw signal.
 
     P1a adds ``session_id`` + ``gen_tag`` as top-level keys.
+
+    PR-5 of petri-schema-v2 (2026-05-23) — adds the 4 provenance
+    fields that landed in baseline.json v2 (PR-2) + the
+    ``missing_dims`` Goodhart surface (PR-4) so cross-run analysis
+    can tell apart real measurements from default-filled fallbacks
+    without joining against baseline.json or the journal.
 
     Schema (JSON object on one line)::
 
@@ -1234,6 +1244,10 @@ def format_results_jsonl_row(
          "dim_means": {...20 entries...},
          "dim_stderr": {...20 entries...},
          "dim_scores": {...20 + 'stability'...},
+         "sample_count": {...20 entries...},          # PR-5
+         "measurement_modality": {...20 entries...},  # PR-5
+         "missing_dims": [...],                       # PR-5 (sorted)
+         "eval_archive": "<path>" | null,             # PR-5
          "verdict": "keep", "description": "...",
          "baseline_active": true}
 
@@ -1246,6 +1260,11 @@ def format_results_jsonl_row(
     # cannot silently drop fields).
     scores_full = {d: round(dim_scores.get(d, 0.0), 4) for d in AXIS_TIERS}
     scores_full["stability"] = round(dim_scores.get("stability", STABILITY_FALLBACK), 4)
+    # PR-5 — emit the 3 provenance dicts with the same dim universe
+    # so a downstream parser can zip them against ``dim_means``. Missing
+    # provenance (dry-run, pre-PR-1 build) → 0 count + empty modality.
+    sample_count_full = {d: int((sample_count or {}).get(d, 0)) for d in AXIS_TIERS}
+    modality_full = {d: str((measurement_modality or {}).get(d, "")) for d in AXIS_TIERS}
     payload = {
         "session_id": session_id,
         "gen_tag": gen_tag,
@@ -1254,6 +1273,13 @@ def format_results_jsonl_row(
         "dim_means": {d: round(dim_means.get(d, 0.0), 4) for d in AXIS_TIERS},
         "dim_stderr": {d: round(dim_stderr.get(d, 0.0), 4) for d in AXIS_TIERS},
         "dim_scores": scores_full,
+        "sample_count": sample_count_full,
+        "measurement_modality": modality_full,
+        # PR-5 — sort defensively. ``compute_missing_dims`` already
+        # returns a sorted list, but a misbehaving caller passing an
+        # unsorted list would break cross-run diff stability.
+        "missing_dims": sorted(missing_dims or []),
+        "eval_archive": eval_archive,
         "verdict": verdict,
         "description": description.replace("\n", " ").strip(),
         "baseline_active": baseline_active,
@@ -1891,6 +1917,15 @@ def main() -> int:
             verdict=verdict,
             description=description,
             baseline_active=baseline_means is not None,
+            # PR-5 of petri-schema-v2 (2026-05-23) — thread the
+            # provenance from PR-1 (run_audit return) + PR-4
+            # (compute_missing_dims) into the JSONL row so cross-run
+            # analysis can disambiguate measurements without
+            # joining against baseline.json or the journal.
+            sample_count=sample_count,
+            measurement_modality=measurement_modality,
+            missing_dims=missing_dims,
+            eval_archive=_resolve_eval_archive_path(),
         )
     )
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -942,6 +942,13 @@ def compute_dim_scores(
     Includes a synthetic ``"stability"`` key (derived from dim_stderr).
     Info-only dims are scored but their weight in fitness is 0; the
     score is still recorded for results.jsonl.
+
+    PR-4 of petri-schema-v2 (2026-05-23) — dims absent from ``dim_means``
+    silently default to 0.0 mean → score 1.0 ("missing dim = best case").
+    That semantic creates a Goodhart vector: a mutation that suppresses
+    measurement of a dim would silently bump fitness. Use
+    :func:`compute_missing_dims` to surface which dims are running on
+    that fallback so the journal + baseline.json can record them.
     """
     out: dict[str, float] = {
         dim: _dim_score(dim_means.get(dim, 0.0))
@@ -952,6 +959,28 @@ def compute_dim_scores(
     }
     out["stability"] = _stability_score(dim_stderr)
     return out
+
+
+def compute_missing_dims(dim_means: dict[str, float]) -> list[str]:
+    """Return dims in ``AXIS_TIERS`` absent from ``dim_means``.
+
+    PR-4 of petri-schema-v2 (2026-05-23) — surfaces the Goodhart-risk
+    fallback path in :func:`compute_dim_scores`. A dim missing from
+    the audit's emit silently scores 1.0 (best case), inflating
+    fitness. The journal ``per_dim_scores`` event records this list
+    so the operator can spot mutations that suppress dim measurement
+    instead of improving it. Additional sinks (baseline.json's
+    ``normalized`` namespace, ``results.jsonl``) land in PR-5; for now
+    this PR is observability-only and the gate logic in
+    :func:`compute_fitness` is unchanged — the surface alone lets the
+    operator triage without a behaviour change.
+
+    Sorted lexicographically so the list is stable across reorderings
+    of ``AXIS_TIERS`` (diff-friendly for cross-run comparison).
+
+    Returns ``[]`` when all ``AXIS_TIERS`` dims are present.
+    """
+    return sorted(dim for dim in AXIS_TIERS if dim not in dim_means)
 
 
 def compute_fitness(
@@ -1792,6 +1821,10 @@ def main() -> int:
         },
     )
     dim_scores = compute_dim_scores(dim_means, dim_stderr)
+    # PR-4 of petri-schema-v2 (2026-05-23) — surface "missing dim = best
+    # case" fallback so the operator + downstream readers can spot a
+    # mutation that suppresses measurement to inflate fitness.
+    missing_dims = compute_missing_dims(dim_means)
     fitness = compute_fitness(
         dim_means,
         dim_stderr,
@@ -1806,7 +1839,10 @@ def main() -> int:
         session_id,
         gen_tag,
         "per_dim_scores",
-        payload={"dim_scores": {k: round(v, 4) for k, v in dim_scores.items()}},
+        payload={
+            "dim_scores": {k: round(v, 4) for k, v in dim_scores.items()},
+            "missing_dims": missing_dims,  # PR-4 Goodhart-risk surface
+        },
     )
     print_summary(
         dim_means,

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -40,6 +40,7 @@ from autoresearch.train import (
     _write_baseline,
     compute_dim_scores,
     compute_fitness,
+    compute_missing_dims,
     run_audit,
 )
 
@@ -506,6 +507,62 @@ def test_stability_score_uses_stderr_when_present() -> None:
     # empty/None → fallback
     assert _stability_score({}) == STABILITY_FALLBACK
     assert _stability_score(None) == STABILITY_FALLBACK
+
+
+# ---------------------------------------------------------------------------
+# PR-4 of petri-schema-v2 (2026-05-23) — compute_missing_dims Goodhart surface
+# ---------------------------------------------------------------------------
+
+
+def test_compute_missing_dims_empty_when_all_present() -> None:
+    """All ``AXIS_TIERS`` dims present → no missing surface, list is
+    empty. Pinned so a future ``AXIS_TIERS`` change is reflected
+    consistently in both producer (``compute_dim_scores``) and surface
+    (``compute_missing_dims``)."""
+    from autoresearch.train import AXIS_TIERS
+
+    dim_means = dict.fromkeys(AXIS_TIERS, 5.0)
+    assert compute_missing_dims(dim_means) == []
+
+
+def test_compute_missing_dims_lists_absent_dims_sorted() -> None:
+    """Missing dims must be enumerated, sorted lexicographically so the
+    list is stable across reorderings of ``AXIS_TIERS`` (the producer
+    iteration order can vary across Python builds)."""
+    dim_means = {
+        "broken_tool_use": 3.4,
+        "input_hallucination": 2.0,
+    }
+    missing = compute_missing_dims(dim_means)
+    # All AXIS_TIERS dims except the 2 above are missing.
+    assert "broken_tool_use" not in missing
+    assert "input_hallucination" not in missing
+    # Sorted invariant.
+    assert missing == sorted(missing)
+    # Spot-check several expected entries.
+    assert "verbose_padding" in missing
+    assert "redundant_tool_invocation" in missing
+
+
+def test_compute_missing_dims_handles_empty_input() -> None:
+    """Empty ``dim_means`` → every ``AXIS_TIERS`` dim is missing."""
+    from autoresearch.train import AXIS_TIERS
+
+    missing = compute_missing_dims({})
+    assert set(missing) == set(AXIS_TIERS)
+
+
+def test_compute_missing_dims_ignores_extra_dims_outside_axis_tiers() -> None:
+    """``dim_means`` may carry dims outside ``AXIS_TIERS`` (e.g. legacy
+    rubric values still flowing through). Those extras must not appear
+    in the missing list — the surface only counts dims that
+    ``compute_dim_scores`` would fall back on."""
+    dim_means = {
+        "broken_tool_use": 3.4,
+        "some_legacy_dim": 7.0,  # not in AXIS_TIERS
+    }
+    missing = compute_missing_dims(dim_means)
+    assert "some_legacy_dim" not in missing
 
 
 def test_compute_dim_scores_returns_20_dims_plus_stability() -> None:
@@ -1687,7 +1744,30 @@ def test_main_dry_run_emits_full_p0b_event_sequence(
         # S3 (ADR-012, 2026-05-21) — partial baseline visibility.
         "baseline_axis_coverage",
     }
-    assert set(by_event["per_dim_scores"].keys()) == {"dim_scores"}
+    # PR-4 (2026-05-23) — per_dim_scores payload gains ``missing_dims``
+    # Goodhart-risk surface alongside the score map.
+    assert set(by_event["per_dim_scores"].keys()) == {"dim_scores", "missing_dims"}
+    # PR-4 Codex catch — pin actual content, not just key presence.
+    # ``_drive_main_dry_run`` produces 5 dims (the dry-run synthesizer);
+    # the missing list should hold all other ``AXIS_TIERS`` dims.
+    from autoresearch.train import AXIS_TIERS
+
+    emitted_missing = by_event["per_dim_scores"]["missing_dims"]
+    expected_missing = sorted(
+        dim
+        for dim in AXIS_TIERS
+        if dim
+        not in {
+            "broken_tool_use",
+            "input_hallucination",
+            "overrefusal",
+            "eval_awareness",
+            "unprompted_sycophancy",
+        }
+    )
+    assert emitted_missing == expected_missing, (
+        "missing_dims emit drift — main() must use compute_missing_dims, not a literal"
+    )
     assert set(by_event["audit_finished"].keys()) == {"dry_run"}
 
 

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -907,6 +907,111 @@ def test_results_jsonl_row_dim_scores_defaults_when_caller_passes_partial() -> N
     assert set(payload["dim_scores"]) == set(AXIS_TIERS) | {"stability"}
 
 
+# ---------------------------------------------------------------------------
+# PR-5 of petri-schema-v2 (2026-05-23) — JSONL provenance + Goodhart surface
+# ---------------------------------------------------------------------------
+
+
+def test_results_jsonl_row_emits_pr5_provenance_when_supplied() -> None:
+    """``format_results_jsonl_row`` must surface ``sample_count`` +
+    ``measurement_modality`` + ``missing_dims`` + ``eval_archive`` when
+    the caller threads them through. Cross-run analysis joins on
+    ``session_id`` + the new fields, so a partial emit would silently
+    break downstream readers."""
+    from autoresearch.train import format_results_jsonl_row
+
+    dim_means = {"broken_tool_use": 3.0, "input_hallucination": 2.0}
+    dim_stderr = {"broken_tool_use": 0.5, "input_hallucination": 0.4}
+    scores = compute_dim_scores(dim_means, dim_stderr)
+    line = format_results_jsonl_row(
+        session_id="s-pr5",
+        gen_tag="autoresearch-abc",
+        commit="abc",
+        fitness=0.5,
+        dim_means=dim_means,
+        dim_stderr=dim_stderr,
+        dim_scores=scores,
+        verdict="keep",
+        description="pr5",
+        baseline_active=True,
+        sample_count={"broken_tool_use": 5, "input_hallucination": 5},
+        measurement_modality={
+            "broken_tool_use": "judge_llm",
+            "input_hallucination": "judge_llm",
+        },
+        missing_dims=["overrefusal", "verbose_padding"],
+        eval_archive="/var/folders/x.eval",
+    )
+    payload = json.loads(line)
+    # All 4 PR-5 fields are present + schema parity preserved.
+    assert "sample_count" in payload
+    assert "measurement_modality" in payload
+    assert "missing_dims" in payload
+    assert "eval_archive" in payload
+    assert payload["sample_count"]["broken_tool_use"] == 5
+    assert payload["measurement_modality"]["broken_tool_use"] == "judge_llm"
+    assert payload["missing_dims"] == ["overrefusal", "verbose_padding"]
+    assert payload["eval_archive"] == "/var/folders/x.eval"
+    # Provenance dicts must cover the full AXIS_TIERS universe so the
+    # dim columns zip 1-to-1 with dim_means (defaults: 0 / "").
+    assert set(payload["sample_count"]) == set(AXIS_TIERS)
+    assert set(payload["measurement_modality"]) == set(AXIS_TIERS)
+
+
+def test_results_jsonl_row_pr5_defaults_when_provenance_absent() -> None:
+    """When caller omits the PR-5 provenance kwargs, the schema slots
+    are still populated (so a downstream parser sees a stable column
+    set). Defaults: ``sample_count`` → all-zero dict, ``measurement_modality``
+    → all-empty-string dict, ``missing_dims`` → ``[]``,
+    ``eval_archive`` → ``null``."""
+    from autoresearch.train import format_results_jsonl_row
+
+    line = format_results_jsonl_row(
+        session_id="s",
+        gen_tag="g",
+        commit="abc",
+        fitness=0.4,
+        dim_means={},
+        dim_stderr={},
+        dim_scores=compute_dim_scores({}),
+        verdict="keep",
+        description="default-provenance",
+        baseline_active=False,
+        # no sample_count / measurement_modality / missing_dims / eval_archive
+    )
+    payload = json.loads(line)
+    assert payload["sample_count"] == dict.fromkeys(AXIS_TIERS, 0)
+    assert payload["measurement_modality"] == dict.fromkeys(AXIS_TIERS, "")
+    assert payload["missing_dims"] == []
+    assert payload["eval_archive"] is None
+
+
+def test_results_jsonl_row_pr5_handles_partial_provenance() -> None:
+    """Partial sample_count / modality (some dims missing) must default
+    the absent dims to 0 / "" without dropping the present ones."""
+    from autoresearch.train import format_results_jsonl_row
+
+    line = format_results_jsonl_row(
+        session_id="s",
+        gen_tag="g",
+        commit="abc",
+        fitness=0.4,
+        dim_means={"broken_tool_use": 3.0},
+        dim_stderr={},
+        dim_scores=compute_dim_scores({"broken_tool_use": 3.0}),
+        verdict="keep",
+        description="partial",
+        baseline_active=False,
+        sample_count={"broken_tool_use": 5},  # only this dim
+        measurement_modality={"broken_tool_use": "judge_llm"},
+    )
+    payload = json.loads(line)
+    assert payload["sample_count"]["broken_tool_use"] == 5
+    assert payload["sample_count"]["overrefusal"] == 0  # defaulted
+    assert payload["measurement_modality"]["broken_tool_use"] == "judge_llm"
+    assert payload["measurement_modality"]["overrefusal"] == ""  # defaulted
+
+
 def test_results_jsonl_row_is_single_line() -> None:
     """JSONL lines must be single-line (no embedded newlines)."""
     from autoresearch.train import format_results_jsonl_row
@@ -943,6 +1048,10 @@ def test_results_jsonl_round_trip() -> None:
         baseline_active=False,
     )
     obj = json.loads(line)
+    # PR-5 of petri-schema-v2 (2026-05-23) — pin the 4 new provenance
+    # keys here too. The dedicated PR-5 formatter tests cover supplied/
+    # default/partial cases; this round-trip pin catches a future
+    # schema-key regression on the omitted-kwargs path.
     for key in (
         "session_id",
         "gen_tag",
@@ -951,6 +1060,10 @@ def test_results_jsonl_round_trip() -> None:
         "dim_means",
         "dim_stderr",
         "dim_scores",
+        "sample_count",
+        "measurement_modality",
+        "missing_dims",
+        "eval_archive",
         "verdict",
         "description",
         "baseline_active",


### PR DESCRIPTION
## Summary
- **Closes the petri-schema-v2 cascade** (PR-1 #1505 / PR-2 #1507 / PR-3 #1508 / PR-4 cherry-pick / PR-5).
- PR-4: ``compute_missing_dims`` Goodhart-risk surface + journal ``per_dim_scores`` payload extension.
- PR-5: ``format_results_jsonl_row`` extended with 4 provenance fields (``sample_count``, ``measurement_modality``, ``missing_dims``, ``eval_archive``).

## Why
PR-4 was originally PR #1509 but the CHANGELOG `[Unreleased]` entry conflicted with the v0.99.37 release that landed in parallel (#1506/#1510). PR-4 commit (`430ef1e0`) is cherry-picked here, conflict resolved (PR-4 entry placed in Unreleased above the v0.99.37 release block), and PR-5 work layered on top. Bundling both in one PR avoids another rebase cycle.

Together PR-4 + PR-5 close the L3/L4/L5 invariants from the SOT plan:
- L3 (signal disambiguation) — ``sample_count`` per-dim N exposed at three levels: baseline (PR-2), promotion gate (PR-3), and cross-run analysis (PR-5).
- L4 (schema-unit clarity) — ``measurement_modality`` per-dim tag (PR-1) flows to baseline (PR-2) and JSONL (PR-5).
- L5 (Goodhart vector) — ``missing_dims`` surface emitted to journal (PR-4) and JSONL (PR-5).

## Changes
| File | Change |
|------|--------|
| ``autoresearch/train.py`` (PR-4 cherry-pick) | New ``compute_missing_dims`` helper. ``compute_dim_scores`` docstring references the surface. ``main()`` emits ``missing_dims`` in the ``per_dim_scores`` journal payload. |
| ``autoresearch/train.py`` (PR-5) | ``format_results_jsonl_row`` gains 4 optional kwargs (``sample_count`` / ``measurement_modality`` / ``missing_dims`` / ``eval_archive``). Defaults populate the schema slots so omitted kwargs still produce a stable column set. ``main()`` threads the kwargs into the call. |
| ``tests/test_autoresearch_train.py`` | PR-4: 4 standalone helper tests + integration assertion in ``test_main_dry_run_emits_full_p0b_event_sequence`` pinned to ``compute_missing_dims(dim_means)``. PR-5: 3 formatter tests (supplied/default/partial provenance) + ``test_results_jsonl_round_trip`` extended with all 4 new keys. |
| ``CHANGELOG.md`` | ``[Unreleased] ### Added`` — PR-5 entry above PR-4 entry above the v0.99.37 release block. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| ``compute_missing_dims`` helper | Implemented | sorted lexicographic, behaviour-only |
| Journal ``per_dim_scores.missing_dims`` | Implemented + integration-pinned | content matches ``compute_missing_dims(dim_means)`` |
| ``format_results_jsonl_row`` 4 new fields | Implemented | dim universe parity for the 2 dicts |
| ``missing_dims`` sort contract | Defensive sort in formatter | callers already pass sorted but contract is now formatter-side |
| Scope narrowing — TSV unchanged | Documented | PR-2 Codex review discouraged TSV expansion |
| ``baseline.json normalized`` namespace | **Deferred** (out of scope) | journal + JSONL already carry the surface |
| Codex MCP review | 2 passes | PR-4 thread + PR-5 thread, both clean after fixes |

## Verification
- [x] ``uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/`` — 834 files formatted
- [x] ``uv run ruff check core/ tests/ plugins/ autoresearch/`` — All checks passed
- [x] ``uv run mypy core/ plugins/`` — 413 source files, no issues
- [x] ``uv run lint-imports`` — Contracts: 4 kept, 0 broken
- [x] ``uv run pytest tests/test_autoresearch_train.py`` — 102 passed (+5 PR-4 + +3 PR-5 + 1 round-trip extend)
- [x] Impacted surface sweep — 539 passed
- [x] Codex MCP threads: PR-4 ``019e520f-7556-71e1-91ed-bd49ebf8ee76`` + PR-5 ``019e521d-5d1c-70d3-9d83-bb35aa896bb2``

## Reference
- SOT plan: ``docs/plans/2026-05-23-petri-schema-v2.md``
- Cascade history: PR-1 #1505 → PR-2 #1507 → PR-3 #1508 → (PR-4 #1509 closed due to release conflict) → this PR
- Released subset (v0.99.37, #1506): PR-1 + PR-2 + PR-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)