### PR TITLE
release: v0.99.42 — C4.fix-contextvar sidecar flake hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,40 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.42] - 2026-05-23
+
+> PR-SIL-5THEME C4 sidecar flake hotfix. `_LAST_LLM_CALL_USAGE` module-level
+> dict 가 pytest-xdist worker 간 격리 깨짐 → ContextVar 교체로 해소. Future
+> concurrent SelfImprovingLoopRunner 의 cross-runner race 도 동시 차단.
+
+### Fixed
+
+- **PR-C4.fix-contextvar — mutation cost ledger sidecar flake**. PR-SIL-5THEME
+  C4 (#1524) 의 `_LAST_LLM_CALL_USAGE: dict[str, Any] = {}` module-level
+  sidecar 가 (a) pytest-xdist worker 간 process 공유로 flaky test fail
+  발생 (`test_propose_populates_cost_from_sidecar` — 격리 실행 pass,
+  full sweep 시 race fail), (b) future concurrent SelfImprovingLoopRunner
+  (cron + manual 동시 호출) 시 cost 가 잘못된 mutation 에 cross-attributed
+  될 silent bug 위험을 동시에 가졌다.
+
+  **Fix**: `_LAST_LLM_CALL_USAGE_VAR: ContextVar[dict[str, Any] | None]`
+  으로 교체. ContextVar 가 asyncio Task / pytest test scope 단위로 격리
+  → 두 문제 동시 해소. `_default_llm_call` 가 ContextVar.set 으로 매번
+  새 dict 적재 (partial mutation 패턴 회피). 기존 `_LAST_LLM_CALL_USAGE`
+  module-level alias 는 `_UsageProxy` 로 보존 — test code 의 `update()`
+  / `clear()` / `__setitem__` 패턴이 ContextVar 의 현재 dict 에 위임
+  되어 backward-compat.
+
+  **Verification**:
+  - tests/test_e1_mutation_cost_ledger.py 14 tests pass (격리 + full
+    sweep + xdist parallel 모두)
+  - PR #1529 CI 8/8 green (flaky 해소 검증)
+  - 6834 passed full sweep (no flaky)
+
+  Same operator-visible pattern as PR-MINIMAL-2 #1398 의 silent dual-
+  prompt drift fix — module-level state 가 silent race 를 부른다는
+  lesson 의 또 다른 사례.
+
 ## [0.99.41] - 2026-05-23
 
 > SIL 5-theme closure release. Bench S6b production wiring + ADR-012 §S6/§S6b

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.41
+- **Version**: 0.99.42
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.41 — Long-running Autonomous Execution Harness
+# GEODE v0.99.42 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.42**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.41 — Long-running Autonomous Execution Harness
+# GEODE v0.99.42 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.42**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.41"
+version = "0.99.42"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.41"
+version = "0.99.42"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Version stamp bump 0.99.41 → 0.99.42 across 5 locations
- CHANGELOG [Unreleased] → [0.99.42] - 2026-05-23 (C4.fix-contextvar hotfix release header)
- PR #1529 (sidecar flake fix) 반영 — develop → main rotation retry 대비

## Why
PR #1528 (release v0.99.41 → main rotation) 의 Test fail 원인 (`_LAST_LLM_CALL_USAGE` xdist race) 가 PR #1529 (ContextVar 교체) 로 해소됨. 본 release branch 가 v0.99.42 stamp + hotfix CHANGELOG 캐리 후 main rotation 재진행.

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] Version stamps verified in 5 locations (pyproject.toml / uv.lock / CLAUDE.md / README × 2)
- [x] CHANGELOG hotfix entry under [0.99.42] header

🤖 Generated with [Claude Code](https://claude.com/claude-code)