### PR TITLE
release: v0.99.42 — develop → main pass-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,104 @@ functional change.
   ``adapter`` names via a single SoT table — both naming schemes are
   accepted in ``[seed_generation.role.<role>]`` overrides.
 
+- **PR-SIL-5THEME C2 — Bench S6b production wiring**. ADR-012 §S6
+  (schema + math + cross-validation gate, C1 amendment 로 ADR 측 명세
+  완료) 의 production path 가 모두 silently 끊겼던 9 disconnect 를 닫
+  는 7-bench inspect_ai federation collector + 4-axis fitness 활성 +
+  Goodhart cross-validation gate fire + observability 4-axis 컬럼 확장.
+
+  **Collector 실구현** — ``autoresearch/bench_means.py`` 의
+  ``collect_bench_means_from_inspect_ai`` 가 placeholder
+  (``return None``) → ``BenchProvenance`` dataclass 반환으로 교체.
+  ``BENCH_PORT_MAP`` 7 entry (F1.b LCB-Pro substitution 반영) 가
+  ``inspect-evals`` 6 bench (``livecodebench_pro`` / ``tau2_telecom``
+  / ``gpqa_diamond`` / ``hle`` / ``osworld`` / ``mle_bench``) +
+  ``inspect-harbor`` 1 bench (``swebenchpro``) 로 dispatch.
+
+  **A1 graceful-skip 의 4 게이트** — (1) ``inspect-evals`` import
+  가용성, (2) ``inspect-harbor`` import 가용성, (3) Docker daemon 가용
+  (``swe_bench_pro_pass`` / ``osworld_success`` / ``mle_bench_medal``
+  의 sandbox 요구), (4) target_model 의 vision 지원
+  (``hle_accuracy`` 의 multi-modal items). 환경 부재 시 해당 bench
+  skip 후 ``missing_benches`` 에 등록 — Petri-side ``compute_missing_dims``
+  (PR-4) 와 symmetric Goodhart suppression surface.
+
+  **``GEODE_BENCH_S6B_LIVE`` env gate** — 기본 off (nominal smoke /
+  unit test / dry-run 환경 보호). ``=1`` 설정 시에만 실제
+  ``inspect_ai.eval`` subprocess fire. off 일 땐 모든 bench 가
+  ``missing_benches`` 에 등록돼 caller / journal / results.jsonl 모두
+  동일 시그널.
+
+  **4-axis fitness 활성 (silent disconnect 9 → 0)**:
+  - ``main()`` 가 ``run_audit`` 직후 collector 호출 →
+    ``compute_fitness(bench_means=current_bench, baseline_bench_means=...)``
+    4-axis 분기 firing path 활성 (이전엔 분기 정의돼 있으나 호출 0회)
+  - ``_baseline_provenance`` dict 에 ``bench_means`` + provenance
+    슬롯 추가 → ``_write_baseline`` 가 ``axes.bench_means`` +
+    ``raw.bench_stderr`` + ``raw.bench_sample_count`` +
+    ``raw.bench_rubric_version`` 영속화 (dim 측 PR-1 패턴 symmetric)
+  - ``_should_promote`` 가 internal ``compute_fitness`` 호출에 bench
+    forward → Goodhart cross-validation gate
+    (``alignment_only_fooling`` / ``capability_at_alignment_cost``) 가
+    promote 결정에 영향. conflict 발화 시 reason payload
+    (``cross-validation conflict (<type>)``) 가 ``promoted_line`` 에
+    surface — 이전엔 fitness=0 이 critical-axis vs cross-validation
+    인지 구분 불가
+  - ``format_results_jsonl_row`` 가 ``bench_means`` / ``bench_stderr``
+    / ``bench_sample_count`` / ``missing_benches`` /
+    ``bench_rubric_version`` 5 컬럼 emit + ``ux_means`` /
+    ``admire_means`` 컬럼 슬롯 (placeholder, S1b/S2b 후속) — cross-run
+    분석이 4-axis breakdown 을 baseline.json join 없이 읽기 가능
+  - OL-C1 eval emit (``eval_response_recorded``) 의
+    ``axis_scores["bench_means_aggregate"]`` 계산 출처를 baseline (이전
+    generation frozen) → ``bench_means_current`` (이번 audit) 로 교체
+    — M4.1 DPO pile 의 chosen/rejected pairing 의 stale signal 해소
+  - ``_emit_journal("per_dim_scores")`` payload 에
+    ``missing_benches`` + ``bench_rubric_version`` 동봉 (cohort 추적)
+
+  **의존성 추가** (``pyproject.toml [audit]`` extra):
+  - ``inspect-evals>=0.13.0`` — 6 bench cover (B1 grounding survey)
+  - ``inspect-harbor>=0.4.5`` — SWE-bench Pro
+
+  **Test guards** (``tests/test_s6b_bench_production_wiring.py`` 신규
+  + ``tests/test_s6_bench_means_fitness.py`` / ``tests/test_autoresearch_train.py`` 갱신):
+  - ``BENCH_PORT_MAP`` ↔ ``BENCH_DIM_WEIGHTS`` 7-key parity (drift 차단)
+  - ``BENCH_PORT_MAP`` 의 package 가 두 PyPI 패키지 중 하나임을 강제
+  - ``BENCH_REQUIRES_DOCKER`` / ``BENCH_REQUIRES_VISION`` subset
+    invariant
+  - ``BENCH_RUBRIC_VERSION`` non-empty (cohort tag 유효)
+  - ``BenchProvenance()`` default state
+  - ``compute_missing_benches`` empty / partial / None 입력 모두
+  - ``collect_bench_means_from_inspect_ai`` 가 ``BenchProvenance``
+    반환 + 7-field universe coverage (means ∪ missing = 7) + vision
+    gate (text-only 모델 → ``hle_accuracy`` missing)
+  - ``format_results_jsonl_row`` 가 bench_provenance 전달 시 5 컬럼
+    모두 emit + 7-field universe 보존 + sorted ``missing_benches`` +
+    rubric_version 보존
+  - ``format_results_jsonl_row`` legacy caller (provenance 미전달)
+    backward-compat — 7-field 0.0 default 채워서 schema 일관성
+  - ``_write_baseline`` 가 ``raw.bench_stderr`` /
+    ``raw.bench_sample_count`` / ``raw.bench_rubric_version`` 영속화
+  - ``_should_promote`` 의 ``alignment_only_fooling`` scenario —
+    dim promote + bench regress 시 promote 차단 + reason 에
+    ``cross-validation conflict (alignment_only_fooling)`` surface
+
+  **F1.b LCB-Pro substitution** (C1 의 amendment 와 grep-provable 일치):
+  ``BENCH_DIM_WEIGHTS`` 의 ``livecodebench_pass1`` →
+  ``livecodebench_pro_accuracy`` rename (weight 0.15 변동 없음).
+  ``BENCH_PORT_MAP[livecodebench_pro_accuracy] = ("inspect_evals",
+  "livecodebench_pro")`` dispatch path 도 갱신.
+
+  **Backward-compat 보장**:
+  - ``BenchProvenance`` field 모두 default factory 라 ``BenchProvenance()``
+    호출이 dry-run path 에서 안전
+  - ``format_results_jsonl_row`` 의 ``bench_provenance=None`` 기본값 →
+    legacy caller (PR-5 이전 코드) 가 빈 7-field default 로 schema
+    유지
+  - ``baseline.json`` 의 ``raw.bench_stderr`` 등 새 슬롯은
+    ``if bench_stderr:`` 조건부 write — empty 시 키 자체 미생성
+    (legacy reader 무영향)
+
 ### Changed
 
 - **Config SoT consolidation — ``~/.geode/config.toml``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,74 @@ functional change.
   translated to the adapter Protocol's ``payg`` / ``subscription`` /
   ``adapter`` names via a single SoT table — both naming schemes are
   accepted in ``[seed_generation.role.<role>]`` overrides.
+- **PR-SIL-5THEME C4 — E1 mutation cost ledger**. `mutations.jsonl` 가
+  git-tracked 으로 존재 (PR-G5b #1350 의 deception fix 으로 보장) 했으나
+  cost 컬럼이 0건이라 operator 가 mutation ROI (cost vs fitness Δ) 볼
+  수 없던 silent disconnect 닫음. 3-step wiring:
+
+  **Step 1 — `_default_llm_call` 의 usage capture**. 이전엔
+  `response, _used_model = asyncio.run(call_with_failover(...))` 에서
+  `_used_model` 만 받고 `response.usage` (`ResponseUsage` dataclass 의
+  `input_tokens` / `output_tokens`) 가 폐기됐다. 이제 module-level
+  sidecar dict (`_LAST_LLM_CALL_USAGE`) 에 호출 직후 `input_tokens` /
+  `output_tokens` / `elapsed_seconds` / `model` 4-field 적재. 같은
+  process 내 단일-threaded propose() 사이클이라 threading.local 불필요
+  (concurrent runner 가 미래 surface 시 교체).
+
+  **Step 2 — `propose()` 의 sidecar consumption**. `_reset_last_llm_call_usage`
+  로 직전 잔여 clear → `self.llm_call(...)` → `_consume_last_llm_call_usage`
+  로 atomic snapshot read-and-clear → `dataclasses.replace` 로 frozen
+  `Mutation` 의 cost 4-field 채워서 새 instance 생성. Mock LLM (test
+  inject) 는 sidecar 채우지 않음 → cost field 가 default 0 / "" 유지 →
+  `to_audit_row()` 가 cost 컬럼 자체 omit (legacy reader 무영향).
+
+  **Step 3 — `compute_attribution` 의 `fitness_delta` 추가**. 새
+  `fitness_before` / `fitness_after` optional kwarg 받음. 둘 다 명시
+  되면 `payload["fitness_before"]` / `payload["fitness_after"]` /
+  `payload["fitness_delta"]` (6 decimal round) 3-key emit. caller 가
+  baseline.json 의 직전 + 현재 fitness scalar 를 둘 다 hand 에 들고 있
+  을 때만 fire (autoresearch run loop / scheduler 가 활용). 부재 시
+  키 자체 미생성.
+
+  **`Mutation` dataclass 확장**:
+  - `cost_input_tokens: int = 0`
+  - `cost_output_tokens: int = 0`
+  - `cost_elapsed_seconds: float = 0.0`
+  - `cost_model: str = ""`
+  - 모두 default 0 / "" → backward-compat. `Mutation` 이 `frozen=True`
+    이라 cost 채우려면 `dataclasses.replace` 사용해야 함 (propose()
+    가 그렇게 함).
+
+  **`to_audit_row()` 의 selective emit**: cost 0 / "" 일 때 row 의
+  cost_* 키 자체 미생성 — JSONL noise 절감 + legacy reader (cost
+  컬럼 부재 시 0 / "" 가정) 무영향. `cost_input_tokens` 와
+  `cost_output_tokens` 는 atomic — 하나만 emit 되는 partial state 없음.
+
+  **`write_attribution` convenience wrapper** — `fitness_before` /
+  `fitness_after` kwarg 동봉 forward (caller 가 `write_attribution`
+  하나로 끝낼 수 있게).
+
+  **Test guards** (`tests/test_e1_mutation_cost_ledger.py` 신규, 14
+  tests):
+  - `Mutation` default cost field state (0 / "" 4-field)
+  - `to_audit_row` cost 0 → 컬럼 omit / cost set → 컬럼 emit / partial
+    (elapsed_seconds 만) 분리 처리
+  - `_LAST_LLM_CALL_USAGE` sidecar lifecycle: `_reset` clears, `_consume`
+    returns-and-clears atomic, empty when unset
+  - `propose()` mock LLM (sidecar 미채움) → cost default / production-
+    style usage sidecar → cost populated / stale sidecar 잔여 차단
+  - `compute_attribution` fitness emit: 둘 다 명시 → 3-key + Δ /
+    부재 → 키 미생성 / only-before → 키 미생성 (Δ 계산 불가) /
+    regression scenario (after < before) → 음수 Δ
+
+  **anti-deception**: PR-G5b #1350 의 "git-tracked audit log" 주장은
+  유효 — 이 PR 이 컬럼만 채워 넣음. `mutations.jsonl` path 자체는
+  `core/paths.py` 에 정착, .gitignore-clean (PR-RATCHET-1 의
+  ``tests/test_ratchet_policies_in_repo.py::test_policy_files_not_gitignored``
+  invariant 으로 pinned).
+
+### Added
+
 - **PR-SIL-5THEME C3 — P3 modality 가중 분리**. `core/audit/dim_extractor`
   가 PR-1 으로 per-dim `measurement_modality` 를 emit 했으나
   `compute_fitness` / `_should_promote` 는 그 신호를 0% 사용하던

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,49 @@ functional change.
   translated to the adapter Protocol's ``payg`` / ``subscription`` /
   ``adapter`` names via a single SoT table — both naming schemes are
   accepted in ``[seed_generation.role.<role>]`` overrides.
+- **PR-SIL-5THEME C5 — D4 X2 system-prompt model-identity injection telemetry**.
+  `HookEvent.PROMPT_ASSEMBLED` 가 `core/hooks/system.py:69` 에 정의됐
+  으나 fire 0회 였다 — X2 injection (Option B 의 단일-line model
+  identity statement, `core/agent/system_prompt.py:337`) 이 매 round
+  마다 발화하지만 관측 marker 0. v0.52.5-style stale-ack 회귀 발생 시
+  production debug 필요했다. C5 가 두 wiring point 활성:
+
+  **Wiring 1 — `_sync_model_and_rebuild_prompt` 가 PROMPT_ASSEMBLED 발화**.
+  System prompt rebuild 후 (drift detected OR prompt_dirty=True) hook
+  발화. Payload: `{model, provider, reason: "model_drift" | "prompt_dirty",
+  x2_injected: True, prompt_len}`. `_hooks` 부재 시 (stub loop / hook
+  system 미초기화) graceful skip — backward compat.
+
+  **Wiring 2 — `_inject_model_switch_breadcrumb` 의 purged_count
+  forward**. `purge_stale_model_switch_acks` 가 이전엔 `None` 반환했
+  으나 이제 purged ack 의 count (int). `_inject_model_switch_breadcrumb`
+  도 그 count 를 forward → `update_model_async` 가 `MODEL_SWITCHED`
+  hook payload 에 `purged_ack_count` 동봉. v0.52.5 incident style 회귀
+  (gpt-5.5 가 "I am gpt-5.4-mini" 식으로 식별 잘못) 발생 시 stream 으
+  로 추적 가능. Trigger 순서도 변경 — breadcrumb 가 끝난 *후* hook 발화
+  (이전엔 trigger 가 먼저였어서 purge 정보가 hook 에 안 들어갔다).
+
+  **`purge_stale_model_switch_acks` 의 return type 변경**: `None → int`.
+  Caller (이 PR 의 `_inject_model_switch_breadcrumb`) 만 활용, 기타
+  caller 는 결과 무시 (backward compat 보장 — return 값 무시는
+  Python 의 silent 동작).
+
+  **Test guards** (`tests/test_d4_x2_telemetry.py` 신규, 11 tests):
+  - `purge_stale_model_switch_acks` returns count: zero / str-form acks /
+    block-form acks (Anthropic) / user message untouched (4 tests)
+  - `_inject_model_switch_breadcrumb` forwards count: empty context → 0 /
+    non-empty with stale ack → count (2 tests)
+  - `update_model_async` fires `MODEL_SWITCHED` with `purged_ack_count`
+    payload (1 test, full async path)
+  - `_sync_model_and_rebuild_prompt` fires `PROMPT_ASSEMBLED`: drift case /
+    prompt_dirty case / no rebuild case / no hooks case (4 tests)
+
+  **Anti-deception**: existing `tests/test_arun_model_drift_sync.py` 의
+  6 tests 는 `_StubLoop` 가 `_hooks` 미정의 — `getattr(self, "_hooks",
+  None)` graceful default 로 기존 stub 호환성 보존.
+
+### Added
+
 - **PR-SIL-5THEME C4 — E1 mutation cost ledger**. `mutations.jsonl` 가
   git-tracked 으로 존재 (PR-G5b #1350 의 deception fix 으로 보장) 했으나
   cost 컬럼이 0건이라 operator 가 mutation ROI (cost vs fitness Δ) 볼

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.42] - 2026-05-23
+
+> Observability central-isation release. ``SessionMetrics`` 신설 (Tier 2 of
+> 3-Tier preservation), ``SessionJournal`` → ``SessionTranscript`` alias-
+> shim 흡수, ``journal/`` directory depth 축소. PR-SIL-5THEME C4 의 sidecar
+> race 가 SessionMetrics ContextVar 단일 객체로 흡수되며 영구 해소. +15
+> tests (6834 → 6849).
+
 ### Added
 
 - **`SessionMetrics` — session-scoped state aggregator (Tier 2 of 3-Tier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.41] - 2026-05-23
+
+> SIL 5-theme closure release. Bench S6b production wiring + ADR-012 §S6/§S6b
+> amendment + P3 modality 가중 분리 + E1 mutation cost ledger + D4 X2
+> telemetry + D1 PAYG exclusion enforcement. PR #1524 (6 commits + plan + fix
+> up). +176 new tests (6658 → 6834).
+
 ### Changed
 
 - **PR-SIL-5THEME C6 — D1 provider B/C closure (PAYG exclusion enforcement)**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,77 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **`SessionMetrics` — session-scoped state aggregator (Tier 2 of 3-Tier
+  preservation architecture)**. Centralises ~13 scattered session-scoped
+  state (LLM cost / tool calls / provider routing / failover counts /
+  mutation lifecycle / Goodhart surface) into a single ContextVar-bound
+  dataclass at ``core/observability/session_metrics.py``.
+
+  **Frontier 정렬** — Claude Code ``AgentLoopState.totalUsage`` +
+  Hermes ``sessions`` SQLite table column shape + Paperclip ``usageJson``
+  JSONB column schema 의 cumulative aggregate grain 일치. Hermes 의
+  ``_SESSION_ID: ContextVar`` family 와 같은 multi-session 격리 패턴.
+
+  **C4 sidecar 흡수** — PR-SIL-5THEME C4 의 ``_LAST_LLM_CALL_USAGE``
+  module-level dict + PR-C4.fix-contextvar 의 ``ContextVar[dict]`` +
+  ``_UsageProxy`` shim 전부 SessionMetrics 의 ``last_call_input_tokens
+  / last_call_output_tokens / last_call_elapsed_seconds / last_call_model``
+  4-field snapshot 으로 흡수. propose() 가 같은 ContextVar 안에서
+  ``current_session_metrics()`` 호출로 race 가능성 0. PR #1530 의 flaky
+  test fail 해소.
+
+  **API**:
+  - ``current_session_metrics()`` — ContextVar lazy-init lookup
+  - ``session_metrics_scope(session_id, gen_tag, component)`` — context
+    manager binding (mirrors ``session_journal_scope``)
+  - ``SessionMetrics.accumulate_llm_call(...)`` — per-call additive
+  - ``SessionMetrics.increment_tool_call() / increment_mutation() /
+    record_retry() / record_circuit_breaker_trip() / record_error() /
+    record_rollback() / record_goodhart()`` — counter mutation
+  - ``SessionMetrics.to_session_row()`` — sessions.jsonl persistence shape
+
+  **15 new tests** (`tests/test_session_metrics.py`):
+  defaults / accumulate additive + last-call overwrite / reset_last_call
+  preserves cumulative / 5 counter APIs / persistence shape / ContextVar
+  lifecycle (lazy / nested isolation / exception restore) / C4 integration.
+
+### Changed
+
+- **`SessionJournal` → `SessionTranscript` 흡수, ``journal/`` directory
+  depth 제거**. Pre-existing 3-Tier preservation 아키텍처가
+  ``core/runtime_state/transcript.py`` docstring 에 이미 정의돼 있었으나
+  ``SessionJournal`` (의도된 Tier 2 자리) 가 실제로는 self-improving-loop
+  의 *별도 Tier 1 event log* 로 운영 중이었다 — 두 객체가 schema /
+  path / API 가 다른 채 공존. 본 PR 이 정합 회복:
+
+  - ``core/observability/session_journal.py`` → thin alias-shim 으로 축소
+    (269 callsite 변경 0). ``SessionJournal.append(event, payload=...)``
+    가 ``SessionTranscript.record_lifecycle_event(...)`` 로 delegating
+  - ``SessionTranscript`` 에 ``record_lifecycle_event`` 메서드 신설 —
+    free-form event + ``{ts, session_id, gen_tag, component, level,
+    event, payload}`` 스키마로 기존 Journal 사용자 보존
+  - file 이름 ``journal.jsonl`` → ``transcript.jsonl`` (mass rename, 269
+    reference)
+  - 디렉터리 depth 축소: ``~/.geode/journal/transcripts/<slug>/<id>.jsonl``
+    → ``~/.geode/transcripts/<slug>/<id>.jsonl``. ``GLOBAL_JOURNAL_DIR``
+    이름은 ``GLOBAL_TRANSCRIPTS_DIR`` 의 backward-compat alias 유지
+  - ``core/cli/cmd_lifecycle.py`` 의 disk usage label ``"journal"`` →
+    ``"transcripts"`` 정렬
+
+  **3-Tier 최종**:
+
+  ```
+  Tier 1  SessionTranscript   (append-only event log) — transcripts/*.jsonl
+  Tier 2  SessionMetrics      (cumulative aggregate) — sessions.jsonl row
+  Tier 3  SessionCheckpoint   (pipeline state) — state.json
+  ```
+
+  Frontier 명명 정렬 — Claude Code ``transcript`` / OpenClaw
+  ``transcript`` / Hermes ``messages`` 의 Tier-1 일치. ``journal`` 의
+  일반 명사 모호성 해소.
+
 ## [0.99.41] - 2026-05-23
 
 > SIL 5-theme closure release. Bench S6b production wiring + ADR-012 §S6/§S6b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,61 @@ functional change.
   is still honoured as a fallback with a one-time deprecation
   warning. Removal target: v1.0.0.
 
+- **PR-SIL-5THEME C1 — ADR-012 §Decision.2 의 3축 → 4축 amendment + §S6 /
+  §S6b 신설**. self-improving loop 의 fitness 명세 — ``dim_means`` (Petri
+  alignment, 음의 압력) 1축 외에 ``ux_means`` (S1, 양의 압력) +
+  ``admire_means`` (S2, 양의 압력) + ``bench_means`` (S6, capability 양의
+  압력) 추가 — 가 코드에는 (`autoresearch/train.py:344-350` 의
+  ``FITNESS_*_4AX`` 상수 + ``bench_means.py:91-101`` 의
+  ``BENCH_DIM_WEIGHTS``) 정착돼 있었으나 ADR 본문은 초안의 3축 상태로
+  남아있었다. 본 amendment 가 그 mismatch 를 정리:
+
+  - §Decision.2 의 "3축 multi-axis strict-reject ratchet" →
+    "**4축** multi-axis strict-reject ratchet" + baseline.json schema
+    가 ``schema_version=2`` 의 ``raw`` + ``axes`` namespace 로 갱신
+  - 축별 권장 가중치 ``dim 0.4 / ux 0.3 / admire 0.3`` (3축) →
+    ``dim 0.30 / ux 0.25 / admire 0.20 / bench 0.25`` (4축, sum=1.0)
+  - ``seed_pool_diversity`` 슬롯 — 초안에 4번째 묶음으로 명시됐으나 코드
+    0 grep, ELO tournament 의 cross-provider panel 이 diversity 신호 흡수 —
+    명시적 deprecate
+  - 신규 §S6 (Bench fitness axis) — 7-bench frontier federation 명세
+    (SWE-bench Pro / **LiveCodeBench-Pro** / τ²-bench / GPQA Diamond /
+    HLE / OSWorld / MLE-bench) + 2026-05 갱신 history + cross-validation
+    gate (alignment_only_fooling / capability_at_alignment_cost) +
+    frontier sources 10건
+  - 신규 §S6b (Production wiring) — collector / dispatcher / persistence /
+    observability / Docker A1 graceful-skip 명세
+  - "후속 PR 시퀀스" 표에 S6 + S6b 두 entry 추가
+
+  **F1.b LiveCodeBench substitution** — vanilla LiveCodeBench (Python
+  algorithmic, pass@1) 의 공식 inspect_ai port 가 부재한 상태에서
+  frontier consensus 가 ``livecodebench_pro`` (C++ competitive, accuracy
+  metric, live-contest scrape + time-cutoff windowing, 2026 v2 가 ICPC
+  WF/IOI/Chinese olympiad 추가) 로 그 niche 를 흡수. ``BENCH_DIM_WEIGHTS``
+  의 ``livecodebench_pass1`` → ``livecodebench_pro_accuracy`` 로 rename
+  (weight 0.15 변동 없음, metric 형식 변경은 0-1 float schema 무영향).
+  ``bench_means.py`` docstring 의 "LiveCodeBench (algo, contam-free)" →
+  "LiveCodeBench-Pro (C++ competitive, contam-defended, 2026 v2)" 로 갱신.
+
+  **Drift invariant 7건** (``tests/test_adr_012_parity.py`` 신규):
+  - ``test_adr012_decision2_header_says_4axis`` — 헤더 "4축" 명시
+  - ``test_adr012_decision2_weights_match_code_constants`` — ADR ↔ code
+    상수 4-axis 가중치 일치 (regex parse)
+  - ``test_adr012_deprecates_seed_pool_diversity`` — deprecate 명시 확인
+  - ``test_adr012_has_s6_section`` — §S6 헤더 존재 (docstring 인용 grep
+    provable 보장)
+  - ``test_adr012_s6_schema_field_names_match_code`` — §S6.2 표의 field
+    name 7개 모두 ``BENCH_DIM_WEIGHTS`` 와 일치
+  - ``test_adr012_s6_weights_match_bench_dim_weights`` — §S6.2 표의
+    weight column 이 코드 dict 와 byte-equivalent
+  - ``test_adr012_has_s6b_section`` — §S6b 헤더 존재
+  - ``test_adr012_pr_sequence_lists_s6_and_s6b`` — "후속 PR 시퀀스" 표가
+    S6 + S6b 모두 포함
+
+  Same anti-deception pattern as PR-G5b #1350 / PR-MINIMAL-2 #1398:
+  ADR 와 코드 docstring 사이의 grep-provable invariant 가 없으면 future
+  ADR 편집이 silent drift 를 부른다.
+
 - **PR-C-P1 — autoresearch ``seed_limit`` lower bound bumped from
   ``ge=1`` to ``ge=5``**. Pydantic now rejects any
   ``[self_improving_loop.autoresearch] seed_limit`` value below 5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,84 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **PR-SIL-5THEME C6 — D1 provider B/C closure (PAYG exclusion enforcement)**.
+  Operator decision (durable memory `project_payg_exclusion_decision.md`,
+  2026-05-23) 으로 autoresearch / Petri audit 의 provider 선택지에서
+  PAYG (Anthropic API key 직접 결제, `api_key`) 영구 exclude. 잔존 옵션:
+  `claude-cli` (Claude Code Max OAuth) / `openai-codex` (ChatGPT Plus
+  OAuth) / `auto` (manifest cascade). 잔존 인프라 코드 (`auth.toml`,
+  BillingError panel, `default_plan_for_payg`) 는 보존.
+
+  **`Source` literal narrowing**:
+  `Literal["claude-cli", "openai-codex", "api_key", "auto"]` →
+  `Literal["claude-cli", "openai-codex", "auto"]`. Operator 가
+  `~/.geode/config.toml` 에 `source = "api_key"` 명시 시 Pydantic
+  ValidationError 발화 + 어느 값이 invalid 인지 명시 (PR-C-P1 의
+  silent-fallback 차단 패턴 재사용). 분리된 `MutatorConfig.source`
+  (line 248 의 별도 Literal) 은 `api_key` 포함 4-element 유지 — mutator
+  LLM 호출은 audit role 과 별개, operator 가 Anthropic API key 로
+  mutator 운영 자유.
+
+  **Default change**: `PetriRoleConfig.source` + `AutoresearchConfig.source`
+  + `autoresearch/train.py:SOURCE` 모두 default `"auto" → "claude-cli"`.
+  `auto` 는 manifest cascade 가 silent PAYG fallback 가능 (`fallback_to_payg`
+  True 일 때) → 명시 `claude-cli` default 면 leak 0. operator 가 explicit
+  으로 `"auto"` 또는 `"openai-codex"` 명시 시 그대로 적용.
+
+  **`check_subscription_cli_for_source` pre-flight** (신규,
+  `autoresearch/prepare.py`): `source` setting 이 `claude-cli` 또는
+  `openai-codex` 일 때 해당 CLI binary 의 PATH 가용성 검증. 부재 시
+  actionable error (`GEODE_CLAUDE_CLI_BIN` / `GEODE_CODEX_CLI_BIN` env
+  override hint 포함). `auto` source 는 cascade 가 fallback 책임이라
+  pre-flight skip.
+
+  **`_read_role_from_self_improving_loop` 의 ValidationError graceful
+  fallback**: 기존 operator config 가 `source = "api_key"` 가진 채로
+  load 시 ValidationError 발화 → petri standalone CLI 의 user_overrides
+  read 는 graceful 하게 legacy `petri.toml` 로 fallback (`petri_role_legacy_fallback`
+  event emit 으로 추적 가능). autoresearch / mutator 의 직접 호출은
+  여전히 ValidationError 가 의도된 surface — 두 경로 의 의도 분리.
+
+  **Known-defaults filter expansion**: `_read_role_from_self_improving_loop`
+  의 source 필터가 `"auto"` 외 `"claude-cli"` 도 known-defaults set 에
+  추가 — override output 이 operator-explicit override 만 surface (default
+  값이 silent 하게 노출 안 됨). explicit `"claude-cli"` 설정의 silent corner
+  는 minor UX nit (효과 동일).
+
+  **Test guards** (`tests/test_d1_provider_closure.py` 신규, 14 tests):
+  - `Source` literal — `api_key` Pydantic reject (PetriRoleConfig +
+    AutoresearchConfig, 2 tests)
+  - 3 valid sources (`claude-cli` / `openai-codex` / `auto`) 수락 (3 tests)
+  - Default `claude-cli` (PetriRoleConfig + AutoresearchConfig, 2 tests)
+  - `check_subscription_cli_for_source` pre-flight: missing binary
+    actionable error (claude-cli + openai-codex), env override wins,
+    auto skip, unknown source graceful (5 tests)
+  - 4-backend matrix: `api_key` reject + 3 valid accept (2 tests for
+    both configs)
+
+  **Existing test updates**:
+  - `test_autoresearch_defaults_match_train_module` — expect `source ==
+    "claude-cli"` (was `"auto"`)
+  - `test_load_reads_autoresearch_subsection` — expect `source ==
+    "claude-cli"` for untouched field
+  - `test_petri_role_default_source_is_auto` → renamed
+    `test_petri_role_default_source_is_subscription_first` — expect
+    `claude-cli`
+  - `test_set_source_updates_override` (petri CLI) — use `"openai-codex"`
+    instead of `"api_key"` (latter rejected by Pydantic)
+  - `test_read_role_override_prefers_self_improving_loop` — use
+    `"openai-codex"` non-default source
+
+  **Backward compat**: `Mutator` source literal (mutator LLM, distinct
+  from audit roles) preserved with `api_key` — operator can still use
+  Anthropic API for mutator. `credential_source.py` 의 PAYG fallback
+  코드 경로 보존 (다른 caller 가 명시 호출 시 활성). 기존 `config.toml`
+  의 `api_key` 설정 operator: petri standalone CLI 는 graceful (legacy
+  fallback + telemetry event), autoresearch 직접 호출은 actionable
+  ValidationError 로 migrate 안내.
+
 ## [0.99.40] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,63 @@ functional change.
   translated to the adapter Protocol's ``payg`` / ``subscription`` /
   ``adapter`` names via a single SoT table — both naming schemes are
   accepted in ``[seed_generation.role.<role>]`` overrides.
+- **PR-SIL-5THEME C3 — P3 modality 가중 분리**. `core/audit/dim_extractor`
+  가 PR-1 으로 per-dim `measurement_modality` 를 emit 했으나
+  `compute_fitness` / `_should_promote` 는 그 신호를 0% 사용하던
+  silent disconnect 닫기.
+
+  **Why** — `_ANALYTICS_MODALITY` 는 2 auxiliary dim
+  (`verbose_padding` + `redundant_tool_invocation`) 만 analytics
+  modality 로 tag (나머지 18 dim 은 `judge_llm`). 두 modality 는 노이즈
+  특성이 다르다:
+  - **judge_llm**: LLM-as-judge stochastic rubric — N 에 비례한 sample
+    stderr, N=5+ 가 의미 있는 신호 floor (PR-C-P1)
+  - **analytics**: transcript regex / token count / tool log 의
+    deterministic 추출 — N=1 에서도 sample 간 분산이 진짜 0 가능
+
+  modality-blind 가중치는 (a) analytics 의 좁은 신호 폭을 judge_llm 의
+  full-weight 로 받아 fitness reproducibility dilute, (b) N=1 widening
+  guard (PR-3) 가 analytics 의 deterministic stderr=0 을 under-sampled
+  stderr=0 과 conflate.
+
+  **Changed**:
+  - `ANALYTICS_WEIGHT_MULTIPLIER = 0.5` + `DIM_MODALITY_WEIGHT_MULTIPLIER`
+    dispatch dict — analytics modality 의 dim weight 0.5× scale
+  - `_dim_weight_with_modality(dim, measurement_modality)` 헬퍼 — base
+    `DIM_WEIGHTS[dim]` × modality multiplier
+  - `compute_fitness(..., measurement_modality: dict[str, str] | None)`
+    파라미터 추가 — None 이면 backward compat (legacy caller 무영향)
+  - `_should_promote(..., measurement_modality, baseline_measurement_modality)`
+    추가 + internal compute_fitness 3 호출에 forward
+  - N=1 widening guard 의 modality check 추가 — `JUDGE_LLM_MODALITIES`
+    (judge_llm + "") set 에 속하는 critical dim 만 widening 적용. analytics
+    critical 은 widening skip (deterministic stderr=0 이 잘못된 신호 아님).
+    Modality 부재 (v1 baseline) 시 보수적 default (judge_llm 가정) →
+    widening 유지
+  - 신규 `_load_baseline_measurement_modality()` — `_load_baseline_sample_count`
+    sibling, v2 schema 의 `raw.measurement_modality` 읽음. v1 → `{}`
+  - `main()` 가 modality dict 를 `compute_fitness` + `_should_promote` 에
+    forward
+
+  **Test guards** (`tests/test_p3_modality_weight_split.py` 신규, 19 tests):
+  - `ANALYTICS_WEIGHT_MULTIPLIER` 0-1 range invariant
+  - `DIM_MODALITY_WEIGHT_MULTIPLIER` 가 `dim_extractor._ANALYTICS_MODALITY` +
+    `DEFAULT_MODALITY` 의 emit 값 모두 cover (drift catch)
+  - `JUDGE_LLM_MODALITIES` 가 빈 문자열 포함 (legacy 안전)
+  - `_dim_weight_with_modality`: None / judge_llm / analytics / unknown
+    modality / unknown dim 모두 (5 tests)
+  - `compute_fitness` modality-blind backward compat
+  - analytics modality 명시 시 fitness 감소 (weight scaled)
+  - 모든 judge_llm 명시 시 modality-blind 와 동일
+  - `_should_promote` N=1 widening fires for judge_llm critical
+  - `_should_promote` N=1 widening skipped for ALL-analytics critical (가정
+    시나리오, future schema 확장 대비)
+  - `_should_promote` modality=None 시 보수적 default → widening 유지
+  - `N1_FITNESS_MARGIN_FLOOR == 0.20` pin
+  - `_load_baseline_measurement_modality`: missing file / v1 legacy / v2
+    raw namespace / malformed entries graceful (4 tests)
+
+### Added
 
 - **PR-SIL-5THEME C2 — Bench S6b production wiring**. ADR-012 §S6
   (schema + math + cross-validation gate, C1 amendment 로 ADR 측 명세

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.41
+- **Version**: 0.99.42
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 355 core + 58 plugins = 413
-- **Tests**: 6834 (+5 live)
+- **Tests**: 6849 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.40
+- **Version**: 0.99.41
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)
 - **Modules**: 355 core + 58 plugins = 413
-- **Tests**: 6658 (+5 live)
+- **Tests**: 6834 (+5 live)
 - **CHANGELOG**: `CHANGELOG.md` (Keep a Changelog + SemVer)
 
 ## Quick Start

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.40 — Long-running Autonomous Execution Harness
+# GEODE v0.99.41 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.40**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.41 — Long-running Autonomous Execution Harness
+# GEODE v0.99.42 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.42**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.40 — Long-running Autonomous Execution Harness
+# GEODE v0.99.41 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.40**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.41 — Long-running Autonomous Execution Harness
+# GEODE v0.99.42 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.41**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.42**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/autoresearch/bench_means.py
+++ b/autoresearch/bench_means.py
@@ -304,7 +304,7 @@ def _is_inspect_evals_installed() -> bool:
     (`livecodebench_pro_accuracy` / `tau2_bench_success` / `gpqa_diamond` /
     `hle_accuracy` / `osworld_success` / `mle_bench_medal`)."""
     try:
-        import inspect_evals  # type: ignore[import-not-found]  # noqa: F401
+        import inspect_evals  # noqa: F401
 
         return True
     except ImportError:
@@ -315,7 +315,7 @@ def _is_inspect_harbor_installed() -> bool:
     """``inspect-harbor`` PyPI 패키지의 import 가용성. SWE-bench Pro 만
     Harbor 의존 — 부재 시 `swe_bench_pro_pass` skip."""
     try:
-        import inspect_harbor  # type: ignore[import-not-found]  # noqa: F401
+        import inspect_harbor  # noqa: F401
 
         return True
     except ImportError:
@@ -398,8 +398,8 @@ def _run_bench_via_inspect_ai(
     package, task_path = BENCH_PORT_MAP[field_name]
     try:
         if package == "inspect_evals":
-            from inspect_ai import eval as inspect_eval  # type: ignore[import-not-found]
-            from inspect_evals import (  # type: ignore[import-not-found]
+            from inspect_ai import eval as inspect_eval
+            from inspect_evals import (
                 __dict__ as inspect_evals_ns,
             )
 
@@ -407,14 +407,14 @@ def _run_bench_via_inspect_ai(
             if task_factory is None:
                 log.warning("inspect_evals task %s not found", task_path)
                 return None
-            eval_logs = inspect_eval(  # type: ignore[no-untyped-call]
+            eval_logs = inspect_eval(
                 task_factory(),
                 model=target_model,
                 limit=sample_limit,
             )
         else:  # inspect_harbor
-            from inspect_ai import eval as inspect_eval  # type: ignore[import-not-found]
-            from inspect_harbor import (  # type: ignore[import-not-found]
+            from inspect_ai import eval as inspect_eval
+            from inspect_harbor import (
                 __dict__ as harbor_ns,
             )
 
@@ -422,7 +422,7 @@ def _run_bench_via_inspect_ai(
             if task_factory is None:
                 log.warning("inspect_harbor task %s not found", task_path)
                 return None
-            eval_logs = inspect_eval(  # type: ignore[no-untyped-call]
+            eval_logs = inspect_eval(
                 task_factory(),
                 model=target_model,
                 limit=sample_limit,

--- a/autoresearch/bench_means.py
+++ b/autoresearch/bench_means.py
@@ -1,19 +1,30 @@
-"""``bench_means`` fitness 축 — ADR-012 S6 (Path C inspect_ai federation).
+"""``bench_means`` fitness 축 — ADR-012 §S6 (4축 fitness 의 4번째 축).
 
 S1 의 ``ux_means`` (행동) + S2 의 ``admire_means`` (체감) 옆에 추가되는
 **capability** 양의 압력 축. Petri 가 alignment evaluation (안 망가지기)
 인 반면, bench 는 real task completion (제대로 함) 의 ground-truth 평가.
 
-**2026-05-21 갱신 — 4 outdated bench 교체 (4 → 7 frontier)**:
+ADR-012 §S6 가 schema + math + cross-validation gate 명세, §S6b 가 이
+모듈을 호출하는 production wiring 명세. 두 §섹션은 2026-05-23 amendment
+(PR-SIL-5THEME C1) 으로 ADR 에 추가됐다 — 이전엔 코드만 4축을 정의하고
+ADR 측은 3축 그대로였다.
+
+**2026-05-21 → 2026-05-23 frontier 갱신 history**:
 
 원본 S6 (2026-05-21 오전, #1413) 의 4 bench 는 모두 saturated / OpenAI
 retire / contamination 으로 outdated. 2026 frontier (Claude Opus 4.5
 system card + GPT-5 system card 공통 채택) 으로 7-field schema 갱신.
+2026-05-23 amendment (F1.b) 에서 vanilla LiveCodeBench → LiveCodeBench-Pro
+substitution 추가:
 
 - SWE-bench → **SWE-bench Pro** (Scale AI): OpenAI 2026-02-23 공식
   retire, saturated + contaminated.
-- HumanEval → **제거 + LiveCodeBench**: Top-4 93-95% saturated,
-  contamination-free 신규.
+- HumanEval → **LiveCodeBench-Pro** (F1.b substitution): Top-4 93-95%
+  saturated. *Vanilla LiveCodeBench* 가 contamination-defense 후속이었으나
+  inspect_ai 생태계에 공식 port 부재 — frontier consensus 는
+  ``livecodebench_pro`` (C++ 경쟁 프로그래밍, live-contest scrape +
+  time-cutoff windowing, 2026 v2 가 ICPC WF/IOI/Chinese olympiad 추가)
+  가 그 niche 를 흡수.
 - TAU-bench → **τ²-bench** (Sierra 2025): telecom domain 0.993
   saturated, dual-control 후속.
 - GAIA → **HLE + OSWorld 분할**: DeepAgent 91.69% saturated. HLE
@@ -21,46 +32,45 @@ system card + GPT-5 system card 공통 채택) 으로 7-field schema 갱신.
 - (신규) **GPQA Diamond**: Anthropic + OpenAI 카드 공통 PhD reasoning.
 - (신규) **MLE-bench**: self-improving loop 도메인 정합 (ML engineering).
 
-**inspect_ai federation** (Path C, ADR-012 §S6 결정 — **S6b 에서 wiring 예정**):
+**inspect_ai federation** (ADR-012 §S6b 의 wiring 명세):
 - Petri 의 alignment scenario + frontier capability bench (7-field) 가
-  **같은 inspect_ai run** 안에서 federated 실행하는 설계. Anthropic
-  inspect_ai framework 기반 — 단일 subprocess 통합 가능. (S6 본 PR 은
-  schema + math + gate 만, 실제 federation wiring 은 S6b 별도 PR.)
-- ``baseline.json`` schema 확장 (S6b 예정) — ``dim_means`` (Petri) +
-  ``bench_means`` (capability) 별도 field.
+  **같은 inspect_ai run** 안에서 또는 **인접 subprocess** 로 실행되는
+  설계. Anthropic inspect_ai framework 기반. S6b 의 ``A1 graceful-skip``
+  패턴 — Docker / VM 미가용 시 해당 bench 만 skip, ``missing_benches``
+  에 등록.
+- ``baseline.json schema_version=2`` 의 ``axes.bench_means`` field +
+  ``raw`` 의 bench provenance (``bench_stderr`` / ``bench_sample_count``
+  / ``bench_rubric_version``) 슬롯에 영속화.
 
-**Schema** (7 field, 모두 0.0-1.0 normalized — 2026-05 갱신):
+**Schema** (7 field, 모두 0.0-1.0 normalized — 2026-05-23 F1.b 후 확정):
 
 .. code-block:: python
 
     {
-      "swe_bench_pro_pass":   0.45,  # Scale AI SWE-bench Pro pass@1
-      "livecodebench_pass1":  0.70,  # LiveCodeBench contam-free
-      "tau2_bench_success":   0.85,  # Sierra τ²-bench (telecom)
-      "gpqa_diamond":         0.60,  # GPQA Diamond PhD reasoning
-      "hle_accuracy":         0.30,  # Humanity's Last Exam
-      "osworld_success":      0.35,  # OSWorld computer-use
-      "mle_bench_medal":      0.40,  # OpenAI MLE-bench medal rate
+      "swe_bench_pro_pass":          0.45,  # Scale AI / Harbor resolve rate
+      "livecodebench_pro_accuracy":  0.70,  # LCB-Pro accuracy (C++ exec)
+      "tau2_bench_success":          0.85,  # Sierra τ²-bench (telecom)
+      "gpqa_diamond":                0.60,  # GPQA Diamond PhD reasoning
+      "hle_accuracy":                0.30,  # Humanity's Last Exam
+      "osworld_success":             0.35,  # OSWorld computer-use
+      "mle_bench_medal":             0.40,  # OpenAI MLE-bench medal rate
     }
 
 **Cross-validation gate** (Goodhart 양방향 방어):
-- Petri promote (dim 개선) + bench regress → fooling 의심
-- bench promote + Petri critical regress → capability gain at alignment cost
-- 두 conflict 모두 ``compute_fitness`` 의 strict-reject (0.0) 발화
+- Petri promote (dim 개선) + bench regress → ``alignment_only_fooling``
+- bench promote + Petri critical regress → ``capability_at_alignment_cost``
+- 두 conflict 모두 ``compute_fitness`` 의 strict-reject (0.0) 발화.
 
-**ADR-012 §Decision.2 의 fitness 4축 다축화** (S6 후):
-- ``dim_means`` (Petri 17-dim, 음의 압력) — 가중치 0.30
-- ``ux_means`` (행동 4-field, S1) — 가중치 0.25
-- ``admire_means`` (체감 2-field, S2) — 가중치 0.20
-- ``bench_means`` (capability 7-field, S6 — 2026-05 갱신) — 가중치 0.25
+**ADR-012 §Decision.2 의 4축 fitness 가중치** (2026-05-23 amendment 후):
 
-bench 비중이 0.25 — ground-truth 평가라 dim 과 동등한 권위. dim 비중이
-0.40 → 0.30 으로 추가 감소 (양의 압력 면적이 7/23 = 30.4% → 14/30 = 46.7%
-로 확장 — 4 outdated bench → 7 frontier bench 교체).
+- ``dim_means`` (Petri 17-22 dim, 음의 압력) — 0.30
+- ``ux_means`` (행동 4-field, S1) — 0.25
+- ``admire_means`` (체감 2-field, S2) — 0.20
+- ``bench_means`` (capability 7-field, S6) — 0.25
 
-S6 (이 갱신 PR) 은 **schema + math + cross-validation gate** + **2026
-frontier 갱신**. 실제 inspect_ai federation 의 multi-eval wiring 은 S6b
-(별도 PR).
+코드 상수 ground-truth: ``autoresearch/train.py`` 의 ``FITNESS_DIM_4AX
+/ FITNESS_UX_4AX / FITNESS_ADMIRE_4AX / FITNESS_BENCH_4AX`` (sum=1.0
+assert).
 
 **Frontier sources** (2026-05):
 
@@ -68,10 +78,12 @@ frontier 갱신**. 실제 inspect_ai federation 의 multi-eval wiring 은 S6b
 - Scale AI SWE-bench Pro: https://labs.scale.com/leaderboard/swe_bench_pro_public
 - Sierra τ²-bench: https://sierra.ai/resources/research/tau-squared-bench
 - Humanity's Last Exam (Nature 2026-01): https://agi.safe.ai/
-- LiveCodeBench (contam-free Python coding)
+- LiveCodeBench-Pro 논문 (arxiv 2506.11928): https://arxiv.org/abs/2506.11928
 - GPQA Diamond (NYU 2024)
 - OSWorld (2024 frontier computer-use agent benchmark)
 - MLE-bench (OpenAI 2024 ML engineering)
+- inspect_evals (UK AISI): https://github.com/UKGovernmentBEIS/inspect_evals
+- inspect_harbor (meridianlabs-ai): https://github.com/meridianlabs-ai/inspect_harbor
 - Claude Opus 4.5 system card: https://www.anthropic.com/claude-opus-4-5-system-card
 - GPT-5 system card: https://cdn.openai.com/gpt-5-system-card.pdf
 """
@@ -80,9 +92,11 @@ from __future__ import annotations
 
 from typing import Any
 
-# Bench field 별 가중치 — 합 1.0. 2026-05 갱신:
-# - SWE-bench Pro (Scale AI, contam-free real PR) 가 frontier 코딩 표준 — 0.25
-# - LiveCodeBench (algo, contam-free) — 0.15
+# Bench field 별 가중치 — 합 1.0. 2026-05-23 F1.b 갱신:
+# - SWE-bench Pro (Scale AI, Harbor resolve rate) — 0.25
+# - LiveCodeBench-Pro (C++ competitive, contam-defended, ICPC/IOI 2026 v2) — 0.15
+#   * vanilla LiveCodeBench port 부재 → LCB-Pro substitution (F1.b 결정,
+#     B1 grounding survey 결과)
 # - τ²-bench (Sierra dual-control + telecom) — 0.20
 # - GPQA Diamond (PhD reasoning) — 0.15
 # - HLE (Humanity's Last Exam, frontier ceiling) — 0.10
@@ -90,7 +104,7 @@ from typing import Any
 # - MLE-bench (ML engineering, self-improving 도메인 정합) — 0.05
 BENCH_DIM_WEIGHTS: dict[str, float] = {
     "swe_bench_pro_pass": 0.25,
-    "livecodebench_pass1": 0.15,
+    "livecodebench_pro_accuracy": 0.15,
     "tau2_bench_success": 0.20,
     "gpqa_diamond": 0.15,
     "hle_accuracy": 0.10,

--- a/autoresearch/bench_means.py
+++ b/autoresearch/bench_means.py
@@ -90,7 +90,90 @@ assert).
 
 from __future__ import annotations
 
+import logging
+import os
+import shutil
+from dataclasses import dataclass, field
 from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# S6b — Bench provenance schema (PR-SIL-5THEME C2, 2026-05-23)
+# ---------------------------------------------------------------------------
+
+#: ``baseline.json:raw.bench_rubric_version`` 의 값. 7-bench cohort 의
+#: 식별자 — 2026-05 frontier 갱신 + F1.b LCB substitution 후. cohort 가
+#: 바뀌면 (예: bench 추가/교체/weight 재calibrate) 새 version tag 발급해서
+#: 이전 baseline 의 bench 점수와 apples-to-oranges 비교를 차단.
+BENCH_RUBRIC_VERSION = "v1-7bench-2026-05-F1b"
+
+
+@dataclass(slots=True)
+class BenchProvenance:
+    """Per-bench 의 provenance 묶음 — ``inspect_ai`` sample-level pass/fail
+    에서 stderr / sample_count 자동 산출, modality 는 7-bench 모두 deterministic
+    analytics (LLM judge 없음).
+
+    `dim_means` 측의 PR-1 provenance (sample_count + measurement_modality)
+    와 symmetry. ``_write_baseline`` 가 ``raw.bench_stderr`` /
+    ``raw.bench_sample_count`` / ``raw.bench_rubric_version`` 슬롯에 영속화.
+    """
+
+    bench_means: dict[str, float] = field(default_factory=dict)
+    bench_stderr: dict[str, float] = field(default_factory=dict)
+    bench_sample_count: dict[str, int] = field(default_factory=dict)
+    missing_benches: list[str] = field(default_factory=list)
+    rubric_version: str = BENCH_RUBRIC_VERSION
+
+
+# ---------------------------------------------------------------------------
+# S6b — Per-bench inspect_ai port dispatch (PR-SIL-5THEME C2)
+# ---------------------------------------------------------------------------
+
+#: 각 bench 가 어느 PyPI 패키지의 inspect_ai task 로 dispatch 되는지의 매핑.
+#: ``inspect-evals`` 6 bench + ``inspect-harbor`` 1 bench. B1 grounding survey
+#: 결과 (vanilla LiveCodeBench port 부재 → F1.b LCB-Pro substitution) 반영.
+BENCH_PORT_MAP: dict[str, tuple[str, str]] = {
+    # field → (package, inspect_ai task path)
+    "swe_bench_pro_pass": ("inspect_harbor", "swebenchpro"),
+    "livecodebench_pro_accuracy": ("inspect_evals", "livecodebench_pro"),
+    "tau2_bench_success": ("inspect_evals", "tau2_telecom"),
+    "gpqa_diamond": ("inspect_evals", "gpqa_diamond"),
+    "hle_accuracy": ("inspect_evals", "hle"),
+    "osworld_success": ("inspect_evals", "osworld"),
+    "mle_bench_medal": ("inspect_evals", "mle_bench"),
+}
+
+#: Docker / VM sandbox 가 필요한 bench. A1 graceful-skip 의 게이트 — Docker
+#: 미가용 시 collector 가 이들 bench 만 skip, nominal 3 bench (LCB-Pro /
+#: τ²-bench / GPQA Diamond) 는 그대로 작동.
+BENCH_REQUIRES_DOCKER: frozenset[str] = frozenset(
+    {
+        "swe_bench_pro_pass",  # scaleapi/SWE-bench_Pro-os image
+        "osworld_success",  # VM sandbox
+        "mle_bench_medal",  # Docker exec + Kaggle dataset
+    }
+)
+
+#: Multi-modal vision 모델이 필요한 bench. text-only 모델 사용 시 skip.
+BENCH_REQUIRES_VISION: frozenset[str] = frozenset({"hle_accuracy"})
+
+
+def compute_missing_benches(bench_means: dict[str, float] | None) -> list[str]:
+    """``BENCH_DIM_WEIGHTS`` universe 중 ``bench_means`` 에 없는 field 목록.
+
+    Goodhart-suppression surface — Petri-side ``compute_missing_dims`` (PR-4)
+    과 symmetry. mutation 이 bench 측정을 silently suppress 해서 fitness
+    aggregate 의 neutral fallback (0.5) 으로 도주하는 패턴을 노출한다.
+
+    Returns sorted list of missing field names. Empty list when all 7 present.
+    """
+    if bench_means is None:
+        return sorted(BENCH_DIM_WEIGHTS)
+    return sorted(set(BENCH_DIM_WEIGHTS) - set(bench_means))
+
 
 # Bench field 별 가중치 — 합 1.0. 2026-05-23 F1.b 갱신:
 # - SWE-bench Pro (Scale AI, Harbor resolve rate) — 0.25
@@ -120,8 +203,8 @@ def compute_bench_aggregate(bench_means: dict[str, float] | None) -> float:
     if bench_means is None:
         return 0.5
     total = 0.0
-    for field, weight in BENCH_DIM_WEIGHTS.items():
-        value = bench_means.get(field, 0.5)  # 누락 field neutral
+    for field_name, weight in BENCH_DIM_WEIGHTS.items():
+        value = bench_means.get(field_name, 0.5)  # 누락 field neutral
         total += weight * max(0.0, min(1.0, value))
     return total
 
@@ -190,27 +273,281 @@ def detect_cross_validation_conflict(
     return None
 
 
-def collect_bench_means_from_inspect_ai(*, _placeholder: bool = True) -> dict[str, float] | None:
-    """Collect ``bench_means`` from inspect_ai federation run.
+def _is_docker_available() -> bool:
+    """Docker daemon + binary 가용성 — A1 graceful-skip 의 1차 게이트.
 
-    S6 (이 PR) 는 schema + math + cross-validation gate 만 신설. 실제
-    inspect_ai 의 multi-eval API 호출 wiring 은 S6b (별도 PR) — Petri
-    scenario set + 7 bench task set 을 한 inspect_ai run 안에서 federated
-    실행, 각각의 결과를 별도 field 로 수집.
-
-    2026-05 갱신 후 7 bench 모두 inspect_ai 기반 또는 inspect_ai-compatible
-    (SWE-bench Pro / LiveCodeBench / τ²-bench / GPQA / HLE / OSWorld /
-    MLE-bench).
+    ``docker`` binary on ``$PATH`` + ``docker info`` 의 exit 0 일 때만 True.
+    ``info`` 는 daemon 이 실제 작동 중인지 확인 (binary 만 있고 daemon 꺼진
+    경우 까지 catch). 환경별 false-positive 방지 — cron / serve background
+    에서도 동일 결과.
     """
-    if _placeholder:
+    docker_bin = shutil.which("docker")
+    if docker_bin is None:
+        return False
+    import subprocess
+
+    try:
+        result = subprocess.run(  # noqa: S603 — docker_bin resolved via shutil.which, fixed argv
+            [docker_bin, "info"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _is_inspect_evals_installed() -> bool:
+    """``inspect-evals`` PyPI 패키지의 import 가용성. ``[audit]`` extra 의
+    optional dep 라 default sync 환경에선 부재. 부재 시 6 bench skip
+    (`livecodebench_pro_accuracy` / `tau2_bench_success` / `gpqa_diamond` /
+    `hle_accuracy` / `osworld_success` / `mle_bench_medal`)."""
+    try:
+        import inspect_evals  # type: ignore[import-not-found]  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _is_inspect_harbor_installed() -> bool:
+    """``inspect-harbor`` PyPI 패키지의 import 가용성. SWE-bench Pro 만
+    Harbor 의존 — 부재 시 `swe_bench_pro_pass` skip."""
+    try:
+        import inspect_harbor  # type: ignore[import-not-found]  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _is_vision_model(target_model: str) -> bool:
+    """주어진 model identifier 가 multi-modal vision 을 지원하는지 추정.
+
+    완전한 capability registry 없이는 보수적으로 추정 — claude-3.5-sonnet
+    이상, gpt-4o / gpt-5 / opus / sonnet 계열은 vision 지원으로 가정.
+    HLE 의 multi-modal items 가 일부라 vision 미지원 모델로도 부분 점수
+    가능하지만, A1 conservative skip 으로 silent partial-score 방지."""
+    model_lower = target_model.lower()
+    vision_patterns = ("claude-3", "claude-4", "claude-opus", "claude-sonnet", "gpt-4o", "gpt-5")
+    return any(p in model_lower for p in vision_patterns)
+
+
+def _eligible_benches(
+    *,
+    target_model: str,
+    has_docker: bool,
+    has_inspect_evals: bool,
+    has_inspect_harbor: bool,
+) -> tuple[set[str], list[str]]:
+    """A1 graceful-skip 의 결정 함수 — (eligible, missing) 반환.
+
+    eligible: 이 collector 호출에서 실제 실행할 bench field 들의 set.
+    missing: skip 된 bench 의 list (sorted, Goodhart surface 로 진입).
+    """
+    eligible: set[str] = set()
+    missing: list[str] = []
+    for field_name, (package, _task) in BENCH_PORT_MAP.items():
+        # Package 가용성 게이트
+        if package == "inspect_evals" and not has_inspect_evals:
+            missing.append(field_name)
+            continue
+        if package == "inspect_harbor" and not has_inspect_harbor:
+            missing.append(field_name)
+            continue
+        # Docker 게이트
+        if field_name in BENCH_REQUIRES_DOCKER and not has_docker:
+            missing.append(field_name)
+            continue
+        # Vision 게이트
+        if field_name in BENCH_REQUIRES_VISION and not _is_vision_model(target_model):
+            missing.append(field_name)
+            continue
+        eligible.add(field_name)
+    return eligible, sorted(missing)
+
+
+def _run_bench_via_inspect_ai(
+    field_name: str,
+    *,
+    target_model: str,
+    sample_limit: int | None,
+) -> tuple[float, float, int] | None:
+    """단일 bench 의 inspect_ai task 실행. ``(value, stderr, sample_count)``
+    또는 실패 시 ``None`` 반환.
+
+    실구현은 ``inspect_ai.eval`` 의 programmatic API 호출 — collector
+    가 7 bench 를 순차 dispatch. 각 task 의 EvalLog 에서 scorer 의
+    aggregate score + per-sample stderr + sample 수를 추출.
+
+    PR-SIL-5THEME C2 의 첫 production wiring 단계 — 실제 호출은
+    ``GEODE_BENCH_S6B_LIVE=1`` env flag 가 있을 때만 fire (default off
+    으로 prepare.py / audit / fitness 의 nominal smoke 가 빈 dict 와
+    동등하게 작동, ``missing_benches`` 에 전체 등록). live flag 가 켜진
+    환경에선 진짜 subprocess 실행. 다단계 wiring 의 첫 단계로 honest —
+    "7-bench port 전부 dispatch 가능, 실제 실행은 env-gated".
+    """
+    live = os.environ.get("GEODE_BENCH_S6B_LIVE", "").strip().lower() in {"1", "true", "yes"}
+    if not live:
+        # nominal path — env flag 미설정 시 모든 bench 가 "현재 cohort 에선
+        # 실행 안 함" 으로 처리. missing_benches 에 등록되어 Goodhart surface
+        # 와 동일한 시그널.
         return None
-    return None  # pragma: no cover — S6b wiring placeholder
+
+    package, task_path = BENCH_PORT_MAP[field_name]
+    try:
+        if package == "inspect_evals":
+            from inspect_ai import eval as inspect_eval  # type: ignore[import-not-found]
+            from inspect_evals import (  # type: ignore[import-not-found]
+                __dict__ as inspect_evals_ns,
+            )
+
+            task_factory = inspect_evals_ns.get(task_path)
+            if task_factory is None:
+                log.warning("inspect_evals task %s not found", task_path)
+                return None
+            eval_logs = inspect_eval(  # type: ignore[no-untyped-call]
+                task_factory(),
+                model=target_model,
+                limit=sample_limit,
+            )
+        else:  # inspect_harbor
+            from inspect_ai import eval as inspect_eval  # type: ignore[import-not-found]
+            from inspect_harbor import (  # type: ignore[import-not-found]
+                __dict__ as harbor_ns,
+            )
+
+            task_factory = harbor_ns.get(task_path)
+            if task_factory is None:
+                log.warning("inspect_harbor task %s not found", task_path)
+                return None
+            eval_logs = inspect_eval(  # type: ignore[no-untyped-call]
+                task_factory(),
+                model=target_model,
+                limit=sample_limit,
+            )
+
+        # inspect_ai.eval returns list[EvalLog]. 단일 task 호출이라 [0].
+        if not eval_logs:
+            return None
+        log_obj = eval_logs[0]
+        # scorer aggregate score — inspect_ai 의 EvalResult.scores 의 첫 entry
+        # 의 metrics dict 에서 'accuracy' / 'mean' / 'pass_rate' 등 추출
+        results = getattr(log_obj, "results", None)
+        if results is None or not getattr(results, "scores", None):
+            return None
+        score_entry = results.scores[0]
+        metrics = getattr(score_entry, "metrics", {})
+        # 가장 일반적인 metric 명들 우선순위
+        value = None
+        for metric_name in ("accuracy", "mean", "pass_rate", "success_rate", "resolve_rate"):
+            metric = metrics.get(metric_name)
+            if metric is not None:
+                value = float(getattr(metric, "value", metric))
+                break
+        if value is None:
+            return None
+        # stderr: inspect_ai 의 metric 객체에 stderr 가 있으면 사용, 없으면 0
+        stderr = 0.0
+        sample_count = 0
+        for metric_name in ("accuracy", "mean", "pass_rate", "success_rate", "resolve_rate"):
+            metric = metrics.get(metric_name)
+            if metric is not None and hasattr(metric, "stderr"):
+                stderr = float(getattr(metric, "stderr", 0.0))
+                break
+        # sample_count: log.samples 의 길이 또는 EvalStats
+        samples = getattr(log_obj, "samples", None)
+        if samples is not None:
+            sample_count = len(samples)
+        return (max(0.0, min(1.0, value)), max(0.0, stderr), sample_count)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("bench %s (%s.%s) failed: %s", field_name, package, task_path, exc)
+        return None
+
+
+def collect_bench_means_from_inspect_ai(
+    *,
+    target_model: str = "",
+    sample_limit: int | None = None,
+) -> BenchProvenance:
+    """7-bench inspect_ai federation collector — S6b production wiring.
+
+    PR-SIL-5THEME C2 (2026-05-23). 이전 placeholder (`return None`) 를
+    교체 — 이제 ``BENCH_PORT_MAP`` 의 7 bench 전부 dispatcher 가
+    존재, A1 graceful-skip 패턴으로 환경별 차등 작동.
+
+    **A1 graceful-skip 의 4 게이트** (순차 확인, 첫 fail 시 해당 bench
+    missing 에 등록):
+
+    1. ``inspect-evals`` PyPI 패키지 import 가능? (6 bench 영향)
+    2. ``inspect-harbor`` PyPI 패키지 import 가능? (`swe_bench_pro_pass` 만)
+    3. Docker daemon 가용? (`swe_bench_pro_pass` / `osworld_success` /
+       `mle_bench_medal` 의 sandbox 요구)
+    4. target_model 이 vision 지원? (`hle_accuracy` 의 multi-modal items)
+
+    **Returns**: ``BenchProvenance`` (dataclass) — ``bench_means`` /
+    ``bench_stderr`` / ``bench_sample_count`` / ``missing_benches`` /
+    ``rubric_version``. caller (autoresearch/train.py:main) 는 그
+    dataclass 의 dict 부분만 따로 빼서 ``compute_fitness(bench_means=...)``
+    / ``_write_baseline(bench_means=...)`` 에 전달.
+
+    **GEODE_BENCH_S6B_LIVE env gate**: 기본 off (nominal smoke / unit
+    test / dry-run 환경 보호). ``GEODE_BENCH_S6B_LIVE=1`` 설정 시에만
+    실제 ``inspect_ai.eval`` subprocess fire. off 일 땐 모든 bench 가
+    ``missing_benches`` 에 등록돼 Goodhart surface 와 동일 시그널.
+    """
+    has_docker = _is_docker_available()
+    has_inspect_evals = _is_inspect_evals_installed()
+    has_inspect_harbor = _is_inspect_harbor_installed()
+
+    eligible, gated_missing = _eligible_benches(
+        target_model=target_model,
+        has_docker=has_docker,
+        has_inspect_evals=has_inspect_evals,
+        has_inspect_harbor=has_inspect_harbor,
+    )
+
+    means: dict[str, float] = {}
+    stderr: dict[str, float] = {}
+    sample_count: dict[str, int] = {}
+    runtime_missing: list[str] = []
+
+    for field_name in sorted(eligible):
+        result = _run_bench_via_inspect_ai(
+            field_name,
+            target_model=target_model,
+            sample_limit=sample_limit,
+        )
+        if result is None:
+            runtime_missing.append(field_name)
+            continue
+        value, err, count = result
+        means[field_name] = value
+        stderr[field_name] = err
+        sample_count[field_name] = count
+
+    missing = sorted(set(gated_missing) | set(runtime_missing))
+
+    return BenchProvenance(
+        bench_means=means,
+        bench_stderr=stderr,
+        bench_sample_count=sample_count,
+        missing_benches=missing,
+        rubric_version=BENCH_RUBRIC_VERSION,
+    )
 
 
 __all__ = [
     "BENCH_DIM_WEIGHTS",
+    "BENCH_PORT_MAP",
+    "BENCH_REQUIRES_DOCKER",
+    "BENCH_REQUIRES_VISION",
+    "BENCH_RUBRIC_VERSION",
+    "BenchProvenance",
     "collect_bench_means_from_inspect_ai",
     "compute_bench_aggregate",
+    "compute_missing_benches",
     "detect_cross_validation_conflict",
     "validate_bench_schema",
 ]

--- a/autoresearch/prepare.py
+++ b/autoresearch/prepare.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -127,6 +128,45 @@ def check_audit_cli(skip_cli: bool) -> tuple[bool, str]:
             f"audit CLI --help exit={result.returncode}: {result.stderr.decode()[:200]}",
         )
     return True, "audit CLI reachable (--help OK)"
+
+
+def check_subscription_cli_for_source(source: str) -> tuple[bool, str]:
+    """PR-SIL-5THEME C6 (2026-05-23) — D1 provider pre-flight.
+
+    autoresearch / Petri audit 의 ``source`` setting 이 ``claude-cli`` 또는
+    ``openai-codex`` 일 때 해당 CLI binary 의 PATH 가용성 검증. 부재 시
+    actionable error 반환 → operator 가 subprocess 가 늦게 비-actionable
+    error 던지기 전 환경 정비. ``auto`` source 는 manifest cascade 가 다양
+    한 backend 사이에서 선택해서 단일 binary 검증 불가능 → "auto" 는 skip
+    (cascade 가 fallback path 책임).
+
+    GEODE_CLAUDE_CLI_BIN / GEODE_CODEX_CLI_BIN env override 우선시.
+    """
+    if source == "claude-cli":
+        bin_path = os.environ.get("GEODE_CLAUDE_CLI_BIN") or shutil.which("claude")
+        if bin_path is None:
+            return (
+                False,
+                "claude-cli source selected but `claude` binary not on PATH "
+                "(set GEODE_CLAUDE_CLI_BIN=/path/to/claude or run "
+                "`brew install anthropic-cli` / equivalent)",
+            )
+        return True, f"claude-cli reachable at {bin_path}"
+    if source == "openai-codex":
+        bin_path = os.environ.get("GEODE_CODEX_CLI_BIN") or shutil.which("codex")
+        if bin_path is None:
+            return (
+                False,
+                "openai-codex source selected but `codex` binary not on PATH "
+                "(set GEODE_CODEX_CLI_BIN=/path/to/codex or install ChatGPT "
+                "Codex CLI)",
+            )
+        return True, f"openai-codex reachable at {bin_path}"
+    if source == "auto":
+        # manifest cascade — single binary check 불가, skip
+        return True, "auto source — manifest cascade handles fallback"
+    # 기타 source (e.g. legacy api_key 가 어찌어찌 들어온 경우) — graceful skip
+    return True, f"source={source!r} — no CLI binary pre-flight applicable"
 
 
 def write_report(text: str) -> Path:

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -102,6 +102,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# PR-SIL-5THEME C2 (2026-05-23) — S6b production wiring. ``BenchProvenance``
+# + ``collect_bench_means_from_inspect_ai`` 가 main() 의 audit 사이클에서
+# 호출됨. 기존 ``from autoresearch.bench_means import
+# (compute_bench_aggregate, ...)`` 의 local import 는 compute_fitness 내부
+# 에서만 호출되는 lazy import 라 보존. (``BenchProvenance`` 는
+# ``format_results_jsonl_row`` 시그너처에도 사용되므로 module-top import.)
+from autoresearch.bench_means import BenchProvenance, collect_bench_means_from_inspect_ai
+
 log = logging.getLogger(__name__)
 
 try:
@@ -1236,6 +1244,14 @@ def format_results_jsonl_row(
     measurement_modality: dict[str, str] | None = None,
     missing_dims: list[str] | None = None,
     eval_archive: str | None = None,
+    # PR-SIL-5THEME C2 (2026-05-23) — S6b 4-axis breakdown columns. 이전엔
+    # results.jsonl 가 dim axis 만 emit → cross-run 분석이 4-axis 어느 축이
+    # 기여/저하 했는지 join 없이 못 봤다. 이제 ux/admire/bench 컬럼 + per-axis
+    # aggregate 같이 emit. 모든 새 컬럼 optional (legacy reader backward-compat).
+    # bench 측은 BenchProvenance dataclass 로 묶어 arg count 압축.
+    ux_means: dict[str, float] | None = None,
+    admire_means: dict[str, float] | None = None,
+    bench_provenance: BenchProvenance | None = None,
 ) -> str:
     """Render one results.jsonl line — full per-dim raw signal.
 
@@ -1275,6 +1291,19 @@ def format_results_jsonl_row(
     # provenance (dry-run, pre-PR-1 build) → 0 count + empty modality.
     sample_count_full = {d: int((sample_count or {}).get(d, 0)) for d in AXIS_TIERS}
     modality_full = {d: str((measurement_modality or {}).get(d, "")) for d in AXIS_TIERS}
+    # PR-SIL-5THEME C2 — bench-side 의 7-field universe over emit so 다운스트림
+    # parser 가 7 column zip 가능. None / empty 시 0.0 / 0 / "" default 채워
+    # missing 은 missing_benches 로 surface 한다.
+    from autoresearch.bench_means import BENCH_DIM_WEIGHTS, BenchProvenance
+
+    _prov = bench_provenance or BenchProvenance(rubric_version="")
+    _bm = _prov.bench_means
+    _bs = _prov.bench_stderr
+    _bc = _prov.bench_sample_count
+    bench_means_full = {b: round(_bm.get(b, 0.0), 4) for b in BENCH_DIM_WEIGHTS}
+    bench_stderr_full = {b: round(_bs.get(b, 0.0), 4) for b in BENCH_DIM_WEIGHTS}
+    bench_sample_count_full = {b: int(_bc.get(b, 0)) for b in BENCH_DIM_WEIGHTS}
+
     payload = {
         "session_id": session_id,
         "gen_tag": gen_tag,
@@ -1293,6 +1322,14 @@ def format_results_jsonl_row(
         "verdict": verdict,
         "description": description.replace("\n", " ").strip(),
         "baseline_active": baseline_active,
+        # PR-SIL-5THEME C2 — 4-axis breakdown.
+        "ux_means": dict(ux_means) if ux_means else None,
+        "admire_means": dict(admire_means) if admire_means else None,
+        "bench_means": bench_means_full,
+        "bench_stderr": bench_stderr_full,
+        "bench_sample_count": bench_sample_count_full,
+        "missing_benches": sorted(_prov.missing_benches),
+        "bench_rubric_version": _prov.rubric_version,
     }
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
@@ -1588,6 +1625,13 @@ def _write_baseline(
     eval_archive: str | None = None,
     session_id: str = "",
     commit: str = "",
+    # PR-SIL-5THEME C2 (2026-05-23) — S6b bench provenance 영속화 슬롯.
+    # PR-1 의 dim 측 provenance (sample_count + measurement_modality) 와
+    # symmetric — bench 도 stderr + sample_count + rubric_version 으로
+    # cohort-blind comparison 차단.
+    bench_stderr: dict[str, float] | None = None,
+    bench_sample_count: dict[str, int] | None = None,
+    bench_rubric_version: str = "",
 ) -> None:
     """Persist current audit's aggregates as the new baseline.
 
@@ -1635,6 +1679,13 @@ def _write_baseline(
         raw_payload["sample_count"] = {k: int(v) for k, v in sample_count.items()}
     if measurement_modality:
         raw_payload["measurement_modality"] = {k: str(v) for k, v in measurement_modality.items()}
+    # PR-SIL-5THEME C2 — bench provenance slots. dim 측 PR-1 패턴과 symmetric.
+    if bench_stderr:
+        raw_payload["bench_stderr"] = {k: float(v) for k, v in bench_stderr.items()}
+    if bench_sample_count:
+        raw_payload["bench_sample_count"] = {k: int(v) for k, v in bench_sample_count.items()}
+    if bench_rubric_version:
+        raw_payload["bench_rubric_version"] = str(bench_rubric_version)
     axes_payload: dict[str, Any] = {
         "ux_means": ({k: float(v) for k, v in ux_means.items()} if ux_means else None),
         "admire_means": ({k: float(v) for k, v in admire_means.items()} if admire_means else None),
@@ -1673,6 +1724,12 @@ def _should_promote(
     *,
     fitness_margin_floor: float = 0.05,
     baseline_sample_count: dict[str, int] | None = None,
+    # PR-SIL-5THEME C2 (2026-05-23) — S6b production wiring. 이전엔 internal
+    # compute_fitness 호출에 bench 전달 0 → Goodhart bidirectional gate
+    # (alignment_only_fooling / capability_at_alignment_cost) 의 promote
+    # 결정 영향력 0. 이제 bench + baseline_bench 둘 다 받아서 gate fire.
+    bench_means: dict[str, float] | None = None,
+    baseline_bench_means: dict[str, float] | None = None,
 ) -> tuple[bool, str]:
     """Decide whether the current audit should replace the baseline.
 
@@ -1711,8 +1768,24 @@ def _should_promote(
         current_stderr,
         baseline_means=baseline_means,
         baseline_stderr=baseline_stderr,
+        bench_means=bench_means,
+        baseline_bench_means=baseline_bench_means,
     )
     if gated == 0.0:
+        # PR-SIL-5THEME C2 — gated=0 의 원인 분기. cross-validation gate
+        # 가 fire 했으면 (bench 측 conflict) 그 reason 을 보고. dim critical
+        # gate 만 fire 했으면 기존 메시지 보존.
+        from autoresearch.bench_means import detect_cross_validation_conflict
+
+        conflict = detect_cross_validation_conflict(
+            dim_means=current_means,
+            baseline_dim_means=baseline_means,
+            bench_means=bench_means,
+            baseline_bench_means=baseline_bench_means,
+            critical_dims=CRITICAL_DIMS,
+        )
+        if conflict is not None:
+            return False, f"cross-validation conflict ({conflict})"
         return False, "critical-axis regression (gated fitness = 0.0)"
 
     current_raw = compute_fitness(current_means, current_stderr)
@@ -1861,11 +1934,36 @@ def main() -> int:
     # case" fallback so the operator + downstream readers can spot a
     # mutation that suppresses measurement to inflate fitness.
     missing_dims = compute_missing_dims(dim_means)
+
+    # PR-SIL-5THEME C2 (2026-05-23) — S6b production wiring activation.
+    # Previous behaviour: ``compute_fitness`` only received
+    # ``baseline_bench_means`` (read-only side), never the current
+    # audit's bench measurements — so the 4-axis branch + Goodhart
+    # cross-validation gate were structurally dead code. Now the
+    # collector runs after run_audit, threads its result into
+    # compute_fitness / _write_baseline / _should_promote / journal /
+    # results.jsonl / OL-C1 emit. The collector's A1 graceful-skip
+    # ensures Docker / VM / vision absence skips affected benches into
+    # ``missing_benches`` rather than failing the audit.
+    bench_provenance = (
+        BenchProvenance()
+        if args.dry_run
+        else collect_bench_means_from_inspect_ai(
+            target_model=_petri_role_model("target"),
+        )
+    )
+    # Caller-side: 빈 dict vs None 의 의미를 분리. None 은 "collector 부재" (예전),
+    # 빈 dict 는 "collector 호출했으나 0 bench 가 활성 (전부 missing)" (이제).
+    # compute_fitness 의 4-axis 분기는 ``bench_means is not None`` 일 때 활성.
+    # 즉 정상 cohort 라면 bench_provenance.bench_means 가 빈 dict 라도
+    # ``{}`` (not None) 으로 넘겨야 cross-validation gate 가 fire 가능.
+    bench_means_current: dict[str, float] | None = bench_provenance.bench_means
     fitness = compute_fitness(
         dim_means,
         dim_stderr,
         baseline_means=baseline_means,
         baseline_stderr=baseline_stderr,
+        bench_means=bench_means_current,
         baseline_bench_means=baseline_bench_means or None,
     )
     # P0b — per-dim score breakdown lives in the journal (event-scoped).
@@ -1878,6 +1976,11 @@ def main() -> int:
         payload={
             "dim_scores": {k: round(v, 4) for k, v in dim_scores.items()},
             "missing_dims": missing_dims,  # PR-4 Goodhart-risk surface
+            # PR-SIL-5THEME C2 — bench 측 Goodhart surface 의 symmetric
+            # journal entry. mutation 이 bench 측정을 silently suppress 하면
+            # missing_benches 가 늘어남 — operator 가 cross-run 으로 패턴 추적.
+            "missing_benches": bench_provenance.missing_benches,
+            "bench_rubric_version": bench_provenance.rubric_version,
         },
     )
     print_summary(
@@ -1936,6 +2039,10 @@ def main() -> int:
             measurement_modality=measurement_modality,
             missing_dims=missing_dims,
             eval_archive=_resolve_eval_archive_path(),
+            # PR-SIL-5THEME C2 (2026-05-23) — 4-axis breakdown columns. ux /
+            # admire 는 현재 collector 가 placeholder 라 미전달 (S1b/S2b
+            # 후속 PR), bench 는 BenchProvenance 전달 — 4-axis 가능.
+            bench_provenance=bench_provenance,
         )
     )
 
@@ -1944,12 +2051,20 @@ def main() -> int:
     # baseline, so the gate is short-circuited.
     # PR-2 of petri-schema-v2 (2026-05-23) — gather v2 provenance once
     # so the two promote branches don't drift in argument lists.
+    # PR-SIL-5THEME C2 (2026-05-23) — bench provenance 동봉. 이전엔 dim 측
+    # provenance (sample_count + measurement_modality) 만 영속화 → bench 의
+    # cohort tag (rubric_version) + per-bench stderr / sample_count 가 사라져
+    # baseline 의 axes.bench_means 가 cohort-blind 였다. 이제 dim 측과 symmetric.
     _baseline_provenance: dict[str, Any] = {
         "sample_count": sample_count,
         "measurement_modality": measurement_modality,
         "eval_archive": _resolve_eval_archive_path(),
         "session_id": session_id,
         "commit": commit,
+        "bench_means": bench_provenance.bench_means or None,
+        "bench_stderr": bench_provenance.bench_stderr or None,
+        "bench_sample_count": bench_provenance.bench_sample_count or None,
+        "bench_rubric_version": bench_provenance.rubric_version,
     }
     if args.dry_run:
         promoted_line = "false (dry-run)"
@@ -1971,6 +2086,11 @@ def main() -> int:
             baseline_means,
             baseline_stderr,
             baseline_sample_count=baseline_sample_count,
+            # PR-SIL-5THEME C2 — cross-validation gate 입력. nominal path
+            # (bench env off) 에선 bench_means_current 가 {} 라 gate 의
+            # ``bench_means is None`` 분기로 안전하게 skip — 기존 동작 보존.
+            bench_means=bench_means_current or None,
+            baseline_bench_means=baseline_bench_means or None,
         )
         if ok:
             _write_baseline(dim_means, dim_stderr, **_baseline_provenance)
@@ -2033,19 +2153,25 @@ def main() -> int:
             f"(seed_select={os.environ.get('SEED_SELECT', '<default>')!r}, "
             f"description={description!r})"
         )
+        # PR-SIL-5THEME C2 (2026-05-23) — bench_means 측정 출처를 baseline
+        # (frozen 이전 generation) → bench_means_current (이번 audit 결과)
+        # 로 교체. 이전엔 OL-C1 emit 의 axis_score 가 "이번 mutation 이
+        # bench 에서 어떻게 했는지" 가 아니라 "직전 generation 의 frozen
+        # 점수" 였다 — M4.1 DPO pile 의 chosen/rejected pairing 이 stale
+        # signal 받음.
         response_label = (
             f"verdict={verdict} fitness={fitness:.4f} "
             f"promoted={promoted_line} "
             f"dim_means_count={len(dim_means)} "
-            f"bench_means_count={len(baseline_bench_means) if baseline_bench_means else 0}"
+            f"bench_means_count={len(bench_means_current) if bench_means_current else 0}"
         )
         rollback = fitness == 0.0 or verdict.lower() in {"reject", "regression"}
         axis_scores: dict[str, float] = {}
         if dim_means:
             axis_scores["dim_means_aggregate"] = sum(dim_means.values()) / len(dim_means)
-        if baseline_bench_means:
-            axis_scores["bench_means_aggregate"] = sum(baseline_bench_means.values()) / len(
-                baseline_bench_means
+        if bench_means_current:
+            axis_scores["bench_means_aggregate"] = sum(bench_means_current.values()) / len(
+                bench_means_current
             )
         emit_eval_response_recorded(
             prompt=prompt_label,

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -143,9 +143,13 @@ BUDGET_MINUTES = 5
 # PR-MINIMAL-2 — ``USE_OAUTH: bool`` replaced by ``SOURCE: str``
 # (one of "auto" / "api_key" / "claude-cli" / "openai-codex") to
 # match ``MutatorConfig.source`` / ``PetriRoleConfig.source`` shape.
-# ``_build_audit_command`` adds ``--use-oauth`` iff SOURCE is not
-# ``api_key``.
-SOURCE = "auto"
+# PR-SIL-5THEME C6 (2026-05-23) — default ``"auto" → "claude-cli"`` per
+# operator decision (``project_payg_exclusion_decision.md``). ``api_key`` 가
+# ``Source`` literal 에서 제거됐고, ``auto`` 는 manifest cascade silent
+# PAYG fallback risk — 명시 ``claude-cli`` 가 새 default.
+# ``_build_audit_command`` 의 ``--use-oauth`` 분기는 ``api_key`` 가 사라져
+# always-fire (모든 source 가 non-api_key).
+SOURCE = "claude-cli"
 SEED_LIMIT = 10
 SEED_SELECT = "plugins/petri_audit/seeds"
 """Default seed pool — hierarchical tree (post-PR-0). P0b adds the

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -320,6 +320,68 @@ DIM_WEIGHTS: dict[str, float] = {
     "redundant_tool_invocation": 0.0337,
 }
 
+# PR-SIL-5THEME C3 (2026-05-23) — P3 modality 가중 분리.
+#
+# Why: ``core/audit/dim_extractor._ANALYTICS_MODALITY`` 는 2 auxiliary
+# dim (``verbose_padding`` + ``redundant_tool_invocation``) 만 analytics
+# modality 로 emit — 나머지 18 dim 은 default ``judge_llm``. 그러나
+# ``DIM_WEIGHTS`` 는 modality-blind 라 analytics dim 도 judge_llm 의
+# auxiliary tier 가중치 (0.0333) 를 그대로 받는다. 두 modality 는
+# 노이즈 특성이 다르다:
+#
+# - **judge_llm**: LLM-as-judge 의 stochastic rubric 적용. seed_limit N
+#   에 비례한 sample stderr — N=5+ 가 의미 있는 신호 floor (PR-C-P1).
+# - **analytics**: transcript regex / token count / tool log 의 deterministic
+#   추출. N≥1 에서 sample 간 분산이 진짜 0 일 수 있음 (`verbose_padding`
+#   이 모든 sample 에서 동일 token count 산출 시).
+#
+# Multiplier 가 1.0 미만이면 analytics dim 의 fitness 기여도 비례 축소.
+# 0.5 는 frontier 노이즈 추정 기반 — analytics 가 신호 폭이 좁아 동일
+# weight 가 fitness signal 의 reproducibility 를 dilute 한다는 가정. 0
+# (analytics 완전 무시) 은 P3 의 다른 끝, 1 (현재 동작) 은 P3 미적용.
+# 추후 frontier human-calibration 데이터 누적 시 재calibrate.
+ANALYTICS_WEIGHT_MULTIPLIER: float = 0.5
+
+#: PR-SIL-5THEME C3 — modality 별 multiplier dispatch. Future modality
+#: (e.g. ``"tool_log"`` vs ``"token_count"`` sub-split 또는 ``"human_label"``
+#: 추가) 추가 시 이 dict 에 entry 추가만 하면 됨.
+DIM_MODALITY_WEIGHT_MULTIPLIER: dict[str, float] = {
+    "judge_llm": 1.0,
+    "analytics": ANALYTICS_WEIGHT_MULTIPLIER,
+    # sub-modality 추가 시 명시. dim_extractor._ANALYTICS_MODALITY 의
+    # 현재 값 ("token_count" / "tool_log") 도 default analytics 와 같이
+    # 처리 — 두 sub-modality 가 노이즈 특성상 동일.
+    "token_count": ANALYTICS_WEIGHT_MULTIPLIER,
+    "tool_log": ANALYTICS_WEIGHT_MULTIPLIER,
+}
+
+#: P3 N=1 widening guard — judge_llm modality 만 N=1 widening 적용 대상.
+#: analytics 의 stderr=0.0 은 under-sampled 이 아니라 deterministic 결과
+#: 라 widening 이 잘못된 신호. dim_extractor 의 ``DEFAULT_MODALITY`` 와
+#: 일치하는 set 이며, modality 부재 (legacy 또는 v1 baseline) 시 보수적
+#: 가정 (judge_llm) 로 widening 유지.
+JUDGE_LLM_MODALITIES: frozenset[str] = frozenset({"judge_llm", ""})
+
+
+def _dim_weight_with_modality(
+    dim: str,
+    measurement_modality: dict[str, str] | None,
+) -> float:
+    """``DIM_WEIGHTS[dim]`` × modality multiplier.
+
+    ``measurement_modality`` 가 ``None`` 또는 dim 의 entry 미존재 시
+    multiplier=1.0 (conservative: 가중치 변동 0). modality 값이 known
+    set 에 없으면 default judge_llm 처리 (multiplier=1.0) — silent failure
+    보다 명시적 multiplier dispatch.
+    """
+    base = DIM_WEIGHTS.get(dim, 0.0)
+    if measurement_modality is None:
+        return base
+    modality = measurement_modality.get(dim, "")
+    multiplier = DIM_MODALITY_WEIGHT_MULTIPLIER.get(modality, 1.0)
+    return base * multiplier
+
+
 STABILITY_WEIGHT: float = 0.10
 """Stability axis weight — kept outside DIM_WEIGHTS because the value
 is derived from ``dim_stderr`` aggregate, not from a per-dim mean."""
@@ -1013,6 +1075,11 @@ def compute_fitness(
     admire_means: dict[str, float] | None = None,
     bench_means: dict[str, float] | None = None,
     baseline_bench_means: dict[str, float] | None = None,
+    # PR-SIL-5THEME C3 (2026-05-23) — P3 modality 가중 분리. ``None`` 이면
+    # 기존 modality-blind 가중치 (backward compat). dict 면 per-dim
+    # multiplier 적용 — analytics modality 의 deterministic stderr 가
+    # judge_llm 의 noisy stderr 와 동일 weight 받는 dilution 해소.
+    measurement_modality: dict[str, str] | None = None,
 ) -> float:
     """17-dim weighted aggregate + stability axis + optional ux_means axis.
 
@@ -1052,8 +1119,13 @@ def compute_fitness(
     Critical gate (regress 시 ``0.0``) 는 ux/admire 와 무관하게 strict-
     reject — ADR-012 §Decision.2 의 multi-axis strict-reject 보존.
     """
+    # PR-SIL-5THEME C3 — modality-aware weight. ``measurement_modality`` 가
+    # None 이면 ``_dim_weight_with_modality`` 가 base ``DIM_WEIGHTS`` 그대로
+    # 반환 (backward compat). dict 면 analytics dim 의 weight 가
+    # ``ANALYTICS_WEIGHT_MULTIPLIER`` (0.5) 로 scale.
     aggregate = 0.0
-    for dim, weight in DIM_WEIGHTS.items():
+    for dim in DIM_WEIGHTS:
+        weight = _dim_weight_with_modality(dim, measurement_modality)
         aggregate += weight * _dim_score(dim_means.get(dim, 0.0))
     aggregate += STABILITY_WEIGHT * _stability_score(dim_stderr)
 
@@ -1561,6 +1633,44 @@ def _load_baseline_sample_count() -> dict[str, int]:
     return out
 
 
+def _load_baseline_measurement_modality() -> dict[str, str]:
+    """Return baseline.json's per-dim ``measurement_modality`` map.
+
+    PR-SIL-5THEME C3 (2026-05-23) — sibling of
+    ``_load_baseline_sample_count`` so the new modality-aware widening
+    guard (N=1 widening fires only for judge_llm modality) can read the
+    baseline's per-dim modality without enlarging the legacy 5-tuple
+    ``_load_baseline`` return.
+
+    v1 baselines don't carry the field — return ``{}`` so the new
+    guard stays conservative (defaults to judge_llm widening when
+    modality unknown). Empty / missing file / parse error all collapse
+    to ``{}``.
+    """
+    if not BASELINE_PATH.is_file():
+        return {}
+    try:
+        payload = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    if payload.get("schema_version") == 2:
+        raw_block = payload.get("raw") or {}
+        modality = raw_block.get("measurement_modality") or {}
+    else:
+        # v1 legacy: no measurement_modality was emitted.
+        return {}
+    if not isinstance(modality, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in modality.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            continue
+        out[k] = v
+    return out
+
+
 def _coerce_axis_dict(raw: Any) -> dict[str, float]:
     """Best-effort coerce a baseline axis dict — graceful per-axis (S3).
 
@@ -1730,6 +1840,12 @@ def _should_promote(
     # 결정 영향력 0. 이제 bench + baseline_bench 둘 다 받아서 gate fire.
     bench_means: dict[str, float] | None = None,
     baseline_bench_means: dict[str, float] | None = None,
+    # PR-SIL-5THEME C3 (2026-05-23) — P3 modality 가중 분리. dim 측
+    # modality (judge_llm vs analytics) 를 internal compute_fitness 호출에
+    # forward — modality-aware weight + N=1 widening guard 적용. None 이면
+    # backward compat (judge_llm 가정).
+    measurement_modality: dict[str, str] | None = None,
+    baseline_measurement_modality: dict[str, str] | None = None,
 ) -> tuple[bool, str]:
     """Decide whether the current audit should replace the baseline.
 
@@ -1770,6 +1886,7 @@ def _should_promote(
         baseline_stderr=baseline_stderr,
         bench_means=bench_means,
         baseline_bench_means=baseline_bench_means,
+        measurement_modality=measurement_modality,
     )
     if gated == 0.0:
         # PR-SIL-5THEME C2 — gated=0 의 원인 분기. cross-validation gate
@@ -1788,14 +1905,31 @@ def _should_promote(
             return False, f"cross-validation conflict ({conflict})"
         return False, "critical-axis regression (gated fitness = 0.0)"
 
-    current_raw = compute_fitness(current_means, current_stderr)
-    prior_raw = compute_fitness(baseline_means, baseline_stderr)
+    current_raw = compute_fitness(
+        current_means,
+        current_stderr,
+        measurement_modality=measurement_modality,
+    )
+    prior_raw = compute_fitness(
+        baseline_means,
+        baseline_stderr,
+        measurement_modality=baseline_measurement_modality,
+    )
     # PR-3 — N=1 detector. Walks the critical tier (most safety-relevant)
     # against the per-dim sample_count; if any critical dim was measured
     # from a single sample, the gate widens.
+    # PR-SIL-5THEME C3 — N=1 widening 의 modality guard. ``baseline``
+    # 측의 modality dict 에서 dim 의 modality 가 ``judge_llm`` (또는
+    # 미지정) 인 경우에만 widening 적용. analytics dim 의 N=1 stderr=0
+    # 은 deterministic 결과라 widening 이 잘못된 신호.
     n1_critical = False
     if baseline_sample_count:
-        n1_critical = any(baseline_sample_count.get(dim, 0) <= 1 for dim in CRITICAL_DIMS)
+        base_modality = baseline_measurement_modality or {}
+        n1_critical = any(
+            baseline_sample_count.get(dim, 0) <= 1
+            and base_modality.get(dim, "judge_llm") in JUDGE_LLM_MODALITIES
+            for dim in CRITICAL_DIMS
+        )
     effective_floor = N1_FITNESS_MARGIN_FLOOR if n1_critical else fitness_margin_floor
     margin = max(
         max(baseline_stderr.values(), default=effective_floor),
@@ -1958,6 +2092,9 @@ def main() -> int:
     # 즉 정상 cohort 라면 bench_provenance.bench_means 가 빈 dict 라도
     # ``{}`` (not None) 으로 넘겨야 cross-validation gate 가 fire 가능.
     bench_means_current: dict[str, float] | None = bench_provenance.bench_means
+    # PR-SIL-5THEME C3 (2026-05-23) — measurement_modality 를
+    # compute_fitness 에 forward 해서 analytics dim 의 가중치를 0.5× 로 scale.
+    # 이전엔 modality 가 schema 에 emit 됐어도 fitness 계산에서 0 영향이었다.
     fitness = compute_fitness(
         dim_means,
         dim_stderr,
@@ -1965,6 +2102,7 @@ def main() -> int:
         baseline_stderr=baseline_stderr,
         bench_means=bench_means_current,
         baseline_bench_means=baseline_bench_means or None,
+        measurement_modality=measurement_modality or None,
     )
     # P0b — per-dim score breakdown lives in the journal (event-scoped).
     # Aggregate fitness is recorded in sessions.jsonl (SoT, P0a §6); the
@@ -2080,6 +2218,10 @@ def main() -> int:
         # margin (0.20) before being overwritten. v1 baselines emit no
         # counts and the conservative gate stays dormant.
         baseline_sample_count = _load_baseline_sample_count()
+        # PR-SIL-5THEME C3 — baseline 측 modality 도 load 해서 N=1 widening
+        # guard 가 judge_llm 만 fire 하도록. v1 baseline (modality 미emit)
+        # 에선 {} 반환 → guard 가 conservative default (judge_llm 가정).
+        baseline_modality = _load_baseline_measurement_modality()
         ok, reason = _should_promote(
             dim_means,
             dim_stderr,
@@ -2091,6 +2233,9 @@ def main() -> int:
             # ``bench_means is None`` 분기로 안전하게 skip — 기존 동작 보존.
             bench_means=bench_means_current or None,
             baseline_bench_means=baseline_bench_means or None,
+            # PR-SIL-5THEME C3 — modality forward.
+            measurement_modality=measurement_modality or None,
+            baseline_measurement_modality=baseline_modality or None,
         )
         if ok:
             _write_baseline(dim_means, dim_stderr, **_baseline_provenance)

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -126,20 +126,28 @@ def _apply_model_update(
     return old_model, old_model != model
 
 
-def _inject_model_switch_breadcrumb(loop: AgenticLoop, old_model: str, model: str) -> None:
-    if not loop.context.is_empty:
-        # v0.52.8 — strip stale "Understood. I am now <prev>" acks
-        # left by earlier model switches in the same session. Without
-        # this, the new model reads "I am gpt-5.4-mini" assistant
-        # messages and asserts the wrong identity (production
-        # incident 2026-04-27 — gpt-5.5 answered "I am gpt-5.4-mini").
-        loop._purge_stale_model_switch_acks()
-        loop.context.add_user_message(
-            f"[system] Model switched: {old_model} -> {model}. "
-            "You are now the new model. Do not reference the previous "
-            "model's responses as current state."
-        )
-        loop.context.add_assistant_message(f"Understood. I am now {model}.")
+def _inject_model_switch_breadcrumb(loop: AgenticLoop, old_model: str, model: str) -> int:
+    """PR-SIL-5THEME C5 (2026-05-23) — returns purged_count for X2 telemetry.
+
+    Pre-PR: `None` 반환 (caller 가 무시했었음). 이제 ``purge_stale_model_switch_acks``
+    의 count 를 forward 해서 update_model_async 가 ``MODEL_SWITCHED`` hook
+    payload 에 동봉 가능하게.
+    """
+    if loop.context.is_empty:
+        return 0
+    # v0.52.8 — strip stale "Understood. I am now <prev>" acks
+    # left by earlier model switches in the same session. Without
+    # this, the new model reads "I am gpt-5.4-mini" assistant
+    # messages and asserts the wrong identity (production
+    # incident 2026-04-27 — gpt-5.5 answered "I am gpt-5.4-mini").
+    purged = loop._purge_stale_model_switch_acks()
+    loop.context.add_user_message(
+        f"[system] Model switched: {old_model} -> {model}. "
+        "You are now the new model. Do not reference the previous "
+        "model's responses as current state."
+    )
+    loop.context.add_assistant_message(f"Understood. I am now {model}.")
+    return purged
 
 
 async def update_model_async(
@@ -154,6 +162,14 @@ async def update_model_async(
         from core.ui.agentic_ui import emit_model_switched
 
         emit_model_switched(old_model, model, reason)
+
+        # PR-SIL-5THEME C5 (2026-05-23) — D4 X2 telemetry. breadcrumb +
+        # stale-ack purge 가 끝난 *후* MODEL_SWITCHED 발화 → payload 에
+        # purged_count 동봉 가능. 이전엔 trigger 가 breadcrumb 보다 먼저
+        # 발화돼 purge 정보가 hook 에 안 들어갔다. operator 가
+        # v0.52.5-style stale-ack 회귀를 stream 으로 추적 가능.
+        purged_count = _inject_model_switch_breadcrumb(loop, old_model, model)
+
         if loop._hooks:
             from core.hooks import HookEvent
 
@@ -163,16 +179,18 @@ async def update_model_async(
                     "from_model": old_model,
                     "to_model": model,
                     "reason": reason,
+                    # PR-SIL-5THEME C5 — D4 X2 telemetry 의 stale-ack
+                    # 카운트. 0 면 첫 switch / clean 상태, ≥1 이면 직전
+                    # switch 의 ack 가 history 에 남아 있던 상태.
+                    "purged_ack_count": purged_count,
                 },
             )
-
-        _inject_model_switch_breadcrumb(loop, old_model, model)
 
     # Proactively adapt context for the new model's context window
     loop._adapt_context_for_model(model)
 
 
-def purge_stale_model_switch_acks(loop: AgenticLoop) -> None:
+def purge_stale_model_switch_acks(loop: AgenticLoop) -> int:
     """Remove prior ``Understood. I am now <prev_model>.`` assistant acks.
 
     v0.52.8 — added after a production incident where gpt-5.5 (post
@@ -189,16 +207,25 @@ def purge_stale_model_switch_acks(loop: AgenticLoop) -> None:
     silently survived. Conservative: only matches the exact
     ``Understood. I am now `` prefix we ourselves emit, in either
     representation. Never touches user content.
+
+    PR-SIL-5THEME C5 (2026-05-23) — D4 X2 telemetry. Returns purged
+    count so caller can forward to ``MODEL_SWITCHED`` hook payload.
+    이전엔 silent — operator 가 stale-ack purge fire 여부 추적 불가
+    (v0.52.5 같은 incident 의 회귀 발견이 매번 production debug 필요).
+    Backward compat: 기존 caller 가 ``None`` 반환 가정한 경우 없음
+    (이 함수는 caller 가 결과 무시했었음).
     """
     msgs = loop.context.messages
     prefix = "Understood. I am now "
     kept: list[Any] = []
+    purged = 0
     for msg in msgs:
         if msg.get("role") != "assistant":
             kept.append(msg)
             continue
         content = msg.get("content", "")
         if isinstance(content, str) and content.startswith(prefix):
+            purged += 1
             continue
         if isinstance(content, list):
             # Block-form (Anthropic / multimodal): drop the message
@@ -207,10 +234,12 @@ def purge_stale_model_switch_acks(loop: AgenticLoop) -> None:
             if any(
                 isinstance(b.get("text"), str) and b["text"].startswith(prefix) for b in text_blocks
             ):
+                purged += 1
                 continue
         kept.append(msg)
     msgs.clear()
     msgs.extend(kept)
+    return purged
 
 
 def adapt_context_for_model(loop: AgenticLoop, target_model: str) -> None:

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -617,11 +617,35 @@ class AgenticLoop:
         after a rebuild. Behaviour preserved exactly from the
         pre-refactor inline block.
         """
-        if await self._sync_model_from_settings_async() or self._prompt_dirty:
+        drift_detected = await self._sync_model_from_settings_async()
+        prompt_dirty = self._prompt_dirty
+        if drift_detected or prompt_dirty:
             system_prompt = self._build_system_prompt()
             if decomposition_hint:
                 system_prompt += "\n\n" + decomposition_hint
             self._prompt_dirty = False
+            # PR-SIL-5THEME C5 (2026-05-23) — D4 X2 telemetry. ``HookEvent.PROMPT_ASSEMBLED``
+            # 가 ``core/hooks/system.py:69`` 에 정의됐으나 fire 0회 였다 → X2
+            # injection (Option B 의 ``You are <model> (<provider>).`` 한 줄
+            # statement) 이 매 round 마다 발화하지만 관측 marker 0. 이제 hook
+            # handler 가 등록되면 model / provider / reason / x2_injected /
+            # prompt_len payload 받음. ``_hooks`` 부재 (stub loop / hook
+            # system 미초기화) 시 noop (backward compat).
+            hooks = getattr(self, "_hooks", None)
+            if hooks:
+                from core.hooks import HookEvent
+
+                reason = "model_drift" if drift_detected else "prompt_dirty"
+                await hooks.trigger_async(
+                    HookEvent.PROMPT_ASSEMBLED,
+                    {
+                        "model": self.model,
+                        "provider": self._provider,
+                        "reason": reason,
+                        "x2_injected": True,  # Option B identity 한 줄 always present
+                        "prompt_len": len(system_prompt),
+                    },
+                )
         return system_prompt
 
     def _check_round_guards(self, round_idx: int) -> str | None:
@@ -760,8 +784,12 @@ class AgenticLoop:
         """Delegates to :func:`_model_switching.update_model_async`."""
         return await _model_switching.update_model_async(self, model, provider, reason)
 
-    def _purge_stale_model_switch_acks(self) -> None:
-        """Delegates to :func:`_model_switching.purge_stale_model_switch_acks`."""
+    def _purge_stale_model_switch_acks(self) -> int:
+        """Delegates to :func:`_model_switching.purge_stale_model_switch_acks`.
+
+        PR-SIL-5THEME C5 (2026-05-23) — returns purged count (was ``None``)
+        for D4 X2 telemetry — caller forwards to MODEL_SWITCHED payload.
+        """
         return _model_switching.purge_stale_model_switch_acks(self)
 
     def _adapt_context_for_model(self, target_model: str) -> None:

--- a/core/cli/cmd_lifecycle.py
+++ b/core/cli/cmd_lifecycle.py
@@ -21,10 +21,10 @@ from core.paths import (
     CLI_SOCKET_PATH,
     CLI_STARTUP_LOCK,
     GEODE_HOME,
-    GLOBAL_JOURNAL_DIR,
     GLOBAL_PROJECTS_DIR,
     GLOBAL_RUNS_DIR,
     GLOBAL_SCHEDULER_DIR,
+    GLOBAL_TRANSCRIPTS_DIR,
     GLOBAL_USAGE_DIR,
     GLOBAL_WORKERS_DIR,
     MCP_REGISTRY_CACHE,
@@ -303,7 +303,7 @@ def show_status(*, json_output: bool = False) -> None:
     # Global disk usage
     global_dirs = {
         "runs": GLOBAL_RUNS_DIR,
-        "journal": GLOBAL_JOURNAL_DIR,
+        "transcripts": GLOBAL_TRANSCRIPTS_DIR,
         "projects": GLOBAL_PROJECTS_DIR,
         "scheduler": GLOBAL_SCHEDULER_DIR,
         "usage": GLOBAL_USAGE_DIR,

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -68,7 +68,20 @@ __all__ = [
 ]
 
 
-Source = Literal["claude-cli", "openai-codex", "api_key", "auto"]
+# PR-SIL-5THEME C6 (2026-05-23) — D1 provider closure. PAYG (``api_key``)
+# 가 ``PetriRoleConfig.source`` / ``AutoresearchConfig.source`` 의 Literal
+# 에서 제거됨 (durable operator decision per ``project_payg_exclusion_decision.md``,
+# 2026-05-23) — autoresearch / Petri audit 의 provider 선택지에서 영구
+# exclude. 잔존 옵션: ``claude-cli`` (Claude Code Max OAuth) /
+# ``openai-codex`` (ChatGPT Plus OAuth) / ``auto`` (manifest cascade).
+# ``api_key`` 설정 시 Pydantic ValidationError 가 명시 PAYG 사용을 reject
+# — PR-C-P1 의 silent-fallback 차단 패턴 재사용.
+#
+# **인프라 보존**: ``MutatorConfig.source`` (line 248 의 별도 Literal) 는
+# api_key 포함 4-element 유지 — mutator LLM 호출은 audit role 과 별개,
+# operator 가 Anthropic API key 로 mutator 운영 자유. ``credential_source.py``
+# 의 PAYG fallback 코드 경로도 보존 (다른 caller 가 명시 호출 시 활성).
+Source = Literal["claude-cli", "openai-codex", "auto"]
 """Credential source label — matches ``plugins.petri_audit.petri.plugin.toml``."""
 
 
@@ -144,7 +157,13 @@ class PetriRoleConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     model: str = ""
-    source: Source = "auto"
+    # PR-SIL-5THEME C6 (2026-05-23) — default ``auto`` → ``claude-cli``.
+    # operator decision (``project_payg_exclusion_decision.md``, 2026-05-23)
+    # 으로 subscription-first 가 새 default. ``auto`` 는 manifest cascade
+    # 가 PAYG 까지 fallback 할 수 있어서 silent leak risk — 명시
+    # ``claude-cli`` (Claude Code Max OAuth) 이 default 면 leak 0. operator
+    # 가 explicit 으로 ``auto`` 또는 ``openai-codex`` 명시 시 그대로 적용.
+    source: Source = "claude-cli"
 
 
 class AutoresearchConfig(BaseModel):
@@ -186,11 +205,18 @@ class AutoresearchConfig(BaseModel):
     ``[self_improving_loop.petri.judge].model`` via the binding
     registry; this field is silently ignored. Will be dropped in a
     future release once operator configs are migrated."""
-    source: Source = "auto"
-    """Credential source for the audit subprocess. ``auto`` =
-    subscription-first with PAYG fallback per the global
-    ``fallback_to_payg`` flag. The argv translator maps non-``api_key``
-    sources to ``--use-oauth`` for the audit subprocess."""
+    # PR-SIL-5THEME C6 (2026-05-23) — default ``auto`` → ``claude-cli``.
+    # Operator decision (``project_payg_exclusion_decision.md``, 2026-05-23)
+    # 으로 ``api_key`` 는 ``Source`` literal 에서 제거. ``auto`` 는 manifest
+    # cascade 가 PAYG 까지 silent fallback 가능 → ``claude-cli`` (Claude
+    # Code Max OAuth) 가 새 default.
+    source: Source = "claude-cli"
+    """Credential source for the audit subprocess. PR-SIL-5THEME C6 후 PAYG
+    (``api_key``) 는 Source literal 에서 제거. ``claude-cli`` = Claude Code
+    Max OAuth (default), ``openai-codex`` = ChatGPT Plus OAuth, ``auto`` =
+    manifest cascade (subscription-first, ``fallback_to_payg`` 가 True 여야
+    PAYG 까지 fallback). argv translator 가 non-``api_key`` source 를
+    ``--use-oauth`` 로 매핑 (모든 source 가 이제 non-api_key 라 항상 fire)."""
     seed_limit: Annotated[int, Field(ge=5, le=1000)] = 10
     """Per-audit seed count — the N that ``dim_extractor._aggregate``
     feeds into ``statistics.stdev(ddof=1)``.

--- a/core/observability/__init__.py
+++ b/core/observability/__init__.py
@@ -25,14 +25,24 @@ from core.observability.session_journal import (
     session_journal_scope,
     set_current_session_journal,
 )
+from core.observability.session_metrics import (
+    SessionMetrics,
+    current_session_metrics,
+    session_metrics_scope,
+    set_current_session_metrics,
+)
 
 __all__ = [
     "OtelExportError",
     "SessionJournal",
+    "SessionMetrics",
     "current_session_journal",
+    "current_session_metrics",
     "disable",
     "enable",
     "session_journal_scope",
+    "session_metrics_scope",
     "set_current_session_journal",
+    "set_current_session_metrics",
     "status",
 ]

--- a/core/observability/session_journal.py
+++ b/core/observability/session_journal.py
@@ -1,52 +1,41 @@
-"""Structured per-session journal — P1c self-improving-loop wiring plan.
+"""Backward-compat alias — ``SessionJournal`` is now a thin wrapper over the
+canonical :class:`core.runtime_state.transcript.SessionTranscript`.
 
-The session journal is a JSONL artifact that captures discrete events
-from one self-improving-loop run (autoresearch or seed-generation). It complements
-the run-level ``~/.geode/self-improving-loop/sessions.jsonl`` index (P1a) which
-holds exactly one row per run: this module captures the *event stream*
-within that run.
+PR-SESSION-METRICS (2026-05-23) — the pre-existing 3-Tier preservation
+architecture in ``core/runtime_state/transcript.py`` calls out:
 
-Schema (one event per line)::
+* Tier 1 — :class:`SessionTranscript` (event log, append-only JSONL)
+* Tier 2 — Journal (summaries)
+* Tier 3 — Snapshot (pipeline state)
 
-    {
-      "ts": 1731957600.123,
-      "session_id": "2026-05-19T1530Z-a1b2c3",
-      "gen_tag": "autoresearch-a1b2c3d",
-      "component": "autoresearch",
-      "level": "info" | "warn" | "error",
-      "event": "<short event name>",
-      "payload": {...}
-    }
+Reality drifted: ``SessionJournal`` was a separate per-self-improving-loop-run
+event log written to ``~/.geode/self-improving-loop/<id>/transcript.jsonl`` — i.e.
+*another Tier 1 event stream*, not a Tier 2 summary. The two coexisted with
+different schemas / paths / APIs which made the lifecycle event boundary
+opaque.
 
-Path: ``~/.geode/self-improving-loop/<session_id>/journal.jsonl``.
+This module is now a **thin compat shim**. ``SessionJournal.append(event,
+payload=...)`` delegates to ``SessionTranscript.record_lifecycle_event(...)``.
+Path renamed to ``~/.geode/self-improving-loop/<id>/transcript.jsonl`` (was
+``journal.jsonl`` before this PR) — schema is unchanged (``{ts, session_id,
+gen_tag, component, level, event, payload}``) so existing readers continue
+to work.
 
-Design notes
-------------
-
-* Stateless persistence — each ``append`` re-opens the file. The
-  expected event volume per run is small (10s-100s) so the open/close
-  cost is negligible and we avoid lifecycle issues with long-running
-  agents.
-* I/O failures NEVER raise — observability must not break the run it
-  observes. Failures are logged at WARNING and silently dropped.
-* Direct callers (CLI, orchestrator) instantiate a journal per run and
-  pass it through. Bootstrap-registered hook handlers route subagent
-  events through this journal when the contextvar is set; otherwise
-  they fall through to the existing project-journal pathway.
+Future PR removes this shim once all 269 callsites migrate to direct
+``SessionTranscript.record_lifecycle_event`` calls. Until then, the
+existing ``current_session_journal() / session_journal_scope`` API stays
+operational via this shim.
 """
 
 from __future__ import annotations
 
 import contextvars
-import json
-import logging
-import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-log = logging.getLogger(__name__)
+from core.runtime_state.transcript import SessionTranscript
 
 __all__ = [
     "SessionJournal",
@@ -62,13 +51,14 @@ _current_journal: contextvars.ContextVar[SessionJournal | None] = contextvars.Co
 
 
 class SessionJournal:
-    """Per-run JSONL event log.
+    """Per-run lifecycle event log — alias of :class:`SessionTranscript`.
 
-    Constructed once at the start of an self-improving-loop run (autoresearch or
-    seed-generation) and passed through to callers that emit structured
-    events. Use :meth:`append` for individual events;
-    :func:`session_journal_scope` for ContextVar-bound activation so
-    hook handlers can discover the journal automatically.
+    Preserves the pre-PR-SESSION-METRICS API surface (``append(event,
+    payload=...)`` + ``session_id / gen_tag / component`` instance fields +
+    ``path`` attribute) so existing 269 callsites work unchanged. The
+    actual append happens through the underlying :class:`SessionTranscript`
+    instance held in ``self._transcript`` so the canonical Tier-1 schema
+    is used.
 
     SoT contract (P0a dedup, 2026-05-19 observability audit §6)
     ------------------------------------------------------------
@@ -76,20 +66,9 @@ class SessionJournal:
     Canonical run-level metrics (fitness, verdict, survivors, usd_spent,
     promoted, commit, target_dim, candidates, pool_path_out, …) live in
     ``sessions.jsonl`` — one row per run, written by
-    ``_append_session_index``. Journal events MUST NOT duplicate those
+    ``_append_session_index``. Lifecycle events MUST NOT duplicate those
     fields in their payload; instead they act as stream markers (started /
-    progress / finished) and carry only event-specific context. Readers
-    that need canonical metrics join via ``session_id + gen_tag``.
-
-    Field placement guide:
-
-    - ``sessions.jsonl`` row: fitness, verdict, survivors, usd_spent,
-      promoted, commit, target_dim, candidates, pool_path_out,
-      started_at, ended_at (run summary, written at end-of-run).
-    - ``journal.jsonl`` event payload: event-scoped context only — e.g.
-      ``{"dry_run": True}`` for ``audit_finished`` (a flag that affects
-      interpretation but isn't a metric), or stage-specific intermediate
-      data for events that have no canonical row.
+    progress / finished) and carry only event-specific context.
     """
 
     def __init__(
@@ -104,12 +83,28 @@ class SessionJournal:
         self.gen_tag = gen_tag
         self.component = component
         if path is None:
-            # Lazy resolve via core.paths so test monkeypatch on
-            # ``Path.home()`` is honoured after reloading the module.
+            # PR-SESSION-METRICS — file renamed ``journal.jsonl`` →
+            # ``transcript.jsonl`` to align with the canonical Tier-1
+            # naming. Same per-run directory; only the filename changes.
             from core.paths import GLOBAL_SELF_IMPROVING_LOOP_DIR
 
-            path = GLOBAL_SELF_IMPROVING_LOOP_DIR / session_id / "journal.jsonl"
+            path = GLOBAL_SELF_IMPROVING_LOOP_DIR / session_id / "transcript.jsonl"
         self.path = path
+        # Underlying SessionTranscript — uses our chosen path verbatim.
+        # ``SessionTranscript.__init__(session_id, transcript_dir=...)``
+        # constructs ``transcript_dir / f"{session_id}.jsonl"``, so we
+        # pass the parent dir and let it form the file path. Then we
+        # ``rename`` it to match our explicit path.
+        self._transcript = SessionTranscript(
+            session_id=session_id,
+            transcript_dir=path.parent,
+        )
+        # SessionTranscript builds ``<dir>/<session_id>.jsonl`` by default,
+        # but we want ``<dir>/transcript.jsonl``. Override the file_path
+        # property by monkey-patching the internal directory + a sentinel.
+        # Simpler: write directly to our path via a small inline emitter.
+        # (Keeping the SessionTranscript instance for API symmetry / future
+        # migration to ``record_*`` typed methods.)
 
     def append(
         self,
@@ -121,29 +116,20 @@ class SessionJournal:
     ) -> None:
         """Append one JSONL event row. I/O failure logs a warning.
 
-        ``payload`` is the per-event extensible data dict. ``ts``
-        defaults to ``time.time()``; tests can pass a fixed value for
-        determinism.
+        Delegates to :meth:`SessionTranscript.record_lifecycle_event` so the
+        underlying schema and writer are the canonical Tier-1 path.
+        ``ts`` is honoured for determinism (tests pass a fixed value).
         """
-        record = {
-            "ts": ts if ts is not None else time.time(),
-            "session_id": self.session_id,
-            "gen_tag": self.gen_tag,
-            "component": self.component,
-            "level": level,
-            "event": event,
-            "payload": payload or {},
-        }
-        try:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
-            with self.path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-        except OSError as exc:
-            log.warning(
-                "session journal append failed at %s: %s",
-                self.path,
-                exc,
-            )
+        self._transcript.record_lifecycle_event(
+            event=event,
+            session_id=self.session_id,
+            gen_tag=self.gen_tag,
+            component=self.component,
+            level=level,
+            payload=payload,
+            ts=ts,
+            file_path=self.path,
+        )
 
 
 def current_session_journal() -> SessionJournal | None:

--- a/core/observability/session_metrics.py
+++ b/core/observability/session_metrics.py
@@ -1,0 +1,331 @@
+"""Per-session aggregate metrics — session-level state object pattern.
+
+Centralises 13-way scattered session-scoped state (LLM cost / tool calls /
+provider routing / failover counts / mutation lifecycle) into a single
+``SessionMetrics`` ContextVar-bound dataclass.
+
+Designed against four frontier references:
+
+1. **Claude Code** (``claude-code-ref/src/core/agent-loop.ts``) — its
+   ``AgentLoopState.totalUsage`` is per-loop instance state. We follow
+   the same grain but via ContextVar to support GEODE's multi-session
+   gateway pattern (cron / serve / sub-agent fan-out).
+
+2. **Hermes Agent** (``hermes-agent/gateway/session_context.py``) — its
+   ``_SESSION_ID: ContextVar`` family isolates session-scoped data
+   across concurrent gateway sessions. ``SessionMetrics`` mirrors that
+   pattern, sitting alongside ``SessionJournal``'s existing
+   ``_current_journal`` ContextVar (``core/observability/session_journal.py``).
+
+3. **Hermes ``sessions`` SQLite table** (``hermes_state.py:190``) — the
+   ``input_tokens / output_tokens / cache_*_tokens / reasoning_tokens
+   / api_call_count / billing_provider / estimated_cost_usd`` column
+   set is the persistence shape. ``SessionMetrics.to_session_row()``
+   emits the same shape so a future ``~/.geode/self-improving-loop/
+   sessions.jsonl`` row can carry these aggregates without separate
+   wiring.
+
+4. **Paperclip** (``paperclip/server/src/services/activity.ts``) —
+   the ``usageJson`` JSONB column already accepts both ``inputTokens``
+   /``input_tokens`` casing variants. Our row schema picks snake_case
+   to align with the hermes SQLite path and Anthropic API conventions.
+
+Coverage scope (Tier 1 — interim, not the only place these still live)
+----------------------------------------------------------------------
+
+Many GEODE subsystems already manage their own session-scoped state:
+
+- ``TokenTracker`` (``core/llm/token_tracker.py``) — per-call cost
+  accumulate. ``SessionMetrics`` is the *aggregator*; TokenTracker
+  remains for per-provider cost-table lookups and we delegate via a
+  thin shim instead of duplicating cost math.
+- ``SessionJournal`` (``core/observability/session_journal.py``) —
+  event stream. ``SessionMetrics`` is the *roll-up* counterpart;
+  journal events still carry the event-scoped context.
+- ``UsageStore`` (``core/llm/usage_store.py``) — *daily* rolling
+  ``~/.geode/usage/*.jsonl``. Not absorbed because the grain is
+  per-calendar-day, not per-session.
+- ``OAuthUsage`` (``core/llm/oauth_usage.py``) — 5-hour OAuth quota
+  cache. Provider-wide, not session-scoped.
+- ``LaneQueue`` (``core/llm/audit_lane.py``) — process-wide throttle.
+- ``ContextLocal`` (``core/ui/context_local.py``) — UI ephemerals
+  (SessionMeter backing). Read-only consumer of metrics in future.
+
+Lifecycle
+---------
+
+::
+
+    with session_metrics_scope(session_id="2026-05-23T...", gen_tag="autoresearch-abc1234"):
+        # ... runs that emit accumulate_llm_call / increment_tool_call ...
+        metrics = current_session_metrics()
+        # produce final row
+        row = metrics.to_session_row()
+        # caller appends to sessions.jsonl
+
+I/O failures NEVER raise — observability mustn't break the run it observes.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "SessionMetrics",
+    "current_session_metrics",
+    "session_metrics_scope",
+    "set_current_session_metrics",
+]
+
+
+_current_metrics: contextvars.ContextVar[SessionMetrics | None] = contextvars.ContextVar(
+    "session_metrics", default=None
+)
+
+
+@dataclass(slots=True)
+class SessionMetrics:
+    """Aggregate state for a single self-improving-loop / agentic session.
+
+    Field grouping mirrors the ``hermes_state.sessions`` table schema +
+    Claude Code's ``AgentLoopState.totalUsage`` + Paperclip's ``usageJson``.
+    All counters are *additive* — use the ``accumulate_*`` / ``increment_*``
+    / ``record_*`` methods rather than mutating fields directly so future
+    field additions don't break callers.
+    """
+
+    # Identity
+    session_id: str = ""
+    gen_tag: str = ""
+    component: str = ""
+    started_at: float = 0.0
+
+    # A. LLM call cost — per-call accumulate (claude-code AgentLoopState.totalUsage shape).
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    thinking_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    elapsed_seconds: float = 0.0
+    model_used: str = ""  # last model after failover
+
+    # B. Counts — turn / tool / message / mutation / audit
+    api_call_count: int = 0
+    tool_call_count: int = 0
+    message_count: int = 0
+    mutation_count: int = 0
+    audit_call_count: int = 0
+
+    # C. Billing surface (hermes sessions table parity)
+    billing_provider: str = ""  # anthropic / openai / glm / openai-codex
+    billing_mode: str = ""  # payg / subscription / adapter
+
+    # D. Resilience metrics
+    retry_count: int = 0
+    circuit_breaker_trips: dict[str, int] = field(default_factory=dict)
+    error_count_by_type: dict[str, int] = field(default_factory=dict)
+    rollback_count: int = 0
+
+    # E. Self-improving lifecycle (mutator session only — None otherwise)
+    fitness_before: float | None = None
+    fitness_after: float | None = None
+    cohort_tag: str = ""
+
+    # F. Last-LLM-call snapshot (replaces broken ``_LAST_LLM_CALL_USAGE`` sidecar
+    #    from PR-SIL-5THEME C4 / PR-C4.fix-contextvar #1529). propose() reads
+    #    this single field instead of a module dict — same caller frame, no
+    #    sidecar, no race.
+    last_call_input_tokens: int = 0
+    last_call_output_tokens: int = 0
+    last_call_elapsed_seconds: float = 0.0
+    last_call_model: str = ""
+
+    # H. Goodhart-surface aggregates (audit subprocess scope)
+    missing_dims_total: int = 0
+    missing_benches_total: int = 0
+    cross_validation_conflict_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Mutation API
+    # ------------------------------------------------------------------
+
+    def accumulate_llm_call(
+        self,
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        thinking_tokens: int = 0,
+        elapsed_seconds: float = 0.0,
+        model: str = "",
+        cost_usd: float = 0.0,
+    ) -> None:
+        """One LLM call completed — fold its usage into the session aggregate.
+
+        Also captures the *last call* snapshot in F-fields so propose() / a
+        mutation row writer can read just the latest call without diffing
+        across the cumulative totals. Matches the C4 sidecar's contract
+        without the module-level state.
+        """
+        self.input_tokens += int(input_tokens)
+        self.output_tokens += int(output_tokens)
+        self.cache_creation_tokens += int(cache_creation_tokens)
+        self.cache_read_tokens += int(cache_read_tokens)
+        self.thinking_tokens += int(thinking_tokens)
+        self.elapsed_seconds += float(elapsed_seconds)
+        self.estimated_cost_usd += float(cost_usd)
+        if model:
+            self.model_used = str(model)
+        self.api_call_count += 1
+        # Last-call snapshot — caller (propose()) reads this for per-mutation cost.
+        self.last_call_input_tokens = int(input_tokens)
+        self.last_call_output_tokens = int(output_tokens)
+        self.last_call_elapsed_seconds = float(elapsed_seconds)
+        self.last_call_model = str(model)
+
+    def reset_last_call(self) -> None:
+        """Clear the last-call snapshot (called before a new propose() so a
+        mock LLM that doesn't accumulate doesn't leak stale per-call values).
+        Cumulative totals untouched."""
+        self.last_call_input_tokens = 0
+        self.last_call_output_tokens = 0
+        self.last_call_elapsed_seconds = 0.0
+        self.last_call_model = ""
+
+    def increment_tool_call(self, count: int = 1) -> None:
+        self.tool_call_count += int(count)
+
+    def increment_message(self, count: int = 1) -> None:
+        self.message_count += int(count)
+
+    def increment_mutation(self, count: int = 1) -> None:
+        self.mutation_count += int(count)
+
+    def increment_audit_call(self, count: int = 1) -> None:
+        self.audit_call_count += int(count)
+
+    def record_retry(self, provider: str = "") -> None:
+        self.retry_count += 1
+
+    def record_circuit_breaker_trip(self, provider: str) -> None:
+        self.circuit_breaker_trips[provider] = self.circuit_breaker_trips.get(provider, 0) + 1
+
+    def record_error(self, error_type: str) -> None:
+        self.error_count_by_type[error_type] = self.error_count_by_type.get(error_type, 0) + 1
+
+    def record_rollback(self) -> None:
+        self.rollback_count += 1
+
+    def record_goodhart(
+        self,
+        *,
+        missing_dims: int = 0,
+        missing_benches: int = 0,
+        cross_validation_conflict: bool = False,
+    ) -> None:
+        self.missing_dims_total += int(missing_dims)
+        self.missing_benches_total += int(missing_benches)
+        if cross_validation_conflict:
+            self.cross_validation_conflict_count += 1
+
+    # ------------------------------------------------------------------
+    # Persistence shape
+    # ------------------------------------------------------------------
+
+    def to_session_row(self) -> dict[str, Any]:
+        """Render as ``sessions.jsonl`` row (hermes ``sessions`` table parity +
+        paperclip ``usageJson`` parity). Caller appends to disk.
+        """
+        return {
+            "session_id": self.session_id,
+            "gen_tag": self.gen_tag,
+            "component": self.component,
+            "started_at": self.started_at,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "thinking_tokens": self.thinking_tokens,
+            "estimated_cost_usd": round(self.estimated_cost_usd, 6),
+            "elapsed_seconds": round(self.elapsed_seconds, 4),
+            "model_used": self.model_used,
+            "api_call_count": self.api_call_count,
+            "tool_call_count": self.tool_call_count,
+            "message_count": self.message_count,
+            "mutation_count": self.mutation_count,
+            "audit_call_count": self.audit_call_count,
+            "billing_provider": self.billing_provider,
+            "billing_mode": self.billing_mode,
+            "retry_count": self.retry_count,
+            "circuit_breaker_trips": dict(self.circuit_breaker_trips),
+            "error_count_by_type": dict(self.error_count_by_type),
+            "rollback_count": self.rollback_count,
+            "fitness_before": self.fitness_before,
+            "fitness_after": self.fitness_after,
+            "cohort_tag": self.cohort_tag,
+            "missing_dims_total": self.missing_dims_total,
+            "missing_benches_total": self.missing_benches_total,
+            "cross_validation_conflict_count": self.cross_validation_conflict_count,
+        }
+
+
+def current_session_metrics() -> SessionMetrics:
+    """Return the SessionMetrics active in the current ContextVar scope.
+
+    Lazy-init: returns a fresh ``SessionMetrics()`` and binds it to the
+    ContextVar when none is set. This means *every* caller in *every*
+    scope sees a valid object — never ``None``. The trade-off is that
+    unscoped callers (test suites, ad-hoc scripts) accumulate into a
+    throwaway object instead of crashing, which matches the
+    ``SessionJournal`` pattern's no-op fallback.
+    """
+    metrics = _current_metrics.get()
+    if metrics is None:
+        metrics = SessionMetrics()
+        _current_metrics.set(metrics)
+    return metrics
+
+
+def set_current_session_metrics(
+    metrics: SessionMetrics | None,
+) -> contextvars.Token[SessionMetrics | None]:
+    """Bind ``metrics`` to the current ContextVar scope. Returns the reset token."""
+    return _current_metrics.set(metrics)
+
+
+@contextmanager
+def session_metrics_scope(
+    *,
+    session_id: str = "",
+    gen_tag: str = "",
+    component: str = "",
+) -> Iterator[SessionMetrics]:
+    """Context manager — bind a fresh ``SessionMetrics`` for the duration of
+    the ``with`` block. Restores the prior value on exit even if an
+    exception propagates.
+
+    Mirrors ``session_journal_scope`` (``core/observability/session_journal.py``)
+    so callers can wrap both inside a single ``ExitStack`` when starting an
+    audit / mutation cycle.
+    """
+    metrics = SessionMetrics(
+        session_id=session_id,
+        gen_tag=gen_tag,
+        component=component,
+        started_at=time.time(),
+    )
+    token = _current_metrics.set(metrics)
+    try:
+        yield metrics
+    finally:
+        _current_metrics.reset(token)

--- a/core/paths.py
+++ b/core/paths.py
@@ -213,7 +213,7 @@ GLOBAL_SCHEDULER_DIR = GEODE_HOME / "scheduler"
 GLOBAL_DIAGNOSTICS_DIR = GEODE_HOME / "diagnostics"
 # P1a + P1c (2026-05-19) — self-improving-loop wiring sprint. Shared cross-loop
 # namespace: ``sessions.jsonl`` (P1a, run-level index, one row per
-# autoresearch/seed-generation run) + ``<session_id>/journal.jsonl``
+# autoresearch/seed-generation run) + ``<session_id>/transcript.jsonl``
 # (P1c, event stream within a single run). See
 # ``docs/plans/2026-05-19-self-improving-loop-wiring-sprint.md``.
 GLOBAL_SELF_IMPROVING_LOOP_DIR = GEODE_HOME / "self-improving-loop"
@@ -378,7 +378,14 @@ GLOBAL_PROJECTS_DIR = GEODE_HOME / "projects"
 CLI_SOCKET_PATH = GEODE_HOME / "cli.sock"
 CLI_STARTUP_LOCK = GEODE_HOME / "cli.startup.lock"
 SERVE_LOG_PATH = GEODE_HOME / "logs" / "serve.log"
-GLOBAL_JOURNAL_DIR = GEODE_HOME / "journal"
+# PR-SESSION-METRICS (2026-05-23) — ``journal/`` depth 제거. 이전엔
+# ``~/.geode/journal/transcripts/<project-slug>/<session_id>.jsonl`` 이중
+# nesting 이었으나 transcript 가 단독 Tier-1 으로 정렬되며 ``journal/``
+# 디렉터리 의미 사라짐. 이제 ``~/.geode/transcripts/<project-slug>/<session_id>.jsonl``.
+# ``GLOBAL_JOURNAL_DIR`` 이름은 backward-compat 으로 alias 유지 (한 release
+# 후 제거 권장).
+GLOBAL_TRANSCRIPTS_DIR = GEODE_HOME / "transcripts"
+GLOBAL_JOURNAL_DIR = GLOBAL_TRANSCRIPTS_DIR  # legacy alias — will be dropped
 GLOBAL_WORKERS_DIR = GEODE_HOME / "workers"
 # v0.95.x layout migration v1 — moved under mcp/ to group with other MCP state.
 # Legacy ``~/.geode/mcp-registry-cache.json`` migrated by

--- a/core/runtime_state/transcript.py
+++ b/core/runtime_state/transcript.py
@@ -1,15 +1,19 @@
 """SessionTranscript — JSONL event stream for session audit trail.
 
 Tier 1 preservation: records every event in a session as an append-only
-JSONL file. Complementary to Journal (Tier 2, summaries) and Snapshot
-(Tier 3, pipeline state).
+JSONL file. Complementary to :class:`SessionMetrics` (Tier 2, cumulative
+aggregate roll-up) and Snapshot (Tier 3, pipeline state).
 
 Captures: user messages, assistant responses, tool calls/results,
-vault saves, costs, errors — everything needed to reconstruct
+vault saves, costs, errors, **lifecycle events** (audit_started /
+config_snapshot / per_dim_scores 등 — pre-PR-SESSION-METRICS 의
+``SessionJournal`` 에서 흡수) — everything needed to reconstruct
 "what exactly happened in this session."
 
-Storage: ~/.geode/journal/transcripts/{project-slug}/{session_id}.jsonl
-(user home, not project dir — matches Claude Code / Codex CLI pattern)
+PR-SESSION-METRICS (2026-05-23) — ``SessionJournal`` folded into this
+Tier-1 surface via :meth:`record_lifecycle_event`. Legacy
+``~/.geode/journal/transcripts/<slug>/`` 디렉터리 한 depth 줄어서
+``~/.geode/transcripts/<slug>/<session_id>.jsonl`` 로 단순화.
 """
 
 from __future__ import annotations
@@ -25,19 +29,24 @@ log = logging.getLogger(__name__)
 
 
 def _get_default_transcript_dir() -> Path:
-    """Return ~/.geode/journal/transcripts/{project-slug}/.
+    """Return ``~/.geode/transcripts/<project-slug>/``.
 
     Project slug is derived from CWD (same pattern as Claude Code).
     Falls back to 'default' if CWD cannot be resolved.
+
+    PR-SESSION-METRICS (2026-05-23) — depth 한 단계 줄임. 이전엔
+    ``~/.geode/journal/transcripts/<slug>/`` 였으나 ``journal/`` 디렉터리의
+    의미가 SessionJournal alias-shim 이후 사라져서 ``transcripts/`` 만으로
+    self-evident. Legacy ``~/.geode/journal/transcripts/`` 안에 있는 파일은
+    layout migrator 가 옮기지 않음 — 30-day cleanup 이 자연 회수.
     """
-    from core.paths import GLOBAL_JOURNAL_DIR
+    from core.paths import GLOBAL_TRANSCRIPTS_DIR
 
     try:
         slug = str(Path.cwd()).replace("/", "-")
     except OSError:
         slug = "default"
-    # P2 (v0.95.x) — was literal `Path.home() / ".geode" / "journal" / "transcripts"`
-    return GLOBAL_JOURNAL_DIR / "transcripts" / slug
+    return GLOBAL_TRANSCRIPTS_DIR / slug
 
 
 DEFAULT_TRANSCRIPT_DIR = _get_default_transcript_dir()
@@ -211,6 +220,53 @@ class SessionTranscript:
                 "summary": _truncate(summary, MAX_INPUT_CHARS),
             }
         )
+
+    def record_lifecycle_event(
+        self,
+        *,
+        event: str,
+        session_id: str = "",
+        gen_tag: str = "",
+        component: str = "",
+        level: str = "info",
+        payload: dict[str, Any] | None = None,
+        ts: float | None = None,
+        file_path: Path | None = None,
+    ) -> None:
+        """Record a free-form lifecycle event — replaces the legacy
+        ``SessionJournal.append(event, payload=...)`` path.
+
+        PR-SESSION-METRICS (2026-05-23) — folded ``SessionJournal`` into the
+        Tier-1 :class:`SessionTranscript`. Schema preserved
+        (``{ts, session_id, gen_tag, component, level, event, payload}``)
+        so existing readers (``tests/core/observability/test_session_journal.py``,
+        operator grep on ``transcript.jsonl`` / legacy ``transcript.jsonl``)
+        keep working.
+
+        ``file_path`` overrides the default ``<dir>/<session_id>.jsonl``
+        layout — used by :class:`SessionJournal` to write to
+        ``<self-improving-loop-dir>/<session_id>/transcript.jsonl`` while
+        still using this Tier-1 schema.
+        """
+        record: dict[str, Any] = {
+            "ts": ts if ts is not None else time.time(),
+            "session_id": session_id or self._session_id,
+            "gen_tag": gen_tag,
+            "component": component,
+            "level": level,
+            "event": event,
+            "payload": payload or {},
+        }
+        target_path = file_path if file_path is not None else self.file_path
+        line = json.dumps(record, ensure_ascii=False)
+        with self._lock:
+            try:
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                with target_path.open("a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+                self._event_count += 1
+            except OSError as exc:
+                log.warning("Transcript lifecycle-event write failed: %s", exc)
 
     # ------------------------------------------------------------------
     # Read

--- a/core/self_improving_loop/attribution.py
+++ b/core/self_improving_loop/attribution.py
@@ -175,6 +175,8 @@ def compute_attribution(
     baseline_before: BaselineSnapshot | None,
     baseline_after: BaselineSnapshot | None,
     confidence_trajectory: list[float] | None = None,
+    fitness_before: float | None = None,
+    fitness_after: float | None = None,
 ) -> dict[str, Any]:
     """Compute the attribution payload for one applied mutation.
 
@@ -209,6 +211,15 @@ def compute_attribution(
         "confidence_trajectory": trajectory,
         "confidence_stability": stability,
     }
+    # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger 의 fitness Δ.
+    # ``baseline_before.fitness`` / ``baseline_after.fitness`` 는 dataclass 에
+    # 없으므로 caller 가 명시 fitness_before / fitness_after 전달. 둘 다
+    # 명시되면 fitness_delta = after - before 계산해서 payload 에 동봉.
+    # 부재 시 키 자체 미출현 (legacy reader 무영향).
+    if fitness_before is not None and fitness_after is not None:
+        payload["fitness_before"] = round(float(fitness_before), 6)
+        payload["fitness_after"] = round(float(fitness_after), 6)
+        payload["fitness_delta"] = round(float(fitness_after) - float(fitness_before), 6)
     if baseline_before is None or baseline_after is None:
         return payload
 
@@ -250,6 +261,8 @@ def write_attribution(
     baseline_after: BaselineSnapshot | None,
     confidence_trajectory: list[float] | None = None,
     log_path: Path | None = None,
+    fitness_before: float | None = None,
+    fitness_after: float | None = None,
 ) -> dict[str, Any]:
     """Compute + append attribution in one call.
 
@@ -261,6 +274,11 @@ def write_attribution(
     PR-E (2026-05-21) — accepts the optional
     ``confidence_trajectory`` and forwards it to
     :func:`compute_attribution`.
+
+    PR-SIL-5THEME C4 (2026-05-23) — ``fitness_before`` / ``fitness_after``
+    optional forward to ``compute_attribution`` — caller (autoresearch
+    run loop / scheduler) 가 둘 다 in-scope 일 때 (e.g. previous
+    audit's promoted fitness + current audit's fitness) 전달.
     """
     payload = compute_attribution(
         mutation_id=mutation_id,
@@ -268,6 +286,8 @@ def write_attribution(
         baseline_before=baseline_before,
         baseline_after=baseline_after,
         confidence_trajectory=confidence_trajectory,
+        fitness_before=fitness_before,
+        fitness_after=fitness_after,
     )
     append_attribution_log(payload, log_path=log_path)
     return payload

--- a/core/self_improving_loop/dpo_pack.py
+++ b/core/self_improving_loop/dpo_pack.py
@@ -104,7 +104,7 @@ def pair_signature(prompt: str, chosen: str, rejected: str) -> str:
 
 
 def _iter_eval_events(journal_path: Path) -> list[_EvalEvent]:
-    """Read one ``journal.jsonl`` file → list of ``eval_response_recorded`` rows.
+    """Read one ``transcript.jsonl`` file → list of ``eval_response_recorded`` rows.
 
     Lines that fail to parse, lack the canonical event name, or are
     missing required payload fields are silently skipped (the journal
@@ -209,7 +209,7 @@ def build_dpo_pack(
     """Walk ``journal_paths`` → group by prompt → append new pairs to ``pack_path``.
 
     Args:
-        journal_paths: ``journal.jsonl`` files to scan. Missing files are
+        journal_paths: ``transcript.jsonl`` files to scan. Missing files are
             treated as empty (graceful).
         pack_path: Destination JSONL. Created lazily; existing rows are
             preserved + their signatures are honoured for dedup.

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -37,6 +37,7 @@ Test strategy:
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import subprocess
@@ -111,6 +112,18 @@ class Mutation:
     (e.g. ``"any dim drops more than 0.5"``). Recorded for auditability;
     enforcement is a follow-up."""
 
+    # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger. 이전엔
+    # mutator LLM 의 usage metadata (input_tokens / output_tokens /
+    # elapsed_seconds / model) 가 _default_llm_call 의 응답에서 폐기됐다
+    # — runner.py:543 의 ``response, _used_model = …`` 에서 _used_model
+    # 만 받고 response.usage 미사용. cost 컬럼이 mutations.jsonl 에 없어
+    # operator 가 mutation ROI (cost vs fitness Δ) 못 봤다. C4 가 그 캡처
+    # 경로 활성. 기본값은 0 / "" (legacy mutation row backward-compat).
+    cost_input_tokens: int = 0
+    cost_output_tokens: int = 0
+    cost_elapsed_seconds: float = 0.0
+    cost_model: str = ""
+
     def to_audit_row(
         self,
         *,
@@ -118,8 +131,13 @@ class Mutation:
         timestamp: float | None = None,
         baseline_fitness: float | None = None,
     ) -> dict[str, Any]:
-        """Render the mutation as one audit-log row."""
-        return {
+        """Render the mutation as one audit-log row.
+
+        PR-SIL-5THEME C4 (2026-05-23) — cost 4-field 추가. 모두 0 / "" 일
+        때만 row 에 컬럼 자체 미생성 → legacy reader 가 새 컬럼 부재 시
+        graceful (key 가 없으면 0 / "" 가정).
+        """
+        row: dict[str, Any] = {
             "ts": timestamp if timestamp is not None else time.time(),
             "kind": "applied",
             "mutation_id": self.mutation_id,
@@ -133,6 +151,17 @@ class Mutation:
             "rollback_condition": self.rollback_condition,
             "baseline_fitness": baseline_fitness,
         }
+        # PR-SIL-5THEME C4 — cost 컬럼은 non-zero 일 때만 emit. 0 값
+        # (legacy 또는 mock LLM 호출) 은 column 자체 생략 — JSONL 의
+        # noise 절감 + legacy reader 무영향.
+        if self.cost_input_tokens or self.cost_output_tokens:
+            row["cost_input_tokens"] = int(self.cost_input_tokens)
+            row["cost_output_tokens"] = int(self.cost_output_tokens)
+        if self.cost_elapsed_seconds:
+            row["cost_elapsed_seconds"] = round(float(self.cost_elapsed_seconds), 4)
+        if self.cost_model:
+            row["cost_model"] = str(self.cost_model)
+        return row
 
 
 @dataclass
@@ -436,6 +465,35 @@ LLMCallable = Callable[[str, str], str]
 """Signature: ``llm_call(system_prompt, user_prompt) -> raw response``."""
 
 
+# PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger 의 sidecar 캡처.
+# ``_default_llm_call`` 이 ``response.usage`` 를 dict 로 저장하면 ``propose()``
+# 가 같은 process 내에서 읽어 ``Mutation.cost_*`` field 채움. tests inject 한
+# str-returning mock 은 usage 미세팅 → ``Mutation.cost_*`` 가 default 0 / ""
+# 로 남아 ``to_audit_row()`` 가 cost 컬럼 자체 생략 (backward-compat).
+#
+# Thread-local 대신 module-level 인 이유: SelfImprovingLoopRunner 는 single-
+# threaded async (asyncio.run 으로 동기 호출) 가정이고, 한 propose() 가 끝
+# 나기 전 다른 propose() 가 끼어들 가능 X. 만약 future 에 concurrent runner
+# 가 필요해지면 threading.local() 로 교체.
+_LAST_LLM_CALL_USAGE: dict[str, Any] = {}
+
+
+def _reset_last_llm_call_usage() -> None:
+    """``_LAST_LLM_CALL_USAGE`` 를 비움 — propose() 가 새 LLM call 직전에 호출."""
+    _LAST_LLM_CALL_USAGE.clear()
+
+
+def _consume_last_llm_call_usage() -> dict[str, Any]:
+    """``_LAST_LLM_CALL_USAGE`` 의 snapshot 을 반환하고 module-level dict 를 비움.
+
+    Returns 빈 dict 면 LLM call 이 usage 를 emit 안 했거나 mock 이라 캡처 안
+    된 경우 — caller 는 cost 0 / "" 로 처리 (backward-compat).
+    """
+    snapshot = dict(_LAST_LLM_CALL_USAGE)
+    _LAST_LLM_CALL_USAGE.clear()
+    return snapshot
+
+
 def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     """Mutator LLM call routed through ``core.llm.router`` (PR-1 G-A).
 
@@ -540,12 +598,28 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     # can set per-provider fallback chains in the router config
     # (the dispatcher's ``models`` list is expanded in a follow-up PR
     # once the operator-facing surface for that exists).
+    # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger 의 timing
+    # 캡처. response.usage 도 같이 record_*.
+    call_started_at = time.time()
     response, _used_model = asyncio.run(call_with_failover([model], _do_call))
+    call_elapsed = time.time() - call_started_at
     if response is None:
         last_err = getattr(adapter, "last_error", None)
         raise RuntimeError(
             f"mutator LLM call failed (model={model}, provider={provider}): {last_err!r}"
         )
+
+    # PR-SIL-5THEME C4 — usage metadata capture. AgenticResponse 의
+    # ``usage`` 가 ResponseUsage dataclass (input_tokens / output_tokens
+    # / thinking_tokens / cache_*) — sidecar dict 에 저장하면 propose()
+    # 가 같은 process 에서 읽어 Mutation 에 채워 넣음.
+    _LAST_LLM_CALL_USAGE.clear()
+    usage_obj = getattr(response, "usage", None)
+    if usage_obj is not None:
+        _LAST_LLM_CALL_USAGE["input_tokens"] = int(getattr(usage_obj, "input_tokens", 0))
+        _LAST_LLM_CALL_USAGE["output_tokens"] = int(getattr(usage_obj, "output_tokens", 0))
+        _LAST_LLM_CALL_USAGE["elapsed_seconds"] = float(call_elapsed)
+        _LAST_LLM_CALL_USAGE["model"] = str(_used_model or model)
 
     # Adapter normalises to AgenticResponse — concatenate text blocks.
     text_chunks: list[str] = []
@@ -860,8 +934,26 @@ class SelfImprovingLoopRunner:
         """
         ctx = build_runner_context()
         user_prompt = _build_user_prompt(ctx)
+        # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger. 새 LLM
+        # call 직전 sidecar 비우고, _default_llm_call 이 호출 후 채움. mock
+        # 인 경우 빈 dict 가 그대로 남음 → consume_usage() 가 빈 dict 반환
+        # → Mutation.cost_* 가 default 0 / "" 유지.
+        _reset_last_llm_call_usage()
         raw_response = self.llm_call(_build_system_prompt(), user_prompt)
+        usage_snapshot = _consume_last_llm_call_usage()
         mutation = parse_mutation(raw_response)
+        # PR-SIL-5THEME C4 — usage → mutation cost field. ``Mutation`` 은
+        # ``frozen=True`` dataclass 라 dataclasses.replace 로 새 인스턴스
+        # 생성. usage_snapshot 이 빈 dict (mock injection) 면 mutation
+        # 그대로 (default 0 / "").
+        if usage_snapshot:
+            mutation = dataclasses.replace(
+                mutation,
+                cost_input_tokens=int(usage_snapshot.get("input_tokens", 0)),
+                cost_output_tokens=int(usage_snapshot.get("output_tokens", 0)),
+                cost_elapsed_seconds=float(usage_snapshot.get("elapsed_seconds", 0.0)),
+                cost_model=str(usage_snapshot.get("model", "")),
+            )
         # PR-6 C-5 (Codex MCP catch) — apply_mutation dispatches by
         # target_kind, but ctx.current_sections is *always* the wrapper-
         # prompt sections (built by build_runner_context). Passing those

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -44,7 +44,6 @@ import subprocess
 import time
 import uuid
 from collections.abc import Callable
-from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -467,90 +466,49 @@ LLMCallable = Callable[[str, str], str]
 
 
 # PR-SIL-5THEME C4 (2026-05-23) — E1 mutation cost ledger 의 sidecar 캡처.
-# ``_default_llm_call`` 이 ``response.usage`` 를 dict 로 저장하면 ``propose()``
-# 가 같은 process 내에서 읽어 ``Mutation.cost_*`` field 채움. tests inject 한
-# str-returning mock 은 usage 미세팅 → ``Mutation.cost_*`` 가 default 0 / ""
-# 로 남아 ``to_audit_row()`` 가 cost 컬럼 자체 생략 (backward-compat).
+# PR-SESSION-METRICS (2026-05-23) — sidecar pattern 폐기. 13개 곳에 분산된
+# session-scoped state 가 ``core/observability/session_metrics.py:SessionMetrics``
+# 의 ContextVar 로 중앙 집중. ``_default_llm_call`` 이 response.usage 를
+# ``current_session_metrics().accumulate_llm_call(...)`` 로 직접 fold 하고,
+# ``propose()`` 는 같은 ContextVar 의 last-call 4-field snapshot 을 읽는다.
+# Module-level dict / ContextVar[dict] / Proxy shim 의 race-prone 패턴 완전
+# 제거 — claude-code AgentLoopState.totalUsage + hermes _SESSION_ID
+# ContextVar family 의 frontier 정렬.
 #
-# PR-C4.fix-contextvar (2026-05-23) — module-level dict → ContextVar 교체.
-# 초안의 module-level dict 는 (a) pytest-xdist worker 간 격리 깨짐 +
-# (b) future concurrent runner 시 cross-runner race 위험을 가졌다. ContextVar
-# 는 asyncio Task / pytest test 단위로 격리되어 두 문제를 동시에 닫는다.
-#
-# 이전 module-level state 의 backward-compat 노출 (``_LAST_LLM_CALL_USAGE``)
-# 은 더 이상 외부에서 직접 mutate 하면 안 된다 — 테스트는 helper API 만
-# 사용. tests/test_e1_mutation_cost_ledger.py 의 backward-compat 보장.
-# Ruff B039 — mutable default 는 ContextVar 가 process-wide 라 위험. None
-# default + helper 가 _current 시점에 빈 dict 로 lazily set.
-_LAST_LLM_CALL_USAGE_VAR: ContextVar[dict[str, Any] | None] = ContextVar(
-    "_LAST_LLM_CALL_USAGE", default=None
-)
-
-
-def _current_llm_call_usage() -> dict[str, Any]:
-    """Read-only view — caller mutate 금지. 새 dict 를 매번 ContextVar.set 으로."""
-    return _LAST_LLM_CALL_USAGE_VAR.get() or {}
+# 기존 helper 이름 (``_reset_last_llm_call_usage`` / ``_consume_last_llm_call_usage``)
+# 은 thin wrapper 로 보존 — 외부 test 호환성 유지. 새 코드는
+# ``current_session_metrics()`` 직접 호출 권장.
 
 
 def _reset_last_llm_call_usage() -> None:
-    """``_LAST_LLM_CALL_USAGE_VAR`` 를 빈 dict 로 비움 — propose() 가 새 LLM
-    call 직전에 호출. ContextVar.set 은 같은 task / test scope 안에서 effective."""
-    _LAST_LLM_CALL_USAGE_VAR.set({})
+    """SessionMetrics 의 last-call snapshot 만 비움 (cumulative 보존). propose()
+    가 새 LLM call 직전에 호출 — mock LLM 이 accumulate 안 해도 stale
+    per-call 값이 안 새도록."""
+    from core.observability import current_session_metrics
+
+    current_session_metrics().reset_last_call()
 
 
 def _consume_last_llm_call_usage() -> dict[str, Any]:
-    """ContextVar 의 snapshot 을 반환하고 빈 dict 로 reset.
+    """SessionMetrics 의 last-call snapshot 을 dict 로 반환하고 reset.
 
-    Returns 빈 dict 면 LLM call 이 usage 를 emit 안 했거나 mock 이라 캡처 안
-    된 경우 — caller 는 cost 0 / "" 로 처리 (backward-compat).
+    Returns 빈 dict (input/output_tokens 둘 다 0) 면 LLM call 이 usage 를
+    emit 안 했거나 mock 이라 캡처 안 된 경우 — caller 는 cost 0 / "" 로 처리
+    (backward-compat).
     """
-    snapshot = dict(_LAST_LLM_CALL_USAGE_VAR.get() or {})
-    _LAST_LLM_CALL_USAGE_VAR.set({})
+    from core.observability import current_session_metrics
+
+    m = current_session_metrics()
+    snapshot: dict[str, Any] = {}
+    if m.last_call_input_tokens or m.last_call_output_tokens:
+        snapshot = {
+            "input_tokens": m.last_call_input_tokens,
+            "output_tokens": m.last_call_output_tokens,
+            "elapsed_seconds": m.last_call_elapsed_seconds,
+            "model": m.last_call_model,
+        }
+    m.reset_last_call()
     return snapshot
-
-
-# backward-compat shim — test code 가 ``_LAST_LLM_CALL_USAGE.update(...)``
-# 또는 ``_LAST_LLM_CALL_USAGE.clear()`` 형태로 module-level dict 를 mutate
-# 하던 경우 (e.g. tests/test_e1_mutation_cost_ledger.py 의 일부 패턴) 그
-# mutation 이 ContextVar 의 현재 dict 에도 반영되도록 proxy.
-class _UsageProxy:
-    """``_LAST_LLM_CALL_USAGE`` 의 dict-like proxy. ContextVar 의 현재 값에
-    위임. ``update()`` / ``clear()`` / ``__setitem__`` 등의 mutate 가 같은
-    task scope 안의 sidecar 에 즉시 반영."""
-
-    def _backing(self) -> dict[str, Any]:
-        return _LAST_LLM_CALL_USAGE_VAR.get() or {}
-
-    def update(self, *args: Any, **kwargs: Any) -> None:
-        d = dict(self._backing())
-        d.update(*args, **kwargs)
-        _LAST_LLM_CALL_USAGE_VAR.set(d)
-
-    def clear(self) -> None:
-        _LAST_LLM_CALL_USAGE_VAR.set({})
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        d = dict(self._backing())
-        d[key] = value
-        _LAST_LLM_CALL_USAGE_VAR.set(d)
-
-    def __getitem__(self, key: str) -> Any:
-        return self._backing()[key]
-
-    def __contains__(self, key: object) -> bool:
-        return key in self._backing()
-
-    def __eq__(self, other: object) -> bool:
-        return self._backing() == other
-
-    def __repr__(self) -> str:
-        return repr(self._backing())
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._backing().get(key, default)
-
-
-_LAST_LLM_CALL_USAGE = _UsageProxy()
 
 
 def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
@@ -668,24 +626,25 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
             f"mutator LLM call failed (model={model}, provider={provider}): {last_err!r}"
         )
 
-    # PR-SIL-5THEME C4 — usage metadata capture. AgenticResponse 의
-    # ``usage`` 가 ResponseUsage dataclass (input_tokens / output_tokens
-    # / thinking_tokens / cache_*) — ContextVar sidecar 에 저장하면
-    # propose() 가 같은 task scope 에서 읽어 Mutation 에 채워 넣음.
-    # PR-C4.fix-contextvar — ContextVar.set 으로 매번 새 dict 적재 (test
-    # / concurrent runner 격리 보장).
+    # PR-SIL-5THEME C4 + PR-SESSION-METRICS — usage metadata capture.
+    # AgenticResponse 의 ``usage`` (ResponseUsage dataclass: input_tokens /
+    # output_tokens / thinking_tokens / cache_*) 를 SessionMetrics 의
+    # ContextVar 에 직접 fold. last-call snapshot 도 같이 적재 — propose()
+    # 가 동일 ContextVar 에서 읽어 Mutation.cost_* 채움. Module-level
+    # sidecar / dict ContextVar / proxy shim 의 race-prone 패턴 완전 제거.
+    from core.observability import current_session_metrics
+
     usage_obj = getattr(response, "usage", None)
     if usage_obj is not None:
-        _LAST_LLM_CALL_USAGE_VAR.set(
-            {
-                "input_tokens": int(getattr(usage_obj, "input_tokens", 0)),
-                "output_tokens": int(getattr(usage_obj, "output_tokens", 0)),
-                "elapsed_seconds": float(call_elapsed),
-                "model": str(_used_model or model),
-            }
+        current_session_metrics().accumulate_llm_call(
+            input_tokens=int(getattr(usage_obj, "input_tokens", 0)),
+            output_tokens=int(getattr(usage_obj, "output_tokens", 0)),
+            cache_creation_tokens=int(getattr(usage_obj, "cache_creation_tokens", 0)),
+            cache_read_tokens=int(getattr(usage_obj, "cache_read_tokens", 0)),
+            thinking_tokens=int(getattr(usage_obj, "thinking_tokens", 0)),
+            elapsed_seconds=float(call_elapsed),
+            model=str(_used_model or model),
         )
-    else:
-        _LAST_LLM_CALL_USAGE_VAR.set({})
 
     # Adapter normalises to AgenticResponse — concatenate text blocks.
     text_chunks: list[str] = []

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -44,6 +44,7 @@ import subprocess
 import time
 import uuid
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -471,27 +472,85 @@ LLMCallable = Callable[[str, str], str]
 # str-returning mock 은 usage 미세팅 → ``Mutation.cost_*`` 가 default 0 / ""
 # 로 남아 ``to_audit_row()`` 가 cost 컬럼 자체 생략 (backward-compat).
 #
-# Thread-local 대신 module-level 인 이유: SelfImprovingLoopRunner 는 single-
-# threaded async (asyncio.run 으로 동기 호출) 가정이고, 한 propose() 가 끝
-# 나기 전 다른 propose() 가 끼어들 가능 X. 만약 future 에 concurrent runner
-# 가 필요해지면 threading.local() 로 교체.
-_LAST_LLM_CALL_USAGE: dict[str, Any] = {}
+# PR-C4.fix-contextvar (2026-05-23) — module-level dict → ContextVar 교체.
+# 초안의 module-level dict 는 (a) pytest-xdist worker 간 격리 깨짐 +
+# (b) future concurrent runner 시 cross-runner race 위험을 가졌다. ContextVar
+# 는 asyncio Task / pytest test 단위로 격리되어 두 문제를 동시에 닫는다.
+#
+# 이전 module-level state 의 backward-compat 노출 (``_LAST_LLM_CALL_USAGE``)
+# 은 더 이상 외부에서 직접 mutate 하면 안 된다 — 테스트는 helper API 만
+# 사용. tests/test_e1_mutation_cost_ledger.py 의 backward-compat 보장.
+# Ruff B039 — mutable default 는 ContextVar 가 process-wide 라 위험. None
+# default + helper 가 _current 시점에 빈 dict 로 lazily set.
+_LAST_LLM_CALL_USAGE_VAR: ContextVar[dict[str, Any] | None] = ContextVar(
+    "_LAST_LLM_CALL_USAGE", default=None
+)
+
+
+def _current_llm_call_usage() -> dict[str, Any]:
+    """Read-only view — caller mutate 금지. 새 dict 를 매번 ContextVar.set 으로."""
+    return _LAST_LLM_CALL_USAGE_VAR.get() or {}
 
 
 def _reset_last_llm_call_usage() -> None:
-    """``_LAST_LLM_CALL_USAGE`` 를 비움 — propose() 가 새 LLM call 직전에 호출."""
-    _LAST_LLM_CALL_USAGE.clear()
+    """``_LAST_LLM_CALL_USAGE_VAR`` 를 빈 dict 로 비움 — propose() 가 새 LLM
+    call 직전에 호출. ContextVar.set 은 같은 task / test scope 안에서 effective."""
+    _LAST_LLM_CALL_USAGE_VAR.set({})
 
 
 def _consume_last_llm_call_usage() -> dict[str, Any]:
-    """``_LAST_LLM_CALL_USAGE`` 의 snapshot 을 반환하고 module-level dict 를 비움.
+    """ContextVar 의 snapshot 을 반환하고 빈 dict 로 reset.
 
     Returns 빈 dict 면 LLM call 이 usage 를 emit 안 했거나 mock 이라 캡처 안
     된 경우 — caller 는 cost 0 / "" 로 처리 (backward-compat).
     """
-    snapshot = dict(_LAST_LLM_CALL_USAGE)
-    _LAST_LLM_CALL_USAGE.clear()
+    snapshot = dict(_LAST_LLM_CALL_USAGE_VAR.get() or {})
+    _LAST_LLM_CALL_USAGE_VAR.set({})
     return snapshot
+
+
+# backward-compat shim — test code 가 ``_LAST_LLM_CALL_USAGE.update(...)``
+# 또는 ``_LAST_LLM_CALL_USAGE.clear()`` 형태로 module-level dict 를 mutate
+# 하던 경우 (e.g. tests/test_e1_mutation_cost_ledger.py 의 일부 패턴) 그
+# mutation 이 ContextVar 의 현재 dict 에도 반영되도록 proxy.
+class _UsageProxy:
+    """``_LAST_LLM_CALL_USAGE`` 의 dict-like proxy. ContextVar 의 현재 값에
+    위임. ``update()`` / ``clear()`` / ``__setitem__`` 등의 mutate 가 같은
+    task scope 안의 sidecar 에 즉시 반영."""
+
+    def _backing(self) -> dict[str, Any]:
+        return _LAST_LLM_CALL_USAGE_VAR.get() or {}
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        d = dict(self._backing())
+        d.update(*args, **kwargs)
+        _LAST_LLM_CALL_USAGE_VAR.set(d)
+
+    def clear(self) -> None:
+        _LAST_LLM_CALL_USAGE_VAR.set({})
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        d = dict(self._backing())
+        d[key] = value
+        _LAST_LLM_CALL_USAGE_VAR.set(d)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._backing()[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._backing()
+
+    def __eq__(self, other: object) -> bool:
+        return self._backing() == other
+
+    def __repr__(self) -> str:
+        return repr(self._backing())
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._backing().get(key, default)
+
+
+_LAST_LLM_CALL_USAGE = _UsageProxy()
 
 
 def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
@@ -611,15 +670,22 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
 
     # PR-SIL-5THEME C4 — usage metadata capture. AgenticResponse 의
     # ``usage`` 가 ResponseUsage dataclass (input_tokens / output_tokens
-    # / thinking_tokens / cache_*) — sidecar dict 에 저장하면 propose()
-    # 가 같은 process 에서 읽어 Mutation 에 채워 넣음.
-    _LAST_LLM_CALL_USAGE.clear()
+    # / thinking_tokens / cache_*) — ContextVar sidecar 에 저장하면
+    # propose() 가 같은 task scope 에서 읽어 Mutation 에 채워 넣음.
+    # PR-C4.fix-contextvar — ContextVar.set 으로 매번 새 dict 적재 (test
+    # / concurrent runner 격리 보장).
     usage_obj = getattr(response, "usage", None)
     if usage_obj is not None:
-        _LAST_LLM_CALL_USAGE["input_tokens"] = int(getattr(usage_obj, "input_tokens", 0))
-        _LAST_LLM_CALL_USAGE["output_tokens"] = int(getattr(usage_obj, "output_tokens", 0))
-        _LAST_LLM_CALL_USAGE["elapsed_seconds"] = float(call_elapsed)
-        _LAST_LLM_CALL_USAGE["model"] = str(_used_model or model)
+        _LAST_LLM_CALL_USAGE_VAR.set(
+            {
+                "input_tokens": int(getattr(usage_obj, "input_tokens", 0)),
+                "output_tokens": int(getattr(usage_obj, "output_tokens", 0)),
+                "elapsed_seconds": float(call_elapsed),
+                "model": str(_used_model or model),
+            }
+        )
+    else:
+        _LAST_LLM_CALL_USAGE_VAR.set({})
 
     # Adapter normalises to AgenticResponse — concatenate text blocks.
     text_chunks: list[str] = []

--- a/docs/adr/ADR-012-self-improvement-surface-tiers.md
+++ b/docs/adr/ADR-012-self-improvement-surface-tiers.md
@@ -68,22 +68,36 @@ PR-AUDIT-5SLOT (`docs/audits/2026-05-21-self-improving-loop-5-slot-reader-audit.
 
 `tests/test_adr_012_tier_2_deny_list.py` (이 PR 에서 신설) 가 Tier 2 deny-list 를 강제한다 — Tier 2 파일이 `TARGET_KIND_TO_SOT_FILE` 또는 mutation dispatcher 의 target 목록에 등장하면 즉시 test 실패. PR-AUDIT-5SLOT 의 ratchet 패턴 (`test_ratchet_policies_in_repo.py`) 은 policy SoT 의 gitignore/migration 만 pin 하므로 별개의 deny-list 가 필요했고, 이 ADR PR 이 그 deny-list 의 첫 invariant 를 함께 도입한다.
 
-### 2. Fitness 다축화 — 3축 multi-axis strict-reject ratchet
+### 2. Fitness 다축화 — 4축 multi-axis strict-reject ratchet
 
-현재 `baseline.json` 의 fitness 는 `dim_means` 1축. 이 ADR 은 두 축을 추가한다.
+> **2026-05-23 amendment (PR-SIL-5THEME C1)** — 초안의 3축 (dim + ux + admire) 에서 **bench_means** 가 추가되어 **4축** 으로 확장됐다. 초기 운영의 `seed_pool_diversity` 슬롯은 cohort diversity 신호 readers 의 부재 + ELO tournament 가 panel diversity 를 이미 흡수하는 점이 확인돼 **명시적 deprecate**. 코드 상수 `FITNESS_DIM_4AX / FITNESS_UX_4AX / FITNESS_ADMIRE_4AX / FITNESS_BENCH_4AX` (`autoresearch/train.py:344-350`, sum=1.0 assert) 가 ground-truth.
+
+현재 `baseline.json` 의 fitness 는 `dim_means` 1축. 이 ADR 은 세 축을 추가한다 (S1 `ux_means`, S2 `admire_means`, S6 `bench_means`).
 
 ```
 baseline.json {
-  "dim_means":     {...17 dim...},                                     # Petri alignment (음의 압력)
-  "ux_means":      {success_rate, token_cost, revert_ratio, latency},  # 행동 (양의 압력)
-  "admire_means":  {pairwise_win_rate, human_calibration_corr},        # 체감 (양의 압력)
-  "seed_pool_diversity": {...}                                         # cohort 균형
+  "schema_version": 2,
+  "raw": {
+    "dim_means":     {...17-22 dim...},                                # Petri alignment (음의 압력)
+    "dim_stderr":    {...},                                            # PR-1 of petri-schema-v2
+    "sample_count":  {...},                                            # PR-1
+    "measurement_modality": {...},                                     # PR-1 (judge_llm / analytics)
+    "rubric_version": "v3-22dim-PR0",
+    "eval_archive":  "<path>"
+  },
+  "axes": {
+    "ux_means":      {success_rate, token_cost, revert_ratio, latency},          # S1 (행동, 양의 압력)
+    "admire_means":  {pairwise_win_rate, human_calibration_corr},                # S2 (체감, 양의 압력)
+    "bench_means":   {swe_bench_pro_pass, livecodebench_pro_accuracy, ...}       # S6 (capability, 양의 압력)
+  }
 }
 ```
 
-**Promote 규칙**: 4 묶음 모두 baseline 대비 monotonic 또는 within-stderr 일 때만. 한 축이라도 regress 면 strict reject — AlphaEvolve 식 다축 정책 그대로.
+> **Deprecated slot — `seed_pool_diversity`** (2026-05-23 amendment): 초안에 4번째 묶음으로 명시됐으나 코드 0 grep, ELO tournament 의 cross-provider panel (`required_diversity_providers ≥ 2`) 이 diversity 신호를 admire_means 안에 이미 흡수. 명시적 deprecate — fitness 축 산정 4축 (dim + ux + admire + bench) 에서 제외.
 
-축별 권장 가중치 (초기): `dim_means` 0.4, `ux_means` 0.3, `admire_means` 0.3. 운영하면서 `[self_improving_loop.fitness] axis_weights = {...}` TOML 으로 조정.
+**Promote 규칙**: 4 축 모두 baseline 대비 monotonic 또는 within-stderr 일 때만. 한 축이라도 regress 면 strict reject — AlphaEvolve 식 다축 정책 그대로. **§S6 (bench) 추가 후의 cross-validation 규칙**: dim promote + bench regress = `alignment_only_fooling`, bench promote + dim critical regress = `capability_at_alignment_cost`. 두 conflict 모두 strict-reject (`compute_fitness → 0.0`) — Goodhart 양방향 방어.
+
+축별 권장 가중치 (2026-05-23 amendment 후): `dim_means` 0.30, `ux_means` 0.25, `admire_means` 0.20, `bench_means` 0.25 (sum=1.0). 운영하면서 `[self_improving_loop.fitness] axis_weights = {...}` TOML 으로 조정.
 
 #### `ux_means` 구성 (S1 신설)
 
@@ -200,6 +214,97 @@ Boris 의 6 근거 중 4개 (1/2/5/6) 가 GEODE 의 `retrieval` slot 에 직접 
 
 → **결론: 옵션 A 채택**. `TARGET_KINDS` 에서 `retrieval` 제거, 5축 → 4축 명시 축소. path constant + dict 매핑 보존 (별도 ADR 로 복원 가능). 정직성 회복 — "되는 것만 명세" 가 self-improving loop 의 ratchet 정신과 일치.
 
+### S6. Bench fitness axis — 7-bench frontier federation (2026-05-23 신설)
+
+> **신설 근거**: 코드 (`autoresearch/bench_means.py` + `autoresearch/train.py` 의 `FITNESS_BENCH_4AX=0.25`) 가 4번째 fitness 축 `bench_means` 를 이미 정의했고 §Decision.2 가 그 사실을 명세화 했지만 (이 amendment), bench 축의 *구성* — 어느 7 benchmark, 가중치, frontier 갱신 근거 — 가 ADR 측에 누락돼 있었다. 본 §S6 가 그 빈자리를 채운다.
+
+#### S6.1 — Bench 의 역할
+
+`dim_means` (Petri alignment, 음의 압력) + `ux_means` / `admire_means` (양의 압력) 옆에 추가되는 **capability** 양의 압력 축. Petri 가 alignment evaluation (안 망가지기), bench 는 real task completion (제대로 함) 의 ground-truth 평가.
+
+#### S6.2 — 7-bench schema (2026-05 frontier 갱신, F1.b LCB substitution 후 확정)
+
+| Field | weight | metric | inspect_ai port (2026-05-23) |
+|-------|--------|--------|-----------------------------|
+| `swe_bench_pro_pass` | 0.25 | resolve rate | `inspect-harbor==0.4.5` (third-party, Docker scaleapi 이미지) |
+| `livecodebench_pro_accuracy` | 0.15 | accuracy (LightCPVerifier C++ exec) | `inspect-evals==0.13.0` |
+| `tau2_bench_success` | 0.20 | pass^1 rate | `inspect-evals` |
+| `gpqa_diamond` | 0.15 | accuracy | `inspect-evals` |
+| `hle_accuracy` | 0.10 | accuracy | `inspect-evals` (multi-modal items: vision 모델 필요 가능) |
+| `osworld_success` | 0.10 | success rate | `inspect-evals` (VM/Docker sandbox) |
+| `mle_bench_medal` | 0.05 | medal rate | `inspect-evals` (Kaggle dataset + Docker exec) |
+| **합** | **1.00** | — | — |
+
+#### S6.3 — Frontier 갱신 history (2026-05)
+
+원본 S6 초안의 4 bench 는 모두 saturated / OpenAI retire / contamination 이슈로 outdated 됐다 — 2026 frontier (Claude Opus 4.5 system card + GPT-5 system card 공통 채택) 으로 7-field schema 갱신:
+
+- **SWE-bench (Verified) → SWE-bench Pro** (Scale AI): OpenAI 2026-02-23 공식 retire, saturated + contaminated
+- **HumanEval → LiveCodeBench-Pro** (F1.b 의 substitution): Top-4 93-95% saturated. *Vanilla LiveCodeBench* 가 contamination-defense 측면에서 후속이었으나 inspect_ai port 부재 — frontier consensus 는 `livecodebench_pro` (C++ 경쟁 프로그래밍, live-contest scrape, time-cutoff windowing, v2 2026 초에 ICPC WF/IOI/Chinese olympiad 추가) 가 그 niche 를 흡수
+- **TAU-bench → τ²-bench** (Sierra 2025): telecom domain 0.993 saturated, dual-control 후속
+- **GAIA → HLE + OSWorld 분할**: DeepAgent 91.69% saturated. HLE (Nature 2026-01) + OSWorld (computer-use) 로 도메인 분리
+- (신규) **GPQA Diamond**: Anthropic + OpenAI 카드 공통 PhD reasoning
+- (신규) **MLE-bench**: self-improving loop 도메인 정합 (ML engineering)
+
+#### S6.4 — Cross-validation gate (Goodhart 양방향 방어)
+
+- **alignment_only_fooling**: dim_means promote (Petri 개선) + bench_means regress (capability 저하) → fooling 의심, strict reject
+- **capability_at_alignment_cost**: bench_means promote + dim critical regress → capability gain at alignment cost, strict reject
+
+두 conflict 모두 `compute_fitness → 0.0` 발화 (`autoresearch/bench_means.py:detect_cross_validation_conflict` + `autoresearch/train.py:compute_fitness` 의 4-axis 분기에서 호출).
+
+#### S6.5 — Frontier sources (2026-05)
+
+- OpenAI SWE-bench retire 공지 — `https://openai.com/index/why-we-no-longer-evaluate-swe-bench-verified/`
+- Scale AI SWE-bench Pro — `https://labs.scale.com/leaderboard/swe_bench_pro_public`
+- Sierra τ²-bench — `https://sierra.ai/resources/research/tau-squared-bench`
+- Humanity's Last Exam (Nature 2026-01) — `https://agi.safe.ai/`
+- LiveCodeBench-Pro 논문 — `https://arxiv.org/abs/2506.11928`
+- GPQA Diamond (NYU 2024)
+- OSWorld (2024 frontier computer-use agent benchmark)
+- MLE-bench (OpenAI 2024 ML engineering)
+- inspect_evals (UK AISI) — `https://github.com/UKGovernmentBEIS/inspect_evals`
+- inspect_harbor (meridianlabs-ai) — `https://github.com/meridianlabs-ai/inspect_harbor`
+- Claude Opus 4.5 system card — `https://www.anthropic.com/claude-opus-4-5-system-card`
+- GPT-5 system card — `https://cdn.openai.com/gpt-5-system-card.pdf`
+
+### S6b. Bench production wiring (2026-05-23 신설, PR-SIL-5THEME C2 의 명세)
+
+§S6 는 **schema + math + cross-validation gate** + **2026 frontier 갱신** 명세. §S6b 는 그 명세의 **실제 production wiring** — collector / dispatcher / persistence / observability / 누락 보고 — 전부.
+
+#### S6b.1 — `collect_bench_means_from_inspect_ai` 실구현
+
+- 7-bench dispatcher: 각 bench 의 inspect_ai task 호출 (`inspect_evals` 또는 `inspect_harbor`)
+- A1 graceful-skip 패턴: Docker / VM 미가용 시 해당 bench 만 skip, `missing_benches` 에 등록, neutral fallback (0.5) 으로 fitness 계산 진행
+- per-bench provenance 동시 emit: `bench_stderr` (sample-level pass/fail 에서 자동 산출) / `bench_sample_count` / `bench_rubric_version="v1-7bench-2026-05"`
+
+#### S6b.2 — `main()` 의 4-axis fitness 활성
+
+- `run_audit` 직후 `collect_bench_means_from_inspect_ai` 호출
+- `compute_fitness(... bench_means=current_bench, baseline_bench_means=baseline_bench)` 4-axis 분기 활성 (현재 분기는 정의돼 있으나 호출 0회, S6b 가 firing path 활성화)
+- `_baseline_provenance` dict 에 `bench_means` + provenance 슬롯 추가 → `_write_baseline` 가 axes.bench_means + raw.bench_provenance 영속화
+- `_should_promote` internal compute_fitness 에 bench 전달 → cross-validation gate 가 promote 결정에 영향
+
+#### S6b.3 — Observability 페이로드 확장
+
+- `format_results_jsonl_row`: `bench_means` / `ux_means` / `admire_means` + per-axis aggregate 컬럼 emit
+- OL-C1 eval emit (`eval_response_recorded`): `axis_scores["bench_means_aggregate"]` 를 baseline → **current** 로 교체 (M4.1 DPO pile 의 stale signal 해소)
+- `_emit_journal("baseline_decision")`: `baseline_axis_coverage` 에 bench count 외 per-bench breakdown 추가
+- conflict 발화 시 reason payload (`alignment_only_fooling` / `capability_at_alignment_cost`) journal + results.jsonl 보존 → fitness=0.0 의 원인 구분 가능
+
+#### S6b.4 — `prepare.py` 의 Docker pre-flight (A1 명세)
+
+`autoresearch/prepare.py` 에 신규 헬퍼:
+- `_check_docker_available()`: `docker --version` + image pull dry-run
+- `_check_inspect_evals_installed()`: `inspect_evals` / `inspect_harbor` import 가용성
+- 결과를 `missing_benches` 에 미리 등록 → collector 가 호출 안 함
+
+#### S6b.5 — 의존성 추가
+
+`pyproject.toml [audit]` extra 에:
+- `inspect-evals==0.13.0` — 6 bench (LCB-Pro + τ²/GPQA/HLE/OSWorld/MLE)
+- `inspect-harbor==0.4.5` — 1 bench (SWE-bench Pro)
+
 ### 4. 단기 → 중기 → 장기 성장 곡선
 
 #### S0 — Audit + Dead Slot 처치 (이미 진행 시작)
@@ -311,6 +416,8 @@ PR-AUDIT-5SLOT 으로 진단 완료. dead slot 별 reader 신설:
 4. **S0d** — `retrieval` 처치 결정 PR
 5. **S1** — `ux_means` fitness 축 신설
 6. **S2** — `admire_means` LLM-judge 채널
-7. (이후) S3-S5 / M1-M5 / 장기 시나리오
+7. **S6** — `bench_means` fitness 축 명세 (schema + math + cross-validation gate) — *이 amendment (PR-SIL-5THEME C1) 으로 ADR 측 명세 완료*
+8. **S6b** — `bench_means` production wiring (collector / dispatcher / persistence / observability / Docker graceful-skip) — *PR-SIL-5THEME C2*
+9. (이후) S3-S5 / M1-M5 / 장기 시나리오
 
 각 PR 은 단일 fitness 축 추가 / 단일 target_kind 추가 / 단일 surrogate 채널 가동을 원자 단위로 보장. 단계 사이마다 baseline.json 이 다축 monotonic 유지 검증.

--- a/docs/plans/2026-05-23-sil-5theme-closure.md
+++ b/docs/plans/2026-05-23-sil-5theme-closure.md
@@ -1,0 +1,256 @@
+# 2026-05-23 — Self-Improving Loop 5-Theme Closure (single PR, 6 commits)
+
+> **Status**: APPROVED (operator confirmed F1.b + A1 + B1 on 2026-05-23)
+> **Scope**: Bench S6b production wiring + ADR-012 §S6 amendment + P3 modality weight split + E1 mutation cost ledger + D4 X2 telemetry + D1 provider B/C closure
+> **PR strategy**: single PR, **6 sequential commits** (one per theme) so reviewer + Codex MCP can audit chunk-by-chunk
+
+## Driving observation
+
+The self-improving loop has 5 independent silent-disconnect gaps. Each can be implemented in isolation, but they share a common diagnostic theme — *spec/code mismatches that the user can't observe today* — and the operator directive bundles them into one PR. The 6-commit split keeps review chunks tractable.
+
+| # | Commit | Theme | LOC est | Risk |
+|---|--------|-------|---------|------|
+| C0 | this plan doc | — | — | — |
+| C1 | `ADR-012` amendment | 3-axis → 4-axis fitness + new §S6 + §S6b | ~250 docs | Doc only — no behavior change |
+| C2 | Bench S6b wiring | 7-bench (F1.b: LCB-Pro) + collector + Docker pre-flight + provenance + cross-validation activation | ~600 (mix code + tests) | Largest commit. Cross-validation gate activates for the first time → fitness landscape shift |
+| C3 | P3 modality weight split | `_JUDGE_LLM_WEIGHTS` + `_ANALYTICS_WEIGHTS` + `compute_fitness(measurement_modality=...)` + N=1 widening 의 analytics-skip 가드 | ~150 | Fitness math change → regression-test heavy |
+| C4 | E1 mutation cost ledger | `mutations.jsonl` 스키마 확장 (`cost_judge_tokens` + `cost_target_tokens` + `cost_seconds` + `fitness_delta`) + runner.py 의 LLM usage capture + attribution baseline_after pairing | ~250 | mutations.jsonl backward-compat (new cols optional) |
+| C5 | D4 X2 telemetry | `HookEvent.PROMPT_ASSEMBLED` fire from `_sync_model_and_rebuild_prompt` + `_inject_model_switch_breadcrumb` 의 purged_count payload | ~120 | New hook fire — handler 부재 시 noop |
+| C6 | D1 provider B/C closure | `PetriRoleConfig.source` default `auto → claude-cli` (Pydantic ValidationError 가 명시 PAYG 시 surface) + per-role source dispatch in `_build_audit_command` + `prepare.py` 의 binary + OAuth pre-flight | ~250 | Default change — operators with `source = "api_key"` 는 명시적 거부 (PR-C-P1 패턴 재사용) |
+
+**Total**: ~1,620 LOC (코드 ~950 + 테스트 ~420 + docs ~250). ~30+ new tests.
+
+---
+
+## C1 — ADR-012 amendment
+
+### Source of mismatch (B1 grounding result)
+
+| 항목 | 코드 (실재) | ADR-012 (문서) | 결정 |
+|------|------------|----------------|------|
+| 축 개수 | 4축 (dim + ux + admire + bench) | **3축** (dim + ux + admire) | ADR 갱신 → 4축 |
+| dim weight | 0.30 | 0.40 | ADR 갱신 → 0.30 |
+| ux weight | 0.25 | 0.30 | ADR 갱신 → 0.25 |
+| admire weight | 0.20 | 0.30 | ADR 갱신 → 0.20 |
+| bench weight | 0.25 | **0 (축 자체 없음)** | ADR 갱신 → 0.25 + §S6 신설 |
+| `seed_pool_diversity` 슬롯 | grep 0건 | §Decision.2 schema 에 포함 | ADR 명시 deprecate / 보류 |
+| §S6 (bench 축) | 코드가 인용하나 doc 부재 | 부재 | 신설 |
+| §S6b (production wiring) | 코드가 "예정" 인용 | 부재 | 신설 (이 PR 의 C2-C6 이 wiring) |
+
+### C1 변경 파일
+
+- `docs/adr/ADR-012-self-improvement-surface-tiers.md`
+  - §Decision.2 의 "3축 multi-axis strict-reject ratchet" → "**4축** multi-axis strict-reject ratchet"
+  - baseline.json schema 갱신: `seed_pool_diversity` 제거 (또는 deprecate 명시) + `bench_means` 추가
+  - 축별 가중치 갱신: dim 0.30 / ux 0.25 / admire 0.20 / **bench 0.25**
+  - **§S6 신설** (Bench fitness axis — 7-bench frontier federation, 2026-05 갱신 history, F1.b 의 LCB → LCB-Pro substitution 명시)
+  - **§S6b 신설** (Production wiring — collector + Docker pre-flight + provenance fields)
+  - "후속 PR 시퀀스" 표에 `S6` / `S6b` 추가
+- `autoresearch/bench_means.py`
+  - docstring 의 "ADR-012 §S6 결정" 인용 → 신설된 §S6 / §S6b 와 grep-provable 일치
+  - "LiveCodeBench (algo, contam-free)" → "LiveCodeBench-Pro (competitive, contam-free, 2026 v2)" (F1.b)
+  - `BENCH_DIM_WEIGHTS` 의 `livecodebench_pass1` → `livecodebench_pro_accuracy` (rename)
+
+### C1 테스트
+
+- `tests/test_adr_012_parity.py` (신규) — ADR-012 §Decision.2 의 4축 가중치 string parse + 코드 상수 (`FITNESS_*_4AX`) 와 일치 invariant. CHANGELOG/PR-body parity 의 doc 측 자동화.
+- `tests/test_s6_bench_means_fitness.py` 갱신 — LCB-Pro rename 적용 + 신 schema 6 field 모두 weight assert (existing 7 field weight sum 1.0 는 변동 없음)
+
+---
+
+## C2 — Bench S6b production wiring (largest)
+
+### 6-step MVP (이전 보고서)
+
+1. `autoresearch/bench_means.py:collect_bench_means_from_inspect_ai` 실구현
+2. `main()` collector 호출 + `compute_fitness(bench_means=…)` + `_baseline_provenance["bench_means"]`
+3. `_should_promote` internal compute_fitness 에 bench 전달 (Goodhart bidirectional gate 활성)
+4. `format_results_jsonl_row` 에 `bench_means` / `ux_means` / `admire_means` 컬럼 emit
+5. OL-C1 `eval_response_recorded` emit 의 `bench_means_aggregate` 를 baseline → current 로 교체
+6. Integration test (stub collector → assert axes.bench_means persists + results.jsonl carries + gate fires)
+
+### 7-bench port 매핑 (F1.b 확정)
+
+| Bench | inspect_ai port | 의존성 | Docker 필요 | A1 graceful-skip |
+|-------|----------------|--------|------------|------------------|
+| swe_bench_pro_pass | `inspect_harbor.swebenchpro` | `inspect-harbor==0.4.5` | ✅ (scaleapi 이미지) | Docker 부재 → skip |
+| **livecodebench_pro_accuracy** | `inspect_evals.livecodebench_pro` | `inspect-evals==0.13.0` | ❌ | nominal |
+| tau2_bench_success | `inspect_evals.tau2_telecom` | 동상 | ❌ | nominal |
+| gpqa_diamond | `inspect_evals.gpqa_diamond` | 동상 | ❌ | nominal |
+| hle_accuracy | `inspect_evals.hle` | 동상 | ⚠️ vision 모델 필요 가능 | vision 미사용 시 skip |
+| osworld_success | `inspect_evals.osworld` | 동상 | ✅ (VM sandbox) | Docker 부재 → skip |
+| mle_bench_medal | `inspect_evals.mle_bench` | 동상 + Kaggle dataset | ✅ (Docker exec) | Docker 부재 → skip |
+
+### C2 변경 파일
+
+- `pyproject.toml`
+  - `[audit]` extra 에 `inspect-evals==0.13.0` + `inspect-harbor==0.4.5` 추가
+- `autoresearch/bench_means.py`
+  - `collect_bench_means_from_inspect_ai` 실구현 (7-bench dispatch + Docker pre-flight + graceful-skip)
+  - 신규 `BENCH_PROVENANCE_SCHEMA` (rubric_version / sample_count / stderr / modality 슬롯)
+  - 신규 `compute_missing_benches(bench_means)` (Goodhart suppression surface)
+- `autoresearch/prepare.py`
+  - `_check_docker_available()` + `_check_inspect_evals_installed()` pre-flight (binary + import 가용성)
+- `autoresearch/train.py`
+  - `main()` — collector 호출 + 4-axis fitness 분기 활성 + `_baseline_provenance` 에 bench 추가
+  - `_should_promote` — bench 전달
+  - `_write_baseline` — bench provenance (stderr / sample_count / rubric_version) 영속화 슬롯 추가
+  - `_load_baseline` — v2 schema reader 가 bench provenance 도 읽도록 확장
+  - `format_results_jsonl_row` — 4-axis 컬럼 emit (bench/ux/admire + per-axis aggregate)
+  - OL-C1 emit — `bench_means_aggregate` 를 current bench 로 교체
+- `core/audit/dim_extractor.py` (있다면) — bench 결과 측 stderr 자동 산출 (inspect_ai sample-level pass/fail 에서)
+
+### C2 테스트
+
+- `tests/test_s6_bench_means_production.py` (신규) — collector 실제 호출 (stub adapter), baseline persist, gate fire, results.jsonl emit, missing_benches Goodhart surface 모두 1-test 1-invariant
+- `tests/test_docker_preflight_graceful_skip.py` (신규) — Docker 부재 시 4 bench skip + nominal 3 bench 작동 + `missing_benches` 표시
+- `tests/test_s6_cross_validation_gate.py` (신규) — alignment_only_fooling + capability_at_alignment_cost 두 conflict 시나리오에서 fitness 0.0 + reason payload 보존
+- `tests/test_provenance_schema.py` (신규) — bench_stderr / bench_sample_count / bench_rubric_version baseline 영속화 invariant
+
+---
+
+## C3 — P3 modality weight split
+
+### Background (B1 GAP findings)
+
+- `_ANALYTICS_MODALITY` (`core/audit/dim_extractor.py:58-61`) 가 2 dim 만 분석 modality (`verbose_padding`, `redundant_tool_invocation`) — 둘 다 auxiliary tier
+- `DIM_WEIGHTS` (`autoresearch/train.py:293-313`) 가 modality-blind — judge_llm 의 1/3 노이즈 특성인 분석 dim 도 동일 weight 0.0333
+- `compute_fitness` 가 `measurement_modality` 파라미터 미수용
+- N=1 widening (`N1_FITNESS_MARGIN_FLOOR=0.20`) 가 deterministic stderr=0.0 (분석 dim) 과 under-sampled stderr=0.0 (judge_llm N=1) 을 conflate
+
+### C3 변경 파일
+
+- `autoresearch/train.py`
+  - `DIM_WEIGHTS` 를 `_JUDGE_LLM_WEIGHTS` + `_ANALYTICS_WEIGHTS` 두 dict 로 split (analytics dim 가중치를 judge_llm 의 0.3-0.5x 로 calibrate — 결정 시 frontier 노이즈 추정 인용)
+  - `compute_fitness(..., measurement_modality: dict[str, str] | None = None)` 신호 받음
+  - `_should_promote` 의 N=1 widening 가드 — `critical_dim 의 modality == "judge_llm"` 일 때만 widening (분석 dim 의 deterministic stderr=0.0 skip)
+- `core/audit/dim_extractor.py`
+  - modality map 자체는 변동 없음 (이미 PR-1 으로 emit)
+
+### C3 테스트
+
+- `tests/test_modality_weight_split.py` (신규)
+  - judge_llm 만 dim 의 fitness vs analytics dim 의 fitness 가중 비율 검증
+  - critical dim 의 N=1 widening 이 judge_llm 일 때만 fire
+  - 분석 dim 이 stderr=0.0 일 때 widening 미발화 (deterministic skip)
+  - 기존 fitness 테스트 무회귀
+
+---
+
+## C4 — E1 mutation cost ledger
+
+### Background (B1 GAP findings)
+
+- `autoresearch/state/mutations.jsonl` git-tracked 존재, cost 컬럼 0건 (`core/self_improving_loop/runner.py:append_audit_log` line 720-732)
+- mutator LLM 호출의 `adapter.agentic_call()` response metadata 폐기 (`runner.py:543`)
+- `audit_seconds` 는 캡처되나 token 분해 없음
+- `attribution.py` 의 attribution row 가 별도 kind 로 append, baseline_after 페어링 미실행
+
+### C4 변경 파일
+
+- `core/self_improving_loop/runner.py`
+  - `_default_llm_call` 응답에서 token usage 캡처 (`tokens_in / tokens_out / total_tokens`)
+  - `append_audit_log` (그리고 `to_audit_row`) 의 row schema 확장:
+    - `cost_judge_tokens: int`
+    - `cost_target_tokens: int` (run_audit 의 audit subprocess 의 LLM 합산 — sessions.jsonl 의 usd_spent 와 일관)
+    - `cost_seconds: float` (audit_seconds + mutator_seconds)
+    - `fitness_delta: float | None` (attribution 후 baseline_after pair 로 계산, attribution row 가 보강)
+  - apply_proposal 후 next audit 의 baseline_after 로딩 → attribution 트리거
+- `core/self_improving_loop/attribution.py`
+  - `compute_attribution` 의 row 에 fitness_delta 추가
+
+### C4 테스트
+
+- `tests/test_mutation_cost_ledger.py` (신규)
+  - mutator LLM 호출 mock → usage 캡처 검증
+  - apply_proposal → next audit → attribution row 의 fitness_delta = baseline_after.fitness - baseline_before.fitness invariant
+  - 기존 mutations.jsonl reader (v1 schema, cost 컬럼 부재) backward-compat — graceful default
+
+---
+
+## C5 — D4 X2 telemetry
+
+### Background (B1 GAP findings)
+
+- `HookEvent.PROMPT_ASSEMBLED` (`core/hooks/system.py:69`) 정의됐으나 zero call site
+- `_sync_model_and_rebuild_prompt` (`core/agent/loop/agent_loop.py:562`) 가 매 round 마다 fire 하지만 관측 marker 0
+- stale-ack purge (`core/agent/loop/_model_switching.py:175-213`) telemetry 0
+
+### C5 변경 파일
+
+- `core/agent/loop/agent_loop.py:_sync_model_and_rebuild_prompt`
+  - `HookEvent.PROMPT_ASSEMBLED.trigger_async` 호출, payload: `{old_model, new_model, reason: "model_drift" | "manual_switch", prompt_hash, x2_injected: True}`
+- `core/agent/loop/_model_switching.py:_inject_model_switch_breadcrumb`
+  - purged_count payload 동봉 (`{purged_count: int, old_model, new_model}`)
+
+### C5 테스트
+
+- `tests/test_prompt_assembled_telemetry.py` (신규)
+  - hook handler register → `_sync_model_and_rebuild_prompt` 호출 → payload schema 검증 (4 keys all present)
+  - stale-ack purge → `purged_count` payload 가 실제 제거 message 수와 일치
+  - PROMPT_ASSEMBLED 가 model 변경 없는 rebuild 에서도 fire (현재 MODEL_SWITCHED 만 fire 하던 gap 보완)
+
+---
+
+## C6 — D1 provider B/C closure
+
+### Background (B1 GAP findings)
+
+- `PetriRoleConfig.source` 스키마 존재 (`core/config/self_improving_loop.py:147`) 하나 dispatcher (`autoresearch/train.py:_build_audit_command:580-624`) per-role 미소비 — 글로벌 `cfg.source` 만 본다
+- default `"auto"` 가 manifest resolver 의 PAYG fallback 까지 도달 가능 (operator decision 위반)
+- 4-backend matrix (`api_key / auto / claude-cli / openai-codex`) 중 2개만 테스트
+- pre-flight 부재 — subprocess 가 늦게 비actionable error 던짐
+
+### C6 변경 파일
+
+- `core/config/self_improving_loop.py`
+  - `PetriRoleConfig.source` default `"auto" → "claude-cli"` (subscription-first 명시)
+  - `Source = Literal["claude-cli", "openai-codex", "auto"]` (Pydantic 가 `api_key` 명시 시 ValidationError surface — PR-C-P1 패턴 재사용)
+  - `AutoresearchConfig.source` 도 동일 변경
+  - 새 docstring: PAYG 제외 정책 + operator action (config.toml 에 `api_key` 명시 시 reject)
+- `autoresearch/train.py:_build_audit_command`
+  - per-role source argv 추가 (`--target-source claude-cli --judge-source openai-codex` 등 또는 env var)
+  - 글로벌 `cfg.source` 와 per-role override 의 dispatch 우선순위 명시 (per-role > global > config)
+- `autoresearch/prepare.py`
+  - 신규 `_check_source_binary(source)` + `_check_oauth_token_freshness(source)` pre-flight
+- `core/self_improving_loop/cli_subprocess.py`
+  - pre-flight 헬퍼 export (`is_claude_cli_available()` / `is_codex_cli_available()`)
+
+### C6 테스트
+
+- `tests/test_provider_dispatch.py` (신규)
+  - 4-backend matrix: api_key (reject) / auto / claude-cli / openai-codex
+  - per-role override: target=claude-cli, judge=openai-codex, auditor=auto → argv 가 3 source 모두 다르게
+  - pre-flight: binary 부재 → actionable error
+  - PAYG 명시 (`source = "api_key"`) → Pydantic ValidationError + operator-friendly message (C-P1 패턴)
+
+---
+
+## 검증 게이트 (per commit + final)
+
+- **각 commit**: `ruff check / ruff format --check / mypy / lint-imports / targeted pytest`
+- **최종 (push 전)**:
+  - `pytest tests/ -m "not live"` — 전체 회귀
+  - Codex MCP 검토 6 라운드 (테마별, anti-deception 5 체크: writer/reader 페어 / hook 등록 / CHANGELOG parity / dead code / 테스트 deletion)
+  - CHANGELOG/PR-body grep verification — 모든 verb/adjective 가 grep-provable
+  - `git check-ignore` 모든 새 path (mutations.jsonl 신 컬럼 / Docker pre-flight log path 등)
+
+## CHANGELOG 전략
+
+5 테마 (실제로는 6 with ADR) → 6 `### Added` / `### Changed` 블록, 각 1-2 단락. 각 verb/adjective 는 grep-provable. CHANGELOG/PR-body parity 의 Codex MCP 자동 catch 패턴 적용.
+
+## Rollback 시나리오
+
+- commit 단위 `git revert` 가능 — 6 독립 commits, semantic isolation 유지
+- mutations.jsonl 스키마 확장: backward-compat (새 컬럼 optional)
+- baseline.json v2 axes.bench_means: 이미 nullable
+- PetriRoleConfig default 변경: explicit `source` 설정 사용자 무영향, 미설정 사용자만 새 default 적용
+- ADR amendment: doc 만 revert 시 코드와 doc 재불일치 → 코드도 동일 revert 권장
+
+## Reference
+
+- F1.b 결정 근거: B1 grounding agent report (LiveCodeBench upstream port 부재, LCB-Pro 가 contamination defense 계승)
+- A1 graceful-skip 결정: cron / serve 환경 Docker 가용성 비대칭 (operator 환경별 nominal path 보존)
+- B1 단일 PR 결정: operator directive (2026-05-23)
+- 4-axis 명세 origin: `autoresearch/train.py:344-350` 의 `FITNESS_*_4AX` 상수 (ADR 외부 결정, 이 PR 의 C1 이 ADR 과 sync)
+- PR-MIC #1515 (C-P1 seed_limit ge=5): 동일한 Pydantic ValidationError surface 패턴 — C6 의 `api_key` reject 가 재사용

--- a/plugins/petri_audit/user_overrides.py
+++ b/plugins/petri_audit/user_overrides.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Any
 
 from core.paths import GLOBAL_PETRI_TOML
+from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
 
@@ -183,14 +184,34 @@ def _read_role_from_self_improving_loop(role: str) -> RoleOverride:
             payload={"role": role, "reason": "import_error"},
         )
         return {}
-    cfg = load_self_improving_loop_config()
+    try:
+        cfg = load_self_improving_loop_config()
+    except ValidationError as exc:
+        # PR-SIL-5THEME C6 (2026-05-23) — D1 provider closure 후 operator
+        # config 의 ``source = "api_key"`` 가 Pydantic Source literal 에서
+        # 제거됐다. autoresearch / mutator 의 직접 호출은 ValidationError 가
+        # 의도된 surface (PR-C-P1 패턴) 이나, petri standalone CLI 의 user
+        # overrides read 는 graceful 이 맞다 — operator 가 petri.toml 의
+        # legacy 경로로 fallback 가능. event emit 으로 추적 가능.
+        _emit_user_overrides_event(
+            "petri_role_legacy_fallback",
+            payload={"role": role, "reason": "validation_error", "error": str(exc)[:200]},
+        )
+        return {}
     entry = cfg.petri.get(role)
     if entry is None:
         return {}
     out: RoleOverride = {}
     if entry.model:
         out["model"] = entry.model
-    if entry.source and entry.source != "auto":
+    # PR-SIL-5THEME C6 (2026-05-23) — Pydantic 의 default 가 explicit 과
+    # 구분 불가하므로 known defaults ("auto", "claude-cli") 는 override
+    # output 에서 제거. operator 가 명시 설정한 explicit 만 surface — 기존
+    # 행동 (auto skip) 보존 + 새 default ("claude-cli") 도 동일 처리.
+    # explicit "claude-cli" 설정이 silent 되는 minor UX corner: operator 가
+    # default 와 같은 값을 명시 설정한 경우 → 효과 같음, 명시 사실만 감춰짐.
+    _KNOWN_DEFAULTS = ("auto", "claude-cli")
+    if entry.source and entry.source not in _KNOWN_DEFAULTS:
         out["source"] = entry.source
     return out
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.41"
+version = "0.99.42"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,17 @@ audit = [
     # can emit tool_use blocks under --max-turns 1 without raw-SDK
     # 429 enforcement on Claude Max OAuth tokens.
     "mcp>=1.0.0",
+    # PR-SIL-5THEME C2 (2026-05-23) — S6b production wiring 의 7-bench
+    # federation dependencies. ``inspect-evals`` 가 6 bench
+    # (livecodebench_pro / tau2_telecom / gpqa_diamond / hle / osworld /
+    # mle_bench) 를 cover, ``inspect-harbor`` 가 SWE-bench Pro 1 bench
+    # 추가. Both gated by ``autoresearch/bench_means.py`` 의 A1
+    # graceful-skip — Docker / VM / vision 부재 시 해당 bench skip 하고
+    # ``missing_benches`` Goodhart surface 에 등록. B1 grounding
+    # survey: vanilla LiveCodeBench port 부재 확인 → F1.b
+    # ``livecodebench_pro`` substitution 결정.
+    "inspect-evals>=0.13.0",
+    "inspect-harbor>=0.4.5",
 ]
 # OpenLLMetry (Apache-2.0) — OTel-compatible LLM/agent tracing.
 # Lazy-imported in core/observability/ so default `uv sync` cold-start is
@@ -460,6 +471,9 @@ module = [
     # `uv sync --extra audit` is run; default sync skips them.
     "inspect_ai.*",
     "inspect_petri.*",
+    # PR-SIL-5THEME C2 — S6b bench federation dependencies, same opt-in.
+    "inspect_evals.*",
+    "inspect_harbor.*",
     # P4 prep — [obs] / [viz] optional extras. Same opt-in pattern.
     "traceloop.*",
     "opentelemetry.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.40"
+version = "0.99.41"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/core/observability/test_session_journal.py
+++ b/tests/core/observability/test_session_journal.py
@@ -23,7 +23,7 @@ def _make_journal(tmp_path: Path) -> SessionJournal:
         session_id="s-test",
         gen_tag="autoresearch-test",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
 
@@ -31,7 +31,7 @@ def test_append_writes_jsonl_row(tmp_path: Path) -> None:
     """append() writes one JSONL row with the full schema."""
     journal = _make_journal(tmp_path)
     journal.append("audit_finished", payload={"fitness": 0.5}, ts=1700000000.0)
-    rows = (tmp_path / "journal.jsonl").read_text().splitlines()
+    rows = (tmp_path / "transcript.jsonl").read_text().splitlines()
     assert len(rows) == 1
     payload = json.loads(rows[0])
     assert payload == {
@@ -49,14 +49,14 @@ def test_append_supports_level_and_default_payload(tmp_path: Path) -> None:
     """level kwarg defaults to 'info'; missing payload becomes empty dict."""
     journal = _make_journal(tmp_path)
     journal.append("subagent_failed", level="error", ts=1.0)
-    row = json.loads((tmp_path / "journal.jsonl").read_text().splitlines()[0])
+    row = json.loads((tmp_path / "transcript.jsonl").read_text().splitlines()[0])
     assert row["level"] == "error"
     assert row["payload"] == {}
 
 
 def test_append_creates_parent_dirs(tmp_path: Path) -> None:
     """Nested paths are auto-mkdir'd before write."""
-    deep = tmp_path / "nested" / "deeper" / "journal.jsonl"
+    deep = tmp_path / "nested" / "deeper" / "transcript.jsonl"
     journal = SessionJournal(
         session_id="s",
         gen_tag="g",
@@ -72,7 +72,7 @@ def test_append_appends_not_overwrites(tmp_path: Path) -> None:
     journal = _make_journal(tmp_path)
     for i in range(3):
         journal.append(f"event-{i}", ts=float(i))
-    rows = (tmp_path / "journal.jsonl").read_text().splitlines()
+    rows = (tmp_path / "transcript.jsonl").read_text().splitlines()
     assert len(rows) == 3
     events = [json.loads(r)["event"] for r in rows]
     assert events == ["event-0", "event-1", "event-2"]
@@ -92,7 +92,7 @@ def test_append_swallows_oserror(
         session_id="s",
         gen_tag="g",
         component="autoresearch",
-        path=tmp_path / "nonexistent" / "journal.jsonl",
+        path=tmp_path / "nonexistent" / "transcript.jsonl",
     )
     journal.append("event")  # Must not raise.
 
@@ -120,7 +120,7 @@ def test_session_journal_scope_restores_on_exception(tmp_path: Path) -> None:
 
 
 def test_default_path_uses_geode_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Unset path falls back to ``GLOBAL_SELF_IMPROVING_LOOP_DIR`` / <session> / journal.jsonl."""
+    """Unset path falls back to ``GLOBAL_SELF_IMPROVING_LOOP_DIR`` / <session> / transcript.jsonl."""
     fake_home = tmp_path / "home"
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
     # Reload both core.paths and core.observability.session_journal so
@@ -137,7 +137,7 @@ def test_default_path_uses_geode_home(monkeypatch: pytest.MonkeyPatch, tmp_path:
         gen_tag="g",
         component="autoresearch",
     )
-    expected = fake_home / ".geode" / "self-improving-loop" / "s-default" / "journal.jsonl"
+    expected = fake_home / ".geode" / "self-improving-loop" / "s-default" / "transcript.jsonl"
     assert journal.path == expected
     journal.append("event")
     assert expected.is_file()
@@ -178,7 +178,7 @@ def test_hook_handlers_route_subagent_events_to_journal(tmp_path: Path) -> None:
             {"task_id": "t-2", "error": "boom", "session_id": "s"},
         )
 
-    rows = [json.loads(r) for r in (tmp_path / "journal.jsonl").read_text().splitlines()]
+    rows = [json.loads(r) for r in (tmp_path / "transcript.jsonl").read_text().splitlines()]
     events = [r["event"] for r in rows]
     levels = [r["level"] for r in rows]
     assert events == ["subagent_started", "subagent_completed", "subagent_failed"]

--- a/tests/plugins/petri_audit/test_credential_source.py
+++ b/tests/plugins/petri_audit/test_credential_source.py
@@ -475,7 +475,7 @@ def _emit_test_journal(tmp_path):
         session_id="s-p1b",
         gen_tag="gen-p1b",
         component="autoresearch",
-        path=sip_home / "s-p1b" / "journal.jsonl",
+        path=sip_home / "s-p1b" / "transcript.jsonl",
     )
     return journal, sip_home
 

--- a/tests/plugins/petri_audit/test_petri_cli.py
+++ b/tests/plugins/petri_audit/test_petri_cli.py
@@ -155,9 +155,17 @@ def test_set_model_missing_args(captured):
 
 
 def test_set_source_updates_override(captured, monkeypatch):
+    """PR-SIL-5THEME C6 (2026-05-23) — D1 provider closure 후 ``api_key``
+    가 Source literal 에서 제거됐다. Test 가 explicit override 의 SAVE +
+    READ round-trip 을 verify — ``openai-codex`` (non-default subscription
+    source) 으로 explicit override 시 read 가 그대로 반환."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-    cmd_petri("source auditor api_key")
-    assert uo.read_role_override("auditor") == {"source": "api_key"}
+    # Switch auditor's default model to GPT-5 first (so openai-codex source
+    # is provider-compatible — auditor manifest default is claude-*).
+    cmd_petri("model auditor gpt-5.5")
+    cmd_petri("source auditor openai-codex")
+    override = uo.read_role_override("auditor")
+    assert override.get("source") == "openai-codex"
 
 
 def test_set_source_rejects_invalid(captured):

--- a/tests/plugins/petri_audit/test_user_overrides.py
+++ b/tests/plugins/petri_audit/test_user_overrides.py
@@ -420,7 +420,7 @@ def test_read_role_emits_journal_when_self_improving_loop_unavailable(
         session_id="s-legacy",
         gen_tag="gen-legacy",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
     # Force the lazy import inside _read_role_from_self_improving_loop to fail
@@ -463,7 +463,7 @@ def test_read_role_no_emit_when_self_improving_loop_available(
         session_id="s-newpath",
         gen_tag="gen-newpath",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with session_journal_scope(journal):
         result = uo._read_role_from_self_improving_loop("auditor")

--- a/tests/plugins/petri_audit/test_user_overrides.py
+++ b/tests/plugins/petri_audit/test_user_overrides.py
@@ -232,7 +232,11 @@ source = "api_key"
             petri={
                 "auditor": SimpleNamespace(
                     model="new-from-config-toml",
-                    source="claude-cli",
+                    source="openai-codex",  # PR-SIL-5THEME C6 — non-default
+                    # subscription source. ``claude-cli`` 가 새 default 라
+                    # known defaults filter 에 걸려서 explicit override 로
+                    # surface 하려면 다른 값 필요. ``api_key`` 는 PR-SIL-5THEME
+                    # C6 로 Source literal 에서 제거됐다.
                     fallback_to_payg=None,
                 )
             }
@@ -240,7 +244,7 @@ source = "api_key"
     )
     override = uo.read_role_override("auditor")
     assert override["model"] == "new-from-config-toml"
-    assert override["source"] == "claude-cli"
+    assert override["source"] == "openai-codex"
 
 
 def test_read_role_override_falls_back_to_petri_toml(

--- a/tests/plugins/seed_generation/test_cli.py
+++ b/tests/plugins/seed_generation/test_cli.py
@@ -395,7 +395,7 @@ def test_run_audit_seeds_emits_cost_preview_into_session_journal(tmp_path: Any) 
     work begins. Verifies the outer-scope wiring introduced in PR-P2."""
     import json
 
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     with (
         patch("plugins.seed_generation.cli.pick_bindings", return_value=_good_picker()),
         patch("plugins.seed_generation.cli.run_pre_flight", return_value=PreFlightReport()),
@@ -432,7 +432,7 @@ def test_run_audit_seeds_emits_cost_preview_into_session_journal(tmp_path: Any) 
 
 
 def test_run_audit_seeds_emits_preflight_passed_when_clean(tmp_path: Any) -> None:
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     from core.observability import SessionJournal as RealJournal
 
     def _bind(**kwargs: Any) -> Any:
@@ -463,7 +463,7 @@ def test_run_audit_seeds_emits_preflight_passed_when_clean(tmp_path: Any) -> Non
 def test_run_audit_seeds_emits_preflight_failed_with_issue_list(tmp_path: Any) -> None:
     """The dominant pre-PR observability gap — preflight error path now
     surfaces the structured issue list before exit code 1."""
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     bad_report = PreFlightReport(
         issues=[
             PreFlightIssue(
@@ -518,7 +518,7 @@ def test_run_audit_seeds_emits_preflight_failed_with_issue_list(tmp_path: Any) -
 
 
 def test_run_audit_seeds_emits_user_aborted_on_decline(tmp_path: Any) -> None:
-    journal_path = tmp_path / "journal.jsonl"
+    journal_path = tmp_path / "transcript.jsonl"
     from core.observability import SessionJournal as RealJournal
 
     def _bind(**kwargs: Any) -> Any:

--- a/tests/plugins/seed_generation/test_orchestrator.py
+++ b/tests/plugins/seed_generation/test_orchestrator.py
@@ -245,7 +245,7 @@ def test_pipeline_emits_phase_started_finished_for_every_phase(tmp_path) -> None
         session_id="t-p1c",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with session_journal_scope(journal):
         asyncio.run(Pipeline(state, registry).arun())
@@ -293,7 +293,7 @@ def test_pipeline_emits_phase_failed_soft_failure(tmp_path) -> None:
         session_id="t-soft",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with session_journal_scope(journal):
         asyncio.run(Pipeline(state, registry).arun())
@@ -320,7 +320,7 @@ def test_pipeline_emits_phase_failed_hard_failure(tmp_path) -> None:
         session_id="t-hard",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     with (
         session_journal_scope(journal),
@@ -343,7 +343,7 @@ def test_registry_register_replace_emits_agent_reregistered(tmp_path) -> None:
         session_id="t-rereg",
         gen_tag="gen2",
         component="seed-generation",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
     registry = PipelineRegistry()
     registry.register(_StubAgent("generator"))

--- a/tests/test_adr_012_parity.py
+++ b/tests/test_adr_012_parity.py
@@ -1,0 +1,153 @@
+"""ADR-012 ↔ code parity invariants — catches silent drift between the
+ADR (`docs/adr/ADR-012-self-improvement-surface-tiers.md`) and the
+ground-truth runtime constants (`autoresearch/train.py` /
+`autoresearch/bench_means.py`).
+
+PR-SIL-5THEME C1 (2026-05-23) — codifies the
+CHANGELOG/PR-body-parity anti-deception lesson (CLAUDE.md DONT row
+1, PR-G5b #1350) for the §S6/§S6b ADR amendments. Without these
+tests a future ADR edit could regress the doc to "3축" or drop
+``§S6`` and the build would stay green.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from autoresearch.bench_means import BENCH_DIM_WEIGHTS
+from autoresearch.train import (
+    FITNESS_ADMIRE_4AX,
+    FITNESS_BENCH_4AX,
+    FITNESS_DIM_4AX,
+    FITNESS_UX_4AX,
+)
+
+ADR_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "adr"
+    / ("ADR-012-self-improvement-surface-tiers.md")
+)
+
+
+def _adr_text() -> str:
+    return ADR_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# §Decision.2 — 4축 명세 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_adr012_decision2_header_says_4axis() -> None:
+    """§Decision.2 의 헤더가 "4축" 명시 (이전 "3축" 에서 amend).
+
+    Why: amendment 가 빠지면 doc 가 코드의 `FITNESS_BENCH_4AX` 명세와
+    drift — PR-G5b #1350 의 "X-driven" 거짓 claim 과 동형 anti-deception.
+    """
+    txt = _adr_text()
+    assert "### 2. Fitness 다축화 — 4축 multi-axis strict-reject ratchet" in txt
+
+
+def test_adr012_decision2_weights_match_code_constants() -> None:
+    """§Decision.2 의 "축별 권장 가중치" 줄 4 개 weight 가 코드 상수와 일치.
+
+    코드 상수는 ``autoresearch/train.py:344-350`` 의 ``FITNESS_*_4AX``
+    (합 1.0 assert). 이 테스트가 ADR 측 표기 ``0.30 / 0.25 / 0.20 / 0.25``
+    가 코드와 같은지 검증 — 둘 다 1.0 이라도 분배가 다르면 fail.
+    """
+    txt = _adr_text()
+    # 첫 amendment 의 가중치 줄
+    pattern = (
+        r"`dim_means`\s*(\d+\.\d+)\s*,\s*"
+        r"`ux_means`\s*(\d+\.\d+)\s*,\s*"
+        r"`admire_means`\s*(\d+\.\d+)\s*,\s*"
+        r"`bench_means`\s*(\d+\.\d+)"
+    )
+    match = re.search(pattern, txt)
+    assert match is not None, "ADR §Decision.2 의 4-axis 가중치 표기 미발견"
+    adr_weights = tuple(float(g) for g in match.groups())
+    code_weights = (
+        FITNESS_DIM_4AX,
+        FITNESS_UX_4AX,
+        FITNESS_ADMIRE_4AX,
+        FITNESS_BENCH_4AX,
+    )
+    assert adr_weights == code_weights, f"ADR weights {adr_weights} != code weights {code_weights}"
+
+
+def test_adr012_deprecates_seed_pool_diversity() -> None:
+    """§Decision.2 의 ``seed_pool_diversity`` 가 명시적 deprecate.
+
+    초안의 4번째 묶음으로 명시됐으나 코드 0 grep (PR-SIL-5THEME C1
+    grounding). amendment 가 deprecate 결정을 명시 — 미명시 시 future
+    reader 가 "코드에 있어야 하나" 혼동.
+    """
+    txt = _adr_text()
+    assert "Deprecated slot — `seed_pool_diversity`" in txt
+
+
+# ---------------------------------------------------------------------------
+# §S6 — Bench fitness axis 신설 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_adr012_has_s6_section() -> None:
+    """ADR 에 ``### S6.`` 섹션 헤더 존재.
+
+    Why: ``autoresearch/bench_means.py`` docstring 의 "ADR-012 §S6"
+    인용이 grep-provable — PR-G5b #1350 lesson.
+    """
+    txt = _adr_text()
+    assert "### S6. Bench fitness axis" in txt
+
+
+def test_adr012_s6_schema_field_names_match_code() -> None:
+    """§S6.2 의 7-bench schema field name 이 ``BENCH_DIM_WEIGHTS`` 와 일치.
+
+    F1.b substitution: ``livecodebench_pass1`` → ``livecodebench_pro_accuracy``.
+    ADR 표기와 코드 상수가 어긋나면 collector 가 어느 쪽 ID 로 emit 할지
+    모호해짐.
+    """
+    txt = _adr_text()
+    for field in BENCH_DIM_WEIGHTS:
+        # Markdown 의 backtick 인용 또는 plain 둘 다 OK
+        assert f"`{field}`" in txt or field in txt, f"ADR §S6 에 field 누락: {field}"
+
+
+def test_adr012_s6_weights_match_bench_dim_weights() -> None:
+    """§S6.2 표의 weight column 이 ``BENCH_DIM_WEIGHTS`` 와 일치.
+
+    표 행의 ``| `<field>` | <weight> | <metric> |`` 패턴을 파싱해서
+    weight 일치 확인.
+    """
+    txt = _adr_text()
+    # 표 라인 패턴: | `field` | 0.NN | ...
+    pattern = re.compile(r"\|\s*`(\w+)`\s*\|\s*(\d+\.\d+)\s*\|")
+    rows = dict(pattern.findall(txt))
+    for field, expected_weight in BENCH_DIM_WEIGHTS.items():
+        assert field in rows, f"ADR §S6.2 의 표에 field 누락: {field}"
+        assert float(rows[field]) == expected_weight, (
+            f"ADR §S6.2 weight mismatch for {field}: ADR={rows[field]} vs code={expected_weight}"
+        )
+
+
+def test_adr012_has_s6b_section() -> None:
+    """ADR 에 ``### S6b.`` (production wiring) 섹션 존재.
+
+    Why: ``autoresearch/bench_means.py`` docstring 의 "§S6b 의 wiring
+    명세" 인용이 grep-provable.
+    """
+    txt = _adr_text()
+    assert "### S6b. Bench production wiring" in txt
+
+
+def test_adr012_pr_sequence_lists_s6_and_s6b() -> None:
+    """ "후속 PR 시퀀스" 표가 S6 / S6b 모두 포함.
+
+    Amendment 가 leakage 없이 doc 의 모든 정합 지점을 갱신했는지 확인.
+    """
+    txt = _adr_text()
+    assert "**S6** — `bench_means`" in txt
+    assert "**S6b** — `bench_means` production wiring" in txt

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1678,7 +1678,7 @@ _SESSIONS_JSONL_CANONICAL_FIELDS = frozenset(
 
 
 def _journal_path(tmp_path: Path, session_id: str) -> Path:
-    return tmp_path / "self-improving-loop" / session_id / "journal.jsonl"
+    return tmp_path / "self-improving-loop" / session_id / "transcript.jsonl"
 
 
 def _redirect_journal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1744,7 +1744,7 @@ def test_emit_journal_noops_on_empty_session_id(
     _emit_journal("", "gen-x", "audit_started", payload={"dry_run": True})
     # No journal file should be created.
     assert not (tmp_path / "self-improving-loop").exists() or not any(
-        (tmp_path / "self-improving-loop").rglob("journal.jsonl")
+        (tmp_path / "self-improving-loop").rglob("transcript.jsonl")
     )
 
 
@@ -1756,7 +1756,7 @@ def test_emit_journal_noops_on_empty_gen_tag(
     _redirect_journal(tmp_path, monkeypatch)
     _emit_journal("s-x", "", "audit_started", payload={"dry_run": True})
     assert not (tmp_path / "self-improving-loop").exists() or not any(
-        (tmp_path / "self-improving-loop").rglob("journal.jsonl")
+        (tmp_path / "self-improving-loop").rglob("transcript.jsonl")
     )
 
 
@@ -1806,7 +1806,7 @@ def _drive_main_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tupl
     # Find the single run dir under sip_home (session_id resolved at runtime).
     run_dirs = [p for p in sip_home.iterdir() if p.is_dir()]
     assert len(run_dirs) == 1, f"expected one run dir under {sip_home}, got {run_dirs}"
-    journal_path = run_dirs[0] / "journal.jsonl"
+    journal_path = run_dirs[0] / "transcript.jsonl"
     sessions_path = sip_home / "sessions.jsonl"
     return exit_code, journal_path, sessions_path
 

--- a/tests/test_autoresearch_train.py
+++ b/tests/test_autoresearch_train.py
@@ -1859,7 +1859,14 @@ def test_main_dry_run_emits_full_p0b_event_sequence(
     }
     # PR-4 (2026-05-23) — per_dim_scores payload gains ``missing_dims``
     # Goodhart-risk surface alongside the score map.
-    assert set(by_event["per_dim_scores"].keys()) == {"dim_scores", "missing_dims"}
+    # PR-SIL-5THEME C2 (2026-05-23) — bench 측 symmetric Goodhart surface
+    # 추가 (``missing_benches`` + ``bench_rubric_version``).
+    assert set(by_event["per_dim_scores"].keys()) == {
+        "dim_scores",
+        "missing_dims",
+        "missing_benches",
+        "bench_rubric_version",
+    }
     # PR-4 Codex catch — pin actual content, not just key presence.
     # ``_drive_main_dry_run`` produces 5 dims (the dry-run synthesizer);
     # the missing list should hold all other ``AXIS_TIERS`` dims.

--- a/tests/test_d1_provider_closure.py
+++ b/tests/test_d1_provider_closure.py
@@ -1,0 +1,184 @@
+"""PR-SIL-5THEME C6 — D1 provider B/C closure tests.
+
+operator decision (durable memory ``project_payg_exclusion_decision.md``,
+2026-05-23) 으로 autoresearch / Petri audit 의 provider 선택지에서 PAYG
+(``api_key``) 영구 exclude. 잔존 옵션 = claude-cli / openai-codex / auto.
+
+C6 의 3 wiring:
+1. ``Source`` literal 에서 ``api_key`` 제거 → Pydantic 가 reject (silent
+   leak 차단)
+2. ``PetriRoleConfig.source`` + ``AutoresearchConfig.source`` default
+   ``auto → claude-cli`` (subscription-first 명시)
+3. ``autoresearch/prepare.py`` 의 ``check_subscription_cli_for_source``
+   pre-flight — binary 부재 시 actionable error
+"""
+
+from __future__ import annotations
+
+import pytest
+from autoresearch.prepare import check_subscription_cli_for_source
+from core.config.self_improving_loop import (
+    AutoresearchConfig,
+    PetriRoleConfig,
+)
+from pydantic import ValidationError
+
+# ---------------------------------------------------------------------------
+# 1. Source literal — api_key reject
+# ---------------------------------------------------------------------------
+
+
+def test_petri_role_source_api_key_rejected() -> None:
+    """PetriRoleConfig 에 ``source = "api_key"`` 설정 시 Pydantic 가 reject —
+    PAYG 가 audit role 선택지에서 영구 제거됐다는 invariant.
+
+    operator 가 config.toml 에 ``[self_improving_loop.petri.target]
+    source = "api_key"`` 명시 → ValidationError + 어느 값이 invalid 인지
+    명시되는 Pydantic 메시지로 surface.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        PetriRoleConfig(source="api_key")  # type: ignore[arg-type]
+    msg = str(exc_info.value)
+    assert "source" in msg
+    assert "api_key" in msg
+
+
+def test_autoresearch_source_api_key_rejected() -> None:
+    """AutoresearchConfig 도 동일 — ``source = "api_key"`` Pydantic reject."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutoresearchConfig(source="api_key")  # type: ignore[arg-type]
+    msg = str(exc_info.value)
+    assert "source" in msg
+    assert "api_key" in msg
+
+
+def test_petri_role_source_accepts_claude_cli() -> None:
+    """``source = "claude-cli"`` 수락 (subscription default)."""
+    p = PetriRoleConfig(source="claude-cli")
+    assert p.source == "claude-cli"
+
+
+def test_petri_role_source_accepts_openai_codex() -> None:
+    """``source = "openai-codex"`` 수락 (ChatGPT Plus OAuth)."""
+    p = PetriRoleConfig(source="openai-codex")
+    assert p.source == "openai-codex"
+
+
+def test_petri_role_source_accepts_auto() -> None:
+    """``source = "auto"`` 수락 (manifest cascade — subscription-first
+    but fallback_to_payg=False 가 default 라 PAYG 까지 안 감)."""
+    p = PetriRoleConfig(source="auto")
+    assert p.source == "auto"
+
+
+# ---------------------------------------------------------------------------
+# 2. Defaults — subscription-first
+# ---------------------------------------------------------------------------
+
+
+def test_petri_role_default_source_claude_cli() -> None:
+    """PetriRoleConfig 의 source default 가 ``claude-cli`` (subscription-first).
+
+    PR-SIL-5THEME C6 후 default 변경. ``auto`` 는 manifest cascade 가
+    silent PAYG fallback 가능 → 명시 default 로 leak 차단.
+    """
+    p = PetriRoleConfig()
+    assert p.source == "claude-cli"
+
+
+def test_autoresearch_config_default_source_claude_cli() -> None:
+    """AutoresearchConfig 의 source default 도 ``claude-cli``."""
+    a = AutoresearchConfig()
+    assert a.source == "claude-cli"
+
+
+# ---------------------------------------------------------------------------
+# 3. check_subscription_cli_for_source — pre-flight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_claude_cli_missing_binary_returns_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``claude`` binary 가 PATH 에 없으면 actionable error 메시지 반환."""
+    monkeypatch.delenv("GEODE_CLAUDE_CLI_BIN", raising=False)
+    # shutil.which("claude") 가 None 반환하도록 mock
+    import autoresearch.prepare as prepare_module
+
+    monkeypatch.setattr(prepare_module.shutil, "which", lambda _: None)
+
+    ok, msg = check_subscription_cli_for_source("claude-cli")
+    assert not ok
+    assert "claude-cli source selected" in msg
+    assert "GEODE_CLAUDE_CLI_BIN" in msg
+
+
+def test_preflight_codex_cli_missing_binary_returns_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``codex`` binary 부재 시 actionable error."""
+    monkeypatch.delenv("GEODE_CODEX_CLI_BIN", raising=False)
+    import autoresearch.prepare as prepare_module
+
+    monkeypatch.setattr(prepare_module.shutil, "which", lambda _: None)
+
+    ok, msg = check_subscription_cli_for_source("openai-codex")
+    assert not ok
+    assert "openai-codex source selected" in msg
+    assert "GEODE_CODEX_CLI_BIN" in msg
+
+
+def test_preflight_claude_cli_env_override_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GEODE_CLAUDE_CLI_BIN env override 가 shutil.which 보다 우선."""
+    monkeypatch.setenv("GEODE_CLAUDE_CLI_BIN", "/custom/path/claude")
+    import autoresearch.prepare as prepare_module
+
+    # shutil.which 가 다른 값을 반환해도 env override 가 이김
+    monkeypatch.setattr(prepare_module.shutil, "which", lambda _: "/usr/local/bin/claude")
+
+    ok, msg = check_subscription_cli_for_source("claude-cli")
+    assert ok
+    assert "/custom/path/claude" in msg
+
+
+def test_preflight_auto_source_skips_binary_check() -> None:
+    """``source="auto"`` → cascade 가 fallback path 책임 → pre-flight skip."""
+    ok, msg = check_subscription_cli_for_source("auto")
+    assert ok
+    assert "auto source" in msg
+    assert "cascade" in msg
+
+
+def test_preflight_unknown_source_graceful_skip() -> None:
+    """Unknown source (e.g. legacy api_key) → graceful skip without error."""
+    ok, msg = check_subscription_cli_for_source("api_key")
+    assert ok
+    assert "api_key" in msg
+
+
+# ---------------------------------------------------------------------------
+# 4. Backend matrix — 4 cases (api_key reject + 3 valid)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_matrix_api_key_rejected_petri_role() -> None:
+    """4-backend matrix: api_key 만 reject, 다른 3 (claude-cli / openai-codex /
+    auto) 는 accept."""
+    # Reject
+    with pytest.raises(ValidationError):
+        PetriRoleConfig(source="api_key")  # type: ignore[arg-type]
+    # Accept (3 valid sources)
+    for source in ("claude-cli", "openai-codex", "auto"):
+        cfg = PetriRoleConfig(source=source)  # type: ignore[arg-type]
+        assert cfg.source == source
+
+
+def test_backend_matrix_api_key_rejected_autoresearch() -> None:
+    """AutoresearchConfig 도 같은 matrix."""
+    with pytest.raises(ValidationError):
+        AutoresearchConfig(source="api_key")  # type: ignore[arg-type]
+    for source in ("claude-cli", "openai-codex", "auto"):
+        cfg = AutoresearchConfig(source=source)  # type: ignore[arg-type]
+        assert cfg.source == source

--- a/tests/test_d4_x2_telemetry.py
+++ b/tests/test_d4_x2_telemetry.py
@@ -1,0 +1,303 @@
+"""PR-SIL-5THEME C5 — D4 X2 system-prompt model-identity injection telemetry.
+
+`HookEvent.PROMPT_ASSEMBLED` 가 `core/hooks/system.py:69` 에 정의됐으나
+fire 0회 였다 → X2 (Option B model identity injection,
+``core/agent/system_prompt.py:337``) 가 매 round 마다 발화하지만 관측
+marker 0. stale-ack purge 도 silent.
+
+C5 가 2 wiring point 활성:
+1. `_sync_model_and_rebuild_prompt` 가 rebuild 후 `PROMPT_ASSEMBLED` fire
+   payload: {model, provider, reason, x2_injected, prompt_len}
+2. `_inject_model_switch_breadcrumb` 가 purged count 반환 →
+   `update_model_async` 가 `MODEL_SWITCHED` payload 에 동봉
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from core.agent.loop._model_switching import (
+    _inject_model_switch_breadcrumb,
+    purge_stale_model_switch_acks,
+    update_model_async,
+)
+from core.hooks import HookEvent, HookSystem
+
+# ---------------------------------------------------------------------------
+# 1. purge_stale_model_switch_acks — returns purged count
+# ---------------------------------------------------------------------------
+
+
+class _FakeContext:
+    """Minimal context for purge tests — mimics loop.context.messages contract."""
+
+    def __init__(self, messages: list[dict[str, Any]]) -> None:
+        self.messages = list(messages)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.messages
+
+    def add_user_message(self, text: str) -> None:
+        self.messages.append({"role": "user", "content": text})
+
+    def add_assistant_message(self, text: str) -> None:
+        self.messages.append({"role": "assistant", "content": text})
+
+
+class _FakeLoop:
+    """Minimal loop stand-in for _model_switching helpers."""
+
+    def __init__(self, messages: list[dict[str, Any]] | None = None) -> None:
+        self.context = _FakeContext(messages or [])
+
+    def _purge_stale_model_switch_acks(self) -> int:
+        return purge_stale_model_switch_acks(self)  # type: ignore[arg-type]
+
+
+def test_purge_returns_zero_when_no_acks() -> None:
+    """Clean history → purged count 0."""
+    loop = _FakeLoop(messages=[{"role": "user", "content": "hi"}])
+    assert purge_stale_model_switch_acks(loop) == 0  # type: ignore[arg-type]
+
+
+def test_purge_returns_count_for_string_form_acks() -> None:
+    """str-form `Understood. I am now ...` ack 가 N 개 → purge_count = N."""
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "Understood. I am now gpt-5.4."},
+        {"role": "user", "content": "follow-up"},
+        {"role": "assistant", "content": "Understood. I am now gpt-5.5."},
+    ]
+    loop = _FakeLoop(messages=messages)
+    assert purge_stale_model_switch_acks(loop) == 2  # type: ignore[arg-type]
+    # 두 ack 모두 제거
+    assert not any(
+        isinstance(m.get("content"), str) and m["content"].startswith("Understood. I am now ")
+        for m in loop.context.messages
+    )
+
+
+def test_purge_returns_count_for_block_form_acks() -> None:
+    """Anthropic block-form `[{"type": "text", "text": "Understood. I am now …"}]`
+    도 catch — PR-MIC 후속 case."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Understood. I am now claude-3."}],
+        },
+    ]
+    loop = _FakeLoop(messages=messages)
+    assert purge_stale_model_switch_acks(loop) == 1  # type: ignore[arg-type]
+
+
+def test_purge_leaves_user_messages_untouched() -> None:
+    """User message 가 ack-prefix 우연 matching 해도 절대 안 건드림 (보수적)."""
+    messages = [
+        {"role": "user", "content": "Understood. I am now confused."},
+        {"role": "assistant", "content": "Understood. I am now gpt-5.5."},
+    ]
+    loop = _FakeLoop(messages=messages)
+    purged = purge_stale_model_switch_acks(loop)  # type: ignore[arg-type]
+    assert purged == 1  # only the assistant ack
+    # User message 살아있음
+    assert loop.context.messages[0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# 2. _inject_model_switch_breadcrumb — forwards purged count
+# ---------------------------------------------------------------------------
+
+
+def test_inject_breadcrumb_returns_zero_for_empty_context() -> None:
+    """빈 context → breadcrumb skip → purged count 0."""
+    loop = _FakeLoop(messages=[])
+    purged = _inject_model_switch_breadcrumb(loop, "old", "new")  # type: ignore[arg-type]
+    assert purged == 0
+
+
+def test_inject_breadcrumb_forwards_purged_count() -> None:
+    """Non-empty context + 기존 ack 존재 → purged count 반환."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "Understood. I am now gpt-5.4."},
+    ]
+    loop = _FakeLoop(messages=messages)
+    purged = _inject_model_switch_breadcrumb(loop, "gpt-5.4", "gpt-5.5")  # type: ignore[arg-type]
+    assert purged == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. update_model_async — MODEL_SWITCHED payload includes purged_ack_count
+# ---------------------------------------------------------------------------
+
+
+def test_update_model_async_fires_model_switched_with_purged_count() -> None:
+    """update_model_async 가 model 변경 시 MODEL_SWITCHED hook 발화 +
+    payload 에 purged_ack_count 동봉. C5 의 핵심 wiring 검증."""
+    hooks = HookSystem()
+    received_payloads: list[dict[str, Any]] = []
+
+    async def capture(_event: HookEvent, payload: dict[str, Any]) -> None:
+        received_payloads.append(payload)
+
+    hooks.register(HookEvent.MODEL_SWITCHED, capture)
+
+    # Fake loop with prior stale ack — purge 가 1 count
+    loop = MagicMock()
+    loop.context = _FakeContext(
+        messages=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Understood. I am now gpt-5.4."},
+        ]
+    )
+    loop._hooks = hooks
+    loop._model = "gpt-5.4"
+    loop._provider = "openai"
+    loop._adapt_context_for_model = MagicMock()
+    loop._purge_stale_model_switch_acks = lambda: purge_stale_model_switch_acks(loop)
+
+    # _apply_model_update mock 으로 changed=True 강제
+    from core.agent.loop import _model_switching as ms_module
+
+    original_apply = ms_module._apply_model_update
+    ms_module._apply_model_update = MagicMock(return_value=("gpt-5.4", True))
+    try:
+        # emit_model_switched 도 mock — UI 의존성 차단
+        original_emit = None
+        try:
+            from core.ui import agentic_ui
+
+            original_emit = agentic_ui.emit_model_switched
+            agentic_ui.emit_model_switched = MagicMock()
+        except (ImportError, AttributeError):
+            pass
+
+        asyncio.run(update_model_async(loop, "gpt-5.5", "openai", "user_switch"))
+
+        if original_emit is not None:
+            agentic_ui.emit_model_switched = original_emit
+    finally:
+        ms_module._apply_model_update = original_apply
+
+    assert len(received_payloads) == 1
+    payload = received_payloads[0]
+    assert payload["from_model"] == "gpt-5.4"
+    assert payload["to_model"] == "gpt-5.5"
+    assert payload["reason"] == "user_switch"
+    assert payload["purged_ack_count"] == 1  # stale ack 1 개 purge 됨
+
+
+# ---------------------------------------------------------------------------
+# 4. _sync_model_and_rebuild_prompt — fires PROMPT_ASSEMBLED hook
+# ---------------------------------------------------------------------------
+
+
+def test_sync_and_rebuild_fires_prompt_assembled_on_drift() -> None:
+    """Model drift (settings.model 변경) 감지 시 PROMPT_ASSEMBLED 발화 +
+    payload 에 model / provider / reason / x2_injected / prompt_len."""
+    hooks = HookSystem()
+    received: list[dict[str, Any]] = []
+
+    async def capture(_event: HookEvent, payload: dict[str, Any]) -> None:
+        received.append(payload)
+
+    hooks.register(HookEvent.PROMPT_ASSEMBLED, capture)
+
+    # Fake AgenticLoop
+    loop = MagicMock()
+    loop._hooks = hooks
+    loop.model = "gpt-5.5"
+    loop._provider = "openai"
+    loop._prompt_dirty = False
+    loop._sync_model_from_settings_async = AsyncMock(return_value=True)  # drift!
+    loop._build_system_prompt = MagicMock(return_value="rebuilt system prompt body")
+
+    # Manually invoke the bound method
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    result = asyncio.run(AgenticLoop._sync_model_and_rebuild_prompt(loop, "old prompt", None))
+    # rebuild 됐는지 — _build_system_prompt 가 호출됐는지 확인
+    loop._build_system_prompt.assert_called_once()
+    assert result == "rebuilt system prompt body"
+    # hook 발화 확인
+    assert len(received) == 1
+    payload = received[0]
+    assert payload["model"] == "gpt-5.5"
+    assert payload["provider"] == "openai"
+    assert payload["reason"] == "model_drift"
+    assert payload["x2_injected"] is True
+    assert payload["prompt_len"] == len("rebuilt system prompt body")
+
+
+def test_sync_and_rebuild_fires_prompt_assembled_on_prompt_dirty() -> None:
+    """_prompt_dirty=True 만 set 된 경우 (drift 없음) → reason='prompt_dirty'."""
+    hooks = HookSystem()
+    received: list[dict[str, Any]] = []
+
+    async def capture(_event: HookEvent, payload: dict[str, Any]) -> None:
+        received.append(payload)
+
+    hooks.register(HookEvent.PROMPT_ASSEMBLED, capture)
+
+    loop = MagicMock()
+    loop._hooks = hooks
+    loop.model = "claude-opus-4-7"
+    loop._provider = "anthropic"
+    loop._prompt_dirty = True  # dirty!
+    loop._sync_model_from_settings_async = AsyncMock(return_value=False)  # no drift
+    loop._build_system_prompt = MagicMock(return_value="rebuilt body")
+
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    asyncio.run(AgenticLoop._sync_model_and_rebuild_prompt(loop, "old", None))
+    assert received[0]["reason"] == "prompt_dirty"
+
+
+def test_sync_and_rebuild_no_fire_when_no_drift_no_dirty() -> None:
+    """drift / dirty 둘 다 False → rebuild skip + hook 미발화 (성능)."""
+    hooks = HookSystem()
+    received: list[dict[str, Any]] = []
+
+    async def capture(_event: HookEvent, payload: dict[str, Any]) -> None:
+        received.append(payload)
+
+    hooks.register(HookEvent.PROMPT_ASSEMBLED, capture)
+
+    loop = MagicMock()
+    loop._hooks = hooks
+    loop.model = "gpt-5.5"
+    loop._provider = "openai"
+    loop._prompt_dirty = False
+    loop._sync_model_from_settings_async = AsyncMock(return_value=False)
+    loop._build_system_prompt = MagicMock()
+
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    result = asyncio.run(AgenticLoop._sync_model_and_rebuild_prompt(loop, "untouched", None))
+    # rebuild 미발생
+    loop._build_system_prompt.assert_not_called()
+    assert result == "untouched"
+    # hook 미발화
+    assert received == []
+
+
+def test_sync_and_rebuild_no_hook_when_loop_has_none_hooks() -> None:
+    """``loop._hooks`` 가 None 일 때 (hook system 미초기화) graceful skip —
+    rebuild 는 정상 진행, trigger 만 noop."""
+    loop = MagicMock()
+    loop._hooks = None
+    loop.model = "gpt-5.5"
+    loop._provider = "openai"
+    loop._prompt_dirty = False
+    loop._sync_model_from_settings_async = AsyncMock(return_value=True)
+    loop._build_system_prompt = MagicMock(return_value="rebuilt")
+
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    result = asyncio.run(AgenticLoop._sync_model_and_rebuild_prompt(loop, "old", None))
+    assert result == "rebuilt"
+    # 예외 없이 통과

--- a/tests/test_e1_mutation_cost_ledger.py
+++ b/tests/test_e1_mutation_cost_ledger.py
@@ -18,11 +18,12 @@ from unittest.mock import MagicMock
 
 from core.self_improving_loop.attribution import compute_attribution
 from core.self_improving_loop.runner import (
-    _LAST_LLM_CALL_USAGE,
     Mutation,
     _consume_last_llm_call_usage,
     _reset_last_llm_call_usage,
 )
+
+from core.observability import current_session_metrics, session_metrics_scope
 
 # ---------------------------------------------------------------------------
 # 1. Mutation cost fields
@@ -88,34 +89,55 @@ def test_mutation_to_audit_row_partial_cost_fields() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2. _LAST_LLM_CALL_USAGE sidecar capture
+# 2. SessionMetrics last-call snapshot capture (PR-SESSION-METRICS)
 # ---------------------------------------------------------------------------
+#
+# PR-SIL-5THEME C4 의 module-level ``_LAST_LLM_CALL_USAGE`` dict + PR-C4.fix-
+# contextvar 의 ``_LAST_LLM_CALL_USAGE_VAR`` ContextVar + ``_UsageProxy`` shim
+# 이 SessionMetrics 의 last-call 4-field snapshot 으로 흡수됨. Test 는
+# ``current_session_metrics()`` ContextVar 를 통해 직접 mutate / read.
 
 
-def test_reset_last_llm_call_usage_clears_module_dict() -> None:
-    """``_reset_last_llm_call_usage`` 는 module-level dict 를 비움 — propose()
-    가 LLM call 직전 호출해서 이전 mutation 의 usage 잔여 차단."""
-    _LAST_LLM_CALL_USAGE["dirty"] = "value"
-    _reset_last_llm_call_usage()
-    assert _LAST_LLM_CALL_USAGE == {}
+def test_reset_last_llm_call_usage_clears_session_metrics_last_call() -> None:
+    """``_reset_last_llm_call_usage`` 는 SessionMetrics 의 last-call snapshot
+    만 비움 (cumulative 보존). propose() 가 LLM call 직전 호출."""
+    with session_metrics_scope(session_id="test"):
+        m = current_session_metrics()
+        m.last_call_input_tokens = 100
+        m.last_call_model = "test-model"
+        _reset_last_llm_call_usage()
+        assert m.last_call_input_tokens == 0
+        assert m.last_call_model == ""
 
 
 def test_consume_last_llm_call_usage_returns_snapshot_and_clears() -> None:
-    """``_consume_last_llm_call_usage`` 가 snapshot 반환 + module dict 비움.
-
-    Atomic — return-and-clear 의 race condition 자체가 single-threaded
-    propose() 사이클 안에서 없도록.
-    """
-    _LAST_LLM_CALL_USAGE.update({"input_tokens": 100, "output_tokens": 50})
-    snapshot = _consume_last_llm_call_usage()
-    assert snapshot == {"input_tokens": 100, "output_tokens": 50}
-    assert _LAST_LLM_CALL_USAGE == {}
+    """``_consume_last_llm_call_usage`` 가 snapshot 반환 + SessionMetrics 의
+    last-call 슬롯 비움. Race condition 없음 — 같은 ContextVar 안의 atomic
+    read-and-clear."""
+    with session_metrics_scope(session_id="test"):
+        m = current_session_metrics()
+        m.accumulate_llm_call(
+            input_tokens=100,
+            output_tokens=50,
+            elapsed_seconds=1.23,
+            model="claude-opus-4-7",
+        )
+        snapshot = _consume_last_llm_call_usage()
+        assert snapshot == {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "elapsed_seconds": 1.23,
+            "model": "claude-opus-4-7",
+        }
+        # last-call 슬롯 비워짐, cumulative 는 보존
+        assert m.last_call_input_tokens == 0
+        assert m.input_tokens == 100  # cumulative untouched
 
 
 def test_consume_last_llm_call_usage_empty_when_unset() -> None:
-    """sidecar 비어 있을 때 (mock LLM 호출 후) consume 은 빈 dict 반환."""
-    _LAST_LLM_CALL_USAGE.clear()
-    assert _consume_last_llm_call_usage() == {}
+    """LLM call mock 이 accumulate 안 했으면 consume 은 빈 dict 반환."""
+    with session_metrics_scope(session_id="test"):
+        assert _consume_last_llm_call_usage() == {}
 
 
 # ---------------------------------------------------------------------------
@@ -189,14 +211,12 @@ def test_propose_populates_cost_from_sidecar(
     )
 
     def llm_call_with_usage(_sys: str, _usr: str) -> str:
-        # production _default_llm_call 처럼 sidecar 에 usage 적재
-        _LAST_LLM_CALL_USAGE.update(
-            {
-                "input_tokens": 2500,
-                "output_tokens": 1200,
-                "elapsed_seconds": 4.567,
-                "model": "claude-opus-4-7",
-            }
+        # production _default_llm_call 처럼 SessionMetrics accumulate
+        current_session_metrics().accumulate_llm_call(
+            input_tokens=2500,
+            output_tokens=1200,
+            elapsed_seconds=4.567,
+            model="claude-opus-4-7",
         )
         return response_json
 
@@ -217,7 +237,8 @@ def test_propose_populates_cost_from_sidecar(
         audit_log_path=tmp_path / "mutations.jsonl",
     )
 
-    proposal = runner.propose()
+    with session_metrics_scope(session_id="test"):
+        proposal = runner.propose()
     m = proposal.mutation
     assert m.cost_input_tokens == 2500
     assert m.cost_output_tokens == 1200
@@ -225,15 +246,13 @@ def test_propose_populates_cost_from_sidecar(
     assert m.cost_model == "claude-opus-4-7"
 
 
-def test_propose_clears_sidecar_before_call(
+def test_propose_clears_last_call_before_invocation(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
-    """이전 mutation 의 sidecar 잔여 (e.g. 이전 propose() 가 실패하고 race
-    한 경우) 가 다음 propose() 의 mutation 에 끼지 못함. _reset_last_llm_call_usage
-    가 LLM call 직전 fire."""
-    # 이전 mutation 의 잔여 sidecar
-    _LAST_LLM_CALL_USAGE.update({"input_tokens": 999, "stale": True})
+    """이전 mutation 의 last-call snapshot 잔여 (e.g. 이전 propose() 가 실패한
+    경우) 가 다음 propose() 의 mutation 에 끼지 못함. ``_reset_last_llm_call_usage``
+    가 LLM call 직전 fire 해서 SessionMetrics 의 last-call 슬롯 비움."""
 
     response_json = json.dumps(
         {
@@ -244,8 +263,7 @@ def test_propose_clears_sidecar_before_call(
     )
 
     def mock_llm(_sys: str, _usr: str) -> str:
-        # mock 는 sidecar 채우지 않음 (test inject 의 일반 패턴)
-        # → propose() 가 _reset 호출했으므로 stale data 미흡수
+        # mock 는 SessionMetrics accumulate 안 함 → reset 후 0 유지
         return response_json
 
     from core.self_improving_loop import runner as runner_mod
@@ -264,9 +282,14 @@ def test_propose_clears_sidecar_before_call(
         rerun_enabled=False,
         audit_log_path=tmp_path / "mutations.jsonl",
     )
-    proposal = runner.propose()
+    with session_metrics_scope(session_id="test") as m:
+        # 이전 mutation 의 last-call 잔여 시뮬레이션
+        m.last_call_input_tokens = 999
+        m.last_call_model = "stale-model"
+        proposal = runner.propose()
     # stale 999 가 안 새들어옴 — default 0
     assert proposal.mutation.cost_input_tokens == 0
+    assert proposal.mutation.cost_model == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_e1_mutation_cost_ledger.py
+++ b/tests/test_e1_mutation_cost_ledger.py
@@ -1,0 +1,330 @@
+"""PR-SIL-5THEME C4 — E1 mutation cost ledger tests.
+
+`mutations.jsonl` 가 git-tracked 으로 존재했으나 cost 컬럼이 0건이라
+operator 가 mutation 의 ROI (cost vs fitness Δ) 볼 수 없었다. C4 가
+3 step 으로 silent disconnect 닫음:
+
+1. _default_llm_call 이 response.usage 를 sidecar dict 에 capture
+2. propose() 가 sidecar 소비하여 Mutation 의 cost 4-field 채움
+3. attribution row 에 fitness_before / fitness_after / fitness_delta 추가
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.self_improving_loop.attribution import compute_attribution
+from core.self_improving_loop.runner import (
+    _LAST_LLM_CALL_USAGE,
+    Mutation,
+    _consume_last_llm_call_usage,
+    _reset_last_llm_call_usage,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Mutation cost fields
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_default_cost_fields_zero_or_empty() -> None:
+    """기본 Mutation 인스턴스의 cost 4 필드는 0 / "" (backward-compat).
+
+    Legacy caller (test mock 등) 가 cost 미설정 시 default 유지 → audit row
+    에 cost 컬럼 자체 미생성 (downstream parser 무영향).
+    """
+    m = Mutation(target_section="s", new_value="v", rationale="r")
+    assert m.cost_input_tokens == 0
+    assert m.cost_output_tokens == 0
+    assert m.cost_elapsed_seconds == 0.0
+    assert m.cost_model == ""
+
+
+def test_mutation_to_audit_row_omits_cost_columns_when_zero() -> None:
+    """Cost 0 / "" 일 때 row 에 cost_* 키 자체 미생성 (legacy reader 무영향)."""
+    m = Mutation(target_section="s", new_value="v", rationale="r")
+    row = m.to_audit_row(previous_value="prev")
+    assert "cost_input_tokens" not in row
+    assert "cost_output_tokens" not in row
+    assert "cost_elapsed_seconds" not in row
+    assert "cost_model" not in row
+
+
+def test_mutation_to_audit_row_includes_cost_columns_when_set() -> None:
+    """Cost 채워진 Mutation → row 가 cost 4 컬럼 emit (cost_input_tokens
+    + cost_output_tokens 둘 다 양수일 때 함께 emit)."""
+    m = Mutation(
+        target_section="s",
+        new_value="v",
+        rationale="r",
+        cost_input_tokens=1234,
+        cost_output_tokens=567,
+        cost_elapsed_seconds=12.345,
+        cost_model="claude-opus-4-7",
+    )
+    row = m.to_audit_row(previous_value="prev")
+    assert row["cost_input_tokens"] == 1234
+    assert row["cost_output_tokens"] == 567
+    assert row["cost_elapsed_seconds"] == 12.345
+    assert row["cost_model"] == "claude-opus-4-7"
+
+
+def test_mutation_to_audit_row_partial_cost_fields() -> None:
+    """Cost 일부만 set 일 때 — input_tokens=0 + output_tokens=0 면 token 컬럼
+    skip, elapsed_seconds 만 set 이면 그 컬럼만 emit. 명확히 separable."""
+    m = Mutation(
+        target_section="s",
+        new_value="v",
+        rationale="r",
+        cost_elapsed_seconds=5.0,
+    )
+    row = m.to_audit_row(previous_value="prev")
+    assert "cost_input_tokens" not in row
+    assert "cost_output_tokens" not in row
+    assert row["cost_elapsed_seconds"] == 5.0
+    assert "cost_model" not in row
+
+
+# ---------------------------------------------------------------------------
+# 2. _LAST_LLM_CALL_USAGE sidecar capture
+# ---------------------------------------------------------------------------
+
+
+def test_reset_last_llm_call_usage_clears_module_dict() -> None:
+    """``_reset_last_llm_call_usage`` 는 module-level dict 를 비움 — propose()
+    가 LLM call 직전 호출해서 이전 mutation 의 usage 잔여 차단."""
+    _LAST_LLM_CALL_USAGE["dirty"] = "value"
+    _reset_last_llm_call_usage()
+    assert _LAST_LLM_CALL_USAGE == {}
+
+
+def test_consume_last_llm_call_usage_returns_snapshot_and_clears() -> None:
+    """``_consume_last_llm_call_usage`` 가 snapshot 반환 + module dict 비움.
+
+    Atomic — return-and-clear 의 race condition 자체가 single-threaded
+    propose() 사이클 안에서 없도록.
+    """
+    _LAST_LLM_CALL_USAGE.update({"input_tokens": 100, "output_tokens": 50})
+    snapshot = _consume_last_llm_call_usage()
+    assert snapshot == {"input_tokens": 100, "output_tokens": 50}
+    assert _LAST_LLM_CALL_USAGE == {}
+
+
+def test_consume_last_llm_call_usage_empty_when_unset() -> None:
+    """sidecar 비어 있을 때 (mock LLM 호출 후) consume 은 빈 dict 반환."""
+    _LAST_LLM_CALL_USAGE.clear()
+    assert _consume_last_llm_call_usage() == {}
+
+
+# ---------------------------------------------------------------------------
+# 3. propose() — sidecar consumption + cost population
+# ---------------------------------------------------------------------------
+
+
+def _build_propose_runner(
+    raw_response: str,
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> Any:
+    """propose() 호출 가능한 minimal runner — mock llm_call + minimal context."""
+    from core.self_improving_loop import runner as runner_mod
+
+    # build_runner_context 가 baseline_reader 등 실제 SoT 를 읽으려 함 — mock.
+    mock_ctx = MagicMock()
+    mock_ctx.baseline_snapshot = None
+    mock_ctx.current_sections = {"# Setup": "current setup content"}
+    mock_ctx.current_policies = {"prompt": {"# Setup": "current setup content"}}
+    mock_ctx.target_dim = ""
+    monkeypatch.setattr(runner_mod, "build_runner_context", lambda: mock_ctx)
+    # apply 가 disk 안 건드리도록 path mock
+    monkeypatch.setattr(runner_mod, "MUTATION_AUDIT_LOG_PATH", tmp_path / "mutations.jsonl")
+
+    return runner_mod.SelfImprovingLoopRunner(
+        llm_call=lambda _sys, _usr: raw_response,
+        commit_enabled=False,
+        rerun_enabled=False,
+        audit_log_path=tmp_path / "mutations.jsonl",
+    )
+
+
+def test_propose_mock_llm_call_leaves_cost_default(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Test 가 inject 한 str-returning mock 은 sidecar 비움 → Mutation 의
+    cost 4-field 가 default 유지. Backward-compat: 기존 mock-based test
+    전체 영향 0.
+    """
+    response_json = json.dumps(
+        {
+            "target_section": "# Setup",
+            "new_value": "new content",
+            "rationale": "test",
+        }
+    )
+    runner = _build_propose_runner(response_json, monkeypatch, tmp_path)
+
+    proposal = runner.propose()
+    m = proposal.mutation
+    assert m.cost_input_tokens == 0
+    assert m.cost_output_tokens == 0
+    assert m.cost_elapsed_seconds == 0.0
+    assert m.cost_model == ""
+
+
+def test_propose_populates_cost_from_sidecar(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """mock llm_call 안에서 sidecar 채워두면 propose() 가 그 값을 mutation
+    에 forward. _default_llm_call 의 production path 시뮬레이션."""
+    response_json = json.dumps(
+        {
+            "target_section": "# Setup",
+            "new_value": "new content",
+            "rationale": "test",
+        }
+    )
+
+    def llm_call_with_usage(_sys: str, _usr: str) -> str:
+        # production _default_llm_call 처럼 sidecar 에 usage 적재
+        _LAST_LLM_CALL_USAGE.update(
+            {
+                "input_tokens": 2500,
+                "output_tokens": 1200,
+                "elapsed_seconds": 4.567,
+                "model": "claude-opus-4-7",
+            }
+        )
+        return response_json
+
+    from core.self_improving_loop import runner as runner_mod
+
+    mock_ctx = MagicMock()
+    mock_ctx.baseline_snapshot = None
+    mock_ctx.current_sections = {"# Setup": "current setup content"}
+    mock_ctx.current_policies = {"prompt": {"# Setup": "current setup content"}}
+    mock_ctx.target_dim = ""
+    monkeypatch.setattr(runner_mod, "build_runner_context", lambda: mock_ctx)
+    monkeypatch.setattr(runner_mod, "MUTATION_AUDIT_LOG_PATH", tmp_path / "mutations.jsonl")
+
+    runner = runner_mod.SelfImprovingLoopRunner(
+        llm_call=llm_call_with_usage,
+        commit_enabled=False,
+        rerun_enabled=False,
+        audit_log_path=tmp_path / "mutations.jsonl",
+    )
+
+    proposal = runner.propose()
+    m = proposal.mutation
+    assert m.cost_input_tokens == 2500
+    assert m.cost_output_tokens == 1200
+    assert m.cost_elapsed_seconds == 4.567
+    assert m.cost_model == "claude-opus-4-7"
+
+
+def test_propose_clears_sidecar_before_call(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """이전 mutation 의 sidecar 잔여 (e.g. 이전 propose() 가 실패하고 race
+    한 경우) 가 다음 propose() 의 mutation 에 끼지 못함. _reset_last_llm_call_usage
+    가 LLM call 직전 fire."""
+    # 이전 mutation 의 잔여 sidecar
+    _LAST_LLM_CALL_USAGE.update({"input_tokens": 999, "stale": True})
+
+    response_json = json.dumps(
+        {
+            "target_section": "# Setup",
+            "new_value": "new content",
+            "rationale": "test",
+        }
+    )
+
+    def mock_llm(_sys: str, _usr: str) -> str:
+        # mock 는 sidecar 채우지 않음 (test inject 의 일반 패턴)
+        # → propose() 가 _reset 호출했으므로 stale data 미흡수
+        return response_json
+
+    from core.self_improving_loop import runner as runner_mod
+
+    mock_ctx = MagicMock()
+    mock_ctx.baseline_snapshot = None
+    mock_ctx.current_sections = {"# Setup": "current setup content"}
+    mock_ctx.current_policies = {"prompt": {"# Setup": "current setup content"}}
+    mock_ctx.target_dim = ""
+    monkeypatch.setattr(runner_mod, "build_runner_context", lambda: mock_ctx)
+    monkeypatch.setattr(runner_mod, "MUTATION_AUDIT_LOG_PATH", tmp_path / "mutations.jsonl")
+
+    runner = runner_mod.SelfImprovingLoopRunner(
+        llm_call=mock_llm,
+        commit_enabled=False,
+        rerun_enabled=False,
+        audit_log_path=tmp_path / "mutations.jsonl",
+    )
+    proposal = runner.propose()
+    # stale 999 가 안 새들어옴 — default 0
+    assert proposal.mutation.cost_input_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. compute_attribution — fitness_before / fitness_after / fitness_delta
+# ---------------------------------------------------------------------------
+
+
+def test_compute_attribution_emits_fitness_delta_when_both_provided() -> None:
+    """fitness_before + fitness_after 둘 다 명시 → payload 에 3 컬럼 emit."""
+    payload = compute_attribution(
+        mutation_id="mut1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        fitness_before=0.50,
+        fitness_after=0.62,
+    )
+    assert payload["fitness_before"] == 0.50
+    assert payload["fitness_after"] == 0.62
+    # rounded to 6 decimals
+    assert payload["fitness_delta"] == 0.12
+
+
+def test_compute_attribution_omits_fitness_keys_when_unset() -> None:
+    """fitness_before / after 미명시 → 키 자체 미생성 (legacy reader 무영향)."""
+    payload = compute_attribution(
+        mutation_id="mut1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+    )
+    assert "fitness_before" not in payload
+    assert "fitness_after" not in payload
+    assert "fitness_delta" not in payload
+
+
+def test_compute_attribution_omits_fitness_when_only_before() -> None:
+    """fitness_before 만 명시 (after 부재) → 키 미생성 (Δ 계산 불가)."""
+    payload = compute_attribution(
+        mutation_id="mut1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        fitness_before=0.5,
+    )
+    assert "fitness_before" not in payload
+    assert "fitness_after" not in payload
+    assert "fitness_delta" not in payload
+
+
+def test_compute_attribution_fitness_delta_negative() -> None:
+    """Regression scenario — after < before → fitness_delta 음수."""
+    payload = compute_attribution(
+        mutation_id="mut1",
+        expected_dim={},
+        baseline_before=None,
+        baseline_after=None,
+        fitness_before=0.70,
+        fitness_after=0.55,
+    )
+    assert payload["fitness_delta"] == -0.15

--- a/tests/test_m4_0_eval_event.py
+++ b/tests/test_m4_0_eval_event.py
@@ -29,7 +29,7 @@ from core.self_improving_loop.eval_journaling import (
 
 @pytest.fixture
 def journal_path(tmp_path: Path) -> Iterator[Path]:
-    yield tmp_path / "journal.jsonl"
+    yield tmp_path / "transcript.jsonl"
 
 
 def _read_events(path: Path) -> list[dict]:

--- a/tests/test_m4_1_dpo_pack.py
+++ b/tests/test_m4_1_dpo_pack.py
@@ -36,7 +36,7 @@ from core.self_improving_loop.eval_journaling import emit_eval_response_recorded
 
 @pytest.fixture
 def journal_path(tmp_path: Path) -> Iterator[Path]:
-    yield tmp_path / "session-A" / "journal.jsonl"
+    yield tmp_path / "session-A" / "transcript.jsonl"
 
 
 @pytest.fixture
@@ -206,8 +206,8 @@ def test_new_pair_appended_on_rerun(journal_path: Path, pack_path: Path) -> None
 
 def test_multi_journal_merge(tmp_path: Path, pack_path: Path) -> None:
     """Two journals (different sessions) feed the same prompt → cross-session pair."""
-    j1 = tmp_path / "s1" / "journal.jsonl"
-    j2 = tmp_path / "s2" / "journal.jsonl"
+    j1 = tmp_path / "s1" / "transcript.jsonl"
+    j2 = tmp_path / "s2" / "transcript.jsonl"
     with session_journal_scope(_journal(j1, session_id="s1")):
         emit_eval_response_recorded(
             prompt="shared", response="great", fitness_score=0.95, source="petri_audit"

--- a/tests/test_ol_c1_emit_eval_caller.py
+++ b/tests/test_ol_c1_emit_eval_caller.py
@@ -28,7 +28,7 @@ def _journal_with_path(tmp_path: Path) -> SessionJournal:
         session_id="ol-c1-test",
         gen_tag="auto-test",
         component="autoresearch",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
 

--- a/tests/test_p3_modality_weight_split.py
+++ b/tests/test_p3_modality_weight_split.py
@@ -1,0 +1,319 @@
+"""PR-SIL-5THEME C3 — P3 modality 가중 분리 tests.
+
+`core/audit/dim_extractor` 가 PR-1 으로 per-dim `measurement_modality`
+를 emit 했으나 `compute_fitness` / `_should_promote` 는 그 신호를
+0% 사용했다. C3 가 그 silent disconnect 를 닫는다:
+
+- analytics modality 의 가중치를 0.5× scale (deterministic stderr 의
+  fitness signal dilution 해소)
+- N=1 widening guard 가 judge_llm 만 fire (analytics 의 deterministic
+  stderr=0 이 under-sampled stderr=0 과 conflate 안 함)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from autoresearch.train import (
+    ANALYTICS_WEIGHT_MULTIPLIER,
+    DIM_MODALITY_WEIGHT_MULTIPLIER,
+    DIM_WEIGHTS,
+    JUDGE_LLM_MODALITIES,
+    N1_FITNESS_MARGIN_FLOOR,
+    _dim_weight_with_modality,
+    _load_baseline_measurement_modality,
+    _should_promote,
+    compute_fitness,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Modality weight constants — schema invariants
+# ---------------------------------------------------------------------------
+
+
+def test_analytics_weight_multiplier_in_range_0_to_1() -> None:
+    """``ANALYTICS_WEIGHT_MULTIPLIER`` 는 0 (analytics 무시) ~ 1 (현재 동작)
+    사이. 1 초과는 analytics 를 judge_llm 보다 *더* 중요시 — 명시 결정 부재 시
+    invariant 위반."""
+    assert 0.0 <= ANALYTICS_WEIGHT_MULTIPLIER <= 1.0
+
+
+def test_modality_multiplier_dispatch_covers_modality_extractor_emit() -> None:
+    """``DIM_MODALITY_WEIGHT_MULTIPLIER`` 가 ``dim_extractor`` 의 emit
+    값 (judge_llm + _ANALYTICS_MODALITY 의 sub-modality) 모두 cover.
+
+    drift 시 unknown modality 가 default 1.0 (judge_llm) 으로 silent
+    처리됨 — analytics 의 의도된 0.5 scale 이 dilute 안 됨.
+    """
+    from core.audit.dim_extractor import _ANALYTICS_MODALITY, DEFAULT_MODALITY
+
+    expected_modalities = set(_ANALYTICS_MODALITY.values()) | {DEFAULT_MODALITY, "analytics"}
+    assert expected_modalities.issubset(set(DIM_MODALITY_WEIGHT_MULTIPLIER))
+
+
+def test_judge_llm_modalities_includes_empty_string() -> None:
+    """``JUDGE_LLM_MODALITIES`` 가 빈 문자열도 포함 — modality 부재 시
+    conservative default 로 N=1 widening 유지 (legacy / v1 baseline 안전)."""
+    assert "" in JUDGE_LLM_MODALITIES
+    assert "judge_llm" in JUDGE_LLM_MODALITIES
+
+
+# ---------------------------------------------------------------------------
+# 2. _dim_weight_with_modality — per-dim multiplier dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dim_weight_no_modality_returns_base() -> None:
+    """``measurement_modality=None`` → DIM_WEIGHTS 값 그대로 (backward compat)."""
+    assert _dim_weight_with_modality("broken_tool_use", None) == DIM_WEIGHTS["broken_tool_use"]
+
+
+def test_dim_weight_judge_llm_modality_unchanged() -> None:
+    """judge_llm modality 명시 시 multiplier 1.0 → 가중치 변동 없음."""
+    modality = {"broken_tool_use": "judge_llm"}
+    assert _dim_weight_with_modality("broken_tool_use", modality) == DIM_WEIGHTS["broken_tool_use"]
+
+
+def test_dim_weight_analytics_scaled() -> None:
+    """analytics modality → ANALYTICS_WEIGHT_MULTIPLIER 적용."""
+    modality = {"verbose_padding": "token_count"}
+    expected = DIM_WEIGHTS["verbose_padding"] * ANALYTICS_WEIGHT_MULTIPLIER
+    assert _dim_weight_with_modality("verbose_padding", modality) == expected
+
+
+def test_dim_weight_unknown_modality_default_judge_llm() -> None:
+    """Unknown modality 값 → 보수적 default (judge_llm, multiplier 1.0).
+    Silent skip 보다 명시 dispatch — analytics 의도가 dilute 되지 않음 +
+    새 modality 추가 시 명시 entry 강제."""
+    modality = {"broken_tool_use": "new_modality_we_didnt_define_yet"}
+    assert _dim_weight_with_modality("broken_tool_use", modality) == DIM_WEIGHTS["broken_tool_use"]
+
+
+def test_dim_weight_unknown_dim_returns_zero() -> None:
+    """``DIM_WEIGHTS`` 에 없는 dim → 0.0 (graceful, fitness 기여 0)."""
+    assert _dim_weight_with_modality("unknown_dim", None) == 0.0
+    assert _dim_weight_with_modality("unknown_dim", {"unknown_dim": "judge_llm"}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. compute_fitness — modality-aware aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_compute_fitness_modality_blind_backward_compat() -> None:
+    """``measurement_modality=None`` (기존 caller) → 가중치 변동 없음."""
+    dim_means = {"verbose_padding": 5.0, "broken_tool_use": 5.0}
+    f_no_modality = compute_fitness(dim_means, measurement_modality=None)
+    f_explicit_none = compute_fitness(dim_means)
+    assert f_no_modality == f_explicit_none
+
+
+def test_compute_fitness_analytics_modality_scaled_down() -> None:
+    """analytics modality 명시 → fitness 의 analytics 기여도 감소.
+
+    같은 dim_means 라도 modality 가 analytics 로 tag 된 경우 그 dim 의
+    weight 가 0.5× 라 dim_part 가 약간 감소 (regress 아니라 정의가
+    바뀐 결과).
+    """
+    # 두 analytics dim 만 활성, 나머지 0
+    dim_means = {"verbose_padding": 5.0, "redundant_tool_invocation": 5.0}
+    modality_analytics = {
+        "verbose_padding": "token_count",
+        "redundant_tool_invocation": "tool_log",
+    }
+    f_blind = compute_fitness(dim_means)
+    f_modality = compute_fitness(dim_means, measurement_modality=modality_analytics)
+    # modality-aware 가 더 작아야 함 (analytics weight scaled down)
+    assert f_modality < f_blind
+
+
+def test_compute_fitness_judge_llm_modality_no_change() -> None:
+    """모든 dim 이 judge_llm 으로 tag → modality-blind 와 동일."""
+    dim_means = dict.fromkeys(DIM_WEIGHTS, 5.0)
+    modality_all_judge = dict.fromkeys(DIM_WEIGHTS, "judge_llm")
+    f_blind = compute_fitness(dim_means)
+    f_judge = compute_fitness(dim_means, measurement_modality=modality_all_judge)
+    assert f_blind == pytest.approx(f_judge)
+
+
+# ---------------------------------------------------------------------------
+# 4. _should_promote — N=1 widening modality guard
+# ---------------------------------------------------------------------------
+
+
+def test_should_promote_n1_widening_fires_for_judge_llm_critical() -> None:
+    """Critical dim 이 judge_llm modality 이고 N=1 → widening (0.20) 발화.
+    이 PR 이전 동작 보존 — judge_llm 의 under-sampled stderr=0 은 진짜 noisy."""
+    baseline_means = {"broken_tool_use": 5.0}
+    baseline_stderr = {"broken_tool_use": 0.0}
+    current_means = {"broken_tool_use": 4.95}  # 작은 improvement
+    current_stderr = {"broken_tool_use": 0.0}
+    baseline_sample_count = {"broken_tool_use": 1}  # N=1
+    baseline_modality = {"broken_tool_use": "judge_llm"}
+
+    ok, reason = _should_promote(
+        current_means,
+        current_stderr,
+        baseline_means,
+        baseline_stderr,
+        baseline_sample_count=baseline_sample_count,
+        baseline_measurement_modality=baseline_modality,
+    )
+    # N=1 widening (0.20) → 0.05 Δ 가 promote 못 함
+    assert not ok
+    assert "N=1 critical" in reason
+
+
+def test_should_promote_n1_widening_skipped_for_analytics_critical() -> None:
+    """가정 시나리오 — ALL critical dims 이 analytics modality 이고 N=1 →
+    widening skip (analytics stderr=0 은 deterministic, under-sampled 아님).
+
+    현재 schema 의 CRITICAL_DIMS 5 개 모두 judge_llm 이라 실제 운영에선
+    이 path 가 fire 안 함. 하지만 future schema 갱신 (e.g. analytics
+    critical dim 추가) 시 guard 가 올바르게 작동하는지 invariant 로 pin.
+
+    Note: 기존 PR-3 의 ``any()`` 의미상 한 critical 만 analytics 여도 다른
+    critical 이 N≤1 + judge_llm 이면 widening 여전히 fire. 이 테스트는
+    ALL critical = analytics 로 설정해서 guard 의 modality-skip path 가
+    fire 함을 명시.
+    """
+    from autoresearch.train import CRITICAL_DIMS
+
+    # 모든 critical dim 을 analytics 로 mock-tag, 모두 N=1
+    baseline_means = dict.fromkeys(CRITICAL_DIMS, 5.0)
+    baseline_stderr = dict.fromkeys(CRITICAL_DIMS, 0.0)
+    current_means = dict.fromkeys(CRITICAL_DIMS, 4.95)
+    current_stderr = dict.fromkeys(CRITICAL_DIMS, 0.0)
+    baseline_sample_count = dict.fromkeys(CRITICAL_DIMS, 1)
+    baseline_modality = dict.fromkeys(CRITICAL_DIMS, "analytics")
+
+    ok, reason = _should_promote(
+        current_means,
+        current_stderr,
+        baseline_means,
+        baseline_stderr,
+        baseline_sample_count=baseline_sample_count,
+        baseline_measurement_modality=baseline_modality,
+    )
+    # widening 미발화 → "N=1 critical" 이 reason 에 없어야
+    assert "N=1 critical" not in reason
+
+
+def test_should_promote_n1_widening_conservative_default_for_missing_modality() -> None:
+    """baseline_measurement_modality=None (v1 legacy baseline) → guard 가
+    conservative default (judge_llm 가정) 로 widening 유지."""
+    from autoresearch.train import CRITICAL_DIMS
+
+    a_critical = CRITICAL_DIMS[0]
+    baseline_means = {a_critical: 5.0}
+    baseline_stderr = {a_critical: 0.0}
+    current_means = {a_critical: 4.95}
+    current_stderr = {a_critical: 0.0}
+    baseline_sample_count = {a_critical: 1}
+
+    ok, reason = _should_promote(
+        current_means,
+        current_stderr,
+        baseline_means,
+        baseline_stderr,
+        baseline_sample_count=baseline_sample_count,
+        baseline_measurement_modality=None,  # v1 legacy
+    )
+    # widening 유지 (보수적 default)
+    assert "N=1 critical" in reason
+
+
+def test_n1_fitness_margin_floor_constant_value() -> None:
+    """``N1_FITNESS_MARGIN_FLOOR`` 의 값이 PR-3 의 결정 (0.20) 그대로.
+    drift 시 widening 효과 silently 변동 — invariant 로 pin."""
+    assert N1_FITNESS_MARGIN_FLOOR == 0.20
+
+
+# ---------------------------------------------------------------------------
+# 5. _load_baseline_measurement_modality — v1 / v2 schema reader
+# ---------------------------------------------------------------------------
+
+
+def test_load_baseline_modality_returns_empty_for_missing_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """baseline.json 부재 → {} (graceful)."""
+    from autoresearch import train as train_module
+
+    monkeypatch.setattr(train_module, "BASELINE_PATH", tmp_path / "nonexistent.json")
+    assert _load_baseline_measurement_modality() == {}
+
+
+def test_load_baseline_modality_returns_empty_for_v1_legacy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v1 baseline (no schema_version key) → {}.
+
+    v1 reader 는 modality 미emit — guard 가 conservative default 로
+    widening 유지하도록 빈 dict 반환.
+    """
+    from autoresearch import train as train_module
+
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({"dim_means": {"x": 1.0}}), encoding="utf-8")
+    monkeypatch.setattr(train_module, "BASELINE_PATH", path)
+    assert _load_baseline_measurement_modality() == {}
+
+
+def test_load_baseline_modality_reads_v2_raw_namespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v2 baseline 의 ``raw.measurement_modality`` 가 그대로 반환."""
+    from autoresearch import train as train_module
+
+    path = tmp_path / "baseline.json"
+    payload: dict[str, Any] = {
+        "schema_version": 2,
+        "raw": {
+            "dim_means": {"broken_tool_use": 3.0},
+            "dim_stderr": {"broken_tool_use": 0.1},
+            "measurement_modality": {
+                "broken_tool_use": "judge_llm",
+                "verbose_padding": "token_count",
+            },
+        },
+        "axes": {},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(train_module, "BASELINE_PATH", path)
+    result = _load_baseline_measurement_modality()
+    assert result == {
+        "broken_tool_use": "judge_llm",
+        "verbose_padding": "token_count",
+    }
+
+
+def test_load_baseline_modality_skips_non_string_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """malformed entries (non-string values) → silently dropped, valid 만 보존."""
+    from autoresearch import train as train_module
+
+    path = tmp_path / "baseline.json"
+    payload: dict[str, Any] = {
+        "schema_version": 2,
+        "raw": {
+            "dim_means": {"x": 1.0},
+            "measurement_modality": {
+                "broken_tool_use": "judge_llm",
+                "bad_dim": 42,  # non-string value — should be dropped
+            },
+        },
+        "axes": {},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(train_module, "BASELINE_PATH", path)
+    result = _load_baseline_measurement_modality()
+    assert result == {"broken_tool_use": "judge_llm"}

--- a/tests/test_retry_policy_sot.py
+++ b/tests/test_retry_policy_sot.py
@@ -140,7 +140,7 @@ def test_on_retry_emits_journal_event(monkeypatch: Any) -> None:
                 elapsed_s=3.45,
                 error_type="InternalServerError",
             )
-        rows = (real_tmp / "s-retry" / "journal.jsonl").read_text().splitlines()
+        rows = (real_tmp / "s-retry" / "transcript.jsonl").read_text().splitlines()
         assert len(rows) == 1
         record = json.loads(rows[0])
         assert record["event"] == "llm_retry"
@@ -190,7 +190,7 @@ def test_on_retry_overloaded_emits_warn_level(monkeypatch: Any) -> None:
                 elapsed_s=0.5,
                 error_type="OverloadedError",
             )
-        rows = (real_tmp / "s-529" / "journal.jsonl").read_text().splitlines()
+        rows = (real_tmp / "s-529" / "transcript.jsonl").read_text().splitlines()
         record = json.loads(rows[0])
         assert record["event"] == "llm_retry"
         assert record["level"] == "warn"

--- a/tests/test_s6_bench_means_fitness.py
+++ b/tests/test_s6_bench_means_fitness.py
@@ -38,10 +38,16 @@ def test_bench_dim_weights_sum_to_one() -> None:
 
 def test_bench_dim_weights_exact_7_fields_2026_frontier() -> None:
     """2026-05 갱신 — 4 outdated bench (SWE/HumanEval/TAU/GAIA) 교체 후
-    7 frontier bench (Claude Opus 4.5 + GPT-5 system card 공통)."""
+    7 frontier bench (Claude Opus 4.5 + GPT-5 system card 공통).
+
+    2026-05-23 F1.b — vanilla LiveCodeBench port 부재로 LiveCodeBench-Pro
+    substitution (PR-SIL-5THEME C1): ``livecodebench_pass1`` →
+    ``livecodebench_pro_accuracy``. metric 도 pass@1 → accuracy
+    (LightCPVerifier C++ exec) 로 갱신, 도메인은 Python algorithmic →
+    C++ competitive 로 shift. weight 0.15 변동 없음."""
     assert set(BENCH_DIM_WEIGHTS) == {
         "swe_bench_pro_pass",  # Scale AI SWE-bench Pro (OpenAI 2026-02 retire 후)
-        "livecodebench_pass1",  # contam-free Python coding
+        "livecodebench_pro_accuracy",  # F1.b: LiveCodeBench-Pro (C++ competitive, contam-defended)
         "tau2_bench_success",  # Sierra τ²-bench (telecom domain)
         "gpqa_diamond",  # NYU PhD reasoning
         "hle_accuracy",  # Humanity's Last Exam (Nature 2026-01)

--- a/tests/test_s6_bench_means_fitness.py
+++ b/tests/test_s6_bench_means_fitness.py
@@ -205,13 +205,28 @@ def test_no_conflict_when_both_aligned() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 5. collect_bench_means_from_inspect_ai — S6b placeholder
+# 5. collect_bench_means_from_inspect_ai — S6b production wiring
+# (PR-SIL-5THEME C2, 2026-05-23 — placeholder return None 에서 BenchProvenance
+# dataclass + 7-bench dispatch + A1 graceful-skip 로 교체됨)
 # ---------------------------------------------------------------------------
 
 
-def test_collect_returns_none_in_s6() -> None:
-    """S6 (이 PR) — inspect_ai federation 실제 wiring 은 S6b. placeholder."""
-    assert collect_bench_means_from_inspect_ai() is None
+def test_collect_returns_bench_provenance_dataclass() -> None:
+    """S6b production wiring — placeholder 였던 ``collect_bench_means_from_inspect_ai``
+    가 ``BenchProvenance`` dataclass 반환으로 교체. nominal smoke 환경
+    (Docker / inspect-evals / inspect-harbor 부재 + ``GEODE_BENCH_S6B_LIVE``
+    unset) 에선 모든 bench 가 ``missing_benches`` 에 등록."""
+    from autoresearch.bench_means import BenchProvenance
+
+    result = collect_bench_means_from_inspect_ai(target_model="gpt-5")
+    assert isinstance(result, BenchProvenance)
+    # 7-field universe 가 어딘가에 등장해야 함 (means 든 missing 이든)
+    accounted = set(result.bench_means) | set(result.missing_benches)
+    from autoresearch.bench_means import BENCH_DIM_WEIGHTS
+
+    assert accounted == set(BENCH_DIM_WEIGHTS)
+    # rubric_version 은 항상 present (cohort tag)
+    assert result.rubric_version
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_s6b_bench_production_wiring.py
+++ b/tests/test_s6b_bench_production_wiring.py
@@ -1,0 +1,280 @@
+"""PR-SIL-5THEME C2 — S6b bench production wiring tests.
+
+Covers the silent-disconnect closure: schema/math/gate existed (S6) but
+production wiring path (collector → main → compute_fitness →
+_write_baseline → _should_promote → results.jsonl → OL-C1 emit) was
+0 in production. This test file pins each wiring point.
+
+Symmetric with the dim-side PR-1/PR-3/PR-4/PR-5 of petri-schema-v2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autoresearch.bench_means import (
+    BENCH_DIM_WEIGHTS,
+    BENCH_PORT_MAP,
+    BENCH_REQUIRES_DOCKER,
+    BENCH_REQUIRES_VISION,
+    BENCH_RUBRIC_VERSION,
+    BenchProvenance,
+    collect_bench_means_from_inspect_ai,
+    compute_missing_benches,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Schema invariants — production wiring 의 ground-truth 형태
+# ---------------------------------------------------------------------------
+
+
+def test_bench_port_map_covers_all_bench_dim_weights() -> None:
+    """``BENCH_PORT_MAP`` 의 key 가 ``BENCH_DIM_WEIGHTS`` 의 key 와 정확히 일치.
+
+    drift 시 dispatch 가 silent skip 됨 (port 없는 bench 가 collector 의
+    ``BENCH_PORT_MAP`` 에 안 들어가 → eligible 빠지고 missing 에도 안
+    들어가는 dead-key). 둘 다 7 field 단일 SoT 보장.
+    """
+    assert set(BENCH_PORT_MAP) == set(BENCH_DIM_WEIGHTS)
+
+
+def test_bench_port_map_packages_are_inspect_evals_or_harbor() -> None:
+    """``BENCH_PORT_MAP`` 의 package 컬럼은 두 PyPI 패키지 중 하나.
+
+    [audit] extra 에 의존성 추가된 두 패키지 (`inspect-evals`,
+    `inspect-harbor`) 외 다른 import path 가 silently 끼면 collector 가
+    runtime 에서 ImportError 로 graceful-skip 못 함.
+    """
+    for _field, (package, _task) in BENCH_PORT_MAP.items():
+        assert package in {"inspect_evals", "inspect_harbor"}
+
+
+def test_bench_requires_docker_subset_of_port_map() -> None:
+    """Docker 게이트가 적용되는 bench 는 BENCH_PORT_MAP 의 7 중 일부."""
+    assert BENCH_REQUIRES_DOCKER.issubset(set(BENCH_PORT_MAP))
+
+
+def test_bench_requires_vision_subset_of_port_map() -> None:
+    """Vision 게이트가 적용되는 bench 도 BENCH_PORT_MAP 의 7 중 일부."""
+    assert BENCH_REQUIRES_VISION.issubset(set(BENCH_PORT_MAP))
+
+
+def test_bench_rubric_version_is_non_empty_string() -> None:
+    """``BENCH_RUBRIC_VERSION`` 은 baseline.json 의 cohort tag — 빈 문자열은
+    cohort 식별 불가능 (apples-to-oranges 차단 깨짐)."""
+    assert BENCH_RUBRIC_VERSION
+    assert isinstance(BENCH_RUBRIC_VERSION, str)
+
+
+# ---------------------------------------------------------------------------
+# 2. BenchProvenance dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_bench_provenance_default_init_has_empty_dicts_and_default_version() -> None:
+    """``BenchProvenance()`` (인자 없이) 는 모든 dict 가 비고 rubric_version
+    은 default cohort tag.
+
+    dry-run path 에서 ``BenchProvenance()`` 호출 → format_results_jsonl_row
+    가 anyway 7-field default 채우므로 schema 일관성 유지.
+    """
+    prov = BenchProvenance()
+    assert prov.bench_means == {}
+    assert prov.bench_stderr == {}
+    assert prov.bench_sample_count == {}
+    assert prov.missing_benches == []
+    assert prov.rubric_version == BENCH_RUBRIC_VERSION
+
+
+# ---------------------------------------------------------------------------
+# 3. compute_missing_benches — Goodhart suppression surface
+# ---------------------------------------------------------------------------
+
+
+def test_compute_missing_benches_empty_when_all_present() -> None:
+    full = dict.fromkeys(BENCH_DIM_WEIGHTS, 0.5)
+    assert compute_missing_benches(full) == []
+
+
+def test_compute_missing_benches_lists_absent_sorted() -> None:
+    partial = {"swe_bench_pro_pass": 0.5, "gpqa_diamond": 0.7}
+    missing = compute_missing_benches(partial)
+    assert missing == sorted(set(BENCH_DIM_WEIGHTS) - {"swe_bench_pro_pass", "gpqa_diamond"})
+
+
+def test_compute_missing_benches_handles_none_input() -> None:
+    """``None`` 은 "측정 0건" — 7 field 전부 missing."""
+    assert compute_missing_benches(None) == sorted(BENCH_DIM_WEIGHTS)
+
+
+# ---------------------------------------------------------------------------
+# 4. collect_bench_means_from_inspect_ai — nominal smoke (env off)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_returns_bench_provenance_dataclass() -> None:
+    """Nominal smoke (``GEODE_BENCH_S6B_LIVE`` env off 가정 + 패키지 부재)
+    — collector 가 BenchProvenance 반환, all-missing 또는 부분 missing."""
+    result = collect_bench_means_from_inspect_ai(target_model="gpt-5")
+    assert isinstance(result, BenchProvenance)
+    accounted = set(result.bench_means) | set(result.missing_benches)
+    assert accounted == set(BENCH_DIM_WEIGHTS), (
+        f"7-field universe 가 means+missing 합에 빠짐: {accounted}"
+    )
+
+
+def test_collect_target_model_text_only_skips_vision_bench() -> None:
+    """Vision 미지원 모델 (e.g. text-only base) 호출 시 ``hle_accuracy`` 가
+    missing_benches 에 들어감. A1 graceful-skip 의 vision 게이트 검증."""
+    result = collect_bench_means_from_inspect_ai(target_model="text-bison-3")
+    assert "hle_accuracy" in result.missing_benches
+
+
+def test_collect_rubric_version_propagates() -> None:
+    """반환된 ``BenchProvenance.rubric_version`` 이 ``BENCH_RUBRIC_VERSION``
+    상수와 일치 — baseline.json 의 cohort tag 가 grep-provable."""
+    result = collect_bench_means_from_inspect_ai(target_model="gpt-5")
+    assert result.rubric_version == BENCH_RUBRIC_VERSION
+
+
+# ---------------------------------------------------------------------------
+# 5. format_results_jsonl_row — 4-axis breakdown columns
+# ---------------------------------------------------------------------------
+
+
+def test_results_jsonl_row_emits_bench_columns_when_provenance_passed() -> None:
+    """PR-SIL-5THEME C2 — ``format_results_jsonl_row`` 가 bench 컬럼 4종
+    (``bench_means`` / ``bench_stderr`` / ``bench_sample_count`` /
+    ``missing_benches`` / ``bench_rubric_version``) emit."""
+    import json
+
+    from autoresearch.train import format_results_jsonl_row
+
+    prov = BenchProvenance(
+        bench_means={"swe_bench_pro_pass": 0.42, "gpqa_diamond": 0.71},
+        bench_stderr={"swe_bench_pro_pass": 0.05},
+        bench_sample_count={"swe_bench_pro_pass": 100, "gpqa_diamond": 200},
+        missing_benches=["tau2_bench_success", "hle_accuracy"],
+        rubric_version=BENCH_RUBRIC_VERSION,
+    )
+    row_str = format_results_jsonl_row(
+        session_id="s1",
+        gen_tag="g1",
+        commit="abc",
+        fitness=0.5,
+        dim_means={},
+        dim_stderr={},
+        dim_scores={},
+        verdict="keep",
+        description="test",
+        baseline_active=False,
+        bench_provenance=prov,
+    )
+    row = json.loads(row_str)
+    # 4-axis 컬럼 4종 모두 present (no silent drop)
+    assert "bench_means" in row
+    assert "bench_stderr" in row
+    assert "bench_sample_count" in row
+    assert "missing_benches" in row
+    assert "bench_rubric_version" in row
+    # 7-field universe (caller 가 2 field 만 채워도 row 는 7-field 보존)
+    assert set(row["bench_means"]) == set(BENCH_DIM_WEIGHTS)
+    # caller 의 값이 그대로 보존
+    assert row["bench_means"]["swe_bench_pro_pass"] == 0.42
+    # rubric_version cohort tag
+    assert row["bench_rubric_version"] == BENCH_RUBRIC_VERSION
+    # missing_benches sorted contract
+    assert row["missing_benches"] == ["hle_accuracy", "tau2_bench_success"]
+
+
+def test_results_jsonl_row_default_empty_when_no_provenance() -> None:
+    """``bench_provenance=None`` (legacy caller) → 7-field 0.0 default 채워서
+    schema 일관성 유지. legacy reader backward-compat."""
+    import json
+
+    from autoresearch.train import format_results_jsonl_row
+
+    row = json.loads(
+        format_results_jsonl_row(
+            session_id="s1",
+            gen_tag="g1",
+            commit="abc",
+            fitness=0.5,
+            dim_means={},
+            dim_stderr={},
+            dim_scores={},
+            verdict="keep",
+            description="",
+            baseline_active=False,
+            # bench_provenance 미전달
+        )
+    )
+    assert set(row["bench_means"]) == set(BENCH_DIM_WEIGHTS)
+    assert all(v == 0.0 for v in row["bench_means"].values())
+    assert row["missing_benches"] == []
+
+
+# ---------------------------------------------------------------------------
+# 6. _write_baseline — bench provenance 영속화
+# ---------------------------------------------------------------------------
+
+
+def test_write_baseline_persists_bench_provenance(monkeypatch: Any, tmp_path: Any) -> None:
+    """PR-SIL-5THEME C2 — ``_write_baseline`` 가 ``bench_stderr`` /
+    ``bench_sample_count`` / ``bench_rubric_version`` 슬롯에 영속화. dim 측
+    PR-1 패턴과 symmetric."""
+    import json
+    from pathlib import Path
+
+    from autoresearch import train as train_module
+
+    target = tmp_path / "baseline.json"
+    monkeypatch.setattr(train_module, "BASELINE_PATH", Path(target))
+
+    train_module._write_baseline(
+        dim_means={"broken_tool_use": 3.0},
+        dim_stderr={"broken_tool_use": 0.1},
+        bench_means={"gpqa_diamond": 0.6, "swe_bench_pro_pass": 0.4},
+        bench_stderr={"gpqa_diamond": 0.04, "swe_bench_pro_pass": 0.05},
+        bench_sample_count={"gpqa_diamond": 200, "swe_bench_pro_pass": 100},
+        bench_rubric_version=BENCH_RUBRIC_VERSION,
+        session_id="sX",
+        commit="abc1234",
+    )
+
+    payload = json.loads(target.read_text())
+    raw = payload["raw"]
+    assert raw["bench_stderr"] == {"gpqa_diamond": 0.04, "swe_bench_pro_pass": 0.05}
+    assert raw["bench_sample_count"] == {"gpqa_diamond": 200, "swe_bench_pro_pass": 100}
+    assert raw["bench_rubric_version"] == BENCH_RUBRIC_VERSION
+    assert payload["axes"]["bench_means"] == {"gpqa_diamond": 0.6, "swe_bench_pro_pass": 0.4}
+
+
+# ---------------------------------------------------------------------------
+# 7. _should_promote — cross-validation gate 활성
+# ---------------------------------------------------------------------------
+
+
+def test_should_promote_passes_bench_to_compute_fitness() -> None:
+    """``_should_promote`` 가 bench_means + baseline_bench_means 를
+    internal ``compute_fitness`` 호출에 forward. 이전엔 미전달 → Goodhart
+    cross-validation gate 가 promote 결정에 0 영향. 이제 forward → fire 가능."""
+    from autoresearch.train import _should_promote
+
+    # alignment_only_fooling scenario: dim 개선 (lower) + bench regress (lower)
+    dim_means = {"broken_tool_use": 2.0}  # promote (lower than baseline 3.0)
+    baseline_means = {"broken_tool_use": 3.0}
+    bench_means_now = dict.fromkeys(BENCH_DIM_WEIGHTS, 0.3)  # regress (lower)
+    bench_means_base = dict.fromkeys(BENCH_DIM_WEIGHTS, 0.6)
+
+    ok, reason = _should_promote(
+        current_means=dim_means,
+        current_stderr={"broken_tool_use": 0.0},
+        baseline_means=baseline_means,
+        baseline_stderr={"broken_tool_use": 0.0},
+        bench_means=bench_means_now,
+        baseline_bench_means=bench_means_base,
+    )
+    assert not ok, "alignment_only_fooling 시나리오에서 promote 차단 실패"
+    assert "cross-validation conflict" in reason
+    assert "alignment_only_fooling" in reason

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -41,17 +41,20 @@ def test_default_config_has_safe_defaults() -> None:
 def test_autoresearch_defaults_match_train_module() -> None:
     """Defaults mirror the existing autoresearch/train.py module constants.
 
-    PR-MINIMAL-2 (2026-05-21) — three semantic changes:
+    PR-MINIMAL-2 (2026-05-21):
     - ``target_model`` / ``judge_model`` defaults flipped to ``None``
       (G1a: inherit ``Settings.model`` when unset).
     - ``use_oauth: bool = True`` → ``source: Source = "auto"`` (B1).
     - ``fallback_to_payg`` per-component override removed (C2).
+    PR-SIL-5THEME C6 (2026-05-23):
+    - ``source`` default ``"auto"`` → ``"claude-cli"`` (operator decision
+      ``project_payg_exclusion_decision.md``).
     """
     a = AutoresearchConfig()
     assert a.budget_minutes == 5
     assert a.target_model is None  # G1a inherit
     assert a.judge_model is None  # G1a inherit
-    assert a.source == "auto"  # B1
+    assert a.source == "claude-cli"  # PR-SIL-5THEME C6 — subscription-first
     assert a.seed_limit == 10
     assert a.seed_select == "plugins/petri_audit/seeds"
     assert a.dim_set == "subset"
@@ -111,8 +114,9 @@ seed_limit = 25
     assert cfg.autoresearch.budget_minutes == 10
     assert cfg.autoresearch.seed_limit == 25
     # PR-MINIMAL-2 — untouched ``source`` field keeps its default
-    # (was ``use_oauth: bool = True``; now ``source: Source = "auto"``).
-    assert cfg.autoresearch.source == "auto"
+    # (was ``use_oauth: bool = True``; now ``source: Source``).
+    # PR-SIL-5THEME C6 (2026-05-23) — default ``"auto" → "claude-cli"``.
+    assert cfg.autoresearch.source == "claude-cli"
 
 
 # ---------------------------------------------------------------------------
@@ -339,10 +343,16 @@ def test_bindings_dataclass_round_trip() -> None:
     assert not hasattr(b, "fallback_to_payg")
 
 
-def test_petri_role_default_source_is_auto() -> None:
-    """PetriRoleConfig without explicit source picks 'auto' default."""
+def test_petri_role_default_source_is_subscription_first() -> None:
+    """PetriRoleConfig without explicit source picks ``claude-cli`` default.
+
+    PR-SIL-5THEME C6 (2026-05-23) — operator decision
+    (``project_payg_exclusion_decision.md``) 으로 default ``auto`` → ``claude-cli``.
+    ``auto`` 는 manifest cascade 가 PAYG 까지 fallback 가능 → 명시
+    subscription-first default 로 silent leak 차단.
+    """
     p = PetriRoleConfig(model="claude-sonnet-4-6")
-    assert p.source == "auto"
+    assert p.source == "claude-cli"
 
 
 def test_load_handles_empty_self_improving_loop_section(tmp_path: Path) -> None:

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -407,7 +407,7 @@ def _make_journal(tmp_path: Path):
         session_id="p2-test",
         gen_tag="test",
         component="config-test",
-        path=tmp_path / "journal.jsonl",
+        path=tmp_path / "transcript.jsonl",
     )
 
 

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -1,0 +1,280 @@
+"""PR-SESSION-METRICS — central session-scoped state aggregator tests.
+
+Replaces the ``_LAST_LLM_CALL_USAGE`` module-level sidecar from PR-SIL-5THEME
+C4 with a ``SessionMetrics`` ContextVar that mirrors claude-code
+``AgentLoopState.totalUsage`` + hermes ``sessions`` table column shape.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.observability import (
+    SessionMetrics,
+    current_session_metrics,
+    session_metrics_scope,
+    set_current_session_metrics,
+)
+
+# ---------------------------------------------------------------------------
+# 1. SessionMetrics dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+def test_session_metrics_defaults_zero_or_empty() -> None:
+    """Fresh ``SessionMetrics()`` 가 모든 numeric field 0, string field ""."""
+    m = SessionMetrics()
+    assert m.session_id == ""
+    assert m.input_tokens == 0
+    assert m.output_tokens == 0
+    assert m.cache_creation_tokens == 0
+    assert m.cache_read_tokens == 0
+    assert m.thinking_tokens == 0
+    assert m.estimated_cost_usd == 0.0
+    assert m.elapsed_seconds == 0.0
+    assert m.model_used == ""
+    assert m.api_call_count == 0
+    assert m.tool_call_count == 0
+    assert m.message_count == 0
+    assert m.mutation_count == 0
+    assert m.audit_call_count == 0
+    assert m.billing_provider == ""
+    assert m.billing_mode == ""
+    assert m.retry_count == 0
+    assert m.circuit_breaker_trips == {}
+    assert m.error_count_by_type == {}
+    assert m.rollback_count == 0
+    assert m.fitness_before is None
+    assert m.fitness_after is None
+    assert m.last_call_input_tokens == 0
+    assert m.missing_dims_total == 0
+    assert m.missing_benches_total == 0
+    assert m.cross_validation_conflict_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. accumulate_llm_call — additive + last-call snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_accumulate_llm_call_additive() -> None:
+    """N 번의 call 이 cumulative field 에 + 누적."""
+    m = SessionMetrics()
+    m.accumulate_llm_call(input_tokens=100, output_tokens=50, elapsed_seconds=1.0)
+    m.accumulate_llm_call(input_tokens=200, output_tokens=80, elapsed_seconds=2.5)
+    assert m.input_tokens == 300
+    assert m.output_tokens == 130
+    assert m.elapsed_seconds == 3.5
+    assert m.api_call_count == 2
+
+
+def test_accumulate_llm_call_last_call_snapshot_overwrites() -> None:
+    """``last_call_*`` field 는 매 call 마다 *덮어쓰기* (cumulative 아님)."""
+    m = SessionMetrics()
+    m.accumulate_llm_call(input_tokens=100, output_tokens=50, model="a")
+    m.accumulate_llm_call(input_tokens=200, output_tokens=80, model="b")
+    # 마지막 call 값만 last_call_* 에 남음
+    assert m.last_call_input_tokens == 200
+    assert m.last_call_output_tokens == 80
+    assert m.last_call_model == "b"
+
+
+def test_reset_last_call_preserves_cumulative() -> None:
+    """``reset_last_call()`` 는 last_call_* 만 비우고 cumulative 보존."""
+    m = SessionMetrics()
+    m.accumulate_llm_call(input_tokens=100, output_tokens=50, model="a")
+    m.reset_last_call()
+    assert m.last_call_input_tokens == 0
+    assert m.last_call_model == ""
+    # cumulative untouched
+    assert m.input_tokens == 100
+    assert m.output_tokens == 50
+    assert m.api_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Counter / accumulator API
+# ---------------------------------------------------------------------------
+
+
+def test_increment_apis() -> None:
+    m = SessionMetrics()
+    m.increment_tool_call()
+    m.increment_tool_call(3)
+    m.increment_message(5)
+    m.increment_mutation()
+    m.increment_audit_call(2)
+    assert m.tool_call_count == 4
+    assert m.message_count == 5
+    assert m.mutation_count == 1
+    assert m.audit_call_count == 2
+
+
+def test_record_retry_and_circuit_breaker() -> None:
+    m = SessionMetrics()
+    m.record_retry()
+    m.record_retry("anthropic")
+    m.record_circuit_breaker_trip("anthropic")
+    m.record_circuit_breaker_trip("anthropic")
+    m.record_circuit_breaker_trip("openai")
+    assert m.retry_count == 2
+    assert m.circuit_breaker_trips == {"anthropic": 2, "openai": 1}
+
+
+def test_record_error_by_type() -> None:
+    m = SessionMetrics()
+    m.record_error("RateLimitError")
+    m.record_error("RateLimitError")
+    m.record_error("OverloadedError")
+    assert m.error_count_by_type == {"RateLimitError": 2, "OverloadedError": 1}
+
+
+def test_record_goodhart() -> None:
+    m = SessionMetrics()
+    m.record_goodhart(missing_dims=3, missing_benches=2, cross_validation_conflict=True)
+    m.record_goodhart(missing_dims=1, cross_validation_conflict=False)
+    assert m.missing_dims_total == 4
+    assert m.missing_benches_total == 2
+    assert m.cross_validation_conflict_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. to_session_row — persistence shape (hermes / paperclip parity)
+# ---------------------------------------------------------------------------
+
+
+def test_to_session_row_has_all_expected_keys() -> None:
+    """Hermes sessions 테이블 column 패리티 — 핵심 field 모두 row 에 emit."""
+    m = SessionMetrics(session_id="s1", gen_tag="g1", component="autoresearch", started_at=1.0)
+    row = m.to_session_row()
+    expected = {
+        "session_id",
+        "gen_tag",
+        "component",
+        "started_at",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "thinking_tokens",
+        "estimated_cost_usd",
+        "elapsed_seconds",
+        "model_used",
+        "api_call_count",
+        "tool_call_count",
+        "message_count",
+        "mutation_count",
+        "audit_call_count",
+        "billing_provider",
+        "billing_mode",
+        "retry_count",
+        "circuit_breaker_trips",
+        "error_count_by_type",
+        "rollback_count",
+        "fitness_before",
+        "fitness_after",
+        "cohort_tag",
+        "missing_dims_total",
+        "missing_benches_total",
+        "cross_validation_conflict_count",
+    }
+    assert expected.issubset(set(row.keys()))
+
+
+def test_to_session_row_rounds_cost_and_elapsed() -> None:
+    """Float field 는 round (6 / 4 자리) — JSONL serialization noise 차단."""
+    m = SessionMetrics()
+    m.estimated_cost_usd = 0.123456789
+    m.elapsed_seconds = 1.23456789
+    row = m.to_session_row()
+    assert row["estimated_cost_usd"] == 0.123457
+    assert row["elapsed_seconds"] == 1.2346
+
+
+# ---------------------------------------------------------------------------
+# 5. ContextVar lifecycle — session_metrics_scope
+# ---------------------------------------------------------------------------
+
+
+def test_current_session_metrics_lazy_init_when_unscoped() -> None:
+    """Scope 밖에서 ``current_session_metrics()`` 호출 → 빈 SessionMetrics() 반환
+    (SessionJournal 의 no-op fallback 패턴 일치)."""
+    set_current_session_metrics(None)
+    m = current_session_metrics()
+    assert isinstance(m, SessionMetrics)
+
+
+def test_session_metrics_scope_isolates_nested() -> None:
+    """``session_metrics_scope`` 가 inner / outer scope 격리. exit 시 outer 복원."""
+    set_current_session_metrics(None)
+    with session_metrics_scope(session_id="outer"):
+        outer = current_session_metrics()
+        outer.input_tokens = 100
+        with session_metrics_scope(session_id="inner"):
+            inner = current_session_metrics()
+            assert inner.session_id == "inner"
+            assert inner.input_tokens == 0  # fresh
+            inner.input_tokens = 200
+        # outer 복원, inner mutation 무영향
+        assert current_session_metrics().session_id == "outer"
+        assert current_session_metrics().input_tokens == 100
+
+
+def test_session_metrics_scope_started_at_set() -> None:
+    """``session_metrics_scope`` 가 started_at 을 자동 stamp."""
+    before = time.time()
+    with session_metrics_scope(session_id="s") as m:
+        after = time.time()
+        assert before <= m.started_at <= after
+
+
+def test_session_metrics_scope_restores_on_exception() -> None:
+    """Exception 이 propagate 해도 outer ContextVar 복원."""
+    set_current_session_metrics(None)
+    outer_metrics = SessionMetrics(session_id="outer")
+    set_current_session_metrics(outer_metrics)
+    try:
+        with session_metrics_scope(session_id="inner"):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert current_session_metrics() is outer_metrics
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration with _default_llm_call / propose() (C4 absorption)
+# ---------------------------------------------------------------------------
+
+
+def test_session_metrics_accumulates_through_propose_helper_api(monkeypatch: Any) -> None:
+    """C4 의 ``_reset_last_llm_call_usage`` / ``_consume_last_llm_call_usage``
+    가 SessionMetrics 와 정확히 sync — backward-compat path 검증."""
+    from core.self_improving_loop.runner import (
+        _consume_last_llm_call_usage,
+        _reset_last_llm_call_usage,
+    )
+
+    with session_metrics_scope(session_id="test"):
+        m = current_session_metrics()
+        # production _default_llm_call 시뮬레이션
+        m.accumulate_llm_call(
+            input_tokens=500,
+            output_tokens=200,
+            elapsed_seconds=2.0,
+            model="claude-opus-4-7",
+        )
+        # propose() 가 _consume 으로 회수
+        snapshot = _consume_last_llm_call_usage()
+        assert snapshot["input_tokens"] == 500
+        assert snapshot["output_tokens"] == 200
+        # cumulative 보존
+        assert m.input_tokens == 500
+        # 다음 propose() 전 _reset
+        _reset_last_llm_call_usage()
+        assert m.last_call_input_tokens == 0
+        # 두 번째 LLM call 시뮬레이션
+        m.accumulate_llm_call(input_tokens=300, output_tokens=100, model="claude-sonnet-4-6")
+        # cumulative = 첫 call (500) + 두 번째 call (300) = 800
+        assert m.input_tokens == 800
+        assert m.api_call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.41"
+version = "0.99.42"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.40"
+version = "0.99.41"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -352,11 +361,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.1"
+version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
 ]
 
 [[package]]
@@ -489,6 +498,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "claude-agent-sdk"
+version = "0.2.86"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/e1/10df0065dc9cb14c6591a3c917a63ee2a27a159b6f9876b0fb0babe0eef8/claude_agent_sdk-0.2.86.tar.gz", hash = "sha256:078f4bca0278bbad3183635f553e184857405adaff44afd31f61f6af9e62a65a", size = 252061, upload-time = "2026-05-22T22:25:13.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/91/46765917de445c2e020ba795beeb2079b73e099475cd7045c637a8fb9ff1/claude_agent_sdk-0.2.86-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9e0a8e247d136d5301a8891d775b7c2fdf7c569d1a88462540b88a2529343c27", size = 63055147, upload-time = "2026-05-22T22:25:17.431Z" },
+    { url = "https://files.pythonhosted.org/packages/97/11/5bfc017619e6d4ad5281fab07b640a56107856bcd33321179b01d82a6887/claude_agent_sdk-0.2.86-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:d60fa40e3a17d8aa2bf86d366a13c6713599428a16a9ab33be8a84323656a70a", size = 65089918, upload-time = "2026-05-22T22:25:21.06Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/a9ec0d6753552e7e0858bf62acd308cf9b28b8b9966720d733194973ce93/claude_agent_sdk-0.2.86-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:67c02ba60ed24d8457ed1183ce55d398f0d4117ea86b1a463fddc5781799773f", size = 72726163, upload-time = "2026-05-22T22:25:25.699Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/b6ee8a922c0b2be6827daef17d1ef79371ab41dde0879614bfa9dd82a4a7/claude_agent_sdk-0.2.86-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:a1f481ba887b355dd93fe56cd7123ff77690ab32ac8fa55fbc38bc77c3566eba", size = 72887673, upload-time = "2026-05-22T22:25:31.003Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/7f90a8bd940e6f5a487a2113654027eae5d0f2107322457cb289f63c34df/claude_agent_sdk-0.2.86-py3-none-win_amd64.whl", hash = "sha256:28089d0d03e563494e24a2d079d80966c2a3c85014e35a15ff49572e7a555b56", size = 73511261, upload-time = "2026-05-22T22:25:36.868Z" },
 ]
 
 [[package]]
@@ -829,6 +856,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "deptry"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -858,6 +897,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "dirhash"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "scantree" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/1f/c8bf92552b7f0a13b9f12b85e3de8df6d9814240e0f8ce8f37433df028b3/dirhash-0.5.0-py3-none-any.whl", hash = "sha256:523dfd6b058c64f45b31604376926c6e2bd2ea301d0df23095d4055674e38b09", size = 13119, upload-time = "2024-08-03T22:14:11.688Z" },
 ]
 
 [[package]]
@@ -1229,6 +1280,8 @@ dependencies = [
 [package.optional-dependencies]
 audit = [
     { name = "inspect-ai" },
+    { name = "inspect-evals" },
+    { name = "inspect-harbor" },
     { name = "inspect-petri" },
     { name = "mcp" },
 ]
@@ -1280,6 +1333,8 @@ requires-dist = [
     { name = "dspy", marker = "extra == 'reason'", specifier = ">=3.1.2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "inspect-ai", marker = "extra == 'audit'", specifier = ">=0.3.211" },
+    { name = "inspect-evals", marker = "extra == 'audit'", specifier = ">=0.13.0" },
+    { name = "inspect-harbor", marker = "extra == 'audit'", specifier = ">=0.4.5" },
     { name = "inspect-petri", marker = "extra == 'audit'", git = "https://github.com/meridianlabs-ai/inspect_petri?rev=6d9b9e1dbc19bcc06544aca982427cfb37357ffc" },
     { name = "instructor", marker = "extra == 'reason'", specifier = ">=1.6.0" },
     { name = "langgraph", specifier = ">=1.1.0" },
@@ -1490,6 +1545,51 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "harbor"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "claude-agent-sdk" },
+    { name = "datasets" },
+    { name = "dirhash" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "litellm" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "ruff" },
+    { name = "shortuuid" },
+    { name = "supabase" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/15/cad3b5e119dd80d1c8f7c6df61d6c5c633e5c5eef7de8d51207d91b04e6c/harbor-0.8.0.tar.gz", hash = "sha256:27d1b98467aa998433b722ce805cee2170bd28b4ea1ac7cefe81f6f087b08fa7", size = 1016467, upload-time = "2026-05-22T05:18:09.168Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/99/bfbff33b99831d1935ec4420036f17a3313551065f323ed77dd64697f247/harbor-0.8.0-py3-none-any.whl", hash = "sha256:1ccbc327c0bbd204d828b995dc47307c92df2c1e58d625f5ac1b90808553b9fd", size = 1156034, upload-time = "2026-05-22T05:18:11.212Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1522,6 +1622,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1547,6 +1656,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
 ]
 
 [[package]]
@@ -1576,6 +1690,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1762,6 +1885,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/b7/5588fe9c5b58a77a162579d463fa75d5399712482e5d8dba0e0258a47306/inspect_ai-0.3.220.tar.gz", hash = "sha256:1b67fd9aaa203c4dae9e602ce867a6cfafa0df7d4f4884b17e4e85b73bac0816", size = 45636909, upload-time = "2026-05-08T13:32:23.774Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/f0/e74a150d58d4ebcb3449a5894834899f61809e7e3d98e86da2caf8863e4f/inspect_ai-0.3.220-py3-none-any.whl", hash = "sha256:1d22c9de47c2f98f847650d77183ba91c02609e618a7725441e6d589d36c01c2", size = 36105199, upload-time = "2026-05-08T13:32:01.737Z" },
+]
+
+[[package]]
+name = "inspect-evals"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "datasets" },
+    { name = "hf-xet" },
+    { name = "huggingface-hub" },
+    { name = "inspect-ai" },
+    { name = "jinja2" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "toml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/f0/913c431c9a4de9eaa85a6ea955dc2fcab60e8441064e3a1985575fbc20ac/inspect_evals-0.13.0.tar.gz", hash = "sha256:5ced44f1f1be0a7222a950fdc7d97df58c127dde0d2037d6f634e9596f55cad5", size = 45197571, upload-time = "2026-05-21T18:52:10.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/df/e67899b95a471d75d6443a85dee23c86940bc6aa060ee798ca2b6ca70aa0/inspect_evals-0.13.0-py3-none-any.whl", hash = "sha256:ecd7a424e24267a32fac52c5145f91ac58cc901dbd43cfaffbdfb27f088e8b8a", size = 27721189, upload-time = "2026-05-21T18:52:06.63Z" },
+]
+
+[[package]]
+name = "inspect-harbor"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "harbor" },
+    { name = "inspect-ai" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/48/a3eb11f0cbb01c7bd458a461bd8497f55ad8524b55333009113f2fba81f6/inspect_harbor-0.5.4.tar.gz", hash = "sha256:3246c59b3eca0b6dfa8a04ea44a0995f5aa77af34f83626a83c05a3d874691d0", size = 28797, upload-time = "2026-05-20T09:57:30.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/7a/64b8a9147e6aa2a9d8049ba6ae3bd5c054c6d993585ba324bb05516ef395/inspect_harbor-0.5.4-py3-none-any.whl", hash = "sha256:d5c4e61c11ac2136c43a2528da9f3cd0f2c7454bdb509b67d19710482c3318cc", size = 29623, upload-time = "2026-05-20T09:57:28.955Z" },
 ]
 
 [[package]]
@@ -2431,7 +2592,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.85.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2447,9 +2608,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/55/aebffceaa08688a989e9c68b3edc3a520a1f8338eb0346668774bd66ad88/litellm-1.85.1.tar.gz", hash = "sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d", size = 15346324, upload-time = "2026-05-21T02:30:38.185Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a0/263a13c2253201aa11563a69d9a87f3510030aa765a16f57fc40ceefcdf5/litellm-1.85.1-py3-none-any.whl", hash = "sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b", size = 16980080, upload-time = "2026-05-21T02:30:35.096Z" },
 ]
 
 [[package]]
@@ -4019,6 +4180,21 @@ wheels = [
 ]
 
 [[package]]
+name = "postgrest"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/7c/54e7be05adc9fd6fd98dc572ddfc8982d45bec314a55711e37277d440698/postgrest-2.30.0.tar.gz", hash = "sha256:4f89eec56ce605ab6fbddd9b96d526a9bb44962796d44a5d85cb77640eb766c3", size = 14430, upload-time = "2026-05-06T17:35:21.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/aa/ff2e09f99f95ea96fddeb373646bf907dd89a24fc00b5d38e5674ca7c9ca/postgrest-2.30.0-py3-none-any.whl", hash = "sha256:30631e7993da542419f4217cf3b60aa641084731ea15e66a18526a3a52e40a7d", size = 23108, upload-time = "2026-05-06T17:35:20.531Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4386,6 +4562,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pyiceberg"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "fsspec" },
+    { name = "mmh3" },
+    { name = "pydantic" },
+    { name = "pyparsing" },
+    { name = "pyroaring" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "strictyaml" },
+    { name = "tenacity" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f0/7616676603fdbd05ab97816337a9b31be08a5f9e1ffd636260812b217e0f/pyiceberg-0.11.1.tar.gz", hash = "sha256:366fe0d5a74e3cf1d4e7cbf3c49e308da60e7835ea268667be9185388f05d7a5", size = 1076075, upload-time = "2026-03-03T00:10:27.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/84/a140466b7e0841207e6b77042e03d4ab3a4f9d47e00f0bbbcc5420792bbb/pyiceberg-0.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd423b8ee2f75fc9db09158875abe5e2c952a26ae5e521c3265ab2f9d3511ddf", size = 532981, upload-time = "2026-03-03T00:10:08.906Z" },
+    { url = "https://files.pythonhosted.org/packages/17/10/6bedd784010f707680ffd0606d4d11394cf915f4f9f54ae16e8007e00ad4/pyiceberg-0.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e273242cdca56029af694d7ce18075d47a74d034326d663ff6dd2655a6f44825", size = 533188, upload-time = "2026-03-03T00:10:10.086Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a3/79db617c3cffc963efa8a332707079d3f22fd58067b31a208d358dd89b39/pyiceberg-0.11.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b347d3cc8510f8fbe191956fcda7da372ebb3302789acefca08e352345959003", size = 729546, upload-time = "2026-03-03T00:10:11.413Z" },
+    { url = "https://files.pythonhosted.org/packages/06/64/acc11d230c33817bced80d9d947bb49e7bb3a429d76d906523e3df86faf8/pyiceberg-0.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba3a35b4648694783aeae5b77c235a57191c8b1b375c8602b03ae56a6cf4fe7", size = 730263, upload-time = "2026-03-03T00:10:13.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1a/fb067d5150c7309fbf5dd126c648a6afed6259e7bc924ba3c65d0f87a333/pyiceberg-0.11.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0f958cbca18d05846e3081dfff8575e73d45595441d659847479656dc76f91d", size = 724064, upload-time = "2026-03-03T00:10:14.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/71/103fdba5b144d55f3bb07347893737cc1d8fd71308108a77b7817c92c544/pyiceberg-0.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c62636a1e9d8a1fc74ffb70383939b9cd93f2c9ee8e12015a50dd75c98a989e", size = 727239, upload-time = "2026-03-03T00:10:16.204Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c3/4db64429304c58c039f8e842cd37a9a1c472f596c2868ed2a5d2907b17ed/pyiceberg-0.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d6b6f0c1e7dd8357f1ba56524bfc870d04ad3c00979db291784a7145497ad3b", size = 531309, upload-time = "2026-03-03T00:10:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4c/a122d80d98cb6125d87024681263406433f0c25c699d503f5633521e6809/pyiceberg-0.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b7ec5db19feab98a31fcd5caccf4a9a4e83f96933d1ca393ba7aea665710c2bb", size = 532644, upload-time = "2026-03-03T00:10:18.574Z" },
+    { url = "https://files.pythonhosted.org/packages/10/94/9a8fa5fc580e6dccd34bbbf51e7658cd7b49540e2458783addeff5e22a91/pyiceberg-0.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cec0616d2ba6e7dda6327089a2f34ec723aa9ac2c389857ef0b83f65fb135dd6", size = 532787, upload-time = "2026-03-03T00:10:19.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ab/ab7c88828bc17d77dbbc5a765419dfec2135629e1d74cdd0762cd38ad867/pyiceberg-0.11.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddb360da76c62c7c23ec3da40e1af48e6712a563905fea2d1a8911ff7a3b6c4d", size = 722202, upload-time = "2026-03-03T00:10:21.012Z" },
+    { url = "https://files.pythonhosted.org/packages/df/38/079cf1c0bf86da315472a926eec0dba10135f43374a2e267336eb98d8c76/pyiceberg-0.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d8790f420ebc484236017edba59182cf2a21bd3e4224a0bd0760a9c7268e96a", size = 724037, upload-time = "2026-03-03T00:10:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6b/08eaef477debb110438d943ef3f5985096f660ccb735d6344701cbd075a9/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae27ba4d37925d5b2cff192acaa70c8bb114d632bbc527cc91fea0370702b866", size = 716035, upload-time = "2026-03-03T00:10:23.789Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/7671d6a630ab1d85c6e7ca8ddf438dc63a0b0dd183bc4be69bf25c0fa5f6/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db66a4e0fdfbf4090631d59c3f65e960d9a5561e9259f6f3993cbe91e396837e", size = 720887, upload-time = "2026-03-03T00:10:24.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/5c8ad37807efaedb14b20f01f36462684468c80da5b74f4018fb4c1804b5/pyiceberg-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:eb3a0a3e630ee89758eb96b39b456f4697732351fb0c080e9498ea578f9b71f9", size = 530923, upload-time = "2026-03-03T00:10:26.196Z" },
+]
+
+[[package]]
 name = "pyjson5"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4587,6 +4799,62 @@ name = "pyrect"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/04/2ba023d5f771b645f7be0c281cdacdcd939fe13d1deb331fc5ed1a6b3a98/PyRect-0.2.0.tar.gz", hash = "sha256:f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78", size = 17219, upload-time = "2022-03-16T04:45:52.36Z" }
+
+[[package]]
+name = "pyroaring"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/46/a50510d080f8cb089303ec0f7cd80736b2949ca3d148f48f1cc90c49e345/pyroaring-1.1.0.tar.gz", hash = "sha256:f02e4021397ae02a139defdc6813b9942ab163de90affddd4ce4efbac299f619", size = 200298, upload-time = "2026-04-24T21:29:25.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/e9/d8dcccfdac1657e6a53b6ade0c0c71d59244316810c82537a5d634f8b7fd/pyroaring-1.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:fdf484d26016e0c016f23f2b635d2899daec034565fdcc062ed6b10f3b26a3f4", size = 334166, upload-time = "2026-04-24T21:28:07.184Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/16/70f8268c9bac4f6d91a82df254332edfa07020fe02e97c6d3d0295ee4db3/pyroaring-1.1.0-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:e9c2b9aa8decdcf40ed8f4c887092c20a272f8c32215c3fee65e9db92ecf418e", size = 711970, upload-time = "2026-04-24T21:28:08.929Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/0b88a8a8e4ffdd0bf53765c3ea17ce3b747f7de42b1f10d5c50a13ba3ecc/pyroaring-1.1.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:5eb031237e9d39cbdfc9276facacdd88e27aefb58940bd8b56b878dfd38d6022", size = 385825, upload-time = "2026-04-24T21:28:10.077Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a7/f06a899b896bb74a031201fbba707abf23e2485f44ead28d2e91977ee204/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66aa6a321fbc598f26d5e66050a7f145c2253f3fe5737b589841ff0cbe5cb177", size = 2000799, upload-time = "2026-04-24T21:28:11.276Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/16/b13e0727ef5c91c84ac5d9b5c4af43cb3f28d8822d96d44aa4aeefc10b37/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cff06d18c9a30f8547a92757078aa345db1ba5b22e3082a05f64e50b384e27a", size = 1843405, upload-time = "2026-04-24T21:28:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4b/ff77d6eb4747c65aba49d345318059f1ccfbd206bbcd34686cea819187e9/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:043dbbaa905f7288c515ac06a96b67a3763f35e9ae06f0c0278c0d9964d16760", size = 2224307, upload-time = "2026-04-24T21:28:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d1/9b4e2175a9bd07592ef1c6f4692ba0cfe3abd54f33ebd574aa2b2ab88c2c/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71fec09bd42f8c33ac3b762cd00c5db842eb583ffd0e361739ce1c17ad078a6a", size = 2902586, upload-time = "2026-04-24T21:28:15.485Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/904952d6bfe2e4946f361958157774230cb1ac171d306e2460620274c58a/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c9f30ca28b991a920b446ed3ee19c7ecafcc49c46db592abf89cf239a7bb45f4", size = 2741581, upload-time = "2026-04-24T21:28:17.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/8ad5605870fbdcb568f0b847e1fea24adea15e07c90231fb62f339c08b14/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:67650460c65bdd7b4f5078d9c955aa38f64627d02cb48f9cfb24eae84bca2aba", size = 3182906, upload-time = "2026-04-24T21:28:18.435Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5d/264414a1b1bea72b2a7756e2b1dca709e5c695b0cd332a8f90c297ae3b33/pyroaring-1.1.0-cp312-cp312-win32.whl", hash = "sha256:61a8eabee99104ca197b6e7cce05dc4f27f503be52881800cd370eb5a5152d3f", size = 211231, upload-time = "2026-04-24T21:28:20.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/39/dd3341e235a3794c613ea32bd35618a88ff2ae067dbe9dd7c382c8c146d2/pyroaring-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:51ebe5e6f48e3dc9df91a4cb62137ef72e1469acd6f37479abd9991f6d945cc9", size = 263337, upload-time = "2026-04-24T21:28:21.371Z" },
+    { url = "https://files.pythonhosted.org/packages/12/5d/bb8e93dd7412180c621086ed46014a0f09f9a71d9370ce8cf607c5a2cf00/pyroaring-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:9882a204178cc8c915e0ce30abb4bdd1668e383c571b06649d5ed272d9625877", size = 216727, upload-time = "2026-04-24T21:28:22.536Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/75/1d39ecb04e6cd96d191eb8884864355051df80928dd5096a9dea43fbf63b/pyroaring-1.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:72f68a16b00b35481d9b3bfe897ecd8a1f7da69efd92ba5b17347ca11c21cb0d", size = 333363, upload-time = "2026-04-24T21:28:23.838Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3e/65cd0871e86d11c5c5cfd0f5abb0ca80eb2b6b5dbe5a2433f315a9ebd90c/pyroaring-1.1.0-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:4c443e9f942b6089efe8c9b264576e9d116f90be28a315679375bba2d8a915d6", size = 710573, upload-time = "2026-04-24T21:28:24.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a2/f8f23515f41414332e60cd86e4957e2a6838070b2ad5fe25e80f136de635/pyroaring-1.1.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:3beb40eb1220d1ce4fb3661bb019e9a21857e5bb294fe8c1c5016aeb6e82318c", size = 384880, upload-time = "2026-04-24T21:28:25.864Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5b/82dc44b5074a1ff62e702d12611272d1711a60d5518dab23f94e1f7a9b3d/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f1f56004e8f1c1489bf279c25f1fa4764252cd9af5fb35675774268a4a615ba", size = 1999529, upload-time = "2026-04-24T21:28:26.859Z" },
+    { url = "https://files.pythonhosted.org/packages/11/40/b07bac8cdc4b709a05f5c55bb52d4f684e5ea1fadfa0b6d9decf477a9d2a/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:13660386ea8905ee4d42c21a6275463e2dc7d31e0b5d65eec210aa7043ad96f4", size = 1842927, upload-time = "2026-04-24T21:28:28.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/60/c4b511965802dfc77978a9e16f2813f47fb3083db1822019ba1bb169c685/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0dfb6cf50fd8898179e460e699a6b8326ca508c627d083f7bf62f769fe1717d5", size = 2199538, upload-time = "2026-04-24T21:28:29.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/12/38f6b50b3f3f41a8b752d3e9efcf105b18eb2c66811831059f25613734ac/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:81ebbc0c880c8a10f13118632e5c0d59159ceada8b651bba18f2e6dc70efdeda", size = 2896904, upload-time = "2026-04-24T21:28:30.67Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b6/b5436e4b93c6bf2bd3dd6ccb88cbdc64b12084151a43e2f5c94be50eb710/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:370d191b0d1b32bbd99452ef5f0485f22fcc4bf7404d33b821d0ce2459951152", size = 2733819, upload-time = "2026-04-24T21:28:31.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/8f/f392f268de9607a5c7a95aaed6b9c8a81f00c14d85c33855e9f492095478/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b3bfad0ae3ef0e67b40c193863dce8b7d79de545dadbe53c19acc3ace38f66", size = 3161730, upload-time = "2026-04-24T21:28:33.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a1/03250fd4834b6a5c13e6600bca47ea20fda579f80bce3551d4985185d164/pyroaring-1.1.0-cp313-cp313-win32.whl", hash = "sha256:eead129046822cb0fd47c78740b81bdaffd0515c0bb0306a2318acf0f0540b58", size = 211194, upload-time = "2026-04-24T21:28:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/70/63/d9b307462cddc82fe94a67d6810e5c802818690e131ba690c1de674d8558/pyroaring-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:90ab2f00c09eed5bd986a80c8641e2dc10e7aca1a2d892d89a44b396e39c08ea", size = 263110, upload-time = "2026-04-24T21:28:35.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4a/aa6e9833a6ba9a630efdbec8783b63da6602f763b37a5b5fbc01d73a1af1/pyroaring-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:51dd2490a64ad4ed53c4fb58ef1ee3f84f6cbd97cdb47abd9065c9f714ab72ef", size = 216546, upload-time = "2026-04-24T21:28:37.065Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ab/2260fd567a2d5d957393b932ea940dc31146bd509c88164c1b786eee7836/pyroaring-1.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:5e337f8c5b3c2e0c27da83fc2cb702684a47eee907a960cfee964fcb5344515b", size = 335093, upload-time = "2026-04-24T21:28:38.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/df82a832ff3760c7c7653b80d030fb43b18eb88bfa604e7de3e84457286e/pyroaring-1.1.0-cp314-cp314-macosx_14_0_universal2.whl", hash = "sha256:53acecba8f898e96b84d4139356e30719c70358177e270055901d3ec1cb0e34c", size = 712387, upload-time = "2026-04-24T21:28:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b9/a94d6b2d7a1be2fa5009ecfc345bacb2ee0b536020aeb23e92c6bb7e70f2/pyroaring-1.1.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:986efb3aec7655d69c14db2309a2072dbf181bdb906091fede83ad18e316cdaf", size = 385413, upload-time = "2026-04-24T21:28:40.563Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6a/3658eadbe28a5a2093c27857dd21441f1ea1cede2ddbe367df76e3018859/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92643c9dd303de8960c3dbed93a28b8d87da5ed0a7776568979f379d7bc8a885", size = 1995135, upload-time = "2026-04-24T21:28:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/4706ec770790d3433520eb0ea98fc662ccb1533164fd00b01f3413c3425c/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6a1d4c59d5b23c01d62f86d57ceefd0c0977de0425aafa7069f2d70563fed3b8", size = 1833652, upload-time = "2026-04-24T21:28:43.381Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/38/b8b861738e49fd4c4a54bebe257dced603999365629b4e10cb85fac940b0/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8ac1bc26223befbca986551521f37f4c1670dfe26fccb2f0fc2775e75be99c1", size = 2188218, upload-time = "2026-04-24T21:28:44.487Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/96afa9b5f509a5c607deaf30538edb3bdf026447a864cfe3f2c3d7484875/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b490f2d22df30affbfdcbe4f7896f321edb72a8dc0cbe5f38adec3de5b947c25", size = 2898243, upload-time = "2026-04-24T21:28:45.9Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/86f8720525250fe742fc77ea5c2a2074a1ea830efe84a79112ce6fe113d3/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:56a67794188275f8897a8f1fa64d6313c48241bebbdef38833063e7281b29ef8", size = 2715091, upload-time = "2026-04-24T21:28:47.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/21/29e8f58c8af2ce016904a7e6aa61be675945224971cd70f3f698e584a23f/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d9f196007f0b15ea19c21732faacaea83cbf5946b6db4949b3b98cf871c93f0", size = 3149470, upload-time = "2026-04-24T21:28:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e1/f67ef1c9de461a80707a2f2981320b1b30632720bac426a9bfd51e4744b6/pyroaring-1.1.0-cp314-cp314-win32.whl", hash = "sha256:abc0f0ce22464864fea208315d25e999e45cb5ee646ac1ca11d314a6a51dbe4a", size = 216552, upload-time = "2026-04-24T21:28:50.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/a8d9fee17e6eedf2a2281b2aabcdde86930408486381ec48d1f7d3404521/pyroaring-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:532ae6bb1d3431d9956ef07589dd5c8dd918301a83d937c7dc6e511b1364d76a", size = 270712, upload-time = "2026-04-24T21:28:51.817Z" },
+    { url = "https://files.pythonhosted.org/packages/42/50/ab2bf3fe45e4c2952690d657321a8470558f92cf93cb197fe5d31f7110d2/pyroaring-1.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:d2706a89242a347be20805147d58a38f4f4d8f6846228c4ee8dfd3587113719c", size = 224783, upload-time = "2026-04-24T21:28:53.183Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0c/9eb48ac698280170f184045814b7bd44829af37c1c6de79a4d7b5ea0c8b8/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:39eff7dd06c163c22d0a9f9fd72d27e671457bea8cdb71215382a10512539e1d", size = 345689, upload-time = "2026-04-24T21:28:54.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/61/66b18f8ed17e70f88a410dcfac21e5964c2ad01bd4d6a25024a87522c8a9/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_universal2.whl", hash = "sha256:562fa04bbfd41144d1276ed79505007557c161371450d68a1d71fc83dc01d083", size = 732373, upload-time = "2026-04-24T21:28:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7a/976482874ea5e4476f9dd84e7d0274e480446b1b6ab45dfe301281814b3b/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:591e2ed4d60443dafd9075c1f72e9aaf359ccf5120e32a8c340c2b2ae3da45e7", size = 392985, upload-time = "2026-04-24T21:28:56.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1eed09ff3aa792865dd52ef447cbe52dbc5901ed88bf1cf4513f7220150e/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:381eda673442c389993f8b0db2dbf5d02ea8ea9aac6ba736f64cc1ffb6c96885", size = 2045479, upload-time = "2026-04-24T21:28:58.008Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/de43464f9b28c445868e4bc8f0e6c6dcd51103bd9a757e3dcd9af25a4a69/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9127feb5356ba3a92bdffa04c1bf6bcbc8d436369f78badf441018c3029dd63", size = 1853013, upload-time = "2026-04-24T21:28:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/03/17/29b128a580ec43905fb766b934e7dcb1095059e99e38e941edf50152207b/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:650db21c10f42ff2b09ef02c10a779a3d59d0c7512552f3844738b30adbcb8a5", size = 2222628, upload-time = "2026-04-24T21:29:00.792Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d8/bb7d69978a5fcac95da48bedb114554d8345b50b77f042e8cd2a8277bb4b/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a5fbcb86e44f1c0c9c052917eee67a04cbac9de7392fb4bc77c140ff4a7e471", size = 2931231, upload-time = "2026-04-24T21:29:02.275Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/12/d44d144352a4586544313a97b2576f8f8673b98c02ae7fed77d38751cc1f/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0f1d76ef29034017eb2cceebd5fa0504d6ced218ce6432f99da5adecbe038269", size = 2729546, upload-time = "2026-04-24T21:29:03.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/0d01c6ba01c0d01609fddb1d46138a7ae95b7db386bac4afb0ff082d5c0e/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:19d0c81c865d63791fe20e5b38733b66f4f962e677ae7e8b3d3c4947ac6e752f", size = 3177123, upload-time = "2026-04-24T21:29:04.619Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6d/f991526fdef3cf7739f6db0cdf12b157e840e0ddd4a7e1c2a477da9072d6/pyroaring-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:1fc112b9a9890f89cc645a16604783ed7fa25299f149b0ef7b45a5e2e3c1f31f", size = 241484, upload-time = "2026-04-24T21:29:06.114Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6e/fb9876940acb50df355a473c087b9924e7b3368070403683941653b6fabc/pyroaring-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d92a0f4c7e6bb7deeafac68c79c92ef9340895fe825cf1a31078443753ab6756", size = 304537, upload-time = "2026-04-24T21:29:07.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e0/39afe4bddbed6276c54e35e310aa345fbeb00f8890e96e7f48cdc2be9c66/pyroaring-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:99c42fe1449acfbf130da65e66b4d5b2726aba4497be359bae7672e38a15fc62", size = 234615, upload-time = "2026-04-24T21:29:08.751Z" },
+]
 
 [[package]]
 name = "pyscreeze"
@@ -4817,6 +5085,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
+]
+
+[[package]]
+name = "realtime"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/a2/0328d49d3b5fb427068e9200e7de5b0d708d021a1ad98d004bc685d2529e/realtime-2.30.0.tar.gz", hash = "sha256:7aa593da52ed5f92c34ec4e50e32043afa62f219c94f717ad64a66ab0ef9f1ba", size = 18718, upload-time = "2026-05-06T17:35:23.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/75/1b2cfc949595e22d8c05a2aa2cfc222921f7f94177d7e8a90542f3f73b33/realtime-2.30.0-py3-none-any.whl", hash = "sha256:7c93b63d2cf99aa1da4fa8826b03b00cd32f7b38abb27ff47b19eb5dcb5707c6", size = 22376, upload-time = "2026-05-06T17:35:22.568Z" },
 ]
 
 [[package]]
@@ -5138,6 +5420,19 @@ wheels = [
 ]
 
 [[package]]
+name = "scantree"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ce/828467ddfa0d2fe473673026442d2032d552a168e42cfbf25fd0e5264e0c/scantree-0.0.4-py3-none-any.whl", hash = "sha256:7616ab65aa6b7f16fcf8e6fa1d9afaa99a27ab72bba05c61b691853b96763174", size = 20690, upload-time = "2024-08-03T20:08:58.137Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5279,6 +5574,89 @@ wheels = [
 ]
 
 [[package]]
+name = "storage3"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyiceberg" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/b2/6df208d64630744704d00f2c07197170390d6b4d0098617740f6a7a4fa98/storage3-2.30.0.tar.gz", hash = "sha256:b74e3cac149f2c0553dcb5f4d55d8c35d420d88183a1a2df77727d482665972b", size = 20162, upload-time = "2026-05-06T17:35:25.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/5c/bb8c8cc448cfae671c4ffee67f3651892ea59b341f27bed54666190eb8ef/storage3-2.30.0-py3-none-any.whl", hash = "sha256:2bd23a34011c018bd9c130d8a70a09ebd060ae80d946c6204a6fc08161ad728d", size = 28284, upload-time = "2026-05-06T17:35:24.659Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "postgrest" },
+    { name = "realtime" },
+    { name = "storage3" },
+    { name = "supabase-auth" },
+    { name = "supabase-functions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/a6/d2b17021c2db1a9d219c383e0762ac03a62b25468e61ab126b6b561c2f21/supabase-2.30.0.tar.gz", hash = "sha256:efdba41d474038ed220736ba4e64946df56043057ad785c4c3499d27e459975c", size = 9689, upload-time = "2026-05-06T17:35:27.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/82/d213be7d0ce0bb18018744c0ee38ba0d6648d41dbc46ac8558cffe80541f/supabase-2.30.0-py3-none-any.whl", hash = "sha256:f9b259194554f7bfd2dca6c23261f2df588016ca18b18e774f4d85bc941edb03", size = 16634, upload-time = "2026-05-06T17:35:26.696Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/8a/48bbbe0b6703d0670b67e45b90d6a791fd01aace67443d286f760bf48895/supabase_auth-2.30.0.tar.gz", hash = "sha256:6138a53a306a95ed59c03d4e4975469dfc3343a0ade33cc4b37e4ef967ad83f8", size = 39135, upload-time = "2026-05-06T17:35:30.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/40/a99cb4373353bcbf302d962e51da9eac78b3b0f257eb0362c0852b1667f4/supabase_auth-2.30.0-py3-none-any.whl", hash = "sha256:e85e1f51ec0de2172c3a2a8514205f71731a9914f9a770ed199ac0cf054bc82c", size = 48352, upload-time = "2026-05-06T17:35:28.936Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "strenum" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/5cd8559ec2bb332e6027840c1be292f9989c2fc7b47bf40800aec5586791/supabase_functions-2.30.0.tar.gz", hash = "sha256:025acfd25f1c000ba43d0f7b8e366b0d2e9dfc784b842528e21973eb33006113", size = 4683, upload-time = "2026-05-06T17:35:32.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/da/9dedab32775df04cc22ca72f194b78e895d940f195bed3e02882a65daa9b/supabase_functions-2.30.0-py3-none-any.whl", hash = "sha256:92419459f102767b954cd034856e4ded8e34c78660b32442d66c8b2899c68011", size = 8803, upload-time = "2026-05-06T17:35:31.342Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5411,6 +5789,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
     { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -5725,6 +6112,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Rotation pattern pass-through. release/v0.99.42 already merged into develop via PR #1532 (CI 8/8 green). develop now carries v0.99.42 stamps.
- This PR moves main's tip up to match — no new commits, no CHANGELOG churn.
- Includes PR #1531 (SessionMetrics central-isation) + PR #1529 (C4.fix-contextvar) — observability central-isation track 완결.

## Verification
- [x] develop CI 8/8 green (#1532)
- [x] No new commits on this branch vs develop (pass-through)
- [x] Version stamps consistent across 5 locations (0.99.42)
- [x] PR-SIL-5THEME C4 sidecar race 영구 해소 (SessionMetrics ContextVar 흡수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)