### PR TITLE
feat(cli): Follow-up D — geode adapters list + audit-seeds config UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ functional change.
 
 ### Added
 
+- **Follow-up D — UI surface for the adapter registry.** Two new
+  read-only Typer subcommands:
+
+  - ``geode adapters list`` enumerates the 6 registered adapters with
+    ``billing_type`` and per-adapter ``test_environment`` status.
+  - ``geode adapters detect-model <name>`` reports the currently
+    configured model + provenance via the adapter's
+    ``detect_credential()`` hook.
+  - ``geode audit-seeds config`` shows the 7-role × (provider, model,
+    source) binding matrix resolved by the picker, plus the judge
+    panel voters.
+
+  UI follows the ``feedback_no_box_ui_no_emoji`` rule: dense aligned
+  table, plain text headers, no box-card / emoji decoration.
+
 - **Follow-up C — S11 PipelineRegistry wire-up.** ``cli._dispatch_pipeline``
   now populates the ``PipelineRegistry`` with one concrete agent per
   ``manifest.enabled_roles`` (generator / critic / proximity / pilot /

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -310,9 +310,11 @@ app = typer.Typer(
 )
 
 # Subcommand groups
+from core.cli.cmd_adapters import app as adapters_app  # noqa: E402
 from core.cli.cmd_config import app as config_app  # noqa: E402
 from core.cli.cmd_skill import app as skill_app  # noqa: E402
 
+app.add_typer(adapters_app, name="adapters")
 app.add_typer(skill_app, name="skill")
 app.add_typer(config_app, name="config")
 

--- a/core/cli/cmd_adapters.py
+++ b/core/cli/cmd_adapters.py
@@ -1,0 +1,82 @@
+"""CLI subcommand: ``geode adapters`` — inspect registered LLM adapters.
+
+v0.99.40 Follow-up D of the paperclip-style LLMAdapter abstraction
+(``docs/plans/2026-05-23-llm-adapter-abstraction.md``). Surface the
+:class:`core.llm.adapters.LLMAdapter` registry so operators can see what
+PAYG / Subscription / Adapter paths are available + verify each path's
+environment before scheduling a seed-generation run.
+
+Two read-only subcommands:
+
+- ``geode adapters list`` — enumerate registered adapters with
+  ``billing_type``, ``test_environment`` summary, and supported model
+  count.
+- ``geode adapters detect-model <adapter>`` — paperclip ``detectModel``
+  equivalent; reports the currently configured model + provenance from
+  the adapter's ``detect_credential()`` hook.
+
+UI: dense aligned table, plain text. No box-card / no emoji (per
+``feedback_no_box_ui_no_emoji`` memory).
+"""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(
+    name="adapters",
+    help="Inspect registered LLM adapters (PAYG / Subscription / Adapter paths).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@app.command("list")
+def adapters_list() -> None:
+    """List all registered adapters with billing_type + environment status."""
+    from core.llm.adapters import bootstrap_builtins, list_adapters
+
+    bootstrap_builtins()
+    adapters = list_adapters()
+    if not adapters:
+        typer.echo("No LLM adapters registered.")
+        raise typer.Exit()
+
+    header = f"{'NAME':<20} {'PROVIDER':<10} {'SOURCE':<14} {'BILLING':<22} STATUS"
+    typer.echo(header)
+    typer.echo("-" * len(header))
+    for a in adapters:
+        report = a.test_environment()
+        status = "ok" if report.ok else "missing — " + (report.hints[0] if report.hints else "")
+        typer.echo(
+            f"{a.name:<20} {a.provider:<10} {a.source:<14} {a.billing_type.value:<22} {status}"
+        )
+    typer.echo(f"\n{len(adapters)} adapter(s) registered.")
+    typer.echo(
+        'Override per role via ~/.geode/config.toml [seed_generation.role.<role>] source = "..."'
+    )
+
+
+@app.command("detect-model")
+def adapters_detect_model(name: str) -> None:
+    """Report the currently configured model + provenance for ``name``."""
+    from core.llm.adapters import AdapterNotFoundError, bootstrap_builtins, get_adapter
+
+    bootstrap_builtins()
+    try:
+        adapter = get_adapter(name)
+    except AdapterNotFoundError as exc:
+        typer.echo(f"adapter {name!r} not registered: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    detection = adapter.detect_credential()
+    if detection is None:
+        typer.echo(f"{name}: no credential detected — run ``geode adapters list`` for hints.")
+        raise typer.Exit(code=2)
+    typer.echo(f"{name}: model={detection.model} provider={detection.provider}")
+    typer.echo(f"  source: {detection.source_path}")
+    if detection.candidates:
+        typer.echo(f"  candidates: {', '.join(detection.candidates)}")
+
+
+__all__ = ["app"]

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -83,6 +83,49 @@ def _get_seed_generation_config() -> Any:
         return SimpleNamespace(candidates_default=15, default_gen_tag="gen1")
 
 
+@audit_seeds_app.command("config")
+def audit_seeds_config() -> None:
+    """Show the 7-role × (model, source) binding matrix.
+
+    Resolved by :func:`plugins.seed_generation.picker.pick_bindings`
+    after merging in user overrides from ``~/.geode/config.toml``
+    ``[seed_generation.role.<role>]`` (or the legacy
+    ``~/.geode/seed-generation.toml`` fallback).
+
+    Read-only — to change a role's source, edit
+    ``~/.geode/config.toml`` directly:
+
+      [seed_generation.role.generator]
+      source = "payg" | "subscription" | "adapter"
+
+    See ``geode adapters list`` for the available source names per
+    provider.
+    """
+    from plugins.seed_generation.picker import pick_bindings
+
+    picker = pick_bindings(auto_probe=False)
+    header = f"{'ROLE':<18} {'PROVIDER':<10} {'MODEL':<26} {'SOURCE':<14}"
+    typer.echo(header)
+    typer.echo("-" * len(header))
+    for role_name in sorted(picker.bindings):
+        b = picker.bindings[role_name]
+        typer.echo(f"{role_name:<18} {b.provider:<10} {b.model:<26} {b.source:<14}")
+
+    if picker.voters:
+        typer.echo("\nJudge panel voters:")
+        voter_header = f"  {'PROVIDER':<10} {'MODEL':<26} {'SOURCE':<14}"
+        typer.echo(voter_header)
+        typer.echo("  " + "-" * (len(voter_header) - 2))
+        for v in picker.voters:
+            typer.echo(f"  {v.provider:<10} {v.model:<26} {v.source:<14}")
+
+    typer.echo(
+        f"\n{len(picker.bindings)} role(s) bound; "
+        f"{len(picker.voters)} voter(s); "
+        f"{len(picker.subscription_paths_in_use)} subscription path(s) active."
+    )
+
+
 @audit_seeds_app.command("generate")
 def audit_seeds_generate(
     target_dim: str | None = typer.Option(

--- a/tests/core/cli/test_cmd_adapters.py
+++ b/tests/core/cli/test_cmd_adapters.py
@@ -1,0 +1,88 @@
+"""``geode adapters`` CLI surface tests — Follow-up D."""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
+from typer.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_builtins():
+    _reset_for_test()
+    bootstrap_builtins()
+    yield
+    _reset_for_test()
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_adapters_list_shows_all_six(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["adapters", "list"])
+    assert result.exit_code == 0, result.output
+    for adapter_name in (
+        "anthropic-payg",
+        "anthropic-oauth",
+        "claude-cli",
+        "openai-payg",
+        "codex-oauth",
+        "codex-cli",
+    ):
+        assert adapter_name in result.output
+
+
+def test_adapters_list_shows_billing_type(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["adapters", "list"])
+    assert "api" in result.output
+    assert "subscription" in result.output
+    assert "subscription_included" in result.output
+
+
+def test_adapters_detect_model_missing_adapter_exits_1(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["adapters", "detect-model", "no-such-adapter"])
+    assert result.exit_code == 1
+
+
+def test_adapters_detect_model_no_credential_exits_2(runner: CliRunner, monkeypatch) -> None:
+    """When a registered adapter has no credentials configured, exit 2."""
+    from core.cli import app
+
+    # Force PAYG to report no credential.
+    monkeypatch.setattr("core.config.settings.anthropic_api_key", "")
+    result = runner.invoke(app, ["adapters", "detect-model", "anthropic-payg"])
+    assert result.exit_code == 2
+    assert "no credential" in result.output.lower()
+
+
+def test_audit_seeds_config_shows_role_table(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["audit-seeds", "config"])
+    assert result.exit_code == 0, result.output
+    # All 7 enabled roles surface
+    for role in (
+        "generator",
+        "critic",
+        "proximity",
+        "pilot",
+        "ranker",
+        "evolver",
+        "meta_reviewer",
+    ):
+        assert role in result.output
+
+
+def test_audit_seeds_config_shows_judge_voters(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["audit-seeds", "config"])
+    assert "Judge panel voters" in result.output

--- a/tests/plugins/seed_generation/test_cli.py
+++ b/tests/plugins/seed_generation/test_cli.py
@@ -369,7 +369,7 @@ def test_audit_seeds_generate_uses_config_defaults() -> None:
     ):
         result = CliRunner().invoke(
             audit_seeds_app,
-            ["--target-dim", "broken_tool_use"],
+            ["generate", "--target-dim", "broken_tool_use"],
         )
     assert result.exit_code == 0, result.output
     assert captured["gen_tag"] == "gen7"
@@ -628,6 +628,7 @@ def test_audit_seeds_generate_cli_overrides_win_over_config() -> None:
         result = CliRunner().invoke(
             audit_seeds_app,
             [
+                "generate",
                 "--target-dim",
                 "broken_tool_use",
                 "--gen-tag",


### PR DESCRIPTION
## Summary

- ``geode adapters list`` — enumerate the 6 registered LLM adapters with ``billing_type`` + ``test_environment`` status.
- ``geode adapters detect-model <name>`` — adapter ``detect_credential()`` report.
- ``geode audit-seeds config`` — 7-role × (provider, model, source) matrix + judge panel voters.

## Why

Closing the visibility gap: operators need to see WHICH adapters are registered, WHICH credentials are configured, and HOW the picker bound each seed_generation role before scheduling a run. Without this surface, the only way to inspect the picker result was to read ``~/.geode/config.toml`` and trace the resolution manually.

Final follow-up of the v0.99.39 paperclip-style LLMAdapter abstraction. Parent chain:
- #1518 — Layer 4 + Layer 3 abstraction
- #1519 (A) — AgenticLoop adapter route + source threading
- #1520 (B) — seed agents pass SubTask.source
- #1521 (C) — S11 PipelineRegistry wire-up
- #THIS (D) — UI surface

## Changes

| File | Change |
|------|--------|
| `core/cli/cmd_adapters.py` | NEW — `adapters list` + `adapters detect-model` |
| `core/cli/__init__.py` | register `adapters_app` as `geode adapters` |
| `plugins/seed_generation/cli.py` | `audit-seeds config` subcommand |
| `tests/core/cli/test_cmd_adapters.py` | NEW — 6 tests pinning CLI exit codes + output shape |
| `CHANGELOG.md` | Added entry under [Unreleased] |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| `adapters list` | Implemented | enumerates registry + billing_type + test_environment |
| `adapters detect-model` | Implemented | calls adapter.detect_credential() |
| `audit-seeds config` | Implemented | matrix + voters |
| Dense plain-text UI (no box-card / no emoji) | Implemented | aligned table, monospace |
| REPL `/seed-model` slash | Deferred | follow-up — not blocking for v0.99.40 UX |

## Verification

- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean
- [x] lint-imports clean
- [x] 6 new CLI tests pass

## Reference

- Parent: #1521 (Follow-up C — S11 PipelineRegistry wire-up)
- Plan: `docs/plans/2026-05-23-llm-adapter-abstraction.md` § Scope cut
- Memory: `feedback_no_box_ui_no_emoji.md` — dense table UI rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)