### PR TITLE
feat(temperature): config-driven sampling, drop 6 hardcoded literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,27 @@ functional change.
 
 ### Changed
 
+- **PR-TEMP — LLM sampling temperature is config-driven, no more hardcoded
+  constants.** Six call sites previously held literal floats (agent loop
+  ``0.0`` × 2, reflection ``0.2``, cross-LLM verification ``0.1`` × 2,
+  commentary signature default ``0.4``, self-improving mutation ``0.3``,
+  progressive compression ``0.0``). Each one now reads from a new
+  ``Settings.temperature_*`` knob, exposed via ``~/.geode/config.toml`` or
+  the matching ``GEODE_TEMPERATURE_*`` env var. Defaults reflect a frontier-
+  API grounding pass (Anthropic / OpenAI / Gemini docs + Moonshot/Kimi):
+  most paths land on ``1.0`` (provider default — Gemini 3 explicitly warns
+  against lowering temperature; OpenAI reasoning models reject ≠ 1);
+  ``temperature_verification`` and ``temperature_progressive_compression``
+  default to ``0.0`` because cross-LLM agreement and reproducible summaries
+  are functional invariants where stochastic output is meaningless.
+  ``tests/test_temperature_config_invariants.py`` (NEW, 19 cases) ratchets
+  the migration: Settings keys + defaults + range validation, plus a per-
+  site grep guard that fails if a literal ``temperature=<float>`` kwarg
+  sneaks back into any of the six policy sites. ``Settings.temperature_*``
+  fields enforce ``ge=0.0, le=2.0``; per-provider clamping (Opus 4.x adaptive
+  models stripping sampling params, Codex gpt-5.x omitting temperature
+  entirely) is untouched and still kicks in downstream.
+
 - **Step I.a — Codex OAuth header construction collapsed onto one helper.**
   Four call sites built the same
   ``{"originator": "codex_cli_rs", "ChatGPT-Account-ID": <jwt-claim>}`` dict

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -285,6 +285,8 @@ async def reflect_async(
             # ``_extract_reflection_input → None → keep previous
             # state``. Cross-provider: ``"auto"`` normalises to
             # ``"auto"`` on OpenAI/Codex via the shared normaliser.
+            from core.config import settings as _settings
+
             return await adapter.agentic_call(
                 model=m,
                 system=active_system,
@@ -292,7 +294,7 @@ async def reflect_async(
                 tools=[active_tool],
                 tool_choice="auto",
                 max_tokens=max_tokens,
-                temperature=0.2,
+                temperature=_settings.temperature_reflection,
             )
 
         response, _used_model = await call_with_failover([model], _do_call)

--- a/core/agent/loop/agent_loop.py
+++ b/core/agent/loop/agent_loop.py
@@ -1741,6 +1741,7 @@ class AgenticLoop:
         # v0.90.0 — the prior overthinking effort-downgrade branch is gone:
         # the post-response check now exits the loop on the same condition,
         # so the only remaining adaptive case is wrap-up.
+        from core.config import settings as _settings
         from core.llm.token_tracker import MODEL_CONTEXT_WINDOW
 
         ctx_window = MODEL_CONTEXT_WINDOW.get(self.model, 200_000)
@@ -1754,6 +1755,11 @@ class AgenticLoop:
             adaptive_max_tokens = max(4096, min(self.max_tokens, ctx_window // 200))
             adaptive_thinking = 0
             adaptive_effort = "low"
+
+        # PR-TEMP (2026-05-23) — config-driven temperature, replacing the
+        # prior hardcoded 0.0. See ``Settings.temperature_agent_loop`` for
+        # the frontier-API grounding behind the new 1.0 default.
+        loop_temperature = _settings.temperature_agent_loop
 
         if self._new_adapter is not None:
             # v0.99.40 Follow-up A — opt-in adapter route. Build adapter-neutral
@@ -1772,7 +1778,7 @@ class AgenticLoop:
                 tools=self._tools,
                 tool_choice=tool_choice,
                 max_tokens=adaptive_max_tokens,
-                temperature=0.0,
+                temperature=loop_temperature,
                 thinking_budget=adaptive_thinking,
                 effort=adaptive_effort,
             )
@@ -1796,7 +1802,7 @@ class AgenticLoop:
                 tools=self._tools,
                 tool_choice=tool_choice,
                 max_tokens=adaptive_max_tokens,
-                temperature=0.0,
+                temperature=loop_temperature,
                 thinking_budget=adaptive_thinking,
                 effort=adaptive_effort,
             )

--- a/core/config/_settings.py
+++ b/core/config/_settings.py
@@ -112,6 +112,110 @@ class Settings(BaseSettings):
             "before any throttling kicks in. PR-C (2026-05-21)."
         ),
     )
+    # Temperature — config-driven sampling (PR-TEMP, 2026-05-23).
+    # Replaces six hardcoded literals (agent_loop 0.0 / reflection 0.2 /
+    # verification 0.1 / commentary 0.4 / mutation 0.3 / compression 0.0)
+    # with operator-tunable knobs. Frontier API grounding:
+    #   * Anthropic: default 1.0, range 0.0-1.0. "closer to 0.0 for
+    #     analytical / multiple choice, closer to 1.0 for creative and
+    #     generative tasks."
+    #   * OpenAI: default 1.0, range 0.0-2.0. Reasoning models (o-series,
+    #     gpt-5 family) reject non-default sampling — the codex adapter's
+    #     ``_is_codex_reasoning_model`` path omits temperature for those.
+    #   * Gemini 3: docs strongly recommend keeping temperature at 1.0;
+    #     lowering "may lead to unexpected behavior, such as looping or
+    #     degraded performance, particularly in complex mathematical or
+    #     reasoning tasks."
+    # Most defaults sit at 1.0 (= provider default) so each provider's
+    # adaptive-sampling logic kicks in unmodified. Verification + budget
+    # compression default to 0.0 because their downstream consumers (cross-
+    # LLM agreement coefficient + reproducible summaries) are functional
+    # invariants where stochastic output is meaningless.
+    temperature_agent_loop: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        validation_alias=AliasChoices(
+            "temperature_agent_loop",
+            "GEODE_TEMPERATURE_AGENT_LOOP",
+        ),
+        description=(
+            "Sampling temperature for the main agentic loop's tool-use "
+            "call. Previously hardcoded to 0.0; the new default 1.0 "
+            "matches Anthropic / OpenAI / Gemini provider defaults."
+        ),
+    )
+    temperature_reflection: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        validation_alias=AliasChoices(
+            "temperature_reflection",
+            "GEODE_TEMPERATURE_REFLECTION",
+        ),
+        description=(
+            "Sampling temperature for the reflection node's hypothesis / "
+            "confidence call. Previously hardcoded to 0.2."
+        ),
+    )
+    temperature_verification: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=2.0,
+        validation_alias=AliasChoices(
+            "temperature_verification",
+            "GEODE_TEMPERATURE_VERIFICATION",
+        ),
+        description=(
+            "Sampling temperature for cross-LLM agreement rescoring. "
+            "Defaults to 0.0 because consensus needs determinism — "
+            "stochastic rescoring would make the G3 agreement coefficient "
+            "noisy. Operators may raise it if the secondary model rejects "
+            "0.0 sampling. Previously hardcoded to 0.1."
+        ),
+    )
+    temperature_commentary: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        validation_alias=AliasChoices(
+            "temperature_commentary",
+            "GEODE_TEMPERATURE_COMMENTARY",
+        ),
+        description=(
+            "Sampling temperature for tool-result commentary generation. "
+            "Previously hardcoded to 0.4 (signature default)."
+        ),
+    )
+    temperature_self_improving_mutation: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        validation_alias=AliasChoices(
+            "temperature_self_improving_mutation",
+            "GEODE_TEMPERATURE_SELF_IMPROVING_MUTATION",
+        ),
+        description=(
+            "Sampling temperature for the self-improving-loop mutator "
+            "call. Previously hardcoded to 0.3."
+        ),
+    )
+    temperature_progressive_compression: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=2.0,
+        validation_alias=AliasChoices(
+            "temperature_progressive_compression",
+            "GEODE_TEMPERATURE_PROGRESSIVE_COMPRESSION",
+        ),
+        description=(
+            "Sampling temperature for budget-summarisation calls in "
+            "progressive context compression. Defaults to 0.0 so "
+            "summaries are reproducible across re-runs. Previously "
+            "hardcoded to 0.0."
+        ),
+    )
+
     verbose: bool = False
     checkpoint_db: str = "geode_checkpoints.db"
 

--- a/core/llm/commentary.py
+++ b/core/llm/commentary.py
@@ -39,12 +39,20 @@ def generate_commentary(
     *,
     model: str | None = None,
     max_tokens: int = 256,
-    temperature: float = 0.4,
+    temperature: float | None = None,
 ) -> str | None:
     """Generate a brief LLM commentary for tool call results.
 
+    ``temperature`` defaults to ``Settings.temperature_commentary`` when
+    omitted (PR-TEMP, 2026-05-23). Callers can still pass an explicit
+    value to override.
+
     Returns the commentary text, or None if generation fails for any reason.
     """
+    if temperature is None:
+        from core.config import settings as _settings
+
+        temperature = _settings.temperature_commentary
     try:
         context_summary = _format_context(context)
         user_prompt = COMMENTARY_USER.format(

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -597,6 +597,10 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
 
         return invoke_codex_cli(system_prompt=system_prompt, user_prompt=user_prompt)
 
+    from core.config import settings as _settings
+
+    mutator_temperature = _settings.temperature_self_improving_mutation
+
     async def _do_call(m: str) -> object:
         return await adapter.agentic_call(
             model=m,
@@ -605,7 +609,7 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
             tools=[],
             tool_choice={"type": "auto"},
             max_tokens=max_tokens,
-            temperature=0.3,
+            temperature=mutator_temperature,
         )
 
     # ``call_with_failover`` is the router's async dispatcher (transport

--- a/core/verification/cross_llm.py
+++ b/core/verification/cross_llm.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import numpy as np
 
+from core.config import settings
 from core.llm.prompts import CROSS_LLM_DUAL_VERIFY, CROSS_LLM_RESCORE, CROSS_LLM_SYSTEM
 from core.llm.router import LLMClientPort
 from core.state import GeodeState
@@ -129,7 +130,7 @@ def run_cross_llm_check(
             response = secondary_adapter.generate(
                 CROSS_LLM_SYSTEM,
                 rescore_prompt,
-                temperature=0.1,
+                temperature=settings.temperature_verification,
                 max_tokens=10,
             )
             secondary_score = _parse_secondary_score(response)
@@ -195,7 +196,7 @@ def run_dual_adapter_check(
         response = secondary_adapter.generate(
             CROSS_LLM_SYSTEM,
             verification_prompt,
-            temperature=0.1,
+            temperature=settings.temperature_verification,
             max_tokens=10,
         )
         secondary_agreement = _parse_secondary_score(response)

--- a/experimental/orchestration/progressive_compression.py
+++ b/experimental/orchestration/progressive_compression.py
@@ -274,6 +274,8 @@ class ProgressiveCompressor:
             client = _get_openai_client()
             if client is None:
                 return None
+            from core.config import settings as _settings
+
             response = client.chat.completions.create(
                 model="gpt-4.1-mini",
                 messages=[
@@ -281,7 +283,7 @@ class ProgressiveCompressor:
                     {"role": "user", "content": text},
                 ],
                 max_tokens=256,
-                temperature=0.0,
+                temperature=_settings.temperature_progressive_compression,
             )
             choice = response.choices[0] if response.choices else None
             if choice and choice.message and choice.message.content:

--- a/tests/test_temperature_config_invariants.py
+++ b/tests/test_temperature_config_invariants.py
@@ -1,0 +1,153 @@
+"""PR-TEMP (2026-05-23) invariants — temperature is config-driven, not hardcoded.
+
+Six former code constants (agent_loop 0.0 / reflection 0.2 / verification 0.1 /
+commentary 0.4 / self-improving mutation 0.3 / progressive compression 0.0)
+were lifted into ``Settings.temperature_*`` knobs so operators can tune each
+call path via ``~/.geode/config.toml`` or env vars.
+
+These tests ratchet the migration so future edits cannot silently
+re-introduce a literal at the same site (Karpathy P4 ratchet).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from core.config import settings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# 1. Settings surface — 6 keys present with frontier-grounded defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("attr", "expected_default"),
+    [
+        ("temperature_agent_loop", 1.0),
+        ("temperature_reflection", 1.0),
+        ("temperature_verification", 0.0),
+        ("temperature_commentary", 1.0),
+        ("temperature_self_improving_mutation", 1.0),
+        ("temperature_progressive_compression", 0.0),
+    ],
+)
+def test_temperature_setting_default(attr: str, expected_default: float) -> None:
+    """Each temperature knob must exist on ``Settings`` with the expected
+    frontier-aligned default. The defaults encode the design decision:
+    most paths default to 1.0 (provider default — Anthropic/OpenAI/Gemini
+    all converge on 1.0); verification and compression default to 0.0
+    because their downstream consumers (cross-LLM agreement coefficient +
+    reproducible summaries) are functional invariants where stochastic
+    output is meaningless.
+    """
+    assert hasattr(settings, attr), f"Settings.{attr} missing"
+    value = getattr(settings, attr)
+    assert isinstance(value, float)
+    assert value == expected_default, (
+        f"Settings.{attr} default drift: expected {expected_default}, got {value}"
+    )
+
+
+def test_temperature_setting_range_validation() -> None:
+    """Each temperature knob must reject out-of-range values
+    (``ge=0.0, le=2.0``). The cap at 2.0 covers OpenAI's wider range
+    while Anthropic's narrower 0.0-1.0 contract is still safe because
+    every adapter clamps / strips before hitting the wire.
+    """
+    from core.config._settings import Settings
+    from pydantic import ValidationError
+
+    for attr in (
+        "temperature_agent_loop",
+        "temperature_reflection",
+        "temperature_verification",
+        "temperature_commentary",
+        "temperature_self_improving_mutation",
+        "temperature_progressive_compression",
+    ):
+        with pytest.raises(ValidationError):
+            Settings(**{attr: -0.1})
+        with pytest.raises(ValidationError):
+            Settings(**{attr: 2.1})
+
+
+# ---------------------------------------------------------------------------
+# 2. Call-site ratchet — no hardcoded temperature literals at the 7 sites
+# ---------------------------------------------------------------------------
+
+
+# Each entry is (path relative to repo root, expected ``settings.temperature_*``
+# reference substring). The test scans the file for the reference; absence is
+# a regression (someone reverted to a literal or removed the call entirely).
+_RATCHET_SITES = (
+    (
+        Path("core/agent/loop/agent_loop.py"),
+        "_settings.temperature_agent_loop",
+    ),
+    (
+        Path("core/agent/loop/_reflection.py"),
+        "_settings.temperature_reflection",
+    ),
+    (
+        Path("core/verification/cross_llm.py"),
+        "settings.temperature_verification",
+    ),
+    (
+        Path("core/llm/commentary.py"),
+        "_settings.temperature_commentary",
+    ),
+    (
+        Path("core/self_improving_loop/runner.py"),
+        "_settings.temperature_self_improving_mutation",
+    ),
+    (
+        Path("experimental/orchestration/progressive_compression.py"),
+        "_settings.temperature_progressive_compression",
+    ),
+)
+
+
+@pytest.mark.parametrize(("rel_path", "expected_ref"), _RATCHET_SITES)
+def test_call_site_reads_from_config(rel_path: Path, expected_ref: str) -> None:
+    """The named call site must reference its ``Settings`` knob, not a
+    literal float. Pinned after PR-TEMP (2026-05-23) lifted six
+    hardcoded constants into config.
+    """
+    path = REPO_ROOT / rel_path
+    source = path.read_text(encoding="utf-8")
+    assert expected_ref in source, (
+        f"{rel_path}: expected reference '{expected_ref}' missing — "
+        "did someone revert PR-TEMP to a hardcoded literal?"
+    )
+
+
+# Regex that matches ``temperature=<float-literal>`` (e.g. ``temperature=0.0``
+# or ``temperature=0.42``). Allowed: ``temperature=<identifier>`` (the config-
+# driven path) or ``temperature=None``.
+_LITERAL_TEMP_KWARG = re.compile(r"temperature\s*=\s*-?\d+(?:\.\d+)?\b")
+
+
+@pytest.mark.parametrize(("rel_path", "expected_ref"), _RATCHET_SITES)
+def test_call_site_has_no_literal_temperature(rel_path: Path, expected_ref: str) -> None:
+    """Defensive ratchet: the file must not contain any ``temperature=<float>``
+    keyword argument. If a literal sneaks back in, this test fails so the
+    operator-tunability invariant stays visible in CI.
+
+    Allow-list: ``providers/`` adapters and ``llm/adapters/`` translators
+    keep their internal ``temperature=<float>`` fallback paths (those are
+    contract-layer wire formatters, not policy decisions). The 6 ratchet
+    files above are policy sites and must read from config.
+    """
+    del expected_ref
+    path = REPO_ROOT / rel_path
+    source = path.read_text(encoding="utf-8")
+    matches = _LITERAL_TEMP_KWARG.findall(source)
+    assert matches == [], (
+        f"{rel_path}: found literal temperature kwarg(s) {matches!r} — "
+        "PR-TEMP invariant says these must read from Settings.temperature_*."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.43"
+version = "0.99.44"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- LLM 샘플링 temperature 의 코드 상수 6곳을 모두 제거하고 `Settings.temperature_*` 6 키로 노출 — `~/.geode/config.toml` / `GEODE_TEMPERATURE_*` env 로 운영자 튜닝 가능
- 기본값은 frontier API 그라운딩 (Anthropic / OpenAI / Gemini / Moonshot) 결과로 좁힘: 대부분 `1.0` (provider default), `verification` 와 `progressive_compression` 만 기능적 결정성 위해 `0.0`
- 19 신규 invariant 테스트로 ratchet (Settings 키 + range 검증 + 호출부 literal 재유입 grep guard)

## Why
- 기존 7 호출부의 temperature 값 (`0.0`, `0.2`, `0.1` × 2, `0.4`, `0.3`, `0.0`) 은 코드/테스트/문서 어디에도 근거가 없는 매직넘버였음
- Frontier API 문서 그라운딩 결과:
  - **Anthropic**: default 1.0, "closer to 0.0 for analytical, closer to 1.0 for creative"
  - **OpenAI reasoning**: temperature != 1 거부 — codex 어댑터의 `_is_codex_reasoning_model` 분기에서 이미 omit 처리됨
  - **Gemini 3**: "strongly recommend keeping the temperature at its default value of 1.0. Changing the temperature (setting it below 1.0) may lead to unexpected behavior, such as looping or degraded performance"
  - **Moonshot/Kimi K2/Thinking**: default 1.0; Hermes 식 `OMIT_TEMPERATURE` sentinel 패턴은 provider 어댑터 측에서 처리
- Hermes 의 `agent_temperature` YAML + per-phase config 패턴 흡수 — GEODE 의 "운영자 surface 부재" 갭 해소
- Codex/Anthropic adaptive-model strip 분기 (`anthropic.py:782-806`, `codex.py:348-354`) 는 그대로 — 본 PR 은 *policy 사이트* 의 매직넘버만 제거

## Changes

| File | Change |
|------|--------|
| `core/config/_settings.py` | `temperature_*` 6 `Field` 추가, `ge=0.0, le=2.0` 검증, env var alias |
| `core/agent/loop/agent_loop.py` | `_call_llm` 의 `temperature=0.0` × 2 → `loop_temperature = settings.temperature_agent_loop` |
| `core/agent/loop/_reflection.py` | `temperature=0.2` → `_settings.temperature_reflection` |
| `core/verification/cross_llm.py` | rescore + dual-verify 두 곳의 `temperature=0.1` → `settings.temperature_verification` (default 0.0) |
| `core/llm/commentary.py` | signature default `0.4` → `None`, 본문에서 `settings.temperature_commentary` 폴백 (caller override 허용) |
| `core/self_improving_loop/runner.py` | mutator `temperature=0.3` → `_settings.temperature_self_improving_mutation` |
| `experimental/orchestration/progressive_compression.py` | budget summary `temperature=0.0` → `_settings.temperature_progressive_compression` (default 0.0) |
| `tests/test_temperature_config_invariants.py` | NEW, 19 cases — Settings 키/기본값/range + 호출부 ratchet |
| `CHANGELOG.md` | `[Unreleased]` Changed 섹션에 PR-TEMP 항목 |
| `uv.lock` | passive sync (0.99.43 → 0.99.44, 본 PR 무관 / develop pyproject 와 정합 회복) |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| 6 코드 상수 제거 | Implemented | grep `temperature=0\.[0-9]` 결과 7개 호출부 모두 식별자 참조로 치환 |
| 운영자 config surface | Implemented | `Settings.temperature_*` 6 필드 + env var alias |
| Range 검증 | Implemented | `ge=0.0, le=2.0` (OpenAI 범위에 맞춤; Anthropic 범위는 provider 측에서 안전) |
| Reasoning 모델 omit 처리 보존 | Untouched | `anthropic.py:_ADAPTIVE_MODELS`, `codex.py:_is_codex_reasoning_model` 변경 없음 |
| Invariant ratchet | Implemented | 6 호출부에 literal kwarg 재유입 시 fail 하는 grep guard |
| 레거시 OpenAI port (`providers/openai.py:176,211,234,276,316`) | Dropped from scope | 시그니처 default 0.3 — 모든 caller 가 명시 override; runtime hot path 아님 |

## Verification

- [x] `uv run ruff check` clean (변경 파일 7 + 신규 test)
- [x] `uv run mypy` clean (7 source files)
- [x] `uv run pytest tests/test_temperature_config_invariants.py` — 19/19
- [x] `uv run pytest tests/test_commentary.py` — 8/8
- [x] Targeted regression sweep (`-k "cross_llm or reflection or commentary or self_improving or progressive_compression or temperature"`) — 286/286
- [x] Agent loop regression (`-k "agent_loop or agentic_loop"`) — 115/115
- [x] Config invariants (`test_config_cascade`, `test_ol_g_config_drift_invariants`) — 21/21

## Reference
- Anthropic Messages API docs: `temperature` 0.0–1.0, default 1.0, "even at 0.0 not fully deterministic"
- Gemini text-generation docs: Gemini 3 강력 권고 1.0 유지
- Moonshot/Kimi platform docs: K2 + Thinking default 1.0; V1 default 0.0 with "very close to 0 → 1 result only"
- Hermes `agent/auxiliary_client.py:190` `OMIT_TEMPERATURE` sentinel + `trajectory_compressor.py:104,156` `summarization.temperature` YAML override 패턴
- GEODE 기존 어댑터 분기: `core/llm/providers/anthropic.py:782-806`, `core/llm/providers/codex.py:348-354`