### PR TITLE
release: v0.99.40 — develop → main (pass-through)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,30 @@ functional change.
 
 ### Added
 
+- **Follow-up A — AgenticLoop opt-in adapter route + source threading.**
+  ``SubTask.source`` + ``WorkerRequest.source`` carry the picker-resolved
+  adapter source (``payg`` / ``subscription`` / ``adapter``) through the
+  parent → worker subprocess boundary into the spawned
+  :class:`AgenticLoop`. When ``source`` is set AND ``provider="anthropic"``,
+  ``AgenticLoop._call_llm`` routes through
+  :func:`core.llm.adapters.resolve_for(provider, source)` →
+  :meth:`LLMAdapter.acomplete` instead of the legacy
+  ``resolve_agentic_adapter(provider)`` path. Translation lives in
+  ``core/llm/adapters/_legacy_bridge.py``
+  (``build_adapter_request`` / ``agentic_response_from_adapter_result``);
+  ``AdapterCallRequest`` gained ``tool_choice`` + ``provider_options``
+  fields to carry the loop-side knobs. Anthropic adapters translate the
+  ``tool_choice`` value (``"auto"`` / ``"any"`` / ``"none"`` / ``"required"`` /
+  dict) into Anthropic's ``{"type": ...}`` payload so the loop's wrap-up
+  ``{"type": "none"}`` actually suppresses tool calls on the new route.
+  Concrete source with a missing registry entry HARD-FAILS — silent
+  fallback would mask operator misconfiguration (Codex MCP 2026-05-23
+  HIGH 2). Non-Anthropic providers (``openai`` / ``openai-codex`` /
+  ``glm``) thread ``source`` for observability but stay on the legacy
+  adapter — full OpenAI / Codex multi-turn translation + Codex
+  encrypted-reasoning replay lands as **Follow-up A2**. Legacy callers
+  (empty ``source``) see no behaviour change.
+
 - **LLM adapter abstraction (paperclip pattern) — Layer 4 Protocol +
   Layer 3 built-ins.** New :class:`core.llm.adapters.LLMAdapter`
   Protocol (paperclip ``ServerAdapterModule`` mirror) + mutable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.40] - 2026-05-23
+
 ### Added
 
 - **Follow-up D — UI surface for the adapter registry.** Two new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,28 @@ functional change.
 
 ### Added
 
+- **Follow-up B — Picker bindings propagation to SubTask.source.** Each
+  seed-generation agent now passes ``source=self.adapter_source`` on
+  ``SubTask`` construction so the picker-resolved per-role source
+  reaches the spawned worker's ``AgenticLoop``. ``BaseSeedAgent`` gained
+  an ``adapter_source`` property + ``picker_source_to_adapter_source``
+  free function that translates the picker's historical source names
+  (``api_key`` / ``claude-cli`` / ``openai-codex`` / ``auto``) into the
+  paperclip-aligned adapter source values (``payg`` / ``subscription`` /
+  ``adapter``) consumed by :func:`core.llm.adapters.resolve_for`. The
+  Ranker agent uses ``picker_source_to_adapter_source(voter.source)``
+  per voter so each judge follows its own binding. ``Pipeline`` gained
+  a ``bindings: dict[str, Any]`` kwarg (default ``{}``) that
+  ``cli._dispatch_pipeline`` populates from ``picker_result.bindings``
+  — stored for observability / journaling but NOT re-injected at
+  ``SubTask`` time (agents already carry the binding values).
+
+  Closes the Codex MCP 2026-05-23 BLOCKER 1 finding ("the main
+  seed-generation path appears unwired") from PR #1519: source now
+  reaches the worker for every role's ``SubTask`` creation site
+  (generator / critic / pilot / ranker / evolver / meta_reviewer /
+  supervisor / proximity).
+
 - **Follow-up A — AgenticLoop opt-in adapter route + source threading.**
   ``SubTask.source`` + ``WorkerRequest.source`` carry the picker-resolved
   adapter source (``payg`` / ``subscription`` / ``adapter``) through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ functional change.
 
 ### Added
 
+- **Follow-up C — S11 PipelineRegistry wire-up.** ``cli._dispatch_pipeline``
+  now populates the ``PipelineRegistry`` with one concrete agent per
+  ``manifest.enabled_roles`` (generator / critic / proximity / pilot /
+  ranker / evolver / meta_reviewer) via the new
+  ``plugins/seed_generation/_registry_builder.py`` helper. Each agent
+  is instantiated with the picker binding's ``model`` + ``source``;
+  Ranker additionally receives ``picker_result.voters`` so each judge
+  follows its own binding. The pre-S11 placeholder
+  (``registry = PipelineRegistry()`` with a runtime "no registered
+  agent" error) is replaced — the production ``geode seeds run`` flow
+  can now actually invoke the pipeline end-to-end. The shared
+  ``SubAgentManager`` is built once via ``build_subagent_manager()``
+  with best-effort AgentRegistry + tool handlers + ``IsolatedRunner``;
+  observability hooks remain unattached (gateway runtime path is
+  Follow-up D).
+
 - **Follow-up B — Picker bindings propagation to SubTask.source.** Each
   seed-generation agent now passes ``source=self.adapter_source`` on
   ``SubTask`` construction so the picker-resolved per-role source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ functional change.
 
 ### Added
 
+- **Follow-up D — UI surface for the adapter registry.** Two new
+  read-only Typer subcommands:
+
+  - ``geode adapters list`` enumerates the 6 registered adapters with
+    ``billing_type`` and per-adapter ``test_environment`` status.
+  - ``geode adapters detect-model <name>`` reports the currently
+    configured model + provenance via the adapter's
+    ``detect_credential()`` hook.
+  - ``geode audit-seeds config`` shows the 7-role × (provider, model,
+    source) binding matrix resolved by the picker, plus the judge
+    panel voters.
+
+  UI follows the ``feedback_no_box_ui_no_emoji`` rule: dense aligned
+  table, plain text headers, no box-card / emoji decoration.
+
 - **Follow-up C — S11 PipelineRegistry wire-up.** ``cli._dispatch_pipeline``
   now populates the ``PipelineRegistry`` with one concrete agent per
   ``manifest.enabled_roles`` (generator / critic / proximity / pilot /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.38
+- **Version**: 0.99.40
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.38 — Long-running Autonomous Execution Harness
+# GEODE v0.99.40 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.38**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.40**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.38 — Long-running Autonomous Execution Harness
+# GEODE v0.99.40 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.38**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.40**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -90,6 +90,7 @@ class AgenticLoop:
         quiet: bool = False,
         disable_settings_drift: bool = False,
         allowed_tool_names: set[str] | None = None,
+        source: str = "",
     ) -> None:
         self.context = context
         self.executor = tool_executor
@@ -146,6 +147,39 @@ class AgenticLoop:
         if allowed_tool_names is not None:
             self._tools = [t for t in self._tools if t.get("name") in allowed_tool_names]
         self._last_llm_error: str | None = None  # last error type for user message
+        # v0.99.40 Follow-up A — opt-in adapter route via the v0.99.39
+        # :class:`LLMAdapter` registry. Scope limited to ``provider="anthropic"``
+        # in this PR: the OpenAI / Codex adapter route needs full multi-turn
+        # message translation (Anthropic tool_use → ``tool_calls`` /
+        # ``function_call`` etc.) + Codex encrypted-reasoning replay, both
+        # tracked as Follow-up A2 (``docs/plans/2026-05-23-llm-adapter-
+        # abstraction.md`` § Scope cut). Concrete source values still thread
+        # through SubTask/WorkerRequest for observability on every provider,
+        # but the actual LLM call stays on the legacy adapter when the
+        # bridge is not yet wired for that provider.
+        #
+        # When ``source`` is concrete (one of CONCRETE_SOURCES) AND the
+        # provider is supported, ``_call_llm`` routes through
+        # ``LLMAdapter.acomplete``. A concrete source with a missing
+        # adapter HARD-FAILS in :func:`resolve_for` — silent fallback would
+        # mask operator misconfiguration (Codex MCP 2026-05-23 HIGH 2).
+        self._source = source
+        self._new_adapter: Any | None = None
+        if source:
+            from core.llm.adapters import CONCRETE_SOURCES, resolve_for
+
+            if source in CONCRETE_SOURCES:
+                if self._provider == "anthropic":
+                    # Hard-fail on resolve mismatch — concrete source MUST resolve.
+                    self._new_adapter = resolve_for(self._provider, source)
+                else:
+                    log.info(
+                        "AgenticLoop: source=%s threaded through but provider=%s "
+                        "stays on legacy adapter — A2 follow-up adds OpenAI/Codex "
+                        "multi-turn translation + reasoning replay.",
+                        source,
+                        self._provider,
+                    )
         self._adapter = resolve_agentic_adapter(self._provider)
         self._op_logger = OperationLogger(quiet=self._quiet)
         self._error_recovery = ErrorRecoveryStrategy(tool_executor)
@@ -1502,23 +1536,57 @@ class AgenticLoop:
             adaptive_thinking = 0
             adaptive_effort = "low"
 
-        response = await self._adapter.agentic_call(
-            model=self.model,
-            system=system,
-            messages=messages,
-            tools=self._tools,
-            tool_choice=tool_choice,
-            max_tokens=adaptive_max_tokens,
-            temperature=0.0,
-            thinking_budget=adaptive_thinking,
-            effort=adaptive_effort,
-        )
+        if self._new_adapter is not None:
+            # v0.99.40 Follow-up A — opt-in adapter route. Build adapter-neutral
+            # request, call ``LLMAdapter.acomplete``, translate result back to
+            # ``AgenticResponse`` so the rest of the loop (tool dispatch, cost
+            # tracking, retry budget) is unchanged.
+            from core.llm.adapters._legacy_bridge import (
+                agentic_response_from_adapter_result,
+                build_adapter_request,
+            )
+
+            req = build_adapter_request(
+                model=self.model,
+                system=system,
+                messages=messages,
+                tools=self._tools,
+                tool_choice=tool_choice,
+                max_tokens=adaptive_max_tokens,
+                temperature=0.0,
+                thinking_budget=adaptive_thinking,
+                effort=adaptive_effort,
+            )
+            try:
+                result = await self._new_adapter.acomplete(req)
+            except Exception as exc:
+                self._last_llm_error = str(exc)
+                log.warning(
+                    "AgenticLoop: adapter.acomplete failed (adapter=%s): %s",
+                    getattr(self._new_adapter, "name", "<unknown>"),
+                    exc,
+                )
+                response = None
+            else:
+                response = agentic_response_from_adapter_result(result)
+        else:
+            response = await self._adapter.agentic_call(
+                model=self.model,
+                system=system,
+                messages=messages,
+                tools=self._tools,
+                tool_choice=tool_choice,
+                max_tokens=adaptive_max_tokens,
+                temperature=0.0,
+                thinking_budget=adaptive_thinking,
+                effort=adaptive_effort,
+            )
 
         if response is None:
             adapter_err = getattr(self._adapter, "last_error", None)
             if adapter_err:
                 self._last_llm_error = str(adapter_err)
-            else:
+            elif not self._last_llm_error:
                 self._last_llm_error = f"All {self._provider} models exhausted"
 
         # v0.57.0 R6 — surface reasoning summaries to AgenticUI. Per-item

--- a/core/agent/sub_agent.py
+++ b/core/agent/sub_agent.py
@@ -117,13 +117,24 @@ SUBAGENT_DENIED_TOOLS: set[str] = {
 
 @dataclass
 class SubTask:
-    """A task to delegate to a sub-agent."""
+    """A task to delegate to a sub-agent.
+
+    ``source`` (v0.99.40 Follow-up A): one of
+    :data:`core.llm.adapters.CONCRETE_SOURCES` (``"payg"`` / ``"subscription"`` /
+    ``"adapter"``) or empty for legacy routing. When set, the spawned worker's
+    :class:`AgenticLoop` uses :func:`core.llm.adapters.resolve_for` to pick
+    the concrete :class:`LLMAdapter` instead of the legacy provider-only
+    ``resolve_agentic_adapter``. The picker (``plugins/seed_generation/
+    picker.py``) translates its ``RoleBinding.source`` into one of the
+    concrete values via :func:`binding_to_adapter_source`.
+    """
 
     task_id: str
     description: str
     task_type: str  # "analyze", "search", "compare"
     args: dict[str, Any] = field(default_factory=dict)
     agent: str | None = None  # Explicit agent override
+    source: str = ""  # adapter source; empty = legacy routing
 
 
 @dataclass
@@ -568,6 +579,7 @@ class SubAgentManager:
             toolkit=agent_toolkit,
             parent_session_key=self._parent_session_key,
             parent_session_id=parent_uuid,
+            source=task.source,
         )
 
     def _resolve_agent(self, task: SubTask) -> dict[str, Any] | None:

--- a/core/agent/worker.py
+++ b/core/agent/worker.py
@@ -75,6 +75,12 @@ class WorkerRequest:
     # cross-session attribution. Empty strings = top-level spawn.
     parent_session_key: str = ""
     parent_session_id: str = ""
+    # v0.99.40 Follow-up A — adapter source for the new
+    # :class:`core.llm.adapters.LLMAdapter` registry. Concrete value
+    # (``"payg"`` / ``"subscription"`` / ``"adapter"``) when the parent's
+    # picker / orchestrator resolved a specific path; empty string falls
+    # back to legacy ``resolve_agentic_adapter(provider)`` routing.
+    source: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -106,6 +112,7 @@ class WorkerRequest:
             toolkit=data.get("toolkit", ""),
             parent_session_key=data.get("parent_session_key", ""),
             parent_session_id=data.get("parent_session_id", ""),
+            source=data.get("source", ""),
         )
 
 
@@ -312,6 +319,7 @@ def _run_agentic(request: WorkerRequest) -> WorkerResult:
         parent_session_id=request.parent_session_id,
         quiet=True,  # Suppress spinner — parent handles UI
         allowed_tool_names=allowed_tool_names,
+        source=request.source,
     )
 
     # 7. Build prompt

--- a/core/cli/__init__.py
+++ b/core/cli/__init__.py
@@ -310,9 +310,11 @@ app = typer.Typer(
 )
 
 # Subcommand groups
+from core.cli.cmd_adapters import app as adapters_app  # noqa: E402
 from core.cli.cmd_config import app as config_app  # noqa: E402
 from core.cli.cmd_skill import app as skill_app  # noqa: E402
 
+app.add_typer(adapters_app, name="adapters")
 app.add_typer(skill_app, name="skill")
 app.add_typer(config_app, name="config")
 

--- a/core/cli/cmd_adapters.py
+++ b/core/cli/cmd_adapters.py
@@ -1,0 +1,82 @@
+"""CLI subcommand: ``geode adapters`` — inspect registered LLM adapters.
+
+v0.99.40 Follow-up D of the paperclip-style LLMAdapter abstraction
+(``docs/plans/2026-05-23-llm-adapter-abstraction.md``). Surface the
+:class:`core.llm.adapters.LLMAdapter` registry so operators can see what
+PAYG / Subscription / Adapter paths are available + verify each path's
+environment before scheduling a seed-generation run.
+
+Two read-only subcommands:
+
+- ``geode adapters list`` — enumerate registered adapters with
+  ``billing_type``, ``test_environment`` summary, and supported model
+  count.
+- ``geode adapters detect-model <adapter>`` — paperclip ``detectModel``
+  equivalent; reports the currently configured model + provenance from
+  the adapter's ``detect_credential()`` hook.
+
+UI: dense aligned table, plain text. No box-card / no emoji (per
+``feedback_no_box_ui_no_emoji`` memory).
+"""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(
+    name="adapters",
+    help="Inspect registered LLM adapters (PAYG / Subscription / Adapter paths).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@app.command("list")
+def adapters_list() -> None:
+    """List all registered adapters with billing_type + environment status."""
+    from core.llm.adapters import bootstrap_builtins, list_adapters
+
+    bootstrap_builtins()
+    adapters = list_adapters()
+    if not adapters:
+        typer.echo("No LLM adapters registered.")
+        raise typer.Exit()
+
+    header = f"{'NAME':<20} {'PROVIDER':<10} {'SOURCE':<14} {'BILLING':<22} STATUS"
+    typer.echo(header)
+    typer.echo("-" * len(header))
+    for a in adapters:
+        report = a.test_environment()
+        status = "ok" if report.ok else "missing — " + (report.hints[0] if report.hints else "")
+        typer.echo(
+            f"{a.name:<20} {a.provider:<10} {a.source:<14} {a.billing_type.value:<22} {status}"
+        )
+    typer.echo(f"\n{len(adapters)} adapter(s) registered.")
+    typer.echo(
+        'Override per role via ~/.geode/config.toml [seed_generation.role.<role>] source = "..."'
+    )
+
+
+@app.command("detect-model")
+def adapters_detect_model(name: str) -> None:
+    """Report the currently configured model + provenance for ``name``."""
+    from core.llm.adapters import AdapterNotFoundError, bootstrap_builtins, get_adapter
+
+    bootstrap_builtins()
+    try:
+        adapter = get_adapter(name)
+    except AdapterNotFoundError as exc:
+        typer.echo(f"adapter {name!r} not registered: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    detection = adapter.detect_credential()
+    if detection is None:
+        typer.echo(f"{name}: no credential detected — run ``geode adapters list`` for hints.")
+        raise typer.Exit(code=2)
+    typer.echo(f"{name}: model={detection.model} provider={detection.provider}")
+    typer.echo(f"  source: {detection.source_path}")
+    if detection.candidates:
+        typer.echo(f"  candidates: {', '.join(detection.candidates)}")
+
+
+__all__ = ["app"]

--- a/core/llm/adapters/_anthropic_common.py
+++ b/core/llm/adapters/_anthropic_common.py
@@ -104,11 +104,31 @@ def build_create_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
         kwargs["temperature"] = req.temperature
     if req.tools:
         kwargs["tools"] = [translate_tool(t) for t in req.tools]
+        tc = _translate_tool_choice(req.tool_choice)
+        if tc is not None:
+            kwargs["tool_choice"] = tc
     if req.stop_sequences:
         kwargs["stop_sequences"] = list(req.stop_sequences)
     if req.thinking_budget > 0:
         kwargs["thinking"] = {"type": "enabled", "budget_tokens": req.thinking_budget}
     return kwargs
+
+
+def _translate_tool_choice(tc: str | dict[str, Any]) -> dict[str, Any] | None:
+    """Adapter-neutral ``tool_choice`` → Anthropic ``tool_choice`` payload.
+
+    Anthropic accepts ``{"type": "auto" | "any" | "none" | "tool", "name": ...}``.
+    The loop emits ``{"type": "none"}`` during wrap-up to forbid tool calls;
+    without explicit translation the SDK silently allows tool use and the
+    wrap-up safety net is defeated (Codex MCP 2026-05-23 MEDIUM 1).
+    """
+    if isinstance(tc, dict):
+        return tc
+    if tc in ("auto", "any", "none"):
+        return {"type": tc}
+    if tc == "required":
+        return {"type": "any"}
+    return None  # unknown literal — let Anthropic default apply
 
 
 def build_stream_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
@@ -127,6 +147,9 @@ def build_stream_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
         kwargs["temperature"] = req.temperature
     if req.tools:
         kwargs["tools"] = [translate_tool(t) for t in req.tools]
+        tc = _translate_tool_choice(req.tool_choice)
+        if tc is not None:
+            kwargs["tool_choice"] = tc
     return kwargs
 
 

--- a/core/llm/adapters/_legacy_bridge.py
+++ b/core/llm/adapters/_legacy_bridge.py
@@ -1,0 +1,147 @@
+"""Translation between the new :class:`LLMAdapter` Protocol and the legacy
+``AgenticResponse`` shape consumed by :class:`AgenticLoop`.
+
+Used by ``AgenticLoop._call_llm`` when an explicit ``source`` is set: the loop
+builds an :class:`AdapterCallRequest`, calls ``adapter.acomplete``, and feeds
+the result back through :func:`agentic_response_from_adapter_result` so the
+downstream tool-use / cost / observability pipeline keeps the same data
+shape.
+
+This bridge is intentionally minimal — it does NOT replicate the full
+``AgenticLLMPort.agentic_call`` (retry, failover, streaming) surface. Those
+behaviours stay in the legacy adapter for callers that don't set ``source``.
+The new path is an opt-in alternative; once every in-tree caller has migrated
+(v1.0.0), the bridge + legacy path are removed together.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.llm.adapters.base import (
+    AdapterCallRequest,
+    AdapterCallResult,
+    Message,
+    ToolSpec,
+)
+from core.llm.agentic_response import (
+    AgenticResponse,
+    ResponseUsage,
+    TextBlock,
+    ToolUseBlock,
+)
+
+
+def build_adapter_request(
+    *,
+    model: str,
+    system: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    tool_choice: dict[str, str] | str,
+    max_tokens: int,
+    temperature: float,
+    thinking_budget: int,
+    effort: str,
+) -> AdapterCallRequest:
+    """Translate AgenticLoop's call-site args → :class:`AdapterCallRequest`.
+
+    ``messages`` arrive in Anthropic shape (``[{"role": ..., "content": ...}, ...]``).
+    We map ``role="tool"`` entries (added during multi-turn tool-use) into the
+    adapter-neutral :class:`Message(tool_use_id=...)` form; adapter
+    implementations re-encode for their provider.
+
+    ``tools`` arrive in Anthropic shape (``[{"name": ..., "description": ...,
+    "input_schema": ...}]``) and translate directly to :class:`ToolSpec`.
+    """
+    adapter_messages: list[Message] = []
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+        tool_use_id = m.get("tool_use_id")
+        adapter_messages.append(Message(role=role, content=content, tool_use_id=tool_use_id))
+    adapter_tools: list[ToolSpec] = [
+        ToolSpec(
+            name=t.get("name", ""),
+            description=t.get("description", ""),
+            input_schema=t.get("input_schema", {}),
+        )
+        for t in tools
+    ]
+    return AdapterCallRequest(
+        model=model,
+        messages=adapter_messages,
+        system_prompt=system,
+        tools=adapter_tools,
+        tool_choice=tool_choice,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        thinking_budget=thinking_budget,
+        effort=effort,
+    )
+
+
+def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticResponse:
+    """Translate :class:`AdapterCallResult` → legacy :class:`AgenticResponse`.
+
+    The new adapter call returns a flat ``(text, usage, stop_reason,
+    tool_uses, raw_response)`` envelope; the legacy ``AgenticResponse`` is a
+    list of typed content blocks plus normalised usage. We rebuild the
+    content list — text block first (when non-empty), then one
+    :class:`ToolUseBlock` per tool_use entry — so ``ToolCallProcessor`` and
+    the rest of the loop see the same shape they did under the legacy
+    adapter.
+    """
+    blocks: list[TextBlock | ToolUseBlock] = []
+    if result.text:
+        blocks.append(TextBlock(type="text", text=result.text))
+    for tu in result.tool_uses:
+        input_field = tu.get("input", {})
+        if isinstance(input_field, str):
+            # Adapters that surface ``arguments`` as a JSON string (OpenAI)
+            # — parse to dict so the executor's signature stays uniform.
+            try:
+                input_field = json.loads(input_field) if input_field else {}
+            except json.JSONDecodeError:
+                input_field = {"_raw": input_field}
+        blocks.append(
+            ToolUseBlock(
+                id=str(tu.get("id", "")),
+                type="tool_use",
+                name=str(tu.get("name", "")),
+                input=input_field if isinstance(input_field, dict) else {},
+            )
+        )
+    usage = ResponseUsage(
+        input_tokens=result.usage.input_tokens,
+        output_tokens=result.usage.output_tokens,
+        cache_read_tokens=result.usage.cached_input_tokens,
+    )
+    return AgenticResponse(
+        content=blocks,
+        stop_reason=_translate_stop_reason(result.stop_reason),
+        usage=usage,
+    )
+
+
+def _translate_stop_reason(stop: str) -> str:
+    """Map provider-flavoured stop reasons → AgenticLoop's two-value enum.
+
+    Legacy ``AgenticResponse.stop_reason`` is one of ``"tool_use"`` /
+    ``"end_turn"``. Provider strings map as follows:
+
+    - Anthropic ``"tool_use"`` → ``"tool_use"``
+    - OpenAI ``"tool_calls"`` → ``"tool_use"``
+    - Codex ``"completed"`` / Anthropic ``"end_turn"`` / OpenAI ``"stop"`` /
+      anything else → ``"end_turn"``
+    """
+    if stop in ("tool_use", "tool_calls"):
+        return "tool_use"
+    return "end_turn"
+
+
+__all__ = [
+    "agentic_response_from_adapter_result",
+    "build_adapter_request",
+]

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -81,18 +81,32 @@ class Message:
 
 @dataclass(frozen=True)
 class AdapterCallRequest:
-    """Request envelope handed to ``LLMAdapter.acomplete`` / ``astream``."""
+    """Request envelope handed to ``LLMAdapter.acomplete`` / ``astream``.
+
+    ``tool_choice`` mirrors the Anthropic ``messages.create`` parameter shape
+    (``{"type": "auto" | "any" | "none" | "tool"}`` or the strings
+    ``"auto"`` / ``"any"`` / ``"none"`` / ``"required"``). Adapters translate
+    to provider-specific syntax in their request builders. Default ``"auto"``
+    lets the model pick whether to call a tool.
+
+    ``provider_options`` is a pass-through dict that adapters may consult for
+    provider-specific knobs without bloating the top-level schema (e.g.
+    Anthropic ``priority_tier``, Codex ``parallel_tool_calls``, OpenAI
+    ``response_format``). Each adapter ignores keys it doesn't recognise.
+    """
 
     model: str
     messages: Sequence[Message]
     system_prompt: str = ""
     tools: Sequence[ToolSpec] = field(default_factory=tuple)
+    tool_choice: str | dict[str, Any] = "auto"
     max_tokens: int = 8192
     temperature: float | None = None
     thinking_budget: int = 0
     effort: str = "medium"
     stop_sequences: tuple[str, ...] = ()
     metadata: dict[str, Any] = field(default_factory=dict)
+    provider_options: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/plugins/seed_generation/_registry_builder.py
+++ b/plugins/seed_generation/_registry_builder.py
@@ -1,0 +1,243 @@
+"""S11 registry wire-up — build a populated :class:`PipelineRegistry`.
+
+Follow-up C of the v0.99.39 LLM adapter abstraction. Replaces the empty
+``PipelineRegistry()`` previously emitted at ``cli._dispatch_pipeline``
+with a real, picker-driven population: each enabled role's concrete agent
+class is instantiated with the binding's ``model`` + ``source`` and the
+shared :class:`SubAgentManager`. The Ranker additionally consumes
+``picker_result.voters``.
+
+Pre-this PR the production CLI flow at ``cli.py:436`` was
+``registry = PipelineRegistry()`` with a NOTE that ``Pipeline.arun`` would
+raise a RuntimeError on the first un-registered role — by design (Session
+63 S11 placeholder) so the orchestrator path was reachable for gate
+testing but no actual LLM ran. This module closes that gap.
+
+Why the agent classes are picked at registry-build time (not auto-discovery):
+the seed_generation roles are a fixed set defined by the manifest's
+``enabled_roles``. A discovery-based loader (entry-points, file scan)
+would over-engineer the contract — and breaks ``geode audit-seeds --help``
+smoke speed because every agent module would import at CLI start.
+The explicit map keeps the production path import-free until the user
+actually invokes ``generate``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from plugins.seed_generation.agents.base import BaseSeedAgent
+    from plugins.seed_generation.manifest import SeedGenerationManifest
+    from plugins.seed_generation.orchestrator import PipelineRegistry
+    from plugins.seed_generation.picker import PickerResult
+
+log = logging.getLogger(__name__)
+
+
+def build_subagent_manager() -> Any:
+    """Construct the production :class:`SubAgentManager` for seed_generation.
+
+    Mirrors the wiring in
+    :meth:`core.server.supervised.services._build_sub_agent_manager` but
+    standalone — the seed_generation CLI runs outside the gateway, so we
+    rebuild the dependency stack inline rather than reach into the
+    Supervisor's instance. The shape matches: ``IsolatedRunner`` + hooks +
+    tool handlers + MCP / skill registries + agent registry.
+
+    Falls back to the minimum viable manager when individual dependencies
+    are unavailable (tests, ad-hoc CLI use) — observability hooks may be
+    None; the agent's ``adelegate`` path still functions.
+    """
+    from core.agent.sub_agent import SubAgentManager
+    from core.config import settings
+    from core.orchestration.isolated_execution import IsolatedRunner
+
+    # Best-effort dependency resolution — none of these are strictly required
+    # for the SubAgentManager to dispatch a subprocess worker, but the worker
+    # subprocess inherits credentials + skill resolution from the parent so
+    # we pass everything we can find.
+    hooks = None
+    lane = None
+    tool_handlers: dict[str, Any] = {}
+    mcp_manager = None
+    skill_registry = None
+    agent_registry = _try_build_agent_registry()
+    # ``get_lane_queue`` is not a public surface in this worktree's wiring;
+    # the SubAgentManager constructs its own IsolatedRunner with the bare
+    # ``hooks=None / lane=None`` path which the runner tolerates (slot wait
+    # falls back to a default semaphore). The follow-up D PR can plumb the
+    # gateway lane through ``runtime.GeodeRuntime`` when the seed-generation
+    # CLI runs under the supervisor.
+    try:
+        from core.cli.tool_handlers import _build_tool_handlers
+
+        tool_handlers = _build_tool_handlers(verbose=False)
+    except Exception:
+        log.debug("seed-generation: tool handler build failed", exc_info=True)
+
+    return SubAgentManager(
+        IsolatedRunner(hooks=hooks, lane=lane),
+        action_handlers=tool_handlers,
+        mcp_manager=mcp_manager,
+        skill_registry=skill_registry,
+        agent_registry=agent_registry,
+        hooks=hooks,
+        max_depth=settings.max_subagent_depth,
+    )
+
+
+def _try_build_agent_registry() -> Any:
+    """Best-effort AgentRegistry — needed so SubTask.agent resolves to the
+    AgentDefinition's system_prompt + tools + model overrides.
+
+    Mirrors ``core.server.supervised.services._build_agent_registry`` but
+    in a function-local form so the seed-generation CLI does not depend
+    on the gateway service singleton. Loads ``AgentRegistry`` defaults +
+    ``.claude/agents/`` + each ``plugins/*/agents/`` directory.
+    Returns ``None`` on any failure (the worker then runs with GEODE's
+    generic default prompt, which is the pre-S11 fallback).
+    """
+    try:
+        from pathlib import Path
+
+        from core.paths import get_project_root
+        from core.skills.agents import AgentRegistry, SubagentLoader
+    except Exception:
+        log.debug("seed-generation: AgentRegistry imports unavailable", exc_info=True)
+        return None
+    try:
+        registry = AgentRegistry()
+        registry.load_defaults()
+        project_root = get_project_root()
+        search_dirs: list[Path] = [project_root / ".claude" / "agents"]
+        plugins_root = project_root / "plugins"
+        if plugins_root.exists():
+            for plugin_agents in sorted(plugins_root.glob("*/agents")):
+                if plugin_agents.is_dir():
+                    search_dirs.append(plugin_agents)
+        loader = SubagentLoader(agents_dirs=search_dirs)
+        for path in loader.discover():
+            try:
+                definition = loader.load_file(path)
+            except Exception:
+                log.debug("seed-generation: agent file load skipped: %s", path, exc_info=True)
+                continue
+            try:
+                registry.register(definition)
+            except ValueError:
+                # default-name conflict — leave the default in place.
+                log.debug(
+                    "seed-generation: agent %r conflicts with default, skipped",
+                    definition.name,
+                )
+                continue
+        return registry
+    except Exception:
+        log.debug("seed-generation: agent registry build failed", exc_info=True)
+        return None
+
+
+def populate_registry(
+    registry: PipelineRegistry,
+    *,
+    picker_result: PickerResult,
+    manifest: SeedGenerationManifest,
+    manager: Any | None = None,
+) -> PipelineRegistry:
+    """Populate ``registry`` with one concrete agent per enabled role.
+
+    Each agent is constructed with ``model + source`` taken from the
+    picker's per-role binding so the SubTask the agent later emits
+    inherits the binding's auth path.
+
+    Mutates ``registry`` in place and also returns it for fluent use.
+    """
+    manager = manager if manager is not None else build_subagent_manager()
+
+    from plugins.seed_generation.agents.critic import Critic
+    from plugins.seed_generation.agents.evolver import Evolver
+    from plugins.seed_generation.agents.generator import Generator
+    from plugins.seed_generation.agents.meta_reviewer import MetaReviewer
+    from plugins.seed_generation.agents.pilot import Pilot
+    from plugins.seed_generation.agents.proximity import Proximity
+    from plugins.seed_generation.agents.ranker import Ranker
+
+    _ROLE_TO_CLASS: dict[str, type[BaseSeedAgent]] = {
+        "generator": Generator,
+        "critic": Critic,
+        "proximity": Proximity,
+        "pilot": Pilot,
+        "evolver": Evolver,
+        "meta_reviewer": MetaReviewer,
+    }
+
+    for role_name in manifest.enabled_roles:
+        if registry.has(role_name):
+            log.debug("seed-generation registry: %s already populated, skipping", role_name)
+            continue
+        binding = picker_result.bindings.get(role_name)
+        manifest_role = manifest.roles.get(role_name)
+        manifest_role_dict: dict[str, object] = {}
+        if manifest_role is not None:
+            # Only known fields — extra attributes (e.g. literature_review's
+            # max_papers added in PR #1517) propagate when present.
+            for field_name in ("default_model", "max_papers", "queries_per_run"):
+                if hasattr(manifest_role, field_name):
+                    manifest_role_dict[field_name] = getattr(manifest_role, field_name)
+
+        if role_name == "ranker":
+            agent: BaseSeedAgent = Ranker(
+                manager,
+                list(picker_result.voters),
+                model=binding.model if binding else _DEFAULT_FALLBACK_MODEL,
+                source=binding.source if binding else "auto",
+                manifest_role=manifest_role_dict,
+            )
+        else:
+            cls = _ROLE_TO_CLASS.get(role_name)
+            if cls is None:
+                log.warning("seed-generation registry: no agent class for role %r", role_name)
+                continue
+            # Each role agent declares its own ctor (variadic across
+            # roles) but they all accept ``(manager, *, model, source,
+            # manifest_role)``. mypy can't infer that from
+            # ``type[BaseSeedAgent]``; suppress the structural complaint.
+            agent = cls(  # type: ignore[misc]
+                manager,
+                model=binding.model if binding else _DEFAULT_FALLBACK_MODEL,
+                source=binding.source if binding else "auto",
+                manifest_role=manifest_role_dict,
+            )
+        registry.register(agent)
+
+    # Supervisor + MetaReviewer are not in ``enabled_roles`` for some
+    # manifest revisions; the orchestrator references them optionally
+    # (the phase short-circuits when the role is missing). Register
+    # supervisor if a binding exists.
+    if "supervisor" not in registry.list_roles():
+        sup_binding = picker_result.bindings.get("supervisor")
+        if sup_binding is not None:
+            from plugins.seed_generation.agents.supervisor import Supervisor
+
+            registry.register(
+                Supervisor(
+                    manager,
+                    model=sup_binding.model,
+                    source=sup_binding.source,
+                )
+            )
+
+    return registry
+
+
+# Fallback model when the picker did not produce a binding for an enabled
+# role — happens if the manifest declares a role the picker doesn't have a
+# binding for (mismatch between picker.bindings and manifest.enabled_roles).
+# We log+continue rather than crashing so the operator gets a clear
+# "no registered agent" error at phase time pointing at the missing role.
+_DEFAULT_FALLBACK_MODEL = "claude-sonnet-4-6"
+
+
+__all__ = ["build_subagent_manager", "populate_registry"]

--- a/plugins/seed_generation/agents/base.py
+++ b/plugins/seed_generation/agents/base.py
@@ -178,6 +178,23 @@ class BaseSeedAgent(abc.ABC):
         self.source = source
         self.manifest_role = manifest_role or {}
 
+    @property
+    def adapter_source(self) -> str:
+        """Picker-source → adapter-source translation for ``SubTask.source``.
+
+        v0.99.40 Follow-up B: the picker emits historical source names
+        (``api_key`` / ``claude-cli`` / ``openai-codex`` / ``auto``). The
+        v0.99.39 :class:`LLMAdapter` registry uses the paperclip-aligned
+        names (``payg`` / ``subscription`` / ``adapter``). This property
+        bridges the two so each agent's ``SubTask(source=...)`` call
+        produces a value the spawned worker's ``AgenticLoop`` can pass
+        directly into :func:`core.llm.adapters.resolve_for`.
+
+        Returns the empty string for ``"auto"`` so unresolved picker output
+        falls back to legacy routing rather than hard-failing.
+        """
+        return picker_source_to_adapter_source(self.source)
+
     @abc.abstractmethod
     async def aexecute(self, state: Any) -> SeedAgentResult:
         """Run one phase of the pipeline against ``state`` (async).
@@ -194,3 +211,20 @@ class BaseSeedAgent(abc.ABC):
             f"{type(self).__name__}(role={self.role!r}, "
             f"model={self.model!r}, source={self.source!r})"
         )
+
+
+def picker_source_to_adapter_source(picker_source: str) -> str:
+    """Free-function variant of :attr:`BaseSeedAgent.adapter_source`.
+
+    Used by agents that build per-voter ``SubTask`` instances (e.g.
+    :class:`RankerAgent`) where each voter carries its own picker source
+    name and the role-level ``self.source`` is not the right input.
+    """
+    if not picker_source or picker_source == "auto":
+        return ""
+    from plugins.seed_generation.picker import binding_to_adapter_source
+
+    try:
+        return binding_to_adapter_source(picker_source)
+    except ValueError:
+        return ""

--- a/plugins/seed_generation/agents/critic.py
+++ b/plugins/seed_generation/agents/critic.py
@@ -205,6 +205,7 @@ class Critic(BaseSeedAgent):
                         "target_dim": target_dim,
                     },
                     agent=_CRITIC_AGENT_NAME,
+                    source=self.adapter_source,
                 )
             )
         return tasks

--- a/plugins/seed_generation/agents/evolver.py
+++ b/plugins/seed_generation/agents/evolver.py
@@ -265,6 +265,7 @@ class Evolver(BaseSeedAgent):
                         "gen_tag": state.gen_tag,
                     },
                     agent=_EVOLVER_AGENT_NAME,
+                    source=self.adapter_source,
                 )
             )
         return tasks

--- a/plugins/seed_generation/agents/generator.py
+++ b/plugins/seed_generation/agents/generator.py
@@ -255,6 +255,7 @@ class Generator(BaseSeedAgent):
                         "pool_path_in": pool_path,
                     },
                     agent=_GENERATOR_AGENT_NAME,
+                    source=self.adapter_source,
                 )
             )
         return tasks

--- a/plugins/seed_generation/agents/meta_reviewer.py
+++ b/plugins/seed_generation/agents/meta_reviewer.py
@@ -166,6 +166,7 @@ class MetaReviewer(BaseSeedAgent):
                 "snapshot": snapshot,
             },
             agent=_META_REVIEWER_AGENT_NAME,
+            source=self.adapter_source,
         )
 
     def _build_description(

--- a/plugins/seed_generation/agents/pilot.py
+++ b/plugins/seed_generation/agents/pilot.py
@@ -198,6 +198,7 @@ class Pilot(BaseSeedAgent):
                         "target_dim": target_dim,
                     },
                     agent=_PILOT_AGENT_NAME,
+                    source=self.adapter_source,
                 )
             )
         return tasks

--- a/plugins/seed_generation/agents/proximity.py
+++ b/plugins/seed_generation/agents/proximity.py
@@ -193,6 +193,7 @@ class Proximity(BaseSeedAgent):
                 "candidate_count": len(state.candidates),
             },
             agent=_PROXIMITY_AGENT_NAME,
+            source=self.adapter_source,
         )
 
     def _build_description(self, state: PipelineState, candidate_summary: str) -> str:

--- a/plugins/seed_generation/agents/ranker.py
+++ b/plugins/seed_generation/agents/ranker.py
@@ -257,6 +257,8 @@ class Ranker(BaseSeedAgent):
         means_a = pilot_means.get(match.a, {})
         means_b = pilot_means.get(match.b, {})
         tasks: list[SubTask] = []
+        from plugins.seed_generation.agents.base import picker_source_to_adapter_source
+
         for voter in self._voters:
             voter_id = f"{voter.provider}.{voter.source}"
             tasks.append(
@@ -280,6 +282,7 @@ class Ranker(BaseSeedAgent):
                         "voter_source": voter.source,
                     },
                     agent=f"seed_ranker_voter_{voter.provider}",
+                    source=picker_source_to_adapter_source(voter.source),
                 )
             )
         return tasks

--- a/plugins/seed_generation/agents/supervisor.py
+++ b/plugins/seed_generation/agents/supervisor.py
@@ -179,6 +179,7 @@ class Supervisor(BaseSeedAgent):
                 "snapshot": snapshot,
             },
             agent=_SUPERVISOR_AGENT_NAME,
+            source=self.adapter_source,
         )
 
     def _build_description(

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -434,12 +434,15 @@ def _dispatch_pipeline(
         max_iterations=max_iterations,
     )
     registry = PipelineRegistry()
-    # NOTE: real registry population happens in S11-wire / S12 (per
-    # sprint plan §S6.5-wire and §S12 data run). For S11 the CLI flow
-    # surfaces every gate + abort path even when the registry is empty
-    # — the Pipeline.arun() will raise a RuntimeError with an actionable
-    # "no registered agent" message that the operator can map back to
-    # the unwired phase.
+    # v0.99.40 Follow-up C — S11 registry wire-up. Each enabled role's
+    # concrete agent is instantiated with the picker-resolved binding
+    # (``model`` + ``source``) and the shared SubAgentManager so the
+    # spawned worker's AgenticLoop receives the per-role source via
+    # SubTask.source threading (Follow-up A + B).
+    from plugins.seed_generation._registry_builder import populate_registry
+    from plugins.seed_generation.manifest import load_manifest
+
+    populate_registry(registry, picker_result=picker_result, manifest=load_manifest())
     pipeline = Pipeline(state=state, registry=registry, bindings=dict(picker_result.bindings))
     out.write(f"seed-generation: starting run {run_id!r}\n")
     out.write(f"seed-generation: run_dir={run_dir}\n")

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -83,6 +83,49 @@ def _get_seed_generation_config() -> Any:
         return SimpleNamespace(candidates_default=15, default_gen_tag="gen1")
 
 
+@audit_seeds_app.command("config")
+def audit_seeds_config() -> None:
+    """Show the 7-role × (model, source) binding matrix.
+
+    Resolved by :func:`plugins.seed_generation.picker.pick_bindings`
+    after merging in user overrides from ``~/.geode/config.toml``
+    ``[seed_generation.role.<role>]`` (or the legacy
+    ``~/.geode/seed-generation.toml`` fallback).
+
+    Read-only — to change a role's source, edit
+    ``~/.geode/config.toml`` directly:
+
+      [seed_generation.role.generator]
+      source = "payg" | "subscription" | "adapter"
+
+    See ``geode adapters list`` for the available source names per
+    provider.
+    """
+    from plugins.seed_generation.picker import pick_bindings
+
+    picker = pick_bindings(auto_probe=False)
+    header = f"{'ROLE':<18} {'PROVIDER':<10} {'MODEL':<26} {'SOURCE':<14}"
+    typer.echo(header)
+    typer.echo("-" * len(header))
+    for role_name in sorted(picker.bindings):
+        b = picker.bindings[role_name]
+        typer.echo(f"{role_name:<18} {b.provider:<10} {b.model:<26} {b.source:<14}")
+
+    if picker.voters:
+        typer.echo("\nJudge panel voters:")
+        voter_header = f"  {'PROVIDER':<10} {'MODEL':<26} {'SOURCE':<14}"
+        typer.echo(voter_header)
+        typer.echo("  " + "-" * (len(voter_header) - 2))
+        for v in picker.voters:
+            typer.echo(f"  {v.provider:<10} {v.model:<26} {v.source:<14}")
+
+    typer.echo(
+        f"\n{len(picker.bindings)} role(s) bound; "
+        f"{len(picker.voters)} voter(s); "
+        f"{len(picker.subscription_paths_in_use)} subscription path(s) active."
+    )
+
+
 @audit_seeds_app.command("generate")
 def audit_seeds_generate(
     target_dim: str | None = typer.Option(

--- a/plugins/seed_generation/cli.py
+++ b/plugins/seed_generation/cli.py
@@ -440,7 +440,7 @@ def _dispatch_pipeline(
     # — the Pipeline.arun() will raise a RuntimeError with an actionable
     # "no registered agent" message that the operator can map back to
     # the unwired phase.
-    pipeline = Pipeline(state=state, registry=registry)
+    pipeline = Pipeline(state=state, registry=registry, bindings=dict(picker_result.bindings))
     out.write(f"seed-generation: starting run {run_id!r}\n")
     out.write(f"seed-generation: run_dir={run_dir}\n")
     out.flush()

--- a/plugins/seed_generation/orchestrator.py
+++ b/plugins/seed_generation/orchestrator.py
@@ -369,12 +369,19 @@ class Pipeline:
         hooks: HookSystem | None = None,
         lane_queue: LaneQueue | None = None,
         on_phase_error: Any | None = None,
+        bindings: dict[str, Any] | None = None,
     ) -> None:
         self.state = state
         self.registry = registry
         self._hooks = hooks
         self._lane_queue = lane_queue
         self._on_phase_error = on_phase_error
+        # v0.99.40 Follow-up B — picker-resolved per-role bindings
+        # (``role_name → RoleBinding``). Stored for observability /
+        # journaling; agents themselves are already constructed with
+        # the binding's model + source, so the Pipeline does not re-
+        # inject the values into SubTask creation.
+        self.bindings = bindings or {}
 
     async def arun(self) -> PipelineState:
         """Walk the 7 phases (then optional iteration cycles). Returns the final state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.38"
+version = "0.99.40"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/agent/test_agent_loop_source_route.py
+++ b/tests/core/agent/test_agent_loop_source_route.py
@@ -1,0 +1,80 @@
+"""AgenticLoop source-route behavioural invariants.
+
+Pins:
+- Empty source → legacy adapter only, no new_adapter attached.
+- Concrete source + ``provider="anthropic"`` → ``resolve_for`` resolves and
+  attaches a new_adapter; legacy adapter still constructed for the fallback
+  surface (unused on this path).
+- Concrete source + provider != anthropic → new_adapter stays None (A2
+  follow-up scope); legacy adapter is the only route.
+- Concrete source + unregistered (provider, source) pair → hard-fail
+  (Codex MCP 2026-05-23 HIGH 2 — no silent fallback).
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.conversation import ConversationContext
+from core.agent.loop import AgenticLoop
+from core.agent.tool_executor import ToolExecutor
+from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
+
+from core.llm.adapters import AdapterNotFoundError
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_builtins():
+    _reset_for_test()
+    bootstrap_builtins()
+    yield
+    _reset_for_test()
+
+
+def _make_loop(*, source: str = "", provider: str = "anthropic") -> AgenticLoop:
+    return AgenticLoop(
+        ConversationContext(),
+        ToolExecutor(action_handlers={}, auto_approve=True),
+        provider=provider,
+        source=source,
+        quiet=True,
+    )
+
+
+def test_empty_source_leaves_new_adapter_none() -> None:
+    loop = _make_loop(source="")
+    assert loop._new_adapter is None
+    assert loop._adapter is not None  # legacy still wired
+
+
+def test_concrete_source_attaches_anthropic_adapter() -> None:
+    loop = _make_loop(source="payg")
+    assert loop._new_adapter is not None
+    assert loop._new_adapter.name == "anthropic-payg"
+    assert loop._adapter is not None  # legacy also wired for fallback
+
+
+def test_concrete_source_each_anthropic_variant() -> None:
+    for source, expected_name in (
+        ("payg", "anthropic-payg"),
+        ("subscription", "anthropic-oauth"),
+        ("adapter", "claude-cli"),
+    ):
+        loop = _make_loop(source=source)
+        assert loop._new_adapter is not None
+        assert loop._new_adapter.name == expected_name
+
+
+def test_non_anthropic_provider_skips_new_adapter() -> None:
+    """A2 follow-up scope — OpenAI/Codex providers still use legacy."""
+    loop = _make_loop(source="payg", provider="openai")
+    assert loop._new_adapter is None  # not yet on adapter route
+    assert loop._adapter is not None  # legacy path
+
+
+def test_unregistered_pair_hard_fails() -> None:
+    """Concrete source + missing adapter must raise — no silent fallback."""
+    from core.llm.adapters.registry import unregister_adapter
+
+    unregister_adapter("anthropic-payg")
+    with pytest.raises(AdapterNotFoundError):
+        _make_loop(source="payg")

--- a/tests/core/agent/test_source_threading.py
+++ b/tests/core/agent/test_source_threading.py
@@ -1,0 +1,52 @@
+"""Source threading invariants — SubTask → WorkerRequest → AgenticLoop.
+
+Pins v0.99.40 Follow-up A: when a parent picker resolves a per-role
+``RoleBinding.source`` (one of ``"payg"`` / ``"subscription"`` / ``"adapter"``),
+that value must reach the spawned worker's :class:`AgenticLoop`.
+Regression here means the operator's per-role auth choice silently collapses
+back onto ``ProfileRotator``'s global type-priority.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.agent.sub_agent import SubTask
+from core.agent.worker import WorkerRequest
+
+
+def test_subtask_default_source_is_empty_legacy() -> None:
+    """Unset source means legacy routing — no behaviour change for old callers."""
+    task = SubTask(task_id="t1", description="d", task_type="analyze")
+    assert task.source == ""
+
+
+def test_subtask_accepts_concrete_source() -> None:
+    """SubTask carries a concrete adapter source for picker-driven flows."""
+    task = SubTask(task_id="t1", description="d", task_type="analyze", source="subscription")
+    assert task.source == "subscription"
+
+
+def test_worker_request_serialisation_round_trip() -> None:
+    """``source`` survives the wire encode / decode used by the worker subprocess."""
+    req = WorkerRequest(task_id="t1", source="adapter")
+    encoded = req.to_dict()
+    assert encoded["source"] == "adapter"
+    decoded = WorkerRequest.from_dict(encoded)
+    assert decoded.source == "adapter"
+
+
+def test_worker_request_legacy_payload_decodes_with_empty_source() -> None:
+    """Backward-compat: old wire payloads without ``source`` decode safely."""
+    legacy_payload = {
+        "task_id": "t1",
+        "task_type": "analyze",
+        "description": "d",
+    }
+    req = WorkerRequest.from_dict(legacy_payload)
+    assert req.source == ""
+
+
+@pytest.mark.parametrize("source", ["payg", "subscription", "adapter", ""])
+def test_worker_request_accepts_all_source_shapes(source: str) -> None:
+    req = WorkerRequest(task_id="t1", source=source)
+    assert req.source == source

--- a/tests/core/cli/test_cmd_adapters.py
+++ b/tests/core/cli/test_cmd_adapters.py
@@ -1,0 +1,88 @@
+"""``geode adapters`` CLI surface tests — Follow-up D."""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
+from typer.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_builtins():
+    _reset_for_test()
+    bootstrap_builtins()
+    yield
+    _reset_for_test()
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_adapters_list_shows_all_six(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["adapters", "list"])
+    assert result.exit_code == 0, result.output
+    for adapter_name in (
+        "anthropic-payg",
+        "anthropic-oauth",
+        "claude-cli",
+        "openai-payg",
+        "codex-oauth",
+        "codex-cli",
+    ):
+        assert adapter_name in result.output
+
+
+def test_adapters_list_shows_billing_type(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["adapters", "list"])
+    assert "api" in result.output
+    assert "subscription" in result.output
+    assert "subscription_included" in result.output
+
+
+def test_adapters_detect_model_missing_adapter_exits_1(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["adapters", "detect-model", "no-such-adapter"])
+    assert result.exit_code == 1
+
+
+def test_adapters_detect_model_no_credential_exits_2(runner: CliRunner, monkeypatch) -> None:
+    """When a registered adapter has no credentials configured, exit 2."""
+    from core.cli import app
+
+    # Force PAYG to report no credential.
+    monkeypatch.setattr("core.config.settings.anthropic_api_key", "")
+    result = runner.invoke(app, ["adapters", "detect-model", "anthropic-payg"])
+    assert result.exit_code == 2
+    assert "no credential" in result.output.lower()
+
+
+def test_audit_seeds_config_shows_role_table(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["audit-seeds", "config"])
+    assert result.exit_code == 0, result.output
+    # All 7 enabled roles surface
+    for role in (
+        "generator",
+        "critic",
+        "proximity",
+        "pilot",
+        "ranker",
+        "evolver",
+        "meta_reviewer",
+    ):
+        assert role in result.output
+
+
+def test_audit_seeds_config_shows_judge_voters(runner: CliRunner) -> None:
+    from core.cli import app
+
+    result = runner.invoke(app, ["audit-seeds", "config"])
+    assert "Judge panel voters" in result.output

--- a/tests/core/llm/adapters/test_legacy_bridge.py
+++ b/tests/core/llm/adapters/test_legacy_bridge.py
@@ -1,0 +1,174 @@
+"""Legacy bridge tests — AgenticLoop ↔ LLMAdapter translation.
+
+Pins the contract between the new ``LLMAdapter.acomplete`` surface and the
+legacy ``AgenticResponse`` consumed by the agentic loop. Regression here
+means the v0.99.40 Follow-up A path silently drops tool_use blocks or
+mangles message content during the round trip.
+"""
+
+from __future__ import annotations
+
+from core.llm.adapters._legacy_bridge import (
+    agentic_response_from_adapter_result,
+    build_adapter_request,
+)
+from core.llm.adapters.base import AdapterCallResult, UsageSummary
+
+
+def test_build_request_translates_user_message() -> None:
+    req = build_adapter_request(
+        model="claude-haiku-4-5",
+        system="You are helpful.",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    assert req.model == "claude-haiku-4-5"
+    assert req.system_prompt == "You are helpful."
+    assert len(req.messages) == 1
+    assert req.messages[0].role == "user"
+    assert req.messages[0].content == "hi"
+    assert req.tool_choice == "auto"
+
+
+def test_build_request_carries_tool_use_id_for_tool_messages() -> None:
+    """Multi-turn tool messages carry tool_use_id so the adapter can re-encode."""
+    req = build_adapter_request(
+        model="m",
+        system="",
+        messages=[
+            {"role": "user", "content": "calc 1+1"},
+            {"role": "tool", "content": "2", "tool_use_id": "tu_123"},
+        ],
+        tools=[],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    assert req.messages[1].role == "tool"
+    assert req.messages[1].tool_use_id == "tu_123"
+
+
+def test_build_request_translates_tools() -> None:
+    req = build_adapter_request(
+        model="m",
+        system="",
+        messages=[{"role": "user", "content": "x"}],
+        tools=[
+            {"name": "search", "description": "web", "input_schema": {"type": "object"}},
+        ],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    assert len(req.tools) == 1
+    assert req.tools[0].name == "search"
+    assert req.tools[0].description == "web"
+    assert req.tools[0].input_schema == {"type": "object"}
+
+
+def test_response_translation_text_only() -> None:
+    """A text-only AdapterCallResult → AgenticResponse with a single TextBlock."""
+    from core.llm.agentic_response import TextBlock
+
+    result = AdapterCallResult(
+        text="hello world",
+        usage=UsageSummary(input_tokens=10, output_tokens=5),
+        stop_reason="end_turn",
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert len(resp.content) == 1
+    block = resp.content[0]
+    assert isinstance(block, TextBlock)
+    assert block.text == "hello world"
+    assert resp.stop_reason == "end_turn"
+    assert resp.usage.input_tokens == 10
+    assert resp.usage.output_tokens == 5
+
+
+def test_response_translation_tool_use_block() -> None:
+    """Tool uses produce ToolUseBlock entries in order after the text block."""
+    from core.llm.agentic_response import ToolUseBlock
+
+    result = AdapterCallResult(
+        text="calling tool",
+        usage=UsageSummary(),
+        stop_reason="tool_use",
+        tool_uses=({"id": "tu_1", "name": "search", "input": {"q": "geode"}},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert len(resp.content) == 2
+    assert resp.content[0].type == "text"
+    block = resp.content[1]
+    assert isinstance(block, ToolUseBlock)
+    assert block.id == "tu_1"
+    assert block.name == "search"
+    assert block.input == {"q": "geode"}
+    assert resp.stop_reason == "tool_use"
+
+
+def test_response_translation_parses_string_input() -> None:
+    """OpenAI-style tool calls with stringified JSON arguments parse cleanly."""
+    from core.llm.agentic_response import ToolUseBlock
+
+    result = AdapterCallResult(
+        text="",
+        usage=UsageSummary(),
+        stop_reason="tool_calls",
+        tool_uses=({"id": "tc_1", "name": "lookup", "input": '{"key": "val"}'},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    # tool_calls → tool_use translation
+    assert resp.stop_reason == "tool_use"
+    block = resp.content[0]
+    assert isinstance(block, ToolUseBlock)
+    assert block.input == {"key": "val"}
+
+
+def test_response_translation_handles_malformed_string_input() -> None:
+    """Malformed stringified args don't crash — wrapped in ``_raw`` for inspection."""
+    from core.llm.agentic_response import ToolUseBlock
+
+    result = AdapterCallResult(
+        text="",
+        usage=UsageSummary(),
+        stop_reason="tool_use",
+        tool_uses=({"id": "tc_x", "name": "x", "input": "{not json"},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    block = resp.content[0]
+    assert isinstance(block, ToolUseBlock)
+    assert block.input == {"_raw": "{not json"}
+
+
+def test_response_translation_drops_empty_text() -> None:
+    """Empty text → no TextBlock prepended (tool-only response)."""
+    result = AdapterCallResult(
+        text="",
+        usage=UsageSummary(),
+        stop_reason="tool_use",
+        tool_uses=({"id": "tu_only", "name": "t", "input": {}},),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert len(resp.content) == 1
+    assert resp.content[0].type == "tool_use"
+
+
+def test_response_translation_carries_cache_tokens() -> None:
+    """``cached_input_tokens`` from the adapter usage maps to ``cache_read_tokens``."""
+    result = AdapterCallResult(
+        text="ok",
+        usage=UsageSummary(input_tokens=100, output_tokens=20, cached_input_tokens=80),
+        stop_reason="end_turn",
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert resp.usage.cache_read_tokens == 80
+    assert resp.usage.input_tokens == 100

--- a/tests/core/llm/adapters/test_tool_choice_translation.py
+++ b/tests/core/llm/adapters/test_tool_choice_translation.py
@@ -1,0 +1,64 @@
+"""Anthropic adapter ``tool_choice`` translation invariants.
+
+Codex MCP 2026-05-23 MEDIUM 1: the loop emits ``{"type": "none"}`` during
+wrap-up to forbid tool calls. Without explicit translation, the SDK silently
+allows tool use and the wrap-up safety net is defeated.
+"""
+
+from __future__ import annotations
+
+import pytest
+from core.llm.adapters._anthropic_common import build_create_kwargs
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+
+
+def _req(tool_choice: object = "auto") -> AdapterCallRequest:
+    return AdapterCallRequest(
+        model="claude-haiku-4-5",
+        messages=[Message(role="user", content="x")],
+        system_prompt="",
+        tools=[ToolSpec(name="t", description="", input_schema={"type": "object"})],
+        tool_choice=tool_choice,  # type: ignore[arg-type]
+        max_tokens=4096,
+    )
+
+
+@pytest.mark.parametrize(
+    ("loop_choice", "expected"),
+    [
+        ("auto", {"type": "auto"}),
+        ("any", {"type": "any"}),
+        ("none", {"type": "none"}),  # wrap-up safety net
+        ("required", {"type": "any"}),
+    ],
+)
+def test_string_tool_choice_translates(loop_choice: str, expected: dict[str, str]) -> None:
+    kwargs = build_create_kwargs(_req(tool_choice=loop_choice))
+    assert kwargs["tool_choice"] == expected
+
+
+def test_dict_tool_choice_passes_through() -> None:
+    """A dict from the loop (e.g. ``{"type": "tool", "name": "X"}``) survives."""
+    forced = {"type": "tool", "name": "X"}
+    kwargs = build_create_kwargs(_req(tool_choice=forced))
+    assert kwargs["tool_choice"] == forced
+
+
+def test_unknown_string_tool_choice_omitted() -> None:
+    """Unrecognised literal → no ``tool_choice`` key, Anthropic default applies."""
+    kwargs = build_create_kwargs(_req(tool_choice="garbage"))
+    assert "tool_choice" not in kwargs
+
+
+def test_no_tools_no_tool_choice() -> None:
+    """When the request carries no tools, ``tool_choice`` is also omitted."""
+    req = AdapterCallRequest(
+        model="claude-haiku-4-5",
+        messages=[Message(role="user", content="x")],
+        tools=(),
+        tool_choice="none",  # would normally translate, but no tools → skip
+        max_tokens=4096,
+    )
+    kwargs = build_create_kwargs(req)
+    assert "tools" not in kwargs
+    assert "tool_choice" not in kwargs

--- a/tests/plugins/seed_generation/test_agent_source_threading.py
+++ b/tests/plugins/seed_generation/test_agent_source_threading.py
@@ -1,0 +1,85 @@
+"""Per-agent SubTask.source threading invariants — Follow-up B.
+
+Pins:
+- BaseSeedAgent.adapter_source translates picker source → adapter source.
+- Each role agent passes self.adapter_source on SubTask construction.
+- RankerAgent uses voter-specific source per voter (not the role source).
+- Pipeline carries picker_result.bindings for observability without
+  re-injecting binding values into SubTask creation (agents already do).
+"""
+
+from __future__ import annotations
+
+import pytest
+from plugins.seed_generation.agents.base import (
+    BaseSeedAgent,
+    SeedAgentResult,
+    picker_source_to_adapter_source,
+)
+
+
+class _StubAgent(BaseSeedAgent):
+    """Minimum concrete BaseSeedAgent for unit-level source translation tests."""
+
+    async def aexecute(self, state):  # type: ignore[no-untyped-def]
+        return SeedAgentResult(role=self.role, status="ok")
+
+
+@pytest.mark.parametrize(
+    ("picker_source", "expected_adapter_source"),
+    [
+        ("api_key", "payg"),
+        ("claude-cli", "adapter"),
+        ("openai-codex", "subscription"),
+        ("payg", "payg"),
+        ("subscription", "subscription"),
+        ("adapter", "adapter"),
+        ("auto", ""),  # unresolved → empty = legacy
+        ("", ""),  # empty input → empty output
+        ("nonexistent", ""),  # unknown picker source → empty (graceful)
+    ],
+)
+def test_picker_source_to_adapter_source(picker_source: str, expected_adapter_source: str) -> None:
+    assert picker_source_to_adapter_source(picker_source) == expected_adapter_source
+
+
+@pytest.mark.parametrize(
+    ("agent_source", "expected"),
+    [
+        ("claude-cli", "adapter"),
+        ("api_key", "payg"),
+        ("openai-codex", "subscription"),
+        ("auto", ""),
+        ("", ""),
+    ],
+)
+def test_agent_adapter_source_property(agent_source: str, expected: str) -> None:
+    agent = _StubAgent(role="r", model="m", source=agent_source)
+    assert agent.adapter_source == expected
+
+
+def test_pipeline_carries_bindings() -> None:
+    """Pipeline stores picker bindings; agents (built earlier with binding
+    values) supply ``source`` directly on SubTask creation. No double-injection."""
+    from plugins.seed_generation.orchestrator import (
+        Pipeline,
+        PipelineRegistry,
+        PipelineState,
+    )
+
+    state = PipelineState(run_id="r-0", target_dim="d", gen_tag="g")
+    pipeline = Pipeline(state=state, registry=PipelineRegistry(), bindings={"role-x": "B"})
+    assert pipeline.bindings == {"role-x": "B"}
+
+
+def test_pipeline_default_bindings_empty_dict() -> None:
+    """No bindings passed → empty dict (not None)."""
+    from plugins.seed_generation.orchestrator import (
+        Pipeline,
+        PipelineRegistry,
+        PipelineState,
+    )
+
+    state = PipelineState(run_id="r-0", target_dim="d", gen_tag="g")
+    pipeline = Pipeline(state=state, registry=PipelineRegistry())
+    assert pipeline.bindings == {}

--- a/tests/plugins/seed_generation/test_cli.py
+++ b/tests/plugins/seed_generation/test_cli.py
@@ -369,7 +369,7 @@ def test_audit_seeds_generate_uses_config_defaults() -> None:
     ):
         result = CliRunner().invoke(
             audit_seeds_app,
-            ["--target-dim", "broken_tool_use"],
+            ["generate", "--target-dim", "broken_tool_use"],
         )
     assert result.exit_code == 0, result.output
     assert captured["gen_tag"] == "gen7"
@@ -628,6 +628,7 @@ def test_audit_seeds_generate_cli_overrides_win_over_config() -> None:
         result = CliRunner().invoke(
             audit_seeds_app,
             [
+                "generate",
                 "--target-dim",
                 "broken_tool_use",
                 "--gen-tag",

--- a/tests/plugins/seed_generation/test_registry_wireup.py
+++ b/tests/plugins/seed_generation/test_registry_wireup.py
@@ -10,7 +10,6 @@ Pins:
 from __future__ import annotations
 
 import pytest
-
 from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
 from plugins.seed_generation._registry_builder import populate_registry
 from plugins.seed_generation.manifest import load_manifest

--- a/tests/plugins/seed_generation/test_registry_wireup.py
+++ b/tests/plugins/seed_generation/test_registry_wireup.py
@@ -1,0 +1,75 @@
+"""S11 PipelineRegistry wire-up — Follow-up C invariants.
+
+Pins:
+- ``populate_registry`` builds one agent per ``manifest.enabled_roles``.
+- Each agent's model + source comes from the picker binding for that role.
+- Ranker receives ``picker_result.voters`` (per-voter routing).
+- Empty picker (no bindings) → empty registry (caller handles missing-agent).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.adapters.registry import _reset_for_test, bootstrap_builtins
+from plugins.seed_generation._registry_builder import populate_registry
+from plugins.seed_generation.manifest import load_manifest
+from plugins.seed_generation.orchestrator import PipelineRegistry
+from plugins.seed_generation.picker import pick_bindings
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_builtins():
+    _reset_for_test()
+    bootstrap_builtins()
+    yield
+    _reset_for_test()
+
+
+def test_populate_registry_registers_all_enabled_roles() -> None:
+    """Every enabled role in the manifest gets a registered agent."""
+    picker = pick_bindings(auto_probe=False)
+    manifest = load_manifest()
+    registry = PipelineRegistry()
+    populate_registry(registry, picker_result=picker, manifest=manifest)
+    registered = sorted(registry.list_roles())
+    assert set(registered) >= set(manifest.enabled_roles)
+
+
+def test_populate_registry_agent_model_matches_binding() -> None:
+    """Each agent's ``model`` is the picker binding's model."""
+    picker = pick_bindings(auto_probe=False)
+    manifest = load_manifest()
+    registry = PipelineRegistry()
+    populate_registry(registry, picker_result=picker, manifest=manifest)
+    for role_name in manifest.enabled_roles:
+        binding = picker.bindings[role_name]
+        agent = registry.get(role_name)
+        assert agent is not None, f"role {role_name} not registered"
+        assert agent.model == binding.model
+        assert agent.source == binding.source
+
+
+def test_populate_registry_idempotent() -> None:
+    """Re-running populate_registry on an already-populated registry is a no-op."""
+    picker = pick_bindings(auto_probe=False)
+    manifest = load_manifest()
+    registry = PipelineRegistry()
+    populate_registry(registry, picker_result=picker, manifest=manifest)
+    before = sorted(registry.list_roles())
+    populate_registry(registry, picker_result=picker, manifest=manifest)
+    after = sorted(registry.list_roles())
+    assert before == after
+
+
+def test_populate_registry_ranker_receives_voters() -> None:
+    """Ranker is built with ``picker_result.voters`` so each judge has a binding."""
+    picker = pick_bindings(auto_probe=False)
+    manifest = load_manifest()
+    registry = PipelineRegistry()
+    populate_registry(registry, picker_result=picker, manifest=manifest)
+    ranker = registry.get("ranker")
+    assert ranker is not None
+    # The Ranker stores voters on a private attribute; the externally-visible
+    # invariant is that the registry has the ranker role + picker has voters.
+    assert len(picker.voters) >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.38"
+version = "0.99.40"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Pass-through rotation: develop → main carrying the v0.99.40 release stamp (#1525 already merged release/v0.99.40 → develop).
- Includes feature PRs #1518-#1522 (LLM adapter abstraction) + #1523 backmerge + #1525 release cut.

## Verification

- [x] release/v0.99.40 already merged into develop (rotation invariant)
- [x] All 5 feature PRs (#1518, #1519, #1520, #1521, #1522) merged to develop with green CI
- [x] CHANGELOG cut + version stamped across 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)