### PR TITLE
step I.b — Codex reasoning-replay inspect_ai pipeline pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,43 @@ functional change.
 
 ## [Unreleased]
 
+### Added
+
+- **Step I.b — Codex reasoning-replay inspect_ai integration smoke test.**
+  Step A2 (v0.99.44) wired Codex encrypted-reasoning replay into the
+  GEODE AgenticLoop's ``Message`` path via
+  ``core.llm.adapters._openai_common.build_codex_input``. Petri's
+  :class:`OpenAICodexAPI` (inspect_ai ``ModelAPI`` subclass) inherits
+  the equivalent capability *for free* — inspect_ai's stock
+  ``openai_responses_inputs`` converter walks the ``ChatMessage`` list
+  and translates ``ContentReasoning`` blocks into Codex Responses-API
+  ``{"type": "reasoning", "encrypted_content": ...}`` typed items via
+  ``responses_reasoning_from_reasoning``
+  (``inspect_ai/model/_openai_responses.py:1130``). The Petri provider
+  must NOT reimplement that replay logic; this PR adds the explicit
+  guard rails so a future contributor doesn't accidentally drift.
+
+  Changes:
+
+  - ``plugins/petri_audit/codex_provider.py`` — multi-line comment
+    block at the ``openai_responses_inputs`` call inside ``register``'s
+    nested ``OpenAICodexAPI.generate`` documenting (a) inspect_ai owns
+    the replay, (b) where the upstream translator lives, (c) the
+    cross-reference to A2's GEODE-path helper, (d) the test pin.
+  - ``tests/plugins/petri_audit/test_codex_reasoning_replay_inspect_pipeline.py``
+    (NEW, 3 cases) — gated on the ``[audit]`` extra via
+    ``pytest.importorskip``:
+    1. ``openai_responses_inputs`` + ``responses_reasoning_from_reasoning``
+       remain importable from inspect_ai (catches an upstream rename
+       at import time).
+    2. ``responses_reasoning_from_reasoning(ContentReasoning(redacted=True))``
+       round-trips the encrypted payload (the GEODE-path contract
+       inspect_ai must mirror).
+    3. ``OpenAICodexAPI.generate`` source contains
+       ``await openai_responses_inputs(`` — anti-deception ratchet
+       against a future refactor that drops the call while leaving
+       the import/comment alone (Codex MCP HIGH catch).
+
 ## [0.99.46] - 2026-05-23
 
 > Cognitive Loop sprint release — 5-PR chain (BUDGET → A3 → A6 → A1 →

--- a/plugins/petri_audit/codex_provider.py
+++ b/plugins/petri_audit/codex_provider.py
@@ -283,6 +283,22 @@ def register() -> None:
 
             request_id = self._http_hooks.start_request()
 
+            # Step I.b (2026-05-23) — Codex encrypted-reasoning replay is
+            # owned by inspect_ai, NOT this subclass. ``openai_responses_inputs``
+            # walks the ``ChatMessage`` list and translates every
+            # ``inspect_ai.tool.ContentReasoning`` block on prior
+            # ``ChatMessageAssistant`` turns into a Codex Responses-API
+            # ``{"type": "reasoning", "encrypted_content": ...}`` typed
+            # item (see ``inspect_ai/model/_openai_responses.py:1130-1131``
+            # → ``responses_reasoning_from_reasoning`` at line 860). Petri's
+            # ``OpenAICodexAPI`` therefore inherits A2's per-turn reasoning
+            # replay for free across multi-turn audits — do NOT reimplement
+            # the replay logic from
+            # ``core.llm.adapters._openai_common.build_codex_input`` here;
+            # that helper exists for the GEODE AgenticLoop's ``Message``
+            # path, and the two should not drift. The integration is
+            # smoke-tested by
+            # ``tests/plugins/petri_audit/test_codex_reasoning_replay_inspect_pipeline.py``.
             raw_input_items = await openai_responses_inputs(
                 input, self, synthesize_phase=self.responses_phase
             )

--- a/tests/plugins/petri_audit/test_codex_reasoning_replay_inspect_pipeline.py
+++ b/tests/plugins/petri_audit/test_codex_reasoning_replay_inspect_pipeline.py
@@ -1,0 +1,120 @@
+"""Step I.b (2026-05-23) — pin the inspect_ai pathway that gives Petri
+multi-turn Codex calls their encrypted-reasoning replay for free.
+
+These tests do NOT exercise the network — they pin the *integration
+contract* between Petri's ``OpenAICodexAPI`` and inspect_ai's stock
+``openai_responses_inputs`` converter. Drift in either layer would
+silently break gpt-5.x ``store=False`` reasoning chains across audit
+turns; we want a fast unit-test gate, not a costly end-to-end run.
+
+Three invariants are pinned:
+
+1. **inspect_ai exposes the documented symbols.** If a future inspect_ai
+   release renames or removes ``openai_responses_inputs`` /
+   ``responses_reasoning_from_reasoning``, the Petri provider's
+   ``generate`` override would silently fail to translate reasoning
+   blocks. This test catches the upstream rename at import time.
+
+2. **The reasoning translator round-trips ``ContentReasoning`` payloads.**
+   We feed a ``ContentReasoning`` with ``redacted=True`` (the gpt-5
+   ``store=False`` shape) and assert the output carries ``type ==
+   "reasoning"`` plus the encrypted payload. The contract documented in
+   ``core/llm/adapters/_openai_common.py``'s A2 docstring (which the
+   Petri provider deliberately mirrors via inspect_ai rather than
+   reimplementing) is what this assertion enforces.
+
+3. **Petri's ``OpenAICodexAPI`` is the consumer of that pipeline.**
+   A ``grep`` on the provider source confirms ``openai_responses_inputs``
+   is invoked inside ``generate`` — so reasoning replay is wired, not
+   bypassed by a future refactor that synthesises the input array
+   directly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _require_inspect_ai() -> None:
+    """Skip when the optional ``[audit]`` extra (``inspect_ai``) isn't installed.
+
+    The Petri provider imports ``inspect_ai`` lazily inside ``register()``
+    so the default ``uv sync`` (no audit extra) doesn't fail; the smoke
+    test follows the same opt-in pattern.
+    """
+    pytest.importorskip("inspect_ai")
+
+
+def test_inspect_ai_exposes_codex_reasoning_translators() -> None:
+    """The two functions Petri's ``OpenAICodexAPI.generate`` relies on
+    must remain importable from inspect_ai.
+
+    ``openai_responses_inputs`` is the public-ish entry point that
+    walks the ``ChatMessage`` list; ``responses_reasoning_from_reasoning``
+    is the per-block translator that handles the encrypted-content
+    case. An upstream rename of either symbol would silently break
+    reasoning replay — better to fail at import time than at runtime
+    on a multi-turn audit.
+    """
+    from inspect_ai.model._openai_responses import (
+        openai_responses_inputs,
+        responses_reasoning_from_reasoning,
+    )
+
+    assert callable(openai_responses_inputs)
+    assert callable(responses_reasoning_from_reasoning)
+
+
+def test_responses_reasoning_translator_preserves_encrypted_content() -> None:
+    """``responses_reasoning_from_reasoning(ContentReasoning(redacted=True))``
+    must emit a Codex ``reasoning`` typed item carrying ``encrypted_content``.
+
+    A2 (v0.99.44) introduced the encrypted-content replay for the GEODE
+    AgenticLoop's ``Message`` path. Petri's provider relies on inspect_ai
+    to perform the equivalent translation on the ``ChatMessage`` path —
+    so the upstream behaviour is part of GEODE's contract, even though
+    GEODE itself doesn't own the code. This test pins that contract.
+    """
+    from inspect_ai.model._openai_responses import responses_reasoning_from_reasoning
+    from inspect_ai.tool import ContentReasoning
+
+    # ``redacted=True`` is the gpt-5 ``store=False`` shape: the model
+    # supplies an opaque blob the next turn must replay verbatim.
+    block = ContentReasoning(
+        reasoning="encrypted-blob-XYZ",
+        redacted=True,
+    )
+    item = responses_reasoning_from_reasoning(block)
+
+    item_dict = dict(item) if not isinstance(item, dict) else item
+    assert item_dict.get("type") == "reasoning"
+    assert item_dict.get("encrypted_content") == "encrypted-blob-XYZ"
+
+
+def test_petri_openai_codex_api_calls_openai_responses_inputs() -> None:
+    """Petri's ``OpenAICodexAPI.generate`` source must invoke
+    ``openai_responses_inputs`` — that call is what wires the reasoning
+    translator into the Petri request build.
+
+    Anti-deception ratchet: a future refactor that synthesises the
+    ``input`` array directly (skipping inspect_ai's converter) would
+    silently drop reasoning replay. This grep guard makes that change
+    fail loudly in CI.
+    """
+    from plugins.petri_audit import codex_provider
+
+    src = inspect.getsource(codex_provider.register)
+    # Match the actual call shape — not just the symbol's occurrence
+    # in the import block or a docstring. The runner's call site uses
+    # ``raw_input_items = await openai_responses_inputs(...)``; a refactor
+    # that drops the call while leaving the import/comment alone would
+    # otherwise pass the looser ``in src`` check (Codex MCP HIGH catch).
+    assert "await openai_responses_inputs(" in src, (
+        "OpenAICodexAPI.generate must route through "
+        "inspect_ai.model._openai_responses.openai_responses_inputs — "
+        "that's where ContentReasoning blocks become Codex reasoning "
+        "typed items. Step I.b regression guard."
+    )


### PR DESCRIPTION
## Summary

- Document that inspect_ai (not Petri's provider) owns Codex encrypted-reasoning replay across multi-turn audits, via ``openai_responses_inputs`` → ``responses_reasoning_from_reasoning``
- Pin the integration with 3 smoke tests gated on the ``[audit]`` extra (``pytest.importorskip``)
- Anti-deception ratchet: the grep guard matches the ``await openai_responses_inputs(`` call shape, not just the symbol's occurrence in the import / comment

## Why

Step A2 (v0.99.44, PR #1538) wired Codex encrypted-reasoning replay into the GEODE AgenticLoop's ``Message`` path via ``core.llm.adapters._openai_common.build_codex_input``. Petri's ``OpenAICodexAPI`` inherits the equivalent capability for free because inspect_ai's stock ``openai_responses_inputs`` walks ``ChatMessage`` and translates ``ContentReasoning`` blocks into the Codex Responses-API typed-item shape. This PR codifies that "no reimplementation needed" decision so a future refactor doesn't accidentally drift.

## Changes

| File | Change |
|------|--------|
| ``plugins/petri_audit/codex_provider.py`` | Multi-line comment at the ``openai_responses_inputs`` call inside ``OpenAICodexAPI.generate`` documenting the inspect_ai contract, the upstream translator location, and the cross-reference to A2's GEODE-path helper. |
| ``tests/plugins/petri_audit/test_codex_reasoning_replay_inspect_pipeline.py`` | NEW (3 cases). Symbol-availability smoke + ``ContentReasoning(redacted=True)`` round-trip + call-shape grep guard. ``pytest.importorskip("inspect_ai")`` so the default ``uv sync`` (no audit extra) skips silently. |
| ``CHANGELOG.md`` | New entry under ``[Unreleased] / Added``. |

## Verification

- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run pytest tests/plugins/petri_audit/test_codex_reasoning_replay_inspect_pipeline.py`` — 3 passed
- [x] Codex MCP read-only verify: GREEN after HIGH (grep guard false-positive risk) fixed by tightening to ``await openai_responses_inputs(`` call shape.

## Reference

- A2 sibling: PR #1538 (v0.99.44 OpenAI/Codex adapter closure)
- inspect_ai pathway: ``inspect_ai/model/_openai_responses.py:1130`` (``ContentReasoning`` case) → ``responses_reasoning_from_reasoning`` (line 860, ``encrypted_content`` field plumbed through)
- Step I.b scope rationale: ``docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md`` (PR #1542)