### PR TITLE
docs(audits): Path-B sprint final audit + operator-mode-a section name sync

### DIFF
--- a/docs/audits/2026-05-23-path-b-sprint-final-audit.md
+++ b/docs/audits/2026-05-23-path-b-sprint-final-audit.md
@@ -1,0 +1,119 @@
+# Path-B sprint final audit — 2026-05-23
+
+End-of-session scope audit + alignment pass for the Path-B
+``LLMAdapter`` migration sprint that ran in this session. Five PRs
+merged to develop:
+
+| Step | PR | Outcome |
+|------|----|---------|
+| I.a — Codex OAuth header dedup | #1542 | 4 inline header dicts collapsed onto :func:`core.llm.providers.codex.build_codex_oauth_headers` |
+| J-b.1 — control-layer SoT relocation | #1549 | ``[self_improving_loop.petri.<role>]`` + ``[self_improving_loop.mutator]`` → ``[self_improving_loop.autoresearch.<role>]`` + ``[self_improving_loop.autoresearch.mutator]`` (1-release back-compat with ``DeprecationWarning``) |
+| J-b.2 — mutator runner API path | #1555 | ``runner.py:_default_llm_call`` API branch migrated from legacy ``AgenticLLMPort`` to Path-B ``resolve_for + acomplete`` |
+| I.b — Codex reasoning-replay pin | #1554 | inspect_ai integration documented + 3-test smoke ratchet |
+| I.c — ``adapter_health(name)`` accessor | #1556 | Ergonomic registry wrapper over ``LLMAdapter.test_environment`` |
+
+Plus one fix-up landed alongside J-b.1: the
+``tests/test_autonomous_safety.py`` xdist isolation fixture closed a
+pre-existing flake that PR-CL-A1 left on develop.
+
+## Sweep results (cross-tree drift)
+
+Five grep sweeps run against the merged develop tip:
+
+| Sweep | Production code | Tests | Docs | Status |
+|-------|-----------------|-------|------|--------|
+| ``cfg.mutator.`` / ``cfg.petri.`` (non-``autoresearch``) | 0 hits | 0 hits | 0 hits | **clean** — J-b.1 migration complete |
+| ``[self_improving_loop.petri.*]`` / ``[self_improving_loop.mutator]`` literal | 0 production-runtime hits (only docstrings + ``DeprecationWarning`` text + back-compat reader) | 12 files (legitimate — back-compat migration fixtures) | ``docs/operator-mode-a.md`` (FIXED in this audit) + 5 historical plan docs (pinned-in-time, left as-is) | **aligned** |
+| ``"originator": "codex_cli_rs"`` literal | 2 hits — both legitimate (1 inside ``build_codex_oauth_headers`` itself, 1 in ``core.llm.registry.codex_cloudflare_headers`` for the Cloudflare User-Agent + originator-only path, NOT a JWT-augmented duplicate) | 0 hits | n/a | **clean** — I.a dedup complete |
+| ``resolve_agentic_adapter`` callsites | 2 production code consumers remain: ``core/agent/loop/_reflection.py:251`` and ``core/agent/loop/agent_loop.py:1998`` | n/a (testing pattern legitimate) | n/a | **backlog** — see below |
+| ``adapter.agentic_call(...)`` non-legacy callers | Same 2 as above | n/a | n/a | **backlog** |
+
+## Remaining drift — explicit backlog
+
+Two production-code surfaces still consume the legacy ``AgenticLLMPort``
+contract after J-b.2 migrated the mutator. They are *not* drift from
+this sprint's claims; they are documented here as the natural
+next-step targets if the Path-B migration continues:
+
+### J-b.3 (backlog) — reflection node API migration
+
+- **Site**: ``core/agent/loop/_reflection.py:59`` import +
+  ``:251`` ``resolve_agentic_adapter(provider)`` + ``:290``
+  ``adapter.agentic_call(...)``.
+- **Scope mirror**: identical pattern J-b.2 migrated for the mutator
+  — a single sync-async call site that wraps a non-streaming LLM
+  invocation. ~50 LOC delta.
+- **Why deferred**: reflection's call shape (``temperature=cognitive_reflection_temperature``,
+  ``max_tokens=cognitive_reflection_max_tokens``) is a separate config
+  surface; migration should keep the per-knob mapping intact.
+  Sizing-wise it's I.a-grade, not a sprint.
+
+### J-b.4 (backlog) — AgenticLoop main-loop API migration
+
+- **Site**: ``core/agent/loop/agent_loop.py:1998``
+  ``self._adapter.agentic_call(...)`` inside the main round body.
+- **Scope**: the whole agentic loop's per-round LLM dispatch. Streaming
+  + tool-use + Codex reasoning replay + telemetry all run through this
+  call. Migration is **substantially larger** than the rest of the
+  Path-B sprint combined; the Codex reasoning replay alone needs the
+  per-``Message`` ``codex_reasoning_items`` annotation to be wired into
+  the loop's message accumulator (currently a runtime-attached
+  ``dict`` key on the assistant message, not the typed ``Message``
+  field).
+- **Why deferred**: this is multi-PR work. Treat as a separate sprint.
+
+## CLI-subscription text-output gap (J-b.2 caveat)
+
+Step J-b.2's docstring + CHANGELOG explicitly recorded:
+
+> The CLI-subscription branches (``claude-cli`` / ``openai-codex``
+> source) **deliberately remain on the dedicated ``invoke_claude_cli``
+> / ``invoke_codex_cli`` helpers** in
+> :mod:`core.self_improving_loop.cli_subprocess` rather than going
+> through the ``ClaudeCliAdapter`` / ``CodexCliAdapter`` built-ins
+> because the built-in adapters speak the streaming-JSON event
+> protocol used by the agentic loop, whereas the mutator parser
+> consumes plain text.
+
+This is a documented seam between two adapter implementations. The
+fix — adding a text-output mode to both ``ClaudeCliAdapter`` and
+``CodexCliAdapter`` — is tracked as a follow-up. It belongs to the
+same J-b.4 sprint above (the agentic loop migration would naturally
+make the CLI adapters more flexible).
+
+## Doc surfaces updated in this audit
+
+- ``docs/operator-mode-a.md`` — Mode B row now references
+  ``[self_improving_loop.autoresearch.mutator]`` (new SoT) and notes
+  the 1-release legacy section migration.
+
+Plan documents under ``docs/plans/2026-05-21*`` are pinned-in-time
+artifacts of their respective sprints; they record the namespaces
+that were canonical when they were written. Leaving them as-is
+matches the project convention (DONT-table style — each plan is a
+frozen lesson).
+
+## Anti-deception sweeps (verified)
+
+| Sweep | Result |
+|-------|--------|
+| Stale ``cfg.mutator``/``cfg.petri`` in production | 0 |
+| Stale legacy section literals in production runtime path | 0 |
+| OAuth header dict duplication | 0 (post-I.a) |
+| Codex MCP review across 5 PRs | All BLOCKER + HIGH closed |
+| ``# type: ignore`` proliferation across sprint | 0 new (I.c LOW-fixed one) |
+| CHANGELOG ↔ code parity | Every verb grep-provable per CANNOT rule |
+
+## End-of-sprint summary
+
+Path-B's adapter abstraction is now the SoT for:
+
+1. Codex OAuth header construction (I.a)
+2. Self-improving loop model selection (J-b.1)
+3. Mutator runner LLM dispatch — API path (J-b.2)
+4. Adapter readiness probing (I.c)
+
+inspect_ai's stock pathway owns Codex reasoning replay for the petri
+provider (I.b documented + pinned). Backlog J-b.3 + J-b.4 are the
+remaining surfaces; they're tracked as separate sprints with explicit
+scope rationale.

--- a/docs/operator-mode-a.md
+++ b/docs/operator-mode-a.md
@@ -10,7 +10,7 @@
 | Mode | Trigger | LLM that proposes mutations |
 |------|---------|----------------------------|
 | **A (this doc)** | An external Claude Code / Codex CLI session, manually started by you | Whatever model the external session runs |
-| **B** (`/self-improving run`) | The GEODE CLI slash command | `[self_improving_loop.mutator] default_model` (defaults to `Settings.model` via PR-MINIMAL-2 G1a) |
+| **B** (`/self-improving run`) | The GEODE CLI slash command | `[self_improving_loop.autoresearch.mutator] default_model` (defaults to `Settings.model` via PR-MINIMAL-2 G1a; section relocated from `[self_improving_loop.mutator]` by Step J-b.1 — legacy section still auto-migrates for one release with a `DeprecationWarning`) |
 
 Both modes write to the same 5 policy SoTs at
 `autoresearch/state/policies/*.json` (git-tracked since


### PR DESCRIPTION
## Summary

- Final scope audit doc covering the 5-PR Path-B LLMAdapter sprint that landed today (I.a / J-b.1 / J-b.2 / I.b / I.c)
- Five cross-tree grep sweeps confirm 0 production-runtime drift from the sprint's claims
- Two production-code surfaces still consume the legacy ``AgenticLLMPort`` (reflection node + AgenticLoop main body) — explicitly tracked as J-b.3 / J-b.4 backlog with scope rationale
- ``docs/operator-mode-a.md`` updated to point at the new ``[self_improving_loop.autoresearch.mutator]`` section

## Why

User-directed end-of-session alignment step: "작업 마치면 세션에서 진행한 스코프를 전체 폴더 트리에서 점검하고 결을 정렬하는 스텝 가지고." Audit doc records what the sprint shipped, what cross-tree grep sweeps confirmed, and what remains for the natural next steps.

## Changes

| File | Change |
|------|--------|
| ``docs/audits/2026-05-23-path-b-sprint-final-audit.md`` | NEW (~120 LOC) — sprint summary, 5 cross-tree sweep results, backlog (J-b.3 reflection node, J-b.4 main loop), CLI-subscription text-output gap documentation. |
| ``docs/operator-mode-a.md`` | Mode B row references the new ``[self_improving_loop.autoresearch.mutator]`` section name + notes the 1-release legacy auto-migration with ``DeprecationWarning``. |

## Verification

- [x] ``uv run ruff check core/ tests/ plugins/`` — All checks passed
- [x] ``uv run pytest tests/test_self_improving_loop_config.py tests/core/llm/adapters/test_registry.py`` — 53 passed
- [x] No source code changes — docs-only PR. Tests for the Path-B sprint were merged in their individual PRs (#1542, #1549, #1555, #1554, #1556).

## Reference

5-PR Path-B chain (all merged today): #1542 (I.a Codex OAuth header dedup) → #1549 (J-b.1 control-layer SoT relocation) → #1555 (J-b.2 mutator API path migration) → #1554 (I.b inspect_ai reasoning replay pin) → #1556 (I.c ``adapter_health`` accessor). Plan doc: ``docs/plans/2026-05-23-adapter-wrap-petri-autoresearch.md`` (added in #1542).