### PR TITLE
PR-DOCS-CANT-CAN — CLAUDE.md restructure: CANNOT/CAN adjacency + 6 new CANNOT rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,32 @@ functional change.
 
 ---
 
+## [Unreleased]
+
 ### Changed
+
+- **PR-DOCS-CANT-CAN — CLAUDE.md restructure: CANNOT/CAN adjacency + 6 frontier-convergent CANNOT rows.**
+  The two governance tables (``### CANNOT`` and ``### CAN``) were
+  separated by ``### Wiring Verification`` + ``### Refactoring Deception
+  Prevention``, which broke the read-as-a-pair invariant that the rest
+  of the doc relies on. The two tables now sit next to each other; the
+  two diagnostic sections move down so the workflow narrative is
+  unchanged. Six new ``CANNOT`` rows codify patterns that came out of
+  a survey of 7 frontier autonomous-agent codebases (claude-code-ref,
+  openclaw, hermes-agent, open-coscientist, paperclip, crumb, cotton).
+  Convergence is cited per row in the table itself — domain naming
+  shows up in 4/7, while the same-name-nested folder anti-pattern is
+  0/7 (GEODE was the only one). The patterns already shaped
+  PR-CLEANUP-1 / PR-CLEANUP-2:
+  - **Naming**: no abstract-noun packages, no same-name-nested folders
+    (``X/X/``), no single-file packages, no ``_helpers``/``_utils``
+    once a caller exists.
+  - **Compat**: no re-export shim past a 1-release grace.
+  - **Registry**: no two registries for the same domain.
+  ``CAN`` also gains one row: cleanup / refactor PRs may bundle
+  aggressively (Socratic Q4 "minimum change" guard does not apply
+  when cleanup *is* the purpose). All new rows cite the specific
+  incident or frontier signal that justifies them.
 
 - **PR-CLEANUP-2 — fold three over-small packages into their natural homes.**
   ``core/`` drops from 25 to 22 top-level packages with zero behaviour

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,26 @@ Rationale cites the originating incident when one exists. The `karpathy-patterns
 | | No leaving `[Unreleased]` on main | Release discipline |
 | | No version mismatch across 5 locations | Single source of truth |
 | | No emoji as section anchors / nav prefixes; no decorative card grids when content is data — dense table/list only on docs/site/CLI surfaces | Slop signal. *Incident: PR-CSP-14-UI mockup (2026-05-23) — see [[feedback-no-box-ui-no-emoji]]* |
+| **Naming** | No abstract-noun package names (`text`, `storage`, `runtime_state`, `helpers`, `common`, `lib`, `manager`) — use domain-verb / domain-noun (claude-code-ref / openclaw / hermes / crumb all converge). *Incident: PR-CLEANUP-2 #1562 (2026-05-23) folded 3 such packages.* | Frontier convergence + [[feedback-explicit-naming]] |
+| | No same-name-nested folders (`X/X/`) — flatten or rename inner | Frontier 0/7 do this; GEODE had `core/scheduler/scheduler/` |
+| | No single-file packages — fold into the nearest domain sibling | PR-CLEANUP-2 precedent (`core/text/`, `core/storage/`) |
+| | No `_helpers.py` / `_utils.py` / `_misc.py` filenames once a caller appears — rename to the actual responsibility (the catch-all suffix hides intent) | autoresearch / openclaw avoid; PR-CLEANUP-1 absorbed `_announce.py` + `_decomposition.py` for similar reason |
+| **Compat** | No re-export shim / backward-compat module past its 1-release grace — delete it and migrate callers in the same PR | *Incident: `core/llm/client.py` (0 callers but kept), `core/agent/loop/loop.py` (deleted PR-CLEANUP-1)* |
+| **Registry** | No two registries for the same domain (skill / tool / adapter / plugin) — one schema, one loader, one call surface | *Incident: `core/llm/skill_registry.py` ↔ `core/skills/skills.py` parsing the same `~/.geode/skills/*.md` twice* |
 | **PR** | No PR that violates the [§6 template](#6-pr--merge) (HEREDOC body with Summary/Why/Changes/Verification) or merges without CI 5/5 green | Format + traceability + Ratchet (P4) |
+
+### CAN — Permitted Freedoms
+
+Anything not in CANNOT is freely permitted. Specifically:
+
+| Freedom | Description |
+|---------|-------------|
+| Simple bug/doc fixes | Skip Plan, implement directly in worktree |
+| Discovering improvements not in plan | Handle in next iteration after completing current work |
+| Selective test execution | Run only tests relevant to changes first, full suite at the end |
+| Commit message language | Korean/English freely (maintain consistency only) |
+| Tool selection | Freely choose faster tool if results are equivalent |
+| Cleanup / refactor PRs may bundle aggressively | The Socratic Q4 "minimum change" guard does **not** apply when the PR's purpose *is* cleanup — find every fold, prune, and rename in scope and ship them together. (cf. [[feedback-cleanup-no-minimal-change]]) |
 
 ### Wiring Verification (Anti-Disconnection)
 
@@ -126,18 +145,6 @@ Rationale cites the originating incident when one exists. The `karpathy-patterns
 |------|------|
 | **Implementation completeness** | No marking plan items complete when partially implemented, stubbed (`pass` only), or shelled out as re-exports while code remains in the original. An independent zero-context agent cross-checks plan + diff and FAILs on any omission. See `verification-team` + `anti-deception-checklist` skills for the operational checklist. |
 | **CHANGELOG/PR-body parity** | Every verb/adjective in the PR title + CHANGELOG ("git-tracked", "X-driven", "automatic", "committed") must be grep-provable in code. Run `git check-ignore`, `grep -rn "<source-doc>"`, and "is there a caller?" before push. *Incident: PR-G5b #1350 (2026-05-20) — both "git-tracked audit log" and "program.md-driven runner" were un-backed; fixed in `runner.py:_load_program_md` and pinned by `test_load_program_md_actually_reads_disk_file`.* |
-
-### CAN — Permitted Freedoms
-
-Anything not in CANNOT is freely permitted. Specifically:
-
-| Freedom | Description |
-|---------|-------------|
-| Simple bug/doc fixes | Skip Plan, implement directly in worktree |
-| Discovering improvements not in plan | Handle in next iteration after completing current work |
-| Selective test execution | Run only tests relevant to changes first, full suite at the end |
-| Commit message language | Korean/English freely (maintain consistency only) |
-| Tool selection | Freely choose faster tool if results are equivalent |
 
 ### Workflow Steps
 


### PR DESCRIPTION
## Summary
- Move `### CAN — Permitted Freedoms` to immediately after `### CANNOT — Absolute Prohibition Rules`. The two diagnostic sections (Wiring Verification, Refactoring Deception Prevention) move down to keep the workflow narrative intact.
- Add 6 new `CANNOT` rows (4 Naming + 1 Compat + 1 Registry) from a 7-codebase frontier survey.
- Add 1 new `CAN` row: cleanup PRs may bundle aggressively (Socratic Q4 doesn't apply).

## Why
The CANNOT/CAN pair is the spine of the scaffold — readers scan them together to decide what's allowed in any given change. With two unrelated sections between them, the pairing wasn't visible at a glance, and `karpathy-patterns` already states the anti-pattern table is meant to be read as a unit.

The 6 new rows codify patterns that came out of the cross-agent audit done during the 2026-05-23 cleanup arc (PR-CLEANUP-1 / PR-CLEANUP-2). Frontier convergence is cited per row in the table itself rather than as a separate appendix — domain-noun naming shows up in 4/7 surveyed codebases, the same-name-nested folder anti-pattern is 0/7, the single-file-package smell killed `core/text/` + `core/storage/` already, and the duplicate-registry case (`core/llm/skill_registry.py` ↔ `core/skills/skills.py`) is the next thing PR-CLEANUP-3 will resolve.

The new `CAN` row formalises the operating principle that cleanup PRs are allowed (and expected) to bundle every found fold/prune/rename rather than being chopped into "minimum change" slices — see `feedback-cleanup-no-minimal-change` for the rationale.

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | Move `### CAN` adjacent to `### CANNOT`; insert 6 new CANNOT rows + 1 new CAN row; cite incidents per row. |
| `CHANGELOG.md` | `[Unreleased]` `### Changed` entry. |

## Verification
- [x] `grep -n '^### ' CLAUDE.md` shows `### CANNOT` (line 75) immediately followed by `### CAN` (line 114).
- [x] Codex MCP read-only verification: 10/10 PASS after CHANGELOG count fixup (initial FAIL on count parity, fixed pre-push).
- [x] No file changes outside `CLAUDE.md` + `CHANGELOG.md`.
- [x] Docs-only — no code gates required.

## Reference
First in the post-PR-CLEANUP-2 sprint. Subsequent: PR-CLEANUP-3 (renames + dupes), PR-CLEANUP-5 (session_journal shim removal + config fold), PR-CLEANUP-6 (tool_handlers fold), PR-CLEANUP-7 (file-naming hygiene), J-b.3 (reflection.py → LLMAdapter Protocol — final).