### PR TITLE
feat(agent/loop): Follow-up A — opt-in LLMAdapter route + source threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,30 @@ functional change.
 
 ### Added
 
+- **Follow-up A — AgenticLoop opt-in adapter route + source threading.**
+  ``SubTask.source`` + ``WorkerRequest.source`` carry the picker-resolved
+  adapter source (``payg`` / ``subscription`` / ``adapter``) through the
+  parent → worker subprocess boundary into the spawned
+  :class:`AgenticLoop`. When ``source`` is set AND ``provider="anthropic"``,
+  ``AgenticLoop._call_llm`` routes through
+  :func:`core.llm.adapters.resolve_for(provider, source)` →
+  :meth:`LLMAdapter.acomplete` instead of the legacy
+  ``resolve_agentic_adapter(provider)`` path. Translation lives in
+  ``core/llm/adapters/_legacy_bridge.py``
+  (``build_adapter_request`` / ``agentic_response_from_adapter_result``);
+  ``AdapterCallRequest`` gained ``tool_choice`` + ``provider_options``
+  fields to carry the loop-side knobs. Anthropic adapters translate the
+  ``tool_choice`` value (``"auto"`` / ``"any"`` / ``"none"`` / ``"required"`` /
+  dict) into Anthropic's ``{"type": ...}`` payload so the loop's wrap-up
+  ``{"type": "none"}`` actually suppresses tool calls on the new route.
+  Concrete source with a missing registry entry HARD-FAILS — silent
+  fallback would mask operator misconfiguration (Codex MCP 2026-05-23
+  HIGH 2). Non-Anthropic providers (``openai`` / ``openai-codex`` /
+  ``glm``) thread ``source`` for observability but stay on the legacy
+  adapter — full OpenAI / Codex multi-turn translation + Codex
+  encrypted-reasoning replay lands as **Follow-up A2**. Legacy callers
+  (empty ``source``) see no behaviour change.
+
 - **LLM adapter abstraction (paperclip pattern) — Layer 4 Protocol +
   Layer 3 built-ins.** New :class:`core.llm.adapters.LLMAdapter`
   Protocol (paperclip ``ServerAdapterModule`` mirror) + mutable

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -90,6 +90,7 @@ class AgenticLoop:
         quiet: bool = False,
         disable_settings_drift: bool = False,
         allowed_tool_names: set[str] | None = None,
+        source: str = "",
     ) -> None:
         self.context = context
         self.executor = tool_executor
@@ -146,6 +147,39 @@ class AgenticLoop:
         if allowed_tool_names is not None:
             self._tools = [t for t in self._tools if t.get("name") in allowed_tool_names]
         self._last_llm_error: str | None = None  # last error type for user message
+        # v0.99.40 Follow-up A — opt-in adapter route via the v0.99.39
+        # :class:`LLMAdapter` registry. Scope limited to ``provider="anthropic"``
+        # in this PR: the OpenAI / Codex adapter route needs full multi-turn
+        # message translation (Anthropic tool_use → ``tool_calls`` /
+        # ``function_call`` etc.) + Codex encrypted-reasoning replay, both
+        # tracked as Follow-up A2 (``docs/plans/2026-05-23-llm-adapter-
+        # abstraction.md`` § Scope cut). Concrete source values still thread
+        # through SubTask/WorkerRequest for observability on every provider,
+        # but the actual LLM call stays on the legacy adapter when the
+        # bridge is not yet wired for that provider.
+        #
+        # When ``source`` is concrete (one of CONCRETE_SOURCES) AND the
+        # provider is supported, ``_call_llm`` routes through
+        # ``LLMAdapter.acomplete``. A concrete source with a missing
+        # adapter HARD-FAILS in :func:`resolve_for` — silent fallback would
+        # mask operator misconfiguration (Codex MCP 2026-05-23 HIGH 2).
+        self._source = source
+        self._new_adapter: Any | None = None
+        if source:
+            from core.llm.adapters import CONCRETE_SOURCES, resolve_for
+
+            if source in CONCRETE_SOURCES:
+                if self._provider == "anthropic":
+                    # Hard-fail on resolve mismatch — concrete source MUST resolve.
+                    self._new_adapter = resolve_for(self._provider, source)
+                else:
+                    log.info(
+                        "AgenticLoop: source=%s threaded through but provider=%s "
+                        "stays on legacy adapter — A2 follow-up adds OpenAI/Codex "
+                        "multi-turn translation + reasoning replay.",
+                        source,
+                        self._provider,
+                    )
         self._adapter = resolve_agentic_adapter(self._provider)
         self._op_logger = OperationLogger(quiet=self._quiet)
         self._error_recovery = ErrorRecoveryStrategy(tool_executor)
@@ -1502,23 +1536,57 @@ class AgenticLoop:
             adaptive_thinking = 0
             adaptive_effort = "low"
 
-        response = await self._adapter.agentic_call(
-            model=self.model,
-            system=system,
-            messages=messages,
-            tools=self._tools,
-            tool_choice=tool_choice,
-            max_tokens=adaptive_max_tokens,
-            temperature=0.0,
-            thinking_budget=adaptive_thinking,
-            effort=adaptive_effort,
-        )
+        if self._new_adapter is not None:
+            # v0.99.40 Follow-up A — opt-in adapter route. Build adapter-neutral
+            # request, call ``LLMAdapter.acomplete``, translate result back to
+            # ``AgenticResponse`` so the rest of the loop (tool dispatch, cost
+            # tracking, retry budget) is unchanged.
+            from core.llm.adapters._legacy_bridge import (
+                agentic_response_from_adapter_result,
+                build_adapter_request,
+            )
+
+            req = build_adapter_request(
+                model=self.model,
+                system=system,
+                messages=messages,
+                tools=self._tools,
+                tool_choice=tool_choice,
+                max_tokens=adaptive_max_tokens,
+                temperature=0.0,
+                thinking_budget=adaptive_thinking,
+                effort=adaptive_effort,
+            )
+            try:
+                result = await self._new_adapter.acomplete(req)
+            except Exception as exc:
+                self._last_llm_error = str(exc)
+                log.warning(
+                    "AgenticLoop: adapter.acomplete failed (adapter=%s): %s",
+                    getattr(self._new_adapter, "name", "<unknown>"),
+                    exc,
+                )
+                response = None
+            else:
+                response = agentic_response_from_adapter_result(result)
+        else:
+            response = await self._adapter.agentic_call(
+                model=self.model,
+                system=system,
+                messages=messages,
+                tools=self._tools,
+                tool_choice=tool_choice,
+                max_tokens=adaptive_max_tokens,
+                temperature=0.0,
+                thinking_budget=adaptive_thinking,
+                effort=adaptive_effort,
+            )
 
         if response is None:
             adapter_err = getattr(self._adapter, "last_error", None)
             if adapter_err:
                 self._last_llm_error = str(adapter_err)
-            else:
+            elif not self._last_llm_error:
                 self._last_llm_error = f"All {self._provider} models exhausted"
 
         # v0.57.0 R6 — surface reasoning summaries to AgenticUI. Per-item

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -117,13 +117,24 @@ SUBAGENT_DENIED_TOOLS: set[str] = {
 
 @dataclass
 class SubTask:
-    """A task to delegate to a sub-agent."""
+    """A task to delegate to a sub-agent.
+
+    ``source`` (v0.99.40 Follow-up A): one of
+    :data:`core.llm.adapters.CONCRETE_SOURCES` (``"payg"`` / ``"subscription"`` /
+    ``"adapter"``) or empty for legacy routing. When set, the spawned worker's
+    :class:`AgenticLoop` uses :func:`core.llm.adapters.resolve_for` to pick
+    the concrete :class:`LLMAdapter` instead of the legacy provider-only
+    ``resolve_agentic_adapter``. The picker (``plugins/seed_generation/
+    picker.py``) translates its ``RoleBinding.source`` into one of the
+    concrete values via :func:`binding_to_adapter_source`.
+    """
 
     task_id: str
     description: str
     task_type: str  # "analyze", "search", "compare"
     args: dict[str, Any] = field(default_factory=dict)
     agent: str | None = None  # Explicit agent override
+    source: str = ""  # adapter source; empty = legacy routing
 
 
 @dataclass
@@ -568,6 +579,7 @@ class SubAgentManager:
             toolkit=agent_toolkit,
             parent_session_key=self._parent_session_key,
             parent_session_id=parent_uuid,
+            source=task.source,
         )
 
     def _resolve_agent(self, task: SubTask) -> dict[str, Any] | None:

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -75,6 +75,12 @@ class WorkerRequest:
     # cross-session attribution. Empty strings = top-level spawn.
     parent_session_key: str = ""
     parent_session_id: str = ""
+    # v0.99.40 Follow-up A — adapter source for the new
+    # :class:`core.llm.adapters.LLMAdapter` registry. Concrete value
+    # (``"payg"`` / ``"subscription"`` / ``"adapter"``) when the parent's
+    # picker / orchestrator resolved a specific path; empty string falls
+    # back to legacy ``resolve_agentic_adapter(provider)`` routing.
+    source: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -106,6 +112,7 @@ class WorkerRequest:
             toolkit=data.get("toolkit", ""),
             parent_session_key=data.get("parent_session_key", ""),
             parent_session_id=data.get("parent_session_id", ""),
+            source=data.get("source", ""),
         )
 
 
@@ -312,6 +319,7 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
         parent_session_id=request.parent_session_id,
         quiet=True,  # Suppress spinner — parent handles UI
         allowed_tool_names=allowed_tool_names,
+        source=request.source,
     )
 
     # 7. Build prompt

--- a/core/llm/adapters/_anthropic_common.py
+++ b/core/llm/adapters/_anthropic_common.py
@@ -104,11 +104,31 @@ def build_create_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
         kwargs["temperature"] = req.temperature
     if req.tools:
         kwargs["tools"] = [translate_tool(t) for t in req.tools]
+        tc = _translate_tool_choice(req.tool_choice)
+        if tc is not None:
+            kwargs["tool_choice"] = tc
     if req.stop_sequences:
         kwargs["stop_sequences"] = list(req.stop_sequences)
     if req.thinking_budget > 0:
         kwargs["thinking"] = {"type": "enabled", "budget_tokens": req.thinking_budget}
     return kwargs
+
+
+def _translate_tool_choice(tc: str | dict[str, Any]) -> dict[str, Any] | None:
+    """Adapter-neutral ``tool_choice`` → Anthropic ``tool_choice`` payload.
+
+    Anthropic accepts ``{"type": "auto" | "any" | "none" | "tool", "name": ...}``.
+    The loop emits ``{"type": "none"}`` during wrap-up to forbid tool calls;
+    without explicit translation the SDK silently allows tool use and the
+    wrap-up safety net is defeated (Codex MCP 2026-05-23 MEDIUM 1).
+    """
+    if isinstance(tc, dict):
+        return tc
+    if tc in ("auto", "any", "none"):
+        return {"type": tc}
+    if tc == "required":
+        return {"type": "any"}
+    return None  # unknown literal — let Anthropic default apply
 
 
 def build_stream_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
@@ -127,6 +147,9 @@ def build_stream_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
         kwargs["temperature"] = req.temperature
     if req.tools:
         kwargs["tools"] = [translate_tool(t) for t in req.tools]
+        tc = _translate_tool_choice(req.tool_choice)
+        if tc is not None:
+            kwargs["tool_choice"] = tc
     return kwargs
 
 

--- a/core/llm/adapters/_legacy_bridge.py
+++ b/core/llm/adapters/_legacy_bridge.py
@@ -1,0 +1,147 @@
+"""Translation between the new :class:`LLMAdapter` Protocol and the legacy
+``AgenticResponse`` shape consumed by :class:`AgenticLoop`.
+
+Used by ``AgenticLoop._call_llm`` when an explicit ``source`` is set: the loop
+builds an :class:`AdapterCallRequest`, calls ``adapter.acomplete``, and feeds
+the result back through :func:`agentic_response_from_adapter_result` so the
+downstream tool-use / cost / observability pipeline keeps the same data
+shape.
+
+This bridge is intentionally minimal — it does NOT replicate the full
+``AgenticLLMPort.agentic_call`` (retry, failover, streaming) surface. Those
+behaviours stay in the legacy adapter for callers that don't set ``source``.
+The new path is an opt-in alternative; once every in-tree caller has migrated
+(v1.0.0), the bridge + legacy path are removed together.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.llm.adapters.base import (
+    AdapterCallRequest,
+    AdapterCallResult,
+    Message,
+    ToolSpec,
+)
+from core.llm.agentic_response import (
+    AgenticResponse,
+    ResponseUsage,
+    TextBlock,
+    ToolUseBlock,
+)
+
+
+def build_adapter_request(
+    *,
+    model: str,
+    system: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    tool_choice: dict[str, str] | str,
+    max_tokens: int,
+    temperature: float,
+    thinking_budget: int,
+    effort: str,
+) -> AdapterCallRequest:
+    """Translate AgenticLoop's call-site args → :class:`AdapterCallRequest`.
+
+    ``messages`` arrive in Anthropic shape (``[{"role": ..., "content": ...}, ...]``).
+    We map ``role="tool"`` entries (added during multi-turn tool-use) into the
+    adapter-neutral :class:`Message(tool_use_id=...)` form; adapter
+    implementations re-encode for their provider.
+
+    ``tools`` arrive in Anthropic shape (``[{"name": ..., "description": ...,
+    "input_schema": ...}]``) and translate directly to :class:`ToolSpec`.
+    """
+    adapter_messages: list[Message] = []
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+        tool_use_id = m.get("tool_use_id")
+        adapter_messages.append(Message(role=role, content=content, tool_use_id=tool_use_id))
+    adapter_tools: list[ToolSpec] = [
+        ToolSpec(
+            name=t.get("name", ""),
+            description=t.get("description", ""),
+            input_schema=t.get("input_schema", {}),
+        )
+        for t in tools
+    ]
+    return AdapterCallRequest(
+        model=model,
+        messages=adapter_messages,
+        system_prompt=system,
+        tools=adapter_tools,
+        tool_choice=tool_choice,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        thinking_budget=thinking_budget,
+        effort=effort,
+    )
+
+
+def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticResponse:
+    """Translate :class:`AdapterCallResult` → legacy :class:`AgenticResponse`.
+
+    The new adapter call returns a flat ``(text, usage, stop_reason,
+    tool_uses, raw_response)`` envelope; the legacy ``AgenticResponse`` is a
+    list of typed content blocks plus normalised usage. We rebuild the
+    content list — text block first (when non-empty), then one
+    :class:`ToolUseBlock` per tool_use entry — so ``ToolCallProcessor`` and
+    the rest of the loop see the same shape they did under the legacy
+    adapter.
+    """
+    blocks: list[TextBlock | ToolUseBlock] = []
+    if result.text:
+        blocks.append(TextBlock(type="text", text=result.text))
+    for tu in result.tool_uses:
+        input_field = tu.get("input", {})
+        if isinstance(input_field, str):
+            # Adapters that surface ``arguments`` as a JSON string (OpenAI)
+            # — parse to dict so the executor's signature stays uniform.
+            try:
+                input_field = json.loads(input_field) if input_field else {}
+            except json.JSONDecodeError:
+                input_field = {"_raw": input_field}
+        blocks.append(
+            ToolUseBlock(
+                id=str(tu.get("id", "")),
+                type="tool_use",
+                name=str(tu.get("name", "")),
+                input=input_field if isinstance(input_field, dict) else {},
+            )
+        )
+    usage = ResponseUsage(
+        input_tokens=result.usage.input_tokens,
+        output_tokens=result.usage.output_tokens,
+        cache_read_tokens=result.usage.cached_input_tokens,
+    )
+    return AgenticResponse(
+        content=blocks,
+        stop_reason=_translate_stop_reason(result.stop_reason),
+        usage=usage,
+    )
+
+
+def _translate_stop_reason(stop: str) -> str:
+    """Map provider-flavoured stop reasons → AgenticLoop's two-value enum.
+
+    Legacy ``AgenticResponse.stop_reason`` is one of ``"tool_use"`` /
+    ``"end_turn"``. Provider strings map as follows:
+
+    - Anthropic ``"tool_use"`` → ``"tool_use"``
+    - OpenAI ``"tool_calls"`` → ``"tool_use"``
+    - Codex ``"completed"`` / Anthropic ``"end_turn"`` / OpenAI ``"stop"`` /
+      anything else → ``"end_turn"``
+    """
+    if stop in ("tool_use", "tool_calls"):
+        return "tool_use"
+    return "end_turn"
+
+
+__all__ = [
+    "agentic_response_from_adapter_result",
+    "build_adapter_request",
+]

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -81,18 +81,32 @@ class Message:
 
 @dataclass(frozen=True)
 class AdapterCallRequest:
-    """Request envelope handed to ``LLMAdapter.acomplete`` / ``astream``."""
+    """Request envelope handed to ``LLMAdapter.acomplete`` / ``astream``.
+
+    ``tool_choice`` mirrors the Anthropic ``messages.create`` parameter shape
+    (``{"type": "auto" | "any" | "none" | "tool"}`` or the strings
+    ``"auto"`` / ``"any"`` / ``"none"`` / ``"required"``). Adapters translate
+    to provider-specific syntax in their request builders. Default ``"auto"``
+    lets the model pick whether to call a tool.
+
+    ``provider_options`` is a pass-through dict that adapters may consult for
+    provider-specific knobs without bloating the top-level schema (e.g.
+    Anthropic ``priority_tier``, Codex ``parallel_tool_calls``, OpenAI
+    ``response_format``). Each adapter ignores keys it doesn't recognise.
+    """
 
     model: str
     messages: Sequence[Message]
     system_prompt: str = ""
     tools: Sequence[ToolSpec] = field(default_factory=tuple)
+    tool_choice: str | dict[str, Any] = "auto"
     max_tokens: int = 8192
     temperature: float | None = None
     thinking_budget: int = 0
     effort: str = "medium"
     stop_sequences: tuple[str, ...] = ()
     metadata: dict[str, Any] = field(default_factory=dict)
+    provider_options: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/tests/core/agent/test_agent_loop_source_route.py
+++ b/tests/core/agent/test_agent_loop_source_route.py
@@ -1,0 +1,80 @@
+"""AgenticLoop source-route behavioural invariants.
+
+Pins:
+- Empty source → legacy adapter only, no new_adapter attached.
+- Concrete source + ``provider="anthropic"`` → ``resolve_for`` resolves and
+  attaches a new_adapter; legacy adapter still constructed for the fallback
+  surface (unused on this path).
+- Concrete source + provider != anthropic → new_adapter stays None (A2
+  follow-up scope); legacy adapter is the only route.
+- Concrete source + unregistered (provider, source) pair → hard-fail
+  (Codex MCP 2026-05-23 HIGH 2 — no silent fallback).
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.conversation import ConversationContext
+from core.agent.loop import AgenticLoop
+from core.agent.tool_executor import ToolExecutor
+from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
+
+from core.llm.adapters import AdapterNotFoundError
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_builtins():
+    _reset_for_test()
+    bootstrap_builtins()
+    yield
+    _reset_for_test()
+
+
+def _make_loop(*, source: str = "", provider: str = "anthropic") -> AgenticLoop:
+    return AgenticLoop(
+        ConversationContext(),
+        ToolExecutor(action_handlers={}, auto_approve=True),
+        provider=provider,
+        source=source,
+        quiet=True,
+    )
+
+
+def test_empty_source_leaves_new_adapter_none() -> None:
+    loop = _make_loop(source="")
+    assert loop._new_adapter is None
+    assert loop._adapter is not None  # legacy still wired
+
+
+def test_concrete_source_attaches_anthropic_adapter() -> None:
+    loop = _make_loop(source="payg")
+    assert loop._new_adapter is not None
+    assert loop._new_adapter.name == "anthropic-payg"
+    assert loop._adapter is not None  # legacy also wired for fallback
+
+
+def test_concrete_source_each_anthropic_variant() -> None:
+    for source, expected_name in (
+        ("payg", "anthropic-payg"),
+        ("subscription", "anthropic-oauth"),
+        ("adapter", "claude-cli"),
+    ):
+        loop = _make_loop(source=source)
+        assert loop._new_adapter is not None
+        assert loop._new_adapter.name == expected_name
+
+
+def test_non_anthropic_provider_skips_new_adapter() -> None:
+    """A2 follow-up scope — OpenAI/Codex providers still use legacy."""
+    loop = _make_loop(source="payg", provider="openai")
+    assert loop._new_adapter is None  # not yet on adapter route
+    assert loop._adapter is not None  # legacy path
+
+
+def test_unregistered_pair_hard_fails() -> None:
+    """Concrete source + missing adapter must raise — no silent fallback."""
+    from core.llm.adapters.registry import unregister_adapter
+
+    unregister_adapter("anthropic-payg")
+    with pytest.raises(AdapterNotFoundError):
+        _make_loop(source="payg")

--- a/tests/core/agent/test_source_threading.py
+++ b/tests/core/agent/test_source_threading.py
@@ -1,0 +1,52 @@
+"""Source threading invariants — SubTask → WorkerRequest → AgenticLoop.
+
+Pins v0.99.40 Follow-up A: when a parent picker resolves a per-role
+``RoleBinding.source`` (one of ``"payg"`` / ``"subscription"`` / ``"adapter"``),
+that value must reach the spawned worker's :class:`AgenticLoop`.
+Regression here means the operator's per-role auth choice silently collapses
+back onto ``ProfileRotator``'s global type-priority.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.sub_agent import SubTask
+from core.agent.worker import WorkerRequest
+
+
+def test_subtask_default_source_is_empty_legacy() -> None:
+    """Unset source means legacy routing — no behaviour change for old callers."""
+    task = SubTask(task_id="t1", description="d", task_type="analyze")
+    assert task.source == ""
+
+
+def test_subtask_accepts_concrete_source() -> None:
+    """SubTask carries a concrete adapter source for picker-driven flows."""
+    task = SubTask(task_id="t1", description="d", task_type="analyze", source="subscription")
+    assert task.source == "subscription"
+
+
+def test_worker_request_serialisation_round_trip() -> None:
+    """``source`` survives the wire encode / decode used by the worker subprocess."""
+    req = WorkerRequest(task_id="t1", source="adapter")
+    encoded = req.to_dict()
+    assert encoded["source"] == "adapter"
+    decoded = WorkerRequest.from_dict(encoded)
+    assert decoded.source == "adapter"
+
+
+def test_worker_request_legacy_payload_decodes_with_empty_source() -> None:
+    """Backward-compat: old wire payloads without ``source`` decode safely."""
+    legacy_payload = {
+        "task_id": "t1",
+        "task_type": "analyze",
+        "description": "d",
+    }
+    req = WorkerRequest.from_dict(legacy_payload)
+    assert req.source == ""
+
+
+@pytest.mark.parametrize("source", ["payg", "subscription", "adapter", ""])
+def test_worker_request_accepts_all_source_shapes(source: str) -> None:
+    req = WorkerRequest(task_id="t1", source=source)
+    assert req.source == source

--- a/tests/core/llm/adapters/test_legacy_bridge.py
+++ b/tests/core/llm/adapters/test_legacy_bridge.py
@@ -1,0 +1,174 @@
+"""Legacy bridge tests — AgenticLoop ↔ LLMAdapter translation.
+
+Pins the contract between the new ``LLMAdapter.acomplete`` surface and the
+legacy ``AgenticResponse`` consumed by the agentic loop. Regression here
+means the v0.99.40 Follow-up A path silently drops tool_use blocks or
+mangles message content during the round trip.
+"""
+
+from __future__ import annotations
+
+from core.llm.adapters._legacy_bridge import (
+    agentic_response_from_adapter_result,
+    build_adapter_request,
+)
+from core.llm.adapters.base import AdapterCallResult, UsageSummary
+
+
+def test_build_request_translates_user_message() -> None:
+    req = build_adapter_request(
+        model="claude-haiku-4-5",
+        system="You are helpful.",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    assert req.model == "claude-haiku-4-5"
+    assert req.system_prompt == "You are helpful."
+    assert len(req.messages) == 1
+    assert req.messages[0].role == "user"
+    assert req.messages[0].content == "hi"
+    assert req.tool_choice == "auto"
+
+
+def test_build_request_carries_tool_use_id_for_tool_messages() -> None:
+    """Multi-turn tool messages carry tool_use_id so the adapter can re-encode."""
+    req = build_adapter_request(
+        model="m",
+        system="",
+        messages=[
+            {"role": "user", "content": "calc 1+1"},
+            {"role": "tool", "content": "2", "tool_use_id": "tu_123"},
+        ],
+        tools=[],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    assert req.messages[1].role == "tool"
+    assert req.messages[1].tool_use_id == "tu_123"
+
+
+def test_build_request_translates_tools() -> None:
+    req = build_adapter_request(
+        model="m",
+        system="",
+        messages=[{"role": "user", "content": "x"}],
+        tools=[
+            {"name": "search", "description": "web", "input_schema": {"type": "object"}},
+        ],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    assert len(req.tools) == 1
+    assert req.tools[0].name == "search"
+    assert req.tools[0].description == "web"
+    assert req.tools[0].input_schema == {"type": "object"}
+
+
+def test_response_translation_text_only() -> None:
+    """A text-only AdapterCallResult → AgenticResponse with a single TextBlock."""
+    from core.llm.agentic_response import TextBlock
+
+    result = AdapterCallResult(
+        text="hello world",
+        usage=UsageSummary(input_tokens=10, output_tokens=5),
+        stop_reason="end_turn",
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert len(resp.content) == 1
+    block = resp.content[0]
+    assert isinstance(block, TextBlock)
+    assert block.text == "hello world"
+    assert resp.stop_reason == "end_turn"
+    assert resp.usage.input_tokens == 10
+    assert resp.usage.output_tokens == 5
+
+
+def test_response_translation_tool_use_block() -> None:
+    """Tool uses produce ToolUseBlock entries in order after the text block."""
+    from core.llm.agentic_response import ToolUseBlock
+
+    result = AdapterCallResult(
+        text="calling tool",
+        usage=UsageSummary(),
+        stop_reason="tool_use",
+        tool_uses=({"id": "tu_1", "name": "search", "input": {"q": "geode"}},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert len(resp.content) == 2
+    assert resp.content[0].type == "text"
+    block = resp.content[1]
+    assert isinstance(block, ToolUseBlock)
+    assert block.id == "tu_1"
+    assert block.name == "search"
+    assert block.input == {"q": "geode"}
+    assert resp.stop_reason == "tool_use"
+
+
+def test_response_translation_parses_string_input() -> None:
+    """OpenAI-style tool calls with stringified JSON arguments parse cleanly."""
+    from core.llm.agentic_response import ToolUseBlock
+
+    result = AdapterCallResult(
+        text="",
+        usage=UsageSummary(),
+        stop_reason="tool_calls",
+        tool_uses=({"id": "tc_1", "name": "lookup", "input": '{"key": "val"}'},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    # tool_calls → tool_use translation
+    assert resp.stop_reason == "tool_use"
+    block = resp.content[0]
+    assert isinstance(block, ToolUseBlock)
+    assert block.input == {"key": "val"}
+
+
+def test_response_translation_handles_malformed_string_input() -> None:
+    """Malformed stringified args don't crash — wrapped in ``_raw`` for inspection."""
+    from core.llm.agentic_response import ToolUseBlock
+
+    result = AdapterCallResult(
+        text="",
+        usage=UsageSummary(),
+        stop_reason="tool_use",
+        tool_uses=({"id": "tc_x", "name": "x", "input": "{not json"},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    block = resp.content[0]
+    assert isinstance(block, ToolUseBlock)
+    assert block.input == {"_raw": "{not json"}
+
+
+def test_response_translation_drops_empty_text() -> None:
+    """Empty text → no TextBlock prepended (tool-only response)."""
+    result = AdapterCallResult(
+        text="",
+        usage=UsageSummary(),
+        stop_reason="tool_use",
+        tool_uses=({"id": "tu_only", "name": "t", "input": {}},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert len(resp.content) == 1
+    assert resp.content[0].type == "tool_use"
+
+
+def test_response_translation_carries_cache_tokens() -> None:
+    """``cached_input_tokens`` from the adapter usage maps to ``cache_read_tokens``."""
+    result = AdapterCallResult(
+        text="ok",
+        usage=UsageSummary(input_tokens=100, output_tokens=20, cached_input_tokens=80),
+        stop_reason="end_turn",
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert resp.usage.cache_read_tokens == 80
+    assert resp.usage.input_tokens == 100

--- a/tests/core/llm/adapters/test_tool_choice_translation.py
+++ b/tests/core/llm/adapters/test_tool_choice_translation.py
@@ -1,0 +1,64 @@
+"""Anthropic adapter ``tool_choice`` translation invariants.
+
+Codex MCP 2026-05-23 MEDIUM 1: the loop emits ``{"type": "none"}`` during
+wrap-up to forbid tool calls. Without explicit translation, the SDK silently
+allows tool use and the wrap-up safety net is defeated.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.adapters._anthropic_common import build_create_kwargs
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+
+
+def _req(tool_choice: object = "auto") -> AdapterCallRequest:
+    return AdapterCallRequest(
+        model="claude-haiku-4-5",
+        messages=[Message(role="user", content="x")],
+        system_prompt="",
+        tools=[ToolSpec(name="t", description="", input_schema={"type": "object"})],
+        tool_choice=tool_choice,  # type: ignore[arg-type]
+        max_tokens=4096,
+    )
+
+
+@pytest.mark.parametrize(
+    ("loop_choice", "expected"),
+    [
+        ("auto", {"type": "auto"}),
+        ("any", {"type": "any"}),
+        ("none", {"type": "none"}),  # wrap-up safety net
+        ("required", {"type": "any"}),
+    ],
+)
+def test_string_tool_choice_translates(loop_choice: str, expected: dict[str, str]) -> None:
+    kwargs = build_create_kwargs(_req(tool_choice=loop_choice))
+    assert kwargs["tool_choice"] == expected
+
+
+def test_dict_tool_choice_passes_through() -> None:
+    """A dict from the loop (e.g. ``{"type": "tool", "name": "X"}``) survives."""
+    forced = {"type": "tool", "name": "X"}
+    kwargs = build_create_kwargs(_req(tool_choice=forced))
+    assert kwargs["tool_choice"] == forced
+
+
+def test_unknown_string_tool_choice_omitted() -> None:
+    """Unrecognised literal → no ``tool_choice`` key, Anthropic default applies."""
+    kwargs = build_create_kwargs(_req(tool_choice="garbage"))
+    assert "tool_choice" not in kwargs
+
+
+def test_no_tools_no_tool_choice() -> None:
+    """When the request carries no tools, ``tool_choice`` is also omitted."""
+    req = AdapterCallRequest(
+        model="claude-haiku-4-5",
+        messages=[Message(role="user", content="x")],
+        tools=(),
+        tool_choice="none",  # would normally translate, but no tools → skip
+        max_tokens=4096,
+    )
+    kwargs = build_create_kwargs(req)
+    assert "tools" not in kwargs
+    assert "tool_choice" not in kwargs


### PR DESCRIPTION
## Summary

- `SubTask.source` + `WorkerRequest.source` thread the picker-resolved adapter source (`payg` / `subscription` / `adapter`) through parent → worker subprocess → `AgenticLoop`.
- When `source` is concrete AND `provider="anthropic"`, `AgenticLoop._call_llm` routes through `LLMAdapter.acomplete` (new path) via `_legacy_bridge` translation. Otherwise legacy `resolve_agentic_adapter` stays.
- `AdapterCallRequest` gained `tool_choice` + `provider_options`. Anthropic adapters translate `tool_choice` → payload (covers loop's wrap-up `{"type": "none"}` safety net).

## Why

Follow-up A of the LLM adapter abstraction (#1518). Without source threading, the picker's per-role auth choice never reaches the LLM call site — `RoleBinding.source` stays a display-only label and `ProfileRotator` continues to pick credentials by global type-priority.

Codex MCP review fixed 2 findings in this PR:
- **HIGH 2 (silent fallback)** → concrete source now hard-fails on resolve mismatch, no silent fallback to legacy.
- **MEDIUM 1 (tool_choice ignored)** → Anthropic adapter translates `tool_choice` so the loop's wrap-up "none" actually suppresses tool calls.

Deferred to Follow-up A2 (Codex MCP findings) — documented in CHANGELOG + agent_loop.py comment:
- **BLOCKER 2 (OpenAI/Codex multi-turn translation)** — needs Anthropic ↔ OpenAI Chat tool_calls / Codex Responses function_call shape conversion (legacy has it at `core/llm/providers/openai.py:_convert_messages_to_*`).
- **HIGH 1 (Codex encrypted-reasoning replay)** — needs `codex_reasoning_items` capture from SSE stream.

Deferred to Follow-up B (not Codex MCP — the natural next step):
- **BLOCKER 1** — `plugins/seed_generation/agents/*.py` SubTask creation sites don't yet pass `source=self.source` from `BaseSeedAgent`. Source threading machinery exists but no upstream sets it. Pipeline.bindings propagation + agent SubTask updates land in Follow-up B.

## Changes

| File | Change |
|------|--------|
| `core/agent/sub_agent.py` | `SubTask.source: str = ""` field |
| `core/agent/worker.py` | `WorkerRequest.source` + round-trip in `to_dict` / `from_dict`; `_run_agentic` threads to `AgenticLoop` |
| `core/agent/loop/agent_loop.py` | `__init__(source=...)` kwarg; `resolve_for` (provider, source) with hard-fail; `_call_llm` branches on `_new_adapter`. Anthropic-only scope in this PR. |
| `core/llm/adapters/base.py` | `AdapterCallRequest.tool_choice` + `provider_options` fields |
| `core/llm/adapters/_anthropic_common.py` | `build_create_kwargs` / `build_stream_kwargs` consume `tool_choice` via `_translate_tool_choice` |
| `core/llm/adapters/_legacy_bridge.py` | NEW — `build_adapter_request` + `agentic_response_from_adapter_result` + `_translate_stop_reason` |
| `tests/core/llm/adapters/test_legacy_bridge.py` | NEW — 9 tests (translation contract) |
| `tests/core/llm/adapters/test_tool_choice_translation.py` | NEW — 7 tests (Anthropic payload shape) |
| `tests/core/agent/test_source_threading.py` | NEW — 5 tests (SubTask / WorkerRequest round-trip) |
| `tests/core/agent/test_agent_loop_source_route.py` | NEW — 5 tests (AgenticLoop source-route behaviour) |
| `CHANGELOG.md` | Added entry under [Unreleased] |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Source threading (SubTask → WorkerRequest → AgenticLoop) | Implemented | round-trip tests pin invariant |
| AgenticLoop adapter route — Anthropic | Implemented | 3 adapters (payg/oauth/cli) via `_legacy_bridge` |
| AgenticLoop adapter route — OpenAI/Codex | Deferred (Follow-up A2) | needs multi-turn translation + reasoning replay |
| Codex MCP HIGH 2 silent fallback | Fixed | hard-fail on resolve_for failure |
| Codex MCP MEDIUM 1 tool_choice | Fixed | Anthropic translation added |
| Seed agents set SubTask.source | Deferred (Follow-up B) | Pipeline.bindings propagation |

## Verification

- [x] ruff check clean (`uv run ruff check core/ tests/ plugins/`)
- [x] ruff format clean
- [x] mypy clean (`uv run mypy core/ plugins/`)
- [x] lint-imports clean
- [x] 26 new adapter/agent tests pass

## Reference

- Parent PR: #1518 (Layer 4 + Layer 3 + picker glue)
- Plan: `docs/plans/2026-05-23-llm-adapter-abstraction.md` § Scope cut
- Codex MCP review thread: 019e52cc-5936-7e60-bbf3-a80fa04c4ed9

🤖 Generated with [Claude Code](https://claude.com/claude-code)