### PR TITLE
feat(llm/adapters): paperclip-style LLMAdapter Protocol + 6 built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,48 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **LLM adapter abstraction (paperclip pattern) — Layer 4 Protocol +
+  Layer 3 built-ins.** New :class:`core.llm.adapters.LLMAdapter`
+  Protocol (paperclip ``ServerAdapterModule`` mirror) + mutable
+  registry (``register_adapter`` / ``unregister_adapter`` /
+  ``resolve_for(provider, source)`` / ``bootstrap_builtins``). Six
+  built-in adapters covering all PAYG / Subscription / Adapter paths
+  for Anthropic + OpenAI:
+
+  | name | provider | source | billing_type |
+  |---|---|---|---|
+  | ``anthropic-payg`` | anthropic | payg | api |
+  | ``anthropic-oauth`` | anthropic | subscription | subscription |
+  | ``claude-cli`` | anthropic | adapter | subscription_included |
+  | ``openai-payg`` | openai | payg | api |
+  | ``codex-oauth`` | openai | subscription | subscription |
+  | ``codex-cli`` | openai | adapter | subscription_included |
+
+  Registry boot happens once at runtime construction via the
+  ``build_llm_adapters`` wiring step. External plugins implement the
+  Protocol and register via :func:`core.llm.adapters.register_adapter`
+  from their entry point (paperclip's external-adapter pattern).
+
+- **Picker → adapter resolution glue.** New
+  :func:`plugins.seed_generation.picker.binding_to_adapter_source` +
+  :func:`resolve_binding_to_adapter` collapse a :class:`RoleBinding`
+  into a concrete :class:`LLMAdapter`. The picker's historical source
+  strings (``api_key`` / ``claude-cli`` / ``openai-codex``) are
+  translated to the adapter Protocol's ``payg`` / ``subscription`` /
+  ``adapter`` names via a single SoT table — both naming schemes are
+  accepted in ``[seed_generation.role.<role>]`` overrides.
+
 ### Changed
+
+- **Config SoT consolidation — ``~/.geode/config.toml``
+  ``[seed_generation.role.<role>]``.** Mirrors the Session 66
+  ``[self_improving_loop.petri.<role>]`` consolidation
+  (PR #1496/#1498/#1499). ``picker.load_user_overrides`` now reads
+  ``config.toml`` first; the legacy ``~/.geode/seed-generation.toml``
+  is still honoured as a fallback with a one-time deprecation
+  warning. Removal target: v1.0.0.
 
 - **PR-C-P1 — autoresearch ``seed_limit`` lower bound bumped from
   ``ge=1`` to ``ge=5``**. Pydantic now rejects any
@@ -92,6 +133,30 @@ functional change.
   ``~/.geode/config.toml`` and raise
   ``[self_improving_loop.autoresearch] seed_limit`` to ``5`` or
   higher (10 is the default).
+
+### Deprecated
+
+- **``core.llm.credentials.resolve_provider_key(provider, fallback)``.**
+  Global type-priority (OAUTH > TOKEN > API_KEY) loses per-role source
+  information. New callers use the
+  :class:`core.llm.adapters.LLMAdapter` registry instead. Removal
+  target: v1.0.0.
+- **``core.config._resolve_provider(model)``.** Resolves only
+  ``provider`` from a model id string — cannot express the source axis
+  (PAYG vs Subscription vs Adapter). New callers use
+  :func:`core.llm.adapters.resolve_for(provider, source)`. Removal
+  target: v1.0.0.
+- **``~/.geode/seed-generation.toml``.** Per-role overrides migrate to
+  ``~/.geode/config.toml`` ``[seed_generation.role.<role>]``. The
+  legacy file is still read with a one-time deprecation warning until
+  v1.0.0.
+- **Layer 2 ``LLMClientPort`` / ``AgenticLLMPort`` /
+  ``resolve_agentic_adapter`` (re-exported via
+  ``core.llm.adapters._legacy``).** Pre-v0.99.39 paperclip-style
+  abstraction superseded by the unified :class:`LLMAdapter`. Kept
+  functional for in-tree callers (``core.agent.loop._reflection``,
+  ``core.llm.router``, ``plugins.petri_audit``); their migration to
+  ``resolve_for`` is the v1.0.0 milestone.
 
 ## [0.99.38] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,52 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-C-P1 — autoresearch ``seed_limit`` lower bound bumped from
+  ``ge=1`` to ``ge=5``**. Pydantic now rejects any
+  ``[self_improving_loop.autoresearch] seed_limit`` value below 5.
+  Operators who had ``seed_limit = 2`` (the historic default in some
+  ``~/.geode/config.toml`` files) will see a ``ValidationError`` with
+  the actionable Pydantic message at audit-launch time, instead of
+  the previous silent fallback to module defaults.
+
+  **Why**. ``core/audit/dim_extractor._aggregate`` forces
+  ``stderr=0.0`` only at N=1 (``statistics.stdev(ddof=1)`` undefined);
+  N=2-4 produces a sample stderr but the CV is too noisy to drive
+  ``_should_promote`` — the gate floors its margin at
+  ``max(stderr, fitness_margin_floor)`` (``fitness_margin_floor=0.05``,
+  raised to ``N1_FITNESS_MARGIN_FLOOR=0.20`` when any ``CRITICAL_DIMS``
+  member has N≤1), so a 0.05+ fitness delta would promote a
+  measurement with no confidence signal. N≥5 keeps the sample stderr
+  meaningful, so the stderr-derived margin rises above the default
+  floor instead of collapsing onto it.
+
+  **Codex MCP catch — narrowed exception**.
+  ``autoresearch.train._get_autoresearch_config`` previously caught
+  bare ``Exception`` and silently fell back to module defaults
+  whenever the loader raised — which meant a config with
+  ``seed_limit = 2`` produced no error, defeating the lower-bound
+  gate. Catch narrowed to ``ImportError`` only so
+  ``pydantic.ValidationError`` surfaces to the operator. Same
+  silent-drift pattern as PR-MINIMAL-2 #1398.
+
+  **Test guards**:
+  - ``tests/test_self_improving_loop_config.py::test_autoresearch_seed_limit_lower_bound_is_5``
+    pins the ``ge=5`` rejection.
+  - ``...::test_autoresearch_seed_limit_boundary_n5_accepted``
+    pins the boundary case so a future typo to ``gt=5`` is caught.
+  - ``...::test_autoresearch_seed_limit_default_remains_10``
+    pins the default so operators with no override see no shift.
+  - ``...::test_get_autoresearch_config_propagates_validation_error_to_operator``
+    pins the narrowed ``ImportError`` catch.
+
+  **Operator action — bumping a low value**. If ``geode`` refuses to
+  start an audit after pulling this PR, edit
+  ``~/.geode/config.toml`` and raise
+  ``[self_improving_loop.autoresearch] seed_limit`` to ``5`` or
+  higher (10 is the default).
+
 ## [0.99.38] - 2026-05-23
 
 > First release under the **rotation pattern** (release branch lands on

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -153,23 +153,32 @@ WRAPPER_OVERRIDE_HOOK_READY = _CORE_WRAPPER_OVERRIDE_READY
 def _get_autoresearch_config() -> Any:
     """Lazily load ``[self_improving_loop.autoresearch]`` from ``~/.geode/config.toml``.
 
-    Returns the typed ``AutoresearchConfig`` (PR-α1) when the loader is
-    available; falls back to a fresh ``AutoresearchConfig`` (whose
-    defaults mirror the module constants verbatim) on
-    ``ImportError`` / load failure so this module stays importable in
-    test contexts that stub ``core.config``.
+    Returns the typed ``AutoresearchConfig`` (PR-α1) when the loader
+    can be imported. Falls back to a ``SimpleNamespace`` whose fields
+    mirror the module constants verbatim **only** on ``ImportError``,
+    so this module stays importable in test contexts that stub
+    ``core.config``. ``pydantic.ValidationError`` and other loader
+    errors (e.g. ``tomllib.TOMLDecodeError``) bubble naturally;
+    missing-file / unreadable-file fallback is the loader's own
+    behaviour (it returns a fully-defaulted ``SelfImprovingLoopConfig``
+    on ``OSError``).
 
     Tests can monkeypatch this function to inject a custom config
     without touching ``~/.geode/config.toml``.
     """
+    # PR-C-P1 (2026-05-23) — Codex MCP catch: this used to be
+    # ``except Exception`` which silently swallowed
+    # ``pydantic.ValidationError`` (e.g. operator config with
+    # ``seed_limit = 2`` < the new ``ge=5`` lower bound) and fell back
+    # to module defaults. The operator never saw the validation
+    # message — same silent-drift pattern as PR-MINIMAL-2 #1398. Now
+    # narrowed to ``ImportError`` (the test-stub case) so the
+    # ValidationError surfaces with the actionable Pydantic message;
+    # TOML parse errors and other loader-raised exceptions bubble too;
+    # missing/unreadable-file fallback stays inside the loader.
     try:
         from core.config.self_improving_loop import load_self_improving_loop_config
-
-        return load_self_improving_loop_config().autoresearch
-    except Exception:
-        # Use the in-module default (matches AutoresearchConfig() exactly,
-        # which is verified by tests/test_self_improving_loop_config.py::
-        # test_autoresearch_defaults_match_train_module).
+    except ImportError:
         from types import SimpleNamespace
 
         return SimpleNamespace(
@@ -180,6 +189,7 @@ def _get_autoresearch_config() -> Any:
             dim_set=DIM_SET_NAME,
             max_turns=MAX_TURNS,
         )
+    return load_self_improving_loop_config().autoresearch
 
 
 def _petri_role_model(role: str) -> str:

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -267,6 +267,12 @@ def _resolve_provider(model: str) -> str:
     Public surface unchanged — every caller (``core.llm.router``,
     ``core.llm.routing.plan_registry``, monkeypatched test sites) keeps
     working without modification.
+
+    .. deprecated:: v0.99.39
+       Resolves only ``provider`` from a model id string — cannot express
+       the source axis (PAYG vs Subscription vs Adapter) that callers
+       increasingly need. Use :func:`core.llm.adapters.resolve_for` which
+       takes ``(provider, source)`` jointly. Removal target: v1.0.0.
     """
     from core.config.routing_manifest import resolve_provider as _manifest_resolve
 

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -191,7 +191,24 @@ class AutoresearchConfig(BaseModel):
     subscription-first with PAYG fallback per the global
     ``fallback_to_payg`` flag. The argv translator maps non-``api_key``
     sources to ``--use-oauth`` for the audit subprocess."""
-    seed_limit: Annotated[int, Field(ge=1, le=1000)] = 10
+    seed_limit: Annotated[int, Field(ge=5, le=1000)] = 10
+    """Per-audit seed count — the N that ``dim_extractor._aggregate``
+    feeds into ``statistics.stdev(ddof=1)``.
+
+    PR-C-P1 (2026-05-23) — lower bound bumped from 1 to **5**.
+    ``_aggregate`` *forces* ``stderr=0.0`` only at N=1 (ddof=1
+    variance undefined); N=2-4 produces a sample stderr but it is
+    too unstable to drive the ``_should_promote`` gate (CV often
+    exceeds the dim's own value range). ``compute_fitness`` then
+    floored its margin gate at ``max(stderr, fitness_margin_floor)``
+    where ``fitness_margin_floor=0.05`` (and PR-3 raised it to
+    ``N1_FITNESS_MARGIN_FLOOR=0.20`` whenever any ``CRITICAL_DIMS``
+    member has N≤1) — so without a sane stderr signal a 0.05+
+    fitness Δ would promote against a measurement with no
+    confidence. N≥5 keeps the sample stderr meaningful, so the
+    stderr-derived margin rises above the default floor instead of
+    collapsing onto it. Operators who want faster smoke runs should
+    pass ``--dry-run`` instead of setting a low ``seed_limit``."""
     seed_select: str = "plugins/petri_audit/seeds"
     dim_set: str = "subset"
     max_turns: Annotated[int, Field(ge=1, le=200)] = 10

--- a/core/llm/adapters/__init__.py
+++ b/core/llm/adapters/__init__.py
@@ -1,0 +1,96 @@
+"""LLM Adapter abstraction — paperclip pattern adoption (v0.99.39).
+
+Layer 4 of the design in
+``docs/plans/2026-05-23-llm-adapter-abstraction.md``:
+
+- :mod:`core.llm.adapters.base` — :class:`LLMAdapter` Protocol + request /
+  result / billing-type dataclasses (paperclip ``ServerAdapterModule`` mirror).
+- :mod:`core.llm.adapters.registry` — mutable global registry
+  (``register_adapter`` / ``resolve_for`` / ``bootstrap_builtins``).
+
+Layer 3 concrete adapters (one per provider × source pair):
+
+- ``anthropic_payg`` / ``anthropic_oauth`` / ``claude_cli``
+- ``openai_payg`` / ``codex_oauth`` / ``codex_cli``
+
+External plugins implement :class:`LLMAdapter` and register via
+:func:`register_adapter` from their entry point.
+"""
+
+from core.llm.adapters._legacy import (
+    _ADAPTER_MAP,
+    AgenticLLMPort,
+    ClaudeAdapter,
+    LLMClientPort,
+    LLMJsonCallable,
+    LLMParsedCallable,
+    LLMTextCallable,
+    infer_provider_from_model,
+    resolve_agentic_adapter,
+)
+from core.llm.adapters.base import (
+    CONCRETE_SOURCES,
+    SOURCE_ADAPTER,
+    SOURCE_AUTO,
+    SOURCE_PAYG,
+    SOURCE_SUBSCRIPTION,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    LLMAdapter,
+    Message,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+    ToolSpec,
+    UsageSummary,
+)
+from core.llm.adapters.registry import (
+    AdapterAlreadyRegisteredError,
+    AdapterNotFoundError,
+    bootstrap_builtins,
+    get_adapter,
+    list_adapters,
+    register_adapter,
+    resolve_for,
+    unregister_adapter,
+)
+
+__all__ = [
+    "CONCRETE_SOURCES",
+    "SOURCE_ADAPTER",
+    "SOURCE_AUTO",
+    "SOURCE_PAYG",
+    "SOURCE_SUBSCRIPTION",
+    "_ADAPTER_MAP",
+    "AdapterAlreadyRegisteredError",
+    "AdapterBillingType",
+    "AdapterCallRequest",
+    "AdapterCallResult",
+    "AdapterNotFoundError",
+    "AgenticLLMPort",
+    "ClaudeAdapter",
+    "CredentialDetection",
+    "EnvironmentReport",
+    "LLMAdapter",
+    "LLMClientPort",
+    "LLMJsonCallable",
+    "LLMParsedCallable",
+    "LLMTextCallable",
+    "Message",
+    "ModelSpec",
+    "QuotaWindows",
+    "StreamEvent",
+    "ToolSpec",
+    "UsageSummary",
+    "bootstrap_builtins",
+    "get_adapter",
+    "infer_provider_from_model",
+    "list_adapters",
+    "register_adapter",
+    "resolve_agentic_adapter",
+    "resolve_for",
+    "unregister_adapter",
+]

--- a/core/llm/adapters/_anthropic_common.py
+++ b/core/llm/adapters/_anthropic_common.py
@@ -1,0 +1,170 @@
+"""Shared Anthropic-side helpers for the v0.99.39 LLMAdapter built-ins.
+
+Lives next to the concrete Anthropic adapters (``anthropic_payg.py``,
+``anthropic_oauth.py``, ``claude_cli.py``) and holds:
+
+1. ``build_async_anthropic_client(api_key)`` — creates a NEW
+   :class:`anthropic.AsyncAnthropic` per adapter rather than reusing the
+   module-level singleton from ``core.llm.providers.anthropic``. The singleton
+   path caches the first caller's api_key, so passing a fresh key from a
+   different adapter (PAYG api_key vs OAuth token) silently returns the
+   already-cached client and the source boundary collapses. Codex MCP review
+   2026-05-23 flagged this as a BLOCKER for the source/billing guarantee.
+2. ``build_messages`` / ``translate_response`` / ``translate_tool`` / etc. —
+   the request and response shape helpers shared across the three Anthropic
+   adapters. Moving them here removes the prior cross-adapter import
+   (``anthropic_oauth`` → ``anthropic_payg``) flagged as MEDIUM layering smell.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from core.llm.adapters.base import (
+    AdapterCallRequest,
+    AdapterCallResult,
+    ToolSpec,
+    UsageSummary,
+)
+
+if TYPE_CHECKING:
+    import anthropic
+
+
+def build_async_anthropic_client(api_key: str) -> anthropic.AsyncAnthropic:
+    """Construct a fresh ``AsyncAnthropic`` bound to ``api_key``.
+
+    Each adapter owns its client — bypassing the module-level singleton in
+    ``core.llm.providers.anthropic`` which is keyed solely by the first
+    caller's resolved key. Same httpx limits/timeout/event-hooks as the
+    singleton so the response-header banner pipeline keeps working.
+    """
+    if not api_key:
+        raise ValueError("build_async_anthropic_client: api_key is empty")
+    import anthropic
+    import httpx
+
+    from core.llm.providers.anthropic import (
+        _async_response_hook,
+        _build_httpx_limits,
+        _build_httpx_timeout,
+    )
+
+    http_client = httpx.AsyncClient(
+        limits=_build_httpx_limits(),
+        timeout=_build_httpx_timeout(),
+        event_hooks={"response": [_async_response_hook]},
+    )
+    return anthropic.AsyncAnthropic(
+        api_key=api_key,
+        max_retries=0,  # app-level retry handles this
+        http_client=http_client,
+    )
+
+
+def build_messages(req: AdapterCallRequest) -> list[dict[str, Any]]:
+    """Translate adapter-neutral Message list → Anthropic ``messages`` payload."""
+    out: list[dict[str, Any]] = []
+    for m in req.messages:
+        if m.role == "tool":
+            out.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": m.tool_use_id or "",
+                            "content": m.content if isinstance(m.content, str) else "",
+                        }
+                    ],
+                }
+            )
+            continue
+        out.append({"role": m.role, "content": m.content})
+    return out
+
+
+def translate_tool(tool: ToolSpec) -> dict[str, Any]:
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "input_schema": tool.input_schema,
+    }
+
+
+def build_create_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
+    """Shared ``messages.create`` kwargs for both PAYG + OAuth Anthropic adapters."""
+    kwargs: dict[str, Any] = {
+        "model": req.model,
+        "system": req.system_prompt,
+        "messages": build_messages(req),
+        "max_tokens": req.max_tokens,
+    }
+    if req.temperature is not None:
+        kwargs["temperature"] = req.temperature
+    if req.tools:
+        kwargs["tools"] = [translate_tool(t) for t in req.tools]
+    if req.stop_sequences:
+        kwargs["stop_sequences"] = list(req.stop_sequences)
+    if req.thinking_budget > 0:
+        kwargs["thinking"] = {"type": "enabled", "budget_tokens": req.thinking_budget}
+    return kwargs
+
+
+def build_stream_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
+    """Variant of :func:`build_create_kwargs` for ``messages.stream``.
+
+    Streaming does not accept ``thinking`` / ``stop_sequences`` for the
+    same models as ``create``, so the kwargs are trimmed.
+    """
+    kwargs: dict[str, Any] = {
+        "model": req.model,
+        "system": req.system_prompt,
+        "messages": build_messages(req),
+        "max_tokens": req.max_tokens,
+    }
+    if req.temperature is not None:
+        kwargs["temperature"] = req.temperature
+    if req.tools:
+        kwargs["tools"] = [translate_tool(t) for t in req.tools]
+    return kwargs
+
+
+def translate_response(response: Any) -> AdapterCallResult:
+    """Anthropic SDK Message → :class:`AdapterCallResult`."""
+    text_blocks: list[str] = []
+    tool_uses: list[dict[str, Any]] = []
+    for block in getattr(response, "content", []) or []:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text_blocks.append(getattr(block, "text", ""))
+        elif block_type == "tool_use":
+            tool_uses.append(
+                {
+                    "id": getattr(block, "id", ""),
+                    "name": getattr(block, "name", ""),
+                    "input": getattr(block, "input", {}),
+                }
+            )
+    usage = getattr(response, "usage", None)
+    return AdapterCallResult(
+        text="".join(text_blocks),
+        usage=UsageSummary(
+            input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
+            output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
+            cached_input_tokens=getattr(usage, "cache_read_input_tokens", 0) if usage else 0,
+        ),
+        stop_reason=getattr(response, "stop_reason", "end_turn") or "end_turn",
+        tool_uses=tuple(tool_uses),
+        raw_response=response,
+    )
+
+
+__all__ = [
+    "build_async_anthropic_client",
+    "build_create_kwargs",
+    "build_messages",
+    "build_stream_kwargs",
+    "translate_response",
+    "translate_tool",
+]

--- a/core/llm/adapters/_legacy.py
+++ b/core/llm/adapters/_legacy.py
@@ -1,8 +1,29 @@
-"""LLM Protocol interfaces and adapter implementations.
+"""Legacy LLM Protocol interfaces — pre-v0.99.39 paperclip-style abstraction.
 
-Extracted from router.py. Contains Protocol definitions (LLMClientPort,
-AgenticLLMPort, etc.), the ClaudeAdapter concrete class, and the
-resolve_agentic_adapter() factory.
+DEPRECATED (v0.99.39, removal target: v1.0.0)
+===========================================
+
+This module holds the "PR-1 G-A" paperclip-style abstraction (referenced in
+``core/agent/loop/_reflection.py:48``) that defined ``LLMClientPort`` /
+``AgenticLLMPort`` / ``resolve_agentic_adapter`` for provider-agnostic agentic
+calls. It is superseded by the unified :class:`core.llm.adapters.LLMAdapter`
+Protocol + registry (Layer 4 of the v0.99.39 adapter abstraction) which folds
+PAYG / OAuth / local-agent-cli into a single contract.
+
+Why kept under ``_legacy``:
+
+- Many internal callers (``core/agent/loop/_reflection.py``, ``core/llm/router``,
+  ``plugins/petri_audit/*``) still call ``resolve_agentic_adapter(provider)``.
+  Renaming them is out of scope for the v0.99.39 PR — the migration is
+  tracked in ``docs/plans/2026-05-23-llm-adapter-abstraction.md`` § Out of
+  scope.
+- External plugins that import from ``core.llm.adapters`` keep working
+  (``__init__.py`` re-exports the legacy symbols).
+- The new :class:`LLMAdapter` is the canonical entry point for new callers.
+
+Removal plan (v1.0.0): the in-tree call sites are migrated to
+``resolve_for(provider, source)`` (which carries explicit source binding the
+legacy ``resolve_agentic_adapter`` cannot express). This file is then deleted.
 """
 
 from __future__ import annotations

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -1,0 +1,187 @@
+"""Shared OpenAI-side helpers for the v0.99.39 LLMAdapter built-ins.
+
+Mirror of :mod:`core.llm.adapters._anthropic_common` for the OpenAI provider:
+fresh-client builder (PAYG vs Codex OAuth must not share the module-level
+singleton in ``core.llm.providers.openai``) + request/response translation.
+
+Codex MCP review 2026-05-23 flagged the singleton sharing as a BLOCKER for
+the source/billing isolation guarantee — same root cause as the Anthropic
+side. The fix mirrors that pattern: each adapter owns its client.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from core.llm.adapters.base import (
+    AdapterCallRequest,
+    AdapterCallResult,
+    ToolSpec,
+    UsageSummary,
+)
+
+if TYPE_CHECKING:
+    import openai
+
+
+def build_async_openai_client(api_key: str, *, base_url: str | None = None) -> openai.AsyncOpenAI:
+    """Construct a fresh ``AsyncOpenAI`` bound to ``api_key`` (PAYG path).
+
+    For Codex OAuth subscription routing, use
+    :func:`build_async_codex_client` instead — the ``chatgpt.com/backend-api/
+    codex`` endpoint requires ``originator`` + ``ChatGPT-Account-ID`` headers
+    that this PAYG builder does not set.
+    """
+    if not api_key:
+        raise ValueError("build_async_openai_client: api_key is empty")
+    import openai
+
+    if base_url:
+        return openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
+    return openai.AsyncOpenAI(api_key=api_key)
+
+
+def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
+    """Construct a fresh ``AsyncOpenAI`` bound to the Codex OAuth endpoint.
+
+    Mirrors ``core.llm.providers.codex._get_async_codex_client`` (which uses a
+    module-level singleton — the adapter must NOT reuse it, so we replicate
+    the header + base_url plumbing here). The ``originator: codex_cli_rs``
+    header and ``ChatGPT-Account-ID`` (extracted from the JWT) are mandatory
+    — the Codex backend rejects unsigned requests with 401.
+    """
+    if not api_key:
+        raise ValueError("build_async_codex_client: api_key is empty")
+    import openai
+
+    from core.config import CODEX_BASE_URL
+    from core.llm.providers.codex import _extract_account_id
+
+    account_id = _extract_account_id(api_key)
+    headers: dict[str, str] = {"originator": "codex_cli_rs"}
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    return openai.AsyncOpenAI(
+        api_key=api_key,
+        base_url=CODEX_BASE_URL,
+        default_headers=headers,
+    )
+
+
+def translate_tool_for_codex(tool: ToolSpec) -> dict[str, Any]:
+    """Codex Responses API uses the FLAT tool shape, not Chat Completions nested.
+
+    Mirrors :func:`core.llm.providers.openai._tools_to_openai` for the
+    Responses-API call path used by ``CodexAgenticAdapter`` — top-level
+    ``type/name/description/parameters`` rather than nested under ``function``.
+    """
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": tool.input_schema,
+    }
+
+
+def build_messages(req: AdapterCallRequest) -> list[dict[str, Any]]:
+    """Translate adapter-neutral Message list → OpenAI Chat ``messages`` payload."""
+    out: list[dict[str, Any]] = []
+    if req.system_prompt:
+        out.append({"role": "system", "content": req.system_prompt})
+    for m in req.messages:
+        if m.role == "tool":
+            out.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": m.tool_use_id or "",
+                    "content": m.content if isinstance(m.content, str) else "",
+                }
+            )
+            continue
+        out.append({"role": m.role, "content": m.content})
+    return out
+
+
+def translate_tool(tool: ToolSpec) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema,
+        },
+    }
+
+
+def translate_chat_response(response: Any) -> AdapterCallResult:
+    """OpenAI ``ChatCompletion`` → :class:`AdapterCallResult`."""
+    choice = response.choices[0] if response.choices else None
+    message = getattr(choice, "message", None) if choice else None
+    text = getattr(message, "content", "") or "" if message else ""
+    tool_calls = getattr(message, "tool_calls", None) if message else None
+    tool_uses: list[dict[str, Any]] = []
+    if tool_calls:
+        for tc in tool_calls:
+            fn = getattr(tc, "function", None)
+            if fn is None:
+                continue
+            tool_uses.append(
+                {
+                    "id": getattr(tc, "id", ""),
+                    "name": getattr(fn, "name", ""),
+                    "input": getattr(fn, "arguments", "{}"),
+                }
+            )
+    usage = getattr(response, "usage", None)
+    return AdapterCallResult(
+        text=text,
+        usage=UsageSummary(
+            input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+            output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+        ),
+        stop_reason=getattr(choice, "finish_reason", "stop") if choice else "stop",
+        tool_uses=tuple(tool_uses),
+        raw_response=response,
+    )
+
+
+def translate_codex_response(response: Any) -> AdapterCallResult:
+    """Codex ``Response`` → :class:`AdapterCallResult`.
+
+    Codex uses ``output_text`` (concatenated) + ``output`` (typed items)
+    instead of OpenAI Chat ``message.content``.
+    """
+    text = getattr(response, "output_text", "") or ""
+    tool_uses: list[dict[str, Any]] = []
+    output_items = getattr(response, "output", []) or []
+    for item in output_items:
+        if getattr(item, "type", "") == "function_call":
+            tool_uses.append(
+                {
+                    "id": getattr(item, "id", "") or getattr(item, "call_id", ""),
+                    "name": getattr(item, "name", ""),
+                    "input": getattr(item, "arguments", "{}"),
+                }
+            )
+    usage = getattr(response, "usage", None)
+    return AdapterCallResult(
+        text=text,
+        usage=UsageSummary(
+            input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
+            output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
+        ),
+        stop_reason=getattr(response, "status", "completed") or "completed",
+        tool_uses=tuple(tool_uses),
+        raw_response=response,
+    )
+
+
+__all__ = [
+    "build_async_codex_client",
+    "build_async_openai_client",
+    "build_messages",
+    "translate_chat_response",
+    "translate_codex_response",
+    "translate_tool",
+    "translate_tool_for_codex",
+]

--- a/core/llm/adapters/_subprocess_common.py
+++ b/core/llm/adapters/_subprocess_common.py
@@ -1,0 +1,41 @@
+"""Shared helpers for subprocess-backed adapters (claude-cli / codex-cli).
+
+Both ``ClaudeCliAdapter`` and ``CodexCliAdapter`` flatten the adapter call
+into a single stdin prompt fed to a local CLI binary (``claude --print`` /
+``codex exec``). The flatten shape is provider-agnostic, so the helper lives
+here rather than being copy-pasted across the two adapters (Codex MCP review
+2026-05-23 MEDIUM finding — cross-adapter helper import).
+"""
+
+from __future__ import annotations
+
+from core.llm.adapters.base import AdapterCallRequest
+
+
+def build_subprocess_stdin(req: AdapterCallRequest) -> str:
+    """Flatten the adapter call into a single stdin prompt.
+
+    System prompt prepended as a marker; user/assistant turns concatenated.
+    Tool turns are skipped — the subprocess text-only path doesn't support
+    them (callers pin ``supports_tools=False`` in their ``list_models``
+    output).
+    """
+    parts: list[str] = []
+    if req.system_prompt:
+        parts.append("[SYSTEM]")
+        parts.append(req.system_prompt)
+        parts.append("")
+    for m in req.messages:
+        if m.role == "tool":
+            continue
+        label = m.role.upper()
+        parts.append(f"[{label}]")
+        if isinstance(m.content, str):
+            parts.append(m.content)
+        else:
+            parts.append(str(m.content))
+        parts.append("")
+    return "\n".join(parts).strip() + "\n"
+
+
+__all__ = ["build_subprocess_stdin"]

--- a/core/llm/adapters/anthropic_oauth.py
+++ b/core/llm/adapters/anthropic_oauth.py
@@ -1,0 +1,197 @@
+"""AnthropicOAuthAdapter — Subscription (Claude.ai) OAuth path.
+
+Layer 3 adapter. Forces credential resolution to the OAuth profile at
+``~/.claude/oauth-token.json``, bypassing the PAYG ``ANTHROPIC_API_KEY`` even
+if both are configured. Owns its own ``AsyncAnthropic`` client (Codex MCP
+review 2026-05-23 BLOCKER fix — pre-refactor the singleton in
+``core.llm.providers.anthropic`` was shared with the PAYG adapter so the
+first caller's api_key won permanently).
+
+Paper-trail: paperclip's ``adapter-claude-local`` package equivalent.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from core.llm.adapters._anthropic_common import (
+    build_async_anthropic_client,
+    build_create_kwargs,
+    build_stream_kwargs,
+    translate_response,
+)
+from core.llm.adapters.base import (
+    SOURCE_SUBSCRIPTION,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+)
+
+log = logging.getLogger(__name__)
+
+
+CLAUDE_OAUTH_TOKEN_PATH = Path.home() / ".claude" / "oauth-token.json"
+
+
+@dataclass
+class AnthropicOAuthAdapter:
+    """Subscription-routed Anthropic adapter — owns its own AsyncAnthropic client."""
+
+    name: str = "anthropic-oauth"
+    provider: str = "anthropic"
+    source: str = SOURCE_SUBSCRIPTION
+    billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION
+    _last_error: Exception | None = field(default=None, init=False, repr=False)
+    _client: Any = field(default=None, init=False, repr=False)
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        token = _resolve_oauth_token()
+        if not token:
+            raise RuntimeError(
+                "AnthropicOAuthAdapter: Claude OAuth token not found at "
+                f"{CLAUDE_OAUTH_TOKEN_PATH}. Run ``claude /login`` in the Claude CLI "
+                "or use the anthropic-payg adapter instead."
+            )
+        self._client = build_async_anthropic_client(token)
+        return self._client
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        client = self._get_client()
+        try:
+            response = await client.messages.create(**build_create_kwargs(req))
+        except Exception as exc:
+            self._last_error = exc
+            log.warning("anthropic-oauth: messages.create failed model=%s err=%s", req.model, exc)
+            raise
+        return translate_response(response)
+
+    async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
+        client = self._get_client()
+        async with client.messages.stream(**build_stream_kwargs(req)) as stream:
+            async for text_chunk in stream.text_stream:
+                yield StreamEvent(kind="text", payload={"text": text_chunk})
+            final = await stream.get_final_message()
+            yield StreamEvent(
+                kind="stop",
+                payload={
+                    "stop_reason": getattr(final, "stop_reason", "end_turn") or "end_turn",
+                    "usage": {
+                        "input_tokens": getattr(final.usage, "input_tokens", 0),
+                        "output_tokens": getattr(final.usage, "output_tokens", 0),
+                    },
+                },
+            )
+
+    def test_environment(self) -> EnvironmentReport:
+        if not CLAUDE_OAUTH_TOKEN_PATH.is_file():
+            return EnvironmentReport(
+                ok=False,
+                checks=(("oauth_token_file", "missing"),),
+                hints=(
+                    f"Expected OAuth token at {CLAUDE_OAUTH_TOKEN_PATH}.",
+                    "Run ``claude /login`` in the Claude CLI to provision it.",
+                ),
+            )
+        token = _resolve_oauth_token()
+        if not token:
+            return EnvironmentReport(
+                ok=False,
+                checks=(
+                    ("oauth_token_file", "present"),
+                    ("oauth_token_parseable", "unreadable"),
+                ),
+                hints=(
+                    "OAuth token file exists but could not be parsed. Re-run ``claude /login``.",
+                ),
+            )
+        return EnvironmentReport(
+            ok=True,
+            checks=(
+                ("oauth_token_file", str(CLAUDE_OAUTH_TOKEN_PATH)),
+                ("oauth_token_length", f"{len(token)} chars"),
+            ),
+        )
+
+    def list_models(self) -> list[ModelSpec]:
+        from core.config import ANTHROPIC_FALLBACK_CHAIN, ANTHROPIC_PRIMARY
+
+        ids = [ANTHROPIC_PRIMARY, *ANTHROPIC_FALLBACK_CHAIN]
+        seen: set[str] = set()
+        models: list[ModelSpec] = []
+        for mid in ids:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            models.append(
+                ModelSpec(
+                    id=mid,
+                    label=mid,
+                    context_tokens=200_000,
+                    supports_thinking=True,
+                    supports_tools=True,
+                )
+            )
+        return models
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        """Subscription quota windows — None until wired by the UI follow-up.
+
+        The Anthropic SDK emits ``anthropic-priority-tier`` headers per
+        response which feed the legacy ``SubscriptionQuotaBanner``
+        (``core/cli/quota_banner.py``). The adapter cannot import from
+        ``core.cli`` (architecture: ``core/llm/`` is below ``core/cli/`` in
+        the dependency layering — verified by ``lint-imports``). The
+        follow-up UI PR (D in the plan doc) introduces a callback /
+        observability hook that the banner can push into, keeping the
+        dependency direction bottom-up. Until then this returns ``None``
+        (treated as "unknown").
+        """
+        return None
+
+    def detect_credential(self) -> CredentialDetection | None:
+        if not CLAUDE_OAUTH_TOKEN_PATH.is_file():
+            return None
+        from core.config import ANTHROPIC_PRIMARY
+
+        return CredentialDetection(
+            model=ANTHROPIC_PRIMARY,
+            provider=self.provider,
+            source_path=str(CLAUDE_OAUTH_TOKEN_PATH),
+        )
+
+
+def _resolve_oauth_token() -> str:
+    """Read Claude OAuth access_token from ``~/.claude/oauth-token.json``.
+
+    Returns empty string when the file is missing, malformed, or expired.
+    Refresh logic lives in ``core/auth/`` — this helper is read-only and
+    surfaces failures via the empty-string sentinel so callers can map it to
+    a clear ``RuntimeError`` hint.
+    """
+    if not CLAUDE_OAUTH_TOKEN_PATH.is_file():
+        return ""
+    import json
+
+    try:
+        data = json.loads(CLAUDE_OAUTH_TOKEN_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug("anthropic-oauth: cannot read OAuth token: %s", exc)
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    token = data.get("access_token") or data.get("token") or ""
+    return str(token) if isinstance(token, (str, int)) else ""
+
+
+__all__ = ["AnthropicOAuthAdapter"]

--- a/core/llm/adapters/anthropic_payg.py
+++ b/core/llm/adapters/anthropic_payg.py
@@ -1,0 +1,149 @@
+"""AnthropicPaygAdapter — PAYG (API-key) path to Anthropic models.
+
+Layer 3 adapter (paperclip ``ServerAdapterModule`` shape). Calls the Anthropic
+SDK with the API key from settings — and *not* the OAuth profile, even if
+``ProfileRotator`` would prefer it under the legacy
+``_resolve_anthropic_key()`` global priority. Codex MCP review 2026-05-23
+flagged the singleton-client sharing as a BLOCKER for source isolation; this
+adapter now owns its client via :func:`_anthropic_common.build_async_anthropic_client`.
+
+Pair with :class:`AnthropicOAuthAdapter` (same provider, different source).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.llm.adapters._anthropic_common import (
+    build_async_anthropic_client,
+    build_create_kwargs,
+    build_stream_kwargs,
+    translate_response,
+)
+from core.llm.adapters.base import (
+    SOURCE_PAYG,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class AnthropicPaygAdapter:
+    """PAYG-routed Anthropic adapter — owns its own AsyncAnthropic client."""
+
+    name: str = "anthropic-payg"
+    provider: str = "anthropic"
+    source: str = SOURCE_PAYG
+    billing_type: AdapterBillingType = AdapterBillingType.API
+    _last_error: Exception | None = field(default=None, init=False, repr=False)
+    _client: Any = field(default=None, init=False, repr=False)
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        from core.config import settings
+
+        api_key = settings.anthropic_api_key
+        if not api_key:
+            raise RuntimeError(
+                "AnthropicPaygAdapter: ANTHROPIC_API_KEY not set. PAYG path requires "
+                "an explicit API key — set ``anthropic_api_key`` in settings or use "
+                "the anthropic-oauth adapter instead."
+            )
+        self._client = build_async_anthropic_client(api_key)
+        return self._client
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        client = self._get_client()
+        try:
+            response = await client.messages.create(**build_create_kwargs(req))
+        except Exception as exc:
+            self._last_error = exc
+            log.warning("anthropic-payg: messages.create failed model=%s err=%s", req.model, exc)
+            raise
+        return translate_response(response)
+
+    async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
+        client = self._get_client()
+        async with client.messages.stream(**build_stream_kwargs(req)) as stream:
+            async for text_chunk in stream.text_stream:
+                yield StreamEvent(kind="text", payload={"text": text_chunk})
+            final = await stream.get_final_message()
+            yield StreamEvent(
+                kind="stop",
+                payload={
+                    "stop_reason": getattr(final, "stop_reason", "end_turn") or "end_turn",
+                    "usage": {
+                        "input_tokens": getattr(final.usage, "input_tokens", 0),
+                        "output_tokens": getattr(final.usage, "output_tokens", 0),
+                    },
+                },
+            )
+
+    def test_environment(self) -> EnvironmentReport:
+        from core.config import settings
+
+        api_key = settings.anthropic_api_key
+        if not api_key:
+            return EnvironmentReport(
+                ok=False,
+                checks=(("anthropic_api_key", "missing"),),
+                hints=(
+                    "Set ``ANTHROPIC_API_KEY`` in your environment or in ~/.geode/config.toml.",
+                    "Or use the anthropic-oauth adapter if you have a Claude subscription.",
+                ),
+            )
+        return EnvironmentReport(
+            ok=True,
+            checks=(("anthropic_api_key", f"set ({len(api_key)} chars)"),),
+        )
+
+    def list_models(self) -> list[ModelSpec]:
+        from core.config import ANTHROPIC_FALLBACK_CHAIN, ANTHROPIC_PRIMARY
+
+        ids = [ANTHROPIC_PRIMARY, *ANTHROPIC_FALLBACK_CHAIN]
+        seen: set[str] = set()
+        models: list[ModelSpec] = []
+        for mid in ids:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            models.append(
+                ModelSpec(
+                    id=mid,
+                    label=mid,
+                    context_tokens=200_000,
+                    supports_thinking=mid.startswith("claude-"),
+                    supports_tools=True,
+                )
+            )
+        return models
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        # PAYG is metered per-call; no aggregate quota window.
+        return None
+
+    def detect_credential(self) -> CredentialDetection | None:
+        from core.config import ANTHROPIC_PRIMARY, settings
+
+        if not settings.anthropic_api_key:
+            return None
+        return CredentialDetection(
+            model=ANTHROPIC_PRIMARY,
+            provider=self.provider,
+            source_path="settings.anthropic_api_key",
+        )
+
+
+__all__ = ["AnthropicPaygAdapter"]

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -1,0 +1,251 @@
+"""LLM Adapter base contract — single Protocol for all call paths.
+
+Mirrors paperclip's ``ServerAdapterModule`` (``packages/adapter-utils/src/
+types.ts:349``): one interface that covers PAYG API calls, OAuth subscription
+calls, and local agent-cli subprocess calls. Provider routing decisions live
+inside concrete adapters (`Layer 3`) — callers above just pick a name (or
+provider+source pair) and invoke ``acomplete`` / ``astream``.
+
+The Protocol is intentionally duck-typed (PEP 544) so external plugins can
+implement it without subclassing — same plug-in friendliness as paperclip's TS
+interface.
+
+See ``docs/plans/2026-05-23-llm-adapter-abstraction.md`` for the full Layer 4
+design and the deprecation roster for Layer 2 direct callers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class AdapterBillingType(str, Enum):  # noqa: UP042 — needs str+Enum for older serialisers
+    """How an adapter's call gets billed.
+
+    Mirrors paperclip ``packages/adapter-utils/src/types.ts:34-43``
+    ``AdapterBillingType``. The 8-value taxonomy lets the UI surface
+    ("PAYG, Subscription, Adapter") map cleanly while still capturing
+    overage/credits/fixed-fee edge cases for non-Anthropic/OpenAI providers.
+    """
+
+    API = "api"
+    SUBSCRIPTION = "subscription"
+    METERED_API = "metered_api"
+    SUBSCRIPTION_INCLUDED = "subscription_included"
+    SUBSCRIPTION_OVERAGE = "subscription_overage"
+    CREDITS = "credits"
+    FIXED = "fixed"
+    UNKNOWN = "unknown"
+
+
+# Concrete source values that picker / overrides emit. Adapter implementations
+# pin themselves to exactly one. ``auto`` is a picker-time sentinel only — never
+# stored on a concrete adapter and never accepted by ``resolve_for``.
+SOURCE_PAYG = "payg"
+SOURCE_SUBSCRIPTION = "subscription"
+SOURCE_ADAPTER = "adapter"
+SOURCE_AUTO = "auto"  # picker sentinel
+
+CONCRETE_SOURCES: frozenset[str] = frozenset({SOURCE_PAYG, SOURCE_SUBSCRIPTION, SOURCE_ADAPTER})
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Tool descriptor passed to the adapter call.
+
+    Provider-agnostic — adapters translate to Anthropic ``tools`` / OpenAI
+    ``tools`` payload shape internally.
+    """
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Message:
+    """Single conversation turn — provider-agnostic.
+
+    ``role`` is one of ``"user" | "assistant" | "tool"``; tool messages carry a
+    ``tool_use_id`` so the adapter can wire results back to the originating
+    tool_use block.
+    """
+
+    role: str
+    content: str | list[dict[str, Any]]
+    tool_use_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AdapterCallRequest:
+    """Request envelope handed to ``LLMAdapter.acomplete`` / ``astream``."""
+
+    model: str
+    messages: Sequence[Message]
+    system_prompt: str = ""
+    tools: Sequence[ToolSpec] = field(default_factory=tuple)
+    max_tokens: int = 8192
+    temperature: float | None = None
+    thinking_budget: int = 0
+    effort: str = "medium"
+    stop_sequences: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class UsageSummary:
+    """Token accounting block from a single LLM call.
+
+    Mirrors paperclip ``UsageSummary`` (``types.ts:30-34``). ``cached_input``
+    tracks prompt-cache hits separately so cost estimation can apply the
+    discounted rate (Anthropic) without losing the gross-input figure.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class AdapterCallResult:
+    """Completed (non-streaming) LLM response.
+
+    ``raw_response`` is the underlying SDK response object — adapters expose it
+    so caller-side observability (token hooks, retry journals) can still extract
+    provider-specific headers (Anthropic ``anthropic-priority-tier`` etc.)
+    without bypassing the adapter.
+    """
+
+    text: str
+    usage: UsageSummary
+    stop_reason: str
+    tool_uses: tuple[dict[str, Any], ...] = ()
+    raw_response: Any = None
+
+
+@dataclass(frozen=True)
+class StreamEvent:
+    """One streaming chunk from ``LLMAdapter.astream``.
+
+    ``kind`` is ``"text" | "tool_use" | "thinking" | "stop" | "usage"``.
+    Concrete adapters translate provider stream events into this single shape so
+    UI / observability code doesn't branch on provider.
+    """
+
+    kind: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """One model the adapter can serve. Returned by ``list_models``.
+
+    Mirrors paperclip ``AdapterModel`` — the UI uses ``label`` + ``context_tokens``
+    to render selection menus.
+    """
+
+    id: str
+    label: str
+    context_tokens: int
+    supports_thinking: bool = False
+    supports_tools: bool = True
+
+
+@dataclass(frozen=True)
+class QuotaWindows:
+    """Live quota/rate-limit windows for OAuth subscription adapters.
+
+    Mirrors paperclip ``ProviderQuotaResult``. Adapters that don't expose quota
+    (PAYG) return ``None`` from ``get_quota_windows``.
+    """
+
+    used_tokens: int
+    total_tokens: int
+    window_seconds: int
+    reset_at: float | None = None  # unix epoch seconds
+
+
+@dataclass(frozen=True)
+class EnvironmentReport:
+    """Result of ``test_environment`` — paperclip ``testEnvironment`` mirror.
+
+    ``ok`` is the headline pass/fail; ``checks`` carries per-credential /
+    per-binary detail rows the UI surfaces. ``hints`` are operator-facing fix
+    suggestions ("set ``ANTHROPIC_API_KEY``", "run ``claude /login``").
+    """
+
+    ok: bool
+    checks: tuple[tuple[str, str], ...] = ()  # (label, status_or_message)
+    hints: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CredentialDetection:
+    """``detect_credential`` result — paperclip ``detectModel`` mirror.
+
+    Adapters that read a local config (``~/.claude/oauth-token.json`` etc.)
+    return the currently configured model + provenance so the UI can show
+    "currently configured: claude-sonnet-4-7 (from ~/.claude/oauth-token.json)".
+    """
+
+    model: str
+    provider: str
+    source_path: str
+    candidates: tuple[str, ...] = ()
+
+
+@runtime_checkable
+class LLMAdapter(Protocol):
+    """Single adapter contract — paperclip ``ServerAdapterModule`` equivalent.
+
+    Concrete implementations live in ``core/llm/adapters/<name>.py``. External
+    plugins implement this Protocol without subclassing and register via
+    :func:`core.llm.adapters.registry.register_adapter`.
+
+    Three required identity attributes (``name`` / ``provider`` / ``source``)
+    plus ``billing_type`` and one async call method (``acomplete``) form the
+    minimum viable adapter. Streaming + introspection methods are required by
+    the Protocol but can return empty / ``None`` for adapters that don't
+    support those surfaces (test_environment must always be honest).
+    """
+
+    name: str
+    provider: str
+    source: str  # one of CONCRETE_SOURCES (never SOURCE_AUTO)
+    billing_type: AdapterBillingType
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult: ...
+
+    def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]: ...
+
+    def test_environment(self) -> EnvironmentReport: ...
+
+    def list_models(self) -> list[ModelSpec]: ...
+
+    def get_quota_windows(self) -> QuotaWindows | None: ...
+
+    def detect_credential(self) -> CredentialDetection | None: ...
+
+
+__all__ = [
+    "CONCRETE_SOURCES",
+    "SOURCE_ADAPTER",
+    "SOURCE_AUTO",
+    "SOURCE_PAYG",
+    "SOURCE_SUBSCRIPTION",
+    "AdapterBillingType",
+    "AdapterCallRequest",
+    "AdapterCallResult",
+    "CredentialDetection",
+    "EnvironmentReport",
+    "LLMAdapter",
+    "Message",
+    "ModelSpec",
+    "QuotaWindows",
+    "StreamEvent",
+    "ToolSpec",
+    "UsageSummary",
+]

--- a/core/llm/adapters/claude_cli.py
+++ b/core/llm/adapters/claude_cli.py
@@ -1,0 +1,198 @@
+"""ClaudeCliAdapter — local ``claude`` binary subprocess path.
+
+Layer 3 adapter for Anthropic provider, source=adapter. Spawns the local
+``claude`` CLI binary (the same one operators use interactively) and pipes the
+prompt through stdin. The binary uses its own OAuth subscription quota — no
+GEODE-side API key, no ProfileRotator involvement.
+
+This is the "Adapter" choice in the user-facing PAYG / Subscription / Adapter
+trichotomy. Maps to paperclip's ``adapter-claude-local`` package.
+
+The actual subprocess implementation is reused from
+:mod:`plugins.petri_audit.claude_cli_provider` (``_run_claude_subprocess`` +
+``build_claude_cli_argv``) — that module is the canonical Anthropic-subprocess
+runner; the adapter is the public Layer 4-shaped surface around it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+from core.llm.adapters._subprocess_common import build_subprocess_stdin
+from core.llm.adapters.base import (
+    SOURCE_ADAPTER,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+    UsageSummary,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ClaudeCliAdapter:
+    """Local ``claude`` CLI subprocess adapter."""
+
+    name: str = "claude-cli"
+    provider: str = "anthropic"
+    source: str = SOURCE_ADAPTER
+    billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION_INCLUDED
+    _last_error: Exception | None = field(default=None, init=False, repr=False)
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        """Single-turn ``claude --print`` invocation.
+
+        Behaviour mirrors :func:`plugins.petri_audit.claude_cli_provider._generate_text_only`
+        — the canonical Claude OAuth-subprocess path. LaneQueue
+        (``core.orchestration.claude_cli_lane``) gates concurrency so multiple
+        adapter callers don't burst-overload the local binary.
+        """
+        from plugins.petri_audit.claude_cli_provider import (
+            ClaudeCliInvocationError,
+            _resolve_claude_binary,
+            _run_claude_subprocess,
+            build_claude_cli_argv,
+        )
+
+        from core.orchestration.claude_cli_lane import acquire_claude_cli_lane_async
+
+        binary = _resolve_claude_binary()
+        argv = build_claude_cli_argv(binary=binary, model_name=req.model, max_turns=1)
+        stdin_text = build_subprocess_stdin(req)
+        lane_key = f"claude-cli:{req.model}"
+        try:
+            async with acquire_claude_cli_lane_async(lane_key):
+                stdout, stderr, rc = await _run_claude_subprocess(argv, stdin_text, timeout_s=600.0)
+        except ClaudeCliInvocationError as exc:
+            self._last_error = exc
+            raise
+        if rc != 0:
+            err_excerpt = stderr.strip().splitlines()[-1] if stderr.strip() else "<no stderr>"
+            raise RuntimeError(f"claude-cli subprocess exited rc={rc}: {err_excerpt}")
+        return AdapterCallResult(
+            text=stdout,
+            usage=UsageSummary(),  # subscription path does not expose token usage
+            stop_reason="end_turn",
+        )
+
+    async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
+        """Yield a single chunk — ``claude --print`` is synchronous-only.
+
+        The subscription-subprocess path doesn't natively stream tokens — the
+        CLI buffers and emits at the end. The adapter yields a single
+        ``text`` event followed by ``stop`` so callers using the streaming
+        surface still get a valid event sequence.
+        """
+        result = await self.acomplete(req)
+        if result.text:
+            yield StreamEvent(kind="text", payload={"text": result.text})
+        yield StreamEvent(
+            kind="stop",
+            payload={"stop_reason": result.stop_reason},
+        )
+
+    def test_environment(self) -> EnvironmentReport:
+        from plugins.petri_audit.adapters.claude_cli_backend import is_available
+
+        try:
+            from plugins.petri_audit.claude_cli_provider import _resolve_claude_binary
+
+            binary = _resolve_claude_binary()
+        except Exception as exc:
+            return EnvironmentReport(
+                ok=False,
+                checks=(("claude_binary", "missing"),),
+                hints=(
+                    f"Could not locate the ``claude`` binary: {exc}",
+                    "Install the Claude CLI from https://claude.ai/code.",
+                ),
+            )
+        if not is_available():
+            return EnvironmentReport(
+                ok=False,
+                checks=(
+                    ("claude_binary", binary),
+                    ("oauth_token", "missing"),
+                ),
+                hints=(
+                    "Claude binary found but OAuth token not resolvable.",
+                    "Run ``claude /login`` to authenticate.",
+                ),
+            )
+        return EnvironmentReport(
+            ok=True,
+            checks=(
+                ("claude_binary", binary),
+                ("oauth_token", "present"),
+            ),
+        )
+
+    def list_models(self) -> list[ModelSpec]:
+        from core.config import ANTHROPIC_FALLBACK_CHAIN, ANTHROPIC_PRIMARY
+
+        ids = [ANTHROPIC_PRIMARY, *ANTHROPIC_FALLBACK_CHAIN]
+        seen: set[str] = set()
+        out: list[ModelSpec] = []
+        for mid in ids:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            out.append(
+                ModelSpec(
+                    id=mid,
+                    label=f"{mid} (via claude-cli)",
+                    context_tokens=200_000,
+                    supports_thinking=True,
+                    supports_tools=False,  # subprocess text-only path
+                )
+            )
+        return out
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        """Read OAuth quota via the petri_audit helper.
+
+        Returns ``None`` when the helper isn't available or quota probe fails —
+        the UI then renders "unknown" instead of "zero".
+        """
+        try:
+            from plugins.petri_audit.adapters.claude_cli_backend import metadata
+
+            md = metadata()
+        except Exception:
+            return None
+        if not isinstance(md, dict):
+            return None
+        used = md.get("used_tokens")
+        total = md.get("total_tokens")
+        if not isinstance(used, int) or not isinstance(total, int) or total <= 0:
+            return None
+        window = md.get("window_seconds")
+        return QuotaWindows(
+            used_tokens=used,
+            total_tokens=total,
+            window_seconds=int(window) if isinstance(window, int) else 0,
+        )
+
+    def detect_credential(self) -> CredentialDetection | None:
+        from plugins.petri_audit.adapters.claude_cli_backend import is_available
+
+        if not is_available():
+            return None
+        from core.config import ANTHROPIC_PRIMARY
+
+        return CredentialDetection(
+            model=ANTHROPIC_PRIMARY,
+            provider=self.provider,
+            source_path="~/.claude/oauth-token.json (via claude binary)",
+        )
+
+
+__all__ = ["ClaudeCliAdapter"]

--- a/core/llm/adapters/codex_cli.py
+++ b/core/llm/adapters/codex_cli.py
@@ -1,0 +1,191 @@
+"""CodexCliAdapter — local ``codex`` binary subprocess path.
+
+Layer 3 adapter for OpenAI provider, source=adapter. Spawns the local ``codex``
+CLI binary (the OpenAI Codex CLI, ChatGPT subscription-billed) and pipes the
+prompt through stdin. The binary uses its own subscription quota — no GEODE-
+side API key, no profile rotator.
+
+Sibling of :class:`core.llm.adapters.claude_cli.ClaudeCliAdapter`. Maps to
+paperclip's ``adapter-codex-local`` package.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+from core.llm.adapters._subprocess_common import build_subprocess_stdin
+from core.llm.adapters.base import (
+    SOURCE_ADAPTER,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+    UsageSummary,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Honoured search paths for the codex binary (highest priority first).
+# Matches the discovery order used by the petri-audit codex_cli_provider.
+_CODEX_BINARY_HINTS: tuple[str, ...] = (
+    "codex",  # PATH lookup
+    "/Users/mango/.local/bin/codex",
+    "/Applications/cmux.app/Contents/Resources/codex/bin/codex",
+)
+
+
+@dataclass
+class CodexCliAdapter:
+    """Local ``codex`` CLI subprocess adapter."""
+
+    name: str = "codex-cli"
+    provider: str = "openai"
+    source: str = SOURCE_ADAPTER
+    billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION_INCLUDED
+    _last_error: Exception | None = field(default=None, init=False, repr=False)
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        import asyncio
+
+        from core.orchestration.codex_cli_lane import acquire_codex_cli_lane_async
+
+        binary = _resolve_codex_binary()
+        if not binary:
+            raise RuntimeError(
+                "CodexCliAdapter: ``codex`` binary not found on PATH or known hints. "
+                "Install the Codex CLI or use the openai-payg / codex-oauth adapter."
+            )
+        argv = [binary, "exec", "--model", req.model, "--full-auto"]
+        stdin_text = build_subprocess_stdin(req)
+        lane_key = f"codex-cli:{req.model}"
+        async with acquire_codex_cli_lane_async(lane_key):
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except (FileNotFoundError, OSError) as exc:
+                self._last_error = exc
+                raise RuntimeError(f"codex-cli: spawn failed — {exc!r}") from exc
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(
+                    proc.communicate(stdin_text.encode("utf-8")),
+                    timeout=600.0,
+                )
+            except TimeoutError as exc:
+                proc.kill()
+                await proc.wait()
+                self._last_error = exc
+                raise RuntimeError("codex-cli: subprocess timeout after 600s") from exc
+        stdout = stdout_b.decode("utf-8", errors="replace")
+        stderr = stderr_b.decode("utf-8", errors="replace")
+        rc = proc.returncode or 0
+        if rc != 0:
+            err_excerpt = stderr.strip().splitlines()[-1] if stderr.strip() else "<no stderr>"
+            raise RuntimeError(f"codex-cli subprocess exited rc={rc}: {err_excerpt}")
+        return AdapterCallResult(
+            text=stdout,
+            usage=UsageSummary(),
+            stop_reason="end_turn",
+        )
+
+    async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
+        result = await self.acomplete(req)
+        if result.text:
+            yield StreamEvent(kind="text", payload={"text": result.text})
+        yield StreamEvent(kind="stop", payload={"stop_reason": result.stop_reason})
+
+    def test_environment(self) -> EnvironmentReport:
+        binary = _resolve_codex_binary()
+        if not binary:
+            return EnvironmentReport(
+                ok=False,
+                checks=(("codex_binary", "missing"),),
+                hints=(
+                    "Install the Codex CLI (https://github.com/openai/codex-cli) "
+                    "and ensure it's on PATH.",
+                ),
+            )
+        from pathlib import Path
+
+        auth = Path.home() / ".codex" / "auth.json"
+        if not auth.is_file():
+            return EnvironmentReport(
+                ok=False,
+                checks=(
+                    ("codex_binary", binary),
+                    ("codex_auth", "missing"),
+                ),
+                hints=("Run ``codex auth login`` to provision the OAuth token.",),
+            )
+        return EnvironmentReport(
+            ok=True,
+            checks=(
+                ("codex_binary", binary),
+                ("codex_auth", str(auth)),
+            ),
+        )
+
+    def list_models(self) -> list[ModelSpec]:
+        from core.config import CODEX_FALLBACK_CHAIN, CODEX_PRIMARY
+
+        ids = [CODEX_PRIMARY, *CODEX_FALLBACK_CHAIN]
+        seen: set[str] = set()
+        out: list[ModelSpec] = []
+        for mid in ids:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            out.append(
+                ModelSpec(
+                    id=mid,
+                    label=f"{mid} (via codex-cli)",
+                    context_tokens=128_000,
+                    supports_thinking=mid.startswith(("o3", "o4")),
+                    supports_tools=False,
+                )
+            )
+        return out
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        return None
+
+    def detect_credential(self) -> CredentialDetection | None:
+        binary = _resolve_codex_binary()
+        if not binary:
+            return None
+        from core.config import CODEX_PRIMARY
+
+        return CredentialDetection(
+            model=CODEX_PRIMARY,
+            provider=self.provider,
+            source_path=f"{binary} (subscription via ~/.codex/auth.json)",
+        )
+
+
+def _resolve_codex_binary() -> str:
+    """Resolve the ``codex`` binary path, honouring known hints + PATH lookup."""
+    for hint in _CODEX_BINARY_HINTS:
+        path = shutil.which(hint) if "/" not in hint else (hint if _is_exec(hint) else "")
+        if path:
+            return path
+    return ""
+
+
+def _is_exec(path: str) -> bool:
+    import os
+
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+__all__ = ["CodexCliAdapter"]

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -1,0 +1,244 @@
+"""CodexOAuthAdapter — ChatGPT subscription OAuth path via Codex backend.
+
+Layer 3 adapter for OpenAI provider, source=subscription. Uses the
+``chatgpt.com/backend-api/codex`` endpoint with the OAuth token resolved by
+:func:`core.llm.providers.codex._resolve_codex_token` — which checks **both**
+the GEODE ``ProfileStore`` (``openai-codex`` profile registered via
+``/login openai``) *and* the external ``~/.codex/auth.json`` (Codex CLI
+fallback). Codex MCP review 2026-05-23 HIGH finding: the prior version only
+checked ``~/.codex/auth.json``, which broke users who only had a GEODE-issued
+profile.
+
+Adapter owns its own ``AsyncOpenAI`` client (Codex MCP BLOCKER fix — the
+module-level singleton in ``core.llm.providers.codex`` would shadow per-call
+credential differences).
+
+Pair with :class:`OpenAIPaygAdapter` (same provider, API key path) and
+:class:`CodexCliAdapter` (subprocess path).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from core.llm.adapters._openai_common import (
+    build_async_codex_client,
+    build_messages,
+    translate_codex_response,
+    translate_tool_for_codex,
+)
+from core.llm.adapters.base import (
+    SOURCE_SUBSCRIPTION,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+)
+
+log = logging.getLogger(__name__)
+
+
+CODEX_AUTH_PATH = Path.home() / ".codex" / "auth.json"
+
+
+@dataclass
+class CodexOAuthAdapter:
+    """Subscription-routed OpenAI adapter via Codex OAuth backend."""
+
+    name: str = "codex-oauth"
+    provider: str = "openai"
+    source: str = SOURCE_SUBSCRIPTION
+    billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION
+    _last_error: Exception | None = field(default=None, init=False, repr=False)
+    _client: Any = field(default=None, init=False, repr=False)
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        from core.llm.providers.codex import _resolve_codex_token
+
+        token = _resolve_codex_token()
+        if not token:
+            raise RuntimeError(
+                "CodexOAuthAdapter: ChatGPT OAuth not found. Looked in GEODE "
+                f"ProfileStore ('openai-codex' profile) and {CODEX_AUTH_PATH}. "
+                "Run ``/login openai`` in GEODE or ``codex auth login`` in the "
+                "Codex CLI to provision credentials, or use the openai-payg / "
+                "codex-cli adapter."
+            )
+        self._client = build_async_codex_client(token)
+        return self._client
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        """Single Codex Responses API call (streamed; final aggregated).
+
+        Mirrors the contract in
+        :meth:`core.llm.providers.codex.CodexAgenticAdapter.agentic_call`
+        — Codex backend has 4 mandatory differences vs. PAYG Responses API:
+
+        - ``max_output_tokens`` is forbidden (server-managed under the Plus
+          quota; sending it returns 400 ``Unsupported parameter``).
+        - ``store = False`` is required.
+        - ``instructions`` field carries the system prompt (Responses API's
+          ``input`` array does not accept ``role: system`` on Codex).
+        - Tools use the FLAT shape (``translate_tool_for_codex``), not the
+          Chat Completions nested ``function`` wrapper.
+
+        We stream by default and aggregate the final response — non-streaming
+        ``responses.create`` returns a structurally empty body on the Codex
+        backend (the actual content arrives only via SSE events).
+        """
+        client = self._get_client()
+        kwargs = _build_codex_call_kwargs(req)
+        try:
+            async with client.responses.stream(**kwargs) as stream:
+                accumulated: list[Any] = []
+                async for event in stream:
+                    if getattr(event, "type", "") == "response.output_item.done":
+                        item = getattr(event, "item", None)
+                        if item is not None:
+                            accumulated.append(item)
+                final = await stream.get_final_response()
+                if accumulated:
+                    final.output = accumulated
+        except Exception as exc:
+            self._last_error = exc
+            log.warning("codex-oauth: responses.stream failed model=%s err=%s", req.model, exc)
+            raise
+        return translate_codex_response(final)
+
+    async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
+        client = self._get_client()
+        kwargs = _build_codex_call_kwargs(req)
+        async with client.responses.stream(**kwargs) as stream:
+            async for event in stream:
+                ev_type = getattr(event, "type", "")
+                if ev_type.endswith("output_text.delta"):
+                    yield StreamEvent(kind="text", payload={"text": getattr(event, "delta", "")})
+                elif ev_type == "response.completed":
+                    yield StreamEvent(kind="stop", payload={"stop_reason": "completed"})
+
+    def test_environment(self) -> EnvironmentReport:
+        from core.llm.providers.codex import _resolve_codex_token
+
+        token = _resolve_codex_token()
+        if not token:
+            return EnvironmentReport(
+                ok=False,
+                checks=(
+                    ("geode_profile_store", "no openai-codex profile"),
+                    (
+                        "codex_auth_file",
+                        "missing" if not CODEX_AUTH_PATH.is_file() else "unreadable",
+                    ),
+                ),
+                hints=(
+                    "Run ``/login openai`` inside GEODE to provision the ChatGPT OAuth profile,",
+                    "or ``codex auth login`` in the Codex CLI to use the external token.",
+                ),
+            )
+        return EnvironmentReport(
+            ok=True,
+            checks=(("codex_token_length", f"{len(token)} chars"),),
+        )
+
+    def list_models(self) -> list[ModelSpec]:
+        from core.config import CODEX_FALLBACK_CHAIN, CODEX_PRIMARY
+
+        ids = [CODEX_PRIMARY, *CODEX_FALLBACK_CHAIN]
+        seen: set[str] = set()
+        out: list[ModelSpec] = []
+        for mid in ids:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            out.append(
+                ModelSpec(
+                    id=mid,
+                    label=mid,
+                    context_tokens=128_000,
+                    supports_thinking=mid.startswith(("o3", "o4")),
+                    supports_tools=True,
+                )
+            )
+        return out
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        """Codex backend exposes rate-limit headers per response but no aggregate.
+
+        Returns ``None`` for now — the UI renders "unknown" rather than
+        guessing. A future ratchet PR can wire the per-response ``rate_limits``
+        block from ``core/llm/providers/codex.py`` into a snapshot cache.
+        """
+        return None
+
+    def detect_credential(self) -> CredentialDetection | None:
+        from core.llm.providers.codex import _resolve_codex_token
+
+        if not _resolve_codex_token():
+            return None
+        from core.config import CODEX_PRIMARY
+
+        # detect_credential only reports the source path — exact provenance
+        # (GEODE profile vs Codex CLI file) is on EnvironmentReport's checks.
+        source_path = (
+            str(CODEX_AUTH_PATH)
+            if CODEX_AUTH_PATH.is_file()
+            else "GEODE ProfileStore (openai-codex)"
+        )
+        return CredentialDetection(
+            model=CODEX_PRIMARY,
+            provider=self.provider,
+            source_path=source_path,
+        )
+
+
+def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
+    """Codex Responses API call kwargs — mirrors CodexAgenticAdapter shape.
+
+    Critical Codex backend constraints (from
+    ``docs/research/codex-oauth-request-spec.md``):
+
+    - ``instructions`` carries the system prompt (not ``input[].role:system``)
+    - ``input`` is the user/assistant/tool array; we drop the leading system
+      entry that :func:`build_messages` would prepend
+    - ``store=False`` is mandatory
+    - ``max_output_tokens`` is FORBIDDEN — Plus subscription manages it
+      server-side, sending the field returns 400
+    - Tools use the FLAT shape (``translate_tool_for_codex``)
+    - gpt-5.x family omits ``temperature`` and adds ``reasoning`` +
+      ``include: ["reasoning.encrypted_content"]``
+    """
+    messages_payload = build_messages(req)
+    # Drop the system entry build_messages prepends — Codex needs it in
+    # ``instructions`` not in ``input``.
+    if req.system_prompt and messages_payload and messages_payload[0].get("role") == "system":
+        messages_payload = messages_payload[1:]
+    kwargs: dict[str, Any] = {
+        "model": req.model,
+        "instructions": req.system_prompt or "You are a helpful assistant.",
+        "input": messages_payload or [{"role": "user", "content": "hello"}],
+        "store": False,
+    }
+    if req.tools:
+        kwargs["tools"] = [translate_tool_for_codex(t) for t in req.tools]
+        kwargs["tool_choice"] = "auto"
+        kwargs["parallel_tool_calls"] = True
+    if req.model.startswith("gpt-5"):
+        # gpt-5.x family — encrypted reasoning passthrough; temperature omitted.
+        kwargs["include"] = ["reasoning.encrypted_content"]
+        kwargs["reasoning"] = {"effort": req.effort, "summary": "auto"}
+    elif req.temperature is not None:
+        kwargs["temperature"] = req.temperature
+    return kwargs
+
+
+__all__ = ["CodexOAuthAdapter"]

--- a/core/llm/adapters/openai_payg.py
+++ b/core/llm/adapters/openai_payg.py
@@ -1,0 +1,167 @@
+"""OpenAIPaygAdapter — PAYG (API-key) path to OpenAI models.
+
+Layer 3 adapter for OpenAI provider, source=payg. Owns its own
+``AsyncOpenAI`` client bound explicitly to ``OPENAI_API_KEY`` — bypasses the
+module-level singleton in ``core.llm.providers.openai`` which routes through
+``ProfileRotator`` and would prefer an OAuth profile if one existed. Codex
+MCP review 2026-05-23 flagged that singleton sharing as a BLOCKER for source
+isolation.
+
+Pair with :class:`CodexOAuthAdapter` (same provider, OAuth path) and
+:class:`CodexCliAdapter` (subprocess path).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.llm.adapters._openai_common import (
+    build_async_openai_client,
+    build_messages,
+    translate_chat_response,
+    translate_tool,
+)
+from core.llm.adapters.base import (
+    SOURCE_PAYG,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    CredentialDetection,
+    EnvironmentReport,
+    ModelSpec,
+    QuotaWindows,
+    StreamEvent,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class OpenAIPaygAdapter:
+    """PAYG-routed OpenAI adapter — owns its own AsyncOpenAI client."""
+
+    name: str = "openai-payg"
+    provider: str = "openai"
+    source: str = SOURCE_PAYG
+    billing_type: AdapterBillingType = AdapterBillingType.API
+    _last_error: Exception | None = field(default=None, init=False, repr=False)
+    _client: Any = field(default=None, init=False, repr=False)
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        from core.config import settings
+
+        if not settings.openai_api_key:
+            raise RuntimeError(
+                "OpenAIPaygAdapter: OPENAI_API_KEY not set. PAYG path requires "
+                "an explicit API key — set ``openai_api_key`` in settings or use "
+                "the codex-oauth / codex-cli adapter instead."
+            )
+        self._client = build_async_openai_client(settings.openai_api_key)
+        return self._client
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        client = self._get_client()
+        kwargs: dict[str, Any] = {
+            "model": req.model,
+            "messages": build_messages(req),
+            "max_tokens": req.max_tokens,
+        }
+        if req.temperature is not None:
+            kwargs["temperature"] = req.temperature
+        if req.tools:
+            kwargs["tools"] = [translate_tool(t) for t in req.tools]
+        if req.stop_sequences:
+            kwargs["stop"] = list(req.stop_sequences)
+        try:
+            response = await client.chat.completions.create(**kwargs)
+        except Exception as exc:
+            self._last_error = exc
+            log.warning(
+                "openai-payg: chat.completions.create failed model=%s err=%s",
+                req.model,
+                exc,
+            )
+            raise
+        return translate_chat_response(response)
+
+    async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
+        client = self._get_client()
+        kwargs: dict[str, Any] = {
+            "model": req.model,
+            "messages": build_messages(req),
+            "max_tokens": req.max_tokens,
+            "stream": True,
+        }
+        if req.temperature is not None:
+            kwargs["temperature"] = req.temperature
+        async for chunk in await client.chat.completions.create(**kwargs):
+            choice = chunk.choices[0] if chunk.choices else None
+            if choice is None:
+                continue
+            delta = getattr(choice, "delta", None)
+            text_chunk = getattr(delta, "content", None) if delta else None
+            if text_chunk:
+                yield StreamEvent(kind="text", payload={"text": text_chunk})
+            finish_reason = getattr(choice, "finish_reason", None)
+            if finish_reason is not None:
+                yield StreamEvent(kind="stop", payload={"stop_reason": finish_reason})
+
+    def test_environment(self) -> EnvironmentReport:
+        from core.config import settings
+
+        if not settings.openai_api_key:
+            return EnvironmentReport(
+                ok=False,
+                checks=(("openai_api_key", "missing"),),
+                hints=(
+                    "Set ``OPENAI_API_KEY`` in your environment or in ~/.geode/config.toml.",
+                    "Or use codex-oauth (ChatGPT subscription) / codex-cli (local binary).",
+                ),
+            )
+        return EnvironmentReport(
+            ok=True,
+            checks=(("openai_api_key", f"set ({len(settings.openai_api_key)} chars)"),),
+        )
+
+    def list_models(self) -> list[ModelSpec]:
+        from core.config import OPENAI_FALLBACK_CHAIN, OPENAI_PRIMARY
+
+        ids = [OPENAI_PRIMARY, *OPENAI_FALLBACK_CHAIN]
+        seen: set[str] = set()
+        models: list[ModelSpec] = []
+        for mid in ids:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            models.append(
+                ModelSpec(
+                    id=mid,
+                    label=mid,
+                    context_tokens=128_000,
+                    supports_thinking=mid.startswith(("o3", "o4")),
+                    supports_tools=True,
+                )
+            )
+        return models
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        return None  # PAYG, metered per call
+
+    def detect_credential(self) -> CredentialDetection | None:
+        from core.config import OPENAI_PRIMARY, settings
+
+        if not settings.openai_api_key:
+            return None
+        return CredentialDetection(
+            model=OPENAI_PRIMARY,
+            provider=self.provider,
+            source_path="settings.openai_api_key",
+        )
+
+
+__all__ = ["OpenAIPaygAdapter"]

--- a/core/llm/adapters/registry.py
+++ b/core/llm/adapters/registry.py
@@ -1,0 +1,172 @@
+"""LLMAdapter registry — mutable global lookup.
+
+Mirrors paperclip ``server/src/adapters/registry.ts``:
+
+- ``registerServerAdapter(adapter)`` → :func:`register_adapter`
+- ``unregisterServerAdapter(type)`` → :func:`unregister_adapter`
+- ``requireServerAdapter(type)`` → :func:`get_adapter`
+
+Built-in adapters register at runtime bootstrap (``core/runtime.py``).
+External plugins call :func:`register_adapter` from their entry point.
+
+The registry is process-global and module-level (matches paperclip's mutable
+Map shape). Test fixtures can call :func:`_reset_for_test` to clear state
+between tests.
+
+See ``docs/plans/2026-05-23-llm-adapter-abstraction.md`` Layer 4 for the
+``resolve_for(provider, source)`` contract — it raises on ``source="auto"``
+because the picker is responsible for collapsing ``auto`` to a concrete value
+before the adapter is selected.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.llm.adapters.base import CONCRETE_SOURCES, SOURCE_AUTO, LLMAdapter
+
+log = logging.getLogger(__name__)
+
+
+_REGISTRY: dict[str, LLMAdapter] = {}
+
+
+class AdapterAlreadyRegisteredError(RuntimeError):
+    """Raised by :func:`register_adapter` when a name collides without ``replace=True``."""
+
+
+class AdapterNotFoundError(KeyError):
+    """Raised by :func:`get_adapter` and :func:`resolve_for` on lookup miss."""
+
+
+def register_adapter(adapter: LLMAdapter, *, replace: bool = False) -> None:
+    """Add ``adapter`` to the global registry.
+
+    Re-registration with ``replace=False`` raises :class:`AdapterAlreadyRegisteredError`
+    — same shape as paperclip's registry which throws on duplicate type. Tests
+    use ``replace=True`` to swap in a mock without first calling
+    :func:`unregister_adapter`.
+    """
+    name = adapter.name
+    if not name:
+        raise ValueError("register_adapter: adapter.name is empty")
+    if adapter.source not in CONCRETE_SOURCES:
+        raise ValueError(
+            f"register_adapter: adapter.source={adapter.source!r} is not a concrete value "
+            f"(must be one of {sorted(CONCRETE_SOURCES)})"
+        )
+    if name in _REGISTRY and not replace:
+        raise AdapterAlreadyRegisteredError(
+            f"adapter {name!r} already registered; pass replace=True to override"
+        )
+    _REGISTRY[name] = adapter
+    log.debug(
+        "adapter registered: %s (provider=%s source=%s)",
+        name,
+        adapter.provider,
+        adapter.source,
+    )
+
+
+def unregister_adapter(name: str) -> None:
+    """Remove ``name`` from the registry. No-op when absent."""
+    _REGISTRY.pop(name, None)
+
+
+def get_adapter(name: str) -> LLMAdapter:
+    """Look up a registered adapter by its canonical ``name``.
+
+    Raises :class:`AdapterNotFoundError` when missing.
+    """
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise AdapterNotFoundError(
+            f"adapter {name!r} not registered. Known: {sorted(_REGISTRY)}"
+        ) from exc
+
+
+def list_adapters() -> list[LLMAdapter]:
+    """All currently registered adapters in registration order."""
+    return list(_REGISTRY.values())
+
+
+def resolve_for(provider: str, source: str) -> LLMAdapter:
+    """Find the unique adapter matching ``(provider, source)``.
+
+    ``source`` MUST be a concrete value (one of
+    ``core.llm.adapters.base.CONCRETE_SOURCES``). The picker collapses
+    ``"auto"`` → concrete before calling. Passing ``"auto"`` here raises
+    :class:`ValueError` — failing loudly is the same anti-leak posture
+    paperclip's registry takes on duplicate type registration.
+
+    Raises :class:`AdapterNotFoundError` when no adapter matches.
+    """
+    if source == SOURCE_AUTO:
+        raise ValueError(
+            "resolve_for: source='auto' is a picker sentinel — collapse it to a "
+            "concrete value (payg / subscription / adapter) before resolving."
+        )
+    if source not in CONCRETE_SOURCES:
+        raise ValueError(
+            f"resolve_for: source={source!r} is not a concrete value "
+            f"(must be one of {sorted(CONCRETE_SOURCES)})"
+        )
+    candidates = [a for a in _REGISTRY.values() if a.provider == provider and a.source == source]
+    if not candidates:
+        known = [(a.provider, a.source) for a in _REGISTRY.values()]
+        raise AdapterNotFoundError(
+            f"no adapter for provider={provider!r} source={source!r}. Known pairs: {known}"
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"resolve_for: multiple adapters match provider={provider!r} source={source!r}: "
+            f"{[a.name for a in candidates]} — registry invariant violated"
+        )
+    return candidates[0]
+
+
+def bootstrap_builtins() -> None:
+    """Register the 6 built-in adapters.
+
+    Called from ``core/runtime.py`` during process bootstrap. Idempotent —
+    re-registration is a no-op (logs at debug level). Mirrors paperclip's
+    ``initializeBuiltinAdapters`` startup hook.
+    """
+    from core.llm.adapters.anthropic_oauth import AnthropicOAuthAdapter
+    from core.llm.adapters.anthropic_payg import AnthropicPaygAdapter
+    from core.llm.adapters.claude_cli import ClaudeCliAdapter
+    from core.llm.adapters.codex_cli import CodexCliAdapter
+    from core.llm.adapters.codex_oauth import CodexOAuthAdapter
+    from core.llm.adapters.openai_payg import OpenAIPaygAdapter
+
+    for adapter_cls in (
+        AnthropicPaygAdapter,
+        AnthropicOAuthAdapter,
+        ClaudeCliAdapter,
+        OpenAIPaygAdapter,
+        CodexOAuthAdapter,
+        CodexCliAdapter,
+    ):
+        instance = adapter_cls()
+        if instance.name in _REGISTRY:
+            log.debug("bootstrap_builtins: %s already registered, skipping", instance.name)
+            continue
+        register_adapter(instance)
+
+
+def _reset_for_test() -> None:
+    """Clear the registry. Test-only — production callers must not invoke."""
+    _REGISTRY.clear()
+
+
+__all__ = [
+    "AdapterAlreadyRegisteredError",
+    "AdapterNotFoundError",
+    "bootstrap_builtins",
+    "get_adapter",
+    "list_adapters",
+    "register_adapter",
+    "resolve_for",
+    "unregister_adapter",
+]

--- a/core/llm/credentials.py
+++ b/core/llm/credentials.py
@@ -33,6 +33,13 @@ def resolve_provider_key(provider: str, settings_fallback: str) -> str:
     Stores the resolved profile in ``_last_profile`` for downstream
     ``on_llm_success``/``on_llm_failure`` callbacks.
 
+    .. deprecated:: v0.99.39
+       Global type-priority (OAUTH > TOKEN > API_KEY) loses per-role
+       source information. Use the :class:`core.llm.adapters.LLMAdapter`
+       registry instead — each concrete adapter (``anthropic-payg`` /
+       ``anthropic-oauth`` / ``claude-cli``) selects its credential
+       explicitly. Removal target: v1.0.0.
+
     Args:
         provider: Provider name for rotator lookup ("anthropic", "openai").
         settings_fallback: API key string from settings (used when rotator unavailable).

--- a/core/wiring/container.py
+++ b/core/wiring/container.py
@@ -378,9 +378,22 @@ def build_llm_adapters(
     tool_registry: ToolRegistry,
     policy_chain: PolicyChain,
 ) -> tuple[LLMClientPort, LLMClientPort | None]:
-    """Build LLM adapters and inject callables into contextvars."""
+    """Build LLM adapters and inject callables into contextvars.
+
+    CSP-15 (2026-05-23) — also registers the v0.99.39 :class:`LLMAdapter`
+    Protocol built-ins (anthropic-payg / anthropic-oauth / claude-cli /
+    openai-payg / codex-oauth / codex-cli) into the module-global adapter
+    registry. The new ``LLMAdapter`` surface is independent from the legacy
+    ``LLMClientPort`` returned here — both coexist until the AgenticLoop
+    migration lands (follow-up #A in
+    ``docs/plans/2026-05-23-llm-adapter-abstraction.md``).
+    """
     from core.config import settings
+    from core.llm.adapters.registry import bootstrap_builtins
     from core.llm.router import set_llm_callable
+
+    # Register the 6 Layer 3 adapters once per process. Idempotent.
+    bootstrap_builtins()
 
     llm_adapter: LLMClientPort = ClaudeAdapter()
     secondary_adapter: LLMClientPort | None = None

--- a/docs/plans/2026-05-23-llm-adapter-abstraction.md
+++ b/docs/plans/2026-05-23-llm-adapter-abstraction.md
@@ -1,0 +1,198 @@
+# LLM Adapter Abstraction — paperclip pattern adoption
+
+**Date**: 2026-05-23
+**Branch**: `feature/llm-adapter-abstraction`
+**Scope**: Single PR
+**Reference**: `~/workspace/paperclip` (`packages/adapter-utils/src/types.ts:349 ServerAdapterModule`, `server/src/adapters/registry.ts`, `adapter-plugin.md` phase-1 notes)
+
+## Why
+
+User-facing requirement: "PAYG, 구독제(OAuth), Adapter(local agent-cli) 세 가지를 UI/UX 에서 선택할 수 있어야 한다. 매번 클로드 코드로만 조작하는 게 아니니까."
+
+Code-grounding verification (2026-05-23, this session):
+
+- `RoleBinding.source` from `plugins/seed_generation/picker.py:262 pick_bindings` is **purely a display/billing label**. It is NEVER threaded through to the LLM call site.
+- `cli.py:443 Pipeline(state=state, registry=registry)` drops `picker_result` entirely (binding never enters the pipeline).
+- `core/agent/sub_agent.py:497 _build_worker_request` resolves provider via `_resolve_provider(worker_model)` — pure model-id prefix string match.
+- `core/llm/providers/anthropic.py:321 _resolve_anthropic_key` → `ProfileRotator.resolve(provider)` uses a global type-priority (OAUTH > TOKEN > API_KEY). Per-role source override is impossible.
+- `core/orchestration/claude_cli_lane.py` (LaneQueue) is wired into `core/self_improving_loop/cli_subprocess.py` and `plugins/petri_audit/claude_cli_provider.py`, but NOT into the seed_generation path.
+
+Two cut points:
+
+1. **W1**: `picker_result.bindings` ─/→ `Pipeline` (cli.py:443)
+2. **W2**: provider resolution ignores `source` (sub_agent.py:560)
+
+Adopting paperclip's adapter pattern unifies these into a single contract.
+
+## Design — 4-layer + glue
+
+### Layer 4 — `LLMAdapter` Protocol (paperclip `ServerAdapterModule` mirror)
+
+`core/llm/adapters/base.py` (NEW). Protocol (PEP 544 duck typing) — external plugins implement without subclassing.
+
+```python
+class LLMAdapter(Protocol):
+    name: str            # canonical id e.g. "anthropic-payg" / "claude-cli"
+    provider: str        # "anthropic" / "openai" / "glm"
+    source: str          # "payg" / "subscription" / "adapter"
+    billing_type: AdapterBillingType  # paperclip enum: api / subscription / subscription_included / ...
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult: ...
+    def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]: ...
+
+    def test_environment(self) -> EnvironmentReport: ...  # paperclip testEnvironment
+    def list_models(self) -> list[ModelSpec]: ...
+    def get_quota_windows(self) -> QuotaWindows | None: ...
+    def detect_credential(self) -> CredentialDetection | None: ...
+```
+
+Companion dataclasses: `AdapterCallRequest` (system + messages + tools + sampling), `AdapterCallResult` (text + usage + stop_reason), `StreamEvent`, `ModelSpec`, `QuotaWindows`, `EnvironmentReport`, `CredentialDetection`. `AdapterBillingType` enum mirrors paperclip 8-value taxonomy.
+
+### Layer 4 — Registry
+
+`core/llm/adapters/registry.py` (NEW). Mutable global registry mirroring paperclip `registerServerAdapter` / `unregisterServerAdapter`.
+
+```python
+def register_adapter(adapter: LLMAdapter, *, replace: bool = False) -> None
+def unregister_adapter(name: str) -> None
+def get_adapter(name: str) -> LLMAdapter  # KeyError if missing
+def list_adapters() -> list[LLMAdapter]
+def resolve_for(provider: str, source: str) -> LLMAdapter  # "auto" raises — picker resolves first
+def bootstrap_builtins() -> None  # called from core/runtime.py
+```
+
+### Layer 3 — 6 concrete adapters
+
+| name | provider | source | billing_type | wraps Layer 2 |
+|---|---|---|---|---|
+| `anthropic-payg` | anthropic | payg | api | `providers/anthropic.py:get_async_anthropic_client(api_key=…)` |
+| `anthropic-oauth` | anthropic | subscription | subscription | `providers/anthropic.py` + ProfileRotator force OAUTH-only |
+| `claude-cli` | anthropic | adapter | subscription_included | `core/orchestration/claude_cli_lane.py` + `plugins/petri_audit/adapters/claude_cli_backend.py` subprocess |
+| `openai-payg` | openai | payg | api | `providers/openai.py` |
+| `codex-oauth` | openai | subscription | subscription | `providers/codex.py:_get_async_codex_client` |
+| `codex-cli` | openai | adapter | subscription_included | `core/orchestration/codex_cli_lane.py` + codex subprocess |
+
+Files: `core/llm/adapters/anthropic_payg.py`, `anthropic_oauth.py`, `claude_cli.py`, `openai_payg.py`, `codex_oauth.py`, `codex_cli.py`.
+
+### Glue — source threading
+
+| # | Change | Location |
+|---|---|---|
+| G1 | `SubTask.source: str = "auto"` | `core/agent/sub_agent.py:119` |
+| G2 | `WorkerRequest.source: str = ""` + propagate from SubTask | `core/agent/sub_agent.py:497` + `core/agent/worker.py:48` |
+| G3 | `AgenticLoop(source=…)` kwarg accepted (consumed by adapter selection at LLM call site) | `core/agent/loop/__init__.py` |
+| G4 | Replace direct `client.messages.create / responses.create` in agentic loop with `adapter.acomplete(req)` (resolve_for at call site using worker_request.provider + source) | `core/agent/loop/_reflection.py` etc. |
+| G5 | `Pipeline.__init__(state, registry, bindings=None)` accepts `bindings: dict[str, RoleBinding] \| None` | `plugins/seed_generation/orchestrator.py:390` |
+| G6 | `cli.py:443` passes `picker_result.bindings` to `Pipeline(...)` | `plugins/seed_generation/cli.py:443` |
+| G7 | `_arun_phase` reads `bindings[role].source / model` and builds `SubTask(source=…, model=…)` | `plugins/seed_generation/orchestrator.py` |
+| G8 | S11 — `PipelineRegistry` populated with 7 agent instances (generator/critic/pilot/ranker/evolver/meta_reviewer/literature_review) | `plugins/seed_generation/cli.py:436` |
+
+### Config SoT — config.toml unification
+
+Existing surface: `~/.geode/seed-generation.toml` (read by `picker.load_user_overrides`).
+New surface: `~/.geode/config.toml` `[seed_generation.role.<role>]` (mirrors `[self_improving_loop.petri.<role>]` consolidation from PR #1496/#1498/#1499, Session 66).
+
+Migration: `picker.load_user_overrides` first reads `~/.geode/config.toml` `[seed_generation.role.*]`. If empty and `~/.geode/seed-generation.toml` exists, emits a one-time deprecation warning and reads the old path until v1.0.0. The old file is NOT auto-migrated (user-driven).
+
+### UI surface
+
+| Surface | NEW |
+|---|---|
+| `geode adapters list` | typer subcommand — enumerate registered adapters with billing_type + test_environment + list_models |
+| `geode adapters detect-model <adapter>` | paperclip `detectModel` equivalent — extract current model from adapter's local config |
+| `geode seeds config show` | print 7 role × (model, source) matrix from manifest + config.toml |
+| `geode seeds config set <role> source=<mode> [model=<id>]` | config.toml writer |
+| REPL `/seed-model <role> <source>` | live override during interactive session |
+
+### Deprecation (scope-out items marked, NOT removed)
+
+Per user directive 2026-05-23 "디자인에서 스코프 넓혀서 벗어난 사안들을 deprecated 로 명시":
+
+| Item | Deprecation reason | Removal target |
+|---|---|---|
+| `core/llm/providers/anthropic.py:get_async_anthropic_client(api_key=…)` direct callers outside `core/llm/adapters/` | Adapter is the canonical path | v1.0.0 |
+| `core/llm/providers/codex.py:_get_async_codex_client` direct callers outside adapters | Adapter is the canonical path | v1.0.0 |
+| `core/llm/credentials.py:resolve_provider_key(provider, fallback)` — global type-priority resolution | Per-role source override required, global priority loses information | v1.0.0 (kept until adapters migrate every caller) |
+| `~/.geode/seed-generation.toml` | config.toml SoT consolidation | v1.0.0 |
+| `core/config/__init__.py:_resolve_provider(model)` — string-prefix only | Adapter resolves provider+source jointly | v1.0.0 |
+
+Each item gets a `.. deprecated:: v0.99.39` Sphinx-style block in the docstring + a CHANGELOG `### Deprecated` entry linked to this plan doc. Runtime `warnings.warn(...)` is intentionally NOT issued — every in-tree caller still uses the legacy path, so a runtime warning would fire on every LLM call until the v1.0.0 migration. The docstring + CHANGELOG signal is sufficient for the new callers' guidance.
+
+## Files (~3,400 LOC)
+
+```
+core/llm/adapters/__init__.py           NEW
+core/llm/adapters/base.py               NEW   (Protocol + dataclasses + enum)
+core/llm/adapters/registry.py           NEW
+core/llm/adapters/anthropic_payg.py     NEW
+core/llm/adapters/anthropic_oauth.py    NEW
+core/llm/adapters/claude_cli.py         NEW
+core/llm/adapters/openai_payg.py        NEW
+core/llm/adapters/codex_oauth.py        NEW
+core/llm/adapters/codex_cli.py          NEW
+core/runtime.py                         MOD   (bootstrap_builtins call)
+core/agent/sub_agent.py                 MOD   (SubTask.source + WorkerRequest.source thread)
+core/agent/worker.py                    MOD   (WorkerRequest.source propagate)
+core/agent/loop/__init__.py             MOD   (AgenticLoop source kwarg)
+core/agent/loop/_reflection.py          MOD   (adapter.acomplete at call site)
+core/llm/credentials.py                 MOD   (DeprecationWarning header)
+core/llm/providers/anthropic.py         MOD   (DeprecationWarning on direct caller paths)
+core/llm/providers/codex.py             MOD   (DeprecationWarning)
+core/config/__init__.py                 MOD   (DeprecationWarning on _resolve_provider)
+plugins/seed_generation/picker.py       MOD   (load_user_overrides reads config.toml first)
+plugins/seed_generation/orchestrator.py MOD   (Pipeline.bindings + _arun_phase reads)
+plugins/seed_generation/cli.py          MOD   (pass bindings + S11 registry populate)
+plugins/seed_generation/seed_generation.plugin.toml  MOD  (default_source per role)
+core/cli/commands/adapters.py           NEW   (geode adapters list/detect-model)
+core/cli/commands/seeds_config.py       NEW   (geode seeds config show/set)
+core/cli/repl/slash/seed_model.py       NEW   (/seed-model slash)
+tests/core/llm/adapters/test_base.py    NEW
+tests/core/llm/adapters/test_registry.py NEW
+tests/core/llm/adapters/test_anthropic_payg.py NEW
+tests/core/llm/adapters/test_anthropic_oauth.py NEW
+tests/core/llm/adapters/test_claude_cli.py NEW
+tests/core/llm/adapters/test_openai_payg.py NEW
+tests/core/llm/adapters/test_codex_oauth.py NEW
+tests/core/llm/adapters/test_codex_cli.py NEW
+tests/plugins/seed_generation/test_picker_config_sot.py NEW
+tests/plugins/seed_generation/test_orchestrator_bindings.py NEW
+tests/core/cli/test_adapters_command.py NEW
+tests/core/cli/test_seeds_config_command.py NEW
+CHANGELOG.md                            MOD
+pyproject.toml                          MOD   (version bump)
+CLAUDE.md                               MOD   (version bump)
+README.md + README.ko.md                MOD   (version bump)
+```
+
+## Quality gates (Single PR)
+
+- `uv run ruff format --check core/ tests/ plugins/`
+- `uv run ruff check core/ tests/ plugins/`
+- `uv run lint-imports`
+- `uv run mypy core/ plugins/`
+- `uv run pytest tests/ -m "not live" -q`
+- Codex MCP verify on full diff: dedup + slop signals (paperclip-style abstraction redundancy / box-card UI / emoji)
+
+## Scope cut — this single PR vs. follow-ups
+
+**This PR (v0.99.39)** — landing the abstraction without rewriting AgenticLoop:
+
+- Layer 4 (Protocol + registry)
+- Layer 3 (6 adapters: anthropic-payg / anthropic-oauth / claude-cli / openai-payg / codex-oauth / codex-cli)
+- `core.runtime` registers builtins at bootstrap
+- `picker.resolve_binding_to_adapter(binding) -> LLMAdapter` helper so `RoleBinding.source` collapses into a concrete adapter pick
+- `picker.load_user_overrides` reads `~/.geode/config.toml` `[seed_generation.role.<role>]` first; falls back to deprecated `~/.geode/seed-generation.toml` with one-time warning
+- Deprecation markers on Layer 2 direct callers (``core/llm/providers/*.py``, ``credentials.py``, ``_resolve_provider``) — kept functional, scheduled for v1.0.0 removal
+- Tests for Layer 4 + Layer 3 + picker integration
+- Codex MCP verify (dedup + slop signals)
+
+**Follow-up PRs** (deferred — each marked deprecated in this PR's diff where applicable):
+
+| Item | Why deferred | Tracking |
+|---|---|---|
+| AgenticLoop migration to ``adapter.acomplete`` at every LLM call site | ~600 LOC refactor across ``core/agent/loop/`` — touches retry/observability/tool-use plumbing. Must land standalone for bisectability. | follow-up #A |
+| ``Pipeline.bindings`` + ``_arun_phase`` reads binding per role | Requires S11 ``PipelineRegistry`` wire-up landed first (seven agent instantiation order matters) | follow-up #B |
+| S11 production ``PipelineRegistry`` populate | The seven seed_generation agents (``generator/critic/pilot/ranker/evolver/meta_reviewer/literature_review``) need their constructor contracts aligned before registry boot — current ``cli.py:436`` leaves a TODO from PR-CSP-14 | follow-up #C |
+| UI surface — ``geode adapters list``, ``geode adapters detect-model``, ``geode seeds config show/set``, REPL ``/seed-model`` slash | Independent UX work; uses the Layer 4 contract this PR ships | follow-up #D |
+| ``~/.geode/seed-generation.toml`` auto-migration to ``~/.geode/config.toml`` | User-initiated only — auto-migration risks silent overwrite of user edits | follow-up #E (CLI assist command) |
+| Glm + Google + DeepSeek + Petri audit + Autoresearch adapter wrap | Each is a per-provider follow-up; pattern proven by the 6 in this PR | follow-up #F-J |

--- a/plugins/seed_generation/picker.py
+++ b/plugins/seed_generation/picker.py
@@ -64,7 +64,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO
 
-from core.paths import GLOBAL_SEED_PIPELINE_TOML
+from core.paths import GLOBAL_CONFIG_TOML, GLOBAL_SEED_PIPELINE_TOML
 
 from plugins.seed_generation.manifest import (
     SeedGenerationManifest,
@@ -80,11 +80,13 @@ __all__ = [
     "PickerResult",
     "RoleBinding",
     "VoterBinding",
+    "binding_to_adapter_source",
     "infer_provider",
     "load_user_overrides",
     "pick_bindings",
     "print_tos_notice",
     "reset_tos_notice",
+    "resolve_binding_to_adapter",
     "validate_runtime_diversity",
 ]
 
@@ -173,26 +175,65 @@ def infer_provider(model: str) -> str:
     )
 
 
+_LEGACY_OVERRIDE_WARNED = False
+
+
 def load_user_overrides(
     path: Path | str | None = None,
 ) -> dict[str, dict[str, str]]:
-    """Load ``~/.geode/seed-generation.toml`` per-role overrides.
+    """Load per-role overrides — config.toml first, legacy file as fallback.
 
-    Schema:
+    CSP-15 (v0.99.39) — config SoT consolidation. The canonical surface is
+    ``~/.geode/config.toml`` with the following schema, mirroring the
+    Session 66 ``[self_improving_loop.petri.<role>]`` consolidation:
 
     .. code-block:: toml
 
-       [generator]
-       source = "api_key"
+       [seed_generation.role.generator]
+       source = "payg"
 
-       [pilot]
-       source = "claude-cli"
+       [seed_generation.role.pilot]
+       source = "subscription"
        model  = "claude-haiku-4-5"
 
-    Returns ``{role: {key: value, …}}``. Empty dict when the file does
-    not exist (the override file is OPTIONAL).
+    The legacy ``~/.geode/seed-generation.toml`` schema (per-role top-level
+    table) is still read when ``[seed_generation.role.*]`` is absent from
+    ``config.toml``. The first time the legacy fallback is used, a one-time
+    warning is logged with the migration command. Removal target: v1.0.0.
+
+    The ``source`` value accepts both legacy (``claude-cli`` / ``openai-codex`` /
+    ``api_key``) and new (``payg`` / ``subscription`` / ``adapter``) names —
+    see :func:`binding_to_adapter_source`.
+
+    Returns ``{role: {key: value, …}}``. Empty dict when neither file holds
+    overrides (the surface is OPTIONAL).
     """
-    target = Path(path) if path is not None else GLOBAL_SEED_PIPELINE_TOML
+    if path is not None:
+        return _load_overrides_from_file(Path(path))
+
+    # 1. Canonical SoT: ~/.geode/config.toml [seed_generation.role.*]
+    canonical_overrides = _load_config_toml_seed_overrides(GLOBAL_CONFIG_TOML)
+    if canonical_overrides:
+        return canonical_overrides
+
+    # 2. Legacy fallback: ~/.geode/seed-generation.toml
+    legacy_overrides = _load_overrides_from_file(GLOBAL_SEED_PIPELINE_TOML)
+    if legacy_overrides:
+        global _LEGACY_OVERRIDE_WARNED
+        if not _LEGACY_OVERRIDE_WARNED:
+            log.warning(
+                "seed-generation picker: reading legacy %s. Migrate per-role "
+                "overrides to ~/.geode/config.toml under [seed_generation.role.<role>] "
+                "(see docs/plans/2026-05-23-llm-adapter-abstraction.md). "
+                "The legacy file will be removed in v1.0.0.",
+                GLOBAL_SEED_PIPELINE_TOML,
+            )
+            _LEGACY_OVERRIDE_WARNED = True
+    return legacy_overrides
+
+
+def _load_overrides_from_file(target: Path) -> dict[str, dict[str, str]]:
+    """Parse a flat ``[<role>]`` override TOML — legacy seed-generation.toml shape."""
     if not target.is_file():
         return {}
     try:
@@ -214,6 +255,94 @@ def load_user_overrides(
             continue
         out[role] = {k: str(v) for k, v in body.items() if isinstance(v, (str, int, float))}
     return out
+
+
+def _load_config_toml_seed_overrides(target: Path) -> dict[str, dict[str, str]]:
+    """Read ``[seed_generation.role.*]`` from the unified config.toml SoT.
+
+    Returns an empty dict when the file is missing, malformed, or carries no
+    ``[seed_generation.role.*]`` table — caller falls back to legacy path.
+    """
+    if not target.is_file():
+        return {}
+    try:
+        raw = tomllib.loads(target.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        log.warning(
+            "seed-generation picker: %s is not valid TOML (%s) — ignoring overrides",
+            target,
+            exc,
+        )
+        return {}
+    seed_section = raw.get("seed_generation")
+    if not isinstance(seed_section, dict):
+        return {}
+    role_section = seed_section.get("role")
+    if not isinstance(role_section, dict):
+        return {}
+    out: dict[str, dict[str, str]] = {}
+    for role, body in role_section.items():
+        if not isinstance(body, dict):
+            log.warning(
+                "seed-generation picker: config.toml entry [seed_generation.role.%s] "
+                "is not a table — ignoring",
+                role,
+            )
+            continue
+        out[role] = {k: str(v) for k, v in body.items() if isinstance(v, (str, int, float))}
+    return out
+
+
+# Picker source → adapter source translation. The picker emits legacy source
+# strings (``claude-cli`` / ``openai-codex`` / ``api_key``) for backwards
+# compatibility with existing overrides; the new adapter Protocol uses
+# ``payg`` / ``subscription`` / ``adapter`` (paperclip-aligned). The mapping
+# below is the single SoT for the translation.
+_PICKER_SOURCE_TO_ADAPTER_SOURCE: dict[str, str] = {
+    "api_key": "payg",
+    "payg": "payg",
+    "claude-cli": "adapter",  # Anthropic local binary
+    "openai-codex": "subscription",  # ChatGPT OAuth endpoint (NOT the codex binary)
+    "subscription": "subscription",
+    "adapter": "adapter",
+}
+
+
+def binding_to_adapter_source(picker_source: str) -> str:
+    """Translate the picker's legacy source name → adapter Protocol source.
+
+    Picker emits one of ``api_key`` / ``claude-cli`` / ``openai-codex``
+    (historical). The new :class:`core.llm.adapters.LLMAdapter` uses
+    ``payg`` / ``subscription`` / ``adapter``. This helper bridges the gap
+    so callers can resolve a registered adapter from a :class:`RoleBinding`.
+
+    Raises :class:`ValueError` for unknown source strings.
+    """
+    out = _PICKER_SOURCE_TO_ADAPTER_SOURCE.get(picker_source)
+    if out is None:
+        raise ValueError(
+            f"binding_to_adapter_source: unknown picker source {picker_source!r}. "
+            f"Known: {sorted(_PICKER_SOURCE_TO_ADAPTER_SOURCE)}"
+        )
+    return out
+
+
+def resolve_binding_to_adapter(binding: RoleBinding) -> object:
+    """Resolve a :class:`RoleBinding` to a concrete :class:`LLMAdapter`.
+
+    Combines :func:`binding_to_adapter_source` with the adapter registry's
+    ``resolve_for(provider, source)``. The return type is ``object`` to avoid
+    a hard module-level import of :class:`LLMAdapter` (keeps picker import
+    lightweight); callers cast via ``isinstance(...)`` or trust the duck type.
+
+    Raises :class:`core.llm.adapters.AdapterNotFoundError` when no adapter
+    matches the binding (e.g. the binding references a provider × source pair
+    the registry doesn't carry — opportunity for an external plugin).
+    """
+    from core.llm.adapters import resolve_for
+
+    adapter_source = binding_to_adapter_source(binding.source)
+    return resolve_for(binding.provider, adapter_source)
 
 
 def _probe_oauth(provider: str) -> bool:

--- a/tests/core/llm/adapters/test_base.py
+++ b/tests/core/llm/adapters/test_base.py
@@ -1,0 +1,119 @@
+"""Layer 4 base dataclasses + Protocol smoke tests."""
+
+from __future__ import annotations
+
+from core.llm.adapters.base import (
+    CONCRETE_SOURCES,
+    SOURCE_ADAPTER,
+    SOURCE_AUTO,
+    SOURCE_PAYG,
+    SOURCE_SUBSCRIPTION,
+    AdapterBillingType,
+    AdapterCallRequest,
+    AdapterCallResult,
+    EnvironmentReport,
+    LLMAdapter,
+    Message,
+    ModelSpec,
+    QuotaWindows,
+    ToolSpec,
+    UsageSummary,
+)
+
+
+def test_concrete_sources_set() -> None:
+    assert frozenset({SOURCE_PAYG, SOURCE_SUBSCRIPTION, SOURCE_ADAPTER}) == CONCRETE_SOURCES
+    assert SOURCE_AUTO not in CONCRETE_SOURCES
+
+
+def test_billing_type_values() -> None:
+    assert AdapterBillingType.API.value == "api"
+    assert AdapterBillingType.SUBSCRIPTION.value == "subscription"
+    assert AdapterBillingType.SUBSCRIPTION_INCLUDED.value == "subscription_included"
+    assert AdapterBillingType.UNKNOWN.value == "unknown"
+
+
+def test_adapter_call_request_defaults() -> None:
+    req = AdapterCallRequest(model="claude-haiku-4-5", messages=[])
+    assert req.system_prompt == ""
+    assert req.max_tokens == 8192
+    assert req.temperature is None
+    assert req.tools == ()
+    assert req.stop_sequences == ()
+
+
+def test_message_shape() -> None:
+    m = Message(role="user", content="hi")
+    assert m.role == "user"
+    assert m.tool_use_id is None
+
+
+def test_tool_spec_required_fields() -> None:
+    t = ToolSpec(name="search", description="", input_schema={"type": "object"})
+    assert t.name == "search"
+
+
+def test_usage_summary_defaults_zero() -> None:
+    u = UsageSummary()
+    assert u.input_tokens == 0
+    assert u.output_tokens == 0
+    assert u.cached_input_tokens == 0
+
+
+def test_environment_report_ok_path() -> None:
+    r = EnvironmentReport(ok=True, checks=(("key", "value"),))
+    assert r.ok
+    assert r.checks == (("key", "value"),)
+    assert r.hints == ()
+
+
+def test_quota_windows_carries_window() -> None:
+    q = QuotaWindows(used_tokens=10, total_tokens=100, window_seconds=300)
+    assert q.used_tokens == 10
+    assert q.total_tokens == 100
+    assert q.window_seconds == 300
+
+
+def test_model_spec_supports_flags() -> None:
+    m = ModelSpec(id="claude-haiku-4-5", label="Haiku", context_tokens=200_000)
+    assert m.supports_tools is True
+    assert m.supports_thinking is False
+
+
+def test_adapter_call_result_immutable_tuple_tool_uses() -> None:
+    r = AdapterCallResult(text="ok", usage=UsageSummary(), stop_reason="end_turn")
+    assert r.tool_uses == ()
+    assert r.raw_response is None
+
+
+class _StubAdapter:
+    """Minimum-viable concrete adapter for runtime_checkable Protocol test."""
+
+    name = "stub"
+    provider = "stub-provider"
+    source = SOURCE_PAYG
+    billing_type = AdapterBillingType.UNKNOWN
+
+    async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
+        return AdapterCallResult(text="", usage=UsageSummary(), stop_reason="end_turn")
+
+    async def astream(self, req):  # type: ignore[no-untyped-def]
+        return
+        yield  # pragma: no cover — never reached, satisfies async-generator typing
+
+    def test_environment(self) -> EnvironmentReport:
+        return EnvironmentReport(ok=True)
+
+    def list_models(self) -> list[ModelSpec]:
+        return []
+
+    def get_quota_windows(self) -> QuotaWindows | None:
+        return None
+
+    def detect_credential(self) -> None:
+        return None
+
+
+def test_protocol_runtime_checkable() -> None:
+    """A class satisfying the LLMAdapter Protocol passes isinstance check."""
+    assert isinstance(_StubAdapter(), LLMAdapter)

--- a/tests/core/llm/adapters/test_builtin_identity.py
+++ b/tests/core/llm/adapters/test_builtin_identity.py
@@ -1,0 +1,108 @@
+"""Identity invariants for each of the 6 built-in adapters.
+
+These tests pin the (name, provider, source, billing_type) tuple for each
+shipped adapter. They DO NOT exercise the actual SDK / subprocess call path —
+that requires live credentials and is out of scope for the unit suite. The
+acomplete path is covered by integration tests in the adapter migration
+follow-up PRs.
+
+The invariants here guard against accidental rename (e.g. ``claude-cli`` →
+``anthropic-cli``) which would silently break operator overrides and the UI's
+adapter list.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.adapters.anthropic_oauth import AnthropicOAuthAdapter
+from core.llm.adapters.anthropic_payg import AnthropicPaygAdapter
+from core.llm.adapters.base import AdapterBillingType
+from core.llm.adapters.claude_cli import ClaudeCliAdapter
+from core.llm.adapters.codex_cli import CodexCliAdapter
+from core.llm.adapters.codex_oauth import CodexOAuthAdapter
+from core.llm.adapters.openai_payg import OpenAIPaygAdapter
+
+
+@pytest.mark.parametrize(
+    ("cls", "expected_name", "expected_provider", "expected_source", "expected_billing"),
+    [
+        (AnthropicPaygAdapter, "anthropic-payg", "anthropic", "payg", AdapterBillingType.API),
+        (
+            AnthropicOAuthAdapter,
+            "anthropic-oauth",
+            "anthropic",
+            "subscription",
+            AdapterBillingType.SUBSCRIPTION,
+        ),
+        (
+            ClaudeCliAdapter,
+            "claude-cli",
+            "anthropic",
+            "adapter",
+            AdapterBillingType.SUBSCRIPTION_INCLUDED,
+        ),
+        (OpenAIPaygAdapter, "openai-payg", "openai", "payg", AdapterBillingType.API),
+        (
+            CodexOAuthAdapter,
+            "codex-oauth",
+            "openai",
+            "subscription",
+            AdapterBillingType.SUBSCRIPTION,
+        ),
+        (
+            CodexCliAdapter,
+            "codex-cli",
+            "openai",
+            "adapter",
+            AdapterBillingType.SUBSCRIPTION_INCLUDED,
+        ),
+    ],
+)
+def test_adapter_identity(
+    cls: type,
+    expected_name: str,
+    expected_provider: str,
+    expected_source: str,
+    expected_billing: AdapterBillingType,
+) -> None:
+    instance = cls()
+    assert instance.name == expected_name
+    assert instance.provider == expected_provider
+    assert instance.source == expected_source
+    assert instance.billing_type is expected_billing
+
+
+def test_test_environment_returns_report() -> None:
+    """Every adapter's test_environment returns an EnvironmentReport (no raise).
+
+    Adapters may report ok=False when credentials are missing — that's a valid
+    outcome. We just confirm the surface doesn't raise on a fresh process.
+    """
+    for cls in (
+        AnthropicPaygAdapter,
+        AnthropicOAuthAdapter,
+        ClaudeCliAdapter,
+        OpenAIPaygAdapter,
+        CodexOAuthAdapter,
+        CodexCliAdapter,
+    ):
+        report = cls().test_environment()
+        # Either ok=True with credentials available, or ok=False with hints.
+        if not report.ok:
+            assert report.hints, f"{cls.__name__}: ok=False but no hints"
+
+
+def test_list_models_returns_specs() -> None:
+    for cls in (
+        AnthropicPaygAdapter,
+        AnthropicOAuthAdapter,
+        ClaudeCliAdapter,
+        OpenAIPaygAdapter,
+        CodexOAuthAdapter,
+        CodexCliAdapter,
+    ):
+        models = cls().list_models()
+        assert models, f"{cls.__name__}: list_models returned empty list"
+        for m in models:
+            assert m.id
+            assert m.context_tokens > 0

--- a/tests/core/llm/adapters/test_client_isolation.py
+++ b/tests/core/llm/adapters/test_client_isolation.py
@@ -1,0 +1,127 @@
+"""Adapter client isolation invariants.
+
+Pins Codex MCP review 2026-05-23 BLOCKER fix: each concrete adapter must own
+its own AsyncAnthropic / AsyncOpenAI client. Pre-fix the adapters reused the
+module-level singletons in ``core.llm.providers.{anthropic,openai}.py`` which
+cache the first caller's api_key — so a PAYG adapter constructed first would
+permanently shadow the OAuth adapter's credentials (and vice versa).
+
+The invariants:
+1. Each adapter holds a ``_client`` field (None until first call).
+2. After ``_get_client()`` the field is populated.
+3. The same call on the OAuth adapter returns a DIFFERENT client object than
+   the PAYG adapter's (separate instances) — proves no singleton sharing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from core.llm.adapters.anthropic_oauth import (
+    CLAUDE_OAUTH_TOKEN_PATH,
+    AnthropicOAuthAdapter,
+)
+from core.llm.adapters.anthropic_payg import AnthropicPaygAdapter
+from core.llm.adapters.openai_payg import OpenAIPaygAdapter
+
+
+def test_anthropic_payg_holds_own_client_field() -> None:
+    """The adapter dataclass exposes _client as a per-instance slot."""
+    a = AnthropicPaygAdapter()
+    assert a._client is None
+    b = AnthropicPaygAdapter()
+    assert b._client is None
+    # Two instances → two independent slots.
+    assert a is not b
+
+
+def test_payg_and_oauth_anthropic_get_distinct_clients(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When both PAYG and OAuth adapters are created and their _get_client is
+    forced, they must NOT share the same anthropic client object.
+
+    We can't easily mock anthropic SDK construction, so instead we patch the
+    shared client builder to record each call and assert it's called twice
+    with different api_key values.
+    """
+    import core.llm.adapters.anthropic_oauth as oauth_mod
+    import core.llm.adapters.anthropic_payg as payg_mod
+
+    from core.llm.adapters import _anthropic_common
+
+    # Stub the SDK boundary so we don't hit anthropic.AsyncAnthropic.
+    seen_keys: list[str] = []
+
+    def _fake_build(api_key: str) -> object:
+        seen_keys.append(api_key)
+        return object()  # opaque marker — unique per call
+
+    monkeypatch.setattr(_anthropic_common, "build_async_anthropic_client", _fake_build)
+    monkeypatch.setattr(payg_mod, "build_async_anthropic_client", _fake_build)
+    monkeypatch.setattr(oauth_mod, "build_async_anthropic_client", _fake_build)
+
+    # Force PAYG to have an api_key and OAuth to have a token file.
+    monkeypatch.setattr("core.config.settings.anthropic_api_key", "test-payg-key-123")
+    token_file = tmp_path / "oauth-token.json"
+    token_file.write_text('{"access_token": "test-oauth-token-456"}', encoding="utf-8")
+    monkeypatch.setattr(oauth_mod, "CLAUDE_OAUTH_TOKEN_PATH", token_file)
+
+    payg = AnthropicPaygAdapter()
+    oauth = AnthropicOAuthAdapter()
+
+    payg_client = payg._get_client()
+    oauth_client = oauth._get_client()
+
+    # Distinct instances + distinct keys passed to the builder.
+    assert payg_client is not oauth_client
+    assert "test-payg-key-123" in seen_keys
+    assert "test-oauth-token-456" in seen_keys
+
+
+def test_payg_client_cached_per_instance() -> None:
+    """Second ``_get_client`` call on the same instance returns the cached client."""
+    import core.llm.adapters.anthropic_payg as payg_mod
+
+    a = AnthropicPaygAdapter()
+    # Pre-populate to skip the settings read path.
+    sentinel = object()
+    a._client = sentinel
+    assert a._get_client() is sentinel
+    # Mutating the instance does NOT affect a fresh instance.
+    b = AnthropicPaygAdapter()
+    assert b._client is None
+    assert b._client is not a._client
+    # Avoid F401 — silence unused module import marker.
+    assert payg_mod is not None
+
+
+def test_openai_payg_holds_own_client_field() -> None:
+    a = OpenAIPaygAdapter()
+    assert a._client is None
+
+
+def test_payg_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without an api_key, PAYG raises a clear RuntimeError instead of silently
+    falling back to OAuth (which would happen with the legacy singleton path).
+    """
+    monkeypatch.setattr("core.config.settings.anthropic_api_key", "")
+    a = AnthropicPaygAdapter()
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY not set"):
+        a._get_client()
+
+
+def test_anthropic_oauth_raises_without_token_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without ~/.claude/oauth-token.json, OAuth raises — does NOT fall through
+    to settings.anthropic_api_key.
+    """
+    import core.llm.adapters.anthropic_oauth as oauth_mod
+
+    monkeypatch.setattr(oauth_mod, "CLAUDE_OAUTH_TOKEN_PATH", tmp_path / "missing.json")
+    a = AnthropicOAuthAdapter()
+    with pytest.raises(RuntimeError, match="Claude OAuth token not found"):
+        a._get_client()
+    assert CLAUDE_OAUTH_TOKEN_PATH

--- a/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
+++ b/tests/core/llm/adapters/test_codex_oauth_backend_invariants.py
@@ -1,0 +1,91 @@
+"""Codex backend payload invariants — Codex MCP review 2026-05-23 BLOCKER pin.
+
+The Codex backend (``chatgpt.com/backend-api/codex``) has 4 mandatory
+differences from PAYG OpenAI Responses API. The first follow-up review caught
+that the adapter was using the PAYG-style call kwargs. These tests guard
+against regression.
+
+References:
+- ``docs/research/codex-oauth-request-spec.md``
+- ``core/llm/providers/codex.py::CodexAgenticAdapter.agentic_call`` (canonical)
+"""
+
+from __future__ import annotations
+
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+from core.llm.adapters.codex_oauth import _build_codex_call_kwargs
+
+
+def _req(model: str = "gpt-5.5", **kw: object) -> AdapterCallRequest:
+    base: dict[str, object] = {
+        "model": model,
+        "messages": [Message(role="user", content="hello")],
+        "system_prompt": "be brief",
+        "max_tokens": 1024,
+    }
+    base.update(kw)
+    return AdapterCallRequest(**base)  # type: ignore[arg-type]
+
+
+def test_codex_kwargs_does_not_send_max_output_tokens() -> None:
+    """Codex backend rejects ``max_output_tokens`` with 400 — must not be sent."""
+    kwargs = _build_codex_call_kwargs(_req(max_tokens=2048))
+    assert "max_output_tokens" not in kwargs
+    assert "max_tokens" not in kwargs
+
+
+def test_codex_kwargs_sets_store_false() -> None:
+    """``store = False`` is required on Codex backend (Plus subscription policy)."""
+    kwargs = _build_codex_call_kwargs(_req())
+    assert kwargs["store"] is False
+
+
+def test_codex_kwargs_lifts_system_prompt_to_instructions() -> None:
+    """System prompt belongs in ``instructions``, not in ``input[].role=system``."""
+    kwargs = _build_codex_call_kwargs(_req(system_prompt="audit only"))
+    assert kwargs["instructions"] == "audit only"
+    roles_in_input = [m.get("role") for m in kwargs["input"]]
+    assert "system" not in roles_in_input
+
+
+def test_codex_kwargs_instructions_default_when_empty() -> None:
+    """Empty system_prompt still produces a non-empty instructions string."""
+    kwargs = _build_codex_call_kwargs(_req(system_prompt=""))
+    assert kwargs["instructions"]  # non-empty fallback
+
+
+def test_codex_kwargs_gpt5_omits_temperature_adds_reasoning() -> None:
+    """gpt-5.x family omits ``temperature`` and adds ``reasoning`` block."""
+    kwargs = _build_codex_call_kwargs(_req(model="gpt-5.5", temperature=0.7))
+    assert "temperature" not in kwargs
+    assert kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
+    assert kwargs["include"] == ["reasoning.encrypted_content"]
+
+
+def test_codex_kwargs_non_gpt5_keeps_temperature() -> None:
+    """Non-gpt-5 models (e.g. o3) keep the temperature path."""
+    kwargs = _build_codex_call_kwargs(_req(model="o3", temperature=0.3))
+    assert kwargs["temperature"] == 0.3
+    assert "reasoning" not in kwargs
+
+
+def test_codex_kwargs_tools_use_flat_responses_shape() -> None:
+    """Codex Responses API requires the FLAT tool shape (not nested ``function``)."""
+    tool = ToolSpec(name="search", description="web search", input_schema={"type": "object"})
+    kwargs = _build_codex_call_kwargs(_req(tools=[tool]))
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "search",
+            "description": "web search",
+            "parameters": {"type": "object"},
+        }
+    ]
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+
+
+def test_codex_kwargs_no_tools_when_none_provided() -> None:
+    kwargs = _build_codex_call_kwargs(_req())
+    assert "tools" not in kwargs
+    assert "parallel_tool_calls" not in kwargs

--- a/tests/core/llm/adapters/test_registry.py
+++ b/tests/core/llm/adapters/test_registry.py
@@ -1,0 +1,183 @@
+"""Adapter registry tests — register / unregister / resolve_for / bootstrap."""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.adapters.base import (
+    CONCRETE_SOURCES,
+    SOURCE_AUTO,
+    SOURCE_PAYG,
+    SOURCE_SUBSCRIPTION,
+)
+from core.llm.adapters.registry import _reset_for_test
+
+from core.llm.adapters import (
+    AdapterAlreadyRegisteredError,
+    AdapterBillingType,
+    AdapterNotFoundError,
+    bootstrap_builtins,
+    get_adapter,
+    list_adapters,
+    register_adapter,
+    resolve_for,
+    unregister_adapter,
+)
+
+
+class _Stub:
+    """Minimum LLMAdapter Protocol stub used across registry tests."""
+
+    def __init__(self, name: str, provider: str, source: str) -> None:
+        self.name = name
+        self.provider = provider
+        self.source = source
+        self.billing_type = AdapterBillingType.UNKNOWN
+
+    async def acomplete(self, req):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def astream(self, req):  # type: ignore[no-untyped-def]
+        return
+        yield  # pragma: no cover — never reached, satisfies async-generator typing
+
+    def test_environment(self):  # type: ignore[no-untyped-def]
+        from core.llm.adapters.base import EnvironmentReport
+
+        return EnvironmentReport(ok=True)
+
+    def list_models(self):  # type: ignore[no-untyped-def]
+        return []
+
+    def get_quota_windows(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def detect_credential(self):  # type: ignore[no-untyped-def]
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> object:
+    """Each registry test runs against a fresh registry."""
+    _reset_for_test()
+    yield
+    _reset_for_test()
+
+
+def test_register_and_get() -> None:
+    s = _Stub("stub-a", "stub", SOURCE_PAYG)
+    register_adapter(s)
+    assert get_adapter("stub-a") is s
+
+
+def test_register_duplicate_raises() -> None:
+    register_adapter(_Stub("dup", "x", SOURCE_PAYG))
+    with pytest.raises(AdapterAlreadyRegisteredError):
+        register_adapter(_Stub("dup", "y", SOURCE_PAYG))
+
+
+def test_register_duplicate_with_replace_overwrites() -> None:
+    register_adapter(_Stub("dup", "x", SOURCE_PAYG))
+    new = _Stub("dup", "y", SOURCE_SUBSCRIPTION)
+    register_adapter(new, replace=True)
+    assert get_adapter("dup") is new
+
+
+def test_register_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match=r"adapter\.name is empty"):
+        register_adapter(_Stub("", "x", SOURCE_PAYG))
+
+
+def test_register_rejects_non_concrete_source() -> None:
+    with pytest.raises(ValueError, match="not a concrete value"):
+        register_adapter(_Stub("bad", "x", "auto"))
+
+
+def test_unregister_idempotent() -> None:
+    register_adapter(_Stub("x", "p", SOURCE_PAYG))
+    unregister_adapter("x")
+    unregister_adapter("x")  # No-op second time.
+
+
+def test_get_adapter_missing_raises() -> None:
+    with pytest.raises(AdapterNotFoundError):
+        get_adapter("not-here")
+
+
+def test_list_adapters_preserves_registration_order() -> None:
+    register_adapter(_Stub("a", "p", SOURCE_PAYG))
+    register_adapter(_Stub("b", "p", SOURCE_SUBSCRIPTION))
+    register_adapter(_Stub("c", "q", SOURCE_PAYG))
+    names = [a.name for a in list_adapters()]
+    assert names == ["a", "b", "c"]
+
+
+def test_resolve_for_returns_unique_match() -> None:
+    a = _Stub("a", "anthropic", SOURCE_PAYG)
+    b = _Stub("b", "anthropic", SOURCE_SUBSCRIPTION)
+    register_adapter(a)
+    register_adapter(b)
+    assert resolve_for("anthropic", SOURCE_PAYG) is a
+    assert resolve_for("anthropic", SOURCE_SUBSCRIPTION) is b
+
+
+def test_resolve_for_rejects_auto_sentinel() -> None:
+    with pytest.raises(ValueError, match="picker sentinel"):
+        resolve_for("anthropic", SOURCE_AUTO)
+
+
+def test_resolve_for_rejects_unknown_source() -> None:
+    with pytest.raises(ValueError, match="not a concrete value"):
+        resolve_for("anthropic", "garbage")
+
+
+def test_resolve_for_no_match_raises() -> None:
+    register_adapter(_Stub("a", "anthropic", SOURCE_PAYG))
+    with pytest.raises(AdapterNotFoundError):
+        resolve_for("openai", SOURCE_PAYG)
+
+
+def test_resolve_for_duplicate_pair_raises() -> None:
+    register_adapter(_Stub("a", "anthropic", SOURCE_PAYG))
+    # Bypass the duplicate-name guard by registering with a different name
+    # but the same (provider, source) — invariant violation.
+    register_adapter(_Stub("b", "anthropic", SOURCE_PAYG))
+    with pytest.raises(RuntimeError, match="multiple adapters match"):
+        resolve_for("anthropic", SOURCE_PAYG)
+
+
+def test_bootstrap_builtins_registers_six() -> None:
+    bootstrap_builtins()
+    names = {a.name for a in list_adapters()}
+    assert names == {
+        "anthropic-payg",
+        "anthropic-oauth",
+        "claude-cli",
+        "openai-payg",
+        "codex-oauth",
+        "codex-cli",
+    }
+
+
+def test_bootstrap_builtins_idempotent() -> None:
+    bootstrap_builtins()
+    bootstrap_builtins()  # Second call must not raise.
+    assert len(list_adapters()) == 6
+
+
+def test_bootstrap_builtins_provider_source_pairs() -> None:
+    bootstrap_builtins()
+    pairs = {(a.provider, a.source) for a in list_adapters()}
+    assert pairs == {
+        ("anthropic", "payg"),
+        ("anthropic", "subscription"),
+        ("anthropic", "adapter"),
+        ("openai", "payg"),
+        ("openai", "subscription"),
+        ("openai", "adapter"),
+    }
+
+
+def test_all_concrete_sources_covered_by_some_builtin() -> None:
+    bootstrap_builtins()
+    seen = {a.source for a in list_adapters()}
+    assert seen >= CONCRETE_SOURCES

--- a/tests/plugins/seed_generation/test_picker_adapter_glue.py
+++ b/tests/plugins/seed_generation/test_picker_adapter_glue.py
@@ -1,0 +1,201 @@
+"""Picker → adapter resolution glue tests + config.toml SoT tests."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import plugins.seed_generation.picker as picker_mod
+import pytest
+from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
+from plugins.seed_generation.picker import (
+    RoleBinding,
+    binding_to_adapter_source,
+    load_user_overrides,
+    resolve_binding_to_adapter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_builtins():
+    _reset_for_test()
+    bootstrap_builtins()
+    yield
+    _reset_for_test()
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_warned():
+    """Force the one-time legacy-warning flag back to False per test."""
+    picker_mod._LEGACY_OVERRIDE_WARNED = False
+    yield
+    picker_mod._LEGACY_OVERRIDE_WARNED = False
+
+
+# ── binding_to_adapter_source ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("picker_source", "expected"),
+    [
+        ("api_key", "payg"),
+        ("payg", "payg"),
+        ("claude-cli", "adapter"),
+        ("openai-codex", "subscription"),
+        ("subscription", "subscription"),
+        ("adapter", "adapter"),
+    ],
+)
+def test_binding_to_adapter_source_known(picker_source: str, expected: str) -> None:
+    assert binding_to_adapter_source(picker_source) == expected
+
+
+def test_binding_to_adapter_source_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="unknown picker source"):
+        binding_to_adapter_source("nonexistent")
+
+
+# ── resolve_binding_to_adapter end-to-end ─────────────────────────────────
+
+
+def test_resolve_binding_claude_cli_returns_claude_cli_adapter() -> None:
+    b = RoleBinding(
+        role="generator", model="claude-sonnet-4-6", provider="anthropic", source="claude-cli"
+    )
+    adapter = resolve_binding_to_adapter(b)
+    assert adapter.name == "claude-cli"  # type: ignore[attr-defined]
+
+
+def test_resolve_binding_api_key_returns_payg_adapter() -> None:
+    b = RoleBinding(
+        role="critic", model="claude-sonnet-4-6", provider="anthropic", source="api_key"
+    )
+    adapter = resolve_binding_to_adapter(b)
+    assert adapter.name == "anthropic-payg"  # type: ignore[attr-defined]
+
+
+def test_resolve_binding_openai_codex_returns_codex_oauth_adapter() -> None:
+    b = RoleBinding(role="evolver", model="gpt-5.5", provider="openai", source="openai-codex")
+    adapter = resolve_binding_to_adapter(b)
+    assert adapter.name == "codex-oauth"  # type: ignore[attr-defined]
+
+
+def test_resolve_binding_new_adapter_name_passthrough() -> None:
+    """A binding with adapter-native source (``adapter`` / ``subscription``) resolves directly."""
+    b = RoleBinding(role="pilot", model="claude-sonnet-4-6", provider="anthropic", source="adapter")
+    adapter = resolve_binding_to_adapter(b)
+    assert adapter.name == "claude-cli"  # type: ignore[attr-defined]
+
+
+# ── Config SoT — config.toml [seed_generation.role.*] precedence ──────────
+
+
+def test_config_toml_wins_over_legacy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When config.toml has [seed_generation.role.*], legacy file is NOT read."""
+    config = tmp_path / "config.toml"
+    config.write_text(
+        textwrap.dedent(
+            """
+            [seed_generation.role.generator]
+            source = "payg"
+
+            [seed_generation.role.pilot]
+            source = "adapter"
+            model = "claude-haiku-4-5"
+            """
+        ),
+        encoding="utf-8",
+    )
+    legacy = tmp_path / "seed-generation.toml"
+    legacy.write_text(
+        textwrap.dedent(
+            """
+            [generator]
+            source = "should_not_be_read"
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(picker_mod, "GLOBAL_CONFIG_TOML", config)
+    monkeypatch.setattr(picker_mod, "GLOBAL_SEED_PIPELINE_TOML", legacy)
+
+    overrides = load_user_overrides()
+    assert overrides == {
+        "generator": {"source": "payg"},
+        "pilot": {"source": "adapter", "model": "claude-haiku-4-5"},
+    }
+
+
+def test_legacy_file_fallback_when_config_toml_lacks_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """Falls back to legacy seed-generation.toml + logs a one-time warning."""
+    config = tmp_path / "config.toml"
+    config.write_text(
+        textwrap.dedent(
+            """
+            [other_section]
+            value = "irrelevant"
+            """
+        ),
+        encoding="utf-8",
+    )
+    legacy = tmp_path / "seed-generation.toml"
+    legacy.write_text(
+        textwrap.dedent(
+            """
+            [generator]
+            source = "api_key"
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(picker_mod, "GLOBAL_CONFIG_TOML", config)
+    monkeypatch.setattr(picker_mod, "GLOBAL_SEED_PIPELINE_TOML", legacy)
+
+    with caplog.at_level("WARNING"):
+        overrides = load_user_overrides()
+    assert overrides == {"generator": {"source": "api_key"}}
+    assert any("legacy" in r.getMessage() for r in caplog.records)
+
+
+def test_legacy_warning_only_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text("# empty\n", encoding="utf-8")
+    legacy = tmp_path / "seed-generation.toml"
+    legacy.write_text('[generator]\nsource = "api_key"\n', encoding="utf-8")
+    monkeypatch.setattr(picker_mod, "GLOBAL_CONFIG_TOML", config)
+    monkeypatch.setattr(picker_mod, "GLOBAL_SEED_PIPELINE_TOML", legacy)
+
+    with caplog.at_level("WARNING"):
+        load_user_overrides()
+        load_user_overrides()
+        legacy_warnings = [r for r in caplog.records if "legacy" in r.getMessage()]
+    assert len(legacy_warnings) == 1
+
+
+def test_both_files_missing_returns_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(picker_mod, "GLOBAL_CONFIG_TOML", tmp_path / "noconfig.toml")
+    monkeypatch.setattr(picker_mod, "GLOBAL_SEED_PIPELINE_TOML", tmp_path / "nolegacy.toml")
+    assert load_user_overrides() == {}
+
+
+def test_explicit_path_bypasses_sot_resolution(tmp_path: Path) -> None:
+    """``load_user_overrides(path=...)`` reads the explicit file directly (legacy shape)."""
+    target = tmp_path / "custom.toml"
+    target.write_text('[generator]\nsource = "adapter"\n', encoding="utf-8")
+    assert load_user_overrides(path=target) == {"generator": {"source": "adapter"}}
+
+
+def test_malformed_config_toml_falls_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """An unparseable config.toml does not crash the picker — fall through."""
+    config = tmp_path / "config.toml"
+    config.write_text("not = valid = toml\n", encoding="utf-8")
+    monkeypatch.setattr(picker_mod, "GLOBAL_CONFIG_TOML", config)
+    monkeypatch.setattr(picker_mod, "GLOBAL_SEED_PIPELINE_TOML", tmp_path / "nolegacy.toml")
+    with caplog.at_level("WARNING"):
+        result = load_user_overrides()
+    assert result == {}
+    assert any("not valid TOML" in r.getMessage() for r in caplog.records)

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -231,7 +231,7 @@ def test_build_audit_command_omits_target_judge_when_cfg_unpinned(
             target_model=None,
             judge_model=None,
             source="claude-cli",
-            seed_limit=2,
+            seed_limit=5,
             seed_select="plugins/petri_audit/seeds",
             dim_set="subset",
             max_turns=5,

--- a/tests/test_provider_label_consistency.py
+++ b/tests/test_provider_label_consistency.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 
 from core.cli.commands import MODEL_PROFILES
 from core.config import _resolve_provider
-from core.llm.adapters import _ADAPTER_MAP
 
 from core.llm import adapters as _adapters_mod
+from core.llm.adapters import _ADAPTER_MAP
 
 
 class TestProviderRouting:

--- a/tests/test_quota_fail_fast.py
+++ b/tests/test_quota_fail_fast.py
@@ -42,10 +42,11 @@ from unittest.mock import MagicMock
 
 import core.agent.loop as _loop_mod
 import core.agent.loop._model_switching as _switching_mod
-import core.llm.adapters as _adapters_mod
 import core.llm.provider_dispatch as _provider_dispatch_mod
 from core.config._settings import Settings
 from core.llm.errors import BillingError
+
+import core.llm.adapters as _adapters_mod
 
 # ---------------------------------------------------------------------------
 # Contract 1 — cross-provider failover removed

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -115,6 +115,81 @@ seed_limit = 25
     assert cfg.autoresearch.source == "auto"
 
 
+# ---------------------------------------------------------------------------
+# PR-C-P1 (2026-05-23) — seed_limit lower bound ≥ 5
+# ---------------------------------------------------------------------------
+
+
+def test_autoresearch_seed_limit_lower_bound_is_5() -> None:
+    """PR-C-P1 bumps ``seed_limit`` from ``ge=1`` to ``ge=5``.
+    ``dim_extractor._aggregate`` forces ``stderr=0.0`` only at N=1
+    (ddof=1 variance undefined); N=2-4 produces a sample stderr but
+    the CV is too unstable to drive ``_should_promote``. Either way
+    the gate ends up flooring at the default 0.05, so a 0.05+ Δ
+    promotes against a measurement with no confidence signal.
+    Pydantic must reject any config that sets it lower."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        AutoresearchConfig(seed_limit=2)
+    msg = str(exc_info.value)
+    assert "seed_limit" in msg
+    assert "greater than or equal to 5" in msg or "ge=5" in msg
+
+
+def test_autoresearch_seed_limit_boundary_n5_accepted() -> None:
+    """Boundary pin — N=5 (the threshold) must be accepted. A future
+    typo bumping to ``gt=5`` would silently exclude the boundary."""
+    cfg = AutoresearchConfig(seed_limit=5)
+    assert cfg.seed_limit == 5
+
+
+def test_autoresearch_seed_limit_default_remains_10() -> None:
+    """The default (already healthy at 10) stays unchanged so operators
+    who never set ``seed_limit`` see no behaviour shift."""
+    cfg = AutoresearchConfig()
+    assert cfg.seed_limit == 10
+
+
+def test_get_autoresearch_config_propagates_validation_error_to_operator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR-C-P1 Codex MCP catch — ``autoresearch.train._get_autoresearch_config``
+    used to ``except Exception:`` and silently fall back to the module
+    defaults, so an operator config with ``seed_limit = 2`` (< new
+    ``ge=5`` floor) produced no error. The narrowed catch now lets
+    ``pydantic.ValidationError`` surface to the operator with the
+    actionable Pydantic message. Same silent-drift pattern as
+    PR-MINIMAL-2 #1398."""
+    from pydantic import ValidationError
+
+    path = tmp_path / "config.toml"
+    _write_toml(
+        path,
+        """
+[self_improving_loop.autoresearch]
+seed_limit = 2
+""",
+    )
+    import autoresearch.train as auto_train
+    from core.config import self_improving_loop as sil_config
+
+    # Capture the unpatched loader, then monkeypatch the import target
+    # to force the tmp_path. ``_get_autoresearch_config`` imports the
+    # loader from ``core.config.self_improving_loop`` so the patch
+    # needs to land on that module attribute.
+    original_loader = sil_config.load_self_improving_loop_config
+
+    def _load_with_tmp_path(*_args: object, **_kwargs: object) -> object:
+        return original_loader(path)
+
+    monkeypatch.setattr(sil_config, "load_self_improving_loop_config", _load_with_tmp_path)
+
+    with pytest.raises(ValidationError):
+        auto_train._get_autoresearch_config()
+
+
 def test_load_reads_petri_role_bindings(tmp_path: Path) -> None:
     """[self_improving_loop.petri.<role>] keys become PetriRoleConfig entries."""
     path = tmp_path / "config.toml"


### PR DESCRIPTION
## Summary

- New `core.llm.adapters.LLMAdapter` Protocol mirroring paperclip's `ServerAdapterModule` + mutable registry (`register_adapter` / `resolve_for(provider, source)` / `bootstrap_builtins`).
- 6 built-in adapters covering all PAYG / Subscription / Adapter paths for Anthropic + OpenAI: `anthropic-payg`, `anthropic-oauth`, `claude-cli`, `openai-payg`, `codex-oauth`, `codex-cli`.
- Picker → adapter resolution glue: `binding_to_adapter_source` + `resolve_binding_to_adapter` map `RoleBinding` to a concrete adapter.
- Config SoT consolidation: `~/.geode/config.toml` `[seed_generation.role.<role>]` (mirrors Session 66 petri-role consolidation), legacy `~/.geode/seed-generation.toml` fallback with one-time deprecation warning.

## Why

The picker's `RoleBinding.source` was a display/billing label that never reached the LLM call site. `cli.py:443 Pipeline(state, registry)` dropped `picker_result` entirely; `SubAgentManager._build_worker_request` resolved provider purely from model-id prefix via `_resolve_provider`, and `ProfileRotator` selected credentials by global type-priority (OAUTH > TOKEN > API_KEY) — making per-role source choice (PAYG vs Subscription vs Adapter) impossible.

User directive 2026-05-23: "PAYG, 구독제(OAuth), Adapter(local agent-cli)는 UI/UX에서 선택할 수 있어야 해". This PR lands the backend abstraction; the AgenticLoop migration + UI surface follow in separate PRs (Scope cut section).

## Changes

| File | Change |
|------|--------|
| `core/llm/adapters/__init__.py` | NEW package — re-exports new + legacy symbols |
| `core/llm/adapters/base.py` | NEW — LLMAdapter Protocol + dataclasses + AdapterBillingType enum |
| `core/llm/adapters/registry.py` | NEW — mutable registry + bootstrap_builtins |
| `core/llm/adapters/_anthropic_common.py` | NEW — fresh-client builder + shared request/response translators |
| `core/llm/adapters/_openai_common.py` | NEW — fresh-client builder (PAYG + Codex variants) + translators |
| `core/llm/adapters/_subprocess_common.py` | NEW — stdin flatten helper for CLI adapters |
| `core/llm/adapters/anthropic_payg.py` | NEW — PAYG api-key path |
| `core/llm/adapters/anthropic_oauth.py` | NEW — Claude OAuth subscription path |
| `core/llm/adapters/claude_cli.py` | NEW — local claude binary subprocess (via LaneQueue) |
| `core/llm/adapters/openai_payg.py` | NEW — OpenAI api-key path |
| `core/llm/adapters/codex_oauth.py` | NEW — ChatGPT OAuth path with backend-specific headers + payload |
| `core/llm/adapters/codex_cli.py` | NEW — local codex binary subprocess |
| `core/llm/adapters/_legacy.py` | RENAME from adapters.py — legacy LLMClientPort/AgenticLLMPort kept functional, deprecated |
| `core/llm/credentials.py` | MOD — DeprecationWarning docstring on resolve_provider_key |
| `core/config/__init__.py` | MOD — DeprecationWarning docstring on _resolve_provider |
| `core/wiring/container.py` | MOD — build_llm_adapters now calls bootstrap_builtins() |
| `plugins/seed_generation/picker.py` | MOD — binding_to_adapter_source + resolve_binding_to_adapter + config.toml SoT precedence |
| `tests/core/llm/adapters/` | NEW — 49 tests (base / registry / builtin_identity / client_isolation / codex_oauth_backend_invariants) |
| `tests/plugins/seed_generation/test_picker_adapter_glue.py` | NEW — 15 tests (translation + config.toml SoT precedence) |
| `tests/test_provider_label_consistency.py` | MOD — adjust for new `_ADAPTER_MAP` re-export path |
| `tests/test_quota_fail_fast.py` | MOD — adjust for new `_ADAPTER_MAP` re-export path |
| `CHANGELOG.md` | Added/Changed/Deprecated entries under [Unreleased] |
| `docs/plans/2026-05-23-llm-adapter-abstraction.md` | NEW — design doc + scope cut + follow-up roadmap |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Layer 4 Protocol + registry | Implemented | base.py + registry.py |
| 6 concrete adapters | Implemented | each adapter owns its client (Codex MCP BLOCKER fix) |
| Picker → adapter helper | Implemented | binding_to_adapter_source + resolve_binding_to_adapter |
| Config SoT migration | Implemented | config.toml [seed_generation.role.*] + legacy fallback warning |
| AgenticLoop migration to adapter.acomplete | Deferred (follow-up A) | Marked deprecated in plan doc; legacy resolve_agentic_adapter still functional |
| Pipeline.bindings propagation | Deferred (follow-up B) | Depends on follow-up A |
| S11 PipelineRegistry wire-up | Deferred (follow-up C) | Depends on follow-up A + B |
| UI surface (geode adapters list / REPL) | Deferred (follow-up D) | Parallel to A/B/C |

## Verification

- [x] ruff check clean (`uv run ruff check core/ tests/ plugins/`)
- [x] ruff format clean (`uv run ruff format --check core/ tests/ plugins/`)
- [x] mypy clean (`uv run mypy core/ plugins/`)
- [x] lint-imports clean (`uv run lint-imports`)
- [x] pytest pass (6697 passed / 42 skipped — 64 new adapter tests included)
- [x] Codex MCP review × 2 rounds — all BLOCKER/HIGH/MEDIUM addressed (see commit message)

## Reference

- paperclip: `~/workspace/paperclip` (`packages/adapter-utils/src/types.ts:349 ServerAdapterModule`, `server/src/adapters/registry.ts`, `adapter-plugin.md` phase-1)
- Plan: `docs/plans/2026-05-23-llm-adapter-abstraction.md`
- Codex backend spec: `docs/research/codex-oauth-request-spec.md`
- Session 66 petri-role consolidation: PR #1496 / #1498 / #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)