### PR TITLE
release: v0.99.48 — cleanup arc + reflection LLMAdapter migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ functional change.
 
 ## [Unreleased]
 
+## [0.99.48] - 2026-05-24
+
+> Cleanup-arc release — 7 PRs (PR-DOCS-CANT-CAN + PR-CLEANUP-3
+> through 7 + Step J-b.3) plus a single naming-pivot follow-up. The
+> arc started from a 25-package `core/` audit against 7 frontier
+> agents and ended with `core/` at 22 packages, 4 `_helpers`/`_utils`
+> survivors renamed or pruned, 2 backward-compat shims removed
+> (`core/llm/client.py`, the `core.observability` re-exports), 6 new
+> Naming/Compat/Registry CANNOT rows landed in CLAUDE.md, and the
+> reflection node migrated to the Path-B `LLMAdapter` Protocol. The
+> SessionJournal → RunTranscript relocation follow-up (PR-CLEANUP-7
+> #1569) closes the operator catch on the misleading "journal" name
+> that the 3-Tier preservation architecture reserves for Tier 2
+> summaries.
+
 ### Changed
 
 - **PR-CLEANUP-7 — ``SessionJournal`` renamed + relocated to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 A general-purpose autonomous execution agent built on LangGraph. Autonomously performs research, analysis, automation, and scheduling.
 
-- **Version**: 0.99.47
+- **Version**: 0.99.48
 - **Python**: >= 3.12
 - **Package Manager**: uv
 - **Entry Point**: `geode.cli:app` (Typer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 
 [English](README.md)
 
-# GEODE v0.99.47 — Long-running Autonomous Execution Harness
+# GEODE v0.99.48 — Long-running Autonomous Execution Harness
 
 탐색적 리서치와 시그널 예측을 위한 범용 자율 에이전트. 자연어로 물으면 GEODE 가 계획을 세우고, 도구를 호출해, 결과를 보고합니다. 1회성 프롬프트도, 장시간 세션도 동일하게.
 
@@ -335,7 +335,7 @@ geode update                  # 소스 체크아웃
 
 ## GEODE 비교
 
-각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.47**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
+각 frontier 하네스의 실제 상태 기준 (2026 년 5 월): **Claude Code v2.1.72** (빌드 2026-03-09), **Codex CLI v0.130.0** (2026-05-08 릴리즈), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.48**. 마커: ✅✅ 해당 축의 리더 · ✅ 지원 · ⚠️ 부분 / 제한적 · ❌ 없음 · n/a 적용 불가.
 
 <details>
 <summary><strong>A. 런타임 자세</strong> — 에이전트가 어떻게 떠 있는가</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-# GEODE v0.99.47 — Long-running Autonomous Execution Harness
+# GEODE v0.99.48 — Long-running Autonomous Execution Harness
 
 A general-purpose autonomous agent for exploratory research and signal prediction. You ask in plain language. GEODE plans, calls tools, and reports — for one prompt or a long-running session.
 
@@ -340,7 +340,7 @@ geode update                  # source checkout
 
 ## How GEODE compares
 
-Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.47**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
+Grounded against the actual state of each frontier harness as of May 2026: **Claude Code v2.1.72** (build 2026-03-09), **Codex CLI v0.130.0** (released 2026-05-08), **OpenClaw v2026.5.12-beta.1**, **GEODE v0.99.48**. Marker legend: ✅✅ leader on the axis · ✅ supported · ⚠️ partial / qualified · ❌ absent · n/a not applicable.
 
 <details>
 <summary><strong>A. Runtime posture</strong> — how the agent stays alive</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geode-agent"
-version = "0.99.47"
+version = "0.99.48"
 description = "GEODE — 범용 자율 실행 에이전트"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "geode-agent"
-version = "0.99.47"
+version = "0.99.48"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Release rotation for the 7-PR cleanup arc + J-b.3. `core/` package count 25 → 22; 6 new CANNOT rows; reflection node on Path-B.

## Verification
- [x] `uv run ruff check core/ tests/ plugins/` — clean
- [x] Version stamped across 5 locations (CHANGELOG, CLAUDE.md, README.md, README.ko.md, pyproject.toml)
- [x] `[Unreleased]` block moved to `## [0.99.48] - 2026-05-24`
- [x] `geode version` → `GEODE v0.99.48`