### PR TITLE
step I.a — collapse Codex OAuth header construction onto one helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,25 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Step I.a — Codex OAuth header construction collapsed onto one helper.**
+  Four call sites built the same
+  ``{"originator": "codex_cli_rs", "ChatGPT-Account-ID": <jwt-claim>}`` dict
+  inline: ``core.llm.providers.codex._get_codex_client`` /
+  ``_get_async_codex_client``, ``core.llm.adapters._openai_common.
+  build_async_codex_client``, and
+  ``plugins.petri_audit.codex_provider.OpenAICodexAPI.__init__``. The new
+  public ``core.llm.providers.codex.build_codex_oauth_headers(token)``
+  helper is now the single SoT — every caller routes through it and
+  receives a fresh dict (so per-thread mutation stays safe).
+  ``tests/test_codex_provider.py::TestCodexOAuthHeaders`` pins the
+  contract (4 cases: claim present / claim absent / malformed token /
+  fresh-dict-per-call). First commit of the
+  ``docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md`` Path-B
+  sequence; Step I.b (Codex reasoning replay extraction) + I.c
+  (credential source ↔ adapter health) are fast-follow PRs.
+
 ### Added
 
 - **PR-CL-A3 — In-loop Verify (Reflexion-style verbal RL) + sessions

--- a/core/llm/adapters/_openai_common.py
+++ b/core/llm/adapters/_openai_common.py
@@ -63,16 +63,12 @@ def build_async_codex_client(api_key: str) -> openai.AsyncOpenAI:
     import openai
 
     from core.config import CODEX_BASE_URL
-    from core.llm.providers.codex import _extract_account_id
+    from core.llm.providers.codex import build_codex_oauth_headers
 
-    account_id = _extract_account_id(api_key)
-    headers: dict[str, str] = {"originator": "codex_cli_rs"}
-    if account_id:
-        headers["ChatGPT-Account-ID"] = account_id
     return openai.AsyncOpenAI(
         api_key=api_key,
         base_url=CODEX_BASE_URL,
-        default_headers=headers,
+        default_headers=build_codex_oauth_headers(api_key),
     )
 
 

--- a/core/llm/providers/codex.py
+++ b/core/llm/providers/codex.py
@@ -53,6 +53,22 @@ def _extract_account_id(token: str) -> str:
         return ""
 
 
+def build_codex_oauth_headers(token: str) -> dict[str, str]:
+    """Build the headers Codex OAuth requires on every Responses-API call.
+
+    The Codex backend (``chatgpt.com/backend-api/codex``) rejects requests
+    without the ``originator: codex_cli_rs`` marker and the
+    ``ChatGPT-Account-ID`` extracted from the OAuth JWT. Returning a fresh
+    dict (rather than caching) keeps the helper safe across threads — the
+    caller mutates the dict's lifetime as it pleases.
+    """
+    account_id = _extract_account_id(token)
+    headers: dict[str, str] = {"originator": "codex_cli_rs"}
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    return headers
+
+
 def _resolve_codex_token() -> str:
     """Resolve Codex OAuth token.
 
@@ -116,17 +132,10 @@ def _get_codex_client() -> Any:
                     log.warning("Codex OAuth token not available")
                     return None
 
-                account_id = _extract_account_id(token)
-                headers: dict[str, str] = {
-                    "originator": "codex_cli_rs",
-                }
-                if account_id:
-                    headers["ChatGPT-Account-ID"] = account_id
-
                 _codex_client = openai.OpenAI(
                     api_key=token,
                     base_url=CODEX_BASE_URL,
-                    default_headers=headers,
+                    default_headers=build_codex_oauth_headers(token),
                 )
     return _codex_client
 
@@ -144,17 +153,10 @@ def _get_async_codex_client() -> Any:
                     log.warning("Codex OAuth token not available")
                     return None
 
-                account_id = _extract_account_id(token)
-                headers: dict[str, str] = {
-                    "originator": "codex_cli_rs",
-                }
-                if account_id:
-                    headers["ChatGPT-Account-ID"] = account_id
-
                 _async_codex_client = openai.AsyncOpenAI(
                     api_key=token,
                     base_url=CODEX_BASE_URL,
-                    default_headers=headers,
+                    default_headers=build_codex_oauth_headers(token),
                 )
     return _async_codex_client
 

--- a/docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md
+++ b/docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md
@@ -1,0 +1,141 @@
+# Adapter wrap port plan — petri_audit + autoresearch (Path B)
+
+> 2026-05-23. Companion to PRs *I.* (petri_audit) and *J.* (autoresearch).
+> Grounded against `~/workspace/paperclip` + `plugins/petri_audit/` +
+> `autoresearch/train.py` before drafting.
+
+## Why Path B (and not Path A)
+
+`paperclip` 's `ServerAdapterModule` (TS interface in
+`packages/adapter-utils/src/types.ts:349`) is a **subprocess-CLI
+invocation contract** — it has no wire-shape translation layer because
+the adapter binary owns the conversation translation internally.
+
+`core.llm.adapters.LLMAdapter` (Python `Protocol` in
+`core/llm/adapters/base.py`) is a richer contract — it speaks
+adapter-neutral `Message`/`AdapterCallRequest` and each built-in (
+`anthropic-payg/oauth/claude-cli`, `openai-payg/codex-oauth/codex-cli`,
+`glm-payg/coding-plan`) translates to the provider wire shape.
+
+`plugins/petri_audit/` already integrates with `inspect_ai`'s `ModelAPI`
+abstraction. inspect_ai owns its own `ChatMessage` → provider-wire
+translation (e.g. `openai_responses_inputs`, `openai_responses_chat_choices`).
+Forcing `inspect_ai.ModelAPI.generate()` to delegate to
+`LLMAdapter.acomplete(Message[])` would be **a lossy round-trip**: inspect's
+`stop_reason`, `usage`, `tool_use_id`, `reasoning_summary` fields have no
+1:1 mapping to `AdapterCallResult`.
+
+So Path B: **collapse only the genuinely duplicated bits**, keep
+`inspect_ai.ModelAPI` as the wire boundary for petri.
+
+## Surfaces in scope
+
+### Layer 1 — Codex OAuth header construction (4 duplicates)
+
+```text
+core/llm/providers/codex.py:119–124   # _get_codex_client (sync)
+core/llm/providers/codex.py:147–152   # _get_async_codex_client
+core/llm/adapters/_openai_common.py:60–63   # build_async_codex_client
+plugins/petri_audit/codex_provider.py:198–201   # OpenAICodexAPI.__init__
+```
+
+All four build the same dict:
+
+```python
+account_id = _extract_account_id(token)
+headers = {"originator": "codex_cli_rs"}
+if account_id:
+    headers["ChatGPT-Account-ID"] = account_id
+```
+
+**Collapse target**: `build_codex_oauth_headers(token: str) -> dict[str, str]`
+in `core/llm/providers/codex.py`. Public function (no leading underscore).
+
+### Layer 2 — Codex encrypted-reasoning replay
+
+`core/llm/adapters/_openai_common.py:158`'s `build_codex_input(req)`
+already implements the per-`Message.codex_reasoning_items` prepend pattern
+that A2 introduced. petri's `OpenAICodexAPI.generate()` does its own
+inspect_ai-flavoured `openai_responses_inputs(...)` call without that
+prepend — so multi-turn petri Codex runs lose encrypted reasoning chains
+across turns the same way the legacy `_legacy.py` path did pre-A2.
+
+**Collapse target**: extract a standalone helper
+`prepend_codex_reasoning(items: list[dict], reasoning_items: tuple[dict, ...])`
+from `build_codex_input`. Petri's `generate()` can call this on the
+inspect-converted input list before passing it to the OpenAI SDK. This is
+**Step I.b** — a fast-follow PR after the header dedup lands and the
+encrypted-reasoning regression test from A2 is verified to fire on the
+petri path too.
+
+### Layer 3 — credential / source resolution
+
+`plugins/petri_audit/credential_source.py:23–148` resolves
+`(provider, source)` through a manifest-driven 4-step chain (override →
+settings → manifest.default → manifest.allowed). `core.llm.adapters.registry`
+has its own `resolve_for(provider, source)` that does similar work for the
+GEODE AgenticLoop.
+
+**Collapse target**: petri's `credential_source.resolve_credential_source`
+calls `core.llm.adapters.registry.adapter_health(provider, source)` to
+augment its readiness probe — single SoT for "is this adapter available".
+The manifest semantics (override → settings → default → allowed) stay in
+petri because they encode petri-specific policy (rotation across allowed
+sources mid-eval). This is **Step I.c** — fast-follow.
+
+### Out of scope for step I
+
+- inspect_ai ModelAPI subclasses (4 files, ~1200 LOC). Wire shape stays
+  owned by inspect_ai. No `generate()` rewrites.
+- `plugins/petri_audit/adapters/{http_anthropic,http_openai,http_zhipuai}.py`
+  thin shims (90 LOC total). Their `register()` + `is_available()` contract
+  is fine; they may delegate to `adapter_health` later but the structure
+  stands.
+- `plugins/petri_audit/manifest.py` TOML schema. petri's
+  `[petri.adapter.<provider>.<source>]` entries serve picker UX (per-eval
+  source rotation) that the LLMAdapter registry doesn't model.
+
+## Step J — autoresearch (preview)
+
+`autoresearch/train.py` (2365 LOC) hosts the self-improving outer-loop's
+mutator runner. The LLM-call surface is narrower than petri:
+
+```text
+autoresearch/train.py:889   from core.llm.audit_lane import acquire_audit_lane
+```
+
+The audit lane already wraps an `LLMAdapter` (post-A1). What remains
+duplicated:
+- mutator runner subprocess invocation for `codex-cli` paths (bypasses
+  the lane when CLI mode is selected)
+- `_FALLBACK_SYSTEM_PROMPT` literal (PR-MINIMAL-2's drift invariant pin)
+
+Step J ports the mutator runner subprocess branch onto
+`core.llm.adapters.resolve_for(provider="openai", source="adapter")`
+(== the `codex-cli` built-in) so the lane is the single LLM-call boundary
+for autoresearch. The `_FALLBACK_SYSTEM_PROMPT` anchor invariant
+(`tests/test_self_improving_minimal_2.py`) stays — it's prompt-layer,
+not LLM-layer.
+
+## Sequencing
+
+| PR | Scope | LOC delta | Risk |
+|----|-------|-----------|------|
+| I.a | `build_codex_oauth_headers` helper, 4 call-site updates, unit test | +60 / -20 | low |
+| I.b | `prepend_codex_reasoning` extract + petri `OpenAICodexAPI` wiring | +120 / -10 | medium (per-turn reasoning chain) |
+| I.c | `credential_source` → `adapter_health` cross-check | +80 / -30 | low |
+| J | autoresearch mutator runner → `resolve_for("openai","adapter")` | +200 / -150 | medium |
+
+I.a lands first as a clean header dedup PR. I.b and I.c are fast-follow.
+J is a separate sprint after step I lands on develop.
+
+## Anti-deception checklist
+
+For each PR:
+
+- [ ] Every claim in CHANGELOG ("collapse", "single SoT", "per-turn replay")
+      is grep-provable in the diff (CHANGELOG/PR-body parity rule)
+- [ ] Codex MCP verify before push (`feedback_codex_mcp_verification`)
+- [ ] No `# type: ignore` introduced
+- [ ] Local gates mirror CI (`ruff format --check` + `lint-imports`)
+- [ ] Tests added for each new helper

--- a/plugins/petri_audit/codex_provider.py
+++ b/plugins/petri_audit/codex_provider.py
@@ -172,8 +172,8 @@ def register() -> None:
         def __init__(self, *args: _Any, **kwargs: _Any) -> None:
             from core.config import CODEX_BASE_URL
             from core.llm.providers.codex import (
-                _extract_account_id,
                 _resolve_codex_token,
+                build_codex_oauth_headers,
             )
             from inspect_ai.model._providers.util import (
                 environment_prerequisite_error,
@@ -195,10 +195,7 @@ def register() -> None:
             # subclass attributes are normally set. We set them first
             # so the override is safe.
             self._codex_token = token
-            self._codex_headers: dict[str, str] = {"originator": "codex_cli_rs"}
-            account_id = _extract_account_id(token)
-            if account_id:
-                self._codex_headers["ChatGPT-Account-ID"] = account_id
+            self._codex_headers = build_codex_oauth_headers(token)
 
             kwargs["api_key"] = token
             kwargs["base_url"] = kwargs.get("base_url") or CODEX_BASE_URL

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -103,6 +103,75 @@ class TestAccountIdExtraction:
         assert _extract_account_id("") == ""
 
 
+class TestCodexOAuthHeaders:
+    """``build_codex_oauth_headers`` is the single SoT for the
+    ``originator`` + ``ChatGPT-Account-ID`` pair that the Codex backend
+    requires. Four call sites (``_get_codex_client``,
+    ``_get_async_codex_client``, ``build_async_codex_client`` adapter
+    builder, ``OpenAICodexAPI`` inspect_ai subclass) all go through it."""
+
+    def _build_token(self, account_id: str | None) -> str:
+        import base64
+
+        header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+        payload_data: dict = {}
+        if account_id is not None:
+            payload_data["https://api.openai.com/auth"] = {
+                "chatgpt_account_id": account_id,
+            }
+        payload = base64.urlsafe_b64encode(json.dumps(payload_data).encode()).rstrip(b"=").decode()
+        return f"{header}.{payload}.signature"
+
+    def test_header_includes_account_id_when_jwt_carries_claim(self):
+        from core.llm.providers.codex import build_codex_oauth_headers
+
+        token = self._build_token("acct-77")
+        headers = build_codex_oauth_headers(token)
+
+        assert headers == {
+            "originator": "codex_cli_rs",
+            "ChatGPT-Account-ID": "acct-77",
+        }
+
+    def test_header_omits_account_id_when_jwt_lacks_claim(self):
+        from core.llm.providers.codex import build_codex_oauth_headers
+
+        token = self._build_token(None)
+        headers = build_codex_oauth_headers(token)
+
+        assert headers == {"originator": "codex_cli_rs"}
+        assert "ChatGPT-Account-ID" not in headers
+
+    def test_header_safe_on_malformed_token(self):
+        """``_extract_account_id`` swallows ``ValueError`` /
+        ``json.JSONDecodeError`` / ``UnicodeDecodeError`` from bad base64
+        decoding and returns ``""`` — so the helper must still ship a
+        valid ``originator``-only dict rather than crashing."""
+        from core.llm.providers.codex import build_codex_oauth_headers
+
+        # Early-return: token has fewer than 2 dotted parts.
+        assert build_codex_oauth_headers("not-a-jwt") == {"originator": "codex_cli_rs"}
+        assert build_codex_oauth_headers("") == {"originator": "codex_cli_rs"}
+        # Dotted but the middle segment is not valid base64 — exercises the
+        # ``except (json.JSONDecodeError, ValueError, UnicodeDecodeError)``
+        # branch of ``_extract_account_id``.
+        assert build_codex_oauth_headers("h.%%%.s") == {"originator": "codex_cli_rs"}
+        # Dotted but the middle segment decodes to non-JSON bytes.
+        assert build_codex_oauth_headers("h.bm9wZQ.s") == {"originator": "codex_cli_rs"}
+
+    def test_returns_fresh_dict_per_call(self):
+        """Caller may mutate the returned dict — the helper must not hand
+        out a cached reference shared across threads."""
+        from core.llm.providers.codex import build_codex_oauth_headers
+
+        token = self._build_token("acct-77")
+        first = build_codex_oauth_headers(token)
+        first["X-Test-Mutation"] = "y"
+        second = build_codex_oauth_headers(token)
+
+        assert "X-Test-Mutation" not in second
+
+
 class TestCodexAdapterProperties:
     def test_provider_name(self):
         from core.llm.providers.codex import CodexAgenticAdapter


### PR DESCRIPTION
## Summary

- Introduce ``core.llm.providers.codex.build_codex_oauth_headers(token)`` as the single SoT for the ``{"originator": "codex_cli_rs", "ChatGPT-Account-ID": <jwt-claim>}`` dict that the Codex OAuth backend (``chatgpt.com/backend-api/codex``) requires on every Responses-API call
- Route the four pre-existing call sites that built the dict inline through the new helper (no behaviour change)
- Pin contract with 4 exhaustive tests (claim present / claim absent / dotted-malformed / fresh-dict)

## Why

The header dict was duplicated four times across three modules — `_get_codex_client`, `_get_async_codex_client`, `build_async_codex_client` (LLMAdapter built-in), and petri_audit's `OpenAICodexAPI.__init__`. Adding a new header (e.g. for a future Codex endpoint variant) required four matching edits with no test gate to catch a missed copy.

This PR is the first commit of the Path-B adapter-wrap sequence described in `docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md`. Step I.b (Codex encrypted-reasoning replay extraction) and I.c (credential source ↔ adapter health) are fast-follow PRs.

## Changes

| File | Change |
|------|--------|
| `core/llm/providers/codex.py` | Add public `build_codex_oauth_headers(token)`. `_get_codex_client` + `_get_async_codex_client` now delegate to it. |
| `core/llm/adapters/_openai_common.py` | `build_async_codex_client` delegates to the new helper; drops the duplicate `_extract_account_id` import. |
| `plugins/petri_audit/codex_provider.py` | `OpenAICodexAPI.__init__` delegates to the new helper. |
| `tests/test_codex_provider.py` | New `TestCodexOAuthHeaders` class — 4 cases pinning the contract. |
| `CHANGELOG.md` | Step I.a entry under `[Unreleased] / Changed`. |
| `docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md` | Plan doc for Path B (I.a/I.b/I.c + step J). |

## Verification

- [x] `uv run ruff check core/llm/providers/codex.py core/llm/adapters/_openai_common.py plugins/petri_audit/codex_provider.py tests/test_codex_provider.py` — clean
- [x] `uv run mypy core/llm/providers/codex.py core/llm/adapters/_openai_common.py plugins/petri_audit/codex_provider.py` — Success: no issues found in 3 source files
- [x] `uv run pytest tests/test_codex_provider.py tests/test_codex_cli_oauth.py tests/test_codex_multiturn_reasoning.py tests/test_codex_normalize_parity.py tests/core/llm/test_codex_oauth_usage.py tests/plugins/petri_audit/test_codex_overrides.py` — 95 passed
- [x] Codex MCP verify (read-only sandbox, `cwd=worktree`): GREEN. One LOW finding on malformed-token coverage gap, addressed by adding the dotted-malformed-base64 + non-JSON-bytes cases to `test_header_safe_on_malformed_token`.

## Reference

Path-B port plan: `docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md` (added in this PR). Source pattern: paperclip `ServerAdapterModule` ([packages/adapter-utils/src/types.ts:349](https://github.com/Anthropic/paperclip)) was grounded but the lossy round-trip via inspect_ai's `ChatMessage` is avoided — petri's ModelAPI subclasses stay as the wire boundary.