### PR TITLE
release: v0.99.42 — SessionMetrics central-isation + SessionJournal absorption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.42] - 2026-05-23
+
+> Observability central-isation release. ``SessionMetrics`` 신설 (Tier 2 of
+> 3-Tier preservation), ``SessionJournal`` → ``SessionTranscript`` alias-
+> shim 흡수, ``journal/`` directory depth 축소. PR-SIL-5THEME C4 의 sidecar
+> race 가 SessionMetrics ContextVar 단일 객체로 흡수되며 영구 해소. +15
+> tests (6834 → 6849).
+
 ### Added
 
 - **`SessionMetrics` — session-scoped state aggregator (Tier 2 of 3-Tier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.41
+- **Version**: 0.99.42
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 355 core + 58 plugins = 413
-- **Tests**: 6834 (+5 live)
+- **Tests**: 6849 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.41 — Long-running Autonomous Execution Harness
+# GEODE v0.99.42 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.42**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.41 — Long-running Autonomous Execution Harness
+# GEODE v0.99.42 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.42**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.41"
+version = "0.99.42"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.41"
+version = "0.99.42"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Version stamp bump 0.99.41 → 0.99.42 across 5 locations (CHANGELOG / pyproject.toml / uv.lock / CLAUDE.md / README × 2)
- CHANGELOG [Unreleased] → [0.99.42] - 2026-05-23 (observability central-isation release header)
- Test count metric: 6834 → 6849 (+15 new test_session_metrics)

## Why
Rotation pattern (release/* → develop → main). v0.99.42 packages PR #1531 — SessionMetrics 신설, SessionJournal → SessionTranscript alias-shim 흡수, `journal/` directory depth 축소, `journal.jsonl` → `transcript.jsonl` 단일화. PR-SIL-5THEME C4 의 sidecar race 가 ContextVar 단일 객체로 영구 해소.

## Verification
- [x] `uv run ruff check core/ tests/ plugins/ autoresearch/` — clean
- [x] `uv run mypy core/ plugins/ autoresearch/ scripts/` — clean (448 source files)
- [x] `pytest -n auto --dist=loadfile tests/ -m "not live"` — **6849 passed** (no flaky)
- [x] Version stamps verified in 5 locations
- [x] C4 race regression test — green (test_propose_populates_cost_from_sidecar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)