### PR TITLE
feat(llm/adapters): A2 OpenAI/Codex closure + F GLM family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,65 @@ functional change.
 
 ### Added
 
+- **Follow-up F — GLM adapter family.** Two new built-ins land the
+  ZhipuAI provider on the v0.99.39 :class:`LLMAdapter` registry:
+
+  - ``glm-payg`` (``provider=glm``, ``source=payg``,
+    ``billing_type=api``) — calls ``api.z.ai/api/paas/v4`` with
+    ``settings.zai_api_key``. PAYG metered.
+  - ``glm-coding-plan`` (``provider=glm``, ``source=subscription``,
+    ``billing_type=subscription``) — calls
+    ``api.z.ai/api/coding/paas/v4`` with the API key bound to a
+    Coding Plan profile resolved via
+    :func:`core.llm.routing.plan_registry.resolve_routing`. Refuses to
+    fall back to PAYG when no Plan is registered — the picker source
+    ``subscription`` means subscription.
+
+  Both share :func:`build_async_openai_client` (per-adapter fresh
+  client, no module-level singleton shadowing) and route
+  ``tool_choice`` through ``normalize("glm", ...)`` for the Chat
+  Completions nested ``function`` wire shape.
+
+- **Follow-up A2 — OpenAI + Codex adapter route closure.** Removes the
+  ``provider == "anthropic"`` guard from
+  ``AgenticLoop.__init__`` so concrete-source resolution now works for
+  every provider via :func:`core.llm.adapters.resolve_for`. The two
+  Codex MCP findings from PR #1519 are closed:
+
+  - **BLOCKER 2 (multi-turn translation).**
+    ``core/llm/adapters/_openai_common.py`` gained ports of
+    ``_convert_messages_to_openai`` / ``_convert_messages_to_responses``
+    from the legacy provider — assistant ``tool_use`` blocks re-encode
+    into Chat ``tool_calls`` (nested ``function``) or Codex Responses
+    ``function_call`` typed items; user ``tool_result`` blocks become
+    ``role: tool`` follow-ups with ``tool_call_id`` (Chat) or
+    ``function_call_output`` items with ``call_id`` (Codex). Pre-A2 the
+    adapter passed the Anthropic content list through verbatim and the
+    SDK returned 400.
+
+  - **HIGH 1 (Codex encrypted-reasoning replay).**
+    :class:`core.llm.adapters.AdapterCallResult` gained
+    ``reasoning_items`` + ``reasoning_summaries`` fields.
+    ``CodexOAuthAdapter.acomplete`` captures ``type: reasoning`` typed
+    items from the ``response.output_item.done`` SSE stream and
+    surfaces them on the result. ``_legacy_bridge.build_adapter_request``
+    pulls ``codex_reasoning_items`` off the prior assistant turn and
+    threads them via ``AdapterCallRequest.provider_options``;
+    ``_build_codex_call_kwargs`` calls
+    :func:`core.llm.adapters._openai_common.inject_reasoning_replay`
+    to prepend the encrypted_content blobs into the next-turn ``input``.
+    Without this chain gpt-5.x ``store=False`` models lose their chain
+    of thought across turns.
+
+  - Tool_choice translation now mirrors the Anthropic adapter pattern.
+    OpenAI Chat receives ``auto``/``none``/``required`` (the
+    adapter-neutral ``"any"`` maps to ``"required"``); Codex Responses
+    same mapping, with unknown literals defaulting to ``"auto"``.
+
+  Tests: ``tests/core/llm/adapters/test_openai_multi_turn.py`` (14
+  cases, Chat + Responses converters + reasoning replay) +
+  ``test_codex_reasoning_replay.py`` (12 cases — SSE accumulation →
+  result → bridge → next-turn provider_options chain).
 - **PR-CL-BUDGET — 2-hour wall-clock cap + automatic T-10min hand-off**.
   Foundation PR for the Cognitive Loop sprint (A3 → A6 → A1). Replaces
   the per-AgenticLoop turn hard-cap with a session-wide wall-clock

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -147,39 +147,28 @@ class AgenticLoop:
         if allowed_tool_names is not None:
             self._tools = [t for t in self._tools if t.get("name") in allowed_tool_names]
         self._last_llm_error: str | None = None  # last error type for user message
-        # v0.99.40 Follow-up A — opt-in adapter route via the v0.99.39
-        # :class:`LLMAdapter` registry. Scope limited to ``provider="anthropic"``
-        # in this PR: the OpenAI / Codex adapter route needs full multi-turn
-        # message translation (Anthropic tool_use → ``tool_calls`` /
-        # ``function_call`` etc.) + Codex encrypted-reasoning replay, both
-        # tracked as Follow-up A2 (``docs/plans/2026-05-23-llm-adapter-
-        # abstraction.md`` § Scope cut). Concrete source values still thread
-        # through SubTask/WorkerRequest for observability on every provider,
-        # but the actual LLM call stays on the legacy adapter when the
-        # bridge is not yet wired for that provider.
+        # v0.99.40 Follow-up A + v0.99.44 Follow-up A2 — opt-in adapter route
+        # via the v0.99.39 :class:`LLMAdapter` registry. A2 closes the
+        # Anthropic-only scope of Follow-up A by porting the multi-turn
+        # message converters to ``core/llm/adapters/_openai_common.py``
+        # (``build_codex_input`` / ``build_messages``) + capturing Codex
+        # encrypted-reasoning items + summaries on the SSE stream, so
+        # OpenAI Chat Completions and Codex Responses routes now also
+        # work through ``LLMAdapter.acomplete``.
         #
-        # When ``source`` is concrete (one of CONCRETE_SOURCES) AND the
-        # provider is supported, ``_call_llm`` routes through
-        # ``LLMAdapter.acomplete``. A concrete source with a missing
-        # adapter HARD-FAILS in :func:`resolve_for` — silent fallback would
-        # mask operator misconfiguration (Codex MCP 2026-05-23 HIGH 2).
+        # When ``source`` is concrete (one of CONCRETE_SOURCES), ``_call_llm``
+        # routes through ``LLMAdapter.acomplete`` for any provider. A
+        # concrete source with a missing adapter HARD-FAILS in
+        # :func:`resolve_for` — silent fallback would mask operator
+        # misconfiguration (Codex MCP 2026-05-23 HIGH 2).
         self._source = source
         self._new_adapter: Any | None = None
         if source:
             from core.llm.adapters import CONCRETE_SOURCES, resolve_for
 
             if source in CONCRETE_SOURCES:
-                if self._provider == "anthropic":
-                    # Hard-fail on resolve mismatch — concrete source MUST resolve.
-                    self._new_adapter = resolve_for(self._provider, source)
-                else:
-                    log.info(
-                        "AgenticLoop: source=%s threaded through but provider=%s "
-                        "stays on legacy adapter — A2 follow-up adds OpenAI/Codex "
-                        "multi-turn translation + reasoning replay.",
-                        source,
-                        self._provider,
-                    )
+                # Hard-fail on resolve mismatch — concrete source MUST resolve.
+                self._new_adapter = resolve_for(self._provider, source)
         self._adapter = resolve_agentic_adapter(self._provider)
         self._op_logger = OperationLogger(quiet=self._quiet)
         self._error_recovery = ErrorRecoveryStrategy(tool_executor)

--- a/core/llm/adapters/_legacy_bridge.py
+++ b/core/llm/adapters/_legacy_bridge.py
@@ -60,7 +60,26 @@ def build_adapter_request(
         role = m.get("role", "user")
         content = m.get("content", "")
         tool_use_id = m.get("tool_use_id")
-        adapter_messages.append(Message(role=role, content=content, tool_use_id=tool_use_id))
+        # A2 (v0.99.44) — Codex reasoning items are attached to the SPECIFIC
+        # assistant turn that emitted them so the adapter can replay each
+        # blob at the correct ordinal position when rebuilding the
+        # next-turn ``input`` array. Flattening into a single
+        # provider_options tuple would lose the per-turn association the
+        # legacy ``inject_reasoning_replay`` walker depends on (Codex MCP
+        # A2 BLOCKER 3).
+        reasoning_items: tuple[dict[str, Any], ...] = ()
+        if role == "assistant":
+            raw = m.get("codex_reasoning_items")
+            if isinstance(raw, list):
+                reasoning_items = tuple(item for item in raw if isinstance(item, dict))
+        adapter_messages.append(
+            Message(
+                role=role,
+                content=content,
+                tool_use_id=tool_use_id,
+                codex_reasoning_items=reasoning_items,
+            )
+        )
     adapter_tools: list[ToolSpec] = [
         ToolSpec(
             name=t.get("name", ""),
@@ -118,10 +137,21 @@ def agentic_response_from_adapter_result(result: AdapterCallResult) -> AgenticRe
         output_tokens=result.usage.output_tokens,
         cache_read_tokens=result.usage.cached_input_tokens,
     )
+    # A2 (v0.99.44) — Codex encrypted reasoning replay + reasoning summaries
+    # forwarded. AgenticLoop's next-turn input builder reads
+    # ``codex_reasoning_items`` and prepends them so gpt-5.x ``store=False``
+    # multi-turn doesn't lose chain of thought. ``reasoning_summaries`` feeds
+    # the live "thinking..." UI surface (``emit_reasoning_summary``).
+    codex_reasoning_items = (
+        [dict(item) for item in result.reasoning_items] if result.reasoning_items else None
+    )
+    reasoning_summaries = list(result.reasoning_summaries) if result.reasoning_summaries else None
     return AgenticResponse(
         content=blocks,
         stop_reason=_translate_stop_reason(result.stop_reason),
         usage=usage,
+        codex_reasoning_items=codex_reasoning_items,
+        reasoning_summaries=reasoning_summaries,
     )
 
 

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -2,20 +2,28 @@
 
 Mirror of :mod:`core.llm.adapters._anthropic_common` for the OpenAI provider:
 fresh-client builder (PAYG vs Codex OAuth must not share the module-level
-singleton in ``core.llm.providers.openai``) + request/response translation.
+singleton in ``core.llm.providers.openai``) + multi-turn request translation
++ response normalisation.
 
-Codex MCP review 2026-05-23 flagged the singleton sharing as a BLOCKER for
-the source/billing isolation guarantee — same root cause as the Anthropic
-side. The fix mirrors that pattern: each adapter owns its client.
+A2 (v0.99.44) — ports the multi-turn converters from
+``core.llm.providers.openai`` so :class:`Message` content lists carrying
+Anthropic-shape tool blocks re-encode correctly into either the Chat
+Completions wire shape (``tool_calls`` on assistant + ``role: tool`` with
+``tool_call_id`` on user) or the Codex Responses API wire shape
+(``function_call`` / ``function_call_output`` typed items). Pre-A2 the
+adapter passed Anthropic content lists through verbatim → OpenAI/Codex
+SDK rejected with 400. Codex MCP review 2026-05-23 BLOCKER 2.
 """
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from core.llm.adapters.base import (
     AdapterCallRequest,
     AdapterCallResult,
+    Message,
     ToolSpec,
     UsageSummary,
 )
@@ -68,12 +76,29 @@ def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
     )
 
 
-def translate_tool_for_codex(tool: ToolSpec) -> dict[str, Any]:
-    """Codex Responses API uses the FLAT tool shape, not Chat Completions nested.
+# ---------------------------------------------------------------------------
+# Tool definition shape — Chat vs Responses API
+# ---------------------------------------------------------------------------
 
-    Mirrors :func:`core.llm.providers.openai._tools_to_openai` for the
-    Responses-API call path used by ``CodexAgenticAdapter`` — top-level
-    ``type/name/description/parameters`` rather than nested under ``function``.
+
+def translate_tool(tool: ToolSpec) -> dict[str, Any]:
+    """Anthropic ToolSpec → OpenAI Chat Completions nested ``function`` shape."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema,
+        },
+    }
+
+
+def translate_tool_for_codex(tool: ToolSpec) -> dict[str, Any]:
+    """Anthropic ToolSpec → Codex Responses API flat shape.
+
+    Mirrors :func:`core.llm.providers.openai._tools_to_openai` — top-level
+    ``type/name/description/parameters`` rather than nested under
+    ``function``. Required by ``chatgpt.com/backend-api/codex/responses``.
     """
     return {
         "type": "function",
@@ -83,13 +108,35 @@ def translate_tool_for_codex(tool: ToolSpec) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Multi-turn message converters — Anthropic content blocks → provider shape
+# ---------------------------------------------------------------------------
+
+
 def build_messages(req: AdapterCallRequest) -> list[dict[str, Any]]:
-    """Translate adapter-neutral Message list → OpenAI Chat ``messages`` payload."""
+    """Translate :class:`Message` list → OpenAI Chat Completions ``messages``.
+
+    Handles three content shapes per message:
+
+    - ``str`` — direct text body, emitted unchanged.
+    - ``list[dict]`` carrying Anthropic blocks (``{"type": "tool_use", ...}``
+      on assistant, ``{"type": "tool_result", "tool_use_id": ...}`` on user)
+      — re-encoded into OpenAI's flat ``tool_calls`` (on assistant) +
+      ``role: tool`` follow-ups (with ``tool_call_id``).
+    - Anything else — stringified.
+
+    A2 (v0.99.44, Codex MCP BLOCKER 2): pre-fix this helper emitted the
+    content list raw, so the OpenAI SDK rejected with 400. Now re-encodes
+    via :func:`_convert_assistant_msg_to_chat` and
+    :func:`_convert_user_msg_to_chat`.
+    """
     out: list[dict[str, Any]] = []
     if req.system_prompt:
         out.append({"role": "system", "content": req.system_prompt})
     for m in req.messages:
         if m.role == "tool":
+            # Adapter-emitted tool result (rare; multi-turn loops use Anthropic
+            # blocks on the user role instead).
             out.append(
                 {
                     "role": "tool",
@@ -98,19 +145,228 @@ def build_messages(req: AdapterCallRequest) -> list[dict[str, Any]]:
                 }
             )
             continue
-        out.append({"role": m.role, "content": m.content})
+        if m.role == "assistant":
+            out.append(_convert_assistant_msg_to_chat(m.content))
+            continue
+        if m.role == "user":
+            out.extend(_convert_user_msg_to_chat(m.content))
+            continue
+        out.append({"role": m.role, "content": _stringify(m.content)})
     return out
 
 
-def translate_tool(tool: ToolSpec) -> dict[str, Any]:
-    return {
-        "type": "function",
-        "function": {
-            "name": tool.name,
-            "description": tool.description,
-            "parameters": tool.input_schema,
-        },
-    }
+def build_codex_input(req: AdapterCallRequest) -> list[dict[str, Any]]:
+    """Translate :class:`Message` list → Codex Responses API ``input`` array.
+
+    Differences from Chat shape:
+
+    - Codex uses ``instructions`` field (passed separately) for the system
+      prompt — this function does NOT prepend a ``role: system`` entry.
+      Callers must thread ``req.system_prompt`` into the ``instructions``
+      kwarg of ``responses.stream(...)``.
+    - Assistant ``tool_use`` blocks → ``{"type": "function_call", "call_id",
+      "name", "arguments"}`` typed items.
+    - User ``tool_result`` blocks → ``{"type": "function_call_output",
+      "call_id", "output"}`` typed items.
+
+    A2 (v0.99.44): when an assistant :class:`Message` carries
+    ``codex_reasoning_items`` (captured from a prior Codex turn), those
+    items are prepended **immediately before** that assistant's entries
+    so gpt-5.x can resume its chain of thought at the correct ordinal
+    position. Flattening to a single tuple at the top of ``input`` would
+    misattribute reasoning across multi-assistant histories — Codex MCP
+    A2 BLOCKER 3.
+
+    Mirrors :func:`core.llm.providers.openai._convert_messages_to_responses`
+    composed with :func:`core.llm.agentic_response.inject_reasoning_replay`.
+    """
+    out: list[dict[str, Any]] = []
+    for m in req.messages:
+        if m.role == "assistant":
+            # Replay this turn's encrypted reasoning items (id-stripped)
+            # right before the assistant's converted entries.
+            for ri in m.codex_reasoning_items:
+                if not isinstance(ri, dict) or not ri.get("encrypted_content"):
+                    continue
+                out.append({k: v for k, v in ri.items() if k != "id"})
+            out.extend(_convert_assistant_msg_to_responses(m.content))
+            continue
+        if m.role == "user":
+            out.extend(_convert_user_msg_to_responses(m.content))
+            continue
+        out.append({"role": m.role, "content": _stringify(m.content)})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Chat Completions per-message conversion
+# ---------------------------------------------------------------------------
+
+
+def _convert_assistant_msg_to_chat(content: Any) -> dict[str, Any]:
+    """Anthropic assistant content → Chat Completions ``assistant`` shape.
+
+    When the content list contains ``tool_use`` blocks they translate into
+    OpenAI's nested ``tool_calls`` array; text blocks concatenate into the
+    ``content`` field (or ``None`` when only tool_calls).
+    """
+    if isinstance(content, str):
+        return {"role": "assistant", "content": content}
+    if not isinstance(content, list):
+        return {"role": "assistant", "content": _stringify(content)}
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            text_parts.append(block.get("text", ""))
+        elif btype == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {}), ensure_ascii=False),
+                    },
+                }
+            )
+    msg: dict[str, Any] = {"role": "assistant"}
+    msg["content"] = "\n".join(text_parts) if text_parts else None
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def _convert_user_msg_to_chat(content: Any) -> list[dict[str, Any]]:
+    """Anthropic user content → Chat Completions entries.
+
+    ``tool_result`` blocks split off into separate ``{"role": "tool",
+    "tool_call_id": ...}`` messages. Text blocks merge into a single
+    ``{"role": "user", "content": "..."}`` follow-up.
+    """
+    if isinstance(content, str):
+        return [{"role": "user", "content": content}]
+    if not isinstance(content, list):
+        return [{"role": "user", "content": _stringify(content)}]
+    result: list[dict[str, Any]] = []
+    text_parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            text_parts.append(_stringify(block))
+            continue
+        btype = block.get("type")
+        if btype == "tool_result":
+            raw = block.get("content", "")
+            result.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": block.get("tool_use_id", ""),
+                    "content": raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False),
+                }
+            )
+        elif btype == "text":
+            text_parts.append(block.get("text", ""))
+        else:
+            text_parts.append(_stringify(block))
+    if text_parts:
+        result.append({"role": "user", "content": "\n".join(text_parts)})
+    return result if result else [{"role": "user", "content": ""}]
+
+
+# ---------------------------------------------------------------------------
+# Codex Responses API per-message conversion
+# ---------------------------------------------------------------------------
+
+
+def _convert_assistant_msg_to_responses(content: Any) -> list[dict[str, Any]]:
+    """Anthropic assistant content → Responses API typed items.
+
+    Splits text + tool_use into separate items (text becomes
+    ``{"role": "assistant", "content": ...}``, tool_use becomes
+    ``{"type": "function_call", "call_id", "name", "arguments"}``) preserving
+    the original ordering so the next-turn pairing with ``function_call_output``
+    matches by ``call_id``.
+    """
+    if isinstance(content, str):
+        return [{"role": "assistant", "content": content}]
+    if not isinstance(content, list):
+        return [{"role": "assistant", "content": _stringify(content)}]
+    items: list[dict[str, Any]] = []
+    text_parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            text_parts.append(block.get("text", ""))
+        elif btype == "tool_use":
+            if text_parts:
+                items.append({"role": "assistant", "content": "\n".join(text_parts)})
+                text_parts = []
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": block.get("id", ""),
+                    "name": block.get("name", ""),
+                    "arguments": json.dumps(block.get("input", {}), ensure_ascii=False),
+                }
+            )
+    if text_parts:
+        items.append({"role": "assistant", "content": "\n".join(text_parts)})
+    return items if items else [{"role": "assistant", "content": ""}]
+
+
+def _convert_user_msg_to_responses(content: Any) -> list[dict[str, Any]]:
+    """Anthropic user content → Responses API typed items.
+
+    ``tool_result`` blocks become ``{"type": "function_call_output",
+    "call_id", "output"}`` items; text blocks aggregate into a follow-up
+    ``{"role": "user", "content": ...}`` entry.
+    """
+    if isinstance(content, str):
+        return [{"role": "user", "content": content}]
+    if not isinstance(content, list):
+        return [{"role": "user", "content": _stringify(content)}]
+    items: list[dict[str, Any]] = []
+    text_parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            text_parts.append(_stringify(block))
+            continue
+        btype = block.get("type")
+        if btype == "tool_result":
+            raw = block.get("content", "")
+            output = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": block.get("tool_use_id", ""),
+                    "output": output,
+                }
+            )
+        elif btype == "text":
+            text_parts.append(block.get("text", ""))
+        else:
+            text_parts.append(_stringify(block))
+    if text_parts:
+        items.append({"role": "user", "content": "\n".join(text_parts)})
+    return items if items else [{"role": "user", "content": ""}]
+
+
+def _stringify(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    return str(content)
+
+
+# ---------------------------------------------------------------------------
+# Response normalisation
+# ---------------------------------------------------------------------------
 
 
 def translate_chat_response(response: Any) -> AdapterCallResult:
@@ -145,24 +401,66 @@ def translate_chat_response(response: Any) -> AdapterCallResult:
     )
 
 
-def translate_codex_response(response: Any) -> AdapterCallResult:
+def translate_codex_response(
+    response: Any,
+    *,
+    accumulated_items: list[Any] | None = None,
+) -> AdapterCallResult:
     """Codex ``Response`` → :class:`AdapterCallResult`.
 
     Codex uses ``output_text`` (concatenated) + ``output`` (typed items)
-    instead of OpenAI Chat ``message.content``.
+    instead of OpenAI Chat ``message.content``. When the caller streams the
+    response, ``accumulated_items`` should be the SSE-collected
+    ``response.output_item.done`` items — we walk those for reasoning items
+    + function_call extraction. Non-streaming callers pass ``None`` and we
+    fall back to ``response.output``.
+
+    A2 (v0.99.44): populates ``reasoning_items`` so the bridge can forward
+    encrypted-reasoning replay to the next turn for gpt-5.x models.
     """
     text = getattr(response, "output_text", "") or ""
+    items_source: list[Any] = (
+        accumulated_items if accumulated_items else (getattr(response, "output", []) or [])
+    )
     tool_uses: list[dict[str, Any]] = []
-    output_items = getattr(response, "output", []) or []
-    for item in output_items:
-        if getattr(item, "type", "") == "function_call":
+    reasoning_items: list[dict[str, Any]] = []
+    reasoning_summaries: list[str] = []
+    for item in items_source:
+        itype = getattr(item, "type", "") if not isinstance(item, dict) else item.get("type", "")
+        if itype == "function_call":
+            # Codex backend assigns ``call_id`` as the durable identifier — the
+            # ``function_call_output`` reply on the next turn MUST reference
+            # this ``call_id`` (not ``id``, which is server-internal and
+            # unstable under ``store=False``). Mirrors the legacy normaliser
+            # at ``core/llm/providers/openai.py`` — Codex MCP A2 BLOCKER 1.
             tool_uses.append(
                 {
-                    "id": getattr(item, "id", "") or getattr(item, "call_id", ""),
-                    "name": getattr(item, "name", ""),
-                    "input": getattr(item, "arguments", "{}"),
+                    "id": _attr_or_key(item, "call_id") or _attr_or_key(item, "id"),
+                    "name": _attr_or_key(item, "name"),
+                    "input": _attr_or_key(item, "arguments") or "{}",
                 }
             )
+        elif itype == "reasoning":
+            entry: dict[str, Any] = {"type": "reasoning"}
+            enc = _attr_or_key(item, "encrypted_content")
+            if enc:
+                entry["encrypted_content"] = enc
+            summary = _attr_or_key(item, "summary")
+            if summary:
+                entry["summary"] = summary
+                if isinstance(summary, list):
+                    for s in summary:
+                        t = (
+                            s.get("text", "")
+                            if isinstance(s, dict)
+                            else getattr(s, "text", "") or ""
+                        )
+                        if t:
+                            reasoning_summaries.append(t)
+            iid = _attr_or_key(item, "id")
+            if iid:
+                entry["id"] = iid
+            reasoning_items.append(entry)
     usage = getattr(response, "usage", None)
     return AdapterCallResult(
         text=text,
@@ -173,12 +471,23 @@ def translate_codex_response(response: Any) -> AdapterCallResult:
         stop_reason=getattr(response, "status", "completed") or "completed",
         tool_uses=tuple(tool_uses),
         raw_response=response,
+        reasoning_items=tuple(reasoning_items),
+        reasoning_summaries=tuple(reasoning_summaries),
     )
 
 
+def _attr_or_key(item: Any, name: str) -> Any:
+    """Read ``item.name`` whether ``item`` is an SDK object or a dict."""
+    if isinstance(item, dict):
+        return item.get(name)
+    return getattr(item, name, None)
+
+
 __all__ = [
+    "Message",
     "build_async_codex_client",
     "build_async_openai_client",
+    "build_codex_input",
     "build_messages",
     "translate_chat_response",
     "translate_codex_response",

--- a/core/llm/adapters/base.py
+++ b/core/llm/adapters/base.py
@@ -72,11 +72,21 @@ class Message:
     ``role`` is one of ``"user" | "assistant" | "tool"``; tool messages carry a
     ``tool_use_id`` so the adapter can wire results back to the originating
     tool_use block.
+
+    ``codex_reasoning_items`` (A2, v0.99.44): Codex backend gpt-5.x family
+    runs with ``store=False`` so the server cannot resolve encrypted
+    reasoning items by id across turns. Each prior assistant message that
+    emitted reasoning carries the items inline here so the Codex adapter
+    can replay them at the correct ordinal position when rebuilding the
+    next-turn ``input`` array. Pre-A2 callers populate this from the
+    AgenticLoop's per-message ``codex_reasoning_items`` annotation
+    (Anthropic-shape dict key on the assistant turn).
     """
 
     role: str
     content: str | list[dict[str, Any]]
     tool_use_id: str | None = None
+    codex_reasoning_items: tuple[dict[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -131,6 +141,19 @@ class AdapterCallResult:
     so caller-side observability (token hooks, retry journals) can still extract
     provider-specific headers (Anthropic ``anthropic-priority-tier`` etc.)
     without bypassing the adapter.
+
+    ``reasoning_items`` (A2, v0.99.44): Codex backend emits encrypted reasoning
+    items (``{type: "reasoning", encrypted_content, summary?, id?}``) that the
+    next-turn ``input`` array must replay verbatim so gpt-5.x can resume its
+    chain of thought under ``store=False``. Codex adapters capture these from
+    ``response.output_item.done`` SSE events; non-Codex adapters leave the
+    tuple empty. The legacy bridge forwards this into
+    :attr:`core.llm.agentic_response.AgenticResponse.codex_reasoning_items`.
+
+    ``reasoning_summaries`` (A2, v0.99.44): Free-text reasoning summaries
+    surfaced for the live "thinking..." UI. Codex populates from
+    ``reasoning.summary[].text`` SSE events; Anthropic adapters populate from
+    ``thinking`` content blocks when available.
     """
 
     text: str
@@ -138,6 +161,8 @@ class AdapterCallResult:
     stop_reason: str
     tool_uses: tuple[dict[str, Any], ...] = ()
     raw_response: Any = None
+    reasoning_items: tuple[dict[str, Any], ...] = ()
+    reasoning_summaries: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/core/llm/adapters/codex_oauth.py
+++ b/core/llm/adapters/codex_oauth.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from core.llm.adapters._openai_common import (
     build_async_codex_client,
-    build_messages,
+    build_codex_input,
     translate_codex_response,
     translate_tool_for_codex,
 )
@@ -95,6 +95,15 @@ class CodexOAuthAdapter:
         We stream by default and aggregate the final response — non-streaming
         ``responses.create`` returns a structurally empty body on the Codex
         backend (the actual content arrives only via SSE events).
+
+        A2 (v0.99.44): the SSE accumulator now also captures ``type:
+        reasoning`` typed items (encrypted_content + summary) — Codex
+        gpt-5.x models lose their chain of thought on the next turn
+        unless those items are replayed in the next ``input`` array
+        (``store=False`` makes server-side resolution by id impossible).
+        :func:`translate_codex_response` surfaces them on
+        :attr:`AdapterCallResult.reasoning_items` and the legacy bridge
+        forwards them to :attr:`AgenticResponse.codex_reasoning_items`.
         """
         client = self._get_client()
         kwargs = _build_codex_call_kwargs(req)
@@ -107,13 +116,11 @@ class CodexOAuthAdapter:
                         if item is not None:
                             accumulated.append(item)
                 final = await stream.get_final_response()
-                if accumulated:
-                    final.output = accumulated
         except Exception as exc:
             self._last_error = exc
             log.warning("codex-oauth: responses.stream failed model=%s err=%s", req.model, exc)
             raise
-        return translate_codex_response(final)
+        return translate_codex_response(final, accumulated_items=accumulated)
 
     async def astream(self, req: AdapterCallRequest) -> AsyncIterator[StreamEvent]:
         client = self._get_client()
@@ -208,29 +215,34 @@ def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
     ``docs/research/codex-oauth-request-spec.md``):
 
     - ``instructions`` carries the system prompt (not ``input[].role:system``)
-    - ``input`` is the user/assistant/tool array; we drop the leading system
-      entry that :func:`build_messages` would prepend
+    - ``input`` is the user/assistant/tool array — built via
+      :func:`build_codex_input` which re-encodes Anthropic content blocks
+      into Codex typed items (``function_call`` / ``function_call_output``)
     - ``store=False`` is mandatory
     - ``max_output_tokens`` is FORBIDDEN — Plus subscription manages it
       server-side, sending the field returns 400
     - Tools use the FLAT shape (``translate_tool_for_codex``)
     - gpt-5.x family omits ``temperature`` and adds ``reasoning`` +
       ``include: ["reasoning.encrypted_content"]``
+    - A2 (v0.99.44): previous-turn reasoning items replay inline via
+      :func:`build_codex_input` — each assistant :class:`Message` carries
+      its own ``codex_reasoning_items`` (populated by the bridge from the
+      Anthropic-shape assistant message dict's ``codex_reasoning_items``
+      key) and ``build_codex_input`` prepends those entries at the
+      correct ordinal position. The legacy whole-input prepend approach
+      lost per-turn association for multi-assistant histories — Codex
+      MCP A2 BLOCKER 3.
     """
-    messages_payload = build_messages(req)
-    # Drop the system entry build_messages prepends — Codex needs it in
-    # ``instructions`` not in ``input``.
-    if req.system_prompt and messages_payload and messages_payload[0].get("role") == "system":
-        messages_payload = messages_payload[1:]
+    resp_input = build_codex_input(req)
     kwargs: dict[str, Any] = {
         "model": req.model,
         "instructions": req.system_prompt or "You are a helpful assistant.",
-        "input": messages_payload or [{"role": "user", "content": "hello"}],
+        "input": resp_input or [{"role": "user", "content": "hello"}],
         "store": False,
     }
     if req.tools:
         kwargs["tools"] = [translate_tool_for_codex(t) for t in req.tools]
-        kwargs["tool_choice"] = "auto"
+        kwargs["tool_choice"] = _translate_codex_tool_choice(req.tool_choice)
         kwargs["parallel_tool_calls"] = True
     if req.model.startswith("gpt-5"):
         # gpt-5.x family — encrypted reasoning passthrough; temperature omitted.
@@ -239,6 +251,23 @@ def _build_codex_call_kwargs(req: AdapterCallRequest) -> dict[str, Any]:
     elif req.temperature is not None:
         kwargs["temperature"] = req.temperature
     return kwargs
+
+
+def _translate_codex_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, Any]:
+    """Adapter-neutral ``tool_choice`` → Codex Responses API wire shape.
+
+    Routes through :func:`core.llm.tool_choice.normalize` with
+    ``provider="openai"`` — Responses API uses the FLAT shape
+    ``{"type": "function", "name": "..."}`` (not the Chat nested
+    ``function`` wrapper). The legacy helper accepts the Anthropic-shape
+    dicts the AgenticLoop emits (``{"type": "auto"}`` / ``{"type":
+    "none"}`` / ``{"type": "any"}`` / ``{"type": "tool", "name": "..."}``)
+    and returns the Codex-correct payload (Codex MCP A2 BLOCKER 2).
+    """
+    from core.llm.tool_choice import normalize
+
+    normalised = normalize("openai", tc)
+    return normalised if normalised is not None else "auto"
 
 
 __all__ = ["CodexOAuthAdapter"]

--- a/core/llm/adapters/glm_coding_plan.py
+++ b/core/llm/adapters/glm_coding_plan.py
@@ -1,14 +1,19 @@
-"""OpenAIPaygAdapter — PAYG (API-key) path to OpenAI models.
+"""GlmCodingPlanAdapter — Coding Plan (api/coding/paas/v4) subscription endpoint.
 
-Layer 3 adapter for OpenAI provider, source=payg. Owns its own
-``AsyncOpenAI`` client bound explicitly to ``OPENAI_API_KEY`` — bypasses the
-module-level singleton in ``core.llm.providers.openai`` which routes through
-``ProfileRotator`` and would prefer an OAuth profile if one existed. Codex
-MCP review 2026-05-23 flagged that singleton sharing as a BLOCKER for source
-isolation.
+Layer 3 adapter for the ``glm`` provider, source=subscription. ZhipuAI's
+Coding Plan binds an API key to a subscription that gets routed to the
+``api.z.ai/api/coding/paas/v4`` endpoint (distinct from PAYG's
+``/api/paas/v4``). Calling a Coding Plan key against the PAYG endpoint
+silently bypasses the subscription quota and incurs metered billing —
+that's why the picker / adapter source must be honoured.
 
-Pair with :class:`CodexOAuthAdapter` (same provider, OAuth path) and
-:class:`CodexCliAdapter` (subprocess path).
+The bound Plan API key is resolved via
+:func:`core.llm.providers.glm._resolve_glm_endpoint` which checks the
+GEODE ``ProfileStore`` for a ``glm-coding-*`` Plan registered via
+``/login``. PAYG fallback explicitly excluded — the picker source
+``subscription`` means subscription, not "best effort".
+
+Codex MCP A2 (v0.99.44) Follow-up F.
 """
 
 from __future__ import annotations
@@ -25,7 +30,7 @@ from core.llm.adapters._openai_common import (
     translate_tool,
 )
 from core.llm.adapters.base import (
-    SOURCE_PAYG,
+    SOURCE_SUBSCRIPTION,
     AdapterBillingType,
     AdapterCallRequest,
     AdapterCallResult,
@@ -40,28 +45,32 @@ log = logging.getLogger(__name__)
 
 
 @dataclass
-class OpenAIPaygAdapter:
-    """PAYG-routed OpenAI adapter — owns its own AsyncOpenAI client."""
+class GlmCodingPlanAdapter:
+    """Subscription-routed GLM adapter (Coding Plan endpoint).
 
-    name: str = "openai-payg"
-    provider: str = "openai"
-    source: str = SOURCE_PAYG
-    billing_type: AdapterBillingType = AdapterBillingType.API
+    Forces the Coding Plan binding from the ProfileStore — if no Plan
+    is registered (only PAYG api_key set), raises so the operator can't
+    silently fall back to PAYG when the picker resolved ``subscription``.
+    """
+
+    name: str = "glm-coding-plan"
+    provider: str = "glm"
+    source: str = SOURCE_SUBSCRIPTION
+    billing_type: AdapterBillingType = AdapterBillingType.SUBSCRIPTION
     _last_error: Exception | None = field(default=None, init=False, repr=False)
     _client: Any = field(default=None, init=False, repr=False)
 
     def _get_client(self) -> Any:
         if self._client is not None:
             return self._client
-        from core.config import settings
-
-        if not settings.openai_api_key:
+        api_key, base_url = _resolve_coding_plan_endpoint()
+        if not api_key:
             raise RuntimeError(
-                "OpenAIPaygAdapter: OPENAI_API_KEY not set. PAYG path requires "
-                "an explicit API key — set ``openai_api_key`` in settings or use "
-                "the codex-oauth / codex-cli adapter instead."
+                "GlmCodingPlanAdapter: no GLM Coding Plan profile registered. "
+                "Run ``/login glm-coding-pro`` (or the matching Plan slug) inside "
+                "GEODE, or use the glm-payg adapter for the metered PAYG path."
             )
-        self._client = build_async_openai_client(settings.openai_api_key)
+        self._client = build_async_openai_client(api_key, base_url=base_url)
         return self._client
 
     async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
@@ -75,7 +84,9 @@ class OpenAIPaygAdapter:
             kwargs["temperature"] = req.temperature
         if req.tools:
             kwargs["tools"] = [translate_tool(t) for t in req.tools]
-            tc = _translate_tool_choice(req.tool_choice)
+            from core.llm.tool_choice import normalize
+
+            tc = normalize("glm", req.tool_choice)
             if tc is not None:
                 kwargs["tool_choice"] = tc
         if req.stop_sequences:
@@ -85,7 +96,7 @@ class OpenAIPaygAdapter:
         except Exception as exc:
             self._last_error = exc
             log.warning(
-                "openai-payg: chat.completions.create failed model=%s err=%s",
+                "glm-coding-plan: chat.completions.create failed model=%s err=%s",
                 req.model,
                 exc,
             )
@@ -115,26 +126,28 @@ class OpenAIPaygAdapter:
                 yield StreamEvent(kind="stop", payload={"stop_reason": finish_reason})
 
     def test_environment(self) -> EnvironmentReport:
-        from core.config import settings
-
-        if not settings.openai_api_key:
+        api_key, base_url = _resolve_coding_plan_endpoint()
+        if not api_key:
             return EnvironmentReport(
                 ok=False,
-                checks=(("openai_api_key", "missing"),),
+                checks=(("glm_coding_plan_profile", "missing"),),
                 hints=(
-                    "Set ``OPENAI_API_KEY`` in your environment or in ~/.geode/config.toml.",
-                    "Or use codex-oauth (ChatGPT subscription) / codex-cli (local binary).",
+                    "Register a Coding Plan via ``/login glm-coding-pro`` inside GEODE.",
+                    "Or use glm-payg (PAYG api/paas/v4 endpoint).",
                 ),
             )
         return EnvironmentReport(
             ok=True,
-            checks=(("openai_api_key", f"set ({len(settings.openai_api_key)} chars)"),),
+            checks=(
+                ("glm_coding_plan_profile", f"key ({len(api_key)} chars)"),
+                ("endpoint", base_url),
+            ),
         )
 
     def list_models(self) -> list[ModelSpec]:
-        from core.config import OPENAI_FALLBACK_CHAIN, OPENAI_PRIMARY
+        from core.config import GLM_FALLBACK_CHAIN, GLM_PRIMARY
 
-        ids = [OPENAI_PRIMARY, *OPENAI_FALLBACK_CHAIN]
+        ids = [GLM_PRIMARY, *GLM_FALLBACK_CHAIN]
         seen: set[str] = set()
         models: list[ModelSpec] = []
         for mid in ids:
@@ -144,43 +157,49 @@ class OpenAIPaygAdapter:
             models.append(
                 ModelSpec(
                     id=mid,
-                    label=mid,
+                    label=f"{mid} (via Coding Plan)",
                     context_tokens=128_000,
-                    supports_thinking=mid.startswith(("o3", "o4")),
+                    supports_thinking=False,
                     supports_tools=True,
                 )
             )
         return models
 
     def get_quota_windows(self) -> QuotaWindows | None:
-        return None  # PAYG, metered per call
+        # GLM Coding Plan does not expose a programmatic quota surface yet.
+        return None
 
     def detect_credential(self) -> CredentialDetection | None:
-        from core.config import OPENAI_PRIMARY, settings
-
-        if not settings.openai_api_key:
+        api_key, base_url = _resolve_coding_plan_endpoint()
+        if not api_key:
             return None
+        from core.config import GLM_PRIMARY
+
         return CredentialDetection(
-            model=OPENAI_PRIMARY,
+            model=GLM_PRIMARY,
             provider=self.provider,
-            source_path="settings.openai_api_key",
+            source_path=f"ProfileStore (glm-coding-*) → {base_url}",
         )
 
 
-def _translate_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, Any] | None:
-    """Adapter-neutral ``tool_choice`` → Chat Completions wire shape.
+def _resolve_coding_plan_endpoint() -> tuple[str, str]:
+    """Return ``(api_key, base_url)`` for the registered Coding Plan, else
+    ``("", "")``.
 
-    Routes through :func:`core.llm.tool_choice.normalize` with
-    ``provider="glm"`` — Chat Completions uses the SAME nested
-    ``{"type": "function", "function": {"name": "..."}}`` shape that
-    GLM does. The legacy helper accepts the Anthropic-shape dicts the
-    AgenticLoop emits (``{"type": "auto"}`` / ``{"type": "none"}`` /
-    ``{"type": "any"}`` / ``{"type": "tool", "name": "..."}``) and
-    returns the Chat-correct payload (Codex MCP A2 BLOCKER 2).
+    Walks :func:`core.llm.routing.plan_registry.resolve_routing` for the
+    ``glm-coding-*`` Plan (the same path :func:`core.llm.providers.glm._resolve_glm_endpoint`
+    uses). If no Plan is bound, returns empty strings so the adapter
+    refuses rather than silently falling back to PAYG.
     """
-    from core.llm.tool_choice import normalize
+    try:
+        from core.llm.routing.plan_registry import resolve_routing
 
-    return normalize("glm", tc)
+        target = resolve_routing("glm-5.1")
+        if target is not None and target.profile.key:
+            return target.profile.key, target.base_url
+    except Exception:
+        log.debug("glm-coding-plan: ProfileStore lookup failed", exc_info=True)
+    return "", ""
 
 
-__all__ = ["OpenAIPaygAdapter"]
+__all__ = ["GlmCodingPlanAdapter"]

--- a/core/llm/adapters/glm_payg.py
+++ b/core/llm/adapters/glm_payg.py
@@ -1,14 +1,13 @@
-"""OpenAIPaygAdapter — PAYG (API-key) path to OpenAI models.
+"""GlmPaygAdapter — PAYG (api/paas/v4) endpoint for ZhipuAI GLM.
 
-Layer 3 adapter for OpenAI provider, source=payg. Owns its own
-``AsyncOpenAI`` client bound explicitly to ``OPENAI_API_KEY`` — bypasses the
-module-level singleton in ``core.llm.providers.openai`` which routes through
-``ProfileRotator`` and would prefer an OAuth profile if one existed. Codex
-MCP review 2026-05-23 flagged that singleton sharing as a BLOCKER for source
-isolation.
+Layer 3 adapter for the ``glm`` provider, source=payg. Uses
+``api.z.ai/api/paas/v4`` (PAYG, metered) with the API key in
+``settings.zai_api_key``. GLM speaks the OpenAI Chat Completions wire
+shape so the adapter reuses :mod:`core.llm.adapters._openai_common`
+helpers (``build_messages`` + ``translate_chat_response``).
 
-Pair with :class:`CodexOAuthAdapter` (same provider, OAuth path) and
-:class:`CodexCliAdapter` (subprocess path).
+Pair with :class:`GlmCodingPlanAdapter` (same provider, subscription
+``api/coding/paas/v4`` endpoint). Codex MCP A2 (v0.99.44) Follow-up F.
 """
 
 from __future__ import annotations
@@ -40,11 +39,19 @@ log = logging.getLogger(__name__)
 
 
 @dataclass
-class OpenAIPaygAdapter:
-    """PAYG-routed OpenAI adapter — owns its own AsyncOpenAI client."""
+class GlmPaygAdapter:
+    """PAYG-routed GLM adapter (api/paas/v4 endpoint).
 
-    name: str = "openai-payg"
-    provider: str = "openai"
+    Owns its own ``AsyncOpenAI`` client bound explicitly to
+    ``settings.zai_api_key`` + :data:`core.config.GLM_PAYG_BASE_URL` so a
+    subscription Coding Plan profile in :class:`ProfileStore` cannot
+    silently shadow the PAYG path (mirrors the
+    :class:`AnthropicPaygAdapter` isolation pattern — Codex MCP
+    2026-05-23 BLOCKER).
+    """
+
+    name: str = "glm-payg"
+    provider: str = "glm"
     source: str = SOURCE_PAYG
     billing_type: AdapterBillingType = AdapterBillingType.API
     _last_error: Exception | None = field(default=None, init=False, repr=False)
@@ -53,15 +60,15 @@ class OpenAIPaygAdapter:
     def _get_client(self) -> Any:
         if self._client is not None:
             return self._client
-        from core.config import settings
+        from core.config import GLM_PAYG_BASE_URL, settings
 
-        if not settings.openai_api_key:
+        if not settings.zai_api_key:
             raise RuntimeError(
-                "OpenAIPaygAdapter: OPENAI_API_KEY not set. PAYG path requires "
-                "an explicit API key — set ``openai_api_key`` in settings or use "
-                "the codex-oauth / codex-cli adapter instead."
+                "GlmPaygAdapter: ZAI_API_KEY not set. PAYG path requires "
+                "an explicit API key — set ``zai_api_key`` in settings or use "
+                "the glm-coding-plan adapter (subscription endpoint) instead."
             )
-        self._client = build_async_openai_client(settings.openai_api_key)
+        self._client = build_async_openai_client(settings.zai_api_key, base_url=GLM_PAYG_BASE_URL)
         return self._client
 
     async def acomplete(self, req: AdapterCallRequest) -> AdapterCallResult:
@@ -85,7 +92,7 @@ class OpenAIPaygAdapter:
         except Exception as exc:
             self._last_error = exc
             log.warning(
-                "openai-payg: chat.completions.create failed model=%s err=%s",
+                "glm-payg: chat.completions.create failed model=%s err=%s",
                 req.model,
                 exc,
             )
@@ -117,24 +124,24 @@ class OpenAIPaygAdapter:
     def test_environment(self) -> EnvironmentReport:
         from core.config import settings
 
-        if not settings.openai_api_key:
+        if not settings.zai_api_key:
             return EnvironmentReport(
                 ok=False,
-                checks=(("openai_api_key", "missing"),),
+                checks=(("zai_api_key", "missing"),),
                 hints=(
-                    "Set ``OPENAI_API_KEY`` in your environment or in ~/.geode/config.toml.",
-                    "Or use codex-oauth (ChatGPT subscription) / codex-cli (local binary).",
+                    "Set ``ZAI_API_KEY`` in your environment or in ~/.geode/config.toml.",
+                    "Or use glm-coding-plan (Coding Plan subscription).",
                 ),
             )
         return EnvironmentReport(
             ok=True,
-            checks=(("openai_api_key", f"set ({len(settings.openai_api_key)} chars)"),),
+            checks=(("zai_api_key", f"set ({len(settings.zai_api_key)} chars)"),),
         )
 
     def list_models(self) -> list[ModelSpec]:
-        from core.config import OPENAI_FALLBACK_CHAIN, OPENAI_PRIMARY
+        from core.config import GLM_FALLBACK_CHAIN, GLM_PRIMARY
 
-        ids = [OPENAI_PRIMARY, *OPENAI_FALLBACK_CHAIN]
+        ids = [GLM_PRIMARY, *GLM_FALLBACK_CHAIN]
         seen: set[str] = set()
         models: list[ModelSpec] = []
         for mid in ids:
@@ -146,41 +153,38 @@ class OpenAIPaygAdapter:
                     id=mid,
                     label=mid,
                     context_tokens=128_000,
-                    supports_thinking=mid.startswith(("o3", "o4")),
+                    supports_thinking=False,
                     supports_tools=True,
                 )
             )
         return models
 
     def get_quota_windows(self) -> QuotaWindows | None:
-        return None  # PAYG, metered per call
+        return None  # PAYG metered per-call
 
     def detect_credential(self) -> CredentialDetection | None:
-        from core.config import OPENAI_PRIMARY, settings
+        from core.config import GLM_PRIMARY, settings
 
-        if not settings.openai_api_key:
+        if not settings.zai_api_key:
             return None
         return CredentialDetection(
-            model=OPENAI_PRIMARY,
+            model=GLM_PRIMARY,
             provider=self.provider,
-            source_path="settings.openai_api_key",
+            source_path="settings.zai_api_key",
         )
 
 
 def _translate_tool_choice(tc: str | dict[str, Any]) -> str | dict[str, Any] | None:
-    """Adapter-neutral ``tool_choice`` → Chat Completions wire shape.
+    """Adapter-neutral ``tool_choice`` → GLM Chat Completions wire shape.
 
-    Routes through :func:`core.llm.tool_choice.normalize` with
-    ``provider="glm"`` — Chat Completions uses the SAME nested
-    ``{"type": "function", "function": {"name": "..."}}`` shape that
-    GLM does. The legacy helper accepts the Anthropic-shape dicts the
-    AgenticLoop emits (``{"type": "auto"}`` / ``{"type": "none"}`` /
-    ``{"type": "any"}`` / ``{"type": "tool", "name": "..."}``) and
-    returns the Chat-correct payload (Codex MCP A2 BLOCKER 2).
+    GLM is OpenAI-compatible (Chat Completions nested ``function`` shape).
+    Reuses the GLM helper in :func:`core.llm.tool_choice.normalize` to
+    accept the AgenticLoop's Anthropic-shape dicts (``{"type": "auto"}``
+    etc.).
     """
     from core.llm.tool_choice import normalize
 
     return normalize("glm", tc)
 
 
-__all__ = ["OpenAIPaygAdapter"]
+__all__ = ["GlmPaygAdapter"]

--- a/core/llm/adapters/registry.py
+++ b/core/llm/adapters/registry.py
@@ -127,17 +127,22 @@ def resolve_for(provider: str, source: str) -> LLMAdapter:
 
 
 def bootstrap_builtins() -> None:
-    """Register the 6 built-in adapters.
+    """Register the 8 built-in adapters.
 
     Called from ``core/runtime.py`` during process bootstrap. Idempotent —
     re-registration is a no-op (logs at debug level). Mirrors paperclip's
     ``initializeBuiltinAdapters`` startup hook.
+
+    v0.99.44 — Follow-up F adds the two GLM adapters (PAYG /api/paas/v4
+    + Coding Plan /api/coding/paas/v4 subscription endpoint).
     """
     from core.llm.adapters.anthropic_oauth import AnthropicOAuthAdapter
     from core.llm.adapters.anthropic_payg import AnthropicPaygAdapter
     from core.llm.adapters.claude_cli import ClaudeCliAdapter
     from core.llm.adapters.codex_cli import CodexCliAdapter
     from core.llm.adapters.codex_oauth import CodexOAuthAdapter
+    from core.llm.adapters.glm_coding_plan import GlmCodingPlanAdapter
+    from core.llm.adapters.glm_payg import GlmPaygAdapter
     from core.llm.adapters.openai_payg import OpenAIPaygAdapter
 
     for adapter_cls in (
@@ -147,6 +152,8 @@ def bootstrap_builtins() -> None:
         OpenAIPaygAdapter,
         CodexOAuthAdapter,
         CodexCliAdapter,
+        GlmPaygAdapter,
+        GlmCodingPlanAdapter,
     ):
         instance = adapter_cls()
         if instance.name in _REGISTRY:

--- a/tests/core/agent/test_agent_loop_source_route.py
+++ b/tests/core/agent/test_agent_loop_source_route.py
@@ -64,11 +64,14 @@ def test_concrete_source_each_anthropic_variant() -> None:
         assert loop._new_adapter.name == expected_name
 
 
-def test_non_anthropic_provider_skips_new_adapter() -> None:
-    """A2 follow-up scope — OpenAI/Codex providers still use legacy."""
+def test_openai_provider_attaches_new_adapter() -> None:
+    """A2 (v0.99.44) — OpenAI providers now resolve through the adapter
+    registry too. Pre-A2 the route was Anthropic-only; A2 ported the
+    multi-turn converters + Codex reasoning replay so the guard is gone."""
     loop = _make_loop(source="payg", provider="openai")
-    assert loop._new_adapter is None  # not yet on adapter route
-    assert loop._adapter is not None  # legacy path
+    assert loop._new_adapter is not None
+    assert loop._new_adapter.name == "openai-payg"
+    assert loop._adapter is not None  # legacy adapter still wired as fallback
 
 
 def test_unregistered_pair_hard_fails() -> None:

--- a/tests/core/llm/adapters/test_builtin_identity.py
+++ b/tests/core/llm/adapters/test_builtin_identity.py
@@ -1,4 +1,4 @@
-"""Identity invariants for each of the 6 built-in adapters.
+"""Identity invariants for each of the 8 built-in adapters.
 
 These tests pin the (name, provider, source, billing_type) tuple for each
 shipped adapter. They DO NOT exercise the actual SDK / subprocess call path —
@@ -9,6 +9,8 @@ follow-up PRs.
 The invariants here guard against accidental rename (e.g. ``claude-cli`` →
 ``anthropic-cli``) which would silently break operator overrides and the UI's
 adapter list.
+
+v0.99.44 — Follow-up F adds the two GLM adapters (PAYG + Coding Plan).
 """
 
 from __future__ import annotations
@@ -20,6 +22,8 @@ from core.llm.adapters.base import AdapterBillingType
 from core.llm.adapters.claude_cli import ClaudeCliAdapter
 from core.llm.adapters.codex_cli import CodexCliAdapter
 from core.llm.adapters.codex_oauth import CodexOAuthAdapter
+from core.llm.adapters.glm_coding_plan import GlmCodingPlanAdapter
+from core.llm.adapters.glm_payg import GlmPaygAdapter
 from core.llm.adapters.openai_payg import OpenAIPaygAdapter
 
 
@@ -56,6 +60,14 @@ from core.llm.adapters.openai_payg import OpenAIPaygAdapter
             "adapter",
             AdapterBillingType.SUBSCRIPTION_INCLUDED,
         ),
+        (GlmPaygAdapter, "glm-payg", "glm", "payg", AdapterBillingType.API),
+        (
+            GlmCodingPlanAdapter,
+            "glm-coding-plan",
+            "glm",
+            "subscription",
+            AdapterBillingType.SUBSCRIPTION,
+        ),
     ],
 )
 def test_adapter_identity(
@@ -85,6 +97,8 @@ def test_test_environment_returns_report() -> None:
         OpenAIPaygAdapter,
         CodexOAuthAdapter,
         CodexCliAdapter,
+        GlmPaygAdapter,
+        GlmCodingPlanAdapter,
     ):
         report = cls().test_environment()
         # Either ok=True with credentials available, or ok=False with hints.
@@ -100,6 +114,8 @@ def test_list_models_returns_specs() -> None:
         OpenAIPaygAdapter,
         CodexOAuthAdapter,
         CodexCliAdapter,
+        GlmPaygAdapter,
+        GlmCodingPlanAdapter,
     ):
         models = cls().list_models()
         assert models, f"{cls.__name__}: list_models returned empty list"

--- a/tests/core/llm/adapters/test_codex_reasoning_replay.py
+++ b/tests/core/llm/adapters/test_codex_reasoning_replay.py
@@ -1,0 +1,277 @@
+"""A2 Codex reasoning replay invariants.
+
+Codex backend gpt-5.x family runs with ``store=False`` so the server cannot
+resolve reasoning items by id on subsequent turns. The adapter chain must:
+
+1. Capture ``type: reasoning`` typed items from ``response.output_item.done``
+   SSE events on the current turn.
+2. Surface them on ``AdapterCallResult.reasoning_items``.
+3. The legacy bridge forwards them to ``AgenticResponse.codex_reasoning_items``.
+4. The next-turn ``build_adapter_request`` reads each assistant message
+   dict's ``codex_reasoning_items`` annotation (set by the AgenticLoop on
+   the assistant turn that emitted them) and attaches the tuple to that
+   :class:`Message`'s ``codex_reasoning_items`` field — preserving the
+   per-turn association.
+5. ``build_codex_input`` walks the messages and, for each assistant
+   Message, inserts the reasoning entries (id-stripped) IMMEDIATELY
+   BEFORE the assistant's converted entries — so the next-turn ``input``
+   array reads ``user → reasoning → assistant → user → reasoning →
+   assistant`` exactly like the legacy provider does.
+
+Without any link in this chain the model loses its chain of thought.
+The pre-A2 redesign attempted to flatten reasoning into a single
+``provider_options["reasoning_items"]`` tuple and prepend it once at the
+head of ``input`` — Codex MCP A2 BLOCKER 3 flagged this as losing
+position for multi-assistant histories.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from core.llm.adapters._legacy_bridge import (
+    agentic_response_from_adapter_result,
+    build_adapter_request,
+)
+from core.llm.adapters._openai_common import translate_codex_response
+from core.llm.adapters.base import AdapterCallResult, UsageSummary
+from core.llm.adapters.codex_oauth import _build_codex_call_kwargs
+
+
+def test_translate_codex_response_extracts_reasoning_items() -> None:
+    """SSE-accumulated typed items → AdapterCallResult.reasoning_items."""
+    accumulated = [
+        SimpleNamespace(
+            type="reasoning",
+            id="rs_1",
+            encrypted_content="blob_1",
+            summary=[SimpleNamespace(type="summary_text", text="thought 1")],
+        ),
+        SimpleNamespace(
+            type="function_call",
+            id="fc_1",
+            call_id="call_1",
+            name="search",
+            arguments='{"q":"geode"}',
+        ),
+    ]
+    response = SimpleNamespace(
+        output_text="response text",
+        output=accumulated,
+        status="completed",
+        usage=SimpleNamespace(input_tokens=100, output_tokens=20),
+    )
+    result = translate_codex_response(response, accumulated_items=accumulated)
+    assert len(result.reasoning_items) == 1
+    assert result.reasoning_items[0]["encrypted_content"] == "blob_1"
+    assert result.reasoning_summaries == ("thought 1",)
+    assert len(result.tool_uses) == 1
+    assert result.tool_uses[0]["name"] == "search"
+
+
+def test_translate_codex_response_function_call_id_prefers_call_id() -> None:
+    """Codex MCP A2 BLOCKER 1: ``call_id`` MUST win over ``id`` so the
+    next-turn ``function_call_output`` pairs correctly. Pre-fix
+    ``id or call_id`` would emit ``fc_*`` and break pairing."""
+    accumulated = [
+        SimpleNamespace(
+            type="function_call",
+            id="fc_internal_999",
+            call_id="call_durable_42",
+            name="search",
+            arguments='{"q":"x"}',
+        ),
+    ]
+    response = SimpleNamespace(
+        output_text="",
+        output=accumulated,
+        status="completed",
+        usage=SimpleNamespace(input_tokens=0, output_tokens=0),
+    )
+    result = translate_codex_response(response, accumulated_items=accumulated)
+    assert result.tool_uses[0]["id"] == "call_durable_42"
+
+
+def test_translate_codex_response_no_reasoning() -> None:
+    """A non-gpt-5.x response without reasoning items → empty reasoning fields."""
+    response = SimpleNamespace(
+        output_text="hi",
+        output=[],
+        status="completed",
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+    )
+    result = translate_codex_response(response, accumulated_items=[])
+    assert result.reasoning_items == ()
+    assert result.reasoning_summaries == ()
+
+
+def test_legacy_bridge_forwards_reasoning_items() -> None:
+    """AdapterCallResult.reasoning_items → AgenticResponse.codex_reasoning_items."""
+    result = AdapterCallResult(
+        text="hi",
+        usage=UsageSummary(),
+        stop_reason="completed",
+        reasoning_items=(
+            {"type": "reasoning", "encrypted_content": "blob_1"},
+            {"type": "reasoning", "encrypted_content": "blob_2"},
+        ),
+        reasoning_summaries=("thought 1", "thought 2"),
+    )
+    resp = agentic_response_from_adapter_result(result)
+    assert resp.codex_reasoning_items is not None
+    assert len(resp.codex_reasoning_items) == 2
+    assert resp.codex_reasoning_items[0]["encrypted_content"] == "blob_1"
+    assert resp.reasoning_summaries == ["thought 1", "thought 2"]
+
+
+def test_legacy_bridge_empty_reasoning_to_none() -> None:
+    """No reasoning items → AgenticResponse fields stay ``None``."""
+    result = AdapterCallResult(text="hi", usage=UsageSummary(), stop_reason="end_turn")
+    resp = agentic_response_from_adapter_result(result)
+    assert resp.codex_reasoning_items is None
+    assert resp.reasoning_summaries is None
+
+
+def test_build_adapter_request_attaches_reasoning_per_assistant_message() -> None:
+    """Assistant messages with ``codex_reasoning_items`` set → per-Message
+    ``codex_reasoning_items`` tuple (NOT flattened to provider_options)."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "thinking 1",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "blob_1"},
+            ],
+        },
+        {"role": "user", "content": "go on"},
+        {
+            "role": "assistant",
+            "content": "thinking 2",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "blob_2"},
+            ],
+        },
+    ]
+    req = build_adapter_request(
+        model="gpt-5.5",
+        system="be brief",
+        messages=messages,
+        tools=[],
+        tool_choice="auto",
+        max_tokens=4096,
+        temperature=0.0,
+        thinking_budget=0,
+        effort="medium",
+    )
+    # Per-Message attachment — each assistant Message carries its own
+    # reasoning items.
+    assert req.messages[1].role == "assistant"
+    assert len(req.messages[1].codex_reasoning_items) == 1
+    assert req.messages[1].codex_reasoning_items[0]["encrypted_content"] == "blob_1"
+    assert req.messages[3].role == "assistant"
+    assert req.messages[3].codex_reasoning_items[0]["encrypted_content"] == "blob_2"
+    # User messages carry empty tuple (default).
+    assert req.messages[0].codex_reasoning_items == ()
+    assert req.messages[2].codex_reasoning_items == ()
+
+
+def test_codex_call_kwargs_replays_reasoning_at_assistant_turn() -> None:
+    """``_build_codex_call_kwargs`` (via build_codex_input) prepends
+    reasoning items at the matching assistant's ordinal position."""
+    from core.llm.adapters.base import AdapterCallRequest, Message
+
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        system_prompt="be brief",
+        messages=[
+            Message(role="user", content="first"),
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "answer 1"}],
+                codex_reasoning_items=(
+                    {"type": "reasoning", "encrypted_content": "blob_prior", "id": "rs_1"},
+                ),
+            ),
+            Message(role="user", content="next"),
+        ],
+    )
+    kwargs = _build_codex_call_kwargs(req)
+    # Sequence: user1, reasoning_for_assistant1, assistant1, user2
+    assert kwargs["input"][0] == {"role": "user", "content": "first"}
+    assert kwargs["input"][1]["type"] == "reasoning"
+    assert kwargs["input"][1]["encrypted_content"] == "blob_prior"
+    assert "id" not in kwargs["input"][1]
+    assert kwargs["input"][2] == {"role": "assistant", "content": "answer 1"}
+    assert kwargs["input"][3] == {"role": "user", "content": "next"}
+
+
+def test_codex_call_kwargs_no_reasoning_when_empty() -> None:
+    """Without prior reasoning, input has no synthetic reasoning entry."""
+    from core.llm.adapters.base import AdapterCallRequest, Message
+
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        system_prompt="be brief",
+        messages=[Message(role="user", content="hello")],
+    )
+    kwargs = _build_codex_call_kwargs(req)
+    assert kwargs["input"][0] == {"role": "user", "content": "hello"}
+
+
+@pytest.mark.parametrize(
+    ("tool_choice", "expected"),
+    [
+        ("auto", "auto"),
+        ("none", "none"),
+        ("required", "required"),
+        ("any", "required"),  # adapter-neutral "any" → "required"
+        # AgenticLoop dict shapes (Anthropic-flavored)
+        ({"type": "auto"}, "auto"),
+        ({"type": "none"}, "none"),
+        ({"type": "any"}, "required"),
+        # forced tool: Anthropic shape → Codex flat shape
+        (
+            {"type": "tool", "name": "search"},
+            {"type": "function", "name": "search"},
+        ),
+    ],
+)
+def test_codex_call_kwargs_tool_choice_translation(
+    tool_choice: str | dict, expected: str | dict
+) -> None:
+    from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
+
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        system_prompt="x",
+        messages=[Message(role="user", content="y")],
+        tools=[ToolSpec(name="t", description="", input_schema={"type": "object"})],
+        tool_choice=tool_choice,
+    )
+    kwargs = _build_codex_call_kwargs(req)
+    assert kwargs["tool_choice"] == expected
+
+
+@pytest.mark.parametrize(
+    ("tool_choice", "expected"),
+    [
+        ("auto", "auto"),
+        ("none", "none"),
+        ("required", "required"),
+        ({"type": "auto"}, "auto"),
+        ({"type": "none"}, "none"),
+        ({"type": "any"}, "required"),
+        # forced tool: Anthropic shape → Chat nested shape
+        (
+            {"type": "tool", "name": "search"},
+            {"type": "function", "function": {"name": "search"}},
+        ),
+    ],
+)
+def test_chat_tool_choice_translation(tool_choice: str | dict, expected: str | dict) -> None:
+    """OpenAI Chat Completions tool_choice translation (BLOCKER 2 fix)."""
+    from core.llm.adapters.openai_payg import _translate_tool_choice
+
+    assert _translate_tool_choice(tool_choice) == expected

--- a/tests/core/llm/adapters/test_openai_multi_turn.py
+++ b/tests/core/llm/adapters/test_openai_multi_turn.py
@@ -1,0 +1,224 @@
+"""A2 multi-turn converter invariants — Anthropic content blocks ↔ OpenAI/Codex wire shape.
+
+Pins the round-trip contract that Codex MCP 2026-05-23 BLOCKER 2 flagged:
+the AgenticLoop emits assistant turns with ``tool_use`` blocks and user
+turns with ``tool_result`` blocks (Anthropic shape). The OpenAI/Codex
+adapter route re-encodes these into:
+
+- OpenAI Chat: ``tool_calls`` array on assistant + ``role: tool`` with
+  ``tool_call_id`` on user.
+- Codex Responses: ``function_call`` / ``function_call_output`` typed
+  items in the ``input`` array.
+
+Without this conversion the SDK rejects with 400.
+"""
+
+from __future__ import annotations
+
+import json
+
+from core.llm.adapters._openai_common import (
+    _convert_assistant_msg_to_chat,
+    _convert_assistant_msg_to_responses,
+    _convert_user_msg_to_chat,
+    _convert_user_msg_to_responses,
+    build_codex_input,
+    build_messages,
+)
+from core.llm.adapters.base import AdapterCallRequest, Message
+
+# ── Chat Completions converter ─────────────────────────────────────────────
+
+
+def test_chat_assistant_text_only() -> None:
+    msg = _convert_assistant_msg_to_chat([{"type": "text", "text": "hello"}])
+    assert msg == {"role": "assistant", "content": "hello"}
+
+
+def test_chat_assistant_tool_use() -> None:
+    msg = _convert_assistant_msg_to_chat(
+        [
+            {"type": "text", "text": "calling search"},
+            {"type": "tool_use", "id": "tu_1", "name": "search", "input": {"q": "geode"}},
+        ]
+    )
+    assert msg["role"] == "assistant"
+    assert msg["content"] == "calling search"
+    assert msg["tool_calls"] == [
+        {
+            "id": "tu_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": json.dumps({"q": "geode"})},
+        }
+    ]
+
+
+def test_chat_assistant_tool_use_only_no_text() -> None:
+    """When the assistant turn only emits tool_use, ``content`` is ``None``."""
+    msg = _convert_assistant_msg_to_chat(
+        [{"type": "tool_use", "id": "tu_1", "name": "x", "input": {}}]
+    )
+    assert msg["content"] is None
+    assert len(msg["tool_calls"]) == 1
+
+
+def test_chat_user_tool_result_splits_to_tool_role() -> None:
+    msgs = _convert_user_msg_to_chat(
+        [
+            {"type": "tool_result", "tool_use_id": "tu_1", "content": "42"},
+            {"type": "text", "text": "thanks"},
+        ]
+    )
+    # tool_result → {"role": "tool", "tool_call_id": ..., "content": ...}
+    assert msgs[0] == {"role": "tool", "tool_call_id": "tu_1", "content": "42"}
+    # trailing text becomes a separate user message
+    assert msgs[1] == {"role": "user", "content": "thanks"}
+
+
+def test_chat_user_tool_result_dict_content_json_encoded() -> None:
+    """Dict tool_result content stringifies to JSON for Chat's content field."""
+    msgs = _convert_user_msg_to_chat(
+        [{"type": "tool_result", "tool_use_id": "tu_1", "content": {"k": "v"}}]
+    )
+    assert msgs[0]["content"] == json.dumps({"k": "v"})
+
+
+def test_build_messages_handles_anthropic_content_lists() -> None:
+    """End-to-end: AdapterCallRequest with Anthropic-shaped messages."""
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        system_prompt="be brief",
+        messages=[
+            Message(role="user", content="search geode"),
+            Message(
+                role="assistant",
+                content=[{"type": "tool_use", "id": "tu_1", "name": "search", "input": {}}],
+            ),
+            Message(
+                role="user",
+                content=[{"type": "tool_result", "tool_use_id": "tu_1", "content": "found"}],
+            ),
+        ],
+    )
+    msgs = build_messages(req)
+    assert msgs[0] == {"role": "system", "content": "be brief"}
+    assert msgs[1] == {"role": "user", "content": "search geode"}
+    assert msgs[2]["role"] == "assistant"
+    assert msgs[2]["tool_calls"][0]["id"] == "tu_1"
+    assert msgs[3] == {"role": "tool", "tool_call_id": "tu_1", "content": "found"}
+
+
+# ── Codex Responses converter ──────────────────────────────────────────────
+
+
+def test_responses_assistant_tool_use_typed_item() -> None:
+    items = _convert_assistant_msg_to_responses(
+        [
+            {"type": "text", "text": "thinking..."},
+            {"type": "tool_use", "id": "tu_1", "name": "search", "input": {"q": "x"}},
+        ]
+    )
+    # text item comes first (preserving order from Anthropic block stream)
+    assert items[0] == {"role": "assistant", "content": "thinking..."}
+    assert items[1] == {
+        "type": "function_call",
+        "call_id": "tu_1",
+        "name": "search",
+        "arguments": json.dumps({"q": "x"}),
+    }
+
+
+def test_responses_user_tool_result_typed_item() -> None:
+    items = _convert_user_msg_to_responses(
+        [
+            {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"},
+        ]
+    )
+    assert items[0] == {"type": "function_call_output", "call_id": "tu_1", "output": "ok"}
+
+
+def test_responses_user_tool_result_dict_content_json_encoded() -> None:
+    items = _convert_user_msg_to_responses(
+        [{"type": "tool_result", "tool_use_id": "tu_1", "content": {"k": "v"}}]
+    )
+    assert items[0]["output"] == json.dumps({"k": "v"})
+
+
+def test_build_codex_input_skips_system_prepend() -> None:
+    """Codex carries system via ``instructions`` kwarg — build_codex_input must NOT
+    prepend a ``role: system`` entry."""
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        system_prompt="be brief",
+        messages=[Message(role="user", content="hi")],
+    )
+    items = build_codex_input(req)
+    assert all(item.get("role") != "system" for item in items)
+    assert items[0] == {"role": "user", "content": "hi"}
+
+
+# ── Per-turn reasoning replay (inline via build_codex_input) ──────────────
+
+
+def test_build_codex_input_inserts_reasoning_at_assistant_turn() -> None:
+    """codex_reasoning_items on an assistant Message prepend at THAT turn."""
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        messages=[
+            Message(role="user", content="first"),
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "reply 1"}],
+                codex_reasoning_items=(
+                    {"type": "reasoning", "encrypted_content": "blob_1", "id": "rs_1"},
+                ),
+            ),
+            Message(role="user", content="second"),
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "reply 2"}],
+                codex_reasoning_items=({"type": "reasoning", "encrypted_content": "blob_2"},),
+            ),
+        ],
+    )
+    items = build_codex_input(req)
+    # Sequence: user1, reasoning_1, assistant1, user2, reasoning_2, assistant2
+    assert items[0] == {"role": "user", "content": "first"}
+    assert items[1]["type"] == "reasoning"
+    assert items[1]["encrypted_content"] == "blob_1"
+    assert "id" not in items[1]  # id stripped
+    assert items[2] == {"role": "assistant", "content": "reply 1"}
+    assert items[3] == {"role": "user", "content": "second"}
+    assert items[4]["type"] == "reasoning"
+    assert items[4]["encrypted_content"] == "blob_2"
+    assert items[5] == {"role": "assistant", "content": "reply 2"}
+
+
+def test_build_codex_input_skips_reasoning_without_encrypted_content() -> None:
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        messages=[
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "reply"}],
+                codex_reasoning_items=({"type": "reasoning", "summary": "no blob"},),
+            ),
+        ],
+    )
+    items = build_codex_input(req)
+    # No reasoning item before assistant — only the assistant entry.
+    assert items == [{"role": "assistant", "content": "reply"}]
+
+
+def test_build_codex_input_no_reasoning_when_empty_tuple() -> None:
+    req = AdapterCallRequest(
+        model="gpt-5.5",
+        messages=[
+            Message(
+                role="assistant",
+                content=[{"type": "text", "text": "reply"}],
+            ),
+        ],
+    )
+    items = build_codex_input(req)
+    assert items == [{"role": "assistant", "content": "reply"}]

--- a/tests/core/llm/adapters/test_registry.py
+++ b/tests/core/llm/adapters/test_registry.py
@@ -145,7 +145,7 @@ def test_resolve_for_duplicate_pair_raises() -> None:
         resolve_for("anthropic", SOURCE_PAYG)
 
 
-def test_bootstrap_builtins_registers_six() -> None:
+def test_bootstrap_builtins_registers_eight() -> None:
     bootstrap_builtins()
     names = {a.name for a in list_adapters()}
     assert names == {
@@ -155,13 +155,15 @@ def test_bootstrap_builtins_registers_six() -> None:
         "openai-payg",
         "codex-oauth",
         "codex-cli",
+        "glm-payg",
+        "glm-coding-plan",
     }
 
 
 def test_bootstrap_builtins_idempotent() -> None:
     bootstrap_builtins()
     bootstrap_builtins()  # Second call must not raise.
-    assert len(list_adapters()) == 6
+    assert len(list_adapters()) == 8
 
 
 def test_bootstrap_builtins_provider_source_pairs() -> None:
@@ -174,6 +176,8 @@ def test_bootstrap_builtins_provider_source_pairs() -> None:
         ("openai", "payg"),
         ("openai", "subscription"),
         ("openai", "adapter"),
+        ("glm", "payg"),
+        ("glm", "subscription"),
     }
 
 


### PR DESCRIPTION
## Summary

- **A2** closes the 2 Codex MCP findings (BLOCKER 2 + HIGH 1) deferred from #1519 — OpenAI Chat + Codex Responses multi-turn translation + encrypted-reasoning replay. AgenticLoop's ``provider == "anthropic"`` guard removed; concrete source now resolves on all providers.
- **F** lands the GLM adapter family — ``glm-payg`` (api/paas/v4) + ``glm-coding-plan`` (api/coding/paas/v4 subscription). Picker source diversity now anthropic + openai + glm 3-provider full grid (8 built-in adapters total).

## Why

A2: PR #1519's adapter route was Anthropic-only because the OpenAI/Codex bridge would have shipped broken — assistant ``tool_use`` blocks weren't re-encoded into ``tool_calls`` / ``function_call`` items, and Codex gpt-5.x lost its encrypted reasoning across turns. This PR ports the converters from ``core/llm/providers/openai.py`` to the adapter layer and threads reasoning items per-assistant-Message so the next-turn ordering preserves ``user → reasoning → assistant`` invariant.

F: GLM 3-provider grid was the last gap before the picker can drive cross-provider 3-judge panels with full diversity (Anthropic + OpenAI + GLM).

## Codex MCP review chain

| Round | Findings | Resolution |
|---|---|---|
| #1 (019e53e0) | BLOCKER 1 (call_id), BLOCKER 2 (tool_choice dict), BLOCKER 3 (reasoning position) | All fixed inline; 3 invariant tests added |
| #2 (019e53e9) | No new issues | clean |

## Verification

- [x] ruff format / check clean
- [x] mypy clean (462 source files)
- [x] lint-imports clean
- [x] 35+ new adapter tests pass; full pytest suite green (one petri_audit test fails on this local worktree due to "openai-codex" substring leaking into the path-printed command line — false positive that disappears on CI runners whose worktree path doesn't contain that string).

## Reference

- Plan: docs/plans/2026-05-23-llm-adapter-abstraction.md § Scope cut (A2 + F)
- Parent: PR #1519 (Follow-up A — Anthropic-only adapter route)
- Codex MCP threads: 019e53e0-9499-7f50-b69e-82f0e73d68ae, 019e53e9-1779-7e02-8922-65a5cd20e095

🤖 Generated with [Claude Code](https://claude.com/claude-code)