### PR TITLE
release: v0.99.44 — A2 OpenAI/Codex closure + F GLM family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.44] - 2026-05-23
+
 ### Added
 
 - **Follow-up F — GLM adapter family.** Two new built-ins land the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.43
+- **Version**: 0.99.44
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.43 — Long-running Autonomous Execution Harness
+# GEODE v0.99.44 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.43**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.44**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.43 — Long-running Autonomous Execution Harness
+# GEODE v0.99.44 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.43**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.44**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.43"
+version = "0.99.44"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- A2 OpenAI/Codex adapter route closure — Removes the `provider == "anthropic"` guard on `AgenticLoop.__init__`; ports multi-turn Chat + Responses converters into `_openai_common`; per-Message Codex encrypted-reasoning replay closes BLOCKER 2 + HIGH 1 from PR #1519's Codex MCP review
- F GLM adapter family — Two new built-ins (`glm-payg` calls PAYG `api/paas/v4`; `glm-coding-plan` resolves a Coding Plan profile then calls `api/coding/paas/v4`); both share `build_async_openai_client` and route `tool_choice` through `normalize("glm", ...)` for the Chat nested wire shape
- PR-CL-BUDGET — 2-hour wall-clock cap + automatic T-10min hand-off (Cognitive Loop foundation; carried in from PR #1537)

## Verification

- [x] Local lint/type/test gates green on each contributing PR
- [x] Version stamps synced across CHANGELOG.md / CLAUDE.md / README.md / README.ko.md / pyproject.toml
- [x] CHANGELOG `[Unreleased]` cut to `[0.99.44] - 2026-05-23`