### PR TITLE
docs(scaffold): CANNOT/DONT 정돈 + RUNTIME CANNOT rename + G1 identity parity fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,46 @@ functional change.
   HumanEval pass@1 via verbal RL) + OpenAI o1 chain-of-verify + AgentHub
   per-branch verify gate + Claude Code Plan/Edit implicit verify.
 
+### Changed
+
+- **Scaffold consolidation — `CLAUDE.md` + `GEODE.md` 정돈.** Absorbed the
+  free-standing `### DONT — Real Incidents` table into the structured
+  `### CANNOT` + `### Wiring Verification` + `### Refactoring Deception
+  Prevention` tables so every prohibition rule lives in one indexable
+  place with the originating sprint incident attached. Five new CANNOT
+  rows distilled from prior incidents (graceful-contract scope / latest
+  vs promoted SoT / dual-SoT drift invariant / 제거 disambiguation /
+  no-emoji-no-card UI). Consolidated the triple-listed Quality Gates
+  recipe (was duplicated across §3 Implement, §4b Correctness, and the
+  trailing `### Quality Gates` table) into a single trailing SoT with
+  the two earlier locations now linking back. Compressed `Refactoring
+  Deception Prevention` (5 rows → 2: implementation-completeness +
+  CHANGELOG/PR-body parity) and `§4c Cleanliness` (4-row table → one
+  line delegating to the `anti-deception-checklist` skill) so the
+  scaffold no longer duplicates skill content. Added cross-reference
+  banners on `### CANNOT`, `### Wiring Verification`, the worktree row,
+  the PR row, and the `4-layer stack` line so each scaffold table now
+  names the skill or sibling document it pairs with.
+- **`GEODE.md` runtime-vs-dev scope disambiguation.** Renamed
+  `## CANNOT` → `## RUNTIME CANNOT` so the runtime agent-guardrail
+  table is no longer confusable with the scaffold's development-time
+  `### CANNOT`. Both headers now carry a one-line banner pointing at
+  the sibling document.
+
+### Fixed
+
+- **G1 identity context — `RUNTIME CANNOT` header parity.**
+  `core/agent/system_prompt.py:_build_identity_context` looked for the
+  hardcoded literal `"## CANNOT"` when extracting the agent-identity
+  block from `GEODE.md`. The scaffold-consolidation rename to
+  `## RUNTIME CANNOT` would have silently dropped the 4-line CANNOT
+  section (G3 Grounding / cross-validation / Confidence loopback /
+  sub-agent delegation) from every LLM system prompt's
+  `<agent_identity>` block. `target_sections` (line 477) and the
+  surrounding module + function docstrings now reference
+  `## RUNTIME CANNOT`. Verified by direct call — the block still
+  contains all 4 RUNTIME CANNOT bullets after the rename.
+
 ## [0.99.44] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ uv run geode "schedule daily standup reminder at 9am"
 ## Project Structure
 
 Production code splits into two top-level Python packages:
-- `core/` — general-purpose autonomous agent runtime. 4-layer stack.
+- `core/` — general-purpose autonomous agent runtime. 4-layer stack (layer diagram → `GEODE.md` → Architecture).
 - `plugins/` — first-party auxiliary plugins.
 
 Check module count: `find core/ -name "*.py" | wc -l` for core, `find plugins/ -name "*.py" | wc -l` for plugins.
@@ -74,11 +74,15 @@ own fixture/E2E gates.
 
 ### CANNOT — Absolute Prohibition Rules
 
+> Development-time guardrails — what the *engineer* must not do when building GEODE.
+> For runtime guardrails (what GEODE the *agent* refuses to do at execution time), see `GEODE.md` → `## RUNTIME CANNOT`.
+
 These cannot be violated at any stage. Violations must be immediately halted and corrected.
+Rationale cites the originating incident when one exists. The `karpathy-patterns` skill's "Anti-patterns" table is the abstract counterpart — this table holds the concrete project-level rules and the sprint incidents that produced them. Before every PR push, scan for an analogous pattern; if your PR could match a row, it probably does.
 
 | Area | Rule | Rationale |
 |------|------|-----------|
-| **Git** | No code work without a worktree | Isolated execution (OpenClaw Session) |
+| **Git** | No code work without a worktree (allocation procedure → [§0](#0-board--worktree-alloc)) | Isolated execution (OpenClaw Session) |
 | | No direct push to main/develop — PR → CI → merge | Ratchet (P4) |
 | | No deleting other sessions' worktrees (`.owner` mismatch) | Ownership protection |
 | | No `git checkout` switching within a worktree | Isolation maintenance |
@@ -86,20 +90,26 @@ These cannot be violated at any stage. Violations must be immediately halted and
 | | No branch creation when remote is out of sync | Conflict prevention |
 | | No claiming "branch needs sync" from commit count alone — verify content with `git diff A B --stat` first | Graph asymmetry ≠ content asymmetry (gitflow merge commits) |
 | **Planning** | No starting implementation without Socratic Gate (except bugs/docs) | Prevent over-engineering |
+| | No interpreting ambiguous "제거"/"remove" as code-path deletion — disambiguate first (knob vs deletion) | Avoid wasted reverts. *Incident: PR-fallback-knob ~30-file revert (2026-05-21)* |
 | **Quality** | No committing with lint/type/test failures | Ratchet (P4) |
 | | No placeholders (XXXX) in metrics — measured values only | Truth guarantee |
 | | No excessive `# type: ignore` — fix type errors instead | Correctness |
 | | No bare `_` for unused variables — use `_prefix` naming (e.g. `_tok_before`) | Readability |
 | | No unauthorized live test (`-m live`) execution | Cost control (P3) |
+| | No "graceful" return contract without applying it at every schema-typed cast (not just outer try) | Boundary completeness. *Incident: PR-G3 #1347 (2026-05-20) — `float()` on non-numeric raised before contract* |
+| | No conflating "latest" and "promoted" SoTs — readers must document which they assume; persist both if the loop needs both | SoT clarity. *Incident: PR-G2 #1346 (2026-05-20) — downstream read stale evidence forever* |
+| | No dual SoT (disk + fallback literal) without shared anchor + drift invariant test | Drift prevention. *Incident: PR-MINIMAL-2 #1398 (2026-05-21) — `program.md` ↔ `_FALLBACK_SYSTEM_PROMPT` divergence* |
 | **Docs** | No omitting CHANGELOG from code commits | Traceability |
 | | No leaving `[Unreleased]` on main | Release discipline |
 | | No version mismatch across 5 locations | Single source of truth |
-| **PR** | No PR body without HEREDOC | Format consistency |
-| | No PR without a "Why" rationale | Decision record |
-| | No PR body without Summary/Why/Changes/Verification sections | Information completeness |
-| | No merging PRs that haven't passed CI guardrails | Ratchet (P4) |
+| | No emoji as section anchors / nav prefixes; no decorative card grids when content is data — dense table/list only on docs/site/CLI surfaces | Slop signal. *Incident: PR-CSP-14-UI mockup (2026-05-23) — see [[feedback-no-box-ui-no-emoji]]* |
+| **PR** | No PR that violates the [§6 template](#6-pr--merge) (HEREDOC body with Summary/Why/Changes/Verification) or merges without CI 5/5 green | Format + traceability + Ratchet (P4) |
 
 ### Wiring Verification (Anti-Disconnection)
+
+> Static parity invariants for runtime wiring (writer-reader, hook-bootstrap, ContextVar set-get).
+> For *pre-change* workflow (read-before-write, hypothesis), see `explore-reason-act` skill.
+> For *static dependency health* (layer violations, circular imports, eager loading), see `dependency-review` skill.
 
 | Item | Rule |
 |------|------|
@@ -107,39 +117,15 @@ These cannot be violated at any stage. Violations must be immediately halted and
 | **Hook registration** | Every hook handler must be registered in bootstrap.py. Handler exists ≠ handler fires. |
 | **ContextVar injection** | Every `get_*()` accessor must have a corresponding `set_*()` call in bootstrap. Unset ContextVar → None → silent skip. |
 | **Singleton lifecycle** | Singleton created at startup may use stale data. Verify refresh/invalidation path exists for mutable state (OAuth tokens, config). |
-| **Conditional read parity** | A reader that loads context in ONE branch (e.g. auto-pick) must load it in the SYMMETRIC branch (explicit input) too — otherwise the feature half-disconnects depending on call shape. |
-| **Writer destination tracked** | Every file the code writes for "audit / history / ledger" must be `git check-ignore`-clean. An ignored path silently breaks `git add`; the writer thinks it persisted, history doesn't. |
+| **Conditional read parity** | A reader that loads context in ONE branch (e.g. auto-pick) must load it in the SYMMETRIC branch (explicit input) too — otherwise the feature half-disconnects depending on call shape. *Incident: PR-G3 #1347 (2026-05-20) — `_resolve_target_dim` loaded baseline only for `--target-dim auto`.* |
+| **Writer destination tracked** | Every file the code writes for "audit / history / ledger" must be `git check-ignore`-clean. An ignored path silently breaks `git add`; the writer thinks it persisted, history doesn't. *Incident: PR-G5b #1350 (2026-05-20) — `autoresearch/state/mutations.jsonl` silently ignored, caught by Codex MCP after 8/8 CI green; pinned by `test_policy_files_not_gitignored`.* |
 
 ### Refactoring Deception Prevention
 
 | Item | Rule |
 |------|------|
-| **Partial implementation disguise** | No marking plan items complete when only partially implemented |
-| **Stub disguise** | No claiming extraction is complete with empty modules (`pass` only) |
-| **Original residue** | No marking "extraction complete" while code remains in the original (re-export only is allowed) |
-| **Zero-context verification** | Independent agent cross-checks plan document + diff → confirms all items implemented → FAIL on any omission |
-| **CHANGELOG/PR-body parity** | Every verb/adjective in the PR title + CHANGELOG ("git-tracked", "X-driven", "automatic", "committed") must be grep-provable in code. Run `git check-ignore`, `grep -rn "<source-doc>"`, and "is there a caller?" before push. |
-
-### DONT — Real Incidents (case studies)
-
-Karpathy program.md style: paste the failure verbatim so future-you doesn't repeat it.
-Append (don't rotate) — each row is a *frozen* lesson.
-
-| Date | Anti-pattern | What you said | What the code did | Lesson |
-|------|--------------|---------------|-------------------|--------|
-| 2026-05-20 PR-G5b #1350 | CHANGELOG/PR-body parity violation | "git-tracked audit log of every applied mutation" | `MUTATION_AUDIT_LOG_PATH = autoresearch/state/mutations.jsonl`, but `.gitignore` matches `autoresearch/state/*`. `git add` fails silently; `_git_commit_audit_log` returns False; ledger never enters git. | Run `git check-ignore <path>` on every path the PR claims is "tracked / committed / persisted". Caught by Codex MCP, missed by ruff/mypy/pytest/CI 8-of-8. Codified as test guard in `tests/test_ratchet_policies_in_repo.py::test_policy_files_not_gitignored` after PR-RATCHET-1 (2026-05-21). |
-| 2026-05-20 PR-G5b #1350 | CHANGELOG/PR-body parity violation | "program.md-driven self-improving loop runner" | `_SYSTEM_PROMPT` is a hardcoded f-string; `grep -rn "program.md" core/ autoresearch/` shows zero reads. PR title overstates implementation. | Any "X-driven" claim → `grep` for X. If the file isn't loaded, the claim is fiction. Fixed in `runner.py:_load_program_md` (G5b.fix1.b); pinned by `tests/test_self_improving_minimal_1.py::test_load_program_md_actually_reads_disk_file` (PR-MINIMAL-1, 2026-05-21). |
-| 2026-05-20 PR-G3 #1347 | Conditional read parity | "seed-generation reads baseline.json evidence" | `_resolve_target_dim` loads baseline ONLY in the `--target-dim auto` branch; explicit `--target-dim <name>` returns `(dim, None)`. Half the call sites get no evidence. | A new context-loading feature must work for ALL call shapes that touch the same downstream prompt. Symmetric branches > one-sided wiring. |
-| 2026-05-20 PR-G3 #1347 | Graceful-contract violation | "`load_baseline` returns `None` on unparseable JSON" | True for malformed JSON, but `float(v)` on non-numeric `dim_means` raises `ValueError` before the contract kicks in. | "Graceful" must be defined at every input boundary, not just the outer try. Schema-typed casts need their own try. |
-| 2026-05-20 PR-G2 #1346 | Reader-assumption drift | "evidence in baseline.json reaches downstream" | Evidence only persists when the audit PROMOTES the baseline. A failing/regressed audit never updates `baseline.json` → downstream reads stale evidence forever. | "Latest" and "promoted" are different SoTs. Document which one each reader assumes; persist both if the loop needs them. |
-| 2026-05-21 PR-fallback-knob | Premature scope expansion (deletion vs knob) | "FALLBACK 체인과 레이어를 제거해. Self-improving Loop + Agentic Loop 스코프에 전역으로 지켜야할 사안" → interpreted as *delete every code path*. After Steps 1-8 finished (~30 files), the user clarified "사용자가 명시적으로 튜닝할 여지를 남겨두는거면 찬성이야" — the intent was a *user-tunable knob*, not full deletion. | When a user directive says "제거" without specifying *what* is being removed (the silent default behaviour vs. the entire code path), pause to disambiguate: ask "should the chain be a knob the user can opt into, or should the chain code itself be deleted?" The cheap one-question gate would have saved ~30 edits + a `git checkout origin/develop -- <files>` revert. |
-| 2026-05-21 PR-MINIMAL-2 #1398 | Silent dual-prompt drift | The mutator runner reads `autoresearch/program.md` from disk via `_load_program_md()`; on `OSError` (missing file / unreadable) it falls back to the hardcoded `_FALLBACK_SYSTEM_PROMPT` literal. If an operator edits `program.md` but not the fallback (or vice versa), the LLM sees a different contract depending on whether the disk read succeeds — the loop continues running but with mismatched instructions. | Pin a stable anchor that BOTH paths must share (`## Setup` header in program.md, mutation-contract schema fields like `target_section`/`new_value`/`rationale` in the fallback) via a drift invariant test. Codified at `tests/test_self_improving_minimal_2.py::test_fallback_prompt_shares_setup_anchor_with_program_md` (PR-MINIMAL-2, 2026-05-21). |
-| 2026-05-23 PR-CSP-14-UI mockup | Slop UI signals — box-card + emoji | Initial literature-bundle mockup used emoji card icons (📊 audit / 📚 literature / 🧪 seeds / 🔬 validation) + rounded card boxes with hover-lift for the landing grid. User flagged as Slop signals — LLM-generated boilerplate aesthetic, not GEODE's dense-information style. | Never use emoji as section anchors / card titles / nav prefixes on docs/site/CLI surfaces. Prefer dense `<table>` + `<dl>` over decorative `<div class="card">` grids when content is data. Hierarchy via typography (h1/h2/h3 weight), not bordered card boxes. Emoji only allowed in opt-in report-generation outputs (CHANGELOG / blog posts). See `[[feedback-no-box-ui-no-emoji]]` for the full rule. |
-
-**How to use this table**:
-1. Before every PR push, scan the table for an analogous pattern. If your PR could match a row, it probably does.
-2. When a new incident lands, append (don't rewrite). The table is the project's accumulated immune system.
-3. The `karpathy-patterns` skill's "Anti-patterns" table is the abstract counterpart; this table holds the concrete sprint-level evidence.
+| **Implementation completeness** | No marking plan items complete when partially implemented, stubbed (`pass` only), or shelled out as re-exports while code remains in the original. An independent zero-context agent cross-checks plan + diff and FAILs on any omission. See `verification-team` + `anti-deception-checklist` skills for the operational checklist. |
+| **CHANGELOG/PR-body parity** | Every verb/adjective in the PR title + CHANGELOG ("git-tracked", "X-driven", "automatic", "committed") must be grep-provable in code. Run `git check-ignore`, `grep -rn "<source-doc>"`, and "is there a caller?" before push. *Incident: PR-G5b #1350 (2026-05-20) — both "git-tracked audit log" and "program.md-driven runner" were un-backed; fixed in `runner.py:_load_program_md` and pinned by `test_load_program_md_actually_reads_disk_file`.* |
 
 ### CAN — Permitted Freedoms
 
@@ -207,13 +193,7 @@ Record on Progress Board then allocate Worktree. On completion: `git push` → `
 
 #### 3. Implement → Unit Verify (iterate)
 
-Code changes → repeat 3 quality gates. Fix on failure.
-
-```bash
-uv run ruff check core/ tests/ plugins/      # Lint: 0 errors
-uv run mypy core/ plugins/                    # Type: 0 errors
-uv run pytest tests/ -m "not live"            # Test: 3900+ pass
-```
+Code changes → re-run the [Quality Gates](#quality-gates) on each iteration. Fix on failure before continuing.
 
 #### 4. Verify (Implementation GAP Audit)
 
@@ -230,21 +210,11 @@ uv run pytest tests/ -m "not live"            # Test: 3900+ pass
 
 **4b. Correctness — Quality gates + E2E**
 
-```bash
-uv run ruff check core/ tests/                      # Lint: 0 errors
-uv run mypy core/                                    # Type: 0 errors
-uv run pytest tests/ -m "not live"                   # Test: 3900+ pass
-uv run geode version                                 # CLI smoke
-```
+All 4 [Quality Gates](#quality-gates) must pass (lint / type / test / CLI smoke) plus any E2E relevant to the change.
 
 **4c. Cleanliness — Dead code & regression audit**
 
-| Check | FAIL condition |
-|-------|---------------|
-| Dead code | Unused import, unreachable function |
-| Test deletion | Test file line count decreased |
-| Lint bypass | New `# noqa`, `# type: ignore` added |
-| Secret exposure | Credentials in committed code |
+Run the `anti-deception-checklist` skill — it covers test deletion/disabling, lint bypass (`# noqa`, `# type: ignore`), coverage regression, secret exposure, and dependency downgrade. Any FAIL verdict blocks merge.
 
 **4d. Verification team (large-scale changes only)**
 

--- a/GEODE.md
+++ b/GEODE.md
@@ -21,7 +21,10 @@ analysis, automation, scheduling, and multi-step tool work.
 4. **Graceful Degradation**: Guarantees fallback paths even during API failures or model errors.
 5. **Reproducibility**: Maintains reproducibility through prompt hashes, seeds, and snapshots.
 
-## CANNOT
+## RUNTIME CANNOT
+
+> Runtime guardrails — what GEODE the *agent* refuses to do at execution time.
+> For development-time guardrails (what the *engineer* must not do when building GEODE), see `CLAUDE.md` → `### CANNOT`.
 
 - Never makes judgments without evidence (G3 Grounding violation)
 - Never finalizes a single LLM output as the definitive result (cross-validation required)

--- a/core/agent/system_prompt.py
+++ b/core/agent/system_prompt.py
@@ -4,7 +4,7 @@ Builds the base system prompt from the router.md template, enriched with
 project memory context.
 
 Memory hierarchy injected into the system prompt (G1-G3):
-  G1: GEODE.md  — Agent identity (Core Principles + CANNOT + Defaults, ~20 lines)
+  G1: GEODE.md  — Agent identity (Core Principles + RUNTIME CANNOT + Defaults, ~20 lines)
   G2: .geode/MEMORY.md — Project meta-index (architecture, pipelines, key files)
   G3: .geode/LEARNING.md — Agent learning (patterns, corrections, preferences)
   G4: .geode/memory/PROJECT.md — Runtime insights + rules
@@ -460,7 +460,7 @@ def _build_user_context() -> str:
 
 
 def _build_identity_context() -> str:
-    """G1: Extract core identity from GEODE.md (Core Principles + CANNOT + Defaults).
+    """G1: Extract core identity from GEODE.md (Core Principles + RUNTIME CANNOT + Defaults).
 
     Reads GEODE.md via OrganizationMemory.get_soul() and extracts only the
     essential sections to stay within context budget (~20 lines).
@@ -473,8 +473,8 @@ def _build_identity_context() -> str:
         if not soul:
             return ""
 
-        # Extract targeted sections: Core Principles, CANNOT, Defaults
-        target_sections = {"## Core Principles", "## CANNOT", "## Defaults"}
+        # Extract targeted sections: Core Principles, RUNTIME CANNOT, Defaults
+        target_sections = {"## Core Principles", "## RUNTIME CANNOT", "## Defaults"}
         extracted_lines: list[str] = []
 
         current_in_target = False

--- a/plugins/petri_audit/optimize.py
+++ b/plugins/petri_audit/optimize.py
@@ -25,7 +25,7 @@ Live invocation triggers paid LLM calls. Default ``dry_run=True`` —
 the report contains the constructed ``compile_id``, the would-be
 output path, and the cost estimate, with no DSPy import on the cold
 path. ``dry_run=False`` requires explicit user authorisation per
-CLAUDE.md L99.
+`CLAUDE.md` → CANNOT → Quality: "No unauthorized live test execution".
 """
 
 from __future__ import annotations

--- a/plugins/petri_audit/targets/geode_target.py
+++ b/plugins/petri_audit/targets/geode_target.py
@@ -188,7 +188,8 @@ async def _default_geode_runner(
     Live LLM authorisation: this function will trigger live API calls
     when the bootstrapped readiness lacks ``force_dry_run``. Callers
     embedding it in a ``geode/<base>`` audit MUST have explicit user
-    authorisation per CLAUDE.md L99.
+    authorisation per `CLAUDE.md` → CANNOT → Quality:
+    "No unauthorized live test execution".
     """
     if not messages:
         raise ValueError(

--- a/plugins/petri_audit/textgrad_wrapper.py
+++ b/plugins/petri_audit/textgrad_wrapper.py
@@ -11,7 +11,7 @@ This wrapper is intentionally thin — it does not duplicate TextGrad's
 public API, just gates the depth/chaining knobs and lazy-imports the
 underlying library so the cold path is unaffected when ``[reason]`` is
 absent. Live calls require an explicit user authorisation per
-CLAUDE.md L99.
+`CLAUDE.md` → CANNOT → Quality: "No unauthorized live test execution".
 """
 
 from __future__ import annotations

--- a/tests/test_adr_012_parity.py
+++ b/tests/test_adr_012_parity.py
@@ -4,10 +4,11 @@ ground-truth runtime constants (`autoresearch/train.py` /
 `autoresearch/bench_means.py`).
 
 PR-SIL-5THEME C1 (2026-05-23) — codifies the
-CHANGELOG/PR-body-parity anti-deception lesson (CLAUDE.md DONT row
-1, PR-G5b #1350) for the §S6/§S6b ADR amendments. Without these
-tests a future ADR edit could regress the doc to "3축" or drop
-``§S6`` and the build would stay green.
+CHANGELOG/PR-body-parity anti-deception lesson (`CLAUDE.md` →
+Refactoring Deception Prevention → "CHANGELOG/PR-body parity",
+incident PR-G5b #1350) for the §S6/§S6b ADR amendments. Without
+these tests a future ADR edit could regress the doc to "3축" or
+drop ``§S6`` and the build would stay green.
 """
 
 from __future__ import annotations

--- a/tests/test_self_improving_minimal_1.py
+++ b/tests/test_self_improving_minimal_1.py
@@ -5,8 +5,9 @@ Pins:
 - ``/self-improving rollback`` prints git revert recipes (B2)
 - ``/self-improving rollback <mutation_id>`` includes the grep form
 - ``_load_program_md`` actually reads ``autoresearch/program.md``
-  from disk (H4 regression guard for the PR-G5b incident in the
-  CLAUDE.md DONT table)
+  from disk (H4 regression guard for incident PR-G5b #1350, codified
+  in `CLAUDE.md` → Refactoring Deception Prevention →
+  "CHANGELOG/PR-body parity")
 """
 
 from __future__ import annotations
@@ -114,7 +115,8 @@ def test_unknown_action_help_line_lists_history_and_rollback(
 
 
 def test_load_program_md_actually_reads_disk_file() -> None:
-    """CLAUDE.md DONT table 2026-05-20 PR-G5b #1350 row:
+    """Incident PR-G5b #1350 (2026-05-20), codified in `CLAUDE.md` →
+    Refactoring Deception Prevention → "CHANGELOG/PR-body parity":
     ``_SYSTEM_PROMPT`` was a hardcoded f-string while the PR title
     claimed "program.md-driven". The G5b.fix1.b commit introduced
     ``_load_program_md`` which actually reads

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.43"
+version = "0.99.44"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- `CLAUDE.md` `### DONT — Real Incidents` (8 case-study rows) 을 구조화된 `### CANNOT` / `### Wiring Verification` / `### Refactoring Deception Prevention` 표로 흡수 — 5 신규 CANNOT 룰 + 기존 룰에 incident 보강. Quality Gates 3중 게재 → 단일 SoT. Refactoring Deception 5행 → 2행 + §4c Cleanliness 표 → 스킬 위임. 5 cross-ref 배너 추가.
- `GEODE.md` `## CANNOT` → `## RUNTIME CANNOT` rename — 런타임 가드레일과 스캐폴드 dev-CANNOT 의 scope 충돌 해소. 양방향 cross-ref 배너.
- `core/agent/system_prompt.py:_build_identity_context` 의 `target_sections` literal 매치를 `## RUNTIME CANNOT` 로 동기화 — rename 이 모든 LLM `<agent_identity>` 시스템 프롬프트에서 CANNOT 4행 (G3 Grounding / cross-validation / Confidence loopback / sub-agent delegation) 을 silently drop 시킬 뻔한 런타임 충돌 fix.

## Why

스캐폴드 DONT 표가 8행으로 누적되면서 같은 패턴이 CANNOT/Wiring/Refactoring 표와 *parallel rule set* 으로 분기됨 — 한 가지 incident 가 두 곳에 등록되거나, 어느 표가 권위인지 모호. 흡수해서 단일 indexable place 로 통합.

`GEODE.md` 와 `CLAUDE.md` 양쪽에 `## CANNOT` 헤더가 있어서 (전자는 runtime 가드, 후자는 dev 가드) 검색·언급할 때 혼선. rename 으로 scope 명확화. 단 GEODE.md 헤더는 `system_prompt.py` 가 *string literal 로 parse* 해서 G1 identity 컨텍스트로 inject — rename 직후 그 코드 측도 동기화하지 않으면 런타임 시스템 프롬프트에서 RUNTIME CANNOT 섹션 4행이 *전부 누락*. 점검 과정에서 발견하여 같은 PR 으로 fix.

스캐폴드 코멘트가 hardcoded line ref (`CLAUDE.md L99`) 와 사라진 `DONT row/table` 을 가리키던 5개 stale reference (plugins 3 + tests 2) 도 rule-name + incident anchor 로 대체.

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | DONT 표 제거. CANNOT 5 신규 룰, Wiring/Refactoring 표 incident 보강, Quality Gates 단일 SoT, Refactoring 압축, §4c 스킬 위임, cross-ref 배너 5개. CANNOT 헤더에 runtime vs dev 구분 배너 |
| `GEODE.md` | `## CANNOT` → `## RUNTIME CANNOT` + dev 카운터파트 cross-ref 배너 |
| `core/agent/system_prompt.py` | `target_sections` literal `"## CANNOT"` → `"## RUNTIME CANNOT"`. 모듈 docstring + `_build_identity_context` docstring 동기화 |
| `plugins/petri_audit/optimize.py` | `CLAUDE.md L99` → `CLAUDE.md → CANNOT → Quality: "No unauthorized live test execution"` |
| `plugins/petri_audit/textgrad_wrapper.py` | 동일 패턴 대체 |
| `plugins/petri_audit/targets/geode_target.py` | 동일 패턴 대체 |
| `tests/test_adr_012_parity.py` | `CLAUDE.md DONT row 1` → `CLAUDE.md → Refactoring Deception Prevention → "CHANGELOG/PR-body parity", incident PR-G5b #1350` |
| `tests/test_self_improving_minimal_1.py` | module docstring + test docstring 2곳 동일 anchor 대체 |
| `CHANGELOG.md` | `[Unreleased]` 에 Changed + Fixed 섹션 추가 |
| `uv.lock` | `geode-agent` 0.99.43 → 0.99.44 stamp 동기화 (release/v0.99.44 잔재) |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| DONT 8행의 모든 lesson 이 새 CANNOT/Wiring/Refactoring 룰로 흡수 | Implemented | DONT 1-2 → Refactoring `CHANGELOG/PR-body parity` 보강, 3 → Wiring `Conditional read parity` 보강, 4 → Quality `graceful contract`, 5 → Quality `latest vs promoted`, 6 → Planning `제거 disambiguation`, 7 → Quality `dual SoT drift`, 8 → Docs `no emoji / no card` |
| `system_prompt.py` 외에 `## CANNOT` 헤더를 string-match 하는 다른 코드 | Verified absent | 전체 트리 grep — 본 PR fix 이후 잔존 0건 |
| Stale `CLAUDE.md L99` / `DONT row/table` 잔존 | Verified absent | 전체 트리 grep `CLAUDE\.md L[0-9]+\|CLAUDE\.md DONT` 결과 empty |
| 5-location version stamp | N/A | docs + 1-line fix, version bump 없음. v0.99.44 유지 |

## Verification

- [x] `ruff check core/ tests/ plugins/` clean
- [x] `ruff format --check core/ tests/ plugins/` 873 files already formatted
- [x] `mypy core/ plugins/` 438 source files, no issues
- [x] `lint-imports` 4 contracts kept, 0 broken
- [x] `pytest tests/ -m "not live"` 6981 passed, 56 skipped (217.74s)
- [x] CLI smoke `geode version` → GEODE v0.99.44
- [x] `_build_identity_context()` 직접 호출 — `<agent_identity>` 블록에 RUNTIME CANNOT 4 bullet (G3 Grounding 포함) 모두 inject 확인

## Reference

- 런타임 충돌 발견 경위: rename 직후 사용자 요청으로 점검 → `core/agent/system_prompt.py:477` `target_sections = {"## Core Principles", "## CANNOT", "## Defaults"}` literal 매치 노출 → fix
- 스캐폴드 정돈 가이드: `karpathy-patterns` 스킬 (incident table 의 abstract counterpart) + `anti-deception-checklist` 스킬 (§4c Cleanliness 위임 대상)