### PR TITLE
release: v0.99.47 — Path-B LLMAdapter sprint + cleanup-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.47] - 2026-05-23
+
+> Path-B ``LLMAdapter`` sprint package — 4 PRs that close the
+> abstraction migration started in v0.99.44 (A2 / F) and the
+> self-improving-loop SoT relocation started in v0.99.46 (J-b.1).
+> The mutator runner's API path now consumes the Path-B Protocol
+> directly (J-b.2 / #1555); inspect_ai's reasoning-replay pathway is
+> documented + smoke-pinned (I.b / #1554); a one-call
+> ``adapter_health(name)`` accessor lands on the registry surface
+> (I.c / #1556); plus the end-of-sprint cross-tree audit + docs
+> alignment (#1557). PR-CLEANUP-1 (#1558) lands alongside as a
+> separate over-split-module compression.
+
 ### Removed
 
 - **PR-CLEANUP-1 — over-split helper modules + 1-release-grace aliases.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.46
+- **Version**: 0.99.47
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.46 — Long-running Autonomous Execution Harness
+# GEODE v0.99.47 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.46**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.47**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.46 — Long-running Autonomous Execution Harness
+# GEODE v0.99.47 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.46**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.47**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.46"
+version = "0.99.47"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.46"
+version = "0.99.47"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

> Resubmission after #1559 was closed by an accidental remote-branch delete during the conflict path. Rebased onto current develop (now includes PR-CLEANUP-1 #1558) and CHANGELOG resolved to bundle both groups under v0.99.47.

Path-B LLMAdapter sprint package — 5 PRs that landed on develop since v0.99.46:

- **J-b.2** (#1555) — mutator runner API path migrated from legacy ``AgenticLLMPort`` to Path-B ``resolve_for + acomplete``
- **I.b** (#1554) — inspect_ai reasoning-replay pathway documented + 3-test smoke ratchet
- **I.c** (#1556) — ``adapter_health(name)`` ergonomic registry accessor
- **#1557** — end-of-sprint cross-tree audit + docs alignment
- **PR-CLEANUP-1** (#1558) — over-split helper modules + 1-release-grace alias removal

## Verification

- [x] 5-location version stamp (pyproject.toml / CLAUDE.md / README.md / README.ko.md / uv.lock)
- [x] CHANGELOG cut: ``[Unreleased]`` → ``[0.99.47] - 2026-05-23`` (preserves PR-CLEANUP-1's Removed section under the new heading)
- [x] All 5 contributing PRs landed CI-green individually + Codex MCP read-only verify GREEN (where applicable)