### PR TITLE
release: v0.99.38 — rotation pattern first run (meta_reviewer debate-read + scaffold refinement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.38] - 2026-05-23
+
+> First release under the **rotation pattern** (release branch lands on
+> develop first, then develop → main pass-through — no backmerge).
+> Bundles the CSP-13a meta_reviewer read-write parity fix-up + the
+> scaffold refinement PR (`auto-backmerge.yml` safety net, new
+> ``geode-gitflow`` ``## Release Flow`` section, updated
+> ``geode-changelog`` On-Release checklist).
+
 ### Fixed
 
 - **PR-CSP-13a — meta_reviewer reads ``state.debate_transcripts``**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.37
+- **Version**: 0.99.38
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 355 core + 58 plugins = 413
-- **Tests**: 6645 (+5 live)
+- **Tests**: 6658 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.37 — Long-running Autonomous Execution Harness
+# GEODE v0.99.38 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.37**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.38**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.37 — Long-running Autonomous Execution Harness
+# GEODE v0.99.38 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.37**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.38**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.37"
+version = "0.99.38"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.37"
+version = "0.99.38"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **First release under the rotation pattern** (PR #1511's `geode-gitflow ## Release Flow`). This PR base is **develop**, not main — that's intentional. develop → main PR comes next, straight pass-through.
- Bundles:
  - PR #1513 (PR-CSP-13a) — meta_reviewer reads `state.debate_transcripts` (closes Phase 1 Loop 2 read-write parity).
  - PR #1511 (scaffold refinement) — `auto-backmerge.yml` safety net + `## Release Flow` section + `On Release` checklist.
- 5-stamp bump + CHANGELOG promote + fresh `[Unreleased]` per the new On Release checklist.

## Why
v0.99.38 is the **proof point** that the rotation pattern eliminates the backmerge PR. Watch:
1. This PR merges → develop has v0.99.38 stamps.
2. Open develop → main PR (next step, abbreviated body).
3. develop → main merges → main has v0.99.38 stamps, identical to develop.
4. **No backmerge PR.**

## Changes
| File | Change |
|------|--------|
| `pyproject.toml` | 0.99.37 → 0.99.38 |
| `CLAUDE.md` | Version + Tests (6645 → 6658) |
| `README.md` | Title + frontier comparison row |
| `README.ko.md` | 동일 |
| `CHANGELOG.md` | `[Unreleased]` → `[0.99.38] - 2026-05-23` + fresh empty `[Unreleased]` |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/ scripts/` — All checks passed
- [x] `uv run ruff format --check ...` — 834 files already formatted (added to local gate after PR #1513 CI catch)
- [x] `uv run mypy core/ plugins/` — Success, 413 source files
- [x] `uv run geode version` — `GEODE v0.99.38`
- [x] 5-stamp consistency: pyproject + CLAUDE.md + README.md×2 + README.ko.md×2

🤖 Generated with [Claude Code](https://claude.com/claude-code)