### PR TITLE
step J-b.1 — relocate self-improving loop model SoT to control layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,48 @@ functional change.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Step J-b.1 fix-up — `test_diversity_hint_injected` xdist leak.**
+  PR-CL-A1 (#1548) added ``_maybe_replan_async`` which reads
+  ``current_session_metrics().last_verify_passed`` / ``.active_plan`` at
+  every round entry. ``current_session_metrics()`` lazy-inits and binds
+  to the ContextVar, so state from a prior test in the same xdist
+  worker (xdist ``loadfile`` packs all tests in
+  ``tests/test_autonomous_safety.py`` into one worker) leaks into the
+  next test. The canary was ``TestDiversityForcing.test_diversity_hint_injected``
+  — the leaked state intermittently tripped a verify_fail replan
+  trigger, the planner mock consumed the tool-response slot, and the
+  diversity tracker never advanced to 5. PR-CL-A1's author documented
+  the failure in 967927fa as "pre-existing xdist race, unrelated"; this
+  fix-up closes it. An ``autouse=True`` ``_isolated_session_metrics``
+  fixture wraps each test in this file with a fresh ``session_metrics_scope``
+  so every test sees default ``last_verify_passed=True`` and
+  ``active_plan=None``, keeping the replan trigger silent.
+
+### Changed
+
+- **Step J-b.1 — self-improving loop model SoT relocated to control layer.**
+  PR #1496 (2026-05-22) had collapsed audit role bindings into
+  ``[self_improving_loop.petri.<role>]`` (executor namespace). Step J-b.1
+  is the layer-aware mirror: the bindings move up to
+  ``[self_improving_loop.autoresearch.<role>]`` (control namespace) so
+  the model selection lives where the self-improving pipeline's control
+  actually runs — ``run → seed gen → petri baseline → autoresearch
+  surface engineering → petri audit → autoresearch Drop/commit``. The
+  mutator binding also relocates from ``[self_improving_loop.mutator]``
+  to ``[self_improving_loop.autoresearch.mutator]`` (autoresearch owns
+  its in-process engineering LLM). Legacy sections continue to load for
+  one release via the loader's
+  ``SelfImprovingLoopConfig._migrate_legacy_role_namespaces`` validator
+  with a ``DeprecationWarning``; the
+  ``SelfImprovingLoopConfig.petri`` / ``.mutator`` Python fields are
+  removed (``extra="forbid"`` keeps typos loud), so reader sites move
+  to ``cfg.autoresearch.target`` / ``.judge`` / ``.auditor`` /
+  ``.mutator``. Writer sites (``cmd_config.py``,
+  ``self_improving._persist_*``, ``geode config migrate-petri-toml``)
+  emit the new section names.
+
 ### Added
 
 - **PR-CL-A1 — Dynamic Replan**. Fourth (final) PR in the Cognitive

--- a/core/cli/cmd_config.py
+++ b/core/cli/cmd_config.py
@@ -69,17 +69,23 @@ _console = Console()
 
 
 def _render_petri_sections(plan: dict[str, dict[str, str]]) -> str:
-    """Render ``plan`` as ``[self_improving_loop.petri.<role>]`` TOML blocks.
+    """Render ``plan`` as ``[self_improving_loop.autoresearch.<role>]`` TOML blocks.
 
     Each block carries ``model`` / ``source`` lines for the role. Empty
     plan yields an empty string. Roles iterate in dict insertion order so
     the operator's existing ``~/.geode/petri.toml`` ordering is preserved.
+
+    Step J-b.1 (2026-05-23) — destination relocated from
+    ``[self_improving_loop.petri.<role>]`` (executor namespace) to
+    ``[self_improving_loop.autoresearch.<role>]`` (control namespace).
+    autoresearch is the upper layer that owns model selection;
+    petri_audit is the executor that reads.
     """
     if not plan:
         return ""
     lines: list[str] = []
     for role, override in plan.items():
-        lines.append(f"[self_improving_loop.petri.{role}]")
+        lines.append(f"[self_improving_loop.autoresearch.{role}]")
         for key, value in override.items():
             lines.append(f'{key} = "{_toml_escape_basic_string(value)}"')
         lines.append("")
@@ -87,9 +93,14 @@ def _render_petri_sections(plan: dict[str, dict[str, str]]) -> str:
 
 
 def _config_already_has_petri_section(path: Path) -> list[str]:
-    """Return the role names whose ``[self_improving_loop.petri.<role>]``
+    """Return role names whose ``[self_improving_loop.autoresearch.<role>]``
     section is already present in ``path``. Empty list when ``path`` is
-    absent or no overlapping sections exist."""
+    absent or no overlapping sections exist.
+
+    Step J-b.1 — checks the new namespace + the legacy
+    ``[self_improving_loop.petri.<role>]`` namespace so a re-run of
+    ``migrate-petri-toml`` does not double-write either layout.
+    """
     if not path.is_file():
         return []
     try:
@@ -101,10 +112,16 @@ def _config_already_has_petri_section(path: Path) -> list[str]:
     sip = raw.get("self_improving_loop")
     if not isinstance(sip, dict):
         return []
-    petri = sip.get("petri")
-    if not isinstance(petri, dict):
-        return []
-    return list(petri.keys())
+    overlap: set[str] = set()
+    autoresearch = sip.get("autoresearch")
+    if isinstance(autoresearch, dict):
+        for role_name in ("target", "judge", "auditor"):
+            if isinstance(autoresearch.get(role_name), dict):
+                overlap.add(role_name)
+    legacy_petri = sip.get("petri")
+    if isinstance(legacy_petri, dict):
+        overlap.update(legacy_petri.keys())
+    return sorted(overlap)
 
 
 @app.command("migrate-petri-toml")
@@ -121,7 +138,8 @@ def migrate_petri_toml(
     ),
 ) -> None:
     """Move petri.* sections from ~/.geode/petri.toml into
-    self_improving_loop.petri.* sections of ~/.geode/config.toml.
+    ``[self_improving_loop.autoresearch.<role>]`` sections of
+    ``~/.geode/config.toml`` (control-layer SoT, Step J-b.1).
 
     Dry-run by default — prints the TOML snippets the operator should
     append. With --yes, the snippets are appended to
@@ -130,7 +148,8 @@ def migrate_petri_toml(
     it is the operator's call after verifying the new path resolves.
 
     Refuses --yes when the destination already contains overlapping
-    self_improving_loop.petri.<role> sections — prevents accidental
+    role sections (either the new ``autoresearch.<role>`` namespace or
+    the legacy ``petri.<role>`` namespace) — prevents accidental
     double-write on re-run.
     """
     from plugins.petri_audit.user_overrides import migration_plan_from_petri_toml
@@ -147,7 +166,7 @@ def migrate_petri_toml(
     if not yes:
         _console.print(
             "# Migration plan from ~/.geode/petri.toml → "
-            "~/.geode/config.toml [self_improving_loop.petri.*]"
+            "~/.geode/config.toml [self_improving_loop.autoresearch.<role>]"
         )
         _console.print("# Re-run with --yes to append automatically.")
         _console.print("")
@@ -168,11 +187,12 @@ def migrate_petri_toml(
 
     overlap = sorted(set(existing_roles) & set(plan.keys()))
     if overlap:
-        # markup=False so literal ``[self_improving_loop.petri.X]`` is not
-        # interpreted by rich as a (missing) style tag and stripped.
+        # markup=False so literal ``[self_improving_loop.autoresearch.X]``
+        # is not interpreted by rich as a (missing) style tag and stripped.
         _console.print(
-            f"{target} already has [self_improving_loop.petri.{{{','.join(overlap)}}}] "
-            "section(s). Refusing to append — remove the existing entries first "
+            f"{target} already has [self_improving_loop.autoresearch.{{{','.join(overlap)}}}] "
+            "(or legacy [petri.<role>]) section(s). Refusing to append — "
+            "remove the existing entries first "
             "or apply the migration plan manually.",
             markup=False,
             style="red",

--- a/core/cli/commands/_state.py
+++ b/core/cli/commands/_state.py
@@ -130,19 +130,21 @@ AGENT_ROLES: list[AgentRole] = [
     # PR-G2 (2026-05-21) — self-improving loop mutator role. Unlike
     # primary / reflection (which live on ``Settings``), the mutator's
     # model knob lives in ``MutatorConfig.default_model``
-    # (``[self_improving_loop.mutator] default_model`` in config.toml).
-    # When ``default_model`` is ``None`` (the new G1a default from
-    # PR-MINIMAL-2) the runner inherits ``Settings.model``. The
-    # ``settings_field=""`` sentinel signals "no Settings attribute to
-    # write" — the picker persists via ``upsert_config_toml`` only,
-    # which is exactly the SoT path ``_default_llm_call`` reads at
-    # dispatch time.
+    # (Step J-b.1, 2026-05-23: relocated to
+    # ``[self_improving_loop.autoresearch.mutator] default_model`` —
+    # autoresearch is the control-layer SoT that owns its in-process
+    # engineering LLM). When ``default_model`` is ``None`` (the new
+    # G1a default from PR-MINIMAL-2) the runner inherits
+    # ``Settings.model``. The ``settings_field=""`` sentinel signals
+    # "no Settings attribute to write" — the picker persists via
+    # ``upsert_config_toml`` only, which is exactly the SoT path
+    # ``_default_llm_call`` reads at dispatch time.
     AgentRole(
         name="mutator",
         label="Mutator",
         settings_field="",
         env_var="GEODE_SELF_IMPROVING_LOOP_MUTATOR_MODEL",
-        toml_section="self_improving_loop.mutator",
+        toml_section="self_improving_loop.autoresearch.mutator",
         toml_key="default_model",
         description=(
             "Self-improving loop mutator — proposes wrapper/policy mutations "

--- a/core/cli/commands/self_improving.py
+++ b/core/cli/commands/self_improving.py
@@ -326,8 +326,8 @@ def _resolve_run_summary_telemetry() -> tuple[str, str]:
         from core.config.self_improving_loop import load_self_improving_loop_config
 
         cfg = load_self_improving_loop_config()
-        model = cfg.mutator.default_model or settings.model
-        source = cfg.mutator.source
+        model = cfg.autoresearch.mutator.default_model or settings.model
+        source = cfg.autoresearch.mutator.source
         return (model, source)
     except Exception:
         import logging
@@ -439,8 +439,8 @@ def _render_preflight(flags: dict[str, Any]) -> None:
         # what the runner will actually invoke. Explicit override
         # (operator set ``[self_improving_loop.mutator] default_model``
         # in config.toml) still wins.
-        mutator_model = cfg.mutator.default_model or settings.model
-        mutator_source = cfg.mutator.source
+        mutator_model = cfg.autoresearch.mutator.default_model or settings.model
+        mutator_source = cfg.autoresearch.mutator.source
     except Exception:
         # Best-effort UI: missing config falls through to the "?" placeholders.
         import logging
@@ -789,13 +789,14 @@ def _render_source_table() -> None:
     inherit_model = settings.model
     rows: list[tuple[str, str, str]] = [
         (
-            "mutator",
-            cfg.mutator.default_model or f"{inherit_model}  [muted](inherit)[/muted]",
-            cfg.mutator.source,
+            "autoresearch.mutator",
+            cfg.autoresearch.mutator.default_model or f"{inherit_model}  [muted](inherit)[/muted]",
+            cfg.autoresearch.mutator.source,
         ),
     ]
-    for petri_name, petri_cfg in cfg.petri.items():
-        rows.append((f"petri.{petri_name}", petri_cfg.model, petri_cfg.source))
+    for role_name in ("auditor", "target", "judge"):
+        role_cfg = getattr(cfg.autoresearch, role_name)
+        rows.append((f"autoresearch.{role_name}", role_cfg.model, role_cfg.source))
     for seed_name, seed_cfg in cfg.seed_generation.roles.items():
         rows.append((f"seed_generation.{seed_name}", seed_cfg.model, seed_cfg.source))
     console.print(f"    {'component':32} {'model':28} source")
@@ -877,25 +878,26 @@ def _cmd_config() -> None:
 
     mutator_changes = _prompt_component(
         "mutator",
-        current_model=cfg.mutator.default_model or settings.model,
-        current_source=cfg.mutator.source,
-        model_is_inherited=cfg.mutator.default_model is None,
+        current_model=cfg.autoresearch.mutator.default_model or settings.model,
+        current_source=cfg.autoresearch.mutator.source,
+        model_is_inherited=cfg.autoresearch.mutator.default_model is None,
     )
     if mutator_changes is None:
         return  # aborted
 
     petri_changes: dict[str, dict[str, str]] = {}
-    for petri_name, petri_cfg in cfg.petri.items():
+    for role_name in ("auditor", "target", "judge"):
+        role_cfg = getattr(cfg.autoresearch, role_name)
         diff = _prompt_component(
-            f"petri.{petri_name}",
-            current_model=petri_cfg.model,
-            current_source=petri_cfg.source,
+            f"autoresearch.{role_name}",
+            current_model=role_cfg.model,
+            current_source=role_cfg.source,
             model_is_inherited=False,
         )
         if diff is None:
             return
         if diff:
-            petri_changes[petri_name] = diff
+            petri_changes[role_name] = diff
 
     seed_changes: dict[str, dict[str, str]] = {}
     for seed_name, seed_cfg in cfg.seed_generation.roles.items():
@@ -1010,8 +1012,16 @@ def _toml_escape(value: str) -> str:
 
 
 def _persist_mutator_updates(updates: dict[str, str]) -> None:
-    """Persist mutator-only `key = "value"` lines to config.toml."""
-    _persist_section_updates("self_improving_loop.mutator", updates)
+    """Persist mutator-only `key = "value"` lines to config.toml.
+
+    Step J-b.1 (2026-05-23) — writer target moved from
+    ``[self_improving_loop.mutator]`` to
+    ``[self_improving_loop.autoresearch.mutator]`` (control-layer SoT).
+    Old configs auto-migrate via the loader's
+    ``_migrate_legacy_role_namespaces`` validator with a
+    ``DeprecationWarning``.
+    """
+    _persist_section_updates("self_improving_loop.autoresearch.mutator", updates)
 
 
 def _persist_full_config(
@@ -1022,9 +1032,9 @@ def _persist_full_config(
 ) -> None:
     """Persist the interactive form's diff across every component."""
     if mutator:
-        _persist_section_updates("self_improving_loop.mutator", mutator)
+        _persist_section_updates("self_improving_loop.autoresearch.mutator", mutator)
     for role, diff in petri.items():
-        _persist_section_updates(f"self_improving_loop.petri.{role}", diff)
+        _persist_section_updates(f"self_improving_loop.autoresearch.{role}", diff)
     for role, diff in seed_generation.items():
         # Note: loader uses ``[self_improving_loop.seed_generation.roles.<role>]``
         # (plural ``roles``) — see ``SeedGenerationConfig.roles`` field. Singular

--- a/core/config/self_improving_loop.py
+++ b/core/config/self_improving_loop.py
@@ -46,8 +46,9 @@ from __future__ import annotations
 import logging
 import os
 import tomllib
+import warnings
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -184,44 +185,66 @@ class PetriRoleConfig(BaseModel):
 
 
 class AutoresearchConfig(BaseModel):
-    """autoresearch/train.py runtime knobs.
+    """autoresearch/train.py runtime knobs + per-role model bindings.
 
-    Single-SoT (2026-05-22) — ``[self_improving_loop.petri.<role>].model``
-    in ``~/.geode/config.toml`` is the **sole** model SoT for every audit
-    role (auditor / target / judge). The autoresearch outer loop reads
-    the role models through that section indirectly: it omits
-    ``--target`` / ``--judge`` / ``--auditor`` from the ``geode audit``
-    argv entirely, and the runner resolves each role via the binding
-    registry (which reads ``[petri.<role>]``).
+    Step J-b.1 (2026-05-23) — **autoresearch is the control-layer SoT**
+    for every model selection in the self-improving pipeline. Pipeline:
 
-    The ``target_model`` / ``judge_model`` fields survive as
-    **deprecated no-op slots** — silently accepted at load time so
-    existing ``~/.geode/config.toml`` files don't ``extra="forbid"``
-    on the loader, but never consulted at runtime. ``_build_audit_command``
-    no longer reads them; the next release will drop the fields
-    entirely after operators have migrated to ``[petri.<role>].model``.
+    ``run → seed gen → petri baseline → autoresearch [GEODE 노출 표면
+    조정] → petri audit → autoresearch [Drop | commit 판단] → 표면
+    재조정 (반복)``
 
-    Operators who want an autoresearch-only model now edit
-    ``[petri.target].model`` / ``[petri.judge].model`` directly;
-    standalone ``geode audit`` and the outer loop share the same
-    bindings end-to-end.
+    Control flows top-down — autoresearch is the upper layer that
+    decides what models the audit (executor) uses and what model the
+    mutator runner uses for surface engineering. The previous PR #1496
+    (2026-05-22) collapse moved the SoT *into* ``[petri.<role>]``, but
+    that placed config ownership in the executor layer. Step J-b.1
+    relocates the SoT back to the control layer while keeping a
+    1-release back-compat reader on the old sections.
+
+    Four sub-roles live here as nested objects:
+
+    - ``target`` / ``judge`` / ``auditor`` — petri eval roles. The
+      petri_audit role binding resolver (``get_binding``) reads from
+      these.
+    - ``mutator`` — autoresearch's own in-process LLM (the engineer
+      that proposes GEODE surface mutations). Consumed by
+      ``core/self_improving_loop/runner.py:_default_llm_call``.
+
+    Standalone ``geode audit`` (run outside the self-improving loop)
+    still reads the same sections — same single SoT, just different
+    invocation context.
+
+    The legacy ``target_model`` / ``judge_model`` string slots remain
+    as deprecated no-op fields (back-compat with pre-2026-05-22
+    configs); operators on those configs already see them silently
+    ignored, so this PR doesn't change that behaviour.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     budget_minutes: Annotated[int, Field(ge=1, le=60)] = 5
+
+    # Step J-b.1 — role sub-fields (the SoT relocation).
+    target: PetriRoleConfig = Field(default_factory=PetriRoleConfig)
+    """petri eval ``target`` role binding (model + source). Read by
+    :func:`plugins.petri_audit.registry.get_binding` when the runtime
+    resolves the audit target."""
+    judge: PetriRoleConfig = Field(default_factory=PetriRoleConfig)
+    """petri eval ``judge`` role binding."""
+    auditor: PetriRoleConfig = Field(default_factory=PetriRoleConfig)
+    """petri eval ``auditor`` role binding."""
+    mutator: MutatorConfig = Field(default_factory=lambda: MutatorConfig())
+    """In-process mutator runner binding. Consumed by
+    :func:`core.self_improving_loop.runner._default_llm_call`."""
+
     target_model: str | None = None
-    """**Deprecated** — surviving slot for back-compat config file load.
-    The runtime always resolves the target through
-    ``[self_improving_loop.petri.target].model`` via the binding
-    registry; this field is silently ignored. Will be dropped in a
-    future release once operator configs are migrated."""
+    """**Deprecated pre-PR #1496 slot** — surviving for back-compat
+    config file load. Never consulted at runtime. Will be dropped in a
+    future release once operator configs are migrated to the
+    ``[self_improving_loop.autoresearch.target] model = ...`` shape."""
     judge_model: str | None = None
-    """**Deprecated** — surviving slot for back-compat config file load.
-    The runtime resolves the judge through
-    ``[self_improving_loop.petri.judge].model`` via the binding
-    registry; this field is silently ignored. Will be dropped in a
-    future release once operator configs are migrated."""
+    """**Deprecated pre-PR #1496 slot** — see :attr:`target_model`."""
     # PR-SIL-5THEME C6 (2026-05-23) — default ``auto`` → ``claude-cli``.
     # Operator decision (``project_payg_exclusion_decision.md``, 2026-05-23)
     # 으로 ``api_key`` 는 ``Source`` literal 에서 제거. ``auto`` 는 manifest
@@ -387,19 +410,71 @@ class SelfImprovingLoopConfig(BaseModel):
 
     # Per-component sub-configs
     autoresearch: AutoresearchConfig = Field(default_factory=AutoresearchConfig)
-    petri: dict[str, PetriRoleConfig] = Field(default_factory=dict)
-    """Map of role name → PetriRoleConfig. Expected keys: auditor /
-    target / judge."""
+    """Control-layer SoT — owns ``target`` / ``judge`` / ``auditor`` /
+    ``mutator`` role bindings (Step J-b.1)."""
     seed_generation: SeedGenerationConfig = Field(default_factory=SeedGenerationConfig)
-    mutator: MutatorConfig = Field(default_factory=MutatorConfig)
-    """PR-1 G-A — mutator role manifest. Closes the hardcoded
-    ``model="claude-opus-4-7"`` + direct ``anthropic.Anthropic()``
-    call in ``core/self_improving_loop/runner.py``."""
 
     scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
     """PR-OL-A1 — auto-trigger schedule. Default off; operator opts in
     via ``[self_improving_loop.scheduler] enabled = true``. The cron
     fires the mutator runner with lockfile + min-interval guards."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_role_namespaces(cls, data: Any) -> Any:
+        """Step J-b.1 — relocate model SoT from executor to control layer.
+
+        The previous layout placed audit role bindings under
+        ``[self_improving_loop.petri.<role>]`` (executor namespace)
+        and the mutator binding under ``[self_improving_loop.mutator]``
+        (top-level). Step J-b.1 reunites them inside
+        ``[self_improving_loop.autoresearch.<role>]`` because
+        autoresearch is the control layer that decides what runs.
+
+        This validator pops the legacy sections from the raw input dict
+        and grafts them under ``autoresearch`` so old configs keep
+        loading. A ``DeprecationWarning`` fires on each migration so
+        operators see the new location in their next config edit.
+
+        The fields are removed from the schema (``extra="forbid"``)
+        rather than kept as no-op slots so future operator typos
+        ``[self_improving_loop.petr.target]`` fail loudly instead of
+        silently ignoring the binding.
+        """
+        if not isinstance(data, dict):
+            return data
+        autoresearch_section = data.setdefault("autoresearch", {})
+        if not isinstance(autoresearch_section, dict):
+            return data  # let pydantic surface the type error
+
+        legacy_petri = data.pop("petri", None)
+        if isinstance(legacy_petri, dict) and legacy_petri:
+            for role_name in ("target", "judge", "auditor"):
+                if role_name in legacy_petri and role_name not in autoresearch_section:
+                    autoresearch_section[role_name] = legacy_petri[role_name]
+            warnings.warn(
+                "[self_improving_loop.petri.*] is deprecated; move audit "
+                "role bindings to [self_improving_loop.autoresearch.<role>] "
+                "(autoresearch is the control-layer SoT). The legacy "
+                "section will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        legacy_mutator = data.pop("mutator", None)
+        if isinstance(legacy_mutator, dict) and legacy_mutator:
+            if "mutator" not in autoresearch_section:
+                autoresearch_section["mutator"] = legacy_mutator
+            warnings.warn(
+                "[self_improving_loop.mutator] is deprecated; move the "
+                "mutator binding to [self_improving_loop.autoresearch.mutator] "
+                "(autoresearch owns its own engineering LLM). The legacy "
+                "section will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return data
 
     @model_validator(mode="after")
     def _abort_above_warn(self) -> SelfImprovingLoopConfig:

--- a/core/self_improving_loop/runner.py
+++ b/core/self_improving_loop/runner.py
@@ -549,14 +549,14 @@ def _default_llm_call(system_prompt: str, user_prompt: str) -> str:
     # PR-MINIMAL-2 (2026-05-21) — G1a inherit: MutatorConfig.default_model
     # defaults to None, fall back to Settings.model so the operator's
     # ``/model`` choice flows through. Explicit override still wins.
-    if cfg.mutator.default_model:
-        model = cfg.mutator.default_model
+    if cfg.autoresearch.mutator.default_model:
+        model = cfg.autoresearch.mutator.default_model
     else:
         from core.config import settings
 
         model = settings.model
-    max_tokens = cfg.mutator.max_tokens
-    source = cfg.mutator.source
+    max_tokens = cfg.autoresearch.mutator.max_tokens
+    source = cfg.autoresearch.mutator.source
 
     # PR-MINIMAL-2 — model allow-list field removed (C1). The
     # router's provider routing already guards model existence per

--- a/plugins/petri_audit/user_overrides.py
+++ b/plugins/petri_audit/user_overrides.py
@@ -198,7 +198,15 @@ def _read_role_from_self_improving_loop(role: str) -> RoleOverride:
             payload={"role": role, "reason": "validation_error", "error": str(exc)[:200]},
         )
         return {}
-    entry = cfg.petri.get(role)
+    # Step J-b.1 — audit role bindings now live under
+    # ``[self_improving_loop.autoresearch.<role>]`` (control layer).
+    # The legacy ``[petri.<role>]`` section is auto-migrated by
+    # :class:`SelfImprovingLoopConfig` 's ``_migrate_legacy_role_namespaces``
+    # so config-file readers see the new location uniformly.
+    autoresearch = getattr(cfg, "autoresearch", None)
+    if autoresearch is None:
+        return {}
+    entry = getattr(autoresearch, role, None)
     if entry is None:
         return {}
     out: RoleOverride = {}
@@ -274,21 +282,24 @@ def save_role_override_to_config_toml(
     source: str | None = None,
 ) -> None:
     """Persist a role override to ``~/.geode/config.toml`` under
-    ``[self_improving_loop.petri.<role>]`` — the operator-config SoT.
+    ``[self_improving_loop.autoresearch.<role>]`` — the control-layer
+    operator-config SoT (Step J-b.1, 2026-05-23).
 
-    Single-SoT (2026-05-22) — all writes flow into the config.toml
-    section. Empty-string (delete-axis) requests are honoured by
+    Pre-Step J-b.1 the writer targeted ``[self_improving_loop.petri.<role>]``
+    (executor namespace, PR #1496). After J-b.1 the loader's
+    before-validator silently migrates any legacy ``[petri.*]`` keys up
+    into ``autoresearch.<role>`` with a ``DeprecationWarning``, so a
+    writer that still emitted the legacy path would create an *ignored*
+    section whenever the operator also had explicit ``autoresearch.<role>``
+    entries — silent no-op, the same write/read asymmetry the previous
+    single-SoT consolidation was meant to kill. Writing directly to the
+    new namespace is the only correct path.
+
+    Empty-string (delete-axis) requests are honoured by
     ``_persist_section_updates`` directly: it drops the matching
-    ``key = "..."`` line so a subsequent
-    :func:`read_role_override` returns ``{}`` for the cleared axis and
-    the binding registry falls through to the manifest default.
-
-    No legacy ``~/.geode/petri.toml`` write path remains —
-    consolidation kills the read/write asymmetry that made
-    ``/petri model <role>`` a silent no-op when the operator had
-    pinned a different value in config.toml. Migration helper
-    (``geode config migrate-petri-toml``) still reads pre-existing
-    legacy files for the diff print.
+    ``key = "..."`` line so a subsequent :func:`read_role_override`
+    returns ``{}`` for the cleared axis and the binding registry falls
+    through to the manifest default.
     """
     updates: dict[str, str] = {}
     if model is not None:
@@ -300,7 +311,7 @@ def save_role_override_to_config_toml(
 
     from core.cli.commands.self_improving import _persist_section_updates
 
-    _persist_section_updates(f"self_improving_loop.petri.{role}", updates)
+    _persist_section_updates(f"self_improving_loop.autoresearch.{role}", updates)
 
 
 def clear_overrides(role: str | None = None, *, path: Path | str | None = None) -> None:

--- a/tests/core/cli/test_cmd_config.py
+++ b/tests/core/cli/test_cmd_config.py
@@ -34,7 +34,7 @@ def test_render_single_role_emits_section_with_model_and_source() -> None:
     rendered = _render_petri_sections(
         {"auditor": {"model": "claude-sonnet-4-6", "source": "claude-cli"}}
     )
-    assert "[self_improving_loop.petri.auditor]" in rendered
+    assert "[self_improving_loop.autoresearch.auditor]" in rendered
     assert 'model = "claude-sonnet-4-6"' in rendered
     assert 'source = "claude-cli"' in rendered
 
@@ -46,9 +46,9 @@ def test_render_preserves_role_insertion_order() -> None:
         "target": {"source": "openai-codex"},
     }
     rendered = _render_petri_sections(plan)
-    j_idx = rendered.index("[self_improving_loop.petri.judge]")
-    a_idx = rendered.index("[self_improving_loop.petri.auditor]")
-    t_idx = rendered.index("[self_improving_loop.petri.target]")
+    j_idx = rendered.index("[self_improving_loop.autoresearch.judge]")
+    a_idx = rendered.index("[self_improving_loop.autoresearch.auditor]")
+    t_idx = rendered.index("[self_improving_loop.autoresearch.target]")
     assert j_idx < a_idx < t_idx
 
 
@@ -77,7 +77,7 @@ def test_migrate_dry_run_prints_preview_and_does_not_write(
     result = runner.invoke(app, [])
     assert result.exit_code == 0, result.output
     assert "Re-run with --yes" in result.output
-    assert "[self_improving_loop.petri.auditor]" in result.output
+    assert "[self_improving_loop.autoresearch.auditor]" in result.output
     assert not target.exists(), "dry-run must not create destination"
 
 
@@ -100,8 +100,8 @@ def test_migrate_yes_appends_to_config_when_destination_absent(
     assert "Appended 2 role(s)" in result.output
     assert target.is_file()
     content = target.read_text(encoding="utf-8")
-    assert "[self_improving_loop.petri.auditor]" in content
-    assert "[self_improving_loop.petri.judge]" in content
+    assert "[self_improving_loop.autoresearch.auditor]" in content
+    assert "[self_improving_loop.autoresearch.judge]" in content
     assert 'model = "claude-opus-4-7"' in content
 
 
@@ -122,7 +122,7 @@ def test_migrate_yes_preserves_existing_unrelated_sections(
     content = target.read_text(encoding="utf-8")
     # Existing content stays intact + new section appended.
     assert "[mcp.servers.calendar]" in content
-    assert "[self_improving_loop.petri.target]" in content
+    assert "[self_improving_loop.autoresearch.target]" in content
 
 
 def test_migrate_yes_refuses_when_destination_already_has_overlapping_section(
@@ -132,7 +132,7 @@ def test_migrate_yes_refuses_when_destination_already_has_overlapping_section(
 
     target = tmp_path / "config.toml"
     target.write_text(
-        '[self_improving_loop.petri.auditor]\nmodel = "old-model"\n',
+        '[self_improving_loop.autoresearch.auditor]\nmodel = "old-model"\n',
         encoding="utf-8",
     )
     monkeypatch.setattr(core.paths, "GLOBAL_CONFIG_TOML", target)
@@ -149,7 +149,7 @@ def test_migrate_yes_refuses_when_destination_already_has_overlapping_section(
     assert "Refusing to append" in normalised
     # Destination MUST NOT be modified — guard against partial double-write.
     assert target.read_text(encoding="utf-8") == (
-        '[self_improving_loop.petri.auditor]\nmodel = "old-model"\n'
+        '[self_improving_loop.autoresearch.auditor]\nmodel = "old-model"\n'
     )
 
 
@@ -191,7 +191,7 @@ def test_render_escapes_embedded_double_quote() -> None:
         {"target": {"model": 'gpt-5.5 "tactical"', "source": "openai-codex"}}
     )
     parsed = tomllib.loads(rendered)
-    assert parsed["self_improving_loop"]["petri"]["target"]["model"] == 'gpt-5.5 "tactical"'
+    assert parsed["self_improving_loop"]["autoresearch"]["target"]["model"] == 'gpt-5.5 "tactical"'
 
 
 def test_render_escapes_backslash() -> None:
@@ -201,7 +201,7 @@ def test_render_escapes_backslash() -> None:
 
     rendered = _render_petri_sections({"auditor": {"source": "claude\\backslash"}})
     parsed = tomllib.loads(rendered)
-    assert parsed["self_improving_loop"]["petri"]["auditor"]["source"] == "claude\\backslash"
+    assert parsed["self_improving_loop"]["autoresearch"]["auditor"]["source"] == "claude\\backslash"
 
 
 def test_render_escapes_control_characters() -> None:
@@ -210,7 +210,7 @@ def test_render_escapes_control_characters() -> None:
 
     rendered = _render_petri_sections({"x": {"model": "a\x01b"}})
     parsed = tomllib.loads(rendered)
-    assert parsed["self_improving_loop"]["petri"]["x"]["model"] == "a\x01b"
+    assert parsed["self_improving_loop"]["autoresearch"]["x"]["model"] == "a\x01b"
 
 
 def test_yes_migration_with_embedded_quotes_writes_valid_toml(
@@ -231,7 +231,7 @@ def test_yes_migration_with_embedded_quotes_writes_valid_toml(
     result = runner.invoke(app, ["--yes"])
     assert result.exit_code == 0, result.output
     parsed = tomllib.loads(target.read_text(encoding="utf-8"))
-    assert parsed["self_improving_loop"]["petri"]["target"]["model"] == 'gpt-5.5 "tactical"'
+    assert parsed["self_improving_loop"]["autoresearch"]["target"]["model"] == 'gpt-5.5 "tactical"'
 
 
 # ── atomic write / failure rollback (Codex CRITICAL #2) ─────────────────
@@ -278,8 +278,8 @@ def test_yes_accepts_source_only_legacy_entry(
     result = runner.invoke(app, ["--yes"])
     assert result.exit_code == 0, result.output
     parsed = tomllib.loads(target.read_text(encoding="utf-8"))
-    assert parsed["self_improving_loop"]["petri"]["judge"]["source"] == "claude-cli"
-    assert "model" not in parsed["self_improving_loop"]["petri"]["judge"]
+    assert parsed["self_improving_loop"]["autoresearch"]["judge"]["source"] == "claude-cli"
+    assert "model" not in parsed["self_improving_loop"]["autoresearch"]["judge"]
 
 
 def test_yes_schema_validation_blocks_invalid_source(
@@ -327,7 +327,7 @@ def test_yes_post_render_validation_blocks_corrupt_combined_toml(
     monkeypatch.setattr(
         cmd_config,
         "_render_petri_sections",
-        lambda plan: "[self_improving_loop.petri.target]\nmodel = unbalanced\n",
+        lambda plan: "[self_improving_loop.autoresearch.target]\nmodel = unbalanced\n",
     )
     result = runner.invoke(app, ["--yes"])
     assert result.exit_code == 3, result.output

--- a/tests/plugins/petri_audit/test_user_overrides.py
+++ b/tests/plugins/petri_audit/test_user_overrides.py
@@ -215,7 +215,11 @@ def test_load_quoting_robust(petri_toml: Path):
 def test_read_role_override_prefers_self_improving_loop(
     petri_toml: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When [self_improving_loop.petri.<role>] is set, it wins over petri.toml."""
+    """When [self_improving_loop.autoresearch.<role>] is set, it wins over petri.toml.
+
+    Step J-b.1 — relocated SoT from ``[petri.<role>]`` (executor) up to
+    ``[autoresearch.<role>]`` (control).
+    """
     petri_toml.write_text(
         """
 [petri.auditor]
@@ -229,8 +233,8 @@ source = "api_key"
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
         lambda: SimpleNamespace(
-            petri={
-                "auditor": SimpleNamespace(
+            autoresearch=SimpleNamespace(
+                auditor=SimpleNamespace(
                     model="new-from-config-toml",
                     source="openai-codex",  # PR-SIL-5THEME C6 — non-default
                     # subscription source. ``claude-cli`` 가 새 default 라
@@ -238,8 +242,10 @@ source = "api_key"
                     # surface 하려면 다른 값 필요. ``api_key`` 는 PR-SIL-5THEME
                     # C6 로 Source literal 에서 제거됐다.
                     fallback_to_payg=None,
-                )
-            }
+                ),
+                target=None,
+                judge=None,
+            ),
         ),
     )
     override = uo.read_role_override("auditor")
@@ -250,7 +256,7 @@ source = "api_key"
 def test_read_role_override_falls_back_to_petri_toml(
     petri_toml: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No [self_improving_loop.petri.<role>] section → legacy petri.toml wins."""
+    """No [self_improving_loop.autoresearch.<role>] section → legacy petri.toml wins."""
     petri_toml.write_text(
         """
 [petri.judge]
@@ -263,7 +269,13 @@ source = "claude-cli"
 
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
-        lambda: SimpleNamespace(petri={}),
+        lambda: SimpleNamespace(
+            autoresearch=SimpleNamespace(
+                auditor=None,
+                target=None,
+                judge=None,
+            ),
+        ),
     )
     override = uo.read_role_override("judge")
     assert override["model"] == "claude-opus-4-7"
@@ -287,13 +299,15 @@ model = "snapshot-model"
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
         lambda: SimpleNamespace(
-            petri={
-                "auditor": SimpleNamespace(
+            autoresearch=SimpleNamespace(
+                auditor=SimpleNamespace(
                     model="self-improving-loop-model",
                     source="auto",
                     fallback_to_payg=None,
-                )
-            }
+                ),
+                target=None,
+                judge=None,
+            ),
         ),
     )
     override = uo.read_role_override("auditor", path=snap)
@@ -310,13 +324,15 @@ def test_read_role_override_auto_source_dropped(
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
         lambda: SimpleNamespace(
-            petri={
-                "auditor": SimpleNamespace(
+            autoresearch=SimpleNamespace(
+                auditor=SimpleNamespace(
                     model="claude-sonnet-4-6",
                     source="auto",
                     fallback_to_payg=None,
-                )
-            }
+                ),
+                target=None,
+                judge=None,
+            ),
         ),
     )
     override = uo.read_role_override("auditor")

--- a/tests/test_autonomous_safety.py
+++ b/tests/test_autonomous_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,31 @@ import pytest
 from core.agent.conversation import ConversationContext
 from core.agent.loop import AgenticLoop, AgenticResult
 from core.agent.tool_executor import ToolExecutor
+from core.observability.session_metrics import session_metrics_scope
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_metrics() -> Iterator[None]:
+    """Step J-b.1 fix-up (2026-05-23) — isolate SessionMetrics per test.
+
+    PR-CL-A1 (#1548) added ``_maybe_replan_async`` which reads
+    ``current_session_metrics().last_verify_passed`` / ``.active_plan`` at
+    every round entry. The ContextVar's lazy-init pattern means state
+    from a prior test in the same xdist worker (xdist ``loadfile``
+    packs all tests in this file into one worker) leaks into the next
+    test's ``arun``. ``test_diversity_hint_injected`` is the canary —
+    when the leaked state trips a verify_fail replan trigger, the
+    planner mock consumes the tool-response slot and the diversity
+    tracker never advances to 5.
+
+    Wrapping every test in this file with a fresh ``session_metrics_scope``
+    closes the leak. Each test sees a clean SessionMetrics with default
+    ``last_verify_passed=True`` and ``active_plan=None`` so the replan
+    trigger stays silent.
+    """
+    with session_metrics_scope():
+        yield
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_mutator_role_tab.py
+++ b/tests/test_mutator_role_tab.py
@@ -4,7 +4,7 @@ Pins:
 - ``mutator`` role registered in ``AGENT_ROLES``.
 - The role has ``settings_field=""`` (sentinel — mutator lives in
   ``MutatorConfig.default_model``, not Settings).
-- ``toml_section="self_improving_loop.mutator"`` / ``toml_key="default_model"``
+- ``toml_section="self_improving_loop.autoresearch.mutator"`` / ``toml_key="default_model"``
   matches the runner's lazy ``load_self_improving_loop_config()`` reader.
 - ``_current_model_for_role(mutator)`` reads the toml value (or empty
   when unset, signalling inherit-Settings.model).
@@ -37,7 +37,7 @@ def test_mutator_role_has_empty_settings_field() -> None:
     role = role_by_name("mutator")
     assert role.settings_field == ""
     # toml routing points at the self-improving-loop section
-    assert role.toml_section == "self_improving_loop.mutator"
+    assert role.toml_section == "self_improving_loop.autoresearch.mutator"
     assert role.toml_key == "default_model"
     # No effort axis on the mutator role
     assert role.has_effort is False
@@ -53,7 +53,7 @@ def test_current_model_for_mutator_reads_toml_when_set(
 
     fake_toml = tmp_path / "config.toml"
     fake_toml.write_text(
-        '[self_improving_loop.mutator]\ndefault_model = "claude-haiku-4-5-20251001"\n',
+        '[self_improving_loop.autoresearch.mutator]\ndefault_model = "claude-haiku-4-5-20251001"\n',
         encoding="utf-8",
     )
     monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
@@ -97,7 +97,10 @@ def test_read_toml_value_handles_malformed_toml(
     fake_toml = tmp_path / "config.toml"
     fake_toml.write_text("[broken section\nkey = value\n", encoding="utf-8")
     monkeypatch.setattr("core.paths.GLOBAL_CONFIG_TOML", fake_toml)
-    assert model_mod._read_toml_value("self_improving_loop.mutator", "default_model") == ""
+    assert (
+        model_mod._read_toml_value("self_improving_loop.autoresearch.mutator", "default_model")
+        == ""
+    )
 
 
 def test_apply_model_for_mutator_skips_settings_write(

--- a/tests/test_ol_g_config_drift_invariants.py
+++ b/tests/test_ol_g_config_drift_invariants.py
@@ -30,35 +30,60 @@ from pathlib import Path
 
 
 def test_g_b_autoresearch_petri_role_is_canonical_sot() -> None:
-    """Petri role models resolve through ``[self_improving_loop.petri.<role>]``.
+    """Audit role models resolve through ``[self_improving_loop.autoresearch.<role>]``.
 
-    Single-SoT (2026-05-22, PR-CSP-12) — ``AutoresearchConfig.target_model``
-    and ``judge_model`` survive as **deprecated no-op slots** for
-    back-compat config load (so an old config.toml doesn't break parse),
-    but the canonical SoT is the petri-role section. The fields must
-    accept any string round-trip, but runtime resolution does NOT
-    consult them — that path runs through ``_petri_role_model``.
+    Step J-b.1 (2026-05-23) — relocates the canonical SoT from the
+    executor layer (``[self_improving_loop.petri.<role>]``, set by
+    PR-CSP-12 on 2026-05-22) up to the control layer
+    (``[self_improving_loop.autoresearch.<role>]``). Rationale: the
+    self-improving pipeline (run → seed gen → petri baseline →
+    autoresearch surface engineering → petri audit → autoresearch
+    Drop/commit) places autoresearch above the audit executor, so
+    config ownership belongs to the control layer. The legacy
+    ``[petri.<role>]`` section continues to load for one release via
+    ``_migrate_legacy_role_namespaces`` with a ``DeprecationWarning``.
+
+    ``AutoresearchConfig.target_model`` / ``judge_model`` survive as
+    pre-PR-CSP-12 deprecated no-op slots; runtime resolution does not
+    consult them, but they accept any string round-trip so an even
+    older config.toml doesn't break parse.
     """
     from core.config.self_improving_loop import (
         AutoresearchConfig,
+        PetriRoleConfig,
         SelfImprovingLoopConfig,
     )
 
     cfg = AutoresearchConfig()
-    # Deprecated fields survive on AutoresearchConfig — default None
-    # signals "not set" (back-compat: an old config.toml carrying
-    # these keys won't fail to parse).
+    # Pre-PR-CSP-12 deprecated fields survive (back-compat with old
+    # configs).
     assert getattr(cfg, "target_model", "MISSING") is None, (
         "G-B regressed: target_model deprecated slot removed before back-compat window"
     )
     assert getattr(cfg, "judge_model", "MISSING") is None, (
         "G-B regressed: judge_model deprecated slot removed before back-compat window"
     )
-    # The petri section lives on the top-level config — it's the
-    # real SoT for per-role model selection.
+    # Step J-b.1 canonical SoT — the role bindings live on
+    # AutoresearchConfig as nested PetriRoleConfig sub-fields.
+    assert isinstance(cfg.target, PetriRoleConfig), (
+        "G-B regressed: autoresearch.target sub-field missing — canonical SoT moved"
+    )
+    assert isinstance(cfg.judge, PetriRoleConfig), (
+        "G-B regressed: autoresearch.judge sub-field missing"
+    )
+    assert isinstance(cfg.auditor, PetriRoleConfig), (
+        "G-B regressed: autoresearch.auditor sub-field missing"
+    )
+    # The top-level [petri.*] / [mutator] sections are no longer fields —
+    # they auto-migrate via the loader's before-validator.
     loop_cfg = SelfImprovingLoopConfig()
-    assert hasattr(loop_cfg, "petri"), (
-        "G-B regressed: SelfImprovingLoopConfig.petri role-config section missing"
+    assert not hasattr(loop_cfg, "petri"), (
+        "Step J-b.1 regressed: SelfImprovingLoopConfig.petri must be relocated "
+        "into autoresearch.<role> (the control-layer SoT)."
+    )
+    assert not hasattr(loop_cfg, "mutator"), (
+        "Step J-b.1 regressed: SelfImprovingLoopConfig.mutator must be relocated "
+        "into autoresearch.mutator (autoresearch owns its engineering LLM)."
     )
 
 

--- a/tests/test_paperclip_wiring.py
+++ b/tests/test_paperclip_wiring.py
@@ -138,9 +138,9 @@ def test_default_llm_call_dispatches_to_claude_cli(monkeypatch: pytest.MonkeyPat
     from core.self_improving_loop import runner
 
     cfg_mock = MagicMock()
-    cfg_mock.mutator.default_model = "claude-opus-4-7"
-    cfg_mock.mutator.source = "claude-cli"
-    cfg_mock.mutator.max_tokens = 1024
+    cfg_mock.autoresearch.mutator.default_model = "claude-opus-4-7"
+    cfg_mock.autoresearch.mutator.source = "claude-cli"
+    cfg_mock.autoresearch.mutator.max_tokens = 1024
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
         lambda: cfg_mock,
@@ -169,9 +169,9 @@ def test_default_llm_call_dispatches_to_codex_cli(monkeypatch: pytest.MonkeyPatc
     from core.self_improving_loop import runner
 
     cfg_mock = MagicMock()
-    cfg_mock.mutator.default_model = "gpt-5-codex"
-    cfg_mock.mutator.source = "openai-codex"
-    cfg_mock.mutator.max_tokens = 1024
+    cfg_mock.autoresearch.mutator.default_model = "gpt-5-codex"
+    cfg_mock.autoresearch.mutator.source = "openai-codex"
+    cfg_mock.autoresearch.mutator.max_tokens = 1024
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
         lambda: cfg_mock,
@@ -192,9 +192,9 @@ def test_default_llm_call_api_key_path_unchanged(monkeypatch: pytest.MonkeyPatch
     from core.self_improving_loop import runner
 
     cfg_mock = MagicMock()
-    cfg_mock.mutator.default_model = "claude-opus-4-7"
-    cfg_mock.mutator.source = "api_key"
-    cfg_mock.mutator.max_tokens = 1024
+    cfg_mock.autoresearch.mutator.default_model = "claude-opus-4-7"
+    cfg_mock.autoresearch.mutator.source = "api_key"
+    cfg_mock.autoresearch.mutator.max_tokens = 1024
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",
         lambda: cfg_mock,
@@ -331,7 +331,8 @@ def test_cmd_source_set_persists_valid_source(
     monkeypatch.setattr("core.config.self_improving_loop.GLOBAL_CONFIG_TOML", fake_toml)
     self_improving._cmd_source_set(["source=claude-cli"])
     text = fake_toml.read_text(encoding="utf-8")
-    assert "[self_improving_loop.mutator]" in text
+    # Step J-b.1 — writer target moved to autoresearch.mutator.
+    assert "[self_improving_loop.autoresearch.mutator]" in text
     assert 'source = "claude-cli"' in text
 
 

--- a/tests/test_run_summary_source_telemetry.py
+++ b/tests/test_run_summary_source_telemetry.py
@@ -74,8 +74,12 @@ def test_resolve_telemetry_inherits_settings_model_when_default_is_none(
         default_model = None
         source = "auto"
 
-    class _StubCfg:
+    class _StubAutoresearch:
         mutator = _StubMutator()
+
+    class _StubCfg:
+        # Step J-b.1 — mutator now lives under autoresearch (control SoT).
+        autoresearch = _StubAutoresearch()
 
     class _StubSettings:
         model = "claude-opus-4-7"
@@ -100,8 +104,11 @@ def test_resolve_telemetry_uses_explicit_default_model(
         default_model = "claude-haiku-4-5-20251001"
         source = "api_key"
 
-    class _StubCfg:
+    class _StubAutoresearch:
         mutator = _StubMutator()
+
+    class _StubCfg:
+        autoresearch = _StubAutoresearch()
 
     monkeypatch.setattr(
         "core.config.self_improving_loop.load_self_improving_loop_config",

--- a/tests/test_self_improving_loop_config.py
+++ b/tests/test_self_improving_loop_config.py
@@ -35,7 +35,12 @@ def test_default_config_has_safe_defaults() -> None:
     assert cfg.abort_threshold == pytest.approx(0.9)
     assert isinstance(cfg.autoresearch, AutoresearchConfig)
     assert isinstance(cfg.seed_generation, SeedGenerationConfig)
-    assert cfg.petri == {}
+    # Step J-b.1 — audit role bindings moved into autoresearch namespace.
+    # Defaults are now PetriRoleConfig() instances (model="", source="claude-cli"),
+    # not entries in a top-level petri dict.
+    assert cfg.autoresearch.target.model == ""
+    assert cfg.autoresearch.judge.model == ""
+    assert cfg.autoresearch.auditor.model == ""
 
 
 def test_autoresearch_defaults_match_train_module() -> None:
@@ -195,30 +200,35 @@ seed_limit = 2
 
 
 def test_load_reads_petri_role_bindings(tmp_path: Path) -> None:
-    """[self_improving_loop.petri.<role>] keys become PetriRoleConfig entries."""
+    """[self_improving_loop.autoresearch.<role>] keys hydrate PetriRoleConfig sub-fields.
+
+    Step J-b.1 — namespace relocated from ``petri`` (executor layer) to
+    ``autoresearch`` (control layer) so role-binding ownership matches
+    the self-improving pipeline's control flow.
+    """
     path = tmp_path / "config.toml"
     _write_toml(
         path,
         """
-[self_improving_loop.petri.auditor]
+[self_improving_loop.autoresearch.auditor]
 model = "claude-sonnet-4-6"
 source = "claude-cli"
 
-[self_improving_loop.petri.target]
+[self_improving_loop.autoresearch.target]
 model = "geode/gpt-5.5"
 source = "openai-codex"
 
-[self_improving_loop.petri.judge]
+[self_improving_loop.autoresearch.judge]
 model = "claude-opus-4-7"
 source = "claude-cli"
 """,
     )
     cfg = load_self_improving_loop_config(path)
-    assert set(cfg.petri) == {"auditor", "target", "judge"}
-    assert cfg.petri["auditor"].model == "claude-sonnet-4-6"
-    assert cfg.petri["auditor"].source == "claude-cli"
-    assert cfg.petri["target"].source == "openai-codex"
-    assert cfg.petri["judge"].model == "claude-opus-4-7"
+    # Step J-b.1 — role bindings live under autoresearch namespace (control SoT).
+    assert cfg.autoresearch.auditor.model == "claude-sonnet-4-6"
+    assert cfg.autoresearch.auditor.source == "claude-cli"
+    assert cfg.autoresearch.target.source == "openai-codex"
+    assert cfg.autoresearch.judge.model == "claude-opus-4-7"
 
 
 def test_load_reads_seed_generation_subsection(tmp_path: Path) -> None:
@@ -508,3 +518,118 @@ warn_threshold = 0.4
         cfg = load_self_improving_loop_config(path)
     assert cfg.warn_threshold == pytest.approx(0.4)
     assert not journal.path.exists() or _read_journal(journal.path) == []
+
+
+# ── Step J-b.1 — control-layer SoT migration semantics ──────────────────
+
+
+def test_step_j_b1_petri_namespace_migrates_to_autoresearch() -> None:
+    """Legacy ``[self_improving_loop.petri.<role>]`` raw input is moved
+    under ``autoresearch`` by the before-validator and the migration
+    fires a ``DeprecationWarning``. The Python field
+    ``SelfImprovingLoopConfig.petri`` no longer exists — readers must
+    use ``cfg.autoresearch.target`` etc.
+    """
+    import warnings
+
+    raw = {
+        "petri": {
+            "target": {"model": "legacy-target", "source": "claude-cli"},
+            "judge": {"model": "legacy-judge"},
+            "auditor": {"model": "legacy-auditor"},
+        },
+    }
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        cfg = SelfImprovingLoopConfig.model_validate(raw)
+    deprecations = [w for w in recorded if issubclass(w.category, DeprecationWarning)]
+    petri_warnings = [w for w in deprecations if "[self_improving_loop.petri.*]" in str(w.message)]
+    assert len(petri_warnings) == 1, (
+        "Step J-b.1 invariant: legacy [petri.*] input must emit exactly one "
+        "DeprecationWarning per load so operators see the migration once."
+    )
+
+    assert cfg.autoresearch.target.model == "legacy-target"
+    assert cfg.autoresearch.judge.model == "legacy-judge"
+    assert cfg.autoresearch.auditor.model == "legacy-auditor"
+    assert not hasattr(cfg, "petri"), (
+        "Step J-b.1 regressed: SelfImprovingLoopConfig.petri must be removed; "
+        "readers route through cfg.autoresearch.<role>."
+    )
+
+
+def test_step_j_b1_mutator_namespace_migrates_to_autoresearch() -> None:
+    """Legacy ``[self_improving_loop.mutator]`` raw input is moved
+    under ``autoresearch.mutator`` by the before-validator with a
+    ``DeprecationWarning``. The top-level ``mutator`` field is removed.
+    """
+    import warnings
+
+    raw = {
+        "mutator": {"default_model": "legacy-mutator", "source": "claude-cli"},
+    }
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        cfg = SelfImprovingLoopConfig.model_validate(raw)
+    mutator_warnings = [
+        w
+        for w in recorded
+        if issubclass(w.category, DeprecationWarning)
+        and "[self_improving_loop.mutator]" in str(w.message)
+    ]
+    assert len(mutator_warnings) == 1
+
+    assert cfg.autoresearch.mutator.default_model == "legacy-mutator"
+    assert cfg.autoresearch.mutator.source == "claude-cli"
+    assert not hasattr(cfg, "mutator"), (
+        "Step J-b.1 regressed: SelfImprovingLoopConfig.mutator must be removed; "
+        "readers route through cfg.autoresearch.mutator."
+    )
+
+
+def test_step_j_b1_new_namespace_wins_when_both_layouts_present() -> None:
+    """When both ``[autoresearch.target]`` and the legacy
+    ``[petri.target]`` are present, the new (control-layer) value wins.
+    Mirrors PR #1496's "new wins" semantics in the opposite direction.
+    """
+    raw = {
+        "autoresearch": {"target": {"model": "NEW-WINS"}},
+        "petri": {"target": {"model": "OLD-LOSES"}},
+    }
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        cfg = SelfImprovingLoopConfig.model_validate(raw)
+    assert cfg.autoresearch.target.model == "NEW-WINS"
+
+
+def test_step_j_b1_clean_input_emits_no_deprecation() -> None:
+    """Pure ``autoresearch.*`` input (no legacy keys) must not emit any
+    DeprecationWarning — the migration warning is a deprecation signal,
+    not noise on every load."""
+    import warnings
+
+    raw = {
+        "autoresearch": {
+            "target": {"model": "new-target"},
+            "judge": {"model": "new-judge"},
+            "mutator": {"default_model": "new-mutator"},
+        },
+    }
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        SelfImprovingLoopConfig.model_validate(raw)
+    deprecations = [
+        w
+        for w in recorded
+        if issubclass(w.category, DeprecationWarning)
+        and (
+            "[self_improving_loop.petri.*]" in str(w.message)
+            or "[self_improving_loop.mutator]" in str(w.message)
+        )
+    ]
+    assert deprecations == [], (
+        "Step J-b.1 regressed: clean (new-style) input should not emit any "
+        "petri/mutator DeprecationWarning."
+    )

--- a/tests/test_self_improving_loop_gap_fill.py
+++ b/tests/test_self_improving_loop_gap_fill.py
@@ -62,8 +62,11 @@ def test_self_improving_loop_config_carries_mutator_section() -> None:
     )
 
     root = SelfImprovingLoopConfig()
-    assert isinstance(root.mutator, MutatorConfig)
-    assert root.mutator.default_model is None  # G1a inherit
+    # Step J-b.1 — MutatorConfig relocated under autoresearch namespace
+    # (control-layer SoT). Old location [self_improving_loop.mutator]
+    # auto-migrates with DeprecationWarning.
+    assert isinstance(root.autoresearch.mutator, MutatorConfig)
+    assert root.autoresearch.mutator.default_model is None  # G1a inherit
 
 
 def test_runner_default_llm_call_routes_through_call_with_failover() -> None:
@@ -113,9 +116,10 @@ def test_runner_default_llm_call_consumes_source() -> None:
     from core.self_improving_loop import runner
 
     src = inspect.getsource(runner._default_llm_call)
-    assert "cfg.mutator.source" in src, (
-        "_default_llm_call must read MutatorConfig.source — otherwise "
-        "the field is a silent declarative knob (Codex MCP anti-pattern)."
+    assert "cfg.autoresearch.mutator.source" in src, (
+        "_default_llm_call must read autoresearch.mutator.source (Step J-b.1 "
+        "relocation) — otherwise the field is a silent declarative knob "
+        "(Codex MCP anti-pattern)."
     )
     # role_contract removed — A1 (PR-MINIMAL-2)
     assert "role_contract" not in src, (
@@ -137,7 +141,7 @@ def test_mutator_default_model_inherits_settings() -> None:
     from core.self_improving_loop import runner
 
     src = _inspect.getsource(runner._default_llm_call)
-    # Inherit path: when cfg.mutator.default_model is None, use Settings.model
+    # Inherit path: when cfg.autoresearch.mutator.default_model is None, use Settings.model
     assert "settings.model" in src, (
         "_default_llm_call must fall back to Settings.model when "
         "MutatorConfig.default_model is None (G1a inherit)."
@@ -172,7 +176,7 @@ def test_runner_reads_default_model_from_config() -> None:
 
     src = inspect.getsource(runner._default_llm_call)
     assert "load_self_improving_loop_config" in src
-    assert "cfg.mutator.default_model" in src or "mutator.default_model" in src
+    assert "cfg.autoresearch.mutator.default_model" in src or "mutator.default_model" in src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_improving_minimal_2.py
+++ b/tests/test_self_improving_minimal_2.py
@@ -56,7 +56,7 @@ def test_runner_default_llm_call_inherits_settings_model() -> None:
     assert "settings.model" in src
     # The inherit happens only when default_model is None — both
     # branches must be visible (truthy default_model + fallback).
-    assert "cfg.mutator.default_model" in src
+    assert "cfg.autoresearch.mutator.default_model" in src
 
 
 def test_build_audit_command_never_pins_role_models_on_argv() -> None:


### PR DESCRIPTION
## Summary

- Move audit role bindings + mutator binding from executor namespace (``[self_improving_loop.petri.<role>]`` / ``[self_improving_loop.mutator]``) up to the control namespace (``[self_improving_loop.autoresearch.<role>]`` / ``[autoresearch.mutator]``)
- ``AutoresearchConfig`` absorbs ``target``/``judge``/``auditor`` (PetriRoleConfig) + ``mutator`` (MutatorConfig) sub-fields; top-level Python fields removed (``extra="forbid"`` keeps operator typos loud)
- 1-release back-compat: a ``model_validator(mode="before")`` migrates legacy raw input with a single ``DeprecationWarning`` per legacy section

## Why

PR #1496 (2026-05-22) had collapsed the role bindings into ``[self_improving_loop.petri.<role>]`` — the executor namespace. That placed model selection ownership inside the audit *executor*, not the control layer. The self-improving pipeline is:

```
run → seed gen → petri baseline → autoresearch [GEODE surface engineering]
→ petri audit → autoresearch [Drop | commit 판단] → 표면 재조정 (반복)
```

autoresearch sits above petri_audit in this pipeline (it decides what the executor evaluates and what the mutator engineers). The model SoT therefore belongs in the control layer. Step J-b.1 is the layer-aware mirror of PR #1496's consolidation.

## Changes

| File | Change |
|------|--------|
| `core/config/self_improving_loop.py` | `AutoresearchConfig` gains `target`/`judge`/`auditor`/`mutator` sub-fields. New `model_validator(mode="before")` `_migrate_legacy_role_namespaces` pops legacy `petri` + `mutator` raw keys and grafts them under `autoresearch.*` with `DeprecationWarning`. Top-level `petri` + `mutator` fields removed. |
| `core/self_improving_loop/runner.py` | `_default_llm_call` reads `cfg.autoresearch.mutator.{default_model,source,max_tokens}`. |
| `core/cli/commands/self_improving.py` | All 12+ reader sites migrated to `cfg.autoresearch.mutator.*`. `cfg.petri.items()` iteration replaced with explicit `("auditor","target","judge")` enumeration. `_persist_full_config` + `_persist_mutator_updates` write to new sections. |
| `core/cli/commands/_state.py` | `AgentRole(name="mutator")` `toml_section` flipped to `self_improving_loop.autoresearch.mutator` so `/model mutator` writes the new section. Codex MCP HIGH finding fix. |
| `plugins/petri_audit/user_overrides.py` | `read_role_override` reads from `cfg.autoresearch.<role>` (duck-typed). `set_role_override_to_config_toml` writes to `[self_improving_loop.autoresearch.<role>]`. Codex MCP BLOCKER finding fix. |
| `core/cli/cmd_config.py` | `_render_petri_sections` / `_config_already_has_petri_section` emit + check the new namespace. `migrate-petri-toml` targets new sections. |
| `tests/test_self_improving_loop_config.py` | 4 new invariant tests: migrate-petri, migrate-mutator, new-wins-over-legacy, clean-input-no-warning. Existing tests migrated. |
| `tests/test_paperclip_wiring.py`, `tests/test_mutator_role_tab.py`, `tests/test_run_summary_source_telemetry.py`, etc. | Reader-mock + TOML-fixture sections updated. |
| `tests/test_ol_g_config_drift_invariants.py` | G-B canonical-SoT invariant flipped to pin the new namespace. |
| `CHANGELOG.md` | New entry under [Unreleased] / Changed. |

## GAP Audit

| Item | Status | Notes |
|------|--------|-------|
| All readers migrated | Implemented | grep confirms no remaining `cfg.petri` / `cfg.mutator` (non-`autoresearch`) references in production. |
| All writers migrated | Implemented | Codex MCP BLOCKER (petri_audit writer) + HIGH (`_state.py` mutator role) closed in fix iteration. |
| Back-compat | Implemented | Legacy input still loads with one DeprecationWarning per legacy section. New invariant tests pin this. |
| Deprecation period | Documented | "Will be removed in a future release" — explicit removal timing left to a follow-up PR after operator configs are observed migrated. |

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — All checks passed
- [x] `uv run mypy core/ plugins/` — Success: no issues found in 438 source files
- [x] `uv run pytest tests/ -m "not live"` — 7034 passed, 56 skipped (0 failed)
- [x] Codex MCP verify (read-only sandbox): BLOCKER + HIGH closed on second iteration. GREEN.

## Reference

- Sibling PR #1542 (Step I.a, merged 2026-05-23): Codex OAuth header dedup, established the Path-B pattern for the self-improving sprint.
- Layer rationale: ``docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md`` (landed in PR #1542).
- Mirror direction reference: PR #1496 (2026-05-22) collapsed 5 SoTs INTO `[petri.<role>]`; this PR moves them UP to `[autoresearch.<role>]` while preserving the single-SoT invariant.