### PR TITLE
feat(observability): SessionMetrics 신설 + SessionJournal 흡수 + transcript 단순화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,77 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **`SessionMetrics` — session-scoped state aggregator (Tier 2 of 3-Tier
+  preservation architecture)**. Centralises ~13 scattered session-scoped
+  state (LLM cost / tool calls / provider routing / failover counts /
+  mutation lifecycle / Goodhart surface) into a single ContextVar-bound
+  dataclass at ``core/observability/session_metrics.py``.
+
+  **Frontier 정렬** — Claude Code ``AgentLoopState.totalUsage`` +
+  Hermes ``sessions`` SQLite table column shape + Paperclip ``usageJson``
+  JSONB column schema 의 cumulative aggregate grain 일치. Hermes 의
+  ``_SESSION_ID: ContextVar`` family 와 같은 multi-session 격리 패턴.
+
+  **C4 sidecar 흡수** — PR-SIL-5THEME C4 의 ``_LAST_LLM_CALL_USAGE``
+  module-level dict + PR-C4.fix-contextvar 의 ``ContextVar[dict]`` +
+  ``_UsageProxy`` shim 전부 SessionMetrics 의 ``last_call_input_tokens
+  / last_call_output_tokens / last_call_elapsed_seconds / last_call_model``
+  4-field snapshot 으로 흡수. propose() 가 같은 ContextVar 안에서
+  ``current_session_metrics()`` 호출로 race 가능성 0. PR #1530 의 flaky
+  test fail 해소.
+
+  **API**:
+  - ``current_session_metrics()`` — ContextVar lazy-init lookup
+  - ``session_metrics_scope(session_id, gen_tag, component)`` — context
+    manager binding (mirrors ``session_journal_scope``)
+  - ``SessionMetrics.accumulate_llm_call(...)`` — per-call additive
+  - ``SessionMetrics.increment_tool_call() / increment_mutation() /
+    record_retry() / record_circuit_breaker_trip() / record_error() /
+    record_rollback() / record_goodhart()`` — counter mutation
+  - ``SessionMetrics.to_session_row()`` — sessions.jsonl persistence shape
+
+  **15 new tests** (`tests/test_session_metrics.py`):
+  defaults / accumulate additive + last-call overwrite / reset_last_call
+  preserves cumulative / 5 counter APIs / persistence shape / ContextVar
+  lifecycle (lazy / nested isolation / exception restore) / C4 integration.
+
+### Changed
+
+- **`SessionJournal` → `SessionTranscript` 흡수, ``journal/`` directory
+  depth 제거**. Pre-existing 3-Tier preservation 아키텍처가
+  ``core/runtime_state/transcript.py`` docstring 에 이미 정의돼 있었으나
+  ``SessionJournal`` (의도된 Tier 2 자리) 가 실제로는 self-improving-loop
+  의 *별도 Tier 1 event log* 로 운영 중이었다 — 두 객체가 schema /
+  path / API 가 다른 채 공존. 본 PR 이 정합 회복:
+
+  - ``core/observability/session_journal.py`` → thin alias-shim 으로 축소
+    (269 callsite 변경 0). ``SessionJournal.append(event, payload=...)``
+    가 ``SessionTranscript.record_lifecycle_event(...)`` 로 delegating
+  - ``SessionTranscript`` 에 ``record_lifecycle_event`` 메서드 신설 —
+    free-form event + ``{ts, session_id, gen_tag, component, level,
+    event, payload}`` 스키마로 기존 Journal 사용자 보존
+  - file 이름 ``journal.jsonl`` → ``transcript.jsonl`` (mass rename, 269
+    reference)
+  - 디렉터리 depth 축소: ``~/.geode/journal/transcripts/<slug>/<id>.jsonl``
+    → ``~/.geode/transcripts/<slug>/<id>.jsonl``. ``GLOBAL_JOURNAL_DIR``
+    이름은 ``GLOBAL_TRANSCRIPTS_DIR`` 의 backward-compat alias 유지
+  - ``core/cli/cmd_lifecycle.py`` 의 disk usage label ``"journal"`` →
+    ``"transcripts"`` 정렬
+
+  **3-Tier 최종**:
+
+  ```
+  Tier 1  SessionTranscript   (append-only event log) — transcripts/*.jsonl
+  Tier 2  SessionMetrics      (cumulative aggregate) — sessions.jsonl row
+  Tier 3  SessionCheckpoint   (pipeline state) — state.json
+  ```
+
+  Frontier 명명 정렬 — Claude Code ``transcript`` / OpenClaw
+  ``transcript`` / Hermes ``messages`` 의 Tier-1 일치. ``journal`` 의
+  일반 명사 모호성 해소.
+
 ## [0.99.41] - 2026-05-23
 
 > SIL 5-theme closure release. Bench S6b production wiring + ADR-012 §S6/§S6b

--- a/core/cli/cmd_lifecycle.py
+++ b/core/cli/cmd_lifecycle.py
@@ -21,10 +21,10 @@ from core.paths import (
     CLI_SOCKET_PATH,
     CLI_STARTUP_LOCK,
     GEODE_HOME,
-    GLOBAL_JOURNAL_DIR,
     GLOBAL_PROJECTS_DIR,
     GLOBAL_RUNS_DIR,
     GLOBAL_SCHEDULER_DIR,
+    GLOBAL_TRANSCRIPTS_DIR,
     GLOBAL_USAGE_DIR,
     GLOBAL_WORKERS_DIR,
     MCP_REGISTRY_CACHE,
@@ -303,7 +303,7 @@ def show_status(*, json_output: bool = False) -> None:
     # Global disk usage
     global_dirs = {
         "runs": GLOBAL_RUNS_DIR,
-        "journal": GLOBAL_JOURNAL_DIR,
+        "transcripts": GLOBAL_TRANSCRIPTS_DIR,
         "projects": GLOBAL_PROJECTS_DIR,
         "scheduler": GLOBAL_SCHEDULER_DIR,
         "usage": GLOBAL_USAGE_DIR,

--- a/core/observability/__init__.py
+++ b/core/observability/__init__.py
@@ -25,14 +25,24 @@ from core.observability.session_journal import (
     session_journal_scope,
     set_current_session_journal,
 )
+from core.observability.session_metrics import (
+    SessionMetrics,
+    current_session_metrics,
+    session_metrics_scope,
+    set_current_session_metrics,
+)
 
 __all__ = [
     "OtelExportError",
     "SessionJournal",
+    "SessionMetrics",
     "current_session_journal",
+    "current_session_metrics",
     "disable",
     "enable",
     "session_journal_scope",
+    "session_metrics_scope",
     "set_current_session_journal",
+    "set_current_session_metrics",
     "status",
 ]

--- a/core/observability/session_journal.py
+++ b/core/observability/session_journal.py
@@ -1,52 +1,41 @@
-"""Structured per-session journal — P1c self-improving-loop wiring plan.
+"""Backward-compat alias — ``SessionJournal`` is now a thin wrapper over the
+canonical :class:`core.runtime_state.transcript.SessionTranscript`.
 
-The session journal is a JSONL artifact that captures discrete events
-from one self-improving-loop run (autoresearch or seed-generation). It complements
-the run-level ``~/.geode/self-improving-loop/sessions.jsonl`` index (P1a) which
-holds exactly one row per run: this module captures the *event stream*
-within that run.
+PR-SESSION-METRICS (2026-05-23) — the pre-existing 3-Tier preservation
+architecture in ``core/runtime_state/transcript.py`` calls out:
 
-Schema (one event per line)::
+* Tier 1 — :class:`SessionTranscript` (event log, append-only JSONL)
+* Tier 2 — Journal (summaries)
+* Tier 3 — Snapshot (pipeline state)
 
-    {
-      "ts": 1731957600.123,
-      "session_id": "2026-05-19T1530Z-a1b2c3",
-      "gen_tag": "autoresearch-a1b2c3d",
-      "component": "autoresearch",
-      "level": "info" | "warn" | "error",
-      "event": "<short event name>",
-      "payload": {...}
-    }
+Reality drifted: ``SessionJournal`` was a separate per-self-improving-loop-run
+event log written to ``~/.geode/self-improving-loop/<id>/transcript.jsonl`` — i.e.
+*another Tier 1 event stream*, not a Tier 2 summary. The two coexisted with
+different schemas / paths / APIs which made the lifecycle event boundary
+opaque.
 
-Path: ``~/.geode/self-improving-loop/<session_id>/journal.jsonl``.
+This module is now a **thin compat shim**. ``SessionJournal.append(event,
+payload=...)`` delegates to ``SessionTranscript.record_lifecycle_event(...)``.
+Path renamed to ``~/.geode/self-improving-loop/<id>/transcript.jsonl`` (was
+``journal.jsonl`` before this PR) — schema is unchanged (``{ts, session_id,
+gen_tag, component, level, event, payload}``) so existing readers continue
+to work.
 
-Design notes
-------------
-
-* Stateless persistence — each ``append`` re-opens the file. The
-  expected event volume per run is small (10s-100s) so the open/close
-  cost is negligible and we avoid lifecycle issues with long-running
-  agents.
-* I/O failures NEVER raise — observability must not break the run it
-  observes. Failures are logged at WARNING and silently dropped.
-* Direct callers (CLI, orchestrator) instantiate a journal per run and
-  pass it through. Bootstrap-registered hook handlers route subagent
-  events through this journal when the contextvar is set; otherwise
-  they fall through to the existing project-journal pathway.
+Future PR removes this shim once all 269 callsites migrate to direct
+``SessionTranscript.record_lifecycle_event`` calls. Until then, the
+existing ``current_session_journal() / session_journal_scope`` API stays
+operational via this shim.
 """
 
 from __future__ import annotations
 
 import contextvars
-import json
-import logging
-import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-log = logging.getLogger(__name__)
+from core.runtime_state.transcript import SessionTranscript
 
 __all__ = [
     "SessionJournal",
@@ -62,13 +51,14 @@ _current_journal: contextvars.ContextVar[SessionJournal | None] = contextvars.Co
 
 
 class SessionJournal:
-    """Per-run JSONL event log.
+    """Per-run lifecycle event log — alias of :class:`SessionTranscript`.
 
-    Constructed once at the start of an self-improving-loop run (autoresearch or
-    seed-generation) and passed through to callers that emit structured
-    events. Use :meth:`append` for individual events;
-    :func:`session_journal_scope` for ContextVar-bound activation so
-    hook handlers can discover the journal automatically.
+    Preserves the pre-PR-SESSION-METRICS API surface (``append(event,
+    payload=...)`` + ``session_id / gen_tag / component`` instance fields +
+    ``path`` attribute) so existing 269 callsites work unchanged. The
+    actual append happens through the underlying :class:`SessionTranscript`
+    instance held in ``self._transcript`` so the canonical Tier-1 schema
+    is used.
 
     SoT contract (P0a dedup, 2026-05-19 observability audit §6)
     ------------------------------------------------------------
@@ -76,20 +66,9 @@ class SessionJournal:
     Canonical run-level metrics (fitness, verdict, survivors, usd_spent,
     promoted, commit, target_dim, candidates, pool_path_out, …) live in
     ``sessions.jsonl`` — one row per run, written by
-    ``_append_session_index``. Journal events MUST NOT duplicate those
+    ``_append_session_index``. Lifecycle events MUST NOT duplicate those
     fields in their payload; instead they act as stream markers (started /
-    progress / finished) and carry only event-specific context. Readers
-    that need canonical metrics join via ``session_id + gen_tag``.
-
-    Field placement guide:
-
-    - ``sessions.jsonl`` row: fitness, verdict, survivors, usd_spent,
-      promoted, commit, target_dim, candidates, pool_path_out,
-      started_at, ended_at (run summary, written at end-of-run).
-    - ``journal.jsonl`` event payload: event-scoped context only — e.g.
-      ``{"dry_run": True}`` for ``audit_finished`` (a flag that affects
-      interpretation but isn't a metric), or stage-specific intermediate
-      data for events that have no canonical row.
+    progress / finished) and carry only event-specific context.
     """
 
     def __init__(
@@ -104,12 +83,28 @@ class SessionJournal:
         self.gen_tag = gen_tag
         self.component = component
         if path is None:
-            # Lazy resolve via core.paths so test monkeypatch on
-            # ``Path.home()`` is honoured after reloading the module.
+            # PR-SESSION-METRICS — file renamed ``journal.jsonl`` →
+            # ``transcript.jsonl`` to align with the canonical Tier-1
+            # naming. Same per-run directory; only the filename changes.
             from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
 
-            path = GLOBAL_SELF_IMPROVING_LOOP_DIR / session_id / "journal.jsonl"
+            path = GLOBAL_SELF_IMPROVING_LOOP_DIR / session_id / "transcript.jsonl"
         self.path = path
+        # Underlying SessionTranscript — uses our chosen path verbatim.
+        # ``SessionTranscript.__init__(session_id, transcript_dir=...)``
+        # constructs ``transcript_dir / f"{session_id}.jsonl"``, so we
+        # pass the parent dir and let it form the file path. Then we
+        # ``rename`` it to match our explicit path.
+        self._transcript = SessionTranscript(
+            session_id=session_id,
+            transcript_dir=path.parent,
+        )
+        # SessionTranscript builds ``<dir>/<session_id>.jsonl`` by default,
+        # but we want ``<dir>/transcript.jsonl``. Override the file_path
+        # property by monkey-patching the internal directory + a sentinel.
+        # Simpler: write directly to our path via a small inline emitter.
+        # (Keeping the SessionTranscript instance for API symmetry / future
+        # migration to ``record_*`` typed methods.)
 
     def append(
         self,
@@ -121,29 +116,20 @@ class SessionJournal:
     ) -> None:
         """Append one JSONL event row. I/O failure logs a warning.
 
-        ``payload`` is the per-event extensible data dict. ``ts``
-        defaults to ``time.time()``; tests can pass a fixed value for
-        determinism.
+        Delegates to :meth:`SessionTranscript.record_lifecycle_event` so the
+        underlying schema and writer are the canonical Tier-1 path.
+        ``ts`` is honoured for determinism (tests pass a fixed value).
         """
-        record = {
-            "ts": ts if ts is not None else time.time(),
-            "session_id": self.session_id,
-            "gen_tag": self.gen_tag,
-            "component": self.component,
-            "level": level,
-            "event": event,
-            "payload": payload or {},
-        }
-        try:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
-            with self.path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-        except OSError as exc:
-            log.warning(
-                "session journal append failed at %s: %s",
-                self.path,
-                exc,
-            )
+        self._transcript.record_lifecycle_event(
+            event=event,
+            session_id=self.session_id,
+            gen_tag=self.gen_tag,
+            component=self.component,
+            level=level,
+            payload=payload,
+            ts=ts,
+            file_path=self.path,
+        )
 
 
 def current_session_journal() -> SessionJournal | None:

--- a/core/observability/session_metrics.py
+++ b/core/observability/session_metrics.py
@@ -1,0 +1,331 @@
+"""Per-session aggregate metrics — session-level state object pattern.
+
+Centralises 13-way scattered session-scoped state (LLM cost / tool calls /
+provider routing / failover counts / mutation lifecycle) into a single
+``SessionMetrics`` ContextVar-bound dataclass.
+
+Designed against four frontier references:
+
+1. **Claude Code** (``claude-code-ref/src/core/agent-loop.ts``) — its
+   ``AgentLoopState.totalUsage`` is per-loop instance state. We follow
+   the same grain but via ContextVar to support GEODE's multi-session
+   gateway pattern (cron / serve / sub-agent fan-out).
+
+2. **Hermes Agent** (``hermes-agent/gateway/session_context.py``) — its
+   ``_SESSION_ID: ContextVar`` family isolates session-scoped data
+   across concurrent gateway sessions. ``SessionMetrics`` mirrors that
+   pattern, sitting alongside ``SessionJournal``'s existing
+   ``_current_journal`` ContextVar (``core/observability/session_journal.py``).
+
+3. **Hermes ``sessions`` SQLite table** (``hermes_state.py:190``) — the
+   ``input_tokens / output_tokens / cache_*_tokens / reasoning_tokens
+   / api_call_count / billing_provider / estimated_cost_usd`` column
+   set is the persistence shape. ``SessionMetrics.to_session_row()``
+   emits the same shape so a future ``~/.geode/self-improving-loop/
+   sessions.jsonl`` row can carry these aggregates without separate
+   wiring.
+
+4. **Paperclip** (``paperclip/server/src/services/activity.ts``) —
+   the ``usageJson`` JSONB column already accepts both ``inputTokens``
+   /``input_tokens`` casing variants. Our row schema picks snake_case
+   to align with the hermes SQLite path and Anthropic API conventions.
+
+Coverage scope (Tier 1 — interim, not the only place these still live)
+----------------------------------------------------------------------
+
+Many GEODE subsystems already manage their own session-scoped state:
+
+- ``TokenTracker`` (``core/llm/token_tracker.py``) — per-call cost
+  accumulate. ``SessionMetrics`` is the *aggregator*; TokenTracker
+  remains for per-provider cost-table lookups and we delegate via a
+  thin shim instead of duplicating cost math.
+- ``SessionJournal`` (``core/observability/session_journal.py``) —
+  event stream. ``SessionMetrics`` is the *roll-up* counterpart;
+  journal events still carry the event-scoped context.
+- ``UsageStore`` (``core/llm/usage_store.py``) — *daily* rolling
+  ``~/.geode/usage/*.jsonl``. Not absorbed because the grain is
+  per-calendar-day, not per-session.
+- ``OAuthUsage`` (``core/llm/oauth_usage.py``) — 5-hour OAuth quota
+  cache. Provider-wide, not session-scoped.
+- ``LaneQueue`` (``core/llm/audit_lane.py``) — process-wide throttle.
+- ``ContextLocal`` (``core/ui/context_local.py``) — UI ephemerals
+  (SessionMeter backing). Read-only consumer of metrics in future.
+
+Lifecycle
+---------
+
+::
+
+    with session_metrics_scope(session_id="2026-05-23T...", gen_tag="autoresearch-abc1234"):
+        # ... runs that emit accumulate_llm_call / increment_tool_call ...
+        metrics = current_session_metrics()
+        # produce final row
+        row = metrics.to_session_row()
+        # caller appends to sessions.jsonl
+
+I/O failures NEVER raise — observability mustn't break the run it observes.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "SessionMetrics",
+    "current_session_metrics",
+    "session_metrics_scope",
+    "set_current_session_metrics",
+]
+
+
+_current_metrics: contextvars.ContextVar[SessionMetrics | None] = contextvars.ContextVar(
+    "session_metrics", default=None
+)
+
+
+@dataclass(slots=True)
+class SessionMetrics:
+    """Aggregate state for a single self-improving-loop / agentic session.
+
+    Field grouping mirrors the ``hermes_state.sessions`` table schema +
+    Claude Code's ``AgentLoopState.totalUsage`` + Paperclip's ``usageJson``.
+    All counters are *additive* — use the ``accumulate_*`` / ``increment_*``
+    / ``record_*`` methods rather than mutating fields directly so future
+    field additions don't break callers.
+    """
+
+    # Identity
+    session_id: str = ""
+    gen_tag: str = ""
+    component: str = ""
+    started_at: float = 0.0
+
+    # A. LLM call cost — per-call accumulate (claude-code AgentLoopState.totalUsage shape).
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    thinking_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    elapsed_seconds: float = 0.0
+    model_used: str = ""  # last model after failover
+
+    # B. Counts — turn / tool / message / mutation / audit
+    api_call_count: int = 0
+    tool_call_count: int = 0
+    message_count: int = 0
+    mutation_count: int = 0
+    audit_call_count: int = 0
+
+    # C. Billing surface (hermes sessions table parity)
+    billing_provider: str = ""  # anthropic / openai / glm / openai-codex
+    billing_mode: str = ""  # payg / subscription / adapter
+
+    # D. Resilience metrics
+    retry_count: int = 0
+    circuit_breaker_trips: dict[str, int] = field(default_factory=dict)
+    error_count_by_type: dict[str, int] = field(default_factory=dict)
+    rollback_count: int = 0
+
+    # E. Self-improving lifecycle (mutator session only — None otherwise)
+    fitness_before: float | None = None
+    fitness_after: float | None = None
+    cohort_tag: str = ""
+
+    # F. Last-LLM-call snapshot (replaces broken ``_LAST_LLM_CALL_USAGE`` sidecar
+    #    from PR-SIL-5THEME C4 / PR-C4.fix-contextvar #1529). propose() reads
+    #    this single field instead of a module dict — same caller frame, no
+    #    sidecar, no race.
+    last_call_input_tokens: int = 0
+    last_call_output_tokens: int = 0
+    last_call_elapsed_seconds: float = 0.0
+    last_call_model: str = ""
+
+    # H. Goodhart-surface aggregates (audit subprocess scope)
+    missing_dims_total: int = 0
+    missing_benches_total: int = 0
+    cross_validation_conflict_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Mutation API
+    # ------------------------------------------------------------------
+
+    def accumulate_llm_call(
+        self,
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        thinking_tokens: int = 0,
+        elapsed_seconds: float = 0.0,
+        model: str = "",
+        cost_usd: float = 0.0,
+    ) -> None:
+        """One LLM call completed — fold its usage into the session aggregate.
+
+        Also captures the *last call* snapshot in F-fields so propose() / a
+        mutation row writer can read just the latest call without diffing
+        across the cumulative totals. Matches the C4 sidecar's contract
+        without the module-level state.
+        """
+        self.input_tokens += int(input_tokens)
+        self.output_tokens += int(output_tokens)
+        self.cache_creation_tokens += int(cache_creation_tokens)
+        self.cache_read_tokens += int(cache_read_tokens)
+        self.thinking_tokens += int(thinking_tokens)
+        self.elapsed_seconds += float(elapsed_seconds)
+        self.estimated_cost_usd += float(cost_usd)
+        if model:
+            self.model_used = str(model)
+        self.api_call_count += 1
+        # Last-call snapshot — caller (propose()) reads this for per-mutation cost.
+        self.last_call_input_tokens = int(input_tokens)
+        self.last_call_output_tokens = int(output_tokens)
+        self.last_call_elapsed_seconds = float(elapsed_seconds)
+        self.last_call_model = str(model)
+
+    def reset_last_call(self) -> None:
+        """Clear the last-call snapshot (called before a new propose() so a
+        mock LLM that doesn't accumulate doesn't leak stale per-call values).
+        Cumulative totals untouched."""
+        self.last_call_input_tokens = 0
+        self.last_call_output_tokens = 0
+        self.last_call_elapsed_seconds = 0.0
+        self.last_call_model = ""
+
+    def increment_tool_call(self, count: int = 1) -> None:
+        self.tool_call_count += int(count)
+
+    def increment_message(self, count: int = 1) -> None:
+        self.message_count += int(count)
+
+    def increment_mutation(self, count: int = 1) -> None:
+        self.mutation_count += int(count)
+
+    def increment_audit_call(self, count: int = 1) -> None:
+        self.audit_call_count += int(count)
+
+    def record_retry(self, provider: str = "") -> None:
+        self.retry_count += 1
+
+    def record_circuit_breaker_trip(self, provider: str) -> None:
+        self.circuit_breaker_trips[provider] = self.circuit_breaker_trips.get(provider, 0) + 1
+
+    def record_error(self, error_type: str) -> None:
+        self.error_count_by_type[error_type] = self.error_count_by_type.get(error_type, 0) + 1
+
+    def record_rollback(self) -> None:
+        self.rollback_count += 1
+
+    def record_goodhart(
+        self,
+        *,
+        missing_dims: int = 0,
+        missing_benches: int = 0,
+        cross_validation_conflict: bool = False,
+    ) -> None:
+        self.missing_dims_total += int(missing_dims)
+        self.missing_benches_total += int(missing_benches)
+        if cross_validation_conflict:
+            self.cross_validation_conflict_count += 1
+
+    # ------------------------------------------------------------------
+    # Persistence shape
+    # ------------------------------------------------------------------
+
+    def to_session_row(self) -> dict[str, Any]:
+        """Render as ``sessions.jsonl`` row (hermes ``sessions`` table parity +
+        paperclip ``usageJson`` parity). Caller appends to disk.
+        """
+        return {
+            "session_id": self.session_id,
+            "gen_tag": self.gen_tag,
+            "component": self.component,
+            "started_at": self.started_at,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "thinking_tokens": self.thinking_tokens,
+            "estimated_cost_usd": round(self.estimated_cost_usd, 6),
+            "elapsed_seconds": round(self.elapsed_seconds, 4),
+            "model_used": self.model_used,
+            "api_call_count": self.api_call_count,
+            "tool_call_count": self.tool_call_count,
+            "message_count": self.message_count,
+            "mutation_count": self.mutation_count,
+            "audit_call_count": self.audit_call_count,
+            "billing_provider": self.billing_provider,
+            "billing_mode": self.billing_mode,
+            "retry_count": self.retry_count,
+            "circuit_breaker_trips": dict(self.circuit_breaker_trips),
+            "error_count_by_type": dict(self.error_count_by_type),
+            "rollback_count": self.rollback_count,
+            "fitness_before": self.fitness_before,
+            "fitness_after": self.fitness_after,
+            "cohort_tag": self.cohort_tag,
+            "missing_dims_total": self.missing_dims_total,
+            "missing_benches_total": self.missing_benches_total,
+            "cross_validation_conflict_count": self.cross_validation_conflict_count,
+        }
+
+
+def current_session_metrics() -> SessionMetrics:
+    """Return the SessionMetrics active in the current ContextVar scope.
+
+    Lazy-init: returns a fresh ``SessionMetrics()`` and binds it to the
+    ContextVar when none is set. This means *every* caller in *every*
+    scope sees a valid object — never ``None``. The trade-off is that
+    unscoped callers (test suites, ad-hoc scripts) accumulate into a
+    throwaway object instead of crashing, which matches the
+    ``SessionJournal`` pattern's no-op fallback.
+    """
+    metrics = _current_metrics.get()
+    if metrics is None:
+        metrics = SessionMetrics()
+        _current_metrics.set(metrics)
+    return metrics
+
+
+def set_current_session_metrics(
+    metrics: SessionMetrics | None,
+) -> contextvars.Token[SessionMetrics | None]:
+    """Bind ``metrics`` to the current ContextVar scope. Returns the reset token."""
+    return _current_metrics.set(metrics)
+
+
+@contextmanager
+def session_metrics_scope(
+    *,
+    session_id: str = "",
+    gen_tag: str = "",
+    component: str = "",
+) -> Iterator[SessionMetrics]:
+    """Context manager — bind a fresh ``SessionMetrics`` for the duration of
+    the ``with`` block. Restores the prior value on exit even if an
+    exception propagates.
+
+    Mirrors ``session_journal_scope`` (``core/observability/session_journal.py``)
+    so callers can wrap both inside a single ``ExitStack`` when starting an
+    audit / mutation cycle.
+    """
+    metrics = SessionMetrics(
+        session_id=session_id,
+        gen_tag=gen_tag,
+        component=component,
+        started_at=time.time(),
+    )
+    token = _current_metrics.set(metrics)
+    try:
+        yield metrics
+    finally:
+        _current_metrics.reset(token)

--- a/core/paths.py
+++ b/core/paths.py
@@ -213,7 +213,7 @@ GLOBAL_SCHEDULER_DIR = GEODE_HOME / "scheduler"
 GLOBAL_DIAGNOSTICS_DIR = GEODE_HOME / "diagnostics"
 # P1a + P1c (2026-05-19) — self-improving-loop wiring sprint. Shared cross-loop
 # namespace: ``sessions.jsonl`` (P1a, run-level index, one row per
-# autoresearch/seed-generation run) + ``<session_id>/journal.jsonl``
+# autoresearch/seed-generation run) + ``<session_id>/transcript.jsonl``
 # (P1c, event stream within a single run). See
 # ``docs/plans/2026-05-19-self-improving-loop-wiring-sprint.md``.
 GLOBAL_SELF_IMPROVING_LOOP_DIR = GEODE_HOME / "self-improving-loop"
@@ -378,7 +378,14 @@ GLOBAL_PROJECTS_DIR = GEODE_HOME / "projects"
 CLI_SOCKET_PATH = GEODE_HOME / "cli.sock"
 CLI_STARTUP_LOCK = GEODE_HOME / "cli.startup.lock"
 SERVE_LOG_PATH = GEODE_HOME / "logs" / "serve.log"
-GLOBAL_JOURNAL_DIR = GEODE_HOME / "journal"
+# PR-SESSION-METRICS (2026-05-23) — ``journal/`` depth 제거. 이전엔
+# ``~/.geode/journal/transcripts/<project-slug>/<session_id>.jsonl`` 이중
+# nesting 이었으나 transcript 가 단독 Tier-1 으로 정렬되며 ``journal/``
+# 디렉터리 의미 사라짐. 이제 ``~/.geode/transcripts/<project-slug>/<session_id>.jsonl``.
+# ``GLOBAL_JOURNAL_DIR`` 이름은 backward-compat 으로 alias 유지 (한 release
+# 후 제거 권장).
+GLOBAL_TRANSCRIPTS_DIR = GEODE_HOME / "transcripts"
+GLOBAL_JOURNAL_DIR = GLOBAL_TRANSCRIPTS_DIR  # legacy alias — will be dropped
 GLOBAL_WORKERS_DIR = GEODE_HOME / "workers"
 # v0.95.x layout migration v1 — moved under mcp/ to group with other MCP state.
 # Legacy ``~/.geode/mcp-registry-cache.json`` migrated by

--- a/core/runtime_state/transcript.py
+++ b/core/runtime_state/transcript.py
@@ -1,15 +1,19 @@
 """SessionTranscript — JSONL event stream for session audit trail.
 
 Tier 1 preservation: records every event in a session as an append-only
-JSONL file. Complementary to Journal (Tier 2, summaries) and Snapshot
-(Tier 3, pipeline state).
+JSONL file. Complementary to :class:`SessionMetrics` (Tier 2, cumulative
+aggregate roll-up) and Snapshot (Tier 3, pipeline state).
 
 Captures: user messages, assistant responses, tool calls/results,
-vault saves, costs, errors — everything needed to reconstruct
+vault saves, costs, errors, **lifecycle events** (audit_started /
+config_snapshot / per_dim_scores 등 — pre-PR-SESSION-METRICS 의
+``SessionJournal`` 에서 흡수) — everything needed to reconstruct
 "what exactly happened in this session."
 
-Storage: ~/.geode/journal/transcripts/{project-slug}/{session_id}.jsonl
-(user home, not project dir — matches Claude Code / Codex CLI pattern)
+PR-SESSION-METRICS (2026-05-23) — ``SessionJournal`` folded into this
+Tier-1 surface via :meth:`record_lifecycle_event`. Legacy
+``~/.geode/journal/transcripts/<slug>/`` 디렉터리 한 depth 줄어서
+``~/.geode/transcripts/<slug>/<session_id>.jsonl`` 로 단순화.
 """
 
 from __future__ import annotations
@@ -25,19 +29,24 @@ log = logging.getLogger(__name__)
 
 
 def _get_default_transcript_dir() -> Path:
-    """Return ~/.geode/journal/transcripts/{project-slug}/.
+    """Return ``~/.geode/transcripts/<project-slug>/``.
 
     Project slug is derived from CWD (same pattern as Claude Code).
     Falls back to 'default' if CWD cannot be resolved.
+
+    PR-SESSION-METRICS (2026-05-23) — depth 한 단계 줄임. 이전엔
+    ``~/.geode/journal/transcripts/<slug>/`` 였으나 ``journal/`` 디렉터리의
+    의미가 SessionJournal alias-shim 이후 사라져서 ``transcripts/`` 만으로
+    self-evident. Legacy ``~/.geode/journal/transcripts/`` 안에 있는 파일은
+    layout migrator 가 옮기지 않음 — 30-day cleanup 이 자연 회수.
     """
-    from core.paths import GLOBAL_JOURNAL_DIR
+    from core.paths import GLOBAL_TRANSCRIPTS_DIR
 
     try:
         slug = str(Path.cwd()).replace("/", "-")
     except OSError:
         slug = "default"
-    # P2 (v0.95.x) — was literal `Path.home() / ".geode" / "journal" / "transcripts"`
-    return GLOBAL_JOURNAL_DIR / "transcripts" / slug
+    return GLOBAL_TRANSCRIPTS_DIR / slug
 
 
 DEFAULT_TRANSCRIPT_DIR = _get_default_transcript_dir()
@@ -211,6 +220,53 @@ class SessionTranscript:
                 "summary": _truncate(summary, MAX_INPUT_CHARS),
             }
         )
+
+    def record_lifecycle_event(
+        self,
+        *,
+        event: str,
+        session_id: str = "",
+        gen_tag: str = "",
+        component: str = "",
+        level: str = "info",
+        payload: dict[str, Any] | None = None,
+        ts: float | None = None,
+        file_path: Path | None = None,
+    ) -> None:
+        """Record a free-form lifecycle event — replaces the legacy
+        ``SessionJournal.append(event, payload=...)`` path.
+
+        PR-SESSION-METRICS (2026-05-23) — folded ``SessionJournal`` into the
+        Tier-1 :class:`SessionTranscript`. Schema preserved
+        (``{ts, session_id, gen_tag, component, level, event, payload}``)
+        so existing readers (``tests/core/observability/test_session_journal.py``,
+        operator grep on ``transcript.jsonl`` / legacy ``transcript.jsonl``)
+        keep working.
+
+        ``file_path`` overrides the default ``<dir>/<session_id>.jsonl``
+        layout — used by :class:`SessionJournal` to write to
+        ``<self-improving-loop-dir>/<session_id>/transcript.jsonl`` while
+        still using this Tier-1 schema.
+        """
+        record: dict[str, Any] = {
+            "ts": ts if ts is not None else time.time(),
+            "session_id": session_id or self._session_id,
+            "gen_tag": gen_tag,
+            "component": component,
+            "level": level,
+            "event": event,
+            "payload": payload or {},
+        }
+        target_path = file_path if file_path is not None else self.file_path
+        line = json.dumps(record, ensure_ascii=False)
+        with self._lock:
+            try:
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                with target_path.open("a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+                self._event_count += 1
+            except OSError as exc:
+                log.warning("Transcript lifecycle-event write failed: %s", exc)
 
     # ------------------------------------------------------------------
     # Read

--- a/core/self_improving_loop/dpo_pack.py
+++ b/core/self_improving_loop/dpo_pack.py
@@ -104,7 +104,7 @@ def pair_signature(prompt: str, chosen: str, rejected: str) -> str:
 
 
 def _iter_eval_events(journal_path: Path) -> list[_EvalEvent]:
-    """Read one ``journal.jsonl`` file → list of ``eval_response_recorded`` rows.
+    """Read one ``transcript.jsonl`` file → list of ``eval_response_recorded`` rows.
 
     Lines that fail to parse, lack the canonical event name, or are
     missing required payload fields are silently skipped (the journal
@@ -209,7 +209,7 @@ def build_dpo_pack(
     """Walk ``journal_paths`` → group by prompt → append new pairs to ``pack_path``.
 
     Args:
-        journal_paths: ``journal.jsonl`` files to scan. Missing files are
+        journal_paths: ``transcript.jsonl`` files to scan. Missing files are
             treated as empty (graceful).
         pack_path: Destination JSONL. Created lazily; existing rows are
             preserved + their signatures are honoured for dedup.

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -44,7 +44,6 @@ import subprocess
 import time
 import uuid
 from collections.abc import Callable
-from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -467,90 +466,49 @@ LLMCallable = Callable[[str, str], str]
 
 
 # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger 의 sidecar 캡처.
-# ``_default_llm_call`` 이 ``response.usage`` 를 dict 로 저장하면 ``propose()``
-# 가 같은 process 내에서 읽어 ``Mutation.cost_*`` field 채움. tests inject 한
-# str-returning mock 은 usage 미세팅 → ``Mutation.cost_*`` 가 default 0 / ""
-# 로 남아 ``to_audit_row()`` 가 cost 컬럼 자체 생략 (backward-compat).
+# PR-SESSION-METRICS (2026-05-23) — sidecar pattern 폐기. 13개 곳에 분산된
+# session-scoped state 가 ``core/observability/session_metrics.py:SessionMetrics``
+# 의 ContextVar 로 중앙 집중. ``_default_llm_call`` 이 response.usage 를
+# ``current_session_metrics().accumulate_llm_call(...)`` 로 직접 fold 하고,
+# ``propose()`` 는 같은 ContextVar 의 last-call 4-field snapshot 을 읽는다.
+# Module-level dict / ContextVar[dict] / Proxy shim 의 race-prone 패턴 완전
+# 제거 — claude-code AgentLoopState.totalUsage + hermes _SESSION_ID
+# ContextVar family 의 frontier 정렬.
 #
-# PR-C4.fix-contextvar (2026-05-23) — module-level dict → ContextVar 교체.
-# 초안의 module-level dict 는 (a) pytest-xdist worker 간 격리 깨짐 +
-# (b) future concurrent runner 시 cross-runner race 위험을 가졌다. ContextVar
-# 는 asyncio Task / pytest test 단위로 격리되어 두 문제를 동시에 닫는다.
-#
-# 이전 module-level state 의 backward-compat 노출 (``_LAST_LLM_CALL_USAGE``)
-# 은 더 이상 외부에서 직접 mutate 하면 안 된다 — 테스트는 helper API 만
-# 사용. tests/test_e1_mutation_cost_ledger.py 의 backward-compat 보장.
-# Ruff B039 — mutable default 는 ContextVar 가 process-wide 라 위험. None
-# default + helper 가 _current 시점에 빈 dict 로 lazily set.
-_LAST_LLM_CALL_USAGE_VAR: ContextVar[dict[str, Any] | None] = ContextVar(
-    "_LAST_LLM_CALL_USAGE", default=None
-)
-
-
-def _current_llm_call_usage() -> dict[str, Any]:
-    """Read-only view — caller mutate 금지. 새 dict 를 매번 ContextVar.set 으로."""
-    return _LAST_LLM_CALL_USAGE_VAR.get() or {}
+# 기존 helper 이름 (``_reset_last_llm_call_usage`` / ``_consume_last_llm_call_usage``)
+# 은 thin wrapper 로 보존 — 외부 test 호환성 유지. 새 코드는
+# ``current_session_metrics()`` 직접 호출 권장.
 
 
 def _reset_last_llm_call_usage() -> None:
-    """``_LAST_LLM_CALL_USAGE_VAR`` 를 빈 dict 로 비움 — propose() 가 새 LLM
-    call 직전에 호출. ContextVar.set 은 같은 task / test scope 안에서 effective."""
-    _LAST_LLM_CALL_USAGE_VAR.set({})
+    """SessionMetrics 의 last-call snapshot 만 비움 (cumulative 보존). propose()
+    가 새 LLM call 직전에 호출 — mock LLM 이 accumulate 안 해도 stale
+    per-call 값이 안 새도록."""
+    from core.observability import current_session_metrics
+
+    current_session_metrics().reset_last_call()
 
 
 def _consume_last_llm_call_usage() -> dict[str, Any]:
-    """ContextVar 의 snapshot 을 반환하고 빈 dict 로 reset.
+    """SessionMetrics 의 last-call snapshot 을 dict 로 반환하고 reset.
 
-    Returns 빈 dict 면 LLM call 이 usage 를 emit 안 했거나 mock 이라 캡처 안
-    된 경우 — caller 는 cost 0 / "" 로 처리 (backward-compat).
+    Returns 빈 dict (input/output_tokens 둘 다 0) 면 LLM call 이 usage 를
+    emit 안 했거나 mock 이라 캡처 안 된 경우 — caller 는 cost 0 / "" 로 처리
+    (backward-compat).
     """
-    snapshot = dict(_LAST_LLM_CALL_USAGE_VAR.get() or {})
-    _LAST_LLM_CALL_USAGE_VAR.set({})
+    from core.observability import current_session_metrics
+
+    m = current_session_metrics()
+    snapshot: dict[str, Any] = {}
+    if m.last_call_input_tokens or m.last_call_output_tokens:
+        snapshot = {
+            "input_tokens": m.last_call_input_tokens,
+            "output_tokens": m.last_call_output_tokens,
+            "elapsed_seconds": m.last_call_elapsed_seconds,
+            "model": m.last_call_model,
+        }
+    m.reset_last_call()
     return snapshot
-
-
-# backward-compat shim — test code 가 ``_LAST_LLM_CALL_USAGE.update(...)``
-# 또는 ``_LAST_LLM_CALL_USAGE.clear()`` 형태로 module-level dict 를 mutate
-# 하던 경우 (e.g. tests/test_e1_mutation_cost_ledger.py 의 일부 패턴) 그
-# mutation 이 ContextVar 의 현재 dict 에도 반영되도록 proxy.
-class _UsageProxy:
-    """``_LAST_LLM_CALL_USAGE`` 의 dict-like proxy. ContextVar 의 현재 값에
-    위임. ``update()`` / ``clear()`` / ``__setitem__`` 등의 mutate 가 같은
-    task scope 안의 sidecar 에 즉시 반영."""
-
-    def _backing(self) -> dict[str, Any]:
-        return _LAST_LLM_CALL_USAGE_VAR.get() or {}
-
-    def update(self, *args: Any, **kwargs: Any) -> None:
-        d = dict(self._backing())
-        d.update(*args, **kwargs)
-        _LAST_LLM_CALL_USAGE_VAR.set(d)
-
-    def clear(self) -> None:
-        _LAST_LLM_CALL_USAGE_VAR.set({})
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        d = dict(self._backing())
-        d[key] = value
-        _LAST_LLM_CALL_USAGE_VAR.set(d)
-
-    def __getitem__(self, key: str) -> Any:
-        return self._backing()[key]
-
-    def __contains__(self, key: object) -> bool:
-        return key in self._backing()
-
-    def __eq__(self, other: object) -> bool:
-        return self._backing() == other
-
-    def __repr__(self) -> str:
-        return repr(self._backing())
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._backing().get(key, default)
-
-
-_LAST_LLM_CALL_USAGE = _UsageProxy()
 
 
 def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
@@ -668,24 +626,25 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
             f"mutator LLM call failed (model={model}, provider={provider}): {last_err!r}"
         )
 
-    # PR-SIL-5THEME C4 — usage metadata capture. AgenticResponse 의
-    # ``usage`` 가 ResponseUsage dataclass (input_tokens / output_tokens
-    # / thinking_tokens / cache_*) — ContextVar sidecar 에 저장하면
-    # propose() 가 같은 task scope 에서 읽어 Mutation 에 채워 넣음.
-    # PR-C4.fix-contextvar — ContextVar.set 으로 매번 새 dict 적재 (test
-    # / concurrent runner 격리 보장).
+    # PR-SIL-5THEME C4 + PR-SESSION-METRICS — usage metadata capture.
+    # AgenticResponse 의 ``usage`` (ResponseUsage dataclass: input_tokens /
+    # output_tokens / thinking_tokens / cache_*) 를 SessionMetrics 의
+    # ContextVar 에 직접 fold. last-call snapshot 도 같이 적재 — propose()
+    # 가 동일 ContextVar 에서 읽어 Mutation.cost_* 채움. Module-level
+    # sidecar / dict ContextVar / proxy shim 의 race-prone 패턴 완전 제거.
+    from core.observability import current_session_metrics
+
     usage_obj = getattr(response, "usage", None)
     if usage_obj is not None:
-        _LAST_LLM_CALL_USAGE_VAR.set(
-            {
-                "input_tokens": int(getattr(usage_obj, "input_tokens", 0)),
-                "output_tokens": int(getattr(usage_obj, "output_tokens", 0)),
-                "elapsed_seconds": float(call_elapsed),
-                "model": str(_used_model or model),
-            }
+        current_session_metrics().accumulate_llm_call(
+            input_tokens=int(getattr(usage_obj, "input_tokens", 0)),
+            output_tokens=int(getattr(usage_obj, "output_tokens", 0)),
+            cache_creation_tokens=int(getattr(usage_obj, "cache_creation_tokens", 0)),
+            cache_read_tokens=int(getattr(usage_obj, "cache_read_tokens", 0)),
+            thinking_tokens=int(getattr(usage_obj, "thinking_tokens", 0)),
+            elapsed_seconds=float(call_elapsed),
+            model=str(_used_model or model),
         )
-    else:
-        _LAST_LLM_CALL_USAGE_VAR.set({})
 
     # Adapter normalises to AgenticResponse — concatenate text blocks.
     text_chunks: list[str] = []

--- a/tests/core/observability/test_session_journal.py
+++ b/tests/core/observability/test_session_journal.py
@@ -23,7 +23,7 @@ def _make_journal(tmp_path: Path) -> SessionJournal:
         session_id="s-test",
         gen_tag="autoresearch-test",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
 
@@ -31,7 +31,7 @@ def test_append_writes_jsonl_row(tmp_path: Path) -> None:
     """append() writes one JSONL row with the full schema."""
     journal = _make_journal(tmp_path)
     journal.append("audit_finished", payload={"fitness": 0.5}, ts=1700000000.0)
-    rows = (tmp_path / "journal.jsonl").read_text().splitlines()
+    rows = (tmp_path / "transcript.jsonl").read_text().splitlines()
     assert len(rows) == 1
     payload = json.loads(rows[0])
     assert payload == {
@@ -49,14 +49,14 @@ def test_append_supports_level_and_default_payload(tmp_path: Path) -> None:
     """level kwarg defaults to 'info'; missing payload becomes empty dict."""
     journal = _make_journal(tmp_path)
     journal.append("subagent_failed", level="error", ts=1.0)
-    row = json.loads((tmp_path / "journal.jsonl").read_text().splitlines()[0])
+    row = json.loads((tmp_path / "transcript.jsonl").read_text().splitlines()[0])
     assert row["level"] == "error"
     assert row["payload"] == {}
 
 
 def test_append_creates_parent_dirs(tmp_path: Path) -> None:
     """Nested paths are auto-mkdir'd before write."""
-    deep = tmp_path / "nested" / "deeper" / "journal.jsonl"
+    deep = tmp_path / "nested" / "deeper" / "transcript.jsonl"
     journal = SessionJournal(
         session_id="s",
         gen_tag="g",
@@ -72,7 +72,7 @@ def test_append_appends_not_overwrites(tmp_path: Path) -> None:
     journal = _make_journal(tmp_path)
     for i in range(3):
         journal.append(f"event-{i}", ts=float(i))
-    rows = (tmp_path / "journal.jsonl").read_text().splitlines()
+    rows = (tmp_path / "transcript.jsonl").read_text().splitlines()
     assert len(rows) == 3
     events = [json.loads(r)["event"] for r in rows]
     assert events == ["event-0", "event-1", "event-2"]
@@ -92,7 +92,7 @@ def test_append_swallows_oserror(
         session_id="s",
         gen_tag="g",
         component="autoresearch",
-        path=tmp_path / "nonexistent" / "journal.jsonl",
+        path=tmp_path / "nonexistent" / "transcript.jsonl",
     )
     journal.append("event")  # Must not raise.
 
@@ -120,7 +120,7 @@ def test_session_journal_scope_restores_on_exception(tmp_path: Path) -> None:
 
 
 def test_default_path_uses_geode_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Unset path falls back to ``GLOBAL_SELF_IMPROVING_LOOP_DIR`` / <session> / journal.jsonl."""
+    """Unset path falls back to ``GLOBAL_SELF_IMPROVING_LOOP_DIR`` / <session> / transcript.jsonl."""
     fake_home = tmp_path / "home"
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
     # Reload both core.paths and core.observability.session_journal so
@@ -137,7 +137,7 @@ def test_default_path_uses_geode_home(monkeypatch: pytest.MonkeyPatch, tmp_path:
         gen_tag="g",
         component="autoresearch",
     )
-    expected = fake_home / ".geode" / "self-improving-loop" / "s-default" / "journal.jsonl"
+    expected = fake_home / ".geode" / "self-improving-loop" / "s-default" / "transcript.jsonl"
     assert journal.path == expected
     journal.append("event")
     assert expected.is_file()
@@ -178,7 +178,7 @@ def test_hook_handlers_route_subagent_events_to_journal(tmp_path: Path) -> None:
             {"task_id": "t-2", "error": "boom", "session_id": "s"},
         )
 
-    rows = [json.loads(r) for r in (tmp_path / "journal.jsonl").read_text().splitlines()]
+    rows = [json.loads(r) for r in (tmp_path / "transcript.jsonl").read_text().splitlines()]
     events = [r["event"] for r in rows]
     levels = [r["level"] for r in rows]
     assert events == ["subagent_started", "subagent_completed", "subagent_failed"]

--- a/tests/plugins/petri_audit/test_credential_source.py
+++ b/tests/plugins/petri_audit/test_credential_source.py
@@ -475,7 +475,7 @@ def _emit_test_journal(tmp_path):
         session_id="s-p1b",
         gen_tag="gen-p1b",
         component="autoresearch",
-        path=sip_home / "s-p1b" / "journal.jsonl",
+        path=sip_home / "s-p1b" / "transcript.jsonl",
     )
     return journal, sip_home
 

--- a/tests/plugins/petri_audit/test_user_overrides.py
+++ b/tests/plugins/petri_audit/test_user_overrides.py
@@ -420,7 +420,7 @@ def test_read_role_emits_journal_when_self_improving_loop_unavailable(
         session_id="s-legacy",
         gen_tag="gen-legacy",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
     # Force the lazy import inside _read_role_from_self_improving_loop to fail
@@ -463,7 +463,7 @@ def test_read_role_no_emit_when_self_improving_loop_available(
         session_id="s-newpath",
         gen_tag="gen-newpath",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with session_journal_scope(journal):
         result = uo._read_role_from_self_improving_loop("auditor")

--- a/tests/plugins/seed_generation/test_cli.py
+++ b/tests/plugins/seed_generation/test_cli.py
@@ -395,7 +395,7 @@ def test_run_audit_seeds_emits_cost_preview_into_session_journal(tmp_path: Any) 
     work begins. Verifies the outer-scope wiring introduced in PR-P2."""
     import json
 
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     with (
         patch("plugins.seed_generation.cli.pick_bindings", return_value=_good_picker()),
         patch("plugins.seed_generation.cli.run_pre_flight", return_value=PreFlightReport()),
@@ -432,7 +432,7 @@ def test_run_audit_seeds_emits_cost_preview_into_session_journal(tmp_path: Any) 
 
 
 def test_run_audit_seeds_emits_preflight_passed_when_clean(tmp_path: Any) -> None:
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     from core.observability import SessionJournal as RealJournal
 
     def _bind(**kwargs: Any) -> Any:
@@ -463,7 +463,7 @@ def test_run_audit_seeds_emits_preflight_passed_when_clean(tmp_path: Any) -> Non
 def test_run_audit_seeds_emits_preflight_failed_with_issue_list(tmp_path: Any) -> None:
     """The dominant pre-PR observability gap — preflight error path now
     surfaces the structured issue list before exit code 1."""
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     bad_report = PreFlightReport(
         issues=[
             PreFlightIssue(
@@ -518,7 +518,7 @@ def test_run_audit_seeds_emits_preflight_failed_with_issue_list(tmp_path: Any) -
 
 
 def test_run_audit_seeds_emits_user_aborted_on_decline(tmp_path: Any) -> None:
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     from core.observability import SessionJournal as RealJournal
 
     def _bind(**kwargs: Any) -> Any:

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -245,7 +245,7 @@ def test_pipeline_emits_phase_started_finished_for_every_phase(tmp_path) -> None
         session_id="t-p1c",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with session_journal_scope(journal):
         asyncio.run(Pipeline(state, registry).arun())
@@ -293,7 +293,7 @@ def test_pipeline_emits_phase_failed_soft_failure(tmp_path) -> None:
         session_id="t-soft",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with session_journal_scope(journal):
         asyncio.run(Pipeline(state, registry).arun())
@@ -320,7 +320,7 @@ def test_pipeline_emits_phase_failed_hard_failure(tmp_path) -> None:
         session_id="t-hard",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with (
         session_journal_scope(journal),
@@ -343,7 +343,7 @@ def test_registry_register_replace_emits_agent_reregistered(tmp_path) -> None:
         session_id="t-rereg",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     registry = PipelineRegistry()
     registry.register(_StubAgent("generator"))

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1678,7 +1678,7 @@ _SESSIONS_JSONL_CANONICAL_FIELDS = frozenset(
 
 
 def _journal_path(tmp_path: Path, session_id: str) -> Path:
-    return tmp_path / "self-improving-loop" / session_id / "journal.jsonl"
+    return tmp_path / "self-improving-loop" / session_id / "transcript.jsonl"
 
 
 def _redirect_journal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1744,7 +1744,7 @@ def test_emit_journal_noops_on_empty_session_id(
     _emit_journal("", "gen-x", "audit_started", payload={"dry_run": True})
     # No journal file should be created.
     assert not (tmp_path / "self-improving-loop").exists() or not any(
-        (tmp_path / "self-improving-loop").rglob("journal.jsonl")
+        (tmp_path / "self-improving-loop").rglob("transcript.jsonl")
     )
 
 
@@ -1756,7 +1756,7 @@ def test_emit_journal_noops_on_empty_gen_tag(
     _redirect_journal(tmp_path, monkeypatch)
     _emit_journal("s-x", "", "audit_started", payload={"dry_run": True})
     assert not (tmp_path / "self-improving-loop").exists() or not any(
-        (tmp_path / "self-improving-loop").rglob("journal.jsonl")
+        (tmp_path / "self-improving-loop").rglob("transcript.jsonl")
     )
 
 
@@ -1806,7 +1806,7 @@ def _drive_main_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tupl
     # Find the single run dir under sip_home (session_id resolved at runtime).
     run_dirs = [p for p in sip_home.iterdir() if p.is_dir()]
     assert len(run_dirs) == 1, f"expected one run dir under {sip_home}, got {run_dirs}"
-    journal_path = run_dirs[0] / "journal.jsonl"
+    journal_path = run_dirs[0] / "transcript.jsonl"
     sessions_path = sip_home / "sessions.jsonl"
     return exit_code, journal_path, sessions_path
 

--- a/tests/test_e1_mutation_cost_ledger.py
+++ b/tests/test_e1_mutation_cost_ledger.py
@@ -18,11 +18,12 @@ from unittest.mock import MagicMock
 
 from core.self_improving_loop.attribution import compute_attribution
 from core.self_improving_loop.runner import (
-    _LAST_LLM_CALL_USAGE,
     Mutation,
     _consume_last_llm_call_usage,
     _reset_last_llm_call_usage,
 )
+
+from core.observability import current_session_metrics, session_metrics_scope
 
 # ---------------------------------------------------------------------------
 # 1. Mutation cost fields
@@ -88,34 +89,55 @@ def test_mutation_to_audit_row_partial_cost_fields() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2. _LAST_LLM_CALL_USAGE sidecar capture
+# 2. SessionMetrics last-call snapshot capture (PR-SESSION-METRICS)
 # ---------------------------------------------------------------------------
+#
+# PR-SIL-5THEME C4 의 module-level ``_LAST_LLM_CALL_USAGE`` dict + PR-C4.fix-
+# contextvar 의 ``_LAST_LLM_CALL_USAGE_VAR`` ContextVar + ``_UsageProxy`` shim
+# 이 SessionMetrics 의 last-call 4-field snapshot 으로 흡수됨. Test 는
+# ``current_session_metrics()`` ContextVar 를 통해 직접 mutate / read.
 
 
-def test_reset_last_llm_call_usage_clears_module_dict() -> None:
-    """``_reset_last_llm_call_usage`` 는 module-level dict 를 비움 — propose()
-    가 LLM call 직전 호출해서 이전 mutation 의 usage 잔여 차단."""
-    _LAST_LLM_CALL_USAGE["dirty"] = "value"
-    _reset_last_llm_call_usage()
-    assert _LAST_LLM_CALL_USAGE == {}
+def test_reset_last_llm_call_usage_clears_session_metrics_last_call() -> None:
+    """``_reset_last_llm_call_usage`` 는 SessionMetrics 의 last-call snapshot
+    만 비움 (cumulative 보존). propose() 가 LLM call 직전 호출."""
+    with session_metrics_scope(session_id="test"):
+        m = current_session_metrics()
+        m.last_call_input_tokens = 100
+        m.last_call_model = "test-model"
+        _reset_last_llm_call_usage()
+        assert m.last_call_input_tokens == 0
+        assert m.last_call_model == ""
 
 
 def test_consume_last_llm_call_usage_returns_snapshot_and_clears() -> None:
-    """``_consume_last_llm_call_usage`` 가 snapshot 반환 + module dict 비움.
-
-    Atomic — return-and-clear 의 race condition 자체가 single-threaded
-    propose() 사이클 안에서 없도록.
-    """
-    _LAST_LLM_CALL_USAGE.update({"input_tokens": 100, "output_tokens": 50})
-    snapshot = _consume_last_llm_call_usage()
-    assert snapshot == {"input_tokens": 100, "output_tokens": 50}
-    assert _LAST_LLM_CALL_USAGE == {}
+    """``_consume_last_llm_call_usage`` 가 snapshot 반환 + SessionMetrics 의
+    last-call 슬롯 비움. Race condition 없음 — 같은 ContextVar 안의 atomic
+    read-and-clear."""
+    with session_metrics_scope(session_id="test"):
+        m = current_session_metrics()
+        m.accumulate_llm_call(
+            input_tokens=100,
+            output_tokens=50,
+            elapsed_seconds=1.23,
+            model="claude-opus-4-7",
+        )
+        snapshot = _consume_last_llm_call_usage()
+        assert snapshot == {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "elapsed_seconds": 1.23,
+            "model": "claude-opus-4-7",
+        }
+        # last-call 슬롯 비워짐, cumulative 는 보존
+        assert m.last_call_input_tokens == 0
+        assert m.input_tokens == 100  # cumulative untouched
 
 
 def test_consume_last_llm_call_usage_empty_when_unset() -> None:
-    """sidecar 비어 있을 때 (mock LLM 호출 후) consume 은 빈 dict 반환."""
-    _LAST_LLM_CALL_USAGE.clear()
-    assert _consume_last_llm_call_usage() == {}
+    """LLM call mock 이 accumulate 안 했으면 consume 은 빈 dict 반환."""
+    with session_metrics_scope(session_id="test"):
+        assert _consume_last_llm_call_usage() == {}
 
 
 # ---------------------------------------------------------------------------
@@ -189,14 +211,12 @@ def test_propose_populates_cost_from_sidecar(
     )
 
     def llm_call_with_usage(_sys: str, _usr: str) -> str:
-        # production _default_llm_call 처럼 sidecar 에 usage 적재
-        _LAST_LLM_CALL_USAGE.update(
-            {
-                "input_tokens": 2500,
-                "output_tokens": 1200,
-                "elapsed_seconds": 4.567,
-                "model": "claude-opus-4-7",
-            }
+        # production _default_llm_call 처럼 SessionMetrics accumulate
+        current_session_metrics().accumulate_llm_call(
+            input_tokens=2500,
+            output_tokens=1200,
+            elapsed_seconds=4.567,
+            model="claude-opus-4-7",
         )
         return response_json
 
@@ -217,7 +237,8 @@ def test_propose_populates_cost_from_sidecar(
         audit_log_path=tmp_path / "mutations.jsonl",
     )
 
-    proposal = runner.propose()
+    with session_metrics_scope(session_id="test"):
+        proposal = runner.propose()
     m = proposal.mutation
     assert m.cost_input_tokens == 2500
     assert m.cost_output_tokens == 1200
@@ -225,15 +246,13 @@ def test_propose_populates_cost_from_sidecar(
     assert m.cost_model == "claude-opus-4-7"
 
 
-def test_propose_clears_sidecar_before_call(
+def test_propose_clears_last_call_before_invocation(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
-    """이전 mutation 의 sidecar 잔여 (e.g. 이전 propose() 가 실패하고 race
-    한 경우) 가 다음 propose() 의 mutation 에 끼지 못함. _reset_last_llm_call_usage
-    가 LLM call 직전 fire."""
-    # 이전 mutation 의 잔여 sidecar
-    _LAST_LLM_CALL_USAGE.update({"input_tokens": 999, "stale": True})
+    """이전 mutation 의 last-call snapshot 잔여 (e.g. 이전 propose() 가 실패한
+    경우) 가 다음 propose() 의 mutation 에 끼지 못함. ``_reset_last_llm_call_usage``
+    가 LLM call 직전 fire 해서 SessionMetrics 의 last-call 슬롯 비움."""
 
     response_json = json.dumps(
         {
@@ -244,8 +263,7 @@ def test_propose_clears_sidecar_before_call(
     )
 
     def mock_llm(_sys: str, _usr: str) -> str:
-        # mock 는 sidecar 채우지 않음 (test inject 의 일반 패턴)
-        # → propose() 가 _reset 호출했으므로 stale data 미흡수
+        # mock 는 SessionMetrics accumulate 안 함 → reset 후 0 유지
         return response_json
 
     from core.self_improving_loop import runner as runner_mod
@@ -264,9 +282,14 @@ def test_propose_clears_sidecar_before_call(
         rerun_enabled=False,
         audit_log_path=tmp_path / "mutations.jsonl",
     )
-    proposal = runner.propose()
+    with session_metrics_scope(session_id="test") as m:
+        # 이전 mutation 의 last-call 잔여 시뮬레이션
+        m.last_call_input_tokens = 999
+        m.last_call_model = "stale-model"
+        proposal = runner.propose()
     # stale 999 가 안 새들어옴 — default 0
     assert proposal.mutation.cost_input_tokens == 0
+    assert proposal.mutation.cost_model == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_m4_0_eval_event.py
+++ b/tests/test_m4_0_eval_event.py
@@ -29,7 +29,7 @@ from core.self_improving_loop.eval_journaling import (
 
 @pytest.fixture
 def journal_path(tmp_path: Path) -> Iterator[Path]:
-    yield tmp_path / "journal.jsonl"
+    yield tmp_path / "transcript.jsonl"
 
 
 def _read_events(path: Path) -> list[dict]:

--- a/tests/test_m4_1_dpo_pack.py
+++ b/tests/test_m4_1_dpo_pack.py
@@ -36,7 +36,7 @@ from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
 
 @pytest.fixture
 def journal_path(tmp_path: Path) -> Iterator[Path]:
-    yield tmp_path / "session-A" / "journal.jsonl"
+    yield tmp_path / "session-A" / "transcript.jsonl"
 
 
 @pytest.fixture
@@ -206,8 +206,8 @@ def test_new_pair_appended_on_rerun(journal_path: Path, pack_path: Path) -> None
 
 def test_multi_journal_merge(tmp_path: Path, pack_path: Path) -> None:
     """Two journals (different sessions) feed the same prompt → cross-session pair."""
-    j1 = tmp_path / "s1" / "journal.jsonl"
-    j2 = tmp_path / "s2" / "journal.jsonl"
+    j1 = tmp_path / "s1" / "transcript.jsonl"
+    j2 = tmp_path / "s2" / "transcript.jsonl"
     with session_journal_scope(_journal(j1, session_id="s1")):
         emit_eval_response_recorded(
             prompt="shared", response="great", fitness_score=0.95, source="petri_audit"

--- a/tests/test_ol_c1_emit_eval_caller.py
+++ b/tests/test_ol_c1_emit_eval_caller.py
@@ -28,7 +28,7 @@ def _journal_with_path(tmp_path: Path) -> SessionJournal:
         session_id="ol-c1-test",
         gen_tag="auto-test",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
 

--- a/tests/test_retry_policy_sot.py
+++ b/tests/test_retry_policy_sot.py
@@ -140,7 +140,7 @@ def test_on_retry_emits_journal_event(monkeypatch: Any) -> None:
                 elapsed_s=3.45,
                 error_type="InternalServerError",
             )
-        rows = (real_tmp / "s-retry" / "journal.jsonl").read_text().splitlines()
+        rows = (real_tmp / "s-retry" / "transcript.jsonl").read_text().splitlines()
         assert len(rows) == 1
         record = json.loads(rows[0])
         assert record["event"] == "llm_retry"
@@ -190,7 +190,7 @@ def test_on_retry_overloaded_emits_warn_level(monkeypatch: Any) -> None:
                 elapsed_s=0.5,
                 error_type="OverloadedError",
             )
-        rows = (real_tmp / "s-529" / "journal.jsonl").read_text().splitlines()
+        rows = (real_tmp / "s-529" / "transcript.jsonl").read_text().splitlines()
         record = json.loads(rows[0])
         assert record["event"] == "llm_retry"
         assert record["level"] == "warn"

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -407,7 +407,7 @@ def _make_journal(tmp_path: Path):
         session_id="p2-test",
         gen_tag="test",
         component="config-test",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
 

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -1,0 +1,280 @@
+"""PR-SESSION-METRICS — central session-scoped state aggregator tests.
+
+Replaces the ``_LAST_LLM_CALL_USAGE`` module-level sidecar from PR-SIL-5THEME
+C4 with a ``SessionMetrics`` ContextVar that mirrors claude-code
+``AgentLoopState.totalUsage`` + hermes ``sessions`` table column shape.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.observability import (
+    SessionMetrics,
+    current_session_metrics,
+    session_metrics_scope,
+    set_current_session_metrics,
+)
+
+# ---------------------------------------------------------------------------
+# 1. SessionMetrics dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+def test_session_metrics_defaults_zero_or_empty() -> None:
+    """Fresh ``SessionMetrics()`` 가 모든 numeric field 0, string field ""."""
+    m = SessionMetrics()
+    assert m.session_id == ""
+    assert m.input_tokens == 0
+    assert m.output_tokens == 0
+    assert m.cache_creation_tokens == 0
+    assert m.cache_read_tokens == 0
+    assert m.thinking_tokens == 0
+    assert m.estimated_cost_usd == 0.0
+    assert m.elapsed_seconds == 0.0
+    assert m.model_used == ""
+    assert m.api_call_count == 0
+    assert m.tool_call_count == 0
+    assert m.message_count == 0
+    assert m.mutation_count == 0
+    assert m.audit_call_count == 0
+    assert m.billing_provider == ""
+    assert m.billing_mode == ""
+    assert m.retry_count == 0
+    assert m.circuit_breaker_trips == {}
+    assert m.error_count_by_type == {}
+    assert m.rollback_count == 0
+    assert m.fitness_before is None
+    assert m.fitness_after is None
+    assert m.last_call_input_tokens == 0
+    assert m.missing_dims_total == 0
+    assert m.missing_benches_total == 0
+    assert m.cross_validation_conflict_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. accumulate_llm_call — additive + last-call snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_accumulate_llm_call_additive() -> None:
+    """N 번의 call 이 cumulative field 에 + 누적."""
+    m = SessionMetrics()
+    m.accumulate_llm_call(input_tokens=100, output_tokens=50, elapsed_seconds=1.0)
+    m.accumulate_llm_call(input_tokens=200, output_tokens=80, elapsed_seconds=2.5)
+    assert m.input_tokens == 300
+    assert m.output_tokens == 130
+    assert m.elapsed_seconds == 3.5
+    assert m.api_call_count == 2
+
+
+def test_accumulate_llm_call_last_call_snapshot_overwrites() -> None:
+    """``last_call_*`` field 는 매 call 마다 *덮어쓰기* (cumulative 아님)."""
+    m = SessionMetrics()
+    m.accumulate_llm_call(input_tokens=100, output_tokens=50, model="a")
+    m.accumulate_llm_call(input_tokens=200, output_tokens=80, model="b")
+    # 마지막 call 값만 last_call_* 에 남음
+    assert m.last_call_input_tokens == 200
+    assert m.last_call_output_tokens == 80
+    assert m.last_call_model == "b"
+
+
+def test_reset_last_call_preserves_cumulative() -> None:
+    """``reset_last_call()`` 는 last_call_* 만 비우고 cumulative 보존."""
+    m = SessionMetrics()
+    m.accumulate_llm_call(input_tokens=100, output_tokens=50, model="a")
+    m.reset_last_call()
+    assert m.last_call_input_tokens == 0
+    assert m.last_call_model == ""
+    # cumulative untouched
+    assert m.input_tokens == 100
+    assert m.output_tokens == 50
+    assert m.api_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Counter / accumulator API
+# ---------------------------------------------------------------------------
+
+
+def test_increment_apis() -> None:
+    m = SessionMetrics()
+    m.increment_tool_call()
+    m.increment_tool_call(3)
+    m.increment_message(5)
+    m.increment_mutation()
+    m.increment_audit_call(2)
+    assert m.tool_call_count == 4
+    assert m.message_count == 5
+    assert m.mutation_count == 1
+    assert m.audit_call_count == 2
+
+
+def test_record_retry_and_circuit_breaker() -> None:
+    m = SessionMetrics()
+    m.record_retry()
+    m.record_retry("anthropic")
+    m.record_circuit_breaker_trip("anthropic")
+    m.record_circuit_breaker_trip("anthropic")
+    m.record_circuit_breaker_trip("openai")
+    assert m.retry_count == 2
+    assert m.circuit_breaker_trips == {"anthropic": 2, "openai": 1}
+
+
+def test_record_error_by_type() -> None:
+    m = SessionMetrics()
+    m.record_error("RateLimitError")
+    m.record_error("RateLimitError")
+    m.record_error("OverloadedError")
+    assert m.error_count_by_type == {"RateLimitError": 2, "OverloadedError": 1}
+
+
+def test_record_goodhart() -> None:
+    m = SessionMetrics()
+    m.record_goodhart(missing_dims=3, missing_benches=2, cross_validation_conflict=True)
+    m.record_goodhart(missing_dims=1, cross_validation_conflict=False)
+    assert m.missing_dims_total == 4
+    assert m.missing_benches_total == 2
+    assert m.cross_validation_conflict_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. to_session_row — persistence shape (hermes / paperclip parity)
+# ---------------------------------------------------------------------------
+
+
+def test_to_session_row_has_all_expected_keys() -> None:
+    """Hermes sessions 테이블 column 패리티 — 핵심 field 모두 row 에 emit."""
+    m = SessionMetrics(session_id="s1", gen_tag="g1", component="autoresearch", started_at=1.0)
+    row = m.to_session_row()
+    expected = {
+        "session_id",
+        "gen_tag",
+        "component",
+        "started_at",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "thinking_tokens",
+        "estimated_cost_usd",
+        "elapsed_seconds",
+        "model_used",
+        "api_call_count",
+        "tool_call_count",
+        "message_count",
+        "mutation_count",
+        "audit_call_count",
+        "billing_provider",
+        "billing_mode",
+        "retry_count",
+        "circuit_breaker_trips",
+        "error_count_by_type",
+        "rollback_count",
+        "fitness_before",
+        "fitness_after",
+        "cohort_tag",
+        "missing_dims_total",
+        "missing_benches_total",
+        "cross_validation_conflict_count",
+    }
+    assert expected.issubset(set(row.keys()))
+
+
+def test_to_session_row_rounds_cost_and_elapsed() -> None:
+    """Float field 는 round (6 / 4 자리) — JSONL serialization noise 차단."""
+    m = SessionMetrics()
+    m.estimated_cost_usd = 0.123456789
+    m.elapsed_seconds = 1.23456789
+    row = m.to_session_row()
+    assert row["estimated_cost_usd"] == 0.123457
+    assert row["elapsed_seconds"] == 1.2346
+
+
+# ---------------------------------------------------------------------------
+# 5. ContextVar lifecycle — session_metrics_scope
+# ---------------------------------------------------------------------------
+
+
+def test_current_session_metrics_lazy_init_when_unscoped() -> None:
+    """Scope 밖에서 ``current_session_metrics()`` 호출 → 빈 SessionMetrics() 반환
+    (SessionJournal 의 no-op fallback 패턴 일치)."""
+    set_current_session_metrics(None)
+    m = current_session_metrics()
+    assert isinstance(m, SessionMetrics)
+
+
+def test_session_metrics_scope_isolates_nested() -> None:
+    """``session_metrics_scope`` 가 inner / outer scope 격리. exit 시 outer 복원."""
+    set_current_session_metrics(None)
+    with session_metrics_scope(session_id="outer"):
+        outer = current_session_metrics()
+        outer.input_tokens = 100
+        with session_metrics_scope(session_id="inner"):
+            inner = current_session_metrics()
+            assert inner.session_id == "inner"
+            assert inner.input_tokens == 0  # fresh
+            inner.input_tokens = 200
+        # outer 복원, inner mutation 무영향
+        assert current_session_metrics().session_id == "outer"
+        assert current_session_metrics().input_tokens == 100
+
+
+def test_session_metrics_scope_started_at_set() -> None:
+    """``session_metrics_scope`` 가 started_at 을 자동 stamp."""
+    before = time.time()
+    with session_metrics_scope(session_id="s") as m:
+        after = time.time()
+        assert before <= m.started_at <= after
+
+
+def test_session_metrics_scope_restores_on_exception() -> None:
+    """Exception 이 propagate 해도 outer ContextVar 복원."""
+    set_current_session_metrics(None)
+    outer_metrics = SessionMetrics(session_id="outer")
+    set_current_session_metrics(outer_metrics)
+    try:
+        with session_metrics_scope(session_id="inner"):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert current_session_metrics() is outer_metrics
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration with _default_llm_call / propose() (C4 absorption)
+# ---------------------------------------------------------------------------
+
+
+def test_session_metrics_accumulates_through_propose_helper_api(monkeypatch: Any) -> None:
+    """C4 의 ``_reset_last_llm_call_usage`` / ``_consume_last_llm_call_usage``
+    가 SessionMetrics 와 정확히 sync — backward-compat path 검증."""
+    from core.self_improving_loop.runner import (
+        _consume_last_llm_call_usage,
+        _reset_last_llm_call_usage,
+    )
+
+    with session_metrics_scope(session_id="test"):
+        m = current_session_metrics()
+        # production _default_llm_call 시뮬레이션
+        m.accumulate_llm_call(
+            input_tokens=500,
+            output_tokens=200,
+            elapsed_seconds=2.0,
+            model="claude-opus-4-7",
+        )
+        # propose() 가 _consume 으로 회수
+        snapshot = _consume_last_llm_call_usage()
+        assert snapshot["input_tokens"] == 500
+        assert snapshot["output_tokens"] == 200
+        # cumulative 보존
+        assert m.input_tokens == 500
+        # 다음 propose() 전 _reset
+        _reset_last_llm_call_usage()
+        assert m.last_call_input_tokens == 0
+        # 두 번째 LLM call 시뮬레이션
+        m.accumulate_llm_call(input_tokens=300, output_tokens=100, model="claude-sonnet-4-6")
+        # cumulative = 첫 call (500) + 두 번째 call (300) = 800
+        assert m.input_tokens == 800
+        assert m.api_call_count == 2


### PR DESCRIPTION
## Summary
- 13개 곳에 분산된 session-scoped state 를 ``SessionMetrics`` ContextVar 로 중앙집중
- PR-SIL-5THEME C4 의 ``_LAST_LLM_CALL_USAGE`` sidecar race 흡수 (PR #1530 flaky 해소)
- ``SessionJournal`` → ``SessionTranscript`` alias-shim, 269 callsite 변경 0
- ``journal/`` 디렉터리 depth 축소: ``~/.geode/journal/transcripts/`` → ``~/.geode/transcripts/``
- ``journal.jsonl`` → ``transcript.jsonl`` (mass rename, 단일 Tier-1 명명)

## Why
**13-way 분산 → 중앙집중 (Tier 2)**. Session-scoped state 가 모듈마다 다르게 관리 (module dict / ContextVar / TokenTracker singleton / RunLog / UsageStore daily / SessionJournal / 등). C4 의 sidecar race 가 그 분산의 한 증상 — 진짜 fix 는 race-prone sidecar 가 *왜 module-level 으로 떠 있는가* 의 architectural 답.

**3-Tier preservation 정합 회복**. ``core/runtime_state/transcript.py`` docstring 이 이미 정의했던 3-Tier (Transcript / Journal-summary / Snapshot) 가 실제로는 SessionJournal 이 별도 Tier 1 event log 로 drift. SessionMetrics 가 의도된 Tier 2 자리 (cumulative aggregate roll-up) 를 채우고, SessionJournal 은 Tier 1 의 alias 로 흡수 — frontier (Claude Code transcript / OpenClaw transcript / Hermes messages) 와 명명 정렬.

**Frontier 정렬 — 4 references 모두**:
- Claude Code: ``AgentLoopState.totalUsage`` per-loop instance state
- Hermes: ``sessions`` SQLite table column + ``_SESSION_ID: ContextVar`` family
- Paperclip: ``usageJson`` JSONB column
- OpenClaw: ``CostUsageTotals`` derived view

## Changes
| File | Change |
|------|--------|
| ``core/observability/session_metrics.py`` (신규, 320 LOC) | ``SessionMetrics`` dataclass + ContextVar + ``session_metrics_scope`` |
| ``core/observability/__init__.py`` | export SessionMetrics + helpers |
| ``core/observability/session_journal.py`` | thin alias-shim — SessionTranscript 로 delegating |
| ``core/runtime_state/transcript.py`` | ``record_lifecycle_event(...)`` 메서드 신설 |
| ``core/paths.py`` | ``GLOBAL_TRANSCRIPTS_DIR`` 신규 + ``GLOBAL_JOURNAL_DIR`` legacy alias |
| ``core/cli/cmd_lifecycle.py`` | disk usage label ``"journal"`` → ``"transcripts"`` |
| ``core/self_improving_loop/runner.py`` | ``_LAST_LLM_CALL_USAGE`` sidecar 제거 → ``current_session_metrics()`` 직접 호출 |
| 269 callsite (core/ + autoresearch/ + plugins/ + tests/) | ``journal.jsonl`` → ``transcript.jsonl`` mass rename (schema 무변동) |
| ``tests/test_session_metrics.py`` (신규, 230 LOC) | 15 tests |
| ``tests/test_e1_mutation_cost_ledger.py`` | sidecar import 제거, SessionMetrics ContextVar pattern 으로 마이그레이션 |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| C4 sidecar race (PR #1530 flaky) | ✅ 해소 | ContextVar 단일 객체 안의 last-call snapshot |
| SessionJournal 별도 객체 | ✅ alias-shim 으로 보존 | 269 callsite 변경 0, transcript SoT |
| 13-way 분산 state | ✅ Tier 2 중앙집중 | TokenTracker / UsageStore / OAuth quota 등은 grain 다른 Tier (별도 유지) |
| SessionCheckpoint Tier 3 drift | ⏳ deferred | 별도 sprint — ``project_session_checkpoint_alignment.md`` 메모리 |
| Hermes / Claude Code 명명 정렬 | ✅ | transcript / messages / SessionMeta 와 일치 |

## Verification
- [x] ``uv run ruff check core/ tests/ plugins/ autoresearch/`` — clean
- [x] ``uv run ruff format --check ...`` — clean
- [x] ``uv run mypy core/ plugins/ autoresearch/ scripts/`` — clean (448 source files)
- [x] ``uv run lint-imports`` — 4 contracts kept
- [x] ``pytest -n auto --dist=loadfile tests/ -m "not live"`` — **6849 passed** (이전 6834 + 15 new, full xdist 통과)
- [x] checkpoint tests: 38 passed (SessionCheckpoint 작동 unchanged)
- [x] C4 flaky 재현 안 됨 (격리 + xdist 둘 다)

## Reference
- Frontier 4-source 비교: claude-code-ref / hermes-agent / paperclip / openclaw — 모두 timeline ↔ aggregate 분리
- ``~/.claude/projects/-Users-mango-workspace-geode/memory/project_session_checkpoint_alignment.md`` — SessionCheckpoint 다음 sprint plan
- PR #1530 close 후 release/v0.99.42 rotation 은 본 PR 머지 후 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)