### PR TITLE
feat(agent): Plan / Action / Judge model separation — PR-CL-A6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,79 @@ functional change.
 
 ### Added
 
+- **PR-CL-A6 — Plan / Action / Judge model separation**. Third PR in
+  the Cognitive Loop sprint (A3 → **A6** → A1). Adds three operator-tunable
+  model knobs that let the loop's three LLM call sites pick the right
+  cost/quality point independently:
+
+  - ``settings.plan_model`` — used by goal decomposition
+    (``_decomposition.try_decompose``). Set to ``claude-opus-4-7`` for
+    reasoning-heavy plans; empty falls back to ``loop.model``.
+  - ``settings.act_model`` — used by the main action loop (per-round
+    ``_call_llm``). When ``AgenticLoop(model=None)`` (caller didn't pin
+    a model), the loop reads this instead of the legacy
+    ``ANTHROPIC_PRIMARY``. Set to ``claude-sonnet-4-6`` to keep planning
+    on Opus while action runs on Sonnet for cost.
+  - ``settings.judge_model`` — used by the per-turn verify LLM-judge mode
+    (``GEODE_VERIFY_MODE=llm_judge``). Closes the PR-CL-A3 stub —
+    ``_verify_llm_judge`` now actually calls an LLM via
+    ``loop._call_llm(model=judge_model)`` and parses the
+    ``{"passed", "score", "reason"}`` JSON response.
+
+  Each knob has env override (``GEODE_PLAN_MODEL`` / ``GEODE_ACT_MODEL`` /
+  ``GEODE_JUDGE_MODEL``) and TOML mapping (``llm.plan_model`` /
+  ``llm.act_model`` / ``llm.judge_model``). Defaults are the empty
+  string so existing callers see no behaviour change until a knob is
+  set; pre-A6 callers continue to use ``settings.model``.
+
+  Implementation:
+  - ``core/config/_settings.py`` — 3 new ``Field`` declarations with
+    ``AliasChoices`` (matches the existing ``cognitive_reflection_model``
+    pattern).
+  - ``core/config/__init__.py`` — 3 new ``_TOML_TO_SETTINGS`` mappings.
+  - ``core/agent/loop/agent_loop.py`` — ``AgenticLoop.__init__`` reads
+    ``settings.act_model`` when ``model`` is None; ``_call_llm`` exposes
+    optional ``model: str | None = None`` keyword override that threads
+    through to ``self._adapter.agentic_call(model=...)`` and the
+    ``build_adapter_request`` bridge path.
+  - ``core/agent/loop/_decomposition.py`` — ``try_decompose`` reads
+    ``settings.plan_model`` for ``GoalDecomposer(model=...)``.
+  - ``core/agent/verify.py`` — ``_verify_llm_judge`` no longer stubs out.
+    Builds a strict-JSON judge prompt, calls ``loop._call_llm(model=
+    settings.judge_model)``, parses the response via
+    ``_parse_judge_payload`` (tolerates code fences + bad JSON + non-
+    numeric scores via clamp-and-default), surfaces failed reason as a
+    ``judge_fail`` rubric_miss + reflexion_hint. New
+    ``verify_turn_async`` + ``_verify_llm_judge_async`` pair lets
+    ``finalize_and_return_async`` await the judge call under the same
+    event loop instead of hopping through a thread pool. The sync
+    wrapper retains a thread-pool fallback for sync callers. The judge
+    call is bounded by a 120s ``asyncio.wait_for`` timeout, and the
+    response's token usage is fed through ``loop._track_usage_async``
+    so judge cost surfaces in the session TokenTracker (Codex MCP
+    MEDIUM #4 fix; per-phase ``phase="judge"`` tagging deferred). 4
+    fallback paths to rule-based with ``effective_mode=RULE_BASED``:
+    loop ref is None, response is None, empty response text, LLM call
+    raises (TimeoutError or otherwise).
+  - ``core/agent/loop/_lifecycle.py`` — new ``_run_turn_verify_async``
+    + shared ``_finalize_verify_outcome`` helper. ``finalize_and_return_async``
+    awaits the async verify path (Codex MCP HIGH #2 fix); sync
+    ``finalize_and_return`` still uses the sync wrapper for legacy callers.
+  - ``core/agent/loop/_model_switching.py`` — drift-sync target reads
+    ``settings.act_model or settings.model`` so an Opus-primary + Sonnet-
+    act split doesn't revert mid-session (Codex MCP HIGH #1 fix).
+  - ``tests/test_model_split.py`` (NEW, 22 tests) — settings defaults +
+    env override + TOML mapping; ``AgenticLoop.__init__`` act_model
+    cascade + explicit-model precedence + empty-fallback; ``_call_llm``
+    signature contract; goal decomposition uses ``plan_model``;
+    ``_verify_llm_judge`` actual LLM call + judge_fail path + 4 fallback
+    cases (no loop / exception / None response / no judge_model);
+    ``_judge_prompt`` truncation; ``_parse_judge_payload`` 5 edge cases.
+
+  Frontier alignment (Socratic Q5): ReWOO (arxiv 2305.18323, 5x token
+  efficiency via plan/observation decouple) + Claude Code Plan/Edit mode
+  + Self-Discover (arxiv 2402.03620, task-level plan composition).
+
 - **PR-CL-A3 — In-loop Verify (Reflexion-style verbal RL) + sessions
   DB persistence**. Per-turn verification of agent action quality,
   fired at the ``TURN_COMPLETED`` hook boundary so it doesn't interrupt

--- a/core/agent/loop/_decomposition.py
+++ b/core/agent/loop/_decomposition.py
@@ -28,11 +28,18 @@ def try_decompose(loop: AgenticLoop, user_input: str) -> str | None:
         return None
 
     try:
+        from core.config import settings
         from core.orchestration.goal_decomposer import GoalDecomposer
 
+        # PR-CL-A6 (2026-05-23) — use ``settings.plan_model`` for goal
+        # decomposition when an operator has set one. Empty string falls
+        # back to ``loop.model`` so the behaviour matches pre-A6 when the
+        # knob isn't configured. ``getattr`` keeps the helper resilient
+        # if ``settings`` is mocked in a test fixture.
+        plan_model = getattr(settings, "plan_model", "") or loop.model
         if loop._goal_decomposer is None:
             loop._goal_decomposer = GoalDecomposer(
-                model=loop.model,
+                model=plan_model,
                 tool_definitions=loop._tools,
             )
 

--- a/core/agent/loop/_lifecycle.py
+++ b/core/agent/loop/_lifecycle.py
@@ -163,54 +163,70 @@ def _final_hook_payloads(
     return session_ended, turn_completed, result.reasoning_metrics or {}
 
 
+def _finalize_verify_outcome(
+    loop: AgenticLoop, result: AgenticResult, vr: Any
+) -> dict[str, Any] | None:
+    """Shared SessionMetrics record + DB persist + payload-build path.
+
+    Called by both the sync and async ``_run_turn_verify*`` wrappers so
+    the bookkeeping stays identical regardless of how the verify outcome
+    was produced. ``None`` mirrors the "skip the hook" semantics for
+    OFF mode.
+    """
+    from core.agent.verify import VerifyMode
+    from core.observability.session_metrics import current_session_metrics
+
+    if vr.mode is VerifyMode.OFF:
+        return None
+    metrics = current_session_metrics()
+    metrics.record_verify(
+        passed=vr.passed,
+        mode=vr.mode.value,
+        effective_mode=vr.effective_mode.value,
+        rubric_misses=vr.rubric_misses,
+        reflexion_hint=vr.reflexion_hint,
+    )
+    _persist_verify_state(loop, metrics, vr.should_retry)
+    payload: dict[str, Any] = vr.to_payload()
+    payload["session_id"] = getattr(loop, "_session_id", "")
+    payload["rounds"] = int(getattr(result, "rounds", 0) or 0)
+    payload["termination_reason"] = getattr(result, "termination_reason", "") or ""
+    payload["tool_call_count"] = len(getattr(result, "tool_calls", []) or [])
+    return payload
+
+
 def _run_turn_verify(loop: AgenticLoop, result: AgenticResult) -> dict[str, Any] | None:
-    """PR-CL-A3 (2026-05-23) — per-turn verify dispatch.
+    """PR-CL-A3 (2026-05-23) — sync per-turn verify dispatch.
 
-    Runs the configured verify mode (env knob ``GEODE_VERIFY_MODE``,
-    default ``rule_based``) over the just-finished turn, records the
-    outcome into ``SessionMetrics`` (Tier 2 aggregator) so the next-turn
-    caller can read ``last_verify_reflexion_hint`` to inject into
-    ``loop._system_suffix``, and returns a payload dict ready for the
-    ``TURN_VERIFY_PASSED`` / ``TURN_VERIFY_FAILED`` hook. ``None`` is
-    returned when verify mode is ``off`` (so the caller skips the hook
-    fire — no payload pollution).
-
-    Failures inside the verify path are swallowed in ``verify_turn``
-    itself — observability mustn't break the run it observes.
+    Sync variant used by ``finalize_and_return`` (legacy sync path) and
+    test fixtures. The async finalizer uses :func:`_run_turn_verify_async`
+    so the LLM-judge call can ``await`` cleanly (Codex MCP HIGH #2 fix,
+    PR-CL-A6).
     """
     try:
-        from core.agent.verify import VerifyMode, verify_turn
-        from core.observability.session_metrics import current_session_metrics
+        from core.agent.verify import verify_turn
 
         vr = verify_turn(result, loop=loop)
-        if vr.mode is VerifyMode.OFF:
-            return None
-        metrics = current_session_metrics()
-        metrics.record_verify(
-            passed=vr.passed,
-            mode=vr.mode.value,
-            effective_mode=vr.effective_mode.value,
-            rubric_misses=vr.rubric_misses,
-            reflexion_hint=vr.reflexion_hint,
-        )
-        # PR-CL-A3 persistence — mirror Tier 2 verify telemetry into the
-        # ``sessions`` SQLite row so resume / cross-process readers can
-        # consume it without replaying SessionMetrics. Silent no-op when
-        # the session row hasn't been ``upsert``-ed (mid-test scenario or
-        # callers that bypass the SessionManager) — observability mustn't
-        # break the run it observes.
-        _persist_verify_state(loop, metrics, vr.should_retry)
-        # Enrich payload with turn context (Codex MCP LOW #8, 2026-05-23) so
-        # external renderers (Inspect viewer / Slack notifier / Petri audit)
-        # can show the relevant turn alongside the verify result.
-        payload = vr.to_payload()
-        payload["session_id"] = getattr(loop, "_session_id", "")
-        payload["rounds"] = int(getattr(result, "rounds", 0) or 0)
-        payload["termination_reason"] = getattr(result, "termination_reason", "") or ""
-        payload["tool_call_count"] = len(getattr(result, "tool_calls", []) or [])
-        return payload
+        return _finalize_verify_outcome(loop, result, vr)
     except Exception:
         log.warning("turn verify dispatch crashed; skipping", exc_info=True)
+        return None
+
+
+async def _run_turn_verify_async(loop: AgenticLoop, result: AgenticResult) -> dict[str, Any] | None:
+    """Async per-turn verify dispatch (PR-CL-A6 — Codex MCP HIGH #2 fix).
+
+    Used by ``finalize_and_return_async`` so an LLM-judge mode call can
+    await ``loop._call_llm`` under the same event loop without the
+    cross-loop thread-pool hop the sync wrapper has to use.
+    """
+    try:
+        from core.agent.verify import verify_turn_async
+
+        vr = await verify_turn_async(result, loop=loop)
+        return _finalize_verify_outcome(loop, result, vr)
+    except Exception:
+        log.warning("turn verify (async) dispatch crashed; skipping", exc_info=True)
         return None
 
 
@@ -303,9 +319,11 @@ async def finalize_and_return_async(
         await loop._hooks.trigger_async(HookEvent.SESSION_ENDED, session_ended)
         await loop._hooks.trigger_async(HookEvent.TURN_COMPLETED, turn_completed)
         await loop._hooks.trigger_async(HookEvent.REASONING_METRICS, reasoning_metrics)
-    # PR-CL-A3 — see ``finalize_and_return`` rationale. The verify dispatch
-    # is sync; hooks (if any) fire async.
-    verify_payload = _run_turn_verify(loop, result)
+    # PR-CL-A3 + PR-CL-A6 — async verify dispatch so LLM-judge mode can
+    # ``await loop._call_llm`` under the same event loop without the
+    # cross-loop thread hop the sync wrapper falls back to (Codex MCP
+    # HIGH #2 fix, 2026-05-23).
+    verify_payload = await _run_turn_verify_async(loop, result)
     if verify_payload is not None and loop._hooks:
         event = (
             HookEvent.TURN_VERIFY_PASSED

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -33,28 +33,39 @@ def _resolve_agentic_adapter(provider: str):  # type: ignore[no-untyped-def]
 
 
 def _settings_model_target(loop: AgenticLoop) -> str | None:
-    """Return settings.model when drift should apply, otherwise None."""
+    """Return the action-model drift target when sync should apply, else None.
+
+    PR-CL-A6 (2026-05-23) — when ``settings.act_model`` is set, the drift
+    target is the action model (not ``settings.model``). Without this fix
+    a session that constructed the loop with ``act_model=sonnet`` would
+    revert to ``settings.model=opus`` on the next sync, undoing the
+    Plan/Act split (Codex MCP HIGH #1).
+    """
     if getattr(loop, "_disable_settings_drift", False):
         return None
 
     from core.config import settings
 
-    if settings.model == loop.model:
+    # Action loop's intended model — ``act_model`` wins when set; falls
+    # back to ``settings.model`` for callers that haven't configured the
+    # Plan/Act knob (pre-A6 behaviour).
+    target_model = (getattr(settings, "act_model", "") or "").strip() or settings.model
+    if target_model == loop.model:
         return None
-    if not loop._drift_target_is_healthy(settings.model):
+    if not loop._drift_target_is_healthy(target_model):
         log.warning(
             "Model drift refused: target=%s has no eligible profile — "
             "keeping loop=%s. Run `/login use <plan>` to enable target.",
-            settings.model,
+            target_model,
             loop.model,
         )
         return None
     log.info(
-        "Model drift detected: loop=%s settings=%s — syncing",
+        "Model drift detected: loop=%s target=%s — syncing",
         loop.model,
-        settings.model,
+        target_model,
     )
-    return str(settings.model)
+    return str(target_model)
 
 
 async def sync_model_from_settings_async(loop: AgenticLoop) -> bool:

--- a/core/agent/loop/_model_switching.py
+++ b/core/agent/loop/_model_switching.py
@@ -48,8 +48,12 @@ def _settings_model_target(loop: AgenticLoop) -> str | None:
 
     # Action loop's intended model — ``act_model`` wins when set; falls
     # back to ``settings.model`` for callers that haven't configured the
-    # Plan/Act knob (pre-A6 behaviour).
-    target_model = (getattr(settings, "act_model", "") or "").strip() or settings.model
+    # Plan/Act knob (pre-A6 behaviour). ``isinstance(..., str)`` filters
+    # MagicMock attrs in test fixtures that auto-create non-string values
+    # (Codex MCP CI catch 2026-05-23).
+    act_raw = getattr(settings, "act_model", "")
+    act_model = act_raw.strip() if isinstance(act_raw, str) else ""
+    target_model = act_model or settings.model
     if target_model == loop.model:
         return None
     if not loop._drift_target_is_healthy(target_model):

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -125,7 +125,10 @@ class AgenticLoop:
             try:
                 from core.config import settings
 
-                act_model = (getattr(settings, "act_model", "") or "").strip()
+                # ``isinstance(..., str)`` filters MagicMock-auto-attrs in
+                # test fixtures that don't seed ``act_model`` explicitly.
+                act_raw = getattr(settings, "act_model", "")
+                act_model = act_raw.strip() if isinstance(act_raw, str) else ""
             except Exception:
                 act_model = ""
             self.model = act_model or ANTHROPIC_PRIMARY

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -117,7 +117,20 @@ class AgenticLoop:
         self._total_empty_rounds = 0
         self._cost_budget = cost_budget
         self._loop_start_time: float = 0.0
-        self.model = model or ANTHROPIC_PRIMARY
+        # PR-CL-A6 (2026-05-23) — when the caller doesn't pass an explicit
+        # ``model``, prefer ``settings.act_model`` over the global default
+        # so operators can split Plan / Act per ReWOO. ``settings.act_model``
+        # default is empty string ("") which falls through to ``ANTHROPIC_PRIMARY``.
+        if model is None:
+            try:
+                from core.config import settings
+
+                act_model = (getattr(settings, "act_model", "") or "").strip()
+            except Exception:
+                act_model = ""
+            self.model = act_model or ANTHROPIC_PRIMARY
+        else:
+            self.model = model
         self._provider = provider  # "anthropic", "openai", or "glm"
         # When True, ``sync_model_from_settings`` becomes a no-op so the
         # caller's chosen ``model`` is sticky for the lifetime of the
@@ -1707,7 +1720,12 @@ class AgenticLoop:
     # ------------------------------------------------------------------
 
     async def _call_llm(
-        self, system: str, messages: list[dict[str, Any]], *, round_idx: int = 0
+        self,
+        system: str,
+        messages: list[dict[str, Any]],
+        *,
+        round_idx: int = 0,
+        model: str | None = None,
     ) -> AgenticResponse | None:
         """Multi-provider LLM call via adapter (P1 Gateway pattern).
 
@@ -1715,11 +1733,20 @@ class AgenticLoop:
         provider-specific message/tool conversion, retry, and failover.
         Returns a normalized ``AgenticResponse`` or None on failure.
         Raises ``UserCancelledError`` on Ctrl+C (caught by ``arun()``).
+
+        PR-CL-A6 (2026-05-23) — optional ``model`` override lets callers
+        (verify judge, future Plan/Act split) request a non-default model
+        for one call without mutating ``self.model``. Falls back to
+        ``self.model`` when ``None``. The override threads through to
+        the adapter's ``agentic_call(model=...)`` parameter; the rest of
+        the loop (token tracker, retry budget, ContextVar metrics) is
+        unaffected.
         """
+        effective_model = model or self.model
         # Sandwich injection: prepend system reminder to messages (Claude Code pattern)
         from core.agent.system_injection import prepend_system_reminder
 
-        prepend_system_reminder(messages, model=self.model, round_idx=round_idx)
+        prepend_system_reminder(messages, model=effective_model, round_idx=round_idx)
 
         # Context overflow detection (Karpathy P6 Context Budget)
         await self._check_context_overflow(system, messages)
@@ -1743,7 +1770,7 @@ class AgenticLoop:
         # so the only remaining adaptive case is wrap-up.
         from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
-        ctx_window = MODEL_CONTEXT_WINDOW.get(self.model, 200_000)
+        ctx_window = MODEL_CONTEXT_WINDOW.get(effective_model, 200_000)
 
         adaptive_max_tokens = self.max_tokens
         adaptive_thinking = self._thinking_budget
@@ -1766,7 +1793,7 @@ class AgenticLoop:
             )
 
             req = build_adapter_request(
-                model=self.model,
+                model=effective_model,
                 system=system,
                 messages=messages,
                 tools=self._tools,
@@ -1790,7 +1817,7 @@ class AgenticLoop:
                 response = agentic_response_from_adapter_result(result)
         else:
             response = await self._adapter.agentic_call(
-                model=self.model,
+                model=effective_model,
                 system=system,
                 messages=messages,
                 tools=self._tools,

--- a/core/agent/verify.py
+++ b/core/agent/verify.py
@@ -258,25 +258,197 @@ def synthesize_reflexion_hint(rubric_misses: tuple[str, ...]) -> str:
     return "\n".join(lines)
 
 
-def _verify_llm_judge(result: AgenticResult, *, loop: Any | None = None) -> VerifyResult:
-    """LLM-self-judge mode — opt-in, one extra LLM call per turn.
+_LLM_JUDGE_SYSTEM_PROMPT = """\
+You are a strict, concise verifier for one agent turn. Read the turn output
+below and emit a single-line JSON object — nothing else — with these keys:
 
-    This PR ships the wiring stub (mode dispatch + result shape); the
-    actual LLM call follows in PR-CL-A6 (Plan / Action Model Separation)
-    which gives us a dedicated judge model knob. Until then, the stub
-    falls back to ``rule_based`` so the mode-knob doesn't break the loop
-    when an operator opts in early.
-    """
-    log.info(
-        "GEODE_VERIFY_MODE=llm_judge selected but the judge call is "
-        "scheduled to land in PR-CL-A6; falling back to rule_based."
+    {"passed": <true|false>, "score": <0.0-1.0>, "reason": "<short>"}
+
+Pass when the turn made measurable progress toward the user's request
+(tool used + text reflecting result, OR clean handoff). Fail when the
+turn was empty, returned only an error, or contradicted the prior plan.
+Score 1.0 = clearly correct, 0.5 = ambiguous, 0.0 = clearly wrong.
+"""
+
+
+def _judge_prompt(result: AgenticResult) -> str:
+    """Render the just-finished turn as input for the judge."""
+    tool_names = [tc.get("name", "?") for tc in (result.tool_calls or []) if isinstance(tc, dict)]
+    return (
+        "Turn output to evaluate:\n"
+        f"- termination_reason: {result.termination_reason!r}\n"
+        f"- rounds: {result.rounds}\n"
+        f"- tool_calls: {tool_names}\n"
+        f"- text (truncated 2000 chars):\n{(result.text or '')[:2000]}\n"
     )
+
+
+def _parse_judge_payload(raw: str) -> tuple[bool, float, str]:
+    """Extract ``(passed, score, reason)`` from the judge's single-line JSON.
+
+    Falls back to neutral pass with score=0.5 when parsing fails — judge
+    crashes must not break the agent run.
+    """
+    import json
+
+    text = (raw or "").strip()
+    # Some models wrap JSON in code fences; strip the obvious decorations.
+    if text.startswith("```"):
+        lines = [ln for ln in text.splitlines() if not ln.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    try:
+        obj = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        log.debug("LLM judge returned non-JSON; treating as pass", extra={"raw": text[:200]})
+        return True, 0.5, "judge_unparseable"
+    passed = bool(obj.get("passed", True))
+    raw_score = obj.get("score", 0.5)
+    try:
+        score = float(raw_score)
+    except (TypeError, ValueError):
+        score = 0.5
+    score = max(0.0, min(1.0, score))
+    reason = str(obj.get("reason", ""))[:200]
+    return passed, score, reason
+
+
+_JUDGE_CALL_TIMEOUT_S: float = 120.0
+
+
+def _build_judge_result_from_response(response: Any, result: AgenticResult) -> VerifyResult:
+    """Shared judge response → VerifyResult translation.
+
+    Pulled out of the call paths so sync and async wrappers parse identically.
+    Falls back to ``_llm_judge_fallback`` when the response carries no usable
+    text — caller already handled the network-level None.
+    """
+    raw_text = (getattr(response, "text", "") or "").strip()
+    if not raw_text:
+        return _llm_judge_fallback(result)
+    passed, score, reason = _parse_judge_payload(raw_text)
+    misses: tuple[str, ...] = ()
+    hint = ""
+    if not passed:
+        misses = ("judge_fail",) if not reason else ("judge_fail", reason[:40])
+        hint = synthesize_reflexion_hint(("judge_fail",)) + (
+            f"\nJudge reason: {reason}" if reason else ""
+        )
+    return VerifyResult(
+        passed=passed,
+        mode=VerifyMode.LLM_JUDGE,
+        effective_mode=VerifyMode.LLM_JUDGE,
+        score=score,
+        rubric_misses=misses,
+        reflexion_hint=hint,
+        should_retry=(not passed),
+        ts=time.monotonic(),
+    )
+
+
+async def _verify_llm_judge_async(
+    result: AgenticResult, *, loop: Any | None = None
+) -> VerifyResult:
+    """Async LLM-judge path — awaits ``loop._call_llm`` cleanly under the
+    same event loop the agentic finalizer runs on (Codex MCP HIGH #2 +
+    MEDIUM #3, 2026-05-23). Bounded by :data:`_JUDGE_CALL_TIMEOUT_S` via
+    :func:`asyncio.wait_for` so a stuck adapter cannot hang finalisation.
+
+    Judge token usage is recorded via the loop's ``_track_usage_async``
+    helper after a non-``None`` response so judge cost surfaces in the
+    session's TokenTracker (Codex MCP MEDIUM #4 fix, 2026-05-23). Cost
+    is currently aggregated into the same TokenTracker that handles the
+    action loop — per-phase tagging (``phase="judge"``) is a follow-up
+    that needs adapter-level API extension.
+    """
+    if loop is None:
+        return _llm_judge_fallback(result)
+    try:
+        import asyncio
+
+        from core.config import settings
+
+        judge_model = (getattr(settings, "judge_model", "") or "").strip() or loop.model
+        prompt = _judge_prompt(result)
+        response = await asyncio.wait_for(
+            loop._call_llm(
+                _LLM_JUDGE_SYSTEM_PROMPT,
+                [{"role": "user", "content": prompt}],
+                model=judge_model,
+            ),
+            timeout=_JUDGE_CALL_TIMEOUT_S,
+        )
+        if response is None:
+            log.debug("LLM judge (async): no response; falling back to rule_based")
+            return _llm_judge_fallback(result)
+        # Codex MCP MEDIUM #4 — record judge usage explicitly. Mirrors the
+        # action-loop path at ``agent_loop.py:_track_usage_async``. Failure
+        # is swallowed so judge usage accounting never breaks the run.
+        track = getattr(loop, "_track_usage_async", None)
+        if track is not None:
+            try:
+                await track(response)
+            except Exception:
+                log.debug("Judge usage tracking failed", exc_info=True)
+        return _build_judge_result_from_response(response, result)
+    except Exception:
+        log.warning(
+            "LLM judge (async) call failed; falling back to rule_based",
+            exc_info=True,
+        )
+        return _llm_judge_fallback(result)
+
+
+def _verify_llm_judge(result: AgenticResult, *, loop: Any | None = None) -> VerifyResult:
+    """Sync LLM-self-judge mode — opt-in, one extra LLM call per turn.
+
+    PR-CL-A6 (2026-05-23) — sync wrapper for callers that aren't inside an
+    asyncio event loop (CLI smoke tests, pure-sync verify dispatch). The
+    async caller path (``_run_turn_verify_async`` from
+    ``finalize_and_return_async``) uses :func:`_verify_llm_judge_async`
+    directly to avoid the cross-loop thread-pool hop (Codex MCP HIGH #2
+    fix). When invoked from a sync context with no running event loop,
+    we use ``asyncio.run`` with the same :data:`_JUDGE_CALL_TIMEOUT_S`
+    timeout. When invoked from inside a running loop, the only safe sync
+    option is a thread pool — we keep it but with the explicit timeout.
+
+    Failures NEVER raise — observability mustn't break the run it observes.
+    """
+    if loop is None:
+        log.debug("LLM judge: no loop reference; falling back to rule_based")
+        return _llm_judge_fallback(result)
+    try:
+        import asyncio
+
+        try:
+            asyncio.get_running_loop()
+            running = True
+        except RuntimeError:
+            running = False
+        if running:
+            # Sync caller inside an active loop is a misuse — schedule the
+            # async path on a worker thread. ``asyncio.run`` inside that
+            # thread builds its own loop so adapter clients are not shared
+            # across loops. ``asyncio.wait_for`` inside ``_verify_llm_judge_async``
+            # bounds the actual LLM call; the thread join here trusts that.
+            import concurrent.futures
+
+            def _run_in_thread() -> VerifyResult:
+                return asyncio.run(_verify_llm_judge_async(result, loop=loop))
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(_run_in_thread).result(timeout=_JUDGE_CALL_TIMEOUT_S + 5.0)
+        return asyncio.run(_verify_llm_judge_async(result, loop=loop))
+    except Exception:
+        log.warning("LLM judge call failed; falling back to rule_based", exc_info=True)
+        return _llm_judge_fallback(result)
+
+
+def _llm_judge_fallback(result: AgenticResult) -> VerifyResult:
+    """Used when the LLM judge can't run (no loop ref / response None /
+    exception). Runs the rule-based path but tags the result mode as
+    LLM_JUDGE (operator intent) with ``effective_mode=RULE_BASED`` so
+    telemetry surfaces the downgrade."""
     rb = _verify_rule_based(result)
-    # ``mode`` reflects the operator's *requested* intent (LLM_JUDGE);
-    # ``effective_mode`` records the *path that actually ran* (RULE_BASED).
-    # Downstream telemetry can distinguish "operator asked for judge but
-    # got rule-based" from "operator asked for rule-based" (Codex MCP
-    # LOW #4 honesty fix, 2026-05-23).
     return VerifyResult(
         passed=rb.passed,
         mode=VerifyMode.LLM_JUDGE,
@@ -284,8 +456,27 @@ def _verify_llm_judge(result: AgenticResult, *, loop: Any | None = None) -> Veri
         score=rb.score,
         rubric_misses=rb.rubric_misses,
         reflexion_hint=rb.reflexion_hint,
+        should_retry=rb.should_retry,
         ts=rb.ts,
     )
+
+
+async def verify_turn_async(result: AgenticResult, *, loop: Any | None = None) -> VerifyResult:
+    """Async dispatcher — preferred for callers running inside an event
+    loop (e.g. ``finalize_and_return_async``). Avoids the cross-loop
+    thread-pool hop that the sync wrapper has to use for in-loop
+    invocation (Codex MCP HIGH #2 fix, 2026-05-23).
+    """
+    mode = get_verify_mode()
+    if mode is VerifyMode.OFF:
+        return VerifyResult(passed=True, mode=mode, effective_mode=mode, ts=time.monotonic())
+    try:
+        if mode is VerifyMode.LLM_JUDGE:
+            return await _verify_llm_judge_async(result, loop=loop)
+        return _verify_rule_based(result)
+    except Exception:
+        log.warning("verify_turn_async crashed; treating as pass", exc_info=True)
+        return VerifyResult(passed=True, mode=mode, effective_mode=mode, ts=time.monotonic())
 
 
 def verify_turn(result: AgenticResult, *, loop: Any | None = None) -> VerifyResult:

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -54,6 +54,11 @@ _TOML_TO_SETTINGS: dict[str, str] = {
     "llm.secondary_model": "default_secondary_model",
     "llm.router_model": "router_model",
     "llm.learning_extract_model": "learning_extract_model",
+    # PR-CL-A6 (2026-05-23) — Plan / Action / Judge model knobs. Empty
+    # string falls back to ``llm.primary_model``.
+    "llm.plan_model": "plan_model",
+    "llm.act_model": "act_model",
+    "llm.judge_model": "judge_model",
     "cognitive.reflection_enabled": "cognitive_reflection_enabled",
     "cognitive.reflection_model": "cognitive_reflection_model",
     "cognitive.reflection_max_tokens": "cognitive_reflection_max_tokens",

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -82,6 +82,43 @@ class Settings(BaseSettings):
             "set this to opus / sonnet. PR-3 C-2."
         ),
     )
+    # PR-CL-A6 (2026-05-23) — Plan / Action / Judge model separation
+    # (agentic-loop-evolution.md A6). Empty string ("") means "fall back
+    # to ``settings.model``" so existing operators see no behaviour change
+    # until they set a concrete value. ReWOO (arxiv 2305.18323) showed
+    # plan / observation decoupling yields 5x token efficiency; Anthropic
+    # Plan / Edit mode pattern (claude-code) splits Opus-class planning
+    # from Sonnet-class action.
+    plan_model: str = Field(
+        default="",
+        validation_alias=AliasChoices("plan_model", "GEODE_PLAN_MODEL"),
+        description=(
+            "Model used by the planning step (goal decomposition before "
+            "the main loop). Empty string falls back to ``settings.model``. "
+            "Set to ``claude-opus-4-7`` for higher-quality plans, "
+            "``claude-haiku-4-5-20251001`` for cheaper. PR-CL-A6."
+        ),
+    )
+    act_model: str = Field(
+        default="",
+        validation_alias=AliasChoices("act_model", "GEODE_ACT_MODEL"),
+        description=(
+            "Model used by the action loop (per-round tool calls). Empty "
+            "string falls back to ``settings.model``. Set to ``claude-"
+            "sonnet-4-6`` to keep planning on Opus while action runs on "
+            "Sonnet for cost. PR-CL-A6."
+        ),
+    )
+    judge_model: str = Field(
+        default="",
+        validation_alias=AliasChoices("judge_model", "GEODE_JUDGE_MODEL"),
+        description=(
+            "Model used by the per-turn verify LLM-judge mode "
+            "(``GEODE_VERIFY_MODE=llm_judge``). Empty string falls back "
+            "to ``settings.model``. Cheap models like Haiku 4.5 are "
+            "appropriate for binary pass/fail judgement. PR-CL-A6."
+        ),
+    )
     cognitive_reflection_max_tokens: int = Field(
         default=512,
         validation_alias=AliasChoices(

--- a/tests/test_model_split.py
+++ b/tests/test_model_split.py
@@ -1,0 +1,584 @@
+"""Unit tests for PR-CL-A6 — Plan/Action/Judge model separation.
+
+Coverage:
+- Settings knobs (``plan_model`` / ``act_model`` / ``judge_model``) default
+  to empty string (= fall back to ``settings.model``).
+- TOML mapping covers all three knobs.
+- ``AgenticLoop.__init__`` honours ``settings.act_model`` when no explicit
+  ``model`` is passed; explicit ``model`` wins.
+- ``_decomposition.try_decompose`` uses ``settings.plan_model`` when set.
+- ``_call_llm(model=...)`` override threads through to the adapter call.
+- ``_verify_llm_judge`` actually calls the LLM via ``loop._call_llm`` with
+  ``settings.judge_model`` + parses the judge JSON response.
+- ``_verify_llm_judge`` falls back to ``rule_based`` (with
+  ``effective_mode=RULE_BASED``) when the loop reference is None or the
+  LLM call errors.
+- Judge JSON parsing tolerates code fences + bad JSON + non-numeric scores.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from core.agent.loop.models import AgenticResult
+from core.agent.verify import (
+    VerifyMode,
+    _judge_prompt,
+    _llm_judge_fallback,
+    _parse_judge_payload,
+    _verify_llm_judge,
+    verify_turn,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEODE_VERIFY_MODE", raising=False)
+    monkeypatch.delenv("GEODE_PLAN_MODEL", raising=False)
+    monkeypatch.delenv("GEODE_ACT_MODEL", raising=False)
+    monkeypatch.delenv("GEODE_JUDGE_MODEL", raising=False)
+
+
+def _make_result(
+    *,
+    text: str = "OK",
+    tool_calls: list[dict] | None = None,
+    termination_reason: str = "natural",
+) -> AgenticResult:
+    return AgenticResult(
+        text=text,
+        tool_calls=tool_calls or [],
+        rounds=1,
+        termination_reason=termination_reason,
+    )
+
+
+# -- Settings knob defaults --------------------------------------------
+
+
+def test_settings_default_to_empty_string() -> None:
+    """All three knobs default to ``""`` so existing callers fall back
+    to ``settings.model`` until they set a concrete value."""
+    from core.config._settings import Settings
+
+    s = Settings()
+    assert s.plan_model == ""
+    assert s.act_model == ""
+    assert s.judge_model == ""
+
+
+def test_settings_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``GEODE_PLAN_MODEL`` / ``ACT_MODEL`` / ``JUDGE_MODEL`` env vars
+    populate the knobs via pydantic AliasChoices."""
+    from core.config._settings import Settings
+
+    monkeypatch.setenv("GEODE_PLAN_MODEL", "claude-opus-4-7")
+    monkeypatch.setenv("GEODE_ACT_MODEL", "claude-sonnet-4-6")
+    monkeypatch.setenv("GEODE_JUDGE_MODEL", "claude-haiku-4-5-20251001")
+    s = Settings()
+    assert s.plan_model == "claude-opus-4-7"
+    assert s.act_model == "claude-sonnet-4-6"
+    assert s.judge_model == "claude-haiku-4-5-20251001"
+
+
+def test_toml_mapping_covers_three_knobs() -> None:
+    """Config cascade maps ``[llm].plan_model`` / ``act_model`` /
+    ``judge_model`` to the matching Settings fields."""
+    from core.config import _TOML_TO_SETTINGS
+
+    assert _TOML_TO_SETTINGS["llm.plan_model"] == "plan_model"
+    assert _TOML_TO_SETTINGS["llm.act_model"] == "act_model"
+    assert _TOML_TO_SETTINGS["llm.judge_model"] == "judge_model"
+
+
+# -- AgenticLoop.__init__ uses act_model when no explicit model --------
+
+
+def test_act_model_used_when_no_explicit_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``settings.act_model`` is set and caller doesn't pass an
+    explicit model, ``AgenticLoop.model`` reflects ``act_model``."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    fake_settings = SimpleNamespace(act_model="claude-sonnet-4-6")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+    # Build a minimal loop — most kwargs are optional, but ConversationContext
+    # + ToolExecutor are required. Use mocks.
+    ctx = MagicMock()
+    ctx.get_messages.return_value = []
+    executor = MagicMock()
+    loop = AgenticLoop(ctx, executor)
+    assert loop.model == "claude-sonnet-4-6"
+
+
+def test_explicit_model_wins_over_act_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller-passed ``model=...`` overrides ``settings.act_model``."""
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    fake_settings = SimpleNamespace(act_model="claude-sonnet-4-6")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+    ctx = MagicMock()
+    ctx.get_messages.return_value = []
+    executor = MagicMock()
+    loop = AgenticLoop(ctx, executor, model="claude-opus-4-7")
+    assert loop.model == "claude-opus-4-7"
+
+
+def test_act_model_empty_falls_back_to_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty ``act_model`` falls back to ``ANTHROPIC_PRIMARY`` (the
+    legacy pre-A6 default)."""
+    from core.agent.loop.agent_loop import AgenticLoop
+    from core.config import ANTHROPIC_PRIMARY
+
+    fake_settings = SimpleNamespace(act_model="")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+    ctx = MagicMock()
+    ctx.get_messages.return_value = []
+    executor = MagicMock()
+    loop = AgenticLoop(ctx, executor)
+    assert loop.model == ANTHROPIC_PRIMARY
+
+
+# -- _call_llm model override -----------------------------------------
+
+
+def test_call_llm_signature_accepts_model_override() -> None:
+    """``_call_llm`` exposes a ``model`` keyword parameter (introspection
+    check — exercises the signature contract without running an LLM)."""
+    import inspect
+
+    from core.agent.loop.agent_loop import AgenticLoop
+
+    sig = inspect.signature(AgenticLoop._call_llm)
+    assert "model" in sig.parameters
+    param = sig.parameters["model"]
+    assert param.default is None  # default falls back to self.model
+    assert param.kind == inspect.Parameter.KEYWORD_ONLY
+
+
+# -- Goal decomposition uses plan_model -------------------------------
+
+
+def test_try_decompose_uses_plan_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``try_decompose`` instantiates ``GoalDecomposer`` with
+    ``settings.plan_model`` when set."""
+    fake_settings = SimpleNamespace(plan_model="claude-opus-4-7", model="claude-haiku-4-5")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    captured: dict[str, str] = {}
+
+    class _FakeDecomposer:
+        def __init__(self, *, model: str, tool_definitions: list) -> None:
+            captured["model"] = model
+
+        def decompose(self, *_args: object, **_kwargs: object) -> None:
+            return None  # short-circuit — we only care about __init__ arg
+
+    monkeypatch.setattr("core.orchestration.goal_decomposer.GoalDecomposer", _FakeDecomposer)
+
+    loop = SimpleNamespace(
+        _enable_goal_decomposition=True,
+        _goal_decomposer=None,
+        _tools=[],
+        model="claude-haiku-4-5",
+    )
+    from core.agent.loop._decomposition import try_decompose
+
+    try_decompose(loop, "compound input with multiple steps")
+    assert captured["model"] == "claude-opus-4-7"
+
+
+def test_try_decompose_falls_back_to_loop_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty ``plan_model`` → ``GoalDecomposer`` gets ``loop.model``."""
+    fake_settings = SimpleNamespace(plan_model="", model="claude-haiku-4-5")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+    captured: dict[str, str] = {}
+
+    class _FakeDecomposer:
+        def __init__(self, *, model: str, tool_definitions: list) -> None:
+            captured["model"] = model
+
+        def decompose(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    monkeypatch.setattr("core.orchestration.goal_decomposer.GoalDecomposer", _FakeDecomposer)
+
+    loop = SimpleNamespace(
+        _enable_goal_decomposition=True,
+        _goal_decomposer=None,
+        _tools=[],
+        model="claude-opus-4-7",  # this should be used
+    )
+    from core.agent.loop._decomposition import try_decompose
+
+    try_decompose(loop, "compound input")
+    assert captured["model"] == "claude-opus-4-7"
+
+
+# -- LLM judge wiring -------------------------------------------------
+
+
+def test_verify_llm_judge_calls_loop_call_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``loop`` is provided + judge_model set, the judge calls
+    ``loop._call_llm`` with the judge model and parses the JSON response."""
+    monkeypatch.setenv("GEODE_VERIFY_MODE", "llm_judge")
+    fake_settings = SimpleNamespace(judge_model="claude-haiku-4-5-20251001")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    captured: dict[str, str] = {}
+
+    async def _fake_call_llm(
+        system: str, messages: list, *, model: str | None = None
+    ) -> SimpleNamespace:
+        captured["model"] = model or ""
+        captured["system"] = system
+        return SimpleNamespace(text='{"passed": true, "score": 0.92, "reason": "ok"}')
+
+    loop = SimpleNamespace(_call_llm=_fake_call_llm, model="claude-opus-4-7")
+    result = _make_result(text="Did the thing", tool_calls=[{"name": "search"}])
+    vr = _verify_llm_judge(result, loop=loop)
+    assert vr.mode is VerifyMode.LLM_JUDGE
+    assert vr.effective_mode is VerifyMode.LLM_JUDGE  # real judge ran
+    assert vr.passed is True
+    assert vr.score == pytest.approx(0.92)
+    assert captured["model"] == "claude-haiku-4-5-20251001"
+    assert "verifier" in captured["system"].lower()
+
+
+def test_verify_llm_judge_judge_fail_records_misses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Judge FAIL response → ``passed=False`` + ``judge_fail`` rubric_miss
+    + reflexion_hint includes judge's reason."""
+    fake_settings = SimpleNamespace(judge_model="claude-haiku-4-5-20251001")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    async def _fake_call_llm(
+        system: str, messages: list, *, model: str | None = None
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            text='{"passed": false, "score": 0.1, "reason": "tool error masked the goal"}'
+        )
+
+    loop = SimpleNamespace(_call_llm=_fake_call_llm, model="claude-opus-4-7")
+    vr = _verify_llm_judge(_make_result(text="weak output"), loop=loop)
+    assert vr.passed is False
+    assert vr.effective_mode is VerifyMode.LLM_JUDGE
+    assert "judge_fail" in vr.rubric_misses
+    assert vr.should_retry is True
+    assert "tool error masked the goal" in vr.reflexion_hint
+
+
+def test_verify_llm_judge_falls_back_when_no_loop() -> None:
+    """``loop=None`` → fallback to rule_based + ``effective_mode=RULE_BASED``."""
+    vr = _verify_llm_judge(_make_result(text=""), loop=None)
+    assert vr.mode is VerifyMode.LLM_JUDGE
+    assert vr.effective_mode is VerifyMode.RULE_BASED
+
+
+def test_verify_llm_judge_falls_back_on_exception() -> None:
+    """Judge LLM exception → fallback. Telemetry shows the downgrade
+    via ``effective_mode=RULE_BASED``."""
+
+    async def _broken(_system: str, _msgs: list, *, model: str | None = None) -> None:
+        raise RuntimeError("network down")
+
+    loop = SimpleNamespace(_call_llm=_broken, model="claude-opus-4-7")
+    vr = _verify_llm_judge(_make_result(text=""), loop=loop)
+    assert vr.mode is VerifyMode.LLM_JUDGE
+    assert vr.effective_mode is VerifyMode.RULE_BASED
+
+
+def test_verify_llm_judge_falls_back_on_none_response() -> None:
+    """``_call_llm`` returning None (e.g. all retries failed) → fallback."""
+
+    async def _returns_none(_system: str, _msgs: list, *, model: str | None = None) -> None:
+        return None
+
+    loop = SimpleNamespace(_call_llm=_returns_none, model="claude-opus-4-7")
+    vr = _verify_llm_judge(_make_result(text=""), loop=loop)
+    assert vr.effective_mode is VerifyMode.RULE_BASED
+
+
+# -- Judge JSON parsing -----------------------------------------------
+
+
+def test_parse_judge_payload_clean_json() -> None:
+    passed, score, reason = _parse_judge_payload('{"passed": true, "score": 0.85, "reason": "ok"}')
+    assert passed is True
+    assert score == pytest.approx(0.85)
+    assert reason == "ok"
+
+
+def test_parse_judge_payload_code_fence_wrapped() -> None:
+    """Some models wrap JSON in ```json fences — strip them."""
+    payload = '```json\n{"passed": false, "score": 0.2, "reason": "weak"}\n```'
+    passed, score, reason = _parse_judge_payload(payload)
+    assert passed is False
+    assert score == pytest.approx(0.2)
+    assert reason == "weak"
+
+
+def test_parse_judge_payload_bad_json_treats_as_pass() -> None:
+    """Unparseable → neutral pass with score=0.5 + ``judge_unparseable`` reason."""
+    passed, score, reason = _parse_judge_payload("not even close to JSON")
+    assert passed is True  # neutral
+    assert score == pytest.approx(0.5)
+    assert reason == "judge_unparseable"
+
+
+def test_parse_judge_payload_non_numeric_score_defaults_half() -> None:
+    """Score field that isn't a number → 0.5."""
+    _passed, score, _reason = _parse_judge_payload('{"passed": true, "score": "high"}')
+    assert score == pytest.approx(0.5)
+
+
+def test_parse_judge_payload_score_clamped() -> None:
+    """Scores outside [0, 1] are clamped."""
+    _, score_high, _ = _parse_judge_payload('{"passed": true, "score": 5.0}')
+    assert score_high == 1.0
+    _, score_low, _ = _parse_judge_payload('{"passed": true, "score": -0.5}')
+    assert score_low == 0.0
+
+
+def test_judge_prompt_includes_turn_context() -> None:
+    """The user-side prompt carries termination_reason / rounds / tool
+    names / truncated text so the judge can rate the turn."""
+    result = _make_result(
+        text="long output " * 100,
+        tool_calls=[{"name": "search"}, {"name": "fetch"}],
+        termination_reason="natural",
+    )
+    prompt = _judge_prompt(result)
+    assert "natural" in prompt
+    assert "search" in prompt and "fetch" in prompt
+    assert "rounds: 1" in prompt
+    # Text truncated at 2000 chars
+    assert len(prompt) < 3000
+
+
+# -- Verify dispatcher wiring -----------------------------------------
+
+
+def test_verify_turn_routes_llm_judge_through_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``verify_turn`` in llm_judge mode passes the loop ref through to
+    ``_verify_llm_judge``."""
+    monkeypatch.setenv("GEODE_VERIFY_MODE", "llm_judge")
+
+    async def _fake_call_llm(
+        _system: str, _msgs: list, *, model: str | None = None
+    ) -> SimpleNamespace:
+        return SimpleNamespace(text='{"passed": true, "score": 1.0}')
+
+    loop = SimpleNamespace(_call_llm=_fake_call_llm, model="claude-opus-4-7")
+    vr = verify_turn(_make_result(text="OK"), loop=loop)
+    assert vr.effective_mode is VerifyMode.LLM_JUDGE
+    assert vr.passed is True
+
+
+def test_llm_judge_fallback_preserves_rubric_misses() -> None:
+    """Fallback path runs rule_based underneath so its rubric_misses
+    + should_retry flow through to the LLM_JUDGE-labeled result."""
+    result = _make_result(text="", tool_calls=[])  # rule-based: empty_turn
+    vr = _llm_judge_fallback(result)
+    assert vr.mode is VerifyMode.LLM_JUDGE
+    assert vr.effective_mode is VerifyMode.RULE_BASED
+    assert "empty_turn" in vr.rubric_misses
+    assert vr.should_retry is True
+
+
+# -- Async judge path (PR-CL-A6 Codex MCP HIGH #2 + MEDIUM #3) ----------
+
+
+def test_verify_turn_async_routes_through_judge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``verify_turn_async`` in llm_judge mode awaits ``loop._call_llm``
+    directly (no thread-pool hop). Verify the asyncio path lands the call
+    + parses the response in the same event loop the caller is on."""
+    import asyncio
+
+    monkeypatch.setenv("GEODE_VERIFY_MODE", "llm_judge")
+
+    captured: dict[str, str] = {}
+
+    async def _fake_call_llm(
+        _system: str, _msgs: list, *, model: str | None = None
+    ) -> SimpleNamespace:
+        captured["model"] = model or ""
+        return SimpleNamespace(text='{"passed": true, "score": 0.85, "reason": "ok"}')
+
+    from core.agent.verify import verify_turn_async
+
+    fake_settings = SimpleNamespace(judge_model="claude-haiku-4-5-20251001")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+    loop = SimpleNamespace(_call_llm=_fake_call_llm, model="claude-opus-4-7")
+    vr = asyncio.run(verify_turn_async(_make_result(text="OK"), loop=loop))
+    assert vr.effective_mode is VerifyMode.LLM_JUDGE
+    assert vr.passed is True
+    assert vr.score == pytest.approx(0.85)
+    assert captured["model"] == "claude-haiku-4-5-20251001"
+
+
+def test_verify_turn_async_timeout_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the judge LLM call exceeds ``_JUDGE_CALL_TIMEOUT_S`` the
+    async path catches the TimeoutError and falls back to rule_based
+    (Codex MCP MEDIUM #3 fix). Patch the timeout to a tiny value to
+    avoid sleeping in tests."""
+    import asyncio
+
+    from core.agent import verify as verify_mod
+
+    monkeypatch.setattr(verify_mod, "_JUDGE_CALL_TIMEOUT_S", 0.05)
+
+    async def _slow(_system: str, _msgs: list, *, model: str | None = None) -> SimpleNamespace:
+        await asyncio.sleep(1.0)
+        return SimpleNamespace(text='{"passed": true, "score": 1.0}')
+
+    loop = SimpleNamespace(_call_llm=_slow, model="claude-opus-4-7")
+    vr = asyncio.run(verify_mod._verify_llm_judge_async(_make_result(text=""), loop=loop))
+    # Timeout → fallback to rule-based.
+    assert vr.mode is VerifyMode.LLM_JUDGE
+    assert vr.effective_mode is VerifyMode.RULE_BASED
+
+
+def test_verify_turn_async_off_mode_returns_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OFF mode in async path returns passing sentinel without LLM call."""
+    import asyncio
+
+    monkeypatch.setenv("GEODE_VERIFY_MODE", "off")
+
+    from core.agent.verify import verify_turn_async
+
+    vr = asyncio.run(verify_turn_async(_make_result(text="", tool_calls=[]), loop=None))
+    assert vr.passed is True
+    assert vr.mode is VerifyMode.OFF
+
+
+# -- Act-model drift (PR-CL-A6 Codex MCP HIGH #1) ----------------------
+
+
+def test_drift_target_uses_act_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The model-drift sync targets ``settings.act_model`` (not
+    ``settings.model``) so an Opus-primary + Sonnet-act split doesn't
+    revert mid-session."""
+    from core.agent.loop._model_switching import _settings_model_target
+
+    fake_settings = SimpleNamespace(model="claude-opus-4-7", act_model="claude-sonnet-4-6")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    loop_stub = SimpleNamespace(
+        model="claude-haiku-4-5-20251001",
+        _disable_settings_drift=False,
+        _drift_target_is_healthy=lambda _m: True,
+    )
+    target = _settings_model_target(loop_stub)
+    assert target == "claude-sonnet-4-6"  # act_model wins over model
+
+
+def test_drift_target_falls_back_to_primary_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty ``act_model`` → drift target is ``settings.model`` (pre-A6
+    behaviour preserved)."""
+    from core.agent.loop._model_switching import _settings_model_target
+
+    fake_settings = SimpleNamespace(model="claude-opus-4-7", act_model="")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    loop_stub = SimpleNamespace(
+        model="claude-haiku-4-5-20251001",
+        _disable_settings_drift=False,
+        _drift_target_is_healthy=lambda _m: True,
+    )
+    target = _settings_model_target(loop_stub)
+    assert target == "claude-opus-4-7"
+
+
+def test_drift_target_no_drift_when_already_matched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``loop.model`` already equals the act-model target, no drift."""
+    from core.agent.loop._model_switching import _settings_model_target
+
+    fake_settings = SimpleNamespace(model="claude-opus-4-7", act_model="claude-sonnet-4-6")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    loop_stub = SimpleNamespace(
+        model="claude-sonnet-4-6",
+        _disable_settings_drift=False,
+        _drift_target_is_healthy=lambda _m: True,
+    )
+    assert _settings_model_target(loop_stub) is None
+
+
+def test_judge_usage_recorded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Codex MCP MEDIUM #4 — the judge LLM call's ``response`` is passed
+    to ``loop._track_usage_async`` so judge cost surfaces in the session
+    TokenTracker (rather than being silently untracked)."""
+    import asyncio
+
+    from core.agent.verify import _verify_llm_judge_async
+
+    fake_settings = SimpleNamespace(judge_model="claude-haiku-4-5-20251001")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    recorded_responses: list[Any] = []
+
+    async def _fake_call_llm(
+        _system: str, _msgs: list, *, model: str | None = None
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            text='{"passed": true, "score": 0.9, "reason": "ok"}',
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+        )
+
+    async def _fake_track_usage(response: Any) -> None:
+        recorded_responses.append(response)
+
+    loop = SimpleNamespace(
+        _call_llm=_fake_call_llm,
+        _track_usage_async=_fake_track_usage,
+        model="claude-opus-4-7",
+    )
+    asyncio.run(_verify_llm_judge_async(_make_result(text="OK"), loop=loop))
+    assert len(recorded_responses) == 1
+    assert recorded_responses[0].usage.input_tokens == 10
+
+
+def test_judge_usage_track_failure_does_not_break_judge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Usage-tracking exception is swallowed — the judge result still
+    returns normally (observability hygiene)."""
+    import asyncio
+
+    from core.agent.verify import _verify_llm_judge_async
+
+    fake_settings = SimpleNamespace(judge_model="claude-haiku-4-5-20251001")
+    monkeypatch.setattr("core.config.settings", fake_settings)
+
+    async def _fake_call_llm(
+        _system: str, _msgs: list, *, model: str | None = None
+    ) -> SimpleNamespace:
+        return SimpleNamespace(text='{"passed": true, "score": 1.0}')
+
+    async def _broken_track(_response: Any) -> None:
+        raise RuntimeError("tracker down")
+
+    loop = SimpleNamespace(
+        _call_llm=_fake_call_llm,
+        _track_usage_async=_broken_track,
+        model="claude-opus-4-7",
+    )
+    vr = asyncio.run(_verify_llm_judge_async(_make_result(text="OK"), loop=loop))
+    assert vr.passed is True  # tracking failure didn't kill the judge result
+    assert vr.effective_mode is VerifyMode.LLM_JUDGE

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.43"
+version = "0.99.44"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- 3 operator-tunable model knobs (``settings.plan_model`` / ``settings.act_model`` / ``settings.judge_model``) let the loop's three LLM call sites pick cost/quality independently.
- Closes the PR-CL-A3 judge stub — ``_verify_llm_judge`` now actually calls the LLM via ``loop._call_llm(model=judge_model)``, parses JSON, and surfaces failed reasons as Reflexion hints.
- Async-native judge path (``verify_turn_async`` + ``_verify_llm_judge_async``) lets the async finalizer await the judge call under the same event loop — no thread-pool hop. 120s timeout. Judge usage flows through ``loop._track_usage_async``.

## Why

Third PR in the Cognitive Loop sprint (A3 → A6 → A1). ReWOO (arxiv 2305.18323) showed plan/observation decoupling yields 5x token efficiency; Self-Discover (arxiv 2402.03620) showed task-level plan composition cuts inferences 10-40x. Without per-phase model selection, GEODE pays Opus rates for tool dispatch (action) and Sonnet quality for plan-heavy reasoning. PR-CL-A1 (Dynamic Replan, next) will use this infrastructure to retry on a different plan_model when verify fails.

## Changes

| File | Change |
|------|--------|
| ``core/config/_settings.py`` | 3 new Field declarations (plan_model / act_model / judge_model) with AliasChoices |
| ``core/config/__init__.py`` | 3 new _TOML_TO_SETTINGS mappings (``llm.plan_model`` / ``llm.act_model`` / ``llm.judge_model``) |
| ``core/agent/loop/agent_loop.py`` | ``__init__`` reads ``settings.act_model`` when caller passes ``model=None``; ``_call_llm`` gains ``model: str \| None = None`` keyword override threading through to adapter call |
| ``core/agent/loop/_decomposition.py`` | ``try_decompose`` instantiates ``GoalDecomposer(model=settings.plan_model or loop.model)`` |
| ``core/agent/loop/_model_switching.py`` | ``_settings_model_target`` reads ``settings.act_model or settings.model`` so Opus-primary + Sonnet-act doesn't revert mid-session (Codex MCP HIGH #1) |
| ``core/agent/verify.py`` | ``_verify_llm_judge`` fully wired; new ``verify_turn_async`` + ``_verify_llm_judge_async`` for async callers; ``asyncio.wait_for`` 120s timeout; judge usage tracking |
| ``core/agent/loop/_lifecycle.py`` | new ``_run_turn_verify_async`` + shared ``_finalize_verify_outcome``; ``finalize_and_return_async`` awaits async verify |
| ``tests/test_model_split.py`` (NEW) | 30 tests — settings defaults / env / TOML; AgenticLoop act_model cascade; ``_call_llm`` signature; goal decomposition uses plan_model; judge LLM call + parse + fallback (4 paths); async path + timeout + OFF; drift target uses act_model (3 cases); judge usage tracking + tracker-failure resilience |
| ``CHANGELOG.md`` | ``[Unreleased]`` ``### Added`` entry |
| ``uv.lock`` | version bump (auto-synced) |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| Q1 — already exists? | No | Model is loop-bound, not phase-bound; verify llm_judge was stubbed |
| Q2 — what breaks if we don't do this? | A1 (Dynamic Replan) needs separate plan/act models for cost-aware replan; verify llm_judge stub blocks operators from exercising the mode |
| Q3 — measurable? | Yes — 30 unit tests cover all 3 knobs + judge round-trip + async timeout + drift |
| Q4 — simplest impl? | Empty-default knobs (zero behaviour change pre-A6) + ``getattr`` defensive reads (mock-friendly) |
| Q5 — frontier coverage | ReWOO + Self-Discover + Claude Code Plan/Edit |

**Deferred to follow-up**: Per-phase cost tagging (``phase="judge"``) — currently judge cost is recorded but aggregated with action cost in the same TokenTracker. Needs adapter-level API extension.

## Verification

- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run ruff format --check core/ tests/`` — 812 files formatted
- [x] ``uv run mypy core/ plugins/`` — 0 errors in 438 source files
- [x] ``uv run pytest tests/test_model_split.py`` — 30/30 passed
- [x] Scoped regression (187 tests in agent_loop / arun / verify / budget / handoff / session_metrics / model_split / hooks) — clean

## Codex MCP review

Thread ``019e5412-2359-78c1-8e36-aeeb57027afc``:
- **HIGH #1** — act_model overwritten by drift sync. Fixed via ``_settings_model_target`` reading ``settings.act_model or settings.model``.
- **HIGH #2** — Cross-event-loop judge call. Fixed via async-native judge path (``verify_turn_async`` + ``_verify_llm_judge_async``).
- **MEDIUM #3** — No timeout on judge LLM call. Fixed via ``asyncio.wait_for(_call_llm(...), timeout=120.0)``.
- **MEDIUM #4** — Judge LLM usage not recorded. Fixed via ``loop._track_usage_async(response)`` after non-None response.
- **LOW #5** — CHANGELOG fallback count off. Fixed: 4 paths (no loop / None response / empty text / exception).
- Follow-up reply confirmed all 5 fixes.

## Reference

- Plan: ``docs/plans/agentic-loop-evolution.md`` § Layer 3 A6
- Operator decision: ``project_budget_handoff_decision`` memory (2026-05-23)
- Frontier sources: ReWOO (arxiv 2305.18323) + Self-Discover (arxiv 2402.03620) + Claude Code Plan/Edit mode
- Sprint chain: PR-CL-BUDGET (#1537) → PR-CL-A3 (#1539) → **PR-CL-A6 (this)** → PR-CL-A1

🤖 Generated with [Claude Code](https://claude.com/claude-code)