### PR TITLE
release: v0.99.46 — Cognitive Loop sprint (5 PR chain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.46] - 2026-05-23
+
+> Cognitive Loop sprint release — 5-PR chain (BUDGET → A3 → A6 → A1 →
+> A1-followup) introduces session-wide wall-clock budget + auto handoff,
+> per-turn verify (Reflexion), Plan/Action/Judge model separation,
+> dynamic replan with explicit Plan object, and GoalDecomposer absorption
+> into Plan. Plus Step J-b.1 self-improving-loop model SoT relocation +
+> test isolation fix-up.
+
 ### Removed
 
 - **PR-CL-A1-followup — GoalDecomposer 제거 + Plan 흡수**. PR-CL-A1 의

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.45
+- **Version**: 0.99.46
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.45 — Long-running Autonomous Execution Harness
+# GEODE v0.99.46 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.45**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.46**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.45 — Long-running Autonomous Execution Harness
+# GEODE v0.99.46 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.45**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.46**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.45"
+version = "0.99.46"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.45"
+version = "0.99.46"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- 5-PR **Cognitive Loop sprint** chain (BUDGET → A3 → A6 → A1 → A1-followup) lands on main: session-wide 2h wall-clock budget + auto T-10min handoff, per-turn Reflexion verify, Plan/Action/Judge model separation, Dynamic Replan with explicit Plan object, GoalDecomposer absorbed into Plan (~450 LOC net reduction).
- Step J-b.1 (#1549) self-improving-loop model SoT relocated to control layer + xdist test isolation fix-up.
- 5-location version stamp (pyproject.toml + uv.lock + CLAUDE.md + README.md + README.ko.md) + CHANGELOG cut `[Unreleased]` → `[0.99.46]`.

## Verification

- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run ruff format --check` — 813 formatted
- [x] `uv run mypy core/ plugins/` — 0 errors in 438 source files
- [x] 5-location stamp verified (pyproject + CLAUDE + README + README.ko + uv.lock)
- [x] CHANGELOG `[Unreleased]` → `[0.99.46]` with sprint summary

## Reference

- Operator decision: Cognitive Loop sprint complete (2026-05-23)
- PR chain: #1537 → #1539 → #1543 → #1548 → #1550 + #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)