### PR TITLE
release: v0.99.45 — scaffold consolidation + RUNTIME CANNOT rename + G1 identity parity fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.45] - 2026-05-23
+
 ### Changed
 
 - **Step I.a — Codex OAuth header construction collapsed onto one helper.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.44
+- **Version**: 0.99.45
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.44 — Long-running Autonomous Execution Harness
+# GEODE v0.99.45 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.44**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.45**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.44 — Long-running Autonomous Execution Harness
+# GEODE v0.99.45 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.44**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.45**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.44"
+version = "0.99.45"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.44"
+version = "0.99.45"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- 5-location version stamp 0.99.44 → 0.99.45 (CHANGELOG / CLAUDE.md / README.md / README.ko.md / pyproject.toml + uv.lock).
- CHANGELOG `[Unreleased]` 안의 Changed (scaffold consolidation) + Fixed (G1 identity RUNTIME CANNOT parity) 항목을 `[0.99.45] - 2026-05-23` 으로 promote.
- PATCH bump 사유: docs scope (CLAUDE.md/GEODE.md 정돈) + 1-line runtime fix (`core/agent/system_prompt.py:_build_identity_context` 의 `target_sections` literal 동기화).

## Why

GEODE gitflow 표준: 모든 변경은 release/* 사이클을 통해 develop → main 으로 전파. release branch 는 stamp + CHANGELOG bump 만 담고 *develop 먼저* 머지해 develop 이 stamp 면에서 main 보다 안 뒤짐. develop → main 은 그 뒤 straight pass-through.

직전 PR #1544 (feature/scaffold-tidy → develop) 가 docs + 1-line fix 를 develop 에 올렸으므로 SemVer PATCH 사이클로 main 까지 전파.

## Verification

- [x] ruff check + format clean
- [x] mypy 438 source files no issues
- [x] lint-imports 4 contracts kept
- [x] CLI smoke `geode version` → GEODE v0.99.45
- [x] PR #1544 base content 는 6981 passed 로 검증됨 — release branch 는 그 위 stamp 만 추가