### PR TITLE
step I.c — adapter_health(name) registry accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,26 @@ functional change.
 
 ### Added
 
+- **Step I.c — `core.llm.adapters.adapter_health(name)` registry accessor.**
+  Thin one-call probe over the existing
+  :meth:`LLMAdapter.test_environment` method so picker UIs, readiness
+  audits, and external consumers (petri_audit's ``credential_source``
+  cascade, the ``/auth`` slash, the routing-recovery loop) can ask
+  "is adapter X healthy?" without an explicit
+  ``get_adapter(name).test_environment()`` two-step. The accessor
+  returns the unmodified :class:`EnvironmentReport`
+  (``ok`` / ``checks`` / ``hints``) so callers retain full access to
+  the operator-facing diagnostic detail.
+
+  Step I.c originally framed an :meth:`LLMAdapter.is_available`
+  Protocol extension; grounding revealed the equivalent contract
+  already exists as ``test_environment`` (every built-in implements
+  it). The PR therefore ships the ergonomic accessor + 4 new tests
+  (delegation parity, ``ok=False`` passthrough, missing-adapter
+  ``KeyError``, 8-built-in smoke), without touching the Protocol
+  surface.
+
+
 - **Step I.b — Codex reasoning-replay inspect_ai integration smoke test.**
   Step A2 (v0.99.44) wired Codex encrypted-reasoning replay into the
   GEODE AgenticLoop's ``Message`` path via

--- a/core/llm/adapters/__init__.py
+++ b/core/llm/adapters/__init__.py
@@ -50,6 +50,7 @@ from core.llm.adapters.base import (
 from core.llm.adapters.registry import (
     AdapterAlreadyRegisteredError,
     AdapterNotFoundError,
+    adapter_health,
     bootstrap_builtins,
     get_adapter,
     list_adapters,
@@ -85,6 +86,7 @@ __all__ = [
     "StreamEvent",
     "ToolSpec",
     "UsageSummary",
+    "adapter_health",
     "bootstrap_builtins",
     "get_adapter",
     "infer_provider_from_model",

--- a/core/llm/adapters/registry.py
+++ b/core/llm/adapters/registry.py
@@ -23,7 +23,12 @@ from __future__ import annotations
 
 import logging
 
-from core.llm.adapters.base import CONCRETE_SOURCES, SOURCE_AUTO, LLMAdapter
+from core.llm.adapters.base import (
+    CONCRETE_SOURCES,
+    SOURCE_AUTO,
+    EnvironmentReport,
+    LLMAdapter,
+)
 
 log = logging.getLogger(__name__)
 
@@ -89,6 +94,25 @@ def get_adapter(name: str) -> LLMAdapter:
 def list_adapters() -> list[LLMAdapter]:
     """All currently registered adapters in registration order."""
     return list(_REGISTRY.values())
+
+
+def adapter_health(name: str) -> EnvironmentReport:
+    """Probe ``adapter.test_environment`` by registry name.
+
+    Step I.c (2026-05-23) — thin one-call accessor over the existing
+    :meth:`LLMAdapter.test_environment` probe so picker UIs / readiness
+    audits / external consumers (petri_audit's ``credential_source``
+    cascade, the ``/auth`` slash, the routing-recovery loop) don't have
+    to ``get_adapter(name).test_environment()`` themselves and don't
+    need to know which exception ``get_adapter`` raises on a typo.
+
+    Raises :class:`KeyError` when no adapter is registered under
+    ``name`` (delegates to :func:`get_adapter`); the underlying
+    ``test_environment`` call NEVER raises — adapters return an
+    :class:`EnvironmentReport` with ``ok=False`` and operator-facing
+    ``hints`` on credential failures by design (paperclip mirror).
+    """
+    return get_adapter(name).test_environment()
 
 
 def resolve_for(provider: str, source: str) -> LLMAdapter:
@@ -170,6 +194,7 @@ def _reset_for_test() -> None:
 __all__ = [
     "AdapterAlreadyRegisteredError",
     "AdapterNotFoundError",
+    "adapter_health",
     "bootstrap_builtins",
     "get_adapter",
     "list_adapters",

--- a/tests/core/llm/adapters/test_registry.py
+++ b/tests/core/llm/adapters/test_registry.py
@@ -15,6 +15,7 @@ from core.llm.adapters import (
     AdapterAlreadyRegisteredError,
     AdapterBillingType,
     AdapterNotFoundError,
+    adapter_health,
     bootstrap_builtins,
     get_adapter,
     list_adapters,
@@ -185,3 +186,74 @@ def test_all_concrete_sources_covered_by_some_builtin() -> None:
     bootstrap_builtins()
     seen = {a.source for a in list_adapters()}
     assert seen >= CONCRETE_SOURCES
+
+
+# ---------------------------------------------------------------------------
+# Step I.c (2026-05-23) — adapter_health(name) registry accessor
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_health_returns_environment_report_for_stub() -> None:
+    """``adapter_health(name)`` delegates to ``adapter.test_environment()``.
+
+    Step I.c — the accessor is the ergonomic one-call probe over the
+    existing ``LLMAdapter.test_environment`` method. The stub above
+    always reports ``ok=True``; this confirms the helper threads the
+    result through unchanged.
+    """
+    from core.llm.adapters.base import EnvironmentReport
+
+    register_adapter(_Stub("stub-health-ok", "stub", SOURCE_PAYG))
+    report = adapter_health("stub-health-ok")
+    assert isinstance(report, EnvironmentReport)
+    assert report.ok is True
+
+
+def test_adapter_health_surfaces_not_ok_report() -> None:
+    """An adapter that returns ``ok=False`` must surface verbatim — no
+    ``adapter_health`` post-processing. Picker UIs depend on the report's
+    full structure (``checks`` + ``hints``) to render actionable errors.
+    """
+    from core.llm.adapters.base import EnvironmentReport
+
+    class _UnhealthyStub(_Stub):
+        def test_environment(self) -> EnvironmentReport:
+            return EnvironmentReport(
+                ok=False,
+                checks=(("ANTHROPIC_API_KEY", "missing"),),
+                hints=("set ANTHROPIC_API_KEY",),
+            )
+
+    register_adapter(_UnhealthyStub("stub-health-fail", "stub", SOURCE_PAYG))
+    report = adapter_health("stub-health-fail")
+    assert report.ok is False
+    assert report.checks == (("ANTHROPIC_API_KEY", "missing"),)
+    assert report.hints == ("set ANTHROPIC_API_KEY",)
+
+
+def test_adapter_health_missing_adapter_raises_keyerror() -> None:
+    """The accessor delegates to :func:`get_adapter` for the lookup,
+    which raises :class:`KeyError` on a typo. Confirm the behaviour
+    propagates (no silent ``ok=False`` swallow that would mask
+    operator typos)."""
+    with pytest.raises(KeyError):
+        adapter_health("never-registered")
+
+
+def test_adapter_health_runs_on_every_builtin() -> None:
+    """Smoke-call ``adapter_health`` on every bootstrapped built-in.
+
+    The probe must not raise for any of the 8 adapters even when
+    credentials are absent (the test environment has no API keys).
+    Adapters honor the contract: ``test_environment`` returns an
+    :class:`EnvironmentReport` with ``ok=False`` instead of raising.
+    """
+    from core.llm.adapters.base import EnvironmentReport
+
+    bootstrap_builtins()
+    for adapter in list_adapters():
+        report = adapter_health(adapter.name)
+        assert isinstance(report, EnvironmentReport), (
+            f"adapter_health({adapter.name!r}) returned {type(report).__name__}; "
+            "every built-in must honor the EnvironmentReport contract."
+        )


### PR DESCRIPTION
## Summary

- New ``core.llm.adapters.adapter_health(name) -> EnvironmentReport`` registry accessor — thin one-call wrapper over the existing ``LLMAdapter.test_environment`` Protocol method
- Re-exported via the ``core.llm.adapters`` package surface
- 4 new tests pin the contract (delegation parity, ``ok=False`` + checks/hints surface, missing-adapter ``KeyError``, 8-built-in smoke)

## Why

Step I.c was originally framed as an ``LLMAdapter.is_available()`` Protocol extension (per the Path-B plan in PR #1542). Grounding revealed the equivalent contract already exists as ``test_environment`` — every built-in implements it (paperclip ``testEnvironment`` mirror). So this PR ships only the ergonomic accessor so external consumers (petri_audit's ``credential_source`` cascade, the ``/auth`` slash, the routing-recovery loop) can ask "is adapter X healthy?" without the explicit ``get_adapter(name).test_environment()`` two-step. No Protocol surface change.

## Changes

| File | Change |
|------|--------|
| ``core/llm/adapters/registry.py`` | New ``adapter_health(name)`` function. ``EnvironmentReport`` import. ``__all__`` export. |
| ``core/llm/adapters/__init__.py`` | Re-export ``adapter_health`` from the package. |
| ``tests/core/llm/adapters/test_registry.py`` | 4 new cases (delegation, ok=False passthrough, missing-adapter, built-in smoke). |
| ``CHANGELOG.md`` | Entry under ``[Unreleased] / Added`` explicitly noting the "no Protocol extension" scoping. |

## Verification

- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run pytest tests/core/llm/adapters/test_registry.py`` — 21 passed
- [x] ``uv run pytest tests/`` — full suite shows 1 unrelated xdist-flake failure (``test_load_bundle_events_auto_trigger_only`` passes in isolation; same pattern as PR-CL-A1 / J-b.1's known cross-file state leak — not from this PR's changes)
- [x] Codex MCP read-only verify: GREEN. 2 LOW fixed (``# type: ignore`` removed in favour of explicit return annotation; ``adapter_health`` added to ``registry.py:__all__``).

## Reference

- Path-B plan: ``docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md`` (PR #1542)
- Sibling: I.b (#1554) pinned the inspect_ai reasoning-replay pathway with the same "no reimplementation needed" framing.