### PR TITLE
PR-C-P1 — autoresearch seed_limit lower bound ge=1 → ge=5 (silent N<5 noise gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,52 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-C-P1 — autoresearch ``seed_limit`` lower bound bumped from
+  ``ge=1`` to ``ge=5``**. Pydantic now rejects any
+  ``[self_improving_loop.autoresearch] seed_limit`` value below 5.
+  Operators who had ``seed_limit = 2`` (the historic default in some
+  ``~/.geode/config.toml`` files) will see a ``ValidationError`` with
+  the actionable Pydantic message at audit-launch time, instead of
+  the previous silent fallback to module defaults.
+
+  **Why**. ``core/audit/dim_extractor._aggregate`` forces
+  ``stderr=0.0`` only at N=1 (``statistics.stdev(ddof=1)`` undefined);
+  N=2-4 produces a sample stderr but the CV is too noisy to drive
+  ``_should_promote`` — the gate floors its margin at
+  ``max(stderr, fitness_margin_floor)`` (``fitness_margin_floor=0.05``,
+  raised to ``N1_FITNESS_MARGIN_FLOOR=0.20`` when any ``CRITICAL_DIMS``
+  member has N≤1), so a 0.05+ fitness delta would promote a
+  measurement with no confidence signal. N≥5 keeps the sample stderr
+  meaningful, so the stderr-derived margin rises above the default
+  floor instead of collapsing onto it.
+
+  **Codex MCP catch — narrowed exception**.
+  ``autoresearch.train._get_autoresearch_config`` previously caught
+  bare ``Exception`` and silently fell back to module defaults
+  whenever the loader raised — which meant a config with
+  ``seed_limit = 2`` produced no error, defeating the lower-bound
+  gate. Catch narrowed to ``ImportError`` only so
+  ``pydantic.ValidationError`` surfaces to the operator. Same
+  silent-drift pattern as PR-MINIMAL-2 #1398.
+
+  **Test guards**:
+  - ``tests/test_self_improving_loop_config.py::test_autoresearch_seed_limit_lower_bound_is_5``
+    pins the ``ge=5`` rejection.
+  - ``...::test_autoresearch_seed_limit_boundary_n5_accepted``
+    pins the boundary case so a future typo to ``gt=5`` is caught.
+  - ``...::test_autoresearch_seed_limit_default_remains_10``
+    pins the default so operators with no override see no shift.
+  - ``...::test_get_autoresearch_config_propagates_validation_error_to_operator``
+    pins the narrowed ``ImportError`` catch.
+
+  **Operator action — bumping a low value**. If ``geode`` refuses to
+  start an audit after pulling this PR, edit
+  ``~/.geode/config.toml`` and raise
+  ``[self_improving_loop.autoresearch] seed_limit`` to ``5`` or
+  higher (10 is the default).
+
 ## [0.99.38] - 2026-05-23
 
 > First release under the **rotation pattern** (release branch lands on

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -153,23 +153,32 @@ WRAPPER_OVERRIDE_HOOK_READY = _CORE_WRAPPER_OVERRIDE_READY
 def _get_autoresearch_config() -> Any:
     """Lazily load ``[self_improving_loop.autoresearch]`` from ``~/.geode/config.toml``.
 
-    Returns the typed ``AutoresearchConfig`` (PR-α1) when the loader is
-    available; falls back to a fresh ``AutoresearchConfig`` (whose
-    defaults mirror the module constants verbatim) on
-    ``ImportError`` / load failure so this module stays importable in
-    test contexts that stub ``core.config``.
+    Returns the typed ``AutoresearchConfig`` (PR-α1) when the loader
+    can be imported. Falls back to a ``SimpleNamespace`` whose fields
+    mirror the module constants verbatim **only** on ``ImportError``,
+    so this module stays importable in test contexts that stub
+    ``core.config``. ``pydantic.ValidationError`` and other loader
+    errors (e.g. ``tomllib.TOMLDecodeError``) bubble naturally;
+    missing-file / unreadable-file fallback is the loader's own
+    behaviour (it returns a fully-defaulted ``SelfImprovingLoopConfig``
+    on ``OSError``).
 
     Tests can monkeypatch this function to inject a custom config
     without touching ``~/.geode/config.toml``.
     """
+    # PR-C-P1 (2026-05-23) — Codex MCP catch: this used to be
+    # ``except Exception`` which silently swallowed
+    # ``pydantic.ValidationError`` (e.g. operator config with
+    # ``seed_limit = 2`` < the new ``ge=5`` lower bound) and fell back
+    # to module defaults. The operator never saw the validation
+    # message — same silent-drift pattern as PR-MINIMAL-2 #1398. Now
+    # narrowed to ``ImportError`` (the test-stub case) so the
+    # ValidationError surfaces with the actionable Pydantic message;
+    # TOML parse errors and other loader-raised exceptions bubble too;
+    # missing/unreadable-file fallback stays inside the loader.
     try:
         from core.config.self_improving_loop import load_self_improving_loop_config
-
-        return load_self_improving_loop_config().autoresearch
-    except Exception:
-        # Use the in-module default (matches AutoresearchConfig() exactly,
-        # which is verified by tests/test_self_improving_loop_config.py::
-        # test_autoresearch_defaults_match_train_module).
+    except ImportError:
         from types import SimpleNamespace
 
         return SimpleNamespace(
@@ -180,6 +189,7 @@ def _get_autoresearch_config() -> Any:
             dim_set=DIM_SET_NAME,
             max_turns=MAX_TURNS,
         )
+    return load_self_improving_loop_config().autoresearch
 
 
 def _petri_role_model(role: str) -> str:

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -191,7 +191,24 @@ class AutoresearchConfig(BaseModel):
     subscription-first with PAYG fallback per the global
     ``fallback_to_payg`` flag. The argv translator maps non-``api_key``
     sources to ``--use-oauth`` for the audit subprocess."""
-    seed_limit: Annotated[int, Field(ge=1, le=1000)] = 10
+    seed_limit: Annotated[int, Field(ge=5, le=1000)] = 10
+    """Per-audit seed count — the N that ``dim_extractor._aggregate``
+    feeds into ``statistics.stdev(ddof=1)``.
+
+    PR-C-P1 (2026-05-23) — lower bound bumped from 1 to **5**.
+    ``_aggregate`` *forces* ``stderr=0.0`` only at N=1 (ddof=1
+    variance undefined); N=2-4 produces a sample stderr but it is
+    too unstable to drive the ``_should_promote`` gate (CV often
+    exceeds the dim's own value range). ``compute_fitness`` then
+    floored its margin gate at ``max(stderr, fitness_margin_floor)``
+    where ``fitness_margin_floor=0.05`` (and PR-3 raised it to
+    ``N1_FITNESS_MARGIN_FLOOR=0.20`` whenever any ``CRITICAL_DIMS``
+    member has N≤1) — so without a sane stderr signal a 0.05+
+    fitness Δ would promote against a measurement with no
+    confidence. N≥5 keeps the sample stderr meaningful, so the
+    stderr-derived margin rises above the default floor instead of
+    collapsing onto it. Operators who want faster smoke runs should
+    pass ``--dry-run`` instead of setting a low ``seed_limit``."""
     seed_select: str = "plugins/petri_audit/seeds"
     dim_set: str = "subset"
     max_turns: Annotated[int, Field(ge=1, le=200)] = 10

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -231,7 +231,7 @@ def test_build_audit_command_omits_target_judge_when_cfg_unpinned(
             target_model=None,
             judge_model=None,
             source="claude-cli",
-            seed_limit=2,
+            seed_limit=5,
             seed_select="plugins/petri_audit/seeds",
             dim_set="subset",
             max_turns=5,

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -115,6 +115,81 @@ seed_limit = 25
     assert cfg.autoresearch.source == "auto"
 
 
+# ---------------------------------------------------------------------------
+# PR-C-P1 (2026-05-23) — seed_limit lower bound ≥ 5
+# ---------------------------------------------------------------------------
+
+
+def test_autoresearch_seed_limit_lower_bound_is_5() -> None:
+    """PR-C-P1 bumps ``seed_limit`` from ``ge=1`` to ``ge=5``.
+    ``dim_extractor._aggregate`` forces ``stderr=0.0`` only at N=1
+    (ddof=1 variance undefined); N=2-4 produces a sample stderr but
+    the CV is too unstable to drive ``_should_promote``. Either way
+    the gate ends up flooring at the default 0.05, so a 0.05+ Δ
+    promotes against a measurement with no confidence signal.
+    Pydantic must reject any config that sets it lower."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        AutoresearchConfig(seed_limit=2)
+    msg = str(exc_info.value)
+    assert "seed_limit" in msg
+    assert "greater than or equal to 5" in msg or "ge=5" in msg
+
+
+def test_autoresearch_seed_limit_boundary_n5_accepted() -> None:
+    """Boundary pin — N=5 (the threshold) must be accepted. A future
+    typo bumping to ``gt=5`` would silently exclude the boundary."""
+    cfg = AutoresearchConfig(seed_limit=5)
+    assert cfg.seed_limit == 5
+
+
+def test_autoresearch_seed_limit_default_remains_10() -> None:
+    """The default (already healthy at 10) stays unchanged so operators
+    who never set ``seed_limit`` see no behaviour shift."""
+    cfg = AutoresearchConfig()
+    assert cfg.seed_limit == 10
+
+
+def test_get_autoresearch_config_propagates_validation_error_to_operator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR-C-P1 Codex MCP catch — ``autoresearch.train._get_autoresearch_config``
+    used to ``except Exception:`` and silently fall back to the module
+    defaults, so an operator config with ``seed_limit = 2`` (< new
+    ``ge=5`` floor) produced no error. The narrowed catch now lets
+    ``pydantic.ValidationError`` surface to the operator with the
+    actionable Pydantic message. Same silent-drift pattern as
+    PR-MINIMAL-2 #1398."""
+    from pydantic import ValidationError
+
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[self_improving_loop.autoresearch]
+seed_limit = 2
+""",
+    )
+    import autoresearch.train as auto_train
+    from core.config import self_improving_loop as sil_config
+
+    # Capture the unpatched loader, then monkeypatch the import target
+    # to force the tmp_path. ``_get_autoresearch_config`` imports the
+    # loader from ``core.config.self_improving_loop`` so the patch
+    # needs to land on that module attribute.
+    original_loader = sil_config.load_self_improving_loop_config
+
+    def _load_with_tmp_path(*_args: object, **_kwargs: object) -> object:
+        return original_loader(path)
+
+    monkeypatch.setattr(sil_config, "load_self_improving_loop_config", _load_with_tmp_path)
+
+    with pytest.raises(ValidationError):
+        auto_train._get_autoresearch_config()
+
+
 def test_load_reads_petri_role_bindings(tmp_path: Path) -> None:
     """[self_improving_loop.petri.<role>] keys become PetriRoleConfig entries."""
     path = tmp_path / "config.toml"


### PR DESCRIPTION
## Summary
- Bump `AutoresearchConfig.seed_limit` Pydantic constraint from `ge=1` to `ge=5`.
- Narrow `_get_autoresearch_config` catch from bare `Exception` to `ImportError` so `ValidationError` surfaces to operators.
- 4 new test guards (lower-bound rejection / N=5 boundary / default unchanged / narrowed-catch propagation) + 1 fixture bump.

## Why
With the historic `ge=1`, an operator config of `seed_limit = 2` was accepted. Then `core/audit/dim_extractor._aggregate` *forces* `stderr=0.0` only at N=1 (`statistics.stdev(ddof=1)` undefined); at N=2-4 it still computes a sample stderr but the CV is too unstable to drive `_should_promote`. Either way `compute_fitness` ends up at its floor — `max(stderr, fitness_margin_floor)` with `fitness_margin_floor=0.05` (or `N1_FITNESS_MARGIN_FLOOR=0.20` when any `CRITICAL_DIMS` member has N≤1). That meant a 0.05+ fitness Δ could promote against a measurement with no confidence signal. N≥5 keeps the sample stderr meaningful, so the stderr-derived margin rises above the default floor rather than collapsing onto it.

Separately, `autoresearch.train._get_autoresearch_config` used to `except Exception` and silently fall back to module defaults whenever the loader raised. That defeated the new lower-bound gate: a `seed_limit = 2` config never reached the operator as a validation error — it just quietly behaved like the default. Same silent-drift pattern as PR-MINIMAL-2 #1398.

## Changes
| File | Change |
|------|--------|
| `core/config/self_improving_loop.py` | `seed_limit: Annotated[int, Field(ge=5, le=1000)] = 10` + extended docstring citing `fitness_margin_floor` (0.05) / `N1_FITNESS_MARGIN_FLOOR` (0.20). |
| `autoresearch/train.py` | `_get_autoresearch_config`: catch narrowed from `Exception` → `ImportError`; docstring + comment updated to spell out which errors bubble (ValidationError, TOMLDecodeError) vs which the loader handles itself (missing/unreadable file). |
| `tests/test_self_improving_loop_config.py` | 4 new tests: `test_autoresearch_seed_limit_lower_bound_is_5`, `test_autoresearch_seed_limit_boundary_n5_accepted`, `test_autoresearch_seed_limit_default_remains_10`, `test_get_autoresearch_config_propagates_validation_error_to_operator`. |
| `tests/test_autoresearch_train.py` | Existing fixture bump `seed_limit=2` → `seed_limit=5` (the pre-existing test had a default below the new floor; the test isn't about the floor itself). |
| `CHANGELOG.md` | `### Changed` entry under `[Unreleased]` documenting the gate, the narrowed catch, the 4 test guards, and the operator action (raise low values in `~/.geode/config.toml`). |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| `seed_limit` writers/readers across codebase | Verified consistent | No other site sets `seed_limit < 5`. Default everywhere is 10. |
| Codex MCP findings (5 checks) | All 4 addressed | (a) writers — non-finding. (b) narrowed catch leaves only ImportError; ValidationError + TOMLDecodeError bubble naturally. (c) monkeypatch — verified real coverage (function does `from … import` per call). (d) CHANGELOG parity — fixed to reference `fitness_margin_floor=0.05` / `N1_FITNESS_MARGIN_FLOOR=0.20` instead of unprovable "CRITICAL axis margin width". (e) docstring softened to cite real constants. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run ruff format --check core/ tests/ plugins/ autoresearch/ scripts/` — clean
- [x] `uv run mypy core/ plugins/` — clean (413 source files)
- [x] `uv run pytest tests/ -m "not live"` — **6624 passed, 42 skipped, 5 deselected**
- [x] `uv run lint-imports` — 4 contracts kept
- [x] Codex MCP review — 4 findings addressed before push

## Reference
- Codex MCP review session: `019e5231-ed0e-7300-8ba3-e6201c1de82e` (5 checks: writers / narrowed-catch failure modes / monkeypatch correctness / CHANGELOG parity / docstring anchor).
- PR-MINIMAL-2 #1398 — the analogous silent-drift pattern this PR mirrors.
- petri-schema-v2 cascade PR-2/3 #1507/#1508 — introduced the `N1_FITNESS_MARGIN_FLOOR` constant + `_should_promote` gate this PR backstops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)