### PR TITLE
Step J-b.3 — reflection node migrated to LLMAdapter Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,67 @@ functional change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Step J-b.3 — reflection node migrated to the LLMAdapter Protocol.**
+  ``core/agent/loop/_reflection.py`` 's dispatch path moves off the
+  legacy ``AgenticLLMPort.agentic_call`` surface (resolved via
+  :func:`core.llm.adapters.resolve_agentic_adapter`) and onto the
+  v0.99.39 Path-B Protocol — :func:`~core.llm.adapters.registry.resolve_for`
+  + :meth:`~core.llm.adapters.base.LLMAdapter.acomplete` with a typed
+  :class:`~core.llm.adapters.base.AdapterCallRequest`. The reflection
+  call therefore inherits I.a's Codex OAuth header dedup and F's GLM
+  adapter family on the same code path the J-b.2 mutator runner now
+  uses (so the agentic loop and the self-improving-loop mutator share
+  one credential / adapter surface for the API path).
+
+  Translation: the in-source ``_REFLECTION_TOOL`` dict (kept as SoT so
+  the ADR-012 ``reflection`` policy override path keeps working) is
+  converted to a :class:`~core.llm.adapters.base.ToolSpec` at request
+  time. The ``strict: True`` field the legacy dict carried is dropped
+  in translation — ``ToolSpec`` does not surface it today, and
+  ``_anthropic_common.translate_tool`` would strip it anyway. The
+  client-side ``_apply_reflection`` isinstance + range checks already
+  enforce the same payload contract, so the regression is a soft
+  degrade from "server-rejects-malformed" to "client-coerces-silently"
+  rather than a fail-open. Restoring server-side strict validation is
+  tracked as a future ``ToolSpec`` Protocol extension.
+
+  Result-side: ``_extract_reflection_input`` now reads from
+  :attr:`AdapterCallResult.tool_uses` (tuple of ``{id, name, input}``
+  dicts) but tolerates the legacy ``AgenticResponse.content`` list-of-
+  ``ToolUseBlock`` shape for back-compat. A ``_normalize_provider_for_registry``
+  helper (4 lines, duplicated from
+  :func:`core.self_improving_loop.runner._normalize_provider_for_registry`
+  per the "no premature hoisting" principle — both callers can
+  diverge later if their needs split) translates
+  ``"openai-codex"`` → ``"openai"`` so the registry's narrower
+  vocabulary lands on the right adapter.
+
+  Tests: ``tests/test_reflection_node.py`` 's ``_StubAdapter`` now
+  implements ``acomplete(AdapterCallRequest)`` instead of
+  ``agentic_call(**kwargs)``, ``_install_reflection_stubs``
+  monkeypatches ``resolve_for`` instead of ``resolve_agentic_adapter``,
+  the happy-path + tool-schema assertions move to the new
+  ``AdapterCallResult(tool_uses=(...))`` / ``ToolSpec`` shape. The
+  ``tools[0].get("strict") is True`` assertion is removed alongside
+  the dict→ToolSpec translation; a comment in the test calls out the
+  intentional contract narrowing.
+  ``tests/test_s0b_reflection_reader.py`` 's source-substring
+  assertions move from ``system=active_system`` / ``tools=[active_tool]``
+  to ``system_prompt=active_system`` / ``tools=(tool_spec,)`` to
+  match the dataclass field names.
+
+  **Out of scope (intentional)**: the AgenticLoop's main call path
+  (``core/agent/loop/agent_loop.py``, ``_model_switching.py``,
+  package ``__init__``) still uses
+  :func:`~core.llm.router.resolve_agentic_adapter` +
+  ``adapter.agentic_call(...)``. That migration is its own sprint —
+  the agentic call surface is materially larger (streaming +
+  ``tool_use_id`` round-trip + retry orchestration) than the
+  reflection call and needs separate Codex-MCP review. J-b.3 stops
+  at the reflection node.
+
 ### Removed
 
 - **PR-CLEANUP-6 — file-name hygiene sweep: catch-all `_helpers` /

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -77,6 +77,7 @@ def _normalize_provider_for_registry(provider: str) -> str:
         return "openai"
     return provider
 
+
 log = logging.getLogger(__name__)
 
 

--- a/core/agent/loop/_reflection.py
+++ b/core/agent/loop/_reflection.py
@@ -56,8 +56,26 @@ from typing import Any
 
 from core.agent.cognitive_state import CognitiveState
 from core.config import _resolve_provider
-from core.llm.adapters import resolve_agentic_adapter
+from core.llm.adapters import resolve_for
+from core.llm.adapters.base import AdapterCallRequest, Message, ToolSpec
 from core.llm.router import call_with_failover
+
+
+def _normalize_provider_for_registry(provider: str) -> str:
+    """Translate :func:`core.config._resolve_provider` output to the
+    Path-B :func:`~core.llm.adapters.registry.resolve_for` registry's
+    provider-key vocabulary.
+
+    Step J-b.3 (2026-05-23) — duplicates the same translation used by
+    :func:`core.self_improving_loop.runner._normalize_provider_for_registry`.
+    The legacy resolver returns ``"openai-codex"`` for gpt-5.x; the
+    Path-B registry collapses that to ``"openai"`` and lets the
+    ``source`` axis pick between ``payg`` / ``subscription`` /
+    ``adapter``.
+    """
+    if provider == "openai-codex":
+        return "openai"
+    return provider
 
 log = logging.getLogger(__name__)
 
@@ -161,15 +179,32 @@ def _build_user_prompt(state: CognitiveState, tool_summary: str) -> str:
     )
 
 
-def _extract_reflection_input(response: Any) -> dict[str, Any] | None:
-    """Find the ``record_reflection`` tool_use block in the response.
+def _extract_reflection_input(result: Any) -> dict[str, Any] | None:
+    """Find the ``record_reflection`` tool_use block in the adapter result.
 
-    Returns the tool's ``input`` dict (already parsed by the adapter
-    normalizer — see :class:`core.llm.agentic_response.ToolUseBlock`).
-    Returns ``None`` when the model declined to invoke the tool;
-    callers swallow this case with a WARN.
+    Step J-b.3 (2026-05-23) — reads from
+    :attr:`core.llm.adapters.base.AdapterCallResult.tool_uses` (tuple of
+    ``{id, name, input}`` dicts) instead of the legacy
+    ``AgenticResponse.content`` list of :class:`ToolUseBlock` objects.
+    Both surfaces carry the same parsed payload; only the container
+    shape changes with the Path-B Protocol.
+
+    Returns the tool's ``input`` dict, or ``None`` when the model
+    declined to invoke the tool (callers swallow this case with a
+    WARN). Also tolerates the pre-Path-B object shape (``.type`` /
+    ``.name`` / ``.input``) so tests that mock the legacy
+    ``AgenticResponse`` keep passing during the rollout.
     """
-    for block in getattr(response, "content", []) or []:
+    # Path-B shape: ``AdapterCallResult.tool_uses: tuple[dict, ...]``.
+    tool_uses = getattr(result, "tool_uses", None)
+    if isinstance(tool_uses, tuple | list):
+        for entry in tool_uses:
+            if isinstance(entry, dict) and entry.get("name") == REFLECTION_TOOL_NAME:
+                payload = entry.get("input")
+                if isinstance(payload, dict):
+                    return payload
+    # Legacy shape: ``AgenticResponse.content: list[ToolUseBlock]``.
+    for block in getattr(result, "content", []) or []:
         if getattr(block, "type", None) == "tool_use" and getattr(block, "name", "") == (
             REFLECTION_TOOL_NAME
         ):
@@ -248,7 +283,12 @@ async def reflect_async(
     # swallowed at WARN" guarantee).
     try:
         provider = _resolve_provider(model)
-        adapter = resolve_agentic_adapter(provider)
+        # Step J-b.3 (2026-05-23) — Path-B Protocol dispatch. The
+        # registry's ``payg`` source covers both API-key and OAuth
+        # subscription paths for our reflection model surface;
+        # downstream credential rotation still happens inside the
+        # adapter.
+        adapter = resolve_for(_normalize_provider_for_registry(provider), "payg")
         tool_summary = _summarise_tool_results(tool_results)
         user_prompt = _build_user_prompt(state, tool_summary)
 
@@ -287,15 +327,32 @@ async def reflect_async(
             # ``"auto"`` on OpenAI/Codex via the shared normaliser.
             from core.config import settings as _settings
 
-            return await adapter.agentic_call(
+            # Step J-b.3 (2026-05-23) — translate the reflection tool
+            # dict (kept as the in-module SoT for policy override
+            # compatibility) into a Path-B :class:`ToolSpec`. The
+            # ``strict: True`` flag the dict carried is intentionally
+            # dropped here: ``ToolSpec`` does not currently surface it
+            # and ``_anthropic_common.translate_tool`` would strip it
+            # anyway. The downstream :func:`_apply_reflection`
+            # isinstance + range checks already enforce the same
+            # contract client-side, so the behaviour degrades from
+            # "server-rejects-malformed" to "client-coerces-silently"
+            # rather than failing open.
+            tool_spec = ToolSpec(
+                name=active_tool["name"],
+                description=active_tool["description"],
+                input_schema=active_tool["input_schema"],
+            )
+            req = AdapterCallRequest(
                 model=m,
-                system=active_system,
-                messages=[{"role": "user", "content": user_prompt}],
-                tools=[active_tool],
+                messages=(Message(role="user", content=user_prompt),),
+                system_prompt=active_system,
+                tools=(tool_spec,),
                 tool_choice="auto",
                 max_tokens=max_tokens,
                 temperature=_settings.temperature_reflection,
             )
+            return await adapter.acomplete(req)
 
         response, _used_model = await call_with_failover([model], _do_call)
     except Exception:

--- a/tests/test_reflection_node.py
+++ b/tests/test_reflection_node.py
@@ -336,9 +336,7 @@ def _install_reflection_stubs(
     monkeypatch.setattr(_reflection, "call_with_failover", _fake_call_with_failover, raising=False)
     # Step J-b.3 — Path-B resolver. ``resolve_for(provider, source)``
     # replaces the legacy ``resolve_agentic_adapter(provider)``.
-    monkeypatch.setattr(
-        _reflection, "resolve_for", lambda _p, _src="payg": adapter, raising=False
-    )
+    monkeypatch.setattr(_reflection, "resolve_for", lambda _p, _src="payg": adapter, raising=False)
     monkeypatch.setattr(_reflection, "_resolve_provider", lambda _m: "anthropic", raising=False)
 
 

--- a/tests/test_reflection_node.py
+++ b/tests/test_reflection_node.py
@@ -288,6 +288,15 @@ def test_run_cognitive_act_observe_cycle_calls_maybe_reflect() -> None:
 
 
 class _StubAdapter:
+    """Step J-b.3 (2026-05-23) — stub matches the
+    :class:`~core.llm.adapters.base.LLMAdapter` Protocol surface
+    (``acomplete(AdapterCallRequest)``) instead of the legacy
+    ``AgenticLLMPort.agentic_call(**kwargs)``. ``last_kwargs`` is
+    rebuilt from the request dataclass so existing assertions
+    (``tools``, ``tool_choice``, …) keep working as a wire-up invariant
+    without leaking the dataclass type into the test body.
+    """
+
     def __init__(
         self,
         response: Any = None,
@@ -297,8 +306,16 @@ class _StubAdapter:
         self._raise = raise_exc
         self.last_kwargs: dict[str, Any] = {}
 
-    async def agentic_call(self, **kwargs: Any) -> Any:
-        self.last_kwargs = dict(kwargs)
+    async def acomplete(self, req: Any) -> Any:
+        self.last_kwargs = {
+            "model": getattr(req, "model", None),
+            "system": getattr(req, "system_prompt", None),
+            "messages": list(getattr(req, "messages", ())),
+            "tools": list(getattr(req, "tools", ())),
+            "tool_choice": getattr(req, "tool_choice", None),
+            "max_tokens": getattr(req, "max_tokens", None),
+            "temperature": getattr(req, "temperature", None),
+        }
         if self._raise is not None:
             raise self._raise
         return self._response
@@ -317,7 +334,11 @@ def _install_reflection_stubs(
         return result, _models[0]
 
     monkeypatch.setattr(_reflection, "call_with_failover", _fake_call_with_failover, raising=False)
-    monkeypatch.setattr(_reflection, "resolve_agentic_adapter", lambda _p: adapter, raising=False)
+    # Step J-b.3 — Path-B resolver. ``resolve_for(provider, source)``
+    # replaces the legacy ``resolve_agentic_adapter(provider)``.
+    monkeypatch.setattr(
+        _reflection, "resolve_for", lambda _p, _src="payg": adapter, raising=False
+    )
     monkeypatch.setattr(_reflection, "_resolve_provider", lambda _m: "anthropic", raising=False)
 
 
@@ -339,9 +360,15 @@ def test_reflect_async_swallows_response_without_tool_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If the LLM ignores the forced tool_choice and returns only
-    text (or some other tool), keep previous state."""
+    text (or some other tool), keep previous state.
+
+    Step J-b.3 (2026-05-23) — empty ``tool_uses`` tuple on
+    :class:`AdapterCallResult` is how the Path-B Protocol surfaces
+    "model returned only text". The extractor must fall through to
+    ``None`` and the caller must preserve previous state.
+    """
     state = CognitiveState(hypotheses=["keep"], confidence=0.4)
-    response = SimpleNamespace(content=[_text_block("I have nothing to say")])
+    response = SimpleNamespace(tool_uses=(), text="I have nothing to say")
     _install_reflection_stubs(monkeypatch, adapter=_StubAdapter(response=response))
 
     asyncio.run(_reflection.reflect_async(state, [], model="m", max_tokens=128))
@@ -350,20 +377,28 @@ def test_reflect_async_swallows_response_without_tool_use(
 
 
 def test_reflect_async_applies_tool_use_response(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Happy path — adapter returns a ToolUseBlock with the parsed
-    input dict; reflect_async applies it to state."""
+    """Happy path — adapter returns an :class:`AdapterCallResult` with a
+    ``tool_uses`` tuple containing the parsed payload; reflect_async
+    applies it to state.
+
+    Step J-b.3 (2026-05-23) — moved from the legacy
+    ``AgenticResponse.content`` shape to the Path-B
+    ``AdapterCallResult.tool_uses`` shape that ``adapter.acomplete``
+    actually returns.
+    """
     state = CognitiveState(goal="x")
     response = SimpleNamespace(
-        content=[
-            _tool_use_block(
-                REFLECTION_TOOL_NAME,
-                {
+        tool_uses=(
+            {
+                "id": "tu_1",
+                "name": REFLECTION_TOOL_NAME,
+                "input": {
                     "hypotheses": ["h1", "h2"],
                     "confidence": 0.7,
                     "next_action_hint": "do it",
                 },
-            )
-        ]
+            },
+        ),
     )
     _install_reflection_stubs(monkeypatch, adapter=_StubAdapter(response=response))
 
@@ -383,12 +418,13 @@ def test_reflect_async_passes_tool_schema_to_adapter(
     state = CognitiveState()
     adapter = _StubAdapter(
         response=SimpleNamespace(
-            content=[
-                _tool_use_block(
-                    REFLECTION_TOOL_NAME,
-                    {"hypotheses": [], "confidence": 0.5},
-                )
-            ]
+            tool_uses=(
+                {
+                    "id": "tu_1",
+                    "name": REFLECTION_TOOL_NAME,
+                    "input": {"hypotheses": [], "confidence": 0.5},
+                },
+            ),
         )
     )
     _install_reflection_stubs(monkeypatch, adapter=adapter)
@@ -397,8 +433,15 @@ def test_reflect_async_passes_tool_schema_to_adapter(
 
     tools = adapter.last_kwargs.get("tools")
     assert isinstance(tools, list) and len(tools) == 1
-    assert tools[0]["name"] == REFLECTION_TOOL_NAME
-    assert tools[0].get("strict") is True
+    # Step J-b.3 (2026-05-23) — ``tools`` is now a tuple of
+    # :class:`~core.llm.adapters.base.ToolSpec` instances, not raw
+    # dicts. The ``strict`` field that the reflection module's
+    # in-source ``_REFLECTION_TOOL`` dict carries is intentionally
+    # dropped at the dict→ToolSpec translation (documented in
+    # ``_reflection.py``); the contract degrades to client-side
+    # coercion via ``_apply_reflection``'s isinstance checks. That
+    # narrowing is a tracked follow-up — see CHANGELOG.
+    assert tools[0].name == REFLECTION_TOOL_NAME
     # PR-B fix-up #2 — ``tool_choice="auto"``. Anthropic docs mark
     # both ``"any"`` and named-tool forcing as incompatible with
     # adaptive/extended thinking, so only ``"auto"`` is safe across

--- a/tests/test_s0b_reflection_reader.py
+++ b/tests/test_s0b_reflection_reader.py
@@ -193,13 +193,23 @@ def test_reflection_module_imports_reader() -> None:
 
 def test_reflection_module_uses_overridden_values() -> None:
     """`_reflection.py` 가 `active_tool` / `active_system` (override 적용된
-    값) 을 사용하는지 — 단순 import 가 아니라 실제 사용 여부 검증."""
+    값) 을 사용하는지 — 단순 import 가 아니라 실제 사용 여부 검증.
+
+    Step J-b.3 (2026-05-23) — substring assertions migrated from the
+    legacy ``AgenticLLMPort.agentic_call(system=..., tools=[...])``
+    keyword call to the Path-B ``AdapterCallRequest(system_prompt=...,
+    tools=(...,))`` dataclass field shape.
+    """
     repo_root = Path(__file__).resolve().parent.parent
     src = (repo_root / "core/agent/loop/_reflection.py").read_text(encoding="utf-8")
     assert "active_tool" in src
     assert "active_system" in src
-    assert "system=active_system" in src
-    assert "tools=[active_tool]" in src
+    assert "system_prompt=active_system" in src
+    # ``active_tool`` dict is translated to a ``ToolSpec`` and the
+    # spec then lands in ``tools=(tool_spec,)``. Match both the
+    # source of the dict-derived fields and the request site.
+    assert "active_tool[" in src
+    assert "tools=(tool_spec,)" in src
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Migrate `core/agent/loop/_reflection.py` 's dispatch off the legacy `AgenticLLMPort.agentic_call` surface and onto the Path-B Protocol (`resolve_for` + `acomplete(AdapterCallRequest)`).
- Translate the in-source `_REFLECTION_TOOL` dict into a `ToolSpec` at request time; drop `strict: True` (documented soft-degrade).
- Update `_extract_reflection_input` to read `AdapterCallResult.tool_uses` first, falling back to the legacy `AgenticResponse.content` shape.
- Rewire `tests/test_reflection_node.py` `_StubAdapter` to the new Protocol surface; update `tests/test_s0b_reflection_reader.py` source-substring assertions.

## Why
Step J-b.2 (#1555 / v0.99.47) migrated the self-improving-loop mutator's API path to Path-B. J-b.3 completes the same migration for the reflection node, so the agentic loop and the self-improving-loop mutator share one credential / adapter surface for the API path. The reflection call therefore inherits I.a's Codex OAuth header dedup and F's GLM adapter family without separate wiring.

This is the **final** step of the post-PR-CLEANUP-2 sprint per operator direction ("J-b.3 worktree 는 보존 (작업 시작 전) … 이 작업을 리팩토링 마지막에 배치해서 해결해").

## Changes
| File | Change |
|------|--------|
| `core/agent/loop/_reflection.py` | Imports flip to `resolve_for` + `AdapterCallRequest` + `Message` + `ToolSpec`; added `_normalize_provider_for_registry` helper; `_do_call` builds an `AdapterCallRequest` and awaits `adapter.acomplete(req)`; `_extract_reflection_input` is dual-shape. |
| `tests/test_reflection_node.py` | `_StubAdapter.acomplete(req)` replaces `agentic_call(**kwargs)`; happy-path tests use `tool_uses=(...)`; `strict` assertion removed with a calling-out comment. |
| `tests/test_s0b_reflection_reader.py` | Source-substring assertions move from `system=active_system` / `tools=[active_tool]` to `system_prompt=active_system` / `tools=(tool_spec,)`. |
| `CHANGELOG.md` | `[Unreleased]` `### Changed` entry. |

## GAP Audit
| Item | Status | Notes |
|------|--------|-------|
| Reflection dispatch on Path-B | Implemented | `resolve_for("payg")` + `acomplete(AdapterCallRequest)`. |
| ToolSpec translation correct | Implemented | name + description + input_schema copied; `strict` dropped + documented. |
| Result extraction dual-shape | Implemented | New `tool_uses` tuple first, legacy `.content` ToolUseBlock list fallback. |
| Tests rewired | Implemented | 82 reflection tests + 135 adjacent loop tests pass. |
| Main AgenticLoop call path | Out of scope | Still uses `resolve_agentic_adapter` + `agentic_call` — documented in CHANGELOG. |

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] `uv run mypy core/ plugins/` — 425 source files clean
- [x] `uv run lint-imports` — 4 kept, 0 broken
- [x] `uv run pytest` scoped (4 reflection test files + 1 temperature invariants) — 82 passed
- [x] `uv run pytest tests/test_agentic_loop.py tests/core/agent/` — 135 passed
- [x] Codex MCP read-only verification — 9 PASS / 1 FAIL (expected: leftover `resolve_agentic_adapter` refs are in the AgenticLoop main path which is intentionally out of scope)

## Reference
Final piece of the post-PR-CLEANUP-2 sprint. Follows PR-DOCS-CANT-CAN (#1563), PR-CLEANUP-3 (#1564), PR-CLEANUP-4 (#1565), PR-CLEANUP-5 (#1566), PR-CLEANUP-6 (#1567). Subsequent (future sprint): AgenticLoop main agentic_call migration to Path-B; ToolSpec Protocol extension for `strict`.